### PR TITLE
Store unqualified macro parameters, qualify before binding

### DIFF
--- a/src/planner/binder/expression/bind_macro_expression.cpp
+++ b/src/planner/binder/expression/bind_macro_expression.cpp
@@ -146,6 +146,11 @@ BindResult ExpressionBinder::BindMacro(FunctionExpression &function, ScalarMacro
 	// replace current expression with stored macro expression
 	expr = macro_def.expression->Copy();
 
+	// qualify only the macro parameters with a new empty binder that only knows the macro binding
+	auto dummy_binder = Binder::CreateBinder(context);
+	dummy_binder->macro_binding = new_macro_binding.get();
+	ExpressionBinder::QualifyColumnNames(*dummy_binder, expr);
+
 	// now replace the parameters
 	vector<unordered_set<string>> lambda_params;
 	ReplaceMacroParameters(expr, lambda_params);

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -175,10 +175,10 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 	}
 	auto this_macro_binding = make_uniq<DummyBinding>(dummy_types, dummy_names, base.name);
 	macro_binding = this_macro_binding.get();
-	ExpressionBinder::QualifyColumnNames(*this, scalar_function.expression);
 
 	// create a copy of the expression because we do not want to alter the original
 	auto expression = scalar_function.expression->Copy();
+	ExpressionBinder::QualifyColumnNames(*this, expression);
 
 	// bind it to verify the function was defined correctly
 	string error;

--- a/test/sql/catalog/function/test_simple_macro.test
+++ b/test/sql/catalog/function/test_simple_macro.test
@@ -334,13 +334,13 @@ create macro zz2(x) as 20+x;
 query II
 select zz1(1),zz2(2);
 ----
-a
+11	22
 
-# should not return any results
+# should not return any results (because we shouldn't display "macro_parameters"
 query III
 select function_name, parameters, macro_definition
 from duckdb_functions()
 where function_name like 'zz%'
-and macro_definition not like '%macro_parameters%';
+and macro_definition like '%macro_parameters%';
 ----
 

--- a/test/sql/catalog/function/test_simple_macro.test
+++ b/test/sql/catalog/function/test_simple_macro.test
@@ -323,3 +323,24 @@ SELECT my_macro(x := 42);
 statement error
 SELECT my_macro(a := 42, a := 42);
 ----
+
+# internal issue 1044
+statement ok
+create macro zz1(x) as (select 10+x);
+
+statement ok
+create macro zz2(x) as 20+x;
+
+query II
+select zz1(1),zz2(2);
+----
+a
+
+# should not return any results
+query III
+select function_name, parameters, macro_definition
+from duckdb_functions()
+where function_name like 'zz%'
+and macro_definition not like '%macro_parameters%';
+----
+


### PR DESCRIPTION
We accidentally stored qualified macro parameters, causing the following behavior:
```sql
create macro zz1(x) as (select 10+x);
create macro zz2(x) as 20+x;

select zz1(1),zz2(2);
┌────────┬────────┐
│ zz1(1) │ zz2(2) │
│ int32  │ int32  │
├────────┼────────┤
│     11 │     22 │
└────────┴────────┘

select function_name, parameters, macro_definition
from duckdb_functions()
where function_name like 'zz%';
┌───────────────┬────────────┬──────────────────────────────────┐
│ function_name │ parameters │         macro_definition         │
│    varchar    │ varchar[]  │             varchar              │
├───────────────┼────────────┼──────────────────────────────────┤
│ zz1           │ [x]        │ (SELECT (10 + x))                │
│ zz2           │ [x]        │ (20 + "0_macro_parameterszz2".x) │
└───────────────┴────────────┴──────────────────────────────────┘
```
As we can see, the macro definition includes the qualified macro parameter. This PR changes the behavior so we do not store the qualified macro parameter. Now, we qualify the macro parameters right before binding, when the macro is called.