### PR TITLE
Throw conversion error when performing hash join that requires a cast even though the build side is empty

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -490,15 +490,15 @@ OperatorResultType PhysicalHashJoin::ExecuteInternal(ExecutionContext &context, 
 		return OperatorResultType::NEED_MORE_INPUT;
 	}
 
+	// resolve the join keys for the left chunk
+	state.join_keys.Reset();
+	state.probe_executor.Execute(input, state.join_keys);
+
 	// probe the HT
 	if (sink.hash_table->Count() == 0) {
 		ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, input, chunk);
 		return OperatorResultType::NEED_MORE_INPUT;
 	}
-
-	// resolve the join keys for the left chunk
-	state.join_keys.Reset();
-	state.probe_executor.Execute(input, state.join_keys);
 
 	// perform the actual probe
 	if (sink.external) {

--- a/test/issues/rigger/test_not_distinct_from.test
+++ b/test/issues/rigger/test_not_distinct_from.test
@@ -1,0 +1,20 @@
+# name: test/issues/rigger/test_not_distinct_from.test
+# description: Test = and not distinct from
+# group: [rigger]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table foo as select * from values (4, null), (5, null) t(a, b);
+
+statement ok
+create table bar as select * from values (4, 'hi'), (6, null) t(c, d);
+
+statement ok
+select * from bar left join foo on bar.d = foo.b;
+
+statement ok
+select * from bar left join foo on bar.d is not distinct from foo.b;
+
+

--- a/test/issues/rigger/test_not_distinct_from.test
+++ b/test/issues/rigger/test_not_distinct_from.test
@@ -11,10 +11,25 @@ create table foo as select * from values (4, null), (5, null) t(a, b);
 statement ok
 create table bar as select * from values (4, 'hi'), (6, null) t(c, d);
 
-statement ok
+statement error
 select * from bar left join foo on bar.d = foo.b;
+----
+Conversion Error
+
+statement error
+select * from bar left join foo on bar.d is not distinct from foo.b;
+----
+Conversion Error
 
 statement ok
+insert into foo values (4, 6);
+
+statement error
+select * from bar left join foo on bar.d = foo.b;
+----
+Conversion Error
+
+statement error
 select * from bar left join foo on bar.d is not distinct from foo.b;
-
-
+----
+Conversion Error


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb/issues/8753

The reason we don't error on equality is because the build side of the hash was empty. With an empty build side we just propagate all the values from the left join without performing the cast. To fix this (and throw a conversion error with both '=' and 'IS NOT DISTINCT FROM') I moved the cast functionality above the check if the build side is empty.
