### PR TITLE
Add `PRAGMA metadata_info` that displays info about the storage of metadata, and correctly write free metadata blocks

### DIFF
--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -1,4 +1,4 @@
-catalog/catalog.cpp	39
+catalog/catalog.cpp	41
 catalog/catalog_entry.cpp	11
 catalog/catalog_entry/duck_schema_entry.cpp	4
 catalog/catalog_entry/duck_table_entry.cpp	7

--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -799,7 +799,7 @@ storage/serialization/serialize_logical_operator.cpp	23
 storage/serialization/serialize_parse_info.cpp	61
 storage/serialization/serialize_table_filter.cpp	20
 storage/serialization/serialize_types.cpp	2
-storage/metadata/metadata_manager.cpp	4
+storage/metadata/metadata_manager.cpp	7
 storage/table/chunk_info.cpp	62
 storage/table/column_checkpoint_state.cpp	20
 storage/table/column_data.cpp	16

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -831,6 +831,10 @@ void Catalog::Alter(ClientContext &context, AlterInfo &info) {
 	return lookup.schema->Alter(context, info);
 }
 
+vector<MetadataBlockInfo> Catalog::GetMetadataInfo(ClientContext &context) {
+	return vector<MetadataBlockInfo>();
+}
+
 void Catalog::Verify() {
 }
 

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -35,6 +35,7 @@
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/function/built_in_functions.hpp"
 #include "duckdb/catalog/similar_catalog_entry.hpp"
