### PR TITLE
Fix `ConstantVector::Reference` for dictionary arrays

### DIFF
--- a/test/sql/types/nested/array/array_sort.test
+++ b/test/sql/types/nested/array/array_sort.test
@@ -7,9 +7,6 @@ PRAGMA enable_verification
 statement ok
 PRAGMA verify_external
 
-# FIXME - there still seems to be a bug with array dictionary vectors
-require no_vector_verification
-
 query I
 SELECT array_value(i -1, i, i + 1) FROM range(4,1,-1) as r(i) ORDER BY 1 DESC;
 ----


### PR DESCRIPTION
We didn't use the selection vector in ConstantVector::Reference causing nulls to appear in deeply nested cross products (such as the one created in `array_sort.test`) using the new dictionary vector verification.

Closes https://github.com/duckdblabs/duckdb-internal/issues/1545