### PR TITLE
[Python] Fix bug in conversion of INTERVAL to `datetime.timedelta`

### DIFF
--- a/tools/pythonpkg/src/native/python_objects.cpp
+++ b/tools/pythonpkg/src/native/python_objects.cpp
@@ -542,7 +542,7 @@ py::object PythonObject::FromValue(const Value &val, const LogicalType &type,
 	}
 	case LogicalTypeId::INTERVAL: {
 		auto interval_value = val.GetValueUnsafe<interval_t>();
-		uint64_t days = duckdb::Interval::DAYS_PER_MONTH * interval_value.months + interval_value.days;
+		int64_t days = duckdb::Interval::DAYS_PER_MONTH * interval_value.months + interval_value.days;
 		return import_cache.datetime.timedelta()(py::arg("days") = days,
 		                                         py::arg("microseconds") = interval_value.micros);
 	}

--- a/tools/pythonpkg/tests/fast/types/test_datetime_datetime.py
+++ b/tools/pythonpkg/tests/fast/types/test_datetime_datetime.py
@@ -47,3 +47,9 @@ class TestDateTimeDateTime(object):
         con.execute("select $1, $1 = '-infinity'::TIMESTAMP", [datetime.datetime.min])
         res = con.fetchall()
         assert res == [(datetime.datetime.min, False)]
+
+    def test_convert_negative_interval(self, duckdb_cursor):
+        res = duckdb_cursor.execute(
+            "SELECT CAST('2023-07-22T11:28:07' AS TIMESTAMP) - CAST('2023-07-23T11:28:07' AS TIMESTAMP)"
+        ).fetchall()
+        assert res == [(datetime.timedelta(days=-1),)]


### PR DESCRIPTION
This PR fixes #10227

We were not accounting for negative intervals, using `uint64_t` instead of `int64_t`