### PR TITLE
DISTINCT ON - greatly improve performance by rewriting ordered FIRST aggregate into arg_min_null

### DIFF
--- a/benchmark/tpch/aggregate/lineitem_distinct_on_few_groups.benchmark
+++ b/benchmark/tpch/aggregate/lineitem_distinct_on_few_groups.benchmark
@@ -1,0 +1,69 @@
+# name: benchmark/tpch/aggregate/lineitem_distinct_on.benchmark
+# description: DISTINCT ON over Lineitem
+# group: [aggregate]
+
+name Lineitem Distinct On (Few Groups)
+group aggregate
+subgroup tpch
+
+require tpch
+
+cache tpch_sf1.duckdb
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT DISTINCT ON (l_quantity) l_quantity, l_extendedprice FROM lineitem ORDER BY l_quantity, l_extendedprice DESC;
+
+result II
+1	2097.99
+2	4193.98
+3	6293.97
+4	8395.96
+5	10489.95
+6	12587.94
+7	14685.93
+8	16791.92
+9	18890.91
+10	20989.9
+11	23055.89
+12	25175.88
+13	27260.87
+14	29357.86
+15	31469.85
+16	33567.84
+17	35682.83
+18	37781.82
+19	39880.81
+20	41979.8
+21	44078.79
+22	46155.78
+23	48253.77
+24	50351.76
+25	52449.75
+26	54573.74
+27	56672.73
+28	58743.72
+29	60870.71
+30	62909.7
+31	65006.69
+32	67135.68
+33	69266.67
+34	71365.66
+35	73429.65
+36	75563.64
+37	77662.63
+38	79761.62
+39	81821.61
+40	83879.6
+41	85976.59
+42	88157.58
+43	90213.57
+44	92223.56
+45	94454.55
+46	96553.54
+47	98652.53
+48	100703.52
+49	102801.51
+50	104949.5

--- a/benchmark/tpch/aggregate/lineitem_distinct_on_few_groups.benchmark
+++ b/benchmark/tpch/aggregate/lineitem_distinct_on_few_groups.benchmark
@@ -1,4 +1,4 @@
-# name: benchmark/tpch/aggregate/lineitem_distinct_on.benchmark
+# name: benchmark/tpch/aggregate/lineitem_distinct_on_few_groups.benchmark
 # description: DISTINCT ON over Lineitem
 # group: [aggregate]
 

--- a/benchmark/tpch/aggregate/lineitem_distinct_on_many_groups.benchmark
+++ b/benchmark/tpch/aggregate/lineitem_distinct_on_many_groups.benchmark
@@ -1,0 +1,25 @@
+# name: benchmark/tpch/aggregate/lineitem_distinct_on_many_groups.benchmark
+# description: DISTINCT ON over Lineitem
+# group: [aggregate]
+
+name Lineitem Distinct On (Many Groups)
+group aggregate
+subgroup tpch
+
+require tpch
+
+cache tpch_sf1.duckdb
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT AVG(l_orderkey), AVG(l_extendedprice)
+FROM (
+  SELECT DISTINCT ON (l_orderkey) l_orderkey, l_extendedprice
+  FROM lineitem
+  ORDER BY l_orderkey, l_extendedprice DESC
+) l;
+
+result II
+2999991.5	59874.92

