### PR TITLE
Fix #11033: don't reset arena allocator in between calls to streaming window expression

### DIFF
--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -113,7 +113,6 @@ OperatorResultType PhysicalStreamingWindow::Execute(ExecutionContext &context, D
                                                     GlobalOperatorState &gstate_p, OperatorState &state_p) const {
 	auto &gstate = gstate_p.Cast<StreamingWindowGlobalState>();
 	auto &state = state_p.Cast<StreamingWindowState>();
-	state.allocator.Reset();
 
 	if (!state.initialized) {
 		state.Initialize(context.client, input, select_list);

--- a/test/sql/window/test_streaming_window_list.test_slow
+++ b/test/sql/window/test_streaming_window_list.test_slow
@@ -1,0 +1,17 @@
+# name: test/sql/window/test_streaming_window_list.test_slow
+# description: Streaming window with LIST aggregate
+# group: [window]
+
+statement ok
+select
+   list(row_number) over(rows between unbounded preceding and current row)
+from generate_series(5000) t(row_number);
+
+query IIII
+SELECT COUNT(*), SUM(LENGTH(list_aggr)), MIN(LENGTH(list_aggr)), MAX(LENGTH(list_aggr)) FROM (
+select
+   list(row_number) over(rows between unbounded preceding and current row)
+from generate_series(5000) t(row_number)
+) t(list_aggr)
+----
+5001	12507501	1	5001


### PR DESCRIPTION
Fixes #11033