### PR TITLE
Issue #9762: Interval Fractional Seconds  

### DIFF
--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -39,6 +39,7 @@ bool Interval::FromCString(const char *str, idx_t len, interval_t &result, strin
 	bool negative;
 	bool found_any = false;
 	int64_t number;
+	int64_t fraction;
 	DatePartSpecifier specifier;
 	string specifier_str;
 
@@ -103,8 +104,19 @@ interval_parse_number:
 			// finished the number, parse it from the string
 			string_t nr_string(str + start_pos, pos - start_pos);
 			number = Cast::Operation<string_t, int64_t>(nr_string);
+			fraction = 0;
+			if (c == '.') {
+				// we expect some microseconds
+				int32_t mult = 100000;
+				for (++pos; pos < len && StringUtil::CharacterIsDigit(str[pos]); ++pos, mult /= 10) {
+					if (mult > 0) {
+						fraction += (str[pos] - '0') * mult;
+					}
+				}
+			}
 			if (negative) {
 				number = -number;
+				fraction = -fraction;
 			}
 			goto interval_parse_identifier;
 		}
@@ -146,6 +158,24 @@ interval_parse_identifier:
 		}
 	}
 	specifier_str = string(str + start_pos, pos - start_pos);
+
+	// Special case SS[.FFFFFF] - implied SECONDS/MICROSECONDS
+	if (specifier_str.empty() && !found_any) {
+		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_SEC);
+		IntervalTryAddition<int64_t>(result.micros, fraction, 1);
+		found_any = true;
+		// parse any trailing whitespace
+		for (; pos < len; pos++) {
+			char c = str[pos];
+			if (c == ' ' || c == '\t' || c == '\n') {
+				continue;
+			} else {
+				return false;
+			}
+		}
+		goto end_of_string;
+	}
+
 	if (!TryGetDatePartSpecifier(specifier_str, specifier)) {
 		HandleCastError::AssignError(StringUtil::Format("extract specifier \"%s\" not recognized", specifier_str),
 		                             error_message);

--- a/src/core_functions/scalar/date/functions.json
+++ b/src/core_functions/scalar/date/functions.json
@@ -321,9 +321,9 @@
     },
     {
         "name": "to_hours",
-        "parameters": "integer",
+        "parameters": "double",
         "description": "Construct a hour interval",
-        "example": "to_hours(5)",
+        "example": "to_hours(5.5)",
         "type": "scalar_function"
     },
     {
@@ -335,16 +335,16 @@
     },
     {
         "name": "to_milliseconds",
-        "parameters": "integer",
+        "parameters": "double",
         "description": "Construct a millisecond interval",
-        "example": "to_milliseconds(5)",
+        "example": "to_milliseconds(5.5)",
         "type": "scalar_function"
     },
     {
         "name": "to_minutes",
-        "parameters": "integer",
+        "parameters": "double",
         "description": "Construct a minute interval",
-        "example": "to_minutes(5)",
+        "example": "to_minutes(5.5)",
         "type": "scalar_function"
     },
     {
@@ -356,9 +356,9 @@
     },
     {
         "name": "to_seconds",
-        "parameters": "integer",
+        "parameters": "double",
         "description": "Construct a second interval",
-        "example": "to_seconds(5)",
+        "example": "to_seconds(5.5)",
         "type": "scalar_function"
     },
     {

--- a/src/core_functions/scalar/date/to_interval.cpp
+++ b/src/core_functions/scalar/date/to_interval.cpp
@@ -1,9 +1,15 @@
 #include "duckdb/core_functions/scalar/date_functions.hpp"
 #include "duckdb/common/types/interval.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/core_functions/to_interval.hpp"
 
 namespace duckdb {
+
+template <>
+bool TryMultiplyOperator::Operation(double left, int64_t right, int64_t &result) {
+	return TryCast::Operation<double, int64_t>(left * right, result);
+}
 
 struct ToYearsOperator {
 	template <class TA, class TR>
@@ -47,9 +53,8 @@ struct ToHoursOperator {
 		interval_t result;
 		result.months = 0;
 		result.days = 0;
-		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_HOUR,
-		                                                               result.micros)) {
-			throw OutOfRangeException("Interval value %d hours out of range", input);
+		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::MICROS_PER_HOUR, result.micros)) {
+			throw OutOfRangeException("Interval value %s hours out of range", NumericHelper::ToString(input));
 		}
 		return result;
 	}
