### PR TITLE
Wrap ALTREP methods with BEGIN_CPP11 and END_CPP11

### DIFF
--- a/tools/rpkg/inst/include/cpp11/declarations.hpp
+++ b/tools/rpkg/inst/include/cpp11/declarations.hpp
@@ -35,7 +35,7 @@ T& unmove(T&& t) {
   SEXP err = R_NilValue;              \
   char buf[CPP11_ERROR_BUFSIZE] = ""; \
   try {
-#define END_CPP11                                               \
+#define END_CPP11_EX(RET)                                       \
   }                                                             \
   catch (cpp11::unwind_exception & e) {                         \
     err = e.token;                                              \
@@ -51,4 +51,5 @@ T& unmove(T&& t) {
   } else if (err != R_NilValue) {                               \
     CPP11_UNWIND                                                \
   }                                                             \
-  return R_NilValue;
+  return RET;
+#define END_CPP11 END_CPP11_EX(R_NilValue)


### PR DESCRIPTION
We need this because we're calling code that uses `cpp11::stop()` . By wrapping with `BEGIN_CPP11` and `END_CPP11`, we bail out safely.

Follow-up to https://github.com/duckdb/duckdb/pull/8600#issuecomment-1683449812.