### PR TITLE
CommitState::WriteCatalogEntry refactor

### DIFF
--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -49,6 +49,8 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 	case CatalogType::INDEX_ENTRY:
 	case CatalogType::SEQUENCE_ENTRY:
 	case CatalogType::TYPE_ENTRY:
+	case CatalogType::MACRO_ENTRY:
+	case CatalogType::TABLE_MACRO_ENTRY:
 		if (entry.type == CatalogType::RENAMED_ENTRY || entry.type == parent.type) {
 			// ALTER statement, read the extra data after the entry
 			auto extra_data_size = Load<idx_t>(dataptr);
@@ -75,6 +77,8 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 			case CatalogType::INDEX_ENTRY:
 			case CatalogType::SEQUENCE_ENTRY:
 			case CatalogType::TYPE_ENTRY:
+			case CatalogType::MACRO_ENTRY:
+			case CatalogType::TABLE_MACRO_ENTRY:
 				(void)column_name;
 				break;
 			}
@@ -103,6 +107,12 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 				// CREATE TYPE statement
 				log->WriteCreateType(parent.Cast<TypeCatalogEntry>());
 				break;
+			case CatalogType::MACRO_ENTRY:
+				log->WriteCreateMacro(parent.Cast<ScalarMacroCatalogEntry>());
+				break;
+			case CatalogType::TABLE_MACRO_ENTRY:
+				log->WriteCreateTableMacro(parent.Cast<TableMacroCatalogEntry>());
+				break;
 			}
 		}
 		break;
@@ -112,12 +122,6 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 			return;
 		}
 		log->WriteCreateSchema(parent.Cast<SchemaCatalogEntry>());
