### PR TITLE
Detect AppleClang in cmake, add defines for `DUCKDB_MAJOR/MINOR/PATCH_VERSION`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,7 +661,7 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY PARAMETERS)
   if(WASM_LOADABLE_EXTENSIONS)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -sSIDE_MODULE=1 -DWASM_LOADABLE_EXTENSIONS")
   elseif (EXTENSION_STATIC_BUILD)
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
       if (APPLE)
         set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
         # Note that on MacOS we need to use the -exported_symbol whitelist feature due to a lack of -exclude-libs flag in mac's ld variant

--- a/src/function/table/version/CMakeLists.txt
+++ b/src/function/table/version/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
 add_definitions(-DDUCKDB_VERSION="\""${DUCKDB_VERSION}"\"")
+add_definitions(-DDUCKDB_VERSION_MAJOR=${DUCKDB_VERSION_MAJOR})
+add_definitions(-DDUCKDB_VERSION_MINOR=${DUCKDB_VERSION_MINOR})
+add_definitions(-DDUCKDB_VERSION_PATCH=${DUCKDB_VERSION_PATCH})
 
 add_library_unity(duckdb_func_table_version OBJECT pragma_version.cpp)
 

--- a/src/function/table/version/CMakeLists.txt
+++ b/src/function/table/version/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_definitions(-DDUCKDB_SOURCE_ID="\""${GIT_COMMIT_HASH}"\"")
 add_definitions(-DDUCKDB_VERSION="\""${DUCKDB_VERSION}"\"")
-add_definitions(-DDUCKDB_VERSION_MAJOR=${DUCKDB_VERSION_MAJOR})
-add_definitions(-DDUCKDB_VERSION_MINOR=${DUCKDB_VERSION_MINOR})
-add_definitions(-DDUCKDB_VERSION_PATCH=${DUCKDB_VERSION_PATCH})
+add_definitions(-DUCKDB_MAJOR_VERSION=${DUCKDB_MAJOR_VERSION})
+add_definitions(-DUCKDB_MINOR_VERSION=${DUCKDB_MINOR_VERSION})
+add_definitions(-DUCKDB_PATCH_VERSION=${DUCKDB_PATCH_VERSION})
 
 add_library_unity(duckdb_func_table_version OBJECT pragma_version.cpp)
 


### PR DESCRIPTION
Trying to build spatial on latest main made me hit a CMake error branch, but upon investigating it seems like it should be supported for Apple+clang, its just that we don't detect the "AppleClang" compiler ID. Not sure what the intended behavior is here but it seems to work with the change in this PR.

This PR also adds defines for `DUCKDB_MAJOR/MINOR/PATCH_VERSION` which is useful for e.g. extensions (spatial) that tries to build for both the latest stable and keep up to date with development versions of DuckDB. Even though we already have a `DUCKDB_VERSION` define, it is defined as a c-string which we can't easily compare in the preprocessor.

CC @samansmink 