### PR TITLE
Fix topn placement

### DIFF
--- a/test/optimizer/arithmetic_simplification.test
+++ b/test/optimizer/arithmetic_simplification.test
@@ -1,32 +1,48 @@
 # name: test/optimizer/arithmetic_simplification.test
-# description: topN 
+# description: Arithmetic simplification test
 # group: [optimizer]
 
 statement ok
-attach 'appian.duckdb' as appian;
+CREATE TABLE test(X INTEGER);
 
 statement ok
-use appian;
+PRAGMA explain_output = OPTIMIZED_ONLY;
 
-statement ok
-WITH CTE AS (
-  SELECT J1P, CUSTOMER_PRIORITY, CUSTOMER_ID FROM CUSTOMERVIEW
-  LEFT JOIN (
-    SELECT ORDER_CUSTOMERID, SUM(ORDERITEMVIEW.ORDERITEM_QUANTITY) AS J1P FROM ORDERVIEW
-    LEFT JOIN ORDERITEMVIEW ON (ORDERVIEW.ORDER_ID = ORDERITEMVIEW.ORDERITEM_ORDERID)
-    WHERE (ORDERVIEW.ORDER_ISEXPEDITEDSHIPPED IS TRUE)
-    GROUP BY ORDERVIEW.ORDER_CUSTOMERID
-  ) AS J1J ON (J1J.ORDER_CUSTOMERID = CUSTOMERVIEW.CUSTOMER_ID)
-  ORDER BY CUSTOMER_PRIORITY ASC
-  LIMIT 50 OFFSET 50
-) SELECT J1P, Q2P, Q3P FROM CTE
-LEFT JOIN (
-  SELECT ORDER_CUSTOMERID FROM ORDERVIEW
-) AS Q1J ON (Q1J.ORDER_CUSTOMERID = CTE.CUSTOMER_ID)
-LEFT JOIN (
-  SELECT CREDITCARD_CUSTOMERID AS Q2P FROM CREDITCARDVIEW
-) AS Q2J ON (Q2J.Q2P = CTE.CUSTOMER_ID)
-LEFT JOIN (
-  SELECT ORDER_CUSTOMERID Q3P FROM ORDERVIEW
-  LEFT JOIN ORDERITEMVIEW ON ORDERVIEW.ORDER_ID = ORDERITEM_ORDERID
-) AS Q3J ON (Q3J.Q3P = CTE.CUSTOMER_ID);
+# verify that nop arithmetic is flattened
+query I nosort xnorm
+EXPLAIN SELECT X FROM test
+----
+
+query I nosort xnorm
+EXPLAIN SELECT X+0 FROM test
+----
+
+query I nosort xnorm
+EXPLAIN SELECT 0+X FROM test
+----
+
+query I nosort xnorm
+EXPLAIN SELECT X-0 FROM test
+----
+
+query I nosort xnorm
+EXPLAIN SELECT X*1 FROM test
+----
+
+query I nosort xnorm
+EXPLAIN SELECT 1*X FROM test
+----
+
+query I nosort xnorm
+EXPLAIN SELECT X//1 FROM test
+----
+
+# division by zero results in a NULL
+query I nosort xnull
+EXPLAIN SELECT NULL FROM test
+----
+
+query I nosort xnull
+EXPLAIN SELECT X//0 FROM test
+----
+

--- a/test/optimizer/topn/complex_top_n.test
+++ b/test/optimizer/topn/complex_top_n.test
@@ -1,14 +1,23 @@
-# name: test/optimizer/arithmetic_simplification.test
+# name: test/optimizer/topn/complex_top_n.test
 # description: topN 
 # group: [optimizer]
 
 statement ok
-attach 'appian.duckdb' as appian;
+SELECT SETSEED(0.42);
 
 statement ok
-use appian;
+create table CUSTOMERVIEW as select range customer_id, range*random()::INT % 3 as customer_priority from range(1000, 2000); 
 
 statement ok
