### PR TITLE
Make ClientContext available during attach

### DIFF
--- a/.github/patches/extensions/postgres_scanner/new_attach_param.patch
+++ b/.github/patches/extensions/postgres_scanner/new_attach_param.patch
@@ -1,0 +1,16 @@
+diff --git a/src/postgres_storage.cpp b/src/postgres_storage.cpp
+index d569f2c..8837840 100644
+--- a/src/postgres_storage.cpp
++++ b/src/postgres_storage.cpp
+@@ -7,8 +7,9 @@
+ 
+ namespace duckdb {
+ 
+-static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, AttachedDatabase &db, const string &name,
+-                                          AttachInfo &info, AccessMode access_mode) {
++static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, ClientContext &context,
++                                          AttachedDatabase &db, const string &name, AttachInfo &info,
++                                          AccessMode access_mode) {
+ 	return make_uniq<PostgresCatalog>(db, info.path, access_mode);
+ }
+ 

--- a/.github/patches/extensions/sqlite_scanner/new_attach_param.patch
+++ b/.github/patches/extensions/sqlite_scanner/new_attach_param.patch
@@ -1,0 +1,16 @@
+diff --git a/src/sqlite_storage.cpp b/src/sqlite_storage.cpp
+index d65bf18..ad72003 100644
+--- a/src/sqlite_storage.cpp
++++ b/src/sqlite_storage.cpp
+@@ -12,8 +12,9 @@
+ 
+ namespace duckdb {
+ 
+-static unique_ptr<Catalog> SQLiteAttach(StorageExtensionInfo *storage_info, AttachedDatabase &db, const string &name,
+-                                        AttachInfo &info, AccessMode access_mode) {
++static unique_ptr<Catalog> SQLiteAttach(StorageExtensionInfo *storage_info, ClientContext &context,
++                                        AttachedDatabase &db, const string &name, AttachInfo &info,
++                                        AccessMode access_mode) {
+ 	return make_uniq<SQLiteCatalog>(db, info.path, access_mode);
+ }
+ 

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -39,8 +39,8 @@ public:
 	//! Create an attached database instance with the specified name and storage
 	AttachedDatabase(DatabaseInstance &db, Catalog &catalog, string name, string file_path, AccessMode access_mode);
 	//! Create an attached database instance with the specified storage extension
-	AttachedDatabase(DatabaseInstance &db, Catalog &catalog, StorageExtension &ext, string name, const AttachInfo &info,
-	                 AccessMode access_mode);
+	AttachedDatabase(DatabaseInstance &db, Catalog &catalog, StorageExtension &ext, ClientContext &context, string name,
+	                 const AttachInfo &info, AccessMode access_mode);
 	~AttachedDatabase() override;
 
 	void Initialize();

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -55,8 +55,8 @@ public:
 
 	DUCKDB_API bool TryGetCurrentSetting(const std::string &key, Value &result);
 
-	unique_ptr<AttachedDatabase> CreateAttachedDatabase(const AttachInfo &info, const string &type,
-	                                                    AccessMode access_mode);
+	unique_ptr<AttachedDatabase> CreateAttachedDatabase(ClientContext &context, const AttachInfo &info,
+	                                                    const string &type, AccessMode access_mode);
 
 private:
 	void Initialize(const char *path, DBConfig *config);

--- a/src/include/duckdb/storage/storage_extension.hpp
+++ b/src/include/duckdb/storage/storage_extension.hpp
@@ -24,8 +24,9 @@ struct StorageExtensionInfo {
 	}
 };
 
-typedef unique_ptr<Catalog> (*attach_function_t)(StorageExtensionInfo *storage_info, AttachedDatabase &db,
-                                                 const string &name, AttachInfo &info, AccessMode access_mode);
+typedef unique_ptr<Catalog> (*attach_function_t)(StorageExtensionInfo *storage_info, ClientContext &context,
+                                                 AttachedDatabase &db, const string &name, AttachInfo &info,
+                                                 AccessMode access_mode);
 typedef unique_ptr<TransactionManager> (*create_transaction_manager_t)(StorageExtensionInfo *storage_info,
                                                                        AttachedDatabase &db, Catalog &catalog);
 

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -40,11 +40,13 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 }
 
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension,
-                                   string name_p, const AttachInfo &info, AccessMode access_mode)
+                                   ClientContext &context, string name_p, const AttachInfo &info,
+                                   AccessMode access_mode)
     : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p) {
 	type = access_mode == AccessMode::READ_ONLY ? AttachedDatabaseType::READ_ONLY_DATABASE
 	                                            : AttachedDatabaseType::READ_WRITE_DATABASE;
-	catalog = storage_extension.attach(storage_extension.storage_info.get(), *this, name, *info.Copy(), access_mode);
+	catalog =
+	    storage_extension.attach(storage_extension.storage_info.get(), context, *this, name, *info.Copy(), access_mode);
 	if (!catalog) {
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
 	}

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -123,8 +123,8 @@ ConnectionManager &ConnectionManager::Get(ClientContext &context) {
 	return ConnectionManager::Get(DatabaseInstance::GetDatabase(context));
 }
 
-unique_ptr<AttachedDatabase> DatabaseInstance::CreateAttachedDatabase(const AttachInfo &info, const string &type,
-                                                                      AccessMode access_mode) {
+unique_ptr<AttachedDatabase> DatabaseInstance::CreateAttachedDatabase(ClientContext &context, const AttachInfo &info,
+                                                                      const string &type, AccessMode access_mode) {
 	unique_ptr<AttachedDatabase> attached_database;
 	if (!type.empty()) {
 		// find the storage extension
@@ -137,7 +137,7 @@ unique_ptr<AttachedDatabase> DatabaseInstance::CreateAttachedDatabase(const Atta
 		if (entry->second->attach != nullptr && entry->second->create_transaction_manager != nullptr) {
 			// use storage extension to create the initial database
 			attached_database = make_uniq<AttachedDatabase>(*this, Catalog::GetSystemCatalog(*this), *entry->second,
-			                                                info.name, info, access_mode);
+			                                                context, info.name, info, access_mode);
 		} else {
 			attached_database =
 			    make_uniq<AttachedDatabase>(*this, Catalog::GetSystemCatalog(*this), info.name, info.path, access_mode);

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -38,7 +38,7 @@ optional_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &co
                                                                const string &db_type, AccessMode access_mode) {
 	// now create the attached database
 	auto &db = DatabaseInstance::GetDatabase(context);
-	auto attached_db = db.CreateAttachedDatabase(info, db_type, access_mode);
+	auto attached_db = db.CreateAttachedDatabase(context, info, db_type, access_mode);
 
 	if (db_type.empty()) {
 		InsertDatabasePath(context, info.path, attached_db->name);


### PR DESCRIPTION
This allows storage extensions to read settings and other information available in the current ClientContext.