### PR TITLE
[Fix][ADBC] Don't filter system catalogs/schemas in ConnectionGetObjects

### DIFF
--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -1218,7 +1218,9 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		res = db.Query("Select * from result order by catalog_name asc");
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 3);
-		REQUIRE(res->GetValue(1, 2).ToString() == "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, 'db_schema_tables': NULL}, {'db_schema_name': pg_catalog, 'db_schema_tables': NULL}]");
+		REQUIRE(res->GetValue(1, 2).ToString() ==
+		        "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, "
+		        "'db_schema_tables': NULL}, {'db_schema_name': pg_catalog, 'db_schema_tables': NULL}]");
 		db.Query("Drop table result;");
 	}
 	// 4.Test ADBC_OBJECT_DEPTH_COLUMNS
@@ -1314,7 +1316,9 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		res = db.Query("Select * from result order by catalog_name asc");
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 3);
-		REQUIRE(res->GetValue(1, 2).ToString() == "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, 'db_schema_tables': NULL}, {'db_schema_name': pg_catalog, 'db_schema_tables': NULL}]");
+		REQUIRE(res->GetValue(1, 2).ToString() ==
+		        "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, "
+		        "'db_schema_tables': NULL}, {'db_schema_name': pg_catalog, 'db_schema_tables': NULL}]");
 		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, nullptr, nullptr,
@@ -1324,8 +1328,10 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 3);
 		REQUIRE(res->GetValue(1, 2).ToString() ==
-		        "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, 'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, "
-		        "'table_columns': NULL, 'table_constraints': NULL}]}, {'db_schema_name': pg_catalog, 'db_schema_tables': NULL}]");
+		        "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, "
+		        "'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, "
+		        "'table_columns': NULL, 'table_constraints': NULL}]}, {'db_schema_name': pg_catalog, "
+		        "'db_schema_tables': NULL}]");
 		db.Query("Drop table result;");
 	}
 	// 5.Test ADBC_OBJECT_DEPTH_ALL
@@ -1420,7 +1426,9 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		res = db.Query("Select * from result order by catalog_name asc");
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 3);
-		REQUIRE(res->GetValue(1, 2).ToString() == "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, 'db_schema_tables': NULL}, {'db_schema_name': pg_catalog, 'db_schema_tables': NULL}]");
+		REQUIRE(res->GetValue(1, 2).ToString() ==
+		        "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, "
+		        "'db_schema_tables': NULL}, {'db_schema_name': pg_catalog, 'db_schema_tables': NULL}]");
 		db.Query("Drop table result;");
 
 		AdbcConnectionGetObjects(&db.adbc_connection, ADBC_OBJECT_DEPTH_COLUMNS, nullptr, nullptr, nullptr, nullptr,
@@ -1430,8 +1438,10 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 		REQUIRE(res->ColumnCount() == 2);
 		REQUIRE(res->RowCount() == 3);
 		REQUIRE(res->GetValue(1, 2).ToString() ==
-		        "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, 'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, "
-		        "'table_columns': NULL, 'table_constraints': NULL}]}, {'db_schema_name': pg_catalog, 'db_schema_tables': NULL}]");
+		        "[{'db_schema_name': information_schema, 'db_schema_tables': NULL}, {'db_schema_name': main, "
+		        "'db_schema_tables': [{'table_name': my_table, 'table_type': BASE TABLE, "
+		        "'table_columns': NULL, 'table_constraints': NULL}]}, {'db_schema_name': pg_catalog, "
+		        "'db_schema_tables': NULL}]");
 		db.Query("Drop table result;");
 	}
 	//	 Now lets test some errors

--- a/tools/pythonpkg/tests/fast/adbc/test_adbc.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_adbc.py
@@ -47,234 +47,242 @@ def test_connection_get_objects(duck_conn):
     with duck_conn.cursor() as cursor:
         cursor.execute("CREATE TABLE getobjects (ints BIGINT PRIMARY KEY)")
         depth_all = duck_conn.adbc_get_objects(depth="all").read_all()
