### PR TITLE
add query() and query_table() functions

### DIFF
--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library_unity(
   arrow_conversion.cpp
   checkpoint.cpp
   glob.cpp
+  query_function.cpp
   range.cpp
   repeat.cpp
   repeat_row.cpp

--- a/src/function/table/query_function.cpp
+++ b/src/function/table/query_function.cpp
@@ -1,5 +1,4 @@
 #include "duckdb/parser/parser.hpp"
-#include "duckdb/common/helper.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/function/table/range.hpp"
 #include "duckdb/function/function_set.hpp"
@@ -23,17 +22,18 @@ static void UnionTablesQuery(TableFunctionBindInput &input, string &query) {
 	                     ? "BY NAME "
 	                     : ""; // 'by_name' variable defaults to false
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
-		query += "FROM " + input.inputs[0].ToString();
+		query += "FROM " + KeywordHelper::WriteOptionallyQuoted(input.inputs[0].ToString());
 	} else if (input.inputs[0].type() == LogicalType::LIST(LogicalType::VARCHAR)) {
 		string union_all_clause = " UNION ALL " + by_name + "FROM ";
 		const auto &children = ListValue::GetChildren(input.inputs[0]);
 		if (children.empty()) {
 			throw InvalidInputException("Input list is empty");
 		}
-		query += "FROM " + children[0].ToString();
+
+		query += "FROM " + KeywordHelper::WriteOptionallyQuoted(children[0].ToString());
 		for (size_t i = 1; i < children.size(); ++i) {
 			auto child = children[i].ToString();
-			query += union_all_clause + child;
+			query += union_all_clause + KeywordHelper::WriteOptionallyQuoted(child);
 		}
 	} else {
 		throw InvalidInputException("Expected a table or a list with tables as input");

--- a/src/function/table/query_function.cpp
+++ b/src/function/table/query_function.cpp
@@ -19,10 +19,31 @@ static unique_ptr<TableRef> QueryBindReplace(ClientContext &context, TableFuncti
 	return std::move(subquery_ref);
 }
 
+static unique_ptr<TableRef> TableBindReplace(ClientContext &context, TableFunctionBindInput &input) {
+	string query = "FROM " + input.inputs[0].ToString();
+	for (size_t i = 1; i < input.inputs.size(); ++i) {
+		query += " UNION ALL FROM " + input.inputs[i].ToString();
+	}
+
+	Parser parser(context.GetParserOptions());
+	parser.ParseQuery(query);
+	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
+		throw ParserException("Expected a table as value");
+	}
+	auto select_stmt = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
+	auto subquery_ref = duckdb::make_uniq<SubqueryRef>(std::move(select_stmt));
+	return std::move(subquery_ref);
+}
+
 void QueryTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction query("query", {LogicalType::VARCHAR}, nullptr, nullptr);
 	query.bind_replace = QueryBindReplace;
 	set.AddFunction(query);
+
+	TableFunction table("query_table", {LogicalType::VARCHAR}, nullptr, nullptr);
+	table.bind_replace = TableBindReplace;
+	table.varargs = LogicalType::VARCHAR;
+	set.AddFunction(table);
 }
 
 } // namespace duckdb

