### PR TITLE
Attach to also use autoloading facility, otherwise falls back to load

### DIFF
--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -56,7 +56,10 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 
 	// if we are loading a database type from an extension - check if that extension is loaded
 	if (!type.empty()) {
-		if (!db.ExtensionIsLoaded(type)) {
+		if (!Catalog::TryAutoLoad(context.client, type)) {
+			// FIXME: Here it might be preferrable to use an AutoLoadOrThrow kind of function
+			// so that either there will be success or a message to throw, and load will be
+			// attempted only once respecting the autoloading options
 			ExtensionHelper::LoadExternalExtension(context.client, type);
 		}
 	}


### PR DESCRIPTION
This allows more uniformity in testing autoloading, and makes so that on ATTACH ... (TYPE SQLITE) both INSTALL and LOAD will be attempted (instead of only LOAD).

Note that IFF autoloading fails, either since permission are missing or files are missing an extra LOAD will be attempted.
This is currently by design, so that this is an incremental fix AND do not changes behaviour, but it migth be preferrable to: add an AutoLoadOrThrow alternative to TryAutoLoad, that either succeeds or throw, and use that here.