### PR TITLE
update R CMD workflow to apply patches in .github/patches/duckdb-r

### DIFF
--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -81,8 +81,9 @@ jobs:
 
       - name: Apply duckdb-r patches
         shell: bash
+        working-directory: ${{ env.DUCKDB_SRC }}
         run: |
-          for filename in $GITHUB_WORKSPACE/$DUCKDB_SRC/.github/patches/duckdb-r/*.patch; do
+          for filename in .github/patches/duckdb-r/*.patch; do
             git apply $filename
           done
 

--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -83,6 +83,7 @@ jobs:
         shell: bash
         working-directory: ${{ env.DUCKDB_SRC }}
         run: |
+          shopt -s nullglob
           for filename in .github/patches/duckdb-r/*.patch; do
             git apply $filename
           done

--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -79,6 +79,13 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Apply duckdb-r patches
+        shell: bash
+        run: |
+          for filename in $GITHUB_WORKSPACE/$DUCKDB_SRC/.github/patches/duckdb-r/*.patch; do
+            git apply $filename
+          done
+
       # needed so we can run git commit in vendor.sh
       - name: setup github and create parallel builds
         shell: bash


### PR DESCRIPTION
If the duckdb repo ever creates breaking changes to the duckdb-r repo that need patches, we can prevent CI from yelling at us if we include the patches. These patches then need to be applied to duckdb-r at some later date. 

Most likely the duckdb-r CI will yell when the sources are updated. One idea might be to apply the patches from within the vendor script.

Needed because https://github.com/duckdb/duckdb/pull/9406 will break the duckdb-r client