### PR TITLE
Allow converting `TIMETZ` to Arrow not only by wasm

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -138,9 +138,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	case LogicalTypeId::DATE:
 		child.format = "tdD";
 		break;
-#ifdef DUCKDB_WASM
 	case LogicalTypeId::TIME_TZ:
-#endif
 	case LogicalTypeId::TIME:
 		child.format = "ttu";
 		break;

--- a/tools/pythonpkg/tests/fast/api/test_native_tz.py
+++ b/tools/pythonpkg/tests/fast/api/test_native_tz.py
@@ -68,7 +68,3 @@ class TestNativeTimeZone(object):
         res = duckdb_cursor.execute(f"select TimeRecStart as tz  from '{filename}'").arrow().to_pandas()
         assert res.dtypes["tz"].tz.zone == 'UTC'
         assert res['tz'][0].hour == 21 and res['tz'][0].minute == 52
-
-    def test_arrow_timestamp_time(self, duckdb_cursor):
-        with pytest.raises(duckdb.NotImplementedException, match="Unsupported Arrow type"):
-            duckdb_cursor.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").arrow()


### PR DESCRIPTION
Parquet `Time(isAdjustedForUTC=true, timeUnit=microseconds)` seems to be imported by `read_parquet` as `TIMETZ`. Not sure why that type was previously only accepted by wasm