### PR TITLE
Add support for specifying columns in read_parquet.

### DIFF
--- a/extension/parquet/include/parquet.json
+++ b/extension/parquet/include/parquet.json
@@ -79,6 +79,12 @@
         "name": "encryption_config",
         "type": "shared_ptr<ParquetEncryptionConfig>",
         "default": "nullptr"
+      },
+      {
+        "id": 105,
+        "name": "columns",
+        "type": "std::set<string>",
+        "default": "std::set<string>()"
       }
     ],
     "pointer_type": "none"

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include <string>
 #ifndef DUCKDB_AMALGAMATION
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/exception.hpp"
@@ -91,6 +92,7 @@ struct ParquetOptions {
 
 	MultiFileReaderOptions file_options;
 	vector<ParquetColumnDefinition> schema;
+	set<string> columns;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/extension/parquet/include/struct_column_reader.hpp
+++ b/extension/parquet/include/struct_column_reader.hpp
@@ -10,6 +10,7 @@
 
 #include "column_reader.hpp"
 #include "templated_column_reader.hpp"
+#include <set>
 
 namespace duckdb {
 
@@ -25,6 +26,8 @@ public:
 
 public:
 	ColumnReader *GetChildReader(idx_t child_idx);
+
+	void RemoveUnusedColumns(const string &prefix, std::set<string> columns);
 
 	void InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) override;
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -402,6 +402,9 @@ unique_ptr<ColumnReader> ParquetReader::CreateReader() {
 	D_ASSERT(file_meta_data->row_groups.empty() || next_file_idx == file_meta_data->row_groups[0].columns.size());
 
 	auto &root_struct_reader = ret->Cast<StructColumnReader>();
+	if (!parquet_options.columns.empty()) {
+		root_struct_reader.RemoveUnusedColumns("", parquet_options.columns);
+	}
 	// add casts if required
 	for (auto &entry : reader_data.cast_map) {
 		auto column_idx = entry.first;

--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -71,6 +71,7 @@ void ParquetOptions::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<MultiFileReaderOptions>(102, "file_options", file_options);
 	serializer.WritePropertyWithDefault<vector<ParquetColumnDefinition>>(103, "schema", schema);
 	serializer.WritePropertyWithDefault<shared_ptr<ParquetEncryptionConfig>>(104, "encryption_config", encryption_config, nullptr);
+	serializer.WritePropertyWithDefault<std::set<string>>(105, "columns", columns, std::set<string>());
 }
 
 ParquetOptions ParquetOptions::Deserialize(Deserializer &deserializer) {
@@ -80,6 +81,7 @@ ParquetOptions ParquetOptions::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadProperty<MultiFileReaderOptions>(102, "file_options", result.file_options);
 	deserializer.ReadPropertyWithDefault<vector<ParquetColumnDefinition>>(103, "schema", result.schema);
 	deserializer.ReadPropertyWithDefault<shared_ptr<ParquetEncryptionConfig>>(104, "encryption_config", result.encryption_config, nullptr);
+	deserializer.ReadPropertyWithDefault<std::set<string>>(105, "columns", result.columns, std::set<string>());
 	return result;
 }
 

--- a/test/parquet/test_parquet_columns.test
+++ b/test/parquet/test_parquet_columns.test
@@ -1,0 +1,41 @@
+# name: test/parquet/test_parquet_columns.test
+# description: Parquet reader columns parameter tests
+# group: [parquet]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+FROM read_parquet('data/parquet-testing/complex.parquet', columns=[]);
+----
+Binder Error: Parquet columns cannot be empty
+
+statement error
+FROM read_parquet('data/parquet-testing/complex.parquet', columns=['not-found']);
+----
+Invalid Input Error: column not-found not found in parquet file
+
+query II
+FROM read_parquet('data/parquet-testing/complex.parquet', columns=['stateId', 'id']);
+----
+{'idNum': 1, 'sessionNum': 1, 'sessionName': PARQUET_TEST_1, 'instanceName': PARQUET_TEST, 'smName': ParquetTestEngine}	1
+{'idNum': 1, 'sessionNum': 1, 'sessionName': PARQUET_TEST_1, 'instanceName': PARQUET_TEST, 'smName': ParquetTestEngine}	2
+
+statement error
+FROM read_parquet('data/parquet-testing/complex.parquet', columns=['stateId.not-found']);
+----
+Invalid Input Error: column stateId.not-found not found in parquet file
+
+query I
+FROM read_parquet('data/parquet-testing/complex.parquet', columns=['stateId.idNum', 'stateId.sessionNum', 'stateId.smName']);
+----
+{'idNum': 1, 'sessionNum': 1, 'smName': ParquetTestEngine}
+{'idNum': 1, 'sessionNum': 1, 'smName': ParquetTestEngine}
+
+query II
+FROM read_parquet('data/parquet-testing/complex.parquet', columns=['stateId.idNum', 'subProduct.stateId.idNum', 'subProduct.stateMeta']);
+----
+{'idNum': 1}	{'stateId': {'idNum': 1}, 'stateMeta': {'creationTime': 2021-11-04 11:26:12.894647+00, 'updateTime': 2021-11-04 11:26:12.894647+00, 'version': 1, 'deleted': false, 'completed': true}}
+{'idNum': 1}	{'stateId': {'idNum': 1}, 'stateMeta': {'creationTime': 2021-11-04 11:26:12.894647+00, 'updateTime': 2021-11-04 11:26:12.894647+00, 'version': 1, 'deleted': false, 'completed': true}}


### PR DESCRIPTION
Currently, DuckDB's projection pushdown optimization cannot work within structs. When accessing parquet files that contain structs, the entire struct will be read even if users only want some fields within it. This undoubtedly results in additional IO overhead.

PyArrow allows for specifying columns that need to be accessed when reading parquet file and then skips other columns. This pull request aims to provide similar functionality in DuckDB. Users can specify the columns they want to read through the `columns` parameter, and those unused columns will be removed when creating parquet reader.  For fields within a struct, users can specify them using the `struct_name.field_name`.

Example:
```
FROM read_parquet('data/parquet-testing/complex.parquet', columns=['stateMeta.creationTime', 'mainProduct.stateId.idNum', 'mainProduct.stateId.sessionNum']);
┌─────────────────────────────────────────────────┬───────────────────────────────────────────────────────────┐
│                    stateMeta                    │                        mainProduct                        │
│  struct(creationtime timestamp with time zone)  │ struct(stateid struct(idnum integer, sessionnum integer)) │
├─────────────────────────────────────────────────┼───────────────────────────────────────────────────────────┤
│ {'creationTime': 2021-11-04 11:26:12.894647+00} │ {'stateId': {'idNum': 1, 'sessionNum': 1}}                │
│ {'creationTime': 2021-11-04 11:26:12.894647+00} │ {'stateId': {'idNum': 1, 'sessionNum': 1}}                │
└─────────────────────────────────────────────────┴───────────────────────────────────────────────────────────┘
```