### PR TITLE
Issue #11894: MIN/MAX_BY DECIMAL Casting

### DIFF
--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -376,6 +376,13 @@ static unique_ptr<FunctionData> BindDecimalArgMinMax(ClientContext &context, Agg
 	idx_t best_target = DConstants::INVALID_INDEX;
 	int64_t lowest_cost = NumericLimits<int64_t>::Maximum();
 	for (idx_t i = 0; i < by_types.size(); ++i) {
+		// Before falling back to casting, check for a physical type match for the by_type
+		if (by_types[i].InternalType() == by_type.InternalType()) {
+			lowest_cost = 0;
+			best_target = DConstants::INVALID_INDEX;
+			break;
+		}
+
 		auto cast_cost = CastFunctionSet::Get(context).ImplicitCastCost(by_type, by_types[i]);
 		if (cast_cost < 0) {
 			continue;

--- a/test/sql/aggregate/aggregates/test_arg_min_max.test
+++ b/test/sql/aggregate/aggregates/test_arg_min_max.test
@@ -158,3 +158,38 @@ query II
 select arg_min(name,salary),arg_max(name,salary)  from names;
 ----
 Pedro	Hubert-Blaine-Wolfeschlegelsteinhausenbergerdorff
+
+statement ok
+CREATE OR REPLACE TABLE employees(
+	employee_id NUMERIC, 
+	department_id NUMERIC, 
+	salary NUMERIC);
+
+statement ok
+INSERT INTO employees VALUES
+  (1001, 10, 10000),
+  (1020, 10, 9000),
+  (1030, 10, 8000),
+  (900, 20, 15000),
+  (2000, 20, NULL),
+  (2010, 20, 15000),
+  (2020, 20, 8000);
+
+foreach casting true false
+
+statement ok
+SET old_implicit_casting=${casting};
+
+query I
+SELECT MAX_BY(employee_id, salary) as employee_with_biggest_salary 
+FROM employees;
+----
+900
+
+query I
+SELECT MIN_BY(employee_id, salary) as employee_with_least_salary 
+FROM employees;
+----
+1030
+
+endloop


### PR DESCRIPTION
Don't add casts for ordering arguments that have a supported physical type.

fixes: duckdb/duckdb#11894
fixes: duckdblabs/duckdb-internal#1956