### PR TITLE
Add MetaTransaction::GetTransaction to threadsan suppressions (false positive)

### DIFF
--- a/.sanitizer-thread-suppressions.txt
+++ b/.sanitizer-thread-suppressions.txt
@@ -1,6 +1,7 @@
 deadlock:LockClients
 deadlock:RollbackTransaction
 deadlock:Checkpoint
+deadlock:MetaTransaction::GetTransaction
 race:NextInnerJoin
 race:~ColumnSegment
 race:duckdb_moodycamel


### PR DESCRIPTION
The thread sanitizer complained about a lock-order inversion after adding the lock to the `MetaTransaction` in #10799

The lock order inversion it found was as follows:

* We grab `MetaTransaction` lock while holding the `Catalog` lock in `Catalog::TryLookupEntry`
* We grab the `Catalog` lock while holding the `Transaction` lock in `CommitState::CommitEntry`
* We grab the `Transaction` lock while holding the `MetaTransaction` lock in `MetaTransaction::GetTransaction`

Now this is a lock order inversion - as we have `MetaTransaction lock <- Catalog lock <- Transaction lock <- Meta Transaction lock`.

What the thread sanitizer fails to account for in this case is that the `MetaTransaction` lock is local to a connection -  and a connection only *initiates* a commit after the binding/execution phase has completed - as such this is a false positive and this lock order inversion cannot lead to a deadlock in practice.