### PR TITLE
Various fixes & clean-up around STRUCT UNNEST

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -2012,6 +2012,8 @@ const char* EnumUtil::ToChars<ExpressionClass>(ExpressionClass value) {
 		return "BOUND_LAMBDA_REF";
 	case ExpressionClass::BOUND_EXPRESSION:
 		return "BOUND_EXPRESSION";
+	case ExpressionClass::BOUND_EXPANDED:
+		return "BOUND_EXPANDED";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
 	}
@@ -2135,6 +2137,9 @@ ExpressionClass EnumUtil::FromString<ExpressionClass>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "BOUND_EXPRESSION")) {
 		return ExpressionClass::BOUND_EXPRESSION;
+	}
+	if (StringUtil::Equals(value, "BOUND_EXPANDED")) {
+		return ExpressionClass::BOUND_EXPANDED;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }
@@ -2278,6 +2283,8 @@ const char* EnumUtil::ToChars<ExpressionType>(ExpressionType value) {
 		return "POSITIONAL_REFERENCE";
 	case ExpressionType::BOUND_LAMBDA_REF:
 		return "BOUND_LAMBDA_REF";
+	case ExpressionType::BOUND_EXPANDED:
+		return "BOUND_EXPANDED";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
 	}
@@ -2488,6 +2495,9 @@ ExpressionType EnumUtil::FromString<ExpressionType>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "BOUND_LAMBDA_REF")) {
 		return ExpressionType::BOUND_LAMBDA_REF;
+	}
+	if (StringUtil::Equals(value, "BOUND_EXPANDED")) {
+		return ExpressionType::BOUND_EXPANDED;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/common/enums/expression_type.cpp
+++ b/src/common/enums/expression_type.cpp
@@ -141,6 +141,8 @@ string ExpressionTypeToString(ExpressionType type) {
 		return "LAMBDA";
 	case ExpressionType::ARROW:
 		return "ARROW";
+	case ExpressionType::BOUND_EXPANDED:
+		return "BOUND_EXPANDED";
 	case ExpressionType::INVALID:
 		break;
 	}
@@ -224,6 +226,8 @@ string ExpressionClassToString(ExpressionClass type) {
 		return "BOUND_LAMBDA";
 	case ExpressionClass::BOUND_EXPRESSION:
 		return "BOUND_EXPRESSION";
+	case ExpressionClass::BOUND_EXPANDED:
+		return "BOUND_EXPANDED";
 	default:
 		return "ExpressionClass::!!UNIMPLEMENTED_CASE!!";
 	}

--- a/src/include/duckdb/common/enums/expression_type.hpp
+++ b/src/include/duckdb/common/enums/expression_type.hpp
@@ -145,7 +145,8 @@ enum class ExpressionType : uint8_t {
 	COLLATE = 230,
 	LAMBDA = 231,
 	POSITIONAL_REFERENCE = 232,
-	BOUND_LAMBDA_REF = 233
+	BOUND_LAMBDA_REF = 233,
+	BOUND_EXPANDED = 234
 };
 
 //===--------------------------------------------------------------------===//
@@ -199,7 +200,8 @@ enum class ExpressionClass : uint8_t {
 	//===--------------------------------------------------------------------===//
 	// Miscellaneous
 	//===--------------------------------------------------------------------===//
-	BOUND_EXPRESSION = 50
+	BOUND_EXPRESSION = 50,
+	BOUND_EXPANDED = 51
 };
 
 DUCKDB_API string ExpressionTypeToString(ExpressionType type);

--- a/src/include/duckdb/common/exception/binder_exception.hpp
+++ b/src/include/duckdb/common/exception/binder_exception.hpp
@@ -30,6 +30,10 @@ public:
 	    : BinderException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(expr)) {
 	}
 	template <typename... ARGS>
+	explicit BinderException(const Expression &expr, const string &msg, ARGS... params)
+			: BinderException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(expr)) {
+	}
+	template <typename... ARGS>
 	explicit BinderException(QueryErrorContext error_context, const string &msg, ARGS... params)
 	    : BinderException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(error_context)) {
 	}

--- a/src/include/duckdb/common/exception/binder_exception.hpp
+++ b/src/include/duckdb/common/exception/binder_exception.hpp
@@ -31,7 +31,7 @@ public:
 	}
 	template <typename... ARGS>
 	explicit BinderException(const Expression &expr, const string &msg, ARGS... params)
-			: BinderException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(expr)) {
+	    : BinderException(ConstructMessage(msg, params...), Exception::InitializeExtraInfo(expr)) {
 	}
 	template <typename... ARGS>
 	explicit BinderException(QueryErrorContext error_context, const string &msg, ARGS... params)

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -324,8 +324,8 @@ private:
 	BoundStatement BindCopyTo(CopyStatement &stmt);
 	BoundStatement BindCopyFrom(CopyStatement &stmt);
 
-	void BindModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result);
-	void BindModifierTypes(BoundQueryNode &result, const vector<LogicalType> &sql_types, idx_t projection_index);
+	void PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result);
+	void BindModifiers(BoundQueryNode &result, idx_t table_index, const vector<LogicalType> &sql_types, const SelectBindState &bind_state);
 
 	unique_ptr<BoundResultModifier> BindLimit(OrderBinder &order_binder, LimitModifier &limit_mod);
 	unique_ptr<BoundResultModifier> BindLimitPercent(OrderBinder &order_binder, LimitPercentModifier &limit_mod);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -325,7 +325,8 @@ private:
 	BoundStatement BindCopyFrom(CopyStatement &stmt);
 
 	void PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result);
-	void BindModifiers(BoundQueryNode &result, idx_t table_index, const vector<LogicalType> &sql_types, const SelectBindState &bind_state);
+	void BindModifiers(BoundQueryNode &result, idx_t table_index, const vector<LogicalType> &sql_types,
+	                   const SelectBindState &bind_state);
 
 	unique_ptr<BoundResultModifier> BindLimit(OrderBinder &order_binder, LimitModifier &limit_mod);
 	unique_ptr<BoundResultModifier> BindLimitPercent(OrderBinder &order_binder, LimitPercentModifier &limit_mod);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -326,7 +326,7 @@ private:
 
 	void PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result);
 	void BindModifiers(BoundQueryNode &result, idx_t table_index, const vector<string> &names,
-					   const vector<LogicalType> &sql_types, const SelectBindState &bind_state);
+	                   const vector<LogicalType> &sql_types, const SelectBindState &bind_state);
 
 	unique_ptr<BoundResultModifier> BindLimit(OrderBinder &order_binder, LimitModifier &limit_mod);
 	unique_ptr<BoundResultModifier> BindLimitPercent(OrderBinder &order_binder, LimitPercentModifier &limit_mod);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -325,8 +325,7 @@ private:
 	BoundStatement BindCopyFrom(CopyStatement &stmt);
 
 	void BindModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result);
-	void BindModifierTypes(BoundQueryNode &result, const vector<LogicalType> &sql_types, idx_t projection_index,
-	                       const vector<idx_t> &expansion_count = {});
+	void BindModifierTypes(BoundQueryNode &result, const vector<LogicalType> &sql_types, idx_t projection_index);
 
 	unique_ptr<BoundResultModifier> BindLimit(OrderBinder &order_binder, LimitModifier &limit_mod);
 	unique_ptr<BoundResultModifier> BindLimitPercent(OrderBinder &order_binder, LimitPercentModifier &limit_mod);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -325,8 +325,8 @@ private:
 	BoundStatement BindCopyFrom(CopyStatement &stmt);
 
 	void PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result);
-	void BindModifiers(BoundQueryNode &result, idx_t table_index, const vector<LogicalType> &sql_types,
-	                   const SelectBindState &bind_state);
+	void BindModifiers(BoundQueryNode &result, idx_t table_index, const vector<string> &names,
+					   const vector<LogicalType> &sql_types, const SelectBindState &bind_state);
 
 	unique_ptr<BoundResultModifier> BindLimit(OrderBinder &order_binder, LimitModifier &limit_mod);
 	unique_ptr<BoundResultModifier> BindLimitPercent(OrderBinder &order_binder, LimitPercentModifier &limit_mod);

