### PR TITLE
Disable jemalloc for ARM distributions and clean up when closing DB

### DIFF
--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -10,7 +10,8 @@
 # Parquet is loaded by default on every build as its a essential part of DuckDB
 duckdb_extension_load(parquet)
 
-# Jemalloc is enabled by default for linux. MacOS malloc is already good enough and Jemalloc on windows has issues.
-if(NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND OS_NAME STREQUAL "linux" AND NOT ANDROID AND NOT ZOS)
+# The Linux allocator has issues so we use jemalloc, but only on x86 because page sizes are fixed at 4KB.
+# If page sizes vary for an architecture (e.g., arm64), we cannot create a portable binary due to jemalloc config
+if(OS_NAME STREQUAL "linux" AND (OS_ARCH STREQUAL "amd64" OR OS_ARCH STREQUAL "i386") AND NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS)
     duckdb_extension_load(jemalloc)
 endif()

--- a/extension/jemalloc/include/jemalloc_extension.hpp
+++ b/extension/jemalloc/include/jemalloc_extension.hpp
@@ -22,6 +22,7 @@ public:
 	static data_ptr_t Reallocate(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t old_size, idx_t size);
 
 	static void ThreadFlush(idx_t threshold);
+	static void FlushAll();
 };
 
 } // namespace duckdb

--- a/extension/jemalloc/jemalloc_extension.cpp
+++ b/extension/jemalloc/jemalloc_extension.cpp
@@ -71,6 +71,18 @@ void JemallocExtension::ThreadFlush(idx_t threshold) {
 	SetJemallocCTL("thread.peak.reset");
 }
 
+void JemallocExtension::FlushAll() {
+	// Flush thread-local cache
+	SetJemallocCTL("thread.tcache.flush");
+
+	// Flush all arenas
+	const auto purge_arena = StringUtil::Format("arena.%llu.purge", MALLCTL_ARENAS_ALL);
+	SetJemallocCTL(purge_arena.c_str());
+
+	// Reset the peak after resetting
+	SetJemallocCTL("thread.peak.reset");
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/helper.hpp"
 
 #include <cstdint>
 
@@ -95,15 +96,9 @@ PrivateAllocatorData::~PrivateAllocatorData() {
 //===--------------------------------------------------------------------===//
 // Allocator
 //===--------------------------------------------------------------------===//
-#ifdef USE_JEMALLOC
-Allocator::Allocator()
-    : Allocator(JemallocExtension::Allocate, JemallocExtension::Free, JemallocExtension::Reallocate, nullptr) {
-}
-#else
 Allocator::Allocator()
     : Allocator(Allocator::DefaultAllocate, Allocator::DefaultFree, Allocator::DefaultReallocate, nullptr) {
 }
-#endif
 
 Allocator::Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,
                      reallocate_function_ptr_t reallocate_function_p, unique_ptr<PrivateAllocatorData> private_data_p)
@@ -136,7 +131,7 @@ data_ptr_t Allocator::AllocateData(idx_t size) {
 	private_data->debug_info->AllocateData(result, size);
 #endif
 	if (!result) {
-		throw OutOfMemoryException("Failed to allocate block of %llu bytes", size);
+		throw OutOfMemoryException("Failed to allocate block of %llu bytes (bad allocation)", size);
 	}
 	return result;
 }
@@ -169,9 +164,34 @@ data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t old_size, idx_t s
 	private_data->debug_info->ReallocateData(pointer, new_pointer, old_size, size);
 #endif
 	if (!new_pointer) {
-		throw OutOfMemoryException("Failed to re-allocate block of %llu bytes", size);
+		throw OutOfMemoryException("Failed to re-allocate block of %llu bytes (bad allocation)", size);
 	}
 	return new_pointer;
+}
+
+data_ptr_t Allocator::DefaultAllocate(PrivateAllocatorData *private_data, idx_t size) {
+#ifdef USE_JEMALLOC
+	return JemallocExtension::Allocate(private_data, size);
+#else
+	return data_ptr_cast(malloc(size));
+#endif
+}
+
+void Allocator::DefaultFree(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size) {
+#ifdef USE_JEMALLOC
+	JemallocExtension::Free(private_data, pointer, size);
+#else
+	free(pointer);
+#endif
+}
+
+data_ptr_t Allocator::DefaultReallocate(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t old_size,
+                                        idx_t size) {
+#ifdef USE_JEMALLOC
+	return JemallocExtension::Reallocate(private_data, pointer, old_size, size);
+#else
+	return data_ptr_cast(realloc(pointer, size));
+#endif
 }
 
 shared_ptr<Allocator> &Allocator::DefaultAllocatorReference() {

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -209,6 +209,12 @@ void Allocator::ThreadFlush(idx_t threshold) {
 #endif
 }
 
+void Allocator::FlushAll() {
+#ifdef USE_JEMALLOC
+	JemallocExtension::FlushAll();
+#endif
+}
+
 //===--------------------------------------------------------------------===//
 // Debug Info (extended)
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -113,6 +113,7 @@ public:
 	DUCKDB_API static shared_ptr<Allocator> &DefaultAllocatorReference();
 
 	static void ThreadFlush(idx_t threshold);
+	static void FlushAll();
 
 private:
 	allocate_function_ptr_t allocate_function;

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -8,8 +8,10 @@
 
 #pragma once
 
-#include "duckdb/common/common.hpp"
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
 class Allocator;
@@ -95,16 +97,10 @@ public:
 	AllocatedData Allocate(idx_t size) {
 		return AllocatedData(*this, AllocateData(size), size);
 	}
-	static data_ptr_t DefaultAllocate(PrivateAllocatorData *private_data, idx_t size) {
-		return data_ptr_cast(malloc(size));
-	}
-	static void DefaultFree(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size) {
-		free(pointer);
-	}
+	static data_ptr_t DefaultAllocate(PrivateAllocatorData *private_data, idx_t size);
+	static void DefaultFree(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size);
 	static data_ptr_t DefaultReallocate(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t old_size,
-	                                    idx_t size) {
-		return data_ptr_cast(realloc(pointer, size));
-	}
+	                                    idx_t size);
 	static Allocator &Get(ClientContext &context);
 	static Allocator &Get(DatabaseInstance &db);
 	static Allocator &Get(AttachedDatabase &db);
