### PR TITLE
[Fix] Table scan print funtion is wrong when printing DELETE or UPDATE physical operation

### DIFF
--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -106,16 +106,16 @@ string PhysicalTableScan::ParamsToString() const {
 		result += "\n[INFOSEPARATOR]\n";
 	}
 	// Get vaild column ids
-	std::vector<idx_t> vaild_column_ids;
+	idx_t vaild_column_id_num = 0;
 	for (auto &id : column_ids) {
 		if (id < names.size()) {
-			vaild_column_ids.emplace_back(id);
+			vaild_column_id_num += 1;
 		}
 	}
 	if (function.projection_pushdown) {
-		if (!projection_ids.empty() && projection_ids.size() < vaild_column_ids.size() && function.filter_prune) {
+		if (!projection_ids.empty() && vaild_column_id_num == column_ids.size() && projection_ids.size() < column_ids.size() && function.filter_prune) {
 			for (idx_t i = 0; i < projection_ids.size(); i++) {
-				const auto &column_id = vaild_column_ids[projection_ids[i]];
+				const auto &column_id = column_ids[projection_ids[i]];
 				if (column_id < names.size()) {
 					if (i > 0) {
 						result += "\n";
@@ -124,8 +124,8 @@ string PhysicalTableScan::ParamsToString() const {
 				}
 			}
 		} else {
-			for (idx_t i = 0; i < vaild_column_ids.size(); i++) {
-				const auto &column_id = vaild_column_ids[i];
+			for (idx_t i = 0; i < column_ids.size(); i++) {
+				const auto &column_id = column_ids[i];
 				if (column_id < names.size()) {
 					if (i > 0) {
 						result += "\n";

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -105,10 +105,17 @@ string PhysicalTableScan::ParamsToString() const {
 		result = function.to_string(bind_data.get());
 		result += "\n[INFOSEPARATOR]\n";
 	}
+	// Get vaild column ids
+	std::vector<idx_t> vaild_column_ids;
+	for (auto &id : column_ids) {
+		if (id < names.size()) {
+			vaild_column_ids.emplace_back(id);
+		}
+	}
 	if (function.projection_pushdown) {
-		if (function.filter_prune) {
+		if (!projection_ids.empty() && projection_ids.size() < vaild_column_ids.size() && function.filter_prune) {
 			for (idx_t i = 0; i < projection_ids.size(); i++) {
-				const auto &column_id = column_ids[projection_ids[i]];
+				const auto &column_id = vaild_column_ids[projection_ids[i]];
 				if (column_id < names.size()) {
 					if (i > 0) {
 						result += "\n";
@@ -117,8 +124,8 @@ string PhysicalTableScan::ParamsToString() const {
 				}
 			}
 		} else {
-			for (idx_t i = 0; i < column_ids.size(); i++) {
-				const auto &column_id = column_ids[i];
+			for (idx_t i = 0; i < vaild_column_ids.size(); i++) {
+				const auto &column_id = vaild_column_ids[i];
 				if (column_id < names.size()) {
 					if (i > 0) {
 						result += "\n";

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -113,7 +113,8 @@ string PhysicalTableScan::ParamsToString() const {
 		}
 	}
 	if (function.projection_pushdown) {
-		if (!projection_ids.empty() && vaild_column_id_num == column_ids.size() && projection_ids.size() < column_ids.size() && function.filter_prune) {
+		if (!projection_ids.empty() && vaild_column_id_num == column_ids.size() &&
+		    projection_ids.size() < column_ids.size() && function.filter_prune) {
 			for (idx_t i = 0; i < projection_ids.size(); i++) {
 				const auto &column_id = column_ids[projection_ids[i]];
 				if (column_id < names.size()) {


### PR DESCRIPTION
When print delete or update physical operation，it cannot print projection columns correctly.
I fix that.
Before fixing:
<img width="236" alt="屏幕截图 2023-12-12 171919" src="https://github.com/duckdb/duckdb/assets/72665617/e81961a7-45db-45c6-9b2e-cd0bc1f7025f">
Now:
<img width="190" alt="new" src="https://github.com/duckdb/duckdb/assets/72665617/f2b95604-d60b-4a2c-8f5f-669995b38684">
