### PR TITLE
ATTACH with reserved names (temp/main)

### DIFF
--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -61,6 +61,7 @@ public:
 	bool IsInitialDatabase() const;
 	void SetInitialDatabase();
 
+	static bool NameIsReserved(const string &name);
 	static string ExtractDatabaseName(const string &dbpath, FileSystem &fs);
 
 private:

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -105,11 +105,19 @@ bool AttachedDatabase::IsReadOnly() const {
 	return type == AttachedDatabaseType::READ_ONLY_DATABASE;
 }
 
+bool AttachedDatabase::NameIsReserved(const string &name) {
+	return name == DEFAULT_SCHEMA || name == TEMP_CATALOG;
+}
+
 string AttachedDatabase::ExtractDatabaseName(const string &dbpath, FileSystem &fs) {
 	if (dbpath.empty() || dbpath == IN_MEMORY_PATH) {
 		return "memory";
 	}
-	return fs.ExtractBaseName(dbpath);
+	auto name = fs.ExtractBaseName(dbpath);
+	if (NameIsReserved(name)) {
+		name += "_db";
+	}
+	return name;
 }
 
 void AttachedDatabase::Initialize() {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -36,6 +36,9 @@ optional_ptr<AttachedDatabase> DatabaseManager::GetDatabase(ClientContext &conte
 
 optional_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &context, const AttachInfo &info,
                                                                const string &db_type, AccessMode access_mode) {
+	if (AttachedDatabase::NameIsReserved(info.name)) {
+		throw BinderException("Attached database name \"%s\" cannot be used because it is a reserved name", info.name);
+	}
 	// now create the attached database
 	auto &db = DatabaseInstance::GetDatabase(context);
 	auto attached_db = db.CreateAttachedDatabase(context, info, db_type, access_mode);

--- a/test/sql/attach/attach_reserved.test
+++ b/test/sql/attach/attach_reserved.test
@@ -1,0 +1,30 @@
+# name: test/sql/attach/attach_reserved.test
+# description: Test ATTACH of reserved names
+# group: [attach]
+
+require noforcestorage
+
+statement ok
+PRAGMA enable_verification
+
+# attach a new database called temp
+statement ok
+ATTACH DATABASE '__TEST_DIR__/temp.db';
+
+# we alias "temp" and "main" to use "_db" instead
+statement ok
+CREATE TABLE temp_db.integers(i INTEGER);
+
+statement ok
+DETACH temp_db;
+
+# explicitly selecting these aliases leads to an error
+statement error
+ATTACH DATABASE ':memory:' AS temp;
+----
+reserved name
+
+statement error
+ATTACH DATABASE ':memory:' AS main;
+----
+reserved name


### PR DESCRIPTION
Fixes #7554

DuckDB has two special schemas - `temp` and `main` - that are used internally. `temp` is used to hold temporary objects, and `main` is used as the default schema if no other is provided. While we disallow creating schemas with these names as they are reserved - we did until recently allow attaching databases with these names. Worse - these names can be automatically chosen because we choose a default database name based on the file name if no name is provided, i.e. `temp.db` is automatically named `temp`.

In this PR we address this issue in two ways:

* When a reserved name - i.e. `temp` or `main` - is chosen automatically we append `_db` to the generated name, i.e. `ATTACH 'temp.db'` or `duckdb temp.db` attaches the database with the name `temp_db` instead of the name `temp`
* When a reserved name is explicitly chosen, we throw an error, i.e. `ATTACH 'file.db' AS temp` will fail 