### PR TITLE
Check if directory exists before removing files in regression test runner

### DIFF
--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -216,6 +216,4 @@ else:
     print(f"Old timing geometric mean: {time_a}")
     print(f"New timing geometric mean: {time_b}")
 
-# nuke cached benchmark data between runs
-shutil.rmtree('duckdb_benchmark_data')
 exit(exit_code)

--- a/scripts/regression_test_runner.py
+++ b/scripts/regression_test_runner.py
@@ -216,4 +216,7 @@ else:
     print(f"Old timing geometric mean: {time_a}")
     print(f"New timing geometric mean: {time_b}")
 
+# nuke cached benchmark data between runs
+if os.path.isdir("duckdb_benchmark_data"):
+    shutil.rmtree('duckdb_benchmark_data')
 exit(exit_code)


### PR DESCRIPTION
The [Weekly regression](https://github.com/duckdblabs/duckdb-internal/blob/main/.github/workflows/WeeklyRegression.yml) runs the regression test runner not in a duckdb directory. The addition of `shuttle.rmtree('ducdkb_benchmark_data')` caused the regression test to fail because of this.

Now we just check and make sure it is a directory before removing the data. That way the weekly regression runner won't fail. 

 