### PR TITLE
Fix potential UB when `list()` aggregate is used in combination with other arena using aggregate functions

### DIFF
--- a/src/core_functions/aggregate/nested/list.cpp
+++ b/src/core_functions/aggregate/nested/list.cpp
@@ -63,6 +63,7 @@ static void ListUpdateFunction(Vector inputs[], AggregateInputData &aggr_input_d
 
 	for (idx_t i = 0; i < count; i++) {
 		auto &state = *states[states_data.sel->get_index(i)];
+		aggr_input_data.allocator.AlignNext();
 		list_bind_data.functions.AppendRow(aggr_input_data.allocator, state.linked_list, input_data, i);
 	}
 }
@@ -178,6 +179,7 @@ static void ListCombineFunction(Vector &states_vector, Vector &combined, Aggrega
 		Vector::RecursiveToUnifiedFormat(input, entry_count, input_data);
 
 		for (idx_t entry_idx = 0; entry_idx < entry_count; ++entry_idx) {
+			aggr_input_data.allocator.AlignNext();
 			list_bind_data.functions.AppendRow(aggr_input_data.allocator, target.linked_list, input_data, entry_idx);
 		}
 	}

--- a/src/include/duckdb/storage/arena_allocator.hpp
+++ b/src/include/duckdb/storage/arena_allocator.hpp
@@ -37,6 +37,9 @@ public:
 	DUCKDB_API data_ptr_t AllocateAligned(idx_t size);
 	DUCKDB_API data_ptr_t ReallocateAligned(data_ptr_t pointer, idx_t old_size, idx_t size);
 
+	//! Increment the internal cursor (if required) so the next allocation is guaranteed to be aligned to 8 bytes
+	DUCKDB_API void AlignNext();
+
 	//! Resets the current head and destroys all previous arena chunks
 	DUCKDB_API void Reset();
 	DUCKDB_API void Destroy();

--- a/src/storage/arena_allocator.cpp
+++ b/src/storage/arena_allocator.cpp
@@ -101,11 +101,20 @@ data_ptr_t ArenaAllocator::Reallocate(data_ptr_t pointer, idx_t old_size, idx_t 
 	}
 }
 
+void ArenaAllocator::AlignNext() {
+	if (head && !ValueIsAligned<idx_t>(head->current_position)) {
+		// move the current position forward so that the next allocation is aligned
+		head->current_position = AlignValue<idx_t>(head->current_position);
+	}
+}
+
 data_ptr_t ArenaAllocator::AllocateAligned(idx_t size) {
+	AlignNext();
 	return Allocate(AlignValue<idx_t>(size));
 }
 
 data_ptr_t ArenaAllocator::ReallocateAligned(data_ptr_t pointer, idx_t old_size, idx_t size) {
+	AlignNext();
 	return Reallocate(pointer, old_size, AlignValue<idx_t>(size));
 }
 


### PR DESCRIPTION
This PR fixes a ubsan issue I encountered when constructing some gnarly sql to output function documentation into a large nested structure for further processing. Even though the list segment code tries it best to ensure any allocations it makes are aligned by rounding up, if the shared aggregate arena is used by other aggregate functions this alignment can get out of sync. 

This PR adds a `AlignNext()` helper function to the `ArenaAllocator` which moves the current position in the head chunk forwards until it is a multiple of 8 (if required), additionally I've also changed the `AllocateAligned` and `ReallocateAligned` to call this function before allocating anything to to ensure the next allocation actually will be aligned regardless of how the state of the allocator is left from previously performed allocations.
