### PR TITLE
[Arrow][Dev] Make each produced Array own its own memory.

### DIFF
--- a/src/common/arrow/appender/list_data.cpp
+++ b/src/common/arrow/appender/list_data.cpp
@@ -69,10 +69,10 @@ void ArrowListData::Finalize(ArrowAppendData &append_data, const LogicalType &ty
 	result->buffers[1] = append_data.main_buffer.data();
 
 	auto &child_type = ListType::GetChildType(type);
-	append_data.child_pointers.resize(1);
+	ArrowAppender::AddChildren(append_data, 1);
 	result->children = append_data.child_pointers.data();
 	result->n_children = 1;
-	append_data.child_pointers[0] = ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[0]));
+	append_data.child_arrays[0] = *ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[0]));
 }
 
 } // namespace duckdb

--- a/src/common/arrow/appender/list_data.cpp
+++ b/src/common/arrow/appender/list_data.cpp
@@ -72,7 +72,7 @@ void ArrowListData::Finalize(ArrowAppendData &append_data, const LogicalType &ty
 	append_data.child_pointers.resize(1);
 	result->children = append_data.child_pointers.data();
 	result->n_children = 1;
-	append_data.child_pointers[0] = ArrowAppender::FinalizeChild(child_type, *append_data.child_data[0]);
+	append_data.child_pointers[0] = ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[0]));
 }
 
 } // namespace duckdb

