### PR TITLE
chore(tests): skip unsupported windows test on windows

### DIFF
--- a/tools/pythonpkg/tests/fast/test_filesystem.py
+++ b/tools/pythonpkg/tests/fast/test_filesystem.py
@@ -139,6 +139,7 @@ class TestPythonFilesystem:
         with raises(ModuleNotFoundError):
             duckdb_cursor.register_filesystem(None)
 
+    @mark.skipif(sys.platform.startswith("win", reason="ArrowFSWrapper doesn't support Windows paths")
     @mark.skipif(sys.version_info < (3, 8), reason="ArrowFSWrapper requires python 3.8 or higher")
     def test_arrow_fs_wrapper(self, tmp_path: Path, duckdb_cursor: DuckDBPyConnection):
         fs = importorskip('pyarrow.fs')


### PR DESCRIPTION
Hi all, trying to get 0.9.0 to build on conda-forge and these tests are breaking things.

The filesystem test says it isn't supported on windows, so that one is a straightforward skip.

I initially thought that `test_union_contains_nested_data` was a problem with Arrow versions, but it isn't.  So I don't know why that test is failing.

Builds are here: https://github.com/conda-forge/python-duckdb-feedstock/pull/84