### PR TITLE
Fix missing move

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -312,11 +312,8 @@ jobs:
 
   sqllogic:
      name: Sqllogic tests
-     runs-on: ubuntu-20.04
+     runs-on: ubuntu-latest # Secondary task of this CI job is to test building duckdb on latest ubuntu
      needs: linux-memory-leaks
-     env:
-       CC: gcc-10
-       CXX: g++-10
 
      steps:
      - uses: actions/checkout@v3

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -185,7 +185,7 @@ public:
 			result->redact_keys.insert(entry.ToString());
 		}
 
-		return result;
+		return std::move(result);
 	}
 
 	//! the map of key -> values that make up the secret


### PR DESCRIPTION
There was an `std::move` missing causing compile issues on recent gcc versions