### PR TITLE
Make `MultiFileReader` filename configurable

### DIFF
--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 void MultiFileReader::AddParameters(TableFunction &table_function) {
-	table_function.named_parameters["filename"] = LogicalType::VARCHAR;
+	table_function.named_parameters["filename"] = LogicalType::ANY;
 	table_function.named_parameters["hive_partitioning"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["union_by_name"] = LogicalType::BOOLEAN;
 	table_function.named_parameters["hive_types"] = LogicalType::ANY;
@@ -65,15 +65,17 @@ bool MultiFileReader::ParseOption(const string &key, const Value &val, MultiFile
                                   ClientContext &context) {
 	auto loption = StringUtil::Lower(key);
 	if (loption == "filename") {
-		Value boolean_value;
-		string error_message;
-		if (val.DefaultTryCastAs(LogicalType::BOOLEAN, boolean_value, &error_message)) {
-			// If the argument can be cast to boolean, we just interpret it as a boolean
-			options.filename = BooleanValue::Get(boolean_value);
-		} else {
+		if (val.type() == LogicalType::VARCHAR) {
 			// If not, we interpret it as the name of the column containing the filename
 			options.filename = true;
 			options.filename_column = StringValue::Get(val);
+		} else {
+			Value boolean_value;
+			string error_message;
+			if (val.DefaultTryCastAs(LogicalType::BOOLEAN, boolean_value, &error_message)) {
+				// If the argument can be cast to boolean, we just interpret it as a boolean
+				options.filename = BooleanValue::Get(boolean_value);
+			}
 		}
 	} else if (loption == "hive_partitioning") {
 		options.hive_partitioning = BooleanValue::Get(val);

--- a/src/include/duckdb/common/multi_file_reader_options.hpp
+++ b/src/include/duckdb/common/multi_file_reader_options.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include "duckdb/common/types.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/hive_partitioning.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
@@ -23,6 +23,10 @@ struct MultiFileReaderOptions {
 	bool union_by_name = false;
 	bool hive_types_autocast = true;
 	case_insensitive_map_t<LogicalType> hive_types_schema;
+
+	// Default/configurable name of the column containing the file names
+	static constexpr const char *DEFAULT_FILENAME_COLUMN = "filename";
+	string filename_column = DEFAULT_FILENAME_COLUMN;
 
 	DUCKDB_API void Serialize(Serializer &serializer) const;
 	DUCKDB_API static MultiFileReaderOptions Deserialize(Deserializer &source);

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -470,6 +470,12 @@
         "id": 105,
         "name": "hive_types_schema",
         "type": "case_insensitive_map_t<LogicalType>"
+      },
+      {
+        "id": 106,
+        "name": "filename_column",
+        "type": "string",
+        "default": "MultiFileReaderOptions::DEFAULT_FILENAME_COLUMN"
       }
     ],
     "pointer_type": "none"

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -334,6 +334,7 @@ void MultiFileReaderOptions::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(103, "union_by_name", union_by_name);
 	serializer.WritePropertyWithDefault<bool>(104, "hive_types_autocast", hive_types_autocast);
 	serializer.WritePropertyWithDefault<case_insensitive_map_t<LogicalType>>(105, "hive_types_schema", hive_types_schema);
+	serializer.WritePropertyWithDefault<string>(106, "filename_column", filename_column, MultiFileReaderOptions::DEFAULT_FILENAME_COLUMN);
 }
 
 MultiFileReaderOptions MultiFileReaderOptions::Deserialize(Deserializer &deserializer) {
@@ -344,6 +345,7 @@ MultiFileReaderOptions MultiFileReaderOptions::Deserialize(Deserializer &deseria
 	deserializer.ReadPropertyWithDefault<bool>(103, "union_by_name", result.union_by_name);
 	deserializer.ReadPropertyWithDefault<bool>(104, "hive_types_autocast", result.hive_types_autocast);
 	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<LogicalType>>(105, "hive_types_schema", result.hive_types_schema);
+	deserializer.ReadPropertyWithDefault<string>(106, "filename_column", result.filename_column, MultiFileReaderOptions::DEFAULT_FILENAME_COLUMN);
 	return result;
 }
 

--- a/test/parquet/test_filename_column.test
+++ b/test/parquet/test_filename_column.test
@@ -1,0 +1,56 @@
+# name: test/parquet/test_filename_column.test
+# description: Test MultiFileReader filename column rename
+# group: [parquet]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+# anything castable to boolean true just defaults to 'filename'
+query I
+SELECT pq.filename FROM read_parquet('data/parquet-testing/enum.parquet', filename=true) pq LIMIT 1
+----
+data/parquet-testing/enum.parquet
+
+query I
+SELECT pq.filename FROM read_parquet('data/parquet-testing/enum.parquet', filename=1) pq LIMIT 1
+----
+data/parquet-testing/enum.parquet
+
+query I
+SELECT pq.filename FROM read_parquet('data/parquet-testing/enum.parquet', filename='TRUE') pq LIMIT 1
+----
+data/parquet-testing/enum.parquet
+
+# this is the output without an additional filename column
+query IIIIIII nosort q0
+SELECT * FROM read_parquet('data/parquet-testing/enum.parquet')
+----
+
+# this shouldn't somehow add a column with the name false/0/FALSE
+query IIIIIII nosort q0
+SELECT * FROM read_parquet('data/parquet-testing/enum.parquet', filename=false)
+----
+
+
+query IIIIIII nosort q0
+SELECT * FROM read_parquet('data/parquet-testing/enum.parquet', filename=0)
+----
+
+
+query IIIIIII nosort q0
+SELECT * FROM read_parquet('data/parquet-testing/enum.parquet', filename='FALSE')
+----
+
+
+# but we can give it a name and select the column using that name
+query I
+SELECT my_cool_filename FROM read_parquet('data/parquet-testing/enum.parquet', filename='my_cool_filename') LIMIT 1
+----
+data/parquet-testing/enum.parquet
+
+query I
+SELECT my_cool_filename FROM read_parquet('data/parquet-testing/enum.parquet', filename=my_cool_filename) LIMIT 1
+----
+data/parquet-testing/enum.parquet

--- a/test/parquet/test_filename_column.test
+++ b/test/parquet/test_filename_column.test
@@ -7,7 +7,7 @@ require parquet
 statement ok
 PRAGMA enable_verification
 
-# anything castable to boolean true just defaults to 'filename'
+# anything non-VARCHAR will be cast to boolean, and interpreted as such
 query I
 SELECT pq.filename FROM read_parquet('data/parquet-testing/enum.parquet', filename=true) pq LIMIT 1
 ----
@@ -18,8 +18,15 @@ SELECT pq.filename FROM read_parquet('data/parquet-testing/enum.parquet', filena
 ----
 data/parquet-testing/enum.parquet
 
+# the string TRUE can be a column name
 query I
-SELECT pq.filename FROM read_parquet('data/parquet-testing/enum.parquet', filename='TRUE') pq LIMIT 1
+SELECT "TRUE" FROM read_parquet('data/parquet-testing/enum.parquet', filename='TRUE') pq LIMIT 1
+----
+data/parquet-testing/enum.parquet
+
+# FALSR too
+query I
+SELECT "FALSE" FROM read_parquet('data/parquet-testing/enum.parquet', filename='FALSE') pq LIMIT 1
 ----
 data/parquet-testing/enum.parquet
 
@@ -39,12 +46,7 @@ SELECT * FROM read_parquet('data/parquet-testing/enum.parquet', filename=0)
 ----
 
 
-query IIIIIII nosort q0
-SELECT * FROM read_parquet('data/parquet-testing/enum.parquet', filename='FALSE')
-----
-
-
-# but we can give it a name and select the column using that name
+# cool names work too
 query I
 SELECT my_cool_filename FROM read_parquet('data/parquet-testing/enum.parquet', filename='my_cool_filename') LIMIT 1
 ----


### PR DESCRIPTION
Instead of only being able to supply true/false like so:
```sql
SELECT filename FROM read_parquet('data/parquet-testing/enum.parquet', filename=true) LIMIT 1;
-- data/parquet-testing/enum.parquet
```

This PR adds functionality to make the name configurable:
```sql
SELECT my_cool_filename FROM read_parquet('data/parquet-testing/enum.parquet', filename=my_cool_filename) LIMIT 1;
-- data/parquet-testing/enum.parquet
```

If the argument is castable to `BOOLEAN`, the behavior is the same as before. If not, we interpret the argument as a string, and rename the `filename` column to the supplied string.