### PR TITLE
Allow for customization of catalog lookup behavior for different catalog types 

### DIFF
--- a/.github/patches/extensions/postgres_scanner/rebind.patch
+++ b/.github/patches/extensions/postgres_scanner/rebind.patch
@@ -10,6 +10,31 @@ index 396664d..eb8f621 100644
  };
  
  class PostgresQueryFunction : public TableFunction {
+diff --git a/src/include/storage/postgres_catalog.hpp b/src/include/storage/postgres_catalog.hpp
+index 7e90c18..1b887fa 100644
+--- a/src/include/storage/postgres_catalog.hpp
++++ b/src/include/storage/postgres_catalog.hpp
+@@ -72,6 +72,20 @@ public:
+ 
+ 	void ClearCache();
+ 
++	//! Whether or not this catalog should search a specific type with the standard priority
++	CatalogLookupBehavior CatalogTypeLookupRule(CatalogType type) const override {
++		switch (type) {
++		case CatalogType::INDEX_ENTRY:
++		case CatalogType::TABLE_ENTRY:
++		case CatalogType::TYPE_ENTRY:
++		case CatalogType::VIEW_ENTRY:
++			return CatalogLookupBehavior::STANDARD;
++		default:
++			// unsupported type (e.g. scalar functions, aggregates, ...)
++			return CatalogLookupBehavior::NEVER_LOOKUP;
++		}
++	}
++
+ private:
+ 	void DropSchema(ClientContext &context, DropInfo &info) override;
+ 
 diff --git a/src/postgres_extension.cpp b/src/postgres_extension.cpp
 index 81bd46e..6e18d5a 100644
 --- a/src/postgres_extension.cpp

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -730,17 +730,28 @@ CatalogEntryLookup Catalog::TryLookupEntry(ClientContext &context, CatalogType t
                                            QueryErrorContext error_context) {
 	auto entries = GetCatalogEntries(context, catalog, schema);
 	vector<CatalogLookup> lookups;
+	vector<CatalogLookup> final_lookups;
 	lookups.reserve(entries.size());
 	for (auto &entry : entries) {
+		optional_ptr<Catalog> catalog_entry;
 		if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-			auto catalog_entry = Catalog::GetCatalogEntry(context, entry.catalog);
-			if (!catalog_entry) {
-				return {nullptr, nullptr, ErrorData()};
-			}
-			lookups.emplace_back(*catalog_entry, entry.schema);
+			catalog_entry = Catalog::GetCatalogEntry(context, entry.catalog);
 		} else {
-			lookups.emplace_back(Catalog::GetCatalog(context, entry.catalog), entry.schema);
+			catalog_entry = &Catalog::GetCatalog(context, entry.catalog);
 		}
+		if (!catalog_entry) {
+			return {nullptr, nullptr, ErrorData()};
+		}
+		D_ASSERT(catalog_entry);
+		auto lookup_behavior = catalog_entry->CatalogTypeLookupRule(type);
+		if (lookup_behavior == CatalogLookupBehavior::STANDARD) {
+			lookups.emplace_back(*catalog_entry, entry.schema);
+		} else if (lookup_behavior == CatalogLookupBehavior::LOWER_PRIORITY) {
+			final_lookups.emplace_back(*catalog_entry, entry.schema);
+		}
+	}
+	for (auto &lookup : final_lookups) {
+		lookups.emplace_back(std::move(lookup));
 	}
 	return Catalog::TryLookupEntry(context, lookups, type, name, if_not_found, error_context);
 }

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/enums/access_mode.hpp"
 #include "duckdb/common/enums/aggregate_handling.hpp"
+#include "duckdb/common/enums/catalog_lookup_behavior.hpp"
 #include "duckdb/common/enums/catalog_type.hpp"
 #include "duckdb/common/enums/compression_type.hpp"
 #include "duckdb/common/enums/cte_materialize.hpp"
