### PR TITLE
Make versions are `vX.Y.Z`

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -275,11 +275,11 @@ def git_dev_version():
         dev_version = long_version.split('-')[1]
         if int(dev_version) == 0:
             # directly on a tag: emit the regular version
-            return '.'.join(version_splits)
+            return "v" + '.'.join(version_splits)
         else:
             # not on a tag: increment the version by one and add a -devX suffix
             version_splits[2] = str(int(version_splits[2]) + 1)
-            return '.'.join(version_splits) + "-dev" + dev_version
+            return "v" + '.'.join(version_splits) + "-dev" + dev_version
     except:
         return "0.0.0"
 

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -134,10 +134,15 @@ def git_commit_hash():
     except:
         return "deadbeeff"
 
+def prefix_version(version):
+    """ Make sure the version is prefixed with 'v' to be of the form vX.Y.Z """
+    if version.startswith('v'):
+        return version
+    return 'v' + version
 
 def git_dev_version():
     if 'SETUPTOOLS_SCM_PRETEND_VERSION' in os.environ:
-        return os.environ['SETUPTOOLS_SCM_PRETEND_VERSION']
+        return prefix_version(os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'])
     try:
         version = subprocess.check_output(['git', 'describe', '--tags', '--abbrev=0']).strip().decode('utf8')
         long_version = subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
@@ -145,11 +150,11 @@ def git_dev_version():
         dev_version = long_version.split('-')[1]
         if int(dev_version) == 0:
             # directly on a tag: emit the regular version
-            return '.'.join(version_splits)
+            return "v" + '.'.join(version_splits)
         else:
             # not on a tag: increment the version by one and add a -devX suffix
             version_splits[2] = str(int(version_splits[2]) + 1)
-            return '.'.join(version_splits) + "-dev" + dev_version
+            return "v" + '.'.join(version_splits) + "-dev" + dev_version
     except:
         return "0.0.0"
 


### PR DESCRIPTION
DuckDB reports its version differently depending on the platform:

CLI is `vX.Y.Z`:
```
D PRAGMA version;
┌─────────────────┬────────────┐
│ library_version │ source_id  │
│     varchar     │  varchar   │
├─────────────────┼────────────┤
│ v0.8.1          │ 6536a77232 │
└─────────────────┴────────────┘
```

While Python is `X.Y.Z`:
```
>>> import duckdb
>>> duckdb.__version__
'0.8.1'
```

(basically what is fed to `DuckDB::LibraryVersion` [here](https://github.com/duckdb/duckdb/blob/e07b94a7485689cf3a29ab33939bc247b555781a/src/function/table/version/pragma_version.cpp#L57))

This PR makes it more consistent and ensures a version is always of the form `vX.Y.Z`.

Hopefully this is the right way to fix it, if not let me know what the best way to do it?

Thanks!!