### PR TITLE
Skip tests for release

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Java Tests
         shell: bash
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: >
           java -cp build/release/tools/jdbc/duckdb_jdbc.jar
           org.duckdb.test.TestDuckDBJDBC
@@ -156,7 +156,7 @@ jobs:
 
           cmake --build . --config Release
       - name: Java Tests
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: |
           java -cp tools/jdbc/duckdb_jdbc.jar org.duckdb.test.TestDuckDBJDBC
@@ -198,7 +198,7 @@ jobs:
         shell: bash
         run: make
       - name: Java Tests
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: >
           java -cp build/release/tools/jdbc/duckdb_jdbc.jar
@@ -290,7 +290,7 @@ jobs:
   jdbc-compliance:
     name: JDBC Compliance
     runs-on: ubuntu-20.04
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     needs: java-linux-amd64
     container: quay.io/pypa/manylinux2014_x86_64
     env:

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Java Tests
         shell: bash
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: >
           java -cp build/release/tools/jdbc/duckdb_jdbc.jar
           org.duckdb.test.TestDuckDBJDBC
@@ -155,6 +156,7 @@ jobs:
 
           cmake --build . --config Release
       - name: Java Tests
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: |
           java -cp tools/jdbc/duckdb_jdbc.jar org.duckdb.test.TestDuckDBJDBC
@@ -196,6 +198,7 @@ jobs:
         shell: bash
         run: make
       - name: Java Tests
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: >
           java -cp build/release/tools/jdbc/duckdb_jdbc.jar
@@ -287,6 +290,7 @@ jobs:
   jdbc-compliance:
     name: JDBC Compliance
     runs-on: ubuntu-20.04
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     needs: java-linux-amd64
     container: quay.io/pypa/manylinux2014_x86_64
     env:

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Java Tests
         shell: bash
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: >
           java -cp build/release/tools/jdbc/duckdb_jdbc.jar
           org.duckdb.test.TestDuckDBJDBC
@@ -156,7 +156,7 @@ jobs:
 
           cmake --build . --config Release
       - name: Java Tests
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: |
           java -cp tools/jdbc/duckdb_jdbc.jar org.duckdb.test.TestDuckDBJDBC
@@ -198,7 +198,7 @@ jobs:
         shell: bash
         run: make
       - name: Java Tests
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: >
           java -cp build/release/tools/jdbc/duckdb_jdbc.jar
