### PR TITLE
C-API: support streaming arrow query

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2351,9 +2351,17 @@ Fetch the internal arrow schema from the prepared statement.
 */
 DUCKDB_API duckdb_state duckdb_prepared_arrow_schema(duckdb_prepared_statement prepared,
                                                      duckdb_arrow_schema *out_schema);
+/*!
+Convert a data chunk into an arrow struct array.
+
+* result: The result object the data chunk have been fetched from.
+* chunk: The data chunk to convert.
+* out_array: The output array.
+*/
+DUCKDB_API void duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, duckdb_arrow_array *out_array);
 
 /*!
-Fetch an internal arrow array from the arrow result.
+Fetch an internal arrow struct array from the arrow result.
 
 This function can be called multiple time to get next chunks, which will free the previous out_array.
 So consume the out_array before calling this function again.

--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -49,7 +49,6 @@ struct PendingStatementWrapper {
 struct ArrowResultWrapper {
 	unique_ptr<MaterializedQueryResult> result;
 	unique_ptr<DataChunk> current_chunk;
-	ClientProperties options;
 };
 
 struct AppenderWrapper {

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -1,8 +1,8 @@
+#include "duckdb/common/arrow/arrow.hpp"
 #include "duckdb/common/arrow/arrow_converter.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/prepared_statement_data.hpp"
-#include "duckdb/common/arrow/arrow.hpp"
 
 using duckdb::ArrowConverter;
 using duckdb::ArrowResultWrapper;
@@ -28,7 +28,7 @@ duckdb_state duckdb_query_arrow_schema(duckdb_arrow result, duckdb_arrow_schema 
 	}
 	auto wrapper = reinterpret_cast<ArrowResultWrapper *>(result);
 	ArrowConverter::ToArrowSchema((ArrowSchema *)*out_schema, wrapper->result->types, wrapper->result->names,
-	                              wrapper->options);
+	                              wrapper->result->client_properties);
 	return DuckDBSuccess;
 }
 
@@ -83,8 +83,19 @@ duckdb_state duckdb_query_arrow_array(duckdb_arrow result, duckdb_arrow_array *o
 	if (!wrapper->current_chunk || wrapper->current_chunk->size() == 0) {
 		return DuckDBSuccess;
 	}
-	ArrowConverter::ToArrowArray(*wrapper->current_chunk, reinterpret_cast<ArrowArray *>(*out_array), wrapper->options);
+	ArrowConverter::ToArrowArray(*wrapper->current_chunk, reinterpret_cast<ArrowArray *>(*out_array),
+	                             wrapper->result->client_properties);
 	return DuckDBSuccess;
+}
+
+void duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, duckdb_arrow_array *out_array) {
+	if (!out_array) {
+		return;
+	}
+	auto dchunk = reinterpret_cast<duckdb::DataChunk *>(chunk);
+	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result.internal_data));
+	ArrowConverter::ToArrowArray(*dchunk, reinterpret_cast<ArrowArray *>(*out_array),
+	                             result_data.result->client_properties);
 }
 
 idx_t duckdb_arrow_row_count(duckdb_arrow result) {
@@ -136,8 +147,6 @@ duckdb_state duckdb_execute_prepared_arrow(duckdb_prepared_statement prepared_st
 		return DuckDBError;
 	}
 	auto arrow_wrapper = new ArrowResultWrapper();
-	arrow_wrapper->options = wrapper->statement->context->GetClientProperties();
-
 	auto result = wrapper->statement->Execute(wrapper->values, false);
 	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
 	arrow_wrapper->result = duckdb::unique_ptr_cast<QueryResult, MaterializedQueryResult>(std::move(result));


### PR DESCRIPTION
Currently, the C-Arrow API uses a wrapper type. As the wrapper was created
before streaming queries, it does not support them. The fact that the query
result and data chunk are hidden in the wrapper prevents users from using
current and future methods, and forces us to add additional functions to support
new features. If we wanted to add support for streaming arrow requests with the
wrapper, without breaking the current code, we'd have to add
`duckdb_execute_prepared_arrow_streaming` and `duckdb_query_arrow_streaming`.

I suggest adding a function to convert the datachunk into an arrow array.
This is compatible with both types of query and should be more future-proof.

I've simplified `ArrowResultWrapper`, so it no longer needs to store
`ClientProperties` since it's already stored in `QueryResult`. I've added a
low-level function that converts a data chunk into and arrow array.
