### PR TITLE
Union exclude

### DIFF
--- a/src/optimizer/pushdown/pushdown_mark_join.cpp
+++ b/src/optimizer/pushdown/pushdown_mark_join.cpp
@@ -35,16 +35,16 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 #endif
 			// this filter references the marker
 			// we can turn this into a SEMI join if the filter is on only the marker
-//			if (filters[i]->filter->type == ExpressionType::BOUND_COLUMN_REF) {
-//				// filter just references the marker: turn into semi join
-//#ifdef DEBUG
-//				simplified_mark_join = true;
-//#endif
-//				join.join_type = JoinType::SEMI;
-//				filters.erase(filters.begin() + i);
-//				i--;
-//				continue;
-//			}
+			if (filters[i]->filter->type == ExpressionType::BOUND_COLUMN_REF) {
+				// filter just references the marker: turn into semi join
+#ifdef DEBUG
+				simplified_mark_join = true;
+#endif
+				join.join_type = JoinType::SEMI;
+				filters.erase(filters.begin() + i);
+				i--;
+				continue;
+			}
 			// if the filter is on NOT(marker) AND the join conditions are all set to "null_values_are_equal" we can
 			// turn this into an ANTI join if all join conditions have null_values_are_equal=true, then the result of
 			// the MARK join is always TRUE or FALSE, and never NULL this happens in the case of a correlated EXISTS
@@ -61,16 +61,16 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 							break;
 						}
 					}
-//					if (all_null_values_are_equal) {
-//#ifdef DEBUG
-//						simplified_mark_join = true;
-//#endif
-//						// all null values are equal, convert to ANTI join
-//						join.join_type = JoinType::ANTI;
-//						filters.erase(filters.begin() + i);
-//						i--;
-//						continue;
-//					}
+					if (all_null_values_are_equal) {
+#ifdef DEBUG
+						simplified_mark_join = true;
+#endif
+						// all null values are equal, convert to ANTI join
+						join.join_type = JoinType::ANTI;
+						filters.erase(filters.begin() + i);
+						i--;
+						continue;
+					}
 				}
 			}
 		}

--- a/src/optimizer/pushdown/pushdown_mark_join.cpp
+++ b/src/optimizer/pushdown/pushdown_mark_join.cpp
@@ -35,16 +35,16 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 #endif
 			// this filter references the marker
 			// we can turn this into a SEMI join if the filter is on only the marker
-			if (filters[i]->filter->type == ExpressionType::BOUND_COLUMN_REF) {
-				// filter just references the marker: turn into semi join
-#ifdef DEBUG
-				simplified_mark_join = true;
-#endif
-				join.join_type = JoinType::SEMI;
-				filters.erase(filters.begin() + i);
-				i--;
-				continue;
-			}
+//			if (filters[i]->filter->type == ExpressionType::BOUND_COLUMN_REF) {
+//				// filter just references the marker: turn into semi join
+//#ifdef DEBUG
+//				simplified_mark_join = true;
+//#endif
+//				join.join_type = JoinType::SEMI;
+//				filters.erase(filters.begin() + i);
+//				i--;
+//				continue;
+//			}
 			// if the filter is on NOT(marker) AND the join conditions are all set to "null_values_are_equal" we can
 			// turn this into an ANTI join if all join conditions have null_values_are_equal=true, then the result of
 			// the MARK join is always TRUE or FALSE, and never NULL this happens in the case of a correlated EXISTS
@@ -61,16 +61,16 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalO
 							break;
 						}
 					}
-					if (all_null_values_are_equal) {
-#ifdef DEBUG
-						simplified_mark_join = true;
-#endif
-						// all null values are equal, convert to ANTI join
-						join.join_type = JoinType::ANTI;
-						filters.erase(filters.begin() + i);
-						i--;
-						continue;
-					}
+//					if (all_null_values_are_equal) {
+//#ifdef DEBUG
+//						simplified_mark_join = true;
+//#endif
+//						// all null values are equal, convert to ANTI join
+//						join.join_type = JoinType::ANTI;
+//						filters.erase(filters.begin() + i);
+//						i--;
+//						continue;
+//					}
 				}
 			}
 		}

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -108,15 +108,56 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 	}
 	case LogicalOperatorType::LOGICAL_ANY_JOIN:
 		break;
-	case LogicalOperatorType::LOGICAL_UNION:
-		// you cannot remove unused columns into a union.
-		// If only 2 columns are selected from a union of 3 columns. The third column could have an effect on the reuslt
-		// of the union. If it is projected out before the union, then the result could be different.
+	case LogicalOperatorType::LOGICAL_UNION: {
+		auto &setop = op.Cast<LogicalSetOperation>();
+		if (setop.setop_all) {
+			// for UNION we can remove unreferenced columns as long as everything_referenced is false (i.e. we
+			// encounter a UNION node that is not preceded by a DISTINCT)
+			// this happens when UNION ALL is used
+
+			vector<idx_t> entries;
+			for (idx_t i = 0; i < setop.column_count; i++) {
+				entries.push_back(i);
+			}
+			ClearUnusedExpressions(entries, setop.table_index);
+			if (entries.size() < setop.column_count) {
+				if (entries.empty()) {
+					// no columns referenced: this happens in the case of a COUNT(*)
+					// extract the first column
+					entries.push_back(0);
+				}
+				// columns were cleared
+				setop.column_count = entries.size();
+
+				for (idx_t child_idx = 0; child_idx < op.children.size(); child_idx++) {
+					RemoveUnusedColumns remove(binder, context, true);
+					auto &child = op.children[child_idx];
+
+					// we push a projection under this child that references the required columns of the union
+					child->ResolveOperatorTypes();
+					auto bindings = child->GetColumnBindings();
+					vector<unique_ptr<Expression>> expressions;
+					expressions.reserve(entries.size());
+					for (auto &column_idx : entries) {
+						expressions.push_back(
+						    make_uniq<BoundColumnRefExpression>(child->types[column_idx], bindings[column_idx]));
+					}
+					auto new_projection =
+					    make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(expressions));
+					new_projection->children.push_back(std::move(child));
+					op.children[child_idx] = std::move(new_projection);
+
+					remove.VisitOperator(*op.children[child_idx]);
+				}
+				return;
+			}
+		}
 		for (auto &child : op.children) {
 			RemoveUnusedColumns remove(binder, context, true);
 			remove.VisitOperator(*child);
 		}
 		return;
