### PR TITLE
feat(py): Py3.12 support for Windows

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -280,7 +280,7 @@ jobs:
       runs-on: windows-2019
       strategy:
        matrix:
-        python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*] # , cp312-*] # TODO: figure out windows build issues
+        python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         exclude:
@@ -296,7 +296,6 @@ jobs:
 
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
-        SETUPTOOLS_USE_DISTUTILS: 'stdlib'
         TWINE_USERNAME: '__token__'
         DUCKDB_BUILD_UNITY: 1
 

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -44,6 +44,9 @@ class CompilerLauncherMixin:
         if compiler_launcher:
 
             def spawn_with_compiler_launcher(cmd, **kwargs):
+                if len(' '.join(cmd)) > 32766:
+                    raise Exception("command too long: " + ' '.join(cmd))
+
                 exclude_programs = ("link.exe",)
                 if not cmd[0].endswith(exclude_programs):
                     cmd = [compiler_launcher] + cmd

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -42,11 +42,11 @@ class CompilerLauncherMixin:
         compiler_launcher = os.getenv("DISTUTILS_C_COMPILER_LAUNCHER")
         if compiler_launcher:
 
-            def spawn_with_compiler_launcher(cmd):
+            def spawn_with_compiler_launcher(cmd, **kwargs):
                 exclude_programs = ("link.exe",)
                 if not cmd[0].endswith(exclude_programs):
                     cmd = [compiler_launcher] + cmd
-                return original_spawn(cmd)
+                return original_spawn(cmd, **kwargs)
 
             original_spawn = self.compiler.spawn
             self.compiler.spawn = spawn_with_compiler_launcher

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -81,36 +81,6 @@ unity_build = 0
 if 'DUCKDB_BUILD_UNITY' in os.environ:
     unity_build = 16
 
-
-def parallel_cpp_compile(
-    self,
-    sources,
-    output_dir=None,
-    macros=None,
-    include_dirs=None,
-    debug=0,
-    extra_preargs=None,
-    extra_postargs=None,
-    depends=None,
-):
-    # Copied from distutils.ccompiler.CCompiler
-    macros, objects, extra_postargs, pp_opts, build = self._setup_compile(
-        output_dir, macros, include_dirs, sources, depends, extra_postargs
-    )
-
-    cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
-
-    def _single_compile(obj):
-        try:
-            src, ext = build[obj]
-        except KeyError:
-            return
-        self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
-
-    list(multiprocessing.pool.ThreadPool(multiprocessing.cpu_count()).imap(_single_compile, objects))
-    return objects
-
-
 # speed up compilation with: -j = cpu_number() on non Windows machines
 if os.name != 'nt' and os.environ.get('DUCKDB_DISABLE_PARALLEL_COMPILE', '') != '1':
     try:
@@ -299,12 +269,6 @@ else:
         language='c++',
         define_macros=define_macros,
     )
-
-# Only include pytest-runner in setup_requires if we're invoking tests
-if {'pytest', 'test', 'ptr'}.intersection(sys.argv):
-    setup_requires = ['pytest-runner']
-else:
-    setup_requires = []
 
 
 # data files need to be formatted as [(directory, [files...]), (directory2, [files...])]

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -5,6 +5,7 @@ import os
 import sys
 import platform
 import multiprocessing.pool
+import traceback
 from glob import glob
 
 from setuptools import setup, Extension
@@ -46,7 +47,11 @@ class CompilerLauncherMixin:
                 exclude_programs = ("link.exe",)
                 if not cmd[0].endswith(exclude_programs):
                     cmd = [compiler_launcher] + cmd
-                return original_spawn(cmd, **kwargs)
+                try:
+                    return original_spawn(cmd, **kwargs)
+                except Exception:
+                    traceback.print_exc()
+                    raise
 
             original_spawn = self.compiler.spawn
             self.compiler.spawn = spawn_with_compiler_launcher

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -154,22 +154,22 @@ for i in range(len(sys.argv)):
     else:
         new_sys_args.append(sys.argv[i])
 sys.argv = new_sys_args
-toolchain_args.append('-DDUCKDB_PYTHON_LIB_NAME=' + lib_name)
+define_macros = [('DUCKDB_PYTHON_LIB_NAME', lib_name)]
 
 if platform.system() == 'Darwin':
     toolchain_args.extend(['-stdlib=libc++', '-mmacosx-version-min=10.7'])
 
 if platform.system() == 'Windows':
-    toolchain_args.extend(['-DDUCKDB_BUILD_LIBRARY', '-DWIN32'])
+    define_macros.extend([('DUCKDB_BUILD_LIBRARY', None), ('WIN32', None)])
 
 if 'BUILD_HTTPFS' in os.environ:
     libraries += ['crypto', 'ssl']
     extensions += ['httpfs']
 
 for ext in extensions:
-    toolchain_args.extend(['-DDUCKDB_EXTENSION_{}_LINKED'.format(ext.upper())])
+    define_macros.append(('DUCKDB_EXTENSION_{}_LINKED'.format(ext.upper()), None))
 
-toolchain_args.extend(['-DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT=1', '-DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT=1'])
+define_macros.extend([('DUCKDB_EXTENSION_AUTOLOAD_DEFAULT', '1'), ('DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT', '1')])
 
 linker_args = toolchain_args
 if platform.system() == 'Windows':
@@ -267,6 +267,7 @@ if len(existing_duckdb_dir) == 0:
         extra_link_args=linker_args,
         libraries=libraries,
         language='c++',
+        define_macros=define_macros,
     )
 else:
     sys.path.append(os.path.join(script_path, '..', '..', 'scripts'))
@@ -288,6 +289,7 @@ else:
         libraries=libnames,
         library_dirs=library_dirs,
         language='c++',
+        define_macros=define_macros,
     )
 
 # Only include pytest-runner in setup_requires if we're invoking tests


### PR DESCRIPTION
Linux and MacOS support was added in a previous PR.

This essentially works around an issue in the setuptools copy of distutils (as opposed to the one that was left frozen in the CPython standard library) that causes link.exe calls to fail on Windows.

The issue is that the call winds up being too long for Windows' limit, which is around 32677 characters, so we use the weird ancient "short paths" to shorten the call. There's a chance this might reoccur in the future though. If that happens, we might have to look into other build systems (instead of setuptools), such as Meson, Bazel, Pants, etc.

Fixes https://github.com/duckdb/duckdb/issues/9301
Fixes https://github.com/duckdb/duckdb/issues/9563