### PR TITLE
Fuzzer #1468: Window RANGE Types

### DIFF
--- a/test/fuzzer/sqlsmith/window_scalar_range.test
+++ b/test/fuzzer/sqlsmith/window_scalar_range.test
@@ -1,7 +1,8 @@
 # name: test/fuzzer/sqlsmith/window_scalar_range.test
-# description: Test multiple constant chunks
+# description: Test various RANGE types
 # group: [sqlsmith]
 
+# Constant ORDER BY
 statement ok
 CREATE TABLE partsupp AS SELECT (random() * 100)::INT AS c2 
 FROM range(8000);
@@ -11,3 +12,16 @@ SELECT percent_rank()
 	OVER (ORDER BY 7543 ASC NULLS FIRST 
 		  RANGE BETWEEN c2 PRECEDING AND c2 FOLLOWING) 
 FROM partsupp;
+
+# LIST + ARRAY
+statement ok
+create table all_types as 
+	select * exclude(small_enum, medium_enum, large_enum) 
+	from test_all_types();
+
+statement error
+SELECT NULL 
+FROM all_types AS t51(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50) 
+QUALIFY row_number() OVER (ORDER BY main.list_value() ASC NULLS FIRST RANGE BETWEEN c43 FOLLOWING AND UNBOUNDED FOLLOWING)
+----
+Invalid type for Window RANGE expression


### PR DESCRIPTION
Explicitly verify RANGE data types instead of
assuming that +/- function existence will cover it.

fixes: duckdb/duckdb-fuzzer#1468