### PR TITLE
Fix building issues in WIN32, remove unnecessary modification.

### DIFF
--- a/src/function/scalar/compressed_materialization/compress_string.cpp
+++ b/src/function/scalar/compressed_materialization/compress_string.cpp
@@ -11,14 +11,23 @@ static string StringCompressFunctionName(const LogicalType &result_type) {
 }
 
 template <idx_t LENGTH>
+#ifdef _WIN32
+static inline void TemplatedReverseMemCpy(const data_ptr_t &__restrict dest, const const_data_ptr_t &__restrict src) {
+#else
 static inline void TemplatedReverseMemCpy(const data_ptr_t __restrict &dest, const const_data_ptr_t __restrict &src) {
+#endif
 	for (idx_t i = 0; i < LENGTH; i++) {
 		dest[i] = src[LENGTH - 1 - i];
 	}
 }
 
+#ifdef _WIN32
+static inline void ReverseMemCpy(const data_ptr_t &__restrict dest, const const_data_ptr_t &__restrict src,
+                                 const idx_t &length) {
+#else
 static inline void ReverseMemCpy(const data_ptr_t __restrict &dest, const const_data_ptr_t __restrict &src,
                                  const idx_t &length) {
+#endif
 	for (idx_t i = 0; i < length; i++) {
 		dest[i] = src[length - 1 - i];
 	}

--- a/src/function/scalar/compressed_materialization/compress_string.cpp
+++ b/src/function/scalar/compressed_materialization/compress_string.cpp
@@ -11,23 +11,14 @@ static string StringCompressFunctionName(const LogicalType &result_type) {
 }
 
 template <idx_t LENGTH>
-#ifdef _WIN32
 static inline void TemplatedReverseMemCpy(const data_ptr_t &__restrict dest, const const_data_ptr_t &__restrict src) {
-#else
-static inline void TemplatedReverseMemCpy(const data_ptr_t __restrict &dest, const const_data_ptr_t __restrict &src) {
-#endif
 	for (idx_t i = 0; i < LENGTH; i++) {
 		dest[i] = src[LENGTH - 1 - i];
 	}
 }
 
-#ifdef _WIN32
 static inline void ReverseMemCpy(const data_ptr_t &__restrict dest, const const_data_ptr_t &__restrict src,
                                  const idx_t &length) {
-#else
-static inline void ReverseMemCpy(const data_ptr_t __restrict &dest, const const_data_ptr_t __restrict &src,
-                                 const idx_t &length) {
-#endif
 	for (idx_t i = 0; i < length; i++) {
 		dest[i] = src[length - 1 - i];
 	}

--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -6,6 +6,10 @@
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 
+#ifdef _WIN32
+#include <cctype>
+#endif
+
 namespace duckdb {
 
 idx_t StrfTimepecifierSize(StrTimeSpecifier specifier) {

--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -5,10 +5,7 @@
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
-
-#ifdef _WIN32
 #include <cctype>
-#endif
 
 namespace duckdb {
 

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -15,6 +15,10 @@
 
 #include <cstring>
 
+#ifdef _WIN32
+#include <algorithm>
+#endif
+
 namespace duckdb {
 
 struct string_t {

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -14,10 +14,7 @@
 #include "duckdb/common/numeric_utils.hpp"
 
 #include <cstring>
-
-#ifdef _WIN32
 #include <algorithm>
-#endif
 
 namespace duckdb {
 


### PR DESCRIPTION
Got some issues below when building on WIN10 with Microsoft Visual C++ 2017:

### common/types/string_type.hpp:
error C2039: "min": is not a member of "std"

### function/scalar/strftime_format.cpp
error C2039: "tolower": is not a member of "std"

### function/scalar/compressed_materialization/compress_string.cpp 
error C2219 syntax error : type qualifier must be after '*'
line 15 and line 21

Have removed the unnecessary modification from the prev one, see:
https://github.com/duckdb/duckdb/pull/11323

BTW, duckdb is awesome, thanks you all for sharing such great project.