### PR TITLE
Refactor upload logic (towards staged releases)

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -41,3 +41,11 @@ jobs:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
+
+  java:
+    uses: ./.github/workflows/Java.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -33,3 +33,11 @@ jobs:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
+
+  python:
+    uses: ./.github/workflows/Python.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -25,3 +25,11 @@ jobs:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
+
+  windows:
+    uses: ./.github/workflows/Windows.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -17,3 +17,11 @@ jobs:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
+
+  linux-release:
+    uses: ./.github/workflows/LinuxRelease.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -1,6 +1,21 @@
 name: Java JDBC
 on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   repository_dispatch:
   push:
     branches:
@@ -34,10 +49,11 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{
     github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha
-    }}
+    }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
 
 jobs:
   java-linux-amd64:
@@ -57,12 +73,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
       - uses: ./.github/actions/manylinux_2014_setup
         with:
           ninja-build: 1
           ccache: 1
           jdk: 1
+          python_alias: 1
+          aws-cli: 1
 
       - name: Build
         shell: bash
@@ -70,15 +89,18 @@ jobs:
 
       - name: Java Tests
         shell: bash
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ inputs.skip_tests != 'true' }}
         working-directory: tools/jdbc
         run: make test_release
 
       - name: Deploy
         shell: bash
-        run: >
-          python3.8 scripts/asset-upload-gha.py
-          duckdb_jdbc-linux-amd64.jar=build/release/tools/jdbc/duckdb_jdbc.jar
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+        run: |
+          cp build/release/tools/jdbc/duckdb_jdbc.jar duckdb_jdbc-linux-amd64.jar
+          ./scripts/upload-assets-to-staging.sh duckdb_jdbc-linux-amd64.jar
       - uses: actions/upload-artifact@v3
         with:
           name: java-linux-amd64
@@ -102,6 +124,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
       - uses: ./.github/actions/ubuntu_18_setup
         with:
@@ -119,9 +142,12 @@ jobs:
 
       - name: Deploy
         shell: bash
-        run: >
-          python3.8 scripts/asset-upload-gha.py
-          duckdb_jdbc-linux-aarch64.jar=build/release/tools/jdbc/duckdb_jdbc.jar
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+        run: |
+          cp build/release/tools/jdbc/duckdb_jdbc.jar duckdb_jdbc-linux-aarch64.jar
+          ./scripts/upload-assets-to-staging.sh duckdb_jdbc-linux-aarch64.jar
 
       - uses: actions/upload-artifact@v3
         with:
@@ -138,6 +164,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -156,15 +183,18 @@ jobs:
 
           cmake --build . --config Release
       - name: Java Tests
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ inputs.skip_tests != 'true' }}
         shell: bash
         working-directory: tools/jdbc
         run: make test_release
       - name: Deploy
         shell: bash
-        run: >
-          python scripts/asset-upload-gha.py
-          duckdb_jdbc-windows-amd64.jar=tools/jdbc/duckdb_jdbc.jar
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+        run: |
+          cp tools/jdbc/duckdb_jdbc.jar duckdb_jdbc-windows-amd64.jar
+          ./scripts/upload-assets-to-staging.sh duckdb_jdbc-windows-amd64.jar
       - uses: actions/upload-artifact@v3
         with:
           name: java-windows-amd64
@@ -186,6 +216,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -198,7 +229,7 @@ jobs:
         shell: bash
         run: make
       - name: Java Tests
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ inputs.skip_tests != 'true' }}
         shell: bash
         working-directory: tools/jdbc
         run: make test_release
@@ -208,9 +239,12 @@ jobs:
           (cd examples/jdbc; make; make maven)
       - name: Deploy
         shell: bash
-        run: >
-          python scripts/asset-upload-gha.py
-          duckdb_jdbc-osx-universal.jar=build/release/tools/jdbc/duckdb_jdbc.jar
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+        run: |
+          cp build/release/tools/jdbc/duckdb_jdbc.jar duckdb_jdbc-osx-universal.jar
+          ./scripts/upload-assets-to-staging.sh duckdb_jdbc-osx-universal.jar
       - uses: actions/upload-artifact@v3
         with:
           name: java-osx-universal
