### PR TITLE
Enable clang-tidy on headers and fix all headers to conform to our clang-tidy rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
-Checks:          '-*,clang-diagnostic-*,bugprone-*,performance-*,google-explicit-constructor,google-build-using-namespace,google-runtime-int,misc-definitions-in-headers,modernize-use-nullptr,modernize-use-override,-bugprone-macro-parentheses,readability-braces-around-statements,-bugprone-branch-clone,readability-identifier-naming,hicpp-exception-baseclass,misc-throw-by-value-catch-by-reference,-bugprone-signed-char-misuse,-bugprone-misplaced-widening-cast,-bugprone-sizeof-expression,-bugprone-narrowing-conversions,-bugprone-easily-swappable-parameters,google-global-names-in-headers,llvm-header-guard,misc-definitions-in-headers,modernize-use-emplace,modernize-use-bool-literals,-performance-inefficient-string-concatenation,-performance-no-int-to-ptr,readability-container-size-empty,cppcoreguidelines-pro-type-cstyle-cast'
+Checks:          '-*,clang-diagnostic-*,bugprone-*,performance-*,google-explicit-constructor,google-build-using-namespace,google-runtime-int,misc-definitions-in-headers,modernize-use-nullptr,modernize-use-override,-bugprone-macro-parentheses,readability-braces-around-statements,-bugprone-branch-clone,readability-identifier-naming,hicpp-exception-baseclass,misc-throw-by-value-catch-by-reference,-bugprone-signed-char-misuse,-bugprone-misplaced-widening-cast,-bugprone-sizeof-expression,-bugprone-narrowing-conversions,-bugprone-easily-swappable-parameters,google-global-names-in-headers,llvm-header-guard,misc-definitions-in-headers,modernize-use-emplace,modernize-use-bool-literals,-performance-inefficient-string-concatenation,-performance-no-int-to-ptr,readability-container-size-empty,cppcoreguidelines-pro-type-cstyle-cast,-llvm-header-guard,-performance-enum-size'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*^(re2.h)'
-AnalyzeTemporaryDtors: false
+HeaderFilterRegex: 'src/include/duckdb/.*'
 FormatStyle:     none
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,7 +37,7 @@ CheckOptions:
   - key:             readability-identifier-naming.EnumConstantCase
     value:           UPPER_CASE
   - key:             readability-identifier-naming.ConstexprVariableCase
-    value:           UPPER_CASE
+    value:           aNy_CasE
   - key:             readability-identifier-naming.StaticConstantCase
     value:           UPPER_CASE
   - key:             readability-identifier-naming.TemplateTemplateParameterCase

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -12,6 +12,7 @@ on:
       - '.github/patches/duckdb-wasm/**'
       - '.github/workflows/**'
       - '!.github/workflows/lcov_exclude'
+      - '!.github/workflows/CodeQuality.yml'
 
   pull_request:
     types: [opened, reopened, ready_for_review]
@@ -20,6 +21,7 @@ on:
       - '.github/patches/duckdb-wasm/**'
       - '.github/workflows/**'
       - '!.github/workflows/lcov_exclude'
+      - '!.github/workflows/CodeQuality.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -92,7 +92,7 @@ jobs:
 
   tidy-check:
     name: Tidy Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: format-check
 
     env:

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -65,6 +65,7 @@ jobs:
 
   enum-check:
     name: C Enum Integrity Check
+    needs: format-check
     runs-on: ubuntu-20.04
 
     env:

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -24,7 +24,7 @@ public:
 	}
 };
 
-enum class ParquetMetadataOperatorType { META_DATA, SCHEMA, KEY_VALUE_META_DATA, FILE_META_DATA };
+enum class ParquetMetadataOperatorType : uint8_t { META_DATA, SCHEMA, KEY_VALUE_META_DATA, FILE_META_DATA };
 
 struct ParquetMetaDataOperatorData : public GlobalTableFunctionState {
 	explicit ParquetMetaDataOperatorData(ClientContext &context, const vector<LogicalType> &types)

--- a/extension/parquet/zstd_file_system.cpp
+++ b/extension/parquet/zstd_file_system.cpp
@@ -27,7 +27,7 @@ ZstdStreamWrapper::~ZstdStreamWrapper() {
 	}
 	try {
 		Close();
-	} catch (...) {
+	} catch (...) { // NOLINT: swallow exceptions in destructor
 	}
 }
 

--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -446,7 +446,7 @@ void BoxRenderer::RenderHeader(const vector<string> &names, const vector<Logical
 		}
 	}
 	ss << config.RTCORNER;
-	ss << std::endl;
+	ss << '\n';
 
 	// render the header names
 	for (idx_t c = 0; c < column_count; c++) {
@@ -460,7 +460,7 @@ void BoxRenderer::RenderHeader(const vector<string> &names, const vector<Logical
 		RenderValue(ss, name, widths[c]);
 	}
 	ss << config.VERTICAL;
-	ss << std::endl;
+	ss << '\n';
 
 	// render the types
 	if (config.render_mode == RenderMode::ROWS) {
@@ -470,7 +470,7 @@ void BoxRenderer::RenderHeader(const vector<string> &names, const vector<Logical
 			RenderValue(ss, type, widths[c]);
 		}
 		ss << config.VERTICAL;
-		ss << std::endl;
+		ss << '\n';
 	}
 
 	// render the line under the header
@@ -485,7 +485,7 @@ void BoxRenderer::RenderHeader(const vector<string> &names, const vector<Logical
 		}
 	}
 	ss << config.RMIDDLE;
-	ss << std::endl;
+	ss << '\n';
 }
 
 void BoxRenderer::RenderValues(const list<ColumnDataCollection> &collections, const vector<idx_t> &column_map,
@@ -534,7 +534,7 @@ void BoxRenderer::RenderValues(const list<ColumnDataCollection> &collections, co
 			RenderValue(ss, str, widths[c], alignment);
 		}
 		ss << config.VERTICAL;
-		ss << std::endl;
+		ss << '\n';
 	}
 
 	if (bottom_rows > 0) {
@@ -590,7 +590,7 @@ void BoxRenderer::RenderValues(const list<ColumnDataCollection> &collections, co
 				RenderValue(ss, str, widths[c], alignment);
 			}
 			ss << config.VERTICAL;
-			ss << std::endl;
+			ss << '\n';
 		}
 		// note that the bottom rows are in reverse order
 		for (idx_t r = 0; r < bottom_rows; r++) {
@@ -605,7 +605,7 @@ void BoxRenderer::RenderValues(const list<ColumnDataCollection> &collections, co
 				RenderValue(ss, str, widths[c], alignments[c]);
 			}
 			ss << config.VERTICAL;
-			ss << std::endl;
+			ss << '\n';
 		}
 	}
 }
@@ -644,7 +644,7 @@ void BoxRenderer::RenderRowCount(string row_count_str, string shown_str, const s
 			}
 		}
 		ss << (render_anything ? config.RMIDDLE : config.RDCORNER);
-		ss << std::endl;
+		ss << '\n';
 	}
 	if (!render_anything) {
 		return;
@@ -658,16 +658,16 @@ void BoxRenderer::RenderRowCount(string row_count_str, string shown_str, const s
 		ss << column_count_str;
 		ss << " ";
 		ss << config.VERTICAL;
-		ss << std::endl;
+		ss << '\n';
 	} else if (render_rows) {
 		RenderValue(ss, row_count_str, total_length - 4);
 		ss << config.VERTICAL;
-		ss << std::endl;
+		ss << '\n';
 
 		if (display_shown_separately) {
 			RenderValue(ss, shown_str, total_length - 4);
 			ss << config.VERTICAL;
-			ss << std::endl;
+			ss << '\n';
 		}
 	}
 	// render the bottom line
@@ -676,7 +676,7 @@ void BoxRenderer::RenderRowCount(string row_count_str, string shown_str, const s
 		ss << config.HORIZONTAL;
 	}
 	ss << config.RDCORNER;
-	ss << std::endl;
+	ss << '\n';
 }
 
 void BoxRenderer::Render(ClientContext &context, const vector<string> &names, const ColumnDataCollection &result,

--- a/src/common/crypto/md5.cpp
+++ b/src/common/crypto/md5.cpp
@@ -156,7 +156,8 @@ void MD5Context::MD5Update(const_data_ptr_t input, idx_t len) {
 	/* Update bitcount */
 
 	t = bits[0];
-	if ((bits[0] = t + ((uint32_t)len << 3)) < t) {
+	bits[0] = t + ((uint32_t)len << 3);
+	if (bits[0] < t) {
 		bits[1]++; /* Carry from low to high */
 	}
 	bits[1] += len >> 29;

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -53,6 +53,7 @@
 #include "duckdb/common/enums/vector_type.hpp"
 #include "duckdb/common/enums/wal_type.hpp"
 #include "duckdb/common/enums/window_aggregation_mode.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/exception_format_value.hpp"
 #include "duckdb/common/extra_type_info.hpp"
 #include "duckdb/common/file_buffer.hpp"
@@ -81,11 +82,14 @@
 #include "duckdb/function/scalar/compressed_materialization_functions.hpp"
 #include "duckdb/function/scalar/strftime_format.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
+#include "duckdb/function/table_function.hpp"
 #include "duckdb/main/appender.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
+#include "duckdb/main/client_properties.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/error_manager.hpp"
 #include "duckdb/main/extension_helper.hpp"
+#include "duckdb/main/external_dependencies.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/settings.hpp"
@@ -540,6 +544,29 @@ ArrowDateTimeType EnumUtil::FromString<ArrowDateTimeType>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "MONTH_DAY_NANO")) {
 		return ArrowDateTimeType::MONTH_DAY_NANO;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<ArrowOffsetSize>(ArrowOffsetSize value) {
+	switch(value) {
+	case ArrowOffsetSize::REGULAR:
+		return "REGULAR";
+	case ArrowOffsetSize::LARGE:
+		return "LARGE";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+ArrowOffsetSize EnumUtil::FromString<ArrowOffsetSize>(const char *value) {
+	if (StringUtil::Equals(value, "REGULAR")) {
+		return ArrowOffsetSize::REGULAR;
+	}
+	if (StringUtil::Equals(value, "LARGE")) {
+		return ArrowOffsetSize::LARGE;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }
@@ -1631,6 +1658,229 @@ ExceptionFormatValueType EnumUtil::FromString<ExceptionFormatValueType>(const ch
 }
 
 template<>
+const char* EnumUtil::ToChars<ExceptionType>(ExceptionType value) {
+	switch(value) {
+	case ExceptionType::INVALID:
+		return "INVALID";
+	case ExceptionType::OUT_OF_RANGE:
+		return "OUT_OF_RANGE";
+	case ExceptionType::CONVERSION:
+		return "CONVERSION";
+	case ExceptionType::UNKNOWN_TYPE:
+		return "UNKNOWN_TYPE";
+	case ExceptionType::DECIMAL:
+		return "DECIMAL";
+	case ExceptionType::MISMATCH_TYPE:
+		return "MISMATCH_TYPE";
+	case ExceptionType::DIVIDE_BY_ZERO:
+		return "DIVIDE_BY_ZERO";
+	case ExceptionType::OBJECT_SIZE:
+		return "OBJECT_SIZE";
+	case ExceptionType::INVALID_TYPE:
+		return "INVALID_TYPE";
+	case ExceptionType::SERIALIZATION:
+		return "SERIALIZATION";
+	case ExceptionType::TRANSACTION:
+		return "TRANSACTION";
+	case ExceptionType::NOT_IMPLEMENTED:
+		return "NOT_IMPLEMENTED";
+	case ExceptionType::EXPRESSION:
+		return "EXPRESSION";
+	case ExceptionType::CATALOG:
+		return "CATALOG";
+	case ExceptionType::PARSER:
+		return "PARSER";
+	case ExceptionType::PLANNER:
+		return "PLANNER";
+	case ExceptionType::SCHEDULER:
+		return "SCHEDULER";
+	case ExceptionType::EXECUTOR:
+		return "EXECUTOR";
+	case ExceptionType::CONSTRAINT:
+		return "CONSTRAINT";
+	case ExceptionType::INDEX:
+		return "INDEX";
+	case ExceptionType::STAT:
+		return "STAT";
+	case ExceptionType::CONNECTION:
+		return "CONNECTION";
+	case ExceptionType::SYNTAX:
+		return "SYNTAX";
+	case ExceptionType::SETTINGS:
+		return "SETTINGS";
+	case ExceptionType::BINDER:
+		return "BINDER";
+	case ExceptionType::NETWORK:
+		return "NETWORK";
+	case ExceptionType::OPTIMIZER:
+		return "OPTIMIZER";
+	case ExceptionType::NULL_POINTER:
+		return "NULL_POINTER";
+	case ExceptionType::IO:
+		return "IO";
+	case ExceptionType::INTERRUPT:
+		return "INTERRUPT";
+	case ExceptionType::FATAL:
+		return "FATAL";
+	case ExceptionType::INTERNAL:
+		return "INTERNAL";
+	case ExceptionType::INVALID_INPUT:
+		return "INVALID_INPUT";
+	case ExceptionType::OUT_OF_MEMORY:
+		return "OUT_OF_MEMORY";
+	case ExceptionType::PERMISSION:
+		return "PERMISSION";
+	case ExceptionType::PARAMETER_NOT_RESOLVED:
+		return "PARAMETER_NOT_RESOLVED";
+	case ExceptionType::PARAMETER_NOT_ALLOWED:
+		return "PARAMETER_NOT_ALLOWED";
+	case ExceptionType::DEPENDENCY:
+		return "DEPENDENCY";
+	case ExceptionType::HTTP:
+		return "HTTP";
+	case ExceptionType::MISSING_EXTENSION:
+		return "MISSING_EXTENSION";
+	case ExceptionType::AUTOLOAD:
+		return "AUTOLOAD";
+	case ExceptionType::SEQUENCE:
+		return "SEQUENCE";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+ExceptionType EnumUtil::FromString<ExceptionType>(const char *value) {
+	if (StringUtil::Equals(value, "INVALID")) {
+		return ExceptionType::INVALID;
+	}
+	if (StringUtil::Equals(value, "OUT_OF_RANGE")) {
+		return ExceptionType::OUT_OF_RANGE;
+	}
+	if (StringUtil::Equals(value, "CONVERSION")) {
+		return ExceptionType::CONVERSION;
+	}
+	if (StringUtil::Equals(value, "UNKNOWN_TYPE")) {
+		return ExceptionType::UNKNOWN_TYPE;
+	}
+	if (StringUtil::Equals(value, "DECIMAL")) {
+		return ExceptionType::DECIMAL;
+	}
+	if (StringUtil::Equals(value, "MISMATCH_TYPE")) {
+		return ExceptionType::MISMATCH_TYPE;
+	}
+	if (StringUtil::Equals(value, "DIVIDE_BY_ZERO")) {
+		return ExceptionType::DIVIDE_BY_ZERO;
+	}
+	if (StringUtil::Equals(value, "OBJECT_SIZE")) {
+		return ExceptionType::OBJECT_SIZE;
+	}
+	if (StringUtil::Equals(value, "INVALID_TYPE")) {
+		return ExceptionType::INVALID_TYPE;
+	}
+	if (StringUtil::Equals(value, "SERIALIZATION")) {
+		return ExceptionType::SERIALIZATION;
+	}
+	if (StringUtil::Equals(value, "TRANSACTION")) {
+		return ExceptionType::TRANSACTION;
+	}
+	if (StringUtil::Equals(value, "NOT_IMPLEMENTED")) {
+		return ExceptionType::NOT_IMPLEMENTED;
+	}
+	if (StringUtil::Equals(value, "EXPRESSION")) {
+		return ExceptionType::EXPRESSION;
+	}
+	if (StringUtil::Equals(value, "CATALOG")) {
+		return ExceptionType::CATALOG;
+	}
+	if (StringUtil::Equals(value, "PARSER")) {
+		return ExceptionType::PARSER;
+	}
+	if (StringUtil::Equals(value, "PLANNER")) {
+		return ExceptionType::PLANNER;
+	}
+	if (StringUtil::Equals(value, "SCHEDULER")) {
+		return ExceptionType::SCHEDULER;
+	}
+	if (StringUtil::Equals(value, "EXECUTOR")) {
+		return ExceptionType::EXECUTOR;
+	}
+	if (StringUtil::Equals(value, "CONSTRAINT")) {
+		return ExceptionType::CONSTRAINT;
+	}
+	if (StringUtil::Equals(value, "INDEX")) {
+		return ExceptionType::INDEX;
+	}
+	if (StringUtil::Equals(value, "STAT")) {
+		return ExceptionType::STAT;
+	}
+	if (StringUtil::Equals(value, "CONNECTION")) {
+		return ExceptionType::CONNECTION;
+	}
+	if (StringUtil::Equals(value, "SYNTAX")) {
+		return ExceptionType::SYNTAX;
+	}
+	if (StringUtil::Equals(value, "SETTINGS")) {
+		return ExceptionType::SETTINGS;
+	}
+	if (StringUtil::Equals(value, "BINDER")) {
+		return ExceptionType::BINDER;
+	}
+	if (StringUtil::Equals(value, "NETWORK")) {
+		return ExceptionType::NETWORK;
+	}
+	if (StringUtil::Equals(value, "OPTIMIZER")) {
+		return ExceptionType::OPTIMIZER;
+	}
+	if (StringUtil::Equals(value, "NULL_POINTER")) {
+		return ExceptionType::NULL_POINTER;
+	}
+	if (StringUtil::Equals(value, "IO")) {
+		return ExceptionType::IO;
+	}
+	if (StringUtil::Equals(value, "INTERRUPT")) {
+		return ExceptionType::INTERRUPT;
+	}
+	if (StringUtil::Equals(value, "FATAL")) {
+		return ExceptionType::FATAL;
+	}
+	if (StringUtil::Equals(value, "INTERNAL")) {
+		return ExceptionType::INTERNAL;
+	}
+	if (StringUtil::Equals(value, "INVALID_INPUT")) {
+		return ExceptionType::INVALID_INPUT;
+	}
+	if (StringUtil::Equals(value, "OUT_OF_MEMORY")) {
+		return ExceptionType::OUT_OF_MEMORY;
+	}
+	if (StringUtil::Equals(value, "PERMISSION")) {
+		return ExceptionType::PERMISSION;
+	}
+	if (StringUtil::Equals(value, "PARAMETER_NOT_RESOLVED")) {
+		return ExceptionType::PARAMETER_NOT_RESOLVED;
+	}
+	if (StringUtil::Equals(value, "PARAMETER_NOT_ALLOWED")) {
+		return ExceptionType::PARAMETER_NOT_ALLOWED;
+	}
+	if (StringUtil::Equals(value, "DEPENDENCY")) {
+		return ExceptionType::DEPENDENCY;
+	}
+	if (StringUtil::Equals(value, "HTTP")) {
+		return ExceptionType::HTTP;
+	}
+	if (StringUtil::Equals(value, "MISSING_EXTENSION")) {
+		return ExceptionType::MISSING_EXTENSION;
+	}
+	if (StringUtil::Equals(value, "AUTOLOAD")) {
+		return ExceptionType::AUTOLOAD;
+	}
+	if (StringUtil::Equals(value, "SEQUENCE")) {
+		return ExceptionType::SEQUENCE;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
 const char* EnumUtil::ToChars<ExplainOutputType>(ExplainOutputType value) {
 	switch(value) {
 	case ExplainOutputType::ALL:
@@ -2266,6 +2516,24 @@ ExtensionLoadResult EnumUtil::FromString<ExtensionLoadResult>(const char *value)
 	}
 	if (StringUtil::Equals(value, "NOT_LOADED")) {
 		return ExtensionLoadResult::NOT_LOADED;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<ExternalDependenciesType>(ExternalDependenciesType value) {
+	switch(value) {
+	case ExternalDependenciesType::PYTHON_DEPENDENCY:
+		return "PYTHON_DEPENDENCY";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+ExternalDependenciesType EnumUtil::FromString<ExternalDependenciesType>(const char *value) {
+	if (StringUtil::Equals(value, "PYTHON_DEPENDENCY")) {
+		return ExternalDependenciesType::PYTHON_DEPENDENCY;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }
@@ -5297,6 +5565,29 @@ SampleMethod EnumUtil::FromString<SampleMethod>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "Reservoir")) {
 		return SampleMethod::RESERVOIR_SAMPLE;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<ScanType>(ScanType value) {
+	switch(value) {
+	case ScanType::TABLE:
+		return "TABLE";
+	case ScanType::PARQUET:
+		return "PARQUET";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+ScanType EnumUtil::FromString<ScanType>(const char *value) {
+	if (StringUtil::Equals(value, "TABLE")) {
+		return ScanType::TABLE;
+	}
+	if (StringUtil::Equals(value, "PARQUET")) {
+		return ScanType::PARQUET;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/common/filename_pattern.cpp
+++ b/src/common/filename_pattern.cpp
@@ -7,34 +7,34 @@ void FilenamePattern::SetFilenamePattern(const string &pattern) {
 	const string id_format {"{i}"};
 	const string uuid_format {"{uuid}"};
 
-	_base = pattern;
+	base = pattern;
 
-	_pos = _base.find(id_format);
-	if (_pos != string::npos) {
-		_base = StringUtil::Replace(_base, id_format, "");
-		_uuid = false;
+	pos = base.find(id_format);
+	if (pos != string::npos) {
+		base = StringUtil::Replace(base, id_format, "");
+		uuid = false;
 	}
 
-	_pos = _base.find(uuid_format);
-	if (_pos != string::npos) {
-		_base = StringUtil::Replace(_base, uuid_format, "");
-		_uuid = true;
+	pos = base.find(uuid_format);
+	if (pos != string::npos) {
+		base = StringUtil::Replace(base, uuid_format, "");
+		uuid = true;
 	}
 
-	_pos = std::min(_pos, (idx_t)_base.length());
+	pos = std::min(pos, (idx_t)base.length());
 }
 
 string FilenamePattern::CreateFilename(FileSystem &fs, const string &path, const string &extension,
                                        idx_t offset) const {
-	string result(_base);
+	string result(base);
 	string replacement;
 
-	if (_uuid) {
+	if (uuid) {
 		replacement = UUID::ToString(UUID::GenerateRandomUUID());
 	} else {
 		replacement = std::to_string(offset);
 	}
-	result.insert(_pos, replacement);
+	result.insert(pos, replacement);
 	return fs.JoinPath(path, result + "." + extension);
 }
 

--- a/src/common/gzip_file_system.cpp
+++ b/src/common/gzip_file_system.cpp
@@ -92,7 +92,7 @@ MiniZStreamWrapper::~MiniZStreamWrapper() {
 	}
 	try {
 		MiniZStreamWrapper::Close();
-	} catch (...) {
+	} catch (...) { // NOLINT - cannot throw in exception
 	}
 }
 

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -23,7 +23,7 @@ idx_t BufferedFileWriter::GetTotalWritten() {
 }
 
 void BufferedFileWriter::WriteData(const_data_ptr_t buffer, idx_t write_size) {
-	if (write_size >= (2 * FILE_BUFFER_SIZE - offset)) {
+	if (write_size >= (2ULL * FILE_BUFFER_SIZE - offset)) {
 		idx_t to_copy = 0;
 		// Check before performing direct IO if there is some data in the current internal buffer.
 		// If so, then fill the buffer (to avoid to small write operation), flush it and then write

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -173,7 +173,6 @@ string StringUtil::Join(const set<string> &input, const string &separator) {
 
 string StringUtil::BytesToHumanReadableString(idx_t bytes, idx_t multiplier) {
 	D_ASSERT(multiplier == 1000 || multiplier == 1024);
-	string db_size;
 	idx_t array[6] = {};
 	const char *unit[2][6] = {{"bytes", "KiB", "MiB", "GiB", "TiB", "PiB"}, {"bytes", "kB", "MB", "GB", "TB", "PB"}};
 

--- a/src/common/tree_renderer.cpp
+++ b/src/common/tree_renderer.cpp
@@ -42,12 +42,12 @@ void RenderTree::SetNode(idx_t x, idx_t y, unique_ptr<RenderTreeNode> node) {
 
 void TreeRenderer::RenderTopLayer(RenderTree &root, std::ostream &ss, idx_t y) {
 	for (idx_t x = 0; x < root.width; x++) {
-		if (x * config.NODE_RENDER_WIDTH >= config.MAXIMUM_RENDER_WIDTH) {
+		if (x * config.node_render_width >= config.maximum_render_width) {
 			break;
 		}
 		if (root.HasNode(x, y)) {
 			ss << config.LTCORNER;
-			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.node_render_width / 2 - 1);
 			if (y == 0) {
 				// top level node: no node above this one
 				ss << config.HORIZONTAL;
@@ -55,10 +55,10 @@ void TreeRenderer::RenderTopLayer(RenderTree &root, std::ostream &ss, idx_t y) {
 				// render connection to node above this one
 				ss << config.DMIDDLE;
 			}
-			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.node_render_width / 2 - 1);
 			ss << config.RTCORNER;
 		} else {
-			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+			ss << StringUtil::Repeat(" ", config.node_render_width);
 		}
 	}
 	ss << '\n';
@@ -66,12 +66,12 @@ void TreeRenderer::RenderTopLayer(RenderTree &root, std::ostream &ss, idx_t y) {
 
 void TreeRenderer::RenderBottomLayer(RenderTree &root, std::ostream &ss, idx_t y) {
 	for (idx_t x = 0; x <= root.width; x++) {
-		if (x * config.NODE_RENDER_WIDTH >= config.MAXIMUM_RENDER_WIDTH) {
+		if (x * config.node_render_width >= config.maximum_render_width) {
 			break;
 		}
 		if (root.HasNode(x, y)) {
 			ss << config.LDCORNER;
-			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.node_render_width / 2 - 1);
 			if (root.HasNode(x, y + 1)) {
 				// node below this one: connect to that one
 				ss << config.TMIDDLE;
@@ -79,14 +79,14 @@ void TreeRenderer::RenderBottomLayer(RenderTree &root, std::ostream &ss, idx_t y
 				// no node below this one: end the box
 				ss << config.HORIZONTAL;
 			}
-			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.node_render_width / 2 - 1);
 			ss << config.RDCORNER;
 		} else if (root.HasNode(x, y + 1)) {
-			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+			ss << StringUtil::Repeat(" ", config.node_render_width / 2);
 			ss << config.VERTICAL;
-			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+			ss << StringUtil::Repeat(" ", config.node_render_width / 2);
 		} else {
-			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+			ss << StringUtil::Repeat(" ", config.node_render_width);
 		}
 	}
 	ss << '\n';
@@ -145,12 +145,12 @@ void TreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_t y)
 			}
 		}
 	}
-	extra_height = MinValue<idx_t>(extra_height, config.MAX_EXTRA_LINES);
+	extra_height = MinValue<idx_t>(extra_height, config.max_extra_lines);
 	idx_t halfway_point = (extra_height + 1) / 2;
 	// now we render the actual node
 	for (idx_t render_y = 0; render_y <= extra_height; render_y++) {
 		for (idx_t x = 0; x < root.width; x++) {
-			if (x * config.NODE_RENDER_WIDTH >= config.MAXIMUM_RENDER_WIDTH) {
+			if (x * config.node_render_width >= config.maximum_render_width) {
 				break;
 			}
 			auto node = root.GetNode(x, y);
@@ -159,35 +159,35 @@ void TreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_t y)
 					bool has_child_to_the_right = NodeHasMultipleChildren(root, x, y);
 					if (root.HasNode(x, y + 1)) {
 						// node right below this one
-						ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2);
+						ss << StringUtil::Repeat(config.HORIZONTAL, config.node_render_width / 2);
 						ss << config.RTCORNER;
 						if (has_child_to_the_right) {
 							// but we have another child to the right! keep rendering the line
-							ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2);
+							ss << StringUtil::Repeat(config.HORIZONTAL, config.node_render_width / 2);
 						} else {
 							// only a child below this one: fill the rest with spaces
-							ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+							ss << StringUtil::Repeat(" ", config.node_render_width / 2);
 						}
 					} else if (has_child_to_the_right) {
 						// child to the right, but no child right below this one: render a full line
-						ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH);
+						ss << StringUtil::Repeat(config.HORIZONTAL, config.node_render_width);
 					} else {
 						// empty spot: render spaces
-						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+						ss << StringUtil::Repeat(" ", config.node_render_width);
 					}
 				} else if (render_y >= halfway_point) {
 					if (root.HasNode(x, y + 1)) {
 						// we have a node below this empty spot: render a vertical line
-						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+						ss << StringUtil::Repeat(" ", config.node_render_width / 2);
 						ss << config.VERTICAL;
-						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+						ss << StringUtil::Repeat(" ", config.node_render_width / 2);
 					} else {
 						// empty spot: render spaces
-						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+						ss << StringUtil::Repeat(" ", config.node_render_width);
 					}
 				} else {
 					// empty spot: render spaces
-					ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+					ss << StringUtil::Repeat(" ", config.node_render_width);
 				}
 			} else {
 				ss << config.VERTICAL;
@@ -200,7 +200,7 @@ void TreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_t y)
 						render_text = extra_info[x][render_y - 1];
 					}
 				}
-				render_text = AdjustTextForRendering(render_text, config.NODE_RENDER_WIDTH - 2);
+				render_text = AdjustTextForRendering(render_text, config.node_render_width - 2);
 				ss << render_text;
 
 				if (render_y == halfway_point && NodeHasMultipleChildren(root, x, y)) {
@@ -259,11 +259,11 @@ void TreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
 }
 
 void TreeRenderer::ToStream(RenderTree &root, std::ostream &ss) {
-	while (root.width * config.NODE_RENDER_WIDTH > config.MAXIMUM_RENDER_WIDTH) {
-		if (config.NODE_RENDER_WIDTH - 2 < config.MINIMUM_RENDER_WIDTH) {
+	while (root.width * config.node_render_width > config.maximum_render_width) {
+		if (config.node_render_width - 2 < config.minimum_render_width) {
 			break;
 		}
-		config.NODE_RENDER_WIDTH -= 2;
+		config.node_render_width -= 2;
 	}
 
 	for (idx_t y = 0; y < root.height; y++) {
@@ -297,7 +297,7 @@ string TreeRenderer::RemovePadding(string l) {
 
 void TreeRenderer::SplitStringBuffer(const string &source, vector<string> &result) {
 	D_ASSERT(Utf8Proc::IsValid(source.c_str(), source.size()));
-	idx_t max_line_render_size = config.NODE_RENDER_WIDTH - 2;
+	idx_t max_line_render_size = config.node_render_width - 2;
 	// utf8 in prompt, get render width
 	idx_t cpos = 0;
 	idx_t start_pos = 0;
@@ -352,7 +352,7 @@ void TreeRenderer::SplitUpExtraInfo(const string &extra_info, vector<string> &re
 }
 
 string TreeRenderer::ExtraInfoSeparator() {
-	return StringUtil::Repeat(string(config.HORIZONTAL) + " ", (config.NODE_RENDER_WIDTH - 7) / 2);
+	return StringUtil::Repeat(string(config.HORIZONTAL) + " ", (config.node_render_width - 7) / 2);
 }
 
 unique_ptr<RenderTreeNode> TreeRenderer::CreateRenderNode(string name, string extra_info) {

--- a/src/common/tree_renderer.cpp
+++ b/src/common/tree_renderer.cpp
@@ -61,7 +61,7 @@ void TreeRenderer::RenderTopLayer(RenderTree &root, std::ostream &ss, idx_t y) {
 			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
 		}
 	}
-	ss << std::endl;
+	ss << '\n';
 }
 
 void TreeRenderer::RenderBottomLayer(RenderTree &root, std::ostream &ss, idx_t y) {
@@ -89,7 +89,7 @@ void TreeRenderer::RenderBottomLayer(RenderTree &root, std::ostream &ss, idx_t y
 			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
 		}
 	}
-	ss << std::endl;
+	ss << '\n';
 }
 
 string AdjustTextForRendering(string source, idx_t max_render_width) {
@@ -210,7 +210,7 @@ void TreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_t y)
 				}
 			}
 		}
-		ss << std::endl;
+		ss << '\n';
 	}
 }
 
@@ -504,8 +504,8 @@ unique_ptr<RenderTree> TreeRenderer::CreateTree(const QueryProfiler::TreeNode &o
 	return CreateRenderTree<QueryProfiler::TreeNode>(op);
 }
 
-unique_ptr<RenderTree> TreeRenderer::CreateTree(const Pipeline &op) {
-	auto operators = op.GetOperators();
+unique_ptr<RenderTree> TreeRenderer::CreateTree(const Pipeline &pipeline) {
+	auto operators = pipeline.GetOperators();
 	D_ASSERT(!operators.empty());
 	unique_ptr<PipelineRenderNode> node;
 	for (auto &op : operators) {

--- a/src/common/types/hash.cpp
+++ b/src/common/types/hash.cpp
@@ -12,22 +12,22 @@ namespace duckdb {
 
 template <>
 hash_t Hash(uint64_t val) {
-	return murmurhash64(val);
+	return MurmurHash64(val);
 }
 
 template <>
 hash_t Hash(int64_t val) {
-	return murmurhash64((uint64_t)val);
+	return MurmurHash64((uint64_t)val);
 }
 
 template <>
 hash_t Hash(hugeint_t val) {
-	return murmurhash64(val.lower) ^ murmurhash64(val.upper);
+	return MurmurHash64(val.lower) ^ MurmurHash64(val.upper);
 }
 
 template <>
 hash_t Hash(uhugeint_t val) {
-	return murmurhash64(val.lower) ^ murmurhash64(val.upper);
+	return MurmurHash64(val.lower) ^ MurmurHash64(val.upper);
 }
 
 template <class T>
@@ -47,7 +47,7 @@ hash_t Hash(float val) {
 	static_assert(sizeof(float) == sizeof(uint32_t), "");
 	FloatingPointEqualityTransform<float>::OP(val);
 	uint32_t uval = Load<uint32_t>(const_data_ptr_cast(&val));
-	return murmurhash64(uval);
+	return MurmurHash64(uval);
 }
 
 template <>
@@ -55,7 +55,7 @@ hash_t Hash(double val) {
 	static_assert(sizeof(double) == sizeof(uint64_t), "");
 	FloatingPointEqualityTransform<double>::OP(val);
 	uint64_t uval = Load<uint64_t>(const_data_ptr_cast(&val));
-	return murmurhash64(uval);
+	return MurmurHash64(uval);
 }
 
 template <>

--- a/src/common/types/hyperloglog.cpp
+++ b/src/common/types/hyperloglog.cpp
@@ -171,6 +171,8 @@ inline uint64_t HashOtherSize(const_data_ptr_t &data, const idx_t &len) {
 		CreateIntegerRecursive<1>(data, x);
 		break;
 	case 0:
+	default:
+		D_ASSERT((len & 7) == 0);
 		break;
 	}
 	return TemplatedHash<uint64_t>(x);

--- a/src/common/types/uuid.cpp
+++ b/src/common/types/uuid.cpp
@@ -3,7 +3,7 @@
 
 namespace duckdb {
 
-bool UUID::FromString(string str, hugeint_t &result) {
+bool UUID::FromString(const string &str, hugeint_t &result) {
 	auto hex2char = [](char ch) -> unsigned char {
 		if (ch >= '0' && ch <= '9') {
 			return ch - '0';

--- a/src/core_functions/scalar/date/time_bucket.cpp
+++ b/src/core_functions/scalar/date/time_bucket.cpp
@@ -22,7 +22,7 @@ struct TimeBucket {
 	// There are 360 months between 1970-01-01 and 2000-01-01
 	constexpr static const int32_t DEFAULT_ORIGIN_MONTHS = 360;
 
-	enum struct BucketWidthType { CONVERTIBLE_TO_MICROS, CONVERTIBLE_TO_MONTHS, UNCLASSIFIED };
+	enum struct BucketWidthType : uint8_t { CONVERTIBLE_TO_MICROS, CONVERTIBLE_TO_MONTHS, UNCLASSIFIED };
 
 	static inline BucketWidthType ClassifyBucketWidth(const interval_t bucket_width) {
 		if (bucket_width.months == 0 && Interval::GetMicro(bucket_width) > 0) {

--- a/src/execution/operator/csv_scanner/scanner/scanner_boundary.cpp
+++ b/src/execution/operator/csv_scanner/scanner/scanner_boundary.cpp
@@ -31,19 +31,19 @@ CSVIterator::CSVIterator() : is_set(false) {
 
 void CSVBoundary::Print() {
 #ifndef DUCKDB_DISABLE_PRINT
-	std::cout << "---Boundary: " << boundary_idx << " ---" << std::endl;
-	std::cout << "File Index:: " << file_idx << std::endl;
-	std::cout << "Buffer Index: " << buffer_idx << std::endl;
-	std::cout << "Buffer Pos: " << buffer_pos << std::endl;
-	std::cout << "End Pos: " << end_pos << std::endl;
-	std::cout << "------------" << end_pos << std::endl;
+	std::cout << "---Boundary: " << boundary_idx << " ---" << '\n';
+	std::cout << "File Index:: " << file_idx << '\n';
+	std::cout << "Buffer Index: " << buffer_idx << '\n';
+	std::cout << "Buffer Pos: " << buffer_pos << '\n';
+	std::cout << "End Pos: " << end_pos << '\n';
+	std::cout << "------------" << end_pos << '\n';
 #endif
 }
 
 void CSVIterator::Print() {
 #ifndef DUCKDB_DISABLE_PRINT
 	boundary.Print();
-	std::cout << "Is set: " << is_set << std::endl;
+	std::cout << "Is set: " << is_set << '\n';
 #endif
 }
 

--- a/src/execution/operator/csv_scanner/util/csv_error.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_error.cpp
@@ -171,8 +171,7 @@ CSVError CSVError::IncorrectColumnAmountError(const CSVReaderOptions &options, s
                                               LinesPerBoundary error_info) {
 	std::ostringstream error;
 	// How many columns were expected and how many were found
-	error << "Expected Number of Columns: " << options.dialect_options.num_cols << " Found: " << actual_columns
-	      << '\n';
+	error << "Expected Number of Columns: " << options.dialect_options.num_cols << " Found: " << actual_columns << '\n';
 	error << '\n' << "Possible fixes:" << '\n';
 	if (!options.null_padding) {
 		error << "* Enable null padding (null_padding=true) to replace missing values with NULL" << '\n';

--- a/src/execution/operator/csv_scanner/util/csv_error.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_error.cpp
@@ -110,7 +110,7 @@ CSVError CSVError::CastError(const CSVReaderOptions &options, string &column_nam
 	// What was the cast error
 	error << cast_error << '\n';
 
-	error << "Column " << column_name << " is being converted as type " << LogicalTypeIdToString(type) << std::endl;
+	error << "Column " << column_name << " is being converted as type " << LogicalTypeIdToString(type) << '\n';
 	if (!options.WasTypeManuallySet(column_idx)) {
 		error << "This type was auto-detected from the CSV file." << '\n';
 		error << "Possible solutions:" << '\n';
@@ -142,7 +142,7 @@ CSVError CSVError::SniffingError(string &file_path) {
 	std::ostringstream error;
 	// Which column
 	error << "Error when sniffing file \"" << file_path << "\"." << '\n';
-	error << "CSV options could not be auto-detected. Consider setting parser options manually." << std::endl;
+	error << "CSV options could not be auto-detected. Consider setting parser options manually." << '\n';
 	return CSVError(error.str(), CSVErrorType::SNIFFING, {});
 }
 

--- a/src/execution/operator/csv_scanner/util/csv_error.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_error.cpp
@@ -16,7 +16,7 @@ CSVErrorHandler::CSVErrorHandler(bool ignore_errors_p) : ignore_errors(ignore_er
 void CSVErrorHandler::ThrowError(CSVError csv_error) {
 	std::ostringstream error;
 	if (PrintLineNumber(csv_error)) {
-		error << "CSV Error on Line: " << GetLine(csv_error.error_info) << std::endl;
+		error << "CSV Error on Line: " << GetLine(csv_error.error_info) << '\n';
 	}
 	error << csv_error.error_message;
 	switch (csv_error.type) {
@@ -106,24 +106,24 @@ CSVError CSVError::CastError(const CSVReaderOptions &options, string &column_nam
                              vector<Value> &row, LinesPerBoundary error_info, LogicalTypeId type) {
 	std::ostringstream error;
 	// Which column
-	error << "Error when converting column \"" << column_name << "\"." << std::endl;
+	error << "Error when converting column \"" << column_name << "\"." << '\n';
 	// What was the cast error
-	error << cast_error << std::endl;
+	error << cast_error << '\n';
 
 	error << "Column " << column_name << " is being converted as type " << LogicalTypeIdToString(type) << std::endl;
 	if (!options.WasTypeManuallySet(column_idx)) {
-		error << "This type was auto-detected from the CSV file." << std::endl;
-		error << "Possible solutions:" << std::endl;
+		error << "This type was auto-detected from the CSV file." << '\n';
+		error << "Possible solutions:" << '\n';
 		error << "* Override the type for this column manually by setting the type explicitly, e.g. types={'"
-		      << column_name << "': 'VARCHAR'}" << std::endl;
+		      << column_name << "': 'VARCHAR'}" << '\n';
 		error << "* Set the sample size to a larger value to enable the auto-detection to scan more values, e.g. "
 		         "sample_size=-1"
-		      << std::endl;
-		error << "* Use a COPY statement to automatically derive types from an existing table." << std::endl;
+		      << '\n';
+		error << "* Use a COPY statement to automatically derive types from an existing table." << '\n';
 	} else {
 		error << "This type was either manually set or derived from an existing table. Select a different type to "
 		         "correctly parse this column."
-		      << std::endl;
+		      << '\n';
 	}
 	error << options.ToString();
 
@@ -133,7 +133,7 @@ CSVError CSVError::CastError(const CSVReaderOptions &options, string &column_nam
 CSVError CSVError::LineSizeError(const CSVReaderOptions &options, idx_t actual_size, LinesPerBoundary error_info) {
 	std::ostringstream error;
 	error << "Maximum line size of " << options.maximum_line_size << " bytes exceeded. ";
-	error << "Actual Size:" << actual_size << " bytes." << std::endl;
+	error << "Actual Size:" << actual_size << " bytes." << '\n';
 	error << options.ToString();
 	return CSVError(error.str(), CSVErrorType::MAXIMUM_LINE_SIZE, error_info);
 }
@@ -141,7 +141,7 @@ CSVError CSVError::LineSizeError(const CSVReaderOptions &options, idx_t actual_s
 CSVError CSVError::SniffingError(string &file_path) {
 	std::ostringstream error;
 	// Which column
-	error << "Error when sniffing file \"" << file_path << "\"." << std::endl;
+	error << "Error when sniffing file \"" << file_path << "\"." << '\n';
 	error << "CSV options could not be auto-detected. Consider setting parser options manually." << std::endl;
 	return CSVError(error.str(), CSVErrorType::SNIFFING, {});
 }
@@ -150,7 +150,7 @@ CSVError CSVError::NullPaddingFail(const CSVReaderOptions &options, LinesPerBoun
 	std::ostringstream error;
 	error << " The parallel scanner does not support null_padding in conjunction with quoted new lines. Please "
 	         "disable the parallel csv reader with parallel=false"
-	      << std::endl;
+	      << '\n';
 	// What were the options
 	error << options.ToString();
 	return CSVError(error.str(), CSVErrorType::NULLPADDED_QUOTED_NEW_VALUE, error_info);
@@ -159,8 +159,8 @@ CSVError CSVError::NullPaddingFail(const CSVReaderOptions &options, LinesPerBoun
 CSVError CSVError::UnterminatedQuotesError(const CSVReaderOptions &options, string_t *vector_ptr,
                                            idx_t vector_line_start, idx_t current_column, LinesPerBoundary error_info) {
 	std::ostringstream error;
-	error << "Value with unterminated quote found." << std::endl;
-	error << std::endl;
+	error << "Value with unterminated quote found." << '\n';
+	error << '\n';
 	// What were the options
 	error << options.ToString();
 	return CSVError(error.str(), CSVErrorType::UNTERMINATED_QUOTES, error_info);
@@ -172,15 +172,15 @@ CSVError CSVError::IncorrectColumnAmountError(const CSVReaderOptions &options, s
 	std::ostringstream error;
 	// How many columns were expected and how many were found
 	error << "Expected Number of Columns: " << options.dialect_options.num_cols << " Found: " << actual_columns
-	      << std::endl;
-	error << std::endl << "Possible fixes:" << std::endl;
+	      << '\n';
+	error << '\n' << "Possible fixes:" << '\n';
 	if (!options.null_padding) {
-		error << "* Enable null padding (null_padding=true) to replace missing values with NULL" << std::endl;
+		error << "* Enable null padding (null_padding=true) to replace missing values with NULL" << '\n';
 	}
 	if (!options.ignore_errors) {
-		error << "* Enable ignore errors (ignore_errors=true) to skip this row" << std::endl;
+		error << "* Enable ignore errors (ignore_errors=true) to skip this row" << '\n';
 	}
-	error << std::endl;
+	error << '\n';
 	// What were the options
 	error << options.ToString();
 	return CSVError(error.str(), CSVErrorType::INCORRECT_COLUMN_AMOUNT, error_info);
@@ -189,7 +189,7 @@ CSVError CSVError::IncorrectColumnAmountError(const CSVReaderOptions &options, s
 CSVError CSVError::InvalidUTF8(const CSVReaderOptions &options, LinesPerBoundary error_info) {
 	std::ostringstream error;
 	// How many columns were expected and how many were found
-	error << "Invalid unicode (byte sequence mismatch) detected." << std::endl;
+	error << "Invalid unicode (byte sequence mismatch) detected." << '\n';
 	// What were the options
 	error << options.ToString();
 	return CSVError(error.str(), CSVErrorType::INVALID_UNICODE, error_info);

--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -62,7 +62,7 @@ struct FixedPreparedBatchData {
 class FixedBatchCopyGlobalState : public GlobalSinkState {
 public:
 	// heuristic - we need at least 4MB of cache space per column per thread we launch
-	static constexpr const idx_t MINIMUM_MEMORY_PER_COLUMN_PER_THREAD = 4 * 1024 * 1024;
+	static constexpr const idx_t MINIMUM_MEMORY_PER_COLUMN_PER_THREAD = 4ULL * 1024ULL * 1024ULL;
 
 public:
 	explicit FixedBatchCopyGlobalState(ClientContext &context_p, unique_ptr<GlobalFunctionData> global_state,
@@ -117,7 +117,7 @@ public:
 	}
 };
 
-enum class FixedBatchCopyState { SINKING_DATA = 1, PROCESSING_TASKS = 2 };
+enum class FixedBatchCopyState : uint8_t { SINKING_DATA = 1, PROCESSING_TASKS = 2 };
 
 class FixedBatchCopyLocalState : public LocalSinkState {
 public:

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -376,7 +376,7 @@ unique_ptr<GlobalSinkState> PhysicalBatchInsert::GetGlobalSinkState(ClientContex
 		table = insert_table.get_mutable();
 	}
 	// heuristic - we start off by allocating 4MB of cache space per column
-	static constexpr const idx_t MINIMUM_MEMORY_PER_COLUMN = 4 * 1024 * 1024;
+	static constexpr const idx_t MINIMUM_MEMORY_PER_COLUMN = 4ULL * 1024ULL * 1024ULL;
 	auto initial_memory = table->GetColumns().PhysicalColumnCount() * MINIMUM_MEMORY_PER_COLUMN;
 	auto result = make_uniq<BatchInsertGlobalState>(context, table->Cast<DuckTableEntry>(), initial_memory);
 	return std::move(result);

--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -22,9 +22,9 @@ static void WriteCatalogEntries(stringstream &ss, vector<reference<CatalogEntry>
 		if (entry.get().internal) {
 			continue;
 		}
-		ss << entry.get().ToSQL() << std::endl;
+		ss << entry.get().ToSQL() << '\n';
 	}
-	ss << std::endl;
+	ss << '\n';
 }
 
 static void WriteStringStreamToFile(FileSystem &fs, stringstream &ss, const string &path) {
@@ -77,7 +77,7 @@ static void WriteCopyStatement(FileSystem &fs, stringstream &ss, CopyInfo &info,
 			throw NotImplementedException("FIXME: serialize list of options");
 		}
 	}
-	ss << ");" << std::endl;
+	ss << ");" << '\n';
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/reservoir_sample.cpp
+++ b/src/execution/reservoir_sample.cpp
@@ -305,7 +305,7 @@ void BaseReservoirSampling::ReplaceElement(double with_weight) {
 		r2 = with_weight;
 	}
 	//! now we insert the new weight into the reservoir
-	reservoir_weights.push(std::make_pair(-r2, min_weighted_entry_index));
+	reservoir_weights.emplace(-r2, min_weighted_entry_index);
 	//! we update the min entry with the new min entry in the reservoir
 	SetNextEntry();
 }

--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -18,9 +18,9 @@ namespace duckdb {
 WindowAggregatorState::WindowAggregatorState() : allocator(Allocator::DefaultAllocator()) {
 }
 
-WindowAggregator::WindowAggregator(AggregateObject aggr, const LogicalType &result_type_p,
+WindowAggregator::WindowAggregator(AggregateObject aggr_p, const LogicalType &result_type_p,
                                    const WindowExcludeMode exclude_mode_p, idx_t partition_count_p)
-    : aggr(std::move(aggr)), result_type(result_type_p), partition_count(partition_count_p),
+    : aggr(std::move(aggr_p)), result_type(result_type_p), partition_count(partition_count_p),
       state_size(aggr.function.state_size()), filter_pos(0), exclude_mode(exclude_mode_p) {
 }
 

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -219,7 +219,7 @@ idx_t FunctionBinder::BindFunction(const string &name, TableFunctionSet &functio
 	return BindFunction(name, functions, types, error);
 }
 
-enum class LogicalTypeComparisonResult { IDENTICAL_TYPE, TARGET_IS_ANY, DIFFERENT_TYPES };
+enum class LogicalTypeComparisonResult : uint8_t { IDENTICAL_TYPE, TARGET_IS_ANY, DIFFERENT_TYPES };
 
 LogicalTypeComparisonResult RequiresCast(const LogicalType &source_type, const LogicalType &target_type) {
 	if (target_type.id() == LogicalTypeId::ANY) {

--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -598,7 +598,9 @@ string StrTimeFormat::ParseFormatSpecifier(const string &format_string, StrTimeF
 					// parse the subformat in a separate format specifier
 					StrfTimeFormat locale_format;
 					string error = StrTimeFormat::ParseFormatSpecifier(subformat, locale_format);
-					D_ASSERT(error.empty());
+					if (!error.empty()) {
+						throw InternalException("Failed to bind sub-format specifier \"%s\": %s", subformat, error);
+					}
 					// add the previous literal to the first literal of the subformat
 					locale_format.literals[0] = std::move(current_literal) + locale_format.literals[0];
 					current_literal = "";

--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -237,7 +237,6 @@ void ArrowTableFunction::PopulateArrowTableType(ArrowTableType &arrow_table, Arr
 		auto arrow_type = GetArrowLogicalType(schema);
 		return_types.emplace_back(arrow_type->GetDuckType(true));
 		arrow_table.AddColumn(col_idx, std::move(arrow_type));
-		auto format = string(schema.format);
 		auto name = string(schema.name);
 		if (name.empty()) {
 			name = string("v") + to_string(col_idx);

--- a/src/function/table/arrow/arrow_array_scan_state.cpp
+++ b/src/function/table/arrow/arrow_array_scan_state.cpp
@@ -14,7 +14,7 @@ ArrowArrayScanState &ArrowArrayScanState::GetChild(idx_t child_idx) {
 		auto child_p = make_uniq<ArrowArrayScanState>(state);
 		auto &child = *child_p;
 		child.owned_data = owned_data;
-		children.emplace(std::make_pair(child_idx, std::move(child_p)));
+		children.emplace(child_idx, std::move(child_p));
 		return child;
 	}
 	if (!it->second->owned_data) {

--- a/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
@@ -29,7 +29,7 @@ public:
 	//! Create a DuckIndexEntry
 	DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &info);
 
-	virtual unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
+	unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
 
 	//! The indexed table information
 	shared_ptr<IndexDataTableInfo> info;

--- a/src/include/duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp
@@ -58,7 +58,7 @@ public:
 	SequenceCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateSequenceInfo &info);
 
 public:
-	virtual unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
+	unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
 	unique_ptr<CreateInfo> GetInfo() const override;
 
 	SequenceData GetData() const;

--- a/src/include/duckdb/catalog/dependency.hpp
+++ b/src/include/duckdb/catalog/dependency.hpp
@@ -135,9 +135,8 @@ public:
 
 struct Dependency {
 	Dependency(CatalogEntry &entry, // NOLINT: Allow implicit conversion from `CatalogEntry`
-			   DependencyDependentFlags flags = DependencyDependentFlags().SetBlocking())
-	    :
-	      entry(entry), flags(std::move(flags)) {
+	           DependencyDependentFlags flags = DependencyDependentFlags().SetBlocking())
+	    : entry(entry), flags(std::move(flags)) {
 	}
 
 	//! The catalog entry this depends on

--- a/src/include/duckdb/catalog/dependency.hpp
+++ b/src/include/duckdb/catalog/dependency.hpp
@@ -134,9 +134,10 @@ public:
 };
 
 struct Dependency {
-	Dependency(CatalogEntry &entry, DependencyDependentFlags flags = DependencyDependentFlags().SetBlocking())
-	    : // NOLINT: Allow implicit conversion from `CatalogEntry`
-	      entry(entry), flags(flags) {
+	Dependency(CatalogEntry &entry, // NOLINT: Allow implicit conversion from `CatalogEntry`
+			   DependencyDependentFlags flags = DependencyDependentFlags().SetBlocking())
+	    :
+	      entry(entry), flags(std::move(flags)) {
 	}
 
 	//! The catalog entry this depends on

--- a/src/include/duckdb/catalog/dependency_manager.hpp
+++ b/src/include/duckdb/catalog/dependency_manager.hpp
@@ -57,7 +57,7 @@ public:
 
 struct MangledEntryName {
 public:
-	MangledEntryName(const CatalogEntryInfo &info);
+	explicit MangledEntryName(const CatalogEntryInfo &info);
 	MangledEntryName() = delete;
 
 public:

--- a/src/include/duckdb/catalog/duck_catalog.hpp
+++ b/src/include/duckdb/catalog/duck_catalog.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 class DuckCatalog : public Catalog {
 public:
 	explicit DuckCatalog(AttachedDatabase &db);
-	~DuckCatalog();
+	~DuckCatalog() override;
 
 public:
 	bool IsDuckCatalog() override;

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -58,10 +58,10 @@ public:
 	DUCKDB_API AllocatedData(AllocatedData &&other) noexcept;
 	DUCKDB_API AllocatedData &operator=(AllocatedData &&) noexcept;
 
-	data_ptr_t get() {
+	data_ptr_t get() { // NOLINT: matching std style
 		return pointer;
 	}
-	const_data_ptr_t get() const {
+	const_data_ptr_t get() const { // NOLINT: matching std style
 		return pointer;
 	}
 	idx_t GetSize() const {

--- a/src/include/duckdb/common/arrow/arrow_wrapper.hpp
+++ b/src/include/duckdb/common/arrow/arrow_wrapper.hpp
@@ -35,7 +35,7 @@ public:
 		arrow_array.length = 0;
 		arrow_array.release = nullptr;
 	}
-	ArrowArrayWrapper(ArrowArrayWrapper &&other) : arrow_array(other.arrow_array) {
+	ArrowArrayWrapper(ArrowArrayWrapper &&other) noexcept : arrow_array(other.arrow_array) {
 		other.arrow_array.release = nullptr;
 	}
 	~ArrowArrayWrapper();

--- a/src/include/duckdb/common/box_renderer.hpp
+++ b/src/include/duckdb/common/box_renderer.hpp
@@ -37,22 +37,22 @@ struct BoxRendererConfig {
 	RenderMode render_mode = RenderMode::ROWS;
 
 #ifndef DUCKDB_ASCII_TREE_RENDERER
-	const char *LTCORNER = "\342\224\214"; // "┌";
-	const char *RTCORNER = "\342\224\220"; // "┐";
-	const char *LDCORNER = "\342\224\224"; // "└";
-	const char *RDCORNER = "\342\224\230"; // "┘";
+	const char *LTCORNER = "\342\224\214"; // NOLINT: "┌";
+	const char *RTCORNER = "\342\224\220"; // NOLINT: "┐";
+	const char *LDCORNER = "\342\224\224"; // NOLINT: "└";
+	const char *RDCORNER = "\342\224\230"; // NOLINT: "┘";
 
-	const char *MIDDLE = "\342\224\274";  // "┼";
-	const char *TMIDDLE = "\342\224\254"; // "┬";
-	const char *LMIDDLE = "\342\224\234"; // "├";
-	const char *RMIDDLE = "\342\224\244"; // "┤";
-	const char *DMIDDLE = "\342\224\264"; // "┴";
+	const char *MIDDLE = "\342\224\274";  // NOLINT: "┼";
+	const char *TMIDDLE = "\342\224\254"; // NOLINT: "┬";
+	const char *LMIDDLE = "\342\224\234"; // NOLINT: "├";
+	const char *RMIDDLE = "\342\224\244"; // NOLINT: "┤";
+	const char *DMIDDLE = "\342\224\264"; // NOLINT: "┴";
 
-	const char *VERTICAL = "\342\224\202";   // "│";
-	const char *HORIZONTAL = "\342\224\200"; // "─";
+	const char *VERTICAL = "\342\224\202";   // NOLINT: "│";
+	const char *HORIZONTAL = "\342\224\200"; // NOLINT: "─";
 
-	const char *DOTDOTDOT = "\xE2\x80\xA6"; // "…";
-	const char *DOT = "\xC2\xB7";           // "·";
+	const char *DOTDOTDOT = "\xE2\x80\xA6"; // NOLINT: "…";
+	const char *DOT = "\xC2\xB7";           // NOLINT: "·";
 	const idx_t DOTDOTDOT_LENGTH = 1;
 
 #else

--- a/src/include/duckdb/common/crypto/md5.hpp
+++ b/src/include/duckdb/common/crypto/md5.hpp
@@ -41,7 +41,6 @@ public:
 
 private:
 	void MD5Update(const_data_ptr_t data, idx_t len);
-	static void DigestToBase16(const_data_ptr_t digest, char *zBuf);
 
 	uint32_t buf[4];
 	uint32_t bits[2];

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -58,6 +58,8 @@ enum class AppenderType : uint8_t;
 
 enum class ArrowDateTimeType : uint8_t;
 
+enum class ArrowOffsetSize : uint8_t;
+
 enum class ArrowVariableSizeType : uint8_t;
 
 enum class BindingMode : uint8_t;
@@ -112,6 +114,8 @@ enum class ErrorType : uint16_t;
 
 enum class ExceptionFormatValueType : uint8_t;
 
+enum class ExceptionType : uint8_t;
+
 enum class ExplainOutputType : uint8_t;
 
 enum class ExplainType : uint8_t;
@@ -121,6 +125,8 @@ enum class ExpressionClass : uint8_t;
 enum class ExpressionType : uint8_t;
 
 enum class ExtensionLoadResult : uint8_t;
+
+enum class ExternalDependenciesType : uint8_t;
 
 enum class ExtraDropInfoType : uint8_t;
 
@@ -235,6 +241,8 @@ enum class RenderMode : uint8_t;
 enum class ResultModifierType : uint8_t;
 
 enum class SampleMethod : uint8_t;
+
+enum class ScanType : uint8_t;
 
 enum class SecretDisplayType : uint8_t;
 
@@ -357,6 +365,9 @@ template<>
 const char* EnumUtil::ToChars<ArrowDateTimeType>(ArrowDateTimeType value);
 
 template<>
+const char* EnumUtil::ToChars<ArrowOffsetSize>(ArrowOffsetSize value);
+
+template<>
 const char* EnumUtil::ToChars<ArrowVariableSizeType>(ArrowVariableSizeType value);
 
 template<>
@@ -438,6 +449,9 @@ template<>
 const char* EnumUtil::ToChars<ExceptionFormatValueType>(ExceptionFormatValueType value);
 
 template<>
+const char* EnumUtil::ToChars<ExceptionType>(ExceptionType value);
+
+template<>
 const char* EnumUtil::ToChars<ExplainOutputType>(ExplainOutputType value);
 
 template<>
@@ -451,6 +465,9 @@ const char* EnumUtil::ToChars<ExpressionType>(ExpressionType value);
 
 template<>
 const char* EnumUtil::ToChars<ExtensionLoadResult>(ExtensionLoadResult value);
+
+template<>
+const char* EnumUtil::ToChars<ExternalDependenciesType>(ExternalDependenciesType value);
 
 template<>
 const char* EnumUtil::ToChars<ExtraDropInfoType>(ExtraDropInfoType value);
@@ -624,6 +641,9 @@ template<>
 const char* EnumUtil::ToChars<SampleMethod>(SampleMethod value);
 
 template<>
+const char* EnumUtil::ToChars<ScanType>(ScanType value);
+
+template<>
 const char* EnumUtil::ToChars<SecretDisplayType>(SecretDisplayType value);
 
 template<>
@@ -784,6 +804,9 @@ template<>
 ArrowDateTimeType EnumUtil::FromString<ArrowDateTimeType>(const char *value);
 
 template<>
+ArrowOffsetSize EnumUtil::FromString<ArrowOffsetSize>(const char *value);
+
+template<>
 ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *value);
 
 template<>
@@ -865,6 +888,9 @@ template<>
 ExceptionFormatValueType EnumUtil::FromString<ExceptionFormatValueType>(const char *value);
 
 template<>
+ExceptionType EnumUtil::FromString<ExceptionType>(const char *value);
+
+template<>
 ExplainOutputType EnumUtil::FromString<ExplainOutputType>(const char *value);
 
 template<>
@@ -878,6 +904,9 @@ ExpressionType EnumUtil::FromString<ExpressionType>(const char *value);
 
 template<>
 ExtensionLoadResult EnumUtil::FromString<ExtensionLoadResult>(const char *value);
+
+template<>
+ExternalDependenciesType EnumUtil::FromString<ExternalDependenciesType>(const char *value);
 
 template<>
 ExtraDropInfoType EnumUtil::FromString<ExtraDropInfoType>(const char *value);
@@ -1049,6 +1078,9 @@ ResultModifierType EnumUtil::FromString<ResultModifierType>(const char *value);
 
 template<>
 SampleMethod EnumUtil::FromString<SampleMethod>(const char *value);
+
+template<>
+ScanType EnumUtil::FromString<ScanType>(const char *value);
 
 template<>
 SecretDisplayType EnumUtil::FromString<SecretDisplayType>(const char *value);

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -27,7 +27,7 @@ class TableRef;
 struct hugeint_t;
 class optional_idx;
 
-inline void assert_restrict_function(const void *left_start, const void *left_end, const void *right_start,
+inline void AssertRestrictFunction(const void *left_start, const void *left_end, const void *right_start,
                                      const void *right_end, const char *fname, int linenr) {
 	// assert that the two pointers do not overlap
 #ifdef DEBUG
@@ -39,13 +39,13 @@ inline void assert_restrict_function(const void *left_start, const void *left_en
 }
 
 #define ASSERT_RESTRICT(left_start, left_end, right_start, right_end)                                                  \
-	assert_restrict_function(left_start, left_end, right_start, right_end, __FILE__, __LINE__)
+	AssertRestrictFunction(left_start, left_end, right_start, right_end, __FILE__, __LINE__)
 
 //===--------------------------------------------------------------------===//
 // Exception Types
 //===--------------------------------------------------------------------===//
 
-enum class ExceptionType {
+enum class ExceptionType : uint8_t {
 	INVALID = 0,          // invalid type
 	OUT_OF_RANGE = 1,     // value out of range error
 	CONVERSION = 2,       // conversion/casting error
@@ -100,11 +100,12 @@ public:
 	DUCKDB_API static string ExceptionTypeToString(ExceptionType type);
 	DUCKDB_API static ExceptionType StringToExceptionType(const string &type);
 
-	template <typename... Args>
-	static string ConstructMessage(const string &msg, Args... params) {
-		const std::size_t num_args = sizeof...(Args);
-		if (num_args == 0)
+	template <typename... ARGS>
+	static string ConstructMessage(const string &msg, ARGS... params) {
+		const std::size_t num_args = sizeof...(ARGS);
+		if (num_args == 0) {
 			return msg;
+		}
 		std::vector<ExceptionFormatValue> values;
 		return ConstructMessageRecursive(msg, values, params...);
 	}
@@ -126,9 +127,9 @@ public:
 
 	DUCKDB_API static string ConstructMessageRecursive(const string &msg, std::vector<ExceptionFormatValue> &values);
 
-	template <class T, typename... Args>
+	template <class T, typename... ARGS>
 	static string ConstructMessageRecursive(const string &msg, std::vector<ExceptionFormatValue> &values, T param,
-	                                        Args... params) {
+	                                        ARGS... params) {
 		values.push_back(ExceptionFormatValue::CreateFormatValue<T>(param));
 		return ConstructMessageRecursive(msg, values, params...);
 	}
@@ -136,7 +137,7 @@ public:
 	DUCKDB_API static bool UncaughtException();
 
 	DUCKDB_API static string GetStackTrace(int max_depth = 120);
-	static string FormatStackTrace(string message = "") {
+	static string FormatStackTrace(const string &message = "") {
 		return (message + "\n" + GetStackTrace());
 	}
 
@@ -150,8 +151,8 @@ class ConnectionException : public Exception {
 public:
 	DUCKDB_API explicit ConnectionException(const string &msg);
 
-	template <typename... Args>
-	explicit ConnectionException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit ConnectionException(const string &msg, ARGS... params)
 	    : ConnectionException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -160,8 +161,8 @@ class PermissionException : public Exception {
 public:
 	DUCKDB_API explicit PermissionException(const string &msg);
 
-	template <typename... Args>
-	explicit PermissionException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit PermissionException(const string &msg, ARGS... params)
 	    : PermissionException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -170,22 +171,22 @@ class OutOfRangeException : public Exception {
 public:
 	DUCKDB_API explicit OutOfRangeException(const string &msg);
 
-	template <typename... Args>
-	explicit OutOfRangeException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit OutOfRangeException(const string &msg, ARGS... params)
 	    : OutOfRangeException(ConstructMessage(msg, params...)) {
 	}
-	DUCKDB_API OutOfRangeException(const int64_t value, const PhysicalType origType, const PhysicalType newType);
-	DUCKDB_API OutOfRangeException(const hugeint_t value, const PhysicalType origType, const PhysicalType newType);
-	DUCKDB_API OutOfRangeException(const double value, const PhysicalType origType, const PhysicalType newType);
-	DUCKDB_API OutOfRangeException(const PhysicalType varType, const idx_t length);
+	DUCKDB_API OutOfRangeException(const int64_t value, const PhysicalType orig_type, const PhysicalType new_type);
+	DUCKDB_API OutOfRangeException(const hugeint_t value, const PhysicalType orig_type, const PhysicalType new_type);
+	DUCKDB_API OutOfRangeException(const double value, const PhysicalType orig_type, const PhysicalType new_type);
+	DUCKDB_API OutOfRangeException(const PhysicalType var_type, const idx_t length);
 };
 
 class OutOfMemoryException : public Exception {
 public:
 	DUCKDB_API explicit OutOfMemoryException(const string &msg);
 
-	template <typename... Args>
-	explicit OutOfMemoryException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit OutOfMemoryException(const string &msg, ARGS... params)
 	    : OutOfMemoryException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -194,8 +195,8 @@ class SyntaxException : public Exception {
 public:
 	DUCKDB_API explicit SyntaxException(const string &msg);
 
-	template <typename... Args>
-	explicit SyntaxException(const string &msg, Args... params) : SyntaxException(ConstructMessage(msg, params...)) {
+	template <typename... ARGS>
+	explicit SyntaxException(const string &msg, ARGS... params) : SyntaxException(ConstructMessage(msg, params...)) {
 	}
 };
 
@@ -203,8 +204,8 @@ class ConstraintException : public Exception {
 public:
 	DUCKDB_API explicit ConstraintException(const string &msg);
 
-	template <typename... Args>
-	explicit ConstraintException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit ConstraintException(const string &msg, ARGS... params)
 	    : ConstraintException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -213,8 +214,8 @@ class DependencyException : public Exception {
 public:
 	DUCKDB_API explicit DependencyException(const string &msg);
 
-	template <typename... Args>
-	explicit DependencyException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit DependencyException(const string &msg, ARGS... params)
 	    : DependencyException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -226,12 +227,12 @@ public:
 	explicit IOException(ExceptionType exception_type, const string &msg) : Exception(exception_type, msg) {
 	}
 
-	template <typename... Args>
-	explicit IOException(const string &msg, Args... params) : IOException(ConstructMessage(msg, params...)) {
+	template <typename... ARGS>
+	explicit IOException(const string &msg, ARGS... params) : IOException(ConstructMessage(msg, params...)) {
 	}
 
-	template <typename... Args>
-	explicit IOException(const string &msg, const unordered_map<string, string> &extra_info, Args... params)
+	template <typename... ARGS>
+	explicit IOException(const string &msg, const unordered_map<string, string> &extra_info, ARGS... params)
 	    : IOException(ConstructMessage(msg, params...), extra_info) {
 	}
 };
@@ -240,8 +241,8 @@ class MissingExtensionException : public Exception {
 public:
 	DUCKDB_API explicit MissingExtensionException(const string &msg);
 
-	template <typename... Args>
-	explicit MissingExtensionException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit MissingExtensionException(const string &msg, ARGS... params)
 	    : MissingExtensionException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -250,8 +251,8 @@ class NotImplementedException : public Exception {
 public:
 	DUCKDB_API explicit NotImplementedException(const string &msg);
 
-	template <typename... Args>
-	explicit NotImplementedException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit NotImplementedException(const string &msg, ARGS... params)
 	    : NotImplementedException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -265,8 +266,8 @@ class SerializationException : public Exception {
 public:
 	DUCKDB_API explicit SerializationException(const string &msg);
 
-	template <typename... Args>
-	explicit SerializationException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit SerializationException(const string &msg, ARGS... params)
 	    : SerializationException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -275,8 +276,8 @@ class SequenceException : public Exception {
 public:
 	DUCKDB_API explicit SequenceException(const string &msg);
 
-	template <typename... Args>
-	explicit SequenceException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit SequenceException(const string &msg, ARGS... params)
 	    : SequenceException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -290,14 +291,14 @@ class FatalException : public Exception {
 public:
 	explicit FatalException(const string &msg) : FatalException(ExceptionType::FATAL, msg) {
 	}
-	template <typename... Args>
-	explicit FatalException(const string &msg, Args... params) : FatalException(ConstructMessage(msg, params...)) {
+	template <typename... ARGS>
+	explicit FatalException(const string &msg, ARGS... params) : FatalException(ConstructMessage(msg, params...)) {
 	}
 
 protected:
 	DUCKDB_API explicit FatalException(ExceptionType type, const string &msg);
-	template <typename... Args>
-	explicit FatalException(ExceptionType type, const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit FatalException(ExceptionType type, const string &msg, ARGS... params)
 	    : FatalException(type, ConstructMessage(msg, params...)) {
 	}
 };
@@ -306,8 +307,8 @@ class InternalException : public Exception {
 public:
 	DUCKDB_API explicit InternalException(const string &msg);
 
-	template <typename... Args>
-	explicit InternalException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit InternalException(const string &msg, ARGS... params)
 	    : InternalException(ConstructMessage(msg, params...)) {
 	}
 };
@@ -317,12 +318,12 @@ public:
 	DUCKDB_API explicit InvalidInputException(const string &msg);
 	DUCKDB_API explicit InvalidInputException(const string &msg, const unordered_map<string, string> &extra_info);
 
-	template <typename... Args>
-	explicit InvalidInputException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit InvalidInputException(const string &msg, ARGS... params)
 	    : InvalidInputException(ConstructMessage(msg, params...)) {
 	}
-	template <typename... Args>
-	explicit InvalidInputException(Expression &expr, const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit InvalidInputException(Expression &expr, const string &msg, ARGS... params)
 	    : InvalidInputException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(expr)) {
 	}
 };
@@ -331,8 +332,7 @@ class InvalidTypeException : public Exception {
 public:
 	DUCKDB_API InvalidTypeException(PhysicalType type, const string &msg);
 	DUCKDB_API InvalidTypeException(const LogicalType &type, const string &msg);
-	DUCKDB_API
-	InvalidTypeException(const string &msg); //! Needed to be able to recreate the exception after it's been serialized
+	DUCKDB_API explicit InvalidTypeException(const string &msg);
 };
 
 class TypeMismatchException : public Exception {
@@ -341,16 +341,15 @@ public:
 	DUCKDB_API TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg);
 	DUCKDB_API TypeMismatchException(optional_idx error_location, const LogicalType &type_1, const LogicalType &type_2,
 	                                 const string &msg);
-	DUCKDB_API
-	TypeMismatchException(const string &msg); //! Needed to be able to recreate the exception after it's been serialized
+	DUCKDB_API explicit TypeMismatchException(const string &msg);
 };
 
 class ParameterNotAllowedException : public Exception {
 public:
 	DUCKDB_API explicit ParameterNotAllowedException(const string &msg);
 
-	template <typename... Args>
-	explicit ParameterNotAllowedException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit ParameterNotAllowedException(const string &msg, ARGS... params)
 	    : ParameterNotAllowedException(ConstructMessage(msg, params...)) {
 	}
 };

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -25,7 +25,7 @@ class ParsedExpression;
 class QueryErrorContext;
 class TableRef;
 struct hugeint_t;
-class optional_idx;
+class optional_idx; // NOLINT: matching std style
 
 inline void AssertRestrictFunction(const void *left_start, const void *left_end, const void *right_start,
                                      const void *right_end, const char *fname, int linenr) {

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -28,7 +28,7 @@ struct hugeint_t;
 class optional_idx; // NOLINT: matching std style
 
 inline void AssertRestrictFunction(const void *left_start, const void *left_end, const void *right_start,
-                                     const void *right_end, const char *fname, int linenr) {
+                                   const void *right_end, const char *fname, int linenr) {
 	// assert that the two pointers do not overlap
 #ifdef DEBUG
 	if (!(left_end <= right_start || right_end <= left_start)) {

--- a/src/include/duckdb/common/exception/binder_exception.hpp
+++ b/src/include/duckdb/common/exception/binder_exception.hpp
@@ -18,23 +18,23 @@ public:
 	DUCKDB_API explicit BinderException(const string &msg, const unordered_map<string, string> &extra_info);
 	DUCKDB_API explicit BinderException(const string &msg);
 
-	template <typename... Args>
-	explicit BinderException(const string &msg, Args... params) : BinderException(ConstructMessage(msg, params...)) {
+	template <typename... ARGS>
+	explicit BinderException(const string &msg, ARGS... params) : BinderException(ConstructMessage(msg, params...)) {
 	}
-	template <typename... Args>
-	explicit BinderException(const TableRef &ref, const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit BinderException(const TableRef &ref, const string &msg, ARGS... params)
 	    : BinderException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(ref)) {
 	}
-	template <typename... Args>
-	explicit BinderException(const ParsedExpression &expr, const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit BinderException(const ParsedExpression &expr, const string &msg, ARGS... params)
 	    : BinderException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(expr)) {
 	}
-	template <typename... Args>
-	explicit BinderException(QueryErrorContext error_context, const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit BinderException(QueryErrorContext error_context, const string &msg, ARGS... params)
 	    : BinderException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(error_context)) {
 	}
-	template <typename... Args>
-	explicit BinderException(optional_idx error_location, const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit BinderException(optional_idx error_location, const string &msg, ARGS... params)
 	    : BinderException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(error_location)) {
 	}
 

--- a/src/include/duckdb/common/exception/catalog_exception.hpp
+++ b/src/include/duckdb/common/exception/catalog_exception.hpp
@@ -20,11 +20,11 @@ public:
 	DUCKDB_API explicit CatalogException(const string &msg);
 	DUCKDB_API explicit CatalogException(const string &msg, const unordered_map<string, string> &extra_info);
 
-	template <typename... Args>
-	explicit CatalogException(const string &msg, Args... params) : CatalogException(ConstructMessage(msg, params...)) {
+	template <typename... ARGS>
+	explicit CatalogException(const string &msg, ARGS... params) : CatalogException(ConstructMessage(msg, params...)) {
 	}
-	template <typename... Args>
-	explicit CatalogException(QueryErrorContext error_context, const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit CatalogException(QueryErrorContext error_context, const string &msg, ARGS... params)
 	    : CatalogException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(error_context)) {
 	}
 

--- a/src/include/duckdb/common/exception/conversion_exception.hpp
+++ b/src/include/duckdb/common/exception/conversion_exception.hpp
@@ -17,15 +17,15 @@ class ConversionException : public Exception {
 public:
 	DUCKDB_API explicit ConversionException(const string &msg);
 	DUCKDB_API explicit ConversionException(optional_idx error_location, const string &msg);
-	DUCKDB_API ConversionException(const PhysicalType origType, const PhysicalType newType);
-	DUCKDB_API ConversionException(const LogicalType &origType, const LogicalType &newType);
+	DUCKDB_API ConversionException(const PhysicalType orig_type, const PhysicalType new_type);
+	DUCKDB_API ConversionException(const LogicalType &orig_type, const LogicalType &new_type);
 
-	template <typename... Args>
-	explicit ConversionException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit ConversionException(const string &msg, ARGS... params)
 	    : ConversionException(ConstructMessage(msg, params...)) {
 	}
-	template <typename... Args>
-	explicit ConversionException(optional_idx error_location, const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit ConversionException(optional_idx error_location, const string &msg, ARGS... params)
 	    : ConversionException(error_location, ConstructMessage(msg, params...)) {
 	}
 };

--- a/src/include/duckdb/common/exception/http_exception.hpp
+++ b/src/include/duckdb/common/exception/http_exception.hpp
@@ -17,10 +17,10 @@ class HTTPException : public Exception {
 public:
 	template <typename>
 	struct ResponseShape {
-		typedef int status;
+		typedef int status; // NOLINT
 	};
 
-	explicit HTTPException(string message) : Exception(ExceptionType::HTTP, std::move(message)) {
+	explicit HTTPException(const string &message) : Exception(ExceptionType::HTTP, message) {
 	}
 
 	template <class RESPONSE, typename ResponseShape<decltype(RESPONSE::status)>::status = 0, typename... ARGS>
@@ -30,7 +30,7 @@ public:
 
 	template <typename>
 	struct ResponseWrapperShape {
-		typedef int code;
+		typedef int code; // NOLINT
 	};
 
 	template <class RESPONSE, typename ResponseWrapperShape<decltype(RESPONSE::code)>::code = 0, typename... ARGS>

--- a/src/include/duckdb/common/exception/parser_exception.hpp
+++ b/src/include/duckdb/common/exception/parser_exception.hpp
@@ -19,11 +19,11 @@ public:
 	DUCKDB_API explicit ParserException(const string &msg);
 	DUCKDB_API explicit ParserException(const string &msg, const unordered_map<string, string> &extra_info);
 
-	template <typename... Args>
-	explicit ParserException(const string &msg, Args... params) : ParserException(ConstructMessage(msg, params...)) {
+	template <typename... ARGS>
+	explicit ParserException(const string &msg, ARGS... params) : ParserException(ConstructMessage(msg, params...)) {
 	}
-	template <typename... Args>
-	explicit ParserException(optional_idx error_location, const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit ParserException(optional_idx error_location, const string &msg, ARGS... params)
 	    : ParserException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(error_location)) {
 	}
 

--- a/src/include/duckdb/common/exception/transaction_exception.hpp
+++ b/src/include/duckdb/common/exception/transaction_exception.hpp
@@ -16,8 +16,8 @@ class TransactionException : public Exception {
 public:
 	DUCKDB_API explicit TransactionException(const string &msg);
 
-	template <typename... Args>
-	explicit TransactionException(const string &msg, Args... params)
+	template <typename... ARGS>
+	explicit TransactionException(const string &msg, ARGS... params)
 	    : TransactionException(ConstructMessage(msg, params...)) {
 	}
 };

--- a/src/include/duckdb/common/exception_format_value.hpp
+++ b/src/include/duckdb/common/exception_format_value.hpp
@@ -19,7 +19,7 @@ namespace duckdb {
 // Escaping " and quoting the value with "
 class SQLIdentifier {
 public:
-	SQLIdentifier(const string &raw_string) : raw_string(raw_string) {
+	explicit SQLIdentifier(const string &raw_string) : raw_string(raw_string) {
 	}
 
 public:
@@ -30,7 +30,7 @@ public:
 // Escaping ' and quoting the value with '
 class SQLString {
 public:
-	SQLString(const string &raw_string) : raw_string(raw_string) {
+	explicit SQLString(const string &raw_string) : raw_string(raw_string) {
 	}
 
 public:

--- a/src/include/duckdb/common/extra_type_info.hpp
+++ b/src/include/duckdb/common/extra_type_info.hpp
@@ -219,7 +219,7 @@ private:
 };
 
 struct IntegerLiteralTypeInfo : public ExtraTypeInfo {
-	IntegerLiteralTypeInfo(Value constant_value);
+	explicit IntegerLiteralTypeInfo(Value constant_value);
 
 	Value constant_value;
 

--- a/src/include/duckdb/common/filename_pattern.hpp
+++ b/src/include/duckdb/common/filename_pattern.hpp
@@ -20,9 +20,7 @@ class FilenamePattern {
 	friend Deserializer;
 
 public:
-	FilenamePattern() : _base("data_"), _pos(_base.length()), _uuid(false) {
-	}
-	~FilenamePattern() {
+	FilenamePattern() : base("data_"), pos(base.length()), uuid(false) {
 	}
 
 public:
@@ -33,9 +31,9 @@ public:
 	static FilenamePattern Deserialize(Deserializer &deserializer);
 
 private:
-	string _base;
-	idx_t _pos;
-	bool _uuid;
+	string base;
+	idx_t pos;
+	bool uuid;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/fixed_size_map.hpp
+++ b/src/include/duckdb/common/fixed_size_map.hpp
@@ -15,13 +15,13 @@
 namespace duckdb {
 
 template <typename T>
-struct fixed_size_map_iterator_t;
+struct fixed_size_map_iterator_t; // NOLINT: match stl case
 
 template <typename T>
-struct const_fixed_size_map_iterator_t;
+struct const_fixed_size_map_iterator_t; // NOLINT: match stl case
 
 template <typename T>
-class fixed_size_map_t {
+class fixed_size_map_t { // NOLINT: match stl case
 	friend struct fixed_size_map_iterator_t<T>;
 	friend struct const_fixed_size_map_iterator_t<T>;
 
@@ -34,18 +34,18 @@ public:
 		resize(capacity);
 	}
 
-	idx_t size() const {
+	idx_t size() const { // NOLINT: match stl case
 		return count;
 	}
 
-	void resize(idx_t capacity_p) {
+	void resize(idx_t capacity_p) { // NOLINT: match stl case
 		capacity = capacity_p;
 		occupied = ValidityMask(capacity);
 		values = make_unsafe_uniq_array<T>(capacity + 1);
 		clear();
 	}
 
-	void clear() {
+	void clear() { // NOLINT: match stl case
 		count = 0;
 		occupied.SetAllInvalid(capacity);
 	}
@@ -62,23 +62,23 @@ public:
 		return values[key];
 	}
 
-	fixed_size_map_iterator_t<T> begin() {
+	fixed_size_map_iterator_t<T> begin() { // NOLINT: match stl case
 		return fixed_size_map_iterator_t<T>(begin_internal(), *this);
 	}
 
-	const_fixed_size_map_iterator_t<T> begin() const {
+	const_fixed_size_map_iterator_t<T> begin() const { // NOLINT: match stl case
 		return const_fixed_size_map_iterator_t<T>(begin_internal(), *this);
 	}
 
-	fixed_size_map_iterator_t<T> end() {
+	fixed_size_map_iterator_t<T> end() { // NOLINT: match stl case
 		return fixed_size_map_iterator_t<T>(capacity, *this);
 	}
 
-	const_fixed_size_map_iterator_t<T> end() const {
+	const_fixed_size_map_iterator_t<T> end() const { // NOLINT: match stl case
 		return const_fixed_size_map_iterator_t<T>(capacity, *this);
 	}
 
-	fixed_size_map_iterator_t<T> find(const idx_t &index) {
+	fixed_size_map_iterator_t<T> find(const idx_t &index) { // NOLINT: match stl case
 		if (occupied.RowIsValid(index)) {
 			return fixed_size_map_iterator_t<T>(index, *this);
 		} else {
@@ -86,7 +86,7 @@ public:
 		}
 	}
 
-	const_fixed_size_map_iterator_t<T> find(const idx_t &index) const {
+	const_fixed_size_map_iterator_t<T> find(const idx_t &index) const { // NOLINT: match stl case
 		if (occupied.RowIsValid(index)) {
 			return const_fixed_size_map_iterator_t<T>(index, *this);
 		} else {
@@ -95,7 +95,7 @@ public:
 	}
 
 private:
-	idx_t begin_internal() const {
+	idx_t begin_internal() const { // NOLINT: match stl case
 		idx_t index;
 		for (index = 0; index < capacity; index++) {
 			if (occupied.RowIsValid(index)) {

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -178,13 +178,13 @@ T SignValue(T a) {
 template <typename T>
 const T Load(const_data_ptr_t ptr) {
 	T ret;
-	memcpy(&ret, ptr, sizeof(ret));
+	memcpy(&ret, ptr, sizeof(ret)); // NOLINT
 	return ret;
 }
 
 template <typename T>
 void Store(const T &val, data_ptr_t ptr) {
-	memcpy(ptr, (void *)&val, sizeof(val));
+	memcpy(ptr, (void *)&val, sizeof(val)); // NOLINT
 }
 
 //! This assigns a shared pointer, but ONLY assigns if "target" is not equal to "source"

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -46,60 +46,54 @@ template<typename T>
 using reference = std::reference_wrapper<T>;
 
 template<class DATA_TYPE, bool SAFE = true>
-struct __unique_if
+struct TemplatedUniqueIf
 {
-    typedef unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, SAFE> __unique_single;
+    typedef unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, SAFE> templated_unique_single_t;
 };
 
-template<class DATA_TYPE>
-struct __unique_if<DATA_TYPE[]>
+template<class DATA_TYPE, size_t N>
+struct TemplatedUniqueIf<DATA_TYPE[N]>
 {
-    typedef unique_ptr<DATA_TYPE[]> __unique_array_unknown_bound;
-};
-
-template<class DATA_TYPE, size_t _Np>
-struct __unique_if<DATA_TYPE[_Np]>
-{
-    typedef void __unique_array_known_bound;
+    typedef void TemplatedUniqueArrayKnownBound; // NOLINT: mimic std style
 };
 
 template<class DATA_TYPE, class... ARGS>
 inline 
-typename __unique_if<DATA_TYPE, true>::__unique_single
-make_uniq(ARGS&&... __args)
+typename TemplatedUniqueIf<DATA_TYPE, true>::templated_unique_single_t
+make_uniq(ARGS&&... args) // NOLINT: mimic std style
 {
-    return unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, true>(new DATA_TYPE(std::forward<ARGS>(__args)...));
+    return unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, true>(new DATA_TYPE(std::forward<ARGS>(args)...));
 }
 
 template<class DATA_TYPE, class... ARGS>
 inline 
-typename __unique_if<DATA_TYPE, false>::__unique_single
-make_unsafe_uniq(ARGS&&... __args)
+typename TemplatedUniqueIf<DATA_TYPE, false>::templated_unique_single_t
+make_unsafe_uniq(ARGS&&... args) // NOLINT: mimic std style
 {
-    return unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, false>(new DATA_TYPE(std::forward<ARGS>(__args)...));
+    return unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, false>(new DATA_TYPE(std::forward<ARGS>(args)...));
 }
 
 template<class DATA_TYPE>
 inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>
-make_uniq_array(size_t __n)
+make_uniq_array(size_t n) // NOLINT: mimic std style
 {
-    return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>(new DATA_TYPE[__n]());
+    return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>(new DATA_TYPE[n]());
 }
 
 template<class DATA_TYPE>
 inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>
-make_unsafe_uniq_array(size_t __n)
+make_unsafe_uniq_array(size_t n) // NOLINT: mimic std style
 {
-    return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>(new DATA_TYPE[__n]());
+    return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>(new DATA_TYPE[n]());
 }
 
 template<class DATA_TYPE, class... ARGS>
-    typename __unique_if<DATA_TYPE>::__unique_array_known_bound
-    make_uniq(ARGS&&...) = delete;
+    typename TemplatedUniqueIf<DATA_TYPE>::TemplatedUniqueArrayKnownBound
+    make_uniq(ARGS&&...) = delete; // NOLINT: mimic std style
 
 
 template <typename S, typename T, typename... ARGS>
-unique_ptr<S> make_uniq_base(ARGS &&... args) {
+unique_ptr<S> make_uniq_base(ARGS &&... args) { // NOLINT: mimic std style
 	return unique_ptr<S>(new T(std::forward<ARGS>(args)...));
 }
 
@@ -111,7 +105,7 @@ unique_ptr<S> make_unique_base(Args &&... args) {
 #endif // DUCKDB_ENABLE_DEPRECATED_API
 
 template <typename T, typename S>
-unique_ptr<S> unique_ptr_cast(unique_ptr<T> src) {
+unique_ptr<S> unique_ptr_cast(unique_ptr<T> src) { // NOLINT: mimic std style
 	return unique_ptr<S>(static_cast<S *>(src.release()));
 }
 
@@ -138,7 +132,7 @@ typename std::remove_reference<T>::type&& move(T&& t) noexcept {
 #endif
 
 template <class T, class... ARGS>
-static duckdb::unique_ptr<T> make_unique(ARGS&&... __args) {
+static duckdb::unique_ptr<T> make_unique(ARGS&&... __args) { // NOLINT: mimic std style
 #ifndef DUCKDB_ENABLE_DEPRECATED_API
 	static_assert(sizeof(T) == 0, "Use make_uniq instead of make_unique!");
 #endif // DUCKDB_ENABLE_DEPRECATED_API

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -39,68 +39,68 @@ namespace duckdb {
 
 template <class... T>
 struct AlwaysFalse {
-	static constexpr bool value = false;
+	static constexpr bool VALUE = false;
 };
 
 template<typename T>
 using reference = std::reference_wrapper<T>;
 
-template<class _Tp, bool SAFE = true>
+template<class DATA_TYPE, bool SAFE = true>
 struct __unique_if
 {
-    typedef unique_ptr<_Tp, std::default_delete<_Tp>, SAFE> __unique_single;
+    typedef unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, SAFE> __unique_single;
 };
 
-template<class _Tp>
-struct __unique_if<_Tp[]>
+template<class DATA_TYPE>
+struct __unique_if<DATA_TYPE[]>
 {
-    typedef unique_ptr<_Tp[]> __unique_array_unknown_bound;
+    typedef unique_ptr<DATA_TYPE[]> __unique_array_unknown_bound;
 };
 
-template<class _Tp, size_t _Np>
-struct __unique_if<_Tp[_Np]>
+template<class DATA_TYPE, size_t _Np>
+struct __unique_if<DATA_TYPE[_Np]>
 {
     typedef void __unique_array_known_bound;
 };
 
-template<class _Tp, class... _Args>
+template<class DATA_TYPE, class... ARGS>
 inline 
-typename __unique_if<_Tp, true>::__unique_single
-make_uniq(_Args&&... __args)
+typename __unique_if<DATA_TYPE, true>::__unique_single
+make_uniq(ARGS&&... __args)
 {
-    return unique_ptr<_Tp, std::default_delete<_Tp>, true>(new _Tp(std::forward<_Args>(__args)...));
+    return unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, true>(new DATA_TYPE(std::forward<ARGS>(__args)...));
 }
 
-template<class _Tp, class... _Args>
+template<class DATA_TYPE, class... ARGS>
 inline 
-typename __unique_if<_Tp, false>::__unique_single
-make_unsafe_uniq(_Args&&... __args)
+typename __unique_if<DATA_TYPE, false>::__unique_single
+make_unsafe_uniq(ARGS&&... __args)
 {
-    return unique_ptr<_Tp, std::default_delete<_Tp>, false>(new _Tp(std::forward<_Args>(__args)...));
+    return unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, false>(new DATA_TYPE(std::forward<ARGS>(__args)...));
 }
 
-template<class _Tp>
-inline unique_ptr<_Tp[], std::default_delete<_Tp>, true>
+template<class DATA_TYPE>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>
 make_uniq_array(size_t __n)
 {
-    return unique_ptr<_Tp[], std::default_delete<_Tp>, true>(new _Tp[__n]());
+    return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, true>(new DATA_TYPE[__n]());
 }
 
-template<class _Tp>
-inline unique_ptr<_Tp[], std::default_delete<_Tp>, false>
+template<class DATA_TYPE>
+inline unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>
 make_unsafe_uniq_array(size_t __n)
 {
-    return unique_ptr<_Tp[], std::default_delete<_Tp>, false>(new _Tp[__n]());
+    return unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE>, false>(new DATA_TYPE[__n]());
 }
 
-template<class _Tp, class... _Args>
-    typename __unique_if<_Tp>::__unique_array_known_bound
-    make_uniq(_Args&&...) = delete;
+template<class DATA_TYPE, class... ARGS>
+    typename __unique_if<DATA_TYPE>::__unique_array_known_bound
+    make_uniq(ARGS&&...) = delete;
 
 
-template <typename S, typename T, typename... Args>
-unique_ptr<S> make_uniq_base(Args &&... args) {
-	return unique_ptr<S>(new T(std::forward<Args>(args)...));
+template <typename S, typename T, typename... ARGS>
+unique_ptr<S> make_uniq_base(ARGS &&... args) {
+	return unique_ptr<S>(new T(std::forward<ARGS>(args)...));
 }
 
 #ifdef DUCKDB_ENABLE_DEPRECATED_API
@@ -137,12 +137,12 @@ typename std::remove_reference<T>::type&& move(T&& t) noexcept {
 }
 #endif
 
-template <class T, class... _Args>
-static duckdb::unique_ptr<T> make_unique(_Args&&... __args) {
+template <class T, class... ARGS>
+static duckdb::unique_ptr<T> make_unique(ARGS&&... __args) {
 #ifndef DUCKDB_ENABLE_DEPRECATED_API
 	static_assert(sizeof(T) == 0, "Use make_uniq instead of make_unique!");
 #endif // DUCKDB_ENABLE_DEPRECATED_API
-	return unique_ptr<T>(new T(std::forward<_Args>(__args)...));
+	return unique_ptr<T>(new T(std::forward<ARGS>(__args)...));
 }
 
 template <typename T>
@@ -211,13 +211,13 @@ using const_reference = std::reference_wrapper<const T>;
 
 //! Returns whether or not two reference wrappers refer to the same object
 template<class T>
-bool RefersToSameObject(const reference<T> &A, const reference<T> &B) {
-	return &A.get() == &B.get();
+bool RefersToSameObject(const reference<T> &a, const reference<T> &b) {
+	return &a.get() == &b.get();
 }
 
 template<class T>
-bool RefersToSameObject(const T &A, const T &B) {
-	return &A == &B;
+bool RefersToSameObject(const T &a, const T &b) {
+	return &a == &b;
 }
 
 template<class T, class SRC>

--- a/src/include/duckdb/common/hugeint.hpp
+++ b/src/include/duckdb/common/hugeint.hpp
@@ -8,7 +8,7 @@
 namespace duckdb {
 
 // Forward declaration to allow conversion between hugeint and uhugeint
-struct uhugeint_t;
+struct uhugeint_t; // NOLINT: use numeric casing
 
 struct hugeint_t { // NOLINT: use numeric casing
 public:

--- a/src/include/duckdb/common/hugeint.hpp
+++ b/src/include/duckdb/common/hugeint.hpp
@@ -10,7 +10,7 @@ namespace duckdb {
 // Forward declaration to allow conversion between hugeint and uhugeint
 struct uhugeint_t;
 
-struct hugeint_t {
+struct hugeint_t { // NOLINT: use numeric casing
 public:
 	uint64_t lower;
 	int64_t upper;

--- a/src/include/duckdb/common/index_vector.hpp
+++ b/src/include/duckdb/common/index_vector.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 template <class T, class INDEX_TYPE>
 class IndexVector {
 public:
-	void push_back(T element) {
+	void push_back(T element) { // NOLINT: match stl API
 		internal_vector.push_back(std::move(element));
 	}
 
@@ -30,34 +30,34 @@ public:
 		return internal_vector[idx.index];
 	}
 
-	idx_t size() const {
+	idx_t size() const { // NOLINT: match stl API
 		return internal_vector.size();
 	}
 
-	bool empty() const {
+	bool empty() const { // NOLINT: match stl API
 		return internal_vector.empty();
 	}
 
-	void reserve(idx_t size) {
+	void reserve(idx_t size) { // NOLINT: match stl API
 		internal_vector.reserve(size);
 	}
 
-	typename vector<T>::iterator begin() {
+	typename vector<T>::iterator begin() { // NOLINT: match stl API
 		return internal_vector.begin();
 	}
-	typename vector<T>::iterator end() {
+	typename vector<T>::iterator end() { // NOLINT: match stl API
 		return internal_vector.end();
 	}
-	typename vector<T>::const_iterator cbegin() {
+	typename vector<T>::const_iterator cbegin() { // NOLINT: match stl API
 		return internal_vector.cbegin();
 	}
-	typename vector<T>::const_iterator cend() {
+	typename vector<T>::const_iterator cend() { // NOLINT: match stl API
 		return internal_vector.cend();
 	}
-	typename vector<T>::const_iterator begin() const {
+	typename vector<T>::const_iterator begin() const { // NOLINT: match stl API
 		return internal_vector.begin();
 	}
-	typename vector<T>::const_iterator end() const {
+	typename vector<T>::const_iterator end() const { // NOLINT: match stl API
 		return internal_vector.end();
 	}
 

--- a/src/include/duckdb/common/memory_safety.hpp
+++ b/src/include/duckdb/common/memory_safety.hpp
@@ -2,13 +2,13 @@
 
 namespace duckdb {
 
-template <bool ENABLED>
+template <bool IS_ENABLED>
 struct MemorySafety {
 #ifdef DEBUG
 	// In DEBUG mode safety is always on
-	static constexpr bool enabled = true;
+	static constexpr bool ENABLED = true;
 #else
-	static constexpr bool enabled = ENABLED;
+	static constexpr bool ENABLED = IS_ENABLED;
 #endif
 };
 

--- a/src/include/duckdb/common/optional_ptr.hpp
+++ b/src/include/duckdb/common/optional_ptr.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 template <class T>
-class optional_ptr {
+class optional_ptr { // NOLINT: mimic std casing
 public:
 	optional_ptr() : ptr(nullptr) {
 	}
@@ -29,7 +29,7 @@ public:
 		}
 	}
 
-	operator bool() const {
+	operator bool() const { // NOLINT: allow implicit conversion to bool
 		return ptr;
 	}
 	T &operator*() {
@@ -48,16 +48,16 @@ public:
 		CheckValid();
 		return ptr;
 	}
-	T *get() {
+	T *get() { // NOLINT: mimic std casing
 		// CheckValid();
 		return ptr;
 	}
-	const T *get() const {
+	const T *get() const { // NOLINT: mimic std casing
 		// CheckValid();
 		return ptr;
 	}
 	// this looks dirty - but this is the default behavior of raw pointers
-	T *get_mutable() const {
+	T *get_mutable() const { // NOLINT: mimic std casing
 		// CheckValid();
 		return ptr;
 	}

--- a/src/include/duckdb/common/platform.h
+++ b/src/include/duckdb/common/platform.h
@@ -3,7 +3,7 @@
 
 namespace duckdb {
 
-std::string DuckDBPlatform() {
+std::string DuckDBPlatform() { // NOLINT: allow definition in header
 #if defined(DUCKDB_CUSTOM_PLATFORM)
 	return DUCKDB_QUOTE_DEFINE(DUCKDB_CUSTOM_PLATFORM);
 #endif

--- a/src/include/duckdb/common/printer.hpp
+++ b/src/include/duckdb/common/printer.hpp
@@ -23,14 +23,14 @@ public:
 	//! Print the object to stderr
 	DUCKDB_API static void Print(const string &str);
 	//! Print the formatted object to the stream
-	template <typename... Args>
-	static void PrintF(OutputStream stream, const string &str, Args... params) {
+	template <typename... ARGS>
+	static void PrintF(OutputStream stream, const string &str, ARGS... params) {
 		Printer::Print(stream, StringUtil::Format(str, params...));
 	}
 	//! Print the formatted object to stderr
-	template <typename... Args>
-	static void PrintF(const string &str, Args... params) {
-		Printer::PrintF(OutputStream::STREAM_STDERR, str, std::forward<Args>(params)...);
+	template <typename... ARGS>
+	static void PrintF(const string &str, ARGS... params) {
+		Printer::PrintF(OutputStream::STREAM_STDERR, str, std::forward<ARGS>(params)...);
 	}
 	//! Directly prints the string to stdout without a newline
 	DUCKDB_API static void RawPrint(OutputStream stream, const string &str);

--- a/src/include/duckdb/common/profiler.hpp
+++ b/src/include/duckdb/common/profiler.hpp
@@ -32,8 +32,8 @@ public:
 	//! the total elapsed time. Otherwise returns how far along the timer is
 	//! right now.
 	double Elapsed() const {
-		auto _end = finished ? end : Tick();
-		return std::chrono::duration_cast<std::chrono::duration<double>>(_end - start).count();
+		auto measured_end = finished ? end : Tick();
+		return std::chrono::duration_cast<std::chrono::duration<double>>(measured_end - start).count();
 	}
 
 private:

--- a/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
@@ -27,11 +27,11 @@ private:
 	int32_t rendered_percentage = -1;
 	static constexpr const idx_t PARTIAL_BLOCK_COUNT = UnicodeBar::PartialBlocksCount();
 #ifndef DUCKDB_ASCII_TREE_RENDERER
-	const char *PROGRESS_EMPTY = " "; // NOLINT
+	const char *PROGRESS_EMPTY = " ";                                  // NOLINT
 	const char *const *PROGRESS_PARTIAL = UnicodeBar::PartialBlocks(); // NOLINT
-	const char *PROGRESS_BLOCK = UnicodeBar::FullBlock(); // NOLINT
-	const char *PROGRESS_START = "\xE2\x96\x95"; // NOLINT
-	const char *PROGRESS_END = "\xE2\x96\x8F"; // NOLINT
+	const char *PROGRESS_BLOCK = UnicodeBar::FullBlock();              // NOLINT
+	const char *PROGRESS_START = "\xE2\x96\x95";                       // NOLINT
+	const char *PROGRESS_END = "\xE2\x96\x8F";                         // NOLINT
 #else
 	const char *PROGRESS_EMPTY = " ";
 	const char *const PROGRESS_PARTIAL[PARTIAL_BLOCK_COUNT] = {" ", " ", " ", " ", " ", " ", " ", " "};

--- a/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp
@@ -27,11 +27,11 @@ private:
 	int32_t rendered_percentage = -1;
 	static constexpr const idx_t PARTIAL_BLOCK_COUNT = UnicodeBar::PartialBlocksCount();
 #ifndef DUCKDB_ASCII_TREE_RENDERER
-	const char *PROGRESS_EMPTY = " ";
-	const char *const *PROGRESS_PARTIAL = UnicodeBar::PartialBlocks();
-	const char *PROGRESS_BLOCK = UnicodeBar::FullBlock();
-	const char *PROGRESS_START = "\xE2\x96\x95";
-	const char *PROGRESS_END = "\xE2\x96\x8F";
+	const char *PROGRESS_EMPTY = " "; // NOLINT
+	const char *const *PROGRESS_PARTIAL = UnicodeBar::PartialBlocks(); // NOLINT
+	const char *PROGRESS_BLOCK = UnicodeBar::FullBlock(); // NOLINT
+	const char *PROGRESS_START = "\xE2\x96\x95"; // NOLINT
+	const char *PROGRESS_END = "\xE2\x96\x8F"; // NOLINT
 #else
 	const char *PROGRESS_EMPTY = " ";
 	const char *const PROGRESS_PARTIAL[PARTIAL_BLOCK_COUNT] = {" ", " ", " ", " ", " ", " ", " ", " "};

--- a/src/include/duckdb/common/random_engine.hpp
+++ b/src/include/duckdb/common/random_engine.hpp
@@ -19,7 +19,7 @@ class ClientContext;
 struct RandomState;
 
 struct RandomEngine {
-	RandomEngine(int64_t seed = -1);
+	explicit RandomEngine(int64_t seed = -1);
 	~RandomEngine();
 
 public:

--- a/src/include/duckdb/common/re2_regex.hpp
+++ b/src/include/duckdb/common/re2_regex.hpp
@@ -32,7 +32,7 @@ struct GroupMatch {
 	const std::string &str() const { // NOLINT
 		return text;
 	}
-	operator std::string() const {  // NOLINT: allow implicit cast
+	operator std::string() const { // NOLINT: allow implicit cast
 		return text;
 	}
 };

--- a/src/include/duckdb/common/re2_regex.hpp
+++ b/src/include/duckdb/common/re2_regex.hpp
@@ -14,8 +14,8 @@ enum class RegexOptions : uint8_t { NONE, CASE_INSENSITIVE };
 
 class Regex {
 public:
-	DUCKDB_API Regex(const std::string &pattern, RegexOptions options = RegexOptions::NONE);
-	Regex(const char *pattern, RegexOptions options = RegexOptions::NONE) : Regex(std::string(pattern)) {
+	DUCKDB_API explicit Regex(const std::string &pattern, RegexOptions options = RegexOptions::NONE);
+	explicit Regex(const char *pattern, RegexOptions options = RegexOptions::NONE) : Regex(std::string(pattern)) {
 	}
 	const duckdb_re2::RE2 &GetRegex() const {
 		return *regex;
@@ -29,10 +29,10 @@ struct GroupMatch {
 	std::string text;
 	uint32_t position;
 
-	const std::string &str() const {
+	const std::string &str() const { // NOLINT
 		return text;
 	}
-	operator std::string() const {
+	operator std::string() const {  // NOLINT: allow implicit cast
 		return text;
 	}
 };
@@ -47,15 +47,15 @@ struct Match {
 		return groups[index];
 	}
 
-	std::string str(uint64_t index) {
+	std::string str(uint64_t index) { // NOLINT
 		return GetGroup(index).text;
 	}
 
-	uint64_t position(uint64_t index) {
+	uint64_t position(uint64_t index) { // NOLINT
 		return GetGroup(index).position;
 	}
 
-	uint64_t length(uint64_t index) {
+	uint64_t length(uint64_t index) { // NOLINT
 		return GetGroup(index).text.size();
 	}
 

--- a/src/include/duckdb/common/serializer/deserialization_data.hpp
+++ b/src/include/duckdb/common/serializer/deserialization_data.hpp
@@ -112,7 +112,7 @@ inline void DeserializationData::Unset<CatalogType>() {
 
 template <>
 inline void DeserializationData::Set(ClientContext &context) {
-	contexts.push(context);
+	contexts.emplace(context);
 }
 
 template <>
@@ -129,7 +129,7 @@ inline void DeserializationData::Unset<ClientContext>() {
 
 template <>
 inline void DeserializationData::Set(DatabaseInstance &db) {
-	databases.push(db);
+	databases.emplace(db);
 }
 
 template <>
@@ -146,7 +146,7 @@ inline void DeserializationData::Unset<DatabaseInstance>() {
 
 template <>
 inline void DeserializationData::Set(bound_parameter_map_t &context) {
-	parameter_data.push(context);
+	parameter_data.emplace(context);
 }
 
 template <>

--- a/src/include/duckdb/common/serializer/serialization_traits.hpp
+++ b/src/include/duckdb/common/serializer/serialization_traits.hpp
@@ -24,6 +24,7 @@ const field_id_t MESSAGE_TERMINATOR_FIELD_ID = 0xFFFF;
 template <class...>
 using void_t = void;
 
+// NOLINTBEGIN: match STL case
 // Check for anything implementing a `void Serialize(Serializer &Serializer)` method
 template <typename T, typename = T>
 struct has_serialize : std::false_type {};
@@ -144,6 +145,8 @@ template <typename T>
 struct is_atomic<std::atomic<T>> : std::true_type {
 	typedef T TYPE;
 };
+
+// NOLINTEND
 
 struct SerializationDefaultValue {
 

--- a/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
+++ b/src/include/duckdb/common/sort/duckdb_pdqsort.hpp
@@ -46,6 +46,8 @@ using duckdb::make_unsafe_uniq_array;
 using duckdb::FastMemcpy;
 using duckdb::FastMemcmp;
 
+// NOLINTBEGIN
+
 enum {
 	// Partitions below this size are sorted using insertion sort.
 	insertion_sort_threshold = 24,
@@ -704,5 +706,6 @@ inline void pdqsort_branchless(const PDQIterator &begin, const PDQIterator &end,
 	}
 	pdqsort_loop<true>(begin, end, constants, log2(end - begin));
 }
+// NOLINTEND
 
 } // namespace duckdb_pdqsort

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -148,8 +148,8 @@ public:
 
 	//! Join multiple items of container with given size, transformed to string
 	//! using function, into one string using the given separator
-	template <typename C, typename S, typename Func>
-	static string Join(const C &input, S count, const string &separator, Func f) {
+	template <typename C, typename S, typename FUNC>
+	static string Join(const C &input, S count, const string &separator, FUNC f) {
 		// The result
 		std::string result;
 
@@ -188,8 +188,8 @@ public:
 	DUCKDB_API static bool CILessThan(const string &l1, const string &l2);
 
 	//! Format a string using printf semantics
-	template <typename... Args>
-	static string Format(const string fmt_str, Args... params) {
+	template <typename... ARGS>
+	static string Format(const string fmt_str, ARGS... params) {
 		return Exception::ConstructMessage(fmt_str, params...);
 	}
 

--- a/src/include/duckdb/common/tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer.hpp
@@ -39,36 +39,36 @@ public:
 };
 
 struct TreeRendererConfig {
-	void enable_detailed() {
-		MAX_EXTRA_LINES = 1000;
+	void EnableDetailed() {
+		max_extra_lines = 1000;
 		detailed = true;
 	}
 
-	void enable_standard() {
-		MAX_EXTRA_LINES = 30;
+	void EnableStandard() {
+		max_extra_lines = 30;
 		detailed = false;
 	}
 
-	idx_t MAXIMUM_RENDER_WIDTH = 240;
-	idx_t NODE_RENDER_WIDTH = 29;
-	idx_t MINIMUM_RENDER_WIDTH = 15;
-	idx_t MAX_EXTRA_LINES = 30;
+	idx_t maximum_render_width = 240;
+	idx_t node_render_width = 29;
+	idx_t minimum_render_width = 15;
+	idx_t max_extra_lines = 30;
 	bool detailed = false;
 
 #ifndef DUCKDB_ASCII_TREE_RENDERER
-	const char *LTCORNER = "\342\224\214"; // "┌";
-	const char *RTCORNER = "\342\224\220"; // "┐";
-	const char *LDCORNER = "\342\224\224"; // "└";
-	const char *RDCORNER = "\342\224\230"; // "┘";
+	const char *LTCORNER = "\342\224\214"; // NOLINT "┌";
+	const char *RTCORNER = "\342\224\220"; // NOLINT "┐";
+	const char *LDCORNER = "\342\224\224"; // NOLINT "└";
+	const char *RDCORNER = "\342\224\230"; // NOLINT "┘";
 
-	const char *MIDDLE = "\342\224\274";  // "┼";
-	const char *TMIDDLE = "\342\224\254"; // "┬";
-	const char *LMIDDLE = "\342\224\234"; // "├";
-	const char *RMIDDLE = "\342\224\244"; // "┤";
-	const char *DMIDDLE = "\342\224\264"; // "┴";
+	const char *MIDDLE = "\342\224\274";  // NOLINT "┼";
+	const char *TMIDDLE = "\342\224\254"; // NOLINT "┬";
+	const char *LMIDDLE = "\342\224\234"; // NOLINT "├";
+	const char *RMIDDLE = "\342\224\244"; // NOLINT "┤";
+	const char *DMIDDLE = "\342\224\264"; // NOLINT "┴";
 
-	const char *VERTICAL = "\342\224\202";   // "│";
-	const char *HORIZONTAL = "\342\224\200"; // "─";
+	const char *VERTICAL = "\342\224\202";   // NOLINT "│";
+	const char *HORIZONTAL = "\342\224\200"; // NOLINT "─";
 #else
 	// ASCII version
 	const char *LTCORNER = "<";
@@ -89,7 +89,7 @@ struct TreeRendererConfig {
 
 class TreeRenderer {
 public:
-	explicit TreeRenderer(TreeRendererConfig config_p = TreeRendererConfig()) : config(std::move(config_p)) {
+	explicit TreeRenderer(TreeRendererConfig config_p = TreeRendererConfig()) : config(config_p) {
 	}
 
 	string ToString(const LogicalOperator &op);
@@ -105,10 +105,10 @@ public:
 	void ToStream(RenderTree &root, std::ostream &ss);
 
 	void EnableDetailed() {
-		config.enable_detailed();
+		config.EnableDetailed();
 	}
 	void EnableStandard() {
-		config.enable_standard();
+		config.EnableStandard();
 	}
 
 private:

--- a/src/include/duckdb/common/typedefs.hpp
+++ b/src/include/duckdb/common/typedefs.hpp
@@ -37,27 +37,27 @@ typedef idx_t column_t;
 typedef idx_t storage_t;
 
 template <class SRC>
-data_ptr_t data_ptr_cast(SRC *src) {
+data_ptr_t data_ptr_cast(SRC *src) { // NOLINT: naming
 	return reinterpret_cast<data_ptr_t>(src);
 }
 
 template <class SRC>
-const_data_ptr_t const_data_ptr_cast(const SRC *src) {
+const_data_ptr_t const_data_ptr_cast(const SRC *src) { // NOLINT: naming
 	return reinterpret_cast<const_data_ptr_t>(src);
 }
 
 template <class SRC>
-char *char_ptr_cast(SRC *src) {
+char *char_ptr_cast(SRC *src) { // NOLINT: naming
 	return reinterpret_cast<char *>(src);
 }
 
 template <class SRC>
-const char *const_char_ptr_cast(const SRC *src) {
+const char *const_char_ptr_cast(const SRC *src) { // NOLINT: naming
 	return reinterpret_cast<const char *>(src);
 }
 
 template <class SRC>
-const unsigned char *const_uchar_ptr_cast(const SRC *src) {
+const unsigned char *const_uchar_ptr_cast(const SRC *src) { // NOLINT: naming
 	return reinterpret_cast<const unsigned char *>(src);
 }
 

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -523,6 +523,7 @@ bool ApproxEqual(double l, double r);
 struct aggregate_state_t {
 	aggregate_state_t() {
 	}
+	// NOLINTNEXTLINE: work around bug in clang-tidy
 	aggregate_state_t(string function_name_p, LogicalType return_type_p, vector<LogicalType> bound_argument_types_p)
 	    : function_name(std::move(function_name_p)), return_type(std::move(return_type_p)),
 	      bound_argument_types(std::move(bound_argument_types_p)) {

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -24,7 +24,7 @@ class TypeCatalogEntry;
 class Vector;
 class ClientContext;
 
-struct string_t;
+struct string_t; // NOLINT: mimic std casing
 
 template <class T>
 using child_list_t = vector<std::pair<std::string, T>>;
@@ -32,12 +32,12 @@ using child_list_t = vector<std::pair<std::string, T>>;
 template <class T>
 using buffer_ptr = shared_ptr<T>;
 
-template <class T, typename... Args>
-buffer_ptr<T> make_buffer(Args &&...args) {
-	return make_shared<T>(std::forward<Args>(args)...);
+template <class T, typename... ARGS>
+buffer_ptr<T> make_buffer(ARGS &&...args) { // NOLINT: mimic std casing
+	return make_shared<T>(std::forward<ARGS>(args)...);
 }
 
-struct list_entry_t {
+struct list_entry_t { // NOLINT: mimic std casing
 	list_entry_t() = default;
 	list_entry_t(uint64_t offset, uint64_t length) : offset(offset), length(length) {
 	}
@@ -234,7 +234,7 @@ enum class LogicalTypeId : uint8_t {
 
 struct ExtraTypeInfo;
 
-struct aggregate_state_t;
+struct aggregate_state_t; // NOLINT: mimic std casing
 
 struct LogicalType {
 	DUCKDB_API LogicalType();
@@ -245,7 +245,7 @@ struct LogicalType {
 
 	DUCKDB_API ~LogicalType();
 
-	inline LogicalTypeId id() const {
+	inline LogicalTypeId id() const { // NOLINT: mimic std casing
 		return id_;
 	}
 	inline PhysicalType InternalType() const {
@@ -279,6 +279,9 @@ struct LogicalType {
 
 	// copy assignment
 	inline LogicalType &operator=(const LogicalType &other) {
+		if (this == &other) {
+			return *this;
+		}
 		id_ = other.id_;
 		physical_type_ = other.physical_type_;
 		type_info_ = other.type_info_;
@@ -337,9 +340,9 @@ struct LogicalType {
 	bool Contains(LogicalTypeId type_id) const;
 
 private:
-	LogicalTypeId id_;
-	PhysicalType physical_type_;
-	shared_ptr<ExtraTypeInfo> type_info_;
+	LogicalTypeId id_; // NOLINT: allow this naming for legacy reasons
+	PhysicalType physical_type_; // NOLINT: allow this naming for legacy reasons
+	shared_ptr<ExtraTypeInfo> type_info_; // NOLINT: allow this naming for legacy reasons
 
 private:
 	PhysicalType GetInternalType();

--- a/src/include/duckdb/common/types/cast_helpers.hpp
+++ b/src/include/duckdb/common/types/cast_helpers.hpp
@@ -356,8 +356,7 @@ struct UhugeintToStringCast {
 		string_t result = StringVector::EmptyString(vector, str.length());
 		auto data = result.GetDataWriteable();
 
-		// null-termination not required
-		memcpy(data, str.data(), str.length());
+		memcpy(data, str.data(), str.length()); // NOLINT: null-termination not required
 		result.Finalize();
 		return result;
 	}

--- a/src/include/duckdb/common/types/column/column_data_collection.hpp
+++ b/src/include/duckdb/common/types/column/column_data_collection.hpp
@@ -28,7 +28,7 @@ public:
 	//! Constructs an in-memory column data collection from an allocator
 	DUCKDB_API ColumnDataCollection(Allocator &allocator, vector<LogicalType> types);
 	//! Constructs an empty (but valid) in-memory column data collection from an allocator
-	DUCKDB_API ColumnDataCollection(Allocator &allocator);
+	DUCKDB_API explicit ColumnDataCollection(Allocator &allocator);
 	//! Constructs a buffer-managed column data collection
 	DUCKDB_API ColumnDataCollection(BufferManager &buffer_manager, vector<LogicalType> types);
 	//! Constructs either an in-memory or a buffer-managed column data collection
@@ -183,39 +183,39 @@ private:
 //! The ColumnDataRowCollection represents a set of materialized rows, as obtained from the ColumnDataCollection
 class ColumnDataRowCollection {
 public:
-	DUCKDB_API ColumnDataRowCollection(const ColumnDataCollection &collection);
+	DUCKDB_API explicit ColumnDataRowCollection(const ColumnDataCollection &collection);
 
 public:
 	DUCKDB_API Value GetValue(idx_t column, idx_t index) const;
 
 public:
 	// container API
-	bool empty() const {
+	bool empty() const { // NOLINT: match stl API
 		return rows.empty();
 	}
-	idx_t size() const {
+	idx_t size() const { // NOLINT: match stl API
 		return rows.size();
 	}
 
 	DUCKDB_API ColumnDataRow &operator[](idx_t i);
 	DUCKDB_API const ColumnDataRow &operator[](idx_t i) const;
 
-	vector<ColumnDataRow>::iterator begin() {
+	vector<ColumnDataRow>::iterator begin() { // NOLINT: match stl API
 		return rows.begin();
 	}
-	vector<ColumnDataRow>::iterator end() {
+	vector<ColumnDataRow>::iterator end() { // NOLINT: match stl API
 		return rows.end();
 	}
-	vector<ColumnDataRow>::const_iterator cbegin() const {
+	vector<ColumnDataRow>::const_iterator cbegin() const { // NOLINT: match stl API
 		return rows.cbegin();
 	}
-	vector<ColumnDataRow>::const_iterator cend() const {
+	vector<ColumnDataRow>::const_iterator cend() const { // NOLINT: match stl API
 		return rows.cend();
 	}
-	vector<ColumnDataRow>::const_iterator begin() const {
+	vector<ColumnDataRow>::const_iterator begin() const { // NOLINT: match stl API
 		return rows.begin();
 	}
-	vector<ColumnDataRow>::const_iterator end() const {
+	vector<ColumnDataRow>::const_iterator end() const { // NOLINT: match stl API
 		return rows.end();
 	}
 

--- a/src/include/duckdb/common/types/column/column_data_collection_iterators.hpp
+++ b/src/include/duckdb/common/types/column/column_data_collection_iterators.hpp
@@ -43,17 +43,17 @@ private:
 	};
 
 public:
-	ColumnDataChunkIterator begin() {
+	ColumnDataChunkIterator begin() { // NOLINT: match stl API
 		return ColumnDataChunkIterator(&collection, column_ids);
 	}
-	ColumnDataChunkIterator end() {
+	ColumnDataChunkIterator end() { // NOLINT: match stl API
 		return ColumnDataChunkIterator(nullptr, vector<column_t>());
 	}
 };
 
 class ColumnDataRowIterationHelper {
 public:
-	DUCKDB_API ColumnDataRowIterationHelper(const ColumnDataCollection &collection);
+	DUCKDB_API explicit ColumnDataRowIterationHelper(const ColumnDataCollection &collection);
 
 private:
 	const ColumnDataCollection &collection;
@@ -79,8 +79,8 @@ private:
 	};
 
 public:
-	DUCKDB_API ColumnDataRowIterator begin();
-	DUCKDB_API ColumnDataRowIterator end();
+	DUCKDB_API ColumnDataRowIterator begin(); // NOLINT: match stl API
+	DUCKDB_API ColumnDataRowIterator end(); // NOLINT: match stl API
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/column/column_data_collection_iterators.hpp
+++ b/src/include/duckdb/common/types/column/column_data_collection_iterators.hpp
@@ -80,7 +80,7 @@ private:
 
 public:
 	DUCKDB_API ColumnDataRowIterator begin(); // NOLINT: match stl API
-	DUCKDB_API ColumnDataRowIterator end(); // NOLINT: match stl API
+	DUCKDB_API ColumnDataRowIterator end();   // NOLINT: match stl API
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/types/constraint_conflict_info.hpp
+++ b/src/include/duckdb/common/types/constraint_conflict_info.hpp
@@ -11,14 +11,13 @@ class Index;
 
 class ConflictInfo {
 public:
-	ConflictInfo(const unordered_set<column_t> &column_ids, bool only_check_unique = true)
+	explicit ConflictInfo(const unordered_set<column_t> &column_ids, bool only_check_unique = true)
 	    : column_ids(column_ids), only_check_unique(only_check_unique) {
 	}
 	const unordered_set<column_t> &column_ids;
 
 public:
 	bool ConflictTargetMatches(Index &index) const;
-	void VerifyAllConflictsMeetCondition() const;
 
 public:
 	bool only_check_unique = true;

--- a/src/include/duckdb/common/types/date.hpp
+++ b/src/include/duckdb/common/types/date.hpp
@@ -18,7 +18,7 @@
 
 namespace duckdb {
 
-struct timestamp_t;
+struct timestamp_t; // NOLINT: primitive case
 
 //! Type used to represent dates (days since 1970-01-01)
 struct date_t { // NOLINT

--- a/src/include/duckdb/common/types/hash.hpp
+++ b/src/include/duckdb/common/types/hash.hpp
@@ -14,13 +14,13 @@
 namespace duckdb {
 
 struct string_t;
-struct interval_t;
+struct interval_t; // NOLINT
 
 // efficient hash function that maximizes the avalanche effect and minimizes
 // bias
 // see: https://nullprogram.com/blog/2018/07/31/
 
-inline hash_t murmurhash64(uint64_t x) {
+inline hash_t MurmurHash64(uint64_t x) {
 	x ^= x >> 32;
 	x *= 0xd6e8feb86659fd93U;
 	x ^= x >> 32;
@@ -29,13 +29,13 @@ inline hash_t murmurhash64(uint64_t x) {
 	return x;
 }
 
-inline hash_t murmurhash32(uint32_t x) {
-	return murmurhash64(x);
+inline hash_t MurmurHash32(uint32_t x) {
+	return MurmurHash64(x);
 }
 
 template <class T>
 hash_t Hash(T value) {
-	return murmurhash32(value);
+	return MurmurHash32(value);
 }
 
 //! Combine two hashes by XORing them

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -13,7 +13,7 @@
 #include "hyperloglog.hpp"
 
 namespace duckdb_hll {
-struct robj;
+struct robj; // NOLINT
 }
 
 namespace duckdb {

--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -12,9 +12,9 @@
 
 namespace duckdb {
 
-struct dtime_t; // NOLINT: literal casing
-struct date_t; // NOLINT: literal casing
-struct dtime_tz_t; // NOLINT: literal casing
+struct dtime_t;     // NOLINT: literal casing
+struct date_t;      // NOLINT: literal casing
+struct dtime_tz_t;  // NOLINT: literal casing
 struct timestamp_t; // NOLINT: literal casing
 
 class Serializer;

--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -12,10 +12,10 @@
 
 namespace duckdb {
 
-struct dtime_t;
-struct date_t;
-struct dtime_tz_t;
-struct timestamp_t;
+struct dtime_t; // NOLINT: literal casing
+struct date_t; // NOLINT: literal casing
+struct dtime_tz_t; // NOLINT: literal casing
+struct timestamp_t; // NOLINT: literal casing
 
 class Serializer;
 class Deserializer;

--- a/src/include/duckdb/common/types/row/tuple_data_segment.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_segment.hpp
@@ -22,7 +22,7 @@ class TupleDataLayout;
 
 struct TupleDataChunkPart {
 public:
-	TupleDataChunkPart(mutex &lock);
+	explicit TupleDataChunkPart(mutex &lock);
 
 	//! Disable copy constructors
 	TupleDataChunkPart(const TupleDataChunkPart &other) = delete;

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -43,7 +43,7 @@ struct SelectionVector {
 	explicit SelectionVector(buffer_ptr<SelectionData> data) {
 		Initialize(std::move(data));
 	}
-	SelectionVector &operator=(SelectionVector &&other) {
+	SelectionVector &operator=(SelectionVector &&other) noexcept {
 		sel_vector = other.sel_vector;
 		other.sel_vector = nullptr;
 		selection_data = std::move(other.selection_data);
@@ -83,24 +83,24 @@ public:
 		sel_vector = other.sel_vector;
 	}
 
-	inline void set_index(idx_t idx, idx_t loc) {
+	inline void set_index(idx_t idx, idx_t loc) { // NOLINT: allow casing for legacy reasons
 		sel_vector[idx] = UnsafeNumericCast<sel_t>(loc);
 	}
-	inline void swap(idx_t i, idx_t j) {
+	inline void swap(idx_t i, idx_t j) { // NOLINT: allow casing for legacy reasons
 		sel_t tmp = sel_vector[i];
 		sel_vector[i] = sel_vector[j];
 		sel_vector[j] = tmp;
 	}
-	inline idx_t get_index(idx_t idx) const {
+	inline idx_t get_index(idx_t idx) const { // NOLINT: allow casing for legacy reasons
 		return sel_vector ? sel_vector[idx] : idx;
 	}
-	sel_t *data() {
+	sel_t *data() { // NOLINT: allow casing for legacy reasons
 		return sel_vector;
 	}
-	const sel_t *data() const {
+	const sel_t *data() const { // NOLINT: allow casing for legacy reasons
 		return sel_vector;
 	}
-	buffer_ptr<SelectionData> sel_data() {
+	buffer_ptr<SelectionData> sel_data() { // NOLINT: allow casing for legacy reasons
 		return selection_data;
 	}
 	buffer_ptr<SelectionData> Slice(const SelectionVector &sel, idx_t count) const;
@@ -119,7 +119,7 @@ private:
 
 class OptionalSelection {
 public:
-	explicit inline OptionalSelection(SelectionVector *sel_p) {
+	inline OptionalSelection(SelectionVector *sel_p) {
 		Initialize(sel_p);
 	}
 	void Initialize(SelectionVector *sel_p) {
@@ -169,10 +169,10 @@ public:
 	bool Initialized() const {
 		return initialized;
 	}
-	void Initialize(idx_t size) {
+	void Initialize(idx_t new_size) {
 		D_ASSERT(!initialized);
-		this->size = size;
-		sel_vec.Initialize(size);
+		this->size = new_size;
+		sel_vec.Initialize(new_size);
 		internal_opt_selvec.Initialize(&sel_vec);
 		initialized = true;
 	}

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -119,7 +119,7 @@ private:
 
 class OptionalSelection {
 public:
-	inline OptionalSelection(SelectionVector *sel_p) {
+	explicit OptionalSelection(SelectionVector *sel_p) {
 		Initialize(sel_p);
 	}
 	void Initialize(SelectionVector *sel_p) {
@@ -130,7 +130,7 @@ public:
 		}
 	}
 
-	inline operator SelectionVector *() {
+	inline operator SelectionVector *() { // NOLINT: allow implicit conversion to SelectionVector
 		return sel;
 	}
 

--- a/src/include/duckdb/common/types/string_heap.hpp
+++ b/src/include/duckdb/common/types/string_heap.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 //! returned pointer will remain valid until the StringHeap is destroyed
 class StringHeap {
 public:
-	DUCKDB_API StringHeap(Allocator &allocator = Allocator::DefaultAllocator());
+	DUCKDB_API explicit StringHeap(Allocator &allocator = Allocator::DefaultAllocator());
 
 	DUCKDB_API void Destroy();
 	DUCKDB_API void Move(StringHeap &other);

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -60,10 +60,10 @@ public:
 		}
 	}
 
-	string_t(const char *data)  // NOLINT: Allow implicit conversion from `const char*`
+	string_t(const char *data) // NOLINT: Allow implicit conversion from `const char*`
 	    : string_t(data, UnsafeNumericCast<uint32_t>(strlen(data))) {
 	}
-	string_t(const string &value)  // NOLINT: Allow implicit conversion from `const char*`
+	string_t(const string &value) // NOLINT: Allow implicit conversion from `const char*`
 	    : string_t(value.c_str(), UnsafeNumericCast<uint32_t>(value.size())) {
 	}
 

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -60,13 +60,11 @@ public:
 		}
 	}
 
-	string_t(const char *data)
-	    : string_t(data,
-	               UnsafeNumericCast<uint32_t>(strlen(data))) { // NOLINT: Allow implicit conversion from `const char*`
+	string_t(const char *data)  // NOLINT: Allow implicit conversion from `const char*`
+	    : string_t(data, UnsafeNumericCast<uint32_t>(strlen(data))) {
 	}
-	string_t(const string &value)
-	    : string_t(value.c_str(),
-	               UnsafeNumericCast<uint32_t>(value.size())) { // NOLINT: Allow implicit conversion from `const char*`
+	string_t(const string &value)  // NOLINT: Allow implicit conversion from `const char*`
+	    : string_t(value.c_str(), UnsafeNumericCast<uint32_t>(value.size())) {
 	}
 
 	bool IsInlined() const {
@@ -88,8 +86,8 @@ public:
 		return value.inlined.inlined;
 	}
 
-	char *GetPrefixWriteable() const {
-		return (char *)value.inlined.inlined;
+	char *GetPrefixWriteable() {
+		return value.inlined.inlined;
 	}
 
 	idx_t GetSize() const {
@@ -142,20 +140,21 @@ public:
 	struct StringComparisonOperators {
 		static inline bool Equals(const string_t &a, const string_t &b) {
 #ifdef DUCKDB_DEBUG_NO_INLINE
-			if (a.GetSize() != b.GetSize())
+			if (a.GetSize() != b.GetSize()) {
 				return false;
+			}
 			return (memcmp(a.GetData(), b.GetData(), a.GetSize()) == 0);
 #endif
-			uint64_t A = Load<uint64_t>(const_data_ptr_cast(&a));
-			uint64_t B = Load<uint64_t>(const_data_ptr_cast(&b));
-			if (A != B) {
+			uint64_t a_bulk_comp = Load<uint64_t>(const_data_ptr_cast(&a));
+			uint64_t b_bulk_comp = Load<uint64_t>(const_data_ptr_cast(&b));
+			if (a_bulk_comp != b_bulk_comp) {
 				// Either length or prefix are different -> not equal
 				return false;
 			}
 			// they have the same length and same prefix!
-			A = Load<uint64_t>(const_data_ptr_cast(&a) + 8u);
-			B = Load<uint64_t>(const_data_ptr_cast(&b) + 8u);
-			if (A == B) {
+			a_bulk_comp = Load<uint64_t>(const_data_ptr_cast(&a) + 8u);
+			b_bulk_comp = Load<uint64_t>(const_data_ptr_cast(&b) + 8u);
+			if (a_bulk_comp == b_bulk_comp) {
 				// either they are both inlined (so compare equal) or point to the same string (so compare equal)
 				return true;
 			}
@@ -177,11 +176,11 @@ public:
 			const uint32_t min_length = std::min<uint32_t>(left_length, right_length);
 
 #ifndef DUCKDB_DEBUG_NO_INLINE
-			uint32_t A = Load<uint32_t>(const_data_ptr_cast(left.GetPrefix()));
-			uint32_t B = Load<uint32_t>(const_data_ptr_cast(right.GetPrefix()));
+			uint32_t a_prefix = Load<uint32_t>(const_data_ptr_cast(left.GetPrefix()));
+			uint32_t b_prefix = Load<uint32_t>(const_data_ptr_cast(right.GetPrefix()));
 
 			// Utility to move 0xa1b2c3d4 into 0xd4c3b2a1, basically inverting the order byte-a-byte
-			auto bswap = [](uint32_t v) -> uint32_t {
+			auto byte_swap = [](uint32_t v) -> uint32_t {
 				uint32_t t1 = (v >> 16u) | (v << 16u);
 				uint32_t t2 = t1 & 0x00ff00ff;
 				uint32_t t3 = t1 & 0xff00ff00;
@@ -194,8 +193,9 @@ public:
 			// 	if the prefix is smaller(after bswap), it will stay smaller regardless of the extra bytes
 			//	if the prefix is equal, the extra bytes are guaranteed to be /0 for the shorter one
 
-			if (A != B)
-				return bswap(A) > bswap(B);
+			if (a_prefix != b_prefix) {
+				return byte_swap(a_prefix) > byte_swap(b_prefix);
+			}
 #endif
 			auto memcmp_res = memcmp(left.GetData(), right.GetData(), min_length);
 			return memcmp_res > 0 || (memcmp_res == 0 && left_length > right_length);

--- a/src/include/duckdb/common/types/time.hpp
+++ b/src/include/duckdb/common/types/time.hpp
@@ -14,8 +14,8 @@
 
 namespace duckdb {
 
-struct dtime_t;
-struct dtime_tz_t;
+struct dtime_t; // NOLINT
+struct dtime_tz_t; // NOLINT
 
 //! The Time class is a static class that holds helper functions for the Time
 //! type.

--- a/src/include/duckdb/common/types/time.hpp
+++ b/src/include/duckdb/common/types/time.hpp
@@ -14,7 +14,7 @@
 
 namespace duckdb {
 
-struct dtime_t; // NOLINT
+struct dtime_t;    // NOLINT
 struct dtime_tz_t; // NOLINT
 
 //! The Time class is a static class that holds helper functions for the Time

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -18,9 +18,9 @@
 
 namespace duckdb {
 
-struct date_t;  // NOLINT
-struct dtime_t;  // NOLINT
-struct dtime_tz_t;  // NOLINT
+struct date_t;     // NOLINT
+struct dtime_t;    // NOLINT
+struct dtime_tz_t; // NOLINT
 
 //! Type used to represent timestamps (seconds,microseconds,milliseconds or nanoseconds since 1970-01-01)
 struct timestamp_t { // NOLINT

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -18,9 +18,9 @@
 
 namespace duckdb {
 
-struct date_t;
-struct dtime_t;
-struct dtime_tz_t;
+struct date_t;  // NOLINT
+struct dtime_t;  // NOLINT
+struct dtime_tz_t;  // NOLINT
 
 //! Type used to represent timestamps (seconds,microseconds,milliseconds or nanoseconds since 1970-01-01)
 struct timestamp_t { // NOLINT

--- a/src/include/duckdb/common/types/uuid.hpp
+++ b/src/include/duckdb/common/types/uuid.hpp
@@ -20,7 +20,7 @@ class UUID {
 public:
 	constexpr static const uint8_t STRING_SIZE = 36;
 	//! Convert a uuid string to a hugeint object
-	static bool FromString(string str, hugeint_t &result);
+	static bool FromString(const string &str, hugeint_t &result);
 	//! Convert a uuid string to a hugeint object
 	static bool FromCString(const char *str, idx_t len, hugeint_t &result) {
 		return FromString(string(str, 0, len), result);
@@ -42,7 +42,7 @@ public:
 		return string(buff, STRING_SIZE);
 	}
 
-	static hugeint_t FromString(string str) {
+	static hugeint_t FromString(const string &str) {
 		hugeint_t result;
 		FromString(str, result);
 		return result;

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -197,7 +197,7 @@ public:
 	T GetValue() const;
 	template <class T>
 	static Value CreateValue(T value) {
-		static_assert(AlwaysFalse<T>::value, "No specialization exists for this type");
+		static_assert(AlwaysFalse<T>::VALUE, "No specialization exists for this type");
 		return Value(nullptr);
 	}
 	// Returns the internal value. Unlike GetValue(), this method does not perform casting, and assumes T matches the

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -191,7 +191,7 @@ public:
 	DUCKDB_API static Value BIT(const string &data);
 
 	//! Creates an aggregate state
-	DUCKDB_API static Value AGGREGATE_STATE(const LogicalType &type, const_data_ptr_t data, idx_t len);
+	DUCKDB_API static Value AGGREGATE_STATE(const LogicalType &type, const_data_ptr_t data, idx_t len); // NOLINT
 
 	template <class T>
 	T GetValue() const;

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -291,19 +291,19 @@ struct ConstantVector {
 struct DictionaryVector {
 	static inline const SelectionVector &SelVector(const Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::DICTIONARY_VECTOR);
-		return ((const DictionaryBuffer &)*vector.buffer).GetSelVector();
+		return vector.buffer->Cast<DictionaryBuffer>().GetSelVector();
 	}
 	static inline SelectionVector &SelVector(Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::DICTIONARY_VECTOR);
-		return ((DictionaryBuffer &)*vector.buffer).GetSelVector();
+		return vector.buffer->Cast<DictionaryBuffer>().GetSelVector();
 	}
 	static inline const Vector &Child(const Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::DICTIONARY_VECTOR);
-		return ((const VectorChildBuffer &)*vector.auxiliary).data;
+		return vector.auxiliary->Cast<VectorChildBuffer>().data;
 	}
 	static inline Vector &Child(Vector &vector) {
 		D_ASSERT(vector.GetVectorType() == VectorType::DICTIONARY_VECTOR);
-		return ((VectorChildBuffer &)*vector.auxiliary).data;
+		return vector.auxiliary->Cast<VectorChildBuffer>().data;
 	}
 };
 
@@ -552,7 +552,7 @@ struct UnionVector {
 struct SequenceVector {
 	static void GetSequence(const Vector &vector, int64_t &start, int64_t &increment, int64_t &sequence_count) {
 		D_ASSERT(vector.GetVectorType() == VectorType::SEQUENCE_VECTOR);
-		auto data = (int64_t *)vector.buffer->GetData();
+		auto data = reinterpret_cast<int64_t *>(vector.buffer->GetData());
 		start = data[0];
 		increment = data[1];
 		sequence_count = data[2];

--- a/src/include/duckdb/common/uhugeint.hpp
+++ b/src/include/duckdb/common/uhugeint.hpp
@@ -7,9 +7,9 @@
 namespace duckdb {
 
 // Forward declaration to allow conversion between hugeint and uhugeint
-struct hugeint_t;
+struct hugeint_t; // NOLINT
 
-struct uhugeint_t {
+struct uhugeint_t { // NOLINT
 public:
 	uint64_t lower;
 	uint64_t upper;

--- a/src/include/duckdb/common/union_by_name.hpp
+++ b/src/include/duckdb/common/union_by_name.hpp
@@ -29,7 +29,7 @@ public:
 		vector<unique_ptr<READER_TYPE>> union_readers;
 		case_insensitive_map_t<idx_t> union_names_map;
 		for (idx_t file_idx = 0; file_idx < files.size(); ++file_idx) {
-			const auto file_name = files[file_idx];
+			const auto &file_name = files[file_idx];
 			auto reader = make_uniq<READER_TYPE>(context, file_name, options);
 
 			auto &col_names = reader->GetNames();

--- a/src/include/duckdb/common/unique_ptr.hpp
+++ b/src/include/duckdb/common/unique_ptr.hpp
@@ -54,7 +54,8 @@ public:
 };
 
 template <class DATA_TYPE, class ALLOCATOR_TYPE, bool SAFE>
-class unique_ptr<DATA_TYPE[], ALLOCATOR_TYPE, SAFE> : public std::unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>> {
+class unique_ptr<DATA_TYPE[], ALLOCATOR_TYPE, SAFE>
+    : public std::unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>> {
 public:
 	using original = std::unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>>;
 	using original::original;

--- a/src/include/duckdb/common/unique_ptr.hpp
+++ b/src/include/duckdb/common/unique_ptr.hpp
@@ -29,7 +29,7 @@ private:
 public:
 	typename std::add_lvalue_reference<_Tp>::type operator*() const {
 		const auto ptr = original::get();
-		if (MemorySafety<SAFE>::enabled) {
+		if (MemorySafety<SAFE>::ENABLED) {
 			AssertNotNull(!ptr);
 		}
 		return *ptr;
@@ -37,7 +37,7 @@ public:
 
 	typename original::pointer operator->() const {
 		const auto ptr = original::get();
-		if (MemorySafety<SAFE>::enabled) {
+		if (MemorySafety<SAFE>::ENABLED) {
 			AssertNotNull(!ptr);
 		}
 		return ptr;
@@ -73,7 +73,7 @@ private:
 public:
 	typename std::add_lvalue_reference<_Tp>::type operator[](size_t __i) const {
 		const auto ptr = original::get();
-		if (MemorySafety<SAFE>::enabled) {
+		if (MemorySafety<SAFE>::ENABLED) {
 			AssertNotNull(!ptr);
 		}
 		return ptr[__i];

--- a/src/include/duckdb/common/unique_ptr.hpp
+++ b/src/include/duckdb/common/unique_ptr.hpp
@@ -9,10 +9,10 @@
 
 namespace duckdb {
 
-template <class _Tp, class _Dp = std::default_delete<_Tp>, bool SAFE = true>
-class unique_ptr : public std::unique_ptr<_Tp, _Dp> {
+template <class DATA_TYPE, class ALLOCATOR_TYPE = std::default_delete<DATA_TYPE>, bool SAFE = true>
+class unique_ptr : public std::unique_ptr<DATA_TYPE, ALLOCATOR_TYPE> { // NOLINT: naming
 public:
-	using original = std::unique_ptr<_Tp, _Dp>;
+	using original = std::unique_ptr<DATA_TYPE, ALLOCATOR_TYPE>;
 	using original::original;
 
 private:
@@ -27,7 +27,7 @@ private:
 	}
 
 public:
-	typename std::add_lvalue_reference<_Tp>::type operator*() const {
+	typename std::add_lvalue_reference<DATA_TYPE>::type operator*() const { // NOLINT: hiding on purpose
 		const auto ptr = original::get();
 		if (MemorySafety<SAFE>::ENABLED) {
 			AssertNotNull(!ptr);
@@ -35,7 +35,7 @@ public:
 		return *ptr;
 	}
 
-	typename original::pointer operator->() const {
+	typename original::pointer operator->() const { // NOLINT: hiding on purpose
 		const auto ptr = original::get();
 		if (MemorySafety<SAFE>::ENABLED) {
 			AssertNotNull(!ptr);
@@ -48,15 +48,15 @@ public:
 	[[clang::reinitializes]]
 #endif
 	inline void
-	reset(typename original::pointer ptr = typename original::pointer()) noexcept {
+	reset(typename original::pointer ptr = typename original::pointer()) noexcept { // NOLINT: hiding on purpose
 		original::reset(ptr);
 	}
 };
 
-template <class _Tp, class _Dp, bool SAFE>
-class unique_ptr<_Tp[], _Dp, SAFE> : public std::unique_ptr<_Tp[], std::default_delete<_Tp[]>> {
+template <class DATA_TYPE, class ALLOCATOR_TYPE, bool SAFE>
+class unique_ptr<DATA_TYPE[], ALLOCATOR_TYPE, SAFE> : public std::unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>> {
 public:
-	using original = std::unique_ptr<_Tp[], std::default_delete<_Tp[]>>;
+	using original = std::unique_ptr<DATA_TYPE[], std::default_delete<DATA_TYPE[]>>;
 	using original::original;
 
 private:
@@ -71,7 +71,7 @@ private:
 	}
 
 public:
-	typename std::add_lvalue_reference<_Tp>::type operator[](size_t __i) const {
+	typename std::add_lvalue_reference<DATA_TYPE>::type operator[](size_t __i) const { // NOLINT: hiding on purpose
 		const auto ptr = original::get();
 		if (MemorySafety<SAFE>::ENABLED) {
 			AssertNotNull(!ptr);

--- a/src/include/duckdb/common/vector.hpp
+++ b/src/include/duckdb/common/vector.hpp
@@ -42,7 +42,8 @@ public:
 	// This is necessary to tell clang-tidy that it reinitializes the variable after a move
 	[[clang::reinitializes]]
 #endif
-	inline void clear() noexcept { // NOLINT: hiding on purpose
+	inline void
+	clear() noexcept { // NOLINT: hiding on purpose
 		original::clear();
 	}
 

--- a/src/include/duckdb/common/vector.hpp
+++ b/src/include/duckdb/common/vector.hpp
@@ -58,7 +58,7 @@ public:
 
 	template <bool _SAFE = false>
 	inline typename original::reference get(typename original::size_type __n) {
-		if (MemorySafety<_SAFE>::enabled) {
+		if (MemorySafety<_SAFE>::ENABLED) {
 			AssertIndexInBounds(__n, original::size());
 		}
 		return original::operator[](__n);
@@ -66,7 +66,7 @@ public:
 
 	template <bool _SAFE = false>
 	inline typename original::const_reference get(typename original::size_type __n) const {
-		if (MemorySafety<_SAFE>::enabled) {
+		if (MemorySafety<_SAFE>::ENABLED) {
 			AssertIndexInBounds(__n, original::size());
 		}
 		return original::operator[](__n);
@@ -88,14 +88,14 @@ public:
 	}
 
 	typename original::reference back() {
-		if (MemorySafety<SAFE>::enabled && original::empty()) {
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
 			throw InternalException("'back' called on an empty vector!");
 		}
 		return get<SAFE>(original::size() - 1);
 	}
 
 	typename original::const_reference back() const {
-		if (MemorySafety<SAFE>::enabled && original::empty()) {
+		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
 			throw InternalException("'back' called on an empty vector!");
 		}
 		return get<SAFE>(original::size() - 1);

--- a/src/include/duckdb/common/vector.hpp
+++ b/src/include/duckdb/common/vector.hpp
@@ -17,10 +17,10 @@
 
 namespace duckdb {
 
-template <class _Tp, bool SAFE = true>
-class vector : public std::vector<_Tp, std::allocator<_Tp>> {
+template <class DATA_TYPE, bool SAFE = true>
+class vector : public std::vector<DATA_TYPE, std::allocator<DATA_TYPE>> { // NOLINT: matching name of std
 public:
-	using original = std::vector<_Tp, std::allocator<_Tp>>;
+	using original = std::vector<DATA_TYPE, std::allocator<DATA_TYPE>>;
 	using original::original;
 	using size_type = typename original::size_type;
 	using const_reference = typename original::const_reference;
@@ -42,59 +42,58 @@ public:
 	// This is necessary to tell clang-tidy that it reinitializes the variable after a move
 	[[clang::reinitializes]]
 #endif
-	inline void
-	clear() noexcept {
+	inline void clear() noexcept { // NOLINT: hiding on purpose
 		original::clear();
 	}
 
 	// Because we create the other constructor, the implicitly created constructor
 	// gets deleted, so we have to be explicit
 	vector() = default;
-	vector(original &&other) : original(std::move(other)) {
+	vector(original &&other) : original(std::move(other)) { // NOLINT: allow implicit conversion
 	}
-	template <bool _SAFE>
-	vector(vector<_Tp, _SAFE> &&other) : original(std::move(other)) {
+	template <bool INTERNAL_SAFE>
+	vector(vector<DATA_TYPE, INTERNAL_SAFE> &&other) : original(std::move(other)) { // NOLINT: allow implicit conversion
 	}
 
-	template <bool _SAFE = false>
-	inline typename original::reference get(typename original::size_type __n) {
-		if (MemorySafety<_SAFE>::ENABLED) {
+	template <bool INTERNAL_SAFE = false>
+	inline typename original::reference get(typename original::size_type __n) { // NOLINT: hiding on purpose
+		if (MemorySafety<INTERNAL_SAFE>::ENABLED) {
 			AssertIndexInBounds(__n, original::size());
 		}
 		return original::operator[](__n);
 	}
 
-	template <bool _SAFE = false>
-	inline typename original::const_reference get(typename original::size_type __n) const {
-		if (MemorySafety<_SAFE>::ENABLED) {
+	template <bool INTERNAL_SAFE = false>
+	inline typename original::const_reference get(typename original::size_type __n) const { // NOLINT: hiding on purpose
+		if (MemorySafety<INTERNAL_SAFE>::ENABLED) {
 			AssertIndexInBounds(__n, original::size());
 		}
 		return original::operator[](__n);
 	}
 
-	typename original::reference operator[](typename original::size_type __n) {
+	typename original::reference operator[](typename original::size_type __n) { // NOLINT: hiding on purpose
 		return get<SAFE>(__n);
 	}
-	typename original::const_reference operator[](typename original::size_type __n) const {
+	typename original::const_reference operator[](typename original::size_type __n) const { // NOLINT: hiding on purpose
 		return get<SAFE>(__n);
 	}
 
-	typename original::reference front() {
+	typename original::reference front() { // NOLINT: hiding on purpose
 		return get<SAFE>(0);
 	}
 
-	typename original::const_reference front() const {
+	typename original::const_reference front() const { // NOLINT: hiding on purpose
 		return get<SAFE>(0);
 	}
 
-	typename original::reference back() {
+	typename original::reference back() { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
 			throw InternalException("'back' called on an empty vector!");
 		}
 		return get<SAFE>(original::size() - 1);
 	}
 
-	typename original::const_reference back() const {
+	typename original::const_reference back() const { // NOLINT: hiding on purpose
 		if (MemorySafety<SAFE>::ENABLED && original::empty()) {
 			throw InternalException("'back' called on an empty vector!");
 		}

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -444,6 +444,8 @@ public:
 				op.Right(i, limit);
 				break;
 			case 0x03:
+			default:
+				D_ASSERT(overlap == 0x03);
 				// i ∈ F ∩ P
 				limit = MinValue(right->end, left->end);
 				op.Both(i, limit);

--- a/src/include/duckdb/common/vector_operations/general_cast.hpp
+++ b/src/include/duckdb/common/vector_operations/general_cast.hpp
@@ -24,7 +24,7 @@ struct VectorTryCastData {
 
 struct HandleVectorCastError {
 	template <class RESULT_TYPE>
-	static RESULT_TYPE Operation(string error_message, ValidityMask &mask, idx_t idx, VectorTryCastData &cast_data) {
+	static RESULT_TYPE Operation(const string &error_message, ValidityMask &mask, idx_t idx, VectorTryCastData &cast_data) {
 		HandleCastError::AssignError(error_message, cast_data.parameters);
 		cast_data.all_converted = false;
 		mask.SetInvalid(idx);

--- a/src/include/duckdb/common/vector_operations/general_cast.hpp
+++ b/src/include/duckdb/common/vector_operations/general_cast.hpp
@@ -24,7 +24,8 @@ struct VectorTryCastData {
 
 struct HandleVectorCastError {
 	template <class RESULT_TYPE>
-	static RESULT_TYPE Operation(const string &error_message, ValidityMask &mask, idx_t idx, VectorTryCastData &cast_data) {
+	static RESULT_TYPE Operation(const string &error_message, ValidityMask &mask, idx_t idx,
+	                             VectorTryCastData &cast_data) {
 		HandleCastError::AssignError(error_message, cast_data.parameters);
 		cast_data.all_converted = false;
 		mask.SetInvalid(idx);

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -26,10 +26,9 @@ struct PrimitiveTypeState {
 
 template <class INPUT_TYPE>
 struct PrimitiveType {
-	PrimitiveType() {
+	PrimitiveType()  = default;
+	PrimitiveType(INPUT_TYPE val) : val(val) { // NOLINT: allow implicit cast
 	}
-	PrimitiveType(INPUT_TYPE val) : val(val) {
-	} // NOLINT: allow implicit cast
 
 	INPUT_TYPE val;
 

--- a/src/include/duckdb/common/vector_operations/generic_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/generic_executor.hpp
@@ -26,7 +26,7 @@ struct PrimitiveTypeState {
 
 template <class INPUT_TYPE>
 struct PrimitiveType {
-	PrimitiveType()  = default;
+	PrimitiveType() = default;
 	PrimitiveType(INPUT_TYPE val) : val(val) { // NOLINT: allow implicit cast
 	}
 

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -192,7 +192,8 @@ public:
 
 	template <class INPUT_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(INPUT_TYPE)>>
 	static void Execute(Vector &input, Vector &result, idx_t count, FUNC fun) {
-		ExecuteStandard<INPUT_TYPE, RESULT_TYPE, UnaryLambdaWrapper, FUNC>(input, result, count, reinterpret_cast<void *>(&fun), false);
+		ExecuteStandard<INPUT_TYPE, RESULT_TYPE, UnaryLambdaWrapper, FUNC>(input, result, count,
+		                                                                   reinterpret_cast<void *>(&fun), false);
 	}
 
 	template <class INPUT_TYPE, class RESULT_TYPE, class OP>

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -192,7 +192,7 @@ public:
 
 	template <class INPUT_TYPE, class RESULT_TYPE, class FUNC = std::function<RESULT_TYPE(INPUT_TYPE)>>
 	static void Execute(Vector &input, Vector &result, idx_t count, FUNC fun) {
-		ExecuteStandard<INPUT_TYPE, RESULT_TYPE, UnaryLambdaWrapper, FUNC>(input, result, count, (void *)&fun, false);
+		ExecuteStandard<INPUT_TYPE, RESULT_TYPE, UnaryLambdaWrapper, FUNC>(input, result, count, reinterpret_cast<void *>(&fun), false);
 	}
 
 	template <class INPUT_TYPE, class RESULT_TYPE, class OP>

--- a/src/include/duckdb/common/vector_operations/unary_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/unary_executor.hpp
@@ -50,7 +50,7 @@ template <class OP>
 struct UnaryStringOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
-		auto vector = (Vector *)dataptr;
+		auto vector = reinterpret_cast<Vector *>(dataptr);
 		return OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, *vector);
 	}
 };

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -53,7 +53,7 @@ public:
 	bool IsPipe(const string &filename) override;
 	void RemoveFile(const string &filename) override;
 
-	virtual vector<string> Glob(const string &path, FileOpener *opener = nullptr) override;
+	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override;
 
 	void RegisterSubSystem(unique_ptr<FileSystem> fs) override;
 

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -29,7 +29,7 @@ struct FlushMoveState;
    stores them in the HT. It uses linear probing for collision resolution.
 */
 
-struct aggr_ht_entry_t {
+struct aggr_ht_entry_t { // NOLINT
 public:
 	explicit aggr_ht_entry_t(hash_t value_p) : value(value_p) {
 	}

--- a/src/include/duckdb/execution/column_binding_resolver.hpp
+++ b/src/include/duckdb/execution/column_binding_resolver.hpp
@@ -19,7 +19,7 @@ namespace duckdb {
 //! are used within the execution engine
 class ColumnBindingResolver : public LogicalOperatorVisitor {
 public:
-	ColumnBindingResolver(bool verify_only = false);
+	explicit ColumnBindingResolver(bool verify_only = false);
 
 	void VisitOperator(LogicalOperator &op) override;
 	static void Verify(LogicalOperator &op);

--- a/src/include/duckdb/execution/expression_executor.hpp
+++ b/src/include/duckdb/execution/expression_executor.hpp
@@ -158,6 +158,6 @@ private:
 private:
 	// it is possible to create an expression executor without a ClientContext - but it should be avoided
 	DUCKDB_API ExpressionExecutor();
-	DUCKDB_API ExpressionExecutor(const vector<unique_ptr<Expression>> &exprs);
+	DUCKDB_API explicit ExpressionExecutor(const vector<unique_ptr<Expression>> &exprs);
 };
 } // namespace duckdb

--- a/src/include/duckdb/execution/expression_executor_state.hpp
+++ b/src/include/duckdb/execution/expression_executor_state.hpp
@@ -53,7 +53,7 @@ public:
 
 struct ExecuteFunctionState : public ExpressionState {
 	ExecuteFunctionState(const Expression &expr, ExpressionExecutorState &root);
-	~ExecuteFunctionState();
+	~ExecuteFunctionState() override;
 
 	unique_ptr<FunctionLocalState> local_state;
 

--- a/src/include/duckdb/execution/merge_sort_tree.hpp
+++ b/src/include/duckdb/execution/merge_sort_tree.hpp
@@ -226,7 +226,7 @@ protected:
 					out << ((i && i % level_width == 0) ? group_separator : separator);
 					out << std::setw(number_width) << level.first[i];
 				}
-				out << std::endl;
+				out << '\n';
 			}
 			// Print the pointers
 			if (!level.second.empty()) {
@@ -239,7 +239,7 @@ protected:
 						                                                                       : separator);
 						out << std::setw(number_width) << level.second[idx + child_nr];
 					}
-					out << std::endl;
+					out << '\n';
 				}
 			}
 			level_width *= FANOUT;

--- a/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
@@ -23,7 +23,7 @@ struct FunctionDataWrapper {
 	unique_ptr<FunctionData> function_data;
 };
 
-struct AggregateObject {
+struct AggregateObject { // NOLINT: work-around bug in clang-tidy
 	AggregateObject(AggregateFunction function, FunctionData *bind_data, idx_t child_count, idx_t payload_size,
 	                AggregateType aggr_type, PhysicalType return_type, Expression *filter = nullptr);
 	explicit AggregateObject(BoundAggregateExpression *aggr);

--- a/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/aggregate_object.hpp
@@ -17,7 +17,7 @@ class BoundAggregateExpression;
 class BoundWindowExpression;
 
 struct FunctionDataWrapper {
-	FunctionDataWrapper(unique_ptr<FunctionData> function_data_p) : function_data(std::move(function_data_p)) {
+	explicit FunctionDataWrapper(unique_ptr<FunctionData> function_data_p) : function_data(std::move(function_data_p)) {
 	}
 
 	unique_ptr<FunctionData> function_data;

--- a/src/include/duckdb/execution/operator/aggregate/distinct_aggregate_data.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/distinct_aggregate_data.hpp
@@ -44,7 +44,7 @@ private:
 
 struct DistinctAggregateData {
 public:
-	DistinctAggregateData(const DistinctAggregateCollectionInfo &info);
+	explicit DistinctAggregateData(const DistinctAggregateCollectionInfo &info);
 	DistinctAggregateData(const DistinctAggregateCollectionInfo &info, const GroupingSet &groups,
 	                      const vector<unique_ptr<Expression>> *group_expressions);
 	//! The data used by the hashtables

--- a/src/include/duckdb/execution/operator/csv_scanner/column_count_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/column_count_scanner.hpp
@@ -48,9 +48,6 @@ public:
 	ColumnCountScanner(shared_ptr<CSVBufferManager> buffer_manager, const shared_ptr<CSVStateMachine> &state_machine,
 	                   shared_ptr<CSVErrorHandler> error_handler);
 
-	~ColumnCountScanner() {
-	}
-
 	ColumnCountResult &ParseChunk() override;
 
 	ColumnCountResult &GetResult() override;

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
@@ -91,7 +91,7 @@ public:
 
 class CSVErrorHandler {
 public:
-	CSVErrorHandler(bool ignore_errors = false);
+	explicit CSVErrorHandler(bool ignore_errors = false);
 	//! Throws the error
 	void Error(CSVError csv_error, bool force_error = false);
 	//! If we have a cached error, and we can now error, we error.

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_option.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_option.hpp
@@ -26,8 +26,8 @@ class Deserializer;
 template <typename T>
 struct CSVOption {
 public:
-	CSVOption(T value_p) : value(value_p) {};
-	CSVOption(T value_p, bool set_by_user_p) : value(value_p), set_by_user(set_by_user_p) {};
+	CSVOption(T value_p) : value(value_p) {} // NOLINT: allow implicit conversion from value
+	CSVOption(T value_p, bool set_by_user_p) : value(value_p), set_by_user(set_by_user_p) {}
 	CSVOption() {};
 
 	//! Sets value.

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_option.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_option.hpp
@@ -24,7 +24,7 @@ class Deserializer;
 //! Wrapper for CSV Options that can be manually set by the user
 //! It is important to make this difference for options that can be automatically sniffed AND manually set.
 template <typename T>
-struct CSVOption {
+struct CSVOption { // NOLINT: work-around bug in clang-tidy
 public:
 	CSVOption(T value_p) : value(value_p) {} // NOLINT: allow implicit conversion from value
 	CSVOption(T value_p, bool set_by_user_p) : value(value_p), set_by_user(set_by_user_p) {}

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_option.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_option.hpp
@@ -26,8 +26,10 @@ class Deserializer;
 template <typename T>
 struct CSVOption { // NOLINT: work-around bug in clang-tidy
 public:
-	CSVOption(T value_p) : value(value_p) {} // NOLINT: allow implicit conversion from value
-	CSVOption(T value_p, bool set_by_user_p) : value(value_p), set_by_user(set_by_user_p) {}
+	CSVOption(T value_p) : value(value_p) { // NOLINT: allow implicit conversion from value
+	}
+	CSVOption(T value_p, bool set_by_user_p) : value(value_p), set_by_user(set_by_user_p) {
+	}
 	CSVOption() {};
 
 	//! Sets value.

--- a/src/include/duckdb/execution/operator/csv_scanner/skip_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/skip_scanner.hpp
@@ -42,9 +42,6 @@ public:
 	SkipScanner(shared_ptr<CSVBufferManager> buffer_manager, const shared_ptr<CSVStateMachine> &state_machine,
 	            shared_ptr<CSVErrorHandler> error_handler, idx_t rows_to_skip);
 
-	~SkipScanner() {
-	}
-
 	SkipResult &ParseChunk() override;
 
 	SkipResult &GetResult() override;

--- a/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
@@ -143,9 +143,6 @@ public:
 	                   const shared_ptr<CSVStateMachine> &state_machine,
 	                   const shared_ptr<CSVErrorHandler> &error_handler);
 
-	~StringValueScanner() {
-	}
-
 	StringValueResult &ParseChunk() override;
 
 	//! Flushes the result to the insert_chunk

--- a/src/include/duckdb/execution/operator/helper/physical_batch_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_batch_collector.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class PhysicalBatchCollector : public PhysicalResultCollector {
 public:
-	PhysicalBatchCollector(PreparedStatementData &data);
+	explicit PhysicalBatchCollector(PreparedStatementData &data);
 
 public:
 	unique_ptr<QueryResult> GetResult(GlobalSinkState &state) override;

--- a/src/include/duckdb/execution/operator/helper/physical_explain_analyze.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_explain_analyze.hpp
@@ -18,7 +18,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXPLAIN_ANALYZE;
 
 public:
-	PhysicalExplainAnalyze(vector<LogicalType> types)
+	explicit PhysicalExplainAnalyze(vector<LogicalType> types)
 	    : PhysicalOperator(PhysicalOperatorType::EXPLAIN_ANALYZE, std::move(types), 1) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
@@ -20,8 +20,8 @@ public:
 
 public:
 	PhysicalPrepare(string name_p, shared_ptr<PreparedStatementData> prepared, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN}, estimated_cardinality), name(std::move(name_p)),
-	      prepared(std::move(prepared)) {
+	    : PhysicalOperator(PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN}, estimated_cardinality),
+	      name(std::move(name_p)), prepared(std::move(prepared)) {
 	}
 
 	string name;

--- a/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_prepare.hpp
@@ -19,8 +19,8 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::PREPARE;
 
 public:
-	PhysicalPrepare(string name, shared_ptr<PreparedStatementData> prepared, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN}, estimated_cardinality), name(name),
+	PhysicalPrepare(string name_p, shared_ptr<PreparedStatementData> prepared, idx_t estimated_cardinality)
+	    : PhysicalOperator(PhysicalOperatorType::PREPARE, {LogicalType::BOOLEAN}, estimated_cardinality), name(std::move(name_p)),
 	      prepared(std::move(prepared)) {
 	}
 

--- a/src/include/duckdb/execution/operator/helper/physical_set.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_set.hpp
@@ -25,7 +25,7 @@ public:
 public:
 	PhysicalSet(const std::string &name_p, Value value_p, SetScope scope_p, idx_t estimated_cardinality)
 	    : PhysicalOperator(PhysicalOperatorType::SET, {LogicalType::BOOLEAN}, estimated_cardinality), name(name_p),
-	      value(value_p), scope(scope_p) {
+	      value(std::move(value_p)), scope(scope_p) {
 	}
 
 public:

--- a/src/include/duckdb/execution/operator/persistent/csv_rejects_table.hpp
+++ b/src/include/duckdb/execution/operator/persistent/csv_rejects_table.hpp
@@ -14,9 +14,8 @@ class ClientContext;
 
 class CSVRejectsTable : public ObjectCacheEntry {
 public:
-	CSVRejectsTable(string name) : name(name), count(0) {
+	CSVRejectsTable(string name_p) : name(std::move(name_p)), count(0) {
 	}
-	~CSVRejectsTable() override = default;
 	mutex write_lock;
 	string name;
 	idx_t count;

--- a/src/include/duckdb/execution/operator/persistent/csv_rejects_table.hpp
+++ b/src/include/duckdb/execution/operator/persistent/csv_rejects_table.hpp
@@ -14,7 +14,7 @@ class ClientContext;
 
 class CSVRejectsTable : public ObjectCacheEntry {
 public:
-	CSVRejectsTable(string name_p) : name(std::move(name_p)), count(0) {
+	explicit CSVRejectsTable(string name_p) : name(std::move(name_p)), count(0) {
 	}
 	mutex write_lock;
 	string name;

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -79,7 +79,7 @@ typedef void (*aggregate_serialize_t)(Serializer &serializer, const optional_ptr
                                       const AggregateFunction &function);
 typedef unique_ptr<FunctionData> (*aggregate_deserialize_t)(Deserializer &deserializer, AggregateFunction &function);
 
-class AggregateFunction : public BaseScalarFunction {
+class AggregateFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	AggregateFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
 	                  aggregate_size_t state_size, aggregate_initialize_t initialize, aggregate_update_t update,

--- a/src/include/duckdb/function/cast/cast_function_set.hpp
+++ b/src/include/duckdb/function/cast/cast_function_set.hpp
@@ -20,9 +20,9 @@ typedef BoundCastInfo (*bind_cast_function_t)(BindCastInput &input, const Logica
 typedef int64_t (*implicit_cast_cost_t)(const LogicalType &from, const LogicalType &to);
 
 struct GetCastFunctionInput {
-	GetCastFunctionInput(optional_ptr<ClientContext> context = nullptr) : context(context) {
+	explicit GetCastFunctionInput(optional_ptr<ClientContext> context = nullptr) : context(context) {
 	}
-	GetCastFunctionInput(ClientContext &context) : context(&context) {
+	explicit GetCastFunctionInput(ClientContext &context) : context(&context) {
 	}
 
 	optional_ptr<ClientContext> context;
@@ -30,8 +30,8 @@ struct GetCastFunctionInput {
 };
 
 struct BindCastFunction {
-	BindCastFunction(bind_cast_function_t function,
-	                 unique_ptr<BindCastInfo> info = nullptr); // NOLINT: allow implicit cast
+	BindCastFunction(bind_cast_function_t function, // NOLINT: allow implicit cast
+	                 unique_ptr<BindCastInfo> info = nullptr);
 
 	bind_cast_function_t function;
 	unique_ptr<BindCastInfo> info;
@@ -40,7 +40,7 @@ struct BindCastFunction {
 class CastFunctionSet {
 public:
 	CastFunctionSet();
-	CastFunctionSet(DBConfig &config);
+	explicit CastFunctionSet(DBConfig &config);
 
 public:
 	DUCKDB_API static CastFunctionSet &Get(ClientContext &context);

--- a/src/include/duckdb/function/cast/default_casts.hpp
+++ b/src/include/duckdb/function/cast/default_casts.hpp
@@ -104,9 +104,9 @@ typedef unique_ptr<FunctionLocalState> (*init_cast_local_state_t)(CastLocalState
 
 struct BoundCastInfo {
 	DUCKDB_API
-	BoundCastInfo(
+	BoundCastInfo( // NOLINT: allow explicit cast from cast_function_t
 	    cast_function_t function, unique_ptr<BoundCastData> cast_data = nullptr,
-	    init_cast_local_state_t init_local_state = nullptr); // NOLINT: allow explicit cast from cast_function_t
+	    init_cast_local_state_t init_local_state = nullptr);
 	cast_function_t function;
 	init_cast_local_state_t init_local_state;
 	unique_ptr<BoundCastData> cast_data;

--- a/src/include/duckdb/function/cast/vector_cast_helpers.hpp
+++ b/src/include/duckdb/function/cast/vector_cast_helpers.hpp
@@ -21,7 +21,7 @@ template <class OP>
 struct VectorStringCastOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
-		auto result = (Vector *)dataptr;
+		auto result = reinterpret_cast<Vector *>(dataptr);
 		return OP::template Operation<INPUT_TYPE>(input, *result);
 	}
 };
@@ -34,7 +34,7 @@ struct VectorTryCastOperator {
 		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output))) {
 			return output;
 		}
-		auto data = (VectorTryCastData *)dataptr;
+		auto data = reinterpret_cast<VectorTryCastData *>(dataptr);
 		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
 		                                                     idx, *data);
 	}
@@ -44,7 +44,7 @@ template <class OP>
 struct VectorTryCastStrictOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
-		auto data = (VectorTryCastData *)dataptr;
+		auto data = reinterpret_cast<VectorTryCastData *>(dataptr);
 		RESULT_TYPE output;
 		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->parameters.strict))) {
 			return output;
@@ -58,7 +58,7 @@ template <class OP>
 struct VectorTryCastErrorOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
-		auto data = (VectorTryCastData *)dataptr;
+		auto data = reinterpret_cast<VectorTryCastData *>(dataptr);
 		RESULT_TYPE output;
 		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->parameters))) {
 			return output;
@@ -74,7 +74,7 @@ template <class OP>
 struct VectorTryCastStringOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
-		auto data = (VectorTryCastData *)dataptr;
+		auto data = reinterpret_cast<VectorTryCastData *>(dataptr);
 		RESULT_TYPE output;
 		if (DUCKDB_LIKELY(
 		        OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->result, data->parameters))) {
@@ -99,7 +99,7 @@ template <class OP>
 struct VectorDecimalCastOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
-		auto data = (VectorDecimalCastData *)dataptr;
+		auto data = reinterpret_cast<VectorDecimalCastData *>(dataptr);
 		RESULT_TYPE result_value;
 		if (!OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, result_value, data->vector_cast_data.parameters,
 		                                                     data->width, data->scale)) {

--- a/src/include/duckdb/function/copy_function.hpp
+++ b/src/include/duckdb/function/copy_function.hpp
@@ -21,8 +21,7 @@ class ColumnDataCollection;
 class ExecutionContext;
 
 struct LocalFunctionData {
-	virtual ~LocalFunctionData() {
-	}
+	virtual ~LocalFunctionData() = default;
 
 	template <class TARGET>
 	TARGET &Cast() {
@@ -37,8 +36,7 @@ struct LocalFunctionData {
 };
 
 struct GlobalFunctionData {
-	virtual ~GlobalFunctionData() {
-	}
+	virtual ~GlobalFunctionData() = default;
 
 	template <class TARGET>
 	TARGET &Cast() {
@@ -53,8 +51,7 @@ struct GlobalFunctionData {
 };
 
 struct PreparedBatchData {
-	virtual ~PreparedBatchData() {
-	}
+	virtual ~PreparedBatchData() = default;
 
 	template <class TARGET>
 	TARGET &Cast() {
@@ -69,12 +66,12 @@ struct PreparedBatchData {
 };
 
 struct CopyFunctionBindInput {
+	explicit CopyFunctionBindInput(const CopyInfo &info_p) : info(info_p) {
+	}
+
 	const CopyInfo &info;
 
 	string file_extension;
-
-	CopyFunctionBindInput(const CopyInfo &info_p) : info(info_p) {
-	}
 };
 
 enum class CopyFunctionExecutionMode { REGULAR_COPY_TO_FILE, PARALLEL_COPY_TO_FILE, BATCH_COPY_TO_FILE };

--- a/src/include/duckdb/function/copy_function.hpp
+++ b/src/include/duckdb/function/copy_function.hpp
@@ -111,7 +111,7 @@ enum class CopyTypeSupport { SUPPORTED, LOSSY, UNSUPPORTED };
 
 typedef CopyTypeSupport (*copy_supports_type_t)(const LogicalType &type);
 
-class CopyFunction : public Function {
+class CopyFunction : public Function { // NOLINT: work-around bug in clang-tidy
 public:
 	explicit CopyFunction(const string &name)
 	    : Function(name), plan(nullptr), copy_to_bind(nullptr), copy_to_initialize_local(nullptr),

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -72,7 +72,7 @@ struct TableFunctionData : public FunctionData {
 	// used to pass on projections to table functions that support them. NB, can contain COLUMN_IDENTIFIER_ROW_ID
 	vector<idx_t> column_ids;
 
-	DUCKDB_API virtual ~TableFunctionData();
+	DUCKDB_API ~TableFunctionData() override;
 
 	DUCKDB_API unique_ptr<FunctionData> Copy() const override;
 	DUCKDB_API bool Equals(const FunctionData &other) const override;

--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -74,7 +74,7 @@ public:
 	template <class FUNC, class CATALOG_ENTRY>
 	static pair<FUNC, unique_ptr<FunctionData>> Deserialize(Deserializer &deserializer, CatalogType catalog_type,
 	                                                        vector<unique_ptr<Expression>> &children,
-	                                                        LogicalType return_type) {
+	                                                        LogicalType return_type) { // NOLINT: clang-tidy bug
 		auto &context = deserializer.Get<ClientContext &>();
 		auto entry = DeserializeBase<FUNC, CATALOG_ENTRY>(deserializer, catalog_type);
 		auto &function = entry.first;

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 template <class T>
 class FunctionSet {
 public:
-	explicit FunctionSet(string name) : name(name) {
+	explicit FunctionSet(string name) : name(std::move(name)) {
 	}
 
 	//! The name of the function set

--- a/src/include/duckdb/function/pragma_function.hpp
+++ b/src/include/duckdb/function/pragma_function.hpp
@@ -28,7 +28,7 @@ typedef void (*pragma_function_t)(ClientContext &context, const FunctionParamete
 //!   -> this is similar to a call pragma but without parameters
 //! Pragma functions can either return a new query to execute (pragma_query_t)
 //! or they can
-class PragmaFunction : public SimpleNamedParameterFunction {
+class PragmaFunction : public SimpleNamedParameterFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	// Call
 	DUCKDB_API static PragmaFunction PragmaCall(const string &name, pragma_query_t query, vector<LogicalType> arguments,

--- a/src/include/duckdb/function/scalar/regexp.hpp
+++ b/src/include/duckdb/function/scalar/regexp.hpp
@@ -44,13 +44,13 @@ struct RegexpExtractAll {
 struct RegexpBaseBindData : public FunctionData {
 	RegexpBaseBindData();
 	RegexpBaseBindData(duckdb_re2::RE2::Options options, string constant_string, bool constant_pattern = true);
-	virtual ~RegexpBaseBindData();
+	~RegexpBaseBindData() override;
 
 	duckdb_re2::RE2::Options options;
 	string constant_string;
 	bool constant_pattern;
 
-	virtual bool Equals(const FunctionData &other_p) const override;
+	bool Equals(const FunctionData &other_p) const override;
 };
 
 struct RegexpMatchesBindData : public RegexpBaseBindData {
@@ -105,7 +105,7 @@ struct RegexStringPieceArgs {
 		}
 	}
 
-	RegexStringPieceArgs &operator=(RegexStringPieceArgs &&other) {
+	RegexStringPieceArgs &operator=(RegexStringPieceArgs &&other) noexcept {
 		std::swap(this->size, other.size);
 		std::swap(this->capacity, other.capacity);
 		std::swap(this->group_buffer, other.group_buffer);

--- a/src/include/duckdb/function/scalar/strftime_format.hpp
+++ b/src/include/duckdb/function/scalar/strftime_format.hpp
@@ -128,7 +128,7 @@ protected:
 	                             char *target);
 };
 
-struct StrpTimeFormat : public StrTimeFormat {
+struct StrpTimeFormat : public StrTimeFormat { // NOLINT: work-around bug in clang-tidy
 public:
 	StrpTimeFormat();
 

--- a/src/include/duckdb/function/scalar/strftime_format.hpp
+++ b/src/include/duckdb/function/scalar/strftime_format.hpp
@@ -95,7 +95,7 @@ protected:
 	DUCKDB_API virtual void AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier);
 };
 
-struct StrfTimeFormat : public StrTimeFormat {
+struct StrfTimeFormat : public StrTimeFormat { // NOLINT: work-around bug in clang-tidy
 	DUCKDB_API idx_t GetLength(date_t date, dtime_t time, int32_t utc_offset, const char *tz_name);
 
 	DUCKDB_API void FormatString(date_t date, int32_t data[8], const char *tz_name, char *target);

--- a/src/include/duckdb/function/scalar/string_functions.hpp
+++ b/src/include/duckdb/function/scalar/string_functions.hpp
@@ -12,7 +12,7 @@
 #include "utf8proc.hpp"
 #include "duckdb/function/built_in_functions.hpp"
 
-namespace re2 {
+namespace duckdb_re2 {
 class RE2;
 }
 

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -71,7 +71,7 @@ typedef void (*function_serialize_t)(Serializer &serializer, const optional_ptr<
                                      const ScalarFunction &function);
 typedef unique_ptr<FunctionData> (*function_deserialize_t)(Deserializer &deserializer, ScalarFunction &function);
 
-class ScalarFunction : public BaseScalarFunction {
+class ScalarFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	DUCKDB_API ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
 	                          scalar_function_t function, bind_scalar_function_t bind = nullptr,

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -135,7 +135,7 @@ public:
 
 public:
 	template <class OP>
-	static scalar_function_t GetScalarUnaryFunction(LogicalType type) {
+	static scalar_function_t GetScalarUnaryFunction(const LogicalType &type) {
 		scalar_function_t function;
 		switch (type.id()) {
 		case LogicalTypeId::TINYINT:
@@ -181,7 +181,7 @@ public:
 	}
 
 	template <class TR, class OP>
-	static scalar_function_t GetScalarUnaryFunctionFixedReturn(LogicalType type) {
+	static scalar_function_t GetScalarUnaryFunctionFixedReturn(const LogicalType &type) {
 		scalar_function_t function;
 		switch (type.id()) {
 		case LogicalTypeId::TINYINT:

--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -82,7 +82,7 @@ public:
 struct ArrowScanLocalState;
 struct ArrowArrayScanState {
 public:
-	ArrowArrayScanState(ArrowScanLocalState &state);
+	explicit ArrowArrayScanState(ArrowScanLocalState &state);
 
 public:
 	ArrowScanLocalState &state;
@@ -146,7 +146,7 @@ public:
 		if (it == array_states.end()) {
 			auto child_p = make_uniq<ArrowArrayScanState>(*this);
 			auto &child = *child_p;
-			array_states.emplace(std::make_pair(child_idx, std::move(child_p)));
+			array_states.emplace(child_idx, std::move(child_p));
 			return child;
 		}
 		return *it->second;

--- a/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
+++ b/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
@@ -35,7 +35,7 @@ enum class ArrowDateTimeType : uint8_t {
 class ArrowType {
 public:
 	//! From a DuckDB type
-	explicit ArrowType(LogicalType type_p) // NOLINT: work-around bug in clang-tidy
+	ArrowType(LogicalType type_p) // NOLINT: allow implicit conversion
 	    : type(std::move(type_p)), size_type(ArrowVariableSizeType::NORMAL),
 	      date_time_precision(ArrowDateTimeType::DAYS) {};
 

--- a/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
+++ b/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
@@ -35,7 +35,7 @@ enum class ArrowDateTimeType : uint8_t {
 class ArrowType {
 public:
 	//! From a DuckDB type
-	ArrowType(LogicalType type_p)
+	explicit ArrowType(LogicalType type_p)
 	    : type(std::move(type_p)), size_type(ArrowVariableSizeType::NORMAL),
 	      date_time_precision(ArrowDateTimeType::DAYS) {};
 

--- a/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
+++ b/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
@@ -35,21 +35,21 @@ enum class ArrowDateTimeType : uint8_t {
 class ArrowType {
 public:
 	//! From a DuckDB type
-	explicit ArrowType(LogicalType type_p)
+	explicit ArrowType(LogicalType type_p) // NOLINT: work-around bug in clang-tidy
 	    : type(std::move(type_p)), size_type(ArrowVariableSizeType::NORMAL),
 	      date_time_precision(ArrowDateTimeType::DAYS) {};
 
 	//! From a DuckDB type + fixed_size
-	ArrowType(LogicalType type_p, idx_t fixed_size_p)
+	ArrowType(LogicalType type_p, idx_t fixed_size_p) // NOLINT: work-around bug in clang-tidy
 	    : type(std::move(type_p)), size_type(ArrowVariableSizeType::FIXED_SIZE),
 	      date_time_precision(ArrowDateTimeType::DAYS), fixed_size(fixed_size_p) {};
 
 	//! From a DuckDB type + variable size type
-	ArrowType(LogicalType type_p, ArrowVariableSizeType size_type_p)
+	ArrowType(LogicalType type_p, ArrowVariableSizeType size_type_p) // NOLINT: work-around bug in clang-tidy
 	    : type(std::move(type_p)), size_type(size_type_p), date_time_precision(ArrowDateTimeType::DAYS) {};
 
 	//! From a DuckDB type + datetime type
-	ArrowType(LogicalType type_p, ArrowDateTimeType date_time_precision_p)
+	ArrowType(LogicalType type_p, ArrowDateTimeType date_time_precision_p) // NOLINT: work-around bug in clang-tidy
 	    : type(std::move(type_p)), size_type(ArrowVariableSizeType::NORMAL),
 	      date_time_precision(date_time_precision_p) {};
 

--- a/src/include/duckdb/function/table/read_csv.hpp
+++ b/src/include/duckdb/function/table/read_csv.hpp
@@ -30,8 +30,6 @@ public:
 };
 
 struct BaseCSVData : public TableFunctionData {
-	virtual ~BaseCSVData() {
-	}
 	//! The file path of the CSV file to read or write
 	vector<string> files;
 	//! The CSV reader options
@@ -55,7 +53,7 @@ struct WriteCSVData : public BaseCSVData {
 	//! The newline string to write
 	string newline = "\n";
 	//! The size of the CSV file (in bytes) that we buffer before we flush it to disk
-	idx_t flush_size = 4096 * 8;
+	idx_t flush_size = 4096ULL * 8ULL;
 	//! For each byte whether or not the CSV file requires quotes when containing the byte
 	unsafe_unique_array<bool> requires_quotes;
 };

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -32,7 +32,7 @@ struct TableScanBindData : public TableFunctionData {
 
 public:
 	bool Equals(const FunctionData &other_p) const override {
-		auto &other = (const TableScanBindData &)other_p;
+		auto &other = other_p.Cast<TableScanBindData>();
 		return &other.table == &table && result_ids == other.result_ids;
 	}
 };

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -211,7 +211,7 @@ typedef void (*table_function_serialize_t)(Serializer &serializer, const optiona
                                            const TableFunction &function);
 typedef unique_ptr<FunctionData> (*table_function_deserialize_t)(Deserializer &deserializer, TableFunction &function);
 
-class TableFunction : public SimpleNamedParameterFunction {
+class TableFunction : public SimpleNamedParameterFunction { // NOLINT: work-around bug in clang-tidy
 public:
 	DUCKDB_API
 	TableFunction(string name, vector<LogicalType> arguments, table_function_t function,

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -149,7 +149,7 @@ public:
 		if (options.find(name) != options.end()) {
 			throw InternalException("This option already exists");
 		}
-		options[name] = std::move(value);
+		options.emplace(name, std::move(value));
 	}
 	template <class T>
 	T GetOption(const string &name) {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -145,7 +145,7 @@ public:
 	ScanType type;
 	optional_ptr<TableCatalogEntry> table;
 
-	void InsertOption(const string &name, Value value) {
+	void InsertOption(const string &name, Value value) { // NOLINT: work-around bug in clang-tidy
 		if (options.find(name) != options.end()) {
 			throw InternalException("This option already exists");
 		}

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -134,7 +134,7 @@ public:
 	optional_ptr<GlobalTableFunctionState> global_state;
 };
 
-enum ScanType { TABLE, PARQUET };
+enum class ScanType : uint8_t { TABLE, PARQUET };
 
 struct BindInfo {
 public:

--- a/src/include/duckdb/function/udf_function.hpp
+++ b/src/include/duckdb/function/udf_function.hpp
@@ -31,8 +31,8 @@ public:
 	}
 
 	template <typename TR, typename... ARGS>
-	inline static scalar_function_t CreateScalarFunction(const string &name, vector<LogicalType> args,
-	                                                     LogicalType ret_type, TR (*udf_func)(ARGS...)) {
+	inline static scalar_function_t CreateScalarFunction(const string &name, const vector<LogicalType> &args,
+	                                                     const LogicalType &ret_type, TR (*udf_func)(ARGS...)) {
 		if (!TypesMatch<TR>(ret_type)) { // LCOV_EXCL_START
 			throw std::runtime_error("Return type doesn't match with the first template type.");
 		} // LCOV_EXCL_STOP
@@ -63,7 +63,7 @@ public:
 
 		LogicalType ret_type = GetArgumentType<TR>();
 
-		RegisterFunction(name, arguments, ret_type, udf_function, context, varargs);
+		RegisterFunction(name, arguments, ret_type, std::move(udf_function), context, std::move(varargs));
 	}
 
 	static void RegisterFunction(string name, vector<LogicalType> args, LogicalType ret_type,
@@ -82,8 +82,8 @@ public:
 	}
 
 	template <typename UDF_OP, typename STATE, typename TR, typename TA>
-	inline static AggregateFunction CreateAggregateFunction(const string &name, LogicalType ret_type,
-	                                                        LogicalType input_type) {
+	inline static AggregateFunction CreateAggregateFunction(const string &name, const LogicalType &ret_type,
+	                                                        const LogicalType &input_type) {
 		if (!TypesMatch<TR>(ret_type)) { // LCOV_EXCL_START
 			throw std::runtime_error("The return argument don't match!");
 		} // LCOV_EXCL_STOP
@@ -96,32 +96,32 @@ public:
 	}
 
 	template <typename UDF_OP, typename STATE, typename TR, typename TA, typename TB>
-	inline static AggregateFunction CreateAggregateFunction(const string &name, LogicalType ret_type,
-	                                                        LogicalType input_typeA, LogicalType input_typeB) {
+	inline static AggregateFunction CreateAggregateFunction(const string &name, const LogicalType &ret_type,
+	                                                        const LogicalType &input_type_a, const LogicalType &input_type_b) {
 		if (!TypesMatch<TR>(ret_type)) { // LCOV_EXCL_START
 			throw std::runtime_error("The return argument don't match!");
 		}
 
-		if (!TypesMatch<TA>(input_typeA)) {
+		if (!TypesMatch<TA>(input_type_a)) {
 			throw std::runtime_error("The first input argument don't match!");
 		}
 
-		if (!TypesMatch<TB>(input_typeB)) {
+		if (!TypesMatch<TB>(input_type_b)) {
 			throw std::runtime_error("The second input argument don't match!");
 		} // LCOV_EXCL_STOP
 
-		return CreateBinaryAggregateFunction<UDF_OP, STATE, TR, TA, TB>(name, ret_type, input_typeA, input_typeB);
+		return CreateBinaryAggregateFunction<UDF_OP, STATE, TR, TA, TB>(name, ret_type, input_type_a, input_type_b);
 	}
 
 	//! A generic CreateAggregateFunction ---------------------------------------------------------------------------//
 	inline static AggregateFunction
-	CreateAggregateFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
+	CreateAggregateFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
 	                        aggregate_size_t state_size, aggregate_initialize_t initialize, aggregate_update_t update,
 	                        aggregate_combine_t combine, aggregate_finalize_t finalize,
 	                        aggregate_simple_update_t simple_update = nullptr, bind_aggregate_function_t bind = nullptr,
 	                        aggregate_destructor_t destructor = nullptr) {
 
-		AggregateFunction aggr_function(std::move(name), std::move(arguments), std::move(return_type), state_size,
+		AggregateFunction aggr_function(name, arguments, return_type, state_size,
 		                                initialize, update, combine, finalize, simple_update, bind, destructor);
 		aggr_function.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 		return aggr_function;
@@ -223,15 +223,15 @@ private:
 	//-------------------------------- Argumented functions --------------------------------//
 
 	template <typename TR, typename... ARGS>
-	inline static scalar_function_t CreateUnaryFunction(const string &name, vector<LogicalType> args,
-	                                                    LogicalType ret_type,
+	inline static scalar_function_t CreateUnaryFunction(const string &name, const vector<LogicalType> &args,
+	                                                    const LogicalType &ret_type,
 	                                                    TR (*udf_func)(ARGS...)) { // LCOV_EXCL_START
 		throw std::runtime_error("Incorrect number of arguments for unary function");
 	} // LCOV_EXCL_STOP
 
 	template <typename TR, typename TA>
-	inline static scalar_function_t CreateUnaryFunction(const string &name, vector<LogicalType> args,
-	                                                    LogicalType ret_type, TR (*udf_func)(TA)) {
+	inline static scalar_function_t CreateUnaryFunction(const string &name, const vector<LogicalType> &args,
+	                                                    const LogicalType &ret_type, TR (*udf_func)(TA)) {
 		if (args.size() != 1) { // LCOV_EXCL_START
 			throw std::runtime_error("The number of LogicalType arguments (\"args\") should be 1!");
 		}
@@ -247,15 +247,15 @@ private:
 	}
 
 	template <typename TR, typename... ARGS>
-	inline static scalar_function_t CreateBinaryFunction(const string &name, vector<LogicalType> args,
-	                                                     LogicalType ret_type,
+	inline static scalar_function_t CreateBinaryFunction(const string &name, const vector<LogicalType> &args,
+	                                                     const LogicalType &ret_type,
 	                                                     TR (*udf_func)(ARGS...)) { // LCOV_EXCL_START
 		throw std::runtime_error("Incorrect number of arguments for binary function");
 	} // LCOV_EXCL_STOP
 
 	template <typename TR, typename TA, typename TB>
-	inline static scalar_function_t CreateBinaryFunction(const string &name, vector<LogicalType> args,
-	                                                     LogicalType ret_type, TR (*udf_func)(TA, TB)) {
+	inline static scalar_function_t CreateBinaryFunction(const string &name, const vector<LogicalType> &args,
+	                                                     const LogicalType &ret_type, TR (*udf_func)(TA, TB)) {
 		if (args.size() != 2) { // LCOV_EXCL_START
 			throw std::runtime_error("The number of LogicalType arguments (\"args\") should be 2!");
 		}
@@ -273,15 +273,15 @@ private:
 	}
 
 	template <typename TR, typename... ARGS>
-	inline static scalar_function_t CreateTernaryFunction(const string &name, vector<LogicalType> args,
-	                                                      LogicalType ret_type,
+	inline static scalar_function_t CreateTernaryFunction(const string &name, const vector<LogicalType> &args,
+	                                                      const LogicalType &ret_type,
 	                                                      TR (*udf_func)(ARGS...)) { // LCOV_EXCL_START
 		throw std::runtime_error("Incorrect number of arguments for ternary function");
 	} // LCOV_EXCL_STOP
 
 	template <typename TR, typename TA, typename TB, typename TC>
-	inline static scalar_function_t CreateTernaryFunction(const string &name, vector<LogicalType> args,
-	                                                      LogicalType ret_type, TR (*udf_func)(TA, TB, TC)) {
+	inline static scalar_function_t CreateTernaryFunction(const string &name, const vector<LogicalType> &args,
+	                                                      const LogicalType &ret_type, TR (*udf_func)(TA, TB, TC)) {
 		if (args.size() != 3) { // LCOV_EXCL_START
 			throw std::runtime_error("The number of LogicalType arguments (\"args\") should be 3!");
 		}
@@ -350,8 +350,8 @@ private:
 	}
 
 	template <typename UDF_OP, typename STATE, typename TR, typename TA>
-	inline static AggregateFunction CreateUnaryAggregateFunction(const string &name, LogicalType ret_type,
-	                                                             LogicalType input_type) {
+	inline static AggregateFunction CreateUnaryAggregateFunction(const string &name, const LogicalType &ret_type,
+	                                                             const LogicalType &input_type) {
 		AggregateFunction aggr_function =
 		    AggregateFunction::UnaryAggregate<STATE, TR, TA, UDF_OP>(input_type, ret_type);
 		aggr_function.name = name;
@@ -361,16 +361,16 @@ private:
 	template <typename UDF_OP, typename STATE, typename TR, typename TA, typename TB>
 	inline static AggregateFunction CreateBinaryAggregateFunction(const string &name) {
 		LogicalType return_type = GetArgumentType<TR>();
-		LogicalType input_typeA = GetArgumentType<TA>();
-		LogicalType input_typeB = GetArgumentType<TB>();
-		return CreateBinaryAggregateFunction<UDF_OP, STATE, TR, TA, TB>(name, return_type, input_typeA, input_typeB);
+		LogicalType input_type_a = GetArgumentType<TA>();
+		LogicalType input_type_b = GetArgumentType<TB>();
+		return CreateBinaryAggregateFunction<UDF_OP, STATE, TR, TA, TB>(name, return_type, input_type_a, input_type_b);
 	}
 
 	template <typename UDF_OP, typename STATE, typename TR, typename TA, typename TB>
-	inline static AggregateFunction CreateBinaryAggregateFunction(const string &name, LogicalType ret_type,
-	                                                              LogicalType input_typeA, LogicalType input_typeB) {
+	inline static AggregateFunction CreateBinaryAggregateFunction(const string &name, const LogicalType &ret_type,
+	                                                              const LogicalType &input_type_a, const LogicalType &input_type_b) {
 		AggregateFunction aggr_function =
-		    AggregateFunction::BinaryAggregate<STATE, TA, TB, TR, UDF_OP>(input_typeA, input_typeB, ret_type);
+		    AggregateFunction::BinaryAggregate<STATE, TA, TB, TR, UDF_OP>(input_type_a, input_type_b, ret_type);
 		aggr_function.name = name;
 		return aggr_function;
 	}

--- a/src/include/duckdb/function/udf_function.hpp
+++ b/src/include/duckdb/function/udf_function.hpp
@@ -15,29 +15,29 @@ namespace duckdb {
 
 struct UDFWrapper {
 public:
-	template <typename TR, typename... Args>
-	inline static scalar_function_t CreateScalarFunction(const string &name, TR (*udf_func)(Args...)) {
-		const std::size_t num_template_argc = sizeof...(Args);
+	template <typename TR, typename... ARGS>
+	inline static scalar_function_t CreateScalarFunction(const string &name, TR (*udf_func)(ARGS...)) {
+		const std::size_t num_template_argc = sizeof...(ARGS);
 		switch (num_template_argc) {
 		case 1:
-			return CreateUnaryFunction<TR, Args...>(name, udf_func);
+			return CreateUnaryFunction<TR, ARGS...>(name, udf_func);
 		case 2:
-			return CreateBinaryFunction<TR, Args...>(name, udf_func);
+			return CreateBinaryFunction<TR, ARGS...>(name, udf_func);
 		case 3:
-			return CreateTernaryFunction<TR, Args...>(name, udf_func);
+			return CreateTernaryFunction<TR, ARGS...>(name, udf_func);
 		default: // LCOV_EXCL_START
 			throw std::runtime_error("UDF function only supported until ternary!");
 		} // LCOV_EXCL_STOP
 	}
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	inline static scalar_function_t CreateScalarFunction(const string &name, vector<LogicalType> args,
-	                                                     LogicalType ret_type, TR (*udf_func)(Args...)) {
+	                                                     LogicalType ret_type, TR (*udf_func)(ARGS...)) {
 		if (!TypesMatch<TR>(ret_type)) { // LCOV_EXCL_START
 			throw std::runtime_error("Return type doesn't match with the first template type.");
 		} // LCOV_EXCL_STOP
 
-		const std::size_t num_template_types = sizeof...(Args);
+		const std::size_t num_template_types = sizeof...(ARGS);
 		if (num_template_types != args.size()) { // LCOV_EXCL_START
 			throw std::runtime_error(
 			    "The number of templated types should be the same quantity of the LogicalType arguments.");
@@ -45,21 +45,21 @@ public:
 
 		switch (num_template_types) {
 		case 1:
-			return CreateUnaryFunction<TR, Args...>(name, args, ret_type, udf_func);
+			return CreateUnaryFunction<TR, ARGS...>(name, args, ret_type, udf_func);
 		case 2:
-			return CreateBinaryFunction<TR, Args...>(name, args, ret_type, udf_func);
+			return CreateBinaryFunction<TR, ARGS...>(name, args, ret_type, udf_func);
 		case 3:
-			return CreateTernaryFunction<TR, Args...>(name, args, ret_type, udf_func);
+			return CreateTernaryFunction<TR, ARGS...>(name, args, ret_type, udf_func);
 		default: // LCOV_EXCL_START
 			throw std::runtime_error("UDF function only supported until ternary!");
 		} // LCOV_EXCL_STOP
 	}
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	inline static void RegisterFunction(const string &name, scalar_function_t udf_function, ClientContext &context,
 	                                    LogicalType varargs = LogicalType(LogicalTypeId::INVALID)) {
 		vector<LogicalType> arguments;
-		GetArgumentTypesRecursive<Args...>(arguments);
+		GetArgumentTypesRecursive<ARGS...>(arguments);
 
 		LogicalType ret_type = GetArgumentType<TR>();
 
@@ -167,21 +167,21 @@ private:
 		return udf_function;
 	}
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	inline static scalar_function_t CreateUnaryFunction(const string &name,
-	                                                    TR (*udf_func)(Args...)) { // LCOV_EXCL_START
+	                                                    TR (*udf_func)(ARGS...)) { // LCOV_EXCL_START
 		throw std::runtime_error("Incorrect number of arguments for unary function");
 	} // LCOV_EXCL_STOP
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	inline static scalar_function_t CreateBinaryFunction(const string &name,
-	                                                     TR (*udf_func)(Args...)) { // LCOV_EXCL_START
+	                                                     TR (*udf_func)(ARGS...)) { // LCOV_EXCL_START
 		throw std::runtime_error("Incorrect number of arguments for binary function");
 	} // LCOV_EXCL_STOP
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	inline static scalar_function_t CreateTernaryFunction(const string &name,
-	                                                      TR (*udf_func)(Args...)) { // LCOV_EXCL_START
+	                                                      TR (*udf_func)(ARGS...)) { // LCOV_EXCL_START
 		throw std::runtime_error("Incorrect number of arguments for ternary function");
 	} // LCOV_EXCL_STOP
 
@@ -208,10 +208,10 @@ private:
 		} // LCOV_EXCL_STOP
 	}
 
-	template <typename TA, typename TB, typename... Args>
+	template <typename TA, typename TB, typename... ARGS>
 	inline static void GetArgumentTypesRecursive(vector<LogicalType> &arguments) {
 		arguments.push_back(GetArgumentType<TA>());
-		GetArgumentTypesRecursive<TB, Args...>(arguments);
+		GetArgumentTypesRecursive<TB, ARGS...>(arguments);
 	}
 
 	template <typename TA>
@@ -222,10 +222,10 @@ private:
 private:
 	//-------------------------------- Argumented functions --------------------------------//
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	inline static scalar_function_t CreateUnaryFunction(const string &name, vector<LogicalType> args,
 	                                                    LogicalType ret_type,
-	                                                    TR (*udf_func)(Args...)) { // LCOV_EXCL_START
+	                                                    TR (*udf_func)(ARGS...)) { // LCOV_EXCL_START
 		throw std::runtime_error("Incorrect number of arguments for unary function");
 	} // LCOV_EXCL_STOP
 
@@ -246,10 +246,10 @@ private:
 		return udf_function;
 	}
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	inline static scalar_function_t CreateBinaryFunction(const string &name, vector<LogicalType> args,
 	                                                     LogicalType ret_type,
-	                                                     TR (*udf_func)(Args...)) { // LCOV_EXCL_START
+	                                                     TR (*udf_func)(ARGS...)) { // LCOV_EXCL_START
 		throw std::runtime_error("Incorrect number of arguments for binary function");
 	} // LCOV_EXCL_STOP
 
@@ -272,10 +272,10 @@ private:
 		return udf_function;
 	}
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	inline static scalar_function_t CreateTernaryFunction(const string &name, vector<LogicalType> args,
 	                                                      LogicalType ret_type,
-	                                                      TR (*udf_func)(Args...)) { // LCOV_EXCL_START
+	                                                      TR (*udf_func)(ARGS...)) { // LCOV_EXCL_START
 		throw std::runtime_error("Incorrect number of arguments for ternary function");
 	} // LCOV_EXCL_STOP
 

--- a/src/include/duckdb/function/udf_function.hpp
+++ b/src/include/duckdb/function/udf_function.hpp
@@ -99,7 +99,8 @@ public:
 
 	template <typename UDF_OP, typename STATE, typename TR, typename TA, typename TB>
 	inline static AggregateFunction CreateAggregateFunction(const string &name, const LogicalType &ret_type,
-	                                                        const LogicalType &input_type_a, const LogicalType &input_type_b) {
+	                                                        const LogicalType &input_type_a,
+	                                                        const LogicalType &input_type_b) {
 		if (!TypesMatch<TR>(ret_type)) { // LCOV_EXCL_START
 			throw std::runtime_error("The return argument don't match!");
 		}
@@ -123,8 +124,8 @@ public:
 	                        aggregate_simple_update_t simple_update = nullptr, bind_aggregate_function_t bind = nullptr,
 	                        aggregate_destructor_t destructor = nullptr) {
 
-		AggregateFunction aggr_function(name, arguments, return_type, state_size,
-		                                initialize, update, combine, finalize, simple_update, bind, destructor);
+		AggregateFunction aggr_function(name, arguments, return_type, state_size, initialize, update, combine, finalize,
+		                                simple_update, bind, destructor);
 		aggr_function.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 		return aggr_function;
 	}
@@ -370,7 +371,8 @@ private:
 
 	template <typename UDF_OP, typename STATE, typename TR, typename TA, typename TB>
 	inline static AggregateFunction CreateBinaryAggregateFunction(const string &name, const LogicalType &ret_type,
-	                                                              const LogicalType &input_type_a, const LogicalType &input_type_b) {
+	                                                              const LogicalType &input_type_a,
+	                                                              const LogicalType &input_type_b) {
 		AggregateFunction aggr_function =
 		    AggregateFunction::BinaryAggregate<STATE, TA, TB, TR, UDF_OP>(input_type_a, input_type_b, ret_type);
 		aggr_function.name = name;

--- a/src/include/duckdb/function/udf_function.hpp
+++ b/src/include/duckdb/function/udf_function.hpp
@@ -13,6 +13,8 @@
 
 namespace duckdb {
 
+// NOLINTBEGIN
+
 struct UDFWrapper {
 public:
 	template <typename TR, typename... ARGS>
@@ -375,5 +377,7 @@ private:
 		return aggr_function;
 	}
 }; // end UDFWrapper
+
+// NOLINTEND
 
 } // namespace duckdb

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -29,7 +29,7 @@ enum class AppenderType : uint8_t {
 class BaseAppender {
 protected:
 	//! The amount of tuples that will be gathered in the column data collection before flushing
-	static constexpr const idx_t FLUSH_COUNT = STANDARD_VECTOR_SIZE * 100;
+	static constexpr const idx_t FLUSH_COUNT = STANDARD_VECTOR_SIZE * 100ULL;
 
 	Allocator &allocator;
 	//! The append types
@@ -66,8 +66,8 @@ public:
 	DUCKDB_API void Append(const char *value, uint32_t length);
 
 	// prepared statements
-	template <typename... Args>
-	void AppendRow(Args... args) {
+	template <typename... ARGS>
+	void AppendRow(ARGS... args) {
 		BeginRow();
 		AppendRowRecursive(args...);
 	}
@@ -80,7 +80,7 @@ public:
 	vector<LogicalType> &GetTypes() {
 		return types;
 	}
-	idx_t CurrentColumn() {
+	idx_t CurrentColumn() const {
 		return column;
 	}
 	DUCKDB_API void AppendDataChunk(DataChunk &value);

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -102,8 +102,8 @@ protected:
 		EndRow();
 	}
 
-	template <typename T, typename... Args>
-	void AppendRowRecursive(T value, Args... args) {
+	template <typename T, typename... ARGS>
+	void AppendRowRecursive(T value, ARGS... args) {
 		Append<T>(value);
 		AppendRowRecursive(args...);
 	}

--- a/src/include/duckdb/main/buffered_data/buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/buffered_data.hpp
@@ -23,7 +23,7 @@ class ClientContextLock;
 
 struct BlockedSink {
 public:
-	BlockedSink(InterruptState state, idx_t chunk_size) : state(state), chunk_size(chunk_size) {
+	BlockedSink(InterruptState state, idx_t chunk_size) : state(std::move(state)), chunk_size(chunk_size) {
 	}
 
 public:
@@ -38,7 +38,7 @@ protected:
 	enum class Type { SIMPLE };
 
 public:
-	BufferedData(Type type, weak_ptr<ClientContext> context) : type(type), context(context) {
+	BufferedData(Type type, weak_ptr<ClientContext> context) : type(type), context(std::move(context)) {
 	}
 	virtual ~BufferedData() {
 	}

--- a/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
@@ -28,7 +28,7 @@ private:
 	static constexpr idx_t BUFFER_SIZE = 100000;
 
 public:
-	SimpleBufferedData(weak_ptr<ClientContext> context);
+	explicit SimpleBufferedData(weak_ptr<ClientContext> context);
 	~SimpleBufferedData() override;
 
 public:

--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -75,8 +75,8 @@ struct DuckDBResultData {
 duckdb_type ConvertCPPTypeToC(const LogicalType &type);
 LogicalTypeId ConvertCTypeToCPP(duckdb_type c_type);
 idx_t GetCTypeSize(duckdb_type type);
-duckdb_state duckdb_translate_result(unique_ptr<QueryResult> result, duckdb_result *out);
-bool deprecated_materialize_result(duckdb_result *result);
+duckdb_state DuckDBTranslateResult(unique_ptr<QueryResult> result, duckdb_result *out);
+bool DeprecatedMaterializeResult(duckdb_result *result);
 duckdb_statement_type StatementTypeToC(duckdb::StatementType statement_type);
 
 } // namespace duckdb

--- a/src/include/duckdb/main/chunk_scan_state/query_result.hpp
+++ b/src/include/duckdb/main/chunk_scan_state/query_result.hpp
@@ -9,8 +9,8 @@ class QueryResult;
 
 class QueryResultChunkScanState : public ChunkScanState {
 public:
-	QueryResultChunkScanState(QueryResult &result);
-	~QueryResultChunkScanState();
+	explicit QueryResultChunkScanState(QueryResult &result);
+	~QueryResultChunkScanState() override;
 
 public:
 	bool LoadNextChunk(ErrorData &error) override;

--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -11,7 +11,8 @@
 #include <string>
 
 namespace duckdb {
-enum ArrowOffsetSize { REGULAR, LARGE };
+
+enum class ArrowOffsetSize : uint8_t { REGULAR, LARGE };
 
 //! A set of properties from the client context that can be used to interpret the query result
 struct ClientProperties {

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -76,6 +76,7 @@ struct ConfigurationOption {
 typedef void (*set_option_callback_t)(ClientContext &context, SetScope scope, Value &parameter);
 
 struct ExtensionOption {
+	// NOLINTNEXTLINE: work around bug in clang-tidy
 	ExtensionOption(string description_p, LogicalType type_p, set_option_callback_t set_function_p,
 	                Value default_value_p)
 	    : description(std::move(description_p)), type(std::move(type_p)), set_function(set_function_p),

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -204,7 +204,7 @@ struct DBConfig {
 
 public:
 	DUCKDB_API DBConfig();
-	DUCKDB_API DBConfig(bool read_only);
+	explicit DUCKDB_API DBConfig(bool read_only);
 	DUCKDB_API DBConfig(const case_insensitive_map_t<Value> &config_dict, bool read_only);
 	DUCKDB_API ~DBConfig();
 

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -165,6 +165,7 @@ public:
 	//! Fetch a list of table names that are required for a given query
 	DUCKDB_API unordered_set<string> GetTableNames(const string &query);
 
+	// NOLINTBEGIN
 	template <typename TR, typename... ARGS>
 	void CreateScalarFunction(const string &name, TR (*udf_func)(ARGS...)) {
 		scalar_function_t function = UDFWrapper::CreateScalarFunction<TR, ARGS...>(name, udf_func);
@@ -229,6 +230,7 @@ public:
 		                                        finalize, simple_update, bind, destructor);
 		UDFWrapper::RegisterAggrFunction(function, *context);
 	}
+	// NOLINTEND
 
 private:
 	unique_ptr<QueryResult> QueryParamsRecursive(const string &query, vector<Value> &values);

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -32,7 +32,7 @@ class LogicalOperator;
 class SelectStatement;
 struct CSVReaderOptions;
 
-typedef void (*warning_callback)(std::string);
+typedef void (*warning_callback_t)(std::string);
 
 //! A connection to a database. This represents a (client) connection that can
 //! be used to query the database.
@@ -49,7 +49,7 @@ public:
 	DUCKDB_API ~Connection();
 
 	shared_ptr<ClientContext> context;
-	warning_callback warning_cb;
+	warning_callback_t warning_cb;
 
 public:
 	//! Returns query profiling information for the current query
@@ -62,8 +62,6 @@ public:
 	DUCKDB_API void EnableProfiling();
 	//! Disable query profiling
 	DUCKDB_API void DisableProfiling();
-
-	DUCKDB_API void SetWarningCallback(warning_callback);
 
 	//! Enable aggressive verification/testing of queries, should only be used in testing
 	DUCKDB_API void EnableQueryVerification();
@@ -83,8 +81,8 @@ public:
 	//! MaterializedQueryResult.
 	DUCKDB_API unique_ptr<MaterializedQueryResult> Query(unique_ptr<SQLStatement> statement);
 	// prepared statements
-	template <typename... Args>
-	unique_ptr<QueryResult> Query(const string &query, Args... args) {
+	template <typename... ARGS>
+	unique_ptr<QueryResult> Query(const string &query, ARGS... args) {
 		vector<Value> values;
 		return QueryParamsRecursive(query, values, args...);
 	}
@@ -167,28 +165,28 @@ public:
 	//! Fetch a list of table names that are required for a given query
 	DUCKDB_API unordered_set<string> GetTableNames(const string &query);
 
-	template <typename TR, typename... Args>
-	void CreateScalarFunction(const string &name, TR (*udf_func)(Args...)) {
-		scalar_function_t function = UDFWrapper::CreateScalarFunction<TR, Args...>(name, udf_func);
-		UDFWrapper::RegisterFunction<TR, Args...>(name, function, *context);
+	template <typename TR, typename... ARGS>
+	void CreateScalarFunction(const string &name, TR (*udf_func)(ARGS...)) {
+		scalar_function_t function = UDFWrapper::CreateScalarFunction<TR, ARGS...>(name, udf_func);
+		UDFWrapper::RegisterFunction<TR, ARGS...>(name, function, *context);
 	}
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	void CreateScalarFunction(const string &name, vector<LogicalType> args, LogicalType ret_type,
-	                          TR (*udf_func)(Args...)) {
-		scalar_function_t function = UDFWrapper::CreateScalarFunction<TR, Args...>(name, args, ret_type, udf_func);
+	                          TR (*udf_func)(ARGS...)) {
+		scalar_function_t function = UDFWrapper::CreateScalarFunction<TR, ARGS...>(name, args, ret_type, udf_func);
 		UDFWrapper::RegisterFunction(name, args, ret_type, function, *context);
 	}
 
-	template <typename TR, typename... Args>
+	template <typename TR, typename... ARGS>
 	void CreateVectorizedFunction(const string &name, scalar_function_t udf_func,
 	                              LogicalType varargs = LogicalType::INVALID) {
-		UDFWrapper::RegisterFunction<TR, Args...>(name, udf_func, *context, std::move(varargs));
+		UDFWrapper::RegisterFunction<TR, ARGS...>(name, udf_func, *context, std::move(varargs));
 	}
 
 	void CreateVectorizedFunction(const string &name, vector<LogicalType> args, LogicalType ret_type,
 	                              scalar_function_t udf_func, LogicalType varargs = LogicalType::INVALID) {
-		UDFWrapper::RegisterFunction(name, std::move(args), std::move(ret_type), udf_func, *context,
+		UDFWrapper::RegisterFunction(name, std::move(args), std::move(ret_type), std::move(udf_func), *context,
 		                             std::move(varargs));
 	}
 
@@ -206,21 +204,21 @@ public:
 	}
 
 	template <typename UDF_OP, typename STATE, typename TR, typename TA>
-	void CreateAggregateFunction(const string &name, LogicalType ret_type, LogicalType input_typeA) {
+	void CreateAggregateFunction(const string &name, LogicalType ret_type, LogicalType input_type_a) {
 		AggregateFunction function =
-		    UDFWrapper::CreateAggregateFunction<UDF_OP, STATE, TR, TA>(name, ret_type, input_typeA);
+		    UDFWrapper::CreateAggregateFunction<UDF_OP, STATE, TR, TA>(name, ret_type, input_type_a);
 		UDFWrapper::RegisterAggrFunction(function, *context);
 	}
 
 	template <typename UDF_OP, typename STATE, typename TR, typename TA, typename TB>
-	void CreateAggregateFunction(const string &name, LogicalType ret_type, LogicalType input_typeA,
-	                             LogicalType input_typeB) {
+	void CreateAggregateFunction(const string &name, LogicalType ret_type, LogicalType input_type_a,
+	                             LogicalType input_type_b) {
 		AggregateFunction function =
-		    UDFWrapper::CreateAggregateFunction<UDF_OP, STATE, TR, TA, TB>(name, ret_type, input_typeA, input_typeB);
+		    UDFWrapper::CreateAggregateFunction<UDF_OP, STATE, TR, TA, TB>(name, ret_type, input_type_a, input_type_b);
 		UDFWrapper::RegisterAggrFunction(function, *context);
 	}
 
-	void CreateAggregateFunction(const string &name, vector<LogicalType> arguments, LogicalType return_type,
+	void CreateAggregateFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
 	                             aggregate_size_t state_size, aggregate_initialize_t initialize,
 	                             aggregate_update_t update, aggregate_combine_t combine, aggregate_finalize_t finalize,
 	                             aggregate_simple_update_t simple_update = nullptr,
@@ -235,8 +233,8 @@ public:
 private:
 	unique_ptr<QueryResult> QueryParamsRecursive(const string &query, vector<Value> &values);
 
-	template <typename T, typename... Args>
-	unique_ptr<QueryResult> QueryParamsRecursive(const string &query, vector<Value> &values, T value, Args... args) {
+	template <typename T, typename... ARGS>
+	unique_ptr<QueryResult> QueryParamsRecursive(const string &query, vector<Value> &values, T value, ARGS... args) {
 		values.push_back(Value::CreateValue<T>(value));
 		return QueryParamsRecursive(query, values, args...);
 	}

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -219,9 +219,10 @@ public:
 		UDFWrapper::RegisterAggrFunction(function, *context);
 	}
 
-	void CreateAggregateFunction(const string &name, const vector<LogicalType> &arguments, const LogicalType &return_type,
-	                             aggregate_size_t state_size, aggregate_initialize_t initialize,
-	                             aggregate_update_t update, aggregate_combine_t combine, aggregate_finalize_t finalize,
+	void CreateAggregateFunction(const string &name, const vector<LogicalType> &arguments,
+	                             const LogicalType &return_type, aggregate_size_t state_size,
+	                             aggregate_initialize_t initialize, aggregate_update_t update,
+	                             aggregate_combine_t combine, aggregate_finalize_t finalize,
 	                             aggregate_simple_update_t simple_update = nullptr,
 	                             bind_aggregate_function_t bind = nullptr,
 	                             aggregate_destructor_t destructor = nullptr) {

--- a/src/include/duckdb/main/error_manager.hpp
+++ b/src/include/duckdb/main/error_manager.hpp
@@ -32,23 +32,23 @@ enum class ErrorType : uint16_t {
 //! It allows for error messages to be overridden by extensions and clients
 class ErrorManager {
 public:
-	template <typename... Args>
-	string FormatException(ErrorType error_type, Args... params) {
+	template <typename... ARGS>
+	string FormatException(ErrorType error_type, ARGS... params) {
 		vector<ExceptionFormatValue> values;
 		return FormatExceptionRecursive(error_type, values, params...);
 	}
 
 	DUCKDB_API string FormatExceptionRecursive(ErrorType error_type, vector<ExceptionFormatValue> &values);
 
-	template <class T, typename... Args>
+	template <class T, typename... ARGS>
 	string FormatExceptionRecursive(ErrorType error_type, vector<ExceptionFormatValue> &values, T param,
-	                                Args... params) {
+	                                ARGS... params) {
 		values.push_back(ExceptionFormatValue::CreateFormatValue<T>(param));
 		return FormatExceptionRecursive(error_type, values, params...);
 	}
 
-	template <typename... Args>
-	static string FormatException(ClientContext &context, ErrorType error_type, Args... params) {
+	template <typename... ARGS>
+	static string FormatException(ClientContext &context, ErrorType error_type, ARGS... params) {
 		return Get(context).FormatException(error_type, params...);
 	}
 

--- a/src/include/duckdb/main/external_dependencies.hpp
+++ b/src/include/duckdb/main/external_dependencies.hpp
@@ -10,7 +10,8 @@
 
 namespace duckdb {
 
-enum ExternalDependenciesType { PYTHON_DEPENDENCY };
+enum class ExternalDependenciesType : uint8_t { PYTHON_DEPENDENCY };
+
 class ExternalDependency {
 public:
 	explicit ExternalDependency(ExternalDependenciesType type_p) : type(type_p) {};

--- a/src/include/duckdb/main/prepared_statement.hpp
+++ b/src/include/duckdb/main/prepared_statement.hpp
@@ -66,8 +66,8 @@ public:
 	DUCKDB_API case_insensitive_map_t<LogicalType> GetExpectedParameterTypes() const;
 
 	//! Create a pending query result of the prepared statement with the given set of arguments
-	template <typename... Args>
-	unique_ptr<PendingQueryResult> PendingQuery(Args... args) {
+	template <typename... ARGS>
+	unique_ptr<PendingQueryResult> PendingQuery(ARGS... args) {
 		vector<Value> values;
 		return PendingQueryRecursive(values, args...);
 	}
@@ -87,8 +87,8 @@ public:
 	                                           bool allow_stream_result = true);
 
 	//! Execute the prepared statement with the given set of arguments
-	template <typename... Args>
-	unique_ptr<QueryResult> Execute(Args... args) {
+	template <typename... ARGS>
+	unique_ptr<QueryResult> Execute(ARGS... args) {
 		vector<Value> values;
 		return ExecuteRecursive(values, args...);
 	}
@@ -158,8 +158,8 @@ private:
 		return PendingQuery(values);
 	}
 
-	template <typename T, typename... Args>
-	unique_ptr<PendingQueryResult> PendingQueryRecursive(vector<Value> &values, T value, Args... args) {
+	template <typename T, typename... ARGS>
+	unique_ptr<PendingQueryResult> PendingQueryRecursive(vector<Value> &values, T value, ARGS... args) {
 		values.push_back(Value::CreateValue<T>(value));
 		return PendingQueryRecursive(values, args...);
 	}
@@ -168,8 +168,8 @@ private:
 		return Execute(values);
 	}
 
-	template <typename T, typename... Args>
-	unique_ptr<QueryResult> ExecuteRecursive(vector<Value> &values, T value, Args... args) {
+	template <typename T, typename... ARGS>
+	unique_ptr<QueryResult> ExecuteRecursive(vector<Value> &values, T value, ARGS... args) {
 		values.push_back(Value::CreateValue<T>(value));
 		return ExecuteRecursive(values, args...);
 	}

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -68,7 +68,7 @@ private:
 //! The QueryProfiler can be used to measure timings of queries
 class QueryProfiler {
 public:
-	DUCKDB_API QueryProfiler(ClientContext &context);
+	DUCKDB_API explicit QueryProfiler(ClientContext &context);
 
 public:
 	struct TreeNode {

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -29,7 +29,7 @@ class PhysicalOperator;
 class SQLStatement;
 
 struct OperatorInformation {
-	explicit OperatorInformation(double time_ = 0, idx_t elements_ = 0) : time(time_), elements(elements_) {
+	explicit OperatorInformation(double time_p = 0, idx_t elements_p = 0) : time(time_p), elements(elements_p) {
 	}
 
 	double time = 0;

--- a/src/include/duckdb/main/query_result.hpp
+++ b/src/include/duckdb/main/query_result.hpp
@@ -65,7 +65,7 @@ public:
 	                       vector<LogicalType> types, vector<string> names, ClientProperties client_properties);
 	//! Creates an unsuccessful query result with error condition
 	DUCKDB_API QueryResult(QueryResultType type, ErrorData error);
-	DUCKDB_API virtual ~QueryResult() override;
+	DUCKDB_API ~QueryResult() override;
 
 	//! Properties from the client context
 	ClientProperties client_properties;
@@ -190,10 +190,10 @@ private:
 	};
 
 public:
-	QueryResultIterator begin() {
+	QueryResultIterator begin() { // NOLINT: match stl API
 		return QueryResultIterator(this);
 	}
-	QueryResultIterator end() {
+	QueryResultIterator end() { // NOLINT: match stl API
 		return QueryResultIterator(nullptr);
 	}
 

--- a/src/include/duckdb/main/relation/query_relation.hpp
+++ b/src/include/duckdb/main/relation/query_relation.hpp
@@ -17,7 +17,7 @@ class SelectStatement;
 class QueryRelation : public Relation {
 public:
 	QueryRelation(const std::shared_ptr<ClientContext> &context, unique_ptr<SelectStatement> select_stmt, string alias);
-	~QueryRelation();
+	~QueryRelation() override;
 
 	unique_ptr<SelectStatement> select_stmt;
 	string alias;

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -51,7 +51,9 @@ public:
 //! should be seen as the method of secret creation. (e.g. user-provided config, env variables, auto-detect)
 class CreateSecretFunctionSet {
 public:
-	CreateSecretFunctionSet(string &name) : name(name) {};
+	explicit CreateSecretFunctionSet(string &name) : name(name) {};
+
+public:
 	bool ProviderExists(const string &provider_name);
 	void AddFunction(CreateSecretFunction &function, OnCreateConflict on_conflict);
 	CreateSecretFunction &GetFunction(const string &provider);
@@ -148,17 +150,17 @@ public:
 		D_ASSERT(!type.empty());
 		serializable = true;
 	}
-	KeyValueSecret(BaseSecret &secret)
+	explicit KeyValueSecret(BaseSecret &secret)
 	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
 		serializable = true;
 	};
-	KeyValueSecret(const KeyValueSecret &secret)
+	explicit KeyValueSecret(const KeyValueSecret &secret)
 	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
 		secret_map = secret.secret_map;
 		redact_keys = secret.redact_keys;
 		serializable = true;
 	};
-	KeyValueSecret(KeyValueSecret &&secret)
+	explicit KeyValueSecret(KeyValueSecret &&secret)
 	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
 		secret_map = std::move(secret.secret_map);
 		redact_keys = std::move(secret.redact_keys);

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -83,8 +83,9 @@ class BaseSecret {
 	friend class SecretManager;
 
 public:
-	BaseSecret(const vector<string> &prefix_paths, const string &type, const string &provider, const string &name)
-	    : prefix_paths(prefix_paths), type(type), provider(provider), name(name), serializable(false) {
+	BaseSecret(vector<string> prefix_paths_p, string type_p, string provider_p, string name_p)
+	    : prefix_paths(std::move(prefix_paths_p)), type(std::move(type_p)), provider(std::move(provider_p)),
+		  name(std::move(name_p)), serializable(false) {
 		D_ASSERT(!type.empty());
 	}
 	BaseSecret(const BaseSecret &other)
@@ -150,7 +151,7 @@ public:
 		D_ASSERT(!type.empty());
 		serializable = true;
 	}
-	explicit KeyValueSecret(BaseSecret &secret)
+	explicit KeyValueSecret(const BaseSecret &secret)
 	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
 		serializable = true;
 	};
@@ -161,7 +162,7 @@ public:
 		serializable = true;
 	};
 	KeyValueSecret(KeyValueSecret &&secret) noexcept
-	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
+	    : BaseSecret(std::move(secret.prefix_paths), std::move(secret.type), std::move(secret.provider), std::move(secret.name)) {
 		secret_map = std::move(secret.secret_map);
 		redact_keys = std::move(secret.redact_keys);
 		serializable = true;

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -85,7 +85,7 @@ class BaseSecret {
 public:
 	BaseSecret(vector<string> prefix_paths_p, string type_p, string provider_p, string name_p)
 	    : prefix_paths(std::move(prefix_paths_p)), type(std::move(type_p)), provider(std::move(provider_p)),
-		  name(std::move(name_p)), serializable(false) {
+	      name(std::move(name_p)), serializable(false) {
 		D_ASSERT(!type.empty());
 	}
 	BaseSecret(const BaseSecret &other)
@@ -162,7 +162,8 @@ public:
 		serializable = true;
 	};
 	KeyValueSecret(KeyValueSecret &&secret) noexcept
-	    : BaseSecret(std::move(secret.prefix_paths), std::move(secret.type), std::move(secret.provider), std::move(secret.name)) {
+	    : BaseSecret(std::move(secret.prefix_paths), std::move(secret.type), std::move(secret.provider),
+	                 std::move(secret.name)) {
 		secret_map = std::move(secret.secret_map);
 		redact_keys = std::move(secret.redact_keys);
 		serializable = true;

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -154,13 +154,13 @@ public:
 	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
 		serializable = true;
 	};
-	explicit KeyValueSecret(const KeyValueSecret &secret)
+	KeyValueSecret(const KeyValueSecret &secret)
 	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
 		secret_map = secret.secret_map;
 		redact_keys = secret.redact_keys;
 		serializable = true;
 	};
-	explicit KeyValueSecret(KeyValueSecret &&secret)
+	KeyValueSecret(KeyValueSecret &&secret) noexcept
 	    : BaseSecret(secret.GetScope(), secret.GetType(), secret.GetProvider(), secret.GetName()) {
 		secret_map = std::move(secret.secret_map);
 		redact_keys = std::move(secret.redact_keys);
@@ -168,7 +168,7 @@ public:
 	};
 
 	//! Print the secret as a key value map in the format 'key1=value;key2=value2'
-	virtual string ToString(SecretDisplayType mode = SecretDisplayType::REDACTED) const override;
+	string ToString(SecretDisplayType mode = SecretDisplayType::REDACTED) const override;
 	void Serialize(Serializer &serializer) const override;
 
 	//! Tries to get the value at key <key>, depending on error_on_missing will throw or return Value()

--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -55,7 +55,8 @@ public:
 //! A Secret Entry in the secret manager
 struct SecretEntry {
 public:
-	explicit SecretEntry(unique_ptr<const BaseSecret> secret) : secret(secret != nullptr ? secret->Clone() : nullptr) {}
+	explicit SecretEntry(unique_ptr<const BaseSecret> secret) : secret(secret != nullptr ? secret->Clone() : nullptr) {
+	}
 	SecretEntry(const SecretEntry &other)
 	    : persist_type(other.persist_type), storage_mode(other.storage_mode),
 	      secret((other.secret != nullptr) ? other.secret->Clone() : nullptr) {

--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -55,8 +55,7 @@ public:
 //! A Secret Entry in the secret manager
 struct SecretEntry {
 public:
-	SecretEntry(unique_ptr<const BaseSecret> secret) : secret(secret != nullptr ? secret->Clone() : nullptr) {};
-
+	explicit SecretEntry(unique_ptr<const BaseSecret> secret) : secret(secret != nullptr ? secret->Clone() : nullptr) {}
 	SecretEntry(const SecretEntry &other)
 	    : persist_type(other.persist_type), storage_mode(other.storage_mode),
 	      secret((other.secret != nullptr) ? other.secret->Clone() : nullptr) {

--- a/src/include/duckdb/main/secret/secret_storage.hpp
+++ b/src/include/duckdb/main/secret/secret_storage.hpp
@@ -26,7 +26,7 @@ class SecretStorage {
 	friend class SecretManager;
 
 public:
-	SecretStorage(const string &name) : storage_name(name), persistent(false) {};
+	explicit SecretStorage(const string &name) : storage_name(name), persistent(false) {};
 	virtual ~SecretStorage() = default;
 
 public:
@@ -103,7 +103,7 @@ public:
 		return storage_name;
 	};
 
-	virtual unique_ptr<SecretEntry> StoreSecret(unique_ptr<const BaseSecret> secret, OnCreateConflict on_conflict,
+	unique_ptr<SecretEntry> StoreSecret(unique_ptr<const BaseSecret> secret, OnCreateConflict on_conflict,
 	                                            optional_ptr<CatalogTransaction> transaction = nullptr) override;
 	vector<SecretEntry> AllSecrets(optional_ptr<CatalogTransaction> transaction = nullptr) override;
 	void DropSecretByName(const string &name, OnEntryNotFound on_entry_not_found,
@@ -153,7 +153,7 @@ protected:
 	//! Implements the writes to disk
 	void WriteSecret(const BaseSecret &secret, OnCreateConflict on_conflict) override;
 	//! Implements the deletes from disk
-	virtual void RemoveSecret(const string &secret, OnEntryNotFound on_entry_not_found) override;
+	void RemoveSecret(const string &secret, OnEntryNotFound on_entry_not_found) override;
 
 	//! Set of persistent secrets that are lazily loaded
 	case_insensitive_set_t persistent_secrets;

--- a/src/include/duckdb/main/secret/secret_storage.hpp
+++ b/src/include/duckdb/main/secret/secret_storage.hpp
@@ -104,7 +104,7 @@ public:
 	};
 
 	unique_ptr<SecretEntry> StoreSecret(unique_ptr<const BaseSecret> secret, OnCreateConflict on_conflict,
-	                                            optional_ptr<CatalogTransaction> transaction = nullptr) override;
+	                                    optional_ptr<CatalogTransaction> transaction = nullptr) override;
 	vector<SecretEntry> AllSecrets(optional_ptr<CatalogTransaction> transaction = nullptr) override;
 	void DropSecretByName(const string &name, OnEntryNotFound on_entry_not_found,
 	                      optional_ptr<CatalogTransaction> transaction = nullptr) override;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -24,12 +24,12 @@ struct SettingLookupResult {
 public:
 	SettingLookupResult() : scope(SettingScope::INVALID) {
 	}
-	SettingLookupResult(SettingScope scope) : scope(scope) {
+	explicit SettingLookupResult(SettingScope scope) : scope(scope) {
 		D_ASSERT(scope != SettingScope::INVALID);
 	}
 
 public:
-	operator bool() {
+	operator bool() { // NOLINT: allow implicit conversion to bool
 		return scope != SettingScope::INVALID;
 	}
 

--- a/src/include/duckdb/optimizer/join_order/cardinality_estimator.hpp
+++ b/src/include/duckdb/optimizer/join_order/cardinality_estimator.hpp
@@ -28,7 +28,7 @@ struct RelationsToTDom {
 	vector<FilterInfo *> filters;
 	vector<string> column_names;
 
-	RelationsToTDom(const column_binding_set_t &column_binding_set)
+	explicit RelationsToTDom(const column_binding_set_t &column_binding_set)
 	    : equivalent_relations(column_binding_set), tdom_hll(0), tdom_no_hll(NumericLimits<idx_t>::Maximum()),
 	      has_tdom_hll(false) {};
 };

--- a/src/include/duckdb/optimizer/join_order/cost_model.hpp
+++ b/src/include/duckdb/optimizer/join_order/cost_model.hpp
@@ -16,7 +16,7 @@ class QueryGraphManager;
 
 class CostModel {
 public:
-	CostModel(QueryGraphManager &query_graph_manager);
+	explicit CostModel(QueryGraphManager &query_graph_manager);
 
 private:
 	//! query graph storing relation manager information

--- a/src/include/duckdb/optimizer/join_order/join_node.hpp
+++ b/src/include/duckdb/optimizer/join_order/join_node.hpp
@@ -38,7 +38,7 @@ public:
 	//! Create a leaf node in the join tree
 	//! set cost to 0 for leaf nodes
 	//! cost will be the cost to *produce* an intermediate table
-	JoinNode(JoinRelationSet &set);
+	explicit JoinNode(JoinRelationSet &set);
 
 	bool operator==(const JoinNode &other) {
 		return other.set.ToString().compare(set.ToString()) == 0;

--- a/src/include/duckdb/optimizer/join_order/query_graph.hpp
+++ b/src/include/duckdb/optimizer/join_order/query_graph.hpp
@@ -26,7 +26,7 @@ namespace duckdb {
 struct FilterInfo;
 
 struct NeighborInfo {
-	NeighborInfo(optional_ptr<JoinRelationSet> neighbor) : neighbor(neighbor) {
+	explicit NeighborInfo(optional_ptr<JoinRelationSet> neighbor) : neighbor(neighbor) {
 	}
 
 	optional_ptr<JoinRelationSet> neighbor;

--- a/src/include/duckdb/optimizer/join_order/query_graph_manager.hpp
+++ b/src/include/duckdb/optimizer/join_order/query_graph_manager.hpp
@@ -57,7 +57,7 @@ struct FilterInfo {
 //! When the plan enumerator finishes, the Query Graph Manger can then recreate the logical plan.
 class QueryGraphManager {
 public:
-	QueryGraphManager(ClientContext &context) : relation_manager(context), context(context) {
+	explicit QueryGraphManager(ClientContext &context) : relation_manager(context), context(context) {
 	}
 
 	//! manage relations and the logical operators they represent

--- a/src/include/duckdb/optimizer/join_order/relation_manager.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_manager.hpp
@@ -31,7 +31,7 @@ struct SingleJoinRelation {
 	SingleJoinRelation(LogicalOperator &op, optional_ptr<LogicalOperator> parent) : op(op), parent(parent) {
 	}
 	SingleJoinRelation(LogicalOperator &op, optional_ptr<LogicalOperator> parent, RelationStats stats)
-	    : op(op), parent(parent), stats(stats) {
+	    : op(op), parent(parent), stats(std::move(stats)) {
 	}
 };
 

--- a/src/include/duckdb/optimizer/matcher/expression_matcher.hpp
+++ b/src/include/duckdb/optimizer/matcher/expression_matcher.hpp
@@ -61,7 +61,7 @@ public:
 	CaseExpressionMatcher() : ExpressionMatcher(ExpressionClass::BOUND_CASE) {
 	}
 
-	bool Match(Expression &expr_, vector<reference<Expression>> &bindings) override;
+	bool Match(Expression &expr, vector<reference<Expression>> &bindings) override;
 };
 
 class ComparisonExpressionMatcher : public ExpressionMatcher {
@@ -74,7 +74,7 @@ public:
 	//! The set matcher matching policy to use
 	SetMatcher::Policy policy;
 
-	bool Match(Expression &expr_, vector<reference<Expression>> &bindings) override;
+	bool Match(Expression &expr, vector<reference<Expression>> &bindings) override;
 };
 
 class CastExpressionMatcher : public ExpressionMatcher {
@@ -84,7 +84,7 @@ public:
 	//! The matcher for the child expressions
 	unique_ptr<ExpressionMatcher> matcher;
 
-	bool Match(Expression &expr_, vector<reference<Expression>> &bindings) override;
+	bool Match(Expression &expr, vector<reference<Expression>> &bindings) override;
 };
 
 class InClauseExpressionMatcher : public ExpressionMatcher {
@@ -96,7 +96,7 @@ public:
 	//! The set matcher matching policy to use
 	SetMatcher::Policy policy;
 
-	bool Match(Expression &expr_, vector<reference<Expression>> &bindings) override;
+	bool Match(Expression &expr, vector<reference<Expression>> &bindings) override;
 };
 
 class ConjunctionExpressionMatcher : public ExpressionMatcher {
@@ -109,7 +109,7 @@ public:
 	//! The set matcher matching policy to use
 	SetMatcher::Policy policy;
 
-	bool Match(Expression &expr_, vector<reference<Expression>> &bindings) override;
+	bool Match(Expression &expr, vector<reference<Expression>> &bindings) override;
 };
 
 class FunctionExpressionMatcher : public ExpressionMatcher {
@@ -123,7 +123,7 @@ public:
 	//! The function name to match
 	unique_ptr<FunctionMatcher> function;
 
-	bool Match(Expression &expr_, vector<reference<Expression>> &bindings) override;
+	bool Match(Expression &expr, vector<reference<Expression>> &bindings) override;
 };
 
 //! The FoldableConstant matcher matches any expression that is foldable into a constant by the ExpressionExecutor (i.e.

--- a/src/include/duckdb/optimizer/matcher/type_matcher.hpp
+++ b/src/include/duckdb/optimizer/matcher/type_matcher.hpp
@@ -24,7 +24,7 @@ public:
 //! The SpecificTypeMatcher class matches only a single specified type
 class SpecificTypeMatcher : public TypeMatcher {
 public:
-	explicit SpecificTypeMatcher(LogicalType type) : type(type) {
+	explicit SpecificTypeMatcher(LogicalType type) : type(std::move(type)) {
 	}
 
 	bool Match(const LogicalType &type_p) override {

--- a/src/include/duckdb/optimizer/unnest_rewriter.hpp
+++ b/src/include/duckdb/optimizer/unnest_rewriter.hpp
@@ -26,7 +26,7 @@ struct ReplaceBinding {
 
 struct LHSBinding {
 	LHSBinding() {};
-	LHSBinding(ColumnBinding binding, LogicalType type) : binding(binding), type(type) {
+	LHSBinding(ColumnBinding binding, LogicalType type_p) : binding(binding), type(std::move(type_p)) {
 	}
 	ColumnBinding binding;
 	LogicalType type;

--- a/src/include/duckdb/parallel/executor_task.hpp
+++ b/src/include/duckdb/parallel/executor_task.hpp
@@ -19,7 +19,7 @@ class ExecutorTask : public Task {
 public:
 	ExecutorTask(Executor &executor, shared_ptr<Event> event);
 	ExecutorTask(ClientContext &context, shared_ptr<Event> event);
-	virtual ~ExecutorTask();
+	~ExecutorTask() override;
 
 public:
 	void Deschedule() override;

--- a/src/include/duckdb/parallel/interrupt.hpp
+++ b/src/include/duckdb/parallel/interrupt.hpp
@@ -44,9 +44,9 @@ public:
 	//! Default interrupt state will be set to InterruptMode::NO_INTERRUPTS and throw an error on use of Callback()
 	InterruptState();
 	//! Register the task to be interrupted and set mode to InterruptMode::TASK, the preferred way to handle interrupts
-	InterruptState(weak_ptr<Task> task);
+	explicit InterruptState(weak_ptr<Task> task);
 	//! Register signal state and set mode to InterruptMode::BLOCKING, used for code paths without Task.
-	InterruptState(weak_ptr<InterruptDoneSignalState> done_signal);
+	explicit InterruptState(weak_ptr<InterruptDoneSignalState> done_signal);
 
 	//! Perform the callback to indicate the Interrupt is over
 	DUCKDB_API void Callback() const;

--- a/src/include/duckdb/parallel/pipeline_event.hpp
+++ b/src/include/duckdb/parallel/pipeline_event.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 //! A PipelineEvent is responsible for scheduling a pipeline
 class PipelineEvent : public BasePipelineEvent {
 public:
-	PipelineEvent(shared_ptr<Pipeline> pipeline);
+	explicit PipelineEvent(shared_ptr<Pipeline> pipeline);
 
 public:
 	void Schedule() override;

--- a/src/include/duckdb/parser/column_list.hpp
+++ b/src/include/duckdb/parser/column_list.hpp
@@ -18,7 +18,7 @@ public:
 	class ColumnListIterator;
 
 public:
-	DUCKDB_API ColumnList(bool allow_duplicate_names = false);
+	DUCKDB_API explicit ColumnList(bool allow_duplicate_names = false);
 	DUCKDB_API explicit ColumnList(vector<ColumnDefinition> columns, bool allow_duplicate_names = false);
 
 	DUCKDB_API void AddColumn(ColumnDefinition column);
@@ -45,7 +45,7 @@ public:
 	idx_t PhysicalColumnCount() const {
 		return physical_columns.size();
 	}
-	bool empty() const {
+	bool empty() const { // NOLINT: match stl API
 		return columns.empty();
 	}
 
@@ -117,10 +117,10 @@ public:
 			return physical ? list.PhysicalColumnCount() : list.LogicalColumnCount();
 		}
 
-		ColumnLogicalIteratorInternal begin() {
+		ColumnLogicalIteratorInternal begin() { // NOLINT: match stl API
 			return ColumnLogicalIteratorInternal(list, physical, 0, Size());
 		}
-		ColumnLogicalIteratorInternal end() {
+		ColumnLogicalIteratorInternal end() { // NOLINT: match stl API
 			return ColumnLogicalIteratorInternal(list, physical, Size(), Size());
 		}
 	};

--- a/src/include/duckdb/parser/expression/bound_expression.hpp
+++ b/src/include/duckdb/parser/expression/bound_expression.hpp
@@ -22,7 +22,7 @@ public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::BOUND_EXPRESSION;
 
 public:
-	BoundExpression(unique_ptr<Expression> expr);
+	explicit BoundExpression(unique_ptr<Expression> expr);
 
 	unique_ptr<Expression> expr;
 

--- a/src/include/duckdb/parser/expression/positional_reference_expression.hpp
+++ b/src/include/duckdb/parser/expression/positional_reference_expression.hpp
@@ -16,7 +16,7 @@ public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::POSITIONAL_REFERENCE;
 
 public:
-	DUCKDB_API PositionalReferenceExpression(idx_t index);
+	DUCKDB_API explicit PositionalReferenceExpression(idx_t index);
 
 	idx_t index;
 

--- a/src/include/duckdb/parser/expression/star_expression.hpp
+++ b/src/include/duckdb/parser/expression/star_expression.hpp
@@ -19,7 +19,7 @@ public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::STAR;
 
 public:
-	StarExpression(string relation_name = string());
+	explicit StarExpression(string relation_name = string());
 
 	//! The relation name in case of tbl.*, or empty if this is a normal *
 	string relation_name;

--- a/src/include/duckdb/parser/parsed_data/alter_scalar_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_scalar_function_info.hpp
@@ -21,7 +21,7 @@ enum class AlterScalarFunctionType : uint8_t { INVALID = 0, ADD_FUNCTION_OVERLOA
 
 struct AlterScalarFunctionInfo : public AlterInfo {
 	AlterScalarFunctionInfo(AlterScalarFunctionType type, AlterEntryData data);
-	virtual ~AlterScalarFunctionInfo() override;
+	~AlterScalarFunctionInfo() override;
 
 	AlterScalarFunctionType alter_scalar_function_type;
 

--- a/src/include/duckdb/parser/parsed_data/alter_table_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_table_function_info.hpp
@@ -21,7 +21,7 @@ enum class AlterTableFunctionType : uint8_t { INVALID = 0, ADD_FUNCTION_OVERLOAD
 
 struct AlterTableFunctionInfo : public AlterInfo {
 	AlterTableFunctionInfo(AlterTableFunctionType type, AlterEntryData data);
-	virtual ~AlterTableFunctionInfo() override;
+	~AlterTableFunctionInfo() override;
 
 	AlterTableFunctionType alter_table_function_type;
 

--- a/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
@@ -307,7 +307,7 @@ public:
 	static unique_ptr<AlterInfo> Deserialize(Deserializer &deserializer);
 
 protected:
-	AlterViewInfo(AlterViewType type);
+	explicit AlterViewInfo(AlterViewType type);
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/parser/parsed_data/create_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_function_info.hpp
@@ -14,7 +14,8 @@
 namespace duckdb {
 
 struct CreateFunctionInfo : public CreateInfo {
-	explicit CreateFunctionInfo(CatalogType type, string schema = DEFAULT_SCHEMA) : CreateInfo(type, std::move(schema)) {
+	explicit CreateFunctionInfo(CatalogType type, string schema = DEFAULT_SCHEMA)
+	    : CreateInfo(type, std::move(schema)) {
 		D_ASSERT(type == CatalogType::SCALAR_FUNCTION_ENTRY || type == CatalogType::AGGREGATE_FUNCTION_ENTRY ||
 		         type == CatalogType::TABLE_FUNCTION_ENTRY || type == CatalogType::PRAGMA_FUNCTION_ENTRY ||
 		         type == CatalogType::MACRO_ENTRY || type == CatalogType::TABLE_MACRO_ENTRY);

--- a/src/include/duckdb/parser/parsed_data/create_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_function_info.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 struct CreateFunctionInfo : public CreateInfo {
-	explicit CreateFunctionInfo(CatalogType type, string schema = DEFAULT_SCHEMA) : CreateInfo(type, schema) {
+	explicit CreateFunctionInfo(CatalogType type, string schema = DEFAULT_SCHEMA) : CreateInfo(type, std::move(schema)) {
 		D_ASSERT(type == CatalogType::SCALAR_FUNCTION_ENTRY || type == CatalogType::AGGREGATE_FUNCTION_ENTRY ||
 		         type == CatalogType::TABLE_FUNCTION_ENTRY || type == CatalogType::PRAGMA_FUNCTION_ENTRY ||
 		         type == CatalogType::MACRO_ENTRY || type == CatalogType::TABLE_MACRO_ENTRY);

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -23,7 +23,7 @@ public:
 
 public:
 	explicit CreateInfo(CatalogType type, string schema = DEFAULT_SCHEMA, string catalog_p = INVALID_CATALOG)
-	    : ParseInfo(TYPE), type(type), catalog(std::move(catalog_p)), schema(schema),
+	    : ParseInfo(TYPE), type(type), catalog(std::move(catalog_p)), schema(std::move(schema)),
 	      on_conflict(OnCreateConflict::ERROR_ON_CONFLICT), temporary(false), internal(false) {
 	}
 	~CreateInfo() override {

--- a/src/include/duckdb/parser/parsed_data/create_macro_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_macro_info.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 struct CreateMacroInfo : public CreateFunctionInfo {
-	CreateMacroInfo(CatalogType type);
+	explicit CreateMacroInfo(CatalogType type);
 
 	unique_ptr<MacroFunction> function;
 

--- a/src/include/duckdb/parser/parsed_data/create_pragma_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_pragma_function_info.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 
 struct CreatePragmaFunctionInfo : public CreateFunctionInfo {
 	DUCKDB_API explicit CreatePragmaFunctionInfo(PragmaFunction function);
-	DUCKDB_API CreatePragmaFunctionInfo(string name, PragmaFunctionSet functions_);
+	DUCKDB_API CreatePragmaFunctionInfo(string name, PragmaFunctionSet functions);
 
 	PragmaFunctionSet functions;
 

--- a/src/include/duckdb/parser/parsed_data/create_secret_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_secret_info.hpp
@@ -41,7 +41,7 @@ public:
 	//! Named parameter list (if any)
 	case_insensitive_map_t<Value> options;
 
-	unique_ptr<CreateInfo> Copy() const;
+	unique_ptr<CreateInfo> Copy() const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/create_secret_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_secret_info.hpp
@@ -18,7 +18,7 @@
 
 namespace duckdb {
 
-struct CreateSecretInfo : public CreateInfo {
+struct CreateSecretInfo : public CreateInfo { // NOLINT: work-around bug in clang-tidy
 public:
 	static constexpr const ParseInfoType TYPE = ParseInfoType::CREATE_SECRET_INFO;
 

--- a/src/include/duckdb/parser/parsed_data/extra_drop_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/extra_drop_info.hpp
@@ -57,9 +57,9 @@ struct ExtraDropSecretInfo : public ExtraDropInfo {
 	string secret_storage;
 
 public:
-	virtual unique_ptr<ExtraDropInfo> Copy() const override;
+	unique_ptr<ExtraDropInfo> Copy() const override;
 
-	virtual void Serialize(Serializer &serializer) const override;
+	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<ExtraDropInfo> Deserialize(Deserializer &deserializer);
 };
 

--- a/src/include/duckdb/parser/parser.hpp
+++ b/src/include/duckdb/parser/parser.hpp
@@ -29,7 +29,7 @@ class GroupByNode;
 //! plan and executed.
 class Parser {
 public:
-	Parser(ParserOptions options = ParserOptions());
+	explicit Parser(ParserOptions options = ParserOptions());
 
 	//! The parsed SQL statements from an invocation to ParseQuery.
 	vector<unique_ptr<SQLStatement>> statements;

--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -38,10 +38,10 @@ struct ParserExtensionParseData {
 struct ParserExtensionParseResult {
 	ParserExtensionParseResult() : type(ParserExtensionResultType::DISPLAY_ORIGINAL_ERROR) {
 	}
-	ParserExtensionParseResult(string error_p)
+	explicit ParserExtensionParseResult(string error_p)
 	    : type(ParserExtensionResultType::DISPLAY_EXTENSION_ERROR), error(std::move(error_p)) {
 	}
-	ParserExtensionParseResult(unique_ptr<ParserExtensionParseData> parse_data_p)
+	explicit ParserExtensionParseResult(unique_ptr<ParserExtensionParseData> parse_data_p)
 	    : type(ParserExtensionResultType::PARSE_SUCCESSFUL), parse_data(std::move(parse_data_p)) {
 	}
 

--- a/src/include/duckdb/parser/parser_extension.hpp
+++ b/src/include/duckdb/parser/parser_extension.hpp
@@ -59,7 +59,7 @@ typedef ParserExtensionParseResult (*parse_function_t)(ParserExtensionInfo *info
 //===--------------------------------------------------------------------===//
 // Plan
 //===--------------------------------------------------------------------===//
-struct ParserExtensionPlanResult {
+struct ParserExtensionPlanResult { // NOLINT: work-around bug in clang-tidy
 	//! The table function to execute
 	TableFunction function;
 	//! Parameters to the function

--- a/src/include/duckdb/parser/query_error_context.hpp
+++ b/src/include/duckdb/parser/query_error_context.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 
 class QueryErrorContext {
 public:
-	explicit QueryErrorContext(optional_idx query_location_ = optional_idx()) : query_location(query_location_) {
+	explicit QueryErrorContext(optional_idx query_location_p = optional_idx()) : query_location(query_location_p) {
 	}
 
 	//! The location in which the error should be thrown

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -55,7 +55,7 @@ class Transformer {
 
 public:
 	explicit Transformer(ParserOptions &options);
-	explicit Transformer(Transformer &parent);
+	Transformer(Transformer &parent);
 	~Transformer();
 
 	//! Transforms a Postgres parse tree into a set of SQL Statements

--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -38,7 +38,7 @@ struct UsingColumnSet {
 //! encountered during the binding process.
 class BindContext {
 public:
-	BindContext(Binder &binder);
+	explicit BindContext(Binder &binder);
 
 	//! Keep track of recursive CTE references
 	case_insensitive_map_t<std::shared_ptr<idx_t>> cte_references;
@@ -133,7 +133,7 @@ public:
 		return cte_bindings;
 	}
 	void SetCTEBindings(case_insensitive_map_t<std::shared_ptr<Binding>> bindings) {
-		cte_bindings = bindings;
+		cte_bindings = std::move(bindings);
 	}
 
 	//! Alias a set of column names for the specified table, using the original names if there are not enough aliases

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -61,6 +61,7 @@ struct CorrelatedColumnInfo {
 	string name;
 	idx_t depth;
 
+	// NOLINTNEXTLINE - work-around bug in clang-tidy
 	CorrelatedColumnInfo(ColumnBinding binding, LogicalType type_p, string name_p, idx_t depth)
 	    : binding(binding), type(std::move(type_p)), name(std::move(name_p)), depth(depth) {
 	}

--- a/src/include/duckdb/planner/expression.hpp
+++ b/src/include/duckdb/planner/expression.hpp
@@ -43,7 +43,7 @@ public:
 		if (!BaseExpression::Equals(other)) {
 			return false;
 		}
-		return return_type == ((Expression &)other).return_type;
+		return return_type == reinterpret_cast<const Expression &>(other).return_type;
 	}
 	static bool Equals(const Expression &left, const Expression &right) {
 		return left.Equals(right);

--- a/src/include/duckdb/planner/expression/bound_case_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_case_expression.hpp
@@ -25,7 +25,7 @@ public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::BOUND_CASE;
 
 public:
-	BoundCaseExpression(LogicalType type);
+	explicit BoundCaseExpression(LogicalType type);
 	BoundCaseExpression(unique_ptr<Expression> when_expr, unique_ptr<Expression> then_expr,
 	                    unique_ptr<Expression> else_expr);
 

--- a/src/include/duckdb/planner/expression/bound_cast_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_cast_expression.hpp
@@ -29,7 +29,7 @@ public:
 	BoundCastInfo bound_cast;
 
 public:
-	LogicalType source_type() {
+	LogicalType source_type() { // NOLINT: allow casing for legacy reasons
 		D_ASSERT(child->return_type.IsValid());
 		return child->return_type;
 	}

--- a/src/include/duckdb/planner/expression/bound_default_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_default_expression.hpp
@@ -18,7 +18,7 @@ public:
 
 public:
 	explicit BoundDefaultExpression(LogicalType type = LogicalType())
-	    : Expression(ExpressionType::VALUE_DEFAULT, ExpressionClass::BOUND_DEFAULT, type) {
+	    : Expression(ExpressionType::VALUE_DEFAULT, ExpressionClass::BOUND_DEFAULT, std::move(type)) {
 	}
 
 public:

--- a/src/include/duckdb/planner/expression/bound_subquery_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_subquery_expression.hpp
@@ -23,7 +23,7 @@ public:
 	explicit BoundSubqueryExpression(LogicalType return_type);
 
 	bool IsCorrelated() {
-		return binder->correlated_columns.size() > 0;
+		return !binder->correlated_columns.empty();
 	}
 
 	//! The binder used to bind the subquery node

--- a/src/include/duckdb/planner/filter/conjunction_filter.hpp
+++ b/src/include/duckdb/planner/filter/conjunction_filter.hpp
@@ -14,20 +14,17 @@
 namespace duckdb {
 class ConjunctionFilter : public TableFilter {
 public:
-	ConjunctionFilter(TableFilterType filter_type_p) : TableFilter(filter_type_p) {
+	explicit ConjunctionFilter(TableFilterType filter_type_p) : TableFilter(filter_type_p) {
 	}
 
-	virtual ~ConjunctionFilter() {
+	~ConjunctionFilter() override {
 	}
 
 	//! The filters of this conjunction
 	vector<unique_ptr<TableFilter>> child_filters;
 
 public:
-	virtual FilterPropagateResult CheckStatistics(BaseStatistics &stats) = 0;
-	virtual string ToString(const string &column_name) = 0;
-
-	virtual bool Equals(const TableFilter &other) const {
+	bool Equals(const TableFilter &other) const override {
 		return TableFilter::Equals(other);
 	}
 };

--- a/src/include/duckdb/planner/operator/logical_create_secret.hpp
+++ b/src/include/duckdb/planner/operator/logical_create_secret.hpp
@@ -19,7 +19,7 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_CREATE_SECRET;
 
 public:
-	LogicalCreateSecret(CreateSecretFunction function_p, CreateSecretInfo info_p)
+	explicit LogicalCreateSecret(CreateSecretInfo info_p)
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_CREATE_SECRET), info(std::move(info_p)) {
 	}
 

--- a/src/include/duckdb/planner/operator/logical_cteref.hpp
+++ b/src/include/duckdb/planner/operator/logical_cteref.hpp
@@ -24,8 +24,8 @@ public:
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_CTE_REF), table_index(table_index), cte_index(cte_index),
 	      correlated_columns(0), materialized_cte(materialized_cte) {
 		D_ASSERT(types.size() > 0);
-		chunk_types = types;
-		bound_columns = colnames;
+		chunk_types = std::move(types);
+		bound_columns = std::move(colnames);
 	}
 
 	vector<string> bound_columns;

--- a/src/include/duckdb/planner/operator/logical_delim_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_delim_get.hpp
@@ -21,7 +21,7 @@ public:
 	LogicalDelimGet(idx_t table_index, vector<LogicalType> types)
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_DELIM_GET), table_index(table_index) {
 		D_ASSERT(types.size() > 0);
-		chunk_types = types;
+		chunk_types = std::move(types);
 	}
 
 	//! The table index in the current bind context

--- a/src/include/duckdb/planner/operator/logical_dummy_scan.hpp
+++ b/src/include/duckdb/planner/operator/logical_dummy_scan.hpp
@@ -39,7 +39,7 @@ public:
 
 protected:
 	void ResolveTypes() override {
-		if (types.size() == 0) {
+		if (types.empty()) {
 			types.emplace_back(LogicalType::INTEGER);
 		}
 	}

--- a/src/include/duckdb/planner/operator/logical_explain.hpp
+++ b/src/include/duckdb/planner/operator/logical_explain.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 class LogicalExplain : public LogicalOperator {
-	LogicalExplain(ExplainType explain_type)
+	explicit LogicalExplain(ExplainType explain_type)
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXPLAIN), explain_type(explain_type) {};
 
 public:

--- a/src/include/duckdb/planner/operator/logical_export.hpp
+++ b/src/include/duckdb/planner/operator/logical_export.hpp
@@ -21,8 +21,8 @@ public:
 
 public:
 	LogicalExport(CopyFunction function, unique_ptr<CopyInfo> copy_info, BoundExportData exported_tables)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXPORT), function(function), copy_info(std::move(copy_info)),
-	      exported_tables(std::move(exported_tables)) {
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXPORT), function(std::move(function)),
+		  copy_info(std::move(copy_info)), exported_tables(std::move(exported_tables)) {
 	}
 	CopyFunction function;
 	unique_ptr<CopyInfo> copy_info;

--- a/src/include/duckdb/planner/operator/logical_export.hpp
+++ b/src/include/duckdb/planner/operator/logical_export.hpp
@@ -22,7 +22,7 @@ public:
 public:
 	LogicalExport(CopyFunction function, unique_ptr<CopyInfo> copy_info, BoundExportData exported_tables)
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXPORT), function(std::move(function)),
-		  copy_info(std::move(copy_info)), exported_tables(std::move(exported_tables)) {
+	      copy_info(std::move(copy_info)), exported_tables(std::move(exported_tables)) {
 	}
 	CopyFunction function;
 	unique_ptr<CopyInfo> copy_info;

--- a/src/include/duckdb/planner/operator/logical_expression_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_expression_get.hpp
@@ -20,7 +20,7 @@ public:
 public:
 	LogicalExpressionGet(idx_t table_index, vector<LogicalType> types,
 	                     vector<vector<unique_ptr<Expression>>> expressions)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXPRESSION_GET), table_index(table_index), expr_types(types),
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXPRESSION_GET), table_index(table_index), expr_types(std::move(types)),
 	      expressions(std::move(expressions)) {
 	}
 

--- a/src/include/duckdb/planner/operator/logical_expression_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_expression_get.hpp
@@ -20,8 +20,8 @@ public:
 public:
 	LogicalExpressionGet(idx_t table_index, vector<LogicalType> types,
 	                     vector<vector<unique_ptr<Expression>>> expressions)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXPRESSION_GET), table_index(table_index), expr_types(std::move(types)),
-	      expressions(std::move(expressions)) {
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXPRESSION_GET), table_index(table_index),
+	      expr_types(std::move(types)), expressions(std::move(expressions)) {
 	}
 
 	//! The table index in the current bind context

--- a/src/include/duckdb/planner/operator/logical_extension_operator.hpp
+++ b/src/include/duckdb/planner/operator/logical_extension_operator.hpp
@@ -26,7 +26,7 @@ public:
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR, std::move(expressions)) {
 	}
 
-	virtual void Serialize(Serializer &serializer) const override;
+	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(Deserializer &deserializer);
 
 	virtual unique_ptr<PhysicalOperator> CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) = 0;

--- a/src/include/duckdb/planner/operator/logical_extension_operator.hpp
+++ b/src/include/duckdb/planner/operator/logical_extension_operator.hpp
@@ -22,7 +22,7 @@ public:
 public:
 	LogicalExtensionOperator() : LogicalOperator(LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR) {
 	}
-	LogicalExtensionOperator(vector<unique_ptr<Expression>> expressions)
+	explicit LogicalExtensionOperator(vector<unique_ptr<Expression>> expressions)
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR, std::move(expressions)) {
 	}
 

--- a/src/include/duckdb/planner/operator/logical_materialized_cte.hpp
+++ b/src/include/duckdb/planner/operator/logical_materialized_cte.hpp
@@ -20,10 +20,10 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_MATERIALIZED_CTE;
 
 public:
-	LogicalMaterializedCTE(string ctename, idx_t table_index, idx_t column_count, unique_ptr<LogicalOperator> cte,
+	LogicalMaterializedCTE(string ctename_p, idx_t table_index, idx_t column_count, unique_ptr<LogicalOperator> cte,
 	                       unique_ptr<LogicalOperator> child)
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_MATERIALIZED_CTE), table_index(table_index),
-	      column_count(column_count), ctename(ctename) {
+	      column_count(column_count), ctename(std::move(ctename_p)) {
 		children.push_back(std::move(cte));
 		children.push_back(std::move(child));
 	}

--- a/src/include/duckdb/planner/operator/logical_pragma.hpp
+++ b/src/include/duckdb/planner/operator/logical_pragma.hpp
@@ -19,7 +19,7 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_PRAGMA;
 
 public:
-	LogicalPragma(unique_ptr<BoundPragmaInfo> info_p)
+	explicit LogicalPragma(unique_ptr<BoundPragmaInfo> info_p)
 	    : LogicalOperator(LogicalOperatorType::LOGICAL_PRAGMA), info(std::move(info_p)) {
 	}
 

--- a/src/include/duckdb/planner/operator/logical_prepare.hpp
+++ b/src/include/duckdb/planner/operator/logical_prepare.hpp
@@ -22,8 +22,8 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_PREPARE;
 
 public:
-	LogicalPrepare(string name, shared_ptr<PreparedStatementData> prepared, unique_ptr<LogicalOperator> logical_plan)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_PREPARE), name(name), prepared(std::move(prepared)) {
+	LogicalPrepare(string name_p, shared_ptr<PreparedStatementData> prepared, unique_ptr<LogicalOperator> logical_plan)
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_PREPARE), name(std::move(name_p)), prepared(std::move(prepared)) {
 		if (logical_plan) {
 			children.push_back(std::move(logical_plan));
 		}

--- a/src/include/duckdb/planner/operator/logical_prepare.hpp
+++ b/src/include/duckdb/planner/operator/logical_prepare.hpp
@@ -23,7 +23,8 @@ public:
 
 public:
 	LogicalPrepare(string name_p, shared_ptr<PreparedStatementData> prepared, unique_ptr<LogicalOperator> logical_plan)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_PREPARE), name(std::move(name_p)), prepared(std::move(prepared)) {
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_PREPARE), name(std::move(name_p)),
+	      prepared(std::move(prepared)) {
 		if (logical_plan) {
 			children.push_back(std::move(logical_plan));
 		}

--- a/src/include/duckdb/planner/operator/logical_recursive_cte.hpp
+++ b/src/include/duckdb/planner/operator/logical_recursive_cte.hpp
@@ -23,8 +23,8 @@ public:
 public:
 	LogicalRecursiveCTE(string ctename_p, idx_t table_index, idx_t column_count, bool union_all,
 	                    unique_ptr<LogicalOperator> top, unique_ptr<LogicalOperator> bottom)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_RECURSIVE_CTE), union_all(union_all), ctename(std::move(ctename_p)),
-	      table_index(table_index), column_count(column_count) {
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_RECURSIVE_CTE), union_all(union_all),
+	      ctename(std::move(ctename_p)), table_index(table_index), column_count(column_count) {
 		children.push_back(std::move(top));
 		children.push_back(std::move(bottom));
 	}

--- a/src/include/duckdb/planner/operator/logical_recursive_cte.hpp
+++ b/src/include/duckdb/planner/operator/logical_recursive_cte.hpp
@@ -21,9 +21,9 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_RECURSIVE_CTE;
 
 public:
-	LogicalRecursiveCTE(string ctename, idx_t table_index, idx_t column_count, bool union_all,
+	LogicalRecursiveCTE(string ctename_p, idx_t table_index, idx_t column_count, bool union_all,
 	                    unique_ptr<LogicalOperator> top, unique_ptr<LogicalOperator> bottom)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_RECURSIVE_CTE), union_all(union_all), ctename(ctename),
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_RECURSIVE_CTE), union_all(union_all), ctename(std::move(ctename_p)),
 	      table_index(table_index), column_count(column_count) {
 		children.push_back(std::move(top));
 		children.push_back(std::move(bottom));

--- a/src/include/duckdb/planner/operator/logical_reset.hpp
+++ b/src/include/duckdb/planner/operator/logical_reset.hpp
@@ -21,7 +21,7 @@ public:
 
 public:
 	LogicalReset(std::string name_p, SetScope scope_p)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_RESET), name(name_p), scope(scope_p) {
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_RESET), name(std::move(name_p)), scope(scope_p) {
 	}
 
 	std::string name;

--- a/src/include/duckdb/planner/operator/logical_set.hpp
+++ b/src/include/duckdb/planner/operator/logical_set.hpp
@@ -21,7 +21,8 @@ public:
 
 public:
 	LogicalSet(std::string name_p, Value value_p, SetScope scope_p)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_SET), name(std::move(name_p)), value(std::move(value_p)), scope(scope_p) {
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_SET), name(std::move(name_p)), value(std::move(value_p)),
+	      scope(scope_p) {
 	}
 
 	std::string name;

--- a/src/include/duckdb/planner/operator/logical_set.hpp
+++ b/src/include/duckdb/planner/operator/logical_set.hpp
@@ -21,7 +21,7 @@ public:
 
 public:
 	LogicalSet(std::string name_p, Value value_p, SetScope scope_p)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_SET), name(name_p), value(value_p), scope(scope_p) {
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_SET), name(std::move(name_p)), value(value_p), scope(scope_p) {
 	}
 
 	std::string name;

--- a/src/include/duckdb/planner/operator/logical_set.hpp
+++ b/src/include/duckdb/planner/operator/logical_set.hpp
@@ -21,7 +21,7 @@ public:
 
 public:
 	LogicalSet(std::string name_p, Value value_p, SetScope scope_p)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_SET), name(std::move(name_p)), value(value_p), scope(scope_p) {
+	    : LogicalOperator(LogicalOperatorType::LOGICAL_SET), name(std::move(name_p)), value(std::move(value_p)), scope(scope_p) {
 	}
 
 	std::string name;

--- a/src/include/duckdb/planner/operator_extension.hpp
+++ b/src/include/duckdb/planner/operator_extension.hpp
@@ -28,7 +28,7 @@ struct LogicalExtensionOperator;
 
 class OperatorExtension {
 public:
-	bind_function_t Bind;
+	bind_function_t Bind; // NOLINT: backwards compatibility
 
 	//! Additional info passed to the CreatePlan & Bind functions
 	shared_ptr<OperatorExtensionInfo> operator_info;

--- a/src/include/duckdb/planner/parsed_data/bound_create_table_info.hpp
+++ b/src/include/duckdb/planner/parsed_data/bound_create_table_info.hpp
@@ -51,7 +51,7 @@ struct BoundCreateTableInfo {
 
 	CreateTableInfo &Base() {
 		D_ASSERT(base);
-		return (CreateTableInfo &)*base;
+		return base->Cast<CreateTableInfo>();
 	}
 };
 

--- a/src/include/duckdb/storage/arena_allocator.hpp
+++ b/src/include/duckdb/storage/arena_allocator.hpp
@@ -28,7 +28,7 @@ class ArenaAllocator {
 	static constexpr const idx_t ARENA_ALLOCATOR_INITIAL_CAPACITY = 2048;
 
 public:
-	DUCKDB_API ArenaAllocator(Allocator &allocator, idx_t initial_capacity = ARENA_ALLOCATOR_INITIAL_CAPACITY);
+	DUCKDB_API explicit ArenaAllocator(Allocator &allocator, idx_t initial_capacity = ARENA_ALLOCATOR_INITIAL_CAPACITY);
 	DUCKDB_API ~ArenaAllocator();
 
 	DUCKDB_API data_ptr_t Allocate(idx_t size);

--- a/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
@@ -56,10 +56,10 @@ public:
 	MetadataWriter &table_data_writer;
 
 public:
-	virtual void WriteColumnDataPointers(ColumnCheckpointState &column_checkpoint_state,
+	void WriteColumnDataPointers(ColumnCheckpointState &column_checkpoint_state,
 	                                     Serializer &serializer) override;
 
-	virtual MetadataWriter &GetPayloadWriter() override;
+	MetadataWriter &GetPayloadWriter() override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/row_group_writer.hpp
@@ -56,8 +56,7 @@ public:
 	MetadataWriter &table_data_writer;
 
 public:
-	void WriteColumnDataPointers(ColumnCheckpointState &column_checkpoint_state,
-	                                     Serializer &serializer) override;
+	void WriteColumnDataPointers(ColumnCheckpointState &column_checkpoint_state, Serializer &serializer) override;
 
 	MetadataWriter &GetPayloadWriter() override;
 };

--- a/src/include/duckdb/storage/checkpoint/string_checkpoint_state.hpp
+++ b/src/include/duckdb/storage/checkpoint/string_checkpoint_state.hpp
@@ -33,7 +33,7 @@ struct StringBlock {
 	unique_ptr<StringBlock> next;
 };
 
-struct string_location_t {
+struct string_location_t { // NOLINT
 	string_location_t(block_id_t block_id, int32_t offset) : block_id(block_id), offset(offset) {
 	}
 	string_location_t() {

--- a/src/include/duckdb/storage/checkpoint_manager.hpp
+++ b/src/include/duckdb/storage/checkpoint_manager.hpp
@@ -51,7 +51,7 @@ protected:
 
 class CheckpointReader {
 public:
-	CheckpointReader(Catalog &catalog) : catalog(catalog) {
+	explicit CheckpointReader(Catalog &catalog) : catalog(catalog) {
 	}
 	virtual ~CheckpointReader() {
 	}
@@ -102,9 +102,9 @@ public:
 	//! connection is available because right now the checkpointing cannot be done online. (TODO)
 	void CreateCheckpoint();
 
-	virtual MetadataWriter &GetMetadataWriter() override;
-	virtual MetadataManager &GetMetadataManager() override;
-	virtual unique_ptr<TableDataWriter> GetTableDataWriter(TableCatalogEntry &table) override;
+	MetadataWriter &GetMetadataWriter() override;
+	MetadataManager &GetMetadataManager() override;
+	unique_ptr<TableDataWriter> GetTableDataWriter(TableCatalogEntry &table) override;
 
 	BlockManager &GetBlockManager();
 

--- a/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_analyze.hpp
@@ -21,7 +21,7 @@ namespace duckdb {
 template <class T>
 struct AlpAnalyzeState : public AnalyzeState {
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	AlpAnalyzeState() : state() {
 	}

--- a/src/include/duckdb/storage/compression/alp/alp_compress.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_compress.hpp
@@ -32,7 +32,7 @@ template <class T>
 struct AlpCompressionState : public CompressionState {
 
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 	explicit AlpCompressionState(ColumnDataCheckpointer &checkpointer, AlpAnalyzeState<T> *analyze_state)
 	    : checkpointer(checkpointer), function(checkpointer.GetCompressionFunction(CompressionType::COMPRESSION_ALP)) {
 		CreateEmptySegment(checkpointer.GetRowGroup().start);

--- a/src/include/duckdb/storage/compression/alp/alp_fetch.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_fetch.hpp
@@ -25,7 +25,7 @@ namespace duckdb {
 
 template <class T>
 void AlpFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx) {
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	AlpScanState<T> scan_state(segment);
 	scan_state.Skip(segment, row_id);

--- a/src/include/duckdb/storage/compression/alp/alp_scan.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_scan.hpp
@@ -66,7 +66,7 @@ public:
 template <class T>
 struct AlpScanState : public SegmentScanState {
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	explicit AlpScanState(ColumnSegment &segment) : segment(segment), count(segment.count) {
 		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);

--- a/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
+++ b/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
@@ -34,7 +34,7 @@ struct AlpRDLeftPartInfo {
 template <class T, bool EMPTY>
 class AlpRDCompressionState {
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	AlpRDCompressionState() : right_bit_width(0), left_bit_width(0), exceptions_count(0) {
 	}
@@ -63,7 +63,7 @@ public:
 template <class T, bool EMPTY>
 struct AlpRDCompression {
 	using State = AlpRDCompressionState<T, EMPTY>;
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 	static constexpr uint8_t EXACT_TYPE_BITSIZE = sizeof(EXACT_TYPE) * 8;
 
 	/*
@@ -199,7 +199,7 @@ struct AlpRDCompression {
 
 template <class T>
 struct AlpRDDecompression {
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	static void Decompress(uint8_t *left_encoded, uint8_t *right_encoded, const uint16_t *left_parts_dict,
 	                       EXACT_TYPE *output, idx_t values_count, uint16_t exceptions_count,

--- a/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
@@ -23,7 +23,7 @@ namespace duckdb {
 template <class T>
 struct AlpRDAnalyzeState : public AnalyzeState {
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	AlpRDAnalyzeState() : state() {
 	}
@@ -45,7 +45,7 @@ unique_ptr<AnalyzeState> AlpRDInitAnalyze(ColumnData &col_data, PhysicalType typ
  */
 template <class T>
 bool AlpRDAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 	auto &analyze_state = (AlpRDAnalyzeState<T> &)state;
 
 	bool must_skip_current_vector = alp::AlpUtils::MustSkipSamplingFromCurrentVector(

--- a/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
@@ -34,7 +34,7 @@ template <class T>
 struct AlpRDCompressionState : public CompressionState {
 
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 	explicit AlpRDCompressionState(ColumnDataCheckpointer &checkpointer, AlpRDAnalyzeState<T> *analyze_state)
 	    : checkpointer(checkpointer),
 	      function(checkpointer.GetCompressionFunction(CompressionType::COMPRESSION_ALPRD)) {

--- a/src/include/duckdb/storage/compression/alprd/alprd_fetch.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_fetch.hpp
@@ -25,7 +25,7 @@ namespace duckdb {
 
 template <class T>
 void AlpRDFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx) {
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 	AlpRDScanState<T> scan_state(segment);
 	scan_state.Skip(segment, row_id);
 	auto result_data = FlatVector::GetData<EXACT_TYPE>(result);

--- a/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_scan.hpp
@@ -28,7 +28,7 @@ namespace duckdb {
 template <class T>
 struct AlpRDVectorState {
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	void Reset() {
 		index = 0;
@@ -70,7 +70,7 @@ public:
 template <class T>
 struct AlpRDScanState : public SegmentScanState {
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	explicit AlpRDScanState(ColumnSegment &segment) : segment(segment), count(segment.count) {
 		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
@@ -220,7 +220,7 @@ unique_ptr<SegmentScanState> AlpRDInitScan(ColumnSegment &segment) {
 template <class T>
 void AlpRDScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
                       idx_t result_offset) {
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 	auto &scan_state = (AlpRDScanState<T> &)*state.scan_state;
 
 	// Get the pointer to the result values

--- a/src/include/duckdb/storage/compression/chimp/algorithm/flag_buffer.hpp
+++ b/src/include/duckdb/storage/compression/chimp/algorithm/flag_buffer.hpp
@@ -58,7 +58,7 @@ public:
 #endif
 
 	uint64_t BitsWritten() const {
-		return counter * 2;
+		return counter * 2ULL;
 	}
 
 	void Insert(ChimpConstants::Flags value) {

--- a/src/include/duckdb/storage/compression/chimp/algorithm/leading_zero_buffer.hpp
+++ b/src/include/duckdb/storage/compression/chimp/algorithm/leading_zero_buffer.hpp
@@ -98,7 +98,7 @@ public:
 #endif
 
 	inline uint64_t BlockIndex() const {
-		return ((counter >> 3) * (LEADING_ZERO_BLOCK_BIT_SIZE / 8));
+		return ((counter >> 3ULL) * (LEADING_ZERO_BLOCK_BIT_SIZE / 8ULL));
 	}
 
 	void FlushBuffer() {
@@ -111,7 +111,7 @@ public:
 		// Verify that the bits are copied correctly
 
 		uint32_t temp_value = 0;
-		memcpy((uint8_t *)&temp_value, (void *)(buffer + buffer_idx), 3);
+		memcpy(reinterpret_cast<uint8_t *>(&temp_value), (void *)(buffer + buffer_idx), 3);
 		for (idx_t i = 0; i < flags.size(); i++) {
 			D_ASSERT(flags[i] == ExtractValue(temp_value, i));
 		}

--- a/src/include/duckdb/storage/compression/chimp/algorithm/leading_zero_buffer.hpp
+++ b/src/include/duckdb/storage/compression/chimp/algorithm/leading_zero_buffer.hpp
@@ -77,7 +77,7 @@ public:
 	}
 
 	uint64_t BitsWritten() const {
-		return counter * 3;
+		return counter * 3ULL;
 	}
 
 	// Reset the counter, but don't replace the buffer

--- a/src/include/duckdb/storage/compression/chimp/chimp.hpp
+++ b/src/include/duckdb/storage/compression/chimp/chimp.hpp
@@ -25,12 +25,12 @@ struct ChimpType {};
 
 template <>
 struct ChimpType<double> {
-	typedef uint64_t TYPE;
+	using TYPE = uint64_t;
 };
 
 template <>
 struct ChimpType<float> {
-	typedef uint32_t TYPE;
+	using TYPE = uint32_t;
 };
 
 class ChimpPrimitives {

--- a/src/include/duckdb/storage/compression/chimp/chimp.hpp
+++ b/src/include/duckdb/storage/compression/chimp/chimp.hpp
@@ -25,12 +25,12 @@ struct ChimpType {};
 
 template <>
 struct ChimpType<double> {
-	typedef uint64_t type;
+	typedef uint64_t TYPE;
 };
 
 template <>
 struct ChimpType<float> {
-	typedef uint32_t type;
+	typedef uint32_t TYPE;
 };
 
 class ChimpPrimitives {
@@ -46,7 +46,7 @@ public:
 template <class T, bool EMPTY>
 struct ChimpState {
 public:
-	using CHIMP_TYPE = typename ChimpType<T>::type;
+	using CHIMP_TYPE = typename ChimpType<T>::TYPE;
 
 	ChimpState() : chimp() {
 	}

--- a/src/include/duckdb/storage/compression/chimp/chimp_fetch.hpp
+++ b/src/include/duckdb/storage/compression/chimp/chimp_fetch.hpp
@@ -26,7 +26,7 @@ namespace duckdb {
 
 template <class T>
 void ChimpFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx) {
-	using INTERNAL_TYPE = typename ChimpType<T>::type;
+	using INTERNAL_TYPE = typename ChimpType<T>::TYPE;
 
 	ChimpScanState<T> scan_state(segment);
 	scan_state.Skip(segment, row_id);

--- a/src/include/duckdb/storage/compression/chimp/chimp_scan.hpp
+++ b/src/include/duckdb/storage/compression/chimp/chimp_scan.hpp
@@ -135,7 +135,7 @@ private:
 template <class T>
 struct ChimpScanState : public SegmentScanState {
 public:
-	using CHIMP_TYPE = typename ChimpType<T>::type;
+	using CHIMP_TYPE = typename ChimpType<T>::TYPE;
 
 	explicit ChimpScanState(ColumnSegment &segment) : segment(segment), segment_count(segment.count) {
 		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
@@ -203,7 +203,7 @@ public:
 		D_ASSERT(leading_zero_block_count <= ChimpPrimitives::CHIMP_SEQUENCE_SIZE / 8);
 
 		// Load the leading zero block count
-		metadata_ptr -= 3 * leading_zero_block_count;
+		metadata_ptr -= 3ULL * leading_zero_block_count;
 		const auto leading_zero_block_ptr = metadata_ptr;
 
 		// Figure out how many flags there are
@@ -240,7 +240,7 @@ public:
 	//! Skip the next 'skip_count' values, we don't store the values
 	// TODO: use the metadata to determine if we can skip a group
 	void Skip(ColumnSegment &segment, idx_t skip_count) {
-		using INTERNAL_TYPE = typename ChimpType<T>::type;
+		using INTERNAL_TYPE = typename ChimpType<T>::TYPE;
 		INTERNAL_TYPE buffer[ChimpPrimitives::CHIMP_SEQUENCE_SIZE];
 
 		while (skip_count) {
@@ -263,7 +263,7 @@ unique_ptr<SegmentScanState> ChimpInitScan(ColumnSegment &segment) {
 template <class T>
 void ChimpScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
                       idx_t result_offset) {
-	using INTERNAL_TYPE = typename ChimpType<T>::type;
+	using INTERNAL_TYPE = typename ChimpType<T>::TYPE;
 	auto &scan_state = state.scan_state->Cast<ChimpScanState<T>>();
 
 	T *result_data = FlatVector::GetData<T>(result);

--- a/src/include/duckdb/storage/compression/patas/patas.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas.hpp
@@ -25,20 +25,20 @@ struct FloatingToExact {};
 
 template <>
 struct FloatingToExact<double> {
-	typedef uint64_t type;
+	typedef uint64_t TYPE;
 };
 
 template <>
 struct FloatingToExact<float> {
-	typedef uint32_t type;
+	typedef uint32_t TYPE;
 };
 
 template <class T, bool EMPTY>
 struct PatasState {
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
-	PatasState(void *state_p = nullptr) : data_ptr(state_p), patas_state() {
+	explicit PatasState(void *state_p = nullptr) : data_ptr(state_p), patas_state() {
 	}
 	//! The Compress/Analyze State
 	void *data_ptr;

--- a/src/include/duckdb/storage/compression/patas/patas.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas.hpp
@@ -25,12 +25,12 @@ struct FloatingToExact {};
 
 template <>
 struct FloatingToExact<double> {
-	typedef uint64_t TYPE;
+	using TYPE = uint64_t;
 };
 
 template <>
 struct FloatingToExact<float> {
-	typedef uint32_t TYPE;
+	using TYPE = uint32_t;
 };
 
 template <class T, bool EMPTY>

--- a/src/include/duckdb/storage/compression/patas/patas_fetch.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas_fetch.hpp
@@ -26,7 +26,7 @@ namespace duckdb {
 
 template <class T>
 void PatasFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx) {
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	PatasScanState<T> scan_state(segment);
 	scan_state.Skip(segment, row_id);

--- a/src/include/duckdb/storage/compression/patas/patas_scan.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas_scan.hpp
@@ -87,7 +87,7 @@ private:
 template <class T>
 struct PatasScanState : public SegmentScanState {
 public:
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 	explicit PatasScanState(ColumnSegment &segment) : segment(segment), count(segment.count) {
 		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
@@ -174,7 +174,7 @@ public:
 public:
 	//! Skip the next 'skip_count' values, we don't store the values
 	void Skip(ColumnSegment &segment, idx_t skip_count) {
-		using EXACT_TYPE = typename FloatingToExact<T>::type;
+		using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
 		if (total_value_count != 0 && !GroupFinished()) {
 			// Finish skipping the current group
@@ -210,7 +210,7 @@ unique_ptr<SegmentScanState> PatasInitScan(ColumnSegment &segment) {
 template <class T>
 void PatasScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
                       idx_t result_offset) {
-	using EXACT_TYPE = typename FloatingToExact<T>::type;
+	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 	auto &scan_state = (PatasScanState<T> &)*state.scan_state;
 
 	// Get the pointer to the result values

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -47,7 +47,7 @@ public:
 	}
 
 	template <class T, class... ARGS>
-	shared_ptr<T> GetOrCreate(const string &key, ARGS &&...args) {
+	shared_ptr<T> GetOrCreate(const string &key, ARGS &&... args) {
 		lock_guard<mutex> glock(lock);
 
 		auto entry = cache.find(key);

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -46,8 +46,8 @@ public:
 		return std::static_pointer_cast<T, ObjectCacheEntry>(object);
 	}
 
-	template <class T, class... Args>
-	shared_ptr<T> GetOrCreate(const string &key, Args &&...args) {
+	template <class T, class... ARGS>
+	shared_ptr<T> GetOrCreate(const string &key, ARGS &&...args) {
 		lock_guard<mutex> glock(lock);
 
 		auto entry = cache.find(key);
@@ -65,7 +65,7 @@ public:
 
 	void Put(string key, shared_ptr<ObjectCacheEntry> value) {
 		lock_guard<mutex> glock(lock);
-		cache[key] = std::move(value);
+		cache.insert(make_pair(std::move(key), std::move(value)));
 	}
 
 	void Delete(const string &key) {

--- a/src/include/duckdb/storage/optimistic_data_writer.hpp
+++ b/src/include/duckdb/storage/optimistic_data_writer.hpp
@@ -15,7 +15,7 @@ class PartialBlockManager;
 
 class OptimisticDataWriter {
 public:
-	OptimisticDataWriter(DataTable &table);
+	explicit OptimisticDataWriter(DataTable &table);
 	OptimisticDataWriter(DataTable &table, OptimisticDataWriter &parent);
 	~OptimisticDataWriter();
 

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -877,23 +877,17 @@
       {
         "id": 200,
         "name": "base",
-        "type": "string",
-        "serialize_property": "_base",
-        "deserialize_property": "_base"
+        "type": "string"
       },
       {
         "id": 201,
         "name": "pos",
-        "type": "idx_t",
-        "serialize_property": "_pos",
-        "deserialize_property": "_pos"
+        "type": "idx_t"
       },
       {
         "id": 202,
         "name": "uuid",
-        "type": "bool",
-        "serialize_property": "_uuid",
-        "deserialize_property": "_uuid"
+        "type": "bool"
       }
     ]
   }

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -49,13 +49,13 @@ public:
 	//! Unpin and pin are nops on this block of memory
 	shared_ptr<BlockHandle> RegisterSmallMemory(idx_t block_size) final;
 
-	idx_t GetUsedMemory() const final override;
-	idx_t GetMaxMemory() const final override;
+	idx_t GetUsedMemory() const final;
+	idx_t GetMaxMemory() const final;
 
 	//! Allocate an in-memory buffer with a single pin.
 	//! The allocated memory is released when the buffer handle is destroyed.
 	DUCKDB_API BufferHandle Allocate(MemoryTag tag, idx_t block_size, bool can_destroy = true,
-	                                 shared_ptr<BlockHandle> *block = nullptr) final override;
+	                                 shared_ptr<BlockHandle> *block = nullptr) final;
 
 	//! Reallocate an in-memory buffer that is pinned.
 	void ReAllocate(shared_ptr<BlockHandle> &handle, idx_t block_size) final;

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -36,8 +36,7 @@ class StandardBufferManager : public BufferManager {
 
 public:
 	StandardBufferManager(DatabaseInstance &db, string temp_directory);
-	~StandardBufferManager() override
-	;
+	~StandardBufferManager() override;
 
 public:
 	static unique_ptr<StandardBufferManager> CreateBufferManager(DatabaseInstance &db, string temp_directory);

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -36,7 +36,8 @@ class StandardBufferManager : public BufferManager {
 
 public:
 	StandardBufferManager(DatabaseInstance &db, string temp_directory);
-	virtual ~StandardBufferManager();
+	~StandardBufferManager() override
+	;
 
 public:
 	static unique_ptr<StandardBufferManager> CreateBufferManager(DatabaseInstance &db, string temp_directory);
@@ -46,7 +47,7 @@ public:
 	//! Registers an in-memory buffer that cannot be unloaded until it is destroyed
 	//! This buffer can be small (smaller than BLOCK_SIZE)
 	//! Unpin and pin are nops on this block of memory
-	shared_ptr<BlockHandle> RegisterSmallMemory(idx_t block_size) final override;
+	shared_ptr<BlockHandle> RegisterSmallMemory(idx_t block_size) final;
 
 	idx_t GetUsedMemory() const final override;
 	idx_t GetMaxMemory() const final override;
@@ -57,28 +58,28 @@ public:
 	                                 shared_ptr<BlockHandle> *block = nullptr) final override;
 
 	//! Reallocate an in-memory buffer that is pinned.
-	void ReAllocate(shared_ptr<BlockHandle> &handle, idx_t block_size) final override;
+	void ReAllocate(shared_ptr<BlockHandle> &handle, idx_t block_size) final;
 
-	BufferHandle Pin(shared_ptr<BlockHandle> &handle) final override;
-	void Unpin(shared_ptr<BlockHandle> &handle) final override;
+	BufferHandle Pin(shared_ptr<BlockHandle> &handle) final;
+	void Unpin(shared_ptr<BlockHandle> &handle) final;
 
 	//! Set a new memory limit to the buffer manager, throws an exception if the new limit is too low and not enough
 	//! blocks can be evicted
-	void SetLimit(idx_t limit = (idx_t)-1) final override;
+	void SetLimit(idx_t limit = (idx_t)-1) final;
 
 	//! Returns informaton about memory usage
 	vector<MemoryInformation> GetMemoryUsageInfo() const override;
 
 	//! Returns a list of all temporary files
-	vector<TemporaryFileInformation> GetTemporaryFiles() final override;
+	vector<TemporaryFileInformation> GetTemporaryFiles() final;
 
-	const string &GetTemporaryDirectory() final override {
+	const string &GetTemporaryDirectory() final {
 		return temp_directory;
 	}
 
-	void SetTemporaryDirectory(const string &new_dir) final override;
+	void SetTemporaryDirectory(const string &new_dir) final;
 
-	DUCKDB_API Allocator &GetBufferAllocator() final override;
+	DUCKDB_API Allocator &GetBufferAllocator() final;
 
 	DatabaseInstance &GetDatabase() {
 		return db;
@@ -88,9 +89,9 @@ public:
 	unique_ptr<FileBuffer> ConstructManagedBuffer(idx_t size, unique_ptr<FileBuffer> &&source,
 	                                              FileBufferType type = FileBufferType::MANAGED_BUFFER) override;
 
-	DUCKDB_API void ReserveMemory(idx_t size) final override;
-	DUCKDB_API void FreeReservedMemory(idx_t size) final override;
-	bool HasTemporaryDirectory() const final override;
+	DUCKDB_API void ReserveMemory(idx_t size) final;
+	DUCKDB_API void FreeReservedMemory(idx_t size) final;
+	bool HasTemporaryDirectory() const final;
 
 protected:
 	//! Helper
@@ -106,24 +107,24 @@ protected:
 	shared_ptr<BlockHandle> RegisterMemory(MemoryTag tag, idx_t block_size, bool can_destroy);
 
 	//! Garbage collect eviction queue
-	void PurgeQueue() final override;
+	void PurgeQueue() final;
 
-	BufferPool &GetBufferPool() const final override;
-	TemporaryMemoryManager &GetTemporaryMemoryManager() final override;
+	BufferPool &GetBufferPool() const final;
+	TemporaryMemoryManager &GetTemporaryMemoryManager() final;
 
 	//! Write a temporary buffer to disk
-	void WriteTemporaryBuffer(MemoryTag tag, block_id_t block_id, FileBuffer &buffer) final override;
+	void WriteTemporaryBuffer(MemoryTag tag, block_id_t block_id, FileBuffer &buffer) final;
 	//! Read a temporary buffer from disk
 	unique_ptr<FileBuffer> ReadTemporaryBuffer(MemoryTag tag, block_id_t id,
-	                                           unique_ptr<FileBuffer> buffer = nullptr) final override;
+	                                           unique_ptr<FileBuffer> buffer = nullptr) final;
 	//! Get the path of the temporary buffer
 	string GetTemporaryPath(block_id_t id);
 
-	void DeleteTemporaryFile(block_id_t id) final override;
+	void DeleteTemporaryFile(block_id_t id) final;
 
 	void RequireTemporaryDirectory();
 
-	void AddToEvictionQueue(shared_ptr<BlockHandle> &handle) final override;
+	void AddToEvictionQueue(shared_ptr<BlockHandle> &handle) final;
 
 	const char *InMemoryWarning();
 

--- a/src/include/duckdb/storage/statistics/numeric_stats_union.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_stats_union.hpp
@@ -27,9 +27,9 @@ struct NumericValueUnion {
 		uint64_t ubigint;
 		hugeint_t hugeint;
 		uhugeint_t uhugeint;
-		float float_; // NOLINT
+		float float_;   // NOLINT
 		double double_; // NOLINT
-	} value_;  // NOLINT
+	} value_;           // NOLINT
 
 	template <class T>
 	T &GetReferenceUnsafe();

--- a/src/include/duckdb/storage/statistics/numeric_stats_union.hpp
+++ b/src/include/duckdb/storage/statistics/numeric_stats_union.hpp
@@ -27,9 +27,9 @@ struct NumericValueUnion {
 		uint64_t ubigint;
 		hugeint_t hugeint;
 		uhugeint_t uhugeint;
-		float float_;
-		double double_;
-	} value_;
+		float float_; // NOLINT
+		double double_; // NOLINT
+	} value_;  // NOLINT
 
 	template <class T>
 	T &GetReferenceUnsafe();

--- a/src/include/duckdb/storage/statistics/segment_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/segment_statistics.hpp
@@ -16,8 +16,8 @@ namespace duckdb {
 
 class SegmentStatistics {
 public:
-	SegmentStatistics(LogicalType type);
-	SegmentStatistics(BaseStatistics statistics);
+	explicit SegmentStatistics(LogicalType type);
+	explicit SegmentStatistics(BaseStatistics statistics);
 
 	//! Type-specific statistics of the segment
 	BaseStatistics statistics;

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -66,10 +66,10 @@ struct MainHeader {
 	static void CheckMagicBytes(FileHandle &handle);
 
 	string LibraryGitDesc() {
-		return string((char *)library_git_desc, 0, MAX_VERSION_SIZE);
+		return string(char_ptr_cast(library_git_desc), 0, MAX_VERSION_SIZE);
 	}
 	string LibraryGitHash() {
-		return string((char *)library_git_hash, 0, MAX_VERSION_SIZE);
+		return string(char_ptr_cast(library_git_hash), 0, MAX_VERSION_SIZE);
 	}
 
 	void Write(WriteStream &ser);

--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -82,9 +82,9 @@ public:
 		D_ASSERT(segment.GetBlockOffset() == 0);
 		auto handle_ptr = handle.Ptr();
 		auto source_data = UnifiedVectorFormat::GetData<string_t>(data);
-		auto result_data = (int32_t *)(handle_ptr + DICTIONARY_HEADER_SIZE);
-		uint32_t *dictionary_size = (uint32_t *)handle_ptr;
-		uint32_t *dictionary_end = (uint32_t *)(handle_ptr + sizeof(uint32_t));
+		auto result_data = reinterpret_cast<int32_t *>(handle_ptr + DICTIONARY_HEADER_SIZE);
+		auto dictionary_size = reinterpret_cast<uint32_t *>(handle_ptr);
+		auto dictionary_end = reinterpret_cast<uint32_t *>(handle_ptr + sizeof(uint32_t));
 
 		idx_t remaining_space = RemainingSpace(segment, handle);
 		auto base_count = segment.count.load();
@@ -136,15 +136,15 @@ public:
 			if (DUCKDB_UNLIKELY(use_overflow_block)) {
 				// write to overflow blocks
 				block_id_t block;
-				int32_t offset;
+				int32_t current_offset;
 				// write the string into the current string block
-				WriteString(segment, source_data[source_idx], block, offset);
+				WriteString(segment, source_data[source_idx], block, current_offset);
 				*dictionary_size += BIG_STRING_MARKER_SIZE;
 				remaining_space -= BIG_STRING_MARKER_SIZE;
 				auto dict_pos = end - *dictionary_size;
 
 				// write a big string marker into the dictionary
-				WriteStringMarker(dict_pos, block, offset);
+				WriteStringMarker(dict_pos, block, current_offset);
 
 				// place the dictionary offset into the set of vectors
 				// note: for overflow strings we write negative value

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -36,7 +36,7 @@ struct ColumnAppendState {
 };
 
 struct RowGroupAppendState {
-	RowGroupAppendState(TableAppendState &parent_p) : parent(parent_p) {
+	explicit RowGroupAppendState(TableAppendState &parent_p) : parent(parent_p) {
 	}
 
 	//! The parent append state

--- a/src/include/duckdb/storage/table/row_group_segment_tree.hpp
+++ b/src/include/duckdb/storage/table/row_group_segment_tree.hpp
@@ -18,7 +18,7 @@ class MetadataReader;
 
 class RowGroupSegmentTree : public SegmentTree<RowGroup, true> {
 public:
-	RowGroupSegmentTree(RowGroupCollection &collection);
+	explicit RowGroupSegmentTree(RowGroupCollection &collection);
 	~RowGroupSegmentTree() override;
 
 	void Initialize(PersistentTableData &data);

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -111,7 +111,7 @@ struct ColumnFetchState {
 
 class CollectionScanState {
 public:
-	CollectionScanState(TableScanState &parent_p);
+	explicit CollectionScanState(TableScanState &parent_p);
 
 	//! The current row_group we are scanning
 	RowGroup *row_group;

--- a/src/include/duckdb/storage/table/segment_lock.hpp
+++ b/src/include/duckdb/storage/table/segment_lock.hpp
@@ -17,7 +17,7 @@ struct SegmentLock {
 public:
 	SegmentLock() {
 	}
-	SegmentLock(mutex &lock) : lock(lock) {
+	explicit SegmentLock(mutex &lock) : lock(lock) {
 	}
 	// disable copy constructors
 	SegmentLock(const SegmentLock &other) = delete;

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -320,10 +320,10 @@ private:
 		};
 
 	public:
-		SegmentIterator begin() {
+		SegmentIterator begin() { // NOLINT: match stl API
 			return SegmentIterator(tree, tree.GetRootSegment());
 		}
-		SegmentIterator end() {
+		SegmentIterator end() { // NOLINT: match stl API
 			return SegmentIterator(tree, nullptr);
 		}
 	};
@@ -349,8 +349,8 @@ private:
 		if (!SUPPORTS_LAZY_LOADING) {
 			return;
 		}
-		while (LoadNextSegment(l))
-			;
+		while (LoadNextSegment(l)) {
+		}
 	}
 };
 

--- a/src/include/duckdb/storage/table/table_statistics.hpp
+++ b/src/include/duckdb/storage/table/table_statistics.hpp
@@ -22,7 +22,7 @@ class Deserializer;
 
 class TableStatisticsLock {
 public:
-	TableStatisticsLock(mutex &l) : guard(l) {
+	explicit TableStatisticsLock(mutex &l) : guard(l) {
 	}
 
 	lock_guard<mutex> guard;

--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -22,7 +22,7 @@ struct UpdateNode;
 
 class UpdateSegment {
 public:
-	UpdateSegment(ColumnData &column_data);
+	explicit UpdateSegment(ColumnData &column_data);
 	~UpdateSegment();
 
 	ColumnData &column_data;

--- a/src/include/duckdb/transaction/transaction_data.hpp
+++ b/src/include/duckdb/transaction/transaction_data.hpp
@@ -16,7 +16,7 @@ class DuckTransaction;
 class Transaction;
 
 struct TransactionData {
-	TransactionData(DuckTransaction &transaction_p);
+	TransactionData(DuckTransaction &transaction_p); // NOLINT: allow implicit conversion
 	TransactionData(transaction_t transaction_id_p, transaction_t start_time_p);
 
 	optional_ptr<DuckTransaction> transaction;

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -28,7 +28,7 @@ public:
 	};
 
 public:
-	UndoBuffer(ClientContext &context);
+	explicit UndoBuffer(ClientContext &context);
 
 	//! Reserve space for an entry of the specified type and length in the undo
 	//! buffer

--- a/src/include/duckdb/transaction/update_info.hpp
+++ b/src/include/duckdb/transaction/update_info.hpp
@@ -27,7 +27,7 @@ struct UpdateInfo {
 	//! The vector index within the uncompressed segment
 	idx_t vector_index;
 	//! The amount of updated tuples
-	sel_t N;
+	sel_t N; // NOLINT
 	//! The maximum amount of tuples that can fit into this UpdateInfo
 	sel_t max;
 	//! The row ids of the tuples that have been updated. This should always be kept sorted!

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -36,7 +36,7 @@ void BaseAppender::Destructor() {
 	// wrapped in a try/catch because Close() can throw if the table was dropped in the meantime
 	try {
 		Close();
-	} catch (...) {
+	} catch (...) { // NOLINT
 	}
 }
 

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -162,7 +162,7 @@ void AttachedDatabase::Close() {
 			}
 			storage->CreateCheckpoint(true);
 		}
-	} catch (...) {
+	} catch (...) { // NOLINT
 	}
 }
 

--- a/src/main/capi/cast/utils-c.cpp
+++ b/src/main/capi/cast/utils-c.cpp
@@ -78,7 +78,7 @@ bool CanUseDeprecatedFetch(duckdb_result *result, idx_t col, idx_t row) {
 	if (!result) {
 		return false;
 	}
-	if (!duckdb::deprecated_materialize_result(result)) {
+	if (!duckdb::DeprecatedMaterializeResult(result)) {
 		return false;
 	}
 	if (col >= result->__deprecated_column_count || row >= result->__deprecated_row_count) {

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -99,7 +99,7 @@ void duckdb_disconnect(duckdb_connection *connection) {
 duckdb_state duckdb_query(duckdb_connection connection, const char *query, duckdb_result *out) {
 	Connection *conn = reinterpret_cast<Connection *>(connection);
 	auto result = conn->Query(query);
-	return duckdb_translate_result(std::move(result), out);
+	return DuckDBTranslateResult(std::move(result), out);
 }
 
 const char *duckdb_library_version() {

--- a/src/main/capi/pending-c.cpp
+++ b/src/main/capi/pending-c.cpp
@@ -162,5 +162,5 @@ duckdb_state duckdb_execute_pending(duckdb_pending_result pending_result, duckdb
 	}
 
 	wrapper->statement.reset();
-	return duckdb_translate_result(std::move(result), out_result);
+	return DuckDBTranslateResult(std::move(result), out_result);
 }

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -333,7 +333,7 @@ duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statemen
 	}
 
 	auto result = wrapper->statement->Execute(wrapper->values, false);
-	return duckdb_translate_result(std::move(result), out_result);
+	return DuckDBTranslateResult(std::move(result), out_result);
 }
 
 duckdb_state duckdb_execute_prepared_streaming(duckdb_prepared_statement prepared_statement,
@@ -344,7 +344,7 @@ duckdb_state duckdb_execute_prepared_streaming(duckdb_prepared_statement prepare
 	}
 
 	auto result = wrapper->statement->Execute(wrapper->values, true);
-	return duckdb_translate_result(std::move(result), out_result);
+	return DuckDBTranslateResult(std::move(result), out_result);
 }
 
 duckdb_statement_type duckdb_prepared_statement_type(duckdb_prepared_statement statement) {

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -273,7 +273,7 @@ duckdb_state deprecated_duckdb_translate_column(MaterializedQueryResult &result,
 	return DuckDBSuccess;
 }
 
-duckdb_state duckdb_translate_result(unique_ptr<QueryResult> result_p, duckdb_result *out) {
+duckdb_state DuckDBTranslateResult(unique_ptr<QueryResult> result_p, duckdb_result *out) {
 	auto &result = *result_p;
 	D_ASSERT(result_p);
 	if (!out) {
@@ -301,7 +301,7 @@ duckdb_state duckdb_translate_result(unique_ptr<QueryResult> result_p, duckdb_re
 	return DuckDBSuccess;
 }
 
-bool deprecated_materialize_result(duckdb_result *result) {
+bool DeprecatedMaterializeResult(duckdb_result *result) {
 	if (!result) {
 		return false;
 	}
@@ -475,7 +475,7 @@ void *duckdb_column_data(duckdb_result *result, idx_t col) {
 	if (!result || col >= result->__deprecated_column_count) {
 		return nullptr;
 	}
-	if (!duckdb::deprecated_materialize_result(result)) {
+	if (!duckdb::DeprecatedMaterializeResult(result)) {
 		return nullptr;
 	}
 	return result->__deprecated_columns[col].__deprecated_data;
@@ -485,7 +485,7 @@ bool *duckdb_nullmask_data(duckdb_result *result, idx_t col) {
 	if (!result || col >= result->__deprecated_column_count) {
 		return nullptr;
 	}
-	if (!duckdb::deprecated_materialize_result(result)) {
+	if (!duckdb::DeprecatedMaterializeResult(result)) {
 		return nullptr;
 	}
 	return result->__deprecated_columns[col].__deprecated_nullmask;

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -19,7 +19,7 @@ namespace duckdb {
 // Install Extension
 //===--------------------------------------------------------------------===//
 const string ExtensionHelper::NormalizeVersionTag(const string &version_tag) {
-	if (version_tag.length() > 0 && version_tag[0] != 'v') {
+	if (!version_tag.empty() && version_tag[0] != 'v') {
 		return "v" + version_tag;
 	}
 	return version_tag;

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -38,7 +38,7 @@ static void ComputeSHA256String(const std::string &to_hash, std::string *res) {
 
 static void ComputeSHA256FileSegment(FileHandle *handle, const idx_t start, const idx_t end, std::string *res) {
 	idx_t iter = start;
-	const idx_t segment_size = 1024 * 8;
+	const idx_t segment_size = 1024ULL * 8ULL;
 
 	duckdb_mbedtls::MbedTlsWrapper::SHA256State state;
 

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -470,7 +470,7 @@ static string JSONSanitize(const string &text) {
 	return result;
 }
 
-static void ToJSONRecursive(QueryProfiler::TreeNode &node, std::ostream &ss, int depth = 1) {
+static void ToJSONRecursive(QueryProfiler::TreeNode &node, std::ostream &ss, idx_t depth = 1) {
 	ss << string(depth * 3, ' ') << " {\n";
 	ss << string(depth * 3, ' ') << "   \"name\": \"" + JSONSanitize(node.name) + "\",\n";
 	ss << string(depth * 3, ' ') << "   \"timing\":" + to_string(node.info.time) + ",\n";

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -285,7 +285,7 @@ BoundStatement SecretManager::BindCreateSecret(CatalogTransaction transaction, C
 	BoundStatement result;
 	result.names = {"Success"};
 	result.types = {LogicalType::BOOLEAN};
-	result.plan = make_uniq<LogicalCreateSecret>(*function, std::move(bound_info));
+	result.plan = make_uniq<LogicalCreateSecret>(std::move(bound_info));
 	return result;
 }
 

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -607,7 +607,6 @@ unique_ptr<CatalogEntry> DefaultSecretGenerator::CreateDefaultEntry(ClientContex
 			auto deserialized_secret = secret_manager.DeserializeSecret(deserializer);
 			deserializer.End();
 
-			auto name = deserialized_secret->GetName();
 			auto entry = make_uniq<SecretCatalogEntry>(std::move(deserialized_secret), catalog);
 			entry->secret->storage_mode = SecretManager::LOCAL_FILE_STORAGE_NAME;
 			entry->secret->persist_type = SecretPersistType::PERSISTENT;

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -730,7 +730,6 @@ Value ExplainOutputSetting::GetSetting(ClientContext &context) {
 // Extension Directory Setting
 //===--------------------------------------------------------------------===//
 void ExtensionDirectorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
-	auto new_directory = input.ToString();
 	config.options.extension_directory = input.ToString();
 }
 

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -410,11 +410,11 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetStringCompress(uniq
 		auto max_string = StringStats::Max(stats);
 
 		uint8_t min_numeric = 0;
-		if (max_string_length != 0 && min_string.length() != 0) {
+		if (max_string_length != 0 && !min_string.empty()) {
 			min_numeric = *reinterpret_cast<const uint8_t *>(min_string.c_str());
 		}
 		uint8_t max_numeric = 0;
-		if (max_string_length != 0 && max_string.length() != 0) {
+		if (max_string_length != 0 && !max_string.empty()) {
 			max_numeric = *reinterpret_cast<const uint8_t *>(max_string.c_str());
 		}
 

--- a/src/parser/transform/statement/transform_create_function.cpp
+++ b/src/parser/transform/statement/transform_create_function.cpp
@@ -40,10 +40,11 @@ unique_ptr<CreateStatement> Transformer::TransformCreateFunction(duckdb_libpgque
 		break;
 	case duckdb_libpgquery::PG_RELPERSISTENCE_UNLOGGED:
 		throw ParserException("Unlogged flag not supported for macros: '%s'", qname.name);
-		break;
 	case duckdb_libpgquery::RELPERSISTENCE_PERMANENT:
 		info->temporary = false;
 		break;
+	default:
+		throw ParserException("Unsupported persistence flag for table '%s'", qname.name);
 	}
 
 	// what to do on conflict

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -201,7 +201,6 @@ void Binder::BindGeneratedColumns(BoundCreateTableInfo &info) {
 			col.SetType(bound_expression->return_type);
 
 			// Update the type in the binding, for future expansions
-			string ignore;
 			table_binding->types[i.index] = col.Type();
 		}
 		bound_indices.insert(i);

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -182,9 +182,9 @@ void Planner::VerifyPlan(ClientContext &context, unique_ptr<LogicalOperator> &op
 			*map = std::move(parameters);
 		}
 		op = std::move(new_plan);
-	} catch (SerializationException &ex) {
+	} catch (SerializationException &ex) { // NOLINT: explicitly allowing these errors (for now)
 		// pass
-	} catch (NotImplementedException &ex) {
+	} catch (NotImplementedException &ex) { // NOLINT: explicitly allowing these errors (for now)
 		// pass
 	}
 }

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -182,10 +182,10 @@ void Planner::VerifyPlan(ClientContext &context, unique_ptr<LogicalOperator> &op
 			*map = std::move(parameters);
 		}
 		op = std::move(new_plan);
-	} catch (SerializationException &ex) { // NOLINT: explicitly allowing these errors (for now)
-		// pass
+	} catch (SerializationException &ex) {  // NOLINT: explicitly allowing these errors (for now)
+		                                    // pass
 	} catch (NotImplementedException &ex) { // NOLINT: explicitly allowing these errors (for now)
-		// pass
+		                                    // pass
 	}
 }
 

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -406,7 +406,7 @@ string_location_t UncompressedStringStorage::FetchStringLocation(StringDictionar
 	D_ASSERT(dict_offset >= -1 * int32_t(Storage::BLOCK_SIZE) && dict_offset <= int32_t(Storage::BLOCK_SIZE));
 	if (dict_offset < 0) {
 		string_location_t result;
-		ReadStringMarker(baseptr + dict.end - (-1 * dict_offset), result.block_id, result.offset);
+		ReadStringMarker(baseptr + dict.end - idx_t(-1 * dict_offset), result.block_id, result.offset);
 		return result;
 	} else {
 		return string_location_t(INVALID_BLOCK, dict_offset);

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -184,16 +184,16 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 }
 
 void FilenamePattern::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<string>(200, "base", _base);
-	serializer.WritePropertyWithDefault<idx_t>(201, "pos", _pos);
-	serializer.WritePropertyWithDefault<bool>(202, "uuid", _uuid);
+	serializer.WritePropertyWithDefault<string>(200, "base", base);
+	serializer.WritePropertyWithDefault<idx_t>(201, "pos", pos);
+	serializer.WritePropertyWithDefault<bool>(202, "uuid", uuid);
 }
 
 FilenamePattern FilenamePattern::Deserialize(Deserializer &deserializer) {
 	FilenamePattern result;
-	deserializer.ReadPropertyWithDefault<string>(200, "base", result._base);
-	deserializer.ReadPropertyWithDefault<idx_t>(201, "pos", result._pos);
-	deserializer.ReadPropertyWithDefault<bool>(202, "uuid", result._uuid);
+	deserializer.ReadPropertyWithDefault<string>(200, "base", result.base);
+	deserializer.ReadPropertyWithDefault<idx_t>(201, "pos", result.pos);
+	deserializer.ReadPropertyWithDefault<bool>(202, "uuid", result.uuid);
 	return result;
 }
 

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -87,7 +87,7 @@ void CleanupState::Flush() {
 	// delete the tuples from all the indexes
 	try {
 		current_table->RemoveFromIndexes(row_identifiers, count);
-	} catch (...) {
+	} catch (...) { // NOLINT: ignore errors here
 	}
 
 	count = 0;

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -18,7 +18,7 @@ TransactionContext::~TransactionContext() {
 	if (current_transaction) {
 		try {
 			Rollback();
-		} catch (...) {
+		} catch (...) { // NOLINT
 		}
 	}
 }

--- a/third_party/hyperloglog/hyperloglog.hpp
+++ b/third_party/hyperloglog/hyperloglog.hpp
@@ -13,6 +13,8 @@
 
 namespace duckdb_hll {
 
+// NOLINTBEGIN
+
 /* Error codes */
 #define HLL_C_OK  0
 #define HLL_C_ERR -1
@@ -39,6 +41,8 @@ robj *hll_merge(robj **hlls, size_t hll_count);
 uint64_t get_size();
 
 uint64_t MurmurHash64A(const void *key, int len, unsigned int seed);
+
+// NOLINTEND
 
 } // namespace duckdb_hll
 

--- a/tools/pythonpkg/CMakeLists.txt
+++ b/tools/pythonpkg/CMakeLists.txt
@@ -1,10 +1,6 @@
 include_directories(src)
 include_directories(../../)
 include_directories(src/include)
-include_directories(${pybind11_INCLUDE_DIR})
-include_directories(${PYTHON_INCLUDE_DIRS})
-
-add_subdirectory(src)
 
 find_package(PythonLibs)
 if(NOT PythonLibs_FOUND)
@@ -15,6 +11,11 @@ find_package(pybind11)
 if(NOT pybind11_FOUND)
   return()
 endif()
+
+include_directories(${pybind11_INCLUDE_DIR})
+include_directories(${PYTHON_INCLUDE_DIRS})
+
+add_subdirectory(src)
 # this is used for clang-tidy checks
 
 set(ALL_OBJECT_FILES duckdb_python.cpp ${ALL_OBJECT_FILES})

--- a/tools/pythonpkg/duckdb_python.cpp
+++ b/tools/pythonpkg/duckdb_python.cpp
@@ -31,7 +31,7 @@ namespace py = pybind11;
 
 namespace duckdb {
 
-enum PySQLTokenType {
+enum PySQLTokenType : uint8_t {
 	PY_SQL_TOKEN_IDENTIFIER = 0,
 	PY_SQL_TOKEN_NUMERIC_CONSTANT,
 	PY_SQL_TOKEN_STRING_CONSTANT,

--- a/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
@@ -86,7 +86,7 @@ py::object PythonTableArrowArrayStreamFactory::ProduceScanner(py::object &arrow_
 unique_ptr<ArrowArrayStreamWrapper> PythonTableArrowArrayStreamFactory::Produce(uintptr_t factory_ptr,
                                                                                 ArrowStreamParameters &parameters) {
 	py::gil_scoped_acquire acquire;
-	auto factory = static_cast<PythonTableArrowArrayStreamFactory *>(reinterpret_cast<void *>(factory_ptr));
+	auto factory = static_cast<PythonTableArrowArrayStreamFactory *>(reinterpret_cast<void *>(factory_ptr)); // NOLINT
 	D_ASSERT(factory->arrow_object);
 	py::handle arrow_obj_handle(factory->arrow_object);
 	auto arrow_object_type = GetArrowType(arrow_obj_handle);
@@ -158,7 +158,7 @@ void PythonTableArrowArrayStreamFactory::GetSchemaInternal(py::handle arrow_obj_
 
 void PythonTableArrowArrayStreamFactory::GetSchema(uintptr_t factory_ptr, ArrowSchemaWrapper &schema) {
 	py::gil_scoped_acquire acquire;
-	auto factory = static_cast<PythonTableArrowArrayStreamFactory *>(reinterpret_cast<void *>(factory_ptr));
+	auto factory = static_cast<PythonTableArrowArrayStreamFactory *>(reinterpret_cast<void *>(factory_ptr)); // NOLINT
 	D_ASSERT(factory->arrow_object);
 	py::handle arrow_obj_handle(factory->arrow_object);
 	GetSchemaInternal(arrow_obj_handle, schema);

--- a/tools/pythonpkg/src/numpy/numpy_bind.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_bind.cpp
@@ -40,7 +40,6 @@ void NumpyBind::Bind(const ClientContext &context, py::handle df, vector<PandasC
 		} else if (bind_data.numpy_type.type == NumpyNullableType::OBJECT &&
 		           string(py::str(df_types[col_idx])) == "string") {
 			bind_data.numpy_type.type = NumpyNullableType::CATEGORY;
-			auto enum_name = string(py::str(df_columns[col_idx]));
 			// here we call numpy.unique
 			// this function call will return the unique values of a given array
 			// together with the indices to reconstruct the given array

--- a/tools/pythonpkg/src/pandas/bind.cpp
+++ b/tools/pythonpkg/src/pandas/bind.cpp
@@ -66,7 +66,6 @@ static LogicalType BindColumn(PandasBindColumn &column_p, PandasColumnBindData &
 		if (categories_pd_type.type == NumpyNullableType::OBJECT) {
 			// Let's hope the object type is a string.
 			bind_data.numpy_type.type = NumpyNullableType::CATEGORY;
-			auto enum_name = string(py::str(column_p.name));
 			vector<string> enum_entries = py::cast<vector<string>>(categories);
 			idx_t size = enum_entries.size();
 			Vector enum_entries_vec(LogicalType::VARCHAR, size);

--- a/tools/pythonpkg/src/pandas/scan.cpp
+++ b/tools/pythonpkg/src/pandas/scan.cpp
@@ -25,8 +25,11 @@ struct PandasScanFunctionData : public PyTableFunctionData {
 	vector<LogicalType> sql_types;
 
 	~PandasScanFunctionData() override {
-		py::gil_scoped_acquire acquire;
-		pandas_bind_data.clear();
+		try {
+			py::gil_scoped_acquire acquire;
+			pandas_bind_data.clear();
+		} catch(...) { // NOLINT
+		}
 	}
 };
 

--- a/tools/pythonpkg/src/pandas/scan.cpp
+++ b/tools/pythonpkg/src/pandas/scan.cpp
@@ -28,7 +28,7 @@ struct PandasScanFunctionData : public PyTableFunctionData {
 		try {
 			py::gil_scoped_acquire acquire;
 			pandas_bind_data.clear();
-		} catch(...) { // NOLINT
+		} catch (...) { // NOLINT
 		}
 	}
 };

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -69,7 +69,7 @@ DuckDBPyConnection::~DuckDBPyConnection() {
 		database.reset();
 		connection.reset();
 		temporary_views.clear();
-	} catch(...) { // NOLINT
+	} catch (...) { // NOLINT
 	}
 }
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -63,11 +63,14 @@ shared_ptr<PythonImportCache> DuckDBPyConnection::import_cache = nullptr;
 PythonEnvironmentType DuckDBPyConnection::environment = PythonEnvironmentType::NORMAL;
 
 DuckDBPyConnection::~DuckDBPyConnection() {
-	py::gil_scoped_release gil;
-	// Release any structures that do not need to hold the GIL here
-	database.reset();
-	connection.reset();
-	temporary_views.clear();
+	try {
+		py::gil_scoped_release gil;
+		// Release any structures that do not need to hold the GIL here
+		database.reset();
+		connection.reset();
+		temporary_views.clear();
+	} catch(...) { // NOLINT
+	}
 }
 
 void DuckDBPyConnection::DetectEnvironment() {

--- a/tools/pythonpkg/src/pyfilesystem.cpp
+++ b/tools/pythonpkg/src/pyfilesystem.cpp
@@ -14,7 +14,7 @@ PythonFileHandle::~PythonFileHandle() {
 		PythonGILWrapper gil;
 		handle.dec_ref();
 		handle.release();
-	} catch(...) { // NOLINT
+	} catch (...) { // NOLINT
 	}
 }
 

--- a/tools/pythonpkg/src/pyfilesystem.cpp
+++ b/tools/pythonpkg/src/pyfilesystem.cpp
@@ -10,9 +10,12 @@ PythonFileHandle::PythonFileHandle(FileSystem &file_system, const string &path, 
     : FileHandle(file_system, path), handle(handle) {
 }
 PythonFileHandle::~PythonFileHandle() {
-	PythonGILWrapper gil;
-	handle.dec_ref();
-	handle.release();
+	try {
+		PythonGILWrapper gil;
+		handle.dec_ref();
+		handle.release();
+	} catch(...) { // NOLINT
+	}
 }
 
 string PythonFilesystem::DecodeFlags(FileOpenFlags flags) {

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -28,9 +28,12 @@ DuckDBPyResult::DuckDBPyResult(unique_ptr<QueryResult> result_p) : result(std::m
 }
 
 DuckDBPyResult::~DuckDBPyResult() {
-	py::gil_scoped_release gil;
-	result.reset();
-	current_chunk.reset();
+	try {
+		py::gil_scoped_release gil;
+		result.reset();
+		current_chunk.reset();
+	} catch(...) { // NOLINT
+	}
 }
 
 const vector<string> &DuckDBPyResult::GetNames() {

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -32,7 +32,7 @@ DuckDBPyResult::~DuckDBPyResult() {
 		py::gil_scoped_release gil;
 		result.reset();
 		current_chunk.reset();
-	} catch(...) { // NOLINT
+	} catch (...) { // NOLINT
 	}
 }
 

--- a/tools/pythonpkg/src/python_import_cache.cpp
+++ b/tools/pythonpkg/src/python_import_cache.cpp
@@ -82,7 +82,7 @@ PythonImportCache::~PythonImportCache() {
 	try {
 		py::gil_scoped_acquire acquire;
 		owned_objects.clear();
-	} catch(...) { // NOLINT
+	} catch (...) { // NOLINT
 	}
 }
 

--- a/tools/pythonpkg/src/python_import_cache.cpp
+++ b/tools/pythonpkg/src/python_import_cache.cpp
@@ -17,7 +17,7 @@ py::handle PythonImportCacheItem::operator()(bool load) {
 
 	optional_ptr<PythonImportCacheItem> item = this;
 	while (item) {
-		hierarchy.push(*item);
+		hierarchy.emplace(*item);
 		item = item->parent;
 	}
 	return PythonImporter::Import(hierarchy, load);

--- a/tools/pythonpkg/src/python_import_cache.cpp
+++ b/tools/pythonpkg/src/python_import_cache.cpp
@@ -79,8 +79,11 @@ py::handle PythonImportCacheItem::Load(PythonImportCache &cache, py::handle sour
 //===--------------------------------------------------------------------===//
 
 PythonImportCache::~PythonImportCache() {
-	py::gil_scoped_acquire acquire;
-	owned_objects.clear();
+	try {
+		py::gil_scoped_acquire acquire;
+		owned_objects.clear();
+	} catch(...) { // NOLINT
+	}
 }
 
 py::handle PythonImportCache::AddCache(py::object item) {

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -162,7 +162,7 @@ static scalar_function_t CreateNativeFunction(PyObject *function, PythonExceptio
                                               const ClientProperties &client_properties) {
 	// Through the capture of the lambda, we have access to the function pointer
 	// We just need to make sure that it doesn't get garbage collected
-	scalar_function_t func = [&](DataChunk &input, ExpressionState &state, Vector &result) -> void {
+	scalar_function_t func = [=](DataChunk &input, ExpressionState &state, Vector &result) -> void {
 		py::gil_scoped_acquire gil;
 
 		// owning references

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -162,7 +162,7 @@ static scalar_function_t CreateNativeFunction(PyObject *function, PythonExceptio
                                               const ClientProperties &client_properties) {
 	// Through the capture of the lambda, we have access to the function pointer
 	// We just need to make sure that it doesn't get garbage collected
-	scalar_function_t func = [=](DataChunk &input, ExpressionState &state, Vector &result) -> void {
+	scalar_function_t func = [&](DataChunk &input, ExpressionState &state, Vector &result) -> void {
 		py::gil_scoped_acquire gil;
 
 		// owning references


### PR DESCRIPTION
Fixes an old issue where clang-tidy was not run on headers because of an incorrect header filter regex