### PR TITLE
test_all_types.py: Formatting according to black 24

### DIFF
--- a/tools/pythonpkg/tests/fast/test_all_types.py
+++ b/tools/pythonpkg/tests/fast/test_all_types.py
@@ -202,7 +202,11 @@ class TestAllTypes(object):
                 (None,),
             ],
             'array_of_structs': [([],), ([{'a': None, 'b': None}, {'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'}, None],), (None,)],
-            'map': [({'key': [], 'value': []},), ({'key': ['key1', 'key2'], 'value': ['🦆🦆🦆🦆🦆🦆', 'goose']},), (None,)],
+            'map': [
+                ({'key': [], 'value': []},),
+                ({'key': ['key1', 'key2'], 'value': ['🦆🦆🦆🦆🦆🦆', 'goose']},),
+                (None,),
+            ],
             'time_tz': [(datetime.time(0, 0),), (datetime.time(23, 59, 59, 999999),), (None,)],
             'interval': [
                 (datetime.timedelta(0),),


### PR DESCRIPTION
This should be an innocuous PR fixing the formatting of a file (that got out of sync since a formatter update) that should bring back CI to a valid state.