### PR TITLE
Add StagedUpload.yml

### DIFF
--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -1,0 +1,37 @@
+name: Staged Upload
+on:
+  workflow_dispatch:
+    inputs:
+      target_git_describe:
+        type: string
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+jobs:
+ staged-upload:
+   runs-on: ubuntu-latest
+   if: ${{ inputs.target_git_describe != '' }}
+   steps:
+     - uses: actions/checkout@v3
+       with:
+         fetch-depth: 0
+
+     - uses: actions/setup-python@v4
+       with:
+         python-version: '3.10'
+
+     - name: Install
+       shell: bash
+       run: pip install awscli
+
+     - name: Download from staging bucket
+       shell: bash
+       run: |
+          mkdir to_be_uploaded
+          aws s3 cp --recursive "s3://duckdb-staging/${{ inputs.target_git_describe }}/$GITHUB_REPOSITORY/github_release" to_be_uploaded --region us-east-2
+
+     - name: Deploy
+       shell: bash
+       run: |
+         python3 scripts/asset-upload-gha.py to_be_uploaded/*


### PR DESCRIPTION
Very much untested (for now), but I will do it properly in the duckdb-test-staging fork.

I will update when this is more solid.

Still no checks are actually done, do NOT invoke this randomly.

Some checks are currently part of `scripts/asset-upload-gha.py`, but still this can be misused in many ways.