### PR TITLE
Path utility fixes

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -585,10 +585,6 @@ string StringUtil::ToJSONMap(ExceptionType type, const string &message, const un
 
 string StringUtil::GetFileName(const string &file_path) {
 
-	if (EndsWith(file_path, "..")) {
-		return "";
-	}
-
 	idx_t pos = file_path.find_last_of("/\\");
 	if (pos == string::npos) {
 		return file_path;

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -114,16 +114,14 @@ void PhysicalCopyToFile::MoveTmpFile(ClientContext &context, const string &tmp_f
 	auto &fs = FileSystem::GetFileSystem(context);
 
 	auto path = StringUtil::GetFilePath(tmp_file_path);
-	auto base = StringUtil::GetFileStem(tmp_file_path);
-	auto extension = StringUtil::GetFileExtension(tmp_file_path);
-	extension = extension.empty() ? extension : "." + extension;
+	auto base = StringUtil::GetFileName(tmp_file_path);
 
-	auto suffix = base.rfind("_tmp");
-	if (suffix != string::npos) {
-		base = base.substr(0, suffix);
+	auto prefix = base.find("tmp_");
+	if (prefix == 0) {
+		base = base.substr(4);
 	}
 
-	auto file_path = fs.JoinPath(path, base + extension);
+	auto file_path = fs.JoinPath(path, base);
 	if (fs.FileExists(file_path)) {
 		fs.RemoveFile(file_path);
 	}

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -14,11 +14,8 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	op.file_path = fs.ExpandPath(op.file_path);
 	if (op.use_tmp_file) {
 		auto path = StringUtil::GetFilePath(op.file_path);
-		auto base = StringUtil::GetFileStem(op.file_path);
-		auto extension = StringUtil::GetFileExtension(op.file_path);
-		extension = extension.empty() ? extension : "." + extension;
-
-		op.file_path = fs.JoinPath(path, base + "_tmp" + extension);
+		auto base = StringUtil::GetFileName(op.file_path);
+		op.file_path = fs.JoinPath(path, "tmp_" + base);
 	}
 	if (op.per_thread_output || op.file_size_bytes.IsValid() || op.partition_output || !op.partition_columns.empty() ||
 	    op.overwrite_or_ignore) {

--- a/test/common/test_string_util.cpp
+++ b/test/common/test_string_util.cpp
@@ -244,7 +244,7 @@ TEST_CASE("Test path utilities", "[string_util]") {
 		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt\\."));
 		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt\\.\\"));
 		REQUIRE("foo.txt" == StringUtil::GetFileName("foo.txt\\.\\\\"));
-		REQUIRE("" == StringUtil::GetFileName(".."));
+		REQUIRE(".." == StringUtil::GetFileName(".."));
 		REQUIRE("" == StringUtil::GetFileName("/"));
 	}
 
@@ -269,7 +269,7 @@ TEST_CASE("Test path utilities", "[string_util]") {
 		REQUIRE("test" == StringUtil::GetFileStem("test.cpp\\."));
 		REQUIRE("test" == StringUtil::GetFileStem("test.cpp\\.\\"));
 		REQUIRE("test" == StringUtil::GetFileStem("test.cpp\\.\\\\"));
-		REQUIRE("" == StringUtil::GetFileStem(".."));
+		REQUIRE(".." == StringUtil::GetFileStem(".."));
 		REQUIRE("" == StringUtil::GetFileStem("/"));
 		REQUIRE("test" == StringUtil::GetFileStem("tmp/test.txt"));
 		REQUIRE("test" == StringUtil::GetFileStem("tmp\\test.txt"));

--- a/test/sql/copy/tmp_file.test
+++ b/test/sql/copy/tmp_file.test
@@ -6,3 +6,20 @@ copy (select 42 as x) to '__TEST_DIR__/foo';
 
 statement ok
 copy (select 42 as x) to '__TEST_DIR__/foo';
+
+statement ok
+COPY (SELECT 36) TO '__TEST_DIR__/.a.b';
+
+statement ok
+COPY (SELECT 37 as x) TO '__TEST_DIR__/.a.b';
+
+query I
+FROM read_csv('__TEST_DIR__/.a.b');
+----
+37
+
+statement ok
+COPY (SELECT 50) TO '__TEST_DIR__/.a.b.c.d.e..';
+
+statement ok
+COPY (SELECT 51) TO '__TEST_DIR__/.a.b.c.d.e..';


### PR DESCRIPTION
Path handling is hard and we should create a proper path abstraction at some point. But right now I just want to handle the easy case. 

Im moving the `_tmp` suffix to be a `tmp_` prefix instead. This allows us to ignore the file extension and just focus on splitting at the path/filename boundary.

The filename of ".." is now ".." apparently.

Closes https://github.com/duckdblabs/duckdb-internal/issues/1212