### PR TITLE
Allow NULL bytes in ART indexes

### DIFF
--- a/test/fuzzer/pedro/art_prefix_error.test
+++ b/test/fuzzer/pedro/art_prefix_error.test
@@ -5,7 +5,6 @@
 statement ok
 CREATE TABLE t0 (c0 BLOB PRIMARY KEY);
 
-statement error
+statement ok
 INSERT INTO t0(c0) VALUES (BLOB '\x00a'), (BLOB '');
-----
-ART indexes cannot contain BLOBs with zero bytes.
+

--- a/test/sql/index/art/issues/test_art_fuzzer.test
+++ b/test/sql/index/art/issues/test_art_fuzzer.test
@@ -19,18 +19,14 @@ statement ok
 INSERT INTO t1(c1) VALUES (2),(3);
 
 # issue 5984, number 22
-# FIXME: eventually, we might want to rethink the way that we null-terminate keys, see #5865
-
 statement ok
 CREATE TABLE t2 (c1 VARCHAR);
 
 statement ok
 CREATE INDEX i2 ON t2 (c1);
 
-statement error
+statement ok
 INSERT INTO t2 VALUES (decode('g\x00'::BLOB)::VARCHAR),('g');
-----
-ART indexes cannot contain BLOBs with zero bytes.
 
 statement ok
 INSERT INTO t2 VALUES ('\0');
@@ -64,7 +60,6 @@ statement ok
 UPDATE t4 SET c1 = NULL;
 
 # issue 5984, number 19
-
 statement ok
 CREATE TABLE t_leak (c1 INT);
 
@@ -77,23 +72,11 @@ CREATE UNIQUE INDEX i_leak ON t_leak (c1);
 Constraint Error: Data contains duplicates on indexed column(s)
 
 # issue 5984, number 22
-# FIXME: eventually, we might want to rethink the way that we null-terminate keys, see #5865
-# FIXME: this fails only with verification enabled and force reload, we should fix this when we
-# FIXME: address the null-terminated keys
-
-require skip_reload
-
 statement ok
 CREATE TABLE t21 (c1 INT);
 
 statement ok
 CREATE INDEX i21 ON t21 (c1, "decode"('\x00'::BLOB));
 
-statement error
+statement ok
 INSERT INTO t21 VALUES (1);
-----
-ART indexes cannot contain BLOBs with zero bytes.
-
-statement error
-CREATE INDEX i21 ON t21 (c1);
-----

--- a/test/sql/index/art/scan/art_null_bytes.test
+++ b/test/sql/index/art/scan/art_null_bytes.test
@@ -61,3 +61,26 @@ query I
 SELECT * FROM blobs WHERE b = '\x00\x01'
 ----
 \x00\x01
+
+query I
+SELECT * FROM blobs WHERE b >= '\x00' ORDER BY b::VARCHAR
+----
+\x00
+\x00\x00
+\x00\x01
+\x01
+\x01\x00
+\x01\x01
+
+query I
+SELECT * FROM blobs WHERE b >= '\x01' ORDER BY b::VARCHAR
+----
+\x01
+\x01\x00
+\x01\x01
+
+query I
+SELECT * FROM blobs WHERE b >= '\x01\x00' ORDER BY b::VARCHAR
+----
+\x01\x00
+\x01\x01

--- a/test/sql/index/art/scan/art_null_bytes.test
+++ b/test/sql/index/art/scan/art_null_bytes.test
@@ -1,0 +1,63 @@
+# name: test/sql/index/art/scan/art_null_bytes.test
+# description: Test ART with null bytes
+# group: [scan]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE varchars(v VARCHAR PRIMARY KEY);
+
+statement ok
+INSERT INTO varchars VALUES ('hello'), ('hello' || chr(0)), ('hello' || chr(0) || chr(0)), ('hello' || chr(0) || chr(0) || chr(0));
+
+statement error
+INSERT INTO varchars VALUES ('hello' || chr(0) || chr(0) || chr(0));
+----
+Duplicate key
+
+query I
+SELECT * FROM varchars WHERE v = 'hello'
+----
+hello
+
+query I
+SELECT * FROM varchars WHERE v = 'hello' || chr(0)
+----
+hello\0
+
+query I
+SELECT * FROM varchars WHERE v = 'hello' || chr(0) || chr(0)
+----
+hello\0\0
+
+query I
+SELECT * FROM varchars WHERE v = 'hello' || chr(0) || chr(0) || chr(0)
+----
+hello\0\0\0
+
+statement ok
+CREATE TABLE blobs(b BLOB PRIMARY KEY);
+
+statement ok
+INSERT INTO blobs VALUES (''), ('\x00'), ('\x01'), ('\x00\x01'), ('\x01\x00'), ('\x01\x01'), ('\x00\x00');
+
+statement error
+INSERT INTO blobs VALUES ('\x00\x01');
+----
+Duplicate key
+
+query I
+SELECT * FROM blobs WHERE b = ''
+----
+(empty)
+
+query I
+SELECT * FROM blobs WHERE b = '\x00'
+----
+\x00
+
+query I
+SELECT * FROM blobs WHERE b = '\x00\x01'
+----
+\x00\x01

--- a/test/sql/storage/null_byte_storage.test
+++ b/test/sql/storage/null_byte_storage.test
@@ -27,10 +27,8 @@ SELECT * FROM null_byte WHERE v=concat('goo', chr(0), 42)
 goo\042
 
 # null byte in index
-statement error
+statement ok
 CREATE INDEX i_index ON null_byte(v)
-----
-ART indexes cannot contain BLOBs with zero bytes.
 
 query I
 SELECT * FROM null_byte WHERE v=concat('goo', chr(0), 42)


### PR DESCRIPTION
Fix #9369

This PR adds support for storing null bytes in ART indexes. The issue we ran into was that we use the null byte (`\0`) as a string delimiter in the byte-comparable key that is generated for the ART. This is required in the ART because we cannot have a node that is both a leaf and a node (i.e. we cannot store rows in the nodes of the ART).

When we would have strings or blobs with null bytes in them that would cause issues. For example, if we had both the string `hello` and `hello\0`, we would normalize this to `hello\0` and `hello\0\0`. At the ART position `hello\0` we would need to have both a leaf (pointing to `hello`) and a node (pointing to `hello\0`).

This PR resolves the issue by escaping null bytes that occur within strings with `\1`. This way, an unescaped `\0` cannot occur naturally in a string. The above strings would be converted into `hello\0` and `hello\1\0\0` instead. 