### PR TITLE
Batch memory manager - keep track of all used memory correctly and enforce that unflushed memory is correctly set to 0 when we are finished

### DIFF
--- a/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
+++ b/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
@@ -34,6 +34,15 @@ public:
 	virtual void Execute(const PhysicalFixedBatchCopy &op, ClientContext &context, GlobalSinkState &gstate_p) = 0;
 };
 
+struct FixedRawBatchData {
+	FixedRawBatchData(idx_t memory_usage_p, unique_ptr<ColumnDataCollection> collection_p)
+	    : memory_usage(memory_usage_p), collection(std::move(collection_p)) {
+	}
+
+	idx_t memory_usage;
+	unique_ptr<ColumnDataCollection> collection;
+};
+
 struct FixedPreparedBatchData {
 	idx_t memory_usage;
 	unique_ptr<PreparedBatchData> prepared_data;
@@ -63,7 +72,7 @@ public:
 	//! The desired batch size (if any)
 	idx_t batch_size;
 	//! Unpartitioned batches
-	map<idx_t, unique_ptr<ColumnDataCollection>> raw_batches;
+	map<idx_t, unique_ptr<FixedRawBatchData>> raw_batches;
 	//! The prepared batch data by batch index - ready to flush
 	map<idx_t, unique_ptr<FixedPreparedBatchData>> batch_data;
 	//! The index of the latest batch index that has been scheduled
@@ -256,7 +265,7 @@ SinkFinalizeType PhysicalFixedBatchCopy::FinalFlush(ClientContext &context, Glob
 	if (gstate.task_manager.TaskCount() != 0) {
 		throw InternalException("Unexecuted tasks are remaining in PhysicalFixedBatchCopy::FinalFlush!?");
 	}
-	idx_t min_batch_index = idx_t(NumericLimits<int64_t>::Maximum());
+	auto min_batch_index = idx_t(NumericLimits<int64_t>::Maximum());
 	FlushBatchData(context, gstate_p, min_batch_index);
 	if (gstate.scheduled_batch_index != gstate.flushed_batch_index) {
 		throw InternalException("Not all batches were flushed to disk - incomplete file?");
@@ -268,13 +277,14 @@ SinkFinalizeType PhysicalFixedBatchCopy::FinalFlush(ClientContext &context, Glob
 			PhysicalCopyToFile::MoveTmpFile(context, file_path);
 		}
 	}
+	gstate.memory_manager.FinalCheck();
 	return SinkFinalizeType::READY;
 }
 
 SinkFinalizeType PhysicalFixedBatchCopy::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
                                                   OperatorSinkFinalizeInput &input) const {
 	auto &gstate = input.global_state.Cast<FixedBatchCopyGlobalState>();
-	idx_t min_batch_index = idx_t(NumericLimits<int64_t>::Maximum());
+	auto min_batch_index = idx_t(NumericLimits<int64_t>::Maximum());
 	// repartition any remaining batches
 	RepartitionBatches(context, input.global_state, min_batch_index, true);
 	// check if we have multiple tasks to execute
@@ -282,11 +292,11 @@ SinkFinalizeType PhysicalFixedBatchCopy::Finalize(Pipeline &pipeline, Event &eve
 		// we don't - just execute the remaining task and finish flushing to disk
 		ExecuteTasks(context, input.global_state);
 		FinalFlush(context, input.global_state);
-		return SinkFinalizeType::READY;
+	} else {
+		// we have multiple tasks remaining - launch an event to execute the tasks in parallel
+		auto new_event = make_shared<ProcessRemainingBatchesEvent>(*this, gstate, pipeline, context);
+		event.InsertEvent(std::move(new_event));
 	}
-	// we have multiple tasks remaining - launch an event to execute the tasks in parallel
-	auto new_event = make_shared<ProcessRemainingBatchesEvent>(*this, gstate, pipeline, context);
-	event.InsertEvent(std::move(new_event));
 	return SinkFinalizeType::READY;
 }
 
