### PR TITLE
[CI] Fix bash syntax in TwineUpload

### DIFF
--- a/.github/workflows/TwineUpload.yml
+++ b/.github/workflows/TwineUpload.yml
@@ -39,8 +39,7 @@ jobs:
         run: |
           TARGET=$(git describe --tags --long)
           # decide target for staging
-          if [ -z "$OVERRIDE_GIT_DESCRIBE" ]; then
-          else
+          if [ "$OVERRIDE_GIT_DESCRIBE" ]; then
             TARGET="$TARGET/$OVERRIDE_GIT_DESCRIBE"
           fi
           cd tools/pythonpkg


### PR DESCRIPTION
Follow up of https://github.com/duckdb/duckdb/pull/11308