### PR TITLE
Deserialize header fields

### DIFF
--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/string.hpp"
 #include "duckdb/common/vector_size.hpp"
 
 namespace duckdb {
@@ -57,6 +58,7 @@ using block_id_t = int64_t;
 //! The MainHeader is the first header in the storage file. The MainHeader is typically written only once for a database
 //! file.
 struct MainHeader {
+	static constexpr idx_t MAX_VERSION_SIZE = 32;
 	static constexpr idx_t MAGIC_BYTE_SIZE = 4;
 	static constexpr idx_t MAGIC_BYTE_OFFSET = Storage::BLOCK_HEADER_SIZE;
 	static constexpr idx_t FLAG_COUNT = 4;
@@ -67,11 +69,21 @@ struct MainHeader {
 	uint64_t version_number;
 	//! The set of flags used by the database
 	uint64_t flags[FLAG_COUNT];
-
 	static void CheckMagicBytes(FileHandle &handle);
+
+	string LibraryGitDesc() {
+		return string((char *)library_git_desc, 0, MAX_VERSION_SIZE);
+	}
+	string LibraryGitHash() {
+		return string((char *)library_git_hash, 0, MAX_VERSION_SIZE);
+	}
 
 	void Write(WriteStream &ser);
 	static MainHeader Read(ReadStream &source);
+
+private:
+	data_t library_git_desc[MAX_VERSION_SIZE];
+	data_t library_git_hash[MAX_VERSION_SIZE];
 };
 
 //! The DatabaseHeader contains information about the current state of the database. Every storage file has two

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -18,11 +18,15 @@ namespace duckdb {
 const char MainHeader::MAGIC_BYTES[] = "DUCK";
 
 void SerializeVersionNumber(WriteStream &ser, const string &version_str) {
-	constexpr const idx_t MAX_VERSION_SIZE = 32;
-	data_t version[MAX_VERSION_SIZE];
-	memset(version, 0, MAX_VERSION_SIZE);
-	memcpy(version, version_str.c_str(), MinValue<idx_t>(version_str.size(), MAX_VERSION_SIZE));
-	ser.WriteData(version, MAX_VERSION_SIZE);
+	data_t version[MainHeader::MAX_VERSION_SIZE];
+	memset(version, 0, MainHeader::MAX_VERSION_SIZE);
+	memcpy(version, version_str.c_str(), MinValue<idx_t>(version_str.size(), MainHeader::MAX_VERSION_SIZE));
+	ser.WriteData(version, MainHeader::MAX_VERSION_SIZE);
+}
+
+void DeserializeVersionNumber(ReadStream &stream, data_t *dest) {
+	memset(dest, 0, MainHeader::MAX_VERSION_SIZE);
+	stream.ReadData(dest, MainHeader::MAX_VERSION_SIZE);
 }
 
 void MainHeader::Write(WriteStream &ser) {
@@ -81,6 +85,8 @@ MainHeader MainHeader::Read(ReadStream &source) {
 	for (idx_t i = 0; i < FLAG_COUNT; i++) {
 		header.flags[i] = source.Read<uint64_t>();
 	}
+	DeserializeVersionNumber(source, header.library_git_desc);
+	DeserializeVersionNumber(source, header.library_git_hash);
 	return header;
 }
 


### PR DESCRIPTION
Note that this is not exposed in any way (yet) to the rest of the system, but this makes so that deserialization and serialization of header are now mirrored.