### PR TITLE
Add "ends_with" as an alias of "suffix"

### DIFF
--- a/src/function/scalar/string/suffix.cpp
+++ b/src/function/scalar/string/suffix.cpp
@@ -41,7 +41,7 @@ ScalarFunction SuffixFun::GetFunction() {
 }
 
 void SuffixFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(GetFunction());
+	set.AddFunction({"suffix", "ends_with"}, GetFunction());
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Add a new `ends_with` function as an alias of `suffix` (for consistency with `starts_with`), as discussed in #8757.

Implemented similarly to the `lcase` / `lower` alias, per feedback from @Mause.

Docs will be updated in this PR: https://github.com/duckdb/duckdb-web/pull/1071