### PR TITLE
[Python] Add support for `datetime64` columns with a time-unit that is not `ns`

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_type.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_type.hpp
@@ -18,30 +18,30 @@ namespace duckdb {
 // Pandas Specific Types (e.g., categorical, datetime_tz,...)
 enum class NumpyNullableType : uint8_t {
 	//! NumPy dtypes
-	BOOL = 0,      //! bool_, bool8
-	INT_8 = 1,     //! byte, int8
-	UINT_8 = 2,    //! ubyte, uint8
-	INT_16 = 3,    //! int16, short
-	UINT_16 = 4,   //! uint16, ushort
-	INT_32 = 5,    //! int32, intc
-	UINT_32 = 6,   //! uint32, uintc,
-	INT_64 = 7,    //! int64, int0, int_, intp, matrix
-	UINT_64 = 8,   //! uint64, uint, uint0, uintp
-	FLOAT_16 = 9,  //! float16, half
-	FLOAT_32 = 10,  //! float32, single
-	FLOAT_64 = 11,  //! float64, float_, double
-	OBJECT = 12,    //! object
-	UNICODE = 13,   //! <U1, unicode_, str_, str0
+	BOOL,        //! bool_, bool8
+	INT_8,       //! byte, int8
+	UINT_8,      //! ubyte, uint8
+	INT_16,      //! int16, short
+	UINT_16,     //! uint16, ushort
+	INT_32,      //! int32, intc
+	UINT_32,     //! uint32, uintc,
+	INT_64,      //! int64, int0, int_, intp, matrix
+	UINT_64,     //! uint64, uint, uint0, uintp
+	FLOAT_16,    //! float16, half
+	FLOAT_32,    //! float32, single
+	FLOAT_64,    //! float64, float_, double
+	OBJECT,      //! object
+	UNICODE,     //! <U1, unicode_, str_, str0
 	DATETIME_S,  //! datetime64[s], <M8[s]
-	DATETIME_MS,  //! datetime64[s], <M8[s]
-	DATETIME_NS,  //! datetime64[s], <M8[s]
-	DATETIME_US,  //! datetime64[s], <M8[s]
-	TIMEDELTA, //! timedelta64[D], timedelta64
+	DATETIME_MS, //! datetime64[ms], <M8[ms]
+	DATETIME_NS, //! datetime64[ns], <M8[ns]
+	DATETIME_US, //! datetime64[us], <M8[us]
+	TIMEDELTA,   //! timedelta64[D], timedelta64
 
 	//! ------------------------------------------------------------
 	//! Extension Types
 	//! ------------------------------------------------------------
-	CATEGORY,    //! category
+	CATEGORY, //! category
 };
 
 struct NumpyType {
@@ -61,6 +61,6 @@ enum class NumpyObjectType : uint8_t {
 };
 
 NumpyType ConvertNumpyType(const py::handle &col_type);
-LogicalType NumpyToLogicalType(const NumpyNullableType &col_type);
+LogicalType NumpyToLogicalType(const NumpyType &col_type);
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_type.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_type.hpp
@@ -12,34 +12,43 @@
 #include "duckdb_python/pybind11/pybind_wrapper.hpp"
 
 namespace duckdb {
+
 // Pandas has two different sets of types
 // NumPy dtypes (e.g., bool, int8,...)
 // Pandas Specific Types (e.g., categorical, datetime_tz,...)
 enum class NumpyNullableType : uint8_t {
 	//! NumPy dtypes
-	BOOL,      //! bool_, bool8
-	INT_8,     //! byte, int8
-	UINT_8,    //! ubyte, uint8
-	INT_16,    //! int16, short
-	UINT_16,   //! uint16, ushort
-	INT_32,    //! int32, intc
-	UINT_32,   //! uint32, uintc,
-	INT_64,    //! int64, int0, int_, intp, matrix
-	UINT_64,   //! uint64, uint, uint0, uintp
-	FLOAT_16,  //! float16, half
-	FLOAT_32,  //! float32, single
-	FLOAT_64,  //! float64, float_, double
-	OBJECT,    //! object
-	UNICODE,   //! <U1, unicode_, str_, str0
-	DATETIME,  //! datetime64[D], datetime64
+	BOOL = 0,      //! bool_, bool8
+	INT_8 = 1,     //! byte, int8
+	UINT_8 = 2,    //! ubyte, uint8
+	INT_16 = 3,    //! int16, short
+	UINT_16 = 4,   //! uint16, ushort
+	INT_32 = 5,    //! int32, intc
+	UINT_32 = 6,   //! uint32, uintc,
+	INT_64 = 7,    //! int64, int0, int_, intp, matrix
+	UINT_64 = 8,   //! uint64, uint, uint0, uintp
+	FLOAT_16 = 9,  //! float16, half
+	FLOAT_32 = 10,  //! float32, single
+	FLOAT_64 = 11,  //! float64, float_, double
+	OBJECT = 12,    //! object
+	UNICODE = 13,   //! <U1, unicode_, str_, str0
+	DATETIME_S,  //! datetime64[s], <M8[s]
+	DATETIME_MS,  //! datetime64[s], <M8[s]
+	DATETIME_NS,  //! datetime64[s], <M8[s]
+	DATETIME_US,  //! datetime64[s], <M8[s]
 	TIMEDELTA, //! timedelta64[D], timedelta64
 
 	//! ------------------------------------------------------------
 	//! Extension Types
 	//! ------------------------------------------------------------
 	CATEGORY,    //! category
-	DATETIME_TZ, //! datetime64[ns, TZ]
+};
 
+struct NumpyType {
+	NumpyNullableType type;
+	//! Optionally if the type is a DATETIME,
+	//! this indicates whether the type has timezone information
+	bool has_timezone = false;
 };
 
 enum class NumpyObjectType : uint8_t {
@@ -51,7 +60,7 @@ enum class NumpyObjectType : uint8_t {
 	DICT,      //! dict of numpy arrays of shape (n,)
 };
 
-NumpyNullableType ConvertNumpyType(const py::handle &col_type);
+NumpyType ConvertNumpyType(const py::handle &col_type);
 LogicalType NumpyToLogicalType(const NumpyNullableType &col_type);
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_bind.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_bind.hpp
@@ -12,7 +12,7 @@ struct RegisteredArray;
 class ClientContext;
 
 struct PandasColumnBindData {
-	NumpyNullableType numpy_type;
+	NumpyType numpy_type;
 	unique_ptr<PandasColumn> pandas_col;
 	unique_ptr<RegisteredArray> mask;
 	//! Only for categorical types

--- a/tools/pythonpkg/src/numpy/array_wrapper.cpp
+++ b/tools/pythonpkg/src/numpy/array_wrapper.cpp
@@ -574,11 +574,17 @@ string RawArrayWrapper::DuckDBToNumpyDtype(const LogicalType &type) {
 	case LogicalTypeId::DECIMAL:
 		return "float64";
 	case LogicalTypeId::TIMESTAMP:
+		return "datetime64[us]";
 	case LogicalTypeId::TIMESTAMP_TZ:
+		return "datetime64[us]";
 	case LogicalTypeId::TIMESTAMP_NS:
+		return "datetime64[ns]";
 	case LogicalTypeId::TIMESTAMP_MS:
+		return "datetime64[ms]";
 	case LogicalTypeId::TIMESTAMP_SEC:
+		return "datetime64[s]";
 	case LogicalTypeId::DATE:
+		// FIXME: should this not be 'date64[ns]' ?
 		return "datetime64[ns]";
 	case LogicalTypeId::INTERVAL:
 		return "timedelta64[ns]";
@@ -705,17 +711,8 @@ void ArrayWrapper::Append(idx_t current_offset, Vector &input, idx_t count) {
 		break;
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
-		may_have_null = ConvertColumn<timestamp_t, int64_t, duckdb_py_convert::TimestampConvert>(
-		    current_offset, dataptr, maskptr, idata, count);
-		break;
 	case LogicalTypeId::TIMESTAMP_SEC:
-		may_have_null = ConvertColumn<timestamp_t, int64_t, duckdb_py_convert::TimestampConvertSec>(
-		    current_offset, dataptr, maskptr, idata, count);
-		break;
 	case LogicalTypeId::TIMESTAMP_MS:
-		may_have_null = ConvertColumn<timestamp_t, int64_t, duckdb_py_convert::TimestampConvertMilli>(
-		    current_offset, dataptr, maskptr, idata, count);
-		break;
 	case LogicalTypeId::TIMESTAMP_NS:
 		may_have_null = ConvertColumn<timestamp_t, int64_t, duckdb_py_convert::TimestampConvertNano>(
 		    current_offset, dataptr, maskptr, idata, count);

--- a/tools/pythonpkg/src/numpy/numpy_bind.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_bind.cpp
@@ -33,13 +33,13 @@ void NumpyBind::Bind(const ClientContext &context, py::handle df, vector<PandasC
 
 		auto column = get_fun(df_columns[col_idx]);
 
-		if (bind_data.numpy_type == NumpyNullableType::FLOAT_16) {
+		if (bind_data.numpy_type.type == NumpyNullableType::FLOAT_16) {
 			bind_data.pandas_col = make_uniq<PandasNumpyColumn>(py::array(column.attr("astype")("float32")));
-			bind_data.numpy_type = NumpyNullableType::FLOAT_32;
+			bind_data.numpy_type.type = NumpyNullableType::FLOAT_32;
 			duckdb_col_type = NumpyToLogicalType(bind_data.numpy_type);
-		} else if (bind_data.numpy_type == NumpyNullableType::OBJECT &&
+		} else if (bind_data.numpy_type.type == NumpyNullableType::OBJECT &&
 		           string(py::str(df_types[col_idx])) == "string") {
-			bind_data.numpy_type = NumpyNullableType::CATEGORY;
+			bind_data.numpy_type.type = NumpyNullableType::CATEGORY;
 			auto enum_name = string(py::str(df_columns[col_idx]));
 			// here we call numpy.unique
 			// this function call will return the unique values of a given array
@@ -61,7 +61,7 @@ void NumpyBind::Bind(const ClientContext &context, py::handle df, vector<PandasC
 			duckdb_col_type = NumpyToLogicalType(bind_data.numpy_type);
 		}
 
-		if (bind_data.numpy_type == NumpyNullableType::OBJECT) {
+		if (bind_data.numpy_type.type == NumpyNullableType::OBJECT) {
 			PandasAnalyzer analyzer(config);
 			if (analyzer.Analyze(get_fun(df_columns[col_idx]))) {
 				duckdb_col_type = analyzer.AnalyzedType();

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -200,7 +200,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 	auto &numpy_col = reinterpret_cast<PandasNumpyColumn &>(*bind_data.pandas_col);
 	auto &array = numpy_col.array;
 
-	switch (bind_data.numpy_type) {
+	switch (bind_data.numpy_type.type) {
 	case NumpyNullableType::BOOL:
 		ScanNumpyMasked<bool>(bind_data, count, offset, out);
 		break;
@@ -234,11 +234,35 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 	case NumpyNullableType::FLOAT_64:
 		ScanNumpyFpColumn<double>(reinterpret_cast<const double *>(array.data()), numpy_col.stride, count, offset, out);
 		break;
-	case NumpyNullableType::DATETIME:
-	case NumpyNullableType::DATETIME_TZ: {
+	case NumpyNullableType::DATETIME_NS:
+	case NumpyNullableType::DATETIME_MS:
+	case NumpyNullableType::DATETIME_US:
+	case NumpyNullableType::DATETIME_S: {
 		auto src_ptr = reinterpret_cast<const int64_t *>(array.data());
 		auto tgt_ptr = FlatVector::GetData<timestamp_t>(out);
 		auto &mask = FlatVector::Validity(out);
+
+		using timestamp_convert_func = std::function<timestamp_t(int64_t)>;
+		timestamp_convert_func convert_func;
+		switch (bind_data.numpy_type.type) {
+		case NumpyNullableType::DATETIME_NS:
+			convert_func = Timestamp::FromEpochNanoSeconds;
+			break;
+		case NumpyNullableType::DATETIME_MS:
+			convert_func = Timestamp::FromEpochMs;
+			break;
+		case NumpyNullableType::DATETIME_US:
+			convert_func = Timestamp::FromEpochMicroSeconds;
+			break;
+		case NumpyNullableType::DATETIME_S:
+			convert_func = Timestamp::FromEpochSeconds;
+			break;
+		default:
+			throw NotImplementedException("Scan for datetime of this type is not supported yet");
+		};
+
+		// FIXME: 'has_timezone' is unused still, we should probably extract the timezone and convert the value back to
+		// GMT?
 
 		for (idx_t row = 0; row < count; row++) {
 			auto source_idx = offset + row;
@@ -247,7 +271,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 				mask.SetInvalid(row);
 				continue;
 			}
-			tgt_ptr[row] = Timestamp::FromEpochSeconds(src_ptr[source_idx]);
+			tgt_ptr[row] = convert_func(src_ptr[source_idx]);
 		}
 		break;
 	}
@@ -297,7 +321,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 
 			// Get the pointer to the object
 			PyObject *val = src_ptr[source_idx];
-			if (bind_data.numpy_type == NumpyNullableType::OBJECT && !py::isinstance<py::str>(val)) {
+			if (bind_data.numpy_type.type == NumpyNullableType::OBJECT && !py::isinstance<py::str>(val)) {
 				if (val == Py_None) {
 					out_mask.SetInvalid(row);
 					continue;

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -242,9 +242,6 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 		auto tgt_ptr = FlatVector::GetData<timestamp_t>(out);
 		auto &mask = FlatVector::Validity(out);
 
-		// FIXME: 'has_timezone' is unused still, we should probably extract the timezone and convert the value back to
-		// GMT?
-
 		using timestamp_convert_func = std::function<timestamp_t(int64_t)>;
 		timestamp_convert_func convert_func;
 

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -242,25 +242,6 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 		auto tgt_ptr = FlatVector::GetData<timestamp_t>(out);
 		auto &mask = FlatVector::Validity(out);
 
-		using timestamp_convert_func = std::function<timestamp_t(int64_t)>;
-		timestamp_convert_func convert_func;
-		switch (bind_data.numpy_type.type) {
-		case NumpyNullableType::DATETIME_NS:
-			convert_func = Timestamp::FromEpochNanoSeconds;
-			break;
-		case NumpyNullableType::DATETIME_MS:
-			convert_func = Timestamp::FromEpochMs;
-			break;
-		case NumpyNullableType::DATETIME_US:
-			convert_func = Timestamp::FromEpochMicroSeconds;
-			break;
-		case NumpyNullableType::DATETIME_S:
-			convert_func = Timestamp::FromEpochSeconds;
-			break;
-		default:
-			throw NotImplementedException("Scan for datetime of this type is not supported yet");
-		};
-
 		// FIXME: 'has_timezone' is unused still, we should probably extract the timezone and convert the value back to
 		// GMT?
 
@@ -271,7 +252,8 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 				mask.SetInvalid(row);
 				continue;
 			}
-			tgt_ptr[row] = convert_func(src_ptr[source_idx]);
+			// Direct conversion, we've already matched the numpy type with the equivalent duckdb type
+			tgt_ptr[row] = Timestamp::FromEpochMicroSeconds(src_ptr[source_idx]);
 		}
 		break;
 	}

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -247,7 +247,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 				mask.SetInvalid(row);
 				continue;
 			}
-			tgt_ptr[row] = Timestamp::FromEpochNanoSeconds(src_ptr[source_idx]);
+			tgt_ptr[row] = Timestamp::FromEpochSeconds(src_ptr[source_idx]);
 		}
 		break;
 	}

--- a/tools/pythonpkg/src/numpy/type.cpp
+++ b/tools/pythonpkg/src/numpy/type.cpp
@@ -7,19 +7,15 @@
 namespace duckdb {
 
 static bool IsDateTime(NumpyNullableType type) {
-	if (type == NumpyNullableType::DATETIME_NS) {
+	switch (type) {
+	case NumpyNullableType::DATETIME_NS:
+	case NumpyNullableType::DATETIME_S:
+	case NumpyNullableType::DATETIME_MS:
+	case NumpyNullableType::DATETIME_US:
 		return true;
-	}
-	if (type == NumpyNullableType::DATETIME_US) {
-		return true;
-	}
-	if (type == NumpyNullableType::DATETIME_MS) {
-		return true;
-	}
-	if (type == NumpyNullableType::DATETIME_S) {
-		return true;
-	}
-	return false;
+	default:
+		return false;
+	};
 }
 
 static NumpyNullableType ConvertNumpyTypeInternal(const string &col_type_str) {

--- a/tools/pythonpkg/src/numpy/type.cpp
+++ b/tools/pythonpkg/src/numpy/type.cpp
@@ -6,72 +6,114 @@
 
 namespace duckdb {
 
-static bool IsDateTime(const string &col_type_str) {
-	if (StringUtil::StartsWith(col_type_str, "datetime64[ns")) {
+static bool IsDateTime(NumpyNullableType type) {
+	if (type == NumpyNullableType::DATETIME_NS) {
 		return true;
 	}
-	if (StringUtil::StartsWith(col_type_str, "datetime64[us")) {
+	if (type == NumpyNullableType::DATETIME_US) {
 		return true;
 	}
-	if (StringUtil::StartsWith(col_type_str, "datetime64[ms")) {
+	if (type == NumpyNullableType::DATETIME_MS) {
 		return true;
 	}
-	if (StringUtil::StartsWith(col_type_str, "datetime64[s")) {
-		return true;
-	}
-	if (col_type_str == "<M8[ns]") {
+	if (type == NumpyNullableType::DATETIME_S) {
 		return true;
 	}
 	return false;
 }
 
-NumpyNullableType ConvertNumpyType(const py::handle &col_type) {
-	auto col_type_str = string(py::str(col_type));
-
+static NumpyNullableType ConvertNumpyTypeInternal(const string &col_type_str) {
 	if (col_type_str == "bool" || col_type_str == "boolean") {
 		return NumpyNullableType::BOOL;
-	} else if (col_type_str == "uint8" || col_type_str == "UInt8") {
+	}
+	if (col_type_str == "uint8" || col_type_str == "UInt8") {
 		return NumpyNullableType::UINT_8;
-	} else if (col_type_str == "uint16" || col_type_str == "UInt16") {
+	}
+	if (col_type_str == "uint16" || col_type_str == "UInt16") {
 		return NumpyNullableType::UINT_16;
-	} else if (col_type_str == "uint32" || col_type_str == "UInt32") {
+	}
+	if (col_type_str == "uint32" || col_type_str == "UInt32") {
 		return NumpyNullableType::UINT_32;
-	} else if (col_type_str == "uint64" || col_type_str == "UInt64") {
+	}
+	if (col_type_str == "uint64" || col_type_str == "UInt64") {
 		return NumpyNullableType::UINT_64;
-	} else if (col_type_str == "int8" || col_type_str == "Int8") {
+	}
+	if (col_type_str == "int8" || col_type_str == "Int8") {
 		return NumpyNullableType::INT_8;
-	} else if (col_type_str == "int16" || col_type_str == "Int16") {
+	}
+	if (col_type_str == "int16" || col_type_str == "Int16") {
 		return NumpyNullableType::INT_16;
-	} else if (col_type_str == "int32" || col_type_str == "Int32") {
+	}
+	if (col_type_str == "int32" || col_type_str == "Int32") {
 		return NumpyNullableType::INT_32;
-	} else if (col_type_str == "int64" || col_type_str == "Int64") {
+	}
+	if (col_type_str == "int64" || col_type_str == "Int64") {
 		return NumpyNullableType::INT_64;
-	} else if (col_type_str == "float16" || col_type_str == "Float16") {
+	}
+	if (col_type_str == "float16" || col_type_str == "Float16") {
 		return NumpyNullableType::FLOAT_16;
-	} else if (col_type_str == "float32" || col_type_str == "Float32") {
+	}
+	if (col_type_str == "float32" || col_type_str == "Float32") {
 		return NumpyNullableType::FLOAT_32;
-	} else if (col_type_str == "float64" || col_type_str == "Float64") {
+	}
+	if (col_type_str == "float64" || col_type_str == "Float64") {
 		return NumpyNullableType::FLOAT_64;
-	} else if (col_type_str == "object" || col_type_str == "string") {
+	}
+	if (col_type_str == "object" || col_type_str == "string") {
 		//! this better be castable to strings
 		return NumpyNullableType::OBJECT;
-	} else if (col_type_str == "timedelta64[ns]") {
-		return NumpyNullableType::TIMEDELTA;
-	} else if (IsDateTime(col_type_str)) {
-		if (hasattr(col_type, "tz")) {
-			// The datetime has timezone information.
-			return NumpyNullableType::DATETIME_TZ;
-		}
-		return NumpyNullableType::DATETIME;
-	} else if (col_type_str == "category") {
-		return NumpyNullableType::CATEGORY;
-	} else {
-		throw NotImplementedException("Data type '%s' not recognized", col_type_str);
 	}
+	if (col_type_str == "timedelta64[ns]") {
+		return NumpyNullableType::TIMEDELTA;
+	}
+	// We use 'StartsWith' because it might have ', tz' at the end, indicating timezone
+	if (StringUtil::StartsWith(col_type_str, "datetime64[ns")) {
+		return NumpyNullableType::DATETIME_NS;
+	}
+	if (StringUtil::StartsWith(col_type_str, "datetime64[us")) {
+		return NumpyNullableType::DATETIME_US;
+	}
+	if (StringUtil::StartsWith(col_type_str, "datetime64[ms")) {
+		return NumpyNullableType::DATETIME_MS;
+	}
+	if (StringUtil::StartsWith(col_type_str, "datetime64[s")) {
+		return NumpyNullableType::DATETIME_S;
+	}
+	// Legacy datetime type indicators
+	if (StringUtil::StartsWith(col_type_str, "<M8[ns")) {
+		return NumpyNullableType::DATETIME_NS;
+	}
+	if (StringUtil::StartsWith(col_type_str, "<M8[s")) {
+		return NumpyNullableType::DATETIME_S;
+	}
+	if (StringUtil::StartsWith(col_type_str, "<M8[us")) {
+		return NumpyNullableType::DATETIME_US;
+	}
+	if (StringUtil::StartsWith(col_type_str, "<M8[ms")) {
+		return NumpyNullableType::DATETIME_MS;
+	}
+	if (col_type_str == "category") {
+		return NumpyNullableType::CATEGORY;
+	}
+	throw NotImplementedException("Data type '%s' not recognized", col_type_str);
 }
 
-LogicalType NumpyToLogicalType(const NumpyNullableType &col_type) {
-	switch (col_type) {
+NumpyType ConvertNumpyType(const py::handle &col_type) {
+	auto col_type_str = string(py::str(col_type));
+	NumpyType numpy_type;
+
+	numpy_type.type = ConvertNumpyTypeInternal(col_type_str);
+	if (IsDateTime(numpy_type.type)) {
+		if (hasattr(col_type, "tz")) {
+			// The datetime has timezone information.
+			numpy_type.has_timezone = true;
+		}
+	}
+	return numpy_type;
+}
+
+LogicalType NumpyToLogicalType(const NumpyType &col_type) {
+	switch (col_type.type) {
 	case NumpyNullableType::BOOL:
 		return LogicalType::BOOLEAN;
 	case NumpyNullableType::INT_8:
@@ -100,10 +142,16 @@ LogicalType NumpyToLogicalType(const NumpyNullableType &col_type) {
 		return LogicalType::VARCHAR;
 	case NumpyNullableType::TIMEDELTA:
 		return LogicalType::INTERVAL;
-	case NumpyNullableType::DATETIME:
+	case NumpyNullableType::DATETIME_MS:
+	case NumpyNullableType::DATETIME_US:
+	case NumpyNullableType::DATETIME_NS:
+	case NumpyNullableType::DATETIME_S: {
+		//FIXME: For now we convert these all to TIMESTAMP, when the support for our other TIMESTAMP types matures we might change this
+		if (col_type.has_timezone) {
+			return LogicalType::TIMESTAMP_TZ;
+		}
 		return LogicalType::TIMESTAMP;
-	case NumpyNullableType::DATETIME_TZ:
-		return LogicalType::TIMESTAMP_TZ;
+	}
 	default:
 		throw InternalException("No known conversion for NumpyNullableType '%d' to LogicalType");
 	}

--- a/tools/pythonpkg/src/numpy/type.cpp
+++ b/tools/pythonpkg/src/numpy/type.cpp
@@ -144,19 +144,19 @@ LogicalType NumpyToLogicalType(const NumpyType &col_type) {
 		return LogicalType::INTERVAL;
 	case NumpyNullableType::DATETIME_MS: {
 		if (col_type.has_timezone) {
-			throw NotImplementedException("TIMESTAMP_MS with timezone not supported yet");
+			return LogicalType::TIMESTAMP_TZ;
 		}
 		return LogicalType::TIMESTAMP_MS;
 	}
 	case NumpyNullableType::DATETIME_NS: {
 		if (col_type.has_timezone) {
-			throw NotImplementedException("TIMESTAMP_NS with timezone not supported yet");
+			return LogicalType::TIMESTAMP_TZ;
 		}
 		return LogicalType::TIMESTAMP_NS;
 	}
 	case NumpyNullableType::DATETIME_S: {
 		if (col_type.has_timezone) {
-			throw NotImplementedException("TIMESTAMP_S with timezone not supported yet");
+			return LogicalType::TIMESTAMP_TZ;
 		}
 		return LogicalType::TIMESTAMP_S;
 	}

--- a/tools/pythonpkg/src/numpy/type.cpp
+++ b/tools/pythonpkg/src/numpy/type.cpp
@@ -146,7 +146,8 @@ LogicalType NumpyToLogicalType(const NumpyType &col_type) {
 	case NumpyNullableType::DATETIME_US:
 	case NumpyNullableType::DATETIME_NS:
 	case NumpyNullableType::DATETIME_S: {
-		//FIXME: For now we convert these all to TIMESTAMP, when the support for our other TIMESTAMP types matures we might change this
+		// FIXME: For now we convert these all to TIMESTAMP, when the support for our other TIMESTAMP types matures we
+		// might change this
 		if (col_type.has_timezone) {
 			return LogicalType::TIMESTAMP_TZ;
 		}

--- a/tools/pythonpkg/src/numpy/type.cpp
+++ b/tools/pythonpkg/src/numpy/type.cpp
@@ -142,12 +142,25 @@ LogicalType NumpyToLogicalType(const NumpyType &col_type) {
 		return LogicalType::VARCHAR;
 	case NumpyNullableType::TIMEDELTA:
 		return LogicalType::INTERVAL;
-	case NumpyNullableType::DATETIME_MS:
-	case NumpyNullableType::DATETIME_US:
-	case NumpyNullableType::DATETIME_NS:
+	case NumpyNullableType::DATETIME_MS: {
+		if (col_type.has_timezone) {
+			throw NotImplementedException("TIMESTAMP_MS with timezone not supported yet");
+		}
+		return LogicalType::TIMESTAMP_MS;
+	}
+	case NumpyNullableType::DATETIME_NS: {
+		if (col_type.has_timezone) {
+			throw NotImplementedException("TIMESTAMP_NS with timezone not supported yet");
+		}
+		return LogicalType::TIMESTAMP_NS;
+	}
 	case NumpyNullableType::DATETIME_S: {
-		// FIXME: For now we convert these all to TIMESTAMP, when the support for our other TIMESTAMP types matures we
-		// might change this
+		if (col_type.has_timezone) {
+			throw NotImplementedException("TIMESTAMP_S with timezone not supported yet");
+		}
+		return LogicalType::TIMESTAMP_S;
+	}
+	case NumpyNullableType::DATETIME_US: {
 		if (col_type.has_timezone) {
 			return LogicalType::TIMESTAMP_TZ;
 		}

--- a/tools/pythonpkg/src/pandas/analyzer.cpp
+++ b/tools/pythonpkg/src/pandas/analyzer.cpp
@@ -335,7 +335,7 @@ LogicalType PandasAnalyzer::GetItemType(py::object ele, bool &can_convert) {
 		auto extended_type = ConvertNumpyType(ele.attr("dtype"));
 		LogicalType ltype;
 		ltype = NumpyToLogicalType(extended_type);
-		if (extended_type == NumpyNullableType::OBJECT) {
+		if (extended_type.type == NumpyNullableType::OBJECT) {
 			LogicalType converted_type = InnerAnalyze(ele, can_convert, false, 1);
 			if (can_convert) {
 				ltype = converted_type;

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -4,7 +4,6 @@ import shutil
 from os.path import abspath, join, dirname, normpath
 import glob
 import duckdb
-from packaging.version import Version
 
 try:
     import pandas
@@ -20,6 +19,17 @@ try:
     pyarrow_dtypes_enabled = not pa_version_under7p0
 except:
     pyarrow_dtypes_enabled = False
+
+
+def pandas_2_or_higher() -> bool:
+    from packaging.version import Version
+
+    try:
+        import pandas
+
+        return Version(pandas.__version__) >= Version('2.0.0')
+    except:
+        return False
 
 
 # https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
@@ -64,9 +74,7 @@ def pandas_supports_arrow_backend():
             return False
     except:
         return False
-    import pandas as pd
-
-    return Version(pd.__version__) >= Version('2.0.0')
+    return pandas_2_or_higher()
 
 
 def numpy_pandas_df(*args, **kwargs):
@@ -132,7 +140,7 @@ class ArrowMockTesting:
 class ArrowPandas:
     def __init__(self):
         self.pandas = pytest.importorskip("pandas")
-        if Version(self.pandas.__version__) >= Version('2.0.0') and pyarrow_dtypes_enabled:
+        if pandas_2_or_higher() and pyarrow_dtypes_enabled:
             self.backend = 'pyarrow'
             self.DataFrame = arrow_pandas_df
         else:

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -200,9 +200,31 @@ def duckdb_cursor(request):
     connection = duckdb.connect('')
     cursor = connection.cursor()
     cursor.execute('CREATE TABLE integers (i integer)')
-    cursor.execute('INSERT INTO integers VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(NULL)')
+    cursor.execute(
+        """
+        INSERT INTO integers VALUES
+            (0),
+            (1),
+            (2),
+            (3),
+            (4),
+            (5),
+            (6),
+            (7),
+            (8),
+            (9),
+            (NULL)
+    """
+    )
     cursor.execute('CREATE TABLE timestamps (t timestamp)')
-    cursor.execute("INSERT INTO timestamps VALUES ('1992-10-03 18:34:45'), ('2010-01-01 00:00:01'), (NULL)")
+    cursor.execute(
+        """
+        INSERT INTO timestamps VALUES
+            ('1992-10-03 18:34:45'),
+            ('2010-01-01 00:00:01'),
+            (NULL)
+    """
+    )
     cursor.execute("CALL dbgen(sf=0.01)")
     return cursor
 

--- a/tools/pythonpkg/tests/fast/api/test_dbapi00.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi00.py
@@ -88,6 +88,8 @@ class TestSimpleDBAPI(object):
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_pandas_selection(self, duckdb_cursor, pandas):
+        import datetime
+
         duckdb_cursor.execute('SELECT * FROM integers')
         result = duckdb_cursor.fetchdf()
         arr = numpy.ma.masked_array(numpy.arange(11))
@@ -98,7 +100,18 @@ class TestSimpleDBAPI(object):
 
         duckdb_cursor.execute('SELECT * FROM timestamps')
         result = duckdb_cursor.fetchdf()
-        df = pandas.DataFrame({'t': pandas.to_datetime(['1992-10-03 18:34:45', '2010-01-01 00:00:01', None])})
+        df = pandas.DataFrame(
+            {
+                't': pandas.Series(
+                    data=[
+                        datetime.datetime(year=1992, month=10, day=3, hour=18, minute=34, second=45),
+                        datetime.datetime(year=2010, month=1, day=1, hour=0, minute=0, second=1),
+                        None,
+                    ],
+                    dtype='datetime64[us]',
+                )
+            }
+        )
         pandas.testing.assert_frame_equal(result, df)
 
     # def test_numpy_creation(self, duckdb_cursor):

--- a/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
@@ -6,18 +6,17 @@ import pandas as pd
 
 
 class TestPandasTimestamps(object):
-    def test_timestamp_types_roundtrip(self, duckdb_cursor):
+    @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
+    def test_timestamp_types_roundtrip(self, unit):
         d = {
-            'a': [pd.Timestamp(datetime.datetime.now(), unit='s')],
-            'b': [pd.Timestamp(datetime.datetime.now(), unit='ms')],
-            'c': [pd.Timestamp(datetime.datetime.now(), unit='us')],
-            'd': [pd.Timestamp(datetime.datetime.now(), unit='ns')],
+            'time': [pd.Timestamp(datetime.datetime.now(), unit=unit)],
         }
         df = pd.DataFrame(data=d)
+        print(df)
         df_from_duck = duckdb.from_df(df).df()
         assert df_from_duck.equals(df)
 
-    def test_timestamp_nulls(self, duckdb_cursor):
+    def test_timestamp_nulls(self):
         d = {
             'a': [pd.Timestamp(None, unit='s')],
             'b': [pd.Timestamp(None, unit='ms')],
@@ -28,7 +27,7 @@ class TestPandasTimestamps(object):
         df_from_duck = duckdb.from_df(df).df()
         assert df_from_duck.equals(df)
 
-    def test_timestamp_timedelta(self, duckdb_cursor):
+    def test_timestamp_timedelta(self):
         df = pd.DataFrame(
             {
                 'a': [pd.Timedelta(1, unit='s')],

--- a/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
@@ -9,20 +9,18 @@ class TestPandasTimestamps(object):
     @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
     def test_timestamp_types_roundtrip(self, unit):
         d = {
-            'time': [pd.Timestamp(datetime.datetime.now(), unit=unit)],
+            'time': pd.Series(
+                [pd.Timestamp(datetime.datetime(2020, 6, 12, 14, 43, 24, 394587), unit=unit)],
+                dtype=f'datetime64[{unit}]',
+            )
         }
         df = pd.DataFrame(data=d)
-        print(df)
         df_from_duck = duckdb.from_df(df).df()
         assert df_from_duck.equals(df)
 
-    def test_timestamp_nulls(self):
-        d = {
-            'a': [pd.Timestamp(None, unit='s')],
-            'b': [pd.Timestamp(None, unit='ms')],
-            'c': [pd.Timestamp(None, unit='us')],
-            'd': [pd.Timestamp(None, unit='ns')],
-        }
+    @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
+    def test_timestamp_nulls(self, unit):
+        d = {'time': pd.Series([pd.Timestamp(None, unit=unit)], dtype=f'datetime64[{unit}]')}
         df = pd.DataFrame(data=d)
         df_from_duck = duckdb.from_df(df).df()
         assert df_from_duck.equals(df)


### PR DESCRIPTION
This PR fixes #8588 

In Pandas < 2.0.0, Pandas would never produce a `datetime64` that is not represented in nanoseconds.
Since 2.0.0, they have added support for other units.

This PR adds support for scanning and producing columns of `datetime64` with any unit.
Pandas timestamp units directly map to our timestamp types, with the exception of `TIMESTAMP_TZ`.

`TIMESTAMP_TZ` is represented in US (microseconds), so whenever we encounter a `datetime64` column that has `tz` info, we resort back to the old approach of converting the value to microseconds.