### PR TITLE
Add duckdb_enum_values C API function to get enum dictionary strings

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1818,12 +1818,13 @@ with `duckdb_free`.
 
 * type: The logical type object
 * values: The array to store the values in
-* length: The length of the values parameter
-* returns: The number of values written to values. This will be the min betwen
-* the lenght parameter and the size of the enum dictionary size (i.e.
-* `duckdb_enum_dictionary_size`).
+* values_length: The length of the values parameter
+* count: The number of values written into the values parameter. On success this
+will be the min between `values_length` and the size of the enum dictionary (i.e.
+`duckdb_enum_dictionary_size`)
+* returns: The duckdb state. Returns DuckDBError if values is null or type isn't an enum.
 */
-idx_t duckdb_enum_values(duckdb_logical_type type, char **values, idx_t length);
+DUCKDB_API duckdb_state duckdb_enum_values(duckdb_logical_type type, char **values, idx_t values_length, idx_t *count);
 
 /*!
 Retrieves the child type of the given list type.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1811,6 +1811,21 @@ The result must be freed with `duckdb_free`.
 DUCKDB_API char *duckdb_enum_dictionary_value(duckdb_logical_type type, idx_t index);
 
 /*!
+Retrieves the dictionary values from the enum.
+
+While the values array is owned by the caller, the individual string must be freed
+with `duckdb_free`.
+
+* type: The logical type object
+* values: The array to store the values in
+* length: The length of the values parameter
+* returns: The number of values written to values. This will be the min betwen
+* the lenght parameter and the size of the enum dictionary size (i.e.
+* `duckdb_enum_dictionary_size`).
+*/
+idx_t duckdb_enum_values(duckdb_logical_type type, char **values, idx_t length);
+
+/*!
 Retrieves the child type of the given list type.
 
 The result must be freed with `duckdb_destroy_logical_type`.

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -213,7 +213,7 @@ duckdb_state duckdb_enum_values(duckdb_logical_type type, char **values, idx_t v
 	auto &ltype = *(reinterpret_cast<duckdb::LogicalType *>(type));
 
 	auto &vector = duckdb::EnumType::GetValuesInsertOrder(ltype);
-	auto strings = duckdb::FlatVector::GetData<string_t>(vector);
+	auto strings = duckdb::FlatVector::GetData<duckdb::string_t>(vector);
 
 	auto enum_count = duckdb::EnumType::GetSize(ltype);
 	*filled_count = values_length < enum_count ? values_length : enum_count;

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -206,7 +206,8 @@ char *duckdb_enum_dictionary_value(duckdb_logical_type type, idx_t index) {
 
 duckdb_state duckdb_enum_values(duckdb_logical_type type, char **values, idx_t values_length, idx_t *filled_count) {
 	if (!AssertLogicalTypeId(type, duckdb::LogicalTypeId::ENUM) || values == NULL) {
-		if (filled_count != NULL) *filled_count = 0;
+		if (filled_count != NULL)
+			*filled_count = 0;
 		return duckdb_state::DuckDBError;
 	}
 	auto &ltype = *(reinterpret_cast<duckdb::LogicalType *>(type));

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -204,9 +204,10 @@ char *duckdb_enum_dictionary_value(duckdb_logical_type type, idx_t index) {
 	return strdup(duckdb::StringValue::Get(value).c_str());
 }
 
-idx_t duckdb_enum_values(duckdb_logical_type type, char **values, idx_t length) {
-	if (!AssertLogicalTypeId(type, duckdb::LogicalTypeId::ENUM)) {
-		return 0;
+duckdb_state duckdb_enum_values(duckdb_logical_type type, char **values, idx_t values_length, idx_t *filled_count) {
+	if (!AssertLogicalTypeId(type, duckdb::LogicalTypeId::ENUM) || values == NULL) {
+		if (filled_count != NULL) *filled_count = 0;
+		return duckdb_state::DuckDBError;
 	}
 	auto &ltype = *(reinterpret_cast<duckdb::LogicalType *>(type));
 
@@ -214,12 +215,13 @@ idx_t duckdb_enum_values(duckdb_logical_type type, char **values, idx_t length) 
 	auto strings = duckdb::FlatVector::GetData<string_t>(vector);
 
 	auto enum_count = duckdb::EnumType::GetSize(ltype);
-	auto fill_count = length < enum_count ? length : enum_count;
-	for (idx_t i = 0; i < fill_count; i++) {
+	*filled_count = values_length < enum_count ? values_length : enum_count;
+	for (idx_t i = 0; i < *filled_count; i++) {
 		auto value = strings[i];
 		values[i] = strdup(duckdb::StringValue::Get(value).c_str());
 	}
-	return fill_count;
+	// filled_count = count;
+	return duckdb_state::DuckDBSuccess;
 }
 
 duckdb_logical_type duckdb_list_type_child_type(duckdb_logical_type type) {

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -204,6 +204,24 @@ char *duckdb_enum_dictionary_value(duckdb_logical_type type, idx_t index) {
 	return strdup(duckdb::StringValue::Get(value).c_str());
 }
 
+idx_t duckdb_enum_values(duckdb_logical_type type, char **values, idx_t length) {
+	if (!AssertLogicalTypeId(type, duckdb::LogicalTypeId::ENUM)) {
+		return 0;
+	}
+	auto &ltype = *(reinterpret_cast<duckdb::LogicalType *>(type));
+
+	auto &vector = duckdb::EnumType::GetValuesInsertOrder(ltype);
+	auto strings = duckdb::FlatVector::GetData<string_t>(vector);
+
+	auto enum_count = duckdb::EnumType::GetSize(ltype);
+	auto fill_count = length < enum_count ? length : enum_count;
+	for (idx_t i = 0; i < fill_count; i++) {
+		auto value = strings[i];
+		values[i] = strdup(duckdb::StringValue::Get(value).c_str());
+	}
+	return fill_count;
+}
+
 duckdb_logical_type duckdb_list_type_child_type(duckdb_logical_type type) {
 	if (!AssertLogicalTypeId(type, duckdb::LogicalTypeId::LIST) &&
 	    !AssertLogicalTypeId(type, duckdb::LogicalTypeId::MAP)) {

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -91,6 +91,38 @@ TEST_CASE("Test enum types C API", "[capi]") {
 	REQUIRE(duckdb_enum_internal_type(nullptr) == DUCKDB_TYPE_INVALID);
 	REQUIRE(duckdb_enum_dictionary_size(nullptr) == 0);
 	REQUIRE(duckdb_enum_dictionary_value(nullptr, 0) == nullptr);
+
+	{
+		char *values[3];
+		auto logical_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(chunk->GetChunk(), 0));
+		auto value_count = duckdb_enum_values(logical_type, values, 3);
+		REQUIRE(value_count == 2);
+		REQUIRE(string(values[0]) == "DUCK_DUCK_ENUM");
+		REQUIRE(string(values[1]) == "GOOSE");
+		for (idx_t i = 0; i < value_count; i++) {
+			duckdb_free(values[i]);
+		}
+	}
+
+	{
+		// pass in a smaller size, it's ok, but we only get part of the enum
+		char *values[1];
+		auto logical_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(chunk->GetChunk(), 0));
+		auto value_count = duckdb_enum_values(logical_type, values, 1);
+		REQUIRE(value_count == 1);
+		REQUIRE(string(values[0]) == "DUCK_DUCK_ENUM");
+		for (idx_t i = 0; i < value_count; i++) {
+			duckdb_free(values[i]);
+		}
+	}
+
+	{
+		// no names for non-enum column
+		char *values[1];
+		auto logical_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(chunk->GetChunk(), 3));
+		auto value_count = duckdb_enum_values(logical_type, values, 1);
+		REQUIRE(value_count == 0);
+	}
 }
 
 TEST_CASE("Test list types C API", "[capi]") {

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -105,6 +105,7 @@ TEST_CASE("Test enum types C API", "[capi]") {
 		for (idx_t i = 0; i < value_count; i++) {
 			duckdb_free(values[i]);
 		}
+		duckdb_destroy_logical_type(&logical_type);
 	}
 
 	{
@@ -120,6 +121,7 @@ TEST_CASE("Test enum types C API", "[capi]") {
 		for (idx_t i = 0; i < value_count; i++) {
 			duckdb_free(values[i]);
 		}
+		duckdb_destroy_logical_type(&logical_type);
 	}
 
 	{
@@ -130,6 +132,7 @@ TEST_CASE("Test enum types C API", "[capi]") {
 		auto status = duckdb_enum_values(logical_type, values, 1, &value_count);
 		REQUIRE(status == DuckDBError);
 		REQUIRE(value_count == 0);
+		duckdb_destroy_logical_type(&logical_type);
 	}
 
 	{
@@ -137,6 +140,7 @@ TEST_CASE("Test enum types C API", "[capi]") {
 		auto logical_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(chunk->GetChunk(), 0));
 		auto status = duckdb_enum_values(logical_type, NULL, 100, NULL);
 		REQUIRE(status == DuckDBError);
+		duckdb_destroy_logical_type(&logical_type);
 	}
 }
 

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -94,8 +94,11 @@ TEST_CASE("Test enum types C API", "[capi]") {
 
 	{
 		char *values[3];
+		idx_t value_count;
 		auto logical_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(chunk->GetChunk(), 0));
-		auto value_count = duckdb_enum_values(logical_type, values, 3);
+		auto status = duckdb_enum_values(logical_type, values, 3, &value_count);
+		REQUIRE(status == DuckDBSuccess);
+
 		REQUIRE(value_count == 2);
 		REQUIRE(string(values[0]) == "DUCK_DUCK_ENUM");
 		REQUIRE(string(values[1]) == "GOOSE");
@@ -107,8 +110,11 @@ TEST_CASE("Test enum types C API", "[capi]") {
 	{
 		// pass in a smaller size, it's ok, but we only get part of the enum
 		char *values[1];
+		idx_t value_count;
 		auto logical_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(chunk->GetChunk(), 0));
-		auto value_count = duckdb_enum_values(logical_type, values, 1);
+		auto status = duckdb_enum_values(logical_type, values, 1, &value_count);
+
+		REQUIRE(status == DuckDBSuccess);
 		REQUIRE(value_count == 1);
 		REQUIRE(string(values[0]) == "DUCK_DUCK_ENUM");
 		for (idx_t i = 0; i < value_count; i++) {
@@ -119,9 +125,18 @@ TEST_CASE("Test enum types C API", "[capi]") {
 	{
 		// no names for non-enum column
 		char *values[1];
+		idx_t value_count;
 		auto logical_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(chunk->GetChunk(), 3));
-		auto value_count = duckdb_enum_values(logical_type, values, 1);
+		auto status = duckdb_enum_values(logical_type, values, 1, &value_count);
+		REQUIRE(status == DuckDBError);
 		REQUIRE(value_count == 0);
+	}
+
+	{
+		// null values
+		auto logical_type = duckdb_vector_get_column_type(duckdb_data_chunk_get_vector(chunk->GetChunk(), 0));
+		auto status = duckdb_enum_values(logical_type, NULL, 100, NULL);
+		REQUIRE(status == DuckDBError);
 	}
 }
 


### PR DESCRIPTION
This adds a `duckdb_enum_values` function to the C-API. It populates the passed-in `char**` with the enum string values, preserving the insertion order. This allows a driver to accept a string value and map it to the internal integer representation. I plan on using in my Zig driver to allow string values to be appended to enum columns (using the existing `duckdb_append_data_chunk`). 