### PR TITLE
fix 9232

### DIFF
--- a/extension/json/buffered_json_reader.cpp
+++ b/extension/json/buffered_json_reader.cpp
@@ -23,7 +23,7 @@ bool JSONFileHandle::IsOpen() const {
 }
 
 void JSONFileHandle::Close() {
-	if (IsOpen() && file_handle->OnDiskFile()) {
+	if (IsOpen() && !file_handle->IsPipe()) {
 		file_handle->Close();
 		file_handle = nullptr;
 	}

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -344,7 +344,7 @@ bool FileSystem::FileExists(const string &filename) {
 }
 
 bool FileSystem::IsPipe(const string &filename) {
-	throw NotImplementedException("%s: IsPipe is not implemented!", GetName());
+	return false;
 }
 
 void FileSystem::RemoveFile(const string &filename) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -500,6 +500,10 @@ bool FileHandle::CanSeek() {
 	return file_system.CanSeek();
 }
 
+bool FileHandle::IsPipe() {
+	return file_system.IsPipe(path);
+}
+
 string FileHandle::ReadLine() {
 	string result;
 	char buffer[1];

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -66,6 +66,7 @@ public:
 	DUCKDB_API string ReadLine();
 
 	DUCKDB_API bool CanSeek();
+	DUCKDB_API bool IsPipe();
 	DUCKDB_API bool OnDiskFile();
 	DUCKDB_API idx_t GetFileSize();
 	DUCKDB_API FileType GetType();

--- a/src/include/duckdb/common/pipe_file_system.hpp
+++ b/src/include/duckdb/common/pipe_file_system.hpp
@@ -28,6 +28,9 @@ public:
 	bool CanSeek() override {
 		return false;
 	}
+	bool IsPipe(const string& path) override {
+		return true;
+	}
 	void FileSync(FileHandle &handle) override;
 
 	std::string GetName() const override {

--- a/src/include/duckdb/common/pipe_file_system.hpp
+++ b/src/include/duckdb/common/pipe_file_system.hpp
@@ -28,7 +28,7 @@ public:
 	bool CanSeek() override {
 		return false;
 	}
-	bool IsPipe(const string& path) override {
+	bool IsPipe(const string &filename) override {
 		return true;
 	}
 	void FileSync(FileHandle &handle) override;


### PR DESCRIPTION
Followup of https://github.com/duckdb/duckdb/pull/9074
fixes https://github.com/duckdb/duckdb/issues/9232

httpfs files were left open, which in combination with keep-alive tcp connections would run into the limit of max open connections.

The solution is is a bit hacky, but wanted to get this in before 0.9.2 @Mytherin 