### PR TITLE
Make FORCE CHECKPOINT abort transactions of concurrently running queries

### DIFF
--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -44,6 +44,7 @@ public:
 	}
 
 	Transaction &GetTransaction(AttachedDatabase &db);
+	void RemoveTransaction(AttachedDatabase &db);
 
 	string Commit();
 	void Rollback();
@@ -58,7 +59,7 @@ public:
 
 private:
 	//! The set of active transactions for each database
-	unordered_map<AttachedDatabase *, Transaction *> transactions;
+	unordered_map<AttachedDatabase *, optional_ptr<Transaction>> transactions;
 	//! The set of transactions in order of when they were started
 	vector<optional_ptr<AttachedDatabase>> all_transactions;
 	//! The database we are modifying - we can only modify one database per transaction

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -40,6 +40,22 @@ Transaction &MetaTransaction::GetTransaction(AttachedDatabase &db) {
 	}
 }
 
+void MetaTransaction::RemoveTransaction(AttachedDatabase &db) {
+	auto entry = transactions.find(&db);
+	if (entry == transactions.end()) {
+		throw InternalException("MetaTransaction::RemoveTransaction called but meta transaction did not have a "
+		                        "transaction for this database");
+	}
+	transactions.erase(entry);
+	for (idx_t i = 0; i < all_transactions.size(); i++) {
+		auto &db_entry = all_transactions[i];
+		if (db_entry.get() == &db) {
+			all_transactions.erase(all_transactions.begin() + i);
+			break;
+		}
+	}
+}
+
 Transaction &Transaction::Get(ClientContext &context, Catalog &catalog) {
 	return Transaction::Get(context, catalog.GetAttached());
 }
@@ -57,10 +73,10 @@ string MetaTransaction::Commit() {
 		auto transaction = entry->second;
 		if (error.empty()) {
 			// commit
-			error = transaction_manager.CommitTransaction(context, transaction);
+			error = transaction_manager.CommitTransaction(context, transaction.get());
 		} else {
 			// we have encountered an error previously - roll back subsequent entries
-			transaction_manager.RollbackTransaction(transaction);
+			transaction_manager.RollbackTransaction(transaction.get());
 		}
 	}
 	return error;
@@ -74,7 +90,7 @@ void MetaTransaction::Rollback() {
 		auto entry = transactions.find(db.get());
 		D_ASSERT(entry != transactions.end());
 		auto transaction = entry->second;
-		transaction_manager.RollbackTransaction(transaction);
+		transaction_manager.RollbackTransaction(transaction.get());
 	}
 }
 

--- a/test/sql/storage/force_checkpoint_abort.test
+++ b/test/sql/storage/force_checkpoint_abort.test
@@ -1,0 +1,38 @@
+# name: test/sql/storage/force_checkpoint_abort.test
+# description: Test behavior of FORCE CHECKPOINT
+# group: [storage]
+
+require skip_reload
+
+load __TEST_DIR__/force_checkpoint_abort.db
+
+statement ok
+CREATE TABLE integers(i INT)
+
+statement ok
+INSERT INTO integers VALUES (1), (2), (3), (NULL);
+
+statement ok con2
+BEGIN
+
+statement ok con2
+UPDATE integers SET i=i+1;
+
+statement ok con1
+FORCE CHECKPOINT
+
+statement error con2
+SELECT * FROM integers
+----
+Current transaction is aborted
+
+statement ok con2
+ROLLBACK
+
+query I con2
+SELECT * FROM integers
+----
+1
+2
+3
+NULL

--- a/test/sql/storage/multiple_clients_checkpoing_dependents.test_slow
+++ b/test/sql/storage/multiple_clients_checkpoing_dependents.test_slow
@@ -49,8 +49,7 @@ SELECT MIN(i), MAX(i), COUNT(*) FROM test;
 ----
 1	1000000	1000000
 
-# force checkpoint has cleared our current transaction, so we can't rollback
-statement error con2
+statement ok con2
 ROLLBACK
 
 statement ok con2

--- a/test/sql/storage/multiple_clients_checkpoint_pending_updates.test
+++ b/test/sql/storage/multiple_clients_checkpoint_pending_updates.test
@@ -26,6 +26,14 @@ statement ok con2
 FORCE CHECKPOINT
 
 # force checkpoint rolled back the transaction of con1
+statement error con1
+SELECT MIN(i), MAX(i), COUNT(*) FROM test;
+----
+transaction is aborted
+
+statement ok con1
+ROLLBACK
+
 query III con1
 SELECT MIN(i), MAX(i), COUNT(*) FROM test;
 ----
@@ -93,20 +101,52 @@ SELECT MIN(i), MAX(i), COUNT(*) FROM test;
 ----
 0	999999	1000000
 
+statement error con2
+SELECT MIN(i), MAX(i), COUNT(*) FROM test;
+----
+transaction is aborted
+
+statement ok con2
+ROLLBACK
+
 query III con2
 SELECT MIN(i), MAX(i), COUNT(*) FROM test;
 ----
 0	999999	1000000
+
+statement error con3
+SELECT MIN(i), MAX(i), COUNT(*) FROM test;
+----
+transaction is aborted
+
+statement ok con3
+ROLLBACK
 
 query III con3
 SELECT MIN(i), MAX(i), COUNT(*) FROM test;
 ----
 0	999999	1000000
 
+statement error con4
+SELECT MIN(i), MAX(i), COUNT(*) FROM test;
+----
+transaction is aborted
+
+statement ok con4
+ROLLBACK
+
 query III con4
 SELECT MIN(i), MAX(i), COUNT(*) FROM test;
 ----
 0	999999	1000000
+
+statement error con5
+SELECT MIN(i), MAX(i), COUNT(*) FROM test;
+----
+transaction is aborted
+
+statement ok con5
+ROLLBACK
 
 query III con5
 SELECT MIN(i), MAX(i), COUNT(*) FROM test;


### PR DESCRIPTION
Instead of silently rolling back concurrently running transactions, they are marked as aborted to avoid confusing scenarios where a transaction is rolled back and subsequent statements (which are assumed to be part of the same transaction) proceed as normal.