### PR TITLE
Avoid running numeric cast checks when CRASH_ON_ASSERT is enabled

### DIFF
--- a/test/common/test_numeric_cast.cpp
+++ b/test/common/test_numeric_cast.cpp
@@ -6,7 +6,9 @@ using namespace duckdb;
 using namespace std;
 
 TEST_CASE("Numeric cast checks", "[numeric_cast]") {
-
+#ifdef DUCKDB_CRASH_ON_ASSERT
+	return;
+#endif
 	// unsigned-unsiged
 	// can not fail upcasting unsigned type
 	REQUIRE_NOTHROW(NumericCast<uint16_t, uint8_t>(NumericLimits<uint8_t>::Maximum()));


### PR DESCRIPTION
These tests explicitly trigger internal exceptions - `CRASH_ON_ASSERT` turns internal exceptions into program aborts, preventing us from running the test suite.