### PR TITLE
Parquet Writer: Early out creating dictionary

### DIFF
--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -64,7 +64,7 @@ public:
 	ParquetWriter(FileSystem &fs, string file_name, vector<LogicalType> types, vector<string> names,
 	              duckdb_parquet::format::CompressionCodec::type codec, ChildFieldIDs field_ids,
 	              const vector<pair<string, string>> &kv_metadata,
-	              shared_ptr<ParquetEncryptionConfig> encryption_config);
+	              shared_ptr<ParquetEncryptionConfig> encryption_config, double dictionary_compression_ratio_threshold);
 
 public:
 	void PrepareRowGroup(ColumnDataCollection &buffer, PreparedRowGroup &result);
@@ -91,6 +91,9 @@ public:
 		lock_guard<mutex> glock(lock);
 		return writer->total_written;
 	}
+	double DictionaryCompressionRatioThreshold() const {
+		return dictionary_compression_ratio_threshold;
+	}
 
 	static CopyTypeSupport TypeIsSupported(const LogicalType &type);
 
@@ -106,6 +109,7 @@ private:
 	duckdb_parquet::format::CompressionCodec::type codec;
 	ChildFieldIDs field_ids;
 	shared_ptr<ParquetEncryptionConfig> encryption_config;
+	double dictionary_compression_ratio_threshold;
 
 	unique_ptr<BufferedFileWriter> writer;
 	shared_ptr<duckdb_apache::thrift::protocol::TProtocol> protocol;

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -130,6 +130,9 @@ struct ParquetWriteBindData : public TableFunctionData {
 	//! How/Whether to encrypt the data
 	shared_ptr<ParquetEncryptionConfig> encryption_config;
 
+	//! Dictionary compression is applied only if the compression ratio exceeds this threshold
+	double dictionary_compression_ratio_threshold = 1.0;
+
 	ChildFieldIDs field_ids;
 };
 
@@ -992,6 +995,15 @@ unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFunctionBi
 			}
 		} else if (loption == "encryption_config") {
 			bind_data->encryption_config = ParquetEncryptionConfig::Create(context, option.second[0]);
+		} else if (loption == "dictionary_compression_ratio_threshold") {
+			auto val = option.second[0].GetValue<double>();
+			if (val == -1) {
+				val = NumericLimits<double>::Maximum();
+			} else if (val < 0) {
+				throw BinderException("dictionary_compression_ratio_threshold must be greater than 0, or -1 to disable "
+				                      "dictionary compression");
+			}
+			bind_data->dictionary_compression_ratio_threshold = val;
 		} else {
 			throw NotImplementedException("Unrecognized option for PARQUET: %s", option.first.c_str());
 		}
@@ -1017,9 +1029,10 @@ unique_ptr<GlobalFunctionData> ParquetWriteInitializeGlobal(ClientContext &conte
 	auto &parquet_bind = bind_data.Cast<ParquetWriteBindData>();
 
 	auto &fs = FileSystem::GetFileSystem(context);
-	global_state->writer = make_uniq<ParquetWriter>(fs, file_path, parquet_bind.sql_types, parquet_bind.column_names,
-	                                                parquet_bind.codec, parquet_bind.field_ids.Copy(),
-	                                                parquet_bind.kv_metadata, parquet_bind.encryption_config);
+	global_state->writer =
+	    make_uniq<ParquetWriter>(fs, file_path, parquet_bind.sql_types, parquet_bind.column_names, parquet_bind.codec,
+	                             parquet_bind.field_ids.Copy(), parquet_bind.kv_metadata,
+	                             parquet_bind.encryption_config, parquet_bind.dictionary_compression_ratio_threshold);
 	return std::move(global_state);
 }
 
@@ -1138,6 +1151,8 @@ static void ParquetCopySerialize(Serializer &serializer, const FunctionData &bin
 	serializer.WriteProperty(106, "field_ids", bind_data.field_ids);
 	serializer.WritePropertyWithDefault<shared_ptr<ParquetEncryptionConfig>>(107, "encryption_config",
 	                                                                         bind_data.encryption_config, nullptr);
+	serializer.WriteProperty(108, "dictionary_compression_ratio_threshold",
+	                         bind_data.dictionary_compression_ratio_threshold);
 }
 
 static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserializer, CopyFunction &function) {
@@ -1151,6 +1166,8 @@ static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserialize
 	data->field_ids = deserializer.ReadProperty<ChildFieldIDs>(106, "field_ids");
 	deserializer.ReadPropertyWithDefault<shared_ptr<ParquetEncryptionConfig>>(107, "encryption_config",
 	                                                                          data->encryption_config, nullptr);
+	deserializer.ReadPropertyWithDefault<double>(108, "dictionary_compression_ratio_threshold",
+	                                             data->dictionary_compression_ratio_threshold, 1.0);
 	return std::move(data);
 }
 // LCOV_EXCL_STOP

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -350,9 +350,11 @@ void VerifyUniqueNames(const vector<string> &names) {
 ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_p, vector<LogicalType> types_p, vector<string> names_p,
                              CompressionCodec::type codec, ChildFieldIDs field_ids_p,
                              const vector<pair<string, string>> &kv_metadata,
-                             shared_ptr<ParquetEncryptionConfig> encryption_config_p)
+                             shared_ptr<ParquetEncryptionConfig> encryption_config_p,
+                             double dictionary_compression_ratio_threshold_p)
     : file_name(std::move(file_name_p)), sql_types(std::move(types_p)), column_names(std::move(names_p)), codec(codec),
