### PR TITLE
Fix #9548 - Throw a more clear error when using parameters inside of the source of a top-level PIVOT statement

### DIFF
--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -48,6 +48,7 @@ class Transformer {
 		unique_ptr<SelectNode> base;
 		unique_ptr<ParsedExpression> column;
 		unique_ptr<QueryNode> subquery;
+		bool has_parameters;
 	};
 
 public:
@@ -90,7 +91,7 @@ private:
 	bool GetParam(const string &name, idx_t &index, PreparedParamType type);
 
 	void AddPivotEntry(string enum_name, unique_ptr<SelectNode> source, unique_ptr<ParsedExpression> column,
-	                   unique_ptr<QueryNode> subquery);
+	                   unique_ptr<QueryNode> subquery, bool has_parameters);
 	unique_ptr<SQLStatement> GenerateCreateEnumStmt(unique_ptr<CreatePivotEntry> entry);
 	bool HasPivotEntries();
 	idx_t PivotEntryCount();

--- a/test/sql/pivot/pivot_prepare.test
+++ b/test/sql/pivot/pivot_prepare.test
@@ -7,27 +7,27 @@ CREATE OR REPLACE TABLE monthly_sales(empid INT, amount INT, month TEXT);
 
 statement ok
 INSERT INTO monthly_sales VALUES
-    (1, 10000, 'JAN'),
-    (1, 400, 'JAN'),
-    (2, 4500, 'JAN'),
-    (2, 35000, 'JAN'),
-    (1, 5000, 'FEB'),
-    (1, 3000, 'FEB'),
-    (2, 200, 'FEB'),
-    (2, 90500, 'FEB'),
-    (1, 6000, 'MAR'),
-    (1, 5000, 'MAR'),
-    (2, 2500, 'MAR'),
-    (2, 9500, 'MAR'),
-    (1, 8000, 'APR'),
-    (1, 10000, 'APR'),
-    (2, 800, 'APR'),
-    (2, 4500, 'APR');
+    (1, 10000, '1-JAN'),
+    (1, 400, '1-JAN'),
+    (2, 4500, '1-JAN'),
+    (2, 35000, '1-JAN'),
+    (1, 5000, '2-FEB'),
+    (1, 3000, '2-FEB'),
+    (2, 200, '2-FEB'),
+    (2, 90500, '2-FEB'),
+    (1, 6000, '3-MAR'),
+    (1, 5000, '3-MAR'),
+    (2, 2500, '3-MAR'),
+    (2, 9500, '3-MAR'),
+    (1, 8000, '4-APR'),
+    (1, 10000, '4-APR'),
+    (2, 800, '4-APR'),
+    (2, 4500, '4-APR');
 
 statement ok
 PREPARE v1 AS SELECT *
   FROM monthly_sales
-    PIVOT(SUM(amount + ?) FOR MONTH IN ('JAN', 'FEB', 'MAR', 'APR'))
+    PIVOT(SUM(amount + ?) FOR MONTH IN ('1-JAN', '2-FEB', '3-MAR', '4-APR'))
       AS p
   ORDER BY EMPID;
 
@@ -43,3 +43,21 @@ EXECUTE v1(1)
 ----
 1	10402	8002	11002	18002
 2	39502	90702	12002	5302
+
+# prepare top-level pivot stmt
+statement ok
+PREPARE v2 AS
+   PIVOT monthly_sales ON MONTH USING SUM(AMOUNT + ?)
+
+query IIIII rowsort
+EXECUTE v2(1)
+----
+1	10402	8002	11002	18002
+2	39502	90702	12002	5302
+
+# parameters within subquery of top-level pivot statement not supported
+statement error
+PREPARE v3 AS
+   PIVOT (SELECT empid, amount + ? AS amount, month FROM monthly_sales) ON MONTH USING SUM(AMOUNT)
+----
+cannot have parameters in their source


### PR DESCRIPTION
Fixes #9548 

Top-level pivot statements currently do not support prepared statement parameters within their data source - as the source is duplicated and spread over multiple SQL statements. This PR detects when this occurs and throws a more descriptive error message hinting that the generic PIVOT must be used instead where the pivot values are explicitly stated.

```sql
D PREPARE v1 AS (PIVOT (SELECT ? AS year) ON year);
Error: Parser Error: PIVOT statements with pivot elements extracted from the data cannot have parameters in their source.
In order to use parameters the PIVOT values must be manually specified, e.g.:
PIVOT ... ON "year" IN (val1, val2, ...)
```