### PR TITLE
[Python] Support replacement scan on `connection.table(<name>)` method

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -969,7 +969,12 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Table(const string &tname) {
 	if (qualified_name.schema.empty()) {
 		qualified_name.schema = DEFAULT_SCHEMA;
 	}
-	return make_uniq<DuckDBPyRelation>(connection->Table(qualified_name.schema, qualified_name.name));
+	auto table_info = connection->TableInfo(qualified_name.schema, qualified_name.name);
+	if (table_info) {
+		return make_uniq<DuckDBPyRelation>(connection->Table(qualified_name.schema, qualified_name.name));
+	}
+	// Not a table in the database, make a query relation that can perform replacement scans
+	return RunQuery(StringUtil::Format("from %s", tname), tname);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Values(py::object params) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -969,12 +969,13 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Table(const string &tname) {
 	if (qualified_name.schema.empty()) {
 		qualified_name.schema = DEFAULT_SCHEMA;
 	}
-	auto table_info = connection->TableInfo(qualified_name.schema, qualified_name.name);
-	if (table_info) {
+	try {
 		return make_uniq<DuckDBPyRelation>(connection->Table(qualified_name.schema, qualified_name.name));
+	} catch (const CatalogException &e) {
+		// CatalogException will be of the type '... is not a table'
+		// Not a table in the database, make a query relation that can perform replacement scans
+		return RunQuery(StringUtil::Format("from %s", tname), tname);
 	}
-	// Not a table in the database, make a query relation that can perform replacement scans
-	return RunQuery(StringUtil::Format("from %s", tname), tname);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Values(py::object params) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -48,6 +48,7 @@
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/main/pending_query_result.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
 
 #include <random>
 
@@ -974,7 +975,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Table(const string &tname) {
 	} catch (const CatalogException &e) {
 		// CatalogException will be of the type '... is not a table'
 		// Not a table in the database, make a query relation that can perform replacement scans
-		return RunQuery(StringUtil::Format("from %s", tname), tname);
+		return RunQuery(StringUtil::Format("from %s", KeywordHelper::WriteOptionallyQuoted(tname)), tname);
 	}
 }
 

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_query.py
@@ -35,7 +35,7 @@ class TestRAPIQuery(object):
         result = rel.execute()
         assert result.fetchall() == [tuple([x]) for x in input]
 
-    def test_query_table_unrelated(self, tbl_table):
+    def test_query_table_basic(self, tbl_table):
         con = duckdb.default_connection
         rel = con.table("tbl")
         # Querying a table relation

--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -1,7 +1,37 @@
 import duckdb
 import os
 import pytest
+pl = pytest.importorskip("polars")
 
+# NOTE: the name has to be 'to_scan' to match the place it's returned into
+def using_table(con, to_scan):
+    return con.table('to_scan')
+
+def using_sql(con, to_scan):
+    return con.sql(f"select * from to_scan")
+
+# Fetch methods
+
+def fetch_polars(rel):
+    return rel.pl()
+
+def fetch_df(rel):
+    return rel.df()
+
+def fetch_arrow(rel):
+    return rel.arrow()
+
+def fetch_arrow_table(rel):
+    return rel.fetch_arrow_table()
+
+def fetch_arrow_record_batch(rel):
+	# Note: this has to executed first, otherwise we'll create a deadlock
+    # Because it will try to execute the input at the same time as executing the relation
+    # On the same connection (that's the core of the issue)
+    return rel.execute().record_batch()
+
+def fetch_relation(rel):
+    return rel
 
 class TestReplacementScan(object):
     def test_csv_replacement(self):
@@ -15,6 +45,27 @@ class TestReplacementScan(object):
         filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'binary_string.parquet')
         res = con.execute("select count(*) from '%s'" % (filename))
         assert res.fetchone()[0] == 3
+
+    @pytest.mark.parametrize('get_relation', [
+        using_table,
+        using_sql
+    ])
+    @pytest.mark.parametrize('fetch_method', [
+        fetch_polars,
+        fetch_df,
+        fetch_arrow,
+        fetch_arrow_table,
+        fetch_arrow_record_batch,
+        fetch_relation
+    ])
+    def test_table_replacement_scans(self, duckdb_cursor, get_relation, fetch_method):
+        base_rel = duckdb_cursor.values([1, 2, 3])
+        # NOTE: do not rename 'to_scan'
+        to_scan = fetch_method(base_rel)
+
+        rel = get_relation(duckdb_cursor, to_scan)
+        res = rel.fetchall()
+        assert res == [(1, 2, 3)]
 
     def test_replacement_scan_relapi(self):
         con = duckdb.connect()

--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -1,37 +1,48 @@
 import duckdb
 import os
 import pytest
+
 pl = pytest.importorskip("polars")
+
 
 # NOTE: the name has to be 'to_scan' to match the place it's returned into
 def using_table(con, to_scan):
     return con.table('to_scan')
 
+
 def using_sql(con, to_scan):
     return con.sql(f"select * from to_scan")
 
+
 # Fetch methods
+
 
 def fetch_polars(rel):
     return rel.pl()
 
+
 def fetch_df(rel):
     return rel.df()
+
 
 def fetch_arrow(rel):
     return rel.arrow()
 
+
 def fetch_arrow_table(rel):
     return rel.fetch_arrow_table()
 
+
 def fetch_arrow_record_batch(rel):
-	# Note: this has to executed first, otherwise we'll create a deadlock
+    # Note: this has to executed first, otherwise we'll create a deadlock
     # Because it will try to execute the input at the same time as executing the relation
     # On the same connection (that's the core of the issue)
     return rel.execute().record_batch()
 
+
 def fetch_relation(rel):
     return rel
+
 
 class TestReplacementScan(object):
     def test_csv_replacement(self):
@@ -46,18 +57,11 @@ class TestReplacementScan(object):
         res = con.execute("select count(*) from '%s'" % (filename))
         assert res.fetchone()[0] == 3
 
-    @pytest.mark.parametrize('get_relation', [
-        using_table,
-        using_sql
-    ])
-    @pytest.mark.parametrize('fetch_method', [
-        fetch_polars,
-        fetch_df,
-        fetch_arrow,
-        fetch_arrow_table,
-        fetch_arrow_record_batch,
-        fetch_relation
-    ])
+    @pytest.mark.parametrize('get_relation', [using_table, using_sql])
+    @pytest.mark.parametrize(
+        'fetch_method',
+        [fetch_polars, fetch_df, fetch_arrow, fetch_arrow_table, fetch_arrow_record_batch, fetch_relation],
+    )
     def test_table_replacement_scans(self, duckdb_cursor, get_relation, fetch_method):
         base_rel = duckdb_cursor.values([1, 2, 3])
         # NOTE: do not rename 'to_scan'


### PR DESCRIPTION
This PR fixes #9134

If the table lookup fails, we fall back to creating a `"select * from name"` query and creating a relation out of that, which utilizes the replacement scan functionality.

Added tests for using `table` for various replacement scan candidates.