### PR TITLE
Issue template: Ask about testing with the nightly build (instead of 'main')

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,14 +90,14 @@ body:
 
   - type: dropdown
     attributes:
-      label: Have you tried this on the latest `main` branch?
+      label: Have you tried this on the latest [nightly build](https://duckdb.org/docs/installation/?version=main)?
       description: |
         * **Python**: `pip install duckdb --upgrade --pre`
         * **R**: `install.packages('duckdb', repos=c('https://duckdb.r-universe.dev', 'https://cloud.r-project.org'))`
         * **Other Platforms**: You can find links to binaries [here](https://duckdb.org/docs/installation/) or compile from source.
       options:
-        - I have tested with a main build
-        - I have tested with a release build (and could not test with a main build)
+        - I have tested with a nightly build
+        - I have tested with a release build (and could not test with a nightly build)
         - I have not tested with any build
     validations:
       required: true


### PR DESCRIPTION
Our current issue template asks users whether they have tested with `main` but gives instructions that will result in the installation of the nightly build. This is confusing as we do not expect users to build from `main` when submitting reports. Instead, testing with the nightly build is sufficient.

I updated the issue template to reflect this.