### PR TITLE
Issue#9854 Scalar functions don't use or inherit collation

### DIFF
--- a/src/core_functions/scalar/string/left_right.cpp
+++ b/src/core_functions/scalar/string/left_right.cpp
@@ -53,7 +53,7 @@ static void LeftFunction(DataChunk &args, ExpressionState &state, Vector &result
 
 ScalarFunction LeftFun::GetFunction() {
 	return ScalarFunction({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR,
-	                      LeftFunction<LeftRightUnicode>);
+	                      LeftFunction<LeftRightUnicode>, FunctionRetCollationBinder);
 }
 
 ScalarFunction LeftGraphemeFun::GetFunction() {
@@ -89,7 +89,7 @@ static void RightFunction(DataChunk &args, ExpressionState &state, Vector &resul
 
 ScalarFunction RightFun::GetFunction() {
 	return ScalarFunction({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR,
-	                      RightFunction<LeftRightUnicode>);
+	                      RightFunction<LeftRightUnicode>, FunctionRetCollationBinder);
 }
 
 ScalarFunction RightGraphemeFun::GetFunction() {

--- a/src/core_functions/scalar/string/repeat.cpp
+++ b/src/core_functions/scalar/string/repeat.cpp
@@ -35,7 +35,8 @@ static void RepeatFunction(DataChunk &args, ExpressionState &state, Vector &resu
 ScalarFunctionSet RepeatFun::GetFunctions() {
 	ScalarFunctionSet repeat;
 	for (const auto &type : {LogicalType::VARCHAR, LogicalType::BLOB}) {
-		repeat.AddFunction(ScalarFunction({type, LogicalType::BIGINT}, type, RepeatFunction));
+		repeat.AddFunction(
+		    ScalarFunction({type, LogicalType::BIGINT}, type, RepeatFunction, FunctionRetCollationBinder));
 	}
 	return repeat;
 }

--- a/src/core_functions/scalar/string/reverse.cpp
+++ b/src/core_functions/scalar/string/reverse.cpp
@@ -50,7 +50,8 @@ static void ReverseFunction(DataChunk &args, ExpressionState &state, Vector &res
 }
 
 ScalarFunction ReverseFun::GetFunction() {
-	return ScalarFunction("reverse", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ReverseFunction);
+	return ScalarFunction("reverse", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ReverseFunction,
+	                      FunctionRetCollationBinder);
 }
 
 } // namespace duckdb

--- a/src/core_functions/scalar/string/starts_with.cpp
+++ b/src/core_functions/scalar/string/starts_with.cpp
@@ -38,7 +38,8 @@ struct StartsWithOperator {
 
 ScalarFunction StartsWithOperatorFun::GetFunction() {
 	return ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, StartsWithOperator>);
+	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, StartsWithOperator>,
+	                      FunctionAllCollationBinder);
 }
 
 } // namespace duckdb

--- a/src/core_functions/scalar/string/trim.cpp
+++ b/src/core_functions/scalar/string/trim.cpp
@@ -127,27 +127,30 @@ static void BinaryTrimFunction(DataChunk &input, ExpressionState &state, Vector 
 
 ScalarFunctionSet TrimFun::GetFunctions() {
 	ScalarFunctionSet trim;
-	trim.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, UnaryTrimFunction<true, true>));
+	trim.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, UnaryTrimFunction<true, true>,
+	                                FunctionAllCollationBinder));
 
 	trim.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                                BinaryTrimFunction<true, true>));
+	                                BinaryTrimFunction<true, true>, FunctionAllCollationBinder));
 	return trim;
 }
 
 ScalarFunctionSet LtrimFun::GetFunctions() {
 	ScalarFunctionSet ltrim;
-	ltrim.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, UnaryTrimFunction<true, false>));
+	ltrim.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, UnaryTrimFunction<true, false>,
+	                                 FunctionAllCollationBinder));
 	ltrim.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                                 BinaryTrimFunction<true, false>));
+	                                 BinaryTrimFunction<true, false>, FunctionAllCollationBinder));
 	return ltrim;
 }
 
 ScalarFunctionSet RtrimFun::GetFunctions() {
 	ScalarFunctionSet rtrim;
-	rtrim.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, UnaryTrimFunction<false, true>));
+	rtrim.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, UnaryTrimFunction<false, true>,
+	                                 FunctionAllCollationBinder));
 
 	rtrim.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
-	                                 BinaryTrimFunction<false, true>));
+	                                 BinaryTrimFunction<false, true>, FunctionAllCollationBinder));
 	return rtrim;
 }
 

