### PR TITLE
Fuzzer #1294: Non-Constant NULL Format

### DIFF
--- a/src/core_functions/scalar/date/strftime.cpp
+++ b/src/core_functions/scalar/date/strftime.cpp
@@ -183,7 +183,14 @@ struct StrpTimeFunction {
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.bind_info->Cast<StrpTimeBindData>();
 
-		if (args.data[1].GetVectorType() == VectorType::CONSTANT_VECTOR && ConstantVector::IsNull(args.data[1])) {
+		//	There is a bizarre situation where the format column is foldable but not constant
+		//	(i.e., the statistics tell us it has only one value)
+		//	We have to check whether that value is NULL
+		const auto count = args.size();
+		UnifiedVectorFormat format_unified;
+		args.data[1].ToUnifiedFormat(count, format_unified);
+
+		if (!format_unified.validity.RowIsValid(0)) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
 			ConstantVector::SetNull(result, true);
 			return;

--- a/test/fuzzer/sqlsmith/strptime_null_statistics.test
+++ b/test/fuzzer/sqlsmith/strptime_null_statistics.test
@@ -1,0 +1,12 @@
+# name: test/fuzzer/sqlsmith/strptime_null_statistics.test
+# description: have you seen the fnords?
+# group: [sqlsmith]
+
+statement ok
+create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types() limit 0;
+
+statement error
+SELECT (COLUMNS(list_filter(*, (c6 -> strptime(c6, TRY_CAST(c3 AS BIGINT))))) BETWEEN c3 AND 6509) 
+FROM duckdb_databases() AS t5(c1, c2, c3, c4)
+----
+Binder Error: Star expression


### PR DESCRIPTION
Handle NULL formats detected by the optimiser.

fixes: duckdb/duckdb-fuzzer#1294