### PR TITLE
Enable purging of BufferPool pages based on time-since-last-unpinned

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -134,6 +134,8 @@ struct DBConfigOptions {
 	//! Whether or not to invoke filesystem trim on free blocks after checkpoint. This will reclaim
 	//! space for sparse files, on platforms that support it.
 	bool trim_free_blocks = false;
+	//! Record timestamps of buffer manager unpin() events. Usable by custom eviction policies.
+	bool buffer_manager_track_eviction_timestamps = false;
 	//! Whether or not to allow printing unredacted secrets
 	bool allow_unredacted_secrets = false;
 	//! The collation type of the database

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -122,8 +122,10 @@ private:
 	MemoryTag tag;
 	//! Pointer to loaded data (if any)
 	unique_ptr<FileBuffer> buffer;
-	//! Internal eviction timestamp
-	atomic<idx_t> eviction_timestamp;
+	//! Internal eviction sequence number
+	atomic<idx_t> eviction_seq_num;
+	//! LRU timestamp (for age-based eviction)
+	atomic<int64_t> lru_timestamp_msec;
 	//! Whether or not the buffer can be destroyed (only used for temporary buffers)
 	bool can_destroy;
 	//! The memory usage of the block (when loaded). If we are pinning/loading

--- a/src/include/duckdb/storage/buffer/buffer_pool.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_pool.hpp
@@ -20,13 +20,10 @@ struct EvictionQueue;
 struct BufferEvictionNode {
 	BufferEvictionNode() {
 	}
-	BufferEvictionNode(weak_ptr<BlockHandle> handle_p, idx_t timestamp_p)
-	    : handle(std::move(handle_p)), timestamp(timestamp_p) {
-		D_ASSERT(!handle.expired());
-	}
+	BufferEvictionNode(weak_ptr<BlockHandle> handle_p, idx_t eviction_seq_num);
 
 	weak_ptr<BlockHandle> handle;
-	idx_t timestamp;
+	idx_t handle_sequence_number;
 
 	bool CanUnload(BlockHandle &handle_p);
 	shared_ptr<BlockHandle> TryGetBlockHandle();
@@ -41,7 +38,7 @@ class BufferPool {
 	friend class StandardBufferManager;
 
 public:
-	explicit BufferPool(idx_t maximum_memory);
+	explicit BufferPool(idx_t maximum_memory, bool track_eviction_timestamps);
 	virtual ~BufferPool();
 
 	//! Set a new memory limit to the buffer pool, throws an exception if the new limit is too low and not enough
@@ -72,6 +69,16 @@ protected:
 	virtual EvictionResult EvictBlocks(MemoryTag tag, idx_t extra_memory, idx_t memory_limit,
 	                                   unique_ptr<FileBuffer> *buffer = nullptr);
 
+	//! Purge all blocks that haven't been pinned within the last N seconds
+	idx_t PurgeAgedBlocks(uint32_t max_age_sec);
+
+	//! Iterate over all purgable blocks and invoke the callback. If the callback returns true
+	//! iteration continues.
+	//! - Callback signature is: bool((BufferEvictionNode &, const std::shared_ptr<BlockHandle> &)
+	//! - Callback is invoked while holding the corresponding BlockHandle mutex.
+	template <typename FN>
+	void IterateUnloadableBlocks(FN fn);
+
 	//! Tries to dequeue an element from the eviction queue, but only after acquiring the purge queue lock.
 	bool TryDequeueWithLock(BufferEvictionNode &node);
 	//! Bulk purge dead nodes from the eviction queue. Then, enqueue those that are still alive.
@@ -98,6 +105,8 @@ protected:
 	atomic<idx_t> current_memory;
 	//! The maximum amount of memory that the buffer manager can keep (in bytes)
 	atomic<idx_t> maximum_memory;
+	//! Record timestamps of buffer manager unpin() events. Usable by custom eviction policies.
+	bool track_eviction_timestamps;
 	//! Eviction queue
 	unique_ptr<EvictionQueue> queue;
 	//! Memory manager for concurrently used temporary memory, e.g., for physical operators

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -375,7 +375,8 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 	if (new_config.buffer_pool) {
 		config.buffer_pool = std::move(new_config.buffer_pool);
 	} else {
-		config.buffer_pool = make_shared_ptr<BufferPool>(config.options.maximum_memory);
+		config.buffer_pool = make_shared_ptr<BufferPool>(config.options.maximum_memory,
+		                                                 config.options.buffer_manager_track_eviction_timestamps);
 	}
 }
 

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -9,9 +9,9 @@
 namespace duckdb {
 
 BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, MemoryTag tag)
-    : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), buffer(nullptr), eviction_timestamp(0),
+    : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), buffer(nullptr), eviction_seq_num(0),
       can_destroy(false), memory_charge(tag, block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr) {
-	eviction_timestamp = 0;
+	eviction_seq_num = 0;
 	state = BlockState::BLOCK_UNLOADED;
 	memory_usage = Storage::BLOCK_ALLOC_SIZE;
 }
@@ -19,7 +19,7 @@ BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, Mem
 BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, MemoryTag tag,
                          unique_ptr<FileBuffer> buffer_p, bool can_destroy_p, idx_t block_size,
                          BufferPoolReservation &&reservation)
-    : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), eviction_timestamp(0),
+    : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), eviction_seq_num(0),
       can_destroy(can_destroy_p), memory_charge(tag, block_manager.buffer_manager.GetBufferPool()),
       unswizzled(nullptr) {
 	buffer = std::move(buffer_p);


### PR DESCRIPTION
The bufferpool currently uses a fixed-size LRU, but will not evict pages unless it is at the size limit. Stale pages can accumulate indefinitely despite not having been recently referenced. Because these pages are 'anonymous' the OS can only reclaim memory by swapping them, which is often counterproductive, compared to simply evicting them. This PR enables evicting pages that have not been referenced in some recency window, defined by the number of seconds since they were last unpinned.

### Overhead

The overhead involves 8 bytes added to the BlockHandle (which is insignificant on this already heavy data structure) and a call to steady_clock::now (which should have a latency measured in ~10 nanoseconds on most platforms, and again be dwarfed by the other work happening when we queue a page for eviction).

### Status

I haven't included tests, in part because I'm not sure the best way to expose this feature. As a DUCKDB_API on the database object? As a table function, similar to checkpoint()? I'd appreciate suggestions. Thanks.