### PR TITLE
Tag memory that is allocated through the buffer manager, and add `duckdb_memory()` function

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -560,7 +560,7 @@ BufferHandle S3FileSystem::Allocate(idx_t part_size, uint16_t max_threads) {
 
 	while (true) {
 		try {
-			duckdb_buffer = buffer_manager.Allocate(part_size);
+			duckdb_buffer = buffer_manager.Allocate(MemoryTag::EXTENSION, part_size);
 
 			if (set_waiting_for_memory) {
 				threads_waiting_for_memory--;

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/common/enums/join_type.hpp"
 #include "duckdb/common/enums/joinref_type.hpp"
 #include "duckdb/common/enums/logical_operator_type.hpp"
+#include "duckdb/common/enums/memory_tag.hpp"
 #include "duckdb/common/enums/on_create_conflict.hpp"
 #include "duckdb/common/enums/on_entry_not_found.hpp"
 #include "duckdb/common/enums/operator_result_type.hpp"
@@ -3479,6 +3480,79 @@ MapInvalidReason EnumUtil::FromString<MapInvalidReason>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "DUPLICATE_KEY")) {
 		return MapInvalidReason::DUPLICATE_KEY;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<MemoryTag>(MemoryTag value) {
+	switch(value) {
+	case MemoryTag::BASE_TABLE:
+		return "BASE_TABLE";
+	case MemoryTag::HASH_TABLE:
+		return "HASH_TABLE";
+	case MemoryTag::PARQUET_READER:
+		return "PARQUET_READER";
+	case MemoryTag::CSV_READER:
+		return "CSV_READER";
+	case MemoryTag::ORDER_BY:
+		return "ORDER_BY";
+	case MemoryTag::ART_INDEX:
+		return "ART_INDEX";
+	case MemoryTag::COLUMN_DATA:
+		return "COLUMN_DATA";
+	case MemoryTag::METADATA:
+		return "METADATA";
+	case MemoryTag::OVERFLOW_STRINGS:
+		return "OVERFLOW_STRINGS";
+	case MemoryTag::IN_MEMORY_TABLE:
+		return "IN_MEMORY_TABLE";
+	case MemoryTag::ALLOCATOR:
+		return "ALLOCATOR";
+	case MemoryTag::EXTENSION:
+		return "EXTENSION";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+MemoryTag EnumUtil::FromString<MemoryTag>(const char *value) {
+	if (StringUtil::Equals(value, "BASE_TABLE")) {
+		return MemoryTag::BASE_TABLE;
+	}
+	if (StringUtil::Equals(value, "HASH_TABLE")) {
+		return MemoryTag::HASH_TABLE;
+	}
+	if (StringUtil::Equals(value, "PARQUET_READER")) {
+		return MemoryTag::PARQUET_READER;
+	}
+	if (StringUtil::Equals(value, "CSV_READER")) {
+		return MemoryTag::CSV_READER;
+	}
+	if (StringUtil::Equals(value, "ORDER_BY")) {
+		return MemoryTag::ORDER_BY;
+	}
+	if (StringUtil::Equals(value, "ART_INDEX")) {
+		return MemoryTag::ART_INDEX;
+	}
+	if (StringUtil::Equals(value, "COLUMN_DATA")) {
+		return MemoryTag::COLUMN_DATA;
+	}
+	if (StringUtil::Equals(value, "METADATA")) {
+		return MemoryTag::METADATA;
+	}
+	if (StringUtil::Equals(value, "OVERFLOW_STRINGS")) {
+		return MemoryTag::OVERFLOW_STRINGS;
+	}
+	if (StringUtil::Equals(value, "IN_MEMORY_TABLE")) {
+		return MemoryTag::IN_MEMORY_TABLE;
+	}
+	if (StringUtil::Equals(value, "ALLOCATOR")) {
+		return MemoryTag::ALLOCATOR;
+	}
+	if (StringUtil::Equals(value, "EXTENSION")) {
+		return MemoryTag::EXTENSION;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/common/sort/radix_sort.cpp
+++ b/src/common/sort/radix_sort.cpp
@@ -248,7 +248,7 @@ void RadixSort(BufferManager &buffer_manager, const data_ptr_t &dataptr, const i
 	} else if (sorting_size <= SortConstants::MSD_RADIX_SORT_SIZE_THRESHOLD) {
 		RadixSortLSD(buffer_manager, dataptr, count, col_offset, sort_layout.entry_size, sorting_size);
 	} else {
-		auto temp_block = buffer_manager.Allocate(MaxValue(count * sort_layout.entry_size, (idx_t)Storage::BLOCK_SIZE));
+		auto temp_block = buffer_manager.Allocate(MemoryTag::ORDER_BY, MaxValue(count * sort_layout.entry_size, (idx_t)Storage::BLOCK_SIZE));
 		auto preallocated_array = make_unsafe_uniq_array<idx_t>(sorting_size * SortConstants::MSD_RADIX_LOCATIONS);
 		RadixSortMSD(dataptr, temp_block.Ptr(), count, col_offset, sort_layout.entry_size, sorting_size, 0,
 		             preallocated_array.get(), false);

--- a/src/common/sort/radix_sort.cpp
+++ b/src/common/sort/radix_sort.cpp
@@ -248,7 +248,8 @@ void RadixSort(BufferManager &buffer_manager, const data_ptr_t &dataptr, const i
 	} else if (sorting_size <= SortConstants::MSD_RADIX_SORT_SIZE_THRESHOLD) {
 		RadixSortLSD(buffer_manager, dataptr, count, col_offset, sort_layout.entry_size, sorting_size);
 	} else {
-		auto temp_block = buffer_manager.Allocate(MemoryTag::ORDER_BY, MaxValue(count * sort_layout.entry_size, (idx_t)Storage::BLOCK_SIZE));
+		auto temp_block = buffer_manager.Allocate(MemoryTag::ORDER_BY,
+		                                          MaxValue(count * sort_layout.entry_size, (idx_t)Storage::BLOCK_SIZE));
 		auto preallocated_array = make_unsafe_uniq_array<idx_t>(sorting_size * SortConstants::MSD_RADIX_LOCATIONS);
 		RadixSortMSD(dataptr, temp_block.Ptr(), count, col_offset, sort_layout.entry_size, sorting_size, 0,
 		             preallocated_array.get(), false);

--- a/src/common/sort/sort_state.cpp
+++ b/src/common/sort/sort_state.cpp
@@ -294,8 +294,8 @@ void LocalSortState::ReOrder(SortedData &sd, data_ptr_t sorting_ptr, RowDataColl
 	auto unordered_data_handle = buffer_manager->Pin(unordered_data_block->block);
 	const data_ptr_t unordered_data_ptr = unordered_data_handle.Ptr();
 	// Create new block that will hold re-ordered row data
-	auto ordered_data_block =
-	    make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, *buffer_manager, unordered_data_block->capacity, unordered_data_block->entry_size);
+	auto ordered_data_block = make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, *buffer_manager,
+	                                                  unordered_data_block->capacity, unordered_data_block->entry_size);
 	ordered_data_block->count = count;
 	auto ordered_data_handle = buffer_manager->Pin(ordered_data_block->block);
 	data_ptr_t ordered_data_ptr = ordered_data_handle.Ptr();

--- a/src/common/sort/sort_state.cpp
+++ b/src/common/sort/sort_state.cpp
@@ -269,7 +269,7 @@ unique_ptr<RowDataBlock> LocalSortState::ConcatenateBlocks(RowDataCollection &ro
 	auto buffer_manager = &row_data.buffer_manager;
 	const idx_t &entry_size = row_data.entry_size;
 	idx_t capacity = MaxValue(((idx_t)Storage::BLOCK_SIZE + entry_size - 1) / entry_size, row_data.count);
-	auto new_block = make_uniq<RowDataBlock>(*buffer_manager, capacity, entry_size);
+	auto new_block = make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, *buffer_manager, capacity, entry_size);
 	new_block->count = row_data.count;
 	auto new_block_handle = buffer_manager->Pin(new_block->block);
 	data_ptr_t new_block_ptr = new_block_handle.Ptr();
@@ -295,7 +295,7 @@ void LocalSortState::ReOrder(SortedData &sd, data_ptr_t sorting_ptr, RowDataColl
 	const data_ptr_t unordered_data_ptr = unordered_data_handle.Ptr();
 	// Create new block that will hold re-ordered row data
 	auto ordered_data_block =
-	    make_uniq<RowDataBlock>(*buffer_manager, unordered_data_block->capacity, unordered_data_block->entry_size);
+	    make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, *buffer_manager, unordered_data_block->capacity, unordered_data_block->entry_size);
 	ordered_data_block->count = count;
 	auto ordered_data_handle = buffer_manager->Pin(ordered_data_block->block);
 	data_ptr_t ordered_data_ptr = ordered_data_handle.Ptr();
@@ -323,7 +323,7 @@ void LocalSortState::ReOrder(SortedData &sd, data_ptr_t sorting_ptr, RowDataColl
 		    std::accumulate(heap.blocks.begin(), heap.blocks.end(), (idx_t)0,
 		                    [](idx_t a, const unique_ptr<RowDataBlock> &b) { return a + b->byte_offset; });
 		idx_t heap_block_size = MaxValue(total_byte_offset, (idx_t)Storage::BLOCK_SIZE);
-		auto ordered_heap_block = make_uniq<RowDataBlock>(*buffer_manager, heap_block_size, 1);
+		auto ordered_heap_block = make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, *buffer_manager, heap_block_size, 1);
 		ordered_heap_block->count = count;
 		ordered_heap_block->byte_offset = total_byte_offset;
 		auto ordered_heap_handle = buffer_manager->Pin(ordered_heap_block->block);

--- a/src/common/sort/sorted_block.cpp
+++ b/src/common/sort/sorted_block.cpp
@@ -29,7 +29,8 @@ void SortedData::CreateBlock() {
 	    MaxValue(((idx_t)Storage::BLOCK_SIZE + layout.GetRowWidth() - 1) / layout.GetRowWidth(), state.block_capacity);
 	data_blocks.push_back(make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, capacity, layout.GetRowWidth()));
 	if (!layout.AllConstant() && state.external) {
-		heap_blocks.push_back(make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1));
+		heap_blocks.push_back(
+		    make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1));
 		D_ASSERT(data_blocks.size() == heap_blocks.size());
 	}
 }
@@ -105,7 +106,8 @@ void SortedBlock::InitializeWrite() {
 void SortedBlock::CreateBlock() {
 	auto capacity = MaxValue(((idx_t)Storage::BLOCK_SIZE + sort_layout.entry_size - 1) / sort_layout.entry_size,
 	                         state.block_capacity);
-	radix_sorting_data.push_back(make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, capacity, sort_layout.entry_size));
+	radix_sorting_data.push_back(
+	    make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, capacity, sort_layout.entry_size));
 }
 
 void SortedBlock::AppendSortedBlocks(vector<unique_ptr<SortedBlock>> &sorted_blocks) {

--- a/src/common/sort/sorted_block.cpp
+++ b/src/common/sort/sorted_block.cpp
@@ -27,9 +27,9 @@ idx_t SortedData::Count() {
 void SortedData::CreateBlock() {
 	auto capacity =
 	    MaxValue(((idx_t)Storage::BLOCK_SIZE + layout.GetRowWidth() - 1) / layout.GetRowWidth(), state.block_capacity);
-	data_blocks.push_back(make_uniq<RowDataBlock>(buffer_manager, capacity, layout.GetRowWidth()));
+	data_blocks.push_back(make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, capacity, layout.GetRowWidth()));
 	if (!layout.AllConstant() && state.external) {
-		heap_blocks.push_back(make_uniq<RowDataBlock>(buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1));
+		heap_blocks.push_back(make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1));
 		D_ASSERT(data_blocks.size() == heap_blocks.size());
 	}
 }
@@ -105,7 +105,7 @@ void SortedBlock::InitializeWrite() {
 void SortedBlock::CreateBlock() {
 	auto capacity = MaxValue(((idx_t)Storage::BLOCK_SIZE + sort_layout.entry_size - 1) / sort_layout.entry_size,
 	                         state.block_capacity);
-	radix_sorting_data.push_back(make_uniq<RowDataBlock>(buffer_manager, capacity, sort_layout.entry_size));
+	radix_sorting_data.push_back(make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, capacity, sort_layout.entry_size));
 }
 
 void SortedBlock::AppendSortedBlocks(vector<unique_ptr<SortedBlock>> &sorted_blocks) {

--- a/src/common/types/column/column_data_allocator.cpp
+++ b/src/common/types/column/column_data_allocator.cpp
@@ -65,7 +65,7 @@ BufferHandle ColumnDataAllocator::AllocateBlock(idx_t size) {
 	BlockMetaData data;
 	data.size = 0;
 	data.capacity = block_size;
-	auto pin = alloc.buffer_manager->Allocate(block_size, false, &data.handle);
+	auto pin = alloc.buffer_manager->Allocate(MemoryTag::COLUMN_DATA, block_size, false, &data.handle);
 	blocks.push_back(std::move(data));
 	return pin;
 }

--- a/src/common/types/row/row_data_collection.cpp
+++ b/src/common/types/row/row_data_collection.cpp
@@ -43,7 +43,7 @@ idx_t RowDataCollection::AppendToBlock(RowDataBlock &block, BufferHandle &handle
 }
 
 RowDataBlock &RowDataCollection::CreateBlock() {
-	blocks.push_back(make_uniq<RowDataBlock>(buffer_manager, block_capacity, entry_size));
+	blocks.push_back(make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, block_capacity, entry_size));
 	return *blocks.back();
 }
 

--- a/src/common/types/row/row_data_collection_scanner.cpp
+++ b/src/common/types/row/row_data_collection_scanner.cpp
@@ -99,8 +99,8 @@ void RowDataCollectionScanner::AlignHeapBlocks(RowDataCollection &swizzled_block
 			}
 
 			// Finally, we allocate a new heap block and copy data to it
-			swizzled_string_heap.blocks.emplace_back(
-			    make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, MaxValue<idx_t>(total_size, (idx_t)Storage::BLOCK_SIZE), 1));
+			swizzled_string_heap.blocks.emplace_back(make_uniq<RowDataBlock>(
+			    MemoryTag::ORDER_BY, buffer_manager, MaxValue<idx_t>(total_size, (idx_t)Storage::BLOCK_SIZE), 1));
 			auto new_heap_handle = buffer_manager.Pin(swizzled_string_heap.blocks.back()->block);
 			auto new_heap_ptr = new_heap_handle.Ptr();
 			for (auto &ptr_and_size : ptrs_and_sizes) {

--- a/src/common/types/row/row_data_collection_scanner.cpp
+++ b/src/common/types/row/row_data_collection_scanner.cpp
@@ -100,7 +100,7 @@ void RowDataCollectionScanner::AlignHeapBlocks(RowDataCollection &swizzled_block
 
 			// Finally, we allocate a new heap block and copy data to it
 			swizzled_string_heap.blocks.emplace_back(
-			    make_uniq<RowDataBlock>(buffer_manager, MaxValue<idx_t>(total_size, (idx_t)Storage::BLOCK_SIZE), 1));
+			    make_uniq<RowDataBlock>(MemoryTag::ORDER_BY, buffer_manager, MaxValue<idx_t>(total_size, (idx_t)Storage::BLOCK_SIZE), 1));
 			auto new_heap_handle = buffer_manager.Pin(swizzled_string_heap.blocks.back()->block);
 			auto new_heap_ptr = new_heap_handle.Ptr();
 			for (auto &ptr_and_size : ptrs_and_sizes) {

--- a/src/common/types/row/tuple_data_allocator.cpp
+++ b/src/common/types/row/tuple_data_allocator.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 using ValidityBytes = TupleDataLayout::ValidityBytes;
 
 TupleDataBlock::TupleDataBlock(BufferManager &buffer_manager, idx_t capacity_p) : capacity(capacity_p), size(0) {
-	buffer_manager.Allocate(capacity, false, &handle);
+	buffer_manager.Allocate(MemoryTag::HASH_TABLE, capacity, false, &handle);
 }
 
 TupleDataBlock::TupleDataBlock(TupleDataBlock &&other) noexcept {

--- a/src/execution/index/fixed_size_buffer.cpp
+++ b/src/execution/index/fixed_size_buffer.cpp
@@ -132,7 +132,8 @@ void FixedSizeBuffer::Pin() {
 
 	// we need to copy the (partial) data into a new (not yet disk-backed) buffer handle
 	shared_ptr<BlockHandle> new_block_handle;
-	auto new_buffer_handle = buffer_manager.Allocate(MemoryTag::ART_INDEX, Storage::BLOCK_SIZE, false, &new_block_handle);
+	auto new_buffer_handle =
+	    buffer_manager.Allocate(MemoryTag::ART_INDEX, Storage::BLOCK_SIZE, false, &new_block_handle);
 
 	memcpy(new_buffer_handle.Ptr(), buffer_handle.Ptr() + block_pointer.offset, allocation_size);
 

--- a/src/execution/index/fixed_size_buffer.cpp
+++ b/src/execution/index/fixed_size_buffer.cpp
@@ -40,7 +40,7 @@ FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager)
       block_handle(nullptr) {
 
 	auto &buffer_manager = block_manager.buffer_manager;
-	buffer_handle = buffer_manager.Allocate(Storage::BLOCK_SIZE, false, &block_handle);
+	buffer_handle = buffer_manager.Allocate(MemoryTag::ART_INDEX, Storage::BLOCK_SIZE, false, &block_handle);
 }
 
 FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager, const idx_t segment_count, const idx_t allocation_size,
@@ -123,7 +123,6 @@ void FixedSizeBuffer::Serialize(PartialBlockManager &partial_block_manager, cons
 }
 
 void FixedSizeBuffer::Pin() {
-
 	auto &buffer_manager = block_manager.buffer_manager;
 	D_ASSERT(block_pointer.IsValid());
 	D_ASSERT(block_handle && block_handle->BlockId() < MAXIMUM_BLOCK);
@@ -133,7 +132,7 @@ void FixedSizeBuffer::Pin() {
 
 	// we need to copy the (partial) data into a new (not yet disk-backed) buffer handle
 	shared_ptr<BlockHandle> new_block_handle;
-	auto new_buffer_handle = buffer_manager.Allocate(Storage::BLOCK_SIZE, false, &new_block_handle);
+	auto new_buffer_handle = buffer_manager.Allocate(MemoryTag::ART_INDEX, Storage::BLOCK_SIZE, false, &new_block_handle);
 
 	memcpy(new_buffer_handle.Ptr(), buffer_handle.Ptr() + block_pointer.offset, allocation_size);
 

--- a/src/execution/operator/csv_scanner/buffer_manager/csv_buffer.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_buffer.cpp
@@ -44,7 +44,7 @@ shared_ptr<CSVBuffer> CSVBuffer::Next(CSVFileHandle &file_handle, idx_t buffer_s
 void CSVBuffer::AllocateBuffer(idx_t buffer_size) {
 	auto &buffer_manager = BufferManager::GetBufferManager(context);
 	bool can_destroy = can_seek;
-	handle = buffer_manager.Allocate(MaxValue<idx_t>(Storage::BLOCK_SIZE, buffer_size), can_destroy, &block);
+	handle = buffer_manager.Allocate(MemoryTag::CSV_READER, MaxValue<idx_t>(Storage::BLOCK_SIZE, buffer_size), can_destroy, &block);
 }
 
 idx_t CSVBuffer::GetBufferSize() {

--- a/src/execution/operator/csv_scanner/buffer_manager/csv_buffer.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_buffer.cpp
@@ -44,7 +44,8 @@ shared_ptr<CSVBuffer> CSVBuffer::Next(CSVFileHandle &file_handle, idx_t buffer_s
 void CSVBuffer::AllocateBuffer(idx_t buffer_size) {
 	auto &buffer_manager = BufferManager::GetBufferManager(context);
 	bool can_destroy = can_seek;
-	handle = buffer_manager.Allocate(MemoryTag::CSV_READER, MaxValue<idx_t>(Storage::BLOCK_SIZE, buffer_size), can_destroy, &block);
+	handle = buffer_manager.Allocate(MemoryTag::CSV_READER, MaxValue<idx_t>(Storage::BLOCK_SIZE, buffer_size),
+	                                 can_destroy, &block);
 }
 
 idx_t CSVBuffer::GetBufferSize() {

--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library_unity(
   duckdb_functions.cpp
   duckdb_keywords.cpp
   duckdb_indexes.cpp
+  duckdb_memory.cpp
   duckdb_optimizers.cpp
   duckdb_schemas.cpp
   duckdb_secrets.cpp

--- a/src/function/table/system/duckdb_memory.cpp
+++ b/src/function/table/system/duckdb_memory.cpp
@@ -1,0 +1,59 @@
+#include "duckdb/function/table/system_functions.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
+
+namespace duckdb {
+
+struct DuckDBMemoryData : public GlobalTableFunctionState {
+    DuckDBMemoryData() : offset(0) {
+    }
+
+    vector<MemoryInformation> entries;
+    idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBMemoryBind(ClientContext &context, TableFunctionBindInput &input,
+                                                         vector<LogicalType> &return_types, vector<string> &names) {
+    names.emplace_back("tag");
+    return_types.emplace_back(LogicalType::VARCHAR);
+
+    names.emplace_back("memory_usage_bytes");
+    return_types.emplace_back(LogicalType::BIGINT);
+
+    return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBMemoryInit(ClientContext &context, TableFunctionInitInput &input) {
+    auto result = make_uniq<DuckDBMemoryData>();
+
+    result->entries = BufferManager::GetBufferManager(context).GetMemoryUsageInfo();
+    return std::move(result);
+}
+
+void DuckDBMemoryFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+    auto &data = data_p.global_state->Cast<DuckDBMemoryData>();
+    if (data.offset >= data.entries.size()) {
+        // finished returning values
+        return;
+    }
+    // start returning values
+    // either fill up the chunk or return all the remaining columns
+    idx_t count = 0;
+    while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+        auto &entry = data.entries[data.offset++];
+        // return values:
+        idx_t col = 0;
+        // tag, VARCHAR
+        output.SetValue(col++, count, EnumUtil::ToString(entry.tag));
+        // memory_usage_bytes, BIGINT
+        output.SetValue(col++, count, Value::BIGINT(entry.size));
+        count++;
+    }
+    output.SetCardinality(count);
+}
+
+void DuckDBMemoryFun::RegisterFunction(BuiltinFunctions &set) {
+    set.AddFunction(TableFunction("duckdb_memory", {}, DuckDBMemoryFunction, DuckDBMemoryBind,
+                                  DuckDBMemoryInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system/duckdb_memory.cpp
+++ b/src/function/table/system/duckdb_memory.cpp
@@ -4,56 +4,60 @@
 namespace duckdb {
 
 struct DuckDBMemoryData : public GlobalTableFunctionState {
-    DuckDBMemoryData() : offset(0) {
-    }
+	DuckDBMemoryData() : offset(0) {
+	}
 
-    vector<MemoryInformation> entries;
-    idx_t offset;
+	vector<MemoryInformation> entries;
+	idx_t offset;
 };
 
 static unique_ptr<FunctionData> DuckDBMemoryBind(ClientContext &context, TableFunctionBindInput &input,
-                                                         vector<LogicalType> &return_types, vector<string> &names) {
-    names.emplace_back("tag");
-    return_types.emplace_back(LogicalType::VARCHAR);
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("tag");
+	return_types.emplace_back(LogicalType::VARCHAR);
 
-    names.emplace_back("memory_usage_bytes");
-    return_types.emplace_back(LogicalType::BIGINT);
+	names.emplace_back("memory_usage_bytes");
+	return_types.emplace_back(LogicalType::BIGINT);
 
-    return nullptr;
+	names.emplace_back("temporary_storage_bytes");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	return nullptr;
 }
 
 unique_ptr<GlobalTableFunctionState> DuckDBMemoryInit(ClientContext &context, TableFunctionInitInput &input) {
-    auto result = make_uniq<DuckDBMemoryData>();
+	auto result = make_uniq<DuckDBMemoryData>();
 
-    result->entries = BufferManager::GetBufferManager(context).GetMemoryUsageInfo();
-    return std::move(result);
+	result->entries = BufferManager::GetBufferManager(context).GetMemoryUsageInfo();
+	return std::move(result);
 }
 
 void DuckDBMemoryFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-    auto &data = data_p.global_state->Cast<DuckDBMemoryData>();
-    if (data.offset >= data.entries.size()) {
-        // finished returning values
-        return;
-    }
-    // start returning values
-    // either fill up the chunk or return all the remaining columns
-    idx_t count = 0;
-    while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
-        auto &entry = data.entries[data.offset++];
-        // return values:
-        idx_t col = 0;
-        // tag, VARCHAR
-        output.SetValue(col++, count, EnumUtil::ToString(entry.tag));
-        // memory_usage_bytes, BIGINT
-        output.SetValue(col++, count, Value::BIGINT(entry.size));
-        count++;
-    }
-    output.SetCardinality(count);
+	auto &data = data_p.global_state->Cast<DuckDBMemoryData>();
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
+		// return values:
+		idx_t col = 0;
+		// tag, VARCHAR
+		output.SetValue(col++, count, EnumUtil::ToString(entry.tag));
+		// memory_usage_bytes, BIGINT
+		output.SetValue(col++, count, Value::BIGINT(entry.size));
+		// temporary_storage_bytes, BIGINT
+		output.SetValue(col++, count, Value::BIGINT(entry.evicted_data));
+		count++;
+	}
+	output.SetCardinality(count);
 }
 
 void DuckDBMemoryFun::RegisterFunction(BuiltinFunctions &set) {
-    set.AddFunction(TableFunction("duckdb_memory", {}, DuckDBMemoryFunction, DuckDBMemoryBind,
-                                  DuckDBMemoryInit));
+	set.AddFunction(TableFunction("duckdb_memory", {}, DuckDBMemoryFunction, DuckDBMemoryBind, DuckDBMemoryInit));
 }
 
 } // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -29,6 +29,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBSchemasFun::RegisterFunction(*this);
 	DuckDBDependenciesFun::RegisterFunction(*this);
 	DuckDBExtensionsFun::RegisterFunction(*this);
+	DuckDBMemoryFun::RegisterFunction(*this);
 	DuckDBOptimizersFun::RegisterFunction(*this);
 	DuckDBSecretsFun::RegisterFunction(*this);
 	DuckDBSequencesFun::RegisterFunction(*this);

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -166,6 +166,8 @@ enum class MacroType : uint8_t;
 
 enum class MapInvalidReason : uint8_t;
 
+enum class MemoryTag : uint8_t;
+
 enum class NType : uint8_t;
 
 enum class NewLineIdentifier : uint8_t;
@@ -509,6 +511,9 @@ const char* EnumUtil::ToChars<MacroType>(MacroType value);
 
 template<>
 const char* EnumUtil::ToChars<MapInvalidReason>(MapInvalidReason value);
+
+template<>
+const char* EnumUtil::ToChars<MemoryTag>(MemoryTag value);
 
 template<>
 const char* EnumUtil::ToChars<NType>(NType value);
@@ -924,6 +929,9 @@ MacroType EnumUtil::FromString<MacroType>(const char *value);
 
 template<>
 MapInvalidReason EnumUtil::FromString<MapInvalidReason>(const char *value);
+
+template<>
+MemoryTag EnumUtil::FromString<MemoryTag>(const char *value);
 
 template<>
 NType EnumUtil::FromString<NType>(const char *value);

--- a/src/include/duckdb/common/enums/memory_tag.hpp
+++ b/src/include/duckdb/common/enums/memory_tag.hpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/memory_tag.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class MemoryTag : uint8_t {
+    BASE_TABLE = 0,
+    HASH_TABLE = 1,
+    PARQUET_READER = 2,
+    CSV_READER = 3,
+    ORDER_BY = 4,
+    ART_INDEX = 5,
+    COLUMN_DATA = 6,
+    METADATA = 7,
+    OVERFLOW_STRINGS = 8,
+    IN_MEMORY_TABLE = 9,
+    ALLOCATOR = 10,
+    EXTENSION = 11
+};
+
+static constexpr const idx_t MEMORY_TAG_COUNT = 12;
+
+} // namespace duckdb

--- a/src/include/duckdb/common/enums/memory_tag.hpp
+++ b/src/include/duckdb/common/enums/memory_tag.hpp
@@ -13,18 +13,18 @@
 namespace duckdb {
 
 enum class MemoryTag : uint8_t {
-    BASE_TABLE = 0,
-    HASH_TABLE = 1,
-    PARQUET_READER = 2,
-    CSV_READER = 3,
-    ORDER_BY = 4,
-    ART_INDEX = 5,
-    COLUMN_DATA = 6,
-    METADATA = 7,
-    OVERFLOW_STRINGS = 8,
-    IN_MEMORY_TABLE = 9,
-    ALLOCATOR = 10,
-    EXTENSION = 11
+	BASE_TABLE = 0,
+	HASH_TABLE = 1,
+	PARQUET_READER = 2,
+	CSV_READER = 3,
+	ORDER_BY = 4,
+	ART_INDEX = 5,
+	COLUMN_DATA = 6,
+	METADATA = 7,
+	OVERFLOW_STRINGS = 8,
+	IN_MEMORY_TABLE = 9,
+	ALLOCATOR = 10,
+	EXTENSION = 11
 };
 
 static constexpr const idx_t MEMORY_TAG_COUNT = 12;

--- a/src/include/duckdb/common/types/row/row_data_collection.hpp
+++ b/src/include/duckdb/common/types/row/row_data_collection.hpp
@@ -17,10 +17,10 @@ namespace duckdb {
 
 struct RowDataBlock {
 public:
-	RowDataBlock(BufferManager &buffer_manager, idx_t capacity, idx_t entry_size)
+	RowDataBlock(MemoryTag tag, BufferManager &buffer_manager, idx_t capacity, idx_t entry_size)
 	    : capacity(capacity), entry_size(entry_size), count(0), byte_offset(0) {
 		idx_t size = MaxValue<idx_t>(Storage::BLOCK_SIZE, capacity * entry_size);
-		buffer_manager.Allocate(size, false, &block);
+		buffer_manager.Allocate(tag, size, false, &block);
 		D_ASSERT(BufferManager::GetAllocSize(size) == block->GetMemoryUsage());
 	}
 	explicit RowDataBlock(idx_t entry_size) : entry_size(entry_size) {

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -89,6 +89,10 @@ struct DuckDBIndexesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBMemoryFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBOptimizersFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -24,8 +24,8 @@ class DatabaseInstance;
 enum class BlockState : uint8_t { BLOCK_UNLOADED = 0, BLOCK_LOADED = 1 };
 
 struct BufferPoolReservation {
-    MemoryTag tag;
-    idx_t size {0};
+	MemoryTag tag;
+	idx_t size {0};
 	BufferPool &pool;
 
 	BufferPoolReservation(MemoryTag tag, BufferPool &pool);
@@ -61,8 +61,8 @@ class BlockHandle {
 
 public:
 	BlockHandle(BlockManager &block_manager, block_id_t block_id, MemoryTag tag);
-	BlockHandle(BlockManager &block_manager, block_id_t block_id, MemoryTag tag, unique_ptr<FileBuffer> buffer, bool can_destroy,
-	            idx_t block_size, BufferPoolReservation &&reservation);
+	BlockHandle(BlockManager &block_manager, block_id_t block_id, MemoryTag tag, unique_ptr<FileBuffer> buffer,
+	            bool can_destroy, idx_t block_size, BufferPoolReservation &&reservation);
 	~BlockHandle();
 
 	BlockManager &block_manager;

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include "duckdb/common/file_buffer.hpp"
+#include "duckdb/common/enums/memory_tag.hpp"
 
 namespace duckdb {
 class BlockManager;
@@ -23,10 +24,11 @@ class DatabaseInstance;
 enum class BlockState : uint8_t { BLOCK_UNLOADED = 0, BLOCK_LOADED = 1 };
 
 struct BufferPoolReservation {
-	idx_t size {0};
+    MemoryTag tag;
+    idx_t size {0};
 	BufferPool &pool;
 
-	BufferPoolReservation(BufferPool &pool);
+	BufferPoolReservation(MemoryTag tag, BufferPool &pool);
 	BufferPoolReservation(const BufferPoolReservation &) = delete;
 	BufferPoolReservation &operator=(const BufferPoolReservation &) = delete;
 
@@ -40,7 +42,7 @@ struct BufferPoolReservation {
 };
 
 struct TempBufferPoolReservation : BufferPoolReservation {
-	TempBufferPoolReservation(BufferPool &pool, idx_t size) : BufferPoolReservation(pool) {
+	TempBufferPoolReservation(MemoryTag tag, BufferPool &pool, idx_t size) : BufferPoolReservation(tag, pool) {
 		Resize(size);
 	}
 	TempBufferPoolReservation(TempBufferPoolReservation &&) = default;
@@ -58,8 +60,8 @@ class BlockHandle {
 	friend class BufferPool;
 
 public:
-	BlockHandle(BlockManager &block_manager, block_id_t block_id);
-	BlockHandle(BlockManager &block_manager, block_id_t block_id, unique_ptr<FileBuffer> buffer, bool can_destroy,
+	BlockHandle(BlockManager &block_manager, block_id_t block_id, MemoryTag tag);
+	BlockHandle(BlockManager &block_manager, block_id_t block_id, MemoryTag tag, unique_ptr<FileBuffer> buffer, bool can_destroy,
 	            idx_t block_size, BufferPoolReservation &&reservation);
 	~BlockHandle();
 
@@ -115,6 +117,8 @@ private:
 	atomic<int32_t> readers;
 	//! The block id of the block
 	const block_id_t block_id;
+	//! Memory tag
+	MemoryTag tag;
 	//! Pointer to loaded data (if any)
 	unique_ptr<FileBuffer> buffer;
 	//! Internal eviction timestamp

--- a/src/include/duckdb/storage/buffer/buffer_pool.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_pool.hpp
@@ -49,7 +49,7 @@ public:
 	//! blocks can be evicted
 	void SetLimit(idx_t limit, const char *exception_postscript);
 
-	void IncreaseUsedMemory(idx_t size);
+	void IncreaseUsedMemory(MemoryTag tag, idx_t size);
 
 	idx_t GetUsedMemory() const;
 
@@ -70,7 +70,7 @@ protected:
 		bool success;
 		TempBufferPoolReservation reservation;
 	};
-	virtual EvictionResult EvictBlocks(idx_t extra_memory, idx_t memory_limit,
+	virtual EvictionResult EvictBlocks(MemoryTag tag, idx_t extra_memory, idx_t memory_limit,
 	                                   unique_ptr<FileBuffer> *buffer = nullptr);
 
 	//! Garbage collect eviction queue
@@ -90,6 +90,8 @@ protected:
 	atomic<uint32_t> queue_insertions;
 	//! Memory manager for concurrently used temporary memory, e.g., for physical operators
 	unique_ptr<TemporaryMemoryManager> temporary_memory_manager;
+	//! Memory usage per tag
+	atomic<idx_t> memory_usage_per_tag[MEMORY_TAG_COUNT];
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/buffer/temporary_file_information.hpp
+++ b/src/include/duckdb/storage/buffer/temporary_file_information.hpp
@@ -8,6 +8,7 @@ namespace duckdb {
 struct MemoryInformation {
 	MemoryTag tag;
 	idx_t size;
+	idx_t evicted_data;
 };
 
 struct TemporaryFileInformation {

--- a/src/include/duckdb/storage/buffer/temporary_file_information.hpp
+++ b/src/include/duckdb/storage/buffer/temporary_file_information.hpp
@@ -1,8 +1,14 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/enums/memory_tag.hpp"
 
 namespace duckdb {
+
+struct MemoryInformation {
+	MemoryTag tag;
+	idx_t size;
+};
 
 struct TemporaryFileInformation {
 	string path;

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/storage/buffer/buffer_handle.hpp"
 #include "duckdb/storage/block_manager.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/enums/memory_tag.hpp"
 #include "duckdb/storage/buffer/temporary_file_information.hpp"
 #include "duckdb/main/config.hpp"
 
@@ -20,20 +21,6 @@ namespace duckdb {
 class Allocator;
 class BufferPool;
 class TemporaryMemoryManager;
-
-enum class MemoryTag : uint32_t {
-	BASE_TABLE,
-    HASH_TABLE,
-	PARQUET_READER,
-	CSV_READER,
-    ORDER_BY,
-    ART_INDEX,
-    COLUMN_DATA,
-    METADATA,
-    OVERFLOW_STRINGS,
-    IN_MEMORY_TABLE,
-    EXTENSION
-};
 
 class BufferManager {
 	friend class BufferHandle;

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -49,6 +49,7 @@ public:
 	virtual DUCKDB_API Allocator &GetBufferAllocator();
 	virtual DUCKDB_API void ReserveMemory(idx_t size);
 	virtual DUCKDB_API void FreeReservedMemory(idx_t size);
+	virtual vector<MemoryInformation> GetMemoryUsageInfo() const = 0;
 	//! Set a new memory limit to the buffer manager, throws an exception if the new limit is too low and not enough
 	//! blocks can be evicted
 	virtual void SetLimit(idx_t limit = (idx_t)-1);

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -80,8 +80,8 @@ public:
 protected:
 	virtual void PurgeQueue() = 0;
 	virtual void AddToEvictionQueue(shared_ptr<BlockHandle> &handle);
-	virtual void WriteTemporaryBuffer(block_id_t block_id, FileBuffer &buffer);
-	virtual unique_ptr<FileBuffer> ReadTemporaryBuffer(block_id_t id, unique_ptr<FileBuffer> buffer);
+	virtual void WriteTemporaryBuffer(MemoryTag tag, block_id_t block_id, FileBuffer &buffer);
+	virtual unique_ptr<FileBuffer> ReadTemporaryBuffer(MemoryTag tag, block_id_t id, unique_ptr<FileBuffer> buffer);
 	virtual void DeleteTemporaryFile(block_id_t id);
 };
 

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -21,6 +21,20 @@ class Allocator;
 class BufferPool;
 class TemporaryMemoryManager;
 
+enum class MemoryTag : uint32_t {
+	BASE_TABLE,
+    HASH_TABLE,
+	PARQUET_READER,
+	CSV_READER,
+    ORDER_BY,
+    ART_INDEX,
+    COLUMN_DATA,
+    METADATA,
+    OVERFLOW_STRINGS,
+    IN_MEMORY_TABLE,
+    EXTENSION
+};
+
 class BufferManager {
 	friend class BufferHandle;
 	friend class BlockHandle;
@@ -34,7 +48,7 @@ public:
 
 public:
 	static unique_ptr<BufferManager> CreateStandardBufferManager(DatabaseInstance &db, DBConfig &config);
-	virtual BufferHandle Allocate(idx_t block_size, bool can_destroy = true,
+	virtual BufferHandle Allocate(MemoryTag tag, idx_t block_size, bool can_destroy = true,
 	                              shared_ptr<BlockHandle> *block = nullptr) = 0;
 	//! Reallocate an in-memory buffer that is pinned.
 	virtual void ReAllocate(shared_ptr<BlockHandle> &handle, idx_t block_size) = 0;

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -92,7 +92,8 @@ public:
 protected:
 	//! Helper
 	template <typename... ARGS>
-	TempBufferPoolReservation EvictBlocksOrThrow(MemoryTag tag, idx_t memory_delta, unique_ptr<FileBuffer> *buffer, ARGS...);
+	TempBufferPoolReservation EvictBlocksOrThrow(MemoryTag tag, idx_t memory_delta, unique_ptr<FileBuffer> *buffer,
+	                                             ARGS...);
 
 	//! Register an in-memory buffer of arbitrary size, as long as it is >= BLOCK_SIZE. can_destroy signifies whether or
 	//! not the buffer can be destroyed when unpinned, or whether or not it needs to be written to a temporary file so
@@ -108,9 +109,10 @@ protected:
 	TemporaryMemoryManager &GetTemporaryMemoryManager() final override;
 
 	//! Write a temporary buffer to disk
-	void WriteTemporaryBuffer(block_id_t block_id, FileBuffer &buffer) final override;
+	void WriteTemporaryBuffer(MemoryTag tag, block_id_t block_id, FileBuffer &buffer) final override;
 	//! Read a temporary buffer from disk
-	unique_ptr<FileBuffer> ReadTemporaryBuffer(block_id_t id, unique_ptr<FileBuffer> buffer = nullptr) final override;
+	unique_ptr<FileBuffer> ReadTemporaryBuffer(MemoryTag tag, block_id_t id,
+	                                           unique_ptr<FileBuffer> buffer = nullptr) final override;
 	//! Get the path of the temporary buffer
 	string GetTemporaryPath(block_id_t id);
 
@@ -148,6 +150,8 @@ protected:
 	Allocator buffer_allocator;
 	//! Block manager for temp data
 	unique_ptr<BlockManager> temp_block_manager;
+	//! Temporary evicted memory data per tag
+	atomic<idx_t> evicted_data_per_tag[MEMORY_TAG_COUNT];
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -63,6 +63,9 @@ public:
 	//! blocks can be evicted
 	void SetLimit(idx_t limit = (idx_t)-1) final override;
 
+	//! Returns informaton about memory usage
+	vector<MemoryInformation> GetMemoryUsageInfo() const override;
+
 	//! Returns a list of all temporary files
 	vector<TemporaryFileInformation> GetTemporaryFiles() final override;
 

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -50,7 +50,7 @@ public:
 
 	//! Allocate an in-memory buffer with a single pin.
 	//! The allocated memory is released when the buffer handle is destroyed.
-	DUCKDB_API BufferHandle Allocate(idx_t block_size, bool can_destroy = true,
+	DUCKDB_API BufferHandle Allocate(MemoryTag tag, idx_t block_size, bool can_destroy = true,
 	                                 shared_ptr<BlockHandle> *block = nullptr) final override;
 
 	//! Reallocate an in-memory buffer that is pinned.

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -89,23 +89,14 @@ public:
 protected:
 	//! Helper
 	template <typename... ARGS>
-	TempBufferPoolReservation EvictBlocksOrThrow(idx_t memory_delta, unique_ptr<FileBuffer> *buffer, ARGS...);
+	TempBufferPoolReservation EvictBlocksOrThrow(MemoryTag tag, idx_t memory_delta, unique_ptr<FileBuffer> *buffer, ARGS...);
 
 	//! Register an in-memory buffer of arbitrary size, as long as it is >= BLOCK_SIZE. can_destroy signifies whether or
 	//! not the buffer can be destroyed when unpinned, or whether or not it needs to be written to a temporary file so
 	//! it can be reloaded. The resulting buffer will already be allocated, but needs to be pinned in order to be used.
 	//! This needs to be private to prevent creating blocks without ever pinning them:
 	//! blocks that are never pinned are never added to the eviction queue
-	shared_ptr<BlockHandle> RegisterMemory(idx_t block_size, bool can_destroy);
-
-	//! Evict blocks until the currently used memory + extra_memory fit, returns false if this was not possible
-	//! (i.e. not enough blocks could be evicted)
-	//! If the "buffer" argument is specified AND the system can find a buffer to re-use for the given allocation size
-	//! "buffer" will be made to point to the re-usable memory. Note that this is not guaranteed.
-	//! Returns a pair. result.first indicates if eviction was successful. result.second contains the
-	//! reservation handle, which can be moved to the BlockHandle that will own the reservation.
-	BufferPool::EvictionResult EvictBlocks(idx_t extra_memory, idx_t memory_limit,
-	                                       unique_ptr<FileBuffer> *buffer = nullptr);
+	shared_ptr<BlockHandle> RegisterMemory(MemoryTag tag, idx_t block_size, bool can_destroy);
 
 	//! Garbage collect eviction queue
 	void PurgeQueue() final override;

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -17,10 +17,11 @@ BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, Mem
 }
 
 BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, MemoryTag tag,
-						 unique_ptr<FileBuffer> buffer_p,
-                         bool can_destroy_p, idx_t block_size, BufferPoolReservation &&reservation)
-    : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), eviction_timestamp(0), can_destroy(can_destroy_p),
-      memory_charge(tag, block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr) {
+                         unique_ptr<FileBuffer> buffer_p, bool can_destroy_p, idx_t block_size,
+                         BufferPoolReservation &&reservation)
+    : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), eviction_timestamp(0),
+      can_destroy(can_destroy_p), memory_charge(tag, block_manager.buffer_manager.GetBufferPool()),
+      unswizzled(nullptr) {
 	buffer = std::move(buffer_p);
 	state = BlockState::BLOCK_LOADED;
 	memory_usage = block_size;
@@ -79,8 +80,8 @@ BufferHandle BlockHandle::Load(shared_ptr<BlockHandle> &handle, unique_ptr<FileB
 		if (handle->can_destroy) {
 			return BufferHandle();
 		} else {
-			handle->buffer =
-			    block_manager.buffer_manager.ReadTemporaryBuffer(handle->block_id, std::move(reusable_buffer));
+			handle->buffer = block_manager.buffer_manager.ReadTemporaryBuffer(handle->tag, handle->block_id,
+			                                                                  std::move(reusable_buffer));
 		}
 	}
 	handle->state = BlockState::BLOCK_LOADED;
@@ -97,7 +98,7 @@ unique_ptr<FileBuffer> BlockHandle::UnloadAndTakeBlock() {
 
 	if (block_id >= MAXIMUM_BLOCK && !can_destroy) {
 		// temporary block that cannot be destroyed: write to temporary file
-		block_manager.buffer_manager.WriteTemporaryBuffer(block_id, *buffer);
+		block_manager.buffer_manager.WriteTemporaryBuffer(tag, block_id, *buffer);
 	}
 	memory_charge.Resize(0);
 	state = BlockState::BLOCK_UNLOADED;

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -8,18 +8,19 @@
 
 namespace duckdb {
 
-BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p)
-    : block_manager(block_manager), readers(0), block_id(block_id_p), buffer(nullptr), eviction_timestamp(0),
-      can_destroy(false), memory_charge(block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr) {
+BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, MemoryTag tag)
+    : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), buffer(nullptr), eviction_timestamp(0),
+      can_destroy(false), memory_charge(tag, block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr) {
 	eviction_timestamp = 0;
 	state = BlockState::BLOCK_UNLOADED;
 	memory_usage = Storage::BLOCK_ALLOC_SIZE;
 }
 
-BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, unique_ptr<FileBuffer> buffer_p,
+BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, MemoryTag tag,
+						 unique_ptr<FileBuffer> buffer_p,
                          bool can_destroy_p, idx_t block_size, BufferPoolReservation &&reservation)
-    : block_manager(block_manager), readers(0), block_id(block_id_p), eviction_timestamp(0), can_destroy(can_destroy_p),
-      memory_charge(block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr) {
+    : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), eviction_timestamp(0), can_destroy(can_destroy_p),
+      memory_charge(tag, block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr) {
 	buffer = std::move(buffer_p);
 	state = BlockState::BLOCK_LOADED;
 	memory_usage = block_size;

--- a/src/storage/buffer/block_manager.cpp
+++ b/src/storage/buffer/block_manager.cpp
@@ -23,7 +23,7 @@ shared_ptr<BlockHandle> BlockManager::RegisterBlock(block_id_t block_id) {
 		}
 	}
 	// create a new block pointer for this block
-	auto result = make_shared<BlockHandle>(*this, block_id);
+	auto result = make_shared<BlockHandle>(*this, block_id, MemoryTag::BASE_TABLE);
 	// register the block pointer in the set of blocks as a weak pointer
 	blocks[block_id] = weak_ptr<BlockHandle>(result);
 	return result;

--- a/src/storage/buffer/buffer_pool_reservation.cpp
+++ b/src/storage/buffer/buffer_pool_reservation.cpp
@@ -3,15 +3,16 @@
 
 namespace duckdb {
 
-BufferPoolReservation::BufferPoolReservation(BufferPool &pool) : pool(pool) {
+BufferPoolReservation::BufferPoolReservation(MemoryTag tag, BufferPool &pool) : tag(tag), pool(pool) {
 }
 
-BufferPoolReservation::BufferPoolReservation(BufferPoolReservation &&src) noexcept : pool(src.pool) {
+BufferPoolReservation::BufferPoolReservation(BufferPoolReservation &&src) noexcept : tag(src.tag), pool(src.pool) {
 	size = src.size;
 	src.size = 0;
 }
 
 BufferPoolReservation &BufferPoolReservation::operator=(BufferPoolReservation &&src) noexcept {
+	tag = src.tag;
 	size = src.size;
 	src.size = 0;
 	return *this;
@@ -23,7 +24,7 @@ BufferPoolReservation::~BufferPoolReservation() {
 
 void BufferPoolReservation::Resize(idx_t new_size) {
 	int64_t delta = (int64_t)new_size - size;
-	pool.IncreaseUsedMemory(delta);
+	pool.IncreaseUsedMemory(tag, delta);
 	size = new_size;
 }
 

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -75,11 +75,11 @@ void BufferManager::AddToEvictionQueue(shared_ptr<BlockHandle> &handle) {
 	throw NotImplementedException("This type of BufferManager does not support 'AddToEvictionQueue");
 }
 
-void BufferManager::WriteTemporaryBuffer(block_id_t block_id, FileBuffer &buffer) {
+void BufferManager::WriteTemporaryBuffer(MemoryTag tag, block_id_t block_id, FileBuffer &buffer) {
 	throw NotImplementedException("This type of BufferManager does not support 'WriteTemporaryBuffer");
 }
 
-unique_ptr<FileBuffer> BufferManager::ReadTemporaryBuffer(block_id_t id, unique_ptr<FileBuffer> buffer) {
+unique_ptr<FileBuffer> BufferManager::ReadTemporaryBuffer(MemoryTag tag, block_id_t id, unique_ptr<FileBuffer> buffer) {
 	throw NotImplementedException("This type of BufferManager does not support 'ReadTemporaryBuffer");
 }
 

--- a/src/storage/checkpoint/write_overflow_strings_to_disk.cpp
+++ b/src/storage/checkpoint/write_overflow_strings_to_disk.cpp
@@ -40,7 +40,7 @@ void WriteOverflowStringsToDisk::WriteString(UncompressedStringSegmentState &sta
                                              block_id_t &result_block, int32_t &result_offset) {
 	auto &buffer_manager = block_manager.buffer_manager;
 	if (!handle.IsValid()) {
-		handle = buffer_manager.Allocate(Storage::BLOCK_SIZE);
+		handle = buffer_manager.Allocate(MemoryTag::OVERFLOW_STRINGS, Storage::BLOCK_SIZE);
 	}
 	// first write the length of the string
 	if (block_id == INVALID_BLOCK || offset + 2 * sizeof(uint32_t) >= STRING_SPACE) {

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -298,7 +298,7 @@ void UncompressedStringStorage::WriteStringMemory(ColumnSegment &segment, string
 		new_block->offset = 0;
 		new_block->size = alloc_size;
 		// allocate an in-memory buffer for it
-		handle = buffer_manager.Allocate(alloc_size, false, &block);
+		handle = buffer_manager.Allocate(MemoryTag::OVERFLOW_STRINGS, alloc_size, false, &block);
 		state.overflow_blocks.insert(make_pair(block->BlockId(), reference<StringBlock>(*new_block)));
 		new_block->block = std::move(block);
 		new_block->next = std::move(state.head);
@@ -342,7 +342,7 @@ string_t UncompressedStringStorage::ReadOverflowString(ColumnSegment &segment, V
 		auto alloc_size = MaxValue<idx_t>(Storage::BLOCK_SIZE, length);
 		// allocate a buffer to store the compressed string
 		// TODO: profile this to check if we need to reuse buffer
-		auto target_handle = buffer_manager.Allocate(alloc_size);
+		auto target_handle = buffer_manager.Allocate(MemoryTag::OVERFLOW_STRINGS, alloc_size);
 		auto target_ptr = target_handle.Ptr();
 
 		// now append the string to the single buffer

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -67,7 +67,7 @@ void MetadataManager::ConvertToTransient(MetadataBlock &block) {
 
 	// allocate a new transient block to replace it
 	shared_ptr<BlockHandle> new_block;
-	auto new_buffer = buffer_manager.Allocate(Storage::BLOCK_SIZE, false, &new_block);
+	auto new_buffer = buffer_manager.Allocate(MemoryTag::METADATA, Storage::BLOCK_SIZE, false, &new_block);
 
 	// copy the data to the transient block
 	memcpy(new_buffer.Ptr(), old_buffer.Ptr(), Storage::BLOCK_SIZE);
@@ -82,7 +82,7 @@ block_id_t MetadataManager::AllocateNewBlock() {
 	auto new_block_id = GetNextBlockId();
 
 	MetadataBlock new_block;
-	auto handle = buffer_manager.Allocate(Storage::BLOCK_SIZE, false, &new_block.block);
+	auto handle = buffer_manager.Allocate(MemoryTag::METADATA, Storage::BLOCK_SIZE, false, &new_block.block);
 	new_block.block_id = new_block_id;
 	for (idx_t i = 0; i < METADATA_BLOCK_COUNT; i++) {
 		new_block.free_blocks.push_back(METADATA_BLOCK_COUNT - i - 1);

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -233,6 +233,17 @@ void StandardBufferManager::SetLimit(idx_t limit) {
 	buffer_pool.SetLimit(limit, InMemoryWarning());
 }
 
+vector<MemoryInformation> StandardBufferManager::GetMemoryUsageInfo() const {
+    vector<MemoryInformation> result;
+    for(idx_t k = 0; k < MEMORY_TAG_COUNT; k++) {
+        MemoryInformation info;
+        info.tag = MemoryTag(k);
+        info.size = buffer_pool.memory_usage_per_tag[k].load();
+        result.push_back(info);
+    }
+    return result;
+}
+
 //===--------------------------------------------------------------------===//
 // Temporary File Management
 //===--------------------------------------------------------------------===//

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -122,7 +122,7 @@ shared_ptr<BlockHandle> StandardBufferManager::RegisterMemory(idx_t block_size, 
 	                                std::move(res));
 }
 
-BufferHandle StandardBufferManager::Allocate(idx_t block_size, bool can_destroy, shared_ptr<BlockHandle> *block) {
+BufferHandle StandardBufferManager::Allocate(MemoryTag tag, idx_t block_size, bool can_destroy, shared_ptr<BlockHandle> *block) {
 	shared_ptr<BlockHandle> local_block;
 	auto block_ptr = block ? block : &local_block;
 	*block_ptr = RegisterMemory(block_size, can_destroy);

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -83,9 +83,9 @@ idx_t StandardBufferManager::GetMaxMemory() const {
 }
 
 template <typename... ARGS>
-TempBufferPoolReservation StandardBufferManager::EvictBlocksOrThrow(idx_t memory_delta, unique_ptr<FileBuffer> *buffer,
+TempBufferPoolReservation StandardBufferManager::EvictBlocksOrThrow(MemoryTag tag, idx_t memory_delta, unique_ptr<FileBuffer> *buffer,
                                                                     ARGS... args) {
-	auto r = buffer_pool.EvictBlocks(memory_delta, buffer_pool.maximum_memory, buffer);
+	auto r = buffer_pool.EvictBlocks(tag, memory_delta, buffer_pool.maximum_memory, buffer);
 	if (!r.success) {
 		string extra_text = StringUtil::Format(" (%s/%s used)", StringUtil::BytesToHumanReadableString(GetUsedMemory()),
 		                                       StringUtil::BytesToHumanReadableString(GetMaxMemory()));
@@ -97,35 +97,35 @@ TempBufferPoolReservation StandardBufferManager::EvictBlocksOrThrow(idx_t memory
 
 shared_ptr<BlockHandle> StandardBufferManager::RegisterSmallMemory(idx_t block_size) {
 	D_ASSERT(block_size < Storage::BLOCK_SIZE);
-	auto res = EvictBlocksOrThrow(block_size, nullptr, "could not allocate block of size %s%s",
+	auto res = EvictBlocksOrThrow(MemoryTag::BASE_TABLE, block_size, nullptr, "could not allocate block of size %s%s",
 	                              StringUtil::BytesToHumanReadableString(block_size));
 
 	auto buffer = ConstructManagedBuffer(block_size, nullptr, FileBufferType::TINY_BUFFER);
 
 	// create a new block pointer for this block
-	return make_shared<BlockHandle>(*temp_block_manager, ++temporary_id, std::move(buffer), false, block_size,
+	return make_shared<BlockHandle>(*temp_block_manager, ++temporary_id, MemoryTag::BASE_TABLE, std::move(buffer), false, block_size,
 	                                std::move(res));
 }
 
-shared_ptr<BlockHandle> StandardBufferManager::RegisterMemory(idx_t block_size, bool can_destroy) {
+shared_ptr<BlockHandle> StandardBufferManager::RegisterMemory(MemoryTag tag, idx_t block_size, bool can_destroy) {
 	D_ASSERT(block_size >= Storage::BLOCK_SIZE);
 	auto alloc_size = GetAllocSize(block_size);
 	// first evict blocks until we have enough memory to store this buffer
 	unique_ptr<FileBuffer> reusable_buffer;
-	auto res = EvictBlocksOrThrow(alloc_size, &reusable_buffer, "could not allocate block of size %s%s",
+	auto res = EvictBlocksOrThrow(tag, alloc_size, &reusable_buffer, "could not allocate block of size %s%s",
 	                              StringUtil::BytesToHumanReadableString(alloc_size));
 
 	auto buffer = ConstructManagedBuffer(block_size, std::move(reusable_buffer));
 
 	// create a new block pointer for this block
-	return make_shared<BlockHandle>(*temp_block_manager, ++temporary_id, std::move(buffer), can_destroy, alloc_size,
+	return make_shared<BlockHandle>(*temp_block_manager, ++temporary_id, tag, std::move(buffer), can_destroy, alloc_size,
 	                                std::move(res));
 }
 
 BufferHandle StandardBufferManager::Allocate(MemoryTag tag, idx_t block_size, bool can_destroy, shared_ptr<BlockHandle> *block) {
 	shared_ptr<BlockHandle> local_block;
 	auto block_ptr = block ? block : &local_block;
-	*block_ptr = RegisterMemory(block_size, can_destroy);
+	*block_ptr = RegisterMemory(tag, block_size, can_destroy);
 	return Pin(*block_ptr);
 }
 
@@ -143,7 +143,7 @@ void StandardBufferManager::ReAllocate(shared_ptr<BlockHandle> &handle, idx_t bl
 		return;
 	} else if (memory_delta > 0) {
 		// evict blocks until we have space to resize this block
-		auto reservation = EvictBlocksOrThrow(memory_delta, nullptr, "failed to resize block from %s to %s%s",
+		auto reservation = EvictBlocksOrThrow(handle->tag, memory_delta, nullptr, "failed to resize block from %s to %s%s",
 		                                      StringUtil::BytesToHumanReadableString(handle->memory_usage),
 		                                      StringUtil::BytesToHumanReadableString(req.alloc_size));
 		// EvictBlocks decrements 'current_memory' for us.
@@ -171,7 +171,7 @@ BufferHandle StandardBufferManager::Pin(shared_ptr<BlockHandle> &handle) {
 	}
 	// evict blocks until we have space for the current block
 	unique_ptr<FileBuffer> reusable_buffer;
-	auto reservation = EvictBlocksOrThrow(required_memory, &reusable_buffer, "failed to pin block of size %s%s",
+	auto reservation = EvictBlocksOrThrow(handle->tag, required_memory, &reusable_buffer, "failed to pin block of size %s%s",
 	                                      StringUtil::BytesToHumanReadableString(required_memory));
 	// lock the handle again and repeat the check (in case anybody loaded in the mean time)
 	lock_guard<mutex> lock(handle->lock);
@@ -734,7 +734,7 @@ void StandardBufferManager::ReserveMemory(idx_t size) {
 	if (size == 0) {
 		return;
 	}
-	auto reservation = EvictBlocksOrThrow(size, nullptr, "failed to reserve memory data of size %s%s",
+	auto reservation = EvictBlocksOrThrow(MemoryTag::EXTENSION, size, nullptr, "failed to reserve memory data of size %s%s",
 	                                      StringUtil::BytesToHumanReadableString(size));
 	reservation.size = 0;
 }
@@ -751,7 +751,7 @@ void StandardBufferManager::FreeReservedMemory(idx_t size) {
 //===--------------------------------------------------------------------===//
 data_ptr_t StandardBufferManager::BufferAllocatorAllocate(PrivateAllocatorData *private_data, idx_t size) {
 	auto &data = private_data->Cast<BufferAllocatorData>();
-	auto reservation = data.manager.EvictBlocksOrThrow(size, nullptr, "failed to allocate data of size %s%s",
+	auto reservation = data.manager.EvictBlocksOrThrow(MemoryTag::ALLOCATOR, size, nullptr, "failed to allocate data of size %s%s",
 	                                                   StringUtil::BytesToHumanReadableString(size));
 	// We rely on manual tracking of this one. :(
 	reservation.size = 0;
@@ -760,7 +760,7 @@ data_ptr_t StandardBufferManager::BufferAllocatorAllocate(PrivateAllocatorData *
 
 void StandardBufferManager::BufferAllocatorFree(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size) {
 	auto &data = private_data->Cast<BufferAllocatorData>();
-	BufferPoolReservation r(data.manager.GetBufferPool());
+	BufferPoolReservation r(MemoryTag::ALLOCATOR, data.manager.GetBufferPool());
 	r.size = size;
 	r.Resize(0);
 	return Allocator::Get(data.manager.db).FreeData(pointer, size);
@@ -772,7 +772,7 @@ data_ptr_t StandardBufferManager::BufferAllocatorRealloc(PrivateAllocatorData *p
 		return pointer;
 	}
 	auto &data = private_data->Cast<BufferAllocatorData>();
-	BufferPoolReservation r(data.manager.GetBufferPool());
+	BufferPoolReservation r(MemoryTag::ALLOCATOR, data.manager.GetBufferPool());
 	r.size = old_size;
 	r.Resize(size);
 	r.size = 0;

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -83,8 +83,8 @@ idx_t StandardBufferManager::GetMaxMemory() const {
 }
 
 template <typename... ARGS>
-TempBufferPoolReservation StandardBufferManager::EvictBlocksOrThrow(MemoryTag tag, idx_t memory_delta, unique_ptr<FileBuffer> *buffer,
-                                                                    ARGS... args) {
+TempBufferPoolReservation StandardBufferManager::EvictBlocksOrThrow(MemoryTag tag, idx_t memory_delta,
+                                                                    unique_ptr<FileBuffer> *buffer, ARGS... args) {
 	auto r = buffer_pool.EvictBlocks(tag, memory_delta, buffer_pool.maximum_memory, buffer);
 	if (!r.success) {
 		string extra_text = StringUtil::Format(" (%s/%s used)", StringUtil::BytesToHumanReadableString(GetUsedMemory()),
@@ -103,8 +103,8 @@ shared_ptr<BlockHandle> StandardBufferManager::RegisterSmallMemory(idx_t block_s
 	auto buffer = ConstructManagedBuffer(block_size, nullptr, FileBufferType::TINY_BUFFER);
 
 	// create a new block pointer for this block
-	return make_shared<BlockHandle>(*temp_block_manager, ++temporary_id, MemoryTag::BASE_TABLE, std::move(buffer), false, block_size,
-	                                std::move(res));
+	return make_shared<BlockHandle>(*temp_block_manager, ++temporary_id, MemoryTag::BASE_TABLE, std::move(buffer),
+	                                false, block_size, std::move(res));
 }
 
 shared_ptr<BlockHandle> StandardBufferManager::RegisterMemory(MemoryTag tag, idx_t block_size, bool can_destroy) {
@@ -118,11 +118,12 @@ shared_ptr<BlockHandle> StandardBufferManager::RegisterMemory(MemoryTag tag, idx
 	auto buffer = ConstructManagedBuffer(block_size, std::move(reusable_buffer));
 
 	// create a new block pointer for this block
-	return make_shared<BlockHandle>(*temp_block_manager, ++temporary_id, tag, std::move(buffer), can_destroy, alloc_size,
-	                                std::move(res));
+	return make_shared<BlockHandle>(*temp_block_manager, ++temporary_id, tag, std::move(buffer), can_destroy,
+	                                alloc_size, std::move(res));
 }
 
-BufferHandle StandardBufferManager::Allocate(MemoryTag tag, idx_t block_size, bool can_destroy, shared_ptr<BlockHandle> *block) {
+BufferHandle StandardBufferManager::Allocate(MemoryTag tag, idx_t block_size, bool can_destroy,
+                                             shared_ptr<BlockHandle> *block) {
 	shared_ptr<BlockHandle> local_block;
 	auto block_ptr = block ? block : &local_block;
 	*block_ptr = RegisterMemory(tag, block_size, can_destroy);
@@ -143,9 +144,10 @@ void StandardBufferManager::ReAllocate(shared_ptr<BlockHandle> &handle, idx_t bl
 		return;
 	} else if (memory_delta > 0) {
 		// evict blocks until we have space to resize this block
-		auto reservation = EvictBlocksOrThrow(handle->tag, memory_delta, nullptr, "failed to resize block from %s to %s%s",
-		                                      StringUtil::BytesToHumanReadableString(handle->memory_usage),
-		                                      StringUtil::BytesToHumanReadableString(req.alloc_size));
+		auto reservation =
+		    EvictBlocksOrThrow(handle->tag, memory_delta, nullptr, "failed to resize block from %s to %s%s",
+		                       StringUtil::BytesToHumanReadableString(handle->memory_usage),
+		                       StringUtil::BytesToHumanReadableString(req.alloc_size));
 		// EvictBlocks decrements 'current_memory' for us.
 		handle->memory_charge.Merge(std::move(reservation));
 	} else {
@@ -171,8 +173,9 @@ BufferHandle StandardBufferManager::Pin(shared_ptr<BlockHandle> &handle) {
 	}
 	// evict blocks until we have space for the current block
 	unique_ptr<FileBuffer> reusable_buffer;
-	auto reservation = EvictBlocksOrThrow(handle->tag, required_memory, &reusable_buffer, "failed to pin block of size %s%s",
-	                                      StringUtil::BytesToHumanReadableString(required_memory));
+	auto reservation =
+	    EvictBlocksOrThrow(handle->tag, required_memory, &reusable_buffer, "failed to pin block of size %s%s",
+	                       StringUtil::BytesToHumanReadableString(required_memory));
 	// lock the handle again and repeat the check (in case anybody loaded in the mean time)
 	lock_guard<mutex> lock(handle->lock);
 	// check if the block is already loaded
@@ -234,14 +237,15 @@ void StandardBufferManager::SetLimit(idx_t limit) {
 }
 
 vector<MemoryInformation> StandardBufferManager::GetMemoryUsageInfo() const {
-    vector<MemoryInformation> result;
-    for(idx_t k = 0; k < MEMORY_TAG_COUNT; k++) {
-        MemoryInformation info;
-        info.tag = MemoryTag(k);
-        info.size = buffer_pool.memory_usage_per_tag[k].load();
-        result.push_back(info);
-    }
-    return result;
+	vector<MemoryInformation> result;
+	for (idx_t k = 0; k < MEMORY_TAG_COUNT; k++) {
+		MemoryInformation info;
+		info.tag = MemoryTag(k);
+		info.size = buffer_pool.memory_usage_per_tag[k].load();
+		info.evicted_data = evicted_data_per_tag[k].load();
+		result.push_back(info);
+	}
+	return result;
 }
 
 //===--------------------------------------------------------------------===//
@@ -635,12 +639,14 @@ void StandardBufferManager::RequireTemporaryDirectory() {
 	}
 }
 
-void StandardBufferManager::WriteTemporaryBuffer(block_id_t block_id, FileBuffer &buffer) {
+void StandardBufferManager::WriteTemporaryBuffer(MemoryTag tag, block_id_t block_id, FileBuffer &buffer) {
 	RequireTemporaryDirectory();
 	if (buffer.size == Storage::BLOCK_SIZE) {
+		evicted_data_per_tag[uint8_t(tag)] += Storage::BLOCK_SIZE;
 		temp_directory_handle->GetTempFile().WriteTemporaryBuffer(block_id, buffer);
 		return;
 	}
+	evicted_data_per_tag[uint8_t(tag)] += buffer.size;
 	// get the path to write to
 	auto path = GetTemporaryPath(block_id);
 	D_ASSERT(buffer.size > Storage::BLOCK_SIZE);
@@ -651,11 +657,12 @@ void StandardBufferManager::WriteTemporaryBuffer(block_id_t block_id, FileBuffer
 	buffer.Write(*handle, sizeof(idx_t));
 }
 
-unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(block_id_t id,
+unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(MemoryTag tag, block_id_t id,
                                                                   unique_ptr<FileBuffer> reusable_buffer) {
 	D_ASSERT(!temp_directory.empty());
 	D_ASSERT(temp_directory_handle.get());
 	if (temp_directory_handle->GetTempFile().HasTemporaryBuffer(id)) {
+		evicted_data_per_tag[uint8_t(tag)] -= Storage::BLOCK_SIZE;
 		return temp_directory_handle->GetTempFile().ReadTemporaryBuffer(id, std::move(reusable_buffer));
 	}
 	idx_t block_size;
@@ -664,6 +671,7 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(block_id_t id,
 	auto &fs = FileSystem::GetFileSystem(db);
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
 	handle->Read(&block_size, sizeof(idx_t), 0);
+	evicted_data_per_tag[uint8_t(tag)] -= block_size;
 
 	// now allocate a buffer of this size and read the data into that buffer
 	auto buffer =
@@ -738,15 +746,16 @@ const char *StandardBufferManager::InMemoryWarning() {
 	return "\nDatabase is launched in in-memory mode and no temporary directory is specified."
 	       "\nUnused blocks cannot be offloaded to disk."
 	       "\n\nLaunch the database with a persistent storage back-end"
-	       "\nOr set PRAGMA temp_directory='/path/to/tmp.tmp'";
+	       "\nOr set SET temp_directory='/path/to/tmp.tmp'";
 }
 
 void StandardBufferManager::ReserveMemory(idx_t size) {
 	if (size == 0) {
 		return;
 	}
-	auto reservation = EvictBlocksOrThrow(MemoryTag::EXTENSION, size, nullptr, "failed to reserve memory data of size %s%s",
-	                                      StringUtil::BytesToHumanReadableString(size));
+	auto reservation =
+	    EvictBlocksOrThrow(MemoryTag::EXTENSION, size, nullptr, "failed to reserve memory data of size %s%s",
+	                       StringUtil::BytesToHumanReadableString(size));
 	reservation.size = 0;
 }
 
@@ -762,8 +771,9 @@ void StandardBufferManager::FreeReservedMemory(idx_t size) {
 //===--------------------------------------------------------------------===//
 data_ptr_t StandardBufferManager::BufferAllocatorAllocate(PrivateAllocatorData *private_data, idx_t size) {
 	auto &data = private_data->Cast<BufferAllocatorData>();
-	auto reservation = data.manager.EvictBlocksOrThrow(MemoryTag::ALLOCATOR, size, nullptr, "failed to allocate data of size %s%s",
-	                                                   StringUtil::BytesToHumanReadableString(size));
+	auto reservation =
+	    data.manager.EvictBlocksOrThrow(MemoryTag::ALLOCATOR, size, nullptr, "failed to allocate data of size %s%s",
+	                                    StringUtil::BytesToHumanReadableString(size));
 	// We rely on manual tracking of this one. :(
 	reservation.size = 0;
 	return Allocator::Get(data.manager.db).AllocateData(size);

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -58,7 +58,7 @@ unique_ptr<ColumnSegment> ColumnSegment::CreateTransientSegment(DatabaseInstance
 	if (segment_size < Storage::BLOCK_SIZE) {
 		block = buffer_manager.RegisterSmallMemory(segment_size);
 	} else {
-		buffer_manager.Allocate(segment_size, false, &block);
+		buffer_manager.Allocate(MemoryTag::IN_MEMORY_TABLE, segment_size, false, &block);
 	}
 	return make_uniq<ColumnSegment>(db, std::move(block), type, ColumnSegmentType::TRANSIENT, start, 0, *function,
 	                                BaseStatistics::CreateEmpty(type), INVALID_BLOCK, 0, segment_size);
@@ -150,7 +150,7 @@ void ColumnSegment::Resize(idx_t new_size) {
 	auto &buffer_manager = BufferManager::GetBufferManager(db);
 	auto old_handle = buffer_manager.Pin(block);
 	shared_ptr<BlockHandle> new_block;
-	auto new_handle = buffer_manager.Allocate(new_size, false, &new_block);
+	auto new_handle = buffer_manager.Allocate(MemoryTag::IN_MEMORY_TABLE, new_size, false, &new_block);
 	memcpy(new_handle.Ptr(), old_handle.Ptr(), segment_size);
 
 	this->block_id = new_block->BlockId();

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -548,7 +548,7 @@ void WriteAheadLogDeserializer::ReplayCreateIndex() {
 
 			// read the data into a buffer handle
 			shared_ptr<BlockHandle> block_handle;
-			buffer_manager.Allocate(Storage::BLOCK_SIZE, false, &block_handle);
+			buffer_manager.Allocate(MemoryTag::ART_INDEX, Storage::BLOCK_SIZE, false, &block_handle);
 			auto buffer_handle = buffer_manager.Pin(block_handle);
 			auto data_ptr = buffer_handle.Ptr();
 

--- a/test/sql/storage/test_buffer_manager.cpp
+++ b/test/sql/storage/test_buffer_manager.cpp
@@ -205,7 +205,7 @@ TEST_CASE("Test buffer reallocation", "[storage][.]") {
 
 	idx_t requested_size = Storage::BLOCK_SIZE;
 	shared_ptr<BlockHandle> block;
-	auto handle = buffer_manager.Allocate(requested_size, false, &block);
+	auto handle = buffer_manager.Allocate(MemoryTag::EXTENSION, requested_size, false, &block);
 	CHECK(buffer_manager.GetUsedMemory() == BufferManager::GetAllocSize(requested_size));
 	for (; requested_size < limit; requested_size *= 2) {
 		// increase size
@@ -249,7 +249,7 @@ TEST_CASE("Test buffer manager variable size allocations", "[storage][.]") {
 
 	idx_t requested_size = 424242;
 	shared_ptr<BlockHandle> block;
-	auto pin = buffer_manager.Allocate(requested_size, false, &block);
+	auto pin = buffer_manager.Allocate(MemoryTag::EXTENSION, requested_size, false, &block);
 	CHECK(buffer_manager.GetUsedMemory() >= requested_size + Storage::BLOCK_HEADER_SIZE);
 
 	pin.Destroy();
@@ -280,7 +280,7 @@ TEST_CASE("Test buffer manager buffer re-use", "[storage][.]") {
 	blocks.reserve(block_count);
 	for (idx_t i = 0; i < block_count; i++) {
 		blocks.emplace_back();
-		buffer_manager.Allocate(Storage::BLOCK_SIZE, false, &blocks.back());
+		buffer_manager.Allocate(MemoryTag::EXTENSION, Storage::BLOCK_SIZE, false, &blocks.back());
 		// used memory should increment by exactly one block at a time, up to 10
 		CHECK(buffer_manager.GetUsedMemory() == MinValue<idx_t>(pin_count, i + 1) * Storage::BLOCK_ALLOC_SIZE);
 	}
@@ -301,7 +301,7 @@ TEST_CASE("Test buffer manager buffer re-use", "[storage][.]") {
 	REQUIRE_NO_FAIL(con.Query(StringUtil::Format("PRAGMA memory_limit='%lldB'", alloc_size * pin_count)));
 	for (idx_t i = 0; i < block_count; i++) {
 		blocks.emplace_back();
-		buffer_manager.Allocate(block_size, false, &blocks.back());
+		buffer_manager.Allocate(MemoryTag::EXTENSION, block_size, false, &blocks.back());
 		CHECK(buffer_manager.GetUsedMemory() == MinValue<idx_t>(pin_count, i + 1) * alloc_size);
 	}
 	for (idx_t i = 0; i < block_count; i++) {
@@ -314,7 +314,7 @@ TEST_CASE("Test buffer manager buffer re-use", "[storage][.]") {
 	// again, the same but incrementing block_size by 1 for every block (has same alloc_size)
 	for (idx_t i = 0; i < block_count; i++) {
 		blocks.emplace_back();
-		buffer_manager.Allocate(block_size, false, &blocks.back());
+		buffer_manager.Allocate(MemoryTag::EXTENSION, block_size, false, &blocks.back());
 		CHECK(buffer_manager.GetUsedMemory() == MinValue<idx_t>(pin_count, i + 1) * alloc_size);
 		// increment block_size
 		block_size++;
@@ -331,7 +331,7 @@ TEST_CASE("Test buffer manager buffer re-use", "[storage][.]") {
 	block_size = 424242;
 	for (idx_t i = 0; i < block_count; i++) {
 		blocks.emplace_back();
-		buffer_manager.Allocate(block_size, false, &blocks.back());
+		buffer_manager.Allocate(MemoryTag::EXTENSION, block_size, false, &blocks.back());
 		CHECK(buffer_manager.GetUsedMemory() == MinValue<idx_t>(pin_count, i + 1) * alloc_size);
 		// increment block_size
 		block_size--;


### PR DESCRIPTION
This PR adds tagging for memory allocated through the buffer manager so we can more easily trace where memory is being consumed. Memory is tagged using one of the following enum values:

```cpp
enum class MemoryTag : uint8_t {
	BASE_TABLE = 0,
	HASH_TABLE = 1,
	PARQUET_READER = 2,
	CSV_READER = 3,
	ORDER_BY = 4,
	ART_INDEX = 5,
	COLUMN_DATA = 6,
	METADATA = 7,
	OVERFLOW_STRINGS = 8,
	IN_MEMORY_TABLE = 9,
	ALLOCATOR = 10,
	EXTENSION = 11
};
```

Both actively used memory, and memory that is off-loaded to disk, is tracked for each of these memory classes. The currently active memory usage can be queried using the `duckdb_memory` table function, e.g.:

```sql
$ > duckdb tpch.db
D FROM duckdb_memory();
┌──────────────────┬────────────────────┬─────────────────────────┐
│       tag        │ memory_usage_bytes │ temporary_storage_bytes │
│     varchar      │       int64        │          int64          │
├──────────────────┼────────────────────┼─────────────────────────┤
│ BASE_TABLE       │             524288 │                       0 │
│ HASH_TABLE       │                  0 │                       0 │
│ PARQUET_READER   │                  0 │                       0 │
│ CSV_READER       │                  0 │                       0 │
│ ORDER_BY         │                  0 │                       0 │
│ ART_INDEX        │                  0 │                       0 │
│ COLUMN_DATA      │                  0 │                       0 │
│ METADATA         │                  0 │                       0 │
│ OVERFLOW_STRINGS │                  0 │                       0 │
│ IN_MEMORY_TABLE  │                  0 │                       0 │
│ ALLOCATOR        │                  0 │                       0 │
│ EXTENSION        │                  0 │                       0 │
├──────────────────┴────────────────────┴─────────────────────────┤
│ 12 rows                                               3 columns │
└─────────────────────────────────────────────────────────────────┘
-- execute Q1, triggering part of lineitem to be loaded in memory
D PRAGMA tpch(1);
D FROM duckdb_memory();
┌──────────────────┬────────────────────┬─────────────────────────┐
│       tag        │ memory_usage_bytes │ temporary_storage_bytes │
│     varchar      │       int64        │          int64          │
├──────────────────┼────────────────────┼─────────────────────────┤
│ BASE_TABLE       │           62652416 │                       0 │
│ HASH_TABLE       │                  0 │                       0 │
│ PARQUET_READER   │                  0 │                       0 │
│ CSV_READER       │                  0 │                       0 │
│ ORDER_BY         │                  0 │                       0 │
│ ART_INDEX        │                  0 │                       0 │
│ COLUMN_DATA      │                  0 │                       0 │
│ METADATA         │                  0 │                       0 │
│ OVERFLOW_STRINGS │                  0 │                       0 │
│ IN_MEMORY_TABLE  │                  0 │                       0 │
│ ALLOCATOR        │                  0 │                       0 │
│ EXTENSION        │                  0 │                       0 │
├──────────────────┴────────────────────┴─────────────────────────┤
│ 12 rows                                               3 columns │
└─────────────────────────────────────────────────────────────────┘
-- reduce the memory limit, triggering part of lineitem to be evicted again
D SET memory_limit='20MB';
D FROM duckdb_memory();
┌──────────────────┬────────────────────┬─────────────────────────┐
│       tag        │ memory_usage_bytes │ temporary_storage_bytes │
│     varchar      │       int64        │          int64          │
├──────────────────┼────────────────────┼─────────────────────────┤
│ BASE_TABLE       │           19922944 │                       0 │
│ HASH_TABLE       │                  0 │                       0 │
│ PARQUET_READER   │                  0 │                       0 │
│ CSV_READER       │                  0 │                       0 │
│ ORDER_BY         │                  0 │                       0 │
│ ART_INDEX        │                  0 │                       0 │
│ COLUMN_DATA      │                  0 │                       0 │
│ METADATA         │                  0 │                       0 │
│ OVERFLOW_STRINGS │                  0 │                       0 │
│ IN_MEMORY_TABLE  │                  0 │                       0 │
│ ALLOCATOR        │                  0 │                       0 │
│ EXTENSION        │                  0 │                       0 │
├──────────────────┴────────────────────┴─────────────────────────┤
│ 12 rows                                               3 columns │
└─────────────────────────────────────────────────────────────────┘


```