### PR TITLE
Fix typos and update variable type info in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ This project and everyone participating in it is governed by a [Code of Conduct]
 
 ## CI for pull requests
 
-* Pull requests will need to be pass all continuous integration checks before merging.
+* Pull requests will need to pass all continuous integration checks before merging.
 * For faster iteration and more control, consider running CI on your own fork or when possible directly locally.
-* Submitting changes to a open pull requests will move it to 'draft' state.
+* Submitting changes to an open pull request will move it to 'draft' state.
 * Pull requests will get a complete run on the main repo CI only when marked as 'ready for review' (via Web UI, button on bottom right).
 
 ## Nightly CI
@@ -63,7 +63,7 @@ This project and everyone participating in it is governed by a [Code of Conduct]
 * Make sure **all** unit tests pass before sending a PR.
 * Slower tests should be added to the **all** unit tests. You can do this by naming the test file `.test_slow` in the sqllogictests, or by adding `[.]` after the test group in the C++ tests.
 * Look at the code coverage report of your branch and attempt to cover all code paths in the fast unit tests. Attempt to trigger exceptions as well. It is acceptable to have some exceptions not triggered (e.g. out of memory exceptions or type switch exceptions), but large branches of code should always be either covered or removed.
-* DuckDB uses GitHub Actions as its continuous integration (CI) tool. You have the option to run GitHub Actions on your forked repository. For detailed instructions, you can refer to the [GitHub documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository). Before running GitHub Actions, please ensure that you have all the Git tags from the duckdb/duckdb repository. To accomplish this, execute the following commands `git fetch <your-duckdb/duckdb-repo-remote-name> --tags` then 
+* DuckDB uses GitHub Actions as its continuous integration (CI) tool. You also have the option to run GitHub Actions on your forked repository. For detailed instructions, you can refer to the [GitHub documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository). Before running GitHub Actions, please ensure that you have all the Git tags from the duckdb/duckdb repository. To accomplish this, execute the following commands `git fetch <your-duckdb/duckdb-repo-remote-name> --tags` and then 
 `git push --tags` These commands will fetch all the git tags from the duckdb/duckdb repository and push them to your forked repository. This ensures that you have all the necessary tags available for your GitHub Actions workflow. 
 
 ## Formatting
@@ -102,7 +102,7 @@ This project and everyone participating in it is governed by a [Code of Conduct]
     	void MyPrivateFunction();
 
     private:
-    	void my_private_variable;
+    	int my_private_variable;
     };
     ```
 * Avoid [unnamed magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming)). Instead, use named variables that are stored in a `constexpr`.


### PR DESCRIPTION
This commit addresses several changes in the Contributing.md file:

1. Fixed several minor typos to improve readability and clarity.
2. Corrected the inaccurate information that variables can be declared of the type void.