### PR TITLE
Use manylinux_2_24 image for Linux aarch64 Python builds

### DIFF
--- a/tools/pythonpkg/cibw.toml
+++ b/tools/pythonpkg/cibw.toml
@@ -7,6 +7,7 @@ before-build = 'pip install oldest-supported-numpy'
 before-test = 'pip install --prefer-binary pandas pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true) && (pip install --prefer-binary "adbc_driver_manager==0.6.0" || true) && (pip install --prefer-binary "tensorflow" || true)'
 test-requires = 'pytest'
 test-command = 'DUCKDB_PYTHON_TEST_EXTENSION_PATH={project} DUCKDB_PYTHON_TEST_EXTENSION_REQUIRED=1 python -m pytest {project}/tests'
+manylinux-aarch64-image = "manylinux_2_24"
 
 # For musllinux we currently don't build extensions yet
 [[tool.cibuildwheel.overrides]]
@@ -18,7 +19,7 @@ test-command = "python -m pytest {project}/tests/fast"
 select = "*i686*"
 test-command = "python -m pytest {project}/tests/fast"
 
-# For aarch64 we don't build extensions
+# For aarch64 we don't build extensions inline, so can't test them yet
 [[tool.cibuildwheel.overrides]]
 select = "*aarch64*"
 test-command = "python -m pytest {project}/tests/fast"


### PR DESCRIPTION
This effectively drops the _gcc4 postfix, enabling compatibility with our standard linux_arm64 platform extension builds.

This is at the cost of dropping compatibility with some fairly old versions Linux versions.

I'm very open to discussion on this, but I think enabling extension use is a big enough boon for the cost of deceased compatibility.
Alternatively, we can continue to publish builds using the manylinux2014 standard and add the builds for the manylinux_2_24 standard.

Fixes https://github.com/duckdb/duckdb/issues/8035