### PR TITLE
[Optimizer] regexp_matches fix InternalException caused by NULL

### DIFF
--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -143,13 +143,13 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 
 	auto constant_value = ExpressionExecutor::EvaluateScalar(GetContext(), constant_expr);
 	D_ASSERT(constant_value.type() == constant_expr.return_type);
-	auto patt_str = StringValue::Get(constant_value);
 
 	duckdb_re2::RE2::Options parsed_options = regexp_bind_data.options;
 
 	if (constant_expr.value.IsNull()) {
 		return make_uniq<BoundConstantExpression>(Value(root.return_type));
 	}
+	auto patt_str = StringValue::Get(constant_value);
 
 	// the constant_expr is a scalar expression that we have to fold
 	if (!constant_expr.IsFoldable()) {

--- a/test/sql/function/string/regex_search.test
+++ b/test/sql/function/string/regex_search.test
@@ -5,40 +5,49 @@
 statement ok
 PRAGMA enable_verification
 
+statement ok
+CREATE TABLE t0 as FROM VALUES('asdf') t(c0);
+
+# null
+query I
+SELECT regexp_matches(c0, NULL) from t0
+----
+NULL
+
 # constant strings
 query T
-SELECT regexp_matches('asdf', '.*sd.*')
+SELECT regexp_matches(c0, '.*sd.*') from t0;
 ----
 1
 
 query T
-SELECT regexp_matches('asdf', '.*yu.*')
+SELECT regexp_matches(c0, '.*yu.*') from t0;
 ----
 0
 
 query T
-SELECT regexp_matches('asdf', '')
+SELECT regexp_matches(c0, '') from t0;
 ----
 1
 
 # partial matches okay
 query T
-SELECT regexp_matches('asdf', 'sd')
+SELECT regexp_matches(c0, 'sd') from t0;
 ----
 1
 
 query T
-SELECT regexp_full_match('asdf', 'sd')
+SELECT regexp_full_match(c0, 'sd') from t0;
 ----
 0
 
 query T
-SELECT regexp_full_match('asdf', '.sd.')
+SELECT regexp_full_match(c0, '.sd.') from t0;
 ----
 1
 
 query T
-SELECT regexp_matches('asdf', '^sdf$')
+SELECT regexp_matches(c0, '^sdf$') from t0;
 ----
 0
 
@@ -55,7 +64,7 @@ SELECT regexp_matches('', '.*')
 
 # NULLs
 query T
-SELECT regexp_matches('asdf', CAST(NULL AS STRING))
+SELECT regexp_matches(c0, CAST(NULL AS STRING)) from t0;
 ----
 NULL
 
@@ -103,12 +112,12 @@ NULL
 # test regex_matches with options
 # case sensitivity
 query T
-SELECT regexp_matches('asdf', '.*SD.*', 'i')
+SELECT regexp_matches(c0, '.*SD.*', 'i') from t0;
 ----
 1
 
 query T
-SELECT regexp_matches('asdf', '.*SD.*', 'c')
+SELECT regexp_matches(c0, '.*SD.*', 'c') from t0;
 ----
 0
 
@@ -138,13 +147,13 @@ world', '.*', 'n')
 
 # whitespace is ignored
 query T
-SELECT regexp_matches('asdf', '.*SD.*', ' i 	')
+SELECT regexp_matches(c0, '.*SD.*', ' i 	') from t0;
 ----
 1
 
 # NULL in options is an error
 statement error
-SELECT regexp_matches('asdf', '.*SD.*', NULL)
+SELECT regexp_matches(c0, '.*SD.*', NULL) from t0;
 ----
 must not be NULL
 
@@ -172,11 +181,11 @@ SELECT regexp_matches(v, 'h.*', v) FROM test ORDER BY v
 
 # throw on invalid options
 statement error
-SELECT regexp_matches('asdf', '.*SD.*', 'q')
+SELECT regexp_matches(c0, '.*SD.*', 'q') from t0;
 
 # can only use "g" with regexp replace
 statement error
-SELECT regexp_matches('asdf', '.*SD.*', 'g')
+SELECT regexp_matches(c0, '.*SD.*', 'g') from t0;
 
 # error in non-constant regex
 statement ok


### PR DESCRIPTION
This PR fixes #9870 

We were calling StringValue::Get before checking if the value is NULL, causing it to throw an InternalException.
I've added a test that would trigger the error on current `main`