### PR TITLE
Fix #9601: Call correct method in duckdb_pending_execution_is_finished

### DIFF
--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -1359,7 +1359,7 @@ DUCKDB_PENDING_RESULT_READY, this function will return true.
 * returns: Boolean indicating pending execution should be considered finished.
 """
 function duckdb_pending_execution_is_finished(pending_state)
-    return ccall((:duckdb_execute_pending, libduckdb), Bool, (duckdb_pending_state,), pending_state)
+    return ccall((:duckdb_pending_execution_is_finished, libduckdb), Bool, (duckdb_pending_state,), pending_state)
 end
 
 #=


### PR DESCRIPTION
Fixes #9601

We should add a script that verifies that the Julia methods are aligned with the C API methods in the future.