### PR TITLE
Support `ALTER TABLE ADD PRIMARY KEY` statements

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -771,9 +771,9 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddConstraint(ClientContext &context, A
 
 	switch (info.constraint->type) {
 	case ConstraintType::UNIQUE: {
-		auto unique = reinterpret_cast<UniqueConstraint *>(info.constraint.get());
+		auto unique = info.constraint->Cast<UniqueConstraint>();
 
-		if (unique->is_primary_key) {
+		if (unique.is_primary_key) {
 			EnsureNoPrimaryKey();
 		}
 
@@ -797,8 +797,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddConstraint(ClientContext &context, A
 
 void DuckTableEntry::EnsureNoPrimaryKey() {
 	for (auto &constraint : constraints) {
-		if (constraint->type == ConstraintType::UNIQUE &&
-		    reinterpret_cast<UniqueConstraint *>(constraint.get())->is_primary_key) {
+		if (constraint->type == ConstraintType::UNIQUE && constraint->Cast<UniqueConstraint>().is_primary_key) {
 			throw CatalogException("table \"%s\" already has a %s.", name, constraint->ToString());
 		}
 	}

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -595,8 +595,8 @@ unique_ptr<CatalogEntry> DuckTableEntry::SetNotNull(ClientContext &context, SetN
 	}
 
 	// Return with new storage info. Note that we need the bound column index here.
-	auto new_storage = make_shared_ptr<DataTable>(
-	    context, *storage, make_uniq<BoundNotNullConstraint>(columns.LogicalToPhysical(LogicalIndex(not_null_idx))));
+	auto bound_constraint = make_uniq<BoundNotNullConstraint>(columns.LogicalToPhysical(LogicalIndex(not_null_idx)));
+	auto new_storage = make_shared_ptr<DataTable>(context, *storage, bound_constraint.get());
 	return make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, new_storage);
 }
 

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -46,8 +46,8 @@ vector<reference<const ColumnDefinition>> GetUniqueConstraintKeys(const ColumnLi
 
 DuckTableEntry::DuckTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, BoundCreateTableInfo &info,
                                shared_ptr<DataTable> inherited_storage)
-	: TableCatalogEntry(catalog, schema, info.Base()), storage(std::move(inherited_storage)),
-	  column_dependency_manager(std::move(info.column_dependency_manager)) {
+    : TableCatalogEntry(catalog, schema, info.Base()), storage(std::move(inherited_storage)),
+      column_dependency_manager(std::move(info.column_dependency_manager)) {
 
 	if (!storage) {
 		// create the physical storage
@@ -56,8 +56,8 @@ DuckTableEntry::DuckTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, Bou
 			storage_columns.push_back(col_def.Copy());
 		}
 		storage =
-			make_shared_ptr<DataTable>(catalog.GetAttached(), StorageManager::Get(catalog).GetTableIOManager(&info),
-			                           schema.name, name, std::move(storage_columns), std::move(info.data));
+		    make_shared_ptr<DataTable>(catalog.GetAttached(), StorageManager::Get(catalog).GetTableIOManager(&info),
+		                               schema.name, name, std::move(storage_columns), std::move(info.data));
 
 		// create the unique indexes for the UNIQUE and PRIMARY KEY and FOREIGN KEY constraints
 		idx_t indexes_idx = 0;
@@ -241,7 +241,7 @@ static void RenameExpression(ParsedExpression &expr, RenameColumnInfo &info) {
 		}
 	}
 	ParsedExpressionIterator::EnumerateChildren(
-		expr, [&](const ParsedExpression &child) { RenameExpression((ParsedExpression &)child, info); });
+	    expr, [&](const ParsedExpression &child) { RenameExpression((ParsedExpression &)child, info); });
 }
 
 unique_ptr<CatalogEntry> DuckTableEntry::RenameColumn(ClientContext &context, RenameColumnInfo &info) {
@@ -299,8 +299,8 @@ unique_ptr<CatalogEntry> DuckTableEntry::RenameColumn(ClientContext &context, Re
 			for (idx_t i = 0; i < columns.size(); i++) {
 				if (columns[i] == info.old_name) {
 					throw CatalogException(
-						"Cannot rename column \"%s\" because this is involved in the foreign key constraint",
-						info.old_name);
+					    "Cannot rename column \"%s\" because this is involved in the foreign key constraint",
+					    info.old_name);
 				}
 			}
 			break;
@@ -385,8 +385,8 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
 				if (bound_check.bound_columns.size() > 1) {
 					// CHECK constraint that concerns mult
 					throw CatalogException(
-						"Cannot drop column \"%s\" because there is a CHECK constraint that depends on it",
-						info.removed_column);
+					    "Cannot drop column \"%s\" because there is a CHECK constraint that depends on it",
+					    info.removed_column);
 				} else {
 					// CHECK constraint that ONLY concerns this column, strip the constraint
 				}
@@ -402,8 +402,8 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
 			if (unique.HasIndex()) {
 				if (unique.GetIndex() == removed_index) {
 					throw CatalogException(
-						"Cannot drop column \"%s\" because there is a UNIQUE constraint that depends on it",
-						info.removed_column);
+					    "Cannot drop column \"%s\" because there is a UNIQUE constraint that depends on it",
+					    info.removed_column);
 				}
 				unique.SetIndex(adjusted_indices[unique.GetIndex().index]);
 			}
@@ -424,8 +424,8 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
 			for (idx_t i = 0; i < columns.size(); i++) {
 				if (columns[i] == info.removed_column) {
 					throw CatalogException(
-						"Cannot drop column \"%s\" because there is a FOREIGN KEY constraint that depends on it",
-						info.removed_column);
+					    "Cannot drop column \"%s\" because there is a FOREIGN KEY constraint that depends on it",
+					    info.removed_column);
 				}
 			}
 			create_info.constraints.push_back(std::move(copy));
@@ -484,7 +484,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::RemoveColumn(ClientContext &context, Re
 		return make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, storage);
 	}
 	auto new_storage =
-		make_shared_ptr<DataTable>(context, *storage, columns.LogicalToPhysical(LogicalIndex(removed_index)).index);
+	    make_shared_ptr<DataTable>(context, *storage, columns.LogicalToPhysical(LogicalIndex(removed_index)).index);
 	return make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, new_storage);
 }
 
@@ -604,8 +604,8 @@ unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context
 		// TODO: check if the generated_expression breaks, only delete it if it does
 		if (copy.Generated() && column_dependency_manager.IsDependencyOf(col.Logical(), change_idx)) {
 			throw BinderException(
-				"This column is referenced by the generated column \"%s\", so its type can not be changed",
-				copy.Name());
+			    "This column is referenced by the generated column \"%s\", so its type can not be changed",
+			    copy.Name());
 		}
 		create_info->columns.AddColumn(std::move(copy));
 	}
@@ -628,7 +628,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context
 			auto physical_index = columns.LogicalToPhysical(change_idx);
 			if (bound_unique.key_set.find(physical_index) != bound_unique.key_set.end()) {
 				throw BinderException(
-					"Cannot change the type of a column that has a UNIQUE or PRIMARY KEY constraint specified");
+				    "Cannot change the type of a column that has a UNIQUE or PRIMARY KEY constraint specified");
 			}
 			break;
 		}
@@ -666,8 +666,8 @@ unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context
 	}
 
 	auto new_storage =
-		make_shared_ptr<DataTable>(context, *storage, columns.LogicalToPhysical(LogicalIndex(change_idx)).index,
-		                           info.target_type, std::move(storage_oids), *bound_expression);
+	    make_shared_ptr<DataTable>(context, *storage, columns.LogicalToPhysical(LogicalIndex(change_idx)).index,
+	                               info.target_type, std::move(storage_oids), *bound_expression);
 	auto result = make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, new_storage);
 	return std::move(result);
 }
@@ -719,7 +719,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddForeignKeyConstraint(optional_ptr<Cl
 	fk_info.pk_keys = info.pk_keys;
 	fk_info.fk_keys = info.fk_keys;
 	create_info->constraints.push_back(
-		make_uniq<ForeignKeyConstraint>(info.pk_columns, info.fk_columns, std::move(fk_info)));
+	    make_uniq<ForeignKeyConstraint>(info.pk_columns, info.fk_columns, std::move(fk_info)));
 
 	unique_ptr<BoundCreateTableInfo> bound_create_info;
 	if (context) {

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -771,8 +771,11 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddConstraint(ClientContext &context, A
 	case ConstraintType::UNIQUE: {
 		const auto unique = info.constraint->Cast<UniqueConstraint>();
 
-		if (unique.is_primary_key && HasPrimaryKey()) {
-			throw CatalogException("table \"%s\" already has a %s.", name, unique.ToString());
+		const auto existing_primary_key = GetPrimaryKey();
+		if (unique.is_primary_key && existing_primary_key != nullptr) {
+			throw CatalogException("table \"%s\" can have only one primary key, "
+			                       "and already has %s.",
+			                       name, existing_primary_key->ToString());
 		}
 
 		create_info->constraints.push_back(info.constraint->Copy());

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -316,16 +316,20 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	}
 }
 
-bool TableCatalogEntry::HasPrimaryKey() const {
+Constraint *TableCatalogEntry::GetPrimaryKey() const {
 	for (const auto &constraint : GetConstraints()) {
 		if (constraint->type == ConstraintType::UNIQUE) {
 			auto &unique = constraint->Cast<UniqueConstraint>();
 			if (unique.IsPrimaryKey()) {
-				return true;
+				return &unique;
 			}
 		}
 	}
-	return false;
+	return nullptr;
+}
+
+bool TableCatalogEntry::HasPrimaryKey() const {
+	return GetPrimaryKey() != nullptr;
 }
 
 } // namespace duckdb

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -316,4 +316,16 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	}
 }
 
