### PR TITLE
[JDBC] Improve type-safe handling of timestamp types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,10 +17,10 @@ x-show-spaces = false
 [*.{java}]
 end_of_line = lf
 insert_final_newline = true
-indent_style = tab
+indent_style = space
 tab_width = 4
 indent_size = tab
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 charset = utf-8
 max_line_length = 120
 x-soft-wrap-text = true

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBAppender.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBAppender.java
@@ -52,6 +52,15 @@ public class DuckDBAppender implements AutoCloseable {
     }
 
     // New naming schema for object params to keep compatibility with calling "append(null)"
+
+    public void appendDuckDBTimestamp(DuckDBTimestamp value) throws SQLException {
+        if (value == null) {
+            DuckDBNative.duckdb_jdbc_appender_append_null(appender_ref);
+        } else {
+            DuckDBNative.duckdb_jdbc_appender_append_timestamp(appender_ref, value.getMicrosEpoch());
+        }
+    }
+
     public void appendLocalDateTime(LocalDateTime value) throws SQLException {
         if (value == null) {
             DuckDBNative.duckdb_jdbc_appender_append_null(appender_ref);

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -377,6 +377,13 @@ public class DuckDBResultSet implements ResultSet {
         return current_chunk[columnIndex - 1].getTimestamp(chunk_idx - 1);
     }
 
+    private DuckDBTimestamp getDuckDBTimestamp(int columnIndex) throws SQLException {
+        if (check_and_null(columnIndex)) {
+            return null;
+        }
+        return current_chunk[columnIndex - 1].getDuckDBTimestamp(chunk_idx - 1);
+    }
+
     private LocalDateTime getLocalDateTime(int columnIndex) throws SQLException {
         if (check_and_null(columnIndex)) {
             return null;
@@ -1240,6 +1247,17 @@ public class DuckDBResultSet implements ResultSet {
                 return type.cast(getTimestamp(columnIndex));
             } else {
                 throw new SQLException("Can't convert value to Timestamp " + type.toString());
+            }
+        } else if (type == DuckDBTimestamp.class) {
+            switch (sqlType) {
+            case TIMESTAMP:
+            case TIMESTAMP_MS:
+            case TIMESTAMP_NS:
+            case TIMESTAMP_S:
+            case TIMESTAMP_WITH_TIME_ZONE:
+                return type.cast(getDuckDBTimestamp(columnIndex));
+            default:
+                throw new SQLException("Can't convert value to DuckDBTimestamp " + type.toString());
             }
         } else if (type == LocalDateTime.class) {
             if (isTimestamp(sqlType)) {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -1260,9 +1260,14 @@ public class DuckDBResultSet implements ResultSet {
                 throw new SQLException("Can't convert value to DuckDBTimestamp " + type.toString());
             }
         } else if (type == LocalDateTime.class) {
-            if (isTimestamp(sqlType)) {
+            switch (sqlType) {
+            case TIMESTAMP:
+            case TIMESTAMP_MS:
+            case TIMESTAMP_NS:
+            case TIMESTAMP_S:
+            case TIMESTAMP_WITH_TIME_ZONE:
                 return type.cast(getLocalDateTime(columnIndex));
-            } else {
+            default:
                 throw new SQLException("Can't convert value to LocalDateTime " + type.toString());
             }
         } else if (type == BigInteger.class) {

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBTimestamp.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBTimestamp.java
@@ -99,6 +99,10 @@ public class DuckDBTimestamp {
         return DuckDBTimestamp.RefLocalDateTime.until(localDateTime, ChronoUnit.MICROS);
     }
 
+    public Instant toInstant() {
+        return Instant.ofEpochSecond(micros2seconds(this.timeMicros), nanosPartMicros(this.timeMicros));
+    }
+
     public Timestamp toSqlTimestamp() {
         return Timestamp.valueOf(this.toLocalDateTime());
     }

--- a/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
+++ b/tools/jdbc/src/main/java/org/duckdb/DuckDBVector.java
@@ -12,11 +12,13 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Struct;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.TextStyle;
@@ -566,6 +568,18 @@ class DuckDBVector {
         }
         if (isType(DuckDBColumnType.TIMESTAMP) || isType(DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)) {
             return DuckDBTimestamp.toLocalDateTime(getbuf(idx, 8).getLong());
+        }
+        if (isType(DuckDBColumnType.TIMESTAMP_MS)) {
+            long epochMillis = getbuf(idx, 8).getLong();
+            return Instant.EPOCH.plusMillis(epochMillis).atZone(ZoneOffset.UTC).toLocalDateTime();
+        }
+        if (isType(DuckDBColumnType.TIMESTAMP_NS)) {
+            long epochNanos = getbuf(idx, 8).getLong();
+            return Instant.EPOCH.plusNanos(epochNanos).atZone(ZoneOffset.UTC).toLocalDateTime();
+        }
+        if (isType(DuckDBColumnType.TIMESTAMP_S)) {
+            long epochSeconds = getbuf(idx, 8).getLong();
+            return Instant.ofEpochSecond(epochSeconds).atZone(ZoneOffset.UTC).toLocalDateTime();
         }
         Object o = getObject(idx);
         return LocalDateTime.parse(o.toString());

--- a/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2222,15 +2222,14 @@ public class TestDuckDBJDBC {
             LocalDateTime b = (LocalDateTime) rs.getObject(2, LocalDateTime.class);
             assertEquals(b, expected.truncatedTo(ChronoUnit.MICROS));
             // c_ms, d_ns, and e_s are timestamps with different precisions
-            // TODO(felipecrv): allow extracting LocalDateTime from different timestamp resolutions
-            // LocalDateTime c_ms = (LocalDateTime) rs.getObject(3, LocalDateTime.class);
-            // assertEquals(c_ms, expected.truncatedTo(ChronoUnit.MILLIS));
-            // if (!skip_ns_timestamp) {
-            //     LocalDateTime d_ns = (LocalDateTime) rs.getObject(4, LocalDateTime.class);
-            //     assertEquals(d_ns, expected);
-            // }
-            // LocalDateTime e_s = (LocalDateTime) rs.getObject(5, LocalDateTime.class);
-            // assertEquals(e_s, expected.truncatedTo(ChronoUnit.SECONDS));
+            LocalDateTime c_ms = (LocalDateTime) rs.getObject(3, LocalDateTime.class);
+            assertEquals(c_ms, expected.truncatedTo(ChronoUnit.MILLIS));
+            if (!skip_ns_timestamp) {
+                LocalDateTime d_ns = (LocalDateTime) rs.getObject(4, LocalDateTime.class);
+                assertEquals(d_ns, expected);
+            }
+            LocalDateTime e_s = (LocalDateTime) rs.getObject(5, LocalDateTime.class);
+            assertEquals(e_s, expected.truncatedTo(ChronoUnit.SECONDS));
         }
         {
             DuckDBTimestamp a = (DuckDBTimestamp) rs.getObject(1, DuckDBTimestamp.class);

--- a/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2226,7 +2226,8 @@ public class TestDuckDBJDBC {
             assertEquals(c_ms, expected.truncatedTo(ChronoUnit.MILLIS));
             if (!skip_ns_timestamp) {
                 LocalDateTime d_ns = (LocalDateTime) rs.getObject(4, LocalDateTime.class);
-                assertEquals(d_ns, expected);
+                // All timestamps inserted via the JDBC driver are truncated to microseconds
+                assertEquals(d_ns, expected.truncatedTo(ChronoUnit.MICROS));
             }
             LocalDateTime e_s = (LocalDateTime) rs.getObject(5, LocalDateTime.class);
             assertEquals(e_s, expected.truncatedTo(ChronoUnit.SECONDS));

--- a/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/tools/jdbc/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2218,9 +2218,9 @@ public class TestDuckDBJDBC {
         assertTrue(rs.next());
         {
             LocalDateTime a = (LocalDateTime) rs.getObject(1, LocalDateTime.class);
-            assertEquals(a, expected);
+            assertEquals(a, expected.truncatedTo(ChronoUnit.MICROS));
             LocalDateTime b = (LocalDateTime) rs.getObject(2, LocalDateTime.class);
-            assertEquals(b, expected);
+            assertEquals(b, expected.truncatedTo(ChronoUnit.MICROS));
             // c_ms, d_ns, and e_s are timestamps with different precisions
             // TODO(felipecrv): allow extracting LocalDateTime from different timestamp resolutions
             // LocalDateTime c_ms = (LocalDateTime) rs.getObject(3, LocalDateTime.class);
@@ -2234,15 +2234,16 @@ public class TestDuckDBJDBC {
         }
         {
             DuckDBTimestamp a = (DuckDBTimestamp) rs.getObject(1, DuckDBTimestamp.class);
-            assertEquals(a.toLocalDateTime(), expected);
+            assertEquals(a.toLocalDateTime(), expected.truncatedTo(ChronoUnit.MICROS));
             DuckDBTimestamp b = (DuckDBTimestamp) rs.getObject(2, DuckDBTimestamp.class);
-            assertEquals(b.toLocalDateTime(), expected);
+            assertEquals(b.toLocalDateTime(), expected.truncatedTo(ChronoUnit.MICROS));
             // c_ms, d_ns, and e_s are timestamps with different precisions
             DuckDBTimestamp c_ms = (DuckDBTimestamp) rs.getObject(3, DuckDBTimestamp.class);
             assertEquals(c_ms.toLocalDateTime(), expected.truncatedTo(ChronoUnit.MILLIS));
             if (!skip_ns_timestamp) {
                 DuckDBTimestamp d_ns = (DuckDBTimestamp) rs.getObject(4, DuckDBTimestamp.class);
-                assertEquals(d_ns.toLocalDateTime(), expected);
+                // All timestamps inserted via the JDBC driver are truncated to microseconds
+                assertEquals(d_ns.toLocalDateTime(), expected.truncatedTo(ChronoUnit.MICROS));
             }
             DuckDBTimestamp e_s = (DuckDBTimestamp) rs.getObject(5, DuckDBTimestamp.class);
             assertEquals(e_s.toLocalDateTime(), expected.truncatedTo(ChronoUnit.SECONDS));
@@ -2257,10 +2258,10 @@ public class TestDuckDBJDBC {
                      + "id INT4, a TIMESTAMP, b TIMESTAMP, c_ms TIMESTAMP_MS, d_ns TIMESTAMP_NS, e_s TIMESTAMP_S)");
         DuckDBAppender appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, "date_and_time");
 
-        LocalDateTime ldt1 = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
+        LocalDateTime ldt1 = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS).plusNanos(1);
         LocalDateTime ldt2 = LocalDateTime.of(-23434, 3, 5, 23, 2);
         LocalDateTime ldt3 = LocalDateTime.of(1970, 1, 1, 0, 0);
-        LocalDateTime ldt4 = LocalDateTime.of(11111, 12, 31, 23, 59, 59, 999999000);
+        LocalDateTime ldt4 = LocalDateTime.of(11111, 12, 31, 23, 59, 59, 999999001);
         DuckDBTimestamp dts1 = new DuckDBTimestamp(ldt1);
         DuckDBTimestamp dts2 = new DuckDBTimestamp(ldt2);
         DuckDBTimestamp dts3 = new DuckDBTimestamp(ldt3);


### PR DESCRIPTION
Having only `java.sql.Timestamp` and `java.time.LocalDateTime` consistently supported in the appender and result-set classes forces all manipulation of typed timestamp values to go through unnecessary timezone conversions between UTC and system default — `java.sql.Timestamp` extends `java.util.Date` which implicitly assumes system timezone.

Many have suggested the use of raw `long` for dealing with timestamps in the JDBC driver, but that can be very error-prone.  Modern Java should avoid time-related classes in `java.util` and stick to using only `java.time.*`.

This PR adds support for appending/retriving `DuckDBTimestamp` and improves the existing `java.time.LocalDateTime` suppport in the `DuckDBResultSet`.

## Tests

`test_appender_date_and_time` was extended to exercise the use of all the Java types against all the internal DuckDB timestamps.

## Future Ideas

The best type for raw timestamp manipulation since Java 8 is `java.time.Instant` (JSR-310 [1]) as all conversions between instants, durations, and zoned times are checked by the type system and you never have to deal with raw integers unless you're passing them over I/O or IPC boundaries.

`java.time.Instant` and other `java.time.*` classes like `java.time.LocalDateTime` are represented using 64+32 bits -- `{seconds: int64, nanos_of_second: int32}` -- so it's not yet possible to losslessly pass them via `DuckDBNative.duckdb_jdbc_appender_append_timestamp` as that (1) requires truncating to micros and (2) has to fit in 64 bits. At the moment of the call to `DuckDBNative.duckdb_jdbc_appender_append_timestamp` the type of the vector isn't known, so even if a variation that takes nanoseconds was available, the caller would be forced to perform a multiplication with a risk of overflow and fail unnecessarily when the vector type requires truncation to some type less precise than nanoseconds.

This limitation is also why `java.data.LocalDataTime` instances pushed into the database lose their nanoseconds part even when the DuckDB table column is a `TIMESTAMP_NS`.

[1] https://jcp.org/aboutJava/communityprocess/pfd/jsr310/JSR-310-guide.html