### PR TITLE
Issue #9869: Strptime Week Start  

### DIFF
--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -770,6 +770,7 @@ bool StrpTimeFormat::Parse(string_t str, ParseResult &result) const {
 	uint64_t weekno = 0;
 	uint64_t weekday = 0;
 	uint64_t yearday = 0;
+	bool has_weekday = false;
 
 	for (idx_t i = 0;; i++) {
 		D_ASSERT(i < literals.size());
@@ -947,6 +948,7 @@ bool StrpTimeFormat::Parse(string_t str, ParseResult &result) const {
 					error_position = start_pos;
 					return false;
 				}
+				has_weekday = true;
 				weekday = number;
 				break;
 			case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
@@ -1110,7 +1112,9 @@ bool StrpTimeFormat::Parse(string_t str, ParseResult &result) const {
 	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
 	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST: {
 		// Adjust weekday to be 0-based for the week type
-		weekday = (weekday + 7 - int(offset_specifier == StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST)) % 7;
+		if (has_weekday) {
+			weekday = (weekday + 7 - int(offset_specifier == StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST)) % 7;
+		}
 		// Get the start of week 1, move back 7 days and then weekno * 7 + weekday gives the date
 		const auto jan1 = Date::FromDate(result_data[0], 1, 1);
 		auto yeardate = Date::GetMondayOfCurrentWeek(jan1);

--- a/test/sql/function/timestamp/test_strptime.test
+++ b/test/sql/function/timestamp/test_strptime.test
@@ -72,11 +72,11 @@ SELECT strptime('jun', '%b')
 ----
 1900-06-01 00:00:00
 
-# First Sunday of Monday weeks is Jan 7
+# First Monday of Monday weeks is Jan 1
 query I
 SELECT strptime('1', '%W')
 ----
-1900-01-07 00:00:00
+1900-01-01 00:00:00
 
 # First Sunday of Sunday weeks is Jan 7
 query I
@@ -90,9 +90,9 @@ SELECT strptime('30', '%U'), strftime('1900-07-29'::DATE, '%U')
 1900-07-29 00:00:00	30
 
 query II
-SELECT strptime('30', '%W'), strftime('1900-07-29'::DATE, '%W')
+SELECT strptime('30', '%W'), strftime('1900-07-23'::DATE, '%W')
 ----
-1900-07-29 00:00:00	30
+1900-07-23 00:00:00	30
 
 # Ignored
 query I

--- a/test/sql/function/timestamp/test_try_strptime.test
+++ b/test/sql/function/timestamp/test_try_strptime.test
@@ -72,11 +72,11 @@ SELECT try_strptime('jun', '%b')
 ----
 1900-06-01 00:00:00
 
-# First Sunday of Monday weeks is Jan 7
+# First Monday of Monday weeks is Jan 7
 query I
 SELECT try_strptime('1', '%W')
 ----
-1900-01-07 00:00:00
+1900-01-01 00:00:00
 
 # First Sunday of Sunday weeks is Jan 7
 query I
@@ -90,9 +90,9 @@ SELECT try_strptime('30', '%U'), strftime('1900-07-29'::DATE, '%U')
 1900-07-29 00:00:00	30
 
 query II
-SELECT try_strptime('30', '%W'), strftime('1900-07-29'::DATE, '%W')
+SELECT try_strptime('30', '%W'), strftime('1900-07-23'::DATE, '%W')
 ----
-1900-07-29 00:00:00	30
+1900-07-23 00:00:00	30
 
 # Ignored
 query I


### PR DESCRIPTION
If no weekday is specified for %W, use Monday, not Sunday as the default. 
This is less confusing, and since Python doesn't support it, we get to make the rules.  

fixes: #9869 
fixes: duckdblabs/duckdb-internal#838