### PR TITLE
Skip tests with the unzip keyword in python and disable unzip.test for 32bit systems

### DIFF
--- a/scripts/parser_test.py
+++ b/scripts/parser_test.py
@@ -1,4 +1,4 @@
-from sqllogictest import SQLLogicParser, SQLLogicTest
+from sqllogictest import SQLParserException, SQLLogicParser, SQLLogicTest
 
 from typing import Optional
 import argparse
@@ -14,7 +14,7 @@ def main():
     parser = SQLLogicParser()
     out: Optional[SQLLogicTest] = parser.parse(filename)
     if not out:
-        raise Exception(f"Test {filename} could not be parsed")
+        raise SQLParserException(f"Test {filename} could not be parsed")
 
 
 if __name__ == "__main__":

--- a/scripts/sqllogictest/__init__.py
+++ b/scripts/sqllogictest/__init__.py
@@ -24,7 +24,7 @@ from .statement import (
 )
 from .decorator import SkipIf, OnlyIf
 from .expected_result import ExpectedResult
-from .parser import SQLLogicParser
+from .parser import SQLLogicParser, SQLParserException
 
 __all__ = [
     TokenType,
@@ -54,4 +54,5 @@ __all__ = [
     SkipIf,
     OnlyIf,
     SQLLogicParser,
+    SQLParserException,
 ]

--- a/scripts/sqllogictest/parser/__init__.py
+++ b/scripts/sqllogictest/parser/__init__.py
@@ -1,3 +1,3 @@
-from .parser import SQLLogicParser, SQLLogicTest
+from .parser import SQLLogicParser, SQLParserException, SQLLogicTest
 
-__all__ = [SQLLogicParser, SQLLogicTest]
+__all__ = [SQLLogicParser, SQLParserException, SQLLogicTest]

--- a/scripts/sqllogictest/parser/parser.py
+++ b/scripts/sqllogictest/parser/parser.py
@@ -53,6 +53,10 @@ def is_space(char: str):
 
 
 ### -------- PARSER ----------
+class SQLParserException(Exception):
+    def __init__(self, message):
+        self.message = "Parser Error: " + message
+        super().__init__(self.message)
 
 
 class SQLLogicParser:
@@ -102,18 +106,18 @@ class SQLLogicParser:
 
     def peek_no_strip(self):
         if self.current_line >= len(self.lines):
-            raise Exception("File already fully consumed")
+            raise SQLParserException("File already fully consumed")
         return self.lines[self.current_line]
 
     def consume(self):
         if self.current_line >= len(self.lines):
-            raise Exception("File already fully consumed")
+            raise SQLParserException("File already fully consumed")
         self.current_line += 1
 
     def fail(self, message):
         file_path = self.current_test.path
         error_message = f"{file_path}:{self.current_line + 1}: {message}"
-        raise Exception(error_message)
+        raise SQLParserException(error_message)
 
     def get_expected_result(self, statement_type: str) -> ExpectedResult:
         type_map = {
@@ -530,7 +534,7 @@ def main():
     parser = SQLLogicParser()
     out: Optional[SQLLogicTest] = parser.parse(filename)
     if not out:
-        raise Exception(f"Test {filename} could not be parsed")
+        raise SQLParserException(f"Test {filename} could not be parsed")
 
 
 if __name__ == "__main__":

--- a/scripts/sqllogictest/test.py
+++ b/scripts/sqllogictest/test.py
@@ -3,18 +3,14 @@ from .base_statement import BaseStatement
 
 
 class SQLLogicTest:
-    __slots__ = ['path', 'statements', 'skipped']
+    __slots__ = ['path', 'statements']
 
     def __init__(self, path: str):
         self.path: str = path
         self.statements: List[BaseStatement] = []
-        self.skipped = False
 
     def add_statement(self, statement: BaseStatement):
         self.statements.append(statement)
 
     def is_sqlite_test(self):
         return 'test/sqlite/select' in self.path or 'third_party/sqllogictest' in self.path
-
-    def skip(self, val):
-        self.skipped = val

--- a/scripts/sqllogictest/test.py
+++ b/scripts/sqllogictest/test.py
@@ -3,14 +3,18 @@ from .base_statement import BaseStatement
 
 
 class SQLLogicTest:
-    __slots__ = ['path', 'statements']
+    __slots__ = ['path', 'statements', 'skipped']
 
     def __init__(self, path: str):
         self.path: str = path
         self.statements: List[BaseStatement] = []
+        self.skipped = False
 
     def add_statement(self, statement: BaseStatement):
         self.statements.append(statement)
 
     def is_sqlite_test(self):
         return 'test/sqlite/select' in self.path or 'third_party/sqllogictest' in self.path
+
+    def skip(self, val):
+        self.skipped = val

--- a/test/sql/storage/unzip.test
+++ b/test/sql/storage/unzip.test
@@ -2,6 +2,16 @@
 # description: Support gzipped files in the test runner
 # group: [storage]
 
+# data/storage/index_0-9-1.db was written with a 64-bit version of duckdb
+require 64bit
+
+require block_size 262144
+
+require vector_size 2048
+
+statement ok
+PRAGMA enable_verification
+
 # unzip to specific path
 unzip data/storage/test.db.gz __TEST_DIR__/test.db
 

--- a/test/sql/storage/unzip.test
+++ b/test/sql/storage/unzip.test
@@ -12,7 +12,7 @@ SELECT a+1 FROM tbl;
 ----
 6
 
-# unzip a 1.8M file to default extraction path -> __TEST_DIR__/
+# unzip a 1.8M file into the default extraction path -> __TEST_DIR__/
 unzip data/storage/index_0-9-1.db.gz
 
 load __TEST_DIR__/index_0-9-1.db readonly

--- a/test/sqlite/sqllogic_command.hpp
+++ b/test/sqlite/sqllogic_command.hpp
@@ -146,7 +146,7 @@ private:
 class UnzipCommand : public Command {
 public:
 	// 1 MB
-	static constexpr const int64_t BUFFER_SIZE = 1u << 23;
+	static constexpr const int64_t BUFFER_SIZE = 1u << 20;
 
 public:
 	UnzipCommand(SQLLogicTestRunner &runner, string &input, string &output);

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -173,12 +173,11 @@ def main():
         if test_directory:
             file_path = os.path.join(test_directory, file_path)
 
-        test = SQLLogicTest("")
         try:
             test = sql_parser.parse(file_path)
-            if not test:
-                raise SQLParserException(f'failed to parse {file_path}')
         except SQLParserException as e:
+            if not ("test" in locals()):  # test hasn't been initialized because of the raised exception
+                test = SQLLogicTest("")
             test.skip(True)
             executor.skip_log.append(str(e.message))
 

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -96,9 +96,6 @@ class SQLLogicTestExecutor(SQLLogicRunner):
             # Yield once to represent one iteration, do not touch the keywords
             yield None
 
-        if self.test.skipped:
-            return ExecuteResult(ExecuteResult.Type.SKIPPED)
-
         self.database = SQLLogicDatabase(':memory:', None)
         pool = self.database.connect()
         context = SQLLogicContext(pool, self, test.statements, keywords, update_value)
@@ -176,10 +173,8 @@ def main():
         try:
             test = sql_parser.parse(file_path)
         except SQLParserException as e:
-            if not ("test" in locals()):  # test hasn't been initialized because of the raised exception
-                test = SQLLogicTest("")
-            test.skip(True)
             executor.skip_log.append(str(e.message))
+            continue
 
         print(f'[{i}/{total_tests}] {file_path}')
         # This is necessary to clean up databases/connections


### PR DESCRIPTION
This PR includes two changes:
1. Tests involving the `unzip` functionality are avoided in Python's test runner (this is not supported yet). 
2. The `unzip.test` requires: 
- a 64-bit system (this is because the `data/storage/index_0-9-1.db` is being written with a 64-bit version of duckdb)
- a maximum `block_size` of `262144`
- a maximum `vector_size` of `2048`