### PR TITLE
[R] Fix retention of time component of TIMESTAMPS when converting time zones #8547

### DIFF
--- a/tools/rpkg/R/Result.R
+++ b/tools/rpkg/R/Result.R
@@ -112,8 +112,8 @@ tz_convert <- function(x, timezone) {
 }
 
 tz_force <- function(x, timezone) {
-  # convert to character, stripping the timezone
-  ct <- as.character(x, usetz = FALSE)
+  # convert to character in ISO format, stripping the timezone
+  ct <- format(x, format = "%Y-%m-%d %H:%M:%OS", usetz = FALSE)
   # recreate the POSIXct with specified timezone
   as.POSIXct(ct, tz = timezone)
 }


### PR DESCRIPTION
This PR fixes #8547, by switching out the use of `as.character()` with `format()` and an explicit datetime format to ensure retention of the time component.

Starting with a failing test, which [fails](https://github.com/duckdb/duckdb/actions/runs/5836807777/job/15831126118#step:7:363) before the patch, and passes after.