### PR TITLE
[CSV Reader] [Bug Fix] Make CSV Results hold the buffers they depend on

### DIFF
--- a/src/execution/operator/csv_scanner/buffer_manager/csv_buffer.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_buffer.cpp
@@ -65,7 +65,7 @@ void CSVBuffer::Reload(CSVFileHandle &file_handle) {
 	file_handle.Read(handle.Ptr(), actual_buffer_size);
 }
 
-unique_ptr<CSVBufferHandle> CSVBuffer::Pin(CSVFileHandle &file_handle, bool &has_seeked) {
+shared_ptr<CSVBufferHandle> CSVBuffer::Pin(CSVFileHandle &file_handle, bool &has_seeked) {
 	auto &buffer_manager = BufferManager::GetBufferManager(context);
 	if (can_seek && block->IsUnloaded()) {
 		// We have to reload it from disk
@@ -73,8 +73,8 @@ unique_ptr<CSVBufferHandle> CSVBuffer::Pin(CSVFileHandle &file_handle, bool &has
 		Reload(file_handle);
 		has_seeked = true;
 	}
-	return make_uniq<CSVBufferHandle>(buffer_manager.Pin(block), actual_buffer_size, last_buffer, file_number,
-	                                  buffer_idx);
+	return make_shared<CSVBufferHandle>(buffer_manager.Pin(block), actual_buffer_size, last_buffer, file_number,
+	                                    buffer_idx);
 }
 
 void CSVBuffer::Unpin() {

--- a/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
@@ -61,7 +61,7 @@ bool CSVBufferManager::ReadNextAndCacheIt() {
 	return false;
 }
 
-unique_ptr<CSVBufferHandle> CSVBufferManager::GetBuffer(const idx_t pos) {
+shared_ptr<CSVBufferHandle> CSVBufferManager::GetBuffer(const idx_t pos) {
 	lock_guard<mutex> parallel_lock(main_mutex);
 	while (pos >= cached_buffers.size()) {
 		if (done) {

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -10,7 +10,7 @@
 namespace duckdb {
 
 StringValueResult::StringValueResult(CSVStates &states, CSVStateMachine &state_machine,
-                                     shared_ptr<CSVBufferHandle> buffer_handle, Allocator &buffer_allocator,
+                                     const shared_ptr<CSVBufferHandle> &buffer_handle, Allocator &buffer_allocator,
                                      idx_t result_size_p, idx_t buffer_position, CSVErrorHandler &error_hander_p,
                                      CSVIterator &iterator_p, bool store_line_size_p,
                                      shared_ptr<CSVFileScan> csv_file_scan_p, idx_t &lines_read_p)

--- a/src/include/duckdb/execution/operator/csv_scanner/buffer_manager/csv_buffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/buffer_manager/csv_buffer.hpp
@@ -65,7 +65,7 @@ public:
 	void Reload(CSVFileHandle &file_handle);
 	//! Wrapper for the Pin Function, if it can seek, it means that the buffer might have been destroyed, hence we must
 	//! Scan it from the disk file again.
-	unique_ptr<CSVBufferHandle> Pin(CSVFileHandle &file_handle, bool &has_seeked);
+	shared_ptr<CSVBufferHandle> Pin(CSVFileHandle &file_handle, bool &has_seeked);
 	//! Wrapper for the unpin
 	void Unpin();
 	char *Ptr() {

--- a/src/include/duckdb/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.hpp
@@ -25,7 +25,7 @@ public:
 	                 const idx_t file_idx);
 	//! Returns a buffer from a buffer id (starting from 0). If it's in the auto-detection then we cache new buffers
 	//! Otherwise we remove them from the cache if they are already there, or just return them bypassing the cache.
-	unique_ptr<CSVBufferHandle> GetBuffer(const idx_t buffer_idx);
+	shared_ptr<CSVBufferHandle> GetBuffer(const idx_t buffer_idx);
 
 	void ResetBuffer(const idx_t buffer_idx);
 	//! unique_ptr to the file handle, gets stolen after sniffing

--- a/src/include/duckdb/execution/operator/csv_scanner/scanner/base_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/scanner/base_scanner.hpp
@@ -95,7 +95,7 @@ protected:
 
 	//! Unique pointer to the buffer_handle, this is unique per scanner, since it also contains the necessary counters
 	//! To offload buffers to disk if necessary
-	unique_ptr<CSVBufferHandle> cur_buffer_handle;
+	shared_ptr<CSVBufferHandle> cur_buffer_handle;
 
 	//! Hold the current buffer ptr
 	char *buffer_handle_ptr = nullptr;

--- a/src/include/duckdb/execution/operator/csv_scanner/scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/scanner/string_value_scanner.hpp
@@ -49,7 +49,7 @@ public:
 
 class StringValueResult : public ScannerResult {
 public:
-	StringValueResult(CSVStates &states, CSVStateMachine &state_machine, CSVBufferHandle &buffer_handle,
+	StringValueResult(CSVStates &states, CSVStateMachine &state_machine, shared_ptr<CSVBufferHandle> buffer_handle,
 	                  Allocator &buffer_allocator, idx_t result_size, idx_t buffer_position,
 	                  CSVErrorHandler &error_hander, CSVIterator &iterator, bool store_line_size,
 	                  shared_ptr<CSVFileScan> csv_file_scan, idx_t &lines_read);
@@ -95,6 +95,9 @@ public:
 	unsafe_unique_array<bool> projected_columns;
 	bool projecting_columns = false;
 	idx_t chunk_col_id = 0;
+
+	//! We must ensure that we keep the buffers alive until processing the query result
+	vector<shared_ptr<CSVBufferHandle>> buffer_handles;
 
 	//! If the current row has an error, we have to skip it
 	bool ignore_current_row = false;
@@ -185,7 +188,7 @@ private:
 	vector<LogicalType> types;
 
 	//! Pointer to the previous buffer handle, necessary for overbuffer values
-	unique_ptr<CSVBufferHandle> previous_buffer_handle;
+	shared_ptr<CSVBufferHandle> previous_buffer_handle;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/csv_scanner/scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/scanner/string_value_scanner.hpp
@@ -123,6 +123,9 @@ public:
 	Value GetValue(idx_t row_idx, idx_t col_idx);
 
 	DataChunk &ToChunk();
+
+	//! Resets the state of the result
+	void Reset();
 };
 
 //! Our dialect scanner basically goes over the CSV and actually parses the values to a DuckDB vector of string_t

--- a/src/include/duckdb/execution/operator/csv_scanner/scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/scanner/string_value_scanner.hpp
@@ -49,9 +49,9 @@ public:
 
 class StringValueResult : public ScannerResult {
 public:
-	StringValueResult(CSVStates &states, CSVStateMachine &state_machine, shared_ptr<CSVBufferHandle> buffer_handle,
-	                  Allocator &buffer_allocator, idx_t result_size, idx_t buffer_position,
-	                  CSVErrorHandler &error_hander, CSVIterator &iterator, bool store_line_size,
+	StringValueResult(CSVStates &states, CSVStateMachine &state_machine,
+	                  const shared_ptr<CSVBufferHandle> &buffer_handle, Allocator &buffer_allocator, idx_t result_size,
+	                  idx_t buffer_position, CSVErrorHandler &error_hander, CSVIterator &iterator, bool store_line_size,
 	                  shared_ptr<CSVFileScan> csv_file_scan, idx_t &lines_read);
 
 	//! Information on the vector


### PR DESCRIPTION
This solves an issue found by the nightly CI with the ` -DDISABLE_STR_INLINE=1 -DDESTROY_UNPINNED_BLOCKS=1 ` flags on.

Basically, on tests where we defined a `buffer_size`, query results could depend on more than two buffers. Because strings are not inlined and blocks would be unpinned, these would result in queries reading junk pieces of memory.

This PR makes them hold the buffers they depend on.

I've also created a method to reset the `StringValueResult` states.