### PR TITLE
[CI] Fix CI failure on `C Enum Integrity Check`

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Install python dependencies
       if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       shell: bash
-      run: python -m pip install clang-5
+      run: python -m pip install libclang
 
     - name: Install libclang
       if: ${{ !startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Verify C enum integrity
       if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       shell: bash
-      run: python scripts/verify_enum_integrity.py src/include/duckdb.h --library_path $(llvm-config --libdir)
+      run: python scripts/verify_enum_integrity.py src/include/duckdb.h
 
   tidy-check:
     name: Tidy Check

--- a/scripts/verify_enum_integrity.py
+++ b/scripts/verify_enum_integrity.py
@@ -27,10 +27,7 @@ def visit_enum(cursor):
     print(f"Succesfully verified the integrity of enum {enum_name} ({len(enum_constants)} entries)")
 
 
-def parse_enum(file_path, clang_path: Optional[str] = None):
-    if clang_path:
-        clang.cindex.Config.set_library_path(clang_path)
-
+def parse_enum(file_path):
     # Create index
     index = clang.cindex.Index.create()
 
@@ -54,7 +51,6 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Parse a C header file and check enum integrity.")
     parser.add_argument("file_path", type=str, help="Path to the C header file")
-    parser.add_argument("--library_path", type=str, help="Path to the clang library", default=None)
 
     args = parser.parse_args()
     file_path = args.file_path
@@ -62,4 +58,4 @@ if __name__ == "__main__":
     if not os.path.exists(file_path):
         raise Exception(f"Error: file '{file_path}' does not exist")
 
-    enum_dict = parse_enum(file_path, args.library_path)
+    enum_dict = parse_enum(file_path)


### PR DESCRIPTION
Looking at <https://pypi.org/project/libclang/> it seems that the override shouldn't be required.
If we install `libclang` it should automatically be able to locate the right library, as it comes prebundled with the install