### PR TITLE
Fix MacOS exception catching

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -1,5 +1,4 @@
 #include "duckdb/common/exception.hpp"
-
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/types.hpp"
@@ -82,91 +81,68 @@ string Exception::ConstructMessageRecursive(const string &msg, std::vector<Excep
 	return ExceptionFormatValue::Format(msg, values);
 }
 
+struct ExceptionEntry {
+	ExceptionType type;
+	char text[48];
+};
+
+static constexpr ExceptionEntry EXCEPTION_MAP[] = {{ExceptionType::INVALID, "Invalid"},
+                                                   {ExceptionType::OUT_OF_RANGE, "Out of Range"},
+                                                   {ExceptionType::CONVERSION, "Conversion"},
+                                                   {ExceptionType::UNKNOWN_TYPE, "Unknown Type"},
+                                                   {ExceptionType::DECIMAL, "Decimal"},
+                                                   {ExceptionType::MISMATCH_TYPE, "Mismatch Type"},
+                                                   {ExceptionType::DIVIDE_BY_ZERO, "Divide by Zero"},
+                                                   {ExceptionType::OBJECT_SIZE, "Object Size"},
+                                                   {ExceptionType::INVALID_TYPE, "Invalid type"},
+                                                   {ExceptionType::SERIALIZATION, "Serialization"},
+                                                   {ExceptionType::TRANSACTION, "TransactionContext"},
+                                                   {ExceptionType::NOT_IMPLEMENTED, "Not implemented"},
+                                                   {ExceptionType::EXPRESSION, "Expression"},
+                                                   {ExceptionType::CATALOG, "Catalog"},
+                                                   {ExceptionType::PARSER, "Parser"},
+                                                   {ExceptionType::BINDER, "Binder"},
+                                                   {ExceptionType::PLANNER, "Planner"},
+                                                   {ExceptionType::SCHEDULER, "Scheduler"},
+                                                   {ExceptionType::EXECUTOR, "Executor"},
+                                                   {ExceptionType::CONSTRAINT, "Constraint"},
+                                                   {ExceptionType::INDEX, "Index"},
+                                                   {ExceptionType::STAT, "Stat"},
+                                                   {ExceptionType::CONNECTION, "Connection"},
+                                                   {ExceptionType::SYNTAX, "Syntax"},
+                                                   {ExceptionType::SETTINGS, "Settings"},
+                                                   {ExceptionType::OPTIMIZER, "Optimizer"},
+                                                   {ExceptionType::NULL_POINTER, "NullPointer"},
+                                                   {ExceptionType::IO, "IO"},
+                                                   {ExceptionType::INTERRUPT, "INTERRUPT"},
+                                                   {ExceptionType::FATAL, "FATAL"},
+                                                   {ExceptionType::INTERNAL, "INTERNAL"},
+                                                   {ExceptionType::INVALID_INPUT, "Invalid Input"},
+                                                   {ExceptionType::OUT_OF_MEMORY, "Out of Memory"},
+                                                   {ExceptionType::PERMISSION, "Permission"},
+                                                   {ExceptionType::PARAMETER_NOT_RESOLVED, "Parameter Not Resolved"},
+                                                   {ExceptionType::PARAMETER_NOT_ALLOWED, "Parameter Not Allowed"},
+                                                   {ExceptionType::DEPENDENCY, "Dependency"},
+                                                   {ExceptionType::MISSING_EXTENSION, "Missing Extension"},
+                                                   {ExceptionType::HTTP, "HTTP"},
+                                                   {ExceptionType::AUTOLOAD, "Extension Autoloading"}};
+
 string Exception::ExceptionTypeToString(ExceptionType type) {
-	switch (type) {
-	case ExceptionType::INVALID:
-		return "Invalid";
-	case ExceptionType::OUT_OF_RANGE:
-		return "Out of Range";
-	case ExceptionType::CONVERSION:
-		return "Conversion";
-	case ExceptionType::UNKNOWN_TYPE:
-		return "Unknown Type";
-	case ExceptionType::DECIMAL:
-		return "Decimal";
-	case ExceptionType::MISMATCH_TYPE:
-		return "Mismatch Type";
-	case ExceptionType::DIVIDE_BY_ZERO:
-		return "Divide by Zero";
-	case ExceptionType::OBJECT_SIZE:
-		return "Object Size";
-	case ExceptionType::INVALID_TYPE:
-		return "Invalid type";
-	case ExceptionType::SERIALIZATION:
-		return "Serialization";
-	case ExceptionType::TRANSACTION:
-		return "TransactionContext";
-	case ExceptionType::NOT_IMPLEMENTED:
-		return "Not implemented";
-	case ExceptionType::EXPRESSION:
-		return "Expression";
-	case ExceptionType::CATALOG:
-		return "Catalog";
-	case ExceptionType::PARSER:
-		return "Parser";
-	case ExceptionType::BINDER:
-		return "Binder";
-	case ExceptionType::PLANNER:
-		return "Planner";
-	case ExceptionType::SCHEDULER:
-		return "Scheduler";
-	case ExceptionType::EXECUTOR:
-		return "Executor";
-	case ExceptionType::CONSTRAINT:
-		return "Constraint";
-	case ExceptionType::INDEX:
-		return "Index";
-	case ExceptionType::STAT:
-		return "Stat";
-	case ExceptionType::CONNECTION:
-		return "Connection";
-	case ExceptionType::SYNTAX:
-		return "Syntax";
-	case ExceptionType::SETTINGS:
-		return "Settings";
-	case ExceptionType::OPTIMIZER:
-		return "Optimizer";
-	case ExceptionType::NULL_POINTER:
-		return "NullPointer";
-	case ExceptionType::IO:
-		return "IO";
-	case ExceptionType::INTERRUPT:
-		return "INTERRUPT";
-	case ExceptionType::FATAL:
-		return "FATAL";
-	case ExceptionType::INTERNAL:
-		return "INTERNAL";
-	case ExceptionType::INVALID_INPUT:
-		return "Invalid Input";
-	case ExceptionType::OUT_OF_MEMORY:
-		return "Out of Memory";
-	case ExceptionType::PERMISSION:
-		return "Permission";
-	case ExceptionType::PARAMETER_NOT_RESOLVED:
-		return "Parameter Not Resolved";
-	case ExceptionType::PARAMETER_NOT_ALLOWED:
-		return "Parameter Not Allowed";
-	case ExceptionType::DEPENDENCY:
-		return "Dependency";
-	case ExceptionType::MISSING_EXTENSION:
-		return "Missing Extension";
-	case ExceptionType::HTTP:
-		return "HTTP";
-	case ExceptionType::AUTOLOAD:
-		return "Extension Autoloading";
-	default:
-		return "Unknown";
+	for (auto &e : EXCEPTION_MAP) {
+		if (e.type == type) {
+			return e.text;
+		}
 	}
+	return "Unknown";
+}
+
+ExceptionType Exception::StringToExceptionType(const string &type) {
+	for (auto &e : EXCEPTION_MAP) {
+		if (e.text == type) {
+			return e.type;
+		}
+	}
+	return ExceptionType::INVALID;
 }
 
 const HTTPException &Exception::AsHTTPException() const {

--- a/src/common/preserved_error.cpp
+++ b/src/common/preserved_error.cpp
@@ -18,6 +18,26 @@ PreservedError::PreservedError(const Exception &exception)
 PreservedError::PreservedError(const string &message)
     : initialized(true), type(ExceptionType::INVALID), raw_message(SanitizeErrorMessage(message)),
       exception_instance(nullptr) {
+	// Given a message in the form: 	xxxxx Error: yyyyy
+	// Try to match xxxxxxx with known error so to potentially reconstruct the original error type
+	auto position_semicolon = raw_message.find(':');
+	if (position_semicolon == std::string::npos) {
+		// Semicolon not found, bail out
+		return;
+	}
+	if (position_semicolon + 2 >= raw_message.size()) {
+		// Not enough characters afterward, bail out
+		return;
+	}
+	string err = raw_message.substr(0, position_semicolon);
+	string msg = raw_message.substr(position_semicolon + 2);
+	if (err.size() > 6 && err.substr(err.size() - 6) == " Error" && !msg.empty()) {
+		ExceptionType newType = Exception::StringToExceptionType(err.substr(0, err.size() - 6));
+		if (newType != type) {
+			type = newType;
+			raw_message = msg;
+		}
+	}
 }
 
 const string &PreservedError::Message() {

--- a/src/common/preserved_error.cpp
+++ b/src/common/preserved_error.cpp
@@ -32,9 +32,9 @@ PreservedError::PreservedError(const string &message)
 	string err = raw_message.substr(0, position_semicolon);
 	string msg = raw_message.substr(position_semicolon + 2);
 	if (err.size() > 6 && err.substr(err.size() - 6) == " Error" && !msg.empty()) {
-		ExceptionType newType = Exception::StringToExceptionType(err.substr(0, err.size() - 6));
-		if (newType != type) {
-			type = newType;
+		ExceptionType new_type = Exception::StringToExceptionType(err.substr(0, err.size() - 6));
+		if (new_type != type) {
+			type = new_type;
 			raw_message = msg;
 		}
 	}

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -97,6 +97,7 @@ public:
 	DUCKDB_API const string &RawMessage() const;
 
 	DUCKDB_API static string ExceptionTypeToString(ExceptionType type);
+	DUCKDB_API static ExceptionType StringToExceptionType(const string &type);
 	[[noreturn]] DUCKDB_API static void ThrowAsTypeWithMessage(ExceptionType type, const string &message,
 	                                                           const std::shared_ptr<Exception> &original);
 	virtual std::shared_ptr<Exception> Copy() const {

--- a/src/include/duckdb/common/preserved_error.hpp
+++ b/src/include/duckdb/common/preserved_error.hpp
@@ -18,9 +18,7 @@ public:
 	//! Not initialized, default constructor
 	DUCKDB_API PreservedError();
 	//! From std::exception
-	PreservedError(const std::exception &ex)
-	    : initialized(true), type(ExceptionType::INVALID), raw_message(SanitizeErrorMessage(ex.what())),
-	      exception_instance(nullptr) {
+	PreservedError(const std::exception &ex) : PreservedError(ex.what()) {
 	}
 	//! From a raw string
 	DUCKDB_API explicit PreservedError(const string &raw_message);


### PR DESCRIPTION
To test this, add this as extension_config_local.cmake:
```
################# SPATIAL
duckdb_extension_load(spatial
        DONT_LINK LOAD_TESTS
        GIT_URL https://github.com/duckdblabs/duckdb_spatial.git
        GIT_TAG 36e5a126976ac3b66716893360ef7e6295707082
        INCLUDE_DIR spatial/include
        TEST_DIR test/sql
        )
```
on the `main` duckdb branch, then
```
GEN=ninja EXTENSION_STATIC_BUILD=1 make
./build/release/duckdb -unsigned -c "LOAD 'build/release/extension/spatial/spatial.duckdb_extension';CREATE TABLE zones AS SELECT zone, LocationId, borough, ST_GeomFromWKB(wkb_geometry) AS geom FROM ST_Read('taxi_zones.shx');"
```
Should error like: `Error: Invalid Error: IO Error: GDAL Error (4): taxi_zones.shx: No such file or directory`

while doing the same from this branch should give: `Error: IO Error: GDAL Error (4): taxi_zones.shx: No such file or directory`.

Fixes #6521