--- a/src/include/duckdb/planner/expression/bound_expanded_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_expanded_expression.hpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/expression/bound_expanded_expression.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/expression.hpp"
+
+namespace duckdb {
+
+//! BoundExpression is an intermediate dummy expression used by the binder.
+//! It holds a set of expressions that will be "expanded" in the select list of a query
+class BoundExpandedExpression : public Expression {
+public:
+	static constexpr const ExpressionClass TYPE = ExpressionClass::BOUND_EXPANDED;
+
+public:
+	explicit BoundExpandedExpression(vector<unique_ptr<Expression>> expanded_expressions);
+
+	vector<unique_ptr<Expression>> expanded_expressions;
+
+public:
+	string ToString() const override;
+
+	bool Equals(const BaseExpression &other) const override;
+
+	unique_ptr<Expression> Copy() override;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -34,6 +34,7 @@ class CatalogEntry;
 class SimpleFunction;
 
 struct DummyBinding;
+struct SelectBindState;
 
 struct BoundColumnReferenceInfo {
 	string name;

--- a/src/include/duckdb/planner/expression_binder/base_select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/base_select_binder.hpp
@@ -28,7 +28,7 @@ struct BoundGroupInformation {
 //! functions.
 class BaseSelectBinder : public ExpressionBinder {
 public:
-	BaseSelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info, bool support_alias_binding = true);
+	BaseSelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
 	bool BoundAggregates() {
 		return bound_aggregate;
@@ -46,23 +46,19 @@ protected:
 
 	bool inside_window;
 	bool bound_aggregate = false;
-	bool support_alias_binding;
 
 	BoundSelectNode &node;
 	BoundGroupInformation &info;
-	const SelectBindState &bind_state;
 
 protected:
-	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth);
 	BindResult BindGroupingFunction(OperatorExpression &op, idx_t depth) override;
 
 	//! Binds a WINDOW expression and returns the result.
-	BindResult BindWindow(WindowExpression &expr, idx_t depth);
+	virtual BindResult BindWindow(WindowExpression &expr, idx_t depth);
+	virtual BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression);
 
 	idx_t TryBindGroup(ParsedExpression &expr);
 	BindResult BindGroup(ParsedExpression &expr, idx_t depth, idx_t group_index);
-
-	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/base_select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/base_select_binder.hpp
@@ -28,9 +28,7 @@ struct BoundGroupInformation {
 //! functions.
 class BaseSelectBinder : public ExpressionBinder {
 public:
-	BaseSelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-	                 case_insensitive_map_t<idx_t> alias_map);
-	BaseSelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
+	BaseSelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info, bool support_alias_binding = true);
 
 	bool BoundAggregates() {
 		return bound_aggregate;
@@ -48,10 +46,11 @@ protected:
 
 	bool inside_window;
 	bool bound_aggregate = false;
+	bool support_alias_binding;
 
 	BoundSelectNode &node;
 	BoundGroupInformation &info;
-	case_insensitive_map_t<idx_t> alias_map;
+	const SelectBindState &bind_state;
 
 protected:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth);

--- a/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
@@ -13,20 +13,19 @@
 
 namespace duckdb {
 
-class BoundSelectNode;
 class ColumnRefExpression;
+struct SelectBindState;
 
 //! A helper binder for WhereBinder and HavingBinder which support alias as a columnref.
 class ColumnAliasBinder {
 public:
-	ColumnAliasBinder(BoundSelectNode &node, const case_insensitive_map_t<idx_t> &alias_map);
+	explicit ColumnAliasBinder(const SelectBindState &bind_state);
 
 	bool BindAlias(ExpressionBinder &enclosing_binder, unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
 	               bool root_expression, BindResult &result);
 
 private:
-	BoundSelectNode &node;
-	const case_insensitive_map_t<idx_t> &alias_map;
+	const SelectBindState &bind_state;
 	unordered_set<idx_t> visited_select_indexes;
 };
 

--- a/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
@@ -19,13 +19,13 @@ struct SelectBindState;
 //! A helper binder for WhereBinder and HavingBinder which support alias as a columnref.
 class ColumnAliasBinder {
 public:
-	explicit ColumnAliasBinder(const SelectBindState &bind_state);
+	explicit ColumnAliasBinder(SelectBindState &bind_state);
 
 	bool BindAlias(ExpressionBinder &enclosing_binder, unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
 	               bool root_expression, BindResult &result);
 
 private:
-	const SelectBindState &bind_state;
+	SelectBindState &bind_state;
 	unordered_set<idx_t> visited_select_indexes;
 };
 

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -14,12 +14,13 @@
 namespace duckdb {
 class ConstantExpression;
 class ColumnRefExpression;
+struct SelectBindState;
 
 //! The GROUP binder is responsible for binding expressions in the GROUP BY clause
 class GroupBinder : public ExpressionBinder {
 public:
 	GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
-	            case_insensitive_map_t<idx_t> &alias_map, case_insensitive_map_t<idx_t> &group_alias_map);
+	            const SelectBindState &bind_state, case_insensitive_map_t<idx_t> &group_alias_map);
 
 	//! The unbound root expression
 	unique_ptr<ParsedExpression> unbound_expression;
@@ -36,7 +37,7 @@ protected:
 	BindResult BindConstant(ConstantExpression &expr);
 
 	SelectNode &node;
-	case_insensitive_map_t<idx_t> &alias_map;
+	const SelectBindState &bind_state;
 	case_insensitive_map_t<idx_t> &group_alias_map;
 	unordered_set<idx_t> used_aliases;
 

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -20,7 +20,7 @@ struct SelectBindState;
 class GroupBinder : public ExpressionBinder {
 public:
 	GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
-	            const SelectBindState &bind_state, case_insensitive_map_t<idx_t> &group_alias_map);
+	            SelectBindState &bind_state, case_insensitive_map_t<idx_t> &group_alias_map);
 
 	//! The unbound root expression
 	unique_ptr<ParsedExpression> unbound_expression;
@@ -37,7 +37,7 @@ protected:
 	BindResult BindConstant(ConstantExpression &expr);
 
 	SelectNode &node;
-	const SelectBindState &bind_state;
+	SelectBindState &bind_state;
 	case_insensitive_map_t<idx_t> &group_alias_map;
 	unordered_set<idx_t> used_aliases;
 

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 class HavingBinder : public BaseSelectBinder {
 public:
 	HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-	             const SelectBindState &bind_state, AggregateHandling aggregate_handling);
+	             AggregateHandling aggregate_handling);
 
 protected:
 	BindResult BindWindow(WindowExpression &expr, idx_t depth) override;

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -21,12 +21,9 @@ public:
 	             const SelectBindState &bind_state, AggregateHandling aggregate_handling);
 
 protected:
-	BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
-	                          bool root_expression = false) override;
-
+	BindResult BindWindow(WindowExpression &expr, idx_t depth) override;
+	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 private:
-	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression);
-
 	ColumnAliasBinder column_alias_binder;
 	AggregateHandling aggregate_handling;
 };

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -23,6 +23,7 @@ public:
 protected:
 	BindResult BindWindow(WindowExpression &expr, idx_t depth) override;
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
+
 private:
 	ColumnAliasBinder column_alias_binder;
 	AggregateHandling aggregate_handling;

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 class HavingBinder : public BaseSelectBinder {
 public:
 	HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-	             case_insensitive_map_t<idx_t> &alias_map, AggregateHandling aggregate_handling);
+	             const SelectBindState &bind_state, AggregateHandling aggregate_handling);
 
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,

--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -22,15 +22,12 @@ struct SelectBindState;
 //! The ORDER binder is responsible for binding an expression within the ORDER BY clause of a SQL statement
 class OrderBinder {
 public:
-	OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectBindState &bind_state, idx_t max_count);
-	OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectNode &node, SelectBindState &bind_state);
+	OrderBinder(vector<Binder *> binders, SelectBindState &bind_state);
+	OrderBinder(vector<Binder *> binders, SelectNode &node, SelectBindState &bind_state);
 
 public:
 	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> expr);
 
-	idx_t MaxCount() const {
-		return max_count;
-	}
 	bool HasExtraList() const {
 		return extra_list;
 	}
@@ -46,9 +43,7 @@ private:
 
 private:
 	vector<Binder *> binders;
-	idx_t projection_index;
-	idx_t max_count;
-	vector<unique_ptr<ParsedExpression>> *extra_list;
+	optional_ptr<vector<unique_ptr<ParsedExpression>>> extra_list;
 	SelectBindState &bind_state;
 };
 

--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -17,14 +17,13 @@ namespace duckdb {
 class Binder;
 class Expression;
 class SelectNode;
+struct SelectBindState;
 
 //! The ORDER binder is responsible for binding an expression within the ORDER BY clause of a SQL statement
 class OrderBinder {
 public:
-	OrderBinder(vector<Binder *> binders, idx_t projection_index, case_insensitive_map_t<idx_t> &alias_map,
-	            parsed_expression_map_t<idx_t> &projection_map, idx_t max_count);
-	OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectNode &node,
-	            case_insensitive_map_t<idx_t> &alias_map, parsed_expression_map_t<idx_t> &projection_map);
+	OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectBindState &bind_state, idx_t max_count);
+	OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectNode &node, SelectBindState &bind_state);
 
 public:
 	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> expr);
@@ -50,8 +49,7 @@ private:
 	idx_t projection_index;
 	idx_t max_count;
 	vector<unique_ptr<ParsedExpression>> *extra_list;
-	case_insensitive_map_t<idx_t> &alias_map;
-	parsed_expression_map_t<idx_t> &projection_map;
+	SelectBindState &bind_state;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -42,8 +42,7 @@ public:
 	unique_ptr<Expression> CreateExtraReference(unique_ptr<ParsedExpression> expr);
 
 private:
-	unique_ptr<Expression> CreateProjectionReference(ParsedExpression &expr, const idx_t index,
-	                                                 const LogicalType &logical_type);
+	unique_ptr<Expression> CreateProjectionReference(ParsedExpression &expr, const idx_t index);
 	unique_ptr<Expression> BindConstant(ParsedExpression &expr, const Value &val);
 
 private:

--- a/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
@@ -17,8 +17,7 @@ struct SelectBindState;
 //! The QUALIFY binder is responsible for binding an expression within the QUALIFY clause of a SQL statement
 class QualifyBinder : public BaseSelectBinder {
 public:
-	QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-				  const SelectBindState &bind_state);
+	QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
 protected:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;

--- a/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
@@ -12,12 +12,13 @@
 #include "duckdb/planner/expression_binder/column_alias_binder.hpp"
 
 namespace duckdb {
+struct SelectBindState;
 
 //! The QUALIFY binder is responsible for binding an expression within the QUALIFY clause of a SQL statement
 class QualifyBinder : public BaseSelectBinder {
 public:
 	QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-	              case_insensitive_map_t<idx_t> &alias_map);
+				  const SelectBindState &bind_state);
 
 protected:
 	BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,

