### PR TITLE
Enable allow-noblas for numpy install in CI

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -170,7 +170,9 @@ jobs:
 
     - name: Install
       shell: bash
-      run: pip install cibuildwheel twine
+      run: |
+        pip install cibuildwheel twine
+        python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"
 
     - uses: actions/download-artifact@v3
       if: ${{ matrix.arch == 'x86_64' }}


### PR DESCRIPTION
On certain platforms we build the Python client for in CI there are no BLAS libraries available. NumPy throws an error in that case if this setting is not set. We don't care if there is a BLAS library available or not since we only install NumPy for testing/deployment purposes.

See [here](https://github.com/numpy/numpy/issues/24703) for more context