### PR TITLE
Fix #9717: Correctly set null statistics of children of structs

### DIFF
--- a/src/include/duckdb/storage/statistics/base_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/base_statistics.hpp
@@ -77,12 +77,20 @@ public:
 	void Set(StatsInfo info);
 	void CombineValidity(BaseStatistics &left, BaseStatistics &right);
 	void CopyValidity(BaseStatistics &stats);
-	inline void SetHasNull() {
+	//! Set that the CURRENT level can have null values
+	//! Note that this is not correct for nested types unless this information is propagated in a different manner
+	//! Use Set(StatsInfo::CAN_HAVE_NULL_VALUES) in the general case
+	inline void SetHasNullFast() {
 		has_null = true;
 	}
-	inline void SetHasNoNull() {
+	//! Set that the CURRENT level can have valiod values
+	//! Note that this is not correct for nested types unless this information is propagated in a different manner
+	//! Use Set(StatsInfo::CAN_HAVE_VALID_VALUES) in the general case
+	inline void SetHasNoNullFast() {
 		has_no_null = true;
 	}
+	void SetHasNull();
+	void SetHasNoNull();
 
 	void Merge(const BaseStatistics &other);
 

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -418,7 +418,7 @@ idx_t ValidityAppend(CompressionAppendState &append_state, ColumnSegment &segmen
 	if (data.validity.AllValid()) {
 		// no null values: skip append
 		segment.count += append_count;
-		validity_stats.SetHasNoNull();
+		validity_stats.SetHasNoNullFast();
 		return append_count;
 	}
 
@@ -427,9 +427,9 @@ idx_t ValidityAppend(CompressionAppendState &append_state, ColumnSegment &segmen
 		auto idx = data.sel->get_index(offset + i);
 		if (!data.validity.RowIsValidUnsafe(idx)) {
 			mask.SetInvalidUnsafe(segment.count + i);
-			validity_stats.SetHasNull();
+			validity_stats.SetHasNullFast();
 		} else {
-			validity_stats.SetHasNoNull();
+			validity_stats.SetHasNoNullFast();
 		}
 	}
 	segment.count += append_count;

--- a/src/storage/statistics/base_statistics.cpp
+++ b/src/storage/statistics/base_statistics.cpp
@@ -255,23 +255,41 @@ void BaseStatistics::CopyBase(const BaseStatistics &other) {
 void BaseStatistics::Set(StatsInfo info) {
 	switch (info) {
 	case StatsInfo::CAN_HAVE_NULL_VALUES:
-		has_null = true;
+		SetHasNull();
 		break;
 	case StatsInfo::CANNOT_HAVE_NULL_VALUES:
 		has_null = false;
 		break;
 	case StatsInfo::CAN_HAVE_VALID_VALUES:
-		has_no_null = true;
+		SetHasNoNull();
 		break;
 	case StatsInfo::CANNOT_HAVE_VALID_VALUES:
 		has_no_null = false;
 		break;
 	case StatsInfo::CAN_HAVE_NULL_AND_VALID_VALUES:
-		has_null = true;
-		has_no_null = true;
+		SetHasNull();
+		SetHasNoNull();
 		break;
 	default:
 		throw InternalException("Unrecognized StatsInfo for BaseStatistics::Set");
+	}
+}
+
+void BaseStatistics::SetHasNull() {
+	has_null = true;
+	if (type.InternalType() == PhysicalType::STRUCT) {
+		for (idx_t c = 0; c < StructType::GetChildCount(type); c++) {
+			StructStats::GetChildStats(*this, c).SetHasNull();
+		}
+	}
+}
+
+void BaseStatistics::SetHasNoNull() {
+	has_no_null = true;
+	if (type.InternalType() == PhysicalType::STRUCT) {
+		for (idx_t c = 0; c < StructType::GetChildCount(type); c++) {
+			StructStats::GetChildStats(*this, c).SetHasNoNull();
+		}
 	}
 }
 

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -239,11 +239,11 @@ struct StructColumnCheckpointState : public ColumnCheckpointState {
 
 public:
 	unique_ptr<BaseStatistics> GetStatistics() override {
-		auto stats = StructStats::CreateEmpty(column_data.type);
+		D_ASSERT(global_stats);
 		for (idx_t i = 0; i < child_states.size(); i++) {
-			StructStats::SetChildStats(stats, i, child_states[i]->GetStatistics());
+			StructStats::SetChildStats(*global_stats, i, child_states[i]->GetStatistics());
 		}
-		return stats.ToUnique();
+		return std::move(global_stats);
 	}
 
 	void WriteDataPointers(RowGroupWriter &writer, Serializer &serializer) override {

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -895,7 +895,7 @@ idx_t UpdateValidityStatistics(UpdateSegment *segment, SegmentStatistics &stats,
 	if (!mask.AllValid() && !validity.CanHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
 			if (!mask.RowIsValid(i)) {
-				validity.SetHasNull();
+				validity.SetHasNullFast();
 				break;
 			}
 		}

--- a/test/sql/types/nested/struct/struct_is_null.test
+++ b/test/sql/types/nested/struct/struct_is_null.test
@@ -1,0 +1,17 @@
+# name: test/sql/types/nested/struct/struct_is_null.test
+# description: Test structs with IS NULL
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table tbl (data struct(str varchar)[]);
+
+statement ok
+insert into tbl (data) values ([struct_pack(str := 'value')]), (null), (null), (null);
+
+query I
+select data[1].str as str from tbl where str is not null;
+----
+value


### PR DESCRIPTION
Fixes #9717

When a struct field can have `NULL` values, the children of that struct field can also have `NULL` values transitively. In the linked query list extract set `CAN_HAVE_NULL` of the child to true, but this did not get properly pushed into the stats of the children of the struct, leading to an incorrect optimization being made. This PR changes the statistics so that `Set(StatsInfo::CAN_HAVE_NULL_VALUES)` correctly propagates this information to the children of structs.