### PR TITLE
Remove no_vector_verification in Map Subscript Test

### DIFF
--- a/test/sql/types/nested/map/test_map_subscript_all_types.test_slow
+++ b/test/sql/types/nested/map/test_map_subscript_all_types.test_slow
@@ -7,9 +7,6 @@
 statement ok
 PRAGMA enable_verification;
 
-# FIXME: bug in dictionary vector operator
-require no_vector_verification
-
 query I nosort all_types
 SELECT [columns(*)]
 FROM test_all_types()


### PR DESCRIPTION
Test now passes with vector verification.