### PR TITLE
SQLLogicTestRunner - Make mode command work in loops, and add mode no_output

### DIFF
--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -123,6 +123,10 @@ LoopCommand::LoopCommand(SQLLogicTestRunner &runner, LoopDefinition definition_p
     : Command(runner), definition(std::move(definition_p)) {
 }
 
+ModeCommand::ModeCommand(SQLLogicTestRunner &runner, string parameter_p)
+    : Command(runner), parameter(std::move(parameter_p)) {
+}
+
 struct ParallelExecuteContext {
 	ParallelExecuteContext(SQLLogicTestRunner &runner, const vector<duckdb::unique_ptr<Command>> &loop_commands,
 	                       LoopDefinition definition)
@@ -282,6 +286,21 @@ void ReconnectCommand::ExecuteInternal(ExecuteContext &context) const {
 		throw std::runtime_error("Cannot reconnect in parallel");
 	}
 	runner.Reconnect();
+}
+
+void ModeCommand::ExecuteInternal(ExecuteContext &context) const {
+	if (parameter == "output_hash") {
+		runner.output_hash_mode = true;
+	} else if (parameter == "output_result") {
+		runner.output_result_mode = true;
+	} else if (parameter == "no_output") {
+		runner.output_hash_mode = false;
+		runner.output_result_mode = false;
+	} else if (parameter == "debug") {
+		runner.debug_mode = true;
+	} else {
+		throw std::runtime_error("unrecognized mode: " + parameter);
+	}
 }
 
 void Statement::ExecuteInternal(ExecuteContext &context) const {

--- a/test/sqlite/sqllogic_command.hpp
+++ b/test/sqlite/sqllogic_command.hpp
@@ -116,4 +116,14 @@ public:
 	void ExecuteInternal(ExecuteContext &context) const override;
 };
 
+class ModeCommand : public Command {
+public:
+	ModeCommand(SQLLogicTestRunner &runner, string parameter);
+
+public:
+	string parameter;
+
+	void ExecuteInternal(ExecuteContext &context) const override;
+};
+
 } // namespace duckdb

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -388,18 +388,14 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			if (token.parameters.size() != 1) {
 				parser.Fail("mode requires one parameter");
 			}
-			if (token.parameters[0] == "output_hash") {
-				output_hash_mode = true;
-			} else if (token.parameters[0] == "output_result") {
-				output_result_mode = true;
-			} else if (token.parameters[0] == "debug") {
-				debug_mode = true;
-			} else if (token.parameters[0] == "skip") {
+			string parameter = token.parameters[0];
+			if (parameter == "skip") {
 				skip_level++;
-			} else if (token.parameters[0] == "unskip") {
+			} else if (parameter == "unskip") {
 				skip_level--;
 			} else {
-				parser.Fail("unrecognized mode: %s", token.parameters[0]);
+				auto command = make_uniq<ModeCommand>(*this, std::move(parameter));
+				ExecuteCommand(std::move(command));
 			}
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_SET) {
 			if (token.parameters.size() < 1) {


### PR DESCRIPTION
`mode no_output` allows you to turn off `mode output_result` again, which is useful if you only want to print the result of certain queries.

In addition, we now allow `mode` commands to be used in a loop, which can be useful if you want to print only part of the queries in a loop. For example, here we only print the results from `SELECT random()` and not the large result from `SELECT * FROM range`:

```sql
loop i 0 100

mode output_result

statement ok
SELECT random()

mode no_output

statement ok
SELECT * FROM range(10000)

endloop
```