### PR TITLE
Fix #9459 - remove unused qualified name parsing

### DIFF
--- a/src/execution/operator/schema/physical_drop.cpp
+++ b/src/execution/operator/schema/physical_drop.cpp
@@ -24,7 +24,6 @@ SourceResultType PhysicalDrop::GetData(ExecutionContext &context, DataChunk &chu
 	case CatalogType::SCHEMA_ENTRY: {
 		auto &catalog = Catalog::GetCatalog(context.client, info->catalog);
 		catalog.DropEntry(context.client, *info);
-		auto qualified_name = QualifiedName::Parse(info->name);
 
 		// Check if the dropped schema was set as the current schema
 		auto &client_data = ClientData::Get(context.client);

--- a/test/sql/catalog/issue_9459.test
+++ b/test/sql/catalog/issue_9459.test
@@ -1,0 +1,12 @@
+# name: test/sql/catalog/issue_9459.test
+# description: Issue #9459 - Dropping schema with double quote in name fails
+# group: [catalog]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create schema """cursed_schema";
+
+statement ok
+drop schema """cursed_schema";


### PR DESCRIPTION
Fixes #9459 

The error was caused by a line of code that didn't need to exist at all :)