### PR TITLE
Full conversion warnings / checks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}"
                                                   STREQUAL "AppleClang")
   set(EXIT_TIME_DESTRUCTORS_WARNING TRUE)
   set(CMAKE_CXX_FLAGS_DEBUG
-      "${CMAKE_CXX_FLAGS_DEBUG} -Wexit-time-destructors -Wimplicit-int-conversion -Wshorten-64-to-32 -Wnarrowing -Wsign-conversion -Wsign-compare"
+      "${CMAKE_CXX_FLAGS_DEBUG} -Wexit-time-destructors -Wimplicit-int-conversion -Wshorten-64-to-32 -Wnarrowing -Wsign-conversion -Wsign-compare -Wconversion"
   )
 endif()
 

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -2486,7 +2486,7 @@ bool DoubleToDecimalCast(SRC input, DST &result, CastParameters &parameters, uin
 		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
-	result = Cast::Operation<SRC, DST>(UnsafeNumericCast<SRC>(value));
+	result = Cast::Operation<SRC, DST>(static_cast<SRC>(value));
 	return true;
 }
 

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1957,7 +1957,7 @@ struct DecimalCastOperation {
 		for (idx_t i = 0; i < state.excessive_decimals; i++) {
 			auto mod = state.result % 10;
 			round_up = NEGATIVE ? mod <= -5 : mod >= 5;
-			state.result /= 10.0;
+			state.result /= static_cast<typename T::StoreType>(10.0);
 		}
 		//! Only round up when exponents are involved
 		if (state.exponent_type == T::ExponentType::POSITIVE && round_up) {
@@ -2486,7 +2486,7 @@ bool DoubleToDecimalCast(SRC input, DST &result, CastParameters &parameters, uin
 		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
-	result = Cast::Operation<SRC, DST>(value);
+	result = Cast::Operation<SRC, DST>(UnsafeNumericCast<SRC>(value));
 	return true;
 }
 

--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -121,7 +121,7 @@ void ProgressBar::Update(bool final) {
 		if (final) {
 			FinishProgressBarPrint();
 		} else {
-			PrintProgress(query_progress.percentage);
+			PrintProgress(NumericCast<int>(query_progress.percentage.load()));
 		}
 #endif
 	}

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1110,7 +1110,7 @@ bool ApproxEqual(float ldecimal, float rdecimal) {
 	if (!Value::FloatIsFinite(ldecimal) || !Value::FloatIsFinite(rdecimal)) {
 		return ldecimal == rdecimal;
 	}
-	float epsilon = std::fabs(rdecimal) * 0.01 + 0.00000001;
+	auto epsilon = UnsafeNumericCast<float>(std::fabs(rdecimal) * 0.01 + 0.00000001);
 	return std::fabs(ldecimal - rdecimal) <= epsilon;
 }
 

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1110,7 +1110,7 @@ bool ApproxEqual(float ldecimal, float rdecimal) {
 	if (!Value::FloatIsFinite(ldecimal) || !Value::FloatIsFinite(rdecimal)) {
 		return ldecimal == rdecimal;
 	}
-	auto epsilon = UnsafeNumericCast<float>(std::fabs(rdecimal) * 0.01 + 0.00000001);
+	float epsilon = static_cast<float>(std::fabs(rdecimal) * 0.01 + 0.00000001);
 	return std::fabs(ldecimal - rdecimal) <= epsilon;
 }
 

--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -157,7 +157,7 @@ struct CastInterpolation {
 	template <typename TARGET_TYPE>
 	static inline TARGET_TYPE Interpolate(const TARGET_TYPE &lo, const double d, const TARGET_TYPE &hi) {
 		const auto delta = hi - lo;
-		return lo + delta * d;
+		return UnsafeNumericCast<TARGET_TYPE>(lo + delta * d);
 	}
 };
 
@@ -295,7 +295,8 @@ bool operator==(const QuantileValue &x, const QuantileValue &y) {
 template <bool DISCRETE>
 struct Interpolator {
 	Interpolator(const QuantileValue &q, const idx_t n_p, const bool desc_p)
-	    : desc(desc_p), RN((double)(n_p - 1) * q.dbl), FRN(floor(RN)), CRN(ceil(RN)), begin(0), end(n_p) {
+	    : desc(desc_p), RN((double)(n_p - 1) * q.dbl), FRN(UnsafeNumericCast<idx_t>(floor(RN))),
+	      CRN(UnsafeNumericCast<idx_t>(ceil(RN))), begin(0), end(n_p) {
 	}
 
 	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
@@ -365,7 +366,7 @@ struct Interpolator<true> {
 		}
 		default:
 			const auto scaled_q = (double)(n * q.dbl);
-			floored = floor(n - scaled_q);
+			floored = UnsafeNumericCast<idx_t>(floor(n - scaled_q));
 			break;
 		}
 

--- a/src/core_functions/scalar/math/numeric.cpp
+++ b/src/core_functions/scalar/math/numeric.cpp
@@ -516,7 +516,7 @@ struct RoundOperatorPrecision {
 				return input;
 			}
 		}
-		return rounded_value;
+		return UnsafeNumericCast<TR>(rounded_value);
 	}
 };
 
@@ -527,7 +527,7 @@ struct RoundOperator {
 		if (std::isinf(rounded_value) || std::isnan(rounded_value)) {
 			return input;
 		}
-		return rounded_value;
+		return UnsafeNumericCast<TR>(rounded_value);
 	}
 };
 

