### PR TITLE
[Test] Make `test_progress_bar.cpp` output more verbose

### DIFF
--- a/test/api/test_progress_bar.cpp
+++ b/test/api/test_progress_bar.cpp
@@ -80,9 +80,9 @@ public:
 		check_thread.join();
 		if (error.IsSet()) {
 			error.ThrowError();
+			// This should never be reached, ThrowError() should contain a failing REQUIRE statement
+			REQUIRE(false);
 		}
-		// This should never be reached, ThrowError() should contain a failing REQUIRE statement
-		REQUIRE(false);
 	}
 };
 


### PR DESCRIPTION
Instead of just setting `correct = false` when an error occurs, save a callback so we can get a proper failing REQUIRE statement which gives us a lot more information about the failure