### PR TITLE
Fix upload assets OSX/2

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   osx:
     uses: ./.github/workflows/OSX.yml
+    secrets: inherit
     with:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -9,12 +9,6 @@ set -e
 
 DRY_RUN_PARAM=""
 
-# dryrun if AWS key is not set
-if [ -z "$AWS_ACCESS_KEY_ID" ]; then
-  echo "No access key available"
-  DRY_RUN_PARAM="--dryrun"
-fi
-
 # dryrun if repo is not duckdb/duckdb
 if [ "$GITHUB_REPOSITORY" != "duckdb/duckdb" ]; then
   echo "Repository is $GITHUB_REPOSITORY (not duckdb/duckdb)"
@@ -23,6 +17,17 @@ fi
 # dryrun if we are not in main
 if [ "$GITHUB_REF" != "refs/heads/main" ]; then
   echo "git ref is $GITHUB_REF (not refs/heads/main)"
+  DRY_RUN_PARAM="--dryrun"
+fi
+
+if [ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
+  echo "overriding DRY_RUN_PARAM, forcing upload"
+  DRY_RUN_PARAM=""
+fi
+
+# dryrun if AWS key is not set
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+  echo "No access key available"
   DRY_RUN_PARAM="--dryrun"
 fi
 
@@ -37,5 +42,5 @@ python3 -m pip install awscli
 
 for var in "$@"
 do
-    aws s3 cp $var s3://duckdb-staging/duckdb/$TARGET/. $DRY_RUN_PARAM
+    aws s3 cp $var s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/ $DRY_RUN_PARAM
 done


### PR DESCRIPTION
This has been tested more properly, I inverted the folder structure from "duckdb/tag" to "tag/$GITHUB_REPOSITORY", making it better suited also for other duckdb repository.

Also pass on secrets more properly.