### PR TITLE
Add android ifdefs

### DIFF
--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -11,6 +11,6 @@
 duckdb_extension_load(parquet)
 
 # Jemalloc is enabled by default for linux. MacOS malloc is already good enough and Jemalloc on windows has issues.
-if(NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND OS_NAME STREQUAL "linux")
+if(NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND OS_NAME STREQUAL "linux" AND NOT ANDROID)
     duckdb_extension_load(jemalloc)
 endif()

--- a/src/function/table/version/pragma_version.cpp
+++ b/src/function/table/version/pragma_version.cpp
@@ -89,6 +89,9 @@ string DuckDB::Platform() {
 		postfix = "_gcc4";
 	}
 #endif
+#if defined(__ANDROID__)
+	postfix += "_android"; // using + because it may also be gcc4
+#endif
 #ifdef __MINGW32__
 	postfix = "_mingw";
 #endif


### PR DESCRIPTION
Android uses its own [special allocator](https://source.android.com/docs/security/test/scudo).

Additionally, Android has its own special standard libraries that need to be linked against (which is handled automatically), but means all binaries need to be specially built.