### PR TITLE
Extensions: apply extension alias beforehand

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -432,7 +432,8 @@ void FindMinimalQualification(ClientContext &context, const string &catalog_name
 	qualify_schema = true;
 }
 
-bool Catalog::TryAutoLoad(ClientContext &context, const string &extension_name) noexcept {
+bool Catalog::TryAutoLoad(ClientContext &context, const string &original_name) noexcept {
+	string extension_name = ExtensionHelper::ApplyExtensionAlias(original_name);
 	if (context.db->ExtensionIsLoaded(extension_name)) {
 		return true;
 	}


### PR DESCRIPTION
Arguably this should happen also elsewhere, either as part of CanAutoloadExtension / TryAutoLoadExtension or on all call-sites. Given timeframe, going for the punctual fix here.
