### PR TITLE
Reduce memory usage of DELETE operations

### DIFF
--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -132,7 +132,7 @@ public:
 	//! Note that "rows" is written to to reflect the row ids that were actually deleted
 	//! i.e. after calling this function, rows will hold [0..actual_delete_count] row ids of the actually deleted tuples
 	idx_t Delete(transaction_t transaction_id, row_t rows[], idx_t count);
-	void CommitDelete(transaction_t commit_id, row_t rows[], idx_t count);
+	void CommitDelete(transaction_t commit_id, uint16_t rows[], idx_t count);
 
 	bool HasDeletes() const override;
 

--- a/src/include/duckdb/storage/table/chunk_info.hpp
+++ b/src/include/duckdb/storage/table/chunk_info.hpp
@@ -17,7 +17,7 @@ class RowGroup;
 struct SelectionVector;
 class Transaction;
 struct TransactionData;
-
+struct DeleteInfo;
 class Serializer;
 class Deserializer;
 
@@ -132,7 +132,7 @@ public:
 	//! Note that "rows" is written to to reflect the row ids that were actually deleted
 	//! i.e. after calling this function, rows will hold [0..actual_delete_count] row ids of the actually deleted tuples
 	idx_t Delete(transaction_t transaction_id, row_t rows[], idx_t count);
-	void CommitDelete(transaction_t commit_id, uint16_t rows[], idx_t count);
+	void CommitDelete(transaction_t commit_id, const DeleteInfo &info);
 
 	bool HasDeletes() const override;
 

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -15,6 +15,7 @@
 
 namespace duckdb {
 
+struct DeleteInfo;
 class MetadataManager;
 struct MetaBlockPointer;
 
@@ -38,7 +39,7 @@ public:
 	void RevertAppend(idx_t start_row);
 
 	idx_t DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count);
-	void CommitDelete(idx_t vector_idx, transaction_t commit_id, uint16_t rows[], idx_t count);
+	void CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info);
 
 	vector<MetaBlockPointer> Checkpoint(MetadataManager &manager);
 	static shared_ptr<RowVersionManager> Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager,

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -38,7 +38,7 @@ public:
 	void RevertAppend(idx_t start_row);
 
 	idx_t DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count);
-	void CommitDelete(idx_t vector_idx, transaction_t commit_id, row_t rows[], idx_t count);
+	void CommitDelete(idx_t vector_idx, transaction_t commit_id, uint16_t rows[], idx_t count);
 
 	vector<MetaBlockPointer> Checkpoint(MetadataManager &manager);
 	static shared_ptr<RowVersionManager> Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager,

