### PR TITLE
Revamp duckdb-wasm extensions CI

### DIFF
--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
     inputs:
       # Git ref of the duckdb repo
-      duckdb-ref:
+      duckdb_ref:
         required: true
         type: string
       # Publish extensions on extensions.duckdb.org?
       release_s3:
-        required: false
+        required: true
         type: boolean
         default: false
 
@@ -16,25 +16,30 @@ env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
-  build_and_publish:
-    name: Build and publish
+  build_wasm:
+    name: Build extensions
     runs-on: ubuntu-latest
     strategy:
       matrix:
         duckdb_wasm_arch: [ 'mvp', 'eh', 'threads' ]
     env:
-      GEN: Ninja
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       DUCKDB_PLATFORM: "wasm_${{ matrix.duckdb_wasm_arch }}"
 
     steps:
             - uses: actions/checkout@v3
               with:
+                  ref: ${{ inputs.duckdb_ref }}
                   fetch-depth: 0
 
             - uses: mymindstorm/setup-emsdk@v12
               with:
                   version: 'latest'
+
+            - name: Install
+              shell: bash
+              run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
             - name: Setup vcpkg
               uses: lukka/run-vcpkg@v11.1
               with:
@@ -45,33 +50,69 @@ jobs:
               with:
                   key: ${{ github.job }}-${{ matrix.duckdb_wasm_arch }}
 
-            - name: Build Wasm module
+            - name: Build Wasm module MVP
+              if: ${{ matrix.duckdb_wasm_arch == 'mvp' }}
               run: |
-                  curl https://raw.githubusercontent.com/duckdb/duckdb-wasm/main/.github/config/extension_config_wasm.cmake -o extension/extension_config.cmake
-                  make ${{ env.DUCKDB_PLATFORM }}
+                mkdir -p ./build/wasm_mvp
+                emcmake cmake -G "Ninja" -DWASM_LOADABLE_EXTENSIONS=1 -DBUILD_EXTENSIONS_ONLY=1 -Bbuild/wasm_mvp -DCMAKE_CXX_FLAGS="-DDUCKDB_CUSTOM_PLATFORM=wasm_mvp" -DDUCKDB_EXPLICIT_PLATFORM=wasm_mvp -DLOCAL_EXTENSION_REPO='build/to_be_deployed' -DDUCKDB_EXTENSION_CONFIGS=".github/config/in_tree_extensions.cmake" -DSKIP_EXTENSIONS="httpfs"
+                emmake ninja -j8 -Cbuild/wasm_mvp
+
+            - name: Build Wasm module EH
+              if: ${{ matrix.duckdb_wasm_arch == 'eh' }}
+              run: |
+                mkdir -p ./build/wasm_eh
+                emcmake cmake -G "Ninja" -DWASM_LOADABLE_EXTENSIONS=1 -DBUILD_EXTENSIONS_ONLY=1 -Bbuild/wasm_eh -DCMAKE_CXX_FLAGS="-fwasm-exceptions -DWEBDB_FAST_EXCEPTIONS=1 -DDUCKDB_CUSTOM_PLATFORM=wasm_eh" -DDUCKDB_EXPLICIT_PLATFORM=wasm_eh -DLOCAL_EXTENSION_REPO='build/to_be_deployed' -DDUCKDB_EXTENSION_CONFIGS=".github/config/in_tree_extensions.cmake" -DSKIP_EXTENSIONS="httpfs"
+                emmake ninja -j8 -Cbuild/wasm_eh
+
+            - name: Build Wasm module THREADS
+              if: ${{ matrix.duckdb_wasm_arch == 'threads' }}
+              run: |
+                mkdir -p ./build/wasm_threads
+                emcmake cmake -G "Ninja" -DWASM_LOADABLE_EXTENSIONS=1 -DBUILD_EXTENSIONS_ONLY=1 -Bbuild/wasm_threads -DCMAKE_CXX_FLAGS="-fwasm-exceptions -DWEBDB_FAST_EXCEPTIONS=1 -DWITH_WASM_THREADS=1 -DWITH_WASM_SIMD=1 -DWITH_WASM_BULK_MEMORY=1 -DDUCKDB_CUSTOM_PLATFORM=wasm_threads" -DDUCKDB_EXPLICIT_PLATFORM=wasm_threads -DLOCAL_EXTENSION_REPO='build/to_be_deployed' -DDUCKDB_EXTENSION_CONFIGS=".github/config/in_tree_extensions.cmake" -DSKIP_EXTENSIONS="httpfs"
+                emmake ninja -j8 -Cbuild/wasm_threads
+
+            - name: Upload artifact
+              uses: actions/upload-artifact@v3
+              with:
+                  name: duckdb_extensions_${{ env.DUCKDB_PLATFORM }}
+                  path: build/to_be_deployed/${{ inputs.duckdb_ref }}/${{ env.DUCKDB_PLATFORM }}
+                  retention-days: 1
+
+  publish:
+    name: Publish extensions
+    runs-on: ubuntu-latest
+    needs:
+    - build_wasm
+    strategy:
+      matrix:
+        duckdb_arch: [ 'wasm_mvp', 'wasm_eh', 'wasm_threads' ]
+    steps:
+            - uses: actions/checkout@v3
+
+            - uses: actions/download-artifact@v3
+              with:
+                name: duckdb_extensions_${{ matrix.duckdb_arch }}
+                path: build/to_be_deployed/${{ inputs.duckdb_ref }}/${{ matrix.duckdb_arch }}
+
+            - uses: actions/setup-python@v4
+              with:
+                python-version: '3.12'
+
+            - name: Install aws
+              run: |
+                  pip install awscli
 
             - name: Sign and deploy Wasm extensions
