### PR TITLE
Julia appender support for missing and nothing values

### DIFF
--- a/tools/juliapkg/src/appender.jl
+++ b/tools/juliapkg/src/appender.jl
@@ -30,8 +30,7 @@ for i in eachrow(df)
     end
     DuckDB.end_row(appender)
 end
-# flush the appender after all rows
-DuckDB.flush(appender)
+# close the appender after all rows
 DuckDB.close(appender)
 ```
 """
@@ -84,6 +83,8 @@ append(appender::Appender, val::UInt32) = duckdb_append_uint32(appender.handle, 
 append(appender::Appender, val::UInt64) = duckdb_append_uint64(appender.handle, val);
 append(appender::Appender, val::Float32) = duckdb_append_float(appender.handle, val);
 append(appender::Appender, val::Float64) = duckdb_append_double(appender.handle, val);
+append(appender::Appender, val::Missing) = duckdb_append_null(appender.handle);
+append(appender::Appender, val::Nothing) = duckdb_append_null(appender.handle);
 append(appender::Appender, val::Type{Missing}) = duckdb_append_null(appender.handle);
 append(appender::Appender, val::Type{Nothing}) = duckdb_append_null(appender.handle);
 append(appender::Appender, val::AbstractString) = duckdb_append_varchar(appender.handle, val);

--- a/tools/juliapkg/test/test_appender.jl
+++ b/tools/juliapkg/test/test_appender.jl
@@ -25,7 +25,6 @@ end
         DuckDB.append(appender, i)
         DuckDB.end_row(appender)
     end
-    DuckDB.flush(appender)
     DuckDB.close(appender)
 
     results = DBInterface.execute(db, "SELECT * FROM integers")
@@ -87,8 +86,7 @@ end
     DuckDB.append(appender, "Foo")
     # End the row of the appender
     DuckDB.end_row(appender)
-    # Destroy the appender and flush the data
-    DuckDB.flush(appender)
+    # Destroy the appender
     DuckDB.close(appender)
 
     # Retrive the data from the table and store it in  a vector
@@ -116,4 +114,19 @@ end
 
     # close the database 
     DBInterface.close!(db)
+end
+
+@testset "missing and nothing values" begin
+    db = DuckDB.DB()
+    DBInterface.execute(db, "CREATE OR REPLACE TABLE data (x INT)")
+
+    df = DataFrame(x = [1, 2, missing, nothing])
+    appender = DuckDB.Appender(db, "data")
+    for i in eachrow(df)
+        for j in i
+            DuckDB.append(appender, j)
+        end
+        DuckDB.end_row(appender)
+    end
+    DuckDB.close(appender)
 end

--- a/tools/juliapkg/test/test_appender.jl
+++ b/tools/juliapkg/test/test_appender.jl
@@ -129,4 +129,7 @@ end
         DuckDB.end_row(appender)
     end
     DuckDB.close(appender)
+
+    df2 = DuckDB.query(db, "select * from data") |> DataFrame
+    @test isequal(df2, DataFrame(x = [1, 2, missing, missing]))
 end


### PR DESCRIPTION
Also, remove references to appender_flush in favor of close! which calls appender_destroy as suggested in the c api documentation.