+bool TableCatalogEntry::HasPrimaryKey() const {
+	for (const auto &constraint : GetConstraints()) {
+		if (constraint->type == ConstraintType::UNIQUE) {
+			auto &unique = constraint->Cast<UniqueConstraint>();
+			if (unique.IsPrimaryKey()) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 } // namespace duckdb

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -361,6 +361,8 @@ const char* EnumUtil::ToChars<AlterTableType>(AlterTableType value) {
 		return "DROP_NOT_NULL";
 	case AlterTableType::SET_COLUMN_COMMENT:
 		return "SET_COLUMN_COMMENT";
+	case AlterTableType::ADD_CONSTRAINT:
+		return "ADD_CONSTRAINT";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
 	}
@@ -400,6 +402,9 @@ AlterTableType EnumUtil::FromString<AlterTableType>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "SET_COLUMN_COMMENT")) {
 		return AlterTableType::SET_COLUMN_COMMENT;
+	}
+	if (StringUtil::Equals(value, "ADD_CONSTRAINT")) {
+		return AlterTableType::ADD_CONSTRAINT;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/function/table/system/duckdb_columns.cpp
+++ b/src/function/table/system/duckdb_columns.cpp
@@ -115,7 +115,7 @@ public:
 	explicit TableColumnHelper(TableCatalogEntry &entry) : entry(entry) {
 		for (auto &constraint : entry.GetConstraints()) {
 			if (constraint->type == ConstraintType::NOT_NULL) {
-				auto &not_null = *reinterpret_cast<NotNullConstraint *>(constraint.get());
+				auto &not_null = constraint->Cast<NotNullConstraint>();
 				not_null_cols.insert(not_null.index.index);
 			}
 		}

--- a/src/function/table/system/duckdb_tables.cpp
+++ b/src/function/table/system/duckdb_tables.cpp
@@ -86,18 +86,6 @@ unique_ptr<GlobalTableFunctionState> DuckDBTablesInit(ClientContext &context, Ta
 	return std::move(result);
 }
 
-static bool TableHasPrimaryKey(TableCatalogEntry &table) {
-	for (auto &constraint : table.GetConstraints()) {
-		if (constraint->type == ConstraintType::UNIQUE) {
-			auto &unique = constraint->Cast<UniqueConstraint>();
-			if (unique.IsPrimaryKey()) {
-				return true;
-			}
-		}
-	}
-	return false;
-}
-
 static idx_t CheckConstraintCount(TableCatalogEntry &table) {
 	idx_t check_count = 0;
 	for (auto &constraint : table.GetConstraints()) {
@@ -148,7 +136,7 @@ void DuckDBTablesFunction(ClientContext &context, TableFunctionInput &data_p, Da
 		// temporary, LogicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(table.temporary));
 		// has_primary_key, LogicalType::BOOLEAN
-		output.SetValue(col++, count, Value::BOOLEAN(TableHasPrimaryKey(table)));
+		output.SetValue(col++, count, Value::BOOLEAN(table.HasPrimaryKey()));
 		// estimated_size, LogicalType::BIGINT
 
 		Value card_val = !storage_info.cardinality.IsValid()

--- a/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
@@ -61,9 +61,6 @@ private:
 	unique_ptr<CatalogEntry> SetColumnComment(ClientContext &context, SetColumnCommentInfo &info);
 	unique_ptr<CatalogEntry> AddConstraint(ClientContext &context, AddConstraintInfo &info);
 
-	// Checks if a primary key constraint already exists and throws if it does.
-	void EnsureNoPrimaryKey();
-
 	void UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_index, const vector<LogicalIndex> &adjusted_indices,
 	                                   const RemoveColumnInfo &info, CreateTableInfo &create_info,
 	                                   const vector<unique_ptr<BoundConstraint>> &bound_constraints, bool is_generated);

--- a/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/parser/constraints/unique_constraint.hpp"
+#include "duckdb/planner/constraints/bound_unique_constraint.hpp"
 
 namespace duckdb {
 
@@ -57,6 +59,10 @@ private:
 	unique_ptr<CatalogEntry> AddForeignKeyConstraint(optional_ptr<ClientContext> context, AlterForeignKeyInfo &info);
 	unique_ptr<CatalogEntry> DropForeignKeyConstraint(ClientContext &context, AlterForeignKeyInfo &info);
 	unique_ptr<CatalogEntry> SetColumnComment(ClientContext &context, SetColumnCommentInfo &info);
+	unique_ptr<CatalogEntry> AddConstraint(ClientContext &context, AddConstraintInfo &info);
+
+	// Checks if a primary key constraint already exists and throws if it does.
+	void EnsureNoPrimaryKey();
 
 	void UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_index, const vector<LogicalIndex> &adjusted_indices,
 	                                   const RemoveColumnInfo &info, CreateTableInfo &create_info,

--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -108,6 +108,8 @@ public:
 	virtual void BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj, LogicalUpdate &update,
 	                                   ClientContext &context);
 
+	bool HasPrimaryKey() const;
+
 protected:
 	//! A list of columns that are part of this table
 	ColumnList columns;

--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -33,6 +33,7 @@ struct AlterForeignKeyInfo;
 struct SetNotNullInfo;
 struct DropNotNullInfo;
 struct SetColumnCommentInfo;
+struct AddConstraintInfo;
 
 class TableFunction;
 struct FunctionData;

--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -108,6 +108,7 @@ public:
 	virtual void BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj, LogicalUpdate &update,
 	                                   ClientContext &context);
 
+	Constraint *GetPrimaryKey() const;
 	bool HasPrimaryKey() const;
 
 protected:

--- a/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
@@ -73,7 +73,8 @@ enum class AlterTableType : uint8_t {
 	FOREIGN_KEY_CONSTRAINT = 7,
 	SET_NOT_NULL = 8,
 	DROP_NOT_NULL = 9,
-	SET_COLUMN_COMMENT = 10
+	SET_COLUMN_COMMENT = 10,
+	ADD_CONSTRAINT = 11
 };
 
 struct AlterTableInfo : public AlterInfo {
@@ -339,6 +340,26 @@ public:
 
 private:
 	RenameViewInfo();
+};
+
+//===--------------------------------------------------------------------===//
+// AddConstraintInfo
+//===--------------------------------------------------------------------===//
+struct AddConstraintInfo : public AlterTableInfo {
+	AddConstraintInfo(AlterEntryData data, unique_ptr<Constraint> constraint);
+	~AddConstraintInfo() override;
+
+	//! The constraint to add
+	unique_ptr<Constraint> constraint;
+
+public:
+	unique_ptr<AlterInfo> Copy() const override;
+	string ToString() const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AlterTableInfo> Deserialize(Deserializer &deserializer);
+
+private:
+	AddConstraintInfo();
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -257,8 +257,9 @@ private:
 	//===--------------------------------------------------------------------===//
 	// Constraints transform
 	//===--------------------------------------------------------------------===//
-	unique_ptr<Constraint> TransformConstraint(duckdb_libpgquery::PGListCell &cell);
-	unique_ptr<Constraint> TransformConstraint(duckdb_libpgquery::PGListCell &cell, ColumnDefinition &column,
+	unique_ptr<Constraint> TransformConstraint(duckdb_libpgquery::PGConstraint *constraint);
+
+	unique_ptr<Constraint> TransformConstraint(duckdb_libpgquery::PGConstraint *constraint, ColumnDefinition &column,
 	                                           idx_t index);
 
 	//===--------------------------------------------------------------------===//

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -132,7 +132,8 @@ public:
 	vector<unique_ptr<BoundConstraint>> BindNewConstraints(vector<unique_ptr<Constraint>> &constraints,
 	                                                       const string &table_name, const ColumnList &columns);
 
-	unique_ptr<BoundConstraint> BindConstraint(Constraint &constraint, const string &table_name, const ColumnList &columns);
+	unique_ptr<BoundConstraint> BindConstraint(Constraint &constraint, const string &table_name,
+	                                           const ColumnList &columns);
 
 	void SetCatalogLookupCallback(catalog_entry_callback_t callback);
 	void BindCreateViewInfo(CreateViewInfo &base);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -24,6 +24,7 @@
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/joinside.hpp"
 #include "duckdb/common/reference_map.hpp"
+#include "duckdb/planner/bound_constraint.hpp"
 
 namespace duckdb {
 class BoundResultModifier;
@@ -47,7 +48,6 @@ class BoundConstraint;
 
 struct CreateInfo;
 struct BoundCreateTableInfo;
-struct BoundCreateFunctionInfo;
 struct CommonTableExpressionInfo;
 struct BoundParameterMap;
 struct BoundPragmaInfo;
@@ -131,6 +131,8 @@ public:
 	vector<unique_ptr<BoundConstraint>> BindConstraints(const TableCatalogEntry &table);
 	vector<unique_ptr<BoundConstraint>> BindNewConstraints(vector<unique_ptr<Constraint>> &constraints,
 	                                                       const string &table_name, const ColumnList &columns);
+
+	unique_ptr<BoundConstraint> BindConstraint(Constraint &constraint, const string &table_name, const ColumnList &columns);
 
 	void SetCatalogLookupCallback(catalog_entry_callback_t callback);
 	void BindCreateViewInfo(CreateViewInfo &base);

--- a/src/include/duckdb/planner/bound_constraint.hpp
+++ b/src/include/duckdb/planner/bound_constraint.hpp
@@ -22,6 +22,8 @@ public:
 
 	ConstraintType type;
 
+	virtual vector<PhysicalIndex> GetColumnIndices() const = 0;
+
 public:
 	template <class TARGET>
 	TARGET &Cast() {

--- a/src/include/duckdb/planner/constraints/bound_check_constraint.hpp
+++ b/src/include/duckdb/planner/constraints/bound_check_constraint.hpp
@@ -25,6 +25,14 @@ public:
 	BoundCheckConstraint() : BoundConstraint(ConstraintType::CHECK) {
 	}
 
+	vector<PhysicalIndex> GetColumnIndices() const final {
+		vector<PhysicalIndex> indexes;
+		for (const auto &index : bound_columns) {
+			indexes.push_back(index);
+		}
+		return indexes;
+	}
+
 	//! The expression
 	unique_ptr<Expression> expression;
 	//! The columns used by the CHECK constraint

--- a/src/include/duckdb/planner/constraints/bound_foreign_key_constraint.hpp
+++ b/src/include/duckdb/planner/constraints/bound_foreign_key_constraint.hpp
@@ -35,6 +35,11 @@ public:
 #endif
 	}
 
+	vector<PhysicalIndex> GetColumnIndices() const final {
+		// Use the vector as it is ordered
+		return info.fk_keys;
+	}
+
 	ForeignKeyInfo info;
 	//! The same keys but stored as an unordered set
 	physical_index_set_t pk_key_set;

--- a/src/include/duckdb/planner/constraints/bound_not_null_constraint.hpp
+++ b/src/include/duckdb/planner/constraints/bound_not_null_constraint.hpp
@@ -21,7 +21,7 @@ public:
 	}
 
 	vector<PhysicalIndex> GetColumnIndices() const final {
-	    return vector<PhysicalIndex>{index};
+		return vector<PhysicalIndex> {index};
 	}
 
 	//! Column index this constraint pertains to

--- a/src/include/duckdb/planner/constraints/bound_not_null_constraint.hpp
+++ b/src/include/duckdb/planner/constraints/bound_not_null_constraint.hpp
@@ -20,6 +20,10 @@ public:
 	explicit BoundNotNullConstraint(PhysicalIndex index) : BoundConstraint(ConstraintType::NOT_NULL), index(index) {
 	}
 
+	vector<PhysicalIndex> GetColumnIndices() const final {
+	    return vector<PhysicalIndex>{index};
+	}
+
 	//! Column index this constraint pertains to
 	PhysicalIndex index;
 };

--- a/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
+++ b/src/include/duckdb/planner/constraints/bound_unique_constraint.hpp
@@ -19,7 +19,7 @@ public:
 	static constexpr const ConstraintType TYPE = ConstraintType::UNIQUE;
 
 public:
-	BoundUniqueConstraint(vector<LogicalIndex> keys, logical_index_set_t key_set, bool is_primary_key)
+	BoundUniqueConstraint(vector<PhysicalIndex> keys, physical_index_set_t key_set, bool is_primary_key)
 	    : BoundConstraint(ConstraintType::UNIQUE), keys(std::move(keys)), key_set(std::move(key_set)),
 	      is_primary_key(is_primary_key) {
 #ifdef DEBUG
@@ -30,10 +30,14 @@ public:
 #endif
 	}
 
+	vector<PhysicalIndex> GetColumnIndices() const final {
+		return keys;
+	}
+
 	//! The keys that define the unique constraint
-	vector<LogicalIndex> keys;
+	vector<PhysicalIndex> keys;
 	//! The same keys but stored as an unordered set
-	logical_index_set_t key_set;
+	physical_index_set_t key_set;
 	//! Whether or not the unique constraint is a primary key
 	bool is_primary_key;
 };

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -225,13 +225,17 @@ public:
 
 	TableStorageInfo GetStorageInfo();
 
-public:
 	static void VerifyUniqueIndexes(TableIndexList &indexes, ClientContext &context, DataChunk &chunk,
 	                                optional_ptr<ConflictManager> conflict_manager);
 
-private:
 	//! Verify the new added constraints against current persistent&local data
 	void VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint);
+	void VerifyNewConstraint(ClientContext &context, DataTable &parent, const BoundConstraint &constraint);
+
+	void AddConstraintIndex(const vector<const ColumnDefinition*> &columns, IndexConstraintType constraint_type,
+						   const IndexStorageInfo &index_info = IndexStorageInfo());
+
+private:
 	//! Verify constraints with a chunk from the Update containing only the specified column_ids
 	void VerifyUpdateConstraints(ConstraintState &state, ClientContext &context, DataChunk &chunk,
 	                             const vector<PhysicalIndex> &column_ids);

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -9,11 +9,8 @@
 #pragma once
 
 #include "duckdb/common/enums/index_constraint_type.hpp"
-#include "duckdb/common/enums/scan_options.hpp"
-#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/unique_ptr.hpp"
-#include "duckdb/storage/block.hpp"
 #include "duckdb/storage/index.hpp"
 #include "duckdb/storage/statistics/column_statistics.hpp"
 #include "duckdb/storage/table/column_segment.hpp"
@@ -24,245 +21,254 @@
 #include "duckdb/storage/table/table_statistics.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 
-namespace duckdb {
-class BoundForeignKeyConstraint;
-class ClientContext;
-class ColumnDataCollection;
-class ColumnDefinition;
-class DataTable;
-class DuckTransaction;
-class OptimisticDataWriter;
-class RowGroup;
-class StorageManager;
-class TableCatalogEntry;
-class TableIOManager;
-class Transaction;
-class WriteAheadLog;
-class TableDataWriter;
-class ConflictManager;
-class TableScanState;
-struct TableDeleteState;
-struct ConstraintState;
-struct TableUpdateState;
-enum class VerifyExistenceType : uint8_t;
+namespace duckdb
+{
+	class BoundForeignKeyConstraint;
+	class ClientContext;
+	class ColumnDataCollection;
+	class ColumnDefinition;
+	class DataTable;
+	class DuckTransaction;
+	class OptimisticDataWriter;
+	class RowGroup;
+	class StorageManager;
+	class TableCatalogEntry;
+	class TableIOManager;
+	class Transaction;
+	class WriteAheadLog;
+	class TableDataWriter;
+	class ConflictManager;
+	class TableScanState;
+	struct TableDeleteState;
+	struct ConstraintState;
+	struct TableUpdateState;
+	enum class VerifyExistenceType : uint8_t;
 
-//! DataTable represents a physical table on disk
-class DataTable {
-public:
-	//! Constructs a new data table from an (optional) set of persistent segments
-	DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_manager, const string &schema,
-	          const string &table, vector<ColumnDefinition> column_definitions_p,
-	          unique_ptr<PersistentTableData> data = nullptr);
-	//! Constructs a DataTable as a delta on an existing data table with a newly added column
-	DataTable(ClientContext &context, DataTable &parent, ColumnDefinition &new_column, Expression &default_value);
-	//! Constructs a DataTable as a delta on an existing data table but with one column removed
-	DataTable(ClientContext &context, DataTable &parent, idx_t removed_column);
-	//! Constructs a DataTable as a delta on an existing data table but with one column changed type
-	DataTable(ClientContext &context, DataTable &parent, idx_t changed_idx, const LogicalType &target_type,
-	          const vector<column_t> &bound_columns, Expression &cast_expr);
-	//! Constructs a DataTable as a delta on an existing data table but with one column added new constraint
-	explicit DataTable(ClientContext &context, DataTable &parent, unique_ptr<BoundConstraint> constraint);
+	//! DataTable represents a physical table on disk
+	class DataTable
+	{
+	public:
+		//! Constructs a new data table from an (optional) set of persistent segments
+		DataTable(AttachedDatabase& db, shared_ptr<TableIOManager> table_io_manager, const string& schema,
+		          const string& table, vector<ColumnDefinition> column_definitions_p,
+		          unique_ptr<PersistentTableData> data = nullptr);
+		//! Constructs a DataTable as a delta on an existing data table with a newly added column
+		DataTable(ClientContext& context, DataTable& parent, ColumnDefinition& new_column, Expression& default_value);
+		//! Constructs a DataTable as a delta on an existing data table but with one column removed
+		DataTable(ClientContext& context, DataTable& parent, idx_t removed_column);
+		//! Constructs a DataTable as a delta on an existing data table but with one column changed type
+		DataTable(ClientContext& context, DataTable& parent, idx_t changed_idx, const LogicalType& target_type,
+		          const vector<column_t>& bound_columns, Expression& cast_expr);
+		//! Constructs a DataTable as a delta on an existing data table but with one column added new constraint
+		explicit DataTable(ClientContext& context, DataTable& parent, BoundConstraint& constraint);
 
-	//! A reference to the database instance
-	AttachedDatabase &db;
+		//! A reference to the database instance
+		AttachedDatabase& db;
 
-public:
-	AttachedDatabase &GetAttached();
-	TableIOManager &GetTableIOManager();
+	public:
+		AttachedDatabase& GetAttached();
+		TableIOManager& GetTableIOManager();
 
-	bool IsTemporary() const;
+		bool IsTemporary() const;
 
-	//! Returns a list of types of the table
-	vector<LogicalType> GetTypes();
-	const vector<ColumnDefinition> &Columns() const;
+		//! Returns a list of types of the table
+		vector<LogicalType> GetTypes();
+		const vector<ColumnDefinition>& Columns() const;
 
-	void InitializeScan(TableScanState &state, const vector<column_t> &column_ids,
-	                    TableFilterSet *table_filter = nullptr);
-	void InitializeScan(DuckTransaction &transaction, TableScanState &state, const vector<column_t> &column_ids,
-	                    TableFilterSet *table_filters = nullptr);
+		void InitializeScan(TableScanState& state, const vector<column_t>& column_ids,
+		                    TableFilterSet* table_filter = nullptr);
+		void InitializeScan(DuckTransaction& transaction, TableScanState& state, const vector<column_t>& column_ids,
+		                    TableFilterSet* table_filters = nullptr);
 
-	//! Returns the maximum amount of threads that should be assigned to scan this data table
-	idx_t MaxThreads(ClientContext &context);
-	void InitializeParallelScan(ClientContext &context, ParallelTableScanState &state);
-	bool NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state);
+		//! Returns the maximum amount of threads that should be assigned to scan this data table
+		idx_t MaxThreads(ClientContext& context);
+		void InitializeParallelScan(ClientContext& context, ParallelTableScanState& state);
+		bool NextParallelScan(ClientContext& context, ParallelTableScanState& state, TableScanState& scan_state);
 
-	//! Scans up to STANDARD_VECTOR_SIZE elements from the table starting
-	//! from offset and store them in result. Offset is incremented with how many
-	//! elements were returned.
-	//! Returns true if all pushed down filters were executed during data fetching
-	void Scan(DuckTransaction &transaction, DataChunk &result, TableScanState &state);
+		//! Scans up to STANDARD_VECTOR_SIZE elements from the table starting
+		//! from offset and store them in result. Offset is incremented with how many
+		//! elements were returned.
+		//! Returns true if all pushed down filters were executed during data fetching
+		void Scan(DuckTransaction& transaction, DataChunk& result, TableScanState& state);
 
-	//! Fetch data from the specific row identifiers from the base table
-	void Fetch(DuckTransaction &transaction, DataChunk &result, const vector<column_t> &column_ids,
-	           const Vector &row_ids, idx_t fetch_count, ColumnFetchState &state);
+		//! Fetch data from the specific row identifiers from the base table
+		void Fetch(DuckTransaction& transaction, DataChunk& result, const vector<column_t>& column_ids,
+		           const Vector& row_ids, idx_t fetch_count, ColumnFetchState& state);
 
-	//! Initializes an append to transaction-local storage
-	void InitializeLocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
-	                           const vector<unique_ptr<BoundConstraint>> &bound_constraints);
-	//! Append a DataChunk to the transaction-local storage of the table.
-	void LocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
-	                 bool unsafe = false);
-	//! Finalizes a transaction-local append
-	void FinalizeLocalAppend(LocalAppendState &state);
-	//! Append a chunk to the transaction-local storage of this table
-	void LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
-	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints);
-	//! Append a column data collection to the transaction-local storage of this table
-	void LocalAppend(TableCatalogEntry &table, ClientContext &context, ColumnDataCollection &collection,
-	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints);
-	//! Merge a row group collection into the transaction-local storage
-	void LocalMerge(ClientContext &context, RowGroupCollection &collection);
-	//! Creates an optimistic writer for this table - used for optimistically writing parallel appends
-	OptimisticDataWriter &CreateOptimisticWriter(ClientContext &context);
-	void FinalizeOptimisticWriter(ClientContext &context, OptimisticDataWriter &writer);
+		//! Initializes an append to transaction-local storage
+		void InitializeLocalAppend(LocalAppendState& state, TableCatalogEntry& table, ClientContext& context,
+		                           const vector<unique_ptr<BoundConstraint>>& bound_constraints);
+		//! Append a DataChunk to the transaction-local storage of the table.
+		void LocalAppend(LocalAppendState& state, TableCatalogEntry& table, ClientContext& context, DataChunk& chunk,
+		                 bool unsafe = false);
+		//! Finalizes a transaction-local append
+		void FinalizeLocalAppend(LocalAppendState& state);
+		//! Append a chunk to the transaction-local storage of this table
+		void LocalAppend(TableCatalogEntry& table, ClientContext& context, DataChunk& chunk,
+		                 const vector<unique_ptr<BoundConstraint>>& bound_constraints);
+		//! Append a column data collection to the transaction-local storage of this table
+		void LocalAppend(TableCatalogEntry& table, ClientContext& context, ColumnDataCollection& collection,
+		                 const vector<unique_ptr<BoundConstraint>>& bound_constraints);
+		//! Merge a row group collection into the transaction-local storage
+		void LocalMerge(ClientContext& context, RowGroupCollection& collection);
+		//! Creates an optimistic writer for this table - used for optimistically writing parallel appends
+		OptimisticDataWriter& CreateOptimisticWriter(ClientContext& context);
+		void FinalizeOptimisticWriter(ClientContext& context, OptimisticDataWriter& writer);
 
-	unique_ptr<TableDeleteState> InitializeDelete(TableCatalogEntry &table, ClientContext &context,
-	                                              const vector<unique_ptr<BoundConstraint>> &bound_constraints);
-	//! Delete the entries with the specified row identifier from the table
-	idx_t Delete(TableDeleteState &state, ClientContext &context, Vector &row_ids, idx_t count);
+		unique_ptr<TableDeleteState> InitializeDelete(TableCatalogEntry& table, ClientContext& context,
+		                                              const vector<unique_ptr<BoundConstraint>>& bound_constraints);
+		//! Delete the entries with the specified row identifier from the table
+		idx_t Delete(TableDeleteState& state, ClientContext& context, Vector& row_ids, idx_t count);
 
-	unique_ptr<TableUpdateState> InitializeUpdate(TableCatalogEntry &table, ClientContext &context,
-	                                              const vector<unique_ptr<BoundConstraint>> &bound_constraints);
-	//! Update the entries with the specified row identifier from the table
-	void Update(TableUpdateState &state, ClientContext &context, Vector &row_ids,
-	            const vector<PhysicalIndex> &column_ids, DataChunk &data);
-	//! Update a single (sub-)column along a column path
-	//! The column_path vector is a *path* towards a column within the table
-	//! i.e. if we have a table with a single column S STRUCT(A INT, B INT)
-	//! and we update the validity mask of "S.B"
-	//! the column path is:
-	//! 0 (first column of table)
-	//! -> 1 (second subcolumn of struct)
-	//! -> 0 (first subcolumn of INT)
-	//! This method should only be used from the WAL replay. It does not verify update constraints.
-	void UpdateColumn(TableCatalogEntry &table, ClientContext &context, Vector &row_ids,
-	                  const vector<column_t> &column_path, DataChunk &updates);
+		unique_ptr<TableUpdateState> InitializeUpdate(TableCatalogEntry& table, ClientContext& context,
+		                                              const vector<unique_ptr<BoundConstraint>>& bound_constraints);
+		//! Update the entries with the specified row identifier from the table
+		void Update(TableUpdateState& state, ClientContext& context, Vector& row_ids,
+		            const vector<PhysicalIndex>& column_ids, DataChunk& data);
+		//! Update a single (sub-)column along a column path
+		//! The column_path vector is a *path* towards a column within the table
+		//! i.e. if we have a table with a single column S STRUCT(A INT, B INT)
+		//! and we update the validity mask of "S.B"
+		//! the column path is:
+		//! 0 (first column of table)
+		//! -> 1 (second subcolumn of struct)
+		//! -> 0 (first subcolumn of INT)
+		//! This method should only be used from the WAL replay. It does not verify update constraints.
+		void UpdateColumn(TableCatalogEntry& table, ClientContext& context, Vector& row_ids,
+		                  const vector<column_t>& column_path, DataChunk& updates);
 
-	//! Fetches an append lock
-	void AppendLock(TableAppendState &state);
-	//! Begin appending structs to this table, obtaining necessary locks, etc
-	void InitializeAppend(DuckTransaction &transaction, TableAppendState &state);
-	//! Append a chunk to the table using the AppendState obtained from InitializeAppend
-	void Append(DataChunk &chunk, TableAppendState &state);
-	//! Finalize an append
-	void FinalizeAppend(DuckTransaction &transaction, TableAppendState &state);
-	//! Commit the append
-	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
-	//! Write a segment of the table to the WAL
-	void WriteToLog(WriteAheadLog &log, idx_t row_start, idx_t count);
-	//! Revert a set of appends made by the given AppendState, used to revert appends in the event of an error during
-	//! commit (e.g. because of an I/O exception)
-	void RevertAppend(idx_t start_row, idx_t count);
-	void RevertAppendInternal(idx_t start_row);
+		//! Fetches an append lock
+		void AppendLock(TableAppendState& state);
+		//! Begin appending structs to this table, obtaining necessary locks, etc
+		void InitializeAppend(DuckTransaction& transaction, TableAppendState& state);
+		//! Append a chunk to the table using the AppendState obtained from InitializeAppend
+		void Append(DataChunk& chunk, TableAppendState& state);
+		//! Finalize an append
+		void FinalizeAppend(DuckTransaction& transaction, TableAppendState& state);
+		//! Commit the append
+		void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
+		//! Write a segment of the table to the WAL
+		void WriteToLog(WriteAheadLog& log, idx_t row_start, idx_t count);
+		//! Revert a set of appends made by the given AppendState, used to revert appends in the event of an error during
+		//! commit (e.g. because of an I/O exception)
+		void RevertAppend(idx_t start_row, idx_t count);
+		void RevertAppendInternal(idx_t start_row);
 
-	void ScanTableSegment(idx_t start_row, idx_t count, const std::function<void(DataChunk &chunk)> &function);
+		void ScanTableSegment(idx_t start_row, idx_t count, const std::function<void(DataChunk& chunk)>& function);
 
-	//! Merge a row group collection directly into this table - appending it to the end of the table without copying
-	void MergeStorage(RowGroupCollection &data, TableIndexList &indexes);
+		//! Merge a row group collection directly into this table - appending it to the end of the table without copying
+		void MergeStorage(RowGroupCollection& data, TableIndexList& indexes);
 
-	//! Append a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table, returns
-	//! whether or not the append succeeded
-	ErrorData AppendToIndexes(DataChunk &chunk, row_t row_start);
-	static ErrorData AppendToIndexes(TableIndexList &indexes, DataChunk &chunk, row_t row_start);
-	//! Remove a chunk with the row ids [row_start, ..., row_start + chunk.size()] from all indexes of the table
-	void RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, row_t row_start);
-	//! Remove the chunk with the specified set of row identifiers from all indexes of the table
-	void RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, Vector &row_identifiers);
-	//! Remove the row identifiers from all the indexes of the table
-	void RemoveFromIndexes(Vector &row_identifiers, idx_t count);
+		//! Append a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table, returns
+		//! whether or not the append succeeded
+		ErrorData AppendToIndexes(DataChunk& chunk, row_t row_start);
+		static ErrorData AppendToIndexes(TableIndexList& indexes, DataChunk& chunk, row_t row_start);
+		//! Remove a chunk with the row ids [row_start, ..., row_start + chunk.size()] from all indexes of the table
+		void RemoveFromIndexes(TableAppendState& state, DataChunk& chunk, row_t row_start);
+		//! Remove the chunk with the specified set of row identifiers from all indexes of the table
+		void RemoveFromIndexes(TableAppendState& state, DataChunk& chunk, Vector& row_identifiers);
+		//! Remove the row identifiers from all the indexes of the table
+		void RemoveFromIndexes(Vector& row_identifiers, idx_t count);
 
