### PR TITLE
Fix issue in copy constructor of ExtraDropSecretInfo

### DIFF
--- a/src/parser/parsed_data/extra_drop_info.cpp
+++ b/src/parser/parsed_data/extra_drop_info.cpp
@@ -7,6 +7,8 @@ ExtraDropSecretInfo::ExtraDropSecretInfo() : ExtraDropInfo(ExtraDropInfoType::SE
 
 ExtraDropSecretInfo::ExtraDropSecretInfo(const ExtraDropSecretInfo &info)
     : ExtraDropInfo(ExtraDropInfoType::SECRET_INFO) {
+	persist_mode = info.persist_mode;
+	secret_storage = info.secret_storage;
 }
 
 unique_ptr<ExtraDropInfo> ExtraDropSecretInfo::Copy() const {


### PR DESCRIPTION
This seems to fix some CI failure we were seeing; when setting the `persist_mode` to persistent here, I can make the tests fail in the same way, so this seems to do it. Thanks to @Tishj for spotting this one!