@@ -290,7 +290,7 @@ jobs:
   jdbc-compliance:
     name: JDBC Compliance
     runs-on: ubuntu-20.04
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs: java-linux-amd64
     container: quay.io/pypa/manylinux2014_x86_64
     env:

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   format_check:
     name: Julia Format Check
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
 
   main_julia:
     name: Julia ${{ matrix.version }}
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   format_check:
     name: Julia Format Check
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
 
   main_julia:
     name: Julia ${{ matrix.version }}
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -39,6 +39,7 @@ concurrency:
 jobs:
   format_check:
     name: Julia Format Check
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -59,6 +60,7 @@ jobs:
 
   main_julia:
     name: Julia ${{ matrix.version }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -78,18 +78,18 @@ jobs:
 
     - name: Test
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: make allunit
 
     - name: Tools Tests
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: |
         python3.7 -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
     - name: Examples
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: |
         (cd examples/embedded-c; make)
         (cd examples/embedded-c++; make)
@@ -250,7 +250,7 @@ jobs:
 
  check-load-install-extensions:
     name: Checks extension functions
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-extensions-64
     env:
@@ -299,7 +299,7 @@ jobs:
 
  symbol-leakage:
     name: Symbol Leakage
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-release-64
 
@@ -328,7 +328,7 @@ jobs:
 
  linux-httpfs:
     name: Linux HTTPFS
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-release-64
     env:
@@ -386,7 +386,7 @@ jobs:
 
  amalgamation-tests:
     name: Amalgamation Tests
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs: linux-release-64
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -78,18 +78,18 @@ jobs:
 
     - name: Test
       shell: bash
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: make allunit
 
     - name: Tools Tests
       shell: bash
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: |
         python3.7 -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
     - name: Examples
       shell: bash
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: |
         (cd examples/embedded-c; make)
         (cd examples/embedded-c++; make)
@@ -250,7 +250,7 @@ jobs:
 
  check-load-install-extensions:
     name: Checks extension functions
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-extensions-64
     env:
@@ -299,7 +299,7 @@ jobs:
 
  symbol-leakage:
     name: Symbol Leakage
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-release-64
 
@@ -328,7 +328,7 @@ jobs:
 
  linux-httpfs:
     name: Linux HTTPFS
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-release-64
     env:
@@ -386,7 +386,7 @@ jobs:
 
  amalgamation-tests:
     name: Amalgamation Tests
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     needs: linux-release-64
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -78,15 +78,18 @@ jobs:
 
     - name: Test
       shell: bash
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: make allunit
 
     - name: Tools Tests
       shell: bash
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: |
         python3.7 -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
     - name: Examples
       shell: bash
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: |
         (cd examples/embedded-c; make)
         (cd examples/embedded-c++; make)
@@ -247,6 +250,7 @@ jobs:
 
  check-load-install-extensions:
     name: Checks extension functions
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-extensions-64
     env:
@@ -295,6 +299,7 @@ jobs:
 
  symbol-leakage:
     name: Symbol Leakage
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-release-64
 
@@ -323,6 +328,7 @@ jobs:
 
  linux-httpfs:
     name: Linux HTTPFS
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-release-64
     env:
@@ -380,6 +386,7 @@ jobs:
 
  amalgamation-tests:
     name: Amalgamation Tests
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     needs: linux-release-64
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -198,6 +198,7 @@ jobs:
         post_install: rm build/release/src/libduckdb*
         deploy_as: linux_amd64
         treat_warn_as_error: 0
+        run_autoload_tests: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run_tests: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         s3_id: ${{ secrets.S3_ID }}
         s3_key: ${{ secrets.S3_KEY }}

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -198,6 +198,7 @@ jobs:
         post_install: rm build/release/src/libduckdb*
         deploy_as: linux_amd64
         treat_warn_as_error: 0
+        run_tests: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         s3_id: ${{ secrets.S3_ID }}
         s3_key: ${{ secrets.S3_KEY }}
         signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -75,6 +75,7 @@ jobs:
 
  force-storage:
     name: Force Storage
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -117,6 +118,7 @@ jobs:
 
  force-restart:
     name: Force Restart
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -159,6 +161,7 @@ jobs:
 
  valgrind:
     name: Valgrind
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -193,6 +196,7 @@ jobs:
 
  docs:
     name: Website Docs
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     steps:
@@ -217,6 +221,7 @@ jobs:
 
  odbc:
     name: ODBC
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-22.04
     needs: linux-debug
     env:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -75,7 +75,6 @@ jobs:
 
  force-storage:
     name: Force Storage
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -118,7 +117,6 @@ jobs:
 
  force-restart:
     name: Force Restart
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -161,7 +159,6 @@ jobs:
 
  valgrind:
     name: Valgrind
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -196,7 +193,6 @@ jobs:
 
  docs:
     name: Website Docs
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     steps:
@@ -221,7 +217,6 @@ jobs:
 
  odbc:
     name: ODBC
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-22.04
     needs: linux-debug
     env:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -38,7 +38,7 @@ env:
 jobs:
  linux-debug:
     name: Linux Debug
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     env:
       CC: gcc-10
@@ -75,7 +75,7 @@ jobs:
 
  force-storage:
     name: Force Storage
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -118,7 +118,7 @@ jobs:
 
  force-restart:
     name: Force Restart
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -161,7 +161,7 @@ jobs:
 
  valgrind:
     name: Valgrind
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -196,7 +196,7 @@ jobs:
 
  docs:
     name: Website Docs
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     steps:
@@ -221,7 +221,7 @@ jobs:
 
  odbc:
     name: ODBC
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-22.04
     needs: linux-debug
     env:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -38,7 +38,7 @@ env:
 jobs:
  linux-debug:
     name: Linux Debug
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     env:
       CC: gcc-10
@@ -75,7 +75,7 @@ jobs:
 
  force-storage:
     name: Force Storage
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -118,7 +118,7 @@ jobs:
 
  force-restart:
     name: Force Restart
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -161,7 +161,7 @@ jobs:
 
  valgrind:
     name: Valgrind
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -196,7 +196,7 @@ jobs:
 
  docs:
     name: Website Docs
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     steps:
@@ -221,7 +221,7 @@ jobs:
 
  odbc:
     name: ODBC
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-22.04
     needs: linux-debug
     env:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -38,6 +38,7 @@ env:
 jobs:
  linux-debug:
     name: Linux Debug
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     env:
       CC: gcc-10
@@ -74,6 +75,7 @@ jobs:
 
  force-storage:
     name: Force Storage
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -116,6 +118,7 @@ jobs:
 
  force-restart:
     name: Force Restart
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -158,6 +161,7 @@ jobs:
 
  valgrind:
     name: Valgrind
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     env:
@@ -192,6 +196,7 @@ jobs:
 
  docs:
     name: Website Docs
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-20.04
     needs: linux-debug
     steps:
@@ -216,6 +221,7 @@ jobs:
 
  odbc:
     name: ODBC
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-22.04
     needs: linux-debug
     env:

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -28,6 +28,7 @@ env:
 jobs:
   xcode-debug:
     name: OSX Debug
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: macos-latest
 
     env:
@@ -123,15 +124,18 @@ jobs:
 
       - name: Unit Test
         shell: bash
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: make allunit
 
       - name: Tools Tests
         shell: bash
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           python -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
       - name: Examples
         shell: bash
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           (cd examples/embedded-c; make)
           (cd examples/embedded-c++; make)
@@ -282,7 +286,7 @@ jobs:
 
       # Run autoload unittests (including the out-of-tree tests) without any extensions linked, relying on the autoloader
       - name: Run tests with auto loading
-        if: ${{ matrix.osx_arch == 'x86_64' }}
+        if: ${{ matrix.osx_arch == 'x86_64' && !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         env:
           LOCAL_EXTENSION_REPO: ${{ github.workspace }}

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -28,7 +28,6 @@ env:
 jobs:
   xcode-debug:
     name: OSX Debug
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: macos-latest
 
     env:
@@ -58,12 +57,14 @@ jobs:
       run: GEN=ninja make debug
 
     - name: Test
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       shell: bash
       run: |
           echo "DUCKDB_INSTALL_LIB=$(find `pwd` -name "libduck*.dylib" | head -n 1)" >> $GITHUB_ENV
           make unittestci
 
     - name: Amalgamation
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       shell: bash
       run: |
         python scripts/amalgamation.py --extended

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   xcode-debug:
     name: OSX Debug
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: macos-latest
 
     env:
@@ -124,18 +124,18 @@ jobs:
 
       - name: Unit Test
         shell: bash
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: make allunit
 
       - name: Tools Tests
         shell: bash
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           python -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
       - name: Examples
         shell: bash
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           (cd examples/embedded-c; make)
           (cd examples/embedded-c++; make)

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -57,14 +57,14 @@ jobs:
       run: GEN=ninja make debug
 
     - name: Test
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       shell: bash
       run: |
           echo "DUCKDB_INSTALL_LIB=$(find `pwd` -name "libduck*.dylib" | head -n 1)" >> $GITHUB_ENV
           make unittestci
 
     - name: Amalgamation
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       shell: bash
       run: |
         python scripts/amalgamation.py --extended
@@ -125,18 +125,18 @@ jobs:
 
       - name: Unit Test
         shell: bash
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: make allunit
 
       - name: Tools Tests
         shell: bash
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           python -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
       - name: Examples
         shell: bash
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           (cd examples/embedded-c; make)
           (cd examples/embedded-c++; make)

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -200,7 +200,8 @@ jobs:
         export DISTUTILS_C_COMPILER_LAUNCHER=ccache
         # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
         if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-          export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
+          sed -i 's@{project}/tests/fast@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
+          sed -i 's@{project}/tests@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
         fi
         cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
         ls wheelhouse
@@ -260,7 +261,8 @@ jobs:
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
           if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
+            sed -i 's@{project}/tests/fast@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
+            sed -i 's@{project}/tests@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
           fi
           cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
 
@@ -328,7 +330,8 @@ jobs:
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
           if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
+            sed -i 's@{project}/tests/fast@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
+            sed -i 's@{project}/tests@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
           fi
           cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -199,9 +199,8 @@ jobs:
         ls duckdb_tarball
         export DISTUTILS_C_COMPILER_LAUNCHER=ccache
         # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
-        if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-          sed -i 's@{project}/tests/fast@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
-          sed -i 's@{project}/tests@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
+        if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ ]] ; then
+          export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
         fi
         cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
         ls wheelhouse
@@ -260,9 +259,8 @@ jobs:
           mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            sed -i 's@{project}/tests/fast@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
-            sed -i 's@{project}/tests@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
+          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ ]] ; then
+            export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
           fi
           cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
 
