### PR TITLE
Fix #9806 - when an overflow is detected during filter pushdown the pushdown should be halted, instead of claiming the result is always false

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -593,7 +593,7 @@ FilterResult FilterCombiner::AddBoundComparisonFilter(Expression &expr) {
 		auto &scalar = left_is_scalar ? comparison.left : comparison.right;
 		Value constant_value;
 		if (!ExpressionExecutor::TryEvaluateScalar(context, *scalar, constant_value)) {
-			return FilterResult::UNSATISFIABLE;
+			return FilterResult::UNSUPPORTED;
 		}
 		if (constant_value.IsNull()) {
 			// comparisons with null are always null (i.e. will never result in rows)

--- a/test/issues/rigger/overflow_filter_pushdown.test
+++ b/test/issues/rigger/overflow_filter_pushdown.test
@@ -1,0 +1,24 @@
+# name: test/issues/rigger/overflow_filter_pushdown.test
+# description: Issue #9806 - Unexpected Results when using IS NOT NULL
+# group: [rigger]
+
+statement ok
+CREATE TABLE t0(c0 INT);
+
+statement ok
+INSERT INTO t0 VALUES (1);
+
+query I
+SELECT * FROM t0;
+----
+1
+
+query I
+SELECT c0>=(2147483647 + 1 IS NOT NULL) FROM t0;
+----
+true
+
+query I
+SELECT * FROM t0 WHERE c0>=(2147483647 + 1 IS NOT NULL);
+----
+1


### PR DESCRIPTION
Fixes #9806