### PR TITLE
Extension::Version() - allow to specify versions also for built-in extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1102,6 +1102,7 @@ foreach(EXT_NAME IN LISTS DUCKDB_EXTENSION_NAMES)
   endif()
 
   if (DEFINED DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH)
+    add_definitions(-DEXT_VERSION_${EXT_NAME_UPPERCASE}="${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_EXT_VERSION}")
     add_subdirectory(${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH} extension/${EXT_NAME})
   else()
     message(FATAL_ERROR "No path found for registered extension '${EXT_NAME}'")

--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -426,6 +426,10 @@ std::string AutocompleteExtension::Name() {
 	return "autocomplete";
 }
 
+std::string AutocompleteExtension::Version() const {
+	return EXT_VERSION_AUTOCOMPLETE;
+}
+
 } // namespace duckdb
 extern "C" {
 

--- a/extension/autocomplete/include/autocomplete_extension.hpp
+++ b/extension/autocomplete/include/autocomplete_extension.hpp
@@ -16,6 +16,7 @@ class AutocompleteExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/extension/excel/excel_extension.cpp
+++ b/extension/excel/excel_extension.cpp
@@ -74,6 +74,10 @@ std::string ExcelExtension::Name() {
 	return "excel";
 }
 
+std::string ExcelExtension::Version() const {
+	return EXT_VERSION_EXCEL;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/extension/excel/include/excel_extension.hpp
+++ b/extension/excel/include/excel_extension.hpp
@@ -17,6 +17,7 @@ class ExcelExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/extension/fts/fts_extension.cpp
+++ b/extension/fts/fts_extension.cpp
@@ -76,6 +76,10 @@ std::string FtsExtension::Name() {
 	return "fts";
 }
 
+std::string FtsExtension::Version() const {
+	return EXT_VERSION_FTS;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/extension/fts/include/fts_extension.hpp
+++ b/extension/fts/include/fts_extension.hpp
@@ -16,6 +16,7 @@ class FtsExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/extension/httpfs/httpfs_extension.cpp
+++ b/extension/httpfs/httpfs_extension.cpp
@@ -68,6 +68,10 @@ std::string HttpfsExtension::Name() {
 	return "httpfs";
 }
 
+std::string HttpfsExtension::Version() const {
+	return EXT_VERSION_HTTPFS;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/extension/httpfs/include/httpfs_extension.hpp
+++ b/extension/httpfs/include/httpfs_extension.hpp
@@ -8,6 +8,7 @@ class HttpfsExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -283,6 +283,10 @@ std::string IcuExtension::Name() {
 	return "icu";
 }
 
+std::string IcuExtension::Version() const {
+	return EXT_VERSION_ICU;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/extension/icu/include/icu_extension.hpp
+++ b/extension/icu/include/icu_extension.hpp
@@ -16,6 +16,7 @@ class IcuExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/extension/inet/include/inet_extension.hpp
+++ b/extension/inet/include/inet_extension.hpp
@@ -17,6 +17,7 @@ class InetExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/extension/inet/inet_extension.cpp
+++ b/extension/inet/inet_extension.cpp
@@ -53,6 +53,10 @@ std::string InetExtension::Name() {
 	return "inet";
 }
 
+std::string InetExtension::Version() const {
+	return EXT_VERSION_INET;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/extension/jemalloc/include/jemalloc_extension.hpp
+++ b/extension/jemalloc/include/jemalloc_extension.hpp
@@ -16,7 +16,7 @@ class JemallocExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
-        std::string Version() const override;
+	std::string Version() const override;
 
 	static data_ptr_t Allocate(PrivateAllocatorData *private_data, idx_t size);
 	static void Free(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size);

--- a/extension/jemalloc/include/jemalloc_extension.hpp
+++ b/extension/jemalloc/include/jemalloc_extension.hpp
@@ -16,6 +16,7 @@ class JemallocExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+        std::string Version() const override;
 
 	static data_ptr_t Allocate(PrivateAllocatorData *private_data, idx_t size);
 	static void Free(PrivateAllocatorData *private_data, data_ptr_t pointer, idx_t size);

--- a/extension/jemalloc/jemalloc_extension.cpp
+++ b/extension/jemalloc/jemalloc_extension.cpp
@@ -86,6 +86,10 @@ void JemallocExtension::FlushAll() {
 	SetJemallocCTL("thread.peak.reset");
 }
 
+std::string JemallocExtension::Version() const {
+	return EXT_VERSION_JEMALLOC;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/extension/json/include/json_extension.hpp
+++ b/extension/json/include/json_extension.hpp
@@ -16,6 +16,7 @@ class JsonExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -68,6 +68,10 @@ std::string JsonExtension::Name() {
 	return "json";
 }
 
+std::string JsonExtension::Version() const {
+	return EXT_VERSION_JSON;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/extension/parquet/include/parquet_extension.hpp
+++ b/extension/parquet/include/parquet_extension.hpp
@@ -8,6 +8,7 @@ class ParquetExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -1310,6 +1310,10 @@ std::string ParquetExtension::Name() {
 	return "parquet";
 }
 
+std::string ParquetExtension::Version() const {
+	return EXT_VERSION_PARQUET;
+}
+
 } // namespace duckdb
 
 #ifdef DUCKDB_BUILD_LOADABLE_EXTENSION

--- a/extension/sqlsmith/include/sqlsmith_extension.hpp
+++ b/extension/sqlsmith/include/sqlsmith_extension.hpp
@@ -16,6 +16,7 @@ class SqlsmithExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/extension/sqlsmith/sqlsmith_extension.cpp
+++ b/extension/sqlsmith/sqlsmith_extension.cpp
@@ -204,6 +204,10 @@ std::string SqlsmithExtension::Name() {
 	return "sqlsmith";
 }
 
+std::string SqlsmithExtension::Version() const {
+	return EXT_VERSION_SQLSMITH;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/extension/tpcds/include/tpcds_extension.hpp
+++ b/extension/tpcds/include/tpcds_extension.hpp
@@ -17,6 +17,7 @@ class TpcdsExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 
 	//! Gets the specified TPC-DS Query number as a string
 	static std::string GetQuery(int query);

--- a/extension/tpcds/tpcds_extension.cpp
+++ b/extension/tpcds/tpcds_extension.cpp
@@ -192,6 +192,10 @@ std::string TpcdsExtension::Name() {
 	return "tpcds";
 }
 
+std::string TpcdsExtension::Version() const {
+	return EXT_VERSION_TPCDS;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/extension/tpch/include/tpch_extension.hpp
+++ b/extension/tpch/include/tpch_extension.hpp
@@ -16,6 +16,7 @@ class TpchExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 
 	//! Gets the specified TPC-H Query number as a string
 	static std::string GetQuery(int query);

--- a/extension/tpch/tpch_extension.cpp
+++ b/extension/tpch/tpch_extension.cpp
@@ -202,6 +202,10 @@ std::string TpchExtension::Name() {
 	return "tpch";
 }
 
+std::string TpchExtension::Version() const {
+	return EXT_VERSION_TPCH;
+}
+
 } // namespace duckdb
 
 extern "C" {

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -112,7 +112,7 @@ public:
 			return;
 		}
 		extension.Load(*this);
-		instance->SetExtensionLoaded(extension.Name());
+		instance->SetExtensionLoaded(extension.Name(), extension.Version());
 	}
 
 	DUCKDB_API FileSystem &GetFileSystem();

--- a/src/include/duckdb/main/extension.hpp
+++ b/src/include/duckdb/main/extension.hpp
@@ -21,6 +21,9 @@ public:
 
 	DUCKDB_API virtual void Load(DuckDB &db) = 0;
 	DUCKDB_API virtual std::string Name() = 0;
+	DUCKDB_API virtual std::string Version() const {
+		return "";
+	}
 };
 
 } // namespace duckdb

--- a/test/sql/extensions/version_is_valid_json.test
+++ b/test/sql/extensions/version_is_valid_json.test
@@ -1,0 +1,12 @@
+# name: test/sql/extensions/version_is_valid_json.test
+# description: Test version metadata on load
+# group: [extensions]
+
+require no_extension_autoloading
+
+require json
+
+query I
+SELECT count(*) FROM duckdb_extensions() WHERE extension_version != '' AND extension_name == 'json';
+----
+1

--- a/test/sql/extensions/version_is_valid_parquet.test
+++ b/test/sql/extensions/version_is_valid_parquet.test
@@ -1,0 +1,12 @@
+# name: test/sql/extensions/version_is_valid_parquet.test
+# description: Test version metadata on load
+# group: [extensions]
+
+require no_extension_autoloading
+
+require parquet
+
+query I
+SELECT count(*) FROM duckdb_extensions() WHERE extension_version != '' AND extension_name == 'parquet';
+----
+1

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -205,7 +205,7 @@ if 'BUILD_HTTPFS' in os.environ:
 
 for ext in extensions:
     define_macros.append(('DUCKDB_EXTENSION_{}_LINKED'.format(ext.upper()), None))
-    define_macros.append(('EXT_VERSION_{}'.format(ext.upper()), None))
+    define_macros.append(('EXT_VERSION_{}'.format(ext.upper()), ""))
 
 if not is_pyodide:
     # currently pyodide environment is not compatible with dynamic extension loading

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -205,7 +205,7 @@ if 'BUILD_HTTPFS' in os.environ:
 
 for ext in extensions:
     define_macros.append(('DUCKDB_EXTENSION_{}_LINKED'.format(ext.upper()), None))
-    define_macros.append(('EXT_VERSION_{}'.format(ext.upper()), ""))
+    define_macros.append(('EXT_VERSION_{}'.format(ext.upper()), ''))
 
 if not is_pyodide:
     # currently pyodide environment is not compatible with dynamic extension loading

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -205,6 +205,7 @@ if 'BUILD_HTTPFS' in os.environ:
 
 for ext in extensions:
     define_macros.append(('DUCKDB_EXTENSION_{}_LINKED'.format(ext.upper()), None))
+    define_macros.append(('EXT_VERSION_{}'.format(ext.upper()), None))
 
 if not is_pyodide:
     # currently pyodide environment is not compatible with dynamic extension loading

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -11,6 +11,7 @@ add_definitions(-DUSE_DUCKDB_SHELL_WRAPPER)
 include_directories(../../third_party/utf8proc/include)
 
 if(DUCKDB_EXTENSION_AUTOCOMPLETE_SHOULD_LINK)
+  add_definitions(-DEXT_VERSION_AUTOCOMPLETE="")
   include_directories(../../extension/autocomplete/include)
   set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES}
                        ../../extension/autocomplete/autocomplete_extension.cpp)


### PR DESCRIPTION
I had not found a better way to propagate CMake information so that there is a single source of thruth.
After this lands, we can make compulsory for the versioning information to match, but for now this works nicely, and I guess we can say it's malformed to define Version() to be different than the DEFINE.

This solves two different problems connected to #11515:
* providing a mechanism to provide versioning information both for statically built-in extensions
This is nice since you might have a given duckdb binary with some linked-in extensions, say for testing, and it might be useful to retrieve information on how it was built.
* fix versioning info for the re-entrancy pattern where extension_init() would call Load (that would in turn invoke SetExtensionLoaded via another codepath). Given this is hard to handle at the code level, this provides a solution