### PR TITLE
fix issue when building without python3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,9 +830,6 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY EXTENSION_VERS
     ${CMAKE_COMMAND} -DEXTENSION=$<TARGET_FILE:${TARGET_NAME}> -DPLATFORM_FILE=${DuckDB_BINARY_DIR}/duckdb_platform_out -DDUCKDB_VERSION="${DUCKDB_NORMALIZED_VERSION}" -DEXTENSION_VERSION="${EXTENSION_VERSION}" -DNULL_FILE=${CMAKE_CURRENT_FUNCTION_LIST_DIR}/scripts/null.txt -P ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/scripts/append_metadata.cmake
     )
   add_dependencies(${TARGET_NAME} duckdb_platform)
-  if (NOT EXTENSION_CONFIG_BUILD AND NOT ${EXTENSION_TESTS_ONLY} AND NOT CLANG_TIDY)
-    add_dependencies(duckdb_local_extension_repo ${TARGET_NAME})
-  endif()
 endfunction()
 
 function(build_loadable_extension NAME PARAMETERS)


### PR DESCRIPTION
[CMake] CMake Error at duckdb\CMakeLists.txt:834 (add_dependencies):
[CMake]   Cannot add target-level dependencies to non-existent target
[CMake]   "duckdb_local_extension_repo".
[CMake]
[CMake]   The add_dependencies works for top-level logical targets created by the
[CMake]   add_executable, add_library, or add_custom_target commands.  If you want to
[CMake]   add file-level dependencies see the DEPENDS option of the add_custom_target
[CMake]   and add_custom_command commands.