### PR TITLE
More extension_version metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1102,6 +1102,7 @@ foreach(EXT_NAME IN LISTS DUCKDB_EXTENSION_NAMES)
   endif()
 
   if (DEFINED DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH)
+    add_definitions(-DEXT_VERSION_${EXT_NAME_UPPERCASE}="${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_EXT_VERSION}")
     add_subdirectory(${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH} extension/${EXT_NAME})
   else()
     message(FATAL_ERROR "No path found for registered extension '${EXT_NAME}'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,7 +760,7 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY EXTENSION_VERS
       if (APPLE)
         set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
         # Note that on MacOS we need to use the -exported_symbol whitelist feature due to a lack of -exclude-libs flag in mac's ld variant
-        set(WHITELIST "-Wl,-exported_symbol,_${NAME}_init -Wl,-exported_symbol,_${NAME}_version -Wl,-exported_symbol,_${NAME}_storage_ini*")
+        set(WHITELIST "-Wl,-exported_symbol,_${NAME}_init -Wl,-exported_symbol,_${NAME}_storage_ini*")
         target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS} -Wl,-dead_strip ${WHITELIST})
       elseif (ZOS)
         target_link_libraries(${TARGET_NAME} duckdb_static ${DUCKDB_EXTRA_LINK_FLAGS})

--- a/extension/excel/excel_extension.cpp
+++ b/extension/excel/excel_extension.cpp
@@ -86,7 +86,6 @@ DUCKDB_EXTENSION_API void excel_init(duckdb::DatabaseInstance &db) {
 	duckdb::DuckDB db_wrapper(db);
 	LoadInternal(db_wrapper);
 }
-
 }
 
 #ifndef DUCKDB_EXTENSION_MAIN

--- a/extension/excel/excel_extension.cpp
+++ b/extension/excel/excel_extension.cpp
@@ -58,7 +58,7 @@ static void NumberFormatFunction(DataChunk &args, ExpressionState &state, Vector
 	    [&](double value, string_t format) { return NumberFormatScalarFunction(result, value, format); });
 }
 
