### PR TITLE
ATTACH - Always run ExtractExtensionPrefix also if a name is provided

### DIFF
--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/storage/storage_extension.hpp"
+#include "duckdb/main/database_path_and_type.hpp"
 
 namespace duckdb {
 
@@ -66,9 +67,12 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 	// get the name and path of the database
 	auto &name = info->name;
 	auto &path = info->path;
+	if (db_type.empty()) {
+		DBPathAndType::ExtractExtensionPrefix(path, db_type);
+	}
 	if (name.empty()) {
 		auto &fs = FileSystem::GetFileSystem(context.client);
-		name = AttachedDatabase::ExtractDatabaseNameAndType(path, db_type, fs);
+		name = AttachedDatabase::ExtractDatabaseName(path, fs);
 	}
 
 	// check ATTACH IF NOT EXISTS

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -62,7 +62,6 @@ public:
 	void SetInitialDatabase();
 
 	static string ExtractDatabaseName(const string &dbpath, FileSystem &fs);
-	static string ExtractDatabaseNameAndType(string &dbpath, string &db_type, FileSystem &fs);
 
 private:
 	DatabaseInstance &db;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -101,14 +101,6 @@ bool AttachedDatabase::IsReadOnly() const {
 	return type == AttachedDatabaseType::READ_ONLY_DATABASE;
 }
 
-string AttachedDatabase::ExtractDatabaseNameAndType(string &dbpath, string &db_type, FileSystem &fs) {
-	// try to extract database type from path
-	if (db_type.empty()) {
-		DBPathAndType::ExtractExtensionPrefix(dbpath, db_type);
-	}
-	return AttachedDatabase::ExtractDatabaseName(dbpath, fs);
-}
-
 string AttachedDatabase::ExtractDatabaseName(const string &dbpath, FileSystem &fs) {
 	if (dbpath.empty() || dbpath == IN_MEMORY_PATH) {
 		return "memory";


### PR DESCRIPTION
Fixes an issue where the extension type was not correctly extracted if a name was provided