### PR TITLE
Fuzzer #1446: Quantile Hugeint Interpolation

### DIFF
--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -21,12 +21,6 @@
 
 namespace duckdb {
 
-// Hugeint arithmetic
-static hugeint_t MultiplyByDouble(const hugeint_t &h, const double &d) {
-	D_ASSERT(d >= 0 && d <= 1);
-	return Hugeint::Convert(Hugeint::Cast<double>(h) * d);
-}
-
 // Interval arithmetic
 static interval_t MultiplyByDouble(const interval_t &i, const double &d) { // NOLINT
 	D_ASSERT(d >= 0 && d <= 1);
@@ -189,8 +183,7 @@ timestamp_t CastInterpolation::Interpolate(const timestamp_t &lo, const double d
 
 template <>
 hugeint_t CastInterpolation::Interpolate(const hugeint_t &lo, const double d, const hugeint_t &hi) {
-	const hugeint_t delta = hi - lo;
-	return lo + MultiplyByDouble(delta, d);
+	return Hugeint::Convert(Interpolate(Hugeint::Cast<double>(lo), d, Hugeint::Cast<double>(hi)));
 }
 
 template <>

--- a/test/fuzzer/sqlsmith/mad_overflow.test
+++ b/test/fuzzer/sqlsmith/mad_overflow.test
@@ -1,0 +1,12 @@
+# name: test/fuzzer/sqlsmith/mad_overflow.test
+# description: Prevent INT128 overflow during interpolation
+# group: [sqlsmith]
+
+statement ok
+create table all_types as 
+	select * exclude(small_enum, medium_enum, large_enum) 
+	from test_all_types();
+
+statement ok
+SELECT mad(dec38_10) 
+FROM all_types;


### PR DESCRIPTION
Interpolate HUGEINT directly as DOUBLEs instead of having multiple round trips that can overflow
or lose accuracy.

fixes: duckdb/duckdb-fuzzer#1446