### PR TITLE
[ODBC] Add escape character to ParseStringFilter to support Power Query ('table_name' is escaped to 'table\_name')

### DIFF
--- a/tools/odbc/src/common/odbc_utils.cpp
+++ b/tools/odbc/src/common/odbc_utils.cpp
@@ -69,6 +69,8 @@ string OdbcUtils::ParseStringFilter(const string &filter_name, const string &fil
 	} else {
 		filter = filter_name + " LIKE '" + filter_value + "'";
 	}
+	// Handle escape character passed by Power Query SDK
+	filter += "ESCAPE '\\'";
 	return filter;
 }
 

--- a/tools/odbc/src/common/odbc_utils.cpp
+++ b/tools/odbc/src/common/odbc_utils.cpp
@@ -70,7 +70,7 @@ string OdbcUtils::ParseStringFilter(const string &filter_name, const string &fil
 		filter = filter_name + " LIKE '" + filter_value + "'";
 	}
 	// Handle escape character passed by Power Query SDK
-	filter += "ESCAPE '\\'";
+	filter += " ESCAPE '\\'";
 	return filter;
 }
 


### PR DESCRIPTION
Fixes https://github.com/MotherDuck-Open-Source/duckdb-power-query-connector/issues/12

Power Query escapes an underscore with a backslash, so the query generated by `SQLGetColumns` for a table with a name with an underscore in it (e.g. `'table_name'`) returns a filter `WHERE "TABLE_NAME" LIKE 'table\_name'` which returns zero rows. This PR adds `ESCAPE '\'` to the filter(s).