### PR TITLE
[Bug Fix] [CSV Sniffing] Removing double quotes in header

### DIFF
--- a/data/csv/double_quoted_header.csv
+++ b/data/csv/double_quoted_header.csv
@@ -1,0 +1,3 @@
+"foo ""bar",name
+1,rob
+2,sally

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -238,7 +238,8 @@ void StringValueResult::AddQuotedValue(StringValueResult &result, const idx_t bu
 		// If it's an escaped value we have to remove all the escapes, this is not really great
 		auto value = StringValueScanner::RemoveEscape(
 		    result.buffer_ptr + result.quoted_position + 1, buffer_pos - result.quoted_position - 2,
-		    result.state_machine.options.GetEscape()[0], result.parse_chunk.data[result.chunk_col_id]);
+		    result.state_machine.dialect_options.state_machine_options.escape.GetValue(),
+		    result.parse_chunk.data[result.chunk_col_id]);
 		result.AddValueToVector(value.GetData(), value.GetSize());
 	} else {
 		if (buffer_pos < result.last_position + 2) {

--- a/test/sql/copy/csv/auto/test_double_quoted_header.test
+++ b/test/sql/copy/csv/auto/test_double_quoted_header.test
@@ -1,0 +1,17 @@
+# name: test/sql/copy/csv/auto/test_double_quoted_header.test
+# group: [auto]
+
+statement ok
+PRAGMA enable_verification
+
+query IIIIII
+describe from 'data/csv/double_quoted_header.csv';
+----
+foo "bar	BIGINT	YES	NULL	NULL	NULL
+name	VARCHAR	YES	NULL	NULL	NULL
+
+query II
+from 'data/csv/double_quoted_header.csv';
+----
+1	rob
+2	sally


### PR DESCRIPTION
Fix: #9602

We were basically not properly removing escape values during the header sniffing.