### PR TITLE
[Python] Output unnamed structs as `tuple` in `fetchone/many/all` methods

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
@@ -196,6 +196,7 @@ public:
 
 struct PythonObject {
 	static void Initialize();
+	static py::object FromStruct(const Value &value, const LogicalType &id, const ClientProperties &client_properties);
 	static py::object FromValue(const Value &value, const LogicalType &id, const ClientProperties &client_properties);
 };
 

--- a/tools/pythonpkg/tests/fast/types/test_nested.py
+++ b/tools/pythonpkg/tests/fast/types/test_nested.py
@@ -3,47 +3,51 @@ import duckdb
 
 class TestNested(object):
     def test_lists(self, duckdb_cursor):
-        duckdb_conn = duckdb.connect()
-        result = duckdb_conn.execute("SELECT LIST_VALUE(1, 2, 3, 4) ").fetchall()
+        result = duckdb_cursor.execute("SELECT LIST_VALUE(1, 2, 3, 4) ").fetchall()
         assert result == [([1, 2, 3, 4],)]
 
-        result = duckdb_conn.execute("SELECT LIST_VALUE() ").fetchall()
+        result = duckdb_cursor.execute("SELECT LIST_VALUE() ").fetchall()
         assert result == [([],)]
 
-        result = duckdb_conn.execute("SELECT LIST_VALUE(1, 2, 3, NULL) ").fetchall()
+        result = duckdb_cursor.execute("SELECT LIST_VALUE(1, 2, 3, NULL) ").fetchall()
         assert result == [([1, 2, 3, None],)]
 
     def test_nested_lists(self, duckdb_cursor):
-        duckdb_conn = duckdb.connect()
-        result = duckdb_conn.execute("SELECT LIST_VALUE(LIST_VALUE(1, 2, 3, 4), LIST_VALUE(1, 2, 3, 4)) ").fetchall()
+        result = duckdb_cursor.execute("SELECT LIST_VALUE(LIST_VALUE(1, 2, 3, 4), LIST_VALUE(1, 2, 3, 4)) ").fetchall()
         assert result == [([[1, 2, 3, 4], [1, 2, 3, 4]],)]
 
-        result = duckdb_conn.execute("SELECT LIST_VALUE(LIST_VALUE(1, 2, 3, 4), LIST_VALUE(1, 2, 3, NULL)) ").fetchall()
+        result = duckdb_cursor.execute(
+            "SELECT LIST_VALUE(LIST_VALUE(1, 2, 3, 4), LIST_VALUE(1, 2, 3, NULL)) "
+        ).fetchall()
         assert result == [([[1, 2, 3, 4], [1, 2, 3, None]],)]
 
     def test_struct(self, duckdb_cursor):
-        duckdb_conn = duckdb.connect()
-        result = duckdb_conn.execute("SELECT STRUCT_PACK(a := 42, b := 43)").fetchall()
+        result = duckdb_cursor.execute("SELECT STRUCT_PACK(a := 42, b := 43)").fetchall()
         assert result == [({'a': 42, 'b': 43},)]
 
-        result = duckdb_conn.execute("SELECT STRUCT_PACK(a := 42, b := NULL)").fetchall()
+        result = duckdb_cursor.execute("SELECT STRUCT_PACK(a := 42, b := NULL)").fetchall()
         assert result == [({'a': 42, 'b': None},)]
 
+    def test_unnamed_struct(self, duckdb_cursor):
+        result = duckdb_cursor.execute("SELECT row('aa','bb') AS x").fetchall()
+        assert result == [(('aa', 'bb'),)]
+
+        result = duckdb_cursor.execute("SELECT row('aa',NULL) AS x").fetchall()
+        assert result == [(('aa', None),)]
+
     def test_nested_struct(self, duckdb_cursor):
-        duckdb_conn = duckdb.connect()
-        result = duckdb_conn.execute("SELECT STRUCT_PACK(a := 42, b := LIST_VALUE(10, 9, 8, 7))").fetchall()
+        result = duckdb_cursor.execute("SELECT STRUCT_PACK(a := 42, b := LIST_VALUE(10, 9, 8, 7))").fetchall()
         assert result == [({'a': 42, 'b': [10, 9, 8, 7]},)]
 
-        result = duckdb_conn.execute("SELECT STRUCT_PACK(a := 42, b := LIST_VALUE(10, 9, 8, NULL))").fetchall()
+        result = duckdb_cursor.execute("SELECT STRUCT_PACK(a := 42, b := LIST_VALUE(10, 9, 8, NULL))").fetchall()
         assert result == [({'a': 42, 'b': [10, 9, 8, None]},)]
 
     def test_map(self, duckdb_cursor):
-        duckdb_conn = duckdb.connect()
-        result = duckdb_conn.execute("select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7))").fetchall()
+        result = duckdb_cursor.execute("select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7))").fetchall()
         assert result == [({'key': [1, 2, 3, 4], 'value': [10, 9, 8, 7]},)]
 
-        result = duckdb_conn.execute("select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, NULL))").fetchall()
+        result = duckdb_cursor.execute("select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, NULL))").fetchall()
         assert result == [({'key': [1, 2, 3, 4], 'value': [10, 9, 8, None]},)]
 
-        result = duckdb_conn.execute("SELECT MAP() ").fetchall()
+        result = duckdb_cursor.execute("SELECT MAP() ").fetchall()
         assert result == [({'key': [], 'value': []},)]


### PR DESCRIPTION
This PR fixes #10090 

We normally turn the struct into a `dict`, but since all keys have to be unique this causes all but one field to survive, since every key of an unnamed struct is `''`

We now turn the struct into a `tuple`, preserving all values of the fields