### PR TITLE
Fix 9384

### DIFF
--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -247,7 +247,7 @@ void Binder::BindLogicalType(ClientContext &context, LogicalType &type, optional
 			}
 
 			if (type.id() == LogicalTypeId::INVALID) {
-				type = Catalog::GetType(context, INVALID_CATALOG, schema, user_type_name);
+				type = Catalog::GetType(context, INVALID_CATALOG, INVALID_SCHEMA, user_type_name);
 			}
 		} else {
 			string type_catalog = UserType::GetCatalog(type);

--- a/test/issues/general/test_9384.test
+++ b/test/issues/general/test_9384.test
@@ -1,0 +1,25 @@
+# name: test/issues/general/test_9384.test
+# description: Issue 9384: DuckDB fails when trying to add a JSON column to an existing table via ALTER TABLE
+# group: [general]
+
+require json
+
+statement ok
+create schema my_schema;
+
+statement ok
+use my_schema;
+
+statement ok
+create table t1 (i json);
+
+statement ok
+alter table t1 add column my_col json;
+
+require inet
+
+statement ok
+create table t2 (i inet);
+
+statement ok
+alter table t2 add column my_col inet;


### PR DESCRIPTION
Fixes #9384

The comment in `Binder::BindLogicalType` explained clearly the desired behavior:
```
// The search order is:
// 1) In the same schema as the table
// 2) In the same catalog
// 3) System catalog
```
But the implementation made a mistake at 3), which this PR corrects.