-		break;
-	case CatalogType::MACRO_ENTRY:
-		log->WriteCreateMacro(parent.Cast<ScalarMacroCatalogEntry>());
-		break;
-	case CatalogType::TABLE_MACRO_ENTRY:
-		log->WriteCreateTableMacro(parent.Cast<TableMacroCatalogEntry>());
 		break;
 	case CatalogType::RENAMED_ENTRY:
 		// This is a rename, nothing needs to be done for this

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -45,7 +45,8 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 
 	switch (parent.type) {
 	case CatalogType::TABLE_ENTRY:
-		if (entry.type == CatalogType::RENAMED_ENTRY || entry.type == CatalogType::TABLE_ENTRY) {
+	case CatalogType::VIEW_ENTRY:
+		if (entry.type == CatalogType::RENAMED_ENTRY || entry.type == parent.type) {
 			// ALTER TABLE statement, read the extra data after the entry
 			auto extra_data_size = Load<idx_t>(dataptr);
 			auto extra_data = data_ptr_cast(dataptr + sizeof(idx_t));
@@ -57,18 +58,34 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 			auto parse_info = deserializer.ReadProperty<unique_ptr<ParseInfo>>(101, "alter_info");
 			deserializer.End();
 
-			if (!column_name.empty()) {
-				D_ASSERT(entry.type != CatalogType::RENAMED_ENTRY);
-				auto &table_entry = entry.Cast<DuckTableEntry>();
-				D_ASSERT(table_entry.IsDuckTable());
-				// write the alter table in the log
-				table_entry.CommitAlter(column_name);
+			switch (parent.type) {
+			case CatalogType::TABLE_ENTRY:
+				if (!column_name.empty()) {
+					D_ASSERT(entry.type != CatalogType::RENAMED_ENTRY);
+					auto &table_entry = entry.Cast<DuckTableEntry>();
+					D_ASSERT(table_entry.IsDuckTable());
+					// write the alter table in the log
+					table_entry.CommitAlter(column_name);
+				}
+				break;
+			case CatalogType::VIEW_ENTRY:
+				(void)column_name;
+				break;
 			}
+
 			auto &alter_info = parse_info->Cast<AlterInfo>();
 			log->WriteAlter(alter_info);
 		} else {
-			// CREATE TABLE statement
-			log->WriteCreateTable(parent.Cast<TableCatalogEntry>());
+			switch (parent.type) {
+			case CatalogType::TABLE_ENTRY:
+				// CREATE TABLE statement
+				log->WriteCreateTable(parent.Cast<TableCatalogEntry>());
+				break;
+			case CatalogType::VIEW_ENTRY:
+				// CREATE VIEW statement
+				log->WriteCreateView(parent.Cast<ViewCatalogEntry>());
+				break;
+			}
 		}
 		break;
 	case CatalogType::SCHEMA_ENTRY:
@@ -77,28 +94,6 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 			return;
 		}
 		log->WriteCreateSchema(parent.Cast<SchemaCatalogEntry>());
-		break;
-	case CatalogType::VIEW_ENTRY:
-		if (entry.type == CatalogType::RENAMED_ENTRY || entry.type == CatalogType::VIEW_ENTRY) {
-			// ALTER TABLE statement, read the extra data after the entry
-			auto extra_data_size = Load<idx_t>(dataptr);
-			auto extra_data = data_ptr_cast(dataptr + sizeof(idx_t));
-			// deserialize it
-			MemoryStream source(extra_data, extra_data_size);
-			BinaryDeserializer deserializer(source);
-			deserializer.Begin();
-			auto column_name = deserializer.ReadProperty<string>(100, "column_name");
-			auto parse_info = deserializer.ReadProperty<unique_ptr<ParseInfo>>(101, "alter_info");
-			deserializer.End();
-
-			(void)column_name;
-
-			// write the alter table in the log
-			auto &alter_info = parse_info->Cast<AlterInfo>();
-			log->WriteAlter(alter_info);
-		} else {
-			log->WriteCreateView(parent.Cast<ViewCatalogEntry>());
-		}
 		break;
 	case CatalogType::SEQUENCE_ENTRY:
 		log->WriteCreateSequence(parent.Cast<SequenceCatalogEntry>());

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -46,6 +46,7 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 	switch (parent.type) {
 	case CatalogType::TABLE_ENTRY:
 	case CatalogType::VIEW_ENTRY:
+	case CatalogType::INDEX_ENTRY:
 		if (entry.type == CatalogType::RENAMED_ENTRY || entry.type == parent.type) {
 			// ALTER TABLE statement, read the extra data after the entry
 			auto extra_data_size = Load<idx_t>(dataptr);
@@ -69,6 +70,7 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 				}
 				break;
 			case CatalogType::VIEW_ENTRY:
+			case CatalogType::INDEX_ENTRY:
 				(void)column_name;
 				break;
 			}
@@ -84,6 +86,9 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 			case CatalogType::VIEW_ENTRY:
 				// CREATE VIEW statement
 				log->WriteCreateView(parent.Cast<ViewCatalogEntry>());
+				break;
+			case CatalogType::INDEX_ENTRY:
+				log->WriteCreateIndex(parent.Cast<IndexCatalogEntry>());
 				break;
 			}
 		}
@@ -103,9 +108,6 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 		break;
 	case CatalogType::TABLE_MACRO_ENTRY:
 		log->WriteCreateTableMacro(parent.Cast<TableMacroCatalogEntry>());
-		break;
-	case CatalogType::INDEX_ENTRY:
-		log->WriteCreateIndex(parent.Cast<IndexCatalogEntry>());
 		break;
 	case CatalogType::TYPE_ENTRY:
 		log->WriteCreateType(parent.Cast<TypeCatalogEntry>());

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -81,6 +81,8 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 			case CatalogType::TABLE_MACRO_ENTRY:
 				(void)column_name;
 				break;
+			default:
+				throw InternalException("Don't know how to drop this type!");
 			}
 
 			auto &alter_info = parse_info->Cast<AlterInfo>();
@@ -113,6 +115,8 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 			case CatalogType::TABLE_MACRO_ENTRY:
 				log->WriteCreateTableMacro(parent.Cast<TableMacroCatalogEntry>());
 				break;
