### PR TITLE
chore: skip arrow union tests on pyarrow<11

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_union.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_union.py
@@ -13,6 +13,7 @@ def test_nested():
 
 
 def test_union_contains_nested_data():
+    _ = importorskip("pyarrow", minversion="11")
     res = run("select ['hello']::UNION(first_name VARCHAR, middle_names VARCHAR[]) as res")
     assert types.is_union(res.type)
     assert res.value == scalar(['hello'], type=list_(string()))


### PR DESCRIPTION
This fixes one of the failing tests in the conda-forge build for 0.9.0.