### PR TITLE
fix make format-master (renamed to make format-main)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,8 +339,8 @@ format-head:
 format-changes:
 	python3 scripts/format.py HEAD --fix --noconfirm
 
-format-master:
-	python3 scripts/format.py master --fix --noconfirm
+format-main:
+	python3 scripts/format.py main --fix --noconfirm
 
 third_party/sqllogictest:
 	git clone --depth=1 --branch hawkfish-statistical-rounding https://github.com/cwida/sqllogictest.git third_party/sqllogictest


### PR DESCRIPTION
I use this extensively, so I ran into this breakage related to the renaming from `master` -> `main`