### PR TITLE
Fix  dbgen/dsdgen when using custom catalog and schema

### DIFF
--- a/extension/tpcds/dsdgen/dsdgen.cpp
+++ b/extension/tpcds/dsdgen/dsdgen.cpp
@@ -21,6 +21,7 @@ template <class T>
 static void CreateTPCDSTable(ClientContext &context, string catalog_name, string schema, string suffix, bool keys,
                              bool overwrite) {
 	auto info = make_uniq<CreateTableInfo>();
+	info->catalog = catalog_name;
 	info->schema = schema;
 	info->table = T::Name + suffix;
 	info->on_conflict = overwrite ? OnCreateConflict::REPLACE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -420,6 +420,7 @@ const LogicalType LineitemInfo::Types[] = {
 template <class T>
 static void CreateTPCHTable(ClientContext &context, string catalog_name, string schema, string suffix) {
 	auto info = make_uniq<CreateTableInfo>();
+	info->catalog = catalog_name;
 	info->schema = schema;
 	info->table = T::Name + suffix;
 	info->on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;

--- a/test/sql/tpcds/tpcds_options.test_slow
+++ b/test/sql/tpcds/tpcds_options.test_slow
@@ -39,3 +39,12 @@ CALL dsdgen(sf=0.01, catalog='db1');
 
 statement ok
 SELECT COUNT(*) FROM db1.call_center
+
+statement ok
+CREATE SCHEMA db1.test_schema
+
+statement ok
+CALL dsdgen(sf=0.01, catalog='db1', schema='test_schema');
+
+statement ok
+SELECT COUNT(*) FROM db1.test_schema.call_center

--- a/test/sql/tpch/test_tpch_options.test_slow
+++ b/test/sql/tpch/test_tpch_options.test_slow
@@ -151,3 +151,23 @@ select count (*) from (SELECT * FROM db1.${tpch_tbl} EXCEPT SELECT * FROM ${tpch
 0
 
 endloop
+
+statement ok
+CREATE SCHEMA db1.test_schema
+
+statement ok
+CALL dbgen(sf=1, catalog='db1', schema='test_schema');
+
+foreach tpch_tbl orders customer lineitem nation part partsupp region supplier
+
+query I
+select count(*) from (SELECT * FROM ${tpch_tbl} EXCEPT SELECT * FROM db1.test_schema.${tpch_tbl});
+----
+0
+
+query I
+select count (*) from (SELECT * FROM db1.test_schema.${tpch_tbl} EXCEPT SELECT * FROM ${tpch_tbl});
+----
+0
+
+endloop


### PR DESCRIPTION
Calling `dbgen(catalog=other_catalog, schema=other_schema)` would fail with `Catalog Error: Schema with name other_schema does not exist!` as the `CreateTableInfo` was not properly referencing the catalog to be used.

This was not a problem for the simple `dbgen(catalog=other_catalog)` as the main schema (i.e. the one used by default) would be available in all catalogs.