### PR TITLE
Correctly parse dollar-quoted strings in sqlite3_complete and linenoise

### DIFF
--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -985,21 +985,38 @@ int sqlite3_complete(const char *zSql) {
 			break;
 		}
 		case '$': { /* Dollar-quoted strings */
-			if (zSql[1] >= '0' && zSql[1] <= '9') {
-				// numeric prepared statement parameter
+			// check if this is a dollar-quoted string
+			idx_t next_dollar = 0;
+			for (idx_t idx = 1; zSql[idx]; idx++) {
+				if (zSql[idx] == '$') {
+					// found the next dollar
+					next_dollar = idx;
+					break;
+				}
+				// all characters can be between A-Z, a-z or \200 - \377
+				if (zSql[idx] >= 'A' && zSql[idx] <= 'Z') {
+					continue;
+				}
+				if (zSql[idx] >= 'a' && zSql[idx] <= 'z') {
+					continue;
+				}
+				if (zSql[idx] >= '\200' && zSql[idx] <= '\377') {
+					continue;
+				}
+				// the first character CANNOT be a numeric, only subsequent characters
+				if (idx > 1 && zSql[idx] >= '0' && zSql[idx] <= '9') {
+					continue;
+				}
+				// not a dollar quoted string
+				break;
+			}
+			if (next_dollar == 0) {
+				// not a dollar quoted string
 				next_state = SQLParseState::NORMAL;
 				break;
 			}
-			zSql++;
-			auto start = zSql;
-			// look for the next $ symbol (which is the terminator
-			while (*zSql && *zSql != '$') {
-				zSql++;
-			}
-			if (zSql[0] == 0) {
-				// unterminated dollar string
-				return 0;
-			}
+			auto start = zSql + 1;
+			zSql += next_dollar;
 			const char *delimiterStart = start;
 			idx_t delimiterLength = zSql - start;
 			zSql++;


### PR DESCRIPTION
The lexer defines dollar quoted strings as being a `$`, followed by bytes in the ranges `a-z, A-Z, \200-\377`, or `0-9` for subsequent characters, followed by another dollar. We did not correctly parse these in `sqlite3_complete` causing named parameters (e.g. `select $name`) to be mistaken as uncompleted dollar-quoted strings. This PR addresses that issue.