### PR TITLE
[PythonDev] Fix up failing tests in CI

### DIFF
--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -69,6 +69,17 @@ BUILTIN_EXTENSIONS = [
     'icu',
 ]
 
+from duckdb import DuckDBPyConnection
+
+# def patch_execute(method):
+#    def patched_execute(self, *args, **kwargs):
+#        print(*args)
+#        return method(self, *args, **kwargs)
+#    return patched_execute
+
+# patched_execute = patch_execute(getattr(DuckDBPyConnection, "execute"))
+# setattr(DuckDBPyConnection, "execute", patched_execute)
+
 
 class SQLLogicStatementData:
     # Context information about a statement

--- a/test/sql/copy/csv/test_export_not_null.test
+++ b/test/sql/copy/csv/test_export_not_null.test
@@ -21,6 +21,10 @@ statement ok
 abort;
 
 statement ok
+begin transaction;
+
+# Very that the table can be imported
+statement ok
 IMPORT DATABASE '__TEST_DIR__/broken_empty_string';
 
 # Force not null can't be used explicitly
@@ -28,6 +32,9 @@ statement error
 EXPORT DATABASE '__TEST_DIR__/broken_empty_string_2' (FORCE_NOT_NULL ['A']);
 ----
 Unrecognized option
+
+statement ok
+abort;
 
 # Try Table with multiple null constraints
 

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -41,6 +41,7 @@ class SQLLogicTestExecutor(SQLLogicRunner):
                 'test/sql/types/timestamp/test_timestamp_tz.test',  # <-- Python client is always loaded wih ICU available - making the TIMESTAMPTZ::DATE cast pass
                 'test/sql/parser/invisible_spaces.test',  # <-- Parser is getting tripped up on the invisible spaces
                 'test/sql/copy/csv/code_cov/csv_state_machine_invalid_utf.test',  # <-- ConversionException is empty, see Python Mega Issue (duckdb-internal #1488)
+                'test/sql/copy/csv/test_csv_timestamp_tz.test',  # <-- ICU is always loaded
             ]
         )
         # TODO: get this from the `duckdb` package


### PR DESCRIPTION
Added a small snippet injecting a print into `connection.execute` to log every `execute` that gets executed, for debugging purposes.

Fixed two tests:
- `test/sql/copy/csv/test_csv_timestamp_tz.test` is expected to fail, but it succeeds because ICU is always present.
- `test/sql/copy/csv/test_export_not_null.test` was actually broken, but a bug in the C++ API was hiding this.