### PR TITLE
[Python] No longer scan `datetime.datetime.max` as infinity

### DIFF
--- a/tools/pythonpkg/scripts/cache_data.json
+++ b/tools/pythonpkg/scripts/cache_data.json
@@ -48,9 +48,9 @@
         "name": "pandas",
         "children": [
             "pandas.DataFrame",
-            "pandas._libs",
             "pandas.isnull",
-            "pandas.ArrowDtype"
+            "pandas.ArrowDtype",
+            "pandas.NaT"
         ],
         "required": false
     },
@@ -60,27 +60,10 @@
         "name": "DataFrame",
         "children": []
     },
-    "pandas._libs": {
+    "pandas.NaT": {
         "type": "attribute",
-        "full_path": "pandas._libs",
-        "name": "_libs",
-        "children": [
-            "pandas._libs.missing"
-        ],
-        "required": false
-    },
-    "pandas._libs.missing": {
-        "type": "attribute",
-        "full_path": "pandas._libs.missing",
-        "name": "missing",
-        "children": [
-            "pandas._libs.missing.NAType"
-        ]
-    },
-    "pandas._libs.missing.NAType": {
-        "type": "attribute",
-        "full_path": "pandas._libs.missing.NAType",
-        "name": "NAType",
+        "full_path": "pandas.NaT",
+        "name": "NaT",
         "children": []
     },
     "pandas.isnull": {
@@ -433,7 +416,7 @@
         "children": [
             "duckdb.filesystem.ModifiedMemoryFileSystem"
         ],
-		"required": false
+        "required": false
     },
     "duckdb.filesystem.ModifiedMemoryFileSystem": {
         "type": "attribute",

--- a/tools/pythonpkg/scripts/cache_data.json
+++ b/tools/pythonpkg/scripts/cache_data.json
@@ -50,7 +50,8 @@
             "pandas.DataFrame",
             "pandas.isnull",
             "pandas.ArrowDtype",
-            "pandas.NaT"
+            "pandas.NaT",
+            "pandas.NA"
         ],
         "required": false
     },
@@ -64,6 +65,12 @@
         "type": "attribute",
         "full_path": "pandas.NaT",
         "name": "NaT",
