### PR TITLE
[JDBC] Sync all methods from a statement that interact with a query result

### DIFF
--- a/tools/jdbc/src/jni/duckdb_java.cpp
+++ b/tools/jdbc/src/jni/duckdb_java.cpp
@@ -994,6 +994,9 @@ void _duckdb_jdbc_appender_append_null(JNIEnv *env, jclass, jobject appender_ref
 }
 
 jlong _duckdb_jdbc_arrow_stream(JNIEnv *env, jclass, jobject res_ref_buf, jlong batch_size) {
+	if (!res_ref_buf) {
+		throw InvalidInputException("Invalid result set");
+	}
 	auto res_ref = (ResultHolder *)env->GetDirectBufferAddress(res_ref_buf);
 	if (!res_ref || !res_ref->res || res_ref->res->HasError()) {
 		throw InvalidInputException("Invalid result set");

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -291,6 +291,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
     public void close() throws SQLException {
         if (select_result != null) {
             select_result.close();
+            select_result = null;
         }
         if (stmt_ref != null) {
             DuckDBNative.duckdb_jdbc_release(stmt_ref);

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -72,7 +72,7 @@ public class DuckDBResultSet implements ResultSet {
         return meta;
     }
 
-    public boolean next() throws SQLException {
+    public synchronized boolean next() throws SQLException {
         if (isClosed()) {
             throw new SQLException("ResultSet was closed");
         }
@@ -109,7 +109,7 @@ public class DuckDBResultSet implements ResultSet {
         close();
     }
 
-    public boolean isClosed() throws SQLException {
+    public synchronized boolean isClosed() throws SQLException {
         return result_ref == null;
     }
 
@@ -129,7 +129,8 @@ public class DuckDBResultSet implements ResultSet {
      * @param arrow_batch_size batch size of arrow vectors to return
      * @return an instance of {@link org.apache.arrow.vector.ipc.ArrowReader}
      */
-    public Object arrowExportStream(Object arrow_buffer_allocator, long arrow_batch_size) throws SQLException {
+    public synchronized Object arrowExportStream(Object arrow_buffer_allocator, long arrow_batch_size)
+        throws SQLException {
         if (isClosed()) {
             throw new SQLException("Result set is closed");
         }

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -146,6 +146,21 @@ public class TestDuckDBJDBC {
         throw new Exception("Expected to throw " + exception.getName());
     }
 
+    // Asserts we are either throwing the correct exception, or not throwing at all
+    private static <T extends Throwable> boolean assertThrowsMaybe(Thrower thrower, Class<T> exception)
+        throws Exception {
+        try {
+            thrower.run();
+            return true;
+        } catch (Throwable e) {
+            if (e.getClass().equals(exception)) {
+                return true;
+            } else {
+                throw new Exception("Unexpected exception: " + e.getClass().getName());
+            }
+        }
+    }
+
     static {
         try {
             Class.forName("org.duckdb.DuckDBDriver");
@@ -179,7 +194,7 @@ public class TestDuckDBJDBC {
         throws InterruptedException {
         executor_service.submit(() -> {
             try (ResultSet resultSet = statement.executeQuery("SELECT * from foo")) {
-                assertThrows(() -> {
+                assertThrowsMaybe(() -> {
                     DuckDBResultSet duckdb_result_set = resultSet.unwrap(DuckDBResultSet.class);
                     while (duckdb_result_set.next()) {
                         // do nothing with the results

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -88,6 +88,8 @@ import static org.duckdb.DuckDBDriver.JDBC_STREAM_RESULTS;
 
 public class TestDuckDBJDBC {
 
+    private static final String JDBC_URL = "jdbc:duckdb:";
+
     private static void assertTrue(boolean val) throws Exception {
         assertTrue(val, null);
     }
@@ -152,8 +154,54 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_StatementCloseParallel() throws SQLException, InterruptedException {
+        ExecutorService executor_service = Executors.newFixedThreadPool(1);
+
+        for (int i = 0; i < 100; i++) {
+            try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+                createTable(conn);
+                try (Statement statement = conn.createStatement()) {
+                    executeStatementWithThread(statement, executor_service);
+                } catch (SQLException e) {
+                    System.out.println("Error executing statement: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    private static void createTable(Connection conn) throws SQLException {
+        try (Statement createStmt = conn.createStatement()) {
+            createStmt.execute("CREATE TABLE foo as select * from range(1000000);");
+        }
+    }
+
+    private static void executeStatementWithThread(Statement statement, ExecutorService executor_service)
+        throws InterruptedException {
+        executor_service.submit(() -> {
+            try (ResultSet resultSet = statement.executeQuery("SELECT * from foo")) {
+                assertThrows(() -> {
+                    DuckDBResultSet duckdb_result_set = resultSet.unwrap(DuckDBResultSet.class);
+                    while (duckdb_result_set.next()) {
+                        // do nothing with the results
+                    }
+                }, SQLException.class);
+
+            } catch (Exception e) {
+                System.out.println("Error executing query: " + e.getMessage());
+            }
+        });
+
+        Thread.sleep(10); // wait for query to start running
+        try {
+            statement.cancel();
+            statement.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
     public static void test_connection() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         assertTrue(conn.isValid(0));
         assertFalse(conn.isClosed());
 
@@ -224,7 +272,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_prepare_exception() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         stmt = conn.createStatement();
@@ -237,7 +285,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_execute_exception() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         assertThrows(() -> {
@@ -247,7 +295,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_autocommit_off() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         ResultSet rs;
 
@@ -304,7 +352,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_enum() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs;
@@ -449,7 +497,7 @@ public class TestDuckDBJDBC {
         try {
             TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
             System.setProperty("user.timezone", "UTC");
-            Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+            Connection conn = DriverManager.getConnection(JDBC_URL);
             Statement stmt = conn.createStatement();
 
             ResultSet rs = stmt.executeQuery(fetchSql);
@@ -480,7 +528,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_timestamp_tz() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs;
@@ -535,7 +583,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_timestamp_as_long() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs;
@@ -556,7 +604,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_timestamptz_as_long() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs;
@@ -580,7 +628,7 @@ public class TestDuckDBJDBC {
 
     public static void test_consecutive_timestamps() throws Exception {
         long expected = 986860800000L;
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement stmt = conn.createStatement()) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
             try (ResultSet rs = stmt.executeQuery(
                      "select range from range(TIMESTAMP '2001-04-10', TIMESTAMP '2001-04-11', INTERVAL 30 MINUTE)")) {
                 while (rs.next()) {
@@ -593,7 +641,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_throw_wrong_datatype() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         ResultSet rs;
 
@@ -615,7 +663,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_list_metadata() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement stmt = conn.createStatement();
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT generate_series(2) as list");) {
             ResultSetMetaData meta = rs.getMetaData();
             assertEquals(meta.getColumnCount(), 1);
@@ -626,7 +674,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_struct_metadata() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement stmt = conn.createStatement();
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT {'i': 42, 'j': 'a'} as struct")) {
             ResultSetMetaData meta = rs.getMetaData();
             assertEquals(meta.getColumnCount(), 1);
@@ -637,7 +685,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_map_metadata() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement stmt = conn.createStatement();
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT map([1,2],['a','b']) as map")) {
             ResultSetMetaData meta = rs.getMetaData();
             assertEquals(meta.getColumnCount(), 1);
@@ -648,7 +696,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_union_metadata() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement stmt = conn.createStatement();
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT union_value(str := 'three') as union")) {
             ResultSetMetaData meta = rs.getMetaData();
             assertEquals(meta.getColumnCount(), 1);
@@ -659,7 +707,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_result() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs;
@@ -733,7 +781,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_empty_table() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE a (i iNTEGER)");
@@ -748,7 +796,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_broken_next() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE t0(c0 INT8, c1 VARCHAR)");
@@ -769,9 +817,9 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_multiple_connections() throws Exception {
-        Connection conn1 = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn1 = DriverManager.getConnection(JDBC_URL);
         Statement stmt1 = conn1.createStatement();
-        Connection conn2 = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn2 = DriverManager.getConnection(JDBC_URL);
         Statement stmt2 = conn2.createStatement();
         Statement stmt3 = conn2.createStatement();
 
@@ -857,7 +905,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void duckdb_timestamp_test() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         stmt.execute("CREATE TABLE a (ts TIMESTAMP)");
 
@@ -948,7 +996,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_duckdb_localdatetime() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         stmt.execute("CREATE TABLE x (ts TIMESTAMP)");
 
@@ -973,7 +1021,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_duckdb_getObject_with_class() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         stmt.execute("CREATE TABLE b (vchar VARCHAR, bo BOOLEAN, sint SMALLINT, nint INTEGER, bigi BIGINT,"
                      + " flt FLOAT, dbl DOUBLE, dte DATE, tme TIME, ts TIMESTAMP, dec16 DECIMAL(3,1),"
@@ -1056,7 +1104,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_multiple_statements_execution() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery("CREATE TABLE integers(i integer);\n"
                                          + "insert into integers select * from range(10);"
@@ -1070,7 +1118,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_multiple_statements_exception() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         boolean succ = false;
         try {
@@ -1085,7 +1133,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_bigdecimal() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         stmt.execute(
             "CREATE TABLE q (id DECIMAL(3,0), dec16 DECIMAL(4,1), dec32 DECIMAL(9,4), dec64 DECIMAL(18,7), dec128 DECIMAL(38,10))");
@@ -1198,7 +1246,7 @@ public class TestDuckDBJDBC {
 
     // Longer, resource intensive test - might be commented out for a quick test run
     public static void test_lots_of_timestamps() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         stmt.execute("CREATE TABLE a (ts TIMESTAMP)");
 
@@ -1225,7 +1273,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_lots_of_decimals() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         // Create the table
         stmt.execute("CREATE TABLE q (id DECIMAL(4,0),dec32 DECIMAL(9,4),dec64 DECIMAL(18,7),dec128 DECIMAL(38,10))");
@@ -1304,7 +1352,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_big_data() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         int rows = 10000;
         stmt.execute("CREATE TABLE a (i iNTEGER)");
@@ -1358,7 +1406,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_crash_bug496() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE t0(c0 BOOLEAN, c1 INT)");
@@ -1369,7 +1417,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_tablepragma_bug491() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE t0(c0 INT)");
@@ -1392,7 +1440,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_nulltruth_bug489() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE t0(c0 INT)");
@@ -1420,7 +1468,7 @@ public class TestDuckDBJDBC {
                              + "INSERT INTO t1(c0) VALUES (0), (1);\n"
                              + "\n"
                              + "SELECT t0.c0 FROM t0, t1;";
-        Connection con = DriverManager.getConnection("jdbc:duckdb:");
+        Connection con = DriverManager.getConnection(JDBC_URL);
         for (String s : fileContent.split("\n")) {
             Statement st = con.createStatement();
             try {
@@ -1433,7 +1481,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_borked_string_bug539() throws Exception {
-        Connection con = DriverManager.getConnection("jdbc:duckdb:");
+        Connection con = DriverManager.getConnection(JDBC_URL);
         Statement s = con.createStatement();
         s.executeUpdate("CREATE TABLE t0 (c0 VARCHAR)");
         String q = String.format("INSERT INTO t0 VALUES('%c')", 55995);
@@ -1443,7 +1491,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_prepare_types() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
 
         PreparedStatement ps = conn.prepareStatement(
             "SELECT CAST(? AS BOOLEAN) c1, CAST(? AS TINYINT) c2, CAST(? AS SMALLINT) c3, CAST(? AS INTEGER) c4, CAST(? AS BIGINT) c5, CAST(? AS FLOAT) c6, CAST(? AS DOUBLE) c7, CAST(? AS STRING) c8");
@@ -1534,7 +1582,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_prepare_insert() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
 
         conn.createStatement().executeUpdate(
             "create table ctstable1 (TYPE_ID int, TYPE_DESC varchar(32), primary key(TYPE_ID))");
@@ -1593,7 +1641,7 @@ public class TestDuckDBJDBC {
         Path database_file = Files.createTempFile("duckdb-jdbc-test-", ".duckdb");
         Files.deleteIfExists(database_file);
 
-        String jdbc_url = "jdbc:duckdb:" + database_file;
+        String jdbc_url = JDBC_URL + database_file;
         Properties ro_prop = new Properties();
         ro_prop.setProperty("duckdb.read_only", "true");
 
@@ -1664,7 +1712,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_hugeint() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs = stmt.executeQuery(
@@ -1687,7 +1735,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_temporal_types() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs = stmt.executeQuery(
@@ -1711,7 +1759,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_calendar_types() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         //	Nail down the location for test portability.
@@ -1733,7 +1781,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_temporal_nulls() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs = stmt.executeQuery("SELECT NULL::timestamp ts, NULL::date dt, NULL::time te");
@@ -1754,7 +1802,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_evil_date() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs = stmt.executeQuery("SELECT '5131-08-05 (BC)'::date d");
@@ -1769,7 +1817,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_decimal() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs = stmt.executeQuery("SELECT '1.23'::decimal(3,2) d");
@@ -1784,7 +1832,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_schema_reflection() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         stmt.execute("CREATE TABLE a (i INTEGER)");
         stmt.execute("CREATE VIEW b AS SELECT i::STRING AS j FROM a");
@@ -1964,7 +2012,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_time_tz() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement s = conn.createStatement()) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement s = conn.createStatement()) {
             s.executeUpdate("create table t (i time with time zone)");
             try (ResultSet rs = conn.getMetaData().getColumns(null, "%", "t", "i");) {
                 rs.next();
@@ -1991,7 +2039,7 @@ public class TestDuckDBJDBC {
 
     public static void test_get_tables_with_current_catalog() throws Exception {
         ResultSet resultSet = null;
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         final String currentCatalog = conn.getCatalog();
         DatabaseMetaData databaseMetaData = conn.getMetaData();
 
@@ -2014,7 +2062,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_get_tables_with_attached_catalog() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         final String currentCatalog = conn.getCatalog();
         DatabaseMetaData databaseMetaData = conn.getMetaData();
         Statement statement = conn.createStatement();
@@ -2071,7 +2119,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_get_tables_param_binding_for_table_types() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         DatabaseMetaData databaseMetaData = conn.getMetaData();
         ResultSet rs = databaseMetaData.getTables(null, null, null,
                                                   new String[] {"') UNION ALL "
@@ -2095,7 +2143,7 @@ public class TestDuckDBJDBC {
         List<String> tableTypesList = new ArrayList<>(asList(tableTypesArray));
         tableTypesList.sort(Comparator.naturalOrder());
 
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         DatabaseMetaData databaseMetaData = conn.getMetaData();
         ResultSet rs = databaseMetaData.getTableTypes();
 
@@ -2111,7 +2159,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_get_schemas_with_params() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         String inputCatalog = conn.getCatalog();
         String inputSchema = conn.getSchema();
         DatabaseMetaData databaseMetaData = conn.getMetaData();
@@ -2187,7 +2235,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_parquet_reader() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM parquet_scan('data/parquet-testing/userdata1.parquet')");
         assertTrue(rs.next());
@@ -2198,7 +2246,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_crash_autocommit_bug939() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         PreparedStatement stmt = conn.prepareStatement("CREATE TABLE ontime(flightdate DATE)");
         conn.setAutoCommit(false); // The is the key to getting the crash to happen.
         stmt.executeUpdate();
@@ -2207,7 +2255,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_explain_bug958() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery("EXPLAIN SELECT 42");
         assertTrue(rs.next());
@@ -2220,7 +2268,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_numbers() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         // int8, int4, int2, int1, float8, float4
@@ -2267,7 +2315,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_date_and_time() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE date_and_time (id INT4, a TIMESTAMP)");
@@ -2320,7 +2368,7 @@ public class TestDuckDBJDBC {
         conn.close();
     }
     public static void test_appender_int_string() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE data (a INTEGER, s VARCHAR)");
@@ -2349,7 +2397,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_string_with_emoji() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE data (str_value VARCHAR(10))");
@@ -2373,7 +2421,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_table_does_not_exist() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         try {
@@ -2388,7 +2436,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_table_deleted() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE data (a INTEGER)");
@@ -2415,7 +2463,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_append_too_many_columns() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE data (a INTEGER)");
@@ -2434,7 +2482,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_append_too_few_columns() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE data (a INTEGER, b INTEGER)");
@@ -2453,7 +2501,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_type_mismatch() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE data (a INTEGER)");
@@ -2471,7 +2519,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_null_integer() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE data (a INTEGER)");
@@ -2496,7 +2544,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_appender_null_varchar() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         stmt.execute("CREATE TABLE data (a VARCHAR)");
@@ -2520,7 +2568,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_get_catalog() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         ResultSet rs = conn.getMetaData().getCatalogs();
         HashSet<String> set = new HashSet<String>();
         while (rs.next()) {
@@ -2533,7 +2581,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_set_catalog() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:")) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
 
             assertThrows(() -> conn.setCatalog("other"), SQLException.class);
 
@@ -2547,7 +2595,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_get_table_types_bug1258() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         stmt.execute("CREATE TABLE a1 (i INTEGER)");
         stmt.execute("CREATE TABLE a2 (i INTEGER)");
@@ -2605,7 +2653,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_utf_string_bug1271() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         ResultSet rs = stmt.executeQuery("SELECT 'Mühleisen', '🦆', '🦄ྀི123456789'");
@@ -2625,7 +2673,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_statement_creation_bug1268() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt;
 
         stmt = conn.createStatement();
@@ -2655,7 +2703,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_blob_bug1090() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         String test_str1 = "asdf";
@@ -2691,7 +2739,7 @@ public class TestDuckDBJDBC {
         // Generated by DuckDB
         String testUuid = "a0a34a0a-1794-47b6-b45c-0ac68cc03702";
 
-        try (DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
              Statement stmt = conn.createStatement();
              DuckDBResultSet rs = stmt.executeQuery("SELECT a, NULL::UUID b, a::VARCHAR c, '" + testUuid +
                                                     "'::UUID d FROM (SELECT uuid() a)")
@@ -2721,7 +2769,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_unsigned_integers() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         Statement stmt = conn.createStatement();
 
         ResultSet rs = stmt.executeQuery(
@@ -2764,7 +2812,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_get_schema() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
 
         assertEquals(conn.getSchema(), DuckDBConnection.DEFAULT_SCHEMA);
 
@@ -2793,7 +2841,7 @@ public class TestDuckDBJDBC {
      */
     public static void test_cached_row_set() throws Exception {
         CachedRowSet rowSet = RowSetProvider.newFactory().createCachedRowSet();
-        rowSet.setUrl("jdbc:duckdb:");
+        rowSet.setUrl(JDBC_URL);
         rowSet.setCommand("select 1");
         rowSet.execute();
 
@@ -2802,7 +2850,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_json() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
 
         try (Statement stmt = conn.createStatement()) {
             ResultSet rs = stmt.executeQuery("select [1, 5]::JSON");
@@ -2834,14 +2882,14 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_bug4218_prepare_types() throws Exception {
-        DuckDBConnection conn = DriverManager.getConnection("jdbc:duckdb:").unwrap(DuckDBConnection.class);
+        DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
         String query = "SELECT ($1 || $2)";
         conn.prepareStatement(query);
         assertTrue(true);
     }
 
     public static void test_bug532_timestamp() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
 
         ResultSet rs;
@@ -2855,7 +2903,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_bug966_typeof() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery("select typeof(1);");
 
@@ -2870,7 +2918,7 @@ public class TestDuckDBJDBC {
         Properties info = new Properties();
         info.put(memory_limit, "500MB");
         info.put(threads, "5");
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:", info);
+        Connection conn = DriverManager.getConnection(JDBC_URL, info);
 
         assertEquals("500.0MB", getSetting(conn, memory_limit));
         assertEquals("5", getSetting(conn, threads));
@@ -2880,7 +2928,7 @@ public class TestDuckDBJDBC {
         Properties info = new Properties();
         info.put("invalid config name", "true");
 
-        String message = assertThrows(() -> DriverManager.getConnection("jdbc:duckdb:", info), SQLException.class);
+        String message = assertThrows(() -> DriverManager.getConnection(JDBC_URL, info), SQLException.class);
 
         assertTrue(message.contains("Unrecognized configuration property \"invalid config name\""));
     }
@@ -2889,7 +2937,7 @@ public class TestDuckDBJDBC {
         Properties info = new Properties();
         info.put("ordered_aggregate_threshold", "123");
 
-        String message = assertThrows(() -> DriverManager.getConnection("jdbc:duckdb:", info), SQLException.class);
+        String message = assertThrows(() -> DriverManager.getConnection(JDBC_URL, info), SQLException.class);
 
         assertTrue(message.contains("Failed to set configuration option \"ordered_aggregate_threshold\""));
     }
@@ -2905,7 +2953,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_describe() throws Exception {
-        Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        Connection conn = DriverManager.getConnection(JDBC_URL);
 
         try (Statement stmt = conn.createStatement()) {
             stmt.execute("CREATE TABLE TEST (COL INT DEFAULT 42)");
@@ -2922,7 +2970,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_null_bytes_in_string() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:")) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
             try (PreparedStatement stmt = conn.prepareStatement("select ?::varchar")) {
                 stmt.setObject(1, "bob\u0000r");
                 ResultSet rs = stmt.executeQuery();
@@ -2934,7 +2982,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_get_functions() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:")) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
             ResultSet functions =
                 conn.getMetaData().getFunctions(null, DuckDBConnection.DEFAULT_SCHEMA, "string_split");
 
@@ -2965,7 +3013,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_get_primary_keys() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement stmt = conn.createStatement();) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();) {
             Object[][] testData = new Object[12][6];
             int testDataIndex = 0;
 
@@ -3083,7 +3131,7 @@ public class TestDuckDBJDBC {
         Path database_file = Files.createTempFile("duckdb-instance-cache-test-", ".duckdb");
         database_file.toFile().delete();
 
-        String jdbc_url = "jdbc:duckdb:" + database_file.toString();
+        String jdbc_url = JDBC_URL + database_file.toString();
 
         Connection conn = DriverManager.getConnection(jdbc_url);
         Connection conn2 = DriverManager.getConnection(jdbc_url);
@@ -3093,7 +3141,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_user_password() throws Exception {
-        String jdbc_url = "jdbc:duckdb:";
+        String jdbc_url = JDBC_URL;
         Properties p = new Properties();
         p.setProperty("user", "wilbur");
         p.setProperty("password", "quack");
@@ -3110,7 +3158,7 @@ public class TestDuckDBJDBC {
     public static void test_readonly_remains_bug5593() throws Exception {
         Path database_file = Files.createTempFile("duckdb-instance-cache-test-", ".duckdb");
         database_file.toFile().delete();
-        String jdbc_url = "jdbc:duckdb:" + database_file.toString();
+        String jdbc_url = JDBC_URL + database_file.toString();
 
         Properties p = new Properties();
         p.setProperty("duckdb.read_only", "true");
@@ -3124,7 +3172,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_supportsLikeEscapeClause_shouldBe_true() throws Exception {
-        Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        Connection connection = DriverManager.getConnection(JDBC_URL);
         DatabaseMetaData databaseMetaData = connection.getMetaData();
         assertTrue(databaseMetaData.supportsLikeEscapeClause(),
                    "DatabaseMetaData.supportsLikeEscapeClause() should be true.");
@@ -3138,7 +3186,7 @@ public class TestDuckDBJDBC {
                                       String.format("AND table_name = '%s'", TABLE_NAME);
         final String QUALIFIED_TABLE_NAME = CATALOG_NAME + "." + TABLE_NAME;
         ResultSet resultSet = null;
-        try (final Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (final Connection connection = DriverManager.getConnection(JDBC_URL);
              final Statement statement = connection.createStatement();) {
             final DatabaseMetaData databaseMetaData = connection.getMetaData();
             statement.execute(String.format("ATTACH '' AS \"%s\"", CATALOG_NAME));
@@ -3184,7 +3232,7 @@ public class TestDuckDBJDBC {
         final String QUALIFIED_TABLE_NAME = CATALOG_NAME + "." + TABLE_NAME;
 
         ResultSet resultSet = null;
-        try (final Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (final Connection connection = DriverManager.getConnection(JDBC_URL);
              final Statement statement = connection.createStatement();) {
             final DatabaseMetaData databaseMetaData = connection.getMetaData();
             statement.execute(String.format("ATTACH '' AS \"%s\"", CATALOG_NAME));
@@ -3245,7 +3293,7 @@ public class TestDuckDBJDBC {
         final String QUALIFIED_INDEX_NAME = CATALOG_NAME + "." + INDEX_NAME;
 
         ResultSet resultSet = null;
-        try (final Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (final Connection connection = DriverManager.getConnection(JDBC_URL);
              final Statement statement = connection.createStatement();) {
             final DatabaseMetaData databaseMetaData = connection.getMetaData();
             statement.execute(String.format("ATTACH '' AS \"%s\"", CATALOG_NAME));
@@ -3289,7 +3337,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_structs() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
              PreparedStatement statement = connection.prepareStatement("select {\"a\": 1}")) {
             ResultSet resultSet = statement.executeQuery();
             assertTrue(resultSet.next());
@@ -3300,7 +3348,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_union() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
              Statement statement = connection.createStatement()) {
             statement.execute("CREATE TABLE tbl1(u UNION(num INT, str VARCHAR));");
             statement.execute("INSERT INTO tbl1 values (1) , ('two') , (union_value(str := 'three'));");
@@ -3316,7 +3364,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_list() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
              Statement statement = connection.createStatement()) {
             try (ResultSet rs = statement.executeQuery("select [1]")) {
                 assertTrue(rs.next());
@@ -3351,7 +3399,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_array_resultset() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
              Statement statement = connection.createStatement()) {
             try (ResultSet rs = statement.executeQuery("select [42, 69]")) {
                 assertTrue(rs.next());
@@ -3484,7 +3532,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_map() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
              PreparedStatement statement = connection.prepareStatement("select map([100, 5], ['a', 'b'])")) {
             ResultSet rs = statement.executeQuery();
             assertTrue(rs.next());
@@ -3493,7 +3541,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_extension_type() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
              Statement stmt = connection.createStatement()) {
 
             DuckDBNative.duckdb_jdbc_create_extension_type((DuckDBConnection) connection);
@@ -3508,7 +3556,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_extension_type_metadata() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement stmt = conn.createStatement();) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();) {
             DuckDBNative.duckdb_jdbc_create_extension_type((DuckDBConnection) conn);
 
             stmt.execute("CREATE TABLE test (foo test_type, bar byte_test_type);");
@@ -3532,7 +3580,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_getColumnClassName() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement s = conn.createStatement();) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement s = conn.createStatement();) {
             try (ResultSet rs = s.executeQuery("select * from test_all_types()")) {
                 ResultSetMetaData rsmd = rs.getMetaData();
                 rs.next();
@@ -3546,7 +3594,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_update_count() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
              Statement s = connection.createStatement()) {
             s.execute("create table t (i int)");
             assertEquals(s.getUpdateCount(), -1);
@@ -3560,7 +3608,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_get_result_set() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:")) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
             try (PreparedStatement p = conn.prepareStatement("select 1")) {
                 p.executeQuery();
                 try (ResultSet resultSet = p.getResultSet()) {
@@ -3582,7 +3630,7 @@ public class TestDuckDBJDBC {
 
     // https://github.com/duckdb/duckdb/issues/7218
     public static void test_unknown_result_type() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
              PreparedStatement p = connection.prepareStatement(
                  "select generate_series.generate_series from generate_series(?, ?) order by 1")) {
             p.setInt(1, 0);
@@ -3719,7 +3767,7 @@ public class TestDuckDBJDBC {
     public static void test_all_types() throws Exception {
         Logger logger = Logger.getAnonymousLogger();
 
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection conn = DriverManager.getConnection(JDBC_URL);
              PreparedStatement stmt = conn.prepareStatement("select * from test_all_types()")) {
             conn.createStatement().execute("set timezone = 'UTC'");
 
@@ -3772,7 +3820,7 @@ public class TestDuckDBJDBC {
 
     public static void test_cancel() throws Exception {
         ExecutorService service = Executors.newFixedThreadPool(1);
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement stmt = conn.createStatement()) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
             Future<String> thread = service.submit(
                 ()
                     -> assertThrows(()
@@ -3786,7 +3834,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_prepared_statement_metadata() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection conn = DriverManager.getConnection(JDBC_URL);
              PreparedStatement stmt = conn.prepareStatement("SELECT 'hello' as world")) {
             ResultSetMetaData metadata = stmt.getMetaData();
             assertEquals(metadata.getColumnCount(), 1);
@@ -3796,7 +3844,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_unbindable_query() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection conn = DriverManager.getConnection(JDBC_URL);
              PreparedStatement stmt = conn.prepareStatement("SELECT ?, ?")) {
             stmt.setString(1, "word1");
             stmt.setInt(2, 42);
@@ -3828,7 +3876,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_labels_with_prepped_statement() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:")) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
             try (PreparedStatement stmt = conn.prepareStatement("SELECT ? as result")) {
                 stmt.setString(1, "Quack");
                 try (ResultSet rs = stmt.executeQuery()) {
@@ -3841,7 +3889,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_execute_updated_on_prep_stmt() throws SQLException {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement s = conn.createStatement()) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement s = conn.createStatement()) {
             s.executeUpdate("create table t (i int)");
 
             try (PreparedStatement p = conn.prepareStatement("insert into t (i) select ?")) {
@@ -3852,7 +3900,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_invalid_execute_calls() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:")) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
             try (Statement s = conn.createStatement()) {
                 s.execute("create table test (id int)");
             }
@@ -3869,7 +3917,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_race() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:")) {
+        try (Connection connection = DriverManager.getConnection(JDBC_URL)) {
             ExecutorService executorService = Executors.newFixedThreadPool(10);
 
             List<Callable<Object>> tasks = Collections.nCopies(1000, () -> {
@@ -3903,8 +3951,8 @@ public class TestDuckDBJDBC {
         props.setProperty(JDBC_STREAM_RESULTS, String.valueOf(true));
 
         String QUERY = "SELECT * FROM range(100000)";
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:", props);
-             Statement stmt1 = conn.createStatement(); Statement stmt2 = conn.createStatement()) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL, props); Statement stmt1 = conn.createStatement();
+             Statement stmt2 = conn.createStatement()) {
 
             try (ResultSet rs1 = stmt1.executeQuery(QUERY); ResultSet ignored = stmt2.executeQuery(QUERY)) {
                 assertThrows(rs1::next, SQLException.class);
@@ -3913,7 +3961,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_offset_limit() throws Exception {
-        try (Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
              Statement s = connection.createStatement()) {
             s.executeUpdate("create table t (i int not null)");
             s.executeUpdate("insert into t values (1), (1), (2), (3), (3), (3)");
@@ -3935,7 +3983,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_UUID_binding() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection conn = DriverManager.getConnection(JDBC_URL);
              PreparedStatement statement = conn.prepareStatement("select '0b17ce61-375c-4ad8-97b3-349d96d35ab1'::UUID");
              ResultSet resultSet = statement.executeQuery()) {
             resultSet.next();
@@ -3947,7 +3995,7 @@ public class TestDuckDBJDBC {
         Properties props = new Properties();
         props.setProperty(JDBC_STREAM_RESULTS, String.valueOf(true));
 
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:", props);
+        try (Connection conn = DriverManager.getConnection(JDBC_URL, props);
              PreparedStatement stmt1 = conn.prepareStatement("SELECT * FROM range(100000)");
              ResultSet rs = stmt1.executeQuery()) {
             while (rs.next()) {
@@ -3959,7 +4007,7 @@ public class TestDuckDBJDBC {
 
     public static void test_struct_use_after_free() throws Exception {
         Object struct, array;
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:");
+        try (Connection conn = DriverManager.getConnection(JDBC_URL);
              PreparedStatement stmt = conn.prepareStatement("SELECT struct_pack(hello := 2), [42]");
              ResultSet rs = stmt.executeQuery()) {
             rs.next();
@@ -3971,7 +4019,7 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_user_agent_default() throws Exception {
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:")) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
             assertEquals(getSetting(conn, "custom_user_agent"), "");
 
             try (PreparedStatement stmt1 = conn.prepareStatement("PRAGMA user_agent");
@@ -3986,7 +4034,7 @@ public class TestDuckDBJDBC {
         Properties props = new Properties();
         props.setProperty(DUCKDB_USER_AGENT_PROPERTY, "CUSTOM_STRING");
 
-        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:", props)) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL, props)) {
             assertEquals(getSetting(conn, "custom_user_agent"), "CUSTOM_STRING");
 
             try (PreparedStatement stmt1 = conn.prepareStatement("PRAGMA user_agent");


### PR DESCRIPTION
When not synchronised, multi-threaded interactions with a statement could cause the query result to segfault, since it could be destroyed while still in use.

Fix #9528