### PR TITLE
Remove old assertions in SegmentTree

### DIFF
--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -188,9 +188,6 @@ public:
 	//! Get the segment index of the column segment for the given row
 	idx_t GetSegmentIndex(SegmentLock &l, idx_t row_number) {
 		idx_t segment_index;
-		D_ASSERT(!nodes.empty());
-		D_ASSERT(row_number >= nodes[0].row_start);
-		D_ASSERT(row_number < nodes.back().row_start + nodes.back().node->count);
 		if (TryGetSegmentIndex(l, row_number, segment_index)) {
 			return segment_index;
 		}


### PR DESCRIPTION
These assertions had been moved to an incorrect location. In general the assertions do not add much - if they do not hold an `InternalException` will be thrown right below. 