### PR TITLE
Fuzzer #1374: ARG_XXX By Decimal

### DIFF
--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -324,16 +324,22 @@ AggregateFunction GetArgMinMaxFunctionInternal(const LogicalType &by_type, const
 template <class OP, class ARG_TYPE>
 AggregateFunction GetArgMinMaxFunctionBy(const LogicalType &by_type, const LogicalType &type) {
 	switch (by_type.InternalType()) {
+	case PhysicalType::INT8:
+		return GetArgMinMaxFunctionInternal<OP, ARG_TYPE, int8_t>(by_type, type);
+	case PhysicalType::INT16:
+		return GetArgMinMaxFunctionInternal<OP, ARG_TYPE, int16_t>(by_type, type);
 	case PhysicalType::INT32:
 		return GetArgMinMaxFunctionInternal<OP, ARG_TYPE, int32_t>(by_type, type);
 	case PhysicalType::INT64:
 		return GetArgMinMaxFunctionInternal<OP, ARG_TYPE, int64_t>(by_type, type);
+	case PhysicalType::FLOAT:
+		return GetArgMinMaxFunctionInternal<OP, ARG_TYPE, float>(by_type, type);
 	case PhysicalType::DOUBLE:
 		return GetArgMinMaxFunctionInternal<OP, ARG_TYPE, double>(by_type, type);
 	case PhysicalType::VARCHAR:
 		return GetArgMinMaxFunctionInternal<OP, ARG_TYPE, string_t>(by_type, type);
 	default:
-		throw InternalException("Unimplemented arg_min/arg_max aggregate");
+		throw InternalException("Unimplemented arg_min/arg_max by aggregate");
 	}
 }
 

--- a/test/fuzzer/duckfuzz/arg_minmax_by_decimal.test
+++ b/test/fuzzer/duckfuzz/arg_minmax_by_decimal.test
@@ -1,0 +1,13 @@
+# name: test/fuzzer/duckfuzz/arg_minmax_by_decimal.test
+# description: Coverage for narrow DECIMAL ordering argument
+# group: [duckfuzz]
+
+statement ok
+create table all_types as 
+	select * exclude(small_enum, medium_enum, large_enum) 
+	from test_all_types() 
+	limit 0;
+
+statement ok
+SELECT min_by(DISTINCT c23, c22) 
+FROM all_types AS t43(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42)


### PR DESCRIPTION
Add implementations for narrow DECIMAL ordering arguments.