### PR TITLE
Safeguard uses of ColumnDefinition::DefaultValue

### DIFF
--- a/.github/patches/extensions/postgres_scanner/default_value.patch
+++ b/.github/patches/extensions/postgres_scanner/default_value.patch
@@ -1,0 +1,15 @@
+diff --git a/src/storage/postgres_table_set.cpp b/src/storage/postgres_table_set.cpp
+index 88786cf..bfd37ab 100644
+--- a/src/storage/postgres_table_set.cpp
++++ b/src/storage/postgres_table_set.cpp
+@@ -205,8 +205,8 @@ string PostgresColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<C
+ 		}
+ 		if (column.Generated()) {
+ 			ss << " GENERATED ALWAYS AS(" << column.GeneratedExpression().ToString() << ")";
+-		} else if (column.DefaultValue()) {
+-			ss << " DEFAULT(" << column.DefaultValue()->ToString() << ")";
++		} else if (column.HasDefaultValue()) {
++			ss << " DEFAULT(" << column.DefaultValue().ToString() << ")";
+ 		}
+ 	}
+ 	// print any extra constraints that still need to be printed

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -136,8 +136,8 @@ string TableCatalogEntry::ColumnsToSQL(const ColumnList &columns, const vector<u
 		}
 		if (column.Generated()) {
 			ss << " GENERATED ALWAYS AS(" << column.GeneratedExpression().ToString() << ")";
-		} else if (column.DefaultValue()) {
-			ss << " DEFAULT(" << column.DefaultValue()->ToString() << ")";
+		} else if (column.HasDefaultValue()) {
+			ss << " DEFAULT(" << column.DefaultValue().ToString() << ")";
 		}
 	}
 	// print any extra constraints that still need to be printed

--- a/src/function/table/system/duckdb_columns.cpp
+++ b/src/function/table/system/duckdb_columns.cpp
@@ -133,8 +133,8 @@ public:
 		auto &column = entry.GetColumn(LogicalIndex(col));
 		if (column.Generated()) {
 			return Value(column.GeneratedExpression().ToString());
-		} else if (column.DefaultValue()) {
-			return Value(column.DefaultValue()->ToString());
+		} else if (column.HasDefaultValue()) {
+			return Value(column.DefaultValue().ToString());
 		}
 		return Value();
 	}

