### PR TITLE
Add correct table bindings for window relations.

### DIFF
--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -41,10 +41,20 @@ void RelationManager::AddAggregateOrWindowRelation(LogicalOperator &op, optional
 		}
 		aggr_op = aggr_op->children[0].get();
 	}
-	auto table_indexes = aggr_op->GetTableIndex();
-	for (auto &index : table_indexes) {
-		D_ASSERT(relation_mapping.find(index) == relation_mapping.end());
-		relation_mapping[index] = relation_id;
+
+	if (aggr_op->type == LogicalOperatorType::LOGICAL_WINDOW) {
+		auto window_bindings = aggr_op->GetColumnBindings();
+		for (auto &binding : window_bindings) {
+			if (relation_mapping.find(binding.table_index) == relation_mapping.end()) {
+				relation_mapping[binding.table_index] = relation_id;
+			}
+		}
+	} else {
+		auto table_indexes = aggr_op->GetTableIndex();
+		for (auto &index : table_indexes) {
+			D_ASSERT(relation_mapping.find(index) == relation_mapping.end());
+			relation_mapping[index] = relation_id;
+		}
 	}
 	relations.push_back(std::move(relation));
 }

--- a/test/optimizer/joins/joins_with_correlated_subqueries.test
+++ b/test/optimizer/joins/joins_with_correlated_subqueries.test
@@ -10,17 +10,18 @@ INSERT INTO df VALUES (0, 2), (1, NULL), (2, 4), (3, 5), (4, NULL);
 
 statement ok
 SELECT
-      x,
-      COALESCE(
-          y,
-          (
-              SELECT 
-                  prev.y + ( (next.y - prev.y) * (parent.x - prev.x) / (next.x - prev.x) )
-              FROM
-                  ( SELECT x, y FROM df WHERE x <= parent.x and y is not null ORDER BY x DESC LIMIT 1 ) AS prev
-              CROSS JOIN
-                  ( SELECT x, y FROM df WHERE x >= parent.x and y is not null ORDER BY x ASC LIMIT 1 ) AS next
-          )
-      ) AS y
-  FROM
-      df parent;
+  x,
+  COALESCE(
+	  y,
+	  (
+		  SELECT 
+			  prev.y + ( (next.y - prev.y) * (parent.x - prev.x) / (next.x - prev.x) )
+		  FROM
+			  ( SELECT x, y FROM df WHERE x <= parent.x and y is not null ORDER BY x DESC LIMIT 1 ) AS prev
+		  CROSS JOIN
+			  ( SELECT x, y FROM df WHERE x >= parent.x and y is not null ORDER BY x ASC LIMIT 1 ) AS next
+	  )
+  ) AS y
+FROM
+  df parent;
+

--- a/test/optimizer/joins/joins_with_correlated_subqueries.test
+++ b/test/optimizer/joins/joins_with_correlated_subqueries.test
@@ -1,0 +1,26 @@
+# name: test/optimizer/joins/joins_with_correlated_subqueries.test
+# description: issue duckdblabs/duckdb-internal #840
+# group: [joins]
+
+statement ok
+CREATE TABLE df (x NUMERIC, y NUMERIC);
+
+statement ok
+INSERT INTO df VALUES (0, 2), (1, NULL), (2, 4), (3, 5), (4, NULL);
+
+statement ok
+SELECT
+      x,
+      COALESCE(
+          y,
+          (
+              SELECT 
+                  prev.y + ( (next.y - prev.y) * (parent.x - prev.x) / (next.x - prev.x) )
+              FROM
+                  ( SELECT x, y FROM df WHERE x <= parent.x and y is not null ORDER BY x DESC LIMIT 1 ) AS prev
+              CROSS JOIN
+                  ( SELECT x, y FROM df WHERE x >= parent.x and y is not null ORDER BY x ASC LIMIT 1 ) AS next
+          )
+      ) AS y
+  FROM
+      df parent;


### PR DESCRIPTION
Currently only the window expression is added to the relation mapping. This can cause an issue in the join order optimizer where if there is a join condition on a column that is projected from a table that also has a window function, the column will not be found. Not finding the column results in an internal exception.


Fixes: https://github.com/duckdblabs/duckdb-internal/issues/840