### PR TITLE
add TRIM support to virtual filesystem, and implementation on linux

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -295,6 +295,11 @@ void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t 
 	throw NotImplementedException("%s: Read (with location) is not implemented!", GetName());
 }
 
+bool FileSystem::Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) {
+	// This is not a required method. Derived FileSystems may optionally override/implement.
+	return false;
+}
+
 void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
 	throw NotImplementedException("%s: Write (with location) is not implemented!", GetName());
 }
@@ -475,6 +480,10 @@ FileHandle::~FileHandle() {
 
 int64_t FileHandle::Read(void *buffer, idx_t nr_bytes) {
 	return file_system.Read(*this, buffer, nr_bytes);
+}
+
+bool FileHandle::Trim(idx_t offset_bytes, idx_t length_bytes) {
+	return file_system.Trim(*this, offset_bytes, length_bytes);
 }
 
 int64_t FileHandle::Write(void *buffer, idx_t nr_bytes) {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -441,6 +441,16 @@ int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_byte
 	return bytes_written;
 }
 
+bool LocalFileSystem::Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) {
+#if defined(__linux__)
+	int fd = handle.Cast<UnixFileHandle>().fd;
+	int res = fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset_bytes, length_bytes);
+	return res == 0;
+#else
+	return false;
+#endif
+}
+
 int64_t LocalFileSystem::GetFileSize(FileHandle &handle) {
 	int fd = handle.Cast<UnixFileHandle>().fd;
 	struct stat s;

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -859,6 +859,11 @@ int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_byte
 	return bytes_written;
 }
 
+bool LocalFileSystem::Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) {
+	// TODO: Not yet implemented on windows.
+	return false;
+}
+
 int64_t LocalFileSystem::GetFileSize(FileHandle &handle) {
 	HANDLE hFile = handle.Cast<WindowsFileHandle>().fd;
 	LARGE_INTEGER result;

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -64,6 +64,7 @@ public:
 	DUCKDB_API void Sync();
 	DUCKDB_API void Truncate(int64_t new_size);
 	DUCKDB_API string ReadLine();
+	DUCKDB_API bool Trim(idx_t offset_bytes, idx_t length_bytes);
 
 	DUCKDB_API bool CanSeek();
 	DUCKDB_API bool IsPipe();
@@ -139,6 +140,9 @@ public:
 	DUCKDB_API virtual int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes);
 	//! Write nr_bytes from the buffer into the file, moving the file pointer forward by nr_bytes.
 	DUCKDB_API virtual int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes);
+	//! Excise a range of the file. The OS can drop pages from the page-cache, and the file-system is free to deallocate
+	//! this range (sparse file support). Reads to the range will succeed but will return undefined data.
+	DUCKDB_API virtual bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes);
 
 	//! Returns the file size of a file handle, returns -1 on error
 	DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -30,6 +30,10 @@ public:
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	//! Write nr_bytes from the buffer into the file, moving the file pointer forward by nr_bytes.
 	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+	//! Excise a range of the file. The file-system is free to deallocate this
