### PR TITLE
local_file_system.cpp: minor fix for macOS libproc code

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -189,7 +189,7 @@ static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
 
 	string process_name, process_owner;
 // macOS >= 10.7 has PROC_PIDT_SHORTBSDINFO
-#if defined PROC_PIDT_SHORTBSDINFO
+#ifdef PROC_PIDT_SHORTBSDINFO
 	// try to find out more about the process holding the lock
 	struct proc_bsdshortinfo proc;
 	if (proc_pidinfo(pid, PROC_PIDT_SHORTBSDINFO, 0, &proc, PROC_PIDT_SHORTBSDINFO_SIZE) ==
@@ -202,17 +202,7 @@ static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
 		}
 	}
 #else
-	// Fallback code for older versions
-	// try to find out more about the process holding the lock
-	struct proc_bsdinfo proc;
-	if (proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &proc, 128) == 128) {
-		process_name = proc.pbi_comm; // only a short version however, let's take it in case proc_pidpath() below fails
-		// try to get actual name of conflicting process owner
-		auto pw = getpwuid(proc.pbi_uid);
-		if (pw) {
-			process_owner = pw->pw_name;
-		}
-	}
+	return string();
 #endif
 	// try to get a better process name (full path)
 	char full_exec_path[PROC_PIDPATHINFO_MAXSIZE];


### PR DESCRIPTION
Recent 23112e9aa344905c2d2a0d1cb696c5f73c329534 commit has broken `duckdb` build on macOS < 10.7.
Add a fallback to fix it.
As an example of a similar code see get_ppid_of.c in gettext’s libtextstyle.