-	void SetAsRoot() {
-		this->is_root = true;
-	}
-	bool IsRoot() {
-		return this->is_root;
-	}
+		void SetAsRoot()
+		{
+			this->is_root = true;
+		}
 
-	//! Get statistics of a physical column within the table
-	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id);
-	//! Sets statistics of a physical column within the table
-	void SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats);
+		bool IsRoot()
+		{
+			return this->is_root;
+		}
 
-	//! Obtains a shared lock to prevent checkpointing while operations are running
-	unique_ptr<StorageLockKey> GetSharedCheckpointLock();
-	//! Obtains a lock during a checkpoint operation that prevents other threads from reading this table
-	unique_ptr<StorageLockKey> GetCheckpointLock();
-	//! Checkpoint the table to the specified table data writer
-	void Checkpoint(TableDataWriter &writer, Serializer &serializer);
-	void CommitDropTable();
-	void CommitDropColumn(idx_t index);
+		//! Get statistics of a physical column within the table
+		unique_ptr<BaseStatistics> GetStatistics(ClientContext& context, column_t column_id);
+		//! Sets statistics of a physical column within the table
+		void SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats);
 
-	idx_t ColumnCount() const;
-	idx_t GetTotalRows() const;
+		//! Obtains a shared lock to prevent checkpointing while operations are running
+		unique_ptr<StorageLockKey> GetSharedCheckpointLock();
+		//! Obtains a lock during a checkpoint operation that prevents other threads from reading this table
+		unique_ptr<StorageLockKey> GetCheckpointLock();
+		//! Checkpoint the table to the specified table data writer
+		void Checkpoint(TableDataWriter& writer, Serializer& serializer);
+		void CommitDropTable();
+		void CommitDropColumn(idx_t index);
 
-	vector<ColumnSegmentInfo> GetColumnSegmentInfo();
-	static bool IsForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, Index &index, ForeignKeyType fk_type);
+		idx_t ColumnCount() const;
+		idx_t GetTotalRows() const;
 
-	//! Scans the next chunk for the CREATE INDEX operator
-	bool CreateIndexScan(TableScanState &state, DataChunk &result, TableScanType type);
-	//! Returns true, if the index name is unique (i.e., no PK, UNIQUE, FK constraint has the same name)
-	//! FIXME: This is only necessary until we treat all indexes as catalog entries, allowing to alter constraints
-	bool IndexNameIsUnique(const string &name);
+		vector<ColumnSegmentInfo> GetColumnSegmentInfo();
+		static bool IsForeignKeyIndex(const vector<PhysicalIndex>& fk_keys, Index& index, ForeignKeyType fk_type);
 
-	//! Initialize constraint verification state
-	unique_ptr<ConstraintState> InitializeConstraintState(TableCatalogEntry &table,
-	                                                      const vector<unique_ptr<BoundConstraint>> &bound_constraints);
-	//! Verify constraints with a chunk from the Append containing all columns of the table
-	void VerifyAppendConstraints(ConstraintState &state, ClientContext &context, DataChunk &chunk,
-	                             optional_ptr<ConflictManager> conflict_manager = nullptr);
+		//! Scans the next chunk for the CREATE INDEX operator
+		bool CreateIndexScan(TableScanState& state, DataChunk& result, TableScanType type);
+		//! Returns true, if the index name is unique (i.e., no PK, UNIQUE, FK constraint has the same name)
+		//! FIXME: This is only necessary until we treat all indexes as catalog entries, allowing to alter constraints
+		bool IndexNameIsUnique(const string& name);
 
-	shared_ptr<DataTableInfo> &GetDataTableInfo();
+		//! Initialize constraint verification state
+		unique_ptr<ConstraintState> InitializeConstraintState(TableCatalogEntry& table,
+		                                                      const vector<unique_ptr<BoundConstraint>>&
+		                                                      bound_constraints);
+		//! Verify constraints with a chunk from the Append containing all columns of the table
+		void VerifyAppendConstraints(ConstraintState& state, ClientContext& context, DataChunk& chunk,
+		                             optional_ptr<ConflictManager> conflict_manager = nullptr);
 
-	void InitializeIndexes(ClientContext &context);
-	bool HasIndexes() const;
-	void AddIndex(unique_ptr<Index> index);
-	bool HasForeignKeyIndex(const vector<PhysicalIndex> &keys, ForeignKeyType type);
-	void SetIndexStorageInfo(vector<IndexStorageInfo> index_storage_info);
-	void VacuumIndexes();
+		shared_ptr<DataTableInfo>& GetDataTableInfo();
 
-	string GetTableName() const;
-	void SetTableName(string new_name);
+		void InitializeIndexes(ClientContext& context);
+		bool HasIndexes() const;
+		void AddIndex(unique_ptr<Index> index);
+		bool HasForeignKeyIndex(const vector<PhysicalIndex>& keys, ForeignKeyType type);
+		void SetIndexStorageInfo(vector<IndexStorageInfo> index_storage_info);
+		void VacuumIndexes();
 
-	TableStorageInfo GetStorageInfo();
+		string GetTableName() const;
+		void SetTableName(string new_name);
 
-	static void VerifyUniqueIndexes(TableIndexList &indexes, ClientContext &context, DataChunk &chunk,
-	                                optional_ptr<ConflictManager> conflict_manager);
+		TableStorageInfo GetStorageInfo();
 
-	//! Verify the new added constraints against current persistent&local data
-	void VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint);
-	void VerifyNewConstraint(ClientContext &context, DataTable &parent, const BoundConstraint &constraint);
+		static void VerifyUniqueIndexes(TableIndexList& indexes, ClientContext& context, DataChunk& chunk,
+		                                optional_ptr<ConflictManager> conflict_manager);
 
-	void AddConstraintIndex(const vector<const ColumnDefinition*> &columns, IndexConstraintType constraint_type,
-						   const IndexStorageInfo &index_info = IndexStorageInfo());
+		//! Verify the new added constraints against current persistent&local data
+		void VerifyNewConstraint(LocalStorage& local_storage, DataTable& parent, const BoundConstraint& constraint);
+		void VerifyNewConstraint(ClientContext& context, DataTable& parent, const BoundConstraint& constraint);
 
-private:
-	//! Verify constraints with a chunk from the Update containing only the specified column_ids
-	void VerifyUpdateConstraints(ConstraintState &state, ClientContext &context, DataChunk &chunk,
-	                             const vector<PhysicalIndex> &column_ids);
-	//! Verify constraints with a chunk from the Delete containing all columns of the table
-	void VerifyDeleteConstraints(TableDeleteState &state, ClientContext &context, DataChunk &chunk);
+		Index* AddConstraintIndex(const vector<const ColumnDefinition*>& columns, IndexConstraintType constraint_type,
+		                          const IndexStorageInfo& index_info = IndexStorageInfo());
 
-	void InitializeScanWithOffset(TableScanState &state, const vector<column_t> &column_ids, idx_t start_row,
-	                              idx_t end_row);
+	private:
+		//! Verify constraints with a chunk from the Update containing only the specified column_ids
+		void VerifyUpdateConstraints(ConstraintState& state, ClientContext& context, DataChunk& chunk,
+		                             const vector<PhysicalIndex>& column_ids);
+		//! Verify constraints with a chunk from the Delete containing all columns of the table
+		void VerifyDeleteConstraints(TableDeleteState& state, ClientContext& context, DataChunk& chunk);
 
-	void VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context, DataChunk &chunk,
-	                                VerifyExistenceType verify_type);
-	void VerifyAppendForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
-	                                      DataChunk &chunk);
-	void VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
-	                                      DataChunk &chunk);
+		void InitializeScanWithOffset(TableScanState& state, const vector<column_t>& column_ids, idx_t start_row,
+		                              idx_t end_row);
 
-private:
-	//! The table info
-	shared_ptr<DataTableInfo> info;
-	//! The set of physical columns stored by this DataTable
-	vector<ColumnDefinition> column_definitions;
-	//! Lock for appending entries to the table
-	mutex append_lock;
-	//! The row groups of the table
-	shared_ptr<RowGroupCollection> row_groups;
-	//! Whether or not the data table is the root DataTable for this table; the root DataTable is the newest version
-	//! that can be appended to
-	atomic<bool> is_root;
-};
+		void VerifyForeignKeyConstraint(const BoundForeignKeyConstraint& bfk, ClientContext& context, DataChunk& chunk,
+		                                VerifyExistenceType verify_type);
+		void VerifyAppendForeignKeyConstraint(const BoundForeignKeyConstraint& bfk, ClientContext& context,
+		                                      DataChunk& chunk);
+		void VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint& bfk, ClientContext& context,
+		                                      DataChunk& chunk);
+
+		// Indexes existing data in the table into the index.
+		void IndexExistingData(ClientContext& context, Index* index);
+
+	private:
+		//! The table info
+		shared_ptr<DataTableInfo> info;
+		//! The set of physical columns stored by this DataTable
+		vector<ColumnDefinition> column_definitions;
+		//! Lock for appending entries to the table
+		mutex append_lock;
+		//! The row groups of the table
+		shared_ptr<RowGroupCollection> row_groups;
+		//! Whether or not the data table is the root DataTable for this table; the root DataTable is the newest version
+		//! that can be appended to
+		atomic<bool> is_root;
+	};
 } // namespace duckdb

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -252,7 +252,7 @@ private:
 	                                      DataChunk &chunk);
 
 	// Indexes existing data in the table into the index.