--- a/src/function/table/query_function.cpp
+++ b/src/function/table/query_function.cpp
@@ -2,45 +2,59 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/function/table/range.hpp"
+#include "duckdb/function/function_set.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 
 namespace duckdb {
 
-static unique_ptr<TableRef> QueryBindReplace(ClientContext &context, TableFunctionBindInput &input) {
-	string query = input.inputs[0].ToString();
-	Parser parser(context.GetParserOptions());
+static unique_ptr<SubqueryRef> parse_subquery(const string &query, const ParserOptions &options,
+                                              const string &error_msg) {
+	Parser parser(options);
 	parser.ParseQuery(query);
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
-		throw ParserException("Expected a single SELECT statement");
+		throw ParserException(error_msg);
 	}
-
 	auto select_stmt = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
-	auto subquery_ref = duckdb::make_uniq<SubqueryRef>(std::move(select_stmt));
-	return std::move(subquery_ref);
+	return duckdb::make_uniq<SubqueryRef>(std::move(select_stmt));
+}
+
+static void union_tables_query(TableFunctionBindInput &input, string &query) {
+	auto it = input.named_parameters.find("by_name");
+	string by_name = (it != input.named_parameters.end() && it->second.GetValue<bool>())
+	                     ? "BY NAME "
+	                     : ""; // 'by_name' variable defaults to false
+	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
+		query += "FROM " + input.inputs[0].ToString();
+	} else if (input.inputs[0].type() == LogicalType::LIST(LogicalType::VARCHAR)) {
+		string union_all_clause = " UNION ALL " + by_name + "FROM ";
+		const auto &children = ListValue::GetChildren(input.inputs[0]);
+		if (children.empty()) {
+			throw InvalidInputException("Input list is empty");
+		}
+		query += "FROM " + children[0].ToString();
+		for (size_t i = 1; i < children.size(); ++i) {
+			auto child = children[i].ToString();
+			query += union_all_clause + child;
+		}
+	}
+}
+
+static unique_ptr<TableRef> QueryBindReplace(ClientContext &context, TableFunctionBindInput &input) {
+	auto query = input.inputs[0].ToString();
+	auto subquery_ref = parse_subquery(query, context.GetParserOptions(), "Expected a single SELECT statement");
+	return subquery_ref;
 }
 
 static unique_ptr<TableRef> TableBindReplace(ClientContext &context, TableFunctionBindInput &input) {
-	D_ASSERT(input.named_parameters.size() == 0 || input.named_parameters.size() == 1);
-	string by_name {""}; // by_name defaults to false
-	if (input.named_parameters.size() == 1) {
-		auto it = input.named_parameters.find("by_name");
-		by_name = (it != input.named_parameters.end() && it->second.GetValue<bool>()) ? "BY NAME " : "";
+	D_ASSERT(input.named_parameters.size() == 0 || input.named_parameters.size() == 1); // expected only by_name arg
+	string err_msg = "Expected a table or a list with tables as input";
+	if (input.inputs.size() != 1) {
+		throw ParserException(err_msg);
 	}
-	// prepare the query
-	string union_all_clause = " UNION ALL " + by_name + "FROM ";
-	string query = "FROM " + input.inputs[0].ToString();
-	for (size_t i = 1; i < input.inputs.size(); ++i) {
-		query += union_all_clause + input.inputs[i].ToString();
-	}
-
-	Parser parser(context.GetParserOptions());
-	parser.ParseQuery(query);
-	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
-		throw ParserException("Expected a table as value");
-	}
-	auto select_stmt = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
-	auto subquery_ref = duckdb::make_uniq<SubqueryRef>(std::move(select_stmt));
-	return std::move(subquery_ref);
+	string query;
+	union_tables_query(input, query);
+	auto subquery_ref = parse_subquery(query, context.GetParserOptions(), err_msg);
+	return subquery_ref;
 }
 
 void QueryTableFunction::RegisterFunction(BuiltinFunctions &set) {
@@ -48,10 +62,14 @@ void QueryTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	query.bind_replace = QueryBindReplace;
 	set.AddFunction(query);
 
-	TableFunction query_table("query_table", {LogicalType::VARCHAR}, nullptr, nullptr);
-	query_table.named_parameters["by_name"] = LogicalType::BOOLEAN;
-	query_table.bind_replace = TableBindReplace;
-	query_table.varargs = LogicalType::VARCHAR;
+	TableFunctionSet query_table("query_table");
+	TableFunction query_table_function({LogicalType::LIST(LogicalType::VARCHAR)}, nullptr, nullptr);
+	query_table_function.named_parameters["by_name"] = LogicalType::BOOLEAN;
+	query_table_function.bind_replace = TableBindReplace;
+	query_table.AddFunction(query_table_function);
+
+	query_table_function.arguments = {LogicalType::VARCHAR};
+	query_table.AddFunction(query_table_function);
 	set.AddFunction(query_table);
 }
 

--- a/src/function/table/query_function.cpp
+++ b/src/function/table/query_function.cpp
@@ -1,0 +1,28 @@
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/function/table/range.hpp"
+#include "duckdb/parser/tableref/subqueryref.hpp"
+
+namespace duckdb {
+
+static unique_ptr<TableRef> QueryBindReplace(ClientContext &context, TableFunctionBindInput &input) {
+	string query = input.inputs[0].ToString();
+	Parser parser(context.GetParserOptions());
+	parser.ParseQuery(query);
+	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
+		throw ParserException("Expected a single SELECT statement");
+	}
+
+	auto select_stmt = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
+	auto subquery_ref = duckdb::make_uniq<SubqueryRef>(std::move(select_stmt));
+	return std::move(subquery_ref);
+}
+
+void QueryTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction query("query", {LogicalType::VARCHAR}, nullptr, nullptr);
+	query.bind_replace = QueryBindReplace;
+	set.AddFunction(query);
+}
+
+} // namespace duckdb

--- a/src/function/table/query_function.cpp
+++ b/src/function/table/query_function.cpp
@@ -60,14 +60,11 @@ void QueryTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(query);
 
 	TableFunctionSet query_table("query_table");
