### PR TITLE
On *nix, return `errno` in IOException extra_info

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -301,6 +301,10 @@ DependencyException::DependencyException(const string &msg) : Exception(Exceptio
 IOException::IOException(const string &msg) : Exception(ExceptionType::IO, msg) {
 }
 
+IOException::IOException(const string &msg, const unordered_map<string, string> &extra_info)
+    : Exception(ExceptionType::IO, msg, extra_info) {
+}
+
 MissingExtensionException::MissingExtensionException(const string &msg)
     : Exception(ExceptionType::MISSING_EXTENSION, msg) {
 }

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -222,11 +222,17 @@ public:
 class IOException : public Exception {
 public:
 	DUCKDB_API explicit IOException(const string &msg);
+	DUCKDB_API explicit IOException(const string &msg, const unordered_map<string, string> &extra_info);
 	explicit IOException(ExceptionType exception_type, const string &msg) : Exception(exception_type, msg) {
 	}
 
 	template <typename... Args>
 	explicit IOException(const string &msg, Args... params) : IOException(ConstructMessage(msg, params...)) {
+	}
+
+	template <typename... Args>
+	explicit IOException(const string &msg, const unordered_map<string, string> &extra_info, Args... params)
+	    : IOException(ConstructMessage(msg, params...), extra_info) {
 	}
 };
 


### PR DESCRIPTION
This gives visibility in the underlying OS error and thus allows extensions to handle exceptions from the LocalFileSystem more gracefully.
E.g. on EAGAIN an implementor might want to retry the operation.

The information is mostly already present (with strerror(errno)), but not in a program-readable way.