### PR TITLE
[PythonDev] Fix #duckdb-internal/418

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -3,6 +3,7 @@ import duckdb
 import os
 import pytest
 import tempfile
+from conftest import pandas_supports_arrow_backend
 
 pa = pytest.importorskip("pyarrow")
 pq = pytest.importorskip("pyarrow.parquet")
@@ -12,6 +13,8 @@ re = pytest.importorskip("re")
 
 
 def create_pyarrow_pandas(rel):
+    if not pandas_supports_arrow_backend():
+        pytest.skip(reason="Pandas version doesn't support 'pyarrow' backend")
     return rel.df().convert_dtypes(dtype_backend='pyarrow')
 
 


### PR DESCRIPTION
Fix up issue from previous PR #9155 

When merging pandas-arrow into the pyarrow filter pushdown we should just if the version of pandas supports `pyarrow` backend.