### PR TITLE
move the logic for immediate_transaction_mode to the physical operator

### DIFF
--- a/src/execution/operator/helper/physical_transaction.cpp
+++ b/src/execution/operator/helper/physical_transaction.cpp
@@ -27,14 +27,14 @@ SourceResultType PhysicalTransaction::GetData(ExecutionContext &context, DataChu
 			// prevent it from being closed after this query, hence
 			// preserving the transaction context for the next query
 			client.transaction.SetAutoCommit(false);
-            auto &config = DBConfig::GetConfig(context.client);
-            if (config.options.immediate_transaction_mode) {
-                // if immediate transaction mode is enabled then start all transactions immediately
-                auto databases = DatabaseManager::Get(client).GetDatabases(client);
-                for (auto db : databases) {
-                    context.client.transaction.ActiveTransaction().GetTransaction(db.get());
-                }
-            }
+			auto &config = DBConfig::GetConfig(context.client);
+			if (config.options.immediate_transaction_mode) {
+				// if immediate transaction mode is enabled then start all transactions immediately
+				auto databases = DatabaseManager::Get(client).GetDatabases(client);
+				for (auto db : databases) {
+					context.client.transaction.ActiveTransaction().GetTransaction(db.get());
+				}
+			}
 		} else {
 			throw TransactionException("cannot start a transaction within a transaction");
 		}

--- a/src/execution/operator/helper/physical_transaction.cpp
+++ b/src/execution/operator/helper/physical_transaction.cpp
@@ -2,6 +2,10 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/valid_checker.hpp"
 #include "duckdb/common/exception/transaction_exception.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
+#include "duckdb/transaction/transaction_manager.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/database_manager.hpp"
 
 namespace duckdb {
 
@@ -23,6 +27,14 @@ SourceResultType PhysicalTransaction::GetData(ExecutionContext &context, DataChu
 			// prevent it from being closed after this query, hence
 			// preserving the transaction context for the next query
 			client.transaction.SetAutoCommit(false);
+            auto &config = DBConfig::GetConfig(context.client);
+            if (config.options.immediate_transaction_mode) {
+                // if immediate transaction mode is enabled then start all transactions immediately
+                auto databases = DatabaseManager::Get(client).GetDatabases(client);
+                for (auto db : databases) {
+                    context.client.transaction.ActiveTransaction().GetTransaction(db.get());
+                }
+            }
 		} else {
 			throw TransactionException("cannot start a transaction within a transaction");
 		}

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -35,15 +35,6 @@ void TransactionContext::BeginTransaction() {
 	for (auto const &s : context.registered_state) {
 		s.second->TransactionBegin(*current_transaction, context);
 	}
-
-	auto &config = DBConfig::GetConfig(context);
-	if (config.options.immediate_transaction_mode) {
-		// if immediate transaction mode is enabled then start all transactions immediately
-		auto databases = DatabaseManager::Get(context).GetDatabases(context);
-		for (auto db : databases) {
-			current_transaction->GetTransaction(db.get());
-		}
-	}
 }
 
 void TransactionContext::Commit() {


### PR DESCRIPTION
=> opening transactions in all databases happens during execution of the BEGIN TRANSACTION statement
   rather than prior to the execution of that statement
=> for auto-commit queries, immediate_transaction_mode no longer has an effect
   in auto-commit queries there is only one query happening at one time, so immediate mode is kinda superfluous then

Not having to deal with immediate mode for auto-commit queries (i.e. RPCs for any query) and later opening of the transactions (when the ClientContext is properly set) does help MotherDuck.