### PR TITLE
initializes unknown indexes on catalog lookup

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -306,9 +306,6 @@ void TableScanPushdownComplexFilter(ClientContext &context, LogicalGet &get, Fun
 		return;
 	}
 
-	// Lazily initialize any unknown indexes that might have been loaded by an extension
-	storage.info->InitializeIndexes(context);
-
 	// behold
 	storage.info->indexes.Scan([&](Index &index) {
 		// first rewrite the index expression so the ColumnBindings align with the column bindings of the current table

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -89,8 +89,6 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t removed_co
 		column_definitions.emplace_back(column_def.Copy());
 	}
 
-	// try to initialize unknown indexes
-	info->InitializeIndexes(context);
 	// first check if there are any indexes that exist that point to the removed column
 	info->indexes.Scan([&](Index &index) {
 		for (auto &column_id : index.column_ids) {
@@ -155,8 +153,6 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_id
 	for (auto &column_def : parent.column_definitions) {
 		column_definitions.emplace_back(column_def.Copy());
 	}
-	// try to initialize unknown indexes
-	info->InitializeIndexes(context);
 
 	// first check if there are any indexes that exist that point to the changed column
 	info->indexes.Scan([&](Index &index) {

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -470,9 +470,6 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
 		storage.AppendToIndexes(transaction, append_state, append_count, true);
 	}
 
-	// try to initialize any unknown indexes
-	table.info->InitializeIndexes(context);
-
 	// possibly vacuum any excess index data
 	table.info->indexes.Scan([&](Index &index) {
 		index.Vacuum();
@@ -575,7 +572,6 @@ TableIndexList &LocalStorage::GetIndexes(DataTable &table) {
 	if (!storage) {
 		throw InternalException("LocalStorage::GetIndexes - local storage not found");
 	}
-	table.info->InitializeIndexes(context);
 	return storage->indexes;
 }
 


### PR DESCRIPTION
Over in https://github.com/Maxxen/duckdb-vss I've ran into an issue where if you create a custom index and restart the database, its not possible to `DROP` the index or the table it applies to without first running a query against the table. This is because we don't initialize "unknown" extension-provided indexes until we need to access them during a scan. 

This PR changes this so that any unknown indexes are initialized as soon as you make a catalog lookup on a table or an index entry directly. Im not sure if this is the best place to do this, but as we're initializing foreign keys here anyway it felt suitable. 