### PR TITLE
Silence warnings on thread sanitizer for CanHave[No]Null

### DIFF
--- a/.sanitizer-thread-suppressions.txt
+++ b/.sanitizer-thread-suppressions.txt
@@ -6,3 +6,5 @@ race:~ColumnSegment
 race:duckdb_moodycamel
 race:duckdb_jemalloc
 race:AddToEvictionQueue
+race:CanHaveNull
+race:CanHaveNoNull


### PR DESCRIPTION
This fixes nightly failures on thread sanitiser job.
Failing on master: https://github.com/duckdb/duckdb/actions/runs/5838251913/job/15835277024#step:6:2604
Working (on my fork CI): https://github.com/carlopi/duckdb/actions/runs/5834538365/job/15824296600

@Mytherin had suggested adding to the suppression list since warning is a false positive.