--- a/src/core_functions/scalar/random/setseed.cpp
+++ b/src/core_functions/scalar/random/setseed.cpp
@@ -39,7 +39,7 @@ static void SetSeedFunction(DataChunk &args, ExpressionState &state, Vector &res
 		if (input_seeds[i] < -1.0 || input_seeds[i] > 1.0 || Value::IsNan(input_seeds[i])) {
 			throw InvalidInputException("SETSEED accepts seed values between -1.0 and 1.0, inclusive");
 		}
-		uint32_t norm_seed = (input_seeds[i] + 1.0) * half_max;
+		auto norm_seed = NumericCast<uint32_t>((input_seeds[i] + 1.0) * half_max);
 		random_engine.SetSeed(norm_seed);
 	}
 

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -122,7 +122,7 @@ idx_t GroupedAggregateHashTable::InitialCapacity() {
 
 idx_t GroupedAggregateHashTable::GetCapacityForCount(idx_t count) {
 	count = MaxValue<idx_t>(InitialCapacity(), count);
-	return NextPowerOfTwo(count * LOAD_FACTOR);
+	return NextPowerOfTwo(NumericCast<uint64_t>(static_cast<double>(count) * LOAD_FACTOR));
 }
 
 idx_t GroupedAggregateHashTable::Capacity() const {
@@ -130,7 +130,7 @@ idx_t GroupedAggregateHashTable::Capacity() const {
 }
 
 idx_t GroupedAggregateHashTable::ResizeThreshold() const {
-	return Capacity() / LOAD_FACTOR;
+	return NumericCast<idx_t>(static_cast<double>(Capacity()) / LOAD_FACTOR);
 }
 
 idx_t GroupedAggregateHashTable::ApplyBitMask(hash_t hash) const {

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -940,7 +940,8 @@ void JoinHashTable::SetRepartitionRadixBits(vector<unique_ptr<JoinHashTable>> &l
 
 		auto new_estimated_size = double(max_partition_size) / partition_multiplier;
 		auto new_estimated_count = double(max_partition_count) / partition_multiplier;
-		auto new_estimated_ht_size = new_estimated_size + PointerTableSize(new_estimated_count);
+		auto new_estimated_ht_size =
+		    new_estimated_size + static_cast<double>(PointerTableSize(NumericCast<idx_t>(new_estimated_count)));
 
 		if (new_estimated_ht_size <= double(max_ht_size) / 4) {
 			// Aim for an estimated partition size of max_ht_size / 4

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -409,7 +409,7 @@ public:
 			total_size += sink_collection.SizeInBytes();
 			total_count += sink_collection.Count();
 		}
-		auto total_blocks = (double(total_size) + Storage::BLOCK_SIZE - 1) / Storage::BLOCK_SIZE;
+		auto total_blocks = NumericCast<idx_t>((double(total_size) + Storage::BLOCK_SIZE - 1) / Storage::BLOCK_SIZE);
 		auto count_per_block = total_count / total_blocks;
 		auto blocks_per_vector = MaxValue<idx_t>(STANDARD_VECTOR_SIZE / count_per_block, 2);
 

--- a/src/include/duckdb/common/operator/numeric_cast.hpp
+++ b/src/include/duckdb/common/operator/numeric_cast.hpp
@@ -75,7 +75,7 @@ bool TryCastWithOverflowCheckFloat(SRC value, T &result, SRC min, SRC max) {
 		return false;
 	}
 	// PG FLOAT => INT casts use statistical rounding.
-	result = UnsafeNumericCast<T>(std::nearbyint(value));
+	result = static_cast<T>(std::nearbyint(value));
 	return true;
 }
 
@@ -182,7 +182,7 @@ bool TryCastWithOverflowCheck(double input, float &result) {
 		return true;
 	}
 	auto res = float(input);
-	if (!Value::DoubleIsFinite(input)) {
+	if (!Value::FloatIsFinite(res)) {
 		return false;
 	}
 	result = res;

--- a/src/include/duckdb/common/operator/numeric_cast.hpp
+++ b/src/include/duckdb/common/operator/numeric_cast.hpp
@@ -75,7 +75,7 @@ bool TryCastWithOverflowCheckFloat(SRC value, T &result, SRC min, SRC max) {
 		return false;
 	}
 	// PG FLOAT => INT casts use statistical rounding.
-	result = std::nearbyint(value);
+	result = UnsafeNumericCast<T>(std::nearbyint(value));
 	return true;
 }
 
@@ -182,7 +182,7 @@ bool TryCastWithOverflowCheck(double input, float &result) {
 		return true;
 	}
 	auto res = float(input);
-	if (!Value::FloatIsFinite(input)) {
+	if (!Value::DoubleIsFinite(input)) {
 		return false;
 	}
 	result = res;

--- a/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
+++ b/src/include/duckdb/storage/compression/alp/algorithm/alp.hpp
@@ -107,10 +107,10 @@ struct AlpCompression {
 	 */
 	static int64_t NumberToInt64(T n) {
 		if (IsImpossibleToEncode(n)) {
-			return AlpConstants::ENCODING_UPPER_LIMIT;
+			return NumericCast<int64_t>(AlpConstants::ENCODING_UPPER_LIMIT);
 		}
 		n = n + AlpTypedConstants<T>::MAGIC_NUMBER - AlpTypedConstants<T>::MAGIC_NUMBER;
-		return static_cast<int64_t>(n);
+		return NumericCast<int64_t>(n);
 	}
 
 	/*
@@ -185,7 +185,7 @@ struct AlpCompression {
 
 		// Evaluate factor/exponent compression size (we optimize for FOR)
 		uint64_t delta = (static_cast<uint64_t>(max_encoded_value) - static_cast<uint64_t>(min_encoded_value));
-		estimated_bits_per_value = std::ceil(std::log2(delta + 1));
+		estimated_bits_per_value = NumericCast<uint32_t>(std::ceil(std::log2(delta + 1)));
 		estimated_compression_size += n_values * estimated_bits_per_value;
 		estimated_compression_size +=
 		    exceptions_count * (EXACT_TYPE_BITSIZE + (AlpConstants::EXCEPTION_POSITION_SIZE * 8));

--- a/src/include/duckdb/storage/compression/alp/alp_constants.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_constants.hpp
@@ -70,11 +70,12 @@ struct AlpTypedConstants<float> {
 	static constexpr float MAGIC_NUMBER = 12582912.0; //! 2^22 + 2^23
 	static constexpr uint8_t MAX_EXPONENT = 10;
 
-	static constexpr const float EXP_ARR[] = {1.0,       10.0,       100.0,       1000.0,       10000.0,      100000.0,
-	                                          1000000.0, 10000000.0, 100000000.0, 1000000000.0, 10000000000.0};
+	static constexpr const float EXP_ARR[] = {1.0F,         10.0F,         100.0F,        1000.0F,
+	                                          10000.0F,     100000.0F,     1000000.0F,    10000000.0F,
+	                                          100000000.0F, 1000000000.0F, 10000000000.0F};
 
-	static constexpr float FRAC_ARR[] = {1.0,      0.1,       0.01,       0.001,       0.0001,      0.00001,
-	                                     0.000001, 0.0000001, 0.00000001, 0.000000001, 0.0000000001};
+	static constexpr float FRAC_ARR[] = {1.0F,      0.1F,       0.01F,       0.001F,       0.0001F,      0.00001F,
+	                                     0.000001F, 0.0000001F, 0.00000001F, 0.000000001F, 0.0000000001F};
 };
 
 template <>

--- a/src/include/duckdb/storage/compression/alp/alp_utils.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_utils.hpp
@@ -42,7 +42,7 @@ public:
 		//! We sample equidistant values within a vector; to do this we jump a fixed number of values
 		uint32_t n_sampled_increments = MaxValue<uint32_t>(
 		    1, UnsafeNumericCast<uint32_t>(std::ceil((double)n_lookup_values / AlpConstants::SAMPLES_PER_VECTOR)));
-		uint32_t n_sampled_values = std::ceil((double)n_lookup_values / n_sampled_increments);
+		uint32_t n_sampled_values = NumericCast<uint32_t>(std::ceil((double)n_lookup_values / n_sampled_increments));
 		D_ASSERT(n_sampled_values < AlpConstants::ALP_VECTOR_SIZE);
 
 		AlpSamplingParameters sampling_params = {n_lookup_values, n_sampled_increments, n_sampled_values};

--- a/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
+++ b/src/include/duckdb/storage/compression/alprd/algorithm/alprd.hpp
@@ -105,7 +105,8 @@ struct AlpRDCompression {
 		// The left parts bit width after compression is determined by how many elements are in the dictionary
 		uint64_t actual_dictionary_size =
 		    MinValue<uint64_t>(AlpRDConstants::MAX_DICTIONARY_SIZE, left_parts_sorted_repetitions.size());
-		uint8_t left_bit_width = MaxValue<uint8_t>(1, std::ceil(std::log2(actual_dictionary_size)));
+		uint8_t left_bit_width =
+		    MaxValue<uint8_t>(1, NumericCast<uint8_t>(std::ceil(std::log2(actual_dictionary_size))));
 
 		if (PERSIST_DICT) {
 			for (idx_t dict_idx = 0; dict_idx < actual_dictionary_size; dict_idx++) {

--- a/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_analyze.hpp
@@ -126,13 +126,15 @@ idx_t AlpRDFinalAnalyze(AnalyzeState &state) {
 	//! Overhead per vector: Pointer to data + Exceptions count
 	double per_vector_overhead = AlpRDConstants::METADATA_POINTER_SIZE + AlpRDConstants::EXCEPTIONS_COUNT_SIZE;
 
-	uint32_t n_vectors = std::ceil((double)analyze_state.total_values_count / AlpRDConstants::ALP_VECTOR_SIZE);
+	uint32_t n_vectors =
+	    NumericCast<uint32_t>(std::ceil((double)analyze_state.total_values_count / AlpRDConstants::ALP_VECTOR_SIZE));
 
 	auto estimated_size = (estimed_compressed_bytes * factor_of_sampling) + (n_vectors * per_vector_overhead);
-	uint32_t estimated_n_blocks = std::ceil(estimated_size / (Storage::BLOCK_SIZE - per_segment_overhead));
+	uint32_t estimated_n_blocks =
+	    NumericCast<uint32_t>(std::ceil(estimated_size / (Storage::BLOCK_SIZE - per_segment_overhead)));
 
 	auto final_analyze_size = estimated_size + (estimated_n_blocks * per_segment_overhead);
-	return final_analyze_size;
+	return NumericCast<idx_t>(final_analyze_size);
 }
 
 } // namespace duckdb

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -423,7 +423,7 @@ idx_t DBConfig::ParseMemoryLimit(const string &arg) {
 		throw ParserException("Unknown unit for memory_limit: %s (expected: KB, MB, GB, TB for 1000^i units or KiB, "
 		                      "MiB, GiB, TiB for 1024^i unites)");
 	}
-	return (idx_t)multiplier * limit;
+	return NumericCast<idx_t>(multiplier * limit);
 }
 
 // Right now we only really care about access mode when comparing DBConfigs

--- a/src/optimizer/join_order/estimated_properties.cpp
+++ b/src/optimizer/join_order/estimated_properties.cpp
@@ -11,7 +11,7 @@ double EstimatedProperties::GetCardinality() const {
 template <>
 idx_t EstimatedProperties::GetCardinality() const {
 	auto max_idx_t = NumericLimits<idx_t>::Maximum() - 10000;
-	return MinValue<double>(cardinality, max_idx_t);
+	return MinValue<idx_t>(NumericCast<idx_t>(cardinality), max_idx_t);
 }
 
 template <>
@@ -22,7 +22,7 @@ double EstimatedProperties::GetCost() const {
 template <>
 idx_t EstimatedProperties::GetCost() const {
 	auto max_idx_t = NumericLimits<idx_t>::Maximum() - 10000;
-	return MinValue<double>(cost, max_idx_t);
+	return MinValue<idx_t>(NumericCast<idx_t>(cost), max_idx_t);
 }
 
 void EstimatedProperties::SetCardinality(double new_card) {

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -183,7 +183,8 @@ bool RelationManager::ExtractJoinRelations(LogicalOperator &input_op,
 		auto &aggr = op->Cast<LogicalAggregate>();
 		auto operator_stats = RelationStatisticsHelper::ExtractAggregationStats(aggr, child_stats);
 		if (!datasource_filters.empty()) {
-			operator_stats.cardinality *= RelationStatisticsHelper::DEFAULT_SELECTIVITY;
+			operator_stats.cardinality = NumericCast<idx_t>(static_cast<double>(operator_stats.cardinality) *
+			                                                RelationStatisticsHelper::DEFAULT_SELECTIVITY);
 		}
 		AddAggregateOrWindowRelation(input_op, parent, operator_stats, op->type);
 		return true;
@@ -196,7 +197,8 @@ bool RelationManager::ExtractJoinRelations(LogicalOperator &input_op,
 		auto &window = op->Cast<LogicalWindow>();
 		auto operator_stats = RelationStatisticsHelper::ExtractWindowStats(window, child_stats);
 		if (!datasource_filters.empty()) {
-			operator_stats.cardinality *= RelationStatisticsHelper::DEFAULT_SELECTIVITY;
+			operator_stats.cardinality = NumericCast<idx_t>(static_cast<double>(operator_stats.cardinality) *
+			                                                RelationStatisticsHelper::DEFAULT_SELECTIVITY);
 		}
 		AddAggregateOrWindowRelation(input_op, parent, operator_stats, op->type);
 		return true;

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -121,8 +121,8 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 		// and there are other table filters (i.e cost > 50), use default selectivity.
 		bool has_equality_filter = (cardinality_after_filters != base_table_cardinality);
 		if (!has_equality_filter && !get.table_filters.filters.empty()) {
-			cardinality_after_filters =
-			    MaxValue<idx_t>(base_table_cardinality * RelationStatisticsHelper::DEFAULT_SELECTIVITY, 1);
+			cardinality_after_filters = MaxValue<idx_t>(
+			    NumericCast<idx_t>(base_table_cardinality * RelationStatisticsHelper::DEFAULT_SELECTIVITY), 1U);
 		}
 		if (base_table_cardinality == 0) {
 			cardinality_after_filters = 0;
@@ -345,7 +345,7 @@ RelationStats RelationStatisticsHelper::ExtractAggregationStats(LogicalAggregate
 		// most likely we are running on parquet files. Therefore we divide by 2.
 		new_card = (double)child_stats.cardinality / 2;
 	}
-	stats.cardinality = new_card;
+	stats.cardinality = NumericCast<idx_t>(new_card);
 	stats.column_names = child_stats.column_names;
 	stats.stats_initialized = true;
 	auto num_child_columns = aggr.GetColumnBindings().size();

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -639,7 +639,9 @@ bool Executor::GetPipelinesProgress(double &current_progress, uint64_t &current_
 
 	for (size_t i = 0; i < progress.size(); i++) {
 		progress[i] = MaxValue(0.0, MinValue(100.0, progress[i]));
-		current_cardinality += double(progress[i]) * double(cardinality[i]) / double(100);
+		current_cardinality = NumericCast<idx_t>(static_cast<double>(
+		    current_cardinality +
+		    static_cast<double>(progress[i]) * static_cast<double>(cardinality[i]) / static_cast<double>(100)));
 		current_progress += progress[i] * double(cardinality[i]) / double(total_cardinality);
 		D_ASSERT(current_cardinality <= total_cardinality);
 	}

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -86,7 +86,7 @@ typedef struct {
 } dictionary_compression_header_t;
 
 struct DictionaryCompressionStorage {
-	static constexpr float MINIMUM_COMPRESSION_RATIO = 1.2;
+	static constexpr float MINIMUM_COMPRESSION_RATIO = 1.2F;
 	static constexpr uint16_t DICTIONARY_HEADER_SIZE = sizeof(dictionary_compression_header_t);
 	static constexpr size_t COMPACTION_FLUSH_LIMIT = (size_t)Storage::BLOCK_SIZE / 5 * 4;
 
@@ -402,7 +402,7 @@ idx_t DictionaryCompressionStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 	auto req_space =
 	    RequiredSpace(state.current_tuple_count, state.current_unique_count, state.current_dict_size, width);
 
-	return MINIMUM_COMPRESSION_RATIO * (state.segment_count * Storage::BLOCK_SIZE + req_space);
+	return NumericCast<idx_t>(MINIMUM_COMPRESSION_RATIO * (state.segment_count * Storage::BLOCK_SIZE + req_space));
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -191,7 +191,7 @@ idx_t FSSTStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 
 	auto estimated_size = estimated_base_size + symtable_size;
 
-	return estimated_size * MINIMUM_COMPRESSION_RATIO;
+	return NumericCast<idx_t>(estimated_size * MINIMUM_COMPRESSION_RATIO);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/statistics/distinct_statistics.cpp
+++ b/src/storage/statistics/distinct_statistics.cpp
@@ -64,7 +64,7 @@ idx_t DistinctStatistics::GetCount() const {
 	double u1 = pow(u / s, 2) * u;
 
 	// Estimate total uniques using Good Turing Estimation
-	idx_t estimate = u + u1 / s * (n - s);
+	idx_t estimate = NumericCast<idx_t>(u + u1 / s * (n - s));
 	return MinValue<idx_t>(estimate, total_count);
 }
 


### PR DESCRIPTION
Follow-up to #11673, enabling all remaining conversion warnings with `-Wconversion` and also fixing them