### PR TITLE
Adding enable_verification to list_sort test and fixing bug

### DIFF
--- a/src/core_functions/scalar/list/list_sort.cpp
+++ b/src/core_functions/scalar/list/list_sort.cpp
@@ -236,9 +236,18 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 static unique_ptr<FunctionData> ListSortBind(ClientContext &context, ScalarFunction &bound_function,
                                              vector<unique_ptr<Expression>> &arguments, OrderType &order,
                                              OrderByNullType &null_order) {
+
+	LogicalType child_type;
+	if (arguments[0]->return_type == LogicalTypeId::UNKNOWN) {
+		bound_function.arguments[0] = LogicalTypeId::UNKNOWN;
+		bound_function.return_type = LogicalType::SQLNULL;
+		child_type = bound_function.return_type;
+		return make_uniq<ListSortBindData>(order, null_order, bound_function.return_type, child_type, context);
+	}
+
 	bound_function.arguments[0] = arguments[0]->return_type;
 	bound_function.return_type = arguments[0]->return_type;
-	auto child_type = ListType::GetChildType(arguments[0]->return_type);
+	child_type = ListType::GetChildType(arguments[0]->return_type);
 
 	return make_uniq<ListSortBindData>(order, null_order, bound_function.return_type, child_type, context);
 }

--- a/test/sql/function/list/list_sort.test
+++ b/test/sql/function/list/list_sort.test
@@ -3,6 +3,9 @@
 # group: [list]
 
 statement ok
+PRAGMA enable_verification;
+
+statement ok
 PRAGMA default_order='ASC';
 
 statement ok


### PR DESCRIPTION
@cryoEncryp found that the `list_sort` tests don't pass with `PRAGMA enable_verification`. This fix adds the pragma to `list_sort.test` and fixes an issue with `UNKOWN`/prepared parameters.