### PR TITLE
[Python] Fix issue related to `fetchone` and query containing multiple statements

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -895,6 +895,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
                                                                    unique_ptr<SQLStatement> statement,
                                                                    const PendingQueryParameters &parameters,
                                                                    bool verify) {
+	InitialCleanup(lock);
 	auto query = statement->query;
 	shared_ptr<PreparedStatementData> prepared;
 	if (verify) {
@@ -1061,8 +1062,6 @@ unordered_set<string> ClientContext::GetTableNames(const string &query) {
 unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContextLock &lock,
                                                                    const shared_ptr<Relation> &relation,
                                                                    bool allow_stream_result) {
-	InitialCleanup(lock);
-
 	string query;
 	if (config.query_verification_enabled) {
 		// run the ToString method of any relation we run, mostly to ensure it doesn't crash

--- a/tools/pythonpkg/tests/fast/api/test_8801.py
+++ b/tools/pythonpkg/tests/fast/api/test_8801.py
@@ -1,0 +1,43 @@
+import pytest
+import duckdb
+
+
+class Test8801(object):
+    def test_8801(self):
+        con = duckdb.connect()
+        con.sql(
+            """
+            create table t (
+                a int
+            )
+        """
+        )
+        rel = con.sql(
+            """
+            select * from (
+                VALUES
+                    (1),
+                    (2)
+                )
+        """
+        )
+        # Fetch the first tuple
+        res = rel.fetchone()
+        # Execute a query containing multiple statements
+        con.sql(
+            """
+            truncate t;
+            insert into t values (1)
+        """
+        )
+        # Fetch the new result
+        rel2 = con.sql(
+            """
+            select * from t
+        """
+        )
+        res = rel2.fetchall()
+        assert res == [(1,)]
+        other_res = rel.fetchall()
+        # Fetch the remainder of the first result
+        assert other_res == [(2,)]


### PR DESCRIPTION
This PR fixes #8801 

Separating the statements fixed the issue, because it uses `Connection::Prepared` instead of `Connection::PendingQuery`, which led me to finding the culprit, we don't clean up the existing transaction in the PendingQuery case.