### PR TITLE
Fix #10486 - allow out-of-order struct casting

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1053,7 +1053,7 @@ LogicalType LogicalType::MaxLogicalType(ClientContext &context, const LogicalTyp
 
 void LogicalType::Verify() const {
 #ifdef DEBUG
-	switch(id_) {
+	switch (id_) {
 	case LogicalTypeId::DECIMAL:
 		D_ASSERT(DecimalType::GetWidth(*this) >= 1 && DecimalType::GetWidth(*this) <= Decimal::MAX_WIDTH_DECIMAL);
 		D_ASSERT(DecimalType::GetScale(*this) >= 0 && DecimalType::GetScale(*this) <= DecimalType::GetWidth(*this));
@@ -1062,7 +1062,7 @@ void LogicalType::Verify() const {
 		// verify child types
 		case_insensitive_set_t child_names;
 		bool all_empty = true;
-		for(auto &entry : StructType::GetChildTypes(*this)) {
+		for (auto &entry : StructType::GetChildTypes(*this)) {
 			if (entry.first.empty()) {
 				D_ASSERT(all_empty);
 			} else {

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1053,9 +1053,39 @@ LogicalType LogicalType::MaxLogicalType(ClientContext &context, const LogicalTyp
 
 void LogicalType::Verify() const {
 #ifdef DEBUG
-	if (id_ == LogicalTypeId::DECIMAL) {
+	switch(id_) {
+	case LogicalTypeId::DECIMAL:
 		D_ASSERT(DecimalType::GetWidth(*this) >= 1 && DecimalType::GetWidth(*this) <= Decimal::MAX_WIDTH_DECIMAL);
 		D_ASSERT(DecimalType::GetScale(*this) >= 0 && DecimalType::GetScale(*this) <= DecimalType::GetWidth(*this));
+		break;
+	case LogicalTypeId::STRUCT: {
+		// verify child types
+		case_insensitive_set_t child_names;
+		bool all_empty = true;
+		for(auto &entry : StructType::GetChildTypes(*this)) {
+			if (entry.first.empty()) {
+				D_ASSERT(all_empty);
+			} else {
+				// check for duplicate struct names
+				all_empty = false;
+				auto existing_entry = child_names.find(entry.first);
+				D_ASSERT(existing_entry == child_names.end());
+				child_names.insert(entry.first);
+			}
+			entry.second.Verify();
+		}
+		break;
+	}
+	case LogicalTypeId::LIST:
+		ListType::GetChildType(*this).Verify();
+		break;
+	case LogicalTypeId::MAP: {
+		MapType::KeyType(*this).Verify();
+		MapType::ValueType(*this).Verify();
+		break;
+	}
+	default:
+		break;
 	}
 #endif
 }

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -36,7 +36,9 @@ unique_ptr<BoundCastData> StructBoundCastData::BindStructToStructCast(BindCastIn
 			// named struct cast - find corresponding member in target
 			auto entry = target_members.find(source_child.first);
 			if (entry == target_members.end()) {
-				throw TypeMismatchException(source, target, "Cannot cast STRUCTs - element \"" + source_child.first + "\" in source struct was not found in target struct" );
+				throw TypeMismatchException(source, target,
+				                            "Cannot cast STRUCTs - element \"" + source_child.first +
+				                                "\" in source struct was not found in target struct");
 			}
 			target_idx = entry->second;
 			target_members.erase(entry);

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -22,7 +22,7 @@ unique_ptr<BoundCastData> StructBoundCastData::BindStructToStructCast(BindCastIn
 		for (idx_t i = 0; i < result_child_types.size(); i++) {
 			auto &target_name = result_child_types[i].first;
 			if (target_members.find(target_name) != target_members.end()) {
-				throw BinderException("Error while casting - duplicate name \"%s\" in struct", target_name);
+				throw NotImplementedException("Error while casting - duplicate name \"%s\" in struct", target_name);
 			}
 			target_members[target_name] = i;
 		}

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -16,15 +16,40 @@ unique_ptr<BoundCastData> StructBoundCastData::BindStructToStructCast(BindCastIn
 	if (source_child_types.size() != result_child_types.size()) {
 		throw TypeMismatchException(source, target, "Cannot cast STRUCTs of different size");
 	}
-	for (idx_t i = 0; i < source_child_types.size(); i++) {
-		if (!target_is_unnamed && !source_is_unnamed &&
-		    !StringUtil::CIEquals(source_child_types[i].first, result_child_types[i].first)) {
-			throw TypeMismatchException(source, target, "Cannot cast STRUCTs with different names");
+	bool named_struct_cast = !source_is_unnamed && !target_is_unnamed;
+	case_insensitive_map_t<idx_t> target_members;
+	if (named_struct_cast) {
+		for (idx_t i = 0; i < result_child_types.size(); i++) {
+			auto &target_name = result_child_types[i].first;
+			if (target_members.find(target_name) != target_members.end()) {
+				throw BinderException("Error while casting - duplicate name \"%s\" in struct", target_name);
+			}
+			target_members[target_name] = i;
 		}
-		auto child_cast = input.GetCastFunction(source_child_types[i].second, result_child_types[i].second);
+	}
+	vector<idx_t> child_member_map;
+	child_member_map.reserve(source_child_types.size());
+	for (idx_t source_idx = 0; source_idx < source_child_types.size(); source_idx++) {
+		auto &source_child = source_child_types[source_idx];
+		idx_t target_idx;
+		if (named_struct_cast) {
+			// named struct cast - find corresponding member in target
+			auto entry = target_members.find(source_child.first);
+			if (entry == target_members.end()) {
+				throw TypeMismatchException(source, target, "Cannot cast STRUCTs - element \"" + source_child.first + "\" in source struct was not found in target struct" );
+			}
+			target_idx = entry->second;
+			target_members.erase(entry);
+		} else {
+			// unnamed struct cast - positionally cast elements
+			target_idx = source_idx;
+		}
+		child_member_map.push_back(target_idx);
+		auto child_cast = input.GetCastFunction(source_child.second, result_child_types[target_idx].second);
 		child_cast_info.push_back(std::move(child_cast));
 	}
-	return make_uniq<StructBoundCastData>(std::move(child_cast_info), target);
+	D_ASSERT(child_member_map.size() == source_child_types.size());
+	return make_uniq<StructBoundCastData>(std::move(child_cast_info), target, std::move(child_member_map));
 }
 
 unique_ptr<FunctionLocalState> StructBoundCastData::InitStructCastLocalState(CastLocalStateParameters &parameters) {
@@ -52,8 +77,10 @@ static bool StructToStructCast(Vector &source, Vector &result, idx_t count, Cast
 	auto &result_children = StructVector::GetEntries(result);
 	bool all_converted = true;
 	for (idx_t c_idx = 0; c_idx < source_child_types.size(); c_idx++) {
-		auto &result_child_vector = *result_children[c_idx];
-		auto &source_child_vector = *source_children[c_idx];
+		auto source_idx = c_idx;
+		auto target_idx = cast_data.child_member_map[source_idx];
+		auto &source_child_vector = *source_children[source_idx];
+		auto &result_child_vector = *result_children[target_idx];
 		CastParameters child_parameters(parameters, cast_data.child_cast_info[c_idx].cast_data,
 		                                lstate.local_states[c_idx]);
 		if (!cast_data.child_cast_info[c_idx].function(source_child_vector, result_child_vector, count,

--- a/src/function/scalar/list/list_zip.cpp
+++ b/src/function/scalar/list/list_zip.cpp
@@ -130,17 +130,15 @@ static unique_ptr<FunctionData> ListZipBind(ClientContext &context, ScalarFuncti
 		size--;
 	}
 
+	case_insensitive_set_t struct_names;
 	for (idx_t i = 0; i < size; i++) {
 		auto &child = arguments[i];
-		if (child->alias.empty()) {
-			child->alias = "list_" + to_string(i + 1);
-		}
 		switch (child->return_type.id()) {
 		case LogicalTypeId::LIST:
-			struct_children.push_back(make_pair(child->alias, ListType::GetChildType(child->return_type)));
+			struct_children.push_back(make_pair(string(), ListType::GetChildType(child->return_type)));
 			break;
 		case LogicalTypeId::SQLNULL:
-			struct_children.push_back(make_pair(child->alias, LogicalTypeId::SQLNULL));
+			struct_children.push_back(make_pair(string(), LogicalTypeId::SQLNULL));
 			break;
 		default:
 			throw ParameterNotResolvedException();

--- a/src/function/table/system/test_all_types.cpp
+++ b/src/function/table/system/test_all_types.cpp
@@ -196,7 +196,7 @@ vector<TestType> TestAllTypesFun::GetTestTypes(bool use_large_enum) {
 	map_struct1.push_back(make_pair("value", Value("🦆🦆🦆🦆🦆🦆")));
 	child_list_t<Value> map_struct2;
 	map_struct2.push_back(make_pair("key", Value("key2")));
-	map_struct2.push_back(make_pair("key", Value("goose")));
+	map_struct2.push_back(make_pair("value", Value("goose")));
 
 	vector<Value> map_values;
 	map_values.push_back(Value::STRUCT(map_struct1));

--- a/src/include/duckdb/function/cast/bound_cast_data.hpp
+++ b/src/include/duckdb/function/cast/bound_cast_data.hpp
@@ -48,12 +48,20 @@ struct ListCast {
 };
 
 struct StructBoundCastData : public BoundCastData {
+	StructBoundCastData(vector<BoundCastInfo> child_casts, LogicalType target_p, vector<idx_t> child_member_map_p)
+	    : child_cast_info(std::move(child_casts)), target(std::move(target_p)), child_member_map(std::move(child_member_map_p)) {
+		D_ASSERT(child_cast_info.size() == child_member_map.size());
+	}
 	StructBoundCastData(vector<BoundCastInfo> child_casts, LogicalType target_p)
-	    : child_cast_info(std::move(child_casts)), target(std::move(target_p)) {
+			: child_cast_info(std::move(child_casts)), target(std::move(target_p)) {
+		for(idx_t i = 0; i < child_cast_info.size(); i++) {
+			child_member_map.push_back(i);
+		}
 	}
 
 	vector<BoundCastInfo> child_cast_info;
 	LogicalType target;
+	vector<idx_t> child_member_map;
 
 	static unique_ptr<BoundCastData> BindStructToStructCast(BindCastInput &input, const LogicalType &source,
 	                                                        const LogicalType &target);
@@ -65,7 +73,7 @@ public:
 		for (auto &info : child_cast_info) {
 			copy_info.push_back(info.Copy());
 		}
-		return make_uniq<StructBoundCastData>(std::move(copy_info), target);
+		return make_uniq<StructBoundCastData>(std::move(copy_info), target, child_member_map);
 	}
 };
 

--- a/src/include/duckdb/function/cast/bound_cast_data.hpp
+++ b/src/include/duckdb/function/cast/bound_cast_data.hpp
@@ -49,12 +49,13 @@ struct ListCast {
 
 struct StructBoundCastData : public BoundCastData {
 	StructBoundCastData(vector<BoundCastInfo> child_casts, LogicalType target_p, vector<idx_t> child_member_map_p)
-	    : child_cast_info(std::move(child_casts)), target(std::move(target_p)), child_member_map(std::move(child_member_map_p)) {
+	    : child_cast_info(std::move(child_casts)), target(std::move(target_p)),
+	      child_member_map(std::move(child_member_map_p)) {
 		D_ASSERT(child_cast_info.size() == child_member_map.size());
 	}
 	StructBoundCastData(vector<BoundCastInfo> child_casts, LogicalType target_p)
-			: child_cast_info(std::move(child_casts)), target(std::move(target_p)) {
-		for(idx_t i = 0; i < child_cast_info.size(); i++) {
+	    : child_cast_info(std::move(child_casts)), target(std::move(target_p)) {
+		for (idx_t i = 0; i < child_cast_info.size(); i++) {
 			child_member_map.push_back(i);
 		}
 	}

--- a/test/common/test_cast_struct.test
+++ b/test/common/test_cast_struct.test
@@ -9,7 +9,7 @@ PRAGMA enable_verification
 statement error
 select struct_extract(struct_pack(b=>42)::struct(a integer), 'a');
 ----
-Mismatch Type Error: Type STRUCT(b INTEGER) does not match with STRUCT(a INTEGER). Cannot cast STRUCTs with different names
+element "b" in source struct was not found in target struct
 
 query I
 select struct_extract(struct_pack(a=>42)::struct(a string), 'a');
@@ -20,7 +20,7 @@ select struct_extract(struct_pack(a=>42)::struct(a string), 'a');
 statement error
 select struct_extract(struct_pack(b=>42)::row(a integer), 'a');
 ----
-Mismatch Type Error: Type STRUCT(b INTEGER) does not match with STRUCT(a INTEGER). Cannot cast STRUCTs with different names
+element "b" in source struct was not found in target struct
 
 query I
 select struct_extract(struct_pack(a=>42)::row(a integer), 'a');
@@ -31,7 +31,7 @@ select struct_extract(struct_pack(a=>42)::row(a integer), 'a');
 statement error
 select struct_extract(struct_pack(b=>42::double)::struct(a integer), 'a');
 ----
-Mismatch Type Error: Type STRUCT(b DOUBLE) does not match with STRUCT(a INTEGER). Cannot cast STRUCTs with different names
+element "b" in source struct was not found in target struct
 
 query I
 select struct_extract(struct_pack(a=>42::double)::struct(a integer), 'a');
@@ -41,7 +41,7 @@ select struct_extract(struct_pack(a=>42::double)::struct(a integer), 'a');
 statement error
 select struct_extract(struct_pack(b=>'42'::double)::struct(a integer), 'a');
 ----
-Mismatch Type Error: Type STRUCT(b DOUBLE) does not match with STRUCT(a INTEGER). Cannot cast STRUCTs with different names
+element "b" in source struct was not found in target struct
 
 query I
 select struct_extract(struct_pack(a=>'42'::double)::struct(a integer), 'a');
@@ -76,12 +76,12 @@ Unimplemented type for cast (STRUCT(b INTEGER) -> INTEGER)
 statement error
 select struct_pack(b=>'hello'::string)::struct(a integer)
 ----
-Mismatch Type Error: Type STRUCT(b VARCHAR) does not match with STRUCT(a INTEGER). Cannot cast STRUCTs with different names
+element "b" in source struct was not found in target struct
 
 statement error
 select struct_pack(b=>'42'::double, c => 'asdf'::string)::struct(a1 integer, a2 string);
 ----
-Mismatch Type Error: Type STRUCT(b DOUBLE, c VARCHAR) does not match with STRUCT(a1 INTEGER, a2 VARCHAR). Cannot cast STRUCTs with different names
+element "b" in source struct was not found in target struct
 
 query I
 select struct_pack(a1 =>'42'::double, a2 => 'asdf'::string)::struct(a1 integer, a2 string);

--- a/test/sql/function/list/list_zip.test
+++ b/test/sql/function/list/list_zip.test
@@ -23,41 +23,41 @@ CREATE TABLE integers2 (j int[])
 statement ok
 INSERT INTO integers2 VALUES ([]), (NULL)
 
-#normal use of list_zip
+# normal use of list_zip
 query I
 SELECT list_zip([1,2,3])
 ----
-[{'list_1': 1}, {'list_1': 2}, {'list_1': 3}]
+[(1), (2), (3)]
 
 query I
 SELECT list_zip([1,2,3], [2,3,4], [3,4,5], []);
 ----
-[{'list_1': 1, 'list_2': 2, 'list_3': 3, 'list_4': NULL}, {'list_1': 2, 'list_2': 3, 'list_3': 4, 'list_4': NULL}, {'list_1': 3, 'list_2': 4, 'list_3': 5, 'list_4': NULL}]
+[(1, 2, 3, NULL), (2, 3, 4, NULL), (3, 4, 5, NULL)]
 
 query I
 SELECT list_zip([1,2,3], [1,2,3])
 ----
-[{'list_1': 1, 'list_2': 1}, {'list_1': 2, 'list_2': 2}, {'list_1': 3, 'list_2': 3}]
+[(1, 1), (2, 2), (3, 3)]
 
 query I
 SELECT list_zip([1,2,3], [1,2])
 ----
-[{'list_1': 1, 'list_2': 1}, {'list_1': 2, 'list_2': 2}, {'list_1': 3, 'list_2': NULL}]
+[(1, 1), (2, 2), (3, NULL)]
 
 query I
 SELECT list_zip([1,2], [1,2,3])
 ----
-[{'list_1': 1, 'list_2': 1}, {'list_1': 2, 'list_2': 2}, {'list_1': NULL, 'list_2': 3}]
+[(1, 1), (2, 2), (NULL, 3)]
 
 query I
 SELECT list_zip([1,2,3], NULL)
 ----
-[{'list_1': 1, 'list_2': NULL}, {'list_1': 2, 'list_2': NULL}, {'list_1': 3, 'list_2': NULL}]
+[(1, NULL), (2, NULL), (3, NULL)]
 
 query I
 SELECT list_zip([1,2,3], [])
 ----
-[{'list_1': 1, 'list_2': NULL}, {'list_1': 2, 'list_2': NULL}, {'list_1': 3, 'list_2': NULL}]
+[(1, NULL), (2, NULL), (3, NULL)]
 
 query I
 SELECT list_zip([1,2,3], NULL, true)
@@ -77,46 +77,46 @@ SELECT list_zip([1,2,3], [2,3,4], [3,4,5], [], true);
 query I
 SELECT list_zip(a.i, b.i) as zipped_list FROM integers AS a, integers as b order by all;
 ----
-[{'i': 1, 'i': 1}, {'i': 2, 'i': 2}, {'i': 3, 'i': 3}]
-[{'i': 1, 'i': 4}, {'i': 2, 'i': 5}, {'i': 3, 'i': 6}]
-[{'i': 4, 'i': 1}, {'i': 5, 'i': 2}, {'i': 6, 'i': 3}]
-[{'i': 4, 'i': 4}, {'i': 5, 'i': 5}, {'i': 6, 'i': 6}]
+[(1, 1), (2, 2), (3, 3)]
+[(1, 4), (2, 5), (3, 6)]
+[(4, 1), (5, 2), (6, 3)]
+[(4, 4), (5, 5), (6, 6)]
 
 query I
 SELECT list_zip(a.i, b.i, b.i) FROM integers AS a, integers AS b order by all
 ----
-[{'i': 1, 'i': 1, 'i': 1}, {'i': 2, 'i': 2, 'i': 2}, {'i': 3, 'i': 3, 'i': 3}]
-[{'i': 1, 'i': 4, 'i': 4}, {'i': 2, 'i': 5, 'i': 5}, {'i': 3, 'i': 6, 'i': 6}]
-[{'i': 4, 'i': 1, 'i': 1}, {'i': 5, 'i': 2, 'i': 2}, {'i': 6, 'i': 3, 'i': 3}]
-[{'i': 4, 'i': 4, 'i': 4}, {'i': 5, 'i': 5, 'i': 5}, {'i': 6, 'i': 6, 'i': 6}]
+[(1, 1, 1), (2, 2, 2), (3, 3, 3)]
+[(1, 4, 4), (2, 5, 5), (3, 6, 6)]
+[(4, 1, 1), (5, 2, 2), (6, 3, 3)]
+[(4, 4, 4), (5, 5, 5), (6, 6, 6)]
 
 query I
 SELECT list_zip([1,2,3], true)
 ----
-[{'list_1': 1}, {'list_1': 2}, {'list_1': 3}]
+[(1), (2), (3)]
 
 query I
 SELECT list_zip([1,2,3], [1,2,3], true)
 ----
-[{'list_1': 1, 'list_2': 1}, {'list_1': 2, 'list_2': 2}, {'list_1': 3, 'list_2': 3}]
+[(1, 1), (2, 2), (3, 3)]
 
 query I
 SELECT list_zip([1,2,3], [1,2], true)
 ----
-[{'list_1': 1, 'list_2': 1}, {'list_1': 2, 'list_2': 2}]
+[(1, 1), (2, 2)]
 
 query I
 SELECT list_zip([1,2], [1,2,3], true)
 ----
-[{'list_1': 1, 'list_2': 1}, {'list_1': 2, 'list_2': 2}]
+[(1, 1), (2, 2)]
 
 query I
 SELECT list_zip(i, j, b) FROM integers, integers2, bools order by all desc
 ----
-[{'i': 4, 'j': NULL}, {'i': 5, 'j': NULL}, {'i': 6, 'j': NULL}]
-[{'i': 4, 'j': NULL}, {'i': 5, 'j': NULL}, {'i': 6, 'j': NULL}]
-[{'i': 1, 'j': NULL}, {'i': 2, 'j': NULL}, {'i': 3, 'j': NULL}]
-[{'i': 1, 'j': NULL}, {'i': 2, 'j': NULL}, {'i': 3, 'j': NULL}]
+[(4, NULL), (5, NULL), (6, NULL)]
+[(4, NULL), (5, NULL), (6, NULL)]
+[(1, NULL), (2, NULL), (3, NULL)]
+[(1, NULL), (2, NULL), (3, NULL)]
 []
 []
 []
@@ -139,23 +139,23 @@ SELECT list_zip([1,2,3], [true, false, NULL], [{'list_1': 1}, {'list_1': 2}, {'l
 query I
 SELECT list_zip([true, false, NULL])
 ----
-[{'list_1': true}, {'list_1': false}, {'list_1': NULL}]
+[(true), (false), (NULL)]
 
 query I
 SELECT list_zip([NULL::BOOLEAN, true])
 ----
-[{'list_1': NULL}, {'list_1': true}]
+[(NULL), (true)]
 
 # VARCHAR
 query I
 SELECT list_zip(['aa', 'a'])
 ----
-[{'list_1': aa}, {'list_1': a}]
+[(aa), (a)]
 
 query I
 SELECT list_zip([NULL::VARCHAR])
 ----
-[{'list_1': NULL}]
+[(NULL)]
 
 # INTEGER types
 foreach type tinyint smallint integer bigint hugeint utinyint usmallint uinteger ubigint
@@ -163,12 +163,12 @@ foreach type tinyint smallint integer bigint hugeint utinyint usmallint uinteger
 query I
 SELECT list_zip([1::${type}, NULL, 2::${type}])
 ----
-[{'list_1': 1}, {'list_1': NULL}, {'list_1': 2}]
+[(1), (NULL), (2)]
 
 query I
 SELECT list_zip([NULL::${type}])
 ----
-[{'list_1': NULL}]
+[(NULL)]
 
 endloop
 
@@ -182,7 +182,7 @@ SELECT list_zip([1::${type}])
 query I
 SELECT list_zip([NULL::${type}])
 ----
-[{'list_1': NULL}]
+[(NULL)]
 
 endloop
 
@@ -192,62 +192,62 @@ endloop
 query I
 SELECT list_zip(['2021-08-20'::DATE])
 ----
-[{'list_1': 2021-08-20}]
+[(2021-08-20)]
 
 # time
 query I
 SELECT list_zip(['14:59:37'::TIME])
 ----
-[{'list_1': 14:59:37}]
+[(14:59:37)]
 
 # timestamp
 query I
 SELECT list_zip(['2021-08-20'::TIMESTAMP])
 ----
-[{'list_1': 2021-08-20 00:00:00}]
+[(2021-08-20 00:00:00)]
 
 # timestamp s
 query I
 SELECT list_zip(['2021-08-20'::TIMESTAMP_S])
 ----
-[{'list_1': 2021-08-20 00:00:00}]
+[(2021-08-20 00:00:00)]
 
 # timestamp ms
 query I
 SELECT list_zip(['2021-08-20 00:00:00.123'::TIMESTAMP_MS])
 ----
-[{'list_1': 2021-08-20 00:00:00.123}]
+[(2021-08-20 00:00:00.123)]
 
 # timestamp ns
 query I
 SELECT list_zip(['2021-08-20 00:00:00.123456'::TIMESTAMP_NS])
 ----
-[{'list_1': 2021-08-20 00:00:00.123456}]
+[(2021-08-20 00:00:00.123456)]
 
 # time with time zone
 query I
 SELECT list_zip(['14:59:37'::TIMETZ])
 ----
-[{'list_1': 14:59:37+00}]
+[(14:59:37+00)]
 
 # timestamp with time zone
 query I
 SELECT list_zip(['2021-08-20'::TIMESTAMPTZ])
 ----
-[{'list_1': 2021-08-20 00:00:00+00}]
+[(2021-08-20 00:00:00+00)]
 
 # interval
 query I
 SELECT list_zip([INTERVAL 1 YEAR])
 ----
-[{'list_1': 1 year}]
+[(1 year)]
 
 foreach type date time timestamp timestamp_s timestamp_ms timestamp_ns timetz timestamptz interval
 
 query I
 SELECT list_zip([NULL::${type}])
 ----
-[{'list_1': NULL}]
+[(NULL)]
 
 endloop
 
@@ -256,12 +256,12 @@ endloop
 query I
 SELECT list_zip(['{a: 1}'::BLOB, '{a: 3}'::BLOB])
 ----
-[{'list_1': {a: 1}}, {'list_1': {a: 3}}]
+[({a: 1}), ({a: 3})]
 
 query I
 SELECT list_zip([NULL::BLOB])
 ----
-[{'list_1': NULL}]
+[(NULL)]
 
 # ENUMS
 
@@ -277,17 +277,17 @@ INSERT INTO enums VALUES (['happy', 'sad'])
 query I
 SELECT list_zip(e) FROM enums
 ----
-[{'e': happy}, {'e': sad}]
+[(happy), (sad)]
 
 # NESTED types
 
 query I
 SELECT list_zip([[1], [1, 2], NULL])
 ----
-[{'list_1': [1]}, {'list_1': [1, 2]}, {'list_1': NULL}]
+[([1]), ([1, 2]), (NULL)]
 
 query I
 SELECT list_zip([{'a': 1}, {'a': 5}, {'a': 3}])
 ----
-[{'list_1': {'a': 1}}, {'list_1': {'a': 5}}, {'list_1': {'a': 3}}]
+[({'a': 1}), ({'a': 5}), ({'a': 3})]
 

--- a/test/sql/types/struct/struct_different_names.test
+++ b/test/sql/types/struct/struct_different_names.test
@@ -17,7 +17,7 @@ CREATE TABLE foo (bar struct(pip int));
 statement error
 INSERT INTO foo VALUES ({'ignoreme': 3});
 ----
-Mismatch Type Error: Type STRUCT(ignoreme INTEGER) does not match with STRUCT(pip INTEGER). Cannot cast STRUCTs with different names
+element "ignoreme" in source struct was not found in target struct
 
 statement error
 create table wrong as from (VALUES (ROW(3)));
@@ -35,15 +35,15 @@ SELECT * FROM foo;
 statement ok
 CREATE OR REPLACE TABLE T AS SELECT [{'a': 'A', 'b':'B'}] as x, [{'b':'BB','a':'AA'}] as y;
 
-statement error
+query III
 SELECT x, y, ARRAY_CONCAT(x, y) FROM T;
 ----
-Mismatch Type Error: Type STRUCT(b VARCHAR, a VARCHAR) does not match with STRUCT(a VARCHAR, b VARCHAR). Cannot cast STRUCTs with different names
+[{'a': A, 'b': B}]	[{'b': BB, 'a': AA}]	[{'a': A, 'b': B}, {'a': AA, 'b': BB}]
 
 statement error
 INSERT INTO t1 VALUES ({c: 34});
 ----
-Mismatch Type Error: Type STRUCT(c INTEGER) does not match with STRUCT(v VARCHAR). Cannot cast STRUCTs with different names
+element "c" in source struct was not found in target struct
 
 statement ok
 CREATE OR REPLACE TABLE T (s STRUCT(a INT, b INT));
@@ -51,7 +51,7 @@ CREATE OR REPLACE TABLE T (s STRUCT(a INT, b INT));
 statement error
 INSERT INTO T VALUES ({l: 1, m: 2}), ({x: 3, y: 4});
 ----
-Mismatch Type Error: Type STRUCT(l INTEGER, m INTEGER) does not match with STRUCT(a INTEGER, b INTEGER). Cannot cast STRUCTs with different names
+element "l" in source struct was not found in target struct
 
 # Can insert unnamed struct into named struct
 
@@ -70,7 +70,7 @@ Invalid Input Error: A table cannot be created from an unnamed struct
 statement error
 SELECT [{'foo': True}, {'bar': False}, {'foobar': NULL}];
 ----
-Mismatch Type Error: Type STRUCT(bar BOOLEAN) does not match with STRUCT(foo BOOLEAN). Cannot cast STRUCTs with different names
+element "bar" in source struct was not found in target struct
 
 statement ok
 PREPARE v1 as SELECT ROW(?);

--- a/test/sql/types/struct/struct_named_cast.test
+++ b/test/sql/types/struct/struct_named_cast.test
@@ -1,0 +1,35 @@
+# name: test/sql/types/struct/struct_named_cast.test
+# description: Test struct named casts
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT {'a': 42, 'b': 84}::STRUCT(b INT, a INT)
+----
+{'b': 84, 'a': 42}
+
+# nested
+query I
+SELECT {'a': ['1', '2', '3'], 'b': 84}::STRUCT(b INT, a INT[])
+----
+{'b': 84, 'a': [1, 2, 3]}
+
+# case insensitivity
+query I
+SELECT {'a': ['1', '2', '3'], 'b': 84}::STRUCT(b INT, A INT[])
+----
+{'b': 84, 'A': [1, 2, 3]}
+
+# name mismatch
+statement error
+SELECT {'a': ['1', '2', '3'], 'b': 84}::STRUCT(b INT, c INT[])
+----
+element "a" in source struct was not found in target struct
+
+# unnamed struct cast
+query I
+SELECT ROW(42, 84)::STRUCT(a INT, b INT)
+----
+{'a': 42, 'b': 84}


### PR DESCRIPTION
Fixes  #10486
Supersedes #10508

This PR allows struct fields to be reordered during a cast, e.g.:

```sql
SELECT {'a': 42, 'b': 84}::STRUCT(b INT, a INT)
-- {'b': 84, 'a': 42}
```

The matching is performed by-name, and the cast can only be completed if all names match (but positions can differ).

This PR also:

* Adds a check to `LogicalType::Verify` that struct elements do not have duplicate names
* Modifies `list_zip` so that it returns unnamed structs instead of named structs

