### PR TITLE
Issue #11279: TIMESTAMP => TIMESTAMPTZ

### DIFF
--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
+#include "duckdb/function/cast_rules.hpp"
 #include "duckdb/main/extension_util.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
@@ -183,7 +184,8 @@ struct ICUFromNaiveTimestamp : public ICUDateFunc {
 		auto &config = DBConfig::GetConfig(db);
 		auto &casts = config.GetCastFunctions();
 
-		casts.RegisterCastFunction(LogicalType::TIMESTAMP, LogicalType::TIMESTAMP_TZ, BindCastFromNaive);
+		const auto implicit_cost = CastRules::ImplicitCast(LogicalType::TIMESTAMP, LogicalType::TIMESTAMP_TZ);
+		casts.RegisterCastFunction(LogicalType::TIMESTAMP, LogicalType::TIMESTAMP_TZ, BindCastFromNaive, implicit_cost);
 		casts.RegisterCastFunction(LogicalType::TIMESTAMP_MS, LogicalType::TIMESTAMP_TZ, BindCastFromNaive);
 		casts.RegisterCastFunction(LogicalType::TIMESTAMP_NS, LogicalType::TIMESTAMP_TZ, BindCastFromNaive);
 		casts.RegisterCastFunction(LogicalType::TIMESTAMP_S, LogicalType::TIMESTAMP_TZ, BindCastFromNaive);

--- a/src/function/cast_rules.cpp
+++ b/src/function/cast_rules.cpp
@@ -24,6 +24,8 @@ static int64_t TargetTypeCost(const LogicalType &type) {
 		return 121;
 	case LogicalTypeId::TIMESTAMP_SEC:
 		return 122;
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return 123;
 	case LogicalTypeId::VARCHAR:
 		return 149;
 	case LogicalTypeId::STRUCT:
@@ -258,6 +260,8 @@ static int64_t ImplicitCastTimestampNS(const LogicalType &to) {
 static int64_t ImplicitCastTimestamp(const LogicalType &to) {
 	switch (to.id()) {
 	case LogicalTypeId::TIMESTAMP_NS:
+		return TargetTypeCost(to);
+	case LogicalTypeId::TIMESTAMP_TZ:
 		return TargetTypeCost(to);
 	default:
 		return -1;

--- a/test/sql/types/timestamp/timestamp_timezone_cast.test
+++ b/test/sql/types/timestamp/timestamp_timezone_cast.test
@@ -35,9 +35,24 @@ SELECT TIMESTAMP '2021-05-25 04:55:03.382494 EST';
 has a timestamp that is not UTC
 
 statement ok
+set Calendar='gregorian';
+
+statement ok
 SET TimeZone='UTC'
 
 query I
 SELECT TIMESTAMPTZ '2021-05-25 04:55:03.382494 EST';
 ----
 2021-05-25 09:55:03.382494+00
+
+statement ok
+set TimeZone='America/Phoenix';
+
+query I
+SELECT
+  DATE_DIFF(
+  	'HOUR',  
+  	TIMESTAMP '2010-07-07 10:20:00' AT TIME ZONE 'Asia/Bangkok', 
+  	TIMESTAMP '2010-07-07 10:20:00+00') AS hours;
+----
+14


### PR DESCRIPTION
Allow implicit casting of TS to TSTZ.
PG allows this, so we need to as well.

fixes: duckdb/duckdb#11279
fixes: duckdblabs/duckdb-internal#1647