-void ExcelExtension::Load(DuckDB &db) {
+static void LoadInternal(DuckDB &db) {
 	auto &db_instance = *db.instance;
 
 	ScalarFunction text_func("text", {LogicalType::DOUBLE, LogicalType::VARCHAR}, LogicalType::VARCHAR,
@@ -68,6 +68,10 @@ void ExcelExtension::Load(DuckDB &db) {
 	ScalarFunction excel_text_func("excel_text", {LogicalType::DOUBLE, LogicalType::VARCHAR}, LogicalType::VARCHAR,
 	                               NumberFormatFunction);
 	ExtensionUtil::RegisterFunction(db_instance, excel_text_func);
+}
+
+void ExcelExtension::Load(DuckDB &db) {
+	LoadInternal(db);
 }
 
 std::string ExcelExtension::Name() {
@@ -80,12 +84,9 @@ extern "C" {
 
 DUCKDB_EXTENSION_API void excel_init(duckdb::DatabaseInstance &db) {
 	duckdb::DuckDB db_wrapper(db);
-	db_wrapper.LoadExtension<duckdb::ExcelExtension>();
+	LoadInternal(db_wrapper);
 }
 
-DUCKDB_EXTENSION_API const char *excel_version() {
-	return duckdb::DuckDB::LibraryVersion();
-}
 }
 
 #ifndef DUCKDB_EXTENSION_MAIN

--- a/extension/inet/inet_extension.cpp
+++ b/extension/inet/inet_extension.cpp
@@ -17,7 +17,7 @@ namespace duckdb {
 
 static constexpr auto INET_TYPE_NAME = "INET";
 
-void InetExtension::Load(DuckDB &db) {
+static void LoadInternal(DuckDB &db) {
 	// add the "inet" type
 	child_list_t<LogicalType> children;
 	children.push_back(make_pair("ip_type", LogicalType::UTINYINT));
@@ -49,6 +49,10 @@ void InetExtension::Load(DuckDB &db) {
 	ExtensionUtil::AddFunctionOverload(*db.instance, add_fun);
 }
 
+void InetExtension::Load(DuckDB &db) {
+	LoadInternal(db);
+}
+
 std::string InetExtension::Name() {
 	return "inet";
 }
@@ -59,12 +63,9 @@ extern "C" {
 
 DUCKDB_EXTENSION_API void inet_init(duckdb::DatabaseInstance &db) {
 	duckdb::DuckDB db_wrapper(db);
-	db_wrapper.LoadExtension<duckdb::InetExtension>();
+	LoadInternal(db_wrapper);
 }
 
-DUCKDB_EXTENSION_API const char *inet_version() {
-	return duckdb::DuckDB::LibraryVersion();
-}
 }
 
 #ifndef DUCKDB_EXTENSION_MAIN

--- a/extension/inet/inet_extension.cpp
+++ b/extension/inet/inet_extension.cpp
@@ -65,7 +65,6 @@ DUCKDB_EXTENSION_API void inet_init(duckdb::DatabaseInstance &db) {
 	duckdb::DuckDB db_wrapper(db);
 	LoadInternal(db_wrapper);
 }
-
 }
 
 #ifndef DUCKDB_EXTENSION_MAIN

--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -23,7 +23,7 @@ static DefaultMacro json_macros[] = {
     {DEFAULT_SCHEMA, "json", {"x", nullptr}, "json_extract(x, '$')"},
     {nullptr, nullptr, {nullptr}, nullptr}};
 
-void JsonExtension::Load(DuckDB &db) {
+static void LoadInternal(DuckDB &db) {
 	auto &db_instance = *db.instance;
 	// JSON type
 	auto json_type = LogicalType::JSON();
@@ -64,6 +64,10 @@ void JsonExtension::Load(DuckDB &db) {
 	}
 }
 
+void JsonExtension::Load(DuckDB &db) {
+	LoadInternal(db);
+}
+
 std::string JsonExtension::Name() {
 	return "json";
 }
@@ -74,12 +78,9 @@ extern "C" {
 
 DUCKDB_EXTENSION_API void json_init(duckdb::DatabaseInstance &db) {
 	duckdb::DuckDB db_wrapper(db);
-	db_wrapper.LoadExtension<duckdb::JsonExtension>();
+	LoadInternal(db_wrapper);
 }
 
-DUCKDB_EXTENSION_API const char *json_version() {
-	return duckdb::DuckDB::LibraryVersion();
-}
 }
 
 #ifndef DUCKDB_EXTENSION_MAIN

--- a/extension/json/json_extension.cpp
+++ b/extension/json/json_extension.cpp
@@ -80,7 +80,6 @@ DUCKDB_EXTENSION_API void json_init(duckdb::DatabaseInstance &db) {
 	duckdb::DuckDB db_wrapper(db);
 	LoadInternal(db_wrapper);
 }
-
 }
 
 #ifndef DUCKDB_EXTENSION_MAIN

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -1323,7 +1323,6 @@ DUCKDB_EXTENSION_API void parquet_init(duckdb::DatabaseInstance &db) { // NOLINT
 	duckdb::DuckDB db_wrapper(db);
 	LoadInternal(db_wrapper);
 }
-
 }
 #endif
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -1247,7 +1247,7 @@ unique_ptr<TableRef> ParquetScanReplacement(ClientContext &context, const string
 	return std::move(table_function);
 }
 
-void ParquetExtension::Load(DuckDB &db) {
+static void LoadInternal(DuckDB &db) {
 	auto &db_instance = *db.instance;
 	auto &fs = db.GetFileSystem();
 	fs.RegisterSubSystem(FileCompressionType::ZSTD, make_uniq<ZStdFileSystem>());
@@ -1306,6 +1306,10 @@ void ParquetExtension::Load(DuckDB &db) {
 	                          LogicalType::BOOLEAN);
 }
 
+void ParquetExtension::Load(DuckDB &db) {
+	LoadInternal(db);
+}
+
 std::string ParquetExtension::Name() {
 	return "parquet";
 }
@@ -1317,12 +1321,9 @@ extern "C" {
 
 DUCKDB_EXTENSION_API void parquet_init(duckdb::DatabaseInstance &db) { // NOLINT
 	duckdb::DuckDB db_wrapper(db);
-	db_wrapper.LoadExtension<duckdb::ParquetExtension>();
+	LoadInternal(db_wrapper);
 }
 
-DUCKDB_EXTENSION_API const char *parquet_version() { // NOLINT
-	return duckdb::DuckDB::LibraryVersion();
-}
 }
 #endif
 

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -112,7 +112,7 @@ public:
 			return;
 		}
 		extension.Load(*this);
-		instance->SetExtensionLoaded(extension.Name());
+		instance->SetExtensionLoaded(extension.Name(), extension.Version());
 	}
 
 	DUCKDB_API FileSystem &GetFileSystem();

--- a/src/include/duckdb/main/extension.hpp
+++ b/src/include/duckdb/main/extension.hpp
@@ -21,6 +21,9 @@ public:
 
 	DUCKDB_API virtual void Load(DuckDB &db) = 0;
 	DUCKDB_API virtual std::string Name() = 0;
+	DUCKDB_API virtual std::string Version() const {
+		return "";
+	}
 };
 
 } // namespace duckdb


### PR DESCRIPTION
2 different fixes towards making extensions_versions available in more places:
* allowing extension to specify their Version for cases where reentrancy in the Load might happen (this also solves versioning for built-in extensions)
* avoid reentrancy for in-tree extensions via the LoadInternal pattern

This is a smaller version of https://github.com/duckdb/duckdb/pull/11683, that had some problems and was too invasive infrastructure-wise.