### PR TITLE
Reusable workflow fixes

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: string
         default: "[]"
+      # Allows overriding the default s3 deploy script with a custom script
+      deploy_script:
+        require: false
+        type: string
+        default: "./duckdb/scripts/extension-upload-oote.sh"
 jobs:
   linux:
     name: Release
@@ -130,24 +135,22 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
           BUCKET_NAME: ${{ secrets.S3_BUCKET }}
+          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_KEY }}
+          # Catchall for secrets, allows overriding the deploy script with a custom one
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
         run: |
           git config --global --add safe.directory '*'
           cd duckdb
           git fetch --tags
           export DUCKDB_VERSION=`git tag --points-at HEAD`
           export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
-          echo "hi"
-          echo "$DUCKDB_VERSION"
-          echo "$BUCKET_NAME"
           cd ..
-          if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
-            echo 'No key set, skipping'
-          elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/tags/v.+)$ ]] ; then
+          if [[ "${{ inputs.extension_ref }}" =~ ^(refs/tags/v.+)$ ]] ; then
             python3 -m pip install pip awscli
-            ./scripts/extension-upload.sh ${{ inputs.extension_name }} ${{ inputs.extension_ref }} $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME true
+            ${{ inputs.deploy_script }} ${{ inputs.extension_name }} ${{ inputs.extension_ref }} $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME true
           elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/heads/main)$ ]] ; then
             python3 -m pip install pip awscli
-            ./scripts/extension-upload.sh ${{ inputs.extension_name }} `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME false
+            ${{ inputs.deploy_script }} ${{ inputs.extension_name }} `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME false
           fi
 
   macos:
@@ -227,6 +230,8 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
           BUCKET_NAME: ${{ secrets.S3_BUCKET }}
           DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_KEY }}
+          # Catchall for secrets, allows overriding the deploy script with a custom one
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
         run: |
           git config --global --add safe.directory '*'
           cd duckdb
@@ -234,14 +239,12 @@ jobs:
           export DUCKDB_VERSION=`git tag --points-at HEAD`
           export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
           cd ..
-          if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
-            echo 'No key set, skipping'
-          elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/tags/v.+)$ ]] ; then
+          if [[ "${{ inputs.extension_ref }}" =~ ^(refs/tags/v.+)$ ]] ; then
             python3 -m pip install pip awscli
-            ./scripts/extension-upload.sh ${{ inputs.extension_name }} ${{ inputs.extension_ref }} $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME true
+            ${{ inputs.deploy_script }} ${{ inputs.extension_name }} ${{ inputs.extension_ref }} $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME true
           elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/heads/main)$ ]] ; then
             python3 -m pip install pip awscli
-            ./scripts/extension-upload.sh ${{ inputs.extension_name }} `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME false
+            ${{ inputs.deploy_script }} ${{ inputs.extension_name }} `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.duckdb_arch}} $BUCKET_NAME false
           fi
 
   windows:
@@ -256,6 +259,8 @@ jobs:
             vcpkg_triplet: 'x64-windows-static-md'
     env:
       GEN: Ninja
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
 
     steps:
       - uses: actions/checkout@v3
@@ -276,6 +281,11 @@ jobs:
         uses: hendrikmuhs/ccache-action@main
         with:
           key: ${{ github.job }}-${{ matrix.duckdb_arch }}
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: 501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
 
       - name: Build extension
         run: |
@@ -300,6 +310,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
           BUCKET_NAME: ${{ secrets.S3_BUCKET }}
+          DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_KEY }}
+          # Catchall for secrets, allows overriding the deploy script with a custom one
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
         run: |
           git config --global --add safe.directory '*'
           cd duckdb
@@ -307,12 +320,10 @@ jobs:
           export DUCKDB_VERSION=`git tag --points-at HEAD`
           export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
           cd ..
