### PR TITLE
Split jdbc tests

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -71,9 +71,8 @@ jobs:
       - name: Java Tests
         shell: bash
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        run: >
-          java -cp build/release/tools/jdbc/duckdb_jdbc.jar
-          org.duckdb.test.TestDuckDBJDBC
+        working-directory: tools/jdbc
+        run: make test_release
 
       - name: Deploy
         shell: bash
@@ -158,8 +157,8 @@ jobs:
       - name: Java Tests
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
-        run: |
-          java -cp tools/jdbc/duckdb_jdbc.jar org.duckdb.test.TestDuckDBJDBC
+        working-directory: tools/jdbc
+        run: make test_release
       - name: Deploy
         shell: bash
         run: >
@@ -200,9 +199,8 @@ jobs:
       - name: Java Tests
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
-        run: >
-          java -cp build/release/tools/jdbc/duckdb_jdbc.jar
-          org.duckdb.test.TestDuckDBJDBC
+        working-directory: tools/jdbc
+        run: make test_release
       - name: Java Example
         shell: bash
         run: |

--- a/tools/jdbc/CMakeLists.txt
+++ b/tools/jdbc/CMakeLists.txt
@@ -10,13 +10,14 @@ endif()
 include(UseJava)
 project(DuckDBJDummy NONE)
 
