### PR TITLE
[Dev] Skip some tests on ALTERNATIVE_VERIFY

### DIFF
--- a/test/sql/fts/test_issue_10254.test
+++ b/test/sql/fts/test_issue_10254.test
@@ -4,6 +4,8 @@
 
 require fts
 
+require noalternativeverify
+
 statement ok
 CREATE TABLE data (context VARCHAR, question VARCHAR, id BIGINT)
 

--- a/test/sql/fts/test_issue_10281.test
+++ b/test/sql/fts/test_issue_10281.test
@@ -4,6 +4,8 @@
 
 require fts
 
+require noalternativeverify
+
 statement ok
 CREATE OR REPLACE TABLE data AS SELECT {'duck': 42} conversations, 42::bigint _id;
 


### PR DESCRIPTION
This PR fixes tests failing on the CI nightly tests [No String Inline / Destroy Unpinned Blocks](https://github.com/duckdb/duckdb/actions/runs/7851223323/job/21428207419#logs)

For example:
```
[627/2883] (21%): test/sql/fts/test_issue_10254.test                            -------------------------------------------------------------------------------
Query unexpectedly failed (test/sql/fts/test_issue_10254.test:19)
================================================================================
SELECT id FROM (SELECT *, fts_main_data.match_bm25(id, 'Какие') AS score FROM data) sq WHERE score IS NOT NULL ORDER BY score DESC;
================================================================================
Actual result:
Not implemented Error: MARK join with correlation in RHS not supported
```