### PR TITLE
Fix results for anti joins on empty tables

### DIFF
--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -98,8 +98,11 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 						if (join.join_type == JoinType::RIGHT_SEMI) {
 							std::swap(join.children[0], join.children[1]);
 						}
-						// when the right child has data, return the left child
 						// when the right child has no data, return an empty set
+						// cannot just return the left child because if the right child has no cardinality
+						// then the whole result should be empty.
+						// TODO: write better CE logic for limits so that we can just look at
+						//  join.children[1].estimated_cardinality.
 						auto limit = make_uniq<LogicalLimit>(1, 0, nullptr, nullptr);
 						limit->AddChild(std::move(join.children[1]));
 						auto cross_product = LogicalCrossProduct::Create(std::move(join.children[0]), std::move(limit));
@@ -111,6 +114,11 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 						auto cross_product =
 						    LogicalCrossProduct::Create(std::move(join.children[0]), std::move(join.children[1]));
 						*node_ptr = std::move(cross_product);
+						return;
+					}
+					case JoinType::ANTI:
+					case JoinType::RIGHT_ANTI: {
+						ReplaceWithEmptyResult(*node_ptr);
 						return;
 					}
 					default:

--- a/src/optimizer/statistics/operator/propagate_join.cpp
+++ b/src/optimizer/statistics/operator/propagate_join.cpp
@@ -47,12 +47,8 @@ void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, uniq
 					if (join.join_type == JoinType::RIGHT_ANTI) {
 						std::swap(join.children[0], join.children[1]);
 					}
-					// when the right child has data, return the left child
-					// when the right child has no data, return an empty set
-					auto limit = make_uniq<LogicalLimit>(1, 0, nullptr, nullptr);
-					limit->AddChild(std::move(join.children[1]));
-					auto cross_product = LogicalCrossProduct::Create(std::move(join.children[0]), std::move(limit));
-					*node_ptr = std::move(cross_product);
+					// If the filter is always false or Null, just return the left child.
+					*node_ptr = std::move(join.children[0]);
 					return;
 				}
 				case JoinType::LEFT:

--- a/test/sql/join/semianti/10406-anti-on-ints-strings.test
+++ b/test/sql/join/semianti/10406-anti-on-ints-strings.test
@@ -1,0 +1,53 @@
+# name: test/sql/join/semianti/10406-anti-on-ints-strings.test
+# description: github reported bug
+# group: [semianti]
+
+statement ok
+create table test_str(k varchar);
+
+statement ok
+create table test_str_del(pk varchar);
+
+statement ok
+create table test_int(k bigint);
+
+statement ok
+create table test_int_del(pk bigint);
+
+statement ok
+insert into test_str values('abc'), ('def');
+
+statement ok
+insert into test_int values(1), (2);
+
+query I
+select l.* from test_str l anti join test_str_del r on l.k = r.pk;
+----
+abc
+def
+
+query I
+select l.* from test_int l anti join test_int_del r on l.k = r.pk;
+----
+1
+2
+
+statement ok
+insert into test_int VALUES (NULL);
+
+query I
+select l.* from test_int l anti join test_int_del r on l.k is not distinct from r.pk;
+----
+1
+2
+NULL
+
+statement ok
+insert into test_int_del VALUES (NULL);
+
+# NULL is now not distinct from null
+query I
+select l.* from test_int l anti join test_int_del r on l.k is not distinct from r.pk;
+----
+1
+2


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/10406

In the statistics propagator, anti joins (and sometimes semi joins) get converted to cross products where the right child has `Limit = 1` if the filter is always false/true. 

The problem arises when the right table is empty, because then the cross product produces an empty result. For semi joins this is fine, but for anti joins we should just be propagating the left side.

Only happens when a table is anti joined on an empty table and the type of the column is numeric.