### PR TITLE
Clear all updates during checkpoint

### DIFF
--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -441,6 +441,7 @@ unique_ptr<ColumnCheckpointState> ColumnData::Checkpoint(RowGroup &row_group,
 
 	// replace the old tree with the new one
 	data.Replace(l, checkpoint_state->new_tree);
+	updates.reset();
 	version++;
 
 	return checkpoint_state;


### PR DESCRIPTION
Fixes an issue where old update data was kept around unnecessarily after a checkpoint