@@ -784,6 +785,34 @@ CTEMaterialize EnumUtil::FromString<CTEMaterialize>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "CTE_MATERIALIZE_NEVER")) {
 		return CTEMaterialize::CTE_MATERIALIZE_NEVER;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<CatalogLookupBehavior>(CatalogLookupBehavior value) {
+	switch(value) {
+	case CatalogLookupBehavior::STANDARD:
+		return "STANDARD";
+	case CatalogLookupBehavior::LOWER_PRIORITY:
+		return "LOWER_PRIORITY";
+	case CatalogLookupBehavior::NEVER_LOOKUP:
+		return "NEVER_LOOKUP";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+CatalogLookupBehavior EnumUtil::FromString<CatalogLookupBehavior>(const char *value) {
+	if (StringUtil::Equals(value, "STANDARD")) {
+		return CatalogLookupBehavior::STANDARD;
+	}
+	if (StringUtil::Equals(value, "LOWER_PRIORITY")) {
+		return CatalogLookupBehavior::LOWER_PRIORITY;
+	}
+	if (StringUtil::Equals(value, "NEVER_LOOKUP")) {
+		return CatalogLookupBehavior::NEVER_LOOKUP;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/enums/on_entry_not_found.hpp"
 #include "duckdb/common/exception/catalog_exception.hpp"
+#include "duckdb/common/enums/catalog_lookup_behavior.hpp"
 #include <functional>
 
 namespace duckdb {
@@ -276,6 +277,11 @@ public:
 
 	virtual bool InMemory() = 0;
 	virtual string GetDBPath() = 0;
+
+	//! Whether or not this catalog should search a specific type with the standard priority
+	DUCKDB_API virtual CatalogLookupBehavior CatalogTypeLookupRule(CatalogType type) const {
+		return CatalogLookupBehavior::STANDARD;
+	}
 
 public:
 	template <class T>

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -72,6 +72,8 @@ enum class CSVState : uint8_t;
 
 enum class CTEMaterialize : uint8_t;
 
+enum class CatalogLookupBehavior : uint8_t;
+
 enum class CatalogType : uint8_t;
 
 enum class CheckpointAbort : uint8_t;
@@ -372,6 +374,9 @@ const char* EnumUtil::ToChars<CSVState>(CSVState value);
 
 template<>
 const char* EnumUtil::ToChars<CTEMaterialize>(CTEMaterialize value);
+
+template<>
+const char* EnumUtil::ToChars<CatalogLookupBehavior>(CatalogLookupBehavior value);
 
 template<>
 const char* EnumUtil::ToChars<CatalogType>(CatalogType value);
@@ -793,6 +798,9 @@ CSVState EnumUtil::FromString<CSVState>(const char *value);
 
 template<>
 CTEMaterialize EnumUtil::FromString<CTEMaterialize>(const char *value);
+
+template<>
+CatalogLookupBehavior EnumUtil::FromString<CatalogLookupBehavior>(const char *value);
 
 template<>
 CatalogType EnumUtil::FromString<CatalogType>(const char *value);

--- a/src/include/duckdb/common/enums/catalog_lookup_behavior.hpp
+++ b/src/include/duckdb/common/enums/catalog_lookup_behavior.hpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/catalog_lookup_behavior.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+//! Enum used for indicating lookup behavior of specific catalog types
+// STANDARD means the catalog lookups are performed in a regular manner (i.e. according to the users' search path)
+// LOWER_PRIORITY means the catalog lookups are de-prioritized and we do lookups in other catalogs first
+// NEVER_LOOKUP means we never do lookups for this specific type in this catalog
+enum class CatalogLookupBehavior : uint8_t { STANDARD = 0, LOWER_PRIORITY = 1, NEVER_LOOKUP = 2 };
+
+} // namespace duckdb


### PR DESCRIPTION
This PR adds a new callback to the catalog:

```cpp
CatalogLookupBehavior CatalogTypeLookupRule(CatalogType type);

enum class CatalogLookupBehavior : uint8_t { STANDARD = 0, LOWER_PRIORITY = 1, NEVER_LOOKUP = 2 };
```

This callback allows individual catalogs to specify whether or not they support certain catalog entries, or whether they support it but at a lower priority than other catalogs. 

* `STANDARD` means the catalog lookups are performed in a regular manner (i.e. according to the users' search path)
* `LOWER_PRIORITY` means the catalog lookups are de-prioritized and we do lookups in other catalogs first
* `NEVER_LOOKUP` means we never do lookups for this specific type in this catalog
