### PR TITLE
[Dev][Util] Have `unittest` respect the `--start-offset` parameter when used alongside `-l`

### DIFF
--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -11,6 +11,7 @@ parser.add_argument('unittest_program', help='Path to the unittest program')
 parser.add_argument('--no-exit', action='store_true', help='Do not exit after running tests')
 parser.add_argument('--profile', action='store_true', help='Enable profiling')
 parser.add_argument('--no-assertions', action='store_false', help='Disable assertions')
+parser.add_argument('--time_execution', action='store_true', help='Measure and print the execution time of each test')
 
 args, extra_args = parser.parse_known_args()
 
@@ -22,6 +23,7 @@ unittest_program = args.unittest_program
 no_exit = args.no_exit
 profile = args.profile
 assertions = args.no_assertions
+time_execution = args.time_execution
 
 # Use the '-l' parameter to output the list of tests to run
 proc = subprocess.Popen([unittest_program, '-l'] + extra_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -72,10 +74,14 @@ for test_number, test_case in enumerate(test_cases):
     stdout = res.stdout.decode('utf8')
     stderr = res.stderr.decode('utf8')
     end = time.time()
+
+    additional_data = ""
     if assertions:
-        print(" (" + parse_assertions(stdout) + ")")
-    else:
-        print()
+        additional_data += " (" + parse_assertions(stdout) + ")"
+    if args.time_execution:
+        additional_data += f" (Time: {end - start:.4f} seconds)"
+
+    print(additional_data)
     if profile:
         print(f'{test_case}	{end - start}')
     if res.returncode is not None and res.returncode != 0:

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -4,35 +4,34 @@ import re
 import os
 import time
 
-no_exit = False
-profile = False
-assertions = True
+import argparse
 
-for i in range(len(sys.argv)):
-    if sys.argv[i] == '--no-exit':
-        no_exit = True
-        del sys.argv[i]
-        i -= 1
-    elif sys.argv[i] == '--profile':
-        profile = True
-        del sys.argv[i]
-        i -= 1
-    elif sys.argv[i] == '--no-assertions':
-        assertions = False
-        del sys.argv[i]
-        i -= 1
+parser = argparse.ArgumentParser(description='Run tests one by one with optional flags.')
+parser.add_argument('unittest_program', help='Path to the unittest program')
+parser.add_argument('--no-exit', action='store_true', help='Do not exit after running tests')
+parser.add_argument('--profile', action='store_true', help='Enable profiling')
+parser.add_argument('--no-assertions', action='store_false', help='Disable assertions')
 
-if len(sys.argv) < 2:
-    print(
-        "Expected usage: python3 scripts/run_tests_one_by_one.py build/debug/test/unittest [--no-exit] [--profile] [--no-assertions]"
-    )
-    exit(1)
-unittest_program = sys.argv[1]
-extra_args = []
-if len(sys.argv) > 2:
-    extra_args = [sys.argv[2]]
+args, extra_args = parser.parse_known_args()
+
+if not args.unittest_program:
+    parser.error('Path to unittest program is required')
+
+# Access the arguments
+unittest_program = args.unittest_program
+no_exit = args.no_exit
+profile = args.profile
+assertions = args.no_assertions
+
+# Access the extra arguments
+print(f'Unittest program: {unittest_program}')
+print(f'--no-exit: {no_exit}')
+print(f'--profile: {profile}')
+print(f'--no-assertions: {assertions}')
+print(f'Extra arguments: {extra_args}')
 
 
+# Use the '-l' parameter to output the list of tests to run
 proc = subprocess.Popen([unittest_program, '-l'] + extra_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 stdout = proc.stdout.read().decode('utf8')
 stderr = proc.stderr.read().decode('utf8')
@@ -43,6 +42,7 @@ if proc.returncode is not None and proc.returncode != 0:
     print(stderr)
     exit(1)
 
+# The output is in the format of 'PATH\tGROUP', we're only interested in the PATH portion
 test_cases = []
 first_line = True
 for line in stdout.splitlines():
@@ -72,11 +72,11 @@ def parse_assertions(stdout):
     return ""
 
 
-for test_number in range(test_count):
+for test_number, test_case in test_cases:
     if not profile:
-        print("[" + str(test_number) + "/" + str(test_count) + "]: " + test_cases[test_number], end="")
+        print("[" + str(test_number) + "/" + str(test_count) + "]: " + test_case, end="")
     start = time.time()
-    res = subprocess.run([unittest_program, test_cases[test_number]], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    res = subprocess.run([unittest_program, test_case], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout = res.stdout.decode('utf8')
     stderr = res.stderr.decode('utf8')
     end = time.time()
@@ -85,7 +85,7 @@ for test_number in range(test_count):
     else:
         print()
     if profile:
-        print(f'{test_cases[test_number]}	{end - start}')
+        print(f'{test_case}	{end - start}')
     if res.returncode is not None and res.returncode != 0:
         print("FAILURE IN RUNNING TEST")
         print(

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -23,14 +23,6 @@ no_exit = args.no_exit
 profile = args.profile
 assertions = args.no_assertions
 
-# Access the extra arguments
-print(f'Unittest program: {unittest_program}')
-print(f'--no-exit: {no_exit}')
-print(f'--profile: {profile}')
-print(f'--no-assertions: {assertions}')
-print(f'Extra arguments: {extra_args}')
-
-
 # Use the '-l' parameter to output the list of tests to run
 proc = subprocess.Popen([unittest_program, '-l'] + extra_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 stdout = proc.stdout.read().decode('utf8')
@@ -72,7 +64,7 @@ def parse_assertions(stdout):
     return ""
 
 
-for test_number, test_case in test_cases:
+for test_number, test_case in enumerate(test_cases):
     if not profile:
         print("[" + str(test_number) + "/" + str(test_count) + "]: " + test_case, end="")
     start = time.time()

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -5302,7 +5302,7 @@ namespace Catch {
         int endOffset = -1;
         int endOffsetPercentage = -1;
 
-        bool outputSQL = false;
+	    bool outputSQL = false;
 
         bool benchmarkNoAnalysis = false;
         unsigned int benchmarkSamples = 100;
@@ -8498,312 +8498,312 @@ namespace clara {
 namespace TextFlow {
 
 inline auto isWhitespace(char c) -> bool {
-    static std::string chars = " \t\n\r";
-    return chars.find(c) != std::string::npos;
+	static std::string chars = " \t\n\r";
+	return chars.find(c) != std::string::npos;
 }
 inline auto isBreakableBefore(char c) -> bool {
-    static std::string chars = "[({<|";
-    return chars.find(c) != std::string::npos;
+	static std::string chars = "[({<|";
+	return chars.find(c) != std::string::npos;
 }
 inline auto isBreakableAfter(char c) -> bool {
-    static std::string chars = "])}>.,:;*+-=&/\\";
-    return chars.find(c) != std::string::npos;
+	static std::string chars = "])}>.,:;*+-=&/\\";
+	return chars.find(c) != std::string::npos;
 }
 
 class Columns;
 
 class Column {
-    std::vector<std::string> m_strings;
-    size_t m_width = CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
-    size_t m_indent = 0;
-    size_t m_initialIndent = std::string::npos;
+	std::vector<std::string> m_strings;
+	size_t m_width = CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
+	size_t m_indent = 0;
+	size_t m_initialIndent = std::string::npos;
 
 public:
-    class iterator {
-        friend Column;
+	class iterator {
+		friend Column;
 
-        Column const& m_column;
-        size_t m_stringIndex = 0;
-        size_t m_pos = 0;
+		Column const& m_column;
+		size_t m_stringIndex = 0;
+		size_t m_pos = 0;
 
-        size_t m_len = 0;
-        size_t m_end = 0;
-        bool m_suffix = false;
+		size_t m_len = 0;
+		size_t m_end = 0;
+		bool m_suffix = false;
 
-        iterator(Column const& column, size_t stringIndex)
-            : m_column(column),
-            m_stringIndex(stringIndex) {}
+		iterator(Column const& column, size_t stringIndex)
+			: m_column(column),
+			m_stringIndex(stringIndex) {}
 
-        auto line() const -> std::string const& { return m_column.m_strings[m_stringIndex]; }
+		auto line() const -> std::string const& { return m_column.m_strings[m_stringIndex]; }
 
-        auto isBoundary(size_t at) const -> bool {
-            assert(at > 0);
-            assert(at <= line().size());
+		auto isBoundary(size_t at) const -> bool {
+			assert(at > 0);
+			assert(at <= line().size());
 
-            return at == line().size() ||
-                (isWhitespace(line()[at]) && !isWhitespace(line()[at - 1])) ||
-                isBreakableBefore(line()[at]) ||
-                isBreakableAfter(line()[at - 1]);
-        }
+			return at == line().size() ||
+				(isWhitespace(line()[at]) && !isWhitespace(line()[at - 1])) ||
+				isBreakableBefore(line()[at]) ||
+				isBreakableAfter(line()[at - 1]);
+		}
 
-        void calcLength() {
-            assert(m_stringIndex < m_column.m_strings.size());
+		void calcLength() {
+			assert(m_stringIndex < m_column.m_strings.size());
 
-            m_suffix = false;
-            auto width = m_column.m_width - indent();
-            m_end = m_pos;
-            if (line()[m_pos] == '\n') {
-                ++m_end;
-            }
-            while (m_end < line().size() && line()[m_end] != '\n')
-                ++m_end;
+			m_suffix = false;
+			auto width = m_column.m_width - indent();
+			m_end = m_pos;
+			if (line()[m_pos] == '\n') {
+				++m_end;
+			}
+			while (m_end < line().size() && line()[m_end] != '\n')
+				++m_end;
 
-            if (m_end < m_pos + width) {
-                m_len = m_end - m_pos;
-            } else {
-                size_t len = width;
-                while (len > 0 && !isBoundary(m_pos + len))
-                    --len;
-                while (len > 0 && isWhitespace(line()[m_pos + len - 1]))
-                    --len;
+			if (m_end < m_pos + width) {
+				m_len = m_end - m_pos;
+			} else {
+				size_t len = width;
+				while (len > 0 && !isBoundary(m_pos + len))
+					--len;
+				while (len > 0 && isWhitespace(line()[m_pos + len - 1]))
+					--len;
 
-                if (len > 0) {
-                    m_len = len;
-                } else {
-                    m_suffix = true;
-                    m_len = width - 1;
-                }
-            }
-        }
+				if (len > 0) {
+					m_len = len;
+				} else {
+					m_suffix = true;
+					m_len = width - 1;
+				}
+			}
+		}
 
-        auto indent() const -> size_t {
-            auto initial = m_pos == 0 && m_stringIndex == 0 ? m_column.m_initialIndent : std::string::npos;
-            return initial == std::string::npos ? m_column.m_indent : initial;
-        }
+		auto indent() const -> size_t {
+			auto initial = m_pos == 0 && m_stringIndex == 0 ? m_column.m_initialIndent : std::string::npos;
+			return initial == std::string::npos ? m_column.m_indent : initial;
+		}
 
-        auto addIndentAndSuffix(std::string const &plain) const -> std::string {
-            return std::string(indent(), ' ') + (m_suffix ? plain + "-" : plain);
-        }
+		auto addIndentAndSuffix(std::string const &plain) const -> std::string {
+			return std::string(indent(), ' ') + (m_suffix ? plain + "-" : plain);
+		}
 
-    public:
-        using difference_type = std::ptrdiff_t;
-        using value_type = std::string;
-        using pointer = value_type * ;
-        using reference = value_type & ;
-        using iterator_category = std::forward_iterator_tag;
+	public:
+		using difference_type = std::ptrdiff_t;
+		using value_type = std::string;
+		using pointer = value_type * ;
+		using reference = value_type & ;
+		using iterator_category = std::forward_iterator_tag;
 
-        explicit iterator(Column const& column) : m_column(column) {
-            assert(m_column.m_width > m_column.m_indent);
-            assert(m_column.m_initialIndent == std::string::npos || m_column.m_width > m_column.m_initialIndent);
-            calcLength();
-            if (m_len == 0)
-                m_stringIndex++; // Empty string
-        }
+		explicit iterator(Column const& column) : m_column(column) {
+			assert(m_column.m_width > m_column.m_indent);
+			assert(m_column.m_initialIndent == std::string::npos || m_column.m_width > m_column.m_initialIndent);
+			calcLength();
+			if (m_len == 0)
+				m_stringIndex++; // Empty string
+		}
 
-        auto operator *() const -> std::string {
-            assert(m_stringIndex < m_column.m_strings.size());
-            assert(m_pos <= m_end);
-            return addIndentAndSuffix(line().substr(m_pos, m_len));
-        }
+		auto operator *() const -> std::string {
+			assert(m_stringIndex < m_column.m_strings.size());
+			assert(m_pos <= m_end);
+			return addIndentAndSuffix(line().substr(m_pos, m_len));
+		}
 
-        auto operator ++() -> iterator& {
-            m_pos += m_len;
-            if (m_pos < line().size() && line()[m_pos] == '\n')
-                m_pos += 1;
-            else
-                while (m_pos < line().size() && isWhitespace(line()[m_pos]))
-                    ++m_pos;
+		auto operator ++() -> iterator& {
+			m_pos += m_len;
+			if (m_pos < line().size() && line()[m_pos] == '\n')
+				m_pos += 1;
+			else
+				while (m_pos < line().size() && isWhitespace(line()[m_pos]))
+					++m_pos;
 
-            if (m_pos == line().size()) {
-                m_pos = 0;
-                ++m_stringIndex;
-            }
-            if (m_stringIndex < m_column.m_strings.size())
-                calcLength();
-            return *this;
-        }
-        auto operator ++(int) -> iterator {
-            iterator prev(*this);
-            operator++();
-            return prev;
-        }
+			if (m_pos == line().size()) {
+				m_pos = 0;
+				++m_stringIndex;
+			}
+			if (m_stringIndex < m_column.m_strings.size())
+				calcLength();
+			return *this;
+		}
+		auto operator ++(int) -> iterator {
+			iterator prev(*this);
+			operator++();
+			return prev;
+		}
 
-        auto operator ==(iterator const& other) const -> bool {
-            return
-                m_pos == other.m_pos &&
-                m_stringIndex == other.m_stringIndex &&
-                &m_column == &other.m_column;
-        }
-        auto operator !=(iterator const& other) const -> bool {
-            return !operator==(other);
-        }
-    };
-    using const_iterator = iterator;
+		auto operator ==(iterator const& other) const -> bool {
+			return
+				m_pos == other.m_pos &&
+				m_stringIndex == other.m_stringIndex &&
+				&m_column == &other.m_column;
+		}
+		auto operator !=(iterator const& other) const -> bool {
+			return !operator==(other);
+		}
+	};
+	using const_iterator = iterator;
 
-    explicit Column(std::string const& text) { m_strings.push_back(text); }
+	explicit Column(std::string const& text) { m_strings.push_back(text); }
 
-    auto width(size_t newWidth) -> Column& {
-        assert(newWidth > 0);
-        m_width = newWidth;
-        return *this;
-    }
-    auto indent(size_t newIndent) -> Column& {
-        m_indent = newIndent;
-        return *this;
-    }
-    auto initialIndent(size_t newIndent) -> Column& {
-        m_initialIndent = newIndent;
-        return *this;
-    }
+	auto width(size_t newWidth) -> Column& {
+		assert(newWidth > 0);
+		m_width = newWidth;
+		return *this;
+	}
+	auto indent(size_t newIndent) -> Column& {
+		m_indent = newIndent;
+		return *this;
+	}
+	auto initialIndent(size_t newIndent) -> Column& {
+		m_initialIndent = newIndent;
+		return *this;
+	}
 
-    auto width() const -> size_t { return m_width; }
-    auto begin() const -> iterator { return iterator(*this); }
-    auto end() const -> iterator { return { *this, m_strings.size() }; }
+	auto width() const -> size_t { return m_width; }
+	auto begin() const -> iterator { return iterator(*this); }
+	auto end() const -> iterator { return { *this, m_strings.size() }; }
 
-    inline friend std::ostream& operator << (std::ostream& os, Column const& col) {
-        bool first = true;
-        for (auto line : col) {
-            if (first)
-                first = false;
-            else
-                os << "\n";
-            os << line;
-        }
-        return os;
-    }
+	inline friend std::ostream& operator << (std::ostream& os, Column const& col) {
+		bool first = true;
+		for (auto line : col) {
+			if (first)
+				first = false;
+			else
+				os << "\n";
+			os << line;
+		}
+		return os;
+	}
 
-    auto operator + (Column const& other)->Columns;
+	auto operator + (Column const& other)->Columns;
 
-    auto toString() const -> std::string {
-        std::ostringstream oss;
-        oss << *this;
-        return oss.str();
-    }
+	auto toString() const -> std::string {
+		std::ostringstream oss;
+		oss << *this;
+		return oss.str();
+	}
 };
 
 class Spacer : public Column {
 
 public:
-    explicit Spacer(size_t spaceWidth) : Column("") {
-        width(spaceWidth);
-    }
+	explicit Spacer(size_t spaceWidth) : Column("") {
+		width(spaceWidth);
+	}
 };
 
 class Columns {
-    std::vector<Column> m_columns;
+	std::vector<Column> m_columns;
 
 public:
 
-    class iterator {
-        friend Columns;
-        struct EndTag {};
+	class iterator {
+		friend Columns;
+		struct EndTag {};
 
-        std::vector<Column> const& m_columns;
-        std::vector<Column::iterator> m_iterators;
-        size_t m_activeIterators;
+		std::vector<Column> const& m_columns;
+		std::vector<Column::iterator> m_iterators;
+		size_t m_activeIterators;
 
-        iterator(Columns const& columns, EndTag)
-            : m_columns(columns.m_columns),
-            m_activeIterators(0) {
-            m_iterators.reserve(m_columns.size());
+		iterator(Columns const& columns, EndTag)
+			: m_columns(columns.m_columns),
+			m_activeIterators(0) {
+			m_iterators.reserve(m_columns.size());
 
-            for (auto const& col : m_columns)
-                m_iterators.push_back(col.end());
-        }
+			for (auto const& col : m_columns)
+				m_iterators.push_back(col.end());
+		}
 
-    public:
-        using difference_type = std::ptrdiff_t;
-        using value_type = std::string;
-        using pointer = value_type * ;
-        using reference = value_type & ;
-        using iterator_category = std::forward_iterator_tag;
+	public:
+		using difference_type = std::ptrdiff_t;
+		using value_type = std::string;
+		using pointer = value_type * ;
+		using reference = value_type & ;
+		using iterator_category = std::forward_iterator_tag;
 
-        explicit iterator(Columns const& columns)
-            : m_columns(columns.m_columns),
-            m_activeIterators(m_columns.size()) {
-            m_iterators.reserve(m_columns.size());
+		explicit iterator(Columns const& columns)
+			: m_columns(columns.m_columns),
+			m_activeIterators(m_columns.size()) {
+			m_iterators.reserve(m_columns.size());
 
-            for (auto const& col : m_columns)
-                m_iterators.push_back(col.begin());
-        }
+			for (auto const& col : m_columns)
+				m_iterators.push_back(col.begin());
+		}
 
-        auto operator ==(iterator const& other) const -> bool {
-            return m_iterators == other.m_iterators;
-        }
-        auto operator !=(iterator const& other) const -> bool {
-            return m_iterators != other.m_iterators;
-        }
-        auto operator *() const -> std::string {
-            std::string row, padding;
+		auto operator ==(iterator const& other) const -> bool {
+			return m_iterators == other.m_iterators;
+		}
+		auto operator !=(iterator const& other) const -> bool {
+			return m_iterators != other.m_iterators;
+		}
+		auto operator *() const -> std::string {
+			std::string row, padding;
 
-            for (size_t i = 0; i < m_columns.size(); ++i) {
-                auto width = m_columns[i].width();
-                if (m_iterators[i] != m_columns[i].end()) {
-                    std::string col = *m_iterators[i];
-                    row += padding + col;
-                    if (col.size() < width)
-                        padding = std::string(width - col.size(), ' ');
-                    else
-                        padding = "";
-                } else {
-                    padding += std::string(width, ' ');
-                }
-            }
-            return row;
-        }
-        auto operator ++() -> iterator& {
-            for (size_t i = 0; i < m_columns.size(); ++i) {
-                if (m_iterators[i] != m_columns[i].end())
-                    ++m_iterators[i];
-            }
-            return *this;
-        }
-        auto operator ++(int) -> iterator {
-            iterator prev(*this);
-            operator++();
-            return prev;
-        }
-    };
-    using const_iterator = iterator;
+			for (size_t i = 0; i < m_columns.size(); ++i) {
+				auto width = m_columns[i].width();
+				if (m_iterators[i] != m_columns[i].end()) {
+					std::string col = *m_iterators[i];
+					row += padding + col;
+					if (col.size() < width)
+						padding = std::string(width - col.size(), ' ');
+					else
+						padding = "";
+				} else {
+					padding += std::string(width, ' ');
+				}
+			}
+			return row;
+		}
+		auto operator ++() -> iterator& {
+			for (size_t i = 0; i < m_columns.size(); ++i) {
+				if (m_iterators[i] != m_columns[i].end())
+					++m_iterators[i];
+			}
+			return *this;
+		}
+		auto operator ++(int) -> iterator {
+			iterator prev(*this);
+			operator++();
+			return prev;
+		}
+	};
+	using const_iterator = iterator;
 
-    auto begin() const -> iterator { return iterator(*this); }
-    auto end() const -> iterator { return { *this, iterator::EndTag() }; }
+	auto begin() const -> iterator { return iterator(*this); }
+	auto end() const -> iterator { return { *this, iterator::EndTag() }; }
 
-    auto operator += (Column const& col) -> Columns& {
-        m_columns.push_back(col);
-        return *this;
-    }
-    auto operator + (Column const& col) -> Columns {
-        Columns combined = *this;
-        combined += col;
-        return combined;
-    }
+	auto operator += (Column const& col) -> Columns& {
+		m_columns.push_back(col);
+		return *this;
+	}
+	auto operator + (Column const& col) -> Columns {
+		Columns combined = *this;
+		combined += col;
+		return combined;
+	}
 
-    inline friend std::ostream& operator << (std::ostream& os, Columns const& cols) {
+	inline friend std::ostream& operator << (std::ostream& os, Columns const& cols) {
 
-        bool first = true;
-        for (auto line : cols) {
-            if (first)
-                first = false;
-            else
-                os << "\n";
-            os << line;
-        }
-        return os;
-    }
+		bool first = true;
+		for (auto line : cols) {
+			if (first)
+				first = false;
+			else
+				os << "\n";
+			os << line;
+		}
+		return os;
+	}
 
-    auto toString() const -> std::string {
-        std::ostringstream oss;
-        oss << *this;
-        return oss.str();
-    }
+	auto toString() const -> std::string {
+		std::ostringstream oss;
+		oss << *this;
+		return oss.str();
+	}
 };
 
 inline auto Column::operator + (Column const& other) -> Columns {
-    Columns cols;
-    cols += *this;
-    cols += other;
-    return cols;
+	Columns cols;
+	cols += *this;
+	cols += other;
+	return cols;
 }
 }
 
@@ -9262,7 +9262,7 @@ namespace detail {
         template<typename T>
         auto operator|( T const &other ) const -> Parser;
 
-        template<typename T>
+		template<typename T>
         auto operator+( T const &other ) const -> Parser;
     };
 
@@ -16474,13 +16474,13 @@ public:
             m_isOpen = true;
             *this << RowBreak();
 
-            Columns headerCols;
-            Spacer spacer(2);
-            for (auto const& info : m_columnInfos) {
-                headerCols += Column(info.name).width(static_cast<std::size_t>(info.width - 2));
-                headerCols += spacer;
-            }
-            m_os << headerCols << '\n';
+			Columns headerCols;
+			Spacer spacer(2);
+			for (auto const& info : m_columnInfos) {
+				headerCols += Column(info.name).width(static_cast<std::size_t>(info.width - 2));
+				headerCols += spacer;
+			}
+			m_os << headerCols << '\n';
 
             m_os << Catch::getLineOfChars<'-'>() << '\n';
         }
@@ -16614,19 +16614,19 @@ void ConsoleReporter::sectionEnded(SectionStats const& _sectionStats) {
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
 void ConsoleReporter::benchmarkPreparing(std::string const& name) {
-    lazyPrintWithoutClosingBenchmarkTable();
+	lazyPrintWithoutClosingBenchmarkTable();
 
-    auto nameCol = Column(name).width(static_cast<std::size_t>(m_tablePrinter->columnInfos()[0].width - 2));
+	auto nameCol = Column(name).width(static_cast<std::size_t>(m_tablePrinter->columnInfos()[0].width - 2));
 
-    bool firstLine = true;
-    for (auto line : nameCol) {
-        if (!firstLine)
-            (*m_tablePrinter) << ColumnBreak() << ColumnBreak() << ColumnBreak();
-        else
-            firstLine = false;
+	bool firstLine = true;
+	for (auto line : nameCol) {
+		if (!firstLine)
+			(*m_tablePrinter) << ColumnBreak() << ColumnBreak() << ColumnBreak();
+		else
+			firstLine = false;
 
-        (*m_tablePrinter) << line << ColumnBreak();
-    }
+		(*m_tablePrinter) << line << ColumnBreak();
+	}
 }
 
 void ConsoleReporter::benchmarkStarting(BenchmarkInfo const& info) {
@@ -16653,7 +16653,7 @@ void ConsoleReporter::benchmarkEnded(BenchmarkStats<> const& stats) {
 }
 
 void ConsoleReporter::benchmarkFailed(std::string const& error) {
-    Colour colour(Colour::Red);
+	Colour colour(Colour::Red);
     (*m_tablePrinter)
         << "Benchmark failed (" << error << ')'
         << ColumnBreak() << RowBreak();
@@ -17213,11 +17213,11 @@ namespace Catch {
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
     void ListeningReporter::benchmarkPreparing( std::string const& name ) {
-        for (auto const& listener : m_listeners) {
-            listener->benchmarkPreparing(name);
-        }
-        m_reporter->benchmarkPreparing(name);
-    }
+		for (auto const& listener : m_listeners) {
+			listener->benchmarkPreparing(name);
+		}
+		m_reporter->benchmarkPreparing(name);
+	}
     void ListeningReporter::benchmarkStarting( BenchmarkInfo const& benchmarkInfo ) {
         for ( auto const& listener : m_listeners ) {
             listener->benchmarkStarting( benchmarkInfo );
@@ -17231,12 +17231,12 @@ namespace Catch {
         m_reporter->benchmarkEnded( benchmarkStats );
     }
 
-    void ListeningReporter::benchmarkFailed( std::string const& error ) {
-        for (auto const& listener : m_listeners) {
-            listener->benchmarkFailed(error);
-        }
-        m_reporter->benchmarkFailed(error);
-    }
+	void ListeningReporter::benchmarkFailed( std::string const& error ) {
+		for (auto const& listener : m_listeners) {
+			listener->benchmarkFailed(error);
+		}
+		m_reporter->benchmarkFailed(error);
+	}
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
     void ListeningReporter::testRunStarting( TestRunInfo const& testRunInfo ) {

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -5302,7 +5302,7 @@ namespace Catch {
         int endOffset = -1;
         int endOffsetPercentage = -1;
 
-	    bool outputSQL = false;
+        bool outputSQL = false;
 
         bool benchmarkNoAnalysis = false;
         unsigned int benchmarkSamples = 100;
@@ -8498,312 +8498,312 @@ namespace clara {
 namespace TextFlow {
 
 inline auto isWhitespace(char c) -> bool {
-	static std::string chars = " \t\n\r";
-	return chars.find(c) != std::string::npos;
+    static std::string chars = " \t\n\r";
+    return chars.find(c) != std::string::npos;
 }
 inline auto isBreakableBefore(char c) -> bool {
-	static std::string chars = "[({<|";
-	return chars.find(c) != std::string::npos;
+    static std::string chars = "[({<|";
+    return chars.find(c) != std::string::npos;
 }
 inline auto isBreakableAfter(char c) -> bool {
-	static std::string chars = "])}>.,:;*+-=&/\\";
-	return chars.find(c) != std::string::npos;
+    static std::string chars = "])}>.,:;*+-=&/\\";
+    return chars.find(c) != std::string::npos;
 }
 
 class Columns;
 
 class Column {
-	std::vector<std::string> m_strings;
-	size_t m_width = CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
-	size_t m_indent = 0;
-	size_t m_initialIndent = std::string::npos;
+    std::vector<std::string> m_strings;
+    size_t m_width = CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
+    size_t m_indent = 0;
+    size_t m_initialIndent = std::string::npos;
 
 public:
-	class iterator {
-		friend Column;
+    class iterator {
+        friend Column;
 
-		Column const& m_column;
-		size_t m_stringIndex = 0;
-		size_t m_pos = 0;
+        Column const& m_column;
+        size_t m_stringIndex = 0;
+        size_t m_pos = 0;
 
-		size_t m_len = 0;
-		size_t m_end = 0;
-		bool m_suffix = false;
+        size_t m_len = 0;
+        size_t m_end = 0;
+        bool m_suffix = false;
 
-		iterator(Column const& column, size_t stringIndex)
-			: m_column(column),
-			m_stringIndex(stringIndex) {}
+        iterator(Column const& column, size_t stringIndex)
+            : m_column(column),
+            m_stringIndex(stringIndex) {}
 
-		auto line() const -> std::string const& { return m_column.m_strings[m_stringIndex]; }
+        auto line() const -> std::string const& { return m_column.m_strings[m_stringIndex]; }
 
-		auto isBoundary(size_t at) const -> bool {
-			assert(at > 0);
-			assert(at <= line().size());
+        auto isBoundary(size_t at) const -> bool {
+            assert(at > 0);
+            assert(at <= line().size());
 
-			return at == line().size() ||
-				(isWhitespace(line()[at]) && !isWhitespace(line()[at - 1])) ||
-				isBreakableBefore(line()[at]) ||
-				isBreakableAfter(line()[at - 1]);
-		}
+            return at == line().size() ||
+                (isWhitespace(line()[at]) && !isWhitespace(line()[at - 1])) ||
+                isBreakableBefore(line()[at]) ||
+                isBreakableAfter(line()[at - 1]);
+        }
 
-		void calcLength() {
-			assert(m_stringIndex < m_column.m_strings.size());
+        void calcLength() {
+            assert(m_stringIndex < m_column.m_strings.size());
 
-			m_suffix = false;
-			auto width = m_column.m_width - indent();
-			m_end = m_pos;
-			if (line()[m_pos] == '\n') {
-				++m_end;
-			}
-			while (m_end < line().size() && line()[m_end] != '\n')
-				++m_end;
+            m_suffix = false;
+            auto width = m_column.m_width - indent();
+            m_end = m_pos;
+            if (line()[m_pos] == '\n') {
+                ++m_end;
+            }
+            while (m_end < line().size() && line()[m_end] != '\n')
+                ++m_end;
 
-			if (m_end < m_pos + width) {
-				m_len = m_end - m_pos;
-			} else {
-				size_t len = width;
-				while (len > 0 && !isBoundary(m_pos + len))
-					--len;
-				while (len > 0 && isWhitespace(line()[m_pos + len - 1]))
-					--len;
+            if (m_end < m_pos + width) {
+                m_len = m_end - m_pos;
+            } else {
+                size_t len = width;
+                while (len > 0 && !isBoundary(m_pos + len))
+                    --len;
+                while (len > 0 && isWhitespace(line()[m_pos + len - 1]))
+                    --len;
 
-				if (len > 0) {
-					m_len = len;
-				} else {
-					m_suffix = true;
-					m_len = width - 1;
-				}
-			}
-		}
+                if (len > 0) {
+                    m_len = len;
+                } else {
+                    m_suffix = true;
+                    m_len = width - 1;
+                }
+            }
+        }
 
-		auto indent() const -> size_t {
-			auto initial = m_pos == 0 && m_stringIndex == 0 ? m_column.m_initialIndent : std::string::npos;
-			return initial == std::string::npos ? m_column.m_indent : initial;
-		}
+        auto indent() const -> size_t {
+            auto initial = m_pos == 0 && m_stringIndex == 0 ? m_column.m_initialIndent : std::string::npos;
+            return initial == std::string::npos ? m_column.m_indent : initial;
+        }
 
-		auto addIndentAndSuffix(std::string const &plain) const -> std::string {
-			return std::string(indent(), ' ') + (m_suffix ? plain + "-" : plain);
-		}
+        auto addIndentAndSuffix(std::string const &plain) const -> std::string {
+            return std::string(indent(), ' ') + (m_suffix ? plain + "-" : plain);
+        }
 
-	public:
-		using difference_type = std::ptrdiff_t;
-		using value_type = std::string;
-		using pointer = value_type * ;
-		using reference = value_type & ;
-		using iterator_category = std::forward_iterator_tag;
+    public:
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::string;
+        using pointer = value_type * ;
+        using reference = value_type & ;
+        using iterator_category = std::forward_iterator_tag;
 
-		explicit iterator(Column const& column) : m_column(column) {
-			assert(m_column.m_width > m_column.m_indent);
-			assert(m_column.m_initialIndent == std::string::npos || m_column.m_width > m_column.m_initialIndent);
-			calcLength();
-			if (m_len == 0)
-				m_stringIndex++; // Empty string
-		}
+        explicit iterator(Column const& column) : m_column(column) {
+            assert(m_column.m_width > m_column.m_indent);
+            assert(m_column.m_initialIndent == std::string::npos || m_column.m_width > m_column.m_initialIndent);
+            calcLength();
+            if (m_len == 0)
+                m_stringIndex++; // Empty string
+        }
 
-		auto operator *() const -> std::string {
-			assert(m_stringIndex < m_column.m_strings.size());
-			assert(m_pos <= m_end);
-			return addIndentAndSuffix(line().substr(m_pos, m_len));
-		}
+        auto operator *() const -> std::string {
+            assert(m_stringIndex < m_column.m_strings.size());
+            assert(m_pos <= m_end);
+            return addIndentAndSuffix(line().substr(m_pos, m_len));
+        }
 
-		auto operator ++() -> iterator& {
-			m_pos += m_len;
-			if (m_pos < line().size() && line()[m_pos] == '\n')
-				m_pos += 1;
-			else
-				while (m_pos < line().size() && isWhitespace(line()[m_pos]))
-					++m_pos;
+        auto operator ++() -> iterator& {
+            m_pos += m_len;
+            if (m_pos < line().size() && line()[m_pos] == '\n')
+                m_pos += 1;
+            else
+                while (m_pos < line().size() && isWhitespace(line()[m_pos]))
+                    ++m_pos;
 
-			if (m_pos == line().size()) {
-				m_pos = 0;
-				++m_stringIndex;
-			}
-			if (m_stringIndex < m_column.m_strings.size())
-				calcLength();
-			return *this;
-		}
-		auto operator ++(int) -> iterator {
-			iterator prev(*this);
-			operator++();
-			return prev;
-		}
+            if (m_pos == line().size()) {
+                m_pos = 0;
+                ++m_stringIndex;
+            }
+            if (m_stringIndex < m_column.m_strings.size())
+                calcLength();
+            return *this;
+        }
+        auto operator ++(int) -> iterator {
+            iterator prev(*this);
+            operator++();
+            return prev;
+        }
 
-		auto operator ==(iterator const& other) const -> bool {
-			return
-				m_pos == other.m_pos &&
-				m_stringIndex == other.m_stringIndex &&
-				&m_column == &other.m_column;
-		}
-		auto operator !=(iterator const& other) const -> bool {
-			return !operator==(other);
-		}
-	};
-	using const_iterator = iterator;
+        auto operator ==(iterator const& other) const -> bool {
+            return
+                m_pos == other.m_pos &&
+                m_stringIndex == other.m_stringIndex &&
+                &m_column == &other.m_column;
+        }
+        auto operator !=(iterator const& other) const -> bool {
+            return !operator==(other);
+        }
+    };
+    using const_iterator = iterator;
 
-	explicit Column(std::string const& text) { m_strings.push_back(text); }
+    explicit Column(std::string const& text) { m_strings.push_back(text); }
 
-	auto width(size_t newWidth) -> Column& {
-		assert(newWidth > 0);
-		m_width = newWidth;
-		return *this;
-	}
-	auto indent(size_t newIndent) -> Column& {
-		m_indent = newIndent;
-		return *this;
-	}
-	auto initialIndent(size_t newIndent) -> Column& {
-		m_initialIndent = newIndent;
-		return *this;
-	}
+    auto width(size_t newWidth) -> Column& {
+        assert(newWidth > 0);
+        m_width = newWidth;
+        return *this;
+    }
+    auto indent(size_t newIndent) -> Column& {
+        m_indent = newIndent;
+        return *this;
+    }
+    auto initialIndent(size_t newIndent) -> Column& {
+        m_initialIndent = newIndent;
+        return *this;
+    }
 
-	auto width() const -> size_t { return m_width; }
-	auto begin() const -> iterator { return iterator(*this); }
-	auto end() const -> iterator { return { *this, m_strings.size() }; }
+    auto width() const -> size_t { return m_width; }
+    auto begin() const -> iterator { return iterator(*this); }
+    auto end() const -> iterator { return { *this, m_strings.size() }; }
 
-	inline friend std::ostream& operator << (std::ostream& os, Column const& col) {
-		bool first = true;
-		for (auto line : col) {
-			if (first)
-				first = false;
-			else
-				os << "\n";
-			os << line;
-		}
-		return os;
-	}
+    inline friend std::ostream& operator << (std::ostream& os, Column const& col) {
+        bool first = true;
+        for (auto line : col) {
+            if (first)
+                first = false;
+            else
+                os << "\n";
+            os << line;
+        }
+        return os;
+    }
 
-	auto operator + (Column const& other)->Columns;
+    auto operator + (Column const& other)->Columns;
 
-	auto toString() const -> std::string {
-		std::ostringstream oss;
-		oss << *this;
-		return oss.str();
-	}
+    auto toString() const -> std::string {
+        std::ostringstream oss;
+        oss << *this;
+        return oss.str();
+    }
 };
 
 class Spacer : public Column {
 
 public:
-	explicit Spacer(size_t spaceWidth) : Column("") {
-		width(spaceWidth);
-	}
+    explicit Spacer(size_t spaceWidth) : Column("") {
+        width(spaceWidth);
+    }
 };
 
 class Columns {
-	std::vector<Column> m_columns;
+    std::vector<Column> m_columns;
 
 public:
 
-	class iterator {
-		friend Columns;
-		struct EndTag {};
+    class iterator {
+        friend Columns;
+        struct EndTag {};
 
-		std::vector<Column> const& m_columns;
-		std::vector<Column::iterator> m_iterators;
-		size_t m_activeIterators;
+        std::vector<Column> const& m_columns;
+        std::vector<Column::iterator> m_iterators;
+        size_t m_activeIterators;
 
-		iterator(Columns const& columns, EndTag)
-			: m_columns(columns.m_columns),
-			m_activeIterators(0) {
-			m_iterators.reserve(m_columns.size());
+        iterator(Columns const& columns, EndTag)
+            : m_columns(columns.m_columns),
+            m_activeIterators(0) {
+            m_iterators.reserve(m_columns.size());
 
-			for (auto const& col : m_columns)
-				m_iterators.push_back(col.end());
-		}
+            for (auto const& col : m_columns)
+                m_iterators.push_back(col.end());
+        }
 
-	public:
-		using difference_type = std::ptrdiff_t;
-		using value_type = std::string;
-		using pointer = value_type * ;
-		using reference = value_type & ;
-		using iterator_category = std::forward_iterator_tag;
+    public:
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::string;
+        using pointer = value_type * ;
+        using reference = value_type & ;
+        using iterator_category = std::forward_iterator_tag;
 
-		explicit iterator(Columns const& columns)
-			: m_columns(columns.m_columns),
-			m_activeIterators(m_columns.size()) {
-			m_iterators.reserve(m_columns.size());
+        explicit iterator(Columns const& columns)
+            : m_columns(columns.m_columns),
+            m_activeIterators(m_columns.size()) {
+            m_iterators.reserve(m_columns.size());
 
-			for (auto const& col : m_columns)
-				m_iterators.push_back(col.begin());
-		}
+            for (auto const& col : m_columns)
+                m_iterators.push_back(col.begin());
+        }
 
-		auto operator ==(iterator const& other) const -> bool {
-			return m_iterators == other.m_iterators;
-		}
-		auto operator !=(iterator const& other) const -> bool {
-			return m_iterators != other.m_iterators;
-		}
-		auto operator *() const -> std::string {
-			std::string row, padding;
+        auto operator ==(iterator const& other) const -> bool {
+            return m_iterators == other.m_iterators;
+        }
+        auto operator !=(iterator const& other) const -> bool {
+            return m_iterators != other.m_iterators;
+        }
+        auto operator *() const -> std::string {
+            std::string row, padding;
 
-			for (size_t i = 0; i < m_columns.size(); ++i) {
-				auto width = m_columns[i].width();
-				if (m_iterators[i] != m_columns[i].end()) {
-					std::string col = *m_iterators[i];
-					row += padding + col;
-					if (col.size() < width)
-						padding = std::string(width - col.size(), ' ');
-					else
-						padding = "";
-				} else {
-					padding += std::string(width, ' ');
-				}
-			}
-			return row;
-		}
-		auto operator ++() -> iterator& {
-			for (size_t i = 0; i < m_columns.size(); ++i) {
-				if (m_iterators[i] != m_columns[i].end())
-					++m_iterators[i];
-			}
-			return *this;
-		}
-		auto operator ++(int) -> iterator {
-			iterator prev(*this);
-			operator++();
-			return prev;
-		}
-	};
-	using const_iterator = iterator;
+            for (size_t i = 0; i < m_columns.size(); ++i) {
+                auto width = m_columns[i].width();
+                if (m_iterators[i] != m_columns[i].end()) {
+                    std::string col = *m_iterators[i];
+                    row += padding + col;
+                    if (col.size() < width)
+                        padding = std::string(width - col.size(), ' ');
+                    else
+                        padding = "";
+                } else {
+                    padding += std::string(width, ' ');
+                }
+            }
+            return row;
+        }
+        auto operator ++() -> iterator& {
+            for (size_t i = 0; i < m_columns.size(); ++i) {
+                if (m_iterators[i] != m_columns[i].end())
+                    ++m_iterators[i];
+            }
+            return *this;
+        }
+        auto operator ++(int) -> iterator {
+            iterator prev(*this);
+            operator++();
+            return prev;
+        }
+    };
+    using const_iterator = iterator;
 
-	auto begin() const -> iterator { return iterator(*this); }
-	auto end() const -> iterator { return { *this, iterator::EndTag() }; }
+    auto begin() const -> iterator { return iterator(*this); }
+    auto end() const -> iterator { return { *this, iterator::EndTag() }; }
 
-	auto operator += (Column const& col) -> Columns& {
-		m_columns.push_back(col);
-		return *this;
-	}
-	auto operator + (Column const& col) -> Columns {
-		Columns combined = *this;
-		combined += col;
-		return combined;
-	}
+    auto operator += (Column const& col) -> Columns& {
+        m_columns.push_back(col);
+        return *this;
+    }
+    auto operator + (Column const& col) -> Columns {
+        Columns combined = *this;
+        combined += col;
+        return combined;
+    }
 
-	inline friend std::ostream& operator << (std::ostream& os, Columns const& cols) {
+    inline friend std::ostream& operator << (std::ostream& os, Columns const& cols) {
 
-		bool first = true;
-		for (auto line : cols) {
-			if (first)
-				first = false;
-			else
-				os << "\n";
-			os << line;
-		}
-		return os;
-	}
+        bool first = true;
+        for (auto line : cols) {
+            if (first)
+                first = false;
+            else
+                os << "\n";
+            os << line;
+        }
+        return os;
+    }
 
-	auto toString() const -> std::string {
-		std::ostringstream oss;
-		oss << *this;
-		return oss.str();
-	}
+    auto toString() const -> std::string {
+        std::ostringstream oss;
+        oss << *this;
+        return oss.str();
+    }
 };
 
 inline auto Column::operator + (Column const& other) -> Columns {
-	Columns cols;
-	cols += *this;
-	cols += other;
-	return cols;
+    Columns cols;
+    cols += *this;
+    cols += other;
+    return cols;
 }
 }
 
@@ -9262,7 +9262,7 @@ namespace detail {
         template<typename T>
         auto operator|( T const &other ) const -> Parser;
 
-		template<typename T>
+        template<typename T>
         auto operator+( T const &other ) const -> Parser;
     };
 
@@ -11308,12 +11308,28 @@ namespace Catch {
         Catch::cout() << "name\tgroup" << std::endl;
 
         auto matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
-        for( auto const& testCaseInfo : matchedTestCases ) {
+        auto total_tests_run = matchedTestCases.size();
+        int start_offset = 0;
+        int end_offset = total_tests_run;
+        if (config.startOffset() >= 0) {
+            start_offset = config.startOffset();
+        } else if (config.startOffsetPercentage() >= 0) {
+            start_offset = int((config.startOffsetPercentage() / 100.0) * total_tests_run);
+        }
+        auto it = matchedTestCases.begin();
+        for(int current_test = 0; it != matchedTestCases.end(); current_test++) {
+            if (current_test < start_offset || current_test >= end_offset) {
+                // skip this test
+                it++;
+                continue;
+            }
+            auto &testCaseInfo = *it;
             Catch::cout() << testCaseInfo.name << "\t";
             if( !testCaseInfo.tags.empty() ) {
                 Catch::cout() << testCaseInfo.tagsAsString();
             }
             Catch::cout() << std::endl;
+            it++;
         }
         return matchedTestCases.size();
     }
@@ -16458,13 +16474,13 @@ public:
             m_isOpen = true;
             *this << RowBreak();
 
-			Columns headerCols;
-			Spacer spacer(2);
-			for (auto const& info : m_columnInfos) {
-				headerCols += Column(info.name).width(static_cast<std::size_t>(info.width - 2));
-				headerCols += spacer;
-			}
-			m_os << headerCols << '\n';
+            Columns headerCols;
+            Spacer spacer(2);
+            for (auto const& info : m_columnInfos) {
+                headerCols += Column(info.name).width(static_cast<std::size_t>(info.width - 2));
+                headerCols += spacer;
+            }
+            m_os << headerCols << '\n';
 
             m_os << Catch::getLineOfChars<'-'>() << '\n';
         }
@@ -16598,19 +16614,19 @@ void ConsoleReporter::sectionEnded(SectionStats const& _sectionStats) {
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
 void ConsoleReporter::benchmarkPreparing(std::string const& name) {
-	lazyPrintWithoutClosingBenchmarkTable();
+    lazyPrintWithoutClosingBenchmarkTable();
 
-	auto nameCol = Column(name).width(static_cast<std::size_t>(m_tablePrinter->columnInfos()[0].width - 2));
+    auto nameCol = Column(name).width(static_cast<std::size_t>(m_tablePrinter->columnInfos()[0].width - 2));
 
-	bool firstLine = true;
-	for (auto line : nameCol) {
-		if (!firstLine)
-			(*m_tablePrinter) << ColumnBreak() << ColumnBreak() << ColumnBreak();
-		else
-			firstLine = false;
+    bool firstLine = true;
+    for (auto line : nameCol) {
+        if (!firstLine)
+            (*m_tablePrinter) << ColumnBreak() << ColumnBreak() << ColumnBreak();
+        else
+            firstLine = false;
 
-		(*m_tablePrinter) << line << ColumnBreak();
-	}
+        (*m_tablePrinter) << line << ColumnBreak();
+    }
 }
 
 void ConsoleReporter::benchmarkStarting(BenchmarkInfo const& info) {
@@ -16637,7 +16653,7 @@ void ConsoleReporter::benchmarkEnded(BenchmarkStats<> const& stats) {
 }
 
 void ConsoleReporter::benchmarkFailed(std::string const& error) {
-	Colour colour(Colour::Red);
+    Colour colour(Colour::Red);
     (*m_tablePrinter)
         << "Benchmark failed (" << error << ')'
         << ColumnBreak() << RowBreak();
@@ -17197,11 +17213,11 @@ namespace Catch {
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
     void ListeningReporter::benchmarkPreparing( std::string const& name ) {
-		for (auto const& listener : m_listeners) {
-			listener->benchmarkPreparing(name);
-		}
-		m_reporter->benchmarkPreparing(name);
-	}
+        for (auto const& listener : m_listeners) {
+            listener->benchmarkPreparing(name);
+        }
+        m_reporter->benchmarkPreparing(name);
+    }
     void ListeningReporter::benchmarkStarting( BenchmarkInfo const& benchmarkInfo ) {
         for ( auto const& listener : m_listeners ) {
             listener->benchmarkStarting( benchmarkInfo );
@@ -17215,12 +17231,12 @@ namespace Catch {
         m_reporter->benchmarkEnded( benchmarkStats );
     }
 
-	void ListeningReporter::benchmarkFailed( std::string const& error ) {
-		for (auto const& listener : m_listeners) {
-			listener->benchmarkFailed(error);
-		}
-		m_reporter->benchmarkFailed(error);
-	}
+    void ListeningReporter::benchmarkFailed( std::string const& error ) {
+        for (auto const& listener : m_listeners) {
+            listener->benchmarkFailed(error);
+        }
+        m_reporter->benchmarkFailed(error);
+    }
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
     void ListeningReporter::testRunStarting( TestRunInfo const& testRunInfo ) {


### PR DESCRIPTION
`run_tests_one_by_one.py` uses the `-l` option to collect the list of tests to run, adding the option to supply a start offset should be helpful

While I was looking into this, I also made small adjustments to the `run_tests_one_by_one.py` script to replace the argument parsing logic with a library specifically designed for it.
With the nice addition of the implicitly added `--help` option