### PR TITLE
Fixes to warning and rendering of bar()

### DIFF
--- a/src/core_functions/scalar/string/bar.cpp
+++ b/src/core_functions/scalar/string/bar.cpp
@@ -52,6 +52,11 @@ static string_t BarScalarFunction(double x, double min, double max, double max_w
 		result += PARTIAL_BLOCKS[remaining];
 	}
 
+	const idx_t integer_max_width = (idx_t)max_width;
+	if (result.size() < integer_max_width) {
+		result += std::string(integer_max_width - result.size(), ' ');
+	}
+
 	return string_t(result);
 }
 

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -80,11 +80,11 @@ public:
 	}
 
 	const char *GetPrefix() const {
-		return value.pointer.prefix;
+		return value.inlined.inlined;
 	}
 
 	char *GetPrefixWriteable() const {
-		return (char *)value.pointer.prefix;
+		return (char *)value.inlined.inlined;
 	}
 
 	idx_t GetSize() const {

--- a/test/sql/function/string/test_bar.test
+++ b/test/sql/function/string/test_bar.test
@@ -8,12 +8,12 @@ pragma enable_verification
 query I
 select bar(x * x, 0, 100) from range(0, 11) t(x)
 ----
-(empty)
-▊
-███▏
-███████▏
-████████████▊
-████████████████████
+                                                                                
+▊                                                                             
+███▏                                                                    
+███████▏                                                        
+████████████▊                                         
+████████████████████                    
 ████████████████████████████▊
 ███████████████████████████████████████▏
 ███████████████████████████████████████████████████▏
@@ -23,7 +23,7 @@ select bar(x * x, 0, 100) from range(0, 11) t(x)
 query I
 select bar(9, 10, 20)
 ----
-(empty)
+                                                                                
 
 query I
 select bar(120, -10, 100, 10)
@@ -38,17 +38,17 @@ select bar(40, 20, 0)
 query I
 select bar(100, 200, 0)
 ----
-(empty)
+                                                                                
 
 query I
 select bar(-10, 20, 0)
 ----
-(empty)
+                                                                                
 
 query I
 select bar('nan'::double, 0, 10)
 ----
-(empty)
+                                                                                
 
 query I
 select bar('infinity'::double, 0, 10)
@@ -58,7 +58,7 @@ select bar('infinity'::double, 0, 10)
 query I
 select bar('-infinity'::double, 0, 10)
 ----
-(empty)
+                                                                                
 
 query I
 select bar(null, 0, 10)
@@ -68,7 +68,7 @@ NULL
 query I
 select bar(1, 'nan'::double, 10)
 ----
-(empty)
+                                                                                
 
 statement error
 select bar(1, '-infinity'::double, 10)
@@ -76,7 +76,7 @@ select bar(1, '-infinity'::double, 10)
 query I
 select bar(1, 'infinity'::double, 10)
 ----
-(empty)
+                                                                                
 
 query I
 select bar(1, null, 10)
@@ -86,7 +86,7 @@ NULL
 query I
 select bar(1, 0, 'nan'::double)
 ----
-(empty)
+                                                                                
 
 query I
 select bar(1, 0, '-infinity'::double)
@@ -96,7 +96,7 @@ select bar(1, 0, '-infinity'::double)
 query I
 select bar(1, 0, 'infinity'::double)
 ----
-(empty)
+                                                                                
 
 statement error
 select bar(1, 0, 10, 'nan'::double)
@@ -110,7 +110,8 @@ select bar(1, 0, 10, '-infinity'::double)
 query I
 select bar(1, 0, 10, 1000)
 ----
-████████████████████████████████████████████████████████████████████████████████████████████████████
+████████████████████████████████████████████████████████████████████████████████████████████████████                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
+
 
 statement error
 select bar(1, 0, 10, 1001)
@@ -118,12 +119,12 @@ select bar(1, 0, 10, 1001)
 query I
 select bar(1, 0, 10, 1)
 ----
-(empty)
+ 
 
 query I
 select bar(10, 10, 10, 10)
 ----
-(empty)
+          
 
 statement error
 select bar(1, 0, 10, 0.99)


### PR DESCRIPTION
Two independent small fixes I bumped against:
* resolves warning like: https://github.com/duckdb/duckdb-node/actions/runs/6862250904/job/18659587317#step:8:183 by making the static analyser aware that there is enough space in the union
* fix rendering of bars (check `SELECT bar(10, 0 100);`, that should be about 10% full but looks like full).