### PR TITLE
Serialize Create Table, Insert , Delete and Update operator using create info

### DIFF
--- a/src/include/duckdb/planner/operator/logical_create_table.hpp
+++ b/src/include/duckdb/planner/operator/logical_create_table.hpp
@@ -35,7 +35,6 @@ protected:
 	void ResolveTypes() override;
 
 private:
-	LogicalCreateTable(ClientContext &context, const string &catalog, const string &schema,
-	                   unique_ptr<CreateInfo> info);
+	LogicalCreateTable(ClientContext &context, unique_ptr<CreateInfo> info);
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_delete.hpp
+++ b/src/include/duckdb/planner/operator/logical_delete.hpp
@@ -37,6 +37,6 @@ protected:
 	void ResolveTypes() override;
 
 private:
-	LogicalDelete(ClientContext &context, const string &catalog, const string &schema, const string &table);
+	LogicalDelete(ClientContext &context, const unique_ptr<CreateInfo> &table_info);
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_insert.hpp
+++ b/src/include/duckdb/planner/operator/logical_insert.hpp
@@ -72,6 +72,6 @@ protected:
 	string GetName() const override;
 
 private:
-	LogicalInsert(ClientContext &context, const string &catalog, const string &schema, const string &table);
+	LogicalInsert(ClientContext &context, const unique_ptr<CreateInfo> table_info);
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/src/include/duckdb/planner/operator/logical_update.hpp
@@ -42,6 +42,6 @@ protected:
 	void ResolveTypes() override;
 
 private:
-	LogicalUpdate(ClientContext &context, const string &catalog, const string &schema, const string &table);
+	LogicalUpdate(ClientContext &context, const unique_ptr<CreateInfo> &table_info);
 };
 } // namespace duckdb

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -567,111 +567,99 @@
     "members": [
       {
         "id": 200,
-        "name": "catalog",
-        "type": "string",
-        "serialize_property": "table.ParentCatalog().GetName()"
+        "name": "table_info",
+        "type": "CreateInfo*",
+        "serialize_property": "table.GetInfo()"
       },
       {
         "id": 201,
-        "name": "schema",
-        "type": "string",
-        "serialize_property": "table.ParentSchema().name"
-      },
-      {
-        "id": 202,
-        "name": "table",
-        "type": "string",
-        "serialize_property": "table.name"
-      },
-      {
-        "id": 203,
         "name": "insert_values",
         "type": "vector<vector<Expression*>>"
       },
       {
-        "id": 204,
+        "id": 202,
         "name": "column_index_map",
         "type": "vector<idx_t>"
       },
       {
-        "id": 205,
+        "id": 203,
         "name": "expected_types",
         "type": "vector<LogicalType>"
       },
       {
-        "id": 206,
+        "id": 204,
         "name": "table_index",
         "type": "idx_t"
       },
       {
-        "id": 207,
+        "id": 205,
         "name": "return_chunk",
         "type": "bool"
       },
       {
-        "id": 208,
+        "id": 206,
         "name": "bound_defaults",
         "type": "vector<Expression*>"
       },
       {
-        "id": 209,
+        "id": 207,
         "name": "action_type",
         "type": "OnConflictAction"
       },
       {
-        "id": 210,
+        "id": 208,
         "name": "expected_set_types",
         "type": "vector<LogicalType>"
       },
       {
-        "id": 211,
+        "id": 209,
         "name": "on_conflict_filter",
         "type": "unordered_set<idx_t>"
       },
       {
-        "id": 212,
+        "id": 210,
         "name": "on_conflict_condition",
         "type": "Expression*",
         "optional": true
       },
       {
-        "id": 213,
+        "id": 211,
         "name": "do_update_condition",
         "type": "Expression*",
         "optional": true
       },
       {
-        "id": 214,
+        "id": 212,
         "name": "set_columns",
         "type": "vector<idx_t>"
       },
       {
-        "id": 215,
+        "id": 213,
         "name": "set_types",
         "type": "vector<LogicalType>"
       },
       {
-        "id": 216,
+        "id": 214,
         "name": "excluded_table_index",
         "type": "idx_t"
       },
       {
-        "id": 217,
+        "id": 215,
         "name": "columns_to_fetch",
         "type": "vector<column_t>"
       },
       {
-        "id": 218,
+        "id": 216,
         "name": "source_columns",
         "type": "vector<column_t>"
       },
       {
-        "id": 219,
+        "id": 217,
         "name": "expressions",
         "type": "vector<Expression*>"
       }
     ],
