### PR TITLE
Add a hint on how to resolve lockups when using ninja.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ This project and everyone participating in it is governed by a [Code of Conduct]
 * To build the project for debugging, run `make debug`.
 * To build optional components, use the flags defined in the Makefile, e.g. to build the JDBC driver, run `BUILD_JDBC=1 make`.
 * For parallel builds, you can use the [Ninja](https://ninja-build.org/) build system: `GEN=ninja make`.
+  * The default number of parallel processes can lockup the system depending on the CPU-to-memory ratio. If this happens, restrict the maximum number of build processes: `CMAKE_BUILD_PARALLEL_LEVEL=4 GEN=ninja make`.
 
 ## Testing
 


### PR DESCRIPTION
I ran into this issue several times when first trying to build the project, and found it difficult to get to a workable solution. Since the top level Makefile is just being used as a task runner, using `-j4` or similar has no effect. I assumed looking at `ninja` docs were the way to go, but it seems that is a bit indirect. Luckily I got a hint from a discussion on the `ninja` project which lead me to the ultimate solution I used as presented here. I know this file can't really have all the build permutations, but I think this is a useful enough hint, and somewhat difficult to get a straight answer on, that it makes sense to add.