### PR TITLE
S3FileHandle Destructor should call `Close()` conditionally

### DIFF
--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -321,7 +321,15 @@ S3AuthParams S3SecretHelper::GetParams(const KeyValueSecret &secret) {
 }
 
 S3FileHandle::~S3FileHandle() {
-	Close();
+	if (Exception::UncaughtException()) {
+		// We are in an exception, don't do anything
+		return;
+	}
+
+	try {
+		Close();
+	} catch (...) { // NOLINT
+	}
 }
 
 S3ConfigParams S3ConfigParams::ReadFrom(optional_ptr<FileOpener> opener) {


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/12038

Depending on the state, `S3FileHandle::Close()`
might require to flush buffers and also
finalize multi-part upload.

So, `S3FileHandle::Close()` could easily throw
exceptions, which has bad consequences in a
destructor, such as termination of process,
see https://github.com/duckdb/duckdb/issues/11796.

Apart from that, the destructor might have been
 triggered via an unrelated failure. For example, see the below
example, where query fails, but DuckDB pushes
(garbage) results to s3.

```sql
COPY (
	SELECT sqrt(generate_series.generate_series)
	FROM generate_series(1000000,-12, -1)
     ) TO 's3://mybucket/tmp/ft5/ft202.parquet';
Out of Range Error: cannot take square root of a negative number

SELECT count(*) FROM
read_parquet('s3://mybucket/tmp/ft5/ft202.parquet');
Invalid Input Error: No magic bytes found at end of file 's3://mybucket/tmp/ft5/ft202.parquet'
```

With this commit, DuckDB does not push the file
to s3 in the above scenario.