### PR TITLE
Make checking the database path atomic again by turning db_paths into a bloom filter instead of a source of truth

### DIFF
--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -53,9 +53,12 @@ public:
 	void SetDefaultDatabase(ClientContext &context, const string &new_value);
 
 	//! Inserts a path to name mapping to the database paths map
-	void InsertDatabasePath(const string &path, const string &name);
+	void InsertDatabasePath(ClientContext &context, const string &path, const string &name);
 	//! Erases a path from the database paths map
 	void EraseDatabasePath(const string &path);
+	//! Returns a database with a specified path
+	optional_ptr<AttachedDatabase> GetDatabaseFromPath(ClientContext &context, const string &path);
+
 	//! Returns the database type. This might require checking the header of the file, in which case the file handle is
 	//! necessary. We can only grab the file handle, if it is not yet held, even for uncommitted changes. Thus, we have
 	//! to lock for this operation.
@@ -98,7 +101,7 @@ private:
 	//! A map containing all attached database path to name mappings
 	//! This allows to attach many databases efficiently, and to avoid attaching the
 	//! same file path twice
-	case_insensitive_map_t<string> db_paths;
+	case_insensitive_set_t db_paths;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -56,8 +56,6 @@ public:
 	void InsertDatabasePath(ClientContext &context, const string &path, const string &name);
 	//! Erases a path from the database paths map
 	void EraseDatabasePath(const string &path);
-	//! Returns a database with a specified path
-	optional_ptr<AttachedDatabase> GetDatabaseFromPath(ClientContext &context, const string &path);
 
 	//! Returns the database type. This might require checking the header of the file, in which case the file handle is
 	//! necessary. We can only grab the file handle, if it is not yet held, even for uncommitted changes. Thus, we have
@@ -85,6 +83,11 @@ public:
 	}
 
 private:
+	//! Returns a database with a specified path
+	optional_ptr<AttachedDatabase> GetDatabaseFromPath(ClientContext &context, const string &path);
+	void CheckPathConflict(ClientContext &context, const string &path);
+
+private:
 	//! The system database is a special database that holds system entries (e.g. functions)
 	unique_ptr<AttachedDatabase> system;
 	//! The set of attached databases
@@ -98,7 +101,7 @@ private:
 
 	//! The lock to add entries to the database path map
 	mutex db_paths_lock;
-	//! A map containing all attached database path to name mappings
+	//! A set containing all attached database path
 	//! This allows to attach many databases efficiently, and to avoid attaching the
 	//! same file path twice
 	case_insensitive_set_t db_paths;

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -40,7 +40,9 @@ optional_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &co
 	auto &db = DatabaseInstance::GetDatabase(context);
 	auto attached_db = db.CreateAttachedDatabase(info, db_type, access_mode);
 
-	InsertDatabasePath(info.path, attached_db->name);
+	if (db_type.empty()) {
+		InsertDatabasePath(context, info.path, attached_db->name);
+	}
 
 	const auto name = attached_db->GetName();
 	attached_db->oid = ModifyCatalog();
@@ -71,7 +73,26 @@ void DatabaseManager::DetachDatabase(ClientContext &context, const string &name,
 	}
 }
 