@@ -231,6 +265,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
       - shell: bash
         run: mkdir jdbc-artifacts
@@ -289,7 +324,7 @@ jobs:
   jdbc-compliance:
     name: JDBC Compliance
     runs-on: ubuntu-20.04
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ inputs.skip_tests != 'true' }}
     needs: java-linux-amd64
     container: quay.io/pypa/manylinux2014_x86_64
     env:
@@ -300,12 +335,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
       - uses: ./.github/actions/manylinux_2014_setup
         with:
           ninja-build: 1
           ccache: 1
           jdk: 1
+          python_alias: 1
+          aws-cli: 1
 
       - name: Install
         shell: bash

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -47,7 +47,7 @@ on:
       - '!.github/workflows/Java.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{
+  group: java-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{
     github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha
     }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -229,8 +229,8 @@ jobs:
         post_install: rm build/release/src/libduckdb*
         deploy_as: linux_amd64
         treat_warn_as_error: 0
-        run_autoload_tests: ${{ inputs.skip_tests == 'true' && 0 || 1 }}
-        run_tests: ${{ inputs.skip_tests == 'true' && 0 || 1 }}
+        run_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
+        run_autoload_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
         s3_id: ${{ secrets.S3_ID }}
         s3_key: ${{ secrets.S3_KEY }}
         signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -46,7 +46,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  group: linuxrelease-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -1,6 +1,21 @@
 name: LinuxRelease
 on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   repository_dispatch:
   push:
     branches:
@@ -31,11 +46,12 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
 
 jobs:
  linux-release-64:
@@ -58,6 +74,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - uses: ./.github/actions/manylinux_2014_setup
       with:
@@ -80,20 +97,20 @@ jobs:
 
     - name: Test
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ inputs.skip_tests != 'true' }}
       run: |
         make
         python3 scripts/run_tests_one_by_one.py build/release/test/unittest "*" --time_execution
 
     - name: Tools Tests
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ inputs.skip_tests != 'true' }}
       run: |
         python3 -m pytest tools/shell/tests --shell-binary build/release/duckdb
 
     - name: Examples
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ inputs.skip_tests != 'true' }}
       run: |
         (cd examples/embedded-c; make)
         (cd examples/embedded-c++; make)
@@ -108,7 +125,7 @@ jobs:
         zip -j libduckdb-linux-amd64.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
         zip -j libduckdb-src.zip src/amalgamation/duckdb.hpp src/amalgamation/duckdb.cpp src/include/duckdb.h
         zip -j duckdb_odbc-linux-amd64.zip build/release/tools/odbc/libduckdb_odbc.so tools/odbc/linux_setup/unixodbc_setup.sh tools/odbc/linux_setup/update_odbc_path.py
-        python3 scripts/asset-upload-gha.py libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_odbc-linux-amd64.zip
+        ./scripts/upload-assets-to-staging.sh libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_odbc-linux-amd64.zip
 
     - uses: actions/upload-artifact@v3
       with:
@@ -141,6 +158,7 @@ jobs:
      - uses: actions/checkout@v3
        with:
          fetch-depth: 0
+         ref: ${{ inputs.git_ref }}
 
      - uses: ./.github/actions/ubuntu_18_setup
        with:
@@ -167,7 +185,7 @@ jobs:
          zip -j duckdb_cli-linux-aarch64.zip build/release/duckdb
          zip -j duckdb_odbc-linux-aarch64.zip build/release/tools/odbc/libduckdb_odbc.so
          zip -j libduckdb-linux-aarch64.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
