### PR TITLE
fix(nodejs): cpp exception handling

### DIFF
--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -177,7 +177,7 @@ void DBConfig::SetOptionByName(const string &name, const Value &value) {
 void DBConfig::SetOption(DatabaseInstance *db, const ConfigurationOption &option, const Value &value) {
 	lock_guard<mutex> l(config_lock);
 	if (!option.set_global) {
-		throw InternalException("Could not set option \"%s\" as a global option", option.name);
+		throw InvalidInputException("Could not set option \"%s\" as a global option", option.name);
 	}
 	D_ASSERT(option.reset_global);
 	Value input = value.DefaultCastAs(option.parameter_type);

--- a/tools/nodejs/binding.gyp.in
+++ b/tools/nodejs/binding.gyp.in
@@ -16,7 +16,6 @@
                 "${INCLUDE_FILES}"
             ],
             "defines": [
-                "NAPI_DISABLE_CPP_EXCEPTIONS=1",
                 "NAPI_VERSION=6",
                 "${DEFINES}"
             ],

--- a/tools/nodejs/src/connection.cpp
+++ b/tools/nodejs/src/connection.cpp
@@ -66,8 +66,7 @@ Connection::Connection(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Connec
 	int length = info.Length();
 
 	if (length <= 0 || !Database::HasInstance(info[0])) {
-		Napi::TypeError::New(env, "Database object expected").ThrowAsJavaScriptException();
-		return;
+		throw Napi::TypeError::New(env, "Database object expected");
 	}
 
 	database_ref = Napi::ObjectWrap<Database>::Unwrap(info[0].As<Napi::Object>());
@@ -277,8 +276,7 @@ struct RegisterUdfTask : public Task {
 Napi::Value Connection::RegisterUdf(const Napi::CallbackInfo &info) {
 	auto env = info.Env();
 	if (info.Length() < 3 || !info[0].IsString() || !info[1].IsString() || !info[2].IsFunction()) {
-		Napi::TypeError::New(env, "Holding it wrong").ThrowAsJavaScriptException();
-		return env.Null();
+		throw Napi::TypeError::New(env, "Holding it wrong");
 	}
 
 	std::string name = info[0].As<Napi::String>();
@@ -290,8 +288,7 @@ Napi::Value Connection::RegisterUdf(const Napi::CallbackInfo &info) {
 	}
 
 	if (udfs.find(name) != udfs.end()) {
-		Napi::TypeError::New(env, "UDF with this name already exists").ThrowAsJavaScriptException();
-		return env.Null();
+		throw Napi::TypeError::New(env, "UDF with this name already exists");
 	}
 
 	auto udf = duckdb_node_udf_function_t::New(env, udf_callback, "duckdb_node_udf" + name, 0, 1, nullptr,
@@ -338,8 +335,7 @@ struct UnregisterUdfTask : public Task {
 Napi::Value Connection::UnregisterUdf(const Napi::CallbackInfo &info) {
 	auto env = info.Env();
 	if (info.Length() < 1 || !info[0].IsString()) {
-		Napi::TypeError::New(env, "Holding it wrong").ThrowAsJavaScriptException();
-		return env.Null();
+		throw Napi::TypeError::New(env, "Holding it wrong");
 	}
 	std::string name = info[0].As<Napi::String>();
 
@@ -441,8 +437,7 @@ Napi::Value Connection::Exec(const Napi::CallbackInfo &info) {
 	auto env = info.Env();
 
 	if (info.Length() < 1 || !info[0].IsString()) {
-		Napi::TypeError::New(env, "SQL query expected").ThrowAsJavaScriptException();
-		return env.Null();
+		throw Napi::TypeError::New(env, "SQL query expected");
 	}
 
 	std::string sql = info[0].As<Napi::String>();
@@ -461,8 +456,7 @@ Napi::Value Connection::RegisterBuffer(const Napi::CallbackInfo &info) {
 	auto env = info.Env();
 
 	if (info.Length() < 2 || !info[0].IsString() || !info[1].IsObject()) {
-		Napi::TypeError::New(env, "Incorrect params").ThrowAsJavaScriptException();
-		return env.Null();
+		throw Napi::TypeError::New(env, "Incorrect params");
 	}
 
 	std::string name = info[0].As<Napi::String>();
@@ -471,17 +465,13 @@ Napi::Value Connection::RegisterBuffer(const Napi::CallbackInfo &info) {
 
 	if (info.Length() > 2) {
 		if (!info[2].IsBoolean()) {
-			Napi::TypeError::New(env, "Parameter 3 is of unexpected type. Expected boolean")
-			    .ThrowAsJavaScriptException();
-			return env.Null();
+			throw Napi::TypeError::New(env, "Parameter 3 is of unexpected type. Expected boolean");
 		}
 		force_register = info[2].As<Napi::Boolean>().Value();
 	}
 
 	if (!force_register && array_references.find(name) != array_references.end()) {
-		Napi::TypeError::New(env, "Buffer with this name already exists and force_register is not enabled")
-		    .ThrowAsJavaScriptException();
-		return env.Null();
+		throw Napi::TypeError::New(env, "Buffer with this name already exists and force_register is not enabled");
 	}
 
 	array_references[name] = Napi::Persistent(array);
@@ -491,9 +481,7 @@ Napi::Value Connection::RegisterBuffer(const Napi::CallbackInfo &info) {
 	for (uint64_t ipc_idx = 0; ipc_idx < array.Length(); ipc_idx++) {
 		Napi::Value v = array[ipc_idx];
 		if (!v.IsObject()) {
-			Napi::TypeError::New(env, "Parameter 2 contains unexpected type at index " + std::to_string(ipc_idx))
-			    .ThrowAsJavaScriptException();
-			return env.Null();
+			throw Napi::TypeError::New(env, "Parameter 2 contains unexpected type at index " + std::to_string(ipc_idx));
 		}
 		Napi::Uint8Array arr = v.As<Napi::Uint8Array>();
 		auto raw_ptr = reinterpret_cast<uint64_t>(arr.ArrayBuffer().Data());
@@ -519,8 +507,7 @@ Napi::Value Connection::UnRegisterBuffer(const Napi::CallbackInfo &info) {
 	auto env = info.Env();
 
 	if (info.Length() < 1 || !info[0].IsString()) {
-		Napi::TypeError::New(env, "Incorrect params").ThrowAsJavaScriptException();
-		return env.Null();
+		throw Napi::TypeError::New(env, "Incorrect params");
 	}
 	std::string name = info[0].As<Napi::String>();
 

--- a/tools/nodejs/src/data_chunk.cpp
+++ b/tools/nodejs/src/data_chunk.cpp
@@ -184,9 +184,7 @@ Napi::Array EncodeDataChunk(Napi::Env env, duckdb::DataChunk &chunk, bool with_t
 				break;
 			}
 			default:
-				Napi::TypeError::New(env, "Unsupported UDF argument type " + vec->GetType().ToString())
-				    .ThrowAsJavaScriptException();
-				break;
+				throw Napi::TypeError::New(env, "Unsupported UDF argument type " + vec->GetType().ToString());
 			}
 		}
 		col_descs.Set(col_idx, col_desc);

--- a/tools/nodejs/src/database.cpp
+++ b/tools/nodejs/src/database.cpp
@@ -43,9 +43,7 @@ struct OpenTask : public Task {
 				try {
 					duckdb_config.SetOptionByName(key, duckdb::Value(val));
 				} catch (std::exception &e) {
-					Napi::TypeError::New(env, "Failed to set configuration option " + key + ": " + e.what())
-					    .ThrowAsJavaScriptException();
-					return;
+					throw Napi::TypeError::New(env, "Failed to set configuration option " + key + ": " + e.what());
 				}
 			}
 		}
@@ -90,8 +88,7 @@ Database::Database(const Napi::CallbackInfo &info)
 	auto env = info.Env();
 
 	if (info.Length() < 1 || !info[0].IsString()) {
-		Napi::TypeError::New(env, "Database location expected").ThrowAsJavaScriptException();
-		return;
+		throw Napi::TypeError::New(env, "Database location expected");
 	}
 	std::string filename = info[0].As<Napi::String>();
 	unsigned int pos = 1;
@@ -193,8 +190,7 @@ Napi::Value Database::Serialize(const Napi::CallbackInfo &info) {
 		return info.This();
 	}
 	if (info.Length() < 1 || !info[0].IsFunction()) {
-		Napi::TypeError::New(env, "Callback expected").ThrowAsJavaScriptException();
-		return env.Null();
+		throw Napi::TypeError::New(env, "Callback expected");
 	}
 	Napi::HandleScope scope(env);
 	info[0].As<Napi::Function>().MakeCallback(info.This(), {});
@@ -355,8 +351,7 @@ Napi::Value Database::RegisterReplacementScan(const Napi::CallbackInfo &info) {
 	auto env = info.Env();
 	auto deferred = Napi::Promise::Deferred::New(info.Env());
 	if (info.Length() < 1) {
-		Napi::TypeError::New(env, "Replacement scan callback expected").ThrowAsJavaScriptException();
-		return env.Null();
+		throw Napi::TypeError::New(env, "Replacement scan callback expected");
 	}
 	Napi::Function rs_callback = info[0].As<Napi::Function>();
 	auto rs =

--- a/tools/nodejs/src/statement.cpp
+++ b/tools/nodejs/src/statement.cpp
@@ -93,11 +93,9 @@ Statement::Statement(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Statemen
 	int length = info.Length();
 
 	if (length <= 0 || !Connection::HasInstance(info[0])) {
-		Napi::TypeError::New(env, "Connection object expected").ThrowAsJavaScriptException();
-		return;
+		throw Napi::TypeError::New(env, "Connection object expected");
 	} else if (length <= 1 || !info[1].IsString()) {
-		Napi::TypeError::New(env, "SQL query expected").ThrowAsJavaScriptException();
-		return;
+		throw Napi::TypeError::New(env, "SQL query expected");
 	}
 
 	connection_ref = Napi::ObjectWrap<Connection>::Unwrap(info[0].As<Napi::Object>());

--- a/tools/nodejs/test/database_fail.test.ts
+++ b/tools/nodejs/test/database_fail.test.ts
@@ -2,6 +2,7 @@ import * as sqlite3 from '..';
 import * as assert from 'assert';
 import {DuckDbError, RowData} from "..";
 import {Worker} from 'worker_threads';
+import {expect} from 'chai';
 
 describe('error handling', function() {
     var db: sqlite3.Database;
@@ -163,4 +164,9 @@ describe('error handling', function() {
       await run_worker(); // first should always succeed
       await run_worker(); // second fails without thread safety
     })
+
+    it("shouldn't crash on an exception", () => {
+        expect(() => new sqlite3.Database(':memory:', {file_search_path: '/'})).to.throw('Could not set option "file_search_path" as a global option');
+    });
 });
+


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/5723

This mainly switches on the build-in CPP exception support in NAPI, though I'm not certain as to why it was turned off in the first place. Maybe @hannes can chime in?