### PR TITLE
Implicit Cast for any Date/Timestamp

### DIFF
--- a/.github/regression/csv.csv
+++ b/.github/regression/csv.csv
@@ -5,3 +5,4 @@ benchmark/micro/csv/null_padding.benchmark
 benchmark/micro/csv/projection_pushdown.benchmark
 benchmark/micro/csv/1_byte_values.benchmark
 benchmark/micro/csv/16_byte_values.benchmark
+benchmark/micro/csv/time_type.benchmark

--- a/.github/regression/micro_extended.csv
+++ b/.github/regression/micro_extended.csv
@@ -86,6 +86,7 @@ benchmark/micro/csv/read.benchmark
 benchmark/micro/csv/small_csv.benchmark
 benchmark/micro/csv/sniffer.benchmark
 benchmark/micro/csv/sniffer_quotes.benchmark
+benchmark/micro/csv/time_type.benchmark
 benchmark/micro/cte/cte.benchmark
 benchmark/micro/cte/materialized_cte.benchmark
 benchmark/micro/date/extract_month.benchmark

--- a/benchmark/micro/csv/time_type.benchmark
+++ b/benchmark/micro/csv/time_type.benchmark
@@ -1,0 +1,14 @@
+# name: benchmark/micro/csv/time_type.benchmark
+# description: Run CSV scan with timestamp and date types
+# group: [csv]
+
+name CSV Read Benchmark with timestamp and date types
+group csv
+
+load
+CREATE TABLE t1 AS select '30/07/1992', '30/07/1992 17:15:30';
+insert into t1  select '30/07/1992', '30/07/1992 17:15:30' from range(0,10000000) tbl(i);
+COPY t1 TO '${BENCHMARK_DIR}/time_timestamp.csv' (FORMAT CSV, HEADER 0);
+
+run
+SELECT * from read_csv('${BENCHMARK_DIR}/time_timestamp.csv',delim= ',',  header = 0)

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -97,6 +97,8 @@ StringValueResult::StringValueResult(CSVStates &states, CSVStateMachine &state_m
 		null_str_ptr[i] = state_machine.options.null_str[i].c_str();
 		null_str_size[i] = state_machine.options.null_str[i].size();
 	}
