### PR TITLE
[Dev] ClientContextWrapper yak shaving

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -289,22 +289,4 @@ private:
 	lock_guard<mutex> client_guard;
 };
 
-class ClientContextWrapper {
-public:
-	explicit ClientContextWrapper(const shared_ptr<ClientContext> &context)
-	    : client_context(context) {
-
-	      };
-	shared_ptr<ClientContext> GetContext() {
-		auto actual_context = client_context.lock();
-		if (!actual_context) {
-			throw ConnectionException("Connection has already been closed");
-		}
-		return actual_context;
-	}
-
-private:
-	weak_ptr<ClientContext> client_context;
-};
-
 } // namespace duckdb

--- a/src/include/duckdb/main/client_context_wrapper.hpp
+++ b/src/include/duckdb/main/client_context_wrapper.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/client_context_wrapper.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/shared_ptr.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+
+class ClientContextWrapper {
+public:
+	explicit ClientContextWrapper(const shared_ptr<ClientContext> &context);
+	shared_ptr<ClientContext> GetContext();
+
+private:
+	weak_ptr<ClientContext> client_context;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/relation.hpp
+++ b/src/include/duckdb/main/relation.hpp
@@ -17,6 +17,7 @@
 #include "duckdb/parser/column_definition.hpp"
 #include "duckdb/common/named_parameter_map.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_context_wrapper.hpp"
 #include "duckdb/main/external_dependencies.hpp"
 #include "duckdb/parser/statement/explain_statement.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
@@ -28,7 +29,6 @@
 namespace duckdb {
 struct BoundStatement;
 
-class ClientContextWrapper;
 class Binder;
 class LogicalOperator;
 class QueryNode;

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library_unity(
   attached_database.cpp
   client_context_file_opener.cpp
   client_context.cpp
+  client_context_wrapper.cpp
   client_data.cpp
   client_verify.cpp
   connection_manager.cpp

--- a/src/main/client_context_wrapper.cpp
+++ b/src/main/client_context_wrapper.cpp
@@ -3,7 +3,8 @@
 
 namespace duckdb {
 
-ClientContextWrapper::ClientContextWrapper(const shared_ptr<ClientContext> &context) : client_context(context) {}
+ClientContextWrapper::ClientContextWrapper(const shared_ptr<ClientContext> &context) : client_context(context) {
+}
 
 shared_ptr<ClientContext> ClientContextWrapper::GetContext() {
 	auto actual_context = client_context.lock();

--- a/src/main/client_context_wrapper.cpp
+++ b/src/main/client_context_wrapper.cpp
@@ -3,7 +3,7 @@
 
 namespace duckdb {
 
-ClientContextWrapper::ClientContextWrapper(const shared_ptr<ClientContext> &context) : client_context(context) {};
+ClientContextWrapper::ClientContextWrapper(const shared_ptr<ClientContext> &context) : client_context(context) {}
 
 shared_ptr<ClientContext> ClientContextWrapper::GetContext() {
 	auto actual_context = client_context.lock();

--- a/src/main/client_context_wrapper.cpp
+++ b/src/main/client_context_wrapper.cpp
@@ -1,0 +1,16 @@
+#include "duckdb/main/client_context_wrapper.hpp"
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+
+ClientContextWrapper::ClientContextWrapper(const shared_ptr<ClientContext> &context) : client_context(context) {};
+
+shared_ptr<ClientContext> ClientContextWrapper::GetContext() {
+	auto actual_context = client_context.lock();
+	if (!actual_context) {
+		throw ConnectionException("Connection has already been closed");
+	}
+	return actual_context;
+}
+
+} // namespace duckdb


### PR DESCRIPTION
This is required to be able to put ClientContextWrapper in classes that need to forward declare ClientContext.

If a member of the class is of type ClientContextWrapper it has to be a complete type, so it can't be forward declared.
ClientContextWrapper can forward declare ClientContext because it's merely a template parameter of `weak_ptr`/`shared_ptr` but it has no impact on the size of the class.