### PR TITLE
Internal #445: Destruct All Aggregates

### DIFF
--- a/src/execution/perfect_aggregate_hashtable.cpp
+++ b/src/execution/perfect_aggregate_hashtable.cpp
@@ -298,12 +298,10 @@ void PerfectAggregateHashTable::Destroy() {
 	RowOperationsState row_state(*aggregate_allocator);
 	data_ptr_t payload_ptr = data;
 	for (idx_t i = 0; i < total_groups; i++) {
-		if (group_is_set[i]) {
-			data_pointers[count++] = payload_ptr;
-			if (count == STANDARD_VECTOR_SIZE) {
-				RowOperations::DestroyStates(row_state, layout, addresses, count);
-				count = 0;
-			}
+		data_pointers[count++] = payload_ptr;
+		if (count == STANDARD_VECTOR_SIZE) {
+			RowOperations::DestroyStates(row_state, layout, addresses, count);
+			count = 0;
 		}
 		payload_ptr += tuple_size;
 	}


### PR DESCRIPTION
Remove the destructor filter in case the Initialize method allocated memory.

fixes: duckdblabs/duckdb-internal#445