### PR TITLE
[ODBC] Fix: Support loading UTF-8 encoded data with Power BI

### DIFF
--- a/tools/odbc/src/connect/connection.cpp
+++ b/tools/odbc/src/connect/connection.cpp
@@ -1044,8 +1044,8 @@ SQLRETURN SQL_API SQLGetInfo(SQLHDBC connection_handle, SQLUSMALLINT info_type, 
 
 		// return SQL_SUCCESS, but with a record message
 		std::string msg = "Unrecognized attribute: " + std::to_string(info_type);
-		return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS, "SQLGetInfo", msg,
-		                                   SQLStateType::ST_HY092, dbc->GetDataSourceName());
+		return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS, "SQLGetInfo", msg, SQLStateType::ST_HY092,
+		                                   dbc->GetDataSourceName());
 	}
 } // end SQLGetInfo
 

--- a/tools/odbc/src/connect/connection.cpp
+++ b/tools/odbc/src/connect/connection.cpp
@@ -7,6 +7,12 @@
 
 #include "duckdb/common/helper.hpp"
 
+// From ODBC Spec (ODBCVER >= 0x0300 and ODBCVER >= 0x0400)
+// https://github.com/microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h
+// Needed for use with Power Query SDK and Power BI
+#define SQL_DTC_TRANSACTION_COST 1750
+#define SQL_RETURN_ESCAPE_CLAUSE 180
+
 using duckdb::OdbcUtils;
 using duckdb::SQLStateType;
 using std::ptrdiff_t;
@@ -1021,6 +1027,14 @@ SQLRETURN SQL_API SQLGetInfo(SQLHDBC connection_handle, SQLUSMALLINT info_type, 
 		duckdb::OdbcUtils::WriteString("", (SQLCHAR *)info_value_ptr, buffer_length, string_length_ptr);
 		return SQL_SUCCESS;
 	}
+	case SQL_DTC_TRANSACTION_COST: {
+		duckdb::Store<SQLUINTEGER>(0, (duckdb::data_ptr_t)info_value_ptr);
+		return SQL_SUCCESS;
+	}
+	case SQL_RETURN_ESCAPE_CLAUSE: {
+		duckdb::Store<SQLUINTEGER>(0, (duckdb::data_ptr_t)info_value_ptr);
+		return SQL_SUCCESS;
+	}
 	default:
 		duckdb::OdbcHandleDbc *dbc = nullptr;
 		SQLRETURN ret = ConvertConnection(connection_handle, dbc);
@@ -1029,7 +1043,8 @@ SQLRETURN SQL_API SQLGetInfo(SQLHDBC connection_handle, SQLUSMALLINT info_type, 
 		}
 
 		// return SQL_SUCCESS, but with a record message
-		return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS, "SQLGetInfo", "Unrecognized attribute.",
+		std::string msg = "Unrecognized attribute: " + std::to_string(info_type);
+		return duckdb::SetDiagnosticRecord(dbc, SQL_SUCCESS, "SQLGetInfo", msg,
 		                                   SQLStateType::ST_HY092, dbc->GetDataSourceName());
 	}
 } // end SQLGetInfo

--- a/tools/odbc/src/statement/statement.cpp
+++ b/tools/odbc/src/statement/statement.cpp
@@ -375,7 +375,7 @@ SQLRETURN SQL_API SQLTables(SQLHSTMT statement_handle, SQLCHAR *catalog_name, SQ
                             SQLSMALLINT name_length3, SQLCHAR *table_type, SQLSMALLINT name_length4) {
 	duckdb::OdbcHandleStmt *hstmt = nullptr;
 	SQLRETURN ret = ConvertHSTMT(statement_handle, hstmt);
-	if (ret != SQL_SUCCESS) {
+	if (!SQL_SUCCEEDED(ret)) {
 		return ret;
 	}
 

--- a/tools/odbc/test/common.cpp
+++ b/tools/odbc/test/common.cpp
@@ -24,7 +24,7 @@ void ODBC_CHECK(SQLRETURN ret, const std::string &msg) {
 		fprintf(stderr, "%s: Unexpected return value\n", msg.c_str());
 		break;
 	}
-	REQUIRE(ret == SQL_SUCCESS);
+	REQUIRE(SQL_SUCCEEDED(ret));
 }
 
 void ACCESS_DIAGNOSTIC(std::string &state, std::string &message, SQLHANDLE handle, SQLSMALLINT handle_type) {


### PR DESCRIPTION
Fixes https://github.com/MotherDuck-Open-Source/duckdb-power-query-connector/issues/16
When reading UTF-8 encoded data from DuckDB via Power Query SDK or Power BI, the ODBC driver's diagnostics logs return errors:

```
ODBC_DuckDB->SQLGetInfo
Unrecognized attribute: 1750
ODBC_DuckDB->SQLGetInfo
Unrecognized attribute: 180
```

This is likely due to Power Query sending `SQLGetInfo` requests with `TypeInfo` values that are not supported by the ODBC driver, in particular, `SQL_DTC_TRANSACTION_COST` (1750) and `SQL_RETURN_ESCAPE_CLAUSE` (180) . This PR adds support for these `InfoType`s to `SQLGetInfo` to enable reading UTF-8 encoded files in Power Query SDK and Power BI. I also added a line to add the `info_type` to the diagnostics logs.

Some relevant info from [MS docs](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlconnect-function?view=sql-server-ver16#optimizing-connection-pooling-performance):
> Although SQL_DTC_TRANSITION_COST was introduced in ODBC 3.5, an ODBC 2.x driver can also support it because the driver manager will query this information regardless of the driver version.

See a similar implementation in the PostgreSQL ODBC driver [here](https://git.postgresql.org/gitweb/?p=psqlodbc.git;a=blob_plain;f=info.c;hb=HEAD) on line 1047.

Before fix:
<img width="589" alt="image" src="https://github.com/duckdb/duckdb/assets/4041805/efdd9161-b2e9-401b-a6fd-e35b472ab3cc">

After fix:

<img width="821" alt="image" src="https://github.com/duckdb/duckdb/assets/4041805/2f76933a-642d-47a5-a0f4-295cf10aa051">
<img width="293" alt="image" src="https://github.com/duckdb/duckdb/assets/4041805/2c36b6aa-397f-4854-87b9-a931a7146c15">

See [here ](https://github.com/MotherDuck-Open-Source/duckdb-power-query-connector/issues/16) for repro steps.