### PR TITLE
Wasm: Add wasm_threads as a class of built extensions

### DIFF
--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        duckdb_wasm_arch: [ 'mvp', 'eh' ]
+        duckdb_wasm_arch: [ 'mvp', 'eh', 'threads' ]
     env:
       GEN: Ninja
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,12 @@ wasm_eh: ${EXTENSION_CONFIG_STEP}
 	emmake make -j8 -Cbuild/wasm_eh && \
 	cd build/wasm_eh && bash ../../scripts/link-wasm-extensions.sh
 
+wasm_threads: ${EXTENSION_CONFIG_STEP}
+	mkdir -p ./build/wasm_threads && \
+	emcmake cmake $(GENERATOR) -DWASM_LOADABLE_EXTENSIONS=1 -DBUILD_EXTENSIONS_ONLY=1 -Bbuild/wasm_threads -DCMAKE_CXX_FLAGS="-fwasm-exceptions -DWEBDB_FAST_EXCEPTIONS=1 -DWITH_WASM_THREADS=1 -DWITH_WASM_SIMD=1 -DWITH_WASM_BULK_MEMORY=1 -DDUCKDB_CUSTOM_PLATFORM=wasm_threads" && \
+	emmake make -j8 -Cbuild/wasm_threads && \
+	cd build/wasm_threads && bash ../../scripts/link-wasm-extensions.sh
+
 cldebug: ${EXTENSION_CONFIG_STEP}
 	mkdir -p ./build/cldebug && \
 	cd build/cldebug && \


### PR DESCRIPTION
As per title, add this additional class of extensions, relevant duckdb-wasm PR is https://github.com/duckdb/duckdb-wasm/pull/1501.