### PR TITLE
[ODBC] Add info to fatal error in compiler

### DIFF
--- a/tools/odbc/CMakeLists.txt
+++ b/tools/odbc/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12.0)
 find_package(ODBC)
 
 if(NOT ODBC_FOUND)
-  message(FATAL_ERROR No ODBC found)
+  message(FATAL_ERROR "No ODBC found; you need to install unixodbc-dev.")
 endif()
 
 set(LINK_LIB_LIST "")


### PR DESCRIPTION
Add info to fatal error when compiling ODBC if unixodbc-dev is not installed.

Related #8976