--- a/src/common/arrow/appender/map_data.cpp
+++ b/src/common/arrow/appender/map_data.cpp
@@ -59,10 +59,11 @@ void ArrowMapData::Finalize(ArrowAppendData &append_data, const LogicalType &typ
 	append_data.child_pointers.resize(1);
 	result->children = append_data.child_pointers.data();
 	result->n_children = 1;
-	append_data.child_pointers[0] = ArrowAppender::FinalizeChild(type, *append_data.child_data[0]);
+
+	auto &struct_data = *append_data.child_data[0];
+	append_data.child_pointers[0] = ArrowAppender::FinalizeChild(type, std::move(append_data.child_data[0]));
 
 	// now that struct has two children: the key and the value type
-	auto &struct_data = *append_data.child_data[0];
 	auto &struct_result = append_data.child_pointers[0];
 	struct_data.child_pointers.resize(2);
 	struct_result->n_buffers = 1;
@@ -74,8 +75,8 @@ void ArrowMapData::Finalize(ArrowAppendData &append_data, const LogicalType &typ
 
 	auto &key_type = MapType::KeyType(type);
 	auto &value_type = MapType::ValueType(type);
-	struct_data.child_pointers[0] = ArrowAppender::FinalizeChild(key_type, *struct_data.child_data[0]);
-	struct_data.child_pointers[1] = ArrowAppender::FinalizeChild(value_type, *struct_data.child_data[1]);
+	struct_data.child_pointers[0] = ArrowAppender::FinalizeChild(key_type, std::move(struct_data.child_data[0]));
+	struct_data.child_pointers[1] = ArrowAppender::FinalizeChild(value_type, std::move(struct_data.child_data[1]));
 
 	// keys cannot have null values
 	if (struct_data.child_pointers[0]->null_count > 0) {

--- a/src/common/arrow/appender/map_data.cpp
+++ b/src/common/arrow/appender/map_data.cpp
@@ -52,34 +52,38 @@ void ArrowMapData::Append(ArrowAppendData &append_data, Vector &input, idx_t fro
 
 void ArrowMapData::Finalize(ArrowAppendData &append_data, const LogicalType &type, ArrowArray *result) {
 	// set up the main map buffer
+	D_ASSERT(result);
 	result->n_buffers = 2;
 	result->buffers[1] = append_data.main_buffer.data();
 
 	// the main map buffer has a single child: a struct
-	append_data.child_pointers.resize(1);
+	ArrowAppender::AddChildren(append_data, 1);
 	result->children = append_data.child_pointers.data();
 	result->n_children = 1;
 
 	auto &struct_data = *append_data.child_data[0];
-	append_data.child_pointers[0] = ArrowAppender::FinalizeChild(type, std::move(append_data.child_data[0]));
+	auto struct_result = ArrowAppender::FinalizeChild(type, std::move(append_data.child_data[0]));
 
-	// now that struct has two children: the key and the value type
-	auto &struct_result = append_data.child_pointers[0];
-	struct_data.child_pointers.resize(2);
-	struct_result->n_buffers = 1;
-	struct_result->n_children = 2;
-	struct_result->length = struct_data.child_data[0]->row_count;
+	// Initialize the struct array data
+	const auto struct_child_count = 2;
+	ArrowAppender::AddChildren(struct_data, struct_child_count);
 	struct_result->children = struct_data.child_pointers.data();
+	struct_result->n_buffers = 1;
+	struct_result->n_children = struct_child_count;
+	struct_result->length = struct_data.child_data[0]->row_count;
+
+	append_data.child_arrays[0] = *struct_result;
 
 	D_ASSERT(struct_data.child_data[0]->row_count == struct_data.child_data[1]->row_count);
 
 	auto &key_type = MapType::KeyType(type);
 	auto &value_type = MapType::ValueType(type);
-	struct_data.child_pointers[0] = ArrowAppender::FinalizeChild(key_type, std::move(struct_data.child_data[0]));
-	struct_data.child_pointers[1] = ArrowAppender::FinalizeChild(value_type, std::move(struct_data.child_data[1]));
+	auto key_data = ArrowAppender::FinalizeChild(key_type, std::move(struct_data.child_data[0]));
+	struct_data.child_arrays[0] = *key_data;
+	struct_data.child_arrays[1] = *ArrowAppender::FinalizeChild(value_type, std::move(struct_data.child_data[1]));
 
 	// keys cannot have null values
-	if (struct_data.child_pointers[0]->null_count > 0) {
+	if (key_data->null_count > 0) {
 		throw std::runtime_error("Arrow doesn't accept NULL keys on Maps");
 	}
 }

--- a/src/common/arrow/appender/struct_data.cpp
+++ b/src/common/arrow/appender/struct_data.cpp
@@ -38,7 +38,7 @@ void ArrowStructData::Finalize(ArrowAppendData &append_data, const LogicalType &
 	result->n_children = child_types.size();
 	for (idx_t i = 0; i < child_types.size(); i++) {
 		auto &child_type = child_types[i].second;
-		append_data.child_pointers[i] = ArrowAppender::FinalizeChild(child_type, *append_data.child_data[i]);
+		append_data.child_pointers[i] = ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[i]));
 	}
 }
 

--- a/src/common/arrow/appender/struct_data.cpp
+++ b/src/common/arrow/appender/struct_data.cpp
@@ -33,12 +33,12 @@ void ArrowStructData::Finalize(ArrowAppendData &append_data, const LogicalType &
 	result->n_buffers = 1;
 
 	auto &child_types = StructType::GetChildTypes(type);
-	append_data.child_pointers.resize(child_types.size());
+	ArrowAppender::AddChildren(append_data, child_types.size());
 	result->children = append_data.child_pointers.data();
 	result->n_children = child_types.size();
 	for (idx_t i = 0; i < child_types.size(); i++) {
 		auto &child_type = child_types[i].second;
-		append_data.child_pointers[i] = ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[i]));
+		append_data.child_arrays[i] = *ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[i]));
 	}
 }
 

--- a/src/common/arrow/appender/union_data.cpp
+++ b/src/common/arrow/appender/union_data.cpp
@@ -58,12 +58,12 @@ void ArrowUnionData::Finalize(ArrowAppendData &append_data, const LogicalType &t
 	result->buffers[1] = append_data.main_buffer.data();
 
 	auto &child_types = UnionType::CopyMemberTypes(type);
-	append_data.child_pointers.resize(child_types.size());
+	ArrowAppender::AddChildren(append_data, child_types.size());
 	result->children = append_data.child_pointers.data();
 	result->n_children = child_types.size();
 	for (idx_t i = 0; i < child_types.size(); i++) {
 		auto &child_type = child_types[i].second;
-		append_data.child_pointers[i] = ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[i]));
+		append_data.child_arrays[i] = *ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[i]));
 	}
 }
 