@@ -305,19 +315,19 @@ public:
 
 class PrepareBatchTask : public BatchCopyTask {
 public:
-	PrepareBatchTask(idx_t batch_index, unique_ptr<ColumnDataCollection> collection_p)
-	    : batch_index(batch_index), collection(std::move(collection_p)) {
+	PrepareBatchTask(idx_t batch_index, unique_ptr<FixedRawBatchData> batch_data_p)
+	    : batch_index(batch_index), batch_data(std::move(batch_data_p)) {
 	}
 
 	idx_t batch_index;
-	unique_ptr<ColumnDataCollection> collection;
+	unique_ptr<FixedRawBatchData> batch_data;
 
 	void Execute(const PhysicalFixedBatchCopy &op, ClientContext &context, GlobalSinkState &gstate_p) override {
 		auto &gstate = gstate_p.Cast<FixedBatchCopyGlobalState>();
-		auto memory_usage = collection->AllocationSize();
-		auto batch_data =
-		    op.function.prepare_batch(context, *op.bind_data, *gstate.global_state, std::move(collection));
-		gstate.AddBatchData(batch_index, std::move(batch_data), memory_usage);
+		auto memory_usage = batch_data->memory_usage;
+		auto prepared_batch =
+		    op.function.prepare_batch(context, *op.bind_data, *gstate.global_state, std::move(batch_data->collection));
+		gstate.AddBatchData(batch_index, std::move(prepared_batch), memory_usage);
 		if (batch_index == gstate.flushed_batch_index) {
 			gstate.task_manager.AddTask(make_uniq<RepartitionedFlushTask>());
 		}
@@ -328,12 +338,12 @@ public:
 // Batch Data Handling
 //===--------------------------------------------------------------------===//
 void PhysicalFixedBatchCopy::AddRawBatchData(ClientContext &context, GlobalSinkState &gstate_p, idx_t batch_index,
-                                             unique_ptr<ColumnDataCollection> collection) const {
+                                             unique_ptr<FixedRawBatchData> raw_batch) const {
 	auto &gstate = gstate_p.Cast<FixedBatchCopyGlobalState>();
 
 	// add the batch index to the set of raw batches
 	lock_guard<mutex> l(gstate.lock);
-	auto entry = gstate.raw_batches.insert(make_pair(batch_index, std::move(collection)));
+	auto entry = gstate.raw_batches.insert(make_pair(batch_index, std::move(raw_batch)));
 	if (!entry.second) {
 		throw InternalException("Duplicate batch index %llu encountered in PhysicalFixedBatchCopy", batch_index);
 	}
@@ -367,7 +377,7 @@ void PhysicalFixedBatchCopy::RepartitionBatches(ClientContext &context, GlobalSi
 				// we have exceeded the minimum batch
 				break;
 			}
-			candidate_rows += entry->second->Count();
+			candidate_rows += entry->second->collection->Count();
 		}
 		if (candidate_rows < gstate.batch_size) {
 			// not enough rows - cancel!
@@ -376,69 +386,73 @@ void PhysicalFixedBatchCopy::RepartitionBatches(ClientContext &context, GlobalSi
 	}
 	// gather all collections we can repartition
 	idx_t max_batch_index = 0;
-	vector<unique_ptr<ColumnDataCollection>> collections;
+	vector<unique_ptr<FixedRawBatchData>> raw_batches;
 	for (auto entry = gstate.raw_batches.begin(); entry != gstate.raw_batches.end();) {
 		if (entry->first >= min_index) {
 			break;
 		}
 		max_batch_index = entry->first;
-		collections.push_back(std::move(entry->second));
+		raw_batches.push_back(std::move(entry->second));
 		entry = gstate.raw_batches.erase(entry);
 	}
-	unique_ptr<ColumnDataCollection> current_collection;
+	unique_ptr<FixedRawBatchData> append_batch;
 	ColumnDataAppendState append_state;
 	// now perform the actual repartitioning
-	for (auto &collection : collections) {
-		if (!current_collection) {
-			if (CorrectSizeForBatch(collection->Count(), gstate.batch_size)) {
+	for (auto &current_batch : raw_batches) {
+		if (!append_batch) {
+			auto current_count = current_batch->collection->Count();
+			if (CorrectSizeForBatch(current_count, gstate.batch_size)) {
 				// the collection is ~approximately equal to the batch size (off by at most one vector)
 				// use it directly
 				task_manager.AddTask(
-				    make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(collection)));
-				collection.reset();
-			} else if (collection->Count() < gstate.batch_size) {
+				    make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(current_batch)));
+				current_batch.reset();
+			} else if (current_count < gstate.batch_size) {
 				// the collection is smaller than the batch size - use it as a starting point
-				current_collection = std::move(collection);
-				collection.reset();
+				append_batch = std::move(current_batch);
+				current_batch.reset();
 			} else {
 				// the collection is too large for a batch - we need to repartition
 				// create an empty collection
-				current_collection =
+				auto new_collection =
 				    make_uniq<ColumnDataCollection>(context, children[0]->types, ColumnDataAllocatorType::HYBRID);
+				append_batch = make_uniq<FixedRawBatchData>(0, std::move(new_collection));
 			}
-			if (current_collection) {
-				current_collection->InitializeAppend(append_state);
+			if (append_batch) {
+				append_batch->collection->InitializeAppend(append_state);
 			}
 		}
-		if (!collection) {
+		if (!current_batch) {
 			// we have consumed the collection already - no need to append
 			continue;
 		}
+		auto &current_collection = *current_batch->collection;
+		append_batch->memory_usage += current_batch->memory_usage;
 		// iterate the collection while appending
-		for (auto &chunk : collection->Chunks()) {
+		for (auto &chunk : current_collection.Chunks()) {
 			// append the chunk to the collection
-			current_collection->Append(append_state, chunk);
-			if (current_collection->Count() < gstate.batch_size) {
+			append_batch->collection->Append(append_state, chunk);
+			if (append_batch->collection->Count() < gstate.batch_size) {
 				// the collection is still under the batch size - continue
 				continue;
 			}
 			// the collection is full - move it to the result and create a new one
-			task_manager.AddTask(
-			    make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(current_collection)));
-			current_collection =
+			task_manager.AddTask(make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(append_batch)));
+
+			auto new_collection =
 			    make_uniq<ColumnDataCollection>(context, children[0]->types, ColumnDataAllocatorType::HYBRID);
-			current_collection->InitializeAppend(append_state);
+			append_batch = make_uniq<FixedRawBatchData>(0, std::move(new_collection));
+			append_batch->collection->InitializeAppend(append_state);
 		}
 	}
-	if (current_collection && current_collection->Count() > 0) {
+	if (append_batch && append_batch->collection->Count() > 0) {
 		// if there are any remaining batches that are not filled up to the batch size
 		// AND this is not the final collection
 		// re-add it to the set of raw (to-be-merged) batches
-		if (final || CorrectSizeForBatch(current_collection->Count(), gstate.batch_size)) {
-			task_manager.AddTask(
-			    make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(current_collection)));
+		if (final || CorrectSizeForBatch(append_batch->collection->Count(), gstate.batch_size)) {
+			task_manager.AddTask(make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(append_batch)));
 		} else {
-			gstate.raw_batches[max_batch_index] = std::move(current_collection);
+			gstate.raw_batches[max_batch_index] = std::move(append_batch);
 		}
 	}
 }
@@ -517,7 +531,8 @@ SinkNextBatchType PhysicalFixedBatchCopy::NextBatch(ExecutionContext &context,
 		// start flushing data
 		auto min_batch_index = lstate.partition_info.min_batch_index.GetIndex();
 		// push the raw batch data into the set of unprocessed batches
-		AddRawBatchData(context.client, gstate_p, state.batch_index.GetIndex(), std::move(state.collection));
+		auto raw_batch = make_uniq<FixedRawBatchData>(state.local_memory_usage, std::move(state.collection));
+		AddRawBatchData(context.client, gstate_p, state.batch_index.GetIndex(), std::move(raw_batch));
 		// attempt to repartition to our desired batch size
 		RepartitionBatches(context.client, gstate_p, min_batch_index);
 		// unblock tasks so they can help process batches (if any are blocked)

--- a/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/filename_pattern.hpp"
 
 namespace duckdb {
+struct FixedRawBatchData;
 
 class PhysicalFixedBatchCopy : public PhysicalOperator {
 public:
@@ -61,7 +62,7 @@ public:
 
 public:
 	void AddRawBatchData(ClientContext &context, GlobalSinkState &gstate_p, idx_t batch_index,
-	                     unique_ptr<ColumnDataCollection> collection) const;
+	                     unique_ptr<FixedRawBatchData> collection) const;
 	void RepartitionBatches(ClientContext &context, GlobalSinkState &gstate_p, idx_t min_index,
 	                        bool final = false) const;
 	void FlushBatchData(ClientContext &context, GlobalSinkState &gstate_p, idx_t min_index) const;

--- a/test/sql/copy/parquet/batched_write/batch_memory_usage.test
+++ b/test/sql/copy/parquet/batched_write/batch_memory_usage.test
@@ -1,0 +1,17 @@
+# name: test/sql/copy/parquet/batched_write/batch_memory_usage.test
+# description: Batched Parquet write memory usage
+# group: [batched_write]
+
+require parquet
+
+statement ok
+SELECT setseed(0.72)
+
+statement ok
+COPY (SELECT uuid()::VARCHAR as varchar, uuid() AS uuid FROM range(10000000) t(i)) TO '__TEST_DIR__/random_uuids.parquet'
+
+statement ok
+SET memory_limit='500MB'
+
+statement ok
+COPY '__TEST_DIR__/random_uuids.parquet' TO '__TEST_DIR__/random_uuids_copy.parquet';


### PR DESCRIPTION
This fixes an issue where we would have a discrepency between the memory we added and the memory we reduced in the batched Parquet writer because we would add the memory usage of the non-merged collections, but then subtract the memory usage of the merged collections. This is unlikely to make a big difference but it is cleaner to enforce that we subtract exactly the same amount that we add to ensure this is all sane and works correctly.