### PR TITLE
[Fix][ADBC] Implement required ADBCConnectionGetObjects schema

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -960,57 +960,312 @@ AdbcStatusCode StatementSetOption(struct AdbcStatement *statement, const char *k
 AdbcStatusCode ConnectionGetObjects(struct AdbcConnection *connection, int depth, const char *catalog,
                                     const char *db_schema, const char *table_name, const char **table_type,
                                     const char *column_name, struct ArrowArrayStream *out, struct AdbcError *error) {
-	if (catalog != nullptr) {
-		if (strcmp(catalog, "duckdb") == 0) {
-			SetError(error, "catalog must be NULL or 'duckdb'");
-			return ADBC_STATUS_INVALID_ARGUMENT;
-		}
-	}
-
 	if (table_type != nullptr) {
 		SetError(error, "Table types parameter not yet supported");
 		return ADBC_STATUS_NOT_IMPLEMENTED;
 	}
+
+	std::string catalog_filter = catalog ? catalog : "%";
+	std::string db_schema_filter = db_schema ? db_schema : "%";
+	std::string table_name_filter = table_name ? table_name : "%";
+	std::string column_name_filter = column_name ? column_name : "%";
+
 	std::string query;
 	switch (depth) {
 	case ADBC_OBJECT_DEPTH_CATALOGS:
-		SetError(error, "ADBC_OBJECT_DEPTH_CATALOGS not yet supported");
-		return ADBC_STATUS_NOT_IMPLEMENTED;
+		// Return metadata on catalogs.
+		query = duckdb::StringUtil::Format(R"(
+				WITH filtered_schemata AS (
+					SELECT
+						catalog_name,
+						schema_name,
+					FROM
+						information_schema.schemata
+					WHERE catalog_name NOT IN ('system', 'temp') AND schema_name NOT IN ('information_schema', 'pg_catalog')
+				)
+				SELECT
+					catalog_name,
+					[]::STRUCT(
+						db_schema_name VARCHAR,
+						db_schema_tables STRUCT(
+							table_name VARCHAR,
+							table_type VARCHAR,
+							table_columns STRUCT(
+								column_name VARCHAR,
+								ordinal_position INTEGER,
+								remarks VARCHAR,
+								xdbc_data_type SMALLINT,
+								xdbc_type_name VARCHAR,
+								xdbc_column_size INTEGER,
+								xdbc_decimal_digits SMALLINT,
+								xdbc_num_prec_radix SMALLINT,
+								xdbc_nullable SMALLINT,
+								xdbc_column_def VARCHAR,
+								xdbc_sql_data_type SMALLINT,
+								xdbc_datetime_sub SMALLINT,
+								xdbc_char_octet_length INTEGER,
+								xdbc_is_nullable VARCHAR,
+								xdbc_scope_catalog VARCHAR,
+								xdbc_scope_schema VARCHAR,
+								xdbc_scope_table VARCHAR,
+								xdbc_is_autoincrement BOOLEAN,
+								xdbc_is_generatedcolumn BOOLEAN
+							)[],
+							table_constraints STRUCT(
+								constraint_name VARCHAR,
+								constraint_type VARCHAR,
+								constraint_column_names VARCHAR[],
+								constraint_column_usage STRUCT(fk_catalog VARCHAR, fk_db_schema VARCHAR, fk_table VARCHAR, fk_column_name VARCHAR)[]
+							)[]
+						)[]
+					)[] catalog_db_schemas
+				FROM
+					filtered_schemata
+				WHERE catalog_name LIKE '%s'
+				GROUP BY catalog_name
+				)",
+		                                   catalog_filter);
+		break;
 	case ADBC_OBJECT_DEPTH_DB_SCHEMAS:
 		// Return metadata on catalogs and schemas.
 		query = duckdb::StringUtil::Format(R"(
-				SELECT table_schema db_schema_name
-				FROM information_schema.columns
-				WHERE table_schema LIKE '%s' AND table_name LIKE '%s' AND column_name LIKE '%s' ;
+				WITH filtered_schemata AS (
+					SELECT
+						catalog_name,
+						schema_name,
+					FROM
+						information_schema.schemata
+					WHERE catalog_name NOT IN ('system', 'temp') AND schema_name NOT IN ('information_schema', 'pg_catalog')
+				),
+				db_schemas AS (
+					SELECT
+						*
+					FROM
+						filtered_schemata
+					WHERE schema_name LIKE '%s'
+				)
+
+				SELECT
+					catalog_name,
+					LIST({
+						db_schema_name: dbs.schema_name,
+						db_schema_tables: []::STRUCT(
+							table_name VARCHAR,
+							table_type VARCHAR,
+							table_columns STRUCT(
+								column_name VARCHAR,
+								ordinal_position INTEGER,
+								remarks VARCHAR,
+								xdbc_data_type SMALLINT,
+								xdbc_type_name VARCHAR,
+								xdbc_column_size INTEGER,
+								xdbc_decimal_digits SMALLINT,
+								xdbc_num_prec_radix SMALLINT,
+								xdbc_nullable SMALLINT,
+								xdbc_column_def VARCHAR,
+								xdbc_sql_data_type SMALLINT,
+								xdbc_datetime_sub SMALLINT,
+								xdbc_char_octet_length INTEGER,
+								xdbc_is_nullable VARCHAR,
+								xdbc_scope_catalog VARCHAR,
+								xdbc_scope_schema VARCHAR,
+								xdbc_scope_table VARCHAR,
+								xdbc_is_autoincrement BOOLEAN,
+								xdbc_is_generatedcolumn BOOLEAN
+							)[],
+							table_constraints STRUCT(
+								constraint_name VARCHAR,
+								constraint_type VARCHAR,
+								constraint_column_names VARCHAR[],
+								constraint_column_usage STRUCT(fk_catalog VARCHAR, fk_db_schema VARCHAR, fk_table VARCHAR, fk_column_name VARCHAR)[]
+							)[]
+						)[],
+					}) FILTER (dbs.schema_name IS NOT null) AS catalog_db_schemas
+				FROM
+					filtered_schemata
+				LEFT JOIN db_schemas dbs
+				USING (catalog_name)
+				WHERE catalog_name LIKE '%s'
+				GROUP BY catalog_name
 				)",
-		                                   db_schema ? db_schema : "%", table_name ? table_name : "%",
-		                                   column_name ? column_name : "%");
+		                                   db_schema_filter, catalog_filter);
 		break;
 	case ADBC_OBJECT_DEPTH_TABLES:
 		// Return metadata on catalogs, schemas, and tables.
 		query = duckdb::StringUtil::Format(R"(
-				SELECT table_schema db_schema_name, LIST(table_schema_list) db_schema_tables
-				FROM (
-					SELECT table_schema, { table_name : table_name} table_schema_list
-					FROM information_schema.columns
-					WHERE table_schema LIKE '%s' AND table_name LIKE '%s' AND column_name LIKE '%s'  GROUP BY table_schema, table_name
-					) GROUP BY table_schema;
+				WITH filtered_schemata AS (
+					SELECT
+						catalog_name,
+						schema_name,
+					FROM
+						information_schema.schemata
+					WHERE catalog_name NOT IN ('system', 'temp') AND schema_name NOT IN ('information_schema', 'pg_catalog')
+				),
+				tables AS (
+					SELECT
+						table_catalog catalog_name,
+						table_schema schema_name,
+						LIST({
+							table_name: table_name,
+							table_type: table_type,
+							table_columns: []::STRUCT(
+								column_name VARCHAR,
+								ordinal_position INTEGER,
+								remarks VARCHAR,
+								xdbc_data_type SMALLINT,
+								xdbc_type_name VARCHAR,
+								xdbc_column_size INTEGER,
+								xdbc_decimal_digits SMALLINT,
+								xdbc_num_prec_radix SMALLINT,
+								xdbc_nullable SMALLINT,
+								xdbc_column_def VARCHAR,
+								xdbc_sql_data_type SMALLINT,
+								xdbc_datetime_sub SMALLINT,
+								xdbc_char_octet_length INTEGER,
+								xdbc_is_nullable VARCHAR,
+								xdbc_scope_catalog VARCHAR,
+								xdbc_scope_schema VARCHAR,
+								xdbc_scope_table VARCHAR,
+								xdbc_is_autoincrement BOOLEAN,
+								xdbc_is_generatedcolumn BOOLEAN
+							)[],
+							table_constraints: []::STRUCT(
+								constraint_name VARCHAR,
+								constraint_type VARCHAR,
+								constraint_column_names VARCHAR[],
+								constraint_column_usage STRUCT(fk_catalog VARCHAR, fk_db_schema VARCHAR, fk_table VARCHAR, fk_column_name VARCHAR)[]
+							)[],
+						}) db_schema_tables
+					FROM information_schema.tables
+					WHERE table_name LIKE '%s'
+					GROUP BY table_catalog, table_schema
+				),
+				db_schemas AS (
+					SELECT
+						catalog_name,
+						schema_name,
+						db_schema_tables,
+					FROM filtered_schemata fs
+					LEFT JOIN tables t
+					USING (catalog_name, schema_name)
+					WHERE schema_name LIKE '%s'
+				)
+
+				SELECT
+					catalog_name,
+					LIST({
+						db_schema_name: dbs.schema_name,
+						db_schema_tables: db_schema_tables,
+					}) FILTER (dbs.schema_name is not null) AS catalog_db_schemas
+				FROM
+					filtered_schemata
+				LEFT JOIN db_schemas dbs
+				USING (catalog_name)
+				WHERE catalog_name LIKE '%s'
+				GROUP BY catalog_name
 				)",
