### PR TITLE
Bugfix/#10441 correctly validate second colon in jdbc url parameter in Java client.

### DIFF
--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBConnection.java
@@ -37,7 +37,7 @@ public final class DuckDBConnection implements java.sql.Connection {
 
     public static DuckDBConnection newConnection(String url, boolean readOnly, Properties properties)
         throws SQLException {
-        if (!url.startsWith("jdbc:duckdb")) {
+        if (!url.startsWith("jdbc:duckdb:")) {
             throw new SQLException("DuckDB JDBC URL needs to start with 'jdbc:duckdb:'");
         }
         String db_dir = url.substring("jdbc:duckdb:".length()).trim();

--- a/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2150,7 +2150,7 @@ public class TestDuckDBJDBC {
         assertNull(d.connect("jdbc:h2:", null));
     }
 
-    public static void test_new_connection_wrong_url_bug10441() {
+    public static void test_new_connection_wrong_url_bug10441() throws Exception {
         try {
             DuckDBConnection.newConnection("jdbc:duckdb@", false, new Properties());
             fail();

--- a/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2151,11 +2151,14 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_new_connection_wrong_url_bug10441() throws Exception {
-        try {
-            DuckDBConnection.newConnection("jdbc:duckdb@", false, new Properties());
-            fail();
-        } catch (SQLException e) {
-        }
+        assertThrows(() -> {
+            Connection connection = DuckDBConnection.newConnection("jdbc:duckdb@", false, new Properties());
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                // ignored
+            }
+        }, SQLException.class);
     }
 
     public static void test_parquet_reader() throws Exception {

--- a/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2150,6 +2150,14 @@ public class TestDuckDBJDBC {
         assertNull(d.connect("jdbc:h2:", null));
     }
 
+    public static void test_new_connection_wrong_url_bug10441() {
+        try {
+            DuckDBConnection.newConnection("jdbc:duckdb@", false, new Properties());
+            fail();
+        } catch (SQLException e) {
+        }
+    }
+
     public static void test_parquet_reader() throws Exception {
         Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();


### PR DESCRIPTION
Add a test case and a bugfix for the incomplete validation of the JDBC `url` parameter in `org.duckdb.DuckDBConnection#newConnection`.