### PR TITLE
[Python] Compatibility with `pandas==2.2.0`

### DIFF
--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -250,16 +250,19 @@ void DuckDBPyResult::ChangeToTZType(PandasDataFrame &df) {
 		if (result->types[i] == LogicalType::TIMESTAMP_TZ) {
 			// first localize to UTC then convert to timezone_config
 			auto utc_local = df[names[i].c_str()].attr("dt").attr("tz_localize")("UTC");
-			df[names[i].c_str()] = utc_local.attr("dt").attr("tz_convert")(result->client_properties.time_zone);
+			df.attr("__setitem__")(names[i].c_str(),
+			                       utc_local.attr("dt").attr("tz_convert")(result->client_properties.time_zone));
 		}
 	}
 }
 
 // TODO: unify these with an enum/flag to indicate which conversions to perform
 void DuckDBPyResult::ChangeDateToDatetime(PandasDataFrame &df) {
+	auto names = df.attr("columns").cast<vector<string>>();
+
 	for (idx_t i = 0; i < result->ColumnCount(); i++) {
 		if (result->types[i] == LogicalType::DATE) {
-			df[result->names[i].c_str()] = df[result->names[i].c_str()].attr("dt").attr("date");
+			df.attr("__setitem__")(names[i].c_str(), df[names[i].c_str()].attr("dt").attr("date"));
 		}
 	}
 }

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -68,6 +68,32 @@ def duckdb_empty_cursor(request):
     return cursor
 
 
+def getTimeSeriesData(nper=None, freq: "Frequency" = "B") -> dict[str, "Series"]:
+    from pandas import DatetimeIndex, bdate_range, Series
+    from datetime import datetime
+    from pandas._typing import Frequency
+    import numpy as np
+    import string
+
+    _N = 30
+    _K = 4
+
+    def getCols(k) -> str:
+        return string.ascii_uppercase[:k]
+
+    def makeDateIndex(k: int = 10, freq: Frequency = "B", name=None, **kwargs) -> DatetimeIndex:
+        dt = datetime(2000, 1, 1)
+        dr = bdate_range(dt, periods=k, freq=freq, name=name)
+        return DatetimeIndex(dr, name=name, **kwargs)
+
+    def makeTimeSeries(nper=None, freq: Frequency = "B", name=None) -> Series:
+        if nper is None:
+            nper = _N
+        return Series(np.random.randn(nper), index=makeDateIndex(nper, freq=freq), name=name)
+
+    return {c: makeTimeSeries(nper, freq) for c in getCols(_K)}
+
+
 def pandas_2_or_higher():
     from packaging.version import Version
 

--- a/tools/pythonpkg/tests/fast/api/test_dbapi_fetch.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi_fetch.py
@@ -37,7 +37,8 @@ class TestDBApiFetch(object):
         arrow = pytest.importorskip("pyarrow")
         con = duckdb.connect()
         c = con.execute('SELECT 42::BIGINT AS a')
-        df = c.arrow().to_pandas()
+        table = c.arrow()
+        df = table.to_pandas()
         pd.testing.assert_frame_equal(df, pd.DataFrame.from_dict({'a': [42]}))
         assert c.arrow() is None
         assert c.arrow() is None

--- a/tools/pythonpkg/tests/fast/api/test_native_tz.py
+++ b/tools/pythonpkg/tests/fast/api/test_native_tz.py
@@ -2,72 +2,70 @@ import duckdb
 import datetime
 import pytz
 import os
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
+pa = pytest.importorskip("pyarrow")
+from packaging.version import Version
 
 filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'data', 'tz.parquet')
 
 
 class TestNativeTimeZone(object):
-    def test_native_python_timestamp_timezone(self):
-        con = duckdb.connect('')
-        con.execute("SET timezone='America/Los_Angeles';")
-        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchone()
+    def test_native_python_timestamp_timezone(self, duckdb_cursor):
+        duckdb_cursor.execute("SET timezone='America/Los_Angeles';")
+        res = duckdb_cursor.execute(f"select TimeRecStart as tz  from '{filename}'").fetchone()
         assert res[0].hour == 14 and res[0].minute == 52
         assert res[0].tzinfo.zone == 'America/Los_Angeles'
 
-        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchall()[0]
+        res = duckdb_cursor.execute(f"select TimeRecStart as tz  from '{filename}'").fetchall()[0]
         assert res[0].hour == 14 and res[0].minute == 52
         assert res[0].tzinfo.zone == 'America/Los_Angeles'
 
-        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchmany(1)[0]
+        res = duckdb_cursor.execute(f"select TimeRecStart as tz  from '{filename}'").fetchmany(1)[0]
         assert res[0].hour == 14 and res[0].minute == 52
         assert res[0].tzinfo.zone == 'America/Los_Angeles'
 
