### PR TITLE
Truncate the db file before the WAL for differential storage

### DIFF
--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -131,11 +131,11 @@ void SingleFileCheckpointWriter::CreateCheckpoint() {
 		throw FatalException("Checkpoint aborted before truncate because of PRAGMA checkpoint_abort flag");
 	}
 
-	// truncate the WAL
-	wal->Truncate(0);
-
 	// truncate the file
 	block_manager.Truncate();
+
+	// truncate the WAL
+	wal->Truncate(0);
 }
 
 void CheckpointReader::LoadCheckpoint(ClientContext &context, MetadataReader &reader) {


### PR DESCRIPTION
Differential relies on the signal of the WAL file being truncated to snapshot the differential file. It would be helpful to have db truncations occur before hand - so we can capture this in our snapshot.

The ordering of these operations (WAL vs DB truncation) do not affect correctness - as the database should be durable after the table_metadata_writer->Flush() completes. At this point - DuckDB is just cleaning up the database/WAL state at the end of the checkpoint.