### PR TITLE
Fix: Unimplemented type for TryAddOperator

### DIFF
--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -250,7 +250,7 @@ function/pragma_function.cpp	6
 function/scalar/generic/constant_or_null.cpp	5
 function/scalar/list/list_concat.cpp	5
 function/scalar/list/list_extract.cpp	10
-function/scalar/operators/add.cpp	4
+function/scalar/operators/add.cpp	6
 function/scalar/operators/arithmetic.cpp	23
 function/scalar/operators/multiply.cpp	3
 function/scalar/operators/subtract.cpp	5

--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -250,7 +250,7 @@ function/pragma_function.cpp	6
 function/scalar/generic/constant_or_null.cpp	5
 function/scalar/list/list_concat.cpp	5
 function/scalar/list/list_extract.cpp	10
-function/scalar/operators/add.cpp	6
+function/scalar/operators/add.cpp	4
 function/scalar/operators/arithmetic.cpp	23
 function/scalar/operators/multiply.cpp	3
 function/scalar/operators/subtract.cpp	5

--- a/src/function/scalar/operators/add.cpp
+++ b/src/function/scalar/operators/add.cpp
@@ -162,8 +162,11 @@ bool TryAddOperator::Operation(int64_t left, int64_t right, int64_t &result) {
 
 template <>
 bool TryAddOperator::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {
+	if (!Hugeint::AddInPlace(left, right)) {
+		return false;
+	}
 	result = left;
-	return Hugeint::AddInPlace(result, right);
+	return true;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/function/scalar/operators/add.cpp
+++ b/src/function/scalar/operators/add.cpp
@@ -160,6 +160,12 @@ bool TryAddOperator::Operation(int64_t left, int64_t right, int64_t &result) {
 	return true;
 }
 
+template <>
+bool TryAddOperator::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {
+	result = left;
+	return Hugeint::AddInPlace(result, right);
+}
+
 //===--------------------------------------------------------------------===//
 // add decimal with overflow check
 //===--------------------------------------------------------------------===//

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -35,6 +35,9 @@ static scalar_function_t GetScalarIntegerFunction(PhysicalType type) {
 	case PhysicalType::INT64:
 		function = &ScalarFunction::BinaryFunction<int64_t, int64_t, int64_t, OP>;
 		break;
+	case PhysicalType::INT128:
+		function = &ScalarFunction::BinaryFunction<hugeint_t, hugeint_t, hugeint_t, OP>;
+		break;
 	case PhysicalType::UINT8:
 		function = &ScalarFunction::BinaryFunction<uint8_t, uint8_t, uint8_t, OP>;
 		break;
@@ -302,7 +305,7 @@ ScalarFunction AddFun::GetFunction(const LogicalType &left_type, const LogicalTy
 			function.serialize = SerializeDecimalArithmetic;
 			function.deserialize = DeserializeDecimalArithmetic<AddOperator, DecimalAddOverflowCheck>;
 			return function;
-		} else if (left_type.IsIntegral() && left_type.id() != LogicalTypeId::HUGEINT) {
+		} else if (left_type.IsIntegral()) {
 			return ScalarFunction("+", {left_type, right_type}, left_type,
 			                      GetScalarIntegerFunction<AddOperatorOverflowCheck>(left_type.InternalType()), nullptr,
 			                      nullptr, PropagateNumericStats<TryAddOperator, AddPropagateStatistics, AddOperator>);

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -567,7 +567,7 @@ ScalarFunction SubtractFun::GetFunction(const LogicalType &left_type, const Logi
 			function.serialize = SerializeDecimalArithmetic;
 			function.deserialize = DeserializeDecimalArithmetic<SubtractOperator, DecimalSubtractOverflowCheck>;
 			return function;
-		} else if (left_type.IsIntegral() && left_type.id() != LogicalTypeId::HUGEINT) {
+		} else if (left_type.IsIntegral()) {
 			return ScalarFunction(
 			    "-", {left_type, right_type}, left_type,
 			    GetScalarIntegerFunction<SubtractOperatorOverflowCheck>(left_type.InternalType()), nullptr, nullptr,
@@ -771,7 +771,7 @@ void MultiplyFun::RegisterFunction(BuiltinFunctions &set) {
 			function.serialize = SerializeDecimalArithmetic;
 			function.deserialize = DeserializeDecimalArithmetic<MultiplyOperator, DecimalMultiplyOverflowCheck>;
 			functions.AddFunction(function);
-		} else if (TypeIsIntegral(type.InternalType()) && type.id() != LogicalTypeId::HUGEINT) {
+		} else if (TypeIsIntegral(type.InternalType())) {
 			functions.AddFunction(ScalarFunction(
 			    {type, type}, type, GetScalarIntegerFunction<MultiplyOperatorOverflowCheck>(type.InternalType()),
 			    nullptr, nullptr,

--- a/src/include/duckdb/common/operator/add.hpp
+++ b/src/include/duckdb/common/operator/add.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/type_util.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/cast_helpers.hpp"
 
 namespace duckdb {
 
@@ -76,8 +77,8 @@ struct AddOperatorOverflowCheck {
 	static inline TR Operation(TA left, TB right) {
 		TR result;
 		if (!TryAddOperator::Operation(left, right, result)) {
-			throw OutOfRangeException("Overflow in addition of %s (%d + %d)!", TypeIdToString(GetTypeId<TA>()), left,
-			                          right);
+			throw OutOfRangeException("Overflow in addition of %s (%s + %s)!", TypeIdToString(GetTypeId<TA>()),
+			                          NumericHelper::ToString(left), NumericHelper::ToString(right));
 		}
 		return result;
 	}

--- a/src/include/duckdb/common/operator/add.hpp
+++ b/src/include/duckdb/common/operator/add.hpp
@@ -68,6 +68,8 @@ template <>
 bool TryAddOperator::Operation(int32_t left, int32_t right, int32_t &result);
 template <>
 DUCKDB_API bool TryAddOperator::Operation(int64_t left, int64_t right, int64_t &result);
+template <>
+bool TryAddOperator::Operation(hugeint_t left, hugeint_t right, hugeint_t &result);
 
 struct AddOperatorOverflowCheck {
 	template <class TA, class TB, class TR>

--- a/src/include/duckdb/common/operator/multiply.hpp
+++ b/src/include/duckdb/common/operator/multiply.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/type_util.hpp"
+#include "duckdb/common/types/cast_helpers.hpp"
 
 namespace duckdb {
 
@@ -64,8 +65,8 @@ struct MultiplyOperatorOverflowCheck {
 	static inline TR Operation(TA left, TB right) {
 		TR result;
 		if (!TryMultiplyOperator::Operation(left, right, result)) {
-			throw OutOfRangeException("Overflow in multiplication of %s (%d * %d)!", TypeIdToString(GetTypeId<TA>()),
-			                          left, right);
+			throw OutOfRangeException("Overflow in multiplication of %s (%s * %s)!", TypeIdToString(GetTypeId<TA>()),
+			                          NumericHelper::ToString(left), NumericHelper::ToString(right));
 		}
 		return result;
 	}

--- a/src/include/duckdb/common/operator/subtract.hpp
+++ b/src/include/duckdb/common/operator/subtract.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/type_util.hpp"
+#include "duckdb/common/types/cast_helpers.hpp"
 
 namespace duckdb {
 
@@ -75,8 +76,8 @@ struct SubtractOperatorOverflowCheck {
 	static inline TR Operation(TA left, TB right) {
 		TR result;
 		if (!TrySubtractOperator::Operation(left, right, result)) {
-			throw OutOfRangeException("Overflow in subtraction of %s (%d - %d)!", TypeIdToString(GetTypeId<TA>()), left,
-			                          right);
+			throw OutOfRangeException("Overflow in subtraction of %s (%s - %s)!", TypeIdToString(GetTypeId<TA>()),
+			                          NumericHelper::ToString(left), NumericHelper::ToString(right));
 		}
 		return result;
 	}


### PR DESCRIPTION
TryAddOperator used in the debugging of bitpacking for type `hugeint_t` was unimplemented, causing an abort when running the debug build. This PR implements the TryAddOperator for `hugeint_t`.