### PR TITLE
Hive partitioned write: lazy partitioning initialization

### DIFF
--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -148,17 +148,6 @@ void HivePartitioning::ApplyFiltersToFileList(ClientContext &context, vector<str
 	files = std::move(pruned_files);
 }
 
-HivePartitionedColumnData::HivePartitionedColumnData(const HivePartitionedColumnData &other)
-    : PartitionedColumnData(other), hashes_v(LogicalType::HASH) {
-	// Synchronize to ensure consistency of shared partition map
-	if (other.global_state) {
-		global_state = other.global_state;
-		unique_lock<mutex> lck(global_state->lock);
-		SynchronizeLocalMap();
-	}
-	InitializeKeys();
-}
-
 void HivePartitionedColumnData::InitializeKeys() {
 	keys.resize(STANDARD_VECTOR_SIZE);
 	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
@@ -320,82 +309,45 @@ std::map<idx_t, const HivePartitionKey *> HivePartitionedColumnData::GetReverseM
 	return ret;
 }
 
-void HivePartitionedColumnData::GrowAllocators() {
-	unique_lock<mutex> lck_gstate(allocators->lock);
-
-	idx_t current_allocator_size = allocators->allocators.size();
-	idx_t required_allocators = local_partition_map.size();
-
-	allocators->allocators.reserve(current_allocator_size);
-	for (idx_t i = current_allocator_size; i < required_allocators; i++) {
-		CreateAllocator();
-	}
-
-	D_ASSERT(allocators->allocators.size() == local_partition_map.size());
+HivePartitionedColumnData::HivePartitionedColumnData(ClientContext &context, vector<LogicalType> types,
+                                                     vector<idx_t> partition_by_cols,
+                                                     shared_ptr<GlobalHivePartitionState> global_state)
+    : PartitionedColumnData(PartitionedColumnDataType::HIVE, context, std::move(types)),
+      global_state(std::move(global_state)), group_by_columns(std::move(partition_by_cols)),
+      hashes_v(LogicalType::HASH) {
+	InitializeKeys();
+	CreateAllocator();
 }
 
-void HivePartitionedColumnData::GrowAppendState(PartitionedColumnDataAppendState &state) {
-	idx_t current_append_state_size = state.partition_append_states.size();
-	idx_t required_append_state_size = local_partition_map.size();
+void HivePartitionedColumnData::AddNewPartition(HivePartitionKey key, idx_t partition_id,
+                                                PartitionedColumnDataAppendState &state) {
+	local_partition_map.emplace(std::move(key), partition_id);
 
-	for (idx_t i = current_append_state_size; i < required_append_state_size; i++) {
-		state.partition_append_states.emplace_back(make_uniq<ColumnDataAppendState>());
-		state.partition_buffers.emplace_back(CreatePartitionBuffer());
+	if (state.partition_append_states.size() <= partition_id) {
+		state.partition_append_states.resize(partition_id + 1);
+		state.partition_buffers.resize(partition_id + 1);
+		partitions.resize(partition_id + 1);
 	}
-}
-
-void HivePartitionedColumnData::GrowPartitions(PartitionedColumnDataAppendState &state) {
-	idx_t current_partitions = partitions.size();
-	idx_t required_partitions = local_partition_map.size();
-
-	D_ASSERT(allocators->allocators.size() == required_partitions);
-
-	for (idx_t i = current_partitions; i < required_partitions; i++) {
-		partitions.emplace_back(CreatePartitionCollection(i));
-		partitions[i]->InitializeAppend(*state.partition_append_states[i]);
-	}
-	D_ASSERT(partitions.size() == local_partition_map.size());
-}
-
-void HivePartitionedColumnData::SynchronizeLocalMap() {
-	// Synchronise global map into local, may contain changes from other threads too
-	for (auto it = global_state->partitions.begin() + NumericCast<int64_t>(local_partition_map.size());
-	     it < global_state->partitions.end(); it++) {
-		local_partition_map[(*it)->first] = (*it)->second;
-	}
+	state.partition_append_states[partition_id] = make_uniq<ColumnDataAppendState>();
+	state.partition_buffers[partition_id] = CreatePartitionBuffer();
+	partitions[partition_id] = CreatePartitionCollection(0);
+	partitions[partition_id]->InitializeAppend(*state.partition_append_states[partition_id]);
 }
 
 idx_t HivePartitionedColumnData::RegisterNewPartition(HivePartitionKey key, PartitionedColumnDataAppendState &state) {
+	idx_t partition_id;
 	if (global_state) {
-		idx_t partition_id;
+		// Synchronize Global state with our local state with the newly discovered partition
+		unique_lock<mutex> lck_gstate(global_state->lock);
 
-		// Synchronize Global state with our local state with the newly discoveren partition
-		{
-			unique_lock<mutex> lck_gstate(global_state->lock);
-
-			// Insert into global map, or return partition if already present
-			auto res =
-			    global_state->partition_map.emplace(std::make_pair(std::move(key), global_state->partition_map.size()));
-			auto it = res.first;
-			partition_id = it->second;
-
-			// Add iterator to vector to allow incrementally updating local states from global state
-			global_state->partitions.emplace_back(it);
-			SynchronizeLocalMap();
-		}
-
-		// After synchronizing with the global state, we need to grow the shared allocators to support
-		// the number of partitions, which guarantees that there's always enough allocators available to each thread
-		GrowAllocators();
-
-		// Grow local partition data
-		GrowAppendState(state);
-		GrowPartitions(state);
-
-		return partition_id;
+		// Insert into global map, or return partition if already present
+		auto res = global_state->partition_map.emplace(std::make_pair(key, global_state->partition_map.size()));
+		partition_id = res.first->second;
 	} else {
-		return local_partition_map.emplace(std::make_pair(std::move(key), local_partition_map.size())).first->second;
+		partition_id = local_partition_map.size();
 	}
+	AddNewPartition(std::move(key), partition_id, state);
+	return partition_id;
 }
 
 } // namespace duckdb

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -160,8 +160,7 @@ string PhysicalCopyToFile::GetTrimmedPath(ClientContext &context) const {
 
 class CopyToFunctionLocalState : public LocalSinkState {
 public:
-	explicit CopyToFunctionLocalState(unique_ptr<LocalFunctionData> local_state)
-	    : local_state(std::move(local_state)) {
+	explicit CopyToFunctionLocalState(unique_ptr<LocalFunctionData> local_state) : local_state(std::move(local_state)) {
 	}
 	unique_ptr<GlobalFunctionData> global_state;
 	unique_ptr<LocalFunctionData> local_state;


### PR DESCRIPTION

This PR changes the way that partitions are initialized for hive partitioned writes. Previously, all found partitions would be eagerly initialized for each partitioned collection through the methods `SynchronizeLocalMap`, `GrowAppendState ` and `GrowPartitions`. This initializes a `ColumnDataCollection` and `DataChunk` for each partition for each thread.

After https://github.com/duckdb/duckdb/pull/10976, we flush the intermediate partitioned states after a set amount of rows (500K by default). After this, we reset the partitioned state. In the current set-up, after the reset happens, the synchronize methods are called and all partitioned states are initialized again. When dealing with many partitions, especially on wider tables, this consumes a lot of memory. We are also doing work that might not be necessary, as not every batch of 500K rows might contain all partitions. 

This PR reworks the initialization of the partitioned states so that, when a new partition is found **locally**, we initialize the partitioned states for that partition. The rest of the states are left uninitialized. This greatly reduces memory usage in many cases when there are many partitions. This is especially true when the partitions are not randomly spread but co-located, for example when partitioning by dates and the dates are sorted. 

###### Benchmarks

Below are some timings running the same query as in https://github.com/duckdb/duckdb/pull/10976, with `n` replaced by the number of partitions. This time we go up to the total number of unique values in the `CounterID` column (`6506`). The table itself is wide (100~ columns, with long strings) which makes this partitioning more challenging as well.


```sql
copy (select CounterID%$n as partition_key, * from '~/Data/hits.parquet') TO 'hits_partitioned' (FORMAT PARQUET, PARTITION_BY partition_key);
```

As shown the old version generally performs worse with more partitions, and runs `OOM` in **both** the temp directory and the non-temp directory cases for the full data set, whereas the temp directory is not necessary in the current implementation.

| Partitions | Version | 52GB mem limit, no temp dir | 52GB mem limit, temp dir |
|------------|---------|-----------------------------|--------------------------|
| 10         | v0.10.2 | 61.1s                       |                          |
|            | New     | 58.8s                       |                          |
| 100        | v0.10.2 | 65.8s                       |                          |
|            | New     | 57.8s                       |                          |
| 1000       | v0.10.2 | 73.8s                       |                          |
|            | New     | 60.8s                       |                          |
| 2000       | v0.10.2 | 82.5s                       |                          |
|            | New     | 62.9s                       |                          |
| 4000       | v0.10.2 | OOM                         | 116s                     |
|            | New     | 62.8s                       |                          |
| 6506       | v0.10.2 | OOM                         | OOM                      |
|            | New     | 66s                         |                          |