--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -160,8 +160,8 @@ static unique_ptr<BaseStatistics> CaseConvertPropagateStats(ClientContext &conte
 }
 
 ScalarFunction LowerFun::GetFunction() {
-	return ScalarFunction("lower", {LogicalType::VARCHAR}, LogicalType::VARCHAR, CaseConvertFunction<false>, nullptr,
-	                      nullptr, CaseConvertPropagateStats<false>);
+	return ScalarFunction("lower", {LogicalType::VARCHAR}, LogicalType::VARCHAR, CaseConvertFunction<false>,
+	                      FunctionRetCollationBinder, nullptr, CaseConvertPropagateStats<false>);
 }
 
 void LowerFun::RegisterFunction(BuiltinFunctions &set) {
@@ -170,8 +170,8 @@ void LowerFun::RegisterFunction(BuiltinFunctions &set) {
 
 void UpperFun::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction({"upper", "ucase"},
-	                ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, CaseConvertFunction<true>, nullptr,
-	                               nullptr, CaseConvertPropagateStats<true>));
+	                ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, CaseConvertFunction<true>,
+	                               FunctionRetCollationBinder, nullptr, CaseConvertPropagateStats<true>));
 }
 
 } // namespace duckdb

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -237,6 +237,7 @@ static unique_ptr<FunctionData> BindConcatFunction(ClientContext &context, Scala
 		arg = LogicalType::VARCHAR;
 	}
 	bound_function.varargs = LogicalType::VARCHAR;
+	FunctionRetCollationBinder(context, bound_function, arguments);
 	return nullptr;
 }
 

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/function/scalar_function.hpp"
 
 #include "duckdb/common/enums/expression_type.hpp"
+#include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 
 namespace duckdb {

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -227,4 +227,17 @@ public:
 	}
 };
 
+//! FunctionRetCollationBinder and FunctionAllCollationBinder are used to calculate and assign collation to Function's
+//! return_type. With these binders, collation can be inherited by some functions. FunctionAllCollationBinder will
+//! invoke PushCollation for all arguments.
+
+//! Calculate collation with arguments' return_type and assign it to Function's return_type.
+unique_ptr<FunctionData> FunctionRetCollationBinder(ClientContext &context, ScalarFunction &bound_function,
+                                                    vector<unique_ptr<Expression>> &arguments);
+
+//! Calculate collation with arguments' return_type, invoke PushCollation to arguments and assign collation to
+//! Function's return_type.
+unique_ptr<FunctionData> FunctionAllCollationBinder(ClientContext &context, ScalarFunction &bound_function,
+                                                    vector<unique_ptr<Expression>> &arguments);
+
 } // namespace duckdb

