### PR TITLE
Improve conversion error message in Parquet reader

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -1013,7 +1013,7 @@ idx_t CastColumnReader::Read(uint64_t num_values, parquet_filter_t &filter, data
 		                       reader.file_name, schema.name, intermediate_vector.GetType(), result.GetType());
 		extended_error += "\nThis can happen when reading multiple Parquet files. The schema information is taken from "
 		                  "the first Parquet file by default. Possible solutions:\n";
-		extended_error += "* Enable the union_by_name=True option to read the metadata of all Parquet files "
+		extended_error += "* Enable the union_by_name=True option to combine the schema of all Parquet files "
 		                  "(duckdb.org/docs/data/multiple_files/combining_schemas)\n";
 		extended_error += "* Use a COPY statement to automatically derive types from an existing table.";
 		throw ConversionException(

--- a/test/sql/copy/parquet/multi_file_conversion_error.test
+++ b/test/sql/copy/parquet/multi_file_conversion_error.test
@@ -1,0 +1,16 @@
+# name: test/sql/copy/parquet/multi_file_conversion_error.test
+# description: Test multi-file conversion error
+# group: [parquet]
+
+require parquet
+
+statement ok
+copy (select 42 as a) to '__TEST_DIR__/conversion_error1.parquet';
+
+statement ok
+copy (select blob 'hello world' as a) to '__TEST_DIR__/conversion_error2.parquet';
+
+statement error
+SELECT * FROM read_parquet(['__TEST_DIR__/conversion_error1.parquet', '__TEST_DIR__/conversion_error2.parquet'])
+----
+failed to cast column "a" from type BLOB to INTEGER


### PR DESCRIPTION
The `CastColumnReader` can lead to error messages being thrown when either (1) an explicit schema is provided through `COPY`, or (2) when combining multiple parquet files with different schemas. For (1) the error is more obvious since the user is reading into a schema defined by the user itself, i.e.:

```sql
D copy (select 'hello world') to test.parquet;
D create table tbl(i int);
D copy tbl from test.parquet;
-- Conversion Error: Could not convert string 'hello world' to INT32
```

However, for (2), the error message is very opaque, e.g.:

```sql
D copy (select 'hello world' as a) to test1.parquet;
D copy (select 42 as a) to test2.parquet;
D from read_parquet(['test2.parquet', 'test1.parquet']);
-- Conversion Error: Could not convert string 'hello world' to INT32
```


This PR improves the error message that is generated by more precisely locating where the error occurs, and helping the user find possible solutions:

```sql
D from read_parquet(['test2.parquet', 'test1.parquet']);
-- Conversion Error: In Parquet reader of file "test1.parquet": failed to cast column "a" from type VARCHAR to INTEGER: Could not convert string 'hello world' to INT32

-- In file "test1.parquet" the column "a" has type VARCHAR, but we are trying to read it as type INTEGER.
-- This can happen when reading multiple Parquet files. The schema information is taken from the first Parquet file by default. Possible solutions:
-- * Enable the union_by_name=True option to combine the schema of all Parquet files (duckdb.org/docs/data/multiple_files/combining_schemas)
-- * Use a COPY statement to automatically derive types from an existing table.


```