### PR TITLE
HivePartition: Add also lock on partition_state

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -122,6 +122,7 @@ SinkCombineResultType PhysicalCopyToFile::Combine(ExecutionContext &context, Ope
 		{
 			// create directories
 			lock_guard<mutex> global_lock(g.lock);
+			lock_guard<mutex> global_lock_on_partition_state(g.partition_state->lock);
 			const auto &global_partitions = g.partition_state->partitions;
 			// global_partitions have partitions added only at the back, so it's fine to only traverse the last part
 


### PR DESCRIPTION
I am not actually sure if the first lock `lock_guard<mutex> global_lock(g.lock);` is actually needed or could be potentially removed, but should not be a problem to keep both.

Ideally I think the inner and outer lock should be the same lock, but that would require a deeper review of the code that the one I am comfortable doing right now.