### PR TITLE
Add regexp_split_to_table macro

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -162,6 +162,9 @@ static DefaultMacro internal_macros[] = {
 	// date functions
 	{DEFAULT_SCHEMA, "date_add", {"date", "interval", nullptr}, "date + interval"},
 
+	// regexp functions
+	{DEFAULT_SCHEMA, "regexp_split_to_table", {"text", "pattern", nullptr}, "unnest(string_split_regex(text, pattern))"},
+
     // storage helper functions
     {DEFAULT_SCHEMA, "get_block_size", {"db_name"}, "(SELECT block_size FROM pragma_database_size() WHERE database_name = db_name)"},
 

--- a/test/sql/function/string/regexp_split_to_table.test
+++ b/test/sql/function/string/regexp_split_to_table.test
@@ -1,0 +1,30 @@
+# name: test/sql/function/string/regexp_split_to_table.test
+# description: regexp_split_to_table test
+# group: [string]
+
+statement ok
+PRAGMA enable_verification
+
+# non-regex split
+query T
+SELECT regexp_split_to_table('a b c', ' ')
+----
+a
+b
+c
+
+# regex-based split
+query T
+SELECT regexp_split_to_table('axbyc', '[x|y]')
+----
+a
+b
+c
+
+# regex-based split with an unaffected column
+query II
+SELECT regexp_split_to_table('axbyc', '[x|y]'), 42
+----
+a	42
+b	42
+c	42


### PR DESCRIPTION
Following the suggestion of @adityawarmanfw on LinkedIn, this PR is adding the `regexp_split_to_table` macro with the same semantics as [Postgres' function of the same name](https://www.postgresql.org/docs/current/functions-string.html).