--- a/src/include/duckdb/transaction/delete_info.hpp
+++ b/src/include/duckdb/transaction/delete_info.hpp
@@ -20,7 +20,7 @@ struct DeleteInfo {
 	idx_t vector_idx;
 	idx_t count;
 	idx_t base_row;
-	row_t rows[1];
+	uint16_t rows[1];
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/delete_info.hpp
+++ b/src/include/duckdb/transaction/delete_info.hpp
@@ -20,6 +20,25 @@ struct DeleteInfo {
 	idx_t vector_idx;
 	idx_t count;
 	idx_t base_row;
+	//! Whether or not row ids are consecutive (0, 1, 2, ..., count).
+	//! If this is true no rows are stored and `rows` should not be accessed.
+	bool is_consecutive;
+
+	uint16_t *GetRows() {
+		if (is_consecutive) {
+			throw InternalException("DeleteInfo is consecutive - rows are not accessible");
+		}
+		return rows;
+	}
+	const uint16_t *GetRows() const {
+		if (is_consecutive) {
+			throw InternalException("DeleteInfo is consecutive - rows are not accessible");
+		}
+		return rows;
+	}
+
+private:
+	//! The per-vector row identifiers (actual row id is base_row + rows[x])
 	uint16_t rows[1];
 };
 

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/transaction/delete_info.hpp"
 
 namespace duckdb {
 
@@ -198,9 +199,16 @@ idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t 
 	return deleted_tuples;
 }
 
-void ChunkVectorInfo::CommitDelete(transaction_t commit_id, uint16_t rows[], idx_t count) {
-	for (idx_t i = 0; i < count; i++) {
-		deleted[rows[i]] = commit_id;
+void ChunkVectorInfo::CommitDelete(transaction_t commit_id, const DeleteInfo &info) {
+	if (info.is_consecutive) {
+		for (idx_t i = 0; i < info.count; i++) {
+			deleted[i] = commit_id;
+		}
+	} else {
+		auto rows = info.GetRows();
+		for (idx_t i = 0; i < info.count; i++) {
+			deleted[rows[i]] = commit_id;
+		}
 	}
 }
 

--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -198,7 +198,7 @@ idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t 
 	return deleted_tuples;
 }
 
-void ChunkVectorInfo::CommitDelete(transaction_t commit_id, row_t rows[], idx_t count) {
+void ChunkVectorInfo::CommitDelete(transaction_t commit_id, uint16_t rows[], idx_t count) {
 	for (idx_t i = 0; i < count; i++) {
 		deleted[rows[i]] = commit_id;
 	}

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -159,10 +159,10 @@ idx_t RowVersionManager::DeleteRows(idx_t vector_idx, transaction_t transaction_
 	return GetVectorInfo(vector_idx).Delete(transaction_id, rows, count);
 }
 
-void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, uint16_t rows[], idx_t count) {
+void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info) {
 	lock_guard<mutex> lock(version_lock);
 	has_changes = true;
-	GetVectorInfo(vector_idx).CommitDelete(commit_id, rows, count);
+	GetVectorInfo(vector_idx).CommitDelete(commit_id, info);
 }
 
 vector<MetaBlockPointer> RowVersionManager::Checkpoint(MetadataManager &manager) {

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -159,7 +159,7 @@ idx_t RowVersionManager::DeleteRows(idx_t vector_idx, transaction_t transaction_
 	return GetVectorInfo(vector_idx).Delete(transaction_id, rows, count);
 }
 
-void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, row_t rows[], idx_t count) {
+void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, uint16_t rows[], idx_t count) {
 	lock_guard<mutex> lock(version_lock);
 	has_changes = true;
 	GetVectorInfo(vector_idx).CommitDelete(commit_id, rows, count);

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -70,8 +70,15 @@ void CleanupState::CleanupDelete(DeleteInfo &info) {
 	indexed_tables[current_table->info->table] = current_table;
 
 	count = 0;
-	for (idx_t i = 0; i < info.count; i++) {
-		row_numbers[count++] = info.base_row + info.rows[i];
+	if (info.is_consecutive) {
+		for (idx_t i = 0; i < info.count; i++) {
+			row_numbers[count++] = info.base_row + i;
+		}
+	} else {
+		auto rows = info.GetRows();
+		for (idx_t i = 0; i < info.count; i++) {
+			row_numbers[count++] = info.base_row + rows[i];
+		}
 	}
 	Flush();
 }

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -204,8 +204,15 @@ void CommitState::WriteDelete(DeleteInfo &info) {
 		delete_chunk->Initialize(Allocator::DefaultAllocator(), delete_types);
 	}
 	auto rows = FlatVector::GetData<row_t>(delete_chunk->data[0]);
-	for (idx_t i = 0; i < info.count; i++) {
-		rows[i] = info.base_row + info.rows[i];
+	if (info.is_consecutive) {
+		for (idx_t i = 0; i < info.count; i++) {
+			rows[i] = info.base_row + i;
+		}
+	} else {
+		auto delete_rows = info.GetRows();
+		for (idx_t i = 0; i < info.count; i++) {
+			rows[i] = info.base_row + delete_rows[i];
+		}
 	}
 	delete_chunk->SetCardinality(info.count);
 	log->WriteDelete(*delete_chunk);
@@ -310,7 +317,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data) {
 			WriteDelete(*info);
 		}
 		// mark the tuples as committed
-		info->version_info->CommitDelete(info->vector_idx, commit_id, info->rows, info->count);
+		info->version_info->CommitDelete(info->vector_idx, commit_id, *info);
 		break;
 	}
 	case UndoFlags::UPDATE_TUPLE: {
@@ -351,7 +358,7 @@ void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
 		auto info = reinterpret_cast<DeleteInfo *>(data);
 		info->table->info->cardinality += info->count;
 		// revert the commit by writing the (uncommitted) transaction_id back into the version info
-		info->version_info->CommitDelete(info->vector_idx, transaction_id, info->rows, info->count);
+		info->version_info->CommitDelete(info->vector_idx, transaction_id, *info);
 		break;
 	}
 	case UndoFlags::UPDATE_TUPLE: {

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -74,13 +74,15 @@ void DuckTransaction::PushCatalogEntry(CatalogEntry &entry, data_ptr_t extra_dat
 void DuckTransaction::PushDelete(DataTable &table, RowVersionManager &info, idx_t vector_idx, row_t rows[], idx_t count,
                                  idx_t base_row) {
 	auto delete_info = reinterpret_cast<DeleteInfo *>(
-	    undo_buffer.CreateEntry(UndoFlags::DELETE_TUPLE, sizeof(DeleteInfo) + sizeof(row_t) * count));
+	    undo_buffer.CreateEntry(UndoFlags::DELETE_TUPLE, sizeof(DeleteInfo) + sizeof(uint16_t) * count));
 	delete_info->version_info = &info;
 	delete_info->vector_idx = vector_idx;
 	delete_info->table = &table;
 	delete_info->count = count;
 	delete_info->base_row = base_row;
-	memcpy(delete_info->rows, rows, sizeof(row_t) * count);
+	for (idx_t i = 0; i < count; i++) {
+		delete_info->rows[i] = NumericCast<uint16_t>(rows[i]);
+	}
 }
 
 void DuckTransaction::PushAppend(DataTable &table, idx_t start_row, idx_t row_count) {

--- a/src/transaction/rollback_state.cpp
+++ b/src/transaction/rollback_state.cpp
@@ -31,7 +31,7 @@ void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::DELETE_TUPLE: {
 		auto info = reinterpret_cast<DeleteInfo *>(data);
 		// reset the deleted flag on rollback
-		info->version_info->CommitDelete(info->vector_idx, NOT_DELETED_ID, info->rows, info->count);
+		info->version_info->CommitDelete(info->vector_idx, NOT_DELETED_ID, *info);
 		break;
 	}
 	case UndoFlags::UPDATE_TUPLE: {


### PR DESCRIPTION
When a delete is executed, we push information about that delete into the `UndoBuffer`. This information allows us to then later commit or rollback the actual delete. This happens in the form of `DeleteInfo` structs. When deleting a lot of data - for example when running a `DELETE FROM large_tbl` command - many of these structs are created. Since the `UndoBuffer` structure does not support offloading to disk (yet) this could lead to out-of-memory exceptions.

This PR improves the memory efficiency of the `DeleteInfo` struct in two ways:

* We switch the `row` field from `row_t` to `uint16_t`. The rows that are stored are *relative to the vector* they refer to. As such these values can never exceed `STANDARD_VECTOR_SIZE`. As such, we can always store these values in a `uint16_t`. This reduces memory usage of the `DeleteInfo` struct by up to 4x.
* When the deleted row identifiers are consecutive (i.e. `0, 1, 2, 3, 4, 5, ...`) we avoid storing the row identifiers at all. Instead, we store a boolean `is_consecutive`. If this is set, during actual delete operations, we reconstruct the row identifiers from the count. This improves memory usage even further, particularly when entire row groups or tables are deleted (as is the case in the previous `DELETE FROM large_tbl` command).