+create table OrderView as select range order_id, ((random()*2::INT)%2)::BOOL order_isExpeditedShipped, range + (random() * 3)::INT order_customerId from range(1000, 2000);
+
+statement ok
+create table OrderItemView as select random()*25 orderItem_quantity, range orderItem_orderId from range(1000, 2000);
+
+statement ok
+create table CREDITCARDVIEW as select range CREDITCARD_CUSTOMERID from range(1000, 2000); 
+
+query III
 WITH CTE AS (
   SELECT J1P, CUSTOMER_PRIORITY, CUSTOMER_ID FROM CUSTOMERVIEW
   LEFT JOIN (
@@ -30,3 +39,5 @@ LEFT JOIN (
   SELECT ORDER_CUSTOMERID Q3P FROM ORDERVIEW
   LEFT JOIN ORDERITEMVIEW ON ORDERVIEW.ORDER_ID = ORDERITEM_ORDERID
 ) AS Q3J ON (Q3J.Q3P = CTE.CUSTOMER_ID);
+----
+432 values hashing to c51b3f7dd78a68c95de3f44866394cfb

--- a/test/optimizer/topn/complex_top_n.test
+++ b/test/optimizer/topn/complex_top_n.test
@@ -1,6 +1,6 @@
 # name: test/optimizer/topn/complex_top_n.test
-# description: topN 
-# group: [optimizer]
+# description: topN
+# group: [topn]
 
 statement ok
 SELECT SETSEED(0.42);

--- a/test/optimizer/topn/complex_top_n.test
+++ b/test/optimizer/topn/complex_top_n.test
@@ -6,16 +6,16 @@ statement ok
 SELECT SETSEED(0.42);
 
 statement ok
-create table CUSTOMERVIEW as select range customer_id, range*random()::INT % 3 as customer_priority from range(1000, 2000); 
+create table CUSTOMERVIEW as select range customer_id, range*random()::INT % 3 as customer_priority from range(1000, 4000); 
 
 statement ok
-create table OrderView as select range order_id, ((random()*2::INT)%2)::BOOL order_isExpeditedShipped, range + (random() * 3)::INT order_customerId from range(1000, 2000);
+create table OrderView as select range order_id, ((random()*2::INT)%2)::BOOL order_isExpeditedShipped, range + (random() * 3)::INT order_customerId from range(1000, 4000);
 
 statement ok
-create table OrderItemView as select random()*25 orderItem_quantity, range orderItem_orderId from range(1000, 2000);
+create table OrderItemView as select random()*25 orderItem_quantity, range orderItem_orderId from range(1000, 4000);
 
 statement ok
-create table CREDITCARDVIEW as select range CREDITCARD_CUSTOMERID from range(1000, 2000); 
+create table CREDITCARDVIEW as select range CREDITCARD_CUSTOMERID from range(1000, 4000); 
 
 query III
 WITH CTE AS (
@@ -40,4 +40,29 @@ LEFT JOIN (
   LEFT JOIN ORDERITEMVIEW ON ORDERVIEW.ORDER_ID = ORDERITEM_ORDERID
 ) AS Q3J ON (Q3J.Q3P = CTE.CUSTOMER_ID);
 ----
-432 values hashing to c51b3f7dd78a68c95de3f44866394cfb
+423 values hashing to 88bbd750b435b7616e6596774a8d5689
+
+query II
+explain WITH CTE AS (
+  SELECT J1P, CUSTOMER_PRIORITY, CUSTOMER_ID FROM CUSTOMERVIEW
+  LEFT JOIN (
+    SELECT ORDER_CUSTOMERID, SUM(ORDERITEMVIEW.ORDERITEM_QUANTITY) AS J1P FROM ORDERVIEW
+    LEFT JOIN ORDERITEMVIEW ON (ORDERVIEW.ORDER_ID = ORDERITEMVIEW.ORDERITEM_ORDERID)
+    WHERE (ORDERVIEW.ORDER_ISEXPEDITEDSHIPPED IS TRUE)
+    GROUP BY ORDERVIEW.ORDER_CUSTOMERID
+  ) AS J1J ON (J1J.ORDER_CUSTOMERID = CUSTOMERVIEW.CUSTOMER_ID)
+  ORDER BY CUSTOMER_PRIORITY ASC
+  LIMIT 50 OFFSET 50
+) SELECT J1P, Q2P, Q3P FROM CTE
+LEFT JOIN (
+  SELECT ORDER_CUSTOMERID FROM ORDERVIEW
+) AS Q1J ON (Q1J.ORDER_CUSTOMERID = CTE.CUSTOMER_ID)
+LEFT JOIN (
+  SELECT CREDITCARD_CUSTOMERID AS Q2P FROM CREDITCARDVIEW
+) AS Q2J ON (Q2J.Q2P = CTE.CUSTOMER_ID)
+LEFT JOIN (
+  SELECT ORDER_CUSTOMERID Q3P FROM ORDERVIEW
+  LEFT JOIN ORDERITEMVIEW ON ORDERVIEW.ORDER_ID = ORDERITEM_ORDERID
+) AS Q3J ON (Q3J.Q3P = CTE.CUSTOMER_ID);
+----
+physical_plan	<REGEX>:.*TOP_N.*

--- a/test/optimizer/topn/complex_top_n.test
+++ b/test/optimizer/topn/complex_top_n.test
@@ -2,6 +2,8 @@
 # description: topN
 # group: [topn]
 
+require skip_reload
+
 statement ok
 SELECT SETSEED(0.42);
 

--- a/test/optimizer/topn/topn_optimizer.test
+++ b/test/optimizer/topn/topn_optimizer.test
@@ -1,4 +1,4 @@
-# name: test/optimizer/topn_optimizer.test
+# name: test/optimizer/topn/opn_optimizer.test
 # description: Test Top N optimization
 # group: [optimizer]
 

--- a/test/optimizer/topn/topn_optimizer.test
+++ b/test/optimizer/topn/topn_optimizer.test
@@ -1,6 +1,6 @@
-# name: test/optimizer/topn/opn_optimizer.test
+# name: test/optimizer/topn/topn_optimizer.test
 # description: Test Top N optimization
-# group: [optimizer]
+# group: [topn]
 
 statement ok
 CREATE TABLE integers(i INTEGER, j INTEGER)


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb/issues/10261

The topN optimizer doesn't support projection maps. So if a (Limit & group_by) can be converted to a topN, AND the group_by operator has a projection map, this bug will show up. The original fix was to support projection maps in the TopN operators, but that proved to be difficult in the physical operator since the implementation requires re-scanning the sorted chunks again, and the second scan ends up applying the projection map again. Correct me if I am wrong @lnkuiper .

The current fix now is to move the placement of the topN optimizer up to before the unused columns.