### PR TITLE
Fix #8500 - if we encounter any ambiguity while binding a function with a parameter we rebind during execution

### DIFF
--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -51,7 +51,12 @@ int64_t FunctionBinder::BindFunctionCost(const SimpleFunction &func, const vecto
 		return -1;
 	}
 	int64_t cost = 0;
+	bool has_parameter = false;
 	for (idx_t i = 0; i < arguments.size(); i++) {
+		if (arguments[i].id() == LogicalTypeId::UNKNOWN) {
+			has_parameter = true;
+			continue;
+		}
 		int64_t cast_cost = CastFunctionSet::Get(context).ImplicitCastCost(arguments[i], func.arguments[i]);
 		if (cast_cost >= 0) {
 			// we can implicitly cast, add the cost to the total cost
@@ -60,6 +65,10 @@ int64_t FunctionBinder::BindFunctionCost(const SimpleFunction &func, const vecto
 			// we can't implicitly cast: throw an error
 			return -1;
 		}
+	}
+	if (has_parameter) {
+		// all arguments are implicitly castable and there is a parameter - return 0 as cost
+		return 0;
 	}
 	return cost;
 }

--- a/test/sql/prepared/test_prepare_issue_8500.test
+++ b/test/sql/prepared/test_prepare_issue_8500.test
@@ -1,0 +1,11 @@
+# name: test/sql/prepared/test_prepare_issue_8500.test
+# description: Issue #8500 - Prepared statement results in INTERVAL type
+# group: [prepared]
+
+statement ok
+PREPARE S1 AS SELECT (? / 1) + 1;
+
+query I
+EXECUTE S1(42)
+----
+43


### PR DESCRIPTION
Fixes #8500