### PR TITLE
add FROM to `InitialKeywords` vector in autocomplete extension

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -82,7 +82,7 @@ static vector<string> InitialKeywords() {
 	return vector<string> {"SELECT",     "INSERT",   "DELETE",  "UPDATE",  "CREATE",   "DROP",      "COPY",
 	                       "ALTER",      "WITH",     "EXPORT",  "BEGIN",   "VACUUM",   "PREPARE",   "EXECUTE",
 	                       "DEALLOCATE", "CALL",     "ANALYZE", "EXPLAIN", "DESCRIBE", "SUMMARIZE", "LOAD",
-	                       "CHECKPOINT", "ROLLBACK", "COMMIT",  "CALL"};
+	                       "CHECKPOINT", "ROLLBACK", "COMMIT",  "CALL",    "FROM"};
 }
 
 static vector<AutoCompleteCandidate> SuggestKeyword(ClientContext &context) {
@@ -90,7 +90,7 @@ static vector<AutoCompleteCandidate> SuggestKeyword(ClientContext &context) {
 	vector<AutoCompleteCandidate> result;
 	for (auto &kw : keywords) {
 		auto score = 0;
-		if (kw == "SELECT" || kw == "DELETE" || kw == "INSERT" || kw == "UPDATE") {
+		if (kw == "FROM" || kw == "SELECT" || kw == "DELETE" || kw == "INSERT" || kw == "UPDATE") {
 			score = 1;
 		}
 		result.emplace_back(kw + " ", score);

--- a/tools/shell/tests/test_autocomplete.py
+++ b/tools/shell/tests/test_autocomplete.py
@@ -17,6 +17,14 @@ def test_autocomplete_select(shell, autocomplete_extension):
     result = test.run()
     result.check_stdout('SELECT')
 
+def test_autocomplete_first_from(shell, autocomplete_extension):
+    test = (
+        ShellTest(shell)
+        .statement("CALL sql_auto_complete('FRO')")
+    )
+    result = test.run()
+    result.check_stdout('FROM')
+
 def test_autocomplete_column(shell, autocomplete_extension):
     test = (
         ShellTest(shell)


### PR DESCRIPTION
This is a small patch to the autocomplete library, adding `FROM` to the list of expected initial keywords. In other words, if I write `FROM sql_auto_complete('FRO')` I should expect to get back `FROM`.

Adds a test case for this in `tools/shell/tests/test_autocomplete.py`.

I haven't made a patch to this part of duckdb before so please let me know if I've made a mistake!