### PR TITLE
HTTPFS: Move from HTTPException to base class IOException

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -303,8 +303,8 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 		                      query_param);
 
 		if (res->code != 200) {
-			throw HTTPException(*res, "Unable to connect to URL %s %s (HTTP code %s)", res->http_url, res->error,
-			                    to_string(res->code));
+			throw IOException("Unable to connect to URL %s %s (HTTP code %s)", res->http_url, res->error,
+			                  to_string(res->code));
 		}
 
 		etag_lookup = res->headers.find("ETag");
@@ -438,7 +438,7 @@ void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 
 	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
 	if (open_tag_pos == string::npos) {
-		throw HTTPException(*res, "Unexpected response during S3 multipart upload finalization: %d", res->code);
+		throw IOException("Unexpected response during S3 multipart upload finalization: %d", res->code);
 	}
 	file_handle.upload_finalized = true;
 }
@@ -1036,7 +1036,7 @@ string AWSListObjectV2::Request(string &path, HTTPParams &http_params, S3AuthPar
 	    listobjectv2_url.c_str(), *headers,
 	    [&](const duckdb_httplib_openssl::Response &response) {
 		    if (response.status >= 400) {
-			    throw HTTPException(response, "HTTP GET error on '%s' (HTTP %d)", listobjectv2_url, response.status);
+			    throw IOException("HTTP GET error on '%s' (HTTP %d)", listobjectv2_url, response.status);
 		    }
 		    return true;
 	    },

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -109,7 +109,7 @@ COPY test TO 's3://test-bucket-public/root-dir/test2.parquet';
 statement error
 SELECT i FROM "http://test-bucket-public.${DUCKDB_S3_ENDPOINT}/root-dir/non-existent-file-ljaslkjdas.parquet" LIMIT 3
 ----
-HTTP Error: Unable to connect to URL "http://test-bucket-public.
+IO Error: Unable to connect to URL "http://test-bucket-public.
 
 # Connection error
 statement error
@@ -121,4 +121,4 @@ IO Error: Connection error for HTTP HEAD to 'http://test-bucket-public.
 statement error
 SELECT * FROM parquet_scan('s3://this-aint-no-bucket/no-path/no-file');
 ----
-HTTP Error: Unable to connect to URL "http://
+IO Error: Unable to connect to URL "http://

--- a/test/sql/copy/s3/fully_qualified_s3_url.test
+++ b/test/sql/copy/s3/fully_qualified_s3_url.test
@@ -36,7 +36,7 @@ SET s3_url_style='path';
 statement error
 COPY test TO 's3://test-bucket/s3_query_params/test.csv';
 ----
-HTTP Error: Unable to connect to URL
+IO Error: Unable to connect to URL
 
 #test with .csv file
 statement ok

--- a/tools/pythonpkg/tests/extensions/test_httpfs.py
+++ b/tools/pythonpkg/tests/extensions/test_httpfs.py
@@ -43,6 +43,7 @@ class TestHTTPFS(object):
         )
         pandas.testing.assert_frame_equal(result_df, exp_result)
 
+    @pytest.mark.skip(reason="To be fixed up given how we will be throwing IOException without payload")
     def test_http_exception(self, require):
         connection = require('httpfs')
 


### PR DESCRIPTION
This commit might need to be back-ported (at least for MacOS builds) to previous released httpfs extension binaries (most affected are v0.9.1 due to how this is put onto the spotlight due to #9286) to fix issue like #9340

My idea on how to proceed is as follow:
1. this can be merged into duckdb and have nightly binaries (and connected extensions) throwing IOExceptions (that are properly handled) instead of specialised payload of HTTPExtensions
   This allows to test (on CI and on nightlies) whether this solves the actual problem
   This also allows, independently, to explore how to build specific extensions with a custom patch (this commit is basically
the patch)
2. Fixing the handling of HTTPExtension in core duckdb. Potentially this could  mean axing the HTTP-specific payload and moving to a generic textual plus custom payload extracted via virtual function calls