### PR TITLE
Issue #8937: Window Order Collation

### DIFF
--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -139,6 +139,12 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	}
 	for (auto &order : window.orders) {
 		BindChild(order.expression, depth, error);
+		if (error.empty()) {
+			//	Restore any collation expressions
+			auto &order_expr = order.expression;
+			auto &bound_order = BoundExpression::GetExpression(*order_expr);
+			ExpressionBinder::PushCollation(context, bound_order, bound_order->return_type, false);
+		}
 	}
 	BindChild(window.filter_expr, depth, error);
 	BindChild(window.start_expr, depth, error);

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -139,12 +139,6 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	}
 	for (auto &order : window.orders) {
 		BindChild(order.expression, depth, error);
-		if (error.empty()) {
-			//	Restore any collation expressions
-			auto &order_expr = order.expression;
-			auto &bound_order = BoundExpression::GetExpression(*order_expr);
-			ExpressionBinder::PushCollation(context, bound_order, bound_order->return_type, false);
-		}
 	}
 	BindChild(window.filter_expr, depth, error);
 	BindChild(window.start_expr, depth, error);
@@ -156,6 +150,13 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	if (!error.empty()) {
 		// failed to bind children of window function
 		return BindResult(error);
+	}
+
+	//	Restore any collation expressions
+	for (auto &order : window.orders) {
+		auto &order_expr = order.expression;
+		auto &bound_order = BoundExpression::GetExpression(*order_expr);
+		ExpressionBinder::PushCollation(context, bound_order, bound_order->return_type, false);
 	}
 	// successfully bound all children: create bound window function
 	vector<LogicalType> types;

--- a/test/sql/window/test_window_order_collate.test
+++ b/test/sql/window/test_window_order_collate.test
@@ -1,0 +1,21 @@
+# name: test/sql/window/test_window_order_collate.test
+# description: Test collation is honoured by over(order by)
+# group: [window]
+
+statement ok
+PRAGMA enable_verification
+
+query III
+select
+    *,
+    array_agg(col) over(partition by id order by col collate nocase) as lead_col_nocase
+from (
+	select 
+		unnest(array[1, 1, 1, 1]) as id, 
+		unnest(array['A', 'a', 'b', 'B']) as col
+)
+----
+1	A	[A, a]
+1	a	[A, a]
+1	b	[A, a, b, B]
+1	B	[A, a, b, B]


### PR DESCRIPTION
Restore any collation expression so that the sort will be executed correctly.

fixes: #8937
fixes: duckdblabs/duckdb-internal#308