### PR TITLE
Fix #3170: Get old value when update on rows with big row_id

### DIFF
--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -427,7 +427,7 @@ void UpdateSegment::FetchRow(TransactionData transaction, idx_t row_id, Vector &
 	if (!root->info[vector_index]) {
 		return;
 	}
-	idx_t row_in_vector = row_id - vector_index * STANDARD_VECTOR_SIZE;
+	idx_t row_in_vector = (row_id - column_data.start) - vector_index * STANDARD_VECTOR_SIZE;
 	fetch_row_function(transaction.start_time, transaction.transaction_id, root->info[vector_index]->info.get(),
 	                   row_in_vector, result, result_idx);
 }

--- a/test/sql/update/test_update_issue_3170.test
+++ b/test/sql/update/test_update_issue_3170.test
@@ -1,6 +1,7 @@
 # name: test/sql/update/test_update_issue_3170.test
 # description: Update indexed table rows with large row_id ( > 122879) which cross the first segment/row_group.
 # group: [update]
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/update/test_update_issue_3170.test
+++ b/test/sql/update/test_update_issue_3170.test
@@ -1,0 +1,63 @@
+# name: test/sql/update/test_update_issue_3170.test
+# description: Update indexed table rows with large row_id ( > 122879) which cross the first segment/row_group.
+# group: [update]
+statement ok
+PRAGMA enable_verification
+
+# create a table
+statement ok
+CREATE TABLE student(id INTEGER,name VARCHAR,PRIMARY KEY(id));
+
+statement ok
+INSERT INTO student SELECT i, 'creator' FROM RANGE(260001) tbl(i)
+
+# read
+# rowgroup 0
+query I
+SELECT name FROM student WHERE id = 122879
+----
+creator
+
+# rowgroup 1
+query I
+SELECT name FROM student WHERE id = 122881
+----
+creator
+
+# rowgroup 2
+query I
+SELECT name FROM student WHERE id = 245780
+----
+creator
+
+# Update
+# rowgroup 0
+statement ok
+UPDATE student SET name = 'updator0' WHERE id = 122879
+
+# rowgroup 1
+statement ok
+UPDATE student SET name = 'updator1' WHERE id = 122881
+
+# rowgroup 2 
+statement ok
+UPDATE student SET name = 'updator2' WHERE id = 245780
+
+# read again
+# rowgroup 0
+query I
+SELECT name FROM student WHERE id = 122879
+----
+updator0
+
+# rowgroup 1
+query I
+SELECT name FROM student WHERE id = 122881
+----
+updator1
+
+# rowgroup 2
+query I
+SELECT name FROM student WHERE id = 245780
+----
+updator2

--- a/test/sql/update/test_update_issue_3170.test
+++ b/test/sql/update/test_update_issue_3170.test
@@ -31,6 +31,12 @@ SELECT name FROM student WHERE id = 245780
 ----
 creator
 
+# rowgroup 1 vector > 0
+query I
+SELECT name FROM student WHERE id = 150881
+----
+creator
+
 # Update
 # rowgroup 0
 statement ok
@@ -43,6 +49,11 @@ UPDATE student SET name = 'updator1' WHERE id = 122881
 # rowgroup 2 
 statement ok
 UPDATE student SET name = 'updator2' WHERE id = 245780
+
+# rowgroup 1 vector > 0
+statement ok
+UPDATE student SET name = 'updator3' WHERE id = 150881
+
 
 # read again
 # rowgroup 0
@@ -62,3 +73,38 @@ query I
 SELECT name FROM student WHERE id = 245780
 ----
 updator2
+
+# rowgroup 1 vector > 0
+query I
+SELECT name FROM student WHERE id = 150881
+----
+updator3
+
+# original issue
+load __TEST_DIR__/list_index_compression.db
+
+statement ok
+CREATE TABLE student(id INTEGER,name VARCHAR,PRIMARY KEY(id));
+
+statement ok
+insert into student select i, 'creator' from range(130001) tbl(i);
+
+query II
+select id, name from student where id=122881;
+----
+122881	creator
+
+statement ok
+update student set name = 'updator' where id = 122881;
+
+query II
+select id, name from student where id=122881;
+----
+122881	updator
+
+restart
+
+query II
+select id, name from student where id=122881;
+----
+122881	updator


### PR DESCRIPTION
Symptom
===============
fix #3170. When id bigger than 122880 update successful but get older value.


Root Cause
===============
A segment/rowgroup stores 122880 rows. In UpdateSegment::FetchRow(), when the updated row is not in the first segment/rowgroup, the row_in_vector was incorrectly caculated which not take column_data.start into account.
In this case, the updated row cannot be fetched and old value was returned.


Fix
===============
row_in_vector calculation should be based on column_data.start.


Test 
===============
New tests added.