### PR TITLE
add list of collations that are required to determine equality. 

### DIFF
--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -238,7 +238,7 @@ void IcuExtension::Load(DuckDB &ddb) {
 		}
 		collation = StringUtil::Lower(collation);
 
-		CreateCollationInfo info(collation, GetICUFunction(collation), false, true);
+		CreateCollationInfo info(collation, GetICUFunction(collation), false, false);
 		ExtensionUtil::RegisterCollation(db, info);
 	}
 	ScalarFunction sort_key("icu_sort_key", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,

--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -32,7 +32,6 @@
 #include "unicode/ucol.h"
 
 #include <cassert>
-#include "iostream"
 
 namespace duckdb {
 
@@ -102,7 +101,7 @@ static void ICUCollateFunction(DataChunk &args, ExpressionState &state, Vector &
 			str_data[i * 2 + 1] = HEX_TABLE[byte % 16];
 		}
 		str_result.Finalize();
-//		printf("%s: %s\n", input.GetString().c_str(), str_result.GetString().c_str());
+		// printf("%s: %s\n", input.GetString().c_str(), str_result.GetString().c_str());
 		return str_result;
 	});
 }

--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -228,7 +228,6 @@ void IcuExtension::Load(DuckDB &ddb) {
 	// iterate over all the collations
 	int32_t count;
 	auto locales = icu::Collator::getAvailableLocales(count);
-	auto not_required_for_equality = true;
 	for (int32_t i = 0; i < count; i++) {
 		string collation;
 		if (string(locales[i].getCountry()).empty()) {
@@ -240,11 +239,7 @@ void IcuExtension::Load(DuckDB &ddb) {
 		}
 		collation = StringUtil::Lower(collation);
 
-		if (collation == "da") {
-			not_required_for_equality = false;
-		}
-		CreateCollationInfo info(collation, GetICUFunction(collation), false, not_required_for_equality);
-		not_required_for_equality = true;
+		CreateCollationInfo info(collation, GetICUFunction(collation), false, true);
 		ExtensionUtil::RegisterCollation(db, info);
 	}
 	ScalarFunction sort_key("icu_sort_key", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,

--- a/src/parser/parsed_data/create_collation_info.cpp
+++ b/src/parser/parsed_data/create_collation_info.cpp
@@ -9,9 +9,6 @@ CreateCollationInfo::CreateCollationInfo(string name_p, ScalarFunction function_
     : CreateInfo(CatalogType::COLLATION_ENTRY), function(std::move(function_p)), combinable(combinable_p),
       not_required_for_equality(not_required_for_equality_p) {
 	this->name = std::move(name_p);
-	if (equality_requires_collation.count(this->name) > 0) {
-		this->not_required_for_equality = false;
-	}
 	internal = true;
 }
 

--- a/src/parser/parsed_data/create_collation_info.cpp
+++ b/src/parser/parsed_data/create_collation_info.cpp
@@ -2,11 +2,16 @@
 
 namespace duckdb {
 
+static unordered_set<string> const equality_requires_collation = {"da"};
+
 CreateCollationInfo::CreateCollationInfo(string name_p, ScalarFunction function_p, bool combinable_p,
                                          bool not_required_for_equality_p)
     : CreateInfo(CatalogType::COLLATION_ENTRY), function(std::move(function_p)), combinable(combinable_p),
       not_required_for_equality(not_required_for_equality_p) {
 	this->name = std::move(name_p);
+	if (equality_requires_collation.count(this->name) > 0) {
+		this->not_required_for_equality = false;
+	}
 	internal = true;
 }
 

--- a/src/parser/parsed_data/create_collation_info.cpp
+++ b/src/parser/parsed_data/create_collation_info.cpp
@@ -2,8 +2,6 @@
 
 namespace duckdb {
 
-static unordered_set<string> const equality_requires_collation = {"da"};
-
 CreateCollationInfo::CreateCollationInfo(string name_p, ScalarFunction function_p, bool combinable_p,
                                          bool not_required_for_equality_p)
     : CreateInfo(CatalogType::COLLATION_ENTRY), function(std::move(function_p)), combinable(combinable_p),

--- a/test/sql/collate/test_icu_collate.test
+++ b/test/sql/collate/test_icu_collate.test
@@ -82,3 +82,41 @@ statement error
 SELECT icu_sort_key('goose', 'DUCK_DUCK_ENUM');
 ----
 Invalid Input Error
+
+
+# issue duckdb/duckdb#9692
+query I
+select chr(2*16*256+1*256+2*16+11) collate da  =chr(12*16+5) collate da;
+----
+True
+
+
+query I
+select icu_sort_key(chr(2*16*256+1*256+2*16+11),'da')=icu_sort_key(chr(12*16+5),'da');
+----
+True
+
+query I
+select chr(2*16*256+1*256+2*16+11) collate da > chr(12*16+5) collate da;
+----
+FALSE
+
+query I
+select chr(2*16*256+1*256+2*16+11) collate da > chr(12*16+5) collate da;
+----
+FALSE
+
+query I
+select count(*) from (select chr(2*16*256+1*256+2*16+11) union select chr(12*16+5)) as t(s) group by s collate da;
+----
+2
+
+query I
+select nfc_normalize(chr(2*16*256+1*256+2*16+11))=nfc_normalize(chr(12*16+5));
+----
+TRUE
+
+query I
+select count(*) from (select chr(2*16*256+1*256+2*16+11) union select chr(12*16+5)) as t(s) group by s collate nfc;
+----
+2


### PR DESCRIPTION
For some collations, we cannot do a normal byte comparison for equality. The collation information is needed instead.

"da" Is the only one I know of so far. @carlopi has suggested to write a script to check all collations and character equalities to see if there are other collations that are required to evaluate equality.

