### PR TITLE
minor secret manager fix

### DIFF
--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -34,6 +34,7 @@ DBConfig::DBConfig() {
 	cast_functions = make_uniq<CastFunctionSet>(*this);
 	index_types = make_uniq<IndexTypeSet>();
 	error_manager = make_uniq<ErrorManager>();
+	secret_manager = make_uniq<SecretManager>();
 }
 
 DBConfig::DBConfig(bool read_only) : DBConfig::DBConfig() {
@@ -328,8 +329,6 @@ void DatabaseInstance::Configure(DBConfig &new_config) {
 	}
 	if (new_config.secret_manager) {
 		config.secret_manager = std::move(new_config.secret_manager);
-	} else {
-		config.secret_manager = make_uniq<SecretManager>();
 	}
 	if (config.options.maximum_memory == (idx_t)-1) {
 		config.SetDefaultMaxMemory();

--- a/test/secrets/test_custom_secret_storage.cpp
+++ b/test/secrets/test_custom_secret_storage.cpp
@@ -118,6 +118,10 @@ TEST_CASE("Test adding a custom secret storage", "[secret][.]") {
 
 	REQUIRE_NO_FAIL(con.Query("set allow_persistent_secrets=true;"));
 
+	// Set custom secret path to prevent interference with other tests
+	auto secret_dir = TestCreatePath("custom_secret_storage_cpp_1");
+	REQUIRE_NO_FAIL(con.Query("set secret_directory='" + secret_dir + "'"));
+
 	REQUIRE_NO_FAIL(con.Query("CREATE SECRET s1 IN TEST_STORAGE (TYPE S3, SCOPE 's3://foo')"));
 	REQUIRE_NO_FAIL(con.Query("CREATE PERSISTENT SECRET s2 IN test_storage (TYPE S3, SCOPE 's3://')"));
 	REQUIRE_NO_FAIL(con.Query("CREATE TEMPORARY SECRET s2 (TYPE S3, SCOPE 's3://')"));
@@ -187,6 +191,10 @@ TEST_CASE("Test tie-break behaviour for custom secret storage", "[secret][.]") {
 	TestSecretLog log2;
 
 	REQUIRE_NO_FAIL(con.Query("set allow_persistent_secrets=true;"));
+
+	// Set custom secret path to prevent interference with other tests
+	auto secret_dir = TestCreatePath("custom_secret_storage_cpp_2");
+	REQUIRE_NO_FAIL(con.Query("set secret_directory='" + secret_dir + "'"));
 
 	// Register custom secret storage
 	auto &secret_manager = duckdb::SecretManager::Get(*db.instance);

--- a/test/sql/secrets/create_secret_storage_backends.test
+++ b/test/sql/secrets/create_secret_storage_backends.test
@@ -16,18 +16,18 @@ set allow_persistent_secrets=false;
 statement error
 CREATE TEMPORARY SECRET s1 IN LOCAL_FILE ( TYPE S3 )
 ----
-Cannot create temporary secrets in a persistent secret storage!
+Invalid Input Error: Persistent secrets are disabled. Restart DuckDB and enable persistent secrets through 'SET allow_persistent_secrets=true'
 
 statement error
 CREATE PERSISTENT SECRET s1 IN NON_EXISTENT_SECRET_STORAGE ( TYPE S3 )
 ----
-Secret storage 'non_existent_secret_storage' not found!
+Invalid Input Error: Persistent secrets are disabled. Restart DuckDB and enable persistent secrets through 'SET allow_persistent_secrets=true'
 
 # We have disabled the permanent secrets, so this should fail
 statement error
 CREATE PERSISTENT SECRET perm_s1 ( TYPE S3 )
 ----
-Persistent secrets are currently disabled. To enable them, restart duckdb and run 'SET allow_persistent_secrets=true'
+Invalid Input Error: Persistent secrets are disabled. Restart DuckDB and enable persistent secrets through 'SET allow_persistent_secrets=true'
 
 restart
 

--- a/tools/pythonpkg/tests/fast/api/test_config.py
+++ b/tools/pythonpkg/tests/fast/api/test_config.py
@@ -74,3 +74,8 @@ class TestDBConfig(object):
         assert regex.match(con_regular.sql("PRAGMA user_agent").fetchone()[0]) is not None
         custom_user_agent = con_regular.sql("SELECT current_setting('custom_user_agent')").fetchone()
         assert custom_user_agent[0] == 'CUSTOM_STRING'
+
+    def test_secret_manager_option(self, duckdb_cursor):
+        con = duckdb.connect(':memory:', config={'allow_persistent_secrets': False})
+        result = con.execute('select count(*) from duckdb_secrets()').fetchall()
+        assert result == [(0,)]


### PR DESCRIPTION
Fixes 2 issues:
- The setting enable_persistent_secrets would not actually disable persistent secrets in all cases
- setting secret manager configuration through python would throw an error:
```
import duckdb
duckdb.connect(config={'allow_persistent_secrets': True})
InternalException: INTERNAL Error: Attempted to dereference unique_ptr that is NULL!`
```