### PR TITLE
[Union] Fix issue with keyword/quoted UNION member names.

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -373,7 +373,9 @@ string LogicalType::ToString() const {
 		string ret = "UNION(";
 		size_t count = UnionType::GetMemberCount(*this);
 		for (size_t i = 0; i < count; i++) {
-			ret += UnionType::GetMemberName(*this, i) + " " + UnionType::GetMemberType(*this, i).ToString();
+			auto member_name = UnionType::GetMemberName(*this, i);
+			auto member_type = UnionType::GetMemberType(*this, i).ToString();
+			ret += StringUtil::Format("%s %s", SQLIdentifier(member_name), member_type);
 			if (i < count - 1) {
 				ret += ", ";
 			}

--- a/test/sql/export/export_quoted_union.test
+++ b/test/sql/export/export_quoted_union.test
@@ -1,0 +1,45 @@
+# name: test/sql/export/export_quoted_union.test
+# description: Test export database
+# group: [export]
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+create table a (
+	u UNION(
+		"member name 1" VARCHAR,
+		"member name 2" BOOL
+	)
+);
+
+statement ok
+insert into a values (
+	union_value("member name 1" := 'hello')
+);
+
+query I
+select * from a
+----
+hello
+
+# now export the db
+statement ok
+EXPORT DATABASE '__TEST_DIR__/export_test' (FORMAT CSV)
+
+statement ok
+ROLLBACK
+
+statement ok
+IMPORT DATABASE '__TEST_DIR__/export_test'
+
+# Verify that the import was succesful
+query I
+select * from a
+----
+hello
+
+query I
+select union_tag(COLUMNS(*)) from a;
+----
+member name 1

--- a/test/sql/index/art/types/test_art_union.test
+++ b/test/sql/index/art/types/test_art_union.test
@@ -39,12 +39,12 @@ DROP INDEX idx_i;
 statement error
 CREATE INDEX idx_u_list ON tbl (u_list);
 ----
-Invalid type Error: Invalid Type [UNION(int INTEGER, list INTEGER[], bool BOOLEAN)]: Invalid type for index key.
+Invalid type Error: Invalid Type [UNION("int" INTEGER, list INTEGER[], bool BOOLEAN)]: Invalid type for index key.
 
 statement error
 CREATE INDEX idx_u_list ON tbl (i, u_list);
 ----
-Invalid type Error: Invalid Type [UNION(int INTEGER, list INTEGER[], bool BOOLEAN)]: Invalid type for index key.
+Invalid type Error: Invalid Type [UNION("int" INTEGER, list INTEGER[], bool BOOLEAN)]: Invalid type for index key.
 
 query IIII
 SELECT * FROM tbl ORDER BY ALL;
@@ -139,7 +139,7 @@ CREATE UNIQUE INDEX idx_c_1 ON tbl ((u_2.string), (u_1.string));
 statement error
 CREATE INDEX idx_c_fail ON tbl ((u_2.string), u_list);
 ----
-Invalid type Error: Invalid Type [UNION(int INTEGER, list INTEGER[], bool BOOLEAN)]: Invalid type for index key.
+Invalid type Error: Invalid Type [UNION("int" INTEGER, list INTEGER[], bool BOOLEAN)]: Invalid type for index key.
 
 statement ok
 CREATE UNIQUE INDEX idx_c_2 ON tbl ((u_list.int), (u_1.string), (u_2.bool));


### PR DESCRIPTION
Among others, EXPORT DATABASE would produce a schema that is invalid and can not be roundtripped.

I've added a test for this that currently fails on `main`