### PR TITLE
[Python] Fix error caused by looking up a TypeCatalogEntry without an active transaction.

### DIFF
--- a/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
+++ b/tools/pythonpkg/src/pyduckdb/connection_wrapper.cpp
@@ -77,7 +77,10 @@ shared_ptr<DuckDBPyType> PyConnectionWrapper::Type(const string &type_str, share
 	if (!conn) {
 		conn = DuckDBPyConnection::DefaultConnection();
 	}
-	return conn->Type(type_str);
+	auto &context = *conn->connection->context;
+	shared_ptr<DuckDBPyType> result;
+	context.RunFunctionInTransaction([&result, &type_str, &conn]() { result = conn->Type(type_str); });
+	return result;
 }
 
 shared_ptr<DuckDBPyConnection> PyConnectionWrapper::ExecuteMany(const py::object &query, py::object params,

--- a/tools/pythonpkg/tests/fast/test_type.py
+++ b/tools/pythonpkg/tests/fast/test_type.py
@@ -196,6 +196,13 @@ class TestType(object):
         child_type = type.v2.child
         assert str(child_type) == 'MAP(BLOB, BIT)'
 
+    def test_json_type(self):
+        json_type = duckdb.type('JSON')
+
+        val = duckdb.Value('{"duck": 42}', json_type)
+        res = duckdb.execute("select typeof($1)", [val]).fetchone()
+        assert res == ('JSON',)
+
     # NOTE: we can support this, but I don't think going through hoops for an outdated version of python is worth it
     @pytest.mark.skipif(sys.version_info < (3, 9), reason="python3.7 does not store Optional[..] in a recognized way")
     def test_optional(self):


### PR DESCRIPTION
This PR fixes #11250 

Since this is not a builtin type, we need to do a lookup in the Catalog, for that we need a transaction, we did not have an active transaction, so we hit an InternalException.

Now we always have a transaction so the lookup doesn't error out anymore.