### PR TITLE
Add folder parameter to upload logic and upload also twine artifacts

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -100,7 +100,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           cp build/release/tools/jdbc/duckdb_jdbc.jar duckdb_jdbc-linux-amd64.jar
-          ./scripts/upload-assets-to-staging.sh duckdb_jdbc-linux-amd64.jar
+          ./scripts/upload-assets-to-staging.sh github_release duckdb_jdbc-linux-amd64.jar
       - uses: actions/upload-artifact@v3
         with:
           name: java-linux-amd64
@@ -147,7 +147,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           cp build/release/tools/jdbc/duckdb_jdbc.jar duckdb_jdbc-linux-aarch64.jar
-          ./scripts/upload-assets-to-staging.sh duckdb_jdbc-linux-aarch64.jar
+          ./scripts/upload-assets-to-staging.sh github_release duckdb_jdbc-linux-aarch64.jar
 
       - uses: actions/upload-artifact@v3
         with:
@@ -194,7 +194,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           cp tools/jdbc/duckdb_jdbc.jar duckdb_jdbc-windows-amd64.jar
-          ./scripts/upload-assets-to-staging.sh duckdb_jdbc-windows-amd64.jar
+          ./scripts/upload-assets-to-staging.sh github_release duckdb_jdbc-windows-amd64.jar
       - uses: actions/upload-artifact@v3
         with:
           name: java-windows-amd64
@@ -244,7 +244,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           cp build/release/tools/jdbc/duckdb_jdbc.jar duckdb_jdbc-osx-universal.jar
-          ./scripts/upload-assets-to-staging.sh duckdb_jdbc-osx-universal.jar
+          ./scripts/upload-assets-to-staging.sh github_release duckdb_jdbc-osx-universal.jar
       - uses: actions/upload-artifact@v3
         with:
           name: java-osx-universal

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -129,7 +129,7 @@ jobs:
         zip -j libduckdb-linux-amd64.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
         zip -j libduckdb-src.zip src/amalgamation/duckdb.hpp src/amalgamation/duckdb.cpp src/include/duckdb.h
         zip -j duckdb_odbc-linux-amd64.zip build/release/tools/odbc/libduckdb_odbc.so tools/odbc/linux_setup/unixodbc_setup.sh tools/odbc/linux_setup/update_odbc_path.py
-        ./scripts/upload-assets-to-staging.sh libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_odbc-linux-amd64.zip
+        ./scripts/upload-assets-to-staging.sh github_release libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_odbc-linux-amd64.zip
 
     - uses: actions/upload-artifact@v3
       with:
@@ -192,7 +192,7 @@ jobs:
          zip -j duckdb_cli-linux-aarch64.zip build/release/duckdb
          zip -j duckdb_odbc-linux-aarch64.zip build/release/tools/odbc/libduckdb_odbc.so
          zip -j libduckdb-linux-aarch64.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
-         ./scripts/upload-assets-to-staging.sh libduckdb-linux-aarch64.zip duckdb_cli-linux-aarch64.zip duckdb_odbc-linux-aarch64.zip
+         ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-aarch64.zip duckdb_cli-linux-aarch64.zip duckdb_odbc-linux-aarch64.zip
 
      - uses: actions/upload-artifact@v3
        with:

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -190,7 +190,7 @@ jobs:
           zip -j duckdb_cli-osx-universal.zip build/release/duckdb
           zip -j libduckdb-osx-universal.zip build/release/src/libduckdb*.dylib src/amalgamation/duckdb.hpp src/include/duckdb.h
           zip -j duckdb_odbc-osx-universal.zip build/release/tools/odbc/libduckdb_odbc.dylib
-          ./scripts/upload-assets-to-staging.sh libduckdb-osx-universal.zip duckdb_cli-osx-universal.zip duckdb_odbc-osx-universal.zip
+          ./scripts/upload-assets-to-staging.sh github_release libduckdb-osx-universal.zip duckdb_cli-osx-universal.zip duckdb_odbc-osx-universal.zip
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -244,7 +244,8 @@ jobs:
       shell: bash
       run: |
         cp tools/pythonpkg/dist/duckdb-*.tar.gz duckdb_python_src.tar.gz
-        ./scripts/upload-assets-to-staging.sh duckdb_python_src.tar.gz
+        ./scripts/upload-assets-to-staging.sh github_release duckdb_python_src.tar.gz
+        ./scripts/upload-assets-to-staging.sh twine_upload duckdb_python_src.tar.gz tools/pythonpkg/wheelhouse/*.whl
         if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
           twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
         fi
@@ -301,8 +302,11 @@ jobs:
         env:
           TWINE_USERNAME: '__token__'
           TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         shell: bash
         run: |
+          ./scripts/upload-assets-to-staging.sh twine_upload tools/pythonpkg/wheelhouse/*.whl
           if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl
           fi
@@ -373,8 +377,11 @@ jobs:
         env:
           TWINE_USERNAME: '__token__'
           TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         shell: bash
         run: |
+          ./scripts/upload-assets-to-staging.sh twine_upload tools/pythonpkg/wheelhouse/*.whl
           if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl
           fi

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -116,7 +116,7 @@ jobs:
         zip -j duckdb_cli-windows-amd64.zip Release/duckdb.exe
         zip -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
         zip -j duckdb_odbc-windows-amd64.zip tools/odbc/bin/Release/*
-        ./scripts/upload-assets-to-staging.sh libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip duckdb_odbc-windows-amd64.zip
+        ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip duckdb_odbc-windows-amd64.zip
 
     - uses: actions/upload-artifact@v3
       with:

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -2,11 +2,18 @@
 
 # Main extension uploading script
 
-# Usage: ./scripts/upload-staging-asset.sh <file>
+# Usage: ./scripts/upload-staging-asset.sh <folder> <file>*
+# <folder>              : Folder to upload to
 # <file>                : File to be uploaded
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Usage: ./scripts/upload-staging-asset.sh <folder> <file1> [... <fileN>]"
+    exit 1
+fi
 
 set -e
 
+FOLDER="$1"
 DRY_RUN_PARAM=""
 
 # dryrun if repo is not duckdb/duckdb
@@ -40,7 +47,7 @@ fi
 
 python3 -m pip install awscli
 
-for var in "$@"
+for var in "${@: 2}"
 do
-    aws s3 cp $var s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/ $DRY_RUN_PARAM --region us-east-2
+    aws s3 cp $var s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/$FOLDER/ $DRY_RUN_PARAM --region us-east-2
 done


### PR DESCRIPTION
Adding folder allows to have staging folders separated by strategy of further upload (GitHub / Pypi / etc)

Currently only two values are:
- github_release
- twine_upload

Twine upload logic is currently duplicated, in the sense that original logic would still send them to pypi, while new logic for now only collects the assets.

Next step: centralising twine upload logic.

This is a follow up of/improvement on: https://github.com/duckdb/duckdb/pull/11156