### PR TITLE
[Dev] Fix ordering issue in test

### DIFF
--- a/test/sql/aggregate/aggregates/test_state_export.test
+++ b/test/sql/aggregate/aggregates/test_state_export.test
@@ -67,7 +67,7 @@ with groups as (select distinct g from dummy)
 select g, FINALIZE(COMBINE(sum_state, sum_state2)) * 2 from groups left join state2 using(g) left join (select g, sum(d) EXPORT_STATE sum_state2 from dummy where g >= 5 GROUP BY g) using (g)
 ----
 
-query IIII
+query IIII rowsort
 with groups as (select distinct g from dummy)
 select g, FINALIZE(sum_state), FINALIZE(sum_state2), FINALIZE(COMBINE(sum_state, sum_state2))  from groups left join state2 using(g) left join (select g, sum(d) EXPORT_STATE sum_state2 from dummy where g >= 3 GROUP BY g) using (g) order by g
 ----


### PR DESCRIPTION
https://github.com/duckdb/duckdb/actions/runs/7858410788/job/21443540929
```
with groups as (select distinct g from dummy)
select g, FINALIZE(sum_state), FINALIZE(sum_state2), FINALIZE(COMBINE(sum_state, sum_state2))  from groups left join state2 using(g) left join (select g, sum(d) EXPORT_STATE sum_state2 from dummy where g >= 3 GROUP BY g) using (g) order by g;
================================================================================
Mismatch on row 1, column 1
7 <> 0
================================================================================
Expected result:
================================================================================
0    450    NULL    450
1    460    NULL    460
2    470    NULL    470
3    480    480    960
4    490    490    980
5    NULL    500    500
6    NULL    510    510
7    NULL    520    520
8    NULL    530    530
9    NULL    540    540
================================================================================
Actual result:
================================================================================
7    NULL    520    520
8    NULL    530    530
9    NULL    540    540
0    450    NULL    450
1    460    NULL    460
2    470    NULL    470
3    480    480    960
4    490    490    980
5    NULL    500    500
6    NULL    510    510
```