### PR TITLE
Fix #11484: support constant indexes in ARRAY - e.g. `ARRAY(SELECT .. ORDER BY 1)`

### DIFF
--- a/src/parser/transform/expression/transform_subquery.cpp
+++ b/src/parser/transform/expression/transform_subquery.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/parser/transformer.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/positional_reference_expression.hpp"
 
 namespace duckdb {
 
@@ -69,10 +71,26 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(duckdb_libpgquery::P
 		vector<unique_ptr<ParsedExpression>> children;
 		children.push_back(std::move(columns_star));
 		auto aggr = make_uniq<FunctionExpression>("array_agg", std::move(children));
+		// push ORDER BY modifiers into the array_agg
 		for (auto &modifier : subquery_expr->subquery->node->modifiers) {
 			if (modifier->type == ResultModifierType::ORDER_MODIFIER) {
 				aggr->order_bys = unique_ptr_cast<ResultModifier, OrderModifier>(modifier->Copy());
 				break;
+			}
+		}
+		// transform constants (e.g. ORDER BY 1) into positional references (ORDER BY #1)
+		if (aggr->order_bys) {
+			for (auto &order : aggr->order_bys->orders) {
+				if (order.expression->type == ExpressionType::VALUE_CONSTANT) {
+					auto &constant_expr = order.expression->Cast<ConstantExpression>();
+					Value bigint_value;
+					string error;
+					if (constant_expr.value.DefaultTryCastAs(LogicalType::BIGINT, bigint_value, &error)) {
+						int64_t order_index = BigIntValue::Get(bigint_value);
+						idx_t positional_index = order_index < 0 ? NumericLimits<idx_t>::Maximum() : order_index;
+						order.expression = make_uniq<PositionalReferenceExpression>(positional_index);
+					}
+				}
 			}
 		}
 		// ARRAY_AGG(COLUMNS(*)) IS NULL

--- a/src/parser/transform/expression/transform_subquery.cpp
+++ b/src/parser/transform/expression/transform_subquery.cpp
@@ -87,7 +87,7 @@ unique_ptr<ParsedExpression> Transformer::TransformSubquery(duckdb_libpgquery::P
 					string error;
 					if (constant_expr.value.DefaultTryCastAs(LogicalType::BIGINT, bigint_value, &error)) {
 						int64_t order_index = BigIntValue::Get(bigint_value);
-						idx_t positional_index = order_index < 0 ? NumericLimits<idx_t>::Maximum() : order_index;
+						idx_t positional_index = order_index < 0 ? NumericLimits<idx_t>::Maximum() : idx_t(order_index);
 						order.expression = make_uniq<PositionalReferenceExpression>(positional_index);
 					}
 				}

--- a/test/sql/subquery/scalar/array_order_subquery.test
+++ b/test/sql/subquery/scalar/array_order_subquery.test
@@ -37,3 +37,46 @@ select array(select unnest(l) AS i order by i desc nulls first) as a from (value
 []
 [12, 11, 10]
 
+# use integer literals
+query I
+SELECT ARRAY
+  (SELECT 1 UNION ALL
+   SELECT 2 UNION ALL
+   SELECT 3
+   ORDER by 1) AS new_array;
+----
+[1, 2, 3]
+
+query I
+SELECT ARRAY
+  (SELECT 1 UNION ALL
+   SELECT 2 UNION ALL
+   SELECT 3
+   ORDER by 1 DESC) AS new_array;
+----
+[3, 2, 1]
+
+statement error
+SELECT ARRAY
+  (SELECT 1 UNION ALL
+   SELECT 2 UNION ALL
+   SELECT 3
+   ORDER by -1) AS new_array;
+----
+ORDER term out of range
+
+statement error
+SELECT ARRAY
+  (SELECT 1 UNION ALL
+   SELECT 2 UNION ALL
+   SELECT 3
+   ORDER by 2) AS new_array;
+----
+ORDER term out of range
+
+statement ok
+SELECT ARRAY
+  (SELECT 1 UNION ALL
+   SELECT 2 UNION ALL
+   SELECT 3
+   ORDER by 'hello world') AS new_array;


### PR DESCRIPTION
Fix #11484