### PR TITLE
Fix array subquery

### DIFF
--- a/src/parser/transform/expression/transform_subquery.cpp
+++ b/src/parser/transform/expression/transform_subquery.cpp
@@ -55,19 +55,20 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(duckdb_libpgquery::P
 		break;
 	}
 	case duckdb_libpgquery::PG_ARRAY_SUBLINK: {
-		auto subquery_table_alias = "__subquery";
-		auto subquery_column_alias = "__arr_element";
-
 		// ARRAY expression
-		// wrap subquery into "SELECT CASE WHEN ARRAY_AGG(i) IS NULL THEN [] ELSE ARRAY_AGG(i) END FROM (...) tbl(i)"
+		// wrap subquery into
+		// "SELECT CASE WHEN ARRAY_AGG(COLUMNS(*)) IS NULL THEN [] ELSE ARRAY_AGG(COLUMNS(*)) END FROM (...) tbl"
 		auto select_node = make_uniq<SelectNode>();
 
-		// ARRAY_AGG(i)
+		// COLUMNS(*)
+		auto columns_star = make_uniq<StarExpression>();
+		columns_star->columns = true;
+
+		// ARRAY_AGG(COLUMNS(*))
 		vector<unique_ptr<ParsedExpression>> children;
-		children.push_back(
-		    make_uniq_base<ParsedExpression, ColumnRefExpression>(subquery_column_alias, subquery_table_alias));
+		children.push_back(std::move(columns_star));
 		auto aggr = make_uniq<FunctionExpression>("array_agg", std::move(children));
-		// ARRAY_AGG(i) IS NULL
+		// ARRAY_AGG(COLUMNS(*)) IS NULL
 		auto agg_is_null = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_IS_NULL, aggr->Copy());
 		// empty list
 		vector<unique_ptr<ParsedExpression>> list_children;
@@ -82,9 +83,8 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(duckdb_libpgquery::P
 
 		select_node->select_list.push_back(std::move(case_expr));
 
-		// FROM (...) tbl(i)
-		auto child_subquery = make_uniq<SubqueryRef>(std::move(subquery_expr->subquery), subquery_table_alias);
-		child_subquery->column_name_alias.emplace_back(subquery_column_alias);
+		// FROM (...) tbl
+		auto child_subquery = make_uniq<SubqueryRef>(std::move(subquery_expr->subquery));
 		select_node->from_table = std::move(child_subquery);
 
 		auto new_subquery = make_uniq<SelectStatement>();

--- a/test/sql/subquery/scalar/array_subquery.test
+++ b/test/sql/subquery/scalar/array_subquery.test
@@ -91,3 +91,8 @@ NULL	[]
 1	[1, 1]
 2	[2, 2]
 3	[3, 3]
+
+# should only allow one column in array subquery
+statement error
+select array(select 1,2)
+----


### PR DESCRIPTION
- Fix https://github.com/duckdb/duckdb/issues/10024
- ~~I added a field `strictly_alias_number_matched` to `SubqueryRef` so that we can ensure the subquery returns an expected column number. Unlike other scalar subquery, `Array` subquery is implemented in the parser transformation, so we need to pass additional information to let the check work.~~
- As suggested by @Mytherin , we use `COLUMNS(*)` to rewrite array subquery, so that we can ensure the subquery returns an expected column number.