### PR TITLE
Refactor ATTACH options

### DIFF
--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -11,64 +11,19 @@
 namespace duckdb {
 
 //===--------------------------------------------------------------------===//
-// Helper
-//===--------------------------------------------------------------------===//
-
-void ParseOptions(const unique_ptr<AttachInfo> &info, AccessMode &access_mode, string &db_type,
-                  string &unrecognized_option) {
-
-	for (auto &entry : info->options) {
-
-		if (entry.first == "readonly" || entry.first == "read_only") {
-			auto read_only = BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
-			if (read_only) {
-				access_mode = AccessMode::READ_ONLY;
-			} else {
-				access_mode = AccessMode::READ_WRITE;
-			}
-			continue;
-		}
-
-		if (entry.first == "readwrite" || entry.first == "read_write") {
-			auto read_only = !BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
-			if (read_only) {
-				access_mode = AccessMode::READ_ONLY;
-			} else {
-				access_mode = AccessMode::READ_WRITE;
-			}
-			continue;
-		}
-
-		if (entry.first == "type") {
-			// extract the database type
-			db_type = StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR));
-			continue;
-		}
-
-		// we allow unrecognized options
-		if (unrecognized_option.empty()) {
-			unrecognized_option = entry.first;
-		}
-	}
-}
-
-//===--------------------------------------------------------------------===//
 // Source
 //===--------------------------------------------------------------------===//
 SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &chunk,
                                          OperatorSourceInput &input) const {
 	// parse the options
 	auto &config = DBConfig::GetConfig(context.client);
-	AccessMode access_mode = config.options.access_mode;
-	string db_type;
-	string unrecognized_option;
-	ParseOptions(info, access_mode, db_type, unrecognized_option);
+	AttachOptions options(info, config.options.access_mode);
 
 	// get the name and path of the database
 	auto &name = info->name;
 	auto &path = info->path;
-	if (db_type.empty()) {
-		DBPathAndType::ExtractExtensionPrefix(path, db_type);
+	if (options.db_type.empty()) {
+		DBPathAndType::ExtractExtensionPrefix(path, options.db_type);
 	}
 	if (name.empty()) {
 		auto &fs = FileSystem::GetFileSystem(context.client);
@@ -82,12 +37,12 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 		auto existing_db = db_manager.GetDatabase(context.client, name);
 		if (existing_db) {
 
-			if ((existing_db->IsReadOnly() && access_mode == AccessMode::READ_WRITE) ||
-			    (!existing_db->IsReadOnly() && access_mode == AccessMode::READ_ONLY)) {
+			if ((existing_db->IsReadOnly() && options.access_mode == AccessMode::READ_WRITE) ||
+			    (!existing_db->IsReadOnly() && options.access_mode == AccessMode::READ_ONLY)) {
 
 				auto existing_mode = existing_db->IsReadOnly() ? AccessMode::READ_ONLY : AccessMode::READ_WRITE;
 				auto existing_mode_str = EnumUtil::ToString(existing_mode);
-				auto attached_mode = EnumUtil::ToString(access_mode);
+				auto attached_mode = EnumUtil::ToString(options.access_mode);
 				throw BinderException("Database \"%s\" is already attached in %s mode, cannot re-attach in %s mode",
 				                      name, existing_mode_str, attached_mode);
 			}
@@ -96,9 +51,11 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 		}
 	}
 
-	// get the database type and attach the database
-	db_manager.GetDatabaseType(context.client, db_type, *info, config, unrecognized_option);
-	auto attached_db = db_manager.AttachDatabase(context.client, *info, db_type, access_mode);
+	// Get the database type and attach the database.
+	db_manager.GetDatabaseType(context.client, *info, config, options);
+	auto attached_db = db_manager.AttachDatabase(context.client, *info, options);
+
+	//! Initialize the database.
 	attached_db->Initialize();
 	return SourceResultType::FINISHED;
 }

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -31,18 +31,36 @@ enum class AttachedDatabaseType {
 	TEMP_DATABASE,
 };
 
-//! The AttachedDatabase represents an attached database instance
+//! AttachOptions holds information about a database we plan to attach. These options are generalized, i.e.,
+//! they have to apply to any database file type (duckdb, sqlite, etc.).
+struct AttachOptions {
+	//! Constructor for databases we attach outside of the ATTACH DATABASE statement.
+	explicit AttachOptions(const DBConfigOptions &options);
+	//! Constructor for databases we attach when using ATTACH DATABASE.
+	AttachOptions(const unique_ptr<AttachInfo> &info, const AccessMode default_access_mode);
+
+	//! Defaults to the access mode configured in the DBConfig, unless specified otherwise.
+	AccessMode access_mode;
+	//! The file format type. The default type is a duckdb database file, but other file formats are possible.
+	string db_type;
+	//! We only set this, if we detect any unrecognized option.
+	string unrecognized_option;
+};
+
+//! The AttachedDatabase represents an attached database instance.
 class AttachedDatabase : public CatalogEntry {
 public:
-	//! Create the built-in system attached database (without storage)
+	//! Create the built-in system database (without storage).
 	explicit AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType type = AttachedDatabaseType::SYSTEM_DATABASE);
-	//! Create an attached database instance with the specified name and storage
-	AttachedDatabase(DatabaseInstance &db, Catalog &catalog, string name, string file_path, AccessMode access_mode);
-	//! Create an attached database instance with the specified storage extension
+	//! Create an attached database instance with the specified name and storage.
+	AttachedDatabase(DatabaseInstance &db, Catalog &catalog, string name, string file_path,
+	                 const AttachOptions &options);
+	//! Create an attached database instance with the specified storage extension.
 	AttachedDatabase(DatabaseInstance &db, Catalog &catalog, StorageExtension &ext, ClientContext &context, string name,
-	                 const AttachInfo &info, AccessMode access_mode);
+	                 const AttachInfo &info, const AttachOptions &options);
 	~AttachedDatabase() override;
 
+	//! Initializes the catalog and storage of the attached database.
 	void Initialize();
 
 	Catalog &ParentCatalog() override;

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -24,6 +24,7 @@ class FileSystem;
 class TaskScheduler;
 class ObjectCache;
 struct AttachInfo;
+struct AttachOptions;
 
 class DatabaseInstance : public std::enable_shared_from_this<DatabaseInstance> {
 	friend class DuckDB;
@@ -56,7 +57,7 @@ public:
 	DUCKDB_API bool TryGetCurrentSetting(const std::string &key, Value &result);
 
 	unique_ptr<AttachedDatabase> CreateAttachedDatabase(ClientContext &context, const AttachInfo &info,
-	                                                    const string &type, AccessMode access_mode);
+	                                                    const AttachOptions &options);
 
 private:
 	void Initialize(const char *path, DBConfig *config);

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -24,6 +24,7 @@ class Catalog;
 class CatalogSet;
 class ClientContext;
 class DatabaseInstance;
+struct AttachOptions;
 
 //! The DatabaseManager is a class that sits at the root of all attached databases
 class DatabaseManager {
@@ -38,12 +39,13 @@ public:
 	static DatabaseManager &Get(ClientContext &db);
 	static DatabaseManager &Get(AttachedDatabase &db);
 
+	//! Initializes the system catalog of the attached SYSTEM_DATABASE.
 	void InitializeSystemCatalog();
 	//! Get an attached database by its name
 	optional_ptr<AttachedDatabase> GetDatabase(ClientContext &context, const string &name);
 	//! Attach a new database
-	optional_ptr<AttachedDatabase> AttachDatabase(ClientContext &context, const AttachInfo &info, const string &db_type,
-	                                              AccessMode access_mode);
+	optional_ptr<AttachedDatabase> AttachDatabase(ClientContext &context, const AttachInfo &info,
+	                                              const AttachOptions &options);
 	//! Detach an existing database
 	void DetachDatabase(ClientContext &context, const string &name, OnEntryNotFound if_not_found);
 	//! Returns a reference to the system catalog
@@ -60,8 +62,7 @@ public:
 	//! Returns the database type. This might require checking the header of the file, in which case the file handle is
 	//! necessary. We can only grab the file handle, if it is not yet held, even for uncommitted changes. Thus, we have
 	//! to lock for this operation.
-	void GetDatabaseType(ClientContext &context, string &db_type, AttachInfo &info, const DBConfig &config,
-	                     const string &unrecognized_option);
+	void GetDatabaseType(ClientContext &context, AttachInfo &info, const DBConfig &config, AttachOptions &options);
 	//! Scans the catalog set and adds each committed database entry, and each database entry of the current
 	//! transaction, to a vector holding AttachedDatabase references
 	vector<reference<AttachedDatabase>> GetDatabases(ClientContext &context);

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -22,7 +22,7 @@ class DatabaseInstance;
 class MetadataManager;
 
 //! BlockManager is an abstract representation to manage blocks on DuckDB. When writing or reading blocks, the
-//! BlockManager creates and accesses blocks. The concrete types implements how blocks are stored.
+//! BlockManager creates and accesses blocks. The concrete types implement specific block storage strategies.
 class BlockManager {
 public:
 	explicit BlockManager(BufferManager &buffer_manager);

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -13,11 +13,67 @@
 
 namespace duckdb {
 
+//===--------------------------------------------------------------------===//
+// Attach Options
+//===--------------------------------------------------------------------===//
+
+AttachOptions::AttachOptions(const DBConfigOptions &options)
+    : access_mode(options.access_mode), db_type(options.database_type) {
+}
+
+AttachOptions::AttachOptions(const unique_ptr<AttachInfo> &info, const AccessMode default_access_mode)
+    : access_mode(default_access_mode) {
+
+	for (auto &entry : info->options) {
+
+		if (entry.first == "readonly" || entry.first == "read_only") {
+			// Extract the read access mode.
+
+			auto read_only = BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
+			if (read_only) {
+				access_mode = AccessMode::READ_ONLY;
+			} else {
+				access_mode = AccessMode::READ_WRITE;
+			}
+			continue;
+		}
+
+		if (entry.first == "readwrite" || entry.first == "read_write") {
+			// Extract the write access mode.
+
+			auto read_write = BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
+			if (!read_write) {
+				access_mode = AccessMode::READ_ONLY;
+			} else {
+				access_mode = AccessMode::READ_WRITE;
+			}
+			continue;
+		}
+
+		if (entry.first == "type") {
+			// Extract the database type.
+			db_type = StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR));
+			continue;
+		}
+
+		// We allow unrecognized options in storage extensions. To track that we saw an unrecognized option,
+		// we set unrecognized_option.
+		if (unrecognized_option.empty()) {
+			unrecognized_option = entry.first;
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Attached Database
+//===--------------------------------------------------------------------===//
+
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType type)
     : CatalogEntry(CatalogType::DATABASE_ENTRY,
                    type == AttachedDatabaseType::SYSTEM_DATABASE ? SYSTEM_CATALOG : TEMP_CATALOG, 0),
       db(db), type(type) {
 
+	// This database does not have storage.
 	D_ASSERT(type == AttachedDatabaseType::TEMP_DATABASE || type == AttachedDatabaseType::SYSTEM_DATABASE);
 	if (type == AttachedDatabaseType::TEMP_DATABASE) {
 		storage = make_uniq<SingleFileStorageManager>(*this, string(IN_MEMORY_PATH), false);
@@ -29,35 +85,47 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, AttachedDatabaseType ty
 }
 
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, string name_p, string file_path_p,
-                                   AccessMode access_mode)
+                                   const AttachOptions &options)
     : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p) {
-	type = access_mode == AccessMode::READ_ONLY ? AttachedDatabaseType::READ_ONLY_DATABASE
-	                                            : AttachedDatabaseType::READ_WRITE_DATABASE;
+
+	if (options.access_mode == AccessMode::READ_ONLY) {
+		type = AttachedDatabaseType::READ_ONLY_DATABASE;
+	} else {
+		type = AttachedDatabaseType::READ_WRITE_DATABASE;
+	}
+
+	// We create the storage after the catalog to guarantee we allow extensions to instantiate the DuckCatalog.
 	catalog = make_uniq<DuckCatalog>(*this);
-	// do this after catalog to guarnatee we allow extension to instantionate DuckCatalog causing creation
-	// of the storage
-	storage = make_uniq<SingleFileStorageManager>(*this, std::move(file_path_p), access_mode == AccessMode::READ_ONLY);
+	auto read_only = options.access_mode == AccessMode::READ_ONLY;
+	storage = make_uniq<SingleFileStorageManager>(*this, std::move(file_path_p), read_only);
 	transaction_manager = make_uniq<DuckTransactionManager>(*this);
 	internal = true;
 }
 
 AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension,
                                    ClientContext &context, string name_p, const AttachInfo &info,
-                                   AccessMode access_mode)
+                                   const AttachOptions &options)
     : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p) {
-	type = access_mode == AccessMode::READ_ONLY ? AttachedDatabaseType::READ_ONLY_DATABASE
-	                                            : AttachedDatabaseType::READ_WRITE_DATABASE;
-	catalog =
-	    storage_extension.attach(storage_extension.storage_info.get(), context, *this, name, *info.Copy(), access_mode);
+
+	if (options.access_mode == AccessMode::READ_ONLY) {
+		type = AttachedDatabaseType::READ_ONLY_DATABASE;
+	} else {
+		type = AttachedDatabaseType::READ_WRITE_DATABASE;
+	}
+
+	StorageExtensionInfo *storage_info = storage_extension.storage_info.get();
+	catalog = storage_extension.attach(storage_info, context, *this, name, *info.Copy(), options.access_mode);
+
 	if (!catalog) {
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
 	}
 	if (catalog->IsDuckCatalog()) {
-		// DuckCatalog, instantiate storage
-		storage = make_uniq<SingleFileStorageManager>(*this, info.path, access_mode == AccessMode::READ_ONLY);
+		// The attached database uses the DuckCatalog.
+		auto read_only = options.access_mode == AccessMode::READ_ONLY;
+		storage = make_uniq<SingleFileStorageManager>(*this, info.path, read_only);
 	}
-	transaction_manager =
-	    storage_extension.create_transaction_manager(storage_extension.storage_info.get(), *this, *catalog);
+
+	transaction_manager = storage_extension.create_transaction_manager(storage_info, *this, *catalog);
 	if (!transaction_manager) {
 		throw InternalException(
 		    "AttachedDatabase - create_transaction_manager function did not return a transaction manager");

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -125,29 +125,31 @@ ConnectionManager &ConnectionManager::Get(ClientContext &context) {
 }
 
 unique_ptr<AttachedDatabase> DatabaseInstance::CreateAttachedDatabase(ClientContext &context, const AttachInfo &info,
-                                                                      const string &type, AccessMode access_mode) {
+                                                                      const AttachOptions &options) {
 	unique_ptr<AttachedDatabase> attached_database;
-	if (!type.empty()) {
-		// find the storage extension
-		auto extension_name = ExtensionHelper::ApplyExtensionAlias(type);
+	auto &catalog = Catalog::GetSystemCatalog(*this);
+
+	if (!options.db_type.empty()) {
+		// Find the storage extension for this database file.
+		auto extension_name = ExtensionHelper::ApplyExtensionAlias(options.db_type);
 		auto entry = config.storage_extensions.find(extension_name);
 		if (entry == config.storage_extensions.end()) {
-			throw BinderException("Unrecognized storage type \"%s\"", type);
+			throw BinderException("Unrecognized storage type \"%s\"", options.db_type);
 		}
 
 		if (entry->second->attach != nullptr && entry->second->create_transaction_manager != nullptr) {
-			// use storage extension to create the initial database
-			attached_database = make_uniq<AttachedDatabase>(*this, Catalog::GetSystemCatalog(*this), *entry->second,
-			                                                context, info.name, info, access_mode);
-		} else {
+			// Use the storage extension to create the initial database.
 			attached_database =
-			    make_uniq<AttachedDatabase>(*this, Catalog::GetSystemCatalog(*this), info.name, info.path, access_mode);
+			    make_uniq<AttachedDatabase>(*this, catalog, *entry->second, context, info.name, info, options);
+			return attached_database;
 		}
-	} else {
-		// check if this is an in-memory database or not
-		attached_database =
-		    make_uniq<AttachedDatabase>(*this, Catalog::GetSystemCatalog(*this), info.name, info.path, access_mode);
+
+		attached_database = make_uniq<AttachedDatabase>(*this, catalog, info.name, info.path, options);
+		return attached_database;
 	}
+
+	// An empty db_type defaults to a duckdb database file.
+	attached_database = make_uniq<AttachedDatabase>(*this, catalog, info.name, info.path, options);
 	return attached_database;
 }
 
@@ -160,8 +162,8 @@ void DatabaseInstance::CreateMainDatabase() {
 	{
 		Connection con(*this);
 		con.BeginTransaction();
-		initial_database =
-		    db_manager->AttachDatabase(*con.context, info, config.options.database_type, config.options.access_mode);
+		AttachOptions options(config.options);
+		initial_database = db_manager->AttachDatabase(*con.context, info, options);
 		con.Commit();
 	}
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -35,12 +35,12 @@ optional_ptr<AttachedDatabase> DatabaseManager::GetDatabase(ClientContext &conte
 }
 
 optional_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &context, const AttachInfo &info,
-                                                               const string &db_type, AccessMode access_mode) {
+                                                               const AttachOptions &options) {
 	// now create the attached database
 	auto &db = DatabaseInstance::GetDatabase(context);
-	auto attached_db = db.CreateAttachedDatabase(context, info, db_type, access_mode);
+	auto attached_db = db.CreateAttachedDatabase(context, info, options);
 
-	if (db_type.empty()) {
+	if (options.db_type.empty()) {
 		InsertDatabasePath(context, info.path, attached_db->name);
 	}
 
@@ -130,41 +130,40 @@ void DatabaseManager::EraseDatabasePath(const string &path) {
 	}
 }
 
-void DatabaseManager::GetDatabaseType(ClientContext &context, string &db_type, AttachInfo &info, const DBConfig &config,
-                                      const string &unrecognized_option) {
+void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, const DBConfig &config,
+                                      AttachOptions &options) {
 
-	// duckdb database file
-	if (StringUtil::CIEquals(db_type, "DUCKDB")) {
-		db_type = "";
+	// Test if the database is a DuckDB database file.
+	if (StringUtil::CIEquals(options.db_type, "DUCKDB")) {
+		options.db_type = "";
 
-		// DUCKDB format does not allow unrecognized options
-		if (!unrecognized_option.empty()) {
-			throw BinderException("Unrecognized option for attach \"%s\"", unrecognized_option);
+		// The DuckDB format does not allow unrecognized options.
+		if (!options.unrecognized_option.empty()) {
+			throw BinderException("Unrecognized option for attach \"%s\"", options.unrecognized_option);
 		}
 		return;
 	}
 
-	// try to extract database type from path
-	if (db_type.empty()) {
+	// Try to extract the database type from the path.
+	if (options.db_type.empty()) {
 		CheckPathConflict(context, info.path);
-
-		DBPathAndType::CheckMagicBytes(info.path, db_type, config);
+		DBPathAndType::CheckMagicBytes(info.path, options.db_type, config);
 	}
 
-	// if we are loading a database type from an extension - check if that extension is loaded
-	if (!db_type.empty()) {
-		if (!Catalog::TryAutoLoad(context, db_type)) {
+	// If we are loading a database type from an extension, then we need to check if that extension is loaded.
+	if (!options.db_type.empty()) {
+		if (!Catalog::TryAutoLoad(context, options.db_type)) {
 			// FIXME: Here it might be preferable to use an AutoLoadOrThrow kind of function
 			// so that either there will be success or a message to throw, and load will be
 			// attempted only once respecting the auto-loading options
-			ExtensionHelper::LoadExternalExtension(context, db_type);
+			ExtensionHelper::LoadExternalExtension(context, options.db_type);
 		}
 		return;
 	}
 
-	// DUCKDB format does not allow unrecognized options
-	if (!unrecognized_option.empty()) {
-		throw BinderException("Unrecognized option for attach \"%s\"", unrecognized_option);
+	// The DUCKDB format does not allow unrecognized options.
+	if (!options.unrecognized_option.empty()) {
+		throw BinderException("Unrecognized option for attach \"%s\"", options.unrecognized_option);
 	}
 }
 


### PR DESCRIPTION
This PR moves those attach options that are independent of the underlying database file into a struct `AttachOptions`. It also adds some early-outs and other nits to the attached database code.