### PR TITLE
[Dev] Fix `array_slice_vector_type.test`

### DIFF
--- a/test/fuzzer/duckfuzz/array_slice_vector_type.test
+++ b/test/fuzzer/duckfuzz/array_slice_vector_type.test
@@ -2,17 +2,51 @@
 # description: Fuzzyduck issue #1228
 # group: [duckfuzz]
 
-query I
-SELECT array_pop_front(x) FROM test_vector_types('x') AS t1(x);
+# Verify that the array_pop_front() properly removes one element
+
+query II nosort expected
+SELECT
+	length(original) == length(altered) + 1
+from (
+	select
+		x as original,
+		array_pop_front(x) as altered
+	FROM test_vector_types('x') AS t1(x)
+);
 ----
-🦆🦆🦆🦆🦆
-oo\0se
+
+query II nosort expected
+select case
+	when x IS NULL
+		then
+			NULL
+		else
+			true
+		end
+	from test_vector_types('x') t1(x);
+----
+
+statement ok
+create table tbl (i integer[]);
+
+statement ok
+insert into tbl VALUES
+(NULL),
+([5,3,2,1]),
+(NULL),
+(NULL),
+([1]),
+([NULL]),
+([345,2,31,23,123,1,2,1,1,1])
+
+# Check that NULLs are handled correctly
+query I
+select array_pop_front(i) from tbl;
+----
 NULL
-🦆🦆🦆🦆🦆
-🦆🦆🦆🦆🦆
-🦆🦆🦆🦆🦆
-oo\0se
+[3, 2, 1]
 NULL
-🦆🦆🦆🦆🦆
-oo\0se
 NULL
+[]
+[]
+[2, 31, 23, 123, 1, 2, 1, 1, 1]


### PR DESCRIPTION
The test was using explicit result checking when using `test_vector_types`, that sadly breaks.

Changed it to not use explicit result checking
Added another test below it that does explicitly check the result, but doesn't break with different sizes.