### PR TITLE
[PythonDev] Rework `duckdb_cursor` fixture in pytest

### DIFF
--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -189,7 +189,7 @@ def require():
 
 
 # By making the scope 'function' we ensure that a new connection gets created for every function that uses the fixture
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(scope='function')
 def spark():
     if not hasattr(spark, 'session'):
         # Cache the import
@@ -199,16 +199,29 @@ def spark():
     return spark.session.builder.master(':memory:').appName('pyspark').getOrCreate()
 
 
-@pytest.fixture(scope='session', autouse=True)
-def duckdb_cursor(request):
+@pytest.fixture(scope='function')
+def duckdb_cursor():
     connection = duckdb.connect('')
-    cursor = connection.cursor()
+    yield connection
+    connection.close()
+
+
+@pytest.fixture(scope='function')
+def integers(duckdb_cursor):
+    cursor = duckdb_cursor
     cursor.execute('CREATE TABLE integers (i integer)')
     cursor.execute('INSERT INTO integers VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(NULL)')
+    yield
+    cursor.execute("drop table integers")
+
+
+@pytest.fixture(scope='function')
+def timestamps(duckdb_cursor):
+    cursor = duckdb_cursor
     cursor.execute('CREATE TABLE timestamps (t timestamp)')
     cursor.execute("INSERT INTO timestamps VALUES ('1992-10-03 18:34:45'), ('2010-01-01 00:00:01'), (NULL)")
-    cursor.execute("CALL dbgen(sf=0.01)")
-    return cursor
+    yield
+    cursor.execute("drop table timestamps")
 
 
 @pytest.fixture(scope="function")

--- a/tools/pythonpkg/tests/fast/api/test_dbapi00.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi00.py
@@ -11,12 +11,12 @@ def assert_result_equal(result):
 
 
 class TestSimpleDBAPI(object):
-    def test_regular_selection(self, duckdb_cursor):
+    def test_regular_selection(self, duckdb_cursor, integers):
         duckdb_cursor.execute('SELECT * FROM integers')
         result = duckdb_cursor.fetchall()
         assert_result_equal(result)
 
-    def test_fetchmany_default(self, duckdb_cursor):
+    def test_fetchmany_default(self, duckdb_cursor, integers):
         # Get truth-value
         truth_value = len(duckdb_cursor.execute("select * from integers").fetchall())
 
@@ -37,7 +37,7 @@ class TestSimpleDBAPI(object):
         res = duckdb_cursor.fetchmany(3)
         assert len(res) == 0
 
-    def test_fetchmany(self, duckdb_cursor):
+    def test_fetchmany(self, duckdb_cursor, integers):
         # Get truth value
         truth_value = len(duckdb_cursor.execute("select * from integers").fetchall())
         duckdb_cursor.execute('select * from integers')
@@ -62,7 +62,7 @@ class TestSimpleDBAPI(object):
         res = duckdb_cursor.fetchmany(3)
         assert len(res) == 0
 
-    def test_fetchmany_too_many(self, duckdb_cursor):
+    def test_fetchmany_too_many(self, duckdb_cursor, integers):
         truth_value = len(duckdb_cursor.execute('select * from integers').fetchall())
         duckdb_cursor.execute('select * from integers')
         res = duckdb_cursor.fetchmany(truth_value * 5)
@@ -73,7 +73,7 @@ class TestSimpleDBAPI(object):
         res = duckdb_cursor.fetchmany(3)
         assert len(res) == 0
 
-    def test_numpy_selection(self, duckdb_cursor):
+    def test_numpy_selection(self, duckdb_cursor, integers, timestamps):
         duckdb_cursor.execute('SELECT * FROM integers')
         result = duckdb_cursor.fetchnumpy()
         arr = numpy.ma.masked_array(numpy.arange(11))
@@ -87,7 +87,7 @@ class TestSimpleDBAPI(object):
         numpy.testing.assert_array_equal(result['t'], arr, "Incorrect result returned")
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_pandas_selection(self, duckdb_cursor, pandas):
+    def test_pandas_selection(self, duckdb_cursor, pandas, integers, timestamps):
         import datetime
 
         duckdb_cursor.execute('SELECT * FROM integers')

--- a/tools/pythonpkg/tests/fast/api/test_dbapi01.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi01.py
@@ -5,7 +5,7 @@ import duckdb
 
 
 class TestMultipleResultSets(object):
-    def test_regular_selection(self, duckdb_cursor):
+    def test_regular_selection(self, duckdb_cursor, integers):
         duckdb_cursor.execute('SELECT * FROM integers')
         duckdb_cursor.execute('SELECT * FROM integers')
         result = duckdb_cursor.fetchall()
@@ -23,7 +23,7 @@ class TestMultipleResultSets(object):
             (None,),
         ], "Incorrect result returned"
 
-    def test_numpy_selection(self, duckdb_cursor):
+    def test_numpy_selection(self, duckdb_cursor, integers):
         duckdb_cursor.execute('SELECT * FROM integers')
         duckdb_cursor.execute('SELECT * FROM integers')
         result = duckdb_cursor.fetchnumpy()
@@ -31,7 +31,7 @@ class TestMultipleResultSets(object):
 
         numpy.testing.assert_array_equal(result['i'], expected)
 
-    def test_numpy_materialized(self, duckdb_cursor):
+    def test_numpy_materialized(self, duckdb_cursor, integers):
         connection = duckdb.connect('')
         cursor = connection.cursor()
         cursor.execute('CREATE TABLE integers (i integer)')

--- a/tools/pythonpkg/tests/fast/api/test_dbapi04.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi04.py
@@ -2,7 +2,7 @@
 
 
 class TestSimpleDBAPI(object):
-    def test_regular_selection(self, duckdb_cursor):
+    def test_regular_selection(self, duckdb_cursor, integers):
         duckdb_cursor.execute('SELECT * FROM integers')
         result = duckdb_cursor.fetchall()
         assert result == [

--- a/tools/pythonpkg/tests/fast/api/test_dbapi10.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi10.py
@@ -18,7 +18,7 @@ class TestCursorDescription(object):
             ["SELECT union_value(tag := 1) AS union_col", "union_col", "UNION(tag INTEGER)", int],
         ],
     )
-    def test_description(self, query, column_name, string_type, real_type, duckdb_cursor):
+    def test_description(self, query, column_name, string_type, real_type, duckdb_cursor, timestamps, integers):
         duckdb_cursor.execute(query)
         assert duckdb_cursor.description == [(column_name, string_type, None, None, None, None, None)]
         assert isinstance(duckdb_cursor.fetchone()[0], real_type)

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_fetch_recordbatch.py
@@ -135,7 +135,7 @@ class TestArrowFetchRecordBatch(object):
         assert res == correct
 
     # Test with Map
-    def test_record_batch_next_batch_list(self, duckdb_cursor):
+    def test_record_batch_next_batch_map(self, duckdb_cursor):
         duckdb_cursor = duckdb.connect()
         duckdb_cursor_check = duckdb.connect()
         duckdb_cursor.execute("CREATE table t as select map([i], [i+1]) as a from range(3000)  as tbl(i);")


### PR DESCRIPTION
It no longer comes prepacked with 'integers' and 'timestamps', these are now separate fixtures that use the connection.
And the scope has been changed from `session` to `function`

Every function will have its own connection, this should hopefully avoid all future issues that would arise from registering objects/tables on the connection that cause unforeseen breakages on other functions that run later.