+#include "duckdb/storage/database_size.hpp"
 #include <algorithm>
 
 namespace duckdb {

--- a/src/catalog/duck_catalog.cpp
+++ b/src/catalog/duck_catalog.cpp
@@ -132,6 +132,10 @@ DatabaseSize DuckCatalog::GetDatabaseSize(ClientContext &context) {
 	return db.GetStorageManager().GetDatabaseSize();
 }
 
+vector<MetadataBlockInfo> DuckCatalog::GetMetadataInfo(ClientContext &context) {
+	return db.GetStorageManager().GetMetadataInfo();
+}
+
 bool DuckCatalog::InMemory() {
 	return db.GetStorageManager().InMemory();
 }

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -187,9 +187,14 @@ string PragmaStorageInfo(ClientContext &context, const FunctionParameters &param
 	return StringUtil::Format("SELECT * FROM pragma_storage_info('%s');", parameters.values[0].ToString());
 }
 
+string PragmaMetadataInfo(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_metadata_info();";
+}
+
 void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaCall("table_info", PragmaTableInfo, {LogicalType::VARCHAR}));
 	set.AddFunction(PragmaFunction::PragmaCall("storage_info", PragmaStorageInfo, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaCall("metadata_info", PragmaMetadataInfo, {}));
 	set.AddFunction(PragmaFunction::PragmaStatement("show_tables", PragmaShowTables));
 	set.AddFunction(PragmaFunction::PragmaStatement("show_tables_expanded", PragmaShowTablesExpanded));
 	set.AddFunction(PragmaFunction::PragmaStatement("show_databases", PragmaShowDatabases));

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   duckdb_views.cpp
   pragma_collations.cpp
   pragma_database_size.cpp
+  pragma_metadata_info.cpp
   pragma_storage_info.cpp
   pragma_table_info.cpp
   test_all_types.cpp

--- a/src/function/table/system/pragma_metadata_info.cpp
+++ b/src/function/table/system/pragma_metadata_info.cpp
@@ -2,7 +2,8 @@
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/storage/database_size.hpp"
-
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/function/function_set.hpp"
 namespace duckdb {
 
 struct PragmaMetadataFunctionData : public TableFunctionData {

--- a/src/function/table/system/pragma_metadata_info.cpp
+++ b/src/function/table/system/pragma_metadata_info.cpp
@@ -1,0 +1,82 @@
+#include "duckdb/function/table/system_functions.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/storage/database_size.hpp"
+
+namespace duckdb {
+
+struct PragmaMetadataFunctionData : public TableFunctionData {
+	explicit PragmaMetadataFunctionData() {
+	}
+
+	vector<MetadataBlockInfo> metadata_info;
+};
+
+struct PragmaMetadataOperatorData : public GlobalTableFunctionState {
+	PragmaMetadataOperatorData() : offset(0) {
+	}
+
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> PragmaMetadataInfoBind(ClientContext &context, TableFunctionBindInput &input,
+                                                       vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("block_id");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("total_blocks");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("free_blocks");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("free_list");
+	return_types.emplace_back(LogicalType::LIST(LogicalType::BIGINT));
+
+	string db_name =
+	    input.inputs.empty() ? DatabaseManager::GetDefaultDatabase(context) : StringValue::Get(input.inputs[0]);
+	auto &catalog = Catalog::GetCatalog(context, db_name);
+	auto result = make_uniq<PragmaMetadataFunctionData>();
+	result->metadata_info = catalog.GetMetadataInfo(context);
+	return std::move(result);
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaMetadataInfoInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<PragmaMetadataOperatorData>();
+}
+
+static void PragmaMetadataInfoFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<PragmaMetadataFunctionData>();
+	auto &data = data_p.global_state->Cast<PragmaMetadataOperatorData>();
+	idx_t count = 0;
+	while (data.offset < bind_data.metadata_info.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = bind_data.metadata_info[data.offset++];
+
+		idx_t col_idx = 0;
+		// block_id
+		output.SetValue(col_idx++, count, Value::BIGINT(entry.block_id));
+		// total_blocks
+		output.SetValue(col_idx++, count, Value::BIGINT(entry.total_blocks));
+		// free_blocks
+		output.SetValue(col_idx++, count, Value::BIGINT(entry.free_list.size()));
+		// free_list
+		vector<Value> list_values;
+		for (auto &free_id : entry.free_list) {
+			list_values.push_back(Value::BIGINT(free_id));
+		}
+		output.SetValue(col_idx++, count, Value::LIST(LogicalType::BIGINT, std::move(list_values)));
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void PragmaMetadataInfo::RegisterFunction(BuiltinFunctions &set) {
+	TableFunctionSet metadata_info("pragma_metadata_info");
+	metadata_info.AddFunction(
+	    TableFunction({}, PragmaMetadataInfoFunction, PragmaMetadataInfoBind, PragmaMetadataInfoInit));
+	metadata_info.AddFunction(TableFunction({LogicalType::VARCHAR}, PragmaMetadataInfoFunction, PragmaMetadataInfoBind,
+	                                        PragmaMetadataInfoInit));
+	set.AddFunction(metadata_info);
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -14,6 +14,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	PragmaCollations::RegisterFunction(*this);
 	PragmaTableInfo::RegisterFunction(*this);
 	PragmaStorageInfo::RegisterFunction(*this);
+	PragmaMetadataInfo::RegisterFunction(*this);
 	PragmaDatabaseSize::RegisterFunction(*this);
 	PragmaLastProfilingOutput::RegisterFunction(*this);
 	PragmaDetailedProfilingOutput::RegisterFunction(*this);

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -34,6 +34,7 @@ struct CreateIndexInfo;
 struct CreateTypeInfo;
 struct CreateTableInfo;
 struct DatabaseSize;
+struct MetadataBlockInfo;
 
 class AttachedDatabase;
 class ClientContext;
@@ -266,6 +267,7 @@ public:
 	                                                    unique_ptr<LogicalOperator> plan) = 0;
 
 	virtual DatabaseSize GetDatabaseSize(ClientContext &context) = 0;
+	virtual vector<MetadataBlockInfo> GetMetadataInfo(ClientContext &context);
 
 	virtual bool InMemory() = 0;
 	virtual string GetDBPath() = 0;

--- a/src/include/duckdb/catalog/duck_catalog.hpp
+++ b/src/include/duckdb/catalog/duck_catalog.hpp
@@ -54,6 +54,7 @@ public:
 	                                                       unique_ptr<LogicalOperator> plan) override;
 
 	DatabaseSize GetDatabaseSize(ClientContext &context) override;
+	vector<MetadataBlockInfo> GetMetadataInfo(ClientContext &context) override;
 
 	DUCKDB_API bool InMemory() override;
 	DUCKDB_API string GetDBPath() override;

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -25,6 +25,10 @@ struct PragmaStorageInfo {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct PragmaMetadataInfo {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct PragmaLastProfilingOutput {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/storage/database_size.hpp
+++ b/src/include/duckdb/storage/database_size.hpp
@@ -21,4 +21,10 @@ struct DatabaseSize {
 	idx_t wal_size = 0;
 };
 
+struct MetadataBlockInfo {
+	block_id_t block_id;
+	idx_t total_blocks;
+	vector<idx_t> free_list;
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -16,6 +16,7 @@
 
 namespace duckdb {
 class DatabaseInstance;
+struct MetadataBlockInfo;
 
 struct MetadataBlock {
 	shared_ptr<BlockHandle> block;
@@ -66,6 +67,7 @@ public:
 	void MarkBlocksAsModified();
 	void ClearModifiedBlocks(const vector<MetaBlockPointer> &pointers);
 
+	vector<MetadataBlockInfo> GetMetadataInfo() const;
 	idx_t BlockCount();
 
 	void Write(WriteStream &sink);

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -68,6 +68,7 @@ public:
 	virtual bool IsCheckpointClean(MetaBlockPointer checkpoint_id) = 0;
 	virtual void CreateCheckpoint(bool delete_wal = false, bool force_checkpoint = false) = 0;
 	virtual DatabaseSize GetDatabaseSize() = 0;
+	virtual vector<MetadataBlockInfo> GetMetadataInfo() = 0;
 	virtual shared_ptr<TableIOManager> GetTableIOManager(BoundCreateTableInfo *info) = 0;
 
 protected:
@@ -112,6 +113,7 @@ public:
 	bool IsCheckpointClean(MetaBlockPointer checkpoint_id) override;
 	void CreateCheckpoint(bool delete_wal, bool force_checkpoint) override;
 	DatabaseSize GetDatabaseSize() override;
+	vector<MetadataBlockInfo> GetMetadataInfo() override;
 	shared_ptr<TableIOManager> GetTableIOManager(BoundCreateTableInfo *info) override;
 
 protected:

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -136,8 +136,6 @@ void SingleFileCheckpointWriter::CreateCheckpoint() {
 
 	// truncate the file
 	block_manager.Truncate();
-
-	metadata_manager.MarkBlocksAsModified();
 }
 
 void CheckpointReader::LoadCheckpoint(ClientContext &context, MetadataReader &reader) {

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -263,14 +263,14 @@ void MetadataManager::MarkBlocksAsModified() {
 		idx_t current_free_blocks = block.FreeBlocksToInteger();
 		// merge the current set of free blocks with the modified blocks
 		idx_t new_free_blocks = current_free_blocks | modified_list;
-		//			if (new_free_blocks == NumericLimits<idx_t>::Maximum()) {
-		//				// if new free_blocks is all blocks - mark entire block as modified
-		//				blocks.erase(entry);
-		//				block_manager.MarkBlockAsModified(block_id);
-		//			} else {
-		// set the new set of free blocks
-		block.FreeBlocksFromInteger(new_free_blocks);
-		//			}
+		if (new_free_blocks == NumericLimits<idx_t>::Maximum()) {
+			// if new free_blocks is all blocks - mark entire block as modified
+			blocks.erase(entry);
+			block_manager.MarkBlockAsModified(block_id);
+		} else {
+			// set the new set of free blocks
+			block.FreeBlocksFromInteger(new_free_blocks);
+		}
 	}
 
 	modified_blocks.clear();

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -443,6 +443,7 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 	for (auto &block : modified_blocks) {
 		free_list.insert(block);
 	}
+	GetMetadataManager().MarkBlocksAsModified();
 	modified_blocks.clear();
 
 	auto &metadata_manager = GetMetadataManager();

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -439,14 +439,14 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 	auto free_list_blocks = GetFreeListBlocks();
 
 	// now handle the free list
+	auto &metadata_manager = GetMetadataManager();
 	// add all modified blocks to the free list: they can now be written to again
+	metadata_manager.MarkBlocksAsModified();
 	for (auto &block : modified_blocks) {
 		free_list.insert(block);
 	}
-	GetMetadataManager().MarkBlocksAsModified();
 	modified_blocks.clear();
 
-	auto &metadata_manager = GetMetadataManager();
 	if (!free_list_blocks.empty()) {
 		// there are blocks to write, either in the free_list or in the modified_blocks
 		// we write these blocks specifically to the free_list_blocks

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -260,6 +260,11 @@ DatabaseSize SingleFileStorageManager::GetDatabaseSize() {
 	return ds;
 }
 
+vector<MetadataBlockInfo> SingleFileStorageManager::GetMetadataInfo() {
+	auto &metadata_manager = block_manager->GetMetadataManager();
+	return metadata_manager.GetMetadataInfo();
+}
+
 bool SingleFileStorageManager::AutomaticCheckpoint(idx_t estimated_wal_bytes) {
 	auto log = GetWriteAheadLog();
 	if (!log) {

--- a/test/sql/pragma/test_metadata_info.test
+++ b/test/sql/pragma/test_metadata_info.test
@@ -1,0 +1,35 @@
+# name: test/sql/pragma/test_metadata_info.test
+# description: Test metadata info
+# group: [pragma]
+
+# skip reload because of attach
+require skip_reload
+
+load __TEST_DIR__/test_metadata_info.db
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER, j INTEGER)
+
+statement ok
+CHECKPOINT
+
+statement ok
+PRAGMA metadata_info;
+
+statement ok
+FROM pragma_metadata_info();
+
+statement ok
+ATTACH '__TEST_DIR__/test_metadata_info_attach.db' AS db1
+
+statement ok
+CREATE TABLE db1.integers(i INTEGER, j INTEGER)
+
+statement ok
+CHECKPOINT db1
+
+statement ok
+FROM pragma_metadata_info('db1');

--- a/test/sql/storage/delete/drop_many_deletes.test_slow
+++ b/test/sql/storage/delete/drop_many_deletes.test_slow
@@ -1,0 +1,38 @@
+# name: test/sql/storage/delete/drop_many_deletes.test_slow
+# description: Test dropping a table that has many deletes
+# group: [delete]
+
+# load the DB from disk
+load __TEST_DIR__/drop_many_deletes.db
+
+statement ok
+CREATE TABLE integers AS SELECT * FROM range(0,10000000) t(i);
+
+query I
+DELETE FROM integers WHERE i%2=0
+----
+5000000
+
+restart
+
+query I
+SELECT COUNT(*) FROM integers
+----
+5000000
+
+# check how many blocks are used by the metadata manager
+query I
+SELECT COUNT(*) FROM pragma_metadata_info()
+----
+7
+
+statement ok
+DROP TABLE integers
+
+restart
+
+# verify that the blocks are returned to the system and the metadata blocks are freed
+query I
+SELECT COUNT(*) FROM pragma_metadata_info()
+----
+1

--- a/test/sql/storage/overflow_strings/load_overflow_strings_slowly.test
+++ b/test/sql/storage/overflow_strings/load_overflow_strings_slowly.test
@@ -4,9 +4,6 @@
 
 load __TEST_DIR__/load_overflow_strings.db
 
-# FIXME - there is an issue with metadata not being freed correctly causing this test to fail in --force-reload
-require skip_reload
-
 loop x 0 10
 
 statement ok


### PR DESCRIPTION
This PR adds the `PRAGMA metadata_info` command that can be used to query information about the metadata manager:

```sql
D PRAGMA metadata_info;
┌──────────┬──────────────┬─────────────┬────────────────────────────────────────────┐
│ block_id │ total_blocks │ free_blocks │                 free_list                  │
│  int64   │    int64     │    int64    │                  int64[]                   │
├──────────┼──────────────┼─────────────┼────────────────────────────────────────────┤
│        0 │           64 │          61 │ [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14…  │
└──────────┴──────────────┴─────────────┴────────────────────────────────────────────┘
```

In addition, this PR fixes an issue found in #8943 where the free list of the metadata manager was not correctly serialized causing small leaking of storage space for every database restart.