### PR TITLE
Windows CLI - emit UTF8 directly using SetConsoleOutputCP(CP_UTF8) if possible

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -467,10 +467,17 @@ void utf8_printf(FILE *out, const char *zFormat, ...){
   va_start(ap, zFormat);
   if( stdout_is_console && (out==stdout || out==stderr) ){
     char *z1 = sqlite3_vmprintf(zFormat, ap);
-    char *z2 = sqlite3_win32_utf8_to_mbcs_v2(z1, 0);
+	if (SetConsoleOutputCP(CP_UTF8)) {
+		// we can write UTF8 directly
+        fputs(z1, out);
+	} else {
+        // failed to set code page
+        // fallback to writing old style windows unicode
+        char *z2 = sqlite3_win32_utf8_to_mbcs_v2(z1, 0);
+        fputs(z2, out);
+        sqlite3_free(z2);
+	}
     sqlite3_free(z1);
-    fputs(z2, out);
-    sqlite3_free(z2);
   }else{
     vfprintf(out, zFormat, ap);
   }


### PR DESCRIPTION
Fixes #11246