### PR TITLE
add tokenize to node client api

### DIFF
--- a/tools/nodejs/lib/duckdb.d.ts
+++ b/tools/nodejs/lib/duckdb.d.ts
@@ -127,6 +127,20 @@ export type ReplacementScanCallback = (
   table: string
 ) => ReplacementScanResult | null;
 
+export enum TokenType {
+  IDENTIFIER = 0,
+  NUMERIC_CONSTANT = 1,
+  STRING_CONSTANT = 2,
+  OPERATOR = 3,
+  KEYWORD = 4,
+  COMMENT = 5,
+}
+
+export interface ScriptTokens {
+  offsets: number[];
+  types: TokenType[];
+}
+
 export class Database {
   constructor(path: string, accessMode?: number | Record<string,string>, callback?: Callback<any>);
   constructor(path: string, callback?: Callback<any>);
@@ -169,6 +183,8 @@ export class Database {
   registerReplacementScan(
     replacementScan: ReplacementScanCallback
   ): Promise<void>;
+
+  tokenize(text: string): ScriptTokens;
 }
 
 export type GenericTypeInfo = {

--- a/tools/nodejs/lib/duckdb.js
+++ b/tools/nodejs/lib/duckdb.js
@@ -64,6 +64,10 @@ var Statement = duckdb.Statement;
  * @class
  */
 var QueryResult = duckdb.QueryResult;
+/**
+ * Types of tokens return by `tokenize`.
+ */
+var TokenType = duckdb.TokenType;
 
 /**
  * @method
@@ -630,6 +634,14 @@ Database.prototype.unregister_udf = function () {
  */
 
 Database.prototype.registerReplacementScan;
+
+/**
+ * Return positions and types of tokens in given text
+ * @method
+ * @arg text
+ * @return {ScriptTokens}
+ */
+Database.prototype.tokenize;
 
 /**
  * Not implemented

--- a/tools/nodejs/src/database.cpp
+++ b/tools/nodejs/src/database.cpp
@@ -384,9 +384,9 @@ Napi::Value Database::Tokenize(const Napi::CallbackInfo &info) {
 	for (size_t i = 0; i < numTokens; i++) {
 		auto token = tokens[i];
 		offsets.Set(i, token.start);
-		types.Set(i, (uint8_t) token.type);
+		types.Set(i, (uint8_t)token.type);
 	}
-	
+
 	auto result = Napi::Object::New(env);
 	result.Set("offsets", offsets);
 	result.Set("types", types);

--- a/tools/nodejs/src/database.cpp
+++ b/tools/nodejs/src/database.cpp
@@ -20,7 +20,7 @@ Napi::FunctionReference Database::Init(Napi::Env env, Napi::Object exports) {
 	     InstanceMethod("serialize", &Database::Serialize), InstanceMethod("parallelize", &Database::Parallelize),
 	     InstanceMethod("connect", &Database::Connect), InstanceMethod("interrupt", &Database::Interrupt),
 	     InstanceMethod("registerReplacementScan", &Database::RegisterReplacementScan),
-			 InstanceMethod("tokenize", &Database::Tokenize)});
+	     InstanceMethod("tokenize", &Database::Tokenize)});
 
 	exports.Set("Database", t);
 

--- a/tools/nodejs/src/duckdb_node.cpp
+++ b/tools/nodejs/src/duckdb_node.cpp
@@ -21,18 +21,17 @@ NodeDuckDB::NodeDuckDB(Napi::Env env, Napi::Object exports) {
 	token_type_enum.Set("COMMENT", 5);
 	token_type_enum_ref = Napi::ObjectReference::New(token_type_enum);
 
-	exports.DefineProperties({
-	    DEFINE_CONSTANT_INTEGER(exports, node_duckdb::Database::DUCKDB_NODEJS_ERROR, ERROR) DEFINE_CONSTANT_INTEGER(
+	exports.DefineProperties(
+	    {DEFINE_CONSTANT_INTEGER(exports, node_duckdb::Database::DUCKDB_NODEJS_ERROR, ERROR) DEFINE_CONSTANT_INTEGER(
 	        exports, node_duckdb::Database::DUCKDB_NODEJS_READONLY, OPEN_READONLY) // same as SQLite
-	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_READWRITE)                        // ignored
-	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_CREATE)                           // ignored
-	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_FULLMUTEX)                        // ignored
-	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_SHAREDCACHE)                      // ignored
-	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_PRIVATECACHE)                     // ignored
+	     DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_READWRITE)                       // ignored
+	     DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_CREATE)                          // ignored
+	     DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_FULLMUTEX)                       // ignored
+	     DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_SHAREDCACHE)                     // ignored
+	     DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_PRIVATECACHE)                    // ignored
 
-	    Napi::PropertyDescriptor::Value("TokenType", token_type_enum,
-	        static_cast<napi_property_attributes>(napi_enumerable | napi_configurable))
-	});
+	     Napi::PropertyDescriptor::Value("TokenType", token_type_enum,
+	                                     static_cast<napi_property_attributes>(napi_enumerable | napi_configurable))});
 }
 
 NODE_API_ADDON(NodeDuckDB);

--- a/tools/nodejs/src/duckdb_node.cpp
+++ b/tools/nodejs/src/duckdb_node.cpp
@@ -13,12 +13,22 @@ NodeDuckDB::NodeDuckDB(Napi::Env env, Napi::Object exports) {
 	query_result_constructor = node_duckdb::QueryResult::Init(env, exports);
 
 	auto token_type_enum = Napi::Object::New(env);
+
 	token_type_enum.Set("IDENTIFIER", 0);
 	token_type_enum.Set("NUMERIC_CONSTANT", 1);
 	token_type_enum.Set("STRING_CONSTANT", 2);
 	token_type_enum.Set("OPERATOR", 3);
 	token_type_enum.Set("KEYWORD", 4);
 	token_type_enum.Set("COMMENT", 5);
+	
+	// TypeScript enums expose an inverse mapping.
+	token_type_enum.Set(0, "IDENTIFIER");
+	token_type_enum.Set(1, "NUMERIC_CONSTANT");
+	token_type_enum.Set(2, "STRING_CONSTANT");
+	token_type_enum.Set(3, "OPERATOR");
+	token_type_enum.Set(4, "KEYWORD");
+	token_type_enum.Set(5, "COMMENT");
+
 	token_type_enum_ref = Napi::ObjectReference::New(token_type_enum);
 
 	exports.DefineProperties(

--- a/tools/nodejs/src/duckdb_node.cpp
+++ b/tools/nodejs/src/duckdb_node.cpp
@@ -20,14 +20,14 @@ NodeDuckDB::NodeDuckDB(Napi::Env env, Napi::Object exports) {
 	token_type_enum.Set("OPERATOR", 3);
 	token_type_enum.Set("KEYWORD", 4);
 	token_type_enum.Set("COMMENT", 5);
-	
+
 	// TypeScript enums expose an inverse mapping.
-	token_type_enum.Set(0, "IDENTIFIER");
-	token_type_enum.Set(1, "NUMERIC_CONSTANT");
-	token_type_enum.Set(2, "STRING_CONSTANT");
-	token_type_enum.Set(3, "OPERATOR");
-	token_type_enum.Set(4, "KEYWORD");
-	token_type_enum.Set(5, "COMMENT");
+	token_type_enum.Set((uint32_t)0, "IDENTIFIER");
+	token_type_enum.Set((uint32_t)1, "NUMERIC_CONSTANT");
+	token_type_enum.Set((uint32_t)2, "STRING_CONSTANT");
+	token_type_enum.Set((uint32_t)3, "OPERATOR");
+	token_type_enum.Set((uint32_t)4, "KEYWORD");
+	token_type_enum.Set((uint32_t)5, "COMMENT");
 
 	token_type_enum_ref = Napi::ObjectReference::New(token_type_enum);
 

--- a/tools/nodejs/src/duckdb_node.cpp
+++ b/tools/nodejs/src/duckdb_node.cpp
@@ -12,6 +12,15 @@ NodeDuckDB::NodeDuckDB(Napi::Env env, Napi::Object exports) {
 	statement_constructor = node_duckdb::Statement::Init(env, exports);
 	query_result_constructor = node_duckdb::QueryResult::Init(env, exports);
 
+	auto token_type_enum = Napi::Object::New(env);
+	token_type_enum.Set("IDENTIFIER", 0);
+	token_type_enum.Set("NUMERIC_CONSTANT", 1);
+	token_type_enum.Set("STRING_CONSTANT", 2);
+	token_type_enum.Set("OPERATOR", 3);
+	token_type_enum.Set("KEYWORD", 4);
+	token_type_enum.Set("COMMENT", 5);
+	token_type_enum_ref = Napi::ObjectReference::New(token_type_enum);
+
 	exports.DefineProperties({
 	    DEFINE_CONSTANT_INTEGER(exports, node_duckdb::Database::DUCKDB_NODEJS_ERROR, ERROR) DEFINE_CONSTANT_INTEGER(
 	        exports, node_duckdb::Database::DUCKDB_NODEJS_READONLY, OPEN_READONLY) // same as SQLite
@@ -20,6 +29,8 @@ NodeDuckDB::NodeDuckDB(Napi::Env env, Napi::Object exports) {
 	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_FULLMUTEX)                        // ignored
 	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_SHAREDCACHE)                      // ignored
 	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_PRIVATECACHE)                     // ignored
+
+			Napi::PropertyDescriptor::Value("TokenType", token_type_enum, static_cast<napi_property_attributes>(napi_enumerable | napi_configurable))
 	});
 }
 

--- a/tools/nodejs/src/duckdb_node.cpp
+++ b/tools/nodejs/src/duckdb_node.cpp
@@ -30,7 +30,8 @@ NodeDuckDB::NodeDuckDB(Napi::Env env, Napi::Object exports) {
 	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_SHAREDCACHE)                      // ignored
 	    DEFINE_CONSTANT_INTEGER(exports, 0, OPEN_PRIVATECACHE)                     // ignored
 
-			Napi::PropertyDescriptor::Value("TokenType", token_type_enum, static_cast<napi_property_attributes>(napi_enumerable | napi_configurable))
+	    Napi::PropertyDescriptor::Value("TokenType", token_type_enum,
+	        static_cast<napi_property_attributes>(napi_enumerable | napi_configurable))
 	});
 }
 

--- a/tools/nodejs/src/duckdb_node.hpp
+++ b/tools/nodejs/src/duckdb_node.hpp
@@ -23,6 +23,7 @@ public:
 	Napi::FunctionReference connection_constructor;
 	Napi::FunctionReference statement_constructor;
 	Napi::FunctionReference query_result_constructor;
+	Napi::ObjectReference token_type_enum_ref;
 };
 
 namespace node_duckdb {
@@ -109,6 +110,7 @@ public:
 	Napi::Value Interrupt(const Napi::CallbackInfo &info);
 	Napi::Value Close(const Napi::CallbackInfo &info);
 	Napi::Value RegisterReplacementScan(const Napi::CallbackInfo &info);
+	Napi::Value Tokenize(const Napi::CallbackInfo &info);
 
 public:
 	constexpr static int DUCKDB_NODEJS_ERROR = -1;

--- a/tools/nodejs/test/tokenize.test.ts
+++ b/tools/nodejs/test/tokenize.test.ts
@@ -1,0 +1,57 @@
+import * as assert from 'assert';
+import * as duckdb from '..';
+
+describe('tokenize', function () {
+  it('should return correct tokens for a single statement', function () {
+    const db = new duckdb.Database(':memory:');
+    const output = db.tokenize('select 1;');
+    assert.deepStrictEqual(output, {
+      offsets: [0, 7, 8],
+      types: [duckdb.TokenType.KEYWORD, duckdb.TokenType.NUMERIC_CONSTANT, duckdb.TokenType.OPERATOR]
+    });
+  });
+  it('should return correct tokens for a multiple statements', function () {
+    const db = new duckdb.Database(':memory:');
+    const output = db.tokenize('select 1; select 2;');
+    assert.deepStrictEqual(output, {
+      offsets: [0, 7, 8, 10, 17, 18],
+      types: [
+        duckdb.TokenType.KEYWORD, duckdb.TokenType.NUMERIC_CONSTANT, duckdb.TokenType.OPERATOR,
+        duckdb.TokenType.KEYWORD, duckdb.TokenType.NUMERIC_CONSTANT, duckdb.TokenType.OPERATOR
+      ]
+    });
+  });
+  it('should return no tokens for an empty string', function () {
+    const db = new duckdb.Database(':memory:');
+    const output = db.tokenize('');
+    assert.deepStrictEqual(output, {
+      offsets: [],
+      types: []
+    });
+  });
+  it('should handle quoted semicolons in string constants', function () {
+    const db = new duckdb.Database(':memory:');
+    const output = db.tokenize(`select ';';`);
+    assert.deepStrictEqual(output, {
+      offsets: [0, 7, 10],
+      types: [duckdb.TokenType.KEYWORD, duckdb.TokenType.STRING_CONSTANT, duckdb.TokenType.OPERATOR]
+    });
+  });
+  it('should handle quoted semicolons in identifiers', function () {
+    const db = new duckdb.Database(':memory:');
+    const output = db.tokenize(`from ";";`);
+    assert.deepStrictEqual(output, {
+      offsets: [0, 5, 8],
+      types: [duckdb.TokenType.KEYWORD, duckdb.TokenType.IDENTIFIER, duckdb.TokenType.OPERATOR]
+    });
+  });
+  it('should handle comments', function () {
+    const db = new duckdb.Database(':memory:');
+    const output = db.tokenize(`select /* comment */ 1`);
+    // Note that the tokenizer doesn't return tokens for comments.
+    assert.deepStrictEqual(output, {
+      offsets: [0, 21],
+      types: [duckdb.TokenType.KEYWORD, duckdb.TokenType.NUMERIC_CONSTANT]
+    });
+  });
+});

--- a/tools/nodejs/test/tokenize.test.ts
+++ b/tools/nodejs/test/tokenize.test.ts
@@ -54,4 +54,13 @@ describe('tokenize', function () {
       types: [duckdb.TokenType.KEYWORD, duckdb.TokenType.NUMERIC_CONSTANT]
     });
   });
+  it('should handle invalid syntax', function () {
+    const db = new duckdb.Database(':memory:');
+    const output = db.tokenize(`selec 1`);
+    // The misspelled keyword is scanned as an identifier.
+    assert.deepStrictEqual(output, {
+      offsets: [0, 6],
+      types: [duckdb.TokenType.IDENTIFIER, duckdb.TokenType.NUMERIC_CONSTANT]
+    });
+  });
 });

--- a/tools/nodejs/test/tokenize.test.ts
+++ b/tools/nodejs/test/tokenize.test.ts
@@ -63,4 +63,12 @@ describe('tokenize', function () {
       types: [duckdb.TokenType.IDENTIFIER, duckdb.TokenType.NUMERIC_CONSTANT]
     });
   });
+  it('should support inverse TokenType mapping', function () {
+    assert.equal(duckdb.TokenType[duckdb.TokenType.IDENTIFIER], "IDENTIFIER");
+    assert.equal(duckdb.TokenType[duckdb.TokenType.NUMERIC_CONSTANT], "NUMERIC_CONSTANT");
+    assert.equal(duckdb.TokenType[duckdb.TokenType.STRING_CONSTANT], "STRING_CONSTANT");
+    assert.equal(duckdb.TokenType[duckdb.TokenType.OPERATOR], "OPERATOR");
+    assert.equal(duckdb.TokenType[duckdb.TokenType.KEYWORD], "KEYWORD");
+    assert.equal(duckdb.TokenType[duckdb.TokenType.COMMENT], "COMMENT");
+  });
 });


### PR DESCRIPTION
Add plumbing to expose the Tokenize method through the Node client API.

The signature of this method follows the [corresponding method from duckdb-wasm](https://github.com/duckdb/duckdb-wasm/blob/main/packages/duckdb-wasm/src/bindings/bindings_interface.ts#L14). It returns an object containing two arrays of numbers, instead of an array of objects, each with two number properties (as the underlying C++ API does), presumably to reduce the number of JS objects that need to be created.

I opted to call the Tokenize method synchronously, since it's lightweight and doesn't require any database resources; it's a static method of the parser. If there's a reason to move the call to the worker thread, let me know.

In addition to exposing the method itself, the `TokenType` enum is also exposed. This requires some code on the C++ side in order to add the runtime enum object to the NodeDuckDB Addon, in addition to the type definition on the TypeScript side.

A basic unit test suite is included.