### PR TITLE
Removing old code that used to check if a buffer was the last buffer from the file handler

### DIFF
--- a/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
@@ -38,17 +38,7 @@ bool CSVBufferManager::ReadNextAndCacheIt() {
 	D_ASSERT(last_buffer);
 	for (idx_t i = 0; i < 2; i++) {
 		if (!last_buffer->IsCSVFileLastBuffer()) {
-			auto cur_buffer_size = buffer_size;
-			if (file_handle->uncompressed) {
-				if (file_handle->FileSize() - bytes_read) {
-					cur_buffer_size = file_handle->FileSize() - bytes_read;
-				}
-			}
-			if (cur_buffer_size == 0) {
-				last_buffer->last_buffer = true;
-				return false;
-			}
-			auto maybe_last_buffer = last_buffer->Next(*file_handle, cur_buffer_size, file_idx, has_seeked);
+			auto maybe_last_buffer = last_buffer->Next(*file_handle, buffer_size, file_idx, has_seeked);
 			if (!maybe_last_buffer) {
 				last_buffer->last_buffer = true;
 				return false;

--- a/test/sql/copy/csv/parallel/csv_parallel_clickbench.test_slow
+++ b/test/sql/copy/csv/parallel/csv_parallel_clickbench.test_slow
@@ -133,7 +133,7 @@ statement ok
 create table hits as select * from hits_og limit 0;
 
 statement ok
-copy hits from '__TEST_DIR__/hits.csv' (nullstr 'null');
+insert into hits from read_csv('__TEST_DIR__/hits.csv', compression = 'none', nullstr = 'null');
 
 #Q 01
 query I


### PR DESCRIPTION
It's no longer necessary since `Next()` already returns whether the buffer was the last one.

Fix: #11828