### PR TITLE
Refactor and fix ART concurrency tests to avoid spurious CI failures

### DIFF
--- a/test/sql/parallelism/interquery/test_concurrent_index.cpp
+++ b/test/sql/parallelism/interquery/test_concurrent_index.cpp
@@ -10,55 +10,50 @@
 using namespace duckdb;
 using namespace std;
 
+//! Synchronize threads
 atomic<bool> concurrent_index_finished;
 
 #define CONCURRENT_INDEX_THREAD_COUNT 10
 #define CONCURRENT_INDEX_INSERT_COUNT 2000
 
-static void ReadFromIntegers(DuckDB *db, bool *correct, idx_t thread_idx) {
+static void CreateIntegerTable(Connection *con, int64_t count) {
+	REQUIRE_NO_FAIL(con->Query("CREATE TABLE integers AS SELECT range AS i FROM range ($1)", count));
+}
 
-	Connection con(*db);
-	correct[thread_idx] = true;
-
-	while (!concurrent_index_finished) {
-		auto result = con.Query("SELECT i FROM integers WHERE i = " + to_string(thread_idx * 10000));
-		if (!CHECK_COLUMN(result, 0, {Value::INTEGER(thread_idx * 10000)})) {
-			correct[thread_idx] = false;
-		}
+static void CheckConstraintViolation(const string &result_str) {
+	auto constraint_violation = result_str.find("constraint violation") != string::npos ||
+	                            result_str.find("constraint violated") != string::npos ||
+	                            result_str.find("Conflict on tuple deletion") != string::npos;
+	if (!constraint_violation) {
+		FAIL(result_str);
 	}
 }
 
-TEST_CASE("Concurrent reads during index creation", "[interquery][.]") {
+static void ReadFromIntegers(DuckDB *db, idx_t thread_idx) {
 
-	duckdb::unique_ptr<QueryResult> result;
+	Connection con(*db);
+	while (!concurrent_index_finished) {
+
+		auto expected_value = to_string(thread_idx * 10000);
+		auto result = con.Query("SELECT i FROM integers WHERE i = " + expected_value);
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(CHECK_COLUMN(result, 0, {Value::INTEGER(thread_idx * 10000)}));
+	}
+}
+
+TEST_CASE("Concurrent reads during index creation", "[index][.]") {
+
 	DuckDB db(nullptr);
 	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
 
-	// enable detailed profiling
-	con.Query("PRAGMA enable_profiling");
-	auto detailed_profiling_output = TestCreatePath("detailed_profiling_output");
-	con.Query("PRAGMA profiling_output='" + detailed_profiling_output + "'");
-	con.Query("PRAGMA profiling_mode = detailed");
-
-	// create a table to append to
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
-
-	// append many entries
-	Appender appender(con, "integers");
-	for (idx_t i = 0; i < 1000000; i++) {
-		appender.BeginRow();
-		appender.Append<int32_t>(i);
-		appender.EndRow();
-	}
-	appender.Close();
-
+	CreateIntegerTable(&con, 1000000);
 	concurrent_index_finished = false;
 
 	// launch many reading threads
-	bool correct[CONCURRENT_INDEX_THREAD_COUNT];
 	thread threads[CONCURRENT_INDEX_THREAD_COUNT];
 	for (idx_t i = 0; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
-		threads[i] = thread(ReadFromIntegers, &db, correct, i);
+		threads[i] = thread(ReadFromIntegers, &db, i);
 	}
 
 	// create the index
@@ -67,49 +62,29 @@ TEST_CASE("Concurrent reads during index creation", "[interquery][.]") {
 
 	for (idx_t i = 0; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
 		threads[i].join();
-		REQUIRE(correct[i]);
 	}
 
 	// test that we can probe the index correctly
-	result = con.Query("SELECT COUNT(*) FROM integers WHERE i=500000");
+	auto result = con.Query("SELECT COUNT(*) FROM integers WHERE i=500000");
+	REQUIRE_NO_FAIL(*result);
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 }
 
 static void AppendToIntegers(DuckDB *db) {
 
 	Connection con(*db);
-
 	for (idx_t i = 0; i < CONCURRENT_INDEX_INSERT_COUNT; i++) {
-		auto result = con.Query("INSERT INTO integers VALUES (1)");
-		if (result->HasError()) {
-			FAIL();
-		}
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1)"));
 	}
 }
 
 TEST_CASE("Concurrent writes during index creation", "[index][.]") {
 
-	duckdb::unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
 
-	// enable detailed profiling
-	con.Query("PRAGMA enable_profiling");
-	auto detailed_profiling_output = TestCreatePath("detailed_profiling_output");
-	con.Query("PRAGMA profiling_output='" + detailed_profiling_output + "'");
-	con.Query("PRAGMA profiling_mode = detailed");
-
-	// create a table to append to
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
-
-	// append many entries
-	Appender appender(con, "integers");
-	for (idx_t i = 0; i < 1000000; i++) {
-		appender.BeginRow();
-		appender.Append<int32_t>(i);
-		appender.EndRow();
-	}
-	appender.Close();
+	CreateIntegerTable(&con, 1000000);
 
 	// launch many concurrently writing threads
 	thread threads[CONCURRENT_INDEX_THREAD_COUNT];
@@ -126,50 +101,50 @@ TEST_CASE("Concurrent writes during index creation", "[index][.]") {
 
 	// first scan the base table to verify the count, we avoid using a filter here to prevent the
 	// optimizer from using an index scan
-	result = con.Query("SELECT i, COUNT(*) FROM integers GROUP BY i ORDER BY i LIMIT 1 OFFSET 1");
+	auto result = con.Query("SELECT i, COUNT(*) FROM integers GROUP BY i ORDER BY i LIMIT 1 OFFSET 1");
+	REQUIRE_NO_FAIL(*result);
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 	REQUIRE(CHECK_COLUMN(result, 1, {1 + CONCURRENT_INDEX_THREAD_COUNT * CONCURRENT_INDEX_INSERT_COUNT}));
 
-	// test that we can probe the index correctly too
-	result = con.Query("SELECT COUNT(*) FROM integers WHERE i=1");
+	// test that we can probe the index correctly
+	result = con.Query("SELECT COUNT(*) FROM integers WHERE i = 1");
+	REQUIRE_NO_FAIL(*result);
 	REQUIRE(CHECK_COLUMN(result, 0, {1 + CONCURRENT_INDEX_THREAD_COUNT * CONCURRENT_INDEX_INSERT_COUNT}));
 }
 
-static void AppendIntoPK(DuckDB *db) {
+static void AppendToPK(DuckDB *db) {
 
 	Connection con(*db);
 	for (idx_t i = 0; i < 1000; i++) {
-		con.Query("INSERT INTO integers VALUES ($1)", i);
+		auto result = con.Query("INSERT INTO integers VALUES ($1)", i);
+		if (result->HasError()) {
+			CheckConstraintViolation(result->ToString());
+		}
 	}
 }
 
-TEST_CASE("Concurrent inserts into PRIMARY KEY", "[interquery][.]") {
+TEST_CASE("Concurrent inserts to PRIMARY KEY", "[index][.]") {
 
-	duckdb::unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);
-
-	// enable detailed profiling
-	con.Query("PRAGMA enable_profiling");
-	auto detailed_profiling_output = TestCreatePath("detailed_profiling_output");
-	con.Query("PRAGMA profiling_output='" + detailed_profiling_output + "'");
-	con.Query("PRAGMA profiling_mode = detailed");
+	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
 
 	// create a table to append to
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER PRIMARY KEY)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers (i INTEGER PRIMARY KEY)"));
 
 	// launch many concurrently writing threads
-	// each thread writes the numbers 1...1000
+	// each thread writes the numbers 1...1000, possibly causing a constraint violation
 	thread threads[CONCURRENT_INDEX_THREAD_COUNT];
 	for (idx_t i = 0; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
-		threads[i] = thread(AppendIntoPK, &db);
+		threads[i] = thread(AppendToPK, &db);
 	}
 	for (idx_t i = 0; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
 		threads[i].join();
 	}
 
-	// test that the counts are correct
-	result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers");
+	// test the result
+	auto result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers");
+	REQUIRE_NO_FAIL(*result);
 	REQUIRE(CHECK_COLUMN(result, 0, {1000}));
 	REQUIRE(CHECK_COLUMN(result, 1, {1000}));
 }
@@ -178,27 +153,22 @@ static void UpdatePK(DuckDB *db) {
 
 	Connection con(*db);
 	for (idx_t i = 0; i < 1000; i++) {
-		con.Query("UPDATE integers SET i=1000+(i % 100) WHERE i=$1", i);
+		auto result = con.Query("UPDATE integers SET i = 1000 + (i % 100) WHERE i = $1", i);
+		if (result->HasError()) {
+			CheckConstraintViolation(result->ToString());
+		}
 	}
 }
 
-TEST_CASE("Concurrent updates to PRIMARY KEY", "[interquery][.]") {
+TEST_CASE("Concurrent updates to PRIMARY KEY", "[index][.]") {
 
-	duckdb::unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);
-
-	// enable detailed profiling
-	con.Query("PRAGMA enable_profiling");
-	auto detailed_profiling_output = TestCreatePath("detailed_profiling_output");
-	con.Query("PRAGMA profiling_output='" + detailed_profiling_output + "'");
-	con.Query("PRAGMA profiling_mode = detailed");
+	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
 
 	// create a table and insert values [1...1000]
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER PRIMARY KEY)"));
-	for (idx_t i = 0; i < 1000; i++) {
-		REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES ($1)", i));
-	}
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers (i INTEGER PRIMARY KEY)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers SELECT range FROM range(1000)"));
 
 	// launch many concurrently updating threads
 	// each thread updates numbers by incrementing them
@@ -210,52 +180,53 @@ TEST_CASE("Concurrent updates to PRIMARY KEY", "[interquery][.]") {
 		threads[i].join();
 	}
 
-	// test that the counts are correct
-	result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers");
+	// test the result
+	auto result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers");
+	REQUIRE_NO_FAIL(*result);
 	REQUIRE(CHECK_COLUMN(result, 0, {1000}));
 	REQUIRE(CHECK_COLUMN(result, 1, {1000}));
 }
 
-static void MixInsertIntoPK(DuckDB *db, atomic<idx_t> *count) {
+static void MixAppendToPK(DuckDB *db, atomic<idx_t> *count) {
 
-	duckdb::unique_ptr<QueryResult> result;
 	Connection con(*db);
-
 	for (idx_t i = 0; i < 100; i++) {
-		result = con.Query("INSERT INTO integers VALUES ($1)", i);
+
+		auto result = con.Query("INSERT INTO integers VALUES ($1)", i);
 		if (!result->HasError()) {
 			(*count)++;
+			continue;
 		}
+
+		CheckConstraintViolation(result->ToString());
 	}
 }
 
 static void MixUpdatePK(DuckDB *db, idx_t thread_idx) {
 
-	duckdb::unique_ptr<QueryResult> result;
-	Connection con(*db);
 	std::uniform_int_distribution<> distribution(1, 100);
 	std::mt19937 gen;
 	gen.seed(thread_idx);
 
+	Connection con(*db);
 	for (idx_t i = 0; i < 100; i++) {
+
 		idx_t old_value = distribution(gen);
 		idx_t new_value = 100 + distribution(gen);
 
-		con.Query("UPDATE integers SET i =" + to_string(new_value) + " WHERE i = " + to_string(old_value));
+		auto result =
+		    con.Query("UPDATE integers SET i =" + to_string(new_value) + " WHERE i = " + to_string(old_value));
+		if (result->HasError()) {
+			CheckConstraintViolation(result->ToString());
+		}
 	}
 }
 
-TEST_CASE("Mix UPDATES and INSERTS for PRIMARY KEY table", "[interquery][.]") {
+TEST_CASE("Mix updates and inserts on PRIMARY KEY", "[index][.]") {
 
-	duckdb::unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);
-
-	// enable detailed profiling
-	con.Query("PRAGMA enable_profiling");
-	auto detailed_profiling_output = TestCreatePath("detailed_profiling_output");
-	con.Query("PRAGMA profiling_output='" + detailed_profiling_output + "'");
-	con.Query("PRAGMA profiling_mode = detailed");
+	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
 
 	atomic<idx_t> atomic_count;
 	atomic_count = 0;
@@ -263,175 +234,132 @@ TEST_CASE("Mix UPDATES and INSERTS for PRIMARY KEY table", "[interquery][.]") {
 	// create a table
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER PRIMARY KEY)"));
 
-	// launch many concurrently updating threads
-	// each thread updates numbers by incrementing them
+	// launch a mix of updating and appending threads
 	thread threads[CONCURRENT_INDEX_THREAD_COUNT];
 	for (idx_t i = 0; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
 		if (i % 2) {
 			threads[i] = thread(MixUpdatePK, &db, i);
-		} else {
-			threads[i] = thread(MixInsertIntoPK, &db, &atomic_count);
+			continue;
 		}
+		threads[i] = thread(MixAppendToPK, &db, &atomic_count);
 	}
+
 	for (idx_t i = 0; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
 		threads[i].join();
 	}
 
-	// test that the counts are correct
-	result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers");
+	// test the result
+	auto result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers");
+	REQUIRE_NO_FAIL(*result);
 	REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(atomic_count)}));
 	REQUIRE(CHECK_COLUMN(result, 1, {Value::BIGINT(atomic_count)}));
 }
 
-string AppendToPK(Connection &con, idx_t thread_idx) {
+static void TransactionalAppendToPK(DuckDB *db, idx_t thread_idx) {
 
-	duckdb::unique_ptr<QueryResult> result;
-	if (con.Query("BEGIN TRANSACTION")->HasError()) {
-		return "Failed BEGIN TRANSACTION";
-	}
+	Connection con(*db);
+	REQUIRE_NO_FAIL(con.Query("BEGIN TRANSACTION"));
 
 	// get the initial count
-	result = con.Query("SELECT COUNT(*) FROM integers WHERE i >= 0");
-	if (result->HasError()) {
-		return "Failed initial query: " + result->GetError();
-	}
+	auto result = con.Query("SELECT COUNT(*) FROM integers WHERE i >= 0");
+	REQUIRE_NO_FAIL(*result);
 
 	auto chunk = result->Fetch();
 	auto initial_count = chunk->GetValue(0, 0).GetValue<int32_t>();
 
 	for (idx_t i = 0; i < 50; i++) {
 
-		result = con.Query("INSERT INTO integers VALUES ($1)", (int32_t)(thread_idx * 1000 + i));
-		if (result->HasError()) {
-			return "Failed INSERT: " + result->GetError();
-		}
+		auto loop_result = con.Query("INSERT INTO integers VALUES ($1)", (int32_t)(thread_idx * 1000 + i));
+		REQUIRE_NO_FAIL(*result);
 
 		// check the count
-		result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers WHERE i >= 0");
-		if (!CHECK_COLUMN(result, 0, {Value::INTEGER(initial_count + i + 1)})) {
-			return "Incorrect result for CHECK_COLUMN [" + result->GetError() + "], expected " +
-			       Value::INTEGER(initial_count + i + 1).ToString() + " rows";
-		}
+		loop_result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers WHERE i >= 0");
+		REQUIRE(CHECK_COLUMN(loop_result, 0, {Value::INTEGER(initial_count + i + 1)}));
 	}
 
-	if (con.Query("COMMIT")->HasError()) {
-		return "Failed COMMIT";
-	}
-	return "";
+	REQUIRE_NO_FAIL(con.Query("COMMIT"));
 }
 
-static void TxAppendToPK(DuckDB *db, idx_t thread_idx, bool success[]) {
-
-	Connection con(*db);
-	success[thread_idx] = true;
-	string result = AppendToPK(con, thread_idx);
-
-	if (!result.empty()) {
-		fprintf(stderr, "Parallel append failed: %s\n", result.c_str());
-		success[thread_idx] = false;
-	}
-}
-
-TEST_CASE("Parallel transactional appends to indexed table", "[interquery][.]") {
+TEST_CASE("Parallel transactional appends to indexed table", "[index][.]") {
 
 	// FIXME: this test causes a data race in the statistics code
 	// FIXME: reproducible by running this test with THREADSAN=1 make reldebug
 
 #ifndef DUCKDB_THREAD_SANITIZER
-	duckdb::unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);
-
-	// enable detailed profiling
-	con.Query("PRAGMA enable_profiling");
-	auto detailed_profiling_output = TestCreatePath("detailed_profiling_output");
-	con.Query("PRAGMA profiling_output='" + detailed_profiling_output + "'");
-	con.Query("PRAGMA profiling_mode = detailed");
+	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
 
 	// create a table
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER PRIMARY KEY)"));
 
 	// launch many concurrently inserting threads
 	thread threads[CONCURRENT_INDEX_THREAD_COUNT];
-	bool success[CONCURRENT_INDEX_THREAD_COUNT];
 	for (idx_t i = 0; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
-		threads[i] = thread(TxAppendToPK, &db, i, success);
+		threads[i] = thread(TransactionalAppendToPK, &db, i);
 	}
 
 	for (idx_t i = 0; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
 		threads[i].join();
-		REQUIRE(success[i]);
 	}
 
 	// test that the counts are correct
-	result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers");
-	REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(CONCURRENT_INDEX_THREAD_COUNT * 50)}));
-	REQUIRE(CHECK_COLUMN(result, 1, {Value::BIGINT(CONCURRENT_INDEX_THREAD_COUNT * 50)}));
+	auto result = con.Query("SELECT COUNT(*), COUNT(DISTINCT i) FROM integers");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(idx_t(CONCURRENT_INDEX_THREAD_COUNT * 50))}));
+	REQUIRE(CHECK_COLUMN(result, 1, {Value::BIGINT(idx_t(CONCURRENT_INDEX_THREAD_COUNT * 50))}));
 #endif
 }
 
