### PR TITLE
[Dev] Trigger R.yml only only if there are changes to R.yml itself

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -3,6 +3,20 @@ on:
   workflow_dispatch:
   repository_dispatch:
   push:
+    branches:
+      - '**'
+      - '!main'
+      - '!feature'
+    tags:
+      - '**'
+    paths-ignore:
+      - '**'
+      - '!.github/workflows/R.yml'
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    paths-ignore:
+      - '**'
+      - '!.github/workflows/R.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}


### PR DESCRIPTION
R.yml is otherwise triggered on every merge commit to main, seems noisy.

Idea is that it will trigger on PRs only when modifying itself (just to check consistency).