### PR TITLE
Fix warnings in ALP and logical_insert

### DIFF
--- a/src/include/duckdb/planner/operator/logical_insert.hpp
+++ b/src/include/duckdb/planner/operator/logical_insert.hpp
@@ -53,7 +53,7 @@ public:
 	// The types of the columns targeted by the DO UPDATE SET expressions
 	vector<LogicalType> set_types;
 	// The table_index referring to the column references qualified with 'excluded'
-	idx_t excluded_table_index;
+	idx_t excluded_table_index = 0;
 	// The columns to fetch from the 'destination' table
 	vector<column_t> columns_to_fetch;
 	// The columns to fetch from the 'source' table

--- a/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
+++ b/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
@@ -133,7 +133,7 @@ struct AlpRDCompression {
 	}
 
 	static double FindBestDictionary(const vector<EXACT_TYPE> &values, State &state) {
-		uint8_t right_bit_width;
+		uint8_t right_bit_width = 0;
 		double best_dict_size = NumericLimits<int32_t>::Maximum();
 		//! Finding the best position to CUT the values
 		for (idx_t i = 1; i <= AlpRDConstants::CUTTING_LIMIT; i++) {


### PR DESCRIPTION
Found while building the node-client and by memory sanitizer run.