### PR TITLE
Expose SeekPosition in HTTPFS

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -489,6 +489,11 @@ void HTTPFileSystem::Seek(FileHandle &handle, idx_t location) {
 	sfh.file_offset = location;
 }
 
+idx_t HTTPFileSystem::SeekPosition(FileHandle &handle) {
+	auto &sfh = (HTTPFileHandle &)handle;
+	return sfh.file_offset;
+}
+
 // Get either the local, global, or no cache depending on settings
 static optional_ptr<HTTPMetadataCache> TryGetMetadataCache(FileOpener *opener, HTTPFileSystem &httpfs) {
 	auto client_context = FileOpener::TryGetClientContext(opener);

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -125,6 +125,7 @@ public:
 	time_t GetLastModifiedTime(FileHandle &handle) override;
 	bool FileExists(const string &filename) override;
 	void Seek(FileHandle &handle, idx_t location) override;
+	idx_t SeekPosition(FileHandle &handle) override;
 	bool CanHandleFile(const string &fpath) override;
 	bool CanSeek() override {
 		return true;


### PR DESCRIPTION
This not being implemented seems like an oversight. By implementing this we can plug in HTTPFS as a file-system backend for Spatial's GDAL integration to enable querying of files remotely directly from `st_read` and even on e.g. WASM. 