### PR TITLE
Include falloc to fix build on some Linux systems

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -40,6 +40,7 @@ extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG)
 #endif
 
 #if defined(__linux__)
+#include <linux/falloc.h>
 #include <libgen.h>
 // See e.g.:
 // https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html


### PR DESCRIPTION
Build was failing for me on Ubuntu 20.04, though it works in the CI. See discussion here: https://github.com/duckdb/duckdb/discussions/11640