### PR TITLE
Fix use of os.environ dictionary in setup.py script

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -191,7 +191,7 @@ main_source_path = os.path.join(script_path, 'src')
 main_source_files = ['duckdb_python.cpp'] + list_source_files(main_source_path)
 include_directories = [main_include_path, get_pybind_include(), get_pybind_include(user=True)]
 if 'BUILD_HTTPFS' in os.environ and 'OPENSSL_ROOT_DIR' in os.environ:
-    include_directories += [os.path.join(os.environ('OPENSSL_ROOT_DIR'), 'include')]
+    include_directories += [os.path.join(os.environ['OPENSSL_ROOT_DIR'], 'include')]
 
 if len(existing_duckdb_dir) == 0:
     # no existing library supplied: compile everything from source


### PR DESCRIPTION
The `os.environ` was use incorrectly in `setup.py` but it was only triggered on a rarely accessed code path:

```python
if 'BUILD_HTTPFS' in os.environ and 'OPENSSL_ROOT_DIR' in os.environ:
    include_directories += [os.path.join(os.environ('OPENSSL_ROOT_DIR'), 'include')]
```

REPL code snippet demonstrating the problem:
```python
>>> import os
>>> print(os.environ('OPENSSL_ROOT_DIR'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: '_Environ' object is not callable
>>> print(os.environ['OPENSSL_ROOT_DIR'])
/opt/homebrew/opt/openssl\@1.1
```

cc @Tishj 