### PR TITLE
[Optimizer] Fix transitive filter issue

### DIFF
--- a/test/fuzzer/pedro/signed_and_unsigned_comparison.test
+++ b/test/fuzzer/pedro/signed_and_unsigned_comparison.test
@@ -1,0 +1,19 @@
+# name: test/fuzzer/pedro/signed_and_unsigned_comparison.test
+# description: Issue #9329: Signed and unsigned integer predicate with wrong result
+# group: [pedro]
+
+statement ok
+pragma enable_verification;
+
+statement ok
+CREATE TABLE t1 (
+	c1 UINT32,
+	c2 INT32
+);
+
+statement ok
+INSERT INTO t1 VALUES (0,0);
+
+query I
+SELECT 1 FROM t1 WHERE t1.c2 = t1.c1 AND t1.c2 < t1.c1;
+----


### PR DESCRIPTION
This PR fixes #9329 

We were not registering the expressions in the `c1 < c2` comparison as "seen before" because the stored expressions are a cast expression on top of a column reference instead of just a column reference.

Now we try to unwrap the expression in case it's a cast expression, so the new expression is recognized as "seen before"