### PR TITLE
Issue: #8867 Fix: remove unused variables for logical_root.

### DIFF
--- a/src/include/duckdb/optimizer/rule.hpp
+++ b/src/include/duckdb/optimizer/rule.hpp
@@ -23,8 +23,6 @@ public:
 
 	//! The expression rewriter this rule belongs to
 	ExpressionRewriter &rewriter;
-	//! The root
-	unique_ptr<LogicalOperatorMatcher> logical_root;
 	//! The expression matcher of the rule
 	unique_ptr<ExpressionMatcher> root;
 

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -59,15 +59,7 @@ void ExpressionRewriter::VisitOperator(LogicalOperator &op) {
 
 	to_apply_rules.clear();
 	for (auto &rule : rules) {
-		if (rule->logical_root && !rule->logical_root->Match(op.type)) {
-			// this rule does not apply to this type of LogicalOperator
-			continue;
-		}
 		to_apply_rules.push_back(*rule);
-	}
-	if (to_apply_rules.empty()) {
-		// no rules to apply on this node
-		return;
 	}
 
 	VisitOperatorExpressions(op);


### PR DESCRIPTION
Now I see that all the rules do not set logical_root, that is to say, this variable is not used at present, it is only used in ExpressionRewriter::VisitOperator, the conditions here must be satisfied, we can directly clear this dirty code.