### PR TITLE
[Tester] Add `require-mode` option to fail the test if the require is not met

### DIFF
--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -21,6 +21,7 @@ using namespace std;
 
 namespace duckdb {
 static string custom_test_directory;
+static RequireMode require_mode = RequireMode::EXIT_ON_FAIL;
 static int debug_initialize_value = -1;
 static bool single_threaded = false;
 
@@ -81,6 +82,10 @@ void SetTestDirectory(string path) {
 	custom_test_directory = path;
 }
 
+void SetRequireMode(RequireMode mode) {
+	require_mode = mode;
+}
+
 void SetDebugInitialize(int value) {
 	debug_initialize_value = value;
 }
@@ -94,6 +99,10 @@ string GetTestDirectory() {
 		return TESTING_DIRECTORY_NAME;
 	}
 	return custom_test_directory;
+}
+
+RequireMode GetRequireMode() {
+	return require_mode;
 }
 
 string TestDirectoryPath() {

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -27,6 +27,8 @@
 #include "duckdb/common/types.hpp"
 namespace duckdb {
 
+enum class RequireMode : uint8_t { EXIT_ON_FAIL, ERROR_ON_FAIL, INVALID };
+
 bool TestForceStorage();
 bool TestForceReload();
 bool TestMemoryLeaks();
@@ -42,9 +44,11 @@ string TestDirectoryPath();
 string TestCreatePath(string suffix);
 unique_ptr<DBConfig> GetTestConfig();
 bool TestIsInternalError(unordered_set<string> &internal_error_messages, const string &error);
+void SetRequireMode(RequireMode mode);
 void SetTestDirectory(string path);
 void SetDebugInitialize(int value);
 void SetSingleThreaded();
+RequireMode GetRequireMode();
 string GetTestDirectory();
 string GetCSVPath();
 void WriteCSV(string path, const char *csv);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -481,38 +481,65 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			// os specific stuff
 			if (param == "notmingw") {
 #ifdef __MINGW32__
+				if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+					parser.Fail(StringUtil::Format("require %s: FAILED", param));
+				}
 				return;
 #endif
 			} else if (param == "mingw") {
 #ifndef __MINGW32__
+				if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+					parser.Fail(StringUtil::Format("require %s: FAILED", param));
+				}
 				return;
 #endif
 			} else if (param == "notwindows") {
 #ifdef _WIN32
+				if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+					parser.Fail(StringUtil::Format("require %s: FAILED", param));
+				}
 				return;
 #endif
 			} else if (param == "windows") {
 #ifndef _WIN32
+				if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+					parser.Fail(StringUtil::Format("require %s: FAILED", param));
+				}
 				return;
 #endif
 			} else if (param == "longdouble") {
 #if LDBL_MANT_DIG < 54
+				if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+					parser.Fail(StringUtil::Format("require %s: FAILED", param));
+				}
 				return;
 #endif
 			} else if (param == "64bit") {
 				if (sizeof(void *) != 8) {
+					if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+						parser.Fail(StringUtil::Format("require %s: FAILED", param));
+					}
 					return;
 				}
 			} else if (param == "noforcestorage") {
 				if (TestForceStorage()) {
+					if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+						parser.Fail(StringUtil::Format("require %s: FAILED", param));
+					}
 					return;
 				}
 			} else if (param == "nothreadsan") {
 #ifdef DUCKDB_THREAD_SANITIZER
+				if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+					parser.Fail(StringUtil::Format("require %s: FAILED", param));
+				}
 				return;
 #endif
 			} else if (param == "strinline") {
 #ifdef DUCKDB_DEBUG_NO_INLINE
+				if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+					parser.Fail(StringUtil::Format("require %s: FAILED", param));
+				}
 				return;
 #endif
 			} else if (param == "vector_size") {
@@ -523,6 +550,9 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 				auto required_vector_size = std::stoi(token.parameters[1]);
 				if (STANDARD_VECTOR_SIZE < required_vector_size) {
 					// vector size is too low for this test: skip it
+					if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+						parser.Fail(StringUtil::Format("require %s: FAILED", param));
+					}
 					return;
 				}
 			} else if (param == "exact_vector_size") {
@@ -533,6 +563,9 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 				auto required_vector_size = std::stoi(token.parameters[1]);
 				if (STANDARD_VECTOR_SIZE != required_vector_size) {
 					// vector size does not match the required vector size: skip it
+					if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+						parser.Fail(StringUtil::Format("require %s: FAILED", param));
+					}
 					return;
 				}
 			} else if (param == "block_size") {
@@ -543,16 +576,25 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 				auto required_block_size = std::stoi(token.parameters[1]);
 				if (Storage::BLOCK_ALLOC_SIZE != required_block_size) {
 					// block size does not match the required block size: skip it
+					if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+						parser.Fail(StringUtil::Format("require %s: FAILED", param));
+					}
 					return;
 				}
 			} else if (param == "skip_reload") {
 				skip_reload = true;
 			} else if (param == "noalternativeverify") {
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
+				if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+					parser.Fail(StringUtil::Format("require %s: FAILED", param));
+				}
 				return;
 #endif
 			} else if (param == "no_extension_autoloading") {
 				if (config->options.autoload_known_extensions) {
+					if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+						parser.Fail(StringUtil::Format("require %s: FAILED", param));
+					}
 					return;
 				}
 			} else {
@@ -573,9 +615,15 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 						parser.Fail("unknown extension type: %s", token.parameters[0]);
 					} else if (result == ExtensionLoadResult::NOT_LOADED) {
 						// extension known but not build: skip this test
+						if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+							parser.Fail(StringUtil::Format("Could not load extension: %s", param));
+						}
 						return;
 					}
 				} else if (excluded_from_autoloading) {
+					if (GetRequireMode() == RequireMode::ERROR_ON_FAIL) {
+						parser.Fail(StringUtil::Format("require %s: FAILED", param));
+					}
 					return;
 				}
 			}

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -24,6 +24,16 @@ bool TestMemoryLeaks() {
 	return test_memory_leaks;
 }
 
+RequireMode ParseRequireMode(string mode) {
+	if (mode == "exit") {
+		return RequireMode::EXIT_ON_FAIL;
+	}
+	if (mode == "fail" || mode == "error") {
+		return RequireMode::ERROR_ON_FAIL;
+	}
+	return RequireMode::INVALID;
+}
+
 } // namespace duckdb
 
 int main(int argc, char *argv[]) {
@@ -43,6 +53,13 @@ int main(int argc, char *argv[]) {
 			test_memory_leaks = true;
 		} else if (string(argv[i]) == "--test-dir") {
 			test_directory = string(argv[++i]);
+		} else if (string(argv[i]) == "--require-mode") {
+			auto mode = ParseRequireMode(string(argv[++i]));
+			if (mode == RequireMode::INVALID) {
+				fprintf(stderr, "--require-mode has to be one of either 'error', 'fail', or 'exit' (default)\n");
+				return 1;
+			}
+			SetRequireMode(mode);
 		} else if (string(argv[i]) == "--test-temp-dir") {
 			delete_test_path = false;
 			auto test_dir = string(argv[++i]);


### PR DESCRIPTION
Currently the behavior of failing a `require` in a test will silently exit the test.

This can create a situation in the CI where we might *think* that a situation is tested, but if duckdb is not been built with the right flags the test will pass without being tested.