### PR TITLE
Fix #8095: Adjust the LG_PAGE parameter in jemalloc to accommodate the 64KB PAGE SIZE in aarch64 Linux systems.

### DIFF
--- a/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -220,7 +220,7 @@ namespace duckdb_jemalloc {
 #elif defined(COMPILER_MSVC) && defined(_M_IX86)
 #define LG_PAGE 12
 #elif defined(__aarch64__)
-#define LG_PAGE 14
+#define LG_PAGE 16
 #elif defined(__ARM_ARCH)
 #define LG_PAGE 14
 #else


### PR DESCRIPTION
Some aarch64 Linux systems have their kernel PAGE SIZE set to 64KB by default. 
In this case, "Out of Memory Error" will be throw.
To accommodate this, setting LG_PAGE to 16 in jemalloc might be more appropriate.

Edit by @szarnyasg: fixes #8095