### PR TITLE
Adjust expected test results after Greenland timezone change

### DIFF
--- a/test/sql/function/timestamp/test_icu_strptime.test
+++ b/test/sql/function/timestamp/test_icu_strptime.test
@@ -116,93 +116,93 @@ foreach func strptime try_strptime
 
 # Full zone names
 query II
-SELECT ${func}('2022-03-05 17:59:17.877 ' || tz_name, '%Y-%m-%d %H:%M:%S.%g %Z') tstz, tz_name
+SELECT ${func}('2023-11-08 17:59:17.877 ' || tz_name, '%Y-%m-%d %H:%M:%S.%g %Z') tstz, tz_name
 FROM zones
 ORDER BY ALL
 ----
-2022-03-04 19:59:17.877-08	Etc/GMT-14
-2022-03-04 20:14:17.877-08	NZ-CHAT
-2022-03-04 20:59:17.877-08	Pacific/Auckland
-2022-03-04 20:59:17.877-08	Pacific/Enderbury
-2022-03-04 22:59:17.877-08	Australia/LHI
-2022-03-04 22:59:17.877-08	Australia/Melbourne
-2022-03-04 22:59:17.877-08	Pacific/Efate
-2022-03-05 00:29:17.877-08	Australia/Darwin
-2022-03-05 00:59:17.877-08	Asia/Tokyo
-2022-03-05 01:14:17.877-08	Australia/Eucla
-2022-03-05 01:59:17.877-08	Asia/Shanghai
-2022-03-05 02:59:17.877-08	Asia/Novosibirsk
-2022-03-05 03:29:17.877-08	Asia/Yangon
-2022-03-05 03:59:17.877-08	Asia/Omsk
-2022-03-05 04:14:17.877-08	Asia/Kathmandu
-2022-03-05 04:29:17.877-08	Asia/Colombo
-2022-03-05 04:59:17.877-08	Asia/Oral
-2022-03-05 05:29:17.877-08	Asia/Kabul
-2022-03-05 05:59:17.877-08	Europe/Astrakhan
-2022-03-05 06:29:17.877-08	Asia/Tehran
-2022-03-05 06:59:17.877-08	Asia/Kuwait
-2022-03-05 07:59:17.877-08	Asia/Nicosia
-2022-03-05 08:59:17.877-08	Europe/Budapest
-2022-03-05 09:59:17.877-08	Etc/GMT-0
-2022-03-05 10:59:17.877-08	Atlantic/Azores
-2022-03-05 11:59:17.877-08	Atlantic/South_Georgia
-2022-03-05 12:59:17.877-08	America/Cordoba
-2022-03-05 13:29:17.877-08	CNT
-2022-03-05 13:59:17.877-08	America/Martinique
-2022-03-05 14:59:17.877-08	America/Louisville
-2022-03-05 15:59:17.877-08	America/Rainy_River
-2022-03-05 16:59:17.877-08	America/Shiprock
-2022-03-05 17:59:17.877-08	Mexico/BajaNorte
-2022-03-05 18:59:17.877-08	America/Sitka
-2022-03-05 19:29:17.877-08	Pacific/Marquesas
-2022-03-05 19:59:17.877-08	Pacific/Johnston
-2022-03-05 20:59:17.877-08	Pacific/Niue
-2022-03-05 21:59:17.877-08	Etc/GMT+12
+2023-11-07 19:59:17.877-08	Etc/GMT-14
+2023-11-07 20:14:17.877-08	NZ-CHAT
+2023-11-07 20:59:17.877-08	Pacific/Auckland
+2023-11-07 20:59:17.877-08	Pacific/Enderbury
+2023-11-07 22:59:17.877-08	Australia/LHI
+2023-11-07 22:59:17.877-08	Australia/Melbourne
+2023-11-07 22:59:17.877-08	Pacific/Efate
+2023-11-08 00:29:17.877-08	Australia/Darwin
+2023-11-08 00:59:17.877-08	Asia/Tokyo
+2023-11-08 01:14:17.877-08	Australia/Eucla
+2023-11-08 01:59:17.877-08	Asia/Shanghai
+2023-11-08 02:59:17.877-08	Asia/Novosibirsk
+2023-11-08 03:29:17.877-08	Asia/Yangon
+2023-11-08 03:59:17.877-08	Asia/Omsk
+2023-11-08 04:14:17.877-08	Asia/Kathmandu
+2023-11-08 04:29:17.877-08	Asia/Colombo
+2023-11-08 04:59:17.877-08	Asia/Oral
+2023-11-08 05:29:17.877-08	Asia/Kabul
+2023-11-08 05:59:17.877-08	Europe/Astrakhan
+2023-11-08 06:29:17.877-08	Asia/Tehran
+2023-11-08 06:59:17.877-08	Asia/Kuwait
+2023-11-08 07:59:17.877-08	Asia/Nicosia
+2023-11-08 08:59:17.877-08	Europe/Budapest
+2023-11-08 09:59:17.877-08	Etc/GMT-0
+2023-11-08 10:59:17.877-08	Atlantic/Azores
+2023-11-08 11:59:17.877-08	America/Nuuk
+2023-11-08 12:59:17.877-08	America/Cayenne
+2023-11-08 13:29:17.877-08	CNT
+2023-11-08 13:59:17.877-08	America/Martinique
+2023-11-08 14:59:17.877-08	America/Louisville
+2023-11-08 15:59:17.877-08	America/Rainy_River
+2023-11-08 16:59:17.877-08	America/Shiprock
+2023-11-08 17:59:17.877-08	Mexico/BajaNorte
+2023-11-08 18:59:17.877-08	America/Sitka
+2023-11-08 19:29:17.877-08	Pacific/Marquesas
+2023-11-08 19:59:17.877-08	Pacific/Johnston
+2023-11-08 20:59:17.877-08	Pacific/Niue
+2023-11-08 21:59:17.877-08	Etc/GMT+12
 
 # Abbreviations
 query II
