### PR TITLE
Add more MultiFilereader features/hooks

### DIFF
--- a/extension/json/json_functions/read_json.cpp
+++ b/extension/json/json_functions/read_json.cpp
@@ -347,7 +347,7 @@ static void ReadJSONFunction(ClientContext &context, TableFunctionInput &data_p,
 	}
 
 	if (output.size() != 0) {
-		MultiFileReader().FinalizeChunk(context, gstate.bind_data.reader_bind, lstate.GetReaderData(), output);
+		MultiFileReader().FinalizeChunk(context, gstate.bind_data.reader_bind, lstate.GetReaderData(), output, nullptr);
 	}
 }
 

--- a/extension/json/json_functions/read_json_objects.cpp
+++ b/extension/json/json_functions/read_json_objects.cpp
@@ -47,7 +47,7 @@ static void ReadJSONObjectsFunction(ClientContext &context, TableFunctionInput &
 	output.SetCardinality(count);
 
 	if (output.size() != 0) {
-		MultiFileReader().FinalizeChunk(context, gstate.bind_data.reader_bind, lstate.GetReaderData(), output);
+		MultiFileReader().FinalizeChunk(context, gstate.bind_data.reader_bind, lstate.GetReaderData(), output, nullptr);
 	}
 }
 

--- a/extension/json/json_scan.cpp
+++ b/extension/json/json_scan.cpp
@@ -207,7 +207,7 @@ unique_ptr<GlobalTableFunctionState> JSONGlobalTableFunctionState::Init(ClientCo
 	for (auto &reader : gstate.json_readers) {
 		MultiFileReader().FinalizeBind(reader->GetOptions().file_options, gstate.bind_data.reader_bind,
 		                               reader->GetFileName(), gstate.names, dummy_types, bind_data.names,
-		                               input.column_ids, reader->reader_data, context);
+		                               input.column_ids, reader->reader_data, context, nullptr);
 	}
 
 	return std::move(result);

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -78,7 +78,7 @@ struct ParquetReadLocalState : public LocalTableFunctionState {
 	bool is_parallel;
 	idx_t batch_index;
 	idx_t file_index;
-	//! The DataChunk containing all read columns (even filter columns that are immediately removed)
+	//! The DataChunk containing all read columns (even columns that are immediately removed)
 	DataChunk all_columns;
 };
 
@@ -110,6 +110,8 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 	//! The scan over the file_list
 	MultiFileListScanData file_list_scan;
 
+    unique_ptr<MultiFileReaderGlobalState> multi_file_reader_state;
+
 	mutex lock;
 
 	//! The current set of parquet readers
@@ -135,7 +137,7 @@ struct ParquetReadGlobalState : public GlobalTableFunctionState {
 		return max_threads;
 	}
 
-	bool CanRemoveFilterColumns() const {
+	bool CanRemoveColumns() const {
 		return !projection_ids.empty();
 	}
 };