-        con.execute("SET timezone='UTC';")
-        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").fetchone()
+        duckdb_cursor.execute("SET timezone='UTC';")
+        res = duckdb_cursor.execute(f"select TimeRecStart as tz  from '{filename}'").fetchone()
         assert res[0].hour == 21 and res[0].minute == 52
         assert res[0].tzinfo.zone == 'UTC'
 
-    def test_native_python_time_timezone(self):
-        con = duckdb.connect('')
+    def test_native_python_time_timezone(self, duckdb_cursor):
         with pytest.raises(duckdb.NotImplementedException, match="Not implemented Error: Unsupported type"):
-            con.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").fetchone()
+            duckdb_cursor.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").fetchone()
 
-    def test_pandas_timestamp_timezone(self):
-        con = duckdb.connect('')
-        res = con.execute("SET timezone='America/Los_Angeles';")
-        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").df()
+    def test_pandas_timestamp_timezone(self, duckdb_cursor):
+        res = duckdb_cursor.execute("SET timezone='America/Los_Angeles';")
+        res = duckdb_cursor.execute(f"select TimeRecStart as tz  from '{filename}'").df()
         assert res.dtypes["tz"].tz.zone == 'America/Los_Angeles'
         assert res['tz'][0].hour == 14 and res['tz'][0].minute == 52
 
-        con.execute("SET timezone='UTC';")
-        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").df()
+        duckdb_cursor.execute("SET timezone='UTC';")
+        res = duckdb_cursor.execute(f"select TimeRecStart as tz  from '{filename}'").df()
         assert res['tz'][0].hour == 21 and res['tz'][0].minute == 52
 
-    def test_pandas_timestamp_time(self):
-        con = duckdb.connect('')
+    def test_pandas_timestamp_time(self, duckdb_cursor):
         with pytest.raises(
             duckdb.NotImplementedException, match="Not implemented Error: Unsupported type \"TIME WITH TIME ZONE\""
         ):
-            con.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").df()
+            duckdb_cursor.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").df()
 
-    def test_arrow_timestamp_timezone(self):
-        pa = pytest.importorskip('pyarrow')
-        con = duckdb.connect('')
-        res = con.execute("SET timezone='America/Los_Angeles';")
-        table = con.execute(f"select TimeRecStart as tz  from '{filename}'").arrow()
+    @pytest.mark.skipif(
+        Version(pa.__version__) <= Version('15.0.0'), reason="pyarrow 14.0.2 'to_pandas' causes a DeprecationWarning"
+    )
+    def test_arrow_timestamp_timezone(self, duckdb_cursor):
+        res = duckdb_cursor.execute("SET timezone='America/Los_Angeles';")
+        table = duckdb_cursor.execute(f"select TimeRecStart as tz  from '{filename}'").arrow()
         res = table.to_pandas()
         assert res.dtypes["tz"].tz.zone == 'America/Los_Angeles'
         assert res['tz'][0].hour == 14 and res['tz'][0].minute == 52
 
-        con.execute("SET timezone='UTC';")
-        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").arrow().to_pandas()
+        duckdb_cursor.execute("SET timezone='UTC';")
+        res = duckdb_cursor.execute(f"select TimeRecStart as tz  from '{filename}'").arrow().to_pandas()
         assert res.dtypes["tz"].tz.zone == 'UTC'
         assert res['tz'][0].hour == 21 and res['tz'][0].minute == 52
 
-    def test_arrow_timestamp_time(self):
-        pa = pytest.importorskip('pyarrow')
-        con = duckdb.connect('')
+    def test_arrow_timestamp_time(self, duckdb_cursor):
         with pytest.raises(duckdb.NotImplementedException, match="Unsupported Arrow type"):
-            con.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").arrow()
+            duckdb_cursor.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").arrow()

--- a/tools/pythonpkg/tests/fast/api/test_native_tz.py
+++ b/tools/pythonpkg/tests/fast/api/test_native_tz.py
@@ -56,7 +56,8 @@ class TestNativeTimeZone(object):
         pa = pytest.importorskip('pyarrow')
         con = duckdb.connect('')
         res = con.execute("SET timezone='America/Los_Angeles';")
-        res = con.execute(f"select TimeRecStart as tz  from '{filename}'").arrow().to_pandas()
+        table = con.execute(f"select TimeRecStart as tz  from '{filename}'").arrow()
+        res = table.to_pandas()
         assert res.dtypes["tz"].tz.zone == 'America/Los_Angeles'
         assert res['tz'][0].hour == 14 and res['tz'][0].minute == 52
 

