### PR TITLE
[CI] Create a bigger table in interrupt test

### DIFF
--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -70,7 +70,7 @@ TEST_CASE("Test closing database during long running query", "[api]") {
 	auto conn = make_uniq<Connection>(*db);
 	// create the database
 	REQUIRE_NO_FAIL(conn->Query("CREATE TABLE integers(i INTEGER)"));
-	REQUIRE_NO_FAIL(conn->Query("INSERT INTO integers VALUES (1), (2), (3), (NULL)"));
+	REQUIRE_NO_FAIL(conn->Query("INSERT INTO integers FROM range(10000)"));
 	conn->DisableProfiling();
 	// perform a long running query in the background (many cross products)
 	bool correct = true;


### PR DESCRIPTION
This test verifies that interrupts work by running a cross product between the same table 15 times. The problem is that the table was too small which caused the query to sometimes successfully complete before the interrupt could cancel the query. This PR makes the table a lot bigger so this shouldn't happen.