### PR TITLE
pin ccache action version

### DIFF
--- a/.github/actions/manylinux_2014_setup/action.yml
+++ b/.github/actions/manylinux_2014_setup/action.yml
@@ -105,7 +105,7 @@ runs:
 
     - name: Setup Ccache
       if: ${{ inputs.ccache == 1 }}
-      uses: hendrikmuhs/ccache-action@main
+      uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases
       with:
         key: ${{ github.job }}
         save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}

--- a/.github/actions/ubuntu_18_setup/action.yml
+++ b/.github/actions/ubuntu_18_setup/action.yml
@@ -88,7 +88,7 @@ runs:
 
     - name: Setup Ccache
       if: ${{ inputs.ccache == 1 }}
-      uses: hendrikmuhs/ccache-action@main
+      uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases
       with:
         key: ${{ github.job }}
         save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -314,7 +314,7 @@ jobs:
           git clone https://github.com/cwida/jdbccts.git
 
       - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@main
+        uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases
         with:
           key: ${{ github.job }}
           save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -321,7 +321,7 @@ jobs:
          fetch-depth: 0
 
      - name: Setup Ccache
-       uses: hendrikmuhs/ccache-action@main
+       uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases
        with:
          key: ${{ github.job }}
          save: ${{ env.CCACHE_SAVE }}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -195,7 +195,7 @@ jobs:
         find tools/pythonpkg -maxdepth 2 -type f -name "*.duckdb_extension"
 
     - name: Setup Ccache
-      uses: hendrikmuhs/ccache-action@main
+      uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases
       with:
         key: ${{ github.job }}-${{ matrix.arch }}-${{ matrix.python_build }}
         save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -149,7 +149,7 @@ jobs:
           ./duckdb/scripts/setup_manylinux2014.sh general aws-cli ccache ssh python_alias openssl
 
       - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@main
+        uses: hendrikmuhs/ccache-action@v1.2.11 # Note: pinned due to GLIBC incompatibility in later releases
         with:
           key: ${{ github.job }}-${{ matrix.duckdb_arch }}
 


### PR DESCRIPTION
Pins the ccache version for our ubuntu 18 and manylinux2014 builds since their glibc is too old for this action to work