-static void JoinIntegers(Connection *con, bool *join_success) {
-
-	*join_success = true;
+static void JoinIntegers(Connection *con) {
 
 	for (idx_t i = 0; i < 10; i++) {
 		auto result = con->Query("SELECT count(*) FROM integers INNER JOIN integers_2 ON (integers.i = integers_2.i)");
-		if (!CHECK_COLUMN(result, 0, {Value::BIGINT(500000)})) {
-			*join_success = false;
-		}
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(500000)}));
 	}
+
+	REQUIRE_NO_FAIL(con->Query("COMMIT"));
 }
 
-TEST_CASE("Concurrent appends during joins", "[interquery][.]") {
+TEST_CASE("Concurrent appends during joins", "[index][.]") {
 
 	duckdb::unique_ptr<QueryResult> result;
 	DuckDB db(nullptr);
 	Connection con(db);
-
-	// enable detailed profiling
-	con.Query("PRAGMA enable_profiling");
-	auto detailed_profiling_output = TestCreatePath("detailed_profiling_output");
-	con.Query("PRAGMA profiling_output='" + detailed_profiling_output + "'");
-	con.Query("PRAGMA profiling_mode = detailed");
+	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
 
 	// create join tables to append to
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers_2(i INTEGER)"));
-
-	// append many entries
-	Appender appender(con, "integers");
-	for (idx_t i = 0; i < 1000000; i++) {
-		appender.BeginRow();
-		appender.Append<int32_t>(i);
-		appender.EndRow();
-	}
-	appender.Close();
-
-	Appender appender_2(con, "integers_2");
-	for (idx_t i = 0; i < 500000; i++) {
-		appender_2.BeginRow();
-		appender_2.Append<int32_t>(i);
-		appender_2.EndRow();
-	}
-	appender_2.Close();
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers AS SELECT range AS i FROM range(1000000)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers_2 AS SELECT range AS i FROM range(500000)"));
 
 	// create the index
 	REQUIRE_NO_FAIL(con.Query("CREATE INDEX i_index ON integers(i)"));
 
-	bool join_success = true;
-	Connection join_con(db);
-	join_con.Query("BEGIN TRANSACTION");
+	// we need to guarantee that this thread starts before the other threads
+	Connection join_con_1(db);
+	REQUIRE_NO_FAIL(join_con_1.Query("BEGIN TRANSACTION"));
+
+	Connection join_con_2(db);
+	REQUIRE_NO_FAIL(con.Query("SET immediate_transaction_mode=true"));
+	REQUIRE_NO_FAIL(join_con_2.Query("BEGIN TRANSACTION"));
 
 	thread threads[CONCURRENT_INDEX_THREAD_COUNT];
-	threads[0] = thread(JoinIntegers, &join_con, &join_success);
 
-	// launch many concurrently writing threads (!)
-	for (idx_t i = 1; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
+	// join the data in join_con_1, which is an uncommitted transaction started
+	// before appending any data
+	threads[0] = thread(JoinIntegers, &join_con_1);
+
+	// launch many concurrently writing threads
+	for (idx_t i = 2; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
 		threads[i] = thread(AppendToIntegers, &db);
 	}
+
+	// join the data in join_con_2, which is an uncommitted transaction started
+	// before appending any data
+	threads[1] = thread(JoinIntegers, &join_con_2);
+
 	for (idx_t i = 0; i < CONCURRENT_INDEX_THREAD_COUNT; i++) {
 		threads[i].join();
 	}
-
-	REQUIRE(join_success);
 }


### PR DESCRIPTION
The `Concurrent appends during joins` test was failing spuriously. The gist of the test is that we start a transaction `t1` with the earliest timestamp, insert values into a table, and then perform a join on that table in `t1`. `t1` is not allowed to see the newly inserted values because it started before any insertions.

In DuckDB, we lazily start transactions when calling `BEGIN TRANSACTION`. The test failed because, in some rare cases, the threads inserting data were faster than `t1`, which was joining the data. Calling `BEGIN TRANSACTION` in `t1` before spawning the writer threads was insufficient. 

To avoid incorrect testing behavior for future ART tests, I added `SET immediate_transaction_mode=true` to all of the `.cpp` tests so that we guarantee to start transactions immediately instead of lazily.

I also found other outdated code and refactored the `test_concurrent_index.cpp` file. 