### PR TITLE
Extension API: Allow autoloading of extensions dependencies & use it for duckdb_aws

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -19,6 +19,7 @@ duckdb_extension_load(aws
         LOAD_TESTS
         GIT_URL https://github.com/duckdblabs/duckdb_aws
         GIT_TAG a1f65419dfbc23e8099fbdd1a8a13bfda425165d
+	APPLY_PATCHES
         )
 
 ################# AZURE

--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -1,4 +1,4 @@
-catalog/catalog.cpp	29
+catalog/catalog.cpp	39
 catalog/catalog_entry.cpp	11
 catalog/catalog_entry/duck_schema_entry.cpp	4
 catalog/catalog_entry/duck_table_entry.cpp	7

--- a/.github/patches/extensions/aws/autoload_httpfs.patch
+++ b/.github/patches/extensions/aws/autoload_httpfs.patch
@@ -1,0 +1,21 @@
+diff --git a/src/aws_extension.cpp b/src/aws_extension.cpp
+index e1467a2..6f78fca 100644
+--- a/src/aws_extension.cpp
++++ b/src/aws_extension.cpp
+@@ -3,6 +3,7 @@
+ #include "aws_extension.hpp"
+ #include "duckdb.hpp"
+ #include "duckdb/common/exception.hpp"
++#include "duckdb/catalog/catalog.hpp"
+ #include "duckdb/main/extension_util.hpp"
+ #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
+ #include <aws/core/Aws.h>
+@@ -104,7 +105,7 @@ static void LoadAWSCredentialsFun(ClientContext &context, TableFunctionInput &da
+ 		return;
+ 	}
+ 
+-	if (!context.db->ExtensionIsLoaded("httpfs")) {
++	if (!Catalog::TryAutoLoad(context, "httpfs")) {
+ 		throw MissingExtensionException("httpfs extension is required for load_aws_credentials");
+ 	}
+ 

--- a/.github/patches/extensions/aws/require_no_autoload.patch
+++ b/.github/patches/extensions/aws/require_no_autoload.patch
@@ -1,0 +1,20 @@
+diff --git a/test/sql/aws_errors.test b/test/sql/aws_errors.test
+index a4ca207..84d86ce 100644
+--- a/test/sql/aws_errors.test
++++ b/test/sql/aws_errors.test
+@@ -2,6 +2,8 @@
+ # description: test aws extension
+ # group: [aws]
+ 
++require no_extension_autoloading
++
+ # Before we load the extension, this will fail
+ statement error
+ CALL load_aws_credentials();
+@@ -20,4 +22,4 @@ httpfs extension is required for load_aws_credentials
+ require httpfs
+ 
+ statement ok
+-CALL load_aws_credentials();
+\ No newline at end of file
++CALL load_aws_credentials();

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -305,6 +305,7 @@ public:
 	static void AutoloadExtensionByConfigName(ClientContext &context, const string &configuration_name);
 	//! Autoload the extension required for `function_name` or throw a CatalogException
 	static bool AutoLoadExtensionByCatalogEntry(ClientContext &context, CatalogType type, const string &entry_name);
+	DUCKDB_API static bool TryAutoLoad(ClientContext &context, const string &extension_name) noexcept;
 
 protected:
 	//! Reference to the database

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -234,6 +234,7 @@ static constexpr ExtensionEntry EXTENSION_FILE_CONTAINS[] = {{".parquet?", "parq
 
 static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     //    "azure",
+    "aws",
     "autocomplete",
     "excel",
     "fts",

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -51,6 +51,7 @@ public:
 
 	//! Autoload an extension by name. Depending on the current settings, this will either load or install+load
 	static void AutoLoadExtension(ClientContext &context, const string &extension_name);
+	DUCKDB_API static bool TryAutoLoadExtension(ClientContext &context, const string &extension_name) noexcept;
 
 	static string ExtensionDirectory(ClientContext &context);
 	static string ExtensionDirectory(DBConfig &config, FileSystem &fs);

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -194,6 +194,21 @@ string ExtensionHelper::AddExtensionInstallHintToErrorMsg(ClientContext &context
 	return base_error;
 }
 
+bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string &extension_name) noexcept {
+	auto &dbconfig = DBConfig::GetConfig(context);
+	try {
+		if (dbconfig.options.autoinstall_known_extensions) {
+			ExtensionHelper::InstallExtension(context, extension_name, false,
+			                                  context.config.autoinstall_extension_repo);
+		}
+		ExtensionHelper::LoadExternalExtension(context, extension_name);
+		return true;
+	} catch (...) {
+		return false;
+	}
+	return false;
+}
+
 void ExtensionHelper::AutoLoadExtension(ClientContext &context, const string &extension_name) {
 	auto &dbconfig = DBConfig::GetConfig(context);
 	try {


### PR DESCRIPTION
This improves extensions API adding a method that tries to autoinstall and autoload a given extension, returning a boolean success | failure.

Basic implementation (say loading is disabled) is `return ExtensionIsLoaded()`, while in the most permissive situation both autoinstall and then autoloading are used (if enabled).

---

First usage / testbed is duckdblabs/duckdb_aws, that has a runtime dependency on httpfs.