### PR TITLE
Add MySQL Scanner Aliases + Enable Autoloading

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -51,14 +51,6 @@ duckdb_extension_load(postgres_scanner
         GIT_TAG 844f46536b5d5f9e65b57b7ff92f4ce3346e2829
         )
 
-################# MYSQL_SCANNER
-# Note: tests for mysql_scanner are currently not run. All of them need a mysql server running.
-duckdb_extension_load(mysql_scanner
-        DONT_LINK
-        GIT_URL https://github.com/duckdb/duckdb_mysql
-        GIT_TAG e9ac678490ab8ee3f2679f188884c7a148c3655a
-        )
-
 ################# SPATIAL
 duckdb_extension_load(spatial
         DONT_LINK LOAD_TESTS

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -51,6 +51,14 @@ duckdb_extension_load(postgres_scanner
         GIT_TAG 844f46536b5d5f9e65b57b7ff92f4ce3346e2829
         )
 
+################# MYSQL_SCANNER
+# Note: tests for mysql_scanner are currently not run. All of them need a mysql server running.
+duckdb_extension_load(mysql_scanner
+        DONT_LINK
+        GIT_URL https://github.com/duckdb/duckdb_mysql
+        GIT_TAG e9ac678490ab8ee3f2679f188884c7a148c3655a
+        )
+
 ################# SPATIAL
 duckdb_extension_load(spatial
         DONT_LINK LOAD_TESTS

--- a/src/main/extension/extension_alias.cpp
+++ b/src/main/extension/extension_alias.cpp
@@ -4,7 +4,8 @@ namespace duckdb {
 
 static ExtensionAlias internal_aliases[] = {{"http", "httpfs"}, // httpfs
                                             {"https", "httpfs"},
-                                            {"md", "motherduck"}, // motherduck
+                                            {"md", "motherduck"},       // motherduck
+                                            {"mysql", "mysql_scanner"}, // mysql
                                             {"s3", "httpfs"},
                                             {"postgres", "postgres_scanner"}, // postgres
                                             {"sqlite", "sqlite_scanner"},     // sqlite

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -112,8 +112,9 @@ static DefaultExtension internal_extensions[] = {
     {"jemalloc", "Overwrites system allocator with JEMalloc", DUCKDB_EXTENSION_JEMALLOC_LINKED},
     {"autocomplete", "Adds support for autocomplete in the shell", DUCKDB_EXTENSION_AUTOCOMPLETE_LINKED},
     {"motherduck", "Enables motherduck integration with the system", false},
-    {"sqlite_scanner", "Adds support for reading SQLite database files", false},
-    {"postgres_scanner", "Adds support for reading from a Postgres database", false},
+    {"mysql_scanner", "Adds support for connecting to a MySQL database", false},
+    {"sqlite_scanner", "Adds support for reading and writing SQLite database files", false},
+    {"postgres_scanner", "Adds support for connecting to a Postgres database", false},
     {"inet", "Adds support for IP-related data types and functions", false},
     {"spatial", "Geospatial extension that adds support for working with spatial data and functions", false},
     {"substrait", "Adds support for the Substrait integration", false},
@@ -139,7 +140,7 @@ DefaultExtension ExtensionHelper::GetDefaultExtension(idx_t index) {
 //===--------------------------------------------------------------------===//
 // Allow Auto-Install Extensions
 //===--------------------------------------------------------------------===//
-static const char *auto_install[] = {"motherduck", "postgres_scanner", "sqlite_scanner", nullptr};
+static const char *auto_install[] = {"motherduck", "postgres_scanner", "mysql_scanner", "sqlite_scanner", nullptr};
 
 // TODO: unify with new autoload mechanism
 bool ExtensionHelper::AllowAutoInstall(const string &extension) {


### PR DESCRIPTION
For the upcoming [mysql_scanner](https://github.com/duckdb/duckdb_mysql) extension