### PR TITLE
[Julia] Remove `DataFrame` from Project.toml

### DIFF
--- a/tools/juliapkg/Project.toml
+++ b/tools/juliapkg/Project.toml
@@ -5,7 +5,6 @@ version = "0.9.2"
 
 [deps]
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DuckDB_jll = "2cbbab25-fc8b-58cf-88d4-687a02676033"
 FixedPointDecimals = "fb4d412d-6eee-574d-9565-ede6634db7b0"


### PR DESCRIPTION
The `DataFrame` dependency was explicitly removed a while back, recent PR accidentally added it back in.