### PR TITLE
Upload pyodide

### DIFF
--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -97,3 +97,11 @@ jobs:
           if-no-files-found: error
           path: |
             ./tools/pythonpkg/dist/*.whl
+
+      - name: Deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+        shell: bash
+        run: |
+          ./scripts/upload-assets-to-staging.sh pyodide tools/pythonpkg/dist/*.whl

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -206,7 +206,9 @@ if 'BUILD_HTTPFS' in os.environ:
 for ext in extensions:
     define_macros.append(('DUCKDB_EXTENSION_{}_LINKED'.format(ext.upper()), None))
 
-define_macros.extend([('DUCKDB_EXTENSION_AUTOLOAD_DEFAULT', '1'), ('DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT', '1')])
+if not is_pyodide:
+    # currently pyodide environment is not compatible with dynamic extesion loading
+    define_macros.extend([('DUCKDB_EXTENSION_AUTOLOAD_DEFAULT', '1'), ('DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT', '1')])
 
 linker_args = toolchain_args[:]
 if platform.system() == 'Windows':

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -207,7 +207,7 @@ for ext in extensions:
     define_macros.append(('DUCKDB_EXTENSION_{}_LINKED'.format(ext.upper()), None))
 
 if not is_pyodide:
-    # currently pyodide environment is not compatible with dynamic extesion loading
+    # currently pyodide environment is not compatible with dynamic extension loading
     define_macros.extend([('DUCKDB_EXTENSION_AUTOLOAD_DEFAULT', '1'), ('DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT', '1')])
 
 linker_args = toolchain_args[:]


### PR DESCRIPTION
Avoid triggering of autoinstall / autoload on pyodide, that are currently not working.
This should make for nicer (and recoverable) error messages.

Also upload pyodide build to bucket, step towards making them available.