@@ -211,6 +213,9 @@ static void ParseFileRowNumberOption(MultiFileReaderBindData &bind_data, Parquet
 static MultiFileReaderBindData BindSchema(ClientContext &context, vector<LogicalType> &return_types,
                                           vector<string> &names, ParquetReadBindData &result, ParquetOptions &options) {
 	D_ASSERT(!options.schema.empty());
+
+    options.file_options.AutoDetectHivePartitioning(*result.file_list, context);
+
 	auto &file_options = options.file_options;
 	if (file_options.union_by_name || file_options.hive_partitioning) {
 		throw BinderException("Parquet schema cannot be combined with union_by_name=true or hive_partitioning=true");
@@ -241,13 +246,18 @@ static MultiFileReaderBindData BindSchema(ClientContext &context, vector<Logical
 
 static void InitializeParquetReader(ParquetReader &reader, const ParquetReadBindData &bind_data,
                                     const vector<column_t> &global_column_ids,
-                                    optional_ptr<TableFilterSet> table_filters, ClientContext &context) {
+                                    optional_ptr<TableFilterSet> table_filters, ClientContext &context, idx_t file_idx,
+                                    optional_ptr<MultiFileReaderGlobalState> reader_state) {
 	auto &parquet_options = bind_data.parquet_options;
 	auto &reader_data = reader.reader_data;
+
+    // Mark the file in the file list we are scanning here
+    reader_data.file_list_idx = file_idx;
+
 	if (bind_data.parquet_options.schema.empty()) {
 		bind_data.multi_file_reader->InitializeReader(reader, parquet_options.file_options, bind_data.reader_bind,
 		                                              bind_data.types, bind_data.names, global_column_ids,
-		                                              table_filters, bind_data.file_list->GetFirstFile(), context);
+		                                              table_filters, bind_data.file_list->GetFirstFile(), context, reader_state);
 		return;
 	}
 
@@ -256,7 +266,7 @@ static void InitializeParquetReader(ParquetReader &reader, const ParquetReadBind
 	// this deals with hive partitioning and filename=true
 	bind_data.multi_file_reader->FinalizeBind(parquet_options.file_options, bind_data.reader_bind, reader.GetFileName(),
 	                                          reader.GetNames(), bind_data.types, bind_data.names, global_column_ids,
-	                                          reader_data, context);
+	                                          reader_data, context, reader_state);
 
 	// create a mapping from field id to column index in file
 	unordered_map<uint32_t, idx_t> field_id_to_column_index;
@@ -275,7 +285,7 @@ static void InitializeParquetReader(ParquetReader &reader, const ParquetReadBind
 		// check if this is a constant column
 		bool constant = false;
 		for (auto &entry : reader_data.constant_map) {
-			if (entry.column_id == i) {
+			if (entry.result_column_id == i) {
 				constant = true;
 				break;
 			}
@@ -298,7 +308,7 @@ static void InitializeParquetReader(ParquetReader &reader, const ParquetReadBind
 		auto it = field_id_to_column_index.find(column_definition.field_id);
 		if (it == field_id_to_column_index.end()) {
 			// field id not present in file, use default value
-			reader_data.constant_map.emplace_back(i, column_definition.default_value);
+			reader_data.constant_map.emplace_back(i, global_column_index, column_definition.default_value);
 			continue;
 		}
 
@@ -315,7 +325,7 @@ static void InitializeParquetReader(ParquetReader &reader, const ParquetReadBind
 	reader_data.empty_columns = reader_data.column_ids.empty();
 
 	// Finally, initialize the filters
-	bind_data.multi_file_reader->CreateFilterMap(bind_data.types, table_filters, reader_data);
+	bind_data.multi_file_reader->CreateFilterMap(bind_data.types, table_filters, reader_data, reader_state);
 	reader_data.filters = table_filters;
 }
 
@@ -475,15 +485,18 @@ public:
 		bool bound_on_first_file = true;
 		if (result->multi_file_reader->Bind(parquet_options.file_options, *result->file_list, result->types,
 		                                    result->names, result->reader_bind)) {
-			// The MultiFileReader has performed a full bind
-			ParseFileRowNumberOption(result->reader_bind, parquet_options, result->types, result->names);
 			result->multi_file_reader->BindOptions(parquet_options.file_options, *result->file_list, result->types,
 			                                       result->names, result->reader_bind);
+            // Enable the parquet file_row_number on the parquet options if the file_row_number_idx was set
+            if (result->reader_bind.file_row_number_idx != DConstants::INVALID_INDEX) {
+                parquet_options.file_row_number = true;
+            }
 			bound_on_first_file = false;
 		} else if (!parquet_options.schema.empty()) {
-			// A schema was suppliedParquetProgress
+			// A schema was supplied: use the schema for binding
 			result->reader_bind = BindSchema(context, result->types, result->names, *result, parquet_options);
 		} else {
+            parquet_options.file_options.AutoDetectHivePartitioning(*result->file_list, context);
 			// Default bind
 			result->reader_bind = result->multi_file_reader->BindReader<ParquetReader>(
 			    context, result->types, result->names, *result->file_list, *result, parquet_options);
@@ -543,8 +556,6 @@ public:
 		}
 
 		auto file_list = multi_file_reader->CreateFileList(context, input.inputs[0]);
-		parquet_options.file_options.AutoDetectHivePartitioning(*file_list, context);
-
 		return ParquetScanBindInternal(context, std::move(multi_file_reader), std::move(file_list), return_types, names,
 		                               parquet_options);
 	}
@@ -575,8 +586,7 @@ public:
 		result->is_parallel = true;
 		result->batch_index = 0;
 
-		// TODO: needs lock?
-		if (input.CanRemoveFilterColumns()) {
+		if (gstate.CanRemoveColumns()) {
 			result->all_columns.Initialize(context.client, gstate.scanned_types);
 		}
 		if (!ParquetParallelStateNext(context.client, bind_data, *result, gstate)) {
@@ -591,7 +601,9 @@ public:
 		auto result = make_uniq<ParquetReadGlobalState>();
 		bind_data.file_list->InitializeScan(result->file_list_scan);
 
-		if (bind_data.file_list->IsEmpty()) {
+        result->multi_file_reader_state = bind_data.multi_file_reader->InitializeGlobalState(context, bind_data.parquet_options.file_options, bind_data.reader_bind,
+                                                                                             *bind_data.file_list, bind_data.types, bind_data.names, input.column_ids);
+        if (bind_data.file_list->IsEmpty()) {
 			result->readers = {};
 		} else if (!bind_data.union_readers.empty()) {
 			// TODO: confirm we are not changing behaviour by modifying the order here?
@@ -619,11 +631,12 @@ public:
 		// Ensure all readers are initialized and FileListScan is sync with readers list
 		for (auto &reader_data : result->readers) {
 			string file_name;
+            idx_t file_idx = result->file_list_scan.current_file_idx;
 			bind_data.file_list->Scan(result->file_list_scan, file_name);
 			if (file_name != reader_data.reader->file_name) {
 				throw InternalException("Mismatch in filename order and reader order in parquet scan");
 			}
-			InitializeParquetReader(*reader_data.reader, bind_data, input.column_ids, input.filters, context);
+			InitializeParquetReader(*reader_data.reader, bind_data, input.column_ids, input.filters, context, file_idx, result->multi_file_reader_state);
 		}
 
 		result->column_ids = input.column_ids;
@@ -632,17 +645,23 @@ public:
 		result->file_index = 0;
 		result->batch_index = 0;
 		result->max_threads = ParquetScanMaxThreads(context, input.bind_data.get());
-		if (input.CanRemoveFilterColumns()) {
-			result->projection_ids = input.projection_ids;
-			const auto table_types = bind_data.types;
-			for (const auto &col_idx : input.column_ids) {
-				if (IsRowIdColumnId(col_idx)) {
-					result->scanned_types.emplace_back(LogicalType::ROW_TYPE);
-				} else {
-					result->scanned_types.push_back(table_types[col_idx]);
-				}
-			}
-		}
+
+		if (input.CanRemoveFilterColumns() || result->multi_file_reader_state->RequiresExtraColumns()) {
+            result->projection_ids = input.projection_ids;
+            const auto table_types = bind_data.types;
+            for (const auto &col_idx: input.column_ids) {
+                if (IsRowIdColumnId(col_idx)) {
+                    result->scanned_types.emplace_back(LogicalType::ROW_TYPE);
+                } else {
+                    result->scanned_types.push_back(table_types[col_idx]);
+                }
+            }
+        }
+
+        for (const auto &column_type : result->multi_file_reader_state->extra_columns) {
+            result->scanned_types.push_back(column_type);
+        }
+
 		return std::move(result);
 	}
 
@@ -691,16 +710,16 @@ public:
 		auto &bind_data = data_p.bind_data->CastNoConst<ParquetReadBindData>();
 
 		do {
-			if (gstate.CanRemoveFilterColumns()) {
+			if (gstate.CanRemoveColumns()) {
 				data.all_columns.Reset();
 				data.reader->Scan(data.scan_state, data.all_columns);
 				bind_data.multi_file_reader->FinalizeChunk(context, bind_data.reader_bind, data.reader->reader_data,
-				                                           data.all_columns);
+				                                           data.all_columns, gstate.multi_file_reader_state);
 				output.ReferenceColumns(data.all_columns, gstate.projection_ids);
 			} else {
 				data.reader->Scan(data.scan_state, output);
 				bind_data.multi_file_reader->FinalizeChunk(context, bind_data.reader_bind, data.reader->reader_data,
-				                                           output);
+				                                           output, gstate.multi_file_reader_state);
 			}
 
 			bind_data.chunk_count++;
@@ -858,7 +877,7 @@ public:
 				try {
 					reader = make_shared_ptr<ParquetReader>(context, current_reader_data.file_to_be_opened, pq_options);
 					InitializeParquetReader(*reader, bind_data, parallel_state.column_ids, parallel_state.filters,
-					                        context);
+					                        context, i, parallel_state.multi_file_reader_state);
 				} catch (...) {
 					parallel_lock.lock();
 					parallel_state.error_opening_file = true;

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -246,8 +246,8 @@ static MultiFileReaderBindData BindSchema(ClientContext &context, vector<Logical
 
 static void InitializeParquetReader(ParquetReader &reader, const ParquetReadBindData &bind_data,
                                     const vector<column_t> &global_column_ids,
-                                    optional_ptr<TableFilterSet> table_filters, ClientContext &context, idx_t file_idx,
-                                    optional_ptr<MultiFileReaderGlobalState> reader_state) {
+                                    optional_ptr<TableFilterSet> table_filters, ClientContext &context,
+                                    optional_idx file_idx, optional_ptr<MultiFileReaderGlobalState> reader_state) {
 	auto &parquet_options = bind_data.parquet_options;
 	auto &reader_data = reader.reader_data;
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -285,7 +285,7 @@ static void InitializeParquetReader(ParquetReader &reader, const ParquetReadBind
 		// check if this is a constant column
 		bool constant = false;
 		for (auto &entry : reader_data.constant_map) {
-			if (entry.result_column_id == i) {
+			if (entry.column_id == i) {
 				constant = true;
 				break;
 			}
@@ -308,7 +308,7 @@ static void InitializeParquetReader(ParquetReader &reader, const ParquetReadBind
 		auto it = field_id_to_column_index.find(column_definition.field_id);
 		if (it == field_id_to_column_index.end()) {
 			// field id not present in file, use default value
-			reader_data.constant_map.emplace_back(i, global_column_index, column_definition.default_value);
+			reader_data.constant_map.emplace_back(i, column_definition.default_value);
 			continue;
 		}
 

--- a/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
@@ -20,7 +20,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, shared_ptr<CSVBufferManager> bu
 		options = union_reader.options;
 		types = union_reader.GetTypes();
 		multi_file_reader->InitializeReader(*this, options.file_options, bind_data.reader_bind, bind_data.return_types,
-		                                    bind_data.return_names, column_ids, nullptr, file_path, context);
+		                                    bind_data.return_names, column_ids, nullptr, file_path, context, nullptr);
 		InitializeFileNamesTypes();
 		return;
 	} else if (!bind_data.column_info.empty()) {
@@ -28,7 +28,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, shared_ptr<CSVBufferManager> bu
 		names = bind_data.column_info[0].names;
 		types = bind_data.column_info[0].types;
 		multi_file_reader->InitializeReader(*this, options.file_options, bind_data.reader_bind, bind_data.return_types,
-		                                    bind_data.return_names, column_ids, nullptr, file_path, context);
+		                                    bind_data.return_names, column_ids, nullptr, file_path, context, nullptr);
 		InitializeFileNamesTypes();
 		return;
 	}
@@ -36,7 +36,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, shared_ptr<CSVBufferManager> bu
 	types = bind_data.return_types;
 	file_schema = bind_data.return_types;
 	multi_file_reader->InitializeReader(*this, options.file_options, bind_data.reader_bind, bind_data.return_types,
-	                                    bind_data.return_names, column_ids, nullptr, file_path, context);
+	                                    bind_data.return_names, column_ids, nullptr, file_path, context, nullptr);
 
 	InitializeFileNamesTypes();
 }
@@ -68,7 +68,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, const string &file_path_p, cons
 			state_machine = union_reader.state_machine;
 			multi_file_reader->InitializeReader(*this, options.file_options, bind_data.reader_bind,
 			                                    bind_data.return_types, bind_data.return_names, column_ids, nullptr,
-			                                    file_path, context);
+			                                    file_path, context, nullptr);
 
 			InitializeFileNamesTypes();
 			return;
@@ -96,7 +96,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, const string &file_path_p, cons
 		    state_machine_cache.Get(options.dialect_options.state_machine_options), options);
 
 		multi_file_reader->InitializeReader(*this, options.file_options, bind_data.reader_bind, bind_data.return_types,
-		                                    bind_data.return_names, column_ids, nullptr, file_path, context);
+		                                    bind_data.return_names, column_ids, nullptr, file_path, context, nullptr);
 		InitializeFileNamesTypes();
 		return;
 	}
@@ -127,7 +127,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, const string &file_path_p, cons
 	    state_machine_cache.Get(options.dialect_options.state_machine_options), options);
 
 	multi_file_reader->InitializeReader(*this, options.file_options, bind_data.reader_bind, bind_data.return_types,
-	                                    bind_data.return_names, column_ids, nullptr, file_path, context);
+	                                    bind_data.return_names, column_ids, nullptr, file_path, context, nullptr);
 	InitializeFileNamesTypes();
 }
 

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -224,7 +224,7 @@ static void ReadCSVFunction(ClientContext &context, TableFunctionInput &data_p, 
 	do {
 		if (output.size() != 0) {
 			MultiFileReader().FinalizeChunk(context, bind_data.reader_bind,
-			                                csv_local_state.csv_reader->csv_file_scan->reader_data, output);
+			                                csv_local_state.csv_reader->csv_file_scan->reader_data, output, nullptr);
 			break;
 		}
 		if (csv_local_state.csv_reader->FinishedIterator()) {

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -37,9 +37,9 @@ struct HivePartitioningIndex {
 
 // Info on columns marked as required
 struct RequiredColumnInfo {
-    string column_name;
-    LogicalType type;
-    bool present_in_bind;
+	string column_name;
+	LogicalType type;
+	bool present_in_bind;
 };
 
 //! The bind data for the multi-file reader, obtained through MultiFileReader::BindReader
@@ -50,32 +50,34 @@ struct MultiFileReaderBindData {
 	vector<HivePartitioningIndex> hive_partitioning_indexes;
 	//! The index of the file_row_number column (if any)
 	idx_t file_row_number_idx = DConstants::INVALID_INDEX;
-    //! Columns that should be included in the scan result regardless of being in the projection
-    vector<RequiredColumnInfo> required_columns;
+	//! Columns that should be included in the scan result regardless of being in the projection
+	vector<RequiredColumnInfo> required_columns;
 
-    //! Allows extensions that override MultiFileReaders to pass extra data
-    case_insensitive_map_t<Value> custom_data;
+	//! Allows extensions that override MultiFileReaders to pass extra data
+	case_insensitive_map_t<Value> custom_data;
 
-    DUCKDB_API void Serialize(Serializer &serializer) const;
+	DUCKDB_API void Serialize(Serializer &serializer) const;
 	DUCKDB_API static MultiFileReaderBindData Deserialize(Deserializer &deserializer);
 };
 
 //! Global state for MultiFileReads
 struct MultiFileReaderGlobalState {
-    MultiFileReaderGlobalState(case_insensitive_map_t<idx_t> required_column_map_p, vector<LogicalType> extra_columns_p, optional_ptr<const MultiFileList> file_list_p) :
-    required_column_map(std::move(required_column_map_p)), extra_columns(std::move(extra_columns_p)), file_list(file_list_p) {};
+	MultiFileReaderGlobalState(case_insensitive_map_t<idx_t> required_column_map_p, vector<LogicalType> extra_columns_p,
+	                           optional_ptr<const MultiFileList> file_list_p)
+	    : required_column_map(std::move(required_column_map_p)), extra_columns(std::move(extra_columns_p)),
+	      file_list(file_list_p) {};
 
-    //! Maps required column names to column index in the result Chunk
-    const case_insensitive_map_t<idx_t> required_column_map;
-    //! the extra column necessary to store the projected out required columns
-    const vector<LogicalType> extra_columns;
-    // the file list driving the current scan
-    optional_ptr<const MultiFileList> file_list;
+	//! Maps required column names to column index in the result Chunk
+	const case_insensitive_map_t<idx_t> required_column_map;
+	//! the extra column necessary to store the projected out required columns
+	const vector<LogicalType> extra_columns;
+	// the file list driving the current scan
+	optional_ptr<const MultiFileList> file_list;
 
-    //! Indicates that the MultiFileReader has added columns to be scanned that are not in the projection
-    bool RequiresExtraColumns() {
-        return !extra_columns.empty();
-    }
+	//! Indicates that the MultiFileReader has added columns to be scanned that are not in the projection
+	bool RequiresExtraColumns() {
+		return !extra_columns.empty();
+	}
 };
 
 struct MultiFileFilterEntry {
@@ -84,13 +86,13 @@ struct MultiFileFilterEntry {
 };
 
 struct MultiFileConstantEntry {
-	MultiFileConstantEntry(idx_t result_column_id_p, idx_t local_column_id_p, Value value_p) :
-    result_column_id(result_column_id_p), local_column_id(local_column_id_p), value(std::move(value_p)) {
+	MultiFileConstantEntry(idx_t result_column_id_p, idx_t local_column_id_p, Value value_p)
+	    : result_column_id(result_column_id_p), local_column_id(local_column_id_p), value(std::move(value_p)) {
 	}
 	//! The column id to apply the constant value to
 	idx_t result_column_id;
-    //! The local column id of the constant (position emitted during bind)
-    idx_t local_column_id;
+	//! The local column id of the constant (position emitted during bind)
+	idx_t local_column_id;
 	//! The constant value
 	Value value;
 };
@@ -113,8 +115,8 @@ struct MultiFileReaderData {
 	//! Map of column_id -> cast, used when reading multiple files when files have diverging types
 	//! for the same column
 	unordered_map<column_t, LogicalType> cast_map;
-    //! (Optionally) The MultiFileReader-generated metadata corresponding to the currently read file
-    idx_t file_list_idx = DConstants::INVALID_INDEX;
+	//! (Optionally) The MultiFileReader-generated metadata corresponding to the currently read file
+	idx_t file_list_idx = DConstants::INVALID_INDEX;
 };
 
 //! The MultiFileReader class provides a set of helper methods to handle scanning from multiple files
@@ -160,11 +162,12 @@ struct MultiFileReader {
 	                                    vector<LogicalType> &return_types, vector<string> &names,
 	                                    MultiFileReaderBindData &bind_data);
 
-    //! Initialize global state used by the MultiFileReader
-    DUCKDB_API virtual unique_ptr<MultiFileReaderGlobalState> InitializeGlobalState(ClientContext &context, const MultiFileReaderOptions &file_options,
-                                                  const MultiFileReaderBindData &bind_data, const MultiFileList& file_list, const vector<LogicalType> &global_types,
-                                                  const vector<string> &global_names,
-                                                  const vector<column_t> &global_column_ids);
+	//! Initialize global state used by the MultiFileReader
+	DUCKDB_API virtual unique_ptr<MultiFileReaderGlobalState>
+	InitializeGlobalState(ClientContext &context, const MultiFileReaderOptions &file_options,
+	                      const MultiFileReaderBindData &bind_data, const MultiFileList &file_list,
+	                      const vector<LogicalType> &global_types, const vector<string> &global_names,
+	                      const vector<column_t> &global_column_ids);
 
 	//! Finalize the bind phase of the multi-file reader after we know (1) the required (output) columns, and (2) the
 	//! pushed down table filters
@@ -173,7 +176,7 @@ struct MultiFileReader {
 	                                     const vector<string> &local_names, const vector<LogicalType> &global_types,
 	                                     const vector<string> &global_names, const vector<column_t> &global_column_ids,
 	                                     MultiFileReaderData &reader_data, ClientContext &context,
-                                         optional_ptr<MultiFileReaderGlobalState> global_state);
+	                                     optional_ptr<MultiFileReaderGlobalState> global_state);
 
 	//! Create all required mappings from the global types/names to the file-local types/names
 	DUCKDB_API virtual void CreateMapping(const string &file_name, const vector<LogicalType> &local_types,
@@ -181,16 +184,16 @@ struct MultiFileReader {
 	                                      const vector<string> &global_names, const vector<column_t> &global_column_ids,
 	                                      optional_ptr<TableFilterSet> filters, MultiFileReaderData &reader_data,
 	                                      const string &initial_file, const MultiFileReaderBindData &options,
-                                          optional_ptr<MultiFileReaderGlobalState> global_state);
+	                                      optional_ptr<MultiFileReaderGlobalState> global_state);
 	//! Populated the filter_map
 	DUCKDB_API virtual void CreateFilterMap(const vector<LogicalType> &global_types,
 	                                        optional_ptr<TableFilterSet> filters, MultiFileReaderData &reader_data,
-                                            optional_ptr<MultiFileReaderGlobalState> global_state);
+	                                        optional_ptr<MultiFileReaderGlobalState> global_state);
 
 	//! Finalize the reading of a chunk - applying any constants that are required
 	DUCKDB_API virtual void FinalizeChunk(ClientContext &context, const MultiFileReaderBindData &bind_data,
 	                                      const MultiFileReaderData &reader_data, DataChunk &chunk,
-                                          optional_ptr<MultiFileReaderGlobalState> global_state);
+	                                      optional_ptr<MultiFileReaderGlobalState> global_state);
 
 	template <class READER_CLASS, class RESULT_CLASS, class OPTIONS_CLASS>
 	MultiFileReaderBindData BindUnionReader(ClientContext &context, vector<LogicalType> &return_types,
@@ -284,7 +287,7 @@ protected:
 	                               const vector<string> &local_names, const vector<LogicalType> &global_types,
 	                               const vector<string> &global_names, const vector<column_t> &global_column_ids,
 	                               MultiFileReaderData &reader_data, const string &initial_file,
-                                   optional_ptr<MultiFileReaderGlobalState> global_state);
+	                               optional_ptr<MultiFileReaderGlobalState> global_state);
 
 	//! Used in errors to report which function is using this MultiFileReader
 	string function_name;

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -53,7 +53,7 @@ struct MultiFileReaderGlobalState {
 	MultiFileReaderGlobalState(vector<LogicalType> extra_columns_p, optional_ptr<const MultiFileList> file_list_p)
 	    : extra_columns(std::move(extra_columns_p)), file_list(file_list_p) {};
 
-	//! the extra column necessary to store the projected out required columns
+	//! extra columns that will be produced during scanning
 	const vector<LogicalType> extra_columns;
 	// the file list driving the current scan
 	const optional_ptr<const MultiFileList> file_list;

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -44,9 +44,6 @@ struct MultiFileReaderBindData {
 	//! The index of the file_row_number column (if any)
 	idx_t file_row_number_idx = DConstants::INVALID_INDEX;
 
-	//! Allows extensions that override MultiFileReaders to pass extra data
-	case_insensitive_map_t<Value> custom_data;
-
 	DUCKDB_API void Serialize(Serializer &serializer) const;
 	DUCKDB_API static MultiFileReaderBindData Deserialize(Deserializer &deserializer);
 };
@@ -84,13 +81,10 @@ struct MultiFileFilterEntry {
 };
 
 struct MultiFileConstantEntry {
-	MultiFileConstantEntry(idx_t result_column_id_p, idx_t local_column_id_p, Value value_p)
-	    : result_column_id(result_column_id_p), local_column_id(local_column_id_p), value(std::move(value_p)) {
+	MultiFileConstantEntry(idx_t column_id, Value value_p) : column_id(column_id), value(std::move(value_p)) {
 	}
 	//! The column id to apply the constant value to
-	idx_t result_column_id;
-	//! The local column id of the constant (position emitted during bind)
-	idx_t local_column_id;
+	idx_t column_id;
 	//! The constant value
 	Value value;
 };

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -108,7 +108,7 @@ struct MultiFileReaderData {
 	//! for the same column
 	unordered_map<column_t, LogicalType> cast_map;
 	//! (Optionally) The MultiFileReader-generated metadata corresponding to the currently read file
-	idx_t file_list_idx = DConstants::INVALID_INDEX;
+	optional_idx file_list_idx;
 };
 
 //! The MultiFileReader class provides a set of helper methods to handle scanning from multiple files

--- a/src/include/duckdb/common/multi_file_reader_options.hpp
+++ b/src/include/duckdb/common/multi_file_reader_options.hpp
@@ -25,8 +25,8 @@ struct MultiFileReaderOptions {
 	bool hive_types_autocast = true;
 	case_insensitive_map_t<LogicalType> hive_types_schema;
 
-    // These are used to pass options through custom multifilereaders
-    case_insensitive_map_t<Value> custom_options;
+	// These are used to pass options through custom multifilereaders
+	case_insensitive_map_t<Value> custom_options;
 
 	DUCKDB_API void Serialize(Serializer &serializer) const;
 	DUCKDB_API static MultiFileReaderOptions Deserialize(Deserializer &source);

--- a/src/include/duckdb/common/multi_file_reader_options.hpp
+++ b/src/include/duckdb/common/multi_file_reader_options.hpp
@@ -25,6 +25,9 @@ struct MultiFileReaderOptions {
 	bool hive_types_autocast = true;
 	case_insensitive_map_t<LogicalType> hive_types_schema;
 
+    // These are used to pass options through custom multifilereaders
+    case_insensitive_map_t<Value> custom_options;
+
 	DUCKDB_API void Serialize(Serializer &serializer) const;
 	DUCKDB_API static MultiFileReaderOptions Deserialize(Deserializer &source);
 	DUCKDB_API void AddBatchInfo(BindInfo &bind_info) const;


### PR DESCRIPTION
This PR adds some missing links for extending the MultiFileReader

Firstly I added a field`case_insensitive_map_t<Value> MultiFileReaderOptions::custom_options` for passing custom options.

Secondly, I added the concept of a `MultiFileReaderGlobalState`. This is a state that should generally be created in the `InitGlobal` of a table function using the MultiFileReader. The global state allows the MultiFileReader to store state that is created while already knowing what columns are in the projection.

A crucial part of the `MultiFileReaderGlobalState` is the extra_columns param. This parameter will be set by the MultiFileReader to indicate that the scan will produce more columns than are actually projected. These columns are for internal use by the MultiFileReader during the `FinalizeChunk` step. This is crucial for the upcoming delta extension to be able to properly apply deletion vectors. To apply a deletion vector, we need to know which rows from the file are actually selected. This means the `file_row_number` column needs to be available in the `FinalizeChunk` step. However, this column should not be returned by the actual scan. The solution is very similar to what we currently do for Filter pruning: where columns that are only used for pushed down filters are removed during the scan.

@Mytherin I've managed to push most complexity into the delta extension for now to keep this PR simple, eventually we may want to pull the logic for populating the extra_columns up in the default MultiFileReader though