### PR TITLE
Support list of strings for column references in the R API

### DIFF
--- a/tools/rpkg/R/cpp11.R
+++ b/tools/rpkg/R/cpp11.R
@@ -32,8 +32,8 @@ rapi_unregister_arrow <- function(conn, name) {
   invisible(.Call(`_duckdb_rapi_unregister_arrow`, conn, name))
 }
 
-rapi_expr_reference <- function(name, table) {
-  .Call(`_duckdb_rapi_expr_reference`, name, table)
+rapi_expr_reference <- function(rnames) {
+  .Call(`_duckdb_rapi_expr_reference`, rnames)
 }
 
 rapi_expr_constant <- function(val) {

--- a/tools/rpkg/R/relational.R
+++ b/tools/rpkg/R/relational.R
@@ -1,18 +1,21 @@
 # expressions
 
 #' Create a column reference expression
-#' @param name the column name to be referenced
+#' @param names the column name to be referenced, could be a list to refer to schema.table.column etc.
 #' @param table the optional table name or a relation object to be referenced
 #' @return a column reference expression
 #' @noRd
 #' @examples
 #' col_ref_expr <- expr_reference("some_column_name")
 #' col_ref_expr2 <- expr_reference("some_column_name", "some_table_name")
-expr_reference <- function(name, table = "") {
+expr_reference <- function(names, table = NA) {
   if (inherits(table, "duckdb_relation")) {
-    table <- rel_alias(table)
+    names <- c(rel_alias(table), names)
   }
-  rapi_expr_reference(name, table)
+  if (is.character(table)) {
+    names <- c(table, names)
+  }
+  rapi_expr_reference(names)
 }
 
 #' Create a constant expression

--- a/tools/rpkg/R/relational.R
+++ b/tools/rpkg/R/relational.R
@@ -8,7 +8,7 @@
 #' @examples
 #' col_ref_expr <- expr_reference("some_column_name")
 #' col_ref_expr2 <- expr_reference("some_column_name", "some_table_name")
-expr_reference <- function(names, table = NA) {
+expr_reference <- function(names, table = NULL) {
   if (inherits(table, "duckdb_relation")) {
     names <- c(rel_alias(table), names)
   }

--- a/tools/rpkg/src/cpp11.cpp
+++ b/tools/rpkg/src/cpp11.cpp
@@ -68,10 +68,10 @@ extern "C" SEXP _duckdb_rapi_unregister_arrow(SEXP conn, SEXP name) {
   END_CPP11
 }
 // relational.cpp
-SEXP rapi_expr_reference(std::string name, std::string table);
-extern "C" SEXP _duckdb_rapi_expr_reference(SEXP name, SEXP table) {
+SEXP rapi_expr_reference(r_vector<r_string> rnames);
+extern "C" SEXP _duckdb_rapi_expr_reference(SEXP rnames) {
   BEGIN_CPP11
-    return cpp11::as_sexp(rapi_expr_reference(cpp11::as_cpp<cpp11::decay_t<std::string>>(name), cpp11::as_cpp<cpp11::decay_t<std::string>>(table)));
+    return cpp11::as_sexp(rapi_expr_reference(cpp11::as_cpp<cpp11::decay_t<r_vector<r_string>>>(rnames)));
   END_CPP11
 }
 // relational.cpp
@@ -389,7 +389,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_execute_arrow",           (DL_FUNC) &_duckdb_rapi_execute_arrow,           2},
     {"_duckdb_rapi_expr_constant",           (DL_FUNC) &_duckdb_rapi_expr_constant,           1},
     {"_duckdb_rapi_expr_function",           (DL_FUNC) &_duckdb_rapi_expr_function,           4},
-    {"_duckdb_rapi_expr_reference",          (DL_FUNC) &_duckdb_rapi_expr_reference,          2},
+    {"_duckdb_rapi_expr_reference",          (DL_FUNC) &_duckdb_rapi_expr_reference,          1},
     {"_duckdb_rapi_expr_set_alias",          (DL_FUNC) &_duckdb_rapi_expr_set_alias,          2},
     {"_duckdb_rapi_expr_tostring",           (DL_FUNC) &_duckdb_rapi_expr_tostring,           1},
     {"_duckdb_rapi_expr_window",             (DL_FUNC) &_duckdb_rapi_expr_window,             9},

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -46,17 +46,17 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 }
 // DuckDB Expressions
 
-[[cpp11::register]] SEXP rapi_expr_reference(std::string name, std::string table) {
-	if (name.size() == 0) {
-		stop("expr_reference: Zero length name");
+[[cpp11::register]] SEXP rapi_expr_reference(r_vector<r_string> rnames) {
+	if (rnames.size() == 0) {
+		stop("expr_reference: Zero length name vector");
 	}
-	if (!table.empty()) {
-		auto res = make_external<ColumnRefExpression>("duckdb_expr", name, table);
-		res->alias = name; // TODO does this really make sense here?
-		return res;
-	} else {
-		return make_external<ColumnRefExpression>("duckdb_expr", name);
+	duckdb::vector<std::string> names;
+	for (auto name : rnames) {
+		names.push_back(name);
 	}
+	auto res = make_external<ColumnRefExpression>("duckdb_expr", names);
+	res->alias = StringUtil::Join(names, ".");
+	return res;
 }
 
 [[cpp11::register]] SEXP rapi_expr_constant(sexp val) {

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -52,6 +52,9 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 	}
 	duckdb::vector<std::string> names;
 	for (auto name : rnames) {
+		if (name.size() == 0) {
+			stop("expr_reference: Zero length name");
+		}
 		names.push_back(name);
 	}
 	return make_external<ColumnRefExpression>("duckdb_expr", names);;

--- a/tools/rpkg/src/relational.cpp
+++ b/tools/rpkg/src/relational.cpp
@@ -54,9 +54,7 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 	for (auto name : rnames) {
 		names.push_back(name);
 	}
-	auto res = make_external<ColumnRefExpression>("duckdb_expr", names);
-	res->alias = StringUtil::Join(names, ".");
-	return res;
+	return make_external<ColumnRefExpression>("duckdb_expr", names);;
 }
 
 [[cpp11::register]] SEXP rapi_expr_constant(sexp val) {


### PR DESCRIPTION
So we can write references like

```R
duckdb:::expr_reference(c("some_schema", "some_table", "some_column"))
```