### PR TITLE
[Dev] Fix ASAN thread limit exceeded issue in CI

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -453,7 +453,7 @@ jobs:
 
       - name: Test
         shell: bash
-        run: build/relassert/test/unittest
+        run: python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest
 
   regression-test-memory-safety:
    name: Regression Tests between safe and unsafe builds


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/1181

The failure is a non-issue, it's a limit set by GCC when ASAN is enabled.
The 4m threads are the total amount of threads, not the amount of threads that are alive.

To fix this we use `run_tests_one_by_one` which runs every test in its own process instead