### PR TITLE
[Python] Grab the GIL in the destructor of PyFilesystem

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyfilesystem.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyfilesystem.hpp
@@ -49,7 +49,7 @@ private:
 class PythonFilesystem : public FileSystem {
 private:
 	const vector<string> protocols;
-	const AbstractFileSystem filesystem;
+	AbstractFileSystem filesystem;
 	std::string DecodeFlags(FileOpenFlags flags);
 	bool Exists(const string &filename, const char *func_name) const;
 
@@ -57,6 +57,7 @@ public:
 	explicit PythonFilesystem(vector<string> protocols, AbstractFileSystem filesystem)
 	    : protocols(std::move(protocols)), filesystem(std::move(filesystem)) {
 	}
+	~PythonFilesystem() override;
 
 protected:
 	string GetName() const override {

--- a/tools/pythonpkg/src/pyfilesystem.cpp
+++ b/tools/pythonpkg/src/pyfilesystem.cpp
@@ -18,6 +18,15 @@ PythonFileHandle::~PythonFileHandle() {
 	}
 }
 
+PythonFilesystem::~PythonFilesystem() {
+	try {
+		PythonGILWrapper gil;
+		filesystem.dec_ref();
+		filesystem.release();
+	} catch (...) { // NOLINT
+	}
+}
+
 string PythonFilesystem::DecodeFlags(FileOpenFlags flags) {
 	// see https://stackoverflow.com/a/58925279 for truth table of python file modes
 	bool read = flags.OpenForReading();


### PR DESCRIPTION
This needs to hold the GIL when its being destroyed, as it contains a python object.