### PR TITLE
Avoid checking LastModifiedTime for remote files in object cache

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -389,10 +389,15 @@ public:
 					// missing metadata entry in cache, no usable stats
 					return nullptr;
 				}
-				auto handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ);
-				// we need to check if the metadata cache entries are current
-				if (fs.GetLastModifiedTime(*handle) >= metadata->read_time) {
-					// missing or invalid metadata entry in cache, no usable stats overall
+				if (!fs.IsRemoteFile(file_name)) {
+					auto handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ);
+					// we need to check if the metadata cache entries are current
+					if (fs.GetLastModifiedTime(*handle) >= metadata->read_time) {
+						// missing or invalid metadata entry in cache, no usable stats overall
+						return nullptr;
+					}
+				} else {
+					// for remote files we just avoid reading stats entirely
 					return nullptr;
 				}
 				ParquetReader reader(context, bind_data.parquet_options, metadata);

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -70,3 +70,25 @@ select sum(column0) from 's3://test-bucket/parquet_glob_s3_paging/paging/t*-${ur
 endloop
 
 endloop
+
+# test with enable_object_cache = true
+statement ok
+SET enable_object_cache=true
+
+foreach urlstyle path vhost
+
+foreach format parquet
+
+loop i 0 2
+
+# Begin tests
+query I
+select sum(column0) from 's3://test-bucket/parquet_glob_s3_paging/paging/t*-${urlstyle}-urls.${format}'
+----
+1999000
+
+endloop
+
+endloop
+
+endloop


### PR DESCRIPTION
This fixes an issue where running with `SET enable_object_cache=true` could actually make remote reads slower. We would open remote files single-threaded during statistics propagation only to fetch the last modified time of the file to make sure the cached stats are still up to date. Instead, we just opt to not emit stats for remote files entirely. 