### PR TITLE
CLI: Add support for ".edit" or "\e"

### DIFF
--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -14,6 +14,7 @@
 #include "linenoise.h"
 
 #define LINENOISE_MAX_LINE 204800
+#define LINENOISE_EDITOR
 
 namespace duckdb {
 struct highlightToken;
@@ -97,6 +98,11 @@ public:
 	void PerformSearch();
 	void SearchPrev();
 	void SearchNext();
+
+#ifdef LINENOISE_EDITOR
+	bool EditBufferWithEditor(const char *editor);
+	bool EditFileWithEditor(const string &file_name, const char *editor);
+#endif
 
 	char Search(char c);
 

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -20,6 +20,14 @@
 #include <sys/time.h>
 #endif
 
+#ifdef LINENOISE_EDITOR
+#if defined(WIN32) || defined(__CYGWIN__)
+#define DEFAULT_EDITOR "notepad.exe"
+#else
+#define DEFAULT_EDITOR "vi"
+#endif
+#endif
+
 namespace duckdb {
 
 static linenoiseCompletionCallback *completionCallback = NULL;
@@ -1137,6 +1145,35 @@ int Linenoise::Edit() {
 		switch (c) {
 		case CTRL_J:
 		case ENTER: { /* enter */
+#ifdef LINENOISE_EDITOR
+			if (len > 0) {
+				// check if this contains ".edit"
+
+				// scroll back to last newline
+				idx_t begin_pos;
+				for (begin_pos = len; begin_pos > 0 && buf[begin_pos - 1] != '\n'; begin_pos--) {
+				}
+				// check if line is ".edit"
+				bool open_editor = false;
+				if (begin_pos + 5 == len && memcmp(buf + begin_pos, ".edit", 5) == 0) {
+					open_editor = true;
+				}
+				// check if line is "\\e"
+				if (begin_pos + 2 == len && memcmp(buf + begin_pos, "\\e", 2) == 0) {
+					open_editor = true;
+				}
+				if (open_editor) {
+					// .edit
+					// clear the buffer and open the editor
+					pos = len = begin_pos;
+					if (!EditBufferWithEditor(nullptr)) {
+						// failed to edit - refresh the removal of ".edit" / "\e"
+						RefreshLine();
+					}
+					break;
+				}
+			}
+#endif
 			if (Terminal::IsMultiline() && len > 0) {
 				// check if this forms a complete SQL statement or not
 				buf[len] = '\0';
@@ -1423,5 +1460,141 @@ void Linenoise::LogTokens(const vector<highlightToken> &tokens) {
 	}
 #endif
 }
+
+#ifdef LINENOISE_EDITOR
+// .edit functionality - code adopted from psql
+
+bool Linenoise::EditFileWithEditor(const string &file_name, const char *editor) {
+	/* Find an editor to use */
+	if (!editor) {
+		editor = getenv("DUCKDB_EDITOR");
+	}
+	if (!editor) {
+		editor = getenv("EDITOR");
+	}
+	if (!editor) {
+		editor = getenv("VISUAL");
+	}
+	if (!editor) {
+		editor = DEFAULT_EDITOR;
+	}
+
+	/*
+	 * On Unix the EDITOR value should *not* be quoted, since it might include
+	 * switches, eg, EDITOR="pico -t"; it's up to the user to put quotes in it
+	 * if necessary.  But this policy is not very workable on Windows, due to
+	 * severe brain damage in their command shell plus the fact that standard
+	 * program paths include spaces.
+	 */
+	string command;
+#ifndef WIN32
+	command = "exec " + string(editor) + " '" + file_name + "'";
+#else
+	command = "\"" + string(editor) + "\" \"" + file_name + "\"";
+#endif
+	int result = system(command.c_str());
+	if (result == -1) {
+		Log("could not start editor \"%s\"\n", editor);
+	} else if (result == 127) {
+		Log("could not start /bin/sh\n");
+	}
+	return result == 0;
+}
+
+bool Linenoise::EditBufferWithEditor(const char *editor) {
+	/* make a temp file to edit */
+#ifndef WIN32
+	const char *tmpdir = getenv("TMPDIR");
+	if (!tmpdir) {
+		tmpdir = "/tmp";
+	}
+#else
+	char tmpdir[MAX_PATH_LENGTH];
+	int ret;
+
+	ret = GetTempPath(MAX_PATH_LENGTH, tmpdir);
+	if (ret == 0 || ret > MAX_PATH_LENGTH) {
+		Log("cannot locate temporary directory: %s", !ret ? strerror(errno) : "");
+		return false;
+	}
+#endif
+	string temporary_file_name;
+#ifndef WIN32
+	temporary_file_name = string(tmpdir) + "/duckdb.edit." + std::to_string(getpid());
+#else
+	temporary_file_name = string(tmpdir) + "duckdb.edit." + std::to_string(getpid());
+#endif
+
+	FILE *f = fopen(temporary_file_name.c_str(), "w+");
+	if (!f) {
+		Log("could not open temporary file \"%s\": %s\n", temporary_file_name, strerror(errno));
+		Terminal::Beep();
+		return false;
+	}
+
+	// write existing buffer to file
+	if (fwrite(buf, 1, len, f) != len) {
+		Log("Failed to write data %s: %s\n", temporary_file_name, strerror(errno));
+		fclose(f);
+		remove(temporary_file_name.c_str());
+		Terminal::Beep();
+		return false;
+	}
+	fclose(f);
+
+	/* call editor */
+	if (!EditFileWithEditor(temporary_file_name, editor)) {
+		Terminal::Beep();
+		return false;
+	}
+
+	// read the file contents again
+	f = fopen(temporary_file_name.c_str(), "rb");
+	if (!f) {
+		Log("Failed to open file%s: %s\n", temporary_file_name, strerror(errno));
+		remove(temporary_file_name.c_str());
+		Terminal::Beep();
+		return false;
+	}
+
+	/* read file back into buffer */
+	string new_buffer;
+	char line[1024];
+	while (fgets(line, sizeof(line), f)) {
+		// strip the existing newline from the line obtained from fgets
+		// the reason for that is that we need the line endings to be "\r\n" for rendering purposes
+		idx_t line_len = strlen(line);
+		idx_t orig_len = line_len;
+		while (line_len > 0 && (line[line_len - 1] == '\r' || line[line_len - 1] == '\n')) {
+			line_len--;
+		}
+		new_buffer.append(line, line_len);
+		if (orig_len != line_len) {
+			// we stripped a newline - add a new newline (but this time always \r\n)
+			new_buffer += "\r\n";
+		}
+	}
+	if (ferror(f)) {
+		Log("Failed while reading back buffer %s: %s\n", temporary_file_name, strerror(errno));
+		Terminal::Beep();
+	}
+	fclose(f);
+
+	/* remove temp file */
+	if (remove(temporary_file_name.c_str()) == -1) {
+		Log("Failed to remove file \"%s\": %s\n", temporary_file_name, strerror(errno));
+		Terminal::Beep();
+		return false;
+	}
+
+	// copy back into buffer
+	memcpy(buf, new_buffer.c_str(), new_buffer.size());
+	len = new_buffer.size();
+	pos = len;
+	RefreshLine();
+
+	return true;
+}
+#endif
 
 } // namespace duckdb

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -13594,11 +13594,13 @@ static const char *(azHelp[]) = {
   ".changes on|off          Show number of rows changed by SQL",
   ".check GLOB              Fail if output since .testcase does not match",
   ".columns                 Column-wise rendering of query results",
+#ifdef HAVE_LINENOISE
   ".constant ?COLOR?        Sets the syntax highlighting color used for constant values",
   "   COLOR is one of:",
   "     red|green|yellow|blue|magenta|cyan|white|brightblack|brightred|brightgreen",
   "     brightyellow|brightblue|brightmagenta|brightcyan|brightwhite",
   ".constantcode ?CODE?     Sets the syntax highlighting terminal code used for constant values",
+#endif
   ".databases               List names and files of attached databases",
   ".dump ?TABLE?            Render database content as SQL",
   "   Options:",
@@ -13615,12 +13617,22 @@ static const char *(azHelp[]) = {
   "      trigger               Like \"full\" but also show trigger bytecode",
   ".excel                   Display the output of next command in spreadsheet",
   "   --bom                   Put a UTF8 byte-order mark on intermediate file",
+#ifdef HAVE_LINENOISE
+  ".edit                    Opens an external text editor to edit a query.",
+  "   Notes:",
+  "     *  The editor is read from the environment variables",
+  "        DUCKDB_EDITOR, EDITOR, VISUAL in-order",
+  "     * If none of these are set, the default editor is vi",
+    "   * \\e can be used as an alais for .edit",
+#endif
   ".exit ?CODE?             Exit this program with return-code CODE",
   ".explain ?on|off|auto?   Change the EXPLAIN formatting mode.  Default: auto",
   ".fullschema ?--indent?   Show schema and the content of sqlite_stat tables",
   ".headers on|off          Turn display of headers on or off",
   ".help ?-all? ?PATTERN?   Show help text for PATTERN",
+#ifdef HAVE_LINENOISE
   ".highlight [on|off]      Toggle syntax highlighting in the shell on/off",
+#endif
   ".import FILE TABLE       Import data from FILE into TABLE",
   "   Options:",
   "     --ascii               Use \\037 and \\036 as column and row separators",
@@ -13640,11 +13652,13 @@ static const char *(azHelp[]) = {
 #ifdef SQLITE_ENABLE_IOTRACE
   ".iotrace FILE            Enable I/O diagnostic logging to FILE",
 #endif
+#ifdef HAVE_LINENOISE
   ".keyword ?COLOR?         Sets the syntax highlighting color used for keywords",
   "   COLOR is one of:",
   "     red|green|yellow|blue|magenta|cyan|white|brightblack|brightred|brightgreen",
   "     brightyellow|brightblue|brightmagenta|brightcyan|brightwhite",
   ".keywordcode ?CODE?      Sets the syntax highlighting terminal code used for keywords",
+#endif
   ".lint OPTIONS            Report potential schema issues.",
   "     Options:",
   "        fkey-indexes     Find missing foreign key indexes",


### PR DESCRIPTION
This PR adds support for using the `.edit` (or `\e` for short) commands to open an editor to either (a) edit the previous history entry, or (b) edit the current buffer. The editor that is opened is by default `vi`, but can be configured using either the `DUCKDB_EDITOR`, `EDITOR` or `VISUAL` environment variables (in that order). When the command is used, the specified editor is opened with the current contents of the edit buffer. If the editor closes successfully (e.g. `:wq` in vim) the edit buffer is replaced with the contents of the file and any queries within the file are executed. If the editor closes unsuccessfully (e.g. `:q!` in vim) the previous buffer is kept around.

Example usage:

```sql
D .edit -- opens an editor containing the previous history entry
D SELECT *
  FROM tbl
  .edit -- opens an editor containing the above text
```