### PR TITLE
Various JSON thread sanitizer fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1143,6 +1143,7 @@ if(NOT DUCKDB_EXPLICIT_PLATFORM)
   add_custom_target(
           duckdb_platform ALL
           COMMAND duckdb_platform_binary > duckdb_platform_out || (echo "Provide explicit DUCKDB_PLATFORM=your_target_arch to avoid build-type detection of the platform" && exit 1)
+          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
           )
   add_dependencies(duckdb_platform duckdb_platform_binary)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1143,7 +1143,6 @@ if(NOT DUCKDB_EXPLICIT_PLATFORM)
   add_custom_target(
           duckdb_platform ALL
           COMMAND duckdb_platform_binary > duckdb_platform_out || (echo "Provide explicit DUCKDB_PLATFORM=your_target_arch to avoid build-type detection of the platform" && exit 1)
-          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
           )
   add_dependencies(duckdb_platform duckdb_platform_binary)
 else()

--- a/extension/json/buffered_json_reader.cpp
+++ b/extension/json/buffered_json_reader.cpp
@@ -304,11 +304,11 @@ idx_t BufferedJSONReader::GetLineNumber(idx_t buf_index, idx_t line_or_object_in
 					line += buffer_line_or_object_counts[b_idx];
 				}
 			}
-		}
-		if (can_throw) {
-			thrown = true;
-			// SQL uses 1-based indexing so I guess we will do that in our exception here as well
-			return line + 1;
+			if (can_throw) {
+				thrown = true;
+				// SQL uses 1-based indexing so I guess we will do that in our exception here as well
+				return line + 1;
+			}
 		}
 		TaskScheduler::YieldThread();
 	}
@@ -331,6 +331,7 @@ void BufferedJSONReader::ThrowTransformError(idx_t buf_index, idx_t line_or_obje
 }
 
 double BufferedJSONReader::GetProgress() const {
+	lock_guard<mutex> guard(lock);
 	if (HasFileHandle()) {
 		return 100.0 - 100.0 * double(file_handle->Remaining()) / double(file_handle->FileSize());
 	} else {

--- a/extension/json/include/buffered_json_reader.hpp
+++ b/extension/json/include/buffered_json_reader.hpp
@@ -90,9 +90,9 @@ private:
 
 	//! Read properties
 	idx_t read_position;
-	idx_t requested_reads;
+	atomic<idx_t> requested_reads;
 	atomic<idx_t> actual_reads;
-	bool last_read_requested;
+	atomic<bool> last_read_requested;
 
 	//! Cached buffers for resetting when reading stream
 	vector<AllocatedData> cached_buffers;
@@ -161,7 +161,7 @@ private:
 	bool thrown;
 
 public:
-	mutex lock;
+	mutable mutex lock;
 	MultiFileReaderData reader_data;
 };
 

--- a/extension/json/json_scan.cpp
+++ b/extension/json/json_scan.cpp
@@ -569,6 +569,7 @@ bool JSONScanLocalState::ReadNextBuffer(JSONScanGlobalState &gstate) {
 			if (file_done) {
 				lock_guard<mutex> guard(gstate.lock);
 				TryIncrementFileIndex(gstate);
+				lock_guard<mutex> reader_guard(current_reader->lock);
 				current_reader->GetFileHandle().Close();
 			}
 


### PR DESCRIPTION
This PR fixes various issues flagged by the thread sanitizer in the JSON reader - primarily turning several variables into atomics.