### PR TITLE
add support for date, time, timestamp types to the Julia appender api

### DIFF
--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -2676,7 +2676,7 @@ Append a duckdb_time value to the appender.
 DUCKDB_API duckdb_state duckdb_append_time(duckdb_appender appender, duckdb_time value);
 """
 function duckdb_append_time(appender, value)
-    return ccall((:duckdb_append_time, libduckdb), duckdb_state, (duckdb_appender, Int32), appender, value)
+    return ccall((:duckdb_append_time, libduckdb), duckdb_state, (duckdb_appender, Int64), appender, value)
 end
 
 """
@@ -2684,7 +2684,7 @@ Append a duckdb_timestamp value to the appender.
 DUCKDB_API duckdb_state duckdb_append_timestamp(duckdb_appender appender, duckdb_timestamp value);
 """
 function duckdb_append_timestamp(appender, value)
-    return ccall((:duckdb_append_timestamp, libduckdb), duckdb_state, (duckdb_appender, Int32), appender, value)
+    return ccall((:duckdb_append_timestamp, libduckdb), duckdb_state, (duckdb_appender, Int64), appender, value)
 end
 
 """

--- a/tools/juliapkg/src/appender.jl
+++ b/tools/juliapkg/src/appender.jl
@@ -1,3 +1,4 @@
+using Dates
 
 """
 An appender object that can be used to append to a table
@@ -40,7 +41,7 @@ function close(appender::Appender)
 end
 
 append(appender::Appender, val::AbstractFloat) = duckdb_append_double(appender.handle, Float64(val));
-append(appender::Appender, val::Bool) = duckdb_append_boolean(appender.handle, val);
+append(appender::Appender, val::Bool) = duckdb_append_bool(appender.handle, val);
 append(appender::Appender, val::Int8) = duckdb_append_int8(appender.handle, val);
 append(appender::Appender, val::Int16) = duckdb_append_int16(appender.handle, val);
 append(appender::Appender, val::Int32) = duckdb_append_int32(appender.handle, val);
@@ -51,11 +52,18 @@ append(appender::Appender, val::UInt32) = duckdb_append_uint32(appender.handle, 
 append(appender::Appender, val::UInt64) = duckdb_append_uint64(appender.handle, val);
 append(appender::Appender, val::Float32) = duckdb_append_float(appender.handle, val);
 append(appender::Appender, val::Float64) = duckdb_append_double(appender.handle, val);
-append(appender::Appender, val::Missing) = duckdb_append_null(appender.handle);
-append(appender::Appender, val::Nothing) = duckdb_append_null(appender.handle);
+append(appender::Appender, val::Type{Missing}) = duckdb_append_null(appender.handle);
+append(appender::Appender, val::Type{Nothing}) = duckdb_append_null(appender.handle);
 append(appender::Appender, val::AbstractString) = duckdb_append_varchar(appender.handle, val);
 append(appender::Appender, val::Vector{UInt8}) = duckdb_append_blob(appender.handle, val, sizeof(val));
 append(appender::Appender, val::WeakRefString{UInt8}) = duckdb_append_varchar(stmt.handle, i, val.ptr, val.len);
+append(appender::Appender, val::Date) =
+    duckdb_append_date(appender.handle, Dates.date2epochdays(val) - ROUNDING_EPOCH_TO_UNIX_EPOCH_DAYS);
+# nanosecond to microseconds
+append(appender::Appender, val::Time) = duckdb_append_time(appender.handle, Dates.value(val) / 1000);
+# milliseconds to microseconds
+append(appender::Appender, val::DateTime) =
+    duckdb_append_timestamp(appender.handle, (Dates.datetime2epochms(val) - ROUNDING_EPOCH_TO_UNIX_EPOCH_MS) * 1000);
 
 function append(appender::Appender, val::Any)
     println(val)

--- a/tools/juliapkg/src/ctypes.jl
+++ b/tools/juliapkg/src/ctypes.jl
@@ -4,7 +4,6 @@ const duckdb_config = Ptr{Cvoid}
 const duckdb_connection = Ptr{Cvoid}
 const duckdb_prepared_statement = Ptr{Cvoid}
 const duckdb_pending_result = Ptr{Cvoid}
-const duckdb_logical_type = Ptr{Cvoid}
 const duckdb_data_chunk = Ptr{Cvoid}
 const duckdb_vector = Ptr{Cvoid}
 const duckdb_appender = Ptr{Cvoid}

--- a/tools/juliapkg/test/test_appender.jl
+++ b/tools/juliapkg/test/test_appender.jl
@@ -53,8 +53,8 @@ end
             time TIME,
             timestamp TIMESTAMP, 
             missingval INTEGER,
-            nothingval INTEGER)"
-            # varchar VARCHAR
+            nothingval INTEGER,
+            varchar VARCHAR)"
     )
 
     # Create the appender
@@ -77,7 +77,7 @@ end
     DuckDB.append(appender, Dates.DateTime("1970-01-02T01:23:45.678"))
     DuckDB.append(appender, Missing)
     DuckDB.append(appender, Nothing)
-    # DuckDB.append(appender, "Foo")
+    DuckDB.append(appender, "Foo")
     # End the row of the appender
     DuckDB.end_row(appender)
     # Destroy the appender and flush the data
@@ -105,7 +105,7 @@ end
     @test df.timestamp == [Dates.DateTime("1970-01-02T01:23:45.678")]
     @test isequal(df.missingval, [missing])
     @test isequal(df.nothingval, [missing])
-    # @test df.varchar == ["Foo"]
+    @test df.varchar == ["Foo"]
 
     # close the database 
     DBInterface.close!(db)

--- a/tools/juliapkg/test/test_appender.jl
+++ b/tools/juliapkg/test/test_appender.jl
@@ -30,60 +30,83 @@ end
     @test df.i == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 end
 
-# @testset "Appender API" begin
-#     # Open the database
-#     db = DuckDB.open(":memory:")
-#     con = DuckDB.connect(db)
-#
-#     # Create the table the data is appended to
-#     DuckDB.execute(con, "CREATE TABLE dtypes(bol BOOLEAN, tint TINYINT, sint SMALLINT, int INTEGER, bint BIGINT, utint UTINYINT, usint USMALLINT, uint UINTEGER, ubint UBIGINT, float FLOAT, double DOUBLE, date DATE, time TIME, vchar VARCHAR, nullval INTEGER)")
-#
-#     # Create the appender
-#     appender = DuckDB.appender_create(con, "dtypes")
-#
-#     # Append the different data types
-#     DuckDB.duckdb_append_bool(appender, true)
-#     DuckDB.duckdb_append_int8(appender, 1)
-#     DuckDB.duckdb_append_int16(appender, 2)
-#     DuckDB.duckdb_append_int32(appender, 3)
-#     DuckDB.duckdb_append_int64(appender, 4)
-#     DuckDB.duckdb_append_uint8(appender, 1)
-#     DuckDB.duckdb_append_uint16(appender, 2)
-#     DuckDB.duckdb_append_uint32(appender, 3)
-#     DuckDB.duckdb_append_uint64(appender, 4)
-#     DuckDB.duckdb_append_float(appender, 1.0)
-#     DuckDB.duckdb_append_double(appender, 2.0)
-#     DuckDB.duckdb_append_date(appender, 100)
-#     DuckDB.duckdb_append_time(appender, 200)
-#     DuckDB.duckdb_append_varchar(appender, "Foo")
-#     DuckDB.duckdb_append_null(appender)
-#     # End the row of the appender
-#     DuckDB.duckdb_appender_end_row(appender)
-#     # Destroy the appender and flush the data
-#     DuckDB.duckdb_appender_destroy(appender)
-#
-#     # Retrive the data from the table and store it in  a vector
-#     df = DuckDB.toDataFrame(con, "select * from dtypes;")
-#     data = Matrix(df)
-#
-#     # Test if the correct types have been appended to the table
-#     @test data[1] === true
-#     @test data[2] === Int8(1)
-#     @test data[3] === Int16(2)
-#     @test data[4] === Int32(3)
-#     @test data[5] === Int64(4)
-#     @test data[6] === UInt8(1)
-#     @test data[7] === UInt16(2)
-#     @test data[8] === UInt32(3)
-#     @test data[9] === UInt64(4)
-#     @test data[10] === Float32(1.0)
-#     @test data[11] === Float64(2.0)
-#     @test data[12] === Dates.Date("1970-04-11")
-#     @test data[13] === Dates.Time(0, 0, 0, 0, 200)
-#     @test data[14] === "Foo"
-#     @test data[15] === missing
-#
-#     # Disconnect and close the database
-#     DuckDB.disconnect(con)
-#     DuckDB.close(db)
-# end
+@testset "Appender API" begin
+    # Open the database
+    db = DBInterface.connect(DuckDB.DB)
+
+    # Create the table the data is appended to
+    DuckDB.execute(
+        db,
+        "CREATE TABLE dtypes(
+            bool BOOLEAN, 
+            tint TINYINT, 
+            sint SMALLINT, 
+            int INTEGER, 
+            bint BIGINT, 
+            utint UTINYINT, 
+            usint USMALLINT, 
+            uint UINTEGER, 
+            ubint UBIGINT, 
+            float FLOAT, 
+            double DOUBLE, 
+            date DATE, 
+            time TIME,
+            timestamp TIMESTAMP, 
+            missingval INTEGER,
+            nothingval INTEGER)"
+            # varchar VARCHAR
+    )
+
+    # Create the appender
+    appender = DuckDB.Appender(db, "dtypes")
+
+    # Append the different data types
+    DuckDB.append(appender, true)
+    DuckDB.append(appender, -1)
+    DuckDB.append(appender, -2)
+    DuckDB.append(appender, -3)
+    DuckDB.append(appender, -4)
+    DuckDB.append(appender, 1)
+    DuckDB.append(appender, 2)
+    DuckDB.append(appender, 3)
+    DuckDB.append(appender, 4)
+    DuckDB.append(appender, 1.0)
+    DuckDB.append(appender, 2.0)
+    DuckDB.append(appender, Dates.Date("1970-04-11"))
+    DuckDB.append(appender, Dates.Time(0, 0, 0, 0, 200))
+    DuckDB.append(appender, Dates.DateTime("1970-01-02T01:23:45.678"))
+    DuckDB.append(appender, Missing)
+    DuckDB.append(appender, Nothing)
+    # DuckDB.append(appender, "Foo")
+    # End the row of the appender
+    DuckDB.end_row(appender)
+    # Destroy the appender and flush the data
+    DuckDB.flush(appender)
+    DuckDB.close(appender)
+
+    # Retrive the data from the table and store it in  a vector
+    results = DBInterface.execute(db, "select * from dtypes;")
+    df = DataFrame(results)
+
+    # Test if the correct types have been appended to the table
+    @test df.bool == [true]
+    @test df.tint == [Int8(-1)]
+    @test df.sint == [Int16(-2)]
+    @test df.int == [Int32(-3)]
+    @test df.bint == [Int64(-4)]
+    @test df.utint == [UInt8(1)]
+    @test df.usint == [UInt16(2)]
+    @test df.uint == [UInt32(3)]
+    @test df.ubint == [UInt64(4)]
+    @test df.float == [Float32(1.0)]
+    @test df.double == [Float64(2.0)]
+    @test df.date == [Dates.Date("1970-04-11")]
+    @test df.time == [Dates.Time(0, 0, 0, 0, 200)]
+    @test df.timestamp == [Dates.DateTime("1970-01-02T01:23:45.678")]
+    @test isequal(df.missingval, [missing])
+    @test isequal(df.nothingval, [missing])
+    # @test df.varchar == ["Foo"]
+
+    # close the database 
+    DBInterface.close!(db)
+end


### PR DESCRIPTION
Add support for date, time, timestamp types to the appender api, and add the test cases for all types.

Also remove a duplicate `const duckdb_logical_type` in the c type api.