### PR TITLE
Upload staging: from 'git describe --tags' to 'git log -1'

### DIFF
--- a/.github/workflows/OnTag.yml
+++ b/.github/workflows/OnTag.yml
@@ -1,0 +1,22 @@
+name: On Tag
+on:
+  workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+  push:
+    tags:        
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  twine_upload:
+    uses: ./.github/workflows/TwineUpload.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe || github.event.release.tag_name }}
+
+  staged_upload:
+    uses: ./.github/workflows/StagedUpload.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe || github.event.release.tag_name }}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -81,7 +81,7 @@ jobs:
         elif [[ -z "${{ inputs.override_git_describe }}" ]]; then
             echo "No override_git_describe provided"
         else
-            echo "UPLOAD_ASSETS_TO_STAGING_TARGET=$(git describe --tags --long)" >> "$GITHUB_ENV"
+            echo "UPLOAD_ASSETS_TO_STAGING_TARGET=$(git log -1 --format=%h)" >> "$GITHUB_ENV"
             echo "override_git_describe ${{ inputs.override_git_describe }}: add tag"
             git tag ${{ inputs.override_git_describe }}
         fi
@@ -212,7 +212,7 @@ jobs:
         elif [[ -z "${{ inputs.override_git_describe }}" ]]; then
             echo "No override_git_describe provided"
         else
-            echo "UPLOAD_ASSETS_TO_STAGING_TARGET=$(git describe --tags --long)" >> "$GITHUB_ENV"
+            echo "UPLOAD_ASSETS_TO_STAGING_TARGET=$(git log -1 --format=%h)" >> "$GITHUB_ENV"
             echo "override_git_describe ${{ inputs.override_git_describe }}: add tag"
             git tag ${{ inputs.override_git_describe }}
         fi
@@ -302,7 +302,7 @@ jobs:
           elif [[ -z "${{ inputs.override_git_describe }}" ]]; then
               echo "No override_git_describe provided"
           else
-              echo "UPLOAD_ASSETS_TO_STAGING_TARGET=$(git describe --tags --long)" >> "$GITHUB_ENV"
+              echo "UPLOAD_ASSETS_TO_STAGING_TARGET=$(git log -1 --format=%h)" >> "$GITHUB_ENV"
               echo "override_git_describe ${{ inputs.override_git_describe }}: add tag"
               git tag ${{ inputs.override_git_describe }}
           fi
@@ -380,7 +380,7 @@ jobs:
           elif [[ -z "${{ inputs.override_git_describe }}" ]]; then
               echo "No override_git_describe provided"
           else
-              echo "UPLOAD_ASSETS_TO_STAGING_TARGET=$(git describe --tags --long)" >> "$GITHUB_ENV"
+              echo "UPLOAD_ASSETS_TO_STAGING_TARGET=$(git log -1 --format=%h)" >> "$GITHUB_ENV"
               echo "override_git_describe ${{ inputs.override_git_describe }}: add tag"
               git tag ${{ inputs.override_git_describe }}
           fi

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -31,8 +31,9 @@ jobs:
          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
        run: |
+          TARGET=$(git log -1 --format=%h)
           mkdir to_be_uploaded
-          aws s3 cp --recursive "s3://duckdb-staging/${{ inputs.target_git_describe }}/$GITHUB_REPOSITORY/github_release" to_be_uploaded --region us-east-2
+          aws s3 cp --recursive "s3://duckdb-staging/$TARGET/${{ inputs.target_git_describe }}/$GITHUB_REPOSITORY/github_release" to_be_uploaded --region us-east-2
 
      - name: Deploy
        shell: bash

--- a/.github/workflows/TwineUpload.yml
+++ b/.github/workflows/TwineUpload.yml
@@ -37,7 +37,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
-          TARGET=$(git describe --tags --long)
+          TARGET=$(git log -1 --format=%h)
           # decide target for staging
           if [ "$OVERRIDE_GIT_DESCRIBE" ]; then
             TARGET="$TARGET/$OVERRIDE_GIT_DESCRIBE"

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -45,7 +45,7 @@ if [ -z "$AWS_ACCESS_KEY_ID" ]; then
 fi
 
 
-TARGET=$(git describe --tags --long)
+TARGET=$(git log -1 --format=%h)
 
 if [ "$UPLOAD_ASSETS_TO_STAGING_TARGET" ]; then
   TARGET="$UPLOAD_ASSETS_TO_STAGING_TARGET"


### PR DESCRIPTION
This makes so that target is independent of actual status (pre or post tagging)

Basically staged artifacts will be at an address like:

s3://bucket-name/GIT_HASH/TARGET_TAG/duckdb/REPO/...

that makes the naming scheme (again) stable between pre or post tagging, since it depends only on GIT_HASH and the TARGET_TAG.

Also add a OnTag.yml workflow to be triggered on tag creation and invoke relevant workflows automatically. 