### PR TITLE
Trivial fixes

### DIFF
--- a/src/execution/operator/aggregate/aggregate_object.cpp
+++ b/src/execution/operator/aggregate/aggregate_object.cpp
@@ -29,7 +29,7 @@ AggregateObject::AggregateObject(BoundWindowExpression &window)
 
 vector<AggregateObject> AggregateObject::CreateAggregateObjects(const vector<BoundAggregateExpression *> &bindings) {
 	vector<AggregateObject> aggregates;
-	aggregates.reserve(aggregates.size());
+	aggregates.reserve(bindings.size());
 	for (auto &binding : bindings) {
 		aggregates.emplace_back(binding);
 	}

--- a/test/sql/join/external/simple_external_join.test_coverage
+++ b/test/sql/join/external/simple_external_join.test_coverage
@@ -61,7 +61,7 @@ pragma debug_force_external=false
 
 # higher memory limit for this because the strings are so large
 statement ok
-pragma memory_limit='150mb'
+pragma memory_limit='200mb'
 
 # add some strings that are longer than Storage::BLOCK_SIZE
 statement ok


### PR DESCRIPTION
Fix CI failures given by too strict memory limit and nonsensical reserve (pointed out by coverity scan)