### PR TITLE
docs(capi): add tests for prepared statement streaming

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1178,7 +1178,8 @@ DUCKDB_API duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepar
                                                 duckdb_result *out_result);
 
 /*!
-Executes the prepared statement with the given bound parameters, and returns a streaming query result.
+Executes the prepared statement with the given bound parameters, and returns an optionally-streaming query result.
+To determine if the resulting query was in fact streamed, use `duckdb_result_is_streaming`
 
 This method can be called multiple times for each prepared statement, and the parameters can be modified
 between calls to this function.

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -370,3 +370,61 @@ TEST_CASE("Test prepared statements with named parameters in C API", "[capi]") {
 
 	duckdb_destroy_prepare(&stmt);
 }
+
+TEST_CASE("Prepared streaming result", "[capi]") {
+	CAPITester tester;
+
+	// open the database in in-memory mode
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	SECTION("non streaming result") {
+		REQUIRE(tester.Query("CREATE TABLE t2 (i INTEGER, j INTEGER);"));
+
+		duckdb_prepared_statement stmt;
+		REQUIRE(duckdb_prepare(tester.connection,
+		                       "INSERT INTO t2  SELECT 2 AS i, 3 AS j  RETURNING *, i * j AS i_times_j",
+		                       &stmt) == DuckDBSuccess);
+		duckdb_result res;
+		REQUIRE(duckdb_execute_prepared_streaming(stmt, &res) == DuckDBSuccess);
+		REQUIRE(!duckdb_result_is_streaming(res));
+		duckdb_destroy_result(&res);
+		duckdb_destroy_prepare(&stmt);
+	}
+
+	SECTION("streaming result") {
+		duckdb_prepared_statement stmt;
+		REQUIRE(duckdb_prepare(tester.connection, "FROM RANGE(0, 10)", &stmt) == DuckDBSuccess);
+
+		duckdb_result res;
+		REQUIRE(duckdb_execute_prepared_streaming(stmt, &res) == DuckDBSuccess);
+		REQUIRE(duckdb_result_is_streaming(res));
+
+		duckdb_data_chunk chunk;
+		chunk = duckdb_stream_fetch_chunk(res);
+		REQUIRE(duckdb_data_chunk_get_size(chunk) == 10);
+
+		auto vec = duckdb_data_chunk_get_vector(chunk, 0);
+		auto column_type = duckdb_vector_get_column_type(vec);
+		REQUIRE(duckdb_get_type_id(column_type) == DUCKDB_TYPE_BIGINT);
+		duckdb_destroy_logical_type(&column_type);
+
+		auto data = (int64_t *)duckdb_vector_get_data(vec);
+		REQUIRE(data[0] == 0);
+		REQUIRE(data[1] == 1);
+		REQUIRE(data[2] == 2);
+		REQUIRE(data[3] == 3);
+		REQUIRE(data[4] == 4);
+		REQUIRE(data[5] == 5);
+		REQUIRE(data[6] == 6);
+		REQUIRE(data[7] == 7);
+		REQUIRE(data[8] == 8);
+		REQUIRE(data[9] == 9);
+
+		duckdb_destroy_data_chunk(&chunk);
+
+		REQUIRE(duckdb_stream_fetch_chunk(res) == nullptr);
+
+		duckdb_destroy_result(&res);
+		duckdb_destroy_prepare(&stmt);
+	}
+}

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -453,7 +453,7 @@ TEST_CASE("Prepared streaming result", "[capi]") {
 			duckdb_destroy_logical_type(&type);
 
 			auto data = (int32_t *)duckdb_vector_get_data(vec);
-			REQUIRE(data[0] == i + 1);
+			REQUIRE(data[0] == (int32_t)(i + 1));
 
 			REQUIRE(duckdb_stream_fetch_chunk(res) == nullptr);
 


### PR DESCRIPTION
Effectively resolves #9878 and https://github.com/duckdb/duckdb/issues/9879