### PR TITLE
expose auto_type_candidates to python and improve it

### DIFF
--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -351,12 +351,14 @@ static Value StringVectorToValue(const vector<string> &vec) {
 static uint8_t GetCandidateSpecificity(const LogicalType &candidate_type) {
 	//! Const ht with accepted auto_types and their weights in specificity
 	const duckdb::unordered_map<uint8_t, uint8_t> auto_type_candidates_specificity {
-	    {(uint8_t)LogicalTypeId::VARCHAR, 0},  {(uint8_t)LogicalTypeId::TIMESTAMP, 1},
-	    {(uint8_t)LogicalTypeId::DATE, 2},     {(uint8_t)LogicalTypeId::TIME, 3},
-	    {(uint8_t)LogicalTypeId::DOUBLE, 4},   {(uint8_t)LogicalTypeId::FLOAT, 5},
-	    {(uint8_t)LogicalTypeId::BIGINT, 6},   {(uint8_t)LogicalTypeId::INTEGER, 7},
-	    {(uint8_t)LogicalTypeId::SMALLINT, 8}, {(uint8_t)LogicalTypeId::TINYINT, 9},
-	    {(uint8_t)LogicalTypeId::BOOLEAN, 10}, {(uint8_t)LogicalTypeId::SQLNULL, 11}};
+	    {(uint8_t)LogicalTypeId::VARCHAR, 0},   {(uint8_t)LogicalTypeId::TIMESTAMP, 1},
+	    {(uint8_t)LogicalTypeId::DATE, 2},      {(uint8_t)LogicalTypeId::TIME, 3},
+	    {(uint8_t)LogicalTypeId::DOUBLE, 4},    {(uint8_t)LogicalTypeId::FLOAT, 5},
+	    {(uint8_t)LogicalTypeId::BIGINT, 6},    {(uint8_t)LogicalTypeId::UBIGINT, 7},
+	    {(uint8_t)LogicalTypeId::INTEGER, 8},   {(uint8_t)LogicalTypeId::UINTEGER, 9},
+	    {(uint8_t)LogicalTypeId::SMALLINT, 10}, {(uint8_t)LogicalTypeId::USMALLINT, 11},
+	    {(uint8_t)LogicalTypeId::TINYINT, 12},  {(uint8_t)LogicalTypeId::UTINYINT, 13},
+	    {(uint8_t)LogicalTypeId::BOOLEAN, 14},  {(uint8_t)LogicalTypeId::SQLNULL, 15}};
 
 	auto id = (uint8_t)candidate_type.id();
 	auto it = auto_type_candidates_specificity.find(id);

--- a/test/sql/copy/csv/auto/test_type_candidates.test
+++ b/test/sql/copy/csv/auto/test_type_candidates.test
@@ -96,10 +96,15 @@ SELECT typeof(column0), typeof(column1), typeof(column2) FROM read_csv_auto ('__
 ----
 SMALLINT	FLOAT	VARCHAR
 
-statement error
+query III
 SELECT * FROM read_csv_auto ('__TEST_DIR__/csv_file.csv', auto_type_candidates=['USMALLINT', 'VARCHAR']);
 ----
-Auto Type Candidate of type USMALLINT is not accepted as a valid input
+1	1.1	bla
+
+query TTT
+SELECT typeof(column0), typeof(column1), typeof(column2) FROM read_csv_auto ('__TEST_DIR__/csv_file.csv', auto_type_candidates=['USMALLINT', 'VARCHAR']);
+----
+USMALLINT	VARCHAR	VARCHAR
 
 statement error
 SELECT * FROM read_csv_auto ('__TEST_DIR__/csv_file.csv', auto_type_candidates=['bla', 'VARCHAR'])

--- a/tools/pythonpkg/duckdb-stubs/__init__.pyi
+++ b/tools/pythonpkg/duckdb-stubs/__init__.pyi
@@ -238,7 +238,8 @@ class DuckDBPyConnection:
         normalize_names: Optional[bool] = None,
         filename: Optional[bool] = None,
         null_padding: Optional[bool] = None,
-        names: Optional[List[str]] = None
+        names: Optional[List[str]] = None,
+        auto_type_candidates: Optional[List[str]] = None
     ) -> DuckDBPyRelation: ...
     def from_csv_auto(
         self,
@@ -261,7 +262,8 @@ class DuckDBPyConnection:
         normalize_names: Optional[bool] = None,
         filename: Optional[bool] = None,
         null_padding: Optional[bool] = None,
-        names: Optional[List[str]] = None
+        names: Optional[List[str]] = None,
+        auto_type_candidates: Optional[List[str]] = None
     ) -> DuckDBPyRelation: ...
     def from_df(self, df: pandas.DataFrame = ...) -> DuckDBPyRelation: ...
     @overload
@@ -608,6 +610,7 @@ def read_csv(
     all_varchar: Optional[bool] = None,
     normalize_names: Optional[bool] = None,
     filename: Optional[bool] = None,
+    auto_type_candidates: Optional[List[str]] = None,
     connection: DuckDBPyConnection = ...
 ) -> DuckDBPyRelation: ...
 def from_csv_auto(
@@ -630,6 +633,7 @@ def from_csv_auto(
     normalize_names: Optional[bool] = None,
     filename: Optional[bool] = None,
     null_padding: Optional[bool] = None,
+    auto_type_candidates: Optional[List[str]] = None,
     connection: DuckDBPyConnection = ...
 ) -> DuckDBPyRelation: ...
 

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -202,7 +202,8 @@ static void InitializeConnectionMethods(py::module_ &m) {
 	    py::arg("encoding") = py::none(), py::arg("parallel") = py::none(), py::arg("date_format") = py::none(),
 	    py::arg("timestamp_format") = py::none(), py::arg("sample_size") = py::none(),
 	    py::arg("all_varchar") = py::none(), py::arg("normalize_names") = py::none(), py::arg("filename") = py::none(),
-	    py::arg("null_padding") = py::none(), py::arg("names") = py::none());
+	    py::arg("null_padding") = py::none(), py::arg("names") = py::none(),
+	    py::arg("auto_type_candidates") = py::none());
 
 	m.def("append", &PyConnectionWrapper::Append, "Append the passed DataFrame to the named table",
 	      py::arg("table_name"), py::arg("df"), py::kw_only(), py::arg("by_name") = false,

--- a/tools/pythonpkg/src/include/duckdb_python/connection_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/connection_wrapper.hpp
@@ -138,7 +138,8 @@ public:
 	        const py::object &date_format = py::none(), const py::object &timestamp_format = py::none(),
 	        const py::object &sample_size = py::none(), const py::object &all_varchar = py::none(),
 	        const py::object &normalize_names = py::none(), const py::object &filename = py::none(),
-	        const py::object &null_padding = py::none(), const py::object &names = py::none());
+	        const py::object &null_padding = py::none(), const py::object &names = py::none(),
+	        const py::object &auto_type_candidates = py::none());
 
 	static py::list FetchAll(shared_ptr<DuckDBPyConnection> conn = nullptr);
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -78,7 +78,7 @@ public:
 	        const py::object &timestamp_format = py::none(), const py::object &sample_size = py::none(),
 	        const py::object &all_varchar = py::none(), const py::object &normalize_names = py::none(),
 	        const py::object &filename = py::none(), const py::object &null_padding = py::none(),
