### PR TITLE
In .mode json in the shell use standard float output method

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -11856,7 +11856,6 @@ static int shell_callback(
         if( (azArg[i]==0) || (aiType && aiType[i]==SQLITE_NULL) ){
           fputs("null",p->out);
         }else if( aiType && aiType[i]==SQLITE_FLOAT ){
-          char z[50];
           double r = sqlite3_column_double(p->pStmt, i);
           sqlite3_uint64 ur;
           memcpy(&ur,&r,sizeof(r));
@@ -11865,8 +11864,7 @@ static int shell_callback(
           }else if( ur==0xfff0000000000000LL ){
             raw_printf(p->out, "-1e999");
           }else{
-            sqlite3_snprintf(50,z,"%!.20g", r);
-            raw_printf(p->out, "%s", z);
+            utf8_printf(p->out, "%s", azArg[i]);
           }
         }else if( aiType && aiType[i]==SQLITE_BLOB && p->pStmt ){
           const void *pBlob = sqlite3_column_blob(p->pStmt, i);


### PR DESCRIPTION
The shell has special code to deal with floating point numbers in JSON format because JSON formally does not support IEEE floating point numbers (it does not support nan/inf values). However it also reverts to a different floating point rendering method that leads to unnecessary precision - this PR reverts it to use the standard rendering.

#### Old
```
D .mode json
D select 4.4 as a;
[{"a":4.4000000000000003552}]
```

#### New
```
D .mode json
D select 4.4 as a;
[{"a":4.4}]
```