### PR TITLE
Fix #10491: Improve correlated subquery error message

### DIFF
--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -45,7 +45,7 @@ unique_ptr<Expression> CreateBoundStructExtractIndex(ClientContext &context, uni
 BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) {
 	// bind the children of the function expression
 	if (depth > 0) {
-		return BindResult(BinderException(function, "UNNEST() for correlated expressions is not supported yet"));
+		throw BinderException(function, "UNNEST() for correlated expressions is not supported yet");
 	}
 	ErrorData error;
 	if (function.children.empty()) {

--- a/src/planner/expression_binder/lateral_binder.cpp
+++ b/src/planner/expression_binder/lateral_binder.cpp
@@ -50,7 +50,7 @@ BindResult LateralBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr,
 }
 
 string LateralBinder::UnsupportedAggregateMessage() {
-	return "LATERAL join cannot contain aggregates!";
+	throw BinderException("LATERAL join cannot contain aggregates!");
 }
 
 class ExpressionDepthReducer : public LogicalOperatorVisitor {

--- a/test/sql/binder/test_alias_reference_in_select.test
+++ b/test/sql/binder/test_alias_reference_in_select.test
@@ -1,0 +1,50 @@
+# name: test/sql/binder/test_alias_reference_in_select.test
+# description: Test that a correct error message is thrown
+# group: [binder]
+
+require json
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE testjson (
+	example JSON
+);
+
+statement ok
+INSERT INTO testjson VALUES ('{ "location" : { "address" : "123 Main St" }, "sampleField" : null, "anotherField" : 123, "yetAnotherField" : "abc" }');
+
+statement error
+SELECT (WITH keys AS (
+    		SELECT unnest(json_keys(example)) AS k
+    	), nonNull AS (
+    		SELECT
+    			keys.k,
+    			example->keys.k AS v
+    		FROM keys
+    		WHERE v IS NOT NULL
+    	)
+    	SELECT json_group_object(nonNull.k, nonNull.v)
+    	FROM nonNull
+)
+FROM testjson;
+----
+"example" not found
+
+query I
+SELECT (WITH keys AS (
+    		SELECT unnest(json_keys(example)) AS k
+    	), nonNull AS (
+    		SELECT
+    			keys.k,
+    			keys.k AS v
+    		FROM keys
+    		WHERE v IS NOT NULL
+    	)
+    	SELECT json_group_object(nonNull.k, nonNull.v)
+    	FROM nonNull
+)
+FROM testjson;
+----
+{"location":"location","sampleField":"sampleField","anotherField":"anotherField","yetAnotherField":"yetAnotherField"}


### PR DESCRIPTION
Fixes #10491 

This PR reworks the error handling of correlated subqueries so that we re-bind and throw a rebound error instead, which should improve the error message that is displayed. This throws the correct error in most situations. In the few situations where we need to throw the correlated error we directly throw instead of returning a BindResult.


