### PR TITLE
[Upsert] Do not require ON CONFLICT clause on INSERT OR REPLACE in some situations.

### DIFF
--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -269,12 +269,13 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 		if (!found_matching_indexes) {
 			throw BinderException(
 			    "There are no UNIQUE/PRIMARY KEY Indexes that refer to this table, ON CONFLICT is a no-op");
-		}
-		if (insert.action_type != OnConflictAction::NOTHING && found_matching_indexes != 1) {
-			// When no conflict target is provided, and the action type is UPDATE,
-			// we only allow the operation when only a single Index exists
-			throw BinderException("Conflict target has to be provided for a DO UPDATE operation when the table has "
-			                      "multiple UNIQUE/PRIMARY KEY constraints");
+		} else if (storage_info.index_info.size() != 1) {
+			if (insert.action_type != OnConflictAction::NOTHING) {
+				// When no conflict target is provided, and the action type is UPDATE,
+				// we only allow the operation when only a single Index exists
+				throw BinderException("Conflict target has to be provided for a DO UPDATE operation when the table has "
+				                      "multiple UNIQUE/PRIMARY KEY constraints");
+			}
 		}
 	}
 

--- a/test/sql/upsert/insert_or_replace_ambiguity.test
+++ b/test/sql/upsert/insert_or_replace_ambiguity.test
@@ -1,0 +1,70 @@
+# name: test/sql/upsert/insert_or_replace_ambiguity.test
+# group: [upsert]
+
+# Single primary key on multiple columns
+statement ok
+create table foo(
+	a int,
+	b int,
+	c int,
+	primary key(a,b,c)
+);
+
+statement ok
+insert or replace into foo values (1,2,3);
+
+# Single INDEX
+statement ok
+create table foo2(
+	a int,
+	b int,
+	c int
+);
+
+statement ok
+create unique index idx2 on foo2(a, b);
+
+statement ok
+insert or replace into foo2 values (1,2,3);
+
+# Multiple unique INDEXes
+statement ok
+create unique index idx3 on foo2(b, c);
+
+statement error
+insert or replace into foo2 values (1,2,3);
+----
+Binder Error: Conflict target has to be provided for a DO UPDATE operation when the table has multiple UNIQUE/PRIMARY KEY constraints
+
+# Single unique index
+statement ok
+create table foo3(
+	a int unique,
+	b int
+);
+
+statement ok
+insert or replace into foo3 values(1, 2);
+
+# Single UNIQUE CONSTRAINT
+statement ok
+create table foo4(
+	a int unique,
+	b int
+);
+
+statement ok
+insert or replace into foo4 values(1, 2);
+
+# Multiple UNIQUE CONSTRAINTs
+statement ok
+create table foo5(
+	a int unique,
+	b int unique,
+	c int
+);
+
+statement error
+insert or replace into foo5 values(1, 2, 3);
+----
+Binder Error: Conflict target has to be provided for a DO UPDATE operation when the table has multiple UNIQUE/PRIMARY KEY constraints

--- a/test/sql/upsert/insert_or_replace_ambiguity.test
+++ b/test/sql/upsert/insert_or_replace_ambiguity.test
@@ -3,7 +3,7 @@
 
 # Single primary key on multiple columns
 statement ok
-create table foo(
+create table single_pk(
 	a int,
 	b int,
 	c int,
@@ -11,60 +11,74 @@ create table foo(
 );
 
 statement ok
-insert or replace into foo values (1,2,3);
+insert or replace into single_pk values (1,2,3);
 
-# Single INDEX
 statement ok
-create table foo2(
+insert or replace into single_pk values (1,2,3);
+
+query III
+select * from single_pk;
+----
+1	2	3
+
+# Single UNIQUE INDEX
+statement ok
+create table using_index(
 	a int,
 	b int,
 	c int
 );
 
 statement ok
-create unique index idx2 on foo2(a, b);
+create UNIQUE index idx2 on using_index(a, b);
 
 statement ok
-insert or replace into foo2 values (1,2,3);
+insert or replace into using_index values (1,2,3);
 
-# Multiple unique INDEXes
 statement ok
-create unique index idx3 on foo2(b, c);
+insert or replace into using_index values (1,2,3);
+
+query III
+select * from using_index;
+----
+1	2	3
+
+# Multiple UNIQUE INDEXes
+statement ok
+create unique index idx3 on using_index(b, c);
 
 statement error
-insert or replace into foo2 values (1,2,3);
+insert or replace into using_index values (1,2,3);
 ----
 Binder Error: Conflict target has to be provided for a DO UPDATE operation when the table has multiple UNIQUE/PRIMARY KEY constraints
 
-# Single unique index
-statement ok
-create table foo3(
-	a int unique,
-	b int
-);
-
-statement ok
-insert or replace into foo3 values(1, 2);
-
 # Single UNIQUE CONSTRAINT
 statement ok
-create table foo4(
+create table single_unique(
 	a int unique,
 	b int
 );
 
 statement ok
-insert or replace into foo4 values(1, 2);
+insert or replace into single_unique values(1, 2);
+
+statement ok
+insert or replace into single_unique values(1, 2);
+
+query II
+select * from single_unique;
+----
+1	2
 
 # Multiple UNIQUE CONSTRAINTs
 statement ok
-create table foo5(
+create table multiple_unique(
 	a int unique,
 	b int unique,
 	c int
 );
 
 statement error
-insert or replace into foo5 values(1, 2, 3);
+insert or replace into multiple_unique values(1, 2, 3);
 ----
 Binder Error: Conflict target has to be provided for a DO UPDATE operation when the table has multiple UNIQUE/PRIMARY KEY constraints


### PR DESCRIPTION
This PR fixes #6576 

Previously we threw an error even when only a single index exists on the table if it contained multiple columns.