### PR TITLE
Add create_sort_key function

### DIFF
--- a/src/core_functions/function_list.cpp
+++ b/src/core_functions/function_list.cpp
@@ -118,6 +118,7 @@ static StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_SCALAR_FUNCTION(CotFun),
 	DUCKDB_AGGREGATE_FUNCTION(CovarPopFun),
 	DUCKDB_AGGREGATE_FUNCTION(CovarSampFun),
+	DUCKDB_SCALAR_FUNCTION(CreateSortKeyFun),
 	DUCKDB_SCALAR_FUNCTION(CurrentDatabaseFun),
 	DUCKDB_SCALAR_FUNCTION(CurrentDateFun),
 	DUCKDB_SCALAR_FUNCTION(CurrentQueryFun),

--- a/src/core_functions/scalar/blob/CMakeLists.txt
+++ b/src/core_functions/scalar/blob/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library_unity(duckdb_func_blob OBJECT base64.cpp create_sort_key.cpp encode.cpp)
+add_library_unity(duckdb_func_blob OBJECT base64.cpp create_sort_key.cpp
+                  encode.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_blob>
     PARENT_SCOPE)

--- a/src/core_functions/scalar/blob/CMakeLists.txt
+++ b/src/core_functions/scalar/blob/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library_unity(duckdb_func_blob OBJECT base64.cpp encode.cpp)
+add_library_unity(duckdb_func_blob OBJECT base64.cpp create_sort_key.cpp encode.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_blob>
     PARENT_SCOPE)

--- a/src/core_functions/scalar/blob/create_sort_key.cpp
+++ b/src/core_functions/scalar/blob/create_sort_key.cpp
@@ -1,0 +1,173 @@
+#include "duckdb/core_functions/scalar/blob_functions.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/common/enums/order_type.hpp"
+#include "duckdb/common/radix.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+struct OrderModifiers {
+	OrderModifiers(OrderType order_type, OrderByNullType null_type) : order_type(order_type), null_type(null_type) {}
+
+	OrderType order_type;
+	OrderByNullType null_type;
+
+	bool operator==(const OrderModifiers& other) const {
+		return order_type == other.order_type && null_type == other.null_type;
+	}
+
+	static OrderModifiers Parse(const string &val) {
+		auto lcase = StringUtil::Lower(val);
+		OrderType order_type;
+		if (StringUtil::StartsWith(lcase, "asc")) {
+			order_type = OrderType::ASCENDING;
+		} else if (StringUtil::StartsWith(lcase, "desc")) {
+			order_type = OrderType::DESCENDING;
+		} else {
+			throw BinderException("create_sort_key modifier must start with either ASC or DESC");
+		}
+		OrderByNullType null_type;
+		if (StringUtil::EndsWith(lcase, "nulls first")) {
+			null_type = OrderByNullType::NULLS_FIRST;
+		} else if (StringUtil::EndsWith(lcase, "nulls last")) {
+			null_type = OrderByNullType::NULLS_LAST;
+		} else {
+			throw BinderException("create_sort_key modifier must end with either NULLS FIRST or NULLS LAST");
+		}
+		return OrderModifiers(order_type, null_type);
+	}
+};
+
+struct CreateSortKeyBindData : public FunctionData {
+	CreateSortKeyBindData() {}
+
+	vector<OrderModifiers> modifiers;
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<CreateSortKeyBindData>();
+		return modifiers == other.modifiers;
+	}
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<CreateSortKeyBindData>();
+		result->modifiers = modifiers;
+		return std::move(result);
+	}
+};
+
+unique_ptr<FunctionData> CreateSortKeyBind(ClientContext &context, ScalarFunction &bound_function,
+											  vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() % 2 != 0) {
+		throw BinderException("Arguments to create_sort_key must be [key1, sort_specifier1, key2, sort_specifier2, ...]");
+	}
+	auto result = make_uniq<CreateSortKeyBindData>();
+	for(idx_t i = 1; i < arguments.size(); i += 2) {
+		if (!arguments[i]->IsFoldable()) {
+			throw BinderException("sort_specifier must be a constant value - but got %s", arguments[i]->ToString());
+		}
+
+		// Rebind to return a date if we are truncating that far
+		Value sort_specifier = ExpressionExecutor::EvaluateScalar(context, *arguments[i]);
+		if (sort_specifier.IsNull()) {
+			throw BinderException("sort_specifier cannot be NULL");
+		}
+		auto sort_specifier_str = sort_specifier.ToString();
+		result->modifiers.push_back(OrderModifiers::Parse(sort_specifier_str));
+	}
+	return result;
+}
+
+static void GetSortKeyLength(Vector &vec, UnifiedVectorFormat &udata, idx_t size, idx_t &constant_length, unsafe_vector<idx_t> &variable_lengths) {
+	auto physical_type = vec.GetType().InternalType();
+	// every row is prefixed by a validity byte
+	constant_length += 1;
+	if (TypeIsConstantSize(physical_type)) {
+		constant_length += GetTypeIdSize(physical_type);
+		return;
+	}
+	// handle variable lengths
+	switch(physical_type) {
+	default:
+		throw InternalException("Unsupported physical type in GetSortKeyLength", physical_type);
+	}
+}
+
+template<class T>
+void ConstructSortKeyConstant(UnifiedVectorFormat &udata, idx_t size, OrderModifiers modifiers, unsafe_vector<idx_t> &offsets, string_t *result_data) {
+	auto data = UnifiedVectorFormat::GetData<T>(udata);
+	data_t null_byte = modifiers.null_type == OrderByNullType::NULLS_LAST ? 1 : 0;
+	data_t valid_byte = 1 - null_byte;
+	bool flip_bytes = modifiers.order_type == OrderType::DESCENDING;
+	for(idx_t r = 0; r < size; r++) {
+		auto ptr = data_ptr_cast(result_data[r].GetDataWriteable());
+		auto idx = udata.sel->get_index(r);
+		if (!udata.validity.RowIsValid(idx)) {
+			// NULL value - write 1 as the validity byte and skip
+			ptr[offsets[r]] = null_byte;
+			offsets[r]++;
+			break;
+		}
+		// valid value - write 0 as the validity byte
+		ptr[offsets[r]] = valid_byte;
+		offsets[r]++;
+		Radix::EncodeData<T>(ptr + offsets[r], data[idx]);
+		if (flip_bytes) {
+			// descending order - so flip bytes
+			for(idx_t b = offsets[r]; b < offsets[r] + sizeof(T); b++) {
+				ptr[b] = ~ptr[b];
+			}
+		}
+		offsets[r] += sizeof(T) + 1;
+	}
+}
+
+static void ConstructSortKey(Vector &vec, UnifiedVectorFormat &udata, idx_t size, OrderModifiers modifiers, unsafe_vector<idx_t> &offsets, string_t *result_data) {
+	switch(vec.GetType().InternalType()) {
+	case PhysicalType::INT32:
+		ConstructSortKeyConstant<int32_t>(udata, size, modifiers, offsets, result_data);
+		break;
+	default:
+		throw InternalException("Unsupported physical type in ConstructSortKey");
+	}
+}
+
+static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<CreateSortKeyBindData>();
+	idx_t constant_length = 0;
+
+	unsafe_vector<idx_t> variable_lengths;
+	variable_lengths.resize(args.size(), 0);
+
+	auto unified_formats = args.ToUnifiedFormat();
+
+	// two phases
+	// a) get the length of the final sorted key
+	// b) allocate the sorted key and construct
+	// we do all of this in a vectorized manner
+	for(idx_t c = 0; c < args.ColumnCount(); c += 2) {
+		GetSortKeyLength(args.data[c], unified_formats[c], args.size(), constant_length, variable_lengths);
+	}
+	// allocate the empty sort keys
+	auto result_data = FlatVector::GetData<string_t>(result);
+	for(idx_t r = 0; r < args.size(); r++) {
+		result_data[r] = StringVector::EmptyString(result, variable_lengths[r] + constant_length);
+	}
+
+	unsafe_vector<idx_t> offsets;
+	offsets.resize(args.size(), 0);
+	// now construct the sort keys
+	for(idx_t c = 0; c < args.ColumnCount(); c += 2) {
+		ConstructSortKey(args.data[c], unified_formats[c], args.size(), bind_data.modifiers[c / 2], offsets, result_data);
+	}
+	for(idx_t r = 0; r < args.size(); r++) {
+		result_data[r].Finalize();
+	}
+}
+
+ScalarFunction CreateSortKeyFun::GetFunction() {
+	ScalarFunction sort_key_function({LogicalType::ANY}, LogicalType::BLOB, CreateSortKeyFunction, CreateSortKeyBind);
+	sort_key_function.varargs = LogicalType::ANY;
+	sort_key_function.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	return sort_key_function;
+}
+
+} // namespace duckdb