-    assert sorted_get_objects(depth_all.to_pylist()) == sorted_get_objects([
-        {
-            'catalog_name': 'system',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'temp',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'memory',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': [
-                        {
-                            'table_name': 'getobjects',
-                            'table_type': 'BASE TABLE',
-                            'table_columns': [
-                                {
-                                    'column_name': 'ints',
-                                    'ordinal_position': 1,
-                                    'remarks': '',
-                                    'xdbc_char_octet_length': None,
-                                    'xdbc_column_def': None,
-                                    'xdbc_column_size': None,
-                                    'xdbc_data_type': None,
-                                    'xdbc_datetime_sub': None,
-                                    'xdbc_decimal_digits': None,
-                                    'xdbc_is_autoincrement': None,
-                                    'xdbc_is_generatedcolumn': None,
-                                    'xdbc_is_nullable': None,
-                                    'xdbc_nullable': None,
-                                    'xdbc_num_prec_radix': None,
-                                    'xdbc_scope_catalog': None,
-                                    'xdbc_scope_schema': None,
-                                    'xdbc_scope_table': None,
-                                    'xdbc_sql_data_type': None,
-                                    'xdbc_type_name': None,
-                                },
-                            ],
-                            'table_constraints': [
-                                {
-                                    'constraint_column_names': [],
-                                    'constraint_column_usage': [],
-                                    'constraint_name': 'getobjects_ints_pkey',
-                                    'constraint_type': 'PRIMARY KEY',
-                                },
-                                {
-                                    'constraint_column_names': [],
-                                    'constraint_column_usage': [],
-                                    'constraint_name': 'getobjects_ints_not_null',
-                                    'constraint_type': 'CHECK',
-                                },
-                            ],
-                        }
-                    ],
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        }
-    ])
+    assert sorted_get_objects(depth_all.to_pylist()) == sorted_get_objects(
+        [
+            {
+                'catalog_name': 'system',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'temp',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'memory',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': [
+                            {
+                                'table_name': 'getobjects',
+                                'table_type': 'BASE TABLE',
+                                'table_columns': [
+                                    {
+                                        'column_name': 'ints',
+                                        'ordinal_position': 1,
+                                        'remarks': '',
+                                        'xdbc_char_octet_length': None,
+                                        'xdbc_column_def': None,
+                                        'xdbc_column_size': None,
+                                        'xdbc_data_type': None,
+                                        'xdbc_datetime_sub': None,
+                                        'xdbc_decimal_digits': None,
+                                        'xdbc_is_autoincrement': None,
+                                        'xdbc_is_generatedcolumn': None,
+                                        'xdbc_is_nullable': None,
+                                        'xdbc_nullable': None,
+                                        'xdbc_num_prec_radix': None,
+                                        'xdbc_scope_catalog': None,
+                                        'xdbc_scope_schema': None,
+                                        'xdbc_scope_table': None,
+                                        'xdbc_sql_data_type': None,
+                                        'xdbc_type_name': None,
+                                    },
+                                ],
+                                'table_constraints': [
+                                    {
+                                        'constraint_column_names': [],
+                                        'constraint_column_usage': [],
+                                        'constraint_name': 'getobjects_ints_pkey',
+                                        'constraint_type': 'PRIMARY KEY',
+                                    },
+                                    {
+                                        'constraint_column_names': [],
+                                        'constraint_column_usage': [],
+                                        'constraint_name': 'getobjects_ints_not_null',
+                                        'constraint_type': 'CHECK',
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+        ]
+    )
 
     depth_tables = duck_conn.adbc_get_objects(depth="tables").read_all()
-    assert sorted_get_objects(depth_tables.to_pylist()) == sorted_get_objects([
-        {
-            'catalog_name': 'system',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'temp',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'memory',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': [
-                        {
-                            'table_name': 'getobjects',
-                            'table_type': 'BASE TABLE',
-                            'table_columns': [],
-                            'table_constraints': [],
-                        }
-                    ],
-                },
-            ],
-        }
-    ])
+    assert sorted_get_objects(depth_tables.to_pylist()) == sorted_get_objects(
+        [
+            {
+                'catalog_name': 'system',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'temp',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'memory',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': [
+                            {
+                                'table_name': 'getobjects',
+                                'table_type': 'BASE TABLE',
+                                'table_columns': [],
+                                'table_constraints': [],
+                            }
+                        ],
+                    },
+                ],
+            },
+        ]
+    )
 
     depth_db_schemas = duck_conn.adbc_get_objects(depth="db_schemas").read_all()
