### PR TITLE
[Dev] Fix sporadically failing test `window-rows-overflow.test`

### DIFF
--- a/test/fuzzer/sqlsmith/window-rows-overflow.test
+++ b/test/fuzzer/sqlsmith/window-rows-overflow.test
@@ -4,37 +4,49 @@
 
 statement ok
 create table all_types as 
-	select * exclude(small_enum, medium_enum, large_enum) 
-	from test_all_types();
+	select * exclude(
+		small_enum,
+		medium_enum,
+		large_enum
+	)
+from test_all_types();
 
 statement error
-SELECT nth_value(1929, c39) 
-		OVER (PARTITION BY (c8 > c3), 747 
-			  ROWS BETWEEN #5 PRECEDING AND CURRENT ROW) 
-FROM all_types AS t41(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40)
+SELECT nth_value(1929, "array_of_structs") OVER (
+	PARTITION BY (
+		"usmallint" > "smallint"
+	), 747 ROWS BETWEEN "bigint" PRECEDING AND CURRENT ROW
+)
+FROM all_types;
 ----
 Out of Range Error: Overflow computing ROWS PRECEDING start
 
 statement error
-SELECT nth_value(1929, c1) 
-		OVER (PARTITION BY (c8 > c3), 747 
-			  ROWS BETWEEN 1 PRECEDING AND "c5" PRECEDING) 
-FROM all_types AS t41(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40)
+SELECT nth_value(1929, "bool") OVER (
+	PARTITION BY (
+		"usmallint" > "smallint"
+	), 747 ROWS BETWEEN 1 PRECEDING AND "bigint" PRECEDING
+)
+FROM all_types;
 ----
 Out of Range Error: Overflow computing ROWS PRECEDING end
 
 statement error
-SELECT nth_value(1929, c1) 
-		OVER (PARTITION BY (c8 > c3), 747 
-			  ROWS BETWEEN "c5" FOLLOWING AND 1 FOLLOWING) 
-FROM all_types AS t41(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40)
+SELECT nth_value(1929, "bool") OVER (
+	PARTITION BY (
+		"usmallint" > "smallint"
+	), 747 ROWS BETWEEN "bigint" FOLLOWING AND 1 FOLLOWING
+)
+FROM all_types;
 ----
 Out of Range Error: Overflow computing ROWS FOLLOWING start
 
 statement error
-SELECT nth_value(1929, c1) 
-		OVER (PARTITION BY (c8 > c3), 747 
-			  ROWS BETWEEN CURRENT ROW AND "c5" FOLLOWING) 
-FROM all_types AS t41(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40)
+SELECT nth_value(1929, "bool") OVER (
+	PARTITION BY (
+		"usmallint" > "smallint"
+	), 747 ROWS BETWEEN CURRENT ROW AND "bigint" FOLLOWING
+)
+FROM all_types;
 ----
 Out of Range Error: Overflow computing ROWS FOLLOWING end


### PR DESCRIPTION
I have removed the excessive aliasing and referring to the columns by offset.

That's not the target of the test, and it looks like this has a problem that is hard to detect.
I have spent quite a lot of effort trying to reproduce this issue locally and in a docker container with no success.

I think the issue might be related to `AddColumnNameToBinding`, we use a `case_insensitive_set_t` which is an `unordered_set` so because this ordering is not guaranteed this might result in some undefined behavior with a different implementation of unordered_set.

The test used to alias 40 columns, but `test_all_types` has likely grown since then, and the behavior of these aliases + referring to columns by position i.e using `#5` seems problematic.