### PR TITLE
CI: Add backlink to original issue when its status changes

### DIFF
--- a/.github/workflows/InternalIssuesUpdateMirror.yml
+++ b/.github/workflows/InternalIssuesUpdateMirror.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Add comment with status to mirror issue
         run: |
           if [ "$MIRROR_ISSUE_NUMBER" != "" ]; then
-            gh issue comment --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --body "The issue has been ${{ github.event.action }}."
+            gh issue comment --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --body "The issue has been ${{ github.event.action }} (https://github.com/duckdb/duckdb/issues/${{ github.event.issue.number }})."
           fi
 
       - name: Add closed label to mirror issue


### PR DESCRIPTION
This change makes navigating from mirrored internal issues back to the public issue tracker slightly more convenient.