### PR TITLE
Add scalar function support to the C API

### DIFF
--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -5,6 +5,9 @@ namespace duckdb {
 FunctionLocalState::~FunctionLocalState() {
 }
 
+ScalarFunctionInfo::~ScalarFunctionInfo() {
+}
+
 ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
                                scalar_function_t function, bind_scalar_function_t bind,
                                dependency_function_t dependency, function_statistics_t statistics,

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2222,7 +2222,8 @@ Sets the return type of the scalar function.
 * scalar_function: The scalar function
 * type: The return type to set
 */
-DUCKDB_API void duckdb_scalar_function_set_return_type(duckdb_scalar_function scalar_function, duckdb_logical_type type);
+DUCKDB_API void duckdb_scalar_function_set_return_type(duckdb_scalar_function scalar_function,
+                                                       duckdb_logical_type type);
 
 /*!
 Assigns extra information to the scalar function that can be fetched during binding, etc.
@@ -2232,8 +2233,7 @@ Assigns extra information to the scalar function that can be fetched during bind
 * destroy: The callback that will be called to destroy the bind data (if any)
 */
 DUCKDB_API void duckdb_scalar_function_set_extra_info(duckdb_scalar_function scalar_function, void *extra_info,
-													 duckdb_delete_callback_t destroy);
-
+                                                      duckdb_delete_callback_t destroy);
 
 /*!
 Sets the main function of the table function.
@@ -2242,7 +2242,7 @@ Sets the main function of the table function.
 * function: The function
 */
 DUCKDB_API void duckdb_scalar_function_set_function(duckdb_scalar_function scalar_function,
-												    duckdb_scalar_function_t function);
+                                                    duckdb_scalar_function_t function);
 
 /*!
 Register the scalar function object within the given connection.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -433,13 +433,17 @@ typedef struct _duckdb_value {
 // Function types
 //===--------------------------------------------------------------------===//
 //! Additional function info. When setting this info, it is necessary to pass a destroy-callback function.
-typedef void *duckdb_function_info;
+typedef struct _duckdb_function_info {
+	void *__val;
+} * duckdb_function_info;
 
 //===--------------------------------------------------------------------===//
 // Scalar function types
 //===--------------------------------------------------------------------===//
 //! A scalar function. Must be destroyed with `duckdb_destroy_scalar_function`.
-typedef void *duckdb_scalar_function;
+typedef struct _duckdb_scalar_function {
+	void *__val;
+} * duckdb_scalar_function;
 
 //! The main function of the scalar function.
 typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
@@ -449,13 +453,19 @@ typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_
 //===--------------------------------------------------------------------===//
 
 //! A table function. Must be destroyed with `duckdb_destroy_table_function`.
-typedef void *duckdb_table_function;
+typedef struct _duckdb_table_function {
+	void *__val;
+} * duckdb_table_function;
 
 //! The bind info of the function. When setting this info, it is necessary to pass a destroy-callback function.
-typedef void *duckdb_bind_info;
+typedef struct _duckdb_bind_info {
+	void *__val;
+} * duckdb_bind_info;
 
 //! Additional function init info. When setting this info, it is necessary to pass a destroy-callback function.
-typedef void *duckdb_init_info;
+typedef struct _duckdb_init_info {
+	void *__val;
+} * duckdb_init_info;
 
 //! The bind function of the table function.
 typedef void (*duckdb_table_function_bind_t)(duckdb_bind_info info);
@@ -471,7 +481,9 @@ typedef void (*duckdb_table_function_t)(duckdb_function_info info, duckdb_data_c
 //===--------------------------------------------------------------------===//
 
 //! Additional replacement scan info. When setting this info, it is necessary to pass a destroy-callback function.
-typedef void *duckdb_replacement_scan_info;
+typedef struct _duckdb_replacement_scan_info {
+	void *__val;
+} * duckdb_replacement_scan_info;
 
 //! A replacement scan function that can be added to a database.
 typedef void (*duckdb_replacement_callback_t)(duckdb_replacement_scan_info info, const char *table_name, void *data);

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -430,6 +430,21 @@ typedef struct _duckdb_value {
 } * duckdb_value;
 
 //===--------------------------------------------------------------------===//
+// Function types
+//===--------------------------------------------------------------------===//
+//! Additional function info. When setting this info, it is necessary to pass a destroy-callback function.
+typedef void *duckdb_function_info;
+
+//===--------------------------------------------------------------------===//
+// Scalar function types
+//===--------------------------------------------------------------------===//
+//! A scalar function. Must be destroyed with `duckdb_destroy_scalar_function`.
+typedef void *duckdb_scalar_function;
+
+//! The main function of the scalar function.
+typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
+
+//===--------------------------------------------------------------------===//
 // Table function types
 //===--------------------------------------------------------------------===//
 
@@ -441,9 +456,6 @@ typedef void *duckdb_bind_info;
 
 //! Additional function init info. When setting this info, it is necessary to pass a destroy-callback function.
 typedef void *duckdb_init_info;
-
-//! Additional function info. When setting this info, it is necessary to pass a destroy-callback function.
-typedef void *duckdb_function_info;
 
 //! The bind function of the table function.
 typedef void (*duckdb_table_function_bind_t)(duckdb_bind_info info);
@@ -2169,6 +2181,81 @@ Equivalent to `duckdb_validity_set_row_validity` with valid set to true.
 */
 DUCKDB_API void duckdb_validity_set_row_valid(uint64_t *validity, idx_t row);
 
+//===--------------------------------------------------------------------===//
+// Scalar Functions
+//===--------------------------------------------------------------------===//
+/*!
+Creates a new empty scalar function.
+
+The return value should be destroyed with `duckdb_destroy_scalar_function`.
+
+* returns: The scalar function object.
+*/
+DUCKDB_API duckdb_scalar_function duckdb_create_scalar_function();
+
+/*!
+Destroys the given table function object.
+
+* table_function: The table function to destroy
+*/
+DUCKDB_API void duckdb_destroy_scalar_function(duckdb_scalar_function *scalar_function);
+
+/*!
+Sets the name of the given scalar function.
+
+* table_function: The scalar function
+* name: The name of the scalar function
+*/
+DUCKDB_API void duckdb_scalar_function_set_name(duckdb_scalar_function scalar_function, const char *name);
+
+/*!
+Adds a parameter to the scalar function.
+
+* scalar_function: The scalar function
+* type: The type of the parameter to add.
+*/
+DUCKDB_API void duckdb_scalar_function_add_parameter(duckdb_scalar_function scalar_function, duckdb_logical_type type);
+
+/*!
+Sets the return type of the scalar function.
+
+* scalar_function: The scalar function
+* type: The return type to set
+*/
+DUCKDB_API void duckdb_scalar_function_set_return_type(duckdb_scalar_function scalar_function, duckdb_logical_type type);
+
+/*!
+Assigns extra information to the scalar function that can be fetched during binding, etc.
+
+* scalar_function: The table function
+* extra_info: The extra information
+* destroy: The callback that will be called to destroy the bind data (if any)
+*/
+DUCKDB_API void duckdb_scalar_function_set_extra_info(duckdb_scalar_function scalar_function, void *extra_info,
+													 duckdb_delete_callback_t destroy);
+
+
+/*!
+Sets the main function of the table function.
+
+* table_function: The table function
+* function: The function
+*/
+DUCKDB_API void duckdb_scalar_function_set_function(duckdb_scalar_function scalar_function,
+												    duckdb_scalar_function_t function);
+
+/*!
+Register the scalar function object within the given connection.
+
+The function requires at least a name, a function and a return type.
+
+If the function is incomplete or a function with this name already exists DuckDBError is returned.
+
+* con: The connection to register it in.
+* function: The function pointer
+* returns: Whether or not the registration was successful.
+*/
+DUCKDB_API duckdb_state duckdb_register_scalar_function(duckdb_connection con, duckdb_scalar_function scalar_function);
 //===--------------------------------------------------------------------===//
 // Table Functions
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -34,6 +34,22 @@ struct FunctionLocalState {
 	}
 };
 
