### PR TITLE
Correctly account for ORDER BY in ColumnLifetimeAnalyzer optimization pass

### DIFF
--- a/src/optimizer/column_lifetime_analyzer.cpp
+++ b/src/optimizer/column_lifetime_analyzer.cpp
@@ -110,6 +110,12 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 		analyzer.VisitOperator(*op.children[0]);
 		return;
 	}
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		// order by, for now reference all columns
+		// FIXME: for ORDER BY we remove columns below an ORDER BY, we just need to make sure that the projections are
+		// updated
+		everything_referenced = true;
+		break;
 	case LogicalOperatorType::LOGICAL_DISTINCT: {
 		// distinct, all projected columns are used for the DISTINCT computation
 		// mark all columns as used and continue to the children

--- a/test/sql/binder/order_by_view.test
+++ b/test/sql/binder/order_by_view.test
@@ -1,0 +1,15 @@
+# name: test/sql/binder/order_by_view.test
+# description: Test ORDER BY a view with DISTINCT ON
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE src("Name" VARCHAR, CreatedAt TIMESTAMP, userID VARCHAR, "Version" VARCHAR, Clients BIGINT, HasDocumentation BOOLEAN, HasCustomAddress BOOLEAN, HasHostname BOOLEAN, RunningContainers BIGINT, HasActions BOOLEAN);
+
+statement ok
+CREATE VIEW model AS SELECT DISTINCT on(userID,  date_trunc('day', CreatedAt))  date_trunc('day', CreatedAt) AS CreatedAt, "Version", Clients, HasCustomAddress, HasHostname, RunningContainers, HasDocumentation, HasActions  FROM src WHERE name = 'events' ORDER BY userID, CreatedAt DESC;
+
+statement ok
+SELECT HasCustomAddress,count(*) AS total_records FROM model WHERE     1 = 1     AND CreatedAt >= '2023-12-01'     AND CreatedAt < '2023-12-13' GROUP BY     HasCustomAddress ORDER BY     true,     total_records DESC NULLS LAST LIMIT 250 OFFSET 0;


### PR DESCRIPTION
This fixes an internal error that could be triggered by the `ColumnLifetimeAnalyzer` during the binding process if an `ORDER BY` was used in the middle of a query