-         python3 scripts/asset-upload-gha.py libduckdb-linux-aarch64.zip duckdb_cli-linux-aarch64.zip duckdb_odbc-linux-aarch64.zip
+         ./scripts/upload-assets-to-staging.sh libduckdb-linux-aarch64.zip duckdb_cli-linux-aarch64.zip duckdb_odbc-linux-aarch64.zip
 
      - uses: actions/upload-artifact@v3
        with:
@@ -190,6 +208,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - uses: ./.github/actions/ubuntu_18_setup
       with:
@@ -203,8 +222,8 @@ jobs:
         post_install: rm build/release/src/libduckdb*
         deploy_as: linux_amd64
         treat_warn_as_error: 0
-        run_autoload_tests: ${{ startsWith(github.ref, 'refs/tags/v') && 0 || 1 }}
-        run_tests: ${{ startsWith(github.ref, 'refs/tags/v') && 0 || 1 }}
+        run_autoload_tests: ${{ inputs.skip_tests == 'true' && 0 || 1 }}
+        run_tests: ${{ inputs.skip_tests == 'true' && 0 || 1 }}
         s3_id: ${{ secrets.S3_ID }}
         s3_key: ${{ secrets.S3_KEY }}
         signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
@@ -228,6 +247,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
       - uses: ./.github/actions/ubuntu_18_setup
         with:
@@ -258,7 +278,7 @@ jobs:
 
  check-load-install-extensions:
     name: Checks extension entries
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ inputs.skip_tests != 'true' }}
     runs-on: ubuntu-20.04
     needs: linux-extensions-64
     env:
@@ -270,6 +290,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - uses: actions/setup-python@v5
       with:
@@ -327,7 +348,7 @@ jobs:
 
  symbol-leakage:
     name: Symbol Leakage
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ inputs.skip_tests != 'true' }}
     runs-on: ubuntu-20.04
     needs: linux-release-64
 
@@ -335,6 +356,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - uses: actions/setup-python@v5
       with:
@@ -356,7 +378,7 @@ jobs:
 
  linux-httpfs:
     name: Linux HTTPFS
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ inputs.skip_tests != 'true' }}
     runs-on: ubuntu-20.04
     needs: linux-release-64
     env:
@@ -378,6 +400,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - uses: actions/setup-python@v5
       with:
@@ -414,7 +437,7 @@ jobs:
 
  amalgamation-tests:
     name: Amalgamation Tests
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ inputs.skip_tests != 'true' }}
     needs: linux-release-64
     runs-on: ubuntu-20.04
     env:
@@ -425,6 +448,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -82,6 +82,7 @@ jobs:
         ccache: 1
         odbc: 1
         python_alias: 1
+        aws-cli: 1
 
     - name: Install pytest
       run: |
@@ -119,6 +120,9 @@ jobs:
 
     - name: Deploy
       shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
         python3 scripts/amalgamation.py
         zip -j duckdb_cli-linux-amd64.zip build/release/duckdb
@@ -180,6 +184,9 @@ jobs:
 
      - name: Deploy
        shell: bash
+       env:
+         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
        run: |
          python3 scripts/amalgamation.py
          zip -j duckdb_cli-linux-aarch64.zip build/release/duckdb

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -8,7 +8,6 @@ on:
         type: string
       skip_tests:
         type: string
-  repository_dispatch:
   workflow_dispatch:
     inputs:
       override_git_describe:
@@ -17,6 +16,7 @@ on:
         type: string
       skip_tests:
         type: string
+  repository_dispatch:
   push:
     branches:
       - '**'
@@ -35,7 +35,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  group: osx-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -54,6 +54,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
+  CIBW_TEST_SKIP: ${{ inputs.skip_tests == 'true' && '*-*' || '' }}
 
 jobs:
 #  This is just a sanity check of Python 3.9 running with Arrow

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -403,4 +403,5 @@ jobs:
 
      - name: Cleanup Releases
        shell: bash
+       if: ${{ github.ref == 'refs/heads/main' && github.repository == 'duckdb/duckdb' }}
        run: python3 scripts/pypi_cleanup.py

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -48,7 +48,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  group: python-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -243,7 +243,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       shell: bash
       run: |