--- a/tools/pythonpkg/tests/fast/api/test_native_tz.py
+++ b/tools/pythonpkg/tests/fast/api/test_native_tz.py
@@ -52,7 +52,7 @@ class TestNativeTimeZone(object):
             duckdb_cursor.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").df()
 
     @pytest.mark.skipif(
-        Version(pa.__version__) <= Version('15.0.0'), reason="pyarrow 14.0.2 'to_pandas' causes a DeprecationWarning"
+        Version(pa.__version__) < Version('15.0.0'), reason="pyarrow 14.0.2 'to_pandas' causes a DeprecationWarning"
     )
     def test_arrow_timestamp_timezone(self, duckdb_cursor):
         res = duckdb_cursor.execute("SET timezone='America/Los_Angeles';")

--- a/tools/pythonpkg/tests/fast/api/test_to_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_to_csv.py
@@ -5,7 +5,7 @@ import pandas._testing as tm
 import datetime
 import csv
 import pytest
-from conftest import NumpyPandas, ArrowPandas
+from conftest import NumpyPandas, ArrowPandas, getTimeSeriesData
 
 
 class TestToCSV(object):
@@ -83,7 +83,7 @@ class TestToCSV(object):
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_to_csv_date_format(self, pandas):
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
-        df = pandas.DataFrame(tm.getTimeSeriesData())
+        df = pandas.DataFrame(getTimeSeriesData())
         dt_index = df.index
         df = pandas.DataFrame({"A": dt_index, "B": dt_index.shift(1)}, index=dt_index)
         rel = duckdb.from_df(df)

--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -506,7 +506,7 @@ class TestArrowFilterPushdown(object):
         assert expected == actual
 
     @pytest.mark.skipif(
-        Version(pa.__version__) <= Version('15.0.0'), reason="pyarrow 14.0.2 'to_pandas' causes a DeprecationWarning"
+        Version(pa.__version__) < Version('15.0.0'), reason="pyarrow 14.0.2 'to_pandas' causes a DeprecationWarning"
     )
     def test_9371(self, duckdb_cursor, tmp_path):
         import datetime

--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import tempfile
 from conftest import pandas_supports_arrow_backend
+from packaging.version import Version
 
 pa = pytest.importorskip("pyarrow")
 pq = pytest.importorskip("pyarrow.parquet")
@@ -504,6 +505,9 @@ class TestArrowFilterPushdown(object):
         actual = duckdb_cursor.execute("select * from arrow_table where i = ?", (value,)).fetchall()
         assert expected == actual
 
+    @pytest.mark.skipif(
+        Version(pa.__version__) <= Version('15.0.0'), reason="pyarrow 14.0.2 'to_pandas' causes a DeprecationWarning"
+    )
     def test_9371(self, duckdb_cursor, tmp_path):
         import datetime
         import pathlib

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -609,7 +609,7 @@ class TestResolveObjectColumns(object):
         # Now interleave nulls into the dataframe
         duckdb_cursor.execute('drop table dates')
         for i in range(0, len(res['i']), 2):
-            res['i'][i] = None
+            res.loc[i, 'i'] = None
         duckdb_cursor.execute('create table dates as select * from res')
 
         expected_res = [

--- a/tools/pythonpkg/tests/fast/spark/test_spark_to_csv.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_to_csv.py
@@ -7,7 +7,7 @@ _ = pytest.importorskip("duckdb.experimental.spark")
 
 from duckdb.experimental.spark.sql import SparkSession as session
 from duckdb import connect, InvalidInputException, read_csv
-from conftest import NumpyPandas, ArrowPandas
+from conftest import NumpyPandas, ArrowPandas, getTimeSeriesData
 import pandas._testing as tm
 import datetime
 import csv
@@ -121,7 +121,7 @@ class TestSparkToCSV(object):
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_to_csv_date_format(self, pandas, spark, tmp_path):
         temp_file_name = os.path.join(tmp_path, "temp_file.csv")
-        pandas_df = pandas.DataFrame(tm.getTimeSeriesData())
+        pandas_df = pandas.DataFrame(getTimeSeriesData())
         dt_index = pandas_df.index
         pandas_df = pandas.DataFrame({"A": dt_index, "B": dt_index.shift(1)}, index=dt_index)
 


### PR DESCRIPTION
1. `pybind11` can't know that we're assigning to an accessor, so it uses `__getitem__` which will create a copy of the column requested with `df['a']`, making changes to that copy does not affect the original dataframe.
We now use `df.__setitem__('a', ...)` directly to fix this.

2. `pandas._testing.getTimeSeriesData` has been removed, we used this in a couple places so now it's part of `conftest.py`