### PR TITLE
[Python][Dev] Skip pyarrow `test_struct_filter_pushdown` on python3.8

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import tempfile
 from conftest import pandas_supports_arrow_backend
+import sys
 from packaging.version import Version
 
 pa = pytest.importorskip("pyarrow")
@@ -714,6 +715,7 @@ class TestArrowFilterPushdown(object):
         match = re.search("│ +b +│", query_res[0][1])
         assert not match
 
+    @pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
     @pytest.mark.parametrize('create_table', [create_pyarrow_pandas, create_pyarrow_table])
     def test_struct_filter_pushdown(self, duckdb_cursor, create_table):
         duckdb_cursor.execute(

--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -783,6 +783,7 @@ class TestArrowFilterPushdown(object):
         match = re.search(".*ARROW_SCAN.*Filters: s\\.a IS NULL.*", query_res[0][1], flags=re.DOTALL)
         assert not match
 
+    @pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
     @pytest.mark.parametrize('create_table', [create_pyarrow_pandas, create_pyarrow_table])
     def test_nested_struct_filter_pushdown(self, duckdb_cursor, create_table):
         duckdb_cursor.execute(


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/1158

As the comment says, this doesn't become an ARROW_SCAN on python3.8