### PR TITLE
User agent in http header

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -273,8 +273,7 @@ void ExtensionHelper::InstallExtensionInternal(DBConfig &config, ClientConfig *c
 	auto url_base = "http://" + hostname_without_http;
 	duckdb_httplib::Client cli(url_base.c_str());
 
-	duckdb_httplib::Headers headers = {{"User-Agent", StringUtil::Format("DuckDB %s %s %s", DuckDB::LibraryVersion(),
-	                                                                     DuckDB::SourceID(), DuckDB::Platform())}};
+	duckdb_httplib::Headers headers = {{"User-Agent", StringUtil::Format("%s %s", config.UserAgent(), DuckDB::SourceID())}};
 
 	auto res = cli.Get(url_local_part.c_str(), headers);
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -273,7 +273,8 @@ void ExtensionHelper::InstallExtensionInternal(DBConfig &config, ClientConfig *c
 	auto url_base = "http://" + hostname_without_http;
 	duckdb_httplib::Client cli(url_base.c_str());
 
-	duckdb_httplib::Headers headers = {{"User-Agent", StringUtil::Format("%s %s", config.UserAgent(), DuckDB::SourceID())}};
+	duckdb_httplib::Headers headers = {
+	    {"User-Agent", StringUtil::Format("%s %s", config.UserAgent(), DuckDB::SourceID())}};
 
 	auto res = cli.Get(url_local_part.c_str(), headers);
 


### PR DESCRIPTION
This is a follow up from https://github.com/duckdb/duckdb/pull/9603#issuecomment-1803132634.

`DBConfig::UserAgent()` does not have the git SHA, so I kept `DuckDB::SourceID()` as the last token in the HTTP User-Agent header sent.


CLI Before:
```
GET /v0.9.1/linux_amd64/httpfs.duckdb_extension.gz HTTP/1.1
User-Agent: DuckDB 0.9.1 19862840b8 linux_amd64
```

CLI After:
```
GET /v0.9.1/linux_amd64/httpfs.duckdb_extension.gz HTTP/1.1
User-Agent: duckdb/0.9.1(linux_amd64) 19862840b8
```

Example from a Go app
```
GET /v0.9.1/linux_amd64/httpfs.duckdb_extension.gz HTTP/1.1
User-Agent: duckdb/0.9.1(linux_amd64) capi 19862840b8
```