### PR TITLE
Use ParsedExpression inside `CopyInfo` instead of strings

### DIFF
--- a/src/include/duckdb/parser/parsed_data/copy_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/copy_info.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/parser/parsed_expression.hpp"
 
 namespace duckdb {
 
@@ -31,7 +32,7 @@ public:
 	//! The table name to copy to/from
 	string table;
 	//! List of columns to copy to/from
-	vector<string> select_list;
+	vector<unique_ptr<ParsedExpression>> select_list;
 	//! Whether or not this is a copy to file (false) or copy from a file (true)
 	bool is_from;
 	//! The file format of the external file
@@ -47,7 +48,9 @@ public:
 		result->catalog = catalog;
 		result->schema = schema;
 		result->table = table;
-		result->select_list = select_list;
+		for (auto &expr : select_list) {
+			result->select_list.push_back(expr->Copy());
+		}
 		result->file_path = file_path;
 		result->is_from = is_from;
 		result->format = format;

--- a/src/parser/statement/copy_statement.cpp
+++ b/src/parser/statement/copy_statement.cpp
@@ -71,7 +71,7 @@ string TablePart(const CopyInfo &info) {
 			if (i > 0) {
 				result += ", ";
 			}
-			result += KeywordHelper::WriteOptionallyQuoted(info.select_list[i]);
+			result += info.select_list[i]->ToString();
 		}
 		result += " )";
 	}

--- a/src/parser/transform/statement/transform_copy.cpp
+++ b/src/parser/transform/statement/transform_copy.cpp
@@ -95,7 +95,7 @@ unique_ptr<CopyStatement> Transformer::TransformCopy(duckdb_libpgquery::PGCopySt
 		for (auto n = stmt.attlist->head; n != nullptr; n = n->next) {
 			auto target = PGPointerCast<duckdb_libpgquery::PGResTarget>(n->data.ptr_value);
 			if (target->name) {
-				info.select_list.emplace_back(target->name);
+				info.select_list.emplace_back(make_uniq<ColumnRefExpression>(target->name));
 			}
 		}
 	}

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -184,7 +184,9 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 	insert.catalog = stmt.info->catalog;
 	for (auto &expr : stmt.info->select_list) {
 		D_ASSERT(expr->type == ExpressionType::COLUMN_REF);
-		insert.columns.push_back(expr->ToString());
+		auto &columnref = expr->Cast<ColumnRefExpression>();
+		D_ASSERT(!columnref.IsQualified());
+		insert.columns.push_back(columnref.ToString());
 	}
 
 	// bind the insert statement to the base table

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -186,7 +186,7 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 		D_ASSERT(expr->type == ExpressionType::COLUMN_REF);
 		auto &columnref = expr->Cast<ColumnRefExpression>();
 		D_ASSERT(!columnref.IsQualified());
-		insert.columns.push_back(columnref.ToString());
+		insert.columns.push_back(columnref.GetColumnName());
 	}
 
 	// bind the insert statement to the base table

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -164,7 +164,7 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 
 		// We can not export generated columns
 		for (auto &col : table.GetColumns().Physical()) {
-			info->select_list.push_back(col.GetName());
+			info->select_list.push_back(make_uniq<ColumnRefExpression>(col.GetName()));
 		}
 
 		ExportedTableData exported_data;


### PR DESCRIPTION
This PR does some "yak shaving" for a future PR.

In any case using a `ParsedExpression` over a `string` only opens up opportunities, so this can't hurt.