### PR TITLE
chore: move links duckdblabs -> duckdb

### DIFF
--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -9,7 +9,7 @@ tpcds,,,
 tpch,,,
 visualizer,,,
 sqlite_scanner,https://github.com/duckdblabs/sqlite_scanner,3443b2999ae1e68a108568fd32145705237a5760,
-postgres_scanner,https://github.com/duckdblabs/postgres_scanner,844f46536b5d5f9e65b57b7ff92f4ce3346e2829,
+postgres_scanner,https://github.com/duckdb/postgres_scanner,844f46536b5d5f9e65b57b7ff92f4ce3346e2829,
 substrait,https://github.com/duckdblabs/substrait,5d621b1d7d16fe86f8b1930870c8e6bf05bcb92a,no-windows
 arrow,https://github.com/duckdblabs/arrow,1b5b9649d28cd7f79496fb3f2e4dd7b03bf90ac5,no-windows
 aws,https://github.com/duckdblabs/duckdb_aws,348ae2625de86ab760f80a43eb76e4441cd01354,

--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -10,7 +10,7 @@ tpch,,,
 visualizer,,,
 sqlite_scanner,https://github.com/duckdb/sqlite_scanner,3443b2999ae1e68a108568fd32145705237a5760,
 postgres_scanner,https://github.com/duckdb/postgres_scanner,844f46536b5d5f9e65b57b7ff92f4ce3346e2829,
-substrait,https://github.com/duckdblabs/substrait,5d621b1d7d16fe86f8b1930870c8e6bf05bcb92a,no-windows
+substrait,https://github.com/duckdb/substrait,5d621b1d7d16fe86f8b1930870c8e6bf05bcb92a,no-windows
 arrow,https://github.com/duckdblabs/arrow,1b5b9649d28cd7f79496fb3f2e4dd7b03bf90ac5,no-windows
 aws,https://github.com/duckdblabs/duckdb_aws,348ae2625de86ab760f80a43eb76e4441cd01354,
 azure,https://github.com/duckdblabs/azure,1fe568d3eb3c8842118e395ba8031e2a8566daed,

--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -13,6 +13,6 @@ postgres_scanner,https://github.com/duckdb/postgres_scanner,844f46536b5d5f9e65b5
 substrait,https://github.com/duckdb/substrait,5d621b1d7d16fe86f8b1930870c8e6bf05bcb92a,no-windows
 arrow,https://github.com/duckdb/arrow,1b5b9649d28cd7f79496fb3f2e4dd7b03bf90ac5,no-windows
 aws,https://github.com/duckdb/duckdb_aws,348ae2625de86ab760f80a43eb76e4441cd01354,
-azure,https://github.com/duckdblabs/azure,1fe568d3eb3c8842118e395ba8031e2a8566daed,
-spatial,https://github.com/duckdblabs/duckdb_spatial.git,36e5a126976ac3b66716893360ef7e6295707082,
+azure,https://github.com/duckdb/duckdb_azure,1fe568d3eb3c8842118e395ba8031e2a8566daed,
+spatial,https://github.com/duckdb/duckdb_spatial,36e5a126976ac3b66716893360ef7e6295707082,
 iceberg,https://github.com/duckdblabs/duckdb_iceberg.git,51ba9564859698c29db4165f17143a2f6af2bb18,

--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -12,7 +12,7 @@ sqlite_scanner,https://github.com/duckdb/sqlite_scanner,3443b2999ae1e68a108568fd
 postgres_scanner,https://github.com/duckdb/postgres_scanner,844f46536b5d5f9e65b57b7ff92f4ce3346e2829,
 substrait,https://github.com/duckdb/substrait,5d621b1d7d16fe86f8b1930870c8e6bf05bcb92a,no-windows
 arrow,https://github.com/duckdb/arrow,1b5b9649d28cd7f79496fb3f2e4dd7b03bf90ac5,no-windows
-aws,https://github.com/duckdblabs/duckdb_aws,348ae2625de86ab760f80a43eb76e4441cd01354,
+aws,https://github.com/duckdb/duckdb_aws,348ae2625de86ab760f80a43eb76e4441cd01354,
 azure,https://github.com/duckdblabs/azure,1fe568d3eb3c8842118e395ba8031e2a8566daed,
 spatial,https://github.com/duckdblabs/duckdb_spatial.git,36e5a126976ac3b66716893360ef7e6295707082,
 iceberg,https://github.com/duckdblabs/duckdb_iceberg.git,51ba9564859698c29db4165f17143a2f6af2bb18,

