### PR TITLE
Issue #11269: DISTINCT Sorted Aggregates

### DIFF
--- a/test/sql/aggregate/aggregates/test_aggregate_types.test
+++ b/test/sql/aggregate/aggregates/test_aggregate_types.test
@@ -53,7 +53,7 @@ world r
 
 # complex agg with distinct and order by and conversion from int to string
 query IIITTT
-SELECT g, COUNT(*), COUNT(s), MIN(s), MAX(s), STRING_AGG(DISTINCT g::VARCHAR ORDER BY g DESC) FROM strings GROUP BY g ORDER BY g;
+SELECT g, COUNT(*), COUNT(s), MIN(s), MAX(s), STRING_AGG(DISTINCT g::VARCHAR ORDER BY g::VARCHAR DESC) FROM strings GROUP BY g ORDER BY g;
 ----
 0
 2

--- a/test/sql/aggregate/aggregates/test_aggregate_types_scalar.test
+++ b/test/sql/aggregate/aggregates/test_aggregate_types_scalar.test
@@ -145,12 +145,12 @@ statement ok
 INSERT INTO test_val VALUES(1), (2), (3), (3), (2)
 
 query T
-SELECT STRING_AGG(DISTINCT val::VARCHAR ORDER BY val DESC) from test_val;
+SELECT STRING_AGG(DISTINCT val::VARCHAR ORDER BY val::VARCHAR DESC) from test_val;
 ----
 3,2,1
 
 query IT
-SELECT COUNT(NULL), STRING_AGG(DISTINCT val::VARCHAR ORDER BY val ASC) from test_val;
+SELECT COUNT(NULL), STRING_AGG(DISTINCT val::VARCHAR ORDER BY val::VARCHAR ASC) from test_val;
 ----
 0
 1,2,3

--- a/test/sql/aggregate/aggregates/test_order_by_aggregate.test
+++ b/test/sql/aggregate/aggregates/test_order_by_aggregate.test
@@ -61,3 +61,36 @@ SELECT grp, FIRST(i ORDER BY i DESC) FROM integers GROUP BY grp ORDER BY ALL
 1	30
 2	20
 
+statement ok
+CREATE TABLE user_causes (
+    user_id INT,
+    cause VARCHAR,
+    "date" DATE
+);
+
+statement ok
+INSERT INTO user_causes (user_id, cause, "date") VALUES
+(1, 'Environmental', '2024-03-18'),
+(1, 'Environmental', '2024-02-18'),
+(1, 'Health', '2024-01-18'),
+(1, 'Social', '2023-12-18'),
+(1, NULL, '2023-11-19');
+
+statement error
+SELECT 
+    user_id, 
+    list(DISTINCT cause ORDER BY "date" DESC) FILTER(cause IS NOT NULL) AS causes
+FROM user_causes 
+GROUP BY user_id;
+----
+Binder Error: In a DISTINCT aggregate, ORDER BY expressions must appear in the argument list
+
+query II
+SELECT 
+    user_id, 
+    list(DISTINCT cause ORDER BY cause DESC) FILTER(cause IS NOT NULL) AS causes
+FROM user_causes 
+GROUP BY user_id;
+----
+1	[Social, Health, Environmental]
+

--- a/test/sql/aggregate/aggregates/test_string_agg.test
+++ b/test/sql/aggregate/aggregates/test_string_agg.test
@@ -169,16 +169,13 @@ ORDER BY 1
 /	i,a
 
 # ORDER + FILTER + DISTINCT
-query II
+statement error
 SELECT g, STRING_AGG(DISTINCT y, ',' ORDER BY x DESC) FILTER (WHERE g < 4)
 FROM strings
 GROUP BY g
 ORDER BY 1
 ----
-1	-,/
-2	-,+,/
-3	/
-4	NULL
+Binder Error: In a DISTINCT aggregate, ORDER BY expressions must appear in the argument list
 
 # ORDER BY on a correlated column
 statement ok

--- a/test/sql/aggregate/distinct/grouped/string_agg.test
+++ b/test/sql/aggregate/distinct/grouped/string_agg.test
@@ -32,24 +32,24 @@ INSERT INTO strings VALUES
 
 # ORDER + FILTER + DISTINCT
 query II
-SELECT g, STRING_AGG(DISTINCT y, ',' ORDER BY x DESC) FILTER (WHERE g < 4)
+SELECT g, STRING_AGG(DISTINCT y, ',' ORDER BY y DESC) FILTER (WHERE g < 4)
 FROM strings
 GROUP BY g
 ORDER BY 1
 ----
-1	-,/
-2	-,+,/
+1	/,-
+2	/,-,+
 3	/
 4	NULL
 
 # ORDER + FILTER + DISTINCT
 query IIII
-SELECT g, count(y), STRING_AGG(DISTINCT y, ',' ORDER BY x DESC) FILTER (WHERE g < 4), sum(1)
+SELECT g, count(y), STRING_AGG(DISTINCT y, ',' ORDER BY y DESC) FILTER (WHERE g < 4), sum(1)
 FROM strings
 GROUP BY g
 ORDER BY 1
 ----
-1	2	-,/	2
-2	3	-,+,/	3
+1	2	/,-	2
+2	3	/,-,+	3
 3	1	/	1
 4	3	NULL	3

--- a/test/sql/function/list/list_sort.test
+++ b/test/sql/function/list/list_sort.test
@@ -451,15 +451,14 @@ order by id;
 1	[10, 15]
 2	[10]
 
-query II
+statement error
 select id, list(distinct foo order by bar) from (
   values (1, '10', 2), (1, '15', 1), (2, '10', 1)
 ) v (id, foo, bar)
 group by all
 order by id;
 ----
-1	[15, 10]
-2	[10]
+Binder Error: In a DISTINCT aggregate, ORDER BY expressions must appear in the argument list
 
 # bug fixes test for #5694
 


### PR DESCRIPTION
These should only be a allowed when the ordering expressions are in the argument list. Anything else is confusing and ambiguous. This is what PG does too.

fixes: duckdb/duckdb#11269
fixes: duckdblabs/duckdb-internal#1639