### PR TITLE
Add `json_serialize_plan`, json_serialize_sql tweaks

### DIFF
--- a/extension/json/CMakeLists.txt
+++ b/extension/json/CMakeLists.txt
@@ -29,6 +29,7 @@ set(JSON_EXTENSION_FILES
     json_functions/json_type.cpp
     json_functions/json_valid.cpp
     json_functions/json_serialize_sql.cpp
+    json_functions/json_serialize_plan.cpp
     json_functions/read_json.cpp
     json_functions/read_json_objects.cpp
     ${YYJSON_OBJECT_FILES})

--- a/extension/json/include/json_functions.hpp
+++ b/extension/json/include/json_functions.hpp
@@ -101,6 +101,7 @@ private:
 	static ScalarFunctionSet GetValidFunction();
 	static ScalarFunctionSet GetSerializeSqlFunction();
 	static ScalarFunctionSet GetDeserializeSqlFunction();
+	static ScalarFunctionSet GetSerializePlanFunction();
 
 	static PragmaFunctionSet GetExecuteJsonSerializedSqlPragmaFunction();
 

--- a/extension/json/include/json_serializer.hpp
+++ b/extension/json/include/json_serializer.hpp
@@ -24,13 +24,13 @@ private:
 	// Either adds a value to the current object with the current tag, or appends it to the current array
 	void PushValue(yyjson_mut_val *val);
 
+public:
 	explicit JsonSerializer(yyjson_mut_doc *doc, bool skip_if_null, bool skip_if_empty)
 	    : doc(doc), stack({yyjson_mut_obj(doc)}), skip_if_null(skip_if_null), skip_if_empty(skip_if_empty) {
 		serialize_enum_as_string = true;
 		serialize_default_values = true;
 	}
 
