### PR TITLE
Removes static member string

### DIFF
--- a/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
+++ b/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
@@ -3,8 +3,6 @@
 
 namespace duckdb {
 
-const string CSVStateMachineCache::STATE_KEY = "CSV_STATE_MACHINE_CACHE";
-
 void InitializeTransitionArray(StateMachine &transition_array, const CSVState cur_state, const CSVState state) {
 	for (uint32_t i = 0; i < StateMachine::NUM_TRANSITIONS; i++) {
 		transition_array[i][static_cast<uint8_t>(cur_state)] = state;
@@ -195,7 +193,7 @@ const StateMachine &CSVStateMachineCache::Get(const CSVStateMachineOptions &stat
 CSVStateMachineCache &CSVStateMachineCache::Get(ClientContext &context) {
 
 	auto &cache = ObjectCache::GetObjectCache(context);
-	return *cache.GetOrCreate<CSVStateMachineCache>(CSVStateMachineCache::STATE_KEY);
+	return *cache.GetOrCreate<CSVStateMachineCache>(CSVStateMachineCache::ObjectType());
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.hpp
@@ -63,7 +63,6 @@ public:
 	//! It first caches it, then returns it.
 	const StateMachine &Get(const CSVStateMachineOptions &state_machine_options);
 
-	static const string STATE_KEY;
 	static string ObjectType() {
 		return "CSV_STATE_MACHINE_CACHE";
 	}


### PR DESCRIPTION
Hi,
pretty similar to https://github.com/duckdb/duckdb/pull/9310

In the 0.10.0 release, another static string slipped in. When I link dynamically against a lib which uses duckdb, AddressSanitizer complains a bit on shutdown.

I would appreciate, if we can remove the static string.
This PR proposes a solution on how to do it.

Thank you.