### PR TITLE
Pin abdc driver manager to 0.6.0 for now

### DIFF
--- a/tools/pythonpkg/cibw.toml
+++ b/tools/pythonpkg/cibw.toml
@@ -4,7 +4,7 @@
 [tool.cibuildwheel]
 environment = "PIP_CONSTRAINT='build-constraints.txt'"
 before-build = 'pip install oldest-supported-numpy'
-before-test = 'pip install --prefer-binary pandas pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true) && (pip install --prefer-binary "adbc_driver_manager" || true) && (pip install --prefer-binary "tensorflow" || true)'
+before-test = 'pip install --prefer-binary pandas pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true) && (pip install --prefer-binary "adbc_driver_manager==0.6.0" || true) && (pip install --prefer-binary "tensorflow" || true)'
 test-requires = 'pytest'
 test-command = 'DUCKDB_PYTHON_TEST_EXTENSION_PATH={project} DUCKDB_PYTHON_TEST_EXTENSION_REQUIRED=1 python -m pytest {project}/tests'
 


### PR DESCRIPTION
The new release today (0.7.0) seems to break a number of tests in the CI