### PR TITLE
Range checks for ACOS

### DIFF
--- a/src/core_functions/scalar/math/numeric.cpp
+++ b/src/core_functions/scalar/math/numeric.cpp
@@ -1115,6 +1115,9 @@ ScalarFunction Atan2Fun::GetFunction() {
 struct ACos {
 	template <class TA, class TR>
 	static inline TR Operation(TA input) {
+		if (input < -1 || input > 1) {
+			throw InvalidInputException("ACOS is undefined outside [-1,1]");
+		}
 		return (double)std::acos(input);
 	}
 };

--- a/test/sql/function/numeric/test_invalid_math.test
+++ b/test/sql/function/numeric/test_invalid_math.test
@@ -50,7 +50,7 @@ SELECT EXP(1e300), EXP(1e100)
 ----
 inf	inf
 
-query RRR
-SELECT ACOS(3), ACOS(100), DEGREES(1e308)
+query R
+SELECT DEGREES(1e308)
 ----
-nan	nan	inf
+inf

--- a/test/sql/function/numeric/test_trigo.test
+++ b/test/sql/function/numeric/test_trigo.test
@@ -450,3 +450,10 @@ NULL
 24
 785
 
+statement error
+select asin(-2);
+----
+
+statement error
+select acos(-2);
+----

--- a/test/sql/function/numeric/test_trigo.test
+++ b/test/sql/function/numeric/test_trigo.test
@@ -453,7 +453,9 @@ NULL
 statement error
 select asin(-2);
 ----
+Invalid Input Error: ASIN is undefined outside [-1,1]
 
 statement error
 select acos(-2);
 ----
+Invalid Input Error: ACOS is undefined outside [-1,1]


### PR DESCRIPTION
We already have a range check for ASIN(x) that checks if x is within `[-1,1]`. This PR adds the same check for ACOS which has the same range but silently returned `NaN` before.