### PR TITLE
[Storage] Only call FinalizeOptimisticWriter after storage merge has succeeded

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -571,12 +571,12 @@ SinkFinalizeType PhysicalBatchInsert::Finalize(Pipeline &pipeline, Event &event,
 		for (auto &merger : mergers) {
 			final_collections.push_back(merger->Flush(writer));
 		}
-		storage.FinalizeOptimisticWriter(context, writer);
 
 		// finally, merge the row groups into the local storage
 		for (auto &collection : final_collections) {
 			storage.LocalMerge(context, *collection);
 		}
+		storage.FinalizeOptimisticWriter(context, writer);
 	} else {
 		// we are writing a small amount of data to disk
 		// append directly to transaction local storage

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -494,8 +494,8 @@ SinkCombineResultType PhysicalInsert::Combine(ExecutionContext &context, Operato
 		storage.FinalizeLocalAppend(gstate.append_state);
 	} else {
 		// we have written rows to disk optimistically - merge directly into the transaction-local storage
-		gstate.table.GetStorage().FinalizeOptimisticWriter(context.client, *lstate.writer);
 		gstate.table.GetStorage().LocalMerge(context.client, *lstate.local_collection);
+		gstate.table.GetStorage().FinalizeOptimisticWriter(context.client, *lstate.writer);
 	}
 
 	return SinkCombineResultType::FINISHED;

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -378,17 +378,16 @@ void LocalStorage::FinalizeAppend(LocalAppendState &state) {
 
 void LocalStorage::LocalMerge(DataTable &table, RowGroupCollection &collection) {
 	auto &storage = table_manager.GetOrCreateStorage(table);
-	ErrorData error;
 	if (!storage.indexes.Empty()) {
 		// append data to indexes if required
 		row_t base_id = MAX_ROW_ID + storage.row_groups->GetTotalRows();
-		error = storage.AppendToIndexes(transaction, collection, storage.indexes, table.GetTypes(), base_id);
+		auto error = storage.AppendToIndexes(transaction, collection, storage.indexes, table.GetTypes(), base_id);
+		if (error.HasError()) {
+			error.Throw();
+		}
 	}
 	storage.row_groups->MergeStorage(collection);
 	storage.merged_storage = true;
-	if (error.HasError()) {
-		error.Throw();
-	}
 }
 
 OptimisticDataWriter &LocalStorage::CreateOptimisticWriter(DataTable &table) {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -378,16 +378,17 @@ void LocalStorage::FinalizeAppend(LocalAppendState &state) {
 
 void LocalStorage::LocalMerge(DataTable &table, RowGroupCollection &collection) {
 	auto &storage = table_manager.GetOrCreateStorage(table);
+	ErrorData error;
 	if (!storage.indexes.Empty()) {
 		// append data to indexes if required
 		row_t base_id = MAX_ROW_ID + storage.row_groups->GetTotalRows();
-		auto error = storage.AppendToIndexes(transaction, collection, storage.indexes, table.GetTypes(), base_id);
-		if (error.HasError()) {
-			error.Throw();
-		}
+		error = storage.AppendToIndexes(transaction, collection, storage.indexes, table.GetTypes(), base_id);
 	}
 	storage.row_groups->MergeStorage(collection);
 	storage.merged_storage = true;
+	if (error.HasError()) {
+		error.Throw();
+	}
 }
 
 OptimisticDataWriter &LocalStorage::CreateOptimisticWriter(DataTable &table) {

--- a/src/storage/partial_block_manager.cpp
+++ b/src/storage/partial_block_manager.cpp
@@ -139,11 +139,11 @@ void PartialBlockManager::Merge(PartialBlockManager &other) {
 		if (!e.second) {
 			throw InternalException("Empty partially filled block found");
 		}
-		auto used_space = Storage::BLOCK_SIZE - e.first;
-		if (HasBlockAllocation(NumericCast<uint32_t>(used_space))) {
+		auto used_space = NumericCast<uint32_t>(Storage::BLOCK_SIZE - e.first);
+		if (HasBlockAllocation(used_space)) {
 			// we can merge this block into an existing block - merge them
 			// merge blocks
-			auto allocation = GetBlockAllocation(NumericCast<uint32_t>(used_space));
+			auto allocation = GetBlockAllocation(used_space);
 			allocation.partial_block->Merge(*e.second, allocation.state.offset, used_space);
 
 			// re-register the partial block

--- a/test/sql/storage/parallel/reclaim_space_parallel_insert.test_slow
+++ b/test/sql/storage/parallel/reclaim_space_parallel_insert.test_slow
@@ -2,9 +2,6 @@
 # description: Test space reclamation of optimistic writing with failures
 # group: [parallel]
 
-# FIXME: reliably fails for smaller block sizes
-require block_size 262144
-
 load __TEST_DIR__/reclaim_space_parallel_insert.db
 
 statement ok


### PR DESCRIPTION
This prevents aborting due to primary key violations from leaving invalid blocks in the partial block manager

Fixes an issue uncovered by the smaller block size change