### PR TITLE
Update R-CMD-Check workflow

### DIFF
--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -17,7 +17,7 @@ on:
       - '!tools/swift/**'
       - '.github/patches/duckdb-wasm/**'
       - '.github/workflows/**'
-      - '!.github/workflows/Swift.yml'
+      - '!.github/workflows/R_CMD_CHECK.yml'
 
   pull_request:
     types: [ opened, reopened, ready_for_review ]
@@ -27,7 +27,7 @@ on:
       - '!tools/odbc/**'
       - '.github/patches/duckdb-wasm/**'
       - '.github/workflows/**'
-      - '!.github/workflows/Main.yml'
+      - '!.github/workflows/R_CMD_CHECK.yml'
 
 
 name: R-CMD-check

--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -92,7 +92,7 @@ jobs:
       - name: update duckdb-r src code with PR code
         shell: bash
         working-directory: ${{ env.DUCKDB_R_SRC }}
-        run: ./vendor.sh
+        run: ./vendor.sh duckdb
 
       - uses: r-lib/actions/check-r-package@v2
         with:


### PR DESCRIPTION
For the R-CMD-check, we build R using code in any new PR. The code is updated using the R's [vendor.sh](https://github.com/duckdb/duckdb-r/blob/main/vendor.sh) script. This script isn't too robust, so I have made some changes [here](https://github.com/duckdb/duckdb-r/pull/20) to pass the dir name of the duckdb directory. 

Here I'm making the change to pass the dir name of the duckdb directory. This should make the R-CMD-Check script more stable so breakage doesn't happen too often.