### PR TITLE
Fix #11393 - improve error message when trying to use a lateral join column in a table function that does not support it

### DIFF
--- a/src/include/duckdb/planner/expression_binder/table_function_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/table_function_binder.hpp
@@ -15,14 +15,17 @@ namespace duckdb {
 //! The table function binder can bind standard table function parameters (i.e., non-table-in-out functions)
 class TableFunctionBinder : public ExpressionBinder {
 public:
-	TableFunctionBinder(Binder &binder, ClientContext &context);
+	TableFunctionBinder(Binder &binder, ClientContext &context, string table_function_name = string());
 
 protected:
 	BindResult BindLambdaReference(LambdaRefExpression &expr, idx_t depth);
-	BindResult BindColumnReference(ColumnRefExpression &expr, idx_t depth, bool root_expression);
+	BindResult BindColumnReference(unique_ptr<ParsedExpression> &expr, idx_t depth, bool root_expression);
 	BindResult BindExpression(unique_ptr<ParsedExpression> &expr, idx_t depth, bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
+
+private:
+	string table_function_name;
 };
 
 } // namespace duckdb

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -102,7 +102,7 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 			continue;
 		}
 
-		TableFunctionBinder binder(*this, context);
+		TableFunctionBinder binder(*this, context, table_function.name);
 		LogicalType sql_type;
 		auto expr = binder.Bind(child, &sql_type);
 		if (expr->HasParameter()) {

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -5,7 +5,8 @@
 
 namespace duckdb {
 
-TableFunctionBinder::TableFunctionBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
+TableFunctionBinder::TableFunctionBinder(Binder &binder, ClientContext &context, string table_function_name_p)
+    : ExpressionBinder(binder, context), table_function_name(std::move(table_function_name_p)) {
 }
 
 BindResult TableFunctionBinder::BindLambdaReference(LambdaRefExpression &expr, idx_t depth) {
@@ -14,23 +15,34 @@ BindResult TableFunctionBinder::BindLambdaReference(LambdaRefExpression &expr, i
 	return (*lambda_bindings)[expr.lambda_idx].Bind(lambda_ref, depth);
 }
 
-BindResult TableFunctionBinder::BindColumnReference(ColumnRefExpression &expr, idx_t depth, bool root_expression) {
-
+BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
+                                                    bool root_expression) {
 	// try binding as a lambda parameter
-	auto &col_ref = expr.Cast<ColumnRefExpression>();
+	auto &col_ref = expr_ptr->Cast<ColumnRefExpression>();
 	if (!col_ref.IsQualified()) {
 		auto lambda_ref = LambdaRefExpression::FindMatchingBinding(lambda_bindings, col_ref.GetName());
 		if (lambda_ref) {
 			return BindLambdaReference(lambda_ref->Cast<LambdaRefExpression>(), depth);
 		}
 	}
+	auto column_names = col_ref.column_names;
+	auto result_name = StringUtil::Join(column_names, ".");
+	if (!table_function_name.empty()) {
+		// check if this is a lateral join column/parameter
+		auto result = BindCorrelatedColumns(expr_ptr, ErrorData("error"));
+		if (!result.HasError()) {
+			// it is a lateral join parameter - this is not supported in this type of table function
+			throw BinderException("Table function \"%s\" does not support lateral join column parameters - cannot use "
+			                      "column \"%s\" in this context",
+			                      table_function_name, result_name);
+		}
+	}
 
-	auto value_function = ExpressionBinder::GetSQLValueFunction(expr.GetColumnName());
+	auto value_function = ExpressionBinder::GetSQLValueFunction(column_names.back());
 	if (value_function) {
 		return BindExpression(value_function, depth, root_expression);
 	}
 
-	auto result_name = StringUtil::Join(expr.column_names, ".");
 	return BindResult(make_uniq<BoundConstantExpression>(Value(result_name)));
 }
 
@@ -41,7 +53,7 @@ BindResult TableFunctionBinder::BindExpression(unique_ptr<ParsedExpression> &exp
 	case ExpressionClass::LAMBDA_REF:
 		return BindLambdaReference(expr.Cast<LambdaRefExpression>(), depth);
 	case ExpressionClass::COLUMN_REF:
-		return BindColumnReference(expr.Cast<ColumnRefExpression>(), depth, root_expression);
+		return BindColumnReference(expr_ptr, depth, root_expression);
 	case ExpressionClass::SUBQUERY:
 		throw BinderException("Table function cannot contain subqueries");
 	case ExpressionClass::DEFAULT:

--- a/test/sql/table_function/lateral_table_function.test
+++ b/test/sql/table_function/lateral_table_function.test
@@ -1,0 +1,17 @@
+# name: test/sql/table_function/lateral_table_function.test
+# description: Test lateral join table function parameters for functions that do not support it
+# group: [table_function]
+
+statement ok
+pragma enable_verification
+
+statement error
+SELECT * FROM read_csv(thisishopefullyanonexistentfile)
+----
+No files found that match the pattern
+
+# lateral join parameter
+statement error
+SELECT * FROM (SELECT 'myfile.csv' AS thisishopefullyanonexistentfile), read_csv(thisishopefullyanonexistentfile)
+----
+does not support lateral join column parameters


### PR DESCRIPTION
Fixes #11393

DuckDB has two types of table functions - table in-out functions and "standard" table functions. Standard table functions are more flexible/versatile and support e.g. parallel execution, but must operate on constant input parameters. Currently, when trying to use a lateral join column with such a function, the column is interpreted as a varchar instead which provides a confusing error message. In this PR, we try to bind such columns using the lateral join binder, and if we find a matching candidate we throw a more descriptive error message.

For example, after this PR:

```sql
D WITH t1(a) AS (SELECT 7) SELECT * FROM t1, generate_series(1, a);
-- Binder Error: Table function "generate_series" does not support lateral join column parameters - cannot use column "a" in this context
```