-SELECT ${func}('2022-03-05 17:59:17.877 ' || tz_name, '%Y-%m-%d %H:%M:%S.%g %Z') tstz, tz_name
+SELECT ${func}('2023-11-08 17:59:17.877 ' || tz_name, '%Y-%m-%d %H:%M:%S.%g %Z') tstz, tz_name
 FROM abbrevs
 ORDER BY ALL
 ----
-2022-03-04 19:59:17.877-08	Etc/GMT-14
-2022-03-04 20:14:17.877-08	NZ-CHAT
-2022-03-04 20:59:17.877-08	NZ
-2022-03-04 20:59:17.877-08	Pacific/Enderbury
-2022-03-04 22:59:17.877-08	Australia/Hobart
-2022-03-04 22:59:17.877-08	Australia/LHI
-2022-03-04 22:59:17.877-08	Pacific/Efate
-2022-03-04 23:29:17.877-08	Australia/Adelaide
-2022-03-05 00:59:17.877-08	Etc/GMT-9
-2022-03-05 01:14:17.877-08	Australia/Eucla
-2022-03-05 01:59:17.877-08	CTT
-2022-03-05 02:59:17.877-08	Asia/Phnom_Penh
-2022-03-05 03:29:17.877-08	Asia/Yangon
-2022-03-05 03:59:17.877-08	Asia/Thimbu
-2022-03-05 04:14:17.877-08	Asia/Kathmandu
-2022-03-05 04:29:17.877-08	IST
-2022-03-05 04:59:17.877-08	Asia/Qyzylorda
-2022-03-05 05:29:17.877-08	Asia/Kabul
-2022-03-05 05:59:17.877-08	Europe/Samara
-2022-03-05 06:29:17.877-08	Iran
-2022-03-05 06:59:17.877-08	EAT
-2022-03-05 07:59:17.877-08	CAT
-2022-03-05 08:59:17.877-08	Europe/Bratislava
-2022-03-05 09:59:17.877-08	GMT
-2022-03-05 10:59:17.877-08	Atlantic/Azores
-2022-03-05 11:59:17.877-08	Atlantic/South_Georgia
-2022-03-05 12:59:17.877-08	America/Cordoba
-2022-03-05 13:29:17.877-08	CNT
-2022-03-05 13:59:17.877-08	PRT
-2022-03-05 14:59:17.877-08	America/Panama
-2022-03-05 15:59:17.877-08	America/Rankin_Inlet
-2022-03-05 16:59:17.877-08	Canada/Yukon
-2022-03-05 17:59:17.877-08	PST
-2022-03-05 18:59:17.877-08	America/Nome
-2022-03-05 19:29:17.877-08	Pacific/Marquesas
-2022-03-05 19:59:17.877-08	Pacific/Johnston
-2022-03-05 20:59:17.877-08	Pacific/Niue
-2022-03-05 21:59:17.877-08	Etc/GMT+12
+2023-11-07 19:59:17.877-08	Etc/GMT-14
+2023-11-07 20:14:17.877-08	NZ-CHAT
+2023-11-07 20:59:17.877-08	NZ
+2023-11-07 20:59:17.877-08	Pacific/Enderbury
+2023-11-07 22:59:17.877-08	Australia/Hobart
+2023-11-07 22:59:17.877-08	Australia/LHI
+2023-11-07 22:59:17.877-08	Pacific/Efate
+2023-11-07 23:29:17.877-08	Australia/Adelaide
+2023-11-08 00:59:17.877-08	Etc/GMT-9
+2023-11-08 01:14:17.877-08	Australia/Eucla
+2023-11-08 01:59:17.877-08	CTT
+2023-11-08 02:59:17.877-08	Asia/Phnom_Penh
+2023-11-08 03:29:17.877-08	Asia/Yangon
+2023-11-08 03:59:17.877-08	Asia/Thimbu
+2023-11-08 04:14:17.877-08	Asia/Kathmandu
+2023-11-08 04:29:17.877-08	IST
+2023-11-08 04:59:17.877-08	Asia/Qyzylorda
+2023-11-08 05:29:17.877-08	Asia/Kabul
+2023-11-08 05:59:17.877-08	Europe/Samara
+2023-11-08 06:29:17.877-08	Iran
+2023-11-08 06:59:17.877-08	EAT
+2023-11-08 07:59:17.877-08	CAT
+2023-11-08 08:59:17.877-08	Europe/Bratislava
+2023-11-08 09:59:17.877-08	GMT
+2023-11-08 10:59:17.877-08	Atlantic/Azores
+2023-11-08 11:59:17.877-08	America/Nuuk
+2023-11-08 12:59:17.877-08	America/Cayenne
+2023-11-08 13:29:17.877-08	CNT
+2023-11-08 13:59:17.877-08	PRT
+2023-11-08 14:59:17.877-08	America/Panama
+2023-11-08 15:59:17.877-08	America/Rankin_Inlet
+2023-11-08 16:59:17.877-08	Canada/Yukon
+2023-11-08 17:59:17.877-08	PST
+2023-11-08 18:59:17.877-08	America/Nome
+2023-11-08 19:29:17.877-08	Pacific/Marquesas
+2023-11-08 19:59:17.877-08	Pacific/Johnston
+2023-11-08 20:59:17.877-08	Pacific/Niue
+2023-11-08 21:59:17.877-08	Etc/GMT+12
 
 #
 # UTC Offsets
