### PR TITLE
Parallelize format.py script

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -411,6 +411,7 @@ def format_directory(directory):
     for thread in threads:
         thread.join()
 
+
 if format_all:
     try:
         os.system(cmake_format_command.replace("${FILE}", "CMakeLists.txt"))

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -9,7 +9,7 @@ import inspect
 import subprocess
 import difflib
 import re
-import threading
+import concurrent.futures
 from python_helpers import open_utf8
 
 try:
@@ -401,15 +401,10 @@ def format_directory(directory):
             format_file(f, full_path, directory, '.' + f.split('.')[-1])
 
     # Create thread for each file
-    threads = []
-    for f in files:
-        thread = threading.Thread(target=process_file, args=(f,))
-        thread.start()
-        threads.append(thread)
-
-    # Wait for all threads to finish
-    for thread in threads:
-        thread.join()
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        threads = [executor.submit(process_file, f) for f in files]
+        # Wait for all tasks to complete
+        concurrent.futures.wait(threads)
 
 
 if format_all:


### PR DESCRIPTION
Start a thread for each file and do the check on the files in parallel.

Reducing the time needed to run make format-check and make format-fix