### PR TITLE
[Dev] Add explicit expected error for `test/sql/storage/multiple_clients_checkpoint_pending_updates.test`

### DIFF
--- a/test/sql/storage/multiple_clients_checkpoint_pending_updates.test
+++ b/test/sql/storage/multiple_clients_checkpoint_pending_updates.test
@@ -19,6 +19,8 @@ UPDATE test SET i=i+1;
 
 statement error con2
 CHECKPOINT
+----
+TransactionContext Error: Cannot CHECKPOINT: there are other transactions. Use FORCE CHECKPOINT to abort the other transactions and force a checkpoint
 
 statement ok con2
 FORCE CHECKPOINT
@@ -75,6 +77,8 @@ UPDATE test SET i=i+1 WHERE i > 3000 AND i < 4000
 
 statement error
 CHECKPOINT
+----
+TransactionContext Error: Cannot CHECKPOINT: there are other transactions. Use FORCE CHECKPOINT to abort the other transactions and force a checkpoint
 
 statement ok
 FORCE CHECKPOINT


### PR DESCRIPTION
This test (and others) stem from a time where we did not have support for expected error message in the unit tester.

I had a plan at some point to add expected error messages to every old test, have to start somewhere