### PR TITLE
Fix typo

### DIFF
--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -347,7 +347,7 @@ bool MaybeRepartition(ClientContext &context, RadixHTGlobalSinkState &gstate, Ra
 	}
 
 	// We can go external when there is only one active thread, but we shouldn't repartition here
-	if (gstate.count_before_combining < 2) {
+	if (gstate.active_threads < 2) {
 		return false;
 	}
 


### PR DESCRIPTION
When fixing this before I auto-filled the wrong variable through CLion. This also fixed the bug, but when reading this later on I saw that I hadn't fixed it how I intended.