### PR TITLE
[FIX] Lambda bug in subqueries

### DIFF
--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -88,7 +88,9 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 	if (op.type == ExpressionType::GROUPING_FUNCTION) {
 		return BindGroupingFunction(op, depth);
 	}
-	// bind the children of the operator expression
+
+	// Bind the children of the operator expression. We already create bound expressions.
+	// Only those children that trigger an error are not yet bound.
 	ErrorData error;
 	for (idx_t i = 0; i < op.children.size(); i++) {
 		BindChild(op.children[i], depth, error);
@@ -96,6 +98,7 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 	if (error.HasError()) {
 		return BindResult(std::move(error));
 	}
+
 	// all children bound successfully
 	string function_name;
 	switch (op.type) {

--- a/test/sql/json/scalar/test_json_arrow_expr.test
+++ b/test/sql/json/scalar/test_json_arrow_expr.test
@@ -1,0 +1,25 @@
+# name: test/sql/json/scalar/test_json_arrow_expr.test
+# description: Test subquery binding of partially bound arrow expressions
+# group: [scalar]
+
+require json
+
+statement ok
+CREATE TABLE testjson AS SELECT JSON '{ "key" : "value" }' AS example;
+
+query I
+SELECT (SELECT (example)->k AS v FROM (SELECT 'key' AS k) keys)
+FROM testjson;
+----
+"value"
+
+query I
+SELECT (SELECT json_extract(example, k) AS v FROM (SELECT 'key' AS k) keys)
+FROM testjson;
+----
+"value"
+
+query I
+SELECT (SELECT (JSON '{ "key" : "value" }')->k AS v FROM (SELECT 'key' AS k) keys);
+----
+"value"


### PR DESCRIPTION
This PR fixes an issue where the binder would fail when binding a subquery. This happened because we partially bound the query (some children are `BOUND`) but failed in one of the children. However, `arrow_expr` was a local variable, so we no longer had these already-bound expressions when calling `auto result = BindCorrelatedColumns(expr, error_msg);`.