+			default:
+				throw InternalException("Don't know how to drop this type!");
 			}
 		}
 		break;

--- a/test/sql/catalog/comment_on_wal.test
+++ b/test/sql/catalog/comment_on_wal.test
@@ -1,0 +1,335 @@
+# name: test/sql/catalog/comment_on_wal.test
+# description: Test COMMENT ON to add comments to various catalog entries
+# group: [catalog]
+
+load __TEST_DIR__/comment_on_wal.db
+
+statement ok
+SET checkpoint_threshold = '10.0 GB';
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+### Generic tests
+
+# TODO: we need further testing of comments not being modified as catalog entries are altered
+
+# String literal or NULL only
+statement error
+COMMENT ON TABLE test IS 1337
+----
+Parser Error: syntax error
+
+# Catalog entry not found is error
+statement error
+COMMENT ON TABLE hahahoehoe IS 'blablabloebloe'
+----
+Catalog Error: Table with name hahahoehoe does not exist!
+
+### Comment on Tables
+statement ok
+CREATE TABLE test_table as SELECT 1 as test_table_column
+
+query I
+select comment from duckdb_tables() where table_name='test_table';
+----
+NULL
+
+statement ok
+COMMENT ON TABLE test_table IS 'very gezellige table'
+
+query I
+select comment from duckdb_tables() where table_name='test_table';
+----
+very gezellige table
+
+restart
+
+query I
+select comment from duckdb_tables() where table_name='test_table';
+----
+very gezellige table
+
+# Reverting to null goes like dis
+statement ok
+COMMENT ON TABLE test_table IS NULL
+
+query I
+select comment from duckdb_tables() where table_name='test_table';
+----
+NULL
+
+# Check table is still functioning
+query I
+SELECT * FROM test_table
+----
+1
+
+### Comment on view
+statement ok
+CREATE VIEW test_view as SELECT 1 as test_view_column
+
+query I
+select comment from duckdb_views() where view_name='test_view';
+----
+NULL
+
+statement ok
+COMMENT ON VIEW test_view IS 'very gezellige view'
+
+query I
+select comment from duckdb_views() where view_name='test_view';
+----
+very gezellige view
+
+restart
+
+query I
+select comment from duckdb_views() where view_name='test_view';
+----
+very gezellige view
+
+# Check view is still functioning
+query I
+SELECT * FROM test_view
+----
+1
+
+statement ok
+DROP VIEW test_view
+
+### Comment on indices
+statement ok
+CREATE INDEX test_index ON test_table using art(test_table_column)
+
+query I
+select comment from duckdb_indexes() where index_name='test_index';
+----
+NULL
+
+statement ok
+COMMENT ON INDEX test_index IS 'very gezellige index'
+
+query I
+select comment from duckdb_indexes() where index_name='test_index';
+----
+very gezellige index
+
+restart
+
+query I
+select comment from duckdb_indexes() where index_name='test_index';
+----
+very gezellige index
+
+# Check index is still functioning
+query I
+SELECT * FROM test_table WHERE test_table_column=1
+----
+1
+
+statement ok
+DROP INDEX test_index;
+
+### Comment on sequences
+statement ok
+CREATE SEQUENCE test_sequence;
+
+query I
+select comment from duckdb_sequences() where sequence_name='test_sequence';
+----
+NULL
+
+statement ok
+COMMENT ON SEQUENCE test_sequence IS 'very gezellige sequence'
+
+query I
+select comment from duckdb_sequences() where sequence_name='test_sequence';
+----
+very gezellige sequence
+
+restart
+
+query I
+select comment from duckdb_sequences() where sequence_name='test_sequence';
+----
+very gezellige sequence
+
+# Check sequence is still functioning
+query I
+SELECT nextval('test_sequence')
+----
+1
+
+statement ok
+DROP SEQUENCE test_sequence
+
+### Comment on types
+statement ok
+CREATE TYPE test_type AS int32;
+
+query I
+select comment from duckdb_types() where type_name='test_type';
+----
+NULL
+
+statement ok
+COMMENT ON TYPE test_type IS 'very gezellige type'
+
+query I
+select comment from duckdb_types() where type_name='test_type';
+----
+very gezellige type
+
+restart
+
+query I
+select comment from duckdb_types() where type_name='test_type';
+----
+very gezellige type
+
+# Check type is still functioning
+query I
+SELECT 1::test_type as val;
+----
+1
+
+statement ok
+DROP TYPE test_type
+
+### Comment on column
+
+query I
+select comment from duckdb_columns() where column_name='test_table_column';
+----
+NULL
+
+statement ok
+COMMENT ON COLUMN test_table.test_table_column IS 'very gezellige column'
+
+query I
+select comment from duckdb_columns() where column_name='test_table_column';
+----
+very gezellige column
+
+restart
+
+query I
+select comment from duckdb_columns() where column_name='test_table_column';
+----
+very gezellige column
+
+# Comment persists rename
+statement ok
+ALTER TABLE test_table RENAME COLUMN test_table_column TO test_table_column_renamed
+
+query I
+select comment from duckdb_columns() where column_name='test_table_column_renamed';
+----
+very gezellige column
+
+### Comment on Macro
+statement ok
+CREATE MACRO test_macro(a, b) AS a + b
+
+query I
+select comment from duckdb_functions() where function_name='test_macro';
+----
+NULL
+
+statement ok
+COMMENT ON MACRO test_macro IS 'very gezellige macro'
+
+query I
+select comment from duckdb_functions() where function_name='test_macro';
+----
+very gezellige macro
+
+restart
+
+query I
+select comment from duckdb_functions() where function_name='test_macro';
+----
+very gezellige macro
+
+# Check macro is still functioning
+query I
+SELECT test_macro(1,2);
+----
+3
+
+statement ok
+DROP MACRO test_macro
+
+### Comment on function (alias for scalar macro)
+statement ok
+CREATE FUNCTION test_function(a, b) AS a + b
+
+query I
+select comment from duckdb_functions() where function_name='test_function';
+----
+NULL
+
+statement ok
+COMMENT ON FUNCTION test_function IS 'very gezellige function'
+
+query I
+select comment from duckdb_functions() where function_name='test_function';
+----
+very gezellige function
+
+restart
+
+query I
+select comment from duckdb_functions() where function_name='test_function';
+----
+very gezellige function
+
+### Comment on TABLE MACRO
+statement ok
+CREATE MACRO test_table_macro(a,b) as TABLE select a,b;
+
+query I
+select comment from duckdb_functions() where function_name='test_table_macro';
+----
+NULL
+
+statement ok
+COMMENT ON MACRO TABLE test_table_macro IS 'very gezellige table macro'
+
+query I
+select comment from duckdb_functions() where function_name='test_table_macro';
+----
+very gezellige table macro
+
+restart
+
+query I
+select comment from duckdb_functions() where function_name='test_table_macro';
+----
+very gezellige table macro
+
+# Check table macro is still functioning
+query II
+from test_table_macro(1,2);
+----
+1	2
+
+statement ok
+DROP MACRO TABLE test_table_macro
+
+### Comment on DATABASE
+statement error
+COMMENT ON DATABASE blabla IS 'bloebloe'
+----
+Not implemented Error: Adding comments to databases is not implemented
+
+### Comment on schemas
+statement error
+COMMENT ON SCHEMA blabla IS 'bloebloe'
+----
+Not implemented Error: Adding comments to schemas is not implemented
+
+statement ok
+DROP TABLE test_table
+


### PR DESCRIPTION
Now most entries go also through the alter codepath.

Problem found with @Tishj, and solution discussed also with @Mytherin, added both as reviewers.

Also adding the original test with changed settings so that it will fail (without this changes) also with default configurations.