### PR TITLE
Fix #11756: Don't throw exception on CREATE UNIQUE INDEX IF NOT EXISTS if index already exists

### DIFF
--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -223,7 +223,8 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::CreateIndex(ClientContext &context, 
 
 	// currently, we can not alter PK/FK/UNIQUE constraints
 	// concurrency-safe name checks against other INDEX catalog entries happens in the catalog
-	if (!table.GetStorage().IndexNameIsUnique(info.index_name)) {
+	if (info.on_conflict != OnCreateConflict::IGNORE_ON_CONFLICT &&
+	    !table.GetStorage().IndexNameIsUnique(info.index_name)) {
 		throw CatalogException("An index with the name " + info.index_name + " already exists!");
 	}
 

--- a/test/sql/catalog/test_catalog_errors.test
+++ b/test/sql/catalog/test_catalog_errors.test
@@ -40,6 +40,7 @@ CREATE INDEX i_index ON integers(i);
 statement error
 CREATE INDEX i_index ON integers(i);
 ----
+already exists
 
 # with IF NOT EXISTS it does not fail!
 statement ok
@@ -58,9 +59,19 @@ DROP INDEX i_index
 statement ok
 DROP INDEX IF EXISTS i_index
 
-# create the index again
+# create the index again, but as unique to exercise special handling due to indexes generated column constraints
 statement ok
-CREATE INDEX i_index ON integers(i);
+CREATE UNIQUE INDEX i_index ON integers(i);
+
+# cannot create an index that already exists
+statement error
+CREATE UNIQUE INDEX i_index ON integers(i);
+----
+already exists
+
+# with IF NOT EXISTS it does not fail!
+statement ok
+CREATE UNIQUE INDEX IF NOT EXISTS i_index ON integers(i);
 
 # dropping the table also drops the index
 statement ok


### PR DESCRIPTION
This was introduced by [8188cd959f3b45d1c2009bda25f663c19eef7434](https://github.com/duckdb/duckdb/commit/8188cd959f3b45d1c2009bda25f663c19eef7434), which tries to handle automatic indexes (pk, fk, unique) better. But in doing so, it short circuits later checks. Since unique indexes could come from a column constraint or just be created by the user, we need to at least handle the IGNORE_ON_CONFLICT case when checking the index types.