### PR TITLE
Perform direct write operation if input data are larger than buffer size

### DIFF
--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -23,7 +23,7 @@ idx_t BufferedFileWriter::GetTotalWritten() {
 }
 
 void BufferedFileWriter::WriteData(const_data_ptr_t buffer, idx_t write_size) {
-	if (write_size >= (FILE_BUFFER_SIZE + offset)) {
+	if (write_size >= (2 * FILE_BUFFER_SIZE - offset)) {
 		idx_t to_copy = 0;
 		// Check before performing direct IO if there is some data in the current internal buffer.
 		// If so, then fill the buffer (to avoid to small write operation), flush it and then write


### PR DESCRIPTION
Hello,

While debugging I saw that the `BufferedFileWriter` was splitting incoming buffer to smaller one before writing then.

```sh
# Test data
curl https://us-prd-motherduck-open-datasets.s3.amazonaws.com/hacker_news/parquet/hacker_news_2021_2022.parquet -o data/hacker_news_2021_2022.parquet

# Tests
for i in seq {1..10}; do rm out.parquet; time ./build/debug/duckdb -c "COPY (SELECT * FROM '../data/hacker_news_2021_2022.parquet' ORDER BY 'id') TO './out.parquet'"; done >with_changes.log 2>&1
```

Here the result I was expecting better improvement...

Before the change
[without_changes.log](https://github.com/duckdb/duckdb/files/14624144/without_changes.log)

After
[with_changes.log](https://github.com/duckdb/duckdb/files/14624143/with_changes.log)

But I still propose this PR because depending on the underlying filesystem it may be preferable to have larger buffer.