### PR TITLE
Rework `vector_hash` for ARRAYs

### DIFF
--- a/src/common/vector_operations/vector_hash.cpp
+++ b/src/common/vector_operations/vector_hash.cpp
@@ -195,8 +195,8 @@ static inline void ArrayLoopHash(Vector &input, Vector &hashes, const SelectionV
 	auto child_count = array_size * count;
 	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		child_count = array_size;
-	} else if (input.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
-		// Based on the largest dict offset
+	} else {
+		// Based on the largest selection offset
 		for (idx_t i = 0; i < count; i++) {
 			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
 			auto lidx = idata.sel->get_index(ridx);

--- a/test/sql/types/nested/array/array_fuzzer_failures.test
+++ b/test/sql/types/nested/array/array_fuzzer_failures.test
@@ -1,0 +1,53 @@
+# name: test/sql/types/nested/array/array_fuzzer_failures.test
+# group: [array]
+
+statement ok
+PRAGMA enable_verification;
+
+# Case 1 #1420
+statement ok
+create table tbl(c8 UTINYINT);
+
+statement ok
+INSERT INTO tbl VALUES (0), (255), (NULL);
+
+statement ok
+SELECT CAST(TRY_CAST(c8 AS ENUM('DUCK_DUCK_ENUM', 'GOOSE')) AS VARCHAR[3]) FROM tbl;
+
+
+# Case 2 #1408
+statement ok
+CREATE TABLE array_tbl(c50 INTEGER[2][]);;
+
+statement ok
+INSERT INTO array_tbl VALUES('[[1, 2], [1, 2]]');
+
+statement ok
+INSERT INTO array_tbl VALUES('[[3, 4], [3, 4]]');
+
+statement ok
+SELECT c50 FROM array_tbl GROUP BY ALL USING SAMPLE 3;
+
+
+# Case 3 #1409
+statement ok
+CREATE TABLE test(c2 BOOL, c48 STRUCT(a INTEGER[3], b VARCHAR[3]));;
+
+statement ok
+INSERT INTO test VALUES(false, '{''a'': [NULL, 2, 3], ''b'': [a, NULL, c]}');
+
+
+# Case 4 #fuzzer-1434 (Solved), turned out related to constant arrays
+statement ok
+create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
+
+statement ok
+SELECT subq_0.c2 AS c4 FROM (SELECT ref_1.fixed_nested_int_array AS c2 FROM main.all_types AS ref_0 LEFT JOIN main.all_types AS ref_1 ON ((ref_0."varchar" !~~* ref_1."varchar"))) AS subq_0 RIGHT JOIN main.all_types AS ref_2 ON ((subq_0.c2 = ref_2.fixed_nested_int_array))
+
+
+# Case 5 #fuzzer-1443
+query I
+SELECT TRY_CAST(c36 AS INTEGER[][3]) FROM all_types AS t51(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50) WHERE c6
+----
+NULL
+NULL

--- a/test/sql/types/nested/array/array_joins_2.test
+++ b/test/sql/types/nested/array/array_joins_2.test
@@ -1,0 +1,42 @@
+# name: test/sql/types/nested/array/array_joins_2.test
+# group: [array]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+PRAGMA verify_external
+
+statement ok
+CREATE TABLE test_array (c1 int[3]);
+
+statement ok
+INSERT INTO test_array values (null), (array[1, 2, 3]), (array[4, 5, 6]), (array[7, 8, 9]);
+
+query II rowsort
+SELECT * FROM test_array JOIN test_array AS t2 ON t2.c1 = test_array.c1;
+----
+[1, 2, 3]	[1, 2, 3]
+[4, 5, 6]	[4, 5, 6]
+[7, 8, 9]	[7, 8, 9]
+
+statement ok
+INSERT INTO test_array values (null);
+
+query II rowsort
+SELECT * FROM test_array JOIN test_array AS t2 ON t2.c1 = test_array.c1;
+----
+[1, 2, 3]	[1, 2, 3]
+[4, 5, 6]	[4, 5, 6]
+[7, 8, 9]	[7, 8, 9]
+
+statement ok
+INSERT INTO test_array values (array[10, 11, 12]);
+
+query II
+SELECT * FROM test_array JOIN test_array AS t2 ON t2.c1 = test_array.c1 ORDER BY test_array.c1;
+----
+[1, 2, 3]	[1, 2, 3]
+[4, 5, 6]	[4, 5, 6]
+[7, 8, 9]	[7, 8, 9]
+[10, 11, 12]	[10, 11, 12]


### PR DESCRIPTION
This PR reworks the hash operation for array vectors thats been having issues.

The underlying problem is that array vectors implicitly assumes that the array elements corresponding to the array at position `x` will be located in the child vector at position `x * (array_size) + (elem_offset)`. This works well in the general case when you get a populated array vector supplied to you. However, during hashing we want to create a temporary vector to store the hashes of the child vector, but as our input vector can be of different vector types, as well as have an additional `rsel` selection vector applied it becomes pretty difficult to calculate the total required size for the temporary child hash vector as the `rsel` can end up indexing outside the assumed `count * array_size` number of child elements.

My previous band-aide fix was to look through any selection vectors to find the "max offset" and simply create a hash vector thats always large enough to contain the furthest selection index, but this is pretty wasteful, especially if the `rsel` or an input dictionary vector is sparse.

Now there's two paths: a fast path if the input and output vectors are contiguous (flat/constant and no `rsel`) where we just hash all `count * array_size` child elements in one go, as well as a slow(er) path where we hash the elements of every input array one at a time (although reusing the temporary hash vector). In theory you could optimize this even further and size the temporary hash vector by figuring out the largest contiguous segment so you could hash the elements of multiple "adjacent" arrays at once. But this is more memory-friendly.

Closes https://github.com/duckdb/duckdb/issues/11552