-	void IndexExistingData(ClientContext &context, Index &index);
+	void AddIndexStorage(ClientContext &context, Index &index);
 
 private:
 	//! The table info

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -235,7 +235,8 @@ namespace duckdb
 		void VerifyNewConstraint(LocalStorage& local_storage, DataTable& parent, const BoundConstraint& constraint);
 		void VerifyNewConstraint(ClientContext& context, DataTable& parent, const BoundConstraint& constraint);
 
-		Index* AddConstraintIndex(const vector<const ColumnDefinition*>& columns, IndexConstraintType constraint_type,
+		Index& AddConstraintIndex(const vector<reference<const ColumnDefinition>>& columns,
+		                          IndexConstraintType constraint_type,
 		                          const IndexStorageInfo& index_info = IndexStorageInfo());
 
 	private:
@@ -256,7 +257,7 @@ namespace duckdb
 		                                      DataChunk& chunk);
 
 		// Indexes existing data in the table into the index.
-		void IndexExistingData(ClientContext& context, Index* index);
+		void IndexExistingData(ClientContext& context, Index& index);
 
 	private:
 		//! The table info

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -21,255 +21,250 @@
 #include "duckdb/storage/table/table_statistics.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 
-namespace duckdb
-{
-	class BoundForeignKeyConstraint;
-	class ClientContext;
-	class ColumnDataCollection;
-	class ColumnDefinition;
-	class DataTable;
-	class DuckTransaction;
-	class OptimisticDataWriter;
-	class RowGroup;
-	class StorageManager;
-	class TableCatalogEntry;
-	class TableIOManager;
-	class Transaction;
-	class WriteAheadLog;
-	class TableDataWriter;
-	class ConflictManager;
-	class TableScanState;
-	struct TableDeleteState;
-	struct ConstraintState;
-	struct TableUpdateState;
-	enum class VerifyExistenceType : uint8_t;
+namespace duckdb {
+class BoundForeignKeyConstraint;
+class ClientContext;
+class ColumnDataCollection;
+class ColumnDefinition;
+class DataTable;
+class DuckTransaction;
+class OptimisticDataWriter;
+class RowGroup;
+class StorageManager;
+class TableCatalogEntry;
+class TableIOManager;
+class Transaction;
+class WriteAheadLog;
+class TableDataWriter;
+class ConflictManager;
+class TableScanState;
+struct TableDeleteState;
+struct ConstraintState;
+struct TableUpdateState;
+enum class VerifyExistenceType : uint8_t;
 
-	//! DataTable represents a physical table on disk
-	class DataTable
-	{
-	public:
-		//! Constructs a new data table from an (optional) set of persistent segments
-		DataTable(AttachedDatabase& db, shared_ptr<TableIOManager> table_io_manager, const string& schema,
-		          const string& table, vector<ColumnDefinition> column_definitions_p,
-		          unique_ptr<PersistentTableData> data = nullptr);
-		//! Constructs a DataTable as a delta on an existing data table with a newly added column
-		DataTable(ClientContext& context, DataTable& parent, ColumnDefinition& new_column, Expression& default_value);
-		//! Constructs a DataTable as a delta on an existing data table but with one column removed
-		DataTable(ClientContext& context, DataTable& parent, idx_t removed_column);
-		//! Constructs a DataTable as a delta on an existing data table but with one column changed type
-		DataTable(ClientContext& context, DataTable& parent, idx_t changed_idx, const LogicalType& target_type,
-		          const vector<column_t>& bound_columns, Expression& cast_expr);
-		//! Constructs a DataTable as a delta on an existing data table but with one column added new constraint
-		explicit DataTable(ClientContext& context, DataTable& parent, BoundConstraint& constraint);
+//! DataTable represents a physical table on disk
+class DataTable {
+public:
+	//! Constructs a new data table from an (optional) set of persistent segments
+	DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_manager, const string &schema,
+	          const string &table, vector<ColumnDefinition> column_definitions_p,
+	          unique_ptr<PersistentTableData> data = nullptr);
+	//! Constructs a DataTable as a delta on an existing data table with a newly added column
+	DataTable(ClientContext &context, DataTable &parent, ColumnDefinition &new_column, Expression &default_value);
+	//! Constructs a DataTable as a delta on an existing data table but with one column removed
+	DataTable(ClientContext &context, DataTable &parent, idx_t removed_column);
+	//! Constructs a DataTable as a delta on an existing data table but with one column changed type
+	DataTable(ClientContext &context, DataTable &parent, idx_t changed_idx, const LogicalType &target_type,
+	          const vector<column_t> &bound_columns, Expression &cast_expr);
+	//! Constructs a DataTable as a delta on an existing data table but with one column added new constraint
+	explicit DataTable(ClientContext &context, DataTable &parent, BoundConstraint &constraint);
 
-		//! A reference to the database instance
-		AttachedDatabase& db;
+	//! A reference to the database instance
+	AttachedDatabase &db;
 
-	public:
-		AttachedDatabase& GetAttached();
-		TableIOManager& GetTableIOManager();
+public:
+	AttachedDatabase &GetAttached();
+	TableIOManager &GetTableIOManager();
 
-		bool IsTemporary() const;
+	bool IsTemporary() const;
 
-		//! Returns a list of types of the table
-		vector<LogicalType> GetTypes();
-		const vector<ColumnDefinition>& Columns() const;
+	//! Returns a list of types of the table
+	vector<LogicalType> GetTypes();
+	const vector<ColumnDefinition> &Columns() const;
 
-		void InitializeScan(TableScanState& state, const vector<column_t>& column_ids,
-		                    TableFilterSet* table_filter = nullptr);
-		void InitializeScan(DuckTransaction& transaction, TableScanState& state, const vector<column_t>& column_ids,
-		                    TableFilterSet* table_filters = nullptr);
+	void InitializeScan(TableScanState &state, const vector<column_t> &column_ids,
+	                    TableFilterSet *table_filter = nullptr);
+	void InitializeScan(DuckTransaction &transaction, TableScanState &state, const vector<column_t> &column_ids,
+	                    TableFilterSet *table_filters = nullptr);
 
-		//! Returns the maximum amount of threads that should be assigned to scan this data table
-		idx_t MaxThreads(ClientContext& context);
-		void InitializeParallelScan(ClientContext& context, ParallelTableScanState& state);
-		bool NextParallelScan(ClientContext& context, ParallelTableScanState& state, TableScanState& scan_state);
+	//! Returns the maximum amount of threads that should be assigned to scan this data table
+	idx_t MaxThreads(ClientContext &context);
+	void InitializeParallelScan(ClientContext &context, ParallelTableScanState &state);
+	bool NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state);
 
-		//! Scans up to STANDARD_VECTOR_SIZE elements from the table starting
-		//! from offset and store them in result. Offset is incremented with how many
-		//! elements were returned.
-		//! Returns true if all pushed down filters were executed during data fetching
-		void Scan(DuckTransaction& transaction, DataChunk& result, TableScanState& state);
+	//! Scans up to STANDARD_VECTOR_SIZE elements from the table starting
+	//! from offset and store them in result. Offset is incremented with how many
+	//! elements were returned.
+	//! Returns true if all pushed down filters were executed during data fetching
+	void Scan(DuckTransaction &transaction, DataChunk &result, TableScanState &state);
 
-		//! Fetch data from the specific row identifiers from the base table
-		void Fetch(DuckTransaction& transaction, DataChunk& result, const vector<column_t>& column_ids,
-		           const Vector& row_ids, idx_t fetch_count, ColumnFetchState& state);
+	//! Fetch data from the specific row identifiers from the base table
+	void Fetch(DuckTransaction &transaction, DataChunk &result, const vector<column_t> &column_ids,
+	           const Vector &row_ids, idx_t fetch_count, ColumnFetchState &state);
 
-		//! Initializes an append to transaction-local storage
-		void InitializeLocalAppend(LocalAppendState& state, TableCatalogEntry& table, ClientContext& context,
-		                           const vector<unique_ptr<BoundConstraint>>& bound_constraints);
-		//! Append a DataChunk to the transaction-local storage of the table.
-		void LocalAppend(LocalAppendState& state, TableCatalogEntry& table, ClientContext& context, DataChunk& chunk,
-		                 bool unsafe = false);
-		//! Finalizes a transaction-local append
-		void FinalizeLocalAppend(LocalAppendState& state);
-		//! Append a chunk to the transaction-local storage of this table
-		void LocalAppend(TableCatalogEntry& table, ClientContext& context, DataChunk& chunk,
-		                 const vector<unique_ptr<BoundConstraint>>& bound_constraints);
-		//! Append a column data collection to the transaction-local storage of this table
-		void LocalAppend(TableCatalogEntry& table, ClientContext& context, ColumnDataCollection& collection,
-		                 const vector<unique_ptr<BoundConstraint>>& bound_constraints);
-		//! Merge a row group collection into the transaction-local storage
-		void LocalMerge(ClientContext& context, RowGroupCollection& collection);
-		//! Creates an optimistic writer for this table - used for optimistically writing parallel appends
-		OptimisticDataWriter& CreateOptimisticWriter(ClientContext& context);
-		void FinalizeOptimisticWriter(ClientContext& context, OptimisticDataWriter& writer);
+	//! Initializes an append to transaction-local storage
+	void InitializeLocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
+	                           const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Append a DataChunk to the transaction-local storage of the table.
+	void LocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+	                 bool unsafe = false);
+	//! Finalizes a transaction-local append
+	void FinalizeLocalAppend(LocalAppendState &state);
+	//! Append a chunk to the transaction-local storage of this table
+	void LocalAppend(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
+	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Append a column data collection to the transaction-local storage of this table
+	void LocalAppend(TableCatalogEntry &table, ClientContext &context, ColumnDataCollection &collection,
+	                 const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Merge a row group collection into the transaction-local storage
+	void LocalMerge(ClientContext &context, RowGroupCollection &collection);
+	//! Creates an optimistic writer for this table - used for optimistically writing parallel appends
+	OptimisticDataWriter &CreateOptimisticWriter(ClientContext &context);
+	void FinalizeOptimisticWriter(ClientContext &context, OptimisticDataWriter &writer);
 
-		unique_ptr<TableDeleteState> InitializeDelete(TableCatalogEntry& table, ClientContext& context,
-		                                              const vector<unique_ptr<BoundConstraint>>& bound_constraints);
-		//! Delete the entries with the specified row identifier from the table
-		idx_t Delete(TableDeleteState& state, ClientContext& context, Vector& row_ids, idx_t count);
+	unique_ptr<TableDeleteState> InitializeDelete(TableCatalogEntry &table, ClientContext &context,
+	                                              const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Delete the entries with the specified row identifier from the table
+	idx_t Delete(TableDeleteState &state, ClientContext &context, Vector &row_ids, idx_t count);
 
-		unique_ptr<TableUpdateState> InitializeUpdate(TableCatalogEntry& table, ClientContext& context,
-		                                              const vector<unique_ptr<BoundConstraint>>& bound_constraints);
-		//! Update the entries with the specified row identifier from the table
-		void Update(TableUpdateState& state, ClientContext& context, Vector& row_ids,
-		            const vector<PhysicalIndex>& column_ids, DataChunk& data);
-		//! Update a single (sub-)column along a column path
-		//! The column_path vector is a *path* towards a column within the table
-		//! i.e. if we have a table with a single column S STRUCT(A INT, B INT)
-		//! and we update the validity mask of "S.B"
-		//! the column path is:
-		//! 0 (first column of table)
-		//! -> 1 (second subcolumn of struct)
-		//! -> 0 (first subcolumn of INT)
-		//! This method should only be used from the WAL replay. It does not verify update constraints.
-		void UpdateColumn(TableCatalogEntry& table, ClientContext& context, Vector& row_ids,
-		                  const vector<column_t>& column_path, DataChunk& updates);
+	unique_ptr<TableUpdateState> InitializeUpdate(TableCatalogEntry &table, ClientContext &context,
+	                                              const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Update the entries with the specified row identifier from the table
+	void Update(TableUpdateState &state, ClientContext &context, Vector &row_ids,
+	            const vector<PhysicalIndex> &column_ids, DataChunk &data);
+	//! Update a single (sub-)column along a column path
+	//! The column_path vector is a *path* towards a column within the table
+	//! i.e. if we have a table with a single column S STRUCT(A INT, B INT)
+	//! and we update the validity mask of "S.B"
+	//! the column path is:
+	//! 0 (first column of table)
+	//! -> 1 (second subcolumn of struct)
+	//! -> 0 (first subcolumn of INT)
+	//! This method should only be used from the WAL replay. It does not verify update constraints.
+	void UpdateColumn(TableCatalogEntry &table, ClientContext &context, Vector &row_ids,
+	                  const vector<column_t> &column_path, DataChunk &updates);
 
-		//! Fetches an append lock
-		void AppendLock(TableAppendState& state);
-		//! Begin appending structs to this table, obtaining necessary locks, etc
-		void InitializeAppend(DuckTransaction& transaction, TableAppendState& state);
-		//! Append a chunk to the table using the AppendState obtained from InitializeAppend
-		void Append(DataChunk& chunk, TableAppendState& state);
-		//! Finalize an append
-		void FinalizeAppend(DuckTransaction& transaction, TableAppendState& state);
-		//! Commit the append
-		void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
-		//! Write a segment of the table to the WAL
-		void WriteToLog(WriteAheadLog& log, idx_t row_start, idx_t count);
-		//! Revert a set of appends made by the given AppendState, used to revert appends in the event of an error during
-		//! commit (e.g. because of an I/O exception)
-		void RevertAppend(idx_t start_row, idx_t count);
-		void RevertAppendInternal(idx_t start_row);
+	//! Fetches an append lock
+	void AppendLock(TableAppendState &state);
+	//! Begin appending structs to this table, obtaining necessary locks, etc
+	void InitializeAppend(DuckTransaction &transaction, TableAppendState &state);
+	//! Append a chunk to the table using the AppendState obtained from InitializeAppend
+	void Append(DataChunk &chunk, TableAppendState &state);
+	//! Finalize an append
+	void FinalizeAppend(DuckTransaction &transaction, TableAppendState &state);
+	//! Commit the append
+	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
+	//! Write a segment of the table to the WAL
+	void WriteToLog(WriteAheadLog &log, idx_t row_start, idx_t count);
+	//! Revert a set of appends made by the given AppendState, used to revert appends in the event of an error during
+	//! commit (e.g. because of an I/O exception)
+	void RevertAppend(idx_t start_row, idx_t count);
+	void RevertAppendInternal(idx_t start_row);
 
-		void ScanTableSegment(idx_t start_row, idx_t count, const std::function<void(DataChunk& chunk)>& function);
+	void ScanTableSegment(idx_t start_row, idx_t count, const std::function<void(DataChunk &chunk)> &function);
 
-		//! Merge a row group collection directly into this table - appending it to the end of the table without copying
-		void MergeStorage(RowGroupCollection& data, TableIndexList& indexes);
+	//! Merge a row group collection directly into this table - appending it to the end of the table without copying
+	void MergeStorage(RowGroupCollection &data, TableIndexList &indexes);
 
-		//! Append a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table, returns
-		//! whether or not the append succeeded
-		ErrorData AppendToIndexes(DataChunk& chunk, row_t row_start);
-		static ErrorData AppendToIndexes(TableIndexList& indexes, DataChunk& chunk, row_t row_start);
-		//! Remove a chunk with the row ids [row_start, ..., row_start + chunk.size()] from all indexes of the table
-		void RemoveFromIndexes(TableAppendState& state, DataChunk& chunk, row_t row_start);
-		//! Remove the chunk with the specified set of row identifiers from all indexes of the table
-		void RemoveFromIndexes(TableAppendState& state, DataChunk& chunk, Vector& row_identifiers);
-		//! Remove the row identifiers from all the indexes of the table
-		void RemoveFromIndexes(Vector& row_identifiers, idx_t count);
+	//! Append a chunk with the row ids [row_start, ..., row_start + chunk.size()] to all indexes of the table, returns
+	//! whether or not the append succeeded
+	ErrorData AppendToIndexes(DataChunk &chunk, row_t row_start);
+	static ErrorData AppendToIndexes(TableIndexList &indexes, DataChunk &chunk, row_t row_start);
+	//! Remove a chunk with the row ids [row_start, ..., row_start + chunk.size()] from all indexes of the table
+	void RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, row_t row_start);
+	//! Remove the chunk with the specified set of row identifiers from all indexes of the table
+	void RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, Vector &row_identifiers);
+	//! Remove the row identifiers from all the indexes of the table
+	void RemoveFromIndexes(Vector &row_identifiers, idx_t count);
 
-		void SetAsRoot()
-		{
-			this->is_root = true;
-		}
+	void SetAsRoot() {
+		this->is_root = true;
+	}
 
-		bool IsRoot()
-		{
-			return this->is_root;
-		}
+	bool IsRoot() {
+		return this->is_root;
+	}
 
-		//! Get statistics of a physical column within the table
-		unique_ptr<BaseStatistics> GetStatistics(ClientContext& context, column_t column_id);
-		//! Sets statistics of a physical column within the table
-		void SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats);
+	//! Get statistics of a physical column within the table
+	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id);
+	//! Sets statistics of a physical column within the table
+	void SetDistinct(column_t column_id, unique_ptr<DistinctStatistics> distinct_stats);
 
-		//! Obtains a shared lock to prevent checkpointing while operations are running
-		unique_ptr<StorageLockKey> GetSharedCheckpointLock();
-		//! Obtains a lock during a checkpoint operation that prevents other threads from reading this table
-		unique_ptr<StorageLockKey> GetCheckpointLock();
-		//! Checkpoint the table to the specified table data writer
-		void Checkpoint(TableDataWriter& writer, Serializer& serializer);
-		void CommitDropTable();
-		void CommitDropColumn(idx_t index);
+	//! Obtains a shared lock to prevent checkpointing while operations are running
+	unique_ptr<StorageLockKey> GetSharedCheckpointLock();
+	//! Obtains a lock during a checkpoint operation that prevents other threads from reading this table
+	unique_ptr<StorageLockKey> GetCheckpointLock();
+	//! Checkpoint the table to the specified table data writer
+	void Checkpoint(TableDataWriter &writer, Serializer &serializer);
+	void CommitDropTable();
+	void CommitDropColumn(idx_t index);
 
-		idx_t ColumnCount() const;
-		idx_t GetTotalRows() const;
+	idx_t ColumnCount() const;
+	idx_t GetTotalRows() const;
 
-		vector<ColumnSegmentInfo> GetColumnSegmentInfo();
-		static bool IsForeignKeyIndex(const vector<PhysicalIndex>& fk_keys, Index& index, ForeignKeyType fk_type);
+	vector<ColumnSegmentInfo> GetColumnSegmentInfo();
+	static bool IsForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, Index &index, ForeignKeyType fk_type);
 
