### PR TITLE
[Dev] Only emit ConstantVectors when `scan_vector` is invoked

### DIFF
--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -292,7 +292,11 @@ void RLESkip(ColumnSegment &segment, ColumnScanState &state, idx_t skip_count) {
 	scan_state.Skip(segment, skip_count);
 }
 
+template <bool ENTIRE_VECTOR>
 static bool CanEmitConstantVector(idx_t position, idx_t run_length, idx_t scan_count) {
+	if (!ENTIRE_VECTOR) {
+		return false;
+	}
 	if (scan_count != STANDARD_VECTOR_SIZE) {
 		// Only when we can fill an entire Vector can we emit a ConstantVector, because subsequent scans require the
 		// input Vector to be flat
@@ -330,9 +334,8 @@ static void RLEScanConstant(RLEScanState<T> &scan_state, rle_count_t *index_poin
 	return;
 }
 
-template <class T>
-void RLEScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
-                    idx_t result_offset) {
+template <class T, bool ENTIRE_VECTOR>
+void RLEScanPartialInternal(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset) {
 	auto &scan_state = state.scan_state->Cast<RLEScanState<T>>();
 
 	auto data = scan_state.handle.Ptr() + segment.GetBlockOffset();
@@ -340,7 +343,7 @@ void RLEScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_c
 	auto index_pointer = reinterpret_cast<rle_count_t *>(data + scan_state.rle_count_offset);
 
 	// If we are scanning an entire Vector and it contains only a single run
-	if (CanEmitConstantVector(scan_state.position_in_entry, index_pointer[scan_state.entry_pos], scan_count)) {
+	if (CanEmitConstantVector<ENTIRE_VECTOR>(scan_state.position_in_entry, index_pointer[scan_state.entry_pos], scan_count)) {
 		RLEScanConstant<T>(scan_state, index_pointer, data_pointer, scan_count, result);
 		return;
 	}
@@ -358,8 +361,14 @@ void RLEScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_c
 }
 
 template <class T>
+void RLEScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
+                    idx_t result_offset) {
+	return RLEScanPartialInternal<T, false>(segment, state, scan_count, result, result_offset);
+}
+
+template <class T>
 void RLEScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
-	RLEScanPartial<T>(segment, state, scan_count, result, 0);
+	RLEScanPartialInternal<T, true>(segment, state, scan_count, result, 0);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -335,7 +335,8 @@ static void RLEScanConstant(RLEScanState<T> &scan_state, rle_count_t *index_poin
 }
 
 template <class T, bool ENTIRE_VECTOR>
-void RLEScanPartialInternal(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset) {
+void RLEScanPartialInternal(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
+                            idx_t result_offset) {
 	auto &scan_state = state.scan_state->Cast<RLEScanState<T>>();
 
 	auto data = scan_state.handle.Ptr() + segment.GetBlockOffset();
@@ -343,7 +344,8 @@ void RLEScanPartialInternal(ColumnSegment &segment, ColumnScanState &state, idx_
 	auto index_pointer = reinterpret_cast<rle_count_t *>(data + scan_state.rle_count_offset);
 
 	// If we are scanning an entire Vector and it contains only a single run
-	if (CanEmitConstantVector<ENTIRE_VECTOR>(scan_state.position_in_entry, index_pointer[scan_state.entry_pos], scan_count)) {
+	if (CanEmitConstantVector<ENTIRE_VECTOR>(scan_state.position_in_entry, index_pointer[scan_state.entry_pos],
+	                                         scan_count)) {
 		RLEScanConstant<T>(scan_state, index_pointer, data_pointer, scan_count, result);
 		return;
 	}

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -91,7 +91,8 @@ void ColumnSegment::Scan(ColumnScanState &state, idx_t scan_count, Vector &resul
 	} else {
 		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
 		ScanPartial(state, scan_count, result, result_offset);
-		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
+		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR ||
+		         result.GetVectorType() == VectorType::CONSTANT_VECTOR);
 	}
 }
 

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -83,22 +83,6 @@ void ColumnSegment::InitializeScan(ColumnScanState &state) {
 	state.scan_state = function.get().init_scan(*this);
 }
 
-static bool ValidVectorType(Vector &result, idx_t offset, idx_t count) {
-	auto vector_type = result.GetVectorType();
-	if (vector_type == VectorType::FLAT_VECTOR) {
-		return true;
-	}
-	if (vector_type != VectorType::CONSTANT_VECTOR) {
-		return false;
-	}
-	// Constant Vectors can be emitted when the entire vector is filled
-	// because no further additions to the vector have to be made
-	if (count != STANDARD_VECTOR_SIZE) {
-		return false;
-	}
-	return true;
-}
-
 void ColumnSegment::Scan(ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset,
                          bool entire_vector) {
 	if (entire_vector) {
@@ -107,7 +91,7 @@ void ColumnSegment::Scan(ColumnScanState &state, idx_t scan_count, Vector &resul
 	} else {
 		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
 		ScanPartial(state, scan_count, result, result_offset);
-		D_ASSERT(ValidVectorType(result));
+		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
 	}
 }
 

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -83,6 +83,22 @@ void ColumnSegment::InitializeScan(ColumnScanState &state) {
 	state.scan_state = function.get().init_scan(*this);
 }
 
+static bool ValidVectorType(Vector &result, idx_t offset, idx_t count) {
+	auto vector_type = result.GetVectorType();
+	if (vector_type == VectorType::FLAT_VECTOR) {
+		return true;
+	}
+	if (vector_type != VectorType::CONSTANT_VECTOR) {
+		return false;
+	}
+	// Constant Vectors can be emitted when the entire vector is filled
+	// because no further additions to the vector have to be made
+	if (count != STANDARD_VECTOR_SIZE) {
+		return false;
+	}
+	return true;
+}
+
 void ColumnSegment::Scan(ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset,
                          bool entire_vector) {
 	if (entire_vector) {
@@ -91,8 +107,7 @@ void ColumnSegment::Scan(ColumnScanState &state, idx_t scan_count, Vector &resul
 	} else {
 		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
 		ScanPartial(state, scan_count, result, result_offset);
-		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR ||
-		         result.GetVectorType() == VectorType::CONSTANT_VECTOR);
+		D_ASSERT(ValidVectorType(result));
 	}
 }
 


### PR DESCRIPTION
In light of #8869 this makes revisions to #8250 

The RLE scan code previously made its own calculation of whether constant vectors could be emitted, but it seems this is not given enough context to determine this.

So now we only emit constant vectors when the `scan_vector` callback is invoked, as opposed to `scan_partial`