### PR TITLE
Set secret directory to a test directory when running sqllogictest

### DIFF
--- a/test/sql/copy/s3/s3_hive_partition.test
+++ b/test/sql/copy/s3/s3_hive_partition.test
@@ -19,6 +19,9 @@ require-env DUCKDB_S3_ENDPOINT
 
 require-env DUCKDB_S3_USE_SSL
 
+# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
+set ignore_error_messages
+
 # Parquet filename name conflict
 statement ok
 CREATE TABLE test AS SELECT 1 as id, 'value1' as value;

--- a/test/sql/copy/s3/s3_hive_partition.test
+++ b/test/sql/copy/s3/s3_hive_partition.test
@@ -19,9 +19,6 @@ require-env DUCKDB_S3_ENDPOINT
 
 require-env DUCKDB_S3_USE_SSL
 
-# override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
-set ignore_error_messages
-
 # Parquet filename name conflict
 statement ok
 CREATE TABLE test AS SELECT 1 as id, 'value1' as value;

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -100,6 +100,7 @@ void SQLLogicTestRunner::Reconnect() {
 	if (original_sqlite_test) {
 		con->Query("SET integer_division=true");
 	}
+	con->Query("SET secret_directory='" + TestCreatePath("test_secret_dir") + "'");
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
 	con->Query("SET pivot_filter_threshold=0");
 #endif


### PR DESCRIPTION
This should ensure we don't read or write persistent secrets from the standard secret directory which can interfere with tests