### PR TITLE
Add try_decode() blob function.

### DIFF
--- a/src/core_functions/function_list.cpp
+++ b/src/core_functions/function_list.cpp
@@ -357,6 +357,7 @@ static StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_SCALAR_FUNCTION(TranslateFun),
 	DUCKDB_SCALAR_FUNCTION_SET(TrimFun),
 	DUCKDB_SCALAR_FUNCTION_SET(TruncFun),
+	DUCKDB_SCALAR_FUNCTION(TryDecodeFun),
 	DUCKDB_SCALAR_FUNCTION_SET(TryStrpTimeFun),
 	DUCKDB_SCALAR_FUNCTION(CurrentTransactionIdFun),
 	DUCKDB_SCALAR_FUNCTION(TypeOfFun),

--- a/src/core_functions/scalar/blob/functions.json
+++ b/src/core_functions/scalar/blob/functions.json
@@ -7,6 +7,13 @@
         "type": "scalar_function"
     },
     {
+        "name": "try_decode",
+        "parameters": "blob",
+        "description": "Convert blob to varchar. Return NULL if blob is not valid utf-8",
+        "example": "try_decode('\\xC3\\xBC'::BLOB)",
+        "type": "scalar_function"
+    },
+    {
         "name": "encode",
         "parameters": "string",
         "description": "Convert varchar to blob. Converts utf-8 characters into literal encoding",

--- a/src/include/duckdb/core_functions/scalar/blob_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/blob_functions.hpp
@@ -24,6 +24,15 @@ struct DecodeFun {
 	static ScalarFunction GetFunction();
 };
 
+struct TryDecodeFun {
+	static constexpr const char *Name = "try_decode";
+	static constexpr const char *Parameters = "blob";
+	static constexpr const char *Description = "Convert blob to varchar. Return NULL if blob is not valid utf-8";
+	static constexpr const char *Example = "try_decode('\\xC3\\xBC'::BLOB)";
+
+	static ScalarFunction GetFunction();
+};
+
 struct EncodeFun {
 	static constexpr const char *Name = "encode";
 	static constexpr const char *Parameters = "string";

--- a/test/sql/function/blob/encode.test
+++ b/test/sql/function/blob/encode.test
@@ -17,7 +17,17 @@ SELECT decode(encode('ü'))
 ü
 
 query I
+SELECT try_decode(encode('ü'))
+----
+ü
+
+query I
 SELECT decode('\xF0\x9F\xA6\x86'::BLOB)
+----
+🦆
+
+query I
+SELECT try_decode('\xF0\x9F\xA6\x86'::BLOB)
 ----
 🦆
 
@@ -27,10 +37,20 @@ SELECT decode('\x00'::BLOB)
 ----
 \0
 
+query I
+SELECT try_decode('\x00'::BLOB)
+----
+\0
+
 # test invalid decodes
 statement error
 SELECT decode('\xFF'::BLOB)
 ----
+
+query I
+SELECT try_decode('\xFF'::BLOB)
+----
+NULL
 
 query I
 SELECT decode(encode(a)) || a from (values ('hello'), ('world')) tbl(a);


### PR DESCRIPTION
This PR adds a `try_decode` method for converting `blob` into `varchar`. When `blob` is not a valid UTF-8 string, `try_decode` method returns null instead of throwing error. Users can use `try_decode` method to filter out and process UTF-8 strings in the input data, ignoring the rest.