### PR TITLE
Catch: prominently display skipped tests

### DIFF
--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -57,6 +57,8 @@ return_code = 0
 
 def parse_assertions(stdout):
     for line in stdout.splitlines():
+        if 'All tests were skipped' in line:
+            return "SKIPPED"
         if line == 'assertions: - none -':
             return "0 assertions"
 

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -642,6 +642,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 					// This extension / setting was explicitly required
 					parser.Fail(StringUtil::Format("require %s: FAILED", param));
 				}
+				SKIP_TEST("require " + token.parameters[0]);
 				return;
 			}
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_REQUIRE_ENV) {
@@ -657,6 +658,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 			auto env_actual = std::getenv(env_var.c_str());
 			if (env_actual == nullptr) {
 				// Environment variable was not found, this test should not be run
+				SKIP_TEST("require-env " + token.parameters[0]);
 				return;
 			}
 
@@ -665,6 +667,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 				auto env_value = token.parameters[1];
 				if (std::strcmp(env_actual, env_value.c_str()) != 0) {
 					// It's not, check the test
+					SKIP_TEST("require-env " + token.parameters[0] + " " + token.parameters[1]);
 					return;
 				}
 			}

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -16857,9 +16857,9 @@ void ConsoleReporter::printTotals( Totals const& totals ) {
         columns.push_back(SummaryColumn("failed", Colour::ResultError)
                           .addRow(totals.testCases.failed)
                           .addRow(totals.assertions.failed));
-        columns.push_back(SummaryColumn("failed as expected", Colour::ResultExpectedFailure)
-                          .addRow(totals.testCases.failedButOk)
-                          .addRow(totals.assertions.failedButOk));
+        columns.push_back(SummaryColumn("skipped", Colour::ResultExpectedFailure)
+                          .addRow(totals.testCases.failedButOk + totals.skippedTests)
+                          .addRow(totals.assertions.failedButOk + totals.skippedTests));
 
         printSummaryRow("test cases", columns, 0);
         printSummaryRow("assertions", columns, 1);


### PR DESCRIPTION
This PR adds the `SKIP_TEST` command to Catch, and displays whether or not tests have been skipped. This should help prevent tests from being skipped accidentally, and allow us to more easily catch skipped tests in the CI.


All tests are skipped:
```
$ > build/reldebug/test/unittest test/sql/skiptest/test_skip.test 
[1/1] (100%): test/sql/skiptest/test_skip.test                                  
===============================================================================
All tests were skipped (total skipped 1)

Skipped tests for the following reasons:
require httpfs: 1
```

Tests are partially skipped:

```
$ > build/reldebug/test/unittest test/sql/skiptest/*
[2/2] (100%): test/sql/skiptest/test_not_skipped.test                           
===============================================================================
All tests passed (1 skipped test, 1 assertion in 1 test case)

Skipped tests for the following reasons:
require httpfs: 1
```

Fast unit tests on my macbook now:

```
$ > build/reldebug/test/unittest
[2891/2891] (100%): test/sql/table_function/icu_range_timestamptz.test          
===============================================================================
All tests passed (69 skipped tests, 381167 assertions in 2822 test cases)

Skipped tests for the following reasons:
require block_size: 3
require exact_vector_size: 1
require excel: 1
require fts: 6
require httpfs: 45
require longdouble: 2
require not_available: 1
require windows: 3
require-env LOCAL_EXTENSION_REPO: 7
```

`run_tests_one_by_one.py`

```
$ > python3 scripts/run_tests_one_by_one.py build/debug/test/unittest "test/sql/skiptest/*"          
[0/2]: test/sql/skiptest/test_skip.test (SKIPPED)
[1/2]: test/sql/skiptest/test_not_skipped.test (1 assertion )
```