-      field_ids(std::move(field_ids_p)), encryption_config(std::move(encryption_config_p)) {
+      field_ids(std::move(field_ids_p)), encryption_config(std::move(encryption_config_p)),
+      dictionary_compression_ratio_threshold(dictionary_compression_ratio_threshold_p) {
 	// initialize the file writer
 	writer = make_uniq<BufferedFileWriter>(fs, file_name.c_str(),
 	                                       FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);

--- a/test/sql/copy/parquet/dictionary_compression_ratio_threshold.test
+++ b/test/sql/copy/parquet/dictionary_compression_ratio_threshold.test
@@ -7,8 +7,6 @@ require parquet
 statement ok
 CREATE TABLE test AS SELECT 'thisisaverylongstringbutitrepeatsmanytimessoitshighlycompressible' || (range % 10) i FROM range(100000)
 
-mode skip
-
 # cannot be negative
 statement error
 COPY test TO '__TEST_DIR__/dictionary_compression_ratio_threshold.parquet' (dictionary_compression_ratio_threshold -2)
@@ -34,8 +32,6 @@ query I
 SELECT dictionary_page_offset IS NULL FROM parquet_metadata('__TEST_DIR__/dictionary_compression_ratio_threshold.parquet')
 ----
 true
-
-mode unskip
 
 # the data compresses more than 10x
 statement ok

--- a/test/sql/copy/parquet/dictionary_compression_ratio_threshold.test
+++ b/test/sql/copy/parquet/dictionary_compression_ratio_threshold.test
@@ -1,0 +1,80 @@
+# name: test/sql/copy/parquet/dictionary_compression_ratio_threshold.test
+# description: Test Parquet dictionary_compression_ratio_threshold parameter
+# group: [parquet]
+
+require parquet
+
+statement ok
+CREATE TABLE test AS SELECT 'thisisaverylongstringbutitrepeatsmanytimessoitshighlycompressible' || (range % 10) i FROM range(100000)
+
+mode skip
+
+# cannot be negative
+statement error
+COPY test TO '__TEST_DIR__/dictionary_compression_ratio_threshold.parquet' (dictionary_compression_ratio_threshold -2)
+----
+Binder Error: dictionary_compression_ratio_threshold must be greater than 0, or -1 to disable dictionary compression
+
+# default is 1.0
+statement ok
+COPY test TO '__TEST_DIR__/dictionary_compression_ratio_threshold.parquet'
+
+# dictionary compression is applied so page offset is non-null
+query I
+SELECT dictionary_page_offset IS NULL FROM parquet_metadata('__TEST_DIR__/dictionary_compression_ratio_threshold.parquet')
+----
+false
+
+# -1 to disable
+statement ok
+COPY test TO '__TEST_DIR__/dictionary_compression_ratio_threshold.parquet' (dictionary_compression_ratio_threshold -1)
+
+# disabled, so no dictionary compression
+query I
+SELECT dictionary_page_offset IS NULL FROM parquet_metadata('__TEST_DIR__/dictionary_compression_ratio_threshold.parquet')
+----
+true
+
+mode unskip
+
+# the data compresses more than 10x
+statement ok
+COPY test TO '__TEST_DIR__/dictionary_compression_ratio_threshold.parquet' (dictionary_compression_ratio_threshold 10)
+
+# dictionary compression should be enabled
+query I
+SELECT dictionary_page_offset IS NULL FROM parquet_metadata('__TEST_DIR__/dictionary_compression_ratio_threshold.parquet')
+----
+false
+
+# compresses less than 20x
+statement ok
+COPY test TO '__TEST_DIR__/dictionary_compression_ratio_threshold.parquet' (dictionary_compression_ratio_threshold 20)
+
+# dictionary compression should be disabled
+query I
+SELECT dictionary_page_offset IS NULL FROM parquet_metadata('__TEST_DIR__/dictionary_compression_ratio_threshold.parquet')
+----
+true
+
+# create table with all uniques
+statement ok
+CREATE OR REPLACE TABLE test AS SELECT 'coolstring' || range i FROM range(100000)
+
+# shouldn't have dictionary compression with default of 1.0
+statement ok
+COPY test TO '__TEST_DIR__/dictionary_compression_ratio_threshold.parquet'
+
+query I
+SELECT dictionary_page_offset IS NULL FROM parquet_metadata('__TEST_DIR__/dictionary_compression_ratio_threshold.parquet')
+----
+true
+
+# but if we set our threshold to 0 we create a dictionary anyway
+statement ok
+COPY test TO '__TEST_DIR__/dictionary_compression_ratio_threshold.parquet' (dictionary_compression_ratio_threshold 0)
+
+query I
+SELECT dictionary_page_offset IS NULL FROM parquet_metadata('__TEST_DIR__/dictionary_compression_ratio_threshold.parquet')
+----
+false


### PR DESCRIPTION
We currently create the whole dictionary, and only after creating it do we check if the compression ratio is greater than 1. If yes, we apply dictionary compression.

However, creating the dictionary requires a lot of string hashing and comparisons. This PR checks whether the compression ratio is less than 1 after inserting 10k values into the dictionary. If yes, we stop inserting into the dictionary, preventing costly string hashing and comparisons. This speeds up writing lineitem at SF10 by 15-20%, as it can early out for the `l_comment` column.

Not sure if this is the best fix, so I'm happy to receive any feedback. I've sent this PR to `main`, but I'm also happy to change it to `feature` instead.