### PR TITLE
Add batch functionality

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -1027,7 +1027,7 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public boolean supportsBatchUpdates() throws SQLException {
-        return false;
+        return true;
     }
 
     @Override

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -896,7 +896,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
     public void setNClob(int parameterIndex, Reader reader) throws SQLException {
         throw new SQLFeatureNotSupportedException("setNClob");
     }
-
+    
     private void requireNonBatch() throws SQLException {
         if (isBatch) {
             throw new SQLException("Batched queries must be executed with executeBatch.");

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -120,7 +120,6 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public boolean execute() throws SQLException {
-        requireNonBatch();
         if (isClosed()) {
             throw new SQLException("Statement was closed");
         }
@@ -167,6 +166,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public ResultSet executeQuery() throws SQLException {
+        requireNonBatch();
         execute();
         if (!returnsResultSet) {
             throw new SQLException("executeQuery() can only be used with queries that return a ResultSet");
@@ -176,6 +176,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public int executeUpdate() throws SQLException {
+        requireNonBatch();
         execute();
         if (!(returnsChangedRows || returnsNothing)) {
             throw new SQLException(
@@ -186,6 +187,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public boolean execute(String sql) throws SQLException {
+        requireNonBatch();
         prepare(sql);
         return execute();
     }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -242,7 +242,6 @@ public class DuckDBPreparedStatement implements PreparedStatement {
         } else if (x instanceof OffsetDateTime) {
             x = new DuckDBTimestampTZ((OffsetDateTime) x);
         }
-
         params[parameterIndex - 1] = x;
     }
 

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -242,6 +242,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
         } else if (x instanceof OffsetDateTime) {
             x = new DuckDBTimestampTZ((OffsetDateTime) x);
         }
+
         params[parameterIndex - 1] = x;
     }
 
@@ -744,6 +745,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
     @Override
     public void addBatch() throws SQLException {
         batchedValues.add(params);
+        clearParameters();
         isBatch = true;
     }
 

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -896,7 +896,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
     public void setNClob(int parameterIndex, Reader reader) throws SQLException {
         throw new SQLFeatureNotSupportedException("setNClob");
     }
-    
+
     private void requireNonBatch() throws SQLException {
         if (isBatch) {
             throw new SQLException("Batched queries must be executed with executeBatch.");

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -120,6 +120,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public boolean execute() throws SQLException {
+        requireNonBatch();
         if (isClosed()) {
             throw new SQLException("Statement was closed");
         }
@@ -166,7 +167,6 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public ResultSet executeQuery() throws SQLException {
-        requireNonBatch();
         execute();
         if (!returnsResultSet) {
             throw new SQLException("executeQuery() can only be used with queries that return a ResultSet");
@@ -176,7 +176,6 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public int executeUpdate() throws SQLException {
-        requireNonBatch();
         execute();
         if (!(returnsChangedRows || returnsNothing)) {
             throw new SQLException(
@@ -187,7 +186,6 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public boolean execute(String sql) throws SQLException {
-        requireNonBatch();
         prepare(sql);
         return execute();
     }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -195,14 +195,12 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public ResultSet executeQuery(String sql) throws SQLException {
-        requireNonBatch();
         prepare(sql);
         return executeQuery();
     }
 
     @Override
     public int executeUpdate(String sql) throws SQLException {
-        requireNonBatch();
         prepare(sql);
         return executeUpdate();
     }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -72,7 +72,6 @@ public class DuckDBPreparedStatement implements PreparedStatement {
     }
 
     private void startTransaction() throws SQLException {
-
         if (this.conn.autoCommit || this.conn.transactionRunning) {
             return;
         }
@@ -181,7 +180,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
         execute();
         if (!(returnsChangedRows || returnsNothing)) {
             throw new SQLException(
-                    "executeUpdate() can only be used with queries that return nothing (eg, a DDL statement), or update rows");
+                "executeUpdate() can only be used with queries that return nothing (eg, a DDL statement), or update rows");
         }
         return getUpdateCountInternal();
     }
@@ -466,16 +465,15 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public int[] executeBatch() throws SQLException {
-        try{
+        try {
             int[] updateCounts = new int[batchedValues.size()];
-            for (int i = 0; i < batchedValues.size(); i++){
+            for (int i = 0; i < batchedValues.size(); i++) {
                 params = batchedValues.get(i);
                 execute();
                 updateCounts[i] = getUpdateCount();
             }
             return updateCounts;
-        }
-        finally{
+        } finally {
             clearBatch();
         }
     }
@@ -614,132 +612,132 @@ public class DuckDBPreparedStatement implements PreparedStatement {
             return;
         }
         switch (targetSqlType) {
-            case Types.BOOLEAN:
-            case Types.BIT:
-                if (x instanceof Boolean) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof Number) {
-                    setObject(parameterIndex, ((Number) x).byteValue() == 1);
-                } else if (x instanceof String) {
-                    setObject(parameterIndex, Boolean.parseBoolean((String) x));
-                } else {
-                    throw new SQLException("Can't convert value to boolean " + x.getClass().toString());
-                }
-                break;
-            case Types.TINYINT:
-                if (x instanceof Byte) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof Number) {
-                    setObject(parameterIndex, ((Number) x).byteValue());
-                } else if (x instanceof String) {
-                    setObject(parameterIndex, Byte.parseByte((String) x));
-                } else if (x instanceof Boolean) {
-                    setObject(parameterIndex, (byte) (((Boolean) x) ? 1 : 0));
-                } else {
-                    throw new SQLException("Can't convert value to byte " + x.getClass().toString());
-                }
-                break;
-            case Types.SMALLINT:
-                if (x instanceof Short) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof Number) {
-                    setObject(parameterIndex, ((Number) x).shortValue());
-                } else if (x instanceof String) {
-                    setObject(parameterIndex, Short.parseShort((String) x));
-                } else if (x instanceof Boolean) {
-                    setObject(parameterIndex, (short) (((Boolean) x) ? 1 : 0));
-                } else {
-                    throw new SQLException("Can't convert value to short " + x.getClass().toString());
-                }
-                break;
-            case Types.INTEGER:
-                if (x instanceof Integer) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof Number) {
-                    setObject(parameterIndex, ((Number) x).intValue());
-                } else if (x instanceof String) {
-                    setObject(parameterIndex, Integer.parseInt((String) x));
-                } else if (x instanceof Boolean) {
-                    setObject(parameterIndex, (int) (((Boolean) x) ? 1 : 0));
-                } else {
-                    throw new SQLException("Can't convert value to int " + x.getClass().toString());
-                }
-                break;
-            case Types.BIGINT:
-                if (x instanceof Long) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof Number) {
-                    setObject(parameterIndex, ((Number) x).longValue());
-                } else if (x instanceof String) {
-                    setObject(parameterIndex, Long.parseLong((String) x));
-                } else if (x instanceof Boolean) {
-                    setObject(parameterIndex, (long) (((Boolean) x) ? 1 : 0));
-                } else {
-                    throw new SQLException("Can't convert value to long " + x.getClass().toString());
-                }
-                break;
-            case Types.REAL:
-            case Types.FLOAT:
-                if (x instanceof Float) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof Number) {
-                    setObject(parameterIndex, ((Number) x).floatValue());
-                } else if (x instanceof String) {
-                    setObject(parameterIndex, Float.parseFloat((String) x));
-                } else if (x instanceof Boolean) {
-                    setObject(parameterIndex, (float) (((Boolean) x) ? 1 : 0));
-                } else {
-                    throw new SQLException("Can't convert value to float " + x.getClass().toString());
-                }
-                break;
-            case Types.DECIMAL:
-                if (x instanceof BigDecimal) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof Double) {
-                    setObject(parameterIndex, new BigDecimal((Double) x));
-                } else if (x instanceof String) {
-                    setObject(parameterIndex, new BigDecimal((String) x));
-                } else {
-                    throw new SQLException("Can't convert value to double " + x.getClass().toString());
-                }
-                break;
-            case Types.NUMERIC:
-            case Types.DOUBLE:
-                if (x instanceof Double) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof Number) {
-                    setObject(parameterIndex, ((Number) x).doubleValue());
-                } else if (x instanceof String) {
-                    setObject(parameterIndex, Double.parseDouble((String) x));
-                } else if (x instanceof Boolean) {
-                    setObject(parameterIndex, (double) (((Boolean) x) ? 1 : 0));
-                } else {
-                    throw new SQLException("Can't convert value to double " + x.getClass().toString());
-                }
-                break;
-            case Types.CHAR:
-            case Types.LONGVARCHAR:
-            case Types.VARCHAR:
-                if (x instanceof String) {
-                    setObject(parameterIndex, (String) x);
-                } else {
-                    setObject(parameterIndex, x.toString());
-                }
-                break;
-            case Types.TIMESTAMP:
-            case Types.TIMESTAMP_WITH_TIMEZONE:
-                if (x instanceof Timestamp) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof LocalDateTime) {
-                    setObject(parameterIndex, x);
-                } else if (x instanceof OffsetDateTime) {
-                    setObject(parameterIndex, x);
-                } else {
-                    throw new SQLException("Can't convert value to timestamp " + x.getClass().toString());
-                }
-                break;
-            default:
-                throw new SQLException("Unknown target type " + targetSqlType);
+        case Types.BOOLEAN:
+        case Types.BIT:
+            if (x instanceof Boolean) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof Number) {
+                setObject(parameterIndex, ((Number) x).byteValue() == 1);
+            } else if (x instanceof String) {
+                setObject(parameterIndex, Boolean.parseBoolean((String) x));
+            } else {
+                throw new SQLException("Can't convert value to boolean " + x.getClass().toString());
+            }
+            break;
+        case Types.TINYINT:
+            if (x instanceof Byte) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof Number) {
+                setObject(parameterIndex, ((Number) x).byteValue());
+            } else if (x instanceof String) {
+                setObject(parameterIndex, Byte.parseByte((String) x));
+            } else if (x instanceof Boolean) {
+                setObject(parameterIndex, (byte) (((Boolean) x) ? 1 : 0));
+            } else {
+                throw new SQLException("Can't convert value to byte " + x.getClass().toString());
+            }
+            break;
+        case Types.SMALLINT:
+            if (x instanceof Short) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof Number) {
+                setObject(parameterIndex, ((Number) x).shortValue());
+            } else if (x instanceof String) {
+                setObject(parameterIndex, Short.parseShort((String) x));
+            } else if (x instanceof Boolean) {
+                setObject(parameterIndex, (short) (((Boolean) x) ? 1 : 0));
+            } else {
+                throw new SQLException("Can't convert value to short " + x.getClass().toString());
+            }
+            break;
+        case Types.INTEGER:
+            if (x instanceof Integer) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof Number) {
+                setObject(parameterIndex, ((Number) x).intValue());
+            } else if (x instanceof String) {
+                setObject(parameterIndex, Integer.parseInt((String) x));
+            } else if (x instanceof Boolean) {
+                setObject(parameterIndex, (int) (((Boolean) x) ? 1 : 0));
+            } else {
+                throw new SQLException("Can't convert value to int " + x.getClass().toString());
+            }
+            break;
+        case Types.BIGINT:
+            if (x instanceof Long) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof Number) {
+                setObject(parameterIndex, ((Number) x).longValue());
+            } else if (x instanceof String) {
+                setObject(parameterIndex, Long.parseLong((String) x));
+            } else if (x instanceof Boolean) {
+                setObject(parameterIndex, (long) (((Boolean) x) ? 1 : 0));
+            } else {
+                throw new SQLException("Can't convert value to long " + x.getClass().toString());
+            }
+            break;
+        case Types.REAL:
+        case Types.FLOAT:
+            if (x instanceof Float) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof Number) {
+                setObject(parameterIndex, ((Number) x).floatValue());
+            } else if (x instanceof String) {
+                setObject(parameterIndex, Float.parseFloat((String) x));
+            } else if (x instanceof Boolean) {
+                setObject(parameterIndex, (float) (((Boolean) x) ? 1 : 0));
+            } else {
+                throw new SQLException("Can't convert value to float " + x.getClass().toString());
+            }
+            break;
+        case Types.DECIMAL:
+            if (x instanceof BigDecimal) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof Double) {
+                setObject(parameterIndex, new BigDecimal((Double) x));
+            } else if (x instanceof String) {
+                setObject(parameterIndex, new BigDecimal((String) x));
+            } else {
+                throw new SQLException("Can't convert value to double " + x.getClass().toString());
+            }
+            break;
+        case Types.NUMERIC:
+        case Types.DOUBLE:
+            if (x instanceof Double) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof Number) {
+                setObject(parameterIndex, ((Number) x).doubleValue());
+            } else if (x instanceof String) {
+                setObject(parameterIndex, Double.parseDouble((String) x));
+            } else if (x instanceof Boolean) {
+                setObject(parameterIndex, (double) (((Boolean) x) ? 1 : 0));
+            } else {
+                throw new SQLException("Can't convert value to double " + x.getClass().toString());
+            }
+            break;
+        case Types.CHAR:
+        case Types.LONGVARCHAR:
+        case Types.VARCHAR:
+            if (x instanceof String) {
+                setObject(parameterIndex, (String) x);
+            } else {
+                setObject(parameterIndex, x.toString());
+            }
+            break;
+        case Types.TIMESTAMP:
+        case Types.TIMESTAMP_WITH_TIMEZONE:
+            if (x instanceof Timestamp) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof LocalDateTime) {
+                setObject(parameterIndex, x);
+            } else if (x instanceof OffsetDateTime) {
+                setObject(parameterIndex, x);
+            } else {
+                throw new SQLException("Can't convert value to timestamp " + x.getClass().toString());
+            }
+            break;
+        default:
+            throw new SQLException("Unknown target type " + targetSqlType);
         }
     }
 

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -4066,8 +4066,8 @@ public class TestDuckDBJDBC {
 
                 ps1.executeBatch();
             }
