### PR TITLE
Remove bound_defaults from BoundCreateTableInfo

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -342,9 +342,9 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddColumn(ClientContext &context, AddCo
 	create_info->columns.AddColumn(std::move(col));
 
 	auto binder = Binder::CreateBinder(context);
-	auto bound_create_info = binder->BindCreateTableInfo(std::move(create_info), schema);
-	auto new_storage =
-	    make_shared<DataTable>(context, *storage, info.new_column, *bound_create_info->bound_defaults.back());
+	vector<unique_ptr<Expression>> bound_defaults;
+	auto bound_create_info = binder->BindCreateTableInfo(std::move(create_info), schema, bound_defaults);
+	auto new_storage = make_shared<DataTable>(context, *storage, info.new_column, *bound_defaults.back());
 	return make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, new_storage);
 }
 

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -119,6 +119,8 @@ public:
 
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info);
 	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema);
+	unique_ptr<BoundCreateTableInfo> BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema,
+	                                                     vector<unique_ptr<Expression>> &bound_defaults);
 
 	void BindCreateViewInfo(CreateViewInfo &base);
 	SchemaCatalogEntry &BindSchema(CreateInfo &info);

--- a/src/include/duckdb/planner/parsed_data/bound_create_table_info.hpp
+++ b/src/include/duckdb/planner/parsed_data/bound_create_table_info.hpp
@@ -38,8 +38,6 @@ struct BoundCreateTableInfo {
 	vector<unique_ptr<Constraint>> constraints;
 	//! List of bound constraints on the table
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
-	//! Bound default values
-	vector<unique_ptr<Expression>> bound_defaults;
 	//! Dependents of the table (in e.g. default values)
 	LogicalDependencyList dependencies;
 	//! The existing table data on disk (if any)


### PR DESCRIPTION
Removes `bound_defaults` from the `BoundCreateTableInfo`. This PR that works towards removing all need for binding for `BoundCreateTableInfo`, which allows us to create tables without having an available `ClientContext`. This subsequently solves a number of issues when it comes to database start-up.