### PR TITLE
Python.yml: Revert to macos-latest for OSX workflow

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -229,7 +229,7 @@ jobs:
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
       name: Python 3 OSX
-      runs-on: macos-14
+      runs-on: macos-latest
       strategy:
        matrix:
         python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]


### PR DESCRIPTION
Partial revert of #10670, since due to a problem in the tests, potentially connected to pola.rs, the CI run would explode while setting up test infrastructure