### PR TITLE
Benchmark runner - allow files (e.g. CSV/Parquet) to be cached using the cache command

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -84,6 +84,48 @@ jobs:
       run: |
         cp -r benchmark duckdb/
 
+    - name: Regression Test Micro
+      if: always()
+      shell: bash
+      run: |
+        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/micro.csv --verbose --threads=2
+
+    - name: Regression Test Ingestion Perf
+      if: always()
+      shell: bash
+      run: |
+        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/ingestion.csv --verbose --threads=2
+
+    - name: Regression Test TPCH
+      if: always()
+      shell: bash
+      run: |
+        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/tpch.csv --verbose --threads=2
+
+    - name: Regression Test TPCH-PARQUET
+      if: always()
+      shell: bash
+      run: |
+        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/tpch_parquet.csv --verbose --threads=2
+
+    - name: Regression Test TPCDS
+      if: always()
+      shell: bash
+      run: |
+        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/tpcds.csv --verbose --threads=2
+
+    - name: Regression Test H2OAI
+      if: always()
+      shell: bash
+      run: |
+        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/h2oai.csv --verbose --threads=2
+
+    - name: Regression Test IMDB
+      if: always()
+      shell: bash
+      run: |
+        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/imdb.csv --verbose --threads=2
+
     - name: Regression Test CSV
       if: always()
       shell: bash

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -27,11 +27,6 @@ on:
       - '.github/workflows/**'
       - '!.github/workflows/Regression.yml'
 
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
-  cancel-in-progress: true
-
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref, '_feature') && 'feature' || 'main') }}

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -84,48 +84,6 @@ jobs:
       run: |
         cp -r benchmark duckdb/
 
