### PR TITLE
Dev: Avoid adding name_extension for extensions with DONT_LINK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,7 +604,10 @@ endfunction()
 
 function(add_extension_dependencies LIBRARY)
   foreach(EXT_NAME IN LISTS DUCKDB_EXTENSION_NAMES)
-    add_dependencies(${LIBRARY} ${EXT_NAME}_extension)
+    string(TOUPPER ${EXT_NAME} EXTENSION_NAME_UPPERCASE)
+    if (DUCKDB_EXTENSION_${EXTENSION_NAME_UPPERCASE}_SHOULD_LINK)
+      add_dependencies(${LIBRARY} ${EXT_NAME}_extension)
+    endif()
   endforeach()
 endfunction()
 


### PR DESCRIPTION
This was fine until CMake version was bumped, afterwards it broke on OSX x86_64 extension builds. I am not sure how this hasn't affected the other builds, but the change should be reasonable anyway.