### PR TITLE
[Dev] Fix CI failure caused by #7113

### DIFF
--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -46,7 +46,7 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 		// catalog was modified or statement does not have clear types: rebind the statement before running the execute
 		Planner prepared_planner(context);
 		for (auto &pair : bind_values) {
-			prepared_planner.parameter_data.emplace(pair);
+			prepared_planner.parameter_data.emplace(std::make_pair(pair.first, BoundParameterData(pair.second)));
 		}
 		prepared = prepared_planner.PrepareSQLStatement(entry->second->unbound_statement->Copy());
 		rebound_plan = std::move(prepared_planner.plan);


### PR DESCRIPTION
GCC4.8 seems to not be happy about us wanting to implicitly construct a `std::pair<string, BoundValueParameter>` from a `std::pair<string, Value>` even though this constructor exists:
```c++
	explicit BoundParameterData(Value val) : value(std::move(val)), return_type(value.type()) {
	}
```

We now explicitly construct the pair, hopefully making GCC4.8 happy

This was the (seemingly innocuous) diff:
```patch
-		for (idx_t i = 0; i < bind_values.size(); i++) {
-			prepared_planner.parameter_data.emplace_back(bind_values[i]);
+		for (auto &pair : bind_values) {
+			prepared_planner.parameter_data.emplace(pair);
```
(they used to be vectors, and are now maps)