### PR TITLE
[Python] Fix issue in DataFrame construction where non-deduplicated names were being used mistakenly

### DIFF
--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -244,11 +244,13 @@ py::dict DuckDBPyResult::FetchNumpyInternal(bool stream, idx_t vectors_per_chunk
 
 // TODO: unify these with an enum/flag to indicate which conversions to do
 void DuckDBPyResult::ChangeToTZType(PandasDataFrame &df) {
+	auto names = df.attr("columns").cast<vector<string>>();
+
 	for (idx_t i = 0; i < result->ColumnCount(); i++) {
 		if (result->types[i] == LogicalType::TIMESTAMP_TZ) {
 			// first localize to UTC then convert to timezone_config
-			auto utc_local = df[result->names[i].c_str()].attr("dt").attr("tz_localize")("UTC");
-			df[result->names[i].c_str()] = utc_local.attr("dt").attr("tz_convert")(result->client_properties.time_zone);
+			auto utc_local = df[names[i].c_str()].attr("dt").attr("tz_localize")("UTC");
+			df[names[i].c_str()] = utc_local.attr("dt").attr("tz_convert")(result->client_properties.time_zone);
 		}
 	}
 }

--- a/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_timestamp.py
@@ -63,3 +63,14 @@ class TestPandasTimestamps(object):
         )
         df_from_duck = duckdb.from_df(df).df()
         assert df_from_duck.equals(df)
+
+    def test_timestamp_timezone(self, duckdb_cursor):
+        rel = duckdb_cursor.query(
+            """
+            SELECT
+                '2019-01-01 00:00:00+00'::TIMESTAMPTZ AS dateTime,
+                '2019-01-01 00:00:00+00'::TIMESTAMPTZ AS dateTime
+        """
+        )
+        res = rel.df()
+        assert res['dateTime'][0] == res['dateTime_2'][0]


### PR DESCRIPTION
This PR fixes #10155 

This issue occurs because the deduplicated names were being used, so the second occurrence of this would cause us to try to re-convert the first column for the second time, which raises an exception.
 