### PR TITLE
Fix timeout in async workflow

### DIFF
--- a/src/parallel/pipeline_finish_event.cpp
+++ b/src/parallel/pipeline_finish_event.cpp
@@ -51,7 +51,7 @@ private:
 	//! Debugging state: number of times blocked
 	int debug_blocked_count = 0;
 	//! Number of times the Finalize will block before actually returning data
-	int debug_blocked_target_count = 10;
+	int debug_blocked_target_count = 1;
 #endif
 };
 


### PR DESCRIPTION
This was bumped by accident i think, causing tests to run pretty slowly. This significantly speeds up the CI job, to around 2.5 hours which I think is reasonable for this job