### PR TITLE
Re-add pypi-cleanup script and use pypi-cleanup package for deleting dev packages

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -353,7 +353,7 @@ jobs:
 
      - name: Install Packages
        shell: bash
-       run: python3 -m pip install pyotp pypi-cleanup==0.1.4
+       run: python3 -m pip install pyotp
 
      - name: Cleanup Releases
        shell: bash

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -331,3 +331,30 @@ jobs:
           if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl
           fi
+
+   linux-release-cleanup:
+     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+     name: PyPi Release Cleanup
+     runs-on: ubuntu-20.04
+     needs: linux-python3-9
+     env:
+       PYPI_CLEANUP_USERNAME: 'mytherin'
+       PYPI_CLEANUP_PASSWORD: ${{secrets.PYPI_CLEANUP_PASSWORD}}
+       PYPI_CLEANUP_OTP: ${{secrets.PYPI_CLEANUP_OTP}}
+
+     steps:
+     - uses: actions/checkout@v3
+       with:
+         fetch-depth: 0
+
+     - uses: actions/setup-python@v4
+       with:
+         python-version: '3.7'
+
+     - name: Install Packages
+       shell: bash
+       run: python3 -m pip install pyotp pypi-cleanup==0.1.4
+
+     - name: Cleanup Releases
+       shell: bash
+       run: python3 scripts/pypi_cleanup.py

--- a/scripts/pypi_cleanup.py
+++ b/scripts/pypi_cleanup.py
@@ -1,112 +1,22 @@
-import ssl
-import urllib.request
-import json
 import os
-import distutils.version as version
-import http.cookiejar
-import re
+import pyotp
+import subprocess
 
 # deletes old dev wheels from pypi. evil hack.
-retain_count = 3
+# how many days to retain dev releases - all dev releases older than 10 days are deleted
+retain_days = 10
 
-pypi_username = "hfmuehleisen"
-pypi_password = os.getenv("PYPI_PASSWORD", "")
+pypi_username = os.environ['PYPI_CLEANUP_USERNAME']
+pypi_password = os.getenv("PYPI_CLEANUP_PASSWORD", "")
+pypi_otp = os.getenv("PYPI_CLEANUP_OTP", "")
 if pypi_password == "":
     print(f'need {pypi_username}\' PyPI password in PYPI_PASSWORD env variable')
     exit(1)
+if pypi_otp == "":
+    print(f'need {pypi_username}\' PyPI otp in PYPI_OTP env variable')
+    exit(1)
 
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
-
-url = 'https://pypi.python.org/pypi/duckdb/json'
-req = urllib.request.urlopen(url, context=ctx)
-raw_resp = req.read().decode()
-resp_json = json.loads(raw_resp)
-
-last_release = resp_json["info"]["version"]
-latest_release_v = version.LooseVersion(last_release)
-
-latest_prereleases = []
-
-
-def parsever(ele):
-    major = version.LooseVersion('.'.join(ele.split('.')[:3]))
-    dev = int(ele.split('.')[3].replace('dev', ''))
-    return (
-        major,
-        dev,
-    )
-
-
-# get a list of all pre-releases
-release_list = resp_json["releases"]
-for ele in release_list:
-    if not ".dev" in ele:
-        continue
-
-    (major, dev) = parsever(ele)
-
-    if major > latest_release_v:
-        latest_prereleases.append((ele, dev))
-
-# sort the pre-releases
-latest_prereleases = sorted(latest_prereleases, key=lambda x: x[1])
-print("List of pre-releases")
-for prerelease in latest_prereleases:
-    print(prerelease[0])
-
-if len(latest_prereleases) <= retain_count:
-    print(f"At most {retain_count} pre-releases - nothing to delete")
-    exit(0)
-
-to_delete = latest_prereleases[: len(latest_prereleases) - retain_count]
-if len(to_delete) < 1:
-    raise ValueError("Nothing to delete")
-
-print("List of to-be-deleted releases")
-for release in to_delete:
-    print(release[0])
-
-to_delete = [x[0] for x in to_delete]
-print(to_delete)
-
-# gah2
-cj = http.cookiejar.CookieJar()
-opener = urllib.request.build_opener(
-    urllib.request.HTTPCookieProcessor(cj), urllib.request.HTTPSHandler(context=ctx, debuglevel=0)
-)
-
-
-def call(url, data=None, headers={}):
-    return opener.open(urllib.request.Request(url, data, headers)).read().decode()
-
-
-csrf_token_re = re.compile(r"name=\"csrf_token\"[^>]+value=\"([^\"]+)\"")
-
-
-def get_token(url):
-    return csrf_token_re.search(call(url)).group(1)
-
-
-login_data = urllib.parse.urlencode(
-    {"csrf_token": get_token("https://pypi.org/account/login/"), "username": pypi_username, "password": pypi_password}
-).encode()
-login_headers = {"Referer": "https://pypi.org/account/login/"}
-
-# perform login
-call("https://pypi.org/account/login/", login_data, login_headers)
-
-# delete gunk
-delete_crsf_token = get_token("https://pypi.org/manage/project/duckdb/releases/")
-delete_headers = {"Referer": "https://pypi.org/manage/project/duckdb/releases/"}
-
-for rev in to_delete:
-    print("Deleting %s" % rev)
-
-    try:
-        delete_data = urllib.parse.urlencode({"confirm_delete_version": rev, "csrf_token": delete_crsf_token}).encode()
-        call("https://pypi.org/manage/project/duckdb/release/%s/" % rev, delete_data, delete_headers)
-    except Exception as e:
-        print(f"Failed to delete {rev}")
-        print(e)
+os.environ['PYPI_CLEANUP_PASSWORD'] = pypi_password
+proc = subprocess.Popen(['pypi-cleanup', '-u', 'Mytherin', '-p', 'duckdb', '-d', str(retain_days), '--do-it'], stdin=subprocess.PIPE)
+# insert otp
+proc.communicate(input=(pyotp.TOTP(pypi_otp).now() + '\n').encode('utf8'))

