### PR TITLE
Sequence clean-up - move all sequence access through a SequenceData entry that is concurrency safe

### DIFF
--- a/src/catalog/catalog_entry/sequence_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/sequence_catalog_entry.cpp
@@ -5,43 +5,102 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/parser/parsed_data/create_sequence_info.hpp"
 #include "duckdb/catalog/dependency_manager.hpp"
+#include "duckdb/common/operator/add.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 
 #include <algorithm>
 #include <sstream>
 
 namespace duckdb {
 
+SequenceData::SequenceData(CreateSequenceInfo &info)
+    : usage_count(info.usage_count), counter(info.start_value), increment(info.increment),
+      start_value(info.start_value), min_value(info.min_value), max_value(info.max_value), cycle(info.cycle) {
+}
+
 SequenceCatalogEntry::SequenceCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateSequenceInfo &info)
-    : StandardEntry(CatalogType::SEQUENCE_ENTRY, schema, catalog, info.name), usage_count(info.usage_count),
-      counter(info.start_value), increment(info.increment), start_value(info.start_value), min_value(info.min_value),
-      max_value(info.max_value), cycle(info.cycle) {
+    : StandardEntry(CatalogType::SEQUENCE_ENTRY, schema, catalog, info.name), data(info) {
 	this->temporary = info.temporary;
 }
 
-unique_ptr<CreateInfo> SequenceCatalogEntry::GetInfo() const {
-	auto result = make_uniq<CreateSequenceInfo>();
+SequenceData SequenceCatalogEntry::GetData() const {
 	lock_guard<mutex> seqlock(lock);
+	return data;
+}
+
+int64_t SequenceCatalogEntry::CurrentValue() {
+	lock_guard<mutex> seqlock(lock);
+	int64_t result;
+	if (data.usage_count == 0u) {
+		throw SequenceException("currval: sequence is not yet defined in this session");
+	}
+	result = data.last_value;
+	return result;
+}
+
+int64_t SequenceCatalogEntry::NextValue(DuckTransaction &transaction) {
+	lock_guard<mutex> seqlock(lock);
+	int64_t result;
+	result = data.counter;
+	bool overflow = !TryAddOperator::Operation(data.counter, data.increment, data.counter);
+	if (data.cycle) {
+		if (overflow) {
+			data.counter = data.increment < 0 ? data.max_value : data.min_value;
+		} else if (data.counter < data.min_value) {
+			data.counter = data.max_value;
+		} else if (data.counter > data.max_value) {
+			data.counter = data.min_value;
+		}
+	} else {
+		if (result < data.min_value || (overflow && data.increment < 0)) {
+			throw SequenceException("nextval: reached minimum value of sequence \"%s\" (%lld)", name, data.min_value);
+		}
+		if (result > data.max_value || overflow) {
+			throw SequenceException("nextval: reached maximum value of sequence \"%s\" (%lld)", name, data.max_value);
+		}
+	}
+	data.last_value = result;
+	data.usage_count++;
+	if (!temporary) {
+		transaction.sequence_usage[this] = SequenceValue(data.usage_count, data.counter);
+	}
+	return result;
+}
+
+void SequenceCatalogEntry::ReplayValue(uint64_t v_usage_count, int64_t v_counter) {
+	if (v_usage_count > data.usage_count) {
+		data.usage_count = v_usage_count;
+		data.counter = v_counter;
+	}
+}
+
+unique_ptr<CreateInfo> SequenceCatalogEntry::GetInfo() const {
+	auto seq_data = GetData();
+
+	auto result = make_uniq<CreateSequenceInfo>();
 	result->catalog = catalog.GetName();
 	result->schema = schema.name;
 	result->name = name;
-	result->usage_count = usage_count;
-	result->increment = increment;
-	result->min_value = min_value;
-	result->max_value = max_value;
-	result->start_value = counter;
-	result->cycle = cycle;
+	result->usage_count = seq_data.usage_count;
+	result->increment = seq_data.increment;
+	result->min_value = seq_data.min_value;
+	result->max_value = seq_data.max_value;
+	result->start_value = seq_data.counter;
+	result->cycle = seq_data.cycle;
 	return std::move(result);
 }
 
 string SequenceCatalogEntry::ToSQL() const {
+	auto seq_data = GetData();
+
 	std::stringstream ss;
 	ss << "CREATE SEQUENCE ";
 	ss << name;
-	ss << " INCREMENT BY " << increment;
-	ss << " MINVALUE " << min_value;
-	ss << " MAXVALUE " << max_value;
-	ss << " START " << counter;
-	ss << " " << (cycle ? "CYCLE" : "NO CYCLE") << ";";
+	ss << " INCREMENT BY " << seq_data.increment;
+	ss << " MINVALUE " << seq_data.min_value;
+	ss << " MAXVALUE " << seq_data.max_value;
+	ss << " START " << seq_data.counter;
+	ss << " " << (seq_data.cycle ? "CYCLE" : "NO CYCLE") << ";";
 	return ss.str();
 }
 } // namespace duckdb

--- a/src/catalog/catalog_entry/sequence_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/sequence_catalog_entry.cpp
@@ -20,6 +20,7 @@ SequenceCatalogEntry::SequenceCatalogEntry(Catalog &catalog, SchemaCatalogEntry 
 
 unique_ptr<CreateInfo> SequenceCatalogEntry::GetInfo() const {
 	auto result = make_uniq<CreateSequenceInfo>();
+	lock_guard<mutex> seqlock(lock);
 	result->catalog = catalog.GetName();
 	result->schema = schema.name;
 	result->name = name;

--- a/src/function/table/system/duckdb_sequences.cpp
+++ b/src/function/table/system/duckdb_sequences.cpp
@@ -87,6 +87,7 @@ void DuckDBSequencesFunction(ClientContext &context, TableFunctionInput &data_p,
 	idx_t count = 0;
 	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &seq = data.entries[data.offset++].get();
+		auto seq_data = seq.GetData();
 
 		// return values:
 		idx_t col = 0;
@@ -105,17 +106,17 @@ void DuckDBSequencesFunction(ClientContext &context, TableFunctionInput &data_p,
 		// temporary, BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(seq.temporary));
 		// start_value, BIGINT
-		output.SetValue(col++, count, Value::BIGINT(seq.start_value));
+		output.SetValue(col++, count, Value::BIGINT(seq_data.start_value));
 		// min_value, BIGINT
-		output.SetValue(col++, count, Value::BIGINT(seq.min_value));
+		output.SetValue(col++, count, Value::BIGINT(seq_data.min_value));
 		// max_value, BIGINT
-		output.SetValue(col++, count, Value::BIGINT(seq.max_value));
+		output.SetValue(col++, count, Value::BIGINT(seq_data.max_value));
 		// increment_by, BIGINT
-		output.SetValue(col++, count, Value::BIGINT(seq.increment));
+		output.SetValue(col++, count, Value::BIGINT(seq_data.increment));
 		// cycle, BOOLEAN
-		output.SetValue(col++, count, Value::BOOLEAN(seq.cycle));
+		output.SetValue(col++, count, Value::BOOLEAN(seq_data.cycle));
 		// last_value, BIGINT
-		output.SetValue(col++, count, seq.usage_count == 0 ? Value() : Value::BOOLEAN(seq.last_value));
+		output.SetValue(col++, count, seq_data.usage_count == 0 ? Value() : Value::BOOLEAN(seq_data.last_value));
 		// sql, LogicalType::VARCHAR
 		output.SetValue(col++, count, Value(seq.ToSQL()));
 

--- a/src/include/duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp
@@ -36,7 +36,7 @@ public:
 	SequenceCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateSequenceInfo &info);
 
 	//! Lock for getting a value on the sequence
-	mutex lock;
+	mutable mutex lock;
 	//! The amount of times the sequence has been used
 	uint64_t usage_count;
 	//! The sequence counter

--- a/src/include/duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"
 
 namespace duckdb {
+class DuckTransaction;
 
 struct SequenceValue {
 	SequenceValue() : usage_count(0), counter(-1) {
@@ -25,18 +26,9 @@ struct SequenceValue {
 	int64_t counter;
 };
 
-//! A sequence catalog entry
-class SequenceCatalogEntry : public StandardEntry {
-public:
-	static constexpr const CatalogType Type = CatalogType::SEQUENCE_ENTRY;
-	static constexpr const char *Name = "sequence";
+struct SequenceData {
+	explicit SequenceData(CreateSequenceInfo &info);
 
-public:
-	//! Create a real TableCatalogEntry and initialize storage for it
-	SequenceCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateSequenceInfo &info);
-
-	//! Lock for getting a value on the sequence
-	mutable mutex lock;
 	//! The amount of times the sequence has been used
 	uint64_t usage_count;
 	//! The sequence counter
@@ -53,10 +45,32 @@ public:
 	int64_t max_value;
 	//! Whether or not the sequence cycles
 	bool cycle;
+};
+
+//! A sequence catalog entry
+class SequenceCatalogEntry : public StandardEntry {
+public:
+	static constexpr const CatalogType Type = CatalogType::SEQUENCE_ENTRY;
+	static constexpr const char *Name = "sequence";
+
+public:
+	//! Create a real TableCatalogEntry and initialize storage for it
+	SequenceCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateSequenceInfo &info);
 
 public:
 	unique_ptr<CreateInfo> GetInfo() const override;
 
+	SequenceData GetData() const;
+	int64_t CurrentValue();
+	int64_t NextValue(DuckTransaction &transaction);
+	void ReplayValue(uint64_t usage_count, int64_t counter);
+
 	string ToSQL() const override;
+
+private:
+	//! Lock for getting a value on the sequence
+	mutable mutex lock;
+	//! Sequence data
+	SequenceData data;
 };
 } // namespace duckdb

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -473,10 +473,7 @@ void WriteAheadLogDeserializer::ReplaySequenceValue() {
 
 	// fetch the sequence from the catalog
 	auto &seq = catalog.GetEntry<SequenceCatalogEntry>(context, schema, name);
-	if (usage_count > seq.usage_count) {
-		seq.usage_count = usage_count;
-		seq.counter = counter;
-	}
+	seq.ReplayValue(usage_count, counter);
 }
 
 //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Fixes a thread-sanitizer issue around sequences and generally cleans up the code.