### PR TITLE
[PythonDev] Don't dereference None when creating pandas dataframe

### DIFF
--- a/tools/pythonpkg/src/numpy/array_wrapper.cpp
+++ b/tools/pythonpkg/src/numpy/array_wrapper.cpp
@@ -216,7 +216,7 @@ struct StringConvert {
 	static NUMPY_T NullValue(bool &set_mask) {
 		if (PANDAS) {
 			set_mask = false;
-			return Py_None;
+			return nullptr;
 		}
 		set_mask = true;
 		return nullptr;

--- a/tools/pythonpkg/src/numpy/array_wrapper.cpp
+++ b/tools/pythonpkg/src/numpy/array_wrapper.cpp
@@ -216,7 +216,7 @@ struct StringConvert {
 	static NUMPY_T NullValue(bool &set_mask) {
 		if (PANDAS) {
 			set_mask = false;
-			return nullptr;
+			Py_RETURN_NONE;
 		}
 		set_mask = true;
 		return nullptr;

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_df_none.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_df_none.py
@@ -6,14 +6,10 @@ import gc
 
 
 class TestPandasDFNone(object):
+    # This used to decrease the ref count of None
     def test_none_deref(self):
         con = duckdb.connect()
         gc.collect()
-        none_refcount = sys.getrefcount(None)
         for _ in range(1000):
             df = con.sql("select NULL::VARCHAR as a").df()
-
         gc.collect()
-        after = sys.getrefcount(None)
-        # Verify that we don't deref None when creating a Pandas DataFrame
-        assert after >= none_refcount

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_df_none.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_df_none.py
@@ -9,7 +9,4 @@ class TestPandasDFNone(object):
     # This used to decrease the ref count of None
     def test_none_deref(self):
         con = duckdb.connect()
-        gc.collect()
-        for _ in range(1000):
-            df = con.sql("select NULL::VARCHAR as a").df()
-        gc.collect()
+        df = con.sql("select NULL::VARCHAR as a from range(1000000)").df()

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_df_none.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_df_none.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+import duckdb
+import sys
+import gc
+
+
+class TestPandasDFNone(object):
+    def test_none_deref(self):
+        con = duckdb.connect()
+        gc.collect()
+        none_refcount = sys.getrefcount(None)
+        for _ in range(1000):
+            df = con.sql("select NULL::VARCHAR as a").df()
+
+        gc.collect()
+        after = sys.getrefcount(None)
+        # Verify that we don't deref None when creating a Pandas DataFrame
+        assert after >= none_refcount


### PR DESCRIPTION
This PR fixes #9110 

When creating a pandas dataframe, we first create Numpy arrays.
Recently we changed the logic for pandas so None is returned for NULL when converting a varchar column.
Because we use `Py_None` this is an object and numpy takes ownership of it, lowering the refcount when it gets deleted.

Instead we should return `nullptr` so Numpy knows that it's not a none.