@@ -329,9 +327,8 @@ jobs:
           mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            sed -i 's@{project}/tests/fast@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
-            sed -i 's@{project}/tests@{project}/tests/fast/api/test_dbapi00.py@g cibw.toml
+          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ ]] ; then
+            export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
           fi
           cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -89,6 +89,7 @@ jobs:
     name: Linux Extensions (ggc4)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
+    needs: linux-python3-9
     env:
       GEN: ninja
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -199,7 +199,7 @@ jobs:
         ls duckdb_tarball
         export DISTUTILS_C_COMPILER_LAUNCHER=ccache
         # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
-        if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ ]] ; then
+        if [[ "$GITHUB_REF" =~ ^refs/tags/v.+$ ]] ; then
           export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
         fi
         cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
@@ -259,7 +259,7 @@ jobs:
           mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ ]] ; then
+          if [[ "$GITHUB_REF" =~ ^refs/tags/v.+$ ]] ; then
             export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
           fi
           cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
@@ -327,7 +327,7 @@ jobs:
           mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ ]] ; then
+          if [[ "$GITHUB_REF" =~ ^refs/tags/v.+$ ]] ; then
             export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
           fi
           cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -89,7 +89,6 @@ jobs:
     name: Linux Extensions (ggc4)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
-    needs: linux-python3-9
     env:
       GEN: ninja
 
