### PR TITLE
Only store CSV Errors if we are doing rejects table, otherwise just ignore it.

### DIFF
--- a/.github/regression/csv.csv
+++ b/.github/regression/csv.csv
@@ -7,3 +7,4 @@ benchmark/micro/csv/1_byte_values.benchmark
 benchmark/micro/csv/16_byte_values.benchmark
 benchmark/micro/csv/multiple_small_files.benchmark
 benchmark/micro/csv/time_type.benchmark
+benchmark/micro/csv/ignore_errors.benchmark

--- a/.github/regression/micro_extended.csv
+++ b/.github/regression/micro_extended.csv
@@ -78,6 +78,7 @@ benchmark/micro/copy/to_parquet_partition_by_few.benchmark
 benchmark/micro/copy/to_parquet_partition_by_many.benchmark
 benchmark/micro/csv/16_byte_values.benchmark
 benchmark/micro/csv/1_byte_values.benchmark
+benchmark/micro/csv/ignore_errors.benchmark
 benchmark/micro/csv/multiple_read.benchmark
 benchmark/micro/csv/multiple_small_files.benchmark
 benchmark/micro/csv/multiple_small_read_csv.benchmark

--- a/benchmark/micro/csv/ignore_errors.benchmark
+++ b/benchmark/micro/csv/ignore_errors.benchmark
@@ -1,0 +1,15 @@
+# name: benchmark/micro/csv/ignore_errors.benchmark
+# description: Run CSV scan with many cast errors over ignored values
+# group: [csv]
+
+name CSV Read Benchmark with ignore errors failing on multiple lines
+group csv
+
+load
+CREATE TABLE t1 AS select 'Pedro', 'bla';
+insert into t1  values ('Pedro', '232');
+insert into t1  select 'Pedro', 'bla' from range(0,10000000) tbl(i);
+COPY t1 TO '${BENCHMARK_DIR}/ignore_errors.csv' (FORMAT CSV, HEADER 0);
+
+run
+SELECT * from read_csv('${BENCHMARK_DIR}/ignore_errors.csv',delim= ',',  header = 0, types=['VARCHAR', 'INTEGER'], ignore_errors = true)

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -141,6 +141,10 @@ void CSVReaderOptions::SetNewline(const string &input) {
 	}
 }
 
+bool CSVReaderOptions::IgnoreErrors(){
+	return ignore_errors.GetValue() && store_rejects.GetValue();
+}
+
 void CSVReaderOptions::SetDateFormat(LogicalTypeId type, const string &format, bool read_format) {
 	string error;
 	if (read_format) {

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -141,8 +141,8 @@ void CSVReaderOptions::SetNewline(const string &input) {
 	}
 }
 
-bool CSVReaderOptions::IgnoreErrors(){
-	return ignore_errors.GetValue() && store_rejects.GetValue();
+bool CSVReaderOptions::IgnoreErrors() const {
+	return ignore_errors.GetValue() && !store_rejects.GetValue();
 }
 
 void CSVReaderOptions::SetDateFormat(LogicalTypeId type, const string &format, bool read_format) {

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
@@ -147,7 +147,7 @@ struct CSVReaderOptions {
 	string GetDelimiter() const;
 
 	//! If we can safely ignore errors (i.e., they are being ignored and not being stored in a rejects table)
-	bool IgnoreErrors();
+	bool IgnoreErrors() const;
 
 	NewLineIdentifier GetNewline() const;
 	void SetNewline(const string &input);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
@@ -146,6 +146,9 @@ struct CSVReaderOptions {
 	void SetDelimiter(const string &delimiter);
 	string GetDelimiter() const;
 
+	//! If we can safely ignore errors (i.e., they are being ignored and not being stored in a rejects table)
+	bool IgnoreErrors();
+
 	NewLineIdentifier GetNewline() const;
 	void SetNewline(const string &input);
 	//! Set an option that is supported by both reading and writing functions, called by


### PR DESCRIPTION
This PR also increases the performance of the CSV Reader when ignore_errors is set to true by ~10x.
It's also important to know that vectorizing our strategy for storing errors in reject tables could improve performance and memory consumption.

Old: 27s
New:3.5s

cc: @djouallah, Hopefully, this also fixes the issue you encountered over the weekend. Could you verify it? Also, thanks for letting me know about it :-)! 
