### PR TITLE
Disable AWS/Azure on Windows for now

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -15,6 +15,8 @@ if (NOT WIN32)
 endif()
 
 ################## AWS
+# FIXME - enable on windows again once building issue is resolved
+if (NOT WIN32)
 if (NOT MINGW)
     duckdb_extension_load(aws
             LOAD_TESTS
@@ -30,6 +32,7 @@ if (NOT MINGW)
             GIT_URL https://github.com/duckdb/duckdb_azure
             GIT_TAG 3ad0348334d2a263e5f19ef08fd02311bdae82f3
             )
+endif()
 endif()
 
 ################# ICEBERG


### PR DESCRIPTION
Fixes the failing Windows Extensions CI after the Windows MSVC version was upgraded