### PR TITLE
Call InitialCleanup in PendingQuery(SQLStatement)

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -880,6 +880,15 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query, 
 unique_ptr<PendingQueryResult> ClientContext::PendingQuery(unique_ptr<SQLStatement> statement,
                                                            bool allow_stream_result) {
 	auto lock = LockContext();
+
+	try {
+		InitialCleanup(*lock);
+	} catch (const Exception &ex) {
+		return make_uniq<PendingQueryResult>(PreservedError(ex));
+	} catch (std::exception &ex) {
+		return make_uniq<PendingQueryResult>(PreservedError(ex));
+	}
+
 	PendingQueryParameters parameters;
 	parameters.allow_stream_result = allow_stream_result;
 	return PendingQueryInternal(*lock, std::move(statement), parameters);


### PR DESCRIPTION
The method `unique_ptr<PendingQueryResult> PendingQuery(unique_ptr<SQLStatement> statement, bool allow_stream_result)` was not cleaning up the state from the previous query. This trips the first assertion in `BeginTransactionInternal` if there is still an active query.