### PR TITLE
Fix CSE elimination for window functions with bind data. Fixes #10124

### DIFF
--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -46,6 +46,12 @@ bool BoundWindowExpression::Equals(const BaseExpression &other_p) const {
 			return false;
 		}
 	}
+	// If there's function data, check if they are equal
+	if (bind_info.get() != other.bind_info.get()) {
+		if (!bind_info || !other.bind_info || !bind_info->Equals(*other.bind_info)) {
+			return false;
+		}
+	}
 	// check if the child expressions are equivalent
 	if (!Expression::ListEquals(children, other.children)) {
 		return false;

--- a/test/sql/window/test_window_cse.test
+++ b/test/sql/window/test_window_cse.test
@@ -62,3 +62,17 @@ query II
 EXPLAIN FROM cse;
 ----
 physical_plan	<!REGEX>:.*sum\(cnt_trace\).*sum\(cnt_trace\).*sum\(cnt_trace\).*
+
+
+statement ok
+CREATE VIEW noncse AS
+SELECT
+    quantile(x, 0.3) over() as q3,
+    quantile(x, 0.7) over() as q7
+FROM generate_series(1, 10) as tbl(x);
+
+# Non-CSE should not eliminate the 2nd quantile computation
+query II
+EXPLAIN FROM noncse;
+----
+physical_plan	<REGEX>:.*quantile\(x\).*quantile\(x\).*


### PR DESCRIPTION
Fixes #10124

Some aggregate window functions have dedicated bind data for their arguments. For example, the QUANTILE family functions store their 2nd argument (FLOAT or LIST of FLOATs) in `bind_data`. So, we also need to check that when determining if two window expressions are equal.

Before this fix:
```sql
D EXPLAIN SELECT
    quantile(x, 0.3) over() as q3,
    quantile(x, 0.7) over() as q7
FROM generate_series(1, 10) as tbl(x);

┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│             q3            │
│             q7            │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│             #0            │
│             #1            │
│             #1            │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│           WINDOW          │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│    quantile(x) OVER ()    │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│      GENERATE_SERIES      │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│           EC: 10          │
└───────────────────────────┘
```
Now:

```sql
D EXPLAIN SELECT
    quantile(x, 0.3) over() as q3,
    quantile(x, 0.7) over() as q7
FROM generate_series(1, 10) as tbl(x);

┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│             q3            │
│             q7            │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│             #0            │
│             #1            │
│             #2            │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│           WINDOW          │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│    quantile(x) OVER ()    │
│    quantile(x) OVER ()    │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│      GENERATE_SERIES      │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│           EC: 10          │
└───────────────────────────┘
```


