### PR TITLE
Attach: Normalize paths

### DIFF
--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/database_manager.hpp"
+#include "duckdb/main/db_instance_cache.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/storage/storage_extension.hpp"
@@ -67,11 +68,13 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 	// get the name and path of the database
 	auto &name = info->name;
 	auto &path = info->path;
+
+	auto &fs = FileSystem::GetFileSystem(context.client);
+	path = GetDBAbsolutePath(path, fs);
 	if (db_type.empty()) {
 		DBPathAndType::ExtractExtensionPrefix(path, db_type);
 	}
 	if (name.empty()) {
-		auto &fs = FileSystem::GetFileSystem(context.client);
 		name = AttachedDatabase::ExtractDatabaseName(path, fs);
 	}
 

--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -69,14 +69,14 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 	auto &name = info->name;
 	auto &path = info->path;
 
-	auto &fs = FileSystem::GetFileSystem(context.client);
-	path = GetDBAbsolutePath(path, fs);
 	if (db_type.empty()) {
 		DBPathAndType::ExtractExtensionPrefix(path, db_type);
 	}
+	auto &fs = FileSystem::GetFileSystem(context.client);
 	if (name.empty()) {
 		name = AttachedDatabase::ExtractDatabaseName(path, fs);
 	}
+	path = GetDBAbsolutePath(path, fs);
 
 	// check ATTACH IF NOT EXISTS
 	auto &db_manager = DatabaseManager::Get(context.client);

--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -14,6 +14,9 @@
 #include "duckdb/function/replacement_scan.hpp"
 
 namespace duckdb {
+
+string GetDBAbsolutePath(const string &database_p, FileSystem &fs);
+
 class DBInstanceCache {
 public:
 	DBInstanceCache() {};


### PR DESCRIPTION
This solves problem when referencing like `~/file.db`

Before this:
```
D ATTACH 'file.db' as relative;
D ATTACH '/path/to/file.db' as absolute;
D -- ??
```
After:
```
D ATTACH 'file.db' as relative;
D ATTACH '/path/to/file.db' as absolute;
Error: Binder Error: Unique file handle conflict: Database "relative" is already attached with path "/path/to/file.db",
```
Unsure if this should be added to the tests.

Also `ATTACH ~/file.db; ATTACH ~/file.db;` was not erroring out, now it is.