### PR TITLE
Close s3 filehandle on destruction

### DIFF
--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -112,6 +112,8 @@ public:
 			throw NotImplementedException("Cannot open an HTTP file for appending");
 		}
 	}
+	~S3FileHandle() override;
+
 	S3AuthParams auth_params;
 	const S3ConfigParams config_params;
 

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -231,6 +231,10 @@ S3AuthParams S3AuthParams::ReadFrom(FileOpener *opener, FileOpenerInfo &info) {
 	        endpoint, url_style,     use_ssl,           s3_url_compatibility_mode};
 }
 
+S3FileHandle::~S3FileHandle() {
+	Close();
+}
+
 S3ConfigParams S3ConfigParams::ReadFrom(FileOpener *opener) {
 	uint64_t uploader_max_filesize;
 	uint64_t max_parts_per_file;


### PR DESCRIPTION
Fixes #9727 

S3 filehandle would not close automatically for s3 filehandles meaning that the multipart uploads would never be finished when the filehandle was not explicitly closed.