### PR TITLE
[ICU] Use the correct lookup precedence for TimeZone settings

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -167,7 +167,7 @@ public:
 	                                                 bool requires_valid_transaction = true);
 
 	//! Equivalent to CURRENT_SETTING(key) SQL function.
-	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const std::string &key, Value &result);
+	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const std::string &key, Value &result) const;
 
 	//! Returns the parser options for this client context
 	DUCKDB_API ParserOptions GetParserOptions() const;

--- a/src/include/duckdb/main/client_data.hpp
+++ b/src/include/duckdb/main/client_data.hpp
@@ -64,6 +64,7 @@ struct ClientData {
 
 public:
 	DUCKDB_API static ClientData &Get(ClientContext &context);
+	DUCKDB_API static const ClientData &Get(const ClientContext &context);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -60,7 +60,7 @@ typedef void (*set_global_function_t)(DatabaseInstance *db, DBConfig &config, co
 typedef void (*set_local_function_t)(ClientContext &context, const Value &parameter);
 typedef void (*reset_global_function_t)(DatabaseInstance *db, DBConfig &config);
 typedef void (*reset_local_function_t)(ClientContext &context);
-typedef Value (*get_setting_function_t)(ClientContext &context);
+typedef Value (*get_setting_function_t)(const ClientContext &context);
 
 struct ConfigurationOption {
 	const char *name;

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -40,6 +40,7 @@ public:
 	BufferPool &GetBufferPool() const;
 	DUCKDB_API SecretManager &GetSecretManager();
 	DUCKDB_API BufferManager &GetBufferManager();
+	DUCKDB_API const BufferManager &GetBufferManager() const;
 	DUCKDB_API DatabaseManager &GetDatabaseManager();
 	DUCKDB_API FileSystem &GetFileSystem();
 	DUCKDB_API TaskScheduler &GetScheduler();
@@ -51,11 +52,12 @@ public:
 	idx_t NumberOfThreads();
 
 	DUCKDB_API static DatabaseInstance &GetDatabase(ClientContext &context);
+	DUCKDB_API static const DatabaseInstance &GetDatabase(const ClientContext &context);
 
 	DUCKDB_API const unordered_set<std::string> &LoadedExtensions();
 	DUCKDB_API bool ExtensionIsLoaded(const string &name);
 
-	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const string &key, Value &result);
+	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) const;
 
 	unique_ptr<AttachedDatabase> CreateAttachedDatabase(ClientContext &context, const AttachInfo &info,
 	                                                    const string &type, AccessMode access_mode);

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -49,7 +49,7 @@ struct AccessModeSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct AllowPersistentSecrets {
@@ -59,7 +59,7 @@ struct AllowPersistentSecrets {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct CheckpointThresholdSetting {
@@ -69,7 +69,7 @@ struct CheckpointThresholdSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DebugCheckpointAbort {
@@ -79,7 +79,7 @@ struct DebugCheckpointAbort {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DebugForceExternal {
@@ -89,7 +89,7 @@ struct DebugForceExternal {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DebugForceNoCrossProduct {
@@ -99,7 +99,7 @@ struct DebugForceNoCrossProduct {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct OrderedAggregateThreshold {
@@ -109,7 +109,7 @@ struct OrderedAggregateThreshold {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT; // NOLINT
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DebugAsOfIEJoin {
@@ -118,7 +118,7 @@ struct DebugAsOfIEJoin {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;                                 // NOLINT
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct PreferRangeJoins {
@@ -127,7 +127,7 @@ struct PreferRangeJoins {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;                     // NOLINT
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DebugWindowMode {
@@ -136,7 +136,7 @@ struct DebugWindowMode {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DefaultCollationSetting {
@@ -147,7 +147,7 @@ struct DefaultCollationSetting {
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DefaultOrderSetting {
@@ -156,7 +156,7 @@ struct DefaultOrderSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DefaultNullOrderSetting {
@@ -165,7 +165,7 @@ struct DefaultNullOrderSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DefaultSecretStorage {
@@ -174,7 +174,7 @@ struct DefaultSecretStorage {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DisabledFileSystemsSetting {
@@ -183,7 +183,7 @@ struct DisabledFileSystemsSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DisabledOptimizersSetting {
@@ -192,7 +192,7 @@ struct DisabledOptimizersSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableExternalAccessSetting {
@@ -203,7 +203,7 @@ struct EnableExternalAccessSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableFSSTVectors {
@@ -213,7 +213,7 @@ struct EnableFSSTVectors {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct AllowUnsignedExtensionsSetting {
@@ -222,7 +222,7 @@ struct AllowUnsignedExtensionsSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct AllowUnredactedSecretsSetting {
@@ -231,7 +231,7 @@ struct AllowUnredactedSecretsSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct CustomExtensionRepository {
@@ -240,7 +240,7 @@ struct CustomExtensionRepository {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct AutoloadExtensionRepository {
@@ -250,7 +250,7 @@ struct AutoloadExtensionRepository {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct AutoinstallKnownExtensions {
@@ -260,7 +260,7 @@ struct AutoinstallKnownExtensions {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct AutoloadKnownExtensions {
@@ -270,7 +270,7 @@ struct AutoloadKnownExtensions {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableObjectCacheSetting {
@@ -279,7 +279,7 @@ struct EnableObjectCacheSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableHTTPMetadataCacheSetting {
@@ -288,7 +288,7 @@ struct EnableHTTPMetadataCacheSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableProfilingSetting {
@@ -298,7 +298,7 @@ struct EnableProfilingSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableProgressBarSetting {
@@ -308,7 +308,7 @@ struct EnableProgressBarSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct EnableProgressBarPrintSetting {
@@ -318,7 +318,7 @@ struct EnableProgressBarPrintSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ErrorsAsJsonSetting {
@@ -327,7 +327,7 @@ struct ErrorsAsJsonSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ExplainOutputSetting {
@@ -336,7 +336,7 @@ struct ExplainOutputSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ExportLargeBufferArrow {
@@ -346,7 +346,7 @@ struct ExportLargeBufferArrow {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ExtensionDirectorySetting {
@@ -355,7 +355,7 @@ struct ExtensionDirectorySetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ExternalThreadsSetting {
@@ -364,7 +364,7 @@ struct ExternalThreadsSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct FileSearchPathSetting {
@@ -373,7 +373,7 @@ struct FileSearchPathSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ForceCompressionSetting {
@@ -382,7 +382,7 @@ struct ForceCompressionSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ForceBitpackingModeSetting {
@@ -391,7 +391,7 @@ struct ForceBitpackingModeSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct HomeDirectorySetting {
@@ -400,7 +400,7 @@ struct HomeDirectorySetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct IntegerDivisionSetting {
@@ -410,7 +410,7 @@ struct IntegerDivisionSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct LogQueryPathSetting {
@@ -420,7 +420,7 @@ struct LogQueryPathSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct LockConfigurationSetting {
@@ -429,7 +429,7 @@ struct LockConfigurationSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ImmediateTransactionModeSetting {
@@ -439,7 +439,7 @@ struct ImmediateTransactionModeSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct MaximumExpressionDepthSetting {
@@ -450,7 +450,7 @@ struct MaximumExpressionDepthSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct MaximumMemorySetting {
@@ -459,7 +459,7 @@ struct MaximumMemorySetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct OldImplicitCasting {
@@ -468,7 +468,7 @@ struct OldImplicitCasting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct PartitionedWriteFlushThreshold {
@@ -478,7 +478,7 @@ struct PartitionedWriteFlushThreshold {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct PasswordSetting {
@@ -487,7 +487,7 @@ struct PasswordSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct PerfectHashThresholdSetting {
@@ -496,7 +496,7 @@ struct PerfectHashThresholdSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct PivotFilterThreshold {
@@ -506,7 +506,7 @@ struct PivotFilterThreshold {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct PivotLimitSetting {
@@ -515,7 +515,7 @@ struct PivotLimitSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct PreserveIdentifierCase {
@@ -525,7 +525,7 @@ struct PreserveIdentifierCase {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct PreserveInsertionOrder {
@@ -536,7 +536,7 @@ struct PreserveInsertionOrder {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ProfileOutputSetting {
@@ -546,7 +546,7 @@ struct ProfileOutputSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ProfilingModeSetting {
@@ -555,7 +555,7 @@ struct ProfilingModeSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ProgressBarTimeSetting {
@@ -565,7 +565,7 @@ struct ProgressBarTimeSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct SchemaSetting {
@@ -575,7 +575,7 @@ struct SchemaSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct SearchPathSetting {
@@ -585,7 +585,7 @@ struct SearchPathSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct SecretDirectorySetting {
@@ -594,7 +594,7 @@ struct SecretDirectorySetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct TempDirectorySetting {
@@ -603,7 +603,7 @@ struct TempDirectorySetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct ThreadsSetting {
@@ -612,7 +612,7 @@ struct ThreadsSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct UsernameSetting {
@@ -621,7 +621,7 @@ struct UsernameSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct FlushAllocatorSetting {
@@ -631,7 +631,7 @@ struct FlushAllocatorSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct DuckDBApiSetting {
@@ -640,7 +640,7 @@ struct DuckDBApiSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 struct CustomUserAgentSetting {
@@ -649,7 +649,7 @@ struct CustomUserAgentSetting {
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
-	static Value GetSetting(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -53,7 +53,7 @@ public:
 	//! blocks can be evicted
 	virtual void SetLimit(idx_t limit = (idx_t)-1);
 	virtual vector<TemporaryFileInformation> GetTemporaryFiles();
-	virtual const string &GetTemporaryDirectory();
+	virtual const string &GetTemporaryDirectory() const;
 	virtual void SetTemporaryDirectory(const string &new_dir);
 	virtual bool HasTemporaryDirectory() const;
 	//! Construct a managed buffer.
@@ -66,7 +66,9 @@ public:
 
 	// Static methods
 	DUCKDB_API static BufferManager &GetBufferManager(DatabaseInstance &db);
+	DUCKDB_API static const BufferManager &GetBufferManager(const DatabaseInstance &db);
 	DUCKDB_API static BufferManager &GetBufferManager(ClientContext &context);
+	DUCKDB_API static const BufferManager &GetBufferManager(const ClientContext &context);
 	DUCKDB_API static BufferManager &GetBufferManager(AttachedDatabase &db);
 
 	static idx_t GetAllocSize(idx_t block_size) {

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -72,7 +72,7 @@ public:
 	//! Returns a list of all temporary files
 	vector<TemporaryFileInformation> GetTemporaryFiles() final;
 
-	const string &GetTemporaryDirectory() final {
+	const string &GetTemporaryDirectory() const final {
 		return temp_directory;
 	}
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1235,7 +1235,7 @@ unique_ptr<QueryResult> ClientContext::Execute(const shared_ptr<Relation> &relat
 	return ErrorResult<MaterializedQueryResult>(ErrorData(err_str));
 }
 
-SettingLookupResult ClientContext::TryGetCurrentSetting(const std::string &key, Value &result) {
+SettingLookupResult ClientContext::TryGetCurrentSetting(const std::string &key, Value &result) const {
 	// first check the built-in settings
 	auto &db_config = DBConfig::GetConfig(*this);
 	auto option = db_config.GetOptionByName(key);
@@ -1270,17 +1270,9 @@ ParserOptions ClientContext::GetParserOptions() const {
 ClientProperties ClientContext::GetClientProperties() const {
 	string timezone = "UTC";
 	Value result;
-	// 1) Check Set Variable
-	auto &client_config = ClientConfig::GetConfig(*this);
-	auto tz_config = client_config.set_variables.find("timezone");
-	if (tz_config == client_config.set_variables.end()) {
-		// 2) Check for Default Value
-		auto default_value = db->config.extension_parameters.find("timezone");
-		if (default_value != db->config.extension_parameters.end()) {
-			timezone = default_value->second.default_value.GetValue<string>();
-		}
-	} else {
-		timezone = tz_config->second.GetValue<string>();
+
+	if (TryGetCurrentSetting("TimeZone", result)) {
+		timezone = result.ToString();
 	}
 	return {timezone, db->config.options.arrow_offset_size};
 }

--- a/src/main/client_data.cpp
+++ b/src/main/client_data.cpp
@@ -50,6 +50,10 @@ ClientData &ClientData::Get(ClientContext &context) {
 	return *context.client_data;
 }
 
+const ClientData &ClientData::Get(const ClientContext &context) {
+	return *context.client_data;
+}
+
 RandomEngine &RandomEngine::Get(ClientContext &context) {
 	return *ClientData::Get(context).random_engine;
 }

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -71,11 +71,19 @@ BufferManager &BufferManager::GetBufferManager(DatabaseInstance &db) {
 	return db.GetBufferManager();
 }
 
+const BufferManager &BufferManager::GetBufferManager(const DatabaseInstance &db) {
+	return db.GetBufferManager();
+}
+
 BufferManager &BufferManager::GetBufferManager(AttachedDatabase &db) {
 	return BufferManager::GetBufferManager(db.GetDatabase());
 }
 
 DatabaseInstance &DatabaseInstance::GetDatabase(ClientContext &context) {
+	return *context.db;
+}
+
+const DatabaseInstance &DatabaseInstance::GetDatabase(const ClientContext &context) {
 	return *context.db;
 }
 
@@ -288,6 +296,10 @@ BufferManager &DatabaseInstance::GetBufferManager() {
 	return *buffer_manager;
 }
 
+const BufferManager &DatabaseInstance::GetBufferManager() const {
+	return *buffer_manager;
+}
+
 BufferPool &DatabaseInstance::GetBufferPool() const {
 	return *config.buffer_pool;
 }
@@ -411,7 +423,7 @@ void DatabaseInstance::SetExtensionLoaded(const std::string &name) {
 	}
 }
 
-SettingLookupResult DatabaseInstance::TryGetCurrentSetting(const std::string &key, Value &result) {
+SettingLookupResult DatabaseInstance::TryGetCurrentSetting(const std::string &key, Value &result) const {
 	// check the session values
 	auto &db_config = DBConfig::GetConfig(*this);
 	const auto &global_config_map = db_config.options.set_variables;

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -47,7 +47,7 @@ void AccessModeSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.options.access_mode = DBConfig().options.access_mode;
 }
 
-Value AccessModeSetting::GetSetting(ClientContext &context) {
+Value AccessModeSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	switch (config.options.access_mode) {
 	case AccessMode::AUTOMATIC:
@@ -73,7 +73,7 @@ void AllowPersistentSecrets::ResetGlobal(DatabaseInstance *db, DBConfig &config)
 	config.secret_manager->ResetEnablePersistentSecrets();
 }
 
-Value AllowPersistentSecrets::GetSetting(ClientContext &context) {
+Value AllowPersistentSecrets::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.secret_manager->PersistentSecretsEnabled());
 }
@@ -90,7 +90,7 @@ void CheckpointThresholdSetting::ResetGlobal(DatabaseInstance *db, DBConfig &con
 	config.options.checkpoint_wal_size = DBConfig().options.checkpoint_wal_size;
 }
 
-Value CheckpointThresholdSetting::GetSetting(ClientContext &context) {
+Value CheckpointThresholdSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value(StringUtil::BytesToHumanReadableString(config.options.checkpoint_wal_size));
 }
@@ -118,7 +118,7 @@ void DebugCheckpointAbort::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.options.checkpoint_abort = DBConfig().options.checkpoint_abort;
 }
 
-Value DebugCheckpointAbort::GetSetting(ClientContext &context) {
+Value DebugCheckpointAbort::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(*context.db);
 	auto setting = config.options.checkpoint_abort;
 	switch (setting) {
@@ -146,7 +146,7 @@ void DebugForceExternal::SetLocal(ClientContext &context, const Value &input) {
 	ClientConfig::GetConfig(context).force_external = input.GetValue<bool>();
 }
 
-Value DebugForceExternal::GetSetting(ClientContext &context) {
+Value DebugForceExternal::GetSetting(const ClientContext &context) {
 	return Value::BOOLEAN(ClientConfig::GetConfig(context).force_external);
 }
 
@@ -161,7 +161,7 @@ void DebugForceNoCrossProduct::SetLocal(ClientContext &context, const Value &inp
 	ClientConfig::GetConfig(context).force_no_cross_product = input.GetValue<bool>();
 }
 
-Value DebugForceNoCrossProduct::GetSetting(ClientContext &context) {
+Value DebugForceNoCrossProduct::GetSetting(const ClientContext &context) {
 	return Value::BOOLEAN(ClientConfig::GetConfig(context).force_no_cross_product);
 }
 
@@ -180,7 +180,7 @@ void OrderedAggregateThreshold::SetLocal(ClientContext &context, const Value &in
 	ClientConfig::GetConfig(context).ordered_aggregate_threshold = param;
 }
 
-Value OrderedAggregateThreshold::GetSetting(ClientContext &context) {
+Value OrderedAggregateThreshold::GetSetting(const ClientContext &context) {
 	return Value::UBIGINT(ClientConfig::GetConfig(context).ordered_aggregate_threshold);
 }
 
@@ -204,7 +204,7 @@ void DebugWindowMode::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.options.window_mode = DBConfig().options.window_mode;
 }
 
-Value DebugWindowMode::GetSetting(ClientContext &context) {
+Value DebugWindowMode::GetSetting(const ClientContext &context) {
 	return Value();
 }
 
@@ -219,7 +219,7 @@ void DebugAsOfIEJoin::SetLocal(ClientContext &context, const Value &input) {
 	ClientConfig::GetConfig(context).force_asof_iejoin = input.GetValue<bool>();
 }
 
-Value DebugAsOfIEJoin::GetSetting(ClientContext &context) {
+Value DebugAsOfIEJoin::GetSetting(const ClientContext &context) {
 	return Value::BOOLEAN(ClientConfig::GetConfig(context).force_asof_iejoin);
 }
 
@@ -234,7 +234,7 @@ void PreferRangeJoins::SetLocal(ClientContext &context, const Value &input) {
 	ClientConfig::GetConfig(context).prefer_range_joins = input.GetValue<bool>();
 }
 
-Value PreferRangeJoins::GetSetting(ClientContext &context) {
+Value PreferRangeJoins::GetSetting(const ClientContext &context) {
 	return Value::BOOLEAN(ClientConfig::GetConfig(context).prefer_range_joins);
 }
 
@@ -263,7 +263,7 @@ void DefaultCollationSetting::SetLocal(ClientContext &context, const Value &inpu
 	config.options.collation = parameter;
 }
 
-Value DefaultCollationSetting::GetSetting(ClientContext &context) {
+Value DefaultCollationSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value(config.options.collation);
 }
@@ -287,7 +287,7 @@ void DefaultOrderSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.options.default_order_type = DBConfig().options.default_order_type;
 }
 
-Value DefaultOrderSetting::GetSetting(ClientContext &context) {
+Value DefaultOrderSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	switch (config.options.default_order_type) {
 	case OrderType::ASCENDING:
@@ -325,7 +325,7 @@ void DefaultNullOrderSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config
 	config.options.default_null_order = DBConfig().options.default_null_order;
 }
 
-Value DefaultNullOrderSetting::GetSetting(ClientContext &context) {
+Value DefaultNullOrderSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	switch (config.options.default_null_order) {
 	case DefaultOrderByNullType::NULLS_FIRST:
@@ -352,7 +352,7 @@ void DefaultSecretStorage::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.secret_manager->ResetDefaultStorage();
 }
 
-Value DefaultSecretStorage::GetSetting(ClientContext &context) {
+Value DefaultSecretStorage::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return config.secret_manager->DefaultStorage();
 }
@@ -377,7 +377,7 @@ void DisabledFileSystemsSetting::ResetGlobal(DatabaseInstance *db, DBConfig &con
 	fs.SetDisabledFileSystems(vector<string>());
 }
 
-Value DisabledFileSystemsSetting::GetSetting(ClientContext &context) {
+Value DisabledFileSystemsSetting::GetSetting(const ClientContext &context) {
 	return Value("");
 }
 
@@ -402,7 +402,7 @@ void DisabledOptimizersSetting::ResetGlobal(DatabaseInstance *db, DBConfig &conf
 	config.options.disabled_optimizers = DBConfig().options.disabled_optimizers;
 }
 
-Value DisabledOptimizersSetting::GetSetting(ClientContext &context) {
+Value DisabledOptimizersSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	string result;
 	for (auto &optimizer : config.options.disabled_optimizers) {
@@ -432,7 +432,7 @@ void EnableExternalAccessSetting::ResetGlobal(DatabaseInstance *db, DBConfig &co
 	config.options.enable_external_access = DBConfig().options.enable_external_access;
 }
 
-Value EnableExternalAccessSetting::GetSetting(ClientContext &context) {
+Value EnableExternalAccessSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.enable_external_access);
 }
@@ -448,7 +448,7 @@ void EnableFSSTVectors::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.options.enable_fsst_vectors = DBConfig().options.enable_fsst_vectors;
 }
 
-Value EnableFSSTVectors::GetSetting(ClientContext &context) {
+Value EnableFSSTVectors::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.enable_fsst_vectors);
 }
@@ -471,7 +471,7 @@ void AllowUnsignedExtensionsSetting::ResetGlobal(DatabaseInstance *db, DBConfig 
 	config.options.allow_unsigned_extensions = DBConfig().options.allow_unsigned_extensions;
 }
 
-Value AllowUnsignedExtensionsSetting::GetSetting(ClientContext &context) {
+Value AllowUnsignedExtensionsSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.allow_unsigned_extensions);
 }
@@ -494,7 +494,7 @@ void AllowUnredactedSecretsSetting::ResetGlobal(DatabaseInstance *db, DBConfig &
 	config.options.allow_unredacted_secrets = DBConfig().options.allow_unredacted_secrets;
 }
 
-Value AllowUnredactedSecretsSetting::GetSetting(ClientContext &context) {
+Value AllowUnredactedSecretsSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.allow_unredacted_secrets);
 }
@@ -510,7 +510,7 @@ void EnableObjectCacheSetting::ResetGlobal(DatabaseInstance *db, DBConfig &confi
 	config.options.object_cache_enable = DBConfig().options.object_cache_enable;
 }
 
-Value EnableObjectCacheSetting::GetSetting(ClientContext &context) {
+Value EnableObjectCacheSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.object_cache_enable);
 }
@@ -526,7 +526,7 @@ void EnableHTTPMetadataCacheSetting::ResetGlobal(DatabaseInstance *db, DBConfig 
 	config.options.http_metadata_cache_enable = DBConfig().options.http_metadata_cache_enable;
 }
 
-Value EnableHTTPMetadataCacheSetting::GetSetting(ClientContext &context) {
+Value EnableHTTPMetadataCacheSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.http_metadata_cache_enable);
 }
@@ -559,7 +559,7 @@ void EnableProfilingSetting::SetLocal(ClientContext &context, const Value &input
 	config.emit_profiler_output = true;
 }
 
-Value EnableProfilingSetting::GetSetting(ClientContext &context) {
+Value EnableProfilingSetting::GetSetting(const ClientContext &context) {
 	auto &config = ClientConfig::GetConfig(context);
 	if (!config.enable_profiler) {
 		return Value();
@@ -587,7 +587,7 @@ void CustomExtensionRepository::SetGlobal(DatabaseInstance *db, DBConfig &config
 	config.options.custom_extension_repo = input.ToString();
 }
 
-Value CustomExtensionRepository::GetSetting(ClientContext &context) {
+Value CustomExtensionRepository::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value(config.options.custom_extension_repo);
 }
@@ -603,7 +603,7 @@ void AutoloadExtensionRepository::SetGlobal(DatabaseInstance *db, DBConfig &conf
 	config.options.autoinstall_extension_repo = input.ToString();
 }
 
-Value AutoloadExtensionRepository::GetSetting(ClientContext &context) {
+Value AutoloadExtensionRepository::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value(config.options.autoinstall_extension_repo);
 }
@@ -619,7 +619,7 @@ void AutoinstallKnownExtensions::ResetGlobal(DatabaseInstance *db, DBConfig &con
 	config.options.autoinstall_known_extensions = DBConfig().options.autoinstall_known_extensions;
 }
 
-Value AutoinstallKnownExtensions::GetSetting(ClientContext &context) {
+Value AutoinstallKnownExtensions::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.autoinstall_known_extensions);
 }
@@ -634,7 +634,7 @@ void AutoloadKnownExtensions::ResetGlobal(DatabaseInstance *db, DBConfig &config
 	config.options.autoload_known_extensions = DBConfig().options.autoload_known_extensions;
 }
 
-Value AutoloadKnownExtensions::GetSetting(ClientContext &context) {
+Value AutoloadKnownExtensions::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.autoload_known_extensions);
 }
@@ -654,7 +654,7 @@ void EnableProgressBarSetting::SetLocal(ClientContext &context, const Value &inp
 	config.enable_progress_bar = input.GetValue<bool>();
 }
 
-Value EnableProgressBarSetting::GetSetting(ClientContext &context) {
+Value EnableProgressBarSetting::GetSetting(const ClientContext &context) {
 	return Value::BOOLEAN(ClientConfig::GetConfig(context).enable_progress_bar);
 }
 
@@ -673,7 +673,7 @@ void EnableProgressBarPrintSetting::ResetLocal(ClientContext &context) {
 	config.print_progress_bar = ClientConfig().print_progress_bar;
 }
 
-Value EnableProgressBarPrintSetting::GetSetting(ClientContext &context) {
+Value EnableProgressBarPrintSetting::GetSetting(const ClientContext &context) {
 	return Value::BOOLEAN(ClientConfig::GetConfig(context).print_progress_bar);
 }
 
@@ -688,7 +688,7 @@ void ErrorsAsJsonSetting::SetLocal(ClientContext &context, const Value &input) {
 	ClientConfig::GetConfig(context).errors_as_json = BooleanValue::Get(input);
 }
 
-Value ErrorsAsJsonSetting::GetSetting(ClientContext &context) {
+Value ErrorsAsJsonSetting::GetSetting(const ClientContext &context) {
 	return Value::BOOLEAN(ClientConfig::GetConfig(context).errors_as_json ? 1 : 0);
 }
 
@@ -713,7 +713,7 @@ void ExplainOutputSetting::SetLocal(ClientContext &context, const Value &input) 
 	}
 }
 
-Value ExplainOutputSetting::GetSetting(ClientContext &context) {
+Value ExplainOutputSetting::GetSetting(const ClientContext &context) {
 	switch (ClientConfig::GetConfig(context).explain_output_type) {
 	case ExplainOutputType::ALL:
 		return "all";
@@ -737,7 +737,7 @@ void ExtensionDirectorySetting::ResetGlobal(DatabaseInstance *db, DBConfig &conf
 	config.options.extension_directory = DBConfig().options.extension_directory;
 }
 
-Value ExtensionDirectorySetting::GetSetting(ClientContext &context) {
+Value ExtensionDirectorySetting::GetSetting(const ClientContext &context) {
 	return Value(DBConfig::GetConfig(context).options.extension_directory);
 }
 
@@ -764,7 +764,7 @@ void ExternalThreadsSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config)
 	config.options.external_threads = new_external_threads;
 }
 
-Value ExternalThreadsSetting::GetSetting(ClientContext &context) {
+Value ExternalThreadsSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BIGINT(config.options.external_threads);
 }
@@ -783,7 +783,7 @@ void FileSearchPathSetting::SetLocal(ClientContext &context, const Value &input)
 	client_data.file_search_path = parameter;
 }
 
-Value FileSearchPathSetting::GetSetting(ClientContext &context) {
+Value FileSearchPathSetting::GetSetting(const ClientContext &context) {
 	auto &client_data = ClientData::Get(context);
 	return Value(client_data.file_search_path);
 }
@@ -813,7 +813,7 @@ void ForceCompressionSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config
 	config.options.force_compression = DBConfig().options.force_compression;
 }
 
-Value ForceCompressionSetting::GetSetting(ClientContext &context) {
+Value ForceCompressionSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(*context.db);
 	return CompressionTypeToString(config.options.force_compression);
 }
@@ -835,7 +835,7 @@ void ForceBitpackingModeSetting::ResetGlobal(DatabaseInstance *db, DBConfig &con
 	config.options.force_bitpacking_mode = DBConfig().options.force_bitpacking_mode;
 }
 
-Value ForceBitpackingModeSetting::GetSetting(ClientContext &context) {
+Value ForceBitpackingModeSetting::GetSetting(const ClientContext &context) {
 	return Value(BitpackingModeToString(context.db->config.options.force_bitpacking_mode));
 }
 
@@ -856,7 +856,7 @@ void HomeDirectorySetting::SetLocal(ClientContext &context, const Value &input) 
 	config.home_directory = input.IsNull() ? string() : input.ToString();
 }
 
-Value HomeDirectorySetting::GetSetting(ClientContext &context) {
+Value HomeDirectorySetting::GetSetting(const ClientContext &context) {
 	auto &config = ClientConfig::GetConfig(context);
 	return Value(config.home_directory);
 }
@@ -873,7 +873,7 @@ void IntegerDivisionSetting::SetLocal(ClientContext &context, const Value &input
 	config.integer_division = input.GetValue<bool>();
 }
 
-Value IntegerDivisionSetting::GetSetting(ClientContext &context) {
+Value IntegerDivisionSetting::GetSetting(const ClientContext &context) {
 	auto &config = ClientConfig::GetConfig(context);
 	return Value(config.integer_division);
 }
@@ -899,7 +899,7 @@ void LogQueryPathSetting::SetLocal(ClientContext &context, const Value &input) {
 	}
 }
 
-Value LogQueryPathSetting::GetSetting(ClientContext &context) {
+Value LogQueryPathSetting::GetSetting(const ClientContext &context) {
 	auto &client_data = ClientData::Get(context);
 	return client_data.log_query_writer ? Value(client_data.log_query_writer->path) : Value();
 }
@@ -916,7 +916,7 @@ void LockConfigurationSetting::ResetGlobal(DatabaseInstance *db, DBConfig &confi
 	config.options.lock_configuration = DBConfig().options.lock_configuration;
 }
 
-Value LockConfigurationSetting::GetSetting(ClientContext &context) {
+Value LockConfigurationSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.lock_configuration);
 }
@@ -932,7 +932,7 @@ void ImmediateTransactionModeSetting::ResetGlobal(DatabaseInstance *db, DBConfig
 	config.options.immediate_transaction_mode = DBConfig().options.immediate_transaction_mode;
 }
 
-Value ImmediateTransactionModeSetting::GetSetting(ClientContext &context) {
+Value ImmediateTransactionModeSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.immediate_transaction_mode);
 }
@@ -948,7 +948,7 @@ void MaximumExpressionDepthSetting::SetLocal(ClientContext &context, const Value
 	ClientConfig::GetConfig(context).max_expression_depth = input.GetValue<uint64_t>();
 }
 
-Value MaximumExpressionDepthSetting::GetSetting(ClientContext &context) {
+Value MaximumExpressionDepthSetting::GetSetting(const ClientContext &context) {
 	return Value::UBIGINT(ClientConfig::GetConfig(context).max_expression_depth);
 }
 
@@ -966,7 +966,7 @@ void MaximumMemorySetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.SetDefaultMaxMemory();
 }
 
-Value MaximumMemorySetting::GetSetting(ClientContext &context) {
+Value MaximumMemorySetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value(StringUtil::BytesToHumanReadableString(config.options.maximum_memory));
 }
@@ -982,7 +982,7 @@ void OldImplicitCasting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.options.old_implicit_casting = DBConfig().options.old_implicit_casting;
 }
 
-Value OldImplicitCasting::GetSetting(ClientContext &context) {
+Value OldImplicitCasting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.old_implicit_casting);
 }
@@ -999,7 +999,7 @@ void PartitionedWriteFlushThreshold::SetLocal(ClientContext &context, const Valu
 	ClientConfig::GetConfig(context).partitioned_write_flush_threshold = input.GetValue<idx_t>();
 }
 
-Value PartitionedWriteFlushThreshold::GetSetting(ClientContext &context) {
+Value PartitionedWriteFlushThreshold::GetSetting(const ClientContext &context) {
 	return Value::BIGINT(ClientConfig::GetConfig(context).partitioned_write_flush_threshold);
 }
 
@@ -1014,7 +1014,7 @@ void PasswordSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	// nop
 }
 
-Value PasswordSetting::GetSetting(ClientContext &context) {
+Value PasswordSetting::GetSetting(const ClientContext &context) {
 	return Value();
 }
 
@@ -1033,7 +1033,7 @@ void PerfectHashThresholdSetting::SetLocal(ClientContext &context, const Value &
 	ClientConfig::GetConfig(context).perfect_ht_threshold = bits;
 }
 
-Value PerfectHashThresholdSetting::GetSetting(ClientContext &context) {
+Value PerfectHashThresholdSetting::GetSetting(const ClientContext &context) {
 	return Value::BIGINT(ClientConfig::GetConfig(context).perfect_ht_threshold);
 }
 
@@ -1048,7 +1048,7 @@ void PivotFilterThreshold::SetLocal(ClientContext &context, const Value &input) 
 	ClientConfig::GetConfig(context).pivot_filter_threshold = input.GetValue<uint64_t>();
 }
 
-Value PivotFilterThreshold::GetSetting(ClientContext &context) {
+Value PivotFilterThreshold::GetSetting(const ClientContext &context) {
 	return Value::BIGINT(ClientConfig::GetConfig(context).pivot_filter_threshold);
 }
 
@@ -1063,7 +1063,7 @@ void PivotLimitSetting::SetLocal(ClientContext &context, const Value &input) {
 	ClientConfig::GetConfig(context).pivot_limit = input.GetValue<uint64_t>();
 }
 
-Value PivotLimitSetting::GetSetting(ClientContext &context) {
+Value PivotLimitSetting::GetSetting(const ClientContext &context) {
 	return Value::BIGINT(ClientConfig::GetConfig(context).pivot_limit);
 }
 
@@ -1078,7 +1078,7 @@ void PreserveIdentifierCase::SetLocal(ClientContext &context, const Value &input
 	ClientConfig::GetConfig(context).preserve_identifier_case = input.GetValue<bool>();
 }
 
-Value PreserveIdentifierCase::GetSetting(ClientContext &context) {
+Value PreserveIdentifierCase::GetSetting(const ClientContext &context) {
 	return Value::BOOLEAN(ClientConfig::GetConfig(context).preserve_identifier_case);
 }
 
@@ -1093,7 +1093,7 @@ void PreserveInsertionOrder::ResetGlobal(DatabaseInstance *db, DBConfig &config)
 	config.options.preserve_insertion_order = DBConfig().options.preserve_insertion_order;
 }
 
-Value PreserveInsertionOrder::GetSetting(ClientContext &context) {
+Value PreserveInsertionOrder::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BOOLEAN(config.options.preserve_insertion_order);
 }
@@ -1111,7 +1111,7 @@ void ExportLargeBufferArrow::ResetGlobal(DatabaseInstance *db, DBConfig &config)
 	config.options.arrow_offset_size = DBConfig().options.arrow_offset_size;
 }
 
-Value ExportLargeBufferArrow::GetSetting(ClientContext &context) {
+Value ExportLargeBufferArrow::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	bool export_large_buffers_arrow = config.options.arrow_offset_size == ArrowOffsetSize::LARGE;
 	return Value::BOOLEAN(export_large_buffers_arrow);
@@ -1130,7 +1130,7 @@ void ProfileOutputSetting::SetLocal(ClientContext &context, const Value &input) 
 	config.profiler_save_location = parameter;
 }
 
-Value ProfileOutputSetting::GetSetting(ClientContext &context) {
+Value ProfileOutputSetting::GetSetting(const ClientContext &context) {
 	auto &config = ClientConfig::GetConfig(context);
 	return Value(config.profiler_save_location);
 }
@@ -1160,7 +1160,7 @@ void ProfilingModeSetting::SetLocal(ClientContext &context, const Value &input) 
 	}
 }
 
-Value ProfilingModeSetting::GetSetting(ClientContext &context) {
+Value ProfilingModeSetting::GetSetting(const ClientContext &context) {
 	auto &config = ClientConfig::GetConfig(context);
 	if (!config.enable_profiler) {
 		return Value();
@@ -1185,7 +1185,7 @@ void ProgressBarTimeSetting::SetLocal(ClientContext &context, const Value &input
 	config.enable_progress_bar = true;
 }
 
-Value ProgressBarTimeSetting::GetSetting(ClientContext &context) {
+Value ProgressBarTimeSetting::GetSetting(const ClientContext &context) {
 	return Value::BIGINT(ClientConfig::GetConfig(context).wait_time);
 }
 
@@ -1204,7 +1204,7 @@ void SchemaSetting::SetLocal(ClientContext &context, const Value &input) {
 	client_data.catalog_search_path->Set(CatalogSearchEntry::Parse(parameter), CatalogSetPathType::SET_SCHEMA);
 }
 
-Value SchemaSetting::GetSetting(ClientContext &context) {
+Value SchemaSetting::GetSetting(const ClientContext &context) {
 	auto &client_data = ClientData::Get(context);
 	return client_data.catalog_search_path->GetDefault().schema;
 }
@@ -1224,7 +1224,7 @@ void SearchPathSetting::SetLocal(ClientContext &context, const Value &input) {
 	client_data.catalog_search_path->Set(CatalogSearchEntry::ParseList(parameter), CatalogSetPathType::SET_SCHEMAS);
 }
 
-Value SearchPathSetting::GetSetting(ClientContext &context) {
+Value SearchPathSetting::GetSetting(const ClientContext &context) {
 	auto &client_data = ClientData::Get(context);
 	auto &set_paths = client_data.catalog_search_path->GetSetPaths();
 	return Value(CatalogSearchEntry::ListToString(set_paths));
@@ -1241,7 +1241,7 @@ void SecretDirectorySetting::ResetGlobal(DatabaseInstance *db, DBConfig &config)
 	config.secret_manager->ResetPersistentSecretPath();
 }
 
-Value SecretDirectorySetting::GetSetting(ClientContext &context) {
+Value SecretDirectorySetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return config.secret_manager->PersistentSecretPath();
 }
@@ -1267,7 +1267,7 @@ void TempDirectorySetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	}
 }
 
-Value TempDirectorySetting::GetSetting(ClientContext &context) {
+Value TempDirectorySetting::GetSetting(const ClientContext &context) {
 	auto &buffer_manager = BufferManager::GetBufferManager(context);
 	return Value(buffer_manager.GetTemporaryDirectory());
 }
@@ -1295,7 +1295,7 @@ void ThreadsSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.options.maximum_threads = new_maximum_threads;
 }
 
-Value ThreadsSetting::GetSetting(ClientContext &context) {
+Value ThreadsSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value::BIGINT(config.options.maximum_threads);
 }
@@ -1311,7 +1311,7 @@ void UsernameSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	// nop
 }
 
-Value UsernameSetting::GetSetting(ClientContext &context) {
+Value UsernameSetting::GetSetting(const ClientContext &context) {
 	return Value();
 }
 
@@ -1332,7 +1332,7 @@ void FlushAllocatorSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) 
 	}
 }
 
-Value FlushAllocatorSetting::GetSetting(ClientContext &context) {
+Value FlushAllocatorSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value(StringUtil::BytesToHumanReadableString(config.options.allocator_flush_threshold));
 }
@@ -1356,7 +1356,7 @@ void DuckDBApiSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 	config.options.duckdb_api = GetDefaultUserAgent();
 }
 
-Value DuckDBApiSetting::GetSetting(ClientContext &context) {
+Value DuckDBApiSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value(config.options.duckdb_api);
 }
@@ -1381,7 +1381,7 @@ void CustomUserAgentSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config)
 	config.options.custom_user_agent = DBConfig().options.custom_user_agent;
 }
 
-Value CustomUserAgentSetting::GetSetting(ClientContext &context) {
+Value CustomUserAgentSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	return Value(config.options.custom_user_agent);
 }

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -31,7 +31,7 @@ vector<TemporaryFileInformation> BufferManager::GetTemporaryFiles() {
 	throw InternalException("This type of BufferManager does not allow temporary files");
 }
 
-const string &BufferManager::GetTemporaryDirectory() {
+const string &BufferManager::GetTemporaryDirectory() const {
 	throw InternalException("This type of BufferManager does not allow a temporary directory");
 }
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -44,6 +44,10 @@ BufferManager &BufferManager::GetBufferManager(ClientContext &context) {
 	return BufferManager::GetBufferManager(*context.db);
 }
 
+const BufferManager &BufferManager::GetBufferManager(const ClientContext &context) {
+	return BufferManager::GetBufferManager(*context.db);
+}
+
 ObjectCache &ObjectCache::GetObjectCache(ClientContext &context) {
 	return context.db->GetObjectCache();
 }

--- a/tools/pythonpkg/tests/fast/api/test_cursor.py
+++ b/tools/pythonpkg/tests/fast/api/test_cursor.py
@@ -82,6 +82,18 @@ class TestDBAPICursor(object):
         cursor1.close()
         cursor2.close()
 
+    def test_cursor_timezone(self):
+        db = duckdb.connect()
+
+        # We set the 'timezone' setting globally
+        con1 = db.cursor()
+        db.execute("set global timezone='UTC'")
+
+        # Because the 'timezone' setting was not explicitly set for the connection
+        # the setting of the DBConfig is used instead
+        res = con1.execute("SELECT make_timestamptz(2000,01,20,03,30,59)").fetchone()
+        assert str(res) == '(datetime.datetime(2000, 1, 20, 3, 30, 59, tzinfo=<UTC>),)'
+
     def test_cursor_closed(self):
         con = duckdb.connect(':memory:')
         con.close()


### PR DESCRIPTION
```py
import duckdb

db = duckdb.connect()

con1 = db.cursor()
db.execute("set global timezone='UTC'")

res = con1.execute("SELECT make_timestamptz(2000,01,20,03,30,59)").fetchone()
```

This example on `main` does not use the UTC timezone inside `con1`, this is because the python conversion code is looking at `ClientProperties.timezone` to determine what the resulting timezone should be.

In `ClientContext::GetClientProperties` when setting `timezone` this was ignoring the setting set in the DBConfig.
I've rectified this by using TryGetCurrentSetting inside GetClientProperties.

Because GetClientProperties is a `const` function however, this led me to find out that TryGetCurrentSetting was not marked `const`.
Fixing this caused all the other file touches you see here
(I would argue it makes sense for a `Get` method to be marked const, because it shouldn't be modifying anything)