### PR TITLE
Commit drop of index memory

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1317,8 +1317,14 @@ idx_t DataTable::GetTotalRows() {
 }
 
 void DataTable::CommitDropTable() {
-	// commit a drop of this table: mark all blocks as modified so they can be reclaimed later on
+	// commit a drop of this table: mark all blocks as modified, so they can be reclaimed later on
 	row_groups->CommitDropTable();
+
+	// propagate dropping this table to its indexes: frees all index memory
+	info->indexes.Scan([&](Index &index) {
+		index.CommitDrop();
+		return false;
+	});
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/sql/index/art/storage/test_art_reclaim_storage.test_slow
+++ b/test/sql/index/art/storage/test_art_reclaim_storage.test_slow
@@ -1,5 +1,5 @@
 # name: test/sql/index/art/storage/test_art_reclaim_storage.test_slow
-# description: Test that the block manager reclaims blocks previously used for indexes
+# description: Test that the block manager reclaims index memory
 # group: [storage]
 
 load __TEST_DIR__/test_reclaim_space.db

--- a/test/sql/index/art/storage/test_art_reclaim_storage_pk_fk.test_slow
+++ b/test/sql/index/art/storage/test_art_reclaim_storage_pk_fk.test_slow
@@ -2,6 +2,8 @@
 # description: Test that the block manager reclaims index memory of PK and FK tables
 # group: [storage]
 
+# PRIMARY KEY
+
 load __TEST_DIR__/pk_mem_cleanup.db
 
 query I
@@ -31,7 +33,7 @@ SELECT used_blocks < 2 FROM pragma_database_size();
 ----
 1
 
-# test foreign key table
+# FOREIGN KEY
 
 load __TEST_DIR__/fk_mem_cleanup.db
 
@@ -57,6 +59,37 @@ DROP TABLE fk_tbl;
 
 statement ok
 DROP TABLE pk_tbl;
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT used_blocks < 2 FROM pragma_database_size();
+----
+1
+
+# UNIQUE
+
+load __TEST_DIR__/unique_mem_cleanup.db
+
+query I
+SELECT used_blocks < 2 FROM pragma_database_size();
+----
+1
+
+statement ok
+CREATE TABLE unique_tbl (i INTEGER UNIQUE);
+
+statement ok
+INSERT INTO unique_tbl SELECT range FROM range(200000);
+
+query I
+SELECT used_blocks > 2 FROM pragma_database_size();
+----
+1
+
+statement ok
+DROP TABLE unique_tbl;
 
 statement ok
 CHECKPOINT

--- a/test/sql/index/art/storage/test_art_reclaim_storage_pk_fk.test_slow
+++ b/test/sql/index/art/storage/test_art_reclaim_storage_pk_fk.test_slow
@@ -1,0 +1,67 @@
+# name: test/sql/index/art/storage/test_art_reclaim_storage_pk_fk.test_slow
+# description: Test that the block manager reclaims index memory of PK and FK tables
+# group: [storage]
+
+load __TEST_DIR__/pk_mem_cleanup.db
+
+query I
+SELECT used_blocks < 2 FROM pragma_database_size();
+----
+1
+
+statement ok
+CREATE TABLE pk_tbl (i INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO pk_tbl SELECT range FROM range(200000);
+
+query I
+SELECT used_blocks > 2 FROM pragma_database_size();
+----
+1
+
+statement ok
+DROP TABLE pk_tbl;
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT used_blocks < 2 FROM pragma_database_size();
+----
+1
+
+# test foreign key table
+
+load __TEST_DIR__/fk_mem_cleanup.db
+
+query I
+SELECT used_blocks < 2 FROM pragma_database_size();
+----
+1
+
+statement ok
+CREATE TABLE pk_tbl (i INTEGER PRIMARY KEY);
+
+statement ok
+INSERT INTO pk_tbl SELECT range FROM range(200000);
+
+statement ok
+CREATE TABLE fk_tbl (i INTEGER REFERENCES pk_tbl(i));
+
+statement ok
+INSERT INTO fk_tbl SELECT range FROM range(200000);
+
+statement ok
+DROP TABLE fk_tbl;
+
+statement ok
+DROP TABLE pk_tbl;
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT used_blocks < 2 FROM pragma_database_size();
+----
+1


### PR DESCRIPTION
This PR propagates dropping a table to the affected indexes and their memory, specifically `PRIMARY KEY`, `FOREIGN KEY`, and `UNIQUE`. It also adds the respective tests.