### PR TITLE
Add a configurable compression_level parameter to the parquet writer

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -221,11 +221,16 @@ void ColumnWriter::CompressPage(MemoryStream &temp_writer, size_t &compressed_si
 		break;
 	}
 	case CompressionCodec::ZSTD: {
+		auto configured_compression = writer.CompressionLevel();
+		int compress_level = ZSTD_CLEVEL_DEFAULT;
+		if (configured_compression.IsValid()) {
+			compress_level = static_cast<int>(configured_compression.GetIndex());
+		}
 		compressed_size = duckdb_zstd::ZSTD_compressBound(temp_writer.GetPosition());
 		compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
-		compressed_size = duckdb_zstd::ZSTD_compress((void *)compressed_buf.get(), compressed_size,
-		                                             (const void *)temp_writer.GetData(), temp_writer.GetPosition(),
-		                                             ZSTD_CLEVEL_DEFAULT);
+		compressed_size =
+		    duckdb_zstd::ZSTD_compress((void *)compressed_buf.get(), compressed_size,
+		                               (const void *)temp_writer.GetData(), temp_writer.GetPosition(), compress_level);
 		compressed_data = compressed_buf.get();
 		break;
 	}

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -64,7 +64,8 @@ public:
 	ParquetWriter(FileSystem &fs, string file_name, vector<LogicalType> types, vector<string> names,
 	              duckdb_parquet::format::CompressionCodec::type codec, ChildFieldIDs field_ids,
 	              const vector<pair<string, string>> &kv_metadata,
-	              shared_ptr<ParquetEncryptionConfig> encryption_config, double dictionary_compression_ratio_threshold);
+	              shared_ptr<ParquetEncryptionConfig> encryption_config, double dictionary_compression_ratio_threshold,
+	              optional_idx compression_level);
 
 public:
 	void PrepareRowGroup(ColumnDataCollection &buffer, PreparedRowGroup &result);
@@ -94,6 +95,9 @@ public:
 	double DictionaryCompressionRatioThreshold() const {
 		return dictionary_compression_ratio_threshold;
 	}
+	optional_idx CompressionLevel() const {
+		return compression_level;
+	}
 
 	static CopyTypeSupport TypeIsSupported(const LogicalType &type);
 
@@ -110,6 +114,7 @@ private:
 	ChildFieldIDs field_ids;
 	shared_ptr<ParquetEncryptionConfig> encryption_config;
 	double dictionary_compression_ratio_threshold;
+	optional_idx compression_level;
 
 	unique_ptr<BufferedFileWriter> writer;
 	std::shared_ptr<duckdb_apache::thrift::protocol::TProtocol> protocol;

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -135,6 +135,8 @@ struct ParquetWriteBindData : public TableFunctionData {
 	double dictionary_compression_ratio_threshold = 1.0;
 
 	ChildFieldIDs field_ids;
+	//! The compression level, higher value is more
+	optional_idx compression_level;
 };
 
 struct ParquetWriteGlobalState : public GlobalFunctionData {
@@ -1005,6 +1007,8 @@ unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFunctionBi
 				                      "dictionary compression");
 			}
 			bind_data->dictionary_compression_ratio_threshold = val;
+		} else if (loption == "compression_level") {
+			bind_data->compression_level = option.second[0].GetValue<uint64_t>();
 		} else {
 			throw NotImplementedException("Unrecognized option for PARQUET: %s", option.first.c_str());
 		}
@@ -1030,10 +1034,10 @@ unique_ptr<GlobalFunctionData> ParquetWriteInitializeGlobal(ClientContext &conte
 	auto &parquet_bind = bind_data.Cast<ParquetWriteBindData>();
 
 	auto &fs = FileSystem::GetFileSystem(context);
-	global_state->writer =
-	    make_uniq<ParquetWriter>(fs, file_path, parquet_bind.sql_types, parquet_bind.column_names, parquet_bind.codec,
-	                             parquet_bind.field_ids.Copy(), parquet_bind.kv_metadata,
-	                             parquet_bind.encryption_config, parquet_bind.dictionary_compression_ratio_threshold);
+	global_state->writer = make_uniq<ParquetWriter>(
+	    fs, file_path, parquet_bind.sql_types, parquet_bind.column_names, parquet_bind.codec,
+	    parquet_bind.field_ids.Copy(), parquet_bind.kv_metadata, parquet_bind.encryption_config,
+	    parquet_bind.dictionary_compression_ratio_threshold, parquet_bind.compression_level);
 	return std::move(global_state);
 }
 
@@ -1154,6 +1158,7 @@ static void ParquetCopySerialize(Serializer &serializer, const FunctionData &bin
 	                                                                         bind_data.encryption_config, nullptr);
 	serializer.WriteProperty(108, "dictionary_compression_ratio_threshold",
 	                         bind_data.dictionary_compression_ratio_threshold);
