### PR TITLE
Call `BindSchemaOrCatalog` when binding functions so that we can qualify functions with only a database as well

### DIFF
--- a/src/include/duckdb/parser/expression/function_expression.hpp
+++ b/src/include/duckdb/parser/expression/function_expression.hpp
@@ -63,9 +63,9 @@ public:
 
 public:
 	template <class T, class BASE, class ORDER_MODIFIER = OrderModifier>
-	static string ToString(const T &entry, const string &schema, const string &function_name, bool is_operator = false,
-	                       bool distinct = false, BASE *filter = nullptr, ORDER_MODIFIER *order_bys = nullptr,
-	                       bool export_state = false, bool add_alias = false) {
+	static string ToString(const T &entry, const string &catalog, const string &schema, const string &function_name,
+	                       bool is_operator = false, bool distinct = false, BASE *filter = nullptr,
+	                       ORDER_MODIFIER *order_bys = nullptr, bool export_state = false, bool add_alias = false) {
 		if (is_operator) {
 			// built-in operator
 			D_ASSERT(!distinct);
@@ -82,7 +82,14 @@ public:
 			}
 		}
 		// standard function call
-		string result = schema.empty() ? function_name : schema + "." + function_name;
+		string result;
+		if (!catalog.empty()) {
+			result += KeywordHelper::WriteOptionallyQuoted(catalog) + ".";
+		}
+		if (!schema.empty()) {
+			result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";
+		}
+		result += function_name;
 		result += "(";
 		if (distinct) {
 			result += "DISTINCT ";

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -35,7 +35,7 @@ FunctionExpression::FunctionExpression(const string &function_name, vector<uniqu
 }
 
 string FunctionExpression::ToString() const {
-	return ToString<FunctionExpression, ParsedExpression>(*this, schema, function_name, is_operator, distinct,
+	return ToString<FunctionExpression, ParsedExpression>(*this, catalog, schema, function_name, is_operator, distinct,
 	                                                      filter.get(), order_bys.get(), export_state, true);
 }
 

--- a/src/planner/binder/expression/bind_function_expression.cpp
+++ b/src/planner/binder/expression/bind_function_expression.cpp
@@ -20,6 +20,8 @@ BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t 
                                             unique_ptr<ParsedExpression> &expr_ptr) {
 	// lookup the function in the catalog
 	QueryErrorContext error_context(binder.root_statement, function.query_location);
+
+	binder.BindSchemaOrCatalog(function.catalog, function.schema);
 	auto func = Catalog::GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, function.catalog, function.schema,
 	                              function.function_name, OnEntryNotFound::RETURN_NULL, error_context);
 	if (!func) {

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -19,7 +19,7 @@ BoundAggregateExpression::BoundAggregateExpression(AggregateFunction function, v
 
 string BoundAggregateExpression::ToString() const {
 	return FunctionExpression::ToString<BoundAggregateExpression, Expression, BoundOrderModifier>(
-	    *this, string(), function.name, false, IsDistinct(), filter.get(), order_bys.get());
+	    *this, string(), string(), function.name, false, IsDistinct(), filter.get(), order_bys.get());
 }
 
 hash_t BoundAggregateExpression::Hash() const {

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -39,7 +39,7 @@ bool BoundFunctionExpression::IsFoldable() const {
 }
 
 string BoundFunctionExpression::ToString() const {
-	return FunctionExpression::ToString<BoundFunctionExpression, Expression>(*this, string(), function.name,
+	return FunctionExpression::ToString<BoundFunctionExpression, Expression>(*this, string(), string(), function.name,
 	                                                                         is_operator);
 }
 bool BoundFunctionExpression::PropagatesNullValues() const {

--- a/test/sql/attach/attach_macros.test
+++ b/test/sql/attach/attach_macros.test
@@ -1,0 +1,35 @@
+# name: test/sql/attach/attach_macros.test
+# description: Tests for macro functions in attached databases
+# group: [attach]
+
+require noforcestorage
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH ':memory:' AS db1;
+
+statement ok
+CREATE TABLE db1.tbl AS SELECT 42 AS x, 3 AS y;
+
+statement ok
+CREATE MACRO db1.two_x_plus_y(x, y) AS 2 * x + y;
+
+query I
+SELECT db1.two_x_plus_y(x, y) FROM db1.tbl;
+----
+87
+
+query I
+SELECT db1.main.two_x_plus_y(x, y) FROM db1.tbl;
+----
+87
+
+statement ok
+USE db1
+
+query I
+SELECT two_x_plus_y(x, y) FROM db1.tbl;
+----
+87


### PR DESCRIPTION
This fixes an issue where the following code would not work

```sql
ATTACH 'db1.db' AS db1;
CREATE TABLE db1.tbl AS SELECT 42 AS x, 3 AS y;
CREATE MACRO db1.two_x_plus_y(x, y) AS 2 * x + y;
SELECT db1.two_x_plus_y(x, y) FROM db1.tbl;
```