### PR TITLE
Avoid requiring expected error message on original sqlite tests

### DIFF
--- a/test/sqlite/sqllogic_parser.cpp
+++ b/test/sqlite/sqllogic_parser.cpp
@@ -87,10 +87,10 @@ vector<string> SQLLogicParser::ExtractExpectedResult() {
 	return result;
 }
 
-string SQLLogicParser::ExtractExpectedError(bool expect_ok) {
+string SQLLogicParser::ExtractExpectedError(bool expect_ok, bool original_sqlite_test) {
 	// check if there is an expected error at all
 	if (current_line >= lines.size() || lines[current_line] != "----") {
-		if (!expect_ok) {
+		if (!expect_ok && !original_sqlite_test) {
 			Fail("Failed to parse statement: statement error needs to have an expected error message");
 		}
 		return string();

--- a/test/sqlite/sqllogic_parser.hpp
+++ b/test/sqlite/sqllogic_parser.hpp
@@ -80,7 +80,7 @@ public:
 	vector<string> ExtractExpectedResult();
 
 	//! Extract the expected error (in case of statement error)
-	string ExtractExpectedError(bool expect_ok);
+	string ExtractExpectedError(bool expect_ok, bool original_sqlite_test);
 
 	//! Tokenize the current line
 	SQLLogicToken Tokenize();

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -298,8 +298,8 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			if (statement_text.empty()) {
 				parser.Fail("Unexpected empty statement text");
 			}
-			command->expected_error =
-			    parser.ExtractExpectedError(command->expected_result == ExpectedResult::RESULT_SUCCESS);
+			command->expected_error = parser.ExtractExpectedError(
+			    command->expected_result == ExpectedResult::RESULT_SUCCESS, original_sqlite_test);
 
 			// perform any renames in the text
 			command->base_sql_query = ReplaceKeywords(std::move(statement_text));


### PR DESCRIPTION
Statement fail expected errors have been compulsory within duckdb codebase, but this relaxes so that in particular third-party sqllogic tests do not need to be changed.