### PR TITLE
duckdb.filesystem module shouldn't be required

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pyduckdb_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pyduckdb_module.hpp
@@ -22,6 +22,11 @@ public:
 		modified_memory_filesystem.LoadAttribute("ModifiedMemoryFileSystem", cache, *this);
 	}
 
+protected:
+	bool IsRequired() const override {
+		return false;
+	}
+
 public:
 	PythonImportCacheItem modified_memory_filesystem;
 };


### PR DESCRIPTION
import can fail due to fsspec being missing

I'm not 100% sure this is the right fix, but it seems to fix the [test_value.py](https://github.com/duckdb/duckdb/blob/main/tools/pythonpkg/tests/fast/test_value.py) tests when fsspec isn't installed