-            try (PreparedStatement ps2 = conn.prepareStatement("SELECT * FROM test ORDER BY x");
-                 ResultSet rs2 = ps2.executeQuery()) {
+            try (Statement s = conn.createStatement();
+                 ResultSet rs2 = s.executeQuery("SELECT * FROM test ORDER BY x")) {
                 rs2.next();
                 assertEquals(rs2.getInt(1), rs2.getObject(1, Integer.class));
                 assertEquals(rs2.getObject(1, Integer.class), 1);

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -4092,8 +4092,8 @@ public class TestDuckDBJDBC {
             }
         }
     }
-    
-    public static test_execute_while_batch() throws Exception {
+
+    public static void test_execute_while_batch() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
             try (Statement s = conn.createStatement()) {
                 s.execute("create table test (id int)");
@@ -4106,7 +4106,7 @@ public class TestDuckDBJDBC {
             }
         }
     }
-    
+
     public static void main(String[] args) throws Exception {
         // Woo I can do reflection too, take this, JUnit!
         Method[] methods = TestDuckDBJDBC.class.getMethods();

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -4148,7 +4148,7 @@ public class TestDuckDBJDBC {
         }
     }
 
-    public static void test_prepared_statement_batch_exception() throws Exception{
+    public static void test_prepared_statement_batch_exception() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
             try (Statement s = conn.createStatement()) {
                 s.execute("CREATE TABLE test (id INT)");

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -4068,7 +4068,7 @@ public class TestDuckDBJDBC {
 
                 ps1.executeBatch();
             }
-            try (PreparedStatement ps2 = conn.prepareStatement("SELECT * FROM test");
+            try (PreparedStatement ps2 = conn.prepareStatement("SELECT * FROM test ORDER BY x");
                  ResultSet rs2 = ps2.executeQuery()) {
                 rs2.next();
                 assertEquals(rs2.getInt(1), rs2.getObject(1, Integer.class));

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -4054,8 +4054,6 @@ public class TestDuckDBJDBC {
                 s.execute("CREATE TABLE test (x INT, y INT, z INT)");
             }
             try (PreparedStatement ps1 = conn.prepareStatement("INSERT INTO test VALUES (?, ?, ?)")) {
-                LocalDateTime ldt = LocalDateTime.of(2021, 1, 18, 21, 20, 7);
-
                 ps1.setObject(1, 1);
                 ps1.setObject(2, 2);
                 ps1.setObject(3, 3);
@@ -4101,7 +4099,9 @@ public class TestDuckDBJDBC {
             try (PreparedStatement ps = conn.prepareStatement("INSERT INTO test VALUES (?)")) {
                 ps.setObject(1, 1);
                 ps.addBatch();
-                String msg = assertThrows(ps::execute, SQLException.class);
+                String msg = assertThrows(() -> {
+                    ps.execute("INSERT INTO test VALUES (1)");
+                }, SQLException.class);
                 assertTrue(msg.contains("Batched queries must be executed with executeBatch."));
             }
         }


### PR DESCRIPTION
Closes #9889 

Updates:
* Add batch write functionality with prepared statements
* Added functionality to addBatch and executeBatch methods, added check to ensure executeBatch is used once batched values are added to the prepared statement
* Add test cases for the above functionality
* Note: not sure if we need the addBatch(String sql) functionality because it appears a DuckDBPreparedStatement object cannot be created without passing in the SQL string to the constructor. Am I wrong on this?

This is my first contribution to duckdb so all advice is greatly welcomed!