### PR TITLE
Implement #2534 - add parquet_file_metadata function that supports scanning top-level file metadata

### DIFF
--- a/extension/parquet/include/parquet_metadata.hpp
+++ b/extension/parquet/include/parquet_metadata.hpp
@@ -28,4 +28,9 @@ public:
 	ParquetKeyValueMetadataFunction();
 };
 
+class ParquetFileMetadataFunction : public TableFunction {
+public:
+	ParquetFileMetadataFunction();
+};
+
 } // namespace duckdb

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -1223,6 +1223,10 @@ void ParquetExtension::Load(DuckDB &db) {
 	ParquetKeyValueMetadataFunction kv_meta_fun;
 	ExtensionUtil::RegisterFunction(db_instance, MultiFileReader::CreateFunctionSet(kv_meta_fun));
 
+	// parquet_file_metadata
+	ParquetFileMetadataFunction file_meta_fun;
+	ExtensionUtil::RegisterFunction(db_instance, MultiFileReader::CreateFunctionSet(file_meta_fun));
+
 	CopyFunction function("parquet");
 	function.copy_to_bind = ParquetWriteBind;
 	function.copy_to_initialize_global = ParquetWriteInitializeGlobal;

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -524,7 +524,6 @@ void ParquetMetaDataOperatorData::LoadFileMetaData(ClientContext &context, const
 	collection.Reset();
 	ParquetOptions parquet_options(context);
 	auto reader = make_uniq<ParquetReader>(context, file_path, parquet_options);
-	idx_t count = 0;
 	DataChunk current_chunk;
 	current_chunk.Initialize(context, return_types);
 	auto meta_data = reader->GetFileMetadata();

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -24,7 +24,7 @@ public:
 	}
 };
 
-enum class ParquetMetadataOperatorType { META_DATA, SCHEMA, KEY_VALUE_META_DATA };
+enum class ParquetMetadataOperatorType { META_DATA, SCHEMA, KEY_VALUE_META_DATA, FILE_META_DATA };
 
 struct ParquetMetaDataOperatorData : public GlobalTableFunctionState {
 	explicit ParquetMetaDataOperatorData(ClientContext &context, const vector<LogicalType> &types)
@@ -39,10 +39,12 @@ public:
 	static void BindMetaData(vector<LogicalType> &return_types, vector<string> &names);
 	static void BindSchema(vector<LogicalType> &return_types, vector<string> &names);
 	static void BindKeyValueMetaData(vector<LogicalType> &return_types, vector<string> &names);
+	static void BindFileMetaData(vector<LogicalType> &return_types, vector<string> &names);
 
-	void LoadFileMetaData(ClientContext &context, const vector<LogicalType> &return_types, const string &file_path);
+	void LoadRowGroupMetadata(ClientContext &context, const vector<LogicalType> &return_types, const string &file_path);
 	void LoadSchemaData(ClientContext &context, const vector<LogicalType> &return_types, const string &file_path);
 	void LoadKeyValueMetaData(ClientContext &context, const vector<LogicalType> &return_types, const string &file_path);
+	void LoadFileMetaData(ClientContext &context, const vector<LogicalType> &return_types, const string &file_path);
 };
 
 template <class T>
@@ -67,6 +69,13 @@ Value ParquetElementString(T &&value, bool is_set) {
 	return Value(ConvertParquetElementToString(value));
 }
 
