### PR TITLE
[Python] Fix issues related to handling of Python exceptions

### DIFF
--- a/tools/pythonpkg/src/common/exceptions.cpp
+++ b/tools/pythonpkg/src/common/exceptions.cpp
@@ -373,6 +373,9 @@ void RegisterExceptions(const py::module &m) {
 		} catch (const duckdb::Exception &ex) {
 			duckdb::ErrorData error(ex);
 			PyThrowException(error, HTTP_EXCEPTION.ptr());
+		} catch (const py::builtin_exception &ex) {
+			// These represent Python exceptions, we don't want to catch these
+			throw;
 		} catch (const std::exception &ex) {
 			duckdb::ErrorData error(ex);
 			if (error.Type() == ExceptionType::INVALID) {

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -145,8 +145,7 @@ static scalar_function_t CreateVectorizedFunction(PyObject *function, PythonExce
 				python_object = py::module_::import("pyarrow").attr("lib").attr("Table").attr("from_arrays")(
 				    single_array, py::arg("names") = single_name);
 			} catch (py::error_already_set &ex) {
-				ex.restore();
-				throw;
+				throw InvalidInputException("Could not convert the result into an Arrow Table");
 			}
 		}
 		// Convert the pyarrow result back to a DuckDB datachunk

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -141,8 +141,13 @@ static scalar_function_t CreateVectorizedFunction(PyObject *function, PythonExce
 
 			single_array[0] = python_object;
 			single_name[0] = "c0";
-			python_object = py::module_::import("pyarrow").attr("lib").attr("Table").attr("from_arrays")(
-			    single_array, py::arg("names") = single_name);
+			try {
+				python_object = py::module_::import("pyarrow").attr("lib").attr("Table").attr("from_arrays")(
+				    single_array, py::arg("names") = single_name);
+			} catch (py::error_already_set &ex) {
+				ex.restore();
+				throw;
+			}
 		}
 		// Convert the pyarrow result back to a DuckDB datachunk
 		ConvertPyArrowToDataChunk(python_object, result, state.GetContext(), count);

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -102,9 +102,9 @@ def pandas_2_or_higher():
 
 def pandas_supports_arrow_backend():
     try:
-        from pandas.compat import pa_version_under7p0
+        from pandas.compat import pa_version_under11p0
 
-        if pa_version_under7p0 == True:
+        if pa_version_under11p0 == True:
             return False
     except ImportError:
         return False

--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -745,7 +745,10 @@ class TestArrowFilterPushdown(object):
         """
         ).fetchall()
 
-        match = re.search(".*ARROW_SCAN.*Filters: s\\.a<2 AND s\\.a IS.*NOT NULL.*", query_res[0][1], flags=re.DOTALL)
+        input = query_res[0][1]
+        if 'PANDAS_SCAN' in input:
+            pytest.skip(reason="This version of pandas does not produce an Arrow object")
+        match = re.search(".*ARROW_SCAN.*Filters: s\\.a<2 AND s\\.a IS.*NOT NULL.*", input, flags=re.DOTALL)
         assert match
 
         # Check that the filter is applied correctly
@@ -812,9 +815,10 @@ class TestArrowFilterPushdown(object):
         """
         ).fetchall()
 
-        match = re.search(
-            ".*ARROW_SCAN.*Filters: s\\.a\\.b<2 AND s\\.a\\.b.*IS NOT NULL.*", query_res[0][1], flags=re.DOTALL
-        )
+        input = query_res[0][1]
+        if 'PANDAS_SCAN' in input:
+            pytest.skip(reason="This version of pandas does not produce an Arrow object")
+        match = re.search(".*ARROW_SCAN.*Filters: s\\.a\\.b<2 AND s\\.a\\.b.*IS NOT NULL.*", input, flags=re.DOTALL)
         assert match
 
         # Check that the filter is applied correctly

--- a/tools/pythonpkg/tests/fast/udf/test_scalar_arrow.py
+++ b/tools/pythonpkg/tests/fast/udf/test_scalar_arrow.py
@@ -101,7 +101,7 @@ class TestPyArrowUDF(object):
 
         con = duckdb.connect()
         con.create_function('will_crash', returns_none, [BIGINT], BIGINT, type='arrow')
-        with pytest.raises(duckdb.Error, match="""TypeError: 'NoneType' object is not iterable"""):
+        with pytest.raises(duckdb.Error, match="""Could not convert the result into an Arrow Table"""):
             res = con.sql("""select will_crash(5)""").fetchall()
 
     def test_empty_result(self):


### PR DESCRIPTION
I noticed an issue with python exceptions thrown from `python_udf.cpp` causing what seemed like a stack overflow on `ex.what()`
Or if it wasn't a stack overflow it might have been a crash inside of the handling of `ex.what()` similar to what we've seen in the past on this function, where we also don't investigate the raised error anymore:

```c++
py::object ArrowTableFromDataframe(const py::object &df) {
	try {
		return py::module_::import("pyarrow").attr("lib").attr("Table").attr("from_pandas")(df);
	} catch (py::error_already_set &e) {
		// We don't fetch the original Python exception because it can cause a segfault
		// The cause of this is not known yet, for now we just side-step the issue.
		throw InvalidInputException(
		    "The dataframe could not be converted to a pyarrow.lib.Table, because a Python exception occurred.");
	}
}
```

Also `pandas.compat` removed the `pa_version_under7p0` attribute we were checking to determine if pyarrow was a supported backend, which is lovely
I've updated it to under11p0 but it should probably be removed in the future because it's brittle

Lastly found another case of the struct filter pushdown test failing because pandas doesn't produce a pyarrow table for whatever reason, now it's checked and skipped before it could cause a test failure