### PR TITLE
[C API] Small fix and more tests

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2016,7 +2016,7 @@ Assigns a string element in the vector at the specified location.
 DUCKDB_API void duckdb_vector_assign_string_element(duckdb_vector vector, idx_t index, const char *str);
 
 /*!
-Assigns a string element in the vector at the specified location.
+Assigns a string element in the vector at the specified location. You may also use this function to assign BLOBs.
 
 * vector: The vector to alter
 * index: The row position in the vector to assign the string to

--- a/src/main/capi/data_chunk-c.cpp
+++ b/src/main/capi/data_chunk-c.cpp
@@ -110,7 +110,7 @@ void duckdb_vector_assign_string_element_len(duckdb_vector vector, idx_t index, 
 	}
 	auto v = reinterpret_cast<duckdb::Vector *>(vector);
 	auto data = duckdb::FlatVector::GetData<duckdb::string_t>(*v);
-	data[index] = duckdb::StringVector::AddString(*v, str, str_len);
+	data[index] = duckdb::StringVector::AddStringOrBlob(*v, str, str_len);
 }
 
 duckdb_vector duckdb_list_vector_get_child(duckdb_vector vector) {

--- a/test/api/capi/test_capi_appender.cpp
+++ b/test/api/capi/test_capi_appender.cpp
@@ -88,6 +88,80 @@ TEST_CASE("Test appending into DECIMAL in C API", "[capi]") {
 	TestAppendingSingleDecimalValue<double, &duckdb_append_double>(12345234234.31243244234324, expected, 26, 1);
 }
 
+TEST_CASE("Test NULL struct Appender", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+	duckdb_state status;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	tester.Query("CREATE TABLE test (simple_struct STRUCT(a INTEGER, b VARCHAR));");
+	duckdb_appender appender;
+
+	status = duckdb_appender_create(tester.connection, nullptr, "test", &appender);
+	REQUIRE(status == DuckDBSuccess);
+	REQUIRE(duckdb_appender_error(appender) == nullptr);
+
+	// create the column types of the data chunk
+	duckdb::vector<duckdb_logical_type> child_types = {duckdb_create_logical_type(DUCKDB_TYPE_INTEGER),
+	                                                   duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR)};
+	duckdb::vector<const char *> names = {"a", "b"};
+	auto struct_type = duckdb_create_struct_type(child_types.data(), names.data(), child_types.size());
+
+	// create the data chunk
+	duckdb_logical_type types[1] = {struct_type};
+	auto data_chunk = duckdb_create_data_chunk(types, 1);
+	REQUIRE(data_chunk);
+	REQUIRE(duckdb_data_chunk_get_column_count(data_chunk) == 1);
+
+	auto struct_vector = duckdb_data_chunk_get_vector(data_chunk, 0);
+	auto first_child_vector = duckdb_struct_vector_get_child(struct_vector, 0);
+	auto second_child_vector = duckdb_struct_vector_get_child(struct_vector, 1);
+
+	// set two values
+	auto first_child_ptr = (int64_t *)duckdb_vector_get_data(first_child_vector);
+	*first_child_ptr = 42;
+	duckdb_vector_assign_string_element(second_child_vector, 0, "hello");
+
+	// set the parent/STRUCT vector to NULL
+	duckdb_vector_ensure_validity_writable(struct_vector);
+	auto validity = duckdb_vector_get_validity(struct_vector);
+	duckdb_validity_set_row_validity(validity, 1, false);
+
+	// set the first child vector to NULL
+	duckdb_vector_ensure_validity_writable(first_child_vector);
+	auto first_validity = duckdb_vector_get_validity(first_child_vector);
+	duckdb_validity_set_row_validity(first_validity, 1, false);
+
+	// set the second child vector to NULL
+	duckdb_vector_ensure_validity_writable(second_child_vector);
+	auto second_validity = duckdb_vector_get_validity(second_child_vector);
+	duckdb_validity_set_row_validity(second_validity, 1, false);
+
+	duckdb_data_chunk_set_size(data_chunk, 2);
+	REQUIRE(duckdb_append_data_chunk(appender, data_chunk) == DuckDBSuccess);
+
+	// close flushes all remaining data
+	status = duckdb_appender_close(appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	// verify the result
+	result = tester.Query("SELECT simple_struct::VARCHAR FROM test;");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<string>(0, 0) == "{'a': 42, 'b': hello}");
+	REQUIRE(result->Fetch<string>(0, 1) == "");
+
+	// destroy the data chunk and the appender
+	duckdb_destroy_data_chunk(&data_chunk);
+	status = duckdb_appender_destroy(&appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	// destroy the logical types
+	for (auto child_type : child_types) {
+		duckdb_destroy_logical_type(&child_type);
+	}
+	duckdb_destroy_logical_type(&struct_type);
+}
+
 TEST_CASE("Test appender statements in C API", "[capi]") {
 	CAPITester tester;
 	duckdb::unique_ptr<CAPIResult> result;

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -97,56 +97,71 @@ TEST_CASE("Test DataChunk C API", "[capi]") {
 	duckdb_state status;
 
 	REQUIRE(tester.OpenDatabase(nullptr));
-
 	REQUIRE(duckdb_vector_size() == STANDARD_VECTOR_SIZE);
 
-	tester.Query("CREATE TABLE test(i BIGINT, j SMALLINT)");
+	// create column types
+	const idx_t COLUMN_COUNT = 3;
+	duckdb_type duckdbTypes[COLUMN_COUNT];
+	duckdbTypes[0] = DUCKDB_TYPE_BIGINT;
+	duckdbTypes[1] = DUCKDB_TYPE_SMALLINT;
+	duckdbTypes[2] = DUCKDB_TYPE_BLOB;
 
-	duckdb_logical_type types[2];
-	types[0] = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
-	types[1] = duckdb_create_logical_type(DUCKDB_TYPE_SMALLINT);
+	duckdb_logical_type types[COLUMN_COUNT];
+	for (idx_t i = 0; i < COLUMN_COUNT; i++) {
+		types[i] = duckdb_create_logical_type(duckdbTypes[i]);
+	}
 
-	auto data_chunk = duckdb_create_data_chunk(types, 2);
+	// create data chunk
+	auto data_chunk = duckdb_create_data_chunk(types, COLUMN_COUNT);
 	REQUIRE(data_chunk);
+	REQUIRE(duckdb_data_chunk_get_column_count(data_chunk) == COLUMN_COUNT);
 
-	REQUIRE(duckdb_data_chunk_get_column_count(data_chunk) == 2);
-
-	auto first_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(data_chunk, 0));
-	REQUIRE(duckdb_get_type_id(first_type) == DUCKDB_TYPE_BIGINT);
-	duckdb_destroy_logical_type(&first_type);
-
-	auto second_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(data_chunk, 1));
-	REQUIRE(duckdb_get_type_id(second_type) == DUCKDB_TYPE_SMALLINT);
-	duckdb_destroy_logical_type(&second_type);
+	// test duckdb_vector_get_column_type
+	for (idx_t i = 0; i < COLUMN_COUNT; i++) {
+		auto vector = duckdb_data_chunk_get_vector(data_chunk, i);
+		auto type = duckdb_vector_get_column_type(vector);
+		REQUIRE(duckdb_get_type_id(type) == duckdbTypes[i]);
+		duckdb_destroy_logical_type(&type);
+	}
 
 	REQUIRE(duckdb_data_chunk_get_vector(data_chunk, 999) == nullptr);
 	REQUIRE(duckdb_data_chunk_get_vector(nullptr, 0) == nullptr);
 	REQUIRE(duckdb_vector_get_column_type(nullptr) == nullptr);
-
 	REQUIRE(duckdb_data_chunk_get_size(data_chunk) == 0);
 	REQUIRE(duckdb_data_chunk_get_size(nullptr) == 0);
 
-	// use the appender to insert a value using the data chunk API
+	// create table
+	tester.Query("CREATE TABLE test(i BIGINT, j SMALLINT, k BLOB)");
+
+	// use the appender to insert values using the data chunk API
 	duckdb_appender appender;
 	status = duckdb_appender_create(tester.connection, nullptr, "test", &appender);
 	REQUIRE(status == DuckDBSuccess);
 
 	// get the column types from the appender
-	REQUIRE(duckdb_appender_column_count(appender) == 2);
+	REQUIRE(duckdb_appender_column_count(appender) == COLUMN_COUNT);
 
-	auto appender_first_type = duckdb_appender_column_type(appender, 0);
-	REQUIRE(duckdb_get_type_id(appender_first_type) == DUCKDB_TYPE_BIGINT);
-	duckdb_destroy_logical_type(&appender_first_type);
+	// test duckdb_appender_column_type
+	for (idx_t i = 0; i < COLUMN_COUNT; i++) {
+		auto type = duckdb_appender_column_type(appender, i);
+		REQUIRE(duckdb_get_type_id(type) == duckdbTypes[i]);
+		duckdb_destroy_logical_type(&type);
+	}
 
-	auto appender_second_type = duckdb_appender_column_type(appender, 1);
-	REQUIRE(duckdb_get_type_id(appender_second_type) == DUCKDB_TYPE_SMALLINT);
-	duckdb_destroy_logical_type(&appender_second_type);
+	// append BIGINT
+	auto bigint_vector = duckdb_data_chunk_get_vector(data_chunk, 0);
+	auto int64_ptr = (int64_t *)duckdb_vector_get_data(bigint_vector);
+	*int64_ptr = 42;
 
-	// append standard primitive values
-	auto col1_ptr = (int64_t *)duckdb_vector_get_data(duckdb_data_chunk_get_vector(data_chunk, 0));
-	*col1_ptr = 42;
-	auto col2_ptr = (int16_t *)duckdb_vector_get_data(duckdb_data_chunk_get_vector(data_chunk, 1));
-	*col2_ptr = 84;
+	// append SMALLINT
+	auto smallint_vector = duckdb_data_chunk_get_vector(data_chunk, 1);
+	auto int16_ptr = (int16_t *)duckdb_vector_get_data(smallint_vector);
+	*int16_ptr = 84;
+
+	// append BLOB
+	string s = "this is my blob";
+	auto blob_vector = duckdb_data_chunk_get_vector(data_chunk, 2);
+	duckdb_vector_assign_string_element_len(blob_vector, 0, s.c_str(), s.length());
 
 	REQUIRE(duckdb_vector_get_data(nullptr) == nullptr);
 
@@ -161,34 +176,33 @@ TEST_CASE("Test DataChunk C API", "[capi]") {
 	duckdb_data_chunk_reset(data_chunk);
 	REQUIRE(duckdb_data_chunk_get_size(data_chunk) == 0);
 
-	duckdb_vector_ensure_validity_writable(duckdb_data_chunk_get_vector(data_chunk, 0));
-	duckdb_vector_ensure_validity_writable(duckdb_data_chunk_get_vector(data_chunk, 1));
-	auto col1_validity = duckdb_vector_get_validity(duckdb_data_chunk_get_vector(data_chunk, 0));
-	REQUIRE(duckdb_validity_row_is_valid(col1_validity, 0));
-	duckdb_validity_set_row_validity(col1_validity, 0, false);
-	REQUIRE(!duckdb_validity_row_is_valid(col1_validity, 0));
+	for (idx_t i = 0; i < COLUMN_COUNT; i++) {
+		auto vector = duckdb_data_chunk_get_vector(data_chunk, i);
+		duckdb_vector_ensure_validity_writable(vector);
+		auto validity = duckdb_vector_get_validity(vector);
 
-	auto col2_validity = duckdb_vector_get_validity(duckdb_data_chunk_get_vector(data_chunk, 1));
-	REQUIRE(col2_validity);
-	REQUIRE(duckdb_validity_row_is_valid(col2_validity, 0));
-	duckdb_validity_set_row_validity(col2_validity, 0, false);
-	REQUIRE(!duckdb_validity_row_is_valid(col2_validity, 0));
+		REQUIRE(duckdb_validity_row_is_valid(validity, 0));
+		duckdb_validity_set_row_validity(validity, 0, false);
+		REQUIRE(!duckdb_validity_row_is_valid(validity, 0));
+	}
 
 	duckdb_data_chunk_set_size(data_chunk, 1);
 	REQUIRE(duckdb_data_chunk_get_size(data_chunk) == 1);
-
 	REQUIRE(duckdb_append_data_chunk(appender, data_chunk) == DuckDBSuccess);
-
 	REQUIRE(duckdb_vector_get_validity(nullptr) == nullptr);
 
 	duckdb_appender_destroy(&appender);
 
 	result = tester.Query("SELECT * FROM test");
 	REQUIRE_NO_FAIL(*result);
+
 	REQUIRE(result->Fetch<int64_t>(0, 0) == 42);
 	REQUIRE(result->Fetch<int16_t>(1, 0) == 84);
+	REQUIRE(result->Fetch<string>(2, 0) == "this is my blob");
+
 	REQUIRE(result->IsNull(0, 1));
 	REQUIRE(result->IsNull(1, 1));
+	REQUIRE(result->IsNull(2, 1));
 
 	duckdb_data_chunk_reset(data_chunk);
 	duckdb_data_chunk_reset(nullptr);
@@ -196,11 +210,11 @@ TEST_CASE("Test DataChunk C API", "[capi]") {
 
 	duckdb_destroy_data_chunk(&data_chunk);
 	duckdb_destroy_data_chunk(&data_chunk);
-
 	duckdb_destroy_data_chunk(nullptr);
 
-	duckdb_destroy_logical_type(&types[0]);
-	duckdb_destroy_logical_type(&types[1]);
+	for (idx_t i = 0; i < COLUMN_COUNT; i++) {
+		duckdb_destroy_logical_type(&types[i]);
+	}
 }
 
 TEST_CASE("Test DataChunk appending incorrect types in C API", "[capi]") {


### PR DESCRIPTION
I encountered this when writing BLOBs with the data chunk functionality of the appender (see new test). If we change `duckdb_vector_assign_string_element_len` to use `AddStringOrBlob`, we can write BLOBs. In release mode, this already works, but without the change in this PR, we trigger an assertion (mismatching vector type) in debug mode. 