### PR TITLE
Fix #11445: correctly detect recursive aliases when using struct unnest

### DIFF
--- a/src/include/duckdb/planner/query_node/bound_select_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_select_node.hpp
@@ -62,6 +62,8 @@ public:
 
 	//! The amount of columns in the final result
 	idx_t column_count;
+	//! The amount of bound columns in the select list
+	idx_t bound_column_count = 0;
 
 	//! Index used by the LogicalProjection
 	idx_t projection_index;

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -506,6 +506,7 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 		bool is_original_column = i < result->column_count;
 		bool can_group_by_all =
 		    statement.aggregate_handling == AggregateHandling::FORCE_AGGREGATES && is_original_column;
+		result->bound_column_count++;
 
 		if (select_binder.HasExpandedExpressions()) {
 			if (!is_original_column) {

--- a/src/planner/expression_binder/base_select_binder.cpp
+++ b/src/planner/expression_binder/base_select_binder.cpp
@@ -83,7 +83,7 @@ BindResult BaseSelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_pt
 		if (alias_entry != alias_map.end()) {
 			// found entry!
 			auto index = alias_entry->second;
-			if (index >= node.select_list.size()) {
+			if (index >= node.bound_column_count) {
 				throw BinderException("Column \"%s\" referenced that exists in the SELECT clause - but this column "
 				                      "cannot be referenced before it is defined",
 				                      colref.column_names[0]);

--- a/test/sql/types/struct/struct_unnest_recursion.test
+++ b/test/sql/types/struct/struct_unnest_recursion.test
@@ -1,0 +1,22 @@
+# name: test/sql/types/struct/struct_unnest_recursion.test
+# description: Test struct unnest recursion
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+SELECT UNNEST ( ( '1,2,3,4,,6' , ( 1 ) ) ) , x x;
+----
+cannot be referenced before it is defined
+
+mode skip
+
+# FIXME this should work
+statement error
+SELECT UNNEST ( ( '1,2,3,4,,6' , ( random() ) ) ), 42 x, x;
+----
+1,2,3,4,,6	1	42	42
+
+mode unskip
+


### PR DESCRIPTION
Fixes #11445

The issue here is that a recursive alias (`x x`) was not correctly detected as such because the struct unnest before it would insert multiple entries into the select list, causing the `index` in the alias to not point to the correct entry. Due to this shift the recursive definition was not detected leading to an infinite recursion/stack overflow.