### PR TITLE
Python staged releases: centralized staged upload

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -397,3 +397,15 @@ jobs:
        shell: bash
        if: ${{ github.ref == 'refs/heads/main' && github.repository == 'duckdb/duckdb' }}
        run: python3 scripts/pypi_cleanup.py
+
+   twine-upload:
+    needs:
+      - osx-python3
+      - win-python3
+      - linux-python3
+    # Note that want to run this by default ONLY if no override_git_describe is provided
+    # This means we are not staging a release
+    if: (( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' )) && (( inputs.override_git_describe == '' ))
+    uses: ./.github/workflows/TwineUpload.yml
+    secrets: inherit
+    # Why? If present, it means we are staging releases, and we want to do the upload manually

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -237,8 +237,6 @@ jobs:
 
     - name: Deploy
       env:
-        TWINE_USERNAME: '__token__'
-        TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       shell: bash
@@ -246,9 +244,6 @@ jobs:
         cp tools/pythonpkg/dist/duckdb-*.tar.gz duckdb_python_src.tar.gz
         ./scripts/upload-assets-to-staging.sh github_release duckdb_python_src.tar.gz
         ./scripts/upload-assets-to-staging.sh twine_upload duckdb_python_src.tar.gz tools/pythonpkg/wheelhouse/*.whl
-        if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-          twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl tools/pythonpkg/dist/duckdb-*.tar.gz
-        fi
 
    osx-python3:
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
@@ -262,7 +257,6 @@ jobs:
         CIBW_BUILD: ${{ matrix.python_build}}
         CIBW_ARCHS: 'x86_64 universal2 arm64'
         CIBW_TEST_COMMAND: 'python -m pytest {project}/tests/fast  --verbose'
-        TWINE_USERNAME: '__token__'
         DUCKDB_BUILD_UNITY: 1
 
       steps:
@@ -300,16 +294,11 @@ jobs:
 
       - name: Deploy
         env:
-          TWINE_USERNAME: '__token__'
-          TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         shell: bash
         run: |
           ./scripts/upload-assets-to-staging.sh twine_upload tools/pythonpkg/wheelhouse/*.whl
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl
-          fi
 
    win-python3:
       name: Python 3 Windows
@@ -332,7 +321,6 @@ jobs:
 
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
-        TWINE_USERNAME: '__token__'
         DUCKDB_BUILD_UNITY: 1
 
       steps:
@@ -375,16 +363,11 @@ jobs:
 
       - name: Deploy
         env:
-          TWINE_USERNAME: '__token__'
-          TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         shell: bash
         run: |
           ./scripts/upload-assets-to-staging.sh twine_upload tools/pythonpkg/wheelhouse/*.whl
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            twine upload --non-interactive --disable-progress-bar --skip-existing tools/pythonpkg/wheelhouse/*.whl
-          fi
 
    linux-release-cleanup:
      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'

--- a/.github/workflows/TwineUpload.yml
+++ b/.github/workflows/TwineUpload.yml
@@ -1,0 +1,54 @@
+name: Python - Twine upload
+on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+  workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
+
+jobs:
+   twine-upload:
+      name: Twine upload
+      runs-on: ubuntu-latest
+
+      env:
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
+
+      steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install
+        shell: bash
+        run: pip install twine
+
+      - name: Download from staging bucket
+        shell: bash
+        run: |
+          # decide target for staging
+          if [ -z "$OVERRIDE_GIT_DESCRIBE" ]; then
+            TARGET=$(git describe --tags --long)
+          else
+            TARGET="$OVERRIDE_GIT_DESCRIBE"
+          fi
+          mkdir to_be_uploaded
+          aws s3 cp --recursive "s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/twine_upload" to_be_uploaded --region us-east-2
+
+      - name: Deploy
+        env:
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+            twine upload --non-interactive --disable-progress-bar --skip-existing to_be_uploaded/*
+          fi


### PR DESCRIPTION
Logic is partially duplicated with https://github.com/duckdb/duckdb/pull/11179, but given there were some constraint on the Python code and I wanted to avoid risk, those will be for now independent.

To be looked at properly, especially for when Python will move out of core.

Centralized upload is NOT properly tested.
My idea is that once this is merged, the first nightly run to follow will build all relevant artifacts and (if no tests fails in the meantime, not exactly a given) and the automatic upload will be triggered.
If not, it can be triggered (and tested) by an admin the day after.