### PR TITLE
improve CheckBoundaryValues in TopN

### DIFF
--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -370,17 +370,12 @@ bool TopNHeap::CheckBoundaryValues(DataChunk &sort_chunk, DataChunk &payload) {
 			final_count += true_count;
 		}
 		idx_t false_count = remaining_count - true_count;
-		if (false_count > 0) {
+		if (!is_last && false_count > 0) {
 			// check what we should continue to check
 			compare_chunk.data[i].Slice(sort_chunk.data[i], false_sel, false_count);
 			remaining_count = VectorOperations::NotDistinctFrom(compare_chunk.data[i], boundary_values.data[i],
 			                                                    &false_sel, false_count, &new_remaining_sel, nullptr);
-			if (is_last) {
-				memcpy(final_sel.data() + final_count, new_remaining_sel.data(), remaining_count * sizeof(sel_t));
-				final_count += remaining_count;
-			} else {
-				remaining_sel.Initialize(new_remaining_sel);
-			}
+			remaining_sel.Initialize(new_remaining_sel);
 		} else {
 			break;
 		}


### PR DESCRIPTION
TopN uses a boundary value to exclude impossible result. Here when `is_last == true`, `VectorOperations::NotDistinctFrom` will select every elements that equals the boundary value, and these elements can be discarded since boundary value is the `limit + offset`-th element so they will be placed after `limit + offset`. 

Original code does skip the last column, but [this commit](https://github.com/duckdb/duckdb/pull/2172/commits/7aecb7f7909946b9ab8f233b4c64af48e6b73677) added check for last column, which is unnecessary. The problem fixed in this commit is that it mistakenly used `sort_chunk` instead of `compare_chunk`.