### PR TITLE
No longer build i686 wheels for Python /2

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        arch: [i686, x86_64, aarch64]
+        arch: [x86_64, aarch64]
         python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
@@ -145,14 +145,12 @@ jobs:
           - isRelease: false
             python_build: 'cp311-*'
           - isRelease: false
-            arch: i686
-          - isRelease: false
             arch: aarch64
     needs: manylinux-extensions-x64
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
       CIBW_SKIP: '*-musllinux_aarch64'
-      CIBW_ARCHS: ${{ matrix.arch == 'i686' && 'auto32' || matrix.arch == 'aarch64' && 'aarch64' || 'auto64' }}
+      CIBW_ARCHS: ${{ matrix.arch == 'aarch64' && 'aarch64' || 'auto64' }}
       SETUPTOOLS_SCM_NO_LOCAL: 'yes'
       PYTEST_TIMEOUT: '600'
       DUCKDB_BUILD_UNITY: 1

--- a/tools/pythonpkg/tests/fast/api/test_read_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_read_csv.py
@@ -398,6 +398,7 @@ class TestReadCSV(object):
         with pytest.raises(ValueError, match="Can not read from a non file-like object"):
             res = duckdb_cursor.read_csv(obj, header=True).fetchall()
 
+    @pytest.mark.skip(reason="depends on garbage collector behaviour, and sporadically breaks in CI")
     def test_internal_object_filesystem_cleanup(self, duckdb_cursor):
         _ = pytest.importorskip("fsspec")
 


### PR DESCRIPTION
PR https://github.com/duckdb/duckdb/pull/9099 from @Mytherin
> These builds are failing because NumPy does not build wheels for this platform anymore, and the source compilation is failing (see https://github.com/numpy/numpy/issues/24703). Rather than trying to fix that I think it is time to stop building wheels for 32-bit platforms.

plus a commit silencing a flaky test.