### PR TITLE
Review of CI on tags + add R extensions CI to InvokeCI.yml

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -7,8 +7,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - '.github/patches/duckdb-wasm/**'

--- a/.github/workflows/ExtendedTests.yml
+++ b/.github/workflows/ExtendedTests.yml
@@ -6,8 +6,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**'
       - '!.github/workflows/ExtendedTests.yml'

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -53,3 +53,11 @@ jobs:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
+
+  R:
+    uses: ./.github/workflows/R.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -253,6 +253,7 @@ jobs:
 
 
   java-combine:
+    if: ${{ inputs.override_git_describe == '' }}
     name: Java Combine
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -7,8 +7,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'examples/**'
@@ -39,7 +37,6 @@ concurrency:
 jobs:
   format_check:
     name: Julia Format Check
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +57,6 @@ jobs:
 
   main_julia:
     name: Julia ${{ matrix.version }}
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -74,7 +70,7 @@ jobs:
         arch:
           - x64
         isRelease:
-          - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+          - ${{ github.ref == 'refs/heads/main' }}
         exclude:
           - isRelease: false
             version: '1.6'

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -22,8 +22,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -7,8 +7,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -657,6 +657,7 @@ jobs:
       BUILD_JSON: 1
       BUILD_EXCEL: 1
       BUILD_JEMALLOC: 1
+      DUCKDB_PLATFORM: linux_amd64
       TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt
 
     steps:

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -7,8 +7,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**'
       - '!.github/workflows/NightlyTests.yml'

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -22,8 +22,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -22,8 +22,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -395,15 +395,3 @@ jobs:
        shell: bash
        if: ${{ github.ref == 'refs/heads/main' && github.repository == 'duckdb/duckdb' }}
        run: python3 scripts/pypi_cleanup.py
