### PR TITLE
Fix unused warning

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -430,8 +430,7 @@ ParquetColumnDefinition ParquetColumnDefinition::FromSchemaValue(ClientContext &
 	result.field_id = IntegerValue::Get(StructValue::GetChildren(column_value)[0]);
 
 	const auto &column_def = StructValue::GetChildren(column_value)[1];
-	const auto &column_type = column_def.type();
-	D_ASSERT(column_type.id() == LogicalTypeId::STRUCT);
+	D_ASSERT(column_def.type().id() == LogicalTypeId::STRUCT);
 
 	const auto children = StructValue::GetChildren(column_def);
 	result.name = StringValue::Get(children[0]);


### PR DESCRIPTION
Hit this on the aarch64 CI on my fork, I suppose it might break nightly when feature gets merge with main?