### PR TITLE
make BufferPool members protected

### DIFF
--- a/src/include/duckdb/storage/buffer/buffer_pool.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_pool.hpp
@@ -64,7 +64,7 @@ protected:
 	void PurgeQueue();
 	void AddToEvictionQueue(shared_ptr<BlockHandle> &handle);
 
-private:
+protected:
 	//! The lock for changing the memory limit
 	mutex limit_lock;
 	//! The current amount of memory that is occupied by the buffer manager (in bytes)


### PR DESCRIPTION
We recently made it possible to customize the implementation of BufferPool, but neglected to make these members protected. This fixes that.