+	//! range (sparse file support). Reads to the range will succeed but will return
+	//! undefined data.
+	bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override;
 
 	//! Returns the file size of a file handle, returns -1 on error
 	int64_t GetFileSize(FileHandle &handle) override;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -127,6 +127,9 @@ struct DBConfigOptions {
 	bool use_temporary_directory = true;
 	//! Directory to store temporary structures that do not fit in memory
 	string temporary_directory;
+	//! Whether or not to invoke filesystem trim on free blocks after checkpoint. This will reclaim
+	//! space for sparse files, on platforms that support it.
+	bool trim_free_blocks = false;
 	//! Whether or not to allow printing unredacted secrets
 	bool allow_unredacted_secrets = false;
 	//! The collation type of the database

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -80,6 +80,7 @@ private:
 
 	//! Return the blocks to which we will write the free list and modified blocks
 	vector<MetadataHandle> GetFreeListBlocks();
+	void TrimFreeBlocks();
 
 private:
 	AttachedDatabase &db;
@@ -93,6 +94,8 @@ private:
 	FileBuffer header_buffer;
 	//! The list of free blocks that can be written to currently
 	set<block_id_t> free_list;
+	//! The list of blocks that were freed since the last checkpoint.
+	set<block_id_t> newly_freed_list;
 	//! The list of multi-use blocks (i.e. blocks that have >1 reference in the file)
 	//! When a multi-use block is marked as modified, the reference count is decreased by 1 instead of directly
 	//! Appending the block to the modified_blocks list

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -294,7 +294,9 @@ void SingleFileBlockManager::LoadFreeList() {
 	auto free_list_count = reader.Read<uint64_t>();
 	free_list.clear();
 	for (idx_t i = 0; i < free_list_count; i++) {
-		free_list.insert(reader.Read<block_id_t>());
+		auto block = reader.Read<block_id_t>();
+		free_list.insert(block);
+		newly_freed_list.insert(block);
 	}
 	auto multi_use_blocks_count = reader.Read<uint64_t>();
 	multi_use_blocks.clear();
@@ -320,6 +322,7 @@ block_id_t SingleFileBlockManager::GetFreeBlockId() {
 		block = *free_list.begin();
 		// erase the entry from the free list again
 		free_list.erase(free_list.begin());
+		newly_freed_list.erase(block);
 	} else {
 		block = max_block++;
 	}
@@ -335,6 +338,7 @@ void SingleFileBlockManager::MarkBlockAsFree(block_id_t block_id) {
 	}
 	multi_use_blocks.erase(block_id);
 	free_list.insert(block_id);
+	newly_freed_list.insert(block_id);
 }
 
 void SingleFileBlockManager::MarkBlockAsModified(block_id_t block_id) {
@@ -432,9 +436,8 @@ void SingleFileBlockManager::Truncate() {
 		return;
 	}
 	// truncate the file
-	for (idx_t i = 0; i < blocks_to_truncate; i++) {
-		free_list.erase(max_block + i);
-	}
+	free_list.erase(free_list.lower_bound(max_block), free_list.end());
+	newly_freed_list.erase(newly_freed_list.lower_bound(max_block), newly_freed_list.end());
 	handle->Truncate(BLOCK_START + max_block * Storage::BLOCK_ALLOC_SIZE);
 }
 
@@ -494,6 +497,7 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 	metadata_manager.MarkBlocksAsModified();
 	for (auto &block : modified_blocks) {
 		free_list.insert(block);
+		newly_freed_list.insert(block);
 	}
 	modified_blocks.clear();
 
@@ -547,6 +551,28 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 	active_header = 1 - active_header;
 	//! Ensure the header write ends up on disk
 	handle->Sync();
+	// Release the free blocks to the filesystem.
+	TrimFreeBlocks();
+	newly_freed_list.clear();
+}
+
+void SingleFileBlockManager::TrimFreeBlocks() {
+	if (DBConfig::Get(db).options.trim_free_blocks) {
+		for (auto itr = newly_freed_list.begin(); itr != newly_freed_list.end(); ++itr) {
+			block_id_t first = *itr;
+			block_id_t last = first;
+			// Find end of contiguous range.
+			for (++itr; itr != newly_freed_list.end() && (*itr == last + 1); ++itr) {
+				last = *itr;
+			}
+			// We are now one too far.
+			--itr;
+			// Trim the range.
+			handle->Trim(BLOCK_START + (first * Storage::BLOCK_ALLOC_SIZE),
+			             (last + 1 - first) * Storage::BLOCK_ALLOC_SIZE);
+		}
+	}
+	newly_freed_list.clear();
 }
 
 } // namespace duckdb

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -553,7 +553,6 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 	handle->Sync();
 	// Release the free blocks to the filesystem.
 	TrimFreeBlocks();
-	newly_freed_list.clear();
 }
 
 void SingleFileBlockManager::TrimFreeBlocks() {

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -147,10 +147,9 @@ unique_ptr<DBConfig> GetTestConfig() {
 #else
 	result->options.checkpoint_on_shutdown = false;
 #endif
-#if defined(__linux__)
-	// Currently this is only supported on linux.
-	// Because we test this mode on linux, and the no-trim mode on other platforms,
-	// we get coverage with the option both on and off.
+#ifdef DUCKDB_RUN_SLOW_VERIFIERS
+	// This mode isn't slow, but we want test coverage both when it's enabled
+	// and when it's not, so we enable only when DUCKDB_RUN_SLOW_VERIFIERS is set.
 	result->options.trim_free_blocks = true;
 #endif
 	result->options.allow_unsigned_extensions = true;

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -147,6 +147,12 @@ unique_ptr<DBConfig> GetTestConfig() {
 #else
 	result->options.checkpoint_on_shutdown = false;
 #endif
+#if defined(__linux__)
+	// Currently this is only supported on linux.
+	// Because we test this mode on linux, and the no-trim mode on other platforms,
+	// we get coverage with the option both on and off.
+	result->options.trim_free_blocks = true;
+#endif
 	result->options.allow_unsigned_extensions = true;
 	if (single_threaded) {
 		result->options.maximum_threads = 1;


### PR DESCRIPTION
Add TRIM method to file system, which enables excising a range of the DB file. The OS can drop pages from the page-cache, and the file-system is free to deallocate the range (sparse file support). Reads to the range will succeed but will return undefined data (though most platforms will return 0s).

This is implemented and tested on linux. Windows/ntfs also has support for trim but I have not implemented it, and so tests do not exercise it.

The feature is enabled via a dbconfig.options.trim_free_blocks, which defaults to false.