### PR TITLE
Support gcs:// and r2:// URLs to read data from GCS and R2

### DIFF
--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -29,12 +29,11 @@ static void LoadInternal(DatabaseInstance &instance) {
 	                          "Backoff factor for exponentially increasing retry wait time (default 4)",
 	                          LogicalType::FLOAT, Value(4));
 	// Global S3 config
-	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);
+	config.AddExtensionOption("s3_region", "S3 Region (default us-east-1)", LogicalType::VARCHAR, Value("us-east-1"));
 	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_secret_access_key", "S3 Access Key", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_session_token", "S3 Session Token", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_endpoint", "S3 Endpoint (default 's3.amazonaws.com')", LogicalType::VARCHAR,
-	                          Value("s3.amazonaws.com"));
+	config.AddExtensionOption("s3_endpoint", "S3 Endpoint (empty for default endpoint)", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_url_style", "S3 url style ('vhost' (default) or 'path')", LogicalType::VARCHAR,
 	                          Value("vhost"));
 	config.AddExtensionOption("s3_use_ssl", "S3 use SSL (default true)", LogicalType::BOOLEAN, Value(true));

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -49,6 +49,7 @@ struct S3AuthParams {
 
 struct ParsedS3Url {
 	const string http_proto;
+	const string prefix;
 	const string host;
 	const string bucket;
 	const string path;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -193,7 +193,13 @@ S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener, FileOpenerInfo &info) {
 	if (FileOpener::TryGetCurrentSetting(opener, "s3_endpoint", value, info)) {
 		endpoint = value.ToString();
 	} else {
-		endpoint = "s3.amazonaws.com";
+		if (StringUtil::StartsWith(info.file_path, "gcs://")) {
+			endpoint = "storage.googleapis.com";
+		} else if (StringUtil::StartsWith(info.file_path, "r2://")) {
+			endpoint = "r2.cloudflarestorage.com";
+		} else {
+			endpoint = "s3.amazonaws.com";
+		}
 	}
 
 	if (FileOpener::TryGetCurrentSetting(opener, "s3_url_style", value, info)) {
@@ -556,17 +562,27 @@ void S3FileSystem::ReadQueryParams(const string &url_query_param, S3AuthParams &
 	}
 }
 
-ParsedS3Url S3FileSystem::S3UrlParse(string url, S3AuthParams &params) {
-	string http_proto, host, bucket, path, query_param, trimmed_s3_url;
-
-	if (url.rfind("s3://", 0) != 0) {
-		throw IOException("URL needs to start with s3://");
+static string GetPrefix(string url) {
+	const string prefixes[] = {"s3://", "gcs://", "r2://"};
+	for (auto &prefix : prefixes) {
+		if (StringUtil::StartsWith(url, prefix)) {
+			return prefix;
+		}
 	}
-	auto slash_pos = url.find('/', 5);
+	throw IOException("URL needs to start with s3://, gcs:// or r2://");
+	return string();
+}
+
+ParsedS3Url S3FileSystem::S3UrlParse(string url, S3AuthParams &params) {
+	string http_proto, prefix, host, bucket, path, query_param, trimmed_s3_url;
+
+	prefix = GetPrefix(url);
+	auto prefix_end_pos = url.find("//") + 2;
+	auto slash_pos = url.find('/', prefix_end_pos);
 	if (slash_pos == string::npos) {
 		throw IOException("URL needs to contain a '/' after the host");
 	}
-	bucket = url.substr(5, slash_pos - 5);
+	bucket = url.substr(prefix_end_pos, slash_pos - prefix_end_pos);
 	if (bucket.empty()) {
 		throw IOException("URL needs to contain a bucket name");
 	}
@@ -611,7 +627,7 @@ ParsedS3Url S3FileSystem::S3UrlParse(string url, S3AuthParams &params) {
 
 	http_proto = params.use_ssl ? "https://" : "http://";
 
-	return {http_proto, host, bucket, path, query_param, trimmed_s3_url};
+	return {http_proto, prefix, host, bucket, path, query_param, trimmed_s3_url};
 }
 
 string S3FileSystem::GetPayloadHash(char *buffer, idx_t buffer_len) {
@@ -812,7 +828,7 @@ void S3FileHandle::Initialize(FileOpener *opener) {
 }
 
 bool S3FileSystem::CanHandleFile(const string &fpath) {
-	return fpath.rfind("s3://", 0) == 0;
+	return this->IsRemoteFile(fpath);
 }
 
 void S3FileSystem::FileSync(FileHandle &handle) {
@@ -927,7 +943,7 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 		// Repeat requests until the keys of all common prefixes are parsed.
 		auto common_prefixes = AWSListObjectV2::ParseCommonPrefix(response_str);
 		while (!common_prefixes.empty()) {
-			auto prefix_path = "s3://" + parsed_s3_url.bucket + '/' + common_prefixes.back();
+			auto prefix_path = parsed_s3_url.prefix + parsed_s3_url.bucket + '/' + common_prefixes.back();
 			common_prefixes.pop_back();
 
 			// TODO we could optimize here by doing a match on the prefix, if it doesn't match we can skip this prefix
@@ -960,7 +976,7 @@ vector<string> S3FileSystem::Glob(const string &glob_pattern, FileOpener *opener
 		bool is_match = Match(key_splits.begin(), key_splits.end(), pattern_splits.begin(), pattern_splits.end());
 
 		if (is_match) {
-			auto result_full_url = "s3://" + parsed_s3_url.bucket + "/" + s3_key;
+			auto result_full_url = parsed_s3_url.prefix + parsed_s3_url.bucket + "/" + s3_key;
 			// if a ? char was present, we re-add it here as the url parsing will have trimmed it.
 			if (!parsed_s3_url.query_param.empty()) {
 				result_full_url += '?' + parsed_s3_url.query_param;

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -191,15 +191,17 @@ S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener, FileOpenerInfo &info) {
 	}
 
 	if (FileOpener::TryGetCurrentSetting(opener, "s3_endpoint", value, info)) {
-		endpoint = value.ToString();
-	} else {
-		if (StringUtil::StartsWith(info.file_path, "gcs://")) {
-			endpoint = "storage.googleapis.com";
-		} else if (StringUtil::StartsWith(info.file_path, "r2://")) {
-			endpoint = "r2.cloudflarestorage.com";
+		if (value.ToString().empty()) {
+			if (StringUtil::StartsWith(info.file_path, "gcs://")) {
+				endpoint = "storage.googleapis.com";
+			} else {
+				endpoint = "s3.amazonaws.com";
+			}
 		} else {
-			endpoint = "s3.amazonaws.com";
+			endpoint = value.ToString();
 		}
+	} else {
+		endpoint = "s3.amazonaws.com";
 	}
 
 	if (FileOpener::TryGetCurrentSetting(opener, "s3_url_style", value, info)) {

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -830,7 +830,7 @@ void S3FileHandle::Initialize(FileOpener *opener) {
 }
 
 bool S3FileSystem::CanHandleFile(const string &fpath) {
-	return this->IsRemoteFile(fpath);
+	return fpath.rfind("s3://", 0) * fpath.rfind("gcs://", 0) * fpath.rfind("r2://", 0) == 0;
 }
 
 void S3FileSystem::FileSync(FileHandle &handle) {

--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -271,6 +271,8 @@ static constexpr ExtensionEntry EXTENSION_FILE_PREFIXES[] = {
     {"http://", "httpfs"},
     {"https://", "httpfs"},
     {"s3://", "httpfs"},
+    {"gcs://", "httpfs"},
+    {"r2://", "httpfs"}
 //    {"azure://", "azure"}
 }; // END_OF_EXTENSION_FILE_PREFIXES
 

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -535,7 +535,7 @@ FileType FileHandle::GetType() {
 }
 
 bool FileSystem::IsRemoteFile(const string &path) {
-	const string prefixes[] = {"http://", "https://", "s3://"};
+	const string prefixes[] = {"http://", "https://", "s3://", "gcs://", "r2://"};
 	for (auto &prefix : prefixes) {
 		if (StringUtil::StartsWith(path, prefix)) {
 			return true;

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -260,8 +260,11 @@ static constexpr ExtensionEntry EXTENSION_COLLATIONS[] = {
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
 static constexpr ExtensionEntry EXTENSION_FILE_PREFIXES[] = {
-    {"http://", "httpfs"}, {"https://", "httpfs"}, {"s3://", "httpfs"},
-    //    {"azure://", "azure"}
+    {"http://", "httpfs"}, 
+    {"https://", "httpfs"}, 
+    {"s3://", "httpfs"}, 
+    {"gcs://", "httpfs"},
+    {"r2://", "httpfs"} // , {"azure://", "azure"}
 }; // END_OF_EXTENSION_FILE_PREFIXES
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -260,12 +260,12 @@ static constexpr ExtensionEntry EXTENSION_COLLATIONS[] = {
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
 static constexpr ExtensionEntry EXTENSION_FILE_PREFIXES[] = {
-    {"http://", "httpfs"}, 
-    {"https://", "httpfs"}, 
-    {"s3://", "httpfs"}, 
+    {"http://", "httpfs"},
+    {"https://", "httpfs"},
+    {"s3://", "httpfs"},
     {"gcs://", "httpfs"},
     {"r2://", "httpfs"} // , {"azure://", "azure"}
-}; // END_OF_EXTENSION_FILE_PREFIXES
+};                      // END_OF_EXTENSION_FILE_PREFIXES
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -102,21 +102,6 @@ SELECT * FROM "${prefix}test-bucket-public/url_encode/question?marks?and*stars[a
 ----
 4
 
-statement error
-SELECT * FROM 's3://test-bucket/whatever';
-----
-Catalog Error: Table with name s3://test-bucket/whatever does not exist!
-
-statement error
-SELECT * FROM 'gcs://test-bucket/whatever';
-----
-Catalog Error: Table with name gcs://test-bucket/whatever does not exist!
-
-statement error
-SELECT * FROM 'r2://test-bucket/whatever';
-----
-Catalog Error: Table with name r2://test-bucket/whatever does not exist!
-
 # HTTP urls will be encoded here
 query I
 SELECT * FROM "http://test-bucket-public.${DUCKDB_S3_ENDPOINT}/url_encode/question%3Fmarks%3Fand%2Astars%5Band%5Dbrackets.parquet" LIMIT 1;
@@ -126,4 +111,35 @@ SELECT * FROM "http://test-bucket-public.${DUCKDB_S3_ENDPOINT}/url_encode/questi
 statement ok
 SET s3_url_compatibility_mode=false;
 
-endloop 
+# Check that the generated urls are correct
+statement ok
+set s3_endpoint='s3.some.random.endpoint.com';
+
+statement error
+SELECT * FROM '${prefix}test-bucket/whatever.parquet';
+----
+IO Error: Connection error for HTTP HEAD to 'http://test-bucket.s3.some.random.endpoint.com/whatever.parquet'
+
+statement ok
+set s3_endpoint='${DUCKDB_S3_ENDPOINT}'
+
+endloop
+
+# Check that the generated urls are correct for an empty endpoint
+statement ok
+set s3_endpoint='';
+
+statement error
+SELECT * FROM 's3://test-bucket/whatever.parquet';
+----
+IO Error: HTTP GET error on 'http://test-bucket.s3.amazonaws.com/whatever.parquet'
+
+statement error
+SELECT * FROM 'r2://test-bucket/whatever.parquet';
+----
+IO Error: HTTP GET error on 'http://test-bucket.s3.amazonaws.com/whatever.parquet'
+
+statement error
+SELECT * FROM 'gcs://test-bucket/whatever.parquet';
+----
+IO Error: HTTP GET error on 'http://test-bucket.storage.googleapis.com/whatever.parquet'

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -29,30 +29,32 @@ CREATE TABLE test_2 as (SELECT 2 FROM range(0,5));
 CREATE TABLE test_3 as (SELECT 3 FROM range(0,5));
 CREATE TABLE test_4 as (SELECT 4 FROM range(0,5));
 
-statement ok
-COPY test_1 TO 's3://test-bucket-public/url_encode/just because you can doesnt mean you should.parquet' (FORMAT 'parquet');
+foreach prefix s3:// r2:// gcs://
 
 statement ok
-COPY test_2 TO 's3://test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet' (FORMAT 'parquet');
+COPY test_1 TO '${prefix}test-bucket-public/url_encode/just because you can doesnt mean you should.parquet' (FORMAT 'parquet');
 
 statement ok
-COPY test_3 TO 's3://test-bucket-public/url_encode/should:avoid:using:colon:in:paths.parquet' (FORMAT 'parquet');
+COPY test_2 TO '${prefix}test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet' (FORMAT 'parquet');
+
+statement ok
+COPY test_3 TO '${prefix}test-bucket-public/url_encode/should:avoid:using:colon:in:paths.parquet' (FORMAT 'parquet');
 
 # For S3 urls spaces are fine
 query I
-SELECT * FROM "s3://test-bucket-public/url_encode/just because you can doesnt mean you should.parquet" LIMIT 1;
+SELECT * FROM "${prefix}test-bucket-public/url_encode/just because you can doesnt mean you should.parquet" LIMIT 1;
 ----
 1
 
 # In S3 urls, + means a plus symbol
 query I
-SELECT * FROM "s3://test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet" LIMIT 1;
+SELECT * FROM "${prefix}test-bucket-public/url_encode/just+dont+use+plus+or+spaces+please.parquet" LIMIT 1;
 ----
 2
 
 # Colons in S3 urls are encoded by duckdb internaly like boto3 (issue #5502)
 query I
-SELECT * FROM "s3://test-bucket-public/url_encode/should:avoid:using:colon:in:paths.parquet" LIMIT 1;
+SELECT * FROM "${prefix}test-bucket-public/url_encode/should:avoid:using:colon:in:paths.parquet" LIMIT 1;
 ----
 3
 
@@ -83,7 +85,7 @@ SELECT * FROM "http://test-bucket-public.${DUCKDB_S3_ENDPOINT}/url_encode/just+d
 
 # Due to our support for query parameters, this will fail
 statement error
-COPY test_4 TO 's3://test-bucket-public/url_encode/question?marks?are?even?worse.parquet' (FORMAT 'parquet');
+COPY test_4 TO '${prefix}test-bucket-public/url_encode/question?marks?are?even?worse.parquet' (FORMAT 'parquet');
 ----
 Invalid query parameters found.
 
@@ -93,12 +95,27 @@ statement ok
 SET s3_url_compatibility_mode=true;
 
 statement ok
-COPY test_4 TO 's3://test-bucket-public/url_encode/question?marks?and*stars[and]brackets.parquet' (FORMAT 'parquet');
+COPY test_4 TO '${prefix}test-bucket-public/url_encode/question?marks?and*stars[and]brackets.parquet' (FORMAT 'parquet');
 
 query I
-SELECT * FROM "s3://test-bucket-public/url_encode/question?marks?and*stars[and]brackets.parquet" LIMIT 1;
+SELECT * FROM "${prefix}test-bucket-public/url_encode/question?marks?and*stars[and]brackets.parquet" LIMIT 1;
 ----
 4
+
+statement error
+SELECT * FROM 's3://test-bucket/whatever';
+----
+Catalog Error: Table with name s3://test-bucket/whatever does not exist!
+
+statement error
+SELECT * FROM 'gcs://test-bucket/whatever';
+----
+Catalog Error: Table with name gcs://test-bucket/whatever does not exist!
+
+statement error
+SELECT * FROM 'r2://test-bucket/whatever';
+----
+Catalog Error: Table with name r2://test-bucket/whatever does not exist!
 
 # HTTP urls will be encoded here
 query I
@@ -108,3 +125,5 @@ SELECT * FROM "http://test-bucket-public.${DUCKDB_S3_ENDPOINT}/url_encode/questi
 
 statement ok
 SET s3_url_compatibility_mode=false;
+
+endloop 


### PR DESCRIPTION
This PR adds two new schemes for the s3 filesystem:
- The default region of all services is changed to `us-east-1`. Relevant links for: [s3](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-region.html), [gcs](https://cloud.google.com/compute/docs/regions-zones) and [r2](https://developers.cloudflare.com/r2/api/s3/api/#bucket-region)
- The gcs and s3 services have their corresponding endpoints as defaults. 
- The r2 gets `s3.amazonaws.com` as default because otherwise (for the`r2.cloudflarestorage.com` endpoint), it needs additionally an account_id (this will be addressed in another PR)
- The gcs and r2 prefixes have been added wherever needed.
- The `url_encode.test` is modified to additionally test gcs and r2 like s3 url.