### PR TITLE
CLI: Only show continuation bytes while editing the query

### DIFF
--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -123,6 +123,7 @@ public:
 	size_t maxrows;                          /* Maximum num of rows used so far (multiline mode) */
 	idx_t history_index;                     /* The history index we are currently editing. */
 	bool clear_screen;                       /* Whether we are clearing the screen */
+	bool continuation_markers;               /* Whether or not to render continuation markers */
 	bool search;                             /* Whether or not we are searching our history */
 	bool render;                             /* Whether or not to re-render */
 	bool has_more_data;                      /* Whether or not there is more data available in the buffer (copy+paste)*/

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -914,6 +914,7 @@ Linenoise::Linenoise(int stdin_fd, int stdout_fd, char *buf, size_t buflen, cons
 	search = false;
 	has_more_data = false;
 	render = true;
+	continuation_markers = true;
 
 	/* Buffer starts empty. */
 	buf[0] = '\0';
@@ -1005,6 +1006,8 @@ int Linenoise::Edit() {
 					break;
 				}
 			}
+			// final refresh before returning control to the shell
+			continuation_markers = false;
 			History::RemoveLastEntry();
 			if (Terminal::IsMultiline()) {
 				if (pos == len) {

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -260,6 +260,9 @@ string Linenoise::AddContinuationMarkers(const char *buf, size_t len, int plen, 
 		if (is_newline) {
 			bool is_cursor_row = rows == cursor_row;
 			const char *prompt = is_cursor_row ? continuationSelectedPrompt : continuationPrompt;
+			if (!continuation_markers) {
+				prompt = "";
+			}
 			size_t continuationLen = strlen(prompt);
 			size_t continuationRender = ComputeRenderWidth(prompt, continuationLen);
 			// pad with spaces prior to prompt


### PR DESCRIPTION
Clear all rendered continuation bytes when actually submitting the query to be run, to allow for easier copy pasting of text from the CLI.

CC @carlopi 