+	serializer.WritePropertyWithDefault<optional_idx>(109, "compression_level", bind_data.compression_level);
 }
 
 static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserializer, CopyFunction &function) {
@@ -1169,6 +1174,7 @@ static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserialize
 	                                                                          data->encryption_config, nullptr);
 	deserializer.ReadPropertyWithDefault<double>(108, "dictionary_compression_ratio_threshold",
 	                                             data->dictionary_compression_ratio_threshold, 1.0);
+	deserializer.ReadPropertyWithDefault<optional_idx>(109, "compression_level", data->compression_level);
 	return std::move(data);
 }
 // LCOV_EXCL_STOP

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -351,7 +351,7 @@ ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_p, vector<LogicalT
                              CompressionCodec::type codec, ChildFieldIDs field_ids_p,
                              const vector<pair<string, string>> &kv_metadata,
                              shared_ptr<ParquetEncryptionConfig> encryption_config_p,
-                             double dictionary_compression_ratio_threshold_p)
+                             double dictionary_compression_ratio_threshold_p, optional_idx compression_level_p)
     : file_name(std::move(file_name_p)), sql_types(std::move(types_p)), column_names(std::move(names_p)), codec(codec),
       field_ids(std::move(field_ids_p)), encryption_config(std::move(encryption_config_p)),
       dictionary_compression_ratio_threshold(dictionary_compression_ratio_threshold_p) {
@@ -384,6 +384,19 @@ ParquetWriter::ParquetWriter(FileSystem &fs, string file_name_p, vector<LogicalT
 		kv.__set_value(kv_pair.second);
 		file_meta_data.key_value_metadata.push_back(kv);
 		file_meta_data.__isset.key_value_metadata = true;
+	}
+	if (compression_level_p.IsValid()) {
+		idx_t level = compression_level_p.GetIndex();
+		switch (codec) {
+		case CompressionCodec::ZSTD:
+			if (level < 1 || level > 22) {
+				throw BinderException("Compression level for ZSTD must be between 1 and 22");
+			}
+			break;
+		default:
+			throw NotImplementedException("Compression level is only supported for the ZSTD compression codec");
+		}
+		compression_level = level;
 	}
 
 	// populate root schema object

--- a/test/sql/copy/parquet/writer/parquet_write_compression_level.test
+++ b/test/sql/copy/parquet/writer/parquet_write_compression_level.test
@@ -1,0 +1,40 @@
+# name: test/sql/copy/parquet/writer/parquet_write_compression_level.test
+# description: Parquet compression level
+# group: [writer]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers AS FROM range(100) t(i)
+
+statement error
+COPY integers TO '__TEST_DIR__/compress_level.parquet' (FORMAT 'parquet', COMPRESSION_LEVEL 10);
+----
+only supported
+
+statement error
+COPY integers TO '__TEST_DIR__/compress_level.parquet' (FORMAT 'parquet', CODEC ZSTD, COMPRESSION_LEVEL 0);
+----
+must be between 1 and 22
+
+statement error
+COPY integers TO '__TEST_DIR__/compress_level.parquet' (FORMAT 'parquet', CODEC ZSTD, COMPRESSION_LEVEL 23);
+----
+must be between 1 and 22
+
+statement ok
+COPY integers TO '__TEST_DIR__/compress_level.parquet' (FORMAT 'parquet', CODEC ZSTD, COMPRESSION_LEVEL 1);
+
+statement ok
+COPY integers TO '__TEST_DIR__/compress_level2.parquet' (FORMAT 'parquet', CODEC ZSTD, COMPRESSION_LEVEL 22);
+
+query I nosort clevel
+SELECT * FROM '__TEST_DIR__/compress_level.parquet'
+----
+
+query I nosort clevel
+SELECT * FROM '__TEST_DIR__/compress_level2.parquet'
+----


### PR DESCRIPTION
Implements https://github.com/duckdb/duckdb/discussions/10170

This adds a `COMPRESSION_LEVEL` configuration to the Parquet writer, currently only supported for ZSTD. ZSTD supports compression levels between 1 and 22. The default level is 3. The higher the compression ratio, the smaller the file will be, at the expense of slower writing performance. 

Usage:

```sql
COPY tbl to 'file.parquet' (CODEC zstd, COMPRESSION_LEVEL 1);
```

Below are some performance/size results when writing the `lineitem` table at scale factor 10 (~10GB in uncompressed CSV format):

| Compression Level | Time (s) | File Size |
|-------------------|----------|-----------|
| 1                 | 5.7s     | 1.61GB    |
| 3                 | 6.4s     | 1.55GB    |
| 10                | 21.1s      | 1.47GB    |
| 22                | 194.5s   | 1.37GB    |
