### PR TITLE
chore: bump vcpgk version

### DIFF
--- a/scripts/merge_vcpkg_deps.py
+++ b/scripts/merge_vcpkg_deps.py
@@ -55,9 +55,9 @@ for dep in dependencies_str:
 
 data = {
     "description": f"Auto-generated vcpkg.json for combined DuckDB extension build",
-    "builtin-baseline": "501db0f17ef6df184fcdbfbe0f87cde2313b6ab1",
+    "builtin-baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2",
     "dependencies": final_deduplicated_deps,
-    "overrides": [{"name": "openssl", "version": "3.0.8"}],
+    "overrides": [{"name": "openssl", "version": "3.0.8"}, {"name": "curl", "version": "8.2.1"}],
 }
 
 if merged_overlay_ports:


### PR DESCRIPTION
During maintenance DuckDB version upgrade internally, we noticed that the azure-sdk has been bumped from `1.8.1` to `1.10.2` through a vcpgk `builtin-baseline` version bump from `501db0f17ef6df184fcdbfbe0f87cde2313b6ab1`([2023.04.15](https://github.com/microsoft/vcpkg/releases/tag/2023.04.15)) to `9edb1b8e590cc086563301d735cae4b6e732d2d2` ([2023.08.09](https://github.com/microsoft/vcpkg/releases/tag/2023.08.09)) which requires also an upgraded version of `curl` required by this newer version of vcpkg (the older version of `curl`, `7.48.0` is not available in this version of vcpkg). 

We're leveraging the DDB `scripts/merge_vcpkg_deps.py` in our build system and we are currently unable to compile the azure extension due to the outdated vcpkg version. Wonder if we can bump it now.