### PR TITLE
For EXPORT DATABASE - always write forward slashes in COPY statements

### DIFF
--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -43,8 +43,8 @@ static void WriteCopyStatement(FileSystem &fs, stringstream &ss, CopyInfo &info,
 		ss << KeywordHelper::WriteOptionallyQuoted(exported_table.schema_name) << ".";
 	}
 
-	ss << StringUtil::Format("%s FROM %s (", SQLIdentifier(exported_table.table_name),
-	                         SQLString(exported_table.file_path));
+	auto file_path = StringUtil::Replace(exported_table.file_path, "\\", "/");
+	ss << StringUtil::Format("%s FROM %s (", SQLIdentifier(exported_table.table_name), SQLString(file_path));
 
 	// write the copy options
 	ss << "FORMAT '" << info.format << "'";

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -284,7 +284,7 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 			auto full_path = fs.JoinPath(directory, name);
 			info->file_path = full_path;
 			auto insert_result = table_name_index.insert(info->file_path);
-			if (insert_result.second == true) {
+			if (insert_result.second) {
 				// this name was not yet taken: take it
 				break;
 			}


### PR DESCRIPTION
This makes sure exported databases are portable between Windows/MacOS/Linux