### PR TITLE
Allow extension optimizers to trigger a rerun of the optimizer + bump spatial

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -57,7 +57,7 @@ duckdb_extension_load(postgres_scanner
 duckdb_extension_load(spatial
         DONT_LINK LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb_spatial.git
-        GIT_TAG a86c504d60e0f4400564c0f2d633547f39feef2c
+        GIT_TAG 5cde7a2abead24e8fc81a33e8ee321188f4df2de
         INCLUDE_DIR spatial/include
         TEST_DIR test/sql
         APPLY_PATCHES

--- a/.github/patches/extensions/spatial/optimizer-fix.patch
+++ b/.github/patches/extensions/spatial/optimizer-fix.patch
@@ -1,0 +1,22 @@
+diff --git a/spatial/src/spatial/core/optimizer_rules.cpp b/spatial/src/spatial/core/optimizer_rules.cpp
+index 837ab0f..c19584f 100644
+--- a/spatial/src/spatial/core/optimizer_rules.cpp
++++ b/spatial/src/spatial/core/optimizer_rules.cpp
+@@ -240,7 +240,7 @@ public:
+ 		}
+ 	}
+ 
+-	static void Optimize(ClientContext &context, OptimizerExtensionInfo *info, unique_ptr<LogicalOperator> &plan) {
++	static bool Optimize(ClientContext &context, OptimizerExtensionInfo *info, unique_ptr<LogicalOperator> &plan) {
+ 
+ 		TryOptimize(context, info, plan);
+ 
+@@ -248,6 +248,8 @@ public:
+ 		for (auto &child : plan->children) {
+ 			Optimize(context, info, child);
+ 		}
++
++		return false;
+ 	}
+ };
+ 

--- a/src/include/duckdb/optimizer/optimizer_extension.hpp
+++ b/src/include/duckdb/optimizer/optimizer_extension.hpp
@@ -19,13 +19,13 @@ struct OptimizerExtensionInfo {
 	}
 };
 
