### PR TITLE
Continue replaying checkpoint on duckdb restart if we see a checkpoint entry in the WAL

### DIFF
--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -99,8 +99,12 @@ public:
 	bool skip_writing;
 
 public:
+	struct ReplayStatus {
+		bool should_truncate_wal;
+		bool should_checkpoint;
+	};
 	//! Replay the WAL
-	static bool Replay(AttachedDatabase &database, string &path);
+	static ReplayStatus Replay(AttachedDatabase &database, string &path);
 
 	//! Returns the current size of the WAL in bytes
 	int64_t GetWALSize();


### PR DESCRIPTION
The presence of this entry means DuckDB was attempting to perform a checkpoint when it crashed last time. Let's just finish up the checkpoint on restart.