### PR TITLE
[Dev] Fix failing CI in Python SQLLogicTest Runner

### DIFF
--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -772,10 +772,9 @@ class SQLLogicContext:
         # set up the config file
         additional_config = {}
         if readonly:
-            additional_config['temp_directory'] = False
+            additional_config['temp_directory'] = ""
             additional_config['access_mode'] = 'read_only'
         else:
-            additional_config['temp_directory'] = True
             additional_config['access_mode'] = 'automatic'
 
         self.pool = None


### PR DESCRIPTION
This fixes https://github.com/duckdblabs/duckdb-internal/issues/1855

This was caused by wrongly interpreting the `sqllogic_test_runner.cpp` code.