### PR TITLE
Update database_size.hpp

### DIFF
--- a/src/include/duckdb/storage/database_size.hpp
+++ b/src/include/duckdb/storage/database_size.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/storage/storage_info.hpp"
 
 namespace duckdb {
 


### PR DESCRIPTION
database_size.hpp is missing import for `block_id_t` which it uses. To account for this `database_size.hpp`  should import `storage_info.hpp` to get [the definition](https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/storage/storage_info.hpp#L51C1-L52C1)