--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -11,7 +11,7 @@ visualizer,,,
 sqlite_scanner,https://github.com/duckdb/sqlite_scanner,3443b2999ae1e68a108568fd32145705237a5760,
 postgres_scanner,https://github.com/duckdb/postgres_scanner,844f46536b5d5f9e65b57b7ff92f4ce3346e2829,
 substrait,https://github.com/duckdb/substrait,5d621b1d7d16fe86f8b1930870c8e6bf05bcb92a,no-windows
-arrow,https://github.com/duckdblabs/arrow,1b5b9649d28cd7f79496fb3f2e4dd7b03bf90ac5,no-windows
+arrow,https://github.com/duckdb/arrow,1b5b9649d28cd7f79496fb3f2e4dd7b03bf90ac5,no-windows
 aws,https://github.com/duckdblabs/duckdb_aws,348ae2625de86ab760f80a43eb76e4441cd01354,
 azure,https://github.com/duckdblabs/azure,1fe568d3eb3c8842118e395ba8031e2a8566daed,
 spatial,https://github.com/duckdblabs/duckdb_spatial.git,36e5a126976ac3b66716893360ef7e6295707082,

--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -8,7 +8,7 @@ parquet,,,
 tpcds,,,
 tpch,,,
 visualizer,,,
-sqlite_scanner,https://github.com/duckdblabs/sqlite_scanner,3443b2999ae1e68a108568fd32145705237a5760,
+sqlite_scanner,https://github.com/duckdb/sqlite_scanner,3443b2999ae1e68a108568fd32145705237a5760,
 postgres_scanner,https://github.com/duckdb/postgres_scanner,844f46536b5d5f9e65b57b7ff92f4ce3346e2829,
 substrait,https://github.com/duckdblabs/substrait,5d621b1d7d16fe86f8b1930870c8e6bf05bcb92a,no-windows
 arrow,https://github.com/duckdblabs/arrow,1b5b9649d28cd7f79496fb3f2e4dd7b03bf90ac5,no-windows

--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -15,4 +15,4 @@ arrow,https://github.com/duckdb/arrow,1b5b9649d28cd7f79496fb3f2e4dd7b03bf90ac5,n
 aws,https://github.com/duckdb/duckdb_aws,348ae2625de86ab760f80a43eb76e4441cd01354,
 azure,https://github.com/duckdb/duckdb_azure,1fe568d3eb3c8842118e395ba8031e2a8566daed,
 spatial,https://github.com/duckdb/duckdb_spatial,36e5a126976ac3b66716893360ef7e6295707082,
-iceberg,https://github.com/duckdblabs/duckdb_iceberg.git,51ba9564859698c29db4165f17143a2f6af2bb18,
+iceberg,https://github.com/duckdb/duckdb_iceberg,51ba9564859698c29db4165f17143a2f6af2bb18,

--- a/.github/patches/extensions/README.md
+++ b/.github/patches/extensions/README.md
@@ -7,7 +7,7 @@ lets say our extension config looks like this:
 ```shell
 duckdb_extension_load(spatial
     DONT_LINK
-    GIT_URL https://github.com/duckdblabs/duckdb_spatial.git
+    GIT_URL https://github.com/duckdb/duckdb_spatial
     GIT_TAG f577b9441793f9170403e489f5d3587e023a945f
     APPLY_PATCHES
 )

--- a/.github/workflows/ExtensionRebuild.yml
+++ b/.github/workflows/ExtensionRebuild.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       extension_repo:
-        description: 'Extension git repo (e.g. https://github.com/duckdblabs/postgres_scanner)'
+        description: 'Extension git repo (e.g. https://github.com/duckdb/postgres_scanner)'
         required: true
         type: string
       extension_ref:

--- a/.github/workflows/ExtensionTrigger.yml
+++ b/.github/workflows/ExtensionTrigger.yml
@@ -12,4 +12,4 @@ jobs:
 
     - name: Trigger Substrait Extension
       run: |
-        curl -XPOST -u "${{secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/duckdblabs/substrait/dispatches --data '{"event_type": "build_application"}'
+        curl -XPOST -u "${{secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/duckdb/substrait/dispatches --data '{"event_type": "build_application"}'

--- a/extension/README.md
+++ b/extension/README.md
@@ -123,7 +123,7 @@ cmake build directory and build it from there:
 ```cmake
 duckdb_extension_load(postgres_scanner
     (DONT_LINK)
-    GIT_URL https://github.com/duckdblabs/postgres_scanner
+    GIT_URL https://github.com/duckdb/postgres_scanner
     GIT_TAG cd043b49cdc9e0d3752535b8333c9433e1007a48
 )
 ```


### PR DESCRIPTION
This changes some links that caught my eye from the duckdblabs organisation to duckdb. 
Hope this helps.