-		//! Scans the next chunk for the CREATE INDEX operator
-		bool CreateIndexScan(TableScanState& state, DataChunk& result, TableScanType type);
-		//! Returns true, if the index name is unique (i.e., no PK, UNIQUE, FK constraint has the same name)
-		//! FIXME: This is only necessary until we treat all indexes as catalog entries, allowing to alter constraints
-		bool IndexNameIsUnique(const string& name);
+	//! Scans the next chunk for the CREATE INDEX operator
+	bool CreateIndexScan(TableScanState &state, DataChunk &result, TableScanType type);
+	//! Returns true, if the index name is unique (i.e., no PK, UNIQUE, FK constraint has the same name)
+	//! FIXME: This is only necessary until we treat all indexes as catalog entries, allowing to alter constraints
+	bool IndexNameIsUnique(const string &name);
 
-		//! Initialize constraint verification state
-		unique_ptr<ConstraintState> InitializeConstraintState(TableCatalogEntry& table,
-		                                                      const vector<unique_ptr<BoundConstraint>>&
-		                                                      bound_constraints);
-		//! Verify constraints with a chunk from the Append containing all columns of the table
-		void VerifyAppendConstraints(ConstraintState& state, ClientContext& context, DataChunk& chunk,
-		                             optional_ptr<ConflictManager> conflict_manager = nullptr);
+	//! Initialize constraint verification state
+	unique_ptr<ConstraintState> InitializeConstraintState(TableCatalogEntry &table,
+	                                                      const vector<unique_ptr<BoundConstraint>> &bound_constraints);
+	//! Verify constraints with a chunk from the Append containing all columns of the table
+	void VerifyAppendConstraints(ConstraintState &state, ClientContext &context, DataChunk &chunk,
+	                             optional_ptr<ConflictManager> conflict_manager = nullptr);
 
-		shared_ptr<DataTableInfo>& GetDataTableInfo();
+	shared_ptr<DataTableInfo> &GetDataTableInfo();
 
-		void InitializeIndexes(ClientContext& context);
-		bool HasIndexes() const;
-		void AddIndex(unique_ptr<Index> index);
-		bool HasForeignKeyIndex(const vector<PhysicalIndex>& keys, ForeignKeyType type);
-		void SetIndexStorageInfo(vector<IndexStorageInfo> index_storage_info);
-		void VacuumIndexes();
+	void InitializeIndexes(ClientContext &context);
+	bool HasIndexes() const;
+	void AddIndex(unique_ptr<Index> index);
+	bool HasForeignKeyIndex(const vector<PhysicalIndex> &keys, ForeignKeyType type);
+	void SetIndexStorageInfo(vector<IndexStorageInfo> index_storage_info);
+	void VacuumIndexes();
 
-		string GetTableName() const;
-		void SetTableName(string new_name);
+	string GetTableName() const;
+	void SetTableName(string new_name);
 
-		TableStorageInfo GetStorageInfo();
+	TableStorageInfo GetStorageInfo();
 
-		static void VerifyUniqueIndexes(TableIndexList& indexes, ClientContext& context, DataChunk& chunk,
-		                                optional_ptr<ConflictManager> conflict_manager);
+	static void VerifyUniqueIndexes(TableIndexList &indexes, ClientContext &context, DataChunk &chunk,
+	                                optional_ptr<ConflictManager> conflict_manager);
 
-		//! Verify the new added constraints against current persistent&local data
-		void VerifyNewConstraint(LocalStorage& local_storage, DataTable& parent, const BoundConstraint& constraint);
-		void VerifyNewConstraint(ClientContext& context, DataTable& parent, const BoundConstraint& constraint);
+	//! Verify the new added constraints against current persistent&local data
+	void VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint);
+	void VerifyNewConstraint(ClientContext &context, DataTable &parent, const BoundConstraint &constraint);
 
-		Index& AddConstraintIndex(const vector<reference<const ColumnDefinition>>& columns,
-		                          IndexConstraintType constraint_type,
-		                          const IndexStorageInfo& index_info = IndexStorageInfo());
+	Index &AddConstraintIndex(const vector<reference<const ColumnDefinition>> &columns,
+	                          IndexConstraintType constraint_type,
+	                          const IndexStorageInfo &index_info = IndexStorageInfo());
 
-	private:
-		//! Verify constraints with a chunk from the Update containing only the specified column_ids
-		void VerifyUpdateConstraints(ConstraintState& state, ClientContext& context, DataChunk& chunk,
-		                             const vector<PhysicalIndex>& column_ids);
-		//! Verify constraints with a chunk from the Delete containing all columns of the table
-		void VerifyDeleteConstraints(TableDeleteState& state, ClientContext& context, DataChunk& chunk);
+private:
+	//! Verify constraints with a chunk from the Update containing only the specified column_ids
+	void VerifyUpdateConstraints(ConstraintState &state, ClientContext &context, DataChunk &chunk,
+	                             const vector<PhysicalIndex> &column_ids);
+	//! Verify constraints with a chunk from the Delete containing all columns of the table
+	void VerifyDeleteConstraints(TableDeleteState &state, ClientContext &context, DataChunk &chunk);
 
-		void InitializeScanWithOffset(TableScanState& state, const vector<column_t>& column_ids, idx_t start_row,
-		                              idx_t end_row);
+	void InitializeScanWithOffset(TableScanState &state, const vector<column_t> &column_ids, idx_t start_row,
+	                              idx_t end_row);
 
-		void VerifyForeignKeyConstraint(const BoundForeignKeyConstraint& bfk, ClientContext& context, DataChunk& chunk,
-		                                VerifyExistenceType verify_type);
-		void VerifyAppendForeignKeyConstraint(const BoundForeignKeyConstraint& bfk, ClientContext& context,
-		                                      DataChunk& chunk);
-		void VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint& bfk, ClientContext& context,
-		                                      DataChunk& chunk);
+	void VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context, DataChunk &chunk,
+	                                VerifyExistenceType verify_type);
+	void VerifyAppendForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
+	                                      DataChunk &chunk);
+	void VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
+	                                      DataChunk &chunk);
 
-		// Indexes existing data in the table into the index.
-		void IndexExistingData(ClientContext& context, Index& index);
+	// Indexes existing data in the table into the index.
+	void IndexExistingData(ClientContext &context, Index &index);
 
-	private:
-		//! The table info
-		shared_ptr<DataTableInfo> info;
-		//! The set of physical columns stored by this DataTable
-		vector<ColumnDefinition> column_definitions;
-		//! Lock for appending entries to the table
-		mutex append_lock;
-		//! The row groups of the table
-		shared_ptr<RowGroupCollection> row_groups;
-		//! Whether or not the data table is the root DataTable for this table; the root DataTable is the newest version
-		//! that can be appended to
-		atomic<bool> is_root;
-	};
+private:
+	//! The table info
+	shared_ptr<DataTableInfo> info;
+	//! The set of physical columns stored by this DataTable
+	vector<ColumnDefinition> column_definitions;
+	//! Lock for appending entries to the table
+	mutex append_lock;
+	//! The row groups of the table
+	shared_ptr<RowGroupCollection> row_groups;
+	//! Whether or not the data table is the root DataTable for this table; the root DataTable is the newest version
+	//! that can be appended to
+	atomic<bool> is_root;
+};
 } // namespace duckdb

--- a/src/include/duckdb/storage/serialization/parse_info.json
+++ b/src/include/duckdb/storage/serialization/parse_info.json
@@ -608,5 +608,17 @@
       }
     ],
     "constructor": ["options"]
+  },
+  {
+    "class": "AddConstraintInfo",
+    "base": "AlterTableInfo",
+    "enum": "ADD_CONSTRAINT",
+    "members": [
+      {
+        "id": 400,
+        "name": "constraint",
+        "type": "unique_ptr<Constraint>"
+      }
+    ]
   }
 ]

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -58,7 +58,7 @@ public:
 		return indexes;
 	}
 	//! Adds an index to the list of indexes of this table
-	void AddIndex(unique_ptr<Index> index);
+	Index* AddIndex(unique_ptr<Index> index);
 	//! Removes an index from the list of indexes of this table
 	void RemoveIndex(const string &name);
 	//! Completely removes all remaining memory of an index after dropping the catalog entry

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -12,11 +12,11 @@
 #include "duckdb/storage/index.hpp"
 #include "duckdb/parser/constraint.hpp"
 
-namespace duckdb {
-
-class ConflictManager;
-struct IndexStorageInfo;
-struct DataTableInfo;
+namespace duckdb
+{
+	class ConflictManager;
+	struct IndexStorageInfo;
+	struct DataTableInfo;
 
 class TableIndexList {
 public:
@@ -72,17 +72,18 @@ public:
 	idx_t Count();
 	void Move(TableIndexList &other);
 
-	Index *FindForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, ForeignKeyType fk_type);
-	void VerifyForeignKey(const vector<PhysicalIndex> &fk_keys, DataChunk &chunk, ConflictManager &conflict_manager);
+		Index* FindForeignKeyIndex(const vector<PhysicalIndex>& fk_keys, ForeignKeyType fk_type);
+		void VerifyForeignKey(const vector<PhysicalIndex>& fk_keys, DataChunk& chunk,
+		                      ConflictManager& conflict_manager);
 
-	//! Serialize all indexes of this table
-	vector<IndexStorageInfo> GetStorageInfos();
+		//! Serialize all indexes of this table
+		vector<IndexStorageInfo> GetStorageInfos();
 
-	vector<column_t> GetRequiredColumns();
+		vector<column_t> GetRequiredColumns();
 
-private:
-	//! Indexes associated with the current table
-	mutex indexes_lock;
-	vector<unique_ptr<Index>> indexes;
-};
+	private:
+		//! Indexes associated with the current table
+		mutex indexes_lock;
+		vector<unique_ptr<Index>> indexes;
+	};
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -57,7 +57,7 @@ public:
 		return indexes;
 	}
 	//! Adds an index to the list of indexes of this table
-	Index *AddIndex(unique_ptr<Index> index);
+	Index &AddIndex(unique_ptr<Index> index);
 	//! Removes an index from the list of indexes of this table
 	void RemoveIndex(const string &name);
 	//! Completely removes all remaining memory of an index after dropping the catalog entry

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -12,11 +12,10 @@
 #include "duckdb/storage/index.hpp"
 #include "duckdb/parser/constraint.hpp"
 
-namespace duckdb
-{
-	class ConflictManager;
-	struct IndexStorageInfo;
-	struct DataTableInfo;
+namespace duckdb {
+class ConflictManager;
+struct IndexStorageInfo;
+struct DataTableInfo;
 
 class TableIndexList {
 public:
@@ -72,18 +71,17 @@ public:
 	idx_t Count();
 	void Move(TableIndexList &other);
 
-		Index* FindForeignKeyIndex(const vector<PhysicalIndex>& fk_keys, ForeignKeyType fk_type);
-		void VerifyForeignKey(const vector<PhysicalIndex>& fk_keys, DataChunk& chunk,
-		                      ConflictManager& conflict_manager);
+	Index *FindForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, ForeignKeyType fk_type);
+	void VerifyForeignKey(const vector<PhysicalIndex> &fk_keys, DataChunk &chunk, ConflictManager &conflict_manager);
 
-		//! Serialize all indexes of this table
-		vector<IndexStorageInfo> GetStorageInfos();
+	//! Serialize all indexes of this table
+	vector<IndexStorageInfo> GetStorageInfos();
 
-		vector<column_t> GetRequiredColumns();
+	vector<column_t> GetRequiredColumns();
 
-	private:
-		//! Indexes associated with the current table
-		mutex indexes_lock;
-		vector<unique_ptr<Index>> indexes;
-	};
+private:
+	//! Indexes associated with the current table
+	mutex indexes_lock;
+	vector<unique_ptr<Index>> indexes;
+};
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -58,7 +58,7 @@ public:
 		return indexes;
 	}
 	//! Adds an index to the list of indexes of this table
-	Index* AddIndex(unique_ptr<Index> index);
+	Index *AddIndex(unique_ptr<Index> index);
 	//! Removes an index from the list of indexes of this table
 	void RemoveIndex(const string &name);
 	//! Completely removes all remaining memory of an index after dropping the catalog entry

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -441,4 +441,29 @@ string RenameViewInfo::ToString() const {
 	return result;
 }
 
+//===--------------------------------------------------------------------===//
+// AddConstraintInfo
+//===--------------------------------------------------------------------===//
+AddConstraintInfo::AddConstraintInfo() : AlterTableInfo(AlterTableType::ADD_CONSTRAINT) {
+}
+
+AddConstraintInfo::AddConstraintInfo(AlterEntryData data, unique_ptr<Constraint> constraint_p)
+    : AlterTableInfo(AlterTableType::ADD_CONSTRAINT, std::move(data)), constraint(std::move(constraint_p)) {
+}
+AddConstraintInfo::~AddConstraintInfo() {
+}
+
+unique_ptr<AlterInfo> AddConstraintInfo::Copy() const {
+	return make_uniq_base<AlterInfo, AddConstraintInfo>(GetAlterEntryData(), constraint->Copy());
+}
+
+string AddConstraintInfo::ToString() const {
+	string result = "ALTER TABLE ";
+	result += QualifierToString(catalog, schema, name);
+	result += " ADD ";
+	result += constraint->ToString();
+	result += ";";
+	return result;
+}
+
 } // namespace duckdb

