### PR TITLE
Fix incorrect template specialization

### DIFF
--- a/src/include/duckdb/function/udf_function.hpp
+++ b/src/include/duckdb/function/udf_function.hpp
@@ -370,7 +370,7 @@ private:
 	inline static AggregateFunction CreateBinaryAggregateFunction(const string &name, LogicalType ret_type,
 	                                                              LogicalType input_typeA, LogicalType input_typeB) {
 		AggregateFunction aggr_function =
-		    AggregateFunction::BinaryAggregate<STATE, TR, TA, TB, UDF_OP>(input_typeA, input_typeB, ret_type);
+		    AggregateFunction::BinaryAggregate<STATE, TA, TB, TR, UDF_OP>(input_typeA, input_typeB, ret_type);
 		aggr_function.name = name;
 		return aggr_function;
 	}


### PR DESCRIPTION
The order of template parameters was incorrect, leading to template specialization failure when compiling. The “TR” type parameters should come after “TA” and “TB”.