### PR TITLE
Fix MSVC linking issue with workaround

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -116,6 +116,17 @@ runs:
         ls -al
         pwd
 
+    - name: Fix for MSVC issue (see e.g. https://github.com/TileDB-Inc/TileDB/pull/4759)
+      shell: bash
+      if: inputs.deploy_as == 'windows_amd64'
+      env:
+        OVERLAY_TRIPLET_SRC:  ${{ github.workspace }}/vcpkg/triplets/community/x64-windows-static-md.cmake
+        OVERLAY_TRIPLET_DST:  ${{ github.workspace }}/overlay_triplets/x64-windows-static-md.cmake
+      run: |
+        mkdir overlay_triplets
+        cp $OVERLAY_TRIPLET_SRC $OVERLAY_TRIPLET_DST
+        echo "set(VCPKG_PLATFORM_TOOLSET_VERSION "14.38")" >> $OVERLAY_TRIPLET_DST
+
     - name: Set Openssl dir
       if: inputs.openssl_path != ''
       shell: bash
@@ -144,6 +155,7 @@ runs:
         GEN: ${{ inputs.ninja == 1 && 'ninja' || '' }}
         USE_MERGED_VCPKG_MANIFEST: 1
         DUCKDB_PLATFORM: ${{ inputs.duckdb_arch }}
+        VCPKG_OVERLAY_TRIPLETS: "${{ github.workspace }}/overlay_triplets"
       run: |
         ls
         mkdir -p ~/.ssh

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -15,8 +15,6 @@ if (NOT WIN32)
 endif()
 
 ################## AWS
-# FIXME - enable on windows again once building issue is resolved
-if (NOT WIN32)
 if (NOT MINGW)
     duckdb_extension_load(aws
             LOAD_TESTS
@@ -32,7 +30,6 @@ if (NOT MINGW)
             GIT_URL https://github.com/duckdb/duckdb_azure
             GIT_TAG 3ad0348334d2a263e5f19ef08fd02311bdae82f3
             )
-endif()
 endif()
 
 ################# ICEBERG


### PR DESCRIPTION
Was an easy workaround thanks to the investigation done by the people at TileDB who ran into the same issue: https://github.com/TileDB-Inc/TileDB/pull/4759.

this PR reenables the azure and aws extension where this link issue would trigger