### PR TITLE
Removing abort() from RE2 again because Google refuses to use exceptions

### DIFF
--- a/third_party/re2/util/logging.h
+++ b/third_party/re2/util/logging.h
@@ -92,10 +92,11 @@ class LogMessage {
 class LogMessageFatal : public LogMessage {
  public:
   LogMessageFatal(const char* file, int line)
-      : LogMessage(file, line) {}
-  ATTRIBUTE_NORETURN ~LogMessageFatal() {
+      : LogMessage(file, line) {
+	  throw std::runtime_error("RE2 Fatal Error");
+  }
+  ~LogMessageFatal() {
     Flush();
-    abort();
   }
  private:
   LogMessageFatal(const LogMessageFatal&) = delete;

--- a/third_party/re2/util/mutex.h
+++ b/third_party/re2/util/mutex.h
@@ -93,8 +93,8 @@ void Mutex::ReaderUnlock() { ReleaseSRWLockShared(&mutex_); }
 
 #define SAFE_PTHREAD(fncall)    \
   do {                          \
-    if ((fncall) != 0) abort(); \
-  } while (0)
+    if ((fncall) != 0) throw std::runtime_error("RE2 pthread failure"); \
+  } while (0);
 
 Mutex::Mutex()             { SAFE_PTHREAD(pthread_rwlock_init(&mutex_, NULL)); }
 Mutex::~Mutex()            { SAFE_PTHREAD(pthread_rwlock_destroy(&mutex_)); }


### PR DESCRIPTION
Fixes a CRAN check cc @krlmlr 