### PR TITLE
Fix #9863 - avoid moving constants for DATE - DATE subtractions

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -608,7 +608,9 @@ FilterResult FilterCombiner::AddBoundComparisonFilter(Expression &expr) {
 		// get the current bucket of constant values
 		D_ASSERT(constant_values.find(equivalence_set) != constant_values.end());
 		auto &info_list = constant_values.find(equivalence_set)->second;
-		D_ASSERT(node.return_type == info.constant.type());
+		if (node.return_type != info.constant.type()) {
+			return FilterResult::UNSUPPORTED;
+		}
 		// check the existing constant comparisons to see if we can do any pruning
 		auto ret = AddConstantComparison(info_list, info);
 

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -21,8 +21,12 @@ MoveConstantsRule::MoveConstantsRule(ExpressionRewriter &rewriter) : Rule(rewrit
 	arithmetic->function = make_uniq<ManyFunctionMatcher>(unordered_set<string> {"+", "-", "*"});
 	// we match only on integral numeric types
 	arithmetic->type = make_uniq<IntegerTypeMatcher>();
-	arithmetic->matchers.push_back(make_uniq<ConstantExpressionMatcher>());
-	arithmetic->matchers.push_back(make_uniq<ExpressionMatcher>());
+	auto child_constant_matcher = make_uniq<ConstantExpressionMatcher>();
+	auto child_expression_matcher = make_uniq<ExpressionMatcher>();
+	child_constant_matcher->type = make_uniq<IntegerTypeMatcher>();
+	child_expression_matcher->type = make_uniq<IntegerTypeMatcher>();
+	arithmetic->matchers.push_back(std::move(child_constant_matcher));
+	arithmetic->matchers.push_back(std::move(child_expression_matcher));
 	arithmetic->policy = SetMatcher::Policy::SOME;
 	op->matchers.push_back(std::move(arithmetic));
 	root = std::move(op);
@@ -34,9 +38,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 	auto &outer_constant = bindings[1].get().Cast<BoundConstantExpression>();
 	auto &arithmetic = bindings[2].get().Cast<BoundFunctionExpression>();
 	auto &inner_constant = bindings[3].get().Cast<BoundConstantExpression>();
-	if (!TypeIsIntegral(arithmetic.return_type.InternalType())) {
-		return nullptr;
-	}
+	D_ASSERT(arithmetic.return_type.IsIntegral());
+	D_ASSERT(arithmetic.children[0]->return_type.IsIntegral());
 	if (inner_constant.value.IsNull() || outer_constant.value.IsNull()) {
 		return make_uniq<BoundConstantExpression>(Value(comparison.return_type));
 	}

--- a/test/sql/optimizer/expression/test_date_subtract_filter.test
+++ b/test/sql/optimizer/expression/test_date_subtract_filter.test
@@ -1,0 +1,20 @@
+# name: test/sql/optimizer/expression/test_date_subtract_filter.test
+# description: Test queries involving Common SubExpressions
+# group: [expression]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE dates(lo_commitdate DATE);
+
+statement ok
+INSERT INTO dates VALUES (DATE '1992-02-10');
+
+query I
+SELECT CAST('2020-02-20' AS date) - CAST(min("ta_1"."lo_commitdate") AS date) AS "ca_1"
+FROM dates AS "ta_1"
+HAVING CAST('2020-02-20' AS date) - CAST(min("ta_1"."lo_commitdate") AS date) > 4
+ORDER BY "ca_1" ASC;
+----
+10237

--- a/test/sql/optimizer/expression/test_date_subtract_filter.test
+++ b/test/sql/optimizer/expression/test_date_subtract_filter.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/expression/test_date_subtract_filter.test
-# description: Test queries involving Common SubExpressions
+# description: Issue #9863 - query involving a subtraction between dates and a comparison
 # group: [expression]
 
 statement ok


### PR DESCRIPTION
Fixes #9863 

The issue here is that the `MoveConstants` optimizer assumes that an arithmetic operation returns the same type as the type of its inputs (i.e. `INT32 - INT32 = INT32`). This is true for (integer) numbers but is not correct for dates - `DATE - DATE` returns `BIGINT` (i.e. `INT32 - INT32 = INT64`). This broken assumption then causes an invalid plan to be generated that leads to a comparison between an `INT32` and an `INT64`, which causes strange behavior.