### PR TITLE
Correctly visit all expressions during lateral join decorrelation, particularly with nested lateral joins

### DIFF
--- a/src/include/duckdb/execution/column_binding_resolver.hpp
+++ b/src/include/duckdb/execution/column_binding_resolver.hpp
@@ -19,13 +19,14 @@ namespace duckdb {
 //! are used within the execution engine
 class ColumnBindingResolver : public LogicalOperatorVisitor {
 public:
-	ColumnBindingResolver();
+	ColumnBindingResolver(bool verify_only = false);
 
 	void VisitOperator(LogicalOperator &op) override;
 	static void Verify(LogicalOperator &op);
 
 protected:
 	vector<ColumnBinding> bindings;
+	bool verify_only;
 
 	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 	static unordered_set<idx_t> VerifyInternal(LogicalOperator &op);

--- a/src/include/duckdb/planner/expression_iterator.hpp
+++ b/src/include/duckdb/planner/expression_iterator.hpp
@@ -27,10 +27,18 @@ public:
 
 	static void EnumerateExpression(unique_ptr<Expression> &expr,
 	                                const std::function<void(Expression &child)> &callback);
+};
 
-	static void EnumerateTableRefChildren(BoundTableRef &ref, const std::function<void(Expression &child)> &callback);
-	static void EnumerateQueryNodeChildren(BoundQueryNode &node,
-	                                       const std::function<void(Expression &child)> &callback);
+class BoundNodeVisitor {
+public:
+	virtual void VisitBoundQueryNode(BoundQueryNode &op);
+	virtual void VisitBoundTableRef(BoundTableRef &ref);
+	virtual void VisitExpression(unique_ptr<Expression> &expression);
+
+protected:
+	// The VisitExpressionChildren method is called at the end of every call to VisitExpression to recursively visit all
+	// expressions in an expression tree. It can be overloaded to prevent automatically visiting the entire tree.
+	virtual void VisitExpressionChildren(Expression &expression);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/subquery/rewrite_correlated_expressions.hpp
+++ b/src/include/duckdb/planner/subquery/rewrite_correlated_expressions.hpp
@@ -27,21 +27,6 @@ protected:
 	unique_ptr<Expression> VisitReplace(BoundSubqueryExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 
 private:
-	//! Helper class used to recursively rewrite correlated expressions within nested subqueries.
-	class RewriteCorrelatedRecursive {
-	public:
-		RewriteCorrelatedRecursive(BoundSubqueryExpression &parent, ColumnBinding base_binding,
-		                           column_binding_map_t<idx_t> &correlated_map);
-		void RewriteJoinRefRecursive(BoundTableRef &ref);
-		void RewriteCorrelatedSubquery(BoundSubqueryExpression &expr);
-		void RewriteCorrelatedExpressions(Expression &child);
-
-		BoundSubqueryExpression &parent;
-		ColumnBinding base_binding;
-		column_binding_map_t<idx_t> &correlated_map;
-	};
-
-private:
 	ColumnBinding base_binding;
 	column_binding_map_t<idx_t> &correlated_map;
 	// To keep track of the number of dependent joins encountered

--- a/src/planner/expression_binder/lateral_binder.cpp
+++ b/src/planner/expression_binder/lateral_binder.cpp
@@ -88,7 +88,8 @@ static void ReduceExpressionSubquery(BoundSubqueryExpression &expr,
 
 class ExpressionDepthReducerRecursive : public BoundNodeVisitor {
 public:
-	ExpressionDepthReducerRecursive(const vector<CorrelatedColumnInfo> &correlated) : correlated_columns(correlated) {
+	explicit ExpressionDepthReducerRecursive(const vector<CorrelatedColumnInfo> &correlated)
+	    : correlated_columns(correlated) {
 	}
 
 	void VisitExpression(unique_ptr<Expression> &expression) override {

--- a/src/planner/expression_binder/lateral_binder.cpp
+++ b/src/planner/expression_binder/lateral_binder.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/planner/logical_operator_visitor.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_subquery_expression.hpp"
+#include "duckdb/planner/tableref/bound_joinref.hpp"
 
 namespace duckdb {
 
@@ -53,59 +54,81 @@ string LateralBinder::UnsupportedAggregateMessage() {
 	return "LATERAL join cannot contain aggregates!";
 }
 
+static void ReduceColumnRefDepth(BoundColumnRefExpression &expr,
+                                 const vector<CorrelatedColumnInfo> &correlated_columns) {
+	// don't need to reduce this
+	if (expr.depth == 0) {
+		return;
+	}
+	for (auto &correlated : correlated_columns) {
+		if (correlated.binding == expr.binding) {
+			D_ASSERT(expr.depth > 1);
+			expr.depth--;
+			break;
+		}
+	}
+}
+
+static void ReduceColumnDepth(vector<CorrelatedColumnInfo> &columns,
+                              const vector<CorrelatedColumnInfo> &affected_columns) {
+	for (auto &s_correlated : columns) {
+		for (auto &affected : affected_columns) {
+			if (affected == s_correlated) {
+				s_correlated.depth--;
+				break;
+			}
+		}
+	}
+}
+
+static void ReduceExpressionSubquery(BoundSubqueryExpression &expr,
+                                     const vector<CorrelatedColumnInfo> &correlated_columns) {
+	ReduceColumnDepth(expr.binder->correlated_columns, correlated_columns);
+}
+
+class ExpressionDepthReducerRecursive : public BoundNodeVisitor {
+public:
+	ExpressionDepthReducerRecursive(const vector<CorrelatedColumnInfo> &correlated) : correlated_columns(correlated) {
+	}
+
+	void VisitExpression(unique_ptr<Expression> &expression) override {
+		if (expression->type == ExpressionType::BOUND_COLUMN_REF) {
+			ReduceColumnRefDepth(expression->Cast<BoundColumnRefExpression>(), correlated_columns);
+		} else if (expression->type == ExpressionType::SUBQUERY) {
+			ReduceExpressionSubquery(expression->Cast<BoundSubqueryExpression>(), correlated_columns);
+		}
+		BoundNodeVisitor::VisitExpression(expression);
+	}
+
+	void VisitBoundTableRef(BoundTableRef &ref) override {
+		if (ref.type == TableReferenceType::JOIN) {
+			// rewrite correlated columns in child joins
+			auto &bound_join = ref.Cast<BoundJoinRef>();
+			ReduceColumnDepth(bound_join.correlated_columns, correlated_columns);
+		}
+		// visit the children of the table ref
+		BoundNodeVisitor::VisitBoundTableRef(ref);
+	}
+
+private:
+	const vector<CorrelatedColumnInfo> &correlated_columns;
+};
+
 class ExpressionDepthReducer : public LogicalOperatorVisitor {
 public:
 	explicit ExpressionDepthReducer(const vector<CorrelatedColumnInfo> &correlated) : correlated_columns(correlated) {
 	}
 
 protected:
-	void ReduceColumnRefDepth(BoundColumnRefExpression &expr) {
-		// don't need to reduce this
-		if (expr.depth == 0) {
-			return;
-		}
-		for (auto &correlated : correlated_columns) {
-			if (correlated.binding == expr.binding) {
-				D_ASSERT(expr.depth > 1);
-				expr.depth--;
-				break;
-			}
-		}
-	}
-
 	unique_ptr<Expression> VisitReplace(BoundColumnRefExpression &expr, unique_ptr<Expression> *expr_ptr) override {
-		ReduceColumnRefDepth(expr);
+		ReduceColumnRefDepth(expr, correlated_columns);
 		return nullptr;
 	}
 
-	void ReduceExpressionSubquery(BoundSubqueryExpression &expr) {
-		for (auto &s_correlated : expr.binder->correlated_columns) {
-			for (auto &correlated : correlated_columns) {
-				if (correlated == s_correlated) {
-					s_correlated.depth--;
-					break;
-				}
-			}
-		}
-	}
-
-	void ReduceExpressionDepth(Expression &expr) {
-		if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
-			ReduceColumnRefDepth(expr.Cast<BoundColumnRefExpression>());
-		}
-		if (expr.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY) {
-			auto &subquery_ref = expr.Cast<BoundSubqueryExpression>();
-			ReduceExpressionSubquery(expr.Cast<BoundSubqueryExpression>());
-			// Recursively update the depth in the bindings of the children nodes
-			ExpressionIterator::EnumerateQueryNodeChildren(
-			    *subquery_ref.subquery, [&](Expression &child_expr) { ReduceExpressionDepth(child_expr); });
-		}
-	}
-
 	unique_ptr<Expression> VisitReplace(BoundSubqueryExpression &expr, unique_ptr<Expression> *expr_ptr) override {
-		ReduceExpressionSubquery(expr);
-		ExpressionIterator::EnumerateQueryNodeChildren(
-		    *expr.subquery, [&](Expression &child_expr) { ReduceExpressionDepth(child_expr); });
+		ReduceExpressionSubquery(expr, correlated_columns);
+		ExpressionDepthReducerRecursive recursive(correlated_columns);
+		recursive.VisitBoundQueryNode(*expr.subquery);
 		return nullptr;
 	}
 

--- a/src/planner/expression_iterator.cpp
+++ b/src/planner/expression_iterator.cpp
@@ -148,86 +148,61 @@ void ExpressionIterator::EnumerateExpression(unique_ptr<Expression> &expr,
 	                                      [&](unique_ptr<Expression> &child) { EnumerateExpression(child, callback); });
 }
 
-void ExpressionIterator::EnumerateTableRefChildren(BoundTableRef &ref,
-                                                   const std::function<void(Expression &child)> &callback) {
-	switch (ref.type) {
-	case TableReferenceType::EXPRESSION_LIST: {
-		auto &bound_expr_list = ref.Cast<BoundExpressionListRef>();
-		for (auto &expr_list : bound_expr_list.values) {
-			for (auto &expr : expr_list) {
-				EnumerateExpression(expr, callback);
-			}
-		}
-		break;
-	}
-	case TableReferenceType::JOIN: {
-		auto &bound_join = ref.Cast<BoundJoinRef>();
-		if (bound_join.condition) {
-			EnumerateExpression(bound_join.condition, callback);
-		}
-		EnumerateTableRefChildren(*bound_join.left, callback);
-		EnumerateTableRefChildren(*bound_join.right, callback);
-		break;
-	}
-	case TableReferenceType::SUBQUERY: {
-		auto &bound_subquery = ref.Cast<BoundSubqueryRef>();
-		EnumerateQueryNodeChildren(*bound_subquery.subquery, callback);
-		break;
-	}
-	case TableReferenceType::TABLE_FUNCTION:
-	case TableReferenceType::EMPTY_FROM:
-	case TableReferenceType::BASE_TABLE:
-	case TableReferenceType::CTE:
-		break;
-	default:
-		throw NotImplementedException("Unimplemented table reference type in ExpressionIterator");
-	}
+void BoundNodeVisitor::VisitExpression(unique_ptr<Expression> &expression) {
+	VisitExpressionChildren(*expression);
 }
 
-void ExpressionIterator::EnumerateQueryNodeChildren(BoundQueryNode &node,
-                                                    const std::function<void(Expression &child)> &callback) {
+void BoundNodeVisitor::VisitExpressionChildren(Expression &expr) {
+	ExpressionIterator::EnumerateChildren(expr, [&](unique_ptr<Expression> &expr) { VisitExpression(expr); });
+}
+
+void BoundNodeVisitor::VisitBoundQueryNode(BoundQueryNode &node) {
 	switch (node.type) {
 	case QueryNodeType::SET_OPERATION_NODE: {
 		auto &bound_setop = node.Cast<BoundSetOperationNode>();
-		EnumerateQueryNodeChildren(*bound_setop.left, callback);
-		EnumerateQueryNodeChildren(*bound_setop.right, callback);
+		VisitBoundQueryNode(*bound_setop.left);
+		VisitBoundQueryNode(*bound_setop.right);
 		break;
 	}
 	case QueryNodeType::RECURSIVE_CTE_NODE: {
 		auto &cte_node = node.Cast<BoundRecursiveCTENode>();
-		EnumerateQueryNodeChildren(*cte_node.left, callback);
-		EnumerateQueryNodeChildren(*cte_node.right, callback);
+		VisitBoundQueryNode(*cte_node.left);
+		VisitBoundQueryNode(*cte_node.right);
 		break;
 	}
 	case QueryNodeType::CTE_NODE: {
 		auto &cte_node = node.Cast<BoundCTENode>();
-		EnumerateQueryNodeChildren(*cte_node.child, callback);
-		EnumerateQueryNodeChildren(*cte_node.query, callback);
+		VisitBoundQueryNode(*cte_node.child);
+		VisitBoundQueryNode(*cte_node.query);
 		break;
 	}
 	case QueryNodeType::SELECT_NODE: {
 		auto &bound_select = node.Cast<BoundSelectNode>();
 		for (auto &expr : bound_select.select_list) {
-			EnumerateExpression(expr, callback);
+			VisitExpression(expr);
 		}
-		EnumerateExpression(bound_select.where_clause, callback);
+		if (bound_select.where_clause) {
+			VisitExpression(bound_select.where_clause);
+		}
 		for (auto &expr : bound_select.groups.group_expressions) {
-			EnumerateExpression(expr, callback);
+			VisitExpression(expr);
 		}
-		EnumerateExpression(bound_select.having, callback);
+		if (bound_select.having) {
+			VisitExpression(bound_select.having);
+		}
 		for (auto &expr : bound_select.aggregates) {
-			EnumerateExpression(expr, callback);
+			VisitExpression(expr);
 		}
 		for (auto &entry : bound_select.unnests) {
 			for (auto &expr : entry.second.expressions) {
-				EnumerateExpression(expr, callback);
+				VisitExpression(expr);
 			}
 		}
 		for (auto &expr : bound_select.windows) {
-			EnumerateExpression(expr, callback);
+			VisitExpression(expr);
 		}
 		if (bound_select.from_table) {
-			EnumerateTableRefChildren(*bound_select.from_table, callback);
+			VisitBoundTableRef(*bound_select.from_table);
 		}
 		break;
 	}
@@ -238,17 +213,63 @@ void ExpressionIterator::EnumerateQueryNodeChildren(BoundQueryNode &node,
 		switch (node.modifiers[i]->type) {
 		case ResultModifierType::DISTINCT_MODIFIER:
 			for (auto &expr : node.modifiers[i]->Cast<BoundDistinctModifier>().target_distincts) {
-				EnumerateExpression(expr, callback);
+				VisitExpression(expr);
 			}
 			break;
 		case ResultModifierType::ORDER_MODIFIER:
 			for (auto &order : node.modifiers[i]->Cast<BoundOrderModifier>().orders) {
-				EnumerateExpression(order.expression, callback);
+				VisitExpression(order.expression);
 			}
 			break;
+		case ResultModifierType::LIMIT_MODIFIER: {
+			auto &limit_expr = node.modifiers[i]->Cast<BoundLimitModifier>().limit_val.GetExpression();
+			auto &offset_expr = node.modifiers[i]->Cast<BoundLimitModifier>().offset_val.GetExpression();
+			if (limit_expr) {
+				VisitExpression(limit_expr);
+			}
+			if (offset_expr) {
+				VisitExpression(offset_expr);
+			}
+			break;
+		}
 		default:
 			break;
 		}
+	}
+}
+
+void BoundNodeVisitor::VisitBoundTableRef(BoundTableRef &ref) {
+	switch (ref.type) {
+	case TableReferenceType::EXPRESSION_LIST: {
+		auto &bound_expr_list = ref.Cast<BoundExpressionListRef>();
+		for (auto &expr_list : bound_expr_list.values) {
+			for (auto &expr : expr_list) {
+				VisitExpression(expr);
+			}
+		}
+		break;
+	}
+	case TableReferenceType::JOIN: {
+		auto &bound_join = ref.Cast<BoundJoinRef>();
+		if (bound_join.condition) {
+			VisitExpression(bound_join.condition);
+		}
+		VisitBoundTableRef(*bound_join.left);
+		VisitBoundTableRef(*bound_join.right);
+		break;
+	}
+	case TableReferenceType::SUBQUERY: {
+		auto &bound_subquery = ref.Cast<BoundSubqueryRef>();
+		VisitBoundQueryNode(*bound_subquery.subquery);
+		break;
+	}
+	case TableReferenceType::TABLE_FUNCTION:
+	case TableReferenceType::EMPTY_FROM:
+	case TableReferenceType::BASE_TABLE:
+	case TableReferenceType::CTE:
+		break;
+	default:
+		throw NotImplementedException("Unimplemented table reference type in ExpressionIterator");
 	}
 }
 

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
+#include "duckdb/execution/column_binding_resolver.hpp"
 
 namespace duckdb {
 
@@ -166,6 +167,8 @@ void Planner::VerifyPlan(ClientContext &context, unique_ptr<LogicalOperator> &op
 	if (!OperatorSupportsSerialization(*op)) {
 		return;
 	}
+	// verify the column bindings of the plan
+	ColumnBindingResolver::Verify(*op);
 
 	// format (de)serialization of this operator
 	try {

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/subquery/rewrite_correlated_expressions.hpp"
 #include "duckdb/planner/subquery/rewrite_cte_scan.hpp"
 #include "duckdb/planner/operator/logical_dependent_join.hpp"
+#include "duckdb/execution/column_binding_resolver.hpp"
 
 namespace duckdb {
 

--- a/src/planner/subquery/rewrite_correlated_expressions.cpp
+++ b/src/planner/subquery/rewrite_correlated_expressions.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/tableref/bound_joinref.hpp"
 #include "duckdb/planner/operator/logical_dependent_join.hpp"
+#include "duckdb/planner/tableref/bound_subqueryref.hpp"
 
 namespace duckdb {
 
@@ -69,6 +70,20 @@ unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundColumnRef
 	return nullptr;
 }
 
+//! Helper class used to recursively rewrite correlated expressions within nested subqueries.
+class RewriteCorrelatedRecursive : public BoundNodeVisitor {
+public:
+	RewriteCorrelatedRecursive(ColumnBinding base_binding, column_binding_map_t<idx_t> &correlated_map);
+
+	void VisitBoundTableRef(BoundTableRef &ref) override;
+	void VisitExpression(unique_ptr<Expression> &expression) override;
+
+	void RewriteCorrelatedSubquery(Binder &binder, BoundQueryNode &subquery);
+
+	ColumnBinding base_binding;
+	column_binding_map_t<idx_t> &correlated_map;
+};
+
 unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundSubqueryExpression &expr,
                                                                   unique_ptr<Expression> *expr_ptr) {
 	if (!expr.IsCorrelated()) {
@@ -76,19 +91,19 @@ unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundSubqueryE
 	}
 	// subquery detected within this subquery
 	// recursively rewrite it using the RewriteCorrelatedRecursive class
-	RewriteCorrelatedRecursive rewrite(expr, base_binding, correlated_map);
-	rewrite.RewriteCorrelatedSubquery(expr);
+	RewriteCorrelatedRecursive rewrite(base_binding, correlated_map);
+	rewrite.RewriteCorrelatedSubquery(*expr.binder, *expr.subquery);
 	return nullptr;
 }
 
-RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelatedRecursive(
-    BoundSubqueryExpression &parent, ColumnBinding base_binding, column_binding_map_t<idx_t> &correlated_map)
-    : parent(parent), base_binding(base_binding), correlated_map(correlated_map) {
+RewriteCorrelatedRecursive::RewriteCorrelatedRecursive(ColumnBinding base_binding,
+                                                       column_binding_map_t<idx_t> &correlated_map)
+    : base_binding(base_binding), correlated_map(correlated_map) {
 }
 
-void RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteJoinRefRecursive(BoundTableRef &ref) {
-	// recursively rewrite bindings in the correlated columns for the table ref and all the children
+void RewriteCorrelatedRecursive::VisitBoundTableRef(BoundTableRef &ref) {
 	if (ref.type == TableReferenceType::JOIN) {
+		// rewrite correlated columns in child joins
 		auto &bound_join = ref.Cast<BoundJoinRef>();
 		for (auto &corr : bound_join.correlated_columns) {
 			auto entry = correlated_map.find(corr.binding);
@@ -96,39 +111,26 @@ void RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteJoinRefRec
 				corr.binding = ColumnBinding(base_binding.table_index, base_binding.column_index + entry->second);
 			}
 		}
-		RewriteJoinRefRecursive(*bound_join.left);
-		RewriteJoinRefRecursive(*bound_join.right);
 	}
+	// visit the children of the table ref
+	BoundNodeVisitor::VisitBoundTableRef(ref);
 }
 
-void RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelatedSubquery(
-    BoundSubqueryExpression &expr) {
+void RewriteCorrelatedRecursive::RewriteCorrelatedSubquery(Binder &binder, BoundQueryNode &subquery) {
 	// rewrite the binding in the correlated list of the subquery)
-	for (auto &corr : expr.binder->correlated_columns) {
+	for (auto &corr : binder.correlated_columns) {
 		auto entry = correlated_map.find(corr.binding);
 		if (entry != correlated_map.end()) {
 			corr.binding = ColumnBinding(base_binding.table_index, base_binding.column_index + entry->second);
 		}
 	}
-	// TODO: Cleanup and find a better way to do this
-	auto &node = *expr.subquery;
-	if (node.type == QueryNodeType::SELECT_NODE) {
-		// Found an unplanned select node, need to update column bindings correlated columns in the from tables
-		auto &bound_select = node.Cast<BoundSelectNode>();
-		if (bound_select.from_table) {
-			BoundTableRef &table_ref = *bound_select.from_table;
-			RewriteJoinRefRecursive(table_ref);
-		}
-	}
-	// now rewrite any correlated BoundColumnRef expressions inside the subquery
-	ExpressionIterator::EnumerateQueryNodeChildren(*expr.subquery,
-	                                               [&](Expression &child) { RewriteCorrelatedExpressions(child); });
+	VisitBoundQueryNode(subquery);
 }
 
-void RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelatedExpressions(Expression &child) {
-	if (child.type == ExpressionType::BOUND_COLUMN_REF) {
+void RewriteCorrelatedRecursive::VisitExpression(unique_ptr<Expression> &expression) {
+	if (expression->type == ExpressionType::BOUND_COLUMN_REF) {
 		// bound column reference
-		auto &bound_colref = child.Cast<BoundColumnRefExpression>();
+		auto &bound_colref = expression->Cast<BoundColumnRefExpression>();
 		if (bound_colref.depth == 0) {
 			// not a correlated column, ignore
 			return;
@@ -142,13 +144,15 @@ void RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelated
 			bound_colref.binding = ColumnBinding(base_binding.table_index, base_binding.column_index + entry->second);
 			bound_colref.depth--;
 		}
-	} else if (child.type == ExpressionType::SUBQUERY) {
+	} else if (expression->type == ExpressionType::SUBQUERY) {
 		// we encountered another subquery: rewrite recursively
-		D_ASSERT(child.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY);
-		auto &bound_subquery = child.Cast<BoundSubqueryExpression>();
-		RewriteCorrelatedRecursive rewrite(bound_subquery, base_binding, correlated_map);
-		rewrite.RewriteCorrelatedSubquery(bound_subquery);
+		auto &bound_subquery = expression->Cast<BoundSubqueryExpression>();
+		RewriteCorrelatedRecursive rewrite(base_binding, correlated_map);
+		rewrite.RewriteCorrelatedSubquery(*bound_subquery.binder, *bound_subquery.subquery);
+		return;
 	}
+	// recurse into the children of this subquery
+	BoundNodeVisitor::VisitExpression(expression);
 }
 
 RewriteCountAggregates::RewriteCountAggregates(column_binding_map_t<idx_t> &replacement_map)

--- a/test/fuzzer/sqlsmith/nested_correlated_subquery.test
+++ b/test/fuzzer/sqlsmith/nested_correlated_subquery.test
@@ -1,0 +1,52 @@
+# name: test/fuzzer/sqlsmith/nested_correlated_subquery.test
+# description: Test nested correlated subquery
+# group: [sqlsmith]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t(ps_supplycost INT, n_name INT);
+
+statement ok
+SELECT NULL
+FROM
+    t AS ref_2,
+    (SELECT (SELECT NULL
+         FROM (FROM t AS ref_5,
+              (SELECT ref_2.n_name AS c1))));
+
+query I
+SELECT NULL
+FROM
+    t AS ref_2,
+    (SELECT (SELECT NULL
+         FROM (FROM t AS ref_5,
+              (SELECT ref_5.ps_supplycost AS c0,
+                      ref_2.n_name AS c1))));
+----
+
+# postgres compatible with explicit LATERAL annotations
+query I
+SELECT NULL
+FROM
+    t AS ref_2,
+    LATERAL (SELECT (SELECT NULL
+         FROM (SELECT * FROM t AS ref_5,
+              LATERAL (SELECT ref_5.ps_supplycost AS c0,
+                      ref_2.n_name AS c1) AS alias1) AS alias2) AS alias3) AS alias4;
+----
+
+statement ok
+INSERT INTO t VALUES (1, 100);
+
+query III
+SELECT *
+FROM
+    t AS ref_2,
+    LATERAL (SELECT (SELECT NULL
+         FROM (SELECT * FROM t AS ref_5,
+              LATERAL (SELECT ref_5.ps_supplycost AS c0,
+                      ref_2.n_name AS c1) AS alias1) AS alias2) AS alias3) AS alias4;
+----
+1	100	NULL


### PR DESCRIPTION
This PR fixes `Failed to bind column reference` errors that could pop-up or `colref.depth == 0` assertions that could trigger when dealing with nested (lateral) joins. The core of the issue is that we were not correctly recursively visiting subqueries when doing the layered unnesting. We would visit joins one level deep, but not multiple levels deep, resulting in queries that could trigger this error. For example:

```sql
CREATE TABLE t(ps_supplycost INT, n_name INT);
SELECT NULL
  FROM
      t AS ref_2,
      (SELECT (SELECT NULL
           FROM (FROM t AS ref_5,
                (SELECT ref_5.ps_supplycost AS c0,
                        ref_2.n_name AS c1))));
```

This query has a have a lateral join nested inside other lateral joins, and the previous code would not correctly decorrelate those expressions.

This PR introduces a `BoundNodeVisitor` that deals with the recursive visiting, this time correctly, fixing the issue and making the above query run correctly.