### PR TITLE
Fix `static bitpacking_width_t FindMinimumBitWidth(T *values, idx_t count)` in `class BitpackingPrimitives`

### DIFF
--- a/src/include/duckdb/common/bitpacking.hpp
+++ b/src/include/duckdb/common/bitpacking.hpp
@@ -133,7 +133,7 @@ private:
 			}
 		}
 
-		return FindMinimumBitWidth<T, round_to_next_byte>(min_value, max_value);
+		return FindMinimumBitWidth<T, is_signed, round_to_next_byte>(min_value, max_value);
 	}
 
 	template <class T, bool is_signed, bool round_to_next_byte = false>


### PR DESCRIPTION
template arguments `is_signed` is not passed.

https://github.com/duckdb/duckdb/blob/4750ce2d7abb05792e34a5c9200af7e60b8ff9a0/src/include/duckdb/common/bitpacking.hpp#L139-L140