@@ -259,48 +259,48 @@ ORDER BY tstz
 
 # First fails
 query II
-SELECT ${func}('2022-03-05 17:59:17.877 ' || tz_name, ['%m/%d/%Y  %H:%M:%S.%g %Z', '%Y-%m-%d %H:%M:%S.%g %Z']) tstz, tz_name
+SELECT ${func}('2023-11-08 17:59:17.877 ' || tz_name, ['%m/%d/%Y  %H:%M:%S.%g %Z', '%Y-%m-%d %H:%M:%S.%g %Z']) tstz, tz_name
 FROM zones
 ORDER BY ALL
 ----
-2022-03-04 19:59:17.877-08	Etc/GMT-14
-2022-03-04 20:14:17.877-08	NZ-CHAT
-2022-03-04 20:59:17.877-08	Pacific/Auckland
-2022-03-04 20:59:17.877-08	Pacific/Enderbury
-2022-03-04 22:59:17.877-08	Australia/LHI
-2022-03-04 22:59:17.877-08	Australia/Melbourne
-2022-03-04 22:59:17.877-08	Pacific/Efate
-2022-03-05 00:29:17.877-08	Australia/Darwin
-2022-03-05 00:59:17.877-08	Asia/Tokyo
-2022-03-05 01:14:17.877-08	Australia/Eucla
-2022-03-05 01:59:17.877-08	Asia/Shanghai
-2022-03-05 02:59:17.877-08	Asia/Novosibirsk
-2022-03-05 03:29:17.877-08	Asia/Yangon
-2022-03-05 03:59:17.877-08	Asia/Omsk
-2022-03-05 04:14:17.877-08	Asia/Kathmandu
-2022-03-05 04:29:17.877-08	Asia/Colombo
-2022-03-05 04:59:17.877-08	Asia/Oral
-2022-03-05 05:29:17.877-08	Asia/Kabul
-2022-03-05 05:59:17.877-08	Europe/Astrakhan
-2022-03-05 06:29:17.877-08	Asia/Tehran
-2022-03-05 06:59:17.877-08	Asia/Kuwait
-2022-03-05 07:59:17.877-08	Asia/Nicosia
-2022-03-05 08:59:17.877-08	Europe/Budapest
-2022-03-05 09:59:17.877-08	Etc/GMT-0
-2022-03-05 10:59:17.877-08	Atlantic/Azores
-2022-03-05 11:59:17.877-08	Atlantic/South_Georgia
-2022-03-05 12:59:17.877-08	America/Cordoba
-2022-03-05 13:29:17.877-08	CNT
-2022-03-05 13:59:17.877-08	America/Martinique
-2022-03-05 14:59:17.877-08	America/Louisville
-2022-03-05 15:59:17.877-08	America/Rainy_River
-2022-03-05 16:59:17.877-08	America/Shiprock
-2022-03-05 17:59:17.877-08	Mexico/BajaNorte
-2022-03-05 18:59:17.877-08	America/Sitka
-2022-03-05 19:29:17.877-08	Pacific/Marquesas
-2022-03-05 19:59:17.877-08	Pacific/Johnston
-2022-03-05 20:59:17.877-08	Pacific/Niue
-2022-03-05 21:59:17.877-08	Etc/GMT+12
+2023-11-07 19:59:17.877-08	Etc/GMT-14
+2023-11-07 20:14:17.877-08	NZ-CHAT
+2023-11-07 20:59:17.877-08	Pacific/Auckland
+2023-11-07 20:59:17.877-08	Pacific/Enderbury
+2023-11-07 22:59:17.877-08	Australia/LHI
+2023-11-07 22:59:17.877-08	Australia/Melbourne
+2023-11-07 22:59:17.877-08	Pacific/Efate
+2023-11-08 00:29:17.877-08	Australia/Darwin
+2023-11-08 00:59:17.877-08	Asia/Tokyo
+2023-11-08 01:14:17.877-08	Australia/Eucla
+2023-11-08 01:59:17.877-08	Asia/Shanghai
+2023-11-08 02:59:17.877-08	Asia/Novosibirsk
+2023-11-08 03:29:17.877-08	Asia/Yangon
+2023-11-08 03:59:17.877-08	Asia/Omsk
+2023-11-08 04:14:17.877-08	Asia/Kathmandu
+2023-11-08 04:29:17.877-08	Asia/Colombo
+2023-11-08 04:59:17.877-08	Asia/Oral
+2023-11-08 05:29:17.877-08	Asia/Kabul
+2023-11-08 05:59:17.877-08	Europe/Astrakhan
+2023-11-08 06:29:17.877-08	Asia/Tehran
+2023-11-08 06:59:17.877-08	Asia/Kuwait
+2023-11-08 07:59:17.877-08	Asia/Nicosia
+2023-11-08 08:59:17.877-08	Europe/Budapest
+2023-11-08 09:59:17.877-08	Etc/GMT-0
+2023-11-08 10:59:17.877-08	Atlantic/Azores
+2023-11-08 11:59:17.877-08	America/Nuuk
+2023-11-08 12:59:17.877-08	America/Cayenne
+2023-11-08 13:29:17.877-08	CNT
+2023-11-08 13:59:17.877-08	America/Martinique
+2023-11-08 14:59:17.877-08	America/Louisville
+2023-11-08 15:59:17.877-08	America/Rainy_River
+2023-11-08 16:59:17.877-08	America/Shiprock
+2023-11-08 17:59:17.877-08	Mexico/BajaNorte
+2023-11-08 18:59:17.877-08	America/Sitka
+2023-11-08 19:29:17.877-08	Pacific/Marquesas
+2023-11-08 19:59:17.877-08	Pacific/Johnston
+2023-11-08 20:59:17.877-08	Pacific/Niue
+2023-11-08 21:59:17.877-08	Etc/GMT+12
 
 endloop
 
