### PR TITLE
Fix ordering issue with nested list type

### DIFF
--- a/src/common/row_operations/row_radix_scatter.cpp
+++ b/src/common/row_operations/row_radix_scatter.cpp
@@ -125,7 +125,7 @@ void RadixScatterListVector(Vector &v, UnifiedVectorFormat &vdata, const Selecti
 					key_locations[i][0] = 1;
 					key_locations[i]++;
 					RowOperations::RadixScatter(child_vector, list_size, *FlatVector::IncrementalSelectionVector(), 1,
-					                            key_locations + i, false, true, false, prefix_len, width - 1,
+					                            key_locations + i, false, true, false, prefix_len, width - 2,
 					                            list_entry.offset);
 				} else {
 					// denote that the list is empty with a 0

--- a/test/sql/order/issue_11936.test
+++ b/test/sql/order/issue_11936.test
@@ -1,0 +1,21 @@
+# name: test/sql/order/issue_11936.test
+# description: Test order nested list
+# group: [order]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE test(col1 INT, col2 INT2[][][][][][]);
+
+statement ok
+INSERT INTO test VALUES(1000000000, null), (1000000001, [[[[[[]]]]]]), (null, [[[[[[]]]]]]), (null, [[[[[[]]]]]]), (1, [[[[[[]]]]]]);
+
+query II
+SELECT col1, col2 FROM test ORDER BY col1 NULLS LAST, col2;
+----
+1	[[[[[[]]]]]]
+1000000000	NULL
+1000000001	[[[[[[]]]]]]
+NULL	[[[[[[]]]]]]
+NULL	[[[[[[]]]]]]


### PR DESCRIPTION
Fixes #11936 .
Back to the code, we have used two bytes, one to indicate whether it is null, and the other to indicate whether the list is empty, so here is width - 2 instead of width - 1.