### PR TITLE
Fix for issue #8108: Random() in lambda

### DIFF
--- a/src/core_functions/lambda_functions.cpp
+++ b/src/core_functions/lambda_functions.cpp
@@ -198,6 +198,7 @@ void LambdaFunctions::ExecuteLambda(DataChunk &args, ExpressionState &state, Vec
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	auto &info = func_expr.bind_info->Cast<ListLambdaBindData>();
 	auto &lambda_expr = info.lambda_expr;
+	bool has_side_effects = lambda_expr->HasSideEffects();
 
 	// get the child vector and child data
 	// FIXME: no more flatten, we should be able to use dictionary vectors
@@ -348,7 +349,7 @@ void LambdaFunctions::ExecuteLambda(DataChunk &args, ExpressionState &state, Vec
 		                       appended_lists_cnt, lists_len, curr_original_list_len, input_chunk, info.has_index);
 	}
 
-	if (args.AllConstant()) {
+	if (args.AllConstant() && !has_side_effects) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 }

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/function/function_serialization.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/core_functions/lambda_functions.hpp"
 
 namespace duckdb {
 
@@ -23,6 +24,17 @@ bool BoundFunctionExpression::HasSideEffects() const {
 
 bool BoundFunctionExpression::IsFoldable() const {
 	// functions with side effects cannot be folded: they have to be executed once for every row
+	if (function.bind_lambda) {
+		// This is a lambda function
+		D_ASSERT(bind_info);
+		auto &lambda_bind_data = bind_info->Cast<ListLambdaBindData>();
+		if (lambda_bind_data.lambda_expr) {
+			auto &expr = *lambda_bind_data.lambda_expr;
+			if (expr.HasSideEffects()) {
+				return false;
+			}
+		}
+	}
 	return function.side_effects == FunctionSideEffects::HAS_SIDE_EFFECTS ? false : Expression::IsFoldable();
 }
 

--- a/test/sql/function/numeric/test_random.test
+++ b/test/sql/function/numeric/test_random.test
@@ -5,8 +5,40 @@
 # we need to be a bit more clever here for testing random
 # it's very unlikely that three random variables are exactly equivalent
 
-require skip_reload
+# test random in lambdas and ranges
+statement ok
+CREATE TABLE t1 AS SELECT [random() for a IN range(1)] FROM range(2);
 
+statement ok
+CREATE TABLE t2 AS SELECT random() FROM range(2);
+
+statement ok
+CREATE TABLE t3 AS SELECT [random()] FROM range(2);
+
+statement ok
+CREATE TABLE t4 AS SELECT [random() + range * 0 for a IN range(1)]  FROM range(2);
+
+query I
+SELECT count(*) FROM t1 WHERE (SELECT min(#1) FROM t1 ) == (SELECT max(#1) FROM t1);
+----
+0
+
+query I
+SELECT count(*) FROM t2 WHERE (SELECT min(#1) FROM t2 ) == (SELECT max(#1) FROM t2);
+----
+0
+
+query I
+SELECT count(*) FROM t3 WHERE (SELECT min(#1) FROM t3 ) == (SELECT max(#1) FROM t3);
+----
+0
+
+query I
+SELECT count(*) FROM t4 WHERE (SELECT min(#1) FROM t4 ) == (SELECT max(#1) FROM t4);
+----
+0
+
+require skip_reload
 
 statement ok
 BEGIN TRANSACTION


### PR DESCRIPTION
This PR fixes the bug found in issue #8108. 

When the `random()` function was called like in the example below, it was incorrectly set to foldable, making the result a constant so both rows contained the same value.  Now the `BoundFunctionExpression::IsFoldable()` function also checks the bound lambda expression for side effects, creating two different random values.
```SQL
select [random() for _ in range(1)]  from range(2);
```
