### PR TITLE
Internal #766: SkipList Coin Toss

### DIFF
--- a/third_party/skiplist/Node.h
+++ b/third_party/skiplist/Node.h
@@ -80,6 +80,7 @@ public:
 
 		_Compare _compare;
 		Node* cache;
+		pcg32_fast prng;
 	};
 
     Node(const T &value, _Compare _cmp, _Pool &pool);
@@ -133,7 +134,7 @@ protected:
 		_nodeRefs.clear();
 		do {
 			_nodeRefs.push_back(this, _nodeRefs.height() ? 0 : 1);
-		} while (tossCoin());
+		} while (_pool.prng() < _pool.prng.max() / 2);
 	}
 
 protected:

--- a/third_party/skiplist/SkipList.h
+++ b/third_party/skiplist/SkipList.h
@@ -447,6 +447,7 @@
 #include <set> // Used for HeadNode::_lacksIntegrityNodeReferencesNotInList()
 #include <string> // Used for class Exception
 #include <random>
+#include "pcg_random.hpp"
 
 #ifdef DEBUG
 #include <cassert>


### PR DESCRIPTION
Replace the use of rand/srand with pcg32_fast in the pool. This also seems to improve performance by about 15%.

fixes: duckdblabs/duckdb-internal#766