-              if: ${{ github.event.inputs.release_s3 }}
+              if: ${{ ! inputs.release_s3 }}
+              run: |
+                  bash ./scripts/extension-upload-wasm.sh ${{ matrix.duckdb_arch }} ${{ inputs.duckdb_ref }}
+
+            - name: Sign and deploy Wasm extensions
+              if: ${{ inputs.release_s3 }}
               env:
                   AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
                   AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
                   AWS_DEFAULT_REGION: us-east-1
                   DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
               run: |
-                  bash ./scripts/extension-upload-wasm.sh ${{ env.DUCKDB_PLATFORM }} ${{ github.event.inputs.duckdb-ref }}
-
-            - name: Upload artifact
-              uses: actions/upload-artifact@v3
-              with:
-                  name: duckdb-wasm-${{ matrix.duckdb_wasm_arch }}
-                  path: build/${{ env.DUCKDB_PLATFORM }}/built_extensions
-                  retention-days: 1
-
-  trigger_github_pages_build:
-    name: Trigger follow-up work
-    runs-on: ubuntu-latest
-    needs: build_and_publish
-    steps:
-            - name: Move control to duckdb-wasm
-              run: |
-                  curl -XPOST -u "${{secrets.PAT_USER}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/duckdb/duckdb-wasm/actions/workflows/main.yml/dispatches --data '{"ref":"${{ github.event.inputs.duckdb-wasm-ref}}"}'
+                  bash ./scripts/extension-upload-wasm.sh ${{ env.DUCKDB_PLATFORM }} ${{ inputs.duckdb_ref }}

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -102,12 +102,12 @@ jobs:
               run: |
                   pip install awscli
 
-            - name: Sign and deploy Wasm extensions
+            - name: Sign and deploy Wasm extensions (no credentials)
               if: ${{ ! inputs.release_s3 }}
               run: |
                   bash ./scripts/extension-upload-wasm.sh ${{ matrix.duckdb_arch }} ${{ inputs.duckdb_ref }}
 
-            - name: Sign and deploy Wasm extensions
+            - name: Sign and deploy Wasm extensions (with credentials)
               if: ${{ inputs.release_s3 }}
               env:
                   AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -115,4 +115,4 @@ jobs:
                   AWS_DEFAULT_REGION: us-east-1
                   DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
               run: |
