### PR TITLE
JDBC - Appender for Decimal

### DIFF
--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -270,6 +270,38 @@ static jobject decode_charbuffer_to_jstring(JNIEnv *env, const char *d_str, idx_
 	return j_str;
 }
 
+static Value create_value_from_bigdecimal(JNIEnv *env, jobject decimal) {
+	jint precision = env->CallIntMethod(decimal, J_Decimal_precision);
+	jint scale = env->CallIntMethod(decimal, J_Decimal_scale);
+
+	// Java BigDecimal type can have scale that exceeds the precision
+	// Which our DECIMAL type does not support (assert(width >= scale))
+	if (scale > precision) {
+		precision = scale;
+	}
+
+	// DECIMAL scale is unsigned, so negative values are not supported
+	if (scale < 0) {
+		throw InvalidInputException("Converting from a BigDecimal with negative scale is not supported");
+	}
+
+	Value val;
+
+	if (precision <= 18) { // normal sizes -> avoid string processing
+		jobject no_point_dec = env->CallObjectMethod(decimal, J_Decimal_scaleByPowTen, scale);
+		jlong result = env->CallLongMethod(no_point_dec, J_Decimal_longValue);
+		val = Value::DECIMAL((int64_t)result, (uint8_t)precision, (uint8_t)scale);
+	} else if (precision <= 38) { // larger than int64 -> get string and cast
+		jobject str_val = env->CallObjectMethod(decimal, J_Decimal_toPlainString);
+		auto *str_char = env->GetStringUTFChars((jstring)str_val, 0);
+		val = Value(str_char);
+		val = val.DefaultCastAs(LogicalType::DECIMAL(precision, scale));
+		env->ReleaseStringUTFChars((jstring)str_val, str_char);
+	}
+
+	return val;
+}
+
 /**
  * Associates a duckdb::Connection with a duckdb::DuckDB. The DB may be shared amongst many ConnectionHolders, but the
  * Connection is unique to this holder. Every Java DuckDBConnection has exactly 1 of these holders, and they are never
@@ -523,33 +555,8 @@ jobject _duckdb_jdbc_execute(JNIEnv *env, jclass, jobject stmt_ref_buf, jobjectA
 				duckdb_params.push_back(Value::DOUBLE(env->CallDoubleMethod(param, J_Double_doubleValue)));
 				continue;
 			} else if (env->IsInstanceOf(param, J_Decimal)) {
-				jint precision = env->CallIntMethod(param, J_Decimal_precision);
-				jint scale = env->CallIntMethod(param, J_Decimal_scale);
-
-				// Java BigDecimal type can have scale that exceeds the precision
-				// Which our DECIMAL type does not support (assert(width >= scale))
-				if (scale > precision) {
-					precision = scale;
-				}
-
-				// DECIMAL scale is unsigned, so negative values are not supported
-				if (scale < 0) {
-					throw InvalidInputException("Converting from a BigDecimal with negative scale is not supported");
-				}
-
-				if (precision <= 18) { // normal sizes -> avoid string processing
-					jobject no_point_dec = env->CallObjectMethod(param, J_Decimal_scaleByPowTen, scale);
-					jlong result = env->CallLongMethod(no_point_dec, J_Decimal_longValue);
-					duckdb_params.push_back(Value::DECIMAL((int64_t)result, (uint8_t)precision, (uint8_t)scale));
-				} else if (precision <= 38) { // larger than int64 -> get string and cast
-					jobject str_val = env->CallObjectMethod(param, J_Decimal_toPlainString);
-					auto *str_char = env->GetStringUTFChars((jstring)str_val, 0);
-					Value val = Value(str_char);
-					val = val.DefaultCastAs(LogicalType::DECIMAL(precision, scale));
-
-					duckdb_params.push_back(val);
-					env->ReleaseStringUTFChars((jstring)str_val, str_char);
-				}
+				Value val = create_value_from_bigdecimal(env, param);
+				duckdb_params.push_back(val);
 				continue;
 			} else if (env->IsInstanceOf(param, J_String)) {
 				auto param_string = jstring_to_string(env, (jstring)param);
@@ -965,34 +972,7 @@ void _duckdb_jdbc_appender_append_timestamp(JNIEnv *env, jclass, jobject appende
 }
 
 void _duckdb_jdbc_appender_append_decimal(JNIEnv *env, jclass, jobject appender_ref_buf, jobject value) {
-	jint precision = env->CallIntMethod(value, J_Decimal_precision);
-	jint scale = env->CallIntMethod(value, J_Decimal_scale);
-
-	// Java BigDecimal type can have scale that exceeds the precision
-	// Which our DECIMAL type does not support (assert(width >= scale))
-	if (scale > precision) {
-		precision = scale;
-	}
-
-	// DECIMAL scale is unsigned, so negative values are not supported
-	if (scale < 0) {
-		throw InvalidInputException("Converting from a BigDecimal with negative scale is not supported");
-	}
-
-	Value val;
-
-	if (precision <= 18) { // normal sizes -> avoid string processing
-		jobject no_point_dec = env->CallObjectMethod(value, J_Decimal_scaleByPowTen, scale);
-		jlong result = env->CallLongMethod(no_point_dec, J_Decimal_longValue);
-		val = Value::DECIMAL((int64_t)result, (uint8_t)precision, (uint8_t)scale);
-	} else if (precision <= 38) { // larger than int64 -> get string and cast
-		jobject str_val = env->CallObjectMethod(value, J_Decimal_toPlainString);
-		auto *str_char = env->GetStringUTFChars((jstring)str_val, 0);
-		val = Value(str_char);
-		val = val.DefaultCastAs(LogicalType::DECIMAL(precision, scale));
-
-		env->ReleaseStringUTFChars((jstring)str_val, str_char);
-	}
+	Value val = create_value_from_bigdecimal(env, value);
 	get_appender(env, appender_ref_buf)->Append(val);
 }
 

--- a/tools/jdbc/src/jni/functions.cpp
+++ b/tools/jdbc/src/jni/functions.cpp
@@ -345,6 +345,16 @@ JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1appe
 	}
 }
 
+JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1decimal(JNIEnv *env, jclass param0,
+                                                                                            jobject param1,
+                                                                                            jobject param2) {
+	try {
+		return _duckdb_jdbc_appender_append_decimal(env, param0, param1, param2);
+	} catch (const std::exception &e) {
+		ThrowJNI(env, e.what());
+	}
+}
+
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1null(JNIEnv *env, jclass param0,
                                                                                          jobject param1) {
 	try {

--- a/tools/jdbc/src/jni/functions.hpp
+++ b/tools/jdbc/src/jni/functions.hpp
@@ -186,6 +186,12 @@ JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1appe
                                                                                               jobject param1,
                                                                                               jlong param2);
 
+void _duckdb_jdbc_appender_append_decimal(JNIEnv *env, jclass param0, jobject param1, jobject param2);
+
+JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1decimal(JNIEnv *env, jclass param0,
+                                                                                            jobject param1,
+                                                                                            jobject param2);
+
 void _duckdb_jdbc_appender_append_null(JNIEnv *env, jclass param0, jobject param1);
 
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1appender_1append_1null(JNIEnv *env, jclass param0,

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBAppender.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBAppender.java
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import org.duckdb.DuckDBTimestamp;
 
 public class DuckDBAppender implements AutoCloseable {
@@ -57,6 +58,14 @@ public class DuckDBAppender implements AutoCloseable {
         } else {
             long timeInMicros = DuckDBTimestamp.localDateTime2Micros(value);
             DuckDBNative.duckdb_jdbc_appender_append_timestamp(appender_ref, timeInMicros);
+        }
+    }
+
+    public void appendBigDecimal(BigDecimal value) throws SQLException {
+        if (value == null) {
+            DuckDBNative.duckdb_jdbc_appender_append_null(appender_ref);
+        } else {
+            DuckDBNative.duckdb_jdbc_appender_append_decimal(appender_ref, value);
         }
     }
 

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.math.BigDecimal;
 
 public class DuckDBNative {
     static {
@@ -152,6 +153,9 @@ public class DuckDBNative {
         throws SQLException;
 
     protected static native void duckdb_jdbc_appender_append_timestamp(ByteBuffer appender_ref, long value)
+        throws SQLException;
+
+    protected static native void duckdb_jdbc_appender_append_decimal(ByteBuffer appender_ref, BigDecimal value)
         throws SQLException;
 
     protected static native void duckdb_jdbc_appender_append_null(ByteBuffer appender_ref) throws SQLException;

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -2327,66 +2327,61 @@ public class TestDuckDBJDBC {
             "CREATE TABLE decimals (id INT4, a DECIMAL(4,2), b DECIMAL(8,4), c DECIMAL(18,6), d DECIMAL(38,20))");
         DuckDBAppender appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
 
-        BigDecimal bd16 = new BigDecimal("12.34").setScale(2);
-        BigDecimal bd32 = new BigDecimal("1234.5678").setScale(4);
-        BigDecimal bd64 = new BigDecimal("123456789012.345678").setScale(6);
-        BigDecimal bd128 = new BigDecimal("123456789012345678.90123456789012345678").setScale(20);
-        BigDecimal nbd16 = new BigDecimal("-12.34").setScale(2);
-        BigDecimal nbd32 = new BigDecimal("-1234.5678").setScale(4);
-        BigDecimal nbd64 = new BigDecimal("-123456789012.345678").setScale(6);
-        BigDecimal nbd128 = new BigDecimal("-123456789012345678.90123456789012345678").setScale(20);
-        BigDecimal sbd16 = new BigDecimal("-1.34").setScale(2);
-        BigDecimal sbd32 = new BigDecimal("-123.5678").setScale(4);
-        BigDecimal sbd64 = new BigDecimal("-12345678901.345678").setScale(6);
-        BigDecimal sbd128 = new BigDecimal("-12345678901234567.90123456789012345678").setScale(20);
-        BigDecimal ibd16 = new BigDecimal("-1").setScale(2);
-        BigDecimal ibd32 = new BigDecimal("-123").setScale(4);
-        BigDecimal ibd64 = new BigDecimal("-12345678901").setScale(6);
-        BigDecimal ibd128 = new BigDecimal("-12345678901234567").setScale(20);
-        BigDecimal onebd16 = new BigDecimal("1").setScale(2);
-        BigDecimal onebd32 = new BigDecimal("1").setScale(4);
-        BigDecimal onebd64 = new BigDecimal("1").setScale(6);
-        BigDecimal onebd128 = new BigDecimal("1").setScale(20);
-
-        BigDecimal td16 = new BigDecimal("121.14").setScale(2);
-        BigDecimal td32 = new BigDecimal("12134.5678").setScale(4);
-        BigDecimal td64 = new BigDecimal("123456789012.345678").setScale(6);
-        BigDecimal td128 = new BigDecimal("123456789012345678.9012345678901234567").setScale(19);
+        BigDecimal bigdec16 = new BigDecimal("12.34").setScale(2);
+        BigDecimal bigdec32 = new BigDecimal("1234.5678").setScale(4);
+        BigDecimal bigdec64 = new BigDecimal("123456789012.345678").setScale(6);
+        BigDecimal bigdec128 = new BigDecimal("123456789012345678.90123456789012345678").setScale(20);
+        BigDecimal negbigdec16 = new BigDecimal("-12.34").setScale(2);
+        BigDecimal negbigdec32 = new BigDecimal("-1234.5678").setScale(4);
+        BigDecimal negbigdec64 = new BigDecimal("-123456789012.345678").setScale(6);
+        BigDecimal negbigdec128 = new BigDecimal("-123456789012345678.90123456789012345678").setScale(20);
+        BigDecimal smallbigdec16 = new BigDecimal("-1.34").setScale(2);
+        BigDecimal smallbigdec32 = new BigDecimal("-123.5678").setScale(4);
+        BigDecimal smallbigdec64 = new BigDecimal("-12345678901.345678").setScale(6);
+        BigDecimal smallbigdec128 = new BigDecimal("-12345678901234567.90123456789012345678").setScale(20);
+        BigDecimal intbigdec16 = new BigDecimal("-1").setScale(2);
+        BigDecimal intbigdec32 = new BigDecimal("-123").setScale(4);
+        BigDecimal intbigdec64 = new BigDecimal("-12345678901").setScale(6);
+        BigDecimal intbigdec128 = new BigDecimal("-12345678901234567").setScale(20);
+        BigDecimal onebigdec16 = new BigDecimal("1").setScale(2);
+        BigDecimal onebigdec32 = new BigDecimal("1").setScale(4);
+        BigDecimal onebigdec64 = new BigDecimal("1").setScale(6);
+        BigDecimal onebigdec128 = new BigDecimal("1").setScale(20);
 
         appender.beginRow();
         appender.append(1);
-        appender.appendBigDecimal(bd16);
-        appender.appendBigDecimal(bd32);
-        appender.appendBigDecimal(bd64);
-        appender.appendBigDecimal(bd128);
+        appender.appendBigDecimal(bigdec16);
+        appender.appendBigDecimal(bigdec32);
+        appender.appendBigDecimal(bigdec64);
+        appender.appendBigDecimal(bigdec128);
         appender.endRow();
         appender.beginRow();
         appender.append(2);
-        appender.appendBigDecimal(nbd16);
-        appender.appendBigDecimal(nbd32);
-        appender.appendBigDecimal(nbd64);
-        appender.appendBigDecimal(nbd128);
+        appender.appendBigDecimal(negbigdec16);
+        appender.appendBigDecimal(negbigdec32);
+        appender.appendBigDecimal(negbigdec64);
+        appender.appendBigDecimal(negbigdec128);
         appender.endRow();
         appender.beginRow();
         appender.append(3);
-        appender.appendBigDecimal(sbd16);
-        appender.appendBigDecimal(sbd32);
-        appender.appendBigDecimal(sbd64);
-        appender.appendBigDecimal(sbd128);
+        appender.appendBigDecimal(smallbigdec16);
+        appender.appendBigDecimal(smallbigdec32);
+        appender.appendBigDecimal(smallbigdec64);
+        appender.appendBigDecimal(smallbigdec128);
         appender.endRow();
         appender.beginRow();
         appender.append(4);
-        appender.appendBigDecimal(ibd16);
-        appender.appendBigDecimal(ibd32);
-        appender.appendBigDecimal(ibd64);
-        appender.appendBigDecimal(ibd128);
+        appender.appendBigDecimal(intbigdec16);
+        appender.appendBigDecimal(intbigdec32);
+        appender.appendBigDecimal(intbigdec64);
+        appender.appendBigDecimal(intbigdec128);
         appender.endRow();
         appender.beginRow();
         appender.append(5);
-        appender.appendBigDecimal(onebd16);
-        appender.appendBigDecimal(onebd32);
-        appender.appendBigDecimal(onebd64);
-        appender.appendBigDecimal(onebd128);
+        appender.appendBigDecimal(onebigdec16);
+        appender.appendBigDecimal(onebigdec32);
+        appender.appendBigDecimal(onebigdec64);
+        appender.appendBigDecimal(onebigdec128);
         appender.endRow();
         appender.close();
 
@@ -2399,10 +2394,10 @@ public class TestDuckDBJDBC {
         BigDecimal rs3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
         BigDecimal rs4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
 
-        assertEquals(rs1, bd16);
-        assertEquals(rs2, bd32);
-        assertEquals(rs3, bd64);
-        assertEquals(rs4, bd128);
+        assertEquals(rs1, bigdec16);
+        assertEquals(rs2, bigdec32);
+        assertEquals(rs3, bigdec64);
+        assertEquals(rs4, bigdec128);
         assertTrue(rs.next());
 
         BigDecimal nrs1 = (BigDecimal) rs.getObject(1, BigDecimal.class);
@@ -2410,10 +2405,10 @@ public class TestDuckDBJDBC {
         BigDecimal nrs3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
         BigDecimal nrs4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
 
-        assertEquals(nrs1, nbd16);
-        assertEquals(nrs2, nbd32);
-        assertEquals(nrs3, nbd64);
-        assertEquals(nrs4, nbd128);
+        assertEquals(nrs1, negbigdec16);
+        assertEquals(nrs2, negbigdec32);
+        assertEquals(nrs3, negbigdec64);
+        assertEquals(nrs4, negbigdec128);
         assertTrue(rs.next());
 
         BigDecimal srs1 = (BigDecimal) rs.getObject(1, BigDecimal.class);
@@ -2421,10 +2416,10 @@ public class TestDuckDBJDBC {
         BigDecimal srs3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
         BigDecimal srs4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
 
-        assertEquals(srs1, sbd16);
-        assertEquals(srs2, sbd32);
-        assertEquals(srs3, sbd64);
-        assertEquals(srs4, sbd128);
+        assertEquals(srs1, smallbigdec16);
+        assertEquals(srs2, smallbigdec32);
+        assertEquals(srs3, smallbigdec64);
+        assertEquals(srs4, smallbigdec128);
         assertTrue(rs.next());
 
         BigDecimal irs1 = (BigDecimal) rs.getObject(1, BigDecimal.class);
@@ -2432,10 +2427,10 @@ public class TestDuckDBJDBC {
         BigDecimal irs3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
         BigDecimal irs4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
 
-        assertEquals(irs1, ibd16);
-        assertEquals(irs2, ibd32);
-        assertEquals(irs3, ibd64);
-        assertEquals(irs4, ibd128);
+        assertEquals(irs1, intbigdec16);
+        assertEquals(irs2, intbigdec32);
+        assertEquals(irs3, intbigdec64);
+        assertEquals(irs4, intbigdec128);
         assertTrue(rs.next());
 
         BigDecimal oners1 = (BigDecimal) rs.getObject(1, BigDecimal.class);
@@ -2443,26 +2438,51 @@ public class TestDuckDBJDBC {
         BigDecimal oners3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
         BigDecimal oners4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
 
-        assertEquals(oners1, onebd16);
-        assertEquals(oners2, onebd32);
-        assertEquals(oners3, onebd64);
-        assertEquals(oners4, onebd128);
+        assertEquals(oners1, onebigdec16);
+        assertEquals(oners2, onebigdec32);
+        assertEquals(oners3, onebigdec64);
+        assertEquals(oners4, onebigdec128);
 
         rs.close();
         stmt.close();
+        conn.close();
+    }
+    
+    public static void test_appender_decimal_wrong_scale() throws Exception {
+        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        Statement stmt = conn.createStatement();
 
-        appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
-        appender.beginRow();
-        appender.append(6);
-        boolean exceptionRaised = false;
+        stmt.execute(
+            "CREATE TABLE decimals (id INT4, a DECIMAL(4,2), b DECIMAL(8,4), c DECIMAL(18,6), d DECIMAL(38,20))");
 
-        try {
+        assertThrows(() -> {
+            DuckDBAppender appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
+            appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
+            appender.append(1);
+            appender.beginRow();
             appender.appendBigDecimal(new BigDecimal("121.14").setScale(2));
-        } catch (SQLException e) {
-            exceptionRaised = true;
-        }
-        assertTrue(exceptionRaised);
+        }, SQLException.class);
 
+        assertThrows(() -> {
+            DuckDBAppender appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
+            appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
+            appender.beginRow();
+            appender.append(2);
+            appender.appendBigDecimal(new BigDecimal("21.1").setScale(2));
+            appender.appendBigDecimal(new BigDecimal("12111.1411").setScale(4));
+        }, SQLException.class);
+
+        assertThrows(() -> {
+            DuckDBAppender appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
+            appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
+            appender.beginRow();
+            appender.append(3);
+            appender.appendBigDecimal(new BigDecimal("21.1").setScale(2));
+            appender.appendBigDecimal(new BigDecimal("21.1").setScale(4));
+            appender.appendBigDecimal(new BigDecimal("1234567890123.123456").setScale(6));
+        }, SQLException.class);
+
+        stmt.close();
         conn.close();
     }
 

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -2447,7 +2447,7 @@ public class TestDuckDBJDBC {
         stmt.close();
         conn.close();
     }
-    
+
     public static void test_appender_decimal_wrong_scale() throws Exception {
         DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -2318,6 +2318,154 @@ public class TestDuckDBJDBC {
         stmt.close();
         conn.close();
     }
+
+    public static void test_appender_decimal() throws Exception {
+        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        Statement stmt = conn.createStatement();
+
+        stmt.execute(
+            "CREATE TABLE decimals (id INT4, a DECIMAL(4,2), b DECIMAL(8,4), c DECIMAL(18,6), d DECIMAL(38,20))");
+        DuckDBAppender appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
+
+        BigDecimal bd16 = new BigDecimal("12.34").setScale(2);
+        BigDecimal bd32 = new BigDecimal("1234.5678").setScale(4);
+        BigDecimal bd64 = new BigDecimal("123456789012.345678").setScale(6);
+        BigDecimal bd128 = new BigDecimal("123456789012345678.90123456789012345678").setScale(20);
+        BigDecimal nbd16 = new BigDecimal("-12.34").setScale(2);
+        BigDecimal nbd32 = new BigDecimal("-1234.5678").setScale(4);
+        BigDecimal nbd64 = new BigDecimal("-123456789012.345678").setScale(6);
+        BigDecimal nbd128 = new BigDecimal("-123456789012345678.90123456789012345678").setScale(20);
+        BigDecimal sbd16 = new BigDecimal("-1.34").setScale(2);
+        BigDecimal sbd32 = new BigDecimal("-123.5678").setScale(4);
+        BigDecimal sbd64 = new BigDecimal("-12345678901.345678").setScale(6);
+        BigDecimal sbd128 = new BigDecimal("-12345678901234567.90123456789012345678").setScale(20);
+        BigDecimal ibd16 = new BigDecimal("-1").setScale(2);
+        BigDecimal ibd32 = new BigDecimal("-123").setScale(4);
+        BigDecimal ibd64 = new BigDecimal("-12345678901").setScale(6);
+        BigDecimal ibd128 = new BigDecimal("-12345678901234567").setScale(20);
+        BigDecimal onebd16 = new BigDecimal("1").setScale(2);
+        BigDecimal onebd32 = new BigDecimal("1").setScale(4);
+        BigDecimal onebd64 = new BigDecimal("1").setScale(6);
+        BigDecimal onebd128 = new BigDecimal("1").setScale(20);
+
+        BigDecimal td16 = new BigDecimal("121.14").setScale(2);
+        BigDecimal td32 = new BigDecimal("12134.5678").setScale(4);
+        BigDecimal td64 = new BigDecimal("123456789012.345678").setScale(6);
+        BigDecimal td128 = new BigDecimal("123456789012345678.9012345678901234567").setScale(19);
+
+        appender.beginRow();
+        appender.append(1);
+        appender.appendBigDecimal(bd16);
+        appender.appendBigDecimal(bd32);
+        appender.appendBigDecimal(bd64);
+        appender.appendBigDecimal(bd128);
+        appender.endRow();
+        appender.beginRow();
+        appender.append(2);
+        appender.appendBigDecimal(nbd16);
+        appender.appendBigDecimal(nbd32);
+        appender.appendBigDecimal(nbd64);
+        appender.appendBigDecimal(nbd128);
+        appender.endRow();
+        appender.beginRow();
+        appender.append(3);
+        appender.appendBigDecimal(sbd16);
+        appender.appendBigDecimal(sbd32);
+        appender.appendBigDecimal(sbd64);
+        appender.appendBigDecimal(sbd128);
+        appender.endRow();
+        appender.beginRow();
+        appender.append(4);
+        appender.appendBigDecimal(ibd16);
+        appender.appendBigDecimal(ibd32);
+        appender.appendBigDecimal(ibd64);
+        appender.appendBigDecimal(ibd128);
+        appender.endRow();
+        appender.beginRow();
+        appender.append(5);
+        appender.appendBigDecimal(onebd16);
+        appender.appendBigDecimal(onebd32);
+        appender.appendBigDecimal(onebd64);
+        appender.appendBigDecimal(onebd128);
+        appender.endRow();
+        appender.close();
+
+        ResultSet rs = stmt.executeQuery("SELECT a,b,c,d FROM decimals ORDER BY id");
+        assertFalse(rs.isClosed());
+        assertTrue(rs.next());
+
+        BigDecimal rs1 = (BigDecimal) rs.getObject(1, BigDecimal.class);
+        BigDecimal rs2 = (BigDecimal) rs.getObject(2, BigDecimal.class);
+        BigDecimal rs3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
+        BigDecimal rs4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
+
+        assertEquals(rs1, bd16);
+        assertEquals(rs2, bd32);
+        assertEquals(rs3, bd64);
+        assertEquals(rs4, bd128);
+        assertTrue(rs.next());
+
+        BigDecimal nrs1 = (BigDecimal) rs.getObject(1, BigDecimal.class);
+        BigDecimal nrs2 = (BigDecimal) rs.getObject(2, BigDecimal.class);
+        BigDecimal nrs3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
+        BigDecimal nrs4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
+
+        assertEquals(nrs1, nbd16);
+        assertEquals(nrs2, nbd32);
+        assertEquals(nrs3, nbd64);
+        assertEquals(nrs4, nbd128);
+        assertTrue(rs.next());
+
+        BigDecimal srs1 = (BigDecimal) rs.getObject(1, BigDecimal.class);
+        BigDecimal srs2 = (BigDecimal) rs.getObject(2, BigDecimal.class);
+        BigDecimal srs3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
+        BigDecimal srs4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
+
+        assertEquals(srs1, sbd16);
+        assertEquals(srs2, sbd32);
+        assertEquals(srs3, sbd64);
+        assertEquals(srs4, sbd128);
+        assertTrue(rs.next());
+
+        BigDecimal irs1 = (BigDecimal) rs.getObject(1, BigDecimal.class);
+        BigDecimal irs2 = (BigDecimal) rs.getObject(2, BigDecimal.class);
+        BigDecimal irs3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
+        BigDecimal irs4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
+
+        assertEquals(irs1, ibd16);
+        assertEquals(irs2, ibd32);
+        assertEquals(irs3, ibd64);
+        assertEquals(irs4, ibd128);
+        assertTrue(rs.next());
+
+        BigDecimal oners1 = (BigDecimal) rs.getObject(1, BigDecimal.class);
+        BigDecimal oners2 = (BigDecimal) rs.getObject(2, BigDecimal.class);
+        BigDecimal oners3 = (BigDecimal) rs.getObject(3, BigDecimal.class);
+        BigDecimal oners4 = (BigDecimal) rs.getObject(4, BigDecimal.class);
+
+        assertEquals(oners1, onebd16);
+        assertEquals(oners2, onebd32);
+        assertEquals(oners3, onebd64);
+        assertEquals(oners4, onebd128);
+
+        rs.close();
+        stmt.close();
+
+        appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "decimals");
+        appender.beginRow();
+        appender.append(6);
+        boolean exceptionRaised = false;
+
+        try {
+            appender.appendBigDecimal(new BigDecimal("121.14").setScale(2));
+        } catch (SQLException e) {
+            exceptionRaised = true;
+        }
+        assertTrue(exceptionRaised);
+
+        conn.close();
+    }
+
     public static void test_appender_int_string() throws Exception {
         DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();


### PR DESCRIPTION
This PR adds the appendBigDecimal method to directly insert BigDecimal into a Decimal column.

Everything down to JNI is touched, but basically the same conversion logic (BigDecimal -> Value::DECIMAL) from SQL insert is used.

A test is included.