### PR TITLE
Issue #10995: ICU VARCHAR TIMETZ

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1529,7 +1529,8 @@ bool TryCastErrorMessage::Operation(string_t input, dtime_tz_t &result, CastPara
 template <>
 bool TryCast::Operation(string_t input, dtime_tz_t &result, bool strict) {
 	idx_t pos;
-	return Time::TryConvertTimeTZ(input.GetData(), input.GetSize(), pos, result, strict);
+	bool has_offset;
+	return Time::TryConvertTimeTZ(input.GetData(), input.GetSize(), pos, result, has_offset, strict);
 }
 
 template <>

--- a/src/common/types/time.cpp
+++ b/src/common/types/time.cpp
@@ -137,8 +137,9 @@ bool Time::TryConvertTime(const char *buf, idx_t len, idx_t &pos, dtime_t &resul
 	return result.micros <= Interval::MICROS_PER_DAY;
 }
 
-bool Time::TryConvertTimeTZ(const char *buf, idx_t len, idx_t &pos, dtime_tz_t &result, bool strict) {
+bool Time::TryConvertTimeTZ(const char *buf, idx_t len, idx_t &pos, dtime_tz_t &result, bool &has_offset, bool strict) {
 	dtime_t time_part;
+	has_offset = false;
 	if (!Time::TryConvertInternal(buf, len, pos, time_part, false)) {
 		if (!strict) {
 			// last chance, check if we can parse as timestamp
@@ -162,7 +163,8 @@ bool Time::TryConvertTimeTZ(const char *buf, idx_t len, idx_t &pos, dtime_tz_t &
 	//	Get the ±HH[:MM] part
 	int hh = 0;
 	int mm = 0;
-	if (pos < len && !Timestamp::TryParseUTCOffset(buf, pos, len, hh, mm)) {
+	has_offset = (pos < len);
+	if (has_offset && !Timestamp::TryParseUTCOffset(buf, pos, len, hh, mm)) {
 		return false;
 	}
 

--- a/src/include/duckdb/common/types/time.hpp
+++ b/src/include/duckdb/common/types/time.hpp
@@ -26,7 +26,7 @@ public:
 	DUCKDB_API static dtime_t FromCString(const char *buf, idx_t len, bool strict = false);
 	DUCKDB_API static bool TryConvertTime(const char *buf, idx_t len, idx_t &pos, dtime_t &result, bool strict = false);
 	DUCKDB_API static bool TryConvertTimeTZ(const char *buf, idx_t len, idx_t &pos, dtime_tz_t &result,
-	                                        bool strict = false);
+	                                        bool &has_offset, bool strict = false);
 	// No hour limit
 	DUCKDB_API static bool TryConvertInterval(const char *buf, idx_t len, idx_t &pos, dtime_t &result,
 	                                          bool strict = false);

--- a/test/sql/function/timetz/test_icu_cast.test
+++ b/test/sql/function/timetz/test_icu_cast.test
@@ -1,0 +1,21 @@
+# name: test/sql/function/timetz/test_icu_cast.test
+# description: have you seen the fnords?
+# group: [timetz]
+
+require icu
+
+statement ok
+SET CALENDAR='gregorian';
+
+statement ok
+SET TIMEZONE='America/Los_Angeles';
+
+query I
+SELECT '01:00:00'::TIMETZ AS ttz
+----
+01:00:00-08
+
+query I
+SELECT '01:00:00+02'::TIMETZ AS ttz
+----
+01:00:00+02


### PR DESCRIPTION
Add missing cast function to apply the current calendar offset to parsed strings with no offsets.

fixes: #10995
fixes: duckdblabs/duckdb-internal#1481