### PR TITLE
allow set readonly on attached db

### DIFF
--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -61,6 +61,7 @@ public:
 	bool IsReadOnly() const;
 	bool IsInitialDatabase() const;
 	void SetInitialDatabase();
+	void SetReadOnlyDatabase();
 
 	static bool NameIsReserved(const string &name);
 	static string ExtractDatabaseName(const string &dbpath, FileSystem &fs);

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -134,6 +134,10 @@ void AttachedDatabase::SetInitialDatabase() {
 	is_initial_database = true;
 }
 
+void AttachedDatabase::SetReadOnlyDatabase() {
+	type = AttachedDatabaseType::READ_ONLY_DATABASE;
+}
+
 void AttachedDatabase::Close() {
 	D_ASSERT(catalog);
 	if (is_closed) {


### PR DESCRIPTION
This will give us the ability to attach db as readonly so that storage extensions can decide that they only expose read-only data.

cc @bleskes 