### PR TITLE
Fix #11669: deduplicate column names in pivot correctly

### DIFF
--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
+#include "duckdb/main/query_result.hpp"
 
 namespace duckdb {
 

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -344,7 +344,9 @@ unique_ptr<BoundTableRef> Binder::BindBoundPivot(PivotRef &ref) {
 	result->bound_pivot.group_count = ref.bound_group_names.size();
 	result->bound_pivot.types = types;
 	auto subquery_alias = ref.alias.empty() ? "__unnamed_pivot" : ref.alias;
+	QueryResult::DeduplicateColumns(names);
 	bind_context.AddGenericBinding(result->bind_index, subquery_alias, names, types);
+
 	MoveCorrelatedExpressions(*result->child_binder);
 	return std::move(result);
 }

--- a/test/sql/pivot/pivot_case_insensitive.test
+++ b/test/sql/pivot/pivot_case_insensitive.test
@@ -1,0 +1,34 @@
+# name: test/sql/pivot/pivot_case_insensitive.test
+# description: Test case insensitivity in pivot names
+# group: [pivot]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE Cities (Name VARCHAR, id INTEGER);
+INSERT INTO Cities VALUES ('Test', 1);
+INSERT INTO Cities VALUES ('test',2);
+
+statement ok
+SET pivot_filter_threshold=1;
+
+query II
+FROM Cities
+PIVOT (
+    array_agg(id)
+    FOR
+        name IN ('test','Test')
+);
+----
+[2]	[1]
+
+query IIII
+FROM Cities
+PIVOT (
+    array_agg(id), sum(id)
+    FOR
+        name IN ('test','Test')
+);
+----
+[2]	2	[1]	1


### PR DESCRIPTION
Fixes #11669 