### PR TITLE
Fixing issues with quote and multi-file filter

### DIFF
--- a/src/execution/operator/csv_scanner/parallel_csv_reader.cpp
+++ b/src/execution/operator/csv_scanner/parallel_csv_reader.cpp
@@ -333,9 +333,23 @@ normal : {
 	for (; position_buffer < end_buffer; position_buffer++) {
 		auto c = (*buffer)[position_buffer];
 		if (c == options.dialect_options.state_machine_options.delimiter) {
+			// Check if previous character is a quote, if yes, this means we are in a non-initialized quoted value
+			// This only matters for when trying to figure out where csv lines start
+			if (position_buffer > 0 && try_add_line) {
+				if ((*buffer)[position_buffer - 1] == options.dialect_options.state_machine_options.quote) {
+					return false;
+				}
+			}
 			// delimiter: end the value and add it to the chunk
 			goto add_value;
 		} else if (StringUtil::CharacterIsNewline(c)) {
+			// Check if previous character is a quote, if yes, this means we are in a non-initialized quoted value
+			// This only matters for when trying to figure out where csv lines start
+			if (position_buffer > 0 && try_add_line) {
+				if ((*buffer)[position_buffer - 1] == options.dialect_options.state_machine_options.quote) {
+					return false;
+				}
+			}
 			// newline: add row
 			if (column > 0 || try_add_line || parse_chunk.data.size() == 1) {
 				goto add_row;

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -178,7 +178,8 @@ public:
 		current_file_path = files_path_p[0];
 		CSVFileHandle *file_handle_ptr;
 
-		if (!buffer_manager || (options.skip_rows_set && options.dialect_options.skip_rows > 0)) {
+		if (!buffer_manager || (options.skip_rows_set && options.dialect_options.skip_rows > 0) ||
+		    buffer_manager->file_handle->GetFilePath() != current_file_path) {
 			// If our buffers are too small, and we skip too many rows there is a chance things will go over-buffer
 			// for now don't reuse the buffer manager
 			buffer_manager.reset();
@@ -210,6 +211,7 @@ public:
 			line_info.lines_read[0][0]++;
 		}
 		first_position = options.dialect_options.true_start;
+		next_byte = options.dialect_options.true_start;
 	}
 	explicit ParallelCSVGlobalState(idx_t system_threads_p)
 	    : system_threads(system_threads_p), line_info(main_mutex, batch_to_tuple_end, tuple_start, tuple_end) {

--- a/test/parallel_csv/test_parallel_csv.cpp
+++ b/test/parallel_csv/test_parallel_csv.cpp
@@ -52,20 +52,20 @@ bool RunParallel(const string &path, idx_t thread_count, idx_t buffer_size,
 	}
 	if (!ground_truth) {
 		//! oh oh, this should not pass
-		std::cout << path << " Failed on single threaded but succeeded on parallel reading" << std::endl;
+		std::cout << path << " Failed on single threaded but succeeded on parallel reading" << '\n';
 		return false;
 	}
 	if (!multi_threaded_passed) {
-		std::cout << path << " Multithreaded failed" << std::endl;
-		std::cout << multi_threaded_result->GetError() << std::endl;
+		std::cout << path << " Multithreaded failed" << '\n';
+		std::cout << multi_threaded_result->GetError() << '\n';
 		return false;
 	}
 	// Results do not match
 	string error_message;
 	if (!ColumnDataCollection::ResultEquals(*ground_truth, *result, error_message, false)) {
 		std::cout << path << " Thread count: " << to_string(thread_count) << " Buffer Size: " << to_string(buffer_size)
-		          << std::endl;
-		std::cout << error_message << std::endl;
+		          << '\n';
+		std::cout << error_message << '\n';
 		return false;
 	}
 	return true;
@@ -192,7 +192,6 @@ TEST_CASE("Test Parallel CSV All Files - test/sql/copy/csv/data/real", "[paralle
 }
 
 TEST_CASE("Test Parallel CSV All Files - test/sql/copy/csv/data/test", "[parallel-csv][.]") {
-	return;
 	std::set<std::string> skip;
 	// This file requires additional parameters, we test it on the following test.
 	skip.insert("test/sql/copy/csv/data/test/5438.csv");

--- a/test/sql/copy/csv/csv_quoted_newline_incorrect.test
+++ b/test/sql/copy/csv/csv_quoted_newline_incorrect.test
@@ -1,11 +1,15 @@
 # name: test/sql/copy/csv/csv_quoted_newline_incorrect.test
-# description: Read a CSV with a null byte
+# description: Read a CSV with an incorrect quoted newline, is expected that the csv reader manages to skip dirty lines
 # group: [csv]
 
 require vector_size 512
 
 statement ok
 PRAGMA enable_verification
+
+# force parallelism of the queries
+statement ok
+PRAGMA verify_parallelism
 
 # CSV reader skips malformed lines
 query II


### PR DESCRIPTION
This PR fixes an issue related to parallel line detection with end quotes and resets the buffer manager accordingly for hive-partitioned files if the path to the file held by the manager is not the same after applying the filter.

This should fix the CI issues related to 
`test/sql/copy/csv/csv_quoted_newline_incorrect.test` 
`test/sql/copy/csv/csv_hive_filename_union.test`
and `test/sql/copy/csv/csv_quoted_newline`