### PR TITLE
Fix total_cardinality is zero will result in undefined-behavior

### DIFF
--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -589,6 +589,9 @@ bool Executor::GetPipelinesProgress(double &current_progress) { // LCOV_EXCL_STA
 		total_cardinality += child_cardinality;
 	}
 	current_progress = 0;
+	if (total_cardinality == 0) {
+		return true;
+	}
 	for (size_t i = 0; i < progress.size(); i++) {
 		current_progress += progress[i] * double(cardinality[i]) / double(total_cardinality);
 	}

--- a/test/sql/select/test_select_empty_table.test
+++ b/test/sql/select/test_select_empty_table.test
@@ -1,0 +1,10 @@
+# name: test/sql/select/test_select_empty_table.test
+# description: Test select empty table
+# group: [select]
+
+statement ok
+CREATE TABLE integers(i INTEGER)
+
+query I
+SELECT * FROM integers
+----


### PR DESCRIPTION
It will result in undefined-behavior error in some compiler when `total_cardinality ` is zero.
 
see #8490 