### PR TITLE
Fix heap buffer overflow in VARCHAR -> TIME trycast

### DIFF
--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -54,6 +54,10 @@ bool Time::TryConvertInternal(const char *buf, idx_t len, idx_t &pos, dtime_t &r
 		}
 	}
 
+	if (pos >= len) {
+		return false;
+	}
+
 	// fetch the separator
 	sep = buf[pos++];
 	if (sep != ':') {


### PR DESCRIPTION
Fixes a bug found in `test/sql/copy/csv/rejects/csv_rejects_auto.test` built with `DISABLE_STRING_INLINE`

`sep = buf[pos++];`

If `pos` already reached `len` this causes a heap buffer overflow
