### PR TITLE
[UnionVerify] Properly deal with SelectionVectors

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -6010,6 +6010,8 @@ const char* EnumUtil::ToChars<UnionInvalidReason>(UnionInvalidReason value) {
 		return "VALIDITY_OVERLAP";
 	case UnionInvalidReason::TAG_MISMATCH:
 		return "TAG_MISMATCH";
+	case UnionInvalidReason::NULL_TAG:
+		return "NULL_TAG";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
 	}
@@ -6031,6 +6033,9 @@ UnionInvalidReason EnumUtil::FromString<UnionInvalidReason>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "TAG_MISMATCH")) {
 		return UnionInvalidReason::TAG_MISMATCH;
+	}
+	if (StringUtil::Equals(value, "NULL_TAG")) {
+		return UnionInvalidReason::NULL_TAG;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1989,14 +1989,12 @@ UnionInvalidReason UnionVector::CheckUnionValidity(Vector &vector, idx_t count, 
 			continue;
 		}
 
-		auto tag_row_idx = tags_vdata.sel->get_index(idx);
-
 		// we can't have null tags in unions
-		if (!tags_vdata.validity.RowIsValid(tag_row_idx)) {
+		if (!tags_vdata.validity.RowIsValid(tags_vdata.sel->get_index(idx))) {
 			return UnionInvalidReason::NULL_TAG;
 		}
 
-		auto tag = (UnifiedVectorFormat::GetData<union_tag_t>(tags_vdata))[tag_row_idx];
+		auto tag = (UnifiedVectorFormat::GetData<union_tag_t>(tags_vdata))[tags_vdata.sel->get_index(idx)];
 		if (tag >= member_count) {
 			return UnionInvalidReason::TAG_OUT_OF_RANGE;
 		}
@@ -2008,8 +2006,7 @@ UnionInvalidReason UnionVector::CheckUnionValidity(Vector &vector, idx_t count, 
 			auto &member = UnionVector::GetMember(vector, member_idx);
 			member.ToUnifiedFormat(count, member_vdata);
 
-			auto member_row_idx = member_vdata.sel->get_index(idx);
-			if (member_vdata.validity.RowIsValid(member_row_idx)) {
+			if (member_vdata.validity.RowIsValid(member_vdata.sel->get_index(idx))) {
 				if (found_valid) {
 					// Only one member can be valid at a time
 					return UnionInvalidReason::VALIDITY_OVERLAP;

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1250,7 +1250,7 @@ void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count)
 		}
 
 		if (vector->GetType().id() == LogicalTypeId::UNION) {
-			VerifyUnion(*vector, *sel, count);
+			VerifyUnion(*vector, sel_p, count);
 		}
 	}
 
@@ -1968,54 +1968,56 @@ union_tag_t UnionVector::GetTag(const Vector &vector, idx_t index) {
 	return FlatVector::GetData<union_tag_t>(tag_vector)[index];
 }
 
-UnionInvalidReason UnionVector::CheckUnionValidity(Vector &vector, idx_t count, const SelectionVector &sel) {
-	D_ASSERT(vector.GetType().id() == LogicalTypeId::UNION);
-	auto member_count = UnionType::GetMemberCount(vector.GetType());
+UnionInvalidReason UnionVector::CheckUnionValidity(Vector &vector_p, idx_t count, const SelectionVector &sel) {
+
+	D_ASSERT(vector_p.GetType().id() == LogicalTypeId::UNION);
+
+	auto member_count = UnionType::GetMemberCount(vector_p.GetType());
 	if (member_count == 0) {
 		return UnionInvalidReason::NO_MEMBERS;
 	}
 
-	UnifiedVectorFormat union_vdata;
-	vector.ToUnifiedFormat(count, union_vdata);
+	UnifiedVectorFormat vector_vdata;
+	vector_p.ToUnifiedFormat(count, vector_vdata);
 
-	UnifiedVectorFormat tags_vdata;
-	auto &tag_vector = UnionVector::GetTags(vector);
-	tag_vector.ToUnifiedFormat(count, tags_vdata);
+	auto &entries = StructVector::GetEntries(vector_p);
+	vector<UnifiedVectorFormat> child_vdata(entries.size());
+	for (idx_t entry_idx = 0; entry_idx < entries.size(); entry_idx++) {
+		auto &child = *entries[entry_idx];
+		child.ToUnifiedFormat(count, child_vdata[entry_idx]);
+	}
 
-	// check that only one member is valid at a time
+	auto &tag_vdata = child_vdata[0];
+
 	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
-		auto idx = sel.get_index(row_idx);
-		if (!union_vdata.validity.RowIsValid(union_vdata.sel->get_index(idx))) {
+		auto mapped_idx = sel.get_index(row_idx);
+
+		if (!vector_vdata.validity.RowIsValid(vector_vdata.sel->get_index(mapped_idx))) {
 			continue;
 		}
 
-		// we can't have null tags in unions
-		if (!tags_vdata.validity.RowIsValid(tags_vdata.sel->get_index(idx))) {
+		if (!tag_vdata.validity.RowIsValid(tag_vdata.sel->get_index(mapped_idx))) {
+			// we can't have NULL tags!
 			return UnionInvalidReason::NULL_TAG;
 		}
 
-		auto tag = (UnifiedVectorFormat::GetData<union_tag_t>(tags_vdata))[tags_vdata.sel->get_index(idx)];
+		auto tag = UnifiedVectorFormat::GetData<union_tag_t>(tag_vdata)[tag_vdata.sel->get_index(mapped_idx)];
 		if (tag >= member_count) {
 			return UnionInvalidReason::TAG_OUT_OF_RANGE;
 		}
 
 		bool found_valid = false;
 		for (idx_t member_idx = 0; member_idx < member_count; member_idx++) {
-
-			UnifiedVectorFormat member_vdata;
-			auto &member = UnionVector::GetMember(vector, member_idx);
-			member.ToUnifiedFormat(count, member_vdata);
-
-			if (member_vdata.validity.RowIsValid(member_vdata.sel->get_index(idx))) {
-				if (found_valid) {
-					// Only one member can be valid at a time
-					return UnionInvalidReason::VALIDITY_OVERLAP;
-				}
-				found_valid = true;
-				if (tag != static_cast<union_tag_t>(member_idx)) {
-					// The tag does not match the valid member
-					return UnionInvalidReason::TAG_MISMATCH;
-				}
+			auto &member_vdata = child_vdata[1 + member_idx]; // skip the tag
+			if (!member_vdata.validity.RowIsValid(member_vdata.sel->get_index(mapped_idx))) {
+				continue;
+			}
+			if (found_valid) {
+				return UnionInvalidReason::VALIDITY_OVERLAP;
+			}
+			found_valid = true;
+			if (tag != static_cast<union_tag_t>(member_idx)) {
+				return UnionInvalidReason::TAG_MISMATCH;
 			}
 		}
 	}

--- a/src/function/cast/union/from_struct.cpp
+++ b/src/function/cast/union/from_struct.cpp
@@ -60,9 +60,11 @@ bool StructToUnionCast::Cast(Vector &source, Vector &result, idx_t count, CastPa
 	}
 
 	auto &tag_vec = *target_children[0];
+	UnifiedVectorFormat tag_data;
+	tag_vec.ToUnifiedFormat(count, tag_data);
 	for (idx_t i = 0; i < count; i++) {
 		// if the tag is NULL, the union is NULL
-		if (FlatVector::IsNull(tag_vec, i)) {
+		if (!tag_data.validity.RowIsValid(tag_data.sel->get_index(i))) {
 			FlatVector::SetNull(result, i, true);
 		}
 	}

--- a/src/function/cast/union/from_struct.cpp
+++ b/src/function/cast/union/from_struct.cpp
@@ -59,6 +59,14 @@ bool StructToUnionCast::Cast(Vector &source, Vector &result, idx_t count, CastPa
 		D_ASSERT(converted);
 	}
 
+	auto &tag_vec = *target_children[0];
+	for (idx_t i = 0; i < count; i++) {
+		// if the tag is NULL, the union is NULL
+		if (FlatVector::IsNull(tag_vec, i)) {
+			FlatVector::SetNull(result, i, true);
+		}
+	}
+
 	auto check_tags = UnionVector::CheckUnionValidity(result, count);
 	switch (check_tags) {
 	case UnionInvalidReason::TAG_OUT_OF_RANGE:
@@ -68,6 +76,8 @@ bool StructToUnionCast::Cast(Vector &source, Vector &result, idx_t count, CastPa
 	case UnionInvalidReason::TAG_MISMATCH:
 		throw ConversionException(
 		    "One or more rows in the produced UNION have tags that don't point to the valid member");
+	case UnionInvalidReason::NULL_TAG:
+		throw ConversionException("One or more rows in the produced UNION have a NULL tag");
 	case UnionInvalidReason::VALID:
 		break;
 	default:

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -467,7 +467,12 @@ struct UnionVector {
 	//	2.	The validity of the tag vector always matches the validity of the
 	//		union vector itself.
 	//
-	//	3.	For each tag in the tag vector, 0 <= tag < |members|
+	//  3.  A valid union cannot have a NULL tag, but the selected member can
+	//  	be NULL. therefore, there is a difference between a union that "is"
+	//  	NULL and a union that "holds" a NULL. The latter still has a valid
+	//  	tag.
+	//
+	//	4.	For each tag in the tag vector, 0 <= tag < |members|
 
 	//! Get the tag vector of a union vector
 	DUCKDB_API static const Vector &GetTags(const Vector &v);

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -447,7 +447,14 @@ struct StructVector {
 	DUCKDB_API static vector<unique_ptr<Vector>> &GetEntries(Vector &vector);
 };
 
-enum class UnionInvalidReason : uint8_t { VALID, TAG_OUT_OF_RANGE, NO_MEMBERS, VALIDITY_OVERLAP, TAG_MISMATCH };
+enum class UnionInvalidReason : uint8_t {
+	VALID,
+	TAG_OUT_OF_RANGE,
+	NO_MEMBERS,
+	VALIDITY_OVERLAP,
+	TAG_MISMATCH,
+	NULL_TAG
+};
 
 struct UnionVector {
 	// Unions are stored as structs, but the first child is always the "tag"

--- a/test/sql/types/union/struct_to_union.test
+++ b/test/sql/types/union/struct_to_union.test
@@ -53,7 +53,7 @@ statement ok
 INSERT INTO struct_tbl VALUES
 	(ROW(0, True, NULL, NULL)),
 	(ROW(1, NULL, 23423, NULL)),
-	(ROW(0, True, NULL, NULL))
+    (ROW(0, True, NULL, NULL))
 
 # Verify case-insensitive
 statement ok

--- a/test/sql/types/union/union_cast.test
+++ b/test/sql/types/union/union_cast.test
@@ -176,8 +176,29 @@ query III
 SELECT union_tag(u), union_tag(u::UNION(i SMALLINT, b INT)), u::UNION(i SMALLINT, b INT) FROM tbl4 ORDER BY ALL;;
 ----
 NULL	NULL	NULL
-NULL	NULL	NULL
 i		i		1
 i		i		3
 b		b		NULL
 b		b		NULL
+b		b		NULL
+
+# DuckDB internal issue #477
+query I
+select [
+    true::UNION(
+        a integer,
+        c bool
+    )
+] as a from range(10);
+----
+[true]
+[true]
+[true]
+[true]
+[true]
+[true]
+[true]
+[true]
+[true]
+[true]
+

--- a/test/sql/types/union/union_validity.test
+++ b/test/sql/types/union/union_validity.test
@@ -1,0 +1,24 @@
+# name: test/sql/types/union/union_validity.test
+# group: [union]
+
+statement ok
+CREATE TABLE tbl (u UNION(a INT, b VARCHAR));
+
+statement ok
+INSERT INTO tbl VALUES (1), (NULL), (NULL::VARCHAR), (NULL::INT);
+
+statement ok
+DELETE FROM tbl
+
+statement ok
+INSERT INTO tbl VALUES (1), (NULL), (NULL::VARCHAR), (NULL::INT);
+
+query II rowsort
+SELECT union_tag(u) as tag, u as val FROM tbl;
+----
+NULL	NULL
+a	1
+a	NULL
+b	NULL
+
+


### PR DESCRIPTION
This PR expands on #9327 

We had a look at the Verify code for UNION and realized it was not properly dealing with the different selection vectors involved:
the incoming selection vector
the selvec from the parents dictionary
the childs selection vector

Now it does