### PR TITLE
Issue #9183: Arbitrary ASOF Conditions

### DIFF
--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -135,6 +135,9 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(ClientContext &con
 	bool need_to_consider_arbitrary_expressions = true;
 	switch (reftype) {
 	case JoinRefType::ASOF: {
+		if (!arbitrary_expressions.empty()) {
+			throw BinderException("Invalid ASOF JOIN condition");
+		}
 		need_to_consider_arbitrary_expressions = false;
 		auto asof_idx = conditions.size();
 		for (size_t c = 0; c < conditions.size(); ++c) {

--- a/test/sql/join/asof/test_asof_join.test
+++ b/test/sql/join/asof/test_asof_join.test
@@ -17,23 +17,6 @@ INSERT INTO events0 VALUES
 	(8, 3)
 ;
 
-# ASOF join on a constant (e.g. ON 1=1)
-query II
-SELECT p.ts, e.value
-FROM range(0,10) p(ts) ASOF JOIN events0 e
-ON 1 = 1 AND p.ts >= e.begin
-ORDER BY p.ts ASC
-----
-1	0
-2	0
-3	1
-4	1
-5	1
-6	2
-7	2
-8	3
-9	3
-
 # Use an ASOF join inside of a correlated subquery
 
 
@@ -49,6 +32,15 @@ ON p.ts <> e.begin
 ORDER BY p.ts ASC
 ----
 Binder Error: Invalid ASOF JOIN comparison
+
+# Invalid ASOF JOIN condition
+statement error
+SELECT p.ts, e.value
+FROM range(0,10) p(ts) ASOF JOIN events0 e
+ON 1 = 1 AND p.ts >= e.begin
+ORDER BY p.ts ASC
+----
+Binder Error: Invalid ASOF JOIN condition
 
 # Missing ASOF JOIN inequality
 statement error


### PR DESCRIPTION
These should not be allowed bcause they don't get pushed through the join correctly.

fixes: #9183 
fixes: duckdblabs/duckdb-internal#424