-        ./scripts/upload-assets-to-staging.sh duckdb_python_src.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz
+        cp tools/pythonpkg/dist/duckdb-*.tar.gz duckdb_python_src.tar.gz
+        ./scripts/upload-assets-to-staging.sh duckdb_python_src.tar.gz
         if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
           twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
         fi

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -1,6 +1,21 @@
 name: Python
 on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   repository_dispatch:
   push:
     branches:
@@ -33,11 +48,12 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
 
 jobs:
 #  This is just a sanity check of Python 3.9 running with Arrow
@@ -54,6 +70,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - uses: actions/setup-python@v5
       with:
@@ -95,6 +112,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - uses: ./.github/actions/manylinux_2014_setup
       with:
@@ -114,8 +132,8 @@ jobs:
         s3_id: ${{ secrets.S3_ID }}
         s3_key: ${{ secrets.S3_KEY }}
         signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
-        run_tests: ${{ startsWith(github.ref, 'refs/tags/v') && 0 || 1  }}
-        run_autoload_tests: ${{ startsWith(github.ref, 'refs/tags/v') && 0 || 1  }}
+        run_tests: ${{ inputs.skip_tests == 'true' && 0 || 1  }}
+        run_autoload_tests: ${{ inputs.skip_tests != 'true' && 0 || 1  }}
         treat_warn_as_error: 0
         ninja: 1
 
@@ -168,6 +186,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
@@ -219,9 +238,11 @@ jobs:
       env:
         TWINE_USERNAME: '__token__'
         TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       shell: bash
       run: |
-        python scripts/asset-upload-gha.py duckdb_python_src.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz
+        ./scripts/upload-assets-to-staging.sh duckdb_python_src.tar.gz=tools/pythonpkg/dist/duckdb-*.tar.gz
         if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
           twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
         fi
@@ -245,6 +266,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
       - uses: actions/setup-python@v5
         with:
@@ -311,6 +333,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
       - uses: actions/setup-python@v5
         with:
@@ -368,6 +391,7 @@ jobs:
      - uses: actions/checkout@v3
        with:
          fetch-depth: 0
+         ref: ${{ inputs.git_ref }}
 
      - uses: actions/setup-python@v5
        with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -133,8 +133,8 @@ jobs:
         s3_id: ${{ secrets.S3_ID }}
         s3_key: ${{ secrets.S3_KEY }}
         signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
-        run_tests: ${{ inputs.skip_tests == 'true' && 0 || 1  }}
-        run_autoload_tests: ${{ inputs.skip_tests != 'true' && 0 || 1  }}
+        run_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
+        run_autoload_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
         treat_warn_as_error: 0
         ninja: 1
 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -291,6 +291,6 @@ jobs:
          s3_id: ${{ secrets.S3_ID }}
          s3_key: ${{ secrets.S3_KEY }}
          signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
-         run_tests: ${{ inputs.skip_tests == 'true' && 0 || 1 }}
-         run_autoload_tests: ${{ inputs.skip_tests == 'true' && 0 || 1 }}
+         run_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
+         run_autoload_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
          unittest_script: python3 scripts/run_tests_one_by_one.py ./build/release/test/Release/unittest.exe

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,6 +1,21 @@
 name: Windows
 on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   repository_dispatch:
   push:
     branches:
@@ -31,11 +46,12 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
 
 jobs:
  win-release-64:
@@ -78,26 +94,29 @@ jobs:
 
     - name: Test
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ inputs.skip_tests != 'true' }}
       run: |
         test/Release/unittest.exe
 
     - name: Tools Test
       shell: bash
