### PR TITLE
[Dev]: ICU 2024a TimeZones

### DIFF
--- a/extension/icu/scripts/makedata.sh
+++ b/extension/icu/scripts/makedata.sh
@@ -26,7 +26,7 @@ find ${data_path/version/$data_version} -type f ! -iname "*.txt" -delete
 cp -r ${data_path/version/$data_version} ${source_path/version/$code_version}
 
 # download IANA and copy the latest Time Zone Data
-tz_version=2023d
+tz_version=2024a
 rm -rf icu-data
 git clone git@github.com:unicode-org/icu-data.git
 cp icu-data/tzdata/icunew/${tz_version}/44/*.txt ${data_path/version/$code_version}/misc

--- a/test/sql/timezone/test_icu_timezone.test
+++ b/test/sql/timezone/test_icu_timezone.test
@@ -901,3 +901,14 @@ query II
 SELECT '2024-03-31 00:59:00-01'::TIMESTAMPTZ, '2024-03-31 01:00:00-01'::TIMESTAMPTZ;
 ----
 2024-03-31 00:59:00-01	2024-03-31 01:00:00-01
+
+
+# 2024a
+# Kazakhstan unifies on UTC+5 beginning 2024-03-01.
+statement ok
+SET TimeZone = 'Asia/Almaty';
+
+query II
+select '2024-02-29 00:00:00+06'::TIMESTAMPTZ, '2024-03-01 01:00:00+06'::TIMESTAMPTZ;
+----
+2024-02-29 00:00:00+06	2024-03-01 00:00:00+05


### PR DESCRIPTION
Kazakhstan unifies on UTC+5 beginning 2024-03-01.
Palestine springs forward a week later after Ramadan. zic no longer pretends to support indefinite-past DST. localtime no longer mishandles Ciudad Juárez in 2422.