--- a/src/parser/transform/constraint/transform_constraint.cpp
+++ b/src/parser/transform/constraint/transform_constraint.cpp
@@ -93,7 +93,7 @@ unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGCon
 		return make_uniq<CheckConstraint>(TransformExpression(constraint->raw_expr));
 	}
 	case duckdb_libpgquery::PG_CONSTR_FOREIGN:
-		return TransformForeignKeyConstraint(*constraint.get());
+		return TransformForeignKeyConstraint(*constraint);
 	default:
 		throw NotImplementedException("Constraint type not handled yet!");
 	}
@@ -135,7 +135,7 @@ unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGCon
 		}
 		return nullptr;
 	case duckdb_libpgquery::PG_CONSTR_FOREIGN:
-		return TransformForeignKeyConstraint(*constraint.get(), &column.Name());
+		return TransformForeignKeyConstraint(*constraint, &column.Name());
 	default:
 		throw NotImplementedException("Constraint not implemented!");
 	}

--- a/src/parser/transform/constraint/transform_constraint.cpp
+++ b/src/parser/transform/constraint/transform_constraint.cpp
@@ -68,9 +68,7 @@ TransformForeignKeyConstraint(duckdb_libpgquery::PGConstraint &constraint,
 	return make_uniq<ForeignKeyConstraint>(pk_columns, fk_columns, std::move(fk_info));
 }
 
-unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGListCell &cell) {
-
-	auto constraint = PGPointerCast<duckdb_libpgquery::PGConstraint>(cell.data.ptr_value);
+unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGConstraint *constraint) {
 	D_ASSERT(constraint);
 
 	switch (constraint->contype) {
@@ -101,17 +99,15 @@ unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGLis
 	}
 }
 
-unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGListCell &cell, ColumnDefinition &column,
-                                                        idx_t index) {
-
-	auto constraint = PGPointerCast<duckdb_libpgquery::PGConstraint>(cell.data.ptr_value);
+unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGConstraint *constraint,
+                                                        ColumnDefinition &column, idx_t index) {
 	D_ASSERT(constraint);
 
 	switch (constraint->contype) {
 	case duckdb_libpgquery::PG_CONSTR_NOTNULL:
 		return make_uniq<NotNullConstraint>(LogicalIndex(index));
 	case duckdb_libpgquery::PG_CONSTR_CHECK:
-		return TransformConstraint(cell);
+		return TransformConstraint(constraint);
 	case duckdb_libpgquery::PG_CONSTR_PRIMARY:
 		return make_uniq<UniqueConstraint>(LogicalIndex(index), true);
 	case duckdb_libpgquery::PG_CONSTR_UNIQUE:

--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -93,7 +93,17 @@ unique_ptr<AlterStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlte
 			result->info = make_uniq<DropNotNullInfo>(std::move(data), command->name);
 			break;
 		}
-		case duckdb_libpgquery::PG_AT_DropConstraint:
+		case duckdb_libpgquery::PG_AT_AddConstraint: {
+			auto pg_constraint = PGPointerCast<duckdb_libpgquery::PGConstraint>(command->def);
+			auto constraint = TransformConstraint(pg_constraint.get());
+
+			if (pg_constraint->contype != duckdb_libpgquery::PGConstrType::PG_CONSTR_PRIMARY) {
+				throw NotImplementedException("No support for that ALTER TABLE option yet!");
+			}
+
+			result->info = make_uniq<AddConstraintInfo>(std::move(data), std::move(constraint));
+			break;
+		}
 		default:
 			throw NotImplementedException("No support for that ALTER TABLE option yet!");
 		}

