### PR TITLE
PR3 for zOS

### DIFF
--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -11,6 +11,6 @@
 duckdb_extension_load(parquet)
 
 # Jemalloc is enabled by default for linux. MacOS malloc is already good enough and Jemalloc on windows has issues.
-if(NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND OS_NAME STREQUAL "linux" AND NOT ANDROID)
+if(NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND OS_NAME STREQUAL "linux" AND NOT ANDROID AND NOT ZOS)
     duckdb_extension_load(jemalloc)
 endif()


### PR DESCRIPTION
The cmake flag `BUILD_JEMALLOC_EXTENSION` seems to have gone missing since the previous PR for zOS.
It was used in [this script](https://github.com/ZOSOpenTools/duckdbport/blob/main/buildenv) to port DuckDB to zOS.

Somehow, zOS is passing the below conditions and jemalloc is picked up.

So a quick PR to add an exclusion here.