### PR TITLE
Improve error message for index limitations

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -902,11 +902,11 @@ string ART::GenerateConstraintErrorMessage(VerifyExistenceType verify_type, cons
 	case VerifyExistenceType::APPEND: {
 		// APPEND to PK/UNIQUE table, but node/key already exists in PK/UNIQUE table
 		string type = IsPrimary() ? "primary key" : "unique";
-		return StringUtil::Format(
-		    "Duplicate key \"%s\" violates %s constraint. "
-		    "If this is an unexpected constraint violation please double "
-		    "check with the known index limitations section in our documentation (docs - sql - indexes).",
-		    key_name, type);
+		return StringUtil::Format("Duplicate key \"%s\" violates %s constraint. "
+		                          "If this is an unexpected constraint violation please double "
+		                          "check with the known index limitations section in our documentation "
+		                          "(https://duckdb.org/docs/sql/indexes).",
+		                          key_name, type);
 	}
 	case VerifyExistenceType::APPEND_FK: {
 		// APPEND_FK to FK table, node/key does not exist in PK/UNIQUE table

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -298,7 +298,7 @@ static void RegisterUpdatedRows(InsertLocalState &lstate, const Vector &row_ids,
 		auto result = updated_rows.insert(data[i]);
 		if (result.second == false) {
 			throw InvalidInputException(
-			    "ON CONFLICT DO UPDATE can not update the same row twice in the same command, Ensure that no rows "
+			    "ON CONFLICT DO UPDATE can not update the same row twice in the same command. Ensure that no rows "
 			    "proposed for insertion within the same command have duplicate constrained values");
 		}
 	}

--- a/test/sql/index/art/constraints/test_art_eager_constraint_checking.test
+++ b/test/sql/index/art/constraints/test_art_eager_constraint_checking.test
@@ -22,7 +22,7 @@ INSERT INTO u VALUES (1, NULL);
 statement error
 UPDATE u SET ju = 1 WHERE iu = 1;
 ----
-Constraint Error: Duplicate key "iu: 1" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (docs - sql - indexes).
+Constraint Error: Duplicate key "iu: 1" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).
 
 # issue #5807
 
@@ -38,7 +38,7 @@ SELECT 1, 41;
 statement error
 UPDATE tunion SET u = 42 WHERE id = 1;
 ----
-Constraint Error: Duplicate key "id: 1" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (docs - sql - indexes).
+Constraint Error: Duplicate key "id: 1" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).
 
 # issue #5771
 
@@ -57,7 +57,7 @@ UPDATE workers SET phone = '345' WHERE id = 1;
 statement error
 UPDATE workers SET worker = 'leo' WHERE id = 1;
 ----
-Constraint Error: Duplicate key "id: 1" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (docs - sql - indexes).
+Constraint Error: Duplicate key "id: 1" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).
 
 # issue #4886
 
@@ -80,7 +80,7 @@ UPDATE test SET i = 4 WHERE i = 1;
 statement error
 INSERT INTO test VALUES (1);
 ----
-Constraint Error: Duplicate key "i: 1" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (docs - sql - indexes).
+Constraint Error: Duplicate key "i: 1" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).
 
 statement ok
 ROLLBACK
@@ -104,6 +104,6 @@ UPDATE tbl
 SET sometext = 'ghi', someothertext = 'mno'
 WHERE id = 2;
 ----
-Constraint Error: Duplicate key "id: 2" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (docs - sql - indexes).
+Constraint Error: Duplicate key "id: 2" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).
 
 

--- a/test/sql/index/art/issues/test_art_issue_7349.test
+++ b/test/sql/index/art/issues/test_art_issue_7349.test
@@ -38,7 +38,7 @@ INSERT INTO tab0 VALUES('2006-12-25');
 statement error
 INSERT INTO td VALUES (date '2008-02-29');
 ----
