### PR TITLE
Fix an InternalException caused by DICTIONARY_VECTOR inside `map_from_entries`

### DIFF
--- a/src/function/scalar/nested_functions.cpp
+++ b/src/function/scalar/nested_functions.cpp
@@ -14,9 +14,6 @@ void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
 	auto &result_struct = ListVector::GetEntry(result);
 	FlatVector::SetValidity(result_struct, input_struct_data.validity);
 
-	// Set the right vector type
-	result.SetVectorType(input.GetVectorType());
-
 	// Copy the list size
 	auto list_size = ListVector::GetListSize(input);
 	ListVector::SetListSize(result, list_size);
@@ -31,6 +28,13 @@ void MapUtil::ReinterpretMap(Vector &result, Vector &input, idx_t count) {
 	auto &input_values = MapVector::GetValues(input);
 	auto &result_values = MapVector::GetValues(result);
 	result_values.Reference(input_values);
+
+	if (input.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		result.Slice(*input_data.sel, count);
+	}
+
+	// Set the right vector type
+	result.SetVectorType(input.GetVectorType());
 }
 
 void BuiltinFunctions::RegisterNestedFunctions() {

--- a/test/sql/types/nested/map/map_from_entries/dictionary_vector.test
+++ b/test/sql/types/nested/map/map_from_entries/dictionary_vector.test
@@ -1,0 +1,25 @@
+# name: test/sql/types/nested/map/map_from_entries/dictionary_vector.test
+# group: [map_from_entries]
+
+statement ok
+create table t1 as select
+	id,
+	[{'key': 0, 'value': id}] as entry
+from range(1000) t(id)
+
+statement ok
+create table t2 as
+	select 0 id
+from range(5);
+
+query II
+select
+	t1.id,
+	map_from_entries(entry)
+from t1 join t2 using (id);
+----
+0	{0=0}
+0	{0=0}
+0	{0=0}
+0	{0=0}
+0	{0=0}


### PR DESCRIPTION
If the input is a dictionary vector, we need to slice the result, otherwise we set the VectorType to DICTIONARY_VECTOR, but none of the invariants that come to that are held up.