### PR TITLE
Ci: Fix trigger of 'needs maintainer approval' job

### DIFF
--- a/.github/workflows/PRNeedsMaintainerApproval.yml
+++ b/.github/workflows/PRNeedsMaintainerApproval.yml
@@ -1,6 +1,6 @@
 name: Pull Request Requires Maintainer Approval
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 


### PR DESCRIPTION
Followup of #8853: this one uses the correct trigger which allows it to access the secret github token.