-		                                   db_schema ? db_schema : "%", table_name ? table_name : "%",
-		                                   column_name ? column_name : "%");
+		                                   table_name_filter, db_schema_filter, catalog_filter);
 		break;
 	case ADBC_OBJECT_DEPTH_COLUMNS:
 		// Return metadata on catalogs, schemas, tables, and columns.
 		query = duckdb::StringUtil::Format(R"(
-				SELECT table_schema db_schema_name, LIST(table_schema_list) db_schema_tables
-				FROM (
-					SELECT table_schema, { table_name : table_name, table_columns : LIST({column_name : column_name, ordinal_position : ordinal_position + 1, remarks : ''})} table_schema_list
+				WITH filtered_schemata AS (
+					SELECT
+						catalog_name,
+						schema_name,
+					FROM
+						information_schema.schemata
+					WHERE catalog_name NOT IN ('system', 'temp') AND schema_name NOT IN ('information_schema', 'pg_catalog')
+				),
+				columns AS (
+					SELECT
+						table_catalog,
+						table_schema,
+						table_name,
+						LIST({
+							column_name: column_name,
+							ordinal_position: ordinal_position,
+							remarks : '',
+							xdbc_data_type: NULL::SMALLINT,
+							xdbc_type_name: NULL::VARCHAR,
+							xdbc_column_size: NULL::INTEGER,
+							xdbc_decimal_digits: NULL::SMALLINT,
+							xdbc_num_prec_radix: NULL::SMALLINT,
+							xdbc_nullable: NULL::SMALLINT,
+							xdbc_column_def: NULL::VARCHAR,
+							xdbc_sql_data_type: NULL::SMALLINT,
+							xdbc_datetime_sub: NULL::SMALLINT,
+							xdbc_char_octet_length: NULL::INTEGER,
+							xdbc_is_nullable: NULL::VARCHAR,
+							xdbc_scope_catalog: NULL::VARCHAR,
+							xdbc_scope_schema: NULL::VARCHAR,
+							xdbc_scope_table: NULL::VARCHAR,
+							xdbc_is_autoincrement: NULL::BOOLEAN,
+							xdbc_is_generatedcolumn: NULL::BOOLEAN,
+						}) table_columns
 					FROM information_schema.columns
-					WHERE table_schema LIKE '%s' AND table_name LIKE '%s' AND column_name LIKE '%s' GROUP BY table_schema, table_name
-					) GROUP BY table_schema;
+					WHERE column_name LIKE '%s'
+					GROUP BY table_catalog, table_schema, table_name
+				),
+				constraints AS (
+					SELECT
+						table_catalog,
+						table_schema,
+						table_name,
+						LIST(
+							{
+								constraint_name: constraint_name,
+								constraint_type: constraint_type,
+								constraint_column_names: []::VARCHAR[],
+								constraint_column_usage: []::STRUCT(fk_catalog VARCHAR, fk_db_schema VARCHAR, fk_table VARCHAR, fk_column_name VARCHAR)[],
+							}
+						) table_constraints
+					FROM information_schema.table_constraints
+					GROUP BY table_catalog, table_schema, table_name
+				),
+				tables AS (
+					SELECT
+						table_catalog catalog_name,
+						table_schema schema_name,
+						LIST({
+							table_name: table_name,
+							table_type: table_type,
+							table_columns: table_columns,
+							table_constraints: table_constraints,
+						}) db_schema_tables
+					FROM information_schema.tables
+					LEFT JOIN columns
+					USING (table_catalog, table_schema, table_name)
+					LEFT JOIN constraints
+					USING (table_catalog, table_schema, table_name)
+					WHERE table_name LIKE '%s'
+					GROUP BY table_catalog, table_schema
+				),
+				db_schemas AS (
+					SELECT
+						catalog_name,
+						schema_name,
+						db_schema_tables,
+					FROM filtered_schemata fs
+					LEFT JOIN tables t
+					USING (catalog_name, schema_name)
+					WHERE schema_name LIKE '%s'
+				)
+
+				SELECT
+					catalog_name,
+					LIST({
+						db_schema_name: dbs.schema_name,
+						db_schema_tables: db_schema_tables,
+					}) FILTER (dbs.schema_name is not null) AS catalog_db_schemas
+				FROM
+					filtered_schemata
+				LEFT JOIN db_schemas dbs
+				USING (catalog_name)
+				WHERE catalog_name LIKE '%s'
+				GROUP BY catalog_name
 				)",
