### PR TITLE
fix cpp11 issue in r api

### DIFF
--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -360,7 +360,7 @@ bool constant_expression_is_not_null(duckdb::expr_extptr_t expr) {
 
 static SEXP result_to_df(duckdb::unique_ptr<QueryResult> res) {
 	if (res->HasError()) {
-		stop("%s", res->GetError());
+		stop("%s", res->GetError().c_str());
 	}
 	if (res->type == QueryResultType::STREAM_RESULT) {
 		res = ((StreamQueryResult &)*res).Materialize();
@@ -442,7 +442,7 @@ static SEXP result_to_df(duckdb::unique_ptr<QueryResult> res) {
 [[cpp11::register]] SEXP rapi_rel_sql(duckdb::rel_extptr_t rel, std::string sql) {
 	auto res = rel->rel->Query("_", sql);
 	if (res->HasError()) {
-		stop("%s", res->GetError());
+		stop("%s", res->GetError().c_str());
 	}
 	return result_to_df(std::move(res));
 }


### PR DESCRIPTION
Fixes the error `../inst/include/cpp11/protect.hpp:183:29: error: cannot pass object of non-trivial type 'std::string' through variadic function; call will abort at runtime [-Wnon-pod-varargs]` on my MacBook 