### PR TITLE
Add missing pipeline dependencies in recursive CTE

### DIFF
--- a/src/execution/operator/set/physical_recursive_cte.cpp
+++ b/src/execution/operator/set/physical_recursive_cte.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/aggregate_hashtable.hpp"
 #include "duckdb/execution/executor.hpp"
+#include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
 #include "duckdb/parallel/event.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/pipeline.hpp"
@@ -173,6 +174,16 @@ void PhysicalRecursiveCTE::ExecuteRecursivePipelines(ExecutionContext &context) 
 //===--------------------------------------------------------------------===//
 // Pipeline Construction
 //===--------------------------------------------------------------------===//
+
+static void GatherColumnDataScans(const PhysicalOperator &op, vector<const_reference<PhysicalOperator>> &delim_scans) {
+	if (op.type == PhysicalOperatorType::DELIM_SCAN || op.type == PhysicalOperatorType::CTE_SCAN) {
+		delim_scans.push_back(op);
+	}
+	for (auto &child : op.children) {
+		GatherColumnDataScans(*child, delim_scans);
+	}
+}
+
 void PhysicalRecursiveCTE::BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline) {
 	op_state.reset();
 	sink_state.reset();
@@ -192,6 +203,20 @@ void PhysicalRecursiveCTE::BuildPipelines(Pipeline &current, MetaPipeline &meta_
 	recursive_meta_pipeline = make_shared<MetaPipeline>(executor, state, this);
 	recursive_meta_pipeline->SetRecursiveCTE();
 	recursive_meta_pipeline->Build(*children[1]);
+
+	vector<const_reference<PhysicalOperator>> ops;
+	GatherColumnDataScans(*children[1], ops);
+
+	for (auto op : ops) {
+		auto entry = state.cte_dependencies.find(op);
+		if (entry == state.cte_dependencies.end()) {
+			continue;
+		}
+		// this chunk scan introduces a dependency to the current pipeline
+		// namely a dependency on the CTE pipeline to finish
+		auto cte_dependency = entry->second.get().shared_from_this();
+		current.AddDependency(cte_dependency);
+	}
 }
 
 vector<const_reference<PhysicalOperator>> PhysicalRecursiveCTE::GetSources() const {


### PR DESCRIPTION
Fix some spurious CI failures in the `test/sql/cte/materialized/recursive_cte_correlated_subquery_materialized.test_slow` test.

https://github.com/duckdb/duckdb/pull/10878#issuecomment-1983410031