### PR TITLE
Internal #1564: Range Join DISTINCT

### DIFF
--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -237,7 +237,12 @@ idx_t PhysicalRangeJoin::LocalSortedTable::MergeNulls(Vector &primary, const vec
 			// Primary is already NULL
 			return count;
 		}
-		for (auto &v : keys.data) {
+		for (size_t c = 1; c < keys.data.size(); ++c) {
+			// Skip comparisons that accept NULLs
+			if (conditions[c].comparison == ExpressionType::COMPARE_DISTINCT_FROM) {
+				continue;
+			}
+			auto &v = keys.data[c];
 			if (ConstantVector::IsNull(v)) {
 				// Create a new validity mask to avoid modifying original mask
 				auto &pvalidity = ConstantVector::Validity(primary);

--- a/test/sql/join/test_complex_range_join.test
+++ b/test/sql/join/test_complex_range_join.test
@@ -5,9 +5,6 @@
 statement ok
 PRAGMA enable_verification
 
-# FIXME: bug in constant operator
-require no_vector_verification
-
 # Coverage for multiple slicing predicates
 query IIIIII
 WITH lhs(i, j, k) AS (VALUES


### PR DESCRIPTION
Check for NULL-accepting comparisons
when the Sink vector is constant.

fixes: duckdblabs/duckdb-internal#1564