### PR TITLE
Serialize decimal quantiles

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -64,7 +64,7 @@
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/types/vector_buffer.hpp"
-#include "duckdb/core_functions/aggregate/holistic_functions.hpp"
+#include "duckdb/core_functions/aggregate/quantile_enum.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 #include "duckdb/execution/index/art/node.hpp"
 #include "duckdb/execution/operator/scan/csv/base_csv_reader.hpp"

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -64,6 +64,7 @@
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/types/vector_buffer.hpp"
+#include "duckdb/core_functions/aggregate/holistic_functions.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 #include "duckdb/execution/index/art/node.hpp"
 #include "duckdb/execution/operator/scan/csv/base_csv_reader.hpp"
@@ -4567,6 +4568,44 @@ ProfilerPrintFormat EnumUtil::FromString<ProfilerPrintFormat>(const char *value)
 	}
 	if (StringUtil::Equals(value, "QUERY_TREE_OPTIMIZER")) {
 		return ProfilerPrintFormat::QUERY_TREE_OPTIMIZER;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<QuantileSerializationType>(QuantileSerializationType value) {
+	switch(value) {
+	case QuantileSerializationType::NON_DECIMAL:
+		return "NON_DECIMAL";
+	case QuantileSerializationType::DECIMAL_DISCRETE:
+		return "DECIMAL_DISCRETE";
+	case QuantileSerializationType::DECIMAL_DISCRETE_LIST:
+		return "DECIMAL_DISCRETE_LIST";
+	case QuantileSerializationType::DECIMAL_CONTINUOUS:
+		return "DECIMAL_CONTINUOUS";
+	case QuantileSerializationType::DECIMAL_CONTINUOUS_LIST:
+		return "DECIMAL_CONTINUOUS_LIST";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+QuantileSerializationType EnumUtil::FromString<QuantileSerializationType>(const char *value) {
+	if (StringUtil::Equals(value, "NON_DECIMAL")) {
+		return QuantileSerializationType::NON_DECIMAL;
+	}
+	if (StringUtil::Equals(value, "DECIMAL_DISCRETE")) {
+		return QuantileSerializationType::DECIMAL_DISCRETE;
+	}
+	if (StringUtil::Equals(value, "DECIMAL_DISCRETE_LIST")) {
+		return QuantileSerializationType::DECIMAL_DISCRETE_LIST;
+	}
+	if (StringUtil::Equals(value, "DECIMAL_CONTINUOUS")) {
+		return QuantileSerializationType::DECIMAL_CONTINUOUS;
+	}
+	if (StringUtil::Equals(value, "DECIMAL_CONTINUOUS_LIST")) {
+		return QuantileSerializationType::DECIMAL_CONTINUOUS_LIST;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -511,7 +511,8 @@ struct QuantileBindData : public FunctionData {
 		deserializer.ReadProperty(101, "order", result->order);
 		deserializer.ReadProperty(102, "desc", result->desc);
 		QuantileSerializationType deserialization_type;
-		deserializer.ReadPropertyWithDefault(103, "type", deserialization_type, QuantileSerializationType::NON_DECIMAL);
+		deserializer.ReadPropertyWithDefault(103, "quantile_type", deserialization_type,
+		                                     QuantileSerializationType::NON_DECIMAL);
 
 		if (deserialization_type != QuantileSerializationType::NON_DECIMAL) {
 			LogicalType arg_type;
@@ -530,7 +531,8 @@ struct QuantileBindData : public FunctionData {
 	                                     const AggregateFunction &function) {
 		Serialize(serializer, bind_data_p, function);
 
-		serializer.WritePropertyWithDefault<int>(103, "flag", 1, 0);
+		serializer.WritePropertyWithDefault<QuantileSerializationType>(
+		    103, "quantile_type", QuantileSerializationType::DECIMAL_DISCRETE, QuantileSerializationType::NON_DECIMAL);
 		serializer.WriteProperty(104, "logical_type", function.arguments[0]);
 	}
 	static void SerializeDecimalDiscreteList(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
@@ -538,14 +540,18 @@ struct QuantileBindData : public FunctionData {
 
 		Serialize(serializer, bind_data_p, function);
 
-		serializer.WritePropertyWithDefault<int>(103, "flag", 2, 0);
+		serializer.WritePropertyWithDefault<QuantileSerializationType>(103, "quantile_type",
+		                                                               QuantileSerializationType::DECIMAL_DISCRETE_LIST,
+		                                                               QuantileSerializationType::NON_DECIMAL);
 		serializer.WriteProperty(104, "logical_type", function.arguments[0]);
 	}
 	static void SerializeDecimalContinuous(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
 	                                       const AggregateFunction &function) {
 		Serialize(serializer, bind_data_p, function);
 
-		serializer.WritePropertyWithDefault<int>(103, "flag", 3, 0);
+		serializer.WritePropertyWithDefault<QuantileSerializationType>(103, "quantile_type",
+		                                                               QuantileSerializationType::DECIMAL_CONTINUOUS,
+		                                                               QuantileSerializationType::NON_DECIMAL);
 		serializer.WriteProperty(104, "logical_type", function.arguments[0]);
 	}
 	static void SerializeDecimalContinuousList(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
@@ -553,7 +559,9 @@ struct QuantileBindData : public FunctionData {
 
 		Serialize(serializer, bind_data_p, function);
 
-		serializer.WritePropertyWithDefault<int>(103, "flag", 4, 0);
+		serializer.WritePropertyWithDefault<QuantileSerializationType>(
+		    103, "quantile_type", QuantileSerializationType::DECIMAL_CONTINUOUS_LIST,
+		    QuantileSerializationType::NON_DECIMAL);
 		serializer.WriteProperty(104, "logical_type", function.arguments[0]);
 	}
 

--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/core_functions/aggregate/holistic_functions.hpp"
+#include "duckdb/core_functions/aggregate/quantile_enum.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/operator/abs.hpp"

--- a/src/function/function_set.cpp
+++ b/src/function/function_set.cpp
@@ -49,7 +49,7 @@ AggregateFunction AggregateFunctionSet::GetFunctionByArguments(ClientContext &co
 			}
 			bool is_prefix = true;
 			for (idx_t k = 0; k < arguments.size(); k++) {
-				if (arguments[k] != func.arguments[k]) {
+				if (arguments[k].id() != func.arguments[k].id()) {
 					is_prefix = false;
 					break;
 				}

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -208,6 +208,8 @@ enum class PreparedParamType : uint8_t;
 
 enum class ProfilerPrintFormat : uint8_t;
 
+enum class QuantileSerializationType : uint8_t;
+
 enum class QueryNodeType : uint8_t;
 
 enum class QueryResultType : uint8_t;
@@ -556,6 +558,9 @@ const char* EnumUtil::ToChars<PreparedParamType>(PreparedParamType value);
 
 template<>
 const char* EnumUtil::ToChars<ProfilerPrintFormat>(ProfilerPrintFormat value);
+
+template<>
+const char* EnumUtil::ToChars<QuantileSerializationType>(QuantileSerializationType value);
 
 template<>
 const char* EnumUtil::ToChars<QueryNodeType>(QueryNodeType value);
@@ -947,6 +952,9 @@ PreparedParamType EnumUtil::FromString<PreparedParamType>(const char *value);
 
 template<>
 ProfilerPrintFormat EnumUtil::FromString<ProfilerPrintFormat>(const char *value);
+
+template<>
+QuantileSerializationType EnumUtil::FromString<QuantileSerializationType>(const char *value);
 
 template<>
 QueryNodeType EnumUtil::FromString<QueryNodeType>(const char *value);

--- a/src/include/duckdb/core_functions/aggregate/holistic_functions.hpp
+++ b/src/include/duckdb/core_functions/aggregate/holistic_functions.hpp
@@ -84,4 +84,12 @@ struct ReservoirQuantileFun {
 	static AggregateFunctionSet GetFunctions();
 };
 
+enum class QuantileSerializationType : uint8_t {
+	NON_DECIMAL = 0,
+	DECIMAL_DISCRETE,
+	DECIMAL_DISCRETE_LIST,
+	DECIMAL_CONTINUOUS,
+	DECIMAL_CONTINUOUS_LIST
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/core_functions/aggregate/holistic_functions.hpp
+++ b/src/include/duckdb/core_functions/aggregate/holistic_functions.hpp
@@ -84,12 +84,4 @@ struct ReservoirQuantileFun {
 	static AggregateFunctionSet GetFunctions();
 };
 
-enum class QuantileSerializationType : uint8_t {
-	NON_DECIMAL = 0,
-	DECIMAL_DISCRETE,
-	DECIMAL_DISCRETE_LIST,
-	DECIMAL_CONTINUOUS,
-	DECIMAL_CONTINUOUS_LIST
-};
-
 } // namespace duckdb

--- a/src/include/duckdb/core_functions/aggregate/quantile_enum.hpp
+++ b/src/include/duckdb/core_functions/aggregate/quantile_enum.hpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/core_functions/aggregate/quantile_enum.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace duckdb {
+
+enum class QuantileSerializationType : uint8_t {
+	NON_DECIMAL = 0,
+	DECIMAL_DISCRETE,
+	DECIMAL_DISCRETE_LIST,
+	DECIMAL_CONTINUOUS,
+	DECIMAL_CONTINUOUS_LIST
+};
+
+}

--- a/test/sql/aggregate/quantile_fun.test
+++ b/test/sql/aggregate/quantile_fun.test
@@ -1,0 +1,51 @@
+# name: test/sql/aggregate/quantile_fun.test
+# description: Test pg_sequence function
+# group: [aggregate]
+
+require tpch
+
+# scalar quantiles
+statement ok
+create table quantiles as select range r, random() FROM range(100) union all values (NULL, 0.1), (NULL, 0.5), (NULL, 0.9) order by 2;
+
+statement ok
+CALL dbgen(sf=0.001);
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+PRAGMA verify_external;
+
+statement ok
+SELECT quantile_disc(0.1::decimal(4,1), [0.1, 0.5, 0.9]);
+
+statement ok
+SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY "l_extendedprice") FROM lineitem;
+
+statement ok
+SET default_null_order='nulls_first';
+
+foreach type decimal(4,1) decimal(8,1) decimal(12,1) decimal(18,1) decimal(24,1)
+
+query I
+SELECT quantile_disc(r::${type}, 0.1) FROM quantiles
+----
+9.0
+
+query I
+SELECT quantile_disc(r::${type}, [0.1, 0.5, 0.9]) FROM quantiles
+----
+[9.0, 49.0, 89.0]
+
+query I
+SELECT quantile_cont(r::${type}, 0.15) FROM quantiles
+----
+14.8
+
+query I
+SELECT quantile_cont(r::${type}, [0.15, 0.5, 0.9]) FROM quantiles
+----
+[14.8, 49.5, 89.1]
+
+endloop


### PR DESCRIPTION
Solution is somehow custom-made, open to suggestions on how to make it more similar to the rest of the Serialization code.

Two main changes (independent but both needed):

* Have that DECIMAL and DECIMAL(X,Y) are a match while looking for overloads in `src/function/function_set.cpp`
* Encode (as a optionally serialisable field) type information (both on function and argument)

This PR will make so that databases that serialize quantile decimal to storage could not be read by previous version of DuckDB. But given the current case is that those statement are illegal to serialize, it should be anyhow be an improvement.

Main improvement I can think of (and that probably I should implement straight away), is moving the integer flag to an enum. There is anything else that needs addressing?