### PR TITLE
[CI] Fix Deploy step to execute only for duckdb organization

### DIFF
--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -13,6 +13,12 @@ fi
 
 set -e
 
+# skip if repo is not in duckdb organization
+if [ "$GITHUB_REPOSITORY_OWNER" != "duckdb" ]; then
+  echo "Repository is $GITHUB_REPOSITORY_OWNER (not duckdb)"
+  exit 0
+fi
+
 FOLDER="$1"
 DRY_RUN_PARAM=""
 


### PR DESCRIPTION
Without this change forks would incur extra unnecessary CI (installing awscli) AND they would require to have tags (not inherited on fork).