-file(GLOB JAVA_SRC_FILES src/main/java/org/duckdb/*.java)
-file(GLOB JAVA_TEST_FILES src/test/java/org/duckdb/test/*.java)
+file(GLOB_RECURSE JAVA_SRC_FILES src/main/java/org/duckdb/*.java)
+file(GLOB_RECURSE JAVA_TEST_FILES src/test/java/org/duckdb/*.java)
 
 set(CMAKE_JAVA_COMPILE_FLAGS -source 1.8 -target 1.8 -encoding utf-8)
 
-add_jar(duckdb_jdbc ${JAVA_SRC_FILES} ${JAVA_TEST_FILES}
-        META-INF/services/java.sql.Driver GENERATE_NATIVE_HEADERS duckdb-native)
+add_jar(duckdb_jdbc ${JAVA_SRC_FILES} META-INF/services/java.sql.Driver
+        GENERATE_NATIVE_HEADERS duckdb-native)
+add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc)
 
 include_directories(../../extension/parquet/include)
 
@@ -36,7 +37,7 @@ set_target_properties(duckdb_java PROPERTIES PREFIX "lib")
 
 add_custom_command(
   OUTPUT dummy_jdbc_target
-  DEPENDS duckdb_java duckdb_jdbc
+  DEPENDS duckdb_java duckdb_jdbc duckdb_jdbc_tests
   COMMAND ${Java_JAR_EXECUTABLE} uf duckdb_jdbc.jar -C
           $<TARGET_FILE_DIR:duckdb_java> $<TARGET_FILE_NAME:duckdb_java>)
 

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -1,8 +1,10 @@
-JARS=build/debug/tools/jdbc
 ifeq ($(OS),Windows_NT)
+	# windows is weird
 	SEP=";"
+	JARS=tools/jdbc
 else
 	SEP=":"
+	JARS=build/debug/tools/jdbc
 endif
 
 JAR=$(JARS)/duckdb_jdbc.jar

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -9,6 +9,8 @@ JAR=$(JARS)/duckdb_jdbc.jar
 TEST_JAR=$(JARS)/duckdb_jdbc_tests.jar
 CP="$(JAR)$(SEP)$(TEST_JAR)"
 
+.ONESHELL:
+
 test_debug: $(JAR) $(TEST_JAR)
 	cd ../..
 	java -cp $(CP) org.duckdb.test.TestDuckDBJDBC

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -1,0 +1,17 @@
+JARS=../../build/debug/tools/jdbc
+ifeq ($(OS),Windows_NT)
+	SEP=";"
+else
+	SEP=":"
+endif
+
+JAR=$(JARS)/duckdb_jdbc.jar
+TEST_JAR=$(JARS)/duckdb_jdbc_tests.jar
+CP="$(JAR)$(SEP)$(TEST_JAR)"
+
+test_debug: $(JAR) $(TEST_JAR)
+	java -cp $(CP) org.duckdb.test.TestDuckDBJDBC
+
+test_release: $(JAR) $(TEST_JAR)
+	java -cp $(subst debug,release,$(CP)) org.duckdb.test.TestDuckDBJDBC
+

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -10,7 +10,7 @@ TEST_JAR=$(JARS)/duckdb_jdbc_tests.jar
 CP="$(JAR)$(SEP)$(TEST_JAR)"
 
 test_debug: ../../$(JAR) ../../$(TEST_JAR)
-	cd ../.. && java -verbose:class -cp $(CP) org.duckdb.test.TestDuckDBJDBC
+	cd ../.. && java -cp $(CP) org.duckdb.test.TestDuckDBJDBC
 
 test_release: ../../$(subst debug,release,$(JAR)) ../../$(subst debug,release,$(TEST_JAR))
 	cd ../.. && java -cp $(subst debug,release,$(CP)) org.duckdb.test.TestDuckDBJDBC

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -1,4 +1,4 @@
-JARS=build/debug/tools/jdbc
+JARS=../../build/debug/tools/jdbc
 ifeq ($(OS),Windows_NT)
 	SEP=";"
 else

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -9,7 +9,7 @@ endif
 
 JAR=$(JARS)/duckdb_jdbc.jar
 TEST_JAR=$(JARS)/duckdb_jdbc_tests.jar
-CP="$(JAR)$(SEP)$(TEST_JAR)"
+CP=$(JAR)$(SEP)$(TEST_JAR)
 
 test_debug: ../../$(JAR) ../../$(TEST_JAR)
 	cd ../.. && java -cp $(CP) org.duckdb.test.TestDuckDBJDBC

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -12,6 +12,6 @@ CP="$(JAR)$(SEP)$(TEST_JAR)"
 test_debug: $(JAR) $(TEST_JAR)
 	java -cp $(CP) org.duckdb.test.TestDuckDBJDBC
 
-test_release: $(JAR) $(TEST_JAR)
+test_release: $(subst debug,release,$(JAR)) $(subst debug,release,$(TEST_JAR))
 	java -cp $(subst debug,release,$(CP)) org.duckdb.test.TestDuckDBJDBC
 

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -1,4 +1,4 @@
-JARS=../../build/debug/tools/jdbc
+JARS=build/debug/tools/jdbc
 ifeq ($(OS),Windows_NT)
 	SEP=";"
 else
@@ -9,8 +9,8 @@ JAR=$(JARS)/duckdb_jdbc.jar
 TEST_JAR=$(JARS)/duckdb_jdbc_tests.jar
 CP="$(JAR)$(SEP)$(TEST_JAR)"
 
-test_debug: $(JAR) $(TEST_JAR)
-	cd ../.. && java -cp $(CP) org.duckdb.test.TestDuckDBJDBC
+test_debug: ../../$(JAR) ../../$(TEST_JAR)
+	cd ../.. && java -verbose:class -cp $(CP) org.duckdb.test.TestDuckDBJDBC
 
-test_release: $(subst debug,release,$(JAR)) $(subst debug,release,$(TEST_JAR))
+test_release: ../../$(subst debug,release,$(JAR)) ../../$(subst debug,release,$(TEST_JAR))
 	cd ../.. && java -cp $(subst debug,release,$(CP)) org.duckdb.test.TestDuckDBJDBC

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -9,13 +9,8 @@ JAR=$(JARS)/duckdb_jdbc.jar
 TEST_JAR=$(JARS)/duckdb_jdbc_tests.jar
 CP="$(JAR)$(SEP)$(TEST_JAR)"
 
-.ONESHELL:
-
 test_debug: $(JAR) $(TEST_JAR)
-	cd ../..
-	java -cp $(CP) org.duckdb.test.TestDuckDBJDBC
+	cd ../.. && java -cp $(CP) org.duckdb.test.TestDuckDBJDBC
 
 test_release: $(subst debug,release,$(JAR)) $(subst debug,release,$(TEST_JAR))
-	cd ../..
-	java -cp $(subst debug,release,$(CP)) org.duckdb.test.TestDuckDBJDBC
-
+	cd ../.. && java -cp $(subst debug,release,$(CP)) org.duckdb.test.TestDuckDBJDBC

--- a/tools/jdbc/Makefile
+++ b/tools/jdbc/Makefile
@@ -1,4 +1,4 @@
-JARS=../../build/debug/tools/jdbc
+JARS=build/debug/tools/jdbc
 ifeq ($(OS),Windows_NT)
 	SEP=";"
 else
@@ -10,8 +10,10 @@ TEST_JAR=$(JARS)/duckdb_jdbc_tests.jar
 CP="$(JAR)$(SEP)$(TEST_JAR)"
 
 test_debug: $(JAR) $(TEST_JAR)
+	cd ../..
 	java -cp $(CP) org.duckdb.test.TestDuckDBJDBC
 
 test_release: $(subst debug,release,$(JAR)) $(subst debug,release,$(TEST_JAR))
+	cd ../..
 	java -cp $(subst debug,release,$(CP)) org.duckdb.test.TestDuckDBJDBC
 

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBNative.java
@@ -13,7 +13,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 import java.math.BigDecimal;
 
-public class DuckDBNative {
+class DuckDBNative {
     static {
         try {
             String os_name = "";

--- a/tools/jdbc/src/test/java/org/duckdb/TestExtensionTypes.java
+++ b/tools/jdbc/src/test/java/org/duckdb/TestExtensionTypes.java
@@ -1,0 +1,53 @@
+package org.duckdb;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.sql.Types;
+
+import static org.duckdb.test.Assertions.assertEquals;
+import static org.duckdb.test.TestDuckDBJDBC.JDBC_URL;
+
+public class TestExtensionTypes {
+
+    public static void test_extension_type() throws Exception {
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
+             Statement stmt = connection.createStatement()) {
+
+            DuckDBNative.duckdb_jdbc_create_extension_type((DuckDBConnection) connection);
+
+            try (ResultSet rs = stmt.executeQuery(
+                     "SELECT {\"hello\": 'foo', \"world\": 'bar'}::test_type, '\\xAA'::byte_test_type")) {
+                rs.next();
+                assertEquals(rs.getObject(1), "{'hello': foo, 'world': bar}");
+                assertEquals(rs.getObject(2), "\\xAA");
+            }
+        }
+    }
+
+    public static void test_extension_type_metadata() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();) {
+            DuckDBNative.duckdb_jdbc_create_extension_type((DuckDBConnection) conn);
+
+            stmt.execute("CREATE TABLE test (foo test_type, bar byte_test_type);");
+            stmt.execute("INSERT INTO test VALUES ({\"hello\": 'foo', \"world\": 'bar'}, '\\xAA');");
+
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM test")) {
+                ResultSetMetaData meta = rs.getMetaData();
+                assertEquals(meta.getColumnCount(), 2);
+
+                assertEquals(meta.getColumnName(1), "foo");
+                assertEquals(meta.getColumnTypeName(1), "test_type");
+                assertEquals(meta.getColumnType(1), Types.JAVA_OBJECT);
+                assertEquals(meta.getColumnClassName(1), "java.lang.String");
+
+                assertEquals(meta.getColumnName(2), "bar");
+                assertEquals(meta.getColumnTypeName(2), "byte_test_type");
+                assertEquals(meta.getColumnType(2), Types.JAVA_OBJECT);
+                assertEquals(meta.getColumnClassName(2), "java.lang.String");
+            }
+        }
+    }
+}

--- a/tools/jdbc/src/test/java/org/duckdb/test/Assertions.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/Assertions.java
@@ -1,0 +1,79 @@
+package org.duckdb.test;
+
+import org.duckdb.test.Thrower;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public class Assertions {
+    public static void assertTrue(boolean val) throws Exception {
+        assertTrue(val, null);
+    }
+
+    public static void assertTrue(boolean val, String message) throws Exception {
+        if (!val) {
+            throw new Exception(message);
+        }
+    }
+
+    public static void assertFalse(boolean val) throws Exception {
+        assertTrue(!val);
+    }
+
+    public static void assertEquals(Object actual, Object expected) throws Exception {
+        Function<Object, String> getClass = (Object a) -> a == null ? "null" : a.getClass().toString();
+
+        String message = String.format("\"%s\" (of %s) should equal \"%s\" (of %s)", actual, getClass.apply(actual),
+                                       expected, getClass.apply(expected));
+        assertTrue(Objects.equals(actual, expected), message);
+    }
+
+    public static void assertNotNull(Object a) throws Exception {
+        assertFalse(a == null);
+    }
+
+    public static void assertNull(Object a) throws Exception {
+        assertEquals(a, null);
+    }
+
+    public static void assertEquals(double a, double b, double epsilon) throws Exception {
+        assertTrue(Math.abs(a - b) < epsilon);
+    }
+
+    public static void fail() throws Exception {
+        fail(null);
+    }
+
+    public static void fail(String s) throws Exception {
+        throw new Exception(s);
+    }
+
+    public static <T extends Throwable> String assertThrows(Thrower thrower, Class<T> exception) throws Exception {
+        return assertThrows(exception, thrower).getMessage();
+    }
+
+    private static <T extends Throwable> Throwable assertThrows(Class<T> exception, Thrower thrower) throws Exception {
+        try {
+            thrower.run();
+        } catch (Throwable e) {
+            assertEquals(e.getClass(), exception);
+            return e;
+        }
+        throw new Exception("Expected to throw " + exception.getName());
+    }
+
+    // Asserts we are either throwing the correct exception, or not throwing at all
+    public static <T extends Throwable> boolean assertThrowsMaybe(Thrower thrower, Class<T> exception)
+        throws Exception {
+        try {
+            thrower.run();
+            return true;
+        } catch (Throwable e) {
+            if (e.getClass().equals(exception)) {
+                return true;
+            } else {
+                throw new Exception("Unexpected exception: " + e.getClass().getName());
+            }
+        }
+    }
+}

--- a/tools/jdbc/src/test/java/org/duckdb/test/Runner.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/Runner.java
@@ -1,0 +1,64 @@
+package org.duckdb.test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Comparator;
+
+public class Runner {
+    static {
+        try {
+            Class.forName("org.duckdb.DuckDBDriver");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public static int runTests(String[] args, Class<TestDuckDBJDBC> testDuckDBJDBCClass) throws Exception {
+        // Woo I can do reflection too, take this, JUnit!
+        Method[] methods = testDuckDBJDBCClass.getMethods();
+
+        Arrays.sort(methods, Comparator.comparing(Method::getName));
+
+        String specific_test = null;
+        if (args.length >= 1) {
+            specific_test = args[0];
+        }
+
+        boolean anySucceeded = false;
+        boolean anyFailed = false;
+        for (Method m : methods) {
+            if (m.getName().startsWith("test_")) {
+                if (specific_test != null && !m.getName().contains(specific_test)) {
+                    continue;
+                }
+                System.out.print(m.getName() + " ");
+
+                LocalDateTime start = LocalDateTime.now();
+                try {
+                    m.invoke(null);
+                    System.out.println("success in " + Duration.between(start, LocalDateTime.now()).getSeconds() +
+                                       " seconds");
+                } catch (Throwable t) {
+                    if (t instanceof InvocationTargetException) {
+                        t = t.getCause();
+                    }
+                    System.out.println("failed with " + t);
+                    t.printStackTrace(System.out);
+                    anyFailed = true;
+                }
+                anySucceeded = true;
+            }
+        }
+        if (!anySucceeded) {
+            System.out.println("No tests found that match " + specific_test);
+            return 1;
+        }
+        System.out.println(anyFailed ? "FAILED" : "OK");
+
+        return anyFailed ? 1 : 0;
+    }
+}

--- a/tools/jdbc/src/test/java/org/duckdb/test/Runner.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/Runner.java
@@ -16,10 +16,9 @@ public class Runner {
         }
     }
 
-
-    public static int runTests(String[] args, Class<TestDuckDBJDBC> testDuckDBJDBCClass) throws Exception {
+    public static int runTests(String[] args, Class<?> testClass) {
         // Woo I can do reflection too, take this, JUnit!
-        Method[] methods = testDuckDBJDBCClass.getMethods();
+        Method[] methods = testClass.getMethods();
 
         Arrays.sort(methods, Comparator.comparing(Method::getName));
 

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -85,81 +85,19 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
 import static org.duckdb.DuckDBDriver.DUCKDB_USER_AGENT_PROPERTY;
 import static org.duckdb.DuckDBDriver.JDBC_STREAM_RESULTS;
+import static org.duckdb.test.Assertions.assertEquals;
+import static org.duckdb.test.Assertions.assertFalse;
+import static org.duckdb.test.Assertions.assertNotNull;
+import static org.duckdb.test.Assertions.assertNull;
+import static org.duckdb.test.Assertions.assertThrows;
+import static org.duckdb.test.Assertions.assertThrowsMaybe;
+import static org.duckdb.test.Assertions.assertTrue;
+import static org.duckdb.test.Assertions.fail;
+import static org.duckdb.test.Runner.runTests;
 
 public class TestDuckDBJDBC {
 
     private static final String JDBC_URL = "jdbc:duckdb:";
-
-    private static void assertTrue(boolean val) throws Exception {
-        assertTrue(val, null);
-    }
-
-    private static void assertTrue(boolean val, String message) throws Exception {
-        if (!val) {
-            throw new Exception(message);
-        }
-    }
-
-    private static void assertFalse(boolean val) throws Exception {
-        assertTrue(!val);
-    }
-
-    private static void assertEquals(Object actual, Object expected) throws Exception {
-        Function<Object, String> getClass = (Object a) -> a == null ? "null" : a.getClass().toString();
-
-        String message = String.format("\"%s\" (of %s) should equal \"%s\" (of %s)", actual, getClass.apply(actual),
-                                       expected, getClass.apply(expected));
-        assertTrue(Objects.equals(actual, expected), message);
-    }
-
-    private static void assertNotNull(Object a) throws Exception {
-        assertFalse(a == null);
-    }
-
-    private static void assertNull(Object a) throws Exception {
-        assertEquals(a, null);
-    }
-
-    private static void assertEquals(double a, double b, double epsilon) throws Exception {
-        assertTrue(Math.abs(a - b) < epsilon);
-    }
-
-    private static void fail() throws Exception {
-        fail(null);
-    }
-
-    private static void fail(String s) throws Exception {
-        throw new Exception(s);
-    }
-
-    private static <T extends Throwable> String assertThrows(Thrower thrower, Class<T> exception) throws Exception {
-        return assertThrows(exception, thrower).getMessage();
-    }
-
-    private static <T extends Throwable> Throwable assertThrows(Class<T> exception, Thrower thrower) throws Exception {
-        try {
-            thrower.run();
-        } catch (Throwable e) {
-            assertEquals(e.getClass(), exception);
-            return e;
-        }
-        throw new Exception("Expected to throw " + exception.getName());
-    }
-
-    // Asserts we are either throwing the correct exception, or not throwing at all
-    private static <T extends Throwable> boolean assertThrowsMaybe(Thrower thrower, Class<T> exception)
-        throws Exception {
-        try {
-            thrower.run();
-            return true;
-        } catch (Throwable e) {
-            if (e.getClass().equals(exception)) {
-                return true;
-            } else {
-                throw new Exception("Unexpected exception: " + e.getClass().getName());
-            }
-        }
-    }
 
     static {
         try {
@@ -4337,52 +4275,6 @@ public class TestDuckDBJDBC {
     }
 
     public static void main(String[] args) throws Exception {
-        // Woo I can do reflection too, take this, JUnit!
-        Method[] methods = TestDuckDBJDBC.class.getMethods();
-
-        Arrays.sort(methods, new Comparator<Method>() {
-            @Override
-            public int compare(Method o1, Method o2) {
-                return o1.getName().compareTo(o2.getName());
-            }
-        });
-
-        String specific_test = null;
-        if (args.length >= 1) {
-            specific_test = args[0];
-        }
-
-        boolean anySucceeded = false;
-        boolean anyFailed = false;
-        for (Method m : methods) {
-            if (m.getName().startsWith("test_")) {
-                if (specific_test != null && !m.getName().contains(specific_test)) {
-                    continue;
-                }
-                System.out.print(m.getName() + " ");
-
-                LocalDateTime start = LocalDateTime.now();
-                try {
-                    m.invoke(null);
-                    System.out.println("success in " + Duration.between(start, LocalDateTime.now()).getSeconds() +
-                                       " seconds");
-                } catch (Throwable t) {
-                    if (t instanceof InvocationTargetException) {
-                        t = t.getCause();
-                    }
-                    System.out.println("failed with " + t);
-                    t.printStackTrace(System.out);
-                    anyFailed = true;
-                }
-                anySucceeded = true;
-            }
-        }
-        if (!anySucceeded) {
-            System.out.println("No tests found that match " + specific_test);
-            System.exit(1);
-        }
-        System.out.println(anyFailed ? "FAILED" : "OK");
-
-        System.exit(anyFailed ? 1 : 0);
+        System.exit(runTests(args, TestDuckDBJDBC.class));
     }
 }

--- a/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/test/TestDuckDBJDBC.java
@@ -3634,7 +3634,6 @@ public class TestDuckDBJDBC {
         }
     }
 
-
     public static void test_getColumnClassName() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement s = conn.createStatement();) {
             try (ResultSet rs = s.executeQuery("select * from test_all_types()")) {


### PR DESCRIPTION
This is to:

 * Improve the maintainability of the JDBC tests
 * Removes them from the distributed JARK
 * Keeps the internals of the driver private

I've also added functionality to allow us to start breaking down the 4300-line test class :smile: (by adding the "Runner" class)