+Value ParquetElementStringVal(const string &value, bool is_set) {
+	if (!is_set) {
+		return Value();
+	}
+	return Value(value);
+}
+
 template <class T>
 Value ParquetElementInteger(T &&value, bool is_iset) {
 	if (!is_iset) {
@@ -83,6 +92,9 @@ Value ParquetElementBigint(T &&value, bool is_iset) {
 	return Value::BIGINT(value);
 }
 
+//===--------------------------------------------------------------------===//
+// Row Group Meta Data
+//===--------------------------------------------------------------------===//
 void ParquetMetaDataOperatorData::BindMetaData(vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("file_name");
 	return_types.emplace_back(LogicalType::VARCHAR);
@@ -162,8 +174,8 @@ Value ConvertParquetStats(const LogicalType &type, const duckdb_parquet::format:
 	return ParquetStatisticsUtils::ConvertValue(type, schema_ele, stats).DefaultCastAs(LogicalType::VARCHAR);
 }
 
-void ParquetMetaDataOperatorData::LoadFileMetaData(ClientContext &context, const vector<LogicalType> &return_types,
-                                                   const string &file_path) {
+void ParquetMetaDataOperatorData::LoadRowGroupMetadata(ClientContext &context, const vector<LogicalType> &return_types,
+                                                       const string &file_path) {
 	collection.Reset();
 	ParquetOptions parquet_options(context);
 	auto reader = make_uniq<ParquetReader>(context, file_path, parquet_options);
@@ -292,6 +304,9 @@ void ParquetMetaDataOperatorData::LoadFileMetaData(ClientContext &context, const
 	collection.InitializeScan(scan_state);
 }
 
+//===--------------------------------------------------------------------===//
+// Schema Data
+//===--------------------------------------------------------------------===//
 void ParquetMetaDataOperatorData::BindSchema(vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("file_name");
 	return_types.emplace_back(LogicalType::VARCHAR);
@@ -433,7 +448,13 @@ void ParquetMetaDataOperatorData::LoadSchemaData(ClientContext &context, const v
 	collection.InitializeScan(scan_state);
 }
 
+//===--------------------------------------------------------------------===//
+// KV Meta Data
+//===--------------------------------------------------------------------===//
 void ParquetMetaDataOperatorData::BindKeyValueMetaData(vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("file_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
 	names.emplace_back("key");
 	return_types.emplace_back(LogicalType::BLOB);
 
@@ -454,8 +475,9 @@ void ParquetMetaDataOperatorData::LoadKeyValueMetaData(ClientContext &context, c
 	for (idx_t col_idx = 0; col_idx < meta_data->key_value_metadata.size(); col_idx++) {
 		auto &entry = meta_data->key_value_metadata[col_idx];
 
-		current_chunk.SetValue(0, count, Value::BLOB_RAW(entry.key));
-		current_chunk.SetValue(1, count, Value::BLOB_RAW(entry.value));
+		current_chunk.SetValue(0, count, Value(file_path));
+		current_chunk.SetValue(1, count, Value::BLOB_RAW(entry.key));
+		current_chunk.SetValue(2, count, Value::BLOB_RAW(entry.value));
 
 		count++;
 		if (count >= STANDARD_VECTOR_SIZE) {
@@ -471,15 +493,85 @@ void ParquetMetaDataOperatorData::LoadKeyValueMetaData(ClientContext &context, c
 	collection.InitializeScan(scan_state);
 }
 
+//===--------------------------------------------------------------------===//
+// File Meta Data
+//===--------------------------------------------------------------------===//
+void ParquetMetaDataOperatorData::BindFileMetaData(vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("file_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("created_by");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("num_rows");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("num_row_groups");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("format_version");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("encryption_algorithm");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("footer_signing_key_metadata");
+	return_types.emplace_back(LogicalType::VARCHAR);
+}
+
+void ParquetMetaDataOperatorData::LoadFileMetaData(ClientContext &context, const vector<LogicalType> &return_types,
+                                                   const string &file_path) {
+	collection.Reset();
+	ParquetOptions parquet_options(context);
+	auto reader = make_uniq<ParquetReader>(context, file_path, parquet_options);
+	idx_t count = 0;
+	DataChunk current_chunk;
+	current_chunk.Initialize(context, return_types);
+	auto meta_data = reader->GetFileMetadata();
+
+	//	file_name
+	current_chunk.SetValue(0, 0, Value(file_path));
+	//	created_by
+	current_chunk.SetValue(1, 0, ParquetElementStringVal(meta_data->created_by, meta_data->__isset.created_by));
+	//	num_rows
+	current_chunk.SetValue(2, 0, Value::BIGINT(meta_data->num_rows));
+	//	num_row_groups
+	current_chunk.SetValue(3, 0, Value::BIGINT(meta_data->row_groups.size()));
+	//	format_version
+	current_chunk.SetValue(4, 0, Value::BIGINT(meta_data->version));
+	//	encryption_algorithm
+	current_chunk.SetValue(
+	    5, 0, ParquetElementString(meta_data->encryption_algorithm, meta_data->__isset.encryption_algorithm));
+	//	footer_signing_key_metadata
+	current_chunk.SetValue(6, 0,
+	                       ParquetElementStringVal(meta_data->footer_signing_key_metadata,
+	                                               meta_data->__isset.footer_signing_key_metadata));
+	current_chunk.SetCardinality(1);
+	collection.Append(current_chunk);
+	collection.InitializeScan(scan_state);
+}
+
+//===--------------------------------------------------------------------===//
+// Bind
+//===--------------------------------------------------------------------===//
 template <ParquetMetadataOperatorType TYPE>
 unique_ptr<FunctionData> ParquetMetaDataBind(ClientContext &context, TableFunctionBindInput &input,
                                              vector<LogicalType> &return_types, vector<string> &names) {
-	if (TYPE == ParquetMetadataOperatorType::SCHEMA) {
+	switch (TYPE) {
+	case ParquetMetadataOperatorType::SCHEMA:
 		ParquetMetaDataOperatorData::BindSchema(return_types, names);
-	} else if (TYPE == ParquetMetadataOperatorType::META_DATA) {
+		break;
+	case ParquetMetadataOperatorType::META_DATA:
 		ParquetMetaDataOperatorData::BindMetaData(return_types, names);
-	} else if (TYPE == ParquetMetadataOperatorType::KEY_VALUE_META_DATA) {
+		break;
+	case ParquetMetadataOperatorType::KEY_VALUE_META_DATA:
 		ParquetMetaDataOperatorData::BindKeyValueMetaData(return_types, names);
+		break;
+	case ParquetMetadataOperatorType::FILE_META_DATA:
+		ParquetMetaDataOperatorData::BindFileMetaData(return_types, names);
+		break;
+	default:
+		throw InternalException("Unsupported ParquetMetadataOperatorType");
 	}
 
 	auto result = make_uniq<ParquetMetaDataBindData>();
@@ -494,12 +586,21 @@ unique_ptr<GlobalTableFunctionState> ParquetMetaDataInit(ClientContext &context,
 	D_ASSERT(!bind_data.files.empty());
 
 	auto result = make_uniq<ParquetMetaDataOperatorData>(context, bind_data.return_types);
-	if (TYPE == ParquetMetadataOperatorType::SCHEMA) {
+	switch (TYPE) {
+	case ParquetMetadataOperatorType::SCHEMA:
 		result->LoadSchemaData(context, bind_data.return_types, bind_data.files[0]);
-	} else if (TYPE == ParquetMetadataOperatorType::META_DATA) {
-		result->LoadFileMetaData(context, bind_data.return_types, bind_data.files[0]);
-	} else if (TYPE == ParquetMetadataOperatorType::KEY_VALUE_META_DATA) {
+		break;
+	case ParquetMetadataOperatorType::META_DATA:
+		result->LoadRowGroupMetadata(context, bind_data.return_types, bind_data.files[0]);
+		break;
+	case ParquetMetadataOperatorType::KEY_VALUE_META_DATA:
 		result->LoadKeyValueMetaData(context, bind_data.return_types, bind_data.files[0]);
+		break;
+	case ParquetMetadataOperatorType::FILE_META_DATA:
+		result->LoadFileMetaData(context, bind_data.return_types, bind_data.files[0]);
+		break;
+	default:
+		throw InternalException("Unsupported ParquetMetadataOperatorType");
 	}
 	result->file_index = 0;
 	return std::move(result);
@@ -515,12 +616,21 @@ void ParquetMetaDataImplementation(ClientContext &context, TableFunctionInput &d
 			if (data.file_index + 1 < bind_data.files.size()) {
 				// load the metadata for the next file
 				data.file_index++;
-				if (TYPE == ParquetMetadataOperatorType::SCHEMA) {
+				switch (TYPE) {
+				case ParquetMetadataOperatorType::SCHEMA:
 					data.LoadSchemaData(context, bind_data.return_types, bind_data.files[data.file_index]);
-				} else if (TYPE == ParquetMetadataOperatorType::META_DATA) {
-					data.LoadFileMetaData(context, bind_data.return_types, bind_data.files[data.file_index]);
-				} else if (TYPE == ParquetMetadataOperatorType::KEY_VALUE_META_DATA) {
+					break;
+				case ParquetMetadataOperatorType::META_DATA:
+					data.LoadRowGroupMetadata(context, bind_data.return_types, bind_data.files[data.file_index]);
+					break;
+				case ParquetMetadataOperatorType::KEY_VALUE_META_DATA:
 					data.LoadKeyValueMetaData(context, bind_data.return_types, bind_data.files[data.file_index]);
+					break;
+				case ParquetMetadataOperatorType::FILE_META_DATA:
+					data.LoadFileMetaData(context, bind_data.return_types, bind_data.files[data.file_index]);
+					break;
+				default:
+					throw InternalException("Unsupported ParquetMetadataOperatorType");
 				}
 				continue;
 			} else {
@@ -553,6 +663,13 @@ ParquetKeyValueMetadataFunction::ParquetKeyValueMetadataFunction()
                     ParquetMetaDataImplementation<ParquetMetadataOperatorType::KEY_VALUE_META_DATA>,
                     ParquetMetaDataBind<ParquetMetadataOperatorType::KEY_VALUE_META_DATA>,
                     ParquetMetaDataInit<ParquetMetadataOperatorType::KEY_VALUE_META_DATA>) {
+}
+
+ParquetFileMetadataFunction::ParquetFileMetadataFunction()
+    : TableFunction("parquet_file_metadata", {LogicalType::VARCHAR},
+                    ParquetMetaDataImplementation<ParquetMetadataOperatorType::FILE_META_DATA>,
+                    ParquetMetaDataBind<ParquetMetadataOperatorType::FILE_META_DATA>,
+                    ParquetMetaDataInit<ParquetMetadataOperatorType::FILE_META_DATA>) {
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -71,6 +71,7 @@ static constexpr ExtensionEntry EXTENSION_FUNCTIONS[] = {
     {"json_valid", "json"},
     {"load_aws_credentials", "aws"},
     {"make_timestamptz", "icu"},
+    {"parquet_file_metadata", "parquet"},
     {"parquet_kv_metadata", "parquet"},
     {"parquet_metadata", "parquet"},
     {"parquet_scan", "parquet"},

--- a/test/sql/copy/parquet/file_metadata.test
+++ b/test/sql/copy/parquet/file_metadata.test
@@ -1,0 +1,9 @@
+# name: test/sql/copy/parquet/file_metadata.test
+# group: [parquet]
+
+require parquet
+
+query IIIIIII
+SELECT * FROM parquet_file_metadata('data/parquet-testing/arrow/alltypes_dictionary.parquet')
+----
+data/parquet-testing/arrow/alltypes_dictionary.parquet	impala version 1.3.0-INTERNAL (build 8a48ddb1eff84592b3fc06bc6f51ec120e1fffc9)	2	1	1	NULL	NULL

--- a/test/sql/copy/parquet/kv_metadata.test
+++ b/test/sql/copy/parquet/kv_metadata.test
@@ -21,7 +21,7 @@ SELECT * FROM '__TEST_DIR__/kv_metadata_test.parquet'
 
 # Test decoding blobs
 query II
-SELECT key::VARCHAR, decode(value) FROM parquet_kv_metadata('__TEST_DIR__/kv_metadata_test.parquet') WHERE key = 'quz';
+SELECT key::VARCHAR, decode(value) FROM parquet_file_metadata('__TEST_DIR__/kv_metadata_test.parquet') WHERE key = 'quz';
 ----
 quz	öäå
 
@@ -36,19 +36,18 @@ statement ok
 COPY (SELECT 3, 'baz') TO '__TEST_DIR__/kv_metadata_test3.parquet' (FORMAT PARQUET);
 
 query II
-SELECT key::VARCHAR, value::VARCHAR FROM parquet_kv_metadata('__TEST_DIR__/kv_metadata_test3.parquet');
+SELECT key::VARCHAR, value::VARCHAR FROM parquet_file_metadata('__TEST_DIR__/kv_metadata_test3.parquet');
 ----
 
 # Test globbing
 statement ok
 COPY (SELECT 2, 'bar') TO  '__TEST_DIR__/kv_metadata_test2.parquet' (FORMAT PARQUET, KV_METADATA {a: 'b', c: 'd'});
 
-query II rowsort
-SELECT key::VARCHAR, value::VARCHAR FROM parquet_kv_metadata('__TEST_DIR__/kv_metadata_tes*');
+query III
+SELECT replace(file_name, '__TEST_DIR__/', '') AS file_name, key::VARCHAR, value::VARCHAR FROM parquet_file_metadata('__TEST_DIR__/kv_metadata_tes*') ORDER BY 1, 2;
 ----
-a	b
-baz	42
-c	d
-foo	bar
-quz	\xC3\xB6\xC3\xA4\xC3\xA5
-
+kv_metadata_test.parquet	baz	42
+kv_metadata_test.parquet	foo	bar
+kv_metadata_test.parquet	quz	\xC3\xB6\xC3\xA4\xC3\xA5
+kv_metadata_test2.parquet	a	b
+kv_metadata_test2.parquet	c	d

--- a/test/sql/copy/parquet/kv_metadata.test
+++ b/test/sql/copy/parquet/kv_metadata.test
@@ -44,7 +44,7 @@ statement ok
 COPY (SELECT 2, 'bar') TO  '__TEST_DIR__/kv_metadata_test2.parquet' (FORMAT PARQUET, KV_METADATA {a: 'b', c: 'd'});
 
 query III
-SELECT replace(file_name, '__TEST_DIR__/', '') AS file_name, key::VARCHAR, value::VARCHAR FROM parquet_kv_metadata('__TEST_DIR__/kv_metadata_tes*') ORDER BY 1, 2;
+SELECT replace(replace(file_name, '\', '/'), '__TEST_DIR__/', '') AS file_name, key::VARCHAR, value::VARCHAR FROM parquet_kv_metadata('__TEST_DIR__/kv_metadata_tes*') ORDER BY 1, 2;
 ----
 kv_metadata_test.parquet	baz	42
 kv_metadata_test.parquet	foo	bar

--- a/test/sql/copy/parquet/kv_metadata.test
+++ b/test/sql/copy/parquet/kv_metadata.test
@@ -21,7 +21,7 @@ SELECT * FROM '__TEST_DIR__/kv_metadata_test.parquet'
 
 # Test decoding blobs
 query II
-SELECT key::VARCHAR, decode(value) FROM parquet_file_metadata('__TEST_DIR__/kv_metadata_test.parquet') WHERE key = 'quz';
+SELECT key::VARCHAR, decode(value) FROM parquet_kv_metadata('__TEST_DIR__/kv_metadata_test.parquet') WHERE key = 'quz';
 ----
 quz	öäå
 
@@ -36,7 +36,7 @@ statement ok
 COPY (SELECT 3, 'baz') TO '__TEST_DIR__/kv_metadata_test3.parquet' (FORMAT PARQUET);
 
 query II
-SELECT key::VARCHAR, value::VARCHAR FROM parquet_file_metadata('__TEST_DIR__/kv_metadata_test3.parquet');
+SELECT key::VARCHAR, value::VARCHAR FROM parquet_kv_metadata('__TEST_DIR__/kv_metadata_test3.parquet');
 ----
 
 # Test globbing
@@ -44,7 +44,7 @@ statement ok
 COPY (SELECT 2, 'bar') TO  '__TEST_DIR__/kv_metadata_test2.parquet' (FORMAT PARQUET, KV_METADATA {a: 'b', c: 'd'});
 
 query III
-SELECT replace(file_name, '__TEST_DIR__/', '') AS file_name, key::VARCHAR, value::VARCHAR FROM parquet_file_metadata('__TEST_DIR__/kv_metadata_tes*') ORDER BY 1, 2;
+SELECT replace(file_name, '__TEST_DIR__/', '') AS file_name, key::VARCHAR, value::VARCHAR FROM parquet_kv_metadata('__TEST_DIR__/kv_metadata_tes*') ORDER BY 1, 2;
 ----
 kv_metadata_test.parquet	baz	42
 kv_metadata_test.parquet	foo	bar


### PR DESCRIPTION
Implements #2534

This PR adds the last missing piece of the Parquet metadata scanning, which is the top-level file metadata. 

```sql
D FROM parquet_file_metadata('data/parquet-testing/arrow/alltypes_dictionary.parquet');
┌──────────────────────┬─────────────────────────────────────────────────┬──────────┬────────────────┬────────────────┬──────────────────────┬─────────────────────────────┐
│      file_name       │                   created_by                    │ num_rows │ num_row_groups │ format_version │ encryption_algorithm │ footer_signing_key_metadata │
│       varchar        │                     varchar                     │  int64   │     int64      │     int64      │       varchar        │           varchar           │
├──────────────────────┼─────────────────────────────────────────────────┼──────────┼────────────────┼────────────────┼──────────────────────┼─────────────────────────────┤
│ data/parquet-testi…  │ impala version 1.3.0-INTERNAL (build 8a48ddb1…  │        2 │              1 │              1 │ NULL                 │ NULL                        │
└──────────────────────┴─────────────────────────────────────────────────┴──────────┴────────────────┴────────────────┴──────────────────────┴─────────────────────────────┘

```

In addition, we also add a `file_name` to the `parquet_kv_metadata` function to make it compatible with the others.

Now all Parquet file metadata should be scannable using the below functions.

|       Function        |         Metadata         |
|-----------------------|--------------------------|
| parquet_file_metadata | Top-Level File Meta Data |
| parquet_metadata      | Row-Group Metadata       |
| parquet_schema        | Schema Metadata          |
| parquet_kv_metadata   | Optional Key-Value Pairs |