### PR TITLE
Issue #12005: RESERVOIR_QUANTILE DECIMAL Binding

### DIFF
--- a/src/core_functions/aggregate/holistic/reservoir_quantile.cpp
+++ b/src/core_functions/aggregate/holistic/reservoir_quantile.cpp
@@ -325,6 +325,7 @@ unique_ptr<FunctionData> BindReservoirQuantile(ClientContext &context, Aggregate
 	}
 
 	if (arguments.size() == 2) {
+		// remove the quantile argument so we can use the unary aggregate
 		if (function.arguments.size() == 2) {
 			Function::EraseArgument(function, arguments, arguments.size() - 1);
 		} else {
@@ -345,9 +346,14 @@ unique_ptr<FunctionData> BindReservoirQuantile(ClientContext &context, Aggregate
 		throw BinderException("Size of the RESERVOIR_QUANTILE sample must be bigger than 0");
 	}
 
-	// remove the quantile argument so we can use the unary aggregate
-	Function::EraseArgument(function, arguments, arguments.size() - 1);
-	Function::EraseArgument(function, arguments, arguments.size() - 1);
+	// remove the quantile arguments so we can use the unary aggregate
+	if (function.arguments.size() == arguments.size()) {
+		Function::EraseArgument(function, arguments, arguments.size() - 1);
+		Function::EraseArgument(function, arguments, arguments.size() - 1);
+	} else {
+		arguments.pop_back();
+		arguments.pop_back();
+	}
 	return make_uniq<ReservoirQuantileBindData>(quantiles, NumericCast<idx_t>(sample_size));
 }
 

--- a/test/sql/aggregate/aggregates/test_approx_quantile.test
+++ b/test/sql/aggregate/aggregates/test_approx_quantile.test
@@ -266,3 +266,9 @@ SELECT reservoir_quantile(r, random()::float)  from quantile
 statement error
 SELECT reservoir_quantile(r, 0.9, random()::float)  from quantile
 ----
+
+# DECIMAL binding
+query I
+SELECT RESERVOIR_QUANTILE(0., 0.9, 1000);
+----
+0


### PR DESCRIPTION
Fix the DECIMAL binding to handle three arguments
as well as two.

fixes: duckdb/duckdb#12005
fixes: duckdblabs/duckdb-internal#2019