### PR TITLE
Make UNION BY NAME also use ForceMaxLogicalType, similar to UNION

### DIFF
--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -118,8 +118,8 @@ static void BuildUnionByNameInfo(ClientContext &context, BoundSetOperationNode &
 		bool right_exist = right_index != right_names_map.end();
 		LogicalType result_type;
 		if (left_exist && right_exist) {
-			result_type = LogicalType::MaxLogicalType(context, left_node.types[left_index->second],
-			                                          right_node.types[right_index->second]);
+			result_type = LogicalType::ForceMaxLogicalType(left_node.types[left_index->second],
+			                                               right_node.types[right_index->second]);
 			if (left_index->second != i || right_index->second != i) {
 				need_reorder = true;
 			}

--- a/test/sql/setops/test_union_all_by_name.test
+++ b/test/sql/setops/test_union_all_by_name.test
@@ -220,10 +220,10 @@ NULL	1
 
 ########## type cast
 
-statement error
+query I
 SELECT DISTINCT ON(x) x FROM (SELECT 1 as x UNION ALL BY NAME SELECT '1' as x);
 ----
-an explicit cast is required
+1
 
 # have to sort here too because distinct on is hash-based, does not preserve order
 query I sort

--- a/test/sql/setops/test_union_by_name.test
+++ b/test/sql/setops/test_union_by_name.test
@@ -146,6 +146,15 @@ NULL	3
 1	NULL
 3	NULL
 
+# union by name with different types
+query I
+select '0' as c union all select 0 as c;
+----
+0
+0
 
-
-
+query I
+select '0' as c union all by name select 0 as c;
+----
+0
+0

--- a/test/sql/setops/test_union_by_name.test
+++ b/test/sql/setops/test_union_by_name.test
@@ -158,3 +158,19 @@ select '0' as c union all by name select 0 as c;
 ----
 0
 0
+
+query I
+select {'a': '0'} as c union all by name select {'a': 0} as c
+----
+{'a': 0}
+{'a': 0}
+
+statement error
+select {'a': 'hello'} as c union all by name select {'b': 'hello'} as c;
+----
+Type Error
+
+statement error
+select {'a': 'hello'} as c union all by name select {'a': 'hello', 'b': 'world'} as c;
+----
+Type Error


### PR DESCRIPTION
This makes `UNION BY NAME` work with types that are not implicitly castable to one another, which is the same behavior that `UNION ALL` has. 