### PR TITLE
Group together index instantiation parameters into a struct, pass options map as well.

### DIFF
--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -64,13 +64,9 @@ public:
 
 public:
 	//! Create a index instance of this type
-	static unique_ptr<Index> Create(const string &name, const IndexConstraintType constraint_type,
-	                                const vector<column_t> &column_ids,
-	                                const vector<unique_ptr<Expression>> &unbound_expressions,
-	                                TableIOManager &table_io_manager, AttachedDatabase &db,
-	                                const IndexStorageInfo &storage_info) {
-		auto art = make_uniq<ART>(name, constraint_type, column_ids, table_io_manager, unbound_expressions, db, nullptr,
-		                          storage_info);
+	static unique_ptr<Index> Create(CreateIndexInput &input) {
+		auto art = make_uniq<ART>(input.name, input.constraint_type, input.column_ids, input.table_io_manager,
+		                          input.unbound_expressions, input.db, nullptr, input.storage_info);
 		return std::move(art);
 	}
 

--- a/src/include/duckdb/execution/index/index_type.hpp
+++ b/src/include/duckdb/execution/index/index_type.hpp
@@ -22,12 +22,26 @@ class TableIOManager;
 class AttachedDatabase;
 struct IndexStorageInfo;
 
-typedef unique_ptr<Index> (*index_create_function_t)(const string &name,
-                                                     const IndexConstraintType index_constraint_type,
-                                                     const vector<column_t> &column_ids,
-                                                     const vector<unique_ptr<Expression>> &unbound_expressions,
-                                                     TableIOManager &table_io_manager, AttachedDatabase &db,
-                                                     const IndexStorageInfo &storage_info);
+struct CreateIndexInput {
+	TableIOManager &table_io_manager;
+	AttachedDatabase &db;
+	IndexConstraintType constraint_type;
+	const string &name;
+	const vector<column_t> &column_ids;
+	const vector<unique_ptr<Expression>> &unbound_expressions;
+	const IndexStorageInfo &storage_info;
+	const case_insensitive_map_t<Value> &options;
+
+	CreateIndexInput(TableIOManager &table_io_manager, AttachedDatabase &db, IndexConstraintType constraint_type,
+	                 const string &name, const vector<column_t> &column_ids,
+	                 const vector<unique_ptr<Expression>> &unbound_expressions, const IndexStorageInfo &storage_info,
+	                 const case_insensitive_map_t<Value> &options)
+	    : table_io_manager(table_io_manager), db(db), constraint_type(constraint_type), name(name),
+	      column_ids(column_ids), unbound_expressions(unbound_expressions), storage_info(storage_info),
+	      options(options) {};
+};
+
+typedef unique_ptr<Index> (*index_create_function_t)(CreateIndexInput &input);
 //! A index "type"
 class IndexType {
 public:

--- a/src/include/duckdb/execution/index/index_type.hpp
+++ b/src/include/duckdb/execution/index/index_type.hpp
@@ -12,6 +12,8 @@
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 
 namespace duckdb {
 

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -75,9 +75,11 @@ void TableIndexList::InitializeIndexes(ClientContext &context, DataTableInfo &ta
 		auto &create_info = unknown_index.GetCreateInfo();
 		auto &storage_info = unknown_index.GetStorageInfo();
 
-		auto index_instance = index_type->create_instance(create_info.index_name, create_info.constraint_type,
-		                                                  create_info.column_ids, unknown_index.unbound_expressions,
-		                                                  *table_info.table_io_manager, table_info.db, storage_info);
+		CreateIndexInput input(*table_info.table_io_manager, table_info.db, create_info.constraint_type,
+		                       create_info.index_name, create_info.column_ids, unknown_index.unbound_expressions,
+		                       storage_info, create_info.options);
+
+		auto index_instance = index_type->create_instance(input);
 
 		index = std::move(index_instance);
 	}

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -615,9 +615,11 @@ void WriteAheadLogDeserializer::ReplayCreateIndex() {
 	}
 
 	auto &data_table = table.GetStorage();
-	auto index_instance =
-	    index_type->create_instance(info.index_name, info.constraint_type, info.column_ids, unbound_expressions,
-	                                TableIOManager::Get(data_table), data_table.db, index_info);
+
+	CreateIndexInput input(TableIOManager::Get(data_table), data_table.db, info.constraint_type, info.index_name,
+	                       info.column_ids, unbound_expressions, index_info, info.options);
+
+	auto index_instance = index_type->create_instance(input);
 	data_table.info->indexes.AddIndex(std::move(index_instance));
 }
 


### PR DESCRIPTION
This PR groups together all the parameters passed during index instantiation into a struct to make it easier to manage and extend in the future. Additionally it now also forwards the `case_insensitive_map_t<Value>` of options passed by the user during index creation so that the index has a chance to configure itself in the case that it takes parameters.