### PR TITLE
Mark BufferPool getters const

### DIFF
--- a/src/include/duckdb/storage/buffer/buffer_pool.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_pool.hpp
@@ -42,9 +42,9 @@ public:
 
 	void IncreaseUsedMemory(idx_t size);
 
-	idx_t GetUsedMemory();
+	idx_t GetUsedMemory() const;
 
-	idx_t GetMaxMemory();
+	idx_t GetMaxMemory() const;
 
 protected:
 	//! Evict blocks until the currently used memory + extra_memory fit, returns false if this was not possible

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -54,10 +54,10 @@ void BufferPool::IncreaseUsedMemory(idx_t size) {
 	current_memory += size;
 }
 
-idx_t BufferPool::GetUsedMemory() {
+idx_t BufferPool::GetUsedMemory() const {
 	return current_memory;
 }
-idx_t BufferPool::GetMaxMemory() {
+idx_t BufferPool::GetMaxMemory() const {
 	return maximum_memory;
 }
 


### PR DESCRIPTION
Minor tweak - just mark the two `BufferPool` getters `const`.