### PR TITLE
Fix MATERIALIZED CTE issue #10260

### DIFF
--- a/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_cte_node.cpp
@@ -30,8 +30,19 @@ unique_ptr<BoundQueryNode> Binder::BindNode(CTENode &statement) {
 		result->names[i] = statement.aliases[i];
 	}
 
+	// Rename columns if duplicate names are detected
+	idx_t index = 1;
+	vector<string> names;
+	for (auto &n : result->names) {
+		string name = n;
+		while (find(names.begin(), names.end(), name) != names.end()) {
+			name = n + ":" + std::to_string(index++);
+		}
+		names.push_back(name);
+	}
+
 	// This allows the right side to reference the CTE
-	bind_context.AddGenericBinding(result->setop_index, statement.ctename, result->names, result->types);
+	bind_context.AddGenericBinding(result->setop_index, statement.ctename, names, result->types);
 
 	result->child_binder = Binder::CreateBinder(context, this);
 
@@ -43,8 +54,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(CTENode &statement) {
 	statement.modifiers.clear();
 
 	// Add bindings of left side to temporary CTE bindings context
-	result->child_binder->bind_context.AddCTEBinding(result->setop_index, statement.ctename, result->names,
-	                                                 result->types);
+	result->child_binder->bind_context.AddCTEBinding(result->setop_index, statement.ctename, names, result->types);
 	result->child = result->child_binder->BindNode(*statement.child);
 
 	// the result types of the CTE are the types of the LHS

--- a/test/sql/cte/materialized/test_issue_10260.test
+++ b/test/sql/cte/materialized/test_issue_10260.test
@@ -1,0 +1,28 @@
+# name: test/sql/cte/materialized/test_issue_10260.test
+# description: Issue #10260: MATERIALIZED causes Binder Error: table has duplicate column name
+# group: [materialized]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE T0(C1 INT);
+
+statement ok
+CREATE TABLE T1(C1 INT);
+
+statement ok
+INSERT INTO T0(C1) VALUES (1);
+
+statement ok
+INSERT INTO T1(C1) VALUES (1);
+
+query I
+WITH CTE AS MATERIALIZED (
+SELECT A1, * FROM T0
+  LEFT JOIN (
+    SELECT C1 AS A1 FROM T1
+  ) ON T0.C1 = A1
+) SELECT A1 FROM CTE;
+----
+1


### PR DESCRIPTION
This PR fixes issue #10260. It equalizes the behavior of MATERIALIZED CTEs with non-MATERIALIZED ones, when column names are specified more than once.