### PR TITLE
Flatten Rewrite

### DIFF
--- a/src/core_functions/scalar/list/flatten.cpp
+++ b/src/core_functions/scalar/list/flatten.cpp
@@ -17,24 +17,33 @@ void ListFlattenFunction(DataChunk &args, ExpressionState &state, Vector &result
 
 	idx_t count = args.size();
 
-	UnifiedVectorFormat list_data;
-	input.ToUnifiedFormat(count, list_data);
-	auto list_entries = UnifiedVectorFormat::GetData<list_entry_t>(list_data);
-	auto &child_vector = ListVector::GetEntry(input);
-
+	// Prepare the result vector
 	result.SetVectorType(VectorType::FLAT_VECTOR);
+	// This holds the new offsets and lengths
 	auto result_entries = FlatVector::GetData<list_entry_t>(result);
 	auto &result_validity = FlatVector::Validity(result);
 
-	if (child_vector.GetType().id() == LogicalTypeId::SQLNULL) {
-		for (idx_t i = 0; i < count; i++) {
-			auto list_index = list_data.sel->get_index(i);
-			if (!list_data.validity.RowIsValid(list_index)) {
-				result_validity.SetInvalid(i);
+	// The outermost list in each row
+	UnifiedVectorFormat row_data;
+	input.ToUnifiedFormat(count, row_data);
+	auto row_entries = UnifiedVectorFormat::GetData<list_entry_t>(row_data);
+
+	// The list elements in each row: [HERE, ...]
+	auto &row_lists = ListVector::GetEntry(input);
+	UnifiedVectorFormat row_lists_data;
+	idx_t total_row_lists = ListVector::GetListSize(input);
+	row_lists.ToUnifiedFormat(total_row_lists, row_lists_data);
+	auto row_lists_entries = UnifiedVectorFormat::GetData<list_entry_t>(row_lists_data);
+
+	if (row_lists.GetType().id() == LogicalTypeId::SQLNULL) {
+		for (idx_t row_cnt = 0; row_cnt < count; row_cnt++) {
+			auto row_idx = row_data.sel->get_index(row_cnt);
+			if (!row_data.validity.RowIsValid(row_idx)) {
+				result_validity.SetInvalid(row_cnt);
 				continue;
 			}
-			result_entries[i].offset = 0;
-			result_entries[i].length = 0;
+			result_entries[row_cnt].offset = 0;
+			result_entries[row_cnt].length = 0;
 		}
 		if (args.AllConstant()) {
 			result.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -42,47 +51,58 @@ void ListFlattenFunction(DataChunk &args, ExpressionState &state, Vector &result
 		return;
 	}
 
-	auto child_size = ListVector::GetListSize(input);
-	UnifiedVectorFormat child_data;
-	child_vector.ToUnifiedFormat(child_size, child_data);
-	auto child_entries = UnifiedVectorFormat::GetData<list_entry_t>(child_data);
-	auto &data_vector = ListVector::GetEntry(child_vector);
+	// The actual elements inside each row list: [[HERE, ...], []]
+	// This one becomes the child vector of the result.
+	auto &elem_vector = ListVector::GetEntry(row_lists);
 
-	idx_t offset = 0;
-	for (idx_t i = 0; i < count; i++) {
-		auto list_index = list_data.sel->get_index(i);
-		if (!list_data.validity.RowIsValid(list_index)) {
-			result_validity.SetInvalid(i);
+	// We'll use this selection vector to slice the elem_vector.
+	idx_t child_elem_cnt = ListVector::GetListSize(row_lists);
+	SelectionVector sel(child_elem_cnt);
+	idx_t sel_idx = 0;
+
+	// HERE, [[]], ...
+	for (idx_t row_cnt = 0; row_cnt < count; row_cnt++) {
+		auto row_idx = row_data.sel->get_index(row_cnt);
+
+		if (!row_data.validity.RowIsValid(row_idx)) {
+			result_validity.SetInvalid(row_cnt);
 			continue;
 		}
-		auto list_entry = list_entries[list_index];
 
-		idx_t source_offset = 0;
-		// Find first valid child list entry to get offset
-		for (idx_t j = 0; j < list_entry.length; j++) {
-			auto child_list_index = child_data.sel->get_index(list_entry.offset + j);
-			if (child_data.validity.RowIsValid(child_list_index)) {
-				source_offset = child_entries[child_list_index].offset;
-				break;
+		idx_t list_offset = sel_idx;
+		idx_t list_length = 0;
+
+		// [HERE, [...], ...]
+		auto row_entry = row_entries[row_idx];
+		for (idx_t row_lists_cnt = 0; row_lists_cnt < row_entry.length; row_lists_cnt++) {
+			auto row_lists_idx = row_lists_data.sel->get_index(row_entry.offset + row_lists_cnt);
+
+			// Skip invalid lists
+			if (!row_lists_data.validity.RowIsValid(row_lists_idx)) {
+				continue;
+			}
+
+			// [[HERE, ...], [.., ...]]
+			auto list_entry = row_lists_entries[row_lists_idx];
+			list_length += list_entry.length;
+
+			for (idx_t elem_cnt = 0; elem_cnt < list_entry.length; elem_cnt++) {
+				// offset of the element in the elem_vector.
+				idx_t offset = list_entry.offset + elem_cnt;
+				sel.set_index(sel_idx, offset);
+				sel_idx++;
 			}
 		}
 
-		idx_t length = 0;
-		// Find last valid child list entry to get length
-		for (idx_t j = list_entry.length - 1; j != (idx_t)-1; j--) {
-			auto child_list_index = child_data.sel->get_index(list_entry.offset + j);
-			if (child_data.validity.RowIsValid(child_list_index)) {
-				auto child_entry = child_entries[child_list_index];
-				length = child_entry.offset + child_entry.length - source_offset;
-				break;
-			}
-		}
-		ListVector::Append(result, data_vector, source_offset + length, source_offset);
-
-		result_entries[i].offset = offset;
-		result_entries[i].length = length;
-		offset += length;
+		result_entries[row_cnt].offset = list_offset;
+		result_entries[row_cnt].length = list_length;
 	}
+
+	ListVector::SetListSize(result, sel_idx);
+
+	auto &result_child_vector = ListVector::GetEntry(result);
+	result_child_vector.Slice(elem_vector, sel, sel_idx);
+	result_child_vector.Flatten(sel_idx);
 
 	if (args.AllConstant()) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -134,7 +134,7 @@ void DeleteArray(T *ptr, idx_t size) {
 }
 
 template <typename T, typename... ARGS>
-T *AllocateObject(ARGS &&...args) {
+T *AllocateObject(ARGS &&... args) {
 	auto data = Allocator::DefaultAllocator().AllocateData(sizeof(T));
 	return new (data) T(std::forward<ARGS>(args)...);
 }

--- a/test/sql/function/list/flatten.test
+++ b/test/sql/function/list/flatten.test
@@ -2,9 +2,6 @@
 # description: Test flatten function
 # group: [list]
 
-# FIXME bug in nested shuffle vector handling
-require no_vector_verification
-
 statement ok
 PRAGMA enable_verification
 


### PR DESCRIPTION
#11138 introduced new verification methods that resulting in `flatten()` producing the incorrect result when `VERIFY_VECTOR=nested_shuffle`.

This prompted a complete rewrite of `flatten()`, now it builds a selection vector based on the offset and lengths of the original vector and then slices the child of the original vector onto the result vector.