### PR TITLE
Check Nested Types for UTF-8 Correctness

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -55,7 +55,7 @@ StringValueResult::StringValueResult(CSVStates &states, CSVStateMachine &state_m
 				parse_types[i] = {type.id(), true};
 				logical_types.emplace_back(type);
 			} else {
-				parse_types[i] = {LogicalTypeId::VARCHAR, type.id() == LogicalTypeId::VARCHAR};
+				parse_types[i] = {LogicalTypeId::VARCHAR, type.id() == LogicalTypeId::VARCHAR || type.IsNested()};
 				logical_types.emplace_back(LogicalType::VARCHAR);
 			}
 		}

--- a/test/sql/copy/csv/code_cov/csv_state_machine_invalid_utf.test
+++ b/test/sql/copy/csv/code_cov/csv_state_machine_invalid_utf.test
@@ -190,7 +190,7 @@ valid	valid	valid
 statement error
 SELECT * FROM read_csv('test/sql/copy/csv/data/test/invalid_utf_list.csv', header=0, auto_detect=false, quote = '"',columns = {'col1': 'INTEGER[]'} )
 ----
-Could not convert string
+Invalid unicode (byte sequence mismatch) detected.
 
 statement error
 SELECT * FROM read_csv('test/sql/copy/csv/data/test/invalid_utf_list.csv', header=0, auto_detect=false, quote = '"',columns = {'col1': 'INTEGER[]'} )


### PR DESCRIPTION
I was counting on a cast error for when CSV types are not varchar to catch UTF-8 errors, these are fine for integers and whatnot, since we do a byte-per-byte conversion, but can be problematic on nested types since these use split functions that might add borked data into string heaps.