### PR TITLE
Allow quotes to be escaped in JSON path

### DIFF
--- a/extension/json/json_common.cpp
+++ b/extension/json/json_common.cpp
@@ -39,7 +39,7 @@ public:
 	}
 
 	static inline JSONKeyReadResult WildCard() {
-		return {DConstants::INVALID_INDEX, string()};
+		return {1, "*"};
 	}
 
 	inline bool IsValid() {
@@ -47,7 +47,7 @@ public:
 	}
 
 	inline bool IsWildCard() {
-		return chars_read == DConstants::INVALID_INDEX;
+		return key == "*";
 	}
 
 public:
@@ -73,19 +73,6 @@ static inline JSONKeyReadResult ReadString(const char *ptr, const char *const en
 				ptr++;
 				continue;
 			}
-			//
-			//			if (backslash) {
-			//				if (*ptr != '"') {
-			//					key[key_len++] = '\\';
-			//				}
-			//				backslash = false;
-			//			} else if (*ptr == '"') {
-			//				break;
-			//			} else if (*ptr == '\\') {
-			//				backslash = true;
-			//				ptr++;
-			//				continue;
-			//			}
 			key[key_len++] = *ptr++;
 		}
 		if (ptr == end || backslash) {
@@ -134,7 +121,6 @@ static inline idx_t ReadInteger(const char *ptr, const char *const end, idx_t &i
 static inline JSONKeyReadResult ReadKey(const char *ptr, const char *const end) {
 	D_ASSERT(ptr != end);
 	if (*ptr == '*') { // Wildcard
-		ptr++;
 		return JSONKeyReadResult::WildCard();
 	}
 	bool escaped = false;
@@ -207,8 +193,7 @@ JSONPathType JSONCommon::ValidatePath(const char *ptr, const idx_t &len, const b
 			auto key = ReadKey(ptr, end);
 			if (!key.IsValid()) {
 				ThrowPathError(ptr, end, binder);
-			}
-			if (key.IsWildCard()) {
+			} else if (key.IsWildCard()) {
 				path_type = JSONPathType::WILDCARD;
 			}
 			ptr += key.chars_read;

--- a/extension/json/json_common.cpp
+++ b/extension/json/json_common.cpp
@@ -63,18 +63,19 @@ static inline JSONKeyReadResult ReadString(const char *ptr, const char *const en
 
 		bool backslash = false;
 		while (ptr != end) {
-			if (*ptr == '"') {
-				if (!backslash) {
-					break;
+			if (backslash) {
+				if (*ptr != '"' && *ptr != '\\') {
+					key[key_len++] = '\\';
 				}
 				backslash = false;
-			} else if (*ptr == '\\') {
-				if (!backslash) {
+			} else {
+				if (*ptr == '"') {
+					break;
+				} else if (*ptr == '\\') {
 					backslash = true;
 					ptr++;
 					continue;
 				}
-				backslash = false;
 			}
 			key[key_len++] = *ptr++;
 		}

--- a/extension/json/json_common.cpp
+++ b/extension/json/json_common.cpp
@@ -1,4 +1,5 @@
 #include "json_common.hpp"
+
 #include "duckdb/common/exception/binder_exception.hpp"
 
 namespace duckdb {
@@ -31,16 +32,67 @@ string ThrowPathError(const char *ptr, const char *end, const bool binder) {
 	}
 }
 
-static inline idx_t ReadString(const char *ptr, const char *const end, const bool escaped) {
+struct JSONKeyReadResult {
+public:
+	static inline JSONKeyReadResult Empty() {
+		return {idx_t(0), string()};
+	}
+
+	static inline JSONKeyReadResult WildCard() {
+		return {DConstants::INVALID_INDEX, string()};
+	}
+
+	inline bool IsValid() {
+		return chars_read != 0;
+	}
+
+	inline bool IsWildCard() {
+		return chars_read == DConstants::INVALID_INDEX;
+	}
+
+public:
+	idx_t chars_read;
+	string key;
+};
+
+static inline JSONKeyReadResult ReadString(const char *ptr, const char *const end, const bool escaped) {
 	const char *const before = ptr;
 	if (escaped) {
+		auto key = make_unsafe_uniq_array<char>(end - ptr);
+		idx_t key_len = 0;
+
+		bool backslash = false;
 		while (ptr != end) {
 			if (*ptr == '"') {
-				break;
+				if (!backslash) {
+					break;
+				}
+				backslash = false;
+			} else if (*ptr == '\\') {
+				backslash = true;
+				ptr++;
+				continue;
 			}
-			ptr++;
+			//
+			//			if (backslash) {
+			//				if (*ptr != '"') {
+			//					key[key_len++] = '\\';
+			//				}
+			//				backslash = false;
+			//			} else if (*ptr == '"') {
+			//				break;
+			//			} else if (*ptr == '\\') {
+			//				backslash = true;
+			//				ptr++;
+			//				continue;
+			//			}
+			key[key_len++] = *ptr++;
 		}
-		return ptr == end ? 0 : ptr - before;
+		if (ptr == end || backslash) {
+			return JSONKeyReadResult::Empty();
+		} else {
+			return {idx_t(ptr - before), string(key.get(), key_len)};
+		}
 	} else {
 		while (ptr != end) {
 			if (*ptr == '.' || *ptr == '[') {
@@ -48,7 +100,7 @@ static inline idx_t ReadString(const char *ptr, const char *const end, const boo
 			}
 			ptr++;
 		}
-		return ptr - before;
+		return {idx_t(ptr - before), string(before, ptr - before)};
 	}
 }
 
@@ -79,28 +131,25 @@ static inline idx_t ReadInteger(const char *ptr, const char *const end, idx_t &i
 	return idx >= (idx_t)IDX_T_MAX ? 0 : ptr - before;
 }
 
-static inline bool ReadKey(const char *&ptr, const char *const end, const char *&key_ptr, idx_t &key_len) {
+static inline JSONKeyReadResult ReadKey(const char *ptr, const char *const end) {
 	D_ASSERT(ptr != end);
 	if (*ptr == '*') { // Wildcard
 		ptr++;
-		key_len = DConstants::INVALID_INDEX;
-		return true;
+		return JSONKeyReadResult::WildCard();
 	}
 	bool escaped = false;
 	if (*ptr == '"') {
 		ptr++; // Skip past opening '"'
 		escaped = true;
 	}
-	key_ptr = ptr;
-	key_len = ReadString(ptr, end, escaped);
-	if (key_len == 0) {
-		return false;
+	auto result = ReadString(ptr, end, escaped);
+	if (!result.IsValid()) {
+		return result;
 	}
-	ptr += key_len;
 	if (escaped) {
-		ptr++; // Skip past closing '"'
+		result.chars_read += 2; // Account for surrounding quotes
 	}
-	return true;
+	return result;
 }
 
 static inline bool ReadArrayIndex(const char *&ptr, const char *const end, idx_t &array_index, bool &from_back) {
@@ -155,14 +204,14 @@ JSONPathType JSONCommon::ValidatePath(const char *ptr, const idx_t &len, const b
 		}
 		switch (c) {
 		case '.': { // Object field
-			const char *key_ptr;
-			idx_t key_len;
-			if (!ReadKey(ptr, end, key_ptr, key_len)) {
+			auto key = ReadKey(ptr, end);
+			if (!key.IsValid()) {
 				ThrowPathError(ptr, end, binder);
 			}
-			if (key_len == DConstants::INVALID_INDEX) {
+			if (key.IsWildCard()) {
 				path_type = JSONPathType::WILDCARD;
 			}
+			ptr += key.chars_read;
 			break;
 		}
 		case '[': { // Array index
@@ -195,16 +244,10 @@ yyjson_val *JSONCommon::GetPath(yyjson_val *val, const char *ptr, const idx_t &l
 			if (!unsafe_yyjson_is_obj(val)) {
 				return nullptr;
 			}
-			const char *key_ptr;
-			idx_t key_len;
-#ifdef DEBUG
-			bool success =
-#endif
-			    ReadKey(ptr, end, key_ptr, key_len);
-#ifdef DEBUG
-			D_ASSERT(success);
-#endif
-			val = yyjson_obj_getn(val, key_ptr, key_len);
+			auto key_result = ReadKey(ptr, end);
+			D_ASSERT(key_result.IsValid());
+			ptr += key_result.chars_read;
+			val = yyjson_obj_getn(val, key_result.key.c_str(), key_result.key.size());
 			break;
 		}
 		case '[': { // Array index
@@ -243,16 +286,10 @@ void GetWildcardPathInternal(yyjson_val *val, const char *ptr, const char *const
 			if (!unsafe_yyjson_is_obj(val)) {
 				return;
 			}
-			const char *key_ptr;
-			idx_t key_len;
-#ifdef DEBUG
-			bool success =
-#endif
-			    ReadKey(ptr, end, key_ptr, key_len);
-#ifdef DEBUG
-			D_ASSERT(success);
-#endif
-			if (key_len == DConstants::INVALID_INDEX) { // Wildcard
+			auto key_result = ReadKey(ptr, end);
+			D_ASSERT(key_result.IsValid());
+			ptr += key_result.chars_read;
+			if (key_result.IsWildCard()) { // Wildcard
 				size_t idx, max;
 				yyjson_val *key, *obj_val;
 				yyjson_obj_foreach(val, idx, max, key, obj_val) {
@@ -260,7 +297,7 @@ void GetWildcardPathInternal(yyjson_val *val, const char *ptr, const char *const
 				}
 				return;
 			}
-			val = yyjson_obj_getn(val, key_ptr, key_len);
+			val = yyjson_obj_getn(val, key_result.key.c_str(), key_result.key.size());
 			break;
 		}
 		case '[': { // Array index

--- a/extension/json/json_common.cpp
+++ b/extension/json/json_common.cpp
@@ -69,9 +69,12 @@ static inline JSONKeyReadResult ReadString(const char *ptr, const char *const en
 				}
 				backslash = false;
 			} else if (*ptr == '\\') {
-				backslash = true;
-				ptr++;
-				continue;
+				if (!backslash) {
+					backslash = true;
+					ptr++;
+					continue;
+				}
+				backslash = false;
 			}
 			key[key_len++] = *ptr++;
 		}

--- a/test/sql/json/scalar/test_json_extract.test
+++ b/test/sql/json/scalar/test_json_extract.test
@@ -330,3 +330,25 @@ query I
 select '{"\"du\\ck\"": 42}'->'$."\"du\\ck\""';
 ----
 42
+
+query I
+select '{"\"du\\ck\"": 42}'->'$."\"du\ck\""';
+----
+42
+
+query I
+select '{"du\\ck": 42}'->'$.du\ck';
+----
+42
+
+# characters other than \\ or \" get ignored (for now)
+query I
+select '{"\"du\nck\"": 42}'->'$."\"du\nck\""';
+----
+NULL
+
+# need to use chr(10) for \n
+query I
+select '{"\"du\nck\"": 42}'->('$."\"du' || chr(10) || 'ck\""');
+----
+42

--- a/test/sql/json/scalar/test_json_extract.test
+++ b/test/sql/json/scalar/test_json_extract.test
@@ -314,3 +314,9 @@ query T
 execute q1('a')
 ----
 1
+
+# test issue 11997
+query I
+select json_extract_string(json('{"j[so]n_\"key": 67}'), '$."j[so]n_\"key"');
+----
+67

--- a/test/sql/json/scalar/test_json_extract.test
+++ b/test/sql/json/scalar/test_json_extract.test
@@ -320,3 +320,13 @@ query I
 select json_extract_string(json('{"j[so]n_\"key": 67}'), '$."j[so]n_\"key"');
 ----
 67
+
+query I
+select '{"\"duck\"": 42}'->'$."\"duck\""';
+----
+42
+
+query I
+select '{"\"du\\ck\"": 42}'->'$."\"du\\ck\""';
+----
+42


### PR DESCRIPTION
We conveniently support escaping JSON object keys that contain the special `[` and `.` characters by surrounding them with quotes.
```json
{
  "duck": [42, 43]
}
```
The path `$.duck` points to `[42, 43]`, and the path `$.duck[0]` points to `42`.

If the key was `"du[ck"` instead, we wouldn't be able to extract because we would interpret `[` as the syntax for extracting from an array. We already implemented escaping these special characters by surrounding them with quotes: `$."du[ck"`.

If the key was `"du\"ck"` instead, we would also be able to extract, by just specifying the path `$.du"ck`. However, if it is necessary to escape special characters like `[`, but keys also contain quotes, you were out of luck.

So, we would not be able to extract if the key was, for example, `"du[\"ck"`. Surrounding the path with quotes does not work because there is a quote in the middle of the key.

This PR solves this problem by allowing quotes within quoted paths to be escaped with a backslash:
```sql
select '{"d[u]_\"ck":42}'->'$."d[u]_\"ck"' v;
┌──────┐
│  v   │
│ json │
├──────┤
│ 42   │
└──────┘
```
Fixes #11997