### PR TITLE
Check for IUTF8 flag defined before setting it

### DIFF
--- a/tools/shell/linenoise/terminal.cpp
+++ b/tools/shell/linenoise/terminal.cpp
@@ -67,7 +67,7 @@ int Terminal::EnableRawMode() {
 	raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
 	/* output modes - disable post processing */
 	raw.c_oflag &= ~(OPOST);
-#ifndef __MVS__
+#ifdef IUTF8
 	/* control modes - set 8 bit chars */
 	raw.c_iflag |= IUTF8;
 #endif


### PR DESCRIPTION
fixes #11487

Problem: Compilation fails on FreeBSD 13 because `IUTF8` is not defined
Solution: Check for `IUTF8` defined before setting flag