### PR TITLE
[Fix] ambiguous lambda parameters

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -105,14 +105,14 @@ static DefaultMacro internal_macros[] = {
     {DEFAULT_SCHEMA, "array_reverse", {"l", nullptr}, "list_reverse(l)"},
 
     // FIXME implement as actual function if we encounter a lot of performance issues. Complexity now: n * m, with hashing possibly n + m
-    {DEFAULT_SCHEMA, "list_intersect", {"l1", "l2", nullptr}, "list_filter(list_distinct(l1), (x) -> list_contains(l2, x))"},
+    {DEFAULT_SCHEMA, "list_intersect", {"l1", "l2", nullptr}, "list_filter(list_distinct(l1), (variable_intersect) -> list_contains(l2, variable_intersect))"},
     {DEFAULT_SCHEMA, "array_intersect", {"l1", "l2", nullptr}, "list_intersect(l1, l2)"},
 
-    {DEFAULT_SCHEMA, "list_has_any", {"l1", "l2", nullptr}, "CASE WHEN l1 IS NULL THEN NULL WHEN l2 IS NULL THEN NULL WHEN len(list_filter(l1, (x) -> list_contains(l2, x))) > 0 THEN true ELSE false END"},
+    {DEFAULT_SCHEMA, "list_has_any", {"l1", "l2", nullptr}, "CASE WHEN l1 IS NULL THEN NULL WHEN l2 IS NULL THEN NULL WHEN len(list_filter(l1, (variable_has_any) -> list_contains(l2, variable_has_any))) > 0 THEN true ELSE false END"},
     {DEFAULT_SCHEMA, "array_has_any", {"l1", "l2", nullptr}, "list_has_any(l1, l2)" },
     {DEFAULT_SCHEMA, "&&", {"l1", "l2", nullptr}, "list_has_any(l1, l2)" }, // "&&" is the operator for "list_has_any
 
-    {DEFAULT_SCHEMA, "list_has_all", {"l1", "l2", nullptr}, "CASE WHEN l1 IS NULL THEN NULL WHEN l2 IS NULL THEN NULL WHEN len(list_filter(l2, (x) -> list_contains(l1, x))) = len(list_filter(l2, x -> x IS NOT NULL)) THEN true ELSE false END"},
+    {DEFAULT_SCHEMA, "list_has_all", {"l1", "l2", nullptr}, "CASE WHEN l1 IS NULL THEN NULL WHEN l2 IS NULL THEN NULL WHEN len(list_filter(l2, (variable_has_all) -> list_contains(l1, variable_has_all))) = len(list_filter(l2, variable_has_all -> variable_has_all IS NOT NULL)) THEN true ELSE false END"},
     {DEFAULT_SCHEMA, "array_has_all", {"l1", "l2", nullptr}, "list_has_all(l1, l2)" },
     {DEFAULT_SCHEMA, "@>", {"l1", "l2", nullptr}, "list_has_all(l1, l2)" }, // "@>" is the operator for "list_has_all
     {DEFAULT_SCHEMA, "<@", {"l1", "l2", nullptr}, "list_has_all(l2, l1)" }, // "<@" is the operator for "list_has_all

--- a/test/sql/function/list/lambdas/incorrect.test
+++ b/test/sql/function/list/lambdas/incorrect.test
@@ -209,3 +209,84 @@ statement error
 SELECT list_transform(UNNEST(s), x -> UNNEST(x)) FROM tbl;
 ----
 failed to bind function
+
+# issue #9970
+
+# ambiguous parameter names
+
+statement error
+SELECT list_transform([1,2], x -> list_transform([3,4], x -> x));
+----
+Ambiguous lambda parameter name
+
+statement error
+SELECT list_has_all([variable_has_all FOR variable_has_all IN ['a']], ['b']) AS list_comp_result;
+----
+Ambiguous lambda parameter name
+
+statement error
+SELECT list_has_all(list_transform(['a'], variable_has_all -> variable_has_all), ['b']) AS list_transform_result;
+----
+Ambiguous lambda parameter name
+
+statement error
+SELECT list_has_any(['b'], list_transform(['a'], variable_has_any -> variable_has_any)) AS list_transform_result;
+----
+Ambiguous lambda parameter name
+
+# implicit nesting creates ambiguous parameter names
+
+# first input parameter can be nested
+query I
+SELECT list_intersect(list_intersect([1], [1]), [1])
+----
+[1]
+
+# second input parameter CANNOT be nested
+statement error
+SELECT list_intersect([1], list_intersect([1], [1]))
+----
+function cannot be nested
+
+# first input parameter can be nested
+query I
+SELECT list_has_any(LIST_VALUE(list_has_any([1], [1])), [1])
+----
+true
+
+# second input parameter CANNOT be nested
+statement error
+SELECT list_has_any([1], LIST_VALUE(list_has_any([1], [1])))
+----
+function cannot be nested
+
+# first input parameter CANNOT be nested
+
+statement error
+SELECT list_has_all(LIST_VALUE(list_has_all([1], [1])), [1])
+----
+function cannot be nested
+
+# second input parameter can be nested
+
+query I
+SELECT list_has_all([1], LIST_VALUE(list_has_all([1], [1])))
+----
+true
+
+# nest different helper functions/rewrites
+
+query I
+SELECT list_has_any(LIST_VALUE(list_has_all(list_intersect([1], [1]), [1])), [1]);
+----
+true
+
+query I
+SELECT list_has_all(LIST_VALUE(list_has_any(list_intersect([1], [1]), [1])), [1]);
+----
+true
+
+query I
+SELECT list_intersect(LIST_VALUE(list_has_all(LIST_VALUE(list_has_any([1], [1])), [1])), [1])
+----
+[true]

--- a/test/sql/function/list/list_intersect.test
+++ b/test/sql/function/list/list_intersect.test
@@ -108,10 +108,10 @@ insert into large_lists values (range(3000), range(3000));
 statement ok
 select list_intersect(l1, l2) from large_lists;
 
-query I
+statement error
 select list_intersect(list_intersect([1,2,3,4], [4,5,6,7]), list_intersect([4,5,6,7],[1,2,3,4]));
 ----
-[4]
+function cannot be nested
 
 query I
 select list_intersect(list_filter([1,2,3,4], x -> x > 2), list_filter([4,5,6,7], x -> x > 2));


### PR DESCRIPTION
Before this PR, the binder did not detect the same lambda parameter name in nested lambda functions. Therefore, the binder would use the outmost matching lambda parameter during binding, creating incorrect results as in #9970.

This PR fixes the issue by detecting ambiguities. However, that also means we now throw a binding error when nesting certain functions: `list_intersect`, `list_has_all`, and `list_has_any`. Before this PR, these functions returned incorrect results when nested.

@szarnyasg, could you please have a look at the error message? Does this need further mentioning in the documentation?

Fixes #9970.