### PR TITLE
Fix RevertAppendInternal

### DIFF
--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -69,6 +69,9 @@ public:
 	}
 	idx_t GetSegmentCount() {
 		auto l = Lock();
+		return GetSegmentCount(l);
+	}
+	idx_t GetSegmentCount(SegmentLock &l) {
 		return nodes.size();
 	}
 	//! Gets a pointer to the nth segment. Negative numbers start from the back.
@@ -185,6 +188,9 @@ public:
 	//! Get the segment index of the column segment for the given row
 	idx_t GetSegmentIndex(SegmentLock &l, idx_t row_number) {
 		idx_t segment_index;
+		D_ASSERT(!nodes.empty());
+		D_ASSERT(row_number >= nodes[0].row_start);
+		D_ASSERT(row_number < nodes.back().row_start + nodes.back().node->count);
 		if (TryGetSegmentIndex(l, row_number, segment_index)) {
 			return segment_index;
 		}
@@ -207,9 +213,6 @@ public:
 		if (nodes.empty()) {
 			return false;
 		}
-		D_ASSERT(!nodes.empty());
-		D_ASSERT(row_number >= nodes[0].row_start);
-		D_ASSERT(row_number < nodes.back().row_start + nodes.back().node->count);
 		idx_t lower = 0;
 		idx_t upper = nodes.size() - 1;
 		// binary search to find the node

--- a/test/sql/transactions/test_index_rollback_flushed_data.test
+++ b/test/sql/transactions/test_index_rollback_flushed_data.test
@@ -1,0 +1,44 @@
+# name: test/sql/transactions/test_index_rollback_flushed_data.test
+# description: Test that we revert the global storage correctly after a constraint violation
+# group: [transactions]
+
+require skip_reload
+
+statement ok
+PRAGMA enable_verification
+
+statement ok con1
+CREATE TABLE integers(i INTEGER UNIQUE);
+
+statement ok con1
+BEGIN TRANSACTION;
+
+statement ok con2
+BEGIN TRANSACTION;
+
+statement ok con1
+INSERT INTO integers VALUES (-10);
+
+statement ok con2
+INSERT INTO integers SELECT range FROM range(2, 4097, 1);
+
+# constraint violation
+statement ok con2
+INSERT INTO integers VALUES (-10);
+
+# con1 commits first
+statement ok con1
+COMMIT;
+
+# con2 fails to commit because of the conflict
+statement error con2
+COMMIT;
+----
+
+statement ok
+INSERT INTO integers SELECT i FROM range(2, 4097, 1) t1(i)
+
+query I
+SELECT MAX(i) FROM integers
+----
+4096


### PR DESCRIPTION
Supersedes https://github.com/duckdb/duckdb/pull/11173

Changes made in https://github.com/duckdb/duckdb/pull/11011 resulted in `total_rows` only being updated and version info only being appended in `FinalizeAppend`. When reverting, `FinalizeAppend` is never called. This lead to not all rows being correctly reverted which lead to rows remaining in the table in case of constraint failures.

This PR alters `RevertAppendInternal` to no longer look at `total_rows`, and instead directly look into the segments to clean up the appends.