--- a/src/function/table/system/pragma_table_info.cpp
+++ b/src/function/table/system/pragma_table_info.cpp
@@ -99,11 +99,11 @@ static Value DefaultValue(const ColumnDefinition &def) {
 	if (def.Generated()) {
 		return Value(def.GeneratedExpression().ToString());
 	}
-	auto &value = def.DefaultValue();
-	if (!value) {
+	if (!def.HasDefaultValue()) {
 		return Value();
 	}
-	return Value(value->ToString());
+	auto &value = def.DefaultValue();
+	return Value(value.ToString());
 }
 
 static void PragmaTableInfoTable(PragmaTableOperatorData &data, TableCatalogEntry &table, DataChunk &output) {

--- a/src/function/table/system/pragma_table_info.cpp
+++ b/src/function/table/system/pragma_table_info.cpp
@@ -95,6 +95,17 @@ static void CheckConstraints(TableCatalogEntry &table, const ColumnDefinition &c
 	}
 }
 
+static Value DefaultValue(const ColumnDefinition &def) {
+	if (def.Generated()) {
+		return Value(def.GeneratedExpression().ToString());
+	}
+	auto &value = def.DefaultValue();
+	if (!value) {
+		return Value();
+	}
+	return Value(value->ToString());
+}
+
 static void PragmaTableInfoTable(PragmaTableOperatorData &data, TableCatalogEntry &table, DataChunk &output) {
 	if (data.offset >= table.GetColumns().LogicalColumnCount()) {
 		// finished returning values
@@ -122,8 +133,7 @@ static void PragmaTableInfoTable(PragmaTableOperatorData &data, TableCatalogEntr
 		// "notnull", PhysicalType::BOOL
 		output.SetValue(3, index, Value::BOOLEAN(not_null));
 		// "dflt_value", PhysicalType::VARCHAR
-		Value def_value = column.DefaultValue() ? Value(column.DefaultValue()->ToString()) : Value();
-		output.SetValue(4, index, def_value);
+		output.SetValue(4, index, DefaultValue(column));
 		// "pk", PhysicalType::BOOL
 		output.SetValue(5, index, Value::BOOLEAN(pk));
 	}

--- a/src/include/duckdb/parser/column_definition.hpp
+++ b/src/include/duckdb/parser/column_definition.hpp
@@ -31,7 +31,8 @@ public:
 
 public:
 	//! default_value
-	const unique_ptr<ParsedExpression> &DefaultValue() const;
+	const ParsedExpression &DefaultValue() const;
+	bool HasDefaultValue() const;
 	void SetDefaultValue(unique_ptr<ParsedExpression> default_value);
 
 	//! type

--- a/src/parser/column_definition.cpp
+++ b/src/parser/column_definition.cpp
@@ -26,7 +26,12 @@ ColumnDefinition ColumnDefinition::Copy() const {
 }
 
 const ParsedExpression &ColumnDefinition::DefaultValue() const {
-	D_ASSERT(HasDefaultValue());
+	if (!HasDefaultValue()) {
+		if (Generated()) {
+			throw InternalException("Calling DefaultValue() on a generated column");
+		}
+		throw InternalException("DefaultValue() called on a column without a default value");
+	}
 	return *expression;
 }
 

--- a/src/parser/column_definition.cpp
+++ b/src/parser/column_definition.cpp
@@ -25,11 +25,16 @@ ColumnDefinition ColumnDefinition::Copy() const {
 	return copy;
 }
 
-const unique_ptr<ParsedExpression> &ColumnDefinition::DefaultValue() const {
+const ParsedExpression &ColumnDefinition::DefaultValue() const {
+	D_ASSERT(HasDefaultValue());
+	return *expression;
+}
+
+bool ColumnDefinition::HasDefaultValue() const {
 	if (Generated()) {
-		throw InternalException("Calling DefaultValue() on a generated column");
+		return false;
 	}
-	return expression;
+	return expression != nullptr;
 }
 
 void ColumnDefinition::SetDefaultValue(unique_ptr<ParsedExpression> default_value) {

--- a/src/parser/transform/constraint/transform_constraint.cpp
+++ b/src/parser/transform/constraint/transform_constraint.cpp
@@ -113,8 +113,9 @@ unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGLis
 	case duckdb_libpgquery::PG_CONSTR_NULL:
 		return nullptr;
 	case duckdb_libpgquery::PG_CONSTR_GENERATED_VIRTUAL: {
-		if (column.DefaultValue()) {
-			throw InvalidInputException("DEFAULT constraint on GENERATED column \"%s\" is not allowed", column.Name());
+		if (column.HasDefaultValue()) {
+			throw InvalidInputException("\"%s\" has a DEFAULT value set, it can not become a GENERATED column",
+			                            column.Name());
 		}
 		column.SetGeneratedExpression(TransformExpression(constraint->raw_expr));
 		return nullptr;

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -212,10 +212,10 @@ void Binder::BindGeneratedColumns(BoundCreateTableInfo &info) {
 void Binder::BindDefaultValues(const ColumnList &columns, vector<unique_ptr<Expression>> &bound_defaults) {
 	for (auto &column : columns.Physical()) {
 		unique_ptr<Expression> bound_default;
-		if (column.DefaultValue()) {
+		if (column.HasDefaultValue()) {
 			// we bind a copy of the DEFAULT value because binding is destructive
 			// and we want to keep the original expression around for serialization
-			auto default_copy = column.DefaultValue()->Copy();
+			auto default_copy = column.DefaultValue().Copy();
 			ConstantBinder default_binder(*this, context, "DEFAULT value");
 			default_binder.target_type = column.Type();
 			bound_default = default_binder.Bind(default_copy);

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -42,8 +42,8 @@ static void CheckInsertColumnCountMismatch(int64_t expected_columns, int64_t res
 }
 
 unique_ptr<ParsedExpression> ExpandDefaultExpression(const ColumnDefinition &column) {
-	if (column.DefaultValue()) {
-		return column.DefaultValue()->Copy();
+	if (column.HasDefaultValue()) {
+		return column.DefaultValue().Copy();
 	} else {
 		return make_uniq<ConstantExpression>(Value(column.Type()));
 	}

--- a/test/sql/pragma/test_table_info.test
+++ b/test/sql/pragma/test_table_info.test
@@ -95,3 +95,15 @@ PRAGMA table_info(tconstraint2)
 # incorrect number of parameters
 statement error
 PRAGMA table_info(1,2,3);
+
+statement ok
+create table t1 (
+	c1 int,
+	c2 int generated always as (c1 + 1)
+);
+
+query IIIIII
+SELECT * FROM pragma_table_info(t1);
+----
+0	c1	INTEGER	false	NULL	false
+1	c2	INTEGER	false	CAST((c1 + 1) AS INTEGER)	false


### PR DESCRIPTION
This PR fixes #9745 

Added `HasDefaultValue` and changed `DefaultValue` to return a reference.
DefaultValue will now assert that HasDefaultValue is true, and HasDefaultValue will return false if the column is a GENERATED column.