### PR TITLE
Allow converting `TIMETZ` to Arrow

### DIFF
--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -138,13 +138,15 @@ static void InitializeFunctionPointers(ArrowAppendData &append_data, const Logic
 	case LogicalTypeId::INTEGER:
 		InitializeAppenderForType<ArrowScalarData<int32_t>>(append_data);
 		break;
+	case LogicalTypeId::TIME_TZ:
+		InitializeAppenderForType<ArrowScalarData<int64_t, dtime_tz_t, ArrowTimeTzConverter>>(append_data);
+		break;
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::TIMESTAMP_SEC:
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_TZ:
-	case LogicalTypeId::TIME_TZ:
 	case LogicalTypeId::BIGINT:
 		InitializeAppenderForType<ArrowScalarData<int64_t>>(append_data);
 		break;

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -138,9 +138,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 	case LogicalTypeId::DATE:
 		child.format = "tdD";
 		break;
-#ifdef DUCKDB_WASM
 	case LogicalTypeId::TIME_TZ:
-#endif
 	case LogicalTypeId::TIME:
 		child.format = "ttu";
 		break;

--- a/src/include/duckdb/common/arrow/appender/scalar_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/scalar_data.hpp
@@ -42,6 +42,21 @@ struct ArrowIntervalConverter {
 	}
 };
 
+struct ArrowTimeTzConverter {
+	template <class TGT, class SRC>
+	static TGT Operation(SRC input) {
+		return input.time().micros;
+	}
+
+	static bool SkipNulls() {
+		return true;
+	}
+
+	template <class TGT>
+	static void SetNull(TGT &value) {
+	}
+};
+
 template <class TGT, class SRC = TGT, class OP = ArrowScalarConverter>
 struct ArrowScalarBaseData {
 	static void Append(ArrowAppendData &append_data, Vector &input, idx_t from, idx_t to, idx_t input_size) {

--- a/tools/pythonpkg/tests/fast/api/test_native_tz.py
+++ b/tools/pythonpkg/tests/fast/api/test_native_tz.py
@@ -70,5 +70,14 @@ class TestNativeTimeZone(object):
         assert res['tz'][0].hour == 21 and res['tz'][0].minute == 52
 
     def test_arrow_timestamp_time(self, duckdb_cursor):
-        with pytest.raises(duckdb.NotImplementedException, match="Unsupported Arrow type"):
-            duckdb_cursor.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").arrow()
+        duckdb_cursor.execute("SET timezone='America/Los_Angeles';")
+        res1 = duckdb_cursor.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").arrow().to_pandas()
+        res2 = duckdb_cursor.execute(f"select TimeRecStart::TIMETZ::TIME  as tz  from '{filename}'").arrow().to_pandas()
+        assert res1['tz'][0].hour == 21 and res1['tz'][0].minute == 52
+        assert res2['tz'][0].hour == res2['tz'][0].hour and res2['tz'][0].minute == res1['tz'][0].minute
+
+        duckdb_cursor.execute("SET timezone='UTC';")
+        res1 = duckdb_cursor.execute(f"select TimeRecStart::TIMETZ  as tz  from '{filename}'").arrow().to_pandas()
+        res2 = duckdb_cursor.execute(f"select TimeRecStart::TIMETZ::TIME  as tz  from '{filename}'").arrow().to_pandas()
+        assert res1['tz'][0].hour == 21 and res1['tz'][0].minute == 52
+        assert res2['tz'][0].hour == res2['tz'][0].hour and res2['tz'][0].minute == res1['tz'][0].minute

--- a/tools/pythonpkg/tests/fast/arrow/test_9443.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_9443.py
@@ -24,5 +24,4 @@ class Test9443(object):
         sql = f'SELECT * FROM "{temp_file}"'
 
         duckdb_cursor.execute(sql)
-        with pytest.raises(Exception, match='Unsupported Arrow type TIME WITH TIME ZONE'):
-            duckdb_cursor.fetch_record_batch()
+        duckdb_cursor.fetch_record_batch()


### PR DESCRIPTION
Just drops the time offset component, just like casting to `TIMETZ` in the query itself.

Fixes random exceptions being thrown when querying imported Parquets.

Successor to #11887 due to the branch being renamed