### PR TITLE
Don't show "blabla" as part of syntax error

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -417,7 +417,7 @@ vector<vector<unique_ptr<ParsedExpression>>> Parser::ParseValuesList(const strin
 }
 
 ColumnList Parser::ParseColumnList(const string &column_list, ParserOptions options) {
-	string mock_query = "CREATE TABLE blabla (" + column_list + ")";
+	string mock_query = "CREATE TABLE tbl (" + column_list + ")";
 	Parser parser(options);
 	parser.ParseQuery(mock_query);
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::CREATE_STATEMENT) {


### PR DESCRIPTION
Just a minor change to make the error a bit more "professional". :)

Before:

```
❯ touch test.json
❯ duckdb -c "SELECT * FROM read_ndjson('test.json', columns={Item: 'JSON NOT xxx'})"
Error: Parser Error: syntax error at or near "xxx"
LINE 1: CREATE TABLE blabla (dummy JSON NOT xxx)
                                            ^
```

After:

```
❯ ./build/release/duckdb -c "SELECT * FROM read_ndjson('test.json', columns={Item: 'JSON NOT xxx'})"
Error: Parser Error: syntax error at or near "xxx"
LINE 1: CREATE TABLE tbl (dummy JSON NOT xxx)
                                         ^
```

Related to this: I know that constraints are technically not supported in select statements. However, `JSON NULL` and `JSON NOT NULL` are parsed and accepted without an error right now, see [Discord](https://discord.com/channels/909674491309850675/1032659480539824208/1176253443862712341).