### PR TITLE
Fix #11293 - for ARRAY([subquery]) explicitly push the ORDER BY of the underlying subquery into the array aggregate

### DIFF
--- a/src/parser/transform/expression/transform_subquery.cpp
+++ b/src/parser/transform/expression/transform_subquery.cpp
@@ -69,6 +69,12 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(duckdb_libpgquery::P
 		vector<unique_ptr<ParsedExpression>> children;
 		children.push_back(std::move(columns_star));
 		auto aggr = make_uniq<FunctionExpression>("array_agg", std::move(children));
+		for (auto &modifier : subquery_expr->subquery->node->modifiers) {
+			if (modifier->type == ResultModifierType::ORDER_MODIFIER) {
+				aggr->order_bys = unique_ptr_cast<ResultModifier, OrderModifier>(modifier->Copy());
+				break;
+			}
+		}
 		// ARRAY_AGG(COLUMNS(*)) IS NULL
 		auto agg_is_null = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_IS_NULL, aggr->Copy());
 		// empty list

--- a/test/sql/subquery/scalar/array_order_subquery.test
+++ b/test/sql/subquery/scalar/array_order_subquery.test
@@ -1,0 +1,39 @@
+# name: test/sql/subquery/scalar/array_order_subquery.test
+# description: Issue #11293: Unstable ordering of array(subquery) function when using DISTINCT and ORDER BY in subquery
+# group: [scalar]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table t (i int);
+
+statement ok
+insert into t values (1),(2),(3),(4),(4);
+
+query III
+select
+  array(select distinct i from t order by i desc) as a,
+  array(select distinct i from t order by i desc) as b,
+  array(select distinct i from t order by i desc) as c;
+----
+[4, 3, 2, 1]	[4, 3, 2, 1]	[4, 3, 2, 1]
+
+
+# correlated
+query I
+select array(select unnest(l) AS i order by i desc nulls last) as a from (values ([NULL, 1, 2, 3, 4]), ([5, 6, NULL, 7, 8]), ([]), ([10, 11, 12])) t(l);
+----
+[4, 3, 2, 1, NULL]
+[8, 7, 6, 5, NULL]
+[]
+[12, 11, 10]
+
+query I
+select array(select unnest(l) AS i order by i desc nulls first) as a from (values ([NULL, 1, 2, 3, 4]), ([5, 6, NULL, 7, 8]), ([]), ([10, 11, 12])) t(l);
+----
+[NULL, 4, 3, 2, 1]
+[NULL, 8, 7, 6, 5]
+[]
+[12, 11, 10]
+


### PR DESCRIPTION
Fixes #11293