### PR TITLE
[Compression] Fix Handling of -0.0 in ALP

### DIFF
--- a/test/sql/storage/compression/alp/alp_negative_numbers.test
+++ b/test/sql/storage/compression/alp/alp_negative_numbers.test
@@ -11,7 +11,8 @@ PRAGMA force_compression='uncompressed'
 # Create a table with random doubles of limited precision compressed as Uncompressed
 # This data should achieve x6 compression ratio
 statement ok
-create table random_double as select round(cos(1 / (random() + 0.001)), 5)::DOUBLE * -1 as data from range(1024) tbl(i);
+create table random_double as select round(cos(1 / (random() + 0.001)), 5)::DOUBLE * -1 as data from range(1023) tbl(i);
+insert into random_double values (-0.0::DOUBLE);
 
 statement ok
 checkpoint


### PR DESCRIPTION
This PR solves an issue in which the special float/double value `-0.0` was incorrectly encoded as `0.0` (note that `-0.0 == 0.0` is `true`). For ALP this special value is an exception since it is not possible to encode it as an integer without losing the sign.

This also adds this value explicitly into a unit test