### PR TITLE
Fix CI failure with test/sql/copy/s3/glob_s3_paging.test_slow

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -506,7 +506,7 @@ static optional_ptr<HTTPMetadataCache> TryGetMetadataCache(FileOpener *opener, H
 	} else {
 		auto lookup = client_context->registered_state.find("http_cache");
 		if (lookup == client_context->registered_state.end()) {
-			auto cache = make_shared<HTTPMetadataCache>(true, false);
+			auto cache = make_shared<HTTPMetadataCache>(true, true);
 			client_context->registered_state["http_cache"] = cache;
 			return cache.get();
 		} else {


### PR DESCRIPTION
A cache was used without locking, this is not correct as it's used by multiple threads within the query.

Caught it with the threadsan, it appears to be fixed now. I've let the threadsan run for a pretty long time without triggering while before it would trigger within half a minute or so