### PR TITLE
Use batch limit only when limit + offset are small constants

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -507,11 +507,13 @@ SinkCombineResultType PhysicalBatchInsert::Combine(ExecutionContext &context, Op
 
 	memory_manager.UpdateMinBatchIndex(lstate.partition_info.min_batch_index.GetIndex());
 
-	if (lstate.current_collection && lstate.current_collection->GetTotalRows() > 0) {
+	if (lstate.current_collection) {
 		TransactionData tdata(0, 0);
 		lstate.current_collection->FinalizeAppend(tdata, lstate.current_append_state);
-		gstate.AddCollection(context.client, lstate.current_index, lstate.partition_info.min_batch_index.GetIndex(),
-		                     std::move(lstate.current_collection));
+		if (lstate.current_collection->GetTotalRows() > 0) {
+			gstate.AddCollection(context.client, lstate.current_index, lstate.partition_info.min_batch_index.GetIndex(),
+			                     std::move(lstate.current_collection));
+		}
 	}
 	if (lstate.writer) {
 		lock_guard<mutex> l(gstate.lock);

--- a/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
+++ b/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
@@ -195,6 +195,10 @@ SinkCombineResultType PhysicalFixedBatchCopy::Combine(ExecutionContext &context,
 	auto &gstate = input.global_state.Cast<FixedBatchCopyGlobalState>();
 	auto &memory_manager = gstate.memory_manager;
 	gstate.rows_copied += state.rows_copied;
+
+	// add any final remaining local batches
+	AddLocalBatch(context.client, gstate, state);
+
 	if (!gstate.any_finished) {
 		// signal that this thread is finished processing batches and that we should move on to Finalize
 		lock_guard<mutex> l(gstate.lock);
@@ -519,6 +523,34 @@ void PhysicalFixedBatchCopy::ExecuteTasks(ClientContext &context, GlobalSinkStat
 //===--------------------------------------------------------------------===//
 // Next Batch
 //===--------------------------------------------------------------------===//
+void PhysicalFixedBatchCopy::AddLocalBatch(ClientContext &context, GlobalSinkState &gstate_p,
+                                           LocalSinkState &lstate) const {
+	auto &state = lstate.Cast<FixedBatchCopyLocalState>();
+	auto &gstate = gstate_p.Cast<FixedBatchCopyGlobalState>();
+	auto &memory_manager = gstate.memory_manager;
+	if (!state.collection || state.collection->Count() == 0) {
+		return;
+	}
+	// we finished processing this batch
+	// start flushing data
+	auto min_batch_index = state.partition_info.min_batch_index.GetIndex();
+	// push the raw batch data into the set of unprocessed batches
+	auto raw_batch = make_uniq<FixedRawBatchData>(state.local_memory_usage, std::move(state.collection));
+	AddRawBatchData(context, gstate, state.batch_index.GetIndex(), std::move(raw_batch));
+	// attempt to repartition to our desired batch size
+	RepartitionBatches(context, gstate, min_batch_index);
+	// unblock tasks so they can help process batches (if any are blocked)
+	auto any_unblocked = memory_manager.UnblockTasks();
+	// if any threads were unblocked they can pick up execution of the tasks
+	// otherwise we will execute a task and flush here
+	if (!any_unblocked) {
+		//! Execute a single repartition task
+		ExecuteTask(context, gstate);
+		//! Flush batch data to disk (if any is ready)
+		FlushBatchData(context, gstate, memory_manager.GetMinimumBatchIndex());
+	}
+}
+
 SinkNextBatchType PhysicalFixedBatchCopy::NextBatch(ExecutionContext &context,
                                                     OperatorSinkNextBatchInput &input) const {
 	auto &lstate = input.local_state;
@@ -526,26 +558,11 @@ SinkNextBatchType PhysicalFixedBatchCopy::NextBatch(ExecutionContext &context,
 	auto &state = lstate.Cast<FixedBatchCopyLocalState>();
 	auto &gstate = input.global_state.Cast<FixedBatchCopyGlobalState>();
 	auto &memory_manager = gstate.memory_manager;
-	if (state.collection && state.collection->Count() > 0) {
-		// we finished processing this batch
-		// start flushing data
-		auto min_batch_index = lstate.partition_info.min_batch_index.GetIndex();
-		// push the raw batch data into the set of unprocessed batches
-		auto raw_batch = make_uniq<FixedRawBatchData>(state.local_memory_usage, std::move(state.collection));
-		AddRawBatchData(context.client, gstate_p, state.batch_index.GetIndex(), std::move(raw_batch));
-		// attempt to repartition to our desired batch size
-		RepartitionBatches(context.client, gstate_p, min_batch_index);
-		// unblock tasks so they can help process batches (if any are blocked)
-		auto any_unblocked = memory_manager.UnblockTasks();
-		// if any threads were unblocked they can pick up execution of the tasks
-		// otherwise we will execute a task and flush here
-		if (!any_unblocked) {
-			//! Execute a single repartition task
-			ExecuteTask(context.client, gstate);
-			//! Flush batch data to disk (if any is ready)
-			FlushBatchData(context.client, gstate, memory_manager.GetMinimumBatchIndex());
-		}
-	}
+
+	// add the previously finished batch (if any) to the state
+	AddLocalBatch(context.client, gstate, state);
+
+	// update the minimum batch index
 	memory_manager.UpdateMinBatchIndex(state.partition_info.min_batch_index.GetIndex());
 	state.batch_index = lstate.partition_info.batch_index.GetIndex();
 

--- a/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
+++ b/src/execution/operator/persistent/physical_fixed_batch_copy.cpp
@@ -554,7 +554,6 @@ void PhysicalFixedBatchCopy::AddLocalBatch(ClientContext &context, GlobalSinkSta
 SinkNextBatchType PhysicalFixedBatchCopy::NextBatch(ExecutionContext &context,
                                                     OperatorSinkNextBatchInput &input) const {
 	auto &lstate = input.local_state;
-	auto &gstate_p = input.global_state;
 	auto &state = lstate.Cast<FixedBatchCopyLocalState>();
 	auto &gstate = input.global_state.Cast<FixedBatchCopyGlobalState>();
 	auto &memory_manager = gstate.memory_manager;

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp
@@ -61,6 +61,7 @@ public:
 	}
 
 private:
+	void AddLocalBatch(ClientContext &context, GlobalSinkState &gstate, LocalSinkState &state) const;
 	void PrepareBatchData(ClientContext &context, GlobalSinkState &gstate_p, idx_t batch_index,
 	                      unique_ptr<ColumnDataCollection> collection) const;
 	void FlushBatchData(ClientContext &context, GlobalSinkState &gstate_p, idx_t min_index) const;

--- a/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
@@ -69,5 +69,6 @@ public:
 	bool ExecuteTask(ClientContext &context, GlobalSinkState &gstate_p) const;
 	void ExecuteTasks(ClientContext &context, GlobalSinkState &gstate_p) const;
 	SinkFinalizeType FinalFlush(ClientContext &context, GlobalSinkState &gstate_p) const;
+	void AddLocalBatch(ClientContext &context, GlobalSinkState &gstate, LocalSinkState &state) const;
 };
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_fixed_batch_copy.hpp
@@ -61,6 +61,7 @@ public:
 	}
 
 public:
+	void AddLocalBatch(ClientContext &context, GlobalSinkState &gstate, LocalSinkState &state) const;
 	void AddRawBatchData(ClientContext &context, GlobalSinkState &gstate_p, idx_t batch_index,
 	                     unique_ptr<FixedRawBatchData> collection) const;
 	void RepartitionBatches(ClientContext &context, GlobalSinkState &gstate_p, idx_t min_index,
@@ -69,6 +70,5 @@ public:
 	bool ExecuteTask(ClientContext &context, GlobalSinkState &gstate_p) const;
 	void ExecuteTasks(ClientContext &context, GlobalSinkState &gstate_p) const;
 	SinkFinalizeType FinalFlush(ClientContext &context, GlobalSinkState &gstate_p) const;
-	void AddLocalBatch(ClientContext &context, GlobalSinkState &gstate, LocalSinkState &state) const;
 };
 } // namespace duckdb

--- a/test/sql/copy/csv/csv_limit_copy.test
+++ b/test/sql/copy/csv/csv_limit_copy.test
@@ -1,0 +1,14 @@
+# name: test/sql/copy/csv/csv_limit_copy.test
+# description: CSV limit copy
+# group: [csv]
+
+statement ok
+CREATE TABLE integers AS FROM range(1000000) t(i);
+
+statement ok
+COPY (FROM integers LIMIT 30000) TO '__TEST_DIR__/limit_copy.csv'
+
+query I
+SELECT COUNT(*) FROM '__TEST_DIR__/limit_copy.csv'
+----
+30000


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/3700 introduced a batch limit operator. This operator materializes the total limit in each thread per batch index, and then uses the batch index to compute the actual values that should be displayed.

This can greatly speed up `LIMIT` queries over selective queries - as instead of doing the entire computation single-threaded, we can do the computation multi-threaded and still return the first 10 rows as we would in single-threaded mode. For example:

```sql
CREATE TABLE watch_ids(id BIGINT);
INSERT INTO watch_ids VALUES  (8948098895940581939),(4777932575813714813),(8656694087808261835),(5051571672317926195),(4623291818784556814),(7941394930037864481),(6120426638180822156),(6364166646977784649),(6313434950399883289),(6623504913745024651);

SELECT * FROM '~/Data/hits.parquet' WHERE WatchId IN (SELECT id FROM watch_ids);
-- 11s

SELECT * FROM '~/Data/hits.parquet' WHERE WatchId IN (SELECT id FROM watch_ids) LIMIT 5;
-- 11s

SET threads=1;
SELECT * FROM '~/Data/hits.parquet' WHERE WatchId IN (SELECT id FROM watch_ids) LIMIT 5;
-- 90s
```

However, this approach has one big disadvantage - we need to materialize the total `limit + offset` bucket for each thread, as opposed to just being able to stream the values. This can cause us to run into memory issues when using large limit + offsets, and can be counterproductive in terms of performance. For example:

```sql
FROM '~/Data/hits.parquet' LIMIT 5 OFFSET 500000;
-- 1.2s
FROM '~/Data/hits.parquet' LIMIT 5 OFFSET 5000000;
-- OOM

SET threads=1;
FROM '~/Data/hits.parquet' LIMIT 5 OFFSET 500000;
-- 0.5s
FROM '~/Data/hits.parquet' LIMIT 5 OFFSET 5000000;
-- 5s
```

This PR fixes this issue by only using the batch limit + offset when they are small constants, and switching back to the streaming approach when they are larger than a given threshold (currently 10K).

