### PR TITLE
Python: use short paths for Windows

### DIFF
--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -181,7 +181,7 @@ def include_package(pkg_name, pkg_dir, include_files, include_list, source_list)
     sys.path = original_path
 
 
-def build_package(target_dir, extensions, linenumbers=False, unity_count=32, folder_name='duckdb'):
+def build_package(target_dir, extensions, linenumbers=False, unity_count=32, folder_name='duckdb', short_paths = False):
     if not os.path.isdir(target_dir):
         os.mkdir(target_dir)
 
@@ -289,7 +289,7 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
         return False
 
     def generate_unity_build(entries, unity_name, linenumbers):
-        ub_file = os.path.join(target_dir, f'ub_{unity_name}.cpp')
+        ub_file = os.path.join(target_dir, unity_name)
         with open_utf8(ub_file, 'w+') as f:
             for entry in entries:
                 if linenumbers:
@@ -326,11 +326,18 @@ def build_package(target_dir, extensions, linenumbers=False, unity_count=32, fol
                             key=lambda x: scores[os.path.basename(x)] if os.path.basename(x) in scores else 99999
                         )
             if not unity_build:
-                new_source_files += [os.path.join(folder_name, file) for file in current_files]
+                if short_paths:
+                    # replace source files with "__"
+                    for file in current_files:
+                        unity_filename = os.path.basename(file)
+                        new_source_files.append(generate_unity_build([file], unity_filename, linenumbers))
+                else:
+                    # directly use the source files
+                    new_source_files += [os.path.join(folder_name, file) for file in current_files]
             else:
-                new_source_files.append(
-                    generate_unity_build(current_files, dirname.replace(os.path.sep, '_'), linenumbers)
-                )
+                unity_base = dirname.replace(os.path.sep, '_')
+                unity_name = f'ub_{unity_base}.cpp'
+                new_source_files.append(generate_unity_build(current_files, unity_name, linenumbers))
         return new_source_files
 
     original_sources = source_list

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -181,7 +181,7 @@ def include_package(pkg_name, pkg_dir, include_files, include_list, source_list)
     sys.path = original_path
 
 
-def build_package(target_dir, extensions, linenumbers=False, unity_count=32, folder_name='duckdb', short_paths = False):
+def build_package(target_dir, extensions, linenumbers=False, unity_count=32, folder_name='duckdb', short_paths=False):
     if not os.path.isdir(target_dir):
         os.mkdir(target_dir)
 

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -172,7 +172,6 @@ libraries = []
 if 'DUCKDB_BINARY_DIR' in os.environ:
     existing_duckdb_dir = os.environ['DUCKDB_BINARY_DIR']
 if 'DUCKDB_COMPILE_FLAGS' in os.environ:
-    # FIXME: this is overwriting the previously set toolchain_args ?
     toolchain_args = ['-std=c++11'] + os.environ['DUCKDB_COMPILE_FLAGS'].split()
 if 'DUCKDB_LIBS' in os.environ:
     libraries = os.environ['DUCKDB_LIBS'].split(' ')
@@ -197,6 +196,10 @@ define_macros.extend([('DUCKDB_EXTENSION_AUTOLOAD_DEFAULT', '1'), ('DUCKDB_EXTEN
 linker_args = toolchain_args
 if platform.system() == 'Windows':
     linker_args.extend(['rstrtmgr.lib'])
+
+short_paths = False
+if platform.system() == 'Windows':
+    short_paths = True
 
 extra_files = []
 header_files = []
@@ -237,7 +240,7 @@ if len(existing_duckdb_dir) == 0:
         import package_build
 
         (source_list, include_list, original_sources) = package_build.build_package(
-            os.path.join(script_path, "duckdb_build"), extensions, False, unity_build, "duckdb_build"
+            os.path.join(script_path, "duckdb_build"), extensions, False, unity_build, "duckdb_build", short_paths
         )
 
         duckdb_sources = [

--- a/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
@@ -76,7 +76,7 @@ template <class T>
 bool try_cast(const handle &object, T &result) {
 	try {
 		result = cast<T>(object);
-	} catch (cast_error &e) {
+	} catch (cast_error &) {
 		return false;
 	}
 	return true;

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -110,7 +110,7 @@ bool DuckDBPyConnection::IsJupyter() {
 py::object ArrowTableFromDataframe(const py::object &df) {
 	try {
 		return py::module_::import("pyarrow").attr("lib").attr("Table").attr("from_pandas")(df);
-	} catch (py::error_already_set &e) {
+	} catch (py::error_already_set &) {
 		// We don't fetch the original Python exception because it can cause a segfault
 		// The cause of this is not known yet, for now we just side-step the issue.
 		throw InvalidInputException(
@@ -995,7 +995,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Table(const string &tname) {
 	}
 	try {
 		return make_uniq<DuckDBPyRelation>(connection->Table(qualified_name.schema, qualified_name.name));
-	} catch (const CatalogException &e) {
+	} catch (const CatalogException &) {
 		// CatalogException will be of the type '... is not a table'
 		// Not a table in the database, make a query relation that can perform replacement scans
 		return RunQuery(StringUtil::Format("from %s", KeywordHelper::WriteOptionallyQuoted(tname)), tname);

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -144,7 +144,7 @@ static scalar_function_t CreateVectorizedFunction(PyObject *function, PythonExce
 			try {
 				python_object = py::module_::import("pyarrow").attr("lib").attr("Table").attr("from_arrays")(
 				    single_array, py::arg("names") = single_name);
-			} catch (py::error_already_set &ex) {
+			} catch (py::error_already_set &) {
 				throw InvalidInputException("Could not convert the result into an Arrow Table");
 			}
 		}


### PR DESCRIPTION
For third party libraries, instead of emitting the full paths (e.g. `third_party/zstd/zstd_compress.cpp`) we inline all builds in the `duckdb_build` directory - and generate `zstd_compress.cpp` instead. This works around an issue where the `lnk.exe` command generated by setuptools exceeds the Windows limit of `2^15` bytes. 