### PR TITLE
Fix test_csv_httpfs.test_slow

### DIFF
--- a/test/sql/copy/csv/test_csv_httpfs.test_slow
+++ b/test/sql/copy/csv/test_csv_httpfs.test_slow
@@ -10,7 +10,7 @@ require parquet
 query I
 SELECT count(*) FROM read_csv_auto('https://datasets.imdbws.com/name.basics.tsv.gz', delim='\t', quote='',header=True)
 ----
-12408002
+12783090
 
 query I
   copy (
@@ -24,4 +24,4 @@ query I
     FROM read_csv_auto('https://datasets.imdbws.com/name.basics.tsv.gz', delim='\t', quote='',header=True)
   ) to '__TEST_DIR__/name_basics.parquet' (FORMAT 'parquet', CODEC 'ZSTD')
 ----
-12408002
+12783090


### PR DESCRIPTION
Micro PR, fixing a test that was broken (probably the live file changed).

Real problem is that we didn't found this before, that means that this test is never actually used. Luckily autoloading of extensions covers a bunch of new corner cases.