### PR TITLE
[Dev] Fix `test_map_vector_types.test`

### DIFF
--- a/test/sql/types/nested/map/test_map_vector_types.test
+++ b/test/sql/types/nested/map/test_map_vector_types.test
@@ -9,12 +9,18 @@ create macro input() as table
 	select *
 	from test_vector_types(NULL::INTEGER[]) t(i) where [x for x in i if x IS NOT NULL] != [] offset 3;
 
-query I
-select map(input, input) from input() t(input);
+query II nosort expected
+select true, true from input()
 ----
-{-2147483648=-2147483648, 2147483647=2147483647}
-{3=3, 5=5}
-{7=7}
+
+query II nosort expected
+select map_keys(m) = input, map_values(m) = input from (
+	select
+		map(input, input) m,
+		input
+	from input() t(input)
+) m;
+----
 
 statement ok
 create table tbl (


### PR DESCRIPTION
Use a reference query so it doesn't break on lower vector sizes

Note: It does seem to take much longer to complete this query now, so something funky might be going on here?