### PR TITLE
Fix OrderPreservationType issue of MATERIALIZED CTEs

### DIFF
--- a/src/core_functions/scalar/list/array_slice.cpp
+++ b/src/core_functions/scalar/list/array_slice.cpp
@@ -318,7 +318,10 @@ static void ArraySliceFunction(DataChunk &args, ExpressionState &state, Vector &
 	D_ASSERT(args.data.size() == 3 || args.data.size() == 4);
 	auto count = args.size();
 
-	Vector &list_or_str_vector = args.data[0];
+	Vector &list_or_str_vector = result;
+	// this ensures that we do not change the input chunk
+	VectorOperations::Copy(args.data[0], list_or_str_vector, count, 0, 0);
+
 	if (list_or_str_vector.GetType().id() == LogicalTypeId::SQLNULL) {
 		auto &result_validity = FlatVector::Validity(result);
 		result_validity.SetInvalid(0);
@@ -346,7 +349,6 @@ static void ArraySliceFunction(DataChunk &args, ExpressionState &state, Vector &
 		    list_or_str_vector.GetVectorType() != VectorType::CONSTANT_VECTOR) {
 			list_or_str_vector.Flatten(count);
 		}
-		ListVector::ReferenceEntry(result, list_or_str_vector);
 		ExecuteSlice<list_entry_t, int64_t>(result, list_or_str_vector, begin_vector, end_vector, step_vector, count,
 		                                    begin_is_empty, end_is_empty);
 		break;

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -14,11 +14,18 @@ static OrderPreservationType OrderPreservationRecursive(PhysicalOperator &op) {
 	if (op.IsSource()) {
 		return op.SourceOrder();
 	}
+
+	idx_t child_idx = 0;
 	for (auto &child : op.children) {
+		// Do not take the materialization phase of physical CTEs into account
+		if (op.type == PhysicalOperatorType::CTE && child_idx == 0) {
+			continue;
+		}
 		auto child_preservation = OrderPreservationRecursive(*child);
 		if (child_preservation != OrderPreservationType::INSERTION_ORDER) {
 			return child_preservation;
 		}
+		child_idx++;
 	}
 	return OrderPreservationType::INSERTION_ORDER;
 }

--- a/src/function/scalar/list/list_concat.cpp
+++ b/src/function/scalar/list/list_concat.cpp
@@ -55,13 +55,13 @@ static void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &
 		if (lhs_data.validity.RowIsValid(lhs_list_index)) {
 			const auto &lhs_entry = lhs_entries[lhs_list_index];
 			result_entries[i].length += lhs_entry.length;
-			ListVector::Append(result, lhs_child, *lhs_child_data.sel, lhs_entry.offset + lhs_entry.length,
+			ListVector::Append(result, lhs_child, lhs_entry.offset + lhs_entry.length,
 			                   lhs_entry.offset);
 		}
 		if (rhs_data.validity.RowIsValid(rhs_list_index)) {
 			const auto &rhs_entry = rhs_entries[rhs_list_index];
 			result_entries[i].length += rhs_entry.length;
-			ListVector::Append(result, rhs_child, *rhs_child_data.sel, rhs_entry.offset + rhs_entry.length,
+			ListVector::Append(result, rhs_child, rhs_entry.offset + rhs_entry.length,
 			                   rhs_entry.offset);
 		}
 		offset += result_entries[i].length;

--- a/src/function/scalar/list/list_concat.cpp
+++ b/src/function/scalar/list/list_concat.cpp
@@ -55,14 +55,12 @@ static void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &
 		if (lhs_data.validity.RowIsValid(lhs_list_index)) {
 			const auto &lhs_entry = lhs_entries[lhs_list_index];
 			result_entries[i].length += lhs_entry.length;
-			ListVector::Append(result, lhs_child, lhs_entry.offset + lhs_entry.length,
-			                   lhs_entry.offset);
+			ListVector::Append(result, lhs_child, lhs_entry.offset + lhs_entry.length, lhs_entry.offset);
 		}
 		if (rhs_data.validity.RowIsValid(rhs_list_index)) {
 			const auto &rhs_entry = rhs_entries[rhs_list_index];
 			result_entries[i].length += rhs_entry.length;
-			ListVector::Append(result, rhs_child, rhs_entry.offset + rhs_entry.length,
-			                   rhs_entry.offset);
+			ListVector::Append(result, rhs_child, rhs_entry.offset + rhs_entry.length, rhs_entry.offset);
 		}
 		offset += result_entries[i].length;
 	}

--- a/src/function/scalar/list/list_concat.cpp
+++ b/src/function/scalar/list/list_concat.cpp
@@ -55,12 +55,14 @@ static void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &
 		if (lhs_data.validity.RowIsValid(lhs_list_index)) {
 			const auto &lhs_entry = lhs_entries[lhs_list_index];
 			result_entries[i].length += lhs_entry.length;
-			ListVector::Append(result, lhs_child, lhs_entry.offset + lhs_entry.length, lhs_entry.offset);
+			ListVector::Append(result, lhs_child, *lhs_child_data.sel, lhs_entry.offset + lhs_entry.length,
+			                   lhs_entry.offset);
 		}
 		if (rhs_data.validity.RowIsValid(rhs_list_index)) {
 			const auto &rhs_entry = rhs_entries[rhs_list_index];
 			result_entries[i].length += rhs_entry.length;
-			ListVector::Append(result, rhs_child, rhs_entry.offset + rhs_entry.length, rhs_entry.offset);
+			ListVector::Append(result, rhs_child, *rhs_child_data.sel, rhs_entry.offset + rhs_entry.length,
+			                   rhs_entry.offset);
 		}
 		offset += result_entries[i].length;
 	}

--- a/test/sql/cte/recursive_hang_2745.test
+++ b/test/sql/cte/recursive_hang_2745.test
@@ -5,7 +5,7 @@
 statement ok
 PRAGMA enable_verification
 
-query III rowsort
+query III
 with RECURSIVE parents_tab (id , value , parent )
 as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
 ),
@@ -17,7 +17,7 @@ parents as (
     union all
     select id, value+2, parent from parents_tab2
 )
-select * from parents;
+select * from parents order by id, value, parent;
 ----
 1	1	2
 1	3	2
@@ -34,7 +34,7 @@ select * from parents;
 7	1	-1
 7	3	-1
 
-query III rowsort
+query III
 with RECURSIVE parents_tab (id , value , parent )
 as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
 ),
