### PR TITLE
[Tester] Add `--require <name>`

### DIFF
--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/execution/operator/csv_scanner/scanner/string_value_scanner.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 
 #include "pid.hpp"
 #include "duckdb/function/table/read_csv.hpp"
@@ -23,6 +24,7 @@ namespace duckdb {
 static string custom_test_directory;
 static int debug_initialize_value = -1;
 static bool single_threaded = false;
+static case_insensitive_set_t required_requires;
 
 bool NO_FAIL(QueryResult &result) {
 	if (result.HasError()) {
@@ -87,6 +89,14 @@ void SetDebugInitialize(int value) {
 
 void SetSingleThreaded() {
 	single_threaded = true;
+}
+
+void AddRequire(string require) {
+	required_requires.insert(require);
+}
+
+bool IsRequired(string require) {
+	return required_requires.count(require);
 }
 
 string GetTestDirectory() {

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -45,6 +45,8 @@ bool TestIsInternalError(unordered_set<string> &internal_error_messages, const s
 void SetTestDirectory(string path);
 void SetDebugInitialize(int value);
 void SetSingleThreaded();
+void AddRequire(string require);
+bool IsRequired(string require);
 string GetTestDirectory();
 string GetCSVPath();
 void WriteCSV(string path, const char *csv);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -206,6 +206,168 @@ bool SQLLogicTestRunner::ForEachTokenReplace(const string &parameter, vector<str
 	return collection;
 }
 
+RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vector<string> &params) {
+	if (params.size() < 1) {
+		parser.Fail("require requires a single parameter");
+	}
+	// require command
+	string param = StringUtil::Lower(params[0]);
+	// os specific stuff
+	if (param == "notmingw") {
+#ifdef __MINGW32__
+		return RequireResult::MISSING;
+#else
+		return RequireResult::PRESENT;
+#endif
+	}
+
+	if (param == "mingw") {
+#ifndef __MINGW32__
+		return RequireResult::MISSING;
+#else
+		return RequireResult::PRESENT;
+#endif
+	}
+
+	if (param == "notwindows") {
+#ifdef _WIN32
+		return RequireResult::MISSING;
+#else
+		return RequireResult::PRESENT;
+#endif
+	}
+
+	if (param == "windows") {
+#ifndef _WIN32
+		return RequireResult::MISSING;
+#else
+		return RequireResult::PRESENT;
+#endif
+	}
+
+	if (param == "longdouble") {
+#if LDBL_MANT_DIG < 54
+		return RequireResult::MISSING;
+#else
+		return RequireResult::PRESENT;
+#endif
+	}
+
+	if (param == "64bit") {
+		if (sizeof(void *) != 8) {
+			return RequireResult::MISSING;
+		}
+		return RequireResult::PRESENT;
+	}
+
+	if (param == "noforcestorage") {
+		if (TestForceStorage()) {
+			return RequireResult::MISSING;
+		}
+		return RequireResult::PRESENT;
+	}
+
+	if (param == "nothreadsan") {
+#ifdef DUCKDB_THREAD_SANITIZER
+		return RequireResult::MISSING;
+#else
+		return RequireResult::PRESENT;
+#endif
+	}
+
+	if (param == "strinline") {
+#ifdef DUCKDB_DEBUG_NO_INLINE
+		return RequireResult::MISSING;
+#else
+		return RequireResult::PRESENT;
+#endif
+	}
+
+	if (param == "vector_size") {
+		if (params.size() != 2) {
+			parser.Fail("require vector_size requires a parameter");
+		}
+		// require a specific vector size
+		auto required_vector_size = std::stoi(params[1]);
+		if (STANDARD_VECTOR_SIZE < required_vector_size) {
+			// vector size is too low for this test: skip it
+			return RequireResult::MISSING;
+		}
+		return RequireResult::PRESENT;
+	}
+
+	if (param == "exact_vector_size") {
+		if (params.size() != 2) {
+			parser.Fail("require exact_vector_size requires a parameter");
+		}
+		// require an exact vector size
+		auto required_vector_size = std::stoi(params[1]);
+		if (STANDARD_VECTOR_SIZE != required_vector_size) {
+			// vector size does not match the required vector size: skip it
+			return RequireResult::MISSING;
+		}
+		return RequireResult::PRESENT;
+	}
+
+	if (param == "block_size") {
+		if (params.size() != 2) {
+			parser.Fail("require block_size requires a parameter");
+		}
+		// require a specific block size
+		auto required_block_size = std::stoi(params[1]);
+		if (Storage::BLOCK_ALLOC_SIZE != required_block_size) {
+			// block size does not match the required block size: skip it
+			return RequireResult::MISSING;
+		}
+		return RequireResult::PRESENT;
+	}
+
+	if (param == "skip_reload") {
+		skip_reload = true;
+		return RequireResult::PRESENT;
+	}
+
+	if (param == "noalternativeverify") {
+#ifdef DUCKDB_ALTERNATIVE_VERIFY
+		return RequireResult::MISSING;
+#else
+		return RequireResult::PRESENT;
+#endif
+	}
+
+	if (param == "no_extension_autoloading") {
+		if (config->options.autoload_known_extensions) {
+			// If autoloading is on, we skip this test
+			return RequireResult::MISSING;
+		}
+		return RequireResult::PRESENT;
+	}
+
+	bool excluded_from_autoloading = true;
+	for (const auto &ext : AUTOLOADABLE_EXTENSIONS) {
+		if (ext == param) {
+			excluded_from_autoloading = false;
+			break;
+		}
+	}
+
+	if (!config->options.autoload_known_extensions) {
+		auto result = ExtensionHelper::LoadExtension(*db, param);
+		if (result == ExtensionLoadResult::LOADED_EXTENSION) {
+			// add the extension to the list of loaded extensions
+			extensions.insert(param);
+		} else if (result == ExtensionLoadResult::EXTENSION_UNKNOWN) {
+			parser.Fail("unknown extension type: %s", params[0]);
+		} else if (result == ExtensionLoadResult::NOT_LOADED) {
+			// extension known but not build: skip this test
+			return RequireResult::MISSING;
+		}
+	} else if (excluded_from_autoloading) {
+		return RequireResult::MISSING;
+	}
+	return RequireResult::PRESENT;
+}
+
 void SQLLogicTestRunner::ExecuteFile(string script) {
 	SQLLogicParser parser;
 	idx_t skip_level = 0;
@@ -473,111 +635,14 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_ENDLOOP) {
 			EndLoop();
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_REQUIRE) {
-			if (token.parameters.size() < 1) {
-				parser.Fail("require requires a single parameter");
-			}
-			// require command
-			string param = StringUtil::Lower(token.parameters[0]);
-			// os specific stuff
-			if (param == "notmingw") {
-#ifdef __MINGW32__
+			auto require_result = CheckRequire(parser, token.parameters);
+			if (require_result == RequireResult::MISSING) {
+				auto &param = token.parameters[0];
+				if (IsRequired(param)) {
+					// This extension / setting was explicitly required
+					parser.Fail(StringUtil::Format("require %s: FAILED", param));
+				}
 				return;
-#endif
-			} else if (param == "mingw") {
-#ifndef __MINGW32__
-				return;
-#endif
-			} else if (param == "notwindows") {
-#ifdef _WIN32
-				return;
-#endif
-			} else if (param == "windows") {
-#ifndef _WIN32
-				return;
-#endif
-			} else if (param == "longdouble") {
-#if LDBL_MANT_DIG < 54
-				return;
-#endif
-			} else if (param == "64bit") {
-				if (sizeof(void *) != 8) {
-					return;
-				}
-			} else if (param == "noforcestorage") {
-				if (TestForceStorage()) {
-					return;
-				}
-			} else if (param == "nothreadsan") {
-#ifdef DUCKDB_THREAD_SANITIZER
-				return;
-#endif
-			} else if (param == "strinline") {
-#ifdef DUCKDB_DEBUG_NO_INLINE
-				return;
-#endif
-			} else if (param == "vector_size") {
-				if (token.parameters.size() != 2) {
-					parser.Fail("require vector_size requires a parameter");
-				}
-				// require a specific vector size
-				auto required_vector_size = std::stoi(token.parameters[1]);
-				if (STANDARD_VECTOR_SIZE < required_vector_size) {
-					// vector size is too low for this test: skip it
-					return;
-				}
-			} else if (param == "exact_vector_size") {
-				if (token.parameters.size() != 2) {
-					parser.Fail("require exact_vector_size requires a parameter");
-				}
-				// require an exact vector size
-				auto required_vector_size = std::stoi(token.parameters[1]);
-				if (STANDARD_VECTOR_SIZE != required_vector_size) {
-					// vector size does not match the required vector size: skip it
-					return;
-				}
-			} else if (param == "block_size") {
-				if (token.parameters.size() != 2) {
-					parser.Fail("require block_size requires a parameter");
-				}
-				// require a specific block size
-				auto required_block_size = std::stoi(token.parameters[1]);
-				if (Storage::BLOCK_ALLOC_SIZE != required_block_size) {
-					// block size does not match the required block size: skip it
-					return;
-				}
-			} else if (param == "skip_reload") {
-				skip_reload = true;
-			} else if (param == "noalternativeverify") {
-#ifdef DUCKDB_ALTERNATIVE_VERIFY
-				return;
-#endif
-			} else if (param == "no_extension_autoloading") {
-				if (config->options.autoload_known_extensions) {
-					return;
-				}
-			} else {
-				bool excluded_from_autoloading = true;
-				for (const auto &ext : AUTOLOADABLE_EXTENSIONS) {
-					if (ext == param) {
-						excluded_from_autoloading = false;
-						break;
-					}
-				}
-
-				if (!config->options.autoload_known_extensions) {
-					auto result = ExtensionHelper::LoadExtension(*db, param);
-					if (result == ExtensionLoadResult::LOADED_EXTENSION) {
-						// add the extension to the list of loaded extensions
-						extensions.insert(param);
-					} else if (result == ExtensionLoadResult::EXTENSION_UNKNOWN) {
-						parser.Fail("unknown extension type: %s", token.parameters[0]);
-					} else if (result == ExtensionLoadResult::NOT_LOADED) {
-						// extension known but not build: skip this test
-						return;
-					}
-				} else if (excluded_from_autoloading) {
-					return;
-				}
 			}
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_REQUIRE_ENV) {
 			if (InLoop()) {

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -16,6 +16,9 @@ namespace duckdb {
 
 class Command;
 class LoopCommand;
+class SQLLogicParser;
+
+enum class RequireResult { PRESENT, MISSING };
 
 class SQLLogicTestRunner {
 public:
@@ -68,6 +71,9 @@ public:
 	static string ReplaceLoopIterator(string text, string loop_iterator_name, string replacement);
 	static string LoopReplacement(string text, const vector<LoopDefinition> &loops);
 	static bool ForEachTokenReplace(const string &parameter, vector<string> &result);
+
+private:
+	RequireResult CheckRequire(SQLLogicParser &parser, const vector<string> &params);
 };
 
 } // namespace duckdb

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -52,6 +52,8 @@ int main(int argc, char *argv[]) {
 				return 1;
 			}
 			SetTestDirectory(test_dir);
+		} else if (string(argv[i]) == "--require") {
+			AddRequire(string(argv[++i]));
 		} else if (string(argv[i]) == "--zero-initialize") {
 			SetDebugInitialize(0);
 		} else if (string(argv[i]) == "--one-initialize") {


### PR DESCRIPTION
Same idea as https://github.com/duckdb/duckdb/pull/10577 but a different execution, more selective.

By specifying `--require json` we add `json` to the list of extensions that have to be present, if we reach a `require json` line and it is not present that constitutes a test failure, rather than silently skipping the test.

This flag works additively, so we can add `--require <name>` for all the extensions we require to be present.