### PR TITLE
Fix #10745 - correctly deal with empty float columns in floating point compression routines

### DIFF
--- a/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
@@ -164,6 +164,10 @@ idx_t AlpFinalAnalyze(AnalyzeState &state) {
 	// Flush last unfinished segment
 	analyze_state.FlushSegment();
 
+	if (compressed_values == 0) {
+		return DConstants::INVALID_INDEX;
+	}
+
 	// We estimate the size by taking into account the portion of the values we took
 	const auto factor_of_sampling = analyze_state.total_values_count / compressed_values;
 	const auto final_analyze_size = analyze_state.TotalUsedBytes() * factor_of_sampling;

--- a/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
@@ -108,6 +108,9 @@ bool AlpRDAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
 template <class T>
 idx_t AlpRDFinalAnalyze(AnalyzeState &state) {
 	auto &analyze_state = (AlpRDAnalyzeState<T> &)state;
+	if (analyze_state.total_values_count == 0) {
+		return DConstants::INVALID_INDEX;
+	}
 	double factor_of_sampling = 1 / ((double)analyze_state.rowgroup_sample.size() / analyze_state.total_values_count);
 
 	// Finding which is the best dictionary for the sample

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -147,6 +147,9 @@ unique_ptr<AnalyzeState> ColumnDataCheckpointer::DetectBestCompressionMethod(idx
 		if (!compression_functions[i]) {
 			continue;
 		}
+		if (!analyze_states[i]) {
+			continue;
+		}
 		//! Check if the method type is the forced method (if forced is used)
 		bool forced_method_found = compression_functions[i]->type == forced_method;
 		auto score = compression_functions[i]->final_analyze(*analyze_states[i]);

--- a/test/sql/storage/types/list/empty_float_arrays.test
+++ b/test/sql/storage/types/list/empty_float_arrays.test
@@ -1,0 +1,33 @@
+# name: test/sql/storage/types/list/empty_float_arrays.test
+# description: Test storage of empty float arrays
+# group: [list]
+
+load __TEST_DIR__/array_empty_storage.db
+
+foreach compression <compression> uncompressed
+
+statement ok
+CREATE TABLE test_table (
+    id INTEGER,
+    emb FLOAT[],
+    emb_arr FLOAT[3]
+);
+
+statement ok
+INSERT INTO test_table (id) VALUES (42);
+
+statement ok
+CHECKPOINT;
+
+query III
+FROM test_table
+----
+42	NULL	NULL
+
+statement ok
+DROP TABLE test_table
+
+statement ok
+SET force_compression='${compression}'
+
+endloop


### PR DESCRIPTION
Fixes #10745
