### PR TITLE
[Dev] Use our parquet writer in `test_filter_pushdown_2145 ` test instead

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -453,8 +453,8 @@ class TestArrowFilterPushdown(object):
         df2 = pandas.DataFrame(np.random.randn(date2.shape[0], 5), columns=list("ABCDE"))
         df2["date"] = date2
 
-        pq.write_table(pa.table(df1), "data1.parquet")
-        pq.write_table(pa.table(df2), "data2.parquet")
+        duckdb.execute("copy (select * from df1) to 'data1.parquet'")
+        duckdb.execute("copy (select * from df2) to 'data2.parquet'")
 
         table = pq.ParquetDataset(["data1.parquet", "data2.parquet"]).read()
 

--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -453,12 +453,12 @@ class TestArrowFilterPushdown(object):
         df2 = pandas.DataFrame(np.random.randn(date2.shape[0], 5), columns=list("ABCDE"))
         df2["date"] = date2
 
-        duckdb.execute("copy (select * from df1) to 'data1.parquet'")
-        duckdb.execute("copy (select * from df2) to 'data2.parquet'")
+        con = duckdb.connect()
+        con.execute("copy (select * from df1) to 'data1.parquet'")
+        con.execute("copy (select * from df2) to 'data2.parquet'")
 
         table = pq.ParquetDataset(["data1.parquet", "data2.parquet"]).read()
 
-        con = duckdb.connect()
         con.register("testarrow", table)
 
         output_df = duckdb.arrow(table).filter("date > '2019-01-01'").df()

--- a/tools/pythonpkg/tests/fast/pandas/test_pyarrow_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pyarrow_filter_pushdown.py
@@ -435,8 +435,8 @@ class TestArrowDFFilterPushdown(object):
         df2 = pandas.DataFrame(np.random.randn(date2.shape[0], 5), columns=list("ABCDE"))
         df2["date"] = date2
 
-        pq.write_table(pa.table(df1), "data1.parquet")
-        pq.write_table(pa.table(df2), "data2.parquet")
+        duckdb.execute("copy (select * from df1) to 'data1.parquet'")
+        duckdb.execute("copy (select * from df2) to 'data2.parquet'")
 
         table = pq.ParquetDataset(["data1.parquet", "data2.parquet"]).read()
 

--- a/tools/pythonpkg/tests/fast/pandas/test_pyarrow_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pyarrow_filter_pushdown.py
@@ -435,12 +435,12 @@ class TestArrowDFFilterPushdown(object):
         df2 = pandas.DataFrame(np.random.randn(date2.shape[0], 5), columns=list("ABCDE"))
         df2["date"] = date2
 
-        duckdb.execute("copy (select * from df1) to 'data1.parquet'")
-        duckdb.execute("copy (select * from df2) to 'data2.parquet'")
+        con = duckdb.connect()
+        con.execute("copy (select * from df1) to 'data1.parquet'")
+        con.execute("copy (select * from df2) to 'data2.parquet'")
 
         table = pq.ParquetDataset(["data1.parquet", "data2.parquet"]).read()
 
-        con = duckdb.connect()
         con.register("testarrow", table)
 
         output_df = duckdb.arrow(table).filter("date > '2019-01-01'").df()


### PR DESCRIPTION
It seems that pyarrow13 has made a change to their parquet writer for timestamps, our reader is not equipped to deal with it so the expected result of the test is wrong.

Using our parquet writer instead solves the issue for now, though this problem should probably be addressed properly at some point.