### PR TITLE
Fix #10141 - Correctly handle recursive and nested types that refer to other types in CREATE TYPE

### DIFF
--- a/test/issues/general/test_5664.test
+++ b/test/issues/general/test_5664.test
@@ -25,4 +25,4 @@ INSERT INTO test VALUES ('duckdb');
 query I
 SELECT typeof(x) FROM test;
 ----
-b
+BLOB

--- a/test/sql/types/alias/nested_alias.test
+++ b/test/sql/types/alias/nested_alias.test
@@ -1,6 +1,6 @@
 # name: test/sql/types/alias/nested_alias.test
-# description: Verify that nested aliases workl
-# group: [alter_type]
+# description: Verify that nested aliases work correctly
+# group: [alias]
 
 statement ok
 CREATE TYPE my_int AS INT

--- a/test/sql/types/alias/nested_alias.test
+++ b/test/sql/types/alias/nested_alias.test
@@ -1,0 +1,14 @@
+# name: test/sql/types/alias/nested_alias.test
+# description: Verify that nested aliases workl
+# group: [alter_type]
+
+statement ok
+CREATE TYPE my_int AS INT
+
+statement ok
+CREATE TYPE my_int_list AS my_int[]
+
+query I
+SELECT [42]::my_int_list
+----
+[42]

--- a/test/sql/types/alias/recursive_alias.test
+++ b/test/sql/types/alias/recursive_alias.test
@@ -1,0 +1,19 @@
+# name: test/sql/types/alias/recursive_alias.test
+# description: Issue #10141 - DuckDB SIGSEGV when setting up ill-formed custom type
+# group: [alter_type]
+
+# recursive type definitions are not allowed
+statement error
+CREATE TYPE t4 AS UNION ( v0 SETOF t4 );
+----
+Type with name t4 does not exist
+
+statement error
+CREATE TYPE t4 AS t4[]
+----
+Type with name t4 does not exist
+
+statement error
+CREATE TYPE t4 AS STRUCT(a t4)
+----
+Type with name t4 does not exist

--- a/test/sql/types/alias/recursive_alias.test
+++ b/test/sql/types/alias/recursive_alias.test
@@ -1,6 +1,6 @@
 # name: test/sql/types/alias/recursive_alias.test
 # description: Issue #10141 - DuckDB SIGSEGV when setting up ill-formed custom type
-# group: [alter_type]
+# group: [alias]
 
 # recursive type definitions are not allowed
 statement error


### PR DESCRIPTION
Fixes an infinite recursion triggered in #10141 and also makes the behavior correct for structs/lists/etc that refer to other type aliases