### PR TITLE
Python: Add missing options to write_parquet

### DIFF
--- a/tools/pythonpkg/duckdb-stubs/__init__.pyi
+++ b/tools/pythonpkg/duckdb-stubs/__init__.pyi
@@ -479,7 +479,10 @@ class DuckDBPyRelation:
     def write_parquet(
             self,
             file_name: str,
-            compression: Optional[str] = None
+            compression: Optional[str] = None,
+            field_ids: Optional[dict | str] = None,
+            row_group_size_bytes: Optional[int | str] = None,
+            row_group_size: Optional[int] = None
     ) -> None: ...
     def __len__(self) -> int: ...
     @property

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -234,7 +234,9 @@ public:
 
 	unique_ptr<DuckDBPyRelation> Join(DuckDBPyRelation *other, const py::object &condition, const string &type);
 
-	void ToParquet(const string &filename, const py::object &compression = py::none());
+	void ToParquet(const string &filename, const py::object &compression = py::none(),
+					const py::object &field_ids = py::none(), const py::object &row_group_size_bytes = py::none(),
+					const py::object &row_group_size = py::none());
 
 	void ToCSV(const string &filename, const py::object &sep = py::none(), const py::object &na_rep = py::none(),
 	           const py::object &header = py::none(), const py::object &quotechar = py::none(),

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -235,8 +235,8 @@ public:
 	unique_ptr<DuckDBPyRelation> Join(DuckDBPyRelation *other, const py::object &condition, const string &type);
 
 	void ToParquet(const string &filename, const py::object &compression = py::none(),
-					const py::object &field_ids = py::none(), const py::object &row_group_size_bytes = py::none(),
-					const py::object &row_group_size = py::none());
+	               const py::object &field_ids = py::none(), const py::object &row_group_size_bytes = py::none(),
+	               const py::object &row_group_size = py::none());
 
 	void ToCSV(const string &filename, const py::object &sep = py::none(), const py::object &na_rep = py::none(),
 	           const py::object &header = py::none(), const py::object &quotechar = py::none(),

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -1060,28 +1060,28 @@ static Value NestedDictToStruct(const py::object &dictionary) {
 
 	child_list_t<Value> children;
 	for (auto item : dict_casted) {
-            py::object item_key = item.first.cast<py::object>();
-            py::object item_value = item.second.cast<py::object>();
+		py::object item_key = item.first.cast<py::object>();
+		py::object item_value = item.second.cast<py::object>();
 
-			if (!py::isinstance<py::str>(item_key)) {
-				throw InvalidInputException("NestedDictToStruct only accepts a dictionary with string keys");
-			}
+		if (!py::isinstance<py::str>(item_key)) {
+			throw InvalidInputException("NestedDictToStruct only accepts a dictionary with string keys");
+		}
 
-			if (py::isinstance<py::int_>(item_value)) {
-				int32_t item_value_int = py::int_(item_value);
-				children.push_back(std::make_pair(py::str(item_key), Value(item_value_int)));
-			} else if (py::isinstance<py::dict>(item_value)) {
-				children.push_back(std::make_pair(py::str(item_key), NestedDictToStruct(item_value)));
-			} else {
-				throw InvalidInputException("NestedDictToStruct only accepts a dictionary with integer values or nested dictionaries");
-			}     
-    }
+		if (py::isinstance<py::int_>(item_value)) {
+			int32_t item_value_int = py::int_(item_value);
+			children.push_back(std::make_pair(py::str(item_key), Value(item_value_int)));
+		} else if (py::isinstance<py::dict>(item_value)) {
+			children.push_back(std::make_pair(py::str(item_key), NestedDictToStruct(item_value)));
+		} else {
+			throw InvalidInputException(
+			    "NestedDictToStruct only accepts a dictionary with integer values or nested dictionaries");
+		}
+	}
 	return Value::STRUCT(std::move(children));
 }
 
