### PR TITLE
Allow overriding of git describe also in scripts (via OVERRIDE_GIT_DESCRIBE environment variable)

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -263,15 +263,25 @@ def copy_if_different(src, dest):
     shutil.copyfile(src, dest)
 
 
+def get_git_describe():
+    if 'OVERRIDE_GIT_DESCRIBE' in os.environ:
+        return os.environ['OVERRIDE_GIT_DESCRIBE']
+    try:
+        return subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
+    except:
+        return "v0.0.0-0-deadbeeff"
+
+
 def git_commit_hash():
-    return subprocess.check_output(['git', 'log', '-1', '--format=%h']).strip().decode('utf8')
+    git_describe = get_git_describe();
+    hash = git_describe.split('-')[2];
+    return hash
 
 
 def git_dev_version():
     try:
-        version = subprocess.check_output(['git', 'describe', '--tags', '--abbrev=0']).strip().decode('utf8')
-        long_version = subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
-        version_splits = version.lstrip('v').split('.')
+        long_version = get_git_describe()
+        version_splits = long_version.split('-')[0].lstrip('v').split('.')
         dev_version = long_version.split('-')[1]
         if int(dev_version) == 0:
             # directly on a tag: emit the regular version

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -262,9 +262,10 @@ def copy_if_different(src, dest):
     # print("Copying " + src + " to " + dest)
     shutil.copyfile(src, dest)
 
+
 def git_commit_hash():
-    git_describe = package_build.get_git_describe();
-    hash = git_describe.split('-')[2];
+    git_describe = package_build.get_git_describe()
+    hash = git_describe.split('-')[2]
     return hash
 
 

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -262,25 +262,15 @@ def copy_if_different(src, dest):
     # print("Copying " + src + " to " + dest)
     shutil.copyfile(src, dest)
 
-
-def get_git_describe():
-    if 'OVERRIDE_GIT_DESCRIBE' in os.environ:
-        return os.environ['OVERRIDE_GIT_DESCRIBE']
-    try:
-        return subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
-    except:
-        return "v0.0.0-0-deadbeeff"
-
-
 def git_commit_hash():
-    git_describe = get_git_describe();
+    git_describe = package_build.get_git_describe();
     hash = git_describe.split('-')[2];
     return hash
 
 
 def git_dev_version():
     try:
-        long_version = get_git_describe()
+        long_version = package_build.get_git_describe()
         version_splits = long_version.split('-')[0].lstrip('v').split('.')
         dev_version = long_version.split('-')[1]
         if int(dev_version) == 0:

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -127,6 +127,13 @@ def get_relative_path(source_dir, target_file):
         target_file = target_file.replace(source_dir, "").lstrip('/')
     return target_file
 
+def get_git_describe():
+    if 'OVERRIDE_GIT_DESCRIBE' in os.environ:
+        return os.environ['OVERRIDE_GIT_DESCRIBE']
+    try:
+        return subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
+    except:
+        return "v0.0.0-0-deadbeeff"
 
 def git_commit_hash():
     if 'SETUPTOOLS_SCM_PRETEND_HASH' in os.environ:
