### PR TITLE
Bugfixes + large allocation hardening

### DIFF
--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -26,7 +26,7 @@ ErrorData::ErrorData(const string &message) : initialized(true), type(ExceptionT
 	if (message.empty() || message[0] != '{') {
 		// not JSON! Use the message as a raw Exception message and leave type as uninitialized
 
-		if (message == "std::bad_alloc") {
+		if (message == std::bad_alloc().what()) {
 			type = ExceptionType::OUT_OF_MEMORY;
 			raw_message = "Allocation failure";
 			return;

--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -25,6 +25,13 @@ ErrorData::ErrorData(const string &message) : initialized(true), type(ExceptionT
 	// parse the constructed JSON
 	if (message.empty() || message[0] != '{') {
 		// not JSON! Use the message as a raw Exception message and leave type as uninitialized
+
+		if (message == "std::bad_alloc") {
+			type = ExceptionType::OUT_OF_MEMORY;
+			raw_message = "Allocation failure";
+			return;
+		}
+
 		raw_message = message;
 		return;
 	} else {

--- a/src/common/types/string_heap.cpp
+++ b/src/common/types/string_heap.cpp
@@ -51,6 +51,10 @@ string_t StringHeap::AddBlob(const string_t &data) {
 
 string_t StringHeap::EmptyString(idx_t len) {
 	D_ASSERT(len > string_t::INLINE_LENGTH);
+	if (len > string_t::MAX_STRING_SIZE) {
+		throw OutOfRangeException("Cannot create a string of size: '%d', the maximum supported string size is: '%d'",
+		                          len, string_t::MAX_STRING_SIZE);
+	}
 	auto insert_pos = const_char_ptr_cast(allocator.Allocate(len));
 	return string_t(insert_pos, UnsafeNumericCast<uint32_t>(len));
 }

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -395,10 +395,17 @@ void Vector::Resize(idx_t cur_size, idx_t new_size) {
 	}
 	for (auto &data_to_resize : to_resize) {
 		if (!data_to_resize.is_nested) {
-			auto new_data =
-			    make_unsafe_uniq_array<data_t>(new_size * data_to_resize.type_size * data_to_resize.nested_multiplier);
-			memcpy(new_data.get(), data_to_resize.data,
-			       cur_size * data_to_resize.type_size * data_to_resize.nested_multiplier * sizeof(data_t));
+			auto old_size = cur_size * data_to_resize.type_size * data_to_resize.nested_multiplier * sizeof(data_t);
+			auto target_size = new_size * data_to_resize.type_size * data_to_resize.nested_multiplier * sizeof(data_t);
+
+			// We have an upper limit of 4GB for a single vector
+			if (target_size > NumericLimits<uint32_t>::Maximum()) {
+				throw OutOfRangeException("Cannot resize vector to %lld bytes: maximum allowed vector size is 4GB",
+				                          target_size);
+			}
+
+			auto new_data = make_unsafe_uniq_array<data_t>(target_size);
+			memcpy(new_data.get(), data_to_resize.data, old_size);
 			data_to_resize.buffer->SetData(std::move(new_data));
 			data_to_resize.vec.data = data_to_resize.buffer->GetData();
 		}

--- a/src/common/types/vector_buffer.cpp
+++ b/src/common/types/vector_buffer.cpp
@@ -68,6 +68,10 @@ VectorListBuffer::VectorListBuffer(const LogicalType &list_type, idx_t initial_c
 void VectorListBuffer::Reserve(idx_t to_reserve) {
 	if (to_reserve > capacity) {
 		idx_t new_capacity = NextPowerOfTwo(to_reserve);
+		if (new_capacity == 0) {
+			// Overflow: set to_reserve to the maximum value
+			new_capacity = to_reserve;
+		}
 		D_ASSERT(new_capacity >= to_reserve);
 		child->Resize(capacity, new_capacity);
 		capacity = new_capacity;

--- a/src/core_functions/scalar/string/repeat.cpp
+++ b/src/core_functions/scalar/string/repeat.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/core_functions/scalar/string_functions.hpp"
+#include "duckdb/common/operator/multiply.hpp"
 
 namespace duckdb {
 
@@ -11,15 +12,22 @@ static void RepeatFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	    str_vector, cnt_vector, result, args.size(), [&](string_t str, int64_t cnt) {
 		    auto input_str = str.GetData();
 		    auto size_str = str.GetSize();
+		    idx_t copy_count = cnt <= 0 || size_str == 0 ? 0 : UnsafeNumericCast<idx_t>(cnt);
 
-		    idx_t copy_count = cnt <= 0 || size_str == 0 ? 0 : idx_t(cnt);
-		    auto result_str = StringVector::EmptyString(result, size_str * copy_count);
-		    auto result_data = result_str.GetDataWriteable();
-		    for (idx_t i = 0; i < copy_count; i++) {
-			    memcpy(result_data + i * size_str, input_str, size_str);
+		    idx_t copy_size;
+		    if (TryMultiplyOperator::Operation(size_str, copy_count, copy_size)) {
+			    auto result_str = StringVector::EmptyString(result, copy_size);
+			    auto result_data = result_str.GetDataWriteable();
+			    for (idx_t i = 0; i < copy_count; i++) {
+				    memcpy(result_data + i * size_str, input_str, size_str);
+			    }
+			    result_str.Finalize();
+			    return result_str;
+		    } else {
+			    throw OutOfRangeException(
+			        "Cannot create a string of size: '%d' * '%d', the maximum supported string size is: '%d'", size_str,
+			        copy_count, string_t::MAX_STRING_SIZE);
 		    }
-		    result_str.Finalize();
-		    return result_str;
 	    });
 }
 

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -204,6 +204,9 @@ static void UnnestVector(UnifiedVectorFormat &child_vector_data, Vector &child_v
 		}
 		break;
 	}
+	case PhysicalType::ARRAY: {
+		throw NotImplementedException("ARRAY type not supported for UNNEST.");
+	}
 	default:
 		throw InternalException("Unimplemented type for UNNEST.");
 	}

--- a/src/function/scalar/list/list_resize.cpp
+++ b/src/function/scalar/list/list_resize.cpp
@@ -28,7 +28,7 @@ void ListResizeFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 	UnifiedVectorFormat new_size_data;
 	new_sizes.ToUnifiedFormat(count, new_size_data);
-	auto new_size_entries = UnifiedVectorFormat::GetData<int64_t>(new_size_data);
+	auto new_size_entries = UnifiedVectorFormat::GetData<uint64_t>(new_size_data);
 
 	UnifiedVectorFormat child_data;
 	child.ToUnifiedFormat(count, child_data);
@@ -38,7 +38,7 @@ void ListResizeFunction(DataChunk &args, ExpressionState &state, Vector &result)
 	for (idx_t i = 0; i < count; i++) {
 		auto index = new_size_data.sel->get_index(i);
 		if (new_size_data.validity.RowIsValid(index)) {
-			new_child_size += UnsafeNumericCast<uint64_t>(new_size_entries[index]);
+			new_child_size += new_size_entries[index];
 		}
 	}
 
@@ -72,7 +72,7 @@ void ListResizeFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 		idx_t new_size_entry = 0;
 		if (new_size_data.validity.RowIsValid(new_index)) {
-			new_size_entry = UnsafeNumericCast<uint64_t>(new_size_entries[new_index]);
+			new_size_entry = new_size_entries[new_index];
 		}
 
 		// find the smallest size between lists and new_sizes

--- a/src/function/scalar/list/list_select.cpp
+++ b/src/function/scalar/list/list_select.cpp
@@ -45,6 +45,12 @@ struct SetSelectionVectorWhere {
 		if (!input_validity.RowIsValid(input_offset + child_idx)) {
 			validity_mask.SetInvalid(target_offset);
 		}
+
+		if (child_idx >= target_length) {
+			selection_vector.set_index(target_offset, 0);
+			validity_mask.SetInvalid(target_offset);
+		}
+
 		target_offset++;
 	}
 

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/limits.hpp"
 
 #include <cstring>
 #include <algorithm>
@@ -26,6 +27,7 @@ public:
 	static constexpr idx_t PREFIX_BYTES = 4 * sizeof(char);
 	static constexpr idx_t INLINE_BYTES = 12 * sizeof(char);
 	static constexpr idx_t HEADER_SIZE = sizeof(uint32_t) + PREFIX_BYTES;
+	static constexpr idx_t MAX_STRING_SIZE = NumericLimits<uint32_t>::Maximum();
 #ifndef DUCKDB_DEBUG_NO_INLINE
 	static constexpr idx_t PREFIX_LENGTH = PREFIX_BYTES;
 	static constexpr idx_t INLINE_LENGTH = INLINE_BYTES;

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -108,6 +108,14 @@ unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {
 		auto &collation = expr->Cast<CollateExpression>();
 		if (collation.child->expression_class == ExpressionClass::CONSTANT) {
 			auto &constant = collation.child->Cast<ConstantExpression>();
+
+			// non-integral expression, we just leave the constant here.
+			// ORDER BY <constant> has no effect
+			// CONTROVERSIAL: maybe we should throw an error
+			if (!constant.value.type().IsIntegral()) {
+				return nullptr;
+			}
+
 			D_ASSERT(constant.value.GetValue<idx_t>() > 0);
 			auto index = constant.value.GetValue<idx_t>() - 1;
 			child_list_t<Value> values;

--- a/test/sql/function/list/list_resize.test
+++ b/test/sql/function/list/list_resize.test
@@ -303,6 +303,10 @@ execute ${q}([1, 2, 3], -1);
 ----
 Conversion Error: Type INT32 with value -1 can't be cast because the value is out of range for the destination type UINT64
 
+statement error
+SELECT LIST_RESIZE([1, 2, 3], 9999999999999999999);
+----
+Out of Range Error: Cannot resize vector to 3106511852580896764 bytes: maximum allowed vector size is 4GB
 
 endloop
 

--- a/test/sql/function/list/list_resize.test
+++ b/test/sql/function/list/list_resize.test
@@ -297,6 +297,19 @@ execute ${q}([1, 2, 3], 1.4);
 statement ok
 execute ${q}([2], 2::TINYINT);
 
+
+statement error
+execute ${q}([1, 2, 3], -1);
+----
+Conversion Error: Type INT32 with value -1 can't be cast because the value is out of range for the destination type UINT64
+
+
+statement error
+SELECT LIST_RESIZE([1, 2, 3], 9999999999999999999);
+----
+Out of Memory Error: Allocation failure
+
+
 endloop
 
 query I

--- a/test/sql/function/list/list_resize.test
+++ b/test/sql/function/list/list_resize.test
@@ -304,12 +304,6 @@ execute ${q}([1, 2, 3], -1);
 Conversion Error: Type INT32 with value -1 can't be cast because the value is out of range for the destination type UINT64
 
 
-statement error
-SELECT LIST_RESIZE([1, 2, 3], 9999999999999999999);
-----
-Out of Memory Error: Allocation failure
-
-
 endloop
 
 query I

--- a/test/sql/function/list/list_select.test
+++ b/test/sql/function/list/list_select.test
@@ -325,3 +325,8 @@ FROM all_types AS t43(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c1
 	all_types AS t86(c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63, c64, c65, c66, c67, c68, c69, c70, c71, c72, c73, c74, c75, c76, c77, c78, c79, c80, c81, c82, c83, c84, c85);
 ----
 Conversion Error
+
+query I
+SELECT LIST_SELECT(ARRAY_VALUE('1', NULL), [1, 2, 3]);
+----
+[1, NULL, NULL]

--- a/test/sql/function/list/list_where.test
+++ b/test/sql/function/list/list_where.test
@@ -227,3 +227,14 @@ query I
 SELECT list_where([1,2,3]::INT[3], [true, false, true]::BOOLEAN[3]);
 ----
 [1, 3]
+
+query I
+SELECT LIST_WHERE(ARRAY_VALUE('1', NULL), [TRUE, TRUE, TRUE]);
+----
+[1, NULL, NULL]
+
+
+query I
+SELECT LIST_WHERE(ARRAY_VALUE('1', NULL), [TRUE, TRUE, FALSE]);
+----
+[1, NULL]


### PR DESCRIPTION
Closes #12004
Closes #12008
Closes #12017

Also adds a check for string sizes out of range in StringHeap::EmptyString() and formats thrown `std::bad_alloc` exceptions. `repeat()` also now detects when the to-be-created strings size would overflow.

Also fixes No. 3, 8, 9, 10 from https://github.com/duckdb/duckdb/issues/12009