-      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ inputs.skip_tests != 'true' }}
       run: |
         python -m pytest tools/shell/tests --shell-binary Release/duckdb.exe
         tools/sqlite3_api_wrapper/Release/test_sqlite3_api_wrapper.exe
 
     - name: Deploy
       shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
         python scripts/amalgamation.py
         choco install zip -y --force
         zip -j duckdb_cli-windows-amd64.zip Release/duckdb.exe
         zip -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
         zip -j duckdb_odbc-windows-amd64.zip tools/odbc/bin/Release/*
-        python scripts/asset-upload-gha.py libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip duckdb_odbc-windows-amd64.zip
+        ./scripts/upload-assets-to-staging.sh libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip duckdb_odbc-windows-amd64.zip
 
     - uses: actions/upload-artifact@v3
       with:
@@ -204,7 +223,7 @@ jobs:
  mingw:
      name: MingW (64 Bit)
      runs-on: windows-latest
-     if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+     if: ${{ inputs.skip_tests != 'true' }}
      needs: win-release-64
      steps:
        - uses: actions/checkout@v3
@@ -270,6 +289,6 @@ jobs:
          s3_id: ${{ secrets.S3_ID }}
          s3_key: ${{ secrets.S3_KEY }}
          signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
-         run_tests: ${{ startsWith(github.ref, 'refs/tags/v') && 0 || 1 }}
-         run_autoload_tests: ${{ startsWith(github.ref, 'refs/tags/v') && 0 || 1 }}
+         run_tests: ${{ inputs.skip_tests == 'true' && 0 || 1 }}
+         run_autoload_tests: ${{ inputs.skip_tests == 'true' && 0 || 1 }}
          unittest_script: python3 scripts/run_tests_one_by_one.py ./build/release/test/Release/unittest.exe

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -46,7 +46,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  group: windows-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -150,6 +150,7 @@ jobs:
         Reg Query "HKCU\SOFTWARE\ODBC\ODBC.INI\ODBC"
 
     - name: Test Standard ODBC tests
+      if: ${{ inputs.skip_tests != 'true' }}
       shell: bash
       run: |
         tools/odbc/bin/Release/test_odbc.exe
@@ -164,6 +165,7 @@ jobs:
         Reg Query "HKCU\SOFTWARE\ODBC\ODBC.INI\DuckDB"
 
     - name: Test Connection ODBC tests
+      if: ${{ inputs.skip_tests != 'true' }}
       shell: bash
       run: |
         tools/odbc/bin/Release/test_connection_odbc.exe

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -42,5 +42,5 @@ python3 -m pip install awscli
 
 for var in "$@"
 do
-    aws s3 cp $var s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/ $DRY_RUN_PARAM
+    aws s3 cp $var s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/ $DRY_RUN_PARAM --region us-east-2
 done


### PR DESCRIPTION
Various different changes connected to https://github.com/duckdb/duckdb/pull/11133.

Idea is moving workflows so that they can be invoked via workflow_call and passing them a regular set of parameters.
This would allow long term more composable workflows, and short term to have a scheduled jobs preparing staged releases artifact ahead of time.

To keep changes manageable, rework is currently done only for workflows that do generate relevant artifacts, basically whatever was uploaded via `scripts/asset-upload-gha.py`.

One of the bonuses of this rework:
* skip_tests can be provided to workflows, and it's not anymore tied to a tag being present
Decoupling this logic allows both more flexibility AND allows to reduce codepaths tested only on release day

Adding `if: ${{ skip_tests == 'true' }}` can (and should) be considered even in more places, but this can also be an incremental change. I added a global variable allowing skipping all Python tests, that can come handy given tests might be finicky in different ways, and we might want to do without the randomness during release processes.

Not done as part of this PR but yet to come:
* fix Python libraries to inherit proper version from OVERRIDE_GIT_DESCRIBE
* move out of `twine upload` and into staged releases also for Python
* add (and test) the script invoking `python3 scripts/asset-upload-gha.py` on the staged artifcats

This PR has been tested in a fork of duckdb with the right privileges, more stress testing underway, but I feel this chunk of work can be already considered for review and eventually merging.