+struct ScalarFunctionInfo {
+	DUCKDB_API virtual ~ScalarFunctionInfo();
+
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
+
 class Binder;
 class BoundFunctionExpression;
 class LogicalDependencyList;
@@ -105,6 +121,8 @@ public:
 
 	function_serialize_t serialize;
 	function_deserialize_t deserialize;
+	//! Additional function info, passed to the bind
+	shared_ptr<ScalarFunctionInfo> function_info;
 
 	DUCKDB_API bool operator==(const ScalarFunction &rhs) const;
 	DUCKDB_API bool operator!=(const ScalarFunction &rhs) const;

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -49,7 +49,6 @@ struct ScalarFunctionInfo {
 	}
 };
 
-
 class Binder;
 class BoundFunctionExpression;
 class LogicalDependencyList;

--- a/src/main/capi/CMakeLists.txt
+++ b/src/main/capi/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library_unity(
   prepared-c.cpp
   replacement_scan-c.cpp
   result-c.cpp
+  scalar_function-c.cpp
   stream-c.cpp
   table_function-c.cpp
   threading-c.cpp

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -1,0 +1,141 @@
+#include "duckdb/main/capi/capi_internal.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+struct CScalarFunctionInfo : public ScalarFunctionInfo {
+	~CScalarFunctionInfo() override {
+		if (extra_info && delete_callback) {
+			delete_callback(extra_info);
+		}
+		extra_info = nullptr;
+		delete_callback = nullptr;
+	}
+
+	duckdb_scalar_function_t function = nullptr;
+	void *extra_info = nullptr;
+	duckdb_delete_callback_t delete_callback = nullptr;
+};
+
+struct CScalarFunctionBindData : public FunctionData {
+	CScalarFunctionBindData(CScalarFunctionInfo &info) : info(info) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<CScalarFunctionBindData>(info);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<CScalarFunctionBindData>();
+		return info.extra_info == other.info.extra_info && info.function == other.info.function;
+	}
+
+	CScalarFunctionInfo &info;
+};
+
+unique_ptr<FunctionData> BindCAPIScalarFunction(ClientContext &context, ScalarFunction &bound_function,
+														   vector<unique_ptr<Expression>> &arguments) {
+	auto &info = bound_function.function_info->Cast<CScalarFunctionInfo>();
+	return make_uniq<CScalarFunctionBindData>(info);
+}
+
+void CAPIScalarFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &bind_info = state.expr.Cast<BoundFunctionExpression>().bind_info;
+	auto &c_bind_info = bind_info->Cast<CScalarFunctionBindData>();
+
+	auto all_const = input.AllConstant();
+	input.Flatten();
+	auto c_input = reinterpret_cast<duckdb_data_chunk>(&input);
+	auto c_result = reinterpret_cast<duckdb_vector >(&result);
+	c_bind_info.info.function(c_bind_info.info.extra_info, c_input, c_result);
+	if (all_const) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+} // namespace duckdb
+
+duckdb_scalar_function duckdb_create_scalar_function() {
+	auto function = new duckdb::ScalarFunction("", {}, duckdb::LogicalType::INVALID, duckdb::CAPIScalarFunction, duckdb::BindCAPIScalarFunction);
+	function->function_info = duckdb::make_shared_ptr<duckdb::CScalarFunctionInfo>();
+	return function;
+}
+
+void duckdb_destroy_scalar_function(duckdb_scalar_function *function) {
+	if (function && *function) {
+		auto scalar_function = reinterpret_cast<duckdb::ScalarFunction *>(*function);
+		delete scalar_function;
+		*function = nullptr;
+	}
+}
+
+void duckdb_scalar_function_set_name(duckdb_scalar_function function, const char *name) {
+	if (!function || !name) {
+		return;
+	}
+	auto scalar_function = reinterpret_cast<duckdb::ScalarFunction *>(function);
+	scalar_function->name = name;
+}
+
+void duckdb_scalar_function_add_parameter(duckdb_scalar_function function, duckdb_logical_type type) {
+	if (!function || !type) {
+		return;
+	}
+	auto scalar_function = reinterpret_cast<duckdb::ScalarFunction *>(function);
+	auto logical_type = reinterpret_cast<duckdb::LogicalType *>(type);
+	scalar_function->arguments.push_back(*logical_type);
+}
+
+void duckdb_scalar_function_set_return_type(duckdb_scalar_function function, duckdb_logical_type type) {
+	if (!function || !type) {
+		return;
+	}
+	auto scalar_function = reinterpret_cast<duckdb::ScalarFunction *>(function);
+	auto logical_type = reinterpret_cast<duckdb::LogicalType *>(type);
+	scalar_function->return_type = *logical_type;
+}
+
+void duckdb_scalar_function_set_extra_info(duckdb_scalar_function function, void *extra_info,
+													  duckdb_delete_callback_t destroy) {
+	if (!function || !extra_info) {
+		return;
+	}
+	auto scalar_function = reinterpret_cast<duckdb::ScalarFunction *>(function);
+	auto &info = scalar_function->function_info->Cast<duckdb::CScalarFunctionInfo>();
+	info.extra_info = extra_info;
+	info.delete_callback = destroy;
+}
+
+void duckdb_scalar_function_set_function(duckdb_scalar_function function, duckdb_scalar_function_t execute_func) {
+	if (!function || !execute_func) {
+		return;
+	}
+	auto scalar_function = reinterpret_cast<duckdb::ScalarFunction *>(function);
+	auto &info = scalar_function->function_info->Cast<duckdb::CScalarFunctionInfo>();
+	info.function = execute_func;
+}
+
+
+duckdb_state duckdb_register_scalar_function(duckdb_connection connection, duckdb_scalar_function function) {
+	if (!connection || !function) {
+		return DuckDBError;
+	}
+	auto scalar_function = reinterpret_cast<duckdb::ScalarFunction *>(function);
+	auto &info = scalar_function->function_info->Cast<duckdb::CScalarFunctionInfo>();
+	if (scalar_function->name.empty() || !info.function || scalar_function->return_type.id() == duckdb::LogicalTypeId::INVALID) {
+		return DuckDBError;
+	}
+	auto con = reinterpret_cast<duckdb::Connection *>(connection);
+	con->context->RunFunctionInTransaction([&]() {
+		auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
+		duckdb::CreateScalarFunctionInfo sf_info(*scalar_function);
+
+		// create the function in the catalog
+		catalog.CreateFunction(*con->context, sf_info);
+	});
+	return DuckDBSuccess;
+
+}

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -136,12 +136,16 @@ duckdb_state duckdb_register_scalar_function(duckdb_connection connection, duckd
 		return DuckDBError;
 	}
 	auto con = reinterpret_cast<duckdb::Connection *>(connection);