+        "children": []
+    },
+    "pandas.NA": {
+        "type": "attribute",
+        "full_path": "pandas.NA",
+        "name": "NA",
         "children": []
     },
     "pandas.isnull": {

--- a/tools/pythonpkg/scripts/imports.py
+++ b/tools/pythonpkg/scripts/imports.py
@@ -10,6 +10,7 @@ import pandas
 
 pandas.DataFrame
 pandas.NaT
+pandas.NA
 pandas.isnull
 pandas.ArrowDtype
 

--- a/tools/pythonpkg/scripts/imports.py
+++ b/tools/pythonpkg/scripts/imports.py
@@ -9,7 +9,7 @@ pyarrow.RecordBatchReader
 import pandas
 
 pandas.DataFrame
-pandas._libs.missing.NAType
+pandas.NaT
 pandas.isnull
 pandas.ArrowDtype
 

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pandas_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pandas_module.hpp
@@ -13,35 +13,6 @@
 
 namespace duckdb {
 
-struct PandasLibsMissingCacheItem : public PythonImportCacheItem {
-
-public:
-	PandasLibsMissingCacheItem(optional_ptr<PythonImportCacheItem> parent)
-	    : PythonImportCacheItem("missing", parent), NAType("NAType", this) {
-	}
-	~PandasLibsMissingCacheItem() override {
-	}
-
-	PythonImportCacheItem NAType;
-};
-
-struct PandasLibsCacheItem : public PythonImportCacheItem {
-
-public:
-	PandasLibsCacheItem(optional_ptr<PythonImportCacheItem> parent)
-	    : PythonImportCacheItem("_libs", parent), missing(this) {
-	}
-	~PandasLibsCacheItem() override {
-	}
-
-	PandasLibsMissingCacheItem missing;
-
-protected:
-	bool IsRequired() const override final {
-		return false;
-	}
-};
-
 struct PandasCacheItem : public PythonImportCacheItem {
 
 public:
@@ -49,16 +20,16 @@ public:
 
 public:
 	PandasCacheItem()
-	    : PythonImportCacheItem("pandas"), DataFrame("DataFrame", this), _libs(this), isnull("isnull", this),
-	      ArrowDtype("ArrowDtype", this) {
+	    : PythonImportCacheItem("pandas"), DataFrame("DataFrame", this), isnull("isnull", this),
+	      ArrowDtype("ArrowDtype", this), NaT("NaT", this) {
 	}
 	~PandasCacheItem() override {
 	}
 
 	PythonImportCacheItem DataFrame;
-	PandasLibsCacheItem _libs;
 	PythonImportCacheItem isnull;
 	PythonImportCacheItem ArrowDtype;
+	PythonImportCacheItem NaT;
 
 protected:
 	bool IsRequired() const override final {

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pandas_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/pandas_module.hpp
@@ -21,7 +21,7 @@ public:
 public:
 	PandasCacheItem()
 	    : PythonImportCacheItem("pandas"), DataFrame("DataFrame", this), isnull("isnull", this),
-	      ArrowDtype("ArrowDtype", this), NaT("NaT", this) {
+	      ArrowDtype("ArrowDtype", this), NaT("NaT", this), NA("NA", this) {
 	}
 	~PandasCacheItem() override {
 	}
@@ -30,6 +30,7 @@ public:
 	PythonImportCacheItem isnull;
 	PythonImportCacheItem ArrowDtype;
 	PythonImportCacheItem NaT;
+	PythonImportCacheItem NA;
 
 protected:
 	bool IsRequired() const override final {

--- a/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
@@ -163,8 +163,6 @@ public:
 	date_t ToDate();
 	dtime_t ToDuckTime();
 	Value ToDuckValue(const LogicalType &target_type);
-	bool IsPositiveInfinity() const;
-	bool IsNegativeInfinity() const;
 
 public:
 	static int32_t GetYears(py::handle &obj);
@@ -186,8 +184,6 @@ public:
 
 public:
 	Value ToDuckValue();
-	bool IsPositiveInfinity() const;
-	bool IsNegativeInfinity() const;
 };
 
 struct PyTimezone {

--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -363,7 +363,7 @@ PythonObjectType GetPythonObjectType(py::handle &ele) {
 
 	if (ele.is_none()) {
 		return PythonObjectType::None;
-	} else if (py::isinstance(ele, import_cache.pandas._libs.missing.NAType())) {
+	} else if (ele.is(import_cache.pandas.NaT())) {
 		return PythonObjectType::None;
 	} else if (py::isinstance<py::bool_>(ele)) {
 		return PythonObjectType::Bool;

--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -365,6 +365,8 @@ PythonObjectType GetPythonObjectType(py::handle &ele) {
 		return PythonObjectType::None;
 	} else if (ele.is(import_cache.pandas.NaT())) {
 		return PythonObjectType::None;
+	} else if (ele.is(import_cache.pandas.NA())) {
+		return PythonObjectType::None;
 	} else if (py::isinstance<py::bool_>(ele)) {
 		return PythonObjectType::Bool;
 	} else if (py::isinstance<py::int_>(ele)) {

--- a/tools/pythonpkg/src/native/python_objects.cpp
+++ b/tools/pythonpkg/src/native/python_objects.cpp
@@ -274,23 +274,7 @@ timestamp_t PyDateTime::ToTimestamp() {
 	return Timestamp::FromDatetime(date, time);
 }
 
-bool PyDateTime::IsPositiveInfinity() const {
-	return year == 9999 && month == 12 && day == 31 && hour == 23 && minute == 59 && second == 59 && micros == 999999;
-}
-
-bool PyDateTime::IsNegativeInfinity() const {
-	return year == 1 && month == 1 && day == 1 && hour == 0 && minute == 0 && second == 0 && micros == 0;
-}
-
 Value PyDateTime::ToDuckValue(const LogicalType &target_type) {
-	if (IsPositiveInfinity()) {
-		// FIXME: respect the target_type ?
-		return Value::TIMESTAMP(timestamp_t::infinity());
-	}
-	if (IsNegativeInfinity()) {
-		// FIXME: respect the target_type ?
-		return Value::TIMESTAMP(timestamp_t::ninfinity());
-	}
 	auto timestamp = ToTimestamp();
 	if (!py::none().is(tzone_obj)) {
 		auto utc_offset = PyTimezone::GetUTCOffset(tzone_obj);
@@ -363,21 +347,8 @@ PyDate::PyDate(py::handle &ele) {
 }
 
 Value PyDate::ToDuckValue() {
-	if (IsPositiveInfinity()) {
-		return Value::DATE(date_t::infinity());
-	}
-	if (IsNegativeInfinity()) {
-		return Value::DATE(date_t::ninfinity());
-	}
-	return Value::DATE(year, month, day);
-}
-
-bool PyDate::IsPositiveInfinity() const {
-	return year == 9999 && month == 12 && day == 31;
-}
-
-bool PyDate::IsNegativeInfinity() const {
-	return year == 1 && month == 1 && day == 1;
+	auto value = Value::DATE(year, month, day);
+	return value;
 }
 
 void PythonObject::Initialize() {

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -341,9 +341,17 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 					continue;
 				}
 				if (import_cache.pandas.NaT(false)) {
-					// If pandas is imported, check if the type is NAType
+					// If pandas is imported, check if this is pandas.NaT
 					py::handle value(val);
 					if (value.is(import_cache.pandas.NaT())) {
+						out_mask.SetInvalid(row);
+						continue;
+					}
+				}
+				if (import_cache.pandas.NA(false)) {
+					// If pandas is imported, check if this is pandas.NA
+					py::handle value(val);
+					if (value.is(import_cache.pandas.NA())) {
 						out_mask.SetInvalid(row);
 						continue;
 					}

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -340,11 +340,10 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 					out_mask.SetInvalid(row);
 					continue;
 				}
-				if (import_cache.pandas._libs.missing.NAType(false)) {
+				if (import_cache.pandas.NaT(false)) {
 					// If pandas is imported, check if the type is NAType
-					auto val_type = Py_TYPE(val);
-					auto na_type = reinterpret_cast<PyTypeObject *>(import_cache.pandas._libs.missing.NAType().ptr());
-					if (val_type == na_type) {
+					py::handle value(val);
+					if (value.is(import_cache.pandas.NaT())) {
 						out_mask.SetInvalid(row);
 						continue;
 					}

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -548,42 +548,67 @@ class TestResolveObjectColumns(object):
         assert len(res['dates'].__array__()) == 4
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_multiple_chunks_aggregate(self, pandas):
-        conn = duckdb.connect()
-        conn.execute(
-            "create table dates as select '2022-09-14'::DATE + INTERVAL (i::INTEGER) DAY as i from range(0, 4096) tbl(i);"
+    def test_multiple_chunks_aggregate(self, pandas, duckdb_cursor):
+        duckdb_cursor.execute(f"SET GLOBAL pandas_analyze_sample=4096")
+        duckdb_cursor.execute(
+            "create table dates as select '2022-09-14'::DATE + INTERVAL (i::INTEGER) DAY as i from range(4096) tbl(i);"
         )
-        res = duckdb.query("select * from dates", connection=conn).df()
+        rel = duckdb_cursor.query("select * from dates")
+        res = rel.df()
         date_df = res.copy()
-        # Convert the values to `datetime.date` values, and the dtype of the column to 'object'
+
+        # Convert the dataframe to datetime
         date_df['i'] = pandas.to_datetime(res['i']).dt.date
         assert str(date_df['i'].dtype) == 'object'
-        expected_res = duckdb.query(
-            'select avg(epoch(i)), min(epoch(i)), max(epoch(i)) from dates;', connection=conn
-        ).fetchall()
-        actual_res = duckdb.query_df(
-            date_df, 'x', 'select avg(epoch(i)), min(epoch(i)), max(epoch(i)) from x'
-        ).fetchall()
+
+        expected_res = [
+            (
+                1840017600.0,  # Saturday, April 22, 2028 12:00:00 PM (avg)
+                1663113600.0,  # Wednesday, September 14, 2022 12:00:00 AM (min)
+                2016921600.0,  # Wednesday, November 30, 2033 12:00:00 AM (max)
+            )
+        ]
+
+        rel = duckdb_cursor.query(
+            """
+            select
+                avg(epoch(i)),
+                min(epoch(i)),
+                max(epoch(i))
+            from date_df
+        """
+        )
+        actual_res = rel.fetchall()
         assert expected_res == actual_res
 
-        conn.execute('drop table dates')
-        # Now with nulls interleaved
+        # Now interleave nulls into the dataframe
+        duckdb_cursor.execute('drop table dates')
         for i in range(0, len(res['i']), 2):
             res['i'][i] = None
+        duckdb_cursor.execute('create table dates as select * from res')
 
-        date_view = conn.register("date_view", res)
-        date_view.execute('create table dates as select * from date_view')
-        expected_res = duckdb.query(
-            "select avg(epoch(i)), min(epoch(i)), max(epoch(i)) from dates", connection=conn
-        ).fetchall()
-
+        expected_res = [
+            (
+                1840060800.0,  # Sunday, April 23, 2028 12:00:00 AM
+                1663200000.0,  # Thursday, September 15, 2022 12:00:00 AM
+                2016921600.0,  # Wednesday, November 30, 2033 12:00:00 AM
+            )
+        ]
+        # Convert the dataframe to datetime
         date_df = res.copy()
-        # Convert the values to `datetime.date` values, and the dtype of the column to 'object'
         date_df['i'] = pandas.to_datetime(res['i']).dt.date
         assert str(date_df['i'].dtype) == 'object'
-        actual_res = duckdb.query_df(
-            date_df, 'x', 'select avg(epoch(i)), min(epoch(i)), max(epoch(i)) from x'
+
+        actual_res = duckdb_cursor.query(
+            """
+            select
+                avg(epoch(i)),
+                min(epoch(i)),
+                max(epoch(i))
+            from date_df
+        """
         ).fetchall()
+
         assert expected_res == actual_res
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_na.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_na.py
@@ -18,15 +18,13 @@ class TestPandasNA(object):
         # DataFrame containing a single pd.NA
         df = pd.DataFrame(pd.Series([pd.NA]))
 
-        conn = duckdb.connect()
-
-        res = conn.execute("select * from df").fetchall()
+        res = duckdb_cursor.execute("select * from df").fetchall()
         assert res[0][0] == None
 
         # DataFrame containing multiple values, with a pd.NA mixed in
         null_index = 3
         df = pd.DataFrame(pd.Series([3, 1, 2, pd.NA, 8, 6]))
-        res = conn.execute("select * from df").fetchall()
+        res = duckdb_cursor.execute("select * from df").fetchall()
         items = [x[0] for x in [y for y in res]]
         assert_nullness(items, [null_index])
 
@@ -62,13 +60,13 @@ class TestPandasNA(object):
         assert str(nan_df['a'].dtype) == 'float64'
         assert str(na_df['a'].dtype) == 'object'  # pd.NA values turn the column into 'object'
 
-        nan_result = conn.execute("select * from nan_df").df()
-        na_result = conn.execute("select * from na_df").df()
+        nan_result = duckdb_cursor.execute("select * from nan_df").df()
+        na_result = duckdb_cursor.execute("select * from na_df").df()
         pd.testing.assert_frame_equal(nan_result, na_result)
 
         # Mixed with stringified pd.NA values
         na_string_df = pd.DataFrame({'a': [str(pd.NA), str(pd.NA), pd.NA, str(pd.NA), pd.NA, pd.NA, pd.NA, str(pd.NA)]})
         null_indices = [2, 4, 5, 6]
-        res = conn.execute("select * from na_string_df").fetchall()
+        res = duckdb_cursor.execute("select * from na_string_df").fetchall()
         items = [x[0] for x in [y for y in res]]
         assert_nullness(items, null_indices)

--- a/tools/pythonpkg/tests/fast/types/test_datetime_date.py
+++ b/tools/pythonpkg/tests/fast/types/test_datetime_date.py
@@ -22,9 +22,9 @@ class TestDateTimeDate(object):
         # positive infinity
         con.execute("select $1, $1 = 'infinity'::DATE", [datetime.date.max])
         res = con.fetchall()
-        assert res == [(datetime.date.max, True)]
+        assert res == [(datetime.date.max, False)]
 
         # negative infinity
         con.execute("select $1, $1 = '-infinity'::DATE", [datetime.date.min])
         res = con.fetchall()
-        assert res == [(datetime.date.min, True)]
+        assert res == [(datetime.date.min, False)]

--- a/tools/pythonpkg/tests/fast/types/test_datetime_datetime.py
+++ b/tools/pythonpkg/tests/fast/types/test_datetime_datetime.py
@@ -41,9 +41,9 @@ class TestDateTimeDateTime(object):
         # positive infinity
         con.execute("select $1, $1 = 'infinity'::TIMESTAMP", [datetime.datetime.max])
         res = con.fetchall()
-        assert res == [(datetime.datetime.max, True)]
+        assert res == [(datetime.datetime.max, False)]
 
         # negative infinity
         con.execute("select $1, $1 = '-infinity'::TIMESTAMP", [datetime.datetime.min])
         res = con.fetchall()
-        assert res == [(datetime.datetime.min, True)]
+        assert res == [(datetime.datetime.min, False)]


### PR DESCRIPTION
This relates to #8143 and fixes #9520 

To fix the issue mentioned we added support for outputting infinity as `datetime.datetime.max`, to be able to roundtrip this, we also scanned `datetime.datetime.max` as infinity.

This caused issues in other places.

To fix both issues, we now output the string`'infinity'` instead.

-----------------

Also fixed some issues found while working on this, related to NaT and NA not being properly recognized as NULL