### PR TITLE
Fix #10057: report correct error message when binding an aliased column fails

### DIFF
--- a/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
@@ -21,8 +21,8 @@ class ColumnAliasBinder {
 public:
 	ColumnAliasBinder(BoundSelectNode &node, const case_insensitive_map_t<idx_t> &alias_map);
 
-	BindResult BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
-	                     bool root_expression);
+	bool BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth, bool root_expression,
+	               BindResult &result);
 
 private:
 	BoundSelectNode &node;

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -12,19 +12,22 @@ ColumnAliasBinder::ColumnAliasBinder(BoundSelectNode &node, const case_insensiti
     : node(node), alias_map(alias_map), visited_select_indexes() {
 }
 
-BindResult ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
-                                        bool root_expression) {
+bool ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
+                                  bool root_expression, BindResult &result) {
 	if (expr.IsQualified()) {
-		return BindResult(StringUtil::Format("Alias %s cannot be qualified.", expr.ToString()));
+		// qualified columns cannot be aliases
+		return false;
 	}
 
 	auto alias_entry = alias_map.find(expr.column_names[0]);
 	if (alias_entry == alias_map.end()) {
-		return BindResult(StringUtil::Format("Alias %s is not found.", expr.ToString()));
+		// no alias found
+		return false;
 	}
 
 	if (visited_select_indexes.find(alias_entry->second) != visited_select_indexes.end()) {
-		return BindResult("Cannot resolve self-referential alias");
+		// self-referential alias cannot be resolved
+		return false;
 	}
 
 	// found an alias: bind the alias expression
@@ -33,9 +36,9 @@ BindResult ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, Colu
 
 	// since the alias has been found, pass a depth of 0. See Issue 4978 (#16)
 	// ColumnAliasBinders are only in Having, Qualify and Where Binders
-	auto result = enclosing_binder.BindExpression(expression, depth, root_expression);
+	result = enclosing_binder.BindExpression(expression, depth, root_expression);
 	visited_select_indexes.erase(alias_entry->second);
-	return result;
+	return true;
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -17,17 +17,21 @@ HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNo
 
 BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
 	auto &expr = expr_ptr->Cast<ColumnRefExpression>();
-	auto alias_result = column_alias_binder.BindAlias(*this, expr, depth, root_expression);
-	if (!alias_result.HasError()) {
+	BindResult alias_result;
+	auto found_alias = column_alias_binder.BindAlias(*this, expr, depth, root_expression, alias_result);
+	if (found_alias) {
 		if (depth > 0) {
-			throw BinderException("Having clause cannot reference alias in correlated subquery");
+			throw BinderException("Having clause cannot reference alias \"%s\" in correlated subquery",
+			                      expr.GetColumnName());
 		}
 		return alias_result;
 	}
 
 	if (aggregate_handling == AggregateHandling::FORCE_AGGREGATES) {
 		if (depth > 0) {
-			throw BinderException("Having clause cannot reference column in correlated subquery and group by all");
+			throw BinderException(
+			    "Having clause cannot reference column \"%s\" in correlated subquery and group by all",
+			    expr.GetColumnName());
 		}
 		auto expr = duckdb::BaseSelectBinder::BindExpression(expr_ptr, depth);
 		if (expr.HasError()) {

--- a/src/planner/expression_binder/qualify_binder.cpp
+++ b/src/planner/expression_binder/qualify_binder.cpp
@@ -22,8 +22,9 @@ BindResult QualifyBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, 
 		return result;
 	}
 
-	auto alias_result = column_alias_binder.BindAlias(*this, expr, depth, root_expression);
-	if (!alias_result.HasError()) {
+	BindResult alias_result;
+	auto found_alias = column_alias_binder.BindAlias(*this, expr, depth, root_expression, alias_result);
+	if (found_alias) {
 		return alias_result;
 	}
 

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -16,12 +16,11 @@ BindResult WhereBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, id
 		return result;
 	}
 
-	BindResult alias_result = column_alias_binder->BindAlias(*this, expr, depth, root_expression);
-	// This code path cannot be exercised at thispoint. #1547 might change that.
-	if (!alias_result.HasError()) {
+	BindResult alias_result;
+	auto found_alias = column_alias_binder->BindAlias(*this, expr, depth, root_expression, alias_result);
+	if (found_alias) {
 		return alias_result;
 	}
-
 	return result;
 }
 

--- a/test/fuzzer/pedro/having_subquery_failed_to_bind.test
+++ b/test/fuzzer/pedro/having_subquery_failed_to_bind.test
@@ -13,7 +13,7 @@ cannot reference alias
 statement error
 SELECT count() as c0 FROM (SELECT 1) t1(c2) HAVING 1 = (SELECT c0 WHERE EXISTS (SELECT 1));
 ----
-Binder Error: column c0 must appear in the GROUP BY clause or be used in an aggregate function
+cannot reference alias
 
 statement error
 SELECT count() as c0 FROM (SELECT 1) t1(c2) GROUP BY c0 HAVING 1 = (SELECT c0 WHERE EXISTS (SELECT 1));
@@ -29,9 +29,9 @@ CREATE TABLE t1 (c0 INT);
 statement error
 SELECT count(*) c1 HAVING EXISTS (SELECT 1 FROM t1 WHERE c1 BETWEEN c0 AND 0);
 ----
-Binder Error: column c1 must appear in the GROUP BY clause or be used in an aggregate function
+cannot reference alias
 
 statement error
 SELECT count(*) c1 HAVING EXISTS (SELECT 1 FROM t1 WHERE c1 = c0);
 ----
-Binder Error: column c1 must appear in the GROUP BY clause or be used in an aggregate function
+cannot reference alias

--- a/test/sql/binder/alias_error_10057.test
+++ b/test/sql/binder/alias_error_10057.test
@@ -1,0 +1,14 @@
+# name: test/sql/binder/old_implicit_cast.test
+# description: Test old_implicit_cast setting
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+with test_data as (
+  select 'foo' as a
+)
+select test_data.foobar as new_column from test_data where new_column is not null;
+----
+foobar

--- a/test/sql/binder/alias_error_10057.test
+++ b/test/sql/binder/alias_error_10057.test
@@ -1,4 +1,4 @@
-# name: test/sql/binder/old_implicit_cast.test
+# name: test/sql/binder/alias_error_10057.test
 # description: Test old_implicit_cast setting
 # group: [binder]
 


### PR DESCRIPTION
Fixes #10057