### PR TITLE
CI: Add workflow to check new issues for code formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,7 @@ body:
   - type: textarea
     attributes:
       label: To Reproduce
-      description: Steps to reproduce the behavior. Please paste the code and the output as text, and avoid using screenshots. Please add the required imports for Python scripts (e.g., import duckdb). Bonus points if the steps only include SQL queries.
+      description: Steps to reproduce the behavior. Please paste the code and the output as text, and avoid using screenshots. Please use [code blocks](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks) for formatting and add the required imports for Python scripts (e.g., import duckdb). Bonus points if the steps only include SQL queries.
     validations:
       required: true
 

--- a/.github/workflows/CheckIssueForCodeFormatting.yml
+++ b/.github/workflows/CheckIssueForCodeFormatting.yml
@@ -1,0 +1,25 @@
+name: Check Issue for Code Formatting
+on:
+  issues:
+    types:
+      - opened
+
+env:
+  GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
+
+jobs:
+  check_code_formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Check issue for code formatting
+        run: |
+          if ! echo "${{ github.event.issue.body }}" | python3 scripts/check-issue-for-code-formatting.py; then
+              gh issue comment ${{ github.event.issue.number }} --body-file .github/workflows/code-formatting-warning.md
+          fi

--- a/.github/workflows/code-formatting-warning.md
+++ b/.github/workflows/code-formatting-warning.md
@@ -1,0 +1,9 @@
+Thanks for opening this issue! Based on our automated check, it seems that your post contains some code but it does not use [code blocks](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks) to format it.
+          
+Please double-check your post and revise it if necessary. To employ syntax highlighting, it's recommended to use code blocks with triple backticks, e.g.:
+````
+```sql
+SELECT ...
+```
+````
+If this is a false positive, feel free to disregard this comment.

--- a/scripts/check-issue-for-code-formatting.py
+++ b/scripts/check-issue-for-code-formatting.py
@@ -1,0 +1,33 @@
+import re
+import sys
+
+post_text = sys.stdin.read()
+
+sql_keyword_list = ["select", "from", "where", "join", "group by", "order by", "having", "with recursive", "union"]
+sql_keyword_regex = f"({'|'.join(sql_keyword_list)})"
+
+sql_keywords = len(re.findall(rf"{sql_keyword_regex}", post_text, flags=re.MULTILINE | re.IGNORECASE))
+
+backticked_code_blocks = len(re.findall(r"^```", post_text))
+
+indented_sql_code_lines = len(re.findall(r"^{sql_keyword_regex}", post_text, flags=re.MULTILINE | re.IGNORECASE))
+indented_python_code_lines = len(re.findall(r"^    (import|duckdb)", post_text, flags=re.MULTILINE | re.IGNORECASE))
+indented_r_code_lines = len(re.findall(r"^    (library|dbExecute)", post_text, flags=re.MULTILINE | re.IGNORECASE))
+indented_hashbang_code_lines = len(re.findall(r"^    #!", post_text, flags=re.MULTILINE | re.IGNORECASE))
+
+indented_code_lines = indented_sql_code_lines + indented_python_code_lines + indented_r_code_lines
+inline_code_snippets = len(re.findall(r"`", post_text)) // 2
+
+print("Metrics computed by 'check-issue-for-code-formatting.py':")
+print(f"- {sql_keywords} SQL keyword(s)")
+print(f"- {backticked_code_blocks} backticked code block(s)")
+print(
+    f"- {indented_code_lines} indented code line(s): {indented_sql_code_lines} SQL, {indented_python_code_lines} Python, {indented_r_code_lines} R, {indented_hashbang_code_lines} hashbangs"
+)
+print(f"- {inline_code_snippets} inline code snippet(s)")
+
+if sql_keywords > 2 and backticked_code_blocks == 0 and indented_code_lines == 0 and inline_code_snippets == 0:
+    print("The post is likely not properly formatted.")
+    exit(1)
+else:
+    print("The post is likely properly formatted.")


### PR DESCRIPTION
On occasion, users open issues which contain some code (e.g., SQL or Python) but the code is not formatted properly, making it difficult to read. I usually format this manually by editing the posts but this can be tedious.

I propose to add a feature to our GitHub Actions workflow, which reads the post, detects if it lacks formatting and submits a comment asking the user for format the code if necessary.

The current detection threshold is very conservative: it requires the post to have SQL keywords (`SELECT`, `FROM`, `WHERE`) and _zero_ code formatting. So if there's a single inline code snippet or a code block, it does not send a warning.

I tested this under my own account, which resulted in the following:

<img width="1159" alt="Screenshot 2024-01-05 at 16 04 42" src="https://github.com/duckdb/duckdb/assets/1402801/8acfc29d-389d-4f92-9e43-a79fc14e054e">
