### PR TITLE
Shell: Remove IEE754 function from CLI

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -14260,7 +14260,6 @@ static void open_db(ShellState *p, int openFlags){
     sqlite3_completion_init(p->db, 0, 0);
     sqlite3_uint_init(p->db, 0, 0);
     sqlite3_decimal_init(p->db, 0, 0);
-    sqlite3_ieee_init(p->db, 0, 0);
 #if !defined(SQLITE_OMIT_VIRTUALTABLE) && defined(SQLITE_ENABLE_DBPAGE_VTAB)
     sqlite3_dbdata_init(p->db, 0, 0);
 #endif


### PR DESCRIPTION
This function is a SQLite UDF that is bundled with the shell, but it suffers from internal integer overflows which trips up the sanitizer. This PR just removes the function.