### PR TITLE
Benchmark runner: check for errors also if no result is specified

### DIFF
--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -467,13 +467,13 @@ string InterpretedBenchmark::VerifyInternal(BenchmarkState *state_p, Materialize
 }
 
 string InterpretedBenchmark::Verify(BenchmarkState *state_p) {
-	if (result_column_count == 0) {
-		// no result specified
-		return string();
-	}
 	auto &state = (InterpretedBenchmarkState &)*state_p;
 	if (state.result->HasError()) {
 		return state.result->GetError();
+	}
+	if (result_column_count == 0) {
+		// no result specified
+		return string();
 	}
 	if (!result_query.empty()) {
 		// we are running a result query


### PR DESCRIPTION
This fixes an issue where, for any benchmarks that did not have an expected result specified, we would also skip checking if the query completed successfully.