### PR TITLE
Display unnamed structs as tuples instead of as structs with empty keys

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -370,10 +370,15 @@ string LogicalType::ToString() const {
 		if (!type_info_) {
 			return "STRUCT";
 		}
+		auto is_unnamed = StructType::IsUnnamed(*this);
 		auto &child_types = StructType::GetChildTypes(*this);
 		string ret = "STRUCT(";
 		for (size_t i = 0; i < child_types.size(); i++) {
-			ret += StringUtil::Format("%s %s", SQLIdentifier(child_types[i].first), child_types[i].second);
+			if (is_unnamed) {
+				ret += child_types[i].second.ToString();
+			} else {
+				ret += StringUtil::Format("%s %s", SQLIdentifier(child_types[i].first), child_types[i].second);
+			}
 			if (i < child_types.size() - 1) {
 				ret += ", ";
 			}
@@ -1206,7 +1211,9 @@ idx_t StructType::GetChildCount(const LogicalType &type) {
 }
 bool StructType::IsUnnamed(const LogicalType &type) {
 	auto &child_types = StructType::GetChildTypes(type);
-	D_ASSERT(child_types.size() > 0);
+	if (child_types.empty()) {
+		return false;
+	}
 	return child_types[0].first.empty();
 }
 

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1432,18 +1432,23 @@ string Value::ToSQLString() const {
 	case LogicalTypeId::ENUM:
 		return "'" + StringUtil::Replace(ToString(), "'", "''") + "'";
 	case LogicalTypeId::STRUCT: {
-		string ret = "{";
+		bool is_unnamed = StructType::IsUnnamed(type_);
+		string ret = is_unnamed ? "(" : "{";
 		auto &child_types = StructType::GetChildTypes(type_);
 		auto &struct_values = StructValue::GetChildren(*this);
 		for (idx_t i = 0; i < struct_values.size(); i++) {
 			auto &name = child_types[i].first;
 			auto &child = struct_values[i];
-			ret += "'" + name + "': " + child.ToSQLString();
+			if (is_unnamed) {
+				ret += child.ToSQLString();
+			} else {
+				ret += "'" + name + "': " + child.ToSQLString();
+			}
 			if (i < struct_values.size() - 1) {
 				ret += ", ";
 			}
 		}
-		ret += "}";
+		ret += is_unnamed ? ")" : "}";
 		return ret;
 	}
 	case LogicalTypeId::FLOAT:

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -285,7 +285,7 @@ static bool FindKeyStruct(const char *buf, idx_t len, idx_t &pos) {
 }
 
 static bool FindValueStruct(const char *buf, idx_t len, idx_t &pos, Vector &varchar_child, idx_t &row_idx,
-                            ValidityMask *child_mask) {
+                            ValidityMask &child_mask) {
 	auto start_pos = pos;
 	idx_t lvl = 0;
 	while (pos < len) {
@@ -302,7 +302,7 @@ static bool FindValueStruct(const char *buf, idx_t len, idx_t &pos, Vector &varc
 			}
 			FlatVector::GetData<string_t>(varchar_child)[row_idx] =
 			    StringVector::AddString(varchar_child, buf + start_pos, end_pos - start_pos);
-			child_mask->SetValid(row_idx); // any child not set to valid will remain invalid
+			child_mask.SetValid(row_idx); // any child not set to valid will remain invalid
 			return true;
 		}
 		pos++;
@@ -312,7 +312,7 @@ static bool FindValueStruct(const char *buf, idx_t len, idx_t &pos, Vector &varc
 
 bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<Vector>> &varchar_vectors,
                                        idx_t &row_idx, string_map_t<idx_t> &child_names,
-                                       vector<ValidityMask *> &child_masks) {
+                                       vector<reference<ValidityMask>> &child_masks) {
 	const char *buf = input.GetData();
 	idx_t len = input.GetSize();
 	idx_t pos = 0;
@@ -332,6 +332,10 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 				return false;
 			}
 			auto key_end = StringTrim(buf, key_start, pos);
+			if (key_start >= key_end) {
+				// empty key name unsupported
+				return false;
+			}
 			string_t found_key(buf + key_start, key_end - key_start);
 
 			auto it = child_names.find(found_key);
@@ -340,7 +344,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 			}
 			child_idx = it->second;
 			SkipWhitespace(buf, ++pos, len);
-			if (!FindValueStruct(buf, len, pos, *varchar_vectors[child_idx], row_idx, child_masks[child_idx])) {
+			if (!FindValueStruct(buf, len, pos, *varchar_vectors[child_idx], row_idx, child_masks[child_idx].get())) {
 				return false;
 			}
 			SkipWhitespace(buf, ++pos, len);

--- a/src/include/duckdb/function/cast/vector_cast_helpers.hpp
+++ b/src/include/duckdb/function/cast/vector_cast_helpers.hpp
@@ -214,7 +214,7 @@ struct VectorStringToArray {
 
 struct VectorStringToStruct {
 	static bool SplitStruct(const string_t &input, vector<unique_ptr<Vector>> &varchar_vectors, idx_t &row_idx,
-	                        string_map_t<idx_t> &child_names, vector<ValidityMask *> &child_masks);
+	                        string_map_t<idx_t> &child_names, vector<reference<ValidityMask>> &child_masks);
 	static bool StringToNestedTypeCastLoop(const string_t *source_data, ValidityMask &source_mask, Vector &result,
 	                                       ValidityMask &result_mask, idx_t count, CastParameters &parameters,
 	                                       const SelectionVector *sel);

--- a/test/common/test_cast_struct.test
+++ b/test/common/test_cast_struct.test
@@ -91,7 +91,7 @@ select struct_pack(a1 =>'42'::double, a2 => 'asdf'::string)::struct(a1 integer, 
 query I
 select ROW(42, 'asdf');
 ----
-{'': 42, '': asdf}
+(42, asdf)
 
 statement error
 select ROW();
@@ -101,12 +101,12 @@ Can't pack nothing into a struct
 query I
 select ROW(NULL);
 ----
-{'': NULL}
+(NULL)
 
 query I
 select ROW(NULL, NULL);
 ----
-{'': NULL, '': NULL}
+(NULL, NULL)
 
 # MB example
 query I

--- a/test/fuzzer/pedro/aggregate_assertion_errors.test
+++ b/test/fuzzer/pedro/aggregate_assertion_errors.test
@@ -31,4 +31,4 @@ SELECT count(c0 ORDER BY 0) FROM (SELECT 2 EXCEPT SELECT 2) c0;
 query I
 SELECT mode((c0, 0)) FROM (SELECT 1 c0), (SELECT 2);
 ----
-{'': 1, '': 0}
+(1, 0)

--- a/test/sql/prepared/test_prepare_ambiguous_type.test
+++ b/test/sql/prepared/test_prepare_ambiguous_type.test
@@ -178,7 +178,7 @@ PREPARE v11 AS SELECT ROW(?, ?)
 query I
 EXECUTE v11(11, 'hello')
 ----
-{'': 11, '': hello}
+(11, hello)
 
 statement ok
 PREPARE v12 AS SELECT ? IS NULL

--- a/test/sql/subquery/scalar/test_issue_6136.test
+++ b/test/sql/subquery/scalar/test_issue_6136.test
@@ -39,10 +39,10 @@ select
 from b
 ORDER BY 1, 2, 3;
 ----
-1	1	1	{'': a, '': A, '': 1}	{'': a, '': A, '': 3}
-2	1	2	{'': c, '': C, '': 1}	{'': a, '': A, '': 3}
-3	1	3	{'': NULL, '': NULL, '': 0}	{'': a, '': A, '': 3}
-4	1	NULL	{'': NULL, '': NULL, '': 0}	{'': a, '': A, '': 3}
-5	2	1	{'': NULL, '': NULL, '': 0}	{'': d, '': D, '': 1}
-6	2	NULL	{'': NULL, '': NULL, '': 0}	{'': d, '': D, '': 1}
-7	99	99	{'': NULL, '': NULL, '': 0}	{'': NULL, '': NULL, '': 0}
+1	1	1	(a, A, 1)	(a, A, 3)
+2	1	2	(c, C, 1)	(a, A, 3)
+3	1	3	(NULL, NULL, 0)	(a, A, 3)
+4	1	NULL	(NULL, NULL, 0)	(a, A, 3)
+5	2	1	(NULL, NULL, 0)	(d, D, 1)
+6	2	NULL	(NULL, NULL, 0)	(d, D, 1)
+7	99	99	(NULL, NULL, 0)	(NULL, NULL, 0)

--- a/test/sql/types/struct/unnamed_struct_casts.test
+++ b/test/sql/types/struct/unnamed_struct_casts.test
@@ -1,0 +1,16 @@
+# name: test/sql/types/struct/unnamed_struct_casts.test
+# description: Test unnamed struct casts
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+select row(42, 'hello') union all select '{'': 42,'': hello}';
+----
+Conversion Error
+
+statement error
+select row(42, 'hello') union all select '(84, world)';
+----
+unsupported


### PR DESCRIPTION
This PR modifies unnamed structs so that they are displayed as tuples similar to how Postgres displays record types. This makes DuckDB match Postgres in this regard and makes the display of the result of this function more clear for users, for example:

```sql
select row(42, 'hello') AS r;
┌──────────────────────────┐
│            r             │
│ struct(integer, varchar) │
├──────────────────────────┤
│ (42, hello)              │
└──────────────────────────┘
```

Previous behavior was to display it as a struct with empty keys, which is somewhat confusing to users:

```sql
D select row(42, 'hello') AS r;
┌────────────────────────────┐
│             r              │
│ struct( integer,  varchar) │
├────────────────────────────┤
│ {'': 42, '': hello}        │
└────────────────────────────┘
```

Bonus points are that this string representation also round-trips in SQL, e.g.:

```sql
D SELECT (42, 84) AS r;
┌──────────────────────────┐
│            r             │
│ struct(integer, integer) │
├──────────────────────────┤
│ (42, 84)                 │
└──────────────────────────┘
```