--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -39,8 +39,9 @@ unique_ptr<AlterStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlte
 
 			auto column_entry = TransformColumnDefinition(*column_def);
 			if (column_def->constraints) {
-				for (auto constr = column_def->constraints->head; constr != nullptr; constr = constr->next) {
-					auto constraint = TransformConstraint(*constr, column_entry, 0);
+				for (auto cell = column_def->constraints->head; cell != nullptr; cell = cell->next) {
+					auto pg_constraint = reinterpret_cast<duckdb_libpgquery::PGConstraint *>(cell->data.ptr_value);
+					auto constraint = TransformConstraint(pg_constraint, column_entry, 0);
 					if (!constraint) {
 						continue;
 					}

--- a/src/parser/transform/statement/transform_create_table.cpp
+++ b/src/parser/transform/statement/transform_create_table.cpp
@@ -100,8 +100,9 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery:
 			auto cdef = PGPointerCast<duckdb_libpgquery::PGColumnDef>(c->data.ptr_value);
 			auto centry = TransformColumnDefinition(*cdef);
 			if (cdef->constraints) {
-				for (auto constr = cdef->constraints->head; constr != nullptr; constr = constr->next) {
-					auto constraint = TransformConstraint(*constr, centry, info->columns.LogicalColumnCount());
+				for (auto cell = cdef->constraints->head; cell != nullptr; cell = cell->next) {
+					auto pg_constraint = reinterpret_cast<duckdb_libpgquery::PGConstraint *>(cell->data.ptr_value);
+					auto constraint = TransformConstraint(pg_constraint, centry, info->columns.LogicalColumnCount());
 					if (constraint) {
 						info->constraints.push_back(std::move(constraint));
 					}
@@ -112,7 +113,8 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery:
 			break;
 		}
 		case duckdb_libpgquery::T_PGConstraint: {
-			info->constraints.push_back(TransformConstraint(*c));
+			auto pg_constraint = reinterpret_cast<duckdb_libpgquery::PGConstraint *>(c->data.ptr_value);
+			info->constraints.push_back(TransformConstraint(pg_constraint));
 			break;
 		}
 		default:

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -98,9 +98,9 @@ unique_ptr<BoundConstraint> Binder::BindConstraint(Constraint &constraint, const
 	switch (constraint.type) {
 	case ConstraintType::CHECK: {
 		unique_ptr<BoundConstraint> bound_constraint = make_uniq<BoundCheckConstraint>();
-		auto check_constraint = reinterpret_cast<BoundCheckConstraint *>(bound_constraint.get());
+		auto check_constraint = bound_constraint->Cast<BoundCheckConstraint>();
 		// check constraint: bind the expression
-		CheckBinder check_binder(*this, context, table_name, columns, check_constraint->bound_columns);
+		CheckBinder check_binder(*this, context, table_name, columns, check_constraint.bound_columns);
 		auto &check = constraint.Cast<CheckConstraint>();
 		// create a copy of the unbound expression because the binding destroys the constraint
 		auto unbound_expression = check.expression->Copy();

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -93,7 +93,8 @@ vector<unique_ptr<BoundConstraint>> Binder::BindNewConstraints(vector<unique_ptr
 	return bound_constraints;
 }
 
-unique_ptr<BoundConstraint> Binder::BindConstraint(Constraint &constraint, const string &table_name, const ColumnList &columns) {
+unique_ptr<BoundConstraint> Binder::BindConstraint(Constraint &constraint, const string &table_name,
+                                                   const ColumnList &columns) {
 	switch (constraint.type) {
 	case ConstraintType::CHECK: {
 		unique_ptr<BoundConstraint> bound_constraint = make_uniq<BoundCheckConstraint>();
@@ -137,8 +138,8 @@ unique_ptr<BoundConstraint> Binder::BindConstraint(Constraint &constraint, const
 				auto column_index = column.Physical();
 				if (key_set.find(column_index) != key_set.end()) {
 					throw ParserException("column \"%s\" appears twice in "
-										  "primary key constraint",
-										  keyname);
+					                      "primary key constraint",
+					                      keyname);
 				}
 				keys.push_back(column_index);
 				key_set.insert(column_index);
@@ -149,8 +150,8 @@ unique_ptr<BoundConstraint> Binder::BindConstraint(Constraint &constraint, const
 	case ConstraintType::FOREIGN_KEY: {
 		auto &fk = constraint.Cast<ForeignKeyConstraint>();
 		D_ASSERT((fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE && !fk.info.pk_keys.empty()) ||
-				 (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE && !fk.info.pk_keys.empty()) ||
-				 fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE);
+		         (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE && !fk.info.pk_keys.empty()) ||
+		         fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE);
 		physical_index_set_t fk_key_set, pk_key_set;
 		for (auto &pk_key : fk.info.pk_keys) {
 			if (pk_key_set.find(pk_key) != pk_key_set.end()) {

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -150,8 +150,8 @@ unique_ptr<BoundConstraint> Binder::BindConstraint(Constraint &constraint, const
 	case ConstraintType::FOREIGN_KEY: {
 		auto &fk = constraint.Cast<ForeignKeyConstraint>();
 		D_ASSERT((fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE && !fk.info.pk_keys.empty()) ||
-			(fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE && !fk.info.pk_keys.empty()) ||
-			fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE);
+		         (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE && !fk.info.pk_keys.empty()) ||
+		         fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE);
 		physical_index_set_t fk_key_set, pk_key_set;
 		for (auto &pk_key : fk.info.pk_keys) {
 			if (pk_key_set.find(pk_key) != pk_key_set.end()) {
@@ -256,7 +256,7 @@ static void ExtractExpressionDependencies(Expression &expr, LogicalDependencyLis
 		}
 	}
 	ExpressionIterator::EnumerateChildren(
-		expr, [&](Expression &child) { ExtractExpressionDependencies(child, dependencies); });
+	    expr, [&](Expression &child) { ExtractExpressionDependencies(child, dependencies); });
 }
 
 static void ExtractDependencies(BoundCreateTableInfo &info, vector<unique_ptr<Expression>> &defaults,

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -98,14 +98,14 @@ unique_ptr<BoundConstraint> Binder::BindConstraint(Constraint &constraint, const
 	switch (constraint.type) {
 	case ConstraintType::CHECK: {
 		unique_ptr<BoundConstraint> bound_constraint = make_uniq<BoundCheckConstraint>();
-		auto check_constraint = bound_constraint->Cast<BoundCheckConstraint>();
+		auto &check_constraint = bound_constraint->Cast<BoundCheckConstraint>();
 		// check constraint: bind the expression
 		CheckBinder check_binder(*this, context, table_name, columns, check_constraint.bound_columns);
 		auto &check = constraint.Cast<CheckConstraint>();
 		// create a copy of the unbound expression because the binding destroys the constraint
 		auto unbound_expression = check.expression->Copy();
 		// now bind the constraint and create a new BoundCheckConstraint
-		check_constraint->expression = check_binder.Bind(check.expression);
+		check_constraint.expression = check_binder.Bind(check.expression);
 		// move the unbound constraint back into the original check expression
 		check.expression = std::move(unbound_expression);
 		return bound_constraint;
@@ -150,8 +150,8 @@ unique_ptr<BoundConstraint> Binder::BindConstraint(Constraint &constraint, const
 	case ConstraintType::FOREIGN_KEY: {
 		auto &fk = constraint.Cast<ForeignKeyConstraint>();
 		D_ASSERT((fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE && !fk.info.pk_keys.empty()) ||
-		         (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE && !fk.info.pk_keys.empty()) ||
-		         fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE);
+			(fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE && !fk.info.pk_keys.empty()) ||
+			fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE);
 		physical_index_set_t fk_key_set, pk_key_set;
 		for (auto &pk_key : fk.info.pk_keys) {
 			if (pk_key_set.find(pk_key) != pk_key_set.end()) {
@@ -256,7 +256,7 @@ static void ExtractExpressionDependencies(Expression &expr, LogicalDependencyLis
 		}
 	}
 	ExpressionIterator::EnumerateChildren(
-	    expr, [&](Expression &child) { ExtractExpressionDependencies(child, dependencies); });
+		expr, [&](Expression &child) { ExtractExpressionDependencies(child, dependencies); });
 }
 
 static void ExtractDependencies(BoundCreateTableInfo &info, vector<unique_ptr<Expression>> &defaults,

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -181,10 +181,10 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, BoundConstraint 
 		info->InitializeIndexes(context);
 	} else {
 		info->InitializeIndexes(context);
-	}
 
-	// Verify the new constraint against current persistent/local data
-	VerifyNewConstraint(local_storage, parent, constraint);
+		// Verify the new constraint against current persistent/local data
+		VerifyNewConstraint(local_storage, parent, constraint);
+	}
 
 	// Get the local data ownership from old dt
 	local_storage.MoveStorage(parent, *this);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1525,7 +1525,7 @@ void DataTable::AddIndexStorage(ClientContext &context, Index &index) {
 		const auto &col = column_definitions[i];
 		column_ids.push_back(col.StorageOid());
 		scan_types.push_back(col.GetType());
-		column_map.push_back(i+1);
+		column_map.push_back(i + 1);
 	}
 	rest.Initialize(context, scan_types);
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1504,6 +1504,11 @@ Index &DataTable::AddConstraintIndex(const vector<reference<const ColumnDefiniti
 }
 
 void DataTable::IndexExistingData(ClientContext &context, Index &index) {
+	if (!index.IsBound()) {
+		throw InternalException("Unbound index found in DataTable::IndexExistingData");
+	}
+	auto &bound_index = index.Cast<BoundIndex>();
+
 	vector<column_t> cids;
 	vector<LogicalType> scan_types;
 	for (const auto &col : column_definitions) {
@@ -1529,7 +1534,7 @@ void DataTable::IndexExistingData(ClientContext &context, Index &index) {
 		Vector row_identifiers(LogicalType::ROW_TYPE);
 		VectorOperations::GenerateSequence(row_identifiers, chunk.size(), indexed_rows, 1);
 
-		auto error = index.Append(chunk, row_identifiers);
+		auto error = bound_index.Append(chunk, row_identifiers);
 		if (error.HasError()) {
 			error.Throw();
 		}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1508,7 +1508,7 @@ Index &DataTable::AddConstraintIndex(const vector<reference<const ColumnDefiniti
 
 void DataTable::AddIndexStorage(ClientContext &context, Index &index) {
 	// If the table is empty, there's nothing to do
-	if (row_groups->GetTotalRows() == 0 || column_definitions.size() == 0) {
+	if (row_groups->GetTotalRows() == 0 || column_definitions.empty()) {
 		return;
 	}
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -805,7 +805,7 @@ void DataTable::VerifyAppendConstraints(ConstraintState &state, ClientContext &c
 			break;
 		}
 		case ConstraintType::CHECK: {
-			auto &check = base_constraint->Cast<BoundCheckConstraint>();
+			auto &check = constraint->Cast<BoundCheckConstraint>();
 			VerifyCheckConstraint(context, table, *check.expression, chunk);
 			break;
 		}
@@ -814,7 +814,7 @@ void DataTable::VerifyAppendConstraints(ConstraintState &state, ClientContext &c
 			break;
 		}
 		case ConstraintType::FOREIGN_KEY: {
-			auto &bfk = base_constraint->Cast<BoundForeignKeyConstraint>();
+			auto &bfk = constraint->Cast<BoundForeignKeyConstraint>();
 			if (bfk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
 			    bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
 				VerifyAppendForeignKeyConstraint(bfk, context, chunk);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -43,7 +43,7 @@ IndexStorageInfo GetIndexInfo(const IndexConstraintType &constraint_type, string
 
 DataTableInfo::DataTableInfo(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_manager_p, string schema,
                              string table)
-	: db(db), table_io_manager(std::move(table_io_manager_p)), schema(std::move(schema)), table(std::move(table)) {
+    : db(db), table_io_manager(std::move(table_io_manager_p)), schema(std::move(schema)), table(std::move(table)) {
 }
 
 void DataTableInfo::InitializeIndexes(ClientContext &context, const char *index_type) {
@@ -57,12 +57,12 @@ bool DataTableInfo::IsTemporary() const {
 DataTable::DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_manager_p, const string &schema,
                      const string &table, vector<ColumnDefinition> column_definitions_p,
                      unique_ptr<PersistentTableData> data)
-	: db(db), info(make_shared_ptr<DataTableInfo>(db, std::move(table_io_manager_p), schema, table)),
-	  column_definitions(std::move(column_definitions_p)), is_root(true) {
+    : db(db), info(make_shared_ptr<DataTableInfo>(db, std::move(table_io_manager_p), schema, table)),
+      column_definitions(std::move(column_definitions_p)), is_root(true) {
 	// initialize the table with the existing data from disk, if any
 	auto types = GetTypes();
 	this->row_groups =
-		make_shared_ptr<RowGroupCollection>(info, TableIOManager::Get(*this).GetBlockManagerForRowData(), types, 0);
+	    make_shared_ptr<RowGroupCollection>(info, TableIOManager::Get(*this).GetBlockManagerForRowData(), types, 0);
 	if (data && data->row_group_count > 0) {
 		this->row_groups->Initialize(*data);
 	} else {
@@ -73,7 +73,7 @@ DataTable::DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_m
 }
 
 DataTable::DataTable(ClientContext &context, DataTable &parent, ColumnDefinition &new_column, Expression &default_value)
-	: db(parent.db), info(parent.info), is_root(true) {
+    : db(parent.db), info(parent.info), is_root(true) {
 	// add the column definitions from this DataTable
 	for (auto &column_def : parent.column_definitions) {
 		column_definitions.emplace_back(column_def.Copy());
@@ -98,7 +98,7 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, ColumnDefinition
 }
 
 DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t removed_column)
-	: db(parent.db), info(parent.info), is_root(true) {
+    : db(parent.db), info(parent.info), is_root(true) {
 	// prevent any new tuples from being added to the parent
 	auto &local_storage = LocalStorage::Get(context, db);
 	lock_guard<mutex> parent_lock(parent.append_lock);
@@ -147,7 +147,7 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t removed_co
 
 // Alter column to add new constraint
 DataTable::DataTable(ClientContext &context, DataTable &parent, BoundConstraint &constraint)
-	: db(parent.db), info(parent.info), row_groups(parent.row_groups), is_root(true) {
+    : db(parent.db), info(parent.info), row_groups(parent.row_groups), is_root(true) {
 
 	auto &local_storage = LocalStorage::Get(context, db);
 	lock_guard<mutex> parent_lock(parent.append_lock);
@@ -192,16 +192,9 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, BoundConstraint 
 	parent.is_root = false;
 }
 
-DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_idx,
-
-
-                     const LogicalType &target_type,
-
-
-                     const vector<column_t> &bound_columns, Expression &cast_expr
-	)
-	:
-	db(parent.db), info(parent.info), is_root(true) {
+DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_idx, const LogicalType &target_type,
+                     const vector<column_t> &bound_columns, Expression &cast_expr)
+    : db(parent.db), info(parent.info), is_root(true) {
 	auto &local_storage = LocalStorage::Get(context, db);
 	// prevent any tuples from being added to the parent
 	lock_guard<mutex> lock(append_lock);
@@ -274,8 +267,7 @@ void DataTable::InitializeScan(TableScanState &state, const vector<column_t> &co
 	row_groups->InitializeScan(state.table_state, column_ids, table_filters);
 }
 
-void DataTable::InitializeScan(DuckTransaction &transaction, TableScanState &state,
-                               const vector<column_t> &column_ids,
+void DataTable::InitializeScan(DuckTransaction &transaction, TableScanState &state, const vector<column_t> &column_ids,
                                TableFilterSet *table_filters) {
 	auto &local_storage = LocalStorage::Get(transaction);
 	InitializeScan(state, column_ids, table_filters);
@@ -561,7 +553,7 @@ void DataTable::VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk,
 	}
 
 	auto &table_entry_ptr =
-		Catalog::GetEntry<TableCatalogEntry>(context, INVALID_CATALOG, bfk.info.schema, bfk.info.table);
+	    Catalog::GetEntry<TableCatalogEntry>(context, INVALID_CATALOG, bfk.info.schema, bfk.info.table);
 	// make the data chunk to check
 	vector<LogicalType> types;
 	for (auto &col : table_entry_ptr.GetColumns().Physical()) {
@@ -615,9 +607,7 @@ void DataTable::VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk,
 	optional_ptr<Index> index;
 	optional_ptr<Index> transaction_index;
 
-	auto fk_type = is_append
-		               ? ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE
-		               : ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
+	auto fk_type = is_append ? ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE : ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
 	// check whether or not the chunk can be inserted or deleted into the referenced table' storage
 	index = data_table.info->indexes.FindForeignKeyIndex(*dst_keys_ptr, fk_type);
 	if (transaction_check) {
@@ -686,8 +676,7 @@ void DataTable::VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint
 	VerifyForeignKeyConstraint(bfk, context, chunk, VerifyExistenceType::DELETE_FK);
 }
 
-void DataTable::VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent,
-                                    const BoundConstraint &constraint) {
+void DataTable::VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint) {
 	if (constraint.type != ConstraintType::NOT_NULL) {
 		throw NotImplementedException("FIXME: ALTER COLUMN with such constraint is not supported yet");
 	}
@@ -844,8 +833,7 @@ void DataTable::InitializeLocalAppend(LocalAppendState &state, TableCatalogEntry
 	state.constraint_state = InitializeConstraintState(table, bound_constraints);
 }
 
-void DataTable::LocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context,
-                            DataChunk &chunk,
+void DataTable::LocalAppend(LocalAppendState &state, TableCatalogEntry &table, ClientContext &context, DataChunk &chunk,
                             bool unsafe) {
 	if (chunk.size() == 0) {
 		return;
@@ -931,8 +919,7 @@ void DataTable::FinalizeAppend(DuckTransaction &transaction, TableAppendState &s
 	row_groups->FinalizeAppend(transaction, state);
 }
 
-void DataTable::ScanTableSegment(idx_t row_start, idx_t count,
-                                 const std::function<void(DataChunk &chunk)> &function) {
+void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::function<void(DataChunk &chunk)> &function) {
 	if (count == 0) {
 		return;
 	}
@@ -951,8 +938,7 @@ void DataTable::ScanTableSegment(idx_t row_start, idx_t count,
 	CreateIndexScanState state;
 
 	InitializeScanWithOffset(state, column_ids, row_start, row_start + count);
-	auto row_start_aligned = state.table_state.row_group->start + state.table_state.vector_index *
-	                         STANDARD_VECTOR_SIZE;
+	auto row_start_aligned = state.table_state.row_group->start + state.table_state.vector_index * STANDARD_VECTOR_SIZE;
 
 	idx_t current_row = row_start_aligned;
 	while (current_row < end) {
@@ -1175,8 +1161,7 @@ void DataTable::VerifyDeleteConstraints(TableDeleteState &state, ClientContext &
 }
 
 unique_ptr<TableDeleteState> DataTable::InitializeDelete(TableCatalogEntry &table, ClientContext &context,
-                                                         const vector<unique_ptr<BoundConstraint>> &
-                                                         bound_constraints) {
+                                                         const vector<unique_ptr<BoundConstraint>> &bound_constraints) {
 	// initialize indexes (if any)
 	info->InitializeIndexes(context);
 
@@ -1277,8 +1262,7 @@ static bool CreateMockChunk(TableCatalogEntry &table, const vector<PhysicalIndex
 	if (found_columns != desired_column_ids.size()) {
 		// not all columns in UPDATE clause are present!
 		// this should not be triggered at all as the binder should add these columns
-		throw InternalException(
-			"Not all columns required for the CHECK constraint are present in the UPDATED chunk!");
+		throw InternalException("Not all columns required for the CHECK constraint are present in the UPDATED chunk!");
 	}
 	// construct a mock DataChunk
 	auto types = table.GetTypes();
@@ -1338,8 +1322,7 @@ void DataTable::VerifyUpdateConstraints(ConstraintState &state, ClientContext &c
 }
 
 unique_ptr<TableUpdateState> DataTable::InitializeUpdate(TableCatalogEntry &table, ClientContext &context,
-                                                         const vector<unique_ptr<BoundConstraint>> &
-                                                         bound_constraints) {
+                                                         const vector<unique_ptr<BoundConstraint>> &bound_constraints) {
 	// check that there are no unknown indexes
 	info->InitializeIndexes(context);
 
@@ -1506,7 +1489,7 @@ Index &DataTable::AddConstraintIndex(const vector<reference<const ColumnDefiniti
 		auto &column = column_p.get();
 		D_ASSERT(!column.Generated());
 		unbound_expressions.push_back(
-			make_uniq<BoundColumnRefExpression>(column.Name(), column.Type(), ColumnBinding(0, column_ids.size())));
+		    make_uniq<BoundColumnRefExpression>(column.Name(), column.Type(), ColumnBinding(0, column_ids.size())));
 
 		bound_expressions.push_back(make_uniq<BoundReferenceExpression>(column.Type(), key_nr++));
 		column_ids.push_back(column.StorageOid());

--- a/src/storage/serialization/serialize_parse_info.cpp
+++ b/src/storage/serialization/serialize_parse_info.cpp
@@ -123,6 +123,9 @@ unique_ptr<AlterInfo> AlterTableInfo::Deserialize(Deserializer &deserializer) {
 	case AlterTableType::ADD_COLUMN:
 		result = AddColumnInfo::Deserialize(deserializer);
 		break;
+	case AlterTableType::ADD_CONSTRAINT:
+		result = AddConstraintInfo::Deserialize(deserializer);
+		break;
 	case AlterTableType::ALTER_COLUMN_TYPE:
 		result = ChangeColumnTypeInfo::Deserialize(deserializer);
 		break;
@@ -181,6 +184,17 @@ unique_ptr<AlterTableInfo> AddColumnInfo::Deserialize(Deserializer &deserializer
 	auto new_column = deserializer.ReadProperty<ColumnDefinition>(400, "new_column");
 	auto result = duckdb::unique_ptr<AddColumnInfo>(new AddColumnInfo(std::move(new_column)));
 	deserializer.ReadPropertyWithDefault<bool>(401, "if_column_not_exists", result->if_column_not_exists);
+	return std::move(result);
+}
+
+void AddConstraintInfo::Serialize(Serializer &serializer) const {
+	AlterTableInfo::Serialize(serializer);
+	serializer.WritePropertyWithDefault<unique_ptr<Constraint>>(400, "constraint", constraint);
+}
+
+unique_ptr<AlterTableInfo> AddConstraintInfo::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<AddConstraintInfo>(new AddConstraintInfo());
+	deserializer.ReadPropertyWithDefault<unique_ptr<Constraint>>(400, "constraint", result->constraint);
 	return std::move(result);
 }
 

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -11,11 +11,12 @@
 #include "duckdb/planner/expression_binder/index_binder.hpp"
 
 namespace duckdb {
-Index *TableIndexList::AddIndex(unique_ptr<Index> index) {
+Index &TableIndexList::AddIndex(unique_ptr<Index> index) {
 	D_ASSERT(index);
 	lock_guard<mutex> lock(indexes_lock);
+	auto &result = *index;
 	indexes.push_back(std::move(index));
-	return indexes.at(indexes.size() - 1).get();
+	return result;
 }
 
 void TableIndexList::RemoveIndex(const string &name) {
@@ -137,8 +138,8 @@ Index *TableIndexList::FindForeignKeyIndex(const vector<PhysicalIndex> &fk_keys,
 void TableIndexList::VerifyForeignKey(const vector<PhysicalIndex> &fk_keys, DataChunk &chunk,
                                       ConflictManager &conflict_manager) {
 	auto fk_type = conflict_manager.LookupType() == VerifyExistenceType::APPEND_FK
-	                   ? ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE
-	                   : ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
+		               ? ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE
+		               : ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
 
 	// check whether the chunk can be inserted or deleted into the referenced table storage
 	auto index = FindForeignKeyIndex(fk_keys, fk_type);

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -14,9 +14,8 @@ namespace duckdb {
 Index &TableIndexList::AddIndex(unique_ptr<Index> index) {
 	D_ASSERT(index);
 	lock_guard<mutex> lock(indexes_lock);
-	auto &result = *index;
 	indexes.push_back(std::move(index));
-	return result;
+	return *indexes.back();
 }
 
 void TableIndexList::RemoveIndex(const string &name) {

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -138,8 +138,8 @@ Index *TableIndexList::FindForeignKeyIndex(const vector<PhysicalIndex> &fk_keys,
 void TableIndexList::VerifyForeignKey(const vector<PhysicalIndex> &fk_keys, DataChunk &chunk,
                                       ConflictManager &conflict_manager) {
 	auto fk_type = conflict_manager.LookupType() == VerifyExistenceType::APPEND_FK
-		               ? ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE
-		               : ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
+	                   ? ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE
+	                   : ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
 
 	// check whether the chunk can be inserted or deleted into the referenced table storage
 	auto index = FindForeignKeyIndex(fk_keys, fk_type);

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -11,7 +11,7 @@
 #include "duckdb/planner/expression_binder/index_binder.hpp"
 
 namespace duckdb {
-Index* TableIndexList::AddIndex(unique_ptr<Index> index) {
+Index *TableIndexList::AddIndex(unique_ptr<Index> index) {
 	D_ASSERT(index);
 	lock_guard<mutex> lock(indexes_lock);
 	indexes.push_back(std::move(index));

--- a/src/storage/table_index_list.cpp
+++ b/src/storage/table_index_list.cpp
@@ -11,10 +11,11 @@
 #include "duckdb/planner/expression_binder/index_binder.hpp"
 
 namespace duckdb {
-void TableIndexList::AddIndex(unique_ptr<Index> index) {
+Index* TableIndexList::AddIndex(unique_ptr<Index> index) {
 	D_ASSERT(index);
 	lock_guard<mutex> lock(indexes_lock);
 	indexes.push_back(std::move(index));
+	return indexes.at(indexes.size() - 1).get();
 }
 
 void TableIndexList::RemoveIndex(const string &name) {

--- a/test/sql/alter/alter_col/test_add_primary_key.test
+++ b/test/sql/alter/alter_col/test_add_primary_key.test
@@ -5,7 +5,7 @@
 statement ok
 PRAGMA enable_verification
 
-# single column pk
+# Scenario #1: single column pk
 statement ok
 CREATE TABLE test1 (i INTEGER, j INTEGER)
 
@@ -46,7 +46,7 @@ ALTER TABLE test1 ADD PRIMARY KEY (j)
 ----
 table "test1" already has a PRIMARY KEY(j)
 
-# multiple column pk
+# Scenario #2: multiple column pk
 statement ok
 CREATE TABLE test2 (i INTEGER, j INTEGER, d TEXT)
 
@@ -69,7 +69,7 @@ INSERT INTO test2 VALUES (NULL, 2, 'nada')
 ----
 NOT NULL constraint failed: test2.i
 
-# primary key already exists
+# Scenario #3: primary key already exists
 statement ok
 CREATE TABLE test3 (i INTEGER PRIMARY KEY, j INTEGER)
 
@@ -78,7 +78,7 @@ ALTER TABLE test3 ADD PRIMARY KEY (i, j)
 ----
 table "test3" already has a PRIMARY KEY(i)
 
-# column does not exist
+# Scenario #4: column does not exist
 statement ok
 CREATE TABLE test4 (i INTEGER, j INTEGER)
 
@@ -87,13 +87,13 @@ ALTER TABLE test4 ADD PRIMARY KEY (i_do_not_exist)
 ----
 Table "test4" does not have a column named "i_do_not_exist"
 
-# table does not exist
+# Scenario #5: table does not exist
 statement error
 ALTER TABLE i_do_not_exist ADD PRIMARY KEY (i, j)
 ----
 Table with name i_do_not_exist does not exist!
 
-# add pk to table containing data invalidating the constraint (this should fail)
+# Scenario #6: add pk to table containing data invalidating the constraint (this should fail)
 statement ok
 CREATE TABLE test5 (i INTEGER, j INTEGER)
 
@@ -103,3 +103,4 @@ INSERT INTO test5 VALUES (1, 10), (2, 20), (3, 30), (1, 100), (NULL, 0)
 statement error
 ALTER TABLE test5 ADD PRIMARY KEY (i)
 ----
+PRIMARY KEY or UNIQUE constraint violated: duplicate key "1"

--- a/test/sql/alter/alter_col/test_add_primary_key.test
+++ b/test/sql/alter/alter_col/test_add_primary_key.test
@@ -1,0 +1,105 @@
+# name: test/sql/alter/alter_col/test_add_primary_key.test
+# description: Test ALTER TABLE table ADD PRIMARY KEY (column)
+# group: [alter_col]
+
+statement ok
+PRAGMA enable_verification
+
+# single column pk
+statement ok
+CREATE TABLE test1 (i INTEGER, j INTEGER)
+
+statement ok
+INSERT INTO test1 VALUES (1, 1)
+
+statement ok
+ALTER TABLE test1 ADD PRIMARY KEY (j)
+
+# Check data is preserved
+query II
+SELECT * FROM test1
+----
+1	1
+
+statement ok
+INSERT INTO test1 VALUES (1, 2)
+
+statement error
+INSERT INTO test1 VALUES (2, 1)
+----
+Duplicate key "j: 1" violates primary key constraint
+
+statement error
+INSERT INTO test1 VALUES (2, NULL)
+----
+NOT NULL constraint failed: test1.j
+
+# altering a second time should fail, only one pk is allowed per table
+statement error
+ALTER TABLE test1 ADD PRIMARY KEY (i)
+----
+table "test1" already has a PRIMARY KEY(j)
+
+# even if it's an exact duplicate
+statement error
+ALTER TABLE test1 ADD PRIMARY KEY (j)
+----
+table "test1" already has a PRIMARY KEY(j)
+
+# multiple column pk
+statement ok
+CREATE TABLE test2 (i INTEGER, j INTEGER, d TEXT)
+
+statement ok
+ALTER TABLE test2 ADD PRIMARY KEY (i, j)
+
+statement ok
+INSERT INTO test2 VALUES (1, 1, 'foo')
+
+statement ok
+INSERT INTO test2 VALUES (1, 2, 'bar')
+
+statement error
+INSERT INTO test2 VALUES (1, 2, 'oops')
+----
+Duplicate key "i: 1, j: 2" violates primary key constraint
+
+statement error
+INSERT INTO test2 VALUES (NULL, 2, 'nada')
+----
+NOT NULL constraint failed: test2.i
+
+# primary key already exists
+statement ok
+CREATE TABLE test3 (i INTEGER PRIMARY KEY, j INTEGER)
+
+statement error
+ALTER TABLE test3 ADD PRIMARY KEY (i, j)
+----
+table "test3" already has a PRIMARY KEY(i)
+
+# column does not exist
+statement ok
+CREATE TABLE test4 (i INTEGER, j INTEGER)
+
+statement error
+ALTER TABLE test4 ADD PRIMARY KEY (i_do_not_exist)
+----
+Table "test4" does not have a column named "i_do_not_exist"
+
+# table does not exist
+statement error
+ALTER TABLE i_do_not_exist ADD PRIMARY KEY (i, j)
+----
+Table with name i_do_not_exist does not exist!
+
+# add pk to table containing data invalidating the constraint (this should fail)
+statement ok
+CREATE TABLE test5 (i INTEGER, j INTEGER)
+
+statement ok
+INSERT INTO test5 VALUES (1, 10), (2, 20), (3, 30), (1, 100), (NULL, 0)
+
+statement error
+ALTER TABLE test5 ADD PRIMARY KEY (i)
+----

--- a/test/sql/alter/alter_col/test_add_primary_key.test
+++ b/test/sql/alter/alter_col/test_add_primary_key.test
@@ -104,3 +104,26 @@ statement error
 ALTER TABLE test5 ADD PRIMARY KEY (i)
 ----
 PRIMARY KEY or UNIQUE constraint violated: duplicate key "1"
+
+# Scenario #7: test with non-consecutive row ids
+statement ok
+CREATE TABLE integers(i integer)
+
+statement ok
+INSERT INTO integers SELECT * FROM range(50000);
+
+query I
+SELECT i FROM integers WHERE i = 100
+----
+100
+
+statement ok
+DELETE FROM integers WHERE i = 42;
+
+statement ok
+ALTER TABLE integers ADD PRIMARY KEY (i);
+
+query I
+SELECT i FROM integers WHERE i = 100
+----
+100

--- a/test/sql/alter/alter_col/test_add_primary_key.test
+++ b/test/sql/alter/alter_col/test_add_primary_key.test
@@ -155,3 +155,52 @@ statement error
 INSERT INTO test8 VALUES (NULL, 100)
 ----
 Constraint Error: NOT NULL constraint failed: test8.i
+
+# Scenario #9: reverse column order in index
+statement ok
+CREATE TABLE test9 (i INTEGER, j INTEGER)
+
+statement ok
+INSERT INTO test9 VALUES (1, 2)
+
+statement ok
+ALTER TABLE test9 ADD PRIMARY KEY (j, i)
+
+statement error
+INSERT INTO test9 VALUES (1, 2)
+----
+Duplicate key "j: 2, i: 1" violates primary key constraint.
+
+statement error
+INSERT INTO test9 (j, i) VALUES (2, 1)
+----
+Duplicate key "j: 2, i: 1" violates primary key constraint.
+
+# Scenario #10: invalid primary key type
+statement ok
+CREATE TABLE test10 (a INTEGER[], b INTEGER)
+
+statement error
+ALTER TABLE test10 ADD PRIMARY KEY (a)
+----
+Invalid type Error: Invalid Type [INTEGER[]]: Invalid type for index key.
+
+statement error
+ALTER TABLE test10 ADD PRIMARY KEY (a, b)
+----
+Invalid type Error: Invalid Type [INTEGER[]]: Invalid type for index key.
+
+# Scenario #11: After adding a primary key to an existing table, verify index is correct
+statement ok
+CREATE TABLE test11 (i INTEGER, j INTEGER)
+
+statement ok
+INSERT INTO test11 VALUES (4, 40), (1, 10), (3, 30), (2, 20), (5, 50)
+
+statement ok
+ALTER TABLE test11 ADD PRIMARY KEY (i)
+
+query II
+SELECT * FROM test11 WHERE i = 2
+----
+2	20

--- a/test/sql/alter/alter_col/test_add_primary_key.test
+++ b/test/sql/alter/alter_col/test_add_primary_key.test
@@ -38,13 +38,13 @@ NOT NULL constraint failed: test1.j
 statement error
 ALTER TABLE test1 ADD PRIMARY KEY (i)
 ----
-table "test1" already has a PRIMARY KEY(j)
+Catalog Error: table "test1" can have only one primary key, and already has PRIMARY KEY(j).
 
 # even if it's an exact duplicate
 statement error
 ALTER TABLE test1 ADD PRIMARY KEY (j)
 ----
-table "test1" already has a PRIMARY KEY(j)
+Catalog Error: table "test1" can have only one primary key, and already has PRIMARY KEY(j).
 
 # Scenario #2: multiple column pk
 statement ok
@@ -76,7 +76,7 @@ CREATE TABLE test3 (i INTEGER PRIMARY KEY, j INTEGER)
 statement error
 ALTER TABLE test3 ADD PRIMARY KEY (i, j)
 ----
-table "test3" already has a PRIMARY KEY(i)
+Catalog Error: table "test3" can have only one primary key, and already has PRIMARY KEY(i).
 
 # Scenario #4: column does not exist
 statement ok
@@ -95,13 +95,13 @@ Table with name i_do_not_exist does not exist!
 
 # Scenario #6: add pk to table containing data invalidating the constraint (this should fail)
 statement ok
-CREATE TABLE test5 (i INTEGER, j INTEGER)
+CREATE TABLE test6 (i INTEGER, j INTEGER)
 
 statement ok
-INSERT INTO test5 VALUES (1, 10), (2, 20), (3, 30), (1, 100), (NULL, 0)
+INSERT INTO test6 VALUES (1, 10), (2, 20), (3, 30), (1, 100), (NULL, 0)
 
 statement error
-ALTER TABLE test5 ADD PRIMARY KEY (i)
+ALTER TABLE test6 ADD PRIMARY KEY (i)
 ----
 PRIMARY KEY or UNIQUE constraint violated: duplicate key "1"
 
@@ -127,3 +127,31 @@ query I
 SELECT i FROM integers WHERE i = 100
 ----
 100
+
+# Scenario #8: Add primary key to column with already a unique index on it
+statement ok
+CREATE TABLE test8 (i INTEGER UNIQUE, j INTEGER)
+
+statement ok
+INSERT INTO test8 VALUES (1, 10), (2, 20), (3, 30)
+
+statement error
+INSERT INTO test8 VALUES (1, 100)
+----
+Constraint Error: Duplicate key "i: 1" violates unique constraint.
+
+statement ok
+INSERT INTO test8 VALUES (NULL, 100)
+
+statement ok
+ALTER TABLE test8 ADD PRIMARY KEY (i)
+
+statement error
+INSERT INTO test8 VALUES (1, 101)
+----
+Constraint Error: Duplicate key "i: 1" violates primary key constraint.
+
+statement error
+INSERT INTO test8 VALUES (NULL, 100)
+----
+Constraint Error: NOT NULL constraint failed: test8.i

--- a/test/sql/alter/alter_col/test_add_primary_key_database.test
+++ b/test/sql/alter/alter_col/test_add_primary_key_database.test
@@ -1,0 +1,79 @@
+# name: test/sql/alter/alter_col/test_add_primary_key_database.test
+# description: Test ALTER TABLE table ADD PRIMARY KEY (column)
+# group: [alter_col]
+
+load __TEST_DIR__/test_add_primary_key.db
+
+statement ok
+PRAGMA enable_verification
+
+# Scenario #1: test storage of primary keys
+statement ok
+CREATE TABLE test1 (i INTEGER, j INTEGER)
+
+statement ok
+ALTER TABLE test1 ADD PRIMARY KEY (j)
+
+statement ok
+INSERT INTO test1 VALUES (1, 1)
+
+restart
+
+statement error
+ALTER TABLE test1 ADD PRIMARY KEY (i)
+----
+Catalog Error: table "test1" can have only one primary key, and already has PRIMARY KEY(j).
+
+statement error
+INSERT INTO test1 VALUES (2, 1)
+----
+Constraint Error: Duplicate key "j: 1" violates primary key constraint.
+
+# Scenario #2: test detach/reattach
+statement ok
+ATTACH ':memory:' as memory
+
+statement ok
+USE memory
+
+statement ok
+DETACH test_add_primary_key
+
+statement ok
+ATTACH '__TEST_DIR__/test_add_primary_key.db' as test_add_primary_key
+
+statement ok
+USE test_add_primary_key
+
+statement error
+ALTER TABLE test1 ADD PRIMARY KEY (i)
+----
+Catalog Error: table "test1" can have only one primary key, and already has PRIMARY KEY(j).
+
+statement error
+INSERT INTO test1 VALUES (2, 1)
+----
+Constraint Error: Duplicate key "j: 1" violates primary key constraint.
+
+# Scenario #3: drop and re-create table (pk should not be persisted)
+statement ok
+CREATE TABLE test3 (i INTEGER, j INTEGER)
+
+statement ok
+ALTER TABLE test3 ADD PRIMARY KEY (j)
+
+statement ok
+INSERT INTO test3 VALUES (1, 1)
+
+statement ok
+DROP TABLE test3
+
+statement ok
+CREATE TABLE test3 (i INTEGER, j INTEGER)
+
+statement ok
+INSERT INTO test3 VALUES (1, 1)
+
+statement ok
+ALTER TABLE test3 ADD PRIMARY KEY (j)
+

--- a/test/sql/alter/alter_col/test_add_primary_key_transaction.test
+++ b/test/sql/alter/alter_col/test_add_primary_key_transaction.test
@@ -1,0 +1,123 @@
+# name: test/sql/alter/alter_col/test_add_primary_key_transaction.test
+# description: Test ALTER TABLE table ADD PRIMARY KEY (column) when using transactions
+# group: [alter_col]
+
+statement ok
+PRAGMA enable_verification
+
+# Scenario #1: invalidate constraint with uncommitted changes but rollback
+statement ok
+CREATE TABLE test1 (i INTEGER, j INTEGER)
+
+statement ok
+BEGIN TRANSACTION
+
+# Uncommitted change
+statement ok
+INSERT INTO test1 VALUES (1, 1)
+
+statement ok
+ALTER TABLE test1 ADD PRIMARY KEY (j)
+
+# This passes as it's not committed yet
+statement ok
+INSERT INTO test1 VALUES (2, 1)
+
+# This should be fine
+statement ok
+ROLLBACK
+
+# Can insert duplicates after rollback
+statement ok
+INSERT INTO test1 VALUES (1, 1)
+
+statement ok
+INSERT INTO test1 VALUES (2, 1)
+
+statement ok
+INSERT INTO test1 VALUES (2, NULL)
+
+# Scenario #2: invalidate constraint with uncommitted changes
+statement ok
+CREATE TABLE test2 (i INTEGER, j INTEGER)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO test2 VALUES (1, 1)
+
+statement ok
+ALTER TABLE test2 ADD PRIMARY KEY (j)
+
+statement ok
+INSERT INTO test2 VALUES (2, 1)
+
+# Now it should fail
+statement error
+COMMIT
+----
+Failed to commit: PRIMARY KEY or UNIQUE constraint violated: duplicate key "1"
+
+# Scenario #3: commit successfully preserves primary key
+statement ok
+CREATE TABLE test3 (i INTEGER, j INTEGER)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO test2 VALUES (1, 1)
+
+statement ok
+ALTER TABLE test2 ADD PRIMARY KEY (j)
+
+statement ok
+COMMIT
+
+statement error
+INSERT INTO test2 VALUES (2, 1)
+----
+Duplicate key "j: 1" violates primary key constraint
+
+# Scenario #4: double primary key added
+statement ok
+CREATE TABLE test4 (i INTEGER, j INTEGER)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+ALTER TABLE test4 ADD PRIMARY KEY (j)
+
+# Errors immediately, but does not cause the transaction to abort
+statement error
+ALTER TABLE test4 ADD PRIMARY KEY (i)
+----
+Catalog Error: table "test4" already has a PRIMARY KEY(j).
+
+statement ok
+COMMIT
+
+# Scenario #5: add and delete conflicting row within transaction
+statement ok
+CREATE TABLE test5 (i INTEGER, j INTEGER)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO test5 VALUES (1, 1)
+
+statement ok
+ALTER TABLE test5 ADD PRIMARY KEY (j)
+
+statement ok
+INSERT INTO test5 VALUES (2, 1)
+
+statement ok
+DELETE FROM test5 WHERE i = 2
+
+statement ok
+COMMIT
+

--- a/test/sql/alter/alter_col/test_add_primary_key_transaction.test
+++ b/test/sql/alter/alter_col/test_add_primary_key_transaction.test
@@ -94,7 +94,7 @@ ALTER TABLE test4 ADD PRIMARY KEY (j)
 statement error
 ALTER TABLE test4 ADD PRIMARY KEY (i)
 ----
-Catalog Error: table "test4" already has a PRIMARY KEY(j).
+Catalog Error: table "test4" can have only one primary key, and already has PRIMARY KEY(j).
 
 statement ok
 COMMIT
@@ -121,3 +121,20 @@ DELETE FROM test5 WHERE i = 2
 statement ok
 COMMIT
 
+# Scenario #6: Multiple transaction try to add primary key
+statement ok
+CREATE TABLE test6 (i INTEGER, j INTEGER)
+
+statement ok tran1
+BEGIN TRANSACTION
+
+statement ok tran1
+ALTER TABLE test6 ADD PRIMARY KEY (j)
+
+statement ok tran2
+BEGIN TRANSACTION
+
+statement error tran2
+ALTER TABLE test6 ADD PRIMARY KEY (j)
+----
+TransactionContext Error: Catalog write-write conflict on alter with "test6"


### PR DESCRIPTION
This PR implements `ALTER TABLE table ADD PRIMARY KEY (col1, ...);` statements, as per #57.

I suggest reviewing by commit, as I tried to make them thematic and self-contained. However, the first commits basically do changes needed for the last 2-3 commits, so please have a look at the final ones if something's unclear.

Let me know if there is anything I can improve.