-
-   twine-upload:
-    needs:
-      - osx-python3
-      - win-python3
-      - linux-python3
-    # Note that want to run this by default ONLY if no override_git_describe is provided
-    # This means we are not staging a release
-    if: (( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' )) && (( inputs.override_git_describe == '' )) && (( github.repository == 'duckdb/duckdb' ))
-    uses: ./.github/workflows/TwineUpload.yml
-    secrets: inherit
-    # Why? If present, it means we are staging releases, and we want to do the upload manually

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -1,14 +1,27 @@
 name: R
 on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   repository_dispatch:
   push:
     branches:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**'
       - '!.github/workflows/R.yml'
@@ -19,22 +32,23 @@ on:
       - '!.github/workflows/R.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
 
 jobs:
   rstats-windows-extensions:
     # Builds extensions for windows_amd64_rtools
     name: R Package Windows (Extensions)
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -7,8 +7,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'examples/**'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -7,8 +7,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'tools/**'
@@ -40,7 +38,6 @@ jobs:
  regression-test-benchmark-runner:
   name: Regression Tests
   runs-on: ubuntu-20.04
-  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -135,7 +132,6 @@ jobs:
  regression-test-storage:
   name: Storage Size Regression Test
   runs-on: ubuntu-20.04
-  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -217,7 +213,6 @@ jobs:
  regression-test-python:
   name: Regression Test (Python Client)
   runs-on: ubuntu-20.04
-  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10
@@ -285,7 +280,6 @@ jobs:
  regression-test-plan-cost:
   name: Regression Test Join Order Plan Cost
   runs-on: ubuntu-20.04
-  if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
   env:
     CC: gcc-10
     CXX: g++-10

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -27,6 +27,9 @@ jobs:
 
      - name: Download from staging bucket
        shell: bash
+       env:
+         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
        run: |
           mkdir to_be_uploaded
           aws s3 cp --recursive "s3://duckdb-staging/${{ inputs.target_git_describe }}/$GITHUB_REPOSITORY/github_release" to_be_uploaded --region us-east-2

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -7,8 +7,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'examples/**'
@@ -49,7 +47,7 @@ jobs:
           - 'iOS Simulator,name=iPhone 14'
           - 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
         isRelease:
-          - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+          - ${{ github.ref == 'refs/heads/main' }}
         exclude:
           - isRelease: false
             destination: 'iOS Simulator,name=iPhone 14'

--- a/.github/workflows/TwineUpload.yml
+++ b/.github/workflows/TwineUpload.yml
@@ -34,6 +34,8 @@ jobs:
         shell: bash
         env:
           OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           # decide target for staging
           if [ -z "$OVERRIDE_GIT_DESCRIBE" ]; then

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -22,8 +22,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -7,8 +7,6 @@ on:
       - '**'
       - '!main'
       - '!feature'
-    tags:
-      - '**'
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -265,7 +265,7 @@ def copy_if_different(src, dest):
 
 def git_commit_hash():
     git_describe = package_build.get_git_describe()
-    hash = git_describe.split('-')[2]
+    hash = git_describe.split('-')[2].lstrip('g')
     return hash
 
 

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -129,16 +129,14 @@ def get_relative_path(source_dir, target_file):
 
 
 def get_git_describe():
-    override_git_describe = ''
-    if 'OVERRIDE_GIT_DESCRIBE' in os.environ:
-        override_git_describe = os.environ['OVERRIDE_GIT_DESCRIBE']
+    override_git_describe = os.getenv('OVERRIDE_GIT_DESCRIBE') or ''
     # empty override_git_describe, either since env was empty string or not existing
     # -> ask git (that can fail, so except in place)
     if len(override_git_describe) == 0:
         try:
             return subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
         except subprocess.CalledProcessError:
-            return "v0.0.0-0-deadbeeff"
+            return "v0.0.0-0-gdeadbeeff"
     if len(override_git_describe.split('-')) == 3:
         return override_git_describe
     if len(override_git_describe.split('-')) == 1:
@@ -147,11 +145,11 @@ def get_git_describe():
     try:
         return (
             override_git_describe
-            + "-"
+            + "-g"
             + subprocess.check_output(['git', 'log', '-1', '--format=%h']).strip().decode('utf8')
         )
     except subprocess.CalledProcessError:
-        return override_git_describe + "-" + "deadbeeff"
+        return override_git_describe + "-g" + "deadbeeff"
 
 
 def git_commit_hash():
@@ -159,7 +157,7 @@ def git_commit_hash():
         return os.environ['SETUPTOOLS_SCM_PRETEND_HASH']
     try:
         git_describe = get_git_describe()
-        hash = git_describe.split('-')[2]
+        hash = git_describe.split('-')[2].lstrip('g')
         return hash
     except:
         return "deadbeeff"

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -367,16 +367,14 @@ packages.extend(spark_packages)
 
 # Duplicated from scripts/package_build.py
 def get_git_describe():
-    override_git_describe = ''
-    if 'OVERRIDE_GIT_DESCRIBE' in os.environ:
-        override_git_describe = os.environ['OVERRIDE_GIT_DESCRIBE']
+    override_git_describe = os.getenv('OVERRIDE_GIT_DESCRIBE') or ''
     # empty override_git_describe, either since env was empty string or not existing
     # -> ask git (that can fail, so except in place)
     if len(override_git_describe) == 0:
         try:
             return subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode('utf8')
         except subprocess.CalledProcessError:
-            return "v0.0.0-0-deadbeeff"
+            return "v0.0.0-0-gdeadbeeff"
     if len(override_git_describe.split('-')) == 3:
         return override_git_describe
     if len(override_git_describe.split('-')) == 1:
@@ -385,11 +383,11 @@ def get_git_describe():
     try:
         return (
             override_git_describe
-            + "-"
+            + "-g"
             + subprocess.check_output(['git', 'log', '-1', '--format=%h']).strip().decode('utf8')
         )
     except subprocess.CalledProcessError:
-        return override_git_describe + "-" + "deadbeeff"
+        return override_git_describe + "-g" + "deadbeeff"
 
 
 def get_version():


### PR DESCRIPTION
After this only two jobs are directly invoked on creating a tag:

* Java.yml, that in the "Combine JARs" step actually performs maven upload
* SwiftRelease.yml, that triggers the Swift release

Both should probably also move out of the push on tags and into a separate (and more testable) workflow, but I'd say for now this is good enough.

Also, adding R.yml to be invokable via workflow_call / workflow_dispatch, and invoke it as part of InvokeCI.