### PR TITLE
Fix non-uniformity in random floating point draws

### DIFF
--- a/src/common/random_engine.cpp
+++ b/src/common/random_engine.cpp
@@ -27,8 +27,9 @@ double RandomEngine::NextRandom(double min, double max) {
 	return min + (NextRandom() * (max - min));
 }
 
+static const float ld22 = std::ldexp(1.0f, -22);
 double RandomEngine::NextRandom() {
-	return std::ldexp(random_state->pcg(), -32);
+	return ((random_state->pcg() >> 10) + 0.5f) * ld22;
 }
 uint32_t RandomEngine::NextRandomInteger() {
 	return random_state->pcg();


### PR DESCRIPTION
Currently, random floating point numbers are generated by taking random bits in the range $[0, 2^{32}-1]$ and dividing them by $2^{32}$.

This doesn't produce a uniform distribution however: since there is roundoff happening more often closer to 1, there are more possible random bits mapping to lower floating point numbers than to higher floating point numbers.

This PR fixes it by taking only bytes within the range of the mantissa to do the calculation. This way, every possible output number number is evenly spaced and has the same probability, leading to a true uniform distribution.

A couple notes:
* I wasn't sure (and the docs made no reference to) if the idea here is to draw a number in a closed interval or in an open interval. The changes in the PR restrict it to `(0,1)` (i.e. neither extreme is possible as a result of the random draw).
* I see there's quite a mixture between different precision types. If the idea is to draw a random `double`, I think it'd be better to use a 64-bit generator as the spacing of possible values will be smaller. However, there's also a method `NextRandomInteger` which is supposed to return `uint32_t`. In theory it could draw a 64-bit number (by switching to e.g. `pcg64`) and discard 32 bits from it, while using more bits for the `double` method, but I don't know if this is the best way.