### PR TITLE
Various CI fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,12 @@ if(NOT MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG
       "${CMAKE_CXX_FLAGS_DEBUG} -Wextra -Wno-unused-parameter -Wno-redundant-move"
   )
-  if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6)
+  if(CMAKE_COMPILER_IS_GNUCC)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6)
+      set(CMAKE_CXX_FLAGS_DEBUG
+          "${CMAKE_CXX_FLAGS_DEBUG} -Wimplicit-fallthrough")
+    endif()
+  else()
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wimplicit-fallthrough")
   endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,8 +8,11 @@ add_extension_definitions()
 
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG
-      "${CMAKE_CXX_FLAGS_DEBUG} -Wextra -Wno-unused-parameter -Wno-redundant-move -Wimplicit-fallthrough"
+      "${CMAKE_CXX_FLAGS_DEBUG} -Wextra -Wno-unused-parameter -Wno-redundant-move"
   )
+  if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wimplicit-fallthrough")
+  endif()
 endif()
 set(EXIT_TIME_DESTRUCTORS_WARNING FALSE)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -401,7 +401,7 @@ TEST_CASE("Prepared streaming result", "[capi]") {
 
 		duckdb_data_chunk chunk;
 		idx_t index = 0;
-		while(true) {
+		while (true) {
 			chunk = duckdb_stream_fetch_chunk(res);
 			if (!chunk) {
 				break;
@@ -415,7 +415,7 @@ TEST_CASE("Prepared streaming result", "[capi]") {
 			duckdb_destroy_logical_type(&column_type);
 
 			auto data = reinterpret_cast<int64_t *>(duckdb_vector_get_data(vec));
-			for(idx_t i = 0; i < chunk_size; i++) {
+			for (idx_t i = 0; i < chunk_size; i++) {
 				REQUIRE(data[i] == index + i);
 			}
 			index += chunk_size;

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -400,27 +400,27 @@ TEST_CASE("Prepared streaming result", "[capi]") {
 		REQUIRE(duckdb_result_is_streaming(res));
 
 		duckdb_data_chunk chunk;
-		chunk = duckdb_stream_fetch_chunk(res);
-		REQUIRE(duckdb_data_chunk_get_size(chunk) == 10);
+		idx_t index = 0;
+		while(true) {
+			chunk = duckdb_stream_fetch_chunk(res);
+			if (!chunk) {
+				break;
+			}
+			auto chunk_size = duckdb_data_chunk_get_size(chunk);
+			REQUIRE(chunk_size > 0);
 
-		auto vec = duckdb_data_chunk_get_vector(chunk, 0);
-		auto column_type = duckdb_vector_get_column_type(vec);
-		REQUIRE(duckdb_get_type_id(column_type) == DUCKDB_TYPE_BIGINT);
-		duckdb_destroy_logical_type(&column_type);
+			auto vec = duckdb_data_chunk_get_vector(chunk, 0);
+			auto column_type = duckdb_vector_get_column_type(vec);
+			REQUIRE(duckdb_get_type_id(column_type) == DUCKDB_TYPE_BIGINT);
+			duckdb_destroy_logical_type(&column_type);
 
-		auto data = (int64_t *)duckdb_vector_get_data(vec);
-		REQUIRE(data[0] == 0);
-		REQUIRE(data[1] == 1);
-		REQUIRE(data[2] == 2);
-		REQUIRE(data[3] == 3);
-		REQUIRE(data[4] == 4);
-		REQUIRE(data[5] == 5);
-		REQUIRE(data[6] == 6);
-		REQUIRE(data[7] == 7);
-		REQUIRE(data[8] == 8);
-		REQUIRE(data[9] == 9);
-
-		duckdb_destroy_data_chunk(&chunk);
+			auto data = reinterpret_cast<int64_t *>(duckdb_vector_get_data(vec));
+			for(idx_t i = 0; i < chunk_size; i++) {
+				REQUIRE(data[i] == index + i);
+			}
+			index += chunk_size;
+			duckdb_destroy_data_chunk(&chunk);
+		}
 
 		REQUIRE(duckdb_stream_fetch_chunk(res) == nullptr);
 

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -416,7 +416,7 @@ TEST_CASE("Prepared streaming result", "[capi]") {
 
 			auto data = reinterpret_cast<int64_t *>(duckdb_vector_get_data(vec));
 			for (idx_t i = 0; i < chunk_size; i++) {
-				REQUIRE(data[i] == index + i);
+				REQUIRE(data[i] == int64_t(index + i));
 			}
 			index += chunk_size;
 			duckdb_destroy_data_chunk(&chunk);

--- a/test/sql/attach/attach_checkpoint_deadlock.test_slow
+++ b/test/sql/attach/attach_checkpoint_deadlock.test_slow
@@ -9,7 +9,7 @@ require skip_reload
 concurrentforeach dbname foo bar i1 i2 i3 i4 i5 i6 i7 i8 i9
 
 statement ok
-attach '__TEST_DIR__/${dbname}.duckdb' as ${dbname}
+attach '__TEST_DIR__/checkpoint_${dbname}.duckdb' as ${dbname}
 
 statement ok
 create table ${dbname}.${dbname}(foo bigint)

--- a/test/sql/attach/attach_force_checkpoint_deadlock.test_slow
+++ b/test/sql/attach/attach_force_checkpoint_deadlock.test_slow
@@ -9,7 +9,7 @@ require skip_reload
 concurrentforeach dbname foo bar i1 i2 i3 i4 i5 i6 i7 i8 i9
 
 statement ok
-attach '__TEST_DIR__/${dbname}.duckdb' as ${dbname}
+attach '__TEST_DIR__/force_checkpoint_${dbname}.duckdb' as ${dbname}
 
 statement ok
 create table ${dbname}.${dbname}(foo bigint)


### PR DESCRIPTION
* Avoid re-using the same database between different checkpoint tests
* Fix streaming C API test for vsize=2
* Fix compilation on old GCC versions by disabling unsupported warning