### PR TITLE
CI: Fix workflow to check new issues for code formatting by using heredoc

### DIFF
--- a/.github/workflows/CheckIssueForCodeFormatting.yml
+++ b/.github/workflows/CheckIssueForCodeFormatting.yml
@@ -20,6 +20,9 @@ jobs:
           python-version: '3.11'
       - name: Check issue for code formatting
         run: |
-          if ! echo "${{ github.event.issue.body }}" | python3 scripts/check-issue-for-code-formatting.py; then
+          cat << 'EOF' >> issue-text.md
+          ${{ github.event.issue.body }}"
+          EOF
+          if ! cat issue-text.md | python3 scripts/check-issue-for-code-formatting.py; then
               gh issue comment ${{ github.event.issue.number }} --body-file .github/workflows/code-formatting-warning.md
           fi


### PR DESCRIPTION
The previous variant didn't work for comments with quotes and other exotic characters. [Heredoc](https://en.wikipedia.org/wiki/Here_document) will be a lot more robust.