### PR TITLE
Improve the error message for STRUCT to STRUCT casts

### DIFF
--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -19,7 +19,8 @@ unique_ptr<BoundCastData> StructBoundCastData::BindStructToStructCast(BindCastIn
 	for (idx_t i = 0; i < source_child_types.size(); i++) {
 		if (!target_is_unnamed && !source_is_unnamed &&
 		    !StringUtil::CIEquals(source_child_types[i].first, result_child_types[i].first)) {
-			throw TypeMismatchException(source, target, "Cannot cast STRUCTs with different names");
+			throw TypeMismatchException(source, target,
+			                            "Cannot cast STRUCTs with different names. Are the fields in the same order?");
 		}
 		auto child_cast = input.GetCastFunction(source_child_types[i].second, result_child_types[i].second);
 		child_cast_info.push_back(std::move(child_cast));


### PR DESCRIPTION
See #10486.

We should also update this in our documentation. I think rewriting the code to support rearranging the child vectors is not necessary?

```sql
CREATE TABLE t1 (s STRUCT(str STRING, i INT));
CREATE TABLE t2 (s STRUCT(i INT, str STRING));
INSERT INTO t1 SELECT {'str': 'hello', 'i': 42};
INSERT INTO t2 SELECT {'i': t1.s.i, 'str': t1.s.str} FROM t1;
FROM t1;
┌────────────────────────────────┐
│               s                │
│ struct(str varchar, i integer) │
├────────────────────────────────┤
│ {'str': hello, 'i': 42}        │
└────────────────────────────────┘
FROM t2;
┌────────────────────────────────┐
│               s                │
│ struct(i integer, str varchar) │
├────────────────────────────────┤
│ {'i': 42, 'str': hello}        │
└────────────────────────────────┘
```