### PR TITLE
fix: check for IsRowId before accessing column name

### DIFF
--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -102,7 +102,9 @@ bool MultiFileReader::ComplexFilterPushdown(ClientContext &context, vector<strin
 
 	unordered_map<string, column_t> column_map;
 	for (idx_t i = 0; i < get.column_ids.size(); i++) {
-		column_map.insert({get.names[get.column_ids[i]], i});
+		if (!IsRowIdColumnId(get.column_ids[i])) {
+			column_map.insert({get.names[get.column_ids[i]], i});
+		}
 	}
 
 	auto start_files = files.size();


### PR DESCRIPTION
We do some re-optimization in our code and this situation arised during query re-optimizing when running this query:
```
SELECT COUNT(*) FROM read_json_auto('s3://md-datadog-bucket/query_text/dt=20230711/hour=00/archive_000446.1149.w2NpeZP2QpSHycYt6sAFWA.json.gz')

INTERNAL Error: Attempted to access index -1 within vector of size 12
```
(There are 12 columns in the JSON file and the code in `MultiFileReader::ComplexFilterPushdown` is trying to access -1 (which is `ROWID`, i.e. -1 as column_id) )

This change fixes the issue. Also, it is safer to check we're not accessing IsRowId (i.e. -1) in column names vector. 
