### PR TITLE
Escape all ASCII control characters in duckbox rendering

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -257,7 +257,55 @@ list<ColumnDataCollection> BoxRenderer::PivotCollections(ClientContext &context,
 }
 
 string ConvertRenderValue(const string &input) {
-	return StringUtil::Replace(StringUtil::Replace(input, "\n", "\\n"), string("\0", 1), "\\0");
+	string result;
+	result.reserve(input.size());
+	for (idx_t c = 0; c < input.size(); c++) {
+		data_t byte_value = const_data_ptr_cast(input.c_str())[c];
+		if (byte_value < 32) {
+			// ASCII control character
+			result += "\\";
+			switch (input[c]) {
+			case 7:
+				// bell
+				result += 'a';
+				break;
+			case 8:
+				// backspace
+				result += 'b';
+				break;
+			case 9:
+				// tab
+				result += 't';
+				break;
+			case 10:
+				// newline
+				result += 'n';
+				break;
+			case 11:
+				// vertical tab
+				result += 'v';
+				break;
+			case 12:
+				// form feed
+				result += 'f';
+				break;
+			case 13:
+				// cariage return
+				result += 'r';
+				break;
+			case 27:
+				// escape
+				result += 'e';
+				break;
+			default:
+				result += to_string(byte_value);
+				break;
+			}
+		} else {
+			result += input[c];
+		}
+	}
+	return result;
 }
 
 string BoxRenderer::GetRenderValue(ColumnDataRowCollection &rows, idx_t c, idx_t r) {


### PR DESCRIPTION
Previously we only escaped common characters (`\n` and `\0`). However, all of these characters can mess up the rendering - as such we escape all of them now.

New behavior:

```sql
D select i,chr(i::int) as control_character from range(33) t(i);
┌───────┬───────────────────┐
│   i   │ control_character │
│ int64 │      varchar      │
├───────┼───────────────────┤
│     0 │ \0                │
│     1 │ \1                │
│     2 │ \2                │
│     3 │ \3                │
│     4 │ \4                │
│     5 │ \5                │
│     6 │ \6                │
│     7 │ \a                │
│     8 │ \b                │
│     9 │ \t                │
│    10 │ \n                │
│    11 │ \v                │
│    12 │ \f                │
│    13 │ \r                │
│    14 │ \14               │
│    15 │ \15               │
│    16 │ \16               │
│    17 │ \17               │
│    18 │ \18               │
│    19 │ \19               │
│    20 │ \20               │
│    21 │ \21               │
│    22 │ \22               │
│    23 │ \23               │
│    24 │ \24               │
│    25 │ \25               │
│    26 │ \26               │
│    27 │ \e                │
│    28 │ \28               │
│    29 │ \29               │
│    30 │ \30               │
│    31 │ \31               │
│    32 │                   │
├───────┴───────────────────┤
│ 33 rows         2 columns │
└───────────────────────────┘
```

Old behavior:

```sql
D select i,chr(i::int) as control_character from range(33) t(i);
┌───────┬───────────────────┐
│   i   │ control_character │
│ int64 │      varchar      │
├───────┼───────────────────┤
│     0 │ \0                │
│     1 │                   │
│     2 │                   │
│     3 │                   │
│     4 │                   │
│     5 │                   │
│     6 │                   │
│     7 │                   │
│     8 │                  │
│     9 │ 	                  │
│    10 │ \n                │
│    11 │ 
                            │
│    12 │ 
                            │
                  │
│    14 │                   │
│    15 │                   │
│    16 │                   │
│    17 │                   │
│    18 │                   │
│    19 │                   │
│    20 │                   │
│    21 │                   │
│    22 │                   │
│    23 │                   │
│    24 │                   │
│    25 │                   │
│    26 │                   │
│    27 │                  │
│    28 │                   │
│    29 │                   │
│    30 │                   │
│    31 │                   │
│    32 │                   │
├───────┴───────────────────┤
│ 33 rows         2 columns │
└───────────────────────────┘

```