-                  bash ./scripts/extension-upload-wasm.sh ${{ env.DUCKDB_PLATFORM }} ${{ inputs.duckdb_ref }}
+                  bash ./scripts/extension-upload-wasm.sh ${{ matrix.duckdb_arch }} ${{ inputs.duckdb_ref }}

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -68,9 +68,7 @@ jobs:
 
       - id: parse-matrices
         run: |
-          cat ./duckdb/.github/config/distribution_matrix.json > distribution_matrix.json
-          grep wasm distribution_matrix.json || (head -n -1 ./duckdb/.github/config/distribution_matrix.json > distribution_matrix.json && echo ',"wasm":{"include":[{"duckdb_arch":"wasm_mvp","vcpkg_triplet":"wasm32-emscripten"},{"duckdb_arch":"wasm_eh","vcpkg_triplet":"wasm32-emscripten"},{"duckdb_arch":"wasm_threads","vcpkg_triplet":"wasm32-emscripten"}]}}' >> distribution_matrix.json)
-          python3 ${{ inputs.matrix_parse_script }} --input distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input ./ducdkb/.github/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
           deploy_matrix="`cat deploy_matrix.json`"
           echo deploy_matrix=$deploy_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`

--- a/scripts/extension-upload-single.sh
+++ b/scripts/extension-upload-single.sh
@@ -99,7 +99,7 @@ if [[ $7 = 'true' ]]; then
   fi
 
   if [[ $4 == wasm* ]]; then
-    aws s3 cp $ext.compressed s3://$5/duckdb-wasm/$1/$2/duckdb-wasm/$3/$4/$1.duckdb_extension.wasm $DRY_RUN_PARAM --acl public-read --content-encoding br --content-type="application/wasm"
+    aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.wasm $DRY_RUN_PARAM --acl public-read --content-encoding br --content-type="application/wasm"
   else
     aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.gz $DRY_RUN_PARAM --acl public-read
   fi
@@ -108,7 +108,7 @@ fi
 # upload to latest version
 if [[ $6 = 'true' ]]; then
   if [[ $4 == wasm* ]]; then
-    aws s3 cp $ext.compressed s3://$5/duckdb-wasm/$3/$4/$1.duckdb_extension.wasm $DRY_RUN_PARAM --acl public-read --content-encoding br --content-type="application/wasm"
+    aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.wasm $DRY_RUN_PARAM --acl public-read --content-encoding br --content-type="application/wasm"
   else
     aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.gz $DRY_RUN_PARAM --acl public-read
   fi

--- a/scripts/extension-upload-wasm.sh
+++ b/scripts/extension-upload-wasm.sh
@@ -2,17 +2,18 @@
 
 # Usage: ./extension-upload-wasm.sh <architecture> <commithash or version_tag>
 
-# The directory that the script lives in, thanks @Tishj
-script_dir="$(dirname "$(readlink -f "$0")")"
-
 set -e
 
 # Ensure we do nothing on failed globs
 shopt -s nullglob
 
-echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
+if [[ -z "${DUCKDB_EXTENSION_SIGNING_PK}" ]]; then
+	cp test/mbedtls/private.pem private.pem
+else
+	echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
+fi
 
-FILES="build/$1/built_extensions/*.duckdb_extension.wasm"
+FILES="build/to_be_deployed/$2/$1/*.duckdb_extension.wasm"
 for f in $FILES
 do
         ext=`basename $f .duckdb_extension.wasm`
@@ -33,7 +34,7 @@ do
         # for a grand total of 2 bytes
         echo -n -e '\x80\x02' >> $f.append
         # the actual payload, 256 bytes, to be added later
-        $script_dir/compute-extension-hash.sh $f.append > $f.hash
+        scripts/compute-extension-hash.sh $f.append > $f.hash
         # encrypt hash with extension signing private key to create signature
         openssl pkeyutl -sign -in $f.hash -inkey private.pem -pkeyopt digest:sha256 -out $f.sign
         # append signature to extension binary
@@ -41,8 +42,12 @@ do
         # compress extension binary
         brotli < $f.append > "$f.brotli"
         # upload compressed extension binary to S3
-        aws s3 cp $f.brotli s3://duckdb-extensions/duckdb-wasm/$2/$1/$ext.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+	if [[ -z "${AWS_SECRET_ACCESS_KEY}" ]]; then
+		#AWS_SECRET_ACCESS_KEY is empty -> dry run
+		aws s3 cp $f.brotli s3://duckdb-extensions/$2/$1/$ext.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm" --dryrun
+	else
+		aws s3 cp $f.brotli s3://duckdb-extensions/$2/$1/$ext.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+	fi
 done
 
 rm private.pem
-

--- a/scripts/extension-upload-wasm.sh
+++ b/scripts/extension-upload-wasm.sh
@@ -8,8 +8,13 @@ set -e
 shopt -s nullglob
 
 if [[ -z "${DUCKDB_EXTENSION_SIGNING_PK}" ]]; then
+	# no private key provided, use the test private key (NOT SAFE)
+	# this is made so private.pem at the end of the block will be in
+	# a valid state, and the rest of the signing process can be tested
+	# even without providing the key
 	cp test/mbedtls/private.pem private.pem
 else
+	# actual private key provided
 	echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
 fi
 
@@ -50,4 +55,5 @@ do
 	fi
 done
 
+# remove private key
 rm private.pem


### PR DESCRIPTION
CI on this PR is not actually checking anything, given the changed files are never invoked.

More proper test for this workflow is as follow:
 * set this branch as main for a fork (I have done it temporarily for https://github/carlopi/duckdb)
 * invoke the "DuckDB-Wasm Extensions" workflow (via WebUI or gh cli) on the fork, passing as parameters  {'duckdb_ref' : 'v0.10.0', 's3_release' : false} (successful test run here: https://github.com/carlopi/duckdb/actions/runs/7912968453)
 here I would expect it should succeed, building the extensions, signing them with a fake key, setting up aws, and invoking aws s3 cp with --dryrun
Sample of the log will be like (based on a past run):
```
autocomplete
(dryrun) upload: build/to_be_deployed/v0.10.0/wasm_eh/autocomplete.duckdb_extension.wasm.brotli to s3://duckdb-extensions/v0.10.0/wasm_eh/autocomplete.duckdb_extension.wasm
excel
(dryrun) upload: build/to_be_deployed/v0.10.0/wasm_eh/excel.duckdb_extension.wasm.brotli to s3://duckdb-extensions/v0.10.0/wasm_eh/excel.duckdb_extension.wasm
fts
(dryrun) upload: build/to_be_deployed/v0.10.0/wasm_eh/fts.duckdb_extension.wasm.brotli to s3://duckdb-extensions/v0.10.0/wasm_eh/fts.duckdb_extension.wasm
icu
(dryrun) upload: build/to_be_deployed/v0.10.0/wasm_eh/icu.duckdb_extension.wasm.brotli to s3://duckdb-extensions/v0.10.0/wasm_eh/icu.duckdb_extension.wasm
----
```
 * invoke the "DuckDB-Wasm Extensions" workflow (via WebUI or gh cli) on the fork, passing as parameters  {'duckdb_ref' : 'v0.10.0', 's3_release' : true} (run is currently in flight here: https://github.com/carlopi/duckdb/actions/runs/7913085453)
This should (if AWS variable are properly inherited from the environment) upload the extensions, otherwise fall back to --dryrun. Please double check you have AWS keys enabled in your repository if you want to try this.

s3_release set to false is not uploading nor signing anything, so it can be safely invoked also also on the duckdb/duckdb repo as an additional test AFTER merging this into main (before that this workflow is present in a older version performing an outdated logic).

My idea is that this PR can be reviewed, eventually merged, and then when it lands on main the workflow can be invoked first passing {'duckdb_ref' : 'v0.10.0', 's3_release' : false} checking the resulting paths make sense / stuff has not exploded, and then invoking it properly passing {'duckdb_ref' : 'v0.10.0', 's3_release' : true}.

Artifacts build during the first step are available after completion in the Summary page: https://github.com/carlopi/duckdb/actions/runs/7912968453.