### PR TITLE
Internal 358: Quantile Value Extraction

### DIFF
--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -288,12 +288,40 @@ struct QuantileCompare {
 	}
 };
 
+//	Avoid using naked Values in inner loops...
+struct QuantileValue {
+	explicit QuantileValue(const Value &v) : val(v), dbl(v.GetValue<double>()) {
+		const auto &type = val.type();
+		switch (type.id()) {
+		case LogicalTypeId::DECIMAL: {
+			integral = IntegralValue::Get(v);
+			scaling = Hugeint::POWERS_OF_TEN[DecimalType::GetScale(type)];
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	Value val;
+
+	//	DOUBLE
+	double dbl;
+
+	//	DECIMAL
+	hugeint_t integral;
+	hugeint_t scaling;
+};
+
+bool operator==(const QuantileValue &x, const QuantileValue &y) {
+	return x.val == y.val;
+}
+
 // Continuous interpolation
 template <bool DISCRETE>
 struct Interpolator {
-	Interpolator(const Value &q, const idx_t n_p, const bool desc_p)
-	    : desc(desc_p), RN((double)(n_p - 1) * q.GetValue<double>()), FRN(floor(RN)), CRN(ceil(RN)), begin(0),
-	      end(n_p) {
+	Interpolator(const QuantileValue &q, const idx_t n_p, const bool desc_p)
+	    : desc(desc_p), RN((double)(n_p - 1) * q.dbl), FRN(floor(RN)), CRN(ceil(RN)), begin(0), end(n_p) {
 	}
 
 	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
@@ -336,21 +364,20 @@ struct Interpolator {
 // Discrete "interpolation"
 template <>
 struct Interpolator<true> {
-	static inline idx_t Index(const Value &q, const idx_t n) {
+	static inline idx_t Index(const QuantileValue &q, const idx_t n) {
 		idx_t floored;
-		const auto &type = q.type();
-		switch (type.id()) {
+		switch (q.val.type().id()) {
 		case LogicalTypeId::DECIMAL: {
 			//	Integer arithmetic for accuracy
-			const auto integral = IntegralValue::Get(q);
-			const auto scaling = Hugeint::POWERS_OF_TEN[DecimalType::GetScale(type)];
+			const auto integral = q.integral;
+			const auto scaling = q.scaling;
 			const auto scaled_q = DecimalMultiplyOverflowCheck::Operation<hugeint_t, hugeint_t, hugeint_t>(n, integral);
 			const auto scaled_n = DecimalMultiplyOverflowCheck::Operation<hugeint_t, hugeint_t, hugeint_t>(n, scaling);
 			floored = Cast::Operation<hugeint_t, idx_t>((scaled_n - scaled_q) / scaling);
 			break;
 		}
 		default:
-			const auto scaled_q = (double)(n * q.GetValue<double>());
+			const auto scaled_q = (double)(n * q.dbl);
 			floored = floor(n - scaled_q);
 			break;
 		}
@@ -358,7 +385,7 @@ struct Interpolator<true> {
 		return MaxValue<idx_t>(1, n - floored) - 1;
 	}
 
-	Interpolator(const Value &q, const idx_t n_p, bool desc_p)
+	Interpolator(const QuantileValue &q, const idx_t n_p, bool desc_p)
 	    : desc(desc_p), FRN(Index(q, n_p)), CRN(FRN), begin(0), end(n_p) {
 	}
 
@@ -420,17 +447,18 @@ struct QuantileBindData : public FunctionData {
 	}
 
 	explicit QuantileBindData(const Value &quantile_p)
-	    : quantiles(1, QuantileAbs(quantile_p)), order(1, 0), desc(quantile_p < 0) {
+	    : quantiles(1, QuantileValue(QuantileAbs(quantile_p))), order(1, 0), desc(quantile_p < 0) {
 	}
 
 	explicit QuantileBindData(const vector<Value> &quantiles_p) {
+		vector<Value> normalised;
 		size_t pos = 0;
 		size_t neg = 0;
 		for (idx_t i = 0; i < quantiles_p.size(); ++i) {
 			const auto &q = quantiles_p[i];
 			pos += (q > 0);
 			neg += (q < 0);
-			quantiles.emplace_back(QuantileAbs(q));
+			normalised.emplace_back(QuantileAbs(q));
 			order.push_back(i);
 		}
 		if (pos && neg) {
@@ -438,8 +466,12 @@ struct QuantileBindData : public FunctionData {
 		}
 		desc = (neg > 0);
 
-		IndirectLess<Value> lt(quantiles.data());
+		IndirectLess<Value> lt(normalised.data());
 		std::sort(order.begin(), order.end(), lt);
+
+		for (const auto &q : normalised) {
+			quantiles.emplace_back(QuantileValue(q));
+		}
 	}
 
 	QuantileBindData(const QuantileBindData &other) : order(other.order), desc(other.desc) {
@@ -460,16 +492,24 @@ struct QuantileBindData : public FunctionData {
 	static void Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
 	                      const AggregateFunction &function) {
 		auto &bind_data = bind_data_p->Cast<QuantileBindData>();
-		serializer.WriteProperty(100, "quantiles", bind_data.quantiles);
+		vector<Value> raw;
+		for (const auto &q : bind_data.quantiles) {
+			raw.emplace_back(q.val);
+		}
+		serializer.WriteProperty(100, "quantiles", raw);
 		serializer.WriteProperty(101, "order", bind_data.order);
 		serializer.WriteProperty(102, "desc", bind_data.desc);
 	}
 
 	static unique_ptr<FunctionData> Deserialize(Deserializer &deserializer, AggregateFunction &function) {
 		auto result = make_uniq<QuantileBindData>();
-		deserializer.ReadProperty(100, "quantiles", result->quantiles);
+		vector<Value> raw;
+		deserializer.ReadProperty(100, "quantiles", raw);
 		deserializer.ReadProperty(101, "order", result->order);
 		deserializer.ReadProperty(102, "desc", result->desc);
+		for (const auto &r : raw) {
+			result->quantiles.emplace_back(QuantileValue(r));
+		}
 		return std::move(result);
 	}
 
@@ -478,7 +518,7 @@ struct QuantileBindData : public FunctionData {
 		throw NotImplementedException("FIXME: serializing quantiles with decimals is not supported right now");
 	}
 
-	vector<Value> quantiles;
+	vector<QuantileValue> quantiles;
 	vector<idx_t> order;
 	bool desc;
 };
@@ -566,7 +606,7 @@ struct QuantileScalarOperation : public QuantileOperation {
 		auto &bind_data = aggr_input_data.bind_data->Cast<QuantileBindData>();
 
 		// Find the two positions needed
-		const auto q = bind_data.quantiles[0];
+		const auto &q = bind_data.quantiles[0];
 
 		bool replace = false;
 		if (frame.start == prev.start + 1 && frame.end == prev.end + 1) {
@@ -1041,7 +1081,11 @@ struct MedianAbsoluteDeviationOperation : public QuantileOperation {
 			return;
 		}
 		using SAVE_TYPE = typename STATE::SaveType;
-		Interpolator<false> interp(0.5, state.v.size(), false);
+		D_ASSERT(finalize_data.input.bind_data);
+		auto &bind_data = finalize_data.input.bind_data->Cast<QuantileBindData>();
+		D_ASSERT(bind_data.quantiles.size() == 1);
+		const auto &q = bind_data.quantiles[0];
+		Interpolator<false> interp(q, state.v.size(), false);
 		const auto med = interp.template Operation<SAVE_TYPE, MEDIAN_TYPE>(state.v.data(), finalize_data.result);
 
 		MadAccessor<SAVE_TYPE, T, MEDIAN_TYPE> accessor(med);
@@ -1050,8 +1094,8 @@ struct MedianAbsoluteDeviationOperation : public QuantileOperation {
 
 	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
 	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
-	                   AggregateInputData &, STATE &state, const FrameBounds &frame, const FrameBounds &prev,
-	                   Vector &result, idx_t ridx, idx_t bias) {
+	                   AggregateInputData &aggr_input_data, STATE &state, const FrameBounds &frame,
+	                   const FrameBounds &prev, Vector &result, idx_t ridx, idx_t bias) {
 		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
 		auto &rmask = FlatVector::Validity(result);
 
@@ -1079,7 +1123,10 @@ struct MedianAbsoluteDeviationOperation : public QuantileOperation {
 		std::partition(index2, index2 + state.pos, included);
 
 		// Find the two positions needed for the median
-		const float q = 0.5;
+		D_ASSERT(aggr_input_data.bind_data);
+		auto &bind_data = aggr_input_data.bind_data->Cast<QuantileBindData>();
+		D_ASSERT(bind_data.quantiles.size() == 1);
+		const auto &q = bind_data.quantiles[0];
 
 		bool replace = false;
 		if (frame.start == prev.start + 1 && frame.end == prev.end + 1) {
@@ -1124,12 +1171,18 @@ struct MedianAbsoluteDeviationOperation : public QuantileOperation {
 	}
 };
 
+unique_ptr<FunctionData> BindMedian(ClientContext &context, AggregateFunction &function,
+                                    vector<unique_ptr<Expression>> &arguments) {
+	return make_uniq<QuantileBindData>(Value::DECIMAL(int16_t(5), 2, 1));
+}
+
 template <typename INPUT_TYPE, typename MEDIAN_TYPE, typename TARGET_TYPE>
 AggregateFunction GetTypedMedianAbsoluteDeviationAggregateFunction(const LogicalType &input_type,
                                                                    const LogicalType &target_type) {
 	using STATE = QuantileState<INPUT_TYPE>;
 	using OP = MedianAbsoluteDeviationOperation<MEDIAN_TYPE>;
 	auto fun = AggregateFunction::UnaryAggregateDestructor<STATE, INPUT_TYPE, TARGET_TYPE, OP>(input_type, target_type);
+	fun.bind = BindMedian;
 	fun.order_dependent = AggregateOrderDependent::NOT_ORDER_DEPENDENT;
 	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, TARGET_TYPE, OP>;
 	return fun;
@@ -1173,11 +1226,6 @@ AggregateFunction GetMedianAbsoluteDeviationAggregateFunction(const LogicalType 
 	}
 }
 
-unique_ptr<FunctionData> BindMedian(ClientContext &context, AggregateFunction &function,
-                                    vector<unique_ptr<Expression>> &arguments) {
-	return make_uniq<QuantileBindData>(Value::DECIMAL(int16_t(5), 2, 1));
-}
-
 unique_ptr<FunctionData> BindMedianDecimal(ClientContext &context, AggregateFunction &function,
                                            vector<unique_ptr<Expression>> &arguments) {
 	auto bind_data = BindMedian(context, function, arguments);
@@ -1195,7 +1243,7 @@ unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(ClientContext &conte
 	function = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->return_type);
 	function.name = "mad";
 	function.order_dependent = AggregateOrderDependent::NOT_ORDER_DEPENDENT;
-	return nullptr;
+	return BindMedian(context, function, arguments);
 }
 
 static const Value &CheckQuantile(const Value &quantile_val) {


### PR DESCRIPTION
Extract the relevant parts of the QUANTILE values at bind time. This was taking 50+% of the per row run time.
Also add binding to MAD so it doesn't have to construct 0.5 every time.

fixes: duckdblabs/duckdb-internal#358