### PR TITLE
Support recursive describe queries (i.e. DESCRIBE(DESCRIBE ..))

### DIFF
--- a/src/parser/tableref/showref.cpp
+++ b/src/parser/tableref/showref.cpp
@@ -13,7 +13,9 @@ string ShowRef::ToString() const {
 		result += "DESCRIBE ";
 	}
 	if (query) {
+		result += "(";
 		result += query->ToString();
+		result += ")";
 	} else if (table_name != "__show_tables_expanded") {
 		result += table_name;
 	}

--- a/src/parser/transform/statement/transform_show_select.cpp
+++ b/src/parser/transform/statement/transform_show_select.cpp
@@ -9,14 +9,13 @@ namespace duckdb {
 
 unique_ptr<SelectStatement> Transformer::TransformShowSelect(duckdb_libpgquery::PGVariableShowSelectStmt &stmt) {
 	// we capture the select statement of SHOW
-	auto select_stmt = PGPointerCast<duckdb_libpgquery::PGSelectStmt>(stmt.stmt);
-
 	auto select_node = make_uniq<SelectNode>();
 	select_node->select_list.push_back(make_uniq<StarExpression>());
 
 	auto show_ref = make_uniq<ShowRef>();
 	show_ref->show_type = stmt.is_summary ? ShowType::SUMMARY : ShowType::DESCRIBE;
-	show_ref->query = TransformSelectNode(*select_stmt);
+	auto select = TransformSelect(stmt.stmt);
+	show_ref->query = std::move(select->node);
 	select_node->from_table = std::move(show_ref);
 
 	auto result = make_uniq<SelectStatement>();

--- a/test/sql/show_select/describe_subquery.test
+++ b/test/sql/show_select/describe_subquery.test
@@ -28,3 +28,13 @@ a
 
 statement ok
 FROM (SHOW databases) t
+
+query I
+SELECT column_name FROM (DESCRIBE ( DESCRIBE SELECT * FROM (SELECT 32 as a)));
+----
+column_name
+column_type
+null
+key
+default
+extra


### PR DESCRIPTION
This is not particularly useful, but it should work instead of throwing a cryptic error.

```sql
D DESCRIBE (DESCRIBE SELECT 42);
┌─────────────┬─────────────┬─────────┬─────────┬─────────┬─────────┐
│ column_name │ column_type │  null   │   key   │ default │  extra  │
│   varchar   │   varchar   │ varchar │ varchar │ varchar │ varchar │
├─────────────┼─────────────┼─────────┼─────────┼─────────┼─────────┤
│ column_name │ VARCHAR     │ YES     │ NULL    │ NULL    │ NULL    │
│ column_type │ VARCHAR     │ YES     │ NULL    │ NULL    │ NULL    │
│ null        │ VARCHAR     │ YES     │ NULL    │ NULL    │ NULL    │
│ key         │ VARCHAR     │ YES     │ NULL    │ NULL    │ NULL    │
│ default     │ VARCHAR     │ YES     │ NULL    │ NULL    │ NULL    │
│ extra       │ VARCHAR     │ YES     │ NULL    │ NULL    │ NULL    │
└─────────────┴─────────────┴─────────┴─────────┴─────────┴─────────┘

```