### PR TITLE
Add reusable workflows for out-of-tree extensions

### DIFF
--- a/.github/workflows/_extension_client_tests.yml
+++ b/.github/workflows/_extension_client_tests.yml
@@ -1,0 +1,78 @@
+# This is a reusable workflow to be used by extensions based on the extension template
+
+name: Client Tests
+on:
+  workflow_call:
+    inputs:
+      duckdb_version:
+        required: true
+        type: string
+
+jobs:
+  nodejs:
+    name: NodeJS
+    runs-on: ubuntu-latest
+    env:
+      GEN: ninja
+
+    steps:
+      - name: Install Ninja
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq ninja-build
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Checkout DuckDB to version
+        run: |
+          cd duckdb
+          git checkout ${{ inputs.duckdb_version }}
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Build DuckDB NodeJS client
+        run: make debug_js
+
+      - name: Run NodeJS client tests
+        run: make test_debug_js
+
+  python:
+    name: Python
+    runs-on: ubuntu-latest
+    env:
+      GEN: ninja
+
+    steps:
+      - name: Install Ninja
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq ninja-build
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Checkout DuckDB to version
+        run: |
+          cd duckdb
+          git checkout ${{ inputs.duckdb_version }}
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Build DuckDB Python client
+        run: make debug_python
+
+      - name: Install Python test dependencies
+        run: python -m pip install --upgrade pytest
+
+      - name: Run Python client tests
+        run: |
+          make test_debug_python

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -1,0 +1,318 @@
+# This is a reusable workflow to be used by extensions for CI. It:
+#   - builds the extension using the CI workflow from the corresponding DuckDB version
+#   - runs the tests using `make test` in the extension repository
+#   - (optionally) deploys the binaries to S3
+
+name: Extension distribution
+on:
+  workflow_call:
+    inputs:
+      # The name with which the extension will be built
+      extension_name:
+        required: true
+        type: string
+      # GitHub ref of the extension repo
+      extension_ref:
+        required: true
+        type: string
+      # Whether the extension is deployed to the specified s3 bucket
+      release_s3:
+        required: false
+        type: boolean
+        default: true
+      # DuckDB version to build against
+      duckdb_version:
+        required: true
+        type: string
+      # Json formatted list of excluded target architectures, e.g. "[ 'linux_amd64', 'linux_amd64_gcc4' ]"
+      exclude_archs:
+        required: false
+        type: string
+        default: "[]"
+jobs:
+  linux:
+    name: Release
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      matrix:
+        duckdb_arch: [ 'linux_amd64', 'linux_arm64', 'linux_amd64_gcc4' ]
+        include:
+          - duckdb_arch: 'linux_amd64_gcc4'
+            container: 'quay.io/pypa/manylinux2014_x86_64'
+            vcpkg_triplet: 'x64-linux'
+          - duckdb_arch: 'linux_amd64'
+            container: 'ubuntu:18.04'
+            vcpkg_triplet: 'x64-linux'
+          - duckdb_arch: 'linux_arm64'
+            container: 'ubuntu:18.04'
+            vcpkg_triplet: 'arm64-linux'
+        exclude: ${{ fromJson(inputs.exclude_archs) }}
+    env:
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      GEN: Ninja
+
+    steps:
+      - name: Install required ubuntu packages
+        if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
+        run: |
+          apt-get update -y -qq
+          apt-get install -y -qq software-properties-common
+          add-apt-repository ppa:git-core/ppa
+          apt-get update -y -qq
+          apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client
+
+      - name: Install Git 2.18.5
+        if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
+        run: |
+          wget https://github.com/git/git/archive/refs/tags/v2.18.5.tar.gz
+          tar xvf v2.18.5.tar.gz
+          cd git-2.18.5
+          make
+          make prefix=/usr install
+          git --version
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Checkout DuckDB to version
+        run: |
+          cd duckdb
+          git checkout ${{ inputs.duckdb_version }}
+
+      - name: Setup ManyLinux2014
+        if: ${{ matrix.duckdb_arch == 'linux_amd64_gcc4' }}
+        run: |
+          ./duckdb/scripts/setup_manylinux2014.sh general aws-cli ccache ssh python_alias openssl
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
+
+      - name: Setup Ubuntu
+        if: ${{ matrix.duckdb_arch == 'linux_amd64' || matrix.duckdb_arch == 'linux_arm64' }}
+        uses: ./duckdb/.github/actions/ubuntu_18_setup
+        with:
+          aarch64_cross_compile: ${{ matrix.duckdb_arch == 'linux_arm64' && 1 }}
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: 501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
+
+      - name: Build extension
+        env:
+          GEN: ninja
+          CC: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || '' }}
+          CXX: ${{ matrix.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}
+        run: |
+          make release
+
+      - name: Test extension
+        if: ${{ matrix.duckdb_arch != 'linux_arm64'}}
+        run: |
+          make test
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.extension_name }}-extension-${{matrix.duckdb_arch}}
+          path: |
+            build/release/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
+
+      - name: Deploy
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
+          BUCKET_NAME: ${{ secrets.S3_BUCKET }}
+        run: |
+          git config --global --add safe.directory '*'
+          cd duckdb
+          git fetch --tags
+          export DUCKDB_VERSION=`git tag --points-at HEAD`
+          export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+          echo "hi"
+          echo "$DUCKDB_VERSION"
+          echo "$BUCKET_NAME"
+          cd ..
+          if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
+            echo 'No key set, skipping'
+          elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/tags/v.+)$ ]] ; then
+            python3 -m pip install pip awscli
+            ./scripts/extension-upload.sh ${{ inputs.extension_name }} ${{ inputs.extension_ref }} $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME true
+          elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/heads/main)$ ]] ; then
+            python3 -m pip install pip awscli
+            ./scripts/extension-upload.sh ${{ inputs.extension_name }} `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME false
+          fi
+
+  macos:
+    name: Release (${{ matrix.duckdb_arch }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        vcpkg_triplet: [ 'x64-osx', 'arm64-osx' ]
+        include:
+          - vcpkg_triplet: 'x64-osx'
+            osx_build_arch: 'x86_64'
+            duckdb_arch: 'osx_amd64'
+          - vcpkg_triplet: 'arm64-osx'
+            osx_build_arch: 'arm64'
+            duckdb_arch: 'osx_arm64'
+
+    env:
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
+      OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
+      GEN: Ninja
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Install Ninja
+        run: |
+          echo "$GITHUB_REF"
+          echo "hiii"
+          brew install ninja
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Checkout DuckDB to version
+        run: |
+          cd duckdb
+          git checkout ${{ inputs.duckdb_version }}
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: 501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
+
+      - name: Build extension
+        shell: bash
+        run: |
+          make release
+
+      - name: Test Extension
+        if: ${{ matrix.osx_build_arch == 'x86_64'}}
+        shell: bash
+        run: |
+          make test
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.extension_name }}-extension-${{ matrix.duckdb_arch }}
+          path: |
+            build/release/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
+
+      - name: Deploy
+        if: ${{ inputs.release_s3 }}
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
+          BUCKET_NAME: ${{ secrets.S3_BUCKET }}
+          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_KEY }}
+        run: |
+          git config --global --add safe.directory '*'
+          cd duckdb
+          git fetch --tags
+          export DUCKDB_VERSION=`git tag --points-at HEAD`
+          export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+          cd ..
+          if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
+            echo 'No key set, skipping'
+          elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/tags/v.+)$ ]] ; then
+            python3 -m pip install pip awscli
+            ./scripts/extension-upload.sh ${{ inputs.extension_name }} ${{ inputs.extension_ref }} $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME true
+          elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/heads/main)$ ]] ; then
+            python3 -m pip install pip awscli
+            ./scripts/extension-upload.sh ${{ inputs.extension_name }} `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME false
+          fi
+
+  windows:
+    name: Release
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        # Add commits/tags to build against other DuckDB versions
+        duckdb_arch: [ 'windows_amd64' ]
+        include:
+          - duckdb_arch: 'windows_amd64'
+            vcpkg_triplet: 'x64-windows-static-md'
+    env:
+      GEN: Ninja
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Checkout DuckDB to version
+        run: |
+          cd duckdb
+          git checkout ${{ inputs.duckdb_version }}
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
+
+      - name: Build extension
+        run: |
+          make release
+
+      - name: Test Extension
+        shell: bash
+        run: |
+          make test
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.extension_name }}-extension-${{ matrix.duckdb_arch }}
+          path: |
+            build/release/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
+
+      - name: Deploy
+        if: ${{ inputs.release_s3 }}
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
+          BUCKET_NAME: ${{ secrets.S3_BUCKET }}
+        run: |
+          git config --global --add safe.directory '*'
+          cd duckdb
+          git fetch --tags
+          export DUCKDB_VERSION=`git tag --points-at HEAD`
+          export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+          cd ..
+          if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
+            echo 'No key set, skipping'
+          elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/tags/v.+)$ ]] ; then
+            python -m pip install awscli
+            ./scripts/extension-upload.sh ${{ inputs.extension_name }} ${{ inputs.extension_ref }} $DUCKDB_VERSION ${{ matrix.duckdb_arch }} $BUCKET_NAME true 
+          elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/heads/main)$ ]] ; then
+            python -m pip install awscli
+            ./scripts/extension-upload.sh ${{ inputs.extension_name }} `git log -1 --format=%h` $DUCKDB_VERSION ${{ matrix.duckdb_arch }} $BUCKET_NAME false 
+          fi


### PR DESCRIPTION
### This pr
The goal is to provide [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) that out of tree extensions can use to reduce code duplication in CI and make it easier for third party developers to maintain their extension CI.

This will allow us to
- remove most ci code from out-of-tree extensions (custom testing setups (e.g. http servers for testing) will need to remain)
- centrally maintain ci of out-of-tree extensions
- keep third party devs of extensions up to date with changes/additions to CI for extension binary testing and distribution.


### Review/merge process 
This pr has a companion pr in  https://github.com/duckdb/extension-template/pull/31. The process to merge the two is first this one, update the tag/branch in the extension-template PR to track current master, then merge extension-template. Finally, when v0.9.0 happens the tag for the workflow in extension-template and the duckdb version should be set to that.
