### PR TITLE
Correctly render duckbox for empty results

### DIFF
--- a/src/common/box_renderer.cpp
+++ b/src/common/box_renderer.cpp
@@ -477,8 +477,8 @@ void BoxRenderer::RenderHeader(const vector<string> &names, const vector<Logical
 	ss << config.LMIDDLE;
 	column_index = 0;
 	for (idx_t k = 0; k < total_length - 2; k++) {
-		if (has_results && column_index + 1 < column_count && k == boundaries[column_index]) {
-			ss << config.MIDDLE;
+		if (column_index + 1 < column_count && k == boundaries[column_index]) {
+			ss << (has_results ? config.MIDDLE : config.DMIDDLE);
 			column_index++;
 		} else {
 			ss << config.HORIZONTAL;


### PR DESCRIPTION
Previously we would render this edge incorrectly:

```
duckdb -c "select 42, 84 where false"
┌───────┬───────┐
│  42   │  84   │
│ int32 │ int32 │
├───────────────┤
│    0 rows     │
└───────────────┘
```

This PR fixes the rendering:

```
build/debug/duckdb -c "select 42, 84 where false"
┌───────┬───────┐
│  42   │  84   │
│ int32 │ int32 │
├───────┴───────┤
│    0 rows     │
└───────────────┘

```