### PR TITLE
Adapt further for z/OS

### DIFF
--- a/third_party/mbedtls/library/entropy_poll.cpp
+++ b/third_party/mbedtls/library/entropy_poll.cpp
@@ -43,7 +43,7 @@
 
 #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
-    !defined(__HAIKU__) && !defined(__midipix__)
+    !defined(__HAIKU__) && !defined(__midipix__) && !defined(__MVS__)
 #error "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in mbedtls_config.h"
 #endif
 

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -292,9 +292,11 @@ static int enableRawMode(int fd) {
 	raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
 	/* output modes - disable post processing */
 	raw.c_oflag &= ~(OPOST);
+#ifndef __MVS__
 	/* control modes - set 8 bit chars */
-	#ifndef __MVS__ raw.c_iflag |= IUTF8;
-	#endif raw.c_cflag |= CS8;
+	raw.c_iflag |= IUTF8;
+#endif
+	raw.c_cflag |= CS8;
 	/* local modes - choing off, canonical off, no extended functions,
 	 * no signal chars (^Z,^C) */
 	raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -293,10 +293,8 @@ static int enableRawMode(int fd) {
 	/* output modes - disable post processing */
 	raw.c_oflag &= ~(OPOST);
 	/* control modes - set 8 bit chars */
-+#ifndef __MVS__
-	raw.c_iflag |= IUTF8;
-+#endif
-	raw.c_cflag |= CS8;
+	#ifndef __MVS__ raw.c_iflag |= IUTF8;
+	#endif raw.c_cflag |= CS8;
 	/* local modes - choing off, canonical off, no extended functions,
 	 * no signal chars (^Z,^C) */
 	raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -293,7 +293,9 @@ static int enableRawMode(int fd) {
 	/* output modes - disable post processing */
 	raw.c_oflag &= ~(OPOST);
 	/* control modes - set 8 bit chars */
++#ifndef __MVS__
 	raw.c_iflag |= IUTF8;
++#endif
 	raw.c_cflag |= CS8;
 	/* local modes - choing off, canonical off, no extended functions,
 	 * no signal chars (^Z,^C) */


### PR DESCRIPTION
A couple of updates to continue succeeding DuckDB builds for z/OS.
Ref: https://github.com/ZOSOpenTools/duckdbport/pull/7

I've also sent a PR upstream for mbedtls.