### PR TITLE
fix some nodejs tests in some envs

### DIFF
--- a/tools/nodejs/package.json
+++ b/tools/nodejs/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",
     "pretest": "node test/support/createdb.js",
-    "test": "mocha -R spec --timeout 480000 --expose-gc",
-    "test-path": "mocha -R spec --timeout 480000 --expose-gc --exclude 'test/*.ts'",
+    "test": "cross-env TZ='Etc/UTC' mocha -R spec --timeout 480000 --expose-gc",
+    "test-path": "cross-env TZ='Etc/UTC' mocha -R spec --timeout 480000 --expose-gc --exclude 'test/*.ts'",
     "pack": "node-pre-gyp package"
   },
   "directories": {
@@ -35,6 +35,7 @@
     "aws-sdk": "^2.790.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
+    "cross-env": "^7.0.3",
     "jsdoc3-parser": "^2.0.0",
     "mocha": "^8.3.0",
     "ts-node": "^10.9.1",

--- a/tools/nodejs/package.json
+++ b/tools/nodejs/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",
     "pretest": "node test/support/createdb.js",
-    "test": "cross-env TZ='Etc/UTC' mocha -R spec --timeout 480000 --expose-gc",
-    "test-path": "cross-env TZ='Etc/UTC' mocha -R spec --timeout 480000 --expose-gc --exclude 'test/*.ts'",
+    "test": "mocha -R spec --timeout 480000 --expose-gc",
+    "test-path": "mocha -R spec --timeout 480000 --expose-gc --exclude 'test/*.ts'",
     "pack": "node-pre-gyp package"
   },
   "directories": {
@@ -35,7 +35,6 @@
     "aws-sdk": "^2.790.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "cross-env": "^7.0.3",
     "jsdoc3-parser": "^2.0.0",
     "mocha": "^8.3.0",
     "ts-node": "^10.9.1",

--- a/tools/nodejs/test/prepare.test.ts
+++ b/tools/nodejs/test/prepare.test.ts
@@ -652,7 +652,16 @@ describe('prepare', function() {
             });
             it("should aggregate kurtosis(num)", function (done) {
                 db.all("SELECT kurtosis(num) as kurtosis FROM foo", function (err: null | Error, res: TableData) {
-                    assert.equal(res[0].kurtosis, -1.1999999999999997);
+                    // The `num` column of table `foo` contains each integer from 0 to 999,999 exactly once.
+                    // This is a uniform distribution. The excess kurtosis for a uniform distribution is exactly -1.2.
+                    // See https://en.wikipedia.org/wiki/Kurtosis#Other_well-known_distributions
+                    const expected = -1.2;
+                    
+                    // The calculated value can differ from the exact answer by small amounts on different platforms due
+                    // to floating-point errors. This tolerance was determined experimentally.
+                    const tolerance = Number.EPSILON * 10;
+
+                    assert.ok(Math.abs(res[0].kurtosis - expected) < tolerance);
                     done(err);
                 });
             });

--- a/tools/nodejs/test/test_all_types.test.ts
+++ b/tools/nodejs/test/test_all_types.test.ts
@@ -90,7 +90,7 @@ const correct_answer_map: Record<string, any[]> = {
   date_array: [
     [],
     [
-      new Date(1970, 0, 1),
+      new Date(Date.UTC(1970, 0, 1)),
       null,
       new Date("0001-01-01T00:00:00.000Z"),
       new Date("9999-12-31T00:00:00.000Z"),
@@ -100,7 +100,7 @@ const correct_answer_map: Record<string, any[]> = {
   timestamp_array: [
     [],
     [
-      new Date(1970, 0, 1),
+      new Date(Date.UTC(1970, 0, 1)),
       null,
       new Date("0001-01-01T00:00:00.000Z"),
       new Date("9999-12-31T23:59:59.999Z"),
@@ -111,7 +111,7 @@ const correct_answer_map: Record<string, any[]> = {
   timestamptz_array: [
     [],
     [
-      new Date(1970, 0, 1),
+      new Date(Date.UTC(1970, 0, 1)),
       null,
       new Date("0001-01-01T00:00:00.000Z"),
       new Date("9999-12-31T23:59:59.999Z"),
@@ -171,7 +171,7 @@ const correct_answer_map: Record<string, any[]> = {
   ],
 
   timestamp: [
-    new Date("1990-01-01T00:00"),
+    new Date(Date.UTC(1990, 0, 1)),
     new Date("9999-12-31T23:59:59.000Z"),
     null,
   ],


### PR DESCRIPTION
This fixes two different environment-specific problems with the Node JS tests that I encountered:

- Some tests (in `test_all_types.test.ts`) are timezone-dependent. When I ran them as-is in my local timezone (Pacific), they fail consistently, with expected and actual time strings differing by exactly that timezone difference. The fix is to ensure the tests always run in the same timezone (UTC) regardless of the settings of the platform on which they are run. I used the `cross-env` package to ensure this environment configuration will work on all platforms.

- One test (the "kurtosis" test in the change) failed, on my M2 MacBook but not my Intel MacBook, with the expected and actual floating-point values differing by very small amounts (about 10 * EPSILON). The existing expected was already different from the exact correct value by a small multiple of EPSILON. I changed the test case to accept values within a small tolerance range; I set this range to the smallest multiple of EPSILON that worked on my M2 MacBook.