### PR TITLE
[ART] Improve error message for zero bytes in BLOBs

### DIFF
--- a/src/execution/index/art/art_key.cpp
+++ b/src/execution/index/art/art_key.cpp
@@ -20,10 +20,10 @@ ARTKey ARTKey::CreateARTKey(ArenaAllocator &allocator, const LogicalType &type, 
 
 	// FIXME: rethink this
 	if (type == LogicalType::BLOB || type == LogicalType::VARCHAR) {
-		// indexes cannot contain BLOBs (or BLOBs cast to VARCHARs) that contain null-terminated bytes
+		// indexes cannot contain BLOBs (or BLOBs cast to VARCHARs) that contain zero bytes
 		for (uint32_t i = 0; i < len - 1; i++) {
 			if (data[i] == '\0') {
-				throw NotImplementedException("Indexes cannot contain BLOBs that contain null-terminated bytes.");
+				throw NotImplementedException("ART indexes cannot contain BLOBs with zero bytes.");
 			}
 		}
 	}
@@ -45,10 +45,10 @@ void ARTKey::CreateARTKey(ArenaAllocator &allocator, const LogicalType &type, AR
 
 	// FIXME: rethink this
 	if (type == LogicalType::BLOB || type == LogicalType::VARCHAR) {
-		// indexes cannot contain BLOBs (or BLOBs cast to VARCHARs) that contain null-terminated bytes
+		// indexes cannot contain BLOBs (or BLOBs cast to VARCHARs) that contain zero bytes
 		for (uint32_t i = 0; i < key.len - 1; i++) {
 			if (key.data[i] == '\0') {
-				throw NotImplementedException("Indexes cannot contain BLOBs that contain null-terminated bytes.");
+				throw NotImplementedException("ART indexes cannot contain BLOBs with zero bytes.");
 			}
 		}
 	}

--- a/test/fuzzer/pedro/art_prefix_error.test
+++ b/test/fuzzer/pedro/art_prefix_error.test
@@ -8,4 +8,4 @@ CREATE TABLE t0 (c0 BLOB PRIMARY KEY);
 statement error
 INSERT INTO t0(c0) VALUES (BLOB '\x00a'), (BLOB '');
 ----
-Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
+ART indexes cannot contain BLOBs with zero bytes.

--- a/test/sql/index/art/issues/test_art_fuzzer.test
+++ b/test/sql/index/art/issues/test_art_fuzzer.test
@@ -30,7 +30,7 @@ CREATE INDEX i2 ON t2 (c1);
 statement error
 INSERT INTO t2 VALUES (decode('g\x00'::BLOB)::VARCHAR),('g');
 ----
-Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
+ART indexes cannot contain BLOBs with zero bytes.
 
 statement ok
 INSERT INTO t2 VALUES ('\0');
@@ -92,7 +92,7 @@ CREATE INDEX i21 ON t21 (c1, "decode"('\x00'::BLOB));
 statement error
 INSERT INTO t21 VALUES (1);
 ----
-Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
+ART indexes cannot contain BLOBs with zero bytes.
 
 statement error
 CREATE INDEX i21 ON t21 (c1);

--- a/test/sql/storage/null_byte_storage.test
+++ b/test/sql/storage/null_byte_storage.test
@@ -30,7 +30,7 @@ goo\042
 statement error
 CREATE INDEX i_index ON null_byte(v)
 ----
-Not implemented Error: Indexes cannot contain BLOBs that contain null-terminated bytes.
+ART indexes cannot contain BLOBs with zero bytes.
 
 query I
 SELECT * FROM null_byte WHERE v=concat('goo', chr(0), 42)


### PR DESCRIPTION
As pointed out in https://github.com/duckdb/duckdb/issues/9369, our error message for zero bytes in BLOBs as ART keys was inaccurate.