### PR TITLE
Set duckdb_api to 'python jupyter' if in Jupyter notebook

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1574,7 +1574,11 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const string &databas
 	config.AddExtensionOption("pandas_analyze_sample",
 	                          "The maximum number of rows to sample when analyzing a pandas object column.",
 	                          LogicalType::UBIGINT, Value::UBIGINT(1000));
-	config_dict["duckdb_api"] = Value("python");
+	if (!DuckDBPyConnection::IsJupyter()) {
+		config_dict["duckdb_api"] = Value("python");
+	} else {
+		config_dict["duckdb_api"] = Value("python jupyter");
+	}
 	config.SetOptionsByName(config_dict);
 
 	auto res = FetchOrCreateInstance(database, config);


### PR DESCRIPTION
When running in a Jupyter Notebook, the `std::cout` buffer from `duckdb` doesn't get flushed until the end of the call (see e.g. https://stackoverflow.com/questions/46068321/jupyter-notebook-does-not-show-c-output-cout or 
 https://github.com/googlecolab/colabtools/issues/197). This can cause issues with interactive prompts, for instance, with the OAuth flow for the `motherduck` extension.
This PR adds `jupyter` to the `duckdb_api` when calling `duckdb` from Jupyter and will allow us to disable OAuth temporarily on the extension side until we find a fix or workaround for the Jupyter behavior.

Todo:
-  [ ] Add tests