### PR TITLE
Fix fuzzer exclusion

### DIFF
--- a/extension/sqlsmith/statement_generator.cpp
+++ b/extension/sqlsmith/statement_generator.cpp
@@ -52,9 +52,9 @@ shared_ptr<GeneratorContext> StatementGenerator::GetDatabaseState(ClientContext 
 		            [&](CatalogEntry &entry) { result->scalar_functions.push_back(entry); });
 		schema.Scan(context, CatalogType::TABLE_FUNCTION_ENTRY, [&](CatalogEntry &entry) {
 			// don't include fuzz functions
-			if (entry.name.find("fuzzyduck") == std::string::npos ||
-			    entry.name.find("fuzz_all_functions") == std::string::npos ||
-			    entry.name.find("reduce_sql_statement") == std::string::npos ||
+			if (entry.name.find("fuzzyduck") == std::string::npos &&
+			    entry.name.find("fuzz_all_functions") == std::string::npos &&
+			    entry.name.find("reduce_sql_statement") == std::string::npos &&
 			    entry.name.find("sqlsmith") == std::string::npos) {
 				result->table_functions.push_back(entry);
 			}


### PR DESCRIPTION
Had a brain fart and used the wrong logical operator for function exclusion.

Previously the conjunction of the `or`s would still let in all the fuzzer functions.  Chaining it to `and` means that a function that does not match *any* of the fuzzer functions will be added. If a function matches *one* of the fuzzer functions `(entry.name.find("fuzzyduck") == std::string::npos)` will be false and the function will not be added