### PR TITLE
Issue#9795 min/max doesn't use collation

### DIFF
--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -3,6 +3,8 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
 
 namespace duckdb {
@@ -151,6 +153,16 @@ struct ArgMinMaxBase {
 	static bool IgnoreNull() {
 		return true;
 	}
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
+	                                     vector<unique_ptr<Expression>> &arguments) {
+		auto result_type =
+		    BoundComparisonExpression::BindComparison(arguments[0]->return_type, arguments[1]->return_type);
+		ExpressionBinder::PushCollation(context, arguments[1], result_type, false);
+		function.arguments[0] = arguments[0]->return_type;
+		function.return_type = arguments[0]->return_type;
+		return nullptr;
+	}
 };
 
 template <typename COMPARATOR>
@@ -275,6 +287,9 @@ AggregateFunction GetArgMinMaxFunctionInternal(const LogicalType &by_type, const
 	auto function = AggregateFunction::BinaryAggregate<STATE, ARG_TYPE, BY_TYPE, ARG_TYPE, OP>(type, by_type, type);
 	if (type.InternalType() == PhysicalType::VARCHAR || by_type.InternalType() == PhysicalType::VARCHAR) {
 		function.destructor = AggregateFunction::StateDestroy<STATE, OP>;
+	}
+	if (by_type.InternalType() == PhysicalType::VARCHAR) {
+		function.bind = OP::Bind;
 	}
 	return function;
 }

--- a/src/core_functions/aggregate/distributive/minmax.cpp
+++ b/src/core_functions/aggregate/distributive/minmax.cpp
@@ -1,9 +1,13 @@
+#include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/core_functions/aggregate/distributive_functions.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/types/null_value.hpp"
 #include "duckdb/planner/expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/function/function_binder.hpp"
 
 namespace duckdb {
 
@@ -583,6 +587,39 @@ static AggregateFunction GetMinMaxOperator(const LogicalType &type) {
 template <class OP, class OP_STRING, class OP_VECTOR>
 unique_ptr<FunctionData> BindMinMax(ClientContext &context, AggregateFunction &function,
                                     vector<unique_ptr<Expression>> &arguments) {
+
+	if (arguments[0]->return_type.id() == LogicalTypeId::VARCHAR) {
+		auto str_collation = StringType::GetCollation(arguments[0]->return_type);
+		if (!str_collation.empty()) {
+			// If aggr function is min/max and uses collations, replace bound_function with arg_min/arg_max
+			// to make sure the result's correctness.
+			string function_name = function.name == "min" ? "arg_min" : "arg_max";
+			QueryErrorContext error_context;
+			auto func = Catalog::GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, "", "", function_name,
+			                              OnEntryNotFound::RETURN_NULL, error_context);
+
+			auto &func_entry = func->Cast<AggregateFunctionCatalogEntry>();
+
+			FunctionBinder function_binder(context);
+			vector<LogicalType> types {arguments[0]->return_type, arguments[0]->return_type};
+			string error;
+			idx_t best_function = function_binder.BindFunction(func_entry.name, func_entry.functions, types, error);
+			if (best_function == DConstants::INVALID_INDEX) {
+				throw BinderException(string("Fail to find corresponding function for collation min/max: ") + error);
+			}
+			function = func_entry.functions.GetFunctionByOffset(best_function);
+
+			// Create a copied child and PushCollation for it.
+			arguments.push_back(arguments[0]->Copy());
+			ExpressionBinder::PushCollation(context, arguments[1], arguments[0]->return_type, false);
+
+			// Bind function like arg_min/arg_max.
+			function.arguments[0] = arguments[0]->return_type;
+			function.return_type = arguments[0]->return_type;
+			return nullptr;
+		}
+	}
+
 	auto input_type = arguments[0]->return_type;
 	auto name = std::move(function.name);
 	function = GetMinMaxOperator<OP, OP_STRING, OP_VECTOR>(input_type);

--- a/test/issues/general/test_9795.test
+++ b/test/issues/general/test_9795.test
@@ -1,0 +1,65 @@
+# name: test/issues/general/test_9795.test
+# description: Issue 1091: Min/Max function doesn't use collations.
+# group: [general]
+
+statement ok
+create table tbl (a varchar);
+
+statement ok
+insert into tbl values ('ö'), ('o'), ('p');
+
+query I
+select max(a) from tbl;
+----
+ö
+
+query I
+select arg_max(a, a) from tbl;
+----
+ö
+
+query I
+select max(a collate noaccent) from tbl;
+----
+p
+
+query I
+select arg_max(a, a collate noaccent) from tbl;
+----
+p
+
+query I
+select min(a) from tbl;
+----
+o
+
+query I
+select arg_min(a, a) from tbl;
+----
+o
+
+query I
+select min(a collate noaccent) from tbl;
+----
+ö
+
+query I
+select arg_min(a, a collate noaccent) from tbl;
+----
+ö
+
+statement ok
+create table tbl2 (a int);
+
+statement ok
+insert into tbl2 values (1), (2), (3);
+
+query I
+select min(a) from tbl2;
+----
+1
+
+query I
+select max(a) from tbl2;
+----
+3


### PR DESCRIPTION
1) Fix arg_min/arg_max collation issue by invoke
   PushCollation() for the second children expression.
2) Add macro to convert min(a)/max(a) to arg_min(a, a)
   and arg_max(a, a) to use collation.