### PR TITLE
Casts: report error location in query for failed casts

### DIFF
--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -260,7 +260,7 @@ struct ICUStrptime : public ICUDateFunc {
 			    bool has_offset = false;
 			    if (!Timestamp::TryConvertTimestampTZ(str, len, result, has_offset, tz)) {
 				    auto msg = Timestamp::ConversionError(string(str, len));
-				    HandleCastError::AssignError(msg, parameters.error_message);
+				    HandleCastError::AssignError(msg, parameters);
 				    mask.SetInvalid(idx);
 			    } else if (!has_offset) {
 				    // Convert parts to a TZ (default or parsed) if no offset was provided

--- a/extension/inet/include/ipaddress.hpp
+++ b/extension/inet/include/ipaddress.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/types/string_type.hpp"
 
 namespace duckdb {
+struct CastParameters;
 
 enum class IPAddressType : uint8_t { IP_ADDRESS_INVALID = 0, IP_ADDRESS_V4 = 1, IP_ADDRESS_V6 = 2 };
 
@@ -31,7 +32,7 @@ public:
 public:
 	static IPAddress FromIPv4(int32_t address, uint16_t mask);
 	static IPAddress FromIPv6(hugeint_t address, uint16_t mask);
-	static bool TryParse(string_t input, IPAddress &result, string *error_message);
+	static bool TryParse(string_t input, IPAddress &result, CastParameters &parameters);
 	static IPAddress FromString(string_t input);
 
 	string ToString() const;

--- a/extension/inet/inet_functions.cpp
+++ b/extension/inet/inet_functions.cpp
@@ -31,7 +31,7 @@ bool INetFunctions::CastVarcharToINET(Vector &source, Vector &result, idx_t coun
 			continue;
 		}
 		IPAddress inet;
-		if (!IPAddress::TryParse(input[idx], inet, parameters.error_message)) {
+		if (!IPAddress::TryParse(input[idx], inet, parameters)) {
 			FlatVector::SetNull(result, i, true);
 			success = false;
 			continue;

--- a/extension/json/include/json_transform.hpp
+++ b/extension/json/include/json_transform.hpp
@@ -40,6 +40,8 @@ public:
 	string error_message;
 	//! Index of the object where the error occurred
 	idx_t object_index = DConstants::INVALID_INDEX;
+	//! Cast parameters
+	CastParameters parameters;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -225,7 +225,7 @@ static bool CastVarcharToJSON(Vector &source, Vector &result, idx_t count, CastP
 			    mask.SetInvalid(idx);
 			    if (success) {
 				    HandleCastError::AssignError(JSONCommon::FormatParseError(data, length, error),
-				                                 parameters.error_message);
+				                                 parameters);
 				    success = false;
 			    }
 		    }

--- a/extension/json/json_functions.cpp
+++ b/extension/json/json_functions.cpp
@@ -224,8 +224,7 @@ static bool CastVarcharToJSON(Vector &source, Vector &result, idx_t count, CastP
 		    if (!doc) {
 			    mask.SetInvalid(idx);
 			    if (success) {
-				    HandleCastError::AssignError(JSONCommon::FormatParseError(data, length, error),
-				                                 parameters);
+				    HandleCastError::AssignError(JSONCommon::FormatParseError(data, length, error), parameters);
 				    success = false;
 			    }
 		    }

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -982,7 +982,7 @@ static bool JSONToAnyCast(Vector &source, Vector &result, idx_t count, CastParam
 
 	auto success = TransformFunctionInternal(source, count, result, alc, options);
 	if (!success) {
-		HandleCastError::AssignError(options.error_message, parameters.error_message);
+		HandleCastError::AssignError(options.error_message, parameters);
 	}
 	return success;
 }

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -13,7 +13,7 @@
 
 namespace duckdb {
 
-JSONTransformOptions::JSONTransformOptions() : 	parameters(false, &error_message) {
+JSONTransformOptions::JSONTransformOptions() : parameters(false, &error_message) {
 }
 
 JSONTransformOptions::JSONTransformOptions(bool strict_cast_p, bool error_duplicate_key_p, bool error_missing_key_p,
@@ -146,8 +146,7 @@ static inline bool GetValueDecimal(yyjson_val *val, T &result, uint8_t w, uint8_
 		success = OP::template Operation<bool, T>(unsafe_yyjson_get_bool(val), result, options.parameters, w, s);
 		break;
 	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT:
-		success =
-		    OP::template Operation<uint64_t, T>(unsafe_yyjson_get_uint(val), result, options.parameters, w, s);
+		success = OP::template Operation<uint64_t, T>(unsafe_yyjson_get_uint(val), result, options.parameters, w, s);
 		break;
 	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT:
 		success = OP::template Operation<int64_t, T>(unsafe_yyjson_get_sint(val), result, options.parameters, w, s);

--- a/extension/json/json_functions/json_transform.cpp
+++ b/extension/json/json_functions/json_transform.cpp
@@ -13,13 +13,13 @@
 
 namespace duckdb {
 
-JSONTransformOptions::JSONTransformOptions() {
+JSONTransformOptions::JSONTransformOptions() : 	parameters(false, &error_message) {
 }
 
 JSONTransformOptions::JSONTransformOptions(bool strict_cast_p, bool error_duplicate_key_p, bool error_missing_key_p,
                                            bool error_unkown_key_p)
     : strict_cast(strict_cast_p), error_duplicate_key(error_duplicate_key_p), error_missing_key(error_missing_key_p),
-      error_unknown_key(error_unkown_key_p) {
+      error_unknown_key(error_unkown_key_p), parameters(false, &error_message) {
 }
 
 //! Forward declaration for recursion
@@ -135,7 +135,7 @@ static inline bool GetValueDecimal(yyjson_val *val, T &result, uint8_t w, uint8_
 	bool success;
 	switch (unsafe_yyjson_get_tag(val)) {
 	case YYJSON_TYPE_STR | YYJSON_SUBTYPE_NONE:
-		success = OP::template Operation<string_t, T>(GetString(val), result, &options.error_message, w, s);
+		success = OP::template Operation<string_t, T>(GetString(val), result, options.parameters, w, s);
 		break;
 	case YYJSON_TYPE_ARR | YYJSON_SUBTYPE_NONE:
 	case YYJSON_TYPE_OBJ | YYJSON_SUBTYPE_NONE:
@@ -143,17 +143,17 @@ static inline bool GetValueDecimal(yyjson_val *val, T &result, uint8_t w, uint8_
 		break;
 	case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_TRUE:
 	case YYJSON_TYPE_BOOL | YYJSON_SUBTYPE_FALSE:
-		success = OP::template Operation<bool, T>(unsafe_yyjson_get_bool(val), result, &options.error_message, w, s);
+		success = OP::template Operation<bool, T>(unsafe_yyjson_get_bool(val), result, options.parameters, w, s);
 		break;
 	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_UINT:
 		success =
-		    OP::template Operation<uint64_t, T>(unsafe_yyjson_get_uint(val), result, &options.error_message, w, s);
+		    OP::template Operation<uint64_t, T>(unsafe_yyjson_get_uint(val), result, options.parameters, w, s);
 		break;
 	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_SINT:
-		success = OP::template Operation<int64_t, T>(unsafe_yyjson_get_sint(val), result, &options.error_message, w, s);
+		success = OP::template Operation<int64_t, T>(unsafe_yyjson_get_sint(val), result, options.parameters, w, s);
 		break;
 	case YYJSON_TYPE_NUM | YYJSON_SUBTYPE_REAL:
-		success = OP::template Operation<double, T>(unsafe_yyjson_get_real(val), result, &options.error_message, w, s);
+		success = OP::template Operation<double, T>(unsafe_yyjson_get_real(val), result, options.parameters, w, s);
 		break;
 	default:
 		throw InternalException("Unknown yyjson tag in GetValueString");

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -232,8 +232,14 @@ TypeMismatchException::TypeMismatchException(const PhysicalType type_1, const Ph
 }
 
 TypeMismatchException::TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg)
+    : TypeMismatchException(optional_idx(), type_1, type_2, msg) {
+}
+
+TypeMismatchException::TypeMismatchException(optional_idx error_location, const LogicalType &type_1,
+                                             const LogicalType &type_2, const string &msg)
     : Exception(ExceptionType::MISMATCH_TYPE,
-                "Type " + type_1.ToString() + " does not match with " + type_2.ToString() + ". " + msg) {
+                "Type " + type_1.ToString() + " does not match with " + type_2.ToString() + ". " + msg,
+                Exception::InitializeExtraInfo(error_location)) {
 }
 
 TypeMismatchException::TypeMismatchException(const string &msg) : Exception(ExceptionType::MISMATCH_TYPE, msg) {

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -215,19 +215,6 @@ void Exception::SetQueryLocation(optional_idx error_location, unordered_map<stri
 	}
 }
 
-ConversionException::ConversionException(const PhysicalType orig_type, const PhysicalType new_type)
-    : Exception(ExceptionType::CONVERSION,
-                "Type " + TypeIdToString(orig_type) + " can't be cast as " + TypeIdToString(new_type)) {
-}
-
-ConversionException::ConversionException(const LogicalType &orig_type, const LogicalType &new_type)
-    : Exception(ExceptionType::CONVERSION,
-                "Type " + orig_type.ToString() + " can't be cast as " + new_type.ToString()) {
-}
-
-ConversionException::ConversionException(const string &msg) : Exception(ExceptionType::CONVERSION, msg) {
-}
-
 InvalidTypeException::InvalidTypeException(PhysicalType type, const string &msg)
     : Exception(ExceptionType::INVALID_TYPE, "Invalid Type [" + TypeIdToString(type) + "]: " + msg) {
 }

--- a/src/common/exception/CMakeLists.txt
+++ b/src/common/exception/CMakeLists.txt
@@ -1,5 +1,6 @@
-add_library_unity(duckdb_common_exception OBJECT binder_exception.cpp
-                  catalog_exception.cpp conversion_exception.cpp parser_exception.cpp)
+add_library_unity(
+  duckdb_common_exception OBJECT binder_exception.cpp catalog_exception.cpp
+  conversion_exception.cpp parser_exception.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common_exception>
     PARENT_SCOPE)

--- a/src/common/exception/CMakeLists.txt
+++ b/src/common/exception/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(duckdb_common_exception OBJECT binder_exception.cpp
-                  catalog_exception.cpp parser_exception.cpp)
+                  catalog_exception.cpp conversion_exception.cpp parser_exception.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common_exception>
     PARENT_SCOPE)

--- a/src/common/exception/conversion_exception.cpp
+++ b/src/common/exception/conversion_exception.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/common/types.hpp"
 
 namespace duckdb {
 

--- a/src/common/exception/conversion_exception.cpp
+++ b/src/common/exception/conversion_exception.cpp
@@ -1,0 +1,21 @@
+#include "duckdb/common/exception/conversion_exception.hpp"
+
+namespace duckdb {
+
+ConversionException::ConversionException(const PhysicalType orig_type, const PhysicalType new_type)
+        : Exception(ExceptionType::CONVERSION,
+                    "Type " + TypeIdToString(orig_type) + " can't be cast as " + TypeIdToString(new_type)) {
+}
+
+ConversionException::ConversionException(const LogicalType &orig_type, const LogicalType &new_type)
+        : Exception(ExceptionType::CONVERSION,
+                    "Type " + orig_type.ToString() + " can't be cast as " + new_type.ToString()) {
+}
+
+ConversionException::ConversionException(const string &msg) : Exception(ExceptionType::CONVERSION, msg) {
+}
+
+ConversionException::ConversionException(optional_idx error_location, const string &msg) :
+        Exception(ExceptionType::CONVERSION, msg, Exception::InitializeExtraInfo(error_location)) {}
+
+}

--- a/src/common/exception/conversion_exception.cpp
+++ b/src/common/exception/conversion_exception.cpp
@@ -3,19 +3,20 @@
 namespace duckdb {
 
 ConversionException::ConversionException(const PhysicalType orig_type, const PhysicalType new_type)
-        : Exception(ExceptionType::CONVERSION,
-                    "Type " + TypeIdToString(orig_type) + " can't be cast as " + TypeIdToString(new_type)) {
+    : Exception(ExceptionType::CONVERSION,
+                "Type " + TypeIdToString(orig_type) + " can't be cast as " + TypeIdToString(new_type)) {
 }
 
 ConversionException::ConversionException(const LogicalType &orig_type, const LogicalType &new_type)
-        : Exception(ExceptionType::CONVERSION,
-                    "Type " + orig_type.ToString() + " can't be cast as " + new_type.ToString()) {
+    : Exception(ExceptionType::CONVERSION,
+                "Type " + orig_type.ToString() + " can't be cast as " + new_type.ToString()) {
 }
 
 ConversionException::ConversionException(const string &msg) : Exception(ExceptionType::CONVERSION, msg) {
 }
 
-ConversionException::ConversionException(optional_idx error_location, const string &msg) :
-        Exception(ExceptionType::CONVERSION, msg, Exception::InitializeExtraInfo(error_location)) {}
-
+ConversionException::ConversionException(optional_idx error_location, const string &msg)
+    : Exception(ExceptionType::CONVERSION, msg, Exception::InitializeExtraInfo(error_location)) {
 }
+
+} // namespace duckdb

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1333,7 +1333,7 @@ string_t CastFromPointer::Operation(uintptr_t input, Vector &vector) {
 template <>
 bool TryCastToBlob::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters) {
 	idx_t result_size;
-	if (!Blob::TryGetBlobSize(input, result_size, parameters.error_message)) {
+	if (!Blob::TryGetBlobSize(input, result_size, parameters)) {
 		return false;
 	}
 
@@ -1374,7 +1374,8 @@ bool CastFromBitToNumeric::Operation(string_t input, hugeint_t &result, CastPara
 	D_ASSERT(input.GetSize() > 1);
 
 	if (input.GetSize() - 1 > sizeof(hugeint_t)) {
-		throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s", GetTypeId<hugeint_t>());
+		throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s",
+		                          GetTypeId<hugeint_t>());
 	}
 	Bit::BitToNumeric(input, result);
 	return (true);
@@ -1385,7 +1386,8 @@ bool CastFromBitToNumeric::Operation(string_t input, uhugeint_t &result, CastPar
 	D_ASSERT(input.GetSize() > 1);
 
 	if (input.GetSize() - 1 > sizeof(uhugeint_t)) {
-		throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s", GetTypeId<uhugeint_t>());
+		throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s",
+		                          GetTypeId<uhugeint_t>());
 	}
 	Bit::BitToNumeric(input, result);
 	return (true);
@@ -1951,17 +1953,20 @@ bool TryDecimalStringCast(string_t input, T &result, CastParameters &parameters,
 }
 
 template <>
-bool TryCastToDecimal::Operation(string_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(string_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return TryDecimalStringCast<int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(string_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(string_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return TryDecimalStringCast<int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(string_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(string_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return TryDecimalStringCast<int64_t>(input, result, parameters, width, scale);
 }
 
@@ -1972,26 +1977,26 @@ bool TryCastToDecimal::Operation(string_t input, hugeint_t &result, CastParamete
 }
 
 template <>
-bool TryCastToDecimalCommaSeparated::Operation(string_t input, int16_t &result, CastParameters &parameters, uint8_t width,
-                                               uint8_t scale) {
+bool TryCastToDecimalCommaSeparated::Operation(string_t input, int16_t &result, CastParameters &parameters,
+                                               uint8_t width, uint8_t scale) {
 	return TryDecimalStringCast<int16_t, ','>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimalCommaSeparated::Operation(string_t input, int32_t &result, CastParameters &parameters, uint8_t width,
-                                               uint8_t scale) {
+bool TryCastToDecimalCommaSeparated::Operation(string_t input, int32_t &result, CastParameters &parameters,
+                                               uint8_t width, uint8_t scale) {
 	return TryDecimalStringCast<int32_t, ','>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimalCommaSeparated::Operation(string_t input, int64_t &result, CastParameters &parameters, uint8_t width,
-                                               uint8_t scale) {
+bool TryCastToDecimalCommaSeparated::Operation(string_t input, int64_t &result, CastParameters &parameters,
+                                               uint8_t width, uint8_t scale) {
 	return TryDecimalStringCast<int64_t, ','>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimalCommaSeparated::Operation(string_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
-                                               uint8_t scale) {
+bool TryCastToDecimalCommaSeparated::Operation(string_t input, hugeint_t &result, CastParameters &parameters,
+                                               uint8_t width, uint8_t scale) {
 	return TryDecimalStringCast<hugeint_t, ','>(input, result, parameters, width, scale);
 }
 
@@ -2031,42 +2036,50 @@ bool TryCastBoolToDecimal(bool input, T &result, CastParameters &parameters, uin
 }
 
 template <>
-bool TryCastToDecimal::Operation(bool input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(bool input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return TryCastBoolToDecimal<int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(bool input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(bool input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return TryCastBoolToDecimal<int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(bool input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(bool input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return TryCastBoolToDecimal<int64_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(bool input, hugeint_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(bool input, hugeint_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return TryCastBoolToDecimal<hugeint_t, Hugeint>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int16_t input, bool &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCast::Operation<int16_t, bool>(input, result);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int32_t input, bool &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCast::Operation<int32_t, bool>(input, result);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int64_t input, bool &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCast::Operation<int64_t, bool>(input, result);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCast::Operation<hugeint_t, bool>(input, result);
 }
 
@@ -2118,19 +2131,23 @@ bool NumericToHugeDecimalCast(SRC input, hugeint_t &result, CastParameters &para
 // Cast int8_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(int8_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int8_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int8_t, int16_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int8_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int8_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int8_t, int32_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int8_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int8_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int8_t, int64_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return NumericToHugeDecimalCast<int8_t>(input, result, parameters, width, scale);
 }
 
@@ -2138,15 +2155,18 @@ bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, CastParameters
 // Cast int16_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(int16_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int16_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int16_t, int16_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int16_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int16_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int16_t, int32_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int16_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int16_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int16_t, int64_t>(input, result, parameters, width, scale);
 }
 template <>
@@ -2159,15 +2179,18 @@ bool TryCastToDecimal::Operation(int16_t input, hugeint_t &result, CastParameter
 // Cast int32_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(int32_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int32_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int32_t, int16_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int32_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int32_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int32_t, int32_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int32_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int32_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int32_t, int64_t>(input, result, parameters, width, scale);
 }
 template <>
@@ -2180,15 +2203,18 @@ bool TryCastToDecimal::Operation(int32_t input, hugeint_t &result, CastParameter
 // Cast int64_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(int64_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int64_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int64_t, int16_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int64_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int64_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int64_t, int32_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int64_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(int64_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return StandardNumericToDecimalCast<int64_t, int64_t>(input, result, parameters, width, scale);
 }
 template <>
@@ -2201,19 +2227,22 @@ bool TryCastToDecimal::Operation(int64_t input, hugeint_t &result, CastParameter
 // Cast uint8_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(uint8_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint8_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                 width, scale);
+bool TryCastToDecimal::Operation(uint8_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                 scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint8_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint8_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                 width, scale);
+bool TryCastToDecimal::Operation(uint8_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                 scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint8_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint8_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                 width, scale);
+bool TryCastToDecimal::Operation(uint8_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                 scale);
 }
 template <>
 bool TryCastToDecimal::Operation(uint8_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
@@ -2225,19 +2254,22 @@ bool TryCastToDecimal::Operation(uint8_t input, hugeint_t &result, CastParameter
 // Cast uint16_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(uint16_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint16_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                  width, scale);
+bool TryCastToDecimal::Operation(uint16_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                  scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint16_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint16_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                  width, scale);
+bool TryCastToDecimal::Operation(uint16_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                  scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint16_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint16_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                  width, scale);
+bool TryCastToDecimal::Operation(uint16_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                  scale);
 }
 template <>
 bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
@@ -2249,19 +2281,22 @@ bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, CastParamete
 // Cast uint32_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(uint32_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint32_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                  width, scale);
+bool TryCastToDecimal::Operation(uint32_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                  scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint32_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint32_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                  width, scale);
+bool TryCastToDecimal::Operation(uint32_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                  scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint32_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint32_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                  width, scale);
+bool TryCastToDecimal::Operation(uint32_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                  scale);
 }
 template <>
 bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
@@ -2273,19 +2308,22 @@ bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, CastParamete
 // Cast uint64_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(uint64_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint64_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                  width, scale);
+bool TryCastToDecimal::Operation(uint64_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                  scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint64_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint64_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                  width, scale);
+bool TryCastToDecimal::Operation(uint64_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                  scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint64_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint64_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters,
-	                                                                                  width, scale);
+bool TryCastToDecimal::Operation(uint64_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters, width,
+	                                                                                  scale);
 }
 template <>
 bool TryCastToDecimal::Operation(uint64_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
@@ -2392,42 +2430,50 @@ bool DoubleToDecimalCast(SRC input, DST &result, CastParameters &parameters, uin
 }
 
 template <>
-bool TryCastToDecimal::Operation(float input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(float input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return DoubleToDecimalCast<float, int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(float input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(float input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return DoubleToDecimalCast<float, int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(float input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(float input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return DoubleToDecimalCast<float, int64_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(float input, hugeint_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(float input, hugeint_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return DoubleToDecimalCast<float, hugeint_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(double input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(double input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return DoubleToDecimalCast<double, int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(double input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(double input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return DoubleToDecimalCast<double, int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(double input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(double input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return DoubleToDecimalCast<double, int64_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(double input, hugeint_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastToDecimal::Operation(double input, hugeint_t &result, CastParameters &parameters, uint8_t width,
+                                 uint8_t scale) {
 	return DoubleToDecimalCast<double, hugeint_t>(input, result, parameters, width, scale);
 }
 
@@ -2468,15 +2514,18 @@ bool TryCastHugeDecimalToNumeric(hugeint_t input, DST &result, CastParameters &p
 // Cast Decimal -> int8_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCastDecimalToNumeric<int16_t, int8_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCastDecimalToNumeric<int32_t, int8_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCastDecimalToNumeric<int64_t, int8_t>(input, result, parameters, scale);
 }
 template <>
@@ -2712,17 +2761,20 @@ bool TryCastDecimalToFloatingPoint(SRC input, DST &result, uint8_t scale) {
 
 // DECIMAL -> FLOAT
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int16_t input, float &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int16_t, float>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int32_t input, float &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int32_t, float>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int64_t input, float &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int64_t, float>(input, result, scale);
 }
 
@@ -2734,17 +2786,20 @@ bool TryCastFromDecimal::Operation(hugeint_t input, float &result, CastParameter
 
 // DECIMAL -> DOUBLE
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int16_t input, double &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int16_t, double>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int32_t input, double &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int32_t, double>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int64_t input, double &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int64_t, double>(input, result, scale);
 }
 

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1009,20 +1009,20 @@ bool TryCast::Operation(string_t input, double &result, bool strict) {
 }
 
 template <>
-bool TryCastErrorMessageCommaSeparated::Operation(string_t input, float &result, string *error_message, bool strict) {
-	if (!TryDoubleCast<float>(input.GetData(), input.GetSize(), result, strict, ',')) {
+bool TryCastErrorMessageCommaSeparated::Operation(string_t input, float &result, CastParameters &parameters) {
+	if (!TryDoubleCast<float>(input.GetData(), input.GetSize(), result, parameters.strict, ',')) {
 		HandleCastError::AssignError(StringUtil::Format("Could not cast string to float: \"%s\"", input.GetString()),
-		                             error_message);
+		                             parameters);
 		return false;
 	}
 	return true;
 }
 
 template <>
-bool TryCastErrorMessageCommaSeparated::Operation(string_t input, double &result, string *error_message, bool strict) {
-	if (!TryDoubleCast<double>(input.GetData(), input.GetSize(), result, strict, ',')) {
+bool TryCastErrorMessageCommaSeparated::Operation(string_t input, double &result, CastParameters &parameters) {
+	if (!TryDoubleCast<double>(input.GetData(), input.GetSize(), result, parameters.strict, ',')) {
 		HandleCastError::AssignError(StringUtil::Format("Could not cast string to double: \"%s\"", input.GetString()),
-		                             error_message);
+		                             parameters);
 		return false;
 	}
 	return true;
@@ -1331,10 +1331,9 @@ string_t CastFromPointer::Operation(uintptr_t input, Vector &vector) {
 // Cast To Blob
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToBlob::Operation(string_t input, string_t &result, Vector &result_vector, string *error_message,
-                              bool strict) {
+bool TryCastToBlob::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters) {
 	idx_t result_size;
-	if (!Blob::TryGetBlobSize(input, result_size, error_message)) {
+	if (!Blob::TryGetBlobSize(input, result_size, parameters.error_message)) {
 		return false;
 	}
 
@@ -1348,10 +1347,9 @@ bool TryCastToBlob::Operation(string_t input, string_t &result, Vector &result_v
 // Cast To Bit
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToBit::Operation(string_t input, string_t &result, Vector &result_vector, string *error_message,
-                             bool strict) {
+bool TryCastToBit::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters) {
 	idx_t result_size;
-	if (!Bit::TryGetBitStringSize(input, result_size, error_message)) {
+	if (!Bit::TryGetBitStringSize(input, result_size, parameters.error_message)) {
 		return false;
 	}
 
@@ -1362,32 +1360,32 @@ bool TryCastToBit::Operation(string_t input, string_t &result, Vector &result_ve
 }
 
 template <>
-bool CastFromBitToNumeric::Operation(string_t input, bool &result, bool strict) {
+bool CastFromBitToNumeric::Operation(string_t input, bool &result, CastParameters &parameters) {
 	D_ASSERT(input.GetSize() > 1);
 
 	uint8_t value;
-	bool success = CastFromBitToNumeric::Operation(input, value, strict);
+	bool success = CastFromBitToNumeric::Operation(input, value, parameters);
 	result = (value > 0);
 	return (success);
 }
 
 template <>
-bool CastFromBitToNumeric::Operation(string_t input, hugeint_t &result, bool strict) {
+bool CastFromBitToNumeric::Operation(string_t input, hugeint_t &result, CastParameters &parameters) {
 	D_ASSERT(input.GetSize() > 1);
 
 	if (input.GetSize() - 1 > sizeof(hugeint_t)) {
-		throw ConversionException("Bitstring doesn't fit inside of %s", GetTypeId<hugeint_t>());
+		throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s", GetTypeId<hugeint_t>());
 	}
 	Bit::BitToNumeric(input, result);
 	return (true);
 }
 
 template <>
-bool CastFromBitToNumeric::Operation(string_t input, uhugeint_t &result, bool strict) {
+bool CastFromBitToNumeric::Operation(string_t input, uhugeint_t &result, CastParameters &parameters) {
 	D_ASSERT(input.GetSize() > 1);
 
 	if (input.GetSize() - 1 > sizeof(uhugeint_t)) {
-		throw ConversionException("Bitstring doesn't fit inside of %s", GetTypeId<uhugeint_t>());
+		throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s", GetTypeId<uhugeint_t>());
 	}
 	Bit::BitToNumeric(input, result);
 	return (true);
@@ -1408,8 +1406,7 @@ string_t CastFromUUID::Operation(hugeint_t input, Vector &vector) {
 // Cast To UUID
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToUUID::Operation(string_t input, hugeint_t &result, Vector &result_vector, string *error_message,
-                              bool strict) {
+bool TryCastToUUID::Operation(string_t input, hugeint_t &result, Vector &result_vector, CastParameters &parameters) {
 	return UUID::FromString(input.GetString(), result);
 }
 
@@ -1417,9 +1414,9 @@ bool TryCastToUUID::Operation(string_t input, hugeint_t &result, Vector &result_
 // Cast To Date
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastErrorMessage::Operation(string_t input, date_t &result, string *error_message, bool strict) {
-	if (!TryCast::Operation<string_t, date_t>(input, result, strict)) {
-		HandleCastError::AssignError(Date::ConversionError(input), error_message);
+bool TryCastErrorMessage::Operation(string_t input, date_t &result, CastParameters &parameters) {
+	if (!TryCast::Operation<string_t, date_t>(input, result, parameters.strict)) {
+		HandleCastError::AssignError(Date::ConversionError(input), parameters);
 		return false;
 	}
 	return true;
@@ -1441,9 +1438,9 @@ date_t Cast::Operation(string_t input) {
 // Cast To Time
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastErrorMessage::Operation(string_t input, dtime_t &result, string *error_message, bool strict) {
-	if (!TryCast::Operation<string_t, dtime_t>(input, result, strict)) {
-		HandleCastError::AssignError(Time::ConversionError(input), error_message);
+bool TryCastErrorMessage::Operation(string_t input, dtime_t &result, CastParameters &parameters) {
+	if (!TryCast::Operation<string_t, dtime_t>(input, result, parameters.strict)) {
+		HandleCastError::AssignError(Time::ConversionError(input), parameters);
 		return false;
 	}
 	return true;
@@ -1464,9 +1461,9 @@ dtime_t Cast::Operation(string_t input) {
 // Cast To TimeTZ
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastErrorMessage::Operation(string_t input, dtime_tz_t &result, string *error_message, bool strict) {
-	if (!TryCast::Operation<string_t, dtime_tz_t>(input, result, strict)) {
-		HandleCastError::AssignError(Time::ConversionError(input), error_message);
+bool TryCastErrorMessage::Operation(string_t input, dtime_tz_t &result, CastParameters &parameters) {
+	if (!TryCast::Operation<string_t, dtime_tz_t>(input, result, parameters.strict)) {
+		HandleCastError::AssignError(Time::ConversionError(input), parameters);
 		return false;
 	}
 	return true;
@@ -1491,15 +1488,15 @@ dtime_tz_t Cast::Operation(string_t input) {
 // Cast To Timestamp
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastErrorMessage::Operation(string_t input, timestamp_t &result, string *error_message, bool strict) {
+bool TryCastErrorMessage::Operation(string_t input, timestamp_t &result, CastParameters &parameters) {
 	auto cast_result = Timestamp::TryConvertTimestamp(input.GetData(), input.GetSize(), result);
 	if (cast_result == TimestampCastResult::SUCCESS) {
 		return true;
 	}
 	if (cast_result == TimestampCastResult::ERROR_INCORRECT_FORMAT) {
-		HandleCastError::AssignError(Timestamp::ConversionError(input), error_message);
+		HandleCastError::AssignError(Timestamp::ConversionError(input), parameters);
 	} else {
-		HandleCastError::AssignError(Timestamp::UnsupportedTimezoneError(input), error_message);
+		HandleCastError::AssignError(Timestamp::UnsupportedTimezoneError(input), parameters);
 	}
 	return false;
 }
@@ -1518,8 +1515,8 @@ timestamp_t Cast::Operation(string_t input) {
 // Cast From Interval
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastErrorMessage::Operation(string_t input, interval_t &result, string *error_message, bool strict) {
-	return Interval::FromCString(input.GetData(), input.GetSize(), result, error_message, strict);
+bool TryCastErrorMessage::Operation(string_t input, interval_t &result, CastParameters &parameters) {
+	return Interval::FromCString(input.GetData(), input.GetSize(), result, parameters.error_message, parameters.strict);
 }
 
 //===--------------------------------------------------------------------===//
@@ -1931,7 +1928,7 @@ struct DecimalCastOperation {
 };
 
 template <class T, char decimal_separator = '.'>
-bool TryDecimalStringCast(string_t input, T &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryDecimalStringCast(string_t input, T &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	DecimalCastData<T> state;
 	state.result = 0;
 	state.width = width;
@@ -1946,7 +1943,7 @@ bool TryDecimalStringCast(string_t input, T &result, string *error_message, uint
 	        input.GetData(), input.GetSize(), state, false)) {
 		string error = StringUtil::Format("Could not convert string \"%s\" to DECIMAL(%d,%d)", input.GetString(),
 		                                  (int)width, (int)scale);
-		HandleCastError::AssignError(error, error_message);
+		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
 	result = state.result;
@@ -1954,48 +1951,48 @@ bool TryDecimalStringCast(string_t input, T &result, string *error_message, uint
 }
 
 template <>
-bool TryCastToDecimal::Operation(string_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryDecimalStringCast<int16_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(string_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryDecimalStringCast<int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(string_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryDecimalStringCast<int32_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(string_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryDecimalStringCast<int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(string_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryDecimalStringCast<int64_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(string_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryDecimalStringCast<int64_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(string_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(string_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return TryDecimalStringCast<hugeint_t>(input, result, error_message, width, scale);
+	return TryDecimalStringCast<hugeint_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimalCommaSeparated::Operation(string_t input, int16_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimalCommaSeparated::Operation(string_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                                uint8_t scale) {
-	return TryDecimalStringCast<int16_t, ','>(input, result, error_message, width, scale);
+	return TryDecimalStringCast<int16_t, ','>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimalCommaSeparated::Operation(string_t input, int32_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimalCommaSeparated::Operation(string_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                                uint8_t scale) {
-	return TryDecimalStringCast<int32_t, ','>(input, result, error_message, width, scale);
+	return TryDecimalStringCast<int32_t, ','>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimalCommaSeparated::Operation(string_t input, int64_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimalCommaSeparated::Operation(string_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                                uint8_t scale) {
-	return TryDecimalStringCast<int64_t, ','>(input, result, error_message, width, scale);
+	return TryDecimalStringCast<int64_t, ','>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimalCommaSeparated::Operation(string_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimalCommaSeparated::Operation(string_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                                uint8_t scale) {
-	return TryDecimalStringCast<hugeint_t, ','>(input, result, error_message, width, scale);
+	return TryDecimalStringCast<hugeint_t, ','>(input, result, parameters, width, scale);
 }
 
 template <>
@@ -2024,7 +2021,7 @@ string_t StringCastFromDecimal::Operation(hugeint_t input, uint8_t width, uint8_
 // Decimal <-> Bool
 //===--------------------------------------------------------------------===//
 template <class T, class OP = NumericHelper>
-bool TryCastBoolToDecimal(bool input, T &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastBoolToDecimal(bool input, T &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	if (width > scale) {
 		result = input ? OP::POWERS_OF_TEN[scale] : 0;
 		return true;
@@ -2034,42 +2031,42 @@ bool TryCastBoolToDecimal(bool input, T &result, string *error_message, uint8_t 
 }
 
 template <>
-bool TryCastToDecimal::Operation(bool input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryCastBoolToDecimal<int16_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(bool input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(bool input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryCastBoolToDecimal<int32_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(bool input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(bool input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryCastBoolToDecimal<int64_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(bool input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<int64_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(bool input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryCastBoolToDecimal<hugeint_t, Hugeint>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(bool input, hugeint_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<hugeint_t, Hugeint>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int16_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCast::Operation<int16_t, bool>(input, result);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int32_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCast::Operation<int32_t, bool>(input, result);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int64_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCast::Operation<int64_t, bool>(input, result);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCast::Operation<hugeint_t, bool>(input, result);
 }
 
@@ -2091,12 +2088,12 @@ struct UnsignedToDecimalOperator {
 };
 
 template <class SRC, class DST, class OP = SignedToDecimalOperator>
-bool StandardNumericToDecimalCast(SRC input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+bool StandardNumericToDecimalCast(SRC input, DST &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	// check for overflow
 	DST max_width = NumericHelper::POWERS_OF_TEN[width - scale];
 	if (OP::template Operation<SRC, DST>(input, max_width)) {
 		string error = StringUtil::Format("Could not cast value %d to DECIMAL(%d,%d)", input, width, scale);
-		HandleCastError::AssignError(error, error_message);
+		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
 	result = DST(input) * NumericHelper::POWERS_OF_TEN[scale];
@@ -2104,13 +2101,13 @@ bool StandardNumericToDecimalCast(SRC input, DST &result, string *error_message,
 }
 
 template <class SRC>
-bool NumericToHugeDecimalCast(SRC input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+bool NumericToHugeDecimalCast(SRC input, hugeint_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	// check for overflow
 	hugeint_t max_width = Hugeint::POWERS_OF_TEN[width - scale];
 	hugeint_t hinput = Hugeint::Convert(input);
 	if (hinput >= max_width || hinput <= -max_width) {
 		string error = StringUtil::Format("Could not cast value %s to DECIMAL(%d,%d)", hinput.ToString(), width, scale);
-		HandleCastError::AssignError(error, error_message);
+		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
 	result = hinput * Hugeint::POWERS_OF_TEN[scale];
@@ -2121,191 +2118,191 @@ bool NumericToHugeDecimalCast(SRC input, hugeint_t &result, string *error_messag
 // Cast int8_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(int8_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int8_t, int16_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int8_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int8_t, int16_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int8_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int8_t, int32_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int8_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int8_t, int32_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int8_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int8_t, int64_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int8_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int8_t, int64_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return NumericToHugeDecimalCast<int8_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return NumericToHugeDecimalCast<int8_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast int16_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(int16_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int16_t, int16_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int16_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int16_t, int16_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int16_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int16_t, int32_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int16_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int16_t, int32_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int16_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int16_t, int64_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int16_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int16_t, int64_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int16_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(int16_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return NumericToHugeDecimalCast<int16_t>(input, result, error_message, width, scale);
+	return NumericToHugeDecimalCast<int16_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast int32_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(int32_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int32_t, int16_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int32_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int32_t, int16_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int32_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int32_t, int32_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int32_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int32_t, int32_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int32_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int32_t, int64_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int32_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int32_t, int64_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int32_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(int32_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return NumericToHugeDecimalCast<int32_t>(input, result, error_message, width, scale);
+	return NumericToHugeDecimalCast<int32_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast int64_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(int64_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int64_t, int16_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int64_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int64_t, int16_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int64_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int64_t, int32_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int64_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int64_t, int32_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int64_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<int64_t, int64_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(int64_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int64_t, int64_t>(input, result, parameters, width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(int64_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(int64_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return NumericToHugeDecimalCast<int64_t>(input, result, error_message, width, scale);
+	return NumericToHugeDecimalCast<int64_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast uint8_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(uint8_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint8_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint8_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                 width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint8_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint8_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint8_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                 width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint8_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint8_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint8_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                 width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint8_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(uint8_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return NumericToHugeDecimalCast<uint8_t>(input, result, error_message, width, scale);
+	return NumericToHugeDecimalCast<uint8_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast uint16_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(uint16_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint16_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint16_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                  width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint16_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint16_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint16_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                  width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint16_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint16_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint16_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                  width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return NumericToHugeDecimalCast<uint16_t>(input, result, error_message, width, scale);
+	return NumericToHugeDecimalCast<uint16_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast uint32_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(uint32_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint32_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint32_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                  width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint32_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint32_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint32_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                  width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint32_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint32_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint32_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                  width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return NumericToHugeDecimalCast<uint32_t>(input, result, error_message, width, scale);
+	return NumericToHugeDecimalCast<uint32_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast uint64_t -> Decimal
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastToDecimal::Operation(uint64_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint64_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint64_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int16_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                  width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint64_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint64_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint64_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int32_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                  width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint64_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return StandardNumericToDecimalCast<uint64_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+bool TryCastToDecimal::Operation(uint64_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int64_t, UnsignedToDecimalOperator>(input, result, parameters,
 	                                                                                  width, scale);
 }
 template <>
-bool TryCastToDecimal::Operation(uint64_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(uint64_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return NumericToHugeDecimalCast<uint64_t>(input, result, error_message, width, scale);
+	return NumericToHugeDecimalCast<uint64_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Hugeint -> Decimal Cast
 //===--------------------------------------------------------------------===//
 template <class DST>
-bool HugeintToDecimalCast(hugeint_t input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+bool HugeintToDecimalCast(hugeint_t input, DST &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	// check for overflow
 	hugeint_t max_width = Hugeint::POWERS_OF_TEN[width - scale];
 	if (input >= max_width || input <= -max_width) {
 		string error = StringUtil::Format("Could not cast value %s to DECIMAL(%d,%d)", input.ToString(), width, scale);
-		HandleCastError::AssignError(error, error_message);
+		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
 	result = Hugeint::Cast<DST>(input * Hugeint::POWERS_OF_TEN[scale]);
@@ -2313,39 +2310,39 @@ bool HugeintToDecimalCast(hugeint_t input, DST &result, string *error_message, u
 }
 
 template <>
-bool TryCastToDecimal::Operation(hugeint_t input, int16_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(hugeint_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return HugeintToDecimalCast<int16_t>(input, result, error_message, width, scale);
+	return HugeintToDecimalCast<int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(hugeint_t input, int32_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(hugeint_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return HugeintToDecimalCast<int32_t>(input, result, error_message, width, scale);
+	return HugeintToDecimalCast<int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(hugeint_t input, int64_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(hugeint_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return HugeintToDecimalCast<int64_t>(input, result, error_message, width, scale);
+	return HugeintToDecimalCast<int64_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(hugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(hugeint_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return HugeintToDecimalCast<hugeint_t>(input, result, error_message, width, scale);
+	return HugeintToDecimalCast<hugeint_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Uhugeint -> Decimal Cast
 //===--------------------------------------------------------------------===//
 template <class DST>
-bool UhugeintToDecimalCast(uhugeint_t input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+bool UhugeintToDecimalCast(uhugeint_t input, DST &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	// check for overflow
 	uhugeint_t max_width = Uhugeint::POWERS_OF_TEN[width - scale];
 	if (input >= max_width) {
 		string error = StringUtil::Format("Could not cast value %s to DECIMAL(%d,%d)", input.ToString(), width, scale);
-		HandleCastError::AssignError(error, error_message);
+		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
 	result = Uhugeint::Cast<DST>(input * Uhugeint::POWERS_OF_TEN[scale]);
@@ -2353,41 +2350,41 @@ bool UhugeintToDecimalCast(uhugeint_t input, DST &result, string *error_message,
 }
 
 template <>
-bool TryCastToDecimal::Operation(uhugeint_t input, int16_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(uhugeint_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return UhugeintToDecimalCast<int16_t>(input, result, error_message, width, scale);
+	return UhugeintToDecimalCast<int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(uhugeint_t input, int32_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(uhugeint_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return UhugeintToDecimalCast<int32_t>(input, result, error_message, width, scale);
+	return UhugeintToDecimalCast<int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(uhugeint_t input, int64_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(uhugeint_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return UhugeintToDecimalCast<int64_t>(input, result, error_message, width, scale);
+	return UhugeintToDecimalCast<int64_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(uhugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastToDecimal::Operation(uhugeint_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                  uint8_t scale) {
-	return UhugeintToDecimalCast<hugeint_t>(input, result, error_message, width, scale);
+	return UhugeintToDecimalCast<hugeint_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Float/Double -> Decimal Cast
 //===--------------------------------------------------------------------===//
 template <class SRC, class DST>
-bool DoubleToDecimalCast(SRC input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+bool DoubleToDecimalCast(SRC input, DST &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	double value = input * NumericHelper::DOUBLE_POWERS_OF_TEN[scale];
 	// Add the sign (-1, 0, 1) times a tiny value to fix floating point issues (issue 3091)
 	double sign = (double(0) < value) - (value < double(0));
 	value += 1e-9 * sign;
 	if (value <= -NumericHelper::DOUBLE_POWERS_OF_TEN[width] || value >= NumericHelper::DOUBLE_POWERS_OF_TEN[width]) {
 		string error = StringUtil::Format("Could not cast value %f to DECIMAL(%d,%d)", value, width, scale);
-		HandleCastError::AssignError(error, error_message);
+		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
 	result = Cast::Operation<SRC, DST>(value);
@@ -2395,50 +2392,50 @@ bool DoubleToDecimalCast(SRC input, DST &result, string *error_message, uint8_t 
 }
 
 template <>
-bool TryCastToDecimal::Operation(float input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return DoubleToDecimalCast<float, int16_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(float input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(float input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return DoubleToDecimalCast<float, int32_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(float input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(float input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return DoubleToDecimalCast<float, int64_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(float input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, int64_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(float input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return DoubleToDecimalCast<float, hugeint_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(float input, hugeint_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, hugeint_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(double input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return DoubleToDecimalCast<double, int16_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(double input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, int16_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(double input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return DoubleToDecimalCast<double, int32_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(double input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, int32_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(double input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return DoubleToDecimalCast<double, int64_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(double input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, int64_t>(input, result, parameters, width, scale);
 }
 
 template <>
-bool TryCastToDecimal::Operation(double input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return DoubleToDecimalCast<double, hugeint_t>(input, result, error_message, width, scale);
+bool TryCastToDecimal::Operation(double input, hugeint_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, hugeint_t>(input, result, parameters, width, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Decimal -> Numeric Cast
 //===--------------------------------------------------------------------===//
 template <class SRC, class DST>
-bool TryCastDecimalToNumeric(SRC input, DST &result, string *error_message, uint8_t scale) {
+bool TryCastDecimalToNumeric(SRC input, DST &result, CastParameters &parameters, uint8_t scale) {
 	// Round away from 0.
 	const auto power = NumericHelper::POWERS_OF_TEN[scale];
 	// https://graphics.stanford.edu/~seander/bithacks.html#ConditionalNegate
@@ -2447,21 +2444,21 @@ bool TryCastDecimalToNumeric(SRC input, DST &result, string *error_message, uint
 	const auto scaled_value = (input + rounding) / power;
 	if (!TryCast::Operation<SRC, DST>(scaled_value, result)) {
 		string error = StringUtil::Format("Failed to cast decimal value %d to type %s", scaled_value, GetTypeId<DST>());
-		HandleCastError::AssignError(error, error_message);
+		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
 	return true;
 }
 
 template <class DST>
-bool TryCastHugeDecimalToNumeric(hugeint_t input, DST &result, string *error_message, uint8_t scale) {
+bool TryCastHugeDecimalToNumeric(hugeint_t input, DST &result, CastParameters &parameters, uint8_t scale) {
 	const auto power = Hugeint::POWERS_OF_TEN[scale];
 	const auto rounding = ((input < 0) ? -power : power) / 2;
 	auto scaled_value = (input + rounding) / power;
 	if (!TryCast::Operation<hugeint_t, DST>(scaled_value, result)) {
 		string error = StringUtil::Format("Failed to cast decimal value %s to type %s",
 		                                  ConvertToString::Operation(scaled_value), GetTypeId<DST>());
-		HandleCastError::AssignError(error, error_message);
+		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
 	return true;
@@ -2471,237 +2468,237 @@ bool TryCastHugeDecimalToNumeric(hugeint_t input, DST &result, string *error_mes
 // Cast Decimal -> int8_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, int8_t>(input, result, error_message, scale);
+bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, int8_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, int8_t>(input, result, error_message, scale);
+bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, int8_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, int8_t>(input, result, error_message, scale);
+bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, int8_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, int8_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, int8_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<int8_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<int8_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal -> int16_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, int16_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int16_t, int16_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, int16_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int32_t, int16_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, int16_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int64_t, int16_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, int16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<int16_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<int16_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal -> int32_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, int32_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int16_t, int32_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, int32_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int32_t, int32_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, int32_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int64_t, int32_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, int32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<int32_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<int32_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal -> int64_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, int64_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int16_t, int64_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, int64_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int32_t, int64_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, int64_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int64_t, int64_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, int64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<int64_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<int64_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal -> uint8_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uint8_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, uint8_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, uint8_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int16_t, uint8_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uint8_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, uint8_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, uint8_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int32_t, uint8_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uint8_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, uint8_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, uint8_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int64_t, uint8_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uint8_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uint8_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<uint8_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<uint8_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal -> uint16_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uint16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, uint16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, uint16_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int16_t, uint16_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uint16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, uint16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, uint16_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int32_t, uint16_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uint16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, uint16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, uint16_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int64_t, uint16_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uint16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uint16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<uint16_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<uint16_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal -> uint32_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uint32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, uint32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, uint32_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int16_t, uint32_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uint32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, uint32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, uint32_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int32_t, uint32_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uint32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, uint32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, uint32_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int64_t, uint32_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uint32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uint32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<uint32_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<uint32_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal -> uint64_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uint64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, uint64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, uint64_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int16_t, uint64_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uint64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, uint64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, uint64_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int32_t, uint64_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uint64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, uint64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, uint64_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int64_t, uint64_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uint64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uint64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<uint64_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<uint64_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal -> hugeint_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, hugeint_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int16_t, hugeint_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, hugeint_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int32_t, hugeint_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, hugeint_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int64_t, hugeint_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<hugeint_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<hugeint_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal -> uhugeint_t
 //===--------------------------------------------------------------------===//
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uhugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, uhugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int16_t, uhugeint_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int16_t, uhugeint_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uhugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, uhugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int32_t, uhugeint_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int32_t, uhugeint_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uhugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, uhugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastDecimalToNumeric<int64_t, uhugeint_t>(input, result, error_message, scale);
+	return TryCastDecimalToNumeric<int64_t, uhugeint_t>(input, result, parameters, scale);
 }
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uhugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uhugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
-	return TryCastHugeDecimalToNumeric<uhugeint_t>(input, result, error_message, scale);
+	return TryCastHugeDecimalToNumeric<uhugeint_t>(input, result, parameters, scale);
 }
 
 //===--------------------------------------------------------------------===//
@@ -2715,44 +2712,44 @@ bool TryCastDecimalToFloatingPoint(SRC input, DST &result, uint8_t scale) {
 
 // DECIMAL -> FLOAT
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, float &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int16_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int16_t, float>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, float &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int32_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int32_t, float>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, float &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int64_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int64_t, float>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, float &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, float &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<hugeint_t, float>(input, result, scale);
 }
 
 // DECIMAL -> DOUBLE
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, double &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int16_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int16_t, double>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, double &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int32_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int32_t, double>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, double &result, string *error_message, uint8_t width, uint8_t scale) {
+bool TryCastFromDecimal::Operation(int64_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<int64_t, double>(input, result, scale);
 }
 
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, double &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, double &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale) {
 	return TryCastDecimalToFloatingPoint<hugeint_t, double>(input, result, scale);
 }

--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -31,11 +31,13 @@ void ExpressionExecutor::Execute(const BoundCastExpression &expr, ExpressionStat
 	if (expr.try_cast) {
 		string error_message;
 		CastParameters parameters(expr.bound_cast.cast_data.get(), false, &error_message, lstate);
+		parameters.query_location = expr.query_location;
 		expr.bound_cast.function(child, result, count, parameters);
 	} else {
 		// cast it to the type specified by the cast expression
 		D_ASSERT(result.GetType() == expr.return_type);
 		CastParameters parameters(expr.bound_cast.cast_data.get(), false, nullptr, lstate);
+		parameters.query_location = expr.query_location;
 		expr.bound_cast.function(child, result, count, parameters);
 	}
 }

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -548,6 +548,7 @@ void StringValueScanner::Flush(DataChunk &insert_chunk) {
 			result_vector.Reinterpret(parse_vector);
 		} else {
 			string error_message;
+			CastParameters parameters(false, &error_message);
 			bool success;
 			idx_t line_error = 0;
 			bool line_error_set = true;
@@ -556,7 +557,7 @@ void StringValueScanner::Flush(DataChunk &insert_chunk) {
 			    type.id() == LogicalTypeId::DATE) {
 				// use the date format to cast the chunk
 				success = CSVCast::TryCastDateVector(state_machine->options.dialect_options.date_format, parse_vector,
-				                                     result_vector, parse_chunk.size(), error_message, line_error);
+				                                     result_vector, parse_chunk.size(), parameters, line_error);
 			} else if (!state_machine->options.dialect_options.date_format.at(LogicalTypeId::TIMESTAMP)
 			                .GetValue()
 			                .Empty() &&
@@ -564,15 +565,15 @@ void StringValueScanner::Flush(DataChunk &insert_chunk) {
 				// use the date format to cast the chunk
 				success =
 				    CSVCast::TryCastTimestampVector(state_machine->options.dialect_options.date_format, parse_vector,
-				                                    result_vector, parse_chunk.size(), error_message);
+				                                    result_vector, parse_chunk.size(), parameters);
 			} else if (state_machine->options.decimal_separator != "." &&
 			           (type.id() == LogicalTypeId::FLOAT || type.id() == LogicalTypeId::DOUBLE)) {
 				success =
 				    CSVCast::TryCastFloatingVectorCommaSeparated(state_machine->options, parse_vector, result_vector,
-				                                                 parse_chunk.size(), error_message, type, line_error);
+				                                                 parse_chunk.size(), parameters, type, line_error);
 			} else if (state_machine->options.decimal_separator != "." && type.id() == LogicalTypeId::DECIMAL) {
 				success = CSVCast::TryCastDecimalVectorCommaSeparated(
-				    state_machine->options, parse_vector, result_vector, parse_chunk.size(), error_message, type);
+				    state_machine->options, parse_vector, result_vector, parse_chunk.size(), parameters, type);
 			} else {
 				// target type is not varchar: perform a cast
 				success = VectorOperations::TryCast(buffer_manager->context, parse_vector, result_vector,

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -563,9 +563,8 @@ void StringValueScanner::Flush(DataChunk &insert_chunk) {
 			                .Empty() &&
 			           type.id() == LogicalTypeId::TIMESTAMP) {
 				// use the date format to cast the chunk
-				success =
-				    CSVCast::TryCastTimestampVector(state_machine->options.dialect_options.date_format, parse_vector,
-				                                    result_vector, parse_chunk.size(), parameters);
+				success = CSVCast::TryCastTimestampVector(state_machine->options.dialect_options.date_format,
+				                                          parse_vector, result_vector, parse_chunk.size(), parameters);
 			} else if (state_machine->options.decimal_separator != "." &&
 			           (type.id() == LogicalTypeId::FLOAT || type.id() == LogicalTypeId::DOUBLE)) {
 				success =

--- a/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
@@ -9,7 +9,8 @@ struct TryCastFloatingOperator {
 	static bool Operation(string_t input) {
 		T result;
 		string error_message;
-		return OP::Operation(input, result, &error_message);
+		CastParameters parameters(false, &error_message);
+		return OP::Operation(input, result, parameters);
 	}
 };
 

--- a/src/execution/operator/csv_scanner/sniffer/type_refinement.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/type_refinement.cpp
@@ -11,16 +11,18 @@ bool CSVSniffer::TryCastVector(Vector &parse_chunk_col, idx_t size, const Logica
 	    sql_type == LogicalTypeId::DATE) {
 		// use the date format to cast the chunk
 		string error_message;
+		CastParameters parameters(false, &error_message);
 		idx_t line_error;
 		return CSVCast::TryCastDateVector(sniffing_state_machine.dialect_options.date_format, parse_chunk_col,
-		                                  dummy_result, size, error_message, line_error);
+		                                  dummy_result, size, parameters, line_error);
 	}
 	if (!sniffing_state_machine.dialect_options.date_format[LogicalTypeId::TIMESTAMP].GetValue().Empty() &&
 	    sql_type == LogicalTypeId::TIMESTAMP) {
 		// use the timestamp format to cast the chunk
 		string error_message;
+		CastParameters parameters(false, &error_message);
 		return CSVCast::TryCastTimestampVector(sniffing_state_machine.dialect_options.date_format, parse_chunk_col,
-		                                       dummy_result, size, error_message);
+		                                       dummy_result, size, parameters);
 	}
 	// target type is not varchar: perform a cast
 	string error_message;

--- a/src/function/cast/array_casts.cpp
+++ b/src/function/cast/array_casts.cpp
@@ -46,7 +46,7 @@ static bool ArrayToArrayCast(Vector &source, Vector &result, idx_t count, CastPa
 		// Cant cast between arrays of different sizes
 		auto msg = StringUtil::Format("Cannot cast array of size %u to array of size %u", source_array_size,
 		                              target_array_size);
-		HandleCastError::AssignError(msg, parameters.error_message);
+		HandleCastError::AssignError(msg, parameters);
 		if (!parameters.strict) {
 			// if this was a TRY_CAST, we know every row will fail, so just return null
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/function/cast/bit_cast.cpp
+++ b/src/function/cast/bit_cast.cpp
@@ -11,31 +11,31 @@ BoundCastInfo DefaultCasts::BitCastSwitch(BindCastInput &input, const LogicalTyp
 	switch (target.id()) {
 	// Numerics
 	case LogicalTypeId::BOOLEAN:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, bool, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, bool, CastFromBitToNumeric>);
 	case LogicalTypeId::TINYINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, int8_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, int8_t, CastFromBitToNumeric>);
 	case LogicalTypeId::SMALLINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, int16_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, int16_t, CastFromBitToNumeric>);
 	case LogicalTypeId::INTEGER:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, int32_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, int32_t, CastFromBitToNumeric>);
 	case LogicalTypeId::BIGINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, int64_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, int64_t, CastFromBitToNumeric>);
 	case LogicalTypeId::UTINYINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, uint8_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, uint8_t, CastFromBitToNumeric>);
 	case LogicalTypeId::USMALLINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, uint16_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, uint16_t, CastFromBitToNumeric>);
 	case LogicalTypeId::UINTEGER:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, uint32_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, uint32_t, CastFromBitToNumeric>);
 	case LogicalTypeId::UBIGINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, uint64_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, uint64_t, CastFromBitToNumeric>);
 	case LogicalTypeId::HUGEINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, hugeint_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, hugeint_t, CastFromBitToNumeric>);
 	case LogicalTypeId::UHUGEINT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, uhugeint_t, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, uhugeint_t, CastFromBitToNumeric>);
 	case LogicalTypeId::FLOAT:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, float, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, float, CastFromBitToNumeric>);
 	case LogicalTypeId::DOUBLE:
-		return BoundCastInfo(&VectorCastHelpers::TryCastLoop<string_t, double, CastFromBitToNumeric>);
+		return BoundCastInfo(&VectorCastHelpers::TryCastErrorLoop<string_t, double, CastFromBitToNumeric>);
 
 	case LogicalTypeId::BLOB:
 		return BoundCastInfo(&VectorCastHelpers::StringCast<string_t, CastFromBitToBlob>);

--- a/src/function/cast/cast_function_set.cpp
+++ b/src/function/cast/cast_function_set.cpp
@@ -14,6 +14,7 @@ BindCastInput::BindCastInput(CastFunctionSet &function_set, optional_ptr<BindCas
 
 BoundCastInfo BindCastInput::GetCastFunction(const LogicalType &source, const LogicalType &target) {
 	GetCastFunctionInput input(context);
+	input.query_location = query_location;
 	return function_set.GetCastFunction(source, target, input);
 }
 
@@ -47,6 +48,7 @@ BoundCastInfo CastFunctionSet::GetCastFunction(const LogicalType &source, const 
 	for (idx_t i = bind_functions.size(); i > 0; i--) {
 		auto &bind_function = bind_functions[i - 1];
 		BindCastInput input(*this, bind_function.info.get(), get_input.context);
+		input.query_location = get_input.query_location;
 		auto result = bind_function.function(input, source, target);
 		if (result.function) {
 			// found a cast function! return it

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -16,16 +16,16 @@ static bool FromDecimalCast(Vector &source, Vector &result, idx_t count, CastPar
 	switch (source_type.InternalType()) {
 	case PhysicalType::INT16:
 		return VectorCastHelpers::TemplatedDecimalCast<int16_t, T, TryCastFromDecimal>(
-		    source, result, count, parameters.error_message, width, scale);
+		    source, result, count, parameters, width, scale);
 	case PhysicalType::INT32:
 		return VectorCastHelpers::TemplatedDecimalCast<int32_t, T, TryCastFromDecimal>(
-		    source, result, count, parameters.error_message, width, scale);
+		    source, result, count, parameters, width, scale);
 	case PhysicalType::INT64:
 		return VectorCastHelpers::TemplatedDecimalCast<int64_t, T, TryCastFromDecimal>(
-		    source, result, count, parameters.error_message, width, scale);
+		    source, result, count, parameters, width, scale);
 	case PhysicalType::INT128:
 		return VectorCastHelpers::TemplatedDecimalCast<hugeint_t, T, TryCastFromDecimal>(
-		    source, result, count, parameters.error_message, width, scale);
+		    source, result, count, parameters, width, scale);
 	default:
 		throw InternalException("Unimplemented internal type for decimal");
 	}
@@ -33,19 +33,18 @@ static bool FromDecimalCast(Vector &source, Vector &result, idx_t count, CastPar
 
 template <class LIMIT_TYPE, class FACTOR_TYPE = LIMIT_TYPE>
 struct DecimalScaleInput {
-	DecimalScaleInput(Vector &result_p, FACTOR_TYPE factor_p) : result(result_p), factor(factor_p) {
+	DecimalScaleInput(Vector &result_p, FACTOR_TYPE factor_p, CastParameters &parameters) : result(result_p), vector_cast_data(result, parameters), factor(factor_p) {
 	}
-	DecimalScaleInput(Vector &result_p, LIMIT_TYPE limit_p, FACTOR_TYPE factor_p, string *error_message_p,
+	DecimalScaleInput(Vector &result_p, LIMIT_TYPE limit_p, FACTOR_TYPE factor_p, CastParameters &parameters,
 	                  uint8_t source_width_p, uint8_t source_scale_p)
-	    : result(result_p), limit(limit_p), factor(factor_p), error_message(error_message_p),
+	    : result(result_p), vector_cast_data(result, parameters), limit(limit_p), factor(factor_p),
 	      source_width(source_width_p), source_scale(source_scale_p) {
 	}
 
 	Vector &result;
+    VectorTryCastData vector_cast_data;
 	LIMIT_TYPE limit;
 	FACTOR_TYPE factor;
-	bool all_converted = true;
-	string *error_message;
 	uint8_t source_width;
 	uint8_t source_scale;
 };
@@ -66,15 +65,14 @@ struct DecimalScaleUpCheckOperator {
 			auto error = StringUtil::Format("Casting value \"%s\" to type %s failed: value is out of range!",
 			                                Decimal::ToString(input, data->source_width, data->source_scale),
 			                                data->result.GetType().ToString());
-			return HandleVectorCastError::Operation<RESULT_TYPE>(std::move(error), mask, idx, data->error_message,
-			                                                     data->all_converted);
+			return HandleVectorCastError::Operation<RESULT_TYPE>(std::move(error), mask, idx, data->vector_cast_data);
 		}
 		return Cast::Operation<INPUT_TYPE, RESULT_TYPE>(input) * data->factor;
 	}
 };
 
 template <class SOURCE, class DEST, class POWERS_SOURCE, class POWERS_DEST>
-bool TemplatedDecimalScaleUp(Vector &source, Vector &result, idx_t count, string *error_message) {
+bool TemplatedDecimalScaleUp(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	auto source_scale = DecimalType::GetScale(source.GetType());
 	auto source_width = DecimalType::GetWidth(source.GetType());
 	auto result_scale = DecimalType::GetScale(result.GetType());
@@ -84,18 +82,18 @@ bool TemplatedDecimalScaleUp(Vector &source, Vector &result, idx_t count, string
 	DEST multiply_factor = POWERS_DEST::POWERS_OF_TEN[scale_difference];
 	idx_t target_width = result_width - scale_difference;
 	if (source_width < target_width) {
-		DecimalScaleInput<SOURCE, DEST> input(result, multiply_factor);
+		DecimalScaleInput<SOURCE, DEST> input(result, multiply_factor, parameters);
 		// type will always fit: no need to check limit
 		UnaryExecutor::GenericExecute<SOURCE, DEST, DecimalScaleUpOperator>(source, result, count, &input);
 		return true;
 	} else {
 		// type might not fit: check limit
 		auto limit = POWERS_SOURCE::POWERS_OF_TEN[target_width];
-		DecimalScaleInput<SOURCE, DEST> input(result, limit, multiply_factor, error_message, source_width,
+		DecimalScaleInput<SOURCE, DEST> input(result, limit, multiply_factor, parameters, source_width,
 		                                      source_scale);
 		UnaryExecutor::GenericExecute<SOURCE, DEST, DecimalScaleUpCheckOperator>(source, result, count, &input,
-		                                                                         error_message);
-		return input.all_converted;
+		                                                                         parameters.error_message);
+		return input.vector_cast_data.all_converted;
 	}
 }
 
@@ -115,15 +113,14 @@ struct DecimalScaleDownCheckOperator {
 			auto error = StringUtil::Format("Casting value \"%s\" to type %s failed: value is out of range!",
 			                                Decimal::ToString(input, data->source_width, data->source_scale),
 			                                data->result.GetType().ToString());
-			return HandleVectorCastError::Operation<RESULT_TYPE>(std::move(error), mask, idx, data->error_message,
-			                                                     data->all_converted);
+			return HandleVectorCastError::Operation<RESULT_TYPE>(std::move(error), mask, idx, data->vector_cast_data);
 		}
 		return Cast::Operation<INPUT_TYPE, RESULT_TYPE>(input / data->factor);
 	}
 };
 
 template <class SOURCE, class DEST, class POWERS_SOURCE>
-bool TemplatedDecimalScaleDown(Vector &source, Vector &result, idx_t count, string *error_message) {
+bool TemplatedDecimalScaleDown(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	auto source_scale = DecimalType::GetScale(source.GetType());
 	auto source_width = DecimalType::GetWidth(source.GetType());
 	auto result_scale = DecimalType::GetScale(result.GetType());
@@ -133,17 +130,17 @@ bool TemplatedDecimalScaleDown(Vector &source, Vector &result, idx_t count, stri
 	idx_t target_width = result_width + scale_difference;
 	SOURCE divide_factor = POWERS_SOURCE::POWERS_OF_TEN[scale_difference];
 	if (source_width < target_width) {
-		DecimalScaleInput<SOURCE> input(result, divide_factor);
+		DecimalScaleInput<SOURCE> input(result, divide_factor, parameters);
 		// type will always fit: no need to check limit
 		UnaryExecutor::GenericExecute<SOURCE, DEST, DecimalScaleDownOperator>(source, result, count, &input);
 		return true;
 	} else {
 		// type might not fit: check limit
 		auto limit = POWERS_SOURCE::POWERS_OF_TEN[target_width];
-		DecimalScaleInput<SOURCE> input(result, limit, divide_factor, error_message, source_width, source_scale);
+		DecimalScaleInput<SOURCE> input(result, limit, divide_factor, parameters, source_width, source_scale);
 		UnaryExecutor::GenericExecute<SOURCE, DEST, DecimalScaleDownCheckOperator>(source, result, count, &input,
-		                                                                           error_message);
-		return input.all_converted;
+                                                                                   parameters.error_message);
+		return input.vector_cast_data.all_converted;
 	}
 }
 
@@ -160,16 +157,16 @@ static bool DecimalDecimalCastSwitch(Vector &source, Vector &result, idx_t count
 		switch (result.GetType().InternalType()) {
 		case PhysicalType::INT16:
 			return TemplatedDecimalScaleUp<SOURCE, int16_t, POWERS_SOURCE, NumericHelper>(source, result, count,
-			                                                                              parameters.error_message);
+			                                                                              parameters);
 		case PhysicalType::INT32:
 			return TemplatedDecimalScaleUp<SOURCE, int32_t, POWERS_SOURCE, NumericHelper>(source, result, count,
-			                                                                              parameters.error_message);
+			                                                                              parameters);
 		case PhysicalType::INT64:
 			return TemplatedDecimalScaleUp<SOURCE, int64_t, POWERS_SOURCE, NumericHelper>(source, result, count,
-			                                                                              parameters.error_message);
+			                                                                              parameters);
 		case PhysicalType::INT128:
 			return TemplatedDecimalScaleUp<SOURCE, hugeint_t, POWERS_SOURCE, Hugeint>(source, result, count,
-			                                                                          parameters.error_message);
+			                                                                          parameters);
 		default:
 			throw NotImplementedException("Unimplemented internal type for decimal");
 		}
@@ -178,16 +175,16 @@ static bool DecimalDecimalCastSwitch(Vector &source, Vector &result, idx_t count
 		switch (result.GetType().InternalType()) {
 		case PhysicalType::INT16:
 			return TemplatedDecimalScaleDown<SOURCE, int16_t, POWERS_SOURCE>(source, result, count,
-			                                                                 parameters.error_message);
+			                                                                 parameters);
 		case PhysicalType::INT32:
 			return TemplatedDecimalScaleDown<SOURCE, int32_t, POWERS_SOURCE>(source, result, count,
-			                                                                 parameters.error_message);
+			                                                                 parameters);
 		case PhysicalType::INT64:
 			return TemplatedDecimalScaleDown<SOURCE, int64_t, POWERS_SOURCE>(source, result, count,
-			                                                                 parameters.error_message);
+			                                                                 parameters);
 		case PhysicalType::INT128:
 			return TemplatedDecimalScaleDown<SOURCE, hugeint_t, POWERS_SOURCE>(source, result, count,
-			                                                                   parameters.error_message);
+			                                                                   parameters);
 		default:
 			throw NotImplementedException("Unimplemented internal type for decimal");
 		}

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -15,17 +15,17 @@ static bool FromDecimalCast(Vector &source, Vector &result, idx_t count, CastPar
 	auto scale = DecimalType::GetScale(source_type);
 	switch (source_type.InternalType()) {
 	case PhysicalType::INT16:
-		return VectorCastHelpers::TemplatedDecimalCast<int16_t, T, TryCastFromDecimal>(
-		    source, result, count, parameters, width, scale);
+		return VectorCastHelpers::TemplatedDecimalCast<int16_t, T, TryCastFromDecimal>(source, result, count,
+		                                                                               parameters, width, scale);
 	case PhysicalType::INT32:
-		return VectorCastHelpers::TemplatedDecimalCast<int32_t, T, TryCastFromDecimal>(
-		    source, result, count, parameters, width, scale);
+		return VectorCastHelpers::TemplatedDecimalCast<int32_t, T, TryCastFromDecimal>(source, result, count,
+		                                                                               parameters, width, scale);
 	case PhysicalType::INT64:
-		return VectorCastHelpers::TemplatedDecimalCast<int64_t, T, TryCastFromDecimal>(
-		    source, result, count, parameters, width, scale);
+		return VectorCastHelpers::TemplatedDecimalCast<int64_t, T, TryCastFromDecimal>(source, result, count,
+		                                                                               parameters, width, scale);
 	case PhysicalType::INT128:
-		return VectorCastHelpers::TemplatedDecimalCast<hugeint_t, T, TryCastFromDecimal>(
-		    source, result, count, parameters, width, scale);
+		return VectorCastHelpers::TemplatedDecimalCast<hugeint_t, T, TryCastFromDecimal>(source, result, count,
+		                                                                                 parameters, width, scale);
 	default:
 		throw InternalException("Unimplemented internal type for decimal");
 	}
@@ -33,7 +33,8 @@ static bool FromDecimalCast(Vector &source, Vector &result, idx_t count, CastPar
 
 template <class LIMIT_TYPE, class FACTOR_TYPE = LIMIT_TYPE>
 struct DecimalScaleInput {
-	DecimalScaleInput(Vector &result_p, FACTOR_TYPE factor_p, CastParameters &parameters) : result(result_p), vector_cast_data(result, parameters), factor(factor_p) {
+	DecimalScaleInput(Vector &result_p, FACTOR_TYPE factor_p, CastParameters &parameters)
+	    : result(result_p), vector_cast_data(result, parameters), factor(factor_p) {
 	}
 	DecimalScaleInput(Vector &result_p, LIMIT_TYPE limit_p, FACTOR_TYPE factor_p, CastParameters &parameters,
 	                  uint8_t source_width_p, uint8_t source_scale_p)
@@ -42,7 +43,7 @@ struct DecimalScaleInput {
 	}
 
 	Vector &result;
-    VectorTryCastData vector_cast_data;
+	VectorTryCastData vector_cast_data;
 	LIMIT_TYPE limit;
 	FACTOR_TYPE factor;
 	uint8_t source_width;
@@ -89,8 +90,7 @@ bool TemplatedDecimalScaleUp(Vector &source, Vector &result, idx_t count, CastPa
 	} else {
 		// type might not fit: check limit
 		auto limit = POWERS_SOURCE::POWERS_OF_TEN[target_width];
-		DecimalScaleInput<SOURCE, DEST> input(result, limit, multiply_factor, parameters, source_width,
-		                                      source_scale);
+		DecimalScaleInput<SOURCE, DEST> input(result, limit, multiply_factor, parameters, source_width, source_scale);
 		UnaryExecutor::GenericExecute<SOURCE, DEST, DecimalScaleUpCheckOperator>(source, result, count, &input,
 		                                                                         parameters.error_message);
 		return input.vector_cast_data.all_converted;
@@ -139,7 +139,7 @@ bool TemplatedDecimalScaleDown(Vector &source, Vector &result, idx_t count, Cast
 		auto limit = POWERS_SOURCE::POWERS_OF_TEN[target_width];
 		DecimalScaleInput<SOURCE> input(result, limit, divide_factor, parameters, source_width, source_scale);
 		UnaryExecutor::GenericExecute<SOURCE, DEST, DecimalScaleDownCheckOperator>(source, result, count, &input,
-                                                                                   parameters.error_message);
+		                                                                           parameters.error_message);
 		return input.vector_cast_data.all_converted;
 	}
 }
@@ -174,17 +174,13 @@ static bool DecimalDecimalCastSwitch(Vector &source, Vector &result, idx_t count
 		// divide
 		switch (result.GetType().InternalType()) {
 		case PhysicalType::INT16:
-			return TemplatedDecimalScaleDown<SOURCE, int16_t, POWERS_SOURCE>(source, result, count,
-			                                                                 parameters);
+			return TemplatedDecimalScaleDown<SOURCE, int16_t, POWERS_SOURCE>(source, result, count, parameters);
 		case PhysicalType::INT32:
-			return TemplatedDecimalScaleDown<SOURCE, int32_t, POWERS_SOURCE>(source, result, count,
-			                                                                 parameters);
+			return TemplatedDecimalScaleDown<SOURCE, int32_t, POWERS_SOURCE>(source, result, count, parameters);
 		case PhysicalType::INT64:
-			return TemplatedDecimalScaleDown<SOURCE, int64_t, POWERS_SOURCE>(source, result, count,
-			                                                                 parameters);
+			return TemplatedDecimalScaleDown<SOURCE, int64_t, POWERS_SOURCE>(source, result, count, parameters);
 		case PhysicalType::INT128:
-			return TemplatedDecimalScaleDown<SOURCE, hugeint_t, POWERS_SOURCE>(source, result, count,
-			                                                                   parameters);
+			return TemplatedDecimalScaleDown<SOURCE, hugeint_t, POWERS_SOURCE>(source, result, count, parameters);
 		default:
 			throw NotImplementedException("Unimplemented internal type for decimal");
 		}

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -32,6 +32,10 @@ bool DefaultCasts::NopCast(Vector &source, Vector &result, idx_t count, CastPara
 	return true;
 }
 
+void HandleCastError::AssignError(const string &error_message, CastParameters &parameters) {
+    AssignError(error_message, parameters.error_message, parameters.query_location);
+}
+
 static string UnimplementedCastMessage(const LogicalType &source_type, const LogicalType &target_type) {
 	return StringUtil::Format("Unimplemented type for cast (%s -> %s)", source_type.ToString(), target_type.ToString());
 }
@@ -41,7 +45,7 @@ bool DefaultCasts::TryVectorNullCast(Vector &source, Vector &result, idx_t count
 	bool success = true;
 	if (VectorOperations::HasNotNull(source, count)) {
 		HandleCastError::AssignError(UnimplementedCastMessage(source.GetType(), result.GetType()),
-		                             parameters.error_message);
+		                             parameters);
 		success = false;
 	}
 	result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/function/cast/default_casts.cpp
+++ b/src/function/cast/default_casts.cpp
@@ -33,7 +33,7 @@ bool DefaultCasts::NopCast(Vector &source, Vector &result, idx_t count, CastPara
 }
 
 void HandleCastError::AssignError(const string &error_message, CastParameters &parameters) {
-    AssignError(error_message, parameters.error_message, parameters.query_location);
+	AssignError(error_message, parameters.error_message, parameters.query_location);
 }
 
 static string UnimplementedCastMessage(const LogicalType &source_type, const LogicalType &target_type) {
@@ -44,8 +44,7 @@ static string UnimplementedCastMessage(const LogicalType &source_type, const Log
 bool DefaultCasts::TryVectorNullCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	bool success = true;
 	if (VectorOperations::HasNotNull(source, count)) {
-		HandleCastError::AssignError(UnimplementedCastMessage(source.GetType(), result.GetType()),
-		                             parameters);
+		HandleCastError::AssignError(UnimplementedCastMessage(source.GetType(), result.GetType()), parameters);
 		success = false;
 	}
 	result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/function/cast/enum_casts.cpp
+++ b/src/function/cast/enum_casts.cpp
@@ -35,8 +35,7 @@ bool EnumEnumCast(Vector &source, Vector &result, idx_t count, CastParameters &p
 			// key doesn't exist on result enum
 			if (!parameters.error_message) {
 				result_data[i] = HandleVectorCastError::Operation<RES_TYPE>(
-				    CastExceptionText<SRC_TYPE, RES_TYPE>(source_data[src_idx]), result_mask, i,
-					vector_cast_data);
+				    CastExceptionText<SRC_TYPE, RES_TYPE>(source_data[src_idx]), result_mask, i, vector_cast_data);
 			} else {
 				result_mask.SetInvalid(i);
 			}

--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -151,7 +151,7 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 			// Cant cast to array, list size mismatch
 			auto msg = StringUtil::Format("Cannot cast list with length %llu to array with length %u", ldata.length,
 			                              array_size);
-			HandleCastError::AssignError(msg, parameters.error_message);
+			HandleCastError::AssignError(msg, parameters);
 			ConstantVector::SetNull(result, true);
 			return false;
 		}
@@ -189,7 +189,7 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 					all_ok = false;
 					auto msg = StringUtil::Format("Cannot cast list with length %llu to array with length %u",
 					                              ldata[i].length, array_size);
-					HandleCastError::AssignError(msg, parameters.error_message);
+					HandleCastError::AssignError(msg, parameters);
 				}
 				FlatVector::SetNull(result, i, true);
 				for (idx_t array_elem = 0; array_elem < array_size; array_elem++) {
@@ -214,7 +214,7 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 			bool ok = cast_data.child_cast_info.function(source_cc, payload_vector, child_count, child_parameters);
 			if (all_ok && !ok) {
 				all_ok = false;
-				HandleCastError::AssignError(*child_parameters.error_message, parameters.error_message);
+				HandleCastError::AssignError(*child_parameters.error_message, parameters);
 			}
 			// Now do the actual copy onto the result vector, making sure to slice properly in case the lists are out of
 			// order
@@ -246,7 +246,7 @@ static bool ListToArrayCast(Vector &source, Vector &result, idx_t count, CastPar
 				    cast_data.child_cast_info.function(list_cast_input, list_cast_output, array_size, child_parameters);
 				if (all_ok && !ok) {
 					all_ok = false;
-					HandleCastError::AssignError(*child_parameters.error_message, parameters.error_message);
+					HandleCastError::AssignError(*child_parameters.error_message, parameters);
 				}
 				VectorOperations::Copy(list_cast_output, result_cc, array_size, 0, i * array_size);
 

--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -20,9 +20,8 @@ bool StringEnumCastLoop(const string_t *source_data, ValidityMask &source_mask, 
 		if (source_mask.RowIsValid(source_idx)) {
 			auto pos = EnumType::GetPos(result_type, source_data[source_idx]);
 			if (pos == -1) {
-				result_data[i] =
-				    HandleVectorCastError::Operation<T>(CastExceptionText<string_t, T>(source_data[source_idx]),
-				                                        result_mask, i, vector_cast_data);
+				result_data[i] = HandleVectorCastError::Operation<T>(
+				    CastExceptionText<string_t, T>(source_data[source_idx]), result_mask, i, vector_cast_data);
 			} else {
 				result_data[i] = pos;
 			}
@@ -45,7 +44,7 @@ bool StringEnumCast(Vector &source, Vector &result, idx_t count, CastParameters 
 		auto result_data = ConstantVector::GetData<T>(result);
 		auto &result_mask = ConstantVector::Validity(result);
 
-        VectorTryCastData vector_cast_data(result, parameters);
+		VectorTryCastData vector_cast_data(result, parameters);
 		return StringEnumCastLoop(source_data, source_mask, source.GetType(), result_data, result_mask,
 		                          result.GetType(), 1, vector_cast_data, nullptr);
 	}
@@ -61,7 +60,7 @@ bool StringEnumCast(Vector &source, Vector &result, idx_t count, CastParameters 
 		auto result_data = FlatVector::GetData<T>(result);
 		auto &result_mask = FlatVector::Validity(result);
 
-        VectorTryCastData vector_cast_data(result, parameters);
+		VectorTryCastData vector_cast_data(result, parameters);
 		return StringEnumCastLoop(source_data, source_mask, source.GetType(), result_data, result_mask,
 		                          result.GetType(), count, vector_cast_data, source_sel);
 	}
@@ -145,7 +144,7 @@ bool VectorStringToList::StringToNestedTypeCastLoop(const string_t *source_data,
 	auto list_data = ListVector::GetData(result);
 	auto child_data = FlatVector::GetData<string_t>(varchar_vector);
 
-    VectorTryCastData vector_cast_data(result, parameters);
+	VectorTryCastData vector_cast_data(result, parameters);
 	idx_t total = 0;
 	for (idx_t i = 0; i < count; i++) {
 		idx_t idx = i;
@@ -171,7 +170,7 @@ bool VectorStringToList::StringToNestedTypeCastLoop(const string_t *source_data,
 	auto &cast_data = parameters.cast_data->Cast<ListBoundCastData>();
 	CastParameters child_parameters(parameters, cast_data.child_cast_info.cast_data, parameters.local_state);
 	return cast_data.child_cast_info.function(varchar_vector, result_child, total_list_size, child_parameters) &&
-            vector_cast_data.all_converted;
+	       vector_cast_data.all_converted;
 }
 
 static LogicalType InitVarcharStructType(const LogicalType &target) {
@@ -205,7 +204,7 @@ bool VectorStringToStruct::StringToNestedTypeCastLoop(const string_t *source_dat
 		child_masks[child_idx].get().SetAllInvalid(count);
 	}
 
-    VectorTryCastData vector_cast_data(result, parameters);
+	VectorTryCastData vector_cast_data(result, parameters);
 	for (idx_t i = 0; i < count; i++) {
 		idx_t idx = i;
 		if (sel) {
@@ -238,7 +237,7 @@ bool VectorStringToStruct::StringToNestedTypeCastLoop(const string_t *source_dat
 		auto &child_cast_info = cast_data.child_cast_info[child_idx];
 		CastParameters child_parameters(parameters, child_cast_info.cast_data, lstate.local_states[child_idx]);
 		if (!child_cast_info.function(child_varchar_vector, result_child_vector, count, child_parameters)) {
-            vector_cast_data.all_converted = false;
+			vector_cast_data.all_converted = false;
 		}
 	}
 	return vector_cast_data.all_converted;
@@ -286,8 +285,7 @@ bool VectorStringToMap::StringToNestedTypeCastLoop(const string_t *source_data, 
 	ListVector::SetListSize(result, total_elements);
 	auto list_data = ListVector::GetData(result);
 
-
-    VectorTryCastData vector_cast_data(result, parameters);
+	VectorTryCastData vector_cast_data(result, parameters);
 	idx_t total = 0;
 	for (idx_t i = 0; i < count; i++) {
 		idx_t idx = i;
@@ -318,11 +316,11 @@ bool VectorStringToMap::StringToNestedTypeCastLoop(const string_t *source_data, 
 
 	CastParameters key_params(parameters, cast_data.key_cast.cast_data, lstate.key_state);
 	if (!cast_data.key_cast.function(varchar_key_vector, result_key_child, total_elements, key_params)) {
-        vector_cast_data.all_converted = false;
+		vector_cast_data.all_converted = false;
 	}
 	CastParameters val_params(parameters, cast_data.value_cast.cast_data, lstate.value_state);
 	if (!cast_data.value_cast.function(varchar_val_vector, result_val_child, total_elements, val_params)) {
-        vector_cast_data.all_converted = false;
+		vector_cast_data.all_converted = false;
 	}
 
 	auto &key_validity = FlatVector::Validity(result_key_child);
@@ -382,7 +380,7 @@ bool VectorStringToArray::StringToNestedTypeCastLoop(const string_t *source_data
 	Vector varchar_vector(LogicalType::VARCHAR, child_count);
 	auto child_data = FlatVector::GetData<string_t>(varchar_vector);
 
-    VectorTryCastData vector_cast_data(result, parameters);
+	VectorTryCastData vector_cast_data(result, parameters);
 	idx_t total = 0;
 	for (idx_t i = 0; i < count; i++) {
 		idx_t idx = i;

--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -11,8 +11,7 @@ namespace duckdb {
 template <class T>
 bool StringEnumCastLoop(const string_t *source_data, ValidityMask &source_mask, const LogicalType &source_type,
                         T *result_data, ValidityMask &result_mask, const LogicalType &result_type, idx_t count,
-                        string *error_message, const SelectionVector *sel) {
-	bool all_converted = true;
+                        VectorTryCastData &vector_cast_data, const SelectionVector *sel) {
 	for (idx_t i = 0; i < count; i++) {
 		idx_t source_idx = i;
 		if (sel) {
@@ -23,7 +22,7 @@ bool StringEnumCastLoop(const string_t *source_data, ValidityMask &source_mask, 
 			if (pos == -1) {
 				result_data[i] =
 				    HandleVectorCastError::Operation<T>(CastExceptionText<string_t, T>(source_data[source_idx]),
-				                                        result_mask, i, error_message, all_converted);
+				                                        result_mask, i, vector_cast_data);
 			} else {
 				result_data[i] = pos;
 			}
@@ -31,7 +30,7 @@ bool StringEnumCastLoop(const string_t *source_data, ValidityMask &source_mask, 
 			result_mask.SetInvalid(i);
 		}
 	}
-	return all_converted;
+	return vector_cast_data.all_converted;
 }
 
 template <class T>
@@ -46,8 +45,9 @@ bool StringEnumCast(Vector &source, Vector &result, idx_t count, CastParameters 
 		auto result_data = ConstantVector::GetData<T>(result);
 		auto &result_mask = ConstantVector::Validity(result);
 
+        VectorTryCastData vector_cast_data(result, parameters);
 		return StringEnumCastLoop(source_data, source_mask, source.GetType(), result_data, result_mask,
-		                          result.GetType(), 1, parameters.error_message, nullptr);
+		                          result.GetType(), 1, vector_cast_data, nullptr);
 	}
 	default: {
 		UnifiedVectorFormat vdata;
@@ -61,8 +61,9 @@ bool StringEnumCast(Vector &source, Vector &result, idx_t count, CastParameters 
 		auto result_data = FlatVector::GetData<T>(result);
 		auto &result_mask = FlatVector::Validity(result);
 
+        VectorTryCastData vector_cast_data(result, parameters);
 		return StringEnumCastLoop(source_data, source_mask, source.GetType(), result_data, result_mask,
-		                          result.GetType(), count, parameters.error_message, source_sel);
+		                          result.GetType(), count, vector_cast_data, source_sel);
 	}
 	}
 }
@@ -144,7 +145,7 @@ bool VectorStringToList::StringToNestedTypeCastLoop(const string_t *source_data,
 	auto list_data = ListVector::GetData(result);
 	auto child_data = FlatVector::GetData<string_t>(varchar_vector);
 
-	bool all_converted = true;
+    VectorTryCastData vector_cast_data(result, parameters);
 	idx_t total = 0;
 	for (idx_t i = 0; i < count; i++) {
 		idx_t idx = i;
@@ -160,7 +161,7 @@ bool VectorStringToList::StringToNestedTypeCastLoop(const string_t *source_data,
 		if (!VectorStringToList::SplitStringList(source_data[idx], child_data, total, varchar_vector)) {
 			string text = "Type VARCHAR with value '" + source_data[idx].GetString() +
 			              "' can't be cast to the destination type LIST";
-			HandleVectorCastError::Operation<string_t>(text, result_mask, idx, parameters.error_message, all_converted);
+			HandleVectorCastError::Operation<string_t>(text, result_mask, idx, vector_cast_data);
 		}
 		list_data[i].length = total - list_data[i].offset; // length is the amount of parts coming from this string
 	}
@@ -170,7 +171,7 @@ bool VectorStringToList::StringToNestedTypeCastLoop(const string_t *source_data,
 	auto &cast_data = parameters.cast_data->Cast<ListBoundCastData>();
 	CastParameters child_parameters(parameters, cast_data.child_cast_info.cast_data, parameters.local_state);
 	return cast_data.child_cast_info.function(varchar_vector, result_child, total_list_size, child_parameters) &&
-	       all_converted;
+            vector_cast_data.all_converted;
 }
 
 static LogicalType InitVarcharStructType(const LogicalType &target) {
@@ -204,7 +205,7 @@ bool VectorStringToStruct::StringToNestedTypeCastLoop(const string_t *source_dat
 		child_masks[child_idx].get().SetAllInvalid(count);
 	}
 
-	bool all_converted = true;
+    VectorTryCastData vector_cast_data(result, parameters);
 	for (idx_t i = 0; i < count; i++) {
 		idx_t idx = i;
 		if (sel) {
@@ -223,7 +224,7 @@ bool VectorStringToStruct::StringToNestedTypeCastLoop(const string_t *source_dat
 			for (auto &child_mask : child_masks) {
 				child_mask.get().SetInvalid(idx); // some values may have already been found and set valid
 			}
-			HandleVectorCastError::Operation<string_t>(text, result_mask, idx, parameters.error_message, all_converted);
+			HandleVectorCastError::Operation<string_t>(text, result_mask, idx, vector_cast_data);
 		}
 	}
 
@@ -237,10 +238,10 @@ bool VectorStringToStruct::StringToNestedTypeCastLoop(const string_t *source_dat
 		auto &child_cast_info = cast_data.child_cast_info[child_idx];
 		CastParameters child_parameters(parameters, child_cast_info.cast_data, lstate.local_states[child_idx]);
 		if (!child_cast_info.function(child_varchar_vector, result_child_vector, count, child_parameters)) {
-			all_converted = false;
+            vector_cast_data.all_converted = false;
 		}
 	}
-	return all_converted;
+	return vector_cast_data.all_converted;
 }
 
 //===--------------------------------------------------------------------===//
@@ -285,7 +286,8 @@ bool VectorStringToMap::StringToNestedTypeCastLoop(const string_t *source_data, 
 	ListVector::SetListSize(result, total_elements);
 	auto list_data = ListVector::GetData(result);
 
-	bool all_converted = true;
+
+    VectorTryCastData vector_cast_data(result, parameters);
 	idx_t total = 0;
 	for (idx_t i = 0; i < count; i++) {
 		idx_t idx = i;
@@ -303,7 +305,7 @@ bool VectorStringToMap::StringToNestedTypeCastLoop(const string_t *source_data, 
 			string text = "Type VARCHAR with value '" + source_data[idx].GetString() +
 			              "' can't be cast to the destination type MAP";
 			FlatVector::SetNull(result, idx, true);
-			HandleVectorCastError::Operation<string_t>(text, result_mask, idx, parameters.error_message, all_converted);
+			HandleVectorCastError::Operation<string_t>(text, result_mask, idx, vector_cast_data);
 		}
 		list_data[i].length = total - list_data[i].offset;
 	}
@@ -316,15 +318,15 @@ bool VectorStringToMap::StringToNestedTypeCastLoop(const string_t *source_data, 
 
 	CastParameters key_params(parameters, cast_data.key_cast.cast_data, lstate.key_state);
 	if (!cast_data.key_cast.function(varchar_key_vector, result_key_child, total_elements, key_params)) {
-		all_converted = false;
+        vector_cast_data.all_converted = false;
 	}
 	CastParameters val_params(parameters, cast_data.value_cast.cast_data, lstate.value_state);
 	if (!cast_data.value_cast.function(varchar_val_vector, result_val_child, total_elements, val_params)) {
-		all_converted = false;
+        vector_cast_data.all_converted = false;
 	}
 
 	auto &key_validity = FlatVector::Validity(result_key_child);
-	if (!all_converted) {
+	if (!vector_cast_data.all_converted) {
 		for (idx_t row_idx = 0; row_idx < count; row_idx++) {
 			if (!result_mask.RowIsValid(row_idx)) {
 				continue;
@@ -339,7 +341,7 @@ bool VectorStringToMap::StringToNestedTypeCastLoop(const string_t *source_data, 
 		}
 	}
 	MapVector::MapConversionVerify(result, count);
-	return all_converted;
+	return vector_cast_data.all_converted;
 }
 
 //===--------------------------------------------------------------------===//
@@ -370,7 +372,7 @@ bool VectorStringToArray::StringToNestedTypeCastLoop(const string_t *source_data
 				if (parameters.strict) {
 					throw ConversionException(msg);
 				}
-				HandleCastError::AssignError(msg, parameters.error_message);
+				HandleCastError::AssignError(msg, parameters);
 			}
 			result_mask.SetInvalid(i);
 		}
@@ -380,7 +382,7 @@ bool VectorStringToArray::StringToNestedTypeCastLoop(const string_t *source_data
 	Vector varchar_vector(LogicalType::VARCHAR, child_count);
 	auto child_data = FlatVector::GetData<string_t>(varchar_vector);
 
-	bool all_converted = true;
+    VectorTryCastData vector_cast_data(result, parameters);
 	idx_t total = 0;
 	for (idx_t i = 0; i < count; i++) {
 		idx_t idx = i;
@@ -404,7 +406,7 @@ bool VectorStringToArray::StringToNestedTypeCastLoop(const string_t *source_data
 		if (!VectorStringToList::SplitStringList(source_data[idx], child_data, total, varchar_vector)) {
 			auto text = StringUtil::Format("Type VARCHAR with value '%s' can't be cast to the destination type ARRAY",
 			                               source_data[idx].GetString());
-			HandleVectorCastError::Operation<string_t>(text, result_mask, idx, parameters.error_message, all_converted);
+			HandleVectorCastError::Operation<string_t>(text, result_mask, idx, vector_cast_data);
 		}
 	}
 	D_ASSERT(total == child_count);
@@ -414,7 +416,7 @@ bool VectorStringToArray::StringToNestedTypeCastLoop(const string_t *source_data
 	CastParameters child_parameters(parameters, cast_data.child_cast_info.cast_data, parameters.local_state);
 	bool cast_result = cast_data.child_cast_info.function(varchar_vector, result_child, child_count, child_parameters);
 
-	return all_lengths_match && cast_result && all_converted;
+	return all_lengths_match && cast_result && vector_cast_data.all_converted;
 }
 
 template <class T>

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -14,7 +14,7 @@ unique_ptr<BoundCastData> StructBoundCastData::BindStructToStructCast(BindCastIn
 	auto source_is_unnamed = StructType::IsUnnamed(source);
 
 	if (source_child_types.size() != result_child_types.size()) {
-		throw TypeMismatchException(source, target, "Cannot cast STRUCTs of different size");
+		throw TypeMismatchException(input.query_location, source, target, "Cannot cast STRUCTs of different size");
 	}
 	bool named_struct_cast = !source_is_unnamed && !target_is_unnamed;
 	case_insensitive_map_t<idx_t> target_members;
@@ -36,7 +36,7 @@ unique_ptr<BoundCastData> StructBoundCastData::BindStructToStructCast(BindCastIn
 			// named struct cast - find corresponding member in target
 			auto entry = target_members.find(source_child.first);
 			if (entry == target_members.end()) {
-				throw TypeMismatchException(source, target,
+				throw TypeMismatchException(input.query_location, source, target,
 				                            "Cannot cast STRUCTs - element \"" + source_child.first +
 				                                "\" in source struct was not found in target struct");
 			}

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -339,6 +339,8 @@ class TypeMismatchException : public Exception {
 public:
 	DUCKDB_API TypeMismatchException(const PhysicalType type_1, const PhysicalType type_2, const string &msg);
 	DUCKDB_API TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg);
+	DUCKDB_API TypeMismatchException(optional_idx error_location, const LogicalType &type_1, const LogicalType &type_2,
+	                                 const string &msg);
 	DUCKDB_API
 	TypeMismatchException(const string &msg); //! Needed to be able to recreate the exception after it's been serialized
 };

--- a/src/include/duckdb/common/exception/conversion_exception.hpp
+++ b/src/include/duckdb/common/exception/conversion_exception.hpp
@@ -24,6 +24,10 @@ public:
 	explicit ConversionException(const string &msg, Args... params)
 	    : ConversionException(ConstructMessage(msg, params...)) {
 	}
+	template <typename... Args>
+	explicit ConversionException(optional_idx error_location, const string &msg, Args... params)
+			: ConversionException(error_location, ConstructMessage(msg, params...)) {
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/exception/conversion_exception.hpp
+++ b/src/include/duckdb/common/exception/conversion_exception.hpp
@@ -26,7 +26,7 @@ public:
 	}
 	template <typename... Args>
 	explicit ConversionException(optional_idx error_location, const string &msg, Args... params)
-			: ConversionException(error_location, ConstructMessage(msg, params...)) {
+	    : ConversionException(error_location, ConstructMessage(msg, params...)) {
 	}
 };
 

--- a/src/include/duckdb/common/exception/conversion_exception.hpp
+++ b/src/include/duckdb/common/exception/conversion_exception.hpp
@@ -9,12 +9,14 @@
 #pragma once
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/optional_idx.hpp"
 
 namespace duckdb {
 
 class ConversionException : public Exception {
 public:
 	DUCKDB_API explicit ConversionException(const string &msg);
+	DUCKDB_API explicit ConversionException(optional_idx error_location, const string &msg);
 	DUCKDB_API ConversionException(const PhysicalType origType, const PhysicalType newType);
 	DUCKDB_API ConversionException(const LogicalType &origType, const LogicalType &newType);
 

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -23,6 +23,7 @@
 #include "duckdb/common/exception/conversion_exception.hpp"
 
 namespace duckdb {
+struct CastParameters;
 struct ValidityMask;
 class Vector;
 
@@ -74,9 +75,10 @@ struct Cast {
 };
 
 struct HandleCastError {
-	static void AssignError(const string &error_message, string *error_message_ptr) {
+    static void AssignError(const string &error_message, CastParameters &parameters);
+	static void AssignError(const string &error_message, string *error_message_ptr, optional_idx error_location = optional_idx()) {
 		if (!error_message_ptr) {
-			throw ConversionException(error_message);
+			throw ConversionException(error_location, error_message);
 		}
 		if (error_message_ptr->empty()) {
 			*error_message_ptr = error_message;

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -38,14 +38,16 @@ struct TryCast {
 struct TryCastErrorMessage {
 	template <class SRC, class DST>
 	static inline bool Operation(SRC input, DST &result, CastParameters &parameters) {
-		throw NotImplementedException(parameters.query_location, "Unimplemented type for cast (%s -> %s)", GetTypeId<SRC>(), GetTypeId<DST>());
+		throw NotImplementedException(parameters.query_location, "Unimplemented type for cast (%s -> %s)",
+		                              GetTypeId<SRC>(), GetTypeId<DST>());
 	}
 };
 
 struct TryCastErrorMessageCommaSeparated {
 	template <class SRC, class DST>
 	static inline bool Operation(SRC input, DST &result, CastParameters &parameters) {
-		throw NotImplementedException(parameters.query_location, "Unimplemented type for cast (%s -> %s)", GetTypeId<SRC>(), GetTypeId<DST>());
+		throw NotImplementedException(parameters.query_location, "Unimplemented type for cast (%s -> %s)",
+		                              GetTypeId<SRC>(), GetTypeId<DST>());
 	}
 };
 
@@ -514,7 +516,8 @@ DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, double &result, C
 template <>
 DUCKDB_API bool TryCastErrorMessageCommaSeparated::Operation(string_t input, float &result, CastParameters &parameters);
 template <>
-DUCKDB_API bool TryCastErrorMessageCommaSeparated::Operation(string_t input, double &result, CastParameters &parameters);
+DUCKDB_API bool TryCastErrorMessageCommaSeparated::Operation(string_t input, double &result,
+                                                             CastParameters &parameters);
 
 //===--------------------------------------------------------------------===//
 // Date Casts
@@ -852,7 +855,8 @@ struct CastFromBitToNumeric {
 		// TODO: Allow conversion if the significant bytes of the bitstring can be cast to the target type
 		// Currently only allows bitstring -> numeric if the full bitstring fits inside the numeric type
 		if (input.GetSize() - 1 > sizeof(DST)) {
-			throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s", GetTypeId<DST>());
+			throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s",
+			                          GetTypeId<DST>());
 		}
 		Bit::BitToNumeric(input, result);
 		return (true);
@@ -904,7 +908,7 @@ struct TryCastToUUID {
 
 template <>
 DUCKDB_API bool TryCastToUUID::Operation(string_t input, hugeint_t &result, Vector &result_vector,
-										 CastParameters &parameters);
+                                         CastParameters &parameters);
 
 //===--------------------------------------------------------------------===//
 // Pointers

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -21,6 +21,7 @@
 #include "duckdb/common/types/bit.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/function/cast/default_casts.hpp"
 
 namespace duckdb {
 struct CastParameters;
@@ -36,15 +37,15 @@ struct TryCast {
 
 struct TryCastErrorMessage {
 	template <class SRC, class DST>
-	static inline bool Operation(SRC input, DST &result, string *error_message, bool strict = false) {
-		throw NotImplementedException("Unimplemented type for cast (%s -> %s)", GetTypeId<SRC>(), GetTypeId<DST>());
+	static inline bool Operation(SRC input, DST &result, CastParameters &parameters) {
+		throw NotImplementedException(parameters.query_location, "Unimplemented type for cast (%s -> %s)", GetTypeId<SRC>(), GetTypeId<DST>());
 	}
 };
 
 struct TryCastErrorMessageCommaSeparated {
 	template <class SRC, class DST>
-	static inline bool Operation(SRC input, DST &result, string *error_message, bool strict = false) {
-		throw NotImplementedException("Unimplemented type for cast (%s -> %s)", GetTypeId<SRC>(), GetTypeId<DST>());
+	static inline bool Operation(SRC input, DST &result, CastParameters &parameters) {
+		throw NotImplementedException(parameters.query_location, "Unimplemented type for cast (%s -> %s)", GetTypeId<SRC>(), GetTypeId<DST>());
 	}
 };
 
@@ -75,8 +76,9 @@ struct Cast {
 };
 
 struct HandleCastError {
-    static void AssignError(const string &error_message, CastParameters &parameters);
-	static void AssignError(const string &error_message, string *error_message_ptr, optional_idx error_location = optional_idx()) {
+	static void AssignError(const string &error_message, CastParameters &parameters);
+	static void AssignError(const string &error_message, string *error_message_ptr,
+	                        optional_idx error_location = optional_idx()) {
 		if (!error_message_ptr) {
 			throw ConversionException(error_location, error_message);
 		}
@@ -506,15 +508,13 @@ DUCKDB_API bool TryCast::Operation(string_t input, float &result, bool strict);
 template <>
 DUCKDB_API bool TryCast::Operation(string_t input, double &result, bool strict);
 template <>
-DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, float &result, string *error_message, bool strict);
+DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, float &result, CastParameters &parameters);
 template <>
-DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, double &result, string *error_message, bool strict);
+DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, double &result, CastParameters &parameters);
 template <>
-DUCKDB_API bool TryCastErrorMessageCommaSeparated::Operation(string_t input, float &result, string *error_message,
-                                                             bool strict);
+DUCKDB_API bool TryCastErrorMessageCommaSeparated::Operation(string_t input, float &result, CastParameters &parameters);
 template <>
-DUCKDB_API bool TryCastErrorMessageCommaSeparated::Operation(string_t input, double &result, string *error_message,
-                                                             bool strict);
+DUCKDB_API bool TryCastErrorMessageCommaSeparated::Operation(string_t input, double &result, CastParameters &parameters);
 
 //===--------------------------------------------------------------------===//
 // Date Casts
@@ -562,7 +562,7 @@ DUCKDB_API bool TryCast::Operation(interval_t input, interval_t &result, bool st
 // String -> Date Casts
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, date_t &result, string *error_message, bool strict);
+DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, date_t &result, CastParameters &parameters);
 template <>
 DUCKDB_API bool TryCast::Operation(string_t input, date_t &result, bool strict);
 template <>
@@ -571,7 +571,7 @@ date_t Cast::Operation(string_t input);
 // String -> Time Casts
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, dtime_t &result, string *error_message, bool strict);
+DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, dtime_t &result, CastParameters &parameters);
 template <>
 DUCKDB_API bool TryCast::Operation(string_t input, dtime_t &result, bool strict);
 template <>
@@ -580,7 +580,7 @@ dtime_t Cast::Operation(string_t input);
 // String -> TimeTZ Casts
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, dtime_tz_t &result, string *error_message, bool strict);
+DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, dtime_tz_t &result, CastParameters &parameters);
 template <>
 DUCKDB_API bool TryCast::Operation(string_t input, dtime_tz_t &result, bool strict);
 template <>
@@ -589,7 +589,7 @@ dtime_tz_t Cast::Operation(string_t input);
 // String -> Timestamp Casts
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, timestamp_t &result, string *error_message, bool strict);
+DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, timestamp_t &result, CastParameters &parameters);
 template <>
 DUCKDB_API bool TryCast::Operation(string_t input, timestamp_t &result, bool strict);
 template <>
@@ -598,7 +598,7 @@ timestamp_t Cast::Operation(string_t input);
 // String -> Interval Casts
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, interval_t &result, string *error_message, bool strict);
+DUCKDB_API bool TryCastErrorMessage::Operation(string_t input, interval_t &result, CastParameters &parameters);
 
 //===--------------------------------------------------------------------===//
 // string -> Non-Standard Timestamps
@@ -825,14 +825,12 @@ string_t CastFromBlobToBit::Operation(string_t input, Vector &result);
 
 struct TryCastToBlob {
 	template <class SRC, class DST>
-	static inline bool Operation(SRC input, DST &result, Vector &result_vector, string *error_message,
-	                             bool strict = false) {
+	static inline bool Operation(SRC input, DST &result, Vector &result_vector, CastParameters &parameters) {
 		throw InternalException("Unsupported type for try cast to blob");
 	}
 };
 template <>
-bool TryCastToBlob::Operation(string_t input, string_t &result, Vector &result_vector, string *error_message,
-                              bool strict);
+bool TryCastToBlob::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters);
 
 //===--------------------------------------------------------------------===//
 // Bits
@@ -848,24 +846,24 @@ duckdb::string_t CastFromBitToString::Operation(duckdb::string_t input, Vector &
 
 struct CastFromBitToNumeric {
 	template <class SRC = string_t, class DST>
-	static inline bool Operation(SRC input, DST &result, bool strict = false) {
+	static inline bool Operation(SRC input, DST &result, CastParameters &parameters) {
 		D_ASSERT(input.GetSize() > 1);
 
 		// TODO: Allow conversion if the significant bytes of the bitstring can be cast to the target type
 		// Currently only allows bitstring -> numeric if the full bitstring fits inside the numeric type
 		if (input.GetSize() - 1 > sizeof(DST)) {
-			throw ConversionException("Bitstring doesn't fit inside of %s", GetTypeId<DST>());
+			throw ConversionException(parameters.query_location, "Bitstring doesn't fit inside of %s", GetTypeId<DST>());
 		}
 		Bit::BitToNumeric(input, result);
 		return (true);
 	}
 };
 template <>
-bool CastFromBitToNumeric::Operation(string_t input, bool &result, bool strict);
+bool CastFromBitToNumeric::Operation(string_t input, bool &result, CastParameters &parameters);
 template <>
-bool CastFromBitToNumeric::Operation(string_t input, hugeint_t &result, bool strict);
+bool CastFromBitToNumeric::Operation(string_t input, hugeint_t &result, CastParameters &parameters);
 template <>
-bool CastFromBitToNumeric::Operation(string_t input, uhugeint_t &result, bool strict);
+bool CastFromBitToNumeric::Operation(string_t input, uhugeint_t &result, CastParameters &parameters);
 
 struct CastFromBitToBlob {
 	template <class SRC>
@@ -877,15 +875,13 @@ struct CastFromBitToBlob {
 
 struct TryCastToBit {
 	template <class SRC, class DST>
-	static inline bool Operation(SRC input, DST &result, Vector &result_vector, string *error_message,
-	                             bool strict = false) {
+	static inline bool Operation(SRC input, DST &result, Vector &result_vector, CastParameters &parameters) {
 		throw InternalException("Unsupported type for try cast to bit");
 	}
 };
 
 template <>
-bool TryCastToBit::Operation(string_t input, string_t &result, Vector &result_vector, string *error_message,
-                             bool strict);
+bool TryCastToBit::Operation(string_t input, string_t &result, Vector &result_vector, CastParameters &parameters);
 
 //===--------------------------------------------------------------------===//
 // UUID
@@ -901,15 +897,14 @@ duckdb::string_t CastFromUUID::Operation(duckdb::hugeint_t input, Vector &vector
 
 struct TryCastToUUID {
 	template <class SRC, class DST>
-	static inline bool Operation(SRC input, DST &result, Vector &result_vector, string *error_message,
-	                             bool strict = false) {
+	static inline bool Operation(SRC input, DST &result, Vector &result_vector, CastParameters &parameters) {
 		throw InternalException("Unsupported type for try cast to uuid");
 	}
 };
 
 template <>
 DUCKDB_API bool TryCastToUUID::Operation(string_t input, hugeint_t &result, Vector &result_vector,
-                                         string *error_message, bool strict);
+										 CastParameters &parameters);
 
 //===--------------------------------------------------------------------===//
 // Pointers

--- a/src/include/duckdb/common/operator/decimal_cast_operators.hpp
+++ b/src/include/duckdb/common/operator/decimal_cast_operators.hpp
@@ -53,13 +53,17 @@ DUCKDB_API bool TryCastToDecimal::Operation(bool input, hugeint_t &result, CastP
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, bool &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, bool &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, bool &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> int8_t
@@ -78,11 +82,14 @@ DUCKDB_API bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, Cas
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
 bool TryCastFromDecimal::Operation(hugeint_t input, int8_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
@@ -104,11 +111,14 @@ DUCKDB_API bool TryCastToDecimal::Operation(int16_t input, hugeint_t &result, Ca
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, int16_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
 bool TryCastFromDecimal::Operation(hugeint_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
@@ -130,11 +140,14 @@ DUCKDB_API bool TryCastToDecimal::Operation(int32_t input, hugeint_t &result, Ca
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, int32_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
 bool TryCastFromDecimal::Operation(hugeint_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
@@ -156,11 +169,14 @@ DUCKDB_API bool TryCastToDecimal::Operation(int64_t input, hugeint_t &result, Ca
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, int64_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
 bool TryCastFromDecimal::Operation(hugeint_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
@@ -178,8 +194,8 @@ template <>
 DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
-                                            uint8_t scale);
+DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, hugeint_t &result, CastParameters &parameters,
+                                            uint8_t width, uint8_t scale);
 
 template <>
 bool TryCastFromDecimal::Operation(int16_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
@@ -198,17 +214,17 @@ bool TryCastFromDecimal::Operation(hugeint_t input, hugeint_t &result, CastParam
 // Cast Decimal <-> uhugeint_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int16_t &result, CastParameters &parameters, uint8_t width,
-                                            uint8_t scale);
+DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int16_t &result, CastParameters &parameters,
+                                            uint8_t width, uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int32_t &result, CastParameters &parameters, uint8_t width,
-                                            uint8_t scale);
+DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int32_t &result, CastParameters &parameters,
+                                            uint8_t width, uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int64_t &result, CastParameters &parameters, uint8_t width,
-                                            uint8_t scale);
+DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int64_t &result, CastParameters &parameters,
+                                            uint8_t width, uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
-                                            uint8_t scale);
+DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, hugeint_t &result, CastParameters &parameters,
+                                            uint8_t width, uint8_t scale);
 
 template <>
 bool TryCastFromDecimal::Operation(int16_t input, uhugeint_t &result, CastParameters &parameters, uint8_t width,
@@ -240,11 +256,14 @@ DUCKDB_API bool TryCastToDecimal::Operation(uint8_t input, hugeint_t &result, Ca
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uint8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, uint8_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uint8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, uint8_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uint8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, uint8_t &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
 bool TryCastFromDecimal::Operation(hugeint_t input, uint8_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
@@ -262,8 +281,8 @@ template <>
 DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
-                                            uint8_t scale);
+DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, CastParameters &parameters,
+                                            uint8_t width, uint8_t scale);
 
 template <>
 bool TryCastFromDecimal::Operation(int16_t input, uint16_t &result, CastParameters &parameters, uint8_t width,
@@ -291,8 +310,8 @@ template <>
 DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
-                                            uint8_t scale);
+DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, CastParameters &parameters,
+                                            uint8_t width, uint8_t scale);
 
 template <>
 bool TryCastFromDecimal::Operation(int16_t input, uint32_t &result, CastParameters &parameters, uint8_t width,
@@ -320,8 +339,8 @@ template <>
 DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
-                                            uint8_t scale);
+DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, hugeint_t &result, CastParameters &parameters,
+                                            uint8_t width, uint8_t scale);
 
 template <>
 bool TryCastFromDecimal::Operation(int16_t input, uint64_t &result, CastParameters &parameters, uint8_t width,
@@ -353,13 +372,17 @@ DUCKDB_API bool TryCastToDecimal::Operation(float input, hugeint_t &result, Cast
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, float &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, float &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, float &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(hugeint_t input, float &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> double
@@ -378,11 +401,14 @@ DUCKDB_API bool TryCastToDecimal::Operation(double input, hugeint_t &result, Cas
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, double &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, double &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, double &result, CastParameters &parameters, uint8_t width,
+                                   uint8_t scale);
 template <>
 bool TryCastFromDecimal::Operation(hugeint_t input, double &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
@@ -400,8 +426,8 @@ template <>
 DUCKDB_API bool TryCastToDecimal::Operation(string_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(string_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
-                                            uint8_t scale);
+DUCKDB_API bool TryCastToDecimal::Operation(string_t input, hugeint_t &result, CastParameters &parameters,
+                                            uint8_t width, uint8_t scale);
 template <>
 DUCKDB_API bool TryCastToDecimalCommaSeparated::Operation(string_t input, int16_t &result, CastParameters &parameters,
                                                           uint8_t width, uint8_t scale);

--- a/src/include/duckdb/common/operator/decimal_cast_operators.hpp
+++ b/src/include/duckdb/common/operator/decimal_cast_operators.hpp
@@ -17,21 +17,21 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 struct TryCastToDecimal {
 	template <class SRC, class DST>
-	static inline bool Operation(SRC input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+	static inline bool Operation(SRC input, DST &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 		throw NotImplementedException("Unimplemented type for TryCastToDecimal!");
 	}
 };
 
 struct TryCastToDecimalCommaSeparated {
 	template <class SRC, class DST>
-	static inline bool Operation(SRC input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+	static inline bool Operation(SRC input, DST &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 		throw NotImplementedException("Unimplemented type for TryCastToDecimal!");
 	}
 };
 
 struct TryCastFromDecimal {
 	template <class SRC, class DST>
-	static inline bool Operation(SRC input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+	static inline bool Operation(SRC input, DST &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 		throw NotImplementedException("Unimplemented type for TryCastFromDecimal!");
 	}
 };
@@ -40,379 +40,379 @@ struct TryCastFromDecimal {
 // Cast Decimal <-> bool
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(bool input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(bool input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(bool input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(bool input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(bool input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(bool input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(bool input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(bool input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, bool &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, bool &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, bool &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> int8_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int8_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int8_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int8_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int8_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int8_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int8_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, int8_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, int8_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> int16_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int16_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int16_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int16_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int16_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int16_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int16_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int16_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int16_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, int16_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, int16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> int32_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int32_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int32_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int32_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int32_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int32_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int32_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int32_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int32_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, int32_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, int32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> int64_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int64_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int64_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int64_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int64_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int64_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int64_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(int64_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(int64_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, int64_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, int64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> hugeint_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(hugeint_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> uhugeint_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uhugeint_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uhugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, uhugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uhugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, uhugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uhugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, uhugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uhugeint_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uhugeint_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> uint8_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint8_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint8_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint8_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint8_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint8_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint8_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint8_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint8_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uint8_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, uint8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uint8_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, uint8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uint8_t &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, uint8_t &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uint8_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uint8_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> uint16_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uint16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, uint16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uint16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, uint16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uint16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, uint16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uint16_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uint16_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> uint32_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uint32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, uint32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uint32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, uint32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uint32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, uint32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uint32_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uint32_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> uint64_t
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(uint64_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, uint64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int16_t input, uint64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, uint64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int32_t input, uint64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, uint64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(int64_t input, uint64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, uint64_t &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, uint64_t &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> float
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(float input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(float input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(float input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(float input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(float input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(float input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(float input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(float input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, float &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, float &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, float &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, float &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(hugeint_t input, float &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> double
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(double input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(double input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(double input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(double input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(double input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(double input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(double input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(double input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 
 template <>
-bool TryCastFromDecimal::Operation(int16_t input, double &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int16_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int32_t input, double &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int32_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(int64_t input, double &result, string *error_message, uint8_t width, uint8_t scale);
+bool TryCastFromDecimal::Operation(int64_t input, double &result, CastParameters &parameters, uint8_t width, uint8_t scale);
 template <>
-bool TryCastFromDecimal::Operation(hugeint_t input, double &result, string *error_message, uint8_t width,
+bool TryCastFromDecimal::Operation(hugeint_t input, double &result, CastParameters &parameters, uint8_t width,
                                    uint8_t scale);
 
 //===--------------------------------------------------------------------===//
 // Cast Decimal <-> VARCHAR
 //===--------------------------------------------------------------------===//
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(string_t input, int16_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(string_t input, int16_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(string_t input, int32_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(string_t input, int32_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(string_t input, int64_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(string_t input, int64_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimal::Operation(string_t input, hugeint_t &result, string *error_message, uint8_t width,
+DUCKDB_API bool TryCastToDecimal::Operation(string_t input, hugeint_t &result, CastParameters &parameters, uint8_t width,
                                             uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimalCommaSeparated::Operation(string_t input, int16_t &result, string *error_message,
+DUCKDB_API bool TryCastToDecimalCommaSeparated::Operation(string_t input, int16_t &result, CastParameters &parameters,
                                                           uint8_t width, uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimalCommaSeparated::Operation(string_t input, int32_t &result, string *error_message,
+DUCKDB_API bool TryCastToDecimalCommaSeparated::Operation(string_t input, int32_t &result, CastParameters &parameters,
                                                           uint8_t width, uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimalCommaSeparated::Operation(string_t input, int64_t &result, string *error_message,
+DUCKDB_API bool TryCastToDecimalCommaSeparated::Operation(string_t input, int64_t &result, CastParameters &parameters,
                                                           uint8_t width, uint8_t scale);
 template <>
-DUCKDB_API bool TryCastToDecimalCommaSeparated::Operation(string_t input, hugeint_t &result, string *error_message,
+DUCKDB_API bool TryCastToDecimalCommaSeparated::Operation(string_t input, hugeint_t &result, CastParameters &parameters,
                                                           uint8_t width, uint8_t scale);
 
 struct StringCastFromDecimal {

--- a/src/include/duckdb/common/types/blob.hpp
+++ b/src/include/duckdb/common/types/blob.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/types.hpp"
 
 namespace duckdb {
+struct CastParameters;
 
 //! The Blob class is a static class that holds helper functions for the Blob type.
 class Blob {
@@ -35,13 +36,15 @@ public:
 	DUCKDB_API static string ToString(string_t blob);
 
 	//! Returns the blob size of a string -> blob conversion
-	DUCKDB_API static bool TryGetBlobSize(string_t str, idx_t &result_size, string *error_message);
+	DUCKDB_API static bool TryGetBlobSize(string_t str, idx_t &result_size, CastParameters &parameters);
 	DUCKDB_API static idx_t GetBlobSize(string_t str);
+	DUCKDB_API static idx_t GetBlobSize(string_t str, CastParameters &parameters);
 	//! Convert a string to a blob. This function should ONLY be called after calling GetBlobSize, since it does NOT
 	//! perform data validation.
 	DUCKDB_API static void ToBlob(string_t str, data_ptr_t output);
 	//! Convert a string object to a blob
 	DUCKDB_API static string ToBlob(string_t str);
+	DUCKDB_API static string ToBlob(string_t str, CastParameters &parameters);
 
 	// base 64 conversion functions
 	//! Returns the string size of a blob -> base64 conversion

--- a/src/include/duckdb/common/vector_operations/general_cast.hpp
+++ b/src/include/duckdb/common/vector_operations/general_cast.hpp
@@ -13,12 +13,21 @@
 
 namespace duckdb {
 
+struct VectorTryCastData {
+	VectorTryCastData(Vector &result_p, CastParameters &parameters)
+			: result(result_p), parameters(parameters) {
+	}
+
+	Vector &result;
+	CastParameters &parameters;
+	bool all_converted = true;
+};
+
 struct HandleVectorCastError {
 	template <class RESULT_TYPE>
-	static RESULT_TYPE Operation(string error_message, ValidityMask &mask, idx_t idx, string *error_message_ptr,
-	                             bool &all_converted) {
-		HandleCastError::AssignError(error_message, error_message_ptr);
-		all_converted = false;
+	static RESULT_TYPE Operation(string error_message, ValidityMask &mask, idx_t idx, VectorTryCastData &cast_data) {
+		HandleCastError::AssignError(error_message, cast_data.parameters);
+		cast_data.all_converted = false;
 		mask.SetInvalid(idx);
 		return NullValue<RESULT_TYPE>();
 	}

--- a/src/include/duckdb/common/vector_operations/general_cast.hpp
+++ b/src/include/duckdb/common/vector_operations/general_cast.hpp
@@ -14,8 +14,7 @@
 namespace duckdb {
 
 struct VectorTryCastData {
-	VectorTryCastData(Vector &result_p, CastParameters &parameters)
-			: result(result_p), parameters(parameters) {
+	VectorTryCastData(Vector &result_p, CastParameters &parameters) : result(result_p), parameters(parameters) {
 	}
 
 	Vector &result;

--- a/src/include/duckdb/execution/operator/csv_scanner/util/csv_casting.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/util/csv_casting.hpp
@@ -37,8 +37,8 @@ class CSVCast {
 
 	template <class OP, class T>
 	static bool TemplatedTryCastDecimalVector(const CSVReaderOptions &options, Vector &input_vector,
-	                                          Vector &result_vector, idx_t count, CastParameters &parameters, uint8_t width,
-	                                          uint8_t scale) {
+	                                          Vector &result_vector, idx_t count, CastParameters &parameters,
+	                                          uint8_t width, uint8_t scale) {
 		D_ASSERT(input_vector.GetType().id() == LogicalTypeId::VARCHAR);
 		bool all_converted = true;
 		UnaryExecutor::Execute<string_t, T>(input_vector, result_vector, count, [&](string_t input) {
@@ -68,7 +68,7 @@ class CSVCast {
 	template <class OP, class T>
 	static bool TemplatedTryCastDateVector(const map<LogicalTypeId, CSVOption<StrpTimeFormat>> &options,
 	                                       Vector &input_vector, Vector &result_vector, idx_t count,
-										   CastParameters &parameters, idx_t &line_error) {
+	                                       CastParameters &parameters, idx_t &line_error) {
 		D_ASSERT(input_vector.GetType().id() == LogicalTypeId::VARCHAR);
 		bool all_converted = true;
 		idx_t cur_line = 0;
@@ -88,11 +88,11 @@ public:
 	static bool TryCastDateVector(const map<LogicalTypeId, CSVOption<StrpTimeFormat>> &options, Vector &input_vector,
 	                              Vector &result_vector, idx_t count, CastParameters &parameters, idx_t &line_error) {
 		return TemplatedTryCastDateVector<TryCastDateOperator, date_t>(options, input_vector, result_vector, count,
-																	   parameters, line_error);
+		                                                               parameters, line_error);
 	}
 	static bool TryCastTimestampVector(const map<LogicalTypeId, CSVOption<StrpTimeFormat>> &options,
 	                                   Vector &input_vector, Vector &result_vector, idx_t count,
-									   CastParameters &parameters) {
+	                                   CastParameters &parameters) {
 		idx_t line_error;
 		return TemplatedTryCastDateVector<TryCastTimestampOperator, timestamp_t>(options, input_vector, result_vector,
 		                                                                         count, parameters, line_error);

--- a/src/include/duckdb/execution/operator/csv_scanner/util/csv_casting.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/util/csv_casting.hpp
@@ -17,14 +17,14 @@ namespace duckdb {
 class CSVCast {
 	template <class OP, class T>
 	static bool TemplatedTryCastFloatingVector(const CSVReaderOptions &options, Vector &input_vector,
-	                                           Vector &result_vector, idx_t count, string &error_message,
+	                                           Vector &result_vector, idx_t count, CastParameters &parameters,
 	                                           idx_t &line_error) {
 		D_ASSERT(input_vector.GetType().id() == LogicalTypeId::VARCHAR);
 		bool all_converted = true;
 		idx_t row = 0;
 		UnaryExecutor::Execute<string_t, T>(input_vector, result_vector, count, [&](string_t input) {
 			T result;
-			if (!OP::Operation(input, result, &error_message)) {
+			if (!OP::Operation(input, result, parameters)) {
 				line_error = row;
 				all_converted = false;
 			} else {
@@ -37,13 +37,13 @@ class CSVCast {
 
 	template <class OP, class T>
 	static bool TemplatedTryCastDecimalVector(const CSVReaderOptions &options, Vector &input_vector,
-	                                          Vector &result_vector, idx_t count, string &error_message, uint8_t width,
+	                                          Vector &result_vector, idx_t count, CastParameters &parameters, uint8_t width,
 	                                          uint8_t scale) {
 		D_ASSERT(input_vector.GetType().id() == LogicalTypeId::VARCHAR);
 		bool all_converted = true;
 		UnaryExecutor::Execute<string_t, T>(input_vector, result_vector, count, [&](string_t input) {
 			T result;
-			if (!OP::Operation(input, result, &error_message, width, scale)) {
+			if (!OP::Operation(input, result, parameters, width, scale)) {
 				all_converted = false;
 			}
 			return result;
@@ -68,13 +68,13 @@ class CSVCast {
 	template <class OP, class T>
 	static bool TemplatedTryCastDateVector(const map<LogicalTypeId, CSVOption<StrpTimeFormat>> &options,
 	                                       Vector &input_vector, Vector &result_vector, idx_t count,
-	                                       string &error_message, idx_t &line_error) {
+										   CastParameters &parameters, idx_t &line_error) {
 		D_ASSERT(input_vector.GetType().id() == LogicalTypeId::VARCHAR);
 		bool all_converted = true;
 		idx_t cur_line = 0;
 		UnaryExecutor::Execute<string_t, T>(input_vector, result_vector, count, [&](string_t input) {
 			T result;
-			if (!OP::Operation(options, input, result, error_message)) {
+			if (!OP::Operation(options, input, result, *parameters.error_message)) {
 				line_error = cur_line;
 				all_converted = false;
 			}
@@ -86,49 +86,49 @@ class CSVCast {
 
 public:
 	static bool TryCastDateVector(const map<LogicalTypeId, CSVOption<StrpTimeFormat>> &options, Vector &input_vector,
-	                              Vector &result_vector, idx_t count, string &error_message, idx_t &line_error) {
+	                              Vector &result_vector, idx_t count, CastParameters &parameters, idx_t &line_error) {
 		return TemplatedTryCastDateVector<TryCastDateOperator, date_t>(options, input_vector, result_vector, count,
-		                                                               error_message, line_error);
+																	   parameters, line_error);
 	}
 	static bool TryCastTimestampVector(const map<LogicalTypeId, CSVOption<StrpTimeFormat>> &options,
 	                                   Vector &input_vector, Vector &result_vector, idx_t count,
-	                                   string &error_message) {
+									   CastParameters &parameters) {
 		idx_t line_error;
 		return TemplatedTryCastDateVector<TryCastTimestampOperator, timestamp_t>(options, input_vector, result_vector,
-		                                                                         count, error_message, line_error);
+		                                                                         count, parameters, line_error);
 	}
 	static bool TryCastFloatingVectorCommaSeparated(const CSVReaderOptions &options, Vector &input_vector,
-	                                                Vector &result_vector, idx_t count, string &error_message,
+	                                                Vector &result_vector, idx_t count, CastParameters &parameters,
 	                                                const LogicalType &result_type, idx_t &line_error) {
 		switch (result_type.InternalType()) {
 		case PhysicalType::DOUBLE:
 			return TemplatedTryCastFloatingVector<TryCastErrorMessageCommaSeparated, double>(
-			    options, input_vector, result_vector, count, error_message, line_error);
+			    options, input_vector, result_vector, count, parameters, line_error);
 		case PhysicalType::FLOAT:
 			return TemplatedTryCastFloatingVector<TryCastErrorMessageCommaSeparated, float>(
-			    options, input_vector, result_vector, count, error_message, line_error);
+			    options, input_vector, result_vector, count, parameters, line_error);
 		default:
 			throw InternalException("Unimplemented physical type for floating");
 		}
 	}
 	static bool TryCastDecimalVectorCommaSeparated(const CSVReaderOptions &options, Vector &input_vector,
-	                                               Vector &result_vector, idx_t count, string &error_message,
+	                                               Vector &result_vector, idx_t count, CastParameters &parameters,
 	                                               const LogicalType &result_type) {
 		auto width = DecimalType::GetWidth(result_type);
 		auto scale = DecimalType::GetScale(result_type);
 		switch (result_type.InternalType()) {
 		case PhysicalType::INT16:
 			return TemplatedTryCastDecimalVector<TryCastToDecimalCommaSeparated, int16_t>(
-			    options, input_vector, result_vector, count, error_message, width, scale);
+			    options, input_vector, result_vector, count, parameters, width, scale);
 		case PhysicalType::INT32:
 			return TemplatedTryCastDecimalVector<TryCastToDecimalCommaSeparated, int32_t>(
-			    options, input_vector, result_vector, count, error_message, width, scale);
+			    options, input_vector, result_vector, count, parameters, width, scale);
 		case PhysicalType::INT64:
 			return TemplatedTryCastDecimalVector<TryCastToDecimalCommaSeparated, int64_t>(
-			    options, input_vector, result_vector, count, error_message, width, scale);
+			    options, input_vector, result_vector, count, parameters, width, scale);
 		case PhysicalType::INT128:
 			return TemplatedTryCastDecimalVector<TryCastToDecimalCommaSeparated, hugeint_t>(
-			    options, input_vector, result_vector, count, error_message, width, scale);
+			    options, input_vector, result_vector, count, parameters, width, scale);
 		default:
 			throw InternalException("Unimplemented physical type for decimal");
 		}

--- a/src/include/duckdb/function/cast/cast_function_set.hpp
+++ b/src/include/duckdb/function/cast/cast_function_set.hpp
@@ -26,6 +26,7 @@ struct GetCastFunctionInput {
 	}
 
 	optional_ptr<ClientContext> context;
+	optional_idx query_location;
 };
 
 struct BindCastFunction {

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -56,13 +56,17 @@ struct BoundCastData {
 struct CastParameters {
 	CastParameters() {
 	}
+	CastParameters(bool strict, string *error_message)
+			: CastParameters(nullptr, strict, error_message, nullptr) {
+	}
 	CastParameters(BoundCastData *cast_data, bool strict, string *error_message,
 	               optional_ptr<FunctionLocalState> local_state)
 	    : cast_data(cast_data), strict(strict), error_message(error_message), local_state(local_state) {
 	}
 	CastParameters(CastParameters &parent, optional_ptr<BoundCastData> cast_data,
 	               optional_ptr<FunctionLocalState> local_state)
-	    : cast_data(cast_data), strict(parent.strict), error_message(parent.error_message), local_state(local_state) {
+	    : cast_data(cast_data), strict(parent.strict), error_message(parent.error_message), local_state(local_state),
+	      query_location(parent.query_location) {
 	}
 
 	//! The bound cast data (if any)

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -119,6 +119,7 @@ struct BindCastInput {
 	CastFunctionSet &function_set;
 	optional_ptr<BindCastInfo> info;
 	optional_ptr<ClientContext> context;
+	optional_idx query_location;
 
 public:
 	DUCKDB_API BoundCastInfo GetCastFunction(const LogicalType &source, const LogicalType &target);

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -56,8 +56,7 @@ struct BoundCastData {
 struct CastParameters {
 	CastParameters() {
 	}
-	CastParameters(bool strict, string *error_message)
-			: CastParameters(nullptr, strict, error_message, nullptr) {
+	CastParameters(bool strict, string *error_message) : CastParameters(nullptr, strict, error_message, nullptr) {
 	}
 	CastParameters(BoundCastData *cast_data, bool strict, string *error_message,
 	               optional_ptr<FunctionLocalState> local_state)

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -73,6 +73,8 @@ struct CastParameters {
 	string *error_message = nullptr;
 	//! Local state
 	optional_ptr<FunctionLocalState> local_state;
+	//! Query location (if any)
+	optional_idx query_location;
 };
 
 struct CastLocalStateParameters {

--- a/src/include/duckdb/function/cast/vector_cast_helpers.hpp
+++ b/src/include/duckdb/function/cast/vector_cast_helpers.hpp
@@ -76,8 +76,8 @@ struct VectorTryCastStringOperator {
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
 		auto data = (VectorTryCastData *)dataptr;
 		RESULT_TYPE output;
-		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(
-		        input, output, data->result, data->parameters))) {
+		if (DUCKDB_LIKELY(
+		        OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->result, data->parameters))) {
 			return output;
 		}
 		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
@@ -101,8 +101,8 @@ struct VectorDecimalCastOperator {
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
 		auto data = (VectorDecimalCastData *)dataptr;
 		RESULT_TYPE result_value;
-		if (!OP::template Operation<INPUT_TYPE, RESULT_TYPE>(
-		        input, result_value, data->vector_cast_data.parameters, data->width, data->scale)) {
+		if (!OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, result_value, data->vector_cast_data.parameters,
+		                                                     data->width, data->scale)) {
 			return HandleVectorCastError::Operation<RESULT_TYPE>("Failed to cast decimal value", mask, idx,
 			                                                     data->vector_cast_data);
 		}

--- a/src/include/duckdb/function/cast/vector_cast_helpers.hpp
+++ b/src/include/duckdb/function/cast/vector_cast_helpers.hpp
@@ -26,17 +26,6 @@ struct VectorStringCastOperator {
 	}
 };
 
-struct VectorTryCastData {
-	VectorTryCastData(Vector &result_p, string *error_message_p, bool strict_p)
-	    : result(result_p), error_message(error_message_p), strict(strict_p) {
-	}
-
-	Vector &result;
-	string *error_message;
-	bool strict;
-	bool all_converted = true;
-};
-
 template <class OP>
 struct VectorTryCastOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
@@ -47,7 +36,7 @@ struct VectorTryCastOperator {
 		}
 		auto data = (VectorTryCastData *)dataptr;
 		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
-		                                                     idx, data->error_message, data->all_converted);
+		                                                     idx, *data);
 	}
 };
 
@@ -57,11 +46,11 @@ struct VectorTryCastStrictOperator {
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
 		auto data = (VectorTryCastData *)dataptr;
 		RESULT_TYPE output;
-		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->strict))) {
+		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->parameters.strict))) {
 			return output;
 		}
 		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
-		                                                     idx, data->error_message, data->all_converted);
+		                                                     idx, *data);
 	}
 };
 
@@ -72,13 +61,13 @@ struct VectorTryCastErrorOperator {
 		auto data = (VectorTryCastData *)dataptr;
 		RESULT_TYPE output;
 		if (DUCKDB_LIKELY(
-		        OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->error_message, data->strict))) {
+		        OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->parameters.error_message, data->parameters.strict))) {
 			return output;
 		}
-		bool has_error = data->error_message && !data->error_message->empty();
+		bool has_error = data->parameters.error_message && !data->parameters.error_message->empty();
 		return HandleVectorCastError::Operation<RESULT_TYPE>(
-		    has_error ? *data->error_message : CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask, idx,
-		    data->error_message, data->all_converted);
+		    has_error ? *data->parameters.error_message : CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask, idx,
+            *data);
 	}
 };
 
@@ -89,23 +78,22 @@ struct VectorTryCastStringOperator {
 		auto data = (VectorTryCastData *)dataptr;
 		RESULT_TYPE output;
 		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->result,
-		                                                                  data->error_message, data->strict))) {
+		                                                                  data->parameters.error_message, data->parameters.strict))) {
 			return output;
 		}
 		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
-		                                                     idx, data->error_message, data->all_converted);
+		                                                     idx, *data);
 	}
 };
 
 struct VectorDecimalCastData {
-	VectorDecimalCastData(string *error_message_p, uint8_t width_p, uint8_t scale_p)
-	    : error_message(error_message_p), width(width_p), scale(scale_p) {
+	VectorDecimalCastData(Vector &result, CastParameters &parameters, uint8_t width_p, uint8_t scale_p)
+	    : vector_cast_data(result, parameters), width(width_p), scale(scale_p) {
 	}
 
-	string *error_message;
+    VectorTryCastData vector_cast_data;
 	uint8_t width;
 	uint8_t scale;
-	bool all_converted = true;
 };
 
 template <class OP>
@@ -114,10 +102,10 @@ struct VectorDecimalCastOperator {
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
 		auto data = (VectorDecimalCastData *)dataptr;
 		RESULT_TYPE result_value;
-		if (!OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, result_value, data->error_message, data->width,
+		if (!OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, result_value, data->vector_cast_data.parameters.error_message, data->width,
 		                                                     data->scale)) {
 			return HandleVectorCastError::Operation<RESULT_TYPE>("Failed to cast decimal value", mask, idx,
-			                                                     data->error_message, data->all_converted);
+			                                                     data->vector_cast_data);
 		}
 		return result_value;
 	}
@@ -132,7 +120,7 @@ struct VectorCastHelpers {
 
 	template <class SRC, class DST, class OP>
 	static bool TemplatedTryCastLoop(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-		VectorTryCastData input(result, parameters.error_message, parameters.strict);
+		VectorTryCastData input(result, parameters);
 		UnaryExecutor::GenericExecute<SRC, DST, OP>(source, result, count, &input, parameters.error_message);
 		return input.all_converted;
 	}
@@ -166,12 +154,12 @@ struct VectorCastHelpers {
 	}
 
 	template <class SRC, class T, class OP>
-	static bool TemplatedDecimalCast(Vector &source, Vector &result, idx_t count, string *error_message, uint8_t width,
+	static bool TemplatedDecimalCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters, uint8_t width,
 	                                 uint8_t scale) {
-		VectorDecimalCastData input(error_message, width, scale);
+		VectorDecimalCastData input(result, parameters, width, scale);
 		UnaryExecutor::GenericExecute<SRC, T, VectorDecimalCastOperator<OP>>(source, result, count, (void *)&input,
-		                                                                     error_message);
-		return input.all_converted;
+		                                                                     parameters.error_message);
+		return input.vector_cast_data.all_converted;
 	}
 
 	template <class T>
@@ -181,16 +169,16 @@ struct VectorCastHelpers {
 		auto scale = DecimalType::GetScale(result_type);
 		switch (result_type.InternalType()) {
 		case PhysicalType::INT16:
-			return TemplatedDecimalCast<T, int16_t, TryCastToDecimal>(source, result, count, parameters.error_message,
+			return TemplatedDecimalCast<T, int16_t, TryCastToDecimal>(source, result, count, parameters,
 			                                                          width, scale);
 		case PhysicalType::INT32:
-			return TemplatedDecimalCast<T, int32_t, TryCastToDecimal>(source, result, count, parameters.error_message,
+			return TemplatedDecimalCast<T, int32_t, TryCastToDecimal>(source, result, count, parameters,
 			                                                          width, scale);
 		case PhysicalType::INT64:
-			return TemplatedDecimalCast<T, int64_t, TryCastToDecimal>(source, result, count, parameters.error_message,
+			return TemplatedDecimalCast<T, int64_t, TryCastToDecimal>(source, result, count, parameters,
 			                                                          width, scale);
 		case PhysicalType::INT128:
-			return TemplatedDecimalCast<T, hugeint_t, TryCastToDecimal>(source, result, count, parameters.error_message,
+			return TemplatedDecimalCast<T, hugeint_t, TryCastToDecimal>(source, result, count, parameters,
 			                                                            width, scale);
 		default:
 			throw InternalException("Unimplemented internal type for decimal");

--- a/src/include/duckdb/main/capi/cast/from_decimal.hpp
+++ b/src/include/duckdb/main/capi/cast/from_decimal.hpp
@@ -21,19 +21,21 @@ bool CastDecimalCInternal(duckdb_result *source, RESULT_TYPE &result, idx_t col,
 	auto width = duckdb::DecimalType::GetWidth(source_type);
 	auto scale = duckdb::DecimalType::GetScale(source_type);
 	void *source_address = UnsafeFetchPtr<hugeint_t>(source, col, row);
+
+	CastParameters parameters;
 	switch (source_type.InternalType()) {
 	case duckdb::PhysicalType::INT16:
 		return duckdb::TryCastFromDecimal::Operation<int16_t, RESULT_TYPE>(UnsafeFetchFromPtr<int16_t>(source_address),
-		                                                                   result, nullptr, width, scale);
+		                                                                   result, parameters, width, scale);
 	case duckdb::PhysicalType::INT32:
 		return duckdb::TryCastFromDecimal::Operation<int32_t, RESULT_TYPE>(UnsafeFetchFromPtr<int32_t>(source_address),
-		                                                                   result, nullptr, width, scale);
+		                                                                   result, parameters, width, scale);
 	case duckdb::PhysicalType::INT64:
 		return duckdb::TryCastFromDecimal::Operation<int64_t, RESULT_TYPE>(UnsafeFetchFromPtr<int64_t>(source_address),
-		                                                                   result, nullptr, width, scale);
+		                                                                   result, parameters, width, scale);
 	case duckdb::PhysicalType::INT128:
 		return duckdb::TryCastFromDecimal::Operation<hugeint_t, RESULT_TYPE>(
-		    UnsafeFetchFromPtr<hugeint_t>(source_address), result, nullptr, width, scale);
+		    UnsafeFetchFromPtr<hugeint_t>(source_address), result, parameters, width, scale);
 	default:
 		throw duckdb::InternalException("Unimplemented internal type for decimal");
 	}

--- a/src/include/duckdb/main/capi/cast/to_decimal.hpp
+++ b/src/include/duckdb/main/capi/cast/to_decimal.hpp
@@ -15,7 +15,8 @@ namespace duckdb {
 template <class INTERNAL_TYPE>
 struct ToCDecimalCastWrapper {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width,
+	                      uint8_t scale) {
 		throw NotImplementedException("Type not implemented for CDecimalCastWrapper");
 	}
 };
@@ -24,10 +25,12 @@ struct ToCDecimalCastWrapper {
 template <>
 struct ToCDecimalCastWrapper<hugeint_t> {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width,
+	                      uint8_t scale) {
 		hugeint_t intermediate_result;
 
-		if (!TryCastToDecimal::Operation<SOURCE_TYPE, hugeint_t>(input, intermediate_result, parameters, width, scale)) {
+		if (!TryCastToDecimal::Operation<SOURCE_TYPE, hugeint_t>(input, intermediate_result, parameters, width,
+		                                                         scale)) {
 			result = FetchDefaultValue::Operation<duckdb_decimal>();
 			return false;
 		}
@@ -47,7 +50,8 @@ struct ToCDecimalCastWrapper<hugeint_t> {
 template <>
 struct ToCDecimalCastWrapper<int16_t> {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width,
+	                      uint8_t scale) {
 		int16_t intermediate_result;
 
 		if (!TryCastToDecimal::Operation<SOURCE_TYPE, int16_t>(input, intermediate_result, parameters, width, scale)) {
@@ -70,7 +74,8 @@ struct ToCDecimalCastWrapper<int16_t> {
 template <>
 struct ToCDecimalCastWrapper<int32_t> {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width,
+	                      uint8_t scale) {
 		int32_t intermediate_result;
 
 		if (!TryCastToDecimal::Operation<SOURCE_TYPE, int32_t>(input, intermediate_result, parameters, width, scale)) {
@@ -93,7 +98,8 @@ struct ToCDecimalCastWrapper<int32_t> {
 template <>
 struct ToCDecimalCastWrapper<int64_t> {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width,
+	                      uint8_t scale) {
 		int64_t intermediate_result;
 
 		if (!TryCastToDecimal::Operation<SOURCE_TYPE, int64_t>(input, intermediate_result, parameters, width, scale)) {
@@ -117,7 +123,7 @@ template <class SOURCE_TYPE, class OP>
 duckdb_decimal TryCastToDecimalCInternal(SOURCE_TYPE source, uint8_t width, uint8_t scale) {
 	duckdb_decimal result;
 	try {
-        CastParameters parameters;
+		CastParameters parameters;
 		if (!OP::template Operation<SOURCE_TYPE>(source, result, parameters, width, scale)) {
 			return FetchDefaultValue::Operation<duckdb_decimal>();
 		}

--- a/src/include/duckdb/main/capi/cast/to_decimal.hpp
+++ b/src/include/duckdb/main/capi/cast/to_decimal.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 template <class INTERNAL_TYPE>
 struct ToCDecimalCastWrapper {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, std::string *error, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 		throw NotImplementedException("Type not implemented for CDecimalCastWrapper");
 	}
 };
@@ -24,10 +24,10 @@ struct ToCDecimalCastWrapper {
 template <>
 struct ToCDecimalCastWrapper<hugeint_t> {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, std::string *error, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 		hugeint_t intermediate_result;
 
-		if (!TryCastToDecimal::Operation<SOURCE_TYPE, hugeint_t>(input, intermediate_result, error, width, scale)) {
+		if (!TryCastToDecimal::Operation<SOURCE_TYPE, hugeint_t>(input, intermediate_result, parameters, width, scale)) {
 			result = FetchDefaultValue::Operation<duckdb_decimal>();
 			return false;
 		}
@@ -47,10 +47,10 @@ struct ToCDecimalCastWrapper<hugeint_t> {
 template <>
 struct ToCDecimalCastWrapper<int16_t> {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, std::string *error, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 		int16_t intermediate_result;
 
-		if (!TryCastToDecimal::Operation<SOURCE_TYPE, int16_t>(input, intermediate_result, error, width, scale)) {
+		if (!TryCastToDecimal::Operation<SOURCE_TYPE, int16_t>(input, intermediate_result, parameters, width, scale)) {
 			result = FetchDefaultValue::Operation<duckdb_decimal>();
 			return false;
 		}
@@ -70,10 +70,10 @@ struct ToCDecimalCastWrapper<int16_t> {
 template <>
 struct ToCDecimalCastWrapper<int32_t> {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, std::string *error, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 		int32_t intermediate_result;
 
-		if (!TryCastToDecimal::Operation<SOURCE_TYPE, int32_t>(input, intermediate_result, error, width, scale)) {
+		if (!TryCastToDecimal::Operation<SOURCE_TYPE, int32_t>(input, intermediate_result, parameters, width, scale)) {
 			result = FetchDefaultValue::Operation<duckdb_decimal>();
 			return false;
 		}
@@ -93,10 +93,10 @@ struct ToCDecimalCastWrapper<int32_t> {
 template <>
 struct ToCDecimalCastWrapper<int64_t> {
 	template <class SOURCE_TYPE>
-	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, std::string *error, uint8_t width, uint8_t scale) {
+	static bool Operation(SOURCE_TYPE input, duckdb_decimal &result, CastParameters &parameters, uint8_t width, uint8_t scale) {
 		int64_t intermediate_result;
 
-		if (!TryCastToDecimal::Operation<SOURCE_TYPE, int64_t>(input, intermediate_result, error, width, scale)) {
+		if (!TryCastToDecimal::Operation<SOURCE_TYPE, int64_t>(input, intermediate_result, parameters, width, scale)) {
 			result = FetchDefaultValue::Operation<duckdb_decimal>();
 			return false;
 		}
@@ -117,7 +117,8 @@ template <class SOURCE_TYPE, class OP>
 duckdb_decimal TryCastToDecimalCInternal(SOURCE_TYPE source, uint8_t width, uint8_t scale) {
 	duckdb_decimal result;
 	try {
-		if (!OP::template Operation<SOURCE_TYPE>(source, result, nullptr, width, scale)) {
+        CastParameters parameters;
+		if (!OP::template Operation<SOURCE_TYPE>(source, result, parameters, width, scale)) {
 			return FetchDefaultValue::Operation<duckdb_decimal>();
 		}
 	} catch (...) {

--- a/src/include/duckdb/planner/expression.hpp
+++ b/src/include/duckdb/planner/expression.hpp
@@ -64,6 +64,7 @@ protected:
 		expression_class = other.expression_class;
 		alias = other.alias;
 		return_type = other.return_type;
+		query_location = other.query_location;
 	}
 };
 

--- a/src/include/duckdb/storage/serialization/expression.json
+++ b/src/include/duckdb/storage/serialization/expression.json
@@ -23,6 +23,12 @@
         "id": 102,
         "name": "alias",
         "type": "string"
+      },
+      {
+        "id": 103,
+        "name": "query_location",
+        "type": "optional_idx",
+        "default": "optional_idx()"
       }
     ]
   },

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -102,7 +102,8 @@ void BaseAppender::AppendDecimalValueInternal(Vector &col, SRC input) {
 		D_ASSERT(type.id() == LogicalTypeId::DECIMAL);
 		auto width = DecimalType::GetWidth(type);
 		auto scale = DecimalType::GetScale(type);
-		TryCastToDecimal::Operation<SRC, DST>(input, FlatVector::GetData<DST>(col)[chunk.size()], nullptr, width,
+		CastParameters parameters;
+		TryCastToDecimal::Operation<SRC, DST>(input, FlatVector::GetData<DST>(col)[chunk.size()], parameters, width,
 		                                      scale);
 		return;
 	}

--- a/src/main/capi/hugeint-c.cpp
+++ b/src/main/capi/hugeint-c.cpp
@@ -77,6 +77,7 @@ double duckdb_decimal_to_double(duckdb_decimal val) {
 	hugeint_t value;
 	value.lower = val.value.lower;
 	value.upper = val.value.upper;
-	duckdb::TryCastFromDecimal::Operation<hugeint_t, double>(value, result, nullptr, val.width, val.scale);
+	duckdb::CastParameters parameters;
+	duckdb::TryCastFromDecimal::Operation<hugeint_t, double>(value, result, parameters, val.width, val.scale);
 	return result;
 }

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -458,6 +458,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 			auto &db_instance = DatabaseInstance::GetDatabase(*this);
 			ValidChecker::Invalidate(db_instance, error.RawMessage());
 		}
+		ProcessError(error, active_query->query);
 		result.SetError(std::move(error));
 	} catch (...) { // LCOV_EXCL_START
 		result.SetError(ErrorData("Unhandled exception in ExecuteTaskInternal"));

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -24,11 +24,11 @@ string QueryErrorContext::Format(const string &query, const string &error_messag
 	idx_t line_number = 1;
 	for (idx_t i = 0; i < error_location; i++) {
 		bool is_newline = false;
-		switch(query[i]) {
+		switch (query[i]) {
 		case '\r':
 			if (i + 1 >= error_location || query[i + 1] != '\n') {
 				// not \r\n
-                is_newline = true;
+				is_newline = true;
 				break;
 			}
 			break;

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -23,7 +23,22 @@ string QueryErrorContext::Format(const string &query, const string &error_messag
 	idx_t start_pos = 0;
 	idx_t line_number = 1;
 	for (idx_t i = 0; i < error_location; i++) {
-		if (StringUtil::CharacterIsNewline(query[i])) {
+		bool is_newline = false;
+		switch(query[i]) {
+		case '\r':
+			if (i + 1 >= error_location || query[i + 1] != '\n') {
+				// not \r\n
+                is_newline = true;
+				break;
+			}
+			break;
+		case '\n':
+			is_newline = true;
+			break;
+		default:
+			break;
+		}
+		if (is_newline) {
 			line_number++;
 			start_pos = i + 1;
 		}

--- a/src/parser/query_error_context.cpp
+++ b/src/parser/query_error_context.cpp
@@ -29,7 +29,6 @@ string QueryErrorContext::Format(const string &query, const string &error_messag
 			if (i + 1 >= error_location || query[i + 1] != '\n') {
 				// not \r\n
 				is_newline = true;
-				break;
 			}
 			break;
 		case '\n':

--- a/src/parser/transform/expression/transform_cast.cpp
+++ b/src/parser/transform/expression/transform_cast.cpp
@@ -23,7 +23,9 @@ unique_ptr<ParsedExpression> Transformer::TransformTypeCast(duckdb_libpgquery::P
 	bool try_cast = root.tryCast;
 
 	// now create a cast operation
-	return make_uniq<CastExpression>(target_type, std::move(expression), try_cast);
+	auto result = make_uniq<CastExpression>(target_type, std::move(expression), try_cast);
+	SetQueryLocation(*result, root.location);
+	return std::move(result);
 }
 
 } // namespace duckdb

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -40,7 +40,9 @@ unique_ptr<Expression> AddCastExpressionInternal(unique_ptr<Expression> expr, co
 			return expr;
 		}
 	}
-	return make_uniq<BoundCastExpression>(std::move(expr), target_type, std::move(bound_cast), try_cast);
+	auto result = make_uniq<BoundCastExpression>(std::move(expr), target_type, std::move(bound_cast), try_cast);
+	result->query_location = result->child->query_location;
+	return std::move(result);
 }
 
 unique_ptr<Expression> AddCastToTypeInternal(unique_ptr<Expression> expr, const LogicalType &target_type,

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -95,6 +95,7 @@ unique_ptr<Expression> BoundCastExpression::AddDefaultCastToType(unique_ptr<Expr
                                                                  const LogicalType &target_type, bool try_cast) {
 	CastFunctionSet default_set;
 	GetCastFunctionInput get_input;
+	get_input.query_location = expr->query_location;
 	return AddCastToTypeInternal(std::move(expr), target_type, default_set, get_input, try_cast);
 }
 
@@ -102,6 +103,7 @@ unique_ptr<Expression> BoundCastExpression::AddCastToType(ClientContext &context
                                                           const LogicalType &target_type, bool try_cast) {
 	auto &cast_functions = DBConfig::GetConfig(context).GetCastFunctions();
 	GetCastFunctionInput get_input(context);
+	get_input.query_location = expr->query_location;
 	return AddCastToTypeInternal(std::move(expr), target_type, cast_functions, get_input, try_cast);
 }
 

--- a/src/storage/serialization/serialize_expression.cpp
+++ b/src/storage/serialization/serialize_expression.cpp
@@ -13,12 +13,14 @@ void Expression::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<ExpressionClass>(100, "expression_class", expression_class);
 	serializer.WriteProperty<ExpressionType>(101, "type", type);
 	serializer.WritePropertyWithDefault<string>(102, "alias", alias);
+	serializer.WritePropertyWithDefault<optional_idx>(103, "query_location", query_location, optional_idx());
 }
 
 unique_ptr<Expression> Expression::Deserialize(Deserializer &deserializer) {
 	auto expression_class = deserializer.ReadProperty<ExpressionClass>(100, "expression_class");
 	auto type = deserializer.ReadProperty<ExpressionType>(101, "type");
 	auto alias = deserializer.ReadPropertyWithDefault<string>(102, "alias");
+	auto query_location = deserializer.ReadPropertyWithDefault<optional_idx>(103, "query_location", optional_idx());
 	deserializer.Set<ExpressionType>(type);
 	unique_ptr<Expression> result;
 	switch (expression_class) {
@@ -78,6 +80,7 @@ unique_ptr<Expression> Expression::Deserialize(Deserializer &deserializer) {
 	}
 	deserializer.Unset<ExpressionType>();
 	result->alias = std::move(alias);
+	result->query_location = query_location;
 	return result;
 }
 

--- a/test/sql/cast/cast_error_location.test
+++ b/test/sql/cast/cast_error_location.test
@@ -82,3 +82,81 @@ select 42::utinyint + 'hello'
 ----
 ^
 
+# bit
+statement error
+SELECT bitstring('1', 9)::BOOL;
+----
+^
+
+# array
+statement error
+SELECT [1,2,3]::INT[2]
+----
+^
+
+# blob
+statement error
+SELECT '\x'::BYTEA
+----
+^
+
+# now with a table
+statement ok
+CREATE TABLE cast_table(i INTEGER, s VARCHAR, d DECIMAL(5,1), l INT[], int_struct ROW(i INTEGER), dbl DOUBLE, hge HUGEINT);
+
+statement ok
+INSERT INTO cast_table VALUES (1000, 'hello', 1000.0, [1000], {'i': 1000}, 1e308, 1000000000000000000000000000000)
+
+# out of range integer cast
+statement error
+SELECT i::utinyint from cast_table
+----
+^
+
+# string cast
+statement error
+SELECT s::int FROM cast_table
+----
+^
+
+# numeric -> decimal cast
+statement error
+SELECT i::decimal(2,1) FROM cast_table
+----
+^
+
+# decimal -> decimal cast
+statement error
+SELECT d::decimal(2,1) FROM cast_data
+----
+^
+
+# list cast
+statement error
+SELECT l::utinyint[] FROM cast_data
+----
+^
+
+# struct cast
+statement error
+SELECT int_struct::row(x tinyint) FROM cast_data
+----
+^
+
+# double -> float
+statement error
+select dbl::float FROM cast_data
+----
+^
+
+# double -> hugeint
+statement error
+select dbl::hugeint
+----
+^
+
+# hugeint -> int
+statement error
+select hge::hugeint::int
+----
+^

--- a/test/sql/cast/cast_error_location.test
+++ b/test/sql/cast/cast_error_location.test
@@ -102,10 +102,10 @@ SELECT '\x'::BYTEA
 
 # now with a table
 statement ok
-CREATE TABLE cast_table(i INTEGER, s VARCHAR, d DECIMAL(5,1), l INT[], int_struct ROW(i INTEGER), dbl DOUBLE, hge HUGEINT);
+CREATE TABLE cast_table(i INTEGER, s VARCHAR, d DECIMAL(5,1), l INT[], int_struct ROW(i INTEGER), dbl DOUBLE, hge HUGEINT, invalid_blob_str VARCHAR);
 
 statement ok
-INSERT INTO cast_table VALUES (1000, 'hello', 1000.0, [1000], {'i': 1000}, 1e308, 1000000000000000000000000000000)
+INSERT INTO cast_table VALUES (1000, 'hello', 1000.0, [1000], {'i': 1000}, 1e308, 1000000000000000000000000000000, '\x')
 
 # out of range integer cast
 statement error
@@ -127,36 +127,48 @@ SELECT i::decimal(2,1) FROM cast_table
 
 # decimal -> decimal cast
 statement error
-SELECT d::decimal(2,1) FROM cast_data
+SELECT d::decimal(2,1) FROM cast_table
 ----
 ^
 
 # list cast
 statement error
-SELECT l::utinyint[] FROM cast_data
+SELECT l::utinyint[] FROM cast_table
 ----
 ^
 
 # struct cast
 statement error
-SELECT int_struct::row(x tinyint) FROM cast_data
+SELECT int_struct::row(x tinyint) FROM cast_table
 ----
 ^
 
 # double -> float
 statement error
-select dbl::float FROM cast_data
+select dbl::float FROM cast_table
 ----
 ^
 
 # double -> hugeint
 statement error
-select dbl::hugeint
+select dbl::hugeint FROM cast_table
 ----
 ^
 
 # hugeint -> int
 statement error
-select hge::hugeint::int
+select hge::hugeint::int FROM cast_table
+----
+^
+
+# array
+statement error
+SELECT l::INT[3] FROM cast_table
+----
+^
+
+# blob
+statement error
+SELECT invalid_blob_str::BYTEA FROM cast_table
 ----
 ^

--- a/test/sql/cast/cast_error_location.test
+++ b/test/sql/cast/cast_error_location.test
@@ -1,0 +1,84 @@
+# name: test/sql/cast/cast_error_location.test
+# description: Test reporting error location of casts
+# group: [cast]
+
+statement ok
+PRAGMA enable_verification
+
+# unimplemented cast
+statement error
+SELECT 1::STRUCT(i INTEGER)
+----
+^
+
+# out of range integer cast
+statement error
+SELECT 1000::utinyint
+----
+^
+
+# string cast
+statement error
+SELECT 'hello'::int
+----
+^
+
+# numeric -> decimal cast
+statement error
+SELECT 1000::decimal(2,1)
+----
+^
+
+# decimal -> decimal cast
+statement error
+SELECT 1000.0::decimal(5,1)::decimal(2,1)
+----
+^
+
+# list cast
+statement error
+SELECT [1000]::utinyint[]
+----
+^
+
+# struct cast
+statement error
+SELECT {'x': 1000}::row(x tinyint)
+----
+^
+
+# double -> float
+statement error
+select 1e308::float
+----
+^
+
+# double -> hugeint
+statement error
+select 1e308::hugeint
+----
+^
+
+# hugeint -> int
+statement error
+select 1000000000000000000000000000000::hugeint::int
+----
+^
+
+# automatically added cast
+statement error
+select nth_value(42, 'hello') over ()
+----
+^
+
+# dates
+statement error
+select '1900'::date
+----
+^
+
+statement error
+select 42::utinyint + 'hello'
+----
+^
+

--- a/test/sql/inet/test_inet_type.test
+++ b/test/sql/inet/test_inet_type.test
@@ -40,31 +40,39 @@ INET
 statement error
 select '127'::inet;
 ----
+^
 
 statement error
 select '127..1'::inet;
 ----
+^
 
 statement error
 SELECT '256.0.0.1'::INET::VARCHAR
 ----
+^
 
 statement error
 SELECT '-1.0.0.1'::INET::VARCHAR
 ----
+^
 
 statement error
 SELECT '127..0.1'::INET::VARCHAR
 ----
+^
 
 statement error
 SELECT '127.0.0.1/33'::INET::VARCHAR
 ----
+^
 
 statement error
 SELECT '127.0.0.1/333'::INET::VARCHAR
 ----
+^
 
 statement error
 SELECT '127.0.0.1/33333333333333333333'::INET::VARCHAR
 ----
+^

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -12,19 +12,19 @@ CREATE TABLE tbl1 (i int);
 query I
 SELECT json_serialize_plan('SELECT 1 + 2 FROM tbl1');
 ----
-{"error":false,"plans":[{"type":"LOGICAL_PROJECTION","children":[{"type":"LOGICAL_GET","children":[],"table_index":0,"returned_types":[{"id":"INTEGER","type_info":null}],"names":["i"],"column_ids":[18446744073709551615],"projection_ids":[],"table_filters":{"filters":[]},"name":"seq_scan","arguments":[],"original_arguments":[],"has_serialize":true,"function_data":{"catalog":"memory","schema":"main","table":"tbl1","is_index_scan":false,"is_create_index":false,"result_ids":[]},"projected_input":[]}],"table_index":1,"expressions":[{"expression_class":"BOUND_FUNCTION","type":"BOUND_FUNCTION","alias":"","return_type":{"id":"INTEGER","type_info":null},"children":[{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","alias":"","value":{"type":{"id":"INTEGER","type_info":null},"is_null":false,"value":1}},{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","alias":"","value":{"type":{"id":"INTEGER","type_info":null},"is_null":false,"value":2}}],"name":"+","arguments":[{"id":"INTEGER","type_info":null},{"id":"INTEGER","type_info":null}],"original_arguments":[],"has_serialize":false,"is_operator":true}]}]}
+<REGEX>:.*LOGICAL_PROJECTION.*LOGICAL_GET.*
 
 # Example with skip_null and skip_empty
 query I
 SELECT json_serialize_plan('SELECT *, 1 + 2 FROM tbl1', skip_null := true, skip_empty := true);
 ----
-{"error":false,"plans":[{"type":"LOGICAL_PROJECTION","children":[{"type":"LOGICAL_GET","table_index":0,"returned_types":[{"id":"INTEGER"}],"names":["i"],"column_ids":[0],"name":"seq_scan","has_serialize":true,"function_data":{"catalog":"memory","schema":"main","table":"tbl1","is_index_scan":false,"is_create_index":false}}],"table_index":1,"expressions":[{"expression_class":"BOUND_REF","type":"BOUND_REF","alias":"i","return_type":{"id":"INTEGER"},"index":0},{"expression_class":"BOUND_FUNCTION","type":"BOUND_FUNCTION","return_type":{"id":"INTEGER"},"children":[{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","value":{"type":{"id":"INTEGER"},"is_null":false,"value":1}},{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","value":{"type":{"id":"INTEGER"},"is_null":false,"value":2}}],"name":"+","arguments":[{"id":"INTEGER"},{"id":"INTEGER"}],"has_serialize":false,"is_operator":true}]}]}
+<REGEX>:.*LOGICAL_PROJECTION.*LOGICAL_GET.*
 
 # Example with skip_null and skip_empty and optimize
 query I
 SELECT json_serialize_plan('SELECT *, 1 + 2 FROM tbl1', skip_null := true, skip_empty := true, optimize := true);
 ----
-{"error":false,"plans":[{"type":"LOGICAL_PROJECTION","children":[{"type":"LOGICAL_GET","table_index":0,"returned_types":[{"id":"INTEGER"}],"names":["i"],"column_ids":[0],"projection_ids":[0],"name":"seq_scan","has_serialize":true,"function_data":{"catalog":"memory","schema":"main","table":"tbl1","is_index_scan":false,"is_create_index":false}}],"table_index":1,"expressions":[{"expression_class":"BOUND_REF","type":"BOUND_REF","alias":"i","return_type":{"id":"INTEGER"},"index":0},{"expression_class":"BOUND_CONSTANT","type":"VALUE_CONSTANT","value":{"type":{"id":"INTEGER"},"is_null":false,"value":3}}]}]}
+<REGEX>:.*LOGICAL_PROJECTION.*LOGICAL_GET.*
 
 # Example with syntax error
 query I

--- a/tools/odbc/odbc_interval.cpp
+++ b/tools/odbc/odbc_interval.cpp
@@ -16,8 +16,9 @@ bool OdbcInterval::GetInterval(Value &value, interval_t &interval, duckdb::OdbcH
 		return true;
 	case LogicalTypeId::VARCHAR: {
 		string error_message;
+		CastParameters parameters(false, &error_message);
 		auto &val_str = StringValue::Get(value);
-		if (!TryCastErrorMessage::Operation<string_t, interval_t>(string_t(val_str), interval, &error_message)) {
+		if (!TryCastErrorMessage::Operation<string_t, interval_t>(string_t(val_str), interval, parameters)) {
 			error_message = CastExceptionText<string_t, interval_t>(string_t(val_str));
 			auto data_source = hstmt->dbc->GetDataSourceName();
 			duckdb::DiagRecord diag_rec(error_message, SQLStateType::ST_22007, data_source);

--- a/tools/odbc/statement_functions.cpp
+++ b/tools/odbc/statement_functions.cpp
@@ -399,7 +399,8 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 		} else {
 			hugeint_t huge_int;
 			string error_message;
-			if (!duckdb::TryCastToDecimal::Operation<string_t, hugeint_t>(str_t, huge_int, &error_message,
+			CastParameters parameters(false, &error_message);
+			if (!duckdb::TryCastToDecimal::Operation<string_t, hugeint_t>(str_t, huge_int, parameters,
 			                                                              numeric->precision, numeric->scale)) {
 				return SQL_ERROR;
 			}


### PR DESCRIPTION
This PR adds query error location reporting to all failed casts, for example:

```sql
D select 'hello'::int;
-- Conversion Error: Could not convert string 'hello' to INT32
-- LINE 1: select 'hello'::int;
--                       ^

D select l::int[] from (values (['hello'])) t(l);
-- Conversion Error: Could not convert string 'hello' to INT32
-- LINE 1: select l::int[] from (values (['hello'])) t(l);
--                 ^

D select x::struct(i int) from (values ({'x': 42})) t(x);
-- Mismatch Type Error: Type STRUCT(x INTEGER) does not match with STRUCT(i INTEGER). Cannot cast STRUCTs -
-- element "x" in source struct was not found in target struct
-- LINE 1: select x::struct(i int) from (values ({'x': 42...
--                ^
```

This is enabled because of the recent exception rework that makes it much easier to display query error locations as part of the error (see #10410).

Cast failures are one of the most common run-time errors, and while for simple queries it is obvious where the error happens, it is not always obvious in more complex queries. Especially since failures are data-dependent, and as casts can also be introduced by the system itself.

This PR looks large but the majority of it is changing `string *error_message` to `CastParameters &parameters` - we just have a lot of cast functions :)


#### Other Changes

This PR also introduces two other changes:

* Serialize `query_location` as part of `Expression`, similar to how we do that for `ParsedExpression` now as well
* Fix a bug in query error location reporting where we would count `\r\n` as two lines leading to an incorrect line number being provided
