### PR TITLE
DuckDB-Wasm fixes related to (auto)loadable extensions

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -139,6 +139,9 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	case LogicalTypeId::DATE:
 		child.format = "tdD";
 		break;
+#ifdef DUCKDB_WASM
+	case LogicalTypeId::TIME_TZ:
+#endif
 	case LogicalTypeId::TIME:
 		child.format = "ttu";
 		break;

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -204,14 +204,13 @@ vector<TestType> TestAllTypesFun::GetTestTypes(bool use_large_enum) {
 	auto max_map_value = Value::MAP(ListType::GetChildType(map_type), map_values);
 	result.emplace_back(map_type, "map", std::move(min_map_value), std::move(max_map_value));
 
-#ifndef DUCKDB_WASM
 	// union
 	child_list_t<LogicalType> members = {{"name", LogicalType::VARCHAR}, {"age", LogicalType::SMALLINT}};
 	auto union_type = LogicalType::UNION(members);
 	const Value &min = Value::UNION(members, 0, Value("Frank"));
 	const Value &max = Value::UNION(members, 1, Value::SMALLINT(5));
 	result.emplace_back(union_type, "union", min, max);
-#endif
+
 	return result;
 }
 

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -204,13 +204,14 @@ vector<TestType> TestAllTypesFun::GetTestTypes(bool use_large_enum) {
 	auto max_map_value = Value::MAP(ListType::GetChildType(map_type), map_values);
 	result.emplace_back(map_type, "map", std::move(min_map_value), std::move(max_map_value));
 
+#ifndef DUCKDB_WASM
 	// union
 	child_list_t<LogicalType> members = {{"name", LogicalType::VARCHAR}, {"age", LogicalType::SMALLINT}};
 	auto union_type = LogicalType::UNION(members);
 	const Value &min = Value::UNION(members, 0, Value("Frank"));
 	const Value &max = Value::UNION(members, 1, Value::SMALLINT(5));
 	result.emplace_back(union_type, "union", min, max);
-
+#endif
 	return result;
 }
 

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -183,10 +183,12 @@ string ExtensionHelper::AddExtensionInstallHintToErrorMsg(ClientContext &context
 void ExtensionHelper::AutoLoadExtension(ClientContext &context, const string &extension_name) {
 	auto &dbconfig = DBConfig::GetConfig(context);
 	try {
+#ifndef DUCKDB_WASM
 		if (dbconfig.options.autoinstall_known_extensions) {
 			ExtensionHelper::InstallExtension(context, extension_name, false,
 			                                  context.config.autoinstall_extension_repo);
 		}
+#endif
 		ExtensionHelper::LoadExternalExtension(context, extension_name);
 	} catch (Exception &e) {
 		throw AutoloadException(extension_name, e);

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -45,7 +45,7 @@ const vector<string> ExtensionHelper::PathComponents() {
 
 string ExtensionHelper::ExtensionDirectory(DBConfig &config, FileSystem &fs) {
 #ifdef WASM_LOADABLE_EXTENSIONS
-	static_assert(0, "ExtensionDirectory functionality is not supported in duckdb-wasm");
+	throw PermissionException("ExtensionDirectory functionality is not supported in duckdb-wasm");
 #endif
 	string extension_directory;
 	if (!config.options.extension_directory.empty()) { // create the extension directory if not present

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -159,9 +159,11 @@ void WriteExtensionFileToDisk(FileSystem &fs, const string &path, void *data, id
 
 string ExtensionHelper::ExtensionUrlTemplate(optional_ptr<const ClientConfig> client_config, const string &repository) {
 	string default_endpoint = "http://extensions.duckdb.org";
-	string versioned_path = "/${REVISION}/${PLATFORM}/${NAME}.duckdb_extension.gz";
+	string versioned_path = "/${REVISION}/${PLATFORM}/${NAME}.duckdb_extension";
 #ifdef WASM_LOADABLE_EXTENSIONS
-	versioned_path = "/duckdb-wasm" + versioned_path;
+	versioned_path = "/duckdb-wasm" + versioned_path + ".wasm";
+#else
+	versioned_path = versioned_path + ".gz";
 #endif
 	string custom_endpoint = client_config ? client_config->custom_extension_repo : string();
 	string endpoint;

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -70,6 +70,7 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 
 	// shorthand case
 	if (!ExtensionHelper::IsFullPath(extension)) {
+		string extension_name = ApplyExtensionAlias(extension);
 #ifdef WASM_LOADABLE_EXTENSIONS
 		string url_template = ExtensionUrlTemplate(client_config, "");
 		string url = ExtensionFinalizeUrlTemplate(url_template, extension_name);
@@ -105,7 +106,6 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 		for (auto &path_ele : path_components) {
 			local_path = fs.JoinPath(local_path, path_ele);
 		}
-		string extension_name = ApplyExtensionAlias(extension);
 		filename = fs.JoinPath(local_path, extension_name + ".duckdb_extension");
 #endif
 	}

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -77,8 +77,8 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 
 		char *str = (char *)EM_ASM_PTR(
 		    {
-			    var jsString = ((typeof runtime == = 'object') && runtime &&
-			                    (typeof runtime.whereToLoad == = 'function') && runtime.whereToLoad)
+			    var jsString = ((typeof runtime == 'object') && runtime && (typeof runtime.whereToLoad == 'function') &&
+			                    runtime.whereToLoad)
 			                       ? runtime.whereToLoad(UTF8ToString($0))
 			                       : (UTF8ToString($1));
 			    var lengthBytes = lengthBytesUTF8(jsString) + 1;


### PR DESCRIPTION
None of those changes should be introduce any functional change when DUCKDB_WASM is not defined.

Missing is a review of error messages around (auto)loading, since it's misleading to instruct users to perform `INSTALL`. Will do that in a separate & independent PR.