### PR TITLE
[Catalog] Fix locking issues + identify problem in MappingValue

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -199,6 +199,8 @@ bool CatalogSet::AlterOwnership(CatalogTransaction transaction, ChangeOwnershipI
 bool CatalogSet::AlterEntry(CatalogTransaction transaction, const string &name, AlterInfo &alter_info) {
 	// lock the catalog for writing
 	lock_guard<mutex> write_lock(catalog.GetWriteLock());
+	// lock this catalog set to disallow reading
+	lock_guard<mutex> read_lock(catalog_lock);
 
 	// first check if the entry exists in the unordered set
 	EntryIndex entry_index;
@@ -209,9 +211,6 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const string &name, 
 	if (!alter_info.allow_internal && entry->internal) {
 		throw CatalogException("Cannot alter entry \"%s\" because it is an internal system entry", entry->name);
 	}
-
-	// lock this catalog set to disallow reading
-	lock_guard<mutex> read_lock(catalog_lock);
 
 	// create a new entry and replace the currently stored one
 	// set the timestamp to the timestamp of the current transaction
@@ -316,6 +315,7 @@ void CatalogSet::DropEntryInternal(CatalogTransaction transaction, EntryIndex en
 bool CatalogSet::DropEntry(CatalogTransaction transaction, const string &name, bool cascade, bool allow_drop_internal) {
 	// lock the catalog for writing
 	lock_guard<mutex> write_lock(catalog.GetWriteLock());
+	lock_guard<mutex> read_lock(catalog_lock);
 	// we can only delete an entry that exists
 	EntryIndex entry_index;
 	auto entry = GetEntryInternal(transaction, name, &entry_index);
@@ -326,7 +326,6 @@ bool CatalogSet::DropEntry(CatalogTransaction transaction, const string &name, b
 		throw CatalogException("Cannot drop entry \"%s\" because it is an internal system entry", entry->name);
 	}
 
-	lock_guard<mutex> read_lock(catalog_lock);
 	DropEntryInternal(transaction, std::move(entry_index), *entry, cascade);
 	return true;
 }

--- a/src/include/duckdb/catalog/catalog_set.hpp
+++ b/src/include/duckdb/catalog/catalog_set.hpp
@@ -122,6 +122,10 @@ public:
 
 	void UpdateTimestamp(CatalogEntry &entry, transaction_t timestamp);
 
+	mutex &GetCatalogLock() {
+		return catalog_lock;
+	}
+
 	void Verify(Catalog &catalog);
 
 private:

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -254,6 +254,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data) {
 		// Grab a write lock on the catalog
 		auto &duck_catalog = catalog.Cast<DuckCatalog>();
 		lock_guard<mutex> write_lock(duck_catalog.GetWriteLock());
+		lock_guard<mutex> read_lock(catalog_entry->set->GetCatalogLock());
 		catalog_entry->set->UpdateTimestamp(*catalog_entry->parent, commit_id);
 		if (catalog_entry->name != catalog_entry->parent->name) {
 			catalog_entry->set->UpdateTimestamp(*catalog_entry, commit_id);

--- a/test/sql/catalog/dependencies/test_concurrent_alter.test
+++ b/test/sql/catalog/dependencies/test_concurrent_alter.test
@@ -1,0 +1,347 @@
+# name: test/sql/catalog/dependencies/test_concurrent_alter.test
+# group: [dependencies]
+
+require skip_reload
+
+mode skip
+
+statement ok
+CREATE TABLE t2 AS (SELECT 42);
+
+statement ok
+create sequence seq;
+
+statement ok
+alter sequence seq owned by t2;
+
+statement ok
+pragma threads=1;
+
+query I
+select current_setting('threads');
+----
+1
+
+concurrentloop i 1 100
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+statement maybe
+alter table t2 rename to t3;
+----
+Catalog
+
+statement maybe
+alter table t3 rename to t2;
+----
+Catalog
+
+endloop


### PR DESCRIPTION
The test this adds is skipped because it's not entirely fixed by this PR.

The issues fixed by this PR were found through the test, but there is a bigger underlying problem that needs more thought.

To summarize the issues fixed by this PR:
When we read from a catalog, we need to grab the CatalogSet's `catalog_lock`, even when we already have the Catalog's `write_lock`.

The issue that isn't fixed is that `DeleteMapping` is too eager, it deletes mappings too eagerly, I think we need a refcount similar to what we do for `EntryValue`<->`EntryIndex` so we can be aware that there are other transactions that make use of the mapping.

-----------

The issue highlighted by the added test is that *sometimes* this could result in a crash.
When we grab a reference to a CatalogEntry and that entry is subsequently deleted after we release the lock, we're holding random memory.

```c++
* thread #23, stop reason = EXC_BAD_ACCESS (code=1, address=0x40)
    frame #0: 0x0000000102bceba8 libduckdb.dylib`duckdb::Binder::Bind(this=0x0000000118f5f9e8, stmt=<unavailable>) at bind_simple.cpp:23:26 [opt]
   20           auto entry = Catalog::GetEntry(context, stmt.info->GetCatalogType(), stmt.info->catalog, stmt.info->schema,
   21                                          stmt.info->name, stmt.info->if_not_found);
   22           if (entry) {
-> 23                   auto &catalog = entry->ParentCatalog();
   24                   if (!entry->temporary) {
   25                           // we can only alter temporary tables/views in read-only mode
   26                           properties.modified_databases.insert(catalog.GetName());
```

When I comment out the `DeleteMapping` call I can not reproduce this crash

--------------

I've also tried taking out the DeleteMapping and moving it into `CommitState::CommitEntry` so it only happens when the transaction is successful, but that still didn't fix it.