### PR TITLE
[PythonDev] Improve `test_fetch_df_chunk.py`

### DIFF
--- a/tools/pythonpkg/tests/fast/pandas/test_fetch_df_chunk.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_fetch_df_chunk.py
@@ -1,65 +1,76 @@
 import pytest
 import duckdb
 
+VECTOR_SIZE = duckdb.__standard_vector_size__
+
 
 class TestType(object):
-    def test_fetch_df_chunk(self, duckdb_cursor):
-        duckdb_cursor.execute("CREATE table t as select range a from range(3000);")
-        query = duckdb_cursor.execute("SELECT a FROM t")
+    def test_fetch_df_chunk(self):
+        size = 3000
+        con = duckdb.connect()
+        con.execute(f"CREATE table t as select range a from range({size});")
+        query = con.execute("SELECT a FROM t")
+
+        # Fetch the first chunk
         cur_chunk = query.fetch_df_chunk()
         assert cur_chunk['a'][0] == 0
-        assert len(cur_chunk) == 2048
-        cur_chunk = query.fetch_df_chunk()
-        assert cur_chunk['a'][0] == 2048
-        assert len(cur_chunk) == 952
-        duckdb_cursor.execute("DROP TABLE t")
+        assert len(cur_chunk) == VECTOR_SIZE
 
-    def test_monahan(self, duckdb_cursor):
-        duckdb_cursor.execute("CREATE table t as select range a from range(3000);")
-        query = duckdb_cursor.execute("SELECT a FROM t")
+        # Fetch the second chunk, can't be entirely filled
         cur_chunk = query.fetch_df_chunk()
-        print(cur_chunk)
-        cur_chunk = query.fetch_df_chunk()
-        print(cur_chunk)
-        cur_chunk = query.fetch_df_chunk()
-        print(cur_chunk)
-        # Should be empty by now
-        try:
+        assert cur_chunk['a'][0] == VECTOR_SIZE
+        expected = size - VECTOR_SIZE
+        assert len(cur_chunk) == expected
+
+    @pytest.mark.parametrize('size', [3000, 10000, 100000, VECTOR_SIZE - 1, VECTOR_SIZE + 1, VECTOR_SIZE])
+    def test_monahan(self, size):
+        con = duckdb.connect()
+        con.execute(f"CREATE table t as select range a from range({size});")
+        query = con.execute("SELECT a FROM t")
+
+        processed = 0
+        expected_chunks = size // VECTOR_SIZE
+        if size % VECTOR_SIZE != 0:
+            expected_chunks += 1
+
+        for _ in range(expected_chunks):
+            expected_size = size - processed
+            if expected_size > VECTOR_SIZE:
+                expected_size = VECTOR_SIZE
             cur_chunk = query.fetch_df_chunk()
-            print(cur_chunk)
-        except Exception as err:
-            print(err)
+            assert len(cur_chunk) == expected_size
+            processed += expected_size
 
-        # Should be empty by now
-        try:
-            cur_chunk = query.fetch_df_chunk()
-            print(cur_chunk)
-        except Exception as err:
-            print(err)
-        duckdb_cursor.execute("DROP TABLE t")
+        cur_chunk = query.fetch_df_chunk()
+        assert len(cur_chunk) == 0
 
-    def test_fetch_df_chunk_parameter(self, duckdb_cursor):
-        duckdb_cursor.execute("CREATE table t as select range a from range(10000);")
-        query = duckdb_cursor.execute("SELECT a FROM t")
+    def test_fetch_df_chunk_parameter(self):
+        size = 10000
+        con = duckdb.connect()
+        con.execute(f"CREATE table t as select range a from range({size});")
+        query = con.execute("SELECT a FROM t")
 
         # Return 2 vectors
         cur_chunk = query.fetch_df_chunk(2)
         assert cur_chunk['a'][0] == 0
-        assert len(cur_chunk) == 4096
+        assert len(cur_chunk) == VECTOR_SIZE * 2
 
         # Return Default 1 vector
         cur_chunk = query.fetch_df_chunk()
-        assert cur_chunk['a'][0] == 4096
-        assert len(cur_chunk) == 2048
+        assert cur_chunk['a'][0] == VECTOR_SIZE * 2
+        assert len(cur_chunk) == VECTOR_SIZE
 
         # Return 0 vectors
         cur_chunk = query.fetch_df_chunk(0)
         assert len(cur_chunk) == 0
 
+        fetched = VECTOR_SIZE * 3
+        expected = size - fetched
+
         # Return more vectors than we have remaining
         cur_chunk = query.fetch_df_chunk(3)
-        assert cur_chunk['a'][0] == 6144
-        assert len(cur_chunk) == 3856
+        assert cur_chunk['a'][0] == fetched
+        assert len(cur_chunk) == expected
 
         # These shouldn't throw errors (Just emmit empty chunks)
         cur_chunk = query.fetch_df_chunk(100)
@@ -70,13 +81,12 @@ class TestType(object):
 
         cur_chunk = query.fetch_df_chunk()
         assert len(cur_chunk) == 0
-        duckdb_cursor.execute("DROP TABLE t")
 
-    def test_fetch_df_chunk_negative_parameter(self, duckdb_cursor):
-        duckdb_cursor.execute("CREATE table t as select range a from range(100);")
-        query = duckdb_cursor.execute("SELECT a FROM t")
+    def test_fetch_df_chunk_negative_parameter(self):
+        con = duckdb.connect()
+        con.execute("CREATE table t as select range a from range(100);")
+        query = con.execute("SELECT a FROM t")
 
         # Return -1 vector should not work
         with pytest.raises(TypeError, match='incompatible function arguments'):
             cur_chunk = query.fetch_df_chunk(-1)
-        duckdb_cursor.execute("DROP TABLE t")


### PR DESCRIPTION
1. Don't use `duckdb_cursor` (more and more I am motivated to fully remove it everywhere)
2. Use `duckdb.__standard_vector_size__`, future proof it
3. Use `mark.parametrize`, we can make the test easily cover more sizes