--- a/src/core_functions/scalar/blob/create_sort_key.cpp
+++ b/src/core_functions/scalar/blob/create_sort_key.cpp
@@ -124,16 +124,24 @@ struct SortKeyLengthInfo {
 };
 
 struct SortKeyVectorData {
-	SortKeyVectorData(Vector &input, idx_t size) :
+	SortKeyVectorData(Vector &input, idx_t size, OrderModifiers modifiers) :
 		vec(input) {
 		input.ToUnifiedFormat(size, format);
 		this->size = size;
 
+		null_byte = modifiers.null_type == OrderByNullType::NULLS_LAST ? 1 : 0;
+		valid_byte = 1 - null_byte;
+
+		// NULLS FIRST/NULLS LAST passed in by the user are only respected at the top level
+		// within nested types NULLS LAST/NULLS FIRST is dependent on ASC/DESC order instead
+		// don't blame me this is what Postgres does
+		auto child_null_type = modifiers.order_type == OrderType::ASCENDING ? OrderByNullType::NULLS_LAST : OrderByNullType::NULLS_FIRST;
+		OrderModifiers child_modifiers(modifiers.order_type, child_null_type);
 		switch(input.GetType().InternalType()) {
 		case PhysicalType::LIST: {
 			auto &child_entry = ListVector::GetEntry(input);
 			auto child_size = ListVector::GetListSize(input);
-			child_data.emplace_back(child_entry, child_size);
+			child_data.emplace_back(child_entry, child_size, child_modifiers);
 			break;
 		}
 		default:
@@ -149,17 +157,19 @@ struct SortKeyVectorData {
 	idx_t size;
 	UnifiedVectorFormat format;
 	vector<SortKeyVectorData> child_data;
+	SelectionVector result_sel;
+	data_t null_byte;
+	data_t valid_byte;
 };
 
-
-static void GetSortKeyLength(SortKeyVectorData &vector_data, const SelectionVector &result_vector, SortKeyLengthInfo &result);
+static void GetSortKeyLengthRecursive(SortKeyVectorData &vector_data, SortKeyLengthInfo &result);
 
 template<class OP>
-void TemplatedGetSortKeyLength(SortKeyVectorData &vector_data, const SelectionVector &result_vector, SortKeyLengthInfo &result) {
+void TemplatedGetSortKeyLength(SortKeyVectorData &vector_data, SortKeyLengthInfo &result) {
 	auto &format = vector_data.format;
 	auto data = UnifiedVectorFormat::GetData<typename OP::TYPE>(vector_data.format);
 	for(idx_t r = 0; r < vector_data.size; r++) {
-		auto result_index = result_vector.get_index(r);
+		auto result_index = vector_data.result_sel.get_index(r);
 		result.variable_lengths[result_index]++; // every value is prefixed by a validity byte
 
 		auto idx = format.sel->get_index(r);
@@ -170,51 +180,46 @@ void TemplatedGetSortKeyLength(SortKeyVectorData &vector_data, const SelectionVe
 	}
 }
 
-void GetSortKeyLengthList(SortKeyVectorData &vector_data, const SelectionVector &result_vector, SortKeyLengthInfo &result) {
+void GetSortKeyLengthList(SortKeyVectorData &vector_data, SortKeyLengthInfo &result) {
 	auto data = UnifiedVectorFormat::GetData<list_entry_t>(vector_data.format);
 	auto &child_data = vector_data.child_data[0];
-
-
-	// construct a selection vector that points, for each of the child elements, to which sort key in the result they belong
-	SelectionVector child_result_sel;
-	child_result_sel.Initialize(child_data.size);
-	idx_t entry = 0;
+	child_data.result_sel.Initialize(child_data.size);
 	for (idx_t r = 0; r < vector_data.size; r++) {
-		auto result_idx = result_vector.get_index(r);
-		result.variable_lengths[result_idx]++; // every list is prefixed by a validity byte
+		auto result_index = vector_data.result_sel.get_index(r);
+		result.variable_lengths[result_index]++; // every list is prefixed by a validity byte
 
 		auto idx = vector_data.format.sel->get_index(r);
 		if (!vector_data.format.validity.RowIsValid(idx)) {
 			continue;
 		}
 		auto list_entry = data[idx];
-		// for each list we have an "end of list" delimiter
-		result.variable_lengths[result_idx]++;
+		// for each non-null list we have an "end of list" delimiter
+		result.variable_lengths[result_index]++;
 		// set up the selection vector for the child
 		for (idx_t k = 0; k < list_entry.length; k++) {
-			child_result_sel.set_index(entry++, result_idx);
+			child_data.result_sel.set_index(list_entry.offset + k, result_index);
 		}
 	}
 	// now recursively call GetSortKeyLength on the child element
-	GetSortKeyLength(child_data, child_result_sel, result);
+	GetSortKeyLengthRecursive(child_data, result);
 }
 
-static void GetSortKeyLength(SortKeyVectorData &vector_data, const SelectionVector &result_vector, SortKeyLengthInfo &result) {
+static void GetSortKeyLengthRecursive(SortKeyVectorData &vector_data, SortKeyLengthInfo &result) {
 	auto physical_type = vector_data.GetPhysicalType();
 	// handle variable lengths
 	switch(physical_type) {
 	case PhysicalType::INT32:
-		TemplatedGetSortKeyLength<SortKeyConstantOperator<int32_t>>(vector_data, result_vector, result);
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<int32_t>>(vector_data, result);
 		break;
 	case PhysicalType::VARCHAR:
 		if (vector_data.vec.GetType().id() == LogicalTypeId::VARCHAR) {
-			TemplatedGetSortKeyLength<SortKeyVarcharOperator>(vector_data, result_vector, result);
+			TemplatedGetSortKeyLength<SortKeyVarcharOperator>(vector_data, result);
 		} else {
 			throw NotImplementedException("FIXME: ConstructSortKey blob");
 		}
 		break;
 	case PhysicalType::LIST:
-		GetSortKeyLengthList(vector_data, result_vector, result);
+		GetSortKeyLengthList(vector_data, result);
 		break;
 	default:
 		throw NotImplementedException("Unsupported physical type %s in GetSortKeyLength", physical_type);
@@ -230,57 +235,105 @@ static void GetSortKeyLength(SortKeyVectorData &vector_data, SortKeyLengthInfo &
 		result.constant_length += GetTypeIdSize(physical_type);
 		return;
 	}
-	GetSortKeyLength(vector_data,  *FlatVector::IncrementalSelectionVector(), result);
+	vector_data.result_sel.Initialize(*FlatVector::IncrementalSelectionVector());
+	GetSortKeyLengthRecursive(vector_data, result);
 }
 
 //===--------------------------------------------------------------------===//
 // Construct Sort Key
 //===--------------------------------------------------------------------===//
+struct SortKeyConstructInfo {
+	SortKeyConstructInfo(OrderModifiers modifiers_p, unsafe_vector<idx_t> &offsets, string_t *result_data) :
+		modifiers(modifiers_p), offsets(offsets), result_data(result_data) {
+		flip_bytes = modifiers.order_type == OrderType::DESCENDING;
+	}
+
+	OrderModifiers modifiers;
+	unsafe_vector<idx_t> &offsets;
+	string_t *result_data;
+	bool flip_bytes;
+};
+
+static void ConstructSortKeyRecursive(SortKeyVectorData &vector_data, idx_t start, idx_t end, SortKeyConstructInfo &info);
+
 template<class OP>
-void TemplatedConstructSortKey(SortKeyVectorData &vector_data, OrderModifiers modifiers, unsafe_vector<idx_t> &offsets, string_t *result_data) {
+void TemplatedConstructSortKey(SortKeyVectorData &vector_data, idx_t start, idx_t end, SortKeyConstructInfo &info) {
 	auto data = UnifiedVectorFormat::GetData<typename OP::TYPE>(vector_data.format);
-	data_t null_byte = modifiers.null_type == OrderByNullType::NULLS_LAST ? 1 : 0;
-	data_t valid_byte = 1 - null_byte;
-	bool flip_bytes = modifiers.order_type == OrderType::DESCENDING;
-	for(idx_t r = 0; r < vector_data.size; r++) {
-		auto result_ptr = data_ptr_cast(result_data[r].GetDataWriteable());
+	auto &offsets = info.offsets;
+	for (idx_t r = start; r < end; r++) {
+		auto result_index = vector_data.result_sel.get_index(r);
+		auto &offset = offsets[result_index];
+		auto result_ptr = data_ptr_cast(info.result_data[result_index].GetDataWriteable());
 		auto idx = vector_data.format.sel->get_index(r);
 		if (!vector_data.format.validity.RowIsValid(idx)) {
 			// NULL value - write the null byte and skip
-			result_ptr[offsets[r]] = null_byte;
-			offsets[r]++;
+			result_ptr[offset++] = vector_data.null_byte;
 			break;
 		}
 		// valid value - write the validity byte
-		result_ptr[offsets[r]] = valid_byte;
-		offsets[r]++;
-		idx_t encode_len = OP::Encode(result_ptr + offsets[r], data[idx]);
-		if (flip_bytes) {
+		result_ptr[offset++] = vector_data.valid_byte;
+		idx_t encode_len = OP::Encode(result_ptr + offset, data[idx]);
+		if (info.flip_bytes) {
 			// descending order - so flip bytes
-			for(idx_t b = offsets[r]; b < offsets[r] + encode_len; b++) {
+			for (idx_t b = offset; b < offset + encode_len; b++) {
 				result_ptr[b] = ~result_ptr[b];
 			}
 		}
-		offsets[r] += encode_len;
+		offset += encode_len;
 	}
 }
 
-static void ConstructSortKey(SortKeyVectorData &vector_data, OrderModifiers modifiers, unsafe_vector<idx_t> &offsets, string_t *result_data) {
+void ConstructSortKeyList(SortKeyVectorData &vector_data, idx_t start, idx_t end, SortKeyConstructInfo &info) {
+	auto data = UnifiedVectorFormat::GetData<list_entry_t>(vector_data.format);
+	auto &offsets = info.offsets;
+	for (idx_t r = start; r < end; r++) {
+		auto result_index = vector_data.result_sel.get_index(r);
+		auto &offset = offsets[result_index];
+		auto result_ptr = data_ptr_cast(info.result_data[result_index].GetDataWriteable());
+		auto idx = vector_data.format.sel->get_index(r);
+		if (!vector_data.format.validity.RowIsValid(idx)) {
+			// NULL value - write the null byte and skip
+			result_ptr[offset++] = vector_data.null_byte;
+			continue;
+		}
+		// valid value - write the validity byte
+		result_ptr[offset++] = vector_data.valid_byte;
+
+		auto list_entry = data[idx];
+		// recurse and write the list elements
+		if (list_entry.length > 0) {
+			ConstructSortKeyRecursive(vector_data.child_data[0], list_entry.offset, list_entry.offset + list_entry.length, info);
+		}
+
+		// write the end-of-list delimiter
+		result_ptr[offset++] = info.flip_bytes ? ~data_t(0) : 0;
+	}
+}
+
+static void ConstructSortKeyRecursive(SortKeyVectorData &vector_data, idx_t start, idx_t end, SortKeyConstructInfo &info) {
 	switch(vector_data.GetPhysicalType()) {
 	case PhysicalType::INT32:
-		TemplatedConstructSortKey<SortKeyConstantOperator<int32_t>>(vector_data, modifiers, offsets, result_data);
+		TemplatedConstructSortKey<SortKeyConstantOperator<int32_t>>(vector_data, start, end, info);
 		break;
 	case PhysicalType::VARCHAR:
 		if (vector_data.vec.GetType().id() == LogicalTypeId::VARCHAR) {
-			TemplatedConstructSortKey<SortKeyVarcharOperator>(vector_data, modifiers, offsets, result_data);
+			TemplatedConstructSortKey<SortKeyVarcharOperator>(vector_data, start, end, info);
 		} else {
 			throw NotImplementedException("FIXME: ConstructSortKey blob");
 		}
+		break;
+	case PhysicalType::LIST:
+		ConstructSortKeyList(vector_data, start, end, info);
 		break;
 	default:
 		throw NotImplementedException("Unsupported type %s in ConstructSortKey", vector_data.vec.GetType());
 	}
 }
+
+static void ConstructSortKey(SortKeyVectorData &vector_data, SortKeyConstructInfo &info) {
+	ConstructSortKeyRecursive(vector_data, 0, vector_data.size, info);
+}
+
 
 static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<CreateSortKeyBindData>();
@@ -288,7 +341,7 @@ static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 	// prepare the sort key data
 	vector<SortKeyVectorData> sort_key_data;
 	for(idx_t c = 0; c < args.ColumnCount(); c += 2) {
-		sort_key_data.emplace_back(args.data[c], args.size());
+		sort_key_data.emplace_back(args.data[c], args.size(), bind_data.modifiers[c / 2]);
 	}
 
 	// two phases
@@ -309,11 +362,15 @@ static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 	offsets.resize(args.size(), 0);
 	// now construct the sort keys
 	for(idx_t c = 0; c < sort_key_data.size(); c++) {
-		ConstructSortKey(sort_key_data[c], bind_data.modifiers[c], offsets, result_data);
+		SortKeyConstructInfo info(bind_data.modifiers[c], offsets, result_data);
+		ConstructSortKey(sort_key_data[c], info);
 	}
 	// call Finalize on the result
 	for(idx_t r = 0; r < args.size(); r++) {
 		result_data[r].Finalize();
+	}
+	if (args.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 }
 

--- a/src/core_functions/scalar/blob/create_sort_key.cpp
+++ b/src/core_functions/scalar/blob/create_sort_key.cpp
@@ -83,6 +83,10 @@ template<class T>
 struct SortKeyConstantOperator {
 	using TYPE = T;
 
+	static idx_t GetEncodeLength(TYPE input) {
+		return sizeof(T);
+	}
+
 	static idx_t Encode(data_ptr_t result, TYPE input) {
 		Radix::EncodeData<T>(result, input);
 		return sizeof(T);
@@ -110,54 +114,138 @@ struct SortKeyVarcharOperator {
 //===--------------------------------------------------------------------===//
 // Get Sort Key Length
 //===--------------------------------------------------------------------===//
-template<class OP>
-void TemplatedGetSortKeyLength(UnifiedVectorFormat &udata, idx_t size, unsafe_vector<idx_t> &variable_lengths) {
-	auto data = UnifiedVectorFormat::GetData<typename OP::TYPE>(udata);
-	for(idx_t r = 0; r < size; r++) {
-		auto idx = udata.sel->get_index(r);
-		if (!udata.validity.RowIsValid(idx)) {
+struct SortKeyLengthInfo {
+	explicit SortKeyLengthInfo(idx_t size) : constant_length(0) {
+		variable_lengths.resize(size, 0);
+	}
+
+	idx_t constant_length;
+	unsafe_vector<idx_t> variable_lengths;
+};
+
+struct SortKeyVectorData {
+	SortKeyVectorData(Vector &input, idx_t size) :
+		vec(input) {
+		input.ToUnifiedFormat(size, format);
+		this->size = size;
+
+		switch(input.GetType().InternalType()) {
+		case PhysicalType::LIST: {
+			auto &child_entry = ListVector::GetEntry(input);
+			auto child_size = ListVector::GetListSize(input);
+			child_data.emplace_back(child_entry, child_size);
 			break;
 		}
-		variable_lengths[r] += OP::GetEncodeLength(data[idx]);
+		default:
+			break;
+		}
+	}
+
+	PhysicalType GetPhysicalType() {
+		return vec.GetType().InternalType();
+	}
+
+	Vector &vec;
+	idx_t size;
+	UnifiedVectorFormat format;
+	vector<SortKeyVectorData> child_data;
+};
+
+
+static void GetSortKeyLength(SortKeyVectorData &vector_data, const SelectionVector &result_vector, SortKeyLengthInfo &result);
+
+template<class OP>
+void TemplatedGetSortKeyLength(SortKeyVectorData &vector_data, const SelectionVector &result_vector, SortKeyLengthInfo &result) {
+	auto &format = vector_data.format;
+	auto data = UnifiedVectorFormat::GetData<typename OP::TYPE>(vector_data.format);
+	for(idx_t r = 0; r < vector_data.size; r++) {
+		auto result_index = result_vector.get_index(r);
+		result.variable_lengths[result_index]++; // every value is prefixed by a validity byte
+
+		auto idx = format.sel->get_index(r);
+		if (!format.validity.RowIsValid(idx)) {
+			continue;
+		}
+		result.variable_lengths[result_index] += OP::GetEncodeLength(data[idx]);
 	}
 }
 
-static void GetSortKeyLength(Vector &vec, UnifiedVectorFormat &udata, idx_t size, idx_t &constant_length, unsafe_vector<idx_t> &variable_lengths) {
-	auto physical_type = vec.GetType().InternalType();
-	// every row is prefixed by a validity byte
-	constant_length += 1;
-	if (TypeIsConstantSize(physical_type)) {
-		constant_length += GetTypeIdSize(physical_type);
-		return;
+void GetSortKeyLengthList(SortKeyVectorData &vector_data, const SelectionVector &result_vector, SortKeyLengthInfo &result) {
+	auto data = UnifiedVectorFormat::GetData<list_entry_t>(vector_data.format);
+	auto &child_data = vector_data.child_data[0];
+
+
+	// construct a selection vector that points, for each of the child elements, to which sort key in the result they belong
+	SelectionVector child_result_sel;
+	child_result_sel.Initialize(child_data.size);
+	idx_t entry = 0;
+	for (idx_t r = 0; r < vector_data.size; r++) {
+		auto result_idx = result_vector.get_index(r);
+		result.variable_lengths[result_idx]++; // every list is prefixed by a validity byte
+
+		auto idx = vector_data.format.sel->get_index(r);
+		if (!vector_data.format.validity.RowIsValid(idx)) {
+			continue;
+		}
+		auto list_entry = data[idx];
+		// for each list we have an "end of list" delimiter
+		result.variable_lengths[result_idx]++;
+		// set up the selection vector for the child
+		for (idx_t k = 0; k < list_entry.length; k++) {
+			child_result_sel.set_index(entry++, result_idx);
+		}
 	}
+	// now recursively call GetSortKeyLength on the child element
+	GetSortKeyLength(child_data, child_result_sel, result);
+}
+
+static void GetSortKeyLength(SortKeyVectorData &vector_data, const SelectionVector &result_vector, SortKeyLengthInfo &result) {
+	auto physical_type = vector_data.GetPhysicalType();
 	// handle variable lengths
 	switch(physical_type) {
+	case PhysicalType::INT32:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<int32_t>>(vector_data, result_vector, result);
+		break;
 	case PhysicalType::VARCHAR:
-		if (vec.GetType().id() == LogicalTypeId::VARCHAR) {
-			TemplatedGetSortKeyLength<SortKeyVarcharOperator>(udata, size, variable_lengths);
+		if (vector_data.vec.GetType().id() == LogicalTypeId::VARCHAR) {
+			TemplatedGetSortKeyLength<SortKeyVarcharOperator>(vector_data, result_vector, result);
 		} else {
-			throw InternalException("FIXME: ConstructSortKey blob");
+			throw NotImplementedException("FIXME: ConstructSortKey blob");
 		}
 		break;
+	case PhysicalType::LIST:
+		GetSortKeyLengthList(vector_data, result_vector, result);
+		break;
 	default:
-		throw InternalException("Unsupported physical type in GetSortKeyLength", physical_type);
+		throw NotImplementedException("Unsupported physical type %s in GetSortKeyLength", physical_type);
 	}
 }
 
+static void GetSortKeyLength(SortKeyVectorData &vector_data, SortKeyLengthInfo &result) {
+	// top-level method
+	auto physical_type = vector_data.GetPhysicalType();
+	if (TypeIsConstantSize(physical_type)) {
+		// every row is prefixed by a validity byte
+		result.constant_length += 1;
+		result.constant_length += GetTypeIdSize(physical_type);
+		return;
+	}
+	GetSortKeyLength(vector_data,  *FlatVector::IncrementalSelectionVector(), result);
+}
 
 //===--------------------------------------------------------------------===//
 // Construct Sort Key
 //===--------------------------------------------------------------------===//
 template<class OP>
-void TemplatedConstructSortKey(UnifiedVectorFormat &udata, idx_t size, OrderModifiers modifiers, unsafe_vector<idx_t> &offsets, string_t *result_data) {
-	auto data = UnifiedVectorFormat::GetData<typename OP::TYPE>(udata);
+void TemplatedConstructSortKey(SortKeyVectorData &vector_data, OrderModifiers modifiers, unsafe_vector<idx_t> &offsets, string_t *result_data) {
+	auto data = UnifiedVectorFormat::GetData<typename OP::TYPE>(vector_data.format);
 	data_t null_byte = modifiers.null_type == OrderByNullType::NULLS_LAST ? 1 : 0;
 	data_t valid_byte = 1 - null_byte;
 	bool flip_bytes = modifiers.order_type == OrderType::DESCENDING;
-	for(idx_t r = 0; r < size; r++) {
+	for(idx_t r = 0; r < vector_data.size; r++) {
 		auto result_ptr = data_ptr_cast(result_data[r].GetDataWriteable());
-		auto idx = udata.sel->get_index(r);
-		if (!udata.validity.RowIsValid(idx)) {
+		auto idx = vector_data.format.sel->get_index(r);
+		if (!vector_data.format.validity.RowIsValid(idx)) {
 			// NULL value - write the null byte and skip
 			result_ptr[offsets[r]] = null_byte;
 			offsets[r]++;
@@ -177,51 +265,53 @@ void TemplatedConstructSortKey(UnifiedVectorFormat &udata, idx_t size, OrderModi
 	}
 }
 
-static void ConstructSortKey(Vector &vec, UnifiedVectorFormat &udata, idx_t size, OrderModifiers modifiers, unsafe_vector<idx_t> &offsets, string_t *result_data) {
-	switch(vec.GetType().InternalType()) {
+static void ConstructSortKey(SortKeyVectorData &vector_data, OrderModifiers modifiers, unsafe_vector<idx_t> &offsets, string_t *result_data) {
+	switch(vector_data.GetPhysicalType()) {
 	case PhysicalType::INT32:
-		TemplatedConstructSortKey<SortKeyConstantOperator<int32_t>>(udata, size, modifiers, offsets, result_data);
+		TemplatedConstructSortKey<SortKeyConstantOperator<int32_t>>(vector_data, modifiers, offsets, result_data);
 		break;
 	case PhysicalType::VARCHAR:
-		if (vec.GetType().id() == LogicalTypeId::VARCHAR) {
-			TemplatedConstructSortKey<SortKeyVarcharOperator>(udata, size, modifiers, offsets, result_data);
+		if (vector_data.vec.GetType().id() == LogicalTypeId::VARCHAR) {
+			TemplatedConstructSortKey<SortKeyVarcharOperator>(vector_data, modifiers, offsets, result_data);
 		} else {
-			throw InternalException("FIXME: ConstructSortKey blob");
+			throw NotImplementedException("FIXME: ConstructSortKey blob");
 		}
 		break;
 	default:
-		throw InternalException("Unsupported physical type in ConstructSortKey");
+		throw NotImplementedException("Unsupported type %s in ConstructSortKey", vector_data.vec.GetType());
 	}
 }
 
 static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<CreateSortKeyBindData>();
-	idx_t constant_length = 0;
 
-	unsafe_vector<idx_t> variable_lengths;
-	variable_lengths.resize(args.size(), 0);
-
-	auto unified_formats = args.ToUnifiedFormat();
+	// prepare the sort key data
+	vector<SortKeyVectorData> sort_key_data;
+	for(idx_t c = 0; c < args.ColumnCount(); c += 2) {
+		sort_key_data.emplace_back(args.data[c], args.size());
+	}
 
 	// two phases
 	// a) get the length of the final sorted key
 	// b) allocate the sorted key and construct
 	// we do all of this in a vectorized manner
-	for(idx_t c = 0; c < args.ColumnCount(); c += 2) {
-		GetSortKeyLength(args.data[c], unified_formats[c], args.size(), constant_length, variable_lengths);
+	SortKeyLengthInfo key_lengths(args.size());
+	for(auto &vector_data : sort_key_data) {
+		GetSortKeyLength(vector_data, key_lengths);
 	}
 	// allocate the empty sort keys
 	auto result_data = FlatVector::GetData<string_t>(result);
 	for(idx_t r = 0; r < args.size(); r++) {
-		result_data[r] = StringVector::EmptyString(result, variable_lengths[r] + constant_length);
+		result_data[r] = StringVector::EmptyString(result, key_lengths.variable_lengths[r] + key_lengths.constant_length);
 	}
 
 	unsafe_vector<idx_t> offsets;
 	offsets.resize(args.size(), 0);
 	// now construct the sort keys
-	for(idx_t c = 0; c < args.ColumnCount(); c += 2) {
-		ConstructSortKey(args.data[c], unified_formats[c], args.size(), bind_data.modifiers[c / 2], offsets, result_data);
+	for(idx_t c = 0; c < sort_key_data.size(); c++) {
+		ConstructSortKey(sort_key_data[c], bind_data.modifiers[c], offsets, result_data);
 	}
+	// call Finalize on the result
 	for(idx_t r = 0; r < args.size(); r++) {
 		result_data[r].Finalize();
 	}

--- a/src/core_functions/scalar/blob/create_sort_key.cpp
+++ b/src/core_functions/scalar/blob/create_sort_key.cpp
@@ -95,7 +95,7 @@ unique_ptr<FunctionData> CreateSortKeyBind(ClientContext &context, ScalarFunctio
 			bound_function.return_type = LogicalType::BIGINT;
 		}
 	}
-	return result;
+	return std::move(result);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/core_functions/scalar/blob/create_sort_key.cpp
+++ b/src/core_functions/scalar/blob/create_sort_key.cpp
@@ -277,8 +277,47 @@ static void GetSortKeyLengthRecursive(SortKeyVectorData &vector_data, SortKeyLen
 	auto physical_type = vector_data.GetPhysicalType();
 	// handle variable lengths
 	switch(physical_type) {
+	case PhysicalType::BOOL:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<bool>>(vector_data, result);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<uint8_t>>(vector_data, result);
+		break;
+	case PhysicalType::INT8:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<int8_t>>(vector_data, result);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<uint16_t>>(vector_data, result);
+		break;
+	case PhysicalType::INT16:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<int16_t>>(vector_data, result);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<uint32_t>>(vector_data, result);
+		break;
 	case PhysicalType::INT32:
 		TemplatedGetSortKeyLength<SortKeyConstantOperator<int32_t>>(vector_data, result);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<uint64_t>>(vector_data, result);
+		break;
+	case PhysicalType::INT64:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<int64_t>>(vector_data, result);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<float>>(vector_data, result);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<double>>(vector_data, result);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<interval_t>>(vector_data, result);
+		break;
+	case PhysicalType::UINT128:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<uhugeint_t>>(vector_data, result);
+		break;
+	case PhysicalType::INT128:
+		TemplatedGetSortKeyLength<SortKeyConstantOperator<hugeint_t>>(vector_data, result);
 		break;
 	case PhysicalType::VARCHAR:
 		if (vector_data.vec.GetType().id() == LogicalTypeId::VARCHAR) {
@@ -415,8 +454,47 @@ void ConstructSortKeyList(SortKeyVectorData &vector_data, idx_t start, idx_t end
 
 static void ConstructSortKeyRecursive(SortKeyVectorData &vector_data, idx_t start, idx_t end, SortKeyConstructInfo &info) {
 	switch(vector_data.GetPhysicalType()) {
+	case PhysicalType::BOOL:
+		TemplatedConstructSortKey<SortKeyConstantOperator<bool>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedConstructSortKey<SortKeyConstantOperator<uint8_t>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::INT8:
+		TemplatedConstructSortKey<SortKeyConstantOperator<int8_t>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedConstructSortKey<SortKeyConstantOperator<uint16_t>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::INT16:
+		TemplatedConstructSortKey<SortKeyConstantOperator<int16_t>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedConstructSortKey<SortKeyConstantOperator<uint32_t>>(vector_data, start, end, info);
+		break;
 	case PhysicalType::INT32:
 		TemplatedConstructSortKey<SortKeyConstantOperator<int32_t>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedConstructSortKey<SortKeyConstantOperator<uint64_t>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::INT64:
+		TemplatedConstructSortKey<SortKeyConstantOperator<int64_t>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedConstructSortKey<SortKeyConstantOperator<float>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedConstructSortKey<SortKeyConstantOperator<double>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedConstructSortKey<SortKeyConstantOperator<interval_t>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::UINT128:
+		TemplatedConstructSortKey<SortKeyConstantOperator<uhugeint_t>>(vector_data, start, end, info);
+		break;
+	case PhysicalType::INT128:
+		TemplatedConstructSortKey<SortKeyConstantOperator<hugeint_t>>(vector_data, start, end, info);
 		break;
 	case PhysicalType::VARCHAR:
 		if (vector_data.vec.GetType().id() == LogicalTypeId::VARCHAR) {

--- a/src/core_functions/scalar/blob/functions.json
+++ b/src/core_functions/scalar/blob/functions.json
@@ -27,5 +27,12 @@
         "example": "base64('A'::blob)",
         "type": "scalar_function",
         "aliases": ["base64"]
+    },
+    {
+        "name": "create_sort_key",
+        "parameters": "parameters...",
+        "description": "Constructs a binary-comparable sort key based on a set of input parameters and sort qualifiers",
+        "example": "create_sort_key('A', 'DESC')",
+        "type": "scalar_function"
     }
 ]

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -117,9 +117,7 @@ public:
 		// set trailing NULL byte
 		if (GetSize() <= INLINE_LENGTH) {
 			// fill prefix with zeros if the length is smaller than the prefix length
-			for (idx_t i = GetSize(); i < INLINE_BYTES; i++) {
-				value.inlined.inlined[i] = '\0';
-			}
+			memset(value.inlined.inlined + GetSize(), 0, INLINE_BYTES - GetSize());
 		} else {
 			// copy the data into the prefix
 #ifndef DUCKDB_DEBUG_NO_INLINE

--- a/src/include/duckdb/core_functions/scalar/blob_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/blob_functions.hpp
@@ -57,4 +57,13 @@ struct Base64Fun {
 	static constexpr const char *Name = "base64";
 };
 
+struct CreateSortKeyFun {
+	static constexpr const char *Name = "create_sort_key";
+	static constexpr const char *Parameters = "parameters...";
+	static constexpr const char *Description = "Constructs a binary-comparable sort key based on a set of input parameters and sort qualifiers";
+	static constexpr const char *Example = "create_sort_key('A', 'DESC')";
+
+	static ScalarFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/test/issues/general/test_2496.test
+++ b/test/issues/general/test_2496.test
@@ -3,6 +3,9 @@
 # group: [general]
 
 statement ok
+PRAGMA enable_verification
+
+statement ok
 CREATE TABLE list_str AS
 SELECT * FROM (VALUES
 	({'x': 'duck', 'y': ''}),

--- a/test/sql/function/blob/create_sort_key.test
+++ b/test/sql/function/blob/create_sort_key.test
@@ -133,3 +133,51 @@ NULL
 [1, 2, 3]
 [1]
 []
+
+
+# test struct types
+statement ok
+CREATE TABLE structs(s ROW(i INT, v VARCHAR));
+
+statement ok
+INSERT INTO structs VALUES ({'i': 42, v: 'hello'}), ({'i': 42, v: 'hello' || chr(0)}), ({'i': 43, v: ''}), (NULL), ({'i': 42, v: NULL}), ({'i': NULL, v: ''})
+
+query I
+SELECT * FROM structs ORDER BY create_sort_key(s, 'ASC NULLS LAST')
+----
+{'i': 42, 'v': hello}
+{'i': 42, 'v': hello\0}
+{'i': 42, 'v': NULL}
+{'i': 43, 'v': }
+{'i': NULL, 'v': }
+NULL
+
+query I
+SELECT * FROM structs ORDER BY create_sort_key(s, 'ASC NULLS FIRST')
+----
+NULL
+{'i': 42, 'v': hello}
+{'i': 42, 'v': hello\0}
+{'i': 42, 'v': NULL}
+{'i': 43, 'v': }
+{'i': NULL, 'v': }
+
+query I
+SELECT * FROM structs ORDER BY create_sort_key(s, 'DESC NULLS LAST')
+----
+{'i': NULL, 'v': }
+{'i': 43, 'v': }
+{'i': 42, 'v': NULL}
+{'i': 42, 'v': hello\0}
+{'i': 42, 'v': hello}
+NULL
+
+query I
+SELECT * FROM structs ORDER BY create_sort_key(s, 'DESC NULLS FIRST')
+----
+NULL
+{'i': NULL, 'v': }
+{'i': 43, 'v': }
+{'i': 42, 'v': NULL}
+{'i': 42, 'v': hello\0}
+{'i': 42, 'v': hello}

--- a/test/sql/function/blob/create_sort_key.test
+++ b/test/sql/function/blob/create_sort_key.test
@@ -1,0 +1,45 @@
+# name: test/sql/function/blob/create_sort_key.test
+# description: Test create_sort_key function
+# group: [blob]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (1), (2), (3), (NULL)
+
+# test integer types with all modifiers
+query I
+SELECT * FROM integers ORDER BY create_sort_key(i, 'ASC NULLS LAST')
+----
+1
+2
+3
+NULL
+
+query I
+SELECT * FROM integers ORDER BY create_sort_key(i, 'ASC NULLS FIRST')
+----
+NULL
+1
+2
+3
+
+query I
+SELECT * FROM integers ORDER BY create_sort_key(i, 'DESC NULLS LAST')
+----
+3
+2
+1
+NULL
+
+query I
+SELECT * FROM integers ORDER BY create_sort_key(i, 'DESC NULLS FIRST')
+----
+NULL
+3
+2
+1

--- a/test/sql/function/blob/create_sort_key.test
+++ b/test/sql/function/blob/create_sort_key.test
@@ -11,6 +11,18 @@ CREATE TABLE integers(i INTEGER);
 statement ok
 INSERT INTO integers VALUES (1), (2), (3), (NULL)
 
+## test list types
+#statement ok
+#CREATE TABLE int_list(l INT[]);
+#
+#statement ok
+#INSERT INTO int_list VALUES ([1, 2, 3]), ([]), ([1]), ([2]), ([NULL]), (NULL);
+#
+#query I
+#SELECT * FROM int_list ORDER BY create_sort_key(l, 'ASC NULLS LAST')
+#----
+
+
 # test integer types with all modifiers
 query I
 SELECT * FROM integers ORDER BY create_sort_key(i, 'ASC NULLS LAST')

--- a/test/sql/function/blob/create_sort_key.test
+++ b/test/sql/function/blob/create_sort_key.test
@@ -5,25 +5,13 @@
 statement ok
 PRAGMA enable_verification
 
+# test integer types with all modifiers
 statement ok
 CREATE TABLE integers(i INTEGER);
 
 statement ok
 INSERT INTO integers VALUES (1), (2), (3), (NULL)
 
-## test list types
-#statement ok
-#CREATE TABLE int_list(l INT[]);
-#
-#statement ok
-#INSERT INTO int_list VALUES ([1, 2, 3]), ([]), ([1]), ([2]), ([NULL]), (NULL);
-#
-#query I
-#SELECT * FROM int_list ORDER BY create_sort_key(l, 'ASC NULLS LAST')
-#----
-
-
-# test integer types with all modifiers
 query I
 SELECT * FROM integers ORDER BY create_sort_key(i, 'ASC NULLS LAST')
 ----
@@ -98,3 +86,50 @@ world
 hello\0\0
 hello
 (empty)
+
+# test list types
+statement ok
+CREATE TABLE int_list(l INT[]);
+
+statement ok
+INSERT INTO int_list VALUES ([1, 2, 3]), ([]), ([1]), ([2]), ([NULL]), (NULL);
+
+query I
+SELECT l FROM int_list ORDER BY create_sort_key(l, 'ASC NULLS LAST')
+----
+[]
+[1]
+[1, 2, 3]
+[2]
+[NULL]
+NULL
+
+query I
+SELECT l FROM int_list ORDER BY create_sort_key(l, 'DESC NULLS LAST')
+----
+[NULL]
+[2]
+[1, 2, 3]
+[1]
+[]
+NULL
+
+query I
+SELECT l FROM int_list ORDER BY create_sort_key(l, 'ASC NULLS FIRST')
+----
+NULL
+[]
+[1]
+[1, 2, 3]
+[2]
+[NULL]
+
+query I
+SELECT l FROM int_list ORDER BY create_sort_key(l, 'DESC NULLS FIRST')
+----
+NULL
+[NULL]
+[2]
+[1, 2, 3]
+[1]
+[]

--- a/test/sql/function/blob/create_sort_key.test
+++ b/test/sql/function/blob/create_sort_key.test
@@ -324,3 +324,28 @@ hello\x00\x00\x00\x00\x00	world
 hello\x00	NULL
 hello	world
 (empty)	(empty)
+
+# test array type
+statement ok
+CREATE TABLE arrays(l INT[3]);
+
+statement ok
+INSERT INTO arrays VALUES ([1, 2, 3]), (NULL), ([NULL, NULL, NULL]), ([1, NULL, 3]), ([2, 3, 4]);
+
+query I
+SELECT l FROM arrays ORDER BY create_sort_key(l, 'ASC NULLS LAST')
+----
+[1, 2, 3]
+[1, NULL, 3]
+[2, 3, 4]
+[NULL, NULL, NULL]
+NULL
+
+query I
+SELECT l FROM arrays ORDER BY create_sort_key(l, 'DESC NULLS FIRST')
+----
+NULL
+[NULL, NULL, NULL]
+[2, 3, 4]
+[1, NULL, 3]
+[1, 2, 3]

--- a/test/sql/function/blob/create_sort_key.test
+++ b/test/sql/function/blob/create_sort_key.test
@@ -43,3 +43,46 @@ NULL
 3
 2
 1
+
+# test varchar types
+statement ok
+CREATE TABLE varchars(v VARCHAR);
+
+statement ok
+INSERT INTO varchars VALUES ('hello'), ('hello' || chr(0) || chr(0)), ('world'), (''), (NULL)
+
+query I
+SELECT * FROM varchars ORDER BY create_sort_key(v, 'ASC NULLS LAST')
+----
+(empty)
+hello
+hello\0\0
+world
+NULL
+
+query I
+SELECT * FROM varchars ORDER BY create_sort_key(v, 'ASC NULLS FIRST')
+----
+NULL
+(empty)
+hello
+hello\0\0
+world
+
+query I
+SELECT * FROM varchars ORDER BY create_sort_key(v, 'DESC NULLS LAST')
+----
+world
+hello\0\0
+hello
+(empty)
+NULL
+
+query I
+SELECT * FROM varchars ORDER BY create_sort_key(v, 'DESC NULLS FIRST')
+----
+NULL
+world
+hello\0\0
+hello
+(empty)

--- a/test/sql/function/blob/create_sort_key.test
+++ b/test/sql/function/blob/create_sort_key.test
@@ -152,25 +152,15 @@ SELECT * FROM structs ORDER BY create_sort_key(s, 'ASC NULLS LAST')
 {'i': NULL, 'v': }
 NULL
 
-query I
-SELECT * FROM structs ORDER BY create_sort_key(s, 'ASC NULLS FIRST')
+query II
+SELECT s.i, s.v FROM structs ORDER BY create_sort_key(s.i, 'ASC NULLS LAST', s.v, 'ASC NULLS LAST')
 ----
-NULL
-{'i': 42, 'v': hello}
-{'i': 42, 'v': hello\0}
-{'i': 42, 'v': NULL}
-{'i': 43, 'v': }
-{'i': NULL, 'v': }
-
-query I
-SELECT * FROM structs ORDER BY create_sort_key(s, 'DESC NULLS LAST')
-----
-{'i': NULL, 'v': }
-{'i': 43, 'v': }
-{'i': 42, 'v': NULL}
-{'i': 42, 'v': hello\0}
-{'i': 42, 'v': hello}
-NULL
+42	hello
+42	hello\0
+42	NULL
+43	(empty)
+NULL	(empty)
+NULL	NULL
 
 query I
 SELECT * FROM structs ORDER BY create_sort_key(s, 'DESC NULLS FIRST')
@@ -181,3 +171,156 @@ NULL
 {'i': 42, 'v': NULL}
 {'i': 42, 'v': hello\0}
 {'i': 42, 'v': hello}
+
+query II
+SELECT s.i, s.v FROM structs ORDER BY create_sort_key(s.i, 'DESC NULLS FIRST', s.v, 'DESC NULLS FIRST')
+----
+NULL	NULL
+NULL	(empty)
+43	(empty)
+42	NULL
+42	hello\0
+42	hello
+
+# test struct types
+statement ok
+CREATE TABLE list_of_structs(s ROW(i INT, v VARCHAR)[]);
+
+statement ok
+INSERT INTO list_of_structs VALUES
+([{'i': 42, v: 'hello'}]),
+([]),
+([{'i': 42, v: 'hello'}, {'i': 84, v: ''}]),
+([{'i': 43, v: ''}]),
+(NULL),
+([NULL]),
+([{'i': 42, v: NULL}]),
+([{'i': NULL, v: ''}]),
+([{'i': 42, v: 'hello'}, {'i': 84, v: chr(0)}]),
+([{'i': 42, v: 'hello'}, NULL, {'i': 84, v: ''}])
+
+query I
+SELECT * FROM list_of_structs ORDER BY create_sort_key(s, 'ASC NULLS LAST')
+----
+[]
+[{'i': 42, 'v': hello}]
+[{'i': 42, 'v': hello}, {'i': 84, 'v': }]
+[{'i': 42, 'v': hello}, {'i': 84, 'v': \0}]
+[{'i': 42, 'v': hello}, NULL, {'i': 84, 'v': }]
+[{'i': 42, 'v': NULL}]
+[{'i': 43, 'v': }]
+[{'i': NULL, 'v': }]
+[NULL]
+NULL
+
+query I
+SELECT * FROM list_of_structs ORDER BY create_sort_key(s, 'DESC NULLS FIRST')
+----
+NULL
+[NULL]
+[{'i': NULL, 'v': }]
+[{'i': 43, 'v': }]
+[{'i': 42, 'v': NULL}]
+[{'i': 42, 'v': hello}, NULL, {'i': 84, 'v': }]
+[{'i': 42, 'v': hello}, {'i': 84, 'v': \0}]
+[{'i': 42, 'v': hello}, {'i': 84, 'v': }]
+[{'i': 42, 'v': hello}]
+[]
+
+
+# test nested lists
+statement ok
+CREATE TABLE nested_lists(s INT[][]);
+
+statement ok
+INSERT INTO nested_lists VALUES
+([]),
+([[], []]),
+(NULL),
+([NULL]),
+([[NULL]]),
+([[42, 84]]),
+([[42], [84]]),
+([[42], NULL, [84]]),
+([[42], [NULL], [84]]),
+([[1, 2, 3, 4, 5, 6, 7, 8, 9]])
+
+query I
+SELECT * FROM nested_lists ORDER BY create_sort_key(s, 'ASC NULLS LAST')
+----
+[]
+[[], []]
+[[1, 2, 3, 4, 5, 6, 7, 8, 9]]
+[[42], [84]]
+[[42], [NULL], [84]]
+[[42], NULL, [84]]
+[[42, 84]]
+[[NULL]]
+[NULL]
+NULL
+
+query I
+SELECT * FROM nested_lists ORDER BY create_sort_key(s, 'DESC NULLS FIRST')
+----
+NULL
+[NULL]
+[[NULL]]
+[[42, 84]]
+[[42], NULL, [84]]
+[[42], [NULL], [84]]
+[[42], [84]]
+[[1, 2, 3, 4, 5, 6, 7, 8, 9]]
+[[], []]
+[]
+
+
+# test blobs
+statement ok
+CREATE TABLE blobs(b BLOB, c BLOB);
+
+statement ok
+INSERT INTO blobs VALUES (NULL, NULL), ('hello\x00\x00\x00\x00\x00', NULL), ('hello', 'world'), ('hello\x01\x01\x01', 'world'), ('', ''), ('hello\x00\x00\x00\x00\x00', 'world'), ('hello\x00', NULL)
+
+query I
+SELECT b FROM blobs ORDER BY create_sort_key(b, 'ASC NULLS LAST')
+----
+(empty)
+hello
+hello\x00
+hello\x00\x00\x00\x00\x00
+hello\x00\x00\x00\x00\x00
+hello\x01\x01\x01
+NULL
+
+query I
+SELECT b FROM blobs ORDER BY create_sort_key(b, 'DESC NULLS FIRST')
+----
+NULL
+hello\x01\x01\x01
+hello\x00\x00\x00\x00\x00
+hello\x00\x00\x00\x00\x00
+hello\x00
+hello
+(empty)
+
+query II
+SELECT * FROM blobs ORDER BY create_sort_key(b, 'ASC NULLS LAST', c, 'ASC NULLS LAST')
+----
+(empty)	(empty)
+hello	world
+hello\x00	NULL
+hello\x00\x00\x00\x00\x00	world
+hello\x00\x00\x00\x00\x00	NULL
+hello\x01\x01\x01	world
+NULL	NULL
+
+query II
+SELECT * FROM blobs ORDER BY create_sort_key(b, 'DESC NULLS FIRST', c, 'DESC NULLS FIRST')
+----
+NULL	NULL
+hello\x01\x01\x01	world
+hello\x00\x00\x00\x00\x00	NULL
+hello\x00\x00\x00\x00\x00	world
+hello\x00	NULL
+hello	world
+(empty)	(empty)


### PR DESCRIPTION
This PR adds a `create_sort_key` function. This function takes any number of inputs and sort conditions, and constructs a `BLOB` field. When sorted, the blob will produce the order as specified by the `create_sort_key` function. For example:

```sql
D select s, create_sort_key(s, 'asc nulls last'), create_sort_key(s, 'asc nulls first') from (values ('hello'), ('world'), (NULL)) t(s);
┌─────────┬──────────────────────────────────────┬───────────────────────────────────────┐
│    s    │ create_sort_key(s, 'asc nulls last') │ create_sort_key(s, 'asc nulls first') │
│ varchar │                 blob                 │                 blob                  │
├─────────┼──────────────────────────────────────┼───────────────────────────────────────┤
│ hello   │ \x01ifmmp\x00                        │ \x02ifmmp\x00                         │
│ world   │ \x01xpsme\x00                        │ \x02xpsme\x00                         │
│ NULL    │ \x02                                 │ \x01                                  │
└─────────┴──────────────────────────────────────┴───────────────────────────────────────┘
```

Because of the binary-comparable nature of the constructed `BLOB`, the following queries are identical:

```sql
SELECT * FROM tbl ORDER BY x DESC NULLS LAST, y ASC NULLS FIRST
SELECT * FROM tbl ORDER BY create_sort_key(x, 'DESC NULLS LAST', y, 'ASC NULLS FIRST');
```

The `create_sort_key` function supports all types supported by DuckDB, including nested types.

The function itself is not particularly useful from a user-perspective - but the idea behind this function is that it can be used to facilitate query rewrites and optimizations around orders. Since all sorting conditions can now be converted into blobs - you would only need to solve the sorting problem for blobs in order to implement e.g. an `ORDER BY` operator, a `Top-N` operator, ordered aggregates, min/max, ...