### PR TITLE
R_CMD_CHECK: Pin to duckdb/duckdb-r 0ed106a71c

### DIFF
--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -33,6 +33,7 @@ name: R-CMD-check
 env:
   DUCKDB_R_REPO: 'duckdb/duckdb-r'
   TARGET_REF: 'main'
+  DUCKDB_R_REF: '0ed106a71c6e54a509e693a71aba49145c0a3a0f'
   DUCKDB_R_SRC: 'duckdb-r'
   DUCKDB_SRC: 'duckdb'
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -62,6 +63,7 @@ jobs:
         with:
           repository: ${{ env.DUCKDB_R_REPO }}
           path: ${{ env.DUCKDB_R_SRC }}
+          ref: ${{ env.DUCKDB_R_REF }}
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
It has been chosen since the latest commit that is known to be working on our CI.

This is NOT the proper solution, since at the very least a strategy for updating the pinned version should be in place, but will do in avoiding adding CI noise and more importantly having some check in place (otherwise we might involuntarily broke R by postponing all tests until a proper fix is in place).