### PR TITLE
Add components of the version to duckdb.hpp

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -298,7 +298,13 @@ def generate_duckdb_hpp(header_file):
         if extended_amalgamation:
             hfile.write("#define DUCKDB_AMALGAMATION_EXTENDED 1\n")
         hfile.write("#define DUCKDB_SOURCE_ID \"%s\"\n" % git_commit_hash())
-        hfile.write("#define DUCKDB_VERSION \"%s\"\n" % git_dev_version())
+
+        dev_version = git_dev_version()
+        dev_v_parts = dev_version.lstrip('v').split('.')
+        hfile.write("#define DUCKDB_VERSION \"%s\"\n" % dev_version)
+        hfile.write("#define DUCKDB_MAJOR_VERSION %d\n" % int(dev_v_parts[0]))
+        hfile.write("#define DUCKDB_MINOR_VERSION %d\n" % int(dev_v_parts[1]))
+        hfile.write("#define DUCKDB_PATCH_VERSION \"%s\"\n" % dev_v_parts[2])
 
         for fpath in main_header_files:
             hfile.write(write_file(fpath))

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -300,11 +300,11 @@ def generate_duckdb_hpp(header_file):
         hfile.write("#define DUCKDB_SOURCE_ID \"%s\"\n" % git_commit_hash())
 
         dev_version = git_dev_version()
-        dev_v_parts = [int(c) for c in dev_version.lstrip('v').split('.')]
+        dev_v_parts = dev_version.lstrip('v').split('.')
         hfile.write("#define DUCKDB_VERSION \"%s\"\n" % dev_version)
-        hfile.write("#define DUCKDB_MAJOR_VERSION %d\n" % dev_v_parts[0])
-        hfile.write("#define DUCKDB_MINOR_VERSION %d\n" % dev_v_parts[1])
-        hfile.write("#define DUCKDB_PATCH_VERSION %d\n" % dev_v_parts[2])
+        hfile.write("#define DUCKDB_MAJOR_VERSION %d\n" % int(dev_v_parts[0]))
+        hfile.write("#define DUCKDB_MINOR_VERSION %d\n" % int(dev_v_parts[1]))
+        hfile.write("#define DUCKDB_PATCH_VERSION \"%s\"\n" % dev_v_parts[2])
 
         for fpath in main_header_files:
             hfile.write(write_file(fpath))

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -298,7 +298,13 @@ def generate_duckdb_hpp(header_file):
         if extended_amalgamation:
             hfile.write("#define DUCKDB_AMALGAMATION_EXTENDED 1\n")
         hfile.write("#define DUCKDB_SOURCE_ID \"%s\"\n" % git_commit_hash())
-        hfile.write("#define DUCKDB_VERSION \"%s\"\n" % git_dev_version())
+
+        dev_version = git_dev_version()
+        dev_v_parts = [int(c) for c in dev_version.lstrip('v').split('.')]
+        hfile.write("#define DUCKDB_VERSION \"%s\"\n" % dev_version)
+        hfile.write("#define DUCKDB_MAJOR_VERSION %d\n" % dev_v_parts[0])
+        hfile.write("#define DUCKDB_MINOR_VERSION %d\n" % dev_v_parts[1])
+        hfile.write("#define DUCKDB_PATCH_VERSION %d\n" % dev_v_parts[2])
 
         for fpath in main_header_files:
             hfile.write(write_file(fpath))

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -227,6 +227,7 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
     os.chdir(os.path.join(scripts_dir, '..'))
     githash = git_commit_hash()
     dev_version = git_dev_version()
+    dev_v_parts = dev_version.lstrip('v').split('.')
     os.chdir(curdir)
     # open the file and read the current contents
     fpath = os.path.join(target_dir, 'src', 'function', 'table', 'version', 'pragma_version.cpp')
@@ -235,20 +236,36 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
     # now add the DUCKDB_SOURCE_ID define, if it is not there already
     found_hash = False
     found_dev = False
+    found_major = False
+    found_minor = False
+    found_patch = False
     lines = text.split('\n')
     for i in range(len(lines)):
         if '#define DUCKDB_SOURCE_ID ' in lines[i]:
             lines[i] = '#define DUCKDB_SOURCE_ID "{}"'.format(githash)
             found_hash = True
-            break
         if '#define DUCKDB_VERSION ' in lines[i]:
             lines[i] = '#define DUCKDB_VERSION "{}"'.format(dev_version)
             found_dev = True
