### PR TITLE
R: Full support of lists and structs in R

### DIFF
--- a/tools/rpkg/src/include/typesr.hpp
+++ b/tools/rpkg/src/include/typesr.hpp
@@ -108,6 +108,7 @@ private:
 
 struct RApiTypes {
 	static RType DetectRType(SEXP v, bool integer64);
+	static LogicalType LogicalTypeFromRType(const RType &rtype, bool experimental);
 	static string DetectLogicalType(const LogicalType &stype, const char *caller);
 	static Value SexpToValue(SEXP valsexp, R_len_t idx);
 	static SEXP ValueToSexp(Value &val, string &timezone_config);

--- a/tools/rpkg/src/include/typesr.hpp
+++ b/tools/rpkg/src/include/typesr.hpp
@@ -110,6 +110,7 @@ struct RApiTypes {
 	static RType DetectRType(SEXP v, bool integer64);
 	static LogicalType LogicalTypeFromRType(const RType &rtype, bool experimental);
 	static string DetectLogicalType(const LogicalType &stype, const char *caller);
+	static R_len_t GetVecSize(RType rtype, SEXP coldata);
 	static Value SexpToValue(SEXP valsexp, R_len_t idx);
 	static SEXP ValueToSexp(Value &val, string &timezone_config);
 };

--- a/tools/rpkg/src/include/typesr.hpp
+++ b/tools/rpkg/src/include/typesr.hpp
@@ -43,6 +43,7 @@ enum class RTypeId {
 	// No RType equivalent
 	BYTE,
 	LIST,
+	STRUCT,
 };
 
 struct RType {
@@ -100,6 +101,9 @@ struct RType {
 
 	static RType LIST(const RType &child);
 	RType GetListChildType() const;
+
+	static RType STRUCT(child_list_t<RType> &&children);
+	child_list_t<RType> GetStructChildTypes() const;
 
 private:
 	RTypeId id_;

--- a/tools/rpkg/src/include/typesr.hpp
+++ b/tools/rpkg/src/include/typesr.hpp
@@ -191,9 +191,12 @@ struct RStringSexpType {
 	static bool IsNull(SEXP val);
 };
 
-struct RRawSexpType {
-	static string_t Convert(SEXP val);
+struct RSexpType {
 	static bool IsNull(SEXP val);
+};
+
+struct RRawSexpType : public RSexpType {
+	static string_t Convert(SEXP val);
 };
 
 } // namespace duckdb

--- a/tools/rpkg/src/include/typesr.hpp
+++ b/tools/rpkg/src/include/typesr.hpp
@@ -76,7 +76,6 @@ struct RType {
 	static constexpr const RTypeId INTEGER = RTypeId::INTEGER;
 	static constexpr const RTypeId NUMERIC = RTypeId::NUMERIC;
 	static constexpr const RTypeId STRING = RTypeId::STRING;
-	static constexpr const RTypeId FACTOR = RTypeId::FACTOR;
 	static constexpr const RTypeId DATE = RTypeId::DATE;
 	static constexpr const RTypeId DATE_INTEGER = RTypeId::DATE_INTEGER;
 	static constexpr const RTypeId TIMESTAMP = RTypeId::TIMESTAMP;
@@ -93,6 +92,11 @@ struct RType {
 	static constexpr const RTypeId INTEGER64 = RTypeId::INTEGER64;
 	static constexpr const RTypeId LIST_OF_NULLS = RTypeId::LIST_OF_NULLS;
 	static constexpr const RTypeId BLOB = RTypeId::BLOB;
+
+	static RType FACTOR(cpp11::strings levels);
+	Vector GetFactorLevels() const;
+	size_t GetFactorLevelsCount() const;
+	Value GetFactorValue(int r_value) const;
 
 	static RType LIST(const RType &child);
 	RType GetListChildType() const;

--- a/tools/rpkg/src/include/typesr.hpp
+++ b/tools/rpkg/src/include/typesr.hpp
@@ -39,6 +39,10 @@ enum class RTypeId {
 	INTEGER64,
 	LIST_OF_NULLS,
 	BLOB,
+
+	// No RType equivalent
+	BYTE,
+	LIST,
 };
 
 struct RType {
@@ -52,11 +56,13 @@ struct RType {
 	// copy assignment
 	inline RType &operator=(const RType &other) {
 		id_ = other.id_;
+		aux_ = other.aux_;
 		return *this;
 	}
 	// move assignment
 	inline RType &operator=(RType &&other) noexcept {
 		id_ = other.id_;
+		std::swap(aux_, other.aux_);
 		return *this;
 	}
 
@@ -88,8 +94,12 @@ struct RType {
 	static constexpr const RTypeId LIST_OF_NULLS = RTypeId::LIST_OF_NULLS;
 	static constexpr const RTypeId BLOB = RTypeId::BLOB;
 
+	static RType LIST(const RType &child);
+	RType GetListChildType() const;
+
 private:
 	RTypeId id_;
+	child_list_t<RType> aux_;
 };
 
 struct RApiTypes {

--- a/tools/rpkg/src/include/typesr.hpp
+++ b/tools/rpkg/src/include/typesr.hpp
@@ -16,7 +16,7 @@ struct DuckDBAltrepListEntryWrapper {
 	duckdb::unsafe_unique_array<data_t> data;
 };
 
-enum class RType {
+enum class RTypeId {
 	UNKNOWN,
 	LOGICAL,
 	INTEGER,
@@ -39,6 +39,57 @@ enum class RType {
 	INTEGER64,
 	LIST_OF_NULLS,
 	BLOB,
+};
+
+struct RType {
+	RType();
+	RType(RTypeId id); // NOLINT: Allow implicit conversion from `RTypeId`
+	RType(const RType &other);
+	RType(RType &&other) noexcept;
+
+	RTypeId id() const;
+
+	// copy assignment
+	inline RType &operator=(const RType &other) {
+		id_ = other.id_;
+		return *this;
+	}
+	// move assignment
+	inline RType &operator=(RType &&other) noexcept {
+		id_ = other.id_;
+		return *this;
+	}
+
+	bool operator==(const RType &rhs) const;
+	inline bool operator!=(const RType &rhs) const {
+		return !(*this == rhs);
+	}
+
+	static constexpr const RTypeId UNKNOWN = RTypeId::UNKNOWN;
+	static constexpr const RTypeId LOGICAL = RTypeId::LOGICAL;
+	static constexpr const RTypeId INTEGER = RTypeId::INTEGER;
+	static constexpr const RTypeId NUMERIC = RTypeId::NUMERIC;
+	static constexpr const RTypeId STRING = RTypeId::STRING;
+	static constexpr const RTypeId FACTOR = RTypeId::FACTOR;
+	static constexpr const RTypeId DATE = RTypeId::DATE;
+	static constexpr const RTypeId DATE_INTEGER = RTypeId::DATE_INTEGER;
+	static constexpr const RTypeId TIMESTAMP = RTypeId::TIMESTAMP;
+	static constexpr const RTypeId TIME_SECONDS = RTypeId::TIME_SECONDS;
+	static constexpr const RTypeId TIME_MINUTES = RTypeId::TIME_MINUTES;
+	static constexpr const RTypeId TIME_HOURS = RTypeId::TIME_HOURS;
+	static constexpr const RTypeId TIME_DAYS = RTypeId::TIME_DAYS;
+	static constexpr const RTypeId TIME_WEEKS = RTypeId::TIME_WEEKS;
+	static constexpr const RTypeId TIME_SECONDS_INTEGER = RTypeId::TIME_SECONDS_INTEGER;
+	static constexpr const RTypeId TIME_MINUTES_INTEGER = RTypeId::TIME_MINUTES_INTEGER;
+	static constexpr const RTypeId TIME_HOURS_INTEGER = RTypeId::TIME_HOURS_INTEGER;
+	static constexpr const RTypeId TIME_DAYS_INTEGER = RTypeId::TIME_DAYS_INTEGER;
+	static constexpr const RTypeId TIME_WEEKS_INTEGER = RTypeId::TIME_WEEKS_INTEGER;
+	static constexpr const RTypeId INTEGER64 = RTypeId::INTEGER64;
+	static constexpr const RTypeId LIST_OF_NULLS = RTypeId::LIST_OF_NULLS;
+	static constexpr const RTypeId BLOB = RTypeId::BLOB;
+
+private:
+	RTypeId id_;
 };
 
 struct RApiTypes {

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -94,9 +94,9 @@ void AppendListColumnSegment(const RType &rtype, SEXP *source_data, idx_t sexp_o
 		} else {
 			auto len = RApiTypes::GetVecSize(child_rtype, val);
 			result_data[i].offset = ListVector::GetListSize(result);
-			for (R_len_t i = 0; i < len; i++) {
-				auto item = RApiTypes::SexpToValue(val, i);
-				ListVector::PushBack(result, item);
+			for (R_len_t child_idx = 0; child_idx < len; ++child_idx) {
+				auto child_item = RApiTypes::SexpToValue(val, child_idx);
+				ListVector::PushBack(result, child_item);
 			}
 			result_data[i].length = len;
 		}

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -80,9 +80,10 @@ static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context
 		data_ptr_t coldata_ptr = nullptr;
 
 		names.push_back(df_names[col_idx]);
-		rtypes.push_back(RApiTypes::DetectRType(coldata, integer64));
+		auto rtype = RApiTypes::DetectRType(coldata, integer64);
+		rtypes.push_back(rtype);
 
-		switch (rtypes[col_idx]) {
+		switch (rtype.id()) {
 		case RType::LOGICAL:
 			duckdb_col_type = LogicalType::BOOLEAN;
 			coldata_ptr = (data_ptr_t)LOGICAL_POINTER(coldata);
@@ -249,7 +250,7 @@ static void DataFrameScanFunc(ClientContext &context, TableFunctionInput &data, 
 		}
 
 		auto coldata_ptr = bind_data.data_ptrs[src_df_col_idx];
-		switch (bind_data.rtypes[src_df_col_idx]) {
+		switch (bind_data.rtypes[src_df_col_idx].id()) {
 		case RType::LOGICAL: {
 			auto data_ptr = (int *)coldata_ptr + sexp_offset;
 			AppendColumnSegment<int, bool, RBooleanType>(data_ptr, v, this_count);

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -50,6 +50,9 @@ data_ptr_t GetColDataPtr(const RType &rtype, SEXP coldata) {
 		return (data_ptr_t)DATAPTR_RO(coldata);
 	case RTypeId::LIST:
 		return (data_ptr_t)DATAPTR_RO(coldata);
+	case RTypeId::STRUCT:
+		// Will bind child columns dynamically. Could also optimize by descending early and recording.
+		return (data_ptr_t)coldata;
 	default:
 		cpp11::stop("rapi_execute: Unsupported column type for bind");
 	}

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -165,7 +165,7 @@ static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context
 		return_types.push_back(RApiTypes::LogicalTypeFromRType(rtype, experimental));
 		data_ptrs.push_back(coldata_ptr);
 	}
-	auto row_count = Rf_length(VECTOR_ELT(df, 0));
+	auto row_count = RApiTypes::GetVecSize(rtypes[0], VECTOR_ELT(df, 0));
 	return make_uniq<DataFrameScanBindData>(df, row_count, rtypes, data_ptrs, input.named_parameters);
 }
 

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -153,6 +153,7 @@ static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context
 			coldata_ptr = (data_ptr_t)INTEGER_POINTER(coldata);
 			duckdb_col_type = LogicalType::DATE;
 			break;
+		case RType::LIST_OF_NULLS:
 		case RType::BLOB:
 			coldata_ptr = (data_ptr_t)DATAPTR_RO(coldata);
 			duckdb_col_type = LogicalType::BLOB;
@@ -368,13 +369,12 @@ static void DataFrameScanFunc(ClientContext &context, TableFunctionInput &data, 
 			AppendColumnSegment<int, date_t, RDateType>(data_ptr, v, this_count);
 			break;
 		}
+		case RType::LIST_OF_NULLS:
 		case RType::BLOB: {
 			auto data_ptr = (SEXP *)coldata_ptr + sexp_offset;
 			AppendColumnSegment<SEXP, string_t, RRawSexpType>(data_ptr, v, this_count);
 			break;
 		}
-		case RType::LIST_OF_NULLS:
-			break;
 		default:
 			cpp11::stop("rapi_execute: Unsupported column type for scan");
 		}

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -135,6 +135,9 @@ static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context
 		case RType::BLOB:
 			coldata_ptr = (data_ptr_t)DATAPTR_RO(coldata);
 			break;
+		case RTypeId::LIST:
+			coldata_ptr = (data_ptr_t)DATAPTR_RO(coldata);
+			break;
 		default:
 			cpp11::stop("rapi_execute: Unsupported column type for bind");
 		}

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -86,12 +86,12 @@ void AppendListColumnSegment(const RType &rtype, SEXP *source_data, idx_t sexp_o
 	source_data += sexp_offset;
 	auto &result_mask = FlatVector::Validity(result);
 	auto child_rtype = rtype.GetListChildType();
+	auto result_data = FlatVector::GetData<list_entry_t>(result);
 	for (idx_t i = 0; i < count; i++) {
 		auto val = source_data[i];
 		if (RSexpType::IsNull(val)) {
 			result_mask.SetInvalid(i);
 		} else {
-			auto result_data = FlatVector::GetData<list_entry_t>(result);
 			auto len = RApiTypes::GetVecSize(child_rtype, val);
 			result_data[i].offset = ListVector::GetListSize(result);
 			for (R_len_t i = 0; i < len; i++) {

--- a/tools/rpkg/src/scan.cpp
+++ b/tools/rpkg/src/scan.cpp
@@ -30,17 +30,17 @@ static void AppendColumnSegment(SRC *source_data, idx_t sexp_offset, Vector &res
 	}
 }
 
-void AppendListColumnSegment(SEXP *source_data, idx_t sexp_offset, Vector &result, idx_t count) {
+void AppendListColumnSegment(const RType &rtype, SEXP *source_data, idx_t sexp_offset, Vector &result, idx_t count) {
 	source_data += sexp_offset;
 	auto &result_mask = FlatVector::Validity(result);
+	auto child_rtype = rtype.GetListChildType();
 	for (idx_t i = 0; i < count; i++) {
 		auto val = source_data[i];
 		if (RSexpType::IsNull(val)) {
 			result_mask.SetInvalid(i);
 		} else {
 			auto result_data = FlatVector::GetData<list_entry_t>(result);
-			// FIXME: Use vec_size() equivalent here
-			auto len = Rf_length(val);
+			auto len = RApiTypes::GetVecSize(child_rtype, val);
 			result_data[i].offset = ListVector::GetListSize(result);
 			for (R_len_t i = 0; i < len; i++) {
 				auto item = RApiTypes::SexpToValue(val, i);
@@ -181,7 +181,7 @@ void AppendAnyColumnSegment(const RType &rtype, bool experimental, data_ptr_t co
 	}
 	case RTypeId::LIST: {
 		auto data_ptr = (SEXP *)coldata_ptr;
-		AppendListColumnSegment(data_ptr, sexp_offset, v, this_count);
+		AppendListColumnSegment(rtype, data_ptr, sexp_offset, v, this_count);
 		break;
 	}
 	default:

--- a/tools/rpkg/src/types.cpp
+++ b/tools/rpkg/src/types.cpp
@@ -353,10 +353,10 @@ bool RStringSexpType::IsNull(SEXP val) {
 	return val == NA_STRING;
 }
 
-string_t RRawSexpType::Convert(SEXP val) {
-	return string_t((char *)RAW(val), Rf_xlength(val));
+bool RSexpType::IsNull(SEXP val) {
+	return val == R_NilValue;
 }
 
-bool RRawSexpType::IsNull(SEXP val) {
-	return val == R_NilValue;
+string_t RRawSexpType::Convert(SEXP val) {
+	return string_t((char *)RAW(val), Rf_xlength(val));
 }

--- a/tools/rpkg/src/types.cpp
+++ b/tools/rpkg/src/types.cpp
@@ -243,6 +243,17 @@ LogicalType RApiTypes::LogicalTypeFromRType(const RType &rtype, bool experimenta
 		return LogicalType::BLOB;
 	case RTypeId::LIST:
 		return LogicalType::LIST(RApiTypes::LogicalTypeFromRType(rtype.GetListChildType(), experimental));
+	case RTypeId::STRUCT: {
+		child_list_t<LogicalType> children;
+		for (auto child : rtype.GetStructChildTypes()) {
+			children.push_back(
+			    std::make_pair(child.first, RApiTypes::LogicalTypeFromRType(child.second, experimental)));
+		}
+		if (children.size() == 0) {
+			cpp11::stop("rapi_execute: Packed column must have at least one column");
+		}
+		return LogicalType::STRUCT(std::move(children));
+	}
 
 	default:
 		cpp11::stop("rapi_execute: Can't convert R type to logical type");

--- a/tools/rpkg/src/types.cpp
+++ b/tools/rpkg/src/types.cpp
@@ -8,6 +8,26 @@
 
 using namespace duckdb;
 
+RType::RType() : id_(RTypeId::UNKNOWN) {
+}
+
+RType::RType(RTypeId id) : id_(id) {
+}
+
+RType::RType(const RType &other) : id_(other.id_) {
+}
+
+RType::RType(RType &&other) noexcept : id_(other.id_) {
+}
+
+RTypeId RType::id() const {
+	return id_;
+}
+
+bool RType::operator==(const RType &rhs) const {
+	return id_ == rhs.id_;
+}
+
 RType RApiTypes::DetectRType(SEXP v, bool integer64) {
 	if (TYPEOF(v) == REALSXP && Rf_inherits(v, "POSIXct")) {
 		return RType::TIMESTAMP;

--- a/tools/rpkg/src/types.cpp
+++ b/tools/rpkg/src/types.cpp
@@ -73,6 +73,17 @@ RType RType::GetListChildType() const {
 	return aux_.front().second;
 }
 
+RType RType::STRUCT(child_list_t<RType> &&children) {
+	RType out = RType(RTypeId::LIST);
+	std::swap(out.aux_, children);
+	return out;
+}
+
+child_list_t<RType> RType::GetStructChildTypes() const {
+	D_ASSERT(id_ == RTypeId::STRUCT);
+	return aux_;
+}
+
 RType RApiTypes::DetectRType(SEXP v, bool integer64) {
 	if (TYPEOF(v) == REALSXP && Rf_inherits(v, "POSIXct")) {
 		return RType::TIMESTAMP;

--- a/tools/rpkg/src/types.cpp
+++ b/tools/rpkg/src/types.cpp
@@ -218,6 +218,9 @@ LogicalType RApiTypes::LogicalTypeFromRType(const RType &rtype, bool experimenta
 	case RType::LIST_OF_NULLS:
 	case RType::BLOB:
 		return LogicalType::BLOB;
+	case RTypeId::LIST:
+		return LogicalType::LIST(RApiTypes::LogicalTypeFromRType(rtype.GetListChildType(), experimental));
+
 	default:
 		cpp11::stop("rapi_execute: Unsupported column type for bind");
 	}

--- a/tools/rpkg/src/types.cpp
+++ b/tools/rpkg/src/types.cpp
@@ -245,7 +245,7 @@ LogicalType RApiTypes::LogicalTypeFromRType(const RType &rtype, bool experimenta
 		return LogicalType::LIST(RApiTypes::LogicalTypeFromRType(rtype.GetListChildType(), experimental));
 	case RTypeId::STRUCT: {
 		child_list_t<LogicalType> children;
-		for (auto child : rtype.GetStructChildTypes()) {
+		for (const auto &child : rtype.GetStructChildTypes()) {
 			children.push_back(
 			    std::make_pair(child.first, RApiTypes::LogicalTypeFromRType(child.second, experimental)));
 		}

--- a/tools/rpkg/src/types.cpp
+++ b/tools/rpkg/src/types.cpp
@@ -222,7 +222,7 @@ LogicalType RApiTypes::LogicalTypeFromRType(const RType &rtype, bool experimenta
 		return LogicalType::LIST(RApiTypes::LogicalTypeFromRType(rtype.GetListChildType(), experimental));
 
 	default:
-		cpp11::stop("rapi_execute: Unsupported column type for bind");
+		cpp11::stop("rapi_execute: Can't convert R type to logical type");
 	}
 }
 

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -97,6 +97,16 @@ static void AppendColumnSegment(SRC *source_data, Vector &result, idx_t count) {
 	}
 }
 
+R_len_t RApiTypes::GetVecSize(RType rtype, SEXP coldata) {
+	while (rtype.id() == RTypeId::STRUCT) {
+		rtype = rtype.GetStructChildTypes()[0].second;
+		D_ASSERT(TYPEOF(coldata) == VECSXP);
+		coldata = VECTOR_ELT(coldata, 0);
+	}
+	// This still isn't quite accurate, but good enough for the types we support.
+	return Rf_length(coldata);
+}
+
 Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx) {
 	auto rtype = RApiTypes::DetectRType(valsexp, false); // TODO
 	switch (rtype.id()) {

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -192,7 +192,7 @@ Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx) {
 		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeWeeksType::Convert(ts_val));
 	}
 	case RType::LIST_OF_NULLS:
-		return Value();
+		return Value(LogicalType::BLOB);
 	case RType::BLOB: {
 		auto ts_val = VECTOR_ELT(valsexp, idx);
 		return Rf_isNull(ts_val) ? Value(LogicalType::BLOB) : Value::BLOB(RAW(ts_val), Rf_xlength(ts_val));

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -121,16 +121,9 @@ Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx) {
 		auto str_val = STRING_ELT(ToUtf8(valsexp), idx);
 		return str_val == NA_STRING ? Value(LogicalType::VARCHAR) : Value(CHAR(str_val));
 	}
-	case RType::FACTOR: {
+	case RTypeId::FACTOR: {
 		auto int_val = INTEGER_POINTER(valsexp)[idx];
-		auto levels = GET_LEVELS(valsexp);
-		bool is_null = RIntegerType::IsNull(int_val);
-		if (!is_null) {
-			auto str_val = STRING_ELT(levels, int_val - 1);
-			return Value(CHAR(str_val));
-		} else {
-			return Value(LogicalType::VARCHAR);
-		}
+		return rtype.GetFactorValue(int_val);
 	}
 	case RType::TIMESTAMP: {
 		auto ts_val = NUMERIC_POINTER(valsexp)[idx];

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -200,6 +200,16 @@ Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx) {
 		auto ts_val = VECTOR_ELT(valsexp, idx);
 		return Rf_isNull(ts_val) ? Value(LogicalType::BLOB) : Value::BLOB(RAW(ts_val), Rf_xlength(ts_val));
 	}
+	case RTypeId::STRUCT: {
+		child_list_t<Value> child_values;
+		auto ncol = Rf_length(valsexp);
+		auto child_rtypes = rtype.GetStructChildTypes();
+		for (R_len_t col = 0; col < ncol; ++col) {
+			auto value = SexpToValue(VECTOR_ELT(valsexp, col), idx);
+			child_values.push_back(std::make_pair(child_rtypes[col].first, value));
+		}
+		return Value::STRUCT(std::move(child_values));
+	}
 	default:
 		cpp11::stop("duckdb_sexp_to_value: Unsupported type");
 		return Value();

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -99,7 +99,7 @@ static void AppendColumnSegment(SRC *source_data, Vector &result, idx_t count) {
 
 Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx) {
 	auto rtype = RApiTypes::DetectRType(valsexp, false); // TODO
-	switch (rtype) {
+	switch (rtype.id()) {
 	case RType::LOGICAL: {
 		auto lgl_val = INTEGER_POINTER(valsexp)[idx];
 		return RBooleanType::IsNull(lgl_val) ? Value(LogicalType::BOOLEAN) : Value::BOOLEAN(lgl_val);

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -200,6 +200,17 @@ Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx) {
 		auto ts_val = VECTOR_ELT(valsexp, idx);
 		return Rf_isNull(ts_val) ? Value(LogicalType::BLOB) : Value::BLOB(RAW(ts_val), Rf_xlength(ts_val));
 	}
+	case RTypeId::LIST: {
+		auto ts_val = VECTOR_ELT(valsexp, idx);
+		auto child_rtype = rtype.GetListChildType();
+		vector<Value> child_values;
+		R_len_t child_len = GetVecSize(child_rtype, ts_val);
+		for (R_len_t child_idx = 0; child_idx < child_len; ++child_idx) {
+			auto value = SexpToValue(ts_val, child_idx);
+			child_values.push_back(value);
+		}
+		return Value::LIST(std::move(child_values));
+	}
 	case RTypeId::STRUCT: {
 		child_list_t<Value> child_values;
 		auto ncol = Rf_length(valsexp);

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -195,6 +195,8 @@ Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx) {
 		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeWeeksType::Convert(ts_val));
 	}
 	case RType::LIST_OF_NULLS:
+		// Performance shortcut: this corresponds to the RType::BLOB case,
+		// but we already know that all values are NULL
 		return Value(LogicalType::BLOB);
 	case RType::BLOB: {
 		auto ts_val = VECTOR_ELT(valsexp, idx);

--- a/tools/rpkg/tests/testthat/test_register.R
+++ b/tools/rpkg/tests/testthat/test_register.R
@@ -72,8 +72,19 @@ test_that("experimental string handling works", {
   on.exit(dbDisconnect(con, shutdown = TRUE))
   df <- data.frame(a=c(NA, as.character(1:10000)))
 
- duckdb_register(con, "df", df, experimental=TRUE)
+  duckdb_register(con, "df", df, experimental=TRUE)
 
   expect_equal(df, dbGetQuery(con, "SELECT a::STRING a FROM df"))
   expect_equal(df, dbGetQuery(con, "SELECT a FROM df"))
+})
+
+test_that("can register list of NULL values", {
+  con <- dbConnect(duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+  df <- tibble::tibble(a = 1:2, b = list(NULL))
+
+  expect_silent(duckdb_register(con, "df1", df))
+  expect_silent(duckdb_register(con, "df2", df[0, ]))
+
+  expect_equal(dbGetQuery(con, "SELECT * FROM df1"), as.data.frame(df))
 })

--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -134,19 +134,35 @@ test_that("nested and packed columns work in full", {
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   df <- vctrs::data_frame(
-    a = vctrs::data_frame(x = 1:5, y = 6:10),
+    a = vctrs::data_frame(
+      x = 1:5,
+      y = as.numeric(6:10),
+      z = vctrs::data_frame(
+        k = c(TRUE, FALSE, NA, TRUE, FALSE),
+        l = letters[1:5]
+      )
+    ),
     b = list(
-      vctrs::data_frame(u = 1:2, v = 3:4, w = 5:6)
+      vctrs::data_frame(
+        u = structure(as.numeric(19577:19578), class = "Date"),
+        v = structure(19577:19578, class = "Date"),
+        w = structure(1691507820, class = c("POSIXct", "POSIXt"), tzone = "UTC") + 0:1
+      )
     ),
     c = list(
       vctrs::data_frame(
-        d = 13:16,
-        e = vctrs::data_frame(u = 1:4, v = 5:8, w = as.list(9:12))
+        # TIME_MINUTES, TIME_MINUTES_INTEGER, TIME_HOURS, ... etc.: Loss ok
+        d = structure(as.numeric(13:16), class = "difftime", units = "secs"),
+        e = vctrs::data_frame(
+          u = structure(17:20, class = "difftime", units = "secs"),
+          v = 5:8,
+          w = as.list(9:12)
+        )
       )
     ),
     f = list(
       vctrs::data_frame(
-        g = 13:16,
+        g = list(as.raw(13), as.raw(14:15), as.raw(16:18), as.raw(19:22)),
         h = vctrs::data_frame(u = 1:4, v = 5:8, w = list(vctrs::data_frame(s = 9:10)))
       )
     ),

--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -108,3 +108,17 @@ test_that("structs give the same results via Arrow", {
     )
   ))
 })
+
+test_that("nested lists of atomic values can be written", {
+  skip_if_not_installed("vctrs")
+
+  con <- dbConnect(duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  df <- vctrs::data_frame(a = 1:3, b = list(4:6, 2:3, 1L))
+  dbWriteTable(con, "df", df)
+  expect_equal(dbReadTable(con, "df"), df)
+
+  duckdb_register(con, "df_reg", df)
+  expect_equal(dbReadTable(con, "df_reg"), df)
+})

--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -122,3 +122,35 @@ test_that("nested lists of atomic values can be written", {
   duckdb_register(con, "df_reg", df)
   expect_equal(dbReadTable(con, "df_reg"), df)
 })
+
+test_that("nested and packed columns work in full", {
+  skip_if_not_installed("vctrs")
+
+  con <- dbConnect(duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  df <- vctrs::data_frame(
+    a = vctrs::data_frame(x = 1:5, y = 6:10),
+    b = list(
+      vctrs::data_frame(u = 1:2, v = 3:4, w = 5:6)
+    ),
+    c = list(
+      vctrs::data_frame(
+        d = 13:16,
+        e = vctrs::data_frame(u = 1:4, v = 5:8, w = as.list(9:12))
+      )
+    ),
+    f = list(
+      vctrs::data_frame(
+        g = 13:16,
+        h = vctrs::data_frame(u = 1:4, v = 5:8, w = list(vctrs::data_frame(s = 9:10)))
+      )
+    ),
+    i = "plain old"
+  )
+  dbWriteTable(con, "df", df)
+  expect_equal(dbReadTable(con, "df"), df)
+
+  duckdb_register(con, "df_reg", df)
+  expect_equal(dbReadTable(con, "df_reg"), df)
+})

--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -121,6 +121,10 @@ test_that("nested lists of atomic values can be written", {
 
   duckdb_register(con, "df_reg", df)
   expect_equal(dbReadTable(con, "df_reg"), df)
+
+  df2 <- vctrs::data_frame(a = 1:2, b = list(4:6, letters[2:3]))
+  expect_error(dbWriteTable(con, "df2", df2), "register")
+  expect_error(duckdb_register(con, "df2_reg", df2), "register")
 })
 
 test_that("nested and packed columns work in full", {


### PR DESCRIPTION
This adds support for lists of atomic vectors. All elements must be of the same type for this to work. The commits make sense individually, but mostly depend on each other.

ALTREP support can be built on top of that.

Closes #2841.