-		                                   db_schema ? db_schema : "%", table_name ? table_name : "%",
-		                                   column_name ? column_name : "%");
+		                                   column_name_filter, table_name_filter, db_schema_filter, catalog_filter);
 		break;
 	default:
 		SetError(error, "Invalid value of Depth");

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -857,8 +857,8 @@ TEST_CASE("Test ADBC ConnectionGetTableSchema", "[adbc]") {
 	REQUIRE(StringUtil::Contains(adbc_error.message, "Catalog \"bla\" does not exist"));
 	adbc_error.release(&adbc_error);
 
-	REQUIRE(SUCCESS(
-	    AdbcConnectionGetTableSchema(&adbc_connection, "memory", "main", "duckdb_indexes", &arrow_schema, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcConnectionGetTableSchema(&adbc_connection, "memory", "main", "duckdb_indexes", &arrow_schema,
+	                                             &adbc_error)));
 	REQUIRE(arrow_schema.n_children == 13);
 	arrow_schema.release(&arrow_schema);
 

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -1065,7 +1065,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(0, 0).ToString() == "test_catalog_depth");
 		REQUIRE(res->GetValue(1, 0).ToString() == "[]");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		// Test Filters
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_CATALOGS, "bla", nullptr, nullptr, nullptr,
@@ -1074,7 +1074,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		res = db.Query("Select * from result");
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 0);
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 	}
 	// 2. Test ADBC_OBJECT_DEPTH_DB_SCHEMAS
 	{
@@ -1103,7 +1103,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		])";
 		REQUIRE(StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
 		        StringUtil::Replace(StringUtil::Replace(StringUtil::Replace(expected, "\n", ""), "\t", ""), " ", ""));
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		// Test Filters
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_DB_SCHEMAS, "bla", nullptr, nullptr, nullptr,
@@ -1112,7 +1112,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		res = db.Query("Select * from result");
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 0);
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_DB_SCHEMAS, nullptr, "bla", nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1121,7 +1121,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "NULL");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 	}
 	// 3. Test ADBC_OBJECT_DEPTH_TABLES
 	{
@@ -1156,7 +1156,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		])";
 		REQUIRE(StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
 		        StringUtil::Replace(StringUtil::Replace(StringUtil::Replace(expected, "\n", ""), "\t", ""), " ", ""));
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		// Test Filters
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, "bla", nullptr, nullptr, nullptr,
@@ -1165,7 +1165,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		res = db.Query("Select * from result");
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 0);
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, "bla", nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1174,7 +1174,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "NULL");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, nullptr, "bla", nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1183,7 +1183,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "[{'db_schema_name': main, 'db_schema_tables': NULL}]");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 	}
 	// 4.Test ADBC_OBJECT_DEPTH_COLUMNS
 	{
@@ -1240,7 +1240,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		])";
 		REQUIRE(StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
 		        StringUtil::Replace(StringUtil::Replace(StringUtil::Replace(expected, "\n", ""), "\t", ""), " ", ""));
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		// Test Filters
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, "bla", nullptr, nullptr, nullptr,
@@ -1249,7 +1249,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		res = db.Query("Select * from result");
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 0);
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, "bla", nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1258,7 +1258,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "NULL");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, "bla", nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1267,7 +1267,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "[{'db_schema_name': main, 'db_schema_tables': NULL}]");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, nullptr, nullptr,
 		                         "bla", &arrow_stream, &adbc_error);
