### PR TITLE
Issue#604 Support LIKE for built-in collations.

### DIFF
--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -28,6 +28,10 @@ struct LowerFun {
 
 	static ScalarFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
+
+	template <bool INVERT, bool ESCAPE>
+	static ScalarFunction GetLikeFunction();
+	class LowerTransform;
 };
 
 struct UpperFun {
@@ -40,6 +44,10 @@ struct StripAccentsFun {
 	static bool IsAscii(const char *input, idx_t n);
 	static ScalarFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
+
+	template <bool INVERT, bool ESCAPE>
+	static ScalarFunction GetLikeFunction();
+	class StripAccentsTransform;
 };
 
 struct ConcatFun {
@@ -82,11 +90,19 @@ struct LengthFun {
 	}
 };
 
+struct StandardCharacterReader;
+struct ASCIILCaseReader;
+template <char PERCENTAGE, char UNDERSCORE, bool HAS_ESCAPE, class READER = StandardCharacterReader>
+bool TemplatedLikeOperator(const char *sdata, idx_t slen, const char *pdata, idx_t plen, char escape);
+
 struct LikeFun {
 	static ScalarFunction GetLikeFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
 	DUCKDB_API static bool Glob(const char *s, idx_t slen, const char *pattern, idx_t plen,
 	                            bool allow_question_mark = true);
+	template <char PERCENTAGE, char UNDERSCORE, class TRANSFORM>
+	static bool LikeWithCollation(string_t &input, string_t &pattern, string_t &escape);
+	static string GetLikeFunctionName(bool is_inverted, bool has_escape);
 };
 
 struct LikeEscapeFun {
@@ -97,6 +113,10 @@ struct LikeEscapeFun {
 struct NFCNormalizeFun {
 	static ScalarFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
+
+	template <bool INVERT, bool ESCAPE>
+	static ScalarFunction GetLikeFunction();
+	class NFCNormalizeTransform;
 };
 
 struct SubstringFun {

--- a/test/issues/general/test_604.test
+++ b/test/issues/general/test_604.test
@@ -1,0 +1,107 @@
+# name: test/issues/general/test_604.test
+# description: Issue 1091: Extended Collation Support
+# group: [general]
+
+# Like with Collation nocase
+query I
+select 'ABCDEFG' like 'abcdefg';
+----
+false
+
+query I
+select 'ABCDEFG' like 'abcdefg' collate nocase;
+----
+true
+
+query I
+select 'ABCDEFG' not like 'abcdefg' collate nocase;
+----
+false
+
+query I
+select 'ABCDEFG' like 'a%d_fg' collate nocase;
+----
+true
+
+query I
+select 'abcdefg' like 'A%D_FG' collate nocase;
+----
+true
+
+query I
+select 'ABCDEFG' not like 'a%d_fg' collate nocase;
+----
+false
+
+query I
+select 'ABC%DE_FG' like 'abc\%de\_fg' collate nocase escape '\';
+----
+true
+
+query I
+select 'ABC%DE_FG' not like 'abc\%de\_fg' collate nocase escape '\';
+----
+false
+
+# Like with Collation noaccent
+query I
+select 'Öë' like 'Oe';
+----
+false
+
+query I
+select 'Öë' like 'Oe' collate noaccent;
+----
+true
+
+query I
+select 'Oe' like 'Öë' collate noaccent;
+----
+true
+
+query I
+select 'Öë' like 'O%' collate noaccent;
+----
+true
+
+query I
+select 'Öe' like '_ë' collate noaccent;
+----
+true
+
+statement error
+select 'Oe' like 'Öë' collate noaccent escape 'Ö';
+
+
+# More test for escape character
+# Two consecutive escape characters
+query I
+select 'abcdefg' like 'AABCDEFG' collate nocase escape 'A';
+----
+true
+
+# Three consecutive escape characters
+query I
+select 'abcdefg' like 'AAABCDEFG' collate nocase escape 'A';
+----
+true
+
+query I
+select 'abcdefg' like 'ABCDEFG' collate nocase escape 'A';
+----
+false
+
+# End with escape character
+query I
+select 'abcdefg' like 'ABCDEFG\' collate nocase escape '\';
+----
+false
+
+statement error
+select 'abcdefgh' like 'ABCDEFG\' collate nocase escape '\';
+
+# Escape before normal character
+query I
+select 'abcdefg' like '\A\B\C\D\E\F\G' collate nocase escape '\';
+----
+true


### PR DESCRIPTION
Replace the built-in wild comparison function if children have collation during bind_function_expression.