### PR TITLE
Avoid rounding down buffer block sizes to uint32_t

### DIFF
--- a/src/common/file_buffer.cpp
+++ b/src/common/file_buffer.cpp
@@ -68,7 +68,7 @@ FileBuffer::MemoryRequirement FileBuffer::CalculateMemory(uint64_t user_size) {
 		result.alloc_size = user_size;
 	} else {
 		result.header_size = Storage::BLOCK_HEADER_SIZE;
-		result.alloc_size = AlignValue<uint32_t, Storage::SECTOR_SIZE>(result.header_size + user_size);
+		result.alloc_size = AlignValue<idx_t, Storage::SECTOR_SIZE>(result.header_size + user_size);
 	}
 	return result;
 }


### PR DESCRIPTION
This was not a sorting issue, but a buffer manager issue. Fixes #7665

This may be the same bug as #8031, as it crashes around the resize to 4GB, although I suspect that #8031 should be fixed by the aggregate rework.