### PR TITLE
Add some pg session function to pg_catalog

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -27,6 +27,11 @@ static DefaultMacro internal_macros[] = {
 
 	{"pg_catalog", "pg_typeof", {"expression", nullptr}, "lower(typeof(expression))"},  // get the data type of any value
 
+	{"pg_catalog", "current_database", {nullptr}, "current_database()"},  	    // name of current database (called "catalog" in the SQL standard)
+	{"pg_catalog", "current_query", {nullptr}, "current_query()"},  	        // the currently executing query (NULL if not inside a plpgsql function)
+	{"pg_catalog", "current_schema", {nullptr}, "current_schema()"},  	        // name of current schema
+	{"pg_catalog", "current_schemas", {"include_implicit"}, "current_schemas(include_implicit)"},  	// names of schemas in search path
+
 	// privilege functions
 	// {"has_any_column_privilege", {"user", "table", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for any column of table
 	{"pg_catalog", "has_any_column_privilege", {"table", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for any column of table

--- a/test/sql/catalog/test_set_search_path.test
+++ b/test/sql/catalog/test_set_search_path.test
@@ -90,6 +90,11 @@ SELECT MAIN.CURRENT_SCHEMAS(false);
 ----
 [test, test2]
 
+query I
+SELECT pg_catalog.CURRENT_SCHEMAS(false);
+----
+[test, test2]
+
 statement ok
 SET SCHEMA = 'test';
 
@@ -100,6 +105,11 @@ test
 
 query I
 SELECT MAIN.CURRENT_SCHEMA();
+----
+test
+
+query I
+SELECT pg_catalog.CURRENT_SCHEMA();
 ----
 test
 

--- a/test/sql/pg_catalog/system_functions.test
+++ b/test/sql/pg_catalog/system_functions.test
@@ -21,6 +21,11 @@ SELECT CURRENT_DATABASE()
 memory
 
 query I
+SELECT pg_catalog.CURRENT_DATABASE()
+----
+memory
+
+query I
 SELECT USER
 ----
 duckdb
@@ -37,6 +42,11 @@ query I
 SELECT current_query();
 ----
 SELECT current_query();
+
+query I
+SELECT pg_catalog.current_query();
+----
+SELECT pg_catalog.current_query();
 
 query IIII
 SELECT 1, 2, 3, current_query();


### PR DESCRIPTION
To enhance the pg compatibility, I tried add the followed functions to `pg_catalog`:
- current_database
- current_query
- current_schema
- crrent_schemas

In native pg, user can query like
```
test=# select pg_catalog.current_schemas(false);
 current_schemas 
-----------------
 {public}
(1 row)
```

In my other project, I used DuckDB as a PG wire protocol server backend. I tried to connect with Metabase, and then I found this behavior isn't supported by DuckDB.

I tried to minimize the impact to the core function. So I created the default macros and invoke the native function.