--- a/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/qualify_binder.hpp
@@ -21,12 +21,9 @@ public:
 				  const SelectBindState &bind_state);
 
 protected:
-	BindResult BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
-	                          bool root_expression = false) override;
+	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 
 private:
-	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression);
-
 	ColumnAliasBinder column_alias_binder;
 };
 

--- a/src/include/duckdb/planner/expression_binder/select_bind_state.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_bind_state.hpp
@@ -28,6 +28,19 @@ struct SelectBindState {
 
 public:
 	unique_ptr<ParsedExpression> BindAlias(idx_t index);
+
+	void SetExpressionIsVolatile(idx_t index);
+	void SetExpressionHasSubquery(idx_t index);
+
+	bool AliasHasSubquery(idx_t index);
+
+private:
+	//! The set of referenced aliases
+	unordered_set<idx_t> referenced_aliases;
+	//! The set of expressions that is volatile
+	unordered_set<idx_t> volatile_expressions;
+	//! The set of expressions that contains a subquery
+	unordered_set<idx_t> subquery_expressions;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/select_bind_state.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_bind_state.hpp
@@ -34,6 +34,9 @@ public:
 
 	bool AliasHasSubquery(idx_t index);
 
+	void AddExpandedColumn(idx_t expand_count);
+	void AddRegularColumn();
+
 private:
 	//! The set of referenced aliases
 	unordered_set<idx_t> referenced_aliases;

--- a/src/include/duckdb/planner/expression_binder/select_bind_state.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_bind_state.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/planner/select_bind_state.hpp
+// duckdb/planner/expression_binder/select_bind_state.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -25,6 +25,9 @@ struct SelectBindState {
 	//! The original unparsed expressions. This is exported after binding, because the binding might change the
 	//! expressions (e.g. when a * clause is present)
 	vector<unique_ptr<ParsedExpression>> original_expressions;
+
+public:
+	unique_ptr<ParsedExpression> BindAlias(idx_t index);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/select_bind_state.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_bind_state.hpp
@@ -32,10 +32,11 @@ public:
 	void SetExpressionIsVolatile(idx_t index);
 	void SetExpressionHasSubquery(idx_t index);
 
-	bool AliasHasSubquery(idx_t index);
+	bool AliasHasSubquery(idx_t index) const;
 
 	void AddExpandedColumn(idx_t expand_count);
 	void AddRegularColumn();
+	idx_t GetFinalIndex(idx_t index) const;
 
 private:
 	//! The set of referenced aliases
@@ -44,6 +45,8 @@ private:
 	unordered_set<idx_t> volatile_expressions;
 	//! The set of expressions that contains a subquery
 	unordered_set<idx_t> subquery_expressions;
+	//! Column indices after expansion of Expanded expressions (e.g. UNNEST(STRUCT) clauses)
+	vector<idx_t> expanded_column_indices;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -15,8 +15,6 @@ namespace duckdb {
 //! The SELECT binder is responsible for binding an expression within the SELECT clause of a SQL statement
 class SelectBinder : public BaseSelectBinder {
 public:
-	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-	             case_insensitive_map_t<idx_t> alias_map);
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
 protected:

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -19,18 +19,10 @@ public:
 	             case_insensitive_map_t<idx_t> alias_map);
 	SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info);
 
-	bool HasExpandedExpressions() {
-		return !expanded_expressions.empty();
-	}
-	vector<unique_ptr<Expression>> &ExpandedExpressions() {
-		return expanded_expressions;
-	}
-
 protected:
 	BindResult BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) override;
 
 	idx_t unnest_level = 0;
-	vector<unique_ptr<Expression>> expanded_expressions;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -19,7 +19,11 @@ public:
 
 protected:
 	BindResult BindUnnest(FunctionExpression &function, idx_t depth, bool root_expression) override;
+	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 
+	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
+
+protected:
 	idx_t unnest_level = 0;
 };
 

--- a/src/include/duckdb/planner/query_node/bound_select_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_select_node.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/planner/bound_tableref.hpp"
 #include "duckdb/parser/parsed_data/sample_options.hpp"
 #include "duckdb/parser/group_by_node.hpp"
+#include "duckdb/planner/select_bind_state.hpp"
 
 namespace duckdb {
 
@@ -41,10 +42,8 @@ public:
 	BoundSelectNode() : BoundQueryNode(QueryNodeType::SELECT_NODE) {
 	}
 
-	//! The original unparsed expressions. This is exported after binding, because the binding might change the
-	//! expressions (e.g. when a * clause is present)
-	vector<unique_ptr<ParsedExpression>> original_expressions;
-
+	//! Bind information
+	SelectBindState bind_state;
 	//! The projection list
 	vector<unique_ptr<Expression>> select_list;
 	//! The FROM clause

--- a/src/include/duckdb/planner/query_node/bound_select_node.hpp
+++ b/src/include/duckdb/planner/query_node/bound_select_node.hpp
@@ -14,7 +14,7 @@
 #include "duckdb/planner/bound_tableref.hpp"
 #include "duckdb/parser/parsed_data/sample_options.hpp"
 #include "duckdb/parser/group_by_node.hpp"
-#include "duckdb/planner/select_bind_state.hpp"
+#include "duckdb/planner/expression_binder/select_bind_state.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/planner/select_bind_state.hpp
+++ b/src/include/duckdb/planner/select_bind_state.hpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/select_bind_state.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/bound_query_node.hpp"
+#include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/parser/expression_map.hpp"
+#include "duckdb/planner/bound_tableref.hpp"
+#include "duckdb/parser/parsed_data/sample_options.hpp"
+#include "duckdb/parser/group_by_node.hpp"
+
+namespace duckdb {
+
+//! Bind state during a SelectNode
+struct SelectBindState {
+	// Mapping of (alias -> index) and a mapping of (Expression -> index) for the SELECT list
+	case_insensitive_map_t<idx_t> alias_map;
+	parsed_expression_map_t<idx_t> projection_map;
+	//! The original unparsed expressions. This is exported after binding, because the binding might change the
+	//! expressions (e.g. when a * clause is present)
+	vector<unique_ptr<ParsedExpression>> original_expressions;
+};
+
+} // namespace duckdb

--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_expanded_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/expression_binder/aggregate_binder.hpp"
@@ -224,8 +225,7 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 				break;
 			}
 		}
