### PR TITLE
Fix #11444: avoid using recursion in string -> list parsing

### DIFF
--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -39,25 +39,25 @@ static bool SkipToCloseQuotes(idx_t &pos, const char *buf, idx_t &len) {
 static bool SkipToClose(idx_t &idx, const char *buf, idx_t &len, idx_t &lvl, char close_bracket) {
 	idx++;
 
+	vector<char> brackets;
+	brackets.push_back(close_bracket);
 	while (idx < len) {
 		if (buf[idx] == '"' || buf[idx] == '\'') {
 			if (!SkipToCloseQuotes(idx, buf, len)) {
 				return false;
 			}
 		} else if (buf[idx] == '{') {
-			if (!SkipToClose(idx, buf, len, lvl, '}')) {
-				return false;
-			}
+			brackets.push_back('}');
 		} else if (buf[idx] == '[') {
-			if (!SkipToClose(idx, buf, len, lvl, ']')) {
-				return false;
-			}
+			brackets.push_back(']');
 			lvl++;
-		} else if (buf[idx] == close_bracket) {
-			if (close_bracket == ']') {
+		} else if (buf[idx] == brackets.back()) {
+			if (buf[idx] == ']') {
 				lvl--;
 			}
-			return true;
+			if (brackets.empty()) {
+				return true;
+			}
 		}
 		idx++;
 	}

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -55,6 +55,7 @@ static bool SkipToClose(idx_t &idx, const char *buf, idx_t &len, idx_t &lvl, cha
 			if (buf[idx] == ']') {
 				lvl--;
 			}
+			brackets.pop_back();
 			if (brackets.empty()) {
 				return true;
 			}

--- a/test/sql/types/list/list_parse_recursion.test
+++ b/test/sql/types/list/list_parse_recursion.test
@@ -1,0 +1,11 @@
+# name: test/sql/types/list/list_parse_recursion.test
+# description: Test string -> list conversion of very deeply nested lists
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+SELECT REPEAT ( '[{"a":' , 100000 )::INT[]
+----
+can't be cast to the destination type


### PR DESCRIPTION
Fixes #11444

The offending query creates a very long list of deeply nested brackets (`[{"a":[{"a":[{"a":[{"a":[{"a":[{"a":[{"a":....`). The string to list parsing algorithm used recursion when dealing with brackets, which caused this to trigger a stack overflow. This PR reworks the algorithm to use a vector instead.