### PR TITLE
Add support for FixedPointDeclimals v0.5

### DIFF
--- a/tools/juliapkg/Project.toml
+++ b/tools/juliapkg/Project.toml
@@ -1,7 +1,7 @@
 name = "DuckDB"
 uuid = "d2f5444f-75bc-4fdf-ac35-56f514c445e1"
 authors = ["Mark Raasveldt <mark@duckdblabs.com", "Hannes Mühleisen <hannes@duckdblabs.com>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"

--- a/tools/juliapkg/Project.toml
+++ b/tools/juliapkg/Project.toml
@@ -15,7 +15,7 @@ WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 [compat]
 DBInterface = "2.5"
 DuckDB_jll = "0.9.2"
-FixedPointDecimals = "0.4"
+FixedPointDecimals = "0.4, 0.5"
 Tables = "1.7"
 WeakRefStrings = "1.4"
 julia = "1.6"


### PR DESCRIPTION
FixedDecimals.jl recently add v0.5.* series which improves handling of overflowing arithmetic and adds `checked_*` operators. It also includes improved handling of equality in cases where the bits/precision of a decimal do not match.