--- a/scripts/pypi_cleanup.py
+++ b/scripts/pypi_cleanup.py
@@ -33,7 +33,7 @@ if pypi_otp == "":
     exit(1)
 
 
-
+###### NOTE: This code is taken from the pypi-cleanup package (https://github.com/arcivanov/pypi-cleanup/tree/master)
 class CsfrParser(HTMLParser):
     def __init__(self, target, contains_input=None):
         super().__init__()

--- a/scripts/pypi_cleanup.py
+++ b/scripts/pypi_cleanup.py
@@ -19,6 +19,6 @@ if pypi_otp == "":
     print(f'need {pypi_username}\' PyPI OTP secret in PYPI_CLEANUP_OTP env variable')
     exit(1)
 
-proc = subprocess.Popen(['pypi-cleanup', '-u', pypi_username, '-p', 'duckdb', '-d', str(retain_days), '--do-it'], stdin=subprocess.PIPE)
+proc = subprocess.Popen(['pypi-cleanup', '-u', pypi_username, '-p', 'duckdb', '-d', str(retain_days), '--do-it', '-v'], stdin=subprocess.PIPE)
 # insert otp
 proc.communicate(input=(pyotp.TOTP(pypi_otp).now() + '\n').encode('utf8'))

--- a/scripts/pypi_cleanup.py
+++ b/scripts/pypi_cleanup.py
@@ -6,17 +6,19 @@ import subprocess
 # how many days to retain dev releases - all dev releases older than 10 days are deleted
 retain_days = 10
 
-pypi_username = os.environ['PYPI_CLEANUP_USERNAME']
+pypi_username = os.getenv('PYPI_CLEANUP_USERNAME', "")
 pypi_password = os.getenv("PYPI_CLEANUP_PASSWORD", "")
 pypi_otp = os.getenv("PYPI_CLEANUP_OTP", "")
+if pypi_username == "":
+    print(f'need username in PYPI_CLEANUP_USERNAME env variable')
+    exit(1)
 if pypi_password == "":
-    print(f'need {pypi_username}\' PyPI password in PYPI_PASSWORD env variable')
+    print(f'need {pypi_username}\' PyPI password in PYPI_CLEANUP_PASSWORD env variable')
     exit(1)
 if pypi_otp == "":
-    print(f'need {pypi_username}\' PyPI otp in PYPI_OTP env variable')
+    print(f'need {pypi_username}\' PyPI OTP secret in PYPI_CLEANUP_OTP env variable')
     exit(1)
 
-os.environ['PYPI_CLEANUP_PASSWORD'] = pypi_password
-proc = subprocess.Popen(['pypi-cleanup', '-u', 'Mytherin', '-p', 'duckdb', '-d', str(retain_days), '--do-it'], stdin=subprocess.PIPE)
+proc = subprocess.Popen(['pypi-cleanup', '-u', pypi_username, '-p', 'duckdb', '-d', str(retain_days), '--do-it'], stdin=subprocess.PIPE)
 # insert otp
 proc.communicate(input=(pyotp.TOTP(pypi_otp).now() + '\n').encode('utf8'))

