### PR TITLE
fix(jdbc): combine jar publish steps

### DIFF
--- a/scripts/jdbc_maven_deploy.py
+++ b/scripts/jdbc_maven_deploy.py
@@ -23,7 +23,7 @@ import re
 
 def exec(cmd):
     print(cmd)
-    res = subprocess.run(cmd.split(' '), capture_output=True)
+    res = subprocess.run(cmd.split(' '), capture_output=True, text=True)
     if res.returncode == 0:
         return res.stdout
     raise ValueError(res.stdout + res.stderr)
@@ -41,7 +41,7 @@ is_release = True
 if release_tag == 'main':
     # for SNAPSHOT builds we increment the minor version and set patch level to zero.
     # seemed the most sensible
-    last_tag = exec('git tag --sort=-committerdate').decode('utf8').split('\n')[0]
+    last_tag = exec('git tag --sort=-committerdate').split('\n')[0]
     re_result = version_regex.search(last_tag)
     if re_result is None:
         raise ValueError("Could not parse last tag %s" % last_tag)
@@ -202,7 +202,7 @@ print("Close/Release steps")
 os.environ["MAVEN_OPTS"] = '--add-opens=java.base/java.util=ALL-UNNAMED'
 
 # this list has horrid output, lets try to parse. What we want starts with orgduckdb- and then a number
-repo_id = re.search(r'(orgduckdb-\d+)', exec("mvn -f %s nexus-staging:rc-list" % (pom)).decode('utf8')).groups()[0]
+repo_id = re.search(r'(orgduckdb-\d+)', exec("mvn -f %s nexus-staging:rc-list" % (pom))).groups()[0]
 exec("mvn -f %s nexus-staging:rc-close -DstagingRepositoryId=%s" % (pom, repo_id))
 exec("mvn -f %s nexus-staging:rc-release -DstagingRepositoryId=%s" % (pom, repo_id))
 

--- a/scripts/jdbc_maven_deploy.py
+++ b/scripts/jdbc_maven_deploy.py
@@ -182,10 +182,15 @@ for jar in [binary_jar, sources_jar, javadoc_jar]:
     shutil.copyfile(jar, os.path.join(results_dir, os.path.basename(jar)))
 
 print("JARs created, uploading (this can take a while!)")
-deploy_cmd_prefix = 'mvn gpg:sign-and-deploy-file -Durl=%s -DrepositoryId=ossrh' % deploy_url
-exec("%s -DpomFile=%s -Dfile=%s" % (deploy_cmd_prefix, pom, binary_jar))
-exec("%s -Dclassifier=sources -DpomFile=%s -Dfile=%s" % (deploy_cmd_prefix, pom, sources_jar))
-exec("%s -Dclassifier=javadoc -DpomFile=%s -Dfile=%s" % (deploy_cmd_prefix, pom, javadoc_jar))
+exec(
+    f"mvn gpg:sign-and-deploy-file "
+    f"-Durl={deploy_url} "
+    f"-DrepositoryId=ossrh "
+    f"-DpomFile={pom} "
+    f"-Dfile={binary_jar} "
+    f"-Dclassifiers=sources,javadoc "
+    f"-Dfiles={sources_jar},{javadoc_jar}"
+)
 
 
 if not is_release:


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/8240

This ensures that the snapshots all end up with the same generated version, and makes gradle happy

If @hannes could give this a proper test (I don't have sonatype access) that would be great too