### PR TITLE
Detect Header columns with nullpadding

### DIFF
--- a/data/csv/locations_header_trailing_comma.csv
+++ b/data/csv/locations_header_trailing_comma.csv
@@ -1,0 +1,2 @@
+id,name,lat,lon,
+1,name,0,0

--- a/data/csv/locations_row_trailing_comma.csv
+++ b/data/csv/locations_row_trailing_comma.csv
@@ -1,0 +1,2 @@
+id,name,lat,lon
+1,name,0,0,

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -55,6 +55,9 @@ struct SniffDialect {
 		if (machine.state == CSVState::INVALID) {
 			return;
 		}
+		if (machine.cur_rows < machine.options.sample_chunk_size && machine.state == CSVState::DELIMITER) {
+			sniffed_column_counts[machine.cur_rows] = ++machine.column_count;
+		}
 		if (machine.cur_rows < machine.options.sample_chunk_size && machine.state != CSVState::EMPTY_LINE) {
 			sniffed_column_counts[machine.cur_rows++] = machine.column_count;
 		}

--- a/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
@@ -153,8 +153,7 @@ void CSVSniffer::DetectHeader() {
 				names.push_back(GenerateColumnName(best_candidate->dialect_options.num_cols, col));
 			}
 		} else if (best_header_row.size() < best_candidate->dialect_options.num_cols) {
-			throw InternalException("Potential Header was detected with number of columns inferior to dialect "
-			                        "detection and null padding is not set, this should not happen!");
+			throw InternalException("Detected header has number of columns inferior to dialect detection");
 		}
 
 	} else {

--- a/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
@@ -148,12 +148,19 @@ void CSVSniffer::DetectHeader() {
 			names.push_back(col_name);
 			name_collision_count[col_name] = 0;
 		}
+		if (best_header_row.size() < best_candidate->dialect_options.num_cols && options.null_padding) {
+			for (idx_t col = best_header_row.size(); col < best_candidate->dialect_options.num_cols; col++) {
+				names.push_back(GenerateColumnName(best_candidate->dialect_options.num_cols, col));
+			}
+		} else if (best_header_row.size() < best_candidate->dialect_options.num_cols) {
+			throw InternalException("Potential Header was detected with number of columns inferior to dialect "
+			                        "detection and null padding is not set, this should not happen!");
+		}
 
 	} else {
 		best_candidate->dialect_options.header = false;
 		for (idx_t col = 0; col < best_candidate->dialect_options.num_cols; col++) {
-			string column_name = GenerateColumnName(best_candidate->dialect_options.num_cols, col);
-			names.push_back(column_name);
+			names.push_back(GenerateColumnName(best_candidate->dialect_options.num_cols, col));
 		}
 	}
 

--- a/test/sql/copy/csv/auto/test_auto_8231.test
+++ b/test/sql/copy/csv/auto/test_auto_8231.test
@@ -1,0 +1,41 @@
+# name: test/sql/copy/csv/auto/test_auto_8231.test
+# description: Test issue 8231 related to missing headers and null padding
+# group: [auto]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create view locations_header_trailing_comma as SELECT * from read_csv_auto('data/csv/locations_row_trailing_comma.csv', null_padding=True)
+
+
+query IIIII
+SELECT * from locations_header_trailing_comma
+----
+1	name	0	0	NULL
+
+query IIIIII
+describe locations_header_trailing_comma;
+----
+id	BIGINT	YES	NULL	NULL	NULL
+name	VARCHAR	YES	NULL	NULL	NULL
+lat	BIGINT	YES	NULL	NULL	NULL
+lon	BIGINT	YES	NULL	NULL	NULL
+column4	BIGINT	YES	NULL	NULL	NULL
+
+statement ok
+create view locations_row_trailing_comma as SELECT * from read_csv_auto('data/csv/locations_row_trailing_comma.csv', null_padding=True)
+
+query IIIII
+select * from locations_row_trailing_comma
+----
+1	name	0	0	NULL
+
+query IIIIII
+describe locations_row_trailing_comma;
+----
+id	BIGINT	YES	NULL	NULL	NULL
+name	VARCHAR	YES	NULL	NULL	NULL
+lat	BIGINT	YES	NULL	NULL	NULL
+lon	BIGINT	YES	NULL	NULL	NULL
+column4	BIGINT	YES	NULL	NULL	NULL

