### PR TITLE
Shell: Set `globalDb` to `NULL` after closing database

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -17996,6 +17996,7 @@ static int do_meta_command(char *zLine, ShellState *p){
     session_close_all(p);
     close_db(p->db);
     p->db = 0;
+    globalDb = 0;
     p->zDbFilename = 0;
     sqlite3_free(p->zFreeOnClose);
     p->zFreeOnClose = 0;


### PR DESCRIPTION
### The Issue

In _shell.c_, after calling `close_db`, the pointer to the `sqlite3` database is set to NULL in the `ShellState`.

https://github.com/duckdb/duckdb/blob/1f04c207eb67711acd89265fba210c57716d9f3f/tools/shell/shell.c#L17997-L17998


However, there is another pointer `globalDb` which is now dangling. `globalDb` is initialized when opening a new database (in `open_db`).

`close_db` calls `sqlite3_close` which frees the memory which `globalDb` points to.

https://github.com/duckdb/duckdb/blob/1f04c207eb67711acd89265fba210c57716d9f3f/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp#L140-L145

When pressing CTRL+C and the `interrupt_handler` is executed after the call to `close_db`, it passes the dangling pointer to `sqlite3_interrupt`, which tries to use `db->con`, leading to a heap use after free and therefore segmentation fault.

https://github.com/duckdb/duckdb/blob/1f04c207eb67711acd89265fba210c57716d9f3f/tools/shell/shell.c#L11342

https://github.com/duckdb/duckdb/blob/1f04c207eb67711acd89265fba210c57716d9f3f/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp#L854-L858

### The Fix

After the call to `close_db`, do not only set the `sqlite3` pointer in `ShellState` to NULL, but also `globalDb`. I have looked for similar situations in the code of _shell.c_, but have not found any (I might have overlooked something, though).

### The Repro

I could not reproduce this error with vanilla DuckDB. But the segmentation fault occurs when using the MotherDuck extension (thanks @carlopi for raising the issue).
1. Open some database
2. Call `.open md:`,
3. Press CRTL+C while `sqlite3_open` has not returned yet
`sqlite3_open` might take a long when using MotherDuck when users first have to log in with their browser.