-	        const py::object &names = py::none());
+	        const py::object &names = py::none(), const py::object &auto_type_candidates = py::none());
 
 	unique_ptr<DuckDBPyRelation> ReadJSON(const string &filename, const Optional<py::object> &columns = py::none(),
 	                                      const Optional<py::object> &sample_size = py::none(),

--- a/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
+++ b/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
@@ -245,18 +245,17 @@ unique_ptr<DuckDBPyRelation> PyConnectionWrapper::ReadJSON(const string &filenam
 	return conn->ReadJSON(filename, columns, sample_size, maximum_depth, records, format);
 }
 
-unique_ptr<DuckDBPyRelation>
-PyConnectionWrapper::ReadCSV(const py::object &name, shared_ptr<DuckDBPyConnection> conn, const py::object &header,
-                             const py::object &compression, const py::object &sep, const py::object &delimiter,
-                             const py::object &dtype, const py::object &na_values, const py::object &skiprows,
-                             const py::object &quotechar, const py::object &escapechar, const py::object &encoding,
-                             const py::object &parallel, const py::object &date_format,
-                             const py::object &timestamp_format, const py::object &sample_size,
-                             const py::object &all_varchar, const py::object &normalize_names,
-                             const py::object &filename, const py::object &null_padding, const py::object &names) {
+unique_ptr<DuckDBPyRelation> PyConnectionWrapper::ReadCSV(
+    const py::object &name, shared_ptr<DuckDBPyConnection> conn, const py::object &header,
+    const py::object &compression, const py::object &sep, const py::object &delimiter, const py::object &dtype,
+    const py::object &na_values, const py::object &skiprows, const py::object &quotechar, const py::object &escapechar,
+    const py::object &encoding, const py::object &parallel, const py::object &date_format,
+    const py::object &timestamp_format, const py::object &sample_size, const py::object &all_varchar,
+    const py::object &normalize_names, const py::object &filename, const py::object &null_padding,
+    const py::object &names, const py::object &auto_type_candidates) {
 	return conn->ReadCSV(name, header, compression, sep, delimiter, dtype, na_values, skiprows, quotechar, escapechar,
 	                     encoding, parallel, date_format, timestamp_format, sample_size, all_varchar, normalize_names,
-	                     filename, null_padding, names);
+	                     filename, null_padding, names, auto_type_candidates);
 }
 
 py::list PyConnectionWrapper::FetchMany(idx_t size, shared_ptr<DuckDBPyConnection> conn) {

--- a/tools/pythonpkg/tests/fast/api/test_read_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_read_csv.py
@@ -540,3 +540,12 @@ class TestReadCSV(object):
         with pytest.raises(duckdb.IOException, match='No files found that match the pattern "not_valid_path"'):
             rel = con.read_csv(files)
             res = rel.fetchall()
+
+    def test_read_csv_auto_type_candidates(self):
+        con = duckdb.connect()
+        file = StringIO('a,b,c\n1,1.1,bla')
+        rel = con.read_csv(file, header=True, auto_type_candidates=['VARCHAR'])
+        res = rel.fetchall()
+        assert res == [('1', '1.1', 'bla')]
+        assert rel.columns == ['a', 'b', 'c']
+        assert rel.types == ['VARCHAR', 'VARCHAR', 'VARCHAR']

--- a/tools/pythonpkg/tests/fast/arrow/test_8522.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_8522.py
@@ -20,6 +20,7 @@ class Test8522(object):
             arrays=[pa.array([dt.datetime(2022, 1, 1)])],
             schema=pa.schema([pa.field("time", pa.timestamp("ms", tz="UTC"))]),
         )
+        duckdb_cursor.sql("SET TIMEZONE='UTC'")
 
         expected = duckdb_cursor.sql("FROM t_us").filter("time>='2022-01-01'").fetchall()
         assert len(expected) == 1


### PR DESCRIPTION
1. Add `auto_type_candidates` to the python API
2. Fix a minor bug in test for #8522 (set timezone to UTC to stop it from failing on machines with local time < UTC)
3. Add more types to chose from for `auto_type_candidates`, overall I don't see why not add all of them, as only a subset is used by default anyway