### PR TITLE
[Arrow][UDF] Properly support `side_effects` parameter for Arrow UDFs.

### DIFF
--- a/tools/pythonpkg/scripts/cache_data.json
+++ b/tools/pythonpkg/scripts/cache_data.json
@@ -214,6 +214,7 @@
         "full_path": "numpy",
         "name": "numpy",
         "children": [
+			"numpy.core",
             "numpy.ndarray",
             "numpy.datetime64",
             "numpy.generic",
@@ -237,6 +238,20 @@
             "numpy.cdouble",
             "numpy.clongdouble"
         ]
+    },
+    "numpy.core": {
+        "type": "attribute",
+        "full_path": "numpy.core",
+        "name": "core",
+        "children": [
+            "numpy.core.multiarray"
+        ]
+    },
+    "numpy.core.multiarray": {
+        "type": "attribute",
+        "full_path": "numpy.core.multiarray",
+        "name": "multiarray",
+        "children": []
     },
     "numpy.ndarray": {
         "type": "attribute",

--- a/tools/pythonpkg/scripts/imports.py
+++ b/tools/pythonpkg/scripts/imports.py
@@ -42,6 +42,7 @@ ipywidgets.FloatProgress
 
 import numpy
 
+numpy.core.multiarray
 numpy.ndarray
 numpy.datetime64
 numpy.generic

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/numpy_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/numpy_module.hpp
@@ -13,6 +13,18 @@
 
 namespace duckdb {
 
+struct NumpyCoreCacheItem : public PythonImportCacheItem {
+
+public:
+	NumpyCoreCacheItem(optional_ptr<PythonImportCacheItem> parent)
+	    : PythonImportCacheItem("core", parent), multiarray("multiarray", this) {
+	}
+	~NumpyCoreCacheItem() override {
+	}
+
+	PythonImportCacheItem multiarray;
+};
+
 struct NumpyCacheItem : public PythonImportCacheItem {
 
 public:
@@ -20,7 +32,7 @@ public:
 
 public:
 	NumpyCacheItem()
-	    : PythonImportCacheItem("numpy"), ndarray("ndarray", this), datetime64("datetime64", this),
+	    : PythonImportCacheItem("numpy"), core(this), ndarray("ndarray", this), datetime64("datetime64", this),
 	      generic("generic", this), int64("int64", this), bool_("bool_", this), byte("byte", this),
 	      ubyte("ubyte", this), short_("short", this), ushort_("ushort", this), intc("intc", this),
 	      uintc("uintc", this), int_("int_", this), uint("uint", this), longlong("longlong", this),
@@ -31,6 +43,7 @@ public:
 	~NumpyCacheItem() override {
 	}
 
+	NumpyCoreCacheItem core;
 	PythonImportCacheItem ndarray;
 	PythonImportCacheItem datetime64;
 	PythonImportCacheItem generic;

--- a/tools/pythonpkg/tests/fast/udf/test_scalar_arrow.py
+++ b/tools/pythonpkg/tests/fast/udf/test_scalar_arrow.py
@@ -128,13 +128,13 @@ class TestPyArrowUDF(object):
         import random as r
 
         def random_arrow(x):
-            if 'data' not in random_arrow.__dict__:
-                random_arrow.__dict__["data"] = 0
+            if not hasattr(random_arrow, 'data'):
+                random_arrow.data = 0
 
             input = x.to_pylist()
-            val = random_arrow.__dict__["data"]
+            val = random_arrow.data
             output = [val + i for i in range(len(input))]
-            random_arrow.__dict__["data"] += len(input)
+            random_arrow.data += len(input)
             return output
 
         duckdb_cursor.create_function(

--- a/tools/pythonpkg/tests/fast/udf/test_scalar_arrow.py
+++ b/tools/pythonpkg/tests/fast/udf/test_scalar_arrow.py
@@ -124,6 +124,30 @@ class TestPyArrowUDF(object):
         with pytest.raises(duckdb.InvalidInputException, match='Returned pyarrow table should have 1 tuples, found 5'):
             res = con.sql("""select too_many_tuples(5)""").fetchall()
 
+    def test_arrow_side_effects(self, duckdb_cursor):
+        import random as r
+
+        def random_arrow(x):
+            if 'data' not in random_arrow.__dict__:
+                random_arrow.__dict__["data"] = 0
+
+            input = x.to_pylist()
+            val = random_arrow.__dict__["data"]
+            output = [val + i for i in range(len(input))]
+            random_arrow.__dict__["data"] += len(input)
+            return output
+
+        duckdb_cursor.create_function(
+            "random_arrow",
+            random_arrow,
+            [VARCHAR],
+            INTEGER,
+            side_effects=True,
+            type="arrow",
+        )
+        res = duckdb_cursor.query("SELECT random_arrow('') FROM range(10)").fetchall()
+        assert res == [(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,)]
+
     def test_return_struct(self):
         def return_struct(col):
             con = duckdb.connect()


### PR DESCRIPTION
This PR fixes #9921 , #9786 

 One issue was that AllConstant is checked for the input chunk, which even when true does not always mean the result should be Constant for UDFs.
The other issue is that `numpy.core.multiarray` does not play well with multiple threads, so we now import it upfront so it will never be imported for the first time from a non-main thread.