### PR TITLE
Issue #10995: TIMETZ DST Fix

### DIFF
--- a/test/sql/function/timetz/test_icu_cast.test
+++ b/test/sql/function/timetz/test_icu_cast.test
@@ -1,5 +1,5 @@
 # name: test/sql/function/timetz/test_icu_cast.test
-# description: have you seen the fnords?
+# description: Test default TIMETZ offsets with ICU loaded.
 # group: [timetz]
 
 require icu
@@ -8,12 +8,12 @@ statement ok
 SET CALENDAR='gregorian';
 
 statement ok
-SET TIMEZONE='America/Los_Angeles';
+SET TIMEZONE='America/Phoenix';
 
 query I
 SELECT '01:00:00'::TIMETZ AS ttz
 ----
-01:00:00-08
+01:00:00-07
 
 query I
 SELECT '01:00:00+02'::TIMETZ AS ttz


### PR DESCRIPTION
Change the test to use a non-DST TZ so it doesn't break this weekend.