### PR TITLE
Fix LIST aggregate prepare statement exception

### DIFF
--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -462,6 +462,10 @@ void SegmentPrimitiveFunction(ListSegmentFunctions &functions) {
 
 void GetSegmentDataFunctions(ListSegmentFunctions &functions, const LogicalType &type) {
 
+	if (type.id() == LogicalTypeId::UNKNOWN) {
+		throw ParameterNotResolvedException();
+	}
+
 	auto physical_type = type.InternalType();
 	switch (physical_type) {
 	case PhysicalType::BIT:

--- a/test/sql/types/nested/list/list_aggregates.test
+++ b/test/sql/types/nested/list/list_aggregates.test
@@ -122,3 +122,11 @@ select i, i % 2, list(i) over(partition by i % 2 order by i rows between 1 prece
 5	1	[3, 5, 7]
 7	1	[5, 7, 9]
 9	1	[7, 9]
+
+# parameter not resolved issue (#484)
+
+statement ok
+PREPARE rebind_stmt AS SELECT list(list_value({'foo': [?]}));
+
+statement ok
+EXECUTE rebind_stmt(10);


### PR DESCRIPTION
This fixes https://github.com/duckdblabs/duckdb-internal/issues/484. We need to throw a `ParameterNotResolved` exception, which we can later catch in the planner to trigger a rebind once executing the prepared statement.