### PR TITLE
[PythonDev] Fix failing `test_statement_bind.py` test

### DIFF
--- a/tools/pythonpkg/cibw.toml
+++ b/tools/pythonpkg/cibw.toml
@@ -4,7 +4,7 @@
 [tool.cibuildwheel]
 environment = "PIP_CONSTRAINT='build-constraints.txt'"
 before-build = 'pip install oldest-supported-numpy'
-before-test = 'pip install --prefer-binary pandas pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true) && (pip install --prefer-binary "adbc_driver_manager" || true) && (pip install --prefer-binary "tensorflow" || true)'
+before-test = 'pip install --prefer-binary pandas pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true) && (pip install --prefer-binary "adbc_driver_manager==0.6.0" || true) && (pip install --prefer-binary "tensorflow" || true)'
 test-requires = 'pytest'
 test-command = 'DUCKDB_PYTHON_TEST_EXTENSION_PATH={project} DUCKDB_PYTHON_TEST_EXTENSION_REQUIRED=1 python -m pytest {project}/tests'
 

--- a/tools/pythonpkg/requirements-dev.txt
+++ b/tools/pythonpkg/requirements-dev.txt
@@ -10,3 +10,4 @@ psutil>=5.9.0
 fsspec
 polars
 tensorflow
+adbc_driver_manager==0.6.0

--- a/tools/pythonpkg/tests/fast/adbc/test_statement_bind.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_statement_bind.py
@@ -162,9 +162,11 @@ class TestADBCStatementBind(object):
 
             array = adbc_driver_manager.ArrowArrayHandle()
             schema = adbc_driver_manager.ArrowSchemaHandle()
+
             data._export_to_c(array.address, schema.address)
             statement.bind(array, schema)
-            with pytest.raises(adbc_driver_manager.ProgrammingError, match="ADBC_STATUS_INVALID_ARGUMENT"):
+
+            with pytest.raises(adbc_driver_manager.ProgrammingError, match="INVALID_ARGUMENT"):
                 res, _ = statement.execute_query()
 
     def test_not_enough_parameters(self):


### PR DESCRIPTION
Test was made for `adbc_driver_manager==0.4.0`, the version was not locked and `0.6.0` seems to break some expected error messages.

I've updated the test for 0.6.0 and locked the version of adbc driver manager to 0.6.0 so we don't get randomly failing tests in the future