### PR TITLE
[CSV Reader] [Bug Fix] Nightly CI Segfaults

### DIFF
--- a/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
@@ -81,7 +81,7 @@ unique_ptr<CSVBufferHandle> CSVBufferManager::GetBuffer(const idx_t pos) {
 
 void CSVBufferManager::ResetBuffer(const idx_t buffer_idx) {
 	D_ASSERT(buffer_idx < cached_buffers.size() && cached_buffers[buffer_idx]);
-	if (buffer_idx == 0) {
+	if (buffer_idx == 0 && cached_buffers.size() > 1) {
 		cached_buffers[buffer_idx].reset();
 		idx_t cur_buffer = buffer_idx + 1;
 		while (reset_when_possible.find(cur_buffer) != reset_when_possible.end()) {
@@ -92,7 +92,7 @@ void CSVBufferManager::ResetBuffer(const idx_t buffer_idx) {
 		return;
 	}
 	// We only reset if previous one was also already reset
-	if (!cached_buffers[buffer_idx - 1]) {
+	if (buffer_idx > 0 && !cached_buffers[buffer_idx - 1]) {
 		cached_buffers[buffer_idx].reset();
 		idx_t cur_buffer = buffer_idx + 1;
 		while (reset_when_possible.find(cur_buffer) != reset_when_possible.end()) {

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -391,7 +391,7 @@ bool StringValueResult::AddRow(StringValueResult &result, const idx_t buffer_pos
 		if (current_line_size > result.state_machine.options.maximum_line_size) {
 			auto csv_error = CSVError::LineSizeError(result.state_machine.options, current_line_size);
 			LinesPerBoundary lines_per_batch(result.iterator.GetBoundaryIdx(), result.number_of_rows + 1);
-			result.error_handler.Error(lines_per_batch, csv_error);
+			result.error_handler.Error(lines_per_batch, csv_error, true);
 		}
 		result.pre_previous_line_start = result.previous_line_start;
 		result.previous_line_start = current_line_start;

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -390,7 +390,7 @@ bool StringValueResult::AddRow(StringValueResult &result, const idx_t buffer_pos
 		}
 		if (current_line_size > result.state_machine.options.maximum_line_size) {
 			auto csv_error = CSVError::LineSizeError(result.state_machine.options, current_line_size);
-			LinesPerBoundary lines_per_batch(result.iterator.GetBoundaryIdx(), result.number_of_rows + 1);
+			LinesPerBoundary lines_per_batch(result.iterator.GetBoundaryIdx(), result.number_of_rows);
 			result.error_handler.Error(lines_per_batch, csv_error, true);
 		}
 		result.pre_previous_line_start = result.previous_line_start;

--- a/test/sql/copy/csv/test_max_line_size.test_slow
+++ b/test/sql/copy/csv/test_max_line_size.test_slow
@@ -23,7 +23,7 @@ CREATE TABLE test (a INTEGER, b VARCHAR, c INTEGER);
 statement error
 COPY test FROM '__TEST_DIR__/test.csv';
 ----
-Line: 1
+Line: 2
 
 # we can override the max line size
 statement ok


### PR DESCRIPTION
This PR fixes two issues related to the CSV Reader. These issues were caught by the nightly CI with `-DDISABLE_STR_INLINE=1 -DDESTROY_UNPINNED_BLOCKS=1`

One is related to the buffer manager removing the first block of the csv too early, the other is related to the sniffer not throwing an error when encountering lines bigger than max line size.