### PR TITLE
Fix return null constant in list_resize and list_aggr

### DIFF
--- a/src/core_functions/scalar/list/list_aggregates.cpp
+++ b/src/core_functions/scalar/list/list_aggregates.cpp
@@ -180,7 +180,8 @@ static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vect
 	auto &result_validity = FlatVector::Validity(result);
 
 	if (lists.GetType().id() == LogicalTypeId::SQLNULL) {
-		result_validity.SetInvalid(0);
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
 		return;
 	}
 

--- a/src/function/scalar/list/list_resize.cpp
+++ b/src/function/scalar/list/list_resize.cpp
@@ -9,7 +9,8 @@ namespace duckdb {
 void ListResizeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	D_ASSERT(args.data[1].GetType().id() == LogicalTypeId::UBIGINT);
 	if (result.GetType().id() == LogicalTypeId::SQLNULL) {
-		FlatVector::SetNull(result, 0, true);
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
 		return;
 	}
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);

--- a/test/sql/function/list/aggregates/null_or_empty.test
+++ b/test/sql/function/list/aggregates/null_or_empty.test
@@ -52,6 +52,16 @@ NULL
 
 endloop
 
+# select * from NULL list
+foreach func_name avg favg approx_count_distinct bit_and bit_or bit_xor bool_or bool_and count entropy first arbitrary histogram kurtosis last mad max median min mode array_agg list product sem skewness string_agg group_concat sum fsum sumKahan kahan_sum var_samp var_pop stddev stddev_pop variance stddev_samp
+
+query I
+select * from (SELECT list_aggr(NULL, '${func_name}'))
+----
+NULL
+
+endloop
+
 # empty list with 0 result
 foreach func_name approx_count_distinct count entropy
 

--- a/test/sql/function/list/list_resize.test
+++ b/test/sql/function/list/list_resize.test
@@ -97,6 +97,11 @@ NULL
 [NULL, NULL, NULL, NULL]
 [NULL, NULL, 5, 6, NULL, NULL]
 
+query I
+select * from (SELECT list_resize(NULL, 1, 1))
+----
+NULL
+
 # Nested Lists
 
 query I


### PR DESCRIPTION
Fixes issue where the following queries return an internal exception.

```sql
select * from (SELECT list_resize(NULL, 1, 1));
select * from (SELECT list_aggr(NULL, 'avg'));
```