### PR TITLE
[Dev] Fix various issues discovered by #11137

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -133,6 +133,10 @@ Value::Value(int32_t val) : type_(LogicalType::INTEGER), is_null(false) {
 	value_.integer = val;
 }
 
+Value::Value(bool val) : type_(LogicalType::BOOLEAN), is_null(false) {
+	value_.boolean = val;
+}
+
 Value::Value(int64_t val) : type_(LogicalType::BIGINT), is_null(false) {
 	value_.bigint = val;
 }

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -38,6 +38,8 @@ public:
 	DUCKDB_API explicit Value(LogicalType type = LogicalType::SQLNULL);
 	//! Create an INTEGER value
 	DUCKDB_API Value(int32_t val); // NOLINT: Allow implicit conversion from `int32_t`
+	//! Create a BOOLEAN value
+	explicit DUCKDB_API Value(bool val);
 	//! Create a BIGINT value
 	DUCKDB_API Value(int64_t val); // NOLINT: Allow implicit conversion from `int64_t`
 	//! Create a FLOAT value
@@ -557,6 +559,8 @@ template <>
 DUCKDB_API date_t Value::GetValueUnsafe() const;
 template <>
 DUCKDB_API dtime_t Value::GetValueUnsafe() const;
+template <>
+DUCKDB_API dtime_tz_t Value::GetValueUnsafe() const;
 template <>
 DUCKDB_API timestamp_t Value::GetValueUnsafe() const;
 template <>

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -225,6 +225,15 @@ struct AllowUnsignedExtensionsSetting {
 	static Value GetSetting(ClientContext &context);
 };
 
