### PR TITLE
LIST to VARCHAR cast fix

### DIFF
--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -79,7 +79,7 @@ static bool ListToVarcharCast(Vector &source, Vector &result, idx_t count, CastP
 	auto list_data = FlatVector::GetData<list_entry_t>(varchar_list);
 	auto &validity = FlatVector::Validity(varchar_list);
 
-	child.Flatten(count);
+	child.Flatten(ListVector::GetListSize(varchar_list));
 	auto child_data = FlatVector::GetData<string_t>(child);
 	auto &child_validity = FlatVector::Validity(child);
 

--- a/test/sql/types/list/list_to_varchar_cast.test
+++ b/test/sql/types/list/list_to_varchar_cast.test
@@ -1,0 +1,9 @@
+# name: test/sql/types/list/list_to_varchar_cast.test
+# description: Tests issue 9808
+# group: [list]
+
+query I
+SELECT concat_ws('.', list_reverse(string_split('1.2..3', '.')));
+----
+[3, , 2, 1]
+


### PR DESCRIPTION
This fixes passing the wrong (parent) count when calling `Flatten` on the child vector.