### PR TITLE
Avoid throwing null pointer exception in Window Segment Tree destructor

### DIFF
--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -616,7 +616,7 @@ void WindowSegmentTree::Finalize(const FrameStats &stats) {
 }
 
 WindowSegmentTree::~WindowSegmentTree() {
-	if (!aggr.function.destructor) {
+	if (!aggr.function.destructor || !gstate) {
 		// nothing to destroy
 		return;
 	}

--- a/test/fuzzer/sqlsmith/window_function_error.test
+++ b/test/fuzzer/sqlsmith/window_function_error.test
@@ -1,0 +1,14 @@
+# name: test/fuzzer/sqlsmith/window_function_error.test
+# description: Correctly handle errors in window expressions
+# group: [sqlsmith]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE tbl AS SELECT 'thisisastring42' AS r_name;
+
+statement error
+SELECT max(CAST(from_hex(CAST(ref_0.r_name AS VARCHAR)) AS BLOB)) OVER (ORDER BY ref_0.r_name) AS c5,
+FROM tbl AS ref_0
+----


### PR DESCRIPTION
This PR fixes an issue where if an error was thrown in a window function expression with an aggregate that has a destructor, before the actual window operation was initiated, we would throw a null pointer dereference exception.