### PR TITLE
Infrastructure: truncate not always available in CI, use dd

### DIFF
--- a/scripts/extension-upload-single.sh
+++ b/scripts/extension-upload-single.sh
@@ -55,10 +55,10 @@ if [ "$DUCKDB_EXTENSION_SIGNING_PK" != "" ]; then
   $script_dir/compute-extension-hash.sh $ext.append > $ext.hash
   openssl pkeyutl -sign -in $ext.hash -inkey private.pem -pkeyopt digest:sha256 -out $ext.sign
   rm -f private.pem
+else
+  # Default to 256 zeros
+  dd if=/dev/zero of=$ext.sign bs=256 count=1
 fi
-
-# Signature is always there, potentially defaulting to 256 zeros
-truncate -s 256 $ext.sign
 
 # append signature to extension binary
 cat $ext.sign >> $ext.append


### PR DESCRIPTION
[OSX Extensions Release (x86_64)](https://github.com/duckdb/duckdb/actions/runs/7441725727/job/20247727544) CI job has been failing since the `truncate` utility is not available in that specific runner.

I changed the logic slightly to use `dd`, that it's also widely available and in particular it's available in that setup (see this CI run where dd is tested explicitly: https://github.com/carlopi/duckdb/actions/runs/7446745412/job/20257640376#step:4:1).

Note that proper testing of this will only come from a nightly run.