### PR TITLE
Add support for the C API duckdb_query function to the Julia api

### DIFF
--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -160,35 +160,35 @@ function duckdb_destroy_config(config)
     return ccall((:duckdb_destroy_config, libduckdb), Cvoid, (Ref{duckdb_config},), config)
 end
 
-# #=
-# //===--------------------------------------------------------------------===//
-# // Query Execution
-# //===--------------------------------------------------------------------===//
-# =#
-#
-# """
-# 	duckdb_query(connection,query,out_result)
-# Executes a SQL query within a connection and stores the full (materialized) result in the out_result pointer.
-# If the query fails to execute, DuckDBError is returned and the error message can be retrieved by calling
-# `duckdb_result_error`.
-# Note that after running `duckdb_query`, `duckdb_destroy_result` must be called on the result object even if the
-# query fails, otherwise the error stored within the result will not be freed correctly.
-# * `connection`: The connection to perform the query in.
-# * `query`: The SQL query to run.
-# * `out_result`: The query result.
-# * returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
-# """
-# function duckdb_query(connection, query, out_result)
-#     return ccall(
-#         (:duckdb_query, libduckdb),
-#         Int32,
-#         (Ptr{Cvoid}, Ptr{UInt8}, Ptr{Cvoid}),
-#         connection[],
-#         query,
-#         out_result,
-#     )
-# end
-#
+#=
+//===--------------------------------------------------------------------===//
+// Query Execution
+//===--------------------------------------------------------------------===//
+=#
+
+"""
+	duckdb_query(connection,query,out_result)
+Executes a SQL query within a connection and stores the full (materialized) result in the out_result pointer.
+If the query fails to execute, DuckDBError is returned and the error message can be retrieved by calling
+`duckdb_result_error`.
+Note that after running `duckdb_query`, `duckdb_destroy_result` must be called on the result object even if the
+query fails, otherwise the error stored within the result will not be freed correctly.
+* `connection`: The connection to perform the query in.
+* `query`: The SQL query to run.
+* `out_result`: The query result.
+* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
+"""
+function duckdb_query(connection, query, out_result)
+    return ccall(
+        (:duckdb_query, libduckdb),
+        duckdb_state,
+        (duckdb_connection, Ptr{UInt8}, Ref{duckdb_result}),
+        connection,
+        query,
+        out_result
+    )
+end
+
 """
 	duckdb_destroy_result(result)
 Closes the result and de-allocates all memory allocated for that connection.

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -858,6 +858,11 @@ DBInterface.execute(db::DB, sql::AbstractString, result_type::Type) =
 
 Base.show(io::IO, result::DuckDB.QueryResult) = print(io, Tables.columntable(result))
 
+"""
+Executes a SQL query within a connection and returns the full (materialized) result. 
+
+The query function is able to run queries with multiple statements, unlike `DBInterface.execute`(@ref) which is only able to prepare a single statement.
+"""
 function query(con::DuckDB.Connection, sql::AbstractString)
     handle = Ref{duckdb_result}()
     ret = duckdb_query(con.handle, sql, handle)
@@ -869,3 +874,4 @@ function query(con::DuckDB.Connection, sql::AbstractString)
     end
     return QueryResult(handle)
 end
+query(db::DuckDB.DB, sql::AbstractString) = query(db.main_connection, sql)

--- a/tools/juliapkg/test/test_basic_queries.jl
+++ b/tools/juliapkg/test/test_basic_queries.jl
@@ -107,8 +107,9 @@ end
 end
 
 # test a PIVOT query that generates multiple prepared statements and will fail with execute
-@testset "Test DBInterface.execute" begin
-    con = DuckDB.connect(DuckDB.DB())
+@testset "Test DBInterface.query" begin
+    db = DuckDB.DB()
+    con = DuckDB.connect(db)
     DuckDB.execute(con, "CREATE TABLE Cities (Country VARCHAR, Name VARCHAR, Year INT, Population INT);")
     DuckDB.execute(con, "INSERT INTO Cities VALUES ('NL', 'Amsterdam', 2000, 1005)")
     DuckDB.execute(con, "INSERT INTO Cities VALUES ('NL', 'Amsterdam', 2010, 1065)")
@@ -128,6 +129,8 @@ end
     @test df[1, :Name] == "Amsterdam"
     @test df[1, "2000"] == 1005
     @test df[1, 4] == 1065
+
+    @test DataFrame(DuckDB.query(db, "select 'a'; select 2;"))[1, 1] == "a"
 
     DBInterface.close!(con)
 end

--- a/tools/juliapkg/test/test_basic_queries.jl
+++ b/tools/juliapkg/test/test_basic_queries.jl
@@ -105,3 +105,29 @@ end
 
     DBInterface.close!(con)
 end
+
+# test a PIVOT query that generates multiple prepared statements and will fail with execute
+@testset "Test DBInterface.execute" begin
+    con = DuckDB.connect(DuckDB.DB())
+    DuckDB.execute(con, "CREATE TABLE Cities (Country VARCHAR, Name VARCHAR, Year INT, Population INT);")
+    DuckDB.execute(con, "INSERT INTO Cities VALUES ('NL', 'Amsterdam', 2000, 1005)")
+    DuckDB.execute(con, "INSERT INTO Cities VALUES ('NL', 'Amsterdam', 2010, 1065)")
+    results = DuckDB.query(con, "PIVOT Cities ON Year USING first(Population);")
+
+    # iterator
+    for row in Tables.rows(results)
+        @test row[:Name] == "Amsterdam"
+        @test row[4] == 1065
+    end
+
+    # convert to DataFrame
+    df = DataFrame(results)
+    @test names(df) == ["Country", "Name", "2000", "2010"]
+    @test size(df, 1) == 1
+    @test df[1, :Country] == "NL"
+    @test df[1, :Name] == "Amsterdam"
+    @test df[1, "2000"] == 1005
+    @test df[1, 4] == 1065
+
+    DBInterface.close!(con)
+end


### PR DESCRIPTION
Add support for the C API duckdb_query function. This will support PIVOT queries that generate multiple prepared statements, which currently will not work with DuckDB.execute() since it uses duckdb_execute_prepared.

fetch_error() was updated to dispatch on abstract string instead of statement so it be can used for both duckb_query() and duckdb_execute_pending().