### PR TITLE
Respect read-only mode in dbgen and dsdgen

### DIFF
--- a/extension/tpcds/tpcds_extension.cpp
+++ b/extension/tpcds/tpcds_extension.cpp
@@ -43,13 +43,17 @@ static duckdb::unique_ptr<FunctionData> DsdgenBind(ClientContext &context, Table
 			result->keys = kv.second.GetValue<bool>();
 		}
 	}
+	if (input.binder) {
+		auto &catalog = Catalog::GetCatalog(context, result->catalog);
+		input.binder->properties.modified_databases.insert(catalog.GetName());
+	}
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");
 	return std::move(result);
 }
 
 static void DsdgenFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &data = (DSDGenFunctionData &)*data_p.bind_data;
+	auto &data = data_p.bind_data->CastNoConst<DSDGenFunctionData>();
 	if (data.finished) {
 		return;
 	}
@@ -82,7 +86,7 @@ static duckdb::unique_ptr<FunctionData> TPCDSQueryBind(ClientContext &context, T
 }
 
 static void TPCDSQueryFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &data = (TPCDSData &)*data_p.global_state;
+	auto &data = data_p.global_state->Cast<TPCDSData>();
 	idx_t tpcds_queries = tpcds::DSDGenWrapper::QueriesCount();
 	if (data.offset >= tpcds_queries) {
 		// finished returning values
@@ -116,7 +120,7 @@ static duckdb::unique_ptr<FunctionData> TPCDSQueryAnswerBind(ClientContext &cont
 }
 
 static void TPCDSQueryAnswerFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &data = (TPCDSData &)*data_p.global_state;
+	auto &data = data_p.global_state->Cast<TPCDSData>();
 	idx_t tpcds_queries = tpcds::DSDGenWrapper::QueriesCount();
 	vector<double> scale_factors {1, 10};
 	idx_t total_answers = tpcds_queries * scale_factors.size();

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -83,9 +83,9 @@ struct LocalTableFunctionState {
 struct TableFunctionBindInput {
 	TableFunctionBindInput(vector<Value> &inputs, named_parameter_map_t &named_parameters,
 	                       vector<LogicalType> &input_table_types, vector<string> &input_table_names,
-	                       optional_ptr<TableFunctionInfo> info)
+	                       optional_ptr<TableFunctionInfo> info, optional_ptr<Binder> binder)
 	    : inputs(inputs), named_parameters(named_parameters), input_table_types(input_table_types),
-	      input_table_names(input_table_names), info(info) {
+	      input_table_names(input_table_names), info(info), binder(binder) {
 	}
 
 	vector<Value> &inputs;
@@ -93,6 +93,7 @@ struct TableFunctionBindInput {
 	vector<LogicalType> &input_table_types;
 	vector<string> &input_table_names;
 	optional_ptr<TableFunctionInfo> info;
+	optional_ptr<Binder> binder;
 };
 
 struct TableFunctionInitInput {

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -140,7 +140,7 @@ Binder::BindTableFunctionInternal(TableFunction &table_function, const string &f
 	vector<string> return_names;
 	if (table_function.bind || table_function.bind_replace) {
 		TableFunctionBindInput bind_input(parameters, named_parameters, input_table_types, input_table_names,
-		                                  table_function.function_info.get());
+		                                  table_function.function_info.get(), this);
 		if (table_function.bind_replace) {
 			auto new_plan = table_function.bind_replace(context, bind_input);
 			if (new_plan != nullptr) {

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -165,7 +165,7 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 		deserializer.ReadProperty(208, "input_table_types", result->input_table_types);
 		deserializer.ReadProperty(209, "input_table_names", result->input_table_names);
 		TableFunctionBindInput input(result->parameters, result->named_parameters, result->input_table_types,
-		                             result->input_table_names, function.function_info.get());
+		                             result->input_table_names, function.function_info.get(), nullptr);
 
 		vector<LogicalType> bind_return_types;
 		vector<string> bind_names;

--- a/test/sql/tpcds/dsdgen_readonly.test
+++ b/test/sql/tpcds/dsdgen_readonly.test
@@ -1,0 +1,30 @@
+# name: test/sql/tpcds/dsdgen_readonly.test
+# description: Test that dsdgen respects read-only mode
+# group: [tpcds]
+
+require tpcds
+
+load __TEST_DIR__/test_dsdgen_ro.db
+
+statement ok
+CREATE TABLE tbl (i INTEGER);
+
+load __TEST_DIR__/test_dsdgen_ro.db readonly
+
+statement error
+CALL dsdgen(sf=0);
+----
+read-only
+
+load
+
+statement ok
+ATTACH '__TEST_DIR__/test_dsdgen_ro.db' AS dsdgentest (READ_ONLY)
+
+statement error
+CALL dsdgen(sf=0, catalog='dsdgentest');
+----
+read-only
+
+statement ok
+CALL dsdgen(sf=0);

--- a/test/sql/tpcds/dsdgen_readonly.test
+++ b/test/sql/tpcds/dsdgen_readonly.test
@@ -4,6 +4,8 @@
 
 require tpcds
 
+require skip_reload
+
 load __TEST_DIR__/test_dsdgen_ro.db
 
 statement ok

--- a/test/sql/tpch/dbgen_readonly.test
+++ b/test/sql/tpch/dbgen_readonly.test
@@ -4,6 +4,8 @@
 
 require tpch
 
+require skip_reload
+
 load __TEST_DIR__/test_dbgen_ro.db
 
 statement ok

--- a/test/sql/tpch/dbgen_readonly.test
+++ b/test/sql/tpch/dbgen_readonly.test
@@ -1,0 +1,30 @@
+# name: test/sql/tpch/dbgen_readonly.test
+# description: Test that dbgen respects read-only mode
+# group: [tpch]
+
+require tpch
+
+load __TEST_DIR__/test_dbgen_ro.db
+
+statement ok
+CREATE TABLE tbl (i INTEGER);
+
+load __TEST_DIR__/test_dbgen_ro.db readonly
+
+statement error
+CALL dbgen(sf=0);
+----
+read-only
+
+load
+
+statement ok
+ATTACH '__TEST_DIR__/test_dbgen_ro.db' AS dbgentest (READ_ONLY)
+
+statement error
+CALL dbgen(sf=0, catalog='dbgentest');
+----
+read-only
+
+statement ok
+CALL dbgen(sf=0);

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -65,7 +65,7 @@ static void ConvertPyArrowToDataChunk(const py::object &table, Vector &out, Clie
 	vector<LogicalType> input_types;
 	vector<string> input_names;
 
-	auto bind_input = TableFunctionBindInput(children, named_params, input_types, input_names, nullptr);
+	TableFunctionBindInput bind_input(children, named_params, input_types, input_names, nullptr, nullptr);
 	vector<LogicalType> return_types;
 	vector<string> return_names;
 


### PR DESCRIPTION
This PR extends the `TableFunctionBindInput` with a `Binder`, that can then be used to correctly set `modified_databases` in the bind phase. This allows the `dbgen` and `dsdgen` functions to correctly register the database they intend to modify, which prevents them from being used in read-only mode.