### PR TITLE
Not including stdlib for just size_t, stddef is smaller header

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -55,7 +55,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This updates duckdb.h and is hence a somewhat dicey change because it might break user code by reducing the included stuff