-    "constructor": ["$ClientContext", "catalog&", "schema&", "table&"]
+    "constructor": ["$ClientContext", "table_info"]
   },
   {
     "class": "LogicalDelete",
@@ -680,39 +668,27 @@
     "members": [
       {
         "id": 200,
-        "name": "catalog",
-        "type": "string",
-        "serialize_property": "table.ParentCatalog().GetName()"
+        "name": "table_info",
+        "type": "CreateInfo*",
+        "serialize_property": "table.GetInfo()"
       },
       {
         "id": 201,
-        "name": "schema",
-        "type": "string",
-        "serialize_property": "table.ParentSchema().name"
-      },
-      {
-        "id": 202,
-        "name": "table",
-        "type": "string",
-        "serialize_property": "table.name"
-      },
-      {
-        "id": 203,
         "name": "table_index",
         "type": "idx_t"
       },
       {
-        "id": 204,
+        "id": 202,
         "name": "return_chunk",
         "type": "bool"
       },
       {
-        "id": 205,
+        "id": 203,
         "name": "expressions",
         "type": "vector<Expression*>"
       }
     ],
-    "constructor": ["$ClientContext", "catalog&", "schema&", "table&"]
+    "constructor": ["$ClientContext", "table_info&"]
   },
   {
     "class": "LogicalUpdate",
@@ -721,54 +697,42 @@
     "members": [
       {
         "id": 200,
-        "name": "catalog",
-        "type": "string",
-        "serialize_property": "table.ParentCatalog().GetName()"
+        "name": "table_info",
+        "type": "CreateInfo*",
+        "serialize_property": "table.GetInfo()"
       },
       {
         "id": 201,
-        "name": "schema",
-        "type": "string",
-        "serialize_property": "table.ParentSchema().name"
-      },
-      {
-        "id": 202,
-        "name": "table",
-        "type": "string",
-        "serialize_property": "table.name"
-      },
-      {
-        "id": 203,
         "name": "table_index",
         "type": "idx_t"
       },
       {
-        "id": 204,
+        "id": 202,
         "name": "return_chunk",
         "type": "bool"
       },
       {
-        "id": 205,
+        "id": 203,
         "name": "expressions",
         "type": "vector<Expression*>"
       },
       {
-        "id": 206,
+        "id": 204,
         "name": "columns",
         "type": "vector<PhysicalIndex>"
       },
       {
-        "id": 207,
+        "id": 205,
         "name": "bound_defaults",
         "type": "vector<Expression*>"
       },
       {
-        "id": 208,
+        "id": 206,
         "name": "update_is_del_and_insert",
         "type": "bool"
       }
     ],
-    "constructor": ["$ClientContext", "catalog&", "schema&", "table&"]
+    "constructor": ["$ClientContext", "table_info&"]
   },
   {
     "class": "LogicalCreateTable",

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -777,24 +777,12 @@
     "members": [
       {
         "id": 200,
-        "name": "catalog",
-        "type": "string",
-        "serialize_property": "schema.ParentCatalog().GetName()"
-      },
-      {
-        "id": 201,
-        "name": "schema",
-        "type": "string",
-        "serialize_property": "schema.name"
-      },
-      {
-        "id": 202,
         "name": "info",
         "type": "CreateInfo*",
         "serialize_property": "info->base"
       }
     ],
-    "constructor": ["$ClientContext", "catalog&", "schema&", "info"]
+    "constructor": ["$ClientContext", "info"]
   },
   {
     "class": "LogicalCreate",

--- a/src/planner/operator/logical_create_table.cpp
+++ b/src/planner/operator/logical_create_table.cpp
@@ -6,9 +6,9 @@ LogicalCreateTable::LogicalCreateTable(SchemaCatalogEntry &schema, unique_ptr<Bo
     : LogicalOperator(LogicalOperatorType::LOGICAL_CREATE_TABLE), schema(schema), info(std::move(info)) {
 }
 
-LogicalCreateTable::LogicalCreateTable(ClientContext &context, const string &catalog, const string &schema,
-                                       unique_ptr<CreateInfo> unbound_info)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_CREATE_TABLE), schema(Catalog::GetSchema(context, catalog, schema)) {
+LogicalCreateTable::LogicalCreateTable(ClientContext &context, unique_ptr<CreateInfo> unbound_info)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_CREATE_TABLE),
+      schema(Catalog::GetSchema(context, unbound_info->catalog, unbound_info->schema)) {
 	D_ASSERT(unbound_info->type == CatalogType::TABLE_ENTRY);
 	auto binder = Binder::CreateBinder(context);
 	info = binder->BindCreateTableInfo(unique_ptr_cast<CreateInfo, CreateTableInfo>(std::move(unbound_info)));

--- a/src/planner/operator/logical_delete.cpp
+++ b/src/planner/operator/logical_delete.cpp
@@ -11,9 +11,10 @@ LogicalDelete::LogicalDelete(TableCatalogEntry &table, idx_t table_index)
       return_chunk(false) {
 }
 
-LogicalDelete::LogicalDelete(ClientContext &context, const string &catalog, const string &schema, const string &table)
+LogicalDelete::LogicalDelete(ClientContext &context, const unique_ptr<CreateInfo> &table_info)
     : LogicalOperator(LogicalOperatorType::LOGICAL_DELETE),
-      table(Catalog::GetEntry<TableCatalogEntry>(context, catalog, schema, table)) {
+      table(Catalog::GetEntry<TableCatalogEntry>(context, table_info->catalog, table_info->schema,
+                                                 dynamic_cast<CreateTableInfo &>(*table_info).table)) {
 }
 
 idx_t LogicalDelete::EstimateCardinality(ClientContext &context) {

--- a/src/planner/operator/logical_insert.cpp
+++ b/src/planner/operator/logical_insert.cpp
@@ -11,9 +11,10 @@ LogicalInsert::LogicalInsert(TableCatalogEntry &table, idx_t table_index)
       action_type(OnConflictAction::THROW) {
 }
 
-LogicalInsert::LogicalInsert(ClientContext &context, const string &catalog, const string &schema, const string &table)
+LogicalInsert::LogicalInsert(ClientContext &context, const unique_ptr<CreateInfo> table_info)
     : LogicalOperator(LogicalOperatorType::LOGICAL_INSERT),
-      table(Catalog::GetEntry<TableCatalogEntry>(context, catalog, schema, table)) {
+      table(Catalog::GetEntry<TableCatalogEntry>(context, table_info->catalog, table_info->schema,
+                                                 dynamic_cast<CreateTableInfo &>(*table_info).table)) {
 }
 
 idx_t LogicalInsert::EstimateCardinality(ClientContext &context) {

--- a/src/planner/operator/logical_update.cpp
+++ b/src/planner/operator/logical_update.cpp
@@ -9,9 +9,10 @@ LogicalUpdate::LogicalUpdate(TableCatalogEntry &table)
     : LogicalOperator(LogicalOperatorType::LOGICAL_UPDATE), table(table), table_index(0), return_chunk(false) {
 }
 
-LogicalUpdate::LogicalUpdate(ClientContext &context, const string &catalog, const string &schema, const string &table)
+LogicalUpdate::LogicalUpdate(ClientContext &context, const unique_ptr<CreateInfo> &table_info)
     : LogicalOperator(LogicalOperatorType::LOGICAL_UPDATE),
-      table(Catalog::GetEntry<TableCatalogEntry>(context, catalog, schema, table)) {
+      table(Catalog::GetEntry<TableCatalogEntry>(context, table_info->catalog, table_info->schema,
+                                                 dynamic_cast<CreateTableInfo &>(*table_info).table)) {
 }
 
 idx_t LogicalUpdate::EstimateCardinality(ClientContext &context) {

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -314,16 +314,12 @@ unique_ptr<LogicalOperator> LogicalCreateIndex::Deserialize(Deserializer &deseri
 
 void LogicalCreateTable::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
-	serializer.WriteProperty(200, "catalog", schema.ParentCatalog().GetName());
-	serializer.WriteProperty(201, "schema", schema.name);
-	serializer.WriteProperty(202, "info", info->base);
+	serializer.WriteProperty(200, "info", info->base);
 }
 
 unique_ptr<LogicalOperator> LogicalCreateTable::Deserialize(Deserializer &deserializer) {
-	auto catalog = deserializer.ReadProperty<string>(200, "catalog");
-	auto schema = deserializer.ReadProperty<string>(201, "schema");
-	auto info = deserializer.ReadProperty<unique_ptr<CreateInfo>>(202, "info");
-	auto result = duckdb::unique_ptr<LogicalCreateTable>(new LogicalCreateTable(deserializer.Get<ClientContext &>(), catalog, schema, std::move(info)));
+	auto info = deserializer.ReadProperty<unique_ptr<CreateInfo>>(200, "info");
+	auto result = duckdb::unique_ptr<LogicalCreateTable>(new LogicalCreateTable(deserializer.Get<ClientContext &>(), std::move(info)));
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -334,22 +334,18 @@ unique_ptr<LogicalOperator> LogicalCrossProduct::Deserialize(Deserializer &deser
 
 void LogicalDelete::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
-	serializer.WriteProperty(200, "catalog", table.ParentCatalog().GetName());
-	serializer.WriteProperty(201, "schema", table.ParentSchema().name);
-	serializer.WriteProperty(202, "table", table.name);
-	serializer.WriteProperty(203, "table_index", table_index);
-	serializer.WriteProperty(204, "return_chunk", return_chunk);
-	serializer.WriteProperty(205, "expressions", expressions);
+	serializer.WriteProperty(200, "table_info", table.GetInfo());
+	serializer.WriteProperty(201, "table_index", table_index);
+	serializer.WriteProperty(202, "return_chunk", return_chunk);
+	serializer.WriteProperty(203, "expressions", expressions);
 }
 
 unique_ptr<LogicalOperator> LogicalDelete::Deserialize(Deserializer &deserializer) {
-	auto catalog = deserializer.ReadProperty<string>(200, "catalog");
-	auto schema = deserializer.ReadProperty<string>(201, "schema");
-	auto table = deserializer.ReadProperty<string>(202, "table");
-	auto result = duckdb::unique_ptr<LogicalDelete>(new LogicalDelete(deserializer.Get<ClientContext &>(), catalog, schema, table));
-	deserializer.ReadProperty(203, "table_index", result->table_index);
-	deserializer.ReadProperty(204, "return_chunk", result->return_chunk);
-	deserializer.ReadProperty(205, "expressions", result->expressions);
+	auto table_info = deserializer.ReadProperty<unique_ptr<CreateInfo>>(200, "table_info");
+	auto result = duckdb::unique_ptr<LogicalDelete>(new LogicalDelete(deserializer.Get<ClientContext &>(), table_info));
+	deserializer.ReadProperty(201, "table_index", result->table_index);
+	deserializer.ReadProperty(202, "return_chunk", result->return_chunk);
+	deserializer.ReadProperty(203, "expressions", result->expressions);
 	return std::move(result);
 }
 
@@ -452,50 +448,46 @@ unique_ptr<LogicalOperator> LogicalFilter::Deserialize(Deserializer &deserialize
 
 void LogicalInsert::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
-	serializer.WriteProperty(200, "catalog", table.ParentCatalog().GetName());
-	serializer.WriteProperty(201, "schema", table.ParentSchema().name);
-	serializer.WriteProperty(202, "table", table.name);
-	serializer.WriteProperty(203, "insert_values", insert_values);
-	serializer.WriteProperty(204, "column_index_map", column_index_map);
-	serializer.WriteProperty(205, "expected_types", expected_types);
-	serializer.WriteProperty(206, "table_index", table_index);
-	serializer.WriteProperty(207, "return_chunk", return_chunk);
-	serializer.WriteProperty(208, "bound_defaults", bound_defaults);
-	serializer.WriteProperty(209, "action_type", action_type);
-	serializer.WriteProperty(210, "expected_set_types", expected_set_types);
-	serializer.WriteProperty(211, "on_conflict_filter", on_conflict_filter);
-	serializer.WritePropertyWithDefault(212, "on_conflict_condition", on_conflict_condition, unique_ptr<Expression>());
-	serializer.WritePropertyWithDefault(213, "do_update_condition", do_update_condition, unique_ptr<Expression>());
-	serializer.WriteProperty(214, "set_columns", set_columns);
-	serializer.WriteProperty(215, "set_types", set_types);
-	serializer.WriteProperty(216, "excluded_table_index", excluded_table_index);
-	serializer.WriteProperty(217, "columns_to_fetch", columns_to_fetch);
-	serializer.WriteProperty(218, "source_columns", source_columns);
-	serializer.WriteProperty(219, "expressions", expressions);
+	serializer.WriteProperty(200, "table_info", table.GetInfo());
+	serializer.WriteProperty(201, "insert_values", insert_values);
+	serializer.WriteProperty(202, "column_index_map", column_index_map);
+	serializer.WriteProperty(203, "expected_types", expected_types);
+	serializer.WriteProperty(204, "table_index", table_index);
+	serializer.WriteProperty(205, "return_chunk", return_chunk);
+	serializer.WriteProperty(206, "bound_defaults", bound_defaults);
+	serializer.WriteProperty(207, "action_type", action_type);
+	serializer.WriteProperty(208, "expected_set_types", expected_set_types);
+	serializer.WriteProperty(209, "on_conflict_filter", on_conflict_filter);
+	serializer.WritePropertyWithDefault(210, "on_conflict_condition", on_conflict_condition, unique_ptr<Expression>());
+	serializer.WritePropertyWithDefault(211, "do_update_condition", do_update_condition, unique_ptr<Expression>());
+	serializer.WriteProperty(212, "set_columns", set_columns);
+	serializer.WriteProperty(213, "set_types", set_types);
+	serializer.WriteProperty(214, "excluded_table_index", excluded_table_index);
+	serializer.WriteProperty(215, "columns_to_fetch", columns_to_fetch);
+	serializer.WriteProperty(216, "source_columns", source_columns);
+	serializer.WriteProperty(217, "expressions", expressions);
 }
 
 unique_ptr<LogicalOperator> LogicalInsert::Deserialize(Deserializer &deserializer) {
-	auto catalog = deserializer.ReadProperty<string>(200, "catalog");
-	auto schema = deserializer.ReadProperty<string>(201, "schema");
-	auto table = deserializer.ReadProperty<string>(202, "table");
-	auto result = duckdb::unique_ptr<LogicalInsert>(new LogicalInsert(deserializer.Get<ClientContext &>(), catalog, schema, table));
-	deserializer.ReadProperty(203, "insert_values", result->insert_values);
-	deserializer.ReadProperty(204, "column_index_map", result->column_index_map);
-	deserializer.ReadProperty(205, "expected_types", result->expected_types);
-	deserializer.ReadProperty(206, "table_index", result->table_index);
-	deserializer.ReadProperty(207, "return_chunk", result->return_chunk);
-	deserializer.ReadProperty(208, "bound_defaults", result->bound_defaults);
-	deserializer.ReadProperty(209, "action_type", result->action_type);
-	deserializer.ReadProperty(210, "expected_set_types", result->expected_set_types);
-	deserializer.ReadProperty(211, "on_conflict_filter", result->on_conflict_filter);
-	deserializer.ReadPropertyWithDefault(212, "on_conflict_condition", result->on_conflict_condition, unique_ptr<Expression>());
-	deserializer.ReadPropertyWithDefault(213, "do_update_condition", result->do_update_condition, unique_ptr<Expression>());
-	deserializer.ReadProperty(214, "set_columns", result->set_columns);
-	deserializer.ReadProperty(215, "set_types", result->set_types);
-	deserializer.ReadProperty(216, "excluded_table_index", result->excluded_table_index);
-	deserializer.ReadProperty(217, "columns_to_fetch", result->columns_to_fetch);
-	deserializer.ReadProperty(218, "source_columns", result->source_columns);
-	deserializer.ReadProperty(219, "expressions", result->expressions);
+	auto table_info = deserializer.ReadProperty<unique_ptr<CreateInfo>>(200, "table_info");
+	auto result = duckdb::unique_ptr<LogicalInsert>(new LogicalInsert(deserializer.Get<ClientContext &>(), std::move(table_info)));
+	deserializer.ReadProperty(201, "insert_values", result->insert_values);
+	deserializer.ReadProperty(202, "column_index_map", result->column_index_map);
+	deserializer.ReadProperty(203, "expected_types", result->expected_types);
+	deserializer.ReadProperty(204, "table_index", result->table_index);
+	deserializer.ReadProperty(205, "return_chunk", result->return_chunk);
+	deserializer.ReadProperty(206, "bound_defaults", result->bound_defaults);
+	deserializer.ReadProperty(207, "action_type", result->action_type);
+	deserializer.ReadProperty(208, "expected_set_types", result->expected_set_types);
+	deserializer.ReadProperty(209, "on_conflict_filter", result->on_conflict_filter);
+	deserializer.ReadPropertyWithDefault(210, "on_conflict_condition", result->on_conflict_condition, unique_ptr<Expression>());
+	deserializer.ReadPropertyWithDefault(211, "do_update_condition", result->do_update_condition, unique_ptr<Expression>());
+	deserializer.ReadProperty(212, "set_columns", result->set_columns);
+	deserializer.ReadProperty(213, "set_types", result->set_types);
+	deserializer.ReadProperty(214, "excluded_table_index", result->excluded_table_index);
+	deserializer.ReadProperty(215, "columns_to_fetch", result->columns_to_fetch);
+	deserializer.ReadProperty(216, "source_columns", result->source_columns);
+	deserializer.ReadProperty(217, "expressions", result->expressions);
 	return std::move(result);
 }
 
@@ -719,28 +711,24 @@ unique_ptr<LogicalOperator> LogicalUnnest::Deserialize(Deserializer &deserialize
 
 void LogicalUpdate::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
-	serializer.WriteProperty(200, "catalog", table.ParentCatalog().GetName());
-	serializer.WriteProperty(201, "schema", table.ParentSchema().name);
-	serializer.WriteProperty(202, "table", table.name);
-	serializer.WriteProperty(203, "table_index", table_index);
-	serializer.WriteProperty(204, "return_chunk", return_chunk);
-	serializer.WriteProperty(205, "expressions", expressions);
-	serializer.WriteProperty(206, "columns", columns);
-	serializer.WriteProperty(207, "bound_defaults", bound_defaults);
-	serializer.WriteProperty(208, "update_is_del_and_insert", update_is_del_and_insert);
+	serializer.WriteProperty(200, "table_info", table.GetInfo());
+	serializer.WriteProperty(201, "table_index", table_index);
+	serializer.WriteProperty(202, "return_chunk", return_chunk);
+	serializer.WriteProperty(203, "expressions", expressions);
+	serializer.WriteProperty(204, "columns", columns);
+	serializer.WriteProperty(205, "bound_defaults", bound_defaults);
+	serializer.WriteProperty(206, "update_is_del_and_insert", update_is_del_and_insert);
 }
 
 unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserializer) {
-	auto catalog = deserializer.ReadProperty<string>(200, "catalog");
-	auto schema = deserializer.ReadProperty<string>(201, "schema");
-	auto table = deserializer.ReadProperty<string>(202, "table");
-	auto result = duckdb::unique_ptr<LogicalUpdate>(new LogicalUpdate(deserializer.Get<ClientContext &>(), catalog, schema, table));
-	deserializer.ReadProperty(203, "table_index", result->table_index);
-	deserializer.ReadProperty(204, "return_chunk", result->return_chunk);
-	deserializer.ReadProperty(205, "expressions", result->expressions);
-	deserializer.ReadProperty(206, "columns", result->columns);
-	deserializer.ReadProperty(207, "bound_defaults", result->bound_defaults);
-	deserializer.ReadProperty(208, "update_is_del_and_insert", result->update_is_del_and_insert);
+	auto table_info = deserializer.ReadProperty<unique_ptr<CreateInfo>>(200, "table_info");
+	auto result = duckdb::unique_ptr<LogicalUpdate>(new LogicalUpdate(deserializer.Get<ClientContext &>(), table_info));
+	deserializer.ReadProperty(201, "table_index", result->table_index);
+	deserializer.ReadProperty(202, "return_chunk", result->return_chunk);
+	deserializer.ReadProperty(203, "expressions", result->expressions);
+	deserializer.ReadProperty(204, "columns", result->columns);
+	deserializer.ReadProperty(205, "bound_defaults", result->bound_defaults);
+	deserializer.ReadProperty(206, "update_is_del_and_insert", result->update_is_del_and_insert);
 	return std::move(result);
 }
 


### PR DESCRIPTION
This PR restores the previous behavior of using the create info field to capture the catalog and schema references. It help extension catalog to integrate into the serialization logic.