### PR TITLE
In DatabaseInstance destructor - destroy TaskScheduler first

### DIFF
--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -44,6 +44,7 @@ public:
 	~AttachedDatabase() override;
 
 	void Initialize();
+	void Close();
 
 	Catalog &ParentCatalog() override;
 	StorageManager &GetStorageManager();
@@ -71,6 +72,7 @@ private:
 	AttachedDatabaseType type;
 	optional_ptr<Catalog> parent_catalog;
 	bool is_initial_database = false;
+	bool is_closed = false;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -24,6 +24,7 @@ class Catalog;
 class CatalogSet;
 class ClientContext;
 class DatabaseInstance;
+class TaskScheduler;
 
 //! The DatabaseManager is a class that sits at the root of all attached databases
 class DatabaseManager {
@@ -67,7 +68,7 @@ public:
 	vector<reference<AttachedDatabase>> GetDatabases(ClientContext &context);
 	//! Removes all databases from the catalog set. This is necessary for the database instance's destructor,
 	//! as the database manager has to be alive when destroying the catalog set objects.
-	void ResetDatabases();
+	void ResetDatabases(unique_ptr<TaskScheduler> &scheduler);
 
 	transaction_t GetNewQueryNumber() {
 		return current_query_number++;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -66,31 +66,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 }
 
 AttachedDatabase::~AttachedDatabase() {
-	D_ASSERT(catalog);
-
-	if (!IsSystem() && !catalog->InMemory()) {
-		db.GetDatabaseManager().EraseDatabasePath(catalog->GetDBPath());
-	}
-
-	if (Exception::UncaughtException()) {
-		return;
-	}
-	if (!storage) {
-		return;
-	}
-
-	// shutting down: attempt to checkpoint the database
-	// but only if we are not cleaning up as part of an exception unwind
-	try {
-		if (!storage->InMemory()) {
-			auto &config = DBConfig::GetConfig(db);
-			if (!config.options.checkpoint_on_shutdown) {
-				return;
-			}
-			storage->CreateCheckpoint(true);
-		}
-	} catch (...) {
-	}
+	Close();
 }
 
 bool AttachedDatabase::IsSystem() const {
@@ -148,6 +124,38 @@ bool AttachedDatabase::IsInitialDatabase() const {
 
 void AttachedDatabase::SetInitialDatabase() {
 	is_initial_database = true;
+}
+
+void AttachedDatabase::Close() {
+	D_ASSERT(catalog);
+	if (is_closed) {
+		return;
+	}
+	is_closed = true;
+
+	if (!IsSystem() && !catalog->InMemory()) {
+		db.GetDatabaseManager().EraseDatabasePath(catalog->GetDBPath());
+	}
+
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	if (!storage) {
+		return;
+	}
+
+	// shutting down: attempt to checkpoint the database
+	// but only if we are not cleaning up as part of an exception unwind
+	try {
+		if (!storage->InMemory()) {
+			auto &config = DBConfig::GetConfig(db);
+			if (!config.options.checkpoint_on_shutdown) {
+				return;
+			}
+			storage->CreateCheckpoint(true);
+		}
+	} catch (...) {
+	}
 }
 
 } // namespace duckdb

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -54,6 +54,9 @@ DatabaseInstance::DatabaseInstance() {
 }
 
 DatabaseInstance::~DatabaseInstance() {
+	// destroy the task scheduler so all in-process tasks are killed
+	scheduler.reset();
+	// destroy all attached databases
 	GetDatabaseManager().ResetDatabases();
 }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -54,10 +54,8 @@ DatabaseInstance::DatabaseInstance() {
 }
 
 DatabaseInstance::~DatabaseInstance() {
-	// destroy the task scheduler so all in-process tasks are killed
-	scheduler.reset();
 	// destroy all attached databases
-	GetDatabaseManager().ResetDatabases();
+	GetDatabaseManager().ResetDatabases(scheduler);
 }
 
 BufferManager &BufferManager::GetBufferManager(DatabaseInstance &db) {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -205,7 +205,13 @@ vector<reference<AttachedDatabase>> DatabaseManager::GetDatabases(ClientContext 
 	return result;
 }
 
-void DatabaseManager::ResetDatabases() {
+void DatabaseManager::ResetDatabases(unique_ptr<TaskScheduler> &scheduler) {
+	vector<reference<AttachedDatabase>> result;
+	databases->Scan([&](CatalogEntry &entry) { result.push_back(entry.Cast<AttachedDatabase>()); });
+	for (auto &database : result) {
+		database.get().Close();
+	}
+	scheduler.reset();
 	databases.reset();
 }
 


### PR DESCRIPTION
This forces all currently active tasks to finish running and all background threads to terminate prior to destroying other components (e.g. block manager, buffer manager, etc) which fixes some rare issues on shutdown.