### PR TITLE
Fuzzer #583: Orders Nary Aggregates

### DIFF
--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -468,11 +468,12 @@ struct SortedAggregateFunction {
 
 					// These are all simple updates, so use it if available
 					if (simple_update) {
-						simple_update(sliced.data.data(), aggr_bind_info, 1, agg_state.data(), sliced.size());
+						simple_update(sliced.data.data(), aggr_bind_info, sliced.data.size(), agg_state.data(),
+						              sliced.size());
 					} else {
 						// We are only updating a constant state
 						agg_state_vec.SetVectorType(VectorType::CONSTANT_VECTOR);
-						update(sliced.data.data(), aggr_bind_info, 1, agg_state_vec, sliced.size());
+						update(sliced.data.data(), aggr_bind_info, sliced.data.size(), agg_state_vec, sliced.size());
 					}
 
 					consumed += input_count;

--- a/test/fuzzer/duckfuzz/ordagg_nargs.test
+++ b/test/fuzzer/duckfuzz/ordagg_nargs.test
@@ -1,0 +1,19 @@
+# name: test/fuzzer/duckfuzz/ordagg_nargs.test
+# description: Ordered Aggregates with > 1 argument
+# group: [duckfuzz]
+
+statement ok
+create table all_types as 
+	select * exclude(small_enum, medium_enum, large_enum) 
+	from test_all_types() 
+	limit 0;
+
+statement ok
+SELECT cume_dist() OVER (ROWS 
+	BETWEEN UNBOUNDED PRECEDING 
+	AND regr_sxx(6311, 8320 
+		ORDER BY 1726 ASC NULLS FIRST, 
+			10101, 
+			(TRY_CAST(946 AS INTEGER[]) BETWEEN 2053 AND 182) DESC NULLS LAST) 
+		FILTER (WHERE 118) PRECEDING
+	)


### PR DESCRIPTION
Pass in the argument count for aggregates
instead of assuming it is always 1.