### PR TITLE
Avoid performing Apple codesign on extensions

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -262,17 +262,6 @@ jobs:
         run: |
           python3 scripts/run_tests_one_by_one.py ./build/release/test/unittest
 
-      - name: Sign Extension Binaries
-        env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.OSX_CODESIGN_BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.OSX_CODESIGN_P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.OSX_CODESIGN_KEYCHAIN_PASSWORD }}
-        run: |
-          if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-          . scripts/osx_import_codesign_certificate.sh
-          codesign --all-architectures --force --sign "Developer ID Application: Stichting DuckDB Foundation" build/release/extension/*/*.duckdb_extension
-          fi
-
       - name: Deploy
         shell: bash
         env:


### PR DESCRIPTION
We have our own signing mechanism, and they conflict making the Apple signature invalid

Until a few days ago, for nightly or releases extensions, we built the binary, codesigned, then applied our signature on top (making the Apple signature not valid anymore).
With the extension metadata rework, we applied our own signature as part of cmake, and this breaks the preconditions of Apple codesigning.
Even if that would be solved, we still modify the binary afterwards.

And another connected problem: codesigning was performed only for extensions built directly by duckdb/duckdb workflows, and not for out-out-tree ones (then possibly updated to extensions.duckdb.org).

All consider, I think the proper solution is just removing the codesigning step on extensions. To be reviewed whether it makes sense and can be introduced everywhere.