### PR TITLE
Fix R ci

### DIFF
--- a/tools/rpkg/tests/testthat/test_arrow.R
+++ b/tools/rpkg/tests/testthat/test_arrow.R
@@ -158,8 +158,7 @@ test_that("to_arrow roundtrip, with dataset", {
       to_arrow() %>%
       filter(int > 5 & part > 1) %>%
       collect() %>%
-      arrange(part, int) %>%
-      as.data.frame(),
+      arrange(part, int),
     ds %>%
       select(-fct) %>%
       filter(int > 5 & part > 1) %>%

--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -53,32 +53,29 @@ test_that("structs give the same results via Arrow", {
   skip_if_not_installed("vctrs")
   skip_if_not_installed("tibble")
   skip_if_not_installed("arrow")
-  library(dplyr)
-  library(arrow)
-  library(duckdb)
 
   con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
-  res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
-  expect_equal(res, tibble::tibble(
+  res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE)
+  expect_equal(tibble::as_tibble(res), tibble::tibble(
     s = tibble::tibble(x = 100L, y = "hello", z = 3.14)
   ))
 
-  res <- dbGetQuery(con, "SELECT 1 AS n, {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
-  expect_equal(res, tibble::tibble(
+  res <- dbGetQuery(con, "SELECT 1 AS n, {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE)
+  expect_equal(tibble::as_tibble(res), tibble::tibble(
     n = 1L,
     s = tibble::tibble(x = 100L, y = "hello", z = 3.14)
   ))
 
-  res <- dbGetQuery(con, "values (100, {'x': 100}), (200, {'x': 200}), (300, NULL)", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
-  expect_equal(res, tibble::tibble(
+  res <- dbGetQuery(con, "values (100, {'x': 100}), (200, {'x': 200}), (300, NULL)", arrow = TRUE)
+  expect_equal(tibble::as_tibble(res), tibble::tibble(
     col0 = c(100L, 200L, 300L),
     col1 = tibble::tibble(x = c(100L, 200L, NA))
   ))
 
-  res <- dbGetQuery(con, "values ('a', {'x': 100, 'y': {'a': 1, 'b': 2}}), ('b', {'x': 200, y: NULL}), ('c', NULL)", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
-  expect_equal(res, tibble::tibble(
+  res <- dbGetQuery(con, "values ('a', {'x': 100, 'y': {'a': 1, 'b': 2}}), ('b', {'x': 200, y: NULL}), ('c', NULL)", arrow = TRUE)
+  expect_equal(tibble::as_tibble(res), tibble::tibble(
     col0 = c("a", "b", "c"),
     col1 = tibble::tibble(
       x = c(100L, 200L, NA),
@@ -86,8 +83,8 @@ test_that("structs give the same results via Arrow", {
     )
   ))
 
-  res <- dbGetQuery(con, "select 100 AS other, [{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}] AS s", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
-  expect_equal(res, tibble::tibble(
+  res <- dbGetQuery(con, "select 100 AS other, [{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}] AS s", arrow = TRUE)
+  expect_equal(tibble::as_tibble(res), tibble::tibble(
     other = 100L,
     s = vctrs::new_list_of(
       list(
@@ -98,8 +95,8 @@ test_that("structs give the same results via Arrow", {
     )
   ))
 
-  res <- dbGetQuery(con, "values ([{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}]), ([]), ([{'x': 1, 'y': 'a'}])", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
-  expect_equal(res, tibble::tibble(
+  res <- dbGetQuery(con, "values ([{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}]), ([]), ([{'x': 1, 'y': 'a'}])", arrow = TRUE)
+  expect_equal(tibble::as_tibble(res), tibble::tibble(
     col0 = vctrs::new_list_of(
       list(
         tibble::tibble(x = c(1L, 2L), y = c("a", "b")),

--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -53,28 +53,31 @@ test_that("structs give the same results via Arrow", {
   skip_if_not_installed("vctrs")
   skip_if_not_installed("tibble")
   skip_if_not_installed("arrow")
+  library(dplyr)
+  library(arrow)
+  library(duckdb)
 
   con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
-  res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE)
+  res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
   expect_equal(res, tibble::tibble(
     s = tibble::tibble(x = 100L, y = "hello", z = 3.14)
   ))
 
-  res <- dbGetQuery(con, "SELECT 1 AS n, {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE)
+  res <- dbGetQuery(con, "SELECT 1 AS n, {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
   expect_equal(res, tibble::tibble(
     n = 1L,
     s = tibble::tibble(x = 100L, y = "hello", z = 3.14)
   ))
 
-  res <- dbGetQuery(con, "values (100, {'x': 100}), (200, {'x': 200}), (300, NULL)", arrow = TRUE)
+  res <- dbGetQuery(con, "values (100, {'x': 100}), (200, {'x': 200}), (300, NULL)", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
   expect_equal(res, tibble::tibble(
     col0 = c(100L, 200L, 300L),
     col1 = tibble::tibble(x = c(100L, 200L, NA))
   ))
 
-  res <- dbGetQuery(con, "values ('a', {'x': 100, 'y': {'a': 1, 'b': 2}}), ('b', {'x': 200, y: NULL}), ('c', NULL)", arrow = TRUE)
+  res <- dbGetQuery(con, "values ('a', {'x': 100, 'y': {'a': 1, 'b': 2}}), ('b', {'x': 200, y: NULL}), ('c', NULL)", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
   expect_equal(res, tibble::tibble(
     col0 = c("a", "b", "c"),
     col1 = tibble::tibble(
@@ -83,7 +86,7 @@ test_that("structs give the same results via Arrow", {
     )
   ))
 
-  res <- dbGetQuery(con, "select 100 AS other, [{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}] AS s", arrow = TRUE)
+  res <- dbGetQuery(con, "select 100 AS other, [{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}] AS s", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
   expect_equal(res, tibble::tibble(
     other = 100L,
     s = vctrs::new_list_of(
@@ -95,7 +98,7 @@ test_that("structs give the same results via Arrow", {
     )
   ))
 
-  res <- dbGetQuery(con, "values ([{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}]), ([]), ([{'x': 1, 'y': 'a'}])", arrow = TRUE)
+  res <- dbGetQuery(con, "values ([{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}]), ([]), ([{'x': 1, 'y': 'a'}])", arrow = TRUE) |> to_duckdb() |> to_arrow() |> collect()
   expect_equal(res, tibble::tibble(
     col0 = vctrs::new_list_of(
       list(


### PR DESCRIPTION
This is a weird bug. I'm not sure if it relates to the new arrow version, but for some reason when comparing tibbles and data frames without explicitly casting them now fails. The problem goes away if an older arrow library is used (pre 13.0.0) or if you explicitly cast data.frames to tibbles. You can also remove explicit casts that cause test that to compare two data frames that have difference types