### PR TITLE
Add FileOpener parameter in some FileSystem method

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/file_opener.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/http_state.hpp"
 #include "duckdb/common/thread.hpp"
 #include "duckdb/common/types/hash.hpp"
@@ -496,9 +497,9 @@ time_t HTTPFileSystem::GetLastModifiedTime(FileHandle &handle) {
 	return sfh.last_modified;
 }
 
-bool HTTPFileSystem::FileExists(const string &filename) {
+bool HTTPFileSystem::FileExists(const string &filename, FileOpener *opener) {
 	try {
-		auto handle = OpenFile(filename.c_str(), FileFlags::FILE_FLAGS_READ);
+		auto handle = OpenFile(filename.c_str(), FileFlags::FILE_FLAGS_READ, DEFAULT_LOCK, DEFAULT_COMPRESSION, opener);
 		auto &sfh = (HTTPFileHandle &)*handle;
 		if (sfh.length == 0) {
 			return false;

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/http_state.hpp"
 #include "duckdb/common/pair.hpp"
@@ -128,7 +129,7 @@ public:
 	void FileSync(FileHandle &handle) override;
 	int64_t GetFileSize(FileHandle &handle) override;
 	time_t GetLastModifiedTime(FileHandle &handle) override;
-	bool FileExists(const string &filename) override;
+	bool FileExists(const string &filename, FileOpener *opener = nullptr) override;
 	void Seek(FileHandle &handle, idx_t location) override;
 	idx_t SeekPosition(FileHandle &handle) override;
 	bool CanHandleFile(const string &fpath) override;

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -229,7 +229,7 @@ public:
 	BufferHandle Allocate(idx_t part_size, uint16_t max_threads);
 
 	//! S3 is object storage so directories effectively always exist
-	bool DirectoryExists(const string &directory) override {
+	bool DirectoryExists(const string &directory, FileOpener *opener = nullptr) override {
 		return true;
 	}
 

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -323,15 +323,15 @@ void FileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 	throw NotImplementedException("%s: Truncate is not implemented!", GetName());
 }
 
-bool FileSystem::DirectoryExists(const string &directory) {
+bool FileSystem::DirectoryExists(const string &directory, FileOpener *opener) {
 	throw NotImplementedException("%s: DirectoryExists is not implemented!", GetName());
 }
 
-void FileSystem::CreateDirectory(const string &directory) {
+void FileSystem::CreateDirectory(const string &directory, FileOpener *opener) {
 	throw NotImplementedException("%s: CreateDirectory is not implemented!", GetName());
 }
 
-void FileSystem::RemoveDirectory(const string &directory) {
+void FileSystem::RemoveDirectory(const string &directory, FileOpener *opener) {
 	throw NotImplementedException("%s: RemoveDirectory is not implemented!", GetName());
 }
 
@@ -340,11 +340,11 @@ bool FileSystem::ListFiles(const string &directory, const std::function<void(con
 	throw NotImplementedException("%s: ListFiles is not implemented!", GetName());
 }
 
-void FileSystem::MoveFile(const string &source, const string &target) {
+void FileSystem::MoveFile(const string &source, const string &target, FileOpener *opener) {
 	throw NotImplementedException("%s: MoveFile is not implemented!", GetName());
 }
 
-bool FileSystem::FileExists(const string &filename) {
+bool FileSystem::FileExists(const string &filename, FileOpener *opener) {
 	throw NotImplementedException("%s: FileExists is not implemented!", GetName());
 }
 
@@ -352,7 +352,7 @@ bool FileSystem::IsPipe(const string &filename) {
 	return false;
 }
 
-void FileSystem::RemoveFile(const string &filename) {
+void FileSystem::RemoveFile(const string &filename, FileOpener *opener) {
 	throw NotImplementedException("%s: RemoveFile is not implemented!", GetName());
 }
 

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -76,15 +76,15 @@ void VirtualFileSystem::FileSync(FileHandle &handle) {
 }
 
 // need to look up correct fs for this
-bool VirtualFileSystem::DirectoryExists(const string &directory) {
-	return FindFileSystem(directory).DirectoryExists(directory);
+bool VirtualFileSystem::DirectoryExists(const string &directory, FileOpener *opener) {
+	return FindFileSystem(directory).DirectoryExists(directory, opener);
 }
-void VirtualFileSystem::CreateDirectory(const string &directory) {
-	FindFileSystem(directory).CreateDirectory(directory);
+void VirtualFileSystem::CreateDirectory(const string &directory, FileOpener *opener) {
+	FindFileSystem(directory).CreateDirectory(directory, opener);
 }
 
-void VirtualFileSystem::RemoveDirectory(const string &directory) {
-	FindFileSystem(directory).RemoveDirectory(directory);
+void VirtualFileSystem::RemoveDirectory(const string &directory, FileOpener *opener) {
+	FindFileSystem(directory).RemoveDirectory(directory, opener);
 }
 
 bool VirtualFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
@@ -92,19 +92,19 @@ bool VirtualFileSystem::ListFiles(const string &directory, const std::function<v
 	return FindFileSystem(directory).ListFiles(directory, callback, opener);
 }
 
-void VirtualFileSystem::MoveFile(const string &source, const string &target) {
-	FindFileSystem(source).MoveFile(source, target);
+void VirtualFileSystem::MoveFile(const string &source, const string &target, FileOpener *opener) {
+	FindFileSystem(source).MoveFile(source, target, opener);
 }
 
-bool VirtualFileSystem::FileExists(const string &filename) {
-	return FindFileSystem(filename).FileExists(filename);
+bool VirtualFileSystem::FileExists(const string &filename, FileOpener *opener) {
+	return FindFileSystem(filename).FileExists(filename, opener);
 }
 
 bool VirtualFileSystem::IsPipe(const string &filename) {
 	return FindFileSystem(filename).IsPipe(filename);
 }
-void VirtualFileSystem::RemoveFile(const string &filename) {
-	FindFileSystem(filename).RemoveFile(filename);
+void VirtualFileSystem::RemoveFile(const string &filename, FileOpener *opener) {
+	FindFileSystem(filename).RemoveFile(filename, opener);
 }
 
 string VirtualFileSystem::PathSeparator(const string &path) {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -153,11 +153,11 @@ public:
 	DUCKDB_API virtual void Truncate(FileHandle &handle, int64_t new_size);
 
 	//! Check if a directory exists
-	DUCKDB_API virtual bool DirectoryExists(const string &directory);
+	DUCKDB_API virtual bool DirectoryExists(const string &directory, FileOpener *opener = nullptr);
 	//! Create a directory if it does not exist
-	DUCKDB_API virtual void CreateDirectory(const string &directory);
+	DUCKDB_API virtual void CreateDirectory(const string &directory, FileOpener *opener = nullptr);
 	//! Recursively remove a directory and all files in it
-	DUCKDB_API virtual void RemoveDirectory(const string &directory);
+	DUCKDB_API virtual void RemoveDirectory(const string &directory, FileOpener *opener = nullptr);
 	//! List files in a directory, invoking the callback method for each one with (filename, is_dir)
 	DUCKDB_API virtual bool ListFiles(const string &directory,
 	                                  const std::function<void(const string &, bool)> &callback,
@@ -165,13 +165,13 @@ public:
 
 	//! Move a file from source path to the target, StorageManager relies on this being an atomic action for ACID
 	//! properties
-	DUCKDB_API virtual void MoveFile(const string &source, const string &target);
+	DUCKDB_API virtual void MoveFile(const string &source, const string &target, FileOpener *opener = nullptr);
 	//! Check if a file exists
-	DUCKDB_API virtual bool FileExists(const string &filename);
+	DUCKDB_API virtual bool FileExists(const string &filename, FileOpener *opener = nullptr);
 	//! Check if path is pipe
 	DUCKDB_API virtual bool IsPipe(const string &filename);
 	//! Remove a file from disk
-	DUCKDB_API virtual void RemoveFile(const string &filename);
+	DUCKDB_API virtual void RemoveFile(const string &filename, FileOpener *opener = nullptr);
 	//! Sync a file handle to disk
 	DUCKDB_API virtual void FileSync(FileHandle &handle);
 	//! Sets the working directory

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -42,24 +42,24 @@ public:
 	void Truncate(FileHandle &handle, int64_t new_size) override;
 
 	//! Check if a directory exists
-	bool DirectoryExists(const string &directory) override;
+	bool DirectoryExists(const string &directory, FileOpener *opener = nullptr) override;
 	//! Create a directory if it does not exist
-	void CreateDirectory(const string &directory) override;
+	void CreateDirectory(const string &directory, FileOpener *opener = nullptr) override;
 	//! Recursively remove a directory and all files in it
-	void RemoveDirectory(const string &directory) override;
+	void RemoveDirectory(const string &directory, FileOpener *opener = nullptr) override;
 	//! List files in a directory, invoking the callback method for each one with (filename, is_dir)
 	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
 	               FileOpener *opener = nullptr) override;
 	//! Move a file from source path to the target, StorageManager relies on this being an atomic action for ACID
 	//! properties
-	void MoveFile(const string &source, const string &target) override;
+	void MoveFile(const string &source, const string &target, FileOpener *opener = nullptr) override;
 	//! Check if a file exists
-	bool FileExists(const string &filename) override;
+	bool FileExists(const string &filename, FileOpener *opener = nullptr) override;
 
 	//! Check if path is a pipe
 	bool IsPipe(const string &filename) override;
 	//! Remove a file from disk
-	void RemoveFile(const string &filename) override;
+	void RemoveFile(const string &filename, FileOpener *opener = nullptr) override;
 	//! Sync a file handle to disk
 	void FileSync(FileHandle &handle) override;
 

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -61,15 +61,15 @@ public:
 		GetFileSystem().FileSync(handle);
 	}
 
-	bool DirectoryExists(const string &directory) override {
-		return GetFileSystem().DirectoryExists(directory);
+	bool DirectoryExists(const string &directory, FileOpener *opener = nullptr) override {
+		return GetFileSystem().DirectoryExists(directory, GetOpener().get());
 	}
-	void CreateDirectory(const string &directory) override {
-		return GetFileSystem().CreateDirectory(directory);
+	void CreateDirectory(const string &directory, FileOpener *opener = nullptr) override {
+		return GetFileSystem().CreateDirectory(directory, GetOpener().get());
 	}
 
-	void RemoveDirectory(const string &directory) override {
-		return GetFileSystem().RemoveDirectory(directory);
+	void RemoveDirectory(const string &directory, FileOpener *opener = nullptr) override {
+		return GetFileSystem().RemoveDirectory(directory, GetOpener().get());
 	}
 
 	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
@@ -80,8 +80,8 @@ public:
 		return GetFileSystem().ListFiles(directory, callback, GetOpener().get());
 	}
 
-	void MoveFile(const string &source, const string &target) override {
-		GetFileSystem().MoveFile(source, target);
+	void MoveFile(const string &source, const string &target, FileOpener *opener = nullptr) override {
+		GetFileSystem().MoveFile(source, target, GetOpener().get());
 	}
 
 	string GetHomeDirectory() override {
@@ -92,15 +92,15 @@ public:
 		return FileSystem::ExpandPath(path, GetOpener());
 	}
 
-	bool FileExists(const string &filename) override {
-		return GetFileSystem().FileExists(filename);
+	bool FileExists(const string &filename, FileOpener *opener = nullptr) override {
+		return GetFileSystem().FileExists(filename, GetOpener().get());
 	}
 
 	bool IsPipe(const string &filename) override {
 		return GetFileSystem().IsPipe(filename);
 	}
-	void RemoveFile(const string &filename) override {
-		GetFileSystem().RemoveFile(filename);
+	void RemoveFile(const string &filename, FileOpener *opener = nullptr) override {
+		GetFileSystem().RemoveFile(filename, GetOpener().get());
 	}
 
 	string PathSeparator(const string &path) override {

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -39,22 +39,22 @@ public:
 	void FileSync(FileHandle &handle) override;
 
 	// need to look up correct fs for this
-	bool DirectoryExists(const string &directory) override;
-	void CreateDirectory(const string &directory) override;
+	bool DirectoryExists(const string &directory, FileOpener *opener = nullptr) override;
+	void CreateDirectory(const string &directory, FileOpener *opener = nullptr) override;
 
-	void RemoveDirectory(const string &directory) override;
+	void RemoveDirectory(const string &directory, FileOpener *opener = nullptr) override;
 
 	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
 	               FileOpener *opener = nullptr) override;
 
-	void MoveFile(const string &source, const string &target) override;
+	void MoveFile(const string &source, const string &target, FileOpener *opener = nullptr) override;
 
-	bool FileExists(const string &filename) override;
+	bool FileExists(const string &filename, FileOpener *opener = nullptr) override;
 
 	bool IsPipe(const string &filename) override;
-	virtual void RemoveFile(const string &filename) override;
+	void RemoveFile(const string &filename, FileOpener *opener = nullptr) override;
 
-	virtual vector<string> Glob(const string &path, FileOpener *opener = nullptr) override;
+	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override;
 
 	void RegisterSubSystem(unique_ptr<FileSystem> fs) override;
 

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/function/table/read_csv.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_data.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
@@ -125,7 +126,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	if (is_remote_file) {
 		use_tmp_file = false;
 	} else {
-		bool is_file_and_exists = config.file_system->FileExists(stmt.info->file_path);
+		bool is_file_and_exists = config.file_system->FileExists(stmt.info->file_path, ClientData::Get(context).file_opener.get());
 		bool is_stdout = stmt.info->file_path == "/dev/stdout";
 		if (!user_set_use_tmp_file) {
 			use_tmp_file = is_file_and_exists && !per_thread_output && partition_cols.empty() && !is_stdout;

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -126,7 +126,8 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	if (is_remote_file) {
 		use_tmp_file = false;
 	} else {
-		bool is_file_and_exists = config.file_system->FileExists(stmt.info->file_path, ClientData::Get(context).file_opener.get());
+		bool is_file_and_exists =
+		    config.file_system->FileExists(stmt.info->file_path, ClientData::Get(context).file_opener.get());
 		bool is_stdout = stmt.info->file_path == "/dev/stdout";
 		if (!user_set_use_tmp_file) {
 			use_tmp_file = is_file_and_exists && !per_thread_output && partition_cols.empty() && !is_stdout;


### PR DESCRIPTION
The file opener allow to access some client context data as secret and variables not exposing them in some method make them no implementable in extensions.