### PR TITLE
Add instructions for jdk installed via brew

### DIFF
--- a/tools/jdbc/README.md
+++ b/tools/jdbc/README.md
@@ -1,0 +1,9 @@
+
+If the build can't find `$JAVA_HOME` You must set $JAVA_HOME yourself.
+
+If you are on a Mac and install `openjdk` via `brew` then additionally, it's required to set:
+```
+export JAVA_AWT_LIBRARY=$JAVA_HOME/libexec/openjdk.jdk/Contents/Home/lib
+```
+because the FindJNI.cmake macro doesn't look there for the `awt` library.
+

--- a/tools/jdbc/README.md
+++ b/tools/jdbc/README.md
@@ -1,5 +1,6 @@
 
-If the build can't find `$JAVA_HOME` You must set $JAVA_HOME yourself.
+It's required to have a JDK installed to build.
+If the build can't find the env variable `$JAVA_HOME` You must set `$JAVA_HOME` yourself.
 
 If you are on a Mac and install `openjdk` via `brew` then additionally, it's required to set:
 ```

--- a/tools/jdbc/README.md
+++ b/tools/jdbc/README.md
@@ -6,5 +6,5 @@ If you are on a Mac and install `openjdk` via `brew` then additionally, it's req
 ```
 export JAVA_AWT_LIBRARY=$JAVA_HOME/libexec/openjdk.jdk/Contents/Home/lib
 ```
-because the FindJNI.cmake macro doesn't look there for the `awt` library.
+because the [`FindJNI.cmake`](https://cmake.org/cmake/help/latest/module/FindJNI.html) module doesn't look there for the `awt` library.
 

--- a/tools/jdbc/README.md
+++ b/tools/jdbc/README.md
@@ -1,6 +1,6 @@
 
 It's required to have a JDK installed to build.
-If the build can't find the env variable `$JAVA_HOME` You must set `$JAVA_HOME` yourself.
+Make sure the `JAVA_HOME` environment variable is set.
 
 If you are on a Mac and install `openjdk` via `brew` then additionally, it's required to set:
 ```


### PR DESCRIPTION
I had an issue with FindJNI.cmake not finding my brew installed JDK.
It looked like some others over time had the same issue on discord, so added a README.
Perhaps it should be in the cmake logic itself, but not sure we can assume brew install.