-          if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
-            echo 'No key set, skipping'
-          elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/tags/v.+)$ ]] ; then
+          if [[ "${{ inputs.extension_ref }}" =~ ^(refs/tags/v.+)$ ]] ; then
             python -m pip install awscli
-            ./scripts/extension-upload.sh ${{ inputs.extension_name }} ${{ inputs.extension_ref }} $DUCKDB_VERSION ${{ matrix.duckdb_arch }} $BUCKET_NAME true 
+            ${{ inputs.deploy_script }} ${{ inputs.extension_name }} ${{ inputs.extension_ref }} $DUCKDB_VERSION ${{ matrix.duckdb_arch }} $BUCKET_NAME true 
           elif [[ "${{ inputs.extension_ref }}" =~ ^(refs/heads/main)$ ]] ; then
             python -m pip install awscli
-            ./scripts/extension-upload.sh ${{ inputs.extension_name }} `git log -1 --format=%h` $DUCKDB_VERSION ${{ matrix.duckdb_arch }} $BUCKET_NAME false 
+            ${{ inputs.deploy_script }} ${{ inputs.extension_name }} `git log -1 --format=%h` $DUCKDB_VERSION ${{ matrix.duckdb_arch }} $BUCKET_NAME false 
           fi

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -31,7 +31,7 @@ on:
         default: "[]"
       # Allows overriding the default s3 deploy script with a custom script
       deploy_script:
-        require: false
+        required: false
         type: string
         default: "./duckdb/scripts/extension-upload-oote.sh"
 jobs:

--- a/scripts/extension-upload-oote.sh
+++ b/scripts/extension-upload-oote.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Extension upload script for out of tree extensions
+
+# Usage: ./extension-upload-oote.sh <name> <extension_version> <duckdb_version> <architecture> <s3_bucket> <copy_to_latest>
+# <name>                : Name of the extension
+# <extension_version>   : Version (commit / version tag) of the extension
+# <duckdb_version>      : Version (commit / version tag) of DuckDB
+# <architecture>        : Architecture target of the extension binary
+# <s3_bucket>           : S3 bucket to upload to
+# <copy_to_latest>      : Set this as the latest version ("true" / "false", default: "false")
+
+set -e
+
+ext="build/release/extension/$1/$1.duckdb_extension"
+
+script_dir="$(dirname "$(readlink -f "$0")")"
+
+# Abort if AWS key is not set
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "No AWS key found, skipping.."
+    exit 0
+fi
+
+# (Optionally) Sign binary
+if [ "$DUCKDB_EXTENSION_SIGNING_PK" != "" ]; then
+  echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
+  $script_dir/compute-extension-hash.sh $ext > $ext.hash
+  openssl pkeyutl -sign -in $ext.hash -inkey private.pem -pkeyopt digest:sha256 -out $ext.sign
+  cat $ext.sign >> $ext
+fi
+
+set -e
+
+# compress extension binary
+gzip < "${ext}" > "$ext.gz"
+
+# upload compressed extension binary to S3
+aws s3 cp $ext.gz s3://$5/$1/$2/$3/$4/$1.duckdb_extension.gz --acl public-read
+
+# upload to latest if copy_to_latest is set to true
+if [[ $6 = 'true' ]]; then
+  aws s3 cp $ext.gz s3://$5/$1/latest/$3/$4/$1.duckdb_extension.gz --acl public-read
+fi
+
+if [ "$DUCKDB_EXTENSION_SIGNING_PK" != "" ]; then
+  rm private.pem
+fi


### PR DESCRIPTION
Some last-minute changes to the reusable workflow that is used by the extension template:
- vcpkg now configured for windows
- add a scripts/extension-upload-oote.sh script that oote's can use to deploy their binaries. This simplifies the process of updating out-of-tree extensions for existing releases as it will sign the binaries using CI which we can then simply copy over to the public repo
- all gh secrets are passed to the upload script, allowing people to still use the reusble workflow for their extension repo while using their own upload script and pass secrets to it