### PR TITLE
Improve hive type auto-casting so that it looks at all files instead of only the first file

### DIFF
--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -421,38 +421,58 @@ bool MultiFileReaderOptions::AutoDetectHivePartitioningInternal(const vector<str
 	}
 	return true;
 }
-void MultiFileReaderOptions::AutoDetectHiveTypesInternal(const string &file, ClientContext &context) {
+void MultiFileReaderOptions::AutoDetectHiveTypesInternal(const vector<string> &files, ClientContext &context) {
+	const LogicalType candidates[] = {LogicalType::DATE, LogicalType::TIMESTAMP, LogicalType::BIGINT};
+
 	auto &fs = FileSystem::GetFileSystem(context);
 
-	std::map<string, string> partitions;
-	auto splits = StringUtil::Split(file, fs.PathSeparator(file));
-	if (splits.size() < 2) {
-		return;
-	}
-	for (auto it = splits.begin(); it != std::prev(splits.end()); it++) {
-		auto part = StringUtil::Split(*it, "=");
-		if (part.size() == 2) {
-			partitions[part.front()] = part.back();
+	unordered_map<string, LogicalType> detected_types;
+	for (auto &file : files) {
+		unordered_map<string, string> partitions;
+		auto splits = StringUtil::Split(file, fs.PathSeparator(file));
+		if (splits.size() < 2) {
+			return;
 		}
-	}
-	if (partitions.empty()) {
-		return;
-	}
-
-	const LogicalType candidates[] = {LogicalType::DATE, LogicalType::TIMESTAMP, LogicalType::BIGINT};
-	for (auto &part : partitions) {
-		const string &name = part.first;
-		if (hive_types_schema.find(name) != hive_types_schema.end()) {
-			continue;
-		}
-		Value value(part.second);
-		for (auto &candidate : candidates) {
-			const bool success = value.TryCastAs(context, candidate, true);
-			if (success) {
-				hive_types_schema[name] = candidate;
-				break;
+		for (auto it = splits.begin(); it != std::prev(splits.end()); it++) {
+			auto part = StringUtil::Split(*it, "=");
+			if (part.size() == 2) {
+				partitions[part.front()] = part.back();
 			}
 		}
+		if (partitions.empty()) {
+			return;
+		}
+
+		for (auto &part : partitions) {
+			const string &name = part.first;
+			if (hive_types_schema.find(name) != hive_types_schema.end()) {
+				// type was explicitly provided by the user
+				continue;
+			}
+			LogicalType detected_type = LogicalType::VARCHAR;
+			Value value(part.second);
+			for (auto &candidate : candidates) {
+				const bool success = value.TryCastAs(context, candidate, true);
+				if (success) {
+					detected_type = candidate;
+					break;
+				}
+			}
+			auto entry = detected_types.find(name);
+			if (entry == detected_types.end()) {
+				// type was not yet detected - insert it
+				detected_types.insert(make_pair(name, std::move(detected_type)));
+			} else {
+				// type was already detected - check if the type matches
+				// if not promote to VARCHAR
+				if (entry->second != detected_type) {
+					entry->second = LogicalType::VARCHAR;
+				}
+			}
+		}
+	}
+	for (auto &entry : detected_types) {
+		hive_types_schema.insert(make_pair(entry.first, std::move(entry.second)));
 	}
 }
 void MultiFileReaderOptions::AutoDetectHivePartitioning(const vector<string> &files, ClientContext &context) {
@@ -471,7 +491,7 @@ void MultiFileReaderOptions::AutoDetectHivePartitioning(const vector<string> &fi
 		hive_partitioning = AutoDetectHivePartitioningInternal(files, context);
 	}
 	if (hive_partitioning && hive_types_autocast) {
-		AutoDetectHiveTypesInternal(files.front(), context);
+		AutoDetectHiveTypesInternal(files, context);
 	}
 }
 void MultiFileReaderOptions::VerifyHiveTypesArePartitions(const std::map<string, string> &partitions) const {

--- a/src/include/duckdb/common/multi_file_reader_options.hpp
+++ b/src/include/duckdb/common/multi_file_reader_options.hpp
@@ -29,7 +29,7 @@ struct MultiFileReaderOptions {
 	DUCKDB_API void AddBatchInfo(BindInfo &bind_info) const;
 	DUCKDB_API void AutoDetectHivePartitioning(const vector<string> &files, ClientContext &context);
 	DUCKDB_API static bool AutoDetectHivePartitioningInternal(const vector<string> &files, ClientContext &context);
-	DUCKDB_API void AutoDetectHiveTypesInternal(const string &file, ClientContext &context);
+	DUCKDB_API void AutoDetectHiveTypesInternal(const vector<string> &file, ClientContext &context);
 	DUCKDB_API void VerifyHiveTypesArePartitions(const std::map<string, string> &partitions) const;
 	DUCKDB_API LogicalType GetHiveLogicalType(const string &hive_partition_column) const;
 	DUCKDB_API Value GetHivePartitionValue(const string &base, const string &entry, ClientContext &context) const;

--- a/test/sql/copy/hive_types.test
+++ b/test/sql/copy/hive_types.test
@@ -6,8 +6,8 @@
 
 require parquet
 
-# statement ok
-# PRAGMA enable_verification
+statement ok
+PRAGMA enable_verification
 
 statement ok
 copy 'data/csv/hive-partitioning/hive_types/himym.csv' to '__TEST_DIR__/partition' (format parquet, partition_by(season,director,aired));
@@ -86,6 +86,22 @@ select typeof(season),typeof(director),typeof(aired) from read_parquet('__TEST_D
 ----
 BIGINT	VARCHAR	DATE
 
+# hive types mix
+statement ok
+copy (select 1 AS a, 1 AS b, '123' AS partition UNION ALL SELECT 2, 2, '1992-01-01' UNION ALL SELECT 3, 3, 'abc') TO '__TEST_DIR__/partition_types' (FORMAT PARQUET, PARTITION_BY(partition));
+
+query III
+SELECT * FROM '__TEST_DIR__/partition_types/**/*.parquet' ORDER BY 1
+----
+1	1	123
+2	2	1992-01-01
+3	3	abc
+
+# explicit overwrite
+statement error
+select * from read_parquet('__TEST_DIR__/partition_types/**/*.parquet', hive_types={'partition':smallint})
+----
+Unable to cast
 
 # Complex filter filtering first file, filter should be pruned completely if hive_partitioning=1
 query II


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/9763
Fixes https://github.com/duckdb/duckdb/issues/11636

Previously the hive auto-type detection would only look at the first file, which provided inconsistent behavior. We now look at all files and merge the types during auto-detection, falling back to `VARCHAR` if the types cannot be merged.