### PR TITLE
Internal #582: Remove utc_offset Dependency

### DIFF
--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -81,6 +81,9 @@ static void ICUTimeZoneFunction(ClientContext &context, TableFunctionInput &data
 			break;
 		}
 
+		//	What PG reports is the total offset for today,
+		//	which is the ICU total offset (i.e., "raw") plus the DST offset.
+		raw_offset_ms += dst_offset_ms;
 		output.SetValue(2, index, Value::INTERVAL(Interval::FromMicro(raw_offset_ms * Interval::MICROS_PER_MSEC)));
 		output.SetValue(3, index, Value(dst_offset_ms != 0));
 		++index;

--- a/test/sql/function/timestamp/test_icu_strptime.test
+++ b/test/sql/function/timestamp/test_icu_strptime.test
@@ -74,43 +74,141 @@ SELECT '1582-10-10'::TIMESTAMPTZ AS ts;
 # Same date, multiple TZ names
 #
 
+# We can't use the offsets in pg_timezone_names() 
+# because they change with the date
+# So hard code the original values
+# The important point is that these cover all the GMT offsets.
 statement ok
 CREATE TABLE zones AS (
-	SELECT median(name) as tz_name
-	FROM pg_timezone_names()
-	GROUP BY utc_offset
-	ORDER BY utc_offset
+	FROM (VALUES
+		('Etc/GMT-14'),
+		('NZ-CHAT'),
+		('Pacific/Auckland'),
+		('Pacific/Enderbury'),
+		('Australia/LHI'),
+		('Australia/Melbourne'),
+		('Pacific/Efate'),
+		('Australia/Darwin'),
+		('Asia/Tokyo'),
+		('Australia/Eucla'),
+		('Asia/Shanghai'),
+		('Asia/Novosibirsk'),
+		('Asia/Yangon'),
+		('Asia/Omsk'),
+		('Asia/Kathmandu'),
+		('Asia/Colombo'),
+		('Asia/Oral'),
+		('Asia/Kabul'),
+		('Europe/Astrakhan'),
+		('Asia/Tehran'),
+		('Asia/Kuwait'),
+		('Asia/Nicosia'),
+		('Europe/Budapest'),
+		('Etc/GMT-0'),
+		('Atlantic/Azores'),
+		('America/Cayenne'),
+		('America/Nuuk'),
+		('CNT'),
+		('America/Martinique'),
+		('America/Louisville'),
+		('America/Rainy_River'),
+		('America/Shiprock'),
+		('Mexico/BajaNorte'),
+		('America/Sitka'),
+		('Pacific/Marquesas'),
+		('Pacific/Johnston'),
+		('Pacific/Niue'),
+		('Etc/GMT+12'),
+	) tbl(tz_name)
 );
 
 statement ok
 CREATE TABLE abbrevs AS (
-	SELECT median(abbrev) as tz_name
-	FROM pg_timezone_names()
-	GROUP BY utc_offset
-	ORDER BY utc_offset
+	FROM (VALUES
+		('Etc/GMT-14'),
+		('NZ-CHAT'),
+		('NZ'),
+		('Pacific/Enderbury'),
+		('Australia/Hobart'),
+		('Australia/LHI'),
+		('Pacific/Efate'),
+		('Australia/Adelaide'),
+		('Etc/GMT-9'),
+		('Australia/Eucla'),
+		('CTT'),
+		('Asia/Phnom_Penh'),
+		('Asia/Yangon'),
+		('Asia/Thimbu'),
+		('Asia/Kathmandu'),
+		('IST'),
+		('Asia/Qyzylorda'),
+		('Asia/Kabul'),
+		('Europe/Samara'),
+		('Iran'),
+		('EAT'),
+		('CAT'),
+		('Europe/Bratislava'),
+		('GMT'),
+		('Atlantic/Azores'),
+		('America/Cayenne'),
+		('America/Nuuk'),
+		('CNT'),
+		('PRT'),
+		('America/Panama'),
+		('America/Rankin_Inlet'),
+		('Canada/Yukon'),
+		('PST'),
+		('America/Nome'),
+		('Pacific/Marquesas'),
+		('Pacific/Johnston'),
+		('Pacific/Niue'),
+		('Etc/GMT+12'),
+	) tbl(tz_name)
 );
 
 statement ok
-CREATE TABLE offsets AS (
-	SELECT
-		CASE WHEN EXTRACT(MINUTE FROM utc_offset) <> 0
-		THEN
-			CASE WHEN utc_offset < INTERVAL 0 SECOND
-				THEN LEFT(utc_offset, 6)
-				ELSE '+' || LEFT(utc_offset, 5)
-			END
-		ELSE
-			CASE WHEN utc_offset < INTERVAL 0 SECOND
-				THEN LEFT(utc_offset, 3)
-				ELSE '+' || LEFT(utc_offset, 2)
-			END
-		END AS utc_offset
-	FROM (
-		SELECT DISTINCT utc_offset
-		FROM pg_timezone_names()
-		ORDER BY ALL
-	) z
-);
+CREATE TABLE offsets AS 
+	FROM (VALUES
+		('+14'),
+		('+13'),
+		('+12:45'),
+		('+12'),
+		('+11'),
+		('+10:30'),
+		('+10'),
+		('+09:30'),
+		('+09'),
+		('+08:45'),
+		('+08'),
+		('+07'),
+		('+06:30'),
+		('+06'),
+		('+05:45'),
+		('+05:30'),
+		('+05'),
+		('+04:30'),
+		('+04'),
+		('+03:30'),
+		('+03'),
+		('+02'),
+		('+01'),
+		('+00'),
+		('-01'),
+		('-02'),
+		('-03'),
+		('-03:30'),
+		('-04'),
+		('-05'),
+		('-06'),
+		('-07'),
+		('-08'),
+		('-09'),
+		('-09:30'),
+		('-10'),
+		('-11'),
+		('-12'),
+	) tbl(utc_offset)
+;
 
 foreach func strptime try_strptime
 

--- a/test/sql/timezone/test_icu_timezone.test
+++ b/test/sql/timezone/test_icu_timezone.test
@@ -164,646 +164,646 @@ select current_localtime();
 #
 # ICU time zone list
 #
-query III
-SELECT name, abbrev, utc_offset FROM pg_timezone_names() ORDER BY name;
+query II
+SELECT name, abbrev FROM pg_timezone_names() ORDER BY name;
 ----
