### PR TITLE
Placeholder extension

### DIFF
--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -9,6 +9,7 @@
 
 # Parquet is loaded by default on every build as its a essential part of DuckDB
 duckdb_extension_load(parquet)
+duckdb_extension_load(placeholder DONT_LINK)
 
 # Jemalloc is enabled by default for linux. MacOS malloc is already good enough and Jemalloc on windows has issues.
 if(NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND OS_NAME STREQUAL "linux" AND NOT ANDROID AND NOT ZOS)

--- a/extension/placeholder/CMakeLists.txt
+++ b/extension/placeholder/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(PlaceholderExtension)
+
+set(PLACEHOLDER_EXTENSION_FILES placeholder_extension.cpp)
+
+build_static_extension(placeholder ${PLACEHOLDER_EXTENSION_FILES})
+set(PARAMETERS "-warnings")
+build_loadable_extension(placeholder ${PARAMETERS}
+                         ${PLACEHOLDER_EXTENSION_FILES})
+
+install(
+  TARGETS placeholder_extension
+  EXPORT "${DUCKDB_EXPORT_SET}"
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")

--- a/extension/placeholder/placeholder_extension.cpp
+++ b/extension/placeholder/placeholder_extension.cpp
@@ -1,0 +1,14 @@
+#define DUCKDB_EXTENSION_MAIN
+
+#include "duckdb/main/extension_util.hpp"
+
+extern "C" {
+
+DUCKDB_EXTENSION_API const char *error_message() { // NOLINT
+	return "This is a placeholder DuckDB extension";
+}
+}
+
+#ifndef DUCKDB_EXTENSION_MAIN
+#error DUCKDB_EXTENSION_MAIN not defined
+#endif

--- a/tools/nodejs/test/extension.test.ts
+++ b/tools/nodejs/test/extension.test.ts
@@ -105,6 +105,9 @@ describe('Extension loading', function() {
         if (extension_name.startsWith('parquet')) { // Parquet is built-in in the Node client, so skip
             continue;
         }
+        if (extension_name.startsWith('placeholder')) { // Placeholder is expected to fail, so skip
+            continue;
+        }
 
         it(extension_name, async function () {
             await new Promise<void>((resolve, reject) => db.run(`LOAD '${extension_path}';`, function (err: null | Error) {


### PR DESCRIPTION
This is a byproduct of duckdb-wasm extension (auto)loading. Given there not all extension will be supported (say aws), I though it would be handy to provide a mechanism to inform users that a given extension is not available on purpose.

This allows to keep the autoloading logic and behaviour the same across platforms, where in each case an extension will be potentially installed and loaded, and load will fail with a relevant error message.

User side say you do:
```
D INSTALL placeholder;   // This succeeds
D LOAD placeholder;
`Error: Invalid Input Error: Extension "path/to/arrow.duckdb_extension" exposes an error_message function
    Self-reported error message: "This is a placeholder DuckDB extension"
```

Error message can be customised and extension rebuild to be more informative.
The same placeholder extension can be served with multiple names, so that they all will eventually see the same file.

While arguable throwing on INSTALL would be arguably more helpful, and can be implemented in the future, in general extensions checks are only performed on actual LOAD, and only after signature checks is performed (in the signed case).

Presence of error_message (and if so failing) is before the checks on versions and do not depend on development name of the extension.

This PR do not take any action on actually deploying these placeholders extensions, and that can be done at a later stage, but only sets up a mechanism that can be used to do so.

Looking forward for feedback if this sort of mechanism could be helpful to put in place.

A MacOS reference placeholder extension containing the message "This is a placeholder DuckDB extension", once gzipped weights 780 bytes + about 256 information bytes for the signature amounts to around 1KB.