### PR TITLE
[Python Dev] Fix shift between `requirements-dev.txt` and `pyproject.toml` `before-test` section

### DIFF
--- a/tools/pythonpkg/MANIFEST.in
+++ b/tools/pythonpkg/MANIFEST.in
@@ -4,4 +4,6 @@ include duckdb_python.cpp
 recursive-include src *.h *.hpp *.cpp
 recursive-include duckdb-stubs *.pyi
 recursive-include duckdb
+include scripts/optional_requirements.py
+include requirements-dev.txt
 include pyproject.toml

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -40,3 +40,8 @@ test-command = "python -m pytest {project}/tests/fast --verbose"
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
 test-command = "python -m pytest {project}/tests/fast --verbose"
+
+# See https://github.com/duckdblabs/duckdb-internal/issues/1923 for context
+[[tool.cibuildwheel.overrides]]
+select = "macos*"
+before-test = 'python scripts/optional_requirements.py --exclude polars'

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -43,4 +43,4 @@ test-command = "python -m pytest {project}/tests/fast --verbose"
 
 # See https://github.com/duckdblabs/duckdb-internal/issues/1923 for context
 [tool.cibuildwheel.macos]
-before-test = 'python scripts/optional_requirements.py --exclude polars'
+before-test = 'python scripts/optional_requirements.py --exclude polars --exclude tensorflow'

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -18,7 +18,7 @@ local_scheme = "no-local-version"
 dependency-versions = "latest"
 environment = "PIP_CONSTRAINT='build-constraints.txt'"
 before-build = 'pip install oldest-supported-numpy'
-before-test = 'pip install --prefer-binary pandas pytest-timeout mypy "psutil>=5.9.0" "requests>=2.26" fsspec   && (pip install --prefer-binary "pyarrow>=8.0" || true) && (pip install --prefer-binary "torch" || true) && (pip install --prefer-binary "polars" || true) && (pip install --prefer-binary "adbc_driver_manager" || true) && (pip install --prefer-binary "tensorflow" || true)'
+before-test = 'python scripts/optional_requirements.py'
 test-requires = 'pytest'
 test-command = 'DUCKDB_PYTHON_TEST_EXTENSION_PATH={project} DUCKDB_PYTHON_TEST_EXTENSION_REQUIRED=1 python -m pytest {project}/tests --verbose'
 

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -42,6 +42,5 @@ archs = ["AMD64"]
 test-command = "python -m pytest {project}/tests/fast --verbose"
 
 # See https://github.com/duckdblabs/duckdb-internal/issues/1923 for context
-[[tool.cibuildwheel.overrides]]
-select = "macos*"
+[tool.cibuildwheel.macos]
 before-test = 'python scripts/optional_requirements.py --exclude polars'

--- a/tools/pythonpkg/requirements-dev.txt
+++ b/tools/pythonpkg/requirements-dev.txt
@@ -5,11 +5,12 @@ setuptools>=58
 pytest
 pandas
 pytest-timeout
-pyarrow>=8.0
 mypy
 psutil>=5.9.0
 requests>=2.26
 fsspec
-polars
+pyarrow>=8.0
 torch
+polars<0.20.22
+adbc_driver_manager
 tensorflow

--- a/tools/pythonpkg/requirements-dev.txt
+++ b/tools/pythonpkg/requirements-dev.txt
@@ -4,9 +4,12 @@ setuptools_scm>=6.3
 setuptools>=58
 pytest
 pandas
-pyarrow
+pytest-timeout
+pyarrow>=8.0
 mypy
 psutil>=5.9.0
+requests>=2.26
 fsspec
 polars
+torch
 tensorflow

--- a/tools/pythonpkg/scripts/optional_requirements.py
+++ b/tools/pythonpkg/scripts/optional_requirements.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+
+
+def install_package(package_name, is_optional):
+    try:
+        subprocess.run(['pip', 'install', '--prefer-binary', package_name], check=True)
+    except subprocess.CalledProcessError:
+        if is_optional:
+            print(f'WARNING: Failed to install (optional) "{package_name}", might require manual review')
+        raise
+
+
+if __name__ == "__main__":
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    requirements_path = os.path.join(script_dir, '..', 'requirements-dev.txt')
+
+    content = open(requirements_path).read()
+    packages = [x for x in content.split('\n') if x != '']
+
+    # Failing to install this package does not constitute a build failure
+    optional_packages = ["pyarrow", "torch", "polars", "adbc_driver_manager", "tensorflow"]
+
+    result = []
+    for package in packages:
+        package_name = package.replace('=', '>').split('>')[0]
+        is_optional = package_name in optional_packages
+        install_package(package, is_optional)

