### PR TITLE
Extension selection: review of which extensions are packaged

### DIFF
--- a/.github/config/bundled_extensions.cmake
+++ b/.github/config/bundled_extensions.cmake
@@ -14,18 +14,19 @@
 #
 ## Extensions that are linked
 #
+duckdb_extension_load(autocomplete)
+duckdb_extension_load(parquet)
+duckdb_extension_load(json)
+
 duckdb_extension_load(icu)
 duckdb_extension_load(inet)
-duckdb_extension_load(tpch)
-duckdb_extension_load(json)
-duckdb_extension_load(fts)
-duckdb_extension_load(parquet)
-duckdb_extension_load(excel)
-duckdb_extension_load(autocomplete)
 
 #
 ## Extensions that are not linked, but we do want to test them as part of the release build
 #
+duckdb_extension_load(excel DONT_LINK)
+duckdb_extension_load(fts DONT_LINK)
 duckdb_extension_load(sqlsmith DONT_LINK)
 duckdb_extension_load(tpcds DONT_LINK)
+duckdb_extension_load(tpch DONT_LINK)
 duckdb_extension_load(visualizer DONT_LINK)

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -9,6 +9,8 @@
 
 # Parquet is loaded by default on every build as its a essential part of DuckDB
 duckdb_extension_load(parquet)
+duckdb_extension_load(json)
+duckdb_extension_load(autocomplete)
 
 # Jemalloc is enabled by default for linux. MacOS malloc is already good enough and Jemalloc on windows has issues.
 if(NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND OS_NAME STREQUAL "linux" AND NOT ANDROID AND NOT ZOS)


### PR DESCRIPTION
Always bundled:
parquet
json
autocomplete

Packaged with CLI (but clients might skip them):
icu
inet
(main blocker to move them to following category is enabling autoloading)

Autoloadable on demand & tested with releases:
excel
fts
sqlsmith
tpcds
tpch
visualizer

This leverages (and stress test) autoloading to keep distributions slim. Main loser are situation where INSTALL & LOAD are not viable somehow BUT users still need niche utility like ICU.

---

Assumption is that this should not change anything for regular users, but uniforms between clients AND allows to stress tests autoloading (in particular) and extensions mechanism in general.
Also there are some small but noticeable improvement in size of the main delivered bundle (I think about 5% by removing excel & tpch & fts).

Main issue that this might expose are situations connected to MacOS cross extension boundaries exceptions, but given only extension that currently change category are excel / tpch and fts we can probably live with that (and eventually properly solve it).