+struct AllowUnredactedSecretsSetting {
+	static constexpr const char *Name = "allow_unredacted_secrets";
+	static constexpr const char *Description = "Allow printing unredacted secrets";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(ClientContext &context);
+};
+
 struct CustomExtensionRepository {
 	static constexpr const char *Name = "custom_extension_repository";
 	static constexpr const char *Description = "Overrides the custom endpoint for remote extension installation";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -70,6 +70,7 @@ static ConfigurationOption internal_options[] = {DUCKDB_GLOBAL(AccessModeSetting
                                                  DUCKDB_GLOBAL(EnableExternalAccessSetting),
                                                  DUCKDB_GLOBAL(EnableFSSTVectors),
                                                  DUCKDB_GLOBAL(AllowUnsignedExtensionsSetting),
+                                                 DUCKDB_GLOBAL(AllowUnredactedSecretsSetting),
                                                  DUCKDB_GLOBAL(CustomExtensionRepository),
                                                  DUCKDB_GLOBAL(AutoloadExtensionRepository),
                                                  DUCKDB_GLOBAL(AutoinstallKnownExtensions),

--- a/src/main/relation/value_relation.cpp
+++ b/src/main/relation/value_relation.cpp
@@ -20,6 +20,7 @@ ValueRelation::ValueRelation(const std::shared_ptr<ClientContext> &context, cons
 		}
 		this->expressions.push_back(std::move(expressions));
 	}
+	QueryResult::DeduplicateColumns(names);
 	context->TryBindRelation(*this, this->columns);
 }
 
@@ -27,6 +28,7 @@ ValueRelation::ValueRelation(const std::shared_ptr<ClientContext> &context, cons
                              vector<string> names_p, string alias_p)
     : Relation(context, RelationType::VALUE_LIST_RELATION), names(std::move(names_p)), alias(std::move(alias_p)) {
 	this->expressions = Parser::ParseValuesList(values_list, context->GetParserOptions());
+	QueryResult::DeduplicateColumns(names);
 	context->TryBindRelation(*this, this->columns);
 }
 

--- a/src/parser/statement/export_statement.cpp
+++ b/src/parser/statement/export_statement.cpp
@@ -6,7 +6,8 @@ ExportStatement::ExportStatement(unique_ptr<CopyInfo> info)
     : SQLStatement(StatementType::EXPORT_STATEMENT), info(std::move(info)) {
 }
 
-ExportStatement::ExportStatement(const ExportStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+ExportStatement::ExportStatement(const ExportStatement &other)
+    : SQLStatement(other), info(other.info->Copy()), database(other.database) {
 }
 
 unique_ptr<SQLStatement> ExportStatement::Copy() const {

--- a/src/parser/statement/relation_statement.cpp
+++ b/src/parser/statement/relation_statement.cpp
@@ -2,8 +2,8 @@
 
 namespace duckdb {
 
-RelationStatement::RelationStatement(shared_ptr<Relation> relation)
-    : SQLStatement(StatementType::RELATION_STATEMENT), relation(std::move(relation)) {
+RelationStatement::RelationStatement(shared_ptr<Relation> relation_p)
+    : SQLStatement(StatementType::RELATION_STATEMENT), relation(std::move(relation_p)) {
 }
 
 unique_ptr<SQLStatement> RelationStatement::Copy() const {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -125,6 +125,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "disabled_filesystems",      // cant change this while db is running
 	    "enable_external_access",    // cant change this while db is running
 	    "allow_unsigned_extensions", // cant change this while db is running
+	    "allow_unredacted_secrets",  // cant change this while db is running
 	    "log_query_path",
 	    "password",
 	    "username",

--- a/test/sql/function/list/list_reverse.test
+++ b/test/sql/function/list/list_reverse.test
@@ -47,8 +47,10 @@ execute q1([5, 42, 3]);
 ----
 [3, 42, 5]
 
+statement ok
+create or replace table tbl_big as select range(5000) as list;
+
 query I
-create table tbl_big as select range(5000) as list;
 select list_sort((list), 'desc') == ${f}(list) from tbl_big;
 ----
 true
@@ -303,4 +305,3 @@ FROM example ORDER BY length(reverse_arr) DESC;
 []
 
 endloop
-

--- a/test/sql/json/test_json_sqlite.test
+++ b/test/sql/json/test_json_sqlite.test
@@ -19,13 +19,17 @@ VALUES('true'),('false'),('null'),('123'),('-234'),('34.5e+6'),
      ('[]'),('{}'),('[true,false,null,123,-234,34.5e+6,{},[]]'),
      ('{"a":true,"b":{"c":false}}');
 
-query T
+query I
 SELECT count(*) FROM j1 WHERE json_type(x) IN ('OBJECT','ARRAY');
+----
+4
+
+query I
   SELECT x FROM j1
    WHERE json_extract(x,'$')<>x
      AND json_type(x) IN ('OBJECT','ARRAY');
 ----
-4
+[true,false,null,123,-234,34.5e+6,{},[]]
 
 statement ok
 CREATE TABLE j2(id INTEGER PRIMARY KEY, json VARCHAR, src VARCHAR);

--- a/test/sql/secrets/create_secret_storage_backends.test
+++ b/test/sql/secrets/create_secret_storage_backends.test
@@ -31,6 +31,10 @@ Invalid Input Error: Persistent secrets are disabled. Restart DuckDB and enable 
 
 restart
 
+# Enable persistent secrets so we can set a 'secret_directory'
+statement ok
+set allow_persistent_secrets=true;
+
 statement ok
 set secret_directory='__TEST_DIR__/create_secret_storages'
 

--- a/test/sql/storage/compression/string/null.test
+++ b/test/sql/storage/compression/string/null.test
@@ -20,7 +20,7 @@ PRAGMA force_compression='${compression}'
 
 # single NULL value
 statement ok
-CREATE TABLE nulls(i VARCHAR)
+CREATE or replace TABLE nulls(i VARCHAR)
 
 statement ok
 INSERT INTO nulls VALUES (NULL)
@@ -37,12 +37,9 @@ SELECT * FROM nulls
 ----
 NULL
 
-statement ok
-DROP TABLE nulls
-
 # many null values
 statement ok
-CREATE TABLE nulls(i VARCHAR)
+CREATE or replace TABLE nulls(i VARCHAR)
 
 statement ok
 INSERT INTO nulls SELECT NULL FROM range(70000)
@@ -59,8 +56,21 @@ SELECT COUNT(*), COUNT(i::INT), SUM(i::INT) FROM nulls
 ----
 70000	0	NULL
 
+statement ok
+select compression from pragma_storage_info('nulls') WHERE segment_type ILIKE 'VARCHAR' LIMIT 1;
+
 query I
-SELECT lower(compression)='uncompressed' or (lower(compression)='dictionary' and '${compression}'='dictionary') FROM pragma_storage_info('nulls') WHERE segment_type ILIKE 'VARCHAR' LIMIT 1
+select current_setting('force_compression') ILIKE '${compression}'
+----
+true
+
+query I
+SELECT
+	compression ILIKE 'uncompressed' or
+	(
+		compression ILIKE 'dictionary' and '${compression}'='dictionary'
+	)
+	FROM pragma_storage_info('nulls') WHERE segment_type ILIKE 'VARCHAR' LIMIT 1
 ----
 1
 
@@ -88,9 +98,8 @@ SELECT lower(compression)='${compression}' FROM pragma_storage_info('nulls') WHE
 ----
 1
 
-statement ok
-DROP TABLE nulls
-
+# enable_fsst_vector
 endloop
 
+# compression
 endloop

--- a/test/sql/types/nested/map/test_map_concat.test
+++ b/test/sql/types/nested/map/test_map_concat.test
@@ -105,7 +105,8 @@ select map_concat(x, y, z) from tbl where rowid != 0;
 {42=small, 1=this is a long string, 0=tiny}
 {5=long, 1337=longer, 0=longest}
 
-query I map_concat(x, y, z) from tbl where rowid == 1;
+query I
+select map_concat(x, y, z) from tbl where rowid == 1;
 ----
 {42=small, 1=this is a long string, 0=tiny}
 

--- a/tools/pythonpkg/scripts/cache_data.json
+++ b/tools/pythonpkg/scripts/cache_data.json
@@ -93,6 +93,7 @@
             "datetime.date",
             "datetime.time",
             "datetime.timedelta",
+            "datetime.timezone",
             "datetime.datetime"
         ]
     },
@@ -135,7 +136,8 @@
         "name": "datetime",
         "children": [
             "datetime.datetime.min",
-            "datetime.datetime.max"
+            "datetime.datetime.max",
+            "datetime.datetime.combine"
         ]
     },
     "datetime.datetime.min": {
@@ -148,6 +150,18 @@
         "type": "attribute",
         "full_path": "datetime.datetime.max",
         "name": "max",
+        "children": []
+    },
+    "datetime.datetime.combine": {
+        "type": "attribute",
+        "full_path": "datetime.datetime.combine",
+        "name": "combine",
+        "children": []
+    },
+    "datetime.timezone": {
+        "type": "attribute",
+        "full_path": "datetime.timezone",
+        "name": "timezone",
         "children": []
     },
     "decimal": {

--- a/tools/pythonpkg/scripts/imports.py
+++ b/tools/pythonpkg/scripts/imports.py
@@ -24,6 +24,8 @@ datetime.timedelta
 datetime.datetime
 datetime.datetime.min
 datetime.datetime.max
+datetime.datetime.combine
+datetime.timezone
 
 import decimal
 

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/datetime_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/datetime_module.hpp
@@ -17,13 +17,14 @@ struct DatetimeDatetimeCacheItem : public PythonImportCacheItem {
 
 public:
 	DatetimeDatetimeCacheItem(optional_ptr<PythonImportCacheItem> parent)
-	    : PythonImportCacheItem("datetime", parent), min("min", this), max("max", this) {
+	    : PythonImportCacheItem("datetime", parent), min("min", this), max("max", this), combine("combine", this) {
 	}
 	~DatetimeDatetimeCacheItem() override {
 	}
 
 	PythonImportCacheItem min;
 	PythonImportCacheItem max;
+	PythonImportCacheItem combine;
 };
 
 struct DatetimeDateCacheItem : public PythonImportCacheItem {
@@ -47,7 +48,7 @@ public:
 public:
 	DatetimeCacheItem()
 	    : PythonImportCacheItem("datetime"), date(this), time("time", this), timedelta("timedelta", this),
-	      datetime(this) {
+	      timezone("timezone", this), datetime(this) {
 	}
 	~DatetimeCacheItem() override {
 	}
@@ -55,6 +56,7 @@ public:
 	DatetimeDateCacheItem date;
 	PythonImportCacheItem time;
 	PythonImportCacheItem timedelta;
+	PythonImportCacheItem timezone;
 	DatetimeDatetimeCacheItem datetime;
 };
 

--- a/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
@@ -191,6 +191,7 @@ public:
 	PyTimezone() = delete;
 
 public:
+	DUCKDB_API static int32_t GetUTCOffsetSeconds(py::handle &tzone_obj);
 	DUCKDB_API static interval_t GetUTCOffset(py::handle &tzone_obj);
 };
 

--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -297,7 +297,10 @@ bool TryTransformPythonNumeric(Value &res, py::handle ele, const LogicalType &ta
 			throw InvalidInputException(StringUtil::Format("Failed to cast value: Python value '%s' to INT64",
 			                                               std::string(pybind11::str(ele))));
 		}
-		return TryTransformPythonIntegerToDouble(res, ele);
+		auto cast_as = target_type.id() == LogicalTypeId::UNKNOWN ? LogicalType::HUGEINT : target_type;
+		auto numeric_string = std::string(py::str(ele));
+		res = Value(numeric_string).DefaultCastAs(cast_as);
+		return true;
 	} else if (overflow == 1) {
 		if (target_type.InternalType() == PhysicalType::INT64) {
 			throw InvalidInputException(StringUtil::Format("Failed to cast value: Python value '%s' to INT64",
@@ -516,8 +519,13 @@ Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool 
 		auto timedelta = PyTimeDelta(ele);
 		return Value::INTERVAL(timedelta.ToInterval());
 	}
-	case PythonObjectType::String:
-		return ele.cast<string>();
+	case PythonObjectType::String: {
+		auto stringified = ele.cast<string>();
+		if (target_type.id() == LogicalTypeId::UNKNOWN) {
+			return Value(stringified);
+		}
+		return Value(stringified).DefaultCastAs(target_type);
+	}
 	case PythonObjectType::ByteArray: {
 		auto byte_array = ele;
 		const_data_ptr_t bytes = const_data_ptr_cast(PyByteArray_AsString(byte_array.ptr())); // NOLINT

--- a/tools/pythonpkg/src/native/python_objects.cpp
+++ b/tools/pythonpkg/src/native/python_objects.cpp
@@ -221,11 +221,8 @@ dtime_t PyTime::ToDuckTime() {
 Value PyTime::ToDuckValue() {
 	auto duckdb_time = this->ToDuckTime();
 	if (!py::none().is(this->timezone_obj)) {
-		auto utc_offset = PyTimezone::GetUTCOffset(this->timezone_obj);
-		// 'Add' requires a date_t for overflows
-		date_t ignored_date;
-		utc_offset = Interval::Invert(utc_offset);
-		duckdb_time = Interval::Add(duckdb_time, utc_offset, ignored_date);
+		auto seconds = PyTimezone::GetUTCOffsetSeconds(this->timezone_obj);
+		return Value::TIMETZ(dtime_tz_t(duckdb_time, seconds));
 	}
 	return Value::TIME(duckdb_time);
 }
@@ -255,6 +252,20 @@ interval_t PyTimezone::GetUTCOffset(py::handle &tzone_obj) {
 	auto res = tzone_obj.attr("utcoffset")(py::none());
 	auto timedelta = PyTimeDelta(res);
 	return timedelta.ToInterval();
+}
+
+int32_t PyTimezone::GetUTCOffsetSeconds(py::handle &tzone_obj) {
+	auto res = tzone_obj.attr("utcoffset")(py::none());
+	auto timedelta = PyTimeDelta(res);
+	if (timedelta.days != 0) {
+		throw InvalidInputException(
+		    "Failed to convert 'tzinfo' object, utcoffset returned an invalid timedelta (days)");
+	}
+	if (timedelta.microseconds != 0) {
+		throw InvalidInputException(
+		    "Failed to convert 'tzinfo' object, utcoffset returned an invalid timedelta (microseconds)");
+	}
+	return timedelta.seconds;
 }
 
 PyDateTime::PyDateTime(py::handle &obj) : obj(obj) {
@@ -470,8 +481,17 @@ py::object PythonObject::FromValue(const Value &val, const LogicalType &type,
 		Timestamp::Convert(timestamp, date, time);
 		Date::Convert(date, year, month, day);
 		Time::Convert(time, hour, min, sec, micros);
-		auto py_timestamp =
-		    py::reinterpret_steal<py::object>(PyDateTime_FromDateAndTime(year, month, day, hour, min, sec, micros));
+		py::object py_timestamp;
+		try {
+			auto python_conversion = PyDateTime_FromDateAndTime(year, month, day, hour, min, sec, micros);
+			if (!python_conversion) {
+				throw py::error_already_set();
+			}
+			py_timestamp = py::reinterpret_steal<py::object>(python_conversion);
+		} catch (py::error_already_set &e) {
+			// Failed to convert, fall back to str
+			return py::str(val.ToString());
+		}
 		if (type.id() == LogicalTypeId::TIMESTAMP_TZ) {
 			// We have to add the timezone info
 			auto tz_utc = import_cache.pytz.timezone()("UTC");
@@ -481,12 +501,45 @@ py::object PythonObject::FromValue(const Value &val, const LogicalType &type,
 		}
 		return py_timestamp;
 	}
+	case LogicalTypeId::TIME_TZ: {
+		D_ASSERT(type.InternalType() == PhysicalType::INT64);
+		int32_t hour, min, sec, microsec;
+		auto time_tz = val.GetValueUnsafe<dtime_tz_t>();
+		auto time = time_tz.time();
+		auto offset = time_tz.offset();
+		duckdb::Time::Convert(time, hour, min, sec, microsec);
+		py::object py_time;
+		try {
+			auto python_conversion = PyTime_FromTime(hour, min, sec, microsec);
+			if (!python_conversion) {
+				throw py::error_already_set();
+			}
+			py_time = py::reinterpret_steal<py::object>(python_conversion);
+		} catch (py::error_already_set &e) {
+			// Failed to convert, fall back to str
+			return py::str(val.ToString());
+		}
+		// We have to add the timezone info
+		auto timedelta = import_cache.datetime.timedelta()(py::arg("seconds") = offset);
+		auto timezone_offset = import_cache.datetime.timezone()(timedelta);
+		auto tmp_datetime = import_cache.datetime.datetime.min();
+		auto tmp_datetime_with_tz = import_cache.datetime.datetime.combine()(tmp_datetime, py_time, timezone_offset);
+		return tmp_datetime_with_tz.attr("timetz")();
+	}
 	case LogicalTypeId::TIME: {
 		D_ASSERT(type.InternalType() == PhysicalType::INT64);
 		int32_t hour, min, sec, microsec;
 		auto time = val.GetValueUnsafe<dtime_t>();
 		duckdb::Time::Convert(time, hour, min, sec, microsec);
-		return py::reinterpret_steal<py::object>(PyTime_FromTime(hour, min, sec, microsec));
+		try {
+			auto pytime = PyTime_FromTime(hour, min, sec, microsec);
+			if (!pytime) {
+				throw py::error_already_set();
+			}
+			return py::reinterpret_steal<py::object>(pytime);
+		} catch (py::error_already_set &e) {
+			return py::str(val.ToString());
+		}
 	}
 	case LogicalTypeId::DATE: {
 		D_ASSERT(type.InternalType() == PhysicalType::INT32);
@@ -499,7 +552,15 @@ py::object PythonObject::FromValue(const Value &val, const LogicalType &type,
 			return py::reinterpret_borrow<py::object>(import_cache.datetime.date.min());
 		}
 		duckdb::Date::Convert(date, year, month, day);
-		return py::reinterpret_steal<py::object>(PyDate_FromDate(year, month, day));
+		try {
+			auto pydate = PyDate_FromDate(year, month, day);
+			if (!pydate) {
+				throw py::error_already_set();
+			}
+			return py::reinterpret_steal<py::object>(pydate);
+		} catch (py::error_already_set &e) {
+			return py::str(val.ToString());
+		}
 	}
 	case LogicalTypeId::LIST: {
 		auto &list_values = ListValue::GetChildren(val);

--- a/tools/pythonpkg/src/typing/pytype.cpp
+++ b/tools/pythonpkg/src/typing/pytype.cpp
@@ -360,6 +360,8 @@ py::list DuckDBPyType::Children() const {
 		children.append(py::make_tuple("child", make_shared<DuckDBPyType>(ListType::GetChildType(type))));
 		return children;
 	}
+	// FIXME: where is ARRAY??
+	// it should expose 'child' and 'size'
 	if (id == LogicalTypeId::STRUCT || id == LogicalTypeId::UNION) {
 		auto &struct_children = StructType::GetChildTypes(type);
 		for (idx_t i = 0; i < struct_children.size(); i++) {

--- a/tools/pythonpkg/tests/fast/api/test_native_tz.py
+++ b/tools/pythonpkg/tests/fast/api/test_native_tz.py
@@ -32,8 +32,11 @@ class TestNativeTimeZone(object):
         assert res[0].tzinfo.zone == 'UTC'
 
     def test_native_python_time_timezone(self, duckdb_cursor):
-        with pytest.raises(duckdb.NotImplementedException, match="Not implemented Error: Unsupported type"):
-            duckdb_cursor.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").fetchone()
+        res = duckdb_cursor.execute(f"select TimeRecStart::TIMETZ as tz from '{filename}'").fetchone()
+        assert res == (datetime.time(21, 52, 27, tzinfo=datetime.timezone.utc),)
+
+        roundtrip = duckdb_cursor.execute("select $1", [res[0]]).fetchone()
+        assert roundtrip == res
 
     def test_pandas_timestamp_timezone(self, duckdb_cursor):
         res = duckdb_cursor.execute("SET timezone='America/Los_Angeles';")


### PR DESCRIPTION
As the title says #11137 discovered some issues, CI is being difficult on the nightly test changes, so I figured I'd separate out the fixes into a new branch.

### Fixes

Value(bool) was converted into an `int32_t` and created an INTEGER Value instead, so I have created an overload that takes `bool` and properly produces a BOOLEAN Value now.

`AllowUnredactedSecretsSetting` (allow_unredacted_secrets) could not be set at all, not even before the database started.
It now acts similar to `access_mode`, `allow_unsigned_extensions` and friends.

When selecting from a Relation, we create a ValueRelation, duplicate columns in this constructor caused the bind to fatally error, so we deduplicate the names now.

TIMETZ was not supported at all in the Python client, so I added support for it

ExportStatement's copy constructor was ignoring the `database` field, which caused an issue in `attach_export_import.test` when the statement got prepared and rebound.

Some tests were malformed, the unittester did not pick up on this, which we might want to look into before merging this actually, so it can hopefully be prevented in the future - the tests are now fixed.