### PR TITLE
Issue#9854 Fix return_type's collation for function

### DIFF
--- a/test/issues/general/test_9854.test
+++ b/test/issues/general/test_9854.test
@@ -1,0 +1,34 @@
+# name: test/issues/general/test_9854.test
+# description: Issue 9854: Collation Issue: ORDER BY CONCAT
+# group: [general]
+
+statement ok
+create table tbl (a varchar);
+
+statement ok
+insert into tbl values ('ö'), ('o'), ('p');
+
+query I
+select a from tbl order by a collate noaccent;
+----
+ö
+o
+p
+
+query I
+select a from tbl order by concat(a, a) collate noaccent;
+----
+ö
+o
+p
+
+query I
+select a from tbl order by concat(a collate noaccent, a);
+----
+ö
+o
+p
+
+statement error
+select a from tbl order by concat(a collate noaccent, a collate nocase);
+----


### PR DESCRIPTION
If scalar function returns VARCHAR, check if collation needs to be binded. If it does, bind the corresponding collation to scalar function's return_type.