-    assert sorted_get_objects(depth_db_schemas.to_pylist()) == sorted_get_objects([
-        {
-            'catalog_name': 'system',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'temp',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'memory',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': [],
-                },
-            ],
-        }
-    ])
+    assert sorted_get_objects(depth_db_schemas.to_pylist()) == sorted_get_objects(
+        [
+            {
+                'catalog_name': 'system',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'temp',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'memory',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': [],
+                    },
+                ],
+            },
+        ]
+    )
 
     depth_catalogs = duck_conn.adbc_get_objects(depth="catalogs").read_all()
-    assert sorted_get_objects(depth_catalogs.to_pylist()) == sorted_get_objects([
-        {
-            'catalog_name': 'system',
-            'catalog_db_schemas': [],
-        },
-        {
-            'catalog_name': 'temp',
-            'catalog_db_schemas': [],
-        },
-        {
-            'catalog_name': 'memory',
-            'catalog_db_schemas': [],
-        },
-    ])
+    assert sorted_get_objects(depth_catalogs.to_pylist()) == sorted_get_objects(
+        [
+            {
+                'catalog_name': 'system',
+                'catalog_db_schemas': [],
+            },
+            {
+                'catalog_name': 'temp',
+                'catalog_db_schemas': [],
+            },
+            {
+                'catalog_name': 'memory',
+                'catalog_db_schemas': [],
+            },
+        ]
+    )
 
     # All result schemas should be the same
     assert depth_all.schema == depth_tables.schema
@@ -287,247 +295,255 @@ def test_connection_get_objects_filters(duck_conn):
         cursor.execute("CREATE TABLE getobjects (ints BIGINT PRIMARY KEY)")
 
     no_filter = duck_conn.adbc_get_objects(depth="all").read_all()
