### PR TITLE
[PythonDev] Avoid `pybind11::error_already_set::what()` in certain paths

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -101,9 +101,10 @@ py::object ArrowTableFromDataframe(const py::object &df) {
 	try {
 		return py::module_::import("pyarrow").attr("lib").attr("Table").attr("from_pandas")(df);
 	} catch (py::error_already_set &e) {
+		// We don't fetch the original python exception because it can cause a segfault
+		// The cause of this is not known yet, for now we just side-step the issue.
 		throw InvalidInputException(
-		    "The dataframe could not be converted to a pyarrow.lib.Table, due to the following python exception: %s",
-		    e.what());
+		    "The dataframe could not be converted to a pyarrow.lib.Table, because a python exception occurred.");
 	}
 }
 

--- a/tools/pythonpkg/src/typing/typing.cpp
+++ b/tools/pythonpkg/src/typing/typing.cpp
@@ -4,37 +4,37 @@
 namespace duckdb {
 
 static void DefineBaseTypes(py::handle &m) {
-	m.attr("SQLNULL") = DuckDBPyType(LogicalType::SQLNULL);
-	m.attr("BOOLEAN") = DuckDBPyType(LogicalType::BOOLEAN);
-	m.attr("TINYINT") = DuckDBPyType(LogicalType::TINYINT);
-	m.attr("UTINYINT") = DuckDBPyType(LogicalType::UTINYINT);
-	m.attr("SMALLINT") = DuckDBPyType(LogicalType::SMALLINT);
-	m.attr("USMALLINT") = DuckDBPyType(LogicalType::USMALLINT);
-	m.attr("INTEGER") = DuckDBPyType(LogicalType::INTEGER);
-	m.attr("UINTEGER") = DuckDBPyType(LogicalType::UINTEGER);
-	m.attr("BIGINT") = DuckDBPyType(LogicalType::BIGINT);
-	m.attr("UBIGINT") = DuckDBPyType(LogicalType::UBIGINT);
-	m.attr("HUGEINT") = DuckDBPyType(LogicalType::HUGEINT);
-	m.attr("UUID") = DuckDBPyType(LogicalType::UUID);
-	m.attr("FLOAT") = DuckDBPyType(LogicalType::FLOAT);
-	m.attr("DOUBLE") = DuckDBPyType(LogicalType::DOUBLE);
-	m.attr("DATE") = DuckDBPyType(LogicalType::DATE);
+	m.attr("SQLNULL") = make_shared<DuckDBPyType>(LogicalType::SQLNULL);
+	m.attr("BOOLEAN") = make_shared<DuckDBPyType>(LogicalType::BOOLEAN);
+	m.attr("TINYINT") = make_shared<DuckDBPyType>(LogicalType::TINYINT);
+	m.attr("UTINYINT") = make_shared<DuckDBPyType>(LogicalType::UTINYINT);
+	m.attr("SMALLINT") = make_shared<DuckDBPyType>(LogicalType::SMALLINT);
+	m.attr("USMALLINT") = make_shared<DuckDBPyType>(LogicalType::USMALLINT);
+	m.attr("INTEGER") = make_shared<DuckDBPyType>(LogicalType::INTEGER);
+	m.attr("UINTEGER") = make_shared<DuckDBPyType>(LogicalType::UINTEGER);
+	m.attr("BIGINT") = make_shared<DuckDBPyType>(LogicalType::BIGINT);
+	m.attr("UBIGINT") = make_shared<DuckDBPyType>(LogicalType::UBIGINT);
+	m.attr("HUGEINT") = make_shared<DuckDBPyType>(LogicalType::HUGEINT);
+	m.attr("UUID") = make_shared<DuckDBPyType>(LogicalType::UUID);
+	m.attr("FLOAT") = make_shared<DuckDBPyType>(LogicalType::FLOAT);
+	m.attr("DOUBLE") = make_shared<DuckDBPyType>(LogicalType::DOUBLE);
+	m.attr("DATE") = make_shared<DuckDBPyType>(LogicalType::DATE);
 
-	m.attr("TIMESTAMP") = DuckDBPyType(LogicalType::TIMESTAMP);
-	m.attr("TIMESTAMP_MS") = DuckDBPyType(LogicalType::TIMESTAMP_MS);
-	m.attr("TIMESTAMP_NS") = DuckDBPyType(LogicalType::TIMESTAMP_NS);
-	m.attr("TIMESTAMP_S") = DuckDBPyType(LogicalType::TIMESTAMP_S);
+	m.attr("TIMESTAMP") = make_shared<DuckDBPyType>(LogicalType::TIMESTAMP);
+	m.attr("TIMESTAMP_MS") = make_shared<DuckDBPyType>(LogicalType::TIMESTAMP_MS);
+	m.attr("TIMESTAMP_NS") = make_shared<DuckDBPyType>(LogicalType::TIMESTAMP_NS);
+	m.attr("TIMESTAMP_S") = make_shared<DuckDBPyType>(LogicalType::TIMESTAMP_S);
 
-	m.attr("TIME") = DuckDBPyType(LogicalType::TIME);
+	m.attr("TIME") = make_shared<DuckDBPyType>(LogicalType::TIME);
 
-	m.attr("TIME_TZ") = DuckDBPyType(LogicalType::TIME_TZ);
-	m.attr("TIMESTAMP_TZ") = DuckDBPyType(LogicalType::TIMESTAMP_TZ);
+	m.attr("TIME_TZ") = make_shared<DuckDBPyType>(LogicalType::TIME_TZ);
+	m.attr("TIMESTAMP_TZ") = make_shared<DuckDBPyType>(LogicalType::TIMESTAMP_TZ);
 
-	m.attr("VARCHAR") = DuckDBPyType(LogicalType::VARCHAR);
+	m.attr("VARCHAR") = make_shared<DuckDBPyType>(LogicalType::VARCHAR);
 
-	m.attr("BLOB") = DuckDBPyType(LogicalType::BLOB);
-	m.attr("BIT") = DuckDBPyType(LogicalType::BIT);
-	m.attr("INTERVAL") = DuckDBPyType(LogicalType::INTERVAL);
+	m.attr("BLOB") = make_shared<DuckDBPyType>(LogicalType::BLOB);
+	m.attr("BIT") = make_shared<DuckDBPyType>(LogicalType::BIT);
+	m.attr("INTERVAL") = make_shared<DuckDBPyType>(LogicalType::INTERVAL);
 }
 
 void DuckDBPyTyping::Initialize(py::module_ &parent) {

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_arrow.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_arrow.py
@@ -36,7 +36,7 @@ class TestPandasArrow(object):
         )
         pyarrow_df = df.convert_dtypes(dtype_backend='pyarrow')
         con = duckdb.connect()
-        with pytest.raises(duckdb.InvalidInputException, match='Conversion failed for column objects with type object'):
+        with pytest.raises(duckdb.InvalidInputException, match='The dataframe could not be converted to a pyarrow.lib.Table'):
             res = con.sql('select * from pyarrow_df').fetchall()
 
         numpy_df = pd.DataFrame(
@@ -61,7 +61,7 @@ class TestPandasArrow(object):
         assert isinstance(df.dtypes['arrow'], pd.ArrowDtype)
         assert isinstance(df.dtypes['python'], np.dtype('O').__class__)
 
-        with pytest.raises(duckdb.InvalidInputException, match='Conversion failed for column python with type object'):
+        with pytest.raises(duckdb.InvalidInputException, match='The dataframe could not be converted to a pyarrow.lib.Table'):
             res = con.sql('select * from df').fetchall()
 
     def test_empty_df(self):

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_arrow.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_arrow.py
@@ -36,7 +36,9 @@ class TestPandasArrow(object):
         )
         pyarrow_df = df.convert_dtypes(dtype_backend='pyarrow')
         con = duckdb.connect()
-        with pytest.raises(duckdb.InvalidInputException, match='The dataframe could not be converted to a pyarrow.lib.Table'):
+        with pytest.raises(
+            duckdb.InvalidInputException, match='The dataframe could not be converted to a pyarrow.lib.Table'
+        ):
             res = con.sql('select * from pyarrow_df').fetchall()
 
         numpy_df = pd.DataFrame(
@@ -61,7 +63,9 @@ class TestPandasArrow(object):
         assert isinstance(df.dtypes['arrow'], pd.ArrowDtype)
         assert isinstance(df.dtypes['python'], np.dtype('O').__class__)
 
-        with pytest.raises(duckdb.InvalidInputException, match='The dataframe could not be converted to a pyarrow.lib.Table'):
+        with pytest.raises(
+            duckdb.InvalidInputException, match='The dataframe could not be converted to a pyarrow.lib.Table'
+        ):
             res = con.sql('select * from df').fetchall()
 
     def test_empty_df(self):


### PR DESCRIPTION
On linux, python3.11 with pyarrow 13.0.0 and pandas 2.1.1 this causes a segfault.

Likely something is messed up on their side.

The culprit that caused the segfault is a frankenstein dataframe consisting of numpy, pandas and pyarrow columns.
```py
        df = pd.concat([numpy_df['a'], arrow_df['a'], python_df['a']], axis=1, keys=['numpy', 'arrow', 'python'])
        assert is_integer_dtype(df.dtypes['numpy'])
        assert isinstance(df.dtypes['arrow'], pd.ArrowDtype)
        assert isinstance(df.dtypes['python'], np.dtype('O').__class__)

        with pytest.raises(duckdb.InvalidInputException, match='The dataframe could not be converted to a pyarrow.lib.Table'):
            res = con.sql('select * from df').fetchall()
```
While attempting to create the exception we expect this caused a segfault in the python Exception API, so something is likely corrupted.