### PR TITLE
[Arrow] Fix issue with scanning of UNION of STRUCTS

### DIFF
--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -639,10 +639,11 @@ static void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowScanLoca
 		for (idx_t type_idx = 0; type_idx < static_cast<idx_t>(array.n_children); type_idx++) {
 			Vector child(members[type_idx].second);
 			auto arrow_array = array.children[type_idx];
+			auto &child_type = arrow_type[type_idx];
 
 			SetValidityMask(child, *arrow_array, scan_state, size, nested_offset);
 
-			ColumnArrowToDuckDB(child, *arrow_array, scan_state, size, arrow_type, nested_offset, &validity_mask);
+			ColumnArrowToDuckDB(child, *arrow_array, scan_state, size, child_type, nested_offset, &validity_mask);
 
 			children.push_back(std::move(child));
 		}


### PR DESCRIPTION
We were not using the right ArrowType when scanning the members of a union
The test I added causes this error on `main`
```
  File "/Users/thijs/DuckDBLabs/duckdb/tmp/pyarrow_union_roundtrip.py", line 15, in <module>
    duckdb.execute("create table other as select * from arrow")
duckdb.duckdb.InternalException: INTERNAL Error: Assertion triggered in file "/Users/thijs/DuckDBLabs/duckdb/src/function/table/arrow/arrow_duck_schema.cpp" on line 48: index < children.size()
```