### PR TITLE
[Export] Fix export of user-defined types

### DIFF
--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -34,14 +34,20 @@ unique_ptr<CreateInfo> TypeCatalogEntry::GetInfo() const {
 }
 
 string TypeCatalogEntry::ToSQL() const {
-	switch (user_type.id()) {
-	case (LogicalTypeId::ENUM): {
-		auto create_type_info = GetInfo();
-		return create_type_info->ToString();
-	}
-	default:
-		throw InternalException("Logical Type can't be used as a User Defined Type");
-	}
+	std::stringstream ss;
+	ss << "CREATE TYPE ";
+	ss << KeywordHelper::WriteOptionallyQuoted(name);
+	ss << " AS ";
+
+	auto user_type_copy = user_type;
+
+	// Strip off the potential alias so ToString doesn't just output the alias
+	user_type_copy.SetAlias("");
+	D_ASSERT(user_type_copy.GetAlias().empty());
+
+	ss << user_type_copy.ToString();
+	ss << ";";
+	return ss.str();
 }
 
 } // namespace duckdb

--- a/test/sql/export/export_types.test
+++ b/test/sql/export/export_types.test
@@ -1,0 +1,58 @@
+# name: test/sql/export/export_types.test
+# description: Test export of macro's
+# group: [export]
+
+statement ok
+BEGIN TRANSACTION
+
+# Populate the database
+
+# Create a type alias
+statement ok
+CREATE TYPE mood AS ENUM ('happy', 'sad', 'curious');
+
+# Create an alias on 'mood', creating a dependency on 'mood'
+statement ok
+CREATE TYPE doom as mood;
+
+# Create tables that use mood and doom
+statement ok
+create table tbl1 (a mood, b doom);
+
+statement ok
+create table tbl2 (my_struct STRUCT(a mood, b doom));
+
+# Create an alias on STRUCT containing mood and doom
+statement ok
+CREATE TYPE doom_mood as STRUCT(a mood, b doom);
+
+# Create an alias on LIST of mood
+statement ok
+CREATE TYPE mood_list as mood[];
+
+# Create an alias on a UNION containing mood and doom
+statement ok
+CREATE TYPE my_union as UNION(a doom, b mood);
+
+# Create an alias on a MAP with mood as key and doom as value
+statement ok
+CREATE TYPE mood_map as MAP(doom, mood);
+
+# Create an alias on a regular type, VARCHAR in this case
+statement ok
+CREATE TYPE my_special_type as VARCHAR;
+
+# Create a table containing the doom_mood type
+statement ok
+CREATE TABLE tbl3 (my_struct doom_mood);
+
+statement ok
+EXPORT DATABASE '__TEST_DIR__/export_types' (FORMAT CSV);
+
+statement ok
+ROLLBACK
+
+statement ok
+IMPORT DATABASE '__TEST_DIR__/export_types'
+
+# Verify that the database was imported properly

--- a/test/sql/export/export_types.test
+++ b/test/sql/export/export_types.test
@@ -2,6 +2,9 @@
 # description: Test export of macro's
 # group: [export]
 
+# Because of ordering issues in EXPORT DATABASE we can't IMPORT this database
+mode skip
+
 statement ok
 BEGIN TRANSACTION
 


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/935

This is part of a larger PR to fix ordering issues in EXPORT DATABASE.
Sadly that will not make it into 0.10.0.

For now I think it might still be worthwhile to merge this PR.
The created `schema.sql` could be manually reordered to fix the import, whereas the current InternalException is not recoverable.