### PR TITLE
Multiline mode: add continuation prompt rendering

### DIFF
--- a/tools/shell/include/linenoise.h
+++ b/tools/shell/include/linenoise.h
@@ -68,6 +68,7 @@ void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
 size_t linenoiseComputeRenderWidth(const char *buf, size_t len);
 int linenoiseGetRenderPosition(const char *buf, size_t len, int max_width, int *n);
+void linenoiseSetPrompt(const char *continuation, const char *continuationSelected);
 
 #ifdef __cplusplus
 }

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -170,6 +170,9 @@ static std::string constant = "\033[33m";
 static std::string reset = "\033[00m";
 #endif
 
+static const char *continuationPrompt = "> ";
+static const char *continuationSelectedPrompt = "> ";
+
 struct searchMatch {
 	size_t history_index;
 	size_t match_start;
@@ -765,6 +768,11 @@ int linenoiseParseOption(const char **azArg, int nArg, const char **out_error) {
 	return 0;
 }
 
+void linenoiseSetPrompt(const char *continuation, const char *continuationSelected) {
+	continuationPrompt = continuation;
+	continuationSelectedPrompt = continuationSelected;
+}
+
 #ifndef DISABLE_HIGHLIGHT
 #include <sstream>
 #include "duckdb/parser/parser.hpp"
@@ -1151,10 +1159,8 @@ static std::string addContinuationMarkers(struct linenoiseState *l, const char *
 			result += buf[prev_pos];
 		}
 		if (is_newline) {
-			for (int p = 0; p + 2 < plen; p++) {
-				result += " ";
-			}
-			result += "> ";
+			const char *prompt = rows == cursor_row ? continuationSelectedPrompt : continuationPrompt;
+			result += prompt;
 		}
 	}
 	for (; prev_pos < cpos; prev_pos++) {

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -1165,7 +1165,7 @@ static std::string addContinuationMarkers(struct linenoiseState *l, const char *
 			size_t continuationLen = strlen(prompt);
 			size_t continuationRender = linenoiseComputeRenderWidth(prompt, continuationLen);
 			// pad with spaces prior to prompt
-			for (size_t i = continuationRender; i < plen; i++) {
+			for (int i = int(continuationRender); i < plen; i++) {
 				result += " ";
 			}
 			result += prompt;

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -452,8 +452,9 @@ static char *Argv0;
 ** Prompt strings. Initialized in main. Settable with
 **   .prompt main continue
 */
-static char mainPrompt[20];     /* First line prompt. default: "sqlite> "*/
-static char continuePrompt[20]; /* Continuation prompt. default: "   ...> " */
+static char mainPrompt[20];             /* First line prompt. default: "D "*/
+static char continuePrompt[20];         /* Continuation prompt. default: "   ...> " */
+static char continuePromptSelected[20]; /* Selected continuation prompt. default: "   ...> " */
 
 /*
 ** Render output like fprintf().  Except, if the output is going to the
@@ -18290,7 +18291,10 @@ static int do_meta_command(char *zLine, ShellState *p){
     if( nArg >= 3) {
       strncpy(continuePrompt,azArg[2],(int)ArraySize(continuePrompt)-1);
     }
-  }else
+    if( nArg >= 4) {
+      strncpy(continuePromptSelected,azArg[3],(int)ArraySize(continuePromptSelected)-1);
+    }
+  } else
 
   if( c=='q' && strncmp(azArg[0], "quit", n)==0 ){
     rc = 2;
@@ -19969,7 +19973,11 @@ static void main_init(ShellState *data) {
   sqlite3_config(SQLITE_CONFIG_LOG, shellLog, data);
   sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
   sqlite3_snprintf(sizeof(mainPrompt), mainPrompt, "D ");
-  sqlite3_snprintf(sizeof(continuePrompt), continuePrompt, "> ");
+  sqlite3_snprintf(sizeof(continuePrompt), continuePrompt, "· ");
+  sqlite3_snprintf(sizeof(continuePromptSelected), continuePromptSelected, "‣ ");
+#ifdef HAVE_LINENOISE
+  linenoiseSetPrompt(continuePrompt, continuePromptSelected);
+#endif
 }
 
 /*


### PR DESCRIPTION
Adds rendering of a continuation marker to the shell in multiline mode, i.e.:

```sql
D SELECT
>     l_returnflag,
>     l_linestatus,
>     sum(l_quantity) AS sum_qty,
>     sum(l_extendedprice) AS sum_base_price,
>     sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
>     sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
>     avg(l_quantity) AS avg_qty,
>     avg(l_extendedprice) AS avg_price,
>     avg(l_discount) AS avg_disc,
>     count(*) AS count_order
> FROM
>     lineitem
> WHERE
>     l_shipdate <= CAST('1998-09-02' AS date)
> GROUP BY
>     l_returnflag,
>     l_linestatus
> ORDER BY
>     l_returnflag,
>     l_linestatus;
```

Instead of:

```sql
D SELECT
    l_returnflag,
    l_linestatus,
    sum(l_quantity) AS sum_qty,
    sum(l_extendedprice) AS sum_base_price,
    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
    avg(l_quantity) AS avg_qty,
    avg(l_extendedprice) AS avg_price,
    avg(l_discount) AS avg_disc,
    count(*) AS count_order
FROM
    lineitem
WHERE
    l_shipdate <= CAST('1998-09-02' AS date)
GROUP BY
    l_returnflag,
    l_linestatus
ORDER BY
    l_returnflag,
    l_linestatus;
```

This is less confusing since there is more feedback on whether or not a query has terminated and looks a bit better because the text is aligned.
