### PR TITLE
pin run-vcpkg action version

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -91,7 +91,7 @@ runs:
 
     - name: Setup vcpkg
       if: inputs.vcpkg_build == 1
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@v11.1
       with:
         vcpkgGitCommitId: 501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
 

--- a/.github/actions/manylinux_2014_setup/action.yml
+++ b/.github/actions/manylinux_2014_setup/action.yml
@@ -83,10 +83,10 @@ runs:
       run: scripts/setup_manylinux2014.sh gcc_4_8
 
     # Note instead of using scripts/setup_manylinux2014.sh vcpkg, we prefer to use
-    # lukka/run-vcpkg@v11 here as it configures vcpkg to cache to GH actions.
+    # lukka/run-vcpkg@v11.1 here as it configures vcpkg to cache to GH actions.
     - name: Setup vcpkg
       if: ${{ inputs.vcpkg == 1 }}
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@v11.1
       with:
         vcpkgGitCommitId: 501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
 

--- a/.github/actions/ubuntu_18_setup/action.yml
+++ b/.github/actions/ubuntu_18_setup/action.yml
@@ -82,7 +82,7 @@ runs:
 
     - name: Setup vcpkg
       if: ${{ inputs.vcpkg == 1 }}
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@v11.1
       with:
         vcpkgGitCommitId: 501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
 

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -36,7 +36,7 @@ jobs:
               with:
                   version: 'latest'
             - name: Setup vcpkg
-              uses: lukka/run-vcpkg@v11
+              uses: lukka/run-vcpkg@v11.1
               with:
                   vcpkgGitCommitId: 501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
 

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -144,7 +144,7 @@ jobs:
           aarch64_cross_compile: ${{ matrix.duckdb_arch == 'linux_arm64' && 1 }}
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@v11.1
         with:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
 
@@ -205,7 +205,7 @@ jobs:
           git checkout ${{ inputs.duckdb_version }}
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@v11.1
         with:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
 
@@ -259,7 +259,7 @@ jobs:
           key: ${{ github.job }}-${{ matrix.duckdb_arch }}
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@v11.1
         with:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
 


### PR DESCRIPTION
Solves issue where the run-vcpkg action would fail due to a glibc error. in v11.2 of https://github.com/lukka/run-vcpkg, Node was bumped to node20. 

between now and june 2024 when the manylinux_2014 image goes EOL, we should probably bump manylinux and update this action to the most recent version again