### PR TITLE
Linenoise: Disable automatic auto-complete rendering by default for now

### DIFF
--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 static const char *continuationPrompt = "> ";
 static const char *continuationSelectedPrompt = "> ";
-static bool enableCompletionRendering = true;
+static bool enableCompletionRendering = false;
 static bool enableErrorRendering = true;
 
 void Linenoise::EnableCompletionRendering() {


### PR DESCRIPTION
Let's turn this off by default for now as it is not as performant as I would like it to be

This can still be toggled on if desired with `.render_completion on`