### PR TITLE
Fix for limit % with subquery on an empty table

### DIFF
--- a/src/execution/operator/helper/physical_limit_percent.cpp
+++ b/src/execution/operator/helper/physical_limit_percent.cpp
@@ -126,7 +126,13 @@ SourceResultType PhysicalLimitPercent::GetData(ExecutionContext &context, DataCh
 	auto &limit = state.limit;
 	auto &current_offset = state.current_offset;
 
-	if (gstate.is_limit_set && !limit.IsValid()) {
+	if (!limit.IsValid()) {
+		if (!gstate.is_limit_set) {
+			// no limit value and we have not set limit_percent
+			// we are running LIMIT % with a subquery over an empty table
+			D_ASSERT(gstate.data.Count() == 0);
+			return SourceResultType::FINISHED;
+		}
 		idx_t count = gstate.data.Count();
 		if (count > 0) {
 			count += offset.GetIndex();

--- a/test/fuzzer/duckfuzz/limit_percent_subquery.test
+++ b/test/fuzzer/duckfuzz/limit_percent_subquery.test
@@ -1,0 +1,21 @@
+# name: test/fuzzer/duckfuzz/limit_percent_subquery.test
+# description: Limit percent subquery
+# group: [duckfuzz]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table tbl(i INT);
+
+query I
+FROM tbl LIMIT (EXISTS(SELECT 42))%
+----
+
+statement ok
+INSERT INTO tbl VALUES (42);
+
+query I
+FROM tbl LIMIT (EXISTS(SELECT 42))%
+----
+


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/duckdb/duckdb/pull/10873