@@ -1278,7 +1278,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->GetValue(1, 0).ToString() ==
 		        "[{'db_schema_name': main, 'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, "
 		        "'table_columns': NULL, 'table_constraints': NULL}]}]");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 	}
 	// 5.Test ADBC_OBJECT_DEPTH_ALL
 	{
@@ -1335,7 +1335,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		])";
 		REQUIRE(StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
 		        StringUtil::Replace(StringUtil::Replace(StringUtil::Replace(expected, "\n", ""), "\t", ""), " ", ""));
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		// Test Filters
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, "bla", nullptr, nullptr, nullptr,
@@ -1344,7 +1344,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		res = db.Query("Select * from result");
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 0);
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, "bla", nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1353,7 +1353,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "NULL");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, "bla", nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1362,7 +1362,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "[{'db_schema_name': main, 'db_schema_tables': NULL}]");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, nullptr, nullptr,
 		                         "bla", &arrow_stream, &adbc_error);
@@ -1373,7 +1373,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->GetValue(1, 0).ToString() ==
 		        "[{'db_schema_name': main, 'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, "
 		        "'table_columns': NULL, 'table_constraints': NULL}]}]");
-		db.QueryArrow("Drop table result;");
+		db.Query("Drop table result;");
 	}
 	//	 Now lets test some errors
 	{

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -851,12 +851,16 @@ TEST_CASE("Test ADBC ConnectionGetTableSchema", "[adbc]") {
 	REQUIRE(arrow_schema.n_children == 13);
 	arrow_schema.release(&arrow_schema);
 
-	// Test Catalog Name (Not accepted)
+	// Test Catalog Name
 	REQUIRE(!SUCCESS(
 	    AdbcConnectionGetTableSchema(&adbc_connection, "bla", "main", "duckdb_indexes", &arrow_schema, &adbc_error)));
-	REQUIRE(std::strcmp(adbc_error.message,
-	                    "Catalog Name is not used in DuckDB. It must be set to nullptr or an empty string") == 0);
+	REQUIRE(StringUtil::Contains(adbc_error.message, "Catalog \"bla\" does not exist"));
 	adbc_error.release(&adbc_error);
+
+	REQUIRE(SUCCESS(
+	    AdbcConnectionGetTableSchema(&adbc_connection, "memory", "main", "duckdb_indexes", &arrow_schema, &adbc_error)));
+	REQUIRE(arrow_schema.n_children == 13);
+	arrow_schema.release(&arrow_schema);
 
 	// Empty schema should be fine
 	REQUIRE(SUCCESS(

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -1101,13 +1101,8 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 				'db_schema_tables': []
 			}
 		])";
-		REQUIRE(
-			StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
-			StringUtil::Replace(
-				StringUtil::Replace(
-					StringUtil::Replace(expected, "\n", ""),
-					"\t", ""),
-				" ", ""));
+		REQUIRE(StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
+		        StringUtil::Replace(StringUtil::Replace(StringUtil::Replace(expected, "\n", ""), "\t", ""), " ", ""));
 		db.QueryArrow("Drop table result;");
 
 		// Test Filters
@@ -1118,7 +1113,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 0);
 		db.QueryArrow("Drop table result;");
