### PR TITLE
Optimise division by a constant at runtime for integer division

### DIFF
--- a/src/common/types/hugeint.cpp
+++ b/src/common/types/hugeint.cpp
@@ -6,10 +6,8 @@
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/windows_undefs.hpp"
-#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/uhugeint.hpp"
-#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/windows_undefs.hpp"
 
 #include <cmath>

--- a/src/common/types/hugeint.cpp
+++ b/src/common/types/hugeint.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/windows_undefs.hpp"
 
 #include <cmath>
+#include <cstdint>
 #include <limits>
 
 namespace duckdb {
@@ -360,7 +361,7 @@ hugeint_t Hugeint::SlowMultiply(hugeint_t lhs, hugeint_t rhs) {
 
 	// combine components
 	result.lower = (third32 << 32) | fourth32;
-	result.upper = (first32 << 32) | second32;
+	result.upper = int64_t((first32 << 32) | second32);
 
 	if (lhs_negative ^ rhs_negative) {
 		NegateInPlace<false>(result);

--- a/src/common/types/hugeint.cpp
+++ b/src/common/types/hugeint.cpp
@@ -5,7 +5,6 @@
 #include "duckdb/common/hugeint.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/numeric_utils.hpp"
-#include "duckdb/common/windows_undefs.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/uhugeint.hpp"
 #include "duckdb/common/windows_undefs.hpp"

--- a/src/common/types/uhugeint.cpp
+++ b/src/common/types/uhugeint.cpp
@@ -1,12 +1,15 @@
 #include "duckdb/common/types/uhugeint.hpp"
-#include "duckdb/common/types/hugeint.hpp"
-#include "duckdb/common/exception.hpp"
+
 #include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/windows_undefs.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/windows_undefs.hpp"
 
 #include <cmath>
 #include <limits>
@@ -168,18 +171,8 @@ bool Uhugeint::TryMultiply(uhugeint_t lhs, uhugeint_t rhs, uhugeint_t &result) {
 }
 
 // No overflow check, will wrap
-template <>
-uhugeint_t Uhugeint::Multiply<false>(uhugeint_t lhs, uhugeint_t rhs) {
+uhugeint_t Uhugeint::SlowMultiply(uhugeint_t lhs, uhugeint_t rhs) {
 	uhugeint_t result;
-#if ((__GNUC__ >= 5) || defined(__clang__)) && defined(__SIZEOF_INT128__)
-	__uint128_t left = __uint128_t(lhs.lower) + (__uint128_t(lhs.upper) << 64);
-	__uint128_t right = __uint128_t(rhs.lower) + (__uint128_t(rhs.upper) << 64);
-	__uint128_t result_u128;
-
-	result_u128 = left * right;
-	result.upper = uint64_t(result_u128 >> 64);
-	result.lower = uint64_t(result_u128 & 0xffffffffffffffff);
-#else
 	// split values into 4 32-bit parts
 	uint64_t top[4] = {lhs.upper >> 32, lhs.upper & 0xffffffff, lhs.lower >> 32, lhs.lower & 0xffffffff};
 	uint64_t bottom[4] = {rhs.upper >> 32, rhs.upper & 0xffffffff, rhs.lower >> 32, rhs.lower & 0xffffffff};
@@ -224,7 +217,6 @@ uhugeint_t Uhugeint::Multiply<false>(uhugeint_t lhs, uhugeint_t rhs) {
 	// combine components
 	result.lower = (third32 << 32) | fourth32;
 	result.upper = (first32 << 32) | second32;
-#endif
 	return result;
 }
 

--- a/src/common/types/uhugeint.cpp
+++ b/src/common/types/uhugeint.cpp
@@ -4,7 +4,6 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/numeric_utils.hpp"
-#include "duckdb/common/windows_undefs.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/hugeint.hpp"

--- a/src/common/types/uhugeint.cpp
+++ b/src/common/types/uhugeint.cpp
@@ -8,7 +8,6 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/hugeint.hpp"
-#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/windows_undefs.hpp"
 
 #include <cmath>

--- a/src/core_functions/function_list.cpp
+++ b/src/core_functions/function_list.cpp
@@ -155,6 +155,7 @@ static const StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_SCALAR_FUNCTION_SET(DecadeFun),
 	DUCKDB_SCALAR_FUNCTION(DecodeFun),
 	DUCKDB_SCALAR_FUNCTION(DegreesFun),
+	DUCKDB_SCALAR_FUNCTION_SET(ConstRHSDivideFun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(Editdist3Fun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(ElementAtFun),
 	DUCKDB_SCALAR_FUNCTION(EncodeFun),

--- a/src/core_functions/scalar/math/functions.json
+++ b/src/core_functions/scalar/math/functions.json
@@ -313,5 +313,11 @@
         "description": "Computes the inverse hyperbolic tan of x",
         "example": "atanh(0.5)",
         "type": "scalar_function"
+        "name": "divide_by_const",
+        "parameters": "x, C",
+        "description": "Same as // but optimised for a constant right hand size",
+        "example": "SELECT divide_by_const(x, 100) FROM Y",
+        "type": "scalar_function_set",
+        "struct": "ConstRHSDivideFun"
     }
 ]

--- a/src/core_functions/scalar/math/functions.json
+++ b/src/core_functions/scalar/math/functions.json
@@ -313,6 +313,8 @@
         "description": "Computes the inverse hyperbolic tan of x",
         "example": "atanh(0.5)",
         "type": "scalar_function"
+	},
+	{
         "name": "divide_by_const",
         "parameters": "x, C",
         "description": "Same as // but optimised for a constant right hand size",

--- a/src/core_functions/scalar/math/numeric.cpp
+++ b/src/core_functions/scalar/math/numeric.cpp
@@ -1517,7 +1517,7 @@ template <>
 inline int32_t Fastdiv<int32_t>(int32_t a, m_t<int32_t> m, int32_t d) {
 	hugeint_t lhs;
 	if (a < 0) {
-		lhs = hugeint_t(0xffffffffffffffff, a);
+		lhs = hugeint_t(int64_t(0xffffffffffffffff), a);
 	} else {
 		lhs = hugeint_t(0, a);
 	}

--- a/src/core_functions/scalar/math/numeric.cpp
+++ b/src/core_functions/scalar/math/numeric.cpp
@@ -1438,23 +1438,35 @@ ScalarFunctionSet LeastCommonMultipleFun::GetFunctions() {
 // and Software Libraries, Software: Practice and Experience 49 (6), 2019.
 // https://arxiv.org/abs/1902.01961
 
-template <class > struct next_size;
-template <class T> using next_size_t = typename next_size<T>::type;
-template <class T> struct tag { using type = T; };
+template <class>
+struct next_size;
+template <class T>
+using next_size_t = typename next_size<T>::type;
+template <class T>
+struct tag {
+	using type = T;
+};
 
-template <> struct next_size<uint8_t>  : tag<uint16_t> { };
-template <> struct next_size<uint16_t> : tag<uint32_t> { };
-template <> struct next_size<uint32_t> : tag<uint64_t> { };
-template <> struct next_size<uint64_t> : tag<uhugeint_t> { };
-template <> struct next_size<int8_t>  : tag<int16_t> { };
-template <> struct next_size<int16_t> : tag<int32_t> { };
-template <> struct next_size<int32_t> : tag<int64_t> { };
+template <>
+struct next_size<uint8_t> : tag<uint16_t> {};
+template <>
+struct next_size<uint16_t> : tag<uint32_t> {};
+template <>
+struct next_size<uint32_t> : tag<uint64_t> {};
+template <>
+struct next_size<uint64_t> : tag<uhugeint_t> {};
+template <>
+struct next_size<int8_t> : tag<int16_t> {};
+template <>
+struct next_size<int16_t> : tag<int32_t> {};
+template <>
+struct next_size<int32_t> : tag<int64_t> {};
 
-template <class T> using m_t = next_size_t<typename std::make_unsigned<T>::type>;
+template <class T>
+using m_t = next_size_t<typename std::make_unsigned<T>::type>;
 
 template <class RHS>
-typename std::enable_if<std::is_unsigned<RHS>::value, next_size_t<RHS>>::type
-ComputeM(RHS rhs) {
+typename std::enable_if<std::is_unsigned<RHS>::value, next_size_t<RHS>>::type ComputeM(RHS rhs) {
 	return next_size_t<RHS>(-1) / rhs + 1;
 }
 
@@ -1464,8 +1476,7 @@ m_t<uint64_t> ComputeM<uint64_t>(uint64_t rhs) {
 }
 
 template <class RHS>
-typename std::enable_if<!std::is_unsigned<RHS>::value, m_t<RHS>>::type
-ComputeM(RHS rhs) {
+typename std::enable_if<!std::is_unsigned<RHS>::value, m_t<RHS>>::type ComputeM(RHS rhs) {
 	if (rhs < 0) {
 		rhs = -rhs;
 	}
@@ -1475,11 +1486,10 @@ ComputeM(RHS rhs) {
 // fastdiv computes (a / d) given precomputed M for d>1
 
 template <class RHS>
-inline static typename std::enable_if<std::is_unsigned<RHS>::value, RHS>::type
-Fastdiv(RHS a, m_t<RHS> m, RHS d) {
+inline static typename std::enable_if<std::is_unsigned<RHS>::value, RHS>::type Fastdiv(RHS a, m_t<RHS> m, RHS d) {
 	// Compute the bottom 32 bits, then the top 32 bits, add them, and only keep the top 32 bits
 	// The reason we need the bottom 32 bits, is because the carry will roll into the top 32 bits.
-	return ((((m & RHS(-1)) * a) >> (sizeof(RHS) * 8)) + ((m >> (sizeof(RHS)*8)) * a)) >> (sizeof(RHS) * 8);
+	return ((((m & RHS(-1)) * a) >> (sizeof(RHS) * 8)) + ((m >> (sizeof(RHS) * 8)) * a)) >> (sizeof(RHS) * 8);
 }
 
 template <>
@@ -1490,8 +1500,7 @@ inline uint64_t Fastdiv<uint64_t>(uint64_t a, m_t<uint64_t> m, uint64_t d) {
 }
 
 template <class RHS>
-static typename std::enable_if<!std::is_unsigned<RHS>::value, RHS>::type
-Fastdiv(RHS a, m_t<RHS> m, RHS d) {
+static typename std::enable_if<!std::is_unsigned<RHS>::value, RHS>::type Fastdiv(RHS a, m_t<RHS> m, RHS d) {
 	next_size_t<next_size_t<RHS>> lhs = a;
 	if (a < 0) {
 		lhs |= next_size_t<next_size_t<RHS>>(-1) << (sizeof(m_t<RHS>) * 8);
@@ -1505,7 +1514,7 @@ Fastdiv(RHS a, m_t<RHS> m, RHS d) {
 }
 
 template <>
-inline int32_t Fastdiv<int32_t> (int32_t a, m_t<int32_t> m, int32_t d) {
+inline int32_t Fastdiv<int32_t>(int32_t a, m_t<int32_t> m, int32_t d) {
 	hugeint_t lhs;
 	if (a < 0) {
 		lhs = hugeint_t(0xffffffffffffffff, a);

--- a/src/core_functions/scalar/math/numeric.cpp
+++ b/src/core_functions/scalar/math/numeric.cpp
@@ -1443,24 +1443,24 @@ struct next_size;
 template <class T>
 using next_size_t = typename next_size<T>::type;
 template <class T>
-struct tag {
+struct Tag {
 	using type = T;
 };
 
 template <>
-struct next_size<uint8_t> : tag<uint16_t> {};
+struct next_size<uint8_t> : Tag<uint16_t> {};
 template <>
-struct next_size<uint16_t> : tag<uint32_t> {};
+struct next_size<uint16_t> : Tag<uint32_t> {};
 template <>
-struct next_size<uint32_t> : tag<uint64_t> {};
+struct next_size<uint32_t> : Tag<uint64_t> {};
 template <>
-struct next_size<uint64_t> : tag<uhugeint_t> {};
+struct next_size<uint64_t> : Tag<uhugeint_t> {};
 template <>
-struct next_size<int8_t> : tag<int16_t> {};
+struct next_size<int8_t> : Tag<int16_t> {};
 template <>
-struct next_size<int16_t> : tag<int32_t> {};
+struct next_size<int16_t> : Tag<int32_t> {};
 template <>
-struct next_size<int32_t> : tag<int64_t> {};
+struct next_size<int32_t> : Tag<int64_t> {};
 
 template <class T>
 using m_t = next_size_t<typename std::make_unsigned<T>::type>;

--- a/src/core_functions/scalar/math/numeric.cpp
+++ b/src/core_functions/scalar/math/numeric.cpp
@@ -1503,7 +1503,7 @@ template <class RHS>
 static typename std::enable_if<!std::is_unsigned<RHS>::value, RHS>::type Fastdiv(RHS a, m_t<RHS> m, RHS d) {
 	next_size_t<next_size_t<RHS>> lhs = a;
 	if (a < 0) {
-		lhs |= next_size_t<next_size_t<RHS>>(-1) << (sizeof(m_t<RHS>) * 8);
+		lhs |= next_size_t<next_size_t<RHS>>(0xFFFFFFFFFFFFFFFF) << (sizeof(m_t<RHS>) * 8);
 	}
 	m_t<RHS> highbits = (lhs * m) >> (sizeof(m_t<RHS>) * 8);
 	highbits += (a < 0 ? 1 : 0);

--- a/src/core_functions/scalar/math/numeric.cpp
+++ b/src/core_functions/scalar/math/numeric.cpp
@@ -1503,7 +1503,7 @@ template <class RHS>
 static typename std::enable_if<!std::is_unsigned<RHS>::value, RHS>::type Fastdiv(RHS a, m_t<RHS> m, RHS d) {
 	next_size_t<next_size_t<RHS>> lhs = a;
 	if (a < 0) {
-		lhs |= next_size_t<next_size_t<RHS>>(0xFFFFFFFFFFFFFFFF) << (sizeof(m_t<RHS>) * 8);
+		lhs |= next_size_t<next_size_t<RHS>>(0xFFFFFFFFFFFFFFFF << (sizeof(m_t<RHS>) * 8));
 	}
 	m_t<RHS> highbits = (lhs * m) >> (sizeof(m_t<RHS>) * 8);
 	highbits += (a < 0 ? 1 : 0);

--- a/src/include/duckdb/common/types/hugeint.hpp
+++ b/src/include/duckdb/common/types/hugeint.hpp
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include "duckdb/common/types.hpp"
-#include "duckdb/common/type_util.hpp"
-#include "duckdb/common/limits.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
+#include "duckdb/common/type_util.hpp"
+#include "duckdb/common/types.hpp"
 
 namespace duckdb {
 
@@ -60,15 +60,46 @@ public:
 		return input;
 	}
 
+	static hugeint_t SlowMultiply(hugeint_t lhs, hugeint_t rhs);
+
 	static bool TryMultiply(hugeint_t lhs, hugeint_t rhs, hugeint_t &result);
 
 	template <bool CHECK_OVERFLOW = true>
 	inline static hugeint_t Multiply(hugeint_t lhs, hugeint_t rhs) {
+		if (CHECK_OVERFLOW) {
+			hugeint_t result;
+			if (!TryMultiply(lhs, rhs, result)) {
+				throw OutOfRangeException("Overflow in HUGEINT multiplication: %s + %s", lhs.ToString(),
+				                          rhs.ToString());
+			}
+			return result;
+		}
+
+#if ((__GNUC__ >= 5) || defined(__clang__)) && defined(__SIZEOF_INT128__)
 		hugeint_t result;
-		if (!TryMultiply(lhs, rhs, result)) {
-			throw OutOfRangeException("Overflow in HUGEINT multiplication: %s + %s", lhs.ToString(), rhs.ToString());
+		bool lhs_negative = lhs.upper < 0;
+		bool rhs_negative = rhs.upper < 0;
+		if (lhs_negative) {
+			NegateInPlace<false>(lhs);
+		}
+		if (rhs_negative) {
+			NegateInPlace<false>(rhs);
+		}
+
+		__uint128_t left = __uint128_t(lhs.lower) + (__uint128_t(lhs.upper) << 64);
+		__uint128_t right = __uint128_t(rhs.lower) + (__uint128_t(rhs.upper) << 64);
+		__uint128_t result_i128;
+		result_i128 = left * right;
+		uint64_t upper = uint64_t(result_i128 >> 64);
+		result.upper = int64_t(upper);
+		result.lower = uint64_t(result_i128 & 0xffffffffffffffff);
+		if (lhs_negative ^ rhs_negative) {
+			NegateInPlace<false>(result);
 		}
 		return result;
+#else
+		return SlowMultiply(lhs, rhs);
+#endif
 	}
 
 	static bool TryDivMod(hugeint_t lhs, hugeint_t rhs, hugeint_t &result, hugeint_t &remainder);

--- a/src/include/duckdb/common/types/uhugeint.hpp
+++ b/src/include/duckdb/common/types/uhugeint.hpp
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include "duckdb/common/types.hpp"
-#include "duckdb/common/type_util.hpp"
-#include "duckdb/common/limits.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
+#include "duckdb/common/type_util.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/uhugeint.hpp"
 
 namespace duckdb {
@@ -61,15 +61,33 @@ public:
 		return input;
 	}
 
+	static uhugeint_t SlowMultiply(uhugeint_t lhs, uhugeint_t rhs);
+
 	static bool TryMultiply(uhugeint_t lhs, uhugeint_t rhs, uhugeint_t &result);
 
 	template <bool CHECK_OVERFLOW = true>
 	inline static uhugeint_t Multiply(uhugeint_t lhs, uhugeint_t rhs) {
-		uhugeint_t result;
-		if (!TryMultiply(lhs, rhs, result)) {
-			throw OutOfRangeException("Overflow in UHUGEINT multiplication!: %s + %s", lhs.ToString(), rhs.ToString());
+		if (CHECK_OVERFLOW) {
+			uhugeint_t result;
+			if (!TryMultiply(lhs, rhs, result)) {
+				throw OutOfRangeException("Overflow in UHUGEINT multiplication!: %s + %s", lhs.ToString(),
+				                          rhs.ToString());
+			}
+			return result;
 		}
+#if ((__GNUC__ >= 5) || defined(__clang__)) && defined(__SIZEOF_INT128__)
+		uhugeint_t result;
+		__uint128_t left = __uint128_t(lhs.lower) + (__uint128_t(lhs.upper) << 64);
+		__uint128_t right = __uint128_t(rhs.lower) + (__uint128_t(rhs.upper) << 64);
+		__uint128_t result_u128;
+
+		result_u128 = left * right;
+		result.upper = uint64_t(result_u128 >> 64);
+		result.lower = uint64_t(result_u128 & 0xffffffffffffffff);
 		return result;
+#else
+		return SlowMultiply(lhs, rhs);
+#endif
 	}
 
 	static bool TryDivMod(uhugeint_t lhs, uhugeint_t rhs, uhugeint_t &result, uhugeint_t &remainder);

--- a/src/include/duckdb/core_functions/scalar/math_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/math_functions.hpp
@@ -60,7 +60,8 @@ struct PowOperatorFunAlias {
 struct FactorialOperatorFun {
 	static constexpr const char *Name = "!__postfix";
 	static constexpr const char *Parameters = "x";
-	static constexpr const char *Description = "Factorial of x. Computes the product of the current integer and all integers below it";
+	static constexpr const char *Description =
+	    "Factorial of x. Computes the product of the current integer and all integers below it";
 	static constexpr const char *Example = "4!";
 
 	static ScalarFunction GetFunction();
@@ -216,7 +217,8 @@ struct IsInfiniteFun {
 struct IsNanFun {
 	static constexpr const char *Name = "isnan";
 	static constexpr const char *Parameters = "x";
-	static constexpr const char *Description = "Returns true if the floating point value is not a number, false otherwise";
+	static constexpr const char *Description =
+	    "Returns true if the floating point value is not a number, false otherwise";
 	static constexpr const char *Example = "isnan('NaN'::FLOAT)";
 
 	static ScalarFunctionSet GetFunctions();
@@ -300,7 +302,8 @@ struct Log10Fun {
 struct LogFun {
 	static constexpr const char *Name = "log";
 	static constexpr const char *Parameters = "b, x";
-	static constexpr const char *Description = "Computes the logarithm of x to base b. b may be omitted, in which case the default 10";
+	static constexpr const char *Description =
+	    "Computes the logarithm of x to base b. b may be omitted, in which case the default 10";
 	static constexpr const char *Example = "log(2, 64)";
 
 	static ScalarFunctionSet GetFunctions();
@@ -448,6 +451,15 @@ struct AtanhFun {
 	static constexpr const char *Example = "atanh(0.5)";
 
 	static ScalarFunction GetFunction();
+};
+
+struct ConstRHSDivideFun {
+	static constexpr const char *Name = "divide_by_const";
+	static constexpr const char *Parameters = "x, C";
+	static constexpr const char *Description = "Same as // but optimised for a constant right hand size";
+	static constexpr const char *Example = "SELECT divide_by_const(x, 100) FROM Y";
+
+	static ScalarFunctionSet GetFunctions();
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/core_functions/scalar/math_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/math_functions.hpp
@@ -60,8 +60,7 @@ struct PowOperatorFunAlias {
 struct FactorialOperatorFun {
 	static constexpr const char *Name = "!__postfix";
 	static constexpr const char *Parameters = "x";
-	static constexpr const char *Description =
-	    "Factorial of x. Computes the product of the current integer and all integers below it";
+	static constexpr const char *Description = "Factorial of x. Computes the product of the current integer and all integers below it";
 	static constexpr const char *Example = "4!";
 
 	static ScalarFunction GetFunction();
@@ -217,8 +216,7 @@ struct IsInfiniteFun {
 struct IsNanFun {
 	static constexpr const char *Name = "isnan";
 	static constexpr const char *Parameters = "x";
-	static constexpr const char *Description =
-	    "Returns true if the floating point value is not a number, false otherwise";
+	static constexpr const char *Description = "Returns true if the floating point value is not a number, false otherwise";
 	static constexpr const char *Example = "isnan('NaN'::FLOAT)";
 
 	static ScalarFunctionSet GetFunctions();
@@ -302,8 +300,7 @@ struct Log10Fun {
 struct LogFun {
 	static constexpr const char *Name = "log";
 	static constexpr const char *Parameters = "b, x";
-	static constexpr const char *Description =
-	    "Computes the logarithm of x to base b. b may be omitted, in which case the default 10";
+	static constexpr const char *Description = "Computes the logarithm of x to base b. b may be omitted, in which case the default 10";
 	static constexpr const char *Example = "log(2, 64)";
 
 	static ScalarFunctionSet GetFunctions();

--- a/src/optimizer/rule/arithmetic_simplification.cpp
+++ b/src/optimizer/rule/arithmetic_simplification.cpp
@@ -1,9 +1,10 @@
 #include "duckdb/optimizer/rule/arithmetic_simplification.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/optimizer/expression_rewriter.hpp"
 
 namespace duckdb {
 
@@ -63,6 +64,15 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 			} else if (constant.value == 0) {
 				// divide by 0, replace with NULL
 				return make_uniq<BoundConstantExpression>(Value(root.return_type));
+			} else {
+				ErrorData error;
+				FunctionBinder binder(rewriter.context);
+				auto function = binder.BindScalarFunction(DEFAULT_SCHEMA, "divide_by_const", std::move(root.children),
+				                                          error, false);
+				if (!function) {
+					error.Throw();
+				}
+				return function;
 			}
 		}
 	} else {


### PR DESCRIPTION
When the rhs of an integer divide is known to be constant, it is possible to optimize this. Libdivide does this optimization at runtime, so even when the constant isn't known at compile time, it can still perform similar optimizations.

As you can see below the code using libdivide runs up to twice as fast. It should be even faster for unsigned integers.
It might be possible for the compiler to auto-vectorise the branchless version of libdivide, but I have not looked into that. Open for future research.

## Issues with this code

I personally find the current method a bit messy, as it is the responsibility of the OPWRAPPER to decide what to optimize and what not. On one hand this allows the OP to be as generic as it was before. On the other hand, adding this libdivide optimization to more types will result in lots of duplicate code across the wrappers.

## Benchmarks (ran with turbo-boost disabled)

No optimisation:
```
name	run	timing
benchmark/micro/arithmetic/division_constrhs.benchmark	1	1.170270
benchmark/micro/arithmetic/division_constrhs.benchmark	2	1.173304
benchmark/micro/arithmetic/division_constrhs.benchmark	3	1.164200
benchmark/micro/arithmetic/division_constrhs.benchmark	4	1.179625
benchmark/micro/arithmetic/division_constrhs.benchmark	5	1.177252
```

Just performing row validity check based on the rhs (if possible):
```
name	run	timing
benchmark/micro/arithmetic/division_constrhs.benchmark	1	1.113453
benchmark/micro/arithmetic/division_constrhs.benchmark	2	1.130460
benchmark/micro/arithmetic/division_constrhs.benchmark	3	1.125331
benchmark/micro/arithmetic/division_constrhs.benchmark	4	1.134362
benchmark/micro/arithmetic/division_constrhs.benchmark	5	1.120623
```

Using libdivide:
```
name	run	timing
benchmark/micro/arithmetic/division_constrhs.benchmark	1	0.498989
benchmark/micro/arithmetic/division_constrhs.benchmark	2	0.497163
benchmark/micro/arithmetic/division_constrhs.benchmark	3	0.498707
benchmark/micro/arithmetic/division_constrhs.benchmark	4	0.504418
benchmark/micro/arithmetic/division_constrhs.benchmark	5	0.502800
```