### PR TITLE
Don't initialize data chunk in ExpressionExecutor if it's just a BoundReferenceExpression

### DIFF
--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -64,7 +64,7 @@ void DataChunk::InitializeEmpty(vector<LogicalType>::const_iterator begin, vecto
 }
 
 void DataChunk::Reset() {
-	if (data.empty()) {
+	if (data.empty() || vector_caches.empty()) {
 		return;
 	}
 	if (vector_caches.size() != data.size()) {

--- a/src/execution/expression_executor/execute_reference.cpp
+++ b/src/execution/expression_executor/execute_reference.cpp
@@ -6,7 +6,7 @@ namespace duckdb {
 unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundReferenceExpression &expr,
                                                                 ExpressionExecutorState &root) {
 	auto result = make_uniq<ExpressionState>(expr, root);
-	result->Finalize();
+	result->Finalize(true);
 	return result;
 }
 

--- a/src/execution/expression_executor_state.cpp
+++ b/src/execution/expression_executor_state.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/execution/expression_executor_state.hpp"
+
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -10,8 +11,13 @@ void ExpressionState::AddChild(Expression *expr) {
 	child_states.push_back(ExpressionExecutor::InitializeState(*expr, root));
 }
 
-void ExpressionState::Finalize() {
-	if (!types.empty()) {
+void ExpressionState::Finalize(bool empty) {
+	if (types.empty()) {
+		return;
+	}
+	if (empty) {
+		intermediate_chunk.InitializeEmpty(types);
+	} else {
 		intermediate_chunk.Initialize(GetAllocator(), types);
 	}
 }

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -33,7 +33,7 @@ struct ExpressionState {
 
 public:
 	void AddChild(Expression *expr);
-	void Finalize();
+	void Finalize(bool empty = false);
 	Allocator &GetAllocator();
 	bool HasContext();
 	DUCKDB_API ClientContext &GetContext();


### PR DESCRIPTION
Fixes #8874