### PR TITLE
Remove redundant default descriptions

### DIFF
--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -19,48 +19,41 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	// Global HTTP config
 	// Single timeout value is used for all 4 types of timeouts, we could split it into 4 if users need that
-	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry (default 30000ms)",
-	                          LogicalType::UBIGINT, Value(30000));
-	config.AddExtensionOption("http_retries", "HTTP retries on I/O error (default 3)", LogicalType::UBIGINT, Value(3));
-	config.AddExtensionOption("http_retry_wait_ms", "Time between retries (default 100ms)", LogicalType::UBIGINT,
-	                          Value(100));
+	config.AddExtensionOption("http_timeout", "HTTP timeout read/write/connection/retry", LogicalType::UBIGINT,
+	                          Value(30000));
+	config.AddExtensionOption("http_retries", "HTTP retries on I/O error", LogicalType::UBIGINT, Value(3));
+	config.AddExtensionOption("http_retry_wait_ms", "Time between retries", LogicalType::UBIGINT, Value(100));
 	config.AddExtensionOption("force_download", "Forces upfront download of file", LogicalType::BOOLEAN, Value(false));
 	// Reduces the number of requests made while waiting, for example retry_wait_ms of 50 and backoff factor of 2 will
 	// result in wait times of  0 50 100 200 400...etc.
-	config.AddExtensionOption("http_retry_backoff",
-	                          "Backoff factor for exponentially increasing retry wait time (default 4)",
+	config.AddExtensionOption("http_retry_backoff", "Backoff factor for exponentially increasing retry wait time",
 	                          LogicalType::FLOAT, Value(4));
 	config.AddExtensionOption(
 	    "http_keep_alive",
 	    "Keep alive connections. Setting this to false can help when running into connection failures",
 	    LogicalType::BOOLEAN, Value(true));
-	config.AddExtensionOption("enable_server_cert_verification",
-	                          "Enable server side certificate verification, defaults to False.", LogicalType::BOOLEAN,
-	                          Value(false));
-	config.AddExtensionOption("ca_cert_file",
-	                          "Path to a custom certificate file for self-signed certificates. By default not set.",
+	config.AddExtensionOption("enable_server_cert_verification", "Enable server side certificate verification.",
+	                          LogicalType::BOOLEAN, Value(false));
+	config.AddExtensionOption("ca_cert_file", "Path to a custom certificate file for self-signed certificates.",
 	                          LogicalType::VARCHAR, Value(""));
 	// Global S3 config
-	config.AddExtensionOption("s3_region", "S3 Region (default us-east-1)", LogicalType::VARCHAR, Value("us-east-1"));
+	config.AddExtensionOption("s3_region", "S3 Region", LogicalType::VARCHAR, Value("us-east-1"));
 	config.AddExtensionOption("s3_access_key_id", "S3 Access Key ID", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_secret_access_key", "S3 Access Key", LogicalType::VARCHAR);
 	config.AddExtensionOption("s3_session_token", "S3 Session Token", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_endpoint", "S3 Endpoint (empty for default endpoint)", LogicalType::VARCHAR);
-	config.AddExtensionOption("s3_url_style", "S3 URL style ('vhost' (default) or 'path')", LogicalType::VARCHAR,
-	                          Value("vhost"));
-	config.AddExtensionOption("s3_use_ssl", "S3 use SSL (default true)", LogicalType::BOOLEAN, Value(true));
+	config.AddExtensionOption("s3_endpoint", "S3 Endpoint", LogicalType::VARCHAR);
+	config.AddExtensionOption("s3_url_style", "S3 URL style", LogicalType::VARCHAR, Value("vhost"));
+	config.AddExtensionOption("s3_use_ssl", "S3 use SSL", LogicalType::BOOLEAN, Value(true));
 	config.AddExtensionOption("s3_url_compatibility_mode", "Disable Globs and Query Parameters on S3 URLs",
 	                          LogicalType::BOOLEAN, Value(false));
 
 	// S3 Uploader config
-	config.AddExtensionOption("s3_uploader_max_filesize",
-	                          "S3 Uploader max filesize (between 50GB and 5TB, default 800GB)", LogicalType::VARCHAR,
-	                          "800GB");
-	config.AddExtensionOption("s3_uploader_max_parts_per_file",
-	                          "S3 Uploader max parts per file (between 1 and 10000, default 10000)",
+	config.AddExtensionOption("s3_uploader_max_filesize", "S3 Uploader max filesize (between 50GB and 5TB)",
+	                          LogicalType::VARCHAR, "800GB");
+	config.AddExtensionOption("s3_uploader_max_parts_per_file", "S3 Uploader max parts per file (between 1 and 10000)",
 	                          LogicalType::UBIGINT, Value(10000));
-	config.AddExtensionOption("s3_uploader_thread_limit", "S3 Uploader global thread limit (default 50)",
-	                          LogicalType::UBIGINT, Value(50));
+	config.AddExtensionOption("s3_uploader_thread_limit", "S3 Uploader global thread limit", LogicalType::UBIGINT,
+	                          Value(50));
 
 	auto provider = make_uniq<AWSEnvironmentCredentialsProvider>(config);
 	provider->SetAll();

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -416,7 +416,7 @@ struct IntegerDivisionSetting {
 struct LogQueryPathSetting {
 	static constexpr const char *Name = "log_query_path";
 	static constexpr const char *Description =
-	    "Specifies the path to which queries should be logged (default: empty string, queries are not logged)";
+	    "Specifies the path to which queries should be logged (default: NULL, queries are not logged)";
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
@@ -492,7 +492,7 @@ struct PasswordSetting {
 
 struct PerfectHashThresholdSetting {
 	static constexpr const char *Name = "perfect_ht_threshold";
-	static constexpr const char *Description = "Threshold in bytes for when to use a perfect hash table (default: 12)";
+	static constexpr const char *Description = "Threshold in bytes for when to use a perfect hash table";
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
@@ -511,8 +511,7 @@ struct PivotFilterThreshold {
 
 struct PivotLimitSetting {
 	static constexpr const char *Name = "pivot_limit";
-	static constexpr const char *Description =
-	    "The maximum number of pivot columns in a pivot statement (default: 100000)";
+	static constexpr const char *Description = "The maximum number of pivot columns in a pivot statement";
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);


### PR DESCRIPTION
These descriptions are redundant: the default values are given separately from the description