### PR TITLE
httpfs: fix null pointer dereference in AWSEnvironmentCredentialsProvider

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -140,7 +140,7 @@ string S3FileSystem::UrlEncode(const string &input, bool encode_slash) {
 }
 
 void AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(string key, const char *env_var_name) {
-	static char *evar;
+	char *evar;
 
 	if ((evar = std::getenv(env_var_name)) != NULL) {
 		if (StringUtil::Lower(evar) == "false") {


### PR DESCRIPTION
The unit tests of a project of mine that embeds duckdb-rs kept segfaulting randomly:

```
❯ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running unittests main.rs (target/debug/deps/amend-98556005b6a72ddb)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests lib.rs (target/debug/deps/amend_core-12cf0645e9308902)

running 6 tests
test serde_raw::tests::get_field ... ok
error: test failed, to rerun pass `-p amend_core --lib`

Caused by:
  process didn't exit successfully: `xxx/target/debug/deps/amend_core-12cf0645e9308902` (signal: 11, 
)
```

Using lldb, I found out that the problem is caused by `SetExtensionOptionValue` in `s3fs.cpp` ([this line](https://github.com/duckdb/duckdb/blob/dab818cd549bfb9ff3282f402c4f336e4fafd8d8/extension/httpfs/s3fs.cpp#L148)).

Here's a backtrace:

```
* thread #6, name = 'duckdb::tests::test_stream_items', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x0000000190787e64 libsystem_platform.dylib`_platform_strlen + 4
libsystem_platform.dylib`_platform_strlen:
->  0x190787e64 <+4>:  ldr    q0, [x1]
    0x190787e68 <+8>:  adr    x3, #-200                 ; ___lldb_unnamed_symbol282
    0x190787e6c <+12>: ldr    q2, [x3], #0x10
    0x190787e70 <+16>: and    x2, x0, #0xf
(lldb) bt 10
* thread #6, name = 'duckdb::tests::test_stream_items', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x0000000190787e64 libsystem_platform.dylib`_platform_strlen + 4
    frame #1: 0x0000000100241c48 amend_core-12cf0645e9308902`std::__1::__constexpr_strlen[abi:v160006](__str=0x0000000000000000) at cstring:114:10
    frame #2: 0x00000001002414cc amend_core-12cf0645e9308902`std::__1::char_traits<char>::length(__s=0x0000000000000000) at char_traits.h:220:12
    frame #3: 0x00000001002579c4 amend_core-12cf0645e9308902`std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::basic_string[abi:v160006]<std::nullptr_t>(this="", __s=0x0000000000000000) at string:882:17
    frame #4: 0x00000001002578ac amend_core-12cf0645e9308902`std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::basic_string[abi:v160006]<std::nullptr_t>(this="", __s=0x0000000000000000) at string:880:58
    frame #5: 0x000000010104004c amend_core-12cf0645e9308902`duckdb::AWSEnvironmentCredentialsProvider::SetExtensionOptionValue(this=0x0000600000008b30, key="s3_region", env_var_name="AWS_DEFAULT_REGION") at s3fs.cpp:148:32
    frame #6: 0x00000001010401bc amend_core-12cf0645e9308902`duckdb::AWSEnvironmentCredentialsProvider::SetAll(this=0x0000600000008b30) at s3fs.cpp:157:8
    frame #7: 0x000000010142cd6c amend_core-12cf0645e9308902`duckdb::LoadInternal(instance=0x00000001059041d8) at httpfs_extension.cpp:55:12
    frame #8: 0x000000010142c33c amend_core-12cf0645e9308902`duckdb::HttpfsExtension::Load(this=0x0000000170833870, db=0x000060000000c030) at httpfs_extension.cpp:59:2
    frame #9: 0x000000010165bb24 amend_core-12cf0645e9308902`void duckdb::DuckDB::LoadExtension<duckdb::HttpfsExtension>(this=0x000060000000c030) at database.hpp:95:13
```

Turns out that using `static char` has some weird side effect leading to random crashes. Changing the declaration from `static char` to `char` ensures that the variable is reinitialized on each function call, which fixes the issue.

(TBH, I'm no expert in C++, and I'd love to learn more about the root cause here!)
