### PR TITLE
Add ends_with as an alias for suffix

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -156,6 +156,9 @@ static DefaultMacro internal_macros[] = {
 	// date functions
 	{DEFAULT_SCHEMA, "date_add", {"date", "interval", nullptr}, "date + interval"},
 
+	// text functions
+	{DEFAULT_SCHEMA, "ends_with", {"string", "search_string", nullptr}, "suffix(string, search_string)"},
+
 	{nullptr, nullptr, {nullptr}, nullptr}
 	};
 


### PR DESCRIPTION
One line PR that adds `ends_with` as an alias for `suffix` (for consistency with the existing `starts_with` function), as discussed in #8757.

I wasn't sure any tests were needed, as it's just an alias for an existing function, but happy to add if you think helpful. I'll file a separate PR in duckdb-web to update the docs.

This is my first DuckDB contribution, so thanks for considering!