### PR TITLE
Remove Python function signature (in test)

### DIFF
--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -68,7 +68,7 @@ def duckdb_empty_cursor(request):
     return cursor
 
 
-def getTimeSeriesData(nper=None, freq: "Frequency" = "B") -> dict[str, "Series"]:
+def getTimeSeriesData(nper=None, freq: "Frequency" = "B"):
     from pandas import DatetimeIndex, bdate_range, Series
     from datetime import datetime
     from pandas._typing import Frequency


### PR DESCRIPTION
There have to be more proper solutions that avoid losing type information AND work cross Python versions.
This fixes nightly CI jobs triggered against Python versions 3.7 and 3.8.