### PR TITLE
[Python] Fix lossy `datetime.timedelta` to INTERVAL conversion

### DIFF
--- a/src/core_functions/scalar/date/to_interval.cpp
+++ b/src/core_functions/scalar/date/to_interval.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/core_functions/scalar/date_functions.hpp"
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/operator/multiply.hpp"
+#include "duckdb/core_functions/to_interval.hpp"
 
 namespace duckdb {
 
@@ -63,20 +64,6 @@ struct ToMinutesOperator {
 		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_MINUTE,
 		                                                               result.micros)) {
 			throw OutOfRangeException("Interval value %d minutes out of range", input);
-		}
-		return result;
-	}
-};
-
-struct ToSecondsOperator {
-	template <class TA, class TR>
-	static inline TR Operation(TA input) {
-		interval_t result;
-		result.months = 0;
-		result.days = 0;
-		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_SEC,
-		                                                               result.micros)) {
-			throw OutOfRangeException("Interval value %d seconds out of range", input);
 		}
 		return result;
 	}

--- a/src/include/duckdb/core_functions/to_interval.hpp
+++ b/src/include/duckdb/core_functions/to_interval.hpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/core_functions/to_interval.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/common/operator/multiply.hpp"
+
+namespace duckdb {
+
+struct ToSecondsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_SEC,
+		                                                               result.micros)) {
+			throw OutOfRangeException("Interval value %d seconds out of range", input);
+		}
+		return result;
+	}
+};
+
+} // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
@@ -110,8 +110,8 @@ private:
 struct PyTimeDelta {
 public:
 	PyTimeDelta(py::handle &obj);
-	int64_t days;
-	int64_t seconds;
+	int32_t days;
+	int32_t seconds;
 	int64_t microseconds;
 
 public:

--- a/tools/pythonpkg/src/native/python_objects.cpp
+++ b/tools/pythonpkg/src/native/python_objects.cpp
@@ -7,6 +7,8 @@
 #include "duckdb/common/types/cast_helpers.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb_python/pyconnection/pyconnection.hpp"
+#include "duckdb/common/operator/add.hpp"
+#include "duckdb/core_functions/to_interval.hpp"
 
 #include "datetime.h" // Python datetime initialize #1
 
@@ -26,19 +28,17 @@ PyTimeDelta::PyTimeDelta(py::handle &obj) {
 }
 
 interval_t PyTimeDelta::ToInterval() {
-	interval_t interval;
+	interval_t result;
 
-	// Timedelta stores any amount of seconds lower than a day only
-	D_ASSERT(seconds < Interval::SECS_PER_DAY);
+	auto micros_interval = Interval::FromMicro(microseconds);
+	auto days_interval = interval_t {/*months = */ 0,
+	                                 /*days = */ days,
+	                                 /*micros = */ 0};
+	auto seconds_interval = ToSecondsOperator::Operation<int64_t, interval_t>(days);
 
-	// Convert overflow of days to months
-	interval.months = days / Interval::DAYS_PER_MONTH;
-	days -= interval.months * Interval::DAYS_PER_MONTH;
-
-	microseconds += seconds * Interval::MICROS_PER_SEC;
-	interval.days = days;
-	interval.micros = microseconds;
-	return interval;
+	result = AddOperator::Operation<interval_t, interval_t, interval_t>(micros_interval, days_interval);
+	result = AddOperator::Operation<interval_t, interval_t, interval_t>(result, seconds_interval);
+	return result;
 }
 
 int64_t PyTimeDelta::GetDays(py::handle &obj) {

--- a/tools/pythonpkg/src/native/python_objects.cpp
+++ b/tools/pythonpkg/src/native/python_objects.cpp
@@ -34,7 +34,7 @@ interval_t PyTimeDelta::ToInterval() {
 	auto days_interval = interval_t {/*months = */ 0,
 	                                 /*days = */ days,
 	                                 /*micros = */ 0};
-	auto seconds_interval = ToSecondsOperator::Operation<int64_t, interval_t>(days);
+	auto seconds_interval = ToSecondsOperator::Operation<int64_t, interval_t>(seconds);
 
 	result = AddOperator::Operation<interval_t, interval_t, interval_t>(micros_interval, days_interval);
 	result = AddOperator::Operation<interval_t, interval_t, interval_t>(result, seconds_interval);

--- a/tools/pythonpkg/tests/fast/pandas/test_timedelta.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_timedelta.py
@@ -15,7 +15,7 @@ class TestTimedelta(object):
         df_out = duckdb.query_df(df_in, "df", "select * from df").df()
         pd.testing.assert_frame_equal(df_out, duckdb_interval)
 
-    def test_timedelta_coverage(self, duckdb_cursor):
+    def test_timedelta_basic(self, duckdb_cursor):
         duckdb_interval = duckdb.query(
             "SELECT '2290-08-30 23:53:40'::TIMESTAMP - '2000-02-01 01:56:00'::TIMESTAMP AS '0'"
         ).df()
@@ -32,3 +32,52 @@ class TestTimedelta(object):
         df_in = pd.DataFrame({0: pd.Series(data=data, dtype='object')})
         df_out = duckdb.query_df(df_in, "df", "select * from df").df()
         pd.testing.assert_frame_equal(df_out, duckdb_interval)
+
+    @pytest.mark.parametrize('days', [1, 9999])
+    @pytest.mark.parametrize('seconds', [0, 60])
+    @pytest.mark.parametrize(
+        'microseconds',
+        [
+            0,
+            232493,
+            999_999,
+        ],
+    )
+    @pytest.mark.parametrize('milliseconds', [0, 999])
+    @pytest.mark.parametrize('minutes', [0, 60])
+    @pytest.mark.parametrize('hours', [0, 24])
+    @pytest.mark.parametrize('weeks', [0, 51])
+    def test_timedelta_coverage(self, duckdb_cursor, days, seconds, microseconds, milliseconds, minutes, hours, weeks):
+        def create_duck_interval(days, seconds, microseconds, milliseconds, minutes, hours, weeks) -> str:
+            instant = f"""
+                (INTERVAL {days + (weeks * 7)} DAYS +
+                INTERVAL {seconds} SECONDS +
+                INTERVAL {microseconds} MICROSECONDS +
+                INTERVAL {milliseconds} MILLISECONDS +
+                INTERVAL {minutes} MINUTE +
+                INTERVAL {hours} HOURS)
+            """
+            return instant
+
+        def create_python_interval(
+            days, seconds, microseconds, milliseconds, minutes, hours, weeks
+        ) -> datetime.timedelta:
+            return datetime.timedelta(days, seconds, microseconds, milliseconds, minutes, hours, weeks)
+
+        duck_interval = create_duck_interval(days, seconds, microseconds, milliseconds, minutes, hours, weeks)
+
+        query = "select '1990/02/11'::DATE - {value}, '1990/02/11'::DATE - $1"
+        query = query.format(value=duck_interval)
+
+        val = create_python_interval(days, seconds, microseconds, milliseconds, minutes, hours, weeks)
+        a, b = duckdb_cursor.execute(query, [val]).fetchone()
+        assert a == b
+
+        equality = "select {value} = $1, {value}, $1"
+        equality = equality.format(value=duck_interval)
+        res, a, b = duckdb_cursor.execute(equality, [val]).fetchone()
+        if res != True:
+            # FIXME: in some cases intervals that are identical don't compare equal.
+            assert a == b
+        else:
+            assert res == True


### PR DESCRIPTION
This PR fixes #9431 

What we used to do was convert days to months by dividing with a constant.
This constant is lossy however, and should not be used in this way.

The issue shows the result of this.

What we do now is create separate INTERVAL values from the components of the timedelta and use the existing addition mechanism to add these together to form the result.