--- a/scripts/pypi_cleanup.py
+++ b/scripts/pypi_cleanup.py
@@ -1,10 +1,23 @@
-import os
 import pyotp
-import subprocess
+import datetime
+import logging
+import os
+import re
+import sys
+import time
+from html.parser import HTMLParser
+from textwrap import dedent
+from urllib.parse import urlparse
+
+import requests
+from requests.exceptions import RequestException
 
 # deletes old dev wheels from pypi. evil hack.
 # how many days to retain dev releases - all dev releases older than 10 days are deleted
 retain_days = 10
+patterns = [re.compile(r".*\.dev\d+$")]
+actually_delete = True
+host = 'https://pypi.org/'
 
 pypi_username = os.getenv('PYPI_CLEANUP_USERNAME', "")
 pypi_password = os.getenv("PYPI_CLEANUP_PASSWORD", "")
@@ -19,6 +32,186 @@ if pypi_otp == "":
     print(f'need {pypi_username}\' PyPI OTP secret in PYPI_CLEANUP_OTP env variable')
     exit(1)
 
-proc = subprocess.Popen(['pypi-cleanup', '-u', pypi_username, '-p', 'duckdb', '-d', str(retain_days), '--do-it', '-v'], stdin=subprocess.PIPE)
-# insert otp
-proc.communicate(input=(pyotp.TOTP(pypi_otp).now() + '\n').encode('utf8'))
+
+
+class CsfrParser(HTMLParser):
+    def __init__(self, target, contains_input=None):
+        super().__init__()
+        self._target = target
+        self._contains_input = contains_input
+        self.csrf = None  # Result value from all forms on page
+        self._csrf = None  # Temp value from current form
+        self._in_form = False  # Currently parsing a form with an action we're interested in
+        self._input_contained = False  # Input field requested is contained in the current form
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "form":
+            attrs = dict(attrs)
+            action = attrs.get("action")  # Might be None.
+            if action and (action == self._target or action.startswith(self._target)):
+                self._in_form = True
+            return
+
+        if self._in_form and tag == "input":
+            attrs = dict(attrs)
+            if attrs.get("name") == "csrf_token":
+                self._csrf = attrs["value"]
+
+            if self._contains_input and attrs.get("name") == self._contains_input:
+                self._input_contained = True
+
+            return
+
+    def handle_endtag(self, tag):
+        if tag == "form":
+            self._in_form = False
+            # If we're in a right form that contains the requested input and csrf is not set
+            if (not self._contains_input or self._input_contained) and not self.csrf:
+                self.csrf = self._csrf
+            return
+
+
+class PypiCleanup:
+    def __init__(self, url, username, package, password, otp, patterns, retain_days, delete):
+        self.url = urlparse(url).geturl()
+        if self.url[-1] == "/":
+            self.url = self.url[:-1]
+        self.username = username
+        self.password = password
+        self.otp = otp
+        self.do_it = delete
+        self.package = package
+        self.patterns = patterns
+        self.verbose = True
+        self.date = datetime.datetime.now() - datetime.timedelta(days=retain_days)
+
+    def run(self):
+        csrf = None
+
+        if self.verbose:
+            logging.root.setLevel(logging.DEBUG)
+
+        if self.do_it:
+            logging.warning("!!! WILL ACTUALLY DELETE THINGS !!!")
+            logging.warning("Will sleep for 3 seconds - Ctrl-C to abort!")
+            time.sleep(3.0)
+        else:
+            logging.info("Running in DRY RUN mode")
+
+        logging.info(f"Will use the following patterns {self.patterns} on package {self.package}")
+
+        with requests.Session() as s:
+            with s.get(f"{self.url}/pypi/{self.package}/json") as r:
+                try:
+                    r.raise_for_status()
+                except RequestException as e:
+                    logging.error(f"Unable to find package {repr(self.package)}", exc_info=e)
+                    return 1
+
+                releases_by_date = {}
+                for release, files in r.json()["releases"].items():
+                    releases_by_date[release] = max([datetime.datetime.strptime(f["upload_time"],
+                                                                                '%Y-%m-%dT%H:%M:%S') for f in files])
+
+            if not releases_by_date:
+                logging.info(f"No releases for package {self.package} have been found")
+                return
+
+            pkg_vers = list(filter(lambda k:
+                                   any(filter(lambda rex: rex.match(k),
+                                              self.patterns)) and releases_by_date[k] < self.date,
+                                   releases_by_date.keys()))
+
+            if not pkg_vers:
+                logging.info(f"No releases were found matching specified patterns and dates in package {self.package}")
+                return
+
+            if set(pkg_vers) == set(releases_by_date.keys()):
+                print(dedent(f"""
+                WARNING:
+                \tYou have selected the following patterns: {self.patterns}
+                \tThese patterns would delete all available released versions of `{self.package}`.
+                \tThis will render your project/package permanently inaccessible.
+                \tSince the costs of an error are too high I'm refusing to do this.
+                \tGoodbye.
+                """), file=sys.stderr)
+
+                if not self.do_it:
+                    return 3
+            for pkg in pkg_vers:
+                if 'dev' not in pkg:
+                    raise Exception(f"Would be deleting version {pkg} but the version is not a dev version")
+
+            if self.username is None:
+                raise Exception("No username provided")
+
+            if self.password is None:
+                raise Exception("No password provided")
+
+            with s.get(f"{self.url}/account/login/") as r:
+                r.raise_for_status()
+                form_action = "/account/login/"
+                parser = CsfrParser(form_action)
+                parser.feed(r.text)
+                if not parser.csrf:
+                    raise ValueError(f"No CSFR found in {form_action}")
+                csrf = parser.csrf
+
+            two_factor = False
+            with s.post(f"{self.url}/account/login/",
+                        data={"csrf_token": csrf,
+                              "username": self.username,
+                              "password": self.password},
+                        headers={"referer": f"{self.url}/account/login/"}) as r:
+                r.raise_for_status()
+                if r.url == f"{self.url}/account/login/":
+                    logging.error(f"Login for user {self.username} failed")
+                    return 1
+
+                if r.url.startswith(f"{self.url}/account/two-factor/"):
+                    form_action = r.url[len(self.url):]
+                    parser = CsfrParser(form_action)
+                    parser.feed(r.text)
+                    if not parser.csrf:
+                        raise ValueError(f"No CSFR found in {form_action}")
+                    csrf = parser.csrf
+                    two_factor = True
+                    two_factor_url = r.url
+
+            if two_factor:
+                auth_code = pyotp.TOTP(self.otp).now()
+                with s.post(two_factor_url, data={"csrf_token": csrf,
+                                                  "method": "totp",
+                                                  "totp_value": auth_code},
+                            headers={"referer": two_factor_url}) as r:
+                    r.raise_for_status()
+                    if r.url == two_factor_url:
+                        logging.error(f"Authentication code {auth_code} is invalid")
+                        return 1
+
+            for pkg_ver in pkg_vers:
+                if self.do_it:
+                    logging.info(f"Deleting {self.package} version {pkg_ver}")
+                    form_action = f"/manage/project/{self.package}/release/{pkg_ver}/"
+                    form_url = f"{self.url}{form_action}"
+                    with s.get(form_url) as r:
+                        r.raise_for_status()
+                        parser = CsfrParser(form_action, "confirm_delete_version")
+                        parser.feed(r.text)
+                        if not parser.csrf:
+                            raise ValueError(f"No CSFR found in {form_action}")
+                        csrf = parser.csrf
+                        referer = r.url
+
+                    with s.post(form_url,
+                                data={"csrf_token": csrf,
+                                      "confirm_delete_version": pkg_ver,
+                                      },
+                                headers={"referer": referer}) as r:
+                        r.raise_for_status()
+
+                    logging.info(f"Deleted {self.package} version {pkg_ver}")
+                else:
+                    logging.info(f"Would be deleting {self.package} version {pkg_ver}, but not doing it!")
+
+PypiCleanup(host, pypi_username, 'duckdb', pypi_password, pypi_otp, patterns, retain_days, actually_delete).run()


### PR DESCRIPTION
Follow-up from #8792

This PR adds the PyPI cleanup script that deletes development releases back in using 2FA support using the [pypi cleanup package](https://github.com/arcivanov/pypi-cleanup). The 2FA tokens are generated using `pyotp`.

As this could potentially be a safety issue if not done properly I have inlined the code from the `pypi-cleanup` package and have gone over it for sanity's sake, as well as added additional failsafes to ensure we are only deleting dev packages. 

I have tried the script locally and have verified that it works in deleting packages, also with 2FA enabled.