@@ -200,6 +199,9 @@ jobs:
         ls duckdb_tarball
         export DISTUTILS_C_COMPILER_LAUNCHER=ccache
         # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
+        if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+          export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
+        fi
         cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
         ls wheelhouse
 
@@ -257,6 +259,9 @@ jobs:
           mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
+          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+            export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
+          fi
           cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
 
       - name: Deploy
@@ -322,6 +327,9 @@ jobs:
           mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
           export DISTUTILS_C_COMPILER_LAUNCHER=ccache
           # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
+          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+|.*)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+            export CIBW_TEST_COMMAND='python -m pytest {project}/tests/fast/api/test_dbapi00.py  --verbose'
+          fi
           cibuildwheel --output-dir wheelhouse --config-file cibw.toml duckdb_tarball
 
       - name: Deploy

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -115,6 +115,7 @@ jobs:
         s3_id: ${{ secrets.S3_ID }}
         s3_key: ${{ secrets.S3_KEY }}
         signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
+        run_tests: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         treat_warn_as_error: 0
         ninja: 1
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -116,6 +116,7 @@ jobs:
         s3_key: ${{ secrets.S3_KEY }}
         signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
         run_tests: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run_autoload_tests: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         treat_warn_as_error: 0
         ninja: 1
 

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -40,7 +40,7 @@ jobs:
  regression-test-benchmark-runner:
   name: Regression Tests
   runs-on: ubuntu-20.04
-  if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -129,7 +129,7 @@ jobs:
  regression-test-storage:
   name: Storage Size Regression Test
   runs-on: ubuntu-20.04
-  if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -211,7 +211,7 @@ jobs:
  regression-test-python:
   name: Regression Test (Python Client)
   runs-on: ubuntu-20.04
-  if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -279,7 +279,7 @@ jobs:
  regression-test-plan-cost:
   name: Regression Test Join Order Plan Cost
   runs-on: ubuntu-20.04
-  if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -40,6 +40,7 @@ jobs:
  regression-test-benchmark-runner:
   name: Regression Tests
   runs-on: ubuntu-20.04
+  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -128,6 +129,7 @@ jobs:
  regression-test-storage:
   name: Storage Size Regression Test
   runs-on: ubuntu-20.04
+  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -209,6 +211,7 @@ jobs:
  regression-test-python:
   name: Regression Test (Python Client)
   runs-on: ubuntu-20.04
