### PR TITLE
[Dev] Fix isses in parallel Checkpoint

### DIFF
--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -401,7 +401,9 @@ void Executor::CancelTasks() {
 		to_be_rescheduled_tasks.clear();
 		events.clear();
 	}
+	// Take all pending tasks and execute them until they cancel
 	WorkOnTasks();
+	// In case there are still tasks being worked, wait for those to properly finish as well
 	for (auto &weak_ref : weak_references) {
 		while (true) {
 			auto weak = weak_ref.lock();

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -799,7 +799,7 @@ public:
 					                                           append_count);
 					append_counts[current_append_idx] += append_count;
 					remaining -= append_count;
-					if (remaining > 0) {
+					if (remaining > 0 || append_counts[current_append_idx] == Storage::ROW_GROUP_SIZE) {
 						// move to the next row group
 						current_append_idx++;
 						new_row_groups[current_append_idx]->InitializeAppend(append_state.row_group_append_state);

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -642,6 +642,26 @@ public:
 		}
 		return false;
 	}
+	void CancelTasks() {
+		// This should only be called after an error has occurred, no other mechanism to cancel checkpoint tasks exists
+		// currently
+		D_ASSERT(error_manager.HasError());
+		// Give every pending task the chance to cancel
+		WorkOnTasks();
+		// Wait for all active tasks to realize they have been canceled
+		while (completed_tasks != total_tasks) {
+		}
+	}
+
+	void WorkOnTasks() {
+		shared_ptr<Task> task_from_producer;
+		while (scheduler.GetTaskFromProducer(*token, task_from_producer)) {
+			auto res = task_from_producer->Execute(TaskExecutionMode::PROCESS_ALL);
+			D_ASSERT(res != TaskExecutionResult::TASK_BLOCKED);
+			task_from_producer.reset();
+		}
+	}
+
 	bool GetTask(shared_ptr<Task> &task) {
 		return scheduler.GetTaskFromProducer(*token, task);
 	}
@@ -660,7 +680,10 @@ public:
 
 	virtual void ExecuteTask() = 0;
 	TaskExecutionResult Execute(TaskExecutionMode mode) override {
+		(void)mode;
+		D_ASSERT(mode == TaskExecutionMode::PROCESS_ALL);
 		if (checkpoint_state.HasError()) {
+			checkpoint_state.FinishTask();
 			return TaskExecutionResult::TASK_FINISHED;
 		}
 		try {
@@ -672,6 +695,7 @@ public:
 		} catch (...) { // LCOV_EXCL_START
 			checkpoint_state.PushError(ErrorData("Unknown exception during Checkpoint!"));
 		} // LCOV_EXCL_STOP
+		checkpoint_state.FinishTask();
 		return TaskExecutionResult::TASK_ERROR;
 	}
 
@@ -942,8 +966,10 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 	// check if we ran into any errors while checkpointing
 	if (checkpoint_state.HasError()) {
 		// throw the error
+		checkpoint_state.CancelTasks();
 		checkpoint_state.ThrowError();
 	}
+
 	// no errors - finalize the row groups
 	idx_t new_total_rows = 0;
 	for (idx_t segment_idx = 0; segment_idx < segments.size(); segment_idx++) {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -657,6 +657,7 @@ public:
 		shared_ptr<Task> task_from_producer;
 		while (scheduler.GetTaskFromProducer(*token, task_from_producer)) {
 			auto res = task_from_producer->Execute(TaskExecutionMode::PROCESS_ALL);
+			(void)res;
 			D_ASSERT(res != TaskExecutionResult::TASK_BLOCKED);
 			task_from_producer.reset();
 		}

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -799,7 +799,9 @@ public:
 					                                           append_count);
 					append_counts[current_append_idx] += append_count;
 					remaining -= append_count;
-					if (remaining > 0 || append_counts[current_append_idx] == Storage::ROW_GROUP_SIZE) {
+					const bool row_group_full = append_counts[current_append_idx] == Storage::ROW_GROUP_SIZE;
+					const bool last_row_group = current_append_idx + 1 >= new_row_groups.size();
+					if (remaining > 0 || (row_group_full && !last_row_group)) {
 						// move to the next row group
 						current_append_idx++;
 						new_row_groups[current_append_idx]->InitializeAppend(append_state.row_group_append_state);

--- a/test/sql/storage/parallel/memory_limit_batch_load_list.test_slow
+++ b/test/sql/storage/parallel/memory_limit_batch_load_list.test_slow
@@ -17,13 +17,25 @@ SET memory_limit='300MB'
 foreach row_group_size 5000 150000 1000000
 
 statement ok
-COPY (SELECT [i] AS l FROM range(10000000) tbl(i)) TO '__TEST_DIR__/giant_row_groups.parquet' (ROW_GROUP_SIZE ${row_group_size})
+COPY (
+	SELECT [i] AS l FROM range(10000000) tbl(i)
+) TO '__TEST_DIR__/giant_row_groups.parquet' (
+	ROW_GROUP_SIZE ${row_group_size}
+)
 
 statement ok
 CREATE TABLE list AS FROM '__TEST_DIR__/giant_row_groups.parquet'
 
 query IIIII
-SELECT SUM(i), MIN(i), MAX(i), COUNT(i), COUNT(*) FROM (SELECT UNNEST(l) AS i FROM list)
+SELECT
+	SUM(i),
+	MIN(i),
+	MAX(i),
+	COUNT(i),
+	COUNT(*)
+FROM (
+	SELECT UNNEST(l) AS i FROM list
+)
 ----
 49999995000000	0	9999999	10000000	10000000
 
@@ -41,18 +53,32 @@ DROP TABLE list
 
 # now with NULL values
 statement ok
-COPY (SELECT CASE WHEN i%2=0 THEN NULL ELSE [i] END AS l FROM range(10000000) tbl(i)) TO '__TEST_DIR__/giant_row_groups_nulls.parquet' (ROW_GROUP_SIZE ${row_group_size})
+COPY (
+	SELECT CASE WHEN i%2=0 THEN NULL ELSE [i] END AS l FROM range(10000000) tbl(i)
+) TO '__TEST_DIR__/giant_row_groups_nulls.parquet' (
+	ROW_GROUP_SIZE ${row_group_size}
+)
 
 statement ok
 CREATE TABLE list AS FROM '__TEST_DIR__/giant_row_groups_nulls.parquet'
 
 query IIIII
-SELECT SUM(i), MIN(i), MAX(i), COUNT(i), COUNT(*) FROM (SELECT UNNEST(l) AS i FROM list)
+SELECT
+	SUM(i),
+	MIN(i),
+	MAX(i),
+	COUNT(i),
+	COUNT(*)
+FROM (
+	SELECT UNNEST(l) AS i FROM list
+)
 ----
 25000000000000	1	9999999	5000000	5000000
 
 query I
-SELECT * FROM list LIMIT 5 OFFSET 99998
+SELECT
+	*
+FROM list LIMIT 5 OFFSET 99998
 ----
 NULL
 [99999]


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/932

There are two separate issues here, the first triggered by the second:

1. Similar to the issue we recently fixed around EndQueryInternal, the object passed as reference to the CheckpointTask was deleted before all tasks had finished, causing a stack-use-after-scope issue. We now properly cancel all tasks before destroying the shared object.

2. The CheckpointTask's ExecuteTask method was causing an assertion to trigger in RowGroup::Append because we were not detecting early enough that a row group was maxed out and moving on to the next row group.