### PR TITLE
JDBC: DuckDBNative - Close Shared Object InputStream Properly

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
@@ -2,6 +2,7 @@ package org.duckdb;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -50,7 +51,9 @@ public class DuckDBNative {
                 System.load(
                     Paths.get("../../build/debug/tools/jdbc", lib_res_name).normalize().toAbsolutePath().toString());
             } else {
-                Files.copy(lib_res.openStream(), lib_file, StandardCopyOption.REPLACE_EXISTING);
+                try (final InputStream lib_res_input_stream = lib_res.openStream()) {
+                    Files.copy(lib_res_input_stream, lib_file, StandardCopyOption.REPLACE_EXISTING);
+                }
                 new File(lib_file.toString()).deleteOnExit();
                 System.load(lib_file.toAbsolutePath().toString());
             }


### PR DESCRIPTION
Use `try-with-resources` to prevent memory leak when copying the shared object file to the `/tmp` directory.