### PR TITLE
fix for System.Data.ODBC GetSchema()

### DIFF
--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -388,11 +388,11 @@ SQLRETURN SQL_API SQLTables(SQLHSTMT statement_handle, SQLCHAR *catalog_name, SQ
 	string table_filter = OdbcUtils::ParseStringFilter("\"TABLE_NAME\"", table_n, hstmt->dbc->sql_attr_metadata_id);
 
 	auto table_tp = OdbcUtils::ReadString(table_type, name_length4);
-    
-    // .Net ODBC driver GetSchema() call includes "SYSTEM TABLE" (doesn't exist in DuckDB),
-    // and the regex tweaks below break if "SYSTEM TABLE" is in the query, so remove it
-    table_tp = std::regex_replace(table_tp, std::regex("('SYSTEM TABLE'|SYSTEM TABLE)"), "");
-    
+
+	// .Net ODBC driver GetSchema() call includes "SYSTEM TABLE" (doesn't exist in DuckDB),
+	// and the regex tweaks below break if "SYSTEM TABLE" is in the query, so remove it
+	table_tp = std::regex_replace(table_tp, std::regex("('SYSTEM TABLE'|SYSTEM TABLE)"), "");
+
 	table_tp = std::regex_replace(table_tp, std::regex("('TABLE'|TABLE)"), "'BASE TABLE'");
 	table_tp = std::regex_replace(table_tp, std::regex("('VIEW'|VIEW)"), "'VIEW'");
 	table_tp = std::regex_replace(table_tp, std::regex("('%'|%)"), "'%'");

--- a/tools/odbc/statement.cpp
+++ b/tools/odbc/statement.cpp
@@ -388,6 +388,11 @@ SQLRETURN SQL_API SQLTables(SQLHSTMT statement_handle, SQLCHAR *catalog_name, SQ
 	string table_filter = OdbcUtils::ParseStringFilter("\"TABLE_NAME\"", table_n, hstmt->dbc->sql_attr_metadata_id);
 
 	auto table_tp = OdbcUtils::ReadString(table_type, name_length4);
+    
+    // .Net ODBC driver GetSchema() call includes "SYSTEM TABLE" (doesn't exist in DuckDB),
+    // and the regex tweaks below break if "SYSTEM TABLE" is in the query, so remove it
+    table_tp = std::regex_replace(table_tp, std::regex("('SYSTEM TABLE'|SYSTEM TABLE)"), "");
+    
 	table_tp = std::regex_replace(table_tp, std::regex("('TABLE'|TABLE)"), "'BASE TABLE'");
 	table_tp = std::regex_replace(table_tp, std::regex("('VIEW'|VIEW)"), "'VIEW'");
 	table_tp = std::regex_replace(table_tp, std::regex("('%'|%)"), "'%'");


### PR DESCRIPTION
System.Data.ODBC GetSchema() includes `SYSTEM TABLE` when building the query for SqlTables() method. This table doesn't exist in DuckDB and so it breaks the query. This fix adds 


```
table_tp = std::regex_replace(table_tp, std::regex("('SYSTEM TABLE'|SYSTEM TABLE)"), "");
```

which removes `SYSTEM TABLE` if it is found in the query. 

Along with helpful changes by @maiadegraaf this will solve #6321.

