### PR TITLE
Fix #8592: correctly deal with torn writes by ignoring SerializationException during initial read

### DIFF
--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -102,9 +102,7 @@ void TableStatistics::CopyStats(TableStatistics &other) {
 }
 
 void TableStatistics::Serialize(Serializer &serializer) const {
-	auto column_count = column_stats.size();
-	serializer.WriteList(100, "column_stats", column_count,
-	                     [&](Serializer::List &list, idx_t i) { list.WriteElement(column_stats[i]); });
+	serializer.WriteProperty(100, "column_stats", column_stats);
 }
 
 void TableStatistics::Deserialize(Deserializer &deserializer, ColumnList &columns) {

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -57,7 +57,10 @@ bool WriteAheadLog::Replay(AttachedDatabase &database, string &path) {
 				deserializer.End();
 			}
 		}
-	} catch (std::exception &ex) { // LCOV_EXCL_START
+	} catch (SerializationException &ex) { // LCOV_EXCL_START
+		                                   // serialization exception - torn WAL
+		                                   // continue reading
+	} catch (std::exception &ex) {
 		Printer::PrintF("Exception in WAL playback during initial read: %s\n", ex.what());
 		return false;
 	} catch (...) {
@@ -104,7 +107,10 @@ bool WriteAheadLog::Replay(AttachedDatabase &database, string &path) {
 				deserializer.End();
 			}
 		}
-	} catch (std::exception &ex) { // LCOV_EXCL_START
+	} catch (SerializationException &ex) { // LCOV_EXCL_START
+		// serialization error during WAL replay: rollback
+		con.Rollback();
+	} catch (std::exception &ex) {
 		// FIXME: this should report a proper warning in the connection
 		Printer::PrintF("Exception in WAL playback: %s\n", ex.what());
 		// exception thrown in WAL replay: rollback

--- a/test/sql/storage/CMakeLists.txt
+++ b/test/sql/storage/CMakeLists.txt
@@ -7,7 +7,8 @@ add_library_unity(
   test_big_storage.cpp
   test_repeated_checkpoint.cpp
   test_storage.cpp
-  test_database_size.cpp)
+  test_database_size.cpp
+  wal_torn_write.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_sql_storage>
     PARENT_SCOPE)

--- a/test/sql/storage/wal_torn_write.cpp
+++ b/test/sql/storage/wal_torn_write.cpp
@@ -1,0 +1,62 @@
+#include "catch.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/common/local_file_system.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+static idx_t GetWALFileSize(FileSystem &fs, const string &path) {
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK);
+	return fs.GetFileSize(*handle);
+}
+
+static void TruncateWAL(FileSystem &fs, const string &path, idx_t new_size) {
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE);
+	fs.Truncate(*handle, new_size);
+}
+
+TEST_CASE("Test torn WAL writes", "[storage][.]") {
+	auto config = GetTestConfig();
+	duckdb::unique_ptr<QueryResult> result;
+	auto storage_database = TestCreatePath("storage_test");
+	auto storage_wal = storage_database + ".wal";
+
+	LocalFileSystem lfs;
+	config->options.checkpoint_wal_size = idx_t(-1);
+	config->options.checkpoint_on_shutdown = false;
+	idx_t wal_size_one_table;
+	idx_t wal_size_two_table;
+	// obtain the size of the WAL when writing one table, and then when writing two tables
+	DeleteDatabase(storage_database);
+	{
+		DuckDB db(storage_database, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE A (a INTEGER);"));
+		wal_size_one_table = GetWALFileSize(lfs, storage_wal);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE B (a INTEGER);"));
+		wal_size_two_table = GetWALFileSize(lfs, storage_wal);
+	}
+	DeleteDatabase(storage_database);
+
+	// now for all sizes in between these two sizes we have a torn write
+	// try all of the possible sizes and truncate the WAL
+	for (idx_t i = wal_size_one_table + 1; i < wal_size_two_table; i++) {
+		DeleteDatabase(storage_database);
+		{
+			DuckDB db(storage_database, config.get());
+			Connection con(db);
+			REQUIRE_NO_FAIL(con.Query("CREATE TABLE A (a INTEGER);"));
+			REQUIRE_NO_FAIL(con.Query("CREATE TABLE B (a INTEGER);"));
+		}
+		TruncateWAL(lfs, storage_wal, i);
+		{
+			// reload and make sure table A is there, and table B is not there
+			DuckDB db(storage_database, config.get());
+			Connection con(db);
+			REQUIRE_NO_FAIL(con.Query("FROM A"));
+			REQUIRE_FAIL(con.Query("FROM B"));
+		}
+	}
+	DeleteDatabase(storage_database);
+}


### PR DESCRIPTION
Fixes #8592 