### PR TITLE
[Python] Set DB-API apilevel global to 2.0

### DIFF
--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -300,7 +300,7 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) { // NOLINT
 	m.attr("__interactive__") = DuckDBPyConnection::DetectAndGetEnvironment();
 	m.attr("__jupyter__") = DuckDBPyConnection::IsJupyter();
 	m.attr("default_connection") = DuckDBPyConnection::DefaultConnection();
-	m.attr("apilevel") = "1.0";
+	m.attr("apilevel") = "2.0";
 	m.attr("threadsafety") = 1;
 	m.attr("paramstyle") = "qmark";
 

--- a/tools/pythonpkg/tests/fast/test_module.py
+++ b/tools/pythonpkg/tests/fast/test_module.py
@@ -9,4 +9,4 @@ class TestModule:
         assert duckdb.threadsafety == 1
 
     def test_apilevel(self):
-        assert duckdb.apilevel == "1.0"
+        assert duckdb.apilevel == "2.0"


### PR DESCRIPTION
The `duckdb.apilevl` global is currently set to `1.0`, however the Python client targets [DB-API 2.0](https://peps.python.org/pep-0249).

This is a tiny PR to set `duckdb.apilevl` to `2.0`.