### PR TITLE
Support struct_extract and unnest for unnamed structs

### DIFF
--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -248,7 +248,8 @@ void ListExtractFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet array_extract("array_extract");
 	array_extract.AddFunction(lfun);
 	array_extract.AddFunction(sfun);
-	array_extract.AddFunction(StructExtractFun::GetFunction());
+	array_extract.AddFunction(StructExtractFun::KeyExtractFunction());
+	array_extract.AddFunction(StructExtractFun::IndexExtractFunction());
 	set.AddFunction(array_extract);
 }
 

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -8,21 +8,18 @@
 namespace duckdb {
 
 struct StructExtractBindData : public FunctionData {
-	StructExtractBindData(string key, idx_t index, LogicalType type)
-	    : key(std::move(key)), index(index), type(std::move(type)) {
+	explicit StructExtractBindData(idx_t index) : index(index) {
 	}
 
-	string key;
 	idx_t index;
-	LogicalType type;
 
 public:
 	unique_ptr<FunctionData> Copy() const override {
-		return make_uniq<StructExtractBindData>(key, index, type);
+		return make_uniq<StructExtractBindData>(index);
 	}
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<StructExtractBindData>();
-		return key == other.key && index == other.index && type == other.type;
+		return index == other.index;
 	}
 };
 
@@ -44,15 +41,20 @@ static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vecto
 static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, ScalarFunction &bound_function,
                                                   vector<unique_ptr<Expression>> &arguments) {
 	D_ASSERT(bound_function.arguments.size() == 2);
-	if (arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
+	auto &child_type = arguments[0]->return_type;
+	if (child_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
-	D_ASSERT(LogicalTypeId::STRUCT == arguments[0]->return_type.id());
-	auto &struct_children = StructType::GetChildTypes(arguments[0]->return_type);
+	D_ASSERT(LogicalTypeId::STRUCT == child_type.id());
+	auto &struct_children = StructType::GetChildTypes(child_type);
 	if (struct_children.empty()) {
 		throw InternalException("Can't extract something from an empty struct");
 	}
-	bound_function.arguments[0] = arguments[0]->return_type;
+	if (StructType::IsUnnamed(child_type)) {
+		throw BinderException(
+		    "struct_extract with a string key cannot be used on an unnamed struct, use a numeric index instead");
+	}
+	bound_function.arguments[0] = child_type;
 
 	auto &key_child = arguments[1];
 	if (key_child->HasParameter()) {
@@ -95,8 +97,44 @@ static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, Scalar
 		throw BinderException("Could not find key \"%s\" in struct\n%s", key, message);
 	}
 
-	bound_function.return_type = return_type;
-	return make_uniq<StructExtractBindData>(std::move(key), key_index, std::move(return_type));
+	bound_function.return_type = std::move(return_type);
+	return make_uniq<StructExtractBindData>(key_index);
+}
+
+static unique_ptr<FunctionData> StructExtractBindIndex(ClientContext &context, ScalarFunction &bound_function,
+                                                       vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+	auto &child_type = arguments[0]->return_type;
+	if (child_type.id() == LogicalTypeId::UNKNOWN) {
+		throw ParameterNotResolvedException();
+	}
+	D_ASSERT(LogicalTypeId::STRUCT == child_type.id());
+	auto &struct_children = StructType::GetChildTypes(child_type);
+	if (struct_children.empty()) {
+		throw InternalException("Can't extract something from an empty struct");
+	}
+	if (!StructType::IsUnnamed(child_type)) {
+		throw BinderException(
+		    "struct_extract with an integer key can only be used on unnamed structs, use a string key instead");
+	}
+	bound_function.arguments[0] = child_type;
+
+	auto &key_child = arguments[1];
+	if (key_child->HasParameter()) {
+		throw ParameterNotResolvedException();
+	}
+
+	if (!key_child->IsFoldable()) {
+		throw BinderException("Key index for struct_extract needs to be a constant value");
+	}
+	Value key_val = ExpressionExecutor::EvaluateScalar(context, *key_child);
+	auto index = key_val.GetValue<int64_t>();
+	if (index <= 0 || idx_t(index) > struct_children.size()) {
+		throw BinderException("Key index %lld for struct_extract out of range - expected an index between 1 and %llu",
+		                      index, struct_children.size());
+	}
+	bound_function.return_type = struct_children[index - 1].second;
+	return make_uniq<StructExtractBindData>(index - 1);
 }
 
 static unique_ptr<BaseStatistics> PropagateStructExtractStats(ClientContext &context, FunctionStatisticsInput &input) {
@@ -108,15 +146,26 @@ static unique_ptr<BaseStatistics> PropagateStructExtractStats(ClientContext &con
 	return struct_child_stats[info.index].ToUnique();
 }
 
-ScalarFunction StructExtractFun::GetFunction() {
+ScalarFunction StructExtractFun::KeyExtractFunction() {
 	return ScalarFunction("struct_extract", {LogicalTypeId::STRUCT, LogicalType::VARCHAR}, LogicalType::ANY,
 	                      StructExtractFunction, StructExtractBind, nullptr, PropagateStructExtractStats);
 }
 
+ScalarFunction StructExtractFun::IndexExtractFunction() {
+	return ScalarFunction("struct_extract", {LogicalTypeId::STRUCT, LogicalType::BIGINT}, LogicalType::ANY,
+	                      StructExtractFunction, StructExtractBindIndex);
+}
+
+ScalarFunctionSet StructExtractFun::GetFunctions() {
+	ScalarFunctionSet functions("struct_extract");
+	functions.AddFunction(KeyExtractFunction());
+	functions.AddFunction(IndexExtractFunction());
+	return functions;
+}
+
 void StructExtractFun::RegisterFunction(BuiltinFunctions &set) {
 	// the arguments and return types are actually set in the binder function
-	auto fun = GetFunction();
-	set.AddFunction(fun);
+	set.AddFunction(GetFunctions());
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/function/scalar/nested_functions.hpp
+++ b/src/include/duckdb/function/scalar/nested_functions.hpp
@@ -103,7 +103,6 @@ struct ListPositionFun {
 };
 
 struct ListResizeFun {
-	static ScalarFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
@@ -123,7 +122,9 @@ struct ListWhereFun {
 };
 
 struct StructExtractFun {
-	static ScalarFunction GetFunction();
+	static ScalarFunction KeyExtractFunction();
+	static ScalarFunction IndexExtractFunction();
+	static ScalarFunctionSet GetFunctions();
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 

--- a/test/common/test_cast_struct.test
+++ b/test/common/test_cast_struct.test
@@ -128,7 +128,7 @@ Key name for struct_extract needs to be a constant string
 statement error
 select struct_extract({'a': 42}, 42)
 ----
-No function matches
+can only be used on unnamed structs
 
 # test string to struct within struct casting
 query I

--- a/test/sql/function/nested/array_extract_unnamed_struct.test
+++ b/test/sql/function/nested/array_extract_unnamed_struct.test
@@ -1,0 +1,51 @@
+# name: test/sql/function/nested/array_extract_unnamed_struct.test
+# description: Test array extract on unnamed structs
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+SELECT (ROW(42, 84))['element']
+----
+cannot be used on an unnamed struct
+
+query I
+SELECT (ROW(42, 84))[1]
+----
+42
+
+query I
+SELECT (ROW(42, 84))[2]
+----
+84
+
+query II
+SELECT UNNEST(ROW(42, 84))
+----
+42	84
+
+statement error
+SELECT (ROW(42, 84))[0]
+----
+out of range
+
+statement error
+SELECT (ROW(42, 84))[9999]
+----
+out of range
+
+statement error
+SELECT (ROW(42, 84))[-1]
+----
+out of range
+
+statement error
+SELECT (ROW(42, 84))[9223372036854775807]
+----
+out of range
+
+statement error
+SELECT (ROW(42, 84))[(-9223372036854775808)::BIGINT]
+----
+out of range

--- a/test/sql/function/nested/array_extract_unnamed_struct.test
+++ b/test/sql/function/nested/array_extract_unnamed_struct.test
@@ -1,6 +1,6 @@
 # name: test/sql/function/nested/array_extract_unnamed_struct.test
 # description: Test array extract on unnamed structs
-# group: [string]
+# group: [nested]
 
 statement ok
 PRAGMA enable_verification


### PR DESCRIPTION
This PR allows `struct_extract` to be used with an integer key for unnamed structs, and also adds support for `UNNEST` to unnamed structs. For example:

```sql
D SELECT (ROW(42, 84))[1] AS ele;
┌───────┐
│  ele  │
│ int32 │
├───────┤
│    42 │
└───────┘
```
```sql
D SELECT UNNEST(ROW(42, 84));
┌──────────┬──────────┐
│ element1 │ element2 │
│  int32   │  int32   │
├──────────┼──────────┤
│       42 │       84 │
└──────────┴──────────┘
```
```sql
D SELECT (ROW(42, 84))['child'];
--Binder Error: struct_extract with a string key cannot be used on an unnamed struct, use a numeric index instead
```

This makes unnamed structs more usable, as the individual elements can be accessed and unnested much like regular structs.