### PR TITLE
Improve binding of CTEs

### DIFF
--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -136,8 +136,8 @@ public:
 
 	//! Add a common table expression to the binder
 	void AddCTE(const string &name, CommonTableExpressionInfo &cte);
-	//! Find a common table expression by name; returns nullptr if none exists
-	optional_ptr<CommonTableExpressionInfo> FindCTE(const string &name, bool skip = false);
+	//! Find all candidate common table expression by name; returns empty vector if none exists
+	vector<reference<CommonTableExpressionInfo>> FindCTE(const string &name, bool skip = false);
 
 	bool CTEIsAlreadyBound(CommonTableExpressionInfo &cte);
 

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -333,17 +333,19 @@ void Binder::AddCTE(const string &name, CommonTableExpressionInfo &info) {
 	CTE_bindings.insert(make_pair(name, reference<CommonTableExpressionInfo>(info)));
 }
 
-optional_ptr<CommonTableExpressionInfo> Binder::FindCTE(const string &name, bool skip) {
+vector<reference<CommonTableExpressionInfo>> Binder::FindCTE(const string &name, bool skip) {
 	auto entry = CTE_bindings.find(name);
+	vector<reference<CommonTableExpressionInfo>> ctes;
 	if (entry != CTE_bindings.end()) {
 		if (!skip || entry->second.get().query->node->type == QueryNodeType::RECURSIVE_CTE_NODE) {
-			return &entry->second.get();
+			ctes.push_back(entry->second);
 		}
 	}
 	if (parent && inherit_ctes) {
-		return parent->FindCTE(name, name == alias);
+		auto parent_ctes = parent->FindCTE(name, name == alias);
+		ctes.insert(ctes.end(), parent_ctes.begin(), parent_ctes.end());
 	}
-	return nullptr;
+	return ctes;
 }
 
 bool Binder::CTEIsAlreadyBound(CommonTableExpressionInfo &cte) {

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -80,61 +80,70 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 	// check if the table name refers to a CTE
 
 	// CTE name should never be qualified (i.e. schema_name should be empty)
-	optional_ptr<CommonTableExpressionInfo> found_cte = nullptr;
+	vector<reference<CommonTableExpressionInfo>> found_ctes;
 	if (ref.schema_name.empty()) {
-		found_cte = FindCTE(ref.table_name, ref.table_name == alias);
+		found_ctes = FindCTE(ref.table_name, ref.table_name == alias);
 	}
 
-	if (found_cte) {
+	if (!found_ctes.empty()) {
 		// Check if there is a CTE binding in the BindContext
-		auto &cte = *found_cte;
-		auto ctebinding = bind_context.GetCTEBinding(ref.table_name);
-		if (!ctebinding) {
-			if (CTEIsAlreadyBound(cte)) {
-				throw BinderException(
-				    "Circular reference to CTE \"%s\", There are two possible solutions. \n1. use WITH RECURSIVE to "
-				    "use recursive CTEs. \n2. If "
-				    "you want to use the TABLE name \"%s\" the same as the CTE name, please explicitly add "
-				    "\"SCHEMA\" before table name. You can try \"main.%s\" (main is the duckdb default schema)",
-				    ref.table_name, ref.table_name, ref.table_name);
-			}
-			// Move CTE to subquery and bind recursively
-			SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(cte.query->Copy()));
-			subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
-			subquery.column_name_alias = cte.aliases;
-			for (idx_t i = 0; i < ref.column_name_alias.size(); i++) {
-				if (i < subquery.column_name_alias.size()) {
-					subquery.column_name_alias[i] = ref.column_name_alias[i];
-				} else {
-					subquery.column_name_alias.push_back(ref.column_name_alias[i]);
+		bool circular_cte = false;
+		for (auto found_cte : found_ctes) {
+			auto &cte = found_cte.get();
+			auto ctebinding = bind_context.GetCTEBinding(ref.table_name);
+			if (!ctebinding) {
+				if (CTEIsAlreadyBound(cte)) {
+					// remember error state
+					circular_cte = true;
+					// retry with next candidate CTE
+					continue;
 				}
-			}
-			return Bind(subquery, found_cte);
-		} else {
-			// There is a CTE binding in the BindContext.
-			// This can only be the case if there is a recursive CTE,
-			// or a materialized CTE present.
-			auto index = GenerateTableIndex();
-			auto materialized = cte.materialized;
-			if (materialized == CTEMaterialize::CTE_MATERIALIZE_DEFAULT) {
+				// Move CTE to subquery and bind recursively
+				SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(cte.query->Copy()));
+				subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
+				subquery.column_name_alias = cte.aliases;
+				for (idx_t i = 0; i < ref.column_name_alias.size(); i++) {
+					if (i < subquery.column_name_alias.size()) {
+						subquery.column_name_alias[i] = ref.column_name_alias[i];
+					} else {
+						subquery.column_name_alias.push_back(ref.column_name_alias[i]);
+					}
+				}
+				return Bind(subquery, &found_cte.get());
+			} else {
+				// There is a CTE binding in the BindContext.
+				// This can only be the case if there is a recursive CTE,
+				// or a materialized CTE present.
+				auto index = GenerateTableIndex();
+				auto materialized = cte.materialized;
+				if (materialized == CTEMaterialize::CTE_MATERIALIZE_DEFAULT) {
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
-				materialized = CTEMaterialize::CTE_MATERIALIZE_ALWAYS;
+					materialized = CTEMaterialize::CTE_MATERIALIZE_ALWAYS;
 #else
-				materialized = CTEMaterialize::CTE_MATERIALIZE_NEVER;
+					materialized = CTEMaterialize::CTE_MATERIALIZE_NEVER;
 #endif
+				}
+				auto result = make_uniq<BoundCTERef>(index, ctebinding->index, materialized);
+				auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
+				auto names = BindContext::AliasColumnNames(alias, ctebinding->names, ref.column_name_alias);
+
+				bind_context.AddGenericBinding(index, alias, names, ctebinding->types);
+				// Update references to CTE
+				auto cteref = bind_context.cte_references[ref.table_name];
+				(*cteref)++;
+
+				result->types = ctebinding->types;
+				result->bound_columns = std::move(names);
+				return std::move(result);
 			}
-			auto result = make_uniq<BoundCTERef>(index, ctebinding->index, materialized);
-			auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
-			auto names = BindContext::AliasColumnNames(alias, ctebinding->names, ref.column_name_alias);
-
-			bind_context.AddGenericBinding(index, alias, names, ctebinding->types);
-			// Update references to CTE
-			auto cteref = bind_context.cte_references[ref.table_name];
-			(*cteref)++;
-
-			result->types = ctebinding->types;
-			result->bound_columns = std::move(names);
-			return std::move(result);
+		}
+		if (circular_cte) {
+			throw BinderException(
+			    "Circular reference to CTE \"%s\", There are two possible solutions. \n1. use WITH RECURSIVE to "
+			    "use recursive CTEs. \n2. If "
+			    "you want to use the TABLE name \"%s\" the same as the CTE name, please explicitly add "
+			    "\"SCHEMA\" before table name. You can try \"main.%s\" (main is the duckdb default schema)",
+			    ref.table_name, ref.table_name, ref.table_name);
 		}
 	}
 	// not a CTE

--- a/src/planner/binder/tableref/bind_subqueryref.cpp
+++ b/src/planner/binder/tableref/bind_subqueryref.cpp
@@ -10,8 +10,8 @@ unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref, optional_ptr<CommonTabl
 	if (cte) {
 		binder->bound_ctes.insert(*cte);
 	}
-	binder->alias = ref.alias.empty() ? "unnamed_subquery" : ref.alias;
 	auto subquery = binder->BindNode(*ref.subquery->node);
+	binder->alias = ref.alias.empty() ? "unnamed_subquery" : ref.alias;
 	idx_t bind_index = subquery->GetRootIndex();
 	string subquery_alias;
 	if (ref.alias.empty()) {

--- a/test/issues/general/test_11391.test
+++ b/test/issues/general/test_11391.test
@@ -1,0 +1,8 @@
+# name: test/issues/general/test_11391.test
+# description: Issue 1091: Catalog Error with nested CTEs
+# group: [general]
+
+query I
+with foo as (with foo as (select 1) select * from foo) select * from foo;
+----
+1


### PR DESCRIPTION
Change `FindCTE` to return a vector of all candidate CTEs instead of just one CTE. This vector is used to implement a retry mechanism in `bind_basetableref.cpp`. Only if binding fails for all CTEs, the appropriate exception is thrown.

Fixes #11391