### PR TITLE
More Array and Union fixes

### DIFF
--- a/src/common/types/row/tuple_data_collection.cpp
+++ b/src/common/types/row/tuple_data_collection.cpp
@@ -263,22 +263,20 @@ static inline void ToUnifiedFormatInternal(TupleDataVectorFormat &format, Vector
 		// vector This allows us to reuse all the list serialization functions for array types too.
 		auto array_size = ArrayType::GetSize(vector.GetType());
 
-		// Get the max offset from the sel vector
-		idx_t max_offset = count;
-		for (idx_t i = 0; i < count; i++) {
-			max_offset = MaxValue(max_offset, format.unified.sel->get_index(i));
-		}
-		max_offset++;
+		// How many list_entry_t's do we need to cover the whole child array?
+		auto child_array_total_size = ArrayVector::GetTotalSize(vector);
+		auto list_entry_t_count = (child_array_total_size + array_size - 1) / array_size;
 
-		// create list entries
-		format.array_list_entries = make_uniq_array<list_entry_t>(max_offset);
-		for (idx_t i = 0; i < max_offset; i++) {
+		// Create list entries!
+		format.array_list_entries = make_uniq_array<list_entry_t>(list_entry_t_count);
+		for (idx_t i = 0; i < list_entry_t_count; i++) {
 			format.array_list_entries[i].length = array_size;
 			format.array_list_entries[i].offset = i * array_size;
 		}
 		format.unified.data = reinterpret_cast<data_ptr_t>(format.array_list_entries.get());
 
-		ToUnifiedFormatInternal(format.children[0], ArrayVector::GetEntry(vector), count * array_size);
+		ToUnifiedFormatInternal(reinterpret_cast<TupleDataVectorFormat &>(format.children[0]),
+		                        ArrayVector::GetEntry(vector), count * array_size);
 	} break;
 	default:
 		break;

--- a/src/common/types/row/tuple_data_collection.cpp
+++ b/src/common/types/row/tuple_data_collection.cpp
@@ -264,8 +264,9 @@ static inline void ToUnifiedFormatInternal(TupleDataVectorFormat &format, Vector
 		auto array_size = ArrayType::GetSize(vector.GetType());
 
 		// How many list_entry_t's do we need to cover the whole child array?
+		// Make sure we round up so its all covered
 		auto child_array_total_size = ArrayVector::GetTotalSize(vector);
-		auto list_entry_t_count = (child_array_total_size + array_size - 1) / array_size;
+		auto list_entry_t_count = (child_array_total_size + array_size) / array_size;
 
 		// Create list entries!
 		format.array_list_entries = make_uniq_array<list_entry_t>(list_entry_t_count);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -683,10 +683,16 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		return Value::MAP(ListType::GetChildType(type), std::move(children));
 	}
 	case LogicalTypeId::UNION: {
-		auto tag = UnionVector::GetTag(*vector, index);
-		auto value = UnionVector::GetMember(*vector, tag).GetValue(index);
-		auto members = UnionType::CopyMemberTypes(type);
-		return Value::UNION(members, tag, std::move(value));
+		// Remember to pass the original index_p here so we dont slice twice when looking up the tag
+		// in case this is a dictionary vector
+		union_tag_t tag;
+		if (UnionVector::TryGetTag(*vector, index_p, tag)) {
+			auto value = UnionVector::GetMember(*vector, tag).GetValue(index_p);
+			auto members = UnionType::CopyMemberTypes(type);
+			return Value::UNION(members, tag, std::move(value));
+		} else {
+			return Value(vector->GetType());
+		}
 	}
 	case LogicalTypeId::STRUCT: {
 		// we can derive the value schema from the vector schema
@@ -2381,17 +2387,34 @@ void UnionVector::SetToMember(Vector &union_vector, union_tag_t tag, Vector &mem
 	}
 }
 
-union_tag_t UnionVector::GetTag(const Vector &vector, idx_t index) {
+bool UnionVector::TryGetTag(const Vector &vector, idx_t index, union_tag_t &result) {
 	// the tag vector is always the first struct child.
 	auto &tag_vector = *StructVector::GetEntries(vector)[0];
 	if (tag_vector.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
 		auto &child = DictionaryVector::Child(tag_vector);
-		return FlatVector::GetData<union_tag_t>(child)[index];
+		auto &dict_sel = DictionaryVector::SelVector(tag_vector);
+		auto mapped_idx = dict_sel.get_index(index);
+		if (FlatVector::IsNull(child, mapped_idx)) {
+			return false;
+		} else {
+			result = FlatVector::GetData<union_tag_t>(child)[mapped_idx];
+			return true;
+		}
 	}
 	if (tag_vector.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-		return ConstantVector::GetData<union_tag_t>(tag_vector)[0];
+		if (ConstantVector::IsNull(tag_vector)) {
+			return false;
+		} else {
+			result = ConstantVector::GetData<union_tag_t>(tag_vector)[0];
+			return true;
+		}
 	}
-	return FlatVector::GetData<union_tag_t>(tag_vector)[index];
+	if (FlatVector::IsNull(tag_vector, index)) {
+		return false;
+	} else {
+		result = FlatVector::GetData<union_tag_t>(tag_vector)[index];
+		return true;
+	}
 }
 
 //! Raw selection vector passed in (not merged with any other selection vectors)

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -526,8 +526,9 @@ struct UnionVector {
 	DUCKDB_API static const Vector &GetTags(const Vector &v);
 	DUCKDB_API static Vector &GetTags(Vector &v);
 
-	//! Get the tag at the specific index of the union vector
-	DUCKDB_API static union_tag_t GetTag(const Vector &vector, idx_t index);
+	//! Try to get the tag at the specific flat index of the union vector. Returns false if the tag is NULL.
+	//! This will handle and map the index properly for constant and dictionary vectors internally.
+	DUCKDB_API static bool TryGetTag(const Vector &vector, idx_t index, union_tag_t &tag);
 
 	//! Get the member vector of a union vector by index
 	DUCKDB_API static const Vector &GetMember(const Vector &vector, idx_t member_index);

--- a/test/fuzzer/duckfuzz/array_hash.test
+++ b/test/fuzzer/duckfuzz/array_hash.test
@@ -2,10 +2,10 @@
 # group: [duckfuzz]
 
 statement ok
-PRAGMA enable_verification
+PRAGMA threads = 1
 
-# FIXME: bug in dictionary vector operator
-require no_vector_verification
+statement ok
+PRAGMA enable_verification
 
 # Duckfuzz Issue #1434
 # Caused by not calculating the correct number of child elements when hashing a constant array vector.

--- a/test/sql/index/art/types/test_art_union.test
+++ b/test/sql/index/art/types/test_art_union.test
@@ -4,12 +4,8 @@
 
 load __TEST_DIR__/test_art_union.db
 
-# FIXME bug in sequence/constant vector handling
-require no_vector_verification
-
-# FIXME - missing verification?
-#statement ok
-#PRAGMA enable_verification
+statement ok
+PRAGMA enable_verification
 
 statement ok
 CREATE TABLE tbl (

--- a/test/sql/types/nested/array/array_cast.test
+++ b/test/sql/types/nested/array/array_cast.test
@@ -7,9 +7,6 @@ PRAGMA enable_verification
 statement ok
 PRAGMA verify_external
 
-# FIXME - there seems to be a bug in handling of constant vectors in array -> LIST casting
-require no_vector_verification
-
 # Should be able to cast to varchar
 query I
 SELECT array_value(1, 2, 3)::VARCHAR

--- a/test/sql/types/nested/array/array_try_cast.test
+++ b/test/sql/types/nested/array/array_try_cast.test
@@ -4,8 +4,6 @@
 statement ok
 PRAGMA enable_verification
 
-# FIXME - there seems to be a bug in list -> array casting and constants
-require no_vector_verification
 
 query I
 SELECT TRY_CAST(array_value(1,2) as INTEGER[3]);

--- a/test/sql/types/union/union_cast.test
+++ b/test/sql/types/union/union_cast.test
@@ -5,9 +5,6 @@
 statement ok
 SET default_null_order='nulls_first';
 
-# FIXME: bug in constant/sequence
-require no_vector_verification
-
 # Test value -> union casts
 statement ok
 create table tbl1(u UNION(i32 INT, str VARCHAR));
@@ -25,7 +22,7 @@ three
 
 # Test union -> value cast
 
-# cannot cast union to value in the general case 
+# cannot cast union to value in the general case
 statement error
 SELECT u::int FROM tbl1;
 ----

--- a/test/sql/types/union/union_join.test
+++ b/test/sql/types/union/union_join.test
@@ -2,12 +2,8 @@
 # description: Test union type joins
 # group: [union]
 
-# FIXME bug in sequence/constant vector handling
-require no_vector_verification
-
-# FIXME - missing verification?
-#statement ok
-#PRAGMA enable_verification
+statement ok
+PRAGMA enable_verification
 
 statement ok
 SET default_null_order='nulls_first';

--- a/test/sql/types/union/union_limit_offset.test
+++ b/test/sql/types/union/union_limit_offset.test
@@ -2,12 +2,8 @@
 # description: Test union type limit and offset
 # group: [union]
 
-# FIXME bug in sequence/constant vector handling
-require no_vector_verification
-
-# FIXME - missing verification?
-#statement ok
-#PRAGMA enable_verification
+statement ok
+PRAGMA enable_verification
 
 statement ok
 CREATE TABLE tbl1 (u UNION(num INT, str VARCHAR));

--- a/test/sql/types/union/union_validity.test
+++ b/test/sql/types/union/union_validity.test
@@ -1,12 +1,8 @@
 # name: test/sql/types/union/union_validity.test
 # group: [union]
 
-# FIXME bug in sequence/constant vector handling
-require no_vector_verification
-
-# FIXME - missing verification?
-#statement ok
-#PRAGMA enable_verification
+statement ok
+PRAGMA enable_verification
 
 statement ok
 CREATE TABLE tbl (u UNION(a INT, b VARCHAR));


### PR DESCRIPTION
This PR fixes a bunch of array and union related issues found by the newly added verification passes and fuzzing.

Closes https://github.com/duckdblabs/duckdb-internal/issues/1567 - When getting the value out of a dictionary union vector we used the index we get after unwrapping the struct vector to get the corresponding tag value, which doesn't work since we then try to slice it again. We now use the "raw" index when accessing the union child vectors just like in the struct case. I also changed the `UnionVector::GetTag` function to be slightly safer and added some comments to avoid making the same mistake again. 
 
Closes https://github.com/duckdblabs/duckdb-internal/issues/1563 - We now handle constant list vector casts even when the list offset is non-zero

Closes https://github.com/duckdblabs/duckdb-internal/issues/1561 - We now allocate enough dummy list_entry_t's during tuple serialization to cover the entire child vector by calculating how many we need based on the size of the attached VectorArrayBuffer instead of trying to find the max dictionary offset.

Closes https://github.com/duckdb/duckdb-fuzzer/issues/1384 - This was just caused by using the original tag vector and not the flattened one we get after the cast, but I also changed it to avoid flattening the intermediate result at all.