### PR TITLE
fix: remove unused ForwardRef import

### DIFF
--- a/tools/pythonpkg/pyduckdb/spark/sql/session.py
+++ b/tools/pythonpkg/pyduckdb/spark/sql/session.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple, Any, Union, Iterable, ForwardRef, TYPE_CHECKING
+from typing import Optional, List, Tuple, Any, Union, Iterable, TYPE_CHECKING
 import uuid
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This was breaking the nightly builds (it isn't available in Python 3.6)

Though perhaps we should just drop Python 3.6? We already dropped it for linux apparently