### PR TITLE
Fix builds when LOCAL_EXTENSION_REPO is not set and python is not found.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,7 +830,7 @@ function(build_loadable_extension_directory NAME OUTPUT_DIRECTORY EXTENSION_VERS
     ${CMAKE_COMMAND} -DEXTENSION=$<TARGET_FILE:${TARGET_NAME}> -DPLATFORM_FILE=${DuckDB_BINARY_DIR}/duckdb_platform_out -DDUCKDB_VERSION="${DUCKDB_NORMALIZED_VERSION}" -DEXTENSION_VERSION="${EXTENSION_VERSION}" -DNULL_FILE=${CMAKE_CURRENT_FUNCTION_LIST_DIR}/scripts/null.txt -P ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/scripts/append_metadata.cmake
     )
   add_dependencies(${TARGET_NAME} duckdb_platform)
-  if (NOT EXTENSION_CONFIG_BUILD AND NOT ${EXTENSION_TESTS_ONLY} AND NOT CLANG_TIDY)
+  if (LOCAL_EXTENSION_REPO)
     add_dependencies(duckdb_local_extension_repo ${TARGET_NAME})
   endif()
 endfunction()


### PR DESCRIPTION
We build duckdb without LOCAL_EXTENSION_REPO set and without python. In such a case, the duckdb_local_extension_repo target is not defined, and it can't be extended.

This change is what I had to do to make 0.10.2 build for me, so I figured I'd offer a patch.