--- a/test/sql/copy/csv/csv_null_padding.test
+++ b/test/sql/copy/csv/csv_null_padding.test
@@ -11,6 +11,8 @@ PRAGMA enable_verification
 query IIII
 FROM read_csv_auto('data/csv/nullpadding_header.csv', null_padding=True)
 ----
+# this file has a bunch of gunk at the top	NULL	NULL	NULL
+one	two	three	four
 1	a	alice	NULL
 2	b	bob	NULL
 

--- a/tools/pythonpkg/tests/fast/api/test_read_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_read_csv.py
@@ -192,7 +192,12 @@ class TestReadCSV(object):
 
         rel = duckdb_cursor.read_csv(TestFile('nullpadding.csv'), null_padding=True)
         res = rel.fetchall()
-        assert res == [(1, 'a', 'alice', None), (2, 'b', 'bob', None)]
+        assert res == [
+            ('# this file has a bunch of gunk at the top', None, None, None),
+            ('one', 'two', 'three', 'four'),
+            ('1', 'a', 'alice', None),
+            ('2', 'b', 'bob', None),
+        ]
 
         rel = duckdb.read_csv(TestFile('nullpadding.csv'), null_padding=False)
         res = rel.fetchall()
@@ -205,7 +210,12 @@ class TestReadCSV(object):
 
         rel = duckdb.read_csv(TestFile('nullpadding.csv'), null_padding=True)
         res = rel.fetchall()
-        assert res == [(1, 'a', 'alice', None), (2, 'b', 'bob', None)]
+        assert res == [
+            ('# this file has a bunch of gunk at the top', None, None, None),
+            ('one', 'two', 'three', 'four'),
+            ('1', 'a', 'alice', None),
+            ('2', 'b', 'bob', None),
+        ]
 
         rel = duckdb_cursor.from_csv_auto(TestFile('nullpadding.csv'), null_padding=False)
         res = rel.fetchall()
@@ -218,7 +228,12 @@ class TestReadCSV(object):
 
         rel = duckdb_cursor.from_csv_auto(TestFile('nullpadding.csv'), null_padding=True)
         res = rel.fetchall()
-        assert res == [(1, 'a', 'alice', None), (2, 'b', 'bob', None)]
+        assert res == [
+            ('# this file has a bunch of gunk at the top', None, None, None),
+            ('one', 'two', 'three', 'four'),
+            ('1', 'a', 'alice', None),
+            ('2', 'b', 'bob', None),
+        ]
 
         rel = duckdb.from_csv_auto(TestFile('nullpadding.csv'), null_padding=False)
         res = rel.fetchall()
@@ -231,7 +246,12 @@ class TestReadCSV(object):
 
         rel = duckdb.from_csv_auto(TestFile('nullpadding.csv'), null_padding=True)
         res = rel.fetchall()
-        assert res == [(1, 'a', 'alice', None), (2, 'b', 'bob', None)]
+        assert res == [
+            ('# this file has a bunch of gunk at the top', None, None, None),
+            ('one', 'two', 'three', 'four'),
+            ('1', 'a', 'alice', None),
+            ('2', 'b', 'bob', None),
+        ]
 
     def test_normalize_names(self, duckdb_cursor):
         rel = duckdb_cursor.read_csv(TestFile('category.csv'), normalize_names=False)


### PR DESCRIPTION
Fixing issue where CSV files with null padding headers wouldn't be recognized.

With this fix, files with nullpadding won't be able to skip notes (or whatever random gunk a csv file might have before actual data), since it will try to nullpad it.

Fixes: #8231