### PR TITLE
Fail Regression test when difference in cardinalities is detected

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -321,13 +321,13 @@ jobs:
         cp -r benchmark duckdb/
 
     - name: Regression Test IMDB
-      continue-on-error: true
+      if: always()
       shell: bash
       run: |
         python scripts/plan_cost_runner.py --old=duckdb/build/release/duckdb --new=build/release/duckdb --dir=benchmark/imdb_plan_cost
 
     - name: Regression Test TPCH
-      continue-on-error: true
+      if: always()
       shell: bash
       run: |
         python scripts/plan_cost_runner.py --old=duckdb/build/release/duckdb --new=build/release/duckdb --dir=benchmark/tpch_plan_cost


### PR DESCRIPTION
The `continue-on-error` would not fail the CI job even though regressions were detected. By removing continue-on-error and adding `if: always()` both plan cost regression runs will still happen, but if either fails then the CI run will also fail 