### PR TITLE
chore: bump iceberg version

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -39,7 +39,7 @@ endif()
 duckdb_extension_load(iceberg
         ${LOAD_ICEBERG_TESTS}
         GIT_URL https://github.com/duckdblabs/duckdb_iceberg
-        GIT_TAG ca70abdbd1e446b5e58b3dd1b3b4fcc072345445
+        GIT_TAG 8d8253200ea4f318e2fc9c0ced7960fe82344254
         )
 
 ################# POSTGRES_SCANNER


### PR DESCRIPTION
We would like to start using https://github.com/duckdb/duckdb/blob/main/.github/config/out_of_tree_extensions.cmake as the golden source-of-truth when it comes to bumping ddb out-of-tree extensions versions. We noticed that the iceberg version pinned at the moment, however, does not work in our build system since the [changes](https://github.com/motherduckdb/duckdb_iceberg/commit/e7e8543dc22e9c37e66f454346fe89bff3a7f1fe) @peterboncz put in aren't yet included in the current hash (i.e. `ca70abdbd1e446b5e58b3dd1b3b4fcc072345445`). Seeing that no major/breaking changes went into iceberg since then, wonder if we could just pin iceberg version to the latest (i.e. `8d8253200ea4f318e2fc9c0ced7960fe82344254 `) for the 0.9.2 release.