### PR TITLE
Attempt at fixing OSX Extensions Release nightly build failures

### DIFF
--- a/scripts/extension-upload-test.sh
+++ b/scripts/extension-upload-test.sh
@@ -40,6 +40,8 @@ if [ ! -f "${duckdb_path}" ]; then
   unittest_path="testext/test/${CMAKE_CONFIG}/unittest.exe"
 fi
 
+${duckdb_path} -c "FROM duckdb_extensions()"
+
 for f in $FILES
 do
 	ext=`basename $f .duckdb_extension`
@@ -51,7 +53,7 @@ do
 		unsigned_flag=-unsigned
 	fi
 	echo ${install_path}
-	${duckdb_path} ${unsigned_flag} -c "INSTALL '${install_path}'"
+	${duckdb_path} ${unsigned_flag} -c "FORCE INSTALL '${install_path}'"
 	${duckdb_path} ${unsigned_flag} -c "LOAD '${ext}'"
 done
 

--- a/test/sql/parallelism/intraquery/test_parallel_nested_aggregates.test
+++ b/test/sql/parallelism/intraquery/test_parallel_nested_aggregates.test
@@ -24,7 +24,7 @@ create table t as select range a, range%10 b from range(100000);
 statement ok
 select first([a]) from t group by b%2;
 
-query II
+query II rowsort
 select min([a]), max([a]) from t group by b%2;
 ----
 [0]	[99998]


### PR DESCRIPTION
Failure is in the 'Test loadable extensions' step.
Problem seems to be there only on main, so attempting to get some more information out of it.

Not exactly best practice, but this commit should not have any consequence and should enable some logging.