@@ -61,9 +66,8 @@ struct ToMinutesOperator {
 		interval_t result;
 		result.months = 0;
 		result.days = 0;
-		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_MINUTE,
-		                                                               result.micros)) {
-			throw OutOfRangeException("Interval value %d minutes out of range", input);
+		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::MICROS_PER_MINUTE, result.micros)) {
+			throw OutOfRangeException("Interval value %s minutes out of range", NumericHelper::ToString(input));
 		}
 		return result;
 	}
@@ -75,9 +79,8 @@ struct ToMilliSecondsOperator {
 		interval_t result;
 		result.months = 0;
 		result.days = 0;
-		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_MSEC,
-		                                                               result.micros)) {
-			throw OutOfRangeException("Interval value %d milliseconds out of range", input);
+		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::MICROS_PER_MSEC, result.micros)) {
+			throw OutOfRangeException("Interval value %s milliseconds out of range", NumericHelper::ToString(input));
 		}
 		return result;
 	}
@@ -110,23 +113,23 @@ ScalarFunction ToDaysFun::GetFunction() {
 }
 
 ScalarFunction ToHoursFun::GetFunction() {
-	return ScalarFunction({LogicalType::BIGINT}, LogicalType::INTERVAL,
-	                      ScalarFunction::UnaryFunction<int64_t, interval_t, ToHoursOperator>);
+	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::INTERVAL,
+	                      ScalarFunction::UnaryFunction<double, interval_t, ToHoursOperator>);
 }
 
 ScalarFunction ToMinutesFun::GetFunction() {
-	return ScalarFunction({LogicalType::BIGINT}, LogicalType::INTERVAL,
-	                      ScalarFunction::UnaryFunction<int64_t, interval_t, ToMinutesOperator>);
+	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::INTERVAL,
+	                      ScalarFunction::UnaryFunction<double, interval_t, ToMinutesOperator>);
 }
 
 ScalarFunction ToSecondsFun::GetFunction() {
-	return ScalarFunction({LogicalType::BIGINT}, LogicalType::INTERVAL,
-	                      ScalarFunction::UnaryFunction<int64_t, interval_t, ToSecondsOperator>);
+	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::INTERVAL,
+	                      ScalarFunction::UnaryFunction<double, interval_t, ToSecondsOperator>);
 }
 
 ScalarFunction ToMillisecondsFun::GetFunction() {
-	return ScalarFunction({LogicalType::BIGINT}, LogicalType::INTERVAL,
-	                      ScalarFunction::UnaryFunction<int64_t, interval_t, ToMilliSecondsOperator>);
+	return ScalarFunction({LogicalType::DOUBLE}, LogicalType::INTERVAL,
+	                      ScalarFunction::UnaryFunction<double, interval_t, ToMilliSecondsOperator>);
 }
 
 ScalarFunction ToMicrosecondsFun::GetFunction() {

--- a/src/include/duckdb/core_functions/scalar/date_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/date_functions.hpp
@@ -446,9 +446,9 @@ struct ToDaysFun {
 
 struct ToHoursFun {
 	static constexpr const char *Name = "to_hours";
-	static constexpr const char *Parameters = "integer";
+	static constexpr const char *Parameters = "double";
 	static constexpr const char *Description = "Construct a hour interval";
-	static constexpr const char *Example = "to_hours(5)";
+	static constexpr const char *Example = "to_hours(5.5)";
 
 	static ScalarFunction GetFunction();
 };
@@ -464,18 +464,18 @@ struct ToMicrosecondsFun {
 
 struct ToMillisecondsFun {
 	static constexpr const char *Name = "to_milliseconds";
-	static constexpr const char *Parameters = "integer";
+	static constexpr const char *Parameters = "double";
 	static constexpr const char *Description = "Construct a millisecond interval";
-	static constexpr const char *Example = "to_milliseconds(5)";
+	static constexpr const char *Example = "to_milliseconds(5.5)";
 
 	static ScalarFunction GetFunction();
 };
 
 struct ToMinutesFun {
 	static constexpr const char *Name = "to_minutes";
-	static constexpr const char *Parameters = "integer";
+	static constexpr const char *Parameters = "double";
 	static constexpr const char *Description = "Construct a minute interval";
-	static constexpr const char *Example = "to_minutes(5)";
+	static constexpr const char *Example = "to_minutes(5.5)";
 
 	static ScalarFunction GetFunction();
 };
@@ -491,9 +491,9 @@ struct ToMonthsFun {
 
 struct ToSecondsFun {
 	static constexpr const char *Name = "to_seconds";
-	static constexpr const char *Parameters = "integer";
+	static constexpr const char *Parameters = "double";
 	static constexpr const char *Description = "Construct a second interval";
-	static constexpr const char *Example = "to_seconds(5)";
+	static constexpr const char *Example = "to_seconds(5.5)";
 
 	static ScalarFunction GetFunction();
 };

--- a/src/include/duckdb/core_functions/to_interval.hpp
+++ b/src/include/duckdb/core_functions/to_interval.hpp
@@ -19,9 +19,8 @@ struct ToSecondsOperator {
 		interval_t result;
 		result.months = 0;
 		result.days = 0;
-		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_SEC,
-		                                                               result.micros)) {
-			throw OutOfRangeException("Interval value %d seconds out of range", input);
+		if (!TryMultiplyOperator::Operation<TA, int64_t, int64_t>(input, Interval::MICROS_PER_SEC, result.micros)) {
+			throw OutOfRangeException("Interval value %s seconds out of range", NumericHelper::ToString(input));
 		}
 		return result;
 	}

--- a/src/parser/transform/expression/transform_interval.cpp
+++ b/src/parser/transform/expression/transform_interval.cpp
@@ -88,19 +88,19 @@ unique_ptr<ParsedExpression> Transformer::TransformInterval(duckdb_libpgquery::P
 	} else if (mask & HOUR_MASK) {
 		// HOUR
 		fname = "to_hours";
-		target_type = LogicalType::BIGINT;
+		target_type = LogicalType::DOUBLE;
 	} else if (mask & MINUTE_MASK) {
 		// MINUTE
 		fname = "to_minutes";
-		target_type = LogicalType::BIGINT;
+		target_type = LogicalType::DOUBLE;
 	} else if (mask & SECOND_MASK) {
 		// SECOND
 		fname = "to_seconds";
-		target_type = LogicalType::BIGINT;
+		target_type = LogicalType::DOUBLE;
 	} else if (mask & MILLISECOND_MASK) {
 		// MILLISECOND
 		fname = "to_milliseconds";
-		target_type = LogicalType::BIGINT;
+		target_type = LogicalType::DOUBLE;
 	} else if (mask & MICROSECOND_MASK) {
 		// SECOND
 		fname = "to_microseconds";

--- a/test/sql/types/interval/interval_constants.test
+++ b/test/sql/types/interval/interval_constants.test
@@ -146,3 +146,38 @@ query I
 select timestamp '1992-01-01 12:00:00' + (interval 3 microseconds + interval 3 milliseconds)
 ----
 1992-01-01 12:00:00.003003
+
+# Fractional seconds
+query I
+select interval '10.123' second;
+----
+00:00:10.123
+
+query I
+select '47.210'::interval;
+----
+00:00:47.21
+
+# Negative values
+query I
+select '-47.210'::interval;
+----
+-00:00:47.21
+
+# Trailing spaces
+query I
+select '47.210  '::interval;
+----
+00:00:47.21
+
+# Nanoseconds are OK
+query I
+select '31.123456789'::interval;
+----
+00:00:31.123456
+
+# Non-alpha specifiers are still not OK
+statement error
+select '47.210 5'::interval;
+----
+Could not convert string '47.210 5' to INTERVAL

--- a/test/sql/window/test_window_wide_frame.test_slow
+++ b/test/sql/window/test_window_wide_frame.test_slow
@@ -25,4 +25,4 @@ window w as (order by timestamp asc range between interval 55 seconds preceding 
 order by 3 desc
 limit 1;
 ----
-2020-10-15 16:58:11	50.000000	3394
+2020-10-15 16:58:10.318385	50.000000	3363


### PR DESCRIPTION
* Convert the to_timepart functions to take DOUBLE instead of BIGINT.
* Parse decimal strings as intervals with implied SECONDS/MICROSECONDS specifiers.

fixes: https://github.com/duckdb/duckdb/issues/9762
fixes: duckdblabs/duckdb-internal#765