### PR TITLE
Support dollar-quoted string-constants in the CLI

### DIFF
--- a/tools/shell/linenoise/history.cpp
+++ b/tools/shell/linenoise/history.cpp
@@ -73,17 +73,42 @@ int History::Add(const char *line) {
 
 	/* Add an heap allocated copy of the line in the history.
 	 * If we reached the max length, remove the older line. */
-	linecopy = strdup(line);
-	if (!linecopy) {
-		return 0;
-	}
 	if (!Terminal::IsMultiline()) {
 		// replace all newlines with spaces
+		linecopy = strdup(line);
+		if (!linecopy) {
+			return 0;
+		}
 		for (auto ptr = linecopy; *ptr; ptr++) {
 			if (*ptr == '\n' || *ptr == '\r') {
 				*ptr = ' ';
 			}
 		}
+	} else {
+		// replace all '\n' with '\r\n'
+		idx_t replaced_newline_count = 0;
+		idx_t len;
+		for (len = 0; line[len]; len++) {
+			if (line[len] == '\r' && line[len + 1] == '\n') {
+				// \r\n - skip past the \n
+				len++;
+			} else if (line[len] == '\n') {
+				replaced_newline_count++;
+			}
+		}
+		linecopy = (char *)malloc((len + replaced_newline_count + 1) * sizeof(char));
+		idx_t pos = 0;
+		for (len = 0; line[len]; len++) {
+			if (line[len] == '\r' && line[len + 1] == '\n') {
+				// \r\n - skip past the \n
+				linecopy[pos++] = '\r';
+				len++;
+			} else if (line[len] == '\n') {
+				linecopy[pos++] = '\r';
+			}
+			linecopy[pos++] = line[len];
+		}
+		linecopy[pos] = '\0';
 	}
 	if (history_len == history_max_len) {
 		free(history[0]);

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -1132,7 +1132,7 @@ int Linenoise::Edit() {
 		Linenoise::Log("%d\n", (int)c);
 		switch (c) {
 		case CTRL_J:
-		case ENTER: /* enter */
+		case ENTER: { /* enter */
 			if (Terminal::IsMultiline() && len > 0) {
 				// check if this forms a complete SQL statement or not
 				buf[len] = '\0';
@@ -1165,7 +1165,17 @@ int Linenoise::Edit() {
 				RefreshLine();
 				hintsCallback = hc;
 			}
-			return (int)len;
+			// rewrite \r\n to \n
+			idx_t new_len = 0;
+			for (idx_t i = 0; i < len; i++) {
+				if (buf[i] == '\r' && buf[i + 1] == '\n') {
+					continue;
+				}
+				buf[new_len++] = buf[i];
+			}
+			buf[new_len] = '\0';
+			return (int)new_len;
+		}
 		case CTRL_O:
 		case CTRL_G:
 		case CTRL_C: /* ctrl-c */ {

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -489,7 +489,7 @@ void Linenoise::AddErrorHighlighting(idx_t render_start, idx_t render_end, vecto
 				state = ScanState::DOLLAR_QUOTED_STRING;
 				quote_pos = i;
 				// scan until the next $
-				for(i++; i < len; i++) {
+				for (i++; i < len; i++) {
 					if (buf[i] == '$') {
 						break;
 					}
@@ -557,7 +557,7 @@ void Linenoise::AddErrorHighlighting(idx_t render_start, idx_t render_end, vecto
 			// skip to the next dollar symbol
 			idx_t start = i + 1;
 			idx_t end = start;
-			while(end < len && buf[end] != '$') {
+			while (end < len && buf[end] != '$') {
 				end++;
 			}
 			if (end >= len) {
@@ -582,7 +582,8 @@ void Linenoise::AddErrorHighlighting(idx_t render_start, idx_t render_end, vecto
 			break;
 		}
 	}
-	if (state == ScanState::IN_DOUBLE_QUOTE || state == ScanState::IN_SINGLE_QUOTE || state == ScanState::DOLLAR_QUOTED_STRING) {
+	if (state == ScanState::IN_DOUBLE_QUOTE || state == ScanState::IN_SINGLE_QUOTE ||
+	    state == ScanState::DOLLAR_QUOTED_STRING) {
 		// quote is never closed
 		errors.push_back(quote_pos);
 	}

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -915,7 +915,7 @@ const char *skipDollarQuotedString(const char *zSql, const char *delimiterStart,
 				return nullptr;
 			}
 			// check if the dollar quoted string name matches
-			if (delimiterLength == zSql - start) {
+			if (delimiterLength == idx_t(zSql - start)) {
 				if (memcmp(start, delimiterStart, delimiterLength) == 0) {
 					return zSql;
 				}

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -898,132 +898,118 @@ SQLITE_API sqlite3_int64 sqlite3_last_insert_rowid(sqlite3 *db) {
 	return SQLITE_ERROR;
 }
 
-// some code borrowed from sqlite
-// its probably best to match its behavior
-
-typedef uint8_t u8;
-
-/*
-** Token types used by the sqlite3_complete() routine.  See the header
-** comments on that procedure for additional information.
-*/
-#define tkSEMI  0
-#define tkWS    1
-#define tkOTHER 2
-
-const unsigned char sqlite3CtypeMap[256] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 00..07    ........ */
-    0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, /* 08..0f    ........ */
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 10..17    ........ */
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 18..1f    ........ */
-    0x01, 0x00, 0x80, 0x00, 0x40, 0x00, 0x00, 0x80, /* 20..27     !"#$%&' */
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 28..2f    ()*+,-./ */
-    0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, /* 30..37    01234567 */
-    0x0c, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* 38..3f    89:;<=>? */
-
-    0x00, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x02, /* 40..47    @ABCDEFG */
-    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 48..4f    HIJKLMNO */
-    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* 50..57    PQRSTUVW */
-    0x02, 0x02, 0x02, 0x80, 0x00, 0x00, 0x00, 0x40, /* 58..5f    XYZ[\]^_ */
-    0x80, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x2a, 0x22, /* 60..67    `abcdefg */
-    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 68..6f    hijklmno */
-    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, /* 70..77    pqrstuvw */
-    0x22, 0x22, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, /* 78..7f    xyz{|}~. */
-
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 80..87    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 88..8f    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 90..97    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* 98..9f    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a0..a7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* a8..af    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b0..b7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* b8..bf    ........ */
-
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c0..c7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* c8..cf    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d0..d7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* d8..df    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e0..e7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* e8..ef    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, /* f0..f7    ........ */
-    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40  /* f8..ff    ........ */
+enum class SQLParseState {
+	SEMICOLON,
+	WHITESPACE,
+	NORMAL
 };
 
-// TODO this can probably be simplified
-#define IdChar(C) ((sqlite3CtypeMap[(unsigned char)C] & 0x46) != 0)
+const char *skipDollarQuotedString(const char *zSql, const char *delimiterStart, idx_t delimiterLength) {
+	for(; *zSql; zSql++) {
+		if (*zSql == '$') {
+			// found a dollar
+			// move forward and find the next dollar
+			zSql++;
+			auto start = zSql;
+			while(*zSql && *zSql != '$') {
+				zSql++;
+			}
+			if (!zSql[0]) {
+				// reached end of string while looking for the dollar
+				return nullptr;
+			}
+			// check if the dollar quoted string name matches
+			if (delimiterLength == zSql - start) {
+				if (memcmp(start, delimiterStart, delimiterLength) == 0) {
+					return zSql;
+				}
+			}
+			// dollar does not match - reset position to start and keep looking
+			zSql = start - 1;
+		}
+	}
+	// unterminated
+	return nullptr;
+}
 
 int sqlite3_complete(const char *zSql) {
-	u8 state = 0; /* Current state, using numbers defined in header comment */
-	u8 token;     /* Value of the next token */
+	auto state = SQLParseState::NORMAL;
 
-	/* If triggers are not supported by this compile then the statement machine
-	 ** used to detect the end of a statement is much simpler
-	 */
-	static const u8 trans[3][3] = {
-	    /* Token:           */
-	    /* State:       **  SEMI  WS  OTHER */
-	    /* 0 INVALID: */ {
-	        1,
-	        0,
-	        2,
-	    },
-	    /* 1   START: */
-	    {
-	        1,
-	        1,
-	        2,
-	    },
-	    /* 2  NORMAL: */
-	    {
-	        1,
-	        2,
-	        2,
-	    },
-	};
-
-	while (*zSql) {
-		switch (*zSql) {
-		case ';': { /* A semicolon */
-			token = tkSEMI;
+	for(; *zSql; zSql++) {
+		SQLParseState next_state;
+		switch(*zSql) {
+		case ';':
+			next_state = SQLParseState::SEMICOLON;
 			break;
-		}
 		case ' ':
 		case '\r':
 		case '\t':
 		case '\n':
 		case '\f': { /* White space is ignored */
-			token = tkWS;
+			next_state = SQLParseState::WHITESPACE;
 			break;
 		}
 		case '/': { /* C-style comments */
 			if (zSql[1] != '*') {
-				token = tkOTHER;
+				next_state = SQLParseState::NORMAL;
 				break;
 			}
 			zSql += 2;
 			while (zSql[0] && (zSql[0] != '*' || zSql[1] != '/')) {
 				zSql++;
 			}
-			if (zSql[0] == 0)
+			if (zSql[0] == 0) {
+				// unterminated c-style string
 				return 0;
+			}
 			zSql++;
-			token = tkWS;
+			next_state = SQLParseState::WHITESPACE;
 			break;
 		}
 		case '-': { /* SQL-style comments from "--" to end of line */
 			if (zSql[1] != '-') {
-				token = tkOTHER;
+				next_state = SQLParseState::NORMAL;
 				break;
 			}
 			while (*zSql && *zSql != '\n') {
 				zSql++;
 			}
-			if (*zSql == 0)
-				return state == 1;
-			token = tkWS;
+			if (*zSql == 0) {
+				// unterminated SQL-style comment - return whether or not we had a semicolon right before it
+				return state == SQLParseState::SEMICOLON ? 1 : 0;
+			}
+			next_state = SQLParseState::WHITESPACE;
 			break;
 		}
-		case '`': /* Grave-accent quoted symbols used by MySQL */
+		case '$': { /* Dollar-quoted strings */
+			if (zSql[1] >= '0' && zSql[1] <= '9') {
+				// numeric prepared statement parameter
+				next_state = SQLParseState::NORMAL;
+				break;
+			}
+			zSql++;
+			auto start = zSql;
+			// look for the next $ symbol (which is the terminator
+			while (*zSql && *zSql != '$') {
+				zSql++;
+			}
+			if (zSql[0] == 0) {
+				// unterminated dollar string
+				return 0;
+			}
+			const char *delimiterStart = start;
+			idx_t delimiterLength = zSql - start;
+			zSql++;
+			// skip the dollar quoted string
+			zSql = skipDollarQuotedString(zSql, delimiterStart, delimiterLength);
+			if (!zSql) {
+				// unterminated dollar string
+				return 0;
+			}
+			next_state = SQLParseState::WHITESPACE;
+			break;
+		}
+//		case '`': /* Grave-accent quoted symbols used by MySQL */
 		case '"': /* single- and double-quoted strings */
 		case '\'': {
 			int c = *zSql;
@@ -1031,32 +1017,22 @@ int sqlite3_complete(const char *zSql) {
 			while (*zSql && *zSql != c) {
 				zSql++;
 			}
-			if (*zSql == 0)
+			if (*zSql == 0) {
+				// unterminated single or double quoted string
 				return 0;
-			token = tkOTHER;
-			break;
-		}
-		default: {
-
-			if (IdChar((u8)*zSql)) {
-				/* Keywords and unquoted identifiers */
-				int nId;
-				for (nId = 1; IdChar(zSql[nId]); nId++) {
-				}
-				token = tkOTHER;
-
-				zSql += nId - 1;
-			} else {
-				/* Operators and special symbols */
-				token = tkOTHER;
 			}
+			next_state = SQLParseState::WHITESPACE;
 			break;
 		}
+		default:
+			next_state = SQLParseState::NORMAL;
 		}
-		state = trans[state][token];
-		zSql++;
+		// white space is ignored (no change in state)
+		if (next_state != SQLParseState::WHITESPACE) {
+			state = next_state;
+		}
 	}
-	return state == 1;
+	return state == SQLParseState::SEMICOLON ? 1 : 0;
 }
 
 // length of varchar or blob value

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -898,20 +898,16 @@ SQLITE_API sqlite3_int64 sqlite3_last_insert_rowid(sqlite3 *db) {
 	return SQLITE_ERROR;
 }
 
-enum class SQLParseState {
-	SEMICOLON,
-	WHITESPACE,
-	NORMAL
-};
+enum class SQLParseState { SEMICOLON, WHITESPACE, NORMAL };
 
 const char *skipDollarQuotedString(const char *zSql, const char *delimiterStart, idx_t delimiterLength) {
-	for(; *zSql; zSql++) {
+	for (; *zSql; zSql++) {
 		if (*zSql == '$') {
 			// found a dollar
 			// move forward and find the next dollar
 			zSql++;
 			auto start = zSql;
-			while(*zSql && *zSql != '$') {
+			while (*zSql && *zSql != '$') {
 				zSql++;
 			}
 			if (!zSql[0]) {
@@ -935,9 +931,9 @@ const char *skipDollarQuotedString(const char *zSql, const char *delimiterStart,
 int sqlite3_complete(const char *zSql) {
 	auto state = SQLParseState::NORMAL;
 
-	for(; *zSql; zSql++) {
+	for (; *zSql; zSql++) {
 		SQLParseState next_state;
-		switch(*zSql) {
+		switch (*zSql) {
 		case ';':
 			next_state = SQLParseState::SEMICOLON;
 			break;
@@ -1009,7 +1005,7 @@ int sqlite3_complete(const char *zSql) {
 			next_state = SQLParseState::WHITESPACE;
 			break;
 		}
-//		case '`': /* Grave-accent quoted symbols used by MySQL */
+			//		case '`': /* Grave-accent quoted symbols used by MySQL */
 		case '"': /* single- and double-quoted strings */
 		case '\'': {
 			int c = *zSql;

--- a/tools/sqlite3_api_wrapper/test/test_sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/test/test_sqlite3_api_wrapper.cpp
@@ -335,3 +335,33 @@ TEST_CASE("Test rollback of aborted transaction", "[sqlite3wrapper]") {
 	// can start a transaction again after a rollback
 	REQUIRE(db.Execute("START TRANSACTION"));
 }
+
+TEST_CASE("Test sqlite3_complete", "[sqlite3wrapper]") {
+	REQUIRE(sqlite3_complete("SELECT $$ this is a dollar quoted string without a marker $$;") == 1);
+	REQUIRE(sqlite3_complete("SELECT $this$is a dollar quoted string$this$;") == 1);
+	REQUIRE(sqlite3_complete("SELECT $this$this$;") == 0);
+	REQUIRE(sqlite3_complete("SELECT $this$is a non-terminated dollar quoted string;") == 0);
+	REQUIRE(sqlite3_complete("SELECT $this$is a non-terminated dollar quoted string;$") == 0);
+	REQUIRE(sqlite3_complete("SELECT $this$is a non-terminated dollar quoted string;$this") == 0);
+	REQUIRE(sqlite3_complete("SELECT $this$is a non-terminated dollar quoted string;$xxx$") == 0);
+	REQUIRE(sqlite3_complete("SELECT $this$is a terminated dollar quoted string;$xxx$$this$") == 0);
+	REQUIRE(sqlite3_complete("SELECT $this$is a terminated dollar quoted string;$xxx$$this$;") == 1);
+	REQUIRE(sqlite3_complete("SELECT $this$$$is a nested $x$ what what $x$ dollar quoted string;$$$this$;") == 1);
+	REQUIRE(sqlite3_complete("") == 0);
+	REQUIRE(sqlite3_complete("S") == 0);
+	REQUIRE(sqlite3_complete("SELECT 42") == 0);
+	REQUIRE(sqlite3_complete("SELECT 42;") == 1);
+	REQUIRE(sqlite3_complete("--comment on first line\nselect 42;") == 1);
+	REQUIRE(sqlite3_complete("SELECT 42;   \n\n\t\t\n\f\t  ") == 1);
+	REQUIRE(sqlite3_complete("SELECT 42;--this is a comment") == 1);
+	REQUIRE(sqlite3_complete("SELECT 42;  --this is a comment") == 1);
+	REQUIRE(sqlite3_complete("SELECT 'quoted semicolon;") == 0);
+	REQUIRE(sqlite3_complete("SELECT 'quoted semicolon\nwith newline\n;") == 0);
+	REQUIRE(sqlite3_complete("SELECT 'quoted semicolon ;\nwith ;; newline\nnow terminated';") == 1);
+	REQUIRE(sqlite3_complete("SELECT \"double-quoted semicolon ;;") == 0);
+	REQUIRE(sqlite3_complete("SELECT 42;\n\t\n--this is a comment") == 1);
+	REQUIRE(sqlite3_complete("SELECT 42;\n\t\n--this is a comment\nS") == 0);
+	REQUIRE(sqlite3_complete("SELECT 42; /* c-style comment *//*followed by another one */  --and this one") == 1);
+	REQUIRE(sqlite3_complete("SELECT 'thisis a string with '';") == 0);
+	REQUIRE(sqlite3_complete("SELECT 'thisis a string with '';;'' escapes';") == 1);
+}


### PR DESCRIPTION
Much like Postgres, DuckDB supports [dollar quoted string constants](https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING), e.g.:


```sql
SELECT $$this isn't a regular SQL string, you don't need to escape anything$$;
```

But also:

```sql
SELECT $MARKER$This string doesn't need to escape double $$ dollars either $MARKER$;
```

This PR adds support for dollar-quoting to the CLI:

* `sqlite3_complete` has been updated to correctly handle dollar-quoted strings, as a result the shell correctly detects when a SQL query with a dollar quoted-string has been terminated, e.g. this no longer executes the query similar to how a semicolon in a string constant does not terminate the query:

```sql
SELECT $$
;
```

* The highlighting/rendering code has been updated to correctly handle dollar-quoted strings, as such this now correctly renders as an error:

```sql
SELECT $$xxx
```

In addition, quotes don't start/terminate within dollar-quoted strings, and neither do brackets, etc. This renders/executes correctly:

```sql
select ($$hello)'world$$);
```

* We replace the `\r\n` that are used internally in the shell with `\n` when executing as a query, as a result we no longer see `\r\n` in string literals, e.g.:

```sql
select '
  ' as newline;
┌─────────┐
│ newline │
│ varchar │
├─────────┤
│ \n      │
└─────────┘
```

This is also what happened in v0.9.2, but was turned into `\r\n` in v0.10.0:

```sql
D select '
  ' AS newline;
┌─────────┐
│ newline │
│ varchar │
├─────────┤
│ \r\n    │
└─────────┘
```

This also applies to newlines in dollar-quoted strings:

```sql
D select $$
  this
  is
  a
  multiline
  string
  $$ AS result;
┌────────────────────────────────────┐
│               result               │
│              varchar               │
├────────────────────────────────────┤
│ \nthis\nis\na\nmultiline\nstring\n │
└────────────────────────────────────┘
```