### PR TITLE
Remove packaging for Python 3.6

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -217,7 +217,7 @@ jobs:
       runs-on: macos-latest
       strategy:
        matrix:
-        python_build: [cp36-*, cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+        python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
       needs: linux-python3-9
       env:
         CIBW_BUILD: ${{ matrix.python_build}}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -271,12 +271,10 @@ jobs:
       runs-on: windows-2019
       strategy:
        matrix:
-        python_build: [cp36-*, cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+        python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' }}
         exclude:
-          - isRelease: false
-            python_build: 'cp36-*'
           - isRelease: false
             python_build: 'cp37-*'
           - isRelease: false

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -336,6 +336,7 @@ setup(
     data_files=data_files,
     packages=packages,
     include_package_data=True,
+    python_requires='>=3.7.0',
     setup_requires=setup_requires + ["setuptools_scm<7.0.0", 'pybind11>=2.6.0'],
     use_scm_version=setuptools_scm_conf,
     tests_require=['google-cloud-storage', 'mypy', 'pytest'],


### PR DESCRIPTION
Python 3.6 is already unsupported since end 2022, and now there are some build problem on Windows that I haven't found a workaoround to