### PR TITLE
Skip a few tests and move tests to slow

### DIFF
--- a/scripts/test_zero_initialize.py
+++ b/scripts/test_zero_initialize.py
@@ -21,7 +21,6 @@ parser.add_argument(
 args = parser.parse_args()
 
 test_list = [
-    'test/sql/index/art/storage/test_art_checkpoint.test',
     'test/sql/storage/compression/simple_compression.test',
     'test/sql/storage/test_store_deletes.test',
     'test/sql/storage/test_store_nulls_strings.test',

--- a/test/parallel_csv/test_parallel_csv.cpp
+++ b/test/parallel_csv/test_parallel_csv.cpp
@@ -192,6 +192,7 @@ TEST_CASE("Test Parallel CSV All Files - test/sql/copy/csv/data/real", "[paralle
 }
 
 TEST_CASE("Test Parallel CSV All Files - test/sql/copy/csv/data/test", "[parallel-csv][.]") {
+	return;
 	std::set<std::string> skip;
 	// This file requires additional parameters, we test it on the following test.
 	skip.insert("test/sql/copy/csv/data/test/5438.csv");

--- a/test/sql/aggregate/aggregates/test_list_aggregate_function.test_slow
+++ b/test/sql/aggregate/aggregates/test_list_aggregate_function.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/aggregate/aggregates/test_list_aggregate_function.test
+# name: test/sql/aggregate/aggregates/test_list_aggregate_function.test_slow
 # description: Test the list aggregate function for all data types
 # group: [aggregates]
 

--- a/test/sql/index/art/issues/test_art_issue_8066.test_slow
+++ b/test/sql/index/art/issues/test_art_issue_8066.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/index/art/issues/test_art_issue_8066.test
+# name: test/sql/index/art/issues/test_art_issue_8066.test_slow
 # description: Test CREATE INDEX on a lot of duplicate values with a persistent DB
 # group: [issues]
 


### PR DESCRIPTION
Broken tests:
* Zero-initialize ART test is not actually broken but storage here is non-deterministic for some reason - have to investigate more but can be skipped for now
* Parallel CSV tests are failing sporadically (CC @pdet)