### PR TITLE
Retry Binding Prior To Execution

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -38,6 +38,7 @@
 #include "duckdb/common/enums/output_type.hpp"
 #include "duckdb/common/enums/pending_execution_result.hpp"
 #include "duckdb/common/enums/physical_operator_type.hpp"
+#include "duckdb/common/enums/prepared_statement_mode.hpp"
 #include "duckdb/common/enums/profiler_format.hpp"
 #include "duckdb/common/enums/relation_type.hpp"
 #include "duckdb/common/enums/scan_options.hpp"
@@ -4862,6 +4863,29 @@ PreparedParamType EnumUtil::FromString<PreparedParamType>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "INVALID")) {
 		return PreparedParamType::INVALID;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<PreparedStatementMode>(PreparedStatementMode value) {
+	switch(value) {
+	case PreparedStatementMode::PREPARE_ONLY:
+		return "PREPARE_ONLY";
+	case PreparedStatementMode::PREPARE_AND_EXECUTE:
+		return "PREPARE_AND_EXECUTE";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+PreparedStatementMode EnumUtil::FromString<PreparedStatementMode>(const char *value) {
+	if (StringUtil::Equals(value, "PREPARE_ONLY")) {
+		return PreparedStatementMode::PREPARE_ONLY;
+	}
+	if (StringUtil::Equals(value, "PREPARE_AND_EXECUTE")) {
+		return PreparedStatementMode::PREPARE_AND_EXECUTE;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -214,6 +214,8 @@ enum class PragmaType : uint8_t;
 
 enum class PreparedParamType : uint8_t;
 
+enum class PreparedStatementMode : uint8_t;
+
 enum class ProfilerPrintFormat : uint8_t;
 
 enum class QuantileSerializationType : uint8_t;
@@ -585,6 +587,9 @@ const char* EnumUtil::ToChars<PragmaType>(PragmaType value);
 
 template<>
 const char* EnumUtil::ToChars<PreparedParamType>(PreparedParamType value);
+
+template<>
+const char* EnumUtil::ToChars<PreparedStatementMode>(PreparedStatementMode value);
 
 template<>
 const char* EnumUtil::ToChars<ProfilerPrintFormat>(ProfilerPrintFormat value);
@@ -1006,6 +1011,9 @@ PragmaType EnumUtil::FromString<PragmaType>(const char *value);
 
 template<>
 PreparedParamType EnumUtil::FromString<PreparedParamType>(const char *value);
+
+template<>
+PreparedStatementMode EnumUtil::FromString<PreparedStatementMode>(const char *value);
 
 template<>
 ProfilerPrintFormat EnumUtil::FromString<ProfilerPrintFormat>(const char *value);

--- a/src/include/duckdb/common/enums/prepared_statement_mode.hpp
+++ b/src/include/duckdb/common/enums/prepared_statement_mode.hpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/prepared_statement_mode.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class PreparedStatementMode : uint8_t {
+	PREPARE_ONLY,
+	PREPARE_AND_EXECUTE,
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -222,6 +222,7 @@ private:
 	unique_ptr<PendingQueryResult> PendingPreparedStatementInternal(ClientContextLock &lock,
 	                                                                shared_ptr<PreparedStatementData> statement_p,
 	                                                                const PendingQueryParameters &parameters);
+	void CheckIfPreparedStatementIsExecutable(PreparedStatementData &statement);
 
 	//! Internally prepare a SQL statement. Caller must hold the context_lock.
 	shared_ptr<PreparedStatementData>

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -24,6 +24,7 @@
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/main/external_dependencies.hpp"
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/common/enums/prepared_statement_mode.hpp"
 #include "duckdb/main/client_properties.hpp"
 #include "duckdb/main/client_context_state.hpp"
 #include "duckdb/main/settings.hpp"
@@ -215,14 +216,18 @@ private:
 	                                                                   unique_ptr<SQLStatement> statement,
 	                                                                   shared_ptr<PreparedStatementData> &prepared,
 	                                                                   const PendingQueryParameters &parameters);
-	unique_ptr<PendingQueryResult> PendingPreparedStatement(ClientContextLock &lock,
+	unique_ptr<PendingQueryResult> PendingPreparedStatement(ClientContextLock &lock, const string &query,
 	                                                        shared_ptr<PreparedStatementData> statement_p,
 	                                                        const PendingQueryParameters &parameters);
+	unique_ptr<PendingQueryResult> PendingPreparedStatementInternal(ClientContextLock &lock,
+	                                                                shared_ptr<PreparedStatementData> statement_p,
+	                                                                const PendingQueryParameters &parameters);
 
 	//! Internally prepare a SQL statement. Caller must hold the context_lock.
 	shared_ptr<PreparedStatementData>
 	CreatePreparedStatement(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
-	                        optional_ptr<case_insensitive_map_t<Value>> values = nullptr);
+	                        optional_ptr<case_insensitive_map_t<Value>> values = nullptr,
+	                        PreparedStatementMode mode = PreparedStatementMode::PREPARE_ONLY);
 	unique_ptr<PendingQueryResult> PendingStatementInternal(ClientContextLock &lock, const string &query,
 	                                                        unique_ptr<SQLStatement> statement,
 	                                                        const PendingQueryParameters &parameters);
@@ -251,6 +256,9 @@ private:
 
 	unique_ptr<PendingQueryResult> PendingQueryInternal(ClientContextLock &, const shared_ptr<Relation> &relation,
 	                                                    bool allow_stream_result);
+
+	void RebindPreparedStatement(ClientContextLock &lock, const string &query,
+	                             shared_ptr<PreparedStatementData> &prepared, const PendingQueryParameters &parameters);
 
 	template <class T>
 	unique_ptr<T> ErrorResult(ErrorData error, const string &query = string());

--- a/src/include/duckdb/main/client_context_state.hpp
+++ b/src/include/duckdb/main/client_context_state.hpp
@@ -9,11 +9,13 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/enums/prepared_statement_mode.hpp"
 
 namespace duckdb {
 class ClientContext;
 class ErrorData;
 class MetaTransaction;
+class PreparedStatementData;
 class SQLStatement;
 
 enum class RebindQueryInfo { DO_NOT_REBIND, ATTEMPT_TO_REBIND };
@@ -40,6 +42,12 @@ public:
 		return false;
 	}
 	virtual RebindQueryInfo OnPlanningError(ClientContext &context, SQLStatement &statement, ErrorData &error) {
+		return RebindQueryInfo::DO_NOT_REBIND;
+	}
+	virtual RebindQueryInfo OnFinalizePrepare(ClientContext &context, PreparedStatementMode mode) {
+		return RebindQueryInfo::DO_NOT_REBIND;
+	}
+	virtual RebindQueryInfo OnExecutePrepared(ClientContext &context, PreparedStatementData &prepared_statement) {
 		return RebindQueryInfo::DO_NOT_REBIND;
 	}
 };

--- a/src/include/duckdb/main/client_context_state.hpp
+++ b/src/include/duckdb/main/client_context_state.hpp
@@ -44,7 +44,8 @@ public:
 	virtual RebindQueryInfo OnPlanningError(ClientContext &context, SQLStatement &statement, ErrorData &error) {
 		return RebindQueryInfo::DO_NOT_REBIND;
 	}
-	virtual RebindQueryInfo OnFinalizePrepare(ClientContext &context, PreparedStatementMode mode) {
+	virtual RebindQueryInfo OnFinalizePrepare(ClientContext &context, PreparedStatementData &prepared_statement,
+	                                          PreparedStatementMode mode) {
 		return RebindQueryInfo::DO_NOT_REBIND;
 	}
 	virtual RebindQueryInfo OnExecutePrepared(ClientContext &context, PreparedStatementData &prepared_statement) {

--- a/src/include/duckdb/main/client_context_state.hpp
+++ b/src/include/duckdb/main/client_context_state.hpp
@@ -48,7 +48,8 @@ public:
 	                                          PreparedStatementMode mode) {
 		return RebindQueryInfo::DO_NOT_REBIND;
 	}
-	virtual RebindQueryInfo OnExecutePrepared(ClientContext &context, PreparedStatementData &prepared_statement) {
+	virtual RebindQueryInfo OnExecutePrepared(ClientContext &context, PreparedStatementData &prepared_statement,
+	                                          RebindQueryInfo current_rebind) {
 		return RebindQueryInfo::DO_NOT_REBIND;
 	}
 };

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -116,6 +116,7 @@ struct DebugClientContextState : public ClientContextState {
 		}
 		active_transaction = false;
 	}
+#ifdef DUCKDB_DEBUG_REBIND
 	RebindQueryInfo OnPlanningError(ClientContext &context, SQLStatement &statement, ErrorData &error) override {
 		return RebindQueryInfo::ATTEMPT_TO_REBIND;
 	}
@@ -130,6 +131,7 @@ struct DebugClientContextState : public ClientContextState {
 	                                  RebindQueryInfo current_rebind) override {
 		return RebindQueryInfo::ATTEMPT_TO_REBIND;
 	}
+#endif
 };
 #endif
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -521,7 +521,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientCon
 	for (auto const &s : registered_state) {
 		auto new_rebind = s.second->OnExecutePrepared(*this, *prepared, rebind);
 		if (new_rebind == RebindQueryInfo::ATTEMPT_TO_REBIND) {
-			rebind = new_rebind;
+			rebind = RebindQueryInfo::ATTEMPT_TO_REBIND;
 		}
 	}
 	if (rebind == RebindQueryInfo::ATTEMPT_TO_REBIND) {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -116,6 +116,18 @@ struct DebugClientContextState : public ClientContextState {
 		}
 		active_transaction = false;
 	}
+	RebindQueryInfo OnPlanningError(ClientContext &context, SQLStatement &statement, ErrorData &error) override {
+		return RebindQueryInfo::ATTEMPT_TO_REBIND;
+	}
+	RebindQueryInfo OnFinalizePrepare(ClientContext &context, PreparedStatementMode mode) override {
+		if (mode == PreparedStatementMode::PREPARE_AND_EXECUTE) {
+			return RebindQueryInfo::ATTEMPT_TO_REBIND;
+		}
+		return RebindQueryInfo::DO_NOT_REBIND;
+	}
+	RebindQueryInfo OnExecutePrepared(ClientContext &context, PreparedStatementData &prepared_statement) override {
+		return RebindQueryInfo::ATTEMPT_TO_REBIND;
+	}
 };
 #endif
 
@@ -353,7 +365,7 @@ ClientContext::CreatePreparedStatementInternal(ClientContextLock &lock, const st
 
 shared_ptr<PreparedStatementData>
 ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
-                                       optional_ptr<case_insensitive_map_t<Value>> values) {
+                                       optional_ptr<case_insensitive_map_t<Value>> values, PreparedStatementMode mode) {
 	// check if any client context state could request a rebind
 	bool can_request_rebind = false;
 	for (auto const &s : registered_state) {
@@ -363,13 +375,14 @@ ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &qu
 		}
 	}
 	if (can_request_rebind) {
+		bool rebind = false;
 		// if any registered state can request a rebind we do the binding on a copy first
+		shared_ptr<PreparedStatementData> result;
 		try {
-			return CreatePreparedStatementInternal(lock, query, statement->Copy(), values);
+			result = CreatePreparedStatementInternal(lock, query, statement->Copy(), values);
 		} catch (std::exception &ex) {
 			ErrorData error(ex);
 			// check if any registered client context state wants to try a rebind
-			bool rebind = false;
 			for (auto const &s : registered_state) {
 				auto info = s.second->OnPlanningError(*this, *statement, error);
 				if (info == RebindQueryInfo::ATTEMPT_TO_REBIND) {
@@ -380,7 +393,17 @@ ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &qu
 				throw;
 			}
 		}
+		for (auto const &s : registered_state) {
+			auto info = s.second->OnFinalizePrepare(*this, mode);
+			if (info == RebindQueryInfo::ATTEMPT_TO_REBIND) {
+				rebind = true;
+			}
+		}
+		if (!rebind) {
+			return result;
+		}
 	}
+
 	// an extension wants to do a rebind - do it once
 	return CreatePreparedStatementInternal(lock, query, std::move(statement), values);
 }
@@ -389,9 +412,35 @@ QueryProgress ClientContext::GetQueryProgress() {
 	return query_progress;
 }
 
-unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientContextLock &lock,
-                                                                       shared_ptr<PreparedStatementData> statement_p,
-                                                                       const PendingQueryParameters &parameters) {
+void BindPreparedStatementParameters(PreparedStatementData &statement, const PendingQueryParameters &parameters) {
+	case_insensitive_map_t<Value> owned_values;
+	if (parameters.parameters) {
+		auto &params = *parameters.parameters;
+		for (auto &val : params) {
+			owned_values.emplace(val);
+		}
+	}
+	statement.Bind(std::move(owned_values));
+}
+
+void ClientContext::RebindPreparedStatement(ClientContextLock &lock, const string &query,
+                                            shared_ptr<PreparedStatementData> &prepared,
+                                            const PendingQueryParameters &parameters) {
+	if (!prepared->unbound_statement) {
+		throw InternalException("ClientContext::RebindPreparedStatement called but PreparedStatementData did not have "
+		                        "an unbound statement so rebinding cannot be done");
+	}
+	// catalog was modified: rebind the statement before execution
+	auto new_prepared =
+	    CreatePreparedStatement(lock, query, prepared->unbound_statement->Copy(), parameters.parameters);
+	D_ASSERT(new_prepared->properties.bound_all_parameters);
+	prepared = std::move(new_prepared);
+	prepared->properties.bound_all_parameters = false;
+}
+
+unique_ptr<PendingQueryResult>
+ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock, shared_ptr<PreparedStatementData> statement_p,
+                                                const PendingQueryParameters &parameters) {
 	D_ASSERT(active_query);
 	auto &statement = *statement_p;
 	if (ValidChecker::IsInvalidated(ActiveTransaction()) && statement.properties.requires_valid_transaction) {
@@ -412,15 +461,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientCon
 		meta_transaction.ModifyDatabase(*entry);
 	}
 
-	// bind the bound values before execution
-	case_insensitive_map_t<Value> owned_values;
-	if (parameters.parameters) {
-		auto &params = *parameters.parameters;
-		for (auto &val : params) {
-			owned_values.emplace(val);
-		}
-	}
-	statement.Bind(std::move(owned_values));
+	BindPreparedStatementParameters(statement, parameters);
 
 	active_query->executor = make_uniq<Executor>(*this);
 	auto &executor = *active_query->executor;
@@ -456,6 +497,25 @@ unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientCon
 	active_query->prepared = std::move(statement_p);
 	active_query->SetOpenResult(*pending_result);
 	return pending_result;
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientContextLock &lock, const string &query,
+                                                                       shared_ptr<PreparedStatementData> prepared,
+                                                                       const PendingQueryParameters &parameters) {
+	bool require_rebind = false;
+	for (auto const &s : registered_state) {
+		auto rebind = s.second->OnExecutePrepared(*this, *prepared);
+		if (rebind == RebindQueryInfo::ATTEMPT_TO_REBIND) {
+			require_rebind = true;
+		}
+	}
+	if (!require_rebind) {
+		require_rebind = prepared->RequireRebind(*this, parameters.parameters);
+	}
+	if (require_rebind) {
+		RebindPreparedStatement(lock, query, prepared, parameters);
+	}
+	return PendingPreparedStatementInternal(lock, prepared, parameters);
 }
 
 PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &lock, BaseQueryResult &result,
@@ -645,7 +705,8 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementInternal(ClientCon
                                                                        unique_ptr<SQLStatement> statement,
                                                                        const PendingQueryParameters &parameters) {
 	// prepare the query for execution
-	auto prepared = CreatePreparedStatement(lock, query, std::move(statement), parameters.parameters);
+	auto prepared = CreatePreparedStatement(lock, query, std::move(statement), parameters.parameters,
+	                                        PreparedStatementMode::PREPARE_AND_EXECUTE);
 	idx_t parameter_count = !parameters.parameters ? 0 : parameters.parameters->size();
 	if (prepared->properties.parameter_count > 0 && parameter_count == 0) {
 		string error_message = StringUtil::Format("Expected %lld parameters, but none were supplied",
@@ -656,7 +717,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementInternal(ClientCon
 		return ErrorResult<PendingQueryResult>(ErrorData("Not all parameters were bound"), query);
 	}
 	// execute the prepared statement
-	return PendingPreparedStatement(lock, std::move(prepared), parameters);
+	return PendingPreparedStatementInternal(lock, std::move(prepared), parameters);
 }
 
 unique_ptr<QueryResult> ClientContext::RunStatementInternal(ClientContextLock &lock, const string &query,
@@ -763,16 +824,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatemen
 		if (statement) {
 			pending = PendingStatementInternal(lock, query, std::move(statement), parameters);
 		} else {
-			if (prepared->RequireRebind(*this, parameters.parameters)) {
-				// catalog was modified: rebind the statement before execution
-				auto new_prepared =
-				    CreatePreparedStatement(lock, query, prepared->unbound_statement->Copy(), parameters.parameters);
-				D_ASSERT(new_prepared->properties.bound_all_parameters);
-				new_prepared->unbound_statement = std::move(prepared->unbound_statement);
-				prepared = std::move(new_prepared);
-				prepared->properties.bound_all_parameters = false;
-			}
-			pending = PendingPreparedStatement(lock, prepared, parameters);
+			pending = PendingPreparedStatement(lock, query, prepared, parameters);
 		}
 	} catch (std::exception &ex) {
 		ErrorData error(ex);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -119,6 +119,7 @@ struct DebugClientContextState : public ClientContextState {
 	RebindQueryInfo OnPlanningError(ClientContext &context, SQLStatement &statement, ErrorData &error) override {
 		return RebindQueryInfo::ATTEMPT_TO_REBIND;
 	}
+#ifdef DUCKDB_DEBUG_REBIND
 	RebindQueryInfo OnFinalizePrepare(ClientContext &context, PreparedStatementMode mode) override {
 		if (mode == PreparedStatementMode::PREPARE_AND_EXECUTE) {
 			return RebindQueryInfo::ATTEMPT_TO_REBIND;
@@ -128,6 +129,7 @@ struct DebugClientContextState : public ClientContextState {
 	RebindQueryInfo OnExecutePrepared(ClientContext &context, PreparedStatementData &prepared_statement) override {
 		return RebindQueryInfo::ATTEMPT_TO_REBIND;
 	}
+#endif
 };
 #endif
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -409,9 +409,9 @@ ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &qu
 		if (!rebind) {
 			return result;
 		}
+		// an extension wants to do a rebind - do it once
 	}
 
-	// an extension wants to do a rebind - do it once
 	return CreatePreparedStatementInternal(lock, query, std::move(statement), values);
 }
 
@@ -520,7 +520,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientCon
 	}
 	for (auto const &s : registered_state) {
 		auto new_rebind = s.second->OnExecutePrepared(*this, *prepared, rebind);
-		if (rebind == RebindQueryInfo::ATTEMPT_TO_REBIND) {
+		if (new_rebind == RebindQueryInfo::ATTEMPT_TO_REBIND) {
 			rebind = new_rebind;
 		}
 	}


### PR DESCRIPTION
This PR adds two new callbacks to the `ClientContextState`:

```cpp
virtual RebindQueryInfo OnFinalizePrepare(ClientContext &context, PreparedStatementData &prepared_statement , PreparedStatementMode mode) {
    return RebindQueryInfo::DO_NOT_REBIND;
}
virtual RebindQueryInfo OnExecutePrepared(ClientContext &context, PreparedStatementData &prepared_statement) {
    return RebindQueryInfo::DO_NOT_REBIND;
}
```

`OnFinalizePrepare` is invoked after successfully creating a prepared statement. `PreparedStatementMode` indicates the purpose of the prepared statement - either we are only preparing (`PREPARE_ONLY`) or we are preparing in order to execute directly (`PREPARE_AND_EXECUTE`).

`OnExecutePrepared` is invoked when we execute a prepared statement that was previously prepared (i.e. one where `OnFinalizePrepare` was called with `PREPARE_ONLY`). 

Both of these callbacks allow the triggering of re-binding. 