### PR TITLE
Fix #10074 - for materialized CTEs the final result names are not influenced by the aliases. Only the names of the CTE itself are influenced by the aliases.

### DIFF
--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -33,9 +33,9 @@ void Transformer::ExtractCTEsRecursive(CommonTableExpressionMap &cte_map) {
 
 void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause &de_with_clause, CommonTableExpressionMap &cte_map,
                                vector<unique_ptr<CTENode>> &materialized_ctes) {
-	// TODO: might need to update in case of future lawsuit
 	stored_cte_map.push_back(&cte_map);
 
+	// TODO: might need to update in case of future lawsuit
 	D_ASSERT(de_with_clause.ctes);
 	for (auto cte_ele = de_with_clause.ctes->head; cte_ele != nullptr; cte_ele = cte_ele->next) {
 		auto info = make_uniq<CommonTableExpressionInfo>();

--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -49,11 +49,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(CTENode &statement) {
 
 	// the result types of the CTE are the types of the LHS
 	result->types = result->child->types;
-	// names are picked from the LHS, unless aliases are explicitly specified
 	result->names = result->child->names;
-	for (idx_t i = 0; i < statement.aliases.size() && i < result->names.size(); i++) {
-		result->names[i] = statement.aliases[i];
-	}
 
 	MoveCorrelatedExpressions(*result->query_binder);
 	MoveCorrelatedExpressions(*result->child_binder);

--- a/test/sql/cte/cte_colname_issue_10074.test
+++ b/test/sql/cte/cte_colname_issue_10074.test
@@ -1,0 +1,16 @@
+# name: test/sql/cte/cte_colname_issue_10074.test
+# description: Issue #10074 - CTE returns wrong column name
+# group: [cte]
+
+statement ok
+pragma enable_verification
+
+statement ok
+create table t as with q(id,s) as (values(1,42)),
+a(s)as materialized(select 42)
+select id from q join a on q.s=a.s
+
+query I
+select id from t
+----
+1


### PR DESCRIPTION
Fixes #10074