### PR TITLE
Unittest does not satify assertion on MSVC/Debug

### DIFF
--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -32,7 +32,7 @@ static void AddCharacter(char chr, LikeString &ret, bool contains) {
 	// if we are not converting into a contains, and the string has LIKE special characters
 	// then don't return a possible LIKE match
 	// same if the character is a control character
-	if (iscntrl(chr) || (!contains && (chr == '%' || chr == '_'))) {
+	if (iscntrl(static_cast<unsigned char>(chr)) || (!contains && (chr == '%' || chr == '_'))) {
 		ret.exists = false;
 		return;
 	}


### PR DESCRIPTION
Hi,

I was running the unittests in debug mode on windows (with german codepage).

While running it, a breakpoint was triggered due to a not satified assertion.

Problem was, that `char` was negative ('Ä' on german windows codepage).

According to the cpp wiki, iscntrl is UB, when the input char is negative.

> Like all other functions from [<cctype>](https://en.cppreference.com/w/cpp/header/cctype), the behavior of std::iscntrl is undefined if the argument's value is neither representable as unsigned char nor equal to [EOF](https://en.cppreference.com/w/cpp/io/c). To use these functions safely with plain chars (or signed chars), the argument should first be converted to unsigned char:

https://en.cppreference.com/w/cpp/string/byte/iscntrl

Therefore, I applied the fix here and the unittest ran flawlessly again.

edit: I am sorry, I didn't write down which test failed. If you want, I can rerun the suit tomorrow. Might be good to know in case some Issues come in. On the other side, giving the CI, it might be only a Debug problem.