### PR TITLE
prevent physical nested loop join with multiple conditions on semi an…

### DIFF
--- a/src/execution/operator/join/physical_nested_loop_join.cpp
+++ b/src/execution/operator/join/physical_nested_loop_join.cpp
@@ -315,10 +315,7 @@ void PhysicalNestedLoopJoin::ResolveSimpleJoin(ExecutionContext &context, DataCh
 	state.left_condition.Reset();
 	state.lhs_executor.Execute(input, state.left_condition);
 
-	bool found_match[STANDARD_VECTOR_SIZE] = {true};
-	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
-		found_match[i] = true;
-	}
+	bool found_match[STANDARD_VECTOR_SIZE] = {false};
 	NestedLoopJoinMark::Perform(state.left_condition, gstate.right_condition_data, found_match, conditions);
 	switch (join_type) {
 	case JoinType::MARK:

--- a/test/sql/join/semianti/plan_blockwise_NL_join_with_mutliple_conditions.test
+++ b/test/sql/join/semianti/plan_blockwise_NL_join_with_mutliple_conditions.test
@@ -1,0 +1,87 @@
+# name: test/sql/join/semianti/plan_blockwise_NL_join_with_mutliple_conditions.test
+# description: Test anti ijoin results
+# group: [semianti]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table t1 as select * from values (1, 2), (2, 4), (3, 8), (6, 25), (1, 25) t(a, b);
+
+statement ok
+create table t2 as select * from values (4), (5) t(b);
+
+query II
+select * from t1 semi join t2 on t1.a < t2.b and t1.b > t2.b order by all;
+----
+1	25
+3	8
+
+query II
+select * from t1 anti join t2 on t1.a < t2.b and t1.b < t2.b order by all;
+----
+1	25
+3	8
+6	25
+
+query II
+Explain select * from t1 anti join t2 on t1.a < t2.b and t1.b < t2.b order by all;
+----
+physical_plan	<REGEX>:.*BLOCKWISE_NL_JOIN.*
+
+query II
+select * from t1 anti join t2 on t1.a < t2.b and t1.b < t2.b order by all;
+----
+1	25
+3	8
+6	25
+
+query II
+select * from t1 semi join t2 on t1.a < t2.b or t1.b < t2.b order by all;
+----
+1	2
+1	25
+2	4
+3	8
+
+query II
+select * from t1 semi join t2 on (t1.a < t2.b and t1.b < t2.b) or (t1.a < t2.b and t1.b = 4) order by all;
+----
+1	2
+2	4
+
+
+query II
+select * from t1 semi join t2 on (t1.a < t2.b or t1.b < t2.b) and (t1.a = 1 or t1.b = 4) order by all;
+----
+1	2
+1	25
+2	4
+
+
+statement ok
+CREATE TABLE flattened ("start" varchar, "end" varchar);
+
+statement ok
+insert into flattened values ('2023-03-15T00:00:00Z', '2023-03-20T00:00:00Z');
+
+statement ok
+create table input_table as select * from VALUES
+('1', '2023-03-14T00:00:00Z', 2),
+('2', '2023-03-15T00:00:00Z', 4),
+('3', '2023-03-16T00:00:00Z', 7),
+('4', '2023-03-17T00:00:00Z', 3),
+('5', '2023-03-18T00:00:00Z', 2),
+('6', '2023-03-19T23:59:59Z', 4),
+('7', '2023-03-20T00:00:00Z', 7),
+('8', '2023-03-21T00:00:00Z', 3) t(user_id, timestamp, value);
+
+
+query III
+SELECT * FROM input_table
+ANTI JOIN flattened
+ON input_table."timestamp" >= flattened.start AND input_table."timestamp" <  flattened.end;
+----
+1	2023-03-14T00:00:00Z	2
+7	2023-03-20T00:00:00Z	7
+8	2023-03-21T00:00:00Z	3


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/10046

The query in the issue is currently planned as PhysicalNestedLoopJoins. If a semi or anti join is planned as a physical nested loop join, then `ResolveSimpleJoin` is used to create the output chunk. The `ResolveSimpleJoin` calls `NestedLoopJoinMark::Perform`. This function implicitly assumes a OR conjunction among all conditions, setting the `found_match` index to true once the condition is satisfied, then keeping the true value during all future comparisons. 

One potential fix is to fix the `NestedLoopJoinMark` logic so that it has better awareness of the conditions, if they have `conjunction_and` or `conjunction_or` etc. However, this is a very rare instance, to satisfy it and plan a nested loop join mark with multiple conditions,

- there need to be *no* equality conditions. Otherwise a hash join with a filter is used. 
- The conditions must all be connected by `AND` statements. If `OR` statements are used then a `PhysicalBlockwiseNLJoin` is used, and the expressions are properly evaluated. 
- It needs to use the explicit `ANTI` or `SEMI` syntax.

The solution I have come up with here is just to check the number of conditions in the SEMI or ANTI join and see if we can plan a `NestedLoopJoin`. If `conditions.size() > 1`, we plan a `PhysicalBlockwiseNLJoin` which will properly evaluate the conditions.


