### PR TITLE
Fix s3fs close issue

### DIFF
--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -104,8 +104,8 @@ public:
 	S3FileHandle(FileSystem &fs, string path_p, uint8_t flags, const HTTPParams &http_params,
 	             const S3AuthParams &auth_params_p, const S3ConfigParams &config_params_p)
 	    : HTTPFileHandle(fs, std::move(path_p), flags, http_params), auth_params(auth_params_p),
-	      config_params(config_params_p) {
-
+	      config_params(config_params_p), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
+	      uploader_has_error(false), upload_exception(nullptr) {
 		if (flags & FileFlags::FILE_FLAGS_WRITE && flags & FileFlags::FILE_FLAGS_READ) {
 			throw NotImplementedException("Cannot open an HTTP file for both reading and writing");
 		} else if (flags & FileFlags::FILE_FLAGS_APPEND) {

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -266,7 +266,9 @@ void S3FileHandle::Close() {
 	auto &s3fs = (S3FileSystem &)file_system;
 	if ((flags & FileFlags::FILE_FLAGS_WRITE) && !upload_finalized) {
 		s3fs.FlushAllBuffers(*this);
-		s3fs.FinalizeMultipartUpload(*this);
+		if (parts_uploaded) {
+			s3fs.FinalizeMultipartUpload(*this);
+		}
 	}
 }
 
@@ -424,6 +426,7 @@ void S3FileSystem::FlushAllBuffers(S3FileHandle &file_handle) {
 
 void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 	auto &s3fs = (S3FileSystem &)file_handle.file_system;
+	file_handle.upload_finalized = true;
 
 	std::stringstream ss;
 	ss << "<CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
@@ -452,7 +455,6 @@ void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
 	if (open_tag_pos == string::npos) {
 		throw IOException("Unexpected response during S3 multipart upload finalization: %d\n\n%s", res->code, result);
 	}
-	file_handle.upload_finalized = true;
 }
 
 // Wrapper around the BufferManager::Allocate to that allows limiting the number of buffers that will be handed out
@@ -826,10 +828,6 @@ void S3FileHandle::Initialize(FileOpener *opener) {
 		D_ASSERT(part_size * max_part_count >= config_params.max_file_size);
 
 		multipart_upload_id = s3fs.InitializeMultipartUpload(*this);
-
-		uploads_in_progress = 0;
-		parts_uploaded = 0;
-		upload_finalized = false;
 	}
 }
 

--- a/test/sql/copy/s3/fully_qualified_s3_url.test
+++ b/test/sql/copy/s3/fully_qualified_s3_url.test
@@ -8,11 +8,6 @@ require httpfs
 
 require-env S3_TEST_SERVER_AVAILABLE 1
 
-# FIXME - this test randomly fails in the CI
-# # terminate called after throwing an instance of 'duckdb::IOException'
-#   what():  IO Error: Unexpected response during S3 multipart upload finalization: 403
-mode skip
-
 # Require that these environment variables are also set
 
 require-env AWS_DEFAULT_REGION

--- a/test/sql/copy/s3/upload_large_file.test_slow
+++ b/test/sql/copy/s3/upload_large_file.test_slow
@@ -27,7 +27,7 @@ set ignore_error_messages
 
 # confirm we use a reasonable amount of memory
 statement ok
-SET memory_limit='2.2GB';
+SET memory_limit='2.5GB';
 
 statement ok
 set http_timeout=120000;


### PR DESCRIPTION
This fixes two CI issues.

The first one arose due to a failure to properly initialize the upload variables for the s3filehandle. This is now solved.

The second due to duckdb's increased memory usage failing the test/sql/copy/s3/upload_large_file.test_slow test. I solved this by slightly bumping the memory. I did not find anything the would point to a memory leak so we just use slightly more memory now. If this would need even more bumping in the future we should probably do more in depth investigation.

