### PR TITLE
Pull vss

### DIFF
--- a/.github/config/extensions.csv
+++ b/.github/config/extensions.csv
@@ -15,4 +15,3 @@ aws,https://github.com/duckdb/duckdb_aws,f7b8729f1cce5ada5d4add70e1486de50763fb9
 azure,https://github.com/duckdb/duckdb_azure,09623777a366572bfb8fa53e47acdf72133a360e,
 spatial,https://github.com/duckdb/duckdb_spatial,8ac803e986ccda34f32dee82a7faae95b72b3492,
 iceberg,https://github.com/duckdb/duckdb_iceberg,d89423c2ff90a0b98a093a133c8dfe2a55b9e092,
-vss,https://github.com/duckdb/duckdb_vss,9038b50cefb8bfd6b8ab8a254d3c728f3f172d15,

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -100,12 +100,3 @@ if (NOT WIN32)
             GIT_TAG 1116fb580edd3e26e675436dbdbdf4a0aa5e456e
             )
 endif()
-
-
-################# VSS
-duckdb_extension_load(vss
-        LOAD_TESTS
-        GIT_URL https://github.com/duckdb/duckdb_vss
-        GIT_TAG 9038b50cefb8bfd6b8ab8a254d3c728f3f172d15
-        TEST_DIR test/sql
-    )


### PR DESCRIPTION
There are still outstanding issues and design decisions to make regarding custom index support in DuckDB before vss can safely be used without risking breaking WAL playback.