--- a/tools/pythonpkg/scripts/optional_requirements.py
+++ b/tools/pythonpkg/scripts/optional_requirements.py
@@ -24,6 +24,6 @@ if __name__ == "__main__":
 
     result = []
     for package in packages:
-        package_name = package.replace('=', '>').split('>')[0]
+        package_name = package.replace('=', '>').replace('<', '>').split('>')[0]
         is_optional = package_name in optional_packages
         install_package(package, is_optional)

--- a/tools/pythonpkg/scripts/optional_requirements.py
+++ b/tools/pythonpkg/scripts/optional_requirements.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import argparse
 
 
 def install_package(package_name, is_optional):
@@ -13,17 +14,30 @@ def install_package(package_name, is_optional):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Import test dependencies')
+    parser.add_argument('--exclude', action='append', help='Exclude a package from installation', default=[])
+
+    args = parser.parse_args()
+
+    # Failing to install this package does not constitute a build failure
+    OPTIONAL_PACKAGES = ["pyarrow", "torch", "polars", "adbc_driver_manager", "tensorflow"]
+
+    for package in args.exclude:
+        if package not in OPTIONAL_PACKAGES:
+            print(f"Unrecognized exclude list item '{package}', has to be one of {', '.join(OPTIONAL_PACKAGES)}")
+            exit(1)
+
     script_dir = os.path.dirname(os.path.abspath(__file__))
     requirements_path = os.path.join(script_dir, '..', 'requirements-dev.txt')
 
     content = open(requirements_path).read()
     packages = [x for x in content.split('\n') if x != '']
 
-    # Failing to install this package does not constitute a build failure
-    optional_packages = ["pyarrow", "torch", "polars", "adbc_driver_manager", "tensorflow"]
-
     result = []
     for package in packages:
         package_name = package.replace('=', '>').replace('<', '>').split('>')[0]
-        is_optional = package_name in optional_packages
+        if package_name in args.exclude:
+            print(f"Skipping {package_name}, as set by the --exclude option")
+            continue
+        is_optional = package_name in OPTIONAL_PACKAGES
         install_package(package, is_optional)

--- a/tools/pythonpkg/scripts/optional_requirements.py
+++ b/tools/pythonpkg/scripts/optional_requirements.py
@@ -8,6 +8,7 @@ def install_package(package_name, is_optional):
     except subprocess.CalledProcessError:
         if is_optional:
             print(f'WARNING: Failed to install (optional) "{package_name}", might require manual review')
+            return
         raise
 
 

--- a/tools/pythonpkg/tests/fast/api/test_connection_interrupt.py
+++ b/tools/pythonpkg/tests/fast/api/test_connection_interrupt.py
@@ -18,6 +18,7 @@ class TestConnectionInterrupt(object):
         thread.start()
         with pytest.raises(duckdb.InterruptException):
             conn.execute("select count(*) from range(1000000000)").fetchall()
+        thread.join()
 
     def test_interrupt_closed_connection(self):
         conn = duckdb.connect()

--- a/tools/pythonpkg/tests/fast/api/test_connection_interrupt.py
+++ b/tools/pythonpkg/tests/fast/api/test_connection_interrupt.py
@@ -17,7 +17,7 @@ class TestConnectionInterrupt(object):
         thread = threading.Thread(target=interrupt)
         thread.start()
         with pytest.raises(duckdb.InterruptException):
-            conn.execute("select count(*) from range(1000000000)").fetchall()
+            conn.execute("select count(*) from range(100000000000)").fetchall()
         thread.join()
 
     def test_interrupt_closed_connection(self):

--- a/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
+++ b/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
@@ -20,7 +20,7 @@ class TestQueryInterruption(object):
         # Start the thread
         thread.start()
         try:
-            res = con.execute('select count(*) from range(1000000000)').fetchall()
+            res = con.execute('select count(*) from range(100000000000)').fetchall()
         except RuntimeError:
             # If this is not reached, we could not cancel the query before it completed
             # indicating that the query interruption functionality is broken

--- a/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
+++ b/tools/pythonpkg/tests/fast/api/test_query_interrupt.py
@@ -27,3 +27,4 @@ class TestQueryInterruption(object):
             assert True
         except KeyboardInterrupt:
             pytest.fail()
+        thread.join()


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/1923

We limit our Polars build to 0.20.21 for now as we have detected a "Fatal Python error: Illegal instruction" problem.
This happens on python3.10, MacOS 10.12 x86_64 with wheel: `polars-0.20.22-cp38-abi3-macosx_10_12_x86_64.whl`

As the title says, I have taken the opportunity to fix some diverging install behaviors between development and CI.