### PR TITLE
Fix #9498: Amalgamation to properly define DUCKDB_VERSION

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -271,7 +271,7 @@ def git_dev_version():
     try:
         version = subprocess.check_output(['git', 'describe', '--tags', '--abbrev=0']).strip().decode('utf8')
         long_version = subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
-        version_splits = version.split('.')
+        version_splits = version.lstrip('v').split('.')
         dev_version = long_version.split('-')[1]
         if int(dev_version) == 0:
             # directly on a tag: emit the regular version


### PR DESCRIPTION
Now `git_dev_version` functions have the same implementation (but the first 2 extra lines) in script/amalgamation.py and scripts/package_build.py, potentially to be refactored.

Fixes #9498.