### PR TITLE
fix: reject creation of persistent secrets when allow_persistent_secrets=false for storage backends other than local_file

### DIFF
--- a/src/include/duckdb/main/secret/secret_storage.hpp
+++ b/src/include/duckdb/main/secret/secret_storage.hpp
@@ -21,6 +21,8 @@ struct SecretEntry;
 
 //! Base class for SecretStorage API
 class SecretStorage {
+	friend class SecretManager;
+
 public:
 	SecretStorage(const string &name) : storage_name(name), persistent(false) {};
 	virtual ~SecretStorage() = default;

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -158,24 +158,28 @@ optional_ptr<SecretEntry> SecretManager::RegisterSecretInternal(CatalogTransacti
 		resolved_storage = storage;
 	}
 
-	if (resolved_storage != TEMPORARY_STORAGE_NAME && persist_type == SecretPersistType::TEMPORARY) {
-		throw InvalidInputException("Can not set secret storage for temporary secrets!");
-	}
-
-	if (persist_type == SecretPersistType::PERSISTENT) {
-		if (!config.allow_persistent_secrets) {
-			throw InvalidInputException("Persistent secrets are currently disabled. To enable them, restart duckdb and "
-			                            "run 'SET allow_persistent_secrets=true'");
-		}
-	}
-
 	//! Lookup which backend to store the secret in
 	auto backend = GetSecretStorage(resolved_storage);
-	if (backend) {
-		return backend->StoreSecret(transaction, std::move(secret), on_conflict);
+	if (!backend) {
+		throw InvalidInputException("Secret storage '%s' not found!", resolved_storage);
 	}
 
-	throw InvalidInputException("Secret storage '%s' not found!", resolved_storage);
+	// Validation on both allow_persistent_secrets and storage backend's own persist type
+	if (persist_type == SecretPersistType::PERSISTENT) {
+		if (backend->persistent) {
+			if (!config.allow_persistent_secrets) {
+				throw InvalidInputException("Persistent secrets are currently disabled. To enable them, restart duckdb and "
+				                            "run 'SET allow_persistent_secrets=true'");
+			}
+		} else { // backend is temp
+			throw InvalidInputException("Cannot create persistent secrets in a temporary secret storage!");
+		}
+	} else { // SecretPersistType::TEMPORARY
+		if (backend->persistent) {
+			throw InvalidInputException("Cannot create temporary secrets in a persistent secret storage!");
+		}
+	}
+	return backend->StoreSecret(transaction, std::move(secret), on_conflict);
 }
 
 optional_ptr<CreateSecretFunction> SecretManager::LookupFunctionInternal(CatalogTransaction transaction,
@@ -491,10 +495,8 @@ void SecretManager::InitializeSecrets(CatalogTransaction transaction) {
 		LoadSecretStorageInternal(make_uniq<TemporarySecretStorage>(TEMPORARY_STORAGE_NAME, *transaction.db));
 
 		// load the persistent storage if enabled
-		if (config.allow_persistent_secrets) {
-			LoadSecretStorageInternal(
-			    make_uniq<LocalFileSecretStorage>(*this, *transaction.db, LOCAL_FILE_STORAGE_NAME, config.secret_path));
-		}
+		LoadSecretStorageInternal(
+			make_uniq<LocalFileSecretStorage>(*this, *transaction.db, LOCAL_FILE_STORAGE_NAME, config.secret_path));
 
 		initialized = true;
 	}

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -168,8 +168,9 @@ optional_ptr<SecretEntry> SecretManager::RegisterSecretInternal(CatalogTransacti
 	if (persist_type == SecretPersistType::PERSISTENT) {
 		if (backend->persistent) {
 			if (!config.allow_persistent_secrets) {
-				throw InvalidInputException("Persistent secrets are currently disabled. To enable them, restart duckdb and "
-				                            "run 'SET allow_persistent_secrets=true'");
+				throw InvalidInputException(
+				    "Persistent secrets are currently disabled. To enable them, restart duckdb and "
+				    "run 'SET allow_persistent_secrets=true'");
 			}
 		} else { // backend is temp
 			throw InvalidInputException("Cannot create persistent secrets in a temporary secret storage!");
@@ -496,7 +497,7 @@ void SecretManager::InitializeSecrets(CatalogTransaction transaction) {
 
 		// load the persistent storage if enabled
 		LoadSecretStorageInternal(
-			make_uniq<LocalFileSecretStorage>(*this, *transaction.db, LOCAL_FILE_STORAGE_NAME, config.secret_path));
+		    make_uniq<LocalFileSecretStorage>(*this, *transaction.db, LOCAL_FILE_STORAGE_NAME, config.secret_path));
 
 		initialized = true;
 	}

--- a/test/secrets/test_custom_secret_storage.cpp
+++ b/test/secrets/test_custom_secret_storage.cpp
@@ -21,7 +21,7 @@ public:
 	TestSecretStorage(const string &name_p, DatabaseInstance &db, TestSecretLog &logger_p, int64_t tie_break_offset_p)
 	    : CatalogSetSecretStorage(name_p), tie_break_offset(tie_break_offset_p), logger(logger_p) {
 		secrets = make_uniq<CatalogSet>(Catalog::GetSystemCatalog(db));
-		persistent = false;
+		persistent = true;
 		include_in_lookups = true;
 	}
 	bool IncludeInLookups() override {
@@ -65,7 +65,7 @@ TEST_CASE("Test adding a custom secret storage", "[secret][.]") {
 	auto &storage_ref = *storage_ptr;
 	secret_manager.LoadSecretStorage(std::move(storage_ptr));
 
-	REQUIRE_NO_FAIL(con.Query("set allow_persistent_secrets=false;"));
+	REQUIRE_NO_FAIL(con.Query("set allow_persistent_secrets=true;"));
 
 	REQUIRE_NO_FAIL(con.Query("CREATE SECRET s1 IN TEST_STORAGE (TYPE S3, SCOPE 's3://foo')"));
 	REQUIRE_NO_FAIL(con.Query("CREATE PERSISTENT SECRET s2 IN test_storage (TYPE S3, SCOPE 's3://')"));
@@ -128,7 +128,7 @@ TEST_CASE("Test tie-break behaviour for custom secret storage", "[secret][.]") {
 	TestSecretLog log1;
 	TestSecretLog log2;
 
-	REQUIRE_NO_FAIL(con.Query("set allow_persistent_secrets=false;"));
+	REQUIRE_NO_FAIL(con.Query("set allow_persistent_secrets=true;"));
 
 	// Register custom secret storage
 	auto &secret_manager = duckdb::SecretManager::Get(*db.instance);

--- a/test/sql/secrets/create_secret_storage_backends.test
+++ b/test/sql/secrets/create_secret_storage_backends.test
@@ -16,12 +16,12 @@ set allow_persistent_secrets=false;
 statement error
 CREATE TEMPORARY SECRET s1 IN LOCAL_FILE ( TYPE S3 )
 ----
-Can not set secret storage for temporary secrets!
+Cannot create temporary secrets in a persistent secret storage!
 
 statement error
 CREATE PERSISTENT SECRET s1 IN NON_EXISTENT_SECRET_STORAGE ( TYPE S3 )
 ----
-Persistent secrets are currently disabled. To enable them, restart duckdb and run 'SET allow_persistent_secrets=true'
+Secret storage 'non_existent_secret_storage' not found!
 
 # We have disabled the permanent secrets, so this should fail
 statement error

--- a/test/sql/secrets/create_secret_storage_backends.test
+++ b/test/sql/secrets/create_secret_storage_backends.test
@@ -21,7 +21,7 @@ Can not set secret storage for temporary secrets!
 statement error
 CREATE PERSISTENT SECRET s1 IN NON_EXISTENT_SECRET_STORAGE ( TYPE S3 )
 ----
-Secret storage 'non_existent_secret_storage' not found!
+Persistent secrets are currently disabled. To enable them, restart duckdb and run 'SET allow_persistent_secrets=true'
 
 # We have disabled the permanent secrets, so this should fail
 statement error
@@ -36,7 +36,7 @@ set secret_directory='__TEST_DIR__/create_secret_storages'
 
 # Default for persistent secret is currently LOCAL_FILE (only native persistent storage method currently)
 statement ok
-CREATE PERSISTENT SECRET perm_s1 ( TYPE S3 )
+CREATE PERSISTENT SECRET perm_s1 IN LOCAL_FILE ( TYPE S3 )
 
 # Specifying IN ... implies persistent, hence this is okay
 statement ok

--- a/test/sql/secrets/create_secret_storage_backends.test
+++ b/test/sql/secrets/create_secret_storage_backends.test
@@ -36,7 +36,7 @@ set secret_directory='__TEST_DIR__/create_secret_storages'
 
 # Default for persistent secret is currently LOCAL_FILE (only native persistent storage method currently)
 statement ok
-CREATE PERSISTENT SECRET perm_s1 IN LOCAL_FILE ( TYPE S3 )
+CREATE PERSISTENT SECRET perm_s1 ( TYPE S3 )
 
 # Specifying IN ... implies persistent, hence this is okay
 statement ok


### PR DESCRIPTION
Currently when `allow_persistent_secrets`(a `SecretManagerConfig` option) is set to `false`, the duck_secret_manager is only rejecting PERSISTENT secret creation when the resolved_storage is local_file. We should instead reject it for any persistent secret creation. Also, this check should be done before calling individual plugged secret storage to handle StoreSecret behavior.

cc @samansmink 