### PR TITLE
Allow S3 URL style to be configured from environment

### DIFF
--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -42,6 +42,7 @@ struct AWSEnvironmentCredentialsProvider {
 	static constexpr const char *SECRET_KEY_ENV_VAR = "AWS_SECRET_ACCESS_KEY";
 	static constexpr const char *SESSION_TOKEN_ENV_VAR = "AWS_SESSION_TOKEN";
 	static constexpr const char *DUCKDB_ENDPOINT_ENV_VAR = "DUCKDB_S3_ENDPOINT";
+	static constexpr const char *DUCKDB_URL_STYLE_ENV_VAR = "DUCKDB_S3_URL_STYLE";
 	static constexpr const char *DUCKDB_USE_SSL_ENV_VAR = "DUCKDB_S3_USE_SSL";
 
 	explicit AWSEnvironmentCredentialsProvider(DBConfig &config) : config(config) {};

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -161,6 +161,7 @@ void AWSEnvironmentCredentialsProvider::SetAll() {
 	this->SetExtensionOptionValue("s3_secret_access_key", this->SECRET_KEY_ENV_VAR);
 	this->SetExtensionOptionValue("s3_session_token", this->SESSION_TOKEN_ENV_VAR);
 	this->SetExtensionOptionValue("s3_endpoint", this->DUCKDB_ENDPOINT_ENV_VAR);
+	this->SetExtensionOptionValue("s3_url_style", this->DUCKDB_URL_STYLE_ENV_VAR);
 	this->SetExtensionOptionValue("s3_use_ssl", this->DUCKDB_USE_SSL_ENV_VAR);
 }
 
@@ -173,6 +174,7 @@ S3AuthParams AWSEnvironmentCredentialsProvider::CreateParams() {
 	params.secret_access_key = this->SECRET_KEY_ENV_VAR;
 	params.session_token = this->SESSION_TOKEN_ENV_VAR;
 	params.endpoint = this->DUCKDB_ENDPOINT_ENV_VAR;
+	params.url_style = this->DUCKDB_URL_STYLE_ENV_VAR;
 	params.use_ssl = this->DUCKDB_USE_SSL_ENV_VAR;
 
 	return params;


### PR DESCRIPTION
Adding `DUCKDB_S3_URL_STYLE` environment variable for consistency with the other `s3_X` configuration parameters in the `s3fs` extension.