### PR TITLE
Write old (empty) index_pointers to table metadata for forwards compatibility with v0.9.2

### DIFF
--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -72,7 +72,10 @@ void SingleFileTableDataWriter::FinalizeTable(TableStatistics &&global_stats, Da
 	serializer.WriteProperty(102, "total_rows", total_rows);
 
 	auto index_storage_infos = info->indexes.GetStorageInfos();
-	serializer.WriteProperty(104, "index_storage_infos", index_storage_infos);
+	// write empty block pointers for forwards compatibility
+	vector<BlockPointer> compat_block_pointers;
+	serializer.WriteProperty(103, "index_pointers", compat_block_pointers);
+	serializer.WritePropertyWithDefault(104, "index_storage_infos", index_storage_infos);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This makes sure that tables without indexes can still be read by older DuckDB versions