### PR TITLE
Python: Uniform DuckDB SQL version to v0.X.Y

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -275,13 +275,13 @@ def git_dev_version():
         dev_version = long_version.split('-')[1]
         if int(dev_version) == 0:
             # directly on a tag: emit the regular version
-            return '.'.join(version_splits)
+            return "v" + '.'.join(version_splits)
         else:
             # not on a tag: increment the version by one and add a -devX suffix
             version_splits[2] = str(int(version_splits[2]) + 1)
-            return '.'.join(version_splits) + "-dev" + dev_version
+            return "v" + '.'.join(version_splits) + "-dev" + dev_version
     except:
-        return "0.0.0"
+        return "v0.0.0"
 
 
 def generate_duckdb_hpp(header_file):

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -135,9 +135,16 @@ def git_commit_hash():
         return "deadbeeff"
 
 
+def prefix_version(version):
+    """Make sure the version is prefixed with 'v' to be of the form vX.Y.Z"""
+    if version.startswith('v'):
+        return version
+    return 'v' + version
+
+
 def git_dev_version():
     if 'SETUPTOOLS_SCM_PRETEND_VERSION' in os.environ:
-        return os.environ['SETUPTOOLS_SCM_PRETEND_VERSION']
+        return prefix_version(os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'])
     try:
         version = subprocess.check_output(['git', 'describe', '--tags', '--abbrev=0']).strip().decode('utf8')
         long_version = subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
@@ -145,13 +152,13 @@ def git_dev_version():
         dev_version = long_version.split('-')[1]
         if int(dev_version) == 0:
             # directly on a tag: emit the regular version
-            return '.'.join(version_splits)
+            return "v" + '.'.join(version_splits)
         else:
             # not on a tag: increment the version by one and add a -devX suffix
             version_splits[2] = str(int(version_splits[2]) + 1)
-            return '.'.join(version_splits) + "-dev" + dev_version
+            return "v" + '.'.join(version_splits) + "-dev" + dev_version
     except:
-        return "0.0.0"
+        return "v0.0.0"
 
 
 def include_package(pkg_name, pkg_dir, include_files, include_list, source_list):

--- a/test/sql/pragma/test_pragma_version.test
+++ b/test/sql/pragma/test_pragma_version.test
@@ -19,3 +19,8 @@ select * from pragma_platform();
 
 statement ok
 select platform from pragma_platform();
+
+query I
+SELECT count(*) FROM pragma_version() WHERE library_version LIKE 'v%';
+----
+1

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -294,7 +294,7 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) { // NOLINT
 
 	m.doc() = "DuckDB is an embeddable SQL OLAP Database Management System";
 	m.attr("__package__") = "duckdb";
-	m.attr("__version__") = DuckDB::LibraryVersion();
+	m.attr("__version__") = std::string(DuckDB::LibraryVersion()).substr(1);
 	m.attr("__standard_vector_size__") = DuckDB::StandardVectorSize();
 	m.attr("__git_revision__") = DuckDB::SourceID();
 	m.attr("__interactive__") = DuckDBPyConnection::DetectAndGetEnvironment();

--- a/tools/pythonpkg/tests/fast/adbc/test_connection_get_info.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_connection_get_info.py
@@ -34,7 +34,7 @@ class TestADBCConnectionGetInfo(object):
         expected_result = pa.array(
             [
                 "duckdb",
-                duckdb.__version__,  # don't hardcode this, as it will change every version
+                "v" + duckdb.__version__,  # don't hardcode this, as it will change every version
                 "ADBC DuckDB Driver",
                 "(unknown)",
                 "(unknown)",


### PR DESCRIPTION
Another take on https://github.com/duckdb/duckdb/pull/9050 (actually I saw that the right thing could be done cutting on the used code).

Idea is that SQL side `PRAGMA version` should be independent of client, so return v0.X.Y even for Python where it was using the 0.X.Y to follow the package versioning scheme.

This means DuckDB Python package and DuckDB version will be not completely aligned, and might even get less aligned over time, see discussion in https://github.com/duckdb/duckdb/pull/9050.