### PR TITLE
Correctly clean up database path when an error is thrown in attach

### DIFF
--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -31,21 +31,18 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType ty
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, string name_p, string file_path_p,
                                    AccessMode access_mode)
     : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p) {
-
-	db.GetDatabaseManager().InsertDatabasePath(file_path_p, name);
 	type = access_mode == AccessMode::READ_ONLY ? AttachedDatabaseType::READ_ONLY_DATABASE
 	                                            : AttachedDatabaseType::READ_WRITE_DATABASE;
 	storage = make_uniq<SingleFileStorageManager>(*this, std::move(file_path_p), access_mode == AccessMode::READ_ONLY);
 	catalog = make_uniq<DuckCatalog>(*this);
 	transaction_manager = make_uniq<DuckTransactionManager>(*this);
 	internal = true;
+	db.GetDatabaseManager().InsertDatabasePath(file_path_p, name);
 }
 
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension,
                                    string name_p, const AttachInfo &info, AccessMode access_mode)
     : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p) {
-
-	db.GetDatabaseManager().InsertDatabasePath(info.path, name);
 	type = access_mode == AccessMode::READ_ONLY ? AttachedDatabaseType::READ_ONLY_DATABASE
 	                                            : AttachedDatabaseType::READ_WRITE_DATABASE;
 	catalog = storage_extension.attach(storage_extension.storage_info.get(), *this, name, *info.Copy(), access_mode);
@@ -59,6 +56,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 		    "AttachedDatabase - create_transaction_manager function did not return a transaction manager");
 	}
 	internal = true;
+	db.GetDatabaseManager().InsertDatabasePath(info.path, name);
 }
 
 AttachedDatabase::~AttachedDatabase() {

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -37,7 +37,6 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 	catalog = make_uniq<DuckCatalog>(*this);
 	transaction_manager = make_uniq<DuckTransactionManager>(*this);
 	internal = true;
-	db.GetDatabaseManager().InsertDatabasePath(file_path_p, name);
 }
 
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension,
@@ -56,12 +55,11 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 		    "AttachedDatabase - create_transaction_manager function did not return a transaction manager");
 	}
 	internal = true;
-	db.GetDatabaseManager().InsertDatabasePath(info.path, name);
 }
 
 AttachedDatabase::~AttachedDatabase() {
-
 	D_ASSERT(catalog);
+
 	if (!IsSystem() && !catalog->InMemory()) {
 		db.GetDatabaseManager().EraseDatabasePath(catalog->GetDBPath());
 	}

--- a/test/sql/attach/attach_filepath_roundtrip.test
+++ b/test/sql/attach/attach_filepath_roundtrip.test
@@ -14,7 +14,7 @@ concurrentloop i 1 100
 statement maybe
 ATTACH '__TEST_DIR__/concurrent.db';
 ----
-already attached
+already
 
 endloop
 

--- a/test/sql/attach/attach_filepath_roundtrip.test
+++ b/test/sql/attach/attach_filepath_roundtrip.test
@@ -13,8 +13,6 @@ concurrentloop i 1 100
 
 statement maybe
 ATTACH '__TEST_DIR__/concurrent.db';
-----
-already
 
 endloop
 


### PR DESCRIPTION
This prevents an entry from being inserted into the `db_paths` preventing that same database from being opened again