### PR TITLE
Explicitly attach duckdb file type

### DIFF
--- a/benchmark/micro/attach.cpp
+++ b/benchmark/micro/attach.cpp
@@ -79,7 +79,7 @@ static void AttachWorker(const string &dir, const idx_t start, const idx_t end, 
 
 	for (idx_t i = start; i < end; i++) {
 		auto filepath = dir + "/board_" + to_string(i) + ".db";
-		auto result = con.Query("ATTACH '" + filepath + "' (READ_ONLY);");
+		auto result = con.Query("ATTACH '" + filepath + "' (READ_ONLY, TYPE DUCKDB);");
 		D_ASSERT(!result->HasError());
 	}
 }

--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -13,10 +13,10 @@ namespace duckdb {
 // Helper
 //===--------------------------------------------------------------------===//
 
-void ParseOptions(const unique_ptr<AttachInfo> &info, AccessMode &access_mode, string &db_type,
-                  string &unrecognized_option) {
+void ParseOptions(const unique_ptr<AttachInfo> &info, AccessMode &access_mode, string &db_type) {
 
 	for (auto &entry : info->options) {
+
 		if (entry.first == "readonly" || entry.first == "read_only") {
 			auto read_only = BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
 			if (read_only) {
@@ -24,18 +24,26 @@ void ParseOptions(const unique_ptr<AttachInfo> &info, AccessMode &access_mode, s
 			} else {
 				access_mode = AccessMode::READ_WRITE;
 			}
-		} else if (entry.first == "readwrite" || entry.first == "read_write") {
+			continue;
+		}
+
+		if (entry.first == "readwrite" || entry.first == "read_write") {
 			auto read_only = !BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
 			if (read_only) {
 				access_mode = AccessMode::READ_ONLY;
 			} else {
 				access_mode = AccessMode::READ_WRITE;
 			}
-		} else if (entry.first == "type") {
-			db_type = StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR));
-		} else if (unrecognized_option.empty()) {
-			unrecognized_option = entry.first;
+			continue;
 		}
+
+		if (entry.first == "type") {
+			// extract the database type
+			db_type = StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR));
+			continue;
+		}
+
+		throw BinderException("Unrecognized option for attach \"%s\"", entry.first);
 	}
 }
 
@@ -57,8 +65,7 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 	auto &config = DBConfig::GetConfig(context.client);
 	AccessMode access_mode = config.options.access_mode;
 	string db_type;
-	string unrecognized_option;
-	ParseOptions(info, access_mode, db_type, unrecognized_option);
+	ParseOptions(info, access_mode, db_type);
 
 	// check ATTACH IF NOT EXISTS
 	auto &db_manager = DatabaseManager::Get(context.client);
@@ -82,9 +89,8 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 		}
 	}
 
-	// get the database type
-	db_manager.GetDbType(context.client, db_type, *info, config, unrecognized_option);
-
+	// get the database type and attach the database
+	db_manager.GetDatabaseType(context.client, db_type, *info, config);
 	auto attached_db = db_manager.AttachDatabase(context.client, *info, db_type, access_mode);
 	attached_db->Initialize();
 	return SourceResultType::FINISHED;

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -59,7 +59,8 @@ public:
 	//! Returns the database type. This might require checking the header of the file, in which case the file handle is
 	//! necessary. We can only grab the file handle, if it is not yet held, even for uncommitted changes. Thus, we have
 	//! to lock for this operation.
-	void GetDatabaseType(ClientContext &context, string &db_type, AttachInfo &info, const DBConfig &config);
+	void GetDatabaseType(ClientContext &context, string &db_type, AttachInfo &info, const DBConfig &config,
+	                     const string &unrecognized_option);
 	//! Scans the catalog set and adds each committed database entry, and each database entry of the current
 	//! transaction, to a vector holding AttachedDatabase references
 	vector<reference<AttachedDatabase>> GetDatabases(ClientContext &context);

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -59,10 +59,7 @@ public:
 	//! Returns the database type. This might require checking the header of the file, in which case the file handle is
 	//! necessary. We can only grab the file handle, if it is not yet held, even for uncommitted changes. Thus, we have
 	//! to lock for this operation.