@@ -314,6 +314,20 @@ FROM zones
 WHERE tstz IS NOT NULL
 ORDER BY ALL
 ----
+
+#
+# Greenland 2023 time zone change
+# Current time zone set to America/Los_Angeles
+#
+query T
+SELECT to_timestamp(epoch(strptime('2022-10-30 07:00 America/Nuuk', '%Y-%m-%d %H:%M %Z')))
+----
+2022-10-30 03:00:00-07
+
+query T
+SELECT to_timestamp(epoch(strptime('2023-10-30 07:00 America/Nuuk', '%Y-%m-%d %H:%M %Z')))
+----
+2023-10-30 02:00:00-07
 
 #
 # Errors/Coverage

--- a/test/sql/timezone/test_icu_timezone.test
+++ b/test/sql/timezone/test_icu_timezone.test
@@ -288,7 +288,7 @@ America/Fort_Nelson	America/Fort_Nelson	-07:00:00
 America/Fort_Wayne	IET	-05:00:00
 America/Fortaleza	America/Fortaleza	-03:00:00
 America/Glace_Bay	America/Glace_Bay	-04:00:00
-America/Godthab	America/Godthab	-03:00:00
+America/Godthab	America/Godthab	-02:00:00
 America/Goose_Bay	America/Goose_Bay	-04:00:00
 America/Grand_Turk	America/Grand_Turk	-05:00:00
 America/Grenada	PRT	-04:00:00
