### PR TITLE
Table name binding does not fail for non-existent tables in DROP TABLE statements

### DIFF
--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -35,7 +35,7 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 	case CatalogType::TYPE_ENTRY: {
 		BindSchemaOrCatalog(stmt.info->catalog, stmt.info->schema);
 		auto entry = Catalog::GetEntry(context, stmt.info->type, stmt.info->catalog, stmt.info->schema, stmt.info->name,
-		                               OnEntryNotFound::RETURN_NULL);
+		                               stmt.info->if_not_found);
 		if (!entry) {
 			break;
 		}


### PR DESCRIPTION
Currently tables that cannot be resolved during the binding phase will not result in a `CatalogException` , which is different than the behaviour exhibited for SELECT statements where trying to select from a non-existent table will result in a `CatalogException` in the bind phase. Instead, for DROP statements, the name binding fails in the execution phase with a `CatalogException`.

As a result a `OptimizerExtension` will get DROP statements that should not have been passed along to them, resulting in inconsistent behaviour and a need for the `OptimizerExtension` to handle them separately.

This PR modifies the behavior to ensure that DROP statements function similarly to SELECT statements, by failing with a `CatalogException` in the bind phase, without producing a differing outcome compared to the current behaviour.