-            break
+        if '#define DUCKDB_MAJOR_VERSION ' in lines[i]:
+            lines[i] = '#define DUCKDB_MAJOR_VERSION {}'.format(int(dev_v_parts[0]))
+            found_major = True
+        if '#define DUCKDB_MINOR_VERSION ' in lines[i]:
+            lines[i] = '#define DUCKDB_MINOR_VERSION {}'.format(int(dev_v_parts[1]))
+            found_minor = True
+        if '#define DUCKDB_PATCH_VERSION ' in lines[i]:
+            lines[i] = '#define DUCKDB_PATCH_VERSION "{}"'.format(dev_v_parts[2])
+            found_patch = True
     if not found_hash:
         lines = ['#ifndef DUCKDB_SOURCE_ID', '#define DUCKDB_SOURCE_ID "{}"'.format(githash), '#endif'] + lines
     if not found_dev:
         lines = ['#ifndef DUCKDB_VERSION', '#define DUCKDB_VERSION "{}"'.format(dev_version), '#endif'] + lines
+    if not found_major:
+        lines = ['#ifndef DUCKDB_MAJOR_VERSION', '#define DUCKDB_MAJOR_VERSION {}'.format(int(dev_v_parts[0])), '#endif'] + lines
+    if not found_minor:
+        lines = ['#ifndef DUCKDB_MINOR_VERSION', '#define DUCKDB_MINOR_VERSION {}'.format(int(dev_v_parts[1])), '#endif'] + lines
+    if not found_patch:
+        lines = ['#ifndef DUCKDB_PATCH_VERSION', '#define DUCKDB_PATCH_VERSION "{}"'.format(dev_v_parts[2]), '#endif'] + lines
     text = '\n'.join(lines)
     with open_utf8(fpath, 'w+') as f:
         f.write(text)

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -261,11 +261,23 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
     if not found_dev:
         lines = ['#ifndef DUCKDB_VERSION', '#define DUCKDB_VERSION "{}"'.format(dev_version), '#endif'] + lines
     if not found_major:
-        lines = ['#ifndef DUCKDB_MAJOR_VERSION', '#define DUCKDB_MAJOR_VERSION {}'.format(int(dev_v_parts[0])), '#endif'] + lines
+        lines = [
+            '#ifndef DUCKDB_MAJOR_VERSION',
+            '#define DUCKDB_MAJOR_VERSION {}'.format(int(dev_v_parts[0])),
+            '#endif'
+        ] + lines
     if not found_minor:
-        lines = ['#ifndef DUCKDB_MINOR_VERSION', '#define DUCKDB_MINOR_VERSION {}'.format(int(dev_v_parts[1])), '#endif'] + lines
+        lines = [
+            '#ifndef DUCKDB_MINOR_VERSION',
+            '#define DUCKDB_MINOR_VERSION {}'.format(int(dev_v_parts[1])),
+            '#endif'
+        ] + lines
     if not found_patch:
-        lines = ['#ifndef DUCKDB_PATCH_VERSION', '#define DUCKDB_PATCH_VERSION "{}"'.format(dev_v_parts[2]), '#endif'] + lines
+        lines = [
+            '#ifndef DUCKDB_PATCH_VERSION',
+            '#define DUCKDB_PATCH_VERSION "{}"'.format(dev_v_parts[2]),
+            '#endif'
+        ] + lines
     text = '\n'.join(lines)
     with open_utf8(fpath, 'w+') as f:
         f.write(text)

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -227,7 +227,7 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
     os.chdir(os.path.join(scripts_dir, '..'))
     githash = git_commit_hash()
     dev_version = git_dev_version()
-    dev_v_parts = [int(c) for c in dev_version.lstrip('v').split('.')]
+    dev_v_parts = dev_version.lstrip('v').split('.')
     os.chdir(curdir)
     # open the file and read the current contents
     fpath = os.path.join(target_dir, 'src', 'function', 'table', 'version', 'pragma_version.cpp')
@@ -261,11 +261,11 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
     if not found_dev:
         lines = ['#ifndef DUCKDB_VERSION', '#define DUCKDB_VERSION "{}"'.format(dev_version), '#endif'] + lines
     if not found_major:
-        lines = ['#ifndef DUCKDB_MAJOR_VERSION', '#define DUCKDB_MAJOR_VERSION {}'.format(dev_v_parts[0]), '#endif'] + lines
+        lines = ['#ifndef DUCKDB_MAJOR_VERSION', '#define DUCKDB_MAJOR_VERSION {}'.format(int(dev_v_parts[0])), '#endif'] + lines
     if not found_minor:
-        lines = ['#ifndef DUCKDB_MINOR_VERSION', '#define DUCKDB_MINOR_VERSION {}'.format(dev_v_parts[1]), '#endif'] + lines
+        lines = ['#ifndef DUCKDB_MINOR_VERSION', '#define DUCKDB_MINOR_VERSION {}'.format(int(dev_v_parts[1])), '#endif'] + lines
     if not found_patch:
