### PR TITLE
Extension sha256: Avoid full copies by updating sha context

### DIFF
--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -489,7 +489,7 @@ main/error_manager.cpp	9
 main/extension/extension_alias.cpp	2
 main/extension/extension_helper.cpp	8
 main/extension/extension_install.cpp	97
-main/extension/extension_load.cpp	59
+main/extension/extension_load.cpp	70
 main/extension/extension_util.cpp	18
 main/materialized_query_result.cpp	9
 main/pending_query_result.cpp	5

--- a/third_party/mbedtls/include/mbedtls_wrapper.hpp
+++ b/third_party/mbedtls/include/mbedtls_wrapper.hpp
@@ -19,5 +19,15 @@ public:
 	static void Hmac256(const char* key, size_t key_len, const char* message, size_t message_len, char* out);
 
 	static constexpr size_t SHA256_HASH_BYTES = 32;
+
+	class SHA256State {
+	public:
+		SHA256State();
+		~SHA256State();
+		void AddString(const std::string & str);
+		std::string Finalize();
+	private:
+		void *sha_context;
+	};
 };
 }

--- a/third_party/mbedtls/mbedtls_wrapper.cpp
+++ b/third_party/mbedtls/mbedtls_wrapper.cpp
@@ -82,3 +82,33 @@ void MbedTlsWrapper::Hmac256(const char* key, size_t key_len, const char* messag
 	}
 	mbedtls_md_free(&hmac_ctx);
 }
+
+MbedTlsWrapper::SHA256State::SHA256State() : sha_context(new mbedtls_sha256_context()) {
+	mbedtls_sha256_init((mbedtls_sha256_context*)sha_context);
+
+	if (mbedtls_sha256_starts((mbedtls_sha256_context*)sha_context, false)) {
+		throw std::runtime_error("SHA256 Error");
+	}
+}
+
+MbedTlsWrapper::SHA256State::~SHA256State() {
+	mbedtls_sha256_free((mbedtls_sha256_context*)sha_context);
+	delete (mbedtls_sha256_context*)sha_context;
+}
+
+void MbedTlsWrapper::SHA256State::AddString(const std::string & str) {
+	if (mbedtls_sha256_update((mbedtls_sha256_context*)sha_context, (unsigned char*)str.data(), str.size())) {
+		throw std::runtime_error("SHA256 Error");
+	}
+}
+
+std::string MbedTlsWrapper::SHA256State::Finalize() {
+	string hash;
+	hash.resize(MbedTlsWrapper::SHA256_HASH_BYTES);
+
+	if (mbedtls_sha256_finish((mbedtls_sha256_context*)sha_context, (unsigned char*)hash.data())) {
+		throw std::runtime_error("SHA256 Error");
+	}
+
+	return hash;
+}


### PR DESCRIPTION
Previously up to min(num_threads * 1MB, size_extension) were allocated when computing signature for extensions, now only up to num_threads * 8KB by performing updates on a given mbedtls context.

This is relevant in particular for auto-loading, since signature computation migth happen mid- execution when the system has already memory allocated, and it's in any case better.

Actual implementation via registering callback I am not completely sure, idea was isolating details in the library.