### PR TITLE
Update logos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,9 @@
 
 
 <p align="center">
-  <a href="https://github.com/duckdb/duckdb/actions">
-    <img src="https://github.com/duckdb/duckdb/actions/workflows/Main.yml/badge.svg?branch=main" alt="Github Actions Badge">
-  </a>
-  <a href="https://discord.gg/tcvwpjfnZx">
-    <img src="https://shields.io/discord/909674491309850675" alt="discord" />
-  </a>
-  <a href="https://github.com/duckdb/duckdb/releases/">
-    <img src="https://img.shields.io/github/v/release/duckdb/duckdb?color=brightgreen&display_name=tag&logo=duckdb&logoColor=white" alt="Latest Release">
-  </a>
+  <a href="https://github.com/duckdb/duckdb/actions"><img src="https://github.com/duckdb/duckdb/actions/workflows/Main.yml/badge.svg?branch=main" alt="Github Actions Badge"></a>
+  <a href="https://discord.gg/tcvwpjfnZx"><img src="https://shields.io/discord/909674491309850675" alt="discord" /></a>
+  <a href="https://github.com/duckdb/duckdb/releases/"><img src="https://img.shields.io/github/v/release/duckdb/duckdb?color=brightgreen&display_name=tag&logo=duckdb&logoColor=white" alt="Latest Release"></a>
 </p>
 
 ## DuckDB


### PR DESCRIPTION
GitHub changed their CSS to include underlines, so the spaces in our README look like this:

<img width="491" alt="Screenshot 2024-03-19 at 17 30 23" src="https://github.com/duckdb/duckdb/assets/1402801/afd831be-36ea-484c-b03f-21b4fffe6a76">

This PR removes the spaces from the link.