### PR TITLE
Fix #9975 - correctly open (and keep open) a transaction when checking if prepared statement needs to be rebound

### DIFF
--- a/src/include/duckdb/common/enums/statement_type.hpp
+++ b/src/include/duckdb/common/enums/statement_type.hpp
@@ -65,6 +65,8 @@ struct StatementProperties {
 	      return_type(StatementReturnType::QUERY_RESULT), parameter_count(0), always_require_rebind(false) {
 	}
 
+	//! The set of databases this statement will read from
+	unordered_set<string> read_databases;
 	//! The set of databases this statement will modify
 	unordered_set<string> modified_databases;
 	//! Whether or not the statement requires a valid transaction. Almost all statements require this, with the

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -41,7 +41,7 @@ public:
 
 public:
 	DUCKDB_API static MetaTransaction &Get(ClientContext &context);
-	timestamp_t GetCurrentTransactionStartTimestamp() {
+	timestamp_t GetCurrentTransactionStartTimestamp() const {
 		return start_timestamp;
 	}
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -319,7 +319,6 @@ ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &qu
 	result->types = planner.types;
 	result->value_map = std::move(planner.value_map);
 	result->catalog_version = MetaTransaction::Get(*this).catalog_version;
-
 	if (!planner.properties.bound_all_parameters) {
 		return result;
 	}

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -55,10 +55,10 @@ bool PreparedStatementData::RequireRebind(ClientContext &context, optional_ptr<c
 	}
 	// prior to checking the catalog version we need to explicitly start transactions in all affected databases
 	// this ensures all catalog entries we rely on are cached
-	for(auto &catalog_name : properties.read_databases) {
+	for (auto &catalog_name : properties.read_databases) {
 		StartTransactionInCatalog(context, catalog_name);
 	}
-	for(auto &catalog_name : properties.modified_databases) {
+	for (auto &catalog_name : properties.modified_databases) {
 		StartTransactionInCatalog(context, catalog_name);
 	}
 	if (Catalog::GetSystemCatalog(context).GetCatalogVersion() != catalog_version) {

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/common/exception/binder_exception.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/transaction/transaction.hpp"
 
 namespace duckdb {
 

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -19,12 +19,19 @@ void PreparedStatementData::CheckParameterCount(idx_t parameter_count) {
 	}
 }
 
+void StartTransactionInCatalog(ClientContext &context, const string &catalog_name) {
+	auto database = DatabaseManager::Get(context).GetDatabase(context, catalog_name);
+	if (!database) {
+		throw BinderException("Prepared statement requires database %s but it was not attached", catalog_name);
+	}
+	Transaction::Get(context, *database);
+}
+
 bool PreparedStatementData::RequireRebind(ClientContext &context, optional_ptr<case_insensitive_map_t<Value>> values) {
 	idx_t count = values ? values->size() : 0;
 	CheckParameterCount(count);
 	if (!unbound_statement) {
-		// no unbound statement!? cannot rebind?
-		return false;
+		throw InternalException("Prepared statement without unbound statement");
 	}
 	if (properties.always_require_rebind) {
 		// this statement must always be re-bound
@@ -32,10 +39,6 @@ bool PreparedStatementData::RequireRebind(ClientContext &context, optional_ptr<c
 	}
 	if (!properties.bound_all_parameters) {
 		// parameters not yet bound: query always requires a rebind
-		return true;
-	}
-	if (Catalog::GetSystemCatalog(context).GetCatalogVersion() != catalog_version) {
-		//! context is out of bounds
 		return true;
 	}
 	for (auto &it : value_map) {
@@ -47,6 +50,18 @@ bool PreparedStatementData::RequireRebind(ClientContext &context, optional_ptr<c
 		if (lookup->second.type() != it.second->return_type) {
 			return true;
 		}
+	}
+	// prior to checking the catalog version we need to explicitly start transactions in all affected databases
+	// this ensures all catalog entries we rely on are cached
+	for(auto &catalog_name : properties.read_databases) {
+		StartTransactionInCatalog(context, catalog_name);
+	}
+	for(auto &catalog_name : properties.modified_databases) {
+		StartTransactionInCatalog(context, catalog_name);
+	}
+	if (Catalog::GetSystemCatalog(context).GetCatalogVersion() != catalog_version) {
+		//! context is out of bounds
+		return true;
 	}
 	return false;
 }

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -181,14 +181,17 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		}
 
 		// could not find an alternative: bind again to get the error
-		table_or_view = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, ref.catalog_name, ref.schema_name,
-		                                  ref.table_name, OnEntryNotFound::THROW_EXCEPTION, error_context);
+		Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, ref.catalog_name, ref.schema_name,
+		                  ref.table_name, OnEntryNotFound::THROW_EXCEPTION, error_context);
+		throw InternalException("Catalog::GetEntry should have thrown an exception above");
 	}
+
 	switch (table_or_view->type) {
 	case CatalogType::TABLE_ENTRY: {
 		// base table: create the BoundBaseTableRef node
 		auto table_index = GenerateTableIndex();
 		auto &table = table_or_view->Cast<TableCatalogEntry>();
+		properties.read_databases.insert(table.ParentCatalog().GetName());
 
 		unique_ptr<FunctionData> bind_data;
 		auto scan_function = table.GetScanFunction(context, bind_data);

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -181,8 +181,8 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		}
 
 		// could not find an alternative: bind again to get the error
-		Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, ref.catalog_name, ref.schema_name,
-		                  ref.table_name, OnEntryNotFound::THROW_EXCEPTION, error_context);
+		Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, ref.catalog_name, ref.schema_name, ref.table_name,
+		                  OnEntryNotFound::THROW_EXCEPTION, error_context);
 		throw InternalException("Catalog::GetEntry should have thrown an exception above");
 	}
 

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -284,6 +284,8 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data) {
 		if (!StringUtil::CIEquals(catalog_entry->name, catalog_entry->Parent().name)) {
 			catalog_entry->set->UpdateTimestamp(*catalog_entry, commit_id);
 		}
+		// modify catalog on commit
+		duck_catalog.ModifyCatalog();
 
 		if (HAS_LOG) {
 			// push the catalog update to the WAL

--- a/test/sql/parallelism/interquery/CMakeLists.txt
+++ b/test/sql/parallelism/interquery/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library_unity(
   test_concurrent_index.cpp
   test_concurrentupdate.cpp
   test_concurrent_sequence.cpp
+  test_concurrent_prepared.cpp
   test_default_catalog.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_sql_interquery_parallelism>

--- a/test/sql/parallelism/interquery/test_concurrent_prepared.cpp
+++ b/test/sql/parallelism/interquery/test_concurrent_prepared.cpp
@@ -1,0 +1,40 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include <iostream>
+#include <thread>
+
+using namespace duckdb;
+using namespace std;
+
+static void SelectTable(Connection con) {
+	for(idx_t i = 0; i < 1000; i++) {
+		auto prepare = con.Prepare("select * from foo");
+		REQUIRE_NO_FAIL(prepare->Execute());
+	}
+}
+
+static void RecreateTable(Connection con) {
+	for(idx_t i = 0; i < 1000; i++) {
+		auto prepare = con.Prepare("create or replace table foo as select * from foo");
+		REQUIRE_NO_FAIL(prepare->Execute());
+	}
+}
+
+TEST_CASE("Test concurrent prepared", "[api][.]") {
+	duckdb::unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.EnableQueryVerification();
+
+	REQUIRE_NO_FAIL(con.Query("create table foo as select unnest(generate_series(1, 10));"));
+
+	Connection select_conn(db);
+	Connection recreate_conn(db);
+	select_conn.EnableQueryVerification();
+
+	std::thread select_function(SelectTable, std::move(select_conn));
+	std::thread recreate_function(RecreateTable, std::move(recreate_conn));
+
+	select_function.join();
+	recreate_function.join();
+}

--- a/test/sql/parallelism/interquery/test_concurrent_prepared.cpp
+++ b/test/sql/parallelism/interquery/test_concurrent_prepared.cpp
@@ -7,14 +7,14 @@ using namespace duckdb;
 using namespace std;
 
 static void SelectTable(Connection con) {
-	for(idx_t i = 0; i < 1000; i++) {
+	for (idx_t i = 0; i < 1000; i++) {
 		auto prepare = con.Prepare("select * from foo");
 		REQUIRE_NO_FAIL(prepare->Execute());
 	}
 }
 
 static void RecreateTable(Connection con) {
-	for(idx_t i = 0; i < 1000; i++) {
+	for (idx_t i = 0; i < 1000; i++) {
 		auto prepare = con.Prepare("create or replace table foo as select * from foo");
 		REQUIRE_NO_FAIL(prepare->Execute());
 	}


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/9975

The issue here is that we would check if a prepared statement had to be rebound because of a catalog change. However, because of the new lazy transactions, we did not yet open a transaction at that point. This could cause a problem if a different client would make a catalog modification - as we could (incorrectly) conclude that we could re-use the prepared statement plan, but actually run into an issue where the table(s) we were planning to read were already destroyed at that point. Opening a transaction prior to doing this check ensures the tables we are planning to read are kept alive even if another connection drops them in the mean-time.

This PR also addresses another issue where we would call `ModifyCatalog` only when modifying the catalog. However, we actually also need to call it when *committing* a modification to the catalog since that is when the change actually becomes visible to other transactions.