### PR TITLE
[Map] Rework `MAP` creation method behavior when input is NULL

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3802,14 +3802,10 @@ const char* EnumUtil::ToChars<MapInvalidReason>(MapInvalidReason value) {
 	switch(value) {
 	case MapInvalidReason::VALID:
 		return "VALID";
-	case MapInvalidReason::NULL_KEY_LIST:
-		return "NULL_KEY_LIST";
 	case MapInvalidReason::NULL_KEY:
 		return "NULL_KEY";
 	case MapInvalidReason::DUPLICATE_KEY:
 		return "DUPLICATE_KEY";
-	case MapInvalidReason::NULL_VALUE_LIST:
-		return "NULL_VALUE_LIST";
 	case MapInvalidReason::NOT_ALIGNED:
 		return "NOT_ALIGNED";
 	case MapInvalidReason::INVALID_PARAMS:
@@ -3824,17 +3820,11 @@ MapInvalidReason EnumUtil::FromString<MapInvalidReason>(const char *value) {
 	if (StringUtil::Equals(value, "VALID")) {
 		return MapInvalidReason::VALID;
 	}
-	if (StringUtil::Equals(value, "NULL_KEY_LIST")) {
-		return MapInvalidReason::NULL_KEY_LIST;
-	}
 	if (StringUtil::Equals(value, "NULL_KEY")) {
 		return MapInvalidReason::NULL_KEY;
 	}
 	if (StringUtil::Equals(value, "DUPLICATE_KEY")) {
 		return MapInvalidReason::DUPLICATE_KEY;
-	}
-	if (StringUtil::Equals(value, "NULL_VALUE_LIST")) {
-		return MapInvalidReason::NULL_VALUE_LIST;
 	}
 	if (StringUtil::Equals(value, "NOT_ALIGNED")) {
 		return MapInvalidReason::NOT_ALIGNED;

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -2089,10 +2089,6 @@ void MapVector::EvalMapInvalidReason(MapInvalidReason reason) {
 		throw InvalidInputException("Map keys must be unique.");
 	case MapInvalidReason::NULL_KEY:
 		throw InvalidInputException("Map keys can not be NULL.");
-	case MapInvalidReason::NULL_KEY_LIST:
-		throw InvalidInputException("The list of map keys must not be NULL.");
-	case MapInvalidReason::NULL_VALUE_LIST:
-		throw InvalidInputException("The list of map values must not be NULL.");
 	case MapInvalidReason::NOT_ALIGNED:
 		throw InvalidInputException("The map key list does not align with the map value list.");
 	case MapInvalidReason::INVALID_PARAMS:

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -317,9 +317,6 @@ static void ArrowToDuckDBMapVerify(Vector &vector, idx_t count) {
 	case MapInvalidReason::NULL_KEY: {
 		throw InvalidInputException("Arrow map contains NULL as map key, which isn't supported by DuckDB map type");
 	}
-	case MapInvalidReason::NULL_KEY_LIST: {
-		throw InvalidInputException("Arrow map contains NULL as key list, which isn't supported by DuckDB map type");
-	}
 	default: {
 		throw InternalException("MapInvalidReason not implemented");
 	}

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -464,15 +464,7 @@ struct FSSTVector {
 	DUCKDB_API static idx_t GetCount(Vector &vector);
 };
 
-enum class MapInvalidReason : uint8_t {
-	VALID,
-	NULL_KEY_LIST,
-	NULL_KEY,
-	DUPLICATE_KEY,
-	NULL_VALUE_LIST,
-	NOT_ALIGNED,
-	INVALID_PARAMS
-};
+enum class MapInvalidReason : uint8_t { VALID, NULL_KEY, DUPLICATE_KEY, NOT_ALIGNED, INVALID_PARAMS };
 
 struct MapVector {
 	DUCKDB_API static const Vector &GetKeys(const Vector &vector);

--- a/test/sql/types/map/map_null.test
+++ b/test/sql/types/map/map_null.test
@@ -1,0 +1,35 @@
+# name: test/sql/types/map/map_null.test
+# group: [map]
+
+statement ok
+pragma enable_verification;
+
+query I
+select map(NULL::INT[], [1,2,3])
+----
+NULL
+
+query I
+select map(NULL, [1,2,3])
+----
+NULL
+
+query I
+select map(NULL, NULL)
+----
+NULL
+
+query I
+select map(NULL, [1,2,3]) IS NULL
+----
+true
+
+query I
+select map([1,2,3], NULL)
+----
+NULL
+
+query I
+select map([1,2,3], NULL::INT[])
+----
+NULL

--- a/test/sql/types/map/map_null.test
+++ b/test/sql/types/map/map_null.test
@@ -33,3 +33,37 @@ query I
 select map([1,2,3], NULL::INT[])
 ----
 NULL
+
+query I
+SELECT * FROM ( VALUES
+	(MAP(NULL, NULL)),
+	(MAP(NULL::INT[], NULL::INT[])),
+	(MAP([1,2,3], [1,2,3]))
+)
+----
+NULL
+NULL
+{1=1, 2=2, 3=3}
+
+query I
+select MAP(a, b) FROM ( VALUES
+	(NULL, ['b', 'c']),
+	(NULL::INT[], NULL),
+	(NULL::INT[], NULL::VARCHAR[]),
+	(NULL::INT[], ['a', 'b', 'c']),
+	(NULL, ['longer string than inlined', 'smol']),
+	(NULL, NULL),
+	([1,2,3], NULL),
+	([1,2,3], ['z', 'y', 'x']),
+	([1,2,3], NULL::VARCHAR[]),
+) t(a, b)
+----
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+{1=z, 2=y, 3=x}
+NULL

--- a/test/sql/types/nested/map/map_error.test
+++ b/test/sql/types/nested/map/map_error.test
@@ -75,10 +75,11 @@ CREATE TABLE null_keys_list (k INT[], v INT[]);
 statement ok
 INSERT INTO null_keys_list VALUES ([1], [2]), (NULL, [4]);
 
-statement error
+query I
 SELECT MAP(k, v) FROM null_keys_list;
 ----
-The list of map keys must not be NULL.
+{1=2}
+NULL
 
 statement ok
 CREATE TABLE null_values_list (k INT[], v INT[]);
@@ -86,7 +87,8 @@ CREATE TABLE null_values_list (k INT[], v INT[]);
 statement ok
 INSERT INTO null_values_list VALUES ([1], [2]), ([4], NULL);
 
-statement error
+query I
 SELECT MAP(k, v) FROM null_values_list;
 ----
-The list of map values must not be NULL.
+{1=2}
+NULL

--- a/test/sql/types/nested/map/test_map_subscript.test
+++ b/test/sql/types/nested/map/test_map_subscript.test
@@ -2,6 +2,9 @@
 # description: Test cardinality function for maps
 # group: [map]
 
+statement ok
+pragma enable_verification
+
 # Single element on map
 query I
 select m[1] from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as m) as T

--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -37,6 +37,20 @@ vector<string> TransformStructKeys(py::handle keys, idx_t size, const LogicalTyp
 	return res;
 }
 
+static bool IsValidMapComponent(const py::handle &component) {
+	// The component is either NULL
+	if (py::none().is(component)) {
+		return true;
+	}
+	if (!py::hasattr(component, "__getitem__")) {
+		return false;
+	}
+	if (!py::hasattr(component, "__len__")) {
+		return false;
+	}
+	return true;
+}
+
 bool DictionaryHasMapFormat(const PyDictionary &dict) {
 	if (dict.len != 2) {
 		return false;
@@ -51,13 +65,19 @@ bool DictionaryHasMapFormat(const PyDictionary &dict) {
 		return false;
 	}
 
-	// Dont check for 'py::list' to allow ducktyping
-	if (!py::hasattr(keys, "__getitem__") || !py::hasattr(keys, "__len__")) {
+	if (!IsValidMapComponent(keys)) {
 		return false;
 	}
-	if (!py::hasattr(values, "__getitem__") || !py::hasattr(values, "__len__")) {
+	if (!IsValidMapComponent(values)) {
 		return false;
 	}
+
+	// If either of the components is NULL, return early
+	if (py::none().is(keys) || py::none().is(values)) {
+		return true;
+	}
+
+	// Verify that both the keys and values are of the same length
 	auto size = py::len(keys);
 	if (size != py::len(values)) {
 		return false;
@@ -91,6 +111,11 @@ Value TransformStructFormatDictionaryToMap(const PyDictionary &dict, const Logic
 	if (target_type.id() != LogicalTypeId::MAP) {
 		throw InvalidInputException("Please provide a valid target type for transform from Python to Value");
 	}
+
+	if (py::none().is(dict.keys) || py::none().is(dict.values)) {
+		return Value(LogicalType::MAP(LogicalTypeId::SQLNULL, LogicalTypeId::SQLNULL));
+	}
+
 	auto size = py::len(dict.keys);
 	D_ASSERT(size == py::len(dict.values));
 
@@ -130,12 +155,18 @@ Value TransformDictionaryToMap(const PyDictionary &dict, const LogicalType &targ
 	auto keys = dict.values.attr("__getitem__")(0);
 	auto values = dict.values.attr("__getitem__")(1);
 
+	if (py::none().is(keys) || py::none().is(values)) {
+		// Either 'key' or 'value' is None, return early with a NULL value
+		return Value(LogicalType::MAP(LogicalTypeId::SQLNULL, LogicalTypeId::SQLNULL));
+	}
+
 	auto key_size = py::len(keys);
 	D_ASSERT(key_size == py::len(values));
 	if (key_size == 0) {
 		// dict == { 'key': [], 'value': [] }
 		return EmptyMapValue();
 	}
+
 	// dict == { 'key': [ ... ], 'value' : [ ... ] }
 	LogicalType key_target = LogicalTypeId::UNKNOWN;
 	LogicalType value_target = LogicalTypeId::UNKNOWN;

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -153,8 +153,6 @@ static void VerifyMapConstraints(Vector &vec, idx_t count) {
 		return;
 	case MapInvalidReason::DUPLICATE_KEY:
 		throw InvalidInputException("Dict->Map conversion failed because 'key' list contains duplicates");
-	case MapInvalidReason::NULL_KEY_LIST:
-		throw InvalidInputException("Dict->Map conversion failed because 'key' list is None");
 	case MapInvalidReason::NULL_KEY:
 		throw InvalidInputException("Dict->Map conversion failed because 'key' list contains None");
 	default:

--- a/tools/pythonpkg/src/pandas/analyzer.cpp
+++ b/tools/pythonpkg/src/pandas/analyzer.cpp
@@ -331,6 +331,10 @@ LogicalType PandasAnalyzer::DictToMap(const PyDictionary &dict, bool &can_conver
 	auto keys = dict.values.attr("__getitem__")(0);
 	auto values = dict.values.attr("__getitem__")(1);
 
+	if (py::none().is(keys) || py::none().is(values)) {
+		return LogicalType::MAP(LogicalTypeId::SQLNULL, LogicalTypeId::SQLNULL);
+	}
+
 	auto key_type = GetListType(keys, can_convert);
 	if (!can_convert) {
 		return EmptyMap();

--- a/tools/pythonpkg/tests/fast/arrow/test_nested_arrow.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_nested_arrow.py
@@ -183,6 +183,15 @@ class TestArrowNested(object):
         ):
             rel = duckdb.from_arrow(arrow_table).fetchall()
 
+    def test_null_map_arrow_to_duckdb(self, duckdb_cursor):
+        if not can_run:
+            return
+        map_type = pa.map_(pa.int32(), pa.int32())
+        values = [None, [(5, 42)]]
+        arrow_table = pa.table({'detail': pa.array(values, map_type)})
+        res = duckdb_cursor.sql("select * from arrow_table").fetchall()
+        assert res == [(None,), ({'key': [5], 'value': [42]},)]
+
     def test_map_arrow_to_pandas(self, duckdb_cursor):
         if not can_run:
             return

--- a/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_df_object_resolution.py
@@ -324,7 +324,7 @@ class TestResolveObjectColumns(object):
         with pytest.raises(
             duckdb.InvalidInputException, match="Dict->Map conversion failed because 'key' list contains duplicates"
         ):
-            converted_col = duckdb_cursor.sql("select * from x").df()
+            duckdb_cursor.sql("select * from x").show()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_map_nullkey(self, pandas, duckdb_cursor):
@@ -337,9 +337,8 @@ class TestResolveObjectColumns(object):
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
     def test_map_nullkeylist(self, pandas, duckdb_cursor):
         x = pandas.DataFrame([[{'key': None, 'value': None}]])
-        # Isn't actually converted to MAP because isinstance(None, list) != True
         converted_col = duckdb_cursor.sql("select * from x").df()
-        duckdb_col = duckdb_cursor.sql("SELECT {key: NULL, value: NULL} as '0'").df()
+        duckdb_col = duckdb_cursor.sql("SELECT MAP(NULL, NULL) as '0'").df()
         pandas.testing.assert_frame_equal(duckdb_col, converted_col)
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])


### PR DESCRIPTION
This PR fixes #11115

### Old behavior:
`MAP(NULL, [1,2,3])` -> Error: Only LIST types are accepted arguments
`MAP([1,2,3], NULL)` -> Error: Only LIST types are accepted arguments
`MAP(NULL, NULL)` -> `{}` (empty map)
`MAP(NULL::INT[], [1,2,3])` -> Error: Key list can not be NULL
`MAP([1,2,3], NULL::INT[])` -> Error: Value list can not be NULL
`MAP(NULL::INT[], NULL::INT[])` -> Error: Key list can not be NULL

### New behavior:
`MAP(NULL, [1,2,3])` -> `NULL`
`MAP([1,2,3], NULL)` -> `NULL`
`MAP(NULL, NULL)` -> `NULL`
`MAP(NULL::INT[], [1,2,3])` -> `NULL`
`MAP([1,2,3], NULL::INT[])` -> `NULL`
`MAP(NULL::INT[], NULL::INT[])` -> `NULL`