-typedef void (*optimize_function_t)(ClientContext &context, OptimizerExtensionInfo *info,
+// Returns true if the optimizer should run again after the extension optimization has been applied
+typedef bool (*optimize_function_t)(ClientContext &context, OptimizerExtensionInfo *info,
                                     unique_ptr<LogicalOperator> &plan);
 
 class OptimizerExtension {
 public:
-	//! The parse function of the parser extension.
-	//! Takes a query string as input and returns ParserExtensionParseData (on success) or an error
+	//! The optimize function of the parser extension.
 	optimize_function_t optimize_function;
 
 	//! Additional parser info passed to the parse function

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -87,117 +87,125 @@ unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan
 	}
 
 	this->plan = std::move(plan_p);
-	// first we perform expression rewrites using the ExpressionRewriter
-	// this does not change the logical plan structure, but only simplifies the expression trees
-	RunOptimizer(OptimizerType::EXPRESSION_REWRITER, [&]() { rewriter.VisitOperator(*plan); });
 
-	// perform filter pullup
-	RunOptimizer(OptimizerType::FILTER_PULLUP, [&]() {
-		FilterPullup filter_pullup;
-		plan = filter_pullup.Rewrite(std::move(plan));
-	});
+	bool run_optimizer = true;
+	while (run_optimizer) {
+		run_optimizer = false;
 
-	// perform filter pushdown
-	RunOptimizer(OptimizerType::FILTER_PUSHDOWN, [&]() {
-		FilterPushdown filter_pushdown(*this);
-		plan = filter_pushdown.Rewrite(std::move(plan));
-	});
+		// first we perform expression rewrites using the ExpressionRewriter
+		// this does not change the logical plan structure, but only simplifies the expression trees
+		RunOptimizer(OptimizerType::EXPRESSION_REWRITER, [&]() { rewriter.VisitOperator(*plan); });
 
-	RunOptimizer(OptimizerType::REGEX_RANGE, [&]() {
-		RegexRangeFilter regex_opt;
-		plan = regex_opt.Rewrite(std::move(plan));
-	});
-
-	RunOptimizer(OptimizerType::IN_CLAUSE, [&]() {
-		InClauseRewriter ic_rewriter(context, *this);
-		plan = ic_rewriter.Rewrite(std::move(plan));
-	});
-
-	// removes any redundant DelimGets/DelimJoins
-	RunOptimizer(OptimizerType::DELIMINATOR, [&]() {
-		Deliminator deliminator;
-		plan = deliminator.Optimize(std::move(plan));
-	});
-
-	// then we perform the join ordering optimization
-	// this also rewrites cross products + filters into joins and performs filter pushdowns
-	RunOptimizer(OptimizerType::JOIN_ORDER, [&]() {
-		JoinOrderOptimizer optimizer(context);
-		plan = optimizer.Optimize(std::move(plan));
-	});
-
-	// rewrites UNNESTs in DelimJoins by moving them to the projection
-	RunOptimizer(OptimizerType::UNNEST_REWRITER, [&]() {
-		UnnestRewriter unnest_rewriter;
-		plan = unnest_rewriter.Optimize(std::move(plan));
-	});
-
-	// removes unused columns
-	RunOptimizer(OptimizerType::UNUSED_COLUMNS, [&]() {
-		RemoveUnusedColumns unused(binder, context, true);
-		unused.VisitOperator(*plan);
-	});
-
-	// Remove duplicate groups from aggregates
-	RunOptimizer(OptimizerType::DUPLICATE_GROUPS, [&]() {
-		RemoveDuplicateGroups remove;
-		remove.VisitOperator(*plan);
-	});
-
-	// then we extract common subexpressions inside the different operators
-	RunOptimizer(OptimizerType::COMMON_SUBEXPRESSIONS, [&]() {
-		CommonSubExpressionOptimizer cse_optimizer(binder);
-		cse_optimizer.VisitOperator(*plan);
-	});
-
-	// creates projection maps so unused columns are projected out early
-	RunOptimizer(OptimizerType::COLUMN_LIFETIME, [&]() {
-		ColumnLifetimeAnalyzer column_lifetime(true);
-		column_lifetime.VisitOperator(*plan);
-	});
-
-	// perform statistics propagation
-	column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
-	RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
-		StatisticsPropagator propagator(*this);
-		propagator.PropagateStatistics(plan);
-		statistics_map = propagator.GetStatisticsMap();
-	});
-
-	// remove duplicate aggregates
-	RunOptimizer(OptimizerType::COMMON_AGGREGATE, [&]() {
-		CommonAggregateOptimizer common_aggregate;
-		common_aggregate.VisitOperator(*plan);
-	});
-
-	// creates projection maps so unused columns are projected out early
-	RunOptimizer(OptimizerType::COLUMN_LIFETIME, [&]() {
-		ColumnLifetimeAnalyzer column_lifetime(true);
-		column_lifetime.VisitOperator(*plan);
-	});
-
-	// compress data based on statistics for materializing operators
-	RunOptimizer(OptimizerType::COMPRESSED_MATERIALIZATION, [&]() {
-		CompressedMaterialization compressed_materialization(context, binder, std::move(statistics_map));
-		compressed_materialization.Compress(plan);
-	});
-
-	// transform ORDER BY + LIMIT to TopN
-	RunOptimizer(OptimizerType::TOP_N, [&]() {
-		TopN topn;
-		plan = topn.Optimize(std::move(plan));
-	});
-
-	// apply simple expression heuristics to get an initial reordering
-	RunOptimizer(OptimizerType::REORDER_FILTER, [&]() {
-		ExpressionHeuristics expression_heuristics(*this);
-		plan = expression_heuristics.Rewrite(std::move(plan));
-	});
-
-	for (auto &optimizer_extension : DBConfig::GetConfig(context).optimizer_extensions) {
-		RunOptimizer(OptimizerType::EXTENSION, [&]() {
-			optimizer_extension.optimize_function(context, optimizer_extension.optimizer_info.get(), plan);
+		// perform filter pullup
+		RunOptimizer(OptimizerType::FILTER_PULLUP, [&]() {
+			FilterPullup filter_pullup;
+			plan = filter_pullup.Rewrite(std::move(plan));
 		});
+
+		// perform filter pushdown
+		RunOptimizer(OptimizerType::FILTER_PUSHDOWN, [&]() {
+			FilterPushdown filter_pushdown(*this);
+			plan = filter_pushdown.Rewrite(std::move(plan));
+		});
+
+		RunOptimizer(OptimizerType::REGEX_RANGE, [&]() {
+			RegexRangeFilter regex_opt;
+			plan = regex_opt.Rewrite(std::move(plan));
+		});
+
+		RunOptimizer(OptimizerType::IN_CLAUSE, [&]() {
+			InClauseRewriter ic_rewriter(context, *this);
+			plan = ic_rewriter.Rewrite(std::move(plan));
+		});
+
+		// removes any redundant DelimGets/DelimJoins
+		RunOptimizer(OptimizerType::DELIMINATOR, [&]() {
+			Deliminator deliminator;
+			plan = deliminator.Optimize(std::move(plan));
+		});
+
+		// then we perform the join ordering optimization
+		// this also rewrites cross products + filters into joins and performs filter pushdowns
+		RunOptimizer(OptimizerType::JOIN_ORDER, [&]() {
+			JoinOrderOptimizer optimizer(context);
+			plan = optimizer.Optimize(std::move(plan));
+		});
+
+		// rewrites UNNESTs in DelimJoins by moving them to the projection
+		RunOptimizer(OptimizerType::UNNEST_REWRITER, [&]() {
+			UnnestRewriter unnest_rewriter;
+			plan = unnest_rewriter.Optimize(std::move(plan));
+		});
+
+		// removes unused columns
+		RunOptimizer(OptimizerType::UNUSED_COLUMNS, [&]() {
+			RemoveUnusedColumns unused(binder, context, true);
+			unused.VisitOperator(*plan);
+		});
+
+		// Remove duplicate groups from aggregates
+		RunOptimizer(OptimizerType::DUPLICATE_GROUPS, [&]() {
+			RemoveDuplicateGroups remove;
+			remove.VisitOperator(*plan);
+		});
+
+		// then we extract common subexpressions inside the different operators
+		RunOptimizer(OptimizerType::COMMON_SUBEXPRESSIONS, [&]() {
+			CommonSubExpressionOptimizer cse_optimizer(binder);
+			cse_optimizer.VisitOperator(*plan);
+		});
+
+		// creates projection maps so unused columns are projected out early
+		RunOptimizer(OptimizerType::COLUMN_LIFETIME, [&]() {
+			ColumnLifetimeAnalyzer column_lifetime(true);
+			column_lifetime.VisitOperator(*plan);
+		});
+
+		// perform statistics propagation
+		column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map;
+		RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
+			StatisticsPropagator propagator(*this);
+			propagator.PropagateStatistics(plan);
+			statistics_map = propagator.GetStatisticsMap();
+		});
+
+		// remove duplicate aggregates
+		RunOptimizer(OptimizerType::COMMON_AGGREGATE, [&]() {
+			CommonAggregateOptimizer common_aggregate;
+			common_aggregate.VisitOperator(*plan);
+		});
+
+		// creates projection maps so unused columns are projected out early
+		RunOptimizer(OptimizerType::COLUMN_LIFETIME, [&]() {
+			ColumnLifetimeAnalyzer column_lifetime(true);
+			column_lifetime.VisitOperator(*plan);
+		});
+
+		// compress data based on statistics for materializing operators
+		RunOptimizer(OptimizerType::COMPRESSED_MATERIALIZATION, [&]() {
+			CompressedMaterialization compressed_materialization(context, binder, std::move(statistics_map));
+			compressed_materialization.Compress(plan);
+		});
+
+		// transform ORDER BY + LIMIT to TopN
+		RunOptimizer(OptimizerType::TOP_N, [&]() {
+			TopN topn;
+			plan = topn.Optimize(std::move(plan));
+		});
+
+		// apply simple expression heuristics to get an initial reordering
+		RunOptimizer(OptimizerType::REORDER_FILTER, [&]() {
+			ExpressionHeuristics expression_heuristics(*this);
+			plan = expression_heuristics.Rewrite(std::move(plan));
+		});
+
+		for (auto &optimizer_extension : DBConfig::GetConfig(context).optimizer_extensions) {
+			RunOptimizer(OptimizerType::EXTENSION, [&]() {
+				// if any of the optimizer extensions requested a rerun of the optimizer, we set the flag here
+				run_optimizer = run_optimizer || optimizer_extension.optimize_function(
+				                                     context, optimizer_extension.optimizer_info.get(), plan);
+			});
+		}
 	}
 
 	Planner::VerifyPlan(context, plan);

--- a/test/extension/loadable_extension_optimizer_demo.cpp
+++ b/test/extension/loadable_extension_optimizer_demo.cpp
@@ -68,10 +68,11 @@ public:
 		}
 	}
 
-	static void WaggleOptimizeFunction(ClientContext &context, OptimizerExtensionInfo *info,
+	static bool WaggleOptimizeFunction(ClientContext &context, OptimizerExtensionInfo *info,
 	                                   duckdb::unique_ptr<LogicalOperator> &plan) {
+
 		if (!HasParquetScan(*plan)) {
-			return;
+			return false;
 		}
 		// rpc
 
@@ -142,6 +143,8 @@ public:
 		WriteChecked(sockfd, &len, sizeof(idx_t));
 		// close the socket
 		close(sockfd);
+
+		return false;
 	}
 };
 


### PR DESCRIPTION
This PR makes the `OptimizerExtensions` `optimize_function` handler return a boolean signaling whether or not to rerun all the optimizer steps after the extension optimizer has been applied. This is useful in scenarios where the optimizer extension significantly rewrites the logical plan so that new opportunities for e.g. column removal or predicate pushdown arise.

Also patches and bumps the spatial extension to the newest version.