### PR TITLE
Expose InterruptState in NextBatch

### DIFF
--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -175,8 +175,10 @@ void PhysicalBatchCopyToFile::FlushBatchData(ClientContext &context, GlobalSinkS
 //===--------------------------------------------------------------------===//
 // Next Batch
 //===--------------------------------------------------------------------===//
-SinkNextBatchType PhysicalBatchCopyToFile::NextBatch(ExecutionContext &context, GlobalSinkState &gstate_p,
-                                                     LocalSinkState &lstate) const {
+SinkNextBatchType PhysicalBatchCopyToFile::NextBatch(ExecutionContext &context,
+                                                     OperatorSinkNextBatchInput &input) const {
+	auto &lstate = input.local_state;
+	auto &gstate_p = input.global_state;
 	auto &state = lstate.Cast<BatchCopyToLocalState>();
 	if (state.collection && state.collection->Count() > 0) {
 		// we finished processing this batch

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -298,10 +298,9 @@ unique_ptr<LocalSinkState> PhysicalBatchInsert::GetLocalSinkState(ExecutionConte
 	return make_uniq<BatchInsertLocalState>(context.client, insert_types, bound_defaults);
 }
 
-SinkNextBatchType PhysicalBatchInsert::NextBatch(ExecutionContext &context, GlobalSinkState &state,
-                                                 LocalSinkState &lstate_p) const {
-	auto &gstate = state.Cast<BatchInsertGlobalState>();
-	auto &lstate = lstate_p.Cast<BatchInsertLocalState>();
+SinkNextBatchType PhysicalBatchInsert::NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const {
+	auto &gstate = input.global_state.Cast<BatchInsertGlobalState>();
+	auto &lstate = input.local_state.Cast<BatchInsertLocalState>();
 
 	auto &table = gstate.table;
 	auto batch_index = lstate.partition_info.batch_index.GetIndex();

--- a/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
+++ b/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
@@ -450,8 +450,10 @@ void PhysicalFixedBatchCopy::ExecuteTasks(ClientContext &context, GlobalSinkStat
 //===--------------------------------------------------------------------===//
 // Next Batch
 //===--------------------------------------------------------------------===//
-SinkNextBatchType PhysicalFixedBatchCopy::NextBatch(ExecutionContext &context, GlobalSinkState &gstate_p,
-                                                    LocalSinkState &lstate) const {
+SinkNextBatchType PhysicalFixedBatchCopy::NextBatch(ExecutionContext &context,
+                                                    OperatorSinkNextBatchInput &input) const {
+	auto &lstate = input.local_state;
+	auto &gstate_p = input.global_state;
 	auto &state = lstate.Cast<FixedBatchCopyLocalState>();
 	if (state.collection && state.collection->Count() > 0) {
 		// we finished processing this batch

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -106,8 +106,7 @@ SinkFinalizeType PhysicalOperator::Finalize(Pipeline &pipeline, Event &event, Cl
 	return SinkFinalizeType::READY;
 }
 
-SinkNextBatchType PhysicalOperator::NextBatch(ExecutionContext &context, GlobalSinkState &state,
-                                              LocalSinkState &lstate_p) const {
+SinkNextBatchType PhysicalOperator::NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const {
 	return SinkNextBatchType::READY;
 }
 

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
@@ -46,8 +46,7 @@ public:
 	                          OperatorSinkFinalizeInput &input) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-	SinkNextBatchType NextBatch(ExecutionContext &context, GlobalSinkState &state,
-	                            LocalSinkState &lstate_p) const override;
+	SinkNextBatchType NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const override;
 
 	bool RequiresBatchIndex() const override {
 		return true;

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
@@ -52,8 +52,7 @@ public:
 	// Sink interface
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
-	SinkNextBatchType NextBatch(ExecutionContext &context, GlobalSinkState &state,
-	                            LocalSinkState &lstate_p) const override;
+	SinkNextBatchType NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const override;
 	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
 	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
 	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,

--- a/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
@@ -45,8 +45,7 @@ public:
 	                          OperatorSinkFinalizeInput &input) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-	SinkNextBatchType NextBatch(ExecutionContext &context, GlobalSinkState &state,
-	                            LocalSinkState &lstate_p) const override;
+	SinkNextBatchType NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const override;
 
 	bool RequiresBatchIndex() const override {
 		return true;

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -146,8 +146,7 @@ public:
 	                                  OperatorSinkFinalizeInput &input) const;
 	//! For sinks with RequiresBatchIndex set to true, when a new batch starts being processed this method is called
 	//! This allows flushing of the current batch (e.g. to disk)
-	virtual SinkNextBatchType NextBatch(ExecutionContext &context, GlobalSinkState &state,
-	                                    LocalSinkState &lstate_p) const;
+	virtual SinkNextBatchType NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const;
 
 	virtual unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const;
 	virtual unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const;

--- a/src/include/duckdb/execution/physical_operator_states.hpp
+++ b/src/include/duckdb/execution/physical_operator_states.hpp
@@ -176,6 +176,12 @@ struct OperatorSinkFinalizeInput {
 	InterruptState &interrupt_state;
 };
 
+struct OperatorSinkNextBatchInput {
+	GlobalSinkState &global_state;
+	LocalSinkState &local_state;
+	InterruptState &interrupt_state;
+};
+
 // LCOV_EXCL_STOP
 
 } // namespace duckdb

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -144,8 +144,9 @@ SinkNextBatchType PipelineExecutor::NextBatch(duckdb::DataChunk &source_chunk) {
 #endif
 	auto current_batch = partition_info.batch_index.GetIndex();
 	partition_info.batch_index = next_batch_index;
+	OperatorSinkNextBatchInput next_batch_input {*pipeline.sink->sink_state, *local_sink_state, interrupt_state};
 	// call NextBatch before updating min_batch_index to provide the opportunity to flush the previous batch
-	auto next_batch_result = pipeline.sink->NextBatch(context, *pipeline.sink->sink_state, *local_sink_state);
+	auto next_batch_result = pipeline.sink->NextBatch(context, next_batch_input);
 
 	if (next_batch_result == SinkNextBatchType::BLOCKED) {
 		partition_info.batch_index = current_batch; // set batch_index back to what it was before


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/9562 to expose the newly added pause capability to custom operator implementations.