@@ -148,7 +155,7 @@ def git_dev_version():
     if 'SETUPTOOLS_SCM_PRETEND_VERSION' in os.environ:
         return prefix_version(os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'])
     try:
-        long_version = subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
+        long_version = get_git_describe()
         version_splits = long_version.split('-')[0].lstrip('v').split('.')
         dev_version = long_version.split('-')[1]
         if int(dev_version) == 0:

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -127,6 +127,7 @@ def get_relative_path(source_dir, target_file):
         target_file = target_file.replace(source_dir, "").lstrip('/')
     return target_file
 
+
 def get_git_describe():
     override_git_describe = ''
     if 'OVERRIDE_GIT_DESCRIBE' in os.environ:
@@ -144,16 +145,21 @@ def get_git_describe():
         override_git_describe += "-0"
     assert len(override_git_describe.split('-')) == 1
     try:
-        return override_git_describe + "-" + subprocess.check_output(['git', 'log', '-1', '--format=%h']).strip().decode('utf8')
+        return (
+            override_git_describe
+            + "-"
+            + subprocess.check_output(['git', 'log', '-1', '--format=%h']).strip().decode('utf8')
+        )
     except:
         return override_git_describe + "-" + "deadbeeff"
+
 
 def git_commit_hash():
     if 'SETUPTOOLS_SCM_PRETEND_HASH' in os.environ:
         return os.environ['SETUPTOOLS_SCM_PRETEND_HASH']
     try:
-        git_describe = get_git_describe();
-        hash = git_describe.split('-')[2];
+        git_describe = get_git_describe()
+        hash = git_describe.split('-')[2]
         return hash
     except:
         return "deadbeeff"

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -148,9 +148,8 @@ def git_dev_version():
     if 'SETUPTOOLS_SCM_PRETEND_VERSION' in os.environ:
         return prefix_version(os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'])
     try:
-        version = subprocess.check_output(['git', 'describe', '--tags', '--abbrev=0']).strip().decode('utf8')
         long_version = subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
-        version_splits = version.lstrip('v').split('.')
+        version_splits = long_version.split('-')[0].lstrip('v').split('.')
         dev_version = long_version.split('-')[1]
         if int(dev_version) == 0:
             # directly on a tag: emit the regular version

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -128,12 +128,25 @@ def get_relative_path(source_dir, target_file):
     return target_file
 
 def get_git_describe():
+    override_git_describe = ''
     if 'OVERRIDE_GIT_DESCRIBE' in os.environ:
-        return os.environ['OVERRIDE_GIT_DESCRIBE']
+        override_git_describe = os.environ['OVERRIDE_GIT_DESCRIBE']
+    # empty override_git_describe, either since env was empty string or not existing
+    # -> ask git (that can fail, so except in place)
+    if len(override_git_describe) == 0:
+        try:
+            return subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
+        except:
+            return "v0.0.0-0-deadbeeff"
+    if len(override_git_describe.split('-')) == 2:
+        return override_git_describe
+    if len(override_git_describe.split('-')) == 0:
+        override_git_describe += "-0"
+    assert len(override_git_describe.split('-')) == 1
     try:
-        return subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
+        return override_git_describe + "-" + subprocess.check_output(['git', 'log', '-1', '--format=%h']).strip().decode('utf8')
     except:
-        return "v0.0.0-0-deadbeeff"
+        return override_git_describe + "-" + "deadbeeff"
 
 def git_commit_hash():
     if 'SETUPTOOLS_SCM_PRETEND_HASH' in os.environ:

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -139,7 +139,9 @@ def git_commit_hash():
     if 'SETUPTOOLS_SCM_PRETEND_HASH' in os.environ:
         return os.environ['SETUPTOOLS_SCM_PRETEND_HASH']
     try:
-        return subprocess.check_output(['git', 'log', '-1', '--format=%h']).strip().decode('utf8')
+        git_describe = get_git_describe();
+        hash = git_describe.split('-')[2];
+        return hash
     except:
         return "deadbeeff"
 

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -134,7 +134,7 @@ void DeleteArray(T *ptr, idx_t size) {
 }
 
 template <typename T, typename... ARGS>
-T *AllocateObject(ARGS &&...args) {
+T *AllocateObject(ARGS &&... args) {
 	auto data = Allocator::DefaultAllocator().AllocateData(sizeof(T));
 	return new (data) T(std::forward<ARGS>(args)...);
 }


### PR DESCRIPTION
Changes the scripts used by python build OR by amalgamation to use (if available) the environment variable OVERRIDE_GIT_DESCRIBE.

Idea is:
1. if OVERRIDE_GIT_DESCRIBE is complete, use that
2. if OVERRIDE_GIT_DESCRIBE has only version, add "-0" and go to point 3
3. if OVERRIDE_GIT_DESCRIBE has version and dev version (possibly through step 2): add the git hash (or the default deadbbeeff)
4. if OVERRIDE_GIT_DESCRIBE is empty or not present: use git describe --tags value

Code is a simple but a bit intricate (try / except and all), would love a proper review (ping to @Mause, @Mytherin or @Tishj).

I noticed that a similar role is covered by SETUPTOOLS_SCM_PRETEND_VERSION / SETUPTOOLS_SCM_PRETEND_HASH. Those variables keep having precedence as they had before, but also that might need a review.