### PR TITLE
Fix null pointer exception when rolling back updates if the rollback was caused by an OOM

### DIFF
--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -501,7 +501,9 @@ void UpdateSegment::RollbackUpdate(UpdateInfo &info) {
 	auto lock_handle = lock.GetExclusiveLock();
 
 	// move the data from the UpdateInfo back into the base info
-	D_ASSERT(root->info[info.vector_index]);
+	if (!root->info[info.vector_index]) {
+		return;
+	}
 	rollback_update_function(*root->info[info.vector_index]->info, info);
 
 	// clean up the update chain


### PR DESCRIPTION
If a large update triggers an allocation failure/OOM, it is possible that we write an entry into the transaction log for a specific update, but never actually create that entry. In that case a null pointer exception would be triggered during the rollback, which assumed that the version info for the vector would have been present. This PR modifies the assertion into an actual check, and simply skips the clean-up in this scenario.