### PR TITLE
Needs documentation workflow: Use correct event

### DIFF
--- a/.github/workflows/NeedsDocumentation.yml
+++ b/.github/workflows/NeedsDocumentation.yml
@@ -3,14 +3,16 @@ on:
   issues:
     types:
       - labeled
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 
 env:
   GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
-  TITLE_PREFIX: "duckdb/#${{ github.event.issue.number }}]"
-  PUBLIC_ISSUE_TITLE: ${{ github.event.issue.title }}
+  # an event triggering this workflow is either an issue or a pull request,
+  # hence only one of the numbers will be filled in the TITLE_PREFIX
+  TITLE_PREFIX: "[duckdb/#${{ github.event.issue.number || github.event.pull_request.number }}]"
+  PUBLIC_ISSUE_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
 
 jobs:
   create_documentation_issue:


### PR DESCRIPTION
This PR fixes the labelling for PRs by targeting the `pull_request_target` event instead of the `pull_request` event. As the triggering event can be labelling an issue *or* a pull request, it now takes the number/title from both of those (whichever is applicable).

See explanation in this blog post by GH:

https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

> GitHub Actions has always been about more than just continuous integration. Our goal is to enable repository maintainers to automate a variety of workflows and reduce manual effort. In order to protect public repositories for malicious users we run all pull request workflows raised from repository forks with a read-only token and no access to secrets. **This makes common workflows like labeling or commenting on pull requests very difficult.**
> **In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request.** This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.