-		
+
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_DB_SCHEMAS, nullptr, "bla", nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
@@ -1159,15 +1154,10 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 				]
 			}
 		])";
-		REQUIRE(
-			StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
-			StringUtil::Replace(
-				StringUtil::Replace(
-					StringUtil::Replace(expected, "\n", ""),
-					"\t", ""),
-				" ", ""));
+		REQUIRE(StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
+		        StringUtil::Replace(StringUtil::Replace(StringUtil::Replace(expected, "\n", ""), "\t", ""), " ", ""));
 		db.QueryArrow("Drop table result;");
-		
+
 		// Test Filters
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, "bla", nullptr, nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
@@ -1176,7 +1166,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 0);
 		db.QueryArrow("Drop table result;");
-		
+
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, "bla", nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
@@ -1185,7 +1175,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "NULL");
 		db.QueryArrow("Drop table result;");
-		
+
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_TABLES, nullptr, nullptr, "bla", nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
@@ -1248,13 +1238,8 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 				]
 			}
 		])";
-		REQUIRE(
-			StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
-			StringUtil::Replace(
-				StringUtil::Replace(
-					StringUtil::Replace(expected, "\n", ""),
-					"\t", ""),
-				" ", ""));
+		REQUIRE(StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
+		        StringUtil::Replace(StringUtil::Replace(StringUtil::Replace(expected, "\n", ""), "\t", ""), " ", ""));
 		db.QueryArrow("Drop table result;");
 
 		// Test Filters
@@ -1265,7 +1250,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 0);
 		db.QueryArrow("Drop table result;");
-		
+
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, "bla", nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
@@ -1274,7 +1259,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "NULL");
 		db.QueryArrow("Drop table result;");
-		
+
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, "bla", nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
@@ -1283,7 +1268,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "[{'db_schema_name': main, 'db_schema_tables': NULL}]");
 		db.QueryArrow("Drop table result;");
-		
+
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, nullptr, nullptr,
 		                         "bla", &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
@@ -1291,7 +1276,8 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() ==
-			"[{'db_schema_name': main, 'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, 'table_columns': NULL, 'table_constraints': NULL}]}]");
+		        "[{'db_schema_name': main, 'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, "
+		        "'table_columns': NULL, 'table_constraints': NULL}]}]");
 		db.QueryArrow("Drop table result;");
 	}
 	// 5.Test ADBC_OBJECT_DEPTH_ALL
@@ -1347,13 +1333,8 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 				]
 			}
 		])";
-		REQUIRE(
-			StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
-			StringUtil::Replace(
-				StringUtil::Replace(
-					StringUtil::Replace(expected, "\n", ""),
-					"\t", ""),
-				" ", ""));
+		REQUIRE(StringUtil::Replace(res->GetValue(1, 0).ToString(), " ", "") ==
+		        StringUtil::Replace(StringUtil::Replace(StringUtil::Replace(expected, "\n", ""), "\t", ""), " ", ""));
 		db.QueryArrow("Drop table result;");
 
 		// Test Filters