--- a/src/common/arrow/appender/union_data.cpp
+++ b/src/common/arrow/appender/union_data.cpp
@@ -63,7 +63,7 @@ void ArrowUnionData::Finalize(ArrowAppendData &append_data, const LogicalType &t
 	result->n_children = child_types.size();
 	for (idx_t i = 0; i < child_types.size(); i++) {
 		auto &child_type = child_types[i].second;
-		append_data.child_pointers[i] = ArrowAppender::FinalizeChild(child_type, *append_data.child_data[i]);
+		append_data.child_pointers[i] = ArrowAppender::FinalizeChild(child_type, std::move(append_data.child_data[i]));
 	}
 }
 

--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -89,7 +89,7 @@ ArrowArray ArrowAppender::Finalize() {
 	auto root_holder = make_uniq<ArrowAppendData>(options);
 
 	ArrowArray result;
-	root_holder->child_pointers.resize(types.size());
+	AddChildren(*root_holder, types.size());
 	result.children = root_holder->child_pointers.data();
 	result.n_children = types.size();
 
@@ -248,6 +248,14 @@ unique_ptr<ArrowAppendData> ArrowAppender::InitializeChild(const LogicalType &ty
 	result->validity.reserve(byte_count);
 	result->initialize(*result, type, capacity);
 	return result;
+}
+
+void ArrowAppender::AddChildren(ArrowAppendData &data, idx_t count) {
+	data.child_pointers.resize(count);
+	data.child_arrays.resize(count);
+	for (idx_t i = 0; i < count; i++) {
+		data.child_pointers[i] = &data.child_arrays[i];
+	}
 }
 
 } // namespace duckdb

--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -52,7 +52,6 @@ void ArrowAppender::ReleaseArray(ArrowArray *array) {
 	}
 	if (array->dictionary && array->dictionary->release) {
 		array->dictionary->release(array->dictionary);
-		D_ASSERT(!array->dictionary->release);
 	}
 	array->release = nullptr;
 	delete holder;

