### PR TITLE
[ODBC] Add Unittests to Windows CI Run

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -259,12 +259,6 @@ jobs:
         cmake -DNANODBC_DISABLE_TESTS=OFF ..
         cmake --build .
 
-    - name: Install psqlodbc
-      shell: bash
-      run: |
-        git clone https://github.com/Mytherin/psqlodbc.git
-        (cd psqlodbc && git checkout edd9890a5046a2006f210849abb97c6a6589a45c && make debug)
-
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main
       with:
@@ -282,10 +276,6 @@ jobs:
     - name: Test nanodbc
       shell: bash
       run: ./tools/odbc/test/run_nanodbc_tests.sh
-
-    - name: Test psqlodbc
-      shell: bash
-      run: ./tools/odbc/test/run_psqlodbc_tests.sh
 
     - name: Test isql
       shell: bash

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -121,18 +121,10 @@ jobs:
         echo "----------------------------------------------------------------"
         Reg Query "HKCU\SOFTWARE\ODBC\ODBC.INI\ODBC"
 
-    - name: Install psqlodbc
+    - name: Test Standard ODBC tests
       shell: bash
       run: |
-        git clone https://github.com/Mytherin/psqlodbc.git
-        (cd psqlodbc && git checkout edd9890a5046a2006f210849abb97c6a6589a45c && make release)
-
-    - name: Test psqlodbc
-      shell: bash
-      run: |
-        cd psqlodbc
-        export PSQLODBC_TEST_DSN=DuckDB
-        build/release/Release/psql_odbc_test.exe -f ../tools/odbc/test/psql_supported_tests
+        tools/odbc/bin/Release/test_odbc.exe
 
     - name: Print ODBC trace on failure
       if: ${{ failure() }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -55,9 +55,9 @@ jobs:
         key: ${{ github.job }}
         save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
 
-    - name: Install pytest
-      run: |
-        python -m pip install pytest
+#    - name: Install pytest
+#      run: |
+#        python -m pip install pytest
 
     - name: Build
       shell: bash
@@ -66,19 +66,19 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 -DENABLE_EXTENSION_AUTOLOADING=1 -DENABLE_EXTENSION_AUTOINSTALL=1 -DDUCKDB_EXTENSION_CONFIGS="${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake" -DBUILD_ODBC_DRIVER=1 -DDISABLE_UNITY=1
         cmake --build . --config Release
 
-    - name: Test
-      shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-      run: |
-        echo "DUCKDB_INSTALL_LIB=D:\a\duckdb\duckdb\src\Release\duckdb.dll" >> $env:GITHUB_ENV
-        test/Release/unittest.exe
-
-    - name: Tools Test
-      shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-      run: |
-        python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
-        tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
+#    - name: Test
+#      shell: bash
+#      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+#      run: |
+#        echo "DUCKDB_INSTALL_LIB=D:\a\duckdb\duckdb\src\Release\duckdb.dll" >> $env:GITHUB_ENV
+#        test/Release/unittest.exe
+#
+#    - name: Tools Test
+#      shell: bash
+#      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+#      run: |
+#        python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
+#        tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
 
     - name: Deploy
       shell: bash

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -55,9 +55,9 @@ jobs:
         key: ${{ github.job }}
         save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
 
-#    - name: Install pytest
-#      run: |
-#        python -m pip install pytest
+    - name: Install pytest
+      run: |
+        python -m pip install pytest
 
     - name: Build
       shell: bash
@@ -66,19 +66,19 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 -DENABLE_EXTENSION_AUTOLOADING=1 -DENABLE_EXTENSION_AUTOINSTALL=1 -DDUCKDB_EXTENSION_CONFIGS="${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake" -DBUILD_ODBC_DRIVER=1 -DDISABLE_UNITY=1
         cmake --build . --config Release
 
-#    - name: Test
-#      shell: bash
-#      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-#      run: |
-#        echo "DUCKDB_INSTALL_LIB=D:\a\duckdb\duckdb\src\Release\duckdb.dll" >> $env:GITHUB_ENV
-#        test/Release/unittest.exe
-#
-#    - name: Tools Test
-#      shell: bash
-#      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-#      run: |
-#        python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
-#        tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
+    - name: Test
+      shell: bash
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      run: |
+        echo "DUCKDB_INSTALL_LIB=D:\a\duckdb\duckdb\src\Release\duckdb.dll" >> $env:GITHUB_ENV
+        test/Release/unittest.exe
+
+    - name: Tools Test
+      shell: bash
+      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      run: |
+        python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
+        tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
 
     - name: Deploy
       shell: bash

--- a/tools/odbc/CMakeLists.txt
+++ b/tools/odbc/CMakeLists.txt
@@ -54,6 +54,6 @@ add_library(
 set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")
 target_link_libraries(duckdb_odbc ${LINK_LIB_LIST} duckdb_static)
 
-if(NOT WIN32 AND NOT CLANG_TIDY)
+if(NOT CLANG_TIDY)
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
As of this PR the Windows CI now runs the ODBC Unittests.

The Windows and Linux CI's also no longer run the psqlodbc tests. 