### PR TITLE
Fix #9308 - avoid pruning plan for ANTI join with filter that is always true

### DIFF
--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -108,10 +108,6 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 						*node_ptr = std::move(cross_product);
 						return;
 					}
-					case JoinType::ANTI:
-						// anti join on true: empty result
-						ReplaceWithEmptyResult(*node_ptr);
-						return;
 					default:
 						// we don't handle mark/single join here yet
 						break;

--- a/test/sql/subquery/exists/test_issue_9308.test
+++ b/test/sql/subquery/exists/test_issue_9308.test
@@ -1,0 +1,25 @@
+# name: test/sql/subquery/exists/test_issue_9308.test
+# description: Issue #9308: wrong result: NOT EXISTS predicate with correlated non-equality comparison
+# group: [exists]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create or replace table t1(c1 int64);
+
+statement ok
+insert into t1 values (1);
+
+statement ok
+create or replace table t2(c1 int64);
+
+query II
+select c1, not exists (select 1 from t2 where t1.c1 <= t2.c1) from t1;
+----
+1	true
+
+query I
+select c1 from t1 where not exists (select 1 from t2 where t1.c1 <= t2.c1);
+----
+1


### PR DESCRIPTION
Fixes #9308 

When an ANTI join is performed on a condition that is proven to be true for every row in the data set the result is the empty set ONLY when the RHS is not empty. The current statistics propagation optimizer always returns the empty set which is incorrect if the RHS is empty. This PR removes this specific optimization for anti joins.