### PR TITLE
CI: Find mirror issues among all issues, not just open issues

### DIFF
--- a/.github/workflows/InternalIssuesUpdateMirror.yml
+++ b/.github/workflows/InternalIssuesUpdateMirror.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Get mirror issue number
         run: |
-          gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt
+          gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --state all --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt
           echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> $GITHUB_ENV
 
       - name: Print whether mirror issue exists


### PR DESCRIPTION
This PR fixes a bug in issue mirroring.

By default, the `gh issue list` command only lists public issues. Therefore, if the mirror issue has been closed, the CI script cannot it and will open a separate issue instead. This can occur when the public issue is reopened. This PR adds the `--state all` flag to fix this.