### PR TITLE
Use all CPUs when compiling from scratch for NodeJS

### DIFF
--- a/tools/nodejs/package.json
+++ b/tools/nodejs/package.json
@@ -16,7 +16,7 @@
     "host": "https://duckdb-node.s3.amazonaws.com"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build",
+    "install": "node-pre-gyp install --fallback-to-build -j max",
     "pretest": "node test/support/createdb.js",
     "test": "mocha -R spec --timeout 480000 --expose-gc",
     "test-path": "mocha -R spec --timeout 480000 --expose-gc --exclude 'test/*.ts'",


### PR DESCRIPTION
Noticed that NodeJS builds take a very long time (15-20mins), and they don't scale with more CPUs. Turns out we can easily ask `node-gyp` to specify the parallel jobs by adding `-j <n>` and using `-j max` to specify the number of CPUs available. 

Running `scripts/build_node.sh`:

Before:
```
gyp info using node-gyp@9.4.0
gyp info using node@18.18.0 | darwin | x64
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
```

After, on my very old MacBook(2+2 cores):
```
gyp info using node-gyp@9.4.0
gyp info using node@18.18.0 | darwin | x64
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build', '--jobs', 4 ]
```