### PR TITLE
[Dev][CI] Add --no-exit to run_tests_one_by_one

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -108,7 +108,7 @@ jobs:
     - name: Test
       shell: bash
       run: |
-          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*"
+          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit
 
 
   linux-clang:
@@ -453,7 +453,7 @@ jobs:
 
       - name: Test
         shell: bash
-        run: python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest
+        run: python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest --no-exit
 
   regression-test-memory-safety:
    name: Regression Tests between safe and unsafe builds
@@ -580,11 +580,11 @@ jobs:
     - name: Test
       shell: bash
       run: |
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[intraquery]"
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[interquery]"
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[detailed_profiler]"
-          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow
+          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --no-exit
+          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[intraquery]" --no-exit
+          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[interquery]" --no-exit
+          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[detailed_profiler]" --no-exit
+          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow --no-exit
 
   vector-sizes:
     name: Vector Sizes


### PR DESCRIPTION
Currently failures due to assertions trigger early failure, but that prevent for collecting information from eventual later failures that will be hidden by the first one.