-ACT	ACT	09:30:00
-AET	AET	10:00:00
-AGT	AGT	-03:00:00
-ART	ART	02:00:00
-AST	AST	-09:00:00
-Africa/Abidjan	Iceland	00:00:00
-Africa/Accra	Iceland	00:00:00
-Africa/Addis_Ababa	EAT	03:00:00
-Africa/Algiers	Africa/Algiers	01:00:00
-Africa/Asmara	EAT	03:00:00
-Africa/Asmera	EAT	03:00:00
-Africa/Bamako	Iceland	00:00:00
-Africa/Bangui	Africa/Bangui	01:00:00
-Africa/Banjul	Iceland	00:00:00
-Africa/Bissau	Africa/Bissau	00:00:00
-Africa/Blantyre	CAT	02:00:00
-Africa/Brazzaville	Africa/Brazzaville	01:00:00
-Africa/Bujumbura	CAT	02:00:00
-Africa/Cairo	ART	02:00:00
-Africa/Casablanca	Africa/Casablanca	00:00:00
-Africa/Ceuta	Africa/Ceuta	01:00:00
-Africa/Conakry	Iceland	00:00:00
-Africa/Dakar	Iceland	00:00:00
-Africa/Dar_es_Salaam	EAT	03:00:00
-Africa/Djibouti	EAT	03:00:00
-Africa/Douala	Africa/Douala	01:00:00
-Africa/El_Aaiun	Africa/El_Aaiun	00:00:00
-Africa/Freetown	Iceland	00:00:00
-Africa/Gaborone	CAT	02:00:00
-Africa/Harare	CAT	02:00:00
-Africa/Johannesburg	Africa/Johannesburg	02:00:00
-Africa/Juba	Africa/Juba	02:00:00
-Africa/Kampala	EAT	03:00:00
-Africa/Khartoum	Africa/Khartoum	02:00:00
-Africa/Kigali	CAT	02:00:00
-Africa/Kinshasa	Africa/Kinshasa	01:00:00
-Africa/Lagos	Africa/Lagos	01:00:00
-Africa/Libreville	Africa/Libreville	01:00:00
-Africa/Lome	Iceland	00:00:00
-Africa/Luanda	Africa/Luanda	01:00:00
-Africa/Lubumbashi	CAT	02:00:00
-Africa/Lusaka	CAT	02:00:00
-Africa/Malabo	Africa/Malabo	01:00:00
-Africa/Maputo	CAT	02:00:00
-Africa/Maseru	Africa/Maseru	02:00:00
-Africa/Mbabane	Africa/Mbabane	02:00:00
-Africa/Mogadishu	EAT	03:00:00
-Africa/Monrovia	Africa/Monrovia	00:00:00
-Africa/Nairobi	EAT	03:00:00
-Africa/Ndjamena	Africa/Ndjamena	01:00:00
-Africa/Niamey	Africa/Niamey	01:00:00
-Africa/Nouakchott	Iceland	00:00:00
-Africa/Ouagadougou	Iceland	00:00:00
-Africa/Porto-Novo	Africa/Porto-Novo	01:00:00
-Africa/Sao_Tome	Africa/Sao_Tome	00:00:00
-Africa/Timbuktu	Iceland	00:00:00
-Africa/Tripoli	Libya	02:00:00
-Africa/Tunis	Africa/Tunis	01:00:00
-Africa/Windhoek	Africa/Windhoek	02:00:00
-America/Adak	America/Adak	-10:00:00
-America/Anchorage	AST	-09:00:00
-America/Anguilla	PRT	-04:00:00
-America/Antigua	PRT	-04:00:00
-America/Araguaina	America/Araguaina	-03:00:00
-America/Argentina/Buenos_Aires	AGT	-03:00:00
-America/Argentina/Catamarca	America/Argentina/Catamarca	-03:00:00
-America/Argentina/ComodRivadavia	America/Argentina/ComodRivadavia	-03:00:00
-America/Argentina/Cordoba	America/Argentina/Cordoba	-03:00:00
-America/Argentina/Jujuy	America/Argentina/Jujuy	-03:00:00
-America/Argentina/La_Rioja	America/Argentina/La_Rioja	-03:00:00
-America/Argentina/Mendoza	America/Argentina/Mendoza	-03:00:00
-America/Argentina/Rio_Gallegos	America/Argentina/Rio_Gallegos	-03:00:00
-America/Argentina/Salta	America/Argentina/Salta	-03:00:00
-America/Argentina/San_Juan	America/Argentina/San_Juan	-03:00:00
-America/Argentina/San_Luis	America/Argentina/San_Luis	-03:00:00
-America/Argentina/Tucuman	America/Argentina/Tucuman	-03:00:00
-America/Argentina/Ushuaia	America/Argentina/Ushuaia	-03:00:00
-America/Aruba	PRT	-04:00:00
-America/Asuncion	America/Asuncion	-04:00:00
-America/Atikokan	America/Atikokan	-05:00:00
-America/Atka	America/Atka	-10:00:00
-America/Bahia	America/Bahia	-03:00:00
-America/Bahia_Banderas	America/Bahia_Banderas	-06:00:00
-America/Barbados	America/Barbados	-04:00:00
-America/Belem	America/Belem	-03:00:00
-America/Belize	America/Belize	-06:00:00
-America/Blanc-Sablon	PRT	-04:00:00
-America/Boa_Vista	America/Boa_Vista	-04:00:00
-America/Bogota	America/Bogota	-05:00:00
-America/Boise	America/Boise	-07:00:00
-America/Buenos_Aires	AGT	-03:00:00
-America/Cambridge_Bay	America/Cambridge_Bay	-07:00:00
-America/Campo_Grande	America/Campo_Grande	-04:00:00
-America/Cancun	America/Cancun	-05:00:00
-America/Caracas	America/Caracas	-04:00:00
-America/Catamarca	America/Catamarca	-03:00:00
-America/Cayenne	America/Cayenne	-03:00:00
-America/Cayman	America/Cayman	-05:00:00
-America/Chicago	CST	-06:00:00
-America/Chihuahua	America/Chihuahua	-06:00:00
-America/Ciudad_Juarez	America/Ciudad_Juarez	-07:00:00
-America/Coral_Harbour	America/Coral_Harbour	-05:00:00
-America/Cordoba	America/Cordoba	-03:00:00
-America/Costa_Rica	America/Costa_Rica	-06:00:00
-America/Creston	PNT	-07:00:00
-America/Cuiaba	America/Cuiaba	-04:00:00
-America/Curacao	PRT	-04:00:00
-America/Danmarkshavn	America/Danmarkshavn	00:00:00
-America/Dawson	America/Dawson	-07:00:00
-America/Dawson_Creek	America/Dawson_Creek	-07:00:00
-America/Denver	Navajo	-07:00:00
-America/Detroit	America/Detroit	-05:00:00
-America/Dominica	PRT	-04:00:00
-America/Edmonton	America/Edmonton	-07:00:00
-America/Eirunepe	America/Eirunepe	-05:00:00
-America/El_Salvador	America/El_Salvador	-06:00:00
-America/Ensenada	America/Ensenada	-08:00:00
-America/Fort_Nelson	America/Fort_Nelson	-07:00:00
-America/Fort_Wayne	IET	-05:00:00
-America/Fortaleza	America/Fortaleza	-03:00:00
-America/Glace_Bay	America/Glace_Bay	-04:00:00
-America/Godthab	America/Godthab	-02:00:00
-America/Goose_Bay	America/Goose_Bay	-04:00:00
-America/Grand_Turk	America/Grand_Turk	-05:00:00
-America/Grenada	PRT	-04:00:00
-America/Guadeloupe	PRT	-04:00:00
-America/Guatemala	America/Guatemala	-06:00:00
-America/Guayaquil	America/Guayaquil	-05:00:00
-America/Guyana	America/Guyana	-04:00:00
-America/Halifax	America/Halifax	-04:00:00
-America/Havana	Cuba	-05:00:00
-America/Hermosillo	America/Hermosillo	-07:00:00
-America/Indiana/Indianapolis	IET	-05:00:00
-America/Indiana/Knox	America/Indiana/Knox	-06:00:00
-America/Indiana/Marengo	America/Indiana/Marengo	-05:00:00
-America/Indiana/Petersburg	America/Indiana/Petersburg	-05:00:00
-America/Indiana/Tell_City	America/Indiana/Tell_City	-06:00:00
-America/Indiana/Vevay	America/Indiana/Vevay	-05:00:00
-America/Indiana/Vincennes	America/Indiana/Vincennes	-05:00:00
-America/Indiana/Winamac	America/Indiana/Winamac	-05:00:00
-America/Indianapolis	IET	-05:00:00
-America/Inuvik	America/Inuvik	-07:00:00
-America/Iqaluit	America/Iqaluit	-05:00:00
-America/Jamaica	Jamaica	-05:00:00
-America/Jujuy	America/Jujuy	-03:00:00
-America/Juneau	America/Juneau	-09:00:00
-America/Kentucky/Louisville	America/Kentucky/Louisville	-05:00:00
-America/Kentucky/Monticello	America/Kentucky/Monticello	-05:00:00
-America/Knox_IN	America/Knox_IN	-06:00:00
-America/Kralendijk	PRT	-04:00:00
-America/La_Paz	America/La_Paz	-04:00:00
-America/Lima	America/Lima	-05:00:00
-America/Los_Angeles	PST	-08:00:00
-America/Louisville	America/Louisville	-05:00:00
-America/Lower_Princes	PRT	-04:00:00
-America/Maceio	America/Maceio	-03:00:00
-America/Managua	America/Managua	-06:00:00
-America/Manaus	America/Manaus	-04:00:00
-America/Marigot	PRT	-04:00:00
-America/Martinique	America/Martinique	-04:00:00
-America/Matamoros	America/Matamoros	-06:00:00
-America/Mazatlan	America/Mazatlan	-07:00:00
-America/Mendoza	America/Mendoza	-03:00:00
-America/Menominee	America/Menominee	-06:00:00
-America/Merida	America/Merida	-06:00:00
-America/Metlakatla	America/Metlakatla	-09:00:00
-America/Mexico_City	America/Mexico_City	-06:00:00
-America/Miquelon	America/Miquelon	-03:00:00
-America/Moncton	America/Moncton	-04:00:00
-America/Monterrey	America/Monterrey	-06:00:00
-America/Montevideo	America/Montevideo	-03:00:00
-America/Montreal	America/Montreal	-05:00:00
-America/Montserrat	PRT	-04:00:00
-America/Nassau	America/Nassau	-05:00:00
-America/New_York	America/New_York	-05:00:00
-America/Nipigon	America/Nipigon	-05:00:00
-America/Nome	America/Nome	-09:00:00
-America/Noronha	America/Noronha	-02:00:00
-America/North_Dakota/Beulah	America/North_Dakota/Beulah	-06:00:00
-America/North_Dakota/Center	America/North_Dakota/Center	-06:00:00
-America/North_Dakota/New_Salem	America/North_Dakota/New_Salem	-06:00:00
-America/Nuuk	America/Nuuk	-02:00:00
-America/Ojinaga	America/Ojinaga	-06:00:00
-America/Panama	America/Panama	-05:00:00
-America/Pangnirtung	America/Pangnirtung	-05:00:00
-America/Paramaribo	America/Paramaribo	-03:00:00
-America/Phoenix	PNT	-07:00:00
-America/Port-au-Prince	America/Port-au-Prince	-05:00:00
-America/Port_of_Spain	PRT	-04:00:00
-America/Porto_Acre	America/Porto_Acre	-05:00:00
-America/Porto_Velho	America/Porto_Velho	-04:00:00
-America/Puerto_Rico	PRT	-04:00:00
-America/Punta_Arenas	America/Punta_Arenas	-03:00:00
-America/Rainy_River	America/Rainy_River	-06:00:00
-America/Rankin_Inlet	America/Rankin_Inlet	-06:00:00
-America/Recife	America/Recife	-03:00:00
-America/Regina	America/Regina	-06:00:00
-America/Resolute	America/Resolute	-06:00:00
-America/Rio_Branco	America/Rio_Branco	-05:00:00
-America/Rosario	America/Rosario	-03:00:00
-America/Santa_Isabel	America/Santa_Isabel	-08:00:00
-America/Santarem	America/Santarem	-03:00:00
-America/Santiago	America/Santiago	-04:00:00
-America/Santo_Domingo	America/Santo_Domingo	-04:00:00
-America/Sao_Paulo	BET	-03:00:00
-America/Scoresbysund	America/Scoresbysund	-01:00:00
-America/Shiprock	Navajo	-07:00:00
-America/Sitka	America/Sitka	-09:00:00
-America/St_Barthelemy	PRT	-04:00:00
-America/St_Johns	CNT	-03:30:00
-America/St_Kitts	PRT	-04:00:00
-America/St_Lucia	PRT	-04:00:00
-America/St_Thomas	PRT	-04:00:00
-America/St_Vincent	PRT	-04:00:00
-America/Swift_Current	America/Swift_Current	-06:00:00
-America/Tegucigalpa	America/Tegucigalpa	-06:00:00
-America/Thule	America/Thule	-04:00:00
-America/Thunder_Bay	America/Thunder_Bay	-05:00:00
-America/Tijuana	America/Tijuana	-08:00:00
-America/Toronto	America/Toronto	-05:00:00
-America/Tortola	PRT	-04:00:00
-America/Vancouver	America/Vancouver	-08:00:00
-America/Virgin	PRT	-04:00:00
-America/Whitehorse	America/Whitehorse	-07:00:00
-America/Winnipeg	America/Winnipeg	-06:00:00
-America/Yakutat	America/Yakutat	-09:00:00
-America/Yellowknife	America/Yellowknife	-07:00:00
-Antarctica/Casey	Antarctica/Casey	11:00:00
-Antarctica/Davis	Antarctica/Davis	07:00:00
-Antarctica/DumontDUrville	Antarctica/DumontDUrville	10:00:00
-Antarctica/Macquarie	Antarctica/Macquarie	10:00:00
-Antarctica/Mawson	Antarctica/Mawson	05:00:00
-Antarctica/McMurdo	NZ	12:00:00
-Antarctica/Palmer	Antarctica/Palmer	-03:00:00
-Antarctica/Rothera	Antarctica/Rothera	-03:00:00
-Antarctica/South_Pole	NZ	12:00:00
-Antarctica/Syowa	Antarctica/Syowa	03:00:00
-Antarctica/Troll	Antarctica/Troll	00:00:00
-Antarctica/Vostok	Antarctica/Vostok	06:00:00
-Arctic/Longyearbyen	Arctic/Longyearbyen	01:00:00
-Asia/Aden	Asia/Aden	03:00:00
-Asia/Almaty	Asia/Almaty	06:00:00
-Asia/Amman	Asia/Amman	03:00:00
-Asia/Anadyr	Asia/Anadyr	12:00:00
-Asia/Aqtau	Asia/Aqtau	05:00:00
-Asia/Aqtobe	Asia/Aqtobe	05:00:00
-Asia/Ashgabat	Asia/Ashgabat	05:00:00
-Asia/Ashkhabad	Asia/Ashkhabad	05:00:00
-Asia/Atyrau	Asia/Atyrau	05:00:00
-Asia/Baghdad	Asia/Baghdad	03:00:00
-Asia/Bahrain	Asia/Bahrain	03:00:00
-Asia/Baku	Asia/Baku	04:00:00
-Asia/Bangkok	Asia/Bangkok	07:00:00
-Asia/Barnaul	Asia/Barnaul	07:00:00
-Asia/Beirut	Asia/Beirut	02:00:00
-Asia/Bishkek	Asia/Bishkek	06:00:00
-Asia/Brunei	Asia/Brunei	08:00:00
-Asia/Calcutta	IST	05:30:00
-Asia/Chita	Asia/Chita	09:00:00
-Asia/Choibalsan	Asia/Choibalsan	08:00:00
-Asia/Chongqing	CTT	08:00:00
-Asia/Chungking	CTT	08:00:00
-Asia/Colombo	Asia/Colombo	05:30:00
-Asia/Dacca	BST	06:00:00
-Asia/Damascus	Asia/Damascus	03:00:00
-Asia/Dhaka	BST	06:00:00
-Asia/Dili	Asia/Dili	09:00:00
-Asia/Dubai	Asia/Dubai	04:00:00
-Asia/Dushanbe	Asia/Dushanbe	05:00:00
-Asia/Famagusta	Asia/Famagusta	02:00:00
-Asia/Gaza	Asia/Gaza	02:00:00
-Asia/Harbin	CTT	08:00:00
-Asia/Hebron	Asia/Hebron	02:00:00
-Asia/Ho_Chi_Minh	VST	07:00:00
-Asia/Hong_Kong	Hongkong	08:00:00
-Asia/Hovd	Asia/Hovd	07:00:00
-Asia/Irkutsk	Asia/Irkutsk	08:00:00
-Asia/Istanbul	Turkey	03:00:00
-Asia/Jakarta	Asia/Jakarta	07:00:00
-Asia/Jayapura	Asia/Jayapura	09:00:00
-Asia/Jerusalem	Israel	02:00:00
-Asia/Kabul	Asia/Kabul	04:30:00
-Asia/Kamchatka	Asia/Kamchatka	12:00:00
-Asia/Karachi	PLT	05:00:00
-Asia/Kashgar	Asia/Kashgar	06:00:00
-Asia/Kathmandu	Asia/Kathmandu	05:45:00
-Asia/Katmandu	Asia/Katmandu	05:45:00
-Asia/Khandyga	Asia/Khandyga	09:00:00
-Asia/Kolkata	IST	05:30:00
-Asia/Krasnoyarsk	Asia/Krasnoyarsk	07:00:00
-Asia/Kuala_Lumpur	Singapore	08:00:00
-Asia/Kuching	Asia/Kuching	08:00:00
-Asia/Kuwait	Asia/Kuwait	03:00:00
-Asia/Macao	Asia/Macao	08:00:00
-Asia/Macau	Asia/Macau	08:00:00
-Asia/Magadan	Asia/Magadan	11:00:00
-Asia/Makassar	Asia/Makassar	08:00:00
-Asia/Manila	Asia/Manila	08:00:00
-Asia/Muscat	Asia/Muscat	04:00:00
-Asia/Nicosia	Asia/Nicosia	02:00:00
-Asia/Novokuznetsk	Asia/Novokuznetsk	07:00:00
-Asia/Novosibirsk	Asia/Novosibirsk	07:00:00
-Asia/Omsk	Asia/Omsk	06:00:00
-Asia/Oral	Asia/Oral	05:00:00
-Asia/Phnom_Penh	Asia/Phnom_Penh	07:00:00
-Asia/Pontianak	Asia/Pontianak	07:00:00
-Asia/Pyongyang	Asia/Pyongyang	09:00:00
-Asia/Qatar	Asia/Qatar	03:00:00
-Asia/Qostanay	Asia/Qostanay	06:00:00
-Asia/Qyzylorda	Asia/Qyzylorda	05:00:00
-Asia/Rangoon	Asia/Rangoon	06:30:00
-Asia/Riyadh	Asia/Riyadh	03:00:00
-Asia/Saigon	VST	07:00:00
-Asia/Sakhalin	Asia/Sakhalin	11:00:00
-Asia/Samarkand	Asia/Samarkand	05:00:00
-Asia/Seoul	ROK	09:00:00
-Asia/Shanghai	CTT	08:00:00
-Asia/Singapore	Singapore	08:00:00
-Asia/Srednekolymsk	Asia/Srednekolymsk	11:00:00
-Asia/Taipei	ROC	08:00:00
-Asia/Tashkent	Asia/Tashkent	05:00:00
-Asia/Tbilisi	Asia/Tbilisi	04:00:00
-Asia/Tehran	Iran	03:30:00
-Asia/Tel_Aviv	Israel	02:00:00
-Asia/Thimbu	Asia/Thimbu	06:00:00
-Asia/Thimphu	Asia/Thimphu	06:00:00
-Asia/Tokyo	JST	09:00:00
-Asia/Tomsk	Asia/Tomsk	07:00:00
-Asia/Ujung_Pandang	Asia/Ujung_Pandang	08:00:00
-Asia/Ulaanbaatar	Asia/Ulaanbaatar	08:00:00
-Asia/Ulan_Bator	Asia/Ulan_Bator	08:00:00
-Asia/Urumqi	Asia/Urumqi	06:00:00
-Asia/Ust-Nera	Asia/Ust-Nera	10:00:00
-Asia/Vientiane	Asia/Vientiane	07:00:00
-Asia/Vladivostok	Asia/Vladivostok	10:00:00
-Asia/Yakutsk	Asia/Yakutsk	09:00:00
-Asia/Yangon	Asia/Yangon	06:30:00
-Asia/Yekaterinburg	Asia/Yekaterinburg	05:00:00
-Asia/Yerevan	NET	04:00:00
-Atlantic/Azores	Atlantic/Azores	-01:00:00
-Atlantic/Bermuda	Atlantic/Bermuda	-04:00:00
-Atlantic/Canary	Atlantic/Canary	00:00:00
-Atlantic/Cape_Verde	Atlantic/Cape_Verde	-01:00:00
-Atlantic/Faeroe	Atlantic/Faeroe	00:00:00
-Atlantic/Faroe	Atlantic/Faroe	00:00:00
-Atlantic/Jan_Mayen	Atlantic/Jan_Mayen	01:00:00
-Atlantic/Madeira	Atlantic/Madeira	00:00:00
-Atlantic/Reykjavik	Iceland	00:00:00
-Atlantic/South_Georgia	Atlantic/South_Georgia	-02:00:00
-Atlantic/St_Helena	Iceland	00:00:00
-Atlantic/Stanley	Atlantic/Stanley	-03:00:00
-Australia/ACT	AET	10:00:00
-Australia/Adelaide	Australia/Adelaide	09:30:00
-Australia/Brisbane	Australia/Brisbane	10:00:00
-Australia/Broken_Hill	Australia/Broken_Hill	09:30:00
-Australia/Canberra	AET	10:00:00
-Australia/Currie	Australia/Currie	10:00:00
-Australia/Darwin	ACT	09:30:00
-Australia/Eucla	Australia/Eucla	08:45:00
-Australia/Hobart	Australia/Hobart	10:00:00
-Australia/LHI	Australia/LHI	10:30:00
-Australia/Lindeman	Australia/Lindeman	10:00:00
-Australia/Lord_Howe	Australia/Lord_Howe	10:30:00
-Australia/Melbourne	Australia/Melbourne	10:00:00
-Australia/NSW	AET	10:00:00
-Australia/North	ACT	09:30:00
-Australia/Perth	Australia/Perth	08:00:00
-Australia/Queensland	Australia/Queensland	10:00:00
-Australia/South	Australia/South	09:30:00
-Australia/Sydney	AET	10:00:00
-Australia/Tasmania	Australia/Tasmania	10:00:00
-Australia/Victoria	Australia/Victoria	10:00:00
-Australia/West	Australia/West	08:00:00
-Australia/Yancowinna	Australia/Yancowinna	09:30:00
-BET	BET	-03:00:00
-BST	BST	06:00:00
-Brazil/Acre	Brazil/Acre	-05:00:00
-Brazil/DeNoronha	Brazil/DeNoronha	-02:00:00
-Brazil/East	BET	-03:00:00
-Brazil/West	Brazil/West	-04:00:00
-CAT	CAT	02:00:00
-CET	CET	01:00:00
-CNT	CNT	-03:30:00
-CST	CST	-06:00:00
-CST6CDT	CST6CDT	-06:00:00
-CTT	CTT	08:00:00
-Canada/Atlantic	Canada/Atlantic	-04:00:00
-Canada/Central	Canada/Central	-06:00:00
-Canada/East-Saskatchewan	Canada/East-Saskatchewan	-06:00:00
-Canada/Eastern	Canada/Eastern	-05:00:00
-Canada/Mountain	Canada/Mountain	-07:00:00
-Canada/Newfoundland	CNT	-03:30:00
-Canada/Pacific	Canada/Pacific	-08:00:00
-Canada/Saskatchewan	Canada/Saskatchewan	-06:00:00
-Canada/Yukon	Canada/Yukon	-07:00:00
-Chile/Continental	Chile/Continental	-04:00:00
-Chile/EasterIsland	Chile/EasterIsland	-06:00:00
-Cuba	Cuba	-05:00:00
-EAT	EAT	03:00:00
-ECT	ECT	01:00:00
-EET	EET	02:00:00
-EST	EST	-05:00:00
-EST5EDT	EST5EDT	-05:00:00
-Egypt	ART	02:00:00
-Eire	Eire	00:00:00
-Etc/GMT	GMT	00:00:00
-Etc/GMT+0	GMT	00:00:00
-Etc/GMT+1	Etc/GMT+1	-01:00:00
-Etc/GMT+10	Etc/GMT+10	-10:00:00
-Etc/GMT+11	Etc/GMT+11	-11:00:00
-Etc/GMT+12	Etc/GMT+12	-12:00:00
-Etc/GMT+2	Etc/GMT+2	-02:00:00
-Etc/GMT+3	Etc/GMT+3	-03:00:00
-Etc/GMT+4	Etc/GMT+4	-04:00:00
-Etc/GMT+5	Etc/GMT+5	-05:00:00
-Etc/GMT+6	Etc/GMT+6	-06:00:00
-Etc/GMT+7	Etc/GMT+7	-07:00:00
-Etc/GMT+8	Etc/GMT+8	-08:00:00
-Etc/GMT+9	Etc/GMT+9	-09:00:00
-Etc/GMT-0	GMT	00:00:00
-Etc/GMT-1	Etc/GMT-1	01:00:00
-Etc/GMT-10	Etc/GMT-10	10:00:00
-Etc/GMT-11	Etc/GMT-11	11:00:00
-Etc/GMT-12	Etc/GMT-12	12:00:00
-Etc/GMT-13	Etc/GMT-13	13:00:00
-Etc/GMT-14	Etc/GMT-14	14:00:00
-Etc/GMT-2	Etc/GMT-2	02:00:00
-Etc/GMT-3	Etc/GMT-3	03:00:00
-Etc/GMT-4	Etc/GMT-4	04:00:00
-Etc/GMT-5	Etc/GMT-5	05:00:00
-Etc/GMT-6	Etc/GMT-6	06:00:00
-Etc/GMT-7	Etc/GMT-7	07:00:00
-Etc/GMT-8	Etc/GMT-8	08:00:00
-Etc/GMT-9	Etc/GMT-9	09:00:00
-Etc/GMT0	GMT	00:00:00
-Etc/Greenwich	GMT	00:00:00
-Etc/UCT	UCT	00:00:00
-Etc/UTC	UCT	00:00:00
-Etc/Universal	UCT	00:00:00
-Etc/Zulu	UCT	00:00:00
-Europe/Amsterdam	Europe/Amsterdam	01:00:00
-Europe/Andorra	Europe/Andorra	01:00:00
-Europe/Astrakhan	Europe/Astrakhan	04:00:00
-Europe/Athens	Europe/Athens	02:00:00
-Europe/Belfast	GB	00:00:00
-Europe/Belgrade	Europe/Belgrade	01:00:00
-Europe/Berlin	Europe/Berlin	01:00:00
-Europe/Bratislava	Europe/Bratislava	01:00:00
-Europe/Brussels	Europe/Brussels	01:00:00
-Europe/Bucharest	Europe/Bucharest	02:00:00
-Europe/Budapest	Europe/Budapest	01:00:00
-Europe/Busingen	Europe/Busingen	01:00:00
-Europe/Chisinau	Europe/Chisinau	02:00:00
-Europe/Copenhagen	Europe/Copenhagen	01:00:00
-Europe/Dublin	Eire	00:00:00
-Europe/Gibraltar	Europe/Gibraltar	01:00:00
-Europe/Guernsey	GB	00:00:00
-Europe/Helsinki	Europe/Helsinki	02:00:00
-Europe/Isle_of_Man	GB	00:00:00
-Europe/Istanbul	Turkey	03:00:00
-Europe/Jersey	GB	00:00:00
-Europe/Kaliningrad	Europe/Kaliningrad	02:00:00
-Europe/Kiev	Europe/Kiev	02:00:00
-Europe/Kirov	Europe/Kirov	03:00:00
-Europe/Kyiv	Europe/Kyiv	02:00:00
-Europe/Lisbon	Portugal	00:00:00
-Europe/Ljubljana	Europe/Ljubljana	01:00:00
-Europe/London	GB	00:00:00
-Europe/Luxembourg	Europe/Luxembourg	01:00:00
-Europe/Madrid	Europe/Madrid	01:00:00
-Europe/Malta	Europe/Malta	01:00:00
-Europe/Mariehamn	Europe/Mariehamn	02:00:00
-Europe/Minsk	Europe/Minsk	03:00:00
-Europe/Monaco	ECT	01:00:00
-Europe/Moscow	W-SU	03:00:00
-Europe/Nicosia	Europe/Nicosia	02:00:00
-Europe/Oslo	Europe/Oslo	01:00:00
-Europe/Paris	ECT	01:00:00
-Europe/Podgorica	Europe/Podgorica	01:00:00
-Europe/Prague	Europe/Prague	01:00:00
-Europe/Riga	Europe/Riga	02:00:00
-Europe/Rome	Europe/Rome	01:00:00
-Europe/Samara	Europe/Samara	04:00:00
-Europe/San_Marino	Europe/San_Marino	01:00:00
-Europe/Sarajevo	Europe/Sarajevo	01:00:00
-Europe/Saratov	Europe/Saratov	04:00:00
-Europe/Simferopol	Europe/Simferopol	03:00:00
-Europe/Skopje	Europe/Skopje	01:00:00
-Europe/Sofia	Europe/Sofia	02:00:00
-Europe/Stockholm	Europe/Stockholm	01:00:00
-Europe/Tallinn	Europe/Tallinn	02:00:00
-Europe/Tirane	Europe/Tirane	01:00:00
-Europe/Tiraspol	Europe/Tiraspol	02:00:00
-Europe/Ulyanovsk	Europe/Ulyanovsk	04:00:00
-Europe/Uzhgorod	Europe/Uzhgorod	02:00:00
-Europe/Vaduz	Europe/Vaduz	01:00:00
-Europe/Vatican	Europe/Vatican	01:00:00
-Europe/Vienna	Europe/Vienna	01:00:00
-Europe/Vilnius	Europe/Vilnius	02:00:00
-Europe/Volgograd	Europe/Volgograd	03:00:00
-Europe/Warsaw	Poland	01:00:00
-Europe/Zagreb	Europe/Zagreb	01:00:00
-Europe/Zaporozhye	Europe/Zaporozhye	02:00:00
-Europe/Zurich	Europe/Zurich	01:00:00
-Factory	Factory	00:00:00
-GB	GB	00:00:00
-GB-Eire	GB	00:00:00
-GMT	GMT	00:00:00
-GMT+0	GMT	00:00:00
-GMT-0	GMT	00:00:00
-GMT0	GMT	00:00:00
-Greenwich	GMT	00:00:00
-HST	HST	-10:00:00
-Hongkong	Hongkong	08:00:00
-IET	IET	-05:00:00
-IST	IST	05:30:00
-Iceland	Iceland	00:00:00
-Indian/Antananarivo	EAT	03:00:00
-Indian/Chagos	Indian/Chagos	06:00:00
-Indian/Christmas	Indian/Christmas	07:00:00
-Indian/Cocos	Indian/Cocos	06:30:00
-Indian/Comoro	EAT	03:00:00
-Indian/Kerguelen	Indian/Kerguelen	05:00:00
-Indian/Mahe	Indian/Mahe	04:00:00
-Indian/Maldives	Indian/Maldives	05:00:00
-Indian/Mauritius	Indian/Mauritius	04:00:00
-Indian/Mayotte	EAT	03:00:00
-Indian/Reunion	Indian/Reunion	04:00:00
-Iran	Iran	03:30:00
-Israel	Israel	02:00:00
-JST	JST	09:00:00
-Jamaica	Jamaica	-05:00:00
-Japan	JST	09:00:00
-Kwajalein	Kwajalein	12:00:00
-Libya	Libya	02:00:00
-MET	MET	01:00:00
-MIT	MIT	13:00:00
-MST	MST	-07:00:00
-MST7MDT	MST7MDT	-07:00:00
-Mexico/BajaNorte	Mexico/BajaNorte	-08:00:00
-Mexico/BajaSur	Mexico/BajaSur	-07:00:00
-Mexico/General	Mexico/General	-06:00:00
-NET	NET	04:00:00
-NST	NZ	12:00:00
-NZ	NZ	12:00:00
-NZ-CHAT	NZ-CHAT	12:45:00
-Navajo	Navajo	-07:00:00
-PLT	PLT	05:00:00
-PNT	PNT	-07:00:00
-PRC	CTT	08:00:00
-PRT	PRT	-04:00:00
-PST	PST	-08:00:00
-PST8PDT	PST8PDT	-08:00:00
-Pacific/Apia	MIT	13:00:00
-Pacific/Auckland	NZ	12:00:00
-Pacific/Bougainville	Pacific/Bougainville	11:00:00
-Pacific/Chatham	NZ-CHAT	12:45:00
-Pacific/Chuuk	Pacific/Chuuk	10:00:00
-Pacific/Easter	Pacific/Easter	-06:00:00
-Pacific/Efate	Pacific/Efate	11:00:00
-Pacific/Enderbury	Pacific/Enderbury	13:00:00
-Pacific/Fakaofo	Pacific/Fakaofo	13:00:00
-Pacific/Fiji	Pacific/Fiji	12:00:00
-Pacific/Funafuti	Pacific/Funafuti	12:00:00
-Pacific/Galapagos	Pacific/Galapagos	-06:00:00
-Pacific/Gambier	Pacific/Gambier	-09:00:00
-Pacific/Guadalcanal	SST	11:00:00
-Pacific/Guam	Pacific/Guam	10:00:00
-Pacific/Honolulu	Pacific/Honolulu	-10:00:00
-Pacific/Johnston	Pacific/Johnston	-10:00:00
-Pacific/Kanton	Pacific/Kanton	13:00:00
-Pacific/Kiritimati	Pacific/Kiritimati	14:00:00
-Pacific/Kosrae	Pacific/Kosrae	11:00:00
-Pacific/Kwajalein	Kwajalein	12:00:00
-Pacific/Majuro	Pacific/Majuro	12:00:00
-Pacific/Marquesas	Pacific/Marquesas	-09:30:00
-Pacific/Midway	Pacific/Midway	-11:00:00
-Pacific/Nauru	Pacific/Nauru	12:00:00
-Pacific/Niue	Pacific/Niue	-11:00:00
-Pacific/Norfolk	Pacific/Norfolk	11:00:00
-Pacific/Noumea	Pacific/Noumea	11:00:00
-Pacific/Pago_Pago	Pacific/Pago_Pago	-11:00:00
-Pacific/Palau	Pacific/Palau	09:00:00
-Pacific/Pitcairn	Pacific/Pitcairn	-08:00:00
-Pacific/Pohnpei	SST	11:00:00
-Pacific/Ponape	SST	11:00:00
-Pacific/Port_Moresby	Pacific/Port_Moresby	10:00:00
-Pacific/Rarotonga	Pacific/Rarotonga	-10:00:00
-Pacific/Saipan	Pacific/Saipan	10:00:00
-Pacific/Samoa	Pacific/Samoa	-11:00:00
-Pacific/Tahiti	Pacific/Tahiti	-10:00:00
-Pacific/Tarawa	Pacific/Tarawa	12:00:00
-Pacific/Tongatapu	Pacific/Tongatapu	13:00:00
-Pacific/Truk	Pacific/Truk	10:00:00
-Pacific/Wake	Pacific/Wake	12:00:00
-Pacific/Wallis	Pacific/Wallis	12:00:00
-Pacific/Yap	Pacific/Yap	10:00:00
-Poland	Poland	01:00:00
-Portugal	Portugal	00:00:00
-ROC	ROC	08:00:00
-ROK	ROK	09:00:00
-SST	SST	11:00:00
-Singapore	Singapore	08:00:00
-SystemV/AST4	SystemV/AST4	-04:00:00
-SystemV/AST4ADT	SystemV/AST4ADT	-04:00:00
-SystemV/CST6	SystemV/CST6	-06:00:00
-SystemV/CST6CDT	SystemV/CST6CDT	-06:00:00
-SystemV/EST5	SystemV/EST5	-05:00:00
-SystemV/EST5EDT	SystemV/EST5EDT	-05:00:00
-SystemV/HST10	SystemV/HST10	-10:00:00
-SystemV/MST7	SystemV/MST7	-07:00:00
-SystemV/MST7MDT	SystemV/MST7MDT	-07:00:00
-SystemV/PST8	SystemV/PST8	-08:00:00
-SystemV/PST8PDT	SystemV/PST8PDT	-08:00:00
-SystemV/YST9	SystemV/YST9	-09:00:00
-SystemV/YST9YDT	SystemV/YST9YDT	-09:00:00
-Turkey	Turkey	03:00:00
-UCT	UCT	00:00:00
-US/Alaska	AST	-09:00:00
-US/Aleutian	US/Aleutian	-10:00:00
-US/Arizona	PNT	-07:00:00
-US/Central	CST	-06:00:00
-US/East-Indiana	IET	-05:00:00
-US/Eastern	US/Eastern	-05:00:00
-US/Hawaii	US/Hawaii	-10:00:00
-US/Indiana-Starke	US/Indiana-Starke	-06:00:00
-US/Michigan	US/Michigan	-05:00:00
-US/Mountain	Navajo	-07:00:00
-US/Pacific	PST	-08:00:00
-US/Pacific-New	PST	-08:00:00
-US/Samoa	US/Samoa	-11:00:00
-UTC	UCT	00:00:00
-Universal	UCT	00:00:00
-VST	VST	07:00:00
-W-SU	W-SU	03:00:00
-WET	WET	00:00:00
-Zulu	UCT	00:00:00
+ACT	ACT
+AET	AET
+AGT	AGT
+ART	ART
+AST	AST
+Africa/Abidjan	Iceland
+Africa/Accra	Iceland
+Africa/Addis_Ababa	EAT
+Africa/Algiers	Africa/Algiers
+Africa/Asmara	EAT
+Africa/Asmera	EAT
+Africa/Bamako	Iceland
+Africa/Bangui	Africa/Bangui
+Africa/Banjul	Iceland
+Africa/Bissau	Africa/Bissau
+Africa/Blantyre	CAT
+Africa/Brazzaville	Africa/Brazzaville
+Africa/Bujumbura	CAT
+Africa/Cairo	ART
+Africa/Casablanca	Africa/Casablanca
+Africa/Ceuta	Africa/Ceuta
+Africa/Conakry	Iceland
+Africa/Dakar	Iceland
+Africa/Dar_es_Salaam	EAT
+Africa/Djibouti	EAT
+Africa/Douala	Africa/Douala
+Africa/El_Aaiun	Africa/El_Aaiun
+Africa/Freetown	Iceland
+Africa/Gaborone	CAT
+Africa/Harare	CAT
+Africa/Johannesburg	Africa/Johannesburg
+Africa/Juba	Africa/Juba
+Africa/Kampala	EAT
+Africa/Khartoum	Africa/Khartoum
+Africa/Kigali	CAT
+Africa/Kinshasa	Africa/Kinshasa
+Africa/Lagos	Africa/Lagos
+Africa/Libreville	Africa/Libreville
+Africa/Lome	Iceland
+Africa/Luanda	Africa/Luanda
+Africa/Lubumbashi	CAT
+Africa/Lusaka	CAT
+Africa/Malabo	Africa/Malabo
+Africa/Maputo	CAT
+Africa/Maseru	Africa/Maseru
+Africa/Mbabane	Africa/Mbabane
+Africa/Mogadishu	EAT
+Africa/Monrovia	Africa/Monrovia
+Africa/Nairobi	EAT
+Africa/Ndjamena	Africa/Ndjamena
+Africa/Niamey	Africa/Niamey
+Africa/Nouakchott	Iceland
+Africa/Ouagadougou	Iceland
+Africa/Porto-Novo	Africa/Porto-Novo
+Africa/Sao_Tome	Africa/Sao_Tome
+Africa/Timbuktu	Iceland
+Africa/Tripoli	Libya
+Africa/Tunis	Africa/Tunis
+Africa/Windhoek	Africa/Windhoek
+America/Adak	America/Adak
+America/Anchorage	AST
+America/Anguilla	PRT
+America/Antigua	PRT
+America/Araguaina	America/Araguaina
+America/Argentina/Buenos_Aires	AGT
+America/Argentina/Catamarca	America/Argentina/Catamarca
+America/Argentina/ComodRivadavia	America/Argentina/ComodRivadavia
+America/Argentina/Cordoba	America/Argentina/Cordoba
+America/Argentina/Jujuy	America/Argentina/Jujuy
+America/Argentina/La_Rioja	America/Argentina/La_Rioja
+America/Argentina/Mendoza	America/Argentina/Mendoza
+America/Argentina/Rio_Gallegos	America/Argentina/Rio_Gallegos
+America/Argentina/Salta	America/Argentina/Salta
+America/Argentina/San_Juan	America/Argentina/San_Juan
+America/Argentina/San_Luis	America/Argentina/San_Luis
+America/Argentina/Tucuman	America/Argentina/Tucuman
+America/Argentina/Ushuaia	America/Argentina/Ushuaia
+America/Aruba	PRT
+America/Asuncion	America/Asuncion
+America/Atikokan	America/Atikokan
+America/Atka	America/Atka
+America/Bahia	America/Bahia
+America/Bahia_Banderas	America/Bahia_Banderas
+America/Barbados	America/Barbados
+America/Belem	America/Belem
+America/Belize	America/Belize
+America/Blanc-Sablon	PRT
+America/Boa_Vista	America/Boa_Vista
+America/Bogota	America/Bogota
+America/Boise	America/Boise
+America/Buenos_Aires	AGT
+America/Cambridge_Bay	America/Cambridge_Bay
+America/Campo_Grande	America/Campo_Grande
+America/Cancun	America/Cancun
+America/Caracas	America/Caracas
+America/Catamarca	America/Catamarca
+America/Cayenne	America/Cayenne
+America/Cayman	America/Cayman
+America/Chicago	CST
+America/Chihuahua	America/Chihuahua
+America/Ciudad_Juarez	America/Ciudad_Juarez
+America/Coral_Harbour	America/Coral_Harbour
+America/Cordoba	America/Cordoba
+America/Costa_Rica	America/Costa_Rica
+America/Creston	PNT
+America/Cuiaba	America/Cuiaba
+America/Curacao	PRT
+America/Danmarkshavn	America/Danmarkshavn
+America/Dawson	America/Dawson
+America/Dawson_Creek	America/Dawson_Creek
+America/Denver	Navajo
+America/Detroit	America/Detroit
+America/Dominica	PRT
+America/Edmonton	America/Edmonton
+America/Eirunepe	America/Eirunepe
+America/El_Salvador	America/El_Salvador
+America/Ensenada	America/Ensenada
+America/Fort_Nelson	America/Fort_Nelson
+America/Fort_Wayne	IET
+America/Fortaleza	America/Fortaleza
+America/Glace_Bay	America/Glace_Bay
+America/Godthab	America/Godthab
+America/Goose_Bay	America/Goose_Bay
+America/Grand_Turk	America/Grand_Turk
+America/Grenada	PRT
+America/Guadeloupe	PRT
+America/Guatemala	America/Guatemala
+America/Guayaquil	America/Guayaquil
+America/Guyana	America/Guyana
+America/Halifax	America/Halifax
+America/Havana	Cuba
+America/Hermosillo	America/Hermosillo
+America/Indiana/Indianapolis	IET
+America/Indiana/Knox	America/Indiana/Knox
+America/Indiana/Marengo	America/Indiana/Marengo
+America/Indiana/Petersburg	America/Indiana/Petersburg
+America/Indiana/Tell_City	America/Indiana/Tell_City
+America/Indiana/Vevay	America/Indiana/Vevay
+America/Indiana/Vincennes	America/Indiana/Vincennes
+America/Indiana/Winamac	America/Indiana/Winamac
+America/Indianapolis	IET
+America/Inuvik	America/Inuvik
+America/Iqaluit	America/Iqaluit
+America/Jamaica	Jamaica
+America/Jujuy	America/Jujuy
+America/Juneau	America/Juneau
+America/Kentucky/Louisville	America/Kentucky/Louisville
+America/Kentucky/Monticello	America/Kentucky/Monticello
+America/Knox_IN	America/Knox_IN
+America/Kralendijk	PRT
+America/La_Paz	America/La_Paz
+America/Lima	America/Lima
+America/Los_Angeles	PST
+America/Louisville	America/Louisville
+America/Lower_Princes	PRT
+America/Maceio	America/Maceio
+America/Managua	America/Managua
+America/Manaus	America/Manaus
+America/Marigot	PRT
+America/Martinique	America/Martinique
+America/Matamoros	America/Matamoros
+America/Mazatlan	America/Mazatlan
+America/Mendoza	America/Mendoza
+America/Menominee	America/Menominee
+America/Merida	America/Merida
+America/Metlakatla	America/Metlakatla
+America/Mexico_City	America/Mexico_City
+America/Miquelon	America/Miquelon
+America/Moncton	America/Moncton
+America/Monterrey	America/Monterrey
+America/Montevideo	America/Montevideo
+America/Montreal	America/Montreal
+America/Montserrat	PRT
+America/Nassau	America/Nassau
+America/New_York	America/New_York
+America/Nipigon	America/Nipigon
+America/Nome	America/Nome
+America/Noronha	America/Noronha
+America/North_Dakota/Beulah	America/North_Dakota/Beulah
+America/North_Dakota/Center	America/North_Dakota/Center
+America/North_Dakota/New_Salem	America/North_Dakota/New_Salem
+America/Nuuk	America/Nuuk
+America/Ojinaga	America/Ojinaga
+America/Panama	America/Panama
+America/Pangnirtung	America/Pangnirtung
+America/Paramaribo	America/Paramaribo
+America/Phoenix	PNT
+America/Port-au-Prince	America/Port-au-Prince
+America/Port_of_Spain	PRT
+America/Porto_Acre	America/Porto_Acre
+America/Porto_Velho	America/Porto_Velho
+America/Puerto_Rico	PRT
+America/Punta_Arenas	America/Punta_Arenas
+America/Rainy_River	America/Rainy_River
+America/Rankin_Inlet	America/Rankin_Inlet
+America/Recife	America/Recife
+America/Regina	America/Regina
+America/Resolute	America/Resolute
+America/Rio_Branco	America/Rio_Branco
+America/Rosario	America/Rosario
+America/Santa_Isabel	America/Santa_Isabel
+America/Santarem	America/Santarem
+America/Santiago	America/Santiago
+America/Santo_Domingo	America/Santo_Domingo
+America/Sao_Paulo	BET
+America/Scoresbysund	America/Scoresbysund
+America/Shiprock	Navajo
+America/Sitka	America/Sitka
+America/St_Barthelemy	PRT
+America/St_Johns	CNT
+America/St_Kitts	PRT
+America/St_Lucia	PRT
+America/St_Thomas	PRT
+America/St_Vincent	PRT
+America/Swift_Current	America/Swift_Current
+America/Tegucigalpa	America/Tegucigalpa
+America/Thule	America/Thule
+America/Thunder_Bay	America/Thunder_Bay
+America/Tijuana	America/Tijuana
+America/Toronto	America/Toronto
+America/Tortola	PRT
+America/Vancouver	America/Vancouver
+America/Virgin	PRT
+America/Whitehorse	America/Whitehorse
+America/Winnipeg	America/Winnipeg
+America/Yakutat	America/Yakutat
+America/Yellowknife	America/Yellowknife
+Antarctica/Casey	Antarctica/Casey
+Antarctica/Davis	Antarctica/Davis
+Antarctica/DumontDUrville	Antarctica/DumontDUrville
+Antarctica/Macquarie	Antarctica/Macquarie
+Antarctica/Mawson	Antarctica/Mawson
+Antarctica/McMurdo	NZ
+Antarctica/Palmer	Antarctica/Palmer
+Antarctica/Rothera	Antarctica/Rothera
+Antarctica/South_Pole	NZ
+Antarctica/Syowa	Antarctica/Syowa
+Antarctica/Troll	Antarctica/Troll
+Antarctica/Vostok	Antarctica/Vostok
+Arctic/Longyearbyen	Arctic/Longyearbyen
+Asia/Aden	Asia/Aden
+Asia/Almaty	Asia/Almaty
+Asia/Amman	Asia/Amman
+Asia/Anadyr	Asia/Anadyr
+Asia/Aqtau	Asia/Aqtau
+Asia/Aqtobe	Asia/Aqtobe
+Asia/Ashgabat	Asia/Ashgabat
+Asia/Ashkhabad	Asia/Ashkhabad
+Asia/Atyrau	Asia/Atyrau
+Asia/Baghdad	Asia/Baghdad
+Asia/Bahrain	Asia/Bahrain
+Asia/Baku	Asia/Baku
+Asia/Bangkok	Asia/Bangkok
+Asia/Barnaul	Asia/Barnaul
+Asia/Beirut	Asia/Beirut
+Asia/Bishkek	Asia/Bishkek
+Asia/Brunei	Asia/Brunei
+Asia/Calcutta	IST
+Asia/Chita	Asia/Chita
+Asia/Choibalsan	Asia/Choibalsan
+Asia/Chongqing	CTT
+Asia/Chungking	CTT
+Asia/Colombo	Asia/Colombo
+Asia/Dacca	BST
+Asia/Damascus	Asia/Damascus
+Asia/Dhaka	BST
+Asia/Dili	Asia/Dili
+Asia/Dubai	Asia/Dubai
+Asia/Dushanbe	Asia/Dushanbe
+Asia/Famagusta	Asia/Famagusta
+Asia/Gaza	Asia/Gaza
+Asia/Harbin	CTT
+Asia/Hebron	Asia/Hebron
+Asia/Ho_Chi_Minh	VST
+Asia/Hong_Kong	Hongkong
+Asia/Hovd	Asia/Hovd
+Asia/Irkutsk	Asia/Irkutsk
+Asia/Istanbul	Turkey
+Asia/Jakarta	Asia/Jakarta
+Asia/Jayapura	Asia/Jayapura
+Asia/Jerusalem	Israel
+Asia/Kabul	Asia/Kabul
+Asia/Kamchatka	Asia/Kamchatka
+Asia/Karachi	PLT
+Asia/Kashgar	Asia/Kashgar
+Asia/Kathmandu	Asia/Kathmandu
+Asia/Katmandu	Asia/Katmandu
+Asia/Khandyga	Asia/Khandyga
+Asia/Kolkata	IST
+Asia/Krasnoyarsk	Asia/Krasnoyarsk
+Asia/Kuala_Lumpur	Singapore
+Asia/Kuching	Asia/Kuching
+Asia/Kuwait	Asia/Kuwait
+Asia/Macao	Asia/Macao
+Asia/Macau	Asia/Macau
+Asia/Magadan	Asia/Magadan
+Asia/Makassar	Asia/Makassar
+Asia/Manila	Asia/Manila
+Asia/Muscat	Asia/Muscat
+Asia/Nicosia	Asia/Nicosia
+Asia/Novokuznetsk	Asia/Novokuznetsk
+Asia/Novosibirsk	Asia/Novosibirsk
+Asia/Omsk	Asia/Omsk
+Asia/Oral	Asia/Oral
+Asia/Phnom_Penh	Asia/Phnom_Penh
+Asia/Pontianak	Asia/Pontianak
+Asia/Pyongyang	Asia/Pyongyang
+Asia/Qatar	Asia/Qatar
+Asia/Qostanay	Asia/Qostanay
+Asia/Qyzylorda	Asia/Qyzylorda
+Asia/Rangoon	Asia/Rangoon
+Asia/Riyadh	Asia/Riyadh
+Asia/Saigon	VST
+Asia/Sakhalin	Asia/Sakhalin
+Asia/Samarkand	Asia/Samarkand
+Asia/Seoul	ROK
+Asia/Shanghai	CTT
+Asia/Singapore	Singapore
+Asia/Srednekolymsk	Asia/Srednekolymsk
+Asia/Taipei	ROC
+Asia/Tashkent	Asia/Tashkent
+Asia/Tbilisi	Asia/Tbilisi
+Asia/Tehran	Iran
+Asia/Tel_Aviv	Israel
+Asia/Thimbu	Asia/Thimbu
+Asia/Thimphu	Asia/Thimphu
+Asia/Tokyo	JST
+Asia/Tomsk	Asia/Tomsk
+Asia/Ujung_Pandang	Asia/Ujung_Pandang
+Asia/Ulaanbaatar	Asia/Ulaanbaatar
+Asia/Ulan_Bator	Asia/Ulan_Bator
+Asia/Urumqi	Asia/Urumqi
+Asia/Ust-Nera	Asia/Ust-Nera
+Asia/Vientiane	Asia/Vientiane
+Asia/Vladivostok	Asia/Vladivostok
+Asia/Yakutsk	Asia/Yakutsk
+Asia/Yangon	Asia/Yangon
+Asia/Yekaterinburg	Asia/Yekaterinburg
+Asia/Yerevan	NET
+Atlantic/Azores	Atlantic/Azores
+Atlantic/Bermuda	Atlantic/Bermuda
+Atlantic/Canary	Atlantic/Canary
+Atlantic/Cape_Verde	Atlantic/Cape_Verde
+Atlantic/Faeroe	Atlantic/Faeroe
+Atlantic/Faroe	Atlantic/Faroe
+Atlantic/Jan_Mayen	Atlantic/Jan_Mayen
+Atlantic/Madeira	Atlantic/Madeira
+Atlantic/Reykjavik	Iceland
+Atlantic/South_Georgia	Atlantic/South_Georgia
+Atlantic/St_Helena	Iceland
+Atlantic/Stanley	Atlantic/Stanley
+Australia/ACT	AET
+Australia/Adelaide	Australia/Adelaide
+Australia/Brisbane	Australia/Brisbane
+Australia/Broken_Hill	Australia/Broken_Hill
+Australia/Canberra	AET
+Australia/Currie	Australia/Currie
+Australia/Darwin	ACT
+Australia/Eucla	Australia/Eucla
+Australia/Hobart	Australia/Hobart
+Australia/LHI	Australia/LHI
+Australia/Lindeman	Australia/Lindeman
+Australia/Lord_Howe	Australia/Lord_Howe
+Australia/Melbourne	Australia/Melbourne
+Australia/NSW	AET
+Australia/North	ACT
+Australia/Perth	Australia/Perth
+Australia/Queensland	Australia/Queensland
+Australia/South	Australia/South
+Australia/Sydney	AET
+Australia/Tasmania	Australia/Tasmania
+Australia/Victoria	Australia/Victoria
+Australia/West	Australia/West
+Australia/Yancowinna	Australia/Yancowinna
+BET	BET
+BST	BST
+Brazil/Acre	Brazil/Acre
+Brazil/DeNoronha	Brazil/DeNoronha
+Brazil/East	BET
+Brazil/West	Brazil/West
+CAT	CAT
+CET	CET
+CNT	CNT
+CST	CST
+CST6CDT	CST6CDT
+CTT	CTT
+Canada/Atlantic	Canada/Atlantic
+Canada/Central	Canada/Central
+Canada/East-Saskatchewan	Canada/East-Saskatchewan
+Canada/Eastern	Canada/Eastern
+Canada/Mountain	Canada/Mountain
+Canada/Newfoundland	CNT
+Canada/Pacific	Canada/Pacific
+Canada/Saskatchewan	Canada/Saskatchewan
+Canada/Yukon	Canada/Yukon
+Chile/Continental	Chile/Continental
+Chile/EasterIsland	Chile/EasterIsland
+Cuba	Cuba
+EAT	EAT
+ECT	ECT
+EET	EET
+EST	EST
+EST5EDT	EST5EDT
+Egypt	ART
+Eire	Eire
+Etc/GMT	GMT
+Etc/GMT+0	GMT
+Etc/GMT+1	Etc/GMT+1
+Etc/GMT+10	Etc/GMT+10
+Etc/GMT+11	Etc/GMT+11
+Etc/GMT+12	Etc/GMT+12
+Etc/GMT+2	Etc/GMT+2
+Etc/GMT+3	Etc/GMT+3
+Etc/GMT+4	Etc/GMT+4
+Etc/GMT+5	Etc/GMT+5
+Etc/GMT+6	Etc/GMT+6
+Etc/GMT+7	Etc/GMT+7
+Etc/GMT+8	Etc/GMT+8
+Etc/GMT+9	Etc/GMT+9
+Etc/GMT-0	GMT
+Etc/GMT-1	Etc/GMT-1
+Etc/GMT-10	Etc/GMT-10
+Etc/GMT-11	Etc/GMT-11
+Etc/GMT-12	Etc/GMT-12
+Etc/GMT-13	Etc/GMT-13
+Etc/GMT-14	Etc/GMT-14
+Etc/GMT-2	Etc/GMT-2
+Etc/GMT-3	Etc/GMT-3
+Etc/GMT-4	Etc/GMT-4
+Etc/GMT-5	Etc/GMT-5
+Etc/GMT-6	Etc/GMT-6
+Etc/GMT-7	Etc/GMT-7
+Etc/GMT-8	Etc/GMT-8
+Etc/GMT-9	Etc/GMT-9
+Etc/GMT0	GMT
+Etc/Greenwich	GMT
+Etc/UCT	UCT
+Etc/UTC	UCT
+Etc/Universal	UCT
+Etc/Zulu	UCT
+Europe/Amsterdam	Europe/Amsterdam
+Europe/Andorra	Europe/Andorra
+Europe/Astrakhan	Europe/Astrakhan
+Europe/Athens	Europe/Athens
+Europe/Belfast	GB
+Europe/Belgrade	Europe/Belgrade
+Europe/Berlin	Europe/Berlin
+Europe/Bratislava	Europe/Bratislava
+Europe/Brussels	Europe/Brussels
+Europe/Bucharest	Europe/Bucharest
+Europe/Budapest	Europe/Budapest
+Europe/Busingen	Europe/Busingen
+Europe/Chisinau	Europe/Chisinau
+Europe/Copenhagen	Europe/Copenhagen
+Europe/Dublin	Eire
+Europe/Gibraltar	Europe/Gibraltar
+Europe/Guernsey	GB
+Europe/Helsinki	Europe/Helsinki
+Europe/Isle_of_Man	GB
+Europe/Istanbul	Turkey
+Europe/Jersey	GB
+Europe/Kaliningrad	Europe/Kaliningrad
+Europe/Kiev	Europe/Kiev
+Europe/Kirov	Europe/Kirov
+Europe/Kyiv	Europe/Kyiv
+Europe/Lisbon	Portugal
+Europe/Ljubljana	Europe/Ljubljana
+Europe/London	GB
+Europe/Luxembourg	Europe/Luxembourg
+Europe/Madrid	Europe/Madrid
+Europe/Malta	Europe/Malta
+Europe/Mariehamn	Europe/Mariehamn
+Europe/Minsk	Europe/Minsk
+Europe/Monaco	ECT
+Europe/Moscow	W-SU
+Europe/Nicosia	Europe/Nicosia
+Europe/Oslo	Europe/Oslo
+Europe/Paris	ECT
+Europe/Podgorica	Europe/Podgorica
+Europe/Prague	Europe/Prague
+Europe/Riga	Europe/Riga
+Europe/Rome	Europe/Rome
+Europe/Samara	Europe/Samara
+Europe/San_Marino	Europe/San_Marino
+Europe/Sarajevo	Europe/Sarajevo
+Europe/Saratov	Europe/Saratov
+Europe/Simferopol	Europe/Simferopol
+Europe/Skopje	Europe/Skopje
+Europe/Sofia	Europe/Sofia
+Europe/Stockholm	Europe/Stockholm
+Europe/Tallinn	Europe/Tallinn
+Europe/Tirane	Europe/Tirane
+Europe/Tiraspol	Europe/Tiraspol
+Europe/Ulyanovsk	Europe/Ulyanovsk
+Europe/Uzhgorod	Europe/Uzhgorod
+Europe/Vaduz	Europe/Vaduz
+Europe/Vatican	Europe/Vatican
+Europe/Vienna	Europe/Vienna
+Europe/Vilnius	Europe/Vilnius
+Europe/Volgograd	Europe/Volgograd
+Europe/Warsaw	Poland
+Europe/Zagreb	Europe/Zagreb
+Europe/Zaporozhye	Europe/Zaporozhye
+Europe/Zurich	Europe/Zurich
+Factory	Factory
+GB	GB
+GB-Eire	GB
+GMT	GMT
+GMT+0	GMT
+GMT-0	GMT
+GMT0	GMT
+Greenwich	GMT
+HST	HST
+Hongkong	Hongkong
+IET	IET
+IST	IST
+Iceland	Iceland
+Indian/Antananarivo	EAT
+Indian/Chagos	Indian/Chagos
+Indian/Christmas	Indian/Christmas
+Indian/Cocos	Indian/Cocos
+Indian/Comoro	EAT
+Indian/Kerguelen	Indian/Kerguelen
+Indian/Mahe	Indian/Mahe
+Indian/Maldives	Indian/Maldives
+Indian/Mauritius	Indian/Mauritius
+Indian/Mayotte	EAT
+Indian/Reunion	Indian/Reunion
+Iran	Iran
+Israel	Israel
+JST	JST
+Jamaica	Jamaica
+Japan	JST
+Kwajalein	Kwajalein
+Libya	Libya
+MET	MET
+MIT	MIT
+MST	MST
+MST7MDT	MST7MDT
+Mexico/BajaNorte	Mexico/BajaNorte
+Mexico/BajaSur	Mexico/BajaSur
+Mexico/General	Mexico/General
+NET	NET
+NST	NZ
+NZ	NZ
+NZ-CHAT	NZ-CHAT
+Navajo	Navajo
+PLT	PLT
+PNT	PNT
+PRC	CTT
+PRT	PRT
+PST	PST
+PST8PDT	PST8PDT
+Pacific/Apia	MIT
+Pacific/Auckland	NZ
+Pacific/Bougainville	Pacific/Bougainville
+Pacific/Chatham	NZ-CHAT
+Pacific/Chuuk	Pacific/Chuuk
+Pacific/Easter	Pacific/Easter
+Pacific/Efate	Pacific/Efate
+Pacific/Enderbury	Pacific/Enderbury
+Pacific/Fakaofo	Pacific/Fakaofo
+Pacific/Fiji	Pacific/Fiji
+Pacific/Funafuti	Pacific/Funafuti
+Pacific/Galapagos	Pacific/Galapagos
+Pacific/Gambier	Pacific/Gambier
+Pacific/Guadalcanal	SST
+Pacific/Guam	Pacific/Guam
+Pacific/Honolulu	Pacific/Honolulu
+Pacific/Johnston	Pacific/Johnston
+Pacific/Kanton	Pacific/Kanton
+Pacific/Kiritimati	Pacific/Kiritimati
+Pacific/Kosrae	Pacific/Kosrae
+Pacific/Kwajalein	Kwajalein
+Pacific/Majuro	Pacific/Majuro
+Pacific/Marquesas	Pacific/Marquesas
+Pacific/Midway	Pacific/Midway
+Pacific/Nauru	Pacific/Nauru
+Pacific/Niue	Pacific/Niue
+Pacific/Norfolk	Pacific/Norfolk
+Pacific/Noumea	Pacific/Noumea
+Pacific/Pago_Pago	Pacific/Pago_Pago
+Pacific/Palau	Pacific/Palau
+Pacific/Pitcairn	Pacific/Pitcairn
+Pacific/Pohnpei	SST
+Pacific/Ponape	SST
+Pacific/Port_Moresby	Pacific/Port_Moresby
+Pacific/Rarotonga	Pacific/Rarotonga
+Pacific/Saipan	Pacific/Saipan
+Pacific/Samoa	Pacific/Samoa
+Pacific/Tahiti	Pacific/Tahiti
+Pacific/Tarawa	Pacific/Tarawa
+Pacific/Tongatapu	Pacific/Tongatapu
+Pacific/Truk	Pacific/Truk
+Pacific/Wake	Pacific/Wake
+Pacific/Wallis	Pacific/Wallis
+Pacific/Yap	Pacific/Yap
+Poland	Poland
+Portugal	Portugal
+ROC	ROC
+ROK	ROK
+SST	SST
+Singapore	Singapore
+SystemV/AST4	SystemV/AST4
+SystemV/AST4ADT	SystemV/AST4ADT
+SystemV/CST6	SystemV/CST6
+SystemV/CST6CDT	SystemV/CST6CDT
+SystemV/EST5	SystemV/EST5
+SystemV/EST5EDT	SystemV/EST5EDT
+SystemV/HST10	SystemV/HST10
+SystemV/MST7	SystemV/MST7
+SystemV/MST7MDT	SystemV/MST7MDT
+SystemV/PST8	SystemV/PST8
+SystemV/PST8PDT	SystemV/PST8PDT
+SystemV/YST9	SystemV/YST9
+SystemV/YST9YDT	SystemV/YST9YDT
+Turkey	Turkey
+UCT	UCT
+US/Alaska	AST
+US/Aleutian	US/Aleutian
+US/Arizona	PNT
+US/Central	CST
+US/East-Indiana	IET
+US/Eastern	US/Eastern
+US/Hawaii	US/Hawaii
+US/Indiana-Starke	US/Indiana-Starke
+US/Michigan	US/Michigan
+US/Mountain	Navajo
+US/Pacific	PST
+US/Pacific-New	PST
+US/Samoa	US/Samoa
+UTC	UCT
+Universal	UCT
+VST	VST
+W-SU	W-SU
+WET	WET
+Zulu	UCT
 
 #
 # Time Zone Rule updates


### PR DESCRIPTION
pg_timezone_names.utc_offset changes over time
so tests should not rely on it. We were lucky for a while but our luck just ran out...

fixes: duckdblabs/duckdb-internal#582