-    assert sorted_get_objects(no_filter.to_pylist()) == sorted_get_objects([
-        {
-            'catalog_name': 'system',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'temp',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'memory',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': [
-                        {
-                            'table_name': 'getobjects',
-                            'table_type': 'BASE TABLE',
-                            'table_columns': [
-                                {
-                                    'column_name': 'ints',
-                                    'ordinal_position': 1,
-                                    'remarks': '',
-                                    'xdbc_char_octet_length': None,
-                                    'xdbc_column_def': None,
-                                    'xdbc_column_size': None,
-                                    'xdbc_data_type': None,
-                                    'xdbc_datetime_sub': None,
-                                    'xdbc_decimal_digits': None,
-                                    'xdbc_is_autoincrement': None,
-                                    'xdbc_is_generatedcolumn': None,
-                                    'xdbc_is_nullable': None,
-                                    'xdbc_nullable': None,
-                                    'xdbc_num_prec_radix': None,
-                                    'xdbc_scope_catalog': None,
-                                    'xdbc_scope_schema': None,
-                                    'xdbc_scope_table': None,
-                                    'xdbc_sql_data_type': None,
-                                    'xdbc_type_name': None,
-                                },
-                            ],
-                            'table_constraints': [
-                                {
-                                    'constraint_column_names': [],
-                                    'constraint_column_usage': [],
-                                    'constraint_name': 'getobjects_ints_pkey',
-                                    'constraint_type': 'PRIMARY KEY',
-                                },
-                                {
-                                    'constraint_column_names': [],
-                                    'constraint_column_usage': [],
-                                    'constraint_name': 'getobjects_ints_not_null',
-                                    'constraint_type': 'CHECK',
-                                },
-                            ],
-                        }
-                    ],
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        }
-    ])
+    assert sorted_get_objects(no_filter.to_pylist()) == sorted_get_objects(
+        [
+            {
+                'catalog_name': 'system',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'temp',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'memory',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': [
+                            {
+                                'table_name': 'getobjects',
+                                'table_type': 'BASE TABLE',
+                                'table_columns': [
+                                    {
+                                        'column_name': 'ints',
+                                        'ordinal_position': 1,
+                                        'remarks': '',
+                                        'xdbc_char_octet_length': None,
+                                        'xdbc_column_def': None,
+                                        'xdbc_column_size': None,
+                                        'xdbc_data_type': None,
+                                        'xdbc_datetime_sub': None,
+                                        'xdbc_decimal_digits': None,
+                                        'xdbc_is_autoincrement': None,
+                                        'xdbc_is_generatedcolumn': None,
+                                        'xdbc_is_nullable': None,
+                                        'xdbc_nullable': None,
+                                        'xdbc_num_prec_radix': None,
+                                        'xdbc_scope_catalog': None,
+                                        'xdbc_scope_schema': None,
+                                        'xdbc_scope_table': None,
+                                        'xdbc_sql_data_type': None,
+                                        'xdbc_type_name': None,
+                                    },
+                                ],
+                                'table_constraints': [
+                                    {
+                                        'constraint_column_names': [],
+                                        'constraint_column_usage': [],
+                                        'constraint_name': 'getobjects_ints_pkey',
+                                        'constraint_type': 'PRIMARY KEY',
+                                    },
+                                    {
+                                        'constraint_column_names': [],
+                                        'constraint_column_usage': [],
+                                        'constraint_name': 'getobjects_ints_not_null',
+                                        'constraint_type': 'CHECK',
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+        ]
+    )
 
     column_filter = duck_conn.adbc_get_objects(depth="all", column_name_filter="notexist").read_all()
-    assert sorted_get_objects(column_filter.to_pylist()) == sorted_get_objects([
-        {
-            'catalog_name': 'system',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'temp',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'memory',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': [
-                        {
-                            'table_name': 'getobjects',
-                            'table_type': 'BASE TABLE',
-                            'table_columns': None,
-                            'table_constraints': [
-                                {
-                                    'constraint_column_names': [],
-                                    'constraint_column_usage': [],
-                                    'constraint_name': 'getobjects_ints_pkey',
-                                    'constraint_type': 'PRIMARY KEY',
-                                },
-                                {
-                                    'constraint_column_names': [],
-                                    'constraint_column_usage': [],
-                                    'constraint_name': 'getobjects_ints_not_null',
-                                    'constraint_type': 'CHECK',
-                                },
-                            ],
-                        }
-                    ],
-                },
-            ],
-        }
-    ])
+    assert sorted_get_objects(column_filter.to_pylist()) == sorted_get_objects(
+        [
+            {
+                'catalog_name': 'system',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'temp',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'memory',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': [
+                            {
+                                'table_name': 'getobjects',
+                                'table_type': 'BASE TABLE',
+                                'table_columns': None,
+                                'table_constraints': [
+                                    {
+                                        'constraint_column_names': [],
+                                        'constraint_column_usage': [],
+                                        'constraint_name': 'getobjects_ints_pkey',
+                                        'constraint_type': 'PRIMARY KEY',
+                                    },
+                                    {
+                                        'constraint_column_names': [],
+                                        'constraint_column_usage': [],
+                                        'constraint_name': 'getobjects_ints_not_null',
+                                        'constraint_type': 'CHECK',
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+        ]
+    )
 
     table_name_filter = duck_conn.adbc_get_objects(depth="all", table_name_filter="notexist").read_all()
-    assert sorted_get_objects(table_name_filter.to_pylist()) == sorted_get_objects([
-        {
-            'catalog_name': 'system',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'temp',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        },
-        {
-            'catalog_name': 'memory',
-            'catalog_db_schemas': [
-                {
-                    'db_schema_name': 'information_schema',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'main',
-                    'db_schema_tables': None,
-                },
-                {
-                    'db_schema_name': 'pg_catalog',
-                    'db_schema_tables': None,
-                },
-            ],
-        }
-    ])
+    assert sorted_get_objects(table_name_filter.to_pylist()) == sorted_get_objects(
+        [
+            {
+                'catalog_name': 'system',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'temp',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+            {
+                'catalog_name': 'memory',
+                'catalog_db_schemas': [
+                    {
+                        'db_schema_name': 'information_schema',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'main',
+                        'db_schema_tables': None,
+                    },
+                    {
+                        'db_schema_name': 'pg_catalog',
+                        'db_schema_tables': None,
+                    },
+                ],
+            },
+        ]
+    )
 
     db_schema_filter = duck_conn.adbc_get_objects(depth="all", db_schema_filter="notexist").read_all()
-    assert sorted_get_objects(db_schema_filter.to_pylist()) == sorted_get_objects([
-        {
-            'catalog_name': 'system',
-            'catalog_db_schemas': None,
-        },
-        {
-            'catalog_name': 'temp',
-            'catalog_db_schemas': None,
-        },
-        {
-            'catalog_name': 'memory',
-            'catalog_db_schemas': None,
-        }
-    ])
+    assert sorted_get_objects(db_schema_filter.to_pylist()) == sorted_get_objects(
+        [
+            {
+                'catalog_name': 'system',
+                'catalog_db_schemas': None,
+            },
+            {
+                'catalog_name': 'temp',
+                'catalog_db_schemas': None,
+            },
+            {
+                'catalog_name': 'memory',
+                'catalog_db_schemas': None,
+            },
+        ]
+    )
 
     catalog_filter = duck_conn.adbc_get_objects(depth="all", catalog_filter="notexist").read_all()
     assert catalog_filter.to_pylist() == []
@@ -719,6 +735,7 @@ def test_read(duck_conn):
             ],
         }
 
+
 def sorted_get_objects(catalogs):
     res = []
     for catalog in sorted(catalogs, key=lambda cat: cat['catalog_name']):
@@ -726,13 +743,13 @@ def sorted_get_objects(catalogs):
             "catalog_name": catalog['catalog_name'],
             "catalog_db_schemas": [],
         }
-        
+
         for db_schema in sorted(catalog['catalog_db_schemas'] or [], key=lambda sch: sch['db_schema_name']):
             new_db_schema = {
                 "db_schema_name": db_schema['db_schema_name'],
                 "db_schema_tables": [],
             }
-            
+
             for table in sorted(db_schema['db_schema_tables'] or [], key=lambda tab: tab['table_name']):
                 new_table = {
                     "table_name": table['table_name'],
@@ -740,13 +757,13 @@ def sorted_get_objects(catalogs):
                     "table_columns": [],
                     "table_constraints": [],
                 }
-                
+
                 for column in sorted(table['table_columns'] or [], key=lambda col: col['ordinal_position']):
                     new_table["table_columns"].append(column)
-                    
+
                 for constraint in sorted(table['table_constraints'] or [], key=lambda con: con['constraint_name']):
                     new_table["table_constraints"].append(constraint)
-                    
+
                 new_db_schema["db_schema_tables"].append(new_table)
             new_catalog["catalog_db_schemas"].append(new_db_schema)
         res.append(new_catalog)

--- a/tools/pythonpkg/tests/fast/adbc/test_adbc.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_adbc.py
@@ -47,10 +47,48 @@ def test_connection_get_objects(duck_conn):
     with duck_conn.cursor() as cursor:
         cursor.execute("CREATE TABLE getobjects (ints BIGINT PRIMARY KEY)")
         depth_all = duck_conn.adbc_get_objects(depth="all").read_all()
-    assert depth_all.to_pylist() == [
+    assert sorted_get_objects(depth_all.to_pylist()) == sorted_get_objects([
+        {
+            'catalog_name': 'system',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
+        {
+            'catalog_name': 'temp',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
         {
             'catalog_name': 'memory',
             'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
                 {
                     'db_schema_name': 'main',
                     'db_schema_tables': [
@@ -97,15 +135,61 @@ def test_connection_get_objects(duck_conn):
                         }
                     ],
                 },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
             ],
         }
-    ]
+    ])
 
     depth_tables = duck_conn.adbc_get_objects(depth="tables").read_all()
-    assert depth_tables.to_pylist() == [
+    assert sorted_get_objects(depth_tables.to_pylist()) == sorted_get_objects([
+        {
+            'catalog_name': 'system',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
+        {
+            'catalog_name': 'temp',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
         {
             'catalog_name': 'memory',
             'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
                 {
                     'db_schema_name': 'main',
                     'db_schema_tables': [
@@ -119,28 +203,78 @@ def test_connection_get_objects(duck_conn):
                 },
             ],
         }
-    ]
+    ])
 
     depth_db_schemas = duck_conn.adbc_get_objects(depth="db_schemas").read_all()
-    assert depth_db_schemas.to_pylist() == [
+    assert sorted_get_objects(depth_db_schemas.to_pylist()) == sorted_get_objects([
+        {
+            'catalog_name': 'system',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
+        {
+            'catalog_name': 'temp',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
         {
             'catalog_name': 'memory',
             'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
                 {
                     'db_schema_name': 'main',
                     'db_schema_tables': [],
                 },
             ],
         }
-    ]
+    ])
 
     depth_catalogs = duck_conn.adbc_get_objects(depth="catalogs").read_all()
-    assert depth_catalogs.to_pylist() == [
+    assert sorted_get_objects(depth_catalogs.to_pylist()) == sorted_get_objects([
+        {
+            'catalog_name': 'system',
+            'catalog_db_schemas': [],
+        },
+        {
+            'catalog_name': 'temp',
+            'catalog_db_schemas': [],
+        },
         {
             'catalog_name': 'memory',
             'catalog_db_schemas': [],
-        }
-    ]
+        },
+    ])
 
     # All result schemas should be the same
     assert depth_all.schema == depth_tables.schema
@@ -153,10 +287,48 @@ def test_connection_get_objects_filters(duck_conn):
         cursor.execute("CREATE TABLE getobjects (ints BIGINT PRIMARY KEY)")
 
     no_filter = duck_conn.adbc_get_objects(depth="all").read_all()
-    assert no_filter.to_pylist() == [
+    assert sorted_get_objects(no_filter.to_pylist()) == sorted_get_objects([
+        {
+            'catalog_name': 'system',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
+        {
+            'catalog_name': 'temp',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
         {
             'catalog_name': 'memory',
             'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
                 {
                     'db_schema_name': 'main',
                     'db_schema_tables': [
@@ -203,15 +375,61 @@ def test_connection_get_objects_filters(duck_conn):
                         }
                     ],
                 },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
             ],
         }
-    ]
+    ])
 
     column_filter = duck_conn.adbc_get_objects(depth="all", column_name_filter="notexist").read_all()
-    assert column_filter.to_pylist() == [
+    assert sorted_get_objects(column_filter.to_pylist()) == sorted_get_objects([
+        {
+            'catalog_name': 'system',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
+        {
+            'catalog_name': 'temp',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
         {
             'catalog_name': 'memory',
             'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
                 {
                     'db_schema_name': 'main',
                     'db_schema_tables': [
@@ -238,28 +456,78 @@ def test_connection_get_objects_filters(duck_conn):
                 },
             ],
         }
-    ]
+    ])
 
     table_name_filter = duck_conn.adbc_get_objects(depth="all", table_name_filter="notexist").read_all()
-    assert table_name_filter.to_pylist() == [
+    assert sorted_get_objects(table_name_filter.to_pylist()) == sorted_get_objects([
         {
-            'catalog_name': 'memory',
+            'catalog_name': 'system',
             'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
                 {
                     'db_schema_name': 'main',
                     'db_schema_tables': None,
                 },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
+        {
+            'catalog_name': 'temp',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
+            ],
+        },
+        {
+            'catalog_name': 'memory',
+            'catalog_db_schemas': [
+                {
+                    'db_schema_name': 'information_schema',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'main',
+                    'db_schema_tables': None,
+                },
+                {
+                    'db_schema_name': 'pg_catalog',
+                    'db_schema_tables': None,
+                },
             ],
         }
-    ]
+    ])
 
     db_schema_filter = duck_conn.adbc_get_objects(depth="all", db_schema_filter="notexist").read_all()
-    assert db_schema_filter.to_pylist() == [
+    assert sorted_get_objects(db_schema_filter.to_pylist()) == sorted_get_objects([
+        {
+            'catalog_name': 'system',
+            'catalog_db_schemas': None,
+        },
+        {
+            'catalog_name': 'temp',
+            'catalog_db_schemas': None,
+        },
         {
             'catalog_name': 'memory',
             'catalog_db_schemas': None,
         }
-    ]
+    ])
 
     catalog_filter = duck_conn.adbc_get_objects(depth="all", catalog_filter="notexist").read_all()
     assert catalog_filter.to_pylist() == []
@@ -450,3 +718,37 @@ def test_read(duck_conn):
                 datetime.datetime(2006, 2, 15, 4, 46, 27),
             ],
         }
+
+def sorted_get_objects(catalogs):
+    res = []
+    for catalog in sorted(catalogs, key=lambda cat: cat['catalog_name']):
+        new_catalog = {
+            "catalog_name": catalog['catalog_name'],
+            "catalog_db_schemas": [],
+        }
+        
+        for db_schema in sorted(catalog['catalog_db_schemas'] or [], key=lambda sch: sch['db_schema_name']):
+            new_db_schema = {
+                "db_schema_name": db_schema['db_schema_name'],
+                "db_schema_tables": [],
+            }
+            
+            for table in sorted(db_schema['db_schema_tables'] or [], key=lambda tab: tab['table_name']):
+                new_table = {
+                    "table_name": table['table_name'],
+                    "table_type": table['table_type'],
+                    "table_columns": [],
+                    "table_constraints": [],
+                }
+                
+                for column in sorted(table['table_columns'] or [], key=lambda col: col['ordinal_position']):
+                    new_table["table_columns"].append(column)
+                    
+                for constraint in sorted(table['table_constraints'] or [], key=lambda con: con['constraint_name']):
+                    new_table["table_constraints"].append(constraint)
+                    
+                new_db_schema["db_schema_tables"].append(new_table)
+            new_catalog["catalog_db_schemas"].append(new_db_schema)
+        res.append(new_catalog)
+
+    return res


### PR DESCRIPTION
Follow-up to: #11446

Removes filtering of system catalogs (`system`, `temp`) and schemas (`information_schema`, `pg_catalog`). There is no actual requirement to omit these objects and by leaving them in, the client may decide themselves whether to include them.

Additionally, adding these catalogs/schemas surfaced a bug in the previous implementation where other objects were getting duplicated because of a bad join on the schemata. This has been corrected in the underlying SQL queries.