+  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -276,6 +279,7 @@ jobs:
  regression-test-plan-cost:
   name: Regression Test Join Order Plan Cost
   runs-on: ubuntu-20.04
+  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -40,7 +40,7 @@ jobs:
  regression-test-benchmark-runner:
   name: Regression Tests
   runs-on: ubuntu-20.04
-  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+  if: ${{ startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -129,7 +129,7 @@ jobs:
  regression-test-storage:
   name: Storage Size Regression Test
   runs-on: ubuntu-20.04
-  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+  if: ${{ startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -211,7 +211,7 @@ jobs:
  regression-test-python:
   name: Regression Test (Python Client)
   runs-on: ubuntu-20.04
-  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+  if: ${{ startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -279,7 +279,7 @@ jobs:
  regression-test-plan-cost:
   name: Regression Test Join Order Plan Cost
   runs-on: ubuntu-20.04
-  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+  if: ${{ startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -244,4 +244,5 @@ jobs:
          s3_key: ${{ secrets.S3_KEY }}
          signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
          run_tests: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+         run_autoload_tests: ${{ !startsWith(github.ref, 'refs/tags/v') }}
          unittest_script: python3 scripts/run_tests_one_by_one.py ./build/release/test/Release/unittest.exe

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -243,4 +243,5 @@ jobs:
          s3_id: ${{ secrets.S3_ID }}
          s3_key: ${{ secrets.S3_KEY }}
          signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
+         run_tests: ${{ !startsWith(github.ref, 'refs/tags/v') }}
          unittest_script: python3 scripts/run_tests_one_by_one.py ./build/release/test/Release/unittest.exe

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -68,14 +68,14 @@ jobs:
 
     - name: Test
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: |
         echo "DUCKDB_INSTALL_LIB=D:\a\duckdb\duckdb\src\Release\duckdb.dll" >> $env:GITHUB_ENV
         test/Release/unittest.exe
 
     - name: Tools Test
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: |
         python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
         tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
@@ -183,7 +183,7 @@ jobs:
  mingw:
      name: MingW (64 Bit)
      runs-on: windows-latest
-     if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
      needs: win-release-64
      steps:
        - uses: actions/checkout@v3

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -68,14 +68,14 @@ jobs:
 
     - name: Test
       shell: bash
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: |
         echo "DUCKDB_INSTALL_LIB=D:\a\duckdb\duckdb\src\Release\duckdb.dll" >> $env:GITHUB_ENV
         test/Release/unittest.exe
 
     - name: Tools Test
       shell: bash
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: |
         python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
         tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
@@ -183,7 +183,7 @@ jobs:
  mingw:
      name: MingW (64 Bit)
      runs-on: windows-latest
-     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+     if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
      needs: win-release-64
      steps:
        - uses: actions/checkout@v3

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -68,12 +68,14 @@ jobs:
 
     - name: Test
       shell: bash
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: |
         echo "DUCKDB_INSTALL_LIB=D:\a\duckdb\duckdb\src\Release\duckdb.dll" >> $env:GITHUB_ENV
         test/Release/unittest.exe
 
     - name: Tools Test
       shell: bash
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       run: |
         python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
         tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
@@ -139,7 +141,7 @@ jobs:
 
  win-release-32:
     name: Windows (32 Bit)
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
+    if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
     runs-on: windows-2019
     needs: win-release-64
 
@@ -181,6 +183,7 @@ jobs:
  mingw:
      name: MingW (64 Bit)
      runs-on: windows-latest
+     if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
      needs: win-release-64
      steps:
        - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adjusts the CI so that running (most) tests is skipped for release builds (tags). This should achieve the following goals:

* Make releases significantly faster by only building and uploading artifacts instead of also running all tests
* Avoid sporadically failing tests from preventing artifacts from being uploaded

Not running the tests should not be an issue. The release should be based on a nightly (which has run all of the tests). If any of the tests fail, finding out about it during the actual release process is too late anyway. 

It would be great if a few others could double-check that these changes are sane and don't disable the uploading of any artifacts. I've tried running them locally on my CI by inverting the condition (i.e. skipping tests if they are **not** releases) and that seems to work as intended.