### PR TITLE
Correctly reset data chunk in RETURNING of DELETE

### DIFF
--- a/src/execution/operator/persistent/physical_delete.cpp
+++ b/src/execution/operator/persistent/physical_delete.cpp
@@ -47,6 +47,7 @@ SinkResultType PhysicalDelete::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	lock_guard<mutex> delete_guard(gstate.delete_lock);
 	if (return_chunk) {
+		ustate.delete_chunk.Reset();
 		row_identifiers.Flatten(chunk.size());
 		table.Fetch(transaction, ustate.delete_chunk, column_ids, row_identifiers, chunk.size(), cfs);
 		gstate.return_collection.Append(ustate.delete_chunk);

--- a/test/sql/returning/returning_delete_list.test
+++ b/test/sql/returning/returning_delete_list.test
@@ -1,0 +1,24 @@
+# name: test/sql/returning/returning_delete_list.test
+# description: Test returning with a nested integer list
+# group: [returning]
+
+
+statement ok
+CREATE TABLE all_types("varchar" VARCHAR, nested_int_array INTEGER[][]);;
+
+statement ok
+INSERT INTO all_types VALUES('🦆🦆🦆🦆🦆🦆',[]);
+
+statement ok
+INSERT INTO all_types VALUES('goo'||chr(0) || 'se' ,[[], [42, 999, NULL, NULL, -42], NULL, [], [42, 999, NULL, NULL, -42]]);
+
+statement ok
+INSERT INTO all_types VALUES(NULL,NULL);
+
+statement ok
+DELETE
+FROM all_types
+WHERE EXISTS
+    (SELECT all_types."varchar" AS c2
+     FROM all_types AS ref_0)
+RETURNING all_types.nested_int_array

--- a/test/sql/returning/returning_delete_list.test
+++ b/test/sql/returning/returning_delete_list.test
@@ -2,7 +2,6 @@
 # description: Test returning with a nested integer list
 # group: [returning]
 
-
 statement ok
 CREATE TABLE all_types("varchar" VARCHAR, nested_int_array INTEGER[][]);;
 


### PR DESCRIPTION
Fixes an issue where `NULL` values would otherwise be returned incorrectly for large vectors