### PR TITLE
[Dev] Bump memory limit on batch_memory_usage.test_slow

### DIFF
--- a/test/sql/copy/parquet/batched_write/batch_memory_usage.test_slow
+++ b/test/sql/copy/parquet/batched_write/batch_memory_usage.test_slow
@@ -12,7 +12,7 @@ COPY (SELECT uuid()::VARCHAR as varchar, uuid() AS uuid FROM range(10000000) t(i
 
 # copy from one parquet file to another in a memory constrained environment
 statement ok
-SET memory_limit='500MB'
+SET memory_limit='650MB'
 
 statement ok
 COPY '__TEST_DIR__/random_uuids.parquet' TO '__TEST_DIR__/random_uuids_copy.parquet';


### PR DESCRIPTION
Unnecessary low limit let do some random failures in nightly CI