-public:
 	template <class T>
 	static yyjson_mut_val *Serialize(T &value, yyjson_mut_doc *doc, bool skip_if_null, bool skip_if_empty) {
 		JsonSerializer serializer(doc, skip_if_null, skip_if_empty);

--- a/extension/json/json_config.py
+++ b/extension/json/json_config.py
@@ -28,6 +28,7 @@ source_files = [
         'extension/json/json_functions/read_json_objects.cpp',
         'extension/json/json_functions/read_json.cpp',
         'extension/json/yyjson/yyjson.cpp',
+        'extension/json/json_functions/json_serialize_plan.cpp',
         'extension/json/json_functions/json_serialize_sql.cpp',
         'extension/json/json_serializer.cpp',
         'extension/json/json_deserializer.cpp',

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -157,6 +157,7 @@ vector<ScalarFunctionSet> JSONFunctions::GetScalarFunctions() {
 	functions.push_back(GetKeysFunction());
 	functions.push_back(GetTypeFunction());
 	functions.push_back(GetValidFunction());
+	functions.push_back(GetSerializePlanFunction());
 	functions.push_back(GetSerializeSqlFunction());
 	functions.push_back(GetDeserializeSqlFunction());
 

--- a/extension/json/json_functions/CMakeLists.txt
+++ b/extension/json/json_functions/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library_unity(
   json_create.cpp
   json_type.cpp
   json_valid.cpp
+  json_serialize_plan.cpp
   json_serialize_sql.cpp
   read_json.cpp
   read_json_objects.cpp)

--- a/extension/json/json_functions/json_serialize_plan.cpp
+++ b/extension/json/json_functions/json_serialize_plan.cpp
@@ -1,0 +1,207 @@
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/parser/parsed_data/create_pragma_function_info.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/planner.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/execution/column_binding_resolver.hpp"
+
+#include "json_deserializer.hpp"
+#include "json_functions.hpp"
+#include "json_serializer.hpp"
+#include "json_common.hpp"
+
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+
+namespace duckdb {
+
+//-----------------------------------------------------------------------------
+// json_serialize_plan
+//-----------------------------------------------------------------------------
+struct JsonSerializePlanBindData : public FunctionData {
+	bool skip_if_null = false;
+	bool skip_if_empty = false;
+	bool format = false;
+	bool optimize = false;
+
+	JsonSerializePlanBindData(bool skip_if_null_p, bool skip_if_empty_p, bool format_p, bool optimize_p)
+	    : skip_if_null(skip_if_null_p), skip_if_empty(skip_if_empty_p), format(format_p), optimize(optimize_p) {
+	}
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<JsonSerializePlanBindData>(skip_if_null, skip_if_empty, format, optimize);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
+	}
+};
+
+static unique_ptr<FunctionData> JsonSerializePlanBind(ClientContext &context, ScalarFunction &bound_function,
+                                                      vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.empty()) {
+		throw BinderException("json_serialize_plan takes at least one argument");
+	}
+
+	if (arguments[0]->return_type != LogicalType::VARCHAR) {
+		throw InvalidTypeException("json_serialize_plan first argument must be a VARCHAR");
+	}
+
+	// Optional arguments
+	bool skip_if_null = false;
+	bool skip_if_empty = false;
+	bool format = false;
+	bool optimize = false;
+
+	for (idx_t i = 1; i < arguments.size(); i++) {
+		auto &arg = arguments[i];
+		if (arg->HasParameter()) {
+			throw ParameterNotResolvedException();
+		}
+		if (!arg->IsFoldable()) {
+			throw BinderException("json_serialize_plan: arguments must be constant");
+		}
+		if (arg->alias == "skip_null") {
+			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+				throw BinderException("json_serialize_plan: 'skip_null' argument must be a boolean");
+			}
+			skip_if_null = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
+		} else if (arg->alias == "skip_empty") {
+			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+				throw BinderException("json_serialize_plan: 'skip_empty' argument must be a boolean");
+			}
+			skip_if_empty = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
+		} else if (arg->alias == "format") {
+			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+				throw BinderException("json_serialize_plan: 'format' argument must be a boolean");
+			}
+			format = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
+		} else if (arg->alias == "optimize") {
+			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
+				throw BinderException("json_serialize_plan: 'optimize' argument must be a boolean");
+			}
+			optimize = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
+		} else {
+			throw BinderException(StringUtil::Format("json_serialize_plan: Unknown argument '%s'", arg->alias.c_str()));
+		}
+	}
+	return make_uniq<JsonSerializePlanBindData>(skip_if_null, skip_if_empty, format, optimize);
+}
+
+static bool OperatorSupportsSerialization(LogicalOperator &op, string &operator_name) {
+	for (auto &child : op.children) {
+		if (!OperatorSupportsSerialization(*child, operator_name)) {
+			return false;
+		}
+	}
+	auto supported = op.SupportSerialization();
+	if (!supported) {
+		operator_name = EnumUtil::ToString(op.type);
+	}
+	return supported;
+}
+
+static void JsonSerializePlanFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &local_state = JSONFunctionLocalState::ResetAndGet(state);
+	auto alc = local_state.json_allocator.GetYYAlc();
+	auto &inputs = args.data[0];
+
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	const auto &info = func_expr.bind_info->Cast<JsonSerializePlanBindData>();
+
+	if (!state.HasContext()) {
+		throw InvalidInputException("json_serialize_plan: No client context available");
+	}
+	auto &context = state.GetContext();
+
+	UnaryExecutor::Execute<string_t, string_t>(inputs, result, args.size(), [&](string_t input) {
+		auto doc = JSONCommon::CreateDocument(alc);
+		auto result_obj = yyjson_mut_obj(doc);
+		yyjson_mut_doc_set_root(doc, result_obj);
+
+		try {
+			Parser parser;
+			parser.ParseQuery(input.GetString());
+			auto plans_arr = yyjson_mut_arr(doc);
+
+			for (auto &statement : parser.statements) {
+				auto stmt = std::move(statement);
+
+				Planner planner(context);
+				planner.CreatePlan(std::move(stmt));
+				auto plan = std::move(planner.plan);
+
+				if (info.optimize && plan->RequireOptimizer()) {
+					Optimizer optimizer(*planner.binder, context);
+					plan = optimizer.Optimize(std::move(plan));
+				}
+
+				ColumnBindingResolver resolver;
+				resolver.Verify(*plan);
+				resolver.VisitOperator(*plan);
+				plan->ResolveOperatorTypes();
+
+				string operator_name;
+				if (!OperatorSupportsSerialization(*plan, operator_name)) {
+					throw InvalidInputException("Operator '%s' does not support serialization", operator_name);
+				}
+
+				auto plan_json = JsonSerializer::Serialize(*plan, doc, info.skip_if_null, info.skip_if_empty);
+				yyjson_mut_arr_append(plans_arr, plan_json);
+			}
+
+			yyjson_mut_obj_add_false(doc, result_obj, "error");
+			yyjson_mut_obj_add_val(doc, result_obj, "plans", plans_arr);
+
+			idx_t len;
+			auto data = yyjson_mut_val_write_opts(result_obj,
+			                                      info.format ? JSONCommon::WRITE_PRETTY_FLAG : JSONCommon::WRITE_FLAG,
+			                                      alc, reinterpret_cast<size_t *>(&len), nullptr);
+			if (data == nullptr) {
+				throw SerializationException(
+				    "Failed to serialize json, perhaps the query contains invalid utf8 characters?");
+			}
+
+			return StringVector::AddString(result, data, len);
+
+		} catch (Exception &exception) {
+			yyjson_mut_obj_add_true(doc, result_obj, "error");
+			yyjson_mut_obj_add_strcpy(doc, result_obj, "error_type",
+			                          StringUtil::Lower(exception.ExceptionTypeToString(exception.type)).c_str());
+			yyjson_mut_obj_add_strcpy(doc, result_obj, "error_message", exception.RawMessage().c_str());
+
+			idx_t len;
+			auto data = yyjson_mut_val_write_opts(result_obj,
+			                                      info.format ? JSONCommon::WRITE_PRETTY_FLAG : JSONCommon::WRITE_FLAG,
+			                                      alc, reinterpret_cast<size_t *>(&len), nullptr);
+			return StringVector::AddString(result, data, len);
+		}
+	});
+}
+
+ScalarFunctionSet JSONFunctions::GetSerializePlanFunction() {
+	ScalarFunctionSet set("json_serialize_plan");
+
+	set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, JSONCommon::JSONType(), JsonSerializePlanFunction,
+	                               JsonSerializePlanBind, nullptr, nullptr, JSONFunctionLocalState::Init));
+
+	set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN}, JSONCommon::JSONType(),
+	                               JsonSerializePlanFunction, JsonSerializePlanBind, nullptr, nullptr,
+	                               JSONFunctionLocalState::Init));
+
+	set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
+	                               JSONCommon::JSONType(), JsonSerializePlanFunction, JsonSerializePlanBind, nullptr,
+	                               nullptr, JSONFunctionLocalState::Init));
+
+	set.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
+	                   JSONCommon::JSONType(), JsonSerializePlanFunction, JsonSerializePlanBind, nullptr, nullptr,
+	                   JSONFunctionLocalState::Init));
+	set.AddFunction(ScalarFunction(
+	    {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
+	    JSONCommon::JSONType(), JsonSerializePlanFunction, JsonSerializePlanBind, nullptr, nullptr,
+	    JSONFunctionLocalState::Init));
+	return set;
+}
+
+} // namespace duckdb

