### PR TITLE
ODBC driver should ignore "driver" and "trusted_connection" keywords in connection string

### DIFF
--- a/tools/odbc/include/connect.hpp
+++ b/tools/odbc/include/connect.hpp
@@ -34,6 +34,8 @@ public:
 	bool GetSuccessWithInfo() const {
 		return success_with_info;
 	}
+	// Ignore keys for use with Power Query
+	std::vector<std::string> PQIgnoreKeys = {"driver"};
 
 private:
 	OdbcHandleDbc *dbc;

--- a/tools/odbc/include/connect.hpp
+++ b/tools/odbc/include/connect.hpp
@@ -35,7 +35,7 @@ public:
 		return success_with_info;
 	}
 	// Ignore keys for use with Power Query
-	std::vector<std::string> PQIgnoreKeys = {"driver"};
+	std::vector<std::string> PQIgnoreKeys = {"driver", "trusted_connection"};
 
 private:
 	OdbcHandleDbc *dbc;

--- a/tools/odbc/src/connect/connect.cpp
+++ b/tools/odbc/src/connect/connect.cpp
@@ -46,7 +46,14 @@ SQLRETURN Connect::FindKeyValPair(const std::string &row) {
 		                            SQLStateType::ST_HY000, ""));
 	}
 
-	SQLRETURN ret = FindMatchingKey(StringUtil::Lower(row.substr(0, val_pos)), key);
+	std::string key_candidate = StringUtil::Lower(row.substr(0, val_pos));
+
+	// Check if the key can be ignored
+	if (std::find(PQIgnoreKeys.begin(), PQIgnoreKeys.end(), key_candidate) != PQIgnoreKeys.end()) {
+		return SQL_SUCCESS;
+	}
+
+	SQLRETURN ret = FindMatchingKey(key_candidate, key);
 	if (ret != SQL_SUCCESS) {
 		return ret;
 	}

--- a/tools/odbc/test/common.cpp
+++ b/tools/odbc/test/common.cpp
@@ -248,9 +248,11 @@ std::string ConvertHexToString(SQLCHAR val[16], int precision) {
 
 std::string GetTesterDirectory() {
 	duckdb::unique_ptr<duckdb::FileSystem> fs = duckdb::FileSystem::CreateLocal();
-	std::string current_directory = fs->GetWorkingDirectory() + "/test/sql/storage_version/storage_version.db";
+	auto cwd = fs->GetWorkingDirectory();
+	std::string current_directory = cwd + "/test/sql/storage_version/storage_version.db";
 	if (!fs->FileExists(current_directory)) {
-		auto s = fs->GetWorkingDirectory() + "/../../../../test/sql/storage_version/storage_version.db";
+		auto base_dir = cwd.substr(0, cwd.rfind("duckdb"));
+		auto s = base_dir + "duckdb/test/sql/storage_version/storage_version.db";
 		if (!fs->FileExists(s)) {
 			throw std::runtime_error("Could not find storage_version.db file.");
 		}

--- a/tools/odbc/test/tests/connect.cpp
+++ b/tools/odbc/test/tests/connect.cpp
@@ -25,7 +25,8 @@ void ConnectWithoutDSN(SQLHANDLE &env, SQLHANDLE &dbc) {
 
 // Connect to a database with extra keywords provided by Power Query SDK
 void ConnectWithPowerQuerySDK(SQLHANDLE &env, SQLHANDLE &dbc) {
-	std::string conn_str = "DRIVER={DuckDB Driver};database=" + GetTesterDirectory() + ";custom_user_agent=powerbi/v0.0(DuckDB);Trusted_Connection=yes;";
+	std::string conn_str = "DRIVER={DuckDB Driver};database=" + GetTesterDirectory() +
+	                       +";custom_user_agent=powerbi/v0.0(DuckDB);Trusted_Connection=yes;";
 	SQLCHAR str[1024];
 	SQLSMALLINT strl;
 

--- a/tools/odbc/test/tests/connect.cpp
+++ b/tools/odbc/test/tests/connect.cpp
@@ -23,6 +23,24 @@ void ConnectWithoutDSN(SQLHANDLE &env, SQLHANDLE &dbc) {
 	                  str, sizeof(str), &strl, SQL_DRIVER_COMPLETE);
 }
 
+// Connect to a database with extra keywords provided by Power Query SDK
+void ConnectWithPowerQuerySDK(SQLHANDLE &env, SQLHANDLE &dbc) {
+	std::string conn_str = "DRIVER={DuckDB Driver};database=" + GetTesterDirectory() + ";custom_user_agent=powerbi/v0.0(DuckDB);Trusted_Connection=yes;";
+	SQLCHAR str[1024];
+	SQLSMALLINT strl;
+
+	SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env);
+	REQUIRE(ret == SQL_SUCCESS);
+
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
+
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+
+	EXECUTE_AND_CHECK("SQLDriverConnect", SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(conn_str.c_str()), SQL_NTS,
+	                  str, sizeof(str), &strl, SQL_DRIVER_COMPLETE);
+}
+
 // Connect with incorrect params
 void ConnectWithIncorrectParam(std::string param) {
 	SQLHANDLE env;
@@ -129,6 +147,7 @@ TEST_CASE("Test SQLConnect and SQLDriverConnect", "[odbc]") {
 	TestSettingConfigs();
 
 	ConnectWithoutDSN(env, dbc);
+	ConnectWithPowerQuerySDK(env, dbc);
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
 


### PR DESCRIPTION
This is a fix to make the DuckDB ODBC driver compatible with Power Query SDK for use with [DuckDB Power BI Connector](https://github.com/MotherDuck-Open-Source/DuckDBPowerQueryConnector).

Fixes https://github.com/duckdb/duckdb/issues/10907 and https://github.com/duckdb/duckdb/issues/11380