@@ -348,7 +348,7 @@ America/Noronha	America/Noronha	-02:00:00
 America/North_Dakota/Beulah	America/North_Dakota/Beulah	-06:00:00
 America/North_Dakota/Center	America/North_Dakota/Center	-06:00:00
 America/North_Dakota/New_Salem	America/North_Dakota/New_Salem	-06:00:00
-America/Nuuk	America/Nuuk	-03:00:00
+America/Nuuk	America/Nuuk	-02:00:00
 America/Ojinaga	America/Ojinaga	-06:00:00
 America/Panama	America/Panama	-05:00:00
 America/Pangnirtung	America/Pangnirtung	-05:00:00


### PR DESCRIPTION
Greenland has [changed its timezone](https://time.is/time_zone_news/time_zone_change_in_greenland) and is now in UTC-2 instead of UTC-3.

Therefore, the expected `utc_offset` in test_icu_timezone.test needs to be adjusted for Nuuk, the capital of Greenland, and Godthåb, the old name for Nuuk.

Furthermore, the tests in test_icu_strptime.test needs to be adjusted, because America/Nuuk happens to be the median name of its timezone group and is hence as `tz_name` for the tables created at the beginning of the test scripts.
So Nuuk is the representative for UTC-2, but in the tests, 2022-03-05 is parsed. At this point in time, Nuuk was still UTC-3. Therefore, the parsed time is 12:59 instead of the expected 11:59. (Atlantic/South_Georgia was the median name for UTC-2 before the timezone change.)

```
SET TimeZone = 'America/Los_Angeles';

D SELECT strptime('2022-03-05 17:59:17.877 Atlantic/South_Georgia', '%Y-%m-%d %H:%M:%S.%g %Z');
2022-03-05 11:59:17.877-08

D SELECT strptime('2022-03-05 17:59:17.877 America/Nuuk', '%Y-%m-%d %H:%M:%S.%g %Z');
2022-03-05 12:59:17.877-08
```

To fix this, I replaced 2022-03-05 with 2023-11-08, a date that is after the timezone change (and also after the US switches to standard time again on November 5).

America/Cayenne is the new median name for UTC-3 after America/Nuuk moved out and replaces America/Cordoba.