### PR TITLE
Add pyodide wheel building github action

### DIFF
--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -1,0 +1,99 @@
+name: Pyodide
+on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
+  workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
+  repository_dispatch:
+  push:
+    branches:
+      - "**"
+      - "!main"
+      - "!feature"
+    paths-ignore:
+      - "**"
+      - "!.github/workflows/Pyodide.yml"
+
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    paths-ignore:
+      - "**"
+      - "!.github/workflows/Pyodide.yml"
+
+jobs:
+  build_pyodide:
+    name: Build pyodide wheel
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - python: "3.10"
+            pyodide-build: "0.22.1"
+          - python: "3.11"
+            pyodide-build: "0.25.1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # fetch everything so that the version on the built wheel path is
+          # correct
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.version.python }}
+
+      - run: pip install 'pyodide-build==${{ matrix.version.pyodide-build }}' 'pydantic<2'
+
+      - name: get emscripten version
+        id: emscripten-version
+        run: |
+          echo "value=$(pyodide config get emscripten_version)" | tee -a "$GITHUB_OUTPUT"
+
+      - uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: ${{ steps.emscripten-version.outputs.value }}
+
+      - name: build wasm wheel
+        run: pyodide build --exports=whole_archive
+        working-directory: ./tools/pythonpkg
+        env:
+          DUCKDB_CUSTOM_PLATFORM: wasm_eh_pyodide
+          CFLAGS: "-fexceptions"
+          LDFLAGS: "-fexceptions"
+
+      - name: smoke test duckdb on pyodide
+        run: |
+          pyodide venv .venv-pyodide
+          source .venv-pyodide/bin/activate
+          pip install ./tools/pythonpkg/dist/*.whl
+
+          python -V
+
+          python <<EOF
+          import duckdb
+          print(duckdb.__version__)
+          print(duckdb.sql("SELECT 1 AS a"))
+
+          (platform,) = duckdb.execute("PRAGMA platform").fetchone()
+          assert platform == "wasm_eh_pyodide", platform
+          EOF
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pyodide-python${{ matrix.version.python }}
+          if-no-files-found: error
+          path: |
+            ./tools/pythonpkg/dist/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -346,3 +346,7 @@ extension/extension_config_local.cmake
 
 # extension_external dir
 extension_external
+
+# pyodide (emscripten python) build and test environment
+.pyodide-xbuildenv
+.venv-pyodide

--- a/tools/pythonpkg/pyodide.md
+++ b/tools/pythonpkg/pyodide.md
@@ -1,0 +1,57 @@
+# Using `duckdb` with Pyodide
+
+[Pyodide](https://pyodide.org/en/stable/) is a WASM-based Python interpreter that runs in the browser.
+
+DuckDB builds binary WASM wheels for Pyodide to allow use of the DuckDB Python
+bindings with Pyodide.
+
+## Usage
+
+Here's a small snippet of HTML showing use of DuckDB inside a Pyodide script.
+
+```html
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js"></script>
+    <script type="text/javascript">
+      async function main() {
+        let pyodide = await loadPyodide();
+        await pyodide.loadPackage("micropip");
+        const micropip = pyodide.pyimport("micropip");
+        await micropip.install(["https://pyodide.duckdb.org/duckdb-0.10.2.dev479-cp311-cp311-emscripten_3_1_46_wasm32.whl"]);
+        await pyodide.runPython(`
+import duckdb
+
+data = """\\
+a,b,c
+1,2,3
+4,5,6
+7,8,9"""
+
+with open('data.csv', mode="w") as f:
+    f.write(data)
+
+print(duckdb.sql("SELECT COUNT(*) FROM 'data.csv'"))
+      `);
+      }
+      main();
+    </script>
+  </body>
+</html>
+```
+
+## Caveats
+
+Only Pythons 3.10 and 3.11 are supported right now, with 3.12 support on the way.
+
+Wheels are tied to a specific version of Pyodide. For example when using
+Pyodide version 0.25.1, you must use the cp311-based wheel.
+
+Some functionality is known to not work, such as extension downloading.
+
+The default extensions (as well as the `httpfs` extension) that ship with
+duckdb Python don't need to be `INSTALL`ed, but others, like `spatial`, won't
+work because they cannot be downloaded in the pyodide runtime.

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -121,8 +121,10 @@ if platform.system() == 'Windows':
     extensions = ['parquet', 'icu', 'fts', 'tpch', 'json']
 
 is_android = hasattr(sys, 'getandroidapilevel')
+is_pyodide = 'PYODIDE' in os.environ
 use_jemalloc = (
     not is_android
+    and not is_pyodide
     and platform.system() == 'Linux'
     and platform.architecture()[0] == '64bit'
     and platform.machine() == 'x86_64'
@@ -183,11 +185,19 @@ if 'DUCKDB_LIBS' in os.environ:
 
 define_macros = [('DUCKDB_PYTHON_LIB_NAME', lib_name)]
 
+custom_platform = os.environ.get('DUCKDB_CUSTOM_PLATFORM')
+if custom_platform is not None:
+    define_macros.append(('DUCKDB_CUSTOM_PLATFORM', custom_platform))
+
 if platform.system() == 'Darwin':
     toolchain_args.extend(['-stdlib=libc++', '-mmacosx-version-min=10.7'])
 
 if platform.system() == 'Windows':
     define_macros.extend([('DUCKDB_BUILD_LIBRARY', None), ('WIN32', None)])
+
+if is_pyodide:
+    # show more useful error messages in the browser
+    define_macros.append(('PYBIND11_DETAILED_ERROR_MESSAGES', None))
 
 if 'BUILD_HTTPFS' in os.environ:
     libraries += ['crypto', 'ssl']


### PR DESCRIPTION
This PR adds a CI job to build a WASM wheel for duckdb-python, so the duckdb
python module can be used in Pyodide.

There are a couple changes here that were required to build the wheel.

1. **static cast to keep pybind11 happy**: pybind11 has a static assert that
   enforces a particular relationship between two integer types (one I'm not
   sure of and the other is `ssize_t`) in its `py::tuple` constructor to
   prevent implicit narrowing. I added a static cast to a type that pybind11
   accepts. ~There's probably some additional things to nail down to make sure
   this cast is safe.~ See the comment in the relevant code section.
1. **avoid jemalloc when building for pyodide**: I disabled jemalloc when
   building for pyodide because of a bunch of undefined macros (e.g.,
   `LG_QUANTUM`). I'm guessing that jemalloc may not be well supported when
   targeting wasm/building with emscripten. Hopefully this change isn't too
   controversial.

Plenty of questions remain :)

1. Where should this wheel be served from? I don't think you can put wasm wheels on PyPI.
1. ~Python 3.10 has a bug in its wheel building module, and doesn't allow 3.10
   WASM wheels to be built. Do we care?~ Not a bug, and it's fixed in this PR.
1. Extension **downloading** doesn't work, but extension loading (for the ones
   that ship directly with duckdb, like parquet) does work. Is there something to do here? It looks like extensions are built for Wasm in another CI job, so maybe something on the extension downloading side needs to be adjusted?
