### PR TITLE
run_tests_one_by_one - add a default timeout of 1 hour

### DIFF
--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -25,8 +25,8 @@ parser.add_argument('--list', action='store_true', help='Print the list of tests
 parser.add_argument(
     '--timeout',
     action='store',
-    help='Add an optional timeout for each test (in seconds)',
-    default=None,
+    help='Add a timeout for each test (in seconds, default: 3600s - i.e. one hour)',
+    default=3600,
     type=valid_timeout,
 )
 


### PR DESCRIPTION
We use `run_tests_one_by_one` in the CI - but the timeout is not set by default. Since our CI jobs have limits of 6 hours each it doesn't make sense to allow individual tests to run for more than an hour.