### PR TITLE
[Block Size Nightly] Enable more block size nightly tests

### DIFF
--- a/test/sql/storage/optimistic_write/optimistic_write_cyclic_dictionary.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_cyclic_dictionary.test_slow
@@ -2,9 +2,6 @@
 # description: Test optimistic write with a cyclic scan
 # group: [optimistic_write]
 
-# FIXME: member access does not point to an object of type 'BlockManager'
-require block_size 262144
-
 load __TEST_DIR__/optimistic_write_cyclic_dictionary.db
 
 statement ok

--- a/test/sql/storage/optimistic_write/optimistic_write_cyclic_scan.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_cyclic_scan.test_slow
@@ -2,9 +2,6 @@
 # description: Test optimistic write with a cyclic scan
 # group: [optimistic_write]
 
-# FIXME: runtime error: member access within address 0x000359ad3c40 which does not point to an object of type 'BlockManager'
-require block_size 262144
-
 load __TEST_DIR__/optimistic_write_cyclic_scan.db
 
 statement ok

--- a/test/sql/storage/parallel/memory_limit_batch_load_list.test_slow
+++ b/test/sql/storage/parallel/memory_limit_batch_load_list.test_slow
@@ -2,9 +2,6 @@
 # description: Test batch streaming to disk with different row group sizes
 # group: [parallel]
 
-# FIXME: with a block size of 16KB and when run in relassert, this test fails with: mutex lock failed: Invalid argument
-require block_size 262144
-
 require parquet
 
 load __TEST_DIR__/memory_limit_batch_load_list.db


### PR DESCRIPTION
PRs https://github.com/duckdb/duckdb/pull/11021 and https://github.com/duckdb/duckdb/pull/10998 solved issues causing some of the 16KB block size tests to fail. This PR enables the tests.