-void DatabaseManager::InsertDatabasePath(const string &path, const string &name) {
+optional_ptr<AttachedDatabase> DatabaseManager::GetDatabaseFromPath(ClientContext &context, const string &path) {
+	auto database_list = GetDatabases(context);
+	for (auto &db_ref : database_list) {
+		auto &db = db_ref.get();
+		if (db.IsSystem()) {
+			continue;
+		}
+		auto &catalog = Catalog::GetCatalog(db);
+		if (catalog.InMemory()) {
+			continue;
+		}
+		auto db_path = catalog.GetDBPath();
+		if (StringUtil::CIEquals(path, db_path)) {
+			return &db;
+		}
+	}
+	return nullptr;
+}
+
+void DatabaseManager::InsertDatabasePath(ClientContext &context, const string &path, const string &name) {
 	if (path.empty() || path == IN_MEMORY_PATH) {
 		return;
 	}
@@ -80,13 +101,17 @@ void DatabaseManager::InsertDatabasePath(const string &path, const string &name)
 
 	// ensure that we did not already attach a database with the same path
 	if (db_paths.find(path) != db_paths.end()) {
-		throw BinderException(
-		    "Unique file handle conflict: Database \"%s\" is already attached with path \"%s\", "
-		    "possibly by another transaction. Commit that transaction, if it already detached the file.",
-		    name, path);
+		// check that the database is actually still attached
+		auto entry = GetDatabaseFromPath(context, path);
+		if (entry) {
+			throw BinderException(
+			    "Unique file handle conflict: Database \"%s\" is already attached with path \"%s\", "
+			    "possibly by another transaction. Commit that transaction, if it already detached the file.",
+			    name, path);
+		}
 	}
 
-	db_paths.insert(make_pair(path, name));
+	db_paths.insert(path);
 }
 
 void DatabaseManager::EraseDatabasePath(const string &path) {
@@ -116,18 +141,6 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, string &db_type, A
 
 	// try to extract database type from path
 	if (db_type.empty()) {
-		lock_guard<mutex> write_lock(db_paths_lock);
-
-		// we cannot infer the database type if we already hold the file handle somewhere else
-		if (db_paths.find(info.path) != db_paths.end()) {
-			throw BinderException(
-			    "Unique file handle conflict: Database \"%s\" is already attached with path \"%s\", "
-			    "possibly by another transaction. Commit that transaction, if it already detached the file. Otherwise, "
-			    "inferring the database type from the file header is not possible, as it requires holding the file "
-			    "handle.",
-			    info.name, info.path);
-		}
-
 		DBPathAndType::CheckMagicBytes(info.path, db_type, config);
 	}
 

--- a/test/sql/attach/attach_filepath_roundtrip.test
+++ b/test/sql/attach/attach_filepath_roundtrip.test
@@ -67,14 +67,12 @@ DETACH con2_rollback_detach;
 statement error con1
 ATTACH '__TEST_DIR__/con2_rollback_detach.db';
 ----
-inferring the database type from the file header is not possible
+already attached
 
 # can't attach con1.db file in con2
 
 statement error con2
 ATTACH '__TEST_DIR__/con1.db';
-----
-already attached
 
 statement ok con1
 DETACH con1;
@@ -83,8 +81,6 @@ DETACH con1;
 
 statement error con2
 ATTACH '__TEST_DIR__/con1.db';
-----
-already attached
 
 # commit con1 and roll back con2
 

--- a/test/sql/attach/attach_filepath_roundtrip.test
+++ b/test/sql/attach/attach_filepath_roundtrip.test
@@ -4,6 +4,8 @@
 
 require noforcestorage
 
+require notwindows
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_filepath_roundtrip.test
+++ b/test/sql/attach/attach_filepath_roundtrip.test
@@ -73,6 +73,8 @@ already attached
 
 statement error con2
 ATTACH '__TEST_DIR__/con1.db';
+----
+write-write
 
 statement ok con1
 DETACH con1;
@@ -81,6 +83,8 @@ DETACH con1;
 
 statement error con2
 ATTACH '__TEST_DIR__/con1.db';
+----
+transaction is aborted
 
 # commit con1 and roll back con2
 

--- a/test/sql/attach/attach_same_db.test
+++ b/test/sql/attach/attach_same_db.test
@@ -4,6 +4,8 @@
 
 require skip_reload
 
+require notwindows
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/attach/attach_same_db.test
+++ b/test/sql/attach/attach_same_db.test
@@ -12,3 +12,16 @@ ATTACH '__TEST_DIR__/attach_same_db.db' AS db1
 
 statement error
 ATTACH '__TEST_DIR__/attach_same_db.db' AS db2
+
+# we can detach and attach in the same transaction
+statement ok
+BEGIN
+
+statement ok
+DETACH db1
+
+statement ok
+ATTACH '__TEST_DIR__/attach_same_db.db' AS db1
+
+statement ok
+COMMIT


### PR DESCRIPTION
Instead of throwing an error when a database path is contained in `db_paths`, we instead revert to the linear look-up that we did before to verify the database is still attached. This should keep the performance improvements of #9671 while keeping the old semantics.

In addition, we only perform this duplicate check for DuckDB database. Other database types allow for the same connection string to be used multiple times so performing this check is unnecessary.