### PR TITLE
[Python] Pandas Analyzer no longer trips up when the `pandas_analyze_sample` would only let it find nulls.

### DIFF
--- a/tools/pythonpkg/src/pandas/analyzer.cpp
+++ b/tools/pythonpkg/src/pandas/analyzer.cpp
@@ -390,17 +390,12 @@ LogicalType PandasAnalyzer::InnerAnalyze(py::object column, bool &can_convert, b
 	}
 	auto row = column.attr("__getitem__");
 
-	vector<LogicalType> types;
-	auto item_type = GetItemType(row(0), can_convert);
-	if (!can_convert) {
-		return item_type;
-	}
-	types.push_back(item_type);
-
 	if (sample) {
 		increment = GetSampleIncrement(rows);
 	}
-	for (idx_t i = increment; i < rows; i += increment) {
+	LogicalType item_type = LogicalType::SQLNULL;
+	vector<LogicalType> types;
+	for (idx_t i = 0; i < rows; i += increment) {
 		auto obj = FindFirstNonNull(row, i, increment);
 		auto next_item_type = GetItemType(obj, can_convert);
 		types.push_back(next_item_type);

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -207,6 +207,19 @@ class TestResolveObjectColumns(object):
         pandas.testing.assert_frame_equal(converted_col, duckdb_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
+    @pytest.mark.parametrize('size', [1000, 10000, 100000])
+    def test_analyzing_nulls(self, pandas, duckdb_cursor, size):
+        data = [None, "a"]
+        n = size
+
+        data = data * n
+        df1 = pandas.DataFrame(data={"col1": data})
+        duckdb_cursor.execute(f"SET GLOBAL pandas_analyze_sample=100")
+        df = duckdb_cursor.execute("select * from df1").df()
+
+        pandas.testing.assert_frame_equal(df1, df)
+
+    @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_map_value_upgrade(self, pandas):
         con = duckdb.connect()
         x = pandas.DataFrame(

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -15,6 +15,19 @@ def create_generic_dataframe(data, pandas):
     return pandas.DataFrame({'0': pandas.Series(data=data, dtype='object')})
 
 
+def create_repeated_nulls(size):
+    data = [None, "a"]
+    n = size
+    data = data * n
+    return data
+
+
+def create_trailing_non_null(size):
+    data = [None for _ in range(size - 1)]
+    data.append('this is a long string')
+    return data
+
+
 class IntString:
     def __init__(self, value: int):
         self.value = value
@@ -207,14 +220,13 @@ class TestResolveObjectColumns(object):
         pandas.testing.assert_frame_equal(converted_col, duckdb_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    @pytest.mark.parametrize('size', [1000, 10000, 100000])
-    def test_analyzing_nulls(self, pandas, duckdb_cursor, size):
-        data = [None, "a"]
-        n = size
-
-        data = data * n
+    @pytest.mark.parametrize('sample_size', [1, 10])
+    @pytest.mark.parametrize('fill', [1000, 10000])
+    @pytest.mark.parametrize('get_data', [create_repeated_nulls, create_trailing_non_null])
+    def test_analyzing_nulls(self, pandas, duckdb_cursor, fill, sample_size, get_data):
+        data = get_data(fill)
         df1 = pandas.DataFrame(data={"col1": data})
-        duckdb_cursor.execute(f"SET GLOBAL pandas_analyze_sample=100")
+        duckdb_cursor.execute(f"SET GLOBAL pandas_analyze_sample={sample_size}")
         df = duckdb_cursor.execute("select * from df1").df()
 
         pandas.testing.assert_frame_equal(df1, df)


### PR DESCRIPTION
This PR fixes #6669 

The logic for getting the offset for sampling is:
```c++
	auto sample = sample_size;
	if (sample > rows) {
		sample = rows;
	}
	return rows / sample;
```

This let's us scan `sample_size` columns from the dataset.

A problem with this is that if there are null values recurring in the dataset at this offset, the analyzer would only find nulls and set the type as NULL, when a non-null value is encountered it's cast to the result type NULL and that causes this issue.

To combat this issue we now find the first non-null value starting from that the offset, instead of just taking the first value we find at that offset.
