### PR TITLE
[Python][Dev] Use `duckdb_cursor` to avoid unintentionally sharing catalogs and registered objects

### DIFF
--- a/tools/pythonpkg/tests/fast/api/test_attribute_getter.py
+++ b/tools/pythonpkg/tests/fast/api/test_attribute_getter.py
@@ -10,50 +10,50 @@ import pytest
 
 
 class TestGetAttribute(object):
-    def test_basic_getattr(self):
-        rel = duckdb.sql('select i as a, (i + 5) % 10 as b, (i + 2) % 3 as c from range(100) tbl(i)')
+    def test_basic_getattr(self, duckdb_cursor):
+        rel = duckdb_cursor.sql('select i as a, (i + 5) % 10 as b, (i + 2) % 3 as c from range(100) tbl(i)')
         assert rel.a.fetchmany(5) == [(0,), (1,), (2,), (3,), (4,)]
         assert rel.b.fetchmany(5) == [(5,), (6,), (7,), (8,), (9,)]
         assert rel.c.fetchmany(5) == [(2,), (0,), (1,), (2,), (0,)]
 
-    def test_basic_getitem(self):
-        rel = duckdb.sql('select i as a, (i + 5) % 10 as b, (i + 2) % 3 as c from range(100) tbl(i)')
+    def test_basic_getitem(self, duckdb_cursor):
+        rel = duckdb_cursor.sql('select i as a, (i + 5) % 10 as b, (i + 2) % 3 as c from range(100) tbl(i)')
         assert rel['a'].fetchmany(5) == [(0,), (1,), (2,), (3,), (4,)]
         assert rel['b'].fetchmany(5) == [(5,), (6,), (7,), (8,), (9,)]
         assert rel['c'].fetchmany(5) == [(2,), (0,), (1,), (2,), (0,)]
 
-    def test_getitem_nonexistant(self):
-        rel = duckdb.sql('select i as a, (i + 5) % 10 as b, (i + 2) % 3 as c from range(100) tbl(i)')
+    def test_getitem_nonexistant(self, duckdb_cursor):
+        rel = duckdb_cursor.sql('select i as a, (i + 5) % 10 as b, (i + 2) % 3 as c from range(100) tbl(i)')
         with pytest.raises(AttributeError):
             rel['d']
 
-    def test_getattr_nonexistant(self):
-        rel = duckdb.sql('select i as a, (i + 5) % 10 as b, (i + 2) % 3 as c from range(100) tbl(i)')
+    def test_getattr_nonexistant(self, duckdb_cursor):
+        rel = duckdb_cursor.sql('select i as a, (i + 5) % 10 as b, (i + 2) % 3 as c from range(100) tbl(i)')
         with pytest.raises(AttributeError):
             rel.d
 
-    def test_getattr_collision(self):
-        rel = duckdb.sql('select i as df from range(100) tbl(i)')
+    def test_getattr_collision(self, duckdb_cursor):
+        rel = duckdb_cursor.sql('select i as df from range(100) tbl(i)')
 
         # 'df' also exists as a method on DuckDBPyRelation
         assert rel.df.__class__ != duckdb.DuckDBPyRelation
 
-    def test_getitem_collision(self):
-        rel = duckdb.sql('select i as df from range(100) tbl(i)')
+    def test_getitem_collision(self, duckdb_cursor):
+        rel = duckdb_cursor.sql('select i as df from range(100) tbl(i)')
 
         # this case is not an issue on __getitem__
         assert rel['df'].__class__ == duckdb.DuckDBPyRelation
 
-    def test_getitem_struct(self):
-        rel = duckdb.sql("select {'a':5, 'b':6} as a, 5 as b")
+    def test_getitem_struct(self, duckdb_cursor):
+        rel = duckdb_cursor.sql("select {'a':5, 'b':6} as a, 5 as b")
         assert rel['a']['a'].fetchall()[0][0] == 5
         assert rel['a']['b'].fetchall()[0][0] == 6
 
-    def test_getattr_struct(self):
-        rel = duckdb.sql("select {'a':5, 'b':6} as a, 5 as b")
+    def test_getattr_struct(self, duckdb_cursor):
+        rel = duckdb_cursor.sql("select {'a':5, 'b':6} as a, 5 as b")
         assert rel.a.a.fetchall()[0][0] == 5
         assert rel.a.b.fetchall()[0][0] == 6
 
-    def test_getattr_spaces(self):
-        rel = duckdb.sql('select 42 as "hello world"')
+    def test_getattr_spaces(self, duckdb_cursor):
+        rel = duckdb_cursor.sql('select 42 as "hello world"')
         assert rel['hello world'].fetchall()[0][0] == 42

--- a/tools/pythonpkg/tests/fast/api/test_dbapi12.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi12.py
@@ -60,7 +60,7 @@ class TestRelationApi(object):
 
     def test_fromquery(self, duckdb_cursor):
         assert duckdb.from_query('select 42').fetchone()[0] == 42
-        assert duckdb.query('select 43').fetchone()[0] == 43
+        assert duckdb_cursor.query('select 43').fetchone()[0] == 43
 
         # assert duckdb_cursor.from_query('select 44').execute().fetchone()[0] == 44
         # assert duckdb_cursor.from_query('select 45').execute().fetchone()[0] == 45

--- a/tools/pythonpkg/tests/fast/api/test_dbapi_fetch.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi_fetch.py
@@ -53,19 +53,19 @@ class TestDBApiFetch(object):
             c.fetchall()
 
     def test_multiple_fetch_all_relation(self, duckdb_cursor):
-        res = duckdb.query('SELECT 42')
+        res = duckdb_cursor.query('SELECT 42')
         assert res.fetchall() == [(42,)]
         assert res.fetchall() == [(42,)]
         assert res.fetchall() == [(42,)]
 
     def test_multiple_fetch_many_relation(self, duckdb_cursor):
-        res = duckdb.query('SELECT 42')
+        res = duckdb_cursor.query('SELECT 42')
         assert res.fetchmany(10000) == [(42,)]
         assert res.fetchmany(10000) == []
         assert res.fetchmany(10000) == []
 
     def test_fetch_one_relation(self, duckdb_cursor):
-        res = duckdb.query('SELECT * FROM range(3)')
+        res = duckdb_cursor.query('SELECT * FROM range(3)')
         assert res.fetchone() == (0,)
         assert res.fetchone() == (1,)
         assert res.fetchone() == (2,)

--- a/tools/pythonpkg/tests/fast/api/test_duckdb_query.py
+++ b/tools/pythonpkg/tests/fast/api/test_duckdb_query.py
@@ -6,18 +6,18 @@ from duckdb import Value
 
 class TestDuckDBQuery(object):
     def test_duckdb_query(self, duckdb_cursor):
-        # we can use duckdb.query to run both DDL statements and select statements
-        duckdb.query('create view v1 as select 42 i')
-        rel = duckdb.query('select * from v1')
+        # we can use duckdb_cursor.sql to run both DDL statements and select statements
+        duckdb_cursor.sql('create view v1 as select 42 i')
+        rel = duckdb_cursor.sql('select * from v1')
         assert rel.fetchall()[0][0] == 42
 
         # also multiple statements
-        duckdb.query('create view v2 as select i*2 j from v1; create view v3 as select j * 2 from v2;')
-        rel = duckdb.query('select * from v3')
+        duckdb_cursor.sql('create view v2 as select i*2 j from v1; create view v3 as select j * 2 from v2;')
+        rel = duckdb_cursor.sql('select * from v3')
         assert rel.fetchall()[0][0] == 168
 
         # we can run multiple select statements - we get only the last result
-        res = duckdb.query('select 42; select 84;').fetchall()
+        res = duckdb_cursor.sql('select 42; select 84;').fetchall()
         assert res == [(84,)]
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])

--- a/tools/pythonpkg/tests/fast/api/test_explain.py
+++ b/tools/pythonpkg/tests/fast/api/test_explain.py
@@ -3,44 +3,44 @@ import duckdb
 
 
 class TestExplain(object):
-    def test_explain_basic(self):
-        res = duckdb.sql('select 42').explain()
+    def test_explain_basic(self, duckdb_cursor):
+        res = duckdb_cursor.sql('select 42').explain()
         assert isinstance(res, str)
 
-    def test_explain_standard(self):
-        res = duckdb.sql('select 42').explain('standard')
+    def test_explain_standard(self, duckdb_cursor):
+        res = duckdb_cursor.sql('select 42').explain('standard')
         assert isinstance(res, str)
 
-        res = duckdb.sql('select 42').explain('STANDARD')
+        res = duckdb_cursor.sql('select 42').explain('STANDARD')
         assert isinstance(res, str)
 
-        res = duckdb.sql('select 42').explain(duckdb.STANDARD)
+        res = duckdb_cursor.sql('select 42').explain(duckdb.STANDARD)
         assert isinstance(res, str)
 
-        res = duckdb.sql('select 42').explain(duckdb.ExplainType.STANDARD)
+        res = duckdb_cursor.sql('select 42').explain(duckdb.ExplainType.STANDARD)
         assert isinstance(res, str)
 
-        res = duckdb.sql('select 42').explain(0)
+        res = duckdb_cursor.sql('select 42').explain(0)
         assert isinstance(res, str)
 
-    def test_explain_analyze(self):
-        res = duckdb.sql('select 42').explain('analyze')
+    def test_explain_analyze(self, duckdb_cursor):
+        res = duckdb_cursor.sql('select 42').explain('analyze')
         assert isinstance(res, str)
 
-        res = duckdb.sql('select 42').explain('ANALYZE')
+        res = duckdb_cursor.sql('select 42').explain('ANALYZE')
         assert isinstance(res, str)
 
-        res = duckdb.sql('select 42').explain(duckdb.ANALYZE)
+        res = duckdb_cursor.sql('select 42').explain(duckdb.ANALYZE)
         assert isinstance(res, str)
 
-        res = duckdb.sql('select 42').explain(duckdb.ExplainType.ANALYZE)
+        res = duckdb_cursor.sql('select 42').explain(duckdb.ExplainType.ANALYZE)
         assert isinstance(res, str)
 
-        res = duckdb.sql('select 42').explain(1)
+        res = duckdb_cursor.sql('select 42').explain(1)
         assert isinstance(res, str)
 
-    def test_explain_df(self):
+    def test_explain_df(self, duckdb_cursor):
         pd = pytest.importorskip("pandas")
         df = pd.DataFrame({'a': [42]})
-        res = duckdb.sql('select * from df').explain('ANALYZE')
+        res = duckdb_cursor.sql('select * from df').explain('ANALYZE')
         assert isinstance(res, str)

--- a/tools/pythonpkg/tests/fast/api/test_read_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_read_csv.py
@@ -423,7 +423,7 @@ class TestReadCSV(object):
         res = con.sql("select * from rel order by all").fetchall()
         assert res == [(1,), (2,), (3,), (4,), (5,), (6,)]
 
-    def test_read_csv_combined(self):
+    def test_read_csv_combined(self, duckdb_cursor):
         CSV_FILE = TestFile('stress_test.csv')
         COLUMNS = {
             'result': 'VARCHAR',
@@ -443,7 +443,7 @@ class TestReadCSV(object):
         )
         res = rel.fetchall()
 
-        rel2 = duckdb.sql(rel.sql_query())
+        rel2 = duckdb_cursor.sql(rel.sql_query())
         res2 = rel2.fetchall()
 
         # Assert that the results are the same

--- a/tools/pythonpkg/tests/fast/api/test_streaming_result.py
+++ b/tools/pythonpkg/tests/fast/api/test_streaming_result.py
@@ -3,9 +3,9 @@ import duckdb
 
 
 class TestStreamingResult(object):
-    def test_fetch_one(self):
+    def test_fetch_one(self, duckdb_cursor):
         # fetch one
-        res = duckdb.sql('SELECT * FROM range(100000)')
+        res = duckdb_cursor.sql('SELECT * FROM range(100000)')
         result = []
         while len(result) < 5000:
             tpl = res.fetchone()
@@ -13,7 +13,7 @@ class TestStreamingResult(object):
         assert result == list(range(5000))
 
         # fetch one with error
