### PR TITLE
fix: parquet serialization

### DIFF
--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -14,12 +14,19 @@
 namespace duckdb {
 
 void ChildFieldIDs::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<unique_ptr<case_insensitive_map_t<FieldID>>>(100, "ids", ids);
+	auto has_ids = !ids->empty();
+	serializer.WriteProperty(100, "has_ids", has_ids);
+	if (has_ids) {
+		serializer.WritePropertyWithDefault<unique_ptr<case_insensitive_map_t<FieldID>>>(101, "ids", ids);
+	}
 }
 
 ChildFieldIDs ChildFieldIDs::Deserialize(Deserializer &deserializer) {
 	ChildFieldIDs result;
-	deserializer.ReadPropertyWithDefault<unique_ptr<case_insensitive_map_t<FieldID>>>(100, "ids", result.ids);
+	auto has_ids = deserializer.ReadProperty<bool>(100, "has_ids");
+	if(has_ids) {
+		deserializer.ReadPropertyWithDefault<unique_ptr<case_insensitive_map_t<FieldID>>>(101, "ids", result.ids);
+	}
 	return result;
 }
 


### PR DESCRIPTION
During testing of a simple copy to s3 query:
```
COPY (SELECT 1 as number) TO 's3://md-test/num.parquet';
```
we got the error below:
```
"Failed to deserialize: expected end of object, but found field id: 108"
```
I had trouble reproducing this in dubkdb alone with `PRAGMA enable_verification` in ddb sql tests but was able to verify that it nows works in MD with this change.

The issue seems to be a problem with serializing an empty map using `WritePropertyWithDefault`.