### PR TITLE
Switching to twine token and remove cleanup job

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -108,6 +108,7 @@ jobs:
         path: |
           libduckdb-linux-amd64.zip
           duckdb_cli-linux-amd64.zip
+          duckdb_odbc-linux-amd64.zip
 
  linux-release-aarch64:
    # Builds binaries for linux_arm64

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -202,8 +202,8 @@ jobs:
 
     - name: Deploy
       env:
-        TWINE_USERNAME: 'hfmuehleisen'
-        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
       shell: bash
       run: |
         python scripts/asset-upload-gha.py duckdb_python_src.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz
@@ -224,7 +224,7 @@ jobs:
         CIBW_ARCHS: 'x86_64 universal2 arm64'
         CIBW_TEST_COMMAND: 'python -m pytest {project}/tests/fast'
         SETUPTOOLS_SCM_NO_LOCAL: 'yes'
-        TWINE_USERNAME: 'hfmuehleisen'
+        TWINE_USERNAME: '__token__'
         DUCKDB_BUILD_UNITY: 1
 
       steps:
@@ -258,8 +258,8 @@ jobs:
 
       - name: Deploy
         env:
-          TWINE_USERNAME: 'hfmuehleisen'
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
         shell: bash
         run: |
           if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
@@ -289,7 +289,7 @@ jobs:
         CIBW_BUILD: ${{ matrix.python_build}}
         SETUPTOOLS_SCM_NO_LOCAL: 'yes'
         SETUPTOOLS_USE_DISTUTILS: 'stdlib'
-        TWINE_USERNAME: 'hfmuehleisen'
+        TWINE_USERNAME: '__token__'
         DUCKDB_BUILD_UNITY: 1
 
       steps:
@@ -323,31 +323,10 @@ jobs:
 
       - name: Deploy
         env:
-          TWINE_USERNAME: 'hfmuehleisen'
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
         shell: bash
         run: |
           if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl
           fi
-
-   linux-release-cleanup:
-      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
-      name: PyPi Release Cleanup
-      runs-on: ubuntu-20.04
-      needs: linux-python3-9
-      env:
-        PYPI_PASSWORD: ${{secrets.PYPI_PASSWORD}}
-
-      steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.7'
-
-      - name: Cleanup Releases
-        shell: bash
-        run: python3 scripts/pypi_cleanup.py


### PR DESCRIPTION
We have 2FA enabled now on PyPI so switching to token based authentication. 