--- a/src/common/arrow/arrow_wrapper.cpp
+++ b/src/common/arrow/arrow_wrapper.cpp
@@ -16,21 +16,21 @@ namespace duckdb {
 ArrowSchemaWrapper::~ArrowSchemaWrapper() {
 	if (arrow_schema.release) {
 		arrow_schema.release(&arrow_schema);
-		arrow_schema.release = nullptr;
+		D_ASSERT(!arrow_schema.release);
 	}
 }
 
 ArrowArrayWrapper::~ArrowArrayWrapper() {
 	if (arrow_array.release) {
 		arrow_array.release(&arrow_array);
-		arrow_array.release = nullptr;
+		D_ASSERT(!arrow_array.release);
 	}
 }
 
 ArrowArrayStreamWrapper::~ArrowArrayStreamWrapper() {
 	if (arrow_array_stream.release) {
 		arrow_array_stream.release(&arrow_array_stream);
-		arrow_array_stream.release = nullptr;
+		D_ASSERT(!arrow_array_stream.release);
 	}
 }
 

--- a/src/include/duckdb/common/arrow/appender/append_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/append_data.hpp
@@ -48,6 +48,8 @@ struct ArrowAppendData {
 	unique_ptr<ArrowArray> array;
 	duckdb::array<const void *, 3> buffers = {{nullptr, nullptr, nullptr}};
 	vector<ArrowArray *> child_pointers;
+	// Arrays so the children can be moved
+	vector<ArrowArray> child_arrays;
 
 	ClientProperties options;
 };

--- a/src/include/duckdb/common/arrow/appender/append_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/append_data.hpp
@@ -27,6 +27,7 @@ typedef void (*finalize_t)(ArrowAppendData &append_data, const LogicalType &type
 // ArrowAppendState
 struct ArrowAppendData {
 	explicit ArrowAppendData(ClientProperties &options_p) : options(options_p) {
+		dictionary.release = nullptr;
 	}
 	// the buffers of the arrow vector
 	ArrowBuffer validity;
@@ -50,6 +51,7 @@ struct ArrowAppendData {
 	vector<ArrowArray *> child_pointers;
 	// Arrays so the children can be moved
 	vector<ArrowArray> child_arrays;
+	ArrowArray dictionary;
 
 	ClientProperties options;
 };

--- a/src/include/duckdb/common/arrow/appender/enum_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/enum_data.hpp
@@ -62,7 +62,7 @@ struct ArrowEnumData : public ArrowScalarBaseData<TGT> {
 		result->n_buffers = 2;
 		result->buffers[1] = append_data.main_buffer.data();
 		// finalize the enum child data, and assign it to the dictionary
-		result->dictionary = ArrowAppender::FinalizeChild(LogicalType::VARCHAR, *append_data.child_data[0]);
+		result->dictionary = ArrowAppender::FinalizeChild(LogicalType::VARCHAR, std::move(append_data.child_data[0]));
 	}
 };
 

--- a/src/include/duckdb/common/arrow/appender/enum_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/enum_data.hpp
@@ -62,7 +62,9 @@ struct ArrowEnumData : public ArrowScalarBaseData<TGT> {
 		result->n_buffers = 2;
 		result->buffers[1] = append_data.main_buffer.data();
 		// finalize the enum child data, and assign it to the dictionary
-		result->dictionary = ArrowAppender::FinalizeChild(LogicalType::VARCHAR, std::move(append_data.child_data[0]));
+		result->dictionary = &append_data.dictionary;
+		append_data.dictionary =
+		    *ArrowAppender::FinalizeChild(LogicalType::VARCHAR, std::move(append_data.child_data[0]));
 	}
 };
 

--- a/src/include/duckdb/common/arrow/arrow_appender.hpp
+++ b/src/include/duckdb/common/arrow/arrow_appender.hpp
@@ -28,7 +28,7 @@ public:
 
 public:
 	static void ReleaseArray(ArrowArray *array);
-	static ArrowArray *FinalizeChild(const LogicalType &type, ArrowAppendData &append_data);
+	static ArrowArray *FinalizeChild(const LogicalType &type, unique_ptr<ArrowAppendData> append_data);
 	static unique_ptr<ArrowAppendData> InitializeChild(const LogicalType &type, idx_t capacity,
 	                                                   ClientProperties &options);
 

--- a/src/include/duckdb/common/arrow/arrow_appender.hpp
+++ b/src/include/duckdb/common/arrow/arrow_appender.hpp
@@ -31,6 +31,7 @@ public:
 	static ArrowArray *FinalizeChild(const LogicalType &type, unique_ptr<ArrowAppendData> append_data);
 	static unique_ptr<ArrowAppendData> InitializeChild(const LogicalType &type, idx_t capacity,
 	                                                   ClientProperties &options);
+	static void AddChildren(ArrowAppendData &data, idx_t count);
 
 private:
 	//! The types of the chunks that will be appended in

--- a/src/include/duckdb/common/arrow/arrow_wrapper.hpp
+++ b/src/include/duckdb/common/arrow/arrow_wrapper.hpp
@@ -35,6 +35,9 @@ public:
 		arrow_array.length = 0;
 		arrow_array.release = nullptr;
 	}
