### PR TITLE
Fix for SQL value functions when there is an alias specified

### DIFF
--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -423,7 +423,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 	if (!expr) {
 		if (!col_ref_p.IsQualified()) {
 			// column was not found - check if it is a SQL value function
-			auto value_function = GetSQLValueFunction(col_ref_p.GetName());
+			auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
 			if (value_function) {
 				return BindExpression(value_function, depth);
 			}

--- a/test/sql/function/timestamp/current_time.test
+++ b/test/sql/function/timestamp/current_time.test
@@ -42,3 +42,9 @@ SELECT typeof(${func}());
 TIMESTAMP WITH TIME ZONE
 
 endloop
+
+statement ok
+SELECT CURRENT_TIME AS TIME
+
+statement ok
+SELECT CURRENT_TIME + interval (1) second AS TIME


### PR DESCRIPTION
Fixes an issue where the query `SELECT CURRENT_TIME AS TIME` did not work correctly