### PR TITLE
fuzz_all_functions no longer cares about max_queries and fuzzer cannot call fuzzer table functions

### DIFF
--- a/extension/sqlsmith/fuzzyduck.cpp
+++ b/extension/sqlsmith/fuzzyduck.cpp
@@ -49,6 +49,10 @@ void FuzzyDuck::FuzzAllFunctions() {
 	StatementGenerator generator(context);
 	auto queries = generator.GenerateAllFunctionCalls();
 
+	if (max_queries == 0) {
+		max_queries = queries.size();
+	}
+
 	std::default_random_engine e(seed);
 	std::shuffle(std::begin(queries), std::end(queries), e);
 	BeginFuzzing();

--- a/extension/sqlsmith/include/fuzzyduck.hpp
+++ b/extension/sqlsmith/include/fuzzyduck.hpp
@@ -21,7 +21,7 @@ public:
 
 	ClientContext &context;
 	uint32_t seed = 0;
-	idx_t max_queries = 2000;
+	idx_t max_queries = 0;
 	string complete_log;
 	string log;
 	bool verbose_output = false;

--- a/extension/sqlsmith/include/fuzzyduck.hpp
+++ b/extension/sqlsmith/include/fuzzyduck.hpp
@@ -21,7 +21,7 @@ public:
 
 	ClientContext &context;
 	uint32_t seed = 0;
-	idx_t max_queries = 0;
+	idx_t max_queries = 2000;
 	string complete_log;
 	string log;
 	bool verbose_output = false;

--- a/extension/sqlsmith/statement_generator.cpp
+++ b/extension/sqlsmith/statement_generator.cpp
@@ -50,16 +50,15 @@ shared_ptr<GeneratorContext> StatementGenerator::GetDatabaseState(ClientContext 
 		auto &schema = schema_ref.get();
 		schema.Scan(context, CatalogType::SCALAR_FUNCTION_ENTRY,
 		            [&](CatalogEntry &entry) { result->scalar_functions.push_back(entry); });
-		schema.Scan(context, CatalogType::TABLE_FUNCTION_ENTRY,
-		            [&](CatalogEntry &entry) {
-			            // don't include fuzz functions
-			            if (entry.name.find("fuzzyduck") == std::string::npos ||
-			                entry.name.find("fuzz_all_functions") == std::string::npos ||
-			                entry.name.find("reduce_sql_statement") == std::string::npos ||
-			                entry.name.find("sqlsmith") == std::string::npos) {
-				            result->table_functions.push_back(entry);
-			            }
-		            });
+		schema.Scan(context, CatalogType::TABLE_FUNCTION_ENTRY, [&](CatalogEntry &entry) {
+			// don't include fuzz functions
+			if (entry.name.find("fuzzyduck") == std::string::npos ||
+			    entry.name.find("fuzz_all_functions") == std::string::npos ||
+			    entry.name.find("reduce_sql_statement") == std::string::npos ||
+			    entry.name.find("sqlsmith") == std::string::npos) {
+				result->table_functions.push_back(entry);
+			}
+		});
 		schema.Scan(context, CatalogType::PRAGMA_FUNCTION_ENTRY,
 		            [&](CatalogEntry &entry) { result->pragma_functions.push_back(entry); });
 		schema.Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {

--- a/extension/sqlsmith/statement_generator.cpp
+++ b/extension/sqlsmith/statement_generator.cpp
@@ -51,7 +51,15 @@ shared_ptr<GeneratorContext> StatementGenerator::GetDatabaseState(ClientContext 
 		schema.Scan(context, CatalogType::SCALAR_FUNCTION_ENTRY,
 		            [&](CatalogEntry &entry) { result->scalar_functions.push_back(entry); });
 		schema.Scan(context, CatalogType::TABLE_FUNCTION_ENTRY,
-		            [&](CatalogEntry &entry) { result->table_functions.push_back(entry); });
+		            [&](CatalogEntry &entry) {
+			            // don't include fuzz functions
+			            if (entry.name.find("fuzzyduck") == std::string::npos ||
+			                entry.name.find("fuzz_all_functions") == std::string::npos ||
+			                entry.name.find("reduce_sql_statement") == std::string::npos ||
+			                entry.name.find("sqlsmith") == std::string::npos) {
+				            result->table_functions.push_back(entry);
+			            }
+		            });
 		schema.Scan(context, CatalogType::PRAGMA_FUNCTION_ENTRY,
 		            [&](CatalogEntry &entry) { result->pragma_functions.push_back(entry); });
 		schema.Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {


### PR DESCRIPTION
Some CI runs for the fuzzer are failing now that we don't default max_queries to idx_t::Maximum(). This is because fuzz_all_functions doesn't take a `max_queries` value, so `BeginFuzzing()` will throw an error. To fix this, if `fuzz_all_functions` is called, we set `max_queries` equal to the number of queries that have been returned in order to fuzz all the functions. 

Also, the `GeneratorContext` of the fuzzer currently includes the table function references to fuzzer functions. Now whenever the `GeneratorContext` is updated, we exclude all fuzzer table reference functions as they can cause recursion and spurious failures.