### PR TITLE
[CSV Reader] Lock when getting progress

### DIFF
--- a/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
+++ b/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
@@ -40,7 +40,7 @@ CSVGlobalState::CSVGlobalState(ClientContext &context_p, const shared_ptr<CSVBuf
 }
 
 double CSVGlobalState::GetProgress(const ReadCSVData &bind_data_p) const {
-
+	lock_guard<mutex> parallel_lock(main_mutex);
 	idx_t total_files = bind_data.files.size();
 	// get the progress WITHIN the current file
 	double progress;

--- a/src/include/duckdb/execution/operator/csv_scanner/global_csv_state.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/global_csv_state.hpp
@@ -51,7 +51,7 @@ private:
 	vector<shared_ptr<CSVFileScan>> file_scans;
 
 	//! Mutex to lock when getting next batch of bytes (Parallel Only)
-	mutex main_mutex;
+	mutable mutex main_mutex;
 
 	//! Basically max number of threads in DuckDB
 	idx_t system_threads;


### PR DESCRIPTION
I spent quite some time attempting to reproduce this error locally across a variety of builds, query loops, and sanitizer flags, but I was unsuccessful, even with the dataset provided by the issue's author. I am open to suggestions for a suitable test.

In any case, the author has confirmed to me that this PR resolves the issue.

Fix: #10812
