### PR TITLE
Set interrupted flag after pushing an error to prevent race condition where the InterruptException could end up being the top-level error

### DIFF
--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -554,10 +554,10 @@ vector<LogicalType> Executor::GetTypes() {
 }
 
 void Executor::PushError(PreservedError exception) {
-	// interrupt execution of any other pipelines that belong to this executor
-	context.interrupted = true;
 	// push the exception onto the stack
 	error_manager.PushError(std::move(exception));
+	// interrupt execution of any other pipelines that belong to this executor
+	context.interrupted = true;
 }
 
 bool Executor::HasError() {

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -177,8 +177,10 @@ void LoopCommand::ExecuteInternal(ExecuteContext &context) const {
 	LoopDefinition loop_def = definition;
 	loop_def.loop_idx = definition.loop_start;
 	if (loop_def.is_parallel) {
-		if (context.is_parallel || !context.running_loops.empty()) {
-			throw std::runtime_error("Nested parallel loop commands not allowed");
+		for (auto &running_loop : context.running_loops) {
+			if (running_loop.is_parallel) {
+				throw std::runtime_error("Nested parallel loop commands not allowed");
+			}
 		}
 		// parallel loop: launch threads
 		std::list<ParallelExecuteContext> contexts;

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -53,10 +53,6 @@ void SQLLogicTestRunner::StartLoop(LoopDefinition definition) {
 	auto loop = make_uniq<LoopCommand>(*this, std::move(definition));
 	auto loop_ptr = loop.get();
 	if (InLoop()) {
-		// already in a loop: add it to the currently active loop
-		if (definition.is_parallel) {
-			throw std::runtime_error("concurrent loop must be the outer-most loop!");
-		}
 		active_loops.back()->loop_commands.push_back(std::move(loop));
 	} else {
 		// not in a loop yet: new top-level loop


### PR DESCRIPTION
This prevents an issue where occasionally the actual exception would be overridden by "Interrupted". 

Also, for the SQLLogicTestRunner - allow concurrent loops inside loops