### PR TITLE
Do not extract filters that cannot be hyper edges (Join Order Optimizer)

### DIFF
--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -334,7 +334,7 @@ vector<unique_ptr<FilterInfo>> RelationManager::ExtractEdges(LogicalOperator &op
 					filter_set.insert(*expression);
 					unordered_set<idx_t> bindings;
 					ExtractBindings(*expression, bindings);
-					if (bindings.size() == 0) {
+					if (bindings.empty()) {
 						// the filter is on a column that is not in our relational map. (example: limit_rownum)
 						// in this case we do not create a FilterInfo for it. (duckdb-internal/#1493)s
 						leftover_expressions.push_back(std::move(expression));

--- a/test/fuzzer/duckfuzz/bind_limit_num.test
+++ b/test/fuzzer/duckfuzz/bind_limit_num.test
@@ -1,0 +1,28 @@
+# name: test/fuzzer/duckfuzz/bind_limit_num.test
+# description: Fuzzyduck issue #1581
+# group: [duckfuzz]
+
+require tpch
+
+statement ok
+call dbgen(sf=0.001);
+
+statement ok
+SELECT subq_2.c0 AS c2
+FROM main.orders AS ref_0,
+(
+	SELECT 1 AS c0
+	FROM main.customer AS ref_1 RIGHT JOIN
+		 main.partsupp AS ref_2 ON
+		 (ref_2.ps_availqty IS NULL),
+			 (
+					 SELECT 20 AS c5,
+					 FROM main.orders AS ref_4,
+							  (
+									  SELECT 97 AS c0,
+												   ref_0.o_orderdate AS c1
+									  FROM main.orders LIMIT 93
+							  ) AS subq_0
+					 WHERE (ref_1.c_mktsegment ~~ ref_0.o_clerk)
+			 ) AS subq_1
+) AS subq_2;


### PR DESCRIPTION
This bug was a bit frustrating. 

Normally during join order optimization, we extract all filters and see if they can be used as join conditions. This helps us to identify filters like `t1.a + t2.b = t3.c` as a join filter. We visit/extract all filters for the relations within the reorder able join tree, and push the filters back in to the tree when we construct the plan.

Naively, the join order optimizer expects all filter expressions to have a column binding where the table index is in the relation mapping. In a happy case, this doesn't error, however, when limit rownum is introduced things start to go wrong. If a query has limit rownum, then a window operator is introduced to calculate the rownum. The rownum expression has its own table index that is never added to the relation map because it exists only between the window operator and the filter operator on top of the window.

This rownum filter is still extracted, and there is an attempt to push the filter back into the plan. The join order optimizer does not push the limit rownum filter perfectly back the place where it was extracted unfortunately. For some queries, it's possible there is another filter on top of the limit rownum filter. These filters are not combined during filter pullup/pushdown because of projection maps. It would require combining projection maps, which is out of scope for this PR. When the filter is pushed back in the wrong place, verifying the plan throws an error because the table index for the rownum expression no longer exists in the TableIndexes of the Filter.

There are multiple fixes for this, but I like this fix the most. Filters that cannot be turned into join conditions are most likely in the right place. I also don't want to apply filter pushdown again because debugging the optimizer can get difficult when certain optimizers are called within other optimizer. 

For now, the current fix is to not extract filters where all expression bindings have no table mapping in the relation mapping.

Still working on a simple test case. The test case requires the presence of the following
1. Delim Join
2. Limit statement
3. Filter on top of the limit statement but still below a join/other operators that might require its own relation