### PR TITLE
Fuzzer #2376: INTERVAL Muliply Overflow

### DIFF
--- a/src/function/scalar/operators/multiply.cpp
+++ b/src/function/scalar/operators/multiply.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/operator/multiply.hpp"
 
 #include "duckdb/common/limits.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/hugeint.hpp"
 #include "duckdb/common/types/uhugeint.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -28,10 +29,9 @@ double MultiplyOperator::Operation(double left, double right) {
 
 template <>
 interval_t MultiplyOperator::Operation(interval_t left, int64_t right) {
-	left.months = MultiplyOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(
-	    left.months, UnsafeNumericCast<int32_t>(right));
-	left.days = MultiplyOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(left.days,
-	                                                                                UnsafeNumericCast<int32_t>(right));
+	const auto right32 = Cast::Operation<int64_t, int32_t>(right);
+	left.months = MultiplyOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(left.months, right32);
+	left.days = MultiplyOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(left.days, right32);
 	left.micros = MultiplyOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(left.micros, right);
 	return left;
 }

--- a/test/fuzzer/sqlsmith/interval_multiply_overflow.test
+++ b/test/fuzzer/sqlsmith/interval_multiply_overflow.test
@@ -1,0 +1,14 @@
+# name: test/fuzzer/sqlsmith/interval_multiply_overflow.test
+# description: Overflow in interval part multiplication
+# group: [sqlsmith]
+
+statement ok
+create table all_types as 
+	select * exclude(small_enum, medium_enum, large_enum) 
+	from test_all_types();
+
+statement error
+SELECT multiply("interval", "bigint") 
+FROM all_types;
+----
+the value is out of range for the destination type INT32


### PR DESCRIPTION
Trap downcast overflow errors in interval multiplication.

fixes: duckdb/duckdb-fuzzer#2376