### PR TITLE
Parallel Checkpointing

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -112,7 +112,7 @@ public:
 	static constexpr const idx_t BATCH_FLUSH_THRESHOLD = LocalStorage::MERGE_THRESHOLD * 3;
 
 public:
-	explicit BatchInsertGlobalState(DuckTableEntry &table) : table(table), insert_count(0) {
+	explicit BatchInsertGlobalState(DuckTableEntry &table) : table(table), insert_count(0), optimistically_written(false) {
 	}
 
 	mutex lock;
@@ -120,7 +120,7 @@ public:
 	idx_t insert_count;
 	vector<RowGroupBatchEntry> collections;
 	idx_t next_start = 0;
-	bool optimistically_written = false;
+	atomic<bool> optimistically_written;
 
 	void FindMergeCollections(idx_t min_batch_index, optional_idx &merged_batch_index,
 	                          vector<unique_ptr<RowGroupCollection>> &result) {

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -112,7 +112,8 @@ public:
 	static constexpr const idx_t BATCH_FLUSH_THRESHOLD = LocalStorage::MERGE_THRESHOLD * 3;
 
 public:
-	explicit BatchInsertGlobalState(DuckTableEntry &table) : table(table), insert_count(0), optimistically_written(false) {
+	explicit BatchInsertGlobalState(DuckTableEntry &table)
+	    : table(table), insert_count(0), optimistically_written(false) {
 	}
 
 	mutex lock;

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/parallel/pipeline.hpp"
+#include "duckdb/execution/task_error_manager.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -123,7 +124,6 @@ private:
 	unique_ptr<PhysicalOperator> owned_plan;
 
 	mutex executor_lock;
-	mutex error_lock;
 	//! All pipelines of the query plan
 	vector<shared_ptr<Pipeline>> pipelines;
 	//! The root pipelines of the query
@@ -138,12 +138,12 @@ private:
 	idx_t root_pipeline_idx;
 	//! The producer of this query
 	unique_ptr<ProducerToken> producer;
-	//! Exceptions that occurred during the execution of the current query
-	vector<PreservedError> exceptions;
 	//! List of events
 	vector<shared_ptr<Event>> events;
 	//! The query profiler
 	shared_ptr<QueryProfiler> profiler;
+	//! Task error manager
+	TaskErrorManager error_manager;
 
 	//! The amount of completed pipelines of the query
 	atomic<idx_t> completed_pipelines;

--- a/src/include/duckdb/execution/task_error_manager.hpp
+++ b/src/include/duckdb/execution/task_error_manager.hpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/task_error_manager.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/preserved_error.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+class TaskErrorManager {
+public:
+	void PushError(PreservedError error) {
+		lock_guard<mutex> elock(error_lock);
+		this->exceptions.push_back(std::move(error));
+	}
+
+	bool HasError() {
+		lock_guard<mutex> elock(error_lock);
+		return !exceptions.empty();
+	}
+
+	void ThrowException() {
+		lock_guard<mutex> elock(error_lock);
+		D_ASSERT(!exceptions.empty());
+		auto &entry = exceptions[0];
+		entry.Throw();
+	}
+
+private:
+	mutex error_lock;
+	//! Exceptions that occurred during the execution of the current query
+	vector<PreservedError> exceptions;
+};
+} // namespace duckdb

--- a/src/include/duckdb/execution/task_error_manager.hpp
+++ b/src/include/duckdb/execution/task_error_manager.hpp
@@ -33,6 +33,11 @@ public:
 		entry.Throw();
 	}
 
+	void Reset() {
+		lock_guard<mutex> elock(error_lock);
+		exceptions.clear();
+	}
+
 private:
 	mutex error_lock;
 	//! Exceptions that occurred during the execution of the current query

--- a/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
@@ -34,9 +34,6 @@ public:
 
 	virtual MetadataWriter &GetPayloadWriter() = 0;
 
-	void RegisterPartialBlock(PartialBlockAllocation &&allocation);
-	PartialBlockAllocation GetBlockAllocation(uint32_t segment_size);
-
 	PartialBlockManager &GetPartialBlockManager() {
 		return partial_block_manager;
 	}

--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -36,6 +36,8 @@ public:
 
 	virtual void AddRowGroup(RowGroupPointer &&row_group_pointer, unique_ptr<RowGroupWriter> &&writer);
 
+	TaskScheduler &GetScheduler();
+
 protected:
 	DuckTableEntry &table;
 	//! Pointers to the start of each row group.

--- a/src/include/duckdb/storage/partial_block_manager.hpp
+++ b/src/include/duckdb/storage/partial_block_manager.hpp
@@ -107,14 +107,8 @@ public:
 	virtual ~PartialBlockManager();
 
 public:
-	//! Flush any remaining partial blocks to disk
-	void FlushPartialBlocks();
-
 	PartialBlockAllocation GetBlockAllocation(uint32_t segment_size);
 
-	virtual void AllocateBlock(PartialBlockState &state, uint32_t segment_size);
-
-	void Merge(PartialBlockManager &other);
 	//! Register a partially filled block that is filled with "segment_size" entries
 	void RegisterPartialBlock(PartialBlockAllocation &&allocation);
 
@@ -124,9 +118,16 @@ public:
 	//! Rollback all data written by this partial block manager
 	void Rollback();
 
+	//! Merge this block manager into another one
+	void Merge(PartialBlockManager &other);
+
+	//! Flush any remaining partial blocks to disk
+	void FlushPartialBlocks();
+
 protected:
 	BlockManager &block_manager;
 	CheckpointType checkpoint_type;
+	mutex partial_block_lock;
 	//! A map of (available space -> PartialBlock) for partially filled blocks
 	//! This is a multimap because there might be outstanding partial blocks with
 	//! the same amount of left-over space
@@ -139,6 +140,7 @@ protected:
 	uint32_t max_use_count;
 
 protected:
+	virtual void AllocateBlock(PartialBlockState &state, uint32_t segment_size);
 	//! Try to obtain a partially filled block that can fit "segment_size" bytes
 	//! If successful, returns true and returns the block_id and offset_in_block to write to
 	//! Otherwise, returns false

--- a/src/include/duckdb/storage/partial_block_manager.hpp
+++ b/src/include/duckdb/storage/partial_block_manager.hpp
@@ -124,6 +124,10 @@ public:
 	//! Flush any remaining partial blocks to disk
 	void FlushPartialBlocks();
 
+	unique_lock<mutex> GetLock() {
+		return unique_lock<mutex>(partial_block_lock);
+	}
+
 protected:
 	BlockManager &block_manager;
 	CheckpointType checkpoint_type;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -120,6 +120,7 @@ public:
 	RowGroupWriteData WriteToDisk(PartialBlockManager &manager, const vector<CompressionType> &compression_types);
 	//! Returns the number of committed rows (count - committed deletes)
 	idx_t GetCommittedRowCount();
+	void WriteToDisk(RowGroupWriter &writer);
 	RowGroupPointer Checkpoint(RowGroupWriter &writer, TableStatistics &global_stats);
 
 	void InitializeAppend(RowGroupAppendState &append_state);

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -120,8 +120,8 @@ public:
 	RowGroupWriteData WriteToDisk(PartialBlockManager &manager, const vector<CompressionType> &compression_types);
 	//! Returns the number of committed rows (count - committed deletes)
 	idx_t GetCommittedRowCount();
-	void WriteToDisk(RowGroupWriter &writer);
-	RowGroupPointer Checkpoint(RowGroupWriter &writer, TableStatistics &global_stats);
+	RowGroupWriteData WriteToDisk(RowGroupWriter &writer);
+	RowGroupPointer Checkpoint(RowGroupWriteData write_data, RowGroupWriter &writer, TableStatistics &global_stats);
 
 	void InitializeAppend(RowGroupAppendState &append_state);
 	void Append(RowGroupAppendState &append_state, DataChunk &chunk, idx_t append_count);

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -30,6 +30,7 @@ class RowGroupSegmentTree;
 struct ColumnSegmentInfo;
 class MetadataManager;
 struct VacuumState;
+struct CollectionCheckpointState;
 
 class RowGroupCollection {
 public:
@@ -89,7 +90,8 @@ public:
 	void Checkpoint(TableDataWriter &writer, TableStatistics &global_stats);
 
 	void InitializeVacuumState(VacuumState &state, vector<SegmentNode<RowGroup>> &segments);
-	void VacuumDeletes(VacuumState &state, vector<SegmentNode<RowGroup>> &segments, idx_t segment_idx);
+	bool ScheduleVacuumTasks(CollectionCheckpointState &checkpoint_state, VacuumState &state, idx_t segment_idx);
+	void ScheduleCheckpointTask(CollectionCheckpointState &checkpoint_state, idx_t segment_idx);
 
 	void CommitDropColumn(idx_t index);
 	void CommitDropTable();

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -521,7 +521,7 @@ void Executor::Reset() {
 	root_pipeline_idx = 0;
 	completed_pipelines = 0;
 	total_pipelines = 0;
-	exceptions.clear();
+	error_manager.Reset();
 	pipelines.clear();
 	events.clear();
 	to_be_rescheduled_tasks.clear();

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -554,23 +554,18 @@ vector<LogicalType> Executor::GetTypes() {
 }
 
 void Executor::PushError(PreservedError exception) {
-	lock_guard<mutex> elock(error_lock);
 	// interrupt execution of any other pipelines that belong to this executor
 	context.interrupted = true;
 	// push the exception onto the stack
-	exceptions.push_back(std::move(exception));
+	error_manager.PushError(exception);
 }
 
 bool Executor::HasError() {
-	lock_guard<mutex> elock(error_lock);
-	return !exceptions.empty();
+	return error_manager.HasError();
 }
 
 void Executor::ThrowException() {
-	lock_guard<mutex> elock(error_lock);
-	D_ASSERT(!exceptions.empty());
-	auto &entry = exceptions[0];
-	entry.Throw();
+	error_manager.ThrowException();
 }
 
 void Executor::Flush(ThreadContext &tcontext) {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -557,7 +557,7 @@ void Executor::PushError(PreservedError exception) {
 	// interrupt execution of any other pipelines that belong to this executor
 	context.interrupted = true;
 	// push the exception onto the stack
-	error_manager.PushError(exception);
+	error_manager.PushError(std::move(exception));
 }
 
 bool Executor::HasError() {

--- a/src/storage/checkpoint/row_group_writer.cpp
+++ b/src/storage/checkpoint/row_group_writer.cpp
@@ -9,14 +9,6 @@ CompressionType RowGroupWriter::GetColumnCompressionType(idx_t i) {
 	return table.GetColumn(LogicalIndex(i)).CompressionType();
 }
 
-void RowGroupWriter::RegisterPartialBlock(PartialBlockAllocation &&allocation) {
-	partial_block_manager.RegisterPartialBlock(std::move(allocation));
-}
-
-PartialBlockAllocation RowGroupWriter::GetBlockAllocation(uint32_t segment_size) {
-	return partial_block_manager.GetBlockAllocation(segment_size);
-}
-
 void SingleFileRowGroupWriter::WriteColumnDataPointers(ColumnCheckpointState &column_checkpoint_state,
                                                        Serializer &serializer) {
 	const auto &data_pointers = column_checkpoint_state.data_pointers;

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/storage/table/column_checkpoint_state.hpp"
 #include "duckdb/storage/table/table_statistics.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 
 namespace duckdb {
 
@@ -27,6 +28,10 @@ CompressionType TableDataWriter::GetColumnCompressionType(idx_t i) {
 void TableDataWriter::AddRowGroup(RowGroupPointer &&row_group_pointer, unique_ptr<RowGroupWriter> &&writer) {
 	row_group_pointers.push_back(std::move(row_group_pointer));
 	writer.reset();
+}
+
+TaskScheduler &TableDataWriter::GetScheduler() {
+	return TaskScheduler::GetScheduler(table.ParentCatalog().GetDatabase());
 }
 
 SingleFileTableDataWriter::SingleFileTableDataWriter(SingleFileCheckpointWriter &checkpoint_manager,

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1226,7 +1226,6 @@ void DataTable::SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> d
 void DataTable::Checkpoint(TableDataWriter &writer, Serializer &serializer) {
 
 	// checkpoint each individual row group
-	// FIXME: we might want to combine adjacent row groups in case they have had deletions...
 	TableStatistics global_stats;
 	row_groups->CopyStats(global_stats);
 	row_groups->Checkpoint(writer, global_stats);

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -80,7 +80,6 @@ void LocalTableStorage::InitializeScan(CollectionScanState &state, optional_ptr<
 }
 
 idx_t LocalTableStorage::EstimatedSize() {
-
 	// count the appended rows
 	idx_t appended_rows = row_groups->GetTotalRows() - deleted_rows;
 

--- a/src/storage/partial_block_manager.cpp
+++ b/src/storage/partial_block_manager.cpp
@@ -43,6 +43,7 @@ PartialBlockManager::~PartialBlockManager() {
 }
 
 PartialBlockAllocation PartialBlockManager::GetBlockAllocation(uint32_t segment_size) {
+	lock_guard<mutex> lock(partial_block_lock);
 	PartialBlockAllocation allocation;
 	allocation.block_manager = &block_manager;
 	allocation.allocation_size = segment_size;
@@ -96,6 +97,7 @@ bool PartialBlockManager::GetPartialBlock(idx_t segment_size, unique_ptr<Partial
 }
 
 void PartialBlockManager::RegisterPartialBlock(PartialBlockAllocation &&allocation) {
+	lock_guard<mutex> lock(partial_block_lock);
 	auto &state = allocation.partial_block->state;
 	D_ASSERT(checkpoint_type != CheckpointType::FULL_CHECKPOINT || state.block_id >= 0);
 	if (state.block_use_count < max_use_count) {

--- a/src/storage/partial_block_manager.cpp
+++ b/src/storage/partial_block_manager.cpp
@@ -43,7 +43,6 @@ PartialBlockManager::~PartialBlockManager() {
 }
 
 PartialBlockAllocation PartialBlockManager::GetBlockAllocation(uint32_t segment_size) {
-	lock_guard<mutex> lock(partial_block_lock);
 	PartialBlockAllocation allocation;
 	allocation.block_manager = &block_manager;
 	allocation.allocation_size = segment_size;
@@ -97,7 +96,6 @@ bool PartialBlockManager::GetPartialBlock(idx_t segment_size, unique_ptr<Partial
 }
 
 void PartialBlockManager::RegisterPartialBlock(PartialBlockAllocation &&allocation) {
-	lock_guard<mutex> lock(partial_block_lock);
 	auto &state = allocation.partial_block->state;
 	D_ASSERT(checkpoint_type != CheckpointType::FULL_CHECKPOINT || state.block_id >= 0);
 	if (state.block_use_count < max_use_count) {

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -38,7 +38,6 @@ bool PartialBlockForCheckpoint::IsFlushed() {
 }
 
 void PartialBlockForCheckpoint::Flush(const idx_t free_space_left) {
-
 	if (IsFlushed()) {
 		throw InternalException("Flush called on partial block that was already flushed");
 	}
@@ -130,7 +129,10 @@ void ColumnCheckpointState::FlushSegment(unique_ptr<ColumnSegment> segment, idx_
 	block_id_t block_id = INVALID_BLOCK;
 	uint32_t offset_in_block = 0;
 
+	unique_lock<mutex> partial_block_lock;
 	if (!segment->stats.statistics.IsConstant()) {
+		partial_block_lock = partial_block_manager.GetLock();
+
 		// non-constant block
 		PartialBlockAllocation allocation = partial_block_manager.GetBlockAllocation(segment_size);
 		block_id = allocation.state.block_id;

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -340,8 +340,8 @@ unique_ptr<ColumnCheckpointState> ListColumnData::CreateCheckpointState(RowGroup
 unique_ptr<ColumnCheckpointState> ListColumnData::Checkpoint(RowGroup &row_group,
                                                              PartialBlockManager &partial_block_manager,
                                                              ColumnCheckpointInfo &checkpoint_info) {
-	auto validity_state = validity.Checkpoint(row_group, partial_block_manager, checkpoint_info);
 	auto base_state = ColumnData::Checkpoint(row_group, partial_block_manager, checkpoint_info);
+	auto validity_state = validity.Checkpoint(row_group, partial_block_manager, checkpoint_info);
 	auto child_state = child_column->Checkpoint(row_group, partial_block_manager, checkpoint_info);
 
 	auto &checkpoint_state = base_state->Cast<ListColumnCheckpointState>();

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -777,6 +777,22 @@ bool RowGroup::HasUnloadedDeletes() const {
 	return !deletes_is_loaded;
 }
 
+void RowGroup::WriteToDisk(RowGroupWriter &writer) {
+	vector<CompressionType> compression_types;
+	compression_types.reserve(columns.size());
+	for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {
+		auto &column = GetColumn(column_idx);
+		if (column.count != this->count) {
+			throw InternalException("Corrupted in-memory column - column with index %llu has misaligned count (row "
+			                        "group has %llu rows, column has %llu)",
+			                        column_idx, this->count.load(), column.count);
+		}
+		compression_types.push_back(writer.GetColumnCompressionType(column_idx));
+	}
+
+	WriteToDisk(writer.GetPartialBlockManager(), compression_types);
+}
+
 RowGroupPointer RowGroup::Checkpoint(RowGroupWriter &writer, TableStatistics &global_stats) {
 	RowGroupPointer row_group_pointer;
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -793,7 +793,8 @@ RowGroupWriteData RowGroup::WriteToDisk(RowGroupWriter &writer) {
 	return WriteToDisk(writer.GetPartialBlockManager(), compression_types);
 }
 
-RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWriter &writer, TableStatistics &global_stats) {
+RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWriter &writer,
+                                     TableStatistics &global_stats) {
 	RowGroupPointer row_group_pointer;
 
 	for (idx_t column_idx = 0; column_idx < GetColumnCount(); column_idx++) {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -894,8 +894,8 @@ bool RowGroupCollection::ScheduleVacuumTasks(CollectionCheckpointState &checkpoi
 		return false;
 	}
 	// schedule the vacuum task
-	auto vacuum_task =
-	    make_uniq<VacuumTask>(checkpoint_state, state, segment_idx, merge_count, target_count, merge_rows, state.row_start);
+	auto vacuum_task = make_uniq<VacuumTask>(checkpoint_state, state, segment_idx, merge_count, target_count,
+	                                         merge_rows, state.row_start);
 	checkpoint_state.ScheduleTask(std::move(vacuum_task));
 	// skip vacuuming by the row groups we have merged
 	state.next_vacuum_idx = segment_idx + merge_count;
@@ -962,7 +962,8 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 		if (!row_group_writer) {
 			throw InternalException("Missing row group writer for index %llu", segment_idx);
 		}
-		auto pointer = row_group.Checkpoint(std::move(checkpoint_state.write_data[segment_idx]), *row_group_writer, global_stats);
+		auto pointer =
+		    row_group.Checkpoint(std::move(checkpoint_state.write_data[segment_idx]), *row_group_writer, global_stats);
 		writer.AddRowGroup(std::move(pointer), std::move(row_group_writer));
 		row_groups->AppendSegment(l, std::move(entry.node));
 		new_total_rows += row_group.count;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/execution/task_error_manager.hpp"
+#include "duckdb/storage/table/column_checkpoint_state.hpp"
 
 namespace duckdb {
 
@@ -654,7 +655,7 @@ private:
 
 class BaseCheckpointTask : public Task {
 public:
-	BaseCheckpointTask(CollectionCheckpointState &checkpoint_state) : checkpoint_state(checkpoint_state) {
+	explicit BaseCheckpointTask(CollectionCheckpointState &checkpoint_state) : checkpoint_state(checkpoint_state) {
 	}
 
 	virtual void ExecuteTask() = 0;

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -695,8 +695,6 @@ public:
 		auto &entry = checkpoint_state.segments[index];
 		auto &row_group = *entry.node;
 		checkpoint_state.writers[index] = checkpoint_state.writer.GetRowGroupWriter(*entry.node);
-		// FIXME - this can be removed with relatively minor changes to the partial block manager
-		lock_guard<mutex> write_lock(checkpoint_state.write_lock);
 		checkpoint_state.write_data[index] = row_group.WriteToDisk(*checkpoint_state.writers[index]);
 	}
 

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -189,6 +189,11 @@ StandardColumnData::CreateCheckpointState(RowGroup &row_group, PartialBlockManag
 unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_group,
                                                                  PartialBlockManager &partial_block_manager,
                                                                  ColumnCheckpointInfo &checkpoint_info) {
+	// we need to checkpoint the main column data first
+	// that is because the checkpointing of the main column data ALSO scans the validity data
+	// to prevent reading the validity data immediately after it is checkpointed we first checkpoint the main column
+	// this is necessary for concurrent checkpointing as due to the partial block manager checkpointed data might be
+	// flushed to disk by a different thread than the one that wrote it, causing a data race
 	auto base_state = ColumnData::Checkpoint(row_group, partial_block_manager, checkpoint_info);
 	auto validity_state = validity.Checkpoint(row_group, partial_block_manager, checkpoint_info);
 	auto &checkpoint_state = base_state->Cast<StandardColumnCheckpointState>();

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -189,8 +189,8 @@ StandardColumnData::CreateCheckpointState(RowGroup &row_group, PartialBlockManag
 unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_group,
                                                                  PartialBlockManager &partial_block_manager,
                                                                  ColumnCheckpointInfo &checkpoint_info) {
-	auto validity_state = validity.Checkpoint(row_group, partial_block_manager, checkpoint_info);
 	auto base_state = ColumnData::Checkpoint(row_group, partial_block_manager, checkpoint_info);
+	auto validity_state = validity.Checkpoint(row_group, partial_block_manager, checkpoint_info);
 	auto &checkpoint_state = base_state->Cast<StandardColumnCheckpointState>();
 	checkpoint_state.validity_state = std::move(validity_state);
 	return base_state;

--- a/test/sql/storage/delete/drop_many_deletes.test_slow
+++ b/test/sql/storage/delete/drop_many_deletes.test_slow
@@ -24,7 +24,7 @@ SELECT COUNT(*) FROM integers
 query I
 SELECT COUNT(*) FROM pragma_metadata_info()
 ----
-3
+1
 
 statement ok
 DROP TABLE integers

--- a/test/sql/storage/parallel/memory_limit_batch_load_list.test_slow
+++ b/test/sql/storage/parallel/memory_limit_batch_load_list.test_slow
@@ -1,0 +1,63 @@
+# name: test/sql/storage/parallel/memory_limit_batch_load_list.test_slow
+# description: Test batch streaming to disk with different row group sizes
+# group: [parallel]
+
+require parquet
+
+load __TEST_DIR__/memory_limit_batch_load_list.db
+
+# in this test we load data of around 100M rows - uncompressed this will be 1.4GB~2GB (without/with NULLs)
+# we do these operations with a low memory limit to verify the data is streamed to and from disk correctly
+statement ok
+SET memory_limit='300MB'
+
+foreach row_group_size 5000 150000 1000000
+
+statement ok
+COPY (SELECT [i] AS l FROM range(10000000) tbl(i)) TO '__TEST_DIR__/giant_row_groups.parquet' (ROW_GROUP_SIZE ${row_group_size})
+
+statement ok
+CREATE TABLE list AS FROM '__TEST_DIR__/giant_row_groups.parquet'
+
+query IIIII
+SELECT SUM(i), MIN(i), MAX(i), COUNT(i), COUNT(*) FROM (SELECT UNNEST(l) AS i FROM list)
+----
+49999995000000	0	9999999	10000000	10000000
+
+query I
+SELECT * FROM list LIMIT 5 OFFSET 99998
+----
+[99998]
+[99999]
+[100000]
+[100001]
+[100002]
+
+statement ok
+DROP TABLE list
+
+# now with NULL values
+statement ok
+COPY (SELECT CASE WHEN i%2=0 THEN NULL ELSE [i] END AS l FROM range(10000000) tbl(i)) TO '__TEST_DIR__/giant_row_groups_nulls.parquet' (ROW_GROUP_SIZE ${row_group_size})
+
+statement ok
+CREATE TABLE list AS FROM '__TEST_DIR__/giant_row_groups_nulls.parquet'
+
+query IIIII
+SELECT SUM(i), MIN(i), MAX(i), COUNT(i), COUNT(*) FROM (SELECT UNNEST(l) AS i FROM list)
+----
+25000000000000	1	9999999	5000000	5000000
+
+query I
+SELECT * FROM list LIMIT 5 OFFSET 99998
+----
+NULL
+[99999]
+NULL
+[100001]
+NULL
+
+statement ok
+DROP TABLE list
+
+endloop

--- a/test/sql/tpch/gzip_csv_auto_detect.test_slow
+++ b/test/sql/tpch/gzip_csv_auto_detect.test_slow
@@ -15,7 +15,7 @@ load __TEST_DIR__/store_tpch_auto_detect.db
 
 # now read the gzip compressed file with sample_size=-1
 statement ok
-SET memory_limit='500MB';
+SET memory_limit='750MB';
 
 statement ok
 CREATE OR REPLACE TABLE lineitem AS (SELECT * FROM read_csv_auto(['__TEST_DIR__/lineitem.csv.gz'], sample_size=-1));


### PR DESCRIPTION
This PR adds support for parallel checkpointing of individual tables during the `CHECKPOINT` process. There are two types of tasks that are scheduled, `VacuumTask` that merge 2+ row groups into fewer row groups (see https://github.com/duckdb/duckdb/pull/9931) and `CheckpointTask` that take a row group and write the row group to disk. Tasks are executed in parallel for individual tables only (i.e. we checkpoint the row groups of a single table in parallel, but do not checkpoint multiple tables at the same time in parallel).

In general row groups are independent from one another so operating on them in parallel is not a problem. The only cause of contention is the `PartialBlockManager` which colocates blocks on the same page, also across row groups. This PR adds fine-grained locking to the checkpointing process around the usage of the `PartialBlockManager` for this reason.

In addition, there was one gnarly change required to the checkpoint of the `StandardColumnData` - we need to checkpoint the validity **after** checkpointing the regular column. That is because when checkpointing the main data column we scan both the validity and the data itself for better compression. If the validity is already checkpointed this can cause a data race when run in parallel with the `PartialBlockManager`, as a different thread can at any point flush a partial block that then triggers an update for every column that is stored on that partial block. If a validity column was flushed while it was being scanned this would cause problems.

##### Performance

Running the same benchmarks in https://github.com/duckdb/duckdb/pull/9931 provides the following performance.

```sql
DELETE FROM lineitem WHERE l_orderkey%2=0;
```

| v0.9.2 | Vacuum | Parallel Checkpoint |
|--------|--------|---------------------|
| 0.12s  | 1.83s  | 0.44s               |

Note that we are still significantly slower than before - as we are rewriting half the table. In the future we could consider limiting the vacuuming that is performed during a checkpoint to e.g. ~20% of all row groups (configurable) which would limit the performance impact of the vacuuming even further.

Running the mix of deletes and additions performance is much closer to before while keeping all of the size and performance benefits of flushing the deletes:

```sql
CALL dbgen(sf=0);
COPY lineitem FROM 'lineitem.parquet';
DELETE FROM lineitem WHERE l_orderkey%2=0;
COPY lineitem FROM 'lineitem.parquet';
DELETE FROM lineitem WHERE l_orderkey%2=0;
COPY lineitem FROM 'lineitem.parquet';
DELETE FROM lineitem WHERE l_orderkey%2=0;
COPY lineitem FROM 'lineitem.parquet';
DELETE FROM lineitem WHERE l_orderkey%2=0;
COPY lineitem FROM 'lineitem.parquet';
DELETE FROM lineitem WHERE l_orderkey%2=0;
COPY lineitem FROM 'lineitem.parquet';
DELETE FROM lineitem WHERE l_orderkey%2=0;
``` 

|     -      | v0.9.2 | Vacuum | Parallel Checkpoint |
|------------|--------|--------|---------------------|
| Load       | 6.41s  | 25.18s | 8.06s               |
| Q01 (Cold) | 0.172s | 0.095s | 0.089s              |
| Q01 (Hot)  | 0.125s | 0.091s | 0.090s              |
| Size       | 977MB  | 686MB  | 662MB               |