### PR TITLE
Fix HeaderFilterRegex in .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 Checks:          '-*,clang-diagnostic-*,bugprone-*,performance-*,google-explicit-constructor,google-build-using-namespace,google-runtime-int,misc-definitions-in-headers,modernize-use-nullptr,modernize-use-override,-bugprone-macro-parentheses,readability-braces-around-statements,-bugprone-branch-clone,readability-identifier-naming,hicpp-exception-baseclass,misc-throw-by-value-catch-by-reference,-bugprone-signed-char-misuse,-bugprone-misplaced-widening-cast,-bugprone-sizeof-expression,-bugprone-narrowing-conversions,-bugprone-easily-swappable-parameters,google-global-names-in-headers,llvm-header-guard,misc-definitions-in-headers,modernize-use-emplace,modernize-use-bool-literals,-performance-inefficient-string-concatenation,-performance-no-int-to-ptr,readability-container-size-empty,cppcoreguidelines-pro-type-cstyle-cast'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*^(re2.h)'
+HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:

--- a/third_party/re2/re2/filtered_re2.h
+++ b/third_party/re2/re2/filtered_re2.h
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// NOLINTBEGIN
+
 #ifndef RE2_FILTERED_RE2_H_
 #define RE2_FILTERED_RE2_H_
 
@@ -108,3 +110,5 @@ class FilteredRE2 {
 }  // namespace duckdb_re2
 
 #endif  // RE2_FILTERED_RE2_H_
+
+// NOLINTEND

--- a/third_party/re2/re2/re2.h
+++ b/third_party/re2/re2/re2.h
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// NOLINTBEGIN
+
 #ifndef RE2_RE2_H_
 #define RE2_RE2_H_
 
@@ -953,3 +955,5 @@ using duckdb_re2::RE2;
 using duckdb_re2::LazyRE2;
 
 #endif  // RE2_RE2_H_
+
+// NOLINTEND


### PR DESCRIPTION
As discussed in #9537, the `HeaderFilterRegex` in `.clang-tidy` only matches `re2.h`. This results in almost all header files not checked by clang-tidy.

I runned `make tidy-check` after fixing it and there are a lot of errors now.