-	con->context->RunFunctionInTransaction([&]() {
-		auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
-		duckdb::CreateScalarFunctionInfo sf_info(scalar_function);
+	try {
+		con->context->RunFunctionInTransaction([&]() {
+			auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
+			duckdb::CreateScalarFunctionInfo sf_info(scalar_function);
 
-		// create the function in the catalog
-		catalog.CreateFunction(*con->context, sf_info);
-	});
+			// create the function in the catalog
+			catalog.CreateFunction(*con->context, sf_info);
+		});
+	} catch (...) {
+		return DuckDBError;
+	}
 	return DuckDBSuccess;
 }

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -8,7 +8,7 @@
 namespace duckdb {
 
 struct CTableFunctionInfo : public TableFunctionInfo {
-	~CTableFunctionInfo() {
+	~CTableFunctionInfo() override {
 		if (extra_info && delete_callback) {
 			delete_callback(extra_info);
 		}

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -7,6 +7,9 @@
 
 namespace duckdb {
 
+//===--------------------------------------------------------------------===//
+// Structures
+//===--------------------------------------------------------------------===//
 struct CTableFunctionInfo : public TableFunctionInfo {
 	~CTableFunctionInfo() override {
 		if (extra_info && delete_callback) {
@@ -25,9 +28,9 @@ struct CTableFunctionInfo : public TableFunctionInfo {
 };
 
 struct CTableBindData : public TableFunctionData {
-	CTableBindData(CTableFunctionInfo &info) : info(info) {
+	explicit CTableBindData(CTableFunctionInfo &info) : info(info) {
 	}
-	~CTableBindData() {
+	~CTableBindData() override {
 		if (bind_data && delete_callback) {
 			delete_callback(bind_data);
 		}
@@ -110,13 +113,50 @@ struct CTableInternalFunctionInfo {
 	string error;
 };
 
+//===--------------------------------------------------------------------===//
+// Helper Functions
+//===--------------------------------------------------------------------===//
+duckdb::TableFunction &GetCTableFunction(duckdb_table_function function) {
+	return *reinterpret_cast<duckdb::TableFunction *>(function);
+}
+
+duckdb::CTableInternalBindInfo &GetCBindInfo(duckdb_bind_info info) {
+	D_ASSERT(info);
+	return *reinterpret_cast<duckdb::CTableInternalBindInfo *>(info);
+}
+
+duckdb_bind_info ToCBindInfo(duckdb::CTableInternalBindInfo &info) {
+	return reinterpret_cast<duckdb_bind_info>(&info);
+}
+
+duckdb::CTableInternalInitInfo &GetCInitInfo(duckdb_init_info info) {
+	D_ASSERT(info);
+	return *reinterpret_cast<duckdb::CTableInternalInitInfo *>(info);
+}
+
+duckdb_init_info ToCInitInfo(duckdb::CTableInternalInitInfo &info) {
+	return reinterpret_cast<duckdb_init_info>(&info);
+}
+
+duckdb::CTableInternalFunctionInfo &GetCFunctionInfo(duckdb_function_info info) {
+	D_ASSERT(info);
+	return *reinterpret_cast<duckdb::CTableInternalFunctionInfo *>(info);
+}
+
+duckdb_function_info ToCFunctionInfo(duckdb::CTableInternalFunctionInfo &info) {
+	return reinterpret_cast<duckdb_function_info>(&info);
+}
+
+//===--------------------------------------------------------------------===//
+// Table Callbacks
+//===--------------------------------------------------------------------===//
 unique_ptr<FunctionData> CTableFunctionBind(ClientContext &context, TableFunctionBindInput &input,
                                             vector<LogicalType> &return_types, vector<string> &names) {
 	auto &info = input.info->Cast<CTableFunctionInfo>();
 	D_ASSERT(info.bind && info.function && info.init);
 	auto result = make_uniq<CTableBindData>(info);
 	CTableInternalBindInfo bind_info(context, input, return_types, names, *result, info);
-	info.bind(&bind_info);
+	info.bind(ToCBindInfo(bind_info));
 	if (!bind_info.success) {
 		throw BinderException(bind_info.error);
 	}
@@ -129,7 +169,7 @@ unique_ptr<GlobalTableFunctionState> CTableFunctionInit(ClientContext &context, 
 	auto result = make_uniq<CTableGlobalInitData>();
 
 	CTableInternalInitInfo init_info(bind_data, result->init_data, data_p.column_ids, data_p.filters);
-	bind_data.info.init(&init_info);
+	bind_data.info.init(ToCInitInfo(init_info));
 	if (!init_info.success) {
 		throw InvalidInputException(init_info.error);
 	}
@@ -145,7 +185,7 @@ unique_ptr<LocalTableFunctionState> CTableFunctionLocalInit(ExecutionContext &co
 	}
 
 	CTableInternalInitInfo init_info(bind_data, result->init_data, data_p.column_ids, data_p.filters);
-	bind_data.info.local_init(&init_info);
+	bind_data.info.local_init(ToCInitInfo(init_info));
 	if (!init_info.success) {
 		throw InvalidInputException(init_info.error);
 	}
@@ -162,10 +202,10 @@ unique_ptr<NodeStatistics> CTableFunctionCardinality(ClientContext &context, con
 
 void CTableFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<CTableBindData>();
-	auto &global_data = (CTableGlobalInitData &)*data_p.global_state;
-	auto &local_data = (CTableLocalInitData &)*data_p.local_state;
+	auto &global_data = data_p.global_state->Cast<CTableGlobalInitData>();
+	auto &local_data = data_p.local_state->Cast<CTableLocalInitData>();
 	CTableInternalFunctionInfo function_info(bind_data, global_data.init_data, local_data.init_data);
-	bind_data.info.function(&function_info, reinterpret_cast<duckdb_data_chunk>(&output));
+	bind_data.info.function(ToCFunctionInfo(function_info), reinterpret_cast<duckdb_data_chunk>(&output));
 	if (!function_info.success) {
 		throw InvalidInputException(function_info.error);
 	}
@@ -176,17 +216,19 @@ void CTableFunction(ClientContext &context, TableFunctionInput &data_p, DataChun
 //===--------------------------------------------------------------------===//
 // Table Function
 //===--------------------------------------------------------------------===//
+using duckdb::GetCTableFunction;
+
 duckdb_table_function duckdb_create_table_function() {
 	auto function = new duckdb::TableFunction("", {}, duckdb::CTableFunction, duckdb::CTableFunctionBind,
 	                                          duckdb::CTableFunctionInit, duckdb::CTableFunctionLocalInit);
 	function->function_info = duckdb::make_shared_ptr<duckdb::CTableFunctionInfo>();
 	function->cardinality = duckdb::CTableFunctionCardinality;
-	return function;
+	return reinterpret_cast<duckdb_table_function>(function);
 }
 
 void duckdb_destroy_table_function(duckdb_table_function *function) {
 	if (function && *function) {
-		auto tf = (duckdb::TableFunction *)*function;
+		auto tf = reinterpret_cast<duckdb::TableFunction *>(*function);
 		delete tf;
 		*function = nullptr;
 	}
@@ -196,17 +238,17 @@ void duckdb_table_function_set_name(duckdb_table_function function, const char *
 	if (!function || !name) {
 		return;
 	}
-	auto tf = (duckdb::TableFunction *)function;
-	tf->name = name;
+	auto &tf = GetCTableFunction(function);
+	tf.name = name;
 }
 
 void duckdb_table_function_add_parameter(duckdb_table_function function, duckdb_logical_type type) {
 	if (!function || !type) {
 		return;
 	}
-	auto tf = (duckdb::TableFunction *)function;
-	auto logical_type = (duckdb::LogicalType *)type;
-	tf->arguments.push_back(*logical_type);
+	auto &tf = GetCTableFunction(function);
+	auto logical_type = reinterpret_cast<duckdb::LogicalType *>(type);
+	tf.arguments.push_back(*logical_type);
 }
 
 void duckdb_table_function_add_named_parameter(duckdb_table_function function, const char *name,
@@ -214,9 +256,9 @@ void duckdb_table_function_add_named_parameter(duckdb_table_function function, c
 	if (!function || !type) {
 		return;
 	}
-	auto tf = (duckdb::TableFunction *)function;
-	auto logical_type = (duckdb::LogicalType *)type;
-	tf->named_parameters.insert({name, *logical_type});
+	auto &tf = GetCTableFunction(function);
+	auto logical_type = reinterpret_cast<duckdb::LogicalType *>(type);
+	tf.named_parameters.insert({name, *logical_type});
 }
 
 void duckdb_table_function_set_extra_info(duckdb_table_function function, void *extra_info,
@@ -224,69 +266,69 @@ void duckdb_table_function_set_extra_info(duckdb_table_function function, void *
 	if (!function) {
 		return;
 	}
-	auto tf = (duckdb::TableFunction *)function;
-	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
-	info->extra_info = extra_info;
-	info->delete_callback = destroy;
+	auto &tf = GetCTableFunction(function);
+	auto &info = tf.function_info->Cast<duckdb::CTableFunctionInfo>();
+	info.extra_info = extra_info;
+	info.delete_callback = destroy;
 }
 
 void duckdb_table_function_set_bind(duckdb_table_function function, duckdb_table_function_bind_t bind) {
 	if (!function || !bind) {
 		return;
 	}
-	auto tf = (duckdb::TableFunction *)function;
-	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
-	info->bind = bind;
+	auto &tf = GetCTableFunction(function);
+	auto &info = tf.function_info->Cast<duckdb::CTableFunctionInfo>();
+	info.bind = bind;
 }
 
 void duckdb_table_function_set_init(duckdb_table_function function, duckdb_table_function_init_t init) {
 	if (!function || !init) {
 		return;
 	}
-	auto tf = (duckdb::TableFunction *)function;
-	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
-	info->init = init;
+	auto &tf = GetCTableFunction(function);
+	auto &info = tf.function_info->Cast<duckdb::CTableFunctionInfo>();
+	info.init = init;
 }
 
 void duckdb_table_function_set_local_init(duckdb_table_function function, duckdb_table_function_init_t init) {
 	if (!function || !init) {
 		return;
 	}
-	auto tf = (duckdb::TableFunction *)function;
-	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
-	info->local_init = init;
+	auto &tf = GetCTableFunction(function);
+	auto &info = tf.function_info->Cast<duckdb::CTableFunctionInfo>();
+	info.local_init = init;
 }
 
 void duckdb_table_function_set_function(duckdb_table_function table_function, duckdb_table_function_t function) {
 	if (!table_function || !function) {
 		return;
 	}
-	auto tf = (duckdb::TableFunction *)table_function;
-	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
-	info->function = function;
+	auto &tf = GetCTableFunction(table_function);
+	auto &info = tf.function_info->Cast<duckdb::CTableFunctionInfo>();
+	info.function = function;
 }
 
 void duckdb_table_function_supports_projection_pushdown(duckdb_table_function table_function, bool pushdown) {
 	if (!table_function) {
 		return;
 	}
-	auto tf = (duckdb::TableFunction *)table_function;
-	tf->projection_pushdown = pushdown;
+	auto &tf = GetCTableFunction(table_function);
+	tf.projection_pushdown = pushdown;
 }
 
 duckdb_state duckdb_register_table_function(duckdb_connection connection, duckdb_table_function function) {
 	if (!connection || !function) {
 		return DuckDBError;
 	}
-	auto con = (duckdb::Connection *)connection;
-	auto tf = (duckdb::TableFunction *)function;
-	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
-	if (tf->name.empty() || !info->bind || !info->init || !info->function) {
+	auto con = reinterpret_cast<duckdb::Connection *>(connection);
+	auto &tf = GetCTableFunction(function);
+	auto &info = tf.function_info->Cast<duckdb::CTableFunctionInfo>();
+	if (tf.name.empty() || !info.bind || !info.init || !info.function) {
 		return DuckDBError;
 	}
 	con->context->RunFunctionInTransaction([&]() {
 		auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
-		duckdb::CreateTableFunctionInfo tf_info(*tf);
+		duckdb::CreateTableFunctionInfo tf_info(tf);
 
 		// create the function in the catalog
 		catalog.CreateTableFunction(*con->context, tf_info);
@@ -297,46 +339,48 @@ duckdb_state duckdb_register_table_function(duckdb_connection connection, duckdb
 //===--------------------------------------------------------------------===//
 // Bind Interface
 //===--------------------------------------------------------------------===//
+using duckdb::GetCBindInfo;
+
 void *duckdb_bind_get_extra_info(duckdb_bind_info info) {
 	if (!info) {
 		return nullptr;
 	}
-	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
-	return bind_info->function_info.extra_info;
+	auto &bind_info = GetCBindInfo(info);
+	return bind_info.function_info.extra_info;
 }
 
 void duckdb_bind_add_result_column(duckdb_bind_info info, const char *name, duckdb_logical_type type) {
 	if (!info || !name || !type) {
 		return;
 	}
-	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
-	bind_info->names.push_back(name);
-	bind_info->return_types.push_back(*(reinterpret_cast<duckdb::LogicalType *>(type)));
+	auto &bind_info = GetCBindInfo(info);
+	bind_info.names.push_back(name);
+	bind_info.return_types.push_back(*(reinterpret_cast<duckdb::LogicalType *>(type)));
 }
 
 idx_t duckdb_bind_get_parameter_count(duckdb_bind_info info) {
 	if (!info) {
 		return 0;
 	}
-	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
-	return bind_info->input.inputs.size();
+	auto &bind_info = GetCBindInfo(info);
+	return bind_info.input.inputs.size();
 }
 
 duckdb_value duckdb_bind_get_parameter(duckdb_bind_info info, idx_t index) {
 	if (!info || index >= duckdb_bind_get_parameter_count(info)) {
 		return nullptr;
 	}
-	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
-	return reinterpret_cast<duckdb_value>(new duckdb::Value(bind_info->input.inputs[index]));
+	auto &bind_info = GetCBindInfo(info);
+	return reinterpret_cast<duckdb_value>(new duckdb::Value(bind_info.input.inputs[index]));
 }
 
 duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *name) {
 	if (!info || !name) {
 		return nullptr;
 	}
-	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
-	auto t = bind_info->input.named_parameters.find(name);
-	if (t == bind_info->input.named_parameters.end()) {
+	auto &bind_info = GetCBindInfo(info);
+	auto t = bind_info.input.named_parameters.find(name);
+	if (t == bind_info.input.named_parameters.end()) {
 		return nullptr;
 	} else {
 		return reinterpret_cast<duckdb_value>(new duckdb::Value(t->second));
@@ -347,20 +391,20 @@ void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_de
 	if (!info) {
 		return;
 	}
-	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
-	bind_info->bind_data.bind_data = bind_data;
-	bind_info->bind_data.delete_callback = destroy;
+	auto &bind_info = GetCBindInfo(info);
+	bind_info.bind_data.bind_data = bind_data;
+	bind_info.bind_data.delete_callback = destroy;
 }
 
 void duckdb_bind_set_cardinality(duckdb_bind_info info, idx_t cardinality, bool is_exact) {
 	if (!info) {
 		return;
 	}
-	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
+	auto &bind_info = GetCBindInfo(info);
 	if (is_exact) {
-		bind_info->bind_data.stats = duckdb::make_uniq<duckdb::NodeStatistics>(cardinality);
+		bind_info.bind_data.stats = duckdb::make_uniq<duckdb::NodeStatistics>(cardinality);
 	} else {
-		bind_info->bind_data.stats = duckdb::make_uniq<duckdb::NodeStatistics>(cardinality, cardinality);
+		bind_info.bind_data.stats = duckdb::make_uniq<duckdb::NodeStatistics>(cardinality, cardinality);
 	}
 }
 
@@ -368,19 +412,21 @@ void duckdb_bind_set_error(duckdb_bind_info info, const char *error) {
 	if (!info || !error) {
 		return;
 	}
-	auto function_info = (duckdb::CTableInternalBindInfo *)info;
-	function_info->error = error;
-	function_info->success = false;
+	auto &bind_info = GetCBindInfo(info);
+	bind_info.error = error;
+	bind_info.success = false;
 }
 
 //===--------------------------------------------------------------------===//
 // Init Interface
 //===--------------------------------------------------------------------===//
+using duckdb::GetCInitInfo;
+
 void *duckdb_init_get_extra_info(duckdb_init_info info) {
 	if (!info) {
 		return nullptr;
 	}
-	auto init_info = (duckdb::CTableInternalInitInfo *)info;
+	auto init_info = reinterpret_cast<duckdb::CTableInternalInitInfo *>(info);
 	return init_info->bind_data.info.extra_info;
 }
 
@@ -388,95 +434,97 @@ void *duckdb_init_get_bind_data(duckdb_init_info info) {
 	if (!info) {
 		return nullptr;
 	}
-	auto init_info = (duckdb::CTableInternalInitInfo *)info;
-	return init_info->bind_data.bind_data;
+	auto &init_info = GetCInitInfo(info);
+	return init_info.bind_data.bind_data;
 }
 
 void duckdb_init_set_init_data(duckdb_init_info info, void *init_data, duckdb_delete_callback_t destroy) {
 	if (!info) {
 		return;
 	}
-	auto init_info = (duckdb::CTableInternalInitInfo *)info;
-	init_info->init_data.init_data = init_data;
-	init_info->init_data.delete_callback = destroy;
+	auto &init_info = GetCInitInfo(info);
+	init_info.init_data.init_data = init_data;
+	init_info.init_data.delete_callback = destroy;
 }
 
 void duckdb_init_set_error(duckdb_init_info info, const char *error) {
 	if (!info || !error) {
 		return;
 	}
-	auto function_info = (duckdb::CTableInternalInitInfo *)info;
-	function_info->error = error;
-	function_info->success = false;
+	auto &init_info = GetCInitInfo(info);
+	init_info.error = error;
+	init_info.success = false;
 }
 
 idx_t duckdb_init_get_column_count(duckdb_init_info info) {
 	if (!info) {
 		return 0;
 	}
-	auto function_info = (duckdb::CTableInternalInitInfo *)info;
-	return function_info->column_ids.size();
+	auto &init_info = GetCInitInfo(info);
+	return init_info.column_ids.size();
 }
 
 idx_t duckdb_init_get_column_index(duckdb_init_info info, idx_t column_index) {
 	if (!info) {
 		return 0;
 	}
-	auto function_info = (duckdb::CTableInternalInitInfo *)info;
-	if (column_index >= function_info->column_ids.size()) {
+	auto &init_info = GetCInitInfo(info);
+	if (column_index >= init_info.column_ids.size()) {
 		return 0;
 	}
-	return function_info->column_ids[column_index];
+	return init_info.column_ids[column_index];
 }
 
 void duckdb_init_set_max_threads(duckdb_init_info info, idx_t max_threads) {
 	if (!info) {
 		return;
 	}
-	auto function_info = (duckdb::CTableInternalInitInfo *)info;
-	function_info->init_data.max_threads = max_threads;
+	auto &init_info = GetCInitInfo(info);
+	init_info.init_data.max_threads = max_threads;
 }
 
 //===--------------------------------------------------------------------===//
 // Function Interface
 //===--------------------------------------------------------------------===//
+using duckdb::GetCFunctionInfo;
+
 void *duckdb_function_get_extra_info(duckdb_function_info info) {
 	if (!info) {
 		return nullptr;
 	}
-	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
-	return function_info->bind_data.info.extra_info;
+	auto &function_info = GetCFunctionInfo(info);
+	return function_info.bind_data.info.extra_info;
 }
 
 void *duckdb_function_get_bind_data(duckdb_function_info info) {
 	if (!info) {
 		return nullptr;
 	}
-	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
-	return function_info->bind_data.bind_data;
+	auto &function_info = GetCFunctionInfo(info);
+	return function_info.bind_data.bind_data;
 }
 
 void *duckdb_function_get_init_data(duckdb_function_info info) {
 	if (!info) {
 		return nullptr;
 	}
-	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
-	return function_info->init_data.init_data;
+	auto &function_info = GetCFunctionInfo(info);
+	return function_info.init_data.init_data;
 }
 
 void *duckdb_function_get_local_init_data(duckdb_function_info info) {
 	if (!info) {
 		return nullptr;
 	}
-	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
-	return function_info->local_data.init_data;
+	auto &function_info = GetCFunctionInfo(info);
+	return function_info.local_data.init_data;
 }
 
 void duckdb_function_set_error(duckdb_function_info info, const char *error) {
 	if (!info || !error) {
 		return;
 	}
-	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
-	function_info->error = error;
-	function_info->success = false;
+	auto &function_info = GetCFunctionInfo(info);
+	function_info.error = error;
+	function_info.success = false;
 }

--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -326,13 +326,17 @@ duckdb_state duckdb_register_table_function(duckdb_connection connection, duckdb
 	if (tf.name.empty() || !info.bind || !info.init || !info.function) {
 		return DuckDBError;
 	}
-	con->context->RunFunctionInTransaction([&]() {
-		auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
-		duckdb::CreateTableFunctionInfo tf_info(tf);
+	try {
+		con->context->RunFunctionInTransaction([&]() {
+			auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
+			duckdb::CreateTableFunctionInfo tf_info(tf);
 
-		// create the function in the catalog
-		catalog.CreateTableFunction(*con->context, tf_info);
-	});
+			// create the function in the catalog
+			catalog.CreateTableFunction(*con->context, tf_info);
+		});
+	} catch (...) {
+		return DuckDBError;
+	}
 	return DuckDBSuccess;
 }
 

--- a/test/api/capi/CMakeLists.txt
+++ b/test/api/capi/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library_unity(
   test_sql_capi
   OBJECT
+  capi_scalar_functions.cpp
   capi_table_functions.cpp
   test_capi.cpp
   test_starting_database.cpp

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -37,7 +37,7 @@ void AddNumbersTogether(duckdb_function_info info, duckdb_data_chunk input, duck
 	}
 }
 
-static void capi_register_scalar_function(duckdb_connection connection, const char *name) {
+static void CAPIRegisterAddition(duckdb_connection connection, const char *name) {
 	duckdb_state status;
 
 	// create a scalar function
@@ -79,7 +79,7 @@ TEST_CASE("Test Scalar Functions C API", "[capi]") {
 	duckdb::unique_ptr<CAPIResult> result;
 
 	REQUIRE(tester.OpenDatabase(nullptr));
-	capi_register_scalar_function(tester.connection, "my_addition");
+	CAPIRegisterAddition(tester.connection, "my_addition");
 
 	// now call it
 	result = tester.Query("SELECT my_addition(40, 2)");
@@ -100,4 +100,82 @@ TEST_CASE("Test Scalar Functions C API", "[capi]") {
 	for(idx_t row = 0; row < 10000; row++) {
 		REQUIRE(result->Fetch<int64_t>(0, row) == static_cast<int64_t>(1000000 + row));
 	}
+}
+
+void ReturnStringInfo(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
+	auto extra_info = string((const char *) info);
+	// get the total number of rows in this chunk
+	idx_t input_size = duckdb_data_chunk_get_size(input);
+	// extract the two input vectors
+	duckdb_vector input_vector = duckdb_data_chunk_get_vector(input, 0);
+	// get the data pointers for the input vectors (both int64 as specified by the parameter types)
+	auto input_data = (duckdb_string_t *) duckdb_vector_get_data(input_vector);
+	// get the validity vectors
+	auto input_validity = duckdb_vector_get_validity(input_vector);
+	duckdb_vector_ensure_validity_writable(output);
+	auto result_validity = duckdb_vector_get_validity(output);
+	for(idx_t row = 0; row < input_size; row++) {
+		if (duckdb_validity_row_is_valid(input_validity, row)) {
+			// not null - do the operation
+			auto input_string = input_data[row];
+			string result = extra_info + "_";
+			if (duckdb_string_is_inlined(input_string)) {
+				result += string(input_string.value.inlined.inlined, input_string.value.inlined.length);
+			} else {
+				result += input_string.value.pointer.ptr;
+			}
+			duckdb_vector_assign_string_element_len(output, row, result.c_str(), result.size());
+		} else {
+			// either a or b is NULL - set the result row to NULL
+			duckdb_validity_set_row_invalid(result_validity, row);
+		}
+	}
+}
+
+static void CAPIRegisterStringInfo(duckdb_connection connection, const char *name, duckdb_function_info info, duckdb_delete_callback_t destroy_func) {
+	duckdb_state status;
+
+	// create a scalar function
+	auto function = duckdb_create_scalar_function();
+	duckdb_scalar_function_set_name(function, name);
+
+	// add a single varchar parameter
+	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+	duckdb_table_function_add_parameter(function, type);
+
+	// set the return type to varchar
+	duckdb_scalar_function_set_return_type(function, type);
+	duckdb_destroy_logical_type(&type);
+
+	// set up the function
+	duckdb_scalar_function_set_function(function, ReturnStringInfo);
+
+	// set the extra info
+	duckdb_scalar_function_set_extra_info(function, info, destroy_func);
+
+	// register and cleanup
+	status = duckdb_register_scalar_function(connection, function);
+	REQUIRE(status == DuckDBSuccess);
+
+	duckdb_destroy_scalar_function(&function);
+}
+
+TEST_CASE("Test Scalar Functions - strings & extra_info", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	auto string_data = (char *) malloc(100);
+	strcpy(string_data, "my_prefix");
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	CAPIRegisterStringInfo(tester.connection, "my_prefix", (duckdb_function_info) string_data, free);
+
+	// now call it
+	result = tester.Query("SELECT my_prefix('hello_world')");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<string>(0, 0) == "my_prefix_hello_world");
+
+	result = tester.Query("SELECT my_prefix(NULL)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->IsNull(0, 0));
 }

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -37,7 +37,7 @@ void AddNumbersTogether(duckdb_function_info info, duckdb_data_chunk input, duck
 	}
 }
 
-static void CAPIRegisterAddition(duckdb_connection connection, const char *name) {
+static void CAPIRegisterAddition(duckdb_connection connection, const char *name, duckdb_state expected_outcome) {
 	duckdb_state status;
 
 	// create a scalar function
@@ -67,7 +67,7 @@ static void CAPIRegisterAddition(duckdb_connection connection, const char *name)
 
 	// register and cleanup
 	status = duckdb_register_scalar_function(connection, function);
-	REQUIRE(status == DuckDBSuccess);
+	REQUIRE(status == expected_outcome);
 
 	duckdb_destroy_scalar_function(&function);
 	duckdb_destroy_scalar_function(&function);
@@ -79,7 +79,9 @@ TEST_CASE("Test Scalar Functions C API", "[capi]") {
 	duckdb::unique_ptr<CAPIResult> result;
 
 	REQUIRE(tester.OpenDatabase(nullptr));
-	CAPIRegisterAddition(tester.connection, "my_addition");
+	CAPIRegisterAddition(tester.connection, "my_addition", DuckDBSuccess);
+	// try to register it again - this should be an error
+	CAPIRegisterAddition(tester.connection, "my_addition", DuckDBError);
 
 	// now call it
 	result = tester.Query("SELECT my_addition(40, 2)");

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -10,9 +10,9 @@ void AddNumbersTogether(duckdb_function_info info, duckdb_data_chunk input, duck
 	duckdb_vector a = duckdb_data_chunk_get_vector(input, 0);
 	duckdb_vector b = duckdb_data_chunk_get_vector(input, 1);
 	// get the data pointers for the input vectors (both int64 as specified by the parameter types)
-	auto a_data = (int64_t *) duckdb_vector_get_data(a);
-	auto b_data = (int64_t *) duckdb_vector_get_data(b);
-	auto result_data = (int64_t *) duckdb_vector_get_data(output);
+	auto a_data = (int64_t *)duckdb_vector_get_data(a);
+	auto b_data = (int64_t *)duckdb_vector_get_data(b);
+	auto result_data = (int64_t *)duckdb_vector_get_data(output);
 	// get the validity vectors
 	auto a_validity = duckdb_vector_get_validity(a);
 	auto b_validity = duckdb_vector_get_validity(b);
@@ -20,7 +20,7 @@ void AddNumbersTogether(duckdb_function_info info, duckdb_data_chunk input, duck
 		// if either a_validity or b_validity is defined there might be NULL values
 		duckdb_vector_ensure_validity_writable(output);
 		auto result_validity = duckdb_vector_get_validity(output);
-		for(idx_t row = 0; row < input_size; row++) {
+		for (idx_t row = 0; row < input_size; row++) {
 			if (duckdb_validity_row_is_valid(a_validity, row) && duckdb_validity_row_is_valid(b_validity, row)) {
 				// not null - do the addition
 				result_data[row] = a_data[row] + b_data[row];
@@ -31,7 +31,7 @@ void AddNumbersTogether(duckdb_function_info info, duckdb_data_chunk input, duck
 		}
 	} else {
 		// no NULL values - iterate and do the operation directly
-		for(idx_t row = 0; row < input_size; row++) {
+		for (idx_t row = 0; row < input_size; row++) {
 			result_data[row] = a_data[row] + b_data[row];
 		}
 	}
@@ -97,24 +97,24 @@ TEST_CASE("Test Scalar Functions C API", "[capi]") {
 	// call it over a vector of values
 	result = tester.Query("SELECT my_addition(1000000, i) FROM range(10000) t(i)");
 	REQUIRE_NO_FAIL(*result);
-	for(idx_t row = 0; row < 10000; row++) {
+	for (idx_t row = 0; row < 10000; row++) {
 		REQUIRE(result->Fetch<int64_t>(0, row) == static_cast<int64_t>(1000000 + row));
 	}
 }
 
 void ReturnStringInfo(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
-	auto extra_info = string((const char *) info);
+	auto extra_info = string((const char *)info);
 	// get the total number of rows in this chunk
 	idx_t input_size = duckdb_data_chunk_get_size(input);
 	// extract the two input vectors
 	duckdb_vector input_vector = duckdb_data_chunk_get_vector(input, 0);
 	// get the data pointers for the input vectors (both int64 as specified by the parameter types)
-	auto input_data = (duckdb_string_t *) duckdb_vector_get_data(input_vector);
+	auto input_data = (duckdb_string_t *)duckdb_vector_get_data(input_vector);
 	// get the validity vectors
 	auto input_validity = duckdb_vector_get_validity(input_vector);
 	duckdb_vector_ensure_validity_writable(output);
 	auto result_validity = duckdb_vector_get_validity(output);
-	for(idx_t row = 0; row < input_size; row++) {
+	for (idx_t row = 0; row < input_size; row++) {
 		if (duckdb_validity_row_is_valid(input_validity, row)) {
 			// not null - do the operation
 			auto input_string = input_data[row];
@@ -132,7 +132,8 @@ void ReturnStringInfo(duckdb_function_info info, duckdb_data_chunk input, duckdb
 	}
 }
 
-static void CAPIRegisterStringInfo(duckdb_connection connection, const char *name, duckdb_function_info info, duckdb_delete_callback_t destroy_func) {
+static void CAPIRegisterStringInfo(duckdb_connection connection, const char *name, duckdb_function_info info,
+                                   duckdb_delete_callback_t destroy_func) {
 	duckdb_state status;
 
 	// create a scalar function
@@ -164,11 +165,11 @@ TEST_CASE("Test Scalar Functions - strings & extra_info", "[capi]") {
 	CAPITester tester;
 	duckdb::unique_ptr<CAPIResult> result;
 
-	auto string_data = (char *) malloc(100);
+	auto string_data = (char *)malloc(100);
 	strcpy(string_data, "my_prefix");
 
 	REQUIRE(tester.OpenDatabase(nullptr));
-	CAPIRegisterStringInfo(tester.connection, "my_prefix", (duckdb_function_info) string_data, free);
+	CAPIRegisterStringInfo(tester.connection, "my_prefix", (duckdb_function_info)string_data, free);
 
 	// now call it
 	result = tester.Query("SELECT my_prefix('hello_world')");

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -49,10 +49,10 @@ static void CAPIRegisterAddition(duckdb_connection connection, const char *name)
 
 	// add a two bigint parameters
 	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
-	duckdb_table_function_add_parameter(nullptr, type);
-	duckdb_table_function_add_parameter(function, nullptr);
-	duckdb_table_function_add_parameter(function, type);
-	duckdb_table_function_add_parameter(function, type);
+	duckdb_scalar_function_add_parameter(nullptr, type);
+	duckdb_scalar_function_add_parameter(function, nullptr);
+	duckdb_scalar_function_add_parameter(function, type);
+	duckdb_scalar_function_add_parameter(function, type);
 
 	// set the return type to bigint
 	duckdb_scalar_function_set_return_type(nullptr, type);
@@ -142,7 +142,7 @@ static void CAPIRegisterStringInfo(duckdb_connection connection, const char *nam
 
 	// add a single varchar parameter
 	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
-	duckdb_table_function_add_parameter(function, type);
+	duckdb_scalar_function_add_parameter(function, type);
 
 	// set the return type to varchar
 	duckdb_scalar_function_set_return_type(function, type);

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -1,0 +1,99 @@
+#include "capi_tester.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+void AddNumbersTogether(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
+	// get the total number of rows in this chunk
+	idx_t input_size = duckdb_data_chunk_get_size(input);
+	// extract the two input vectors
+	duckdb_vector a = duckdb_data_chunk_get_vector(input, 0);
+	duckdb_vector b = duckdb_data_chunk_get_vector(input, 1);
+	// get the data pointers for the input vectors (both int64 as specified by the parameter types)
+	auto a_data = (int64_t *) duckdb_vector_get_data(a);
+	auto b_data = (int64_t *) duckdb_vector_get_data(b);
+	auto result_data = (int64_t *) duckdb_vector_get_data(output);
+	// get the validity vectors
+	auto a_validity = duckdb_vector_get_validity(a);
+	auto b_validity = duckdb_vector_get_validity(b);
+	uint64_t *result_validity = nullptr;
+	if (a_validity || b_validity) {
+		// if either a_validity or b_validity is defined there might be NULL values
+		duckdb_vector_ensure_validity_writable(output);
+		result_validity = duckdb_vector_get_validity(output);
+	}
+	for(idx_t row = 0; row < input_size; row++) {
+		if (duckdb_validity_row_is_valid(a_validity, row) && duckdb_validity_row_is_valid(b_validity, row)) {
+			// not null - do the addition
+			result_data[row] = a_data[row] + b_data[row];
+		} else {
+			// either a or b is NULL - set the result row to NULL
+			duckdb_validity_set_row_invalid(result_validity, row);
+		}
+	}
+}
+
+static void capi_register_scalar_function(duckdb_connection connection, const char *name) {
+	duckdb_state status;
+
+	// create a scalar function
+	auto function = duckdb_create_scalar_function();
+	duckdb_scalar_function_set_name(nullptr, name);
+	duckdb_scalar_function_set_name(function, nullptr);
+	duckdb_scalar_function_set_name(function, name);
+	duckdb_scalar_function_set_name(function, name);
+
+	// add a two bigint parameters
+	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+	duckdb_table_function_add_parameter(nullptr, type);
+	duckdb_table_function_add_parameter(function, nullptr);
+	duckdb_table_function_add_parameter(function, type);
+	duckdb_table_function_add_parameter(function, type);
+
+	// set the return type to bigint
+	duckdb_scalar_function_set_return_type(nullptr, type);
+	duckdb_scalar_function_set_return_type(function, nullptr);
+	duckdb_scalar_function_set_return_type(function, type);
+	duckdb_destroy_logical_type(&type);
+
+	// set up the function
+	duckdb_scalar_function_set_function(nullptr, AddNumbersTogether);
+	duckdb_scalar_function_set_function(function, nullptr);
+	duckdb_scalar_function_set_function(function, AddNumbersTogether);
+
+	// register and cleanup
+	status = duckdb_register_scalar_function(connection, function);
+	REQUIRE(status == DuckDBSuccess);
+
+	duckdb_destroy_scalar_function(&function);
+	duckdb_destroy_scalar_function(&function);
+	duckdb_destroy_scalar_function(nullptr);
+}
+
+TEST_CASE("Test Scalar Functions C API", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	capi_register_scalar_function(tester.connection, "my_addition");
+
+	// now call it
+	result = tester.Query("SELECT my_addition(40, 2)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 42);
+
+	result = tester.Query("SELECT my_addition(40, NULL)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->IsNull(0, 0));
+
+	result = tester.Query("SELECT my_addition(NULL, 2)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->IsNull(0, 0));
+
+	// call it over a vector of values
+	result = tester.Query("SELECT my_addition(1000000, i) FROm range(10000) t(i)");
+	REQUIRE_NO_FAIL(*result);
+	for(idx_t row = 0; row < 10000; row++) {
+		REQUIRE(result->Fetch<int64_t>(0, row) == 1000000 + row);
+	}
+}

--- a/test/api/capi/capi_table_functions.cpp
+++ b/test/api/capi/capi_table_functions.cpp
@@ -52,7 +52,7 @@ void my_function(duckdb_function_info info, duckdb_data_chunk output) {
 
 static void capi_register_table_function(duckdb_connection connection, const char *name,
                                          duckdb_table_function_bind_t bind, duckdb_table_function_init_t init,
-                                         duckdb_table_function_t f) {
+                                         duckdb_table_function_t f, duckdb_state expected_state = DuckDBSuccess) {
 	duckdb_state status;
 
 	// create a table function
@@ -79,7 +79,7 @@ static void capi_register_table_function(duckdb_connection connection, const cha
 
 	// register and cleanup
 	status = duckdb_register_table_function(connection, function);
-	REQUIRE(status == DuckDBSuccess);
+	REQUIRE(status == expected_state);
 
 	duckdb_destroy_table_function(&function);
 	duckdb_destroy_table_function(&function);
@@ -92,6 +92,8 @@ TEST_CASE("Test Table Functions C API", "[capi]") {
 
 	REQUIRE(tester.OpenDatabase(nullptr));
 	capi_register_table_function(tester.connection, "my_function", my_bind, my_init, my_function);
+	// registering again causes an error
+	capi_register_table_function(tester.connection, "my_function", my_bind, my_init, my_function, DuckDBError);
 
 	// now call it
 	result = tester.Query("SELECT * FROM my_function(1)");


### PR DESCRIPTION
This PR adds initial support for scalar functions to the C API. This allows simple scalar functions to be defined and registered using only the C API, which in turn will enable these functions to be added using other APIs that build on top of the C API (e.g. Rust or Go).

The main function signature is as follows:

```cpp
typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
```

These are the added callbacks that allow for creating and registering a function:

```cpp
duckdb_scalar_function duckdb_create_scalar_function();
void duckdb_destroy_scalar_function(duckdb_scalar_function *scalar_function);
void duckdb_scalar_function_set_name(duckdb_scalar_function scalar_function, const char *name);
void duckdb_scalar_function_add_parameter(duckdb_scalar_function scalar_function, duckdb_logical_type type);
void duckdb_scalar_function_set_return_type(duckdb_scalar_function scalar_function, duckdb_logical_type type);
void duckdb_scalar_function_set_extra_info(duckdb_scalar_function scalar_function, void *extra_info,
													 duckdb_delete_callback_t destroy);
void duckdb_scalar_function_set_function(duckdb_scalar_function scalar_function,
												    duckdb_scalar_function_t function);
duckdb_state duckdb_register_scalar_function(duckdb_connection con, duckdb_scalar_function scalar_function);
```

Here is an example program that registers a custom addition function

```cpp

void MyAddition(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
	// get the total number of rows in this chunk
	idx_t input_size = duckdb_data_chunk_get_size(input);
	// extract the two input vectors
	duckdb_vector a = duckdb_data_chunk_get_vector(input, 0);
	duckdb_vector b = duckdb_data_chunk_get_vector(input, 1);
	// get the data pointers for the input vectors (both int64 as specified by the parameter types)
	auto a_data = (int64_t *) duckdb_vector_get_data(a);
	auto b_data = (int64_t *) duckdb_vector_get_data(b);
	auto result_data = (int64_t *) duckdb_vector_get_data(output);
	// get the validity vectors
	auto a_validity = duckdb_vector_get_validity(a);
	auto b_validity = duckdb_vector_get_validity(b);
	// if either a_validity or b_validity is defined there might be NULL values
	duckdb_vector_ensure_validity_writable(output);
	auto result_validity = duckdb_vector_get_validity(output);
	for(idx_t row = 0; row < input_size; row++) {
		if (duckdb_validity_row_is_valid(a_validity, row) && duckdb_validity_row_is_valid(b_validity, row)) {
			// not null - do the addition
			result_data[row] = a_data[row] + b_data[row];
		} else {
			// either a or b is NULL - set the result row to NULL
			duckdb_validity_set_row_invalid(result_validity, row);
		}
	}
}

static void CAPIRegisterAddition(duckdb_connection connection) {
	duckdb_state status;

	// create a scalar function
	auto function = duckdb_create_scalar_function();
	duckdb_scalar_function_set_name(function, "my_addition");

	// add a two bigint parameters
	duckdb_logical_type type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
	duckdb_table_function_add_parameter(function, type);
	duckdb_table_function_add_parameter(function, type);

	// set the return type to bigint
	duckdb_scalar_function_set_return_type(function, type);
	duckdb_destroy_logical_type(&type);

	// set up the function
	duckdb_scalar_function_set_function(function, MyAddition);

	// register and cleanup
        duckdb_register_scalar_function(connection, function);

	duckdb_destroy_scalar_function(&function);
}

```

##### Performance

As this uses the efficient DataChunk and Vector API, the performance is identical scalar functions defined in C++. Running `my_addition` versus our regular addition (with some added optimization for no NULL values - see the included test file) results in the same performance. e.g. running the function over 100M values:

```cpp
CREATE TABLE big_table AS SELECT (random() * 100)::BIGINT i FROM range(100000000) t(i);
SELECT MIN(my_addition(i, i)) FROM big_table;
-- 22ms
SELECT MIN(i + i) FROM big_table;
-- 21ms

```
