### PR TITLE
Check IsLoaded() before importing cached item

### DIFF
--- a/scripts/regression_test_python.py
+++ b/scripts/regression_test_python.py
@@ -246,7 +246,8 @@ class ArrowDictionaryBenchmark:
 
 class PandasDFLoadBenchmark:
     def __init__(self):
-        pass
+        self.initialize_connection()
+        self.generate()
 
     def initialize_connection(self):
         self.con = duckdb.connect()
@@ -258,7 +259,9 @@ class PandasDFLoadBenchmark:
     def generate(self):
         self.con.execute("call dbgen(sf=0.2)")
         new_table = "*, " + ", ".join(["l_shipdate"] * 300)
-        self.con.exucute(f"create table wide as select {new_table} from lineitem")
+        self.con.execute(f"create table wide as select {new_table} from lineitem")
+        import pdb
+        pdb.set_trace()
         self.con.execute(f"copy wide to 'wide_table.csv' (FORMAT CSV)")
 
     def benchmark(self) -> List[BenchmarkResult]:

--- a/scripts/regression_test_python.py
+++ b/scripts/regression_test_python.py
@@ -243,9 +243,11 @@ class ArrowDictionaryBenchmark:
             results.append(BenchmarkResult(duration, nrun))
         return results
 
+
 class PandasDFLoadBenchmark:
     def __init__(self):
         pass
+
     def initialize_connection(self):
         self.con = duckdb.connect()
         if not threads:
@@ -253,9 +255,9 @@ class PandasDFLoadBenchmark:
         print_msg(f'Limiting threads to {threads}')
         self.con.execute(f"SET threads={threads}")
 
-    def generate(self, unique_values, values, arrow_dict: ArrowDictionary):
+    def generate(self):
         self.con.execute("call dbgen(sf=0.2)")
-        new_table = "*, " + ", ".join([l_shipdate] * 300)
+        new_table = "*, " + ", ".join(["l_shipdate"] * 300)
         self.con.exucute(f"create table wide as select {new_table} from lineitem")
         self.con.execute(f"copy wide to 'wide_table.csv' (FORMAT CSV)")
 
@@ -266,9 +268,7 @@ class PandasDFLoadBenchmark:
             pandas_df = pd.read_csv('wide_table.csv')
             start = time.time()
             for amplification in range(30):
-                res = self.con.execute(
-                    """select * from pandas_df"""
-                ).df()
+                res = self.con.execute("""select * from pandas_df""").df()
             end = time.time()
             duration = float(end - start)
             del res
@@ -294,11 +294,12 @@ def test_arrow_dictionaries_scan():
 def test_loading_pandas_df_many_times():
     test = PandasDFLoadBenchmark()
     results = test.benchmark()
-    benchmark_name = f"load pandas df many times"
+    benchmark_name = f"load_pandas_df_many_times"
     for res in results:
         run_number = res.run_number
         duration = res.duration
         write_result(benchmark_name, run_number, duration)
+
 
 def main():
     test_tpch()

--- a/scripts/regression_test_python.py
+++ b/scripts/regression_test_python.py
@@ -260,8 +260,6 @@ class PandasDFLoadBenchmark:
         self.con.execute("call dbgen(sf=0.2)")
         new_table = "*, " + ", ".join(["l_shipdate"] * 300)
         self.con.execute(f"create table wide as select {new_table} from lineitem")
-        import pdb
-        pdb.set_trace()
         self.con.execute(f"copy wide to 'wide_table.csv' (FORMAT CSV)")
 
     def benchmark(self) -> List[BenchmarkResult]:

--- a/scripts/regression_test_python.py
+++ b/scripts/regression_test_python.py
@@ -257,9 +257,9 @@ class PandasDFLoadBenchmark:
         self.con.execute(f"SET threads={threads}")
 
     def generate(self):
-        self.con.execute("call dbgen(sf=0.2)")
+        self.con.execute("call dbgen(sf=0.1)")
         new_table = "*, " + ", ".join(["l_shipdate"] * 300)
-        self.con.execute(f"create table wide as select {new_table} from lineitem")
+        self.con.execute(f"create table wide as select {new_table} from lineitem limit 500")
         self.con.execute(f"copy wide to 'wide_table.csv' (FORMAT CSV)")
 
     def benchmark(self) -> List[BenchmarkResult]:

--- a/tools/pythonpkg/src/python_import_cache.cpp
+++ b/tools/pythonpkg/src/python_import_cache.cpp
@@ -10,6 +10,9 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 
 py::handle PythonImportCacheItem::operator()(bool load) {
+	if (IsLoaded()) {
+		return object;
+	}
 	stack<reference<PythonImportCacheItem>> hierarchy;
 
 	optional_ptr<PythonImportCacheItem> item = this;
@@ -24,7 +27,7 @@ bool PythonImportCacheItem::LoadSucceeded() const {
 	return load_succeeded;
 }
 
-bool PythonImportCacheItem::IsLoaded() const {
+inline bool PythonImportCacheItem::IsLoaded() const {
 	return object.ptr() != nullptr;
 }
 


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/1335

The regression only shows up when reading data frames with multiple object types (VARCHARS). The cache item is checked for every new column, so when a number of columns need to be type checked the extra time starts to become noticeable. Also why in the original script the query had to be run 100 times. 