### PR TITLE
[RE2] Add includes and remove potential throw from destructor

### DIFF
--- a/third_party/re2/util/logging.h
+++ b/third_party/re2/util/logging.h
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <ostream>
 #include <sstream>
+#include <stdexcept>
 
 #include "util/util.h"
 

--- a/third_party/re2/util/mutex.h
+++ b/third_party/re2/util/mutex.h
@@ -36,6 +36,7 @@ typedef int MutexType;
 #elif defined(MUTEX_IS_WIN32_SRWLOCK)
 typedef SRWLOCK MutexType;
 #elif defined(MUTEX_IS_PTHREAD_RWLOCK)
+#include <stdexcept>
 #include <pthread.h>
 #include <stdlib.h>
 typedef pthread_rwlock_t MutexType;
@@ -97,7 +98,7 @@ void Mutex::ReaderUnlock() { ReleaseSRWLockShared(&mutex_); }
   } while (0);
 
 Mutex::Mutex()             { SAFE_PTHREAD(pthread_rwlock_init(&mutex_, NULL)); }
-Mutex::~Mutex()            { SAFE_PTHREAD(pthread_rwlock_destroy(&mutex_)); }
+Mutex::~Mutex()            { pthread_rwlock_destroy(&mutex_); }
 void Mutex::Lock()         { SAFE_PTHREAD(pthread_rwlock_wrlock(&mutex_)); }
 void Mutex::Unlock()       { SAFE_PTHREAD(pthread_rwlock_unlock(&mutex_)); }
 void Mutex::ReaderLock()   { SAFE_PTHREAD(pthread_rwlock_rdlock(&mutex_)); }


### PR DESCRIPTION
Includes should be trivial, make compilation work on GCC.

How to handle error codes in `pthread_rwlock_destroy` within `Mutex::~Mutex` I have no proper alternative, given:
* abort gets flagged
* throws are also not possible given destructors are noexcept by default (and flagged by -Werror in OSX Debug build)
* having a cleanup function, and calling it seems also non-trivial / error prone

I went for making the failure silent, this does solve the problem and it might be OK.