### PR TITLE
feat: make SecretEntry copyable so we don't lose the underlying BaseSecret obj for non-CatalogSet secrets

### DIFF
--- a/src/function/table/system/duckdb_secrets.cpp
+++ b/src/function/table/system/duckdb_secrets.cpp
@@ -97,17 +97,17 @@ void DuckDBSecretsFunction(ClientContext &context, TableFunctionInput &data_p, D
 		auto &secret_entry = secrets[data.offset];
 
 		vector<Value> scope_value;
-		for (const auto &scope_entry : secret_entry.get().secret->GetScope()) {
+		for (const auto &scope_entry : secret_entry.secret->GetScope()) {
 			scope_value.push_back(scope_entry);
 		}
 
-		const auto &secret = *secret_entry.get().secret;
+		const auto &secret = *secret_entry.secret;
 
 		output.SetValue(0, count, secret.GetName());
 		output.SetValue(1, count, Value(secret.GetType()));
 		output.SetValue(2, count, Value(secret.GetProvider()));
-		output.SetValue(3, count, Value(secret_entry.get().persist_type == SecretPersistType::PERSISTENT));
-		output.SetValue(4, count, Value(secret_entry.get().storage_mode));
+		output.SetValue(3, count, Value(secret_entry.persist_type == SecretPersistType::PERSISTENT));
+		output.SetValue(4, count, Value(secret_entry.storage_mode));
 		output.SetValue(5, count, Value::LIST(LogicalType::VARCHAR, scope_value));
 		output.SetValue(6, count, secret.ToString(bind_data.redact));
 

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -101,6 +101,7 @@ public:
 	virtual void Serialize(Serializer &serializer) const;
 
 	virtual unique_ptr<const BaseSecret> Clone() const {
+		D_ASSERT(typeid(BaseSecret) == typeid(*this));
 		return make_uniq<BaseSecret>(*this);
 	}
 

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -100,6 +100,10 @@ public:
 	//! Serialize this secret
 	virtual void Serialize(Serializer &serializer) const;
 
+	virtual unique_ptr<const BaseSecret> Clone() const {
+		return make_uniq<BaseSecret>(*this);
+	}
+
 	//! Getters
 	const vector<string> &GetScope() const {
 		return prefix_paths;
@@ -186,6 +190,10 @@ public:
 		}
 
 		return duckdb::unique_ptr_cast<TYPE, BaseSecret>(std::move(result));
+	}
+
+	unique_ptr<const BaseSecret> Clone() const override {
+		return make_uniq<KeyValueSecret>(*this);
 	}
 
 	//! the map of key -> values that make up the secret

--- a/src/include/duckdb/main/secret/secret_storage.hpp
+++ b/src/include/duckdb/main/secret/secret_storage.hpp
@@ -38,10 +38,10 @@ public:
 	};
 
 	//! Store a secret
-	virtual optional_ptr<SecretEntry> StoreSecret(unique_ptr<const BaseSecret> secret, OnCreateConflict on_conflict,
-	                                              optional_ptr<CatalogTransaction> transaction = nullptr) = 0;
+	virtual unique_ptr<SecretEntry> StoreSecret(unique_ptr<const BaseSecret> secret, OnCreateConflict on_conflict,
+	                                            optional_ptr<CatalogTransaction> transaction = nullptr) = 0;
 	//! Get all secrets
-	virtual vector<reference<SecretEntry>> AllSecrets(optional_ptr<CatalogTransaction> transaction = nullptr) = 0;
+	virtual vector<SecretEntry> AllSecrets(optional_ptr<CatalogTransaction> transaction = nullptr) = 0;
 	//! Drop secret by name
 	virtual void DropSecretByName(const string &name, OnEntryNotFound on_entry_not_found,
 	                              optional_ptr<CatalogTransaction> transaction = nullptr) = 0;
@@ -49,8 +49,8 @@ public:
 	virtual SecretMatch LookupSecret(const string &path, const string &type,
 	                                 optional_ptr<CatalogTransaction> transaction = nullptr) = 0;
 	//! Get a secret by name
-	virtual optional_ptr<SecretEntry> GetSecretByName(const string &name,
-	                                                  optional_ptr<CatalogTransaction> transaction = nullptr) = 0;
+	virtual unique_ptr<SecretEntry> GetSecretByName(const string &name,
+	                                                optional_ptr<CatalogTransaction> transaction = nullptr) = 0;
 
 	//! Return the offset associated to this storage for tie-breaking secrets between storages
 	virtual int64_t GetTieBreakOffset() = 0;
@@ -103,15 +103,15 @@ public:
 		return storage_name;
 	};
 
-	virtual optional_ptr<SecretEntry> StoreSecret(unique_ptr<const BaseSecret> secret, OnCreateConflict on_conflict,
-	                                              optional_ptr<CatalogTransaction> transaction = nullptr) override;
-	vector<reference<SecretEntry>> AllSecrets(optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	virtual unique_ptr<SecretEntry> StoreSecret(unique_ptr<const BaseSecret> secret, OnCreateConflict on_conflict,
+	                                            optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	vector<SecretEntry> AllSecrets(optional_ptr<CatalogTransaction> transaction = nullptr) override;
 	void DropSecretByName(const string &name, OnEntryNotFound on_entry_not_found,
 	                      optional_ptr<CatalogTransaction> transaction = nullptr) override;
 	SecretMatch LookupSecret(const string &path, const string &type,
 	                         optional_ptr<CatalogTransaction> transaction = nullptr) override;
-	optional_ptr<SecretEntry> GetSecretByName(const string &name,
-	                                          optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	unique_ptr<SecretEntry> GetSecretByName(const string &name,
+	                                        optional_ptr<CatalogTransaction> transaction = nullptr) override;
 
 protected:
 	//! Callback called on Store to allow child classes to implement persistence.


### PR DESCRIPTION
Address https://github.com/duckdb/duckdb/pull/10421/files#r1474885988