### PR TITLE
Fix gcc weird behaviour around template deduction (#8533)

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -317,7 +317,7 @@ ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &qu
 	if (values) {
 		auto &parameter_values = *values;
 		for (auto &value : parameter_values) {
-			planner.parameter_data.emplace(value);
+			planner.parameter_data.emplace(value.first, BoundParameterData(value.second));
 		}
 	}
 


### PR DESCRIPTION
Follow up of #8533, fixing a template deduction problem in older gcc compilers.

This should fix failures in nightly jobs Linux 32 bit, gcc 4.8 and Python Address Sanitizer. Tested in my fork at https://github.com/carlopi/duckdb/actions/runs/5864648533.