@@ -1364,7 +1345,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 0);
 		db.QueryArrow("Drop table result;");
-		
+
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, "bla", nullptr, nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
@@ -1373,7 +1354,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "NULL");
 		db.QueryArrow("Drop table result;");
-		
+
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, "bla", nullptr,
 		                         nullptr, &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
@@ -1382,7 +1363,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() == "[{'db_schema_name': main, 'db_schema_tables': NULL}]");
 		db.QueryArrow("Drop table result;");
-		
+
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, nullptr, nullptr,
 		                         "bla", &arrow_stream, &adbc_error);
 		db.CreateTable("result", arrow_stream);
@@ -1390,7 +1371,8 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 1);
 		REQUIRE(res->GetValue(1, 0).ToString() ==
-			"[{'db_schema_name': main, 'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, 'table_columns': NULL, 'table_constraints': NULL}]}]");
+		        "[{'db_schema_name': main, 'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, "
+		        "'table_columns': NULL, 'table_constraints': NULL}]}]");
 		db.QueryArrow("Drop table result;");
 	}
 	//	 Now lets test some errors

--- a/tools/pythonpkg/tests/fast/adbc/test_adbc.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_adbc.py
@@ -339,12 +339,26 @@ def test_connection_get_table_schema(duck_conn):
             ]
         )
 
-        # Catalog name is currently not supported
+        # Test invalid catalog name
         with pytest.raises(
-            adbc_driver_manager_lib.NotSupportedError,
-            match=r'Catalog Name is not used in DuckDB. It must be set to nullptr or an empty string',
+            adbc_driver_manager.InternalError,
+            match=r'Catalog "bla" does not exist',
         ):
             duck_conn.adbc_get_table_schema("tableschema", catalog_filter="bla", db_schema_filter="test")
+
+        # Catalog and DB Schema name
+        assert duck_conn.adbc_get_table_schema("tableschema", catalog_filter="memory", db_schema_filter="test") == pyarrow.schema(
+            [
+                ("test_ints", "int64"),
+            ]
+        )
+
+        # DB Schema is inferred to be "main" if unspecified
+        assert duck_conn.adbc_get_table_schema("tableschema", catalog_filter="memory") == pyarrow.schema(
+            [
+                ("ints", "int64"),
+            ]
+        )
 
 
 def test_prepared_statement(duck_conn):

--- a/tools/pythonpkg/tests/fast/adbc/test_adbc.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_adbc.py
@@ -97,7 +97,7 @@ def test_connection_get_objects(duck_conn):
                         }
                     ],
                 },
-            ]
+            ],
         }
     ]
 
@@ -117,7 +117,7 @@ def test_connection_get_objects(duck_conn):
                         }
                     ],
                 },
-            ]
+            ],
         }
     ]
 
@@ -130,7 +130,7 @@ def test_connection_get_objects(duck_conn):
                     'db_schema_name': 'main',
                     'db_schema_tables': [],
                 },
-            ]
+            ],
         }
     ]
 
@@ -147,10 +147,11 @@ def test_connection_get_objects(duck_conn):
     assert depth_all.schema == depth_db_schemas.schema
     assert depth_all.schema == depth_catalogs.schema
 
+
 def test_connection_get_objects_filters(duck_conn):
     with duck_conn.cursor() as cursor:
         cursor.execute("CREATE TABLE getobjects (ints BIGINT PRIMARY KEY)")
-    
+
     no_filter = duck_conn.adbc_get_objects(depth="all").read_all()
     assert no_filter.to_pylist() == [
         {
@@ -202,7 +203,7 @@ def test_connection_get_objects_filters(duck_conn):
                         }
                     ],
                 },
-            ]
+            ],
         }
     ]
 
@@ -235,7 +236,7 @@ def test_connection_get_objects_filters(duck_conn):
                         }
                     ],
                 },
-            ]
+            ],
         }
     ]
 
@@ -248,7 +249,7 @@ def test_connection_get_objects_filters(duck_conn):
                     'db_schema_name': 'main',
                     'db_schema_tables': None,
                 },
-            ]
+            ],
         }
     ]
 
@@ -267,7 +268,6 @@ def test_connection_get_objects_filters(duck_conn):
     assert no_filter.schema == table_name_filter.schema
     assert no_filter.schema == db_schema_filter.schema
     assert no_filter.schema == catalog_filter.schema
-
 
 
 def test_commit(tmp_path):

--- a/tools/pythonpkg/tests/fast/adbc/test_adbc.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_adbc.py
@@ -45,18 +45,230 @@ def test_connection_get_table_types(duck_conn):
 
 def test_connection_get_objects(duck_conn):
     with duck_conn.cursor() as cursor:
