### PR TITLE
Issue #10867: AsOf Predicate Pushdown

### DIFF
--- a/src/optimizer/pushdown/pushdown_cross_product.cpp
+++ b/src/optimizer/pushdown/pushdown_cross_product.cpp
@@ -7,9 +7,19 @@ namespace duckdb {
 using Filter = FilterPushdown::Filter;
 
 unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<LogicalOperator> op) {
-	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_CROSS_PRODUCT);
+	D_ASSERT(op->children.size() > 1);
 	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
 	vector<unique_ptr<Expression>> join_expressions;
+	auto join_ref_type = JoinRefType::REGULAR;
+	switch (op->type) {
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		break;
+	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
+		join_ref_type = JoinRefType::ASOF;
+		break;
+	default:
+		throw InternalException("Unsupported join type for cross product push down");
+	}
 	unordered_set<idx_t> left_bindings, right_bindings;
 	if (!filters.empty()) {
 		// check to see into which side we should push the filters
@@ -41,16 +51,17 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 		// extract join conditions
 		vector<JoinCondition> conditions;
 		vector<unique_ptr<Expression>> arbitrary_expressions;
-		auto join_type = JoinType::INNER;
+		const auto join_type = JoinType::INNER;
 		LogicalComparisonJoin::ExtractJoinConditions(GetContext(), join_type, op->children[0], op->children[1],
 		                                             left_bindings, right_bindings, join_expressions, conditions,
 		                                             arbitrary_expressions);
 		// create the join from the join conditions
-		return LogicalComparisonJoin::CreateJoin(GetContext(), JoinType::INNER, JoinRefType::REGULAR,
-		                                         std::move(op->children[0]), std::move(op->children[1]),
-		                                         std::move(conditions), std::move(arbitrary_expressions));
+		return LogicalComparisonJoin::CreateJoin(GetContext(), join_type, join_ref_type, std::move(op->children[0]),
+		                                         std::move(op->children[1]), std::move(conditions),
+		                                         std::move(arbitrary_expressions));
 	} else {
 		// no join conditions found: keep as cross product
+		D_ASSERT(op->type == LogicalOperatorType::LOGICAL_CROSS_PRODUCT);
 		return op;
 	}
 }

--- a/src/optimizer/pushdown/pushdown_inner_join.cpp
+++ b/src/optimizer/pushdown/pushdown_inner_join.cpp
@@ -24,12 +24,10 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<Logical
 			// filter statically evaluates to false, strip tree
 			return make_uniq<LogicalEmptyResult>(std::move(op));
 		}
-	} else if (op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN) {
-		// Don't mess with non-standard condition interpretations
-		return FinishPushdown(std::move(op));
 	} else {
 		// comparison join
-		D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN);
+		D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+		         op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN);
 		auto &comp_join = join.Cast<LogicalComparisonJoin>();
 		// turn the conditions into filters
 		for (auto &i : comp_join.conditions) {
@@ -41,6 +39,11 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<Logical
 		}
 	}
 	GenerateFilters();
+
+	//	For AsOf joins, just use the original op
+	if (op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN) {
+		return PushdownCrossProduct(std::move(op));
+	}
 
 	// turn the inner join into a cross product
 	auto cross_product = make_uniq<LogicalCrossProduct>(std::move(op->children[0]), std::move(op->children[1]));

--- a/test/sql/join/asof/test_asof_join_pushdown.test
+++ b/test/sql/join/asof/test_asof_join_pushdown.test
@@ -1,0 +1,45 @@
+# name: test/sql/join/asof/test_asof_join_pushdown.test
+# description: Test prericate pushdown for ASOF joins
+# group: [asof]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE OR REPLACE TABLE right_pushdown(time INTEGER, value FLOAT);
+
+statement ok
+INSERT INTO right_pushdown VALUES
+    (0, 0), 
+    (1, NULL), 
+;
+
+query IIII
+SELECT 
+	d1.time,
+	d2.time,
+	d1.value, 
+	d2.value
+FROM right_pushdown d1 
+ASOF JOIN (
+	SELECT * FROM right_pushdown WHERE value is not NULL
+	) d2
+	ON d1.time >= d2.time;
+----
+0 	0	0.0	0.0
+1 	0	NULL	0.0
+
+query IIII
+SELECT 
+	d1.time,
+	d2.time,
+	d1.value, 
+	d2.value
+FROM right_pushdown d1 
+ASOF LEFT JOIN (
+	SELECT * FROM right_pushdown WHERE value is not NULL
+	) d2
+	ON d1.time >= d2.time;
+----
+0 	0	0.0	0.0
+1 	0	NULL	0.0


### PR DESCRIPTION
Implement correct predicate pushdown for INNER AsOf joins. Since we do push them down for LEFT AsOf joins,
this was especially unfortunate.

fixes: duckdb/duckdb#10867
fixes: duckdblabs/duckdb-internal#1382