-    - name: Regression Test Micro
-      if: always()
-      shell: bash
-      run: |
-        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/micro.csv --verbose --threads=2
-
-    - name: Regression Test Ingestion Perf
-      if: always()
-      shell: bash
-      run: |
-        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/ingestion.csv --verbose --threads=2
-
-    - name: Regression Test TPCH
-      if: always()
-      shell: bash
-      run: |
-        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/tpch.csv --verbose --threads=2
-
-    - name: Regression Test TPCH-PARQUET
-      if: always()
-      shell: bash
-      run: |
-        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/tpch_parquet.csv --verbose --threads=2
-
-    - name: Regression Test TPCDS
-      if: always()
-      shell: bash
-      run: |
-        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/tpcds.csv --verbose --threads=2
-
-    - name: Regression Test H2OAI
-      if: always()
-      shell: bash
-      run: |
-        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/h2oai.csv --verbose --threads=2
-
-    - name: Regression Test IMDB
-      if: always()
-      shell: bash
-      run: |
-        python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/imdb.csv --verbose --threads=2
-
     - name: Regression Test CSV
       if: always()
       shell: bash

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -27,6 +27,11 @@ on:
       - '.github/workflows/**'
       - '!.github/workflows/Regression.yml'
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref, '_feature') && 'feature' || 'main') }}

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -58,7 +58,8 @@ void BenchmarkRunner::InitializeBenchmarkDirectory() {
 atomic<bool> is_active;
 atomic<bool> timeout;
 
-void sleep_thread(Benchmark *benchmark, BenchmarkRunner *runner, BenchmarkState *state, bool hotrun, int timeout_duration) {
+void sleep_thread(Benchmark *benchmark, BenchmarkRunner *runner, BenchmarkState *state, bool hotrun,
+                  int timeout_duration) {
 	if (timeout_duration < 0) {
 		return;
 	}

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -58,28 +58,44 @@ void BenchmarkRunner::InitializeBenchmarkDirectory() {
 atomic<bool> is_active;
 atomic<bool> timeout;
 
-void sleep_thread(Benchmark *benchmark, BenchmarkState *state, int timeout_duration) {
-	// timeout is given in seconds
-	// we wait 10ms per iteration, so timeout * 100 gives us the amount of
-	// iterations
+void sleep_thread(Benchmark *benchmark, BenchmarkRunner *runner, BenchmarkState *state, bool hotrun, int timeout_duration) {
 	if (timeout_duration < 0) {
 		return;
 	}
+	// timeout is given in seconds
+	// we wait 10ms per iteration, so timeout * 100 gives us the amount of
+	// iterations
 	for (size_t i = 0; i < (size_t)(timeout_duration * 100) && is_active; i++) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(10));
 	}
 	if (is_active) {
 		timeout = true;
 		benchmark->Interrupt(state);
+
+		// wait again after interrupting
+		for (size_t i = 0; i < (size_t)(timeout_duration * 100) && is_active; i++) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		}
+		if (is_active) {
+			// still active - we might be stuck in an infinite loop
+			// our interrupt is not working
+			if (!hotrun) {
+				runner->Log(StringUtil::Format("%s\t%d\t", benchmark->name, 0));
+			}
+			runner->LogResult("KILLED");
+			exit(1);
+		}
 	}
 }
 
 void BenchmarkRunner::Log(string message) {
 	fprintf(stderr, "%s", message.c_str());
+	fflush(stderr);
 }
 
 void BenchmarkRunner::LogLine(string message) {
 	fprintf(stderr, "%s\n", message.c_str());
+	fflush(stderr);
 }
 
 void BenchmarkRunner::LogResult(string message) {
@@ -113,7 +129,7 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 		}
 		is_active = true;
 		timeout = false;
-		std::thread interrupt_thread(sleep_thread, benchmark, state.get(), benchmark->Timeout());
+		std::thread interrupt_thread(sleep_thread, benchmark, this, state.get(), hotrun, benchmark->Timeout());
 
 		profiler.Start();
 		benchmark->Run(state.get());

--- a/benchmark/include/interpreted_benchmark.hpp
+++ b/benchmark/include/interpreted_benchmark.hpp
@@ -69,6 +69,7 @@ private:
 
 	string benchmark_path;
 	string cache_db = "";
+	string cache_file = "";
 	// check the existence of a cached db, but do not connect
 	// can be used to test accessing data from a different db in a non-persistent connection
 	bool cache_no_connect = false;

--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -187,6 +187,11 @@ void InterpretedBenchmark::LoadBenchmark() {
 				throw std::runtime_error(
 				    reader.FormatException("cache requires a db file, and optionally a no_connect"));
 			}
+			if (StringUtil::EndsWith(cache_db, ".csv") || StringUtil::EndsWith(cache_db, ".parquet") ||
+			    StringUtil::EndsWith(cache_db, ".csv.gz")) {
+				cache_file = cache_db;
+				cache_db = string();
+			}
 		} else if (splits[0] == "storage") {
 			if (splits.size() != 2) {
 				throw std::runtime_error(reader.FormatException("storage requires a single parameter"));
@@ -353,7 +358,13 @@ unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfigurati
 		load_query = queries["load"];
 	}
 
-	if (cache_db.empty() && cache_db.compare(DEFAULT_DB_PATH) != 0) {
+	if (!cache_file.empty()) {
+		auto fs = FileSystem::CreateLocal();
+		if (!fs->FileExists(fs->JoinPath(BenchmarkRunner::DUCKDB_BENCHMARK_DIRECTORY, cache_file))) {
+			// no cache or db_path specified: just run the initialization code
+			result = state->con.Query(load_query);
+		}
+	} else if (cache_db.empty() && cache_db.compare(DEFAULT_DB_PATH) != 0) {
 		// no cache or db_path specified: just run the initialization code
 		result = state->con.Query(load_query);
 	} else {

--- a/benchmark/micro/csv/projection_pushdown.benchmark
+++ b/benchmark/micro/csv/projection_pushdown.benchmark
@@ -7,10 +7,16 @@ group csv
 
 require tpch
 
-cache tpch_sf1.duckdb
+cache lineitem_sf1.csv
 
-load benchmark/tpch/sf1/load.sql
-COPY lineitem TO '${BENCHMARK_DIR}/lineitem.csv' (FORMAT CSV, DELIMITER '|', HEADER);
+load
+CALL dbgen(sf=1);
+COPY lineitem TO '${BENCHMARK_DIR}/lineitem_sf1.csv' (FORMAT CSV, DELIMITER '|', HEADER);
 
 run
-SELECT l_returnflag, MIN(l_orderkey) FROM '${BENCHMARK_DIR}/lineitem.csv' GROUP BY l_returnflag;
+SELECT l_returnflag, MIN(l_orderkey) FROM '${BENCHMARK_DIR}/lineitem_sf1.csv' GROUP BY l_returnflag ORDER BY l_returnflag;
+
+result II
+A	3
+N	1
+R	3

--- a/benchmark/micro/csv/read.benchmark
+++ b/benchmark/micro/csv/read.benchmark
@@ -7,10 +7,11 @@ group csv
 
 require tpch
 
-cache tpch_sf1.duckdb
+cache lineitem_sf1.csv
 
-load benchmark/tpch/sf1/load.sql
-COPY lineitem TO '${BENCHMARK_DIR}/lineitem.csv' (FORMAT CSV, DELIMITER '|', HEADER);
+load
+CALL dbgen(sf=1);
+COPY lineitem TO '${BENCHMARK_DIR}/lineitem_sf1.csv' (FORMAT CSV, DELIMITER '|', HEADER);
 
 run
-SELECT * FROM '${BENCHMARK_DIR}/lineitem.csv'
+SELECT * FROM '${BENCHMARK_DIR}/lineitem_sf1.csv'

--- a/benchmark/micro/csv/sniffer.benchmark
+++ b/benchmark/micro/csv/sniffer.benchmark
@@ -7,10 +7,11 @@ group csv
 
 require tpch
 
-cache tpch_sf1.duckdb
+cache lineitem_sf1.csv
 
-load benchmark/tpch/sf1/load.sql
-COPY lineitem TO '${BENCHMARK_DIR}/lineitem.csv' (FORMAT CSV, DELIMITER '|', HEADER);
+load
+CALL dbgen(sf=1);
+COPY lineitem TO '${BENCHMARK_DIR}/lineitem_sf1.csv' (FORMAT CSV, DELIMITER '|', HEADER);
 
 run
-DESCRIBE SELECT * FROM '${BENCHMARK_DIR}/lineitem.csv'
+DESCRIBE SELECT * FROM '${BENCHMARK_DIR}/lineitem_sf1.csv'

--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -9,11 +9,13 @@ import functools
 import shutil
 print = functools.partial(print, flush=True)
 
+non_numeric_results = ['INCORRECT', 'KILLED', 'TIMEOUT']
 
 # Geometric mean of an array of numbers
 def geomean(xs):
-    if 'INCORRECT' in xs:
-        return 'INCORRECT'
+    for non_numeric_result in non_numeric_results:
+        if non_numeric_result in xs:
+            return non_numeric_result
     return math.exp(math.fsum(math.log(float(x)) for x in xs) / len(xs))
 
 
@@ -193,7 +195,7 @@ time_b = geomean(complete_timings[new_runner])
 
 
 print("")
-if time_a == 'INCORRECT' or time_b == 'INCORRECT':
+if time_a in non_numeric_results or time_b in non_numeric_results:
     print(f"Old: {time_a}")
     print(f"New: {time_b}")
 elif time_a > time_b * 1.01:

--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -7,9 +7,11 @@ import statistics
 import math
 import functools
 import shutil
+
 print = functools.partial(print, flush=True)
 
 non_numeric_results = ['INCORRECT', 'KILLED', 'TIMEOUT']
+
 
 # Geometric mean of an array of numbers
 def geomean(xs):

--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -6,6 +6,7 @@ import csv
 import statistics
 import math
 import functools
+import shutil
 print = functools.partial(print, flush=True)
 
 
@@ -205,4 +206,6 @@ else:
     print(f"Old timing geometric mean: {time_a}")
     print(f"New timing geometric mean: {time_b}")
 
+# nuke cached benchmark data between runs
+shutil.rmtree('duckdb_benchmark_data')
 exit(exit_code)

--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -10,6 +10,7 @@ import shutil
 
 print = functools.partial(print, flush=True)
 
+
 # Geometric mean of an array of numbers
 def geomean(xs):
     if len(xs) == 0:

--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -5,6 +5,8 @@ from io import StringIO
 import csv
 import statistics
 import math
+import functools
+print = functools.partial(print, flush=True)
 
 
 # Geometric mean of an array of numbers

--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -9,6 +9,8 @@ import math
 
 # Geometric mean of an array of numbers
 def geomean(xs):
+    if 'INCORRECT' in xs:
+        return 'INCORRECT'
     return math.exp(math.fsum(math.log(float(x)) for x in xs) / len(xs))
 
 
@@ -186,8 +188,12 @@ for res in other_results:
 time_a = geomean(complete_timings[old_runner])
 time_b = geomean(complete_timings[new_runner])
 
+
 print("")
-if time_a > time_b * 1.01:
+if time_a == 'INCORRECT' or time_b == 'INCORRECT':
+    print(f"Old: {time_a}")
+    print(f"New: {time_b}")
+elif time_a > time_b * 1.01:
     print(f"Old timing geometric mean: {time_a}")
     print(f"New timing geometric mean: {time_b}, roughly {int((time_a - time_b) * 100.0 / time_a)}% faster")
 elif time_b > time_a * 1.01:

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -425,7 +425,10 @@ void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, 
 			throw IOException("Could not write file \"%s\": %s", {{"errno", std::to_string(errno)}}, handle.path,
 			                  strerror(errno));
 		}
-		D_ASSERT(bytes_written >= 0 && bytes_written);
+		if (bytes_written == 0) {
+			throw IOException("Could not write to file \"%s\" - attempted to write 0 bytes: %s", {{"errno", std::to_string(errno)}}, handle.path,
+							  strerror(errno));
+		}
 		write_buffer += bytes_written;
 		nr_bytes -= bytes_written;
 	}

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -426,8 +426,8 @@ void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, 
 			                  strerror(errno));
 		}
 		if (bytes_written == 0) {
-			throw IOException("Could not write to file \"%s\" - attempted to write 0 bytes: %s", {{"errno", std::to_string(errno)}}, handle.path,
-							  strerror(errno));
+			throw IOException("Could not write to file \"%s\" - attempted to write 0 bytes: %s",
+			                  {{"errno", std::to_string(errno)}}, handle.path, strerror(errno));
 		}
 		write_buffer += bytes_written;
 		nr_bytes -= bytes_written;


### PR DESCRIPTION
And also fix the `load` step of various CSV benchmarks

Also improve the timeout in both the benchmark runner itself - after a timeout we wait for another 30 seconds after an interrupt, after which we kill the benchmark runner entirely and report `KILLED`.

In addition for the `regression_test_runner.py` script used in the CI we add another layer of timeouts where we kill the benchmark if it has not yet completed within 10 minutes. 