### PR TITLE
[Python] Pandas 2.1.0 update

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pandas_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pandas_module.hpp
@@ -23,6 +23,11 @@ public:
 
 public:
 	PythonImportCacheItem ArrowDtype;
+
+protected:
+	bool IsRequired() const override final {
+		return false;
+	}
 };
 
 // pandas.core.arrays.arrow

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pandas_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pandas_module.hpp
@@ -13,9 +13,9 @@
 namespace duckdb {
 
 // pandas.core.arrays.arrow.dtype
-struct PandasCoreArraysArrowDtypeCacheItem : public PythonImportCacheItem {
+struct PandasCoreDtypesDtypesCacheItem : public PythonImportCacheItem {
 public:
-	~PandasCoreArraysArrowDtypeCacheItem() override {
+	~PandasCoreDtypesDtypesCacheItem() override {
 	}
 	virtual void LoadSubtypes(PythonImportCache &cache) override {
 		ArrowDtype.LoadAttribute("ArrowDtype", cache, *this);
@@ -36,11 +36,11 @@ public:
 	~PandasCoreArraysArrowCacheItem() override {
 	}
 	virtual void LoadSubtypes(PythonImportCache &cache) override {
-		dtype.LoadModule("pandas.core.arrays.arrow.dtype", cache);
+		dtype.LoadModule("pandas.core.dtypes.dtypes", cache);
 	}
 
 public:
-	PandasCoreArraysArrowDtypeCacheItem dtype;
+	PandasCoreDtypesDtypesCacheItem dtype;
 
 protected:
 	bool IsRequired() const override final {

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -8,7 +8,7 @@ import duckdb
 try:
     import pandas
 
-    pyarrow_dtype = pandas.core.dtypes.dtypes.ArrowDtype
+    pyarrow_dtype = pandas.ArrowDtype
 except:
     pyarrow_dtype = None
 

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -8,7 +8,7 @@ import duckdb
 try:
     import pandas
 
-    pyarrow_dtype = pandas.core.arrays.arrow.dtype.ArrowDtype
+    pyarrow_dtype = pandas.core.dtypes.dtypes.ArrowDtype
 except:
     pyarrow_dtype = None
 

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_arrow.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_arrow.py
@@ -56,8 +56,8 @@ class TestPandasArrow(object):
         python_df = pd.DataFrame({'a': pd.Series(['test', [5, 4, 3], {'a': 42}])}).convert_dtypes()
 
         df = pd.concat([numpy_df['a'], arrow_df['a'], python_df['a']], axis=1, keys=['numpy', 'arrow', 'python'])
-        assert isinstance(df.dtypes['numpy'], pd.core.arrays.integer.IntegerDtype)
-        assert isinstance(df.dtypes['arrow'], pd.core.dtypes.dtypes.ArrowDtype)
+        assert isinstance(df.dtypes['numpy'], pd.Int64Dtype)
+        assert isinstance(df.dtypes['arrow'], pd.ArrowDtype)
         assert isinstance(df.dtypes['python'], np.dtype('O').__class__)
 
         with pytest.raises(duckdb.InvalidInputException, match='Conversion failed for column python with type object'):

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_arrow.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_arrow.py
@@ -56,9 +56,9 @@ class TestPandasArrow(object):
         python_df = pd.DataFrame({'a': pd.Series(['test', [5, 4, 3], {'a': 42}])}).convert_dtypes()
 
         df = pd.concat([numpy_df['a'], arrow_df['a'], python_df['a']], axis=1, keys=['numpy', 'arrow', 'python'])
-        assert isinstance(df.dtypes[0], pd.core.arrays.integer.IntegerDtype)
-        assert isinstance(df.dtypes[1], pd.core.arrays.arrow.dtype.ArrowDtype)
-        assert isinstance(df.dtypes[2], np.dtype('O').__class__)
+        assert isinstance(df.dtypes['numpy'], pd.core.arrays.integer.IntegerDtype)
+        assert isinstance(df.dtypes['arrow'], pd.core.dtypes.dtypes.ArrowDtype)
+        assert isinstance(df.dtypes['python'], np.dtype('O').__class__)
 
         with pytest.raises(duckdb.InvalidInputException, match='Conversion failed for column python with type object'):
             res = con.sql('select * from df').fetchall()


### PR DESCRIPTION
Fixes #8735 

Pandas has moved the location of `ArrowDtype`, and say this is subject to change, so we make the import not required so it can fail without causing an error.

I've updated the location and fixed all tests that broke with pandas 2.1.0