### PR TITLE
Fix exploding Delim Joins

### DIFF
--- a/benchmark/micro/join/delim_join_no_blowup.benchmark
+++ b/benchmark/micro/join/delim_join_no_blowup.benchmark
@@ -1,0 +1,32 @@
+# name: benchmark/micro/join/delim_join_no_blowup.benchmark
+# description: Delim joins dont result in a blow up and therefore take forever
+# group: [join]
+
+name High Cardinality Duplicate elimination join
+group join
+
+load
+create table big_table (id integer);
+insert into big_table select range from range(10000000);
+create table medium_1 (id integer, fk_to_big integer, fk_to_medium_2 integer);
+insert into  medium_1  (select 
+				range,
+                CASE WHEN range<10 THEN 0 ELSE range END,
+                range + 9999,
+                from range(10000));
+create table medium_2 (id integer);
+insert into  medium_2 (select range from range(10000));
+pragma disabled_optimizers='statistics_propagation';
+
+run
+SELECT *
+FROM big_table as bt
+WHERE
+exists(
+   SELECT *
+		 FROM medium_2
+			 INNER JOIN medium_1
+				 ON ((medium_2.id = medium_1.fk_to_medium_2))
+		 WHERE  
+		   (medium_1.fk_to_big % 7 = bt.id % 7)
+)

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -201,6 +201,10 @@ bool RelationManager::ExtractJoinRelations(LogicalOperator &input_op,
 		// Adding relations to the current join order optimizer
 		bool can_reorder_left = ExtractJoinRelations(*op->children[0], filter_operators, op);
 		bool can_reorder_right = ExtractJoinRelations(*op->children[1], filter_operators, op);
+		if (!can_reorder_right) {
+			// optimize left
+			// return false;
+		}
 		return can_reorder_left && can_reorder_right;
 	}
 	case LogicalOperatorType::LOGICAL_DUMMY_SCAN: {
@@ -231,10 +235,11 @@ bool RelationManager::ExtractJoinRelations(LogicalOperator &input_op,
 		return true;
 	}
 	case LogicalOperatorType::LOGICAL_DELIM_GET: {
-		auto &delim_get = op->Cast<LogicalDelimGet>();
-		auto stats = RelationStatisticsHelper::ExtractDelimGetStats(delim_get, context);
-		AddRelation(input_op, parent, stats);
-		return true;
+//      Removed until we can extract better stats from delim gets. See #596
+//		auto &delim_get = op->Cast<LogicalDelimGet>();
+//		auto stats = RelationStatisticsHelper::ExtractDelimGetStats(delim_get, context);
+//		AddRelation(input_op, parent, stats);
+		return false;
 	}
 	case LogicalOperatorType::LOGICAL_PROJECTION: {
 		auto child_stats = RelationStats();

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -231,10 +231,10 @@ bool RelationManager::ExtractJoinRelations(LogicalOperator &input_op,
 		return true;
 	}
 	case LogicalOperatorType::LOGICAL_DELIM_GET: {
-//      Removed until we can extract better stats from delim gets. See #596
-//		auto &delim_get = op->Cast<LogicalDelimGet>();
-//		auto stats = RelationStatisticsHelper::ExtractDelimGetStats(delim_get, context);
-//		AddRelation(input_op, parent, stats);
+		//      Removed until we can extract better stats from delim gets. See #596
+		//		auto &delim_get = op->Cast<LogicalDelimGet>();
+		//		auto stats = RelationStatisticsHelper::ExtractDelimGetStats(delim_get, context);
+		//		AddRelation(input_op, parent, stats);
 		return false;
 	}
 	case LogicalOperatorType::LOGICAL_PROJECTION: {

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -201,10 +201,6 @@ bool RelationManager::ExtractJoinRelations(LogicalOperator &input_op,
 		// Adding relations to the current join order optimizer
 		bool can_reorder_left = ExtractJoinRelations(*op->children[0], filter_operators, op);
 		bool can_reorder_right = ExtractJoinRelations(*op->children[1], filter_operators, op);
-		if (!can_reorder_right) {
-			// optimize left
-			// return false;
-		}
 		return can_reorder_left && can_reorder_right;
 	}
 	case LogicalOperatorType::LOGICAL_DUMMY_SCAN: {

--- a/test/optimizer/joins/delim_join_dont_explode.test
+++ b/test/optimizer/joins/delim_join_dont_explode.test
@@ -1,0 +1,8 @@
+# name: test/optimizer/joins/delim_join_dont_explode.test
+# description: In the join order optimizer queries need to have the correct bindings
+# group: [joins]
+
+
+# disable deliminator
+
+# run query with delim gets

--- a/test/optimizer/joins/delim_join_dont_explode.test
+++ b/test/optimizer/joins/delim_join_dont_explode.test
@@ -1,8 +1,0 @@
-# name: test/optimizer/joins/delim_join_dont_explode.test
-# description: In the join order optimizer queries need to have the correct bindings
-# group: [joins]
-
-
-# disable deliminator
-
-# run query with delim gets

--- a/test/optimizer/joins/delim_join_dont_explode.test_slow
+++ b/test/optimizer/joins/delim_join_dont_explode.test_slow
@@ -1,4 +1,4 @@
-# name: test/optimizer/joins/delim_join_dont_explode.test
+# name: test/optimizer/joins/delim_join_dont_explode.test_slow
 # description: In the join order optimizer queries need to have the correct bindings
 # group: [joins]
 

--- a/test/optimizer/joins/delim_join_dont_explode.test_slow
+++ b/test/optimizer/joins/delim_join_dont_explode.test_slow
@@ -1,0 +1,65 @@
+# name: test/optimizer/joins/delim_join_dont_explode.test
+# description: In the join order optimizer queries need to have the correct bindings
+# group: [joins]
+
+statement ok
+create table big_table (id integer);
+
+statement ok
+insert into big_table select range from range(1000);
+
+statement ok
+create table medium_1 (id integer, fk_to_big integer, fk_to_medium_2 integer);
+
+statement ok
+insert into  medium_1  (select range::varchar,
+                CASE WHEN range<10 THEN 0 ELSE range END,
+                range + 99,
+                from range(100));
+
+
+statement ok
+create table medium_2 (id integer);
+
+statement ok
+insert into medium_2 (select range from range(100));
+
+query I
+select count(*) from medium_2, medium_1 where medium_2.id = medium_1.fk_to_medium_2;
+----
+1
+
+query I
+SELECT *
+FROM big_table as bt
+WHERE
+exists(
+   SELECT *
+		 FROM medium_2
+			 INNER JOIN medium_1
+				 ON ((medium_2.id = medium_1.fk_to_medium_2))
+		 WHERE  
+		   (medium_1.fk_to_big % 7 = bt.id % 7)
+) order by bt.id
+----
+143 values hashing to dc5d1675d206057ccfe13739a38ee082
+
+query II
+EXPLAIN 
+SELECT *
+FROM big_table as bt
+WHERE
+exists(
+  SELECT *
+	 FROM medium_2
+		 INNER JOIN medium_1
+			 ON ((medium_2.id = medium_1.fk_to_medium_2))
+	 WHERE  
+	   (medium_1.fk_to_big % 7 = bt.id % 7)
+)
+order by bt.id
+----
+physical_plan	<REGEX>:.*HASH_JOIN.*DELIM_SCAN.*SEQ_SCAN.*SEQ_SCAN.*
+
+
+


### PR DESCRIPTION
After refactoring the join order optimizer, delim scans were allowed to be reordered. Unfortunately, getting statistics from delim scans wasn't possible and the cardinality was estimated to be 0. This throws off the join order optimizer. Delim scans become perfect candidates for first joins because the cardinality of any join with a (supposedly empty) table is 0, which is great for the cost model.

In some cases, this delim scan has a lot of data, and the join at the bottom of the table can blow up significantly. A proper fix for this would be to inspect the delim join and get the query from there, but to match 0.8.1 functionality, the idea is to not allow delim scans to be reordered.

Added a benchmark for testing. On my laptop 8 cores, 16GB memory, results look like this

```
current

benchmark/micro/join/delim_join_no_blowup.benchmark 1   14.247793
benchmark/micro/join/delim_join_no_blowup.benchmark 2   13.947187
benchmark/micro/join/delim_join_no_blowup.benchmark 3   13.267580
benchmark/micro/join/delim_join_no_blowup.benchmark 4   13.384650
benchmark/micro/join/delim_join_no_blowup.benchmark 5   13.450060

with fix

benchmark/micro/join/delim_join_no_blowup.benchmark 1   1.472236
benchmark/micro/join/delim_join_no_blowup.benchmark 2   1.508781
benchmark/micro/join/delim_join_no_blowup.benchmark 3   1.618396
benchmark/micro/join/delim_join_no_blowup.benchmark 4   1.430282
benchmark/micro/join/delim_join_no_blowup.benchmark 5   1.412266
```