### PR TITLE
[Generated Column] Return stringified generated expression in `duckdb_columns`

### DIFF
--- a/src/function/table/system/duckdb_columns.cpp
+++ b/src/function/table/system/duckdb_columns.cpp
@@ -131,7 +131,9 @@ public:
 	}
 	const Value ColumnDefault(idx_t col) override {
 		auto &column = entry.GetColumn(LogicalIndex(col));
-		if (column.DefaultValue()) {
+		if (column.Generated()) {
+			return Value(column.GeneratedExpression().ToString());
+		} else if (column.DefaultValue()) {
 			return Value(column.DefaultValue()->ToString());
 		}
 		return Value();

--- a/test/sql/generated_columns/virtual/gcol_duckdb_columns.test
+++ b/test/sql/generated_columns/virtual/gcol_duckdb_columns.test
@@ -1,0 +1,13 @@
+# name: test/sql/generated_columns/virtual/gcol_duckdb_columns.test
+# group: [virtual]
+
+# Create a table containing a generated column
+statement ok
+create table t (i int, j int as (1));
+
+# duckdb_columns should return the stringified generated column expression as 'column_default'
+query I
+select column_default from duckdb_columns;
+----
+NULL
+CAST(1 AS INTEGER)


### PR DESCRIPTION
This PR fixes #8833 

DefaultValue should not be called on a generated column, this was done unchecked.
Instead of throwing an internal exception we now return the generated column expression in the `column_default` column.