### PR TITLE
include csv_rejects_table headers for amalgamation

### DIFF
--- a/src/include/duckdb/execution/operator/persistent/csv_rejects_table.hpp
+++ b/src/include/duckdb/execution/operator/persistent/csv_rejects_table.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include "duckdb.hpp"
-#ifndef DUCKDB_AMALGAMATION
 #include "duckdb/storage/object_cache.hpp"
-#endif
 
 namespace duckdb {
 

--- a/src/include/duckdb/execution/operator/persistent/csv_rejects_table.hpp
+++ b/src/include/duckdb/execution/operator/persistent/csv_rejects_table.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
 #include "duckdb/storage/object_cache.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/string.hpp"
 
 namespace duckdb {
 
 struct ReadCSVData;
+class TableCatalogEntry;
+class ClientContext;
 
 class CSVRejectsTable : public ObjectCacheEntry {
 public:


### PR DESCRIPTION
When this was implemented I used the parquet code for reference on how to use the objectcache, this preprocess directive must have snuck in as well.