### PR TITLE
Issue #9755: TIMESTAMP_XX DOUBLE Parts

### DIFF
--- a/src/core_functions/scalar/date/date_part.cpp
+++ b/src/core_functions/scalar/date/date_part.cpp
@@ -1335,6 +1335,9 @@ static unique_ptr<FunctionData> DatePartBind(ClientContext &context, ScalarFunct
 		bound_function.return_type = LogicalType::DOUBLE;
 		switch (arguments[0]->return_type.id()) {
 		case LogicalType::TIMESTAMP:
+		case LogicalType::TIMESTAMP_S:
+		case LogicalType::TIMESTAMP_MS:
+		case LogicalType::TIMESTAMP_NS:
 			bound_function.function = DatePart::UnaryFunction<timestamp_t, double, DatePart::JulianDayOperator>;
 			bound_function.statistics = DatePart::JulianDayOperator::template PropagateStatistics<timestamp_t>;
 			break;
@@ -1353,6 +1356,9 @@ static unique_ptr<FunctionData> DatePartBind(ClientContext &context, ScalarFunct
 		bound_function.return_type = LogicalType::DOUBLE;
 		switch (arguments[0]->return_type.id()) {
 		case LogicalType::TIMESTAMP:
+		case LogicalType::TIMESTAMP_S:
+		case LogicalType::TIMESTAMP_MS:
+		case LogicalType::TIMESTAMP_NS:
 			bound_function.function = DatePart::UnaryFunction<timestamp_t, double, DatePart::EpochOperator>;
 			bound_function.statistics = DatePart::EpochOperator::template PropagateStatistics<timestamp_t>;
 			break;

--- a/test/sql/function/timestamp/test_date_part.test
+++ b/test/sql/function/timestamp/test_date_part.test
@@ -194,6 +194,22 @@ WHERE p <> f
 
 endloop
 
+# Cast injection for DOUBLE types
+foreach tstype TIMESTAMP TIMESTAMP_S TIMESTAMP_MS TIMESTAMP_NS
+
+query I
+SELECT EXTRACT(EPOCH FROM ${tstype} '1992-09-20 11:30:00.0');
+----
+716988600.0
+
+query I
+SELECT EXTRACT(JULIAN FROM ${tstype} '1992-09-20 00:00:00.0');
+----
+2448886.0
+
+endloop
+
+
 #
 # Structs
 #


### PR DESCRIPTION
Handle the different precision timstamp types for the special DOUBLE returning date parts (epoch and julian).

fixes: #9755
fixes: duckdblabs/duckdb-internal#761