### PR TITLE
unittester: if test-dir is provided avoid deleting it

### DIFF
--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -44,6 +44,7 @@ int main(int argc, char *argv[]) {
 		} else if (string(argv[i]) == "--test-dir") {
 			test_directory = string(argv[++i]);
 		} else if (string(argv[i]) == "--test-temp-dir") {
+			delete_test_path = false;
 			auto test_dir = string(argv[++i]);
 			if (fs->DirectoryExists(test_dir)) {
 				fprintf(stderr, "--test-temp-dir cannot point to a directory that already exists (%s)\n",


### PR DESCRIPTION
Fix nightly CI run that checks for 0-1 initialization