### PR TITLE
Fix VS2022 Preview ClangCl build

### DIFF
--- a/src/include/duckdb/common/bit_utils.hpp
+++ b/src/include/duckdb/common/bit_utils.hpp
@@ -11,7 +11,7 @@
 #include "duckdb/common/hugeint.hpp"
 #include "duckdb/common/uhugeint.hpp"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #define __restrict__
 #define __BYTE_ORDER__          __ORDER_LITTLE_ENDIAN__
 #define __ORDER_LITTLE_ENDIAN__ 2

--- a/third_party/fsst/fsst.h
+++ b/third_party/fsst/fsst.h
@@ -48,7 +48,7 @@
 #ifndef FSST_INCLUDED_H
 #define FSST_INCLUDED_H
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #define __restrict__ 
 #define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
 #define __ORDER_LITTLE_ENDIAN__ 2

--- a/tools/sqlite3_api_wrapper/sqlite3/stripped_sqlite_int.h
+++ b/tools/sqlite3_api_wrapper/sqlite3/stripped_sqlite_int.h
@@ -20,6 +20,7 @@ typedef uint64_t sqlite3_uint64;
 #ifdef USE_DUCKDB_SHELL_WRAPPER
 #include "duckdb_shell_wrapper.h"
 void *sqlite3_realloc64(void *ptr, sqlite3_uint64 n);
+void *sqlite3_free(void *ptr);
 #else
 #define sqlite3_realloc64 realloc
 #define sqlite3_free      free


### PR DESCRIPTION
The bundled clang-cl in VS 2022 Preview failed building DuckDB. This PR fixes the errors it encountered.

- The code checked if we were under MSVC by checking `_MSC_VER`, which clang-cl also defines. However, clang-cl has the GCC-style `__builtin_*` functions, which lead to a double definition error.
- os_win.c uses `sqlite3_free` which is defined by `"duckdb_shell_wrapper.h"` to be `duckdb_shell_sqlite3_free`. Neither of these functions is declared in this file if `USE_DUCKDB_SHELL_WRAPPER` is defined. Haven't looked into how this could compile with other compilers (probably some build-system shenanigans). Nevertheless, seems like just an oversight when a78f6a46 introduced the macro and the whole branch, since the realloc one is paired with `sqlite3_realloc`.