-        lines = ['#ifndef DUCKDB_PATCH_VERSION', '#define DUCKDB_PATCH_VERSION {}'.format(dev_v_parts[2]), '#endif'] + lines
+        lines = ['#ifndef DUCKDB_PATCH_VERSION', '#define DUCKDB_PATCH_VERSION "{}"'.format(dev_v_parts[2]), '#endif'] + lines
     text = '\n'.join(lines)
     with open_utf8(fpath, 'w+') as f:
         f.write(text)

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -264,19 +264,19 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
         lines = [
             '#ifndef DUCKDB_MAJOR_VERSION',
             '#define DUCKDB_MAJOR_VERSION {}'.format(int(dev_v_parts[0])),
-            '#endif'
+            '#endif',
         ] + lines
     if not found_minor:
         lines = [
             '#ifndef DUCKDB_MINOR_VERSION',
             '#define DUCKDB_MINOR_VERSION {}'.format(int(dev_v_parts[1])),
-            '#endif'
+            '#endif',
         ] + lines
     if not found_patch:
         lines = [
             '#ifndef DUCKDB_PATCH_VERSION',
             '#define DUCKDB_PATCH_VERSION "{}"'.format(dev_v_parts[2]),
-            '#endif'
+            '#endif',
         ] + lines
     text = '\n'.join(lines)
     with open_utf8(fpath, 'w+') as f:

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -227,6 +227,7 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
     os.chdir(os.path.join(scripts_dir, '..'))
     githash = git_commit_hash()
     dev_version = git_dev_version()
+    dev_v_parts = [int(c) for c in dev_version.lstrip('v').split('.')]
     os.chdir(curdir)
     # open the file and read the current contents
     fpath = os.path.join(target_dir, 'src', 'function', 'table', 'version', 'pragma_version.cpp')
@@ -235,20 +236,36 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
     # now add the DUCKDB_SOURCE_ID define, if it is not there already
     found_hash = False
     found_dev = False
+    found_major = False
+    found_minor = False
+    found_patch = False
     lines = text.split('\n')
     for i in range(len(lines)):
         if '#define DUCKDB_SOURCE_ID ' in lines[i]:
             lines[i] = '#define DUCKDB_SOURCE_ID "{}"'.format(githash)
             found_hash = True
-            break
         if '#define DUCKDB_VERSION ' in lines[i]:
             lines[i] = '#define DUCKDB_VERSION "{}"'.format(dev_version)
             found_dev = True
-            break
+        if '#define DUCKDB_MAJOR_VERSION ' in lines[i]:
+            lines[i] = '#define DUCKDB_MAJOR_VERSION {}'.format(dev_v_parts[0])
+            found_major = True
+        if '#define DUCKDB_MINOR_VERSION ' in lines[i]:
+            lines[i] = '#define DUCKDB_MINOR_VERSION {}'.format(dev_v_parts[1])
+            found_minor = True
+        if '#define DUCKDB_PATCH_VERSION ' in lines[i]:
+            lines[i] = '#define DUCKDB_PATCH_VERSION {}'.format(dev_v_parts[2])
+            found_patch = True
     if not found_hash:
         lines = ['#ifndef DUCKDB_SOURCE_ID', '#define DUCKDB_SOURCE_ID "{}"'.format(githash), '#endif'] + lines
     if not found_dev:
         lines = ['#ifndef DUCKDB_VERSION', '#define DUCKDB_VERSION "{}"'.format(dev_version), '#endif'] + lines
+    if not found_major:
+        lines = ['#ifndef DUCKDB_MAJOR_VERSION', '#define DUCKDB_MAJOR_VERSION {}'.format(dev_v_parts[0]), '#endif'] + lines
+    if not found_minor:
+        lines = ['#ifndef DUCKDB_MINOR_VERSION', '#define DUCKDB_MINOR_VERSION {}'.format(dev_v_parts[1]), '#endif'] + lines
+    if not found_patch:
+        lines = ['#ifndef DUCKDB_PATCH_VERSION', '#define DUCKDB_PATCH_VERSION {}'.format(dev_v_parts[2]), '#endif'] + lines
     text = '\n'.join(lines)
     with open_utf8(fpath, 'w+') as f:
         f.write(text)


### PR DESCRIPTION
This simple PR adds the three components of the version to the `duckdb.hpp`. 

It would be useful to detect breaking changes between releases, for example to define #ifdef preprocesor directives to write conditional includes or typedefs. 

An example is the renaming of the `PreservedError` class from `v0.9.x` to `ErrorData` in the `v0.10.x` releases.
