### PR TITLE
Add callback that can be registered for when a new extension is loaded

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -39,6 +39,7 @@ class CompressionFunction;
 class TableFunctionRef;
 class OperatorExtension;
 class StorageExtension;
+class ExtensionCallback;
 
 struct CompressionFunctionSet;
 struct DBConfig;
@@ -212,6 +213,8 @@ public:
 	case_insensitive_map_t<duckdb::unique_ptr<StorageExtension>> storage_extensions;
 	//! A buffer pool can be shared across multiple databases (if desired).
 	shared_ptr<BufferPool> buffer_pool;
+	//! Set of callbacks that can be installed by extensions
+	vector<unique_ptr<ExtensionCallback>> extension_callbacks;
 
 public:
 	DUCKDB_API static DBConfig &GetConfig(ClientContext &context);

--- a/src/include/duckdb/planner/extension_callback.hpp
+++ b/src/include/duckdb/planner/extension_callback.hpp
@@ -15,10 +15,12 @@ class DatabaseInstance;
 
 class ExtensionCallback {
 public:
-	virtual ~ExtensionCallback() {}
+	virtual ~ExtensionCallback() {
+	}
 
 	//! Called after an extension is finished loading
-	virtual void OnExtensionLoaded(DatabaseInstance &db, const string &name) {}
+	virtual void OnExtensionLoaded(DatabaseInstance &db, const string &name) {
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/extension_callback.hpp
+++ b/src/include/duckdb/planner/extension_callback.hpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/extension_callback.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+class DatabaseInstance;
+
+class ExtensionCallback {
+public:
+	virtual ~ExtensionCallback() {}
+
+	//! Called after an extension is finished loading
+	virtual void OnExtensionLoaded(DatabaseInstance &db, const string &name) {}
+};
+
+} // namespace duckdb

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
+#include "duckdb/planner/extension_callback.hpp"
 
 #ifndef DUCKDB_NO_THREADS
 #include "duckdb/common/thread.hpp"
@@ -381,6 +382,11 @@ bool DuckDB::ExtensionIsLoaded(const std::string &name) {
 void DatabaseInstance::SetExtensionLoaded(const std::string &name) {
 	auto extension_name = ExtensionHelper::GetExtensionName(name);
 	loaded_extensions.insert(extension_name);
+
+	auto &callbacks = DBConfig::GetConfig(*this).extension_callbacks;
+	for (auto &callback : callbacks) {
+		callback->OnExtensionLoaded(*this, name);
+	}
 }
 
 bool DatabaseInstance::TryGetCurrentSetting(const std::string &key, Value &result) {

--- a/test/extension/load_extension.test
+++ b/test/extension/load_extension.test
@@ -44,3 +44,8 @@ QUAC
 
 statement error
 QUACK NOT QUACK
+
+query I
+SELECT contains(loaded_extensions(), 'loadable_extension_demo')
+----
+true

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -6,6 +6,8 @@
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/parser/parsed_data/create_type_info.hpp"
 #include "duckdb/catalog/catalog_entry/type_catalog_entry.hpp"
+#include "duckdb/planner/extension_callback.hpp"
+
 using namespace duckdb;
 
 //===--------------------------------------------------------------------===//
@@ -212,6 +214,25 @@ public:
 	}
 };
 
+static set<string> test_loaded_extension_list;
+
+class QuackLoadExtension : public ExtensionCallback {
+	void OnExtensionLoaded(DatabaseInstance &db, const string &name) override {
+		test_loaded_extension_list.insert(name);
+	}
+};
+
+inline void LoadedExtensionsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	string result_str;
+	for (auto &ext : test_loaded_extension_list) {
+		if (!result_str.empty()) {
+			result_str += ", ";
+		}
+		result_str += ext;
+	}
+	result.Reference(Value(result_str));
+}
+
 //===--------------------------------------------------------------------===//
 // Extension load + setup
 //===--------------------------------------------------------------------===//
@@ -227,7 +248,6 @@ DUCKDB_EXTENSION_API void loadable_extension_demo_init(duckdb::DatabaseInstance 
 	con.BeginTransaction();
 	con.CreateScalarFunction<int32_t, string_t>("hello", {LogicalType(LogicalTypeId::VARCHAR)},
 	                                            LogicalType(LogicalTypeId::INTEGER), &hello_fun);
-
 	catalog.CreateFunction(client_context, hello_alias_info);
 
 	// Add alias POINT type
@@ -254,6 +274,11 @@ DUCKDB_EXTENSION_API void loadable_extension_demo_init(duckdb::DatabaseInstance 
 	CreateScalarFunctionInfo sub_point_info(sub_point_func);
 	catalog.CreateFunction(client_context, sub_point_info);
 
+	// Function sub point
+	ScalarFunction loaded_extensions("loaded_extensions", {}, LogicalType::VARCHAR, LoadedExtensionsFunction);
+	CreateScalarFunctionInfo loaded_extensions_info(loaded_extensions);
+	catalog.CreateFunction(client_context, loaded_extensions_info);
+
 	// Quack function
 	QuackFunction quack_function;
 	CreateTableFunctionInfo quack_info(quack_function);
@@ -264,6 +289,7 @@ DUCKDB_EXTENSION_API void loadable_extension_demo_init(duckdb::DatabaseInstance 
 	// add a parser extension
 	auto &config = DBConfig::GetConfig(db);
 	config.parser_extensions.push_back(QuackExtension());
+	config.extension_callbacks.push_back(make_uniq<QuackLoadExtension>());
 }
 
 DUCKDB_EXTENSION_API const char *loadable_extension_demo_version() {


### PR DESCRIPTION
This PR adds a new callback that can be registered that will be called whenever an extension is loaded. The callback works by inheriting from the following interface:

```cpp
class ExtensionCallback {
public:
	virtual ~ExtensionCallback() {
	}

	//! Called after an extension is finished loading
	virtual void OnExtensionLoaded(DatabaseInstance &db, const string &name) {
	}
};
```

The interface is generic so that other callbacks can be easily added in the future if required. An example of how to use this is provided in the `loadable_extension_demo`.

CC @bleskes 

