### PR TITLE
Python: fix exception hierarchy, and also catch std::exception

### DIFF
--- a/tools/pythonpkg/src/common/exceptions.cpp
+++ b/tools/pythonpkg/src/common/exceptions.cpp
@@ -303,7 +303,7 @@ void RegisterExceptions(const py::module &m) {
 	// The base class is mapped to Error in python to somewhat match the DBAPI 2.0 specifications
 	py::register_exception<Warning>(m, "Warning");
 	auto error = py::register_exception<PyError>(m, "Error").ptr();
-	auto db_error = py::register_exception<PyError>(m, "DatabaseError", error).ptr();
+	auto db_error = py::register_exception<DatabaseError>(m, "DatabaseError", error).ptr();
 
 	// order of declaration matters, and this needs to be checked last
 	// Unknown

--- a/tools/pythonpkg/src/common/exceptions.cpp
+++ b/tools/pythonpkg/src/common/exceptions.cpp
@@ -367,7 +367,7 @@ void RegisterExceptions(const py::module &m) {
 		} catch (const duckdb::Exception &ex) {
 			duckdb::ErrorData error(ex);
 			PyThrowException(error, HTTP_EXCEPTION.ptr());
-		} catch(const std::exception &ex) {
+		} catch (const std::exception &ex) {
 			duckdb::ErrorData error(ex);
 			if (error.Type() == ExceptionType::INVALID) {
 				// we need to pass non-DuckDB exceptions through as-is

--- a/tools/pythonpkg/src/common/exceptions.cpp
+++ b/tools/pythonpkg/src/common/exceptions.cpp
@@ -132,6 +132,12 @@ public:
 	}
 };
 
+class PyHTTPException : public PyIOException {
+public:
+	explicit PyHTTPException(const string &err) : PyIOException(err) {
+	}
+};
+
 //===--------------------------------------------------------------------===//
 // Integrity Error
 //===--------------------------------------------------------------------===//
@@ -329,7 +335,7 @@ void RegisterExceptions(const py::module &m) {
 	auto io_exception = py::register_exception<PyIOException>(m, "IOException", operational_error).ptr();
 	py::register_exception<PySerializationException>(m, "SerializationException", operational_error);
 
-	static py::exception<HTTPException> HTTP_EXCEPTION(m, "HTTPException", io_exception);
+	static py::exception<PyHTTPException> HTTP_EXCEPTION(m, "HTTPException", io_exception);
 	const auto string_type = py::type::of(py::str());
 	const auto Dict = py::module_::import("typing").attr("Dict");
 	HTTP_EXCEPTION.attr("__annotations__") =

--- a/tools/pythonpkg/src/common/exceptions.cpp
+++ b/tools/pythonpkg/src/common/exceptions.cpp
@@ -12,6 +12,18 @@ namespace duckdb {
 
 class Warning : public std::exception {};
 
+// This is the error structure defined in the DBAPI spec
+// StandardError
+// |__ Warning
+// |__ Error
+//    |__ InterfaceError
+//    |__ DatabaseError
+//       |__ DataError
+//       |__ OperationalError
+//       |__ IntegrityError
+//       |__ InternalError
+//       |__ ProgrammingError
+//       |__ NotSupportedError
 //===--------------------------------------------------------------------===//
 // Base Error
 //===--------------------------------------------------------------------===//
@@ -21,39 +33,45 @@ public:
 	}
 };
 
+class DatabaseError : public PyError {
+public:
+	explicit DatabaseError(const string &err) : PyError(err) {
+	}
+};
+
 //===--------------------------------------------------------------------===//
 // Unknown Errors
 //===--------------------------------------------------------------------===//
-class PyFatalException : public PyError {
+class PyFatalException : public DatabaseError {
 public:
-	explicit PyFatalException(const string &err) : PyError(err) {
+	explicit PyFatalException(const string &err) : DatabaseError(err) {
 	}
 };
 
-class PyInterruptException : public PyError {
+class PyInterruptException : public DatabaseError {
 public:
-	explicit PyInterruptException(const string &err) : PyError(err) {
+	explicit PyInterruptException(const string &err) : DatabaseError(err) {
 	}
 };
 
-class PyPermissionException : public PyError {
+class PyPermissionException : public DatabaseError {
 public:
-	explicit PyPermissionException(const string &err) : PyError(err) {
+	explicit PyPermissionException(const string &err) : DatabaseError(err) {
 	}
 };
 
-class PySequenceException : public PyError {
+class PySequenceException : public DatabaseError {
 public:
-	explicit PySequenceException(const string &err) : PyError(err) {
+	explicit PySequenceException(const string &err) : DatabaseError(err) {
 	}
 };
 
 //===--------------------------------------------------------------------===//
 // Data Error
 //===--------------------------------------------------------------------===//
-class DataError : public std::runtime_error {
+class DataError : public DatabaseError {
 public:
-	explicit DataError(const string &err) : std::runtime_error(err) {
+	explicit DataError(const string &err) : DatabaseError(err) {
 	}
 };
 
@@ -78,9 +96,9 @@ public:
 //===--------------------------------------------------------------------===//
 // Operational Error
 //===--------------------------------------------------------------------===//
-class OperationalError : public std::runtime_error {
+class OperationalError : public DatabaseError {
 public:
-	explicit OperationalError(const string &err) : std::runtime_error(err) {
+	explicit OperationalError(const string &err) : DatabaseError(err) {
 	}
 };
 
@@ -117,9 +135,9 @@ public:
 //===--------------------------------------------------------------------===//
 // Integrity Error
 //===--------------------------------------------------------------------===//
-class IntegrityError : public std::runtime_error {
+class IntegrityError : public DatabaseError {
 public:
-	explicit IntegrityError(const string &err) : std::runtime_error(err) {
+	explicit IntegrityError(const string &err) : DatabaseError(err) {
 	}
 };
 
@@ -132,9 +150,9 @@ public:
 //===--------------------------------------------------------------------===//
 // Internal Error
 //===--------------------------------------------------------------------===//
-class InternalError : public std::runtime_error {
+class InternalError : public DatabaseError {
 public:
-	explicit InternalError(const string &err) : std::runtime_error(err) {
+	explicit InternalError(const string &err) : DatabaseError(err) {
 	}
 };
 
@@ -147,9 +165,9 @@ public:
 //===--------------------------------------------------------------------===//
 // Programming Error
 //===--------------------------------------------------------------------===//
-class ProgrammingError : public std::runtime_error {
+class ProgrammingError : public DatabaseError {
 public:
-	explicit ProgrammingError(const string &err) : std::runtime_error(err) {
+	explicit ProgrammingError(const string &err) : DatabaseError(err) {
 	}
 };
 
@@ -192,9 +210,9 @@ public:
 //===--------------------------------------------------------------------===//
 // Not Supported Error
 //===--------------------------------------------------------------------===//
-class NotSupportedError : public std::runtime_error {
+class NotSupportedError : public DatabaseError {
 public:
-	explicit NotSupportedError(const string &err) : std::runtime_error(err) {
+	explicit NotSupportedError(const string &err) : DatabaseError(err) {
 	}
 };
 
@@ -204,52 +222,114 @@ public:
 	}
 };
 
+//===--------------------------------------------------------------------===//
+// PyThrowException
+//===--------------------------------------------------------------------===//
+void PyThrowException(ErrorData &error, PyObject *http_exception) {
+	switch (error.Type()) {
+	case ExceptionType::HTTP: {
+		// construct exception object
+		auto e = py::handle(http_exception)(py::str(error.Message()));
+
+		auto headers = py::dict();
+		for (auto &entry : error.ExtraInfo()) {
+			if (entry.first == "status_code") {
+				e.attr("status_code") = std::stoi(entry.second);
+			} else if (entry.first == "response_body") {
+				e.attr("body") = entry.second;
+			} else if (entry.first == "reason") {
+				e.attr("reason") = entry.second;
+			} else if (StringUtil::StartsWith(entry.first, "header_")) {
+				headers[py::str(entry.first.substr(7))] = entry.second;
+			}
+		}
+		e.attr("headers") = std::move(headers);
+
+		// "throw" exception object
+		PyErr_SetObject(http_exception, e.ptr());
+		break;
+	}
+	case ExceptionType::CATALOG:
+		throw PyCatalogException(error.Message());
+	case ExceptionType::FATAL:
+		throw PyFatalException(error.Message());
+	case ExceptionType::INTERRUPT:
+		throw PyInterruptException(error.Message());
+	case ExceptionType::PERMISSION:
+		throw PyPermissionException(error.Message());
+	case ExceptionType::SEQUENCE:
+		throw PySequenceException(error.Message());
+	case ExceptionType::OUT_OF_RANGE:
+		throw PyOutOfRangeException(error.Message());
+	case ExceptionType::CONVERSION:
+		throw PyConversionException(error.Message());
+	case ExceptionType::MISMATCH_TYPE:
+		throw PyTypeMismatchException(error.Message());
+	case ExceptionType::TRANSACTION:
+		throw PyTransactionException(error.Message());
+	case ExceptionType::OUT_OF_MEMORY:
+		throw PyOutOfMemoryException(error.Message());
+	case ExceptionType::CONNECTION:
+		throw PyConnectionException(error.Message());
+	case ExceptionType::SERIALIZATION:
+		throw PySerializationException(error.Message());
+	case ExceptionType::CONSTRAINT:
+		throw PyConstraintException(error.Message());
+	case ExceptionType::INTERNAL:
+		throw PyInternalException(error.Message());
+	case ExceptionType::PARSER:
+		throw PyParserException(error.Message());
+	case ExceptionType::SYNTAX:
+		throw PySyntaxException(error.Message());
+	case ExceptionType::IO:
+		throw PyIOException(error.Message());
+	case ExceptionType::BINDER:
+		throw PyBinderException(error.Message());
+	case ExceptionType::INVALID_INPUT:
+		throw PyInvalidInputException(error.Message());
+	case ExceptionType::INVALID_TYPE:
+		throw PyInvalidTypeException(error.Message());
+	case ExceptionType::NOT_IMPLEMENTED:
+		throw PyNotImplementedException(error.Message());
+	default:
+		throw PyError(error.RawMessage());
+	}
+}
+
 /**
  * @see https://peps.python.org/pep-0249/#exceptions
  */
 void RegisterExceptions(const py::module &m) {
-	// This is the error structure defined in the DBAPI spec
-	// StandardError
-	// |__ Warning
-	// |__ Error
-	//    |__ InterfaceError
-	//    |__ DatabaseError
-	//       |__ DataError
-	//       |__ OperationalError
-	//       |__ IntegrityError
-	//       |__ InternalError
-	//       |__ ProgrammingError
-	//       |__ NotSupportedError
 	// The base class is mapped to Error in python to somewhat match the DBAPI 2.0 specifications
-	auto warning_class = py::register_exception<Warning>(m, "Warning").ptr();
+	py::register_exception<Warning>(m, "Warning");
 	auto error = py::register_exception<PyError>(m, "Error").ptr();
-	// FIXME: missing DatabaseError
+	auto db_error = py::register_exception<PyError>(m, "DatabaseError", error).ptr();
 
 	// order of declaration matters, and this needs to be checked last
 	// Unknown
-	py::register_exception<PyFatalException>(m, "FatalException", error);
-	py::register_exception<PyInterruptException>(m, "InterruptException", error);
-	py::register_exception<PyPermissionException>(m, "PermissionException", error);
-	py::register_exception<PySequenceException>(m, "SequenceException", error);
+	py::register_exception<PyFatalException>(m, "FatalException", db_error);
+	py::register_exception<PyInterruptException>(m, "InterruptException", db_error);
+	py::register_exception<PyPermissionException>(m, "PermissionException", db_error);
+	py::register_exception<PySequenceException>(m, "SequenceException", db_error);
 
 	// DataError
-	auto data_error = py::register_exception<DataError>(m, "DataError", error).ptr();
+	auto data_error = py::register_exception<DataError>(m, "DataError", db_error).ptr();
 	py::register_exception<PyOutOfRangeException>(m, "OutOfRangeException", data_error);
 	py::register_exception<PyConversionException>(m, "ConversionException", data_error);
 	// no unknown type error, or decimal type
 	py::register_exception<PyTypeMismatchException>(m, "TypeMismatchException", data_error);
 
 	// OperationalError
-	auto operational_error = py::register_exception<OperationalError>(m, "OperationalError", error).ptr();
+	auto operational_error = py::register_exception<OperationalError>(m, "OperationalError", db_error).ptr();
 	py::register_exception<PyTransactionException>(m, "TransactionException", operational_error);
 	py::register_exception<PyOutOfMemoryException>(m, "OutOfMemoryException", operational_error);
 	py::register_exception<PyConnectionException>(m, "ConnectionException", operational_error);
 	// no object size error
 	// no null pointer errors
-	py::register_exception<PyIOException>(m, "IOException", operational_error);
+	auto io_exception = py::register_exception<PyIOException>(m, "IOException", operational_error).ptr();
 	py::register_exception<PySerializationException>(m, "SerializationException", operational_error);
 
-	static py::exception<HTTPException> HTTP_EXCEPTION(m, "HTTPException", operational_error);
+	static py::exception<HTTPException> HTTP_EXCEPTION(m, "HTTPException", io_exception);
 	const auto string_type = py::type::of(py::str());
 	const auto Dict = py::module_::import("typing").attr("Dict");
 	HTTP_EXCEPTION.attr("__annotations__") =
@@ -258,15 +338,15 @@ void RegisterExceptions(const py::module &m) {
 	HTTP_EXCEPTION.doc() = "Thrown when an error occurs in the httpfs extension, or whilst downloading an extension.";
 
 	// IntegrityError
-	auto integrity_error = py::register_exception<IntegrityError>(m, "IntegrityError", error).ptr();
+	auto integrity_error = py::register_exception<IntegrityError>(m, "IntegrityError", db_error).ptr();
 	py::register_exception<PyConstraintException>(m, "ConstraintException", integrity_error);
 
 	// InternalError
-	auto internal_error = py::register_exception<InternalError>(m, "InternalError", error).ptr();
+	auto internal_error = py::register_exception<InternalError>(m, "InternalError", db_error).ptr();
 	py::register_exception<PyInternalException>(m, "InternalException", internal_error);
 
 	//// ProgrammingError
-	auto programming_error = py::register_exception<ProgrammingError>(m, "ProgrammingError", error).ptr();
+	auto programming_error = py::register_exception<ProgrammingError>(m, "ProgrammingError", db_error).ptr();
 	py::register_exception<PyParserException>(m, "ParserException", programming_error);
 	py::register_exception<PySyntaxException>(m, "SyntaxException", programming_error);
 	py::register_exception<PyBinderException>(m, "BinderException", programming_error);
@@ -276,7 +356,7 @@ void RegisterExceptions(const py::module &m) {
 	py::register_exception<PyCatalogException>(m, "CatalogException", programming_error);
 
 	// NotSupportedError
-	auto not_supported_error = py::register_exception<NotSupportedError>(m, "NotSupportedError", error).ptr();
+	auto not_supported_error = py::register_exception<NotSupportedError>(m, "NotSupportedError", db_error).ptr();
 	py::register_exception<PyNotImplementedException>(m, "NotImplementedException", not_supported_error);
 
 	py::register_exception_translator([](std::exception_ptr p) { // NOLINT(performance-unnecessary-value-param)
@@ -286,74 +366,14 @@ void RegisterExceptions(const py::module &m) {
 			}
 		} catch (const duckdb::Exception &ex) {
 			duckdb::ErrorData error(ex);
-			switch (error.Type()) {
-			case ExceptionType::HTTP: {
-				// construct exception object
-				auto e = py::handle(HTTP_EXCEPTION.ptr())(py::str(error.Message()));
-
-				auto headers = py::dict();
-				for (auto &entry : error.ExtraInfo()) {
-					if (entry.first == "status_code") {
-						e.attr("status_code") = std::stoi(entry.second);
-					} else if (entry.first == "response_body") {
-						e.attr("body") = entry.second;
-					} else if (entry.first == "reason") {
-						e.attr("reason") = entry.second;
-					} else if (StringUtil::StartsWith(entry.first, "header_")) {
-						headers[py::str(entry.first.substr(7))] = entry.second;
-					}
-				}
-				e.attr("headers") = std::move(headers);
-
-				// "throw" exception object
-				PyErr_SetObject(HTTP_EXCEPTION.ptr(), e.ptr());
-				break;
+			PyThrowException(error, HTTP_EXCEPTION.ptr());
+		} catch(const std::exception &ex) {
+			duckdb::ErrorData error(ex);
+			if (error.Type() == ExceptionType::INVALID) {
+				// we need to pass non-DuckDB exceptions through as-is
+				throw;
 			}
-			case ExceptionType::CATALOG:
-				throw PyCatalogException(error.Message());
-			case ExceptionType::FATAL:
-				throw PyFatalException(error.Message());
-			case ExceptionType::INTERRUPT:
-				throw PyInterruptException(error.Message());
-			case ExceptionType::PERMISSION:
-				throw PyPermissionException(error.Message());
-			case ExceptionType::SEQUENCE:
-				throw PySequenceException(error.Message());
-			case ExceptionType::OUT_OF_RANGE:
-				throw PyOutOfRangeException(error.Message());
-			case ExceptionType::CONVERSION:
-				throw PyConversionException(error.Message());
-			case ExceptionType::MISMATCH_TYPE:
-				throw PyTypeMismatchException(error.Message());
-			case ExceptionType::TRANSACTION:
-				throw PyTransactionException(error.Message());
-			case ExceptionType::OUT_OF_MEMORY:
-				throw PyOutOfMemoryException(error.Message());
-			case ExceptionType::CONNECTION:
-				throw PyConnectionException(error.Message());
-			case ExceptionType::SERIALIZATION:
-				throw PySerializationException(error.Message());
-			case ExceptionType::CONSTRAINT:
-				throw PyConstraintException(error.Message());
-			case ExceptionType::INTERNAL:
-				throw PyInternalException(error.Message());
-			case ExceptionType::PARSER:
-				throw PyParserException(error.Message());
-			case ExceptionType::SYNTAX:
-				throw PySyntaxException(error.Message());
-			case ExceptionType::IO:
-				throw PyIOException(error.Message());
-			case ExceptionType::BINDER:
-				throw PyBinderException(error.Message());
-			case ExceptionType::INVALID_INPUT:
-				throw PyInvalidInputException(error.Message());
-			case ExceptionType::INVALID_TYPE:
-				throw PyInvalidTypeException(error.Message());
-			case ExceptionType::NOT_IMPLEMENTED:
-				throw PyNotImplementedException(error.Message());
-			default:
-				throw std::runtime_error(error.RawMessage());
-			}
+			PyThrowException(error, HTTP_EXCEPTION.ptr());
 		}
 	});
 }

--- a/tools/pythonpkg/tests/fast/udf/test_scalar_arrow.py
+++ b/tools/pythonpkg/tests/fast/udf/test_scalar_arrow.py
@@ -101,7 +101,7 @@ class TestPyArrowUDF(object):
 
         con = duckdb.connect()
         con.create_function('will_crash', returns_none, [BIGINT], BIGINT, type='arrow')
-        with pytest.raises(RuntimeError, match="""TypeError: 'NoneType' object is not iterable"""):
+        with pytest.raises(duckdb.Error, match="""TypeError: 'NoneType' object is not iterable"""):
             res = con.sql("""select will_crash(5)""").fetchall()
 
     def test_empty_result(self):


### PR DESCRIPTION
Addresses earlier PR comments

* Restore original Exception hierarchy
* Add previously missing `DatabaseError` into the hierarchy
* Make HTTPException inherit from IOException again
* Also catch `std::exception`, but only re-throw as a DuckDB exception if the text matches our JSON format and contains a valid DuckDB exception type - otherwise re-throw the exception as-is

CC @Mause 