### PR TITLE
Update __init__.py To export "extract_statements" function

### DIFF
--- a/tools/pythonpkg/duckdb/__init__.py
+++ b/tools/pythonpkg/duckdb/__init__.py
@@ -220,6 +220,7 @@ _exported_symbols.extend([
     "enum_type",
     "execute",
     "executemany",
+    "extract_statements",
     "fetch_arrow_table",
     "fetch_df",
     "fetch_df_chunk",


### PR DESCRIPTION
This is a minor edit to actually include extract_statements in the list of symbols exported. 
I suspect its absence is an oversight as it is included in the documentation