-        cursor.execute("CREATE TABLE getobjects (ints BIGINT)")
-    assert duck_conn.adbc_get_objects(depth="all").read_all().to_pylist() == [
+        cursor.execute("CREATE TABLE getobjects (ints BIGINT PRIMARY KEY)")
+        depth_all = duck_conn.adbc_get_objects(depth="all").read_all()
+    assert depth_all.to_pylist() == [
         {
-            'db_schema_name': 'main',
-            'db_schema_tables': [
+            'catalog_name': 'memory',
+            'catalog_db_schemas': [
                 {
-                    'table_name': 'getobjects',
-                    'table_columns': [{'column_name': 'ints', 'ordinal_position': 2, 'remarks': ''}],
-                }
-            ],
+                    'db_schema_name': 'main',
+                    'db_schema_tables': [
+                        {
+                            'table_name': 'getobjects',
+                            'table_type': 'BASE TABLE',
+                            'table_columns': [
+                                {
+                                    'column_name': 'ints',
+                                    'ordinal_position': 1,
+                                    'remarks': '',
+                                    'xdbc_char_octet_length': None,
+                                    'xdbc_column_def': None,
+                                    'xdbc_column_size': None,
+                                    'xdbc_data_type': None,
+                                    'xdbc_datetime_sub': None,
+                                    'xdbc_decimal_digits': None,
+                                    'xdbc_is_autoincrement': None,
+                                    'xdbc_is_generatedcolumn': None,
+                                    'xdbc_is_nullable': None,
+                                    'xdbc_nullable': None,
+                                    'xdbc_num_prec_radix': None,
+                                    'xdbc_scope_catalog': None,
+                                    'xdbc_scope_schema': None,
+                                    'xdbc_scope_table': None,
+                                    'xdbc_sql_data_type': None,
+                                    'xdbc_type_name': None,
+                                },
+                            ],
+                            'table_constraints': [
+                                {
+                                    'constraint_column_names': [],
+                                    'constraint_column_usage': [],
+                                    'constraint_name': 'getobjects_ints_pkey',
+                                    'constraint_type': 'PRIMARY KEY',
+                                },
+                                {
+                                    'constraint_column_names': [],
+                                    'constraint_column_usage': [],
+                                    'constraint_name': 'getobjects_ints_not_null',
+                                    'constraint_type': 'CHECK',
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ]
         }
     ]
+
+    depth_tables = duck_conn.adbc_get_objects(depth="tables").read_all()
+    assert depth_tables.to_pylist() == [
+        {
+            'catalog_name': 'memory',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': [
+                        {
+                            'table_name': 'getobjects',
+                            'table_type': 'BASE TABLE',
+                            'table_columns': [],
+                            'table_constraints': [],
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
+
+    depth_db_schemas = duck_conn.adbc_get_objects(depth="db_schemas").read_all()
+    assert depth_db_schemas.to_pylist() == [
+        {
+            'catalog_name': 'memory',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': [],
+                },
+            ]
+        }
+    ]
+
+    depth_catalogs = duck_conn.adbc_get_objects(depth="catalogs").read_all()
+    assert depth_catalogs.to_pylist() == [
+        {
+            'catalog_name': 'memory',
+            'catalog_db_schemas': [],
+        }
+    ]
+
+    # All result schemas should be the same
+    assert depth_all.schema == depth_tables.schema
+    assert depth_all.schema == depth_db_schemas.schema
+    assert depth_all.schema == depth_catalogs.schema
+
+def test_connection_get_objects_filters(duck_conn):
+    with duck_conn.cursor() as cursor:
+        cursor.execute("CREATE TABLE getobjects (ints BIGINT PRIMARY KEY)")
+    
+    no_filter = duck_conn.adbc_get_objects(depth="all").read_all()
+    assert no_filter.to_pylist() == [
+        {
+            'catalog_name': 'memory',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': [
+                        {
+                            'table_name': 'getobjects',
+                            'table_type': 'BASE TABLE',
+                            'table_columns': [
+                                {
+                                    'column_name': 'ints',
+                                    'ordinal_position': 1,
+                                    'remarks': '',
+                                    'xdbc_char_octet_length': None,
+                                    'xdbc_column_def': None,
+                                    'xdbc_column_size': None,
+                                    'xdbc_data_type': None,
+                                    'xdbc_datetime_sub': None,
+                                    'xdbc_decimal_digits': None,
+                                    'xdbc_is_autoincrement': None,
+                                    'xdbc_is_generatedcolumn': None,
+                                    'xdbc_is_nullable': None,
+                                    'xdbc_nullable': None,
+                                    'xdbc_num_prec_radix': None,
+                                    'xdbc_scope_catalog': None,
+                                    'xdbc_scope_schema': None,
+                                    'xdbc_scope_table': None,
+                                    'xdbc_sql_data_type': None,
+                                    'xdbc_type_name': None,
+                                },
+                            ],
+                            'table_constraints': [
+                                {
+                                    'constraint_column_names': [],
+                                    'constraint_column_usage': [],
+                                    'constraint_name': 'getobjects_ints_pkey',
+                                    'constraint_type': 'PRIMARY KEY',
+                                },
+                                {
+                                    'constraint_column_names': [],
+                                    'constraint_column_usage': [],
+                                    'constraint_name': 'getobjects_ints_not_null',
+                                    'constraint_type': 'CHECK',
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
+
+    column_filter = duck_conn.adbc_get_objects(depth="all", column_name_filter="notexist").read_all()
+    assert column_filter.to_pylist() == [
+        {
+            'catalog_name': 'memory',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': [
+                        {
+                            'table_name': 'getobjects',
+                            'table_type': 'BASE TABLE',
+                            'table_columns': None,
+                            'table_constraints': [
+                                {
+                                    'constraint_column_names': [],
+                                    'constraint_column_usage': [],
+                                    'constraint_name': 'getobjects_ints_pkey',
+                                    'constraint_type': 'PRIMARY KEY',
+                                },
+                                {
+                                    'constraint_column_names': [],
+                                    'constraint_column_usage': [],
+                                    'constraint_name': 'getobjects_ints_not_null',
+                                    'constraint_type': 'CHECK',
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
+
+    table_name_filter = duck_conn.adbc_get_objects(depth="all", table_name_filter="notexist").read_all()
+    assert table_name_filter.to_pylist() == [
+        {
+            'catalog_name': 'memory',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+            ]
+        }
+    ]
+
+    db_schema_filter = duck_conn.adbc_get_objects(depth="all", db_schema_filter="notexist").read_all()
+    assert db_schema_filter.to_pylist() == [
+        {
+            'catalog_name': 'memory',
+            'catalog_db_schemas': None,
+        }
+    ]
+
+    catalog_filter = duck_conn.adbc_get_objects(depth="all", catalog_filter="notexist").read_all()
+    assert catalog_filter.to_pylist() == []
+
+    assert no_filter.schema == column_filter.schema
+    assert no_filter.schema == table_name_filter.schema
+    # assert no_filter.schema == table_name_filter.schema
+    assert no_filter.schema == db_schema_filter.schema
+    assert no_filter.schema == catalog_filter.schema
+
 
 
 def test_commit(tmp_path):

--- a/tools/pythonpkg/tests/fast/adbc/test_adbc.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_adbc.py
@@ -347,7 +347,9 @@ def test_connection_get_table_schema(duck_conn):
             duck_conn.adbc_get_table_schema("tableschema", catalog_filter="bla", db_schema_filter="test")
 
         # Catalog and DB Schema name
-        assert duck_conn.adbc_get_table_schema("tableschema", catalog_filter="memory", db_schema_filter="test") == pyarrow.schema(
+        assert duck_conn.adbc_get_table_schema(
+            "tableschema", catalog_filter="memory", db_schema_filter="test"
+        ) == pyarrow.schema(
             [
                 ("test_ints", "int64"),
             ]

--- a/tools/pythonpkg/tests/fast/adbc/test_adbc.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_adbc.py
@@ -265,7 +265,6 @@ def test_connection_get_objects_filters(duck_conn):
 
     assert no_filter.schema == column_filter.schema
     assert no_filter.schema == table_name_filter.schema
-    # assert no_filter.schema == table_name_filter.schema
     assert no_filter.schema == db_schema_filter.schema
     assert no_filter.schema == catalog_filter.schema
 


### PR DESCRIPTION
Fixes: #11330

Previously, the output of ADBCConnectionGetObjects did not output results in the [schema expected](https://github.com/apache/arrow-adbc/blob/ff866d9e2a696accbff3de3157eff70b3509fa79/adbc.h#L1468) by ADBC.

This fix ensures that the proper schema is used for GetObjects at all search depths and with any filter patterns.

Additionally:
- `depth='catalog'` is now implemented
- `table_type` is now included in results but still not valid for filtering (not implemented in upstream api)
- Table constraints are now included in the results (see limitations)

Limitations:
- The official GetObjects result schema specifies certain fields to be `not null`. The nullability is technically part of the schema, so it must be specified to have an exact schema match. In practice this would likely require defining the schema explicitly rather than deriving it from the query result to get it exact. That may be a better approach but at least for this implementation the response should be compatible with what most consumers would be expecting.
- Table constraints `names` and `types` are added to the response, but the current `information_schema` tables only contain `column` information for certain constraint types. For consistency across all constraint types, I've left the constraint-column fields as NULL.