### PR TITLE
R: Avoid leaking format specifiers in `cpp11::stop()` calls

### DIFF
--- a/tools/rpkg/src/register.cpp
+++ b/tools/rpkg/src/register.cpp
@@ -42,7 +42,7 @@ using namespace duckdb;
 	static_cast<cpp11::sexp>(conn).attr("_registered_df_" + name) = R_NilValue;
 	auto res = conn->conn->Query("DROP VIEW IF EXISTS \"" + name + "\"");
 	if (res->HasError()) {
-		cpp11::stop(res->GetError().c_str());
+		cpp11::stop("%s", res->GetError().c_str());
 	}
 }
 

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -360,7 +360,7 @@ bool constant_expression_is_not_null(duckdb::expr_extptr_t expr) {
 
 static SEXP result_to_df(duckdb::unique_ptr<QueryResult> res) {
 	if (res->HasError()) {
-		stop(res->GetError());
+		stop("%s", res->GetError());
 	}
 	if (res->type == QueryResultType::STREAM_RESULT) {
 		res = ((StreamQueryResult &)*res).Materialize();
@@ -442,7 +442,7 @@ static SEXP result_to_df(duckdb::unique_ptr<QueryResult> res) {
 [[cpp11::register]] SEXP rapi_rel_sql(duckdb::rel_extptr_t rel, std::string sql) {
 	auto res = rel->rel->Query("_", sql);
 	if (res->HasError()) {
-		stop(res->GetError());
+		stop("%s", res->GetError());
 	}
 	return result_to_df(std::move(res));
 }


### PR DESCRIPTION
Processing error strings coming from elsewhere with `"%s"` .