### PR TITLE
[CSV] Bug Fix related to quoted values starting with empty values

### DIFF
--- a/data/csv/empty_space_start_value.csv
+++ b/data/csv/empty_space_start_value.csv
@@ -1,0 +1,5 @@
+"Year", "Score", "Title"
+1968,  86, "Greetings"
+1970,  17, "Bloody Mama"
+1970,  73, "Hi, Mom!"
+1971,  40, "Born to Win"

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -699,6 +699,8 @@ const char* EnumUtil::ToChars<CSVState>(CSVState value) {
 		return "NOT_SET";
 	case CSVState::QUOTED_NEW_LINE:
 		return "QUOTED_NEW_LINE";
+	case CSVState::EMPTY_SPACE:
+		return "EMPTY_SPACE";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
 	}
@@ -735,6 +737,9 @@ CSVState EnumUtil::FromString<CSVState>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "QUOTED_NEW_LINE")) {
 		return CSVState::QUOTED_NEW_LINE;
+	}
+	if (StringUtil::Equals(value, "EMPTY_SPACE")) {
+		return CSVState::EMPTY_SPACE;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -237,7 +237,7 @@ void StringValueResult::AddQuotedValue(StringValueResult &result, const idx_t bu
 		}
 		// If it's an escaped value we have to remove all the escapes, this is not really great
 		auto value = StringValueScanner::RemoveEscape(
-		    result.buffer_ptr + result.last_position + 1, buffer_pos - result.last_position - 2,
+		    result.buffer_ptr + result.quoted_position + 1, buffer_pos - result.quoted_position - 2,
 		    result.state_machine.options.GetEscape()[0], result.parse_chunk.data[result.chunk_col_id]);
 		result.AddValueToVector(value.GetData(), value.GetSize());
 	} else {
@@ -246,8 +246,8 @@ void StringValueResult::AddQuotedValue(StringValueResult &result, const idx_t bu
 			auto value = string_t();
 			result.AddValueToVector(value.GetData(), value.GetSize());
 		} else {
-			result.AddValueToVector(result.buffer_ptr + result.last_position + 1,
-			                        buffer_pos - result.last_position - 2);
+			result.AddValueToVector(result.buffer_ptr + result.quoted_position + 1,
+			                        buffer_pos - result.quoted_position - 2);
 		}
 	}
 	result.quoted = false;
