### PR TITLE
Change serialization for ChildFieldIDs

### DIFF
--- a/extension/parquet/include/parquet.json
+++ b/extension/parquet/include/parquet.json
@@ -112,13 +112,7 @@
     "includes": [
       "parquet_writer.hpp"
     ],
-    "members": [
-      {
-        "id": 100,
-        "name": "ids",
-        "type": "unique_ptr<case_insensitive_map_t<FieldID>>"
-      }
-    ],
+    "custom_implementation": true,
     "pointer_type": "none"
   }
 ]

--- a/extension/parquet/include/parquet.json
+++ b/extension/parquet/include/parquet.json
@@ -112,7 +112,15 @@
     "includes": [
       "parquet_writer.hpp"
     ],
-    "custom_implementation": true,
+    "members": [
+      {
+        "id": 100,
+        "name": "ids",
+        "type": "case_insensitive_map_t<FieldID>",
+        "serialize_property": "ids.operator*()",
+        "deserialize_property": "ids.operator*()"
+      }
+    ],
     "pointer_type": "none"
   }
 ]

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -15,6 +15,8 @@
 #include "duckdb/main/connection.hpp"
 #include "duckdb/parser/parsed_data/create_copy_function_info.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
 #endif
 
 namespace duckdb {
@@ -42,6 +44,18 @@ ChildFieldIDs ChildFieldIDs::Copy() const {
 	for (const auto &id : *ids) {
 		result.ids->emplace(id.first, id.second.Copy());
 	}
+	return result;
+}
+
+void ChildFieldIDs::Serialize(Serializer &serializer) const {
+	D_ASSERT(ids);
+	serializer.WritePropertyWithDefault<case_insensitive_map_t<FieldID>>(100, "ids", ids.operator*());
+}
+
+ChildFieldIDs ChildFieldIDs::Deserialize(Deserializer &deserializer) {
+	ChildFieldIDs result;
+	D_ASSERT(result.ids);
+	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<FieldID>>(100, "ids", result.ids.operator*());
 	return result;
 }
 

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -47,18 +47,6 @@ ChildFieldIDs ChildFieldIDs::Copy() const {
 	return result;
 }
 
-void ChildFieldIDs::Serialize(Serializer &serializer) const {
-	D_ASSERT(ids);
-	serializer.WritePropertyWithDefault<case_insensitive_map_t<FieldID>>(100, "ids", ids.operator*());
-}
-
-ChildFieldIDs ChildFieldIDs::Deserialize(Deserializer &deserializer) {
-	ChildFieldIDs result;
-	D_ASSERT(result.ids);
-	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<FieldID>>(100, "ids", result.ids.operator*());
-	return result;
-}
-
 FieldID::FieldID() : set(false) {
 }
 

--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -13,6 +13,16 @@
 
 namespace duckdb {
 
+void ChildFieldIDs::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<case_insensitive_map_t<FieldID>>(100, "ids", ids.operator*());
+}
+
+ChildFieldIDs ChildFieldIDs::Deserialize(Deserializer &deserializer) {
+	ChildFieldIDs result;
+	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<FieldID>>(100, "ids", result.ids.operator*());
+	return result;
+}
+
 void FieldID::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(100, "set", set);
 	serializer.WritePropertyWithDefault<int32_t>(101, "field_id", field_id);

--- a/extension/parquet/serialize_parquet.cpp
+++ b/extension/parquet/serialize_parquet.cpp
@@ -13,16 +13,6 @@
 
 namespace duckdb {
 
-void ChildFieldIDs::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<unique_ptr<case_insensitive_map_t<FieldID>>>(100, "ids", ids);
-}
-
-ChildFieldIDs ChildFieldIDs::Deserialize(Deserializer &deserializer) {
-	ChildFieldIDs result;
-	deserializer.ReadPropertyWithDefault<unique_ptr<case_insensitive_map_t<FieldID>>>(100, "ids", result.ids);
-	return result;
-}
-
 void FieldID::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(100, "set", set);
 	serializer.WritePropertyWithDefault<int32_t>(101, "field_id", field_id);

--- a/src/include/duckdb/common/serializer/binary_deserializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_deserializer.hpp
@@ -89,6 +89,7 @@ private:
 	}
 
 	void ReadData(data_ptr_t buffer, idx_t read_size) {
+		D_ASSERT(!has_buffered_field);
 		stream.ReadData(buffer, read_size);
 	}
 

--- a/src/include/duckdb/common/serializer/binary_deserializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_deserializer.hpp
@@ -103,7 +103,7 @@ private:
 	template <class T>
 	T VarIntDecode() {
 		// FIXME: maybe we should pass a source to EncodingUtil instead
-		uint8_t buffer[16];
+		uint8_t buffer[16] = {};
 		idx_t varint_size;
 		for (varint_size = 0; varint_size < 16; varint_size++) {
 			ReadData(buffer + varint_size, 1);

--- a/src/include/duckdb/common/serializer/binary_serializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_serializer.hpp
@@ -44,7 +44,7 @@ private:
 
 	template <class T>
 	void VarIntEncode(T value) {
-		uint8_t buffer[16];
+		uint8_t buffer[16] = {};
 		auto write_size = EncodingUtil::EncodeLEB128<T>(buffer, value);
 		D_ASSERT(write_size <= sizeof(buffer));
 		WriteData(buffer, write_size);


### PR DESCRIPTION
Only relevant change: moving from [de]serializing `unique_ptr<case_insensitive_map_t<FieldID>>` to [de]serializing `case_insensitive_map_t<FieldID>`, given in this particular case the unique_ptr is always valid it should be OK iff:
- in this particular case we do not care with compatibility across version for this specific statement (??). This is attenuated by the fact that currently deserialization in this case is broken, so the fact it's not working probably points to the fact that is not relevant. If cross version [de]serialization happens for this statement this can still generate problems when say an old version produces something broken that is then reinterpreted as something different by a new version. Unsure what's the care needed around this.

There are other possible solution to this problem, but giving they require to add surface I went for the minimal fix.
Probably figuring out the underlying cause of failures in serialization, that are somewhere at the interstection of unique_ptr and serialization of vectors, but have not been able to figure out a proper fix there.

I also added two minor improvements (I think): forcing 0 initialization of buffers (although not needed) and enforcing invariant that while pre-fetching bytes to check for field ID no bytes are ever read from the stream. Neither were actual problems, but I think it make sense to add those lightweight changes.

Closes #11985