-		expanded_expressions = std::move(struct_expressions);
-		unnest_expr = make_uniq<BoundConstantExpression>(Value(42));
+		unnest_expr = make_uniq<BoundExpandedExpression>(std::move(struct_expressions));
 	}
 	return BindResult(std::move(unnest_expr));
 }

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -26,7 +26,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
-#include "duckdb/planner/select_bind_state.hpp"
+#include "duckdb/planner/expression_binder/select_bind_state.hpp"
 
 namespace duckdb {
 
@@ -448,7 +448,7 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 
 	// bind the HAVING clause, if any
 	if (statement.having) {
-		HavingBinder having_binder(*this, context, *result, info, bind_state, statement.aggregate_handling);
+		HavingBinder having_binder(*this, context, *result, info, statement.aggregate_handling);
 		ExpressionBinder::QualifyColumnNames(*this, statement.having);
 		result->having = having_binder.Bind(statement.having);
 	}
@@ -459,7 +459,7 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 		if (statement.aggregate_handling == AggregateHandling::FORCE_AGGREGATES) {
 			throw BinderException("Combining QUALIFY with GROUP BY ALL is not supported yet");
 		}
-		qualify_binder = make_uniq<QualifyBinder>(*this, context, *result, info, bind_state);
+		qualify_binder = make_uniq<QualifyBinder>(*this, context, *result, info);
 		ExpressionBinder::QualifyColumnNames(*this, statement.qualify);
 		result->qualify = qualify_binder->Bind(statement.qualify);
 		if (qualify_binder->HasBoundColumns() && qualify_binder->BoundAggregates()) {

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -507,6 +507,13 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 			continue;
 		}
 
+		if (expr->IsVolatile()) {
+			result->bind_state.SetExpressionIsVolatile(i);
+		}
+		if (expr->HasSubquery()) {
+			result->bind_state.SetExpressionHasSubquery(i);
+		}
+
 		if (can_group_by_all && select_binder.HasBoundColumns()) {
 			if (select_binder.BoundAggregates()) {
 				throw BinderException("Cannot mix aggregates with non-aggregated columns!");

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -244,8 +244,7 @@ static void AssignReturnType(unique_ptr<Expression> &expr, const vector<LogicalT
 	bound_colref.return_type = sql_types[bound_colref.binding.column_index];
 }
 
-void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType> &sql_types, idx_t,
-                               const vector<idx_t> &expansion_count) {
+void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType> &sql_types, idx_t) {
 	for (auto &bound_mod : result.modifiers) {
 		switch (bound_mod->type) {
 		case ResultModifierType::DISTINCT_MODIFIER: {
@@ -258,13 +257,6 @@ void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType>
 				if (bound_colref.binding.column_index == DConstants::INVALID_INDEX) {
 					throw BinderException("Ambiguous name in DISTINCT ON!");
 				}
-
-				idx_t max_count = sql_types.size();
-				if (bound_colref.binding.column_index > max_count - 1) {
-					D_ASSERT(bound_colref.return_type == LogicalType::ANY);
-					throw BinderException("ORDER term out of range - should be between 1 and %lld", max_count);
-				}
-
 				bound_colref.return_type = sql_types[bound_colref.binding.column_index];
 			}
 			for (auto &target_distinct : distinct.target_distincts) {
@@ -281,7 +273,6 @@ void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType>
 			break;
 		}
 		case ResultModifierType::ORDER_MODIFIER: {
-
 			auto &order = bound_mod->Cast<BoundOrderModifier>();
 			for (auto &order_node : order.orders) {
 
@@ -291,17 +282,6 @@ void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType>
 				if (bound_colref.binding.column_index == DConstants::INVALID_INDEX) {
 					throw BinderException("Ambiguous name in ORDER BY!");
 				}
-
-				if (!expansion_count.empty() && bound_colref.return_type.id() != LogicalTypeId::ANY) {
-					bound_colref.binding.column_index = expansion_count[bound_colref.binding.column_index];
-				}
-
-				idx_t max_count = sql_types.size();
-				if (bound_colref.binding.column_index > max_count - 1) {
-					D_ASSERT(bound_colref.return_type == LogicalType::ANY);
-					throw BinderException("ORDER term out of range - should be between 1 and %lld", max_count);
-				}
-
 				const auto &sql_type = sql_types[bound_colref.binding.column_index];
 				bound_colref.return_type = sql_type;
 
@@ -492,11 +472,9 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 
 	// if we expand select-list expressions, e.g., via UNNEST, then we need to possibly
 	// adjust the column index of the already bound ORDER BY modifiers, and not only set their types
-	vector<LogicalType> modifier_sql_types;
-	vector<idx_t> modifier_expansion_count;
-
 	vector<idx_t> group_by_all_indexes;
 	vector<string> new_names;
+	vector<LogicalType> internal_sql_types;
 
 	for (idx_t i = 0; i < statement.select_list.size(); i++) {
 		bool is_window = statement.select_list[i]->IsWindow();
@@ -518,22 +496,17 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 
 			auto &struct_expressions = select_binder.ExpandedExpressions();
 			D_ASSERT(!struct_expressions.empty());
-			modifier_expansion_count.push_back(modifier_sql_types.size());
 
 			for (auto &struct_expr : struct_expressions) {
-				modifier_sql_types.push_back(struct_expr->return_type);
 				new_names.push_back(struct_expr->GetName());
 				result->types.push_back(struct_expr->return_type);
+				internal_sql_types.push_back(struct_expr->return_type);
 				result->select_list.push_back(std::move(struct_expr));
 			}
 
 			struct_expressions.clear();
 			continue;
 		}
-
-		// not an expanded expression
-		modifier_expansion_count.push_back(modifier_sql_types.size());
-		modifier_sql_types.push_back(result_type);
 
 		if (can_group_by_all && select_binder.HasBoundColumns()) {
 			if (select_binder.BoundAggregates()) {
@@ -555,6 +528,7 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 			new_names.push_back(std::move(result->names[i]));
 			result->types.push_back(result_type);
 		}
+		internal_sql_types.push_back(result_type);
 
 		if (can_group_by_all) {
 			select_binder.ResetBindings();
@@ -617,7 +591,7 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 	}
 
 	// now that the SELECT list is bound, we set the types of DISTINCT/ORDER BY expressions
-	BindModifierTypes(*result, modifier_sql_types, result->projection_index, modifier_expansion_count);
+	BindModifierTypes(*result, internal_sql_types, result->projection_index);
 	return std::move(result);
 }
 

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -231,13 +231,13 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 	}
 }
 
-unique_ptr<Expression> CreateOrderExpression(unique_ptr<Expression> expr, const vector<string> &names, const vector<LogicalType> &sql_types,
-                                             idx_t table_index, idx_t index) {
+unique_ptr<Expression> CreateOrderExpression(unique_ptr<Expression> expr, const vector<string> &names,
+                                             const vector<LogicalType> &sql_types, idx_t table_index, idx_t index) {
 	if (index >= sql_types.size()) {
 		throw BinderException(*expr, "ORDER term out of range - should be between 1 and %lld", sql_types.size());
 	}
 	auto result = make_uniq<BoundColumnRefExpression>(std::move(expr->alias), sql_types[index],
-	                                           ColumnBinding(table_index, index));
+	                                                  ColumnBinding(table_index, index));
 	if (result->alias.empty() && index < names.size()) {
 		result->alias = names[index];
 	}
@@ -245,8 +245,7 @@ unique_ptr<Expression> CreateOrderExpression(unique_ptr<Expression> expr, const 
 }
 
 unique_ptr<Expression> FinalizeBindOrderExpression(unique_ptr<Expression> expr, idx_t table_index,
-												   const vector<string> &names,
-                                                   const vector<LogicalType> &sql_types,
+                                                   const vector<string> &names, const vector<LogicalType> &sql_types,
                                                    const SelectBindState &bind_state) {
 	auto &constant = expr->Cast<BoundConstantExpression>();
 	switch (constant.value.type().id()) {
@@ -284,10 +283,8 @@ unique_ptr<Expression> FinalizeBindOrderExpression(unique_ptr<Expression> expr, 
 	}
 }
 
-static void AssignReturnType(unique_ptr<Expression> &expr, idx_t table_index,
-							 const vector<string> &names,
-							 const vector<LogicalType> &sql_types,
-							 const SelectBindState &bind_state) {
+static void AssignReturnType(unique_ptr<Expression> &expr, idx_t table_index, const vector<string> &names,
+                             const vector<LogicalType> &sql_types, const SelectBindState &bind_state) {
 	if (!expr) {
 		return;
 	}
@@ -302,7 +299,7 @@ static void AssignReturnType(unique_ptr<Expression> &expr, idx_t table_index,
 }
 
 void Binder::BindModifiers(BoundQueryNode &result, idx_t table_index, const vector<string> &names,
-						   const vector<LogicalType> &sql_types, const SelectBindState &bind_state) {
+                           const vector<LogicalType> &sql_types, const SelectBindState &bind_state) {
 	for (auto &bound_mod : result.modifiers) {
 		switch (bound_mod->type) {
 		case ResultModifierType::DISTINCT_MODIFIER: {

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -552,7 +552,7 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 
 		if (expr->type == ExpressionType::BOUND_EXPANDED) {
 			if (!is_original_column) {
-				throw InternalException("Only original columns can have expanded expressions");
+				throw BinderException("UNNEST of struct cannot be used in ORDER BY/DISTINCT ON clause");
 			}
 			if (statement.aggregate_handling == AggregateHandling::FORCE_AGGREGATES) {
 				throw BinderException("UNNEST of struct cannot be combined with GROUP BY ALL");

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -9,12 +9,12 @@
 #include "duckdb/planner/expression_binder/order_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/planner/query_node/bound_set_operation_node.hpp"
+#include "duckdb/planner/select_bind_state.hpp"
 #include "duckdb/common/enum_util.hpp"
 
 namespace duckdb {
 
-static void GatherAliases(BoundQueryNode &node, case_insensitive_map_t<idx_t> &aliases,
-                          parsed_expression_map_t<idx_t> &expressions, const vector<idx_t> &reorder_idx) {
+static void GatherAliases(BoundQueryNode &node, SelectBindState &bind_state, const vector<idx_t> &reorder_idx) {
 	if (node.type == QueryNodeType::SET_OPERATION_NODE) {
 		// setop, recurse
 		auto &setop = node.Cast<BoundSetOperationNode>();
@@ -32,13 +32,13 @@ static void GatherAliases(BoundQueryNode &node, case_insensitive_map_t<idx_t> &a
 			}
 
 			// use new reorder index
-			GatherAliases(*setop.left, aliases, expressions, new_left_reorder_idx);
-			GatherAliases(*setop.right, aliases, expressions, new_right_reorder_idx);
+			GatherAliases(*setop.left, bind_state, new_left_reorder_idx);
+			GatherAliases(*setop.right, bind_state, new_right_reorder_idx);
 			return;
 		}
 
-		GatherAliases(*setop.left, aliases, expressions, reorder_idx);
-		GatherAliases(*setop.right, aliases, expressions, reorder_idx);
+		GatherAliases(*setop.left, bind_state, reorder_idx);
+		GatherAliases(*setop.right, bind_state, reorder_idx);
 	} else {
 		// query node
 		D_ASSERT(node.type == QueryNodeType::SELECT_NODE);
@@ -46,27 +46,27 @@ static void GatherAliases(BoundQueryNode &node, case_insensitive_map_t<idx_t> &a
 		// fill the alias lists
 		for (idx_t i = 0; i < select.names.size(); i++) {
 			auto &name = select.names[i];
-			auto &expr = select.original_expressions[i];
+			auto &expr = select.bind_state.original_expressions[i];
 			// first check if the alias is already in there
-			auto entry = aliases.find(name);
+			auto entry = bind_state.alias_map.find(name);
 
 			idx_t index = reorder_idx[i];
 
-			if (entry == aliases.end()) {
+			if (entry == bind_state.alias_map.end()) {
 				// the alias is not in there yet, just assign it
-				aliases[name] = index;
+				bind_state.alias_map[name] = index;
 			}
 			// now check if the node is already in the set of expressions
-			auto expr_entry = expressions.find(*expr);
-			if (expr_entry != expressions.end()) {
+			auto expr_entry = bind_state.projection_map.find(*expr);
+			if (expr_entry != bind_state.projection_map.end()) {
 				// the node is in there
 				// repeat the same as with the alias: if there is an ambiguity we insert "-1"
 				if (expr_entry->second != index) {
-					expressions[*expr] = DConstants::INVALID_INDEX;
+					bind_state.projection_map[*expr] = DConstants::INVALID_INDEX;
 				}
 			} else {
 				// not in there yet, just place it in there
-				expressions[*expr] = index;
+				bind_state.projection_map[*expr] = index;
 			}
 		}
 	}
@@ -230,22 +230,21 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SetOperationNode &statement) {
 
 		// we recursively visit the children of this node to extract aliases and expressions that can be referenced
 		// in the ORDER BY
-		case_insensitive_map_t<idx_t> alias_map;
-		parsed_expression_map_t<idx_t> expression_map;
+		SelectBindState bind_state;
 
 		if (result->setop_type == SetOperationType::UNION_BY_NAME) {
-			GatherAliases(*result->left, alias_map, expression_map, result->left_reorder_idx);
-			GatherAliases(*result->right, alias_map, expression_map, result->right_reorder_idx);
+			GatherAliases(*result->left, bind_state, result->left_reorder_idx);
+			GatherAliases(*result->right, bind_state, result->right_reorder_idx);
 		} else {
 			vector<idx_t> reorder_idx;
 			for (idx_t i = 0; i < result->names.size(); i++) {
 				reorder_idx.push_back(i);
 			}
-			GatherAliases(*result, alias_map, expression_map, reorder_idx);
+			GatherAliases(*result, bind_state, reorder_idx);
 		}
 		// now we perform the actual resolution of the ORDER BY/DISTINCT expressions
 		OrderBinder order_binder({result->left_binder.get(), result->right_binder.get()}, result->setop_index,
-		                         alias_map, expression_map, result->names.size());
+								 bind_state, result->names.size());
 		BindModifiers(order_binder, statement, *result);
 	}
 

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -43,10 +43,9 @@ static void GatherAliases(BoundQueryNode &node, SelectBindState &bind_state, con
 		// query node
 		D_ASSERT(node.type == QueryNodeType::SELECT_NODE);
 		auto &select = node.Cast<BoundSelectNode>();
-		// fill the alias lists
+		// fill the alias lists with the names
 		for (idx_t i = 0; i < select.names.size(); i++) {
 			auto &name = select.names[i];
-			auto &expr = select.bind_state.original_expressions[i];
 			// first check if the alias is already in there
 			auto entry = bind_state.alias_map.find(name);
 
@@ -56,6 +55,11 @@ static void GatherAliases(BoundQueryNode &node, SelectBindState &bind_state, con
 				// the alias is not in there yet, just assign it
 				bind_state.alias_map[name] = index;
 			}
+		}
+		// check if the expression matches one of the expressions in the original expression liset
+		for (idx_t i = 0; i < select.bind_state.original_expressions.size(); i++) {
+			auto &expr = select.bind_state.original_expressions[i];
+			idx_t index = reorder_idx[i];
 			// now check if the node is already in the set of expressions
 			auto expr_entry = bind_state.projection_map.find(*expr);
 			if (expr_entry != bind_state.projection_map.end()) {

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -244,7 +244,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SetOperationNode &statement) {
 		}
 		// now we perform the actual resolution of the ORDER BY/DISTINCT expressions
 		OrderBinder order_binder({result->left_binder.get(), result->right_binder.get()}, result->setop_index,
-								 bind_state, result->names.size());
+		                         bind_state, result->names.size());
 		BindModifiers(order_binder, statement, *result);
 	}
 

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/planner/expression_binder/order_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/planner/query_node/bound_set_operation_node.hpp"
-#include "duckdb/planner/select_bind_state.hpp"
+#include "duckdb/planner/expression_binder/select_bind_state.hpp"
 #include "duckdb/common/enum_util.hpp"
 
 namespace duckdb {

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -248,7 +248,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SetOperationNode &statement) {
 	}
 
 	// finally bind the types of the ORDER/DISTINCT clause expressions
-	BindModifiers(*result, result->setop_index, result->types, bind_state);
+	BindModifiers(*result, result->setop_index, result->names, result->types, bind_state);
 	return std::move(result);
 }
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -42,7 +42,7 @@
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/function/table/table_scan.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
-#include "duckdb/planner/select_bind_state.hpp"
+#include "duckdb/planner/expression_binder/select_bind_state.hpp"
 
 namespace duckdb {
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -42,6 +42,7 @@
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/function/table/table_scan.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
+#include "duckdb/planner/select_bind_state.hpp"
 
 namespace duckdb {
 
@@ -184,11 +185,10 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 
 	// bind it to verify the function was defined correctly
 	ErrorData error;
-	auto sel_node = make_uniq<BoundSelectNode>();
-	auto group_info = make_uniq<BoundGroupInformation>();
-	SelectBinder binder(*this, context, *sel_node, *group_info);
+	BoundSelectNode sel_node;
+	BoundGroupInformation group_info;
+	SelectBinder binder(*this, context, sel_node, group_info);
 	error = binder.Bind(expression, 0, false);
-
 	if (error.HasError()) {
 		error.Throw();
 	}

--- a/src/planner/expression/CMakeLists.txt
+++ b/src/planner/expression/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   bound_comparison_expression.cpp
   bound_conjunction_expression.cpp
   bound_constant_expression.cpp
+  bound_expanded_expression.cpp
   bound_function_expression.cpp
   bound_lambda_expression.cpp
   bound_lambdaref_expression.cpp

--- a/src/planner/expression/bound_expanded_expression.cpp
+++ b/src/planner/expression/bound_expanded_expression.cpp
@@ -1,0 +1,23 @@
+#include "duckdb/planner/expression/bound_expanded_expression.hpp"
+
+
+namespace duckdb {
+
+BoundExpandedExpression::BoundExpandedExpression(vector<unique_ptr<Expression>> expanded_expressions_p)
+	: Expression(ExpressionType::BOUND_EXPANDED, ExpressionClass::BOUND_EXPANDED, LogicalType::INTEGER),
+	  expanded_expressions(std::move(expanded_expressions_p)) {
+}
+
+string BoundExpandedExpression::ToString() const {
+	return "BOUND_EXPANDED";
+}
+
+bool BoundExpandedExpression::Equals(const BaseExpression &other_p) const {
+	return false;
+}
+
+unique_ptr<Expression> BoundExpandedExpression::Copy() {
+	throw SerializationException("Cannot copy BoundExpandedExpression");
+}
+
+} // namespace duckdb

--- a/src/planner/expression/bound_expanded_expression.cpp
+++ b/src/planner/expression/bound_expanded_expression.cpp
@@ -1,11 +1,10 @@
 #include "duckdb/planner/expression/bound_expanded_expression.hpp"
 
-
 namespace duckdb {
 
 BoundExpandedExpression::BoundExpandedExpression(vector<unique_ptr<Expression>> expanded_expressions_p)
-	: Expression(ExpressionType::BOUND_EXPANDED, ExpressionClass::BOUND_EXPANDED, LogicalType::INTEGER),
-	  expanded_expressions(std::move(expanded_expressions_p)) {
+    : Expression(ExpressionType::BOUND_EXPANDED, ExpressionClass::BOUND_EXPANDED, LogicalType::INTEGER),
+      expanded_expressions(std::move(expanded_expressions_p)) {
 }
 
 string BoundExpandedExpression::ToString() const {

--- a/src/planner/expression_binder/CMakeLists.txt
+++ b/src/planner/expression_binder/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library_unity(
   relation_binder.cpp
   returning_binder.cpp
   select_binder.cpp
+  select_bind_state.cpp
   table_function_binder.cpp
   update_binder.cpp
   where_binder.cpp)

--- a/src/planner/expression_binder/base_select_binder.cpp
+++ b/src/planner/expression_binder/base_select_binder.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression_binder/aggregate_binder.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
-#include "duckdb/planner/select_bind_state.hpp"
+#include "duckdb/planner/expression_binder/select_bind_state.hpp"
 
 namespace duckdb {
 

--- a/src/planner/expression_binder/base_select_binder.cpp
+++ b/src/planner/expression_binder/base_select_binder.cpp
@@ -13,8 +13,8 @@
 namespace duckdb {
 
 BaseSelectBinder::BaseSelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node,
-                                   BoundGroupInformation &info, bool support_alias_binding)
-    : ExpressionBinder(binder, context), inside_window(false), support_alias_binding(support_alias_binding), node(node), info(info), bind_state(node.bind_state) {
+                                   BoundGroupInformation &info)
+    : ExpressionBinder(binder, context), inside_window(false), node(node), info(info) {
 }
 
 BindResult BaseSelectBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
@@ -26,7 +26,7 @@ BindResult BaseSelectBinder::BindExpression(unique_ptr<ParsedExpression> &expr_p
 	}
 	switch (expr.expression_class) {
 	case ExpressionClass::COLUMN_REF:
-		return BindColumnRef(expr_ptr, depth);
+		return BindColumnRef(expr_ptr, depth, root_expression);
 	case ExpressionClass::DEFAULT:
 		return BindResult("SELECT clause cannot contain DEFAULT clause");
 	case ExpressionClass::WINDOW:
@@ -63,42 +63,8 @@ idx_t BaseSelectBinder::TryBindGroup(ParsedExpression &expr) {
 	return DConstants::INVALID_INDEX;
 }
 
-BindResult BaseSelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth) {
-	// first try to bind the column reference regularly
-	auto result = ExpressionBinder::BindExpression(expr_ptr, depth);
-	if (!result.HasError()) {
-		return result;
-	}
-	// binding failed
-	// check in the alias map
-	auto &colref = (expr_ptr.get())->Cast<ColumnRefExpression>();
-	if (!colref.IsQualified() && support_alias_binding) {
-		auto alias_entry = bind_state.alias_map.find(colref.column_names[0]);
-		if (alias_entry != bind_state.alias_map.end()) {
-			// found entry!
-			auto index = alias_entry->second;
-			if (index >= node.bound_column_count) {
-				throw BinderException("Column \"%s\" referenced that exists in the SELECT clause - but this column "
-				                      "cannot be referenced before it is defined",
-				                      colref.column_names[0]);
-			}
-			if (node.select_list[index]->IsVolatile()) {
-				throw BinderException("Alias \"%s\" referenced in a SELECT clause - but the expression has side "
-				                      "effects. This is not yet supported.",
-				                      colref.column_names[0]);
-			}
-			if (node.select_list[index]->HasSubquery()) {
-				throw BinderException("Alias \"%s\" referenced in a SELECT clause - but the expression has a subquery."
-				                      " This is not yet supported.",
-				                      colref.column_names[0]);
-			}
-			auto copied_expression = node.bind_state.original_expressions[index]->Copy();
-			result = BindExpression(copied_expression, depth, false);
-			return result;
-		}
-	}
-	// entry was not found in the alias map: return the original error
-	return result;
+BindResult BaseSelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
+	return ExpressionBinder::BindExpression(expr_ptr, depth);
 }
 
 BindResult BaseSelectBinder::BindGroupingFunction(OperatorExpression &op, idx_t depth) {
@@ -139,13 +105,6 @@ BindResult BaseSelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, idx_
 		return BindResult(make_uniq<BoundColumnRefExpression>(expr.GetName(), group->return_type,
 		                                                      ColumnBinding(node.group_index, group_index), depth));
 	}
-}
-
-bool BaseSelectBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
-	if (!colref.IsQualified() && support_alias_binding) {
-		return bind_state.alias_map.find(colref.column_names[0]) != bind_state.alias_map.end();
-	}
-	return false;
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -8,8 +8,7 @@
 
 namespace duckdb {
 
-ColumnAliasBinder::ColumnAliasBinder(SelectBindState &bind_state)
-    : bind_state(bind_state), visited_select_indexes() {
+ColumnAliasBinder::ColumnAliasBinder(SelectBindState &bind_state) : bind_state(bind_state), visited_select_indexes() {
 }
 
 bool ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, unique_ptr<ParsedExpression> &expr_ptr,

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -4,11 +4,11 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/select_bind_state.hpp"
+#include "duckdb/planner/expression_binder/select_bind_state.hpp"
 
 namespace duckdb {
 
-ColumnAliasBinder::ColumnAliasBinder(const SelectBindState &bind_state)
+ColumnAliasBinder::ColumnAliasBinder(SelectBindState &bind_state)
     : bind_state(bind_state), visited_select_indexes() {
 }
 
@@ -35,12 +35,10 @@ bool ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, unique_ptr
 	}
 
 	// We found an alias, so we copy the alias expression into this expression.
-	auto original_expr = bind_state.original_expressions[alias_entry->second]->Copy();
+	auto original_expr = bind_state.BindAlias(alias_entry->second);
 	expr_ptr = std::move(original_expr);
 	visited_select_indexes.insert(alias_entry->second);
 
-	// Since the alias has been found, we pass a depth of 0. See issue 4978 (#16).
-	// Only HAVING, QUALIFY, and WHERE binders contain ColumnAliasBinders.
 	result = enclosing_binder.BindExpression(expr_ptr, depth, root_expression);
 	visited_select_indexes.erase(alias_entry->second);
 	return true;

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -9,8 +9,8 @@
 namespace duckdb {
 
 GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
-                         case_insensitive_map_t<idx_t> &alias_map, case_insensitive_map_t<idx_t> &group_alias_map)
-    : ExpressionBinder(binder, context), node(node), alias_map(alias_map), group_alias_map(group_alias_map),
+						 const SelectBindState &bind_state, case_insensitive_map_t<idx_t> &group_alias_map)
+    : ExpressionBinder(binder, context), node(node), bind_state(bind_state), group_alias_map(group_alias_map),
       group_index(group_index) {
 }
 
@@ -94,8 +94,8 @@ BindResult GroupBinder::BindColumnRef(ColumnRefExpression &colref) {
 		// failed to bind the column and the node is the root expression with depth = 0
 		// check if refers to an alias in the select clause
 		auto alias_name = colref.column_names[0];
-		auto entry = alias_map.find(alias_name);
-		if (entry == alias_map.end()) {
+		auto entry = bind_state.alias_map.find(alias_name);
+		if (entry == bind_state.alias_map.end()) {
 			// no matching alias found
 			return result;
 		}

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression_binder/select_bind_state.hpp"
 #include "duckdb/common/to_string.hpp"
 
 namespace duckdb {

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -9,7 +9,7 @@
 namespace duckdb {
 
 GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
-						 SelectBindState &bind_state, case_insensitive_map_t<idx_t> &group_alias_map)
+                         SelectBindState &bind_state, case_insensitive_map_t<idx_t> &group_alias_map)
     : ExpressionBinder(binder, context), node(node), bind_state(bind_state), group_alias_map(group_alias_map),
       group_index(group_index) {
 }

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -9,7 +9,7 @@
 namespace duckdb {
 
 GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
-						 const SelectBindState &bind_state, case_insensitive_map_t<idx_t> &group_alias_map)
+						 SelectBindState &bind_state, case_insensitive_map_t<idx_t> &group_alias_map)
     : ExpressionBinder(binder, context), node(node), bind_state(bind_state), group_alias_map(group_alias_map),
       group_index(group_index) {
 }

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -10,13 +10,12 @@ namespace duckdb {
 
 HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
 						   const SelectBindState &bind_state, AggregateHandling aggregate_handling)
-    : BaseSelectBinder(binder, context, node, info, false), column_alias_binder(bind_state),
+    : BaseSelectBinder(binder, context, node, info), column_alias_binder(bind_state),
       aggregate_handling(aggregate_handling) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }
 
 BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
-
 	// Keep the original column name to return a meaningful error message.
 	auto column_name = expr_ptr->Cast<ColumnRefExpression>().GetColumnName();
 
@@ -37,7 +36,7 @@ BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, i
 			    "Having clause cannot reference column \"%s\" in correlated subquery and group by all", column_name);
 		}
 
-		auto expr = duckdb::BaseSelectBinder::BindExpression(expr_ptr, depth);
+		auto expr = duckdb::BaseSelectBinder::BindColumnRef(expr_ptr, depth, root_expression);
 		if (expr.HasError()) {
 			return expr;
 		}
@@ -54,21 +53,8 @@ BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, i
 	    "column %s must appear in the GROUP BY clause or be used in an aggregate function", column_name));
 }
 
-BindResult HavingBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
-	auto &expr = *expr_ptr;
-	// check if the expression binds to one of the groups
-	auto group_index = TryBindGroup(expr);
-	if (group_index != DConstants::INVALID_INDEX) {
-		return BindGroup(expr, depth, group_index);
-	}
-	switch (expr.expression_class) {
-	case ExpressionClass::WINDOW:
-		return BindResult("HAVING clause cannot contain window functions!");
-	case ExpressionClass::COLUMN_REF:
-		return BindColumnRef(expr_ptr, depth, root_expression);
-	default:
-		return duckdb::BaseSelectBinder::BindExpression(expr_ptr, depth);
-	}
+BindResult HavingBinder::BindWindow(WindowExpression &expr, idx_t depth) {
+	return BindResult("HAVING clause cannot contain window functions!");
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -9,8 +9,8 @@
 namespace duckdb {
 
 HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-						   const SelectBindState &bind_state, AggregateHandling aggregate_handling)
-    : BaseSelectBinder(binder, context, node, info), column_alias_binder(bind_state),
+						   AggregateHandling aggregate_handling)
+    : BaseSelectBinder(binder, context, node, info), column_alias_binder(node.bind_state),
       aggregate_handling(aggregate_handling) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -9,8 +9,8 @@
 namespace duckdb {
 
 HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-                           case_insensitive_map_t<idx_t> &alias_map, AggregateHandling aggregate_handling)
-    : BaseSelectBinder(binder, context, node, info), column_alias_binder(node, alias_map),
+						   const SelectBindState &bind_state, AggregateHandling aggregate_handling)
+    : BaseSelectBinder(binder, context, node, info, false), column_alias_binder(bind_state),
       aggregate_handling(aggregate_handling) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -9,7 +9,7 @@
 namespace duckdb {
 
 HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-						   AggregateHandling aggregate_handling)
+                           AggregateHandling aggregate_handling)
     : BaseSelectBinder(binder, context, node, info), column_alias_binder(node.bind_state),
       aggregate_handling(aggregate_handling) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -15,7 +15,7 @@
 namespace duckdb {
 
 OrderBinder::OrderBinder(vector<Binder *> binders, SelectBindState &bind_state)
-    : binders(std::move(binders)), extra_list(nullptr),  bind_state(bind_state) {
+    : binders(std::move(binders)), extra_list(nullptr), bind_state(bind_state) {
 }
 OrderBinder::OrderBinder(vector<Binder *> binders, SelectNode &node, SelectBindState &bind_state)
     : binders(std::move(binders)), bind_state(bind_state) {

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -8,8 +8,10 @@
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/expression_binder/select_bind_state.hpp"
 #include "duckdb/common/pair.hpp"
 
 namespace duckdb {

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -33,6 +33,7 @@ unique_ptr<Expression> OrderBinder::CreateProjectionReference(ParsedExpression &
 	}
 	auto result = make_uniq<BoundConstantExpression>(Value::UBIGINT(index));
 	result->alias = std::move(alias);
+	result->query_location = expr.query_location;
 	return std::move(result);
 }
 

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -15,9 +15,10 @@ namespace duckdb {
 
 OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectBindState &bind_state, idx_t max_count)
     : binders(std::move(binders)), projection_index(projection_index), max_count(max_count), extra_list(nullptr),
-	  bind_state(bind_state) {
+      bind_state(bind_state) {
 }
-OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectNode &node, SelectBindState &bind_state)
+OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectNode &node,
+                         SelectBindState &bind_state)
     : binders(std::move(binders)), projection_index(projection_index), bind_state(bind_state) {
 	this->max_count = node.select_list.size();
 	this->extra_list = &node.select_list;
@@ -32,7 +33,8 @@ unique_ptr<Expression> OrderBinder::CreateProjectionReference(ParsedExpression &
 			alias = expr.alias;
 		}
 	}
-	return make_uniq<BoundColumnRefExpression>(std::move(alias), LogicalType::INVALID, ColumnBinding(projection_index, index));
+	return make_uniq<BoundColumnRefExpression>(std::move(alias), LogicalType::INVALID,
+	                                           ColumnBinding(projection_index, index));
 }
 
 unique_ptr<Expression> OrderBinder::CreateExtraReference(unique_ptr<ParsedExpression> expr) {

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -56,8 +56,13 @@ unique_ptr<Expression> OrderBinder::BindConstant(ParsedExpression &expr, const V
 		return nullptr;
 	}
 	// INTEGER constant: we use the integer as an index into the select list (e.g. ORDER BY 1)
-	auto index = (idx_t)val.GetValue<int64_t>();
-	return CreateProjectionReference(expr, index - 1);
+	auto index = idx_t(val.GetValue<int64_t>() - 1);
+	child_list_t<Value> values;
+	values.push_back(make_pair("index", Value::UBIGINT(index)));
+	auto result = make_uniq<BoundConstantExpression>(Value::STRUCT(std::move(values)));
+	result->alias = std::move(expr.alias);
+	result->query_location = expr.query_location;
+	return std::move(result);
 }
 
 unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {

--- a/src/planner/expression_binder/qualify_binder.cpp
+++ b/src/planner/expression_binder/qualify_binder.cpp
@@ -10,8 +10,8 @@
 namespace duckdb {
 
 QualifyBinder::QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-                             case_insensitive_map_t<idx_t> &alias_map)
-    : BaseSelectBinder(binder, context, node, info), column_alias_binder(node, alias_map) {
+							 const SelectBindState &bind_state)
+    : BaseSelectBinder(binder, context, node, info, false), column_alias_binder(bind_state) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }
 

--- a/src/planner/expression_binder/qualify_binder.cpp
+++ b/src/planner/expression_binder/qualify_binder.cpp
@@ -11,13 +11,12 @@ namespace duckdb {
 
 QualifyBinder::QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
 							 const SelectBindState &bind_state)
-    : BaseSelectBinder(binder, context, node, info, false), column_alias_binder(bind_state) {
+    : BaseSelectBinder(binder, context, node, info), column_alias_binder(bind_state) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }
 
 BindResult QualifyBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
-
-	auto result = duckdb::BaseSelectBinder::BindExpression(expr_ptr, depth);
+	auto result = duckdb::BaseSelectBinder::BindColumnRef(expr_ptr, depth, root_expression);
 	if (!result.HasError()) {
 		return result;
 	}
@@ -34,23 +33,6 @@ BindResult QualifyBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, 
 
 	return BindResult(
 	    StringUtil::Format("Referenced column %s not found in FROM clause and can't find in alias map.", expr_string));
-}
-
-BindResult QualifyBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
-	auto &expr = *expr_ptr;
-	// check if the expression binds to one of the groups
-	auto group_index = TryBindGroup(expr);
-	if (group_index != DConstants::INVALID_INDEX) {
-		return BindGroup(expr, depth, group_index);
-	}
-	switch (expr.expression_class) {
-	case ExpressionClass::WINDOW:
-		return BindWindow(expr.Cast<WindowExpression>(), depth);
-	case ExpressionClass::COLUMN_REF:
-		return BindColumnRef(expr_ptr, depth, root_expression);
-	default:
-		return duckdb::BaseSelectBinder::BindExpression(expr_ptr, depth);
-	}
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/qualify_binder.cpp
+++ b/src/planner/expression_binder/qualify_binder.cpp
@@ -9,9 +9,8 @@
 
 namespace duckdb {
 
-QualifyBinder::QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-							 const SelectBindState &bind_state)
-    : BaseSelectBinder(binder, context, node, info), column_alias_binder(bind_state) {
+QualifyBinder::QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info)
+    : BaseSelectBinder(binder, context, node, info), column_alias_binder(node.bind_state) {
 	target_type = LogicalType(LogicalTypeId::BOOLEAN);
 }
 

--- a/src/planner/expression_binder/select_bind_state.cpp
+++ b/src/planner/expression_binder/select_bind_state.cpp
@@ -1,0 +1,9 @@
+#include "duckdb/planner/expression_binder/select_bind_state.hpp"
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> SelectBindState::BindAlias(idx_t index) {
+	return original_expressions[index]->Copy();
+}
+
+}

--- a/src/planner/expression_binder/select_bind_state.cpp
+++ b/src/planner/expression_binder/select_bind_state.cpp
@@ -31,11 +31,9 @@ bool SelectBindState::AliasHasSubquery(idx_t index) {
 }
 
 void SelectBindState::AddExpandedColumn(idx_t expand_count) {
-
 }
 
 void SelectBindState::AddRegularColumn() {
-
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/select_bind_state.cpp
+++ b/src/planner/expression_binder/select_bind_state.cpp
@@ -30,4 +30,12 @@ bool SelectBindState::AliasHasSubquery(idx_t index) {
 	return subquery_expressions.find(index) != subquery_expressions.end();
 }
 
+void SelectBindState::AddExpandedColumn(idx_t expand_count) {
+
+}
+
+void SelectBindState::AddRegularColumn() {
+
+}
+
 } // namespace duckdb

--- a/src/planner/expression_binder/select_bind_state.cpp
+++ b/src/planner/expression_binder/select_bind_state.cpp
@@ -26,14 +26,26 @@ void SelectBindState::SetExpressionHasSubquery(idx_t index) {
 	subquery_expressions.insert(index);
 }
 
-bool SelectBindState::AliasHasSubquery(idx_t index) {
+bool SelectBindState::AliasHasSubquery(idx_t index) const {
 	return subquery_expressions.find(index) != subquery_expressions.end();
 }
 
 void SelectBindState::AddExpandedColumn(idx_t expand_count) {
+	if (expanded_column_indices.empty()) {
+		expanded_column_indices.push_back(0);
+	}
+	expanded_column_indices.push_back(expanded_column_indices.back() + expand_count);
 }
 
 void SelectBindState::AddRegularColumn() {
+	AddExpandedColumn(1);
+}
+
+idx_t SelectBindState::GetFinalIndex(idx_t index) const {
+	if (expanded_column_indices.empty()) {
+		return index;
+	}
+	return expanded_column_indices[index];
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/select_bind_state.cpp
+++ b/src/planner/expression_binder/select_bind_state.cpp
@@ -3,7 +3,31 @@
 namespace duckdb {
 
 unique_ptr<ParsedExpression> SelectBindState::BindAlias(idx_t index) {
+	if (volatile_expressions.find(index) != volatile_expressions.end()) {
+		throw BinderException("Alias \"%s\" referenced - but the expression has side "
+		                      "effects. This is not yet supported.",
+		                      original_expressions[index]->alias);
+	}
+	referenced_aliases.insert(index);
 	return original_expressions[index]->Copy();
 }
 
+void SelectBindState::SetExpressionIsVolatile(idx_t index) {
+	// check if this expression has been referenced before
+	if (referenced_aliases.find(index) != referenced_aliases.end()) {
+		throw BinderException("Alias \"%s\" referenced - but the expression has side "
+		                      "effects. This is not yet supported.",
+		                      original_expressions[index]->alias);
+	}
+	volatile_expressions.insert(index);
 }
+
+void SelectBindState::SetExpressionHasSubquery(idx_t index) {
+	subquery_expressions.insert(index);
+}
+
+bool SelectBindState::AliasHasSubquery(idx_t index) {
+	return subquery_expressions.find(index) != subquery_expressions.end();
+}
+
+} // namespace duckdb

--- a/src/planner/expression_binder/select_bind_state.cpp
+++ b/src/planner/expression_binder/select_bind_state.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/planner/expression_binder/select_bind_state.hpp"
+#include "duckdb/common/exception/binder_exception.hpp"
 
 namespace duckdb {
 

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -2,13 +2,8 @@
 
 namespace duckdb {
 
-SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
-                           case_insensitive_map_t<idx_t> alias_map)
-    : BaseSelectBinder(binder, context, node, info, std::move(alias_map)) {
-}
-
 SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info)
-    : SelectBinder(binder, context, node, info, case_insensitive_map_t<idx_t>()) {
+    : BaseSelectBinder(binder, context, node, info) {
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -6,4 +6,49 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
     : BaseSelectBinder(binder, context, node, info) {
 }
 
+BindResult SelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
+	// first try to bind the column reference regularly
+	auto result = BaseSelectBinder::BindColumnRef(expr_ptr, depth, root_expression);
+	if (!result.HasError()) {
+		return result;
+	}
+	// binding failed
+	// check in the alias map
+	auto &colref = (expr_ptr.get())->Cast<ColumnRefExpression>();
+	if (!colref.IsQualified()) {
+		auto alias_entry = node.bind_state.alias_map.find(colref.column_names[0]);
+		if (alias_entry != node.bind_state.alias_map.end()) {
+			// found entry!
+			auto index = alias_entry->second;
+			if (index >= node.bound_column_count) {
+				throw BinderException("Column \"%s\" referenced that exists in the SELECT clause - but this column "
+									  "cannot be referenced before it is defined",
+									  colref.column_names[0]);
+			}
+			if (node.select_list[index]->IsVolatile()) {
+				throw BinderException("Alias \"%s\" referenced in a SELECT clause - but the expression has side "
+									  "effects. This is not yet supported.",
+									  colref.column_names[0]);
+			}
+			if (node.select_list[index]->HasSubquery()) {
+				throw BinderException("Alias \"%s\" referenced in a SELECT clause - but the expression has a subquery."
+									  " This is not yet supported.",
+									  colref.column_names[0]);
+			}
+			auto copied_expression = node.bind_state.original_expressions[index]->Copy();
+			result = BindExpression(copied_expression, depth, false);
+			return result;
+		}
+	}
+	// entry was not found in the alias map: return the original error
+	return result;
+}
+
+bool SelectBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
+	if (!colref.IsQualified()) {
+		return node.bind_state.alias_map.find(colref.column_names[0]) != node.bind_state.alias_map.end();
+	}
+	return false;
+}
+
 } // namespace duckdb

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/planner/expression_binder/select_binder.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/planner/query_node/bound_select_node.hpp"
 
 namespace duckdb {
 

--- a/test/planner/projection_binding.test
+++ b/test/planner/projection_binding.test
@@ -10,9 +10,6 @@ PRAGMA explain_output = PHYSICAL_ONLY;
 
 # verify that ORDER BY binding is consistent in presence of different "table.column" vs "column" bindings
 query I nosort orderbinder
-EXPLAIN SELECT i FROM a ORDER BY 1
-----
-query I nosort orderbinder
 EXPLAIN SELECT i FROM a ORDER BY i
 ----
 
@@ -25,10 +22,6 @@ EXPLAIN SELECT i FROM a ORDER BY a.i
 ----
 
 # with alias
-query I nosort orderbinderk
-EXPLAIN SELECT i AS k FROM a ORDER BY 1
-----
-
 query I nosort orderbinderk
 EXPLAIN SELECT i AS k FROM a ORDER BY k
 ----

--- a/test/planner/projection_binding.test
+++ b/test/planner/projection_binding.test
@@ -3,7 +3,7 @@
 # group: [planner]
 
 statement ok
-CREATE TABLE a (i INTEGER, j INTEGER)
+CREATE TABLE a (i INTEGER, j INTEGER);
 
 statement ok
 PRAGMA explain_output = PHYSICAL_ONLY;
@@ -12,7 +12,6 @@ PRAGMA explain_output = PHYSICAL_ONLY;
 query I nosort orderbinder
 EXPLAIN SELECT i FROM a ORDER BY 1
 ----
-
 query I nosort orderbinder
 EXPLAIN SELECT i FROM a ORDER BY i
 ----

--- a/test/sql/binder/alias_where_side_effects.test
+++ b/test/sql/binder/alias_where_side_effects.test
@@ -1,0 +1,11 @@
+# name: test/sql/binder/alias_where_side_effects.test
+# description: Issue #10099: Incorrect query result when using random value in where clause
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+select count(*) from (select random() as num from range(20) where num > 0.9) where num <= 0.9
+----
+expression has side effects

--- a/test/sql/collate/test_collate_orderby_column_number.test
+++ b/test/sql/collate/test_collate_orderby_column_number.test
@@ -42,7 +42,7 @@ SELECT 'a' FROM ORDER BY -0 COLLATE NOCASE;
 ----
 
 statement ok
-CREATE TABLE collate_test(s VARCHAR)
+CREATE TABLE collate_test(s VARCHAR);
 
 statement ok
 INSERT INTO collate_test VALUES ('ã'),('B'),('a'),('A');
@@ -96,14 +96,22 @@ NULL
 NULL
 
 
-statement error
+query I
 SELECT (SELECT s) FROM collate_test ORDER BY 1 COLLATE NOCASE;
 ----
+a
+A
+B
+ã
 
 statement error
 SELECT (SELECT s) AS c1 FROM collate_test ORDER BY c11 COLLATE NOCASE;
 ----
 
-statement error
+query I
 SELECT concat('a', (SELECT s)) FROM collate_test ORDER BY 1 COLLATE NOCASE;
 ----
+aa
+aA
+aB
+aã

--- a/test/sql/order/negative_offset.test
+++ b/test/sql/order/negative_offset.test
@@ -8,21 +8,25 @@ PRAGMA enable_verification
 statement error
 SELECT * FROM generate_series(0,10,1) LIMIT 3 OFFSET -1;
 ----
+cannot be negative
 
 statement error
 SELECT * FROM generate_series(0,10,1) LIMIT -3;
 ----
+cannot be negative
 
 statement error
 SELECT * FROM generate_series(0,10,1) LIMIT -1%
 ----
+out of range
 
 statement ok
-CREATE TABLE integers AS SELECT -1 k
+CREATE TABLE integers AS SELECT -1 k;
 
 statement error
 SELECT * FROM generate_series(0,10,1) LIMIT (SELECT k FROM integers);
 ----
+out of range
 
 statement error
 SELECT * FROM generate_series(0,10,1) LIMIT 1 OFFSET (SELECT k FROM integers);

--- a/test/sql/types/struct/struct_unnest_recursion.test
+++ b/test/sql/types/struct/struct_unnest_recursion.test
@@ -10,13 +10,12 @@ SELECT UNNEST ( ( '1,2,3,4,,6' , ( 1 ) ) ) , x x;
 ----
 cannot be referenced before it is defined
 
-mode skip
-
-# FIXME this should work
-statement error
-SELECT UNNEST ( ( '1,2,3,4,,6' , ( random() ) ) ), 42 x, x;
+query IIII
+SELECT UNNEST ( ( '1,2,3,4,,6' , ( case when random() < 10 then 0 else 1 end ) ) ), 42 x, x;
 ----
-1,2,3,4,,6	1	42	42
+1,2,3,4,,6	0	42	42
 
-mode unskip
+
+
+
 

--- a/test/sql/types/struct/unnest_struct_mix.test
+++ b/test/sql/types/struct/unnest_struct_mix.test
@@ -1,0 +1,89 @@
+# name: test/sql/types/struct/unnest_struct_mix.test
+# description: Test UNNEST of struct mixed with other constructs
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+# unnest of struct in set operation
+statement ok
+CREATE TABLE tbl_structs AS SELECT {'a': 1, 'b': 2, 'c': 3} AS s;
+
+statement ok
+INSERT INTO tbl_structs VALUES ({'a': 2, 'b': 3, 'c': 1});
+
+statement ok
+INSERT INTO tbl_structs VALUES ({'a': 3, 'b': 1, 'c': 2});
+
+query III
+SELECT UNNEST(s) FROM tbl_structs UNION ALL SELECT s.a, s.b, s.c FROM tbl_structs ORDER BY s.a, s.b, s.c;
+----
+1	2	3
+1	2	3
+2	3	1
+2	3	1
+3	1	2
+3	1	2
+
+# order by unnest of struct
+statement error
+SELECT * FROM tbl_structs ORDER BY UNNEST(s);
+----
+cannot be used
+
+# order by all
+statement ok
+CREATE OR REPLACE TABLE tbl_structs AS SELECT {'a': 1, 'b': 2, 'c': 3} AS s;
+
+statement ok
+INSERT INTO tbl_structs VALUES ({'a': 1, 'b': 3, 'c': 1});
+
+statement ok
+INSERT INTO tbl_structs VALUES ({'a': 1, 'b': 1, 'c': 2});
+
+query III
+select unnest(s) from tbl_structs order by all;
+----
+1	1	2
+1	2	3
+1	3	1
+
+# order by index with collate
+statement error
+select unnest(s) from tbl_structs order by 2 collate nocase;
+----
+COLLATE can only be applied to varchar columns
+
+statement ok
+CREATE OR REPLACE TABLE tbl_structs AS SELECT {'a': 'hello'} s;
+
+statement ok
+INSERT INTO tbl_structs VALUES ({'a': 'WORLD'});
+
+query I
+SELECT UNNEST(s) FROM tbl_structs ORDER BY 1 COLLATE NOCASE;
+----
+hello
+WORLD
+
+statement ok
+CREATE OR REPLACE TABLE tbl_structs AS SELECT {'a': 'hello', 'b': 1} s;
+
+statement ok
+INSERT INTO tbl_structs VALUES ({'a': 'WORLD', 'b': 2});
+
+query II
+SELECT UNNEST(s) FROM tbl_structs UNION ALL SELECT s.a, s.b FROM tbl_structs ORDER BY 1 COLLATE NOCASE;
+----
+hello	1
+hello	1
+WORLD	2
+WORLD	2
+
+query III
+SELECT UNNEST(s), -s.b AS id FROM tbl_structs UNION ALL SELECT s.a, s.b, s.b FROM tbl_structs ORDER BY id;
+----
+WORLD	2	-2
+hello	1	-1
+hello	1	1
+WORLD	2	2


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/11578

This PR does a more comprehensive fix of various issues surrounding struct unnest. The issue with struct unnest is that it takes a "special path" since the column expansion happens post-binding. This was previously not handled correctly in a number of places, e.g. `ORDER BY [index]`, `ORDER BY ALL`, alias binding, expression maps and set operations. This PR cleans this process up by moving the expansion to a separate structure (`SelectBindState`) that has various functions that correctly deal with the extra columns. This cleans up the code and fixes a number of bugs.