### PR TITLE
Allow pausing pipeline in NextBatch call

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -5119,6 +5119,29 @@ SinkFinalizeType EnumUtil::FromString<SinkFinalizeType>(const char *value) {
 }
 
 template<>
+const char* EnumUtil::ToChars<SinkNextBatchType>(SinkNextBatchType value) {
+	switch(value) {
+	case SinkNextBatchType::READY:
+		return "READY";
+	case SinkNextBatchType::BLOCKED:
+		return "BLOCKED";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+SinkNextBatchType EnumUtil::FromString<SinkNextBatchType>(const char *value) {
+	if (StringUtil::Equals(value, "READY")) {
+		return SinkNextBatchType::READY;
+	}
+	if (StringUtil::Equals(value, "BLOCKED")) {
+		return SinkNextBatchType::BLOCKED;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
 const char* EnumUtil::ToChars<SinkResultType>(SinkResultType value) {
 	switch(value) {
 	case SinkResultType::NEED_MORE_INPUT:

--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -175,8 +175,8 @@ void PhysicalBatchCopyToFile::FlushBatchData(ClientContext &context, GlobalSinkS
 //===--------------------------------------------------------------------===//
 // Next Batch
 //===--------------------------------------------------------------------===//
-void PhysicalBatchCopyToFile::NextBatch(ExecutionContext &context, GlobalSinkState &gstate_p,
-                                        LocalSinkState &lstate) const {
+SinkNextBatchType PhysicalBatchCopyToFile::NextBatch(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                                     LocalSinkState &lstate) const {
 	auto &state = lstate.Cast<BatchCopyToLocalState>();
 	if (state.collection && state.collection->Count() > 0) {
 		// we finished processing this batch
@@ -188,6 +188,7 @@ void PhysicalBatchCopyToFile::NextBatch(ExecutionContext &context, GlobalSinkSta
 	state.batch_index = lstate.partition_info.batch_index.GetIndex();
 
 	state.InitializeCollection(context.client, *this);
+	return SinkNextBatchType::READY;
 }
 
 unique_ptr<LocalSinkState> PhysicalBatchCopyToFile::GetLocalSinkState(ExecutionContext &context) const {

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -298,7 +298,8 @@ unique_ptr<LocalSinkState> PhysicalBatchInsert::GetLocalSinkState(ExecutionConte
 	return make_uniq<BatchInsertLocalState>(context.client, insert_types, bound_defaults);
 }
 
-void PhysicalBatchInsert::NextBatch(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const {
+SinkNextBatchType PhysicalBatchInsert::NextBatch(ExecutionContext &context, GlobalSinkState &state,
+                                                 LocalSinkState &lstate_p) const {
 	auto &gstate = state.Cast<BatchInsertGlobalState>();
 	auto &lstate = lstate_p.Cast<BatchInsertLocalState>();
 
@@ -316,6 +317,7 @@ void PhysicalBatchInsert::NextBatch(ExecutionContext &context, GlobalSinkState &
 		lstate.CreateNewCollection(table, insert_types);
 	}
 	lstate.current_index = batch_index;
+	return SinkNextBatchType::READY;
 }
 
 SinkResultType PhysicalBatchInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {

--- a/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
+++ b/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
@@ -450,8 +450,8 @@ void PhysicalFixedBatchCopy::ExecuteTasks(ClientContext &context, GlobalSinkStat
 //===--------------------------------------------------------------------===//
 // Next Batch
 //===--------------------------------------------------------------------===//
-void PhysicalFixedBatchCopy::NextBatch(ExecutionContext &context, GlobalSinkState &gstate_p,
-                                       LocalSinkState &lstate) const {
+SinkNextBatchType PhysicalFixedBatchCopy::NextBatch(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                                    LocalSinkState &lstate) const {
 	auto &state = lstate.Cast<FixedBatchCopyLocalState>();
 	if (state.collection && state.collection->Count() > 0) {
 		// we finished processing this batch
@@ -468,6 +468,7 @@ void PhysicalFixedBatchCopy::NextBatch(ExecutionContext &context, GlobalSinkStat
 	state.batch_index = lstate.partition_info.batch_index.GetIndex();
 
 	state.InitializeCollection(context.client, *this);
+	return SinkNextBatchType::READY;
 }
 
 unique_ptr<LocalSinkState> PhysicalFixedBatchCopy::GetLocalSinkState(ExecutionContext &context) const {

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -106,7 +106,9 @@ SinkFinalizeType PhysicalOperator::Finalize(Pipeline &pipeline, Event &event, Cl
 	return SinkFinalizeType::READY;
 }
 
-void PhysicalOperator::NextBatch(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const {
+SinkNextBatchType PhysicalOperator::NextBatch(ExecutionContext &context, GlobalSinkState &state,
+                                              LocalSinkState &lstate_p) const {
+	return SinkNextBatchType::READY;
 }
 
 unique_ptr<LocalSinkState> PhysicalOperator::GetLocalSinkState(ExecutionContext &context) const {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -236,6 +236,8 @@ enum class SinkCombineResultType : uint8_t;
 
 enum class SinkFinalizeType : uint8_t;
 
+enum class SinkNextBatchType : uint8_t;
+
 enum class SinkResultType : uint8_t;
 
 enum class SourceResultType : uint8_t;
@@ -596,6 +598,9 @@ const char* EnumUtil::ToChars<SinkCombineResultType>(SinkCombineResultType value
 
 template<>
 const char* EnumUtil::ToChars<SinkFinalizeType>(SinkFinalizeType value);
+
+template<>
+const char* EnumUtil::ToChars<SinkNextBatchType>(SinkNextBatchType value);
 
 template<>
 const char* EnumUtil::ToChars<SinkResultType>(SinkResultType value);
@@ -984,6 +989,9 @@ SinkCombineResultType EnumUtil::FromString<SinkCombineResultType>(const char *va
 
 template<>
 SinkFinalizeType EnumUtil::FromString<SinkFinalizeType>(const char *value);
+
+template<>
+SinkNextBatchType EnumUtil::FromString<SinkNextBatchType>(const char *value);
 
 template<>
 SinkResultType EnumUtil::FromString<SinkResultType>(const char *value);

--- a/src/include/duckdb/common/enums/operator_result_type.hpp
+++ b/src/include/duckdb/common/enums/operator_result_type.hpp
@@ -56,4 +56,10 @@ enum class SinkCombineResultType : uint8_t { FINISHED, BLOCKED };
 //! BLOCKED means the finalize call to the sink is currently blocked, e.g. by some async I/O.
 enum class SinkFinalizeType : uint8_t { READY, NO_OUTPUT_POSSIBLE, BLOCKED };
 
+//! The SinkNextBatchType is used to indicate the result of a NextBatch call on a sink
+//! There are two possible results:
+//! READY means the sink is ready for further processing
+//! BLOCKED means the NextBatch call to the sink is currently blocked, e.g. by some async I/O.
+enum class SinkNextBatchType : uint8_t { READY, BLOCKED };
+
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
@@ -46,7 +46,8 @@ public:
 	                          OperatorSinkFinalizeInput &input) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-	void NextBatch(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const override;
+	SinkNextBatchType NextBatch(ExecutionContext &context, GlobalSinkState &state,
+	                            LocalSinkState &lstate_p) const override;
 
 	bool RequiresBatchIndex() const override {
 		return true;

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
@@ -52,7 +52,8 @@ public:
 	// Sink interface
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
-	void NextBatch(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const override;
+	SinkNextBatchType NextBatch(ExecutionContext &context, GlobalSinkState &state,
+	                            LocalSinkState &lstate_p) const override;
 	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
 	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
 	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,

--- a/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
@@ -45,7 +45,8 @@ public:
 	                          OperatorSinkFinalizeInput &input) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-	void NextBatch(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const override;
+	SinkNextBatchType NextBatch(ExecutionContext &context, GlobalSinkState &state,
+	                            LocalSinkState &lstate_p) const override;
 
 	bool RequiresBatchIndex() const override {
 		return true;

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -145,8 +145,9 @@ public:
 	virtual SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
 	                                  OperatorSinkFinalizeInput &input) const;
 	//! For sinks with RequiresBatchIndex set to true, when a new batch starts being processed this method is called
-	//! This allows flushing of the current batch (e.g. to disk) TODO: should this be able to block too?
-	virtual void NextBatch(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const;
+	//! This allows flushing of the current batch (e.g. to disk)
+	virtual SinkNextBatchType NextBatch(ExecutionContext &context, GlobalSinkState &state,
+	                                    LocalSinkState &lstate_p) const;
 
 	virtual unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const;
 	virtual unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const;

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -106,6 +106,10 @@ private:
 	//! This flag is set when the pipeline gets interrupted by the Sink -> the final_chunk should be re-sink-ed.
 	bool remaining_sink_chunk = false;
 
+	//! This flag is set when the pipeline gets interrupted by NextBatch -> NextBatch should be called again and the
+	//! source_chunk should be sent through the pipeline
+	bool next_batch_blocked = false;
+
 	//! Current operator being flushed
 	idx_t flushing_idx;
 	//! Whether the current flushing_idx should be flushed: this needs to be stored to make flushing code re-entrant
@@ -131,6 +135,9 @@ private:
 	//! Returns whether or not a new input chunk is needed, or whether or not we are finished
 	OperatorResultType Execute(DataChunk &input, DataChunk &result, idx_t initial_index = 0);
 
+	//! Notifies the sink that a new batch has started
+	SinkNextBatchType NextBatch(DataChunk &source_chunk);
+
 	//! Tries to flush all state from intermediate operators. Will return true if all state is flushed, false in the
 	//! case of a blocked sink.
 	bool TryFlushCachingOperators();
@@ -143,6 +150,7 @@ private:
 	int debug_blocked_sink_count = 0;
 	int debug_blocked_source_count = 0;
 	int debug_blocked_combine_count = 0;
+	int debug_blocked_next_batch_count = 0;
 	//! Number of times the Sink/Source will block before actually returning data
 	int debug_blocked_target_count = 1;
 #endif

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -106,6 +106,57 @@ bool PipelineExecutor::TryFlushCachingOperators() {
 	return true;
 }
 
+SinkNextBatchType PipelineExecutor::NextBatch(duckdb::DataChunk &source_chunk) {
+	D_ASSERT(requires_batch_index);
+	idx_t next_batch_index;
+	if (source_chunk.size() == 0) {
+		next_batch_index = NumericLimits<int64_t>::Maximum();
+	} else {
+		next_batch_index =
+		    pipeline.source->GetBatchIndex(context, source_chunk, *pipeline.source_state, *local_source_state);
+		// we start with the base_batch_index as a valid starting value. Make sure that next batch is called below
+		next_batch_index += pipeline.base_batch_index + 1;
+	}
+	auto &partition_info = local_sink_state->partition_info;
+	if (next_batch_index == partition_info.batch_index.GetIndex()) {
+		// no changes, return
+		return SinkNextBatchType::READY;
+	}
+	// batch index has changed - update it
+	if (partition_info.batch_index.GetIndex() > next_batch_index) {
+		throw InternalException(
+		    "Pipeline batch index - gotten lower batch index %llu (down from previous batch index of %llu)",
+		    next_batch_index, partition_info.batch_index.GetIndex());
+	}
+#ifdef DUCKDB_DEBUG_ASYNC_SINK_SOURCE
+	if (debug_blocked_next_batch_count < debug_blocked_target_count) {
+		debug_blocked_next_batch_count++;
+
+		auto &callback_state = interrupt_state;
+		std::thread rewake_thread([callback_state] {
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			callback_state.Callback();
+		});
+		rewake_thread.detach();
+
+		return SinkNextBatchType::BLOCKED;
+	}
+#endif
+	auto current_batch = partition_info.batch_index.GetIndex();
+	partition_info.batch_index = next_batch_index;
+	// call NextBatch before updating min_batch_index to provide the opportunity to flush the previous batch
+	auto next_batch_result = pipeline.sink->NextBatch(context, *pipeline.sink->sink_state, *local_sink_state);
+
+	if (next_batch_result == SinkNextBatchType::BLOCKED) {
+		partition_info.batch_index = current_batch; // set batch_index back to what it was before
+		return SinkNextBatchType::BLOCKED;
+	}
+
+	partition_info.min_batch_index = pipeline.UpdateBatchIndex(current_batch, next_batch_index);
+
+	return SinkNextBatchType::READY;
+}
+
 PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 	D_ASSERT(pipeline.sink);
 	auto &source_chunk = pipeline.operators.empty() ? final_chunk : *intermediate_chunks[0];
@@ -115,7 +166,8 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 		}
 
 		OperatorResultType result;
-		if (exhausted_source && done_flushing && !remaining_sink_chunk && in_process_operators.empty()) {
+		if (exhausted_source && done_flushing && !remaining_sink_chunk && !next_batch_blocked &&
+		    in_process_operators.empty()) {
 			break;
 		} else if (remaining_sink_chunk) {
 			// The pipeline was interrupted by the Sink. We should retry sinking the final chunk.
@@ -127,7 +179,7 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 			// the result for the pipeline
 			D_ASSERT(source_chunk.size() > 0);
 			result = ExecutePushInternal(source_chunk);
-		} else if (exhausted_source && !done_flushing) {
+		} else if (exhausted_source && !next_batch_blocked && !done_flushing) {
 			// The source was exhausted, try flushing all operators
 			auto flush_completed = TryFlushCachingOperators();
 			if (flush_completed) {
@@ -136,21 +188,33 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 			} else {
 				return PipelineExecuteResult::INTERRUPTED;
 			}
-		} else if (!exhausted_source) {
-			// "Regular" path: fetch a chunk from the source and push it through the pipeline
-			source_chunk.Reset();
-			SourceResultType source_result = FetchFromSource(source_chunk);
-
-			if (source_result == SourceResultType::BLOCKED) {
-				return PipelineExecuteResult::INTERRUPTED;
-			}
-
-			if (source_result == SourceResultType::FINISHED) {
-				exhausted_source = true;
-				if (source_chunk.size() == 0) {
-					continue;
+		} else if (!exhausted_source || next_batch_blocked) {
+			SourceResultType source_result;
+			if (!next_batch_blocked) {
+				// "Regular" path: fetch a chunk from the source and push it through the pipeline
+				source_chunk.Reset();
+				source_result = FetchFromSource(source_chunk);
+				if (source_result == SourceResultType::BLOCKED) {
+					return PipelineExecuteResult::INTERRUPTED;
+				}
+				if (source_result == SourceResultType::FINISHED) {
+					exhausted_source = true;
 				}
 			}
+
+			if (requires_batch_index) {
+				auto next_batch_result = NextBatch(source_chunk);
+				next_batch_blocked = next_batch_result == SinkNextBatchType::BLOCKED;
+				if (next_batch_blocked) {
+					return PipelineExecuteResult::INTERRUPTED;
+				}
+			}
+
+			if (exhausted_source && source_chunk.size() == 0) {
+				// To ensure that we're not early-terminating the pipeline
+				continue;
+			}
+
 			result = ExecutePushInternal(source_chunk);
 		} else {
 			throw InternalException("Unexpected state reached in pipeline executor");
@@ -285,6 +349,7 @@ void PipelineExecutor::ExecutePull(DataChunk &result) {
 	auto &executor = pipeline.executor;
 	try {
 		D_ASSERT(!pipeline.sink);
+		D_ASSERT(!requires_batch_index);
 		auto &source_chunk = pipeline.operators.empty() ? result : *intermediate_chunks[0];
 		while (result.size() == 0 && !exhausted_source) {
 			if (in_process_operators.empty()) {
@@ -488,32 +553,6 @@ SourceResultType PipelineExecutor::FetchFromSource(DataChunk &result) {
 
 	// Ensures Sinks only return empty results when Blocking or Finished
 	D_ASSERT(res != SourceResultType::BLOCKED || result.size() == 0);
-
-	if (requires_batch_index && res != SourceResultType::BLOCKED) {
-		idx_t next_batch_index;
-		if (result.size() == 0) {
-			next_batch_index = NumericLimits<int64_t>::Maximum();
-		} else {
-			next_batch_index =
-			    pipeline.source->GetBatchIndex(context, result, *pipeline.source_state, *local_source_state);
-			// we start with the base_batch_index as a valid starting value. Make sure that next batch is called below
-			next_batch_index += pipeline.base_batch_index + 1;
-		}
-		auto &partition_info = local_sink_state->partition_info;
-		if (next_batch_index != partition_info.batch_index.GetIndex()) {
-			// batch index has changed - update it
-			if (partition_info.batch_index.GetIndex() > next_batch_index) {
-				throw InternalException(
-				    "Pipeline batch index - gotten lower batch index %llu (down from previous batch index of %llu)",
-				    next_batch_index, partition_info.batch_index.GetIndex());
-			}
-			auto current_batch = partition_info.batch_index.GetIndex();
-			partition_info.batch_index = next_batch_index;
-			// call NextBatch before updating min_batch_index to provide the opportunity to flush the previous batch
-			pipeline.sink->NextBatch(context, *pipeline.sink->sink_state, *local_sink_state);
-			partition_info.min_batch_index = pipeline.UpdateBatchIndex(current_batch, next_batch_index);
-		}
-	}
 
 	EndOperator(*pipeline.source, &result);
 


### PR DESCRIPTION
Resumable pipelines allow pausing a pipeline executor when the source or sink is blocked, for example on IO. Pipeline execution can currently be paused at various stages, e.g. when retrieving data from a source, when pushing data to a sink, when combining parallel sink states, or when finalizing a sink. A missing place where this won't happen is when the sink is informed about batch completion. As this typically entails flushing the existing data in the sink, and this can potentially entail IO as well, PhysicalOperator::NextBatch should be pausable as well. This PR solves this unresolved TODO in the code.

I've tested the PR by running `make unittest` with the following patch (setting `FORCE_ASYNC_SINK_SOURCE` to true):

```
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 67444dbc8c..e23c515a63 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ option(DISABLE_MEMORY_SAFETY "Debug setting: disable memory access checks at run
 option(DISABLE_ASSERTIONS "Debug setting: disable assertions" FALSE)
 option(ALTERNATIVE_VERIFY "Debug setting: use alternative verify mode" FALSE)
 option(DESTROY_UNPINNED_BLOCKS "Debug setting: destroy unpinned buffer-managed blocks" FALSE)
-option(FORCE_ASYNC_SINK_SOURCE "Debug setting: forces sinks/sources to block the first 2 times they're called" FALSE)
+option(FORCE_ASYNC_SINK_SOURCE "Debug setting: forces sinks/sources to block the first 2 times they're called" TRUE)
 option(DEBUG_STACKTRACE "Debug setting: print a stracktrace on asserts and when testing crashes" FALSE)
 option(DEBUG_MOVE "Debug setting: Ensure std::move is being used" FALSE)
 option(CLANG_TIDY "Enable build for clang-tidy, this disables all source files excluding the core database. This does not produce a working build." FALSE)
```