### PR TITLE
Make unnamed_subquery naming predictable

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -203,10 +203,12 @@ private:
 	unordered_set<string> table_names;
 	//! The set of bound views
 	reference_set_t<ViewCatalogEntry> bound_views;
+	//! Unnamed subquery index
+	idx_t unnamed_subquery_index = 1;
 
 private:
 	//! Get the root binder (binder with no parent)
-	Binder *GetRootBinder();
+	Binder &GetRootBinder();
 	//! Determine the depth of the binder
 	idx_t GetBinderDepth() const;
 	//! Bind the expressions of generated columns to check for errors
@@ -271,6 +273,7 @@ private:
 	unique_ptr<LogicalOperator> CreatePlan(BoundSetOperationNode &node);
 	unique_ptr<LogicalOperator> CreatePlan(BoundQueryNode &node);
 
+	unique_ptr<BoundTableRef> BindJoin(Binder &parent, TableRef &ref);
 	unique_ptr<BoundTableRef> Bind(BaseTableRef &ref);
 	unique_ptr<BoundTableRef> Bind(JoinRef &ref);
 	unique_ptr<BoundTableRef> Bind(SubqueryRef &ref, optional_ptr<CommonTableExpressionInfo> cte = nullptr);

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -21,20 +21,20 @@
 
 namespace duckdb {
 
-Binder *Binder::GetRootBinder() {
-	Binder *root = this;
-	while (root->parent) {
-		root = root->parent.get();
+Binder &Binder::GetRootBinder() {
+	reference<Binder> root = *this;
+	while (root.get().parent) {
+		root = *root.get().parent;
 	}
-	return root;
+	return root.get();
 }
 
 idx_t Binder::GetBinderDepth() const {
-	const Binder *root = this;
+	const_reference<Binder> root = *this;
 	idx_t depth = 1;
-	while (root->parent) {
+	while (root.get().parent) {
 		depth++;
-		root = root->parent.get();
+		root = *root.get().parent;
 	}
 	return depth;
 }
@@ -299,8 +299,8 @@ void Binder::AddBoundView(ViewCatalogEntry &view) {
 }
 
 idx_t Binder::GenerateTableIndex() {
-	auto root_binder = GetRootBinder();
-	return root_binder->bound_tables++;
+	auto &root_binder = GetRootBinder();
+	return root_binder.bound_tables++;
 }
 
 void Binder::PushExpressionBinder(ExpressionBinder &binder) {
@@ -326,13 +326,13 @@ bool Binder::HasActiveBinder() {
 }
 
 vector<reference<ExpressionBinder>> &Binder::GetActiveBinders() {
-	auto root_binder = GetRootBinder();
-	return root_binder->active_binders;
+	auto &root_binder = GetRootBinder();
+	return root_binder.active_binders;
 }
 
 void Binder::AddUsingBindingSet(unique_ptr<UsingColumnSet> set) {
-	auto root_binder = GetRootBinder();
-	root_binder->bind_context.AddUsingBindingSet(std::move(set));
+	auto &root_binder = GetRootBinder();
+	root_binder.bind_context.AddUsingBindingSet(std::move(set));
 }
 
 void Binder::MoveCorrelatedExpressions(Binder &other) {
@@ -401,14 +401,13 @@ bool Binder::HasMatchingBinding(const string &catalog_name, const string &schema
 }
 
 void Binder::SetBindingMode(BindingMode mode) {
-	auto root_binder = GetRootBinder();
-	// FIXME: this used to also set the 'mode' for the current binder, was that necessary?
-	root_binder->mode = mode;
+	auto &root_binder = GetRootBinder();
+	root_binder.mode = mode;
 }
 
 BindingMode Binder::GetBindingMode() {
-	auto root_binder = GetRootBinder();
-	return root_binder->mode;
+	auto &root_binder = GetRootBinder();
+	return root_binder.mode;
 }
 
 void Binder::SetCanContainNulls(bool can_contain_nulls_p) {
@@ -428,13 +427,13 @@ void Binder::SetAlwaysRequireRebind() {
 }
 
 void Binder::AddTableName(string table_name) {
-	auto root_binder = GetRootBinder();
-	root_binder->table_names.insert(std::move(table_name));
+	auto &root_binder = GetRootBinder();
+	root_binder.table_names.insert(std::move(table_name));
 }
 
 const unordered_set<string> &Binder::GetTableNames() {
-	auto root_binder = GetRootBinder();
-	return root_binder->table_names;
+	auto &root_binder = GetRootBinder();
+	return root_binder.table_names;
 }
 
 // FIXME: this is extremely naive

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -15,7 +15,12 @@ unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref, optional_ptr<CommonTabl
 	idx_t bind_index = subquery->GetRootIndex();
 	string subquery_alias;
 	if (ref.alias.empty()) {
-		subquery_alias = "unnamed_subquery" + to_string(bind_index);
+		auto index = unnamed_subquery_index++;
+		subquery_alias = "unnamed_subquery";
+		;
+		if (index > 1) {
+			subquery_alias += to_string(index);
+		}
 	} else {
 		subquery_alias = ref.alias;
 	}

--- a/test/sql/pivot/unpivot_unnamed_subquery.test
+++ b/test/sql/pivot/unpivot_unnamed_subquery.test
@@ -1,0 +1,13 @@
+# name: test/sql/pivot/unpivot_funky_names.test
+# description: Test top-level pivot syntax
+# group: [pivot]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+unpivot (select cast(columns(*) as varchar) from (select 42 as col1, 'woot' as col2))
+    on columns(*);
+----
+CAST(unnamed_subquery.col1 AS VARCHAR)	42
+CAST(unnamed_subquery.col2 AS VARCHAR)	woot

--- a/test/sql/pivot/unpivot_unnamed_subquery.test
+++ b/test/sql/pivot/unpivot_unnamed_subquery.test
@@ -1,4 +1,4 @@
-# name: test/sql/pivot/unpivot_funky_names.test
+# name: test/sql/pivot/unpivot_unnamed_subquery.test
 # description: Test top-level pivot syntax
 # group: [pivot]
 

--- a/test/sql/subquery/table/test_unnamed_subquery.test
+++ b/test/sql/subquery/table/test_unnamed_subquery.test
@@ -19,3 +19,27 @@ query II
 SELECT * FROM (VALUES (42, 43))
 ----
 42	43
+
+# longer chains
+query IIII
+SELECT * FROM (SELECT 42 a), (SELECT 43 b), (SELECT 44 c), (SELECT 45 d)
+----
+42	43	44	45
+
+# nested
+query IIII
+SELECT * FROM (FROM (SELECT 42 a), (SELECT 43 b)) JOIN (SELECT 44 c) ON (true) JOIN (SELECT 45 d) ON (true)
+----
+42	43	44	45
+
+# names are predictable
+query II
+SELECT * FROM (SELECT unnamed_subquery.a FROM (SELECT 42 a)), (SELECT unnamed_subquery.b FROM (SELECT 43 b))
+----
+42	43
+
+# names are predictable
+query II
+SELECT unnamed_subquery.a, unnamed_subquery2.b FROM (SELECT 42 a), (SELECT 43 b)
+----
+42	43


### PR DESCRIPTION
This PR reworks how we name subqueries without aliases. Previously we used the table index we got from the binder, e.g.:

```sql
D select unnamed_subquery1.* FROM (SELECT 42 a, 43 b);
┌───────┬───────┐
│   a   │   b   │
│ int32 │ int32 │
├───────┼───────┤
│    42 │    43 │
└───────┴───────┘
```

The problem is that this numbering is unstable and unpredictable. From the perspective of the user the name seems completely arbitrary, e.g.:

```sql
-- now it is 7
D select unnamed_subquery7.* FROM (FROM (SELECT 42 a, 43 b) t);
┌───────┬───────┐
│   a   │   b   │
│ int32 │ int32 │
├───────┼───────┤
│    42 │    43 │
└───────┴───────┘
-- now it is 8
D select unnamed_subquery8.* FROM (SELECT 84) t, (SELECT 42 a, 43 b);
┌───────┬───────┐
│   a   │   b   │
│ int32 │ int32 │
├───────┼───────┤
│    42 │    43 │
└───────┴───────┘
```

This causes problems also because queries are no longer portable, e.g. this query works:

```sql
select unnamed_subquery1.* FROM (SELECT 42 a, 43 b);
┌───────┬───────┐
│   a   │   b   │
│ int32 │ int32 │
├───────┼───────┤
│    42 │    43 │
└───────┴───────┘
```

But this fails:

```sql
D select (select unnamed_subquery1.* FROM (SELECT 42 a, 43 b));
-- Error: Binder Error: Referenced table "unnamed_subquery1" not found!
-- Candidate tables: "unnamed_subquery8"
```

This PR reworks the naming of unnamed subqueries so that they are predictable - they are named starting at `unnamed_subquery` (without a number) - and then numbers are added as more unnamed subqueries are found **within the same level of the `FROM` clause**. For example:

```sql
-- standard case, single unnamed subquery, the table is called "unnamed_subquery"
D select unnamed_subquery.* FROM (SELECT 42 a, 43 b);
┌───────┬───────┐
│   a   │   b   │
│ int32 │ int32 │
├───────┼───────┤
│    42 │    43 │
└───────┴───────┘
-- two unnamed subqueries, the second one is called "unnamed_subquery2"
D select unnamed_subquery.a, unnamed_subquery2.b FROM (SELECT 42 a), (SELECT 43 b);
┌───────┬───────┐
│   a   │   b   │
│ int32 │ int32 │
├───────┼───────┤
│    42 │    43 │
└───────┴───────┘
-- unnamed subqueries/subqueries WITHIN do not affect naming at the current level
D select unnamed_subquery.a, unnamed_subquery2.b FROM (FROM (SELECT 42 a) t), (SELECT 43 b);
┌───────┬───────┐
│   a   │   b   │
│ int32 │ int32 │
├───────┼───────┤
│    42 │    43 │
└───────┴───────┘
-- similarly names are stable and queries are portable
D select (select unnamed_subquery.a from (select 42 a, 43 b)) AS res;
┌───────┐
│  res  │
│ int32 │
├───────┤
│    42 │
└───────┘
```

This also fixes an issue with using unnamed subqueries in the UNPIVOT, found [here](https://github.com/duckdb/duckdb/issues/10757#issuecomment-1953157597)
