### PR TITLE
CAPI: Make it possible to create enum types

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1385,6 +1385,18 @@ DUCKDB_API duckdb_logical_type duckdb_create_struct_type(duckdb_logical_type *me
                                                          idx_t member_count);
 
 /*!
+Creates an ENUM type from the passed member name array.
+The resulting type should be destroyed with `duckdb_destroy_logical_type`.
+
+* enum_name: The name of the enum.
+* member_names: The array of names that the enum should consist of.
+* member_count: The number of elements that were specified in the array.
+* returns: The logical type.
+*/
+DUCKDB_API duckdb_logical_type duckdb_create_enum_type(const char *enum_name, const char **member_names,
+                                                       idx_t member_count);
+
+/*!
 Creates a `duckdb_logical_type` of type decimal with the specified width and scale
 The resulting type should be destroyed with `duckdb_destroy_logical_type`.
 

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1393,8 +1393,7 @@ The resulting type should be destroyed with `duckdb_destroy_logical_type`.
 * member_count: The number of elements that were specified in the array.
 * returns: The logical type.
 */
-DUCKDB_API duckdb_logical_type duckdb_create_enum_type(const char *enum_name, const char **member_names,
-                                                       idx_t member_count);
+DUCKDB_API duckdb_logical_type duckdb_create_enum_type(const char **member_names, idx_t member_count);
 
 /*!
 Creates a `duckdb_logical_type` of type decimal with the specified width and scale

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -73,6 +73,28 @@ duckdb_logical_type duckdb_create_struct_type(duckdb_logical_type *member_types_
 	return reinterpret_cast<duckdb_logical_type>(mtype);
 }
 
+duckdb_logical_type duckdb_create_enum_type(const char *enum_name, const char **member_names, idx_t member_count) {
+	if (!enum_name || !member_names) {
+		return nullptr;
+	}
+	for (idx_t i = 0; i < member_count; i++) {
+		if (!member_names[i]) {
+			return nullptr;
+		}
+	}
+
+	duckdb::Vector enum_vector(duckdb::LogicalType::VARCHAR, member_count);
+	auto enum_vector_ptr = duckdb::FlatVector::GetData<duckdb::string_t>(enum_vector);
+
+	for (idx_t i = 0; i < member_count; i++) {
+		enum_vector_ptr[i] = duckdb::StringVector::AddStringOrBlob(enum_vector, member_names[i]);
+	}
+
+	duckdb::LogicalType *mtype = new duckdb::LogicalType;
+	*mtype = duckdb::LogicalType::ENUM(enum_name, enum_vector, member_count);
+	return reinterpret_cast<duckdb_logical_type>(mtype);
+}
+
 duckdb_logical_type duckdb_create_map_type(duckdb_logical_type key_type, duckdb_logical_type value_type) {
 	if (!key_type || !value_type) {
 		return nullptr;

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -73,25 +73,22 @@ duckdb_logical_type duckdb_create_struct_type(duckdb_logical_type *member_types_
 	return reinterpret_cast<duckdb_logical_type>(mtype);
 }
 
-duckdb_logical_type duckdb_create_enum_type(const char *enum_name, const char **member_names, idx_t member_count) {
-	if (!enum_name || !member_names) {
+duckdb_logical_type duckdb_create_enum_type(const char **member_names, idx_t member_count) {
+	if (!member_names) {
 		return nullptr;
 	}
-	for (idx_t i = 0; i < member_count; i++) {
-		if (!member_names[i]) {
-			return nullptr;
-		}
-	}
-
 	duckdb::Vector enum_vector(duckdb::LogicalType::VARCHAR, member_count);
 	auto enum_vector_ptr = duckdb::FlatVector::GetData<duckdb::string_t>(enum_vector);
 
 	for (idx_t i = 0; i < member_count; i++) {
+		if (!member_names[i]) {
+			return nullptr;
+		}
 		enum_vector_ptr[i] = duckdb::StringVector::AddStringOrBlob(enum_vector, member_names[i]);
 	}
 
 	duckdb::LogicalType *mtype = new duckdb::LogicalType;
-	*mtype = duckdb::LogicalType::ENUM(enum_name, enum_vector, member_count);
+	*mtype = duckdb::LogicalType::ENUM(enum_vector, member_count);
 	return reinterpret_cast<duckdb_logical_type>(mtype);
 }
 

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -200,3 +200,19 @@ TEST_CASE("Test struct types creation C API", "[capi]") {
 	}
 	duckdb_destroy_logical_type(&logical_type);
 }
+
+TEST_CASE("Test enum types creation C API", "[capi]") {
+	duckdb::vector<const char *> names = {"a", "b"};
+
+	auto logical_type = duckdb_create_enum_type("name", names.data(), names.size());
+	REQUIRE(duckdb_get_type_id(logical_type) == duckdb_type::DUCKDB_TYPE_ENUM);
+	REQUIRE(duckdb_enum_dictionary_size(logical_type) == 2);
+
+	for (idx_t i = 0; i < names.size(); i++) {
+		auto name = duckdb_enum_dictionary_value(logical_type, i);
+		string str_name(name);
+		duckdb_free(name);
+		REQUIRE(str_name == names[i]);
+	}
+	duckdb_destroy_logical_type(&logical_type);
+}

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -204,7 +204,7 @@ TEST_CASE("Test struct types creation C API", "[capi]") {
 TEST_CASE("Test enum types creation C API", "[capi]") {
 	duckdb::vector<const char *> names = {"a", "b"};
 
-	auto logical_type = duckdb_create_enum_type("name", names.data(), names.size());
+	auto logical_type = duckdb_create_enum_type(names.data(), names.size());
 	REQUIRE(duckdb_get_type_id(logical_type) == duckdb_type::DUCKDB_TYPE_ENUM);
 	REQUIRE(duckdb_enum_dictionary_size(logical_type) == 2);
 
@@ -215,4 +215,6 @@ TEST_CASE("Test enum types creation C API", "[capi]") {
 		REQUIRE(str_name == names[i]);
 	}
 	duckdb_destroy_logical_type(&logical_type);
+
+	REQUIRE(duckdb_create_enum_type(nullptr, 0) == nullptr);
 }


### PR DESCRIPTION
The C API was previously able to only create union and struct logical types, but not enums. This PR adds support for enums as well.