### PR TITLE
Fix prepare statement issue

### DIFF
--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -228,7 +228,7 @@ void FunctionBinder::CastToFunctionArguments(SimpleFunction &function, vector<un
 	for (idx_t i = 0; i < children.size(); i++) {
 		auto target_type = i < function.arguments.size() ? function.arguments[i] : function.varargs;
 		target_type.Verify();
-		// don't cast lambda children, they get removed anyways
+		// don't cast lambda children, they get removed before execution
 		if (children[i]->return_type.id() == LogicalTypeId::LAMBDA) {
 			continue;
 		}

--- a/src/include/duckdb/planner/bound_parameter_map.hpp
+++ b/src/include/duckdb/planner/bound_parameter_map.hpp
@@ -35,6 +35,9 @@ public:
 
 	unique_ptr<BoundParameterExpression> BindParameterExpression(ParameterExpression &expr);
 
+	//! Flag to indicate that we need to rebind this prepared statement before execution
+	bool rebind = false;
+
 private:
 	shared_ptr<BoundParameterData> CreateOrGetData(const string &identifier);
 	void CreateNewParameter(const string &id, const shared_ptr<BoundParameterData> &param_data);

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -76,7 +76,7 @@ void Planner::CreatePlan(SQLStatement &statement) {
 	}
 	this->properties = binder->properties;
 	this->properties.parameter_count = parameter_count;
-	properties.bound_all_parameters = parameters_resolved;
+	properties.bound_all_parameters = !bound_parameters.rebind && parameters_resolved;
 
 	Planner::VerifyPlan(context, plan, bound_parameters.GetParametersPtr());
 

--- a/test/sql/prepared/test_prepare_select.test
+++ b/test/sql/prepared/test_prepare_select.test
@@ -31,3 +31,11 @@ SELECT * FROM a WHERE i=$1
 statement error
 SELECT * FROM a WHERE i=CAST($1 AS VARCHAR)
 
+# issue that swallows an UNKNOWN type, if not explicitly setting the rebind-flag
+
+statement ok
+PREPARE s1 AS SELECT to_years($1), CAST(list_value($1) AS BIGINT[]);
+
+statement ok
+EXECUTE s1(1);
+


### PR DESCRIPTION
### What happens

The below query prepares a `SELECT` statement that contains two equal parameters. Both are referenced by `$1`. When preparing this statement, we first create a `BoundParameterMap` entry for the parameter in `to_years($1)`, with `"1"` as its identifier. This bound parameter entry has `return_type = UNKNOWN`. Its respective `BoundParameterExpression` also has `return_type = UNKNOWN`. Later, in `AddCastToTypeInternal`, we determine we know the return type of this `BoundParameterExpression`, which is `INTEGER`. We adjust the `BoundParameterExpression` and its corresponding entry in the `BoundParameterMap`. 

Now, when we bind the second parameter, we find the corresponding `BoundParameterMap` entry because both have the same identifier. `bound_expr->return_type = return_type` sets the return type of this `BoundParameterExpression` to `UNKNOWN`, which would potentially get propagated to the bind result and cause rebinding by thrown a `ParameterNotResolved` exception. However, because it is wrapped in a cast, this does not happen.

Because we found a type for the first parameter occurrence, and the `CAST` swallowed the second parameter occurrence, we later assumed that we do not have to rebind this prepared statement during execution. This leads to a leaking `BoundParameterExpression` with an `UNKNOWN` return type, which throws `INTERNAL Error: Invalid PhysicalType for GetTypeIdSize`.

```sql
statement ok
PREPARE s1 AS SELECT to_years($1), CAST(list_value($1) AS BIGINT[]);

statement ok
EXECUTE s1(1);
```

### Fix

My fix always determines if we previously found a type for a matching `BoundParameterMap` entry (same identifier). If so, we always rebind when executing the prepared statement. This avoids leaking `UNKNOWN` types into execution by not rebinding. If there is a better/alternative solution to fix this, I am also very open to suggestions!