### PR TITLE
Nested Array Validity Fixes + `RowOperations`

### DIFF
--- a/src/common/row_operations/row_gather.cpp
+++ b/src/common/row_operations/row_gather.cpp
@@ -113,7 +113,7 @@ static void GatherNestedVector(Vector &rows, const SelectionVector &row_sel, Vec
 	}
 
 	// Deserialise into the selected locations
-	HorizontalParentValidity parent_validity(mask_locations.get(), col_no);
+	NestedValidity parent_validity(mask_locations.get(), col_no);
 	RowOperations::HeapGather(col, count, col_sel, data_locations.get(), &parent_validity);
 }
 

--- a/src/common/row_operations/row_gather.cpp
+++ b/src/common/row_operations/row_gather.cpp
@@ -113,7 +113,8 @@ static void GatherNestedVector(Vector &rows, const SelectionVector &row_sel, Vec
 	}
 
 	// Deserialise into the selected locations
-	RowOperations::HeapGather(col, count, col_sel, col_no, data_locations.get(), mask_locations.get());
+	HorizontalParentValidity parent_validity(mask_locations.get(), col_no);
+	RowOperations::HeapGather(col, count, col_sel, data_locations.get(), &parent_validity);
 }
 
 void RowOperations::Gather(Vector &rows, const SelectionVector &row_sel, Vector &col, const SelectionVector &col_sel,

--- a/src/common/row_operations/row_heap_gather.cpp
+++ b/src/common/row_operations/row_heap_gather.cpp
@@ -49,7 +49,8 @@ static void HeapGatherStructVector(Vector &v, const idx_t vcount, const Selectio
 	// now deserialize into the struct vectors
 	auto &children = StructVector::GetEntries(v);
 	for (idx_t i = 0; i < child_types.size(); i++) {
-		RowOperations::HeapGather(*children[i], vcount, sel, i, key_locations, struct_validitymask_locations);
+		HorizontalParentValidity parent_validity(struct_validitymask_locations, i);
+		RowOperations::HeapGather(*children[i], vcount, sel, key_locations, &parent_validity);
 	}
 }
 
@@ -122,7 +123,7 @@ static void HeapGatherListVector(Vector &v, const idx_t vcount, const SelectionV
 			}
 
 			// now deserialize and add to listvector
-			RowOperations::HeapGather(list_vec_to_append, next, *FlatVector::IncrementalSelectionVector(), 0,
+			RowOperations::HeapGather(list_vec_to_append, next, *FlatVector::IncrementalSelectionVector(),
 			                          list_entry_locations, nullptr);
 			ListVector::Append(v, list_vec_to_append, next);
 
@@ -136,7 +137,6 @@ static void HeapGatherListVector(Vector &v, const idx_t vcount, const SelectionV
 static void HeapGatherArrayVector(Vector &v, const idx_t vcount, const SelectionVector &sel,
                                   data_ptr_t *key_locations) {
 	// Setup
-	auto &validity = FlatVector::Validity(v);
 	auto &child_type = ArrayType::GetChildType(v.GetType());
 	auto array_size = ArrayType::GetSize(v.GetType());
 	auto &child_vector = ArrayVector::GetEntry(v);
@@ -148,19 +148,7 @@ static void HeapGatherArrayVector(Vector &v, const idx_t vcount, const Selection
 	// array must have a validitymask for its elements
 	auto array_validitymask_size = (array_size + 7) / 8;
 
-	auto &child_validity = FlatVector::Validity(child_vector);
-
 	for (idx_t i = 0; i < vcount; i++) {
-		// row idx
-		const auto col_idx = sel.get_index(i);
-		if (!validity.RowIsValid(col_idx)) {
-			// we still need to zero out the child validity corresponding to this row
-			for (idx_t elem_idx = 0; elem_idx < array_size; elem_idx++) {
-				child_validity.Set(col_idx * array_size + elem_idx, false);
-			}
-			continue;
-		}
-
 		// Setup validity mask
 		data_ptr_t array_validitymask_location = key_locations[i];
 		key_locations[i] += array_validitymask_size;
@@ -173,20 +161,14 @@ static void HeapGatherArrayVector(Vector &v, const idx_t vcount, const Selection
 			key_locations[i] += array_size * sizeof(idx_t);
 		}
 
-		auto array_start = col_idx * array_size;
-		auto elem_remaining = array_size;
+		// row idx
+		const auto row_idx = sel.get_index(i);
 
-		idx_t offset_in_byte = 0;
+		auto array_start = row_idx * array_size;
+		auto elem_remaining = array_size;
 
 		while (elem_remaining > 0) {
 			auto chunk_size = MinValue(static_cast<idx_t>(STANDARD_VECTOR_SIZE), elem_remaining);
-			for (idx_t elem_idx = 0; elem_idx < chunk_size; elem_idx++) {
-				child_validity.Set(array_start + elem_idx, *(array_validitymask_location) & (1 << offset_in_byte));
-				if (++offset_in_byte == 8) {
-					array_validitymask_location++;
-					offset_in_byte = 0;
-				}
-			}
 
 			SelectionVector array_sel(STANDARD_VECTOR_SIZE);
 
@@ -207,7 +189,9 @@ static void HeapGatherArrayVector(Vector &v, const idx_t vcount, const Selection
 				}
 			}
 
-			RowOperations::HeapGather(child_vector, chunk_size, array_sel, 0, array_entry_locations, nullptr);
+			// Pass on this array's validity mask to the child vector
+			VerticalParentValidity parent_validity(array_validitymask_location);
+			RowOperations::HeapGather(child_vector, chunk_size, array_sel, array_entry_locations, &parent_validity);
 
 			elem_remaining -= chunk_size;
 			array_start += chunk_size;
@@ -215,20 +199,14 @@ static void HeapGatherArrayVector(Vector &v, const idx_t vcount, const Selection
 	}
 }
 
-void RowOperations::HeapGather(Vector &v, const idx_t &vcount, const SelectionVector &sel, const idx_t &col_no,
-                               data_ptr_t *key_locations, data_ptr_t *validitymask_locations) {
+void RowOperations::HeapGather(Vector &v, const idx_t &vcount, const SelectionVector &sel, data_ptr_t *key_locations,
+                               optional_ptr<ParentValidity> parent_validity) {
 	v.SetVectorType(VectorType::FLAT_VECTOR);
 
 	auto &validity = FlatVector::Validity(v);
-	if (validitymask_locations) {
-		// Precompute mask indexes
-		idx_t entry_idx;
-		idx_t idx_in_entry;
-		ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
-
+	if (parent_validity) {
 		for (idx_t i = 0; i < vcount; i++) {
-			ValidityBytes row_mask(validitymask_locations[i]);
-			const auto valid = row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
+			const auto valid = parent_validity->IsValid(i);
 			const auto col_idx = sel.get_index(i);
 			validity.Set(col_idx, valid);
 		}

--- a/src/common/row_operations/row_heap_gather.cpp
+++ b/src/common/row_operations/row_heap_gather.cpp
@@ -49,7 +49,7 @@ static void HeapGatherStructVector(Vector &v, const idx_t vcount, const Selectio
 	// now deserialize into the struct vectors
 	auto &children = StructVector::GetEntries(v);
 	for (idx_t i = 0; i < child_types.size(); i++) {
-		HorizontalParentValidity parent_validity(struct_validitymask_locations, i);
+		NestedValidity parent_validity(struct_validitymask_locations, i);
 		RowOperations::HeapGather(*children[i], vcount, sel, key_locations, &parent_validity);
 	}
 }
@@ -190,7 +190,7 @@ static void HeapGatherArrayVector(Vector &v, const idx_t vcount, const Selection
 			}
 
 			// Pass on this array's validity mask to the child vector
-			VerticalParentValidity parent_validity(array_validitymask_location);
+			NestedValidity parent_validity(array_validitymask_location);
 			RowOperations::HeapGather(child_vector, chunk_size, array_sel, array_entry_locations, &parent_validity);
 
 			elem_remaining -= chunk_size;
@@ -200,7 +200,7 @@ static void HeapGatherArrayVector(Vector &v, const idx_t vcount, const Selection
 }
 
 void RowOperations::HeapGather(Vector &v, const idx_t &vcount, const SelectionVector &sel, data_ptr_t *key_locations,
-                               optional_ptr<ParentValidity> parent_validity) {
+                               optional_ptr<NestedValidity> parent_validity) {
 	v.SetVectorType(VectorType::FLAT_VECTOR);
 
 	auto &validity = FlatVector::Validity(v);

--- a/src/common/row_operations/row_heap_scatter.cpp
+++ b/src/common/row_operations/row_heap_scatter.cpp
@@ -45,43 +45,6 @@ bool NestedValidity::IsValid(idx_t idx) {
 	}
 }
 
-/*
-VerticalParentValidity::VerticalParentValidity(data_ptr_t validitymask_location)
-    : validitymask_location(validitymask_location) {
-}
-
-void VerticalParentValidity::SetInvalid(idx_t idx) {
-    auto entry_offset = idx / 8;
-    auto bit_offset = idx % 8;
-    const auto bit = ~(1UL << bit_offset);
-    validitymask_location[entry_offset] &= bit;
-}
-
-bool VerticalParentValidity::IsValid(idx_t idx) {
-    auto entry_offset = idx / 8;
-    auto bit_offset = idx % 8;
-    ValidityBytes row_mask(validitymask_location + entry_offset);
-    const auto valid = row_mask.RowIsValid(row_mask.GetValidityEntry(0), bit_offset);
-    return valid;
-}
-
-HorizontalParentValidity::HorizontalParentValidity(data_ptr_t *validitymask_locations, idx_t child_vector_index)
-    : validitymask_locations(validitymask_locations), entry_idx(0), idx_in_entry(0) {
-    ValidityBytes::GetEntryIndex(child_vector_index, entry_idx, idx_in_entry);
-}
-
-void HorizontalParentValidity::SetInvalid(idx_t idx) {
-    const auto bit = ~(1UL << idx_in_entry);
-    *(validitymask_locations[idx] + entry_idx) &= bit;
-}
-
-bool HorizontalParentValidity::IsValid(idx_t idx) {
-    ValidityBytes row_mask(validitymask_locations[idx]);
-    const auto valid = row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
-    return valid;
-}
- */
-
 static void ComputeStringEntrySizes(UnifiedVectorFormat &vdata, idx_t entry_sizes[], const idx_t ser_count,
                                     const SelectionVector &sel, const idx_t offset) {
 	auto strings = UnifiedVectorFormat::GetData<string_t>(vdata);

--- a/src/common/row_operations/row_heap_scatter.cpp
+++ b/src/common/row_operations/row_heap_scatter.cpp
@@ -7,6 +7,41 @@ namespace duckdb {
 
 using ValidityBytes = TemplatedValidityMask<uint8_t>;
 
+VerticalParentValidity::VerticalParentValidity(data_ptr_t validitymask_location)
+    : validitymask_location(validitymask_location) {
+}
+
+void VerticalParentValidity::SetInvalid(idx_t idx) {
+	auto entry_offset = idx / 8;
+	auto bit_offset = idx % 8;
+	const auto bit = ~(1UL << bit_offset);
+	validitymask_location[entry_offset] &= bit;
+}
+
+bool VerticalParentValidity::IsValid(idx_t idx) {
+	auto entry_offset = idx / 8;
+	auto bit_offset = idx % 8;
+	ValidityBytes row_mask(validitymask_location + entry_offset);
+	const auto valid = row_mask.RowIsValid(row_mask.GetValidityEntry(0), bit_offset);
+	return valid;
+}
+
+HorizontalParentValidity::HorizontalParentValidity(data_ptr_t *validitymask_locations, idx_t child_vector_index)
+    : validitymask_locations(validitymask_locations), entry_idx(0), idx_in_entry(0) {
+	ValidityBytes::GetEntryIndex(child_vector_index, entry_idx, idx_in_entry);
+}
+
+void HorizontalParentValidity::SetInvalid(idx_t idx) {
+	const auto bit = ~(1UL << idx_in_entry);
+	*(validitymask_locations[idx] + entry_idx) &= bit;
+}
+
+bool HorizontalParentValidity::IsValid(idx_t idx) {
+	ValidityBytes row_mask(validitymask_locations[idx]);
+	const auto valid = row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
+	return valid;
+}
+
 static void ComputeStringEntrySizes(UnifiedVectorFormat &vdata, idx_t entry_sizes[], const idx_t ser_count,
                                     const SelectionVector &sel, const idx_t offset) {
 	auto strings = UnifiedVectorFormat::GetData<string_t>(vdata);
@@ -86,11 +121,12 @@ static void ComputeArrayEntrySizes(Vector &v, UnifiedVectorFormat &vdata, idx_t 
 	auto child_vector = ArrayVector::GetEntry(v);
 
 	idx_t array_entry_sizes[STANDARD_VECTOR_SIZE];
+	const idx_t array_validitymask_size = (array_size + 7) / 8;
 
 	for (idx_t i = 0; i < ser_count; i++) {
 
 		// Validity for the array elements
-		entry_sizes[i] += (array_size + 7) / 8;
+		entry_sizes[i] += array_validitymask_size;
 
 		// serialize size of each entry (if non-constant size)
 		if (!TypeIsConstantSize(ArrayType::GetChildType(v.GetType()).InternalType())) {
@@ -160,10 +196,11 @@ void RowOperations::ComputeEntrySizes(Vector &v, idx_t entry_sizes[], idx_t vcou
 }
 
 template <class T>
-static void TemplatedHeapScatter(UnifiedVectorFormat &vdata, const SelectionVector &sel, idx_t count, idx_t col_idx,
-                                 data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+static void TemplatedHeapScatter(UnifiedVectorFormat &vdata, const SelectionVector &sel, idx_t count,
+                                 data_ptr_t *key_locations, optional_ptr<ParentValidity> parent_validity,
+                                 idx_t offset) {
 	auto source = UnifiedVectorFormat::GetData<T>(vdata);
-	if (!validitymask_locations) {
+	if (!parent_validity) {
 		for (idx_t i = 0; i < count; i++) {
 			auto idx = sel.get_index(i);
 			auto source_idx = vdata.sel->get_index(idx + offset);
@@ -173,10 +210,6 @@ static void TemplatedHeapScatter(UnifiedVectorFormat &vdata, const SelectionVect
 			key_locations[i] += sizeof(T);
 		}
 	} else {
-		idx_t entry_idx;
-		idx_t idx_in_entry;
-		ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
-		const auto bit = ~(1UL << idx_in_entry);
 		for (idx_t i = 0; i < count; i++) {
 			auto idx = sel.get_index(i);
 			auto source_idx = vdata.sel->get_index(idx + offset);
@@ -187,19 +220,20 @@ static void TemplatedHeapScatter(UnifiedVectorFormat &vdata, const SelectionVect
 
 			// set the validitymask
 			if (!vdata.validity.RowIsValid(source_idx)) {
-				*(validitymask_locations[i] + entry_idx) &= bit;
+				parent_validity->SetInvalid(i);
 			}
 		}
 	}
 }
 
-static void HeapScatterStringVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
-                                    data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+static void HeapScatterStringVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count,
+                                    data_ptr_t *key_locations, optional_ptr<ParentValidity> parent_validity,
+                                    idx_t offset) {
 	UnifiedVectorFormat vdata;
 	v.ToUnifiedFormat(vcount, vdata);
 
 	auto strings = UnifiedVectorFormat::GetData<string_t>(vdata);
-	if (!validitymask_locations) {
+	if (!parent_validity) {
 		for (idx_t i = 0; i < ser_count; i++) {
 			auto idx = sel.get_index(i);
 			auto source_idx = vdata.sel->get_index(idx + offset);
@@ -214,10 +248,6 @@ static void HeapScatterStringVector(Vector &v, idx_t vcount, const SelectionVect
 			}
 		}
 	} else {
-		idx_t entry_idx;
-		idx_t idx_in_entry;
-		ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
-		const auto bit = ~(1UL << idx_in_entry);
 		for (idx_t i = 0; i < ser_count; i++) {
 			auto idx = sel.get_index(i);
 			auto source_idx = vdata.sel->get_index(idx + offset);
@@ -231,25 +261,20 @@ static void HeapScatterStringVector(Vector &v, idx_t vcount, const SelectionVect
 				key_locations[i] += string_entry.GetSize();
 			} else {
 				// set the validitymask
-				*(validitymask_locations[i] + entry_idx) &= bit;
+				parent_validity->SetInvalid(i);
 			}
 		}
 	}
 }
 
-static void HeapScatterStructVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
-                                    data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+static void HeapScatterStructVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count,
+                                    data_ptr_t *key_locations, optional_ptr<ParentValidity> parent_validity,
+                                    idx_t offset) {
 	UnifiedVectorFormat vdata;
 	v.ToUnifiedFormat(vcount, vdata);
 
 	auto &children = StructVector::GetEntries(v);
 	idx_t num_children = children.size();
-
-	// the whole struct itself can be NULL
-	idx_t entry_idx;
-	idx_t idx_in_entry;
-	ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
-	const auto bit = ~(1UL << idx_in_entry);
 
 	// struct must have a validitymask for its fields
 	const idx_t struct_validitymask_size = (num_children + 7) / 8;
@@ -263,27 +288,24 @@ static void HeapScatterStructVector(Vector &v, idx_t vcount, const SelectionVect
 		// set whether the whole struct is null
 		auto idx = sel.get_index(i);
 		auto source_idx = vdata.sel->get_index(idx) + offset;
-		if (validitymask_locations && !vdata.validity.RowIsValid(source_idx)) {
-			*(validitymask_locations[i] + entry_idx) &= bit;
+		if (parent_validity && !vdata.validity.RowIsValid(source_idx)) {
+			parent_validity->SetInvalid(i);
 		}
 	}
 
 	// now serialize the struct vectors
 	for (idx_t i = 0; i < children.size(); i++) {
 		auto &struct_vector = *children[i];
-		RowOperations::HeapScatter(struct_vector, vcount, sel, ser_count, i, key_locations,
-		                           struct_validitymask_locations, offset);
+		HorizontalParentValidity struct_validity(struct_validitymask_locations, i);
+		RowOperations::HeapScatter(struct_vector, vcount, sel, ser_count, key_locations, &struct_validity, offset);
 	}
 }
 
-static void HeapScatterListVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_no,
-                                  data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+static void HeapScatterListVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count,
+                                  data_ptr_t *key_locations, optional_ptr<ParentValidity> parent_validity,
+                                  idx_t offset) {
 	UnifiedVectorFormat vdata;
 	v.ToUnifiedFormat(vcount, vdata);
-
-	idx_t entry_idx;
-	idx_t idx_in_entry;
-	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
 
 	auto list_data = ListVector::GetData(v);
 	auto &child_vector = ListVector::GetEntry(v);
@@ -299,10 +321,9 @@ static void HeapScatterListVector(Vector &v, idx_t vcount, const SelectionVector
 		auto idx = sel.get_index(i);
 		auto source_idx = vdata.sel->get_index(idx + offset);
 		if (!vdata.validity.RowIsValid(source_idx)) {
-			if (validitymask_locations) {
+			if (parent_validity) {
 				// set the row validitymask for this column to invalid
-				ValidityBytes row_mask(validitymask_locations[i]);
-				row_mask.SetInvalidUnsafe(entry_idx, idx_in_entry);
+				parent_validity->SetInvalid(i);
 			}
 			continue;
 		}
@@ -366,8 +387,8 @@ static void HeapScatterListVector(Vector &v, idx_t vcount, const SelectionVector
 
 			// now serialize to the locations
 			RowOperations::HeapScatter(child_vector, ListVector::GetListSize(v),
-			                           *FlatVector::IncrementalSelectionVector(), next, 0, list_entry_locations,
-			                           nullptr, entry_offset);
+			                           *FlatVector::IncrementalSelectionVector(), next, list_entry_locations, nullptr,
+			                           entry_offset);
 
 			// update for next iteration
 			entry_remaining -= next;
@@ -376,8 +397,9 @@ static void HeapScatterListVector(Vector &v, idx_t vcount, const SelectionVector
 	}
 }
 
-static void HeapScatterArrayVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
-                                   data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+static void HeapScatterArrayVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count,
+                                   data_ptr_t *key_locations, optional_ptr<ParentValidity> parent_validity,
+                                   idx_t offset) {
 
 	auto &child_vector = ArrayVector::GetEntry(v);
 	auto array_size = ArrayType::GetSize(v.GetType());
@@ -397,23 +419,17 @@ static void HeapScatterArrayVector(Vector &v, idx_t vcount, const SelectionVecto
 	// array must have a validitymask for its elements
 	auto array_validitymask_size = (array_size + 7) / 8;
 
-	idx_t entry_idx;
-	idx_t idx_in_entry;
-	ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
-	const auto bit = ~(1UL << idx_in_entry);
-
 	for (idx_t i = 0; i < ser_count; i++) {
+		// Set if the whole array itself is null in the parent entry
 		auto source_idx = vdata.sel->get_index(sel.get_index(i) + offset);
-
-		// First off, set the validity of the mask itself in the parent entry
-		if (validitymask_locations && !vdata.validity.RowIsValid(source_idx)) {
-			*(validitymask_locations[i] + entry_idx) &= bit;
+		if (parent_validity && !vdata.validity.RowIsValid(source_idx)) {
+			parent_validity->SetInvalid(i);
 		}
 
 		// Now we can serialize the array itself
 		// Every array starts with a validity mask for the children
 		data_ptr_t array_validitymask_location = key_locations[i];
-		memset(array_validitymask_location, -1, (array_size + 7) / 8);
+		memset(array_validitymask_location, -1, array_validitymask_size);
 		key_locations[i] += array_validitymask_size;
 
 		// If the array contains variable size entries, we reserve spaces for them here
@@ -427,23 +443,9 @@ static void HeapScatterArrayVector(Vector &v, idx_t vcount, const SelectionVecto
 		auto array_start = source_idx * array_size;
 		auto elem_remaining = array_size;
 
-		idx_t offset_in_byte = 0;
-
 		while (elem_remaining > 0) {
 			// the array elements can span multiple vectors, so we divide it into chunks
 			auto chunk_size = MinValue(static_cast<idx_t>(STANDARD_VECTOR_SIZE), elem_remaining);
-
-			// serialize list validity
-			for (idx_t elem_idx = 0; elem_idx < chunk_size; elem_idx++) {
-				auto idx_in_array = child_vdata.sel->get_index(array_start + elem_idx);
-				if (!child_vdata.validity.RowIsValid(idx_in_array)) {
-					*(array_validitymask_location) &= ~(1UL << offset_in_byte);
-				}
-				if (++offset_in_byte == 8) {
-					array_validitymask_location++;
-					offset_in_byte = 0;
-				}
-			}
 
 			// Setup the locations for the elements
 			if (child_type_is_var_size) {
@@ -467,9 +469,10 @@ static void HeapScatterArrayVector(Vector &v, idx_t vcount, const SelectionVecto
 				}
 			}
 
+			VerticalParentValidity array_parent_validity(array_validitymask_location);
 			RowOperations::HeapScatter(child_vector, ArrayVector::GetTotalSize(v),
-			                           *FlatVector::IncrementalSelectionVector(), chunk_size, 0, array_entry_locations,
-			                           nullptr, array_start);
+			                           *FlatVector::IncrementalSelectionVector(), chunk_size, array_entry_locations,
+			                           &array_parent_validity, array_start);
 
 			// update for next iteration
 			elem_remaining -= chunk_size;
@@ -478,26 +481,26 @@ static void HeapScatterArrayVector(Vector &v, idx_t vcount, const SelectionVecto
 	}
 }
 
-void RowOperations::HeapScatter(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
-                                data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+void RowOperations::HeapScatter(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count,
+                                data_ptr_t *key_locations, optional_ptr<ParentValidity> parent_validity, idx_t offset) {
 	if (TypeIsConstantSize(v.GetType().InternalType())) {
 		UnifiedVectorFormat vdata;
 		v.ToUnifiedFormat(vcount, vdata);
-		RowOperations::HeapScatterVData(vdata, v.GetType().InternalType(), sel, ser_count, col_idx, key_locations,
-		                                validitymask_locations, offset);
+		RowOperations::HeapScatterVData(vdata, v.GetType().InternalType(), sel, ser_count, key_locations,
+		                                parent_validity, offset);
 	} else {
 		switch (v.GetType().InternalType()) {
 		case PhysicalType::VARCHAR:
-			HeapScatterStringVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			HeapScatterStringVector(v, vcount, sel, ser_count, key_locations, parent_validity, offset);
 			break;
 		case PhysicalType::STRUCT:
-			HeapScatterStructVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			HeapScatterStructVector(v, vcount, sel, ser_count, key_locations, parent_validity, offset);
 			break;
 		case PhysicalType::LIST:
-			HeapScatterListVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			HeapScatterListVector(v, vcount, sel, ser_count, key_locations, parent_validity, offset);
 			break;
 		case PhysicalType::ARRAY:
-			HeapScatterArrayVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			HeapScatterArrayVector(v, vcount, sel, ser_count, key_locations, parent_validity, offset);
 			break;
 		default:
 			// LCOV_EXCL_START
@@ -509,48 +512,48 @@ void RowOperations::HeapScatter(Vector &v, idx_t vcount, const SelectionVector &
 }
 
 void RowOperations::HeapScatterVData(UnifiedVectorFormat &vdata, PhysicalType type, const SelectionVector &sel,
-                                     idx_t ser_count, idx_t col_idx, data_ptr_t *key_locations,
-                                     data_ptr_t *validitymask_locations, idx_t offset) {
+                                     idx_t ser_count, data_ptr_t *key_locations,
+                                     optional_ptr<ParentValidity> parent_validity, idx_t offset) {
 	switch (type) {
 	case PhysicalType::BOOL:
 	case PhysicalType::INT8:
-		TemplatedHeapScatter<int8_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<int8_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::INT16:
-		TemplatedHeapScatter<int16_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<int16_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::INT32:
-		TemplatedHeapScatter<int32_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<int32_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::INT64:
-		TemplatedHeapScatter<int64_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<int64_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::UINT8:
-		TemplatedHeapScatter<uint8_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<uint8_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::UINT16:
-		TemplatedHeapScatter<uint16_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<uint16_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::UINT32:
-		TemplatedHeapScatter<uint32_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<uint32_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::UINT64:
-		TemplatedHeapScatter<uint64_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<uint64_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::INT128:
-		TemplatedHeapScatter<hugeint_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<hugeint_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::UINT128:
-		TemplatedHeapScatter<uhugeint_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<uhugeint_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::FLOAT:
-		TemplatedHeapScatter<float>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<float>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::DOUBLE:
-		TemplatedHeapScatter<double>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<double>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	case PhysicalType::INTERVAL:
-		TemplatedHeapScatter<interval_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		TemplatedHeapScatter<interval_t>(vdata, sel, ser_count, key_locations, parent_validity, offset);
 		break;
 	default:
 		throw NotImplementedException("FIXME: Serialize to of constant type column to row-format");

--- a/src/common/row_operations/row_heap_scatter.cpp
+++ b/src/common/row_operations/row_heap_scatter.cpp
@@ -20,10 +20,11 @@ NestedValidity::NestedValidity(data_ptr_t *validitymask_locations, idx_t child_v
 void NestedValidity::SetInvalid(idx_t idx) {
 	if (list_validity_location) {
 		// Is List
-		auto entry_offset = idx / 8;
-		auto bit_offset = idx % 8;
-		const auto bit = ~(1UL << bit_offset);
-		list_validity_location[entry_offset] &= bit;
+		idx_t list_entry_idx;
+		idx_t list_idx_in_entry;
+		ValidityBytes::GetEntryIndex(idx, list_entry_idx, list_idx_in_entry);
+		const auto bit = ~(1UL << list_idx_in_entry);
+		list_validity_location[list_entry_idx] &= bit;
 	} else {
 		// Is Struct
 		const auto bit = ~(1UL << idx_in_entry);
@@ -34,14 +35,15 @@ void NestedValidity::SetInvalid(idx_t idx) {
 bool NestedValidity::IsValid(idx_t idx) {
 	if (list_validity_location) {
 		// Is List
-		auto entry_offset = idx / 8;
-		auto bit_offset = idx % 8;
-		return list_validity_location[entry_offset] & (1UL << bit_offset);
+		idx_t list_entry_idx;
+		idx_t list_idx_in_entry;
+		ValidityBytes::GetEntryIndex(idx, list_entry_idx, list_idx_in_entry);
+		const auto bit = (1UL << list_idx_in_entry);
+		return list_validity_location[list_entry_idx] & bit;
 	} else {
 		// Is Struct
-		ValidityBytes row_mask(struct_validity_locations[idx]);
-		const auto valid = row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
-		return valid;
+		const auto bit = (1UL << idx_in_entry);
+		return *(struct_validity_locations[idx] + entry_idx) & bit;
 	}
 }
 

--- a/src/common/row_operations/row_scatter.cpp
+++ b/src/common/row_operations/row_scatter.cpp
@@ -107,7 +107,8 @@ static void ScatterNestedVector(Vector &vec, UnifiedVectorFormat &col, Vector &r
 	}
 
 	// Serialise the data
-	RowOperations::HeapScatter(vec, vcount, sel, count, col_no, data_locations, validitymask_locations);
+	HorizontalParentValidity parent_validity(validitymask_locations, col_no);
+	RowOperations::HeapScatter(vec, vcount, sel, count, data_locations, &parent_validity);
 }
 
 void RowOperations::Scatter(DataChunk &columns, UnifiedVectorFormat col_data[], const RowLayout &layout, Vector &rows,

--- a/src/common/row_operations/row_scatter.cpp
+++ b/src/common/row_operations/row_scatter.cpp
@@ -107,7 +107,7 @@ static void ScatterNestedVector(Vector &vec, UnifiedVectorFormat &col, Vector &r
 	}
 
 	// Serialise the data
-	HorizontalParentValidity parent_validity(validitymask_locations, col_no);
+	NestedValidity parent_validity(validitymask_locations, col_no);
 	RowOperations::HeapScatter(vec, vcount, sel, count, data_locations, &parent_validity);
 }
 

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -909,6 +909,8 @@ void Vector::Flatten(idx_t count) {
 			//                          | 2 |
 			// 							 ...
 
+			child.Flatten(count * array_size);
+
 			// Create a selection vector
 			SelectionVector sel(count * array_size);
 			for (idx_t array_idx = 0; array_idx < count; array_idx++) {

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -28,7 +28,7 @@
 namespace duckdb {
 
 Vector::Vector(LogicalType type_p, bool create_data, bool zero_data, idx_t capacity)
-    : vector_type(VectorType::FLAT_VECTOR), type(std::move(type_p)), data(nullptr) {
+    : vector_type(VectorType::FLAT_VECTOR), type(std::move(type_p)), data(nullptr), validity(capacity) {
 	if (create_data) {
 		Initialize(zero_data, capacity);
 	}

--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -49,7 +49,7 @@ public:
 		auto internal_type = type.InternalType();
 		result.vector_type = VectorType::FLAT_VECTOR;
 		AssignSharedPointer(result.buffer, buffer);
-		result.validity.Reset();
+		result.validity.Reset(capacity);
 		switch (internal_type) {
 		case PhysicalType::LIST: {
 			result.data = owned_data.get();
@@ -77,10 +77,6 @@ public:
 			auto &child_cache = child_caches[0]->Cast<VectorCacheBuffer>();
 			auto &array_child = result.auxiliary->Cast<VectorArrayBuffer>().GetChild();
 			child_cache.ResetFromCache(array_child, child_caches[0]);
-
-			// Ensure the child validity is (will be) large enough, even if its not initialized.
-			auto validity_target_size = array_child.validity.TargetCount();
-			array_child.validity.Resize(validity_target_size, std::max(validity_target_size, child_cache.capacity));
 			break;
 		}
 		case PhysicalType::STRUCT: {

--- a/src/include/duckdb/common/row_operations/row_operations.hpp
+++ b/src/include/duckdb/common/row_operations/row_operations.hpp
@@ -25,30 +25,18 @@ class StringHeap;
 class Vector;
 struct UnifiedVectorFormat;
 
-// The parent validity classes help to set the validity of the parent vector
-struct ParentValidity {
-	virtual void SetInvalid(idx_t idx) = 0;
-	virtual bool IsValid(idx_t idx) = 0;
-};
-
-// For STRUCT vectors, where the nested elements are stored "horizontally" across the multiple child vectors
-struct HorizontalParentValidity final : public ParentValidity {
-	data_ptr_t *validitymask_locations;
+// The NestedValidity class help to set/get the validity from inside nested vectors
+class NestedValidity {
+	data_ptr_t list_validity_location;
+	data_ptr_t *struct_validity_locations;
 	idx_t entry_idx;
 	idx_t idx_in_entry;
 
-	HorizontalParentValidity(data_ptr_t *validitymask_locations, idx_t child_vector_index);
-	void SetInvalid(idx_t idx) final;
-	bool IsValid(idx_t idx) final;
-};
-
-// For LIST and ARRAY vectors, where the nested elements are stored "vertically" within the single child vector
-struct VerticalParentValidity final : public ParentValidity {
-	data_ptr_t validitymask_location;
-
-	explicit VerticalParentValidity(data_ptr_t validitymask_location);
-	void SetInvalid(idx_t idx) final;
-	bool IsValid(idx_t idx) final;
+public:
+	explicit NestedValidity(data_ptr_t validitymask_location);
+	NestedValidity(data_ptr_t *validitymask_locations, idx_t child_vector_index);
+	void SetInvalid(idx_t idx);
+	bool IsValid(idx_t idx);
 };
 
 struct RowOperationsState {
@@ -118,14 +106,14 @@ struct RowOperations {
 	                              idx_t ser_count, const SelectionVector &sel, idx_t offset = 0);
 	//! Scatter vector with variable size type to the heap.
 	static void HeapScatter(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count,
-	                        data_ptr_t *key_locations, optional_ptr<ParentValidity> parent_validity, idx_t offset = 0);
+	                        data_ptr_t *key_locations, optional_ptr<NestedValidity> parent_validity, idx_t offset = 0);
 	//! Scatter vector data with variable size type to the heap.
 	static void HeapScatterVData(UnifiedVectorFormat &vdata, PhysicalType type, const SelectionVector &sel,
 	                             idx_t ser_count, data_ptr_t *key_locations,
-	                             optional_ptr<ParentValidity> parent_validity, idx_t offset = 0);
+	                             optional_ptr<NestedValidity> parent_validity, idx_t offset = 0);
 	//! Gather a single column with variable size type from the heap.
 	static void HeapGather(Vector &v, const idx_t &vcount, const SelectionVector &sel, data_ptr_t key_locations[],
-	                       optional_ptr<ParentValidity> parent_validity);
+	                       optional_ptr<NestedValidity> parent_validity);
 
 	//===--------------------------------------------------------------------===//
 	// Sorting Operators

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -135,10 +135,10 @@ public:
 	inline V *GetData() const {
 		return validity_mask;
 	}
-	inline void Reset() {
+	inline void Reset(idx_t target_count_p = STANDARD_VECTOR_SIZE) {
 		validity_mask = nullptr;
 		validity_data.reset();
-		target_count = STANDARD_VECTOR_SIZE;
+		target_count = target_count_p;
 	}
 
 	static inline idx_t EntryCount(idx_t count) {

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -242,7 +242,7 @@ void ValidityScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t s
 	for (idx_t i = 0; i < scan_count; i++) {
 		if (!source_mask.RowIsValid(start + i)) {
 			if (result_mask.AllValid()) {
-				result_mask.Initialize();
+				result_mask.Initialize(result_mask.TargetCount());
 			}
 			result_mask.SetInvalid(result_offset + i);
 		}
@@ -323,7 +323,7 @@ void ValidityScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t s
 		// now finally we can merge the input mask with the result mask
 		if (input_mask != ValidityMask::ValidityBuffer::MAX_ENTRY) {
 			if (!result_data) {
-				result_mask.Initialize();
+				result_mask.Initialize(result_mask.TargetCount());
 				result_data = (validity_t *)result_mask.GetData();
 			}
 			result_data[current_result_idx] &= input_mask;
@@ -363,7 +363,7 @@ void ValidityScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_cou
 				continue;
 			}
 			if (!result_data) {
-				result_mask.Initialize();
+				result_mask.Initialize(result_mask.TargetCount());
 				result_data = result_mask.GetData();
 			}
 			result_data[i] = input_entry;

--- a/test/sql/types/nested/array/array_compression.test_slow
+++ b/test/sql/types/nested/array/array_compression.test_slow
@@ -1,0 +1,37 @@
+# name: test/sql/types/nested/array/array_compression.test_slow
+# description: Test array compression and storage
+# group: [array]
+
+# load the DB from disk
+load __TEST_DIR__/array_compression.db
+
+statement ok
+PRAGMA enable_verification
+
+foreach compression <compression>
+
+statement ok
+PRAGMA force_compression='${compression}'
+
+statement ok
+CREATE TABLE tbl1 AS SELECT array_value(1,NULL,3)
+
+loop i 0 12
+
+statement ok
+INSERT INTO tbl1 SELECT * FROM tbl1;
+
+endloop
+
+query I nosort r1
+SELECT * FROM tbl1;
+
+restart
+
+query I nosort r1
+SELECT * FROM tbl1;
+
+statement ok
+DROP TABLE tbl1;
+
+endloop

--- a/test/sql/types/nested/array/array_sort.test
+++ b/test/sql/types/nested/array/array_sort.test
@@ -23,16 +23,16 @@ SELECT array_value(i -1, i, i + 1) FROM range(4,1,-1) as r(i) ORDER BY 1 ASC;
 
 # Try with larger arrays (more than 1 byte of validity data)
 query I
-SELECT * FROM (VALUES (array_value(0,1,2,3,4,NULL,6,7,8,9)), (array_value(10,11,NULL,13,14,15,16,17,18,19))) ORDER BY 1 ASC;
+SELECT * FROM (VALUES (array_value(0,1,2,3,4,NULL,6,7,8,9)), (array_value(10,11,NULL,13,14,15,16,17,NULL,19))) ORDER BY 1 ASC;
 ----
 [0, 1, 2, 3, 4, NULL, 6, 7, 8, 9]
-[10, 11, NULL, 13, 14, 15, 16, 17, 18, 19]
+[10, 11, NULL, 13, 14, 15, 16, 17, NULL, 19]
 
 
 query I
-SELECT * FROM (VALUES (array_value(0,1,2,3,4,NULL,6,7,8,9)), (array_value(10,11,NULL,13,14,15,16,17,18,19))) ORDER BY 1 DESC
+SELECT * FROM (VALUES (array_value(0,1,2,3,4,NULL,6,7,8,9)), (array_value(10,11,NULL,13,14,15,16,17,NULL,19))) ORDER BY 1 DESC
 ----
-[10, 11, NULL, 13, 14, 15, 16, 17, 18, 19]
+[10, 11, NULL, 13, 14, 15, 16, 17, NULL, 19]
 [0, 1, 2, 3, 4, NULL, 6, 7, 8, 9]
 
 

--- a/test/sql/types/nested/array/array_sort.test
+++ b/test/sql/types/nested/array/array_sort.test
@@ -36,6 +36,23 @@ SELECT * FROM (VALUES (array_value(0,1,2,3,4,NULL,6,7,8,9)), (array_value(10,11,
 [0, 1, 2, 3, 4, NULL, 6, 7, 8, 9]
 
 
+# Nested larger array sorting
+query I
+SELECT * FROM (VALUES
+		(array_value(array_value(0,1,2,3,4,NULL,6,7,8,9), array_value(10,11,NULL,13,14,15,16,17,NULL,19))),
+		(array_value(NULL, NULL)),
+		(array_value(NULL, array_value(20,21,22,23,24,NULL,26,27,28,29))),
+		(NULL),
+		(array_value(array_value(20,21,22,23,24,NULL,26,27,28,29), array_value(30,31,NULL,33,34,35,36,37,NULL,39)))
+) ORDER BY 1 ASC;
+----
+[[0, 1, 2, 3, 4, NULL, 6, 7, 8, 9], [10, 11, NULL, 13, 14, 15, 16, 17, NULL, 19]]
+[[20, 21, 22, 23, 24, NULL, 26, 27, 28, 29], [30, 31, NULL, 33, 34, 35, 36, 37, NULL, 39]]
+[NULL, [20, 21, 22, 23, 24, NULL, 26, 27, 28, 29]]
+[NULL, NULL]
+NULL
+
+
 # Nested sorting
 # Test combinations of array/list nesting (up to 3 levels)
 


### PR DESCRIPTION
This PR fixes a bunch of small issues related to maintaining the validity variants for nested array types, and most notably fixes sorting of arrays containing nulled complex types such as VARCHAR or nulled nested types.

The validity of an `ARRAY`s child vector must "match" the parent vector. E.g. if an array itself is null, all the child elements corresponding to that array must also be null. Previously when de/serializing an array vector from/to the row-format during sorting we tried to maintain this invariant by doing another "validity broadcasting" phase after the parent vector is deserialized where we loop over all the child elements and invalidate them so as to match the parent validity. However, this does not work very well recursively, and in the case of e.g. arrays holding strings it breaks immediately as we end up deserializing strings that contain invalid data before we get the chance to NULL them, which causes the verification to fail.

In this PR we generalize how nested validity is handled for row-format de/serialization by abstracting the validity mask location pointer (and potential struct entry offset) behind a optional `NestedValidity` pointer, which transparently hides how the validity bits of the nested vector should be set depending on if they are within a struct or a list/array. This enables us to avoid having to invalid the children "after" deserialization in the case of arrays, which avoids a bunch of extra work, allows string verification to work properly and is also less error prone. 

The cost is introducing an extra branch when getting/setting validity during row format de/serialization but I don't think it is going to be very significant as it should be easily be predicted and I know the whole row-format is subject to change in the future anyway. We could always get rid of this branch with templating in the future as well.

I still need to fix the exact same issue in the tuple-data serialization used during joins, but will do that in a follow up PR ASAP.