### PR TITLE
Add documentation example for Julia appender api.

### DIFF
--- a/tools/juliapkg/src/appender.jl
+++ b/tools/juliapkg/src/appender.jl
@@ -1,7 +1,39 @@
 using Dates
 
 """
-An appender object that can be used to append to a table
+An appender object that can be used to append rows to an existing table.
+
+* DateTime objects in Julia are stored in milliseconds since the Unix epoch but are converted to microseconds when stored in duckdb.
+* Time objects in Julia are stored in nanoseconds since midnight but are converted to microseconds when stored in duckdb.
+* Missing and Nothing are stored as NULL in duckdb, but will be converted to Missing when the data is queried back.
+
+# Example
+```julia
+using DuckDB, DataFrames, Dates
+db = DuckDB.DB()
+
+# create a table
+DBInterface.execute(db, "CREATE OR REPLACE TABLE data(id INT PRIMARY KEY, value FLOAT, timestamp TIMESTAMP, date DATE)")
+
+# data to insert 
+len = 100
+df = DataFrames.DataFrame(id=collect(1:len),
+    value=rand(len),
+    timestamp=Dates.now() + Dates.Second.(1:len),
+    date=Dates.today() + Dates.Day.(1:len))
+
+# append data by row
+appender = DuckDB.Appender(db, "data")
+for i in eachrow(df)
+    for j in i
+        DuckDB.append(appender, j)
+    end
+    DuckDB.end_row(appender)
+end
+# flush the appender after all rows
+DuckDB.flush(appender)
+DuckDB.close(appender)
+```
 """
 mutable struct Appender
     handle::duckdb_appender
@@ -56,7 +88,7 @@ append(appender::Appender, val::Type{Missing}) = duckdb_append_null(appender.han
 append(appender::Appender, val::Type{Nothing}) = duckdb_append_null(appender.handle);
 append(appender::Appender, val::AbstractString) = duckdb_append_varchar(appender.handle, val);
 append(appender::Appender, val::Vector{UInt8}) = duckdb_append_blob(appender.handle, val, sizeof(val));
-append(appender::Appender, val::WeakRefString{UInt8}) = duckdb_append_varchar(stmt.handle, i, val.ptr, val.len);
+# append(appender::Appender, val::WeakRefString{UInt8}) = duckdb_append_varchar(stmt.handle, i, val.ptr, val.len);
 append(appender::Appender, val::Date) =
     duckdb_append_date(appender.handle, Dates.date2epochdays(val) - ROUNDING_EPOCH_TO_UNIX_EPOCH_DAYS);
 # nanosecond to microseconds
@@ -80,4 +112,4 @@ function flush(appender::Appender)
     return
 end
 
-DBInterface.close!(appender::Appender) = _close_appender(db)
+DBInterface.close!(appender::Appender) = _close_appender(appender)

--- a/tools/juliapkg/test/test_appender.jl
+++ b/tools/juliapkg/test/test_appender.jl
@@ -16,18 +16,25 @@ end
     DuckDB.close(appender)
     DuckDB.close(appender)
 
+    # close!
+    appender = DuckDB.Appender(db, "integers")
+    DBInterface.close!(appender)
+
     appender = DuckDB.Appender(db, "integers")
     for i in 0:9
         DuckDB.append(appender, i)
         DuckDB.end_row(appender)
     end
     DuckDB.flush(appender)
+    DuckDB.close(appender)
 
     results = DBInterface.execute(db, "SELECT * FROM integers")
     df = DataFrame(results)
     @test names(df) == ["i"]
     @test size(df, 1) == 10
     @test df.i == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    # close the database 
+    DuckDB.close(appender)
 end
 
 @testset "Appender API" begin


### PR DESCRIPTION
* Add documentation example for Julia appender api.
* Remove non-working support for appending WeakRefString{UInt8} 
* Fix DBInterface.close!
