### PR TITLE
Hive partitioning: make OVERWRITE_OR_IGNORE remove files on local file systems

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -210,9 +210,6 @@ unique_ptr<GlobalFunctionData> PhysicalCopyToFile::CreateFileState(ClientContext
 	idx_t this_file_offset = g.last_file_offset++;
 	auto &fs = FileSystem::GetFileSystem(context);
 	string output_path(filename_pattern.CreateFilename(fs, file_path, file_extension, this_file_offset));
-	if (fs.FileExists(output_path)) {
-		throw InternalException("%s exists!");
-	}
 	return function.copy_to_initialize_global(context, *bind_data, output_path);
 }
 

--- a/test/sql/copy/format_uuid.test
+++ b/test/sql/copy/format_uuid.test
@@ -61,7 +61,6 @@ SELECT * FROM '__TEST_DIR__/part/a=9/leading_????????-????-4???-????-???????????
 query III sort
 SELECT * FROM '__TEST_DIR__/part/a=9/leading_????????-????-4???-????-????????????*.parquet';
 ----
-9	18	81
 9	27	729
 
 # Test without a specified format name for the outputfile.
@@ -78,8 +77,6 @@ SELECT * FROM '__TEST_DIR__/part/a=9/data_[0-9]*.parquet';
 query III sort
 SELECT * FROM '__TEST_DIR__/part/a=9/*.parquet';
 ----
-9	18	81
-9	27	729
 9	36	6561
 
 # Test where the FILENAME_PATTERN does not contain "{i}" or "{uuid}". 
@@ -96,9 +93,6 @@ SELECT * FROM '__TEST_DIR__/part/a=9/basename[0-9]*.parquet';
 query III sort
 SELECT * FROM '__TEST_DIR__/part/a=9/*.parquet';
 ----
-9	18	81
-9	27	729
-9	36	6561
 9	45	59049
 
 # Test without the overwrite_or_ignore param, that tries to add a file to an existing directory

--- a/test/sql/copy/parquet/parquet_hive_null.test
+++ b/test/sql/copy/parquet/parquet_hive_null.test
@@ -8,10 +8,7 @@ statement ok
 create table test as select i%5 as a, i%2 as b from range(0,10) tbl(i);
 
 statement ok
-copy test to '__TEST_DIR__/null-parquet' (FORMAT 'parquet', PARTITION_BY (a,b));
-
-statement ok
-copy (select 'NULL' as a, 'NULL' as b) to '__TEST_DIR__/null-parquet' (PARTITION_BY (a,b), OVERWRITE_OR_IGNORE, FORMAT 'parquet');
+copy (FROM test UNION ALL select 'NULL' as a, 'NULL' as b) to '__TEST_DIR__/null-parquet' (PARTITION_BY (a,b), FORMAT 'parquet');
 
 query II
 select * 

--- a/test/sql/copy/partitioned/hive_partitioning_overwrite.test
+++ b/test/sql/copy/partitioned/hive_partitioning_overwrite.test
@@ -31,9 +31,7 @@ COPY (SELECT 42 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET);
 statement error
 COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET, PARTITION_BY (part_col));
 ----
-path exists but is not a directory
 
 statement error
 COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE_OR_IGNORE 1);
 ----
-path exists but is not a directory

--- a/test/sql/copy/partitioned/hive_partitioning_overwrite.test
+++ b/test/sql/copy/partitioned/hive_partitioning_overwrite.test
@@ -31,7 +31,12 @@ COPY (SELECT 42 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET);
 statement error
 COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET, PARTITION_BY (part_col));
 ----
+it exists and is a file
 
-statement error
+statement ok
 COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE_OR_IGNORE 1);
+
+query I
+SELECT * FROM '__TEST_DIR__/overwrite_test2/**/*.parquet'
 ----
+84

--- a/test/sql/copy/partitioned/hive_partitioning_overwrite.test
+++ b/test/sql/copy/partitioned/hive_partitioning_overwrite.test
@@ -1,0 +1,39 @@
+# name: test/sql/copy/partitioned/hive_partitioning_overwrite.test
+# description: Test OVERWRITE option
+# group: [partitioned]
+
+require parquet
+
+# write a partition with value 42
+statement ok
+COPY (SELECT 42 AS part_col) TO '__TEST_DIR__/overwrite_test' (FORMAT PARQUET, PARTITION_BY (part_col));
+
+# writing to the same directory fails now
+statement error
+COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test' (FORMAT PARQUET, PARTITION_BY (part_col));
+----
+Enable OVERWRITE_OR_IGNORE option to force writing
+
+# test the overwrite setting
+statement ok
+COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE_OR_IGNORE 1);
+
+# the old file (with part_col=42) should now be removed
+query I
+SELECT * FROM '__TEST_DIR__/overwrite_test/**/*.parquet'
+----
+84
+
+# what if the file is a file?
+statement ok
+COPY (SELECT 42 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET);
+
+statement error
+COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET, PARTITION_BY (part_col));
+----
+path exists but is not a directory
+
+statement error
+COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE_OR_IGNORE 1);
+----
+path exists but is not a directory

--- a/test/sql/copy/s3/README.md
+++ b/test/sql/copy/s3/README.md
@@ -59,3 +59,7 @@ build/debug/test/unittest test/sql/copy/s3/s3_hive_partition.test
 ```
 
 > minio uses port 9000. Clickhouse also uses port 9000. If the tests are not working and you have a running Clickhouse service - try killing it first, e.g. using `killall -9 clickhouse`
+
+#### Test Data
+
+The configuration for minio is stored in `scripts/minio_s3.yml`. Data is stored in `/tmp/minio_test_data`.


### PR DESCRIPTION
Fix https://github.com/duckdb/duckdb/issues/11307
Fix https://github.com/duckdb/duckdb/issues/10282

This PR reworks the way file conflict detection works for hive partitioning. Instead of checking both (a) up-front with `fs.ListFiles` if the directory is empty, and (b) calling `FileExists` while writing files, we check once up-front with a (recursive) glob. If `OVERWRITE_OR_IGNORE` is specified, we remove all files found. Otherwise, we throw an error if any files are found.

Note that we only support this behavior for local file systems, as the `S3FileSystem` does not support `RemoveFile`. For partitioned writes over S3 the old behavior is maintained (for now).