-	TableFunction query_table_function({LogicalType::LIST(LogicalType::VARCHAR)}, nullptr, nullptr);
+	TableFunction query_table_function({LogicalType::VARCHAR}, nullptr, nullptr);
 	query_table_function.bind_replace = TableBindReplace;
 	query_table.AddFunction(query_table_function);
-	// add by_name option
-	query_table_function.arguments.emplace_back(LogicalType::BOOLEAN);
-	query_table.AddFunction(query_table_function);
 
-	query_table_function.arguments = {LogicalType::VARCHAR};
+	query_table_function.arguments = {LogicalType::LIST(LogicalType::VARCHAR)};
 	query_table.AddFunction(query_table_function);
 	// add by_name option
 	query_table_function.arguments.emplace_back(LogicalType::BOOLEAN);

--- a/src/function/table/query_function.cpp
+++ b/src/function/table/query_function.cpp
@@ -7,8 +7,7 @@
 
 namespace duckdb {
 
-static unique_ptr<SubqueryRef> parse_subquery(const string &query, const ParserOptions &options,
-                                              const string &err_msg) {
+static unique_ptr<SubqueryRef> ParseSubquery(const string &query, const ParserOptions &options, const string &err_msg) {
 	Parser parser(options);
 	parser.ParseQuery(query);
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
@@ -18,7 +17,7 @@ static unique_ptr<SubqueryRef> parse_subquery(const string &query, const ParserO
 	return duckdb::make_uniq<SubqueryRef>(std::move(select_stmt));
 }
 
-static void union_tables_query(TableFunctionBindInput &input, string &query) {
+static void UnionTablesQuery(TableFunctionBindInput &input, string &query) {
 	string by_name = (input.inputs.size() == 2 &&
 	                  (input.inputs[1].type().id() == LogicalTypeId::BOOLEAN && input.inputs[1].GetValue<bool>()))
 	                     ? "BY NAME "
@@ -43,15 +42,15 @@ static void union_tables_query(TableFunctionBindInput &input, string &query) {
 
 static unique_ptr<TableRef> QueryBindReplace(ClientContext &context, TableFunctionBindInput &input) {
 	auto query = input.inputs[0].ToString();
-	auto subquery_ref = parse_subquery(query, context.GetParserOptions(), "Expected a single SELECT statement");
+	auto subquery_ref = ParseSubquery(query, context.GetParserOptions(), "Expected a single SELECT statement");
 	return std::move(subquery_ref);
 }
 
 static unique_ptr<TableRef> TableBindReplace(ClientContext &context, TableFunctionBindInput &input) {
 	string query;
-	union_tables_query(input, query);
+	UnionTablesQuery(input, query);
 	auto subquery_ref =
-	    parse_subquery(query, context.GetParserOptions(), "Expected a table or a list with tables as input");
+	    ParseSubquery(query, context.GetParserOptions(), "Expected a table or a list with tables as input");
 	return std::move(subquery_ref);
 }
 

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -282,6 +282,7 @@ void BuiltinFunctions::RegisterTableFunctions() {
 	CSVSnifferFunction::RegisterFunction(*this);
 	ReadBlobFunction::RegisterFunction(*this);
 	ReadTextFunction::RegisterFunction(*this);
+	QueryTableFunction::RegisterFunction(*this);
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/function/table/range.hpp
+++ b/src/include/duckdb/function/table/range.hpp
@@ -49,4 +49,8 @@ struct ReadTextFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct QueryTableFunction {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 } // namespace duckdb

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -26,11 +26,6 @@ FROM query('SELECT abs(-42)');
 42
 
 query I
-FROM query('FROM query("SELECT 1")');
-----
-1
-
-query I
 SELECT * FROM query('SELECT * FROM (SELECT 1 + 2)');
 ----
 3
@@ -39,11 +34,6 @@ query III
 FROM query('SELECT 1, 2, 3');
 ----
 1	2	3
-
-query I
-SELECT * FROM query('FROM query(''SELECT 17 + 25'')');
-----
-42
 
 query I
 FROM query('SELECT 42;;;--- hello;');
@@ -63,10 +53,10 @@ hello
 
 # query from table
 statement ok
-CREATE TABLE tbl1 (a INT, b INT);
+CREATE TABLE tbl (a INT, b INT);
 
 statement ok
-FROM query('SELECT *, 1 + 2 FROM tbl1');
+FROM query('SELECT *, 1 + 2 FROM tbl');
 
 statement ok
 CREATE TABLE tbl2 (a INT, b INT, c INT);
@@ -134,23 +124,6 @@ Parser Error: Expected a single SELECT statement
 
 
 # test query_table()
-statement ok
-create table t as select 42;
-
-statement ok
-create table t2 as select 'duckdb';
-
-statement ok
-create table t3 as select '';
-
-statement ok
-create table t4 as select '1?ch@racter$';
-
-query I
-from query_table('t');
-----
-42
-
 query III
 from query_table(tbl2);
 ----
@@ -158,18 +131,33 @@ from query_table(tbl2);
 4	5	6
 7	8	9
 
-query I
-from query_table('t','t2','t4');
-----
-42
-duckdb
-1?ch@racter$
+statement ok
+create table t_int as select 42;
+
+statement ok
+create table t_varchar as select 'duckdb';
+
+statement ok
+create table t_empty as select '';
+
+statement ok
+create table t2_varchar as select '1?ch@racter$';
 
 query I
-from query_table(t, t2);
+from query_table('t_int');
 ----
 42
-duckdb
+
+query I
+from query_table(['t_int']);
+----
+42
+
+query I
+from query_table(['t_int', t2_varchar]);
+----
+42
+1?ch@racter$
 
 query I
 from query_table('(select 17 + 25)');
@@ -177,7 +165,7 @@ from query_table('(select 17 + 25)');
 42
 
 query I
-from query_table('t', 't2', 't3', t4, '(select ''I am a subquery'')');
+from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')']);
 ----
 42
 duckdb
@@ -185,10 +173,26 @@ duckdb
 1?ch@racter$
 I am a subquery
 
+# test incorrect usage
 statement error
-from query_table(['t', 't2', 't3', t4, '(select ''I am a subquery'')']);
+from query_table([]);
 ----
-Binder Error: No function matches the given name and argument types 'query_table(VARCHAR[])'.
+Binder Error: No function matches the given name and argument types 'query_table(INTEGER[])'.
+
+statement error
+from query_table(['']);
+----
+Parser Error: syntax error at end of input
+
+statement error
+from query_table('t_int', 't_varchar', t2_varchar);
+----
+Binder Error: No function matches the given name and argument types 'query_table(VARCHAR, VARCHAR, VARCHAR)'.
+
+statement error
+from query_table([t_int, tbl2]);
+----
+Binder Error: Set operations can only apply to expressions with the same number of result columns
 
 statement error
 from query_table(not_defined_tbl);
@@ -213,8 +217,17 @@ from query_table(tbl2, by_name=true);
 4	5	6
 7	8	9
 
+query I
+from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')'], by_name=false);
+----
+42
+duckdb
+(empty)
+1?ch@racter$
+I am a subquery
+
 query IIIII
-from query_table('t', 't2', 't3', t4, '(select ''I am a subquery'')', by_name=true);
+from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')'], by_name=true);
 ----
 42	NULL	NULL	NULL	NULL
 NULL	duckdb	NULL	NULL	NULL
@@ -222,7 +235,8 @@ NULL	NULL	(empty)	NULL	NULL
 NULL	NULL	NULL	1?ch@racter$	NULL
 NULL	NULL	NULL	NULL	I am a subquery
 
+# test incorrect usage
 statement error
-from query_table('t', not_valid=true);
+from query_table('t_int', not_valid=true);
 ----
 Binder Error: Invalid named parameter "not_valid" for function query_table

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -1,0 +1,134 @@
+# name: test/sql/catalog/function/query_function.test
+# description: test query() function
+# group: [function]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT * FROM query('SELECT 42');
+----
+42
+
+query I
+FROM query('SELECT 42 as a');
+----
+42
+
+query I
+FROM query('SELECT 10 + 32;');
+----
+42
+
+query I
+FROM query('SELECT abs(-42)');
+----
+42
+
+query I
+FROM query('FROM query("SELECT 1")');
+----
+1
+
+query I
+SELECT * FROM query('SELECT * FROM (SELECT 1 + 2)');
+----
+3
+
+query III
+FROM query('SELECT 1, 2, 3');
+----
+1	2	3
+
+query I
+SELECT * FROM query('FROM query(''SELECT 17 + 25'')');
+----
+42
+
+query I
+FROM query('SELECT 42;;;--- hello;');
+----
+42
+
+# query text
+query I
+SELECT 'hello';
+----
+hello
+
+query I
+SELECT * FROM query('SELECT ''hello''');
+----
+hello
+
+# query from table
+statement ok
+CREATE TABLE tbl1 (a INT, b INT);
+
+statement ok
+FROM query('SELECT *, 1 + 2 FROM tbl1');
+
+statement ok
+CREATE TABLE tbl2 (a INT, b INT, c INT);
+
+statement ok
+INSERT INTO tbl2 VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
+
+query III
+SELECT * FROM query('FROM tbl2');
+----
+1	2	3
+4	5	6
+7	8	9
+
+query I
+SELECT * FROM query('SELECT a + b + c FROM tbl2');
+----
+6
+15
+24
+
+# query multiple nested type tags
+query II
+SELECT * FROM query('WITH a(i) as (SELECT 1) SELECT a1.i as i1, a2.i as i2 FROM a as a1, a as a2');
+----
+1	1
+
+# test incorrect usage
+statement error
+SELECT * FROM query(NULL);
+----
+Parser Error: syntax error at or near "NULL"
+
+statement error
+SELECT * FROM query(' ');
+----
+Parser Error: Expected a single SELECT statement
+
+statement error
+SELECT * FROM query('');
+----
+Parser Error: Expected a single SELECT statement
+
+statement error
+SELECT * FROM query('FROM query(FROM)');
+----
+Parser Error: syntax error at or near "FROM"
+
+# multiple statements are not supported
+statement error
+SELECT * FROM query('SELECT 1; SELECT 2');
+----
+Parser Error: Expected a single SELECT statement
+
+# syntax error
+statement error
+SELECT query(SELECT 1);
+----
+Parser Error: syntax error at or near "SELECT"
+
+statement error
+SELECT * FROM query('CREATE TABLE tbl (a INT)');
+----
+Parser Error: Expected a single SELECT statement
+

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -211,14 +211,14 @@ Parser Error: syntax error at or near "NULL"
 
 # test by_name argument
 query III
-from query_table(tbl2, by_name=true);
+from query_table(tbl2, true);
 ----
 1	2	3
 4	5	6
 7	8	9
 
 query I
-from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')'], by_name=false);
+from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')'], false);
 ----
 42
 duckdb
