### PR TITLE
Add bot for the 'Needs Documentation' label

### DIFF
--- a/.github/workflows/NeedsDocumentation.yml
+++ b/.github/workflows/NeedsDocumentation.yml
@@ -1,0 +1,37 @@
+name: Create Documentation issue for the Needs Documentation label
+on:
+  issues:
+    types:
+      - labeled
+  pull_request:
+    types:
+      - labeled
+
+env:
+  GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
+  TITLE_PREFIX: "duckdb/#${{ github.event.issue.number }}]"
+  PUBLIC_ISSUE_TITLE: ${{ github.event.issue.title }}
+
+jobs:
+  create_documentation_issue:
+    if: github.event.label.name == 'Needs Documentation'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get mirror issue number
+        run: |
+          gh issue list --repo duckdb/duckdb-web --json title,number --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")).number" > mirror_issue_number.txt
+          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> ${GITHUB_ENV}
+
+      - name: Print whether mirror issue exists
+        run: |
+          if [ "${MIRROR_ISSUE_NUMBER}" == "" ]; then
+            echo "Mirror issue with title prefix '${TITLE_PREFIX}' does not exist yet"
+          else
+            echo "Mirror issue with title prefix '${TITLE_PREFIX}' exists with number ${MIRROR_ISSUE_NUMBER}"
+          fi
+
+      - name: Create mirror issue if it does not yet exist
+        run: |
+          if [ "${MIRROR_ISSUE_NUMBER}" == "" ]; then
+            gh issue create --repo duckdb/duckdb-web --title "${TITLE_PREFIX} - ${PUBLIC_ISSUE_TITLE} needs documentation" --body "See https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number }}"
+          fi


### PR DESCRIPTION
This PR implements the following workflow: When the "Needs Documentation" is applied on an issue or a PR, it opens an issue in the documentation repository (duckdb-web) and links to the original issue/PR.

The primary use case is to allow PR authors to easily raise an issue in the documentation when their PR has user-facing effects. 