-	void GetDbType(ClientContext &context, string &db_type, AttachInfo &info, const DBConfig &config,
-	               const string &unrecognized_option);
-	//! Returns a pointer to an attached database matching the path. If none exists, it returns nullptr
-	optional_ptr<AttachedDatabase> GetDatabaseFromPath(ClientContext &context, const string &path);
+	void GetDatabaseType(ClientContext &context, string &db_type, AttachInfo &info, const DBConfig &config);
 	//! Scans the catalog set and adds each committed database entry, and each database entry of the current
 	//! transaction, to a vector holding AttachedDatabase references
 	vector<reference<AttachedDatabase>> GetDatabases(ClientContext &context);

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -98,12 +98,17 @@ void DatabaseManager::EraseDatabasePath(const string &path) {
 	}
 }
 
-void DatabaseManager::GetDatabaseType(ClientContext &context, string &db_type, AttachInfo &info,
-                                      const DBConfig &config) {
+void DatabaseManager::GetDatabaseType(ClientContext &context, string &db_type, AttachInfo &info, const DBConfig &config,
+                                      const string &unrecognized_option) {
 
 	// duckdb database file
 	if (StringUtil::CIEquals(db_type, "DUCKDB")) {
 		db_type = "";
+
+		// DUCKDB format does not allow unrecognized options
+		if (!unrecognized_option.empty()) {
+			throw BinderException("Unrecognized option for attach \"%s\"", unrecognized_option);
+		}
 		return;
 	}
 
@@ -133,6 +138,12 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, string &db_type, A
 			// attempted only once respecting the auto-loading options
 			ExtensionHelper::LoadExternalExtension(context, db_type);
 		}
+		return;
+	}
+
+	// DUCKDB format does not allow unrecognized options
+	if (!unrecognized_option.empty()) {
+		throw BinderException("Unrecognized option for attach \"%s\"", unrecognized_option);
 	}
 }
 

--- a/test/sql/attach/attach_duckdb_type.test
+++ b/test/sql/attach/attach_duckdb_type.test
@@ -2,6 +2,11 @@
 # description: Test attaching a file with type DUCKDB
 # group: [attach]
 
+require noforcestorage
+
+statement ok
+PRAGMA enable_verification
+
 statement ok
 ATTACH 'first.db' (TYPE DUCKDB);
 

--- a/test/sql/attach/attach_duckdb_type.test
+++ b/test/sql/attach/attach_duckdb_type.test
@@ -1,0 +1,14 @@
+# name: test/sql/attach/attach_duckdb_type.test
+# description: Test attaching a file with type DUCKDB
+# group: [attach]
+
+statement ok
+ATTACH 'first.db' (TYPE DUCKDB);
+
+query I
+SELECT database_name FROM duckdb_databases() ORDER BY 1;
+----
+first
+memory
+system
+temp

--- a/test/sql/attach/attach_duckdb_type.test
+++ b/test/sql/attach/attach_duckdb_type.test
@@ -8,7 +8,7 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-ATTACH 'first.db' (TYPE DUCKDB);
+ATTACH '__TEST_DIR__/first.db' (TYPE DUCKDB);
 
 query I
 SELECT database_name FROM duckdb_databases() ORDER BY 1;
@@ -17,3 +17,15 @@ first
 memory
 system
 temp
+
+# DUCKDB type does not allow unrecognized options
+
+statement error
+ATTACH '__TEST_DIR__/error.db' (TYPE DUCKDB, HELLO, OPTION 2);
+----
+Unrecognized option for attach
+
+statement error
+ATTACH '__TEST_DIR__/error.db' (HELLO, OPTION 2);
+----
+Unrecognized option for attach


### PR DESCRIPTION
This PR supports setting the duckdb database file type during `ATTACH`. This avoids acquiring a file handle to check the header to determine the file type.

```sql
ATTACH 'my.db' (TYPE DUCKDB);
```

I also tidied up the code a bit more.