### PR TITLE
Fix overlooked function argument rename that leads to seg faults.

### DIFF
--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -261,7 +261,7 @@ void ColumnData::Skip(ColumnScanState &state, idx_t s_count) {
 
 void ColumnData::Append(BaseStatistics &append_stats, ColumnAppendState &state, Vector &vector, idx_t append_count) {
 	UnifiedVectorFormat vdata;
-	vector.ToUnifiedFormat(count, vdata);
+	vector.ToUnifiedFormat(append_count, vdata);
 	AppendData(append_stats, state, vdata, append_count);
 }
 

--- a/test/sql/create/create_as_issue_11968.test
+++ b/test/sql/create/create_as_issue_11968.test
@@ -1,4 +1,4 @@
-# name: test/sql/create/create_as_issue_1234.test
+# name: test/sql/create/create_as_issue_11968.test
 # group: [create]
 
 load __TEST_DIR__/temp_create_as.db

--- a/test/sql/create/create_as_issue_11968.test
+++ b/test/sql/create/create_as_issue_11968.test
@@ -1,0 +1,16 @@
+# name: test/sql/create/create_as_issue_1234.test
+# group: [create]
+
+load __TEST_DIR__/temp_create_as.db
+
+statement ok
+CREATE TABLE test (x INTEGER[]);
+
+statement ok
+INSERT INTO test SELECT CASE WHEN x <= 520 THEN [0, 0] ELSE [0] END FROM generate_series(1, 2048) s(x);
+
+statement ok
+CHECKPOINT;
+
+statement ok
+CREATE TABLE test2 AS SELECT x FROM test;


### PR DESCRIPTION
This PR fixes the segmentation fault described in #11968, which as far as I can tell was introduced by 2ef214f5. That commit included a change to the name of the `count` argument in the implementations of several `duckdb::ColumnData` member functions. 

One use of the argument (in `duckdb::ColumnData::Append`) was missed. This did not lead to a compilation failure, because the class also has a `count` member that was previously shadowed. Using the wrong count value in this particular case can lead to an invalid memory read.
