### PR TITLE
retry on 500 error

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -116,6 +116,7 @@ RunRequestWithRetry(const std::function<duckdb_httplib_openssl::Result(void)> &r
 			case 408: // Request Timeout
 			case 418: // Server is pretending to be a teapot
 			case 429: // Rate limiter hit
+			case 500: // Server has error
 			case 503: // Server has error
 			case 504: // Server has error
 				break;


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/11166

As pointed out, the aws docs state explicitly to retry on 500