### PR TITLE
[Python][StreamQueryResult] Fix memory ownership issues in StreamQueryResult::FetchRaw

### DIFF
--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -55,7 +55,12 @@ unique_ptr<DataChunk> StreamQueryResult::FetchRaw() {
 	{
 		auto lock = LockContext();
 		CheckExecutableInternal(*lock);
-		chunk = context->Fetch(*lock, *this);
+		auto system_chunk = context->Fetch(*lock, *this);
+		if (system_chunk) {
+			chunk = make_uniq<DataChunk>();
+			chunk->Initialize(Allocator::DefaultAllocator(), system_chunk->GetTypes());
+			system_chunk->Copy(*chunk, 0);
+		}
 	}
 	if (!chunk || chunk->ColumnCount() == 0 || chunk->size() == 0) {
 		Close();


### PR DESCRIPTION
It recently came to my attention that we return DataChunks from `StreamQueryResult::FetchRaw` that contain data held by the system, meaning once the system has released these pins we are holding random memory - which isn't great.

Because of this, we now copy the received chunk.

In a future PR we are replacing the mechanism these chunks are produced anyways, so in the meantime I think it's fine to just fix this oversight.