### PR TITLE
Clean up ExecutorTask and simplify waiting for all tasks to be cancelled

### DIFF
--- a/.sanitizer-thread-suppressions.txt
+++ b/.sanitizer-thread-suppressions.txt
@@ -2,7 +2,6 @@ deadlock:LockClients
 deadlock:RollbackTransaction
 deadlock:Checkpoint
 deadlock:MetaTransaction::GetTransaction
-race:Executor::CancelTasks
 race:NextInnerJoin
 race:~ColumnSegment
 race:duckdb_moodycamel

--- a/.sanitizer-thread-suppressions.txt
+++ b/.sanitizer-thread-suppressions.txt
@@ -2,6 +2,7 @@ deadlock:LockClients
 deadlock:RollbackTransaction
 deadlock:Checkpoint
 deadlock:MetaTransaction::GetTransaction
+race:Executor::CancelTasks
 race:NextInnerJoin
 race:~ColumnSegment
 race:duckdb_moodycamel

--- a/src/common/sort/partition_state.cpp
+++ b/src/common/sort/partition_state.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/types/column/column_data_consumer.hpp"
 #include "duckdb/common/row_operations/row_operations.hpp"
 #include "duckdb/main/config.hpp"
-#include "duckdb/parallel/event.hpp"
+#include "duckdb/parallel/executor_task.hpp"
 
 #include <numeric>
 
