### PR TITLE
R: Allow microsecond precision for timestamps

### DIFF
--- a/tools/rpkg/src/types.cpp
+++ b/tools/rpkg/src/types.cpp
@@ -166,7 +166,7 @@ date_t RDateType::Convert(double val) {
 }
 
 timestamp_t RTimestampType::Convert(double val) {
-	return Timestamp::FromEpochSeconds(val);
+	return Timestamp::FromEpochMicroSeconds(round(val * Interval::MICROS_PER_SEC));
 }
 
 dtime_t RTimeSecondsType::Convert(double val) {

--- a/tools/rpkg/tests/testthat/test_timestamp.R
+++ b/tools/rpkg/tests/testthat/test_timestamp.R
@@ -1,0 +1,9 @@
+test_that("fractional seconds can be roundtripped", {
+  con <- dbConnect(duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  df <- data.frame(a = as.POSIXct(1.234567 + (1:100) * 1e-6, tz = "UTC"))
+  dbWriteTable(con, "df", df)
+  df_out <- dbReadTable(con, "df")
+  expect_equal(df_out, df)
+})


### PR DESCRIPTION
This is what R supports too.

Fixes #8585.