### PR TITLE
add option for keep_alive setting

### DIFF
--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -28,6 +28,10 @@ static void LoadInternal(DatabaseInstance &instance) {
 	config.AddExtensionOption("http_retry_backoff",
 	                          "Backoff factor for exponentially increasing retry wait time (default 4)",
 	                          LogicalType::FLOAT, Value(4));
+	config.AddExtensionOption(
+	    "http_keep_alive",
+	    "Keep alive connections. Setting this to false can help when running into connection failures",
+	    LogicalType::BOOLEAN, Value(true));
 	// Global S3 config
 	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -35,12 +35,14 @@ struct HTTPParams {
 	static constexpr uint64_t DEFAULT_RETRY_WAIT_MS = 100;
 	static constexpr float DEFAULT_RETRY_BACKOFF = 4;
 	static constexpr bool DEFAULT_FORCE_DOWNLOAD = false;
+	static constexpr bool DEFAULT_KEEP_ALIVE = true;
 
 	uint64_t timeout;
 	uint64_t retries;
 	uint64_t retry_wait_ms;
 	float retry_backoff;
 	bool force_download;
+	bool keep_alive;
 
 	static HTTPParams ReadFrom(FileOpener *opener);
 };

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -210,6 +210,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"http_retry_backoff", "httpfs"},
     {"http_retry_wait_ms", "httpfs"},
     {"http_timeout", "httpfs"},
+    {"http_keep_alive", "httpfs"},
     {"pg_debug_show_queries", "postgres_scanner"},
     {"pg_use_binary_copy", "postgres_scanner"},
     {"pg_experimental_filter_pushdown", "postgres_scanner"},

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -48,6 +48,9 @@ SET http_retry_backoff=1;
 statement ok
 SET http_timeout=50000;
 
+statement ok
+SET http_keep_alive=false;
+
 # Test the vhost style urls (this is the default)
 statement ok
 SET s3_url_style='${url_style}';


### PR DESCRIPTION
As demonstrated by https://github.com/duckdb/duckdb/pull/9647, keep alive connections results in a limit to how many open httpfs files we can have. Adding this as an option is pretty sane as it provides a workaround for situation where duckdb might open a lot of files.