+	date_format = state_machine.options.dialect_options.date_format.at(LogicalTypeId::DATE).GetValue();
+	timestamp_format = state_machine.options.dialect_options.date_format.at(LogicalTypeId::TIMESTAMP).GetValue();
 }
 
 StringValueResult::~StringValueResult() {
@@ -215,11 +217,9 @@ void StringValueResult::AddValueToVector(const char *value_ptr, const idx_t size
 		                               false, state_machine.options.decimal_separator[0]);
 		break;
 	case LogicalTypeId::DATE: {
-		if (!state_machine.dialect_options.date_format.find(LogicalTypeId::DATE)->second.GetValue().Empty()) {
-			success =
-			    state_machine.dialect_options.date_format.find(LogicalTypeId::DATE)
-			        ->second.GetValue()
-			        .TryParseDate(value_ptr, size, static_cast<date_t *>(vector_ptr[chunk_col_id])[number_of_rows]);
+		if (!date_format.Empty()) {
+			success = date_format.TryParseDate(value_ptr, size,
+			                                   static_cast<date_t *>(vector_ptr[chunk_col_id])[number_of_rows]);
 		} else {
 			idx_t pos;
 			bool special;
@@ -229,11 +229,9 @@ void StringValueResult::AddValueToVector(const char *value_ptr, const idx_t size
 		break;
 	}
 	case LogicalTypeId::TIMESTAMP: {
-		if (!state_machine.dialect_options.date_format.find(LogicalTypeId::TIMESTAMP)->second.GetValue().Empty()) {
-			success = state_machine.dialect_options.date_format.find(LogicalTypeId::TIMESTAMP)
-			              ->second.GetValue()
-			              .TryParseTimestamp(value_ptr, size,
-			                                 static_cast<timestamp_t *>(vector_ptr[chunk_col_id])[number_of_rows]);
+		if (!timestamp_format.Empty()) {
+			success = timestamp_format.TryParseTimestamp(
+			    value_ptr, size, static_cast<timestamp_t *>(vector_ptr[chunk_col_id])[number_of_rows]);
 		} else {
 			success = Timestamp::TryConvertTimestamp(
 			              value_ptr, size, static_cast<timestamp_t *>(vector_ptr[chunk_col_id])[number_of_rows]) ==

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -216,11 +216,10 @@ void StringValueResult::AddValueToVector(const char *value_ptr, const idx_t size
 		break;
 	case LogicalTypeId::DATE: {
 		if (!state_machine.dialect_options.date_format.find(LogicalTypeId::DATE)->second.GetValue().Empty()) {
-			string error_message;
-			success = state_machine.dialect_options.date_format.find(LogicalTypeId::DATE)
-			              ->second.GetValue()
-			              .TryParseDate(value_ptr, size,
-			                            static_cast<date_t *>(vector_ptr[chunk_col_id])[number_of_rows], error_message);
+			success =
+			    state_machine.dialect_options.date_format.find(LogicalTypeId::DATE)
+			        ->second.GetValue()
+			        .TryParseDate(value_ptr, size, static_cast<date_t *>(vector_ptr[chunk_col_id])[number_of_rows]);
 		} else {
 			idx_t pos;
 			bool special;
@@ -231,11 +230,10 @@ void StringValueResult::AddValueToVector(const char *value_ptr, const idx_t size
 	}
 	case LogicalTypeId::TIMESTAMP: {
 		if (!state_machine.dialect_options.date_format.find(LogicalTypeId::TIMESTAMP)->second.GetValue().Empty()) {
-			timestamp_t result;
-			string error_message;
-			//			success =  state_machine.dialect_options.date_format.find(LogicalTypeId::TIMESTAMP)
-			//			    ->second.GetValue()
-			//			    .TryParseTimestamp(value, result, error_message);
+			success = state_machine.dialect_options.date_format.find(LogicalTypeId::TIMESTAMP)
+			              ->second.GetValue()
+			              .TryParseTimestamp(value_ptr, size,
+			                                 static_cast<timestamp_t *>(vector_ptr[chunk_col_id])[number_of_rows]);
 		} else {
 			success = Timestamp::TryConvertTimestamp(
 			              value_ptr, size, static_cast<timestamp_t *>(vector_ptr[chunk_col_id])[number_of_rows]) ==

--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -1414,7 +1414,7 @@ bool StrpTimeFormat::TryParseDate(string_t input, date_t &result, string &error_
 	return parse_result.TryToDate(result);
 }
 
-bool StrpTimeFormat::TryParseDate(const char *data, size_t size, date_t &result, string &error_message) const {
+bool StrpTimeFormat::TryParseDate(const char *data, size_t size, date_t &result) const {
 	ParseResult parse_result;
 	if (!Parse(data, size, parse_result)) {
 		return false;
@@ -1435,6 +1435,14 @@ bool StrpTimeFormat::TryParseTimestamp(string_t input, timestamp_t &result, stri
 	ParseResult parse_result;
 	if (!Parse(input, parse_result)) {
 		error_message = parse_result.FormatError(input, format_specifier);
+		return false;
+	}
+	return parse_result.TryToTimestamp(result);
+}
+
+bool StrpTimeFormat::TryParseTimestamp(const char *data, size_t size, timestamp_t &result) const {
+	ParseResult parse_result;
+	if (!Parse(data, size, parse_result)) {
 		return false;
 	}
 	return parse_result.TryToTimestamp(result);

--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -740,8 +740,7 @@ int32_t StrpTimeFormat::TryParseCollection(const char *data, idx_t &pos, idx_t s
 	return -1;
 }
 
-//! Parses a timestamp using the given specifier
-bool StrpTimeFormat::Parse(string_t str, ParseResult &result) const {
+bool StrpTimeFormat::Parse(const char *data, size_t size, ParseResult &result) const {
 	auto &result_data = result.data;
 	auto &error_message = result.error_message;
 	auto &error_position = result.error_position;
@@ -755,15 +754,11 @@ bool StrpTimeFormat::Parse(string_t str, ParseResult &result) const {
 	result_data[5] = 0;
 	result_data[6] = 0;
 	result_data[7] = 0;
-
-	auto data = str.GetData();
-	idx_t size = str.GetSize();
 	// skip leading spaces
 	while (StringUtil::CharacterIsSpace(*data)) {
 		data++;
 		size--;
 	}
-
 	//	Check for specials
 	//	Precheck for alphas for performance.
 	idx_t pos = 0;
@@ -1067,7 +1062,6 @@ bool StrpTimeFormat::Parse(string_t str, ParseResult &result) const {
 				case StrTimeSpecifier::YEAR_DECIMAL:
 					// Just validate, don't use
 					break;
-					break;
 				case StrTimeSpecifier::WEEKDAY_DECIMAL:
 					// First offset specifier
 					offset_specifier = specifiers[i];
@@ -1324,6 +1318,13 @@ bool StrpTimeFormat::Parse(string_t str, ParseResult &result) const {
 	return true;
 }
 
+//! Parses a timestamp using the given specifier
+bool StrpTimeFormat::Parse(string_t str, ParseResult &result) const {
+	auto data = str.GetData();
+	idx_t size = str.GetSize();
+	return Parse(data, size, result);
+}
+
 StrpTimeFormat::ParseResult StrpTimeFormat::Parse(const string &format_string, const string &text) {
 	StrpTimeFormat format;
 	format.format_specifier = format_string;
@@ -1408,6 +1409,14 @@ bool StrpTimeFormat::TryParseDate(string_t input, date_t &result, string &error_
 	ParseResult parse_result;
 	if (!Parse(input, parse_result)) {
 		error_message = parse_result.FormatError(input, format_specifier);
+		return false;
+	}
+	return parse_result.TryToDate(result);
+}
+
+bool StrpTimeFormat::TryParseDate(const char *data, size_t size, date_t &result, string &error_message) const {
+	ParseResult parse_result;
+	if (!Parse(data, size, parse_result)) {
 		return false;
 	}
 	return parse_result.TryToDate(result);

--- a/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
@@ -145,7 +145,7 @@ public:
 
 	//! Errors happening in the current line (if any)
 	vector<CurrentError> current_errors;
-
+	StrpTimeFormat date_format, timestamp_format;
 	bool sniffing;
 	//! Specialized code for quoted values, makes sure to remove quotes and escapes
 	static inline void AddQuotedValue(StringValueResult &result, const idx_t buffer_pos);

--- a/src/include/duckdb/function/scalar/strftime_format.hpp
+++ b/src/include/duckdb/function/scalar/strftime_format.hpp
@@ -161,6 +161,10 @@ public:
 
 	DUCKDB_API bool Parse(string_t str, ParseResult &result) const;
 
+	DUCKDB_API bool Parse(const char *data, size_t size, ParseResult &result) const;
+
+	DUCKDB_API bool TryParseDate(const char *data, size_t size, date_t &result, string &error_message) const;
+
 	DUCKDB_API bool TryParseDate(string_t str, date_t &result, string &error_message) const;
 	DUCKDB_API bool TryParseTime(string_t str, dtime_t &result, string &error_message) const;
 	DUCKDB_API bool TryParseTimestamp(string_t str, timestamp_t &result, string &error_message) const;

--- a/src/include/duckdb/function/scalar/strftime_format.hpp
+++ b/src/include/duckdb/function/scalar/strftime_format.hpp
@@ -163,7 +163,8 @@ public:
 
 	DUCKDB_API bool Parse(const char *data, size_t size, ParseResult &result) const;
 
-	DUCKDB_API bool TryParseDate(const char *data, size_t size, date_t &result, string &error_message) const;
+	DUCKDB_API bool TryParseDate(const char *data, size_t size, date_t &result) const;
+	DUCKDB_API bool TryParseTimestamp(const char *data, size_t size, timestamp_t &result) const;
 
 	DUCKDB_API bool TryParseDate(string_t str, date_t &result, string &error_message) const;
 	DUCKDB_API bool TryParseTime(string_t str, dtime_t &result, string &error_message) const;

--- a/test/sql/copy/csv/csv_hive_filename_union.test
+++ b/test/sql/copy/csv/csv_hive_filename_union.test
@@ -56,7 +56,7 @@ xxx	42
 statement error
 select * from read_csv_auto(['data/csv/hive-partitioning/mismatching_contents/part=1/test.csv', 'data/csv/hive-partitioning/mismatching_contents/part=2/test.csv'])  order by 1
 ----
-date field value out of range
+Error when converting column "c". Could not convert string "world" to 'DATE'
 
 query III
 select a, b, c from read_csv_auto('data/csv/hive-partitioning/mismatching_contents/*/*.csv', UNION_BY_NAME=1)  order by 2 NULLS LAST

--- a/test/sql/copy/csv/rejects/csv_rejects_flush_cast.test
+++ b/test/sql/copy/csv/rejects/csv_rejects_flush_cast.test
@@ -20,6 +20,6 @@ DATE	VARCHAR	2811
 query IIIIIIIII
 SELECT * EXCLUDE (scan_id) FROM reject_errors order by all;
 ----
-0	439	6997	NULL	1	a	CAST	B, bla	Error when converting column "a". Could not parse string "B" according to format specifier "%d-%m-%Y"
-0	2813	44972	NULL	1	a	CAST	c, bla	Error when converting column "a". Could not parse string "c" according to format specifier "%d-%m-%Y"
+0	439	6997	6997	1	a	CAST	B, bla	Error when converting column "a". Could not convert string "B" to 'DATE'
+0	2813	44972	44972	1	a	CAST	c, bla	Error when converting column "a". Could not convert string "c" to 'DATE'
 

--- a/test/sql/copy/csv/rejects/test_multiple_errors_same_line.test
+++ b/test/sql/copy/csv/rejects/test_multiple_errors_same_line.test
@@ -61,8 +61,8 @@ oogie boogie	3	2023-01-02	2023-01-03
 query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id) FROM reject_errors ORDER BY ALL;
 ----
-0	4	110	NULL	3	current_day	CAST	oogie boogie,3, bla_2, bla_1	Error when converting column "current_day". date field value out of range: " bla_2", expected format is (YYYY-MM-DD)
-0	4	110	NULL	4	tomorrow	CAST	oogie boogie,3, bla_2, bla_1	Error when converting column "tomorrow". date field value out of range: " bla_1", expected format is (YYYY-MM-DD)
+0	4	110	125	3	current_day	CAST	oogie boogie,3, bla_2, bla_1	Error when converting column "current_day". Could not convert string " bla_2" to 'DATE'
+0	4	110	132	4	tomorrow	CAST	oogie boogie,3, bla_2, bla_1	Error when converting column "tomorrow". Could not convert string " bla_1" to 'DATE'
 
 statement ok
 DROP TABLE reject_errors;
@@ -82,6 +82,7 @@ oogie boogie	3	2023-01-02	5
 query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id) FROM reject_errors ORDER BY ALL;
 ----
+0	4	89	104	3	current_day	CAST	oogie boogie,3, bla_2, bla_1	Error when converting column "current_day". Could not convert string " bla_2" to 'DATE'
 0	4	89	111	4	barks	CAST	oogie boogie,3, bla_2, bla_1	Error when converting column "barks". Could not convert string " bla_1" to 'INTEGER'
 
 statement ok
@@ -370,10 +371,13 @@ SELECT * EXCLUDE (scan_id) FROM reject_errors ORDER BY ALL;
 ----
 0	4	89	116	4	barks	CAST	oogie boogie,3, 2023-01-03, bla, 7	Error when converting column "barks". Could not convert string " bla" to 'INTEGER'
 0	4	89	120	5	NULL	TOO MANY COLUMNS	oogie boogie,3, 2023-01-03, bla, 7	Expected Number of Columns: 4 Found: 5
+0	5	124	139	3	current_day	CAST	oogie boogie,3, bla, bla, 7	Error when converting column "current_day". Could not convert string " bla" to 'DATE'
 0	5	124	144	4	barks	CAST	oogie boogie,3, bla, bla, 7	Error when converting column "barks". Could not convert string " bla" to 'INTEGER'
 0	5	124	148	5	NULL	TOO MANY COLUMNS	oogie boogie,3, bla, bla, 7	Expected Number of Columns: 4 Found: 5
 0	6	152	152	1	name	UNQUOTED VALUE	"oogie boogie"bla,3, 2023-01-04	Value with unterminated quote found.
 0	6	152	183	3	barks	MISSING COLUMNS	"oogie boogie"bla,3, 2023-01-04	Expected Number of Columns: 4 Found: 3
+0	7	184	199	3	current_day	CAST	oogie boogie,3, bla	Error when converting column "current_day". Could not convert string " bla" to 'DATE'
 0	7	184	203	3	barks	MISSING COLUMNS	oogie boogie,3, bla	Expected Number of Columns: 4 Found: 3
 0	8	204	204	NULL	NULL	LINE SIZE OVER MAXIMUM	oogie boogieoogie boogieoogie boogieoogie boogieoogie boogieoogie boogieoogie boogie,3, bla	Maximum line size of 40 bytes exceeded. Actual Size:92 bytes.
+0	8	204	291	3	current_day	CAST	oogie boogieoogie boogieoogie boogieoogie boogieoogie boogieoogie boogieoogie boogie,3, bla	Error when converting column "current_day". Could not convert string " bla" to 'DATE'
 0	8	204	295	3	barks	MISSING COLUMNS	oogie boogieoogie boogieoogie boogieoogie boogieoogie boogieoogie boogieoogie boogie,3, bla	Expected Number of Columns: 4 Found: 3

--- a/test/sql/copy/csv/timestamp_with_tz.test
+++ b/test/sql/copy/csv/timestamp_with_tz.test
@@ -9,7 +9,7 @@ CREATE TABLE tbl(id int, ts timestamp);
 statement error
 COPY tbl FROM 'data/csv/timestamp_with_tz.csv' (HEADER)
 ----
-timestamp that is not UTC
+Error when converting column "ts". Could not convert string "2021-05-25 04:55:03.382494 EST" to 'TIMESTAMP'
 
 require icu
 


### PR DESCRIPTION
About 2x faster than older code. Also avoids using Flush in date/timestamp types, so we get better errors for the rejects tables (-:

Old: 0.65
New: 0.30