### PR TITLE
[Python] Code Quality - PEP8 Compliant + only relevant imports

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/conf.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/conf.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, List, Tuple
+from typing import Optional, List, Tuple
 from duckdb.experimental.spark.exception import ContributionsAcceptedError
 
 

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
@@ -3,10 +3,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     List,
     Optional,
-    Sequence,
     Tuple,
     Union,
     cast,
@@ -16,6 +14,7 @@ from typing import (
 import duckdb
 from duckdb import ColumnExpression, Expression, StarExpression
 
+from ._typing import ColumnOrName
 from ..errors import PySparkTypeError
 from ..exception import ContributionsAcceptedError
 from .column import Column
@@ -38,7 +37,7 @@ class DataFrame:
         self.relation = relation
         self.session = session
         self._schema = None
-        if self.relation != None:
+        if self.relation is not None:
             self._schema = duckdb_to_spark_schema(self.relation.columns, self.relation.types)
 
     def show(self, **kwargs) -> None:

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/group.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/group.py
@@ -16,12 +16,13 @@
 #
 
 from ..exception import ContributionsAcceptedError
-from typing import Callable, List, Optional, TYPE_CHECKING, overload, Dict, Union, cast, Tuple
+from typing import Callable, TYPE_CHECKING, overload, Dict, Union
 
 from .column import Column
 from .session import SparkSession
 from .dataframe import DataFrame
 from .functions import _to_column
+from ._typing import ColumnOrName
 
 if TYPE_CHECKING:
     from ._typing import LiteralType

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/readwriter.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/readwriter.py
@@ -1,12 +1,13 @@
-from typing import TYPE_CHECKING, Iterable, List, Optional, Union, cast
+from typing import TYPE_CHECKING, List, Optional, Union, cast
 
 from ..exception import ContributionsAcceptedError
 from .types import StructType
 
-PrimitiveType = Union[bool, float, int, str]
-OptionalPrimitiveType = Optional[PrimitiveType]
 
 from ..errors import PySparkNotImplementedError, PySparkTypeError
+
+PrimitiveType = Union[bool, float, int, str]
+OptionalPrimitiveType = Optional[PrimitiveType]
 
 if TYPE_CHECKING:
     from duckdb.experimental.spark.sql.dataframe import DataFrame
@@ -340,92 +341,92 @@ class DataFrameReader:
         +---+------------+
         """
 
-        if schema != None:
+        if schema is not None:
             raise ContributionsAcceptedError("The 'schema' option is not supported")
-        if primitivesAsString != None:
+        if primitivesAsString is not None:
             raise ContributionsAcceptedError(
                 "The 'primitivesAsString' option is not supported"
             )
-        if prefersDecimal != None:
+        if prefersDecimal is not None:
             raise ContributionsAcceptedError(
                 "The 'prefersDecimal' option is not supported"
             )
-        if allowComments != None:
+        if allowComments is not None:
             raise ContributionsAcceptedError(
                 "The 'allowComments' option is not supported"
             )
-        if allowUnquotedFieldNames != None:
+        if allowUnquotedFieldNames is not None:
             raise ContributionsAcceptedError(
                 "The 'allowUnquotedFieldNames' option is not supported"
             )
-        if allowSingleQuotes != None:
+        if allowSingleQuotes is not None:
             raise ContributionsAcceptedError(
                 "The 'allowSingleQuotes' option is not supported"
             )
-        if allowNumericLeadingZero != None:
+        if allowNumericLeadingZero is not None:
             raise ContributionsAcceptedError(
                 "The 'allowNumericLeadingZero' option is not supported"
             )
-        if allowBackslashEscapingAnyCharacter != None:
+        if allowBackslashEscapingAnyCharacter is not None:
             raise ContributionsAcceptedError(
                 "The 'allowBackslashEscapingAnyCharacter' option is not supported"
             )
-        if mode != None:
+        if mode is not None:
             raise ContributionsAcceptedError("The 'mode' option is not supported")
-        if columnNameOfCorruptRecord != None:
+        if columnNameOfCorruptRecord is not None:
             raise ContributionsAcceptedError(
                 "The 'columnNameOfCorruptRecord' option is not supported"
             )
-        if dateFormat != None:
+        if dateFormat is not None:
             raise ContributionsAcceptedError("The 'dateFormat' option is not supported")
-        if timestampFormat != None:
+        if timestampFormat is not None:
             raise ContributionsAcceptedError(
                 "The 'timestampFormat' option is not supported"
             )
-        if multiLine != None:
+        if multiLine is not None:
             raise ContributionsAcceptedError("The 'multiLine' option is not supported")
-        if allowUnquotedControlChars != None:
+        if allowUnquotedControlChars is not None:
             raise ContributionsAcceptedError(
                 "The 'allowUnquotedControlChars' option is not supported"
             )
-        if lineSep != None:
+        if lineSep is not None:
             raise ContributionsAcceptedError("The 'lineSep' option is not supported")
-        if samplingRatio != None:
+        if samplingRatio is not None:
             raise ContributionsAcceptedError(
                 "The 'samplingRatio' option is not supported"
             )
-        if dropFieldIfAllNull != None:
+        if dropFieldIfAllNull is not None:
             raise ContributionsAcceptedError(
                 "The 'dropFieldIfAllNull' option is not supported"
             )
-        if encoding != None:
+        if encoding is not None:
             raise ContributionsAcceptedError("The 'encoding' option is not supported")
-        if locale != None:
+        if locale is not None:
             raise ContributionsAcceptedError("The 'locale' option is not supported")
-        if pathGlobFilter != None:
+        if pathGlobFilter is not None:
             raise ContributionsAcceptedError(
                 "The 'pathGlobFilter' option is not supported"
             )
-        if recursiveFileLookup != None:
+        if recursiveFileLookup is not None:
             raise ContributionsAcceptedError(
                 "The 'recursiveFileLookup' option is not supported"
             )
-        if modifiedBefore != None:
+        if modifiedBefore is not None:
             raise ContributionsAcceptedError(
                 "The 'modifiedBefore' option is not supported"
             )
-        if modifiedAfter != None:
+        if modifiedAfter is not None:
             raise ContributionsAcceptedError(
                 "The 'modifiedAfter' option is not supported"
             )
-        if allowNonNumericNumbers != None:
+        if allowNonNumericNumbers is not None:
             raise ContributionsAcceptedError(
                 "The 'allowNonNumericNumbers' option is not supported"
             )
 
         if isinstance(path, str):
             path = [path]
-        if type(path) == list:
+        if  isinstance(path, list):
             if len(path) == 1:
                 rel = self.session.conn.read_json(path[0])
                 from .dataframe import DataFrame

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/session.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/session.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple, Any, Union, Iterable, TYPE_CHECKING
+from typing import Optional, List, Any, Union, Iterable, TYPE_CHECKING
 import uuid
 
 if TYPE_CHECKING:
@@ -54,9 +54,8 @@ class SparkSession:
     def _create_dataframe(self, data: Union[Iterable[Any], "PandasDataFrame"]) -> DataFrame:
         try:
             import pandas
-
             has_pandas = True
-        except:
+        except ImportError:
             has_pandas = False
         if has_pandas and isinstance(data, pandas.DataFrame):
             unique_name = f'pyspark_pandas_df_{uuid.uuid1()}'
@@ -155,7 +154,7 @@ class SparkSession:
             import pandas
 
             has_pandas = True
-        except:
+        except ImportError:
             has_pandas = False
         # Falsey check on pandas dataframe is not defined, so first check if it's not a pandas dataframe
         # Then check if 'data' is None or []

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/type_utils.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/type_utils.py
@@ -1,4 +1,3 @@
-import typing
 from duckdb.typing import DuckDBPyType
 from typing import List, Tuple, cast
 from .types import (

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/types.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/types.py
@@ -13,13 +13,13 @@ from typing import (
     TypeVar,
     ClassVar,
     Iterator,
-    TYPE_CHECKING,
 )
 from builtins import tuple
 import datetime
 import calendar
 import time
 import math
+import re
 
 import duckdb
 from duckdb.typing import DuckDBPyType
@@ -1079,7 +1079,6 @@ _all_complex_types: Dict[str, Type[Union[ArrayType, MapType, StructType]]] = dic
     (v.typeName(), v) for v in _complex_types
 )
 
-import re
 
 _FIXED_DECIMAL = re.compile(r"decimal\(\s*(\d+)\s*,\s*(-?\d+)\s*\)")
 _INTERVAL_DAYTIME = re.compile(r"interval (day|hour|minute|second)( to (day|hour|minute|second))?")

--- a/tools/pythonpkg/duckdb/filesystem.py
+++ b/tools/pythonpkg/duckdb/filesystem.py
@@ -1,6 +1,5 @@
 from fsspec import filesystem, AbstractFileSystem
 from fsspec.implementations.memory import MemoryFileSystem
-from shutil import copyfileobj
 from .bytes_io_wrapper import BytesIOWrapper
 from io import TextIOBase
 

--- a/tools/pythonpkg/scripts/generate_import_cache_cpp.py
+++ b/tools/pythonpkg/scripts/generate_import_cache_cpp.py
@@ -1,7 +1,7 @@
 import os
 
 script_dir = os.path.dirname(__file__)
-from typing import List, Dict, Union
+from typing import List, Dict
 import json
 
 # Load existing JSON data from a file if it exists
@@ -12,7 +12,6 @@ try:
         json_data = json.load(file)
 except FileNotFoundError:
     print("Please first use 'generate_import_cache_json.py' first to generate json")
-    pass
 
 
 # deal with leaf nodes?? Those are just PythonImportCacheItem

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -56,7 +56,7 @@ def pytest_collection_modifyitems(config, items):
         if item.name in skipped_tests:
             # test is named specifically
             item.add_marker(skip_listed)
-        elif item.parent != None and item.parent.name in skipped_tests:
+        elif item.parent is not None and item.parent.name in skipped_tests:
             # the class is named specifically
             item.add_marker(skip_listed)
 
@@ -142,7 +142,7 @@ def convert_arrow_to_numpy_backend(df):
 def convert_to_numpy(df):
     if (
         pyarrow_dtypes_enabled
-        and pyarrow_dtype != None
+        and pyarrow_dtype is not None
         and any([True for x in df.dtypes if isinstance(x, pyarrow_dtype)])
     ):
         return convert_arrow_to_numpy_backend(df)


### PR DESCRIPTION
- Remove unused python standard modules from files
- Keep imports on top of file when it's possible
- Add missing typing `ColumnOrName` on some spark module file
- Applie PEP8 good practices to core module
  - Avoid bare exception on pandas module check
  - Avoid checking equality on None (using `is` instead of `==`)

