### PR TITLE
Close file after file lock failure

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -383,6 +383,10 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 						           "using the -readonly parameter in the CLI";
 					}
 				}
+				rc = close(fd);
+				if (rc == -1) {
+					message += ". Also, failed closing file";
+				}
 				message += ". See also https://duckdb.org/docs/connect/concurrency";
 				throw IOException("Could not set lock on file \"%s\": %s", {{"errno", std::to_string(retained_errno)}},
 				                  path, message);


### PR DESCRIPTION
Currently, after file lock acquisition fails, file descriptors don't get closed.

A consequence of this is that the read lock that is acquired (right [here](https://github.com/duckdb/duckdb/blob/866a328/src/common/local_file_system.cpp#L380)) after failing to get a read/write lock is never unlocked after failing to attach a database.

For example, when I open two terminal windows and run the following:

Terminal 1:
```
ATTACH 'my_db';  // step 1.  creates database.
DETACH my_db;  // step 2.  unlocks file
ATTACH 'my_db' (READ_ONLY); // step 3.  attach in read only mode
DETACH my_db; // step 5
ATTACH 'my_db'; // step 6.  This fails!
``` 

Terminal 2:
```
ATTACH 'my_db';  // step 4.  This fails with message "...However, you would be able to open this database in read-only mode, e.g. by using the -readonly parameter in the CLI"
```

Now, until terminal window 2 is closed, no other duckdb instance can attach the database, even though it is attached nowhere.  This happens because the read lock on the file is acquired in window 2 (even though the attach failed), but the file is never closed (therefore never unlocked).

I appreciate feedback (especially on the message!).  Thank you! 