--- a/test/issues/general/test_9854.test
+++ b/test/issues/general/test_9854.test
@@ -1,0 +1,337 @@
+# name: test/issues/general/test_9854.test
+# description: Issue 1091: Functions don't check or pass collation.
+# group: [general]
+
+statement ok
+create table tbl (a varchar, b varchar);
+
+statement ok
+insert into tbl values ('ö', '>>>>>ö<<<<<'), ('o', '>>>>>o<<<<<'), ('p', '>>>>>p<<<<<');
+
+######### !!! test concat()
+
+query I
+select a from tbl order by a;
+----
+o
+p
+ö
+
+query I
+select a from tbl order by a collate noaccent;
+----
+ö
+o
+p
+
+query I
+select a from tbl order by concat(a collate noaccent, a);
+----
+ö
+o
+p
+
+query I
+select a from tbl order by concat(a, a collate noaccent);
+----
+ö
+o
+p
+
+query I
+select a from tbl order by concat(a, a collate noaccent);
+----
+ö
+o
+p
+
+query I
+select a from tbl order by concat(concat(a, a collate noaccent), a);
+----
+ö
+o
+p
+
+query I
+select a from tbl order by concat(a collate noaccent, a collate noaccent);
+----
+ö
+o
+p
+
+statement error
+select a from tbl order by concat(a collate noaccent, a collate nocase);
+----
+
+query I
+select a from tbl order by a collate noaccent;
+----
+ö
+o
+p
+
+######### !!! test lower() and upper()
+
+query I
+select a from tbl order by lower(a);
+----
+o
+p
+ö
+
+query I
+select a from tbl order by lower(a collate noaccent);
+----
+ö
+o
+p
+
+query I
+select a from tbl order by upper(a);
+----
+o
+p
+ö
+
+query I
+select a from tbl order by upper(a collate noaccent);
+----
+ö
+o
+p
+
+######### !!! test trim(), ltrim() and rtrim()
+
+query I
+select a from tbl order by trim(b);
+----
+o
+p
+ö
+
+query I
+select a from tbl order by trim(b, '><');
+----
+o
+p
+ö
+
+query I
+select a from tbl order by trim(b collate noaccent);
+----
+ö
+o
+p
+
+query I
+select a from tbl order by trim(b collate noaccent, '><');
+----
+ö
+o
+p
+
+query I
+select a from tbl order by trim(b, '><' collate noaccent);
+----
+ö
+o
+p
+
+statement error
+select a from tbl order by trim(b collate nocase, '><' collate noaccent);
+----
+
+query I
+select a from tbl order by ltrim(b);
+----
+o
+p
+ö
+
+query I
+select a from tbl order by ltrim(b, '><');
+----
+o
+p
+ö
+
+query I
+select a from tbl order by ltrim(b collate noaccent);
+----
+ö
+o
+p
+
+query I
+select a from tbl order by ltrim(b collate noaccent, '><');
+----
+ö
+o
+p
+
+query I
+select a from tbl order by ltrim(b, '><' collate noaccent);
+----
+ö
+o
+p
+
+statement error
+select a from tbl order by ltrim(b collate nocase, '><' collate noaccent);
+----
+
+query I
+select a from tbl order by rtrim(b);
+----
+o
+p
+ö
+
+query I
+select a from tbl order by rtrim(b, '><');
+----
+o
+p
+ö
+
+query I
+select a from tbl order by rtrim(b collate noaccent);
+----
+ö
+o
+p
+
+query I
+select a from tbl order by rtrim(b collate noaccent, '><');
+----
+ö
+o
+p
+
+query I
+select a from tbl order by rtrim(b, '><' collate noaccent);
+----
+ö
+o
+p
+
+statement error
+select a from tbl order by rtrim(b collate nocase, '><' collate noaccent);
+----
+
+query I
+select trim(b, '>o') from tbl;
+----
+ö<<<<<
+<<<<<
+p<<<<<
+
+query I
+select trim(b, '>o' collate noaccent) from tbl;
+----
+<<<<<
+<<<<<
+p<<<<<
+
+query I
+select ltrim(b, '>o') from tbl;
+----
+ö<<<<<
+<<<<<
+p<<<<<
+
+query I
+select ltrim(b, '>o' collate noaccent) from tbl;
+----
+<<<<<
+<<<<<
+p<<<<<
+
+query I
+select rtrim(b, '<o') from tbl;
+----
+>>>>>ö
+>>>>>
+>>>>>p
+
+query I
+select rtrim(b, '<o' collate noaccent) from tbl;
+----
+>>>>>
+>>>>>
+>>>>>p
+
+
+######### !!! test repeat()
+
+query I
+select a from tbl order by repeat(a, 10);
+----
+o
+p
+ö
+
+query I
+select a from tbl order by repeat(a collate noaccent, 10);
+----
+ö
+o
+p
+
+######### !!! test left() and right()
+
+query I
+select a from tbl order by left(b, 6);
+----
+o
+p
+ö
+
+query I
+select a from tbl order by left(b collate noaccent, 6);
+----
+ö
+o
+p
+
+query I
+select a from tbl order by right(b, 6);
+----
+o
+p
+ö
+
+query I
+select a from tbl order by right(b collate noaccent, 6);
+----
+ö
+o
+p
+
+######### !!! test reverse()
+
+query I
+select a from tbl order by reverse(b);
+----
+o
+p
+ö
+
+query I
+select a from tbl order by reverse(b collate noaccent);
+----
+ö
+o
+p
+
+######### !!! test start_with()
+
+query I
+SELECT * FROM (SELECT 'A' COLLATE NOCASE) AS DERIVED(C1) WHERE c1 = 'a';
+----
+A
+
+query I
+SELECT * FROM (SELECT 'A' COLLATE NOCASE) AS DERIVED(C1) WHERE starts_with(c1, 'a');
+----
+A


### PR DESCRIPTION
This commit fixes:
1. Functions (trim, rtrim, ltrim, start_with) don't use collation during execution.
2. Functions (trim, rtrim, ltrim, concat, reverse, left, right, repeat, lower, upper) take VARCHAR as argument and return VARCHAR type, but the returned type doesn't inherit collation information.