### PR TITLE
Don't reset validity target count

### DIFF
--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -77,6 +77,9 @@ public:
 			auto &child_cache = child_caches[0]->Cast<VectorCacheBuffer>();
 			auto &array_child = result.auxiliary->Cast<VectorArrayBuffer>().GetChild();
 			child_cache.ResetFromCache(array_child, child_caches[0]);
+
+			// Ensure the child validity is (will be) large enough, even if its not initialized.
+			array_child.validity.Resize(array_child.validity.TargetCount(), child_cache.capacity);
 			break;
 		}
 		case PhysicalType::STRUCT: {

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -79,7 +79,8 @@ public:
 			child_cache.ResetFromCache(array_child, child_caches[0]);
 
 			// Ensure the child validity is (will be) large enough, even if its not initialized.
-			array_child.validity.Resize(array_child.validity.TargetCount(), child_cache.capacity);
+			auto validity_target_size = array_child.validity.TargetCount();
+			array_child.validity.Resize(validity_target_size, std::max(validity_target_size, child_cache.capacity));
 			break;
 		}
 		case PhysicalType::STRUCT: {

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -138,6 +138,7 @@ public:
 	inline void Reset() {
 		validity_mask = nullptr;
 		validity_data.reset();
+		target_count = STANDARD_VECTOR_SIZE;
 	}
 
 	static inline idx_t EntryCount(idx_t count) {

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -138,7 +138,6 @@ public:
 	inline void Reset() {
 		validity_mask = nullptr;
 		validity_data.reset();
-		target_count = STANDARD_VECTOR_SIZE;
 	}
 
 	static inline idx_t EntryCount(idx_t count) {


### PR DESCRIPTION
Closes https://github.com/duckdblabs/duckdb-internal/issues/604

~~I've been thinking about this a bit and I think this fix should be ok. The target_count is only ever not `STANDARD_VECTOR_SIZE` when the validity is initialized by the child of an `ARRAY` vector, everywhere else where the default is not desired it is either resized or explicitly initialized with a specific size, at which point the target_count is changed anyway. So I don't think this will lead to a bunch of validity masks being kept around unnecessarily large.~~

We need to resize the array child validity to the array child capacity after resetting from vector cache. Right now this forces an initialization of the validity mask, but once https://github.com/duckdb/duckdb/pull/9461 lands this will no longer be the case.