### PR TITLE
Fix Failing Nightly Swift test

### DIFF
--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -48,6 +48,13 @@ jobs:
           - 'macOS'
           - 'iOS Simulator,name=iPhone 14'
           - 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
+        isRelease:
+          - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+        exclude:
+          - isRelease: false
+            destination: 'iOS Simulator,name=iPhone 14'
+          - isRelease: false
+            destination: 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
     runs-on: macos-12
     steps:
 

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -48,13 +48,6 @@ jobs:
           - 'macOS'
           - 'iOS Simulator,name=iPhone 14'
           - 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
-        isRelease:
-          - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
-        exclude:
-          - isRelease: false
-            destination: 'iOS Simulator,name=iPhone 14'
-          - isRelease: false
-            destination: 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
     runs-on: macos-12
     steps:
 

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -41,11 +41,13 @@ extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG)
 
 #if defined(__linux__)
 #include <libgen.h>
+// See e.g.:
+// https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
 #elif defined(__APPLE__)
-#  include <TargetConditionals.h>
-#  if not (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
-#    include <libproc.h>
-#  endif
+#include <TargetConditionals.h> // NOLINT
+#if not (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1) // NOLINT
+#include <libproc.h> // NOLINT
+#endif // NOLINT
 #elif defined(_WIN32)
 #include <RestartManager.h>
 #endif
@@ -178,7 +180,7 @@ static FileType GetFileTypeInternal(int fd) { // LCOV_EXCL_START
 	}
 } // LCOV_EXCL_STOP
 
-#ifdef __APPLE__ && !TARGET_OS_IPHONE
+#if __APPLE__ && !TARGET_OS_IPHONE
 
 static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
 	if (pid == getpid()) {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -44,10 +44,10 @@ extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG)
 // See e.g.:
 // https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
 #elif defined(__APPLE__)
-#include <TargetConditionals.h> // NOLINT
-#if not (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1) // NOLINT
-#include <libproc.h> // NOLINT
-#endif // NOLINT
+#include <TargetConditionals.h>                             // NOLINT
+#if not(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1) // NOLINT
+#include <libproc.h>                                        // NOLINT
+#endif                                                      // NOLINT
 #elif defined(_WIN32)
 #include <RestartManager.h>
 #endif

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -42,7 +42,10 @@ extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG)
 #if defined(__linux__)
 #include <libgen.h>
 #elif defined(__APPLE__)
-#include <libproc.h>
+#  include <TargetConditionals.h>
+#  if not (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
+#    include <libproc.h>
+#  endif
 #elif defined(_WIN32)
 #include <RestartManager.h>
 #endif
@@ -175,7 +178,7 @@ static FileType GetFileTypeInternal(int fd) { // LCOV_EXCL_START
 	}
 } // LCOV_EXCL_STOP
 
-#ifdef __APPLE__
+#ifdef __APPLE__ && !TARGET_OS_IPHONE
 
 static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
 	if (pid == getpid()) {


### PR DESCRIPTION
Currently there is a failing nightly swift test. (https://github.com/duckdb/duckdb/actions/runs/7633655908)

For iOS systems, we should not be poking around in other processes, as Apple really doesn't like that. To fix the failing nightly test, we do not include <libproc.h> if the operating system is iOS. 

See https://github.com/Tmonster/duckdb/pull/116/commits/972df1cdd4a005ef7c6578bd6cc45984f087001a to verify that the test actually passes with this fix. 

