### PR TITLE
Wasm extension signing

### DIFF
--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -3,20 +3,8 @@
 #   - runs the tests using `make test` in the extension repository
 #   - (optionally) deploys the binaries to S3
 
-name: Build and sign duckdb-wasm extensions
+name: DuckDB-Wasm extensions
 on:
-  repository_dispatch:
-    inputs:
-      # Git ref of the duckdb-wasm repo
-      duckdb-wasm-ref:
-        required: false
-        type: string
-        default: main
-      # Publish extensions on extensions.duckdb.org?
-      release_s3:
-        required: false
-        type: boolean
-        default: true
   workflow_dispatch:
     inputs:
       # Git ref of the duckdb-wasm repo
@@ -24,11 +12,15 @@ on:
         required: false
         type: string
         default: main
+      # Git ref of the duckdb repo
+      duckdb-ref:
+        required: true
+        type: string
       # Publish extensions on extensions.duckdb.org?
       release_s3:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   build_and_publish:
@@ -40,12 +32,13 @@ jobs:
     env:
       GEN: Ninja
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      DUCKDB_PLATFORM: "wasm_${{ github.event.inputs.duckdb_wasm_arch }}"
 
     steps:
             - uses: actions/checkout@v3
               with:
                   submodules: 'recursive'
-                  repository: 'carlopi/duckdb-wasm'
+                  repository: 'duckdb/duckdb-wasm'
                   ref: ${{ github.event.inputs.duckdb-wasm-ref }}
                   fetch-depth: 0
 
@@ -76,6 +69,11 @@ jobs:
                   cp .github/config/extension_config_wasm.cmake submodules/duckdb/extension/extension_config.cmake
                   DUCKDB_WASM_LOADABLE_EXTENSIONS="signed" GEN=ninja ./scripts/wasm_build_lib.sh relsize ${{ matrix.duckdb_wasm_arch }}
                   bash ./scripts/build_loadable.sh relsize ${{ matrix.duckdb_wasm_arch }}
+
+            - name: Sign and deploy Wasm extensions
+              if: ${{ github.event.inputs.release_s3 }}
+              run: |
+                  bash ./scripts/extension-upload-wasm.sh ${{ env.DUCKDB_PLATFORM }} ${{ github.event.inputs.duckdb-ref }}
 
             - name: Upload artifact
               uses: actions/upload-artifact@v3

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -1,0 +1,85 @@
+# This is a reusable workflow to be used by extensions for CI. It:
+#   - builds the extension using the CI workflow from the corresponding DuckDB version
+#   - runs the tests using `make test` in the extension repository
+#   - (optionally) deploys the binaries to S3
+
+name: Build and sign duckdb-wasm extensions
+on:
+  repository_dispatch:
+    inputs:
+      # Git ref of the duckdb-wasm repo
+      duckdb-wasm-ref:
+        required: false
+        type: string
+        default: main
+      # Publish extensions on extensions.duckdb.org?
+      release_s3:
+        required: false
+        type: boolean
+        default: true
+  workflow_dispatch:
+    inputs:
+      # Git ref of the duckdb-wasm repo
+      duckdb-wasm-ref:
+        required: false
+        type: string
+        default: main
+      # Publish extensions on extensions.duckdb.org?
+      release_s3:
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  build_and_publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        duckdb_wasm_arch: [ 'mvp', 'eh' ]
+    env:
+      GEN: Ninja
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+    steps:
+            - uses: actions/checkout@v3
+              with:
+                  submodules: 'recursive'
+                  repository: 'carlopi/duckdb-wasm'
+                  ref: ${{ github.event.inputs.duckdb-wasm-ref }}
+                  fetch-depth: 0
+
+            - name: Prepare repository
+              run: |
+                  [ -f duckdb.patch ] && cd submodules/duckdb && git apply ../../duckdb.patch || echo "No patching needed"
+
+            - uses: mymindstorm/setup-emsdk@v12
+              with:
+                  version: 'latest'
+            - name: Setup vcpkg
+              uses: lukka/run-vcpkg@v11
+              with:
+                  vcpkgGitCommitId: 501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
+
+            - name: Setup Ccache
+              uses: hendrikmuhs/ccache-action@main
+              with:
+                  key: ${{ github.job }}
+
+            - name: Git submodule status
+              run: |
+                  brotli --version
+                  git submodule status > git_submodule_status.txt
+
+            - name: Build Wasm module
+              run: |
+                  cp .github/config/extension_config_wasm.cmake submodules/duckdb/extension/extension_config.cmake
+                  DUCKDB_WASM_LOADABLE_EXTENSIONS="signed" GEN=ninja ./scripts/wasm_build_lib.sh relsize ${{ matrix.duckdb_wasm_arch }}
+                  bash ./scripts/build_loadable.sh relsize ${{ matrix.duckdb_wasm_arch }}
+
+            - name: Upload artifact
+              uses: actions/upload-artifact@v3
+              with:
+                  name: duckdb-wasm-${{ matrix.duckdb_wasm_arch }}
+                  path: loadable_extensions/
+                  retention-days: 1

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -81,3 +81,11 @@ jobs:
                   name: duckdb-wasm-${{ matrix.duckdb_wasm_arch }}
                   path: loadable_extensions/
                   retention-days: 1
