### PR TITLE
Fix warning on unused utf_type

### DIFF
--- a/src/common/types/string_type.cpp
+++ b/src/common/types/string_type.cpp
@@ -21,6 +21,7 @@ void string_t::VerifyUTF8() const {
 	D_ASSERT(dataptr);
 
 	auto utf_type = Utf8Proc::Analyze(dataptr, GetSize());
+	(void)utf_type;
 	D_ASSERT(utf_type != UnicodeType::INVALID);
 }
 


### PR DESCRIPTION
Few CI failures tied to this, like https://github.com/duckdb/duckdb/actions/runs/8303873932/job/22730743708#step:6:187 or https://github.com/duckdb/duckdb/actions/runs/8303873928/job/22728728365