### PR TITLE
Change extension_directory default

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -142,6 +142,7 @@ static unique_ptr<ArrowType> GetArrowLogicalTypeNoDictionary(ArrowSchema &schema
 		vector<unique_ptr<ArrowType>> children;
 		auto n_children = schema.n_children;
 		D_ASSERT(n_children == 2);
+		(void)n_children;
 		D_ASSERT(string(schema.children[0]->name) == "run_ends");
 		D_ASSERT(string(schema.children[1]->name) == "values");
 		for (idx_t i = 0; i < 2; i++) {

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -121,6 +121,7 @@ private:
 	                                     const string &local_path, const string &extension, bool force_install,
 	                                     const string &repository);
 	static const vector<string> PathComponents();
+	static string DefaultExtensionFolder(FileSystem &fs);
 	static bool AllowAutoInstall(const string &extension);
 	static ExtensionInitResult InitialLoad(DBConfig &config, FileSystem &fs, const string &extension,
 	                                       optional_ptr<const ClientConfig> client_config);

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -48,8 +48,8 @@ duckdb::string ExtensionHelper::DefaultExtensionFolder(FileSystem &fs) {
 	// exception if the home directory does not exist, don't create whatever we think is home
 	if (!fs.DirectoryExists(home_directory)) {
 		throw IOException("Can't find the home directory at '%s'\nSpecify a home directory using the SET "
-				  "home_directory='/path/to/dir' option.",
-				  home_directory);
+		                  "home_directory='/path/to/dir' option.",
+		                  home_directory);
 	}
 	string res = home_directory;
 	res = fs.JoinPath(res, ".duckdb");

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -40,7 +40,21 @@ const string ExtensionHelper::GetVersionDirectoryName() {
 }
 
 const vector<string> ExtensionHelper::PathComponents() {
-	return vector<string> {".duckdb", "extensions", GetVersionDirectoryName(), DuckDB::Platform()};
+	return vector<string> {GetVersionDirectoryName(), DuckDB::Platform()};
+}
+
+duckdb::string ExtensionHelper::DefaultExtensionFolder(FileSystem &fs) {
+	string home_directory = fs.GetHomeDirectory();
+	// exception if the home directory does not exist, don't create whatever we think is home
+	if (!fs.DirectoryExists(home_directory)) {
+		throw IOException("Can't find the home directory at '%s'\nSpecify a home directory using the SET "
+				  "home_directory='/path/to/dir' option.",
+				  home_directory);
+	}
+	string res = home_directory;
+	res = fs.JoinPath(res, ".duckdb");
+	res = fs.JoinPath(res, "extensions");
+	return res;
 }
 
 string ExtensionHelper::ExtensionDirectory(DBConfig &config, FileSystem &fs) {
@@ -52,6 +66,10 @@ string ExtensionHelper::ExtensionDirectory(DBConfig &config, FileSystem &fs) {
 		extension_directory = config.options.extension_directory;
 		// TODO this should probably live in the FileSystem
 		// convert random separators to platform-canonic
+	} else { // otherwise default to home
+		extension_directory = DefaultExtensionFolder(fs);
+	}
+	{
 		extension_directory = fs.ConvertSeparators(extension_directory);
 		// expand ~ in extension directory
 		extension_directory = fs.ExpandPath(extension_directory);
@@ -70,15 +88,6 @@ string ExtensionHelper::ExtensionDirectory(DBConfig &config, FileSystem &fs) {
 				}
 			}
 		}
-	} else { // otherwise default to home
-		string home_directory = fs.GetHomeDirectory();
-		// exception if the home directory does not exist, don't create whatever we think is home
-		if (!fs.DirectoryExists(home_directory)) {
-			throw IOException("Can't find the home directory at '%s'\nSpecify a home directory using the SET "
-			                  "home_directory='/path/to/dir' option.",
-			                  home_directory);
-		}
-		extension_directory = home_directory;
 	}
 	D_ASSERT(fs.DirectoryExists(extension_directory));
 

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -96,7 +96,7 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 #else
 
 		string local_path =
-		    !config.options.extension_directory.empty() ? config.options.extension_directory : fs.GetHomeDirectory();
+		    !config.options.extension_directory.empty() ? config.options.extension_directory : ExtensionHelper::DefaultExtensionFolder(fs);
 
 		// convert random separators to platform-canonic
 		local_path = fs.ConvertSeparators(local_path);

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -95,8 +95,8 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 		filename = address;
 #else
 
-		string local_path =
-		    !config.options.extension_directory.empty() ? config.options.extension_directory : ExtensionHelper::DefaultExtensionFolder(fs);
+		string local_path = !config.options.extension_directory.empty() ? config.options.extension_directory
+		                                                                : ExtensionHelper::DefaultExtensionFolder(fs);
 
 		// convert random separators to platform-canonic
 		local_path = fs.ConvertSeparators(local_path);


### PR DESCRIPTION
### Overview
Before this PR:
```sql
D SET extension_directory = 'folder';
D LOAD x;
Error: IO Error: Extension "folder/.duckdb/extensions/v0.9.2/osx_arm64/x.duckdb_extension" not found.
```

After this PR:
```sql
D SET extension_directory = 'folder';
D LOAD x;
Error: IO Error: Extension "folder/v0.9.2/osx_arm64/x.duckdb_extension" not found.
```
Basically making so that `folder` will behave as the root of the extension folder.

Why this might be better? It's arguably simpler and more intuitive, at least to me, see here for context conversation with @samansmink: https://github.com/duckdb/duckdb/pull/10329#discussion_r1466237762

### Details
Behaviour is also consistent between INSTALL and LOAD, so the same scripts will keep working
before and after this PR, BUT actual file paths will change since there are no more the extra
`.duckdb` and `extensions` folders.
This might be visible:
* if you rely on exact paths (since you are using some other script or tool), in this case you need to change script or invocation.
* if you are pointing to your current work-directory and will find it populated by directories like `98ffa7d67d` or `v0.10.0`. In this case changing `SET extension_directory' = 'path/to/workdir/duckdb_extensions';` would be more appropriate.

Behaviour will stay the exactly same if `extension_directory` variable is not set.

---

Also fixing a very minor & unrelated unused variable on amalgamation that was detected on nightly.