### PR TITLE
Satisfy GCC's LTO checks

### DIFF
--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -118,7 +118,10 @@ static void TemplatedConcatWS(DataChunk &args, const string_t *sep_data, const S
                               const SelectionVector &rsel, idx_t count, Vector &result) {
 	vector<idx_t> result_lengths(args.size(), 0);
 	vector<bool> has_results(args.size(), false);
-	auto orrified_data = make_unsafe_uniq_array<UnifiedVectorFormat>(args.ColumnCount() - 1);
+
+	// we overallocate here, but this is important for static analysis
+	auto orrified_data = make_unsafe_uniq_array<UnifiedVectorFormat>(args.ColumnCount());
+
 	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
 		args.data[col_idx].ToUnifiedFormat(args.size(), orrified_data[col_idx - 1]);
 	}


### PR DESCRIPTION
This is necessary for the R package and perhaps later for other static analysis tools.

Follow-up to https://github.com/duckdb/duckdb-r/pull/35.