-Constraint Error: Duplicate key "tz: 2008-02-29" violates unique constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (docs - sql - indexes).
+Constraint Error: Duplicate key "tz: 2008-02-29" violates unique constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).
 
 statement ok
 COMMIT TRANSACTION;
@@ -54,7 +54,7 @@ INSERT INTO tab0 VALUES('2006-12-25');
 statement error
 INSERT INTO td VALUES (date '2008-02-29');
 ----
-Constraint Error: Duplicate key "tz: 2008-02-29" violates unique constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (docs - sql - indexes).
+Constraint Error: Duplicate key "tz: 2008-02-29" violates unique constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).
 
 statement ok
 COMMIT TRANSACTION;

--- a/test/sql/index/art/types/test_art_union.test
+++ b/test/sql/index/art/types/test_art_union.test
@@ -108,7 +108,7 @@ restart
 statement error
 INSERT INTO tbl VALUES ('helloo', 'nop', 7, true);
 ----
-Constraint Error: Duplicate key "union_extract(u_2, 'string'): helloo" violates unique constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (docs - sql - indexes).
+Constraint Error: Duplicate key "union_extract(u_2, 'string'): helloo" violates unique constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).
 
 restart
 
@@ -190,4 +190,4 @@ restart
 statement error
 INSERT INTO tbl VALUES ('sunshine', 'love', 85, true);
 ----
-Constraint Error: Duplicate key "union_extract(u_2, 'string'): sunshine, union_extract(u_1, 'string'): love" violates unique constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (docs - sql - indexes).
+Constraint Error: Duplicate key "union_extract(u_2, 'string'): sunshine, union_extract(u_1, 'string'): love" violates unique constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).

--- a/test/sql/upsert/test_big_insert.test
+++ b/test/sql/upsert/test_big_insert.test
@@ -44,7 +44,7 @@ SELECT COUNT(*) FILTER (WHERE j = 10) FROM integers
 statement error
 INSERT INTO integers(i,j) select i%5,i from range(5000) tbl(i) on conflict do update set j = excluded.j, k = excluded.i;
 ----
-Invalid Input Error: ON CONFLICT DO UPDATE can not update the same row twice in the same command, Ensure that no rows proposed for insertion within the same command have duplicate constrained values
+Invalid Input Error: ON CONFLICT DO UPDATE can not update the same row twice in the same command. Ensure that no rows proposed for insertion within the same command have duplicate constrained values
 
 statement ok
 INSERT INTO integers(i,j) select i%5,i from range(4995, 5000) tbl(i) on conflict do update set j = excluded.j, k = excluded.i;

--- a/test/sql/upsert/upsert_basic.test
+++ b/test/sql/upsert/upsert_basic.test
@@ -79,7 +79,7 @@ insert into tbl VALUES
 ON CONFLICT (i) DO UPDATE SET
 	k = excluded.k;
 ----
-Invalid Input Error: ON CONFLICT DO UPDATE can not update the same row twice in the same command, Ensure that no rows proposed for insertion within the same command have duplicate constrained values
+Invalid Input Error: ON CONFLICT DO UPDATE can not update the same row twice in the same command. Ensure that no rows proposed for insertion within the same command have duplicate constrained values
 
 # Since the query errored, no operation is performed
 query III

--- a/test/sql/upsert/upsert_transaction.test
+++ b/test/sql/upsert/upsert_transaction.test
@@ -67,7 +67,7 @@ insert into tbl VALUES
 ON CONFLICT (a) DO UPDATE SET
 	b = excluded.b;
 ----
-ON CONFLICT DO UPDATE can not update the same row twice in the same command, Ensure that no rows proposed for insertion within the same command have duplicate constrained values
+ON CONFLICT DO UPDATE can not update the same row twice in the same command. Ensure that no rows proposed for insertion within the same command have duplicate constrained values
 
 statement ok
 COMMIT;


### PR DESCRIPTION
The new error message has an actual URL to the docs instead of providing the breadcrumb.