### PR TITLE
[Dev] Fix a SerializationException on CopyInfo

### DIFF
--- a/extension/json/json_functions/copy_json.cpp
+++ b/extension/json/json_functions/copy_json.cpp
@@ -65,9 +65,10 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	auto select_stmt = make_uniq<SelectStatement>();
 	select_stmt->node = std::move(copied_info.select_statement);
 	auto subquery_ref = make_uniq<SubqueryRef>(std::move(select_stmt));
+
 	copied_info.select_statement = make_uniq_base<QueryNode, SelectNode>();
-	auto &new_select_node = copied_info.select_statement->Cast<SelectNode>();
-	new_select_node.from_table = std::move(subquery_ref);
+	auto &select_node = copied_info.select_statement->Cast<SelectNode>();
+	select_node.from_table = std::move(subquery_ref);
 
 	// Create new select list
 	vector<unique_ptr<ParsedExpression>> select_list;
@@ -95,7 +96,6 @@ static BoundStatement CopyToJSONPlan(Binder &binder, CopyStatement &stmt) {
 	}
 
 	// Now create the struct_pack/to_json to create a JSON object per row
-	auto &select_node = copied_info.select_statement->Cast<SelectNode>();
 	vector<unique_ptr<ParsedExpression>> struct_pack_child;
 	struct_pack_child.emplace_back(make_uniq<FunctionExpression>("struct_pack", std::move(select_list)));
 	select_node.select_list.emplace_back(make_uniq<FunctionExpression>("to_json", std::move(struct_pack_child)));

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -47,7 +47,8 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 
 	auto &copy_info = *stmt.info;
 	// bind the select statement
-	auto select_node = Bind(*copy_info.select_statement);
+	auto node_copy = copy_info.select_statement->Copy();
+	auto select_node = Bind(*node_copy);
 
 	if (!copy_function.function.copy_to_bind) {
 		throw NotImplementedException("COPY TO is not supported for FORMAT \"%s\"", stmt.info->format);

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -182,10 +182,16 @@ void Planner::VerifyPlan(ClientContext &context, unique_ptr<LogicalOperator> &op
 			*map = std::move(parameters);
 		}
 		op = std::move(new_plan);
-	} catch (SerializationException &ex) {  // NOLINT: explicitly allowing these errors (for now)
-		                                    // pass
-	} catch (NotImplementedException &ex) { // NOLINT: explicitly allowing these errors (for now)
-		                                    // pass
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		switch (error.Type()) {
+		case ExceptionType::SERIALIZATION:   // NOLINT: explicitly allowing these errors (for now)
+			break;                           // pass
+		case ExceptionType::NOT_IMPLEMENTED: // NOLINT: explicitly allowing these errors (for now)
+			break;                           // pass
+		default:
+			throw;
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes the CI failure here: https://github.com/duckdb/duckdb/actions/runs/8916754832/job/24491338899

Two issues, CopyInfo recently gained the SelectNode that was previously in CopyStatement.
CopyInfo gets serialized in certain placed, SelectNode contains Expressions, these can not be BoundExpressions otherwise it can't be serialized - and throws a SerializationException.

We don't currently act on SerializationExceptions in the VerifyPlan method, which brings me to the next issue.
The CI should not have failed on this, because these exceptions get swallowed.

This did not get swallowed because the Exception originated from a different build, see https://github.com/duckdb/duckdb/pull/10410 for more details on this issue.

We now catch the exceptions in a way that is safe from this issue 👍 