### PR TITLE
[Python Dev] Fix spurious failure in `test_to_csv.py`

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -118,7 +118,6 @@ jobs:
     name: Linux Extensions (linux_amd64_gcc4)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
-    needs: linux-python3-9
     env:
       GEN: ninja
 
@@ -165,25 +164,10 @@ jobs:
         arch: [x86_64, aarch64]
         python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
         manylinux: [manylinux2014, manylinux_2_28]
-        isRelease:
-          - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         exclude:
           # For now we don't distribute the 2_28 wheels on x64
           - arch: x86_64
             manylinux: manylinux_2_28
-          # Speed things up a bit for non-releases
-          - isRelease: false
-            python_build: 'cp37-*'
-          - isRelease: false
-            python_build: 'cp38-*'
-          - isRelease: false
-            python_build: 'cp39-*'
-          - isRelease: false
-            python_build: 'cp310-*'
-          - isRelease: false
-            python_build: 'cp311-*'
-          - isRelease: false
-            arch: aarch64
     needs: manylinux-extensions-x64
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
@@ -274,13 +258,11 @@ jobs:
         ./scripts/upload-assets-to-staging.sh twine_upload tools/pythonpkg/dist/duckdb-*.tar.gz tools/pythonpkg/wheelhouse/*.whl
 
    osx-python3:
-      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
       name: Python 3 OSX
       runs-on: macos-latest
       strategy:
        matrix:
         python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
-      needs: linux-python3-9
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
         CIBW_ARCHS: 'x86_64 universal2 arm64'
@@ -348,18 +330,6 @@ jobs:
       strategy:
        matrix:
         python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
-        isRelease:
-          - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
-        exclude:
-          - isRelease: false
-            python_build: 'cp37-*'
-          - isRelease: false
-            python_build: 'cp38-*'
-          - isRelease: false
-            python_build: 'cp39-*'
-          - isRelease: false
-            python_build: 'cp311-*'
-      needs: linux-python3-9
 
       env:
         CIBW_BUILD: ${{ matrix.python_build}}
@@ -429,7 +399,6 @@ jobs:
      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
      name: PyPi Release Cleanup
      runs-on: ubuntu-20.04
-     needs: linux-python3-9
      env:
        PYPI_CLEANUP_USERNAME: 'mytherin'
        PYPI_CLEANUP_PASSWORD: ${{secrets.PYPI_CLEANUP_PASSWORD}}

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -33,6 +33,7 @@ public:
 	string file_extension;
 	bool overwrite_or_ignore;
 	bool parallel;
+	//! If set, causes every thread to write to a separate output file in a folder
 	bool per_thread_output;
 	optional_idx file_size_bytes;
 

--- a/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
+++ b/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
@@ -34,6 +34,7 @@ public:
 	FilenamePattern filename_pattern;
 	string file_extension;
 	bool overwrite_or_ignore;
+	//! If set, causes every thread to write to a separate output file in a folder
 	bool per_thread_output;
 	optional_idx file_size_bytes;
 

--- a/tools/pythonpkg/tests/fast/api/test_to_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_to_csv.py
@@ -225,9 +225,9 @@ class TestToCSV(object):
         rel.to_csv(temp_file_name, header=True, per_thread_output=True)
         created_files = duckdb_cursor.sql(f"select * from glob('{temp_file_name}/*.csv')").fetchall()
         print(created_files)
-        assert len(created_files) == 1
-        content = open(created_files[0][0]).read()
-        print(content)
+        for i, item in enumerate(created_files):
+            print(f'File {i}')
+            print(open(item[0]).read())
 
         csv_rel = duckdb_cursor.read_csv(f'{temp_file_name}/*.csv', header=True)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()

--- a/tools/pythonpkg/tests/fast/api/test_to_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_to_csv.py
@@ -7,10 +7,14 @@ import pytest
 from conftest import NumpyPandas, ArrowPandas, getTimeSeriesData
 
 
+@pytest.fixture(scope="function")
+def temp_file_name(request, tmp_path_factory):
+    return str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+
+
 class TestToCSV(object):
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_basic_to_csv(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_basic_to_csv(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': [5, 3, 23, 2], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -20,8 +24,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_sep(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_sep(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': [5, 3, 23, 2], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -31,8 +34,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_na_rep(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_na_rep(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': [5, None, 23, 2], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -42,8 +44,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_header(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_header(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': [5, None, 23, 2], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -53,8 +54,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quotechar(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_quotechar(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': ["\'a,b,c\'", None, "hello", "bye"], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -64,8 +64,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_escapechar(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_escapechar(self, pandas, temp_file_name):
         df = pandas.DataFrame(
             {
                 "c_bool": [True, False],
@@ -80,8 +79,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_date_format(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_date_format(self, pandas, temp_file_name):
         df = pandas.DataFrame(getTimeSeriesData())
         dt_index = df.index
         df = pandas.DataFrame({"A": dt_index, "B": dt_index.shift(1)}, index=dt_index)
@@ -93,8 +91,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_timestamp_format(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_timestamp_format(self, pandas, temp_file_name):
         data = [datetime.time(hour=23, minute=1, second=34, microsecond=234345)]
         df = pandas.DataFrame({'0': pandas.Series(data=data, dtype='object')})
         rel = duckdb.from_df(df)
@@ -105,8 +102,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quoting_off(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_quoting_off(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, quoting=None)
@@ -115,8 +111,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quoting_on(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_quoting_on(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, quoting="force")
@@ -125,8 +120,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quoting_quote_all(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_quoting_quote_all(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, quoting=csv.QUOTE_ALL)
@@ -135,8 +129,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_encoding_incorrect(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_encoding_incorrect(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         with pytest.raises(
@@ -145,8 +138,7 @@ class TestToCSV(object):
             rel.to_csv(temp_file_name, encoding="nope")
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_encoding_correct(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_encoding_correct(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, encoding="UTF-8")
@@ -154,8 +146,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_compression_gzip(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_compression_gzip(self, pandas, temp_file_name):
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, compression="gzip")
@@ -163,8 +154,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_partition(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_partition(self, pandas, temp_file_name):
         df = pandas.DataFrame(
             {
                 "c_category": ['a', 'a', 'b', 'b'],
@@ -182,8 +172,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_overwrite(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_overwrite(self, pandas, temp_file_name):
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],
@@ -203,8 +192,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_overwrite_not_enabled(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_overwrite_not_enabled(self, pandas, temp_file_name):
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],
@@ -221,8 +209,7 @@ class TestToCSV(object):
             rel.to_csv(temp_file_name, header=True, partition_by=["c_category_1"])
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_per_thread_output(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_per_thread_output(self, pandas, temp_file_name):
         num_threads = duckdb.sql("select current_setting('threads')").fetchone()[0]
         print('num_threads:', num_threads)
         df = pandas.DataFrame(
@@ -240,8 +227,7 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_use_tmp_file(self, request, pandas, tmp_path_factory):
-        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
+    def test_to_csv_use_tmp_file(self, pandas, temp_file_name):
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],

--- a/tools/pythonpkg/tests/fast/api/test_to_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_to_csv.py
@@ -1,5 +1,4 @@
 import duckdb
-import tempfile
 import os
 import pandas._testing as tm
 import datetime
@@ -10,8 +9,8 @@ from conftest import NumpyPandas, ArrowPandas, getTimeSeriesData
 
 class TestToCSV(object):
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_basic_to_csv(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_basic_to_csv(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': [5, 3, 23, 2], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -21,8 +20,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_sep(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_sep(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': [5, 3, 23, 2], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -32,8 +31,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_na_rep(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_na_rep(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': [5, None, 23, 2], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -43,8 +42,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_header(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_header(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': [5, None, 23, 2], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -54,8 +53,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quotechar(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_quotechar(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': ["\'a,b,c\'", None, "hello", "bye"], 'b': [45, 234, 234, 2]})
         rel = duckdb.from_df(df)
 
@@ -65,8 +64,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_escapechar(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_escapechar(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame(
             {
                 "c_bool": [True, False],
@@ -81,8 +80,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_date_format(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_date_format(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame(getTimeSeriesData())
         dt_index = df.index
         df = pandas.DataFrame({"A": dt_index, "B": dt_index.shift(1)}, index=dt_index)
@@ -94,8 +93,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_timestamp_format(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_timestamp_format(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         data = [datetime.time(hour=23, minute=1, second=34, microsecond=234345)]
         df = pandas.DataFrame({'0': pandas.Series(data=data, dtype='object')})
         rel = duckdb.from_df(df)
@@ -106,8 +105,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quoting_off(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_quoting_off(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, quoting=None)
@@ -116,8 +115,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quoting_on(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_quoting_on(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, quoting="force")
@@ -126,8 +125,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quoting_quote_all(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_quoting_quote_all(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, quoting=csv.QUOTE_ALL)
@@ -136,8 +135,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_encoding_incorrect(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_encoding_incorrect(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         with pytest.raises(
@@ -146,8 +145,8 @@ class TestToCSV(object):
             rel.to_csv(temp_file_name, encoding="nope")
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_encoding_correct(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_encoding_correct(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, encoding="UTF-8")
@@ -155,8 +154,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_compression_gzip(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_compression_gzip(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, compression="gzip")
@@ -164,8 +163,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_partition(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_partition(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame(
             {
                 "c_category": ['a', 'a', 'b', 'b'],
@@ -183,8 +182,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_overwrite(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_overwrite(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],
@@ -204,8 +203,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_overwrite_not_enabled(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_overwrite_not_enabled(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],
@@ -222,8 +221,8 @@ class TestToCSV(object):
             rel.to_csv(temp_file_name, header=True, partition_by=["c_category_1"])
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_per_thread_output(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_per_thread_output(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         num_threads = duckdb.sql("select current_setting('threads')").fetchone()[0]
         print('num_threads:', num_threads)
         df = pandas.DataFrame(
@@ -241,8 +240,8 @@ class TestToCSV(object):
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_use_tmp_file(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_use_tmp_file(self, request, pandas, tmp_path_factory):
+        temp_file_name = str(tmp_path_factory.mktemp(request.function.__name__, numbered=True) / 'file.csv')
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/1824

The issue we saw in CI was probably that the directory either didn't get cleaned up and was reused, so it contained old files, or even that another test directly populated the directory that `test_to_csv_per_thread_output` was scanning.

Using a pytest-native solution means that the directory gets cleaned up properly, and we can use a generic fixture to avoid issues like these creeping in again later.

Printing `temp_file_name` shows that each test gets its own folder:
```
=============================================================================================== PASSES ================================================================================================
________________________________________________________________________________ TestToCSV.test_basic_to_csv[pandas0] _________________________________________________________________________________
---------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------
/private/var/folders/0b/xnmc2md17tz7phhl5khwfltc0000gn/T/pytest-of-thijs/pytest-30/test_basic_to_csv0/file.csv
________________________________________________________________________________ TestToCSV.test_basic_to_csv[pandas1] _________________________________________________________________________________
---------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------
/private/var/folders/0b/xnmc2md17tz7phhl5khwfltc0000gn/T/pytest-of-thijs/pytest-30/test_basic_to_csv1/file.csv
_________________________________________________________________________________ TestToCSV.test_to_csv_sep[pandas0] __________________________________________________________________________________
---------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------
/private/var/folders/0b/xnmc2md17tz7phhl5khwfltc0000gn/T/pytest-of-thijs/pytest-30/test_to_csv_sep0/file.csv
_________________________________________________________________________________ TestToCSV.test_to_csv_sep[pandas1] __________________________________________________________________________________
---------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------
/private/var/folders/0b/xnmc2md17tz7phhl5khwfltc0000gn/T/pytest-of-thijs/pytest-30/test_to_csv_sep1/file.csv
```

Which seems much more sane than the result on `main`
```
=============================================================================================== PASSES ================================================================================================
________________________________________________________________________________ TestToCSV.test_basic_to_csv[pandas0] _________________________________________________________________________________
---------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------
/var/folders/0b/xnmc2md17tz7phhl5khwfltc0000gn/T/tmps8m1hz0k/e7vtltp9
________________________________________________________________________________ TestToCSV.test_basic_to_csv[pandas1] _________________________________________________________________________________
---------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------
/var/folders/0b/xnmc2md17tz7phhl5khwfltc0000gn/T/tmp3lgvn8hk/r7x3pkqm
_________________________________________________________________________________ TestToCSV.test_to_csv_sep[pandas0] __________________________________________________________________________________
---------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------
/var/folders/0b/xnmc2md17tz7phhl5khwfltc0000gn/T/tmpqe0h4gg1/en01jz0e
_________________________________________________________________________________ TestToCSV.test_to_csv_sep[pandas1] __________________________________________________________________________________
---------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------
/var/folders/0b/xnmc2md17tz7phhl5khwfltc0000gn/T/tmpn5lqzoao/6sbeprzs
```