### PR TITLE
Fix: correctly calculate the range of build side for perfect hash join

### DIFF
--- a/src/common/types/row/partitioned_tuple_data.cpp
+++ b/src/common/types/row/partitioned_tuple_data.cpp
@@ -32,12 +32,6 @@ void PartitionedTupleData::InitializeAppendState(PartitionedTupleDataAppendState
 	state.partition_sel.Initialize();
 	state.reverse_partition_sel.Initialize();
 
-	vector<column_t> column_ids;
-	column_ids.reserve(layout.ColumnCount());
-	for (idx_t col_idx = 0; col_idx < layout.ColumnCount(); col_idx++) {
-		column_ids.emplace_back(col_idx);
-	}
-
 	InitializeAppendStateInternal(state, properties);
 }
 

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1051,4 +1051,21 @@ double PhysicalHashJoin::GetProgress(ClientContext &context, GlobalSourceState &
 	return progress * 100.0;
 }
 
+string PhysicalHashJoin::ParamsToString() const {
+	string result = EnumUtil::ToString(join_type) + "\n";
+	for (auto &it : conditions) {
+		string op = ExpressionTypeToOperator(it.comparison);
+		result += it.left->GetName() + " " + op + " " + it.right->GetName() + "\n";
+	}
+	result += "\n[INFOSEPARATOR]\n";
+	if (perfect_join_statistics.is_build_small) {
+		// perfect hash join
+		result += "Build Min: " + perfect_join_statistics.build_min.ToString() + "\n";
+		result += "Build Max: " + perfect_join_statistics.build_max.ToString() + "\n";
+		result += "\n[INFOSEPARATOR]\n";
+	}
+	result += StringUtil::Format("EC: %llu\n", estimated_cardinality);
+	return result;
+}
+
 } // namespace duckdb

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -82,7 +82,7 @@ void CheckForPerfectJoinOpt(LogicalComparisonJoin &op, PerfectHashJoinStats &joi
 	}
 
 	// and when the build range is smaller than the threshold
-	auto &stats_build = *op.join_stats[0].get(); // lhs stats
+	auto &stats_build = *op.join_stats[1].get(); // rhs stats
 	if (!NumericStats::HasMinMax(stats_build)) {
 		return;
 	}
@@ -97,7 +97,7 @@ void CheckForPerfectJoinOpt(LogicalComparisonJoin &op, PerfectHashJoinStats &joi
 	}
 
 	// Fill join_stats for invisible join
-	auto &stats_probe = *op.join_stats[1].get(); // rhs stats
+	auto &stats_probe = *op.join_stats[0].get(); // lhs stats
 	if (!NumericStats::HasMinMax(stats_probe)) {
 		return;
 	}

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -53,6 +53,9 @@ public:
 	PerfectHashJoinStats perfect_join_statistics;
 
 public:
+	string ParamsToString() const override;
+
+public:
 	// Operator Interface
 	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;
 

--- a/test/sql/join/inner/perfect_hash_join.test
+++ b/test/sql/join/inner/perfect_hash_join.test
@@ -1,0 +1,43 @@
+# name: test/sql/join/inner/perfect_hash_join.test
+# description: Test perfect hash join
+# group: [inner]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t1 (a INTEGER)
+
+statement ok
+CREATE TABLE t2 (a INTEGER)
+
+statement ok
+INSERT INTO t1 SELECT * FROM range(10)
+
+statement ok
+INSERT INTO t2 SELECT * FROM range(100)
+
+# perfect hash join is used when build range is small
+query II
+EXPLAIN SELECT * FROM t1 INNER JOIN t2 on t1.a = t2.a + 1
+----
+physical_plan	<REGEX>:.*Build Min: 0.*Build Max: 9.*
+
+
+statement ok
+CREATE TABLE t3 (a INTEGER)
+
+statement ok
+CREATE TABLE t4 (a INTEGER)
+
+statement ok
+INSERT INTO t3 SELECT * FROM range(0, 10000000, 1000000)
+
+statement ok
+INSERT INTO t4 SELECT * FROM range(0, 10000000, 1000000)
+
+# perfect hash join is not used when build range is large
+query II
+EXPLAIN SELECT * FROM t3 INNER JOIN t4 on t3.a = t4.a
+----
+physical_plan	<!REGEX>:.*Build Min: .*


### PR DESCRIPTION
The probe side sits on the lhs, and the build side sits on the rhs. Therefore, the range of the build side should be calculated based on the rhs.
Also, we remove a piece of unused code in this pr.