### PR TITLE
C-API: Fix `duckdb_arrow_scan` API 

### DIFF
--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -168,7 +168,7 @@ void EmptyStreamRelease(ArrowArrayStream *) {
 void FactoryGetSchema(uintptr_t stream_factory_ptr, duckdb::ArrowSchemaWrapper &schema) {
 	auto stream = reinterpret_cast<ArrowArrayStream *>(stream_factory_ptr);
 	stream->get_schema(stream, &schema.arrow_schema);
-	
+
 	// Need to nullify the root schema's release function here, because streams don't allow us to set the release
 	// function. For the schema's children, we nullify the release functions in `duckdb_arrow_scan`, so we don't need to
 	// handle them again here. We set this to nullptr and not EmptySchemaRelease to prevent ArrowSchemaWrapper's

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -166,10 +166,9 @@ void EmptyStreamRelease(ArrowArrayStream *) {
 }
 
 void FactoryGetSchema(uintptr_t stream_factory_ptr, duckdb::ArrowSchemaWrapper &schema) {
-	auto private_data =
-	    reinterpret_cast<PrivateData *>(reinterpret_cast<ArrowArrayStream *>(stream_factory_ptr)->private_data);
-	schema.arrow_schema = *private_data->schema;
-
+	auto stream = reinterpret_cast<ArrowArrayStream *>(stream_factory_ptr);
+	stream->get_schema(stream, &schema.arrow_schema);
+	
 	// Need to nullify the root schema's release function here, because streams don't allow us to set the release
 	// function. For the schema's children, we nullify the release functions in `duckdb_arrow_scan`, so we don't need to
 	// handle them again here. We set this to nullptr and not EmptySchemaRelease to prevent ArrowSchemaWrapper's


### PR DESCRIPTION
The `ArrowArrayStream` consumer should not use `private_data` as also mentioned in the arrow [specs](https://arrow.apache.org/docs/format/CStreamInterface.html#c.ArrowArrayStream.private_data). 
The current code works for `duckdb_arrow_array_scan` API since it is also producing an `ArrowArrayStream` internally so it is able to access schema from the `private_data`. This will however not work in the case of `duckdb_arrow_scan` API.