### PR TITLE
Change parquet_write_memory_limit.test_slow to not preserve order

### DIFF
--- a/test/sql/copy/parquet/writer/parquet_write_memory_limit.test_slow
+++ b/test/sql/copy/parquet/writer/parquet_write_memory_limit.test_slow
@@ -1,6 +1,6 @@
 # name: test/sql/copy/parquet/batched_write/parquet_write_memory_limit.test_slow
 # description: Verify data is streamed and memory limit is not exceeded in Parquet write
-# group: [batched_write]
+# group: [writer]
 
 require parquet
 
@@ -12,13 +12,13 @@ load __TEST_DIR__/parquet_write_memory_limit.db
 statement ok
 COPY (SELECT i, i // 5 AS j FROM range(100000000) t(i)) TO '__TEST_DIR__/large_integers.parquet'
 
-# set threads to 4 and a memory limit of 900MB. the limit in this test used to be 300MB,
-# but we weren't using the BufferAllocator for the ColumnDataCollection buffers in ParquetWriteLocalState
 statement ok
-SET threads=4
+SET memory_limit='0.3GB'
 
+# we need to do this otherwise we buffer a lot more data in a BatchedDataCollection
+# by disable order preservation we can immediately flush the ColumnDataCollections
 statement ok
-SET memory_limit='1GB'
+set preserve_insertion_order=false
 
 # stream from one parquet file to another
 query I

--- a/test/sql/copy/parquet/writer/parquet_write_memory_limit.test_slow
+++ b/test/sql/copy/parquet/writer/parquet_write_memory_limit.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/copy/parquet/batched_write/parquet_write_memory_limit.test_slow
+# name: test/sql/copy/parquet/writer/parquet_write_memory_limit.test_slow
 # description: Verify data is streamed and memory limit is not exceeded in Parquet write
 # group: [writer]
 


### PR DESCRIPTION
... and move it to a different test directory since it no longer does a batched write.

This test has been spuriously failing because it uses a lot of memory during `PhysicalFixedBatchCopy`. We probably want to reduce the memory usage there, but for now, I've moved this test so it no longer fails our nightly builds.