### PR TITLE
CI: Create/label mirror issue job should list all internal issues

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get mirror issue number
         run: |
-          gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt
+          gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --state all --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt
           echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> $GITHUB_ENV
 
       - name: Print whether mirror issue exists

--- a/.github/workflows/NeedsDocumentation.yml
+++ b/.github/workflows/NeedsDocumentation.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get mirror issue number
         run: |
-          gh issue list --repo duckdb/duckdb-web --json title,number --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")).number" > mirror_issue_number.txt
+          gh issue list --repo duckdb/duckdb-web --json title,number --state all --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")).number" > mirror_issue_number.txt
           echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> ${GITHUB_ENV}
 
       - name: Print whether mirror issue exists

--- a/.github/workflows/PRNeedsMaintainerApproval.yml
+++ b/.github/workflows/PRNeedsMaintainerApproval.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get mirror issue number
         run: |
-          gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")).number" > mirror_issue_number.txt
+          gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --state all --jq ".[] | select(.title | startswith(\"${TITLE_PREFIX}\")).number" > mirror_issue_number.txt
           echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> ${GITHUB_ENV}
 
       - name: Print whether mirror issue exists


### PR DESCRIPTION
Followup of #11170, where @carlopi [pointed out](https://github.com/duckdb/duckdb/pull/11170#issuecomment-1999340592) that the `--state all` flag should apply to all CI jobs that mirror issues in some other repositories.