### PR TITLE
Allow to build python packages without c++ sources

### DIFF
--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -93,6 +93,10 @@ jobs:
           assert platform == "wasm_eh_pyodide", platform
           EOF
 
+      - name: Wheel sizes
+        run: |
+          ls -lah ./tools/pythonpkg/dist/*.whl
+
       - uses: actions/upload-artifact@v3
         with:
           name: pyodide-python${{ matrix.version.python }}

--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -25,12 +25,14 @@ on:
     paths-ignore:
       - "**"
       - "!.github/workflows/Pyodide.yml"
+      - "!tools/pythonpkg/setup.py"
 
   pull_request:
     types: [opened, reopened, ready_for_review]
     paths-ignore:
       - "**"
       - "!.github/workflows/Pyodide.yml"
+      - "!tools/pythonpkg/setup.py"
 
 jobs:
   build_pyodide:

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -122,6 +122,7 @@ if platform.system() == 'Windows':
 
 is_android = hasattr(sys, 'getandroidapilevel')
 is_pyodide = 'PYODIDE' in os.environ
+no_source_wheel = is_pyodide
 use_jemalloc = (
     not is_android
     and not is_pyodide
@@ -355,7 +356,7 @@ def setup_data_files(data_files):
 
 
 data_files = setup_data_files(extra_files + header_files)
-if is_pyodide:
+if no_source_wheel:
     data_files = []
 
 packages = [

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -355,6 +355,8 @@ def setup_data_files(data_files):
 
 
 data_files = setup_data_files(extra_files + header_files)
+if is_pyodide:
+    data_files = []
 
 packages = [
     lib_name,


### PR DESCRIPTION
Enabled only for pyodide builds, where sources are of basically no use and download time (= latency) is more relevant.

Drops package size from 22MB to 9.3MB.

Unsure if there are other items that can be removed from the wheels, possibly there are ways to reduce even further, but this was significant to start with.