### PR TITLE
Add duckdb_optimizers function

### DIFF
--- a/src/common/enums/optimizer_type.cpp
+++ b/src/common/enums/optimizer_type.cpp
@@ -40,6 +40,14 @@ string OptimizerTypeToString(OptimizerType type) {
 	throw InternalException("Invalid optimizer type");
 }
 
+vector<string> ListAllOptimizers() {
+	vector<string> result;
+	for (idx_t i = 0; internal_optimizer_types[i].name; i++) {
+		result.push_back(internal_optimizer_types[i].name);
+	}
+	return result;
+}
+
 OptimizerType OptimizerTypeFromString(const string &str) {
 	for (idx_t i = 0; internal_optimizer_types[i].name; i++) {
 		if (internal_optimizer_types[i].name == str) {

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library_unity(
   duckdb_functions.cpp
   duckdb_keywords.cpp
   duckdb_indexes.cpp
+  duckdb_optimizers.cpp
   duckdb_schemas.cpp
   duckdb_sequences.cpp
   duckdb_settings.cpp

--- a/src/function/table/system/duckdb_optimizers.cpp
+++ b/src/function/table/system/duckdb_optimizers.cpp
@@ -1,0 +1,57 @@
+#include "duckdb/function/table/system_functions.hpp"
+#include "duckdb/common/types/chunk_collection.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/enums/optimizer_type.hpp"
+
+namespace duckdb {
+
+struct DuckDBOptimizersData : public GlobalTableFunctionState {
+	DuckDBOptimizersData() : offset(0) {
+	}
+
+	vector<string> optimizers;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBOptimizersBind(ClientContext &context, TableFunctionBindInput &input,
+                                                     vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBOptimizersInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<DuckDBOptimizersData>();
+	result->optimizers = ListAllOptimizers();
+	return std::move(result);
+}
+
+void DuckDBOptimizersFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<DuckDBOptimizersData>();
+	if (data.offset >= data.optimizers.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.optimizers.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.optimizers[data.offset++];
+
+		// return values:
+		// name, LogicalType::VARCHAR
+		output.SetValue(0, count, Value(entry));
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBOptimizersFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("duckdb_optimizers", {}, DuckDBOptimizersFunction, DuckDBOptimizersBind, DuckDBOptimizersInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -29,6 +29,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBSchemasFun::RegisterFunction(*this);
 	DuckDBDependenciesFun::RegisterFunction(*this);
 	DuckDBExtensionsFun::RegisterFunction(*this);
+	DuckDBOptimizersFun::RegisterFunction(*this);
 	DuckDBSequencesFun::RegisterFunction(*this);
 	DuckDBSettingsFun::RegisterFunction(*this);
 	DuckDBTablesFun::RegisterFunction(*this);

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -36,5 +36,6 @@ enum class OptimizerType : uint32_t {
 
 string OptimizerTypeToString(OptimizerType type);
 OptimizerType OptimizerTypeFromString(const string &str);
+vector<string> ListAllOptimizers();
 
 } // namespace duckdb

--- a/src/include/duckdb/common/enums/optimizer_type.hpp
+++ b/src/include/duckdb/common/enums/optimizer_type.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -85,6 +85,10 @@ struct DuckDBIndexesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBOptimizersFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBSequencesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/test/sql/table_function/duckdb_optimizers.test
+++ b/test/sql/table_function/duckdb_optimizers.test
@@ -1,0 +1,11 @@
+# name: test/sql/table_function/duckdb_optimizers.test
+# description: Test duckdb_optimizers function
+# group: [table_function]
+
+statement ok
+SELECT * FROM duckdb_optimizers();
+
+query I
+SELECT name FROM duckdb_optimizers() WHERE name='join_order';
+----
+join_order


### PR DESCRIPTION
```sql
D FROM duckdb_optimizers();
┌────────────────────────────┐
│            name            │
│          varchar           │
├────────────────────────────┤
│ expression_rewriter        │
│ filter_pullup              │
│ filter_pushdown            │
│ regex_range                │
│ in_clause                  │
│ join_order                 │
│ deliminator                │
│ unnest_rewriter            │
│ unused_columns             │
│ statistics_propagation     │
│ common_subexpressions      │
│ common_aggregate           │
│ column_lifetime            │
│ top_n                      │
│ compressed_materialization │
│ duplicate_groups           │
│ reorder_filter             │
│ extension                  │
├────────────────────────────┤
│          18 rows           │
└────────────────────────────┘
```

This is useful when combined with `PRAGMA disabled_optimizers`