### PR TITLE
Issue #10809: RANGE Hint Corrections

### DIFF
--- a/src/execution/window_executor.cpp
+++ b/src/execution/window_executor.cpp
@@ -207,19 +207,24 @@ static idx_t FindTypedRangeBound(const WindowInputColumn &over, const idx_t orde
 	WindowColumnIterator<T> begin(over, order_begin);
 	WindowColumnIterator<T> end(over, order_end);
 
-	if (order_begin < prev.start && prev.start < order_end) {
-		const auto first = over.GetCell<T>(prev.start);
-		if (!comp(val, first)) {
-			//	prev.first <= val, so we can start further forward
-			begin += (prev.start - order_begin);
+	//	Try to reuse the previous bounds to restrict the search.
+	//	This is only valid if the previous bounds were non-empty
+	//	Only inject the comparisons if the previous bounds are a strict subset.
+	if (prev.start < prev.end) {
+		if (order_begin < prev.start && prev.start < order_end) {
+			const auto first = over.GetCell<T>(prev.start);
+			if (!comp(val, first)) {
+				//	prev.first <= val, so we can start further forward
+				begin += (prev.start - order_begin);
+			}
 		}
-	}
-	if (order_begin <= prev.end && prev.end < order_end) {
-		const auto second = over.GetCell<T>(prev.end);
-		if (!comp(second, val)) {
-			//	val <= prev.second, so we can end further back
-			// (prev.second is the largest peer)
-			end -= (order_end - prev.end - 1);
+		if (order_begin < prev.end && prev.end < order_end) {
+			const auto second = over.GetCell<T>(prev.end - 1);
+			if (!comp(second, val)) {
+				//	val <= prev.second, so we can end further back
+				// (prev.second is the largest peer)
+				end -= (order_end - prev.end - 1);
+			}
 		}
 	}
 

--- a/test/sql/window/test_range_optimisation.test
+++ b/test/sql/window/test_range_optimisation.test
@@ -1,0 +1,50 @@
+# name: test/sql/window/test_range_optimisation.test
+# description: Range search optimisation stress tests
+# group: [window]
+
+statement ok
+CREATE TABLE rides (
+	id INTEGER,
+	requested_date DATE,
+	city VARCHAR,
+	wait_time INTEGER
+);
+
+statement ok
+INSERT INTO rides VALUES
+	(0, '2023-01-05', 'San Francisco', 2925),
+	(1, '2023-01-03', 'San Francisco', 755),
+	(2, '2023-01-03', 'San Francisco', 2880),
+	(3, '2023-01-05', 'San Francisco', 1502),
+	(4, '2023-01-03', 'San Francisco', 2900),
+	(5, '2023-01-01', 'San Francisco', 1210),
+	(6, '2023-01-04', 'San Francisco', 200),
+	(7, '2023-01-02', 'San Francisco', 980),
+	(8, '2023-01-02', 'San Francisco', 430),
+	(9, '2023-01-05', 'San Francisco', 2999),
+	(10, '2023-01-01', 'San Francisco', 856),
+	(11, '2023-01-02', 'San Francisco', 490),
+	(12, '2023-01-02', 'San Francisco', 720),
+
+query IIIII
+SELECT "id", "requested_date", "city", "wait_time", min("wait_time") OVER win_3d 
+FROM rides 
+WINDOW win_3d AS (
+	PARTITION BY "city" 
+	ORDER BY requested_date ASC 
+	RANGE BETWEEN INTERVAL 3 DAYS PRECEDING AND INTERVAL 1 DAYS PRECEDING) 
+ORDER BY "requested_date", "city"
+----
+5	2023-01-01	San Francisco	1210	NULL
+10	2023-01-01	San Francisco	856	NULL
+7	2023-01-02	San Francisco	980	856
+8	2023-01-02	San Francisco	430	856
+11	2023-01-02	San Francisco	490	856
+12	2023-01-02	San Francisco	720	856
+1	2023-01-03	San Francisco	755	430
+2	2023-01-03	San Francisco	2880	430
+4	2023-01-03	San Francisco	2900	430
+6	2023-01-04	San Francisco	200	430
+0	2023-01-05	San Francisco	2925	200
+3	2023-01-05	San Francisco	1502	200
+9	2023-01-05	San Francisco	2999	200


### PR DESCRIPTION
Correct the rules for the RANGE search optimisation to handle empty prior ranges
and fix a fencepost error on range ends.

fixes: #10809
fixes: duckdblabs/duckdb-internal#1345