@@ -227,7 +227,7 @@ duckdb
 I am a subquery
 
 query IIIII
-from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')'], by_name=true);
+from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')'], true);
 ----
 42	NULL	NULL	NULL	NULL
 NULL	duckdb	NULL	NULL	NULL
@@ -237,6 +237,6 @@ NULL	NULL	NULL	NULL	I am a subquery
 
 # test incorrect usage
 statement error
-from query_table('t_int', not_valid=true);
+from query_table(true);
 ----
-Binder Error: Invalid named parameter "not_valid" for function query_table
+Binder Error: No function matches the given name and argument types 'query_table(BOOLEAN)'.

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -94,6 +94,33 @@ SELECT * FROM query('WITH a(i) as (SELECT 1) SELECT a1.i as i1, a2.i as i2 FROM 
 ----
 1	1
 
+# dynamic table macro example
+statement ok
+create table t as select 42;
+
+statement ok
+create table t2 as select 'duckdb';
+
+statement ok
+create table t3 as select '';
+
+statement ok
+create table t4 as select '1?ch@racter$';
+
+statement ok
+CREATE MACRO union_all(table_list, by_name:='FALSE') AS TABLE (
+    FROM query('FROM ' || list_reduce(table_list, (x, y) ->  x || ' UNION ALL ' || CASE WHEN by_name THEN 'BY NAME ' ELSE '' END || 'FROM ' || y))
+);
+
+query I
+from union_all(['t', 't2', 't3', t4, '(select ''I am a subquery'')'], by_name:='FALSE');
+----
+42
+duckdb
+(empty)
+1?ch@racter$
+I am a subquery
+
 # test incorrect usage
 statement error
 SELECT * FROM query(NULL);

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -11,7 +11,7 @@ SELECT * FROM query('SELECT 42');
 42
 
 query I
-FROM query('SELECT 42 as a');
+FROM query('SELECT 42 AS a');
 ----
 42
 
@@ -42,37 +42,29 @@ FROM query('SELECT 42;;;--- hello;');
 
 # query text
 query I
-SELECT 'hello';
-----
-hello
-
-query I
 SELECT * FROM query('SELECT ''hello''');
 ----
 hello
 
-# query from table
+# query a table
 statement ok
-CREATE TABLE tbl (a INT, b INT);
+CREATE TABLE tbl (a INT, b INT, c INT);
 
 statement ok
 FROM query('SELECT *, 1 + 2 FROM tbl');
 
 statement ok
-CREATE TABLE tbl2 (a INT, b INT, c INT);
-
-statement ok
-INSERT INTO tbl2 VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
+INSERT INTO tbl VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
 
 query III
-SELECT * FROM query('FROM tbl2');
+SELECT * FROM query('FROM tbl');
 ----
 1	2	3
 4	5	6
 7	8	9
 
 query I
-SELECT * FROM query('SELECT a + b + c FROM tbl2');
+SELECT * FROM query('SELECT a + b + c FROM tbl');
 ----
 6
 15
@@ -80,7 +72,7 @@ SELECT * FROM query('SELECT a + b + c FROM tbl2');
 
 # query multiple nested type tags
 query II
-SELECT * FROM query('WITH a(i) as (SELECT 1) SELECT a1.i as i1, a2.i as i2 FROM a as a1, a as a2');
+SELECT * FROM query('WITH a(i) AS (SELECT 1) SELECT a1.i AS i1, a2.i AS i2 FROM a AS a1, a AS a2');
 ----
 1	1
 
@@ -111,7 +103,7 @@ SELECT * FROM query('SELECT 1; SELECT 2');
 ----
 Parser Error: Expected a single SELECT statement
 
-# syntax error
+# invalid input
 statement error
 SELECT query(SELECT 1);
 ----
@@ -124,117 +116,168 @@ Parser Error: Expected a single SELECT statement
 
 
 # test query_table()
+statement ok
+CREATE TABLE tbl_int AS SELECT 42;
+
+statement ok
+CREATE TABLE tbl_varchar AS SELECT 'duckdb';
+
+statement ok
+CREATE TABLE tbl2_varchar AS SELECT '1?ch@racter$';
+
+statement ok
+CREATE TABLE tbl_empty AS SELECT '';
+
+query I
+FROM query_table('tbl_int');
+----
+42
+
+query I
+FROM query_table(['tbl_int']);
+----
+42
+
 query III
-from query_table(tbl2);
+FROM query_table(tbl);
 ----
 1	2	3
 4	5	6
 7	8	9
 
 statement ok
-create table t_int as select 42;
+CREATE TABLE tbl2 (a INT, b INT, c INT);
 
 statement ok
-create table t_varchar as select 'duckdb';
+INSERT INTO tbl2 VALUES (9, 8, 7), (6, 5, 4), (3, 2, 1);
 
-statement ok
-create table t_empty as select '';
-
-statement ok
-create table t2_varchar as select '1?ch@racter$';
-
-query I
-from query_table('t_int');
+query III
+FROM query_table([tbl, tbl2]);
 ----
-42
-
-query I
-from query_table(['t_int']);
-----
-42
-
-query I
-from query_table(['t_int', t2_varchar]);
-----
-42
-1?ch@racter$
-
-query I
-from query_table('(select 17 + 25)');
-----
-42
-
-query I
-from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')']);
-----
-42
-duckdb
-(empty)
-1?ch@racter$
-I am a subquery
+1	2	3
+4	5	6
+7	8	9
+9	8	7
+6	5	4
+3	2	1
 
 # test incorrect usage
 statement error
