### PR TITLE
[Dev] Cancel tasks in EndQueryInternal

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -149,6 +149,11 @@ ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success,
 		s.second->QueryEnd();
 	}
 
+	if (active_query->executor) {
+		active_query->executor->CancelTasks();
+	}
+	active_query->progress_bar.reset();
+
 	D_ASSERT(active_query.get());
 	active_query.reset();
 	query_progress.Initialize();


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/1205

I have tested this on a linux VM, before this change I hit the thread sanitizer, afterwards I don't.
The reasoning behind this is the Executor is being used by the worker threads, but because of `active_query.reset()` it gets destroyed.

Canceling the tasks makes sure that no worker thread can still be accessing the Executor after (or during) the process of destruction.