### PR TITLE
Suspend duckdb shell on Ctrl+Z

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -115,6 +115,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <signal.h>
 #include "linenoise.h"
 #include "utf8proc_wrapper.hpp"
 #include <unordered_set>
@@ -226,6 +227,7 @@ enum KEY_ACTION {
 	CTRL_T = 20,    /* Ctrl-t */
 	CTRL_U = 21,    /* Ctrl+u */
 	CTRL_W = 23,    /* Ctrl+w */
+	CTRL_Z = 26,    /* Ctrl+z */
 	ESC = 27,       /* Escape */
 	BACKSPACE = 127 /* Backspace */
 };
@@ -1936,6 +1938,12 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 				free(history[history_len]);
 				return -1;
 			}
+			break;
+		case CTRL_Z: /* ctrl-z, suspends shell */
+			disableRawMode(STDIN_FILENO);
+			raise(SIGTSTP);
+			enableRawMode(STDIN_FILENO);
+			refreshLine(&l);
 			break;
 		case CTRL_T: /* ctrl-t, swaps current character with previous. */
 			if (l.pos > 0 && l.pos < l.len) {


### PR DESCRIPTION
In a terminal, Ctrl+Z yields SIGTSTP, which is delivered to the foreground process. It's default action is Stop and a shell that supports job control takes over and adds the stopped process into its list of suspended jobs.

In contrast to SIGSTOP, SIGTSTP can be caught or ignored. A common use case for catching it is to restore the terminal to a state in which the shell is usable again followed by suspension.

Almost all command line and text user interface programs support SIGTSTP and work well in combination with shell job control.

This change is inspired by a patch posted in:

https://github.com/antirez/linenoise/issues/141#issuecomment-433280306

The traditional approach to catching and raising SIGTSTP in a signal handler is detailed in:

https://man7.org/tlpi/code/online/dist/pgsjc/handling_SIGTSTP.c.html