+	}
 	case LogicalOperatorType::LOGICAL_EXCEPT:
 	case LogicalOperatorType::LOGICAL_INTERSECT:
 		// for INTERSECT/EXCEPT operations we can't remove anything, just recursively visit the children

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -111,10 +111,9 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_UNION: {
 		auto &setop = op.Cast<LogicalSetOperation>();
 		if (setop.setop_all) {
-			// for UNION we can remove unreferenced columns as long as everything_referenced is false (i.e. we
-			// encounter a UNION node that is not preceded by a DISTINCT)
-			// this happens when UNION ALL is used
-
+			// for UNION we can remove unreferenced columns if union all is used
+			// it's possible not all columns are referenced, but unreferenced columns in the union can
+			// still have an affect on the result of the union
 			vector<idx_t> entries;
 			for (idx_t i = 0; i < setop.column_count; i++) {
 				entries.push_back(i);

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -110,7 +110,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		break;
 	case LogicalOperatorType::LOGICAL_UNION: {
 		auto &setop = op.Cast<LogicalSetOperation>();
-		if (setop.setop_all) {
+		if (setop.setop_all && !everything_referenced) {
 			// for UNION we can remove unreferenced columns if union all is used
 			// it's possible not all columns are referenced, but unreferenced columns in the union can
 			// still have an affect on the result of the union

--- a/test/optimizer/union_exclude.test
+++ b/test/optimizer/union_exclude.test
@@ -2,7 +2,6 @@
 # description: Test union and exclude
 # group: [optimizer]
 
-
 statement ok
 CREATE TABLE test_df_a(number BIGINT, date VARCHAR, rn BIGINT);
 
@@ -40,11 +39,28 @@ statement ok
 INSERT INTO test_df_b VALUES(7076,'2017-07-31',1);
 
 query II
-with t as (select * from test_df_a UNION select * from test_df_b) select * exclude rn from t;
+with t as (select * from test_df_a UNION select * from test_df_b) select * exclude rn from t order by all;
 ----
-7076	2017-07-31
 7012	2015-07-31
+7058	2015-07-31
+7058	2015-07-31
 7075	2016-07-31
-7058	2015-07-31
-7058	2015-07-31
 7076	2017-07-31
+7076	2017-07-31
+
+
+statement ok
+create table t1 as select 1 a, range b from range(100);
+
+statement ok
+create table t2 as select 1 a, range b from range(100);
+
+query I
+select count(a) from (select * from t1 union select * from t2) t_union;
+----
+100
+
+query I
+select count(a) from (select * from t1 union all select * from t2) t_union;
+----
+200

--- a/test/optimizer/union_exclude.test
+++ b/test/optimizer/union_exclude.test
@@ -1,0 +1,50 @@
+# name: test/optimizer/union_exclude.test
+# description: Test union and exclude
+# group: [optimizer]
+
+
+statement ok
+CREATE TABLE test_df_a(number BIGINT, date VARCHAR, rn BIGINT);
+
+statement ok
+INSERT INTO test_df_a VALUES(7058,'2015-07-31',1);
+
+statement ok
+INSERT INTO test_df_a VALUES(7058,'2015-07-31',2);
+
+statement ok
+INSERT INTO test_df_a VALUES(7075,'2016-07-31',1);
+
+statement ok
+INSERT INTO test_df_a VALUES(7076,'2017-07-31',1);
+
+statement ok
+INSERT INTO test_df_a VALUES(7076,'2017-07-31',2);
+
+statement ok
+CREATE TABLE test_df_b(number BIGINT, date VARCHAR, rn BIGINT);;
+
+statement ok
+INSERT INTO test_df_b VALUES(7058,'2015-07-31',1);
+
+statement ok
+INSERT INTO test_df_b VALUES(7058,'2015-07-31',2);
+
+statement ok
+INSERT INTO test_df_b VALUES(7012,'2015-07-31',1);
+
+statement ok
+INSERT INTO test_df_b VALUES(7075,'2016-07-31',1);
+
+statement ok
+INSERT INTO test_df_b VALUES(7076,'2017-07-31',1);
+
+query II
+with t as (select * from test_df_a UNION select * from test_df_b) select * exclude rn from t;
+----
+7076	2017-07-31
+7012	2015-07-31
+7075	2016-07-31
+7058	2015-07-31
+7058	2015-07-31
+7076	2017-07-31


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/1257

Turns out we would push unused columns through union operators. This should not happen since these "unused columns" can affect the result of the union. 