-from query_table([]);
-----
-Binder Error: No function matches the given name and argument types 'query_table(INTEGER[])'.
-
-statement error
-from query_table(['']);
-----
-Parser Error: syntax error at end of input
-
-statement error
-from query_table('t_int', 't_varchar', t2_varchar);
-----
-Binder Error: No function matches the given name and argument types 'query_table(VARCHAR, VARCHAR, VARCHAR)'.
-
-statement error
-from query_table([t_int, tbl2]);
-----
-Binder Error: Set operations can only apply to expressions with the same number of result columns
-
-statement error
-from query_table(not_defined_tbl);
-----
-Catalog Error: Table with name not_defined_tbl does not exist!
-
-statement error
-from query_table();
+FROM query_table();
 ----
 No function matches the given name and argument types 'query_table()'.
 
 statement error
-from query_table(NULL);
+FROM query_table(NULL);
 ----
-Parser Error: syntax error at or near "NULL"
+Catalog Error: Table with name NULL does not exist!
+
+statement error
+FROM query_table([]);
+----
+Binder Error: No function matches the given name and argument types 'query_table(INTEGER[])'.
+
+statement error
+FROM query_table(['']);
+----
+Parser Error: syntax error at end of input
+
+statement error
+FROM query_table('tbl_int', 'tbl_varchar', tbl2_varchar);
+----
+Binder Error: No function matches the given name and argument types 'query_table(VARCHAR, VARCHAR, VARCHAR)'.
+
+statement error
+FROM query_table([tbl_int, tbl2]);
+----
+Binder Error: Set operations can only apply to expressions with the same number of result columns
+
+statement error
+FROM query_table(not_defined_tbl);
+----
+Catalog Error: Table with name not_defined_tbl does not exist!
+
+statement error
+FROM query_table('FROM query(''select 1 + 2;'')');
+----
+Catalog Error: Table with name FROM query('select 1 + 2;') does not exist!
+
+statement error
+FROM query_table('FROM query("select 1 + 2;")');
+----
+Catalog Error: Table with name FROM query("select 1 + 2;") does not exist!
+
+statement error
+FROM query_table('(SELECT 17 + 25)');
+----
+Catalog Error: Table with name (SELECT 17 + 25) does not exist!
+
+# tables with special table names
+statement ok
+CREATE TABLE "(SELECT 17 + 25)"(i int);
+
+statement ok
+insert into "(SELECT 17 + 25)" values (100);
+
+query I
+SELECT * FROM "(SELECT 17 + 25)";
+----
+100
+
+query I 
+FROM query_table("(SELECT 17 + 25)");
+----
+100
+
+query I 
+FROM query_table('(SELECT 17 + 25)');
+----
+100
+
+statement error
+FROM query_table(SELECT 17 + 25);
+----
+Parser Error: syntax error at or near "SELECT"
+
+statement error 
+FROM query_table("SELECT 4 + 2");
+----
+Catalog Error: Table with name SELECT 4 + 2 does not exist!
+
+statement error
+FROM query_table('SELECT 4 + 2');
+----
+Catalog Error: Table with name SELECT 4 + 2 does not exist!
 
 # test by_name argument
 query I