@@ -43,7 +43,7 @@ as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7
 )
 select * from parents_tab
 union all
-select id, value+2, parent from parents_tab2;
+select id, value+2, parent from parents_tab2 ORDER BY id, value, parent;
 ----
 1	1	2
 1	3	2
@@ -60,7 +60,7 @@ select id, value+2, parent from parents_tab2;
 7	1	-1
 7	3	-1
 
-query III rowsort
+query III
 with parents_tab (id , value , parent )
 as (values (1, 1, 2), (2, 2, 4), (3, 1, 4), (4, 2, -1), (5, 1, 2), (6, 2, 7), (7, 1, -1)
 ),
@@ -72,7 +72,7 @@ parents as (
     union all
     select id, value+2, parent from parents_tab2
 )
-select * from parents;
+select * from parents ORDER BY id, value, parent;
 ----
 1	1	2
 1	3	2

--- a/test/sql/function/list/list_reverse.test
+++ b/test/sql/function/list/list_reverse.test
@@ -147,7 +147,7 @@ tattarrattat
 statement ok
 DROP TABLE palindromes;
 
-query I rowsort
+query I
 WITH example AS (
   SELECT [1, 2, 3] AS arr UNION ALL
   SELECT [4, 5] AS arr UNION ALL
@@ -155,7 +155,7 @@ WITH example AS (
 )
 SELECT
   ${f}(arr) AS reverse_arr
-FROM example;
+FROM example ORDER BY length(reverse_arr) DESC;
 ----
 [3, 2, 1]
 [5, 4]

--- a/test/sql/join/left_outer/test_left_join_on_true.test
+++ b/test/sql/join/left_outer/test_left_join_on_true.test
@@ -51,7 +51,7 @@ ORDER BY 1, 2
 2	NULL
 4	NULL
 
-query II rowsort
+query II
 WITH t AS (
   SELECT 1 AS r, ARRAY[1, 2, 3] AS a
   UNION SELECT 2 AS r, ARRAY[4] AS a

--- a/test/sql/types/list/unnest_null_empty.test
+++ b/test/sql/types/list/unnest_null_empty.test
@@ -70,7 +70,7 @@ ORDER BY r, n;
 1	[1, 2, 3]	3
 2	[4]	4
 
-query II rowsort
+query II
 WITH t AS (
 	SELECT 1 AS r, ARRAY[1, 2, 3] AS a
 	UNION SELECT 2 AS r, ARRAY[4] AS a
@@ -84,7 +84,7 @@ ORDER BY r, a.value
 1	3
 2	4
 
-query II rowsort
+query II
 WITH t AS (
 	SELECT 1 AS r, ARRAY[1, 2, 3] AS a
 	UNION SELECT 2 AS r, ARRAY[4] AS a
@@ -104,7 +104,7 @@ CREATE TABLE t AS SELECT 5 AS r, ARRAY[1, 2, 3] AS a;
 statement ok
 INSERT INTO t VALUES (6, [4]), (7, NULL);
 
-query II rowsort
+query II
 SELECT r, a.value
 FROM t, UNNEST(a) AS a(value)
 ORDER BY r, a.value
@@ -114,7 +114,7 @@ ORDER BY r, a.value
 5	3
 6	4
 
-query II rowsort
+query II
 WITH t AS (
 	SELECT 5 AS r, ARRAY[1, 2, 3] AS a
 	UNION SELECT 6 AS r, ARRAY[4] AS a


### PR DESCRIPTION
Materialized CTEs did sometimes create the incorrect `OrderPreservationType`. This is because `OrderPreservationRecursive` tried to take the materialization phase into account, which should not be done.

Fixes https://github.com/duckdb/duckdb/pull/10576, reverts and fixes https://github.com/duckdb/duckdb/pull/10560.

The tests will likely fail, however, because this revealed another—unrelated—bug:

`test/sql/function/list/list_reverse.test`

```
WITH example AS (
  SELECT [1, 2, 3] AS arr UNION ALL
  SELECT [4, 5] AS arr UNION ALL
  SELECT [] AS arr
)
SELECT
  list_reverse(arr) AS reverse_arr
FROM example ORDER BY length(reverse_arr) DESC;
```

```
Invalid Error: Unoptimized statement differs from original result!
Original Result:
reverse_arr
INTEGER[]
[ Rows: 3]
[3, 2, 1]
[5, 4]
[]

Unoptimized:
reverse_arr
INTEGER[]
[ Rows: 3]
[1, 2, 3]
[4, 5]
[]
```