### PR TITLE
Properly avoid build-time dependency on Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -715,6 +715,8 @@ endif()
 set(LOCAL_EXTENSION_REPO FALSE)
 if (NOT EXTENSION_CONFIG_BUILD AND NOT ${EXTENSION_TESTS_ONLY} AND NOT CLANG_TIDY)
   if (NOT Python3_FOUND)
+    add_custom_target(
+          duckdb_local_extension_repo ALL)
     MESSAGE(STATUS "Could not find python3, create extension directory step will be skipped")
   else()
     add_custom_target(


### PR DESCRIPTION
Triggered by https://github.com/duckdb/duckdb/pull/11710, but still keeping local repo functionality.