### PR TITLE
Add R CMD Check workflow back for duckdb src PRs

### DIFF
--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -24,8 +24,6 @@ jobs:
       fail-fast: true
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
 
     env:

--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -1,0 +1,76 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+name: R-CMD-check
+
+env:
+  DUCKDB_R_REPO: 'duckdb/duckdb-r'
+  TARGET_REF: 'main'
+  DUCKDB_R_SRC: 'duckdb-r'
+  DUCKDB_SRC: 'duckdb'
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: true
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ env.DUCKDB_SRC }}
+
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ env.DUCKDB_R_REPO }}
+          path: ${{ env.DUCKDB_R_SRC }}
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: ${{ env.DUCKDB_R_SRC }}
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      # needed so we can run git commit in vendor.sh
+      - name: setup github
+        shell: bash
+        run: |
+          git config --global user.email "duck@duck.com"
+          git config --global user.name "mr. duck"
+
+      # error is from git_dev_version() but does not affect this workflow
+      - name: update duckdb-r src code with PR code
+        shell: bash
+        working-directory: ${{ env.DUCKDB_R_SRC }}
+        run: ./vendor.sh
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          # Fails on R 3.6 on Windows, remove when this job is removed?
+          args: 'c("--no-tests", "--no-manual", "--as-cran", "--no-multiarch")'
+          working-directory: ${{ env.DUCKDB_R_SRC }}

--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -57,11 +57,13 @@ jobs:
           needs: check
 
       # needed so we can run git commit in vendor.sh
-      - name: setup github
+      - name: setup github and create parallel builds
         shell: bash
         run: |
           git config --global user.email "duck@duck.com"
           git config --global user.name "mr. duck"
+          mkdir -p ~/.R
+          echo 'MAKEFLAGS = -j2' >> ~/.R/Makevars
 
       # error is from git_dev_version() but does not affect this workflow
       - name: update duckdb-r src code with PR code


### PR DESCRIPTION
The duckdb R package is no longer in the duckdb source. We still want to check with every PR that the duckdb R package can built with no errors. This PR will fix that by running the [r-cmd-check](https://github.com/r-lib/actions/tree/v2-branch/check-r-package) on duckdb PRs. Tests are not run, only building the R package is checked

the workflow is as follows
1. checkout duckdb pull request branch
2. checkout duckdb-r source
3. Setup R
4. Install duckdb package dependencies
5. update the duckdb-r source with the source from the pull request branch (using the ./vendor.sh script)
6. Run `R CMD build .` and `R CMD check .`
7. sanity check that the library can be imported.