### PR TITLE
Fix return null constant in array_slice and other array issues

### DIFF
--- a/src/core_functions/scalar/list/array_slice.cpp
+++ b/src/core_functions/scalar/list/array_slice.cpp
@@ -325,8 +325,8 @@ static void ArraySliceFunction(DataChunk &args, ExpressionState &state, Vector &
 	VectorOperations::Copy(args.data[0], list_or_str_vector, count, 0, 0);
 
 	if (list_or_str_vector.GetType().id() == LogicalTypeId::SQLNULL) {
-		auto &result_validity = FlatVector::Validity(result);
-		result_validity.SetInvalid(0);
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
 		return;
 	}
 

--- a/src/core_functions/scalar/list/list_sort.cpp
+++ b/src/core_functions/scalar/list/list_sort.cpp
@@ -305,6 +305,8 @@ static unique_ptr<FunctionData> ListGradeUpBind(ClientContext &context, ScalarFu
 	order = config.ResolveOrder(order);
 	null_order = config.ResolveNullOrder(order, null_order);
 
+	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
+
 	bound_function.arguments[0] = arguments[0]->return_type;
 	bound_function.return_type = LogicalType::LIST(LogicalTypeId::BIGINT);
 	auto child_type = ListType::GetChildType(arguments[0]->return_type);

--- a/src/function/cast/array_casts.cpp
+++ b/src/function/cast/array_casts.cpp
@@ -169,9 +169,7 @@ static bool ArrayToListCast(Vector &source, Vector &result, idx_t count, CastPar
 
 	// FIXME: dont flatten
 	source.Flatten(count);
-	if (count == 1) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	}
+
 	auto array_size = ArrayType::GetSize(source.GetType());
 	auto child_count = count * array_size;
 

--- a/test/sql/function/list/list_grade_up.test
+++ b/test/sql/function/list/list_grade_up.test
@@ -301,3 +301,20 @@ CREATE TABLE health (a VARCHAR[]);
 
 statement ok
 INSERT INTO health SELECT list_grade_up(string_to_array(s, ',')) AS a FROM stage;
+
+
+# Make sure it works for arrays too
+query I
+SELECT array_grade_up(array_value(4,5,3), 'ASC')
+----
+[3, 1, 2]
+
+query I
+SELECT array_grade_up(array_value(4,5,3), 'DESC');
+----
+[2, 1, 3]
+
+query I
+SELECT array_grade_up(NULL::INT[3]);
+----
+NULL

--- a/test/sql/function/string/test_string_array_slice.test
+++ b/test/sql/function/string/test_string_array_slice.test
@@ -230,3 +230,15 @@ SELECT array_slice(s, (-2147483646-1), -2147483647) FROM strings
 (empty)
 (empty)
 NULL
+
+# With constant null
+query I
+select * from (SELECT list_slice(NULL, 1, 3, 2));
+----
+NULL
+
+# With constant null
+query I
+select s[1:2] from (SELECT NULL) as t(s);
+----
+NULL

--- a/test/sql/function/string/test_string_array_slice.test
+++ b/test/sql/function/string/test_string_array_slice.test
@@ -242,3 +242,9 @@ query I
 select s[1:2] from (SELECT NULL) as t(s);
 ----
 NULL
+
+# Also for arrays
+query I
+select * from (SELECT list_slice(NULL::INT[3], 1, 3, 2));
+----
+NULL


### PR DESCRIPTION
Closes https://github.com/duckdblabs/duckdb-internal/issues/1475
Closes https://github.com/duckdb/duckdb-fuzzer/issues/1379

Also fixes a corner case when we set the result vector type too early when casting a constant array to list.

Also fixes a missing cast in list_grade_up when the input is an array.
Closes https://github.com/duckdb/duckdb-fuzzer/issues/1429