### PR TITLE
Fix empty box in explain analyze statement

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -11617,18 +11617,22 @@ static int shell_callback(
       if (nArg != 2) {
         break;
       }
-      utf8_printf(p->out, "\n┌─────────────────────────────┐\n");
-      utf8_printf(p->out, "│┌───────────────────────────┐│\n");
-      if (strcmp(azArg[0], "logical_plan") == 0) {
-      utf8_printf(p->out, "││ Unoptimized Logical Plan  ││\n");
-      } else if (strcmp(azArg[0], "logical_opt") == 0) {
-      utf8_printf(p->out, "││  Optimized Logical Plan   ││\n");
-      } else if (strcmp(azArg[0], "physical_plan") == 0) {
-      utf8_printf(p->out, "││       Physical Plan       ││\n");
-
+      int logical_plan = strcmp(azArg[0], "logical_plan");
+      int logical_opt = strcmp(azArg[0], "logical_opt");
+      int physical_plan = strcmp(azArg[0], "physical_plan");
+      if (logical_plan * logical_opt * physical_plan == 0) {
+        utf8_printf(p->out, "\n┌─────────────────────────────┐\n");
+        utf8_printf(p->out, "│┌───────────────────────────┐│\n");
+        if (logical_plan == 0) {
+          utf8_printf(p->out, "││ Unoptimized Logical Plan  ││\n");
+        } else if (logical_opt == 0) {
+          utf8_printf(p->out, "││  Optimized Logical Plan   ││\n");
+        } else if (physical_plan == 0) {
+          utf8_printf(p->out, "││       Physical Plan       ││\n");
+        }
+        utf8_printf(p->out, "│└───────────────────────────┘│\n");
+        utf8_printf(p->out, "└─────────────────────────────┘\n");
       }
-      utf8_printf(p->out, "│└───────────────────────────┘│\n");
-      utf8_printf(p->out, "└─────────────────────────────┘\n");
       utf8_printf(p->out, "%s", azArg[1]);
       break;
     }


### PR DESCRIPTION
This PR removes the empty box printed in an `explain analyze` statement output. This was caused because the `MODE_Explain` is expecting either a logical or physical plan as an argument).

![empty_box](https://github.com/duckdb/duckdb/assets/25373111/6acb9588-880f-4f13-9a77-855eaf1c3bb4)