--- a/src/execution/physical_plan/plan_distinct.cpp
+++ b/src/execution/physical_plan/plan_distinct.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_distinct.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/rule/ordered_aggregate_optimizer.hpp"
 
 namespace duckdb {
 
@@ -61,6 +62,15 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDistinct &
 			auto first_aggregate = function_binder.BindAggregateFunction(
 			    FirstFun::GetFunction(logical_type), std::move(first_children), nullptr, AggregateType::NON_DISTINCT);
 			first_aggregate->order_bys = op.order_by ? op.order_by->Copy() : nullptr;
+
+			if (ClientConfig::GetConfig(context).enable_optimizer) {
+				bool changes_made = false;
+				auto new_expr = OrderedAggregateOptimizer::Apply(context, *first_aggregate, groups, changes_made);
+				if (new_expr) {
+					D_ASSERT(new_expr->type == ExpressionType::BOUND_AGGREGATE);
+					first_aggregate = unique_ptr_cast<Expression, BoundAggregateExpression>(std::move(new_expr));
+				}
+			}
 			// add the projection
 			projections.push_back(make_uniq<BoundReferenceExpression>(logical_type, group_count + aggregates.size()));
 			// push it to the list of aggregates

--- a/src/include/duckdb/optimizer/rule/ordered_aggregate_optimizer.hpp
+++ b/src/include/duckdb/optimizer/rule/ordered_aggregate_optimizer.hpp
@@ -17,6 +17,8 @@ class OrderedAggregateOptimizer : public Rule {
 public:
 	explicit OrderedAggregateOptimizer(ExpressionRewriter &rewriter);
 
+	static unique_ptr<Expression> Apply(ClientContext &context, BoundAggregateExpression &aggr,
+	                                    vector<unique_ptr<Expression>> &groups, bool &changes_made);
 	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
 	                             bool is_root) override;
 };

--- a/src/optimizer/rule/ordered_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/ordered_aggregate_optimizer.cpp
@@ -17,9 +17,8 @@ OrderedAggregateOptimizer::OrderedAggregateOptimizer(ExpressionRewriter &rewrite
 	root->expr_class = ExpressionClass::BOUND_AGGREGATE;
 }
 
