### PR TITLE
Bump-back duckdb_azure to pre-lzma custom vcpkg-port

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -38,7 +38,7 @@ if (NOT MINGW)
     duckdb_extension_load(azure
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_azure
-            GIT_TAG 6620a32454c1eb2e455104d87262061d2464aad0
+            GIT_TAG 506b1fa0f3f892000130feac7a0e1de346095e80
             APPLY_PATCHES
             )
 endif()

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -38,7 +38,7 @@ if (NOT MINGW)
     duckdb_extension_load(azure
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_azure
-            GIT_TAG 506b1fa0f3f892000130feac7a0e1de346095e80
+            GIT_TAG 4512a652479016d40d712f990cab9b9aab43d341
             APPLY_PATCHES
             )
 endif()


### PR DESCRIPTION
This should restore CI to working state after https://github.com/tukaani-project/xz is back online (only with older versions), see https://github.com/microsoft/vcpkg/pull/37841#issuecomment-2046039866