### PR TITLE
Fix #11211 - correctly fill in string_t padding for bit type

### DIFF
--- a/src/common/types/bit.cpp
+++ b/src/common/types/bit.cpp
@@ -287,6 +287,7 @@ idx_t Bit::GetBitInternal(string_t bit_string, idx_t n) {
 
 void Bit::SetBit(string_t &bit_string, idx_t n, idx_t new_value) {
 	SetBitInternal(bit_string, n + GetBitPadding(bit_string), new_value);
+	Bit::Finalize(bit_string);
 }
 
 void Bit::SetBitInternal(string_t &bit_string, idx_t n, idx_t new_value) {

--- a/src/common/types/bit.cpp
+++ b/src/common/types/bit.cpp
@@ -51,6 +51,7 @@ void Bit::Finalize(string_t &str) {
 	for (idx_t i = 0; i < idx_t(padding); i++) {
 		Bit::SetBitInternal(str, i, 1);
 	}
+	str.Finalize();
 	Bit::Verify(str);
 }
 
@@ -145,7 +146,6 @@ void Bit::ToBit(string_t str, string_t &output_str) {
 		*(output++) = byte;
 	}
 	Bit::Finalize(output_str);
-	Bit::Verify(output_str);
 }
 
 string Bit::ToBit(string_t str) {
@@ -332,7 +332,6 @@ void Bit::LeftShift(const string_t &bit_string, const idx_t &shift, string_t &re
 		}
 	}
 	Bit::Finalize(result);
-	Bit::Verify(result);
 }
 
 void Bit::BitwiseAnd(const string_t &rhs, const string_t &lhs, string_t &result) {
@@ -348,8 +347,7 @@ void Bit::BitwiseAnd(const string_t &rhs, const string_t &lhs, string_t &result)
 	for (idx_t i = 1; i < lhs.GetSize(); i++) {
 		buf[i] = l_buf[i] & r_buf[i];
 	}
-	// and should preserve padding bits
-	Bit::Verify(result);
+	Bit::Finalize(result);
 }
 
 void Bit::BitwiseOr(const string_t &rhs, const string_t &lhs, string_t &result) {
@@ -365,8 +363,7 @@ void Bit::BitwiseOr(const string_t &rhs, const string_t &lhs, string_t &result) 
 	for (idx_t i = 1; i < lhs.GetSize(); i++) {
 		buf[i] = l_buf[i] | r_buf[i];
 	}
-	// or should preserve padding bits
-	Bit::Verify(result);
+	Bit::Finalize(result);
 }
 
 void Bit::BitwiseXor(const string_t &rhs, const string_t &lhs, string_t &result) {
@@ -403,6 +400,8 @@ void Bit::Verify(const string_t &input) {
 	for (idx_t i = 0; i < padding; i++) {
 		D_ASSERT(Bit::GetBitInternal(input, i));
 	}
+	// verify bit respects the "normal" string_t rules (i.e. null padding for inlined strings, prefix matches)
+	input.VerifyCharacters();
 #endif
 }
 

--- a/test/sql/types/bit/bit_issue_11211.test
+++ b/test/sql/types/bit/bit_issue_11211.test
@@ -1,0 +1,28 @@
+# name: test/sql/types/bit/bit_issue_11211.test
+# description: Issue #11211 - Incorrect equality comparison for BIT type
+# group: [bit]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+select ( 2::bit & 2::bit ) = 2::bit as b;
+----
+true
+
+query I
+select ( 2::bit & 2::bit ) = 2::bit as b;
+----
+true
+
+query IIII
+FROM
+(
+  SELECT
+  ( 2::bit & 2::bit ) AS a,
+  2::bit AS b,
+  (a = b) AS '(a = b)',
+)
+SELECT a, b, a = b, "(a = b)";
+----
+00000000000000000000000000000010	00000000000000000000000000000010	true	true

--- a/test/sql/types/bit/test_bit_functions.test
+++ b/test/sql/types/bit/test_bit_functions.test
@@ -129,7 +129,6 @@ SELECT set_bit('011'::BIT, -1, 0)
 ----
 Out of Range Error: bit index -1 out of valid range
 
-
 # **** BIT_COUNT ****
 query I
 SELECT bit_count('10101'::BIT)


### PR DESCRIPTION
Fixes #11211 

Bits are internally represented as `string_t` - meaning this struct needs to be filled in correctly by calling `string_t::Finalize()`. Not doing so has no effect on bit operations, but can cause operations on the underlying `string_t` (like equality) to be incorrect. 