### PR TITLE
JSON S3 optimization

### DIFF
--- a/extension/json/buffered_json_reader.cpp
+++ b/extension/json/buffered_json_reader.cpp
@@ -74,12 +74,12 @@ idx_t JSONFileHandle::GetPositionAndSize(idx_t &position, idx_t requested_size) 
 void JSONFileHandle::ReadAtPosition(char *pointer, idx_t size, idx_t position, bool sample_run,
                                     optional_ptr<FileHandle> override_handle) {
 	D_ASSERT(size != 0);
-	auto handle = override_handle ? override_handle.get() : file_handle.get();
+	auto &handle = override_handle ? *override_handle.get() : *file_handle.get();
 
 	if (can_seek) {
-		handle->Read(pointer, size, position);
+		handle.Read(pointer, size, position);
 	} else if (sample_run) { // Cache the buffer
-		handle->Read(pointer, size, position);
+		handle.Read(pointer, size, position);
 
 		cached_buffers.emplace_back(allocator.Allocate(size));
 		memcpy(cached_buffers.back().get(), pointer, size);
@@ -90,7 +90,7 @@ void JSONFileHandle::ReadAtPosition(char *pointer, idx_t size, idx_t position, b
 		}
 
 		if (size != 0) {
-			handle->Read(pointer, size, position);
+			handle.Read(pointer, size, position);
 		}
 	}
 	if (++actual_reads > requested_reads) {

--- a/extension/json/buffered_json_reader.cpp
+++ b/extension/json/buffered_json_reader.cpp
@@ -14,8 +14,7 @@ JSONBufferHandle::JSONBufferHandle(idx_t buffer_index_p, idx_t readers_p, Alloca
 
 JSONFileHandle::JSONFileHandle(unique_ptr<FileHandle> file_handle_p, Allocator &allocator_p)
     : file_handle(std::move(file_handle_p)), allocator(allocator_p), can_seek(file_handle->CanSeek()),
-      plain_file_source(file_handle->OnDiskFile() && can_seek), file_size(file_handle->GetFileSize()), read_position(0),
-      requested_reads(0), actual_reads(0), cached_size(0) {
+      file_size(file_handle->GetFileSize()), read_position(0), requested_reads(0), actual_reads(0), cached_size(0) {
 }
 
 bool JSONFileHandle::IsOpen() const {
@@ -55,6 +54,10 @@ bool JSONFileHandle::CanSeek() const {
 	return can_seek;
 }
 
+FileHandle &JSONFileHandle::GetHandle() {
+	return *file_handle;
+}
+
 idx_t JSONFileHandle::GetPositionAndSize(idx_t &position, idx_t requested_size) {
 	D_ASSERT(requested_size != 0);
 
@@ -68,12 +71,15 @@ idx_t JSONFileHandle::GetPositionAndSize(idx_t &position, idx_t requested_size) 
 	return actual_size;
 }
 
-void JSONFileHandle::ReadAtPosition(char *pointer, idx_t size, idx_t position, bool sample_run) {
+void JSONFileHandle::ReadAtPosition(char *pointer, idx_t size, idx_t position, bool sample_run,
+                                    optional_ptr<FileHandle> override_handle) {
 	D_ASSERT(size != 0);
-	if (plain_file_source) {
-		file_handle->Read(pointer, size, position);
+	auto handle = override_handle ? override_handle.get() : file_handle.get();
+
+	if (can_seek) {
+		handle->Read(pointer, size, position);
 	} else if (sample_run) { // Cache the buffer
-		file_handle->Read(pointer, size, position);
+		handle->Read(pointer, size, position);
 
 		cached_buffers.emplace_back(allocator.Allocate(size));
 		memcpy(cached_buffers.back().get(), pointer, size);
@@ -84,7 +90,7 @@ void JSONFileHandle::ReadAtPosition(char *pointer, idx_t size, idx_t position, b
 		}
 
 		if (size != 0) {
-			file_handle->Read(pointer, size, position);
+			handle->Read(pointer, size, position);
 		}
 	}
 	if (++actual_reads > requested_reads) {
@@ -94,7 +100,7 @@ void JSONFileHandle::ReadAtPosition(char *pointer, idx_t size, idx_t position, b
 
 idx_t JSONFileHandle::Read(char *pointer, idx_t requested_size, bool sample_run) {
 	D_ASSERT(requested_size != 0);
-	if (plain_file_source) {
+	if (can_seek) {
 		auto actual_size = ReadInternal(pointer, requested_size);
 		read_position += actual_size;
 		return actual_size;

--- a/extension/json/include/buffered_json_reader.hpp
+++ b/extension/json/include/buffered_json_reader.hpp
@@ -66,9 +66,13 @@ public:
 
 	bool CanSeek() const;
 
+	FileHandle &GetHandle();
+
 	idx_t GetPositionAndSize(idx_t &position, idx_t requested_size);
-	void ReadAtPosition(char *pointer, idx_t size, idx_t position, bool sample_run);
 	idx_t Read(char *pointer, idx_t requested_size, bool sample_run);
+	//! Read at position optionally allows passing a custom handle to read from, otherwise the default one is used
+	void ReadAtPosition(char *pointer, idx_t size, idx_t position, bool sample_run,
+	                    optional_ptr<FileHandle> override_handle = nullptr);
 
 private:
 	idx_t ReadInternal(char *pointer, const idx_t requested_size);
@@ -81,7 +85,6 @@ private:
 
 	//! File properties
 	const bool can_seek;
-	const bool plain_file_source;
 	const idx_t file_size;
 
 	//! Read properties

--- a/extension/json/include/json_scan.hpp
+++ b/extension/json/include/json_scan.hpp
@@ -250,6 +250,12 @@ private:
 	//! Whether this is the last batch of the file
 	bool is_last;
 
+	//! The current main filesystem
+	FileSystem &fs;
+
+	//! For some filesystems (e.g. S3), using a filehandle per thread increases performance
+	unique_ptr<FileHandle> thread_local_filehandle;
+
 	//! Current buffer read info
 	char *buffer_ptr;
 	idx_t buffer_size;

--- a/test/sql/copy/s3/upload_large_json_file.test_slow
+++ b/test/sql/copy/s3/upload_large_json_file.test_slow
@@ -67,3 +67,21 @@ WHERE
     AND l_quantity < 24;
 ----
 11803420.2534
+
+# This query triggers an edge case where we apply an S3-specific optimization using multiple cached filehandles
+query I
+SELECT
+    sum(l_extendedprice * l_discount)/3 AS revenue
+FROM
+    read_json_auto([
+        's3://test-bucket/multipart/export_large.json',
+        's3://test-bucket/multipart/export_large.json',
+        's3://test-bucket/multipart/export_large.json',])
+WHERE
+    l_shipdate >= CAST('1994-01-01' AS date)
+    AND l_shipdate < CAST('1995-01-01' AS date)
+    AND l_discount BETWEEN 0.05
+    AND 0.07
+    AND l_quantity < 24;
+----
+11803420.2534

--- a/test/sql/copy/s3/upload_large_json_file.test_slow
+++ b/test/sql/copy/s3/upload_large_json_file.test_slow
@@ -1,0 +1,69 @@
+# name: test/sql/copy/s3/upload_large_json_file.test_slow
+# description: Copy large json files from and to S3.
+# group: [s3]
+
+require tpch
+
+require json
+
+require parquet
+
+require httpfs
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+# Require that these environment variables are also set
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
+statement ok
+set http_timeout=120000;
+
+# More retries (longest wait will be 25600ms)
+statement ok
+set http_retries=6;
+
+statement ok
+CALL DBGEN(sf=0.1)
+
+query I
+SELECT
+    sum(l_extendedprice * l_discount) AS revenue
+FROM
+    lineitem
+WHERE
+    l_shipdate >= CAST('1994-01-01' AS date)
+    AND l_shipdate < CAST('1995-01-01' AS date)
+    AND l_discount BETWEEN 0.05
+    AND 0.07
+    AND l_quantity < 24;
+----
+11803420.2534
+
+statement ok
+COPY lineitem TO 's3://test-bucket/multipart/export_large.json' (FORMAT 'json');
+
+query I
+SELECT
+    sum(l_extendedprice * l_discount) AS revenue
+FROM
+    "s3://test-bucket/multipart/export_large.json"
+WHERE
+    l_shipdate >= CAST('1994-01-01' AS date)
+    AND l_shipdate < CAST('1995-01-01' AS date)
+    AND l_discount BETWEEN 0.05
+    AND 0.07
+    AND l_quantity < 24;
+----
+11803420.2534


### PR DESCRIPTION
This PR adds an optimization to the JSON reader improving its performance for S3 reads.

## The problem
Previously, the JSON reader would share a single file handle globally. Because that means that a single socket is shared over all threads, the network requests would be sequential. This is especially bad for S3 where per-connection throttling exists. For S3 it is therefore always recommended to download with multiple connections concurrently for max performance. 

## Some benchmarks 
I ran a few benchmarks to demonstrate the problem: (note: values are noisy, each benchmark was run once)

|File          |Type    |Size   |Copy method                     |Destination|Timing|
|--------------|--------|-------|--------------------------------|-----------|------|
|lineitem sf0.1|JSON    |207.4 MB|`CREATE TABLE test AS FROM "<file>"` |S3         |**17.54s** |
|lineitem sf0.1|JSON    |207.4 MB|`CREATE TABLE test AS FROM "<file>"` |local file  |0.20s  |
|lineitem sf0.1|JSON    |207.4 MB|`aws s3 cp "<file> ."` |S3         |3.48s  |
|lineitem sf0.1|JSON    |207.4 MB|`curl "<file>" --output test.json` |S3         |19.00s |
|lineitem sf1  |PARQUET |258.3 MB|`CREATE TABLE test AS FROM "<file>"` |S3         |4.91s |
|lineitem sf1  |PARQUET |258.3 MB|`CREATE TABLE test AS FROM "<file>"` |local file  |0.26s  |
|lineitem sf1  |PARQUET |258.3 MB|`aws s3 cp "<file>" . `|S3         |4.10s  |
|lineitem sf1  |PARQUET |258.3 MB|`curl "<file>" --output test.json` |S3         |20.00s |

We can clearly see here that for `CREATE TABLE test AS FROM <json_file_on_s3>` we are way slower than expected. Note that downloading the file with curl is similarly slow. `aws cli` downloads however are very fast: these use multiple connections for a download. Also note that  our parquet download is very fast, being quite close to the time it takes the aws cli to download a file.

### New result
With this PR, the time for `CREATE TABLE test AS FROM "<file>"` is reduced to **7.2s**, wich is over **2x faster**.  This was with a network speed of ~900MBps. At lower speeds this difference will likely be smaller.

Essentially, this optimization will increase performance up to the point where `number of threads * s3 throttle speed = available bandwidth` after that point, bandwidth becomes the bottleneck, as it should be :)

Note that this is still over 2x under the theoretical max speed of 3.48s + 0.20s = 3.68s (aws cli download time + local file json parse) This is probably due to the fact that for the sample_run we do a pret=ty hefty read which is not done in parallel with the other downloads.

## Future work
- Push performance even closer to optimal?
- investigate if the same applies to the CSV reader