### PR TITLE
[CSVScanner] Fix heap-use-after-free in StringValueResult

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -253,7 +253,7 @@ void StringValueResult::AddQuotedValue(StringValueResult &result, const idx_t bu
 			result.AddValueToVector(value.GetData(), value.GetSize());
 		} else {
 			result.AddValueToVector(result.buffer_ptr + result.quoted_position + 1,
-			                        buffer_pos - result.quoted_position - 2);
+			                        buffer_pos - result.quoted_position - 2, true);
 		}
 	}
 	result.quoted = false;
@@ -267,7 +267,7 @@ void StringValueResult::AddValue(StringValueResult &result, const idx_t buffer_p
 	if (result.quoted) {
 		StringValueResult::AddQuotedValue(result, buffer_pos);
 	} else {
-		result.AddValueToVector(result.buffer_ptr + result.last_position, buffer_pos - result.last_position);
+		result.AddValueToVector(result.buffer_ptr + result.last_position, buffer_pos - result.last_position, true);
 	}
 	result.last_position = buffer_pos + 1;
 }
@@ -401,7 +401,7 @@ bool StringValueResult::AddRow(StringValueResult &result, const idx_t buffer_pos
 		if (result.quoted) {
 			StringValueResult::AddQuotedValue(result, buffer_pos);
 		} else {
-			result.AddValueToVector(result.buffer_ptr + result.last_position, buffer_pos - result.last_position);
+			result.AddValueToVector(result.buffer_ptr + result.last_position, buffer_pos - result.last_position, true);
 		}
 		if (result.state_machine.dialect_options.state_machine_options.new_line == NewLineIdentifier::CARRY_ON) {
 			if (result.states.states[1] == CSVState::RECORD_SEPARATOR) {


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/1231

~~The StringValueResult now contains a vector of `shared_ptr<CSVBufferHandle>` to keep the data alive that it is still referencing.~~

We now always allocate a new string when adding a string to the StringValueResult, as not to reference the ephemeral csv buffer handle data