### PR TITLE
Fix sample serialization

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -76,6 +76,7 @@
 #include "duckdb/execution/operator/csv_scanner/csv_option.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_state.hpp"
 #include "duckdb/execution/operator/csv_scanner/quote_rules.hpp"
+#include "duckdb/execution/reservoir_sample.hpp"
 #include "duckdb/function/aggregate_state.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/macro_function.hpp"
@@ -5593,6 +5594,34 @@ SampleMethod EnumUtil::FromString<SampleMethod>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "Reservoir")) {
 		return SampleMethod::RESERVOIR_SAMPLE;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<SampleType>(SampleType value) {
+	switch(value) {
+	case SampleType::BLOCKING_SAMPLE:
+		return "BLOCKING_SAMPLE";
+	case SampleType::RESERVOIR_SAMPLE:
+		return "RESERVOIR_SAMPLE";
+	case SampleType::RESERVOIR_PERCENTAGE_SAMPLE:
+		return "RESERVOIR_PERCENTAGE_SAMPLE";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+SampleType EnumUtil::FromString<SampleType>(const char *value) {
+	if (StringUtil::Equals(value, "BLOCKING_SAMPLE")) {
+		return SampleType::BLOCKING_SAMPLE;
+	}
+	if (StringUtil::Equals(value, "RESERVOIR_SAMPLE")) {
+		return SampleType::RESERVOIR_SAMPLE;
+	}
+	if (StringUtil::Equals(value, "RESERVOIR_PERCENTAGE_SAMPLE")) {
+		return SampleType::RESERVOIR_PERCENTAGE_SAMPLE;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -273,7 +273,7 @@ void DataChunk::Deserialize(Deserializer &deserializer) {
 
 	// initialize the data chunk
 	D_ASSERT(!types.empty());
-	Initialize(Allocator::DefaultAllocator(), types);
+	Initialize(Allocator::DefaultAllocator(), types, MaxValue<idx_t>(row_count, STANDARD_VECTOR_SIZE));
 	SetCardinality(row_count);
 
 	// read the data

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1213,7 +1213,7 @@ void Vector::Deserialize(Deserializer &deserializer, idx_t count) {
 	validity.Reset();
 	const auto has_validity = deserializer.ReadProperty<bool>(100, "all_valid");
 	if (has_validity) {
-		validity.Initialize(count);
+		validity.Initialize(MaxValue<idx_t>(count, STANDARD_VECTOR_SIZE));
 		deserializer.ReadProperty(101, "validity", data_ptr_cast(validity.GetData()), validity.ValidityMaskSize(count));
 	}
 

--- a/src/execution/reservoir_sample.cpp
+++ b/src/execution/reservoir_sample.cpp
@@ -4,15 +4,22 @@
 
 namespace duckdb {
 
-void BlockingSample::Serialize(Serializer &serializer) const {
+void ReservoirChunk::Serialize(Serializer &serializer) const {
+	chunk.Serialize(serializer);
 }
 
-unique_ptr<BlockingSample> BlockingSample::Deserialize(Deserializer &deserializer) {
-	return nullptr;
+unique_ptr<ReservoirChunk> ReservoirChunk::Deserialize(Deserializer &deserializer) {
+	auto result = make_uniq<ReservoirChunk>();
+	result->chunk.Deserialize(deserializer);
+	return result;
 }
 
 ReservoirSample::ReservoirSample(Allocator &allocator, idx_t sample_count, int64_t seed)
     : BlockingSample(seed), allocator(allocator), sample_count(sample_count), reservoir_initialized(false) {
+}
+
+ReservoirSample::ReservoirSample(idx_t sample_count, int64_t seed)
+    : ReservoirSample(Allocator::DefaultAllocator(), sample_count, seed) {
 }
 
 void ReservoirSample::AddToReservoir(DataChunk &input) {
@@ -153,6 +160,11 @@ ReservoirSamplePercentage::ReservoirSamplePercentage(Allocator &allocator, doubl
       is_finalized(false) {
 	reservoir_sample_size = idx_t(sample_percentage * RESERVOIR_THRESHOLD);
 	current_sample = make_uniq<ReservoirSample>(allocator, reservoir_sample_size, random.NextRandomInteger());
+}
+
+
+ReservoirSamplePercentage::ReservoirSamplePercentage(double percentage, int64_t seed)
+    : ReservoirSamplePercentage(Allocator::DefaultAllocator(), percentage, seed) {
 }
 
 void ReservoirSamplePercentage::AddToReservoir(DataChunk &input) {

--- a/src/execution/reservoir_sample.cpp
+++ b/src/execution/reservoir_sample.cpp
@@ -20,32 +20,32 @@ void ReservoirSample::AddToReservoir(DataChunk &input) {
 		// sample count is 0, means no samples were requested
 		return;
 	}
-	base_reservoir_sample.num_entries_seen_total += input.size();
+	old_base_reservoir_sample.num_entries_seen_total += input.size();
 	// Input: A population V of n weighted items
 	// Output: A reservoir R with a size m
 	// 1: The first m items of V are inserted into R
 	// first we need to check if the reservoir already has "m" elements
-	if (!reservoir_chunk || reservoir_chunk->size() < sample_count) {
+	if (!reservoir_data_chunk || reservoir_data_chunk->size() < sample_count) {
 		if (FillReservoir(input) == 0) {
 			// entire chunk was consumed by reservoir
 			return;
 		}
 	}
-	D_ASSERT(reservoir_chunk);
-	D_ASSERT(reservoir_chunk->size() == sample_count);
+	D_ASSERT(reservoir_data_chunk);
+	D_ASSERT(reservoir_data_chunk->size() == sample_count);
 	// Initialize the weights if they have not been already
-	if (base_reservoir_sample.reservoir_weights.empty()) {
-		base_reservoir_sample.InitializeReservoir(reservoir_chunk->size(), sample_count);
+	if (old_base_reservoir_sample.reservoir_weights.empty()) {
+		old_base_reservoir_sample.InitializeReservoir(reservoir_data_chunk->size(), sample_count);
 	}
 	// find the position of next_index_to_sample relative to number of seen entries (num_entries_to_skip_b4_next_sample)
 	idx_t remaining = input.size();
 	idx_t base_offset = 0;
 	while (true) {
 		idx_t offset =
-		    base_reservoir_sample.next_index_to_sample - base_reservoir_sample.num_entries_to_skip_b4_next_sample;
+		    old_base_reservoir_sample.next_index_to_sample - old_base_reservoir_sample.num_entries_to_skip_b4_next_sample;
 		if (offset >= remaining) {
 			// not in this chunk! increment current count and go to the next chunk
-			base_reservoir_sample.num_entries_to_skip_b4_next_sample += remaining;
+			old_base_reservoir_sample.num_entries_to_skip_b4_next_sample += remaining;
 			return;
 		}
 		// in this chunk! replace the element
@@ -57,47 +57,47 @@ void ReservoirSample::AddToReservoir(DataChunk &input) {
 }
 
 unique_ptr<DataChunk> ReservoirSample::GetChunk() {
-	if (!reservoir_chunk || reservoir_chunk->size() == 0) {
+	if (!reservoir_data_chunk || reservoir_data_chunk->size() == 0) {
 		return nullptr;
 	}
-	auto collected_sample_count = reservoir_chunk->size();
+	auto collected_sample_count = reservoir_data_chunk->size();
 	if (collected_sample_count > STANDARD_VECTOR_SIZE) {
 		// get from the back to avoid creating two selection vectors
 		// one to return the first STANDARD_VECTOR_SIZE
-		// another to replace the reservoir_chunk with the first STANDARD VECTOR SIZE missing
+		// another to replace the reservoir_data_chunk with the first STANDARD VECTOR SIZE missing
 		auto ret = make_uniq<DataChunk>();
 		auto samples_remaining = collected_sample_count - STANDARD_VECTOR_SIZE;
-		auto reservoir_types = reservoir_chunk->GetTypes();
+		auto reservoir_types = reservoir_data_chunk->GetTypes();
 		SelectionVector sel(STANDARD_VECTOR_SIZE);
 		for (idx_t i = samples_remaining; i < collected_sample_count; i++) {
 			sel.set_index(i - samples_remaining, i);
 		}
 		ret->Initialize(allocator, reservoir_types.begin(), reservoir_types.end(), STANDARD_VECTOR_SIZE);
-		ret->Slice(*reservoir_chunk, sel, STANDARD_VECTOR_SIZE);
+		ret->Slice(*reservoir_data_chunk, sel, STANDARD_VECTOR_SIZE);
 		ret->SetCardinality(STANDARD_VECTOR_SIZE);
 		// reduce capacity and cardinality of the sample data chunk
-		reservoir_chunk->SetCardinality(samples_remaining);
+		reservoir_data_chunk->SetCardinality(samples_remaining);
 		return ret;
 	}
-	return std::move(reservoir_chunk);
+	return std::move(reservoir_data_chunk);
 }
 
 void ReservoirSample::ReplaceElement(DataChunk &input, idx_t index_in_chunk, double with_weight) {
 	// replace the entry in the reservoir
 	// 8. The item in R with the minimum key is replaced by item vi
-	D_ASSERT(input.ColumnCount() == reservoir_chunk->ColumnCount());
+	D_ASSERT(input.ColumnCount() == reservoir_data_chunk->ColumnCount());
 	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
-		reservoir_chunk->SetValue(col_idx, base_reservoir_sample.min_weighted_entry_index,
+		reservoir_data_chunk->SetValue(col_idx, old_base_reservoir_sample.min_weighted_entry_index,
 		                          input.GetValue(col_idx, index_in_chunk));
 	}
-	base_reservoir_sample.ReplaceElement(with_weight);
+	old_base_reservoir_sample.ReplaceElement(with_weight);
 }
 
 void ReservoirSample::InitializeReservoir(DataChunk &input) {
-	reservoir_chunk = make_uniq<DataChunk>();
-	reservoir_chunk->Initialize(allocator, input.GetTypes(), sample_count);
-	for (idx_t col_idx = 0; col_idx < reservoir_chunk->ColumnCount(); col_idx++) {
-		FlatVector::Validity(reservoir_chunk->data[col_idx]).Initialize(sample_count);
+	reservoir_data_chunk = make_uniq<DataChunk>();
+	reservoir_data_chunk->Initialize(allocator, input.GetTypes(), sample_count);
+	for (idx_t col_idx = 0; col_idx < reservoir_data_chunk->ColumnCount(); col_idx++) {
+		FlatVector::Validity(reservoir_data_chunk->data[col_idx]).Initialize(sample_count);
 	}
 	reservoir_initialized = true;
 }
@@ -105,7 +105,7 @@ void ReservoirSample::InitializeReservoir(DataChunk &input) {
 idx_t ReservoirSample::FillReservoir(DataChunk &input) {
 	idx_t chunk_count = input.size();
 	input.Flatten();
-	auto num_added_samples = reservoir_chunk ? reservoir_chunk->size() : 0;
+	auto num_added_samples = reservoir_data_chunk ? reservoir_data_chunk->size() : 0;
 	D_ASSERT(num_added_samples <= sample_count);
 
 	// required count is what we still need to add to the reservoir
@@ -123,8 +123,8 @@ idx_t ReservoirSample::FillReservoir(DataChunk &input) {
 	if (!reservoir_initialized) {
 		InitializeReservoir(input);
 	}
-	reservoir_chunk->Append(input, false, nullptr, required_count);
-	base_reservoir_sample.InitializeReservoir(required_count, sample_count);
+	reservoir_data_chunk->Append(input, false, nullptr, required_count);
+	old_base_reservoir_sample.InitializeReservoir(required_count, sample_count);
 
 	// check if there are still elements remaining in the Input data chunk that should be
 	// randomly sampled and potentially added. This happens if we are on a boundary
@@ -156,7 +156,7 @@ ReservoirSamplePercentage::ReservoirSamplePercentage(Allocator &allocator, doubl
 }
 
 void ReservoirSamplePercentage::AddToReservoir(DataChunk &input) {
-	base_reservoir_sample.num_entries_seen_total += input.size();
+	old_base_reservoir_sample.num_entries_seen_total += input.size();
 	if (current_count + input.size() > RESERVOIR_THRESHOLD) {
 		// we don't have enough space in our current reservoir
 		// first check what we still need to append to the current sample

--- a/src/execution/reservoir_sample.cpp
+++ b/src/execution/reservoir_sample.cpp
@@ -48,8 +48,8 @@ void ReservoirSample::AddToReservoir(DataChunk &input) {
 	idx_t remaining = input.size();
 	idx_t base_offset = 0;
 	while (true) {
-		idx_t offset =
-		    old_base_reservoir_sample.next_index_to_sample - old_base_reservoir_sample.num_entries_to_skip_b4_next_sample;
+		idx_t offset = old_base_reservoir_sample.next_index_to_sample -
+		               old_base_reservoir_sample.num_entries_to_skip_b4_next_sample;
 		if (offset >= remaining) {
 			// not in this chunk! increment current count and go to the next chunk
 			old_base_reservoir_sample.num_entries_to_skip_b4_next_sample += remaining;
@@ -95,7 +95,7 @@ void ReservoirSample::ReplaceElement(DataChunk &input, idx_t index_in_chunk, dou
 	D_ASSERT(input.ColumnCount() == reservoir_data_chunk->ColumnCount());
 	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
 		reservoir_data_chunk->SetValue(col_idx, old_base_reservoir_sample.min_weighted_entry_index,
-		                          input.GetValue(col_idx, index_in_chunk));
+		                               input.GetValue(col_idx, index_in_chunk));
 	}
 	old_base_reservoir_sample.ReplaceElement(with_weight);
 }
@@ -161,7 +161,6 @@ ReservoirSamplePercentage::ReservoirSamplePercentage(Allocator &allocator, doubl
 	reservoir_sample_size = idx_t(sample_percentage * RESERVOIR_THRESHOLD);
 	current_sample = make_uniq<ReservoirSample>(allocator, reservoir_sample_size, random.NextRandomInteger());
 }
-
 
 ReservoirSamplePercentage::ReservoirSamplePercentage(double percentage, int64_t seed)
     : ReservoirSamplePercentage(Allocator::DefaultAllocator(), percentage, seed) {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -244,6 +244,8 @@ enum class ResultModifierType : uint8_t;
 
 enum class SampleMethod : uint8_t;
 
+enum class SampleType : uint8_t;
+
 enum class ScanType : uint8_t;
 
 enum class SecretDisplayType : uint8_t;
@@ -644,6 +646,9 @@ const char* EnumUtil::ToChars<ResultModifierType>(ResultModifierType value);
 
 template<>
 const char* EnumUtil::ToChars<SampleMethod>(SampleMethod value);
+
+template<>
+const char* EnumUtil::ToChars<SampleType>(SampleType value);
 
 template<>
 const char* EnumUtil::ToChars<ScanType>(ScanType value);
@@ -1086,6 +1091,9 @@ ResultModifierType EnumUtil::FromString<ResultModifierType>(const char *value);
 
 template<>
 SampleMethod EnumUtil::FromString<SampleMethod>(const char *value);
+
+template<>
+SampleType EnumUtil::FromString<SampleType>(const char *value);
 
 template<>
 ScanType EnumUtil::FromString<ScanType>(const char *value);

--- a/src/include/duckdb/common/serializer/deserializer.hpp
+++ b/src/include/duckdb/common/serializer/deserializer.hpp
@@ -340,6 +340,19 @@ private:
 		return std::make_pair(first, second);
 	}
 
+	// Deserialize a priority_queue
+	template <typename T = void>
+	inline typename std::enable_if<is_queue<T>::value, T>::type Read() {
+		using ELEMENT_TYPE = typename is_queue<T>::ELEMENT_TYPE;
+		T queue;
+		auto size = OnListBegin();
+		for (idx_t i = 0; i < size; i++) {
+			queue.emplace(Read<ELEMENT_TYPE>());
+		}
+		OnListEnd();
+		return queue;
+	}
+
 	// Primitive types
 	// Deserialize a bool
 	template <typename T = void>

--- a/src/include/duckdb/common/serializer/serialization_traits.hpp
+++ b/src/include/duckdb/common/serializer/serialization_traits.hpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/set.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/queue.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/optional_idx.hpp"
 
@@ -97,6 +98,13 @@ struct is_map<typename duckdb::map<Args...>> : std::true_type {
 	typedef typename std::tuple_element<1, std::tuple<Args...>>::type VALUE_TYPE;
 	typedef typename std::tuple_element<2, std::tuple<Args...>>::type HASH_TYPE;
 	typedef typename std::tuple_element<3, std::tuple<Args...>>::type EQUAL_TYPE;
+};
+
+template <typename T>
+struct is_queue : std::false_type {};
+template <typename T>
+struct is_queue<typename std::priority_queue<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
 };
 
 template <typename T>
@@ -221,6 +229,16 @@ struct SerializationDefaultValue {
 
 	template <typename T = void>
 	static inline bool IsDefault(const typename std::enable_if<is_vector<T>::value, T>::type &value) {
+		return value.empty();
+	}
+
+	template <typename T = void>
+	static inline typename std::enable_if<is_queue<T>::value, T>::type GetDefault() {
+		return T();
+	}
+
+	template <typename T = void>
+	static inline bool IsDefault(const typename std::enable_if<is_queue<T>::value, T>::type &value) {
 		return value.empty();
 	}
 

--- a/src/include/duckdb/common/serializer/serializer.hpp
+++ b/src/include/duckdb/common/serializer/serializer.hpp
@@ -259,6 +259,18 @@ protected:
 		OnListEnd();
 	}
 
+	// priority queue
+	template <typename T>
+	void WriteValue(const std::priority_queue<T> &queue) {
+		vector<T> placeholder;
+		auto queue_copy = std::priority_queue<T>(queue);
+		while (queue_copy.size() > 0) {
+			placeholder.emplace_back(queue_copy.top());
+			queue_copy.pop();
+		}
+		WriteValue(placeholder);
+	}
+
 	// class or struct implementing `Serialize(Serializer& Serializer)`;
 	template <typename T>
 	typename std::enable_if<has_serialize<T>::value>::type WriteValue(const T &value) {

--- a/src/include/duckdb/execution/reservoir_sample.hpp
+++ b/src/include/duckdb/execution/reservoir_sample.hpp
@@ -116,7 +116,7 @@ public:
 
 public:
 	ReservoirSample(Allocator &allocator, idx_t sample_count, int64_t seed = 1);
-	ReservoirSample(idx_t sample_count, int64_t seed = 1);
+	explicit ReservoirSample(idx_t sample_count, int64_t seed = 1);
 
 	//! Add a chunk of data to the sample
 	void AddToReservoir(DataChunk &input) override;
@@ -157,7 +157,7 @@ public:
 
 public:
 	ReservoirSamplePercentage(Allocator &allocator, double percentage, int64_t seed = -1);
-	ReservoirSamplePercentage(double percentage, int64_t seed = -1);
+	explicit ReservoirSamplePercentage(double percentage, int64_t seed = -1);
 
 	//! Add a chunk of data to the sample
 	void AddToReservoir(DataChunk &input) override;

--- a/src/include/duckdb/execution/reservoir_sample.hpp
+++ b/src/include/duckdb/execution/reservoir_sample.hpp
@@ -107,8 +107,6 @@ public:
 	DataChunk chunk;
 	void Serialize(Serializer &serializer) const;
 	static unique_ptr<ReservoirChunk> Deserialize(Deserializer &deserializer);
-
-	unique_ptr<ReservoirChunk> Copy();
 };
 
 //! The reservoir sample class maintains a streaming sample of fixed size "sample_count"

--- a/src/include/duckdb/execution/reservoir_sample.hpp
+++ b/src/include/duckdb/execution/reservoir_sample.hpp
@@ -17,6 +17,8 @@
 
 namespace duckdb {
 
+enum class SampleType : uint8_t { BLOCKING_SAMPLE = 0, RESERVOIR_SAMPLE = 1, RESERVOIR_PERCENTAGE_SAMPLE = 2 };
+
 class BaseReservoirSampling {
 public:
 	explicit BaseReservoirSampling(int64_t seed);
@@ -29,8 +31,6 @@ public:
 	void ReplaceElement(double with_weight = -1);
 	//! The random generator
 	RandomEngine random;
-	//! Priority queue of [random element, index] for each of the elements in the sample
-	std::priority_queue<std::pair<double, idx_t>> reservoir_weights;
 	//! The next element to sample
 	idx_t next_index_to_sample;
 	//! The reservoir threshold of the current min entry
@@ -43,11 +43,26 @@ public:
 	//! when collecting a sample in parallel, we want to know how many values each thread has seen
 	//! so we can collect the samples from the thread local states in a uniform manner
 	idx_t num_entries_seen_total;
+	//! Priority queue of [random element, index] for each of the elements in the sample
+	std::priority_queue<std::pair<double, idx_t>> reservoir_weights;
+
+	void Serialize(Serializer &serializer) const;
+	static unique_ptr<BaseReservoirSampling> Deserialize(Deserializer &deserializer);
 };
 
 class BlockingSample {
 public:
-	explicit BlockingSample(int64_t seed) : base_reservoir_sample(seed), random(base_reservoir_sample.random) {
+	static constexpr const SampleType TYPE = SampleType::BLOCKING_SAMPLE;
+
+	unique_ptr<BaseReservoirSampling> base_reservoir_sample;
+	//! The sample type
+	SampleType type;
+	//! has the sample been destroyed due to updates to the referenced table
+	bool destroyed;
+
+public:
+	explicit BlockingSample(int64_t seed) : random(base_reservoir_sample->random) {
+		base_reservoir_sample = make_uniq<BaseReservoirSampling>(seed);
 	}
 	virtual ~BlockingSample() {
 	}
@@ -59,18 +74,47 @@ public:
 	//! Fetches a chunk from the sample. Note that this method is destructive and should only be used after the
 	//! sample is completely built.
 	virtual unique_ptr<DataChunk> GetChunk() = 0;
-	BaseReservoirSampling base_reservoir_sample;
 
 	virtual void Serialize(Serializer &serializer) const;
 	static unique_ptr<BlockingSample> Deserialize(Deserializer &deserializer);
 
-protected:
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		if (type != TARGET::TYPE && TARGET::TYPE != SampleType::BLOCKING_SAMPLE) {
+			throw InternalException("Failed to cast sample to type - sample type mismatch");
+		}
+		return reinterpret_cast<TARGET &>(*this);
+	}
+
+	template <class TARGET>
+	const TARGET &Cast() const {
+		if (type != TARGET::TYPE && TARGET::TYPE != SampleType::BLOCKING_SAMPLE) {
+			throw InternalException("Failed to cast sample to type - sample type mismatch");
+		}
+		return reinterpret_cast<const TARGET &>(*this);
+	}
 	//! The reservoir sampling
 	RandomEngine &random;
 };
 
+class ReservoirChunk {
+public:
+	ReservoirChunk() {
+	}
+
+	DataChunk chunk;
+	void Serialize(Serializer &serializer) const;
+	static unique_ptr<ReservoirChunk> Deserialize(Deserializer &deserializer);
+
+	unique_ptr<ReservoirChunk> Copy();
+};
+
 //! The reservoir sample class maintains a streaming sample of fixed size "sample_count"
 class ReservoirSample : public BlockingSample {
+public:
+	static constexpr const SampleType TYPE = SampleType::RESERVOIR_SAMPLE;
+
 public:
 	ReservoirSample(Allocator &allocator, idx_t sample_count, int64_t seed);
 
@@ -96,8 +140,9 @@ public:
 	//! when explicit number used, sample_count = number
 	idx_t sample_count;
 	bool reservoir_initialized;
+
 	//! The current reservoir
-	unique_ptr<DataChunk> reservoir_chunk;
+	unique_ptr<ReservoirChunk> reservoir_chunk;
 };
 
 //! The reservoir sample sample_size class maintains a streaming sample of variable size
@@ -105,6 +150,8 @@ class ReservoirSamplePercentage : public BlockingSample {
 	constexpr static idx_t RESERVOIR_THRESHOLD = 100000;
 
 public:
+	static constexpr const SampleType TYPE = SampleType::RESERVOIR_PERCENTAGE_SAMPLE;
+
 	ReservoirSamplePercentage(Allocator &allocator, double percentage, int64_t seed);
 
 	//! Add a chunk of data to the sample
@@ -114,6 +161,9 @@ public:
 	//! sample is completely built.
 	unique_ptr<DataChunk> GetChunk() override;
 	void Finalize() override;
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<BlockingSample> Deserialize(Deserializer &deserializer);
 
 private:
 	Allocator &allocator;

--- a/src/include/duckdb/execution/reservoir_sample.hpp
+++ b/src/include/duckdb/execution/reservoir_sample.hpp
@@ -61,7 +61,7 @@ public:
 	bool destroyed;
 
 public:
-	explicit BlockingSample(int64_t seed) : old_base_reservoir_sample(seed), random(old_base_reservoir_sample.random){
+	explicit BlockingSample(int64_t seed) : old_base_reservoir_sample(seed), random(old_base_reservoir_sample.random) {
 		base_reservoir_sample = nullptr;
 	}
 	virtual ~BlockingSample() {

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -203,6 +203,104 @@
     ]
   },
   {
+    "class": "BaseReservoirSampling",
+    "includes": [
+      "duckdb/execution/reservoir_sample.hpp",
+      "duckdb/common/queue.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "next_index_to_sample",
+        "type": "idx_t"
+      },
+      {
+        "id": 101,
+        "name": "min_weight_threshold",
+        "type": "double"
+      },
+      {
+        "id": 102,
+        "name": "min_weighted_entry_index",
+        "type": "idx_t"
+      },
+      {
+        "id": 103,
+        "name": "num_entries_to_skip_b4_next_sample",
+        "type": "idx_t"
+      },
+      {
+        "id": 104,
+        "name": "num_entries_seen_total",
+        "type": "idx_t"
+      },
+      {
+        "id": 105,
+        "name": "reservoir_weights",
+        "type": "std::priority_queue<std::pair<double, idx_t>>"
+      }
+    ]
+  },
+  {
+    "class": "BlockingSample",
+    "class_type": "type",
+    "members": [
+      {
+        "id" : 100,
+        "name" : "base_reservoir_sample",
+        "type" : "unique_ptr<BaseReservoirSampling>"
+      },
+      {
+        "id" : 101,
+        "name": "type",
+        "type": "SampleType"
+      },
+      {
+        "id": 102,
+        "name": "destroyed",
+        "type": "bool"
+      }
+    ]
+  },
+  {
+    "class": "ReservoirSample",
+    "base": "BlockingSample",
+    "enum": "RESERVOIR_SAMPLE",
+    "includes": [],
+    "members": [
+      {
+        "id": 200,
+        "name": "sample_count",
+        "type": "idx_t"
+      },
+      {
+        "id": 201,
+        "name": "reservoir_chunk",
+        "type": "unique_ptr<ReservoirChunk>"
+      }
+    ],
+    "constructor": ["sample_count"]
+  },
+  {
+    "class": "ReservoirSamplePercentage",
+    "base": "BlockingSample",
+    "enum": "RESERVOIR_PERCENTAGE_SAMPLE",
+    "includes": [],
+    "members": [
+      {
+        "id": 200,
+        "name": "sample_percentage",
+        "type": "double"
+      },
+      {
+        "id": 201,
+        "name": "reservoir_sample_size",
+        "type": "idx_t"
+      }
+    ],
+    "constructor": ["sample_percentage"]
+  },
+  {
     "class": "PivotColumn",
     "includes": [
       "duckdb/parser/tableref/pivotref.hpp"

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -14,6 +14,8 @@
 #include "duckdb/parser/expression/case_expression.hpp"
 #include "duckdb/planner/expression/bound_case_expression.hpp"
 #include "duckdb/parser/parsed_data/sample_options.hpp"
+#include "duckdb/execution/reservoir_sample.hpp"
+#include "duckdb/common/queue.hpp"
 #include "duckdb/parser/tableref/pivotref.hpp"
 #include "duckdb/planner/tableref/bound_pivotref.hpp"
 #include "duckdb/parser/column_definition.hpp"
@@ -32,6 +34,52 @@
 #include "duckdb/common/types/interval.hpp"
 
 namespace duckdb {
+
+void BlockingSample::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<unique_ptr<BaseReservoirSampling>>(100, "base_reservoir_sample", base_reservoir_sample);
+	serializer.WriteProperty<SampleType>(101, "type", type);
+	serializer.WritePropertyWithDefault<bool>(102, "destroyed", destroyed);
+}
+
+unique_ptr<BlockingSample> BlockingSample::Deserialize(Deserializer &deserializer) {
+	auto base_reservoir_sample = deserializer.ReadPropertyWithDefault<unique_ptr<BaseReservoirSampling>>(100, "base_reservoir_sample");
+	auto type = deserializer.ReadProperty<SampleType>(101, "type");
+	auto destroyed = deserializer.ReadPropertyWithDefault<bool>(102, "destroyed");
+	unique_ptr<BlockingSample> result;
+	switch (type) {
+	case SampleType::RESERVOIR_PERCENTAGE_SAMPLE:
+		result = ReservoirSamplePercentage::Deserialize(deserializer);
+		break;
+	case SampleType::RESERVOIR_SAMPLE:
+		result = ReservoirSample::Deserialize(deserializer);
+		break;
+	default:
+		throw SerializationException("Unsupported type for deserialization of BlockingSample!");
+	}
+	result->base_reservoir_sample = std::move(base_reservoir_sample);
+	result->destroyed = destroyed;
+	return result;
+}
+
+void BaseReservoirSampling::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<idx_t>(100, "next_index_to_sample", next_index_to_sample);
+	serializer.WriteProperty<double>(101, "min_weight_threshold", min_weight_threshold);
+	serializer.WritePropertyWithDefault<idx_t>(102, "min_weighted_entry_index", min_weighted_entry_index);
+	serializer.WritePropertyWithDefault<idx_t>(103, "num_entries_to_skip_b4_next_sample", num_entries_to_skip_b4_next_sample);
+	serializer.WritePropertyWithDefault<idx_t>(104, "num_entries_seen_total", num_entries_seen_total);
+	serializer.WritePropertyWithDefault<std::priority_queue<std::pair<double, idx_t>>>(105, "reservoir_weights", reservoir_weights);
+}
+
+unique_ptr<BaseReservoirSampling> BaseReservoirSampling::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<BaseReservoirSampling>(new BaseReservoirSampling());
+	deserializer.ReadPropertyWithDefault<idx_t>(100, "next_index_to_sample", result->next_index_to_sample);
+	deserializer.ReadProperty<double>(101, "min_weight_threshold", result->min_weight_threshold);
+	deserializer.ReadPropertyWithDefault<idx_t>(102, "min_weighted_entry_index", result->min_weighted_entry_index);
+	deserializer.ReadPropertyWithDefault<idx_t>(103, "num_entries_to_skip_b4_next_sample", result->num_entries_to_skip_b4_next_sample);
+	deserializer.ReadPropertyWithDefault<idx_t>(104, "num_entries_seen_total", result->num_entries_seen_total);
+	deserializer.ReadPropertyWithDefault<std::priority_queue<std::pair<double, idx_t>>>(105, "reservoir_weights", result->reservoir_weights);
+	return result;
+}
 
 void BoundCaseCheck::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(100, "when_expr", when_expr);
@@ -419,6 +467,32 @@ unique_ptr<ReadCSVData> ReadCSVData::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadProperty<MultiFileReaderBindData>(107, "reader_bind", result->reader_bind);
 	deserializer.ReadPropertyWithDefault<vector<ColumnInfo>>(108, "column_info", result->column_info);
 	return result;
+}
+
+void ReservoirSample::Serialize(Serializer &serializer) const {
+	BlockingSample::Serialize(serializer);
+	serializer.WritePropertyWithDefault<idx_t>(200, "sample_count", sample_count);
+	serializer.WritePropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", reservoir_chunk);
+}
+
+unique_ptr<BlockingSample> ReservoirSample::Deserialize(Deserializer &deserializer) {
+	auto sample_count = deserializer.ReadPropertyWithDefault<idx_t>(200, "sample_count");
+	auto result = duckdb::unique_ptr<ReservoirSample>(new ReservoirSample(sample_count));
+	deserializer.ReadPropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", result->reservoir_chunk);
+	return std::move(result);
+}
+
+void ReservoirSamplePercentage::Serialize(Serializer &serializer) const {
+	BlockingSample::Serialize(serializer);
+	serializer.WriteProperty<double>(200, "sample_percentage", sample_percentage);
+	serializer.WritePropertyWithDefault<idx_t>(201, "reservoir_sample_size", reservoir_sample_size);
+}
+
+unique_ptr<BlockingSample> ReservoirSamplePercentage::Deserialize(Deserializer &deserializer) {
+	auto sample_percentage = deserializer.ReadProperty<double>(200, "sample_percentage");
+	auto result = duckdb::unique_ptr<ReservoirSamplePercentage>(new ReservoirSamplePercentage(sample_percentage));
+	deserializer.ReadPropertyWithDefault<idx_t>(201, "reservoir_sample_size", result->reservoir_sample_size);
+	return std::move(result);
 }
 
 void SampleOptions::Serialize(Serializer &serializer) const {

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -472,13 +472,13 @@ unique_ptr<ReadCSVData> ReadCSVData::Deserialize(Deserializer &deserializer) {
 void ReservoirSample::Serialize(Serializer &serializer) const {
 	BlockingSample::Serialize(serializer);
 	serializer.WritePropertyWithDefault<idx_t>(200, "sample_count", sample_count);
-	serializer.WritePropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", reservoir_chunk, nullptr);
+	serializer.WritePropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", reservoir_chunk);
 }
 
 unique_ptr<BlockingSample> ReservoirSample::Deserialize(Deserializer &deserializer) {
 	auto sample_count = deserializer.ReadPropertyWithDefault<idx_t>(200, "sample_count");
 	auto result = duckdb::unique_ptr<ReservoirSample>(new ReservoirSample(sample_count));
-	deserializer.ReadPropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", result->reservoir_chunk, nullptr);
+	deserializer.ReadPropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", result->reservoir_chunk);
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -472,13 +472,13 @@ unique_ptr<ReadCSVData> ReadCSVData::Deserialize(Deserializer &deserializer) {
 void ReservoirSample::Serialize(Serializer &serializer) const {
 	BlockingSample::Serialize(serializer);
 	serializer.WritePropertyWithDefault<idx_t>(200, "sample_count", sample_count);
-	serializer.WritePropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", reservoir_chunk);
+	serializer.WritePropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", reservoir_chunk, nullptr);
 }
 
 unique_ptr<BlockingSample> ReservoirSample::Deserialize(Deserializer &deserializer) {
 	auto sample_count = deserializer.ReadPropertyWithDefault<idx_t>(200, "sample_count");
 	auto result = duckdb::unique_ptr<ReservoirSample>(new ReservoirSample(sample_count));
-	deserializer.ReadPropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", result->reservoir_chunk);
+	deserializer.ReadPropertyWithDefault<unique_ptr<ReservoirChunk>>(201, "reservoir_chunk", result->reservoir_chunk, nullptr);
 	return std::move(result);
 }
 

--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -125,7 +125,7 @@ void TableStatistics::Deserialize(Deserializer &deserializer, ColumnList &column
 
 		deserializer.Unset<LogicalType>();
 	});
-	table_sample = deserializer.ReadPropertyWithDefault<unique_ptr<BlockingSample>>(101, "sample", nullptr);
+	table_sample = deserializer.ReadPropertyWithDefault<unique_ptr<BlockingSample>>(101, "table_sample", nullptr);
 }
 
 unique_ptr<TableStatisticsLock> TableStatistics::GetLock() {


### PR DESCRIPTION
This PR will add the extra serialization fields for sampling that will most likely be included in v1.1.0. With the PR, if users create a database with v1.0.0, amend it and add a table with v.1.1.0, v1.0.0 can still read the database file.

This PR serializes all extra fields that are serialized in my branch that adds samples. 
https://github.com/Tmonster/duckdb/pull/115. 
The overall logic is that if the fields are serialized in v1.0.0, then nullptr/empty values are serialized. If the fields are serialized in v1.1.0 and read in v1.0.0, the fields may have data, but the data isn't used anywhere.