### PR TITLE
fix(arrow): union buffer count & handle schema errors

### DIFF
--- a/src/common/arrow/appender/union_data.cpp
+++ b/src/common/arrow/appender/union_data.cpp
@@ -55,8 +55,8 @@ void ArrowUnionData::Append(ArrowAppendData &append_data, Vector &input, idx_t f
 }
 
 void ArrowUnionData::Finalize(ArrowAppendData &append_data, const LogicalType &type, ArrowArray *result) {
-	result->n_buffers = 2;
-	result->buffers[1] = append_data.main_buffer.data();
+	result->n_buffers = 1;
+	result->buffers[0] = append_data.main_buffer.data();
 
 	auto &child_types = UnionType::CopyMemberTypes(type);
 	ArrowAppender::AddChildren(append_data, child_types.size());

--- a/src/main/capi/arrow-c.cpp
+++ b/src/main/capi/arrow-c.cpp
@@ -27,8 +27,12 @@ duckdb_state duckdb_query_arrow_schema(duckdb_arrow result, duckdb_arrow_schema 
 		return DuckDBSuccess;
 	}
 	auto wrapper = reinterpret_cast<ArrowResultWrapper *>(result);
-	ArrowConverter::ToArrowSchema((ArrowSchema *)*out_schema, wrapper->result->types, wrapper->result->names,
-	                              wrapper->result->client_properties);
+	try {
+		ArrowConverter::ToArrowSchema((ArrowSchema *)*out_schema, wrapper->result->types, wrapper->result->names,
+		                              wrapper->result->client_properties);
+	} catch (...) {
+		return DuckDBError;
+	}
 	return DuckDBSuccess;
 }
 

--- a/test/api/capi/test_capi_arrow.cpp
+++ b/test/api/capi/test_capi_arrow.cpp
@@ -159,6 +159,20 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 		duckdb_destroy_prepare(&stmt);
 	}
 
+	SECTION("test unsupported type") {
+		auto state = duckdb_query_arrow(tester.connection, "SELECT 0::UHUGEINT", &arrow_result);
+		REQUIRE(state == DuckDBSuccess);
+
+		ArrowSchema arrow_schema;
+		arrow_schema.Init();
+		auto arrow_schema_ptr = &arrow_schema;
+
+		state = duckdb_query_arrow_schema(arrow_result, reinterpret_cast<duckdb_arrow_schema *>(&arrow_schema_ptr));
+		REQUIRE(state == DuckDBError);
+
+		duckdb_destroy_arrow(&arrow_result);
+	}
+
 	SECTION("test scan") {
 
 		const auto logical_types = duckdb::vector<LogicalType> {LogicalType(LogicalTypeId::INTEGER)};


### PR DESCRIPTION
Fixes two small issues I found while adding nested type support to duckdb-rs