### PR TITLE
 Fix #11542 - correctly check if a column data segment has updates, and clean up the updates

### DIFF
--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -75,6 +75,8 @@ public:
 	virtual void SetStart(idx_t new_start);
 	//! The root type of the column
 	const LogicalType &RootType() const;
+	//! Whether or not the column has any updates
+	virtual bool HasUpdates() const;
 
 	//! Initialize a scan of the column
 	virtual void InitializeScan(ColumnScanState &state);
@@ -163,7 +165,7 @@ protected:
 	//! The segments holding the data of this column segment
 	ColumnSegmentTree data;
 	//! The lock for the updates
-	mutex update_lock;
+	mutable mutex update_lock;
 	//! The updates for this column segment
 	unique_ptr<UpdateSegment> updates;
 	//! The stats of the root segment

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -161,6 +161,13 @@ protected:
 	template <bool SCAN_COMMITTED, bool ALLOW_UPDATES>
 	idx_t ScanVector(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result);
 
+	void ClearUpdates();
+	void FetchUpdates(TransactionData transaction, idx_t vector_index, Vector &result, idx_t scan_count,
+	                  bool allow_updates, bool scan_committed);
+	void FetchUpdateRow(TransactionData transaction, row_t row_id, Vector &result, idx_t result_idx);
+	void UpdateInternal(TransactionData transaction, idx_t column_index, Vector &update_vector, row_t *row_ids,
+	                    idx_t update_count, Vector &base_vector);
+
 protected:
 	//! The segments holding the data of this column segment
 	ColumnSegmentTree data;

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -23,6 +23,8 @@ public:
 	ValidityColumnData validity;
 
 public:
+	bool HasUpdates() const override;
+
 	void SetStart(idx_t new_start) override;
 	bool CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -21,6 +21,10 @@ void StandardColumnData::SetStart(idx_t new_start) {
 	validity.SetStart(new_start);
 }
 
+bool StandardColumnData::HasUpdates() const {
+	return ColumnData::HasUpdates() || validity.HasUpdates();
+}
+
 bool StandardColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
 	if (!state.segment_checked) {
 		if (!state.current) {


### PR DESCRIPTION
Fixes #11542 

The problem here was that merging updates assumed the data was represented as a flat vector. Normally this would be enforced on the upper layer (during the scan), but it was possible to emit a constant vector if (a) all values in the column were constant, (b) updates existed **only** in the validity layer. This PR addresses this by correctly checking in `ColumnData::HasUpdates` whether or not updates exist in **either** the current column, or in its validity layer.

In addition, this PR also cleans up the update code and makes sure the update lock is grabbed whenever `updates` is accessed instead of holding onto it unnecessarily for the entirety of the checkpoint.