+
+  trigger_github_pages_build:
+    name: Trigger follow-up work
+    runs-on: ubuntu-latest
+    steps:
+            - name: Move control to duckdb-wasm
+              run: |
+                  curl -XPOST -u "${{secrets.PAT_USER}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/duckdb/duckdb-wasm/actions/workflows/main.yml/dispatches --data '{"ref":"${{ github.event.inputs.duckdb-wasm-ref"}'

--- a/scripts/extension-upload-wasm.sh
+++ b/scripts/extension-upload-wasm.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Usage: ./extension-upload-wasm.sh <architecture> <commithash or version_tag>
+
+set -e
+
+#echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
+
+FILES="loadable_extensions/*.duckdb_extension.wasm"
+for f in $FILES
+do
+        ext=`basename $f .duckdb_extension.wasm`
+        echo $ext
+        # calculate SHA256 hash of extension binary
+        cat $f > $f.append
+        # 0 for custom section
+        # 113 in hex = 275 in decimal, total lenght of what follows (1 + 16 + 2 + 256)
+        # [1(continuation) + 0010011(payload) = \x93, 0(continuation) + 10(payload) = \x02]
+        echo -n -e '\x00' >> $f.append
+        echo -n -e '\x93\x02' >> $f.append
+        # 10 in hex = 16 in decimal, lenght of name, 1 byte
+        echo -n -e '\x10' >> $f.append
+        echo -n -e 'duckdb_signature' >> $f.append
+        # the name of the WebAssembly custom section, 16 bytes
+        # 100 in hex, 256 in decimal
+        # [1(continuation) + 0000000(payload) = ff, 0(continuation) + 10(payload)],
+        # for a grand total of 2 bytes
+        echo -n -e '\x80\x02' >> $f.append
+        # the actual payload, 256 bytes, to be added later
+        openssl dgst -binary -sha256 $f.append > $f.hash
+        # encrypt hash with extension signing private key to create signature
+        openssl pkeyutl -sign -in $f.hash -inkey private.pem -pkeyopt digest:sha256 -out $f.sign
+        # append signature to extension binary
+        cat $f.sign >> $f.append
+        # compress extension binary
+        brotli < $f.append > "$f.brotli"
+        # upload compressed extension binary to S3
+        aws s3 cp $f.brotli s3://duckdb-extensions/duckdb-wasm/$2/$1/$ext.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+done
+
+rm private.pem
+

--- a/scripts/extension-upload-wasm.sh
+++ b/scripts/extension-upload-wasm.sh
@@ -35,7 +35,7 @@ do
         # compress extension binary
         brotli < $f.append > "$f.brotli"
         # upload compressed extension binary to S3
-        aws s3 cp $f.brotli s3://duckdb-extensions/duckdb-wasm/$2/$1/$ext.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+        aws s3 cp $f.brotli s3://test-duckdb-wasm-extensions/duckdb-wasm/$2/$1/$ext.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
 done
 
 rm private.pem


### PR DESCRIPTION
Script and workflows to generate, sign and deploy duckdb-wasm loadable extensions.

There are quite some details that might be off and will potentially discovered only on running this inside Github Actions.

This for now will deploy to a test S3 bucket.