### PR TITLE
Fix #11294 - avoid applying Filter Pushdown optimization for UNION/EXCEPT without ALL

### DIFF
--- a/src/optimizer/pushdown/pushdown_set_operation.cpp
+++ b/src/optimizer/pushdown/pushdown_set_operation.cpp
@@ -69,7 +69,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 		// both empty: return empty result
 		return make_uniq<LogicalEmptyResult>(std::move(op));
 	}
-	if (left_empty) {
+	if (left_empty && setop.setop_all) {
 		// left child is empty result
 		switch (op->type) {
 		case LogicalOperatorType::LOGICAL_UNION:
@@ -88,7 +88,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<Logi
 		default:
 			throw InternalException("Unsupported set operation");
 		}
-	} else if (right_empty) {
+	} else if (right_empty && setop.setop_all) {
 		// right child is empty result
 		switch (op->type) {
 		case LogicalOperatorType::LOGICAL_UNION:

--- a/test/optimizer/pushdown_set_op.test
+++ b/test/optimizer/pushdown_set_op.test
@@ -30,7 +30,7 @@ logical_opt	<!REGEX>:.*EXCEPT.*
 
 # if RHS is empty we can optimize away the except
 query II
-explain select 42 except select 42 where 1=0;
+explain select 42 except all select 42 where 1=0;
 ----
 logical_opt	<!REGEX>:.*EXCEPT.*
 
@@ -41,12 +41,12 @@ explain select * from (select 42 intersect select 42) tbl(i) where i=42;
 logical_opt	<REGEX>:.*INTERSECT.*
 
 query II
-explain select * from (select 42 intersect select 43) tbl(i) where i=42;
+explain select * from (select 42 intersect all select 43) tbl(i) where i=42;
 ----
 logical_opt	<!REGEX>:.*INTERSECT.*
 
 query II
-explain select * from (select 43 intersect select 42) tbl(i) where i=42;
+explain select * from (select 43 intersect all select 42) tbl(i) where i=42;
 ----
 logical_opt	<!REGEX>:.*INTERSECT.*
 
@@ -56,12 +56,12 @@ explain select * from (select 42 except select 42) tbl(i) where i=42;
 logical_opt	<REGEX>:.*EXCEPT.*
 
 query II
-explain select * from (select 42 except select 43) tbl(i) where i=42;
+explain select * from (select 42 except all select 43) tbl(i) where i=42;
 ----
 logical_opt	<!REGEX>:.*EXCEPT.*
 
 query II
-explain select * from (select 43 except select 42) tbl(i) where i=42;
+explain select * from (select 43 except all select 42) tbl(i) where i=42;
 ----
 logical_opt	<!REGEX>:.*EXCEPT.*
 

--- a/test/sql/setops/test_union_except_empty.test
+++ b/test/sql/setops/test_union_except_empty.test
@@ -1,0 +1,28 @@
+# name: test/sql/setops/test_union_except_empty.test
+# description: Test order of UNION statements
+# group: [setops]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table t (i int);
+
+statement ok
+insert into t values (1),(2),(3),(4),(4);
+
+query I
+select i from t union select 1 where false order by 1;
+----
+1
+2
+3
+4
+
+query I
+select i from t except select 1 where false order by 1;
+----
+1
+2
+3
+4


### PR DESCRIPTION
Fixes #11294 
Fixes https://github.com/duckdb/duckdb/issues/11163

This was a regression introduced by an internal change in how `UNION/EXCEPT` without `ALL` were planned. Previously an explicit `LogicalDistinct` would be pushed into the plan, but after the change the `LogicalSetOperation` would instead store this information internally. The filter pushdown optimizer was not correctly adjusted for the new operator causing it to always assume the set operation was of the `UNION ALL`/`EXCEPT ALL` variant - which caused an incorrect plan to be constructed.