### PR TITLE
Fix #11254: Add missing includes to terminal

### DIFF
--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
+#include <sys/time.h>
 
 namespace duckdb {
 


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/11254