### PR TITLE
Add ToString and Print method for JoinRelationSetManager and Fix JoinNode Print

### DIFF
--- a/src/include/duckdb/optimizer/join_order/join_node.hpp
+++ b/src/include/duckdb/optimizer/join_order/join_node.hpp
@@ -46,7 +46,7 @@ public:
 
 private:
 public:
-	void PrintJoinNode();
+	void Print();
 	string ToString();
 };
 

--- a/src/include/duckdb/optimizer/join_order/join_relation.hpp
+++ b/src/include/duckdb/optimizer/join_order/join_relation.hpp
@@ -49,6 +49,8 @@ public:
 	JoinRelationSet &Union(JoinRelationSet &left, JoinRelationSet &right);
 	// //! Create the set difference of left \ right (i.e. all elements in left that are not in right)
 	// JoinRelationSet *Difference(JoinRelationSet *left, JoinRelationSet *right);
+	string ToString() const;
+	void Print();
 
 private:
 	JoinRelationTreeNode root;

--- a/src/optimizer/join_order/join_node.cpp
+++ b/src/optimizer/join_order/join_node.cpp
@@ -33,4 +33,8 @@ string JoinNode::ToString() {
 	return result;
 }
 
+void JoinNode::Print() {
+	Printer::Print(ToString());
+}
+
 } // namespace duckdb

--- a/src/optimizer/join_order/join_relation_set.cpp
+++ b/src/optimizer/join_order/join_relation_set.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/optimizer/join_order/join_relation.hpp"
+#include "duckdb/common/printer.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 
@@ -138,5 +139,24 @@ JoinRelationSet &JoinRelationSetManager::Union(JoinRelationSet &left, JoinRelati
 // 	}
 // 	return GetJoinRelation(std::move(relations), count);
 // }
+
+static string JoinRelationTreeNodeToString(const JoinRelationTreeNode *node) {
+	string result = "";
+	if (node->relation) {
+		result += node->relation.get()->ToString() + "\n";
+	}
+	for (auto &child : node->children) {
+		result += JoinRelationTreeNodeToString(child.second.get());
+	}
+	return result;
+}
+
+string JoinRelationSetManager::ToString() const {
+	return JoinRelationTreeNodeToString(&root);
+}
+
+void JoinRelationSetManager::Print() {
+	Printer::Print(ToString());
+}
 
 } // namespace duckdb


### PR DESCRIPTION
1.When we want to debug JoinRelationSetManager., we need to add the ToString and Print method.

for example: explain SELECT    COUNT(*)  FROM    t1, t2, t3, t4  WHERE    t1.c1 = t2.c1 AND    t2.c2 = t3.c2 AND    t3.c3 = t4.c3 ;

set_manager.Print();

will output:

```
child: 0
  relation: [0]
  child: 1
      relation: [0, 1]
child: 1
  relation: [1]
  child: 2
      relation: [1, 2]
child: 3
  relation: [3]
child: 2
  relation: [2]
  child: 3
      relation: [2, 3]
```

2.Change PrintJoinNode to Print and implement it.