### PR TITLE
Disable false positive for vector size nightly in test

### DIFF
--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -112,8 +112,7 @@ OptionValueSet &GetValueForOption(const string &name) {
 	    {"arrow_output_list_view", {true}},
 	    {"enable_http_logging", {true}},
 	    {"http_logging_output", {"my_cool_outputfile"}},
-	    {"produce_arrow_string_view", {true}}
-	};
+	    {"produce_arrow_string_view", {true}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {
 		REQUIRE(name == "MISSING_FROM_MAP");

--- a/test/sql/copy/row_groups_per_file.test
+++ b/test/sql/copy/row_groups_per_file.test
@@ -4,6 +4,8 @@
 
 require parquet
 
+require vector_size 2048
+
 statement ok
 CREATE TABLE bigdata AS SELECT i AS col_a, i AS col_b FROM range(0,10000) tbl(i);
 


### PR DESCRIPTION
Test failure is expected, as we see different results for different (compiled) vector sizes. Also, there is a random `format-fix` issue.