### PR TITLE
[Dev] BatchedDataCollection - make it possible to scan a range of batches

### DIFF
--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -483,6 +483,7 @@ main/capi/arrow-c.cpp	8
 main/capi/cast/from_decimal-c.cpp	5
 main/capi/cast/utils-c.cpp	3
 main/chunk_scan_state/query_result.cpp	28
+main/chunk_scan_state/batched_data_collection.cpp	31
 main/capi/data_chunk-c.cpp	30
 main/capi/duckdb-c.cpp	3
 main/capi/duckdb_value-c.cpp	14

--- a/.github/config/uncovered_files.csv
+++ b/.github/config/uncovered_files.csv
@@ -68,7 +68,7 @@ common/tree_renderer.cpp	9
 common/types.cpp	88
 common/extra_type_info.cpp	34
 common/virtual_file_system.cpp	32
-common/types/batched_data_collection.cpp	11
+common/types/batched_data_collection.cpp	39
 common/types/bit.cpp	9
 common/types/blob.cpp	3
 common/types/chunk_collection.cpp	94

--- a/src/common/types/batched_data_collection.cpp
+++ b/src/common/types/batched_data_collection.cpp
@@ -11,6 +11,11 @@ BatchedDataCollection::BatchedDataCollection(ClientContext &context_p, vector<Lo
     : context(context_p), types(std::move(types_p)), buffer_managed(buffer_managed_p) {
 }
 
+BatchedDataCollection::BatchedDataCollection(ClientContext &context_p, vector<LogicalType> types_p, batch_map_t batches,
+                                             bool buffer_managed_p)
+    : context(context_p), types(std::move(types_p)), buffer_managed(buffer_managed_p), data(std::move(batches)) {
+}
+
 void BatchedDataCollection::Append(DataChunk &input, idx_t batch_index) {
 	D_ASSERT(batch_index != DConstants::INVALID_INDEX);
 	optional_ptr<ColumnDataCollection> collection;
@@ -50,28 +55,34 @@ void BatchedDataCollection::Merge(BatchedDataCollection &other) {
 	other.data.clear();
 }
 
-void BatchedDataCollection::InitializeScan(BatchedChunkScanState &state) {
-	state.iterator = data.begin();
-	if (state.iterator == data.end()) {
+void BatchedDataCollection::InitializeScan(BatchedChunkScanState &state, const BatchedChunkIteratorRange &range) {
+	state.range = range;
+	if (state.range.begin == state.range.end) {
 		return;
 	}
-	state.iterator->second->InitializeScan(state.scan_state);
+	state.range.begin->second->InitializeScan(state.scan_state);
+}
+
+void BatchedDataCollection::InitializeScan(BatchedChunkScanState &state) {
+	auto range = BatchRange();
+	return InitializeScan(state, range);
 }
 
 void BatchedDataCollection::Scan(BatchedChunkScanState &state, DataChunk &output) {
-	while (state.iterator != data.end()) {
+	while (state.range.begin != state.range.end) {
 		// check if there is a chunk remaining in this collection
-		auto collection = state.iterator->second.get();
+		auto collection = state.range.begin->second.get();
 		collection->Scan(state.scan_state, output);
 		if (output.size() > 0) {
 			return;
 		}
 		// there isn't! move to the next collection
-		state.iterator++;
-		if (state.iterator == data.end()) {
+		state.range.begin->second.reset();
+		state.range.begin++;
+		if (state.range.begin == state.range.end) {
 			return;
 		}
-		state.iterator->second->InitializeScan(state.scan_state);
+		state.range.begin->second->InitializeScan(state.scan_state);
 	}
 }
 
@@ -90,6 +101,64 @@ unique_ptr<ColumnDataCollection> BatchedDataCollection::FetchCollection() {
 		return make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), types);
 	}
 	return result;
+}
+
+const vector<LogicalType> &BatchedDataCollection::Types() const {
+	return types;
+}
+
+idx_t BatchedDataCollection::Count() const {
+	idx_t count = 0;
+	for (auto &collection : data) {
+		count += collection.second->Count();
+	}
+	return count;
+}
+
+idx_t BatchedDataCollection::BatchCount() const {
+	return data.size();
+}
+
+idx_t BatchedDataCollection::IndexToBatchIndex(idx_t index) const {
+	if (index >= data.size()) {
+		throw InternalException("Index %d is out of range for this collection, it only contains %d batches", index,
+		                        data.size());
+	}
+	auto entry = data.begin();
+	std::advance(entry, index);
+	return entry->first;
+}
+
+idx_t BatchedDataCollection::BatchSize(idx_t batch_index) const {
+	auto &collection = Batch(batch_index);
+	return collection.Count();
+}
+
+const ColumnDataCollection &BatchedDataCollection::Batch(idx_t batch_index) const {
+	auto entry = data.find(batch_index);
+	if (entry == data.end()) {
+		throw InternalException("This batched data collection does not contain a collection for batch_index %d",
+		                        batch_index);
+	}
+	return *entry->second;
+}
+
+BatchedChunkIteratorRange BatchedDataCollection::BatchRange(idx_t begin_idx, idx_t end_idx) {
+	D_ASSERT(begin_idx < end_idx);
+	if (end_idx > data.size()) {
+		// Limit the iterator to the end
+		end_idx = DConstants::INVALID_INDEX;
+	}
+	BatchedChunkIteratorRange range;
+	range.begin = data.begin();
+	std::advance(range.begin, begin_idx);
+	if (end_idx == DConstants::INVALID_INDEX) {
+		range.end = data.end();
+	} else {
+		range.end = data.begin();
+		std::advance(range.end, end_idx);
+	}
+	return range;
 }
 
 string BatchedDataCollection::ToString() const {

--- a/src/include/duckdb/common/types/batched_data_collection.hpp
+++ b/src/include/duckdb/common/types/batched_data_collection.hpp
@@ -15,8 +15,16 @@ namespace duckdb {
 class BufferManager;
 class ClientContext;
 
+using batch_map_t = map<idx_t, unique_ptr<ColumnDataCollection>>;
+using batch_iterator_t = typename batch_map_t::iterator;
+
+struct BatchedChunkIteratorRange {
+	batch_iterator_t begin;
+	batch_iterator_t end;
+};
+
 struct BatchedChunkScanState {
-	map<idx_t, unique_ptr<ColumnDataCollection>>::iterator iterator;
+	BatchedChunkIteratorRange range;
 	ColumnDataScanState scan_state;
 };
 
@@ -25,12 +33,17 @@ struct BatchedChunkScanState {
 class BatchedDataCollection {
 public:
 	DUCKDB_API BatchedDataCollection(ClientContext &context, vector<LogicalType> types, bool buffer_managed = false);
+	DUCKDB_API BatchedDataCollection(ClientContext &context, vector<LogicalType> types, batch_map_t batches,
+	                                 bool buffer_managed = false);
 
 	//! Appends a datachunk with the given batch index to the batched collection
 	DUCKDB_API void Append(DataChunk &input, idx_t batch_index);
 
 	//! Merge the other batched chunk collection into this batched collection
 	DUCKDB_API void Merge(BatchedDataCollection &other);
+
+	// Initialize a scan over a range of batches of the batched chunk collection
+	void InitializeScan(BatchedChunkScanState &state, const BatchedChunkIteratorRange &range);
 
 	//! Initialize a scan over the batched chunk collection
 	DUCKDB_API void InitializeScan(BatchedChunkScanState &state);
@@ -40,6 +53,27 @@ public:
 
 	//! Fetch a column data collection from the batched data collection - this consumes all of the data stored within
 	DUCKDB_API unique_ptr<ColumnDataCollection> FetchCollection();
+
+	//! Inspect how many tuples this batched data collection contains
+	DUCKDB_API idx_t Count() const;
+
+	//! Inspect the types of the collection
+	DUCKDB_API const vector<LogicalType> &Types() const;
+
+	//! Inspect how many batches this collection contains
+	DUCKDB_API idx_t BatchCount() const;
+
+	//! Retrieve the batch index of the nth batch in the collection
+	DUCKDB_API idx_t IndexToBatchIndex(idx_t index) const;
+
+	//! Inspect how big a given batch is
+	DUCKDB_API idx_t BatchSize(idx_t batch_index) const;
+
+	//! Inspect a given batch through a const reference
+	const ColumnDataCollection &Batch(idx_t batch_index) const;
+
+	//! Create an iterator range from the provided indices
+	BatchedChunkIteratorRange BatchRange(idx_t begin = 0, idx_t end = DConstants::INVALID_INDEX);
 
 	DUCKDB_API string ToString() const;
 	DUCKDB_API void Print() const;
@@ -59,4 +93,5 @@ private:
 	//! The last batch collection that was inserted into
 	CachedCollection last_collection;
 };
+
 } // namespace duckdb


### PR DESCRIPTION
Previously the scan state only allowed us to scan all batches.

For the Numpy Array ResultCollector I am creating Tasks that each contain a single batch to convert to Numpy data.
This is part of that PR, but I figured I would split the work into multiple PRs to make it more manageable.

Also as a sanity check to see if this should even be the approach to take for this.
This change should have no effect on the existing use of the BatchedDataCollection.

One thing to note:
While scanning from the scan state, we now clean up the previous batch:
`state.range.begin->second.reset();`