@@ -669,7 +669,7 @@ void StringValueScanner::ProcessExtraRow() {
 			if (states.states[0] == CSVState::UNQUOTED) {
 				result.SetEscaped(result);
 			}
-			result.SetQuoted(result);
+			result.SetQuoted(result,iterator.pos.buffer_pos);
 			iterator.pos.buffer_pos++;
 			while (state_machine->transition_array
 			           .skip_quoted[static_cast<uint8_t>(buffer_handle_ptr[iterator.pos.buffer_pos])] &&

--- a/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
+++ b/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
@@ -62,7 +62,7 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 		    CSVState::RECORD_SEPARATOR;
 	}
 	transition_array[quote][static_cast<uint8_t>(CSVState::DELIMITER)] = CSVState::QUOTED;
-	if (delimiter != ' '){
+	if (delimiter != ' ') {
 		transition_array[' '][static_cast<uint8_t>(CSVState::DELIMITER)] = CSVState::EMPTY_SPACE;
 	}
 
@@ -78,7 +78,7 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 		    CSVState::RECORD_SEPARATOR;
 	}
 	transition_array[quote][static_cast<uint8_t>(CSVState::RECORD_SEPARATOR)] = CSVState::QUOTED;
-	if (delimiter != ' '){
+	if (delimiter != ' ') {
 		transition_array[' '][static_cast<uint8_t>(CSVState::RECORD_SEPARATOR)] = CSVState::EMPTY_SPACE;
 	}
 
@@ -88,7 +88,7 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 	transition_array[static_cast<uint8_t>('\r')][static_cast<uint8_t>(CSVState::CARRIAGE_RETURN)] =
 	    CSVState::CARRIAGE_RETURN;
 	transition_array[quote][static_cast<uint8_t>(CSVState::CARRIAGE_RETURN)] = CSVState::QUOTED;
-	if (delimiter != ' '){
+	if (delimiter != ' ') {
 		transition_array[' '][static_cast<uint8_t>(CSVState::CARRIAGE_RETURN)] = CSVState::EMPTY_SPACE;
 	}
 
@@ -128,7 +128,9 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 		    CSVState::RECORD_SEPARATOR;
 	}
 	transition_array[static_cast<uint8_t>(quote)][static_cast<uint8_t>(CSVState::NOT_SET)] = CSVState::QUOTED;
-
+	if (delimiter != ' ') {
+		transition_array[' '][static_cast<uint8_t>(CSVState::NOT_SET)] = CSVState::EMPTY_SPACE;
+	}
 	// 9) Quoted NewLine
 	transition_array[quote][static_cast<uint8_t>(CSVState::QUOTED_NEW_LINE)] = CSVState::UNQUOTED;
 	if (state_machine_options.quote != state_machine_options.escape) {
@@ -136,8 +138,10 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 	}
 
 	// 10) Empty Value State
-	transition_array[delimiter][static_cast<uint8_t>(static_cast<uint8_t>(CSVState::EMPTY_SPACE))] = CSVState::DELIMITER;
-	transition_array[static_cast<uint8_t>('\n')][static_cast<uint8_t>(CSVState::EMPTY_SPACE)] = CSVState::RECORD_SEPARATOR;
+	transition_array[delimiter][static_cast<uint8_t>(static_cast<uint8_t>(CSVState::EMPTY_SPACE))] =
+	    CSVState::DELIMITER;
+	transition_array[static_cast<uint8_t>('\n')][static_cast<uint8_t>(CSVState::EMPTY_SPACE)] =
+	    CSVState::RECORD_SEPARATOR;
 	if (new_line_id == NewLineIdentifier::CARRY_ON) {
 		transition_array[static_cast<uint8_t>('\r')][static_cast<uint8_t>(CSVState::EMPTY_SPACE)] =
 		    CSVState::CARRIAGE_RETURN;

--- a/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
+++ b/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
@@ -62,6 +62,10 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 		    CSVState::RECORD_SEPARATOR;
 	}
 	transition_array[quote][static_cast<uint8_t>(CSVState::DELIMITER)] = CSVState::QUOTED;
+	if (delimiter != ' '){
+		transition_array[' '][static_cast<uint8_t>(CSVState::DELIMITER)] = CSVState::EMPTY_SPACE;
+	}
+
 	// 3) Record Separator State
 	transition_array[delimiter][static_cast<uint8_t>(CSVState::RECORD_SEPARATOR)] = CSVState::DELIMITER;
 	transition_array[static_cast<uint8_t>('\n')][static_cast<uint8_t>(CSVState::RECORD_SEPARATOR)] =
@@ -74,6 +78,9 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 		    CSVState::RECORD_SEPARATOR;
 	}
 	transition_array[quote][static_cast<uint8_t>(CSVState::RECORD_SEPARATOR)] = CSVState::QUOTED;
+	if (delimiter != ' '){
+		transition_array[' '][static_cast<uint8_t>(CSVState::RECORD_SEPARATOR)] = CSVState::EMPTY_SPACE;
+	}
 
 	// 4) Carriage Return State
 	transition_array[static_cast<uint8_t>('\n')][static_cast<uint8_t>(CSVState::CARRIAGE_RETURN)] =
@@ -81,6 +88,9 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 	transition_array[static_cast<uint8_t>('\r')][static_cast<uint8_t>(CSVState::CARRIAGE_RETURN)] =
 	    CSVState::CARRIAGE_RETURN;
 	transition_array[quote][static_cast<uint8_t>(CSVState::CARRIAGE_RETURN)] = CSVState::QUOTED;
+	if (delimiter != ' '){
+		transition_array[' '][static_cast<uint8_t>(CSVState::CARRIAGE_RETURN)] = CSVState::EMPTY_SPACE;
+	}
 
 	// 5) Quoted State
 	transition_array[quote][static_cast<uint8_t>(CSVState::QUOTED)] = CSVState::UNQUOTED;
@@ -124,6 +134,18 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 	if (state_machine_options.quote != state_machine_options.escape) {
 		transition_array[escape][static_cast<uint8_t>(CSVState::QUOTED_NEW_LINE)] = CSVState::ESCAPE;
 	}
+
+	// 10) Empty Value State
+	transition_array[delimiter][static_cast<uint8_t>(static_cast<uint8_t>(CSVState::EMPTY_SPACE))] = CSVState::DELIMITER;
+	transition_array[static_cast<uint8_t>('\n')][static_cast<uint8_t>(CSVState::EMPTY_SPACE)] = CSVState::RECORD_SEPARATOR;
+	if (new_line_id == NewLineIdentifier::CARRY_ON) {
+		transition_array[static_cast<uint8_t>('\r')][static_cast<uint8_t>(CSVState::EMPTY_SPACE)] =
+		    CSVState::CARRIAGE_RETURN;
+	} else {
+		transition_array[static_cast<uint8_t>('\r')][static_cast<uint8_t>(CSVState::EMPTY_SPACE)] =
+		    CSVState::RECORD_SEPARATOR;
+	}
+	transition_array[quote][static_cast<uint8_t>(CSVState::EMPTY_SPACE)] = CSVState::QUOTED;
 	// Initialize characters we can skip during processing, for Standard and Quoted states
 	for (idx_t i = 0; i < StateMachine::NUM_TRANSITIONS; i++) {
 		transition_array.skip_standard[i] = true;

--- a/src/include/duckdb/execution/operator/csv_scanner/scanner/base_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/scanner/base_scanner.hpp
@@ -22,7 +22,7 @@ public:
 
 	//! Adds a Value to the result
 	static inline void SetQuoted(ScannerResult &result, idx_t quoted_position) {
-		if (!result.quoted){
+		if (!result.quoted) {
 			result.quoted_position = quoted_position;
 		}
 		result.quoted = true;

--- a/src/include/duckdb/execution/operator/csv_scanner/scanner/base_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/scanner/base_scanner.hpp
@@ -21,7 +21,10 @@ public:
 	ScannerResult(CSVStates &states, CSVStateMachine &state_machine);
 
 	//! Adds a Value to the result
-	static inline void SetQuoted(ScannerResult &result) {
+	static inline void SetQuoted(ScannerResult &result, idx_t quoted_position) {
+		if (!result.quoted){
+			result.quoted_position = quoted_position;
+		}
 		result.quoted = true;
 	}
 	//! Adds a Row to the result
@@ -31,6 +34,7 @@ public:
 	// Variable to keep information regarding quoted and escaped values
 	bool quoted = false;
 	bool escaped = false;
+	idx_t quoted_position = 0;
 
 protected:
 	CSVStates &states;
@@ -172,7 +176,7 @@ protected:
 				if (states.states[0] == CSVState::UNQUOTED) {
 					T::SetEscaped(result);
 				}
-				T::SetQuoted(result);
+				T::SetQuoted(result, iterator.pos.buffer_pos);
 				iterator.pos.buffer_pos++;
 				while (state_machine->transition_array
 				           .skip_quoted[static_cast<uint8_t>(buffer_handle_ptr[iterator.pos.buffer_pos])] &&

--- a/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state.hpp
@@ -23,7 +23,8 @@ enum class CSVState : uint8_t {
 	ESCAPE = 6,           //! State when encountering an escape character (e.g., \)
 	INVALID = 7,          //! Got to an Invalid State, this should error.
 	NOT_SET = 8,          //! If the state is not set, usually the first state before getting the first character
-	QUOTED_NEW_LINE = 9   //! If we have a quoted newline
+	QUOTED_NEW_LINE = 9,   //! If we have a quoted newline
+	EMPTY_SPACE = 10 //! If we have empty spaces in the beginning and end of value
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state.hpp
@@ -23,8 +23,8 @@ enum class CSVState : uint8_t {
 	ESCAPE = 6,           //! State when encountering an escape character (e.g., \)
 	INVALID = 7,          //! Got to an Invalid State, this should error.
 	NOT_SET = 8,          //! If the state is not set, usually the first state before getting the first character
-	QUOTED_NEW_LINE = 9,   //! If we have a quoted newline
-	EMPTY_SPACE = 10 //! If we have empty spaces in the beginning and end of value
+	QUOTED_NEW_LINE = 9,  //! If we have a quoted newline
+	EMPTY_SPACE = 10      //! If we have empty spaces in the beginning and end of value
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state_machine.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state_machine.hpp
@@ -74,8 +74,6 @@ struct CSVStates {
 //! the states. Note: The State Machine is currently utilized solely in the CSV Sniffer.
 class CSVStateMachine {
 public:
-	std::once_flag call_once_flag;
-
 	explicit CSVStateMachine(CSVReaderOptions &options_p, const CSVStateMachineOptions &state_machine_options,
 	                         CSVStateMachineCache &csv_state_machine_cache_p);
 

--- a/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.hpp
@@ -19,7 +19,7 @@ namespace duckdb {
 //! Class to wrap the state machine matrix
 class StateMachine {
 public:
-	static constexpr uint32_t NUM_STATES = 10;
+	static constexpr uint32_t NUM_STATES = 11;
 	static constexpr uint32_t NUM_TRANSITIONS = 256;
 	CSVState state_machine[NUM_TRANSITIONS][NUM_STATES];
 	//! Transitions where we might skip processing

--- a/test/sql/copy/csv/auto/test_sniffer_empty_start_value.test
+++ b/test/sql/copy/csv/auto/test_sniffer_empty_start_value.test
@@ -1,0 +1,14 @@
+# name: test/sql/copy/csv/auto/test_sniffer_empty_start_value.test
+# description: Test reading a value with empty spaces at the beginning
+# group: [auto]
+
+statement ok
+PRAGMA enable_verification
+
+query III
+from read_csv('data/csv/empty_space_start_value.csv', delim = ',')
+----
+1968	86	Greetings
+1970	17	Bloody Mama
+1970	73	Hi, Mom!
+1971	40	Born to Win

--- a/test/sql/copy/csv/auto/test_sniffer_empty_start_value.test
+++ b/test/sql/copy/csv/auto/test_sniffer_empty_start_value.test
@@ -6,7 +6,7 @@ statement ok
 PRAGMA enable_verification
 
 query III
-from read_csv('data/csv/empty_space_start_value.csv', delim = ',')
+from read_csv('data/csv/empty_space_start_value.csv')
 ----
 1968	86	Greetings
 1970	17	Bloody Mama


### PR DESCRIPTION
Before, we could only detect quoted values if the quote started right after the delimiter
1968,  86,"Greetings"

Now, we can eliminate white spaces after delimiters.
1968,  86, "Greetings"

This PR introduces a new CSV State to figure that out.