### PR TITLE
C-API: support streaming arrow query 2

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2471,6 +2471,15 @@ Fetch the internal arrow schema from the prepared statement.
 */
 DUCKDB_API duckdb_state duckdb_prepared_arrow_schema(duckdb_prepared_statement prepared,
                                                      duckdb_arrow_schema *out_schema);
+
+/*!
+Fetch the internal arrow schema from the query result.
+
+* result: The result object to fetch the schema from.
+* out_schema: The output schema.
+*/
+DUCKDB_API duckdb_state duckdb_result_arrow_schema(duckdb_result result, duckdb_arrow_schema *out_schema);
+
 /*!
 Convert a data chunk into an arrow struct array.
 
@@ -2478,7 +2487,8 @@ Convert a data chunk into an arrow struct array.
 * chunk: The data chunk to convert.
 * out_array: The output array.
 */
-DUCKDB_API void duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, duckdb_arrow_array *out_array);
+DUCKDB_API duckdb_state duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk,
+                                                  duckdb_arrow_array *out_array);
 
 /*!
 Fetch an internal arrow struct array from the arrow result.

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -88,14 +88,25 @@ duckdb_state duckdb_query_arrow_array(duckdb_arrow result, duckdb_arrow_array *o
 	return DuckDBSuccess;
 }
 
-void duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, duckdb_arrow_array *out_array) {
+duckdb_state duckdb_result_arrow_schema(duckdb_result result, duckdb_arrow_schema *out_schema) {
+	if (!out_schema) {
+		return DuckDBSuccess;
+	}
+	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result.internal_data));
+	ArrowConverter::ToArrowSchema((ArrowSchema *)*out_schema, result_data.result->types, result_data.result->names,
+	                              result_data.result->client_properties);
+	return DuckDBSuccess;
+}
+
+duckdb_state duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, duckdb_arrow_array *out_array) {
 	if (!out_array) {
-		return;
+		return DuckDBSuccess;
 	}
 	auto dchunk = reinterpret_cast<duckdb::DataChunk *>(chunk);
 	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result.internal_data));
 	ArrowConverter::ToArrowArray(*dchunk, reinterpret_cast<ArrowArray *>(*out_array),
 	                             result_data.result->client_properties);
+	return DuckDBSuccess;
 }
 
 idx_t duckdb_arrow_row_count(duckdb_arrow result) {

--- a/test/api/capi/test_capi_streaming.cpp
+++ b/test/api/capi/test_capi_streaming.cpp
@@ -124,7 +124,17 @@ TEST_CASE("Test streaming arrow results in C API", "[capi][arrow]") {
 
 	// Check handle null out_array
 	duckdb_result_arrow_array(result->InternalResult(), chunk->GetChunk(), nullptr);
+	// Check handle null out_schema
+	duckdb_result_arrow_schema(result->InternalResult(), nullptr);
 
+	// Query schema
+	ArrowSchema *arrow_schema = new ArrowSchema();
+	duckdb_result_arrow_schema(result->InternalResult(), (duckdb_arrow_schema *)&arrow_schema);
+	REQUIRE(string(arrow_schema->name) == "duckdb_query_result");
+	arrow_schema->release(arrow_schema);
+	delete arrow_schema;
+
+	// Query content
 	int nb_row = 0;
 	while (chunk) {
 		ArrowArray *arrow_array = new ArrowArray();


### PR DESCRIPTION
Following my previous PR #8642.

Add `duckdb_result_arrow_schema` to fetch arrow schema from a query result.