### PR TITLE
[Dev] Always use `SQLStatement->Copy()` when ALTERNATIVE_VERIFY is defined

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -762,6 +762,11 @@ void ClientContext::SetActiveResult(ClientContextLock &lock, BaseQueryResult &re
 unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatementInternal(
     ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
     shared_ptr<PreparedStatementData> &prepared, const PendingQueryParameters &parameters) {
+#ifdef DUCKDB_ALTERNATIVE_VERIFY
+	if (statement && statement->type != StatementType::LOGICAL_PLAN_STATEMENT) {
+		statement = statement->Copy();
+	}
+#endif
 	// check if we are on AutoCommit. In this case we should start a transaction.
 	if (statement && config.AnyVerification()) {
 		// query verification is enabled


### PR DESCRIPTION
This verifies that all the Copy methods of statements are correct