### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -69,6 +69,7 @@ jobs:
     name: Release Assertions
     runs-on: ubuntu-20.04
     needs: linux-memory-leaks
+    timeout-minutes: 120
     env:
       CC: gcc-10
       CXX: g++-10
@@ -107,7 +108,6 @@ jobs:
 
     - name: Test
       shell: bash
-      timeout-minutes: 120
       run: |
           python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit
 

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -107,6 +107,7 @@ jobs:
 
     - name: Test
       shell: bash
+      timeout-minutes: 120
       run: |
           python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit
 

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -586,6 +586,49 @@ jobs:
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[detailed_profiler]" --no-exit
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow --no-exit
 
+
+  threadsan-relassert-all:
+    name: Thread Sanitizer (Relassert + All tests)
+    runs-on: ubuntu-latest
+    needs: linux-memory-leaks
+    env:
+      GEN: ninja
+      EXTENSION_STATIC_BUILD: 1
+      BUILD_ICU: 1
+      BUILD_INET: 1
+      BUILD_TPCH: 1
+      BUILD_TPCDS: 1
+      BUILD_FTS: 1
+      BUILD_VISUALIZER: 1
+      BUILD_JSON: 1
+      BUILD_EXCEL: 1
+      BUILD_JEMALLOC: 1
+      TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install
+      shell: bash
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ env.CCACHE_SAVE }}
+
+    - name: Build
+      shell: bash
+      run: THREADSAN=1 make relassert
+
+    - name: Test
+      shell: bash
+      run: |
+          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit
+
   vector-sizes:
     name: Vector Sizes
     runs-on: ubuntu-20.04

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -31,11 +31,15 @@ jobs:
           tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
     - name: Install dependencies
       run: sudo apt install -y git g++ cmake ninja-build libssl-dev default-jdk unixodbc-dev
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
     - name: Build with cov-build
       run: cov-analysis-linux64/bin/cov-build --dir cov-int make
       env:
         PYTHON_USER_SPACE: 1
-        PYTHON_EDITABLE_BUILD: 1
         BUILD_PYTHON: 1
         BUILD_JDBC: 1
         BUILD_ODBC: 1

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -5,16 +5,16 @@
 # Also, ensure that the 'github.repository' comparison and 'COVERITY_PROJECT_NAME' values below are accurate
 name: Coverity Scan
 on:
-  schedule:
-  # Run once daily, duckdb is at ~900k LOC
+  repository_dispatch:
+  # Run once daily (via repository_dispatch), duckdb is at ~900k LOC
   # Scan frequency limits from https://scan.coverity.com/faq#frequency :
   # Up to 28 builds per week, with a maximum of 4 builds per day, for projects with fewer than 100K lines of code
   # Up to 21 builds per week, with a maximum of 3 builds per day, for projects with 100K to 500K lines of code
   # Up to 14 builds per week, with a maximum of 2 build per day, for projects with 500K to 1 million lines of code
   # Up to 7 builds per week, with a maximum of 1 build per day, for projects with more than 1 million lines of code
-  - cron: '0 0 * * *'
   # Support manual execution
   workflow_dispatch:
+
 jobs:
   coverity:
     # So it doesn't try to run on forks

--- a/scripts/test_vector_sizes.py
+++ b/scripts/test_vector_sizes.py
@@ -32,4 +32,4 @@ for vector_size in vector_sizes:
     )
     execute_system_command('rm -rf build')
     execute_system_command('make relassert')
-    execute_system_command('python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest')
+    execute_system_command('python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest --no-exit')

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -171,7 +171,7 @@ string ExtensionHelper::ExtensionUrlTemplate(optional_ptr<const DBConfig> db_con
 	string versioned_path = "/${REVISION}/${PLATFORM}/${NAME}.duckdb_extension";
 #ifdef WASM_LOADABLE_EXTENSIONS
 	string default_endpoint = "https://extensions.duckdb.org";
-	versioned_path = "/duckdb-wasm" + versioned_path + ".wasm";
+	versioned_path = versioned_path + ".wasm";
 #else
 	string default_endpoint = "http://extensions.duckdb.org";
 	versioned_path = versioned_path + ".gz";

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -82,7 +82,7 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 				(void)column_name;
 				break;
 			default:
-				throw InternalException("Don't know how to drop this type!");
+				throw InternalException("Don't know how to alter this type!");
 			}
 
 			auto &alter_info = parse_info->Cast<AlterInfo>();
@@ -116,7 +116,7 @@ void CommitState::WriteCatalogEntry(CatalogEntry &entry, data_ptr_t dataptr) {
 				log->WriteCreateTableMacro(parent.Cast<TableMacroCatalogEntry>());
 				break;
 			default:
-				throw InternalException("Don't know how to drop this type!");
+				throw InternalException("Don't know how to create this type!");
 			}
 		}
 		break;


### PR DESCRIPTION
* absorb part of the duckdb-wasm changes
* Add --no-exit to vector size nightly tests
* Add threadsanitizer run on all tests + relassert
* Fix review comments from https://github.com/duckdb/duckdb/pull/10555/files#r1484558517
* Attempt at making coverity-scan compile