### PR TITLE
Fix #8895: Reading .csv.zst files depends on parquet extension (check…

### DIFF
--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -1135,6 +1135,9 @@ unique_ptr<TableRef> ReadCSVReplacement(ClientContext &context, const string &ta
 	if (StringUtil::EndsWith(lower_name, ".gz")) {
 		lower_name = lower_name.substr(0, lower_name.size() - 3);
 	} else if (StringUtil::EndsWith(lower_name, ".zst")) {
+		if (!Catalog::TryAutoLoad(context, "parquet")) {
+			throw MissingExtensionException("parquet extension is required for reading zst compressed file");
+		}
 		lower_name = lower_name.substr(0, lower_name.size() - 4);
 	}
 	if (!StringUtil::EndsWith(lower_name, ".csv") && !StringUtil::Contains(lower_name, ".csv?") &&


### PR DESCRIPTION
…, TryAutoLoad or fail)

Behaviour is unchanged in all cases where parquet is already (statically or dinamycally) loaded. If parquet is not already loaded, and autoloading is enabled, it will be tried to be autoloaded, otherwise error will be thrown.

Fixes #8895.