### PR TITLE
[CI] Add patch argument to patch the extension's sources before building

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: boolean
         default: true
+      # Patch file to patch the extension's sources before building
+      patch:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   generate_matrix:
@@ -60,6 +65,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'true'
+
+      - if: ${{ inputs.patch != '' }}
+        run: |
+          patch -p1 < ${{ inputs.patch }}
+        shell: bash
 
       - name: Checkout DuckDB to version
         run: |
@@ -137,6 +147,11 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - if: ${{ inputs.patch != '' }}
+        run: |
+          patch -p1 < ${{ inputs.patch }}
+        shell: bash
+
       - name: Checkout DuckDB to version
         run: |
           cd duckdb
@@ -203,6 +218,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'true'
+
+      - if: ${{ inputs.patch != '' }}
+        run: |
+          patch -p1 < ${{ inputs.patch }}
+        shell: bash
 
       - name: Install Ninja
         run: |
@@ -274,6 +294,11 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - if: ${{ inputs.patch != '' }}
+        run: |
+          patch -p1 < ${{ inputs.patch }}
+        shell: bash
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -335,6 +360,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'true'
+
+      - if: ${{ inputs.patch != '' }}
+        run: |
+          patch -p1 < ${{ inputs.patch }}
+        shell: bash
 
       - name: Checkout DuckDB to version
         run: |


### PR DESCRIPTION
I tried building an extension for both v0.9.2 and v0.10.0. It seems that this requires a different `Makefile` for each version. My solution was to provide a patch file to restore the v0.9.2 state before building it.

Example: https://github.com/hannes/duckdb-rfuns/blob/main/.github/0.9.2.patch, used in https://github.com/hannes/duckdb-rfuns/blob/87184f8b2ed13f99c3a102dd27f587adc4367cec/.github/workflows/MainDistributionPipeline-0.9.2.yml#L29