### PR TITLE
CLI - Insert spaces when copy-pasting tabs

### DIFF
--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -1116,6 +1116,10 @@ int Linenoise::Edit() {
 		if (c == TAB && completionCallback != NULL) {
 			if (has_more_data) {
 				// if there is more data, this tab character was added as part of copy-pasting data
+				// instead insert some spaces
+				if (EditInsertMulti("    ")) {
+					return -1;
+				}
 				continue;
 			}
 			c = CompleteLine(current_sequence);


### PR DESCRIPTION
Currently when copy-pasting a query containing tabs we swallow the tabs. This is an improvement over triggering auto-complete for the tab but it messes up the formatting. This PR makes it so that we add 4 spaces to the buffer per tab instead so we maintain the original formatting.