### PR TITLE
Fix #7880 part 1 - rebind expression during alias replacement instead of copying the already bound expression

### DIFF
--- a/src/planner/expression_binder/base_select_binder.cpp
+++ b/src/planner/expression_binder/base_select_binder.cpp
@@ -98,11 +98,8 @@ BindResult BaseSelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_pt
 				                      " This is not yet supported.",
 				                      colref.column_names[0]);
 			}
-			auto result = BindResult(node.select_list[index]->Copy());
-			if (result.expression->type == ExpressionType::BOUND_COLUMN_REF) {
-				auto &result_expr = result.expression->Cast<BoundColumnRefExpression>();
-				result_expr.depth = depth;
-			}
+			auto copied_expression = node.original_expressions[index]->Copy();
+			result = BindExpression(copied_expression, depth, false);
 			return result;
 		}
 	}

--- a/test/sql/binder/group_by_incremental_alias.test
+++ b/test/sql/binder/group_by_incremental_alias.test
@@ -1,0 +1,18 @@
+# name: test/sql/binder/group_by_incremental_alias.test
+# description: Issue #7880: Group By incremental alias issues
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table my_functions as select 'my_name' as function_name;
+
+query II
+select
+    function_name as raw,
+    replace(raw, '_', ' ') as prettier
+from my_functions
+group by all;
+----
+my_name	my name


### PR DESCRIPTION
Fixes #7880 (part 1)