@@ -565,7 +565,7 @@ class PartitionMergeTask : public ExecutorTask {
 public:
 	PartitionMergeTask(shared_ptr<Event> event_p, ClientContext &context_p, PartitionGlobalMergeStates &hash_groups_p,
 	                   PartitionGlobalSinkState &gstate)
-	    : ExecutorTask(context_p), event(std::move(event_p)), local_state(gstate), hash_groups(hash_groups_p) {
+	    : ExecutorTask(context_p, std::move(event_p)), local_state(gstate), hash_groups(hash_groups_p) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
@@ -582,7 +582,6 @@ private:
 		Executor &executor;
 	};
 
-	shared_ptr<Event> event;
 	PartitionLocalMergeState local_state;
 	PartitionGlobalMergeStates &hash_groups;
 };

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/parallel/pipeline.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/parallel/executor_task.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
@@ -478,7 +479,7 @@ class HashAggregateFinalizeTask : public ExecutorTask {
 public:
 	HashAggregateFinalizeTask(ClientContext &context, Pipeline &pipeline, shared_ptr<Event> event_p,
 	                          const PhysicalHashAggregate &op, HashAggregateGlobalSinkState &state_p)
-	    : ExecutorTask(pipeline.executor), context(context), pipeline(pipeline), event(std::move(event_p)), op(op),
+	    : ExecutorTask(pipeline.executor, std::move(event_p)), context(context), pipeline(pipeline), op(op),
 	      gstate(state_p) {
 	}
 
@@ -539,7 +540,7 @@ class HashAggregateDistinctFinalizeTask : public ExecutorTask {
 public:
 	HashAggregateDistinctFinalizeTask(Pipeline &pipeline, shared_ptr<Event> event_p, const PhysicalHashAggregate &op,
 	                                  HashAggregateGlobalSinkState &state_p)
-	    : ExecutorTask(pipeline.executor), pipeline(pipeline), event(std::move(event_p)), op(op), gstate(state_p) {
+	    : ExecutorTask(pipeline.executor, std::move(event_p)), pipeline(pipeline), op(op), gstate(state_p) {
 	}
 
 public:
@@ -550,7 +551,6 @@ private:
 
 private:
 	Pipeline &pipeline;
-	shared_ptr<Event> event;
 
 	const PhysicalHashAggregate &op;
 	HashAggregateGlobalSinkState &gstate;

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -489,7 +489,6 @@ public:
 private:
 	ClientContext &context;
 	Pipeline &pipeline;
-	shared_ptr<Event> event;
 
 	const PhysicalHashAggregate &op;
 	HashAggregateGlobalSinkState &gstate;

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -413,8 +413,6 @@ private:
 	TaskExecutionResult AggregateDistinct();
 
 private:
-	shared_ptr<Event> event;
-
 	const PhysicalUngroupedAggregate &op;
 	UngroupedAggregateGlobalSinkState &gstate;
 

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/parallel/base_pipeline_event.hpp"
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/parallel/executor_task.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 
@@ -402,7 +403,7 @@ public:
 	UngroupedDistinctAggregateFinalizeTask(Executor &executor, shared_ptr<Event> event_p,
 	                                       const PhysicalUngroupedAggregate &op,
 	                                       UngroupedAggregateGlobalSinkState &state_p)
-	    : ExecutorTask(executor), event(std::move(event_p)), op(op), gstate(state_p),
+	    : ExecutorTask(executor, std::move(event_p)), op(op), gstate(state_p),
 	      allocator(gstate.CreateAllocator()), aggregate_state(op.aggregates) {
 	}
 

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -403,8 +403,8 @@ public:
 	UngroupedDistinctAggregateFinalizeTask(Executor &executor, shared_ptr<Event> event_p,
 	                                       const PhysicalUngroupedAggregate &op,
 	                                       UngroupedAggregateGlobalSinkState &state_p)
-	    : ExecutorTask(executor, std::move(event_p)), op(op), gstate(state_p),
-	      allocator(gstate.CreateAllocator()), aggregate_state(op.aggregates) {
+	    : ExecutorTask(executor, std::move(event_p)), op(op), gstate(state_p), allocator(gstate.CreateAllocator()),
+	      aggregate_state(op.aggregates) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/parallel/pipeline.hpp"
 #include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/parallel/executor_task.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
@@ -288,7 +289,7 @@ class HashJoinFinalizeTask : public ExecutorTask {
 public:
 	HashJoinFinalizeTask(shared_ptr<Event> event_p, ClientContext &context, HashJoinGlobalSinkState &sink_p,
 	                     idx_t chunk_idx_from_p, idx_t chunk_idx_to_p, bool parallel_p)
-	    : ExecutorTask(context), event(std::move(event_p)), sink(sink_p), chunk_idx_from(chunk_idx_from_p),
+	    : ExecutorTask(context, std::move(event_p)), sink(sink_p), chunk_idx_from(chunk_idx_from_p),
 	      chunk_idx_to(chunk_idx_to_p), parallel(parallel_p) {
 	}
 
@@ -374,7 +375,7 @@ class HashJoinRepartitionTask : public ExecutorTask {
 public:
 	HashJoinRepartitionTask(shared_ptr<Event> event_p, ClientContext &context, JoinHashTable &global_ht,
 	                        JoinHashTable &local_ht)
-	    : ExecutorTask(context), event(std::move(event_p)), global_ht(global_ht), local_ht(local_ht) {
+	    : ExecutorTask(context, std::move(event_p)), global_ht(global_ht), local_ht(local_ht) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
@@ -384,8 +385,6 @@ public:
 	}
 
 private:
-	shared_ptr<Event> event;
-
 	JoinHashTable &global_ht;
 	JoinHashTable &local_ht;
 };

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -300,7 +300,6 @@ public:
 	}
 
 private:
-	shared_ptr<Event> event;
 	HashJoinGlobalSinkState &sink;
 	idx_t chunk_idx_from;
 	idx_t chunk_idx_to;

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/base_pipeline_event.hpp"
 #include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/parallel/executor_task.hpp"
 
 #include <thread>
 
@@ -90,7 +91,7 @@ public:
 
 public:
 	RangeJoinMergeTask(shared_ptr<Event> event_p, ClientContext &context, GlobalSortedTable &table)
-	    : ExecutorTask(context), event(std::move(event_p)), context(context), table(table) {
+	    : ExecutorTask(context, std::move(event_p)), context(context), table(table) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
@@ -104,7 +105,6 @@ public:
 	}
 
 private:
-	shared_ptr<Event> event;
 	ClientContext &context;
 	GlobalSortedTable &table;
 };

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/base_pipeline_event.hpp"
-#include "duckdb/parallel/event.hpp"
+#include "duckdb/parallel/executor_task.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 
 namespace duckdb {
@@ -112,7 +112,7 @@ SinkCombineResultType PhysicalOrder::Combine(ExecutionContext &context, Operator
 class PhysicalOrderMergeTask : public ExecutorTask {
 public:
 	PhysicalOrderMergeTask(shared_ptr<Event> event_p, ClientContext &context, OrderGlobalSinkState &state)
-	    : ExecutorTask(context), event(std::move(event_p)), context(context), state(state) {
+	    : ExecutorTask(context, std::move(event_p)), context(context), state(state) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
@@ -125,7 +125,6 @@ public:
 	}
 
 private:
-	shared_ptr<Event> event;
 	ClientContext &context;
 	OrderGlobalSinkState &state;
 };

--- a/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
+++ b/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/execution/operator/persistent/batch_memory_manager.hpp"
 #include "duckdb/execution/operator/persistent/batch_task_manager.hpp"
+#include "duckdb/parallel/executor_task.hpp"
 #include <algorithm>
 
 namespace duckdb {
@@ -212,7 +213,7 @@ class ProcessRemainingBatchesTask : public ExecutorTask {
 public:
 	ProcessRemainingBatchesTask(Executor &executor, shared_ptr<Event> event_p, FixedBatchCopyGlobalState &state_p,
 	                            ClientContext &context, const PhysicalFixedBatchCopy &op)
-	    : ExecutorTask(executor), event(std::move(event_p)), op(op), gstate(state_p), context(context) {
+	    : ExecutorTask(executor, std::move(event_p)), op(op), gstate(state_p), context(context) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
@@ -224,7 +225,6 @@ public:
 	}
 
 private:
-	shared_ptr<Event> event;
 	const PhysicalFixedBatchCopy &op;
 	FixedBatchCopyGlobalState &gstate;
 	ClientContext &context;

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -99,6 +99,13 @@ public:
 	//! Returns true if all pipelines have been completed
 	bool ExecutionIsFinished();
 
+	void RegisterTask() {
+		executor_tasks++;
+	}
+	void UnregisterTask() {
+		executor_tasks--;
+	}
+
 private:
 	bool ResultCollectorIsBlocked();
 	void InitializeInternal(PhysicalOperator &physical_plan);
@@ -118,13 +125,6 @@ private:
 
 	void VerifyPipeline(Pipeline &pipeline);
 	void VerifyPipelines();
-
-	void RegisterTask() {
-		executor_tasks++;
-	}
-	void UnregisterTask() {
-		executor_tasks--;
-	}
 
 private:
 	optional_ptr<PhysicalOperator> physical_plan;

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -119,6 +119,13 @@ private:
 	void VerifyPipeline(Pipeline &pipeline);
 	void VerifyPipelines();
 
+	void RegisterTask() {
+		executor_tasks++;
+	}
+	void UnregisterTask() {
+		executor_tasks--;
+	}
+
 private:
 	optional_ptr<PhysicalOperator> physical_plan;
 	unique_ptr<PhysicalOperator> owned_plan;
@@ -157,5 +164,8 @@ private:
 
 	//! Task that have been descheduled
 	unordered_map<Task *, shared_ptr<Task>> to_be_rescheduled_tasks;
+
+	//! Currently alive executor tasks
+	atomic<idx_t> executor_tasks;
 };
 } // namespace duckdb

--- a/src/include/duckdb/parallel/executor_task.hpp
+++ b/src/include/duckdb/parallel/executor_task.hpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parallel/executor_task.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/parallel/task.hpp"
+#include "duckdb/parallel/event.hpp"
+
+namespace duckdb {
+
+//! Execute a task within an executor, including exception handling
+//! This should be used within queries
+class ExecutorTask : public Task {
+public:
+	ExecutorTask(Executor &executor, shared_ptr<Event> event);
+	ExecutorTask(ClientContext &context, shared_ptr<Event> event);
+	virtual ~ExecutorTask();
+
+public:
+	void Deschedule() override;
+	void Reschedule() override;
+
+public:
+	Executor &executor;
+	shared_ptr<Event> event;
+
+public:
+	virtual TaskExecutionResult ExecuteTask(TaskExecutionMode mode) = 0;
+	TaskExecutionResult Execute(TaskExecutionMode mode) override;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/common/reference_map.hpp"
+#include "duckdb/parallel/executor_task.hpp"
 
 namespace duckdb {
 
@@ -31,7 +32,6 @@ public:
 	explicit PipelineTask(Pipeline &pipeline_p, shared_ptr<Event> event_p);
 
 	Pipeline &pipeline;
-	shared_ptr<Event> event;
 	unique_ptr<PipelineExecutor> pipeline_executor;
 
 public:

--- a/src/include/duckdb/parallel/task.hpp
+++ b/src/include/duckdb/parallel/task.hpp
@@ -52,24 +52,4 @@ public:
 	}
 };
 
-//! Execute a task within an executor, including exception handling
-//! This should be used within queries
-class ExecutorTask : public Task {
-public:
-	ExecutorTask(Executor &executor);
-	ExecutorTask(ClientContext &context);
-	virtual ~ExecutorTask();
-
-public:
-	void Deschedule() override;
-	void Reschedule() override;
-
-public:
-	Executor &executor;
-
-public:
-	virtual TaskExecutionResult ExecuteTask(TaskExecutionMode mode) = 0;
-	TaskExecutionResult Execute(TaskExecutionMode mode) override;
-};
-
 } // namespace duckdb

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -407,11 +407,9 @@ void Executor::CancelTasks() {
 		events.clear();
 	}
 	// Take all pending tasks and execute them until they cancel
-	WorkOnTasks();
-	// there might still be tasks executing in background threads
-	// wait until there are no more executor tasks remaining
-	while (executor_tasks > 0)
-		;
+	while (executor_tasks > 0) {
+		WorkOnTasks();
+	}
 }
 
 void Executor::WorkOnTasks() {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -24,10 +24,7 @@ Executor::Executor(ClientContext &context) : context(context), executor_tasks(0)
 }
 
 Executor::~Executor() {
-	if (executor_tasks > 0) {
-		throw InternalException("Executor was destroyed while there were still %llu outstanding executor tasks",
-		                        executor_tasks.load()); // NOLINT
-	}
+	D_ASSERT(executor_tasks == 0);
 }
 
 Executor &Executor::Get(ClientContext &context) {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -20,10 +20,14 @@
 
 namespace duckdb {
 
-Executor::Executor(ClientContext &context) : context(context) {
+Executor::Executor(ClientContext &context) : context(context), executor_tasks(0) {
 }
 
 Executor::~Executor() {
+	if (executor_tasks > 0) {
+		throw InternalException("Executor was destroyed while there were still %llu outstanding executor tasks",
+		                        executor_tasks.load()); // NOLINT
+	}
 }
 
 Executor &Executor::Get(ClientContext &context) {

--- a/src/parallel/executor_task.cpp
+++ b/src/parallel/executor_task.cpp
@@ -4,11 +4,13 @@
 
 namespace duckdb {
 
-ExecutorTask::ExecutorTask(Executor &executor_p) : executor(executor_p) {
+ExecutorTask::ExecutorTask(Executor &executor_p, shared_ptr<Event> event_p)
+    : executor(executor_p), event(std::move(event_p)) {
 	executor.RegisterTask();
 }
 
-ExecutorTask::ExecutorTask(ClientContext &context) : ExecutorTask(Executor::Get(context)) {
+ExecutorTask::ExecutorTask(ClientContext &context, shared_ptr<Event> event_p)
+    : ExecutorTask(Executor::Get(context), std::move(event_p)) {
 }
 
 ExecutorTask::~ExecutorTask() {

--- a/src/parallel/executor_task.cpp
+++ b/src/parallel/executor_task.cpp
@@ -5,12 +5,14 @@
 namespace duckdb {
 
 ExecutorTask::ExecutorTask(Executor &executor_p) : executor(executor_p) {
+	executor.RegisterTask();
 }
 
 ExecutorTask::ExecutorTask(ClientContext &context) : ExecutorTask(Executor::Get(context)) {
 }
 
 ExecutorTask::~ExecutorTask() {
+	executor.UnregisterTask();
 }
 
 void ExecutorTask::Deschedule() {

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -16,7 +16,7 @@
 namespace duckdb {
 
 PipelineTask::PipelineTask(Pipeline &pipeline_p, shared_ptr<Event> event_p)
-    : ExecutorTask(pipeline_p.executor), pipeline(pipeline_p), event(std::move(event_p)) {
+    : ExecutorTask(pipeline_p.executor, std::move(event_p)), pipeline(pipeline_p) {
 }
 
 bool PipelineTask::TaskBlockedOnResult() const {

--- a/src/parallel/pipeline_finish_event.cpp
+++ b/src/parallel/pipeline_finish_event.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/parallel/pipeline_finish_event.hpp"
 #include "duckdb/execution/executor.hpp"
 #include "duckdb/parallel/interrupt.hpp"
+#include "duckdb/parallel/executor_task.hpp"
 
 namespace duckdb {
 
@@ -9,11 +10,10 @@ namespace duckdb {
 class PipelineFinishTask : public ExecutorTask {
 public:
 	explicit PipelineFinishTask(Pipeline &pipeline_p, shared_ptr<Event> event_p)
-	    : ExecutorTask(pipeline_p.executor), pipeline(pipeline_p), event(std::move(event_p)) {
+	    : ExecutorTask(pipeline_p.executor, std::move(event_p)), pipeline(pipeline_p) {
 	}
 
 	Pipeline &pipeline;
-	shared_ptr<Event> event;
 
 public:
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {

--- a/src/parallel/pipeline_initialize_event.cpp
+++ b/src/parallel/pipeline_initialize_event.cpp
@@ -11,11 +11,10 @@ PipelineInitializeEvent::PipelineInitializeEvent(shared_ptr<Pipeline> pipeline_p
 class PipelineInitializeTask : public ExecutorTask {
 public:
 	explicit PipelineInitializeTask(Pipeline &pipeline_p, shared_ptr<Event> event_p)
-	    : ExecutorTask(pipeline_p.executor), pipeline(pipeline_p), event(std::move(event_p)) {
+	    : ExecutorTask(pipeline_p.executor, std::move(event_p)), pipeline(pipeline_p) {
 	}
 
 	Pipeline &pipeline;
-	shared_ptr<Event> event;
 
 public:
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {


### PR DESCRIPTION
This PR cleans up the ExecutorTask so that it contains a `shared_ptr<Event>` - this is significantly cleaner since every task that inherits from `ExecutorTask` contains one (and has to contain one - a task needs to belong to an event).

In addition, we simplify waiting for all tasks to be cancelled. Previously we would wait until all pipelines were destroyed. But this is rather complex - instead we just keep track of how many outstanding tasks there are using an atomic and wait until all tasks are cleaned up.