### PR TITLE
[Python] Make the NumPy module optional, not throwing if it's not installed

### DIFF
--- a/tools/pythonpkg/scripts/cache_data.json
+++ b/tools/pythonpkg/scripts/cache_data.json
@@ -252,7 +252,8 @@
             "numpy.csingle",
             "numpy.cdouble",
             "numpy.clongdouble"
-        ]
+        ],
+        "required": false
     },
     "numpy.core": {
         "type": "attribute",

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/numpy_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/numpy_module.hpp
@@ -79,6 +79,11 @@ public:
 	PythonImportCacheItem csingle;
 	PythonImportCacheItem cdouble;
 	PythonImportCacheItem clongdouble;
+
+protected:
+	bool IsRequired() const override final {
+		return false;
+	}
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This PR fixes #11871 

We don't have an explicit dependency on NumPy.

Without this change, when attempting to check the type of a python object, we attempt to import this module.
If it's not available we throw, even when we are just trying to do an `isinstance` check.

This might require a better fix at some point, for now this makes sure the error isn't thrown if NumPy is missing.