+	ArrowArrayWrapper(ArrowArrayWrapper &&other) : arrow_array(other.arrow_array) {
+		other.arrow_array.release = nullptr;
+	}
 	~ArrowArrayWrapper();
 };
 

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -64,7 +64,7 @@ duckdb_state duckdb_prepared_arrow_schema(duckdb_prepared_statement prepared, du
 	if (result_schema->release) {
 		// Need to release the existing schema before we overwrite it
 		result_schema->release(result_schema);
-		result_schema->release = nullptr;
+		D_ASSERT(!result_schema->release);
 	}
 
 	ArrowConverter::ToArrowSchema(result_schema, prepared_types, prepared_names, properties);

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -155,14 +155,17 @@ struct PrivateData {
 
 // LCOV_EXCL_START
 // This function is never called, but used to set ArrowSchema's release functions to a non-null NOOP.
-void EmptySchemaRelease(ArrowSchema *) {
+void EmptySchemaRelease(ArrowSchema *schema) {
+	schema->release = nullptr;
 }
 // LCOV_EXCL_STOP
 
-void EmptyArrayRelease(ArrowArray *) {
+void EmptyArrayRelease(ArrowArray *array) {
+	array->release = nullptr;
 }
 
-void EmptyStreamRelease(ArrowArrayStream *) {
+void EmptyStreamRelease(ArrowArrayStream *stream) {
+	stream->release = nullptr;
 }
 
 void FactoryGetSchema(uintptr_t stream_factory_ptr, duckdb::ArrowSchemaWrapper &schema) {

--- a/test/arrow/CMakeLists.txt
+++ b/test/arrow/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(test_arrow_roundtrip OBJECT arrow_test_helper.cpp
-                  arrow_roundtrip.cpp)
+                  arrow_roundtrip.cpp arrow_move_children.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_arrow_roundtrip>
     PARENT_SCOPE)

--- a/test/arrow/arrow_move_children.cpp
+++ b/test/arrow/arrow_move_children.cpp
@@ -1,12 +1,64 @@
 #include "catch.hpp"
 
 #include "arrow/arrow_test_helper.hpp"
+#include "duckdb/common/adbc/single_batch_array_stream.hpp"
 
 using namespace duckdb;
 
+static void EmptyRelease(ArrowArray *array) {
+	for (int64_t i = 0; i < array->n_children; i++) {
+		auto child = array->children[i];
+		if (child->release) {
+			child->release(child);
+		}
+	}
+	array->release = nullptr;
+}
+
 template <class T>
-void AssertExpectedResult(ArrowArrayWrapper &array, T expected_value, bool is_null = false) {
-	array.arrow_array.release(&array.arrow_array);
+void AssertExpectedResult(ArrowSchema schema, ArrowArrayWrapper &array, T expected_value, bool is_null = false) {
+	ArrowArrayStream stream;
+	stream.release = nullptr;
+
+	ArrowArray struct_array;
+	struct_array.n_children = 1;
+	ArrowArray *children[1];
+	struct_array.children = (ArrowArray **)&children;
+	struct_array.children[0] = &array.arrow_array;
+	struct_array.length = array.arrow_array.length;
+	struct_array.release = EmptyRelease;
+
+	duckdb_adbc::AdbcError unused;
+	(void)BatchToArrayStream(&struct_array, &schema, &stream, &unused);
+
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto params = ArrowTestHelper::ConstructArrowScan(stream);
+	stream.release = nullptr;
+
+	auto result = ArrowTestHelper::ScanArrowObject(conn, params);
+	unique_ptr<DataChunk> chunk;
+	while (true) {
+		chunk = result->Fetch();
+		if (!chunk) {
+			break;
+		}
+		REQUIRE(chunk->ColumnCount() == 1);
+		REQUIRE(chunk->size() == STANDARD_VECTOR_SIZE);
+		auto vec = chunk->data[0];
+		for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+			auto value = vec.GetValue(i);
+			auto expected = Value(expected_value);
+			if (is_null) {
+				REQUIRE(value.IsNull());
+			} else {
+				REQUIRE(value == expected);
+			}
+		}
+	}
+	if (schema.release) {
+		schema.release(&schema);
+	}
 }
 
 vector<ArrowArrayWrapper> FetchChildrenFromArray(shared_ptr<ArrowArrayWrapper> parent) {
@@ -28,7 +80,8 @@ vector<ArrowArrayWrapper> FetchChildrenFromArray(shared_ptr<ArrowArrayWrapper> p
 
 // https://arrow.apache.org/docs/format/CDataInterface.html#moving-child-arrays
 TEST_CASE("Test move children", "[arrow]") {
-	auto query = "select 'a', 'this is a long string', 42, true, NULL from range(4096);";
+	auto query = StringUtil::Format("select 'a', 'this is a long string', 42, true, NULL from range(%d);",
+	                                STANDARD_VECTOR_SIZE * 2);
 
 	// Create the stream that will produce arrow arrays
 	DuckDB db(nullptr);
@@ -48,6 +101,9 @@ TEST_CASE("Test move children", "[arrow]") {
 			parameters.projected_columns.columns.emplace_back(name);
 		}
 	}
+	auto res_names = initial_result->names;
+	auto res_types = initial_result->types;
+	auto res_properties = initial_result->client_properties;
 
 	// Create a test factory and produce a stream from it
 	auto factory =
@@ -63,16 +119,21 @@ TEST_CASE("Test move children", "[arrow]") {
 		auto children = FetchChildrenFromArray(std::move(chunk));
 		D_ASSERT(children.size() == 5);
 		for (idx_t i = 0; i < children.size(); i++) {
+			ArrowSchema schema;
+			vector<LogicalType> single_type {res_types[i]};
+			vector<string> single_name {res_names[i]};
+			ArrowConverter::ToArrowSchema(&schema, single_type, single_name, res_properties);
+
 			if (i == 0) {
-				AssertExpectedResult<string>(children[i], "a");
+				AssertExpectedResult<string>(schema, children[i], "a");
 			} else if (i == 1) {
-				AssertExpectedResult<string>(children[i], "this is a long string");
+				AssertExpectedResult<string>(schema, children[i], "this is a long string");
 			} else if (i == 2) {
-				AssertExpectedResult<int32_t>(children[i], 42);
+				AssertExpectedResult<int32_t>(schema, children[i], 42);
 			} else if (i == 3) {
-				AssertExpectedResult<bool>(children[i], true);
+				AssertExpectedResult<bool>(schema, children[i], true);
 			} else if (i == 4) {
-				AssertExpectedResult<int32_t>(children[i], 0, true);
+				AssertExpectedResult<int32_t>(schema, children[i], 0, true);
 			} else {
 				// Not possible
 				REQUIRE(false);

--- a/test/arrow/arrow_move_children.cpp
+++ b/test/arrow/arrow_move_children.cpp
@@ -1,0 +1,80 @@
+#include "catch.hpp"
+
+#include "arrow/arrow_test_helper.hpp"
+
+using namespace duckdb;
+
+template <class T>
+void AssertExpectedResult(ArrowArrayWrapper array, T expected_value, bool is_null = false) {
+}
+
+vector<ArrowArrayWrapper> FetchChildrenFromArray(shared_ptr<ArrowArrayWrapper> parent) {
+	vector<ArrowArrayWrapper> children;
+	children.resize(parent->arrow_array.n_children);
+	for (int64_t i = 0; i < parent->arrow_array.n_children; i++) {
+		auto child = parent->arrow_array.children[i];
+		auto &wrapper = children[i];
+		wrapper.arrow_array = *child;
+		// Unset the 'release' method to null for the child inside the parent
+		// to indicate that it has been moved
+		child->release = nullptr;
+	}
+	// Release the parent, should not affect the children
+	parent->arrow_array.release(&parent->arrow_array);
+	return children;
+}
+
+// https://arrow.apache.org/docs/format/CDataInterface.html#moving-child-arrays
+TEST_CASE("Test move children", "[arrow]") {
+	auto query = "select 'a', 'this is a long string', 42, true, NULL from range(4096);";
+
+	// Create the stream that will produce arrow arrays
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto initial_result = conn.Query(query);
+	auto client_properties = conn.context->GetClientProperties();
+	auto types = initial_result->types;
+	auto names = initial_result->names;
+
+	// Scan every column
+	ArrowStreamParameters parameters;
+	for (idx_t idx = 0; idx < initial_result->names.size(); idx++) {
+		auto col_idx = idx;
+		auto &name = initial_result->names[idx];
+		if (col_idx != COLUMN_IDENTIFIER_ROW_ID) {
+			parameters.projected_columns.projection_map[idx] = name;
+			parameters.projected_columns.columns.emplace_back(name);
+		}
+	}
+
+	// Create a test factory and produce a stream from it
+	auto factory =
+	    ArrowTestFactory(std::move(types), std::move(names), std::move(initial_result), false, client_properties);
+	auto stream = ArrowTestFactory::CreateStream((uintptr_t)&factory, parameters);
+
+	// For every array, extract the children and scan them
+	while (true) {
+		auto chunk = stream->GetNextChunk();
+		if (!chunk) {
+			break;
+		}
+		auto children = FetchChildrenFromArray(std::move(chunk));
+		D_ASSERT(children.size() == 5);
+		for (idx_t i = 0; i < children.size(); i++) {
+			if (i == 0) {
+				AssertExpectedResult<string>(std::move(children[i]), "a");
+			} else if (i == 1) {
+				AssertExpectedResult<string>(std::move(children[i]), "this is a long string");
+			} else if (i == 2) {
+				AssertExpectedResult<int32_t>(std::move(children[i]), 42);
+			} else if (i == 3) {
+				AssertExpectedResult<bool>(std::move(children[i]), true);
+			} else if (i == 4) {
+				AssertExpectedResult<int32_t>(std::move(children[i]), 0, true);
+			} else {
+				// Not possible
+				REQUIRE(false);
+			}
+		}
+	}
+}

--- a/test/arrow/arrow_test_helper.cpp
+++ b/test/arrow/arrow_test_helper.cpp
@@ -133,17 +133,21 @@ bool ArrowTestHelper::CompareResults(unique_ptr<QueryResult> arrow, unique_ptr<M
 	return true;
 }
 
-vector<Value> ArrowTestHelper::ConstructArrowScan(uintptr_t arrow_object, bool from_duckdb_result) {
+vector<Value> ArrowTestHelper::ConstructArrowScan(ArrowTestFactory &factory) {
 	vector<Value> params;
+	auto arrow_object = (uintptr_t)(&factory);
 	params.push_back(Value::POINTER(arrow_object));
-	if (from_duckdb_result) {
-		params.push_back(Value::POINTER((uintptr_t)&ArrowTestFactory::CreateStream));
-		params.push_back(Value::POINTER((uintptr_t)&ArrowTestFactory::GetSchema));
-	} else {
-		params.push_back(Value::POINTER((uintptr_t)&ArrowStreamTestFactory::CreateStream));
-		params.push_back(Value::POINTER((uintptr_t)&ArrowStreamTestFactory::GetSchema));
-	}
+	params.push_back(Value::POINTER((uintptr_t)&ArrowTestFactory::CreateStream));
+	params.push_back(Value::POINTER((uintptr_t)&ArrowTestFactory::GetSchema));
+	return params;
+}
 
+vector<Value> ArrowTestHelper::ConstructArrowScan(ArrowArrayStream &stream) {
+	vector<Value> params;
+	auto arrow_object = (uintptr_t)(&stream);
+	params.push_back(Value::POINTER(arrow_object));
+	params.push_back(Value::POINTER((uintptr_t)&ArrowStreamTestFactory::CreateStream));
+	params.push_back(Value::POINTER((uintptr_t)&ArrowStreamTestFactory::GetSchema));
 	return params;
 }
 
@@ -163,7 +167,7 @@ bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, b
 	                         client_properties);
 
 	// construct the arrow scan
-	auto params = ConstructArrowScan((uintptr_t)&factory, true);
+	auto params = ConstructArrowScan(factory);
 
 	// run the arrow scan over the result
 	auto arrow_result = ScanArrowObject(con, params);
@@ -177,7 +181,7 @@ bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, b
 
 bool ArrowTestHelper::RunArrowComparison(Connection &con, const string &query, ArrowArrayStream &arrow_stream) {
 	// construct the arrow scan
-	auto params = ConstructArrowScan((uintptr_t)&arrow_stream, false);
+	auto params = ConstructArrowScan(arrow_stream);
 
 	// run the arrow scan over the result
 	auto arrow_result = ScanArrowObject(con, params);

--- a/test/arrow/arrow_test_helper.cpp
+++ b/test/arrow/arrow_test_helper.cpp
@@ -45,12 +45,13 @@ const char *ArrowTestFactory::ArrowArrayStreamGetLastError(struct ArrowArrayStre
 }
 
 void ArrowTestFactory::ArrowArrayStreamRelease(struct ArrowArrayStream *stream) {
-	if (!stream->private_data) {
+	if (!stream || !stream->private_data) {
 		return;
 	}
 	auto data = (ArrowArrayStreamData *)stream->private_data;
 	delete data;
 	stream->private_data = nullptr;
+	stream->release = nullptr;
 }
 
 duckdb::unique_ptr<duckdb::ArrowArrayStreamWrapper> ArrowTestFactory::CreateStream(uintptr_t this_ptr,

--- a/test/include/arrow/arrow_test_helper.hpp
+++ b/test/include/arrow/arrow_test_helper.hpp
@@ -81,6 +81,7 @@ private:
 	static unique_ptr<QueryResult> ScanArrowObject(Connection &con, vector<Value> &params);
 	static bool CompareResults(unique_ptr<QueryResult> arrow, unique_ptr<MaterializedQueryResult> duck,
 	                           const string &query);
-	static vector<Value> ConstructArrowScan(uintptr_t arrow_object, bool from_duckdb_result);
+	static vector<Value> ConstructArrowScan(ArrowTestFactory &factory);
+	static vector<Value> ConstructArrowScan(ArrowArrayStream &stream);
 };
 } // namespace duckdb

--- a/test/include/arrow/arrow_test_helper.hpp
+++ b/test/include/arrow/arrow_test_helper.hpp
@@ -78,9 +78,11 @@ public:
 	static bool RunArrowComparison(Connection &con, const string &query, ArrowArrayStream &arrow_stream);
 
 private:
-	static unique_ptr<QueryResult> ScanArrowObject(Connection &con, vector<Value> &params);
 	static bool CompareResults(unique_ptr<QueryResult> arrow, unique_ptr<MaterializedQueryResult> duck,
 	                           const string &query);
+
+public:
+	static unique_ptr<QueryResult> ScanArrowObject(Connection &con, vector<Value> &params);
 	static vector<Value> ConstructArrowScan(ArrowTestFactory &factory);
 	static vector<Value> ConstructArrowScan(ArrowArrayStream &stream);
 };


### PR DESCRIPTION
As the (now deleted) FIXME says:
> This violates a property of the arrow format, if root owns all the child memory then consumers can't move child arrays.

https://arrow.apache.org/docs/format/CDataInterface.html#moving-child-arrays

By moving the ArrowAppendData struct when finalizing and cleaning up child arrays in `release`, as is mandated by the Arrow C data interface protocol it is now possible to move child arrays.

This likely caused a memory leak or a heap-use-after-free otherwise.
Most notably when creating a `arrow::SimpleTable` in the Arrow C++ implementation, this holds a `vector<ChunkedArray>` and a `Schema`.

When we produce arrays we create them with this artificial top level struct to be able to directly provide a "table" of arrays.
To turn this into an arrow::SimpleTable would require breaking down this top-level struct and moving the child arrays.
Since the memory of the child arrays are owned by the parent, this artificial struct array would need to be kept alive for as long as the children are, otherwise any usage of the children would(should) result in a heap-use-after-free error.

-----------

Admittedly, this feels like it contradicts with this paragraph:
https://arrow.apache.org/docs/format/CDataInterface.html#release-callback-semantics-for-consumers

> In any case, a consumer MUST not try to access the base structure anymore after calling its release callback – including any associated data such as its children.

And another thing to note is that the "moving children" rule does not seem to apply to ArrowSchema, even though they also have `children` schema elements.

-----------

One last issue that should be resolved is that the `ArrowArray` structure that the parent points to is owned by the child.
This means that once we release the child, any access into the `children[child_idx]` is a heap-use-after-free.