### PR TITLE
Issue template: Ask contributors to avoid using screenshots in issue reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,20 +34,20 @@ body:
   - type: input
     attributes:
       label: "OS:"
-      placeholder: e.g. iOS
-      description: Please include operating system version and architecture (eg, aarch64, x86, x64, etc)
+      placeholder: e.g., iOS
+      description: Please include operating system version and architecture (e.g., aarch64, x86, x64, etc)
     validations:
       required: true
   - type: input
     attributes:
       label: "DuckDB Version:"
-      placeholder: e.g. 22
+      placeholder: e.g., 22
     validations:
       required: true
   - type: input
     attributes:
       label: "DuckDB Client:"
-      placeholder: e.g. Python
+      placeholder: e.g., Python
     validations:
       required: true
 
@@ -57,13 +57,13 @@ body:
   - type: input
     attributes:
       label: "Full Name:"
-      placeholder: e.g. John Doe
+      placeholder: e.g., John Doe
     validations:
       required: true
   - type: input
     attributes:
       label: "Affiliation:"
-      placeholder: e.g. Oracle
+      placeholder: e.g., Oracle
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,7 @@ body:
   - type: textarea
     attributes:
       label: To Reproduce
-      description: Steps to reproduce the behavior. Bonus points if those are only SQL queries.
+      description: Steps to reproduce the behavior. Please paste the code and the output as text, and avoid using screenshots. Bonus points if the steps only include SQL queries.
     validations:
       required: true
 


### PR DESCRIPTION
Issues where the code is captured as a screenshot are more difficult to reproduce than they should be. We should emphasize that we do not want to allow this.