### PR TITLE
Streamline handling issues that come with PRs fixing them

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -14,12 +14,12 @@ jobs:
     if: github.event.label.name == 'reproduced' || github.event.label.name == 'under review'
     runs-on: ubuntu-latest
     steps:
-      - name: Remove needs triage / under review if reproduced
+      - name: Remove 'needs triage' / 'under review' if 'reproduced'
         if: github.event.label.name == 'reproduced'
         run: |
           gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number }} --remove-label "needs triage" --remove-label "under review"
 
-      - name: Remove needs triage / reproduced if under review
+      - name: Remove 'needs triage' / 'reproduced' if 'under review'
         if: github.event.label.name == 'under review'
         run: |
           gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number }} --remove-label "needs triage" --remove-label "reproduced"

--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -24,6 +24,11 @@ jobs:
         run: |
           gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number }} --remove-label "needs triage" --remove-label "reproduced"
 
+      - name: Remove 'needs triage' if 'PR submitted'
+        if: github.event.label.name == 'PR submitted'
+        run: |
+          gh issue edit --repo duckdb/duckdb ${{ github.event.issue.number }} --remove-label "needs triage"
+
       - name: Get mirror issue number
         run: |
           gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt


### PR DESCRIPTION
Sometimes an issue is immediately followed up by a PR that fixes it, see e.g. #10112 and #10113. For these cases, I added a new label called "PR submitted". Applying this label should remove the "needs triage" label.

This PR implements the logic for the bot.