### PR TITLE
Fix #11798 - lateral join parameters should not be visible in views

### DIFF
--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -58,7 +58,7 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	}
 
 	// Bind the select statement of the original to resolve the types
-	auto dummy_binder = Binder::CreateBinder(binder.context, &binder, true);
+	auto dummy_binder = Binder::CreateBinder(binder.context, &binder);
 	auto bound_original = dummy_binder->Bind(*stmt.select_statement);
 
 	// Create new SelectNode with the original SelectNode as a subquery in the FROM clause

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -600,6 +600,29 @@ ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *va
 }
 
 template<>
+const char* EnumUtil::ToChars<BinderType>(BinderType value) {
+	switch(value) {
+	case BinderType::REGULAR_BINDER:
+		return "REGULAR_BINDER";
+	case BinderType::VIEW_BINDER:
+		return "VIEW_BINDER";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+BinderType EnumUtil::FromString<BinderType>(const char *value) {
+	if (StringUtil::Equals(value, "REGULAR_BINDER")) {
+		return BinderType::REGULAR_BINDER;
+	}
+	if (StringUtil::Equals(value, "VIEW_BINDER")) {
+		return BinderType::VIEW_BINDER;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
 const char* EnumUtil::ToChars<BindingMode>(BindingMode value) {
 	switch(value) {
 	case BindingMode::STANDARD_BINDING:

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -62,6 +62,8 @@ enum class ArrowOffsetSize : uint8_t;
 
 enum class ArrowVariableSizeType : uint8_t;
 
+enum class BinderType : uint8_t;
+
 enum class BindingMode : uint8_t;
 
 enum class BitpackingMode : uint8_t;
@@ -369,6 +371,9 @@ const char* EnumUtil::ToChars<ArrowOffsetSize>(ArrowOffsetSize value);
 
 template<>
 const char* EnumUtil::ToChars<ArrowVariableSizeType>(ArrowVariableSizeType value);
+
+template<>
+const char* EnumUtil::ToChars<BinderType>(BinderType value);
 
 template<>
 const char* EnumUtil::ToChars<BindingMode>(BindingMode value);
@@ -808,6 +813,9 @@ ArrowOffsetSize EnumUtil::FromString<ArrowOffsetSize>(const char *value);
 
 template<>
 ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *value);
+
+template<>
+BinderType EnumUtil::FromString<BinderType>(const char *value);
 
 template<>
 BindingMode EnumUtil::FromString<BindingMode>(const char *value);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -56,6 +56,7 @@ struct PivotColumnEntry;
 struct UnpivotEntry;
 
 enum class BindingMode : uint8_t { STANDARD_BINDING, EXTRACT_NAMES };
+enum class BinderType : uint8_t { REGULAR_BINDER, VIEW_BINDER };
 
 struct CorrelatedColumnInfo {
 	ColumnBinding binding;
@@ -88,7 +89,7 @@ class Binder : public enable_shared_from_this<Binder> {
 
 public:
 	DUCKDB_API static shared_ptr<Binder> CreateBinder(ClientContext &context, optional_ptr<Binder> parent = nullptr,
-	                                                  bool inherit_ctes = true);
+	                                                  BinderType binder_type = BinderType::REGULAR_BINDER);
 
 	//! The client context
 	ClientContext &context;
@@ -209,8 +210,8 @@ private:
 	bool has_unplanned_dependent_joins = false;
 	//! Whether or not outside dependent joins have been planned and flattened
 	bool is_outside_flattened = true;
-	//! Whether CTEs should reference the parent binder (if it exists)
-	bool inherit_ctes = true;
+	//! What kind of node we are binding using this binder
+	BinderType binder_type = BinderType::REGULAR_BINDER;
 	//! Whether or not the binder can contain NULLs as the root of expressions
 	bool can_contain_nulls = false;
 	//! The root statement of the query that is currently being parsed
@@ -392,7 +393,7 @@ private:
 public:
 	// This should really be a private constructor, but make_shared_ptr does not allow it...
 	// If you are thinking about calling this, you should probably call Binder::CreateBinder
-	Binder(bool i_know_what_i_am_doing, ClientContext &context, shared_ptr<Binder> parent, bool inherit_ctes);
+	Binder(bool i_know_what_i_am_doing, ClientContext &context, shared_ptr<Binder> parent, BinderType binder_type);
 };
 
 } // namespace duckdb

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -40,26 +40,25 @@ idx_t Binder::GetBinderDepth() const {
 	return depth;
 }
 
-shared_ptr<Binder> Binder::CreateBinder(ClientContext &context, optional_ptr<Binder> parent, bool inherit_ctes) {
+shared_ptr<Binder> Binder::CreateBinder(ClientContext &context, optional_ptr<Binder> parent, BinderType binder_type) {
 	auto depth = parent ? parent->GetBinderDepth() : 0;
 	if (depth > context.config.max_expression_depth) {
 		throw BinderException("Max expression depth limit of %lld exceeded. Use \"SET max_expression_depth TO x\" to "
 		                      "increase the maximum expression depth.",
 		                      context.config.max_expression_depth);
 	}
-	return make_shared_ptr<Binder>(true, context, parent ? parent->shared_from_this() : nullptr, inherit_ctes);
+	return make_shared_ptr<Binder>(true, context, parent ? parent->shared_from_this() : nullptr, binder_type);
 }
 
-Binder::Binder(bool, ClientContext &context, shared_ptr<Binder> parent_p, bool inherit_ctes_p)
-    : context(context), bind_context(*this), parent(std::move(parent_p)), bound_tables(0),
-      inherit_ctes(inherit_ctes_p) {
+Binder::Binder(bool, ClientContext &context, shared_ptr<Binder> parent_p, BinderType binder_type)
+    : context(context), bind_context(*this), parent(std::move(parent_p)), bound_tables(0), binder_type(binder_type) {
 	if (parent) {
 
 		// We have to inherit macro and lambda parameter bindings and from the parent binder, if there is a parent.
 		macro_binding = parent->macro_binding;
 		lambda_bindings = parent->lambda_bindings;
 
-		if (inherit_ctes) {
+		if (binder_type == BinderType::REGULAR_BINDER) {
 			// We have to inherit CTE bindings from the parent bind_context, if there is a parent.
 			bind_context.SetCTEBindings(parent->bind_context.GetCTEBindings());
 			bind_context.cte_references = parent->bind_context.cte_references;
@@ -342,7 +341,7 @@ vector<reference<CommonTableExpressionInfo>> Binder::FindCTE(const string &name,
 			ctes.push_back(entry->second);
 		}
 	}
-	if (parent && inherit_ctes) {
+	if (parent && binder_type == BinderType::REGULAR_BINDER) {
 		auto parent_ctes = parent->FindCTE(name, name == alias);
 		ctes.insert(ctes.end(), parent_ctes.begin(), parent_ctes.end());
 	}
@@ -353,7 +352,7 @@ bool Binder::CTEIsAlreadyBound(CommonTableExpressionInfo &cte) {
 	if (bound_ctes.find(cte) != bound_ctes.end()) {
 		return true;
 	}
-	if (parent && inherit_ctes) {
+	if (parent && binder_type == BinderType::REGULAR_BINDER) {
 		return parent->CTEIsAlreadyBound(cte);
 	}
 	return false;
@@ -399,7 +398,11 @@ bool Binder::HasActiveBinder() {
 }
 
 vector<reference<ExpressionBinder>> &Binder::GetActiveBinders() {
-	auto &root_binder = GetRootBinder();
+	reference<Binder> root = *this;
+	while (root.get().parent && root.get().binder_type == BinderType::REGULAR_BINDER) {
+		root = *root.get().parent;
+	}
+	auto &root_binder = root.get();
 	return root_binder.active_binders;
 }
 

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -45,7 +45,7 @@ unique_ptr<Expression> Binder::BindOrderExpression(OrderBinder &order_binder, un
 
 BoundLimitNode Binder::BindLimitValue(OrderBinder &order_binder, unique_ptr<ParsedExpression> limit_val,
                                       bool is_percentage, bool is_offset) {
-	auto new_binder = Binder::CreateBinder(context, this, true);
+	auto new_binder = Binder::CreateBinder(context, this);
 	ExpressionBinder expr_binder(*new_binder, context);
 	auto target_type = is_percentage ? LogicalType::DOUBLE : LogicalType::BIGINT;
 	expr_binder.target_type = target_type;

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -231,8 +231,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		// We need to use a new binder for the view that doesn't reference any CTEs
 		// defined for this binder so there are no collisions between the CTEs defined
 		// for the view and for the current query
-		bool inherit_ctes = false;
-		auto view_binder = Binder::CreateBinder(context, this, inherit_ctes);
+		auto view_binder = Binder::CreateBinder(context, this, BinderType::VIEW_BINDER);
 		view_binder->can_contain_nulls = true;
 		SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(view_catalog_entry.query->Copy()));
 		subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -31,7 +31,7 @@ static bool IsTableInTableOutFunction(TableFunctionCatalogEntry &table_function)
 
 bool Binder::BindTableInTableOutFunction(vector<unique_ptr<ParsedExpression>> &expressions,
                                          unique_ptr<BoundSubqueryRef> &subquery, ErrorData &error) {
-	auto binder = Binder::CreateBinder(this->context, this, true);
+	auto binder = Binder::CreateBinder(this->context, this);
 	unique_ptr<QueryNode> subquery_node;
 	if (expressions.size() == 1 && expressions[0]->type == ExpressionType::SUBQUERY) {
 		// general case: argument is a subquery, bind it as part of the node
@@ -91,7 +91,7 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 				error = ErrorData("Table function can have at most one subquery parameter");
 				return false;
 			}
-			auto binder = Binder::CreateBinder(this->context, this, true);
+			auto binder = Binder::CreateBinder(this->context, this);
 			auto &se = child->Cast<SubqueryExpression>();
 			auto node = binder->BindNode(*se.subquery->node);
 			subquery = make_uniq<BoundSubqueryRef>(std::move(binder), std::move(node));

--- a/test/fuzzer/pedro/view_not_rebound_error.test
+++ b/test/fuzzer/pedro/view_not_rebound_error.test
@@ -19,4 +19,3 @@ CREATE TABLE t1 (c2 INT);
 statement error
 SELECT 1 FROM t2 JOIN t1 ON (SELECT TRUE FROM t0);
 ----
-Contents of view were altered

--- a/test/sql/subquery/lateral/lateral_binding_views.test
+++ b/test/sql/subquery/lateral/lateral_binding_views.test
@@ -1,0 +1,19 @@
+# name: test/sql/subquery/lateral/lateral_binding_views.test
+# description: Verify that views cannot reference lateral join columns
+# group: [lateral]
+
+statement ok
+copy (select date '2000-01-01' as dt) to '__TEST_DIR__/datetest.csv';
+
+statement ok
+create view v1 as select * from read_csv('__TEST_DIR__/datetest.csv', columns={'dt': date});
+
+query I
+from v1
+----
+2000-01-01
+
+query II
+select * from (select date '1992-01-01' as date), v1;
+----
+1992-01-01	2000-01-01


### PR DESCRIPTION
Fixes #11798 

Much like CTEs, lateral join parameters should not be visible in views as views should be bound independent from the rest of the query.