### PR TITLE
bundle-library: Add optional Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,3 +427,13 @@ generate-files:
 	python3 scripts/generate_functions.py
 	python3 scripts/generate_serialization.py
 	python3 scripts/generate_enum_util.py
+
+bundle-library: release
+	cd build/release && \
+	mkdir -p bundle && \
+	cp src/libduckdb_static.a bundle/. && \
+	cp third_party/*/libduckdb_*.a bundle/. && \
+	cp extension/*/lib*_extension.a bundle/. && \
+	cd bundle && \
+	find . -name '*.a' -exec ${AR} -x {} \; && \
+	${AR} cr ../libduckdb_bundle.a *.o


### PR DESCRIPTION
make bundle-library can be used by third party developers that want to statically link against duckdb library to generate a single static library comprised of all statically built extensions and all necessary third party libraries

Solves (to some degree) https://github.com/duckdb/duckdb/issues/9475 and issue encountered in the go-duckdb API while bundling extensions

Note that since this is only adding an optional Makefile target it should be more easy to prove it can't have any effect on other targets. Also, this is, at the current moment, not tested in any CI job.