-from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')'], false);
+FROM query_table(['tbl_int', 'tbl_varchar', 'tbl_empty', 'tbl2_varchar'], false);
 ----
 42
 duckdb
 (empty)
 1?ch@racter$
-I am a subquery
 
-query IIIII
-from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')'], true);
+query IIII
+from query_table([tbl_int, tbl_varchar, tbl_empty, tbl2_varchar], true);
 ----
-42	NULL	NULL	NULL	NULL
-NULL	duckdb	NULL	NULL	NULL
-NULL	NULL	(empty)	NULL	NULL
-NULL	NULL	NULL	1?ch@racter$	NULL
-NULL	NULL	NULL	NULL	I am a subquery
+42	NULL	NULL	NULL
+NULL	duckdb	NULL	NULL
+NULL	NULL	(empty)	NULL
+NULL	NULL	NULL	1?ch@racter$
 
 # test incorrect usage
 statement error
-from query_table(true);
+FROM query_table(true);
 ----
 Binder Error: No function matches the given name and argument types 'query_table(BOOLEAN)'.
 
 statement error
-from query_table(tbl2, true);
+FROM query_table(tbl2, true);
 ----
 Binder Error: No function matches the given name and argument types 'query_table(VARCHAR, BOOLEAN)'.
+
+statement error
+FROM query_table(['tbl_int', 'tbl_varchar', 'tbl_empty', '(select ''I am a subquery'')'], false);
+----
+Catalog Error: Table with name (select 'I am a subquery') does not exist!

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -210,13 +210,6 @@ from query_table(NULL);
 Parser Error: syntax error at or near "NULL"
 
 # test by_name argument