-        res = duckdb.sql(
+        res = duckdb_cursor.sql(
             "SELECT CASE WHEN i < 10000 THEN i ELSE concat('hello', i::VARCHAR)::INT END FROM range(100000) t(i)"
         )
         with pytest.raises(duckdb.ConversionException):
@@ -22,9 +22,9 @@ class TestStreamingResult(object):
                 if tpl is None:
                     break
 
-    def test_fetch_many(self):
+    def test_fetch_many(self, duckdb_cursor):
         # fetch many
-        res = duckdb.sql('SELECT * FROM range(100000)')
+        res = duckdb_cursor.sql('SELECT * FROM range(100000)')
         result = []
         while len(result) < 5000:
             tpl = res.fetchmany(10)
@@ -32,7 +32,7 @@ class TestStreamingResult(object):
         assert result == list(range(5000))
 
         # fetch many with error
-        res = duckdb.sql(
+        res = duckdb_cursor.sql(
             "SELECT CASE WHEN i < 10000 THEN i ELSE concat('hello', i::VARCHAR)::INT END FROM range(100000) t(i)"
         )
         with pytest.raises(duckdb.ConversionException):
@@ -41,11 +41,11 @@ class TestStreamingResult(object):
                 if tpl is None:
                     break
 
-    def test_record_batch_reader(self):
+    def test_record_batch_reader(self, duckdb_cursor):
         pytest.importorskip("pyarrow")
         pytest.importorskip("pyarrow.dataset")
         # record batch reader
-        res = duckdb.sql('SELECT * FROM range(100000) t(i)')
+        res = duckdb_cursor.sql('SELECT * FROM range(100000) t(i)')
         reader = res.fetch_arrow_reader(batch_size=16_384)
         result = []
         for batch in reader:
@@ -53,7 +53,7 @@ class TestStreamingResult(object):
         assert result == list(range(100000))
 
         # record batch reader with error
-        res = duckdb.sql(
+        res = duckdb_cursor.sql(
             "SELECT CASE WHEN i < 10000 THEN i ELSE concat('hello', i::VARCHAR)::INT END FROM range(100000) t(i)"
         )
         reader = res.fetch_arrow_reader(batch_size=16_384)

--- a/tools/pythonpkg/tests/fast/arrow/test_7652.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_7652.py
@@ -8,7 +8,7 @@ pq = pytest.importorskip("pyarrow.parquet", minversion="11")
 
 
 class Test7652(object):
-    def test_7652(self):
+    def test_7652(self, duckdb_cursor):
         temp_file_name = tempfile.NamedTemporaryFile(suffix='.parquet').name
         # Generate a list of values that aren't uniform in changes.
         generated_list = [1, 0, 2]
@@ -36,7 +36,7 @@ class Test7652(object):
 
         # Attempt to perform the same thing with duckdb.
         print("Retrieving from duckdb")
-        duckdb_result = list(map(lambda v: v[0], duckdb.query(f"select * from '{temp_file_name}'").fetchall()))
+        duckdb_result = list(map(lambda v: v[0], duckdb_cursor.sql(f"select * from '{temp_file_name}'").fetchall()))
 
         print("DuckDB result:", duckdb_result)
         assert min(duckdb_result) == min(generated_list)

--- a/tools/pythonpkg/tests/fast/arrow/test_7699.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_7699.py
@@ -8,7 +8,7 @@ pl = pytest.importorskip("polars")
 
 
 class Test7699(object):
-    def test_7699(self):
+    def test_7699(self, duckdb_cursor):
         pl_tbl = pl.DataFrame(
             {
                 "col1": pl.Series([string.ascii_uppercase[ix + 10] for ix in list(range(2)) + list(range(3))]).cast(
@@ -18,8 +18,8 @@ class Test7699(object):
         )
 
         nickname = "df1234"
-        duckdb.register(nickname, pl_tbl)
+        duckdb_cursor.register(nickname, pl_tbl)
 
-        rel = duckdb.sql("select * from df1234")
+        rel = duckdb_cursor.sql("select * from df1234")
         res = rel.fetchall()
         assert res == [('K',), ('L',), ('K',), ('L',), ('M',)]

--- a/tools/pythonpkg/tests/fast/arrow/test_8522.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_8522.py
@@ -10,7 +10,7 @@ pa = pytest.importorskip("pyarrow")
 # arrow supports timestamp_tz with different units than US, we only support US
 # so we have to convert ConstantValues back to their native unit when pushing the filter expression containing them down to pyarrow
 class Test8522(object):
-    def test_8522(self):
+    def test_8522(self, duckdb_cursor):
         t_us = pa.Table.from_arrays(
             arrays=[pa.array([dt.datetime(2022, 1, 1)])],
             schema=pa.schema([pa.field("time", pa.timestamp("us", tz="UTC"))]),
@@ -21,8 +21,8 @@ class Test8522(object):
             schema=pa.schema([pa.field("time", pa.timestamp("ms", tz="UTC"))]),
         )
 
-        expected = duckdb.sql("FROM t_us").filter("time>='2022-01-01'").fetchall()
+        expected = duckdb_cursor.sql("FROM t_us").filter("time>='2022-01-01'").fetchall()
         assert len(expected) == 1
 
-        actual = duckdb.sql("FROM t_ms").filter("time>='2022-01-01'").fetchall()
+        actual = duckdb_cursor.sql("FROM t_ms").filter("time>='2022-01-01'").fetchall()
         assert actual == expected

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_union.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_union.py
@@ -6,21 +6,21 @@ import duckdb
 from pyarrow import scalar, string, large_string, list_, int32, types
 
 
-def test_nested():
-    res = run('select 42::UNION(name VARCHAR, attr UNION(age INT, veteran BOOL)) as res')
+def test_nested(duckdb_cursor):
+    res = run(duckdb_cursor, 'select 42::UNION(name VARCHAR, attr UNION(age INT, veteran BOOL)) as res')
     assert types.is_union(res.type)
     assert res.value.value == scalar(42, type=int32())
 
 
-def test_union_contains_nested_data():
+def test_union_contains_nested_data(duckdb_cursor):
     _ = importorskip("pyarrow", minversion="11")
-    res = run("select ['hello']::UNION(first_name VARCHAR, middle_names VARCHAR[]) as res")
+    res = run(duckdb_cursor, "select ['hello']::UNION(first_name VARCHAR, middle_names VARCHAR[]) as res")
     assert types.is_union(res.type)
     assert res.value == scalar(['hello'], type=list_(string()))
 
 
-def test_unions_inside_lists_structs_maps():
-    res = run("select [union_value(name := 'Frank')] as res")
+def test_unions_inside_lists_structs_maps(duckdb_cursor):
+    res = run(duckdb_cursor, "select [union_value(name := 'Frank')] as res")
     assert types.is_list(res.type)
     assert types.is_union(res.type.value_type)
     assert res[0].value == scalar('Frank', type=string())
@@ -47,5 +47,5 @@ def test_unions_with_struct(duckdb_cursor):
     assert res == [({'a': 42, 'b': True},)]
 
 
-def run(query):
-    return duckdb.sql(query).arrow().columns[0][0]
+def run(conn, query):
+    return conn.sql(query).arrow().columns[0][0]

--- a/tools/pythonpkg/tests/fast/arrow/test_integration.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_integration.py
@@ -193,7 +193,7 @@ class TestArrowIntegration(object):
         assert duckdb_tbl_arrow[7].value == None
 
         # List
-        query = duckdb.query(
+        query = duckdb_cursor.sql(
             "SELECT a from (select list_value(INTERVAL 3 MONTHS, INTERVAL 5 DAYS, INTERVAL 10 SECONDS, NULL) as a) as t"
         ).arrow()['a']
         assert query[0][0].value == pyarrow.MonthDayNano([3, 0, 0])
@@ -203,8 +203,8 @@ class TestArrowIntegration(object):
 
         # Struct
         query = "SELECT a from (SELECT STRUCT_PACK(a := INTERVAL 1 MONTHS, b := INTERVAL 10 DAYS, c:= INTERVAL 20 SECONDS) as a) as t"
-        true_answer = duckdb.query(query).fetchall()
-        from_arrow = duckdb.from_arrow(duckdb.query(query).arrow()).fetchall()
+        true_answer = duckdb_cursor.sql(query).fetchall()
+        from_arrow = duckdb.from_arrow(duckdb_cursor.sql(query).arrow()).fetchall()
         assert true_answer[0][0]['a'] == from_arrow[0][0]['a']
         assert true_answer[0][0]['b'] == from_arrow[0][0]['b']
         assert true_answer[0][0]['c'] == from_arrow[0][0]['c']

--- a/tools/pythonpkg/tests/fast/arrow/test_nested_arrow.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_nested_arrow.py
@@ -12,14 +12,14 @@ except:
     can_run = False
 
 
-def compare_results(query):
-    true_answer = duckdb.query(query).fetchall()
-    from_arrow = duckdb.from_arrow(duckdb.query(query).arrow()).fetchall()
+def compare_results(duckdb_cursor, query):
+    true_answer = duckdb_cursor.query(query).fetchall()
+    from_arrow = duckdb.from_arrow(duckdb_cursor.query(query).arrow()).fetchall()
     assert true_answer == from_arrow
 
 
-def arrow_to_pandas(query):
-    return duckdb.query(query).arrow().to_pandas()['a'].values.tolist()
+def arrow_to_pandas(duckdb_cursor, query):
+    return duckdb_cursor.query(query).arrow().to_pandas()['a'].values.tolist()
 
 
 class TestArrowNested(object):
@@ -28,17 +28,17 @@ class TestArrowNested(object):
             return
 
         # Test Constant List
-        query = duckdb.query("SELECT a from (select list_value(3,5,10) as a) as t").arrow()['a'].to_numpy()
+        query = duckdb_cursor.query("SELECT a from (select list_value(3,5,10) as a) as t").arrow()['a'].to_numpy()
         assert query[0][0] == 3
         assert query[0][1] == 5
         assert query[0][2] == 10
 
         # Empty List
-        query = duckdb.query("SELECT a from (select list_value() as a) as t").arrow()['a'].to_numpy()
+        query = duckdb_cursor.query("SELECT a from (select list_value() as a) as t").arrow()['a'].to_numpy()
         assert len(query[0]) == 0
 
         # Test Constant List With Null
-        query = duckdb.query("SELECT a from (select list_value(3,NULL) as a) as t").arrow()['a'].to_numpy()
+        query = duckdb_cursor.query("SELECT a from (select list_value(3,NULL) as a) as t").arrow()['a'].to_numpy()
         assert query[0][0] == 3
         assert np.isnan(query[0][1])
 
@@ -90,66 +90,85 @@ class TestArrowNested(object):
         if not can_run:
             return
         # Integers
-        compare_results("SELECT a from (select list_value(3,5,10) as a) as t")
-        compare_results("SELECT a from (select list_value(3,5,NULL) as a) as t")
-        compare_results("SELECT a from (select list_value(NULL,NULL,NULL) as a) as t")
-        compare_results("SELECT a from (select list_value() as a) as t")
+        compare_results(duckdb_cursor, "SELECT a from (select list_value(3,5,10) as a) as t")
+        compare_results(duckdb_cursor, "SELECT a from (select list_value(3,5,NULL) as a) as t")
+        compare_results(duckdb_cursor, "SELECT a from (select list_value(NULL,NULL,NULL) as a) as t")
+        compare_results(duckdb_cursor, "SELECT a from (select list_value() as a) as t")
         # Strings
-        compare_results("SELECT a from (select list_value('test','test_one','test_two') as a) as t")
-        compare_results("SELECT a from (select list_value('test','test_one',NULL) as a) as t")
+        compare_results(duckdb_cursor, "SELECT a from (select list_value('test','test_one','test_two') as a) as t")
+        compare_results(duckdb_cursor, "SELECT a from (select list_value('test','test_one',NULL) as a) as t")
         # Big Lists
-        compare_results("SELECT a from (SELECT LIST(i) as a FROM range(10000) tbl(i)) as t")
+        compare_results(duckdb_cursor, "SELECT a from (SELECT LIST(i) as a FROM range(10000) tbl(i)) as t")
         # Multiple Lists
-        compare_results("SELECT a from (SELECT LIST(i) as a FROM range(10000) tbl(i) group by i%10 order by all) as t")
+        compare_results(
+            duckdb_cursor,
+            "SELECT a from (SELECT LIST(i) as a FROM range(10000) tbl(i) group by i%10 order by all) as t",
+        )
         # Unique Constants
-        compare_results("SELECT a from (SELECT list_value(1) as a FROM range(10) tbl(i)) as t")
+        compare_results(duckdb_cursor, "SELECT a from (SELECT list_value(1) as a FROM range(10) tbl(i)) as t")
         # Nested Lists
         compare_results(
-            "SELECT LIST(le order by le) FROM (SELECT LIST(i order by i) le from range(100) tbl(i) group by i%10) as t"
+            duckdb_cursor,
+            "SELECT LIST(le order by le) FROM (SELECT LIST(i order by i) le from range(100) tbl(i) group by i%10) as t",
         )
 
         # LIST[LIST[LIST[LIST[LIST[INTEGER]]]]]]
         compare_results(
-            "SELECT list (lllle order by lllle) llllle from (SELECT list (llle order by llle) lllle from (SELECT list(lle order by lle) llle from (SELECT LIST(le order by le) lle FROM (SELECT LIST(i order by i) le from range(100) tbl(i) group by i%10) as t) as t1) as t2) as t3"
+            duckdb_cursor,
+            "SELECT list (lllle order by lllle) llllle from (SELECT list (llle order by llle) lllle from (SELECT list(lle order by lle) llle from (SELECT LIST(le order by le) lle FROM (SELECT LIST(i order by i) le from range(100) tbl(i) group by i%10) as t) as t1) as t2) as t3",
         )
 
         compare_results(
+            duckdb_cursor,
             '''SELECT grp,lst,cs FROM (select grp, lst, case when grp>1 then lst else list_value(null) end as cs
-                        from (SELECT a%4 as grp, list(a order by a) as lst FROM range(7) tbl(a) group by grp) as lst_tbl) as T order by all;'''
+                        from (SELECT a%4 as grp, list(a order by a) as lst FROM range(7) tbl(a) group by grp) as lst_tbl) as T order by all;''',
         )
         # Tests for converting multiple lists to/from Arrow with NULL values and/or strings
         compare_results(
-            "SELECT list(st order by st) from (select i, case when i%10 then NULL else i::VARCHAR end as st from range(1000) tbl(i)) as t group by i%5 order by all"
+            duckdb_cursor,
+            "SELECT list(st order by st) from (select i, case when i%10 then NULL else i::VARCHAR end as st from range(1000) tbl(i)) as t group by i%5 order by all",
         )
 
     def test_struct_roundtrip(self, duckdb_cursor):
         if not can_run:
             return
-        compare_results("SELECT a from (SELECT STRUCT_PACK(a := 42, b := 43) as a) as t")
-        compare_results("SELECT a from (SELECT STRUCT_PACK(a := NULL, b := 43) as a) as t")
-        compare_results("SELECT a from (SELECT STRUCT_PACK(a := NULL) as a) as t")
-        compare_results("SELECT a from (SELECT STRUCT_PACK(a := i, b := i) as a FROM range(10000) tbl(i)) as t")
+        compare_results(duckdb_cursor, "SELECT a from (SELECT STRUCT_PACK(a := 42, b := 43) as a) as t")
+        compare_results(duckdb_cursor, "SELECT a from (SELECT STRUCT_PACK(a := NULL, b := 43) as a) as t")
+        compare_results(duckdb_cursor, "SELECT a from (SELECT STRUCT_PACK(a := NULL) as a) as t")
         compare_results(
-            "SELECT a from (SELECT STRUCT_PACK(a := LIST_VALUE(1,2,3), b := i) as a FROM range(10000) tbl(i)) as t"
+            duckdb_cursor, "SELECT a from (SELECT STRUCT_PACK(a := i, b := i) as a FROM range(10000) tbl(i)) as t"
+        )
+        compare_results(
+            duckdb_cursor,
+            "SELECT a from (SELECT STRUCT_PACK(a := LIST_VALUE(1,2,3), b := i) as a FROM range(10000) tbl(i)) as t",
         )
 
     def test_map_roundtrip(self, duckdb_cursor):
         if not can_run:
             return
-        compare_results("SELECT a from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as a) as t")
-
-        compare_results("SELECT a from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as a) as t")
-
-        compare_results("SELECT a from (select MAP(LIST_VALUE(),LIST_VALUE()) as a) as t")
         compare_results(
-            "SELECT a from (select MAP(LIST_VALUE('Jon Lajoie', 'Backstreet Boys', 'Tenacious D'),LIST_VALUE(10,9,10)) as a) as t"
+            duckdb_cursor, "SELECT a from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as a) as t"
+        )
+
+        compare_results(
+            duckdb_cursor, "SELECT a from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as a) as t"
+        )
+
+        compare_results(duckdb_cursor, "SELECT a from (select MAP(LIST_VALUE(),LIST_VALUE()) as a) as t")
+        compare_results(
+            duckdb_cursor,
+            "SELECT a from (select MAP(LIST_VALUE('Jon Lajoie', 'Backstreet Boys', 'Tenacious D'),LIST_VALUE(10,9,10)) as a) as t",
         )
         compare_results(
-            "SELECT a from (select MAP(LIST_VALUE('Jon Lajoie','Tenacious D'),LIST_VALUE(10,10)) as a) as t"
+            duckdb_cursor,
+            "SELECT a from (select MAP(LIST_VALUE('Jon Lajoie','Tenacious D'),LIST_VALUE(10,10)) as a) as t",
         )
-        compare_results("SELECT m from (select MAP(list_value(1), list_value(2)) from range(5) tbl(i)) tbl(m)")
         compare_results(
-            "SELECT m from (select MAP(lsta,lstb) as m from (SELECT list(i) as lsta, list(i) as lstb from range(10000) tbl(i) group by i%5 order by all) as lst_tbl) as T"
+            duckdb_cursor, "SELECT m from (select MAP(list_value(1), list_value(2)) from range(5) tbl(i)) tbl(m)"
+        )
+        compare_results(
+            duckdb_cursor,
+            "SELECT m from (select MAP(lsta,lstb) as m from (SELECT list(i) as lsta, list(i) as lstb from range(10000) tbl(i) group by i%5 order by all) as lst_tbl) as T",
         )
 
     def test_map_arrow_to_duckdb(self, duckdb_cursor):
@@ -168,51 +187,58 @@ class TestArrowNested(object):
         if not can_run:
             return
         assert arrow_to_pandas(
-            "SELECT a from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as a) as t"
+            duckdb_cursor, "SELECT a from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as a) as t"
         ) == [[(1, 10), (2, 9), (3, 8), (4, 7)]]
-        assert arrow_to_pandas("SELECT a from (select MAP(LIST_VALUE(),LIST_VALUE()) as a) as t") == [[]]
+        assert arrow_to_pandas(duckdb_cursor, "SELECT a from (select MAP(LIST_VALUE(),LIST_VALUE()) as a) as t") == [[]]
         assert arrow_to_pandas(
-            "SELECT a from (select MAP(LIST_VALUE('Jon Lajoie', 'Backstreet Boys', 'Tenacious D'),LIST_VALUE(10,9,10)) as a) as t"
+            duckdb_cursor,
+            "SELECT a from (select MAP(LIST_VALUE('Jon Lajoie', 'Backstreet Boys', 'Tenacious D'),LIST_VALUE(10,9,10)) as a) as t",
         ) == [[('Jon Lajoie', 10), ('Backstreet Boys', 9), ('Tenacious D', 10)]]
         assert arrow_to_pandas(
-            "SELECT a from (select MAP(list_value(1), list_value(2)) from range(5) tbl(i)) tbl(a)"
+            duckdb_cursor, "SELECT a from (select MAP(list_value(1), list_value(2)) from range(5) tbl(i)) tbl(a)"
         ) == [[(1, 2)], [(1, 2)], [(1, 2)], [(1, 2)], [(1, 2)]]
         assert arrow_to_pandas(
-            "SELECT MAP(LIST_VALUE({'i':1,'j':2},{'i':3,'j':4}),LIST_VALUE({'i':1,'j':2},{'i':3,'j':4})) as a"
+            duckdb_cursor,
+            "SELECT MAP(LIST_VALUE({'i':1,'j':2},{'i':3,'j':4}),LIST_VALUE({'i':1,'j':2},{'i':3,'j':4})) as a",
         ) == [[({'i': 1, 'j': 2}, {'i': 1, 'j': 2}), ({'i': 3, 'j': 4}, {'i': 3, 'j': 4})]]
 
     def test_frankstein_nested(self, duckdb_cursor):
         if not can_run:
             return
         # List of structs W/ Struct that is NULL entirely
-        compare_results("SELECT [{'i':1,'j':2},NULL,{'i':2,'j':NULL}]")
+        compare_results(duckdb_cursor, "SELECT [{'i':1,'j':2},NULL,{'i':2,'j':NULL}]")
 
         # Lists of structs with lists
-        compare_results("SELECT [{'i':1,'j':[2,3]},NULL]")
+        compare_results(duckdb_cursor, "SELECT [{'i':1,'j':[2,3]},NULL]")
 
         # Maps embedded in a struct
         compare_results(
-            "SELECT {'i':mp,'j':mp2} FROM (SELECT MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as mp, MAP(LIST_VALUE(1, 2, 3, 5),LIST_VALUE(10, 9, 8, 7)) as mp2) as t"
+            duckdb_cursor,
+            "SELECT {'i':mp,'j':mp2} FROM (SELECT MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as mp, MAP(LIST_VALUE(1, 2, 3, 5),LIST_VALUE(10, 9, 8, 7)) as mp2) as t",
         )
 
         # List of maps
         compare_results(
-            "SELECT [mp,mp2] FROM (SELECT MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as mp, MAP(LIST_VALUE(1, 2, 3, 5),LIST_VALUE(10, 9, 8, 7)) as mp2) as t"
+            duckdb_cursor,
+            "SELECT [mp,mp2] FROM (SELECT MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as mp, MAP(LIST_VALUE(1, 2, 3, 5),LIST_VALUE(10, 9, 8, 7)) as mp2) as t",
         )
 
         # Map with list as key and/or value
-        compare_results("SELECT MAP(LIST_VALUE([1,2],[3,4],[5,4]),LIST_VALUE([1,2],[3,4],[5,4]))")
+        compare_results(duckdb_cursor, "SELECT MAP(LIST_VALUE([1,2],[3,4],[5,4]),LIST_VALUE([1,2],[3,4],[5,4]))")
 
         # Map with struct as key and/or value
-        compare_results("SELECT MAP(LIST_VALUE({'i':1,'j':2},{'i':3,'j':4}),LIST_VALUE({'i':1,'j':2},{'i':3,'j':4}))")
+        compare_results(
+            duckdb_cursor, "SELECT MAP(LIST_VALUE({'i':1,'j':2},{'i':3,'j':4}),LIST_VALUE({'i':1,'j':2},{'i':3,'j':4}))"
+        )
 
         # Struct that is NULL entirely
-        compare_results("SELECT * FROM (VALUES ({'i':1,'j':2}), (NULL), ({'i':1,'j':2}), (NULL)) as a")
+        compare_results(duckdb_cursor, "SELECT * FROM (VALUES ({'i':1,'j':2}), (NULL), ({'i':1,'j':2}), (NULL)) as a")
 
         # Null checks on lists with structs
-        compare_results("SELECT [{'i':1,'j':[2,3]},NULL,{'i':1,'j':[2,3]}]")
+        compare_results(duckdb_cursor, "SELECT [{'i':1,'j':[2,3]},NULL,{'i':1,'j':[2,3]}]")
 
         # MAP that is NULL entirely
         compare_results(
-            "SELECT * FROM (VALUES (MAP(LIST_VALUE(1,2),LIST_VALUE(3,4))),(NULL), (MAP(LIST_VALUE(1,2),LIST_VALUE(3,4))), (NULL)) as a"
+            duckdb_cursor,
+            "SELECT * FROM (VALUES (MAP(LIST_VALUE(1,2),LIST_VALUE(3,4))),(NULL), (MAP(LIST_VALUE(1,2),LIST_VALUE(3,4))), (NULL)) as a",
         )

--- a/tools/pythonpkg/tests/fast/arrow/test_polars.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_polars.py
@@ -17,12 +17,12 @@ class TestPolars(object):
             }
         )
         # scan plus return a polars dataframe
-        polars_result = duckdb.sql('SELECT * FROM df').pl()
+        polars_result = duckdb_cursor.sql('SELECT * FROM df').pl()
         pl_testing.assert_frame_equal(df, polars_result)
 
         # now do the same for a lazy dataframe
         lazy_df = df.lazy()
-        lazy_result = duckdb.sql('SELECT * FROM lazy_df').pl()
+        lazy_result = duckdb_cursor.sql('SELECT * FROM lazy_df').pl()
         pl_testing.assert_frame_equal(df, lazy_result)
 
         con = duckdb.connect()

--- a/tools/pythonpkg/tests/fast/numpy/test_numpy_new_path.py
+++ b/tools/pythonpkg/tests/fast/numpy/test_numpy_new_path.py
@@ -11,27 +11,27 @@ import pytest
 class TestScanNumpy(object):
     def test_scan_numpy(self, duckdb_cursor):
         z = np.array([1, 2, 3])
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [(1,), (2,), (3,)]
 
         z = np.array([[1, 2, 3], [4, 5, 6]])
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [(1, 4), (2, 5), (3, 6)]
 
         z = [np.array([1, 2, 3]), np.array([4, 5, 6])]
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [(1, 4), (2, 5), (3, 6)]
 
         z = {"z": np.array([1, 2, 3]), "x": np.array([4, 5, 6])}
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [(1, 4), (2, 5), (3, 6)]
 
         z = np.array(["zzz", "xxx"])
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [('zzz',), ('xxx',)]
 
         z = [np.array(["zzz", "xxx"]), np.array([1, 2])]
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [('zzz', 1), ('xxx', 2)]
 
         # test ndarray with dtype = object (python dict)
@@ -39,7 +39,7 @@ class TestScanNumpy(object):
         for i in range(3):
             z.append({str(3 - i): i})
         z = np.array(z)
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [
             ({'key': ['3'], 'value': [0]},),
             ({'key': ['2'], 'value': [1]},),
@@ -50,7 +50,7 @@ class TestScanNumpy(object):
         delta = timedelta(days=50, seconds=27, microseconds=10, milliseconds=29000, minutes=5, hours=8, weeks=2)
         delta2 = timedelta(days=5, seconds=27, microseconds=10, milliseconds=29000, minutes=5, hours=8, weeks=2)
         z = np.array([delta, delta2])
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [
             (timedelta(days=64, seconds=29156, microseconds=10),),
             (timedelta(days=19, seconds=29156, microseconds=10),),
@@ -58,27 +58,27 @@ class TestScanNumpy(object):
 
         # np.empty
         z = np.empty((3,))
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert len(res) == 3
 
         # empty list
         z = np.array([])
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == []
 
         # np.nan
         z = np.array([np.nan])
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [(None,)]
 
         # dict of mixed types
         z = {"z": np.array([1, 2, 3]), "x": np.array(["z", "x", "c"])}
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [(1, 'z'), (2, 'x'), (3, 'c')]
 
         # list of mixed types
         z = [np.array([1, 2, 3]), np.array(["z", "x", "c"])]
-        res = duckdb.sql("select * from z").fetchall()
+        res = duckdb_cursor.sql("select * from z").fetchall()
         assert res == [(1, 'z'), (2, 'x'), (3, 'c')]
 
         # currently unsupported formats, will throw duckdb.InvalidInputException
@@ -86,24 +86,24 @@ class TestScanNumpy(object):
         # list of arrays with different length
         z = [np.array([1, 2]), np.array([3])]
         with pytest.raises(duckdb.InvalidInputException):
-            duckdb.sql("select * from z")
+            duckdb_cursor.sql("select * from z")
 
         # dict of ndarrays of different length
         z = {"z": np.array([1, 2]), "x": np.array([3])}
         with pytest.raises(duckdb.InvalidInputException):
-            duckdb.sql("select * from z")
+            duckdb_cursor.sql("select * from z")
 
         # high dimensional tensors
         z = np.array([[[1, 2]]])
         with pytest.raises(duckdb.InvalidInputException):
-            duckdb.sql("select * from z")
+            duckdb_cursor.sql("select * from z")
 
         # list of ndarrys with len(shape) > 1
         z = [np.array([[1, 2], [3, 4]])]
         with pytest.raises(duckdb.InvalidInputException):
-            duckdb.sql("select * from z")
+            duckdb_cursor.sql("select * from z")
 
         # dict of ndarrays with len(shape) > 1
         z = {"x": np.array([[1, 2], [3, 4]])}
         with pytest.raises(duckdb.InvalidInputException):
-            duckdb.sql("select * from z")
+            duckdb_cursor.sql("select * from z")

--- a/tools/pythonpkg/tests/fast/pandas/test_datetime_time.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_datetime_time.py
@@ -10,7 +10,7 @@ _ = pytest.importorskip("pandas", minversion="2.0.0")
 class TestDateTimeTime(object):
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_time_high(self, duckdb_cursor, pandas):
-        duckdb_time = duckdb.query("SELECT make_time(23, 1, 34.234345) AS '0'").df()
+        duckdb_time = duckdb_cursor.sql("SELECT make_time(23, 1, 34.234345) AS '0'").df()
         data = [time(hour=23, minute=1, second=34, microsecond=234345)]
         df_in = pandas.DataFrame({'0': pandas.Series(data=data, dtype='object')})
         df_out = duckdb.query_df(df_in, "df", "select * from df").df()
@@ -18,7 +18,7 @@ class TestDateTimeTime(object):
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_time_low(self, duckdb_cursor, pandas):
-        duckdb_time = duckdb.query("SELECT make_time(00, 01, 1.000) AS '0'").df()
+        duckdb_time = duckdb_cursor.sql("SELECT make_time(00, 01, 1.000) AS '0'").df()
         data = [time(hour=0, minute=1, second=1)]
         df_in = pandas.DataFrame({'0': pandas.Series(data=data, dtype='object')})
         df_out = duckdb.query_df(df_in, "df", "select * from df").df()

--- a/tools/pythonpkg/tests/fast/pandas/test_datetime_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_datetime_timestamp.py
@@ -20,7 +20,7 @@ class TestDateTimeTimeStamp(object):
                 )
             }
         )
-        df_out = duckdb_cursor.sql(df_in, "df", "select * from df").df()
+        df_out = duckdb_cursor.sql("select * from df_in").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
@@ -45,7 +45,7 @@ class TestDateTimeTimeStamp(object):
         )
         print('original:', duckdb_time['0'].dtype)
         print('df_in:', df_in['0'].dtype)
-        df_out = duckdb_cursor.sql(df_in, "df", "select * from df").df()
+        df_out = duckdb_cursor.sql("select * from df_in").df()
         print('df_out:', df_out['0'].dtype)
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
@@ -69,7 +69,7 @@ class TestDateTimeTimeStamp(object):
                 )
             }
         )
-        df_out = duckdb_cursor.sql(df_in, "df", "select * from df").df()
+        df_out = duckdb_cursor.sql("select * from df_in").df()
         print(df_out)
         print(duckdb_time)
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
@@ -95,7 +95,7 @@ class TestDateTimeTimeStamp(object):
                 )
             }
         )
-        df_out = duckdb_cursor.sql(df_in, "df", "select * from df").df()
+        df_out = duckdb_cursor.sql("select * from df_in").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
     @pytest.mark.skipif(
@@ -120,5 +120,5 @@ class TestDateTimeTimeStamp(object):
                 )
             }
         )
-        df_out = duckdb_cursor.sql(df_in, "df", """select * from df""").df()
+        df_out = duckdb_cursor.sql("""select * from df_in""").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)

--- a/tools/pythonpkg/tests/fast/pandas/test_datetime_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_datetime_timestamp.py
@@ -10,8 +10,8 @@ pd = pytest.importorskip("pandas")
 
 class TestDateTimeTimeStamp(object):
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_high(self, pandas):
-        duckdb_time = duckdb.query("SELECT '2260-01-01 23:59:00'::TIMESTAMP AS '0'").df()
+    def test_timestamp_high(self, pandas, duckdb_cursor):
+        duckdb_time = duckdb_cursor.sql("SELECT '2260-01-01 23:59:00'::TIMESTAMP AS '0'").df()
         df_in = pandas.DataFrame(
             {
                 0: pandas.Series(
@@ -20,12 +20,12 @@ class TestDateTimeTimeStamp(object):
                 )
             }
         )
-        df_out = duckdb.query_df(df_in, "df", "select * from df").df()
+        df_out = duckdb_cursor.sql(df_in, "df", "select * from df").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_low(self, pandas):
-        duckdb_time = duckdb.query(
+    def test_timestamp_low(self, pandas, duckdb_cursor):
+        duckdb_time = duckdb_cursor.sql(
             """
             SELECT '1680-01-01 23:59:00.234243'::TIMESTAMP AS '0'
         """
@@ -45,7 +45,7 @@ class TestDateTimeTimeStamp(object):
         )
         print('original:', duckdb_time['0'].dtype)
         print('df_in:', df_in['0'].dtype)
-        df_out = duckdb.query_df(df_in, "df", "select * from df").df()
+        df_out = duckdb_cursor.sql(df_in, "df", "select * from df").df()
         print('df_out:', df_out['0'].dtype)
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
@@ -53,8 +53,8 @@ class TestDateTimeTimeStamp(object):
         Version(pd.__version__) < Version('2.0.2'), reason="pandas < 2.0.2 does not properly convert timezones"
     )
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_timezone_regular(self, pandas):
-        duckdb_time = duckdb.query(
+    def test_timestamp_timezone_regular(self, pandas, duckdb_cursor):
+        duckdb_time = duckdb_cursor.sql(
             """
             SELECT timestamp '2022-01-01 12:00:00' AT TIME ZONE 'Pacific/Easter' as "0"
         """
@@ -69,7 +69,7 @@ class TestDateTimeTimeStamp(object):
                 )
             }
         )
-        df_out = duckdb.query_df(df_in, "df", "select * from df").df()
+        df_out = duckdb_cursor.sql(df_in, "df", "select * from df").df()
         print(df_out)
         print(duckdb_time)
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
@@ -78,8 +78,8 @@ class TestDateTimeTimeStamp(object):
         Version(pd.__version__) < Version('2.0.2'), reason="pandas < 2.0.2 does not properly convert timezones"
     )
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_timezone_negative_extreme(self, pandas):
-        duckdb_time = duckdb.query(
+    def test_timestamp_timezone_negative_extreme(self, pandas, duckdb_cursor):
+        duckdb_time = duckdb_cursor.sql(
             """
             SELECT timestamp '2022-01-01 12:00:00' AT TIME ZONE 'Chile/EasterIsland' as "0"
         """
@@ -95,15 +95,15 @@ class TestDateTimeTimeStamp(object):
                 )
             }
         )
-        df_out = duckdb.query_df(df_in, "df", "select * from df").df()
+        df_out = duckdb_cursor.sql(df_in, "df", "select * from df").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)
 
     @pytest.mark.skipif(
         Version(pd.__version__) < Version('2.0.2'), reason="pandas < 2.0.2 does not properly convert timezones"
     )
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_timestamp_timezone_positive_extreme(self, pandas):
-        duckdb_time = duckdb.query(
+    def test_timestamp_timezone_positive_extreme(self, pandas, duckdb_cursor):
+        duckdb_time = duckdb_cursor.sql(
             """
             SELECT timestamp '2021-12-31 23:00:00' AT TIME ZONE 'kea_CV' as "0"
         """
@@ -120,5 +120,5 @@ class TestDateTimeTimeStamp(object):
                 )
             }
         )
-        df_out = duckdb.query_df(df_in, "df", """select * from df""").df()
+        df_out = duckdb_cursor.sql(df_in, "df", """select * from df""").df()
         pandas.testing.assert_frame_equal(df_out, duckdb_time)

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -49,25 +49,25 @@ def ConvertStringToDecimal(data: list, pandas):
 class TestResolveObjectColumns(object):
     # TODO: add support for ArrowPandas
     @pytest.mark.parametrize('pandas', [NumpyPandas()])
-    def test_integers(self, pandas):
+    def test_integers(self, pandas, duckdb_cursor):
         data = [5, 0, 3]
         df_in = create_generic_dataframe(data, pandas)
         # These are float64 because pandas would force these to be float64 even if we set them to int8, int16, int32, int64 respectively
         df_expected_res = pandas.DataFrame({'0': pandas.Series(data=data, dtype='int32')})
-        df_out = duckdb.query_df(df_in, "data", "SELECT * FROM data").df()
+        df_out = duckdb_cursor.sql("SELECT * FROM df_in").df()
         print(df_out)
         pandas.testing.assert_frame_equal(df_expected_res, df_out)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_struct_correct(self, pandas):
+    def test_struct_correct(self, pandas, duckdb_cursor):
         data = [{'a': 1, 'b': 3, 'c': 3, 'd': 7}]
         df = pandas.DataFrame({'0': pandas.Series(data=data)})
-        duckdb_col = duckdb.query("SELECT {a: 1, b: 3, c: 3, d: 7} as '0'").df()
-        converted_col = duckdb.query_df(df, "data", "SELECT * FROM data").df()
+        duckdb_col = duckdb_cursor.sql("SELECT {a: 1, b: 3, c: 3, d: 7} as '0'").df()
+        converted_col = duckdb_cursor.sql("SELECT * FROM df").df()
         pandas.testing.assert_frame_equal(duckdb_col, converted_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_fallback_different_keys(self, pandas):
+    def test_map_fallback_different_keys(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [{'a': 1, 'b': 3, 'c': 3, 'd': 7}],
@@ -78,7 +78,7 @@ class TestResolveObjectColumns(object):
             ]
         )
 
-        converted_df = duckdb.query_df(x, "x", "SELECT * FROM x").df()
+        converted_df = duckdb_cursor.sql("SELECT * FROM x").df()
         y = pandas.DataFrame(
             [
                 [{'key': ['a', 'b', 'c', 'd'], 'value': [1, 3, 3, 7]}],
@@ -88,11 +88,11 @@ class TestResolveObjectColumns(object):
                 [{'key': ['a', 'b', 'c', 'd'], 'value': [1, 3, 3, 7]}],
             ]
         )
-        equal_df = duckdb.query_df(y, "y", "SELECT * FROM y").df()
+        equal_df = duckdb_cursor.sql("SELECT * FROM y").df()
         pandas.testing.assert_frame_equal(converted_df, equal_df)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_fallback_incorrect_amount_of_keys(self, pandas):
+    def test_map_fallback_incorrect_amount_of_keys(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [{'a': 1, 'b': 3, 'c': 3, 'd': 7}],
@@ -102,7 +102,7 @@ class TestResolveObjectColumns(object):
                 [{'a': 1, 'b': 3, 'c': 3, 'd': 7}],
             ]
         )
-        converted_df = duckdb.query_df(x, "x", "SELECT * FROM x").df()
+        converted_df = duckdb_cursor.sql("SELECT * FROM x").df()
         y = pandas.DataFrame(
             [
                 [{'key': ['a', 'b', 'c', 'd'], 'value': [1, 3, 3, 7]}],
@@ -112,11 +112,11 @@ class TestResolveObjectColumns(object):
                 [{'key': ['a', 'b', 'c', 'd'], 'value': [1, 3, 3, 7]}],
             ]
         )
-        equal_df = duckdb.query_df(y, "y", "SELECT * FROM y").df()
+        equal_df = duckdb_cursor.sql("SELECT * FROM y").df()
         pandas.testing.assert_frame_equal(converted_df, equal_df)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_struct_value_upgrade(self, pandas):
+    def test_struct_value_upgrade(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [{'a': 1, 'b': 3, 'c': 3, 'd': 'string'}],
@@ -135,12 +135,12 @@ class TestResolveObjectColumns(object):
                 [{'a': 1, 'b': 3, 'c': 3, 'd': '7'}],
             ]
         )
-        converted_df = duckdb.query_df(x, "x", "SELECT * FROM x").df()
-        equal_df = duckdb.query_df(y, "y", "SELECT * FROM y").df()
+        converted_df = duckdb_cursor.sql("SELECT * FROM x").df()
+        equal_df = duckdb_cursor.sql("SELECT * FROM y").df()
         pandas.testing.assert_frame_equal(converted_df, equal_df)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_struct_null(self, pandas):
+    def test_struct_null(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [None],
@@ -159,12 +159,12 @@ class TestResolveObjectColumns(object):
                 [{'a': 1, 'b': 3, 'c': 3, 'd': 7}],
             ]
         )
-        converted_df = duckdb.query_df(x, "x", "SELECT * FROM x").df()
-        equal_df = duckdb.query_df(y, "y", "SELECT * FROM y").df()
+        converted_df = duckdb_cursor.sql("SELECT * FROM x").df()
+        equal_df = duckdb_cursor.sql("SELECT * FROM y").df()
         pandas.testing.assert_frame_equal(converted_df, equal_df)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_fallback_value_upgrade(self, pandas):
+    def test_map_fallback_value_upgrade(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [{'a': 1, 'b': 3, 'c': 3, 'd': 'test'}],
@@ -183,13 +183,12 @@ class TestResolveObjectColumns(object):
                 [{'a': '1', 'b': '3', 'c': '3', 'd': '7'}],
             ]
         )
-        converted_df = duckdb.query_df(x, "df", "SELECT * FROM df").df()
-        equal_df = duckdb.query_df(y, "df", "SELECT * FROM df").df()
+        converted_df = duckdb_cursor.sql("SELECT * FROM x").df()
+        equal_df = duckdb_cursor.sql("SELECT * FROM y").df()
         pandas.testing.assert_frame_equal(converted_df, equal_df)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_correct(self, pandas):
-        con = duckdb.connect()
+    def test_map_correct(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [{'key': ['a', 'b', 'c', 'd'], 'value': [1, 3, 3, 7]}],
@@ -200,8 +199,8 @@ class TestResolveObjectColumns(object):
             ]
         )
         x.rename(columns={0: 'a'}, inplace=True)
-        converted_col = duckdb.query_df(x, "x", "select * from x as 'a'", connection=con).df()
-        con.query(
+        converted_col = duckdb_cursor.sql("select * from x as 'a'").df()
+        duckdb_cursor.sql(
             """
             CREATE TABLE tmp(
                 a MAP(VARCHAR, INTEGER)
@@ -209,12 +208,12 @@ class TestResolveObjectColumns(object):
         """
         )
         for _ in range(5):
-            con.query(
+            duckdb_cursor.sql(
                 """
                 INSERT INTO tmp VALUES (MAP(['a', 'b', 'c', 'd'], [1, 3, 3, 7]))
             """
             )
-        duckdb_col = con.query("select a from tmp AS '0'").df()
+        duckdb_col = duckdb_cursor.sql("select a from tmp AS '0'").df()
         print(duckdb_col.columns)
         print(converted_col.columns)
         pandas.testing.assert_frame_equal(converted_col, duckdb_col)
@@ -232,8 +231,7 @@ class TestResolveObjectColumns(object):
         pandas.testing.assert_frame_equal(df1, df)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_value_upgrade(self, pandas):
-        con = duckdb.connect()
+    def test_map_value_upgrade(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [{'key': ['a', 'b', 'c', 'd'], 'value': [1, 3, 3, 'test']}],
@@ -244,64 +242,64 @@ class TestResolveObjectColumns(object):
             ]
         )
         x.rename(columns={0: 'a'}, inplace=True)
-        converted_col = duckdb.query_df(x, "x", "select * from x", connection=con).df()
-        con.query(
+        converted_col = duckdb_cursor.sql("select * from x").df()
+        duckdb_cursor.sql(
             """
             CREATE TABLE tmp2(
                 a MAP(VARCHAR, VARCHAR)
             );
         """
         )
-        con.query(
+        duckdb_cursor.sql(
             """
             INSERT INTO tmp2 VALUES (MAP(['a', 'b', 'c', 'd'], ['1', '3', '3', 'test']))
         """
         )
         for _ in range(4):
-            con.query(
+            duckdb_cursor.sql(
                 """
                 INSERT INTO tmp2 VALUES (MAP(['a', 'b', 'c', 'd'], ['1', '3', '3', '7']))
             """
             )
-        duckdb_col = con.query("select a from tmp2 AS '0'").df()
+        duckdb_col = duckdb_cursor.sql("select a from tmp2 AS '0'").df()
         print(duckdb_col.columns)
         print(converted_col.columns)
         pandas.testing.assert_frame_equal(converted_col, duckdb_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_duplicate(self, pandas):
+    def test_map_duplicate(self, pandas, duckdb_cursor):
         x = pandas.DataFrame([[{'key': ['a', 'a', 'b'], 'value': [4, 0, 4]}]])
         with pytest.raises(
             duckdb.InvalidInputException, match="Dict->Map conversion failed because 'key' list contains duplicates"
         ):
-            converted_col = duckdb.query_df(x, "x", "select * from x").df()
+            converted_col = duckdb_cursor.sql("select * from x").df()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_nullkey(self, pandas):
+    def test_map_nullkey(self, pandas, duckdb_cursor):
         x = pandas.DataFrame([[{'key': [None, 'a', 'b'], 'value': [4, 0, 4]}]])
         with pytest.raises(
             duckdb.InvalidInputException, match="Dict->Map conversion failed because 'key' list contains None"
         ):
-            converted_col = duckdb.query_df(x, "x", "select * from x").df()
+            converted_col = duckdb_cursor.sql("select * from x").df()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_nullkeylist(self, pandas):
+    def test_map_nullkeylist(self, pandas, duckdb_cursor):
         x = pandas.DataFrame([[{'key': None, 'value': None}]])
         # Isn't actually converted to MAP because isinstance(None, list) != True
-        converted_col = duckdb.query_df(x, "x", "select * from x").df()
-        duckdb_col = duckdb.query("SELECT {key: NULL, value: NULL} as '0'").df()
+        converted_col = duckdb_cursor.sql("select * from x").df()
+        duckdb_col = duckdb_cursor.sql("SELECT {key: NULL, value: NULL} as '0'").df()
         pandas.testing.assert_frame_equal(duckdb_col, converted_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_fallback_nullkey(self, pandas):
+    def test_map_fallback_nullkey(self, pandas, duckdb_cursor):
         x = pandas.DataFrame([[{'a': 4, None: 0, 'c': 4}], [{'a': 4, None: 0, 'd': 4}]])
         with pytest.raises(
             duckdb.InvalidInputException, match="Dict->Map conversion failed because 'key' list contains None"
         ):
-            converted_col = duckdb.query_df(x, "x", "select * from x").df()
+            converted_col = duckdb_cursor.sql("select * from x").df()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_map_fallback_nullkey_coverage(self, pandas):
+    def test_map_fallback_nullkey_coverage(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [{'key': None, 'value': None}],
@@ -311,55 +309,54 @@ class TestResolveObjectColumns(object):
         with pytest.raises(
             duckdb.InvalidInputException, match="Dict->Map conversion failed because 'key' list contains None"
         ):
-            converted_col = duckdb.query_df(x, "x", "select * from x").df()
+            converted_col = duckdb_cursor.sql("select * from x").df()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_struct_key_conversion(self, pandas):
+    def test_struct_key_conversion(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [{IntString(5): 1, IntString(-25): 3, IntString(32): 3, IntString(32456): 7}],
             ]
         )
-        duckdb_col = duckdb.query("select {'5':1, '-25':3, '32':3, '32456':7} as '0'").df()
-        converted_col = duckdb.query_df(x, "tbl", "select * from tbl").df()
-        duckdb.query("drop view if exists tbl")
+        duckdb_col = duckdb_cursor.sql("select {'5':1, '-25':3, '32':3, '32456':7} as '0'").df()
+        converted_col = duckdb_cursor.sql("select * from x").df()
+        duckdb_cursor.sql("drop view if exists tbl")
         pandas.testing.assert_frame_equal(duckdb_col, converted_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_list_correct(self, pandas):
+    def test_list_correct(self, pandas, duckdb_cursor):
         x = pandas.DataFrame([{'0': [[5], [34], [-245]]}])
-        duckdb_col = duckdb.query("select [[5], [34], [-245]] as '0'").df()
-        converted_col = duckdb.query_df(x, "tbl", "select * from tbl").df()
-        duckdb.query("drop view if exists tbl")
+        duckdb_col = duckdb_cursor.sql("select [[5], [34], [-245]] as '0'").df()
+        converted_col = duckdb_cursor.sql("select * from x").df()
+        duckdb_cursor.sql("drop view if exists tbl")
         pandas.testing.assert_frame_equal(duckdb_col, converted_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_list_contains_null(self, pandas):
+    def test_list_contains_null(self, pandas, duckdb_cursor):
         x = pandas.DataFrame([{'0': [[5], None, [-245]]}])
-        duckdb_col = duckdb.query("select [[5], NULL, [-245]] as '0'").df()
-        converted_col = duckdb.query_df(x, "tbl", "select * from tbl").df()
-        duckdb.query("drop view if exists tbl")
+        duckdb_col = duckdb_cursor.sql("select [[5], NULL, [-245]] as '0'").df()
+        converted_col = duckdb_cursor.sql("select * from x").df()
+        duckdb_cursor.sql("drop view if exists tbl")
         pandas.testing.assert_frame_equal(duckdb_col, converted_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_list_starts_with_null(self, pandas):
+    def test_list_starts_with_null(self, pandas, duckdb_cursor):
         x = pandas.DataFrame([{'0': [None, [5], [-245]]}])
-        duckdb_col = duckdb.query("select [NULL, [5], [-245]] as '0'").df()
-        converted_col = duckdb.query_df(x, "tbl", "select * from tbl").df()
-        duckdb.query("drop view if exists tbl")
+        duckdb_col = duckdb_cursor.sql("select [NULL, [5], [-245]] as '0'").df()
+        converted_col = duckdb_cursor.sql("select * from x").df()
+        duckdb_cursor.sql("drop view if exists tbl")
         pandas.testing.assert_frame_equal(duckdb_col, converted_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_list_value_upgrade(self, pandas):
+    def test_list_value_upgrade(self, pandas, duckdb_cursor):
         x = pandas.DataFrame([{'0': [['5'], [34], [-245]]}])
-        duckdb_col = duckdb.query("select [['5'], ['34'], ['-245']] as '0'").df()
-        converted_col = duckdb.query_df(x, "tbl", "select * from tbl").df()
-        duckdb.query("drop view if exists tbl")
+        duckdb_col = duckdb_cursor.sql("select [['5'], ['34'], ['-245']] as '0'").df()
+        converted_col = duckdb_cursor.sql("select * from x").df()
+        duckdb_cursor.sql("drop view if exists tbl")
         pandas.testing.assert_frame_equal(duckdb_col, converted_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_list_column_value_upgrade(self, pandas):
-        con = duckdb.connect()
+    def test_list_column_value_upgrade(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [[1, 25, 300]],
@@ -368,41 +365,41 @@ class TestResolveObjectColumns(object):
             ]
         )
         x.rename(columns={0: 'a'}, inplace=True)
-        converted_col = duckdb.query_df(x, "x", "select * from x", connection=con).df()
-        con.query(
+        converted_col = duckdb_cursor.sql("select * from x").df()
+        duckdb_cursor.sql(
             """
             CREATE TABLE tmp3(
                 a VARCHAR[]
             );
         """
         )
-        con.query(
+        duckdb_cursor.sql(
             """
             INSERT INTO tmp3 VALUES (['1', '25', '300'])
         """
         )
-        con.query(
+        duckdb_cursor.sql(
             """
             INSERT INTO tmp3 VALUES (['500', '345', '30'])
         """
         )
-        con.query(
+        duckdb_cursor.sql(
             """
             INSERT INTO tmp3 VALUES (['50', 'a', '67'])
         """
         )
-        duckdb_col = con.query("select a from tmp3 AS '0'").df()
+        duckdb_col = duckdb_cursor.sql("select a from tmp3 AS '0'").df()
         print(duckdb_col.columns)
         print(converted_col.columns)
         pandas.testing.assert_frame_equal(converted_col, duckdb_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_ubigint_object_conversion(self, pandas):
+    def test_ubigint_object_conversion(self, pandas, duckdb_cursor):
         # UBIGINT + TINYINT would result in HUGEINT, but conversion to HUGEINT is not supported yet from pandas->duckdb
         # So this instead becomes a DOUBLE
         data = [18446744073709551615, 0]
         x = pandas.DataFrame({'0': pandas.Series(data=data, dtype='object')})
-        converted_col = duckdb.query_df(x, "x", "select * from x").df()
+        converted_col = duckdb_cursor.sql("select * from x").df()
         if pandas.backend == 'numpy_nullable':
             float64 = np.dtype('float64')
             assert isinstance(converted_col['0'].dtype, float64.__class__) == True
@@ -411,16 +408,15 @@ class TestResolveObjectColumns(object):
             assert isinstance(converted_col['0'].dtype, uint64.__class__) == True
 
     @pytest.mark.parametrize('pandas', [NumpyPandas()])
-    def test_double_object_conversion(self, pandas):
+    def test_double_object_conversion(self, pandas, duckdb_cursor):
         data = [18446744073709551616, 0]
         x = pandas.DataFrame({'0': pandas.Series(data=data, dtype='object')})
-        converted_col = duckdb.query_df(x, "x", "select * from x").df()
+        converted_col = duckdb_cursor.sql("select * from x").df()
         double_dtype = np.dtype('float64')
         assert isinstance(converted_col['0'].dtype, double_dtype.__class__) == True
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numpy_object_with_stride(self, pandas):
-        con = duckdb.connect()
+    def test_numpy_object_with_stride(self, pandas, duckdb_cursor):
         df = pandas.DataFrame(columns=["idx", "evens", "zeros"])
 
         df["idx"] = list(range(10))
@@ -432,7 +428,7 @@ class TestResolveObjectColumns(object):
             df.loc[df["idx"] == i, "evens"] += counter
             counter += 2
 
-        res = con.sql("select * from df").fetchall()
+        res = duckdb_cursor.sql("select * from df").fetchall()
         assert res == [
             (0, 0, 0),
             (1, 2, 0),
@@ -447,18 +443,17 @@ class TestResolveObjectColumns(object):
         ]
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numpy_stringliterals(self, pandas):
-        con = duckdb.connect()
+    def test_numpy_stringliterals(self, pandas, duckdb_cursor):
         df = pandas.DataFrame({"x": list(map(np.str_, range(3)))})
 
-        res = con.execute("select * from df").fetchall()
+        res = duckdb_cursor.execute("select * from df").fetchall()
         assert res == [('0',), ('1',), ('2',)]
 
     @pytest.mark.parametrize('pandas', [NumpyPandas()])
-    def test_integer_conversion_fail(self, pandas):
+    def test_integer_conversion_fail(self, pandas, duckdb_cursor):
         data = [2**10000, 0]
         x = pandas.DataFrame({'0': pandas.Series(data=data, dtype='object')})
-        converted_col = duckdb.query_df(x, "x", "select * from x").df()
+        converted_col = duckdb_cursor.sql("select * from x").df()
         print(converted_col['0'])
         double_dtype = np.dtype('object')
         assert isinstance(converted_col['0'].dtype, double_dtype.__class__) == True
@@ -467,7 +462,7 @@ class TestResolveObjectColumns(object):
     # But to support arbitrary precision, it can fall back to using an `int` internally
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])  # Which we don't support yet
-    def test_numpy_datetime(self, pandas):
+    def test_numpy_datetime(self, pandas, duckdb_cursor):
         numpy = pytest.importorskip("numpy")
 
         data = []
@@ -476,11 +471,11 @@ class TestResolveObjectColumns(object):
         data += [numpy.datetime64('1974-06-05T13:12:01.000000')] * standard_vector_size
         data += [numpy.datetime64('2049-01-13T00:24:31.999999')] * standard_vector_size
         x = pandas.DataFrame({'dates': pandas.Series(data=data, dtype='object')})
-        res = duckdb.query_df(x, "x", "select distinct * from x").df()
+        res = duckdb_cursor.sql("select distinct * from x").df()
         assert len(res['dates'].__array__()) == 4
 
     @pytest.mark.parametrize('pandas', [NumpyPandas()])
-    def test_numpy_datetime_int_internally(self, pandas):
+    def test_numpy_datetime_int_internally(self, pandas, duckdb_cursor):
         numpy = pytest.importorskip("numpy")
 
         data = [numpy.datetime64('2022-12-10T21:38:24.0000000000001')]
@@ -492,7 +487,7 @@ class TestResolveObjectColumns(object):
             rel = duckdb.query_df(x, "x", "create table dates as select dates::TIMESTAMP WITHOUT TIME ZONE from x")
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_fallthrough_object_conversion(self, pandas):
+    def test_fallthrough_object_conversion(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 [IntString(4)],
@@ -500,14 +495,12 @@ class TestResolveObjectColumns(object):
                 [IntString(0)],
             ]
         )
-        duckdb_col = duckdb.query_df(x, "x", "select * from x").df()
+        duckdb_col = duckdb_cursor.sql("select * from x").df()
         df_expected_res = pandas.DataFrame({'0': pandas.Series(['4', '2', '0'])})
         pandas.testing.assert_frame_equal(duckdb_col, df_expected_res)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numeric_decimal(self, pandas):
-        duckdb_conn = duckdb.connect()
-
+    def test_numeric_decimal(self, pandas, duckdb_cursor):
         # DuckDB uses DECIMAL where possible, so all the 'float' types here are actually DECIMAL
         reference_query = """
             CREATE TABLE tbl AS SELECT * FROM (
@@ -520,7 +513,7 @@ class TestResolveObjectColumns(object):
                 (1.234,               -324234234,               1324234359)
             ) tbl(a, b, c);
         """
-        duckdb_conn.execute(reference_query)
+        duckdb_cursor.execute(reference_query)
         # Because of this we need to wrap these native floats as DECIMAL for this test, to avoid these decimals being "upgraded" to DOUBLE
         x = pandas.DataFrame(
             {
@@ -533,19 +526,17 @@ class TestResolveObjectColumns(object):
                 ),
             }
         )
-        reference = duckdb.query("select * from tbl", connection=duckdb_conn).fetchall()
-        conversion = duckdb.query_df(x, "x", "select * from x").fetchall()
+        reference = duckdb_cursor.sql("select * from tbl").fetchall()
+        conversion = duckdb_cursor.sql("select * from x").fetchall()
 
         assert conversion == reference
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numeric_decimal_coverage(self, pandas):
-        duckdb_conn = duckdb.connect()
-
+    def test_numeric_decimal_coverage(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             {'0': [Decimal("nan"), Decimal("+nan"), Decimal("-nan"), Decimal("inf"), Decimal("+inf"), Decimal("-inf")]}
         )
-        conversion = duckdb.query_df(x, "x", "select * from x").fetchall()
+        conversion = duckdb_cursor.sql("select * from x").fetchall()
         print(conversion[0][0].__class__)
         for item in conversion:
             assert isinstance(item[0], float)
@@ -562,14 +553,14 @@ class TestResolveObjectColumns(object):
     @pytest.mark.parametrize(
         'pandas', [NumpyPandas(), ArrowPandas()]
     )  # and that the same 2048 (STANDARD_VECTOR_SIZE) values are not being scanned over and over again
-    def test_multiple_chunks(self, pandas):
+    def test_multiple_chunks(self, pandas, duckdb_cursor):
         data = []
         data += [datetime.date(2022, 9, 13) for x in range(standard_vector_size)]
         data += [datetime.date(2022, 9, 14) for x in range(standard_vector_size)]
         data += [datetime.date(2022, 9, 15) for x in range(standard_vector_size)]
         data += [datetime.date(2022, 9, 16) for x in range(standard_vector_size)]
         x = pandas.DataFrame({'dates': pandas.Series(data=data, dtype='object')})
-        res = duckdb.query_df(x, "x", "select distinct * from x").df()
+        res = duckdb_cursor.sql("select distinct * from x").df()
         assert len(res['dates'].__array__()) == 4
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
@@ -578,7 +569,7 @@ class TestResolveObjectColumns(object):
         duckdb_cursor.execute(
             "create table dates as select '2022-09-14'::DATE + INTERVAL (i::INTEGER) DAY as i from range(4096) tbl(i);"
         )
-        rel = duckdb_cursor.query("select * from dates")
+        rel = duckdb_cursor.sql("select * from dates")
         res = rel.df()
         date_df = res.copy()
 
@@ -594,7 +585,7 @@ class TestResolveObjectColumns(object):
             )
         ]
 
-        rel = duckdb_cursor.query(
+        rel = duckdb_cursor.sql(
             """
             select
                 avg(epoch(i)),
@@ -624,7 +615,7 @@ class TestResolveObjectColumns(object):
         date_df['i'] = pandas.to_datetime(res['i']).dt.date
         assert str(date_df['i'].dtype) == 'object'
 
-        actual_res = duckdb_cursor.query(
+        actual_res = duckdb_cursor.sql(
             """
             select
                 avg(epoch(i)),
@@ -637,7 +628,7 @@ class TestResolveObjectColumns(object):
         assert expected_res == actual_res
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_mixed_object_types(self, pandas):
+    def test_mixed_object_types(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             {
                 'nested': pandas.Series(
@@ -645,11 +636,11 @@ class TestResolveObjectColumns(object):
                 ),
             }
         )
-        res = duckdb.query_df(x, "x", "select * from x").df()
+        res = duckdb_cursor.sql("select * from x").df()
         assert res['nested'].dtype == np.dtype('object')
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_struct_deeply_nested_in_struct(self, pandas):
+    def test_struct_deeply_nested_in_struct(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             [
                 {
@@ -664,12 +655,11 @@ class TestResolveObjectColumns(object):
         )
         # The dataframe has incompatible struct schemas in the nested child
         # This gets upgraded to STRUCT(b MAP(VARCHAR, VARCHAR))
-        con = duckdb.connect()
-        res = con.sql("select * from x").fetchall()
+        res = duckdb_cursor.sql("select * from x").fetchall()
         assert res == [({'b': {'key': ['x', 'y'], 'value': ['A', 'B']}},), ({'b': {'key': ['x'], 'value': ['A']}},)]
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_struct_deeply_nested_in_list(self, pandas):
+    def test_struct_deeply_nested_in_list(self, pandas, duckdb_cursor):
         x = pandas.DataFrame(
             {
                 'a': [
@@ -684,20 +674,18 @@ class TestResolveObjectColumns(object):
         )
         # The dataframe has incompatible struct schemas in the nested child
         # This gets upgraded to STRUCT(b MAP(VARCHAR, VARCHAR))
-        con = duckdb.connect()
-        res = con.sql("select * from x").fetchall()
+        res = duckdb_cursor.sql("select * from x").fetchall()
         assert res == [([{'key': ['x', 'y'], 'value': ['A', 'B']}, {'key': ['x'], 'value': ['A']}],)]
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_analyze_sample_too_small(self, pandas):
+    def test_analyze_sample_too_small(self, pandas, duckdb_cursor):
         data = [1 for _ in range(9)] + [[1, 2, 3]] + [1 for _ in range(9991)]
         x = pandas.DataFrame({'a': pandas.Series(data=data)})
         with pytest.raises(duckdb.InvalidInputException, match="Failed to cast value: Unimplemented type for cast"):
-            res = duckdb.query_df(x, "x", "select * from x").df()
+            res = duckdb_cursor.sql("select * from x").df()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numeric_decimal_zero_fractional(self, pandas):
-        duckdb_conn = duckdb.connect()
+    def test_numeric_decimal_zero_fractional(self, pandas, duckdb_cursor):
         decimals = pandas.DataFrame(
             data={
                 "0": [
@@ -723,15 +711,14 @@ class TestResolveObjectColumns(object):
                 (321.00)
             ) tbl(a);
         """
-        duckdb_conn.execute(reference_query)
-        reference = duckdb.query("select * from tbl", connection=duckdb_conn).fetchall()
+        duckdb_cursor.execute(reference_query)
+        reference = duckdb_cursor.sql("select * from tbl").fetchall()
         conversion = duckdb.query_df(decimals, "x", "select * from x").fetchall()
 
         assert conversion == reference
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numeric_decimal_incompatible(self, pandas):
-        duckdb_conn = duckdb.connect()
+    def test_numeric_decimal_incompatible(self, pandas, duckdb_cursor):
         reference_query = """
             CREATE TABLE tbl AS SELECT * FROM (
                 VALUES
@@ -743,7 +730,7 @@ class TestResolveObjectColumns(object):
                 (1.234,               -324234234,               1324234359)
             ) tbl(a, b, c);
         """
-        duckdb_conn.execute(reference_query)
+        duckdb_cursor.execute(reference_query)
         x = pandas.DataFrame(
             {
                 '0': ConvertStringToDecimal(['5', '12.0', '-123.0', '-234234.0', None, '1.234'], pandas),
@@ -753,8 +740,8 @@ class TestResolveObjectColumns(object):
                 ),
             }
         )
-        reference = duckdb.query("select * from tbl", connection=duckdb_conn).fetchall()
-        conversion = duckdb.query_df(x, "x", "select * from x").fetchall()
+        reference = duckdb_cursor.sql("select * from tbl").fetchall()
+        conversion = duckdb_cursor.sql("select * from x").fetchall()
 
         assert conversion == reference
         print(reference)
@@ -763,8 +750,7 @@ class TestResolveObjectColumns(object):
     @pytest.mark.parametrize(
         'pandas', [NumpyPandas(), ArrowPandas()]
     )  # result: [('1E-28',), ('10000000000000000000000000.0',)]
-    def test_numeric_decimal_combined(self, pandas):
-        duckdb_conn = duckdb.connect()
+    def test_numeric_decimal_combined(self, pandas, duckdb_cursor):
         decimals = pandas.DataFrame(
             data={"0": [Decimal("0.0000000000000000000000000001"), Decimal("10000000000000000000000000.0")]}
         )
@@ -775,8 +761,8 @@ class TestResolveObjectColumns(object):
                 (10000000000000000000000000.0),
             ) tbl(a);
         """
-        duckdb_conn.execute(reference_query)
-        reference = duckdb.query("select * from tbl", connection=duckdb_conn).fetchall()
+        duckdb_cursor.execute(reference_query)
+        reference = duckdb_cursor.sql("select * from tbl").fetchall()
         conversion = duckdb.query_df(decimals, "x", "select * from x").fetchall()
         assert conversion == reference
         print(reference)
@@ -784,8 +770,7 @@ class TestResolveObjectColumns(object):
 
     # result: [('1234.0',), ('123456789.0',), ('1234567890123456789.0',), ('0.1234567890123456789',)]
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numeric_decimal_varying_sizes(self, pandas):
-        duckdb_conn = duckdb.connect()
+    def test_numeric_decimal_varying_sizes(self, pandas, duckdb_cursor):
         decimals = pandas.DataFrame(
             data={
                 "0": [
@@ -805,16 +790,15 @@ class TestResolveObjectColumns(object):
                     (0.1234567890123456789)
             ) tbl(a);
         """
-        duckdb_conn.execute(reference_query)
-        reference = duckdb.query("select * from tbl", connection=duckdb_conn).fetchall()
+        duckdb_cursor.execute(reference_query)
+        reference = duckdb_cursor.sql("select * from tbl").fetchall()
         conversion = duckdb.query_df(decimals, "x", "select * from x").fetchall()
         assert conversion == reference
         print(reference)
         print(conversion)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numeric_decimal_fallback_to_double(self, pandas):
-        duckdb_conn = duckdb.connect()
+    def test_numeric_decimal_fallback_to_double(self, pandas, duckdb_cursor):
         # The widths of these decimal values are bigger than the max supported width for DECIMAL
         data = [
             Decimal("1.234567890123456789012345678901234567890123456789"),
@@ -828,15 +812,14 @@ class TestResolveObjectColumns(object):
                     (123456789012345678901234567890123456789012345678.0)
             ) tbl(a);
         """
-        duckdb_conn.execute(reference_query)
-        reference = duckdb.query("select * from tbl", connection=duckdb_conn).fetchall()
+        duckdb_cursor.execute(reference_query)
+        reference = duckdb_cursor.sql("select * from tbl").fetchall()
         conversion = duckdb.query_df(decimals, "x", "select * from x").fetchall()
         assert conversion == reference
         assert isinstance(conversion[0][0], float)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numeric_decimal_double_mixed(self, pandas):
-        duckdb_conn = duckdb.connect()
+    def test_numeric_decimal_double_mixed(self, pandas, duckdb_cursor):
         data = [
             Decimal("1.234"),
             Decimal("1.234567891234567890123456789012345678901234567890123456789"),
@@ -861,15 +844,14 @@ class TestResolveObjectColumns(object):
                     (123.5e300)
             ) tbl(a);
         """
-        duckdb_conn.execute(reference_query)
-        reference = duckdb.query("select * from tbl", connection=duckdb_conn).fetchall()
-        conversion = duckdb.query_df(decimals, "x", "select * from x").fetchall()
+        duckdb_cursor.execute(reference_query)
+        reference = duckdb_cursor.sql("select * from tbl").fetchall()
+        conversion = duckdb_cursor.sql("select * from decimals").fetchall()
         assert conversion == reference
         assert isinstance(conversion[0][0], float)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_numeric_decimal_out_of_range(self, pandas):
-        duckdb_conn = duckdb.connect()
+    def test_numeric_decimal_out_of_range(self, pandas, duckdb_cursor):
         data = [Decimal("1.234567890123456789012345678901234567"), Decimal("123456789012345678901234567890123456.0")]
         decimals = pandas.DataFrame(data={"0": data})
         reference_query = """
@@ -879,7 +861,7 @@ class TestResolveObjectColumns(object):
                     (123456789012345678901234567890123456.0)
             ) tbl(a);
         """
-        duckdb_conn.execute(reference_query)
-        reference = duckdb.query("select * from tbl", connection=duckdb_conn).fetchall()
-        conversion = duckdb.query_df(decimals, "x", "select * from x").fetchall()
+        duckdb_cursor.execute(reference_query)
+        reference = duckdb_cursor.sql("select * from tbl").fetchall()
+        conversion = duckdb_cursor.sql("select * from decimals").fetchall()
         assert conversion == reference

--- a/tools/pythonpkg/tests/fast/pandas/test_df_recursive_nested.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_recursive_nested.py
@@ -8,12 +8,12 @@ from conftest import NumpyPandas, ArrowPandas
 NULL = None
 
 
-def check_equal(df, reference_query):
+def check_equal(conn, df, reference_query):
     duckdb_conn = duckdb.connect()
     duckdb_conn.execute(reference_query)
-    res = duckdb.query('SELECT * FROM tbl', connection=duckdb_conn).fetchall()
-    df_res = duckdb.query('SELECT * FROM tbl', connection=duckdb_conn).df()
-    out = duckdb.query_df(df, 'x', "SELECT * FROM x").fetchall()
+    res = duckdb_conn.query('SELECT * FROM tbl').fetchall()
+    df_res = duckdb_conn.query('SELECT * FROM tbl').df()
+    out = conn.sql("SELECT * FROM df").fetchall()
     assert res == out
 
 
@@ -28,7 +28,7 @@ class TestDFRecursiveNested(object):
         data = [[{'a': 5}, NULL, {'a': NULL}], NULL, [{'a': 5}, NULL, {'a': NULL}]]
         reference_query = create_reference_query(data)
         df = pandas.DataFrame([{'a': data}])
-        check_equal(df, reference_query)
+        check_equal(duckdb_cursor, df, reference_query)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_list_of_map(self, duckdb_cursor, pandas):
@@ -49,7 +49,7 @@ class TestDFRecursiveNested(object):
         ]
         reference_query = create_reference_query(reference_data)
         df = pandas.DataFrame([{'a': data}])
-        check_equal(df, reference_query)
+        check_equal(duckdb_cursor, df, reference_query)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_recursive_list(self, duckdb_cursor, pandas):
@@ -57,7 +57,7 @@ class TestDFRecursiveNested(object):
         data = [[[[3, NULL, 5], NULL], NULL, [[5, -20, NULL]]], NULL, [[[NULL]], [[]], NULL]]
         reference_query = create_reference_query(data)
         df = pandas.DataFrame([{'a': data}])
-        check_equal(df, reference_query)
+        check_equal(duckdb_cursor, df, reference_query)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_recursive_struct(self, duckdb_cursor, pandas):
@@ -68,7 +68,7 @@ class TestDFRecursiveNested(object):
         }
         reference_query = create_reference_query(data)
         df = pandas.DataFrame([{'a': data}])
-        check_equal(df, reference_query)
+        check_equal(duckdb_cursor, df, reference_query)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_recursive_map(self, duckdb_cursor, pandas):
@@ -88,7 +88,7 @@ class TestDFRecursiveNested(object):
         }
         reference_query = create_reference_query(data)
         df = pandas.DataFrame([{'a': data}])
-        check_equal(df, reference_query)
+        check_equal(duckdb_cursor, df, reference_query)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_recursive_stresstest(self, duckdb_cursor, pandas):
@@ -123,4 +123,4 @@ class TestDFRecursiveNested(object):
         ]
         reference_query = create_reference_query(data)
         df = pandas.DataFrame([{'a': data}])
-        check_equal(df, reference_query)
+        check_equal(duckdb_cursor, df, reference_query)

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
@@ -37,7 +37,7 @@ class TestPandasObject(object):
 
     def test_2273(self, duckdb_cursor):
         df_in = pd.DataFrame([[datetime.date(1992, 7, 30)]])
-        assert duckdb.query("Select * from df_in").fetchall() == [(datetime.date(1992, 7, 30),)]
+        assert duckdb_cursor.query("Select * from df_in").fetchall() == [(datetime.date(1992, 7, 30),)]
 
     def test_object_to_string_with_stride(self, duckdb_cursor):
         data = np.array([["a", "b", "c"], [1, 2, 3], [1, 2, 3], [11, 22, 33]])

--- a/tools/pythonpkg/tests/fast/pandas/test_timedelta.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_timedelta.py
@@ -7,30 +7,30 @@ import pytest
 
 class TestTimedelta(object):
     def test_timedelta_positive(self, duckdb_cursor):
-        duckdb_interval = duckdb.query(
+        duckdb_interval = duckdb_cursor.query(
             "SELECT '2290-01-01 23:59:00'::TIMESTAMP - '2000-01-01 23:59:00'::TIMESTAMP AS '0'"
         ).df()
         data = [datetime.timedelta(microseconds=9151574400000000)]
         df_in = pd.DataFrame({0: pd.Series(data=data, dtype='object')})
-        df_out = duckdb.query_df(df_in, "df", "select * from df").df()
+        df_out = duckdb.query_df(df_in, "df", "select * from df", connection=duckdb_cursor).df()
         pd.testing.assert_frame_equal(df_out, duckdb_interval)
 
     def test_timedelta_basic(self, duckdb_cursor):
-        duckdb_interval = duckdb.query(
+        duckdb_interval = duckdb_cursor.query(
             "SELECT '2290-08-30 23:53:40'::TIMESTAMP - '2000-02-01 01:56:00'::TIMESTAMP AS '0'"
         ).df()
         data = [datetime.timedelta(microseconds=9169797460000000)]
         df_in = pd.DataFrame({0: pd.Series(data=data, dtype='object')})
-        df_out = duckdb.query_df(df_in, "df", "select * from df").df()
+        df_out = duckdb.query_df(df_in, "df", "select * from df", connection=duckdb_cursor).df()
         pd.testing.assert_frame_equal(df_out, duckdb_interval)
 
     def test_timedelta_negative(self, duckdb_cursor):
-        duckdb_interval = duckdb.query(
+        duckdb_interval = duckdb_cursor.query(
             "SELECT '2000-01-01 23:59:00'::TIMESTAMP - '2290-01-01 23:59:00'::TIMESTAMP AS '0'"
         ).df()
         data = [datetime.timedelta(microseconds=-9151574400000000)]
         df_in = pd.DataFrame({0: pd.Series(data=data, dtype='object')})
-        df_out = duckdb.query_df(df_in, "df", "select * from df").df()
+        df_out = duckdb.query_df(df_in, "df", "select * from df", connection=duckdb_cursor).df()
         pd.testing.assert_frame_equal(df_out, duckdb_interval)
 
     @pytest.mark.parametrize('days', [1, 9999])

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_description.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_description.py
@@ -3,25 +3,25 @@ import pytest
 
 
 class TestRAPIDescription(object):
-    def test_rapi_description(self):
-        res = duckdb.query('select 42::INT AS a, 84::BIGINT AS b')
+    def test_rapi_description(self, duckdb_cursor):
+        res = duckdb_cursor.query('select 42::INT AS a, 84::BIGINT AS b')
         desc = res.description
         names = [x[0] for x in desc]
         types = [x[1] for x in desc]
         assert names == ['a', 'b']
         assert types == ['NUMBER', 'NUMBER']
 
-    def test_rapi_describe(self):
+    def test_rapi_describe(self, duckdb_cursor):
         np = pytest.importorskip("numpy")
         pd = pytest.importorskip("pandas")
-        res = duckdb.query('select 42::INT AS a, 84::BIGINT AS b')
+        res = duckdb_cursor.query('select 42::INT AS a, 84::BIGINT AS b')
         duck_describe = res.describe().df()
         np.testing.assert_array_equal(duck_describe['aggr'], ['count', 'mean', 'stddev', 'min', 'max', 'median'])
         np.testing.assert_array_equal(duck_describe['a'], [1, 42, float('nan'), 42, 42, 42])
         np.testing.assert_array_equal(duck_describe['b'], [1, 84, float('nan'), 84, 84, 84])
 
         # now with more values
-        res = duckdb.query(
+        res = duckdb_cursor.query(
             'select CASE WHEN i%2=0 THEN i ELSE NULL END AS i, i * 10 AS j, (i * 23 // 27)::DOUBLE AS k FROM range(10000) t(i)'
         )
         duck_describe = res.describe().df()
@@ -30,22 +30,22 @@ class TestRAPIDescription(object):
         np.testing.assert_allclose(duck_describe['k'], [10000.0, 4258.3518, 2459.207430770227, 0.0, 8517.0, 4258.5])
 
         # describe data with other (non-numeric) types
-        res = duckdb.query("select 'hello world' AS a, [1, 2, 3] AS b")
+        res = duckdb_cursor.query("select 'hello world' AS a, [1, 2, 3] AS b")
         duck_describe = res.describe().df()
         assert len(duck_describe) > 0
 
         # describe mixed table
-        res = duckdb.query("select 42::INT AS a, 84::BIGINT AS b, 'hello world' AS c")
+        res = duckdb_cursor.query("select 42::INT AS a, 84::BIGINT AS b, 'hello world' AS c")
         duck_describe = res.describe().df()
         np.testing.assert_array_equal(duck_describe['a'], [1, 42, float('nan'), 42, 42, 42])
         np.testing.assert_array_equal(duck_describe['b'], [1, 84, float('nan'), 84, 84, 84])
 
         # timestamps
-        res = duckdb.query("select timestamp '1992-01-01', date '2000-01-01'")
+        res = duckdb_cursor.query("select timestamp '1992-01-01', date '2000-01-01'")
         duck_describe = res.describe().df()
         assert len(duck_describe) > 0
 
         # describe empty result
-        res = duckdb.query("select 42 AS a LIMIT 0")
+        res = duckdb_cursor.query("select 42 AS a LIMIT 0")
         duck_describe = res.describe().df()
         assert len(duck_describe) > 0

--- a/tools/pythonpkg/tests/fast/relational_api/test_rapi_functions.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_rapi_functions.py
@@ -2,8 +2,8 @@ import duckdb
 
 
 class TestRAPIFunctions(object):
-    def test_rapi_str_print(self):
-        res = duckdb.query('select 42::INT AS a, 84::BIGINT AS b')
+    def test_rapi_str_print(self, duckdb_cursor):
+        res = duckdb_cursor.query('select 42::INT AS a, 84::BIGINT AS b')
         assert str(res) is not None
         res.show()
 

--- a/tools/pythonpkg/tests/fast/spark/test_spark_readjson.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_readjson.py
@@ -8,10 +8,10 @@ import duckdb
 
 
 class TestSparkReadJson(object):
-    def test_read_json(self, spark, tmp_path):
+    def test_read_json(self, duckdb_cursor, spark, tmp_path):
         file_path = tmp_path / 'basic.parquet'
         file_path = file_path.as_posix()
-        duckdb.execute(f"COPY (select 42 a, true b, 'this is a long string' c) to '{file_path}' (FORMAT JSON)")
+        duckdb_cursor.execute(f"COPY (select 42 a, true b, 'this is a long string' c) to '{file_path}' (FORMAT JSON)")
         df = spark.read.json(file_path)
         res = df.collect()
         assert res == [Row(a=42, b=True, c='this is a long string')]

--- a/tools/pythonpkg/tests/fast/spark/test_spark_readparquet.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_readparquet.py
@@ -8,10 +8,12 @@ import duckdb
 
 
 class TestSparkReadParquet(object):
-    def test_read_parquet(self, spark, tmp_path):
+    def test_read_parquet(self, duckdb_cursor, spark, tmp_path):
         file_path = tmp_path / 'basic.parquet'
         file_path = file_path.as_posix()
-        duckdb.execute(f"COPY (select 42 a, true b, 'this is a long string' c) to '{file_path}' (FORMAT PARQUET)")
+        duckdb_cursor.execute(
+            f"COPY (select 42 a, true b, 'this is a long string' c) to '{file_path}' (FORMAT PARQUET)"
+        )
         df = spark.read.parquet(file_path)
         res = df.collect()
         assert res == [Row(a=42, b=True, c='this is a long string')]

--- a/tools/pythonpkg/tests/fast/test_memory_leaks.py
+++ b/tools/pythonpkg/tests/fast/test_memory_leaks.py
@@ -20,9 +20,9 @@ def check_leaks():
 
 
 class TestMemoryLeaks(object):
-    def test_fetchmany(self, check_leaks):
+    def test_fetchmany(self, duckdb_cursor, check_leaks):
         datetimes = ['1985-01-30T16:41:43' for _ in range(10000)]
 
         df = pd.DataFrame({'time': pd.Series(data=datetimes)})
         for _ in range(100):
-            duckdb.sql('select time::TIMESTAMP from df').fetchmany(10000)
+            duckdb_cursor.sql('select time::TIMESTAMP from df').fetchmany(10000)

--- a/tools/pythonpkg/tests/fast/test_non_default_conn.py
+++ b/tools/pythonpkg/tests/fast/test_non_default_conn.py
@@ -7,26 +7,23 @@ import tempfile
 
 class TestNonDefaultConn(object):
     def test_values(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        duckdb.values([1], conn).insert_into("t")
-        assert conn.execute("select count(*) from t").fetchall()[0] == (1,)
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb.values([1], duckdb_cursor).insert_into("t")
+        assert duckdb_cursor.execute("select count(*) from t").fetchall()[0] == (1,)
 
     def test_query(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1)")
-        assert duckdb.query("select count(*) from t", connection=conn).execute().fetchall()[0] == (1,)
-        assert duckdb.from_query("select count(*) from t", connection=conn).execute().fetchall()[0] == (1,)
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1)")
+        assert duckdb_cursor.query("select count(*) from t").execute().fetchall()[0] == (1,)
+        assert duckdb_cursor.from_query("select count(*) from t").execute().fetchall()[0] == (1,)
 
     def test_from_csv(self, duckdb_cursor):
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4]})
         test_df.to_csv(temp_file_name, index=False)
-        rel = duckdb.from_csv_auto(temp_file_name, conn)
+        rel = duckdb_cursor.from_csv_auto(temp_file_name)
         assert rel.query('t_2', 'select count(*) from t inner join t_2 on (a = i)').fetchall()[0] == (1,)
 
     def test_from_parquet(self, duckdb_cursor):
@@ -35,22 +32,20 @@ class TestNonDefaultConn(object):
         except ImportError:
             return
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4]})
         test_df.to_parquet(temp_file_name, index=False)
-        rel = duckdb.from_parquet(temp_file_name, connection=conn)
+        rel = duckdb_cursor.from_parquet(temp_file_name)
         assert rel.query('t_2', 'select count(*) from t inner join t_2 on (a = i)').fetchall()[0] == (1,)
 
     def test_from_df(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4]})
-        rel = duckdb.df(test_df, connection=conn)
+        rel = duckdb.df(test_df, connection=duckdb_cursor)
         assert rel.query('t_2', 'select count(*) from t inner join t_2 on (a = i)').fetchall()[0] == (1,)
-        rel = duckdb.from_df(test_df, connection=conn)
+        rel = duckdb_cursor.from_df(test_df)
         assert rel.query('t_2', 'select count(*) from t inner join t_2 on (a = i)').fetchall()[0] == (1,)
 
     def test_from_arrow(self, duckdb_cursor):
@@ -59,68 +54,60 @@ class TestNonDefaultConn(object):
         except:
             return
 
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4]})
         test_arrow = pa.Table.from_pandas(test_df)
-        rel = duckdb.from_arrow(test_arrow, connection=conn)
+        rel = duckdb_cursor.from_arrow(test_arrow)
         assert rel.query('t_2', 'select count(*) from t inner join t_2 on (a = i)').fetchall()[0] == (1,)
-        rel = duckdb.arrow(test_arrow, connection=conn)
+        rel = duckdb.arrow(test_arrow, connection=duckdb_cursor)
         assert rel.query('t_2', 'select count(*) from t inner join t_2 on (a = i)').fetchall()[0] == (1,)
 
     def test_filter_df(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1), (4)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1), (4)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4]})
-        rel = duckdb.filter(test_df, "i < 2", connection=conn)
+        rel = duckdb.filter(test_df, "i < 2", connection=duckdb_cursor)
         assert rel.query('t_2', 'select count(*) from t inner join t_2 on (a = i)').fetchall()[0] == (1,)
 
     def test_project_df(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1), (4)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1), (4)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": [1, 2, 3, 4]})
-        rel = duckdb.project(test_df, "i", connection=conn)
+        rel = duckdb.project(test_df, "i", connection=duckdb_cursor)
         assert rel.query('t_2', 'select * from t inner join t_2 on (a = i)').fetchall()[0] == (1, 1)
 
     def test_agg_df(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1), (4)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1), (4)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4], "j": [1, 2, 3, 4]})
-        rel = duckdb.aggregate(test_df, "count(*) as i", connection=conn)
+        rel = duckdb.aggregate(test_df, "count(*) as i", connection=duckdb_cursor)
         assert rel.query('t_2', 'select * from t inner join t_2 on (a = i)').fetchall()[0] == (4, 4)
 
     def test_distinct_df(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1)")
         test_df = pd.DataFrame.from_dict({"i": [1, 1, 2, 3, 4]})
-        rel = duckdb.distinct(test_df, connection=conn)
+        rel = duckdb.distinct(test_df, connection=duckdb_cursor)
         assert rel.query('t_2', 'select * from t inner join t_2 on (a = i)').fetchall()[0] == (1, 1)
 
     def test_limit_df(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1),(4)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1),(4)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4]})
-        rel = duckdb.limit(test_df, 1, connection=conn)
+        rel = duckdb.limit(test_df, 1, connection=duckdb_cursor)
         assert rel.query('t_2', 'select * from t inner join t_2 on (a = i)').fetchall()[0] == (1, 1)
 
     def test_query_df(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1),(4)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1),(4)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4]})
-        rel = duckdb.query_df(test_df, 't_2', 'select * from t inner join t_2 on (a = i)', connection=conn)
+        rel = duckdb.query_df(test_df, 't_2', 'select * from t inner join t_2 on (a = i)', connection=duckdb_cursor)
         assert rel.fetchall()[0] == (1, 1)
 
     def test_query_order(self, duckdb_cursor):
-        conn = duckdb.connect()
-        conn.execute("create table t (a integer)")
-        conn.execute("insert into t values (1),(4)")
+        duckdb_cursor.execute("create table t (a integer)")
+        duckdb_cursor.execute("insert into t values (1),(4)")
         test_df = pd.DataFrame.from_dict({"i": [1, 2, 3, 4]})
-        rel = duckdb.order(test_df, 'i', connection=conn)
+        rel = duckdb.order(test_df, 'i', connection=duckdb_cursor)
         assert rel.query('t_2', 'select * from t inner join t_2 on (a = i)').fetchall()[0] == (1, 1)

--- a/tools/pythonpkg/tests/fast/test_relation_dependency_leak.py
+++ b/tools/pythonpkg/tests/fast/test_relation_dependency_leak.py
@@ -12,62 +12,62 @@ except ImportError:
 from conftest import NumpyPandas, ArrowPandas
 
 
-def check_memory(function_to_check, pandas):
+def check_memory(function_to_check, pandas, duckdb_cursor):
     process = psutil.Process(os.getpid())
     mem_usage = process.memory_info().rss / (10**9)
     for __ in range(100):
-        function_to_check(pandas)
+        function_to_check(pandas, duckdb_cursor)
     cur_mem_usage = process.memory_info().rss / (10**9)
     # This seems a good empirical value
     assert cur_mem_usage / 3 < mem_usage
 
 
-def from_df(pandas):
+def from_df(pandas, duckdb_cursor):
     df = pandas.DataFrame({"x": np.random.rand(1_000_000)})
-    return duckdb.from_df(df)
+    return duckdb_cursor.from_df(df)
 
 
-def from_arrow(pandas):
+def from_arrow(pandas, duckdb_cursor):
     data = pa.array(np.random.rand(1_000_000), type=pa.float32())
     arrow_table = pa.Table.from_arrays([data], ['a'])
-    duckdb.from_arrow(arrow_table)
+    duckdb_cursor.from_arrow(arrow_table)
 
 
-def arrow_replacement(pandas):
+def arrow_replacement(pandas, duckdb_cursor):
     data = pa.array(np.random.rand(1_000_000), type=pa.float32())
     arrow_table = pa.Table.from_arrays([data], ['a'])
-    duckdb.query("select sum(a) from arrow_table").fetchall()
+    duckdb_cursor.query("select sum(a) from arrow_table").fetchall()
 
 
-def pandas_replacement(pandas):
+def pandas_replacement(pandas, duckdb_cursor):
     df = pandas.DataFrame({"x": np.random.rand(1_000_000)})
-    duckdb.query("select sum(x) from df").fetchall()
+    duckdb_cursor.query("select sum(x) from df").fetchall()
 
 
 class TestRelationDependencyMemoryLeak(object):
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_from_arrow_leak(self, duckdb_cursor, pandas):
+    def test_from_arrow_leak(self, pandas, duckdb_cursor):
         if not can_run:
             return
-        check_memory(from_arrow, pandas)
+        check_memory(from_arrow, pandas, duckdb_cursor)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_from_df_leak(self, duckdb_cursor, pandas):
-        check_memory(from_df, pandas)
+    def test_from_df_leak(self, pandas, duckdb_cursor):
+        check_memory(from_df, pandas, duckdb_cursor)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_arrow_replacement_scan_leak(self, duckdb_cursor, pandas):
+    def test_arrow_replacement_scan_leak(self, pandas, duckdb_cursor):
         if not can_run:
             return
-        check_memory(arrow_replacement, pandas)
+        check_memory(arrow_replacement, pandas, duckdb_cursor)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_pandas_replacement_scan_leak(self, duckdb_cursor, pandas):
-        check_memory(pandas_replacement, pandas)
+    def test_pandas_replacement_scan_leak(self, pandas, duckdb_cursor):
+        check_memory(pandas_replacement, pandas, duckdb_cursor)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_relation_view_leak(self, duckdb_cursor, pandas):
-        rel = from_df(pandas)
+    def test_relation_view_leak(self, pandas, duckdb_cursor):
+        rel = from_df(pandas, duckdb_cursor)
         rel.create_view("bla")
-        duckdb.default_connection.unregister("bla")
+        duckdb_cursor.unregister("bla")
         assert rel.query("bla", "select count(*) from bla").fetchone()[0] == 1_000_000


### PR DESCRIPTION
This PR fixes the failures on the main CI

More specifically, the failures involving:
`tools/pythonpkg/tests/fast/test_relation_dependency_leak.py`
`tools/pythonpkg/tests/fast/test_memory_leaks.py`

I had already started phasing this change in, but now I pulled the trigger and replaced every usage in the tests, hopefully this will stop all future issues of this, as long as we stop using `duckdb.execute("create table ..")` and `register` calls.