### PR TITLE
Issue #8674: Interrupt Work Stealing

### DIFF
--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -77,7 +77,7 @@ common/types/conflict_manager.cpp	3
 common/types/data_chunk.cpp	19
 common/types/date.cpp	24
 common/types/hash.cpp	5
-common/types/hugeint.cpp	34
+common/types/hugeint.cpp	35
 common/types/hyperloglog.cpp	11
 common/types/interval.cpp	31
 common/types/row/partitioned_tuple_data.cpp	10
@@ -160,7 +160,7 @@ execution/index/art/iterator.cpp	2
 execution/index/art/leaf.cpp	3
 execution/index/art/node.cpp	11
 execution/index/art/node256.cpp	1
-execution/index/art/node48.cpp	5
+execution/index/art/node48.cpp	10
 execution/index/art/prefix.cpp	2
 execution/join_hashtable.cpp	23
 execution/nested_loop_join/nested_loop_join_inner.cpp	24

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -550,7 +550,7 @@ WindowGlobalSourceState::Task WindowGlobalSourceState::NextTask(idx_t hash_bin) 
 	}
 
 	//	Work stealing
-	while (tasks_remaining) {
+	while (!context.interrupted && tasks_remaining) {
 		auto result = StealWork();
 		if (result.second) {
 			return result;


### PR DESCRIPTION
Check the work stealing loop for aborts so it doesn't loop forever.

fixes duckdblabs/duckdb-internal#140