### PR TITLE
Reset `refresh` in CompressedFile::Close()

### DIFF
--- a/src/common/compressed_file_system.cpp
+++ b/src/common/compressed_file_system.cpp
@@ -113,6 +113,7 @@ void CompressedFile::Close() {
 	stream_data.in_buff_end = nullptr;
 	stream_data.in_buf_size = 0;
 	stream_data.out_buf_size = 0;
+	stream_data.refresh = false;
 }
 
 int64_t CompressedFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {


### PR DESCRIPTION
This enables us to properly rewind and fake a `SEEK(SET, 0) in a compressed file using ::Reset(), which enables GDAL in spatial to read compressed files directly through DuckDB.