### PR TITLE
[ART] Don't allow index creation in readonly mode

### DIFF
--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -502,6 +502,9 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 	case CatalogType::INDEX_ENTRY: {
 		auto &base = stmt.info->Cast<CreateIndexInfo>();
 
+		auto catalog = BindCatalog(base.catalog);
+		properties.modified_databases.insert(catalog);
+
 		// visit the table reference
 		auto table_ref = make_uniq<BaseTableRef>();
 		table_ref->catalog_name = base.catalog;

--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -44,7 +44,7 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 		}
 		stmt.info->catalog = entry->ParentCatalog().GetName();
 		if (!entry->temporary) {
-			// we can only drop temporary tables in read-only mode
+			// we can only drop temporary schema entries in read-only mode
 			properties.modified_databases.insert(stmt.info->catalog);
 		}
 		stmt.info->schema = entry->ParentSchema().name;

--- a/test/sql/index/art/storage/test_art_readonly.test
+++ b/test/sql/index/art/storage/test_art_readonly.test
@@ -1,0 +1,31 @@
+# name: test/sql/index/art/storage/test_art_readonly.test
+# description: Test that index creation is disabled in readonly mode
+# group: [storage]
+
+load __TEST_DIR__/test_index.db
+
+statement ok
+CREATE TABLE tbl (i INTEGER);
+
+statement ok
+CREATE INDEX idx_drop ON tbl(i);
+
+# try index creation in readonly
+
+load __TEST_DIR__/test_index.db readonly
+
+statement error
+CREATE INDEX idx ON tbl (i);
+----
+read-only mode
+
+statement error
+DROP INDEX idx_drop
+----
+read-only mode
+
+# ensure that we did not create another index
+query I
+SELECT index_name FROM duckdb_indexes();
+----
+idx_drop


### PR DESCRIPTION
See title.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/590.