### PR TITLE
allow injecting custom BufferManager implementation

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -34,6 +34,7 @@
 
 namespace duckdb {
 
+class BufferManager;
 class BufferPool;
 class CastFunctionSet;
 class ClientContext;
@@ -233,6 +234,8 @@ public:
 	case_insensitive_map_t<duckdb::unique_ptr<StorageExtension>> storage_extensions;
 	//! A buffer pool can be shared across multiple databases (if desired).
 	shared_ptr<BufferPool> buffer_pool;
+	//! Provide a custom buffer manager implementation (if desired).
+	shared_ptr<BufferManager> buffer_manager;
 	//! Set of callbacks that can be installed by extensions
 	vector<unique_ptr<ExtensionCallback>> extension_callbacks;
 

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -65,7 +65,7 @@ private:
 	void Configure(DBConfig &config);
 
 private:
-	unique_ptr<BufferManager> buffer_manager;
+	shared_ptr<BufferManager> buffer_manager;
 	unique_ptr<DatabaseManager> db_manager;
 	unique_ptr<TaskScheduler> scheduler;
 	unique_ptr<ObjectCache> object_cache;

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -34,7 +34,6 @@ public:
 	}
 
 public:
-	static unique_ptr<BufferManager> CreateStandardBufferManager(DatabaseInstance &db, DBConfig &config);
 	virtual BufferHandle Allocate(MemoryTag tag, idx_t block_size, bool can_destroy = true,
 	                              shared_ptr<BlockHandle> *block = nullptr) = 0;
 	//! Reallocate an in-memory buffer that is pinned.
@@ -56,7 +55,6 @@ public:
 	virtual vector<TemporaryFileInformation> GetTemporaryFiles();
 	virtual const string &GetTemporaryDirectory();
 	virtual void SetTemporaryDirectory(const string &new_dir);
-	virtual DatabaseInstance &GetDatabase();
 	virtual bool HasTemporaryDirectory() const;
 	//! Construct a managed buffer.
 	virtual unique_ptr<FileBuffer> ConstructManagedBuffer(idx_t size, unique_ptr<FileBuffer> &&source,

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -77,7 +77,7 @@ public:
 
 	DUCKDB_API Allocator &GetBufferAllocator() final override;
 
-	DatabaseInstance &GetDatabase() final override {
+	DatabaseInstance &GetDatabase() {
 		return db;
 	}
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -213,7 +213,11 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	}
 
 	db_manager = make_uniq<DatabaseManager>(*this);
-	buffer_manager = make_uniq<StandardBufferManager>(*this, config.options.temporary_directory);
+	if (config.buffer_manager) {
+		buffer_manager = config.buffer_manager;
+	} else {
+		buffer_manager = make_uniq<StandardBufferManager>(*this, config.options.temporary_directory);
+	}
 	scheduler = make_uniq<TaskScheduler>(*this);
 	object_cache = make_uniq<ObjectCache>();
 	connection_manager = make_uniq<ConnectionManager>();

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -8,10 +8,6 @@
 
 namespace duckdb {
 
-unique_ptr<BufferManager> BufferManager::CreateStandardBufferManager(DatabaseInstance &db, DBConfig &config) {
-	return make_uniq<StandardBufferManager>(db, config.options.temporary_directory);
-}
-
 shared_ptr<BlockHandle> BufferManager::RegisterSmallMemory(idx_t block_size) {
 	throw NotImplementedException("This type of BufferManager can not create 'small-memory' blocks");
 }
@@ -49,10 +45,6 @@ TemporaryMemoryManager &BufferManager::GetTemporaryMemoryManager() {
 
 void BufferManager::SetTemporaryDirectory(const string &new_dir) {
 	throw NotImplementedException("This type of BufferManager can not set a temporary directory");
-}
-
-DatabaseInstance &BufferManager::GetDatabase() {
-	throw NotImplementedException("This type of BufferManager is not linked to a DatabaseInstance");
 }
 
 bool BufferManager::HasTemporaryDirectory() const {


### PR DESCRIPTION
Similar to how we support injecting a custom BufferPool, support injecting a custom BufferManager.

Also prune some unused functions:
- BufferManager::GetDatabase
- StandardBufferManager::CreateStandardBufferManager