-query III
-from query_table(tbl2, true);
-----
-1	2	3
-4	5	6
-7	8	9
-
 query I
 from query_table(['t_int', 't_varchar', 't_empty', t2_varchar, '(select ''I am a subquery'')'], false);
 ----
@@ -240,3 +233,8 @@ statement error
 from query_table(true);
 ----
 Binder Error: No function matches the given name and argument types 'query_table(BOOLEAN)'.
+
+statement error
+from query_table(tbl2, true);
+----
+Binder Error: No function matches the given name and argument types 'query_table(VARCHAR, BOOLEAN)'.

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -94,33 +94,6 @@ SELECT * FROM query('WITH a(i) as (SELECT 1) SELECT a1.i as i1, a2.i as i2 FROM 
 ----
 1	1
 
-# dynamic table macro example
-statement ok
-create table t as select 42;
-
-statement ok
-create table t2 as select 'duckdb';
-
-statement ok
-create table t3 as select '';
-
-statement ok
-create table t4 as select '1?ch@racter$';
-
-statement ok
-CREATE MACRO union_all(table_list, by_name:='FALSE') AS TABLE (
-    FROM query('FROM ' || list_reduce(table_list, (x, y) ->  x || ' UNION ALL ' || CASE WHEN by_name THEN 'BY NAME ' ELSE '' END || 'FROM ' || y))
-);
-
-query I
-from union_all(['t', 't2', 't3', t4, '(select ''I am a subquery'')'], by_name:='FALSE');
-----
-42
-duckdb
-(empty)
-1?ch@racter$
-I am a subquery
-
 # test incorrect usage
 statement error
 SELECT * FROM query(NULL);
@@ -159,3 +132,89 @@ SELECT * FROM query('CREATE TABLE tbl (a INT)');
 ----
 Parser Error: Expected a single SELECT statement
 
+# test query_table()
+statement ok
+create table t as select 42;
+
+statement ok
+create table t2 as select 'duckdb';
+
+statement ok
+create table t3 as select '';
+
+statement ok
+create table t4 as select '1?ch@racter$';
+
+query I
+from query_table('t');
+----
+42
+
+query III
+from query_table(tbl2);
+----
+1	2	3
+4	5	6
+7	8	9
+
+query I
+from query_table('t','t2','t4');
+----
+42
+duckdb
+1?ch@racter$
+
+query I
+from query_table(t, t2);
+----
+42
+duckdb
+
+query I
+from query_table('(select 17 + 25)');
+----
+42
+
+query I
+from query_table('t', 't2', 't3', t4, '(select ''I am a subquery'')');
+----
+42
+duckdb
+(empty)
+1?ch@racter$
+I am a subquery
+
+# dynamic table macro example
+statement ok
+CREATE MACRO union_all(table_list, by_name:='FALSE') AS TABLE (
+    FROM query('FROM ' || list_reduce(table_list, (x, y) ->  x || ' UNION ALL ' || CASE WHEN by_name THEN 'BY NAME ' ELSE '' END || 'FROM ' || y))
+);
+
+query I
+from union_all(['t', 't2', 't3', t4, '(select ''I am a subquery'')'], by_name:='FALSE');
+----
+42
+duckdb
+(empty)
+1?ch@racter$
+I am a subquery
+
+statement error
+from query_table(['t', 't2', 't3', t4, '(select ''I am a subquery'')']);
+----
+Binder Error: No function matches the given name and argument types 'query_table(VARCHAR[])'.
+
+statement error
+from query_table(not_defined_tbl);
+----
+Catalog Error: Table with name not_defined_tbl does not exist!
+
+statement error
+from query_table();
+----
+No function matches the given name and argument types 'query_table()'.
+
+statement error
+from query_table(NULL);
+----
+Parser Error: syntax error at or near "NULL"

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -132,6 +132,7 @@ SELECT * FROM query('CREATE TABLE tbl (a INT)');
 ----
 Parser Error: Expected a single SELECT statement
 
+
 # test query_table()
 statement ok
 create table t as select 42;
@@ -184,21 +185,6 @@ duckdb
 1?ch@racter$
 I am a subquery
 
-# dynamic table macro example
-statement ok
-CREATE MACRO union_all(table_list, by_name:='FALSE') AS TABLE (
-    FROM query('FROM ' || list_reduce(table_list, (x, y) ->  x || ' UNION ALL ' || CASE WHEN by_name THEN 'BY NAME ' ELSE '' END || 'FROM ' || y))
-);
-
-query I
-from union_all(['t', 't2', 't3', t4, '(select ''I am a subquery'')'], by_name:='FALSE');
-----
-42
-duckdb
-(empty)
-1?ch@racter$
-I am a subquery
-
 statement error
 from query_table(['t', 't2', 't3', t4, '(select ''I am a subquery'')']);
 ----
@@ -218,3 +204,25 @@ statement error
 from query_table(NULL);
 ----
 Parser Error: syntax error at or near "NULL"
+
+# test by_name argument
+query III
+from query_table(tbl2, by_name=true);
+----
+1	2	3
+4	5	6
+7	8	9
+
+query IIIII
+from query_table('t', 't2', 't3', t4, '(select ''I am a subquery'')', by_name=true);
+----
+42	NULL	NULL	NULL	NULL
+NULL	duckdb	NULL	NULL	NULL
+NULL	NULL	(empty)	NULL	NULL
+NULL	NULL	NULL	1?ch@racter$	NULL
+NULL	NULL	NULL	NULL	I am a subquery
+
+statement error
+from query_table('t', not_valid=true);
+----
+Binder Error: Invalid named parameter "not_valid" for function query_table


### PR DESCRIPTION
This PR adds two functions as discussed [here](https://github.com/duckdblabs/duckdb-internal/issues/1026).

```
# Executes a select statement
TABLE_REF query(VARCHAR qstr)

# Parses and evaluates a table or a union of an arbitrary list of tables
TABLE_REF query_table(VARCHAR tbl_name)
TABLE_REF query_table(LIST<VARCHAR> tbl_names [, BOOLEAN by_name])
```
The `query_table()` implements the `union all` function as commented [below](https://github.com/duckdb/duckdb/pull/10586#issuecomment-1951571760) with the difference that it does not allow the execution of expressions other than querying tables.
The optional parameter `by_name` defaults to `false`. When set to `true`, it performs the union operation `BY NAME` (as `union_all` does).