### PR TITLE
fix extension load error message grammar

### DIFF
--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/common/dl.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
-#include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/error_manager.hpp"
+#include "duckdb/main/extension_helper.hpp"
 #include "mbedtls_wrapper.hpp"
 
 #ifndef DUCKDB_NO_THREADS
@@ -165,7 +165,7 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 
 	if (file_size < 1024) {
 		throw InvalidInputException(
-		    "Extension \"%s\" do not have metadata compatible with DuckDB loading it "
+		    "Extension \"%s\" does not have metadata compatible with the DuckDB loading it "
 		    "(version %s, platform %s). File size in particular is lower than minimum threshold of 1024",
 		    filename, engine_version, engine_platform);
 	}
@@ -192,7 +192,7 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 		if (strncmp(a, metadata_field[0].data(), 32) != 0) {
 			// metadata do not looks right, add this to the error message
 			metadata_mismatch_error =
-			    "\n" + StringUtil::Format("Extension \"%s\" do not have metadata compatible with DuckDB "
+			    "\n" + StringUtil::Format("Extension \"%s\" does not have metadata compatible with the DuckDB "
 			                              "loading it (version %s, platform %s)",
 			                              filename, engine_version, engine_platform);
 		} else if (engine_version != extension_duckdb_version || engine_platform != extension_duckdb_platform) {

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -190,7 +190,7 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 		char a[32] = {0};
 		a[0] = '4';
 		if (strncmp(a, metadata_field[0].data(), 32) != 0) {
-			// metadata do not looks right, add this to the error message
+			// metadata does not look right, add this to the error message
 			metadata_mismatch_error =
 			    "\n" + StringUtil::Format("Extension \"%s\" does not have metadata compatible with the DuckDB "
 			                              "loading it (version %s, platform %s)",

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -197,7 +197,7 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 			                              filename, engine_version, engine_platform);
 		} else if (engine_version != extension_duckdb_version || engine_platform != extension_duckdb_platform) {
 			metadata_mismatch_error = "\n" + StringUtil::Format("Extension \"%s\" (version %s, platfrom %s) does not "
-			                                                    "match DuckDB loading it (version %s, platform %s)",
+			                                                    "match the DuckDB loading it (version %s, platform %s)",
 			                                                    filename, PrettyPrintString(extension_duckdb_version),
 			                                                    PrettyPrintString(extension_duckdb_platform),
 			                                                    engine_version, engine_platform);

--- a/test/sql/extensions/checked_load.test
+++ b/test/sql/extensions/checked_load.test
@@ -5,7 +5,7 @@
 statement error
 LOAD 'README.md';
 ----
-Invalid Input Error: Extension "README.md" do not have metadata compatible with DuckDB loading it
+Invalid Input Error: Extension "README.md" does not have metadata compatible with the DuckDB loading it
 
 statement ok
 SET allow_extensions_metadata_mismatch=true;


### PR DESCRIPTION
I experienced some unusual grammar when trying to load an extension that didn't line up with the running DuckDB. Below is the before and after of the messaging change

before

> Invalid Input Error: Extension "zig-out/lib/quack.duckdb_extension" do not have metadata compatible with DuckDB loading it (version v0.10.2, platform osx_arm64)

after

> Invalid Input Error: Extension "zig-out/lib/quack.duckdb_extension" does not have metadata compatible with the DuckDB loading it (version v0.10.2, platform osx_arm64)