-unique_ptr<Expression> OrderedAggregateOptimizer::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
-                                                        bool &changes_made, bool is_root) {
-	auto &aggr = bindings[0].get().Cast<BoundAggregateExpression>();
+unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, BoundAggregateExpression &aggr,
+                                                        vector<unique_ptr<Expression>> &groups, bool &changes_made) {
 	if (!aggr.order_bys) {
 		// no ORDER BYs defined
 		return nullptr;
@@ -32,7 +31,7 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(LogicalOperator &op, vec
 	}
 
 	// Remove unnecessary ORDER BY clauses and return if nothing remains
-	if (aggr.order_bys->Simplify(op.Cast<LogicalAggregate>().groups)) {
+	if (aggr.order_bys->Simplify(groups)) {
 		aggr.order_bys.reset();
 		changes_made = true;
 		return nullptr;
@@ -51,7 +50,6 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(LogicalOperator &op, vec
 		return nullptr;
 	}
 
-	auto &context = rewriter.context;
 	FunctionBinder binder(context);
 	vector<unique_ptr<Expression>> sort_children;
 	for (auto &order : aggr.order_bys->orders) {
@@ -93,8 +91,12 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(LogicalOperator &op, vec
 	auto bound_function = func.functions.GetFunctionByOffset(best_function);
 	return binder.BindAggregateFunction(bound_function, std::move(children), std::move(aggr.filter),
 	                                    aggr.IsDistinct() ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT);
+}
 
-	return nullptr;
+unique_ptr<Expression> OrderedAggregateOptimizer::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
+                                                        bool &changes_made, bool is_root) {
+	auto &aggr = bindings[0].get().Cast<BoundAggregateExpression>();
+	return Apply(rewriter.context, aggr, op.Cast<LogicalAggregate>().groups, changes_made);
 }
 
 } // namespace duckdb

--- a/test/sql/aggregate/distinct/distinct_on_nulls.test
+++ b/test/sql/aggregate/distinct/distinct_on_nulls.test
@@ -1,0 +1,83 @@
+# name: test/sql/aggregate/distinct/distinct_on_nulls.test
+# description: Test DISTINCT ON with NULL values
+# group: [distinct]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (2, 3), (4, 5), (2, NULL), (NULL, NULL);
+
+query II
+SELECT DISTINCT ON (i) i, j FROM integers ORDER BY j
+----
+2	3
+4	5
+NULL	NULL
+
+query II
+SELECT DISTINCT ON (i) i, j FROM integers ORDER BY i, j
+----
+2	3
+4	5
+NULL	NULL
+
+query II
+SELECT DISTINCT ON (i) i, j FROM integers ORDER BY i NULLS FIRST, j NULLS FIRST
+----
+NULL	NULL
+2	NULL
+4	5
+
+query II
+SELECT DISTINCT ON (i) i, j FROM integers ORDER BY i, j NULLS FIRST
+----
+2	NULL
+4	5
+NULL	NULL
+
+# multi-way sort and ties
+statement ok
+CREATE TABLE distinct_on_test(key INTEGER, v1 VARCHAR, v2 INTEGER[], v3 INTEGER);
+
+statement ok
+INSERT INTO distinct_on_test VALUES
+	(1, 'hello', ARRAY[1], 42), -- ASC
+	(1, 'hello', ARRAY[1], 42),
+	(1, 'hello', ARRAY[1], 43), -- DESC
+	(2, NULL, NULL, 0),     -- ASC
+	(2, NULL, NULL, 1),
+	(2, NULL, NULL, NULL),  -- DESC
+	(3, 'thisisalongstring', NULL, 0),     -- ASC
+	(3, 'thisisalongstringbutlonger', NULL, 1),
+	(3, 'thisisalongstringbutevenlonger', ARRAY[1, 2, 3, 4, 5, 6, 7, 8, 9], 2)  -- DESC
+;
+
+query IIII
+SELECT DISTINCT ON (key) * FROM distinct_on_test ORDER BY key, v1, v2, v3
+----
+1	hello	[1]	42
+2	NULL	NULL	0
+3	thisisalongstring	NULL	0
+
+query IIII
+SELECT DISTINCT ON (key) * FROM distinct_on_test  WHERE key <> 2 ORDER BY key, v1, v2, v3
+----
+1	hello	[1]	42
+3	thisisalongstring	NULL	0
+
+query IIII
+SELECT DISTINCT ON (key) * FROM distinct_on_test ORDER BY key, v1 DESC NULLS FIRST, v2 DESC NULLS FIRST, v3 DESC NULLS FIRST
+----
+1	hello	[1]	43
+2	NULL	NULL	NULL
+3	thisisalongstringbutlonger	NULL	1
+
+query IIII
+SELECT DISTINCT ON (key) * FROM distinct_on_test WHERE key <> 2 ORDER BY key, v1 DESC NULLS FIRST, v2 DESC NULLS FIRST, v3 DESC NULLS FIRST
+----
+1	hello	[1]	43
+3	thisisalongstringbutlonger	NULL	1

--- a/test/sql/aggregate/distinct/issue8505.test
+++ b/test/sql/aggregate/distinct/issue8505.test
@@ -11,14 +11,14 @@ explain select record_key from (
     select distinct on (id, provider) id, provider, record_key from test order by id, provider, record_rank desc, record_date
 )
 ----
-physical_plan	<REGEX>:.*HASH_GROUP_BY.*#0.*#1.*first\(#2, #3, #4\).*first\(#5, #6, #7\).*first\(#8, #9, #10\).*
+physical_plan	<REGEX>:.*HASH_GROUP_BY.*#0.*#1.*arg_min_null.*
 
 
 # this query was slow, but should be equivalent to the first query
 query II
 explain select distinct on (id, provider) record_key from test order by id, provider, record_rank desc, record_date
 ----
-physical_plan	<REGEX>:.*HASH_GROUP_BY.*#0.*#1.*first\(#2, #3, #4\).*first\(#5, #6, #7\).*first\(#8, #9, #10\).*
+physical_plan	<REGEX>:.*HASH_GROUP_BY.*#0.*#1.*arg_min_null.*
 
 # the problem was that our aggregate became way too big in the second case because we didn't de-duplicate columns
 # this regex checks that they both have the same 'minimal' aggregate (this test is a bit fragile to binder changes tho)


### PR DESCRIPTION
Fixes #8505
Fixes #10675

Follow-up from #10457

Now that we have a fast/memory efficient `FIRST(x ORDER BY y)` rewrite, we can use that rewrite also in the `DISTINCT ON` clause. This has to be done explicitly as the `DISTINCT ON` clause only generates the ordered aggregates during physical planning, which is too late for the other optimization pass.

