### PR TITLE
Fix #11621 - correctly zero-initialize padding bits in bitpacking compression

### DIFF
--- a/scripts/test_zero_initialize.py
+++ b/scripts/test_zero_initialize.py
@@ -27,6 +27,7 @@ test_list = [
     'test/sql/storage/update/test_store_null_updates.test',
     'test/sql/storage/test_store_integers.test',
     'test/sql/storage/mix/test_update_delete_string.test',
+    'test/sql/storage/nested/struct_of_lists_unaligned.test',
 ]
 
 

--- a/src/include/duckdb/storage/partial_block_manager.hpp
+++ b/src/include/duckdb/storage/partial_block_manager.hpp
@@ -34,7 +34,7 @@ struct UninitializedRegion {
 //! The current state of a partial block
 struct PartialBlockState {
 	//! The block id of the partial block
-	block_id_t block_id;
+	block_id_t block_id = INVALID_BLOCK;
 	//! The total bytes that we can assign to this block
 	uint32_t block_size;
 	//! Next allocation offset, and also the current allocation size

--- a/src/include/duckdb/storage/partial_block_manager.hpp
+++ b/src/include/duckdb/storage/partial_block_manager.hpp
@@ -34,7 +34,7 @@ struct UninitializedRegion {
 //! The current state of a partial block
 struct PartialBlockState {
 	//! The block id of the partial block
-	block_id_t block_id = INVALID_BLOCK;
+	block_id_t block_id;
 	//! The total bytes that we can assign to this block
 	uint32_t block_size;
 	//! Next allocation offset, and also the current allocation size

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -514,7 +514,8 @@ public:
 		auto base_ptr = handle.Ptr();
 
 		// Compact the segment by moving the metadata next to the data.
-		idx_t metadata_offset = AlignValue(data_ptr - base_ptr);
+		idx_t unaligned_offset = data_ptr - base_ptr;
+		idx_t metadata_offset = AlignValue(unaligned_offset);
 		idx_t metadata_size = base_ptr + Storage::BLOCK_SIZE - metadata_ptr;
 		idx_t total_segment_size = metadata_offset + metadata_size;
 
@@ -523,6 +524,10 @@ public:
 			throw InternalException("Error in bitpacking size calculation");
 		}
 
+		if (unaligned_offset != metadata_offset) {
+			// zero initialize any padding bits
+			memset(base_ptr + unaligned_offset, 0, metadata_offset - unaligned_offset);
+		}
 		memmove(base_ptr + metadata_offset, metadata_ptr, metadata_size);
 
 		// Store the offset of the metadata of the first group (which is at the highest address).

--- a/test/sql/storage/nested/struct_of_lists_unaligned.test
+++ b/test/sql/storage/nested/struct_of_lists_unaligned.test
@@ -1,0 +1,15 @@
+# name: test/sql/storage/nested/struct_of_lists_unaligned.test
+# description: Test storage of structs with lists in it
+# group: [nested]
+
+# load the DB from disk
+load __TEST_DIR__/test_store_list_of_structs.db
+
+statement ok
+CREATE TABLE test_list_2 (a integer, b STRUCT(c VARCHAR[], d VARCHAR[], e INTEGER[]));
+
+statement ok
+INSERT INTO test_list_2 SELECT 1, row(['a', 'b', 'c', 'd', 'e', 'f'], ['A', 'B'], [1, 5, 9]) FROM range(10);
+
+statement ok
+CHECKPOINT;

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -1061,6 +1061,7 @@ Linenoise::Linenoise(int stdin_fd, int stdout_fd, char *buf, size_t buflen, cons
 	render = true;
 	continuation_markers = true;
 	insert = false;
+	search_index = 0;
 
 	/* Buffer starts empty. */
 	buf[0] = '\0';


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/11621