-void DuckDBPyRelation::ToParquet(const string &filename, const py::object &compression,
-								 const py::object &field_ids, const py::object &row_group_size_bytes,
-								 const py::object &row_group_size) {
+void DuckDBPyRelation::ToParquet(const string &filename, const py::object &compression, const py::object &field_ids,
+                                 const py::object &row_group_size_bytes, const py::object &row_group_size) {
 	case_insensitive_map_t<vector<Value>> options;
 
 	if (!py::none().is(compression)) {
@@ -1109,7 +1109,8 @@ void DuckDBPyRelation::ToParquet(const string &filename, const py::object &compr
 		} else if (py::isinstance<py::str>(row_group_size_bytes)) {
 			options["row_group_size_bytes"] = {Value(py::str(row_group_size_bytes))};
 		} else {
-			throw InvalidInputException("to_parquet only accepts 'row_group_size_bytes' as an integer or 'auto' string");
+			throw InvalidInputException(
+			    "to_parquet only accepts 'row_group_size_bytes' as an integer or 'auto' string");
 		}
 	}
 

--- a/tools/pythonpkg/src/pyrelation/initialize.cpp
+++ b/tools/pythonpkg/src/pyrelation/initialize.cpp
@@ -33,7 +33,7 @@ static void InitializeConsumers(py::class_<DuckDBPyRelation> &m) {
 	DefineMethod({"to_parquet", "write_parquet"}, m, &DuckDBPyRelation::ToParquet,
 	             "Write the relation object to a Parquet file in 'file_name'", py::arg("file_name"), py::kw_only(),
 	             py::arg("compression") = py::none(), py::arg("field_ids") = py::none(),
-				 py::arg("row_group_size_bytes") = py::none(), py::arg("row_group_size") = py::none());
+	             py::arg("row_group_size_bytes") = py::none(), py::arg("row_group_size") = py::none());
 
 	DefineMethod({"to_csv", "write_csv"}, m, &DuckDBPyRelation::ToCSV,
 	             "Write the relation object to a CSV file in 'file_name'", py::arg("file_name"), py::kw_only(),

--- a/tools/pythonpkg/src/pyrelation/initialize.cpp
+++ b/tools/pythonpkg/src/pyrelation/initialize.cpp
@@ -32,7 +32,8 @@ static void InitializeConsumers(py::class_<DuckDBPyRelation> &m) {
 
 	DefineMethod({"to_parquet", "write_parquet"}, m, &DuckDBPyRelation::ToParquet,
 	             "Write the relation object to a Parquet file in 'file_name'", py::arg("file_name"), py::kw_only(),
-	             py::arg("compression") = py::none());
+	             py::arg("compression") = py::none(), py::arg("field_ids") = py::none(),
+				 py::arg("row_group_size_bytes") = py::none(), py::arg("row_group_size") = py::none());
 
 	DefineMethod({"to_csv", "write_csv"}, m, &DuckDBPyRelation::ToCSV,
 	             "Write the relation object to a CSV file in 'file_name'", py::arg("file_name"), py::kw_only(),

--- a/tools/pythonpkg/tests/fast/api/test_to_parquet.py
+++ b/tools/pythonpkg/tests/fast/api/test_to_parquet.py
@@ -41,15 +41,17 @@ class TestToParquet(object):
         rel.to_parquet(temp_file_name, field_ids=dict(i=42, my_struct={'__duckdb_field_id': 43, 'j': 44}))
         parquet_rel = duckdb.read_parquet(temp_file_name)
         assert rel.execute().fetchall() == parquet_rel.execute().fetchall()
-        assert [
-            ('duckdb_schema', None),
-            ('i', 42),
-            ('my_struct', 43),
-            ('j', 44)
-        ] == duckdb.sql(f'''
+        assert (
+            [('duckdb_schema', None), ('i', 42), ('my_struct', 43), ('j', 44)]
+            == duckdb.sql(
+                f'''
             select name,field_id
             from parquet_schema('{temp_file_name}')
-        ''').execute().fetchall()
+        '''
+            )
+            .execute()
+            .fetchall()
+        )
 
     @pytest.mark.parametrize('row_group_size_bytes', [122880 * 1024, '2MB'])
     def test_row_group_size_bytes(self, row_group_size_bytes):


### PR DESCRIPTION
Addresses one of the points in https://github.com/duckdb/duckdb/discussions/8896 .
Adds the following parameters to write_parquet:

- field_ids
- row_group_size_bytes
- row_group_size

Relevant docs: https://duckdb.org/docs/sql/statements/copy.html#copy--to-options