### PR TITLE
when you add the relation, make sure you call gettableIndexes() on th…

### DIFF
--- a/src/include/duckdb/optimizer/join_order/relation_manager.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_manager.hpp
@@ -55,7 +55,8 @@ public:
 	bool ExtractBindings(Expression &expression, unordered_set<idx_t> &bindings);
 	void AddRelation(LogicalOperator &op, optional_ptr<LogicalOperator> parent, const RelationStats &stats);
 
-	void AddAggregateRelation(LogicalOperator &op, optional_ptr<LogicalOperator> parent, const RelationStats &stats);
+	void AddAggregateOrWindowRelation(LogicalOperator &op, optional_ptr<LogicalOperator> parent,
+	                                  const RelationStats &stats, LogicalOperatorType op_type);
 	vector<unique_ptr<SingleJoinRelation>> GetRelations();
 
 	const vector<RelationStats> GetRelationStats();

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -15,7 +15,7 @@
 namespace duckdb {
 
 #ifdef DEBUG
-bool DBConfigOptions::debug_print_bindings = false;
+bool DBConfigOptions::debug_print_bindings = true;
 #endif
 
 #define DUCKDB_GLOBAL(_PARAM)                                                                                          \

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -15,7 +15,7 @@
 namespace duckdb {
 
 #ifdef DEBUG
-bool DBConfigOptions::debug_print_bindings = true;
+bool DBConfigOptions::debug_print_bindings = false;
 #endif
 
 #define DUCKDB_GLOBAL(_PARAM)                                                                                          \

--- a/test/optimizer/joins/filter_on_subquery_with_aggregate.test
+++ b/test/optimizer/joins/filter_on_subquery_with_aggregate.test
@@ -1,0 +1,19 @@
+# name: test/optimizer/joins/filter_on_subquery_with_aggregate.test
+# description: some fuzzer issues
+# group: [joins]
+
+statement ok
+create table df as select unnest(range(1, 10)) as A, unnest(range(1, 10)) as B;
+
+query II
+WITH cte AS (
+    SELECT A, B
+    FROM df
+    WHERE A >= 7
+)
+SELECT *
+FROM cte
+WHERE A = (SELECT MAX(A) FROM cte);
+----
+9	9
+


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-fuzzer/issues/1318
Fixes https://github.com/duckdblabs/duckdb-internal/issues/918

Basically, there's a weird case where we attempt to add the child relations of a hash join, but a child has a filter on top of it. We attempt to add the filter as the relation, but the filter doesn't have table indexes, so we get this error. 

Thinking about more tests though.

