### PR TITLE
Add fix for substrait CI failure

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -87,5 +87,6 @@ if (NOT WIN32)
             DONT_LINK
             GIT_URL https://github.com/duckdblabs/substrait
             GIT_TAG 0cd88fa8b240babe5316924e32fb68aaba408780
+            APPLY_PATCHES
             )
 endif()

--- a/.github/patches/extensions/substrait/substrait_materialize_result.patch
+++ b/.github/patches/extensions/substrait/substrait_materialize_result.patch
@@ -1,43 +1,56 @@
-diff --git a/duckdb b/duckdb
-index 811683f..02412e1 160000
---- a/duckdb
-+++ b/duckdb
-@@ -1 +1 @@
--Subproject commit 811683f695f8db22948950e25018d62ff3357237
-+Subproject commit 02412e10151c893be139082cf3f1362f455308b0
 diff --git a/src/substrait_extension.cpp b/src/substrait_extension.cpp
-index 06fd2b2..b4faf3e 100644
+index a2f03b1..c24497f 100644
 --- a/src/substrait_extension.cpp
 +++ b/src/substrait_extension.cpp
-@@ -74,7 +74,16 @@ static void VerifySubstraitRoundtrip(unique_ptr<LogicalOperator> &query_plan, Co
+@@ -71,13 +71,26 @@ static void VerifySubstraitRoundtrip(unique_ptr<LogicalOperator> &query_plan, Co
+                                      ToSubstraitFunctionData &data, const string &serialized, bool json) {
+ 	// We round-trip the generated json and verify if the result is the same
+ 	auto actual_result = con.Query(data.query);
++
  	auto sub_relation = SubstraitPlanToDuckDBRel(con, serialized, json);
  	auto substrait_result = sub_relation->Execute();
  	substrait_result->names = actual_result->names;
 -	if (!actual_result->Equals(*substrait_result)) {
-+	unique_ptr<QueryResult> substrait_materialized;
++	unique_ptr<MaterializedQueryResult> substrait_materialized;
 +
 +	if (substrait_result->type == QueryResultType::STREAM_RESULT) {
 +		auto &stream_query = substrait_result->Cast<duckdb::StreamQueryResult>();
-+		substrait_materialized = stream_query.Materialize();
-+	} else {
-+		substrait_materialized = std::move(substrait_result);
-+	}
 +
-+	if (!actual_result->Equals(*substrait_materialized)) {
++		substrait_materialized = stream_query.Materialize();
++	} else if (substrait_result->type == QueryResultType::MATERIALIZED_RESULT) {
++		substrait_materialized = unique_ptr_cast<QueryResult, MaterializedQueryResult>(std::move(substrait_result));
++	}
++	auto actual_col_coll = actual_result->Collection();
++	auto subs_col_coll = substrait_materialized->Collection();
++	string error_message;
++	if (!ColumnDataCollection::ResultEquals(actual_col_coll, subs_col_coll, error_message)) {
  		query_plan->Print();
  		sub_relation->Print();
- 		throw InternalException("The query result of DuckDB's query plan does not match Substrait");
+-		throw InternalException("The query result of DuckDB's query plan does not match Substrait");
++		throw InternalException("The query result of DuckDB's query plan does not match Substrait : " + error_message);
+ 	}
+ }
+
 diff --git a/test/sql/test_substrait_parquet.test b/test/sql/test_substrait_parquet.test
-index ff662a8..9a2c710 100644
+index 9a2c710..76abfde 100644
 --- a/test/sql/test_substrait_parquet.test
 +++ b/test/sql/test_substrait_parquet.test
-@@ -34,9 +34,6 @@ CALL from_substrait('\x12\x09\x1A\x07\x10\x01\x1A\x03sum\x12\x07\x1A\x05\x10\x02
+@@ -34,11 +34,16 @@ CALL from_substrait('\x12\x09\x1A\x07\x10\x01\x1A\x03sum\x12\x07\x1A\x05\x10\x02
  ----
  19107076.83379995
- 
--# TODO FIXME
--mode skip
--
+
++loop i 0 1000
++
  # Test Globbing
  statement ok
  CALL get_substrait('select * from parquet_scan(''data/parquet-testing/glob*/t?.parquet'') order by i')
+
++endloop
++
+ statement error
+ CALL get_substrait('select * from parquet_scan('''') order by i')
+ ----
+-No files found that match the pattern ""
+\ No newline at end of file
++No files found that match the pattern ""
++

--- a/.github/patches/extensions/substrait/substrait_materialize_result.patch
+++ b/.github/patches/extensions/substrait/substrait_materialize_result.patch
@@ -1,0 +1,43 @@
+diff --git a/duckdb b/duckdb
+index 811683f..02412e1 160000
+--- a/duckdb
++++ b/duckdb
+@@ -1 +1 @@
+-Subproject commit 811683f695f8db22948950e25018d62ff3357237
++Subproject commit 02412e10151c893be139082cf3f1362f455308b0
+diff --git a/src/substrait_extension.cpp b/src/substrait_extension.cpp
+index 06fd2b2..b4faf3e 100644
+--- a/src/substrait_extension.cpp
++++ b/src/substrait_extension.cpp
+@@ -74,7 +74,16 @@ static void VerifySubstraitRoundtrip(unique_ptr<LogicalOperator> &query_plan, Co
+ 	auto sub_relation = SubstraitPlanToDuckDBRel(con, serialized, json);
+ 	auto substrait_result = sub_relation->Execute();
+ 	substrait_result->names = actual_result->names;
+-	if (!actual_result->Equals(*substrait_result)) {
++	unique_ptr<QueryResult> substrait_materialized;
++
++	if (substrait_result->type == QueryResultType::STREAM_RESULT) {
++		auto &stream_query = substrait_result->Cast<duckdb::StreamQueryResult>();
++		substrait_materialized = stream_query.Materialize();
++	} else {
++		substrait_materialized = std::move(substrait_result);
++	}
++
++	if (!actual_result->Equals(*substrait_materialized)) {
+ 		query_plan->Print();
+ 		sub_relation->Print();
+ 		throw InternalException("The query result of DuckDB's query plan does not match Substrait");
+diff --git a/test/sql/test_substrait_parquet.test b/test/sql/test_substrait_parquet.test
+index ff662a8..9a2c710 100644
+--- a/test/sql/test_substrait_parquet.test
++++ b/test/sql/test_substrait_parquet.test
+@@ -34,9 +34,6 @@ CALL from_substrait('\x12\x09\x1A\x07\x10\x01\x1A\x03sum\x12\x07\x1A\x05\x10\x02
+ ----
+ 19107076.83379995
+ 
+-# TODO FIXME
+-mode skip
+-
+ # Test Globbing
+ statement ok
+ CALL get_substrait('select * from parquet_scan(''data/parquet-testing/glob*/t?.parquet'') order by i')


### PR DESCRIPTION
The way the query result code works, is that it checks chunk per chunk.
However, we were sometimes checking materialized and stream query results, where chunks could be of different sizes. Although the final result would be the same.