### PR TITLE
[Python] Fix issue caused by deadlock between `thread.join()` and acquiring the GIL

### DIFF
--- a/src/include/duckdb/main/relation/table_function_relation.hpp
+++ b/src/include/duckdb/main/relation/table_function_relation.hpp
@@ -20,6 +20,8 @@ public:
 
 	TableFunctionRelation(const std::shared_ptr<ClientContext> &context, string name, vector<Value> parameters,
 	                      shared_ptr<Relation> input_relation_p = nullptr, bool auto_init = true);
+	~TableFunctionRelation() override {
+	}
 
 	string name;
 	vector<Value> parameters;

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -52,6 +52,7 @@ public:
 public:
 	explicit DuckDBPyConnection() {
 	}
+	~DuckDBPyConnection();
 
 public:
 	static void Initialize(py::handle &m);

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -31,6 +31,11 @@ class PythonDependencies : public ExternalDependency {
 public:
 	explicit PythonDependencies() : ExternalDependency(ExternalDependenciesType::PYTHON_DEPENDENCY) {
 	}
+	~PythonDependencies() override {
+		py::gil_scoped_acquire gil;
+		py_object_list.clear();
+	}
+
 	explicit PythonDependencies(py::function map_function)
 	    : ExternalDependency(ExternalDependenciesType::PYTHON_DEPENDENCY), map_function(std::move(map_function)) {};
 	explicit PythonDependencies(unique_ptr<RegisteredObject> py_object)
@@ -51,6 +56,7 @@ struct DuckDBPyRelation {
 public:
 	explicit DuckDBPyRelation(shared_ptr<Relation> rel);
 	explicit DuckDBPyRelation(unique_ptr<DuckDBPyResult> result);
+	~DuckDBPyRelation();
 
 public:
 	static void Initialize(py::handle &m);

--- a/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
@@ -19,6 +19,7 @@ namespace duckdb {
 struct DuckDBPyResult {
 public:
 	explicit DuckDBPyResult(unique_ptr<QueryResult> result);
+	~DuckDBPyResult();
 
 public:
 	Optional<py::tuple> Fetchone();

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -61,6 +61,14 @@ DBInstanceCache instance_cache;
 shared_ptr<PythonImportCache> DuckDBPyConnection::import_cache = nullptr;
 PythonEnvironmentType DuckDBPyConnection::environment = PythonEnvironmentType::NORMAL;
 
+DuckDBPyConnection::~DuckDBPyConnection() {
+	py::gil_scoped_release gil;
+	// Release any structures that do not need to hold the GIL here
+	database.reset();
+	connection.reset();
+	temporary_views.clear();
+}
+
 void DuckDBPyConnection::DetectEnvironment() {
 	// If __main__ does not have a __file__ attribute, we are in interactive mode
 	auto main_module = py::module_::import("__main__");

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -43,6 +43,14 @@ bool DuckDBPyRelation::CanBeRegisteredBy(Connection &con) {
 	return context == con.context;
 }
 
+DuckDBPyRelation::~DuckDBPyRelation() {
+	// FIXME: It makes sense to release the GIL here, but it causes a crash
+	// because pybind11's gil_scoped_acquire and gil_scoped_release can not be nested
+	// The Relation will need to call the destructor of the ExternalDependency, which might need to hold the GIL
+	// py::gil_scoped_release gil;
+	rel.reset();
+}
+
 DuckDBPyRelation::DuckDBPyRelation(unique_ptr<DuckDBPyResult> result_p) : rel(nullptr), result(std::move(result_p)) {
 	if (!result) {
 		throw InternalException("DuckDBPyRelation created without a result");

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -27,6 +27,12 @@ DuckDBPyResult::DuckDBPyResult(unique_ptr<QueryResult> result_p) : result(std::m
 	}
 }
 
+DuckDBPyResult::~DuckDBPyResult() {
+	py::gil_scoped_release gil;
+	result.reset();
+	current_chunk.reset();
+}
+
 const vector<string> &DuckDBPyResult::GetNames() {
 	if (!result) {
 		throw InternalException("Calling GetNames without a result object");


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/1331

While destroying the DuckDBPyRelation, we were holding the GIL
As part of that destructor, we destroy the DatabaseInstance, which in turn destroys the TaskScheduler.

The TaskScheduler attempts to join all the active threads.
The worker thread in this case was trying to release an ArrowArrayStream created by PyArrow, this attempted to grab the GIL.

This resulted in a deadlock, because the thread would not join until the thread had finished, and the thread couldn't finish until it grabbed the GIL.