### PR TITLE
UNPIVOT - maintain original types and throw a better exception if type matching is not possible

### DIFF
--- a/src/core_functions/scalar/list/list_value.cpp
+++ b/src/core_functions/scalar/list/list_value.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/storage/statistics/list_stats.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/parser/query_error_context.hpp"
 
 namespace duckdb {
 
@@ -41,8 +42,19 @@ static unique_ptr<FunctionData> ListValueBind(ClientContext &context, ScalarFunc
 	for (idx_t i = 1; i < arguments.size(); i++) {
 		auto arg_type = ExpressionBinder::GetExpressionReturnType(*arguments[i]);
 		if (!LogicalType::TryGetMaxLogicalType(context, child_type, arg_type, child_type)) {
-			throw BinderException("Cannot create a list of types %s and %s - an explicit cast is required",
-			                      child_type.ToString(), arg_type.ToString());
+			string list_arguments = "Full list: ";
+			idx_t error_index = list_arguments.size();
+			for(idx_t k = 0; k < arguments.size(); k++) {
+				if (k > 0) {
+					list_arguments += ", ";
+				}
+				if (k == i) {
+					error_index = list_arguments.size();
+				}
+				list_arguments += arguments[k]->ToString() + " " + arguments[k]->return_type.ToString();
+			}
+			auto error = StringUtil::Format("Cannot create a list of types %s and %s - an explicit cast is required", child_type.ToString(), arg_type.ToString());
+			throw BinderException(QueryErrorContext::Format(list_arguments, error, int(error_index), false));
 		}
 	}
 	child_type = LogicalType::NormalizeType(child_type);

--- a/src/core_functions/scalar/list/list_value.cpp
+++ b/src/core_functions/scalar/list/list_value.cpp
@@ -44,7 +44,7 @@ static unique_ptr<FunctionData> ListValueBind(ClientContext &context, ScalarFunc
 		if (!LogicalType::TryGetMaxLogicalType(context, child_type, arg_type, child_type)) {
 			string list_arguments = "Full list: ";
 			idx_t error_index = list_arguments.size();
-			for(idx_t k = 0; k < arguments.size(); k++) {
+			for (idx_t k = 0; k < arguments.size(); k++) {
 				if (k > 0) {
 					list_arguments += ", ";
 				}
@@ -53,7 +53,8 @@ static unique_ptr<FunctionData> ListValueBind(ClientContext &context, ScalarFunc
 				}
 				list_arguments += arguments[k]->ToString() + " " + arguments[k]->return_type.ToString();
 			}
-			auto error = StringUtil::Format("Cannot create a list of types %s and %s - an explicit cast is required", child_type.ToString(), arg_type.ToString());
+			auto error = StringUtil::Format("Cannot create a list of types %s and %s - an explicit cast is required",
+			                                child_type.ToString(), arg_type.ToString());
 			throw BinderException(QueryErrorContext::Format(list_arguments, error, int(error_index), false));
 		}
 	}

--- a/src/include/duckdb/parser/query_error_context.hpp
+++ b/src/include/duckdb/parser/query_error_context.hpp
@@ -29,7 +29,7 @@ public:
 	idx_t query_location;
 
 public:
-	DUCKDB_API static string Format(const string &query, const string &error_message, int error_location);
+	DUCKDB_API static string Format(const string &query, const string &error_message, int error_location, bool add_line_indicator = true);
 
 	DUCKDB_API string FormatErrorRecursive(const string &msg, vector<ExceptionFormatValue> &values);
 	template <class T, typename... Args>

--- a/src/include/duckdb/parser/query_error_context.hpp
+++ b/src/include/duckdb/parser/query_error_context.hpp
@@ -29,7 +29,8 @@ public:
 	idx_t query_location;
 
 public:
-	DUCKDB_API static string Format(const string &query, const string &error_message, int error_location, bool add_line_indicator = true);
+	DUCKDB_API static string Format(const string &query, const string &error_message, int error_location,
+	                                bool add_line_indicator = true);
 
 	DUCKDB_API string FormatErrorRecursive(const string &msg, vector<ExceptionFormatValue> &values);
 	template <class T, typename... Args>

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -7,7 +7,8 @@
 
 namespace duckdb {
 
-string QueryErrorContext::Format(const string &query, const string &error_message, int error_loc, bool add_line_indicator) {
+string QueryErrorContext::Format(const string &query, const string &error_message, int error_loc,
+                                 bool add_line_indicator) {
 	if (error_loc < 0 || size_t(error_loc) >= query.size()) {
 		// no location in query provided
 		return error_message;

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -7,7 +7,7 @@
 
 namespace duckdb {
 
-string QueryErrorContext::Format(const string &query, const string &error_message, int error_loc) {
+string QueryErrorContext::Format(const string &query, const string &error_message, int error_loc, bool add_line_indicator) {
 	if (error_loc < 0 || size_t(error_loc) >= query.size()) {
 		// no location in query provided
 		return error_message;
@@ -90,7 +90,10 @@ string QueryErrorContext::Format(const string &query, const string &error_messag
 			break;
 		}
 	}
-	string line_indicator = "LINE " + to_string(line_number) + ": ";
+	string line_indicator;
+	if (add_line_indicator) {
+		line_indicator = "LINE " + to_string(line_number) + ": ";
+	}
 	string begin_trunc = truncate_beginning ? "..." : "";
 	string end_trunc = truncate_end ? "..." : "";
 

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -561,8 +561,7 @@ unique_ptr<SelectNode> Binder::BindUnpivot(Binder &child_binder, PivotRef &ref,
 		expressions.reserve(unpivot.entries.size());
 		for (auto &entry : unpivot.entries) {
 			auto colref = make_uniq<ColumnRefExpression>(entry.values[v_idx].ToString());
-			auto cast = make_uniq<CastExpression>(LogicalType::VARCHAR, std::move(colref));
-			expressions.push_back(std::move(cast));
+			expressions.push_back(std::move(colref));
 		}
 		unpivot_expressions.push_back(std::move(expressions));
 	}

--- a/test/sql/pivot/test_unpivot.test
+++ b/test/sql/pivot/test_unpivot.test
@@ -135,29 +135,12 @@ SELECT empid, dept, april, month, sales FROM monthly_sales
 ----
 referenced in UNPIVOT but no matching entry was found in the table
 
-# what if there are no columns left?
-query II
+# mix of types in pivot
+statement error
 SELECT * FROM monthly_sales
     UNPIVOT(sales FOR month IN (empid, dept, jan, feb, mar, april))
 ----
-empid	1
-dept	electronics
-Jan	100
-Feb	200
-Mar	300
-April	100
-empid	2
-dept	clothes
-Jan	100
-Feb	300
-Mar	150
-April	200
-empid	3
-dept	cars
-Jan	200
-Feb	400
-Mar	100
-April	50
+an explicit cast is required
 
 # unpivot over subquery
 query IIIII

--- a/test/sql/pivot/unpivot_types.test
+++ b/test/sql/pivot/unpivot_types.test
@@ -1,0 +1,18 @@
+# name: test/sql/pivot/unpivot_types.test
+# description: Test return types of UNPIVOT statement
+# group: [pivot]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+SELECT column_name, column_type FROM (DESCRIBE unpivot ( select 42) on columns(*))
+----
+name	VARCHAR
+value	INTEGER
+
+query II
+SELECT column_name, column_type FROM (DESCRIBE unpivot ( select {n : 1 }) on columns(*))
+----
+name	VARCHAR
+value	STRUCT(n INTEGER)


### PR DESCRIPTION
Follow-up from #10115

UNPIVOT maintains the original input types again as it did previously. It also now requires types to be implicitly castable to one another, otherwise the UNPIVOT statement will fail:

```sql
UNPIVOT (SELECT 42 AS Jan, 'hello' as Feb) ON Jan, Feb;
-- Error: Binder Error: Cannot create a list of types INTEGER and VARCHAR - an explicit cast is required
-- Full list: Jan INTEGER, Feb VARCHAR
--                         ^
UNPIVOT (SELECT 42::VARCHAR AS Jan, 'hello' as Feb) ON Jan, Feb;
┌─────────┬─────────┐
│  name   │  value  │
│ varchar │ varchar │
├─────────┼─────────┤
│ Jan     │ 42      │
│ Feb     │ hello   │
└─────────┴─────────┘

```

This matches the behavior of both BigQuery and Snowflake. 
