### PR TITLE
Explicitly cast FTS column to VARCHAR

### DIFF
--- a/extension/fts/fts_indexing.cpp
+++ b/extension/fts/fts_indexing.cpp
@@ -64,7 +64,7 @@ static string IndexingScript(ClientContext &context, QualifiedName &qname, const
 	}
 
 	// create tokenize macro based on parameters
-	string tokenize = "s";
+	string tokenize = "s::VARCHAR";
 	vector<string> before;
 	vector<string> after;
 	if (strip_accents) {

--- a/test/sql/fts/test_issue_10281.test
+++ b/test/sql/fts/test_issue_10281.test
@@ -1,0 +1,17 @@
+# name: test/sql/fts/test_issue_10281.test
+# description: Test issue #10281: Error when trying to create FTS index for column with struct data
+# group: [fts]
+
+require fts
+
+statement ok
+CREATE OR REPLACE TABLE data AS SELECT {'duck': 42} conversations, 42::bigint _id;
+
+statement ok
+PRAGMA create_fts_index('data', '_id', 'conversations');
+
+# we should be able to retrieve the struct col
+query I
+SELECT _id FROM (SELECT *, fts_main_data.match_bm25(_id, 'duck') AS score FROM data) sq WHERE score IS NOT NULL ORDER BY score DESC;
+----
+42


### PR DESCRIPTION
[Now that implicit cast rules have changed](https://github.com/duckdb/duckdb/pull/10115).

Fixes https://github.com/duckdb/duckdb/issues/10281