### PR TITLE
httpfs: Avoid corruptions with servers sending more data than asked for

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -329,6 +329,15 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRangeRequest(FileHandle &handle, 
 				    hfs.state->total_bytes_received += data_length;
 			    }
 			    if (buffer_out != nullptr) {
+				    if (data_length + out_offset > buffer_out_len) {
+					    // As of v0.8.2-dev4424 we might end up here when very big files are served from servers
+					    // that returns more data than requested via range header. This is an uncommon but legal
+					    // behaviour, so we have to improve logic elsewhere to properly handle this case.
+
+					    // To avoid corruption of memory, we bail out.
+					    throw IOException("Server sent back more data than expected, `SET force_download=true` might "
+					                      "help in this case");
+				    }
 				    memcpy(buffer_out + out_offset, data, data_length);
 				    out_offset += data_length;
 			    }


### PR DESCRIPTION
Fixes #8930 and fixes #8908 (avoiding the fatal crash).

HTTP server are allowed to send back more data than asked for, and be somehow unreliably. In this case a GET request with a range headers gets more data than asked for, and with very big files we ended up overriding the current buffer.

This is an uncommon but legal behaviour, to properly handle this situation so we will have to improve logic elsewhere to properly handle this case.