### PR TITLE
[CI] Re-enable skipped test `window-rows-overflow.test`

### DIFF
--- a/test/fuzzer/sqlsmith/window-rows-overflow.test
+++ b/test/fuzzer/sqlsmith/window-rows-overflow.test
@@ -2,11 +2,6 @@
 # description: Overflow testing for rows offsets.
 # group: [sqlsmith]
 
-# Query failed, but error message did not match expected error message:
-#     Out of Range Error: Overflow computing ROWS PRECEDING start (test/fuzzer/sqlsmith/window-rows-overflow.test:14)!
-# Skipping for now since it's causing non-deterministic failures on CI
-mode skip
-
 statement ok
 create table all_types as 
 	select * exclude(
@@ -17,7 +12,7 @@ create table all_types as
 from test_all_types();
 
 statement error
-SELECT nth_value(1929, "array_of_structs") OVER (
+SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
 	), 747 ROWS BETWEEN "bigint" PRECEDING AND CURRENT ROW
@@ -27,7 +22,7 @@ FROM all_types;
 Out of Range Error: Overflow computing ROWS PRECEDING start
 
 statement error
-SELECT nth_value(1929, "bool") OVER (
+SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
 	), 747 ROWS BETWEEN 1 PRECEDING AND "bigint" PRECEDING
@@ -37,7 +32,7 @@ FROM all_types;
 Out of Range Error: Overflow computing ROWS PRECEDING end
 
 statement error
-SELECT nth_value(1929, "bool") OVER (
+SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
 	), 747 ROWS BETWEEN "bigint" FOLLOWING AND 1 FOLLOWING
@@ -47,7 +42,7 @@ FROM all_types;
 Out of Range Error: Overflow computing ROWS FOLLOWING start
 
 statement error
-SELECT nth_value(1929, "bool") OVER (
+SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
 	), 747 ROWS BETWEEN CURRENT ROW AND "bigint" FOLLOWING


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/114

The query originates from a fuzzer, so it's very abstract
It actually contained two errors and that was causing a race as to which error would be bubbled up to the surface

We have now removed the noise.