### PR TITLE
[CI] Remove GITHUB_PAT variable from R-CMD-check

### DIFF
--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -51,7 +51,6 @@ jobs:
           - {os: ubuntu-latest,   r: 'release'}
 
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:


### PR DESCRIPTION
GITHUB_TOKEN is now available with restricted read-only capability, so I was making a review of the places where this was used, and this is the last remaining case.

I am not sure if GITHUB_PAT as a role anymore, or this can be safely removed.

Opening the PR to figure this out, also given the recent changes to duckdb/duckdb-r this looks more likely to be outdated.