### PR TITLE
[Dev] Fix CI failure related to pandas and timezones

### DIFF
--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -4,7 +4,6 @@ import shutil
 from os.path import abspath, join, dirname, normpath
 import glob
 import duckdb
-from packaging.version import Version
 
 try:
     import pandas
@@ -56,6 +55,13 @@ def duckdb_empty_cursor(request):
     return cursor
 
 
+def pandas_2_or_higher():
+    from packaging.version import Version
+    import pandas as pd
+
+    return Version(pd.__version__) >= Version('2.0.0')
+
+
 def pandas_supports_arrow_backend():
     try:
         from pandas.compat import pa_version_under7p0
@@ -64,9 +70,7 @@ def pandas_supports_arrow_backend():
             return False
     except:
         return False
-    import pandas as pd
-
-    return Version(pd.__version__) >= Version('2.0.0')
+    return pandas_2_or_higher()
 
 
 def numpy_pandas_df(*args, **kwargs):
@@ -132,7 +136,7 @@ class ArrowMockTesting:
 class ArrowPandas:
     def __init__(self):
         self.pandas = pytest.importorskip("pandas")
-        if Version(self.pandas.__version__) >= Version('2.0.0') and pyarrow_dtypes_enabled:
+        if pandas_2_or_higher() and pyarrow_dtypes_enabled:
             self.backend = 'pyarrow'
             self.DataFrame = arrow_pandas_df
         else:

--- a/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
@@ -4,8 +4,7 @@ import datetime
 import pytest
 import pandas as pd
 
-from tools.pythonpkg.tests.conftest import pandas_2_or_higher
-
+from conftest import pandas_2_or_higher
 
 class TestPandasTimestamps(object):
     @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])

--- a/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from conftest import pandas_2_or_higher
 
+
 class TestPandasTimestamps(object):
     @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
     def test_timestamp_types_roundtrip(self, unit):


### PR DESCRIPTION
Failure encountered in:
https://github.com/duckdb/duckdb/actions/runs/5945486712/job/16125920975#step:9:10170

The test fails because it's run on python 3.7 with pandas 1.3.5

Solution:
We just skip the test on pandas versions below 2.0.0