### PR TITLE
Fix the table in the attached database that relies on a sequence

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -117,7 +117,8 @@ public:
 
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info);
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema);
-	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema, bool from_deserialization);
+	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema,
+	                                                     bool from_deserialization);
 
 	void BindCreateViewInfo(CreateViewInfo &base);
 	SchemaCatalogEntry &BindSchema(CreateInfo &info);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -117,6 +117,7 @@ public:
 
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info);
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema);
+	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema, bool from_deserialization);
 
 	void BindCreateViewInfo(CreateViewInfo &base);
 	SchemaCatalogEntry &BindSchema(CreateInfo &info);

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -254,7 +254,8 @@ static void ExtractDependencies(BoundCreateTableInfo &info) {
 		}
 	}
 }
-unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema, bool from_deserialization) {
+unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema,
+                                                             bool from_deserialization) {
 	auto &base = info->Cast<CreateTableInfo>();
 	auto result = make_uniq<BoundCreateTableInfo>(schema, std::move(info));
 	if (base.query) {
@@ -284,7 +285,7 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 		// we skip this step if we are deserializing CreateTableInfo(e.g. ATTACH foo.db)
 		// col_bar DEFAULT nextval('col_bar_seq') , even col_bar_seq does exist in catalog 'foo'
 		// We can't find the 'col_bar_seq' in the current catalog when ATTACH 'foo' is not done
-		if(!from_deserialization){
+		if (!from_deserialization) {
 			BindDefaultValues(base.columns, result->bound_defaults);
 		}
 	}

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -541,7 +541,7 @@ void CheckpointReader::ReadTable(ClientContext &context, Deserializer &deseriali
 	auto info = deserializer.ReadProperty<unique_ptr<CreateInfo>>(100, "table");
 	auto binder = Binder::CreateBinder(context);
 	auto &schema = catalog.GetSchema(context, info->schema);
-	auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);
+	auto bound_info = binder->BindCreateTableInfo(std::move(info), schema, true);
 
 	// now read the actual table data and place it into the CreateTableInfo
 	ReadTableData(context, deserializer, *bound_info);

--- a/test/sql/attach/attach_table_with_sequence.test
+++ b/test/sql/attach/attach_table_with_sequence.test
@@ -32,11 +32,11 @@ ATTACH ':memory:' AS mem;
 statement ok
 USE mem;
 
-# Detach the table-with-seq.db
+# Detach the seq.db
 statement ok
 DETACH seq;
 
-# we cant read the table anymore
+# we can't read the table anymore
 statement error
 FROM person;
 ----
@@ -47,3 +47,24 @@ ATTACH '__TEST_DIR__/seq.db' AS seq;
 statement ok
 use seq;
 
+statement ok
+INSERT INTO person (age) VALUES (20) , (30);
+
+query II
+SELECT * FROM person;
+----
+1	10
+2	20
+3	30
+
+# Use the memory catalog
+statement ok
+USE mem;
+
+# read the person table again
+query II
+SELECT * FROM seq.person;
+----
+1	10
+2	20
+3	30

--- a/test/sql/attach/attach_table_with_sequence.test
+++ b/test/sql/attach/attach_table_with_sequence.test
@@ -1,13 +1,16 @@
 # name: test/sql/attach/attach_table_with_sequence.test
-# description: Test attaching a DuckDB file that contains a table relying on a sequence. (issue 10263)
+# description: Test attaching a duckdb file that contains a table relying on a sequence. (issue 10263)
 # group: [attach]
 
-require skip_reload
+require noforcestorage
 
-# load the DB from disk
-load __TEST_DIR__/seq.db
+# create a table with a sequence in seq.db
+statement ok
+ATTACH '__TEST_DIR__/seq.db' AS seq;
 
-# create a table with a sequence in table-with-seq.db
+statement ok
+USE seq;
+
 statement ok
 CREATE SEQUENCE 'id_seq';
 
@@ -17,16 +20,21 @@ CREATE TABLE person (id INT DEFAULT nextval('id_seq'), age INT NOT NULL);
 statement ok
 INSERT INTO person (age) VALUES (10);
 
+query II
+SELECT * FROM seq.person;
+----
+1	10
+
 # use memory catalog as default
 statement ok
-ATTACH DATABASE ':memory:' AS mem;
+ATTACH ':memory:' AS mem;
 
 statement ok
 USE mem;
 
 # Detach the table-with-seq.db
 statement ok
-DETACH DATABASE seq;
+DETACH seq;
 
 # we cant read the table anymore
 statement error
@@ -34,4 +42,8 @@ FROM person;
 ----
 
 statement ok
-ATTACH DATABASE '__TEST_DIR__/seq.db' AS seq;
+ATTACH '__TEST_DIR__/seq.db' AS seq;
+
+statement ok
+use seq;
+

--- a/test/sql/attach/attach_table_with_sequence.test
+++ b/test/sql/attach/attach_table_with_sequence.test
@@ -32,7 +32,7 @@ ATTACH ':memory:' AS mem;
 statement ok
 USE mem;
 
-# Detach the seq.db
+# detach the seq.db
 statement ok
 DETACH seq;
 

--- a/test/sql/attach/attach_table_with_sequence.test
+++ b/test/sql/attach/attach_table_with_sequence.test
@@ -1,0 +1,37 @@
+# name: test/sql/attach/attach_table_with_sequence.test
+# description: Test attaching a DuckDB file that contains a table relying on a sequence. (issue 10263)
+# group: [attach]
+
+require skip_reload
+
+# load the DB from disk
+load __TEST_DIR__/seq.db
+
+# create a table with a sequence in table-with-seq.db
+statement ok
+CREATE SEQUENCE 'id_seq';
+
+statement ok
+CREATE TABLE person (id INT DEFAULT nextval('id_seq'), age INT NOT NULL);
+
+statement ok
+INSERT INTO person (age) VALUES (10);
+
+# use memory catalog as default
+statement ok
+ATTACH DATABASE ':memory:' AS mem;
+
+statement ok
+USE mem;
+
+# Detach the table-with-seq.db
+statement ok
+DETACH DATABASE seq;
+
+# we cant read the table anymore
+statement error
+FROM person;
+----
+
+statement ok
+ATTACH DATABASE '__TEST_DIR__/seq.db' AS seq;


### PR DESCRIPTION
Fix https://github.com/duckdb/duckdb/issues/10263

When attaching a DuckDB database (for example, foo.db) that includes a table with a column defaulting to a `DEFAULT` value derived from a SEQUENCE (using `nextval('some_seq')`), we encounter a problem during the CREATE TABLE INFO binding process. Even if the SEQUENCE has been deserialized from the database prior to the table deserialization, it remains unfindable in the catalog.

The root of this issue lies in the requirement to complete the `ATTACH` statement to access `foo.some_seq` in the catalog. However, the CREATE TABLE binding, which includes the `BindDefaultValues` step, must be performed first. During `BindDefaultValues`, we need to bind to `foo.some_seq`, creating a circular dependency akin to the chicken-and-egg problem.

A possible solution involves skipping the `BindDefaultValues` step during deserialization. This is based on that all tables have already been bound within the database upon deserialization, allowing us to bypass this step.