### PR TITLE
Issue #8659: Non-Invertible Casts

### DIFF
--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -142,12 +142,10 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 	}
 	if (source_type.id() == LogicalTypeId::VARCHAR) {
 		switch (target_type.id()) {
-		case LogicalTypeId::TIME:
 		case LogicalTypeId::TIMESTAMP:
 		case LogicalTypeId::TIMESTAMP_NS:
 		case LogicalTypeId::TIMESTAMP_MS:
 		case LogicalTypeId::TIMESTAMP_SEC:
-		case LogicalTypeId::TIME_TZ:
 		case LogicalTypeId::TIMESTAMP_TZ:
 			return true;
 		default:

--- a/test/sql/optimizer/expression/test_comparison_simplification.test
+++ b/test/sql/optimizer/expression/test_comparison_simplification.test
@@ -1,0 +1,17 @@
+# name: test/sql/optimizer/expression/test_comparison_simplification.test
+# description: Test ComparisonSimplificationRule
+# group: [expression]
+
+statement ok
+PRAGMA enable_verification
+
+# VARCHAR => TIME is not invertible.
+query I
+WITH results AS (     
+	SELECT '2023-08-17T23:00:08.539Z' as timestamp 
+	) 
+SELECT * 
+FROM results 
+WHERE timestamp::TIME BETWEEN '22:00:00'::TIME AND '23:59:59'::TIME ;
+----
+2023-08-17T23:00:08.539Z


### PR DESCRIPTION
VARCHAR => TIME is not invertible because
we allow casting full TIMESTAMP strings to TIME.

fixes #8659