### PR TITLE
Add TableCatalogEntry to bind info

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -83,5 +83,6 @@ if (NOT WIN32)
             LOAD_TESTS DONT_LINK
             GIT_URL https://github.com/duckdb/substrait
             GIT_TAG 5d621b1d7d16fe86f8b1930870c8e6bf05bcb92a
+            APPLY_PATCHES
             )
 endif()

--- a/.github/patches/extensions/substrait/get_bind_info.patch
+++ b/.github/patches/extensions/substrait/get_bind_info.patch
@@ -1,0 +1,18 @@
+diff --git a/src/to_substrait.cpp b/src/to_substrait.cpp
+index 7ca777e..bac1f35 100644
+--- a/src/to_substrait.cpp
++++ b/src/to_substrait.cpp
+@@ -1058,11 +1058,11 @@ substrait::Rel *DuckDBToSubstrait::TransformGet(LogicalOperator &dop) {
+ 	substrait::Rel *rel = get_rel;
+ 	auto &dget = (LogicalGet &)dop;
+ 
+-	if (!dget.function.get_batch_info) {
++	if (!dget.function.get_bind_info) {
+ 		throw NotImplementedException("This Scanner Type can't be used in substrait because a get batch info "
+ 		                              "is not yet implemented");
+ 	}
+-	auto bind_info = dget.function.get_batch_info(dget.bind_data.get());
++	auto bind_info = dget.function.get_bind_info(dget.bind_data.get());
+ 	auto sget = get_rel->mutable_read();
+ 
+ 	if (!dget.table_filters.filters.empty()) {

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -149,7 +149,7 @@ struct ParquetWriteLocalState : public LocalFunctionData {
 	ColumnDataAppendState append_state;
 };
 
-BindInfo ParquetGetBatchInfo(const FunctionData *bind_data) {
+BindInfo ParquetGetBindInfo(const optional_ptr<FunctionData> bind_data) {
 	auto bind_info = BindInfo(ScanType::PARQUET);
 	auto &parquet_bind = bind_data->Cast<ParquetReadBindData>();
 	vector<Value> file_path;
@@ -317,7 +317,7 @@ public:
 		table_function.get_batch_index = ParquetScanGetBatchIndex;
 		table_function.serialize = ParquetScanSerialize;
 		table_function.deserialize = ParquetScanDeserialize;
-		table_function.get_batch_info = ParquetGetBatchInfo;
+		table_function.get_bind_info = ParquetGetBindInfo;
 		table_function.projection_pushdown = true;
 		table_function.filter_pushdown = true;
 		table_function.filter_prune = true;

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -18,7 +18,7 @@ TableFunction::TableFunction(string name, vector<LogicalType> arguments, table_f
       init_global(init_global), init_local(init_local), function(function), in_out_function(nullptr),
       in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr), cardinality(nullptr),
       pushdown_complex_filter(nullptr), to_string(nullptr), table_scan_progress(nullptr), get_batch_index(nullptr),
-      get_batch_info(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
+      get_bind_info(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
       filter_pushdown(false), filter_prune(false) {
 }
 
@@ -31,7 +31,7 @@ TableFunction::TableFunction()
     : SimpleNamedParameterFunction("", {}), bind(nullptr), bind_replace(nullptr), init_global(nullptr),
       init_local(nullptr), function(nullptr), in_out_function(nullptr), statistics(nullptr), dependency(nullptr),
       cardinality(nullptr), pushdown_complex_filter(nullptr), to_string(nullptr), table_scan_progress(nullptr),
-      get_batch_index(nullptr), get_batch_info(nullptr), serialize(nullptr), deserialize(nullptr),
+      get_batch_index(nullptr), get_bind_info(nullptr), serialize(nullptr), deserialize(nullptr),
       projection_pushdown(false), filter_pushdown(false), filter_prune(false) {
 }
 

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -42,8 +42,6 @@ struct TableScanFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 	static TableFunction GetFunction();
 	static TableFunction GetIndexScanFunction();
-	static optional_ptr<TableCatalogEntry> GetTableEntry(const TableFunction &function,
-	                                                     const optional_ptr<FunctionData> bind_data);
 };
 
 } // namespace duckdb

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -23,7 +23,10 @@ LogicalGet::LogicalGet(idx_t table_index, TableFunction function, unique_ptr<Fun
 }
 
 optional_ptr<TableCatalogEntry> LogicalGet::GetTable() const {
-	return TableScanFunction::GetTableEntry(function, bind_data.get());
+	if (!function.get_bind_info) {
+		return nullptr;
+	}
+	return function.get_bind_info(bind_data.get()).table;
 }
 
 string LogicalGet::ParamsToString() const {


### PR DESCRIPTION
This prevents a dependency where `TableScanFunction::GetTableEntry` only works for DuckDB tables, limiting certain optimizations for non-DuckDB tables.