### PR TITLE
Keep file extension for temporary files

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -215,7 +215,7 @@ string FileSystem::GetWorkingDirectory() {
 
 string FileSystem::JoinPath(const string &a, const string &b) {
 	// FIXME: sanitize paths
-	return a + PathSeparator(a) + b;
+	return a.empty() ? b : a + PathSeparator(a) + b;
 }
 
 string FileSystem::ConvertSeparators(const string &path) {

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -583,4 +583,38 @@ string StringUtil::ToJSONMap(ExceptionType type, const string &message, const un
 	return result;
 }
 
+string StringUtil::GetFileName(const string &file_path) {
+	idx_t pos = file_path.find_last_of("/\\");
+	if (pos == string::npos) {
+		return file_path;
+	}
+	return file_path.substr(pos + 1);
+}
+
+string StringUtil::GetFileExtension(const string &file_name) {
+	auto name = GetFileName(file_name);
+	idx_t pos = name.find_last_of('.');
+	if (pos == string::npos) {
+		return "";
+	}
+	return name.substr(pos + 1);
+}
+
+string StringUtil::GetFileStem(const string &file_name) {
+	auto name = GetFileName(file_name);
+	idx_t pos = name.find_last_of('.');
+	if (pos == string::npos) {
+		return name;
+	}
+	return name.substr(0, pos);
+}
+
+string StringUtil::GetFilePath(const string &file_path) {
+	idx_t pos = file_path.find_last_of("/\\");
+	if (pos == string::npos) {
+		return "";
+	}
+	return file_path.substr(0, pos);
+}
+
 } // namespace duckdb

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -584,17 +584,39 @@ string StringUtil::ToJSONMap(ExceptionType type, const string &message, const un
 }
 
 string StringUtil::GetFileName(const string &file_path) {
+
+	if (EndsWith(file_path, "..")) {
+		return "";
+	}
+
 	idx_t pos = file_path.find_last_of("/\\");
 	if (pos == string::npos) {
 		return file_path;
 	}
-	return file_path.substr(pos + 1);
+	auto end = file_path.size() - 1;
+
+	// If the rest of the string is just slashes or dots, trim them
+	if (file_path.find_first_not_of("/\\.", pos) == string::npos) {
+		// Trim the trailing slashes and dots
+		while (end > 0 && (file_path[end] == '/' || file_path[end] == '.' || file_path[end] == '\\')) {
+			end--;
+		}
+
+		// Now find the next slash
+		pos = file_path.find_last_of("/\\", end);
+		if (pos == string::npos) {
+			return file_path.substr(0, end + 1);
+		}
+	}
+
+	return file_path.substr(pos + 1, end - pos);
 }
 
 string StringUtil::GetFileExtension(const string &file_name) {
 	auto name = GetFileName(file_name);
 	idx_t pos = name.find_last_of('.');
-	if (pos == string::npos) {
+	// We dont consider e.g. `.gitignore` to have an extension
+	if (pos == string::npos || pos == 0) {
 		return "";
 	}
 	return name.substr(pos + 1);
@@ -602,6 +624,9 @@ string StringUtil::GetFileExtension(const string &file_name) {
 
 string StringUtil::GetFileStem(const string &file_name) {
 	auto name = GetFileName(file_name);
+	if (name.size() > 1 && name[0] == '.') {
+		return name;
+	}
 	idx_t pos = name.find_last_of('.');
 	if (pos == string::npos) {
 		return name;

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -635,11 +635,23 @@ string StringUtil::GetFileStem(const string &file_name) {
 }
 
 string StringUtil::GetFilePath(const string &file_path) {
-	idx_t pos = file_path.find_last_of("/\\");
+
+	// Trim the trailing slashes
+	auto end = file_path.size() - 1;
+	while (end > 0 && (file_path[end] == '/' || file_path[end] == '\\')) {
+		end--;
+	}
+
+	auto pos = file_path.find_last_of("/\\", end);
 	if (pos == string::npos) {
 		return "";
 	}
-	return file_path.substr(0, pos);
+
+	while (pos > 0 && (file_path[pos] == '/' || file_path[pos] == '\\')) {
+		pos--;
+	}
+
+	return file_path.substr(0, pos + 1);
 }
 
 } // namespace duckdb

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -14,10 +14,6 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFile(const string &path, uint8_t f
 	if (compression == FileCompressionType::AUTO_DETECT) {
 		// auto detect compression settings based on file name
 		auto lower_path = StringUtil::Lower(path);
-		if (StringUtil::EndsWith(lower_path, ".tmp")) {
-			// strip .tmp
-			lower_path = lower_path.substr(0, lower_path.length() - 4);
-		}
 		if (StringUtil::EndsWith(lower_path, ".gz")) {
 			compression = FileCompressionType::GZIP;
 		} else if (StringUtil::EndsWith(lower_path, ".zst")) {

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -14,6 +14,10 @@ unique_ptr<FileHandle> VirtualFileSystem::OpenFile(const string &path, uint8_t f
 	if (compression == FileCompressionType::AUTO_DETECT) {
 		// auto detect compression settings based on file name
 		auto lower_path = StringUtil::Lower(path);
+		if (StringUtil::EndsWith(lower_path, ".tmp")) {
+			// strip .tmp
+			lower_path = lower_path.substr(0, lower_path.length() - 4);
+		}
 		if (StringUtil::EndsWith(lower_path, ".gz")) {
 			compression = FileCompressionType::GZIP;
 		} else if (StringUtil::EndsWith(lower_path, ".zst")) {

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -112,7 +112,7 @@ unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext
 //===--------------------------------------------------------------------===//
 void PhysicalCopyToFile::MoveTmpFile(ClientContext &context, const string &tmp_file_path) {
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto file_path = tmp_file_path.substr(0, tmp_file_path.length() - 4);
+	auto file_path = tmp_file_path.substr(strlen("tmp_"));
 	if (fs.FileExists(file_path)) {
 		fs.RemoveFile(file_path);
 	}

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -116,13 +116,14 @@ void PhysicalCopyToFile::MoveTmpFile(ClientContext &context, const string &tmp_f
 	auto path = StringUtil::GetFilePath(tmp_file_path);
 	auto base = StringUtil::GetFileStem(tmp_file_path);
 	auto extension = StringUtil::GetFileExtension(tmp_file_path);
+	extension = extension.empty() ? extension : "." + extension;
 
 	auto suffix = base.rfind("_tmp");
 	if (suffix != string::npos) {
 		base = base.substr(0, suffix);
 	}
 
-	auto file_path = fs.JoinPath(path, base + "." + extension);
+	auto file_path = fs.JoinPath(path, base + extension);
 	if (fs.FileExists(file_path)) {
 		fs.RemoveFile(file_path);
 	}

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -112,7 +112,17 @@ unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext
 //===--------------------------------------------------------------------===//
 void PhysicalCopyToFile::MoveTmpFile(ClientContext &context, const string &tmp_file_path) {
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto file_path = tmp_file_path.substr(strlen("tmp_"));
+
+	auto path = StringUtil::GetFilePath(tmp_file_path);
+	auto base = StringUtil::GetFileStem(tmp_file_path);
+	auto extension = StringUtil::GetFileExtension(tmp_file_path);
+
+	auto suffix = base.rfind("_tmp");
+	if (suffix != string::npos) {
+		base = base.substr(0, suffix);
+	}
+
+	auto file_path = fs.JoinPath(path, base + "." + extension);
 	if (fs.FileExists(file_path)) {
 		fs.RemoveFile(file_path);
 	}

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -13,7 +13,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	auto &fs = FileSystem::GetFileSystem(context);
 	op.file_path = fs.ExpandPath(op.file_path);
 	if (op.use_tmp_file) {
-		op.file_path += ".tmp";
+		op.file_path = "tmp_" + op.file_path;
 	}
 	if (op.per_thread_output || op.file_size_bytes.IsValid() || op.partition_output || !op.partition_columns.empty() ||
 	    op.overwrite_or_ignore) {

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -13,7 +13,10 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	auto &fs = FileSystem::GetFileSystem(context);
 	op.file_path = fs.ExpandPath(op.file_path);
 	if (op.use_tmp_file) {
-		op.file_path = "tmp_" + op.file_path;
+		auto path = StringUtil::GetFilePath(op.file_path);
+		auto base = StringUtil::GetFileStem(op.file_path);
+		auto extension = StringUtil::GetFileExtension(op.file_path);
+		op.file_path = fs.JoinPath(path, base + "_tmp." + extension);
 	}
 	if (op.per_thread_output || op.file_size_bytes.IsValid() || op.partition_output || !op.partition_columns.empty() ||
 	    op.overwrite_or_ignore) {

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -16,7 +16,9 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 		auto path = StringUtil::GetFilePath(op.file_path);
 		auto base = StringUtil::GetFileStem(op.file_path);
 		auto extension = StringUtil::GetFileExtension(op.file_path);
-		op.file_path = fs.JoinPath(path, base + "_tmp." + extension);
+		extension = extension.empty() ? extension : "." + extension;
+
+		op.file_path = fs.JoinPath(path, base + "_tmp" + extension);
 	}
 	if (op.per_thread_output || op.file_size_bytes.IsValid() || op.partition_output || !op.partition_columns.empty() ||
 	    op.overwrite_or_ignore) {

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -257,6 +257,11 @@ public:
 	//! NOTE: this method is not efficient
 	DUCKDB_API static string ToJSONMap(ExceptionType type, const string &message,
 	                                   const unordered_map<string, string> &map);
+
+	DUCKDB_API static string GetFileName(const string &file_path);
+	DUCKDB_API static string GetFileExtension(const string &file_name);
+	DUCKDB_API static string GetFileStem(const string &file_name);
+	DUCKDB_API static string GetFilePath(const string &file_path);
 };
 
 } // namespace duckdb

--- a/test/common/test_string_util.cpp
+++ b/test/common/test_string_util.cpp
@@ -229,3 +229,32 @@ TEST_CASE("Test split quoted strings", "[string_util]") {
 		REQUIRE_THROWS_AS(StringUtil::SplitWithQuote("x y"), ParserException);
 	}
 }
+
+TEST_CASE("Test path utilities", "[string_util]") {
+	SECTION("File name") {
+		REQUIRE("bin" == StringUtil::GetFileName("/usr/bin/"));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("/tmp/foo.txt"));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt/."));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt/.//"));
+		REQUIRE("" == StringUtil::GetFileName(".."));
+		REQUIRE("" == StringUtil::GetFileName("/"));
+	}
+
+	SECTION("File extension") {
+		REQUIRE("cpp" == StringUtil::GetFileExtension("test.cpp"));
+		REQUIRE("gz" == StringUtil::GetFileExtension("test.cpp.gz"));
+		REQUIRE("" == StringUtil::GetFileExtension("test"));
+		REQUIRE("" == StringUtil::GetFileExtension(".gitignore"));
+	}
+
+	SECTION("File stem (base name)") {
+		REQUIRE("test" == StringUtil::GetFileStem("test.cpp"));
+		REQUIRE("test.cpp" == StringUtil::GetFileStem("test.cpp.gz"));
+		REQUIRE("test" == StringUtil::GetFileStem("test"));
+		REQUIRE(".gitignore" == StringUtil::GetFileStem(".gitignore"));
+	}
+
+	SECTION("File path") {
+		REQUIRE("/usr/local/bin" == StringUtil::GetFilePath("/usr/local/bin/test.cpp"));
+	}
+}

--- a/test/common/test_string_util.cpp
+++ b/test/common/test_string_util.cpp
@@ -233,9 +233,17 @@ TEST_CASE("Test split quoted strings", "[string_util]") {
 TEST_CASE("Test path utilities", "[string_util]") {
 	SECTION("File name") {
 		REQUIRE("bin" == StringUtil::GetFileName("/usr/bin/"));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt"));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("tmp/foo.txt"));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("tmp\\foo.txt"));
 		REQUIRE("foo.txt" == StringUtil::GetFileName("/tmp/foo.txt"));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("\\tmp\\foo.txt"));
 		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt/."));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt/./"));
 		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt/.//"));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt\\."));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt\\.\\"));
+		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt\\.\\\\"));
 		REQUIRE("" == StringUtil::GetFileName(".."));
 		REQUIRE("" == StringUtil::GetFileName("/"));
 	}
@@ -252,9 +260,33 @@ TEST_CASE("Test path utilities", "[string_util]") {
 		REQUIRE("test.cpp" == StringUtil::GetFileStem("test.cpp.gz"));
 		REQUIRE("test" == StringUtil::GetFileStem("test"));
 		REQUIRE(".gitignore" == StringUtil::GetFileStem(".gitignore"));
+
+		REQUIRE("test" == StringUtil::GetFileStem("test.cpp/"));
+		REQUIRE("test" == StringUtil::GetFileStem("test.cpp/."));
+		REQUIRE("test" == StringUtil::GetFileStem("test.cpp/./"));
+		REQUIRE("test" == StringUtil::GetFileStem("test.cpp/.//"));
+		REQUIRE("test" == StringUtil::GetFileStem("test.cpp\\"));
+		REQUIRE("test" == StringUtil::GetFileStem("test.cpp\\."));
+		REQUIRE("test" == StringUtil::GetFileStem("test.cpp\\.\\"));
+		REQUIRE("test" == StringUtil::GetFileStem("test.cpp\\.\\\\"));
+		REQUIRE("" == StringUtil::GetFileStem(".."));
+		REQUIRE("" == StringUtil::GetFileStem("/"));
+		REQUIRE("test" == StringUtil::GetFileStem("tmp/test.txt"));
+		REQUIRE("test" == StringUtil::GetFileStem("tmp\\test.txt"));
+		REQUIRE("test" == StringUtil::GetFileStem("/tmp/test.txt"));
+		REQUIRE("test" == StringUtil::GetFileStem("\\tmp\\test.txt"));
 	}
 
 	SECTION("File path") {
 		REQUIRE("/usr/local/bin" == StringUtil::GetFilePath("/usr/local/bin/test.cpp"));
+		REQUIRE("\\usr\\local\\bin" == StringUtil::GetFilePath("\\usr\\local\\bin\\test.cpp"));
+		REQUIRE("tmp" == StringUtil::GetFilePath("tmp/test.txt"));
+		REQUIRE("tmp" == StringUtil::GetFilePath("tmp\\test.txt"));
+		REQUIRE("/tmp" == StringUtil::GetFilePath("/tmp/test.txt"));
+		REQUIRE("\\tmp" == StringUtil::GetFilePath("\\tmp\\test.txt"));
+		REQUIRE("/tmp" == StringUtil::GetFilePath("/tmp/test.txt/"));
+		REQUIRE("\\tmp" == StringUtil::GetFilePath("\\tmp\\test.txt\\"));
+		REQUIRE("/tmp" == StringUtil::GetFilePath("/tmp//test.txt"));
+		REQUIRE("\\tmp" == StringUtil::GetFilePath("\\tmp\\\\test.txt"));
 	}
 }

--- a/test/sql/copy/tmp_file.test
+++ b/test/sql/copy/tmp_file.test
@@ -1,0 +1,8 @@
+# name: test/sql/copy/tmp_file.test
+# group: [copy]
+
+statement ok
+copy (select 42 as x) to '__TEST_DIR__/foo';
+
+statement ok
+copy (select 42 as x) to '__TEST_DIR__/foo';


### PR DESCRIPTION
When executing a `COPY TO` and the output file already exists, DuckDB by default writes the result to a temporary file which it then replaces the original file with when the copy is done. This temporary file gets the suffix `.tmp`. 

However, when implementing copy functions using external libraries (*cough* GDAL *cough*) they sometimes enforce the file extension as an extra validation step. This then breaks when the temporary file extension is changed.

This PR changes it so that temporary files keep their original extension, but instead get suffixed with a `_tmp` _before_ the extension part. So `foo.csv.tmp` becomes `foo_tmp.csv`. These files are usually not in focus to the user anyway so the exact representation is not that important IMO.

In the process I've also added some additional methods to the `StringUtil` class to help with path manipulation. Im happy to receive feedback on these but I loosely modeled their semantics after the path library in [rust](https://doc.rust-lang.org/std/path/struct.Path.html) (which I think is very well thought-out).

Closes https://github.com/duckdb/duckdb_spatial/issues/231