### PR TITLE
Fix #9742: correctly catch empty ROW case in UPDATE

### DIFF
--- a/src/parser/transform/expression/transform_multi_assign_reference.cpp
+++ b/src/parser/transform/expression/transform_multi_assign_reference.cpp
@@ -15,13 +15,13 @@ unique_ptr<ParsedExpression> Transformer::TransformMultiAssignRef(duckdb_libpgqu
 			return TransformExpression(root.source);
 		}
 
+		int provided_values = func.args ? func.args->length : 0;
 		// Too many columns (ie. (x, y) = (1, 2, 3) )
-		if (root.ncolumns < func.args->length) {
+		if (root.ncolumns < provided_values || !func.args) {
 			throw ParserException(
 			    "Could not perform multiple assignment, target only expects %d values, %d were provided", root.ncolumns,
-			    func.args->length);
+			    provided_values);
 		}
-
 		// Get the expression corresponding with the current column
 		idx_t idx = 1;
 		auto list = func.args->head;

--- a/test/sql/types/struct/update_empty_row.test
+++ b/test/sql/types/struct/update_empty_row.test
@@ -1,0 +1,8 @@
+# name: test/sql/types/struct/update_empty_row.test
+# description: Test storing structs in in-memory tables
+# group: [struct]
+
+statement error
+UPDATE t0 SET ( c0 ) = ROW ( );
+----
+target only expects 1 values, 0 were provided


### PR DESCRIPTION
Fixes #9742