### PR TITLE
CI: skip test/fuzzer/sqlsmith/window-rows-overflow.test

### DIFF
--- a/test/fuzzer/sqlsmith/window-rows-overflow.test
+++ b/test/fuzzer/sqlsmith/window-rows-overflow.test
@@ -2,6 +2,11 @@
 # description: Overflow testing for rows offsets.
 # group: [sqlsmith]
 
+# Query failed, but error message did not match expected error message:
+#     Out of Range Error: Overflow computing ROWS PRECEDING start (test/fuzzer/sqlsmith/window-rows-overflow.test:14)!
+# Skipping for now since it's causing non-deterministic failures on CI
+mode skip
+
 statement ok
 create table all_types as 
 	select * exclude(


### PR DESCRIPTION
Underlying issue needs fixing, but it's better to have CI be reliable