### PR TITLE
Use `optional_idx` in more places

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -763,7 +763,7 @@ void DuckTableEntry::SetAsRoot() {
 
 void DuckTableEntry::CommitAlter(string &column_name) {
 	D_ASSERT(!column_name.empty());
-	idx_t removed_index = DConstants::INVALID_INDEX;
+	optional_idx removed_index;
 	for (auto &col : columns.Logical()) {
 		if (col.Name() == column_name) {
 			// No need to alter storage, removed column is generated column
@@ -774,8 +774,7 @@ void DuckTableEntry::CommitAlter(string &column_name) {
 			break;
 		}
 	}
-	D_ASSERT(removed_index != DConstants::INVALID_INDEX);
-	storage->CommitDropColumn(columns.LogicalToPhysical(LogicalIndex(removed_index)).index);
+	storage->CommitDropColumn(columns.LogicalToPhysical(LogicalIndex(removed_index.GetIndex())).index);
 }
 
 void DuckTableEntry::CommitDrop() {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -117,7 +117,7 @@ void FileSystem::SetWorkingDirectory(const string &path) {
 	}
 }
 
-idx_t FileSystem::GetAvailableMemory() {
+optional_idx FileSystem::GetAvailableMemory() {
 	errno = 0;
 
 #ifdef __MVS__
@@ -128,7 +128,7 @@ idx_t FileSystem::GetAvailableMemory() {
 	idx_t max_memory = MinValue<idx_t>((idx_t)sysconf(_SC_PHYS_PAGES) * (idx_t)sysconf(_SC_PAGESIZE), UINTPTR_MAX);
 #endif
 	if (errno != 0) {
-		return DConstants::INVALID_INDEX;
+		return optional_idx();
 	}
 	return max_memory;
 }

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -218,7 +218,7 @@ void FileSystem::SetWorkingDirectory(const string &path) {
 	}
 }
 
-idx_t FileSystem::GetAvailableMemory() {
+optional_idx FileSystem::GetAvailableMemory() {
 	ULONGLONG available_memory_kb;
 	if (GetPhysicallyInstalledSystemMemory(&available_memory_kb)) {
 		return MinValue<idx_t>(available_memory_kb * 1000, UINTPTR_MAX);
@@ -230,7 +230,7 @@ idx_t FileSystem::GetAvailableMemory() {
 	if (GlobalMemoryStatusEx(&mem_state)) {
 		return MinValue<idx_t>(mem_state.ullTotalPhys, UINTPTR_MAX);
 	}
-	return DConstants::INVALID_INDEX;
+	return optional_idx();
 }
 
 string FileSystem::GetWorkingDirectory() {

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -172,7 +172,7 @@ MultiFileReaderBindData MultiFileReader::BindOptions(MultiFileReaderOptions &opt
 		}
 
 		for (auto &part : partitions) {
-			idx_t hive_partitioning_index = DConstants::INVALID_INDEX;
+			idx_t hive_partitioning_index;
 			auto lookup = std::find(names.begin(), names.end(), part.first);
 			if (lookup != names.end()) {
 				// hive partitioning column also exists in file - override

--- a/src/core_functions/aggregate/distributive/minmax.cpp
+++ b/src/core_functions/aggregate/distributive/minmax.cpp
@@ -607,12 +607,12 @@ unique_ptr<FunctionData> BindMinMax(ClientContext &context, AggregateFunction &f
 			FunctionBinder function_binder(context);
 			vector<LogicalType> types {arguments[0]->return_type, arguments[0]->return_type};
 			ErrorData error;
-			idx_t best_function = function_binder.BindFunction(func_entry.name, func_entry.functions, types, error);
-			if (best_function == DConstants::INVALID_INDEX) {
+			auto best_function = function_binder.BindFunction(func_entry.name, func_entry.functions, types, error);
+			if (!best_function.IsValid()) {
 				throw BinderException(string("Fail to find corresponding function for collation min/max: ") +
 				                      error.Message());
 			}
-			function = func_entry.functions.GetFunctionByOffset(best_function);
+			function = func_entry.functions.GetFunctionByOffset(best_function.GetIndex());
 
 			// Create a copied child and PushCollation for it.
 			arguments.push_back(arguments[0]->Copy());

--- a/src/core_functions/scalar/list/list_aggregates.cpp
+++ b/src/core_functions/scalar/list/list_aggregates.cpp
@@ -474,12 +474,12 @@ static unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, Scala
 
 	FunctionBinder function_binder(context);
 	auto best_function_idx = function_binder.BindFunction(func.name, func.functions, types, error);
-	if (best_function_idx == DConstants::INVALID_INDEX) {
+	if (!best_function_idx.IsValid()) {
 		throw BinderException("No matching aggregate function\n%s", error.Message());
 	}
 
 	// found a matching function, bind it as an aggregate
-	auto best_function = func.functions.GetFunctionByOffset(best_function_idx);
+	auto best_function = func.functions.GetFunctionByOffset(best_function_idx.GetIndex());
 	if (IS_AGGR) {
 		return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, child_type, best_function, arguments);
 	}

--- a/src/function/function_set.cpp
+++ b/src/function/function_set.cpp
@@ -16,12 +16,12 @@ ScalarFunctionSet::ScalarFunctionSet(ScalarFunction fun) : FunctionSet(std::move
 ScalarFunction ScalarFunctionSet::GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
-	idx_t index = binder.BindFunction(name, *this, arguments, error);
-	if (index == DConstants::INVALID_INDEX) {
+	auto index = binder.BindFunction(name, *this, arguments, error);
+	if (!index.IsValid()) {
 		throw InternalException("Failed to find function %s(%s)\n%s", name, StringUtil::ToString(arguments, ","),
 		                        error.Message());
 	}
-	return GetFunctionByOffset(index);
+	return GetFunctionByOffset(index.GetIndex());
 }
 
 AggregateFunctionSet::AggregateFunctionSet() : FunctionSet("") {
@@ -38,8 +38,8 @@ AggregateFunction AggregateFunctionSet::GetFunctionByArguments(ClientContext &co
                                                                const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
-	idx_t index = binder.BindFunction(name, *this, arguments, error);
-	if (index == DConstants::INVALID_INDEX) {
+	auto index = binder.BindFunction(name, *this, arguments, error);
+	if (!index.IsValid()) {
 		// check if the arguments are a prefix of any of the arguments
 		// this is used for functions such as quantile or string_agg that delete part of their arguments during bind
 		// FIXME: we should come up with a better solution here
@@ -61,7 +61,7 @@ AggregateFunction AggregateFunctionSet::GetFunctionByArguments(ClientContext &co
 		throw InternalException("Failed to find function %s(%s)\n%s", name, StringUtil::ToString(arguments, ","),
 		                        error.Message());
 	}
-	return GetFunctionByOffset(index);
+	return GetFunctionByOffset(index.GetIndex());
 }
 
 TableFunctionSet::TableFunctionSet(string name) : FunctionSet(std::move(name)) {
@@ -74,12 +74,12 @@ TableFunctionSet::TableFunctionSet(TableFunction fun) : FunctionSet(std::move(fu
 TableFunction TableFunctionSet::GetFunctionByArguments(ClientContext &context, const vector<LogicalType> &arguments) {
 	ErrorData error;
 	FunctionBinder binder(context);
-	idx_t index = binder.BindFunction(name, *this, arguments, error);
-	if (index == DConstants::INVALID_INDEX) {
+	auto index = binder.BindFunction(name, *this, arguments, error);
+	if (!index.IsValid()) {
 		throw InternalException("Failed to find function %s(%s)\n%s", name, StringUtil::ToString(arguments, ","),
 		                        error.Message());
 	}
-	return GetFunctionByOffset(index);
+	return GetFunctionByOffset(index.GetIndex());
 }
 
 PragmaFunctionSet::PragmaFunctionSet(string name) : FunctionSet(std::move(name)) {

--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -1342,11 +1342,11 @@ bool StrTimeFormat::Empty() const {
 	return format_specifier.empty();
 }
 
-string StrpTimeFormat::FormatStrpTimeError(const string &input, idx_t position) {
-	if (position == DConstants::INVALID_INDEX) {
+string StrpTimeFormat::FormatStrpTimeError(const string &input, optional_idx position) {
+	if (!position.IsValid()) {
 		return string();
 	}
-	return input + "\n" + string(position, ' ') + "^";
+	return input + "\n" + string(position.GetIndex(), ' ') + "^";
 }
 
 date_t StrpTimeFormat::ParseResult::ToDate() {

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -216,13 +216,13 @@ static unique_ptr<FunctionData> BindAggregateState(ClientContext &context, Scala
 	ErrorData error;
 
 	FunctionBinder function_binder(context);
-	idx_t best_function =
+	auto best_function =
 	    function_binder.BindFunction(aggr.name, aggr.functions, state_type.bound_argument_types, error);
-	if (best_function == DConstants::INVALID_INDEX) {
+	if (!best_function.IsValid()) {
 		throw InternalException("Could not re-bind exported aggregate %s: %s", state_type.function_name,
 		                        error.Message());
 	}
-	auto bound_aggr = aggr.functions.GetFunctionByOffset(best_function);
+	auto bound_aggr = aggr.functions.GetFunctionByOffset(best_function.GetIndex());
 	if (bound_aggr.bind) {
 		// FIXME: this is really hacky
 		// but the aggregate state export needs a rework around how it handles more complex aggregates anyway

--- a/src/function/table/system/duckdb_tables.cpp
+++ b/src/function/table/system/duckdb_tables.cpp
@@ -145,7 +145,8 @@ void DuckDBTablesFunction(ClientContext &context, TableFunctionInput &data_p, Da
 		// has_primary_key, LogicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(TableHasPrimaryKey(table)));
 		// estimated_size, LogicalType::BIGINT
-		Value card_val = !storage_info.cardinality.IsValid() ? Value() : Value::BIGINT(storage_info.cardinality.GetIndex());
+		Value card_val =
+		    !storage_info.cardinality.IsValid() ? Value() : Value::BIGINT(storage_info.cardinality.GetIndex());
 		output.SetValue(col++, count, card_val);
 		// column_count, LogicalType::BIGINT
 		output.SetValue(col++, count, Value::BIGINT(table.GetColumns().LogicalColumnCount()));

--- a/src/function/table/system/duckdb_tables.cpp
+++ b/src/function/table/system/duckdb_tables.cpp
@@ -145,8 +145,7 @@ void DuckDBTablesFunction(ClientContext &context, TableFunctionInput &data_p, Da
 		// has_primary_key, LogicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(TableHasPrimaryKey(table)));
 		// estimated_size, LogicalType::BIGINT
-		Value card_val =
-		    storage_info.cardinality == DConstants::INVALID_INDEX ? Value() : Value::BIGINT(storage_info.cardinality);
+		Value card_val = !storage_info.cardinality.IsValid() ? Value() : Value::BIGINT(storage_info.cardinality.GetIndex());
 		output.SetValue(col++, count, card_val);
 		// column_count, LogicalType::BIGINT
 		output.SetValue(col++, count, Value::BIGINT(table.GetColumns().LogicalColumnCount()));

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -171,7 +171,7 @@ public:
 	//! Expands a given path, including e.g. expanding the home directory of the user
 	DUCKDB_API virtual string ExpandPath(const string &path);
 	//! Returns the system-available memory in bytes. Returns DConstants::INVALID_INDEX if the system function fails.
-	DUCKDB_API static idx_t GetAvailableMemory();
+	DUCKDB_API static optional_idx GetAvailableMemory();
 	//! Path separator for path
 	DUCKDB_API virtual string PathSeparator(const string &path);
 	//! Checks if path is starts with separator (i.e., '/' on UNIX '\\' on Windows)

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -27,26 +27,26 @@ public:
 
 public:
 	//! Bind a scalar function from the set of functions and input arguments. Returns the index of the chosen function,
-	//! returns DConstants::INVALID_INDEX and sets error if none could be found
-	DUCKDB_API idx_t BindFunction(const string &name, ScalarFunctionSet &functions,
-	                              const vector<LogicalType> &arguments, ErrorData &error);
-	DUCKDB_API idx_t BindFunction(const string &name, ScalarFunctionSet &functions,
-	                              vector<unique_ptr<Expression>> &arguments, ErrorData &error);
+	//! returns optional_idx() and sets error if none could be found
+	DUCKDB_API optional_idx BindFunction(const string &name, ScalarFunctionSet &functions,
+	                                     const vector<LogicalType> &arguments, ErrorData &error);
+	DUCKDB_API optional_idx BindFunction(const string &name, ScalarFunctionSet &functions,
+	                                     vector<unique_ptr<Expression>> &arguments, ErrorData &error);
 	//! Bind an aggregate function from the set of functions and input arguments. Returns the index of the chosen
-	//! function, returns DConstants::INVALID_INDEX and sets error if none could be found
-	DUCKDB_API idx_t BindFunction(const string &name, AggregateFunctionSet &functions,
-	                              const vector<LogicalType> &arguments, ErrorData &error);
-	DUCKDB_API idx_t BindFunction(const string &name, AggregateFunctionSet &functions,
-	                              vector<unique_ptr<Expression>> &arguments, ErrorData &error);
+	//! function, returns optional_idx() and sets error if none could be found
+	DUCKDB_API optional_idx BindFunction(const string &name, AggregateFunctionSet &functions,
+	                                     const vector<LogicalType> &arguments, ErrorData &error);
+	DUCKDB_API optional_idx BindFunction(const string &name, AggregateFunctionSet &functions,
+	                                     vector<unique_ptr<Expression>> &arguments, ErrorData &error);
 	//! Bind a table function from the set of functions and input arguments. Returns the index of the chosen
-	//! function, returns DConstants::INVALID_INDEX and sets error if none could be found
-	DUCKDB_API idx_t BindFunction(const string &name, TableFunctionSet &functions, const vector<LogicalType> &arguments,
-	                              ErrorData &error);
-	DUCKDB_API idx_t BindFunction(const string &name, TableFunctionSet &functions,
-	                              vector<unique_ptr<Expression>> &arguments, ErrorData &error);
+	//! function, returns optional_idx() and sets error if none could be found
+	DUCKDB_API optional_idx BindFunction(const string &name, TableFunctionSet &functions,
+	                                     const vector<LogicalType> &arguments, ErrorData &error);
+	DUCKDB_API optional_idx BindFunction(const string &name, TableFunctionSet &functions,
+	                                     vector<unique_ptr<Expression>> &arguments, ErrorData &error);
 	//! Bind a pragma function from the set of functions and input arguments
-	DUCKDB_API idx_t BindFunction(const string &name, PragmaFunctionSet &functions, vector<Value> &parameters,
-	                              ErrorData &error);
+	DUCKDB_API optional_idx BindFunction(const string &name, PragmaFunctionSet &functions, vector<Value> &parameters,
+	                                     ErrorData &error);
 
 	DUCKDB_API unique_ptr<Expression> BindScalarFunction(const string &schema, const string &name,
 	                                                     vector<unique_ptr<Expression>> children, ErrorData &error,
@@ -70,20 +70,21 @@ public:
 private:
 	//! Cast a set of expressions to the arguments of this function
 	void CastToFunctionArguments(SimpleFunction &function, vector<unique_ptr<Expression>> &children);
-	int64_t BindVarArgsFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments);
-	int64_t BindFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments);
+	optional_idx BindVarArgsFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments);
+	optional_idx BindFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments);
 
 	template <class T>
 	vector<idx_t> BindFunctionsFromArguments(const string &name, FunctionSet<T> &functions,
 	                                         const vector<LogicalType> &arguments, ErrorData &error);
 
 	template <class T>
-	idx_t MultipleCandidateException(const string &name, FunctionSet<T> &functions, vector<idx_t> &candidate_functions,
-	                                 const vector<LogicalType> &arguments, ErrorData &error);
+	optional_idx MultipleCandidateException(const string &name, FunctionSet<T> &functions,
+	                                        vector<idx_t> &candidate_functions, const vector<LogicalType> &arguments,
+	                                        ErrorData &error);
 
 	template <class T>
-	idx_t BindFunctionFromArguments(const string &name, FunctionSet<T> &functions, const vector<LogicalType> &arguments,
-	                                ErrorData &error);
+	optional_idx BindFunctionFromArguments(const string &name, FunctionSet<T> &functions,
+	                                       const vector<LogicalType> &arguments, ErrorData &error);
 
 	vector<LogicalType> GetLogicalTypesFromExpressions(vector<unique_ptr<Expression>> &arguments);
 };

--- a/src/include/duckdb/function/scalar/strftime_format.hpp
+++ b/src/include/duckdb/function/scalar/strftime_format.hpp
@@ -137,7 +137,7 @@ public:
 		int32_t data[8]; // year, month, day, hour, min, sec, µs, offset
 		string tz;
 		string error_message;
-		idx_t error_position = DConstants::INVALID_INDEX;
+		optional_idx error_position;
 
 		bool is_special;
 		date_t special;
@@ -169,7 +169,7 @@ public:
 	static StrpTimeFormat Deserialize(Deserializer &deserializer);
 
 protected:
-	static string FormatStrpTimeError(const string &input, idx_t position);
+	static string FormatStrpTimeError(const string &input, optional_idx position);
 	DUCKDB_API void AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier) override;
 	int NumericSpecifierWidth(StrTimeSpecifier specifier);
 	int32_t TryParseCollection(const char *data, idx_t &pos, idx_t size, const string_t collection[],

--- a/src/include/duckdb/storage/compression/chimp/chimp_analyze.hpp
+++ b/src/include/duckdb/storage/compression/chimp/chimp_analyze.hpp
@@ -33,7 +33,6 @@ bool ChimpAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
 template <class T>
 idx_t ChimpFinalAnalyze(AnalyzeState &state) {
 	throw InternalException("Chimp has been deprecated, can no longer be used to compress data");
-	return DConstants::INVALID_INDEX;
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/compression/patas/patas_analyze.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas_analyze.hpp
@@ -33,7 +33,6 @@ bool PatasAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
 template <class T>
 idx_t PatasFinalAnalyze(AnalyzeState &state) {
 	throw InternalException("Patas has been deprecated, can no longer be used to compress data");
-	return DConstants::INVALID_INDEX;
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table_storage_info.hpp
+++ b/src/include/duckdb/storage/table_storage_info.hpp
@@ -38,7 +38,7 @@ struct ColumnSegmentInfo {
 class TableStorageInfo {
 public:
 	//! The (estimated) cardinality of the table
-	idx_t cardinality = DConstants::INVALID_INDEX;
+	optional_idx cardinality;
 	//! Info of the indexes of a table
 	vector<IndexInfo> index_info;
 };

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -256,8 +256,8 @@ IndexTypeSet &DBConfig::GetIndexTypes() {
 
 void DBConfig::SetDefaultMaxMemory() {
 	auto memory = FileSystem::GetAvailableMemory();
-	if (memory != DConstants::INVALID_INDEX) {
-		options.maximum_memory = memory * 8 / 10;
+	if (memory.IsValid()) {
+		options.maximum_memory = memory.GetIndex() * 8 / 10;
 	}
 }
 
@@ -340,7 +340,8 @@ idx_t DBConfig::GetSystemMaxThreads(FileSystem &fs) {
 
 idx_t DBConfig::ParseMemoryLimit(const string &arg) {
 	if (arg[0] == '-' || arg == "null" || arg == "none") {
-		return DConstants::INVALID_INDEX;
+		// infinite
+		return NumericLimits<idx_t>::Maximum();
 	}
 	// split based on the number/non-number
 	idx_t idx = 0;

--- a/src/optimizer/cse_optimizer.cpp
+++ b/src/optimizer/cse_optimizer.cpp
@@ -110,8 +110,8 @@ void CommonSubExpressionOptimizer::PerformCSEReplacement(unique_ptr<Expression> 
 				state.cached_expressions.push_back(std::move(expr_ptr));
 			}
 			// replace the original expression with a bound column ref
-			expr_ptr = make_uniq<BoundColumnRefExpression>(alias, type,
-			                                               ColumnBinding(state.projection_index, node.column_index.GetIndex()));
+			expr_ptr = make_uniq<BoundColumnRefExpression>(
+			    alias, type, ColumnBinding(state.projection_index, node.column_index.GetIndex()));
 			return;
 		}
 	}

--- a/src/optimizer/cse_optimizer.cpp
+++ b/src/optimizer/cse_optimizer.cpp
@@ -13,9 +13,9 @@ namespace duckdb {
 //! underlying projection
 struct CSENode {
 	idx_t count;
-	idx_t column_index;
+	optional_idx column_index;
 
-	CSENode() : count(1), column_index(DConstants::INVALID_INDEX) {
+	CSENode() : count(1), column_index() {
 	}
 };
 
@@ -102,7 +102,7 @@ void CommonSubExpressionOptimizer::PerformCSEReplacement(unique_ptr<Expression> 
 			// check if it has already been pushed into the projection
 			auto alias = expr.alias;
 			auto type = expr.return_type;
-			if (node.column_index == DConstants::INVALID_INDEX) {
+			if (!node.column_index.IsValid()) {
 				// has not been pushed yet: push it
 				node.column_index = state.expressions.size();
 				state.expressions.push_back(std::move(expr_ptr));
@@ -111,7 +111,7 @@ void CommonSubExpressionOptimizer::PerformCSEReplacement(unique_ptr<Expression> 
 			}
 			// replace the original expression with a bound column ref
 			expr_ptr = make_uniq<BoundColumnRefExpression>(alias, type,
-			                                               ColumnBinding(state.projection_index, node.column_index));
+			                                               ColumnBinding(state.projection_index, node.column_index.GetIndex()));
 			return;
 		}
 	}

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -234,17 +234,17 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			// for every table filter, push a column binding into the column references map to prevent the column from
 			// being projected out
 			for (auto &filter : get.table_filters.filters) {
-				idx_t index = DConstants::INVALID_INDEX;
+				optional_idx index;
 				for (idx_t i = 0; i < get.column_ids.size(); i++) {
 					if (get.column_ids[i] == filter.first) {
 						index = i;
 						break;
 					}
 				}
-				if (index == DConstants::INVALID_INDEX) {
+				if (!index.IsValid()) {
 					throw InternalException("Could not find column index for table filter");
 				}
-				ColumnBinding filter_binding(get.table_index, index);
+				ColumnBinding filter_binding(get.table_index, index.GetIndex());
 				if (column_references.find(filter_binding) == column_references.end()) {
 					column_references.insert(make_pair(filter_binding, vector<BoundColumnRefExpression *>()));
 				}

--- a/src/optimizer/rule/ordered_aggregate_optimizer.cpp
+++ b/src/optimizer/rule/ordered_aggregate_optimizer.cpp
@@ -84,11 +84,11 @@ unique_ptr<Expression> OrderedAggregateOptimizer::Apply(ClientContext &context, 
 		types.emplace_back(child->return_type);
 	}
 	auto best_function = binder.BindFunction(func.name, func.functions, types, error);
-	if (best_function == DConstants::INVALID_INDEX) {
+	if (!best_function.IsValid()) {
 		error.Throw();
 	}
 	// found a matching function!
-	auto bound_function = func.functions.GetFunctionByOffset(best_function);
+	auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 	return binder.BindAggregateFunction(bound_function, std::move(children), std::move(aggr.filter),
 	                                    aggr.IsDistinct() ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT);
 }

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -212,13 +212,13 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 
 	// bind the aggregate
 	FunctionBinder function_binder(context);
-	idx_t best_function = function_binder.BindFunction(func.name, func.functions, types, error);
-	if (best_function == DConstants::INVALID_INDEX) {
+	auto best_function = function_binder.BindFunction(func.name, func.functions, types, error);
+	if (!best_function.IsValid()) {
 		error.AddQueryLocation(aggr);
 		error.Throw();
 	}
 	// found a matching function!
-	auto bound_function = func.functions.GetFunctionByOffset(best_function);
+	auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 
 	// Bind any sort columns, unless the aggregate is order-insensitive
 	unique_ptr<BoundOrderModifier> order_bys;

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -252,12 +252,12 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 		ErrorData error;
 		FunctionBinder function_binder(context);
 		auto best_function = function_binder.BindFunction(func.name, func.functions, types, error);
-		if (best_function == DConstants::INVALID_INDEX) {
+		if (!best_function.IsValid()) {
 			error.AddQueryLocation(window);
 			error.Throw();
 		}
 		// found a matching function! bind it as an aggregate
-		auto bound_function = func.functions.GetFunctionByOffset(best_function);
+		auto bound_function = func.functions.GetFunctionByOffset(best_function.GetIndex());
 		auto bound_aggregate = function_binder.BindAggregateFunction(bound_function, std::move(children));
 		// create the aggregate
 		aggregate = make_uniq<AggregateFunction>(bound_aggregate->function);

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -305,25 +305,23 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 	}
 
 	auto bindings = insert.children[0]->GetColumnBindings();
-	idx_t projection_index = DConstants::INVALID_INDEX;
-	vector<unique_ptr<LogicalOperator>> *insert_child_operators;
-	insert_child_operators = &insert.children;
-	while (projection_index == DConstants::INVALID_INDEX) {
-		if (insert_child_operators->empty()) {
+	optional_idx projection_index;
+	reference<vector<unique_ptr<LogicalOperator>>> insert_child_operators = insert.children;
+	while (!projection_index.IsValid()) {
+		if (insert_child_operators.get().empty()) {
 			// No further children to visit
 			break;
 		}
-		D_ASSERT(insert_child_operators->size() >= 1);
-		auto &current_child = (*insert_child_operators)[0];
+		auto &current_child = insert_child_operators.get()[0];
 		auto table_indices = current_child->GetTableIndex();
 		if (table_indices.empty()) {
 			// This operator does not have a table index to refer to, we have to visit its children
-			insert_child_operators = &current_child->children;
+			insert_child_operators = current_child->children;
 			continue;
 		}
 		projection_index = table_indices[0];
 	}
-	if (projection_index == DConstants::INVALID_INDEX) {
+	if (!projection_index.IsValid()) {
 		throw InternalException("Could not locate a table_index from the children of the insert");
 	}
 
@@ -335,7 +333,7 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 
 	// Replace any column bindings to refer to the projection table_index, rather than the source table
 	if (insert.on_conflict_condition) {
-		ReplaceColumnBindings(*insert.on_conflict_condition, table_index, projection_index);
+		ReplaceColumnBindings(*insert.on_conflict_condition, table_index, projection_index.GetIndex());
 	}
 
 	if (insert.action_type == OnConflictAction::REPLACE) {
@@ -387,11 +385,11 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 	// Replace the column bindings to refer to the child operator
 	for (auto &expr : insert.expressions) {
 		// Change the non-excluded column references to refer to the projection index
-		ReplaceColumnBindings(*expr, table_index, projection_index);
+		ReplaceColumnBindings(*expr, table_index, projection_index.GetIndex());
 	}
 	// Do the same for the (optional) DO UPDATE condition
 	if (insert.do_update_condition) {
-		ReplaceColumnBindings(*insert.do_update_condition, table_index, projection_index);
+		ReplaceColumnBindings(*insert.do_update_condition, table_index, projection_index.GetIndex());
 	}
 }
 

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -31,13 +31,13 @@ unique_ptr<BoundPragmaInfo> Binder::BindPragma(PragmaInfo &info, QueryErrorConte
 	auto &entry = Catalog::GetEntry<PragmaFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, info.name);
 	FunctionBinder function_binder(context);
 	ErrorData error;
-	idx_t bound_idx = function_binder.BindFunction(entry.name, entry.functions, params, error);
-	if (bound_idx == DConstants::INVALID_INDEX) {
+	auto bound_idx = function_binder.BindFunction(entry.name, entry.functions, params, error);
+	if (!bound_idx.IsValid()) {
 		D_ASSERT(error.HasError());
 		error.AddQueryLocation(error_context);
 		error.Throw();
 	}
-	auto bound_function = entry.functions.GetFunctionByOffset(bound_idx);
+	auto bound_function = entry.functions.GetFunctionByOffset(bound_idx.GetIndex());
 	// bind and check named params
 	BindNamedParameters(bound_function.named_parameters, named_parameters, error_context, bound_function.name);
 	return make_uniq<BoundPragmaInfo>(std::move(bound_function), std::move(params), std::move(named_parameters));

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -251,12 +251,12 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 
 	// select the function based on the input parameters
 	FunctionBinder function_binder(context);
-	idx_t best_function_idx = function_binder.BindFunction(function.name, function.functions, arguments, error);
-	if (best_function_idx == DConstants::INVALID_INDEX) {
+	auto best_function_idx = function_binder.BindFunction(function.name, function.functions, arguments, error);
+	if (!best_function_idx.IsValid()) {
 		error.AddQueryLocation(ref);
 		error.Throw();
 	}
-	auto table_function = function.functions.GetFunctionByOffset(best_function_idx);
+	auto table_function = function.functions.GetFunctionByOffset(best_function_idx.GetIndex());
 
 	// now check the named parameters
 	BindNamedParameters(table_function.named_parameters, named_parameters, error_context, table_function.name);


### PR DESCRIPTION
There are still a number of places using the magic number `DConstants::INVALID_INDEX`. This PR switches a bunch of them to the safer `optional_idx` variant.