@@ -137,7 +133,7 @@ void DeleteArray(T *ptr, idx_t size) {
 }
 
 template <typename T, typename... ARGS>
-T *AllocateObject(ARGS &&... args) {
+T *AllocateObject(ARGS &&...args) {
 	auto data = Allocator::DefaultAllocator().AllocateData(sizeof(T));
 	return new (data) T(std::forward<ARGS>(args)...);
 }

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -92,10 +92,8 @@ private:
 	vector<unique_ptr<atomic<bool>>> markers;
 	//! The threshold after which to flush the allocator after completing a task
 	atomic<idx_t> allocator_flush_threshold;
-	//! Requested thread count (set by the 'threads' setting)
-	atomic<int32_t> requested_thread_count;
-	//! The amount of threads currently running
-	atomic<int32_t> current_thread_count;
+	//! Requested thread count
+	atomic<int32_t> thread_count;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -92,8 +92,10 @@ private:
 	vector<unique_ptr<atomic<bool>>> markers;
 	//! The threshold after which to flush the allocator after completing a task
 	atomic<idx_t> allocator_flush_threshold;
-	//! Requested thread count
-	atomic<int32_t> thread_count;
+	//! Requested thread count (set by the 'threads' setting)
+	atomic<int32_t> requested_thread_count;
+	//! The amount of threads currently running
+	atomic<int32_t> current_thread_count;
 };
 
 } // namespace duckdb

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -56,7 +56,13 @@ DatabaseInstance::DatabaseInstance() {
 DatabaseInstance::~DatabaseInstance() {
 	// destroy all attached databases
 	GetDatabaseManager().ResetDatabases(scheduler);
-	// flush allocations
+	// destroy child elements
+	connection_manager.reset();
+	object_cache.reset();
+	scheduler.reset();
+	db_manager.reset();
+	buffer_manager.reset();
+	// finally, flush allocations
 	Allocator::FlushAll();
 }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -56,6 +56,8 @@ DatabaseInstance::DatabaseInstance() {
 DatabaseInstance::~DatabaseInstance() {
 	// destroy all attached databases
 	GetDatabaseManager().ResetDatabases(scheduler);
+	// flush allocations
+	Allocator::FlushAll();
 }
 
 BufferManager &BufferManager::GetBufferManager(DatabaseInstance &db) {

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -21,6 +21,10 @@ struct SchedulerThread {
 	explicit SchedulerThread(unique_ptr<thread> thread_p) : internal_thread(std::move(thread_p)) {
 	}
 
+	~SchedulerThread() {
+		Allocator::ThreadFlush(0);
+	}
+
 	unique_ptr<thread> internal_thread;
 #endif
 };

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -9,6 +9,7 @@
 #include "concurrentqueue.h"
 #include "duckdb/common/thread.hpp"
 #include "lightweightsemaphore.h"
+
 #include <thread>
 #else
 #include <queue>


### PR DESCRIPTION
jemalloc uses `#define`s, which make for unportable ARM builds, because page sizes are not consistent across different ARM archictectures. jemalloc is now only enabled on Linux x86 builds. This fixes an issue found internally.

Threads now clean up after themselves when they exit, and we do a bigger cleanup when the DB instance exits. This gets our memory footprint down quickly after closing, whereas before, it would only be guaranteed to clean up fully when the host process closed.

This fixes the following two related issues:
1. https://github.com/duckdb/duckdb/issues/9712
2. https://github.com/duckdb/duckdb/issues/11037

I've verified this like so:
```python3
$ python3 
Python 3.11.6 (main, Nov  2 2023, 04:39:43) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import duckdb
>>> con = duckdb.connect()
>>> con.sql('call dbgen(sf=2)')
100% ▕████████████████████████████████████████████████████████████▏ 
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ 0 rows  │
└─────────┘

>>> con.close()
```
Before, jemalloc would still hold on to memory, but now, the python process goes down to a negligible amount of memory.