--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -50,25 +50,25 @@ static unique_ptr<FunctionData> JsonSerializeBind(ClientContext &context, Scalar
 			throw ParameterNotResolvedException();
 		}
 		if (!arg->IsFoldable()) {
-			throw InvalidInputException("arguments to json_serialize_sql must be constant");
+			throw BinderException("json_serialize_sql: arguments must be constant");
 		}
 		if (arg->alias == "skip_null") {
 			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
-				throw InvalidTypeException("skip_null argument must be a boolean");
+				throw BinderException("json_serialize_sql: 'skip_null' argument must be a boolean");
 			}
 			skip_if_null = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (arg->alias == "skip_empty") {
 			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
-				throw InvalidTypeException("skip_empty argument must be a boolean");
+				throw BinderException("json_serialize_sql: 'skip_empty' argument must be a boolean");
 			}
 			skip_if_empty = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else if (arg->alias == "format") {
 			if (arg->return_type.id() != LogicalTypeId::BOOLEAN) {
-				throw InvalidTypeException("indent argument must be a boolean");
+				throw BinderException("json_serialize_sql: 'format' argument must be a boolean");
 			}
 			format = BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arg));
 		} else {
-			throw BinderException(StringUtil::Format("Unknown argument to json_serialize_sql: %s", arg->alias.c_str()));
+			throw BinderException(StringUtil::Format("json_serialize_sql: Unknown argument '%s'", arg->alias.c_str()));
 		}
 	}
 	return make_uniq<JsonSerializeBindData>(skip_if_null, skip_if_empty, format);

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -61,6 +61,7 @@ static constexpr ExtensionEntry EXTENSION_FUNCTIONS[] = {
     {"json_merge_patch", "json"},
     {"json_object", "json"},
     {"json_quote", "json"},
+    {"json_serialize_plan", "json"},
     {"json_serialize_sql", "json"},
     {"json_structure", "json"},
     {"json_transform", "json"},

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -1,6 +1,8 @@
 # name: test/sql/json/test_json_serialize_plan.test
 # group: [json]
 
+require noforcestorage
+
 require json
 
 statement ok

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -31,10 +31,11 @@ SELECT json_serialize_plan('SELECT AND LAUNCH ROCKETS WHERE 1 = 1');
 {"error":true,"error_type":"parser","error_message":"syntax error at or near \"AND\"\nLINE 1: SELECT AND LAUNCH ROCKETS WHERE 1 = 1\n               ^"}
 
 # Example with binding error
+# The binding error message "did you mean table xyz" is not deterministic, so use a LIKE here.
 query I
-SELECT json_serialize_plan('SELECT * FROM nonexistent_table');
+SELECT json_serialize_plan('SELECT * FROM nonexistent_table') LIKE '{"error":true,"error_type":"catalog","error_message":"Table with name nonexistent_table does not exist%';
 ----
-{"error":true,"error_type":"catalog","error_message":"Table with name nonexistent_table does not exist!\nDid you mean \"temp.information_schema.tables\"?\nLINE 1: SELECT * FROM nonexistent_table\n                      ^"}
+true
 
 query I
 SELECT json_serialize_plan('COPY (SELECT 1) TO ''foobar''');

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -1,0 +1,42 @@
+# name: test/sql/json/test_json_serialize_plan.test
+# group: [json]
+
+require json
+
+statement ok
+CREATE TABLE tbl1 (i int);
+
+# Example with simple query
+query I
+SELECT json_serialize_plan('SELECT 1 + 2 FROM tbl1');
+----
+{"error":false,"plans":[{"type":"LOGICAL_PROJECTION","children":[{"type":"LOGICAL_GET","children":[],"table_index":0,"returned_types":[{"id":"INTEGER","type_info":null}],"names":["i"],"column_ids":[18446744073709551615],"projection_ids":[],"table_filters":{"filters":[]},"name":"seq_scan","arguments":[],"original_arguments":[],"has_serialize":true,"function_data":{"catalog":"memory","schema":"main","table":"tbl1","is_index_scan":false,"is_create_index":false,"result_ids":[]},"projected_input":[]}],"table_index":1,"expressions":[{"expression_class":"BOUND_FUNCTION","type":"BOUND_FUNCTION","alias":"","return_type":{"id":"INTEGER","type_info":null},"children":[{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","alias":"","value":{"type":{"id":"INTEGER","type_info":null},"is_null":false,"value":1}},{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","alias":"","value":{"type":{"id":"INTEGER","type_info":null},"is_null":false,"value":2}}],"name":"+","arguments":[{"id":"INTEGER","type_info":null},{"id":"INTEGER","type_info":null}],"original_arguments":[],"has_serialize":false,"is_operator":true}]}]}
+
+# Example with skip_null and skip_empty
+query I
+SELECT json_serialize_plan('SELECT *, 1 + 2 FROM tbl1', skip_null := true, skip_empty := true);
+----
+{"error":false,"plans":[{"type":"LOGICAL_PROJECTION","children":[{"type":"LOGICAL_GET","table_index":0,"returned_types":[{"id":"INTEGER"}],"names":["i"],"column_ids":[0],"name":"seq_scan","has_serialize":true,"function_data":{"catalog":"memory","schema":"main","table":"tbl1","is_index_scan":false,"is_create_index":false}}],"table_index":1,"expressions":[{"expression_class":"BOUND_REF","type":"BOUND_REF","alias":"i","return_type":{"id":"INTEGER"},"index":0},{"expression_class":"BOUND_FUNCTION","type":"BOUND_FUNCTION","return_type":{"id":"INTEGER"},"children":[{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","value":{"type":{"id":"INTEGER"},"is_null":false,"value":1}},{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","value":{"type":{"id":"INTEGER"},"is_null":false,"value":2}}],"name":"+","arguments":[{"id":"INTEGER"},{"id":"INTEGER"}],"has_serialize":false,"is_operator":true}]}]}
+
+# Example with skip_null and skip_empty and optimize
+query I
+SELECT json_serialize_plan('SELECT *, 1 + 2 FROM tbl1', skip_null := true, skip_empty := true, optimize := true);
+----
+{"error":false,"plans":[{"type":"LOGICAL_PROJECTION","children":[{"type":"LOGICAL_GET","table_index":0,"returned_types":[{"id":"INTEGER"}],"names":["i"],"column_ids":[0],"projection_ids":[0],"name":"seq_scan","has_serialize":true,"function_data":{"catalog":"memory","schema":"main","table":"tbl1","is_index_scan":false,"is_create_index":false}}],"table_index":1,"expressions":[{"expression_class":"BOUND_REF","type":"BOUND_REF","alias":"i","return_type":{"id":"INTEGER"},"index":0},{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","value":{"type":{"id":"INTEGER"},"is_null":false,"value":3}}]}]}
+
+# Example with syntax error
+query I
+SELECT json_serialize_plan('SELECT AND LAUNCH ROCKETS WHERE 1 = 1');
+----
+{"error":true,"error_type":"parser","error_message":"syntax error at or near \"AND\"\nLINE 1: SELECT AND LAUNCH ROCKETS WHERE 1 = 1\n               ^"}
+
+# Example with binding error
+query I
+SELECT json_serialize_plan('SELECT * FROM nonexistent_table');
+----
+{"error":true,"error_type":"catalog","error_message":"Table with name nonexistent_table does not exist!\nDid you mean \"temp.information_schema.tables\"?\nLINE 1: SELECT * FROM nonexistent_table\n                      ^"}
+
+query I
+SELECT json_serialize_plan('COPY (SELECT 1) TO ''foobar''');
+----
+{"error":true,"error_type":"invalid input","error_message":"Operator 'LOGICAL_COPY_TO_FILE' does not support serialization"}

--- a/test/sql/json/test_json_serialize_sql.test
+++ b/test/sql/json/test_json_serialize_sql.test
@@ -1,4 +1,4 @@
-# name: test/sql/json/test_serialize_sql.test
+# name: test/sql/json/test_json_serialize_sql.test
 # group: [json]
 
 require json


### PR DESCRIPTION
This PR adds a new `json_serialize_plan(VARCHAR)` scalar function to serialize a sequence of semicolon-separated sql statements into a json containing a list of each statements query plan, in json format. This is now possible for most* operators due to the recent serialization overhaul.

Like the `json_serialize_sql` function, this also takes `skip_empty := bool`, `skip_null := bool`, `format := bool` optional arguments to control the json output, as well as an additional `optimize := bool` argument specifying whether or not to serialize after or before plan optimization (default false, without optimizing).

Future work:
- Implement de/serialization support for the last couple of unsupported operators
- Implement a way to execute the produced json serialized plans, similar to the `json_execute_serialized_sql` table function. This is more complicated since the plans are already bound after deserialization and some plans don't produce any values as results (e.g. insert), but we still need to bind some column return types/names if we go the table function route.
