### PR TITLE
Fix #9455 - avoid calling filter pushdown on partial plan from within statistics propagation

### DIFF
--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -163,7 +163,11 @@ unordered_set<idx_t> ColumnBindingResolver::VerifyInternal(LogicalOperator &op) 
 
 void ColumnBindingResolver::Verify(LogicalOperator &op) {
 #ifdef DEBUG
+	op.GetColumnBindings();
 	VerifyInternal(op);
+	for(auto &child : op.children) {
+		Verify(*child);
+	}
 #endif
 }
 

--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -165,7 +165,7 @@ void ColumnBindingResolver::Verify(LogicalOperator &op) {
 #ifdef DEBUG
 	op.GetColumnBindings();
 	VerifyInternal(op);
-	for(auto &child : op.children) {
+	for (auto &child : op.children) {
 		Verify(*child);
 	}
 #endif

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -348,8 +348,6 @@ void StatisticsPropagator::CreateFilterFromJoinStats(unique_ptr<LogicalOperator>
 		child->expressions.emplace_back(std::move(filter_expr));
 	}
 
-	FilterPushdown filter_pushdown(optimizer);
-	child = filter_pushdown.Rewrite(std::move(child));
 	PropagateExpression(expr);
 }
 

--- a/test/sql/optimizer/test_mark_join_mix.test
+++ b/test/sql/optimizer/test_mark_join_mix.test
@@ -1,0 +1,37 @@
+# name: test/sql/optimizer/test_mark_join_mix.test
+# description: Issue #9455 - INTERNAL Error: Attempted to access index 7 within vector of size 7
+# group: [optimizer]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE visit_occurrence(visit_occurrence_id BIGINT, person_id BIGINT);
+
+statement ok
+INSERT INTO visit_occurrence VALUES(1,1);
+
+statement ok
+INSERT INTO visit_occurrence VALUES(2,1);
+
+statement ok
+CREATE TABLE procedure_occurrence(visit_occurrence_id BIGINT, person_id BIGINT, procedure_concept_id BIGINT);
+
+statement ok
+INSERT INTO procedure_occurrence VALUES(1, 1, 1);
+
+statement ok
+CREATE TABLE procedure_vocab(procedure_concept_id BIGINT);
+
+statement ok
+INSERT INTO procedure_vocab VALUES(1);
+
+query IIII
+SELECT *
+FROM
+    visit_occurrence AS vo
+    JOIN procedure_occurrence po USING(visit_occurrence_id, person_id)
+    JOIN procedure_vocab pm ON po.procedure_concept_id = pm.procedure_concept_id
+WHERE vo.person_id IN (1,2,3,4,5,6,7,8,9,10,12);
+----
+1	1	1	1


### PR DESCRIPTION
Fixes #9455 