### PR TITLE
Add docker alpine build to check on builds

### DIFF
--- a/scripts/test_docker_images.sh
+++ b/scripts/test_docker_images.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+make clean
+docker run -i --rm -v $(pwd):/duckdb --workdir /duckdb alpine:latest <<< "apk add g++ git make cmake ninja && GEN=ninja make" 2>&1
+echo "alpine:latest completed"


### PR DESCRIPTION
This is currently NOT invoked on any CI job, that is yet to come, but can be invoked like ./scripts/test_docker_images.sh

Idea and implementation by @szarnyasg

Other images can be added later in the script.