### PR TITLE
Platform detection: Fix thread sanitizer job passing absolute path

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -556,7 +556,7 @@ jobs:
       BUILD_JSON: 1
       BUILD_EXCEL: 1
       BUILD_JEMALLOC: 1
-      TSAN_OPTIONS: suppressions=.sanitizer-thread-suppressions.txt
+      TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
TSAN_OPTION is an environment variable that influences runtime, and needs to be passed as absolute path