### PR TITLE
fix: drop secret if exists on non-existing secret should not cause ex

### DIFF
--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -385,16 +385,18 @@ void SecretManager::DropSecretByName(CatalogTransaction transaction, const strin
 		    name, list_of_matches);
 	}
 
-	if (matches.empty() && on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-		string storage_str;
-		if (!storage.empty()) {
-			storage_str = " for storage '" + storage + "'";
+	if (matches.empty()) {
+		if (on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+			string storage_str;
+			if (!storage.empty()) {
+				storage_str = " for storage '" + storage + "'";
+			}
+			throw InvalidInputException("Failed to remove non-existent secret with name '%s'%s", name, storage_str);
 		}
-
-		throw InvalidInputException("Failed to remove non-existent secret with name '%s'%s", name, storage_str);
+		// Do nothing on OnEntryNotFound::RETURN_NULL...
+	} else {
+		matches[0].get().DropSecretByName(transaction, name, on_entry_not_found);
 	}
-
-	matches[0].get().DropSecretByName(transaction, name, on_entry_not_found);
 }
 
 SecretType SecretManager::LookupType(CatalogTransaction transaction, const string &type) {

--- a/test/sql/secrets/create_secret_defaults.test
+++ b/test/sql/secrets/create_secret_defaults.test
@@ -11,6 +11,9 @@ require httpfs
 statement ok
 set allow_persistent_secrets=false;
 
+statement ok
+DROP SECRET IF EXISTS s1;
+
 # Without name we use the __default_<type> name. The default config for for the S3 type is config
 statement ok
 CREATE SECRET (


### PR DESCRIPTION
Minor logic fix so that we don't get `INTERNAL Error: Attempted to access index 0 within vector of size 0` when user tries to drop a secret that doesn't exist with `OnEntryNotFound::RETURN_NULL` mode.

cc @samansmink 