### PR TITLE
S3: Add more details to error on multipart upload

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -450,7 +450,7 @@ void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 
 	auto open_tag_pos = result.find("<CompleteMultipartUploadResult", 0);
 	if (open_tag_pos == string::npos) {
-		throw IOException("Unexpected response during S3 multipart upload finalization: %d", res->code);
+		throw IOException("Unexpected response during S3 multipart upload finalization: %d\n\n%s", res->code, result);
 	}
 	file_handle.upload_finalized = true;
 }


### PR DESCRIPTION
There have been some failures recently on Linux HTTPFS nightly test that were adding more logging, given the response is available, should be easy and of some use.

Message after this commit will go from:
```
terminate called after throwing an instance of 'duckdb::IOException'
  what():  IO Error: Unexpected response during S3 multipart upload finalization: 403
```
to (in this particular case)
```
terminate called after throwing an instance of 'duckdb::IOException'
  what():  IO Error: Unexpected response during S3 multipart upload finalization: 403

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidAccessKeyId</Code><Message>The Access Key Id you provided does not exist in our records.</Message><Key>s3_query_params/test.csv</Key><BucketName>test-bucket</BucketName><Resource>/test-bucket/s3_query_params/test.csv</Resource><Region>eu-west-1</Region><RequestId>179BAB7430A19B4F</RequestId><HostId>b66ef44d-c0d5-4e73-879b-eba0a389de97</HostId></Error>
```