### PR TITLE
Add "Tags" support to catalog entries

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -263,6 +263,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::RenameColumn(ClientContext &context, Re
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->temporary = temporary;
 	create_info->comment = comment;
+	create_info->tags = tags;
 	for (auto &col : columns.Logical()) {
 		auto copy = col.Copy();
 		if (rename_idx == col.Logical()) {
@@ -336,6 +337,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddColumn(ClientContext &context, AddCo
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->temporary = temporary;
 	create_info->comment = comment;
+	create_info->tags = tags;
 
 	for (auto &col : columns.Logical()) {
 		create_info->columns.AddColumn(col.Copy());
@@ -458,6 +460,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::RemoveColumn(ClientContext &context, Re
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->temporary = temporary;
 	create_info->comment = comment;
+	create_info->tags = tags;
 
 	logical_index_set_t removed_columns;
 	if (column_dependency_manager.HasDependents(removed_index)) {
@@ -499,6 +502,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::RemoveColumn(ClientContext &context, Re
 unique_ptr<CatalogEntry> DuckTableEntry::SetDefault(ClientContext &context, SetDefaultInfo &info) {
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->comment = comment;
+	create_info->tags = tags;
 	auto default_idx = GetColumnIndex(info.column_name);
 	if (default_idx.index == COLUMN_IDENTIFIER_ROW_ID) {
 		throw CatalogException("Cannot SET DEFAULT for rowid column");
@@ -531,6 +535,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::SetNotNull(ClientContext &context, SetN
 
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->comment = comment;
+	create_info->tags = tags;
 	create_info->columns = columns.Copy();
 
 	auto not_null_idx = GetColumnIndex(info.column_name);
@@ -568,6 +573,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::SetNotNull(ClientContext &context, SetN
 unique_ptr<CatalogEntry> DuckTableEntry::DropNotNull(ClientContext &context, DropNotNullInfo &info) {
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->comment = comment;
+	create_info->tags = tags;
 	create_info->columns = columns.Copy();
 
 	auto not_null_idx = GetColumnIndex(info.column_name);
@@ -594,6 +600,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->temporary = temporary;
 	create_info->comment = comment;
+	create_info->tags = tags;
 
 	auto binder = Binder::CreateBinder(context);
 	auto bound_constraints = binder->BindConstraints(constraints, name, columns);
@@ -681,6 +688,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context
 unique_ptr<CatalogEntry> DuckTableEntry::SetColumnComment(ClientContext &context, SetColumnCommentInfo &info) {
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->comment = comment;
+	create_info->tags = tags;
 	auto default_idx = GetColumnIndex(info.column_name);
 	if (default_idx.index == COLUMN_IDENTIFIER_ROW_ID) {
 		throw CatalogException("Cannot SET DEFAULT for rowid column");
@@ -710,6 +718,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddForeignKeyConstraint(ClientContext &
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->temporary = temporary;
 	create_info->comment = comment;
+	create_info->tags = tags;
 
 	create_info->columns = columns.Copy();
 	for (idx_t i = 0; i < constraints.size(); i++) {
@@ -735,6 +744,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::DropForeignKeyConstraint(ClientContext 
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->temporary = temporary;
 	create_info->comment = comment;
+	create_info->tags = tags;
 
 	create_info->columns = columns.Copy();
 	for (idx_t i = 0; i < constraints.size(); i++) {
@@ -757,6 +767,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::DropForeignKeyConstraint(ClientContext 
 unique_ptr<CatalogEntry> DuckTableEntry::Copy(ClientContext &context) const {
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->comment = comment;
+	create_info->tags = tags;
 	create_info->columns = columns.Copy();
 
 	for (idx_t i = 0; i < constraints.size(); i++) {

--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -30,6 +30,7 @@ unique_ptr<CreateInfo> IndexCatalogEntry::GetInfo() const {
 	}
 
 	result->comment = comment;
+	result->tags = tags;
 
 	return std::move(result);
 }

--- a/src/catalog/catalog_entry/macro_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/macro_catalog_entry.cpp
@@ -12,6 +12,7 @@ MacroCatalogEntry::MacroCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schem
 	this->temporary = info.temporary;
 	this->internal = info.internal;
 	this->comment = info.comment;
+	this->tags = info.tags;
 }
 
 ScalarMacroCatalogEntry::ScalarMacroCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateMacroInfo &info)
@@ -43,6 +44,7 @@ unique_ptr<CreateInfo> MacroCatalogEntry::GetInfo() const {
 	info->name = name;
 	info->function = function->Copy();
 	info->comment = comment;
+	info->tags = tags;
 	return std::move(info);
 }
 

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -14,6 +14,7 @@ SchemaCatalogEntry::SchemaCatalogEntry(Catalog &catalog, CreateSchemaInfo &info)
     : InCatalogEntry(CatalogType::SCHEMA_ENTRY, catalog, info.schema) {
 	this->internal = info.internal;
 	this->comment = info.comment;
+	this->tags = info.tags;
 }
 
 CatalogTransaction SchemaCatalogEntry::GetCatalogTransaction(ClientContext &context) {
@@ -37,6 +38,7 @@ unique_ptr<CreateInfo> SchemaCatalogEntry::GetInfo() const {
 	auto result = make_uniq<CreateSchemaInfo>();
 	result->schema = name;
 	result->comment = comment;
+	result->tags = tags;
 	return std::move(result);
 }
 

--- a/src/catalog/catalog_entry/sequence_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/sequence_catalog_entry.cpp
@@ -22,6 +22,7 @@ SequenceCatalogEntry::SequenceCatalogEntry(Catalog &catalog, SchemaCatalogEntry 
     : StandardEntry(CatalogType::SEQUENCE_ENTRY, schema, catalog, info.name), data(info) {
 	this->temporary = info.temporary;
 	this->comment = info.comment;
+	this->tags = info.tags;
 }
 
 unique_ptr<CatalogEntry> SequenceCatalogEntry::Copy(ClientContext &context) const {
@@ -99,6 +100,7 @@ unique_ptr<CreateInfo> SequenceCatalogEntry::GetInfo() const {
 	result->start_value = seq_data.counter;
 	result->cycle = seq_data.cycle;
 	result->comment = comment;
+	result->tags = tags;
 	return std::move(result);
 }
 

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -24,6 +24,7 @@ TableCatalogEntry::TableCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schem
       constraints(std::move(info.constraints)) {
 	this->temporary = info.temporary;
 	this->comment = info.comment;
+	this->tags = info.tags;
 }
 
 bool TableCatalogEntry::HasGeneratedColumns() const {
@@ -67,6 +68,7 @@ unique_ptr<CreateInfo> TableCatalogEntry::GetInfo() const {
 	std::for_each(constraints.begin(), constraints.end(),
 	              [&result](const unique_ptr<Constraint> &c) { result->constraints.emplace_back(c->Copy()); });
 	result->comment = comment;
+	result->tags = tags;
 	return std::move(result);
 }
 

--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -14,6 +14,7 @@ TypeCatalogEntry::TypeCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema,
 	this->temporary = info.temporary;
 	this->internal = info.internal;
 	this->comment = info.comment;
+	this->tags = info.tags;
 }
 
 unique_ptr<CatalogEntry> TypeCatalogEntry::Copy(ClientContext &context) const {
@@ -30,6 +31,7 @@ unique_ptr<CreateInfo> TypeCatalogEntry::GetInfo() const {
 	result->name = name;
 	result->type = user_type;
 	result->comment = comment;
+	result->tags = tags;
 	return std::move(result);
 }
 

--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -21,6 +21,7 @@ void ViewCatalogEntry::Initialize(CreateViewInfo &info) {
 	this->sql = info.sql;
 	this->internal = info.internal;
 	this->comment = info.comment;
+	this->tags = info.tags;
 	this->column_comments = info.column_comments;
 }
 
@@ -40,6 +41,7 @@ unique_ptr<CreateInfo> ViewCatalogEntry::GetInfo() const {
 	result->types = types;
 	result->temporary = temporary;
 	result->comment = comment;
+	result->tags = tags;
 	result->column_comments = column_comments;
 	return std::move(result);
 }

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -715,6 +715,18 @@ Value Value::MAP(const LogicalType &key_type, const LogicalType &value_type, vec
 	return result;
 }
 
+Value Value::MAP(const unordered_map<string, string> &kv_pairs) {
+	Value result;
+	result.type_ = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
+	result.is_null = false;
+	vector<Value> pairs;
+	for (auto &kv : kv_pairs) {
+		pairs.push_back(Value::STRUCT({{"key", Value(kv.first)}, {"value", Value(kv.second)}}));
+	}
+	result.value_info_ = make_shared_ptr<NestedValueInfo>(std::move(pairs));
+	return result;
+}
+
 Value Value::UNION(child_list_t<LogicalType> members, uint8_t tag, Value value) {
 	D_ASSERT(!members.empty());
 	D_ASSERT(members.size() <= UnionType::MAX_UNION_MEMBERS);

--- a/src/function/table/system/duckdb_databases.cpp
+++ b/src/function/table/system/duckdb_databases.cpp
@@ -26,6 +26,9 @@ static unique_ptr<FunctionData> DuckDBDatabasesBind(ClientContext &context, Tabl
 	names.emplace_back("comment");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	names.emplace_back("internal");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
@@ -80,6 +83,8 @@ void DuckDBDatabasesFunction(ClientContext &context, TableFunctionInput &data_p,
 		output.SetValue(col++, count, db_path);
 		// comment, VARCHAR
 		output.SetValue(col++, count, Value(attached.comment));
+		// tags, MAP
+		output.SetValue(col++, count, Value::MAP(attached.tags));
 		// internal, BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(is_internal));
 		// type, VARCHAR

--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -49,6 +49,9 @@ static unique_ptr<FunctionData> DuckDBFunctionsBind(ClientContext &context, Tabl
 	names.emplace_back("comment");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	names.emplace_back("return_type");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
@@ -469,6 +472,9 @@ bool ExtractFunctionData(FunctionEntry &entry, idx_t function_idx, DataChunk &ou
 
 	// comment, LogicalType::VARCHAR
 	output.SetValue(col++, output_offset, entry.comment);
+
+	// tags, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)
+	output.SetValue(col++, output_offset, Value::MAP(entry.tags));
 
 	// return_type, LogicalType::VARCHAR
 	output.SetValue(col++, output_offset, OP::GetReturnType(function, function_idx));

--- a/src/function/table/system/duckdb_indexes.cpp
+++ b/src/function/table/system/duckdb_indexes.cpp
@@ -45,6 +45,9 @@ static unique_ptr<FunctionData> DuckDBIndexesBind(ClientContext &context, TableF
 	names.emplace_back("comment");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	names.emplace_back("is_unique");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
@@ -109,6 +112,8 @@ void DuckDBIndexesFunction(ClientContext &context, TableFunctionInput &data_p, D
 		output.SetValue(col++, count, Value::BIGINT(NumericCast<int64_t>(table_entry.oid)));
 		// comment, VARCHAR
 		output.SetValue(col++, count, Value(index.comment));
+		// tags, MAP
+		output.SetValue(col++, count, Value::MAP(index.tags));
 		// is_unique, BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(index.IsUnique()));
 		// is_primary, BOOLEAN

--- a/src/function/table/system/duckdb_schemas.cpp
+++ b/src/function/table/system/duckdb_schemas.cpp
@@ -33,6 +33,9 @@ static unique_ptr<FunctionData> DuckDBSchemasBind(ClientContext &context, TableF
 	names.emplace_back("comment");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	names.emplace_back("internal");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
@@ -75,6 +78,8 @@ void DuckDBSchemasFunction(ClientContext &context, TableFunctionInput &data_p, D
 		output.SetValue(col++, count, Value(entry.name));
 		// "comment", PhysicalType::VARCHAR
 		output.SetValue(col++, count, Value(entry.comment));
+		// "tags", MAP(VARCHAR, VARCHAR)
+		output.SetValue(col++, count, Value::MAP(entry.tags));
 		// "internal", PhysicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(entry.internal));
 		// "sql", PhysicalType::VARCHAR

--- a/src/function/table/system/duckdb_sequences.cpp
+++ b/src/function/table/system/duckdb_sequences.cpp
@@ -41,6 +41,9 @@ static unique_ptr<FunctionData> DuckDBSequencesBind(ClientContext &context, Tabl
 	names.emplace_back("comment");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	names.emplace_back("temporary");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
@@ -109,6 +112,8 @@ void DuckDBSequencesFunction(ClientContext &context, TableFunctionInput &data_p,
 		output.SetValue(col++, count, Value::BIGINT(NumericCast<int64_t>(seq.oid)));
 		// comment, VARCHAR
 		output.SetValue(col++, count, Value(seq.comment));
+		// tags, MAP(VARCHAR, VARCHAR)
+		output.SetValue(col++, count, Value::MAP(seq.tags));
 		// temporary, BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(seq.temporary));
 		// start_value, BIGINT

--- a/src/function/table/system/duckdb_tables.cpp
+++ b/src/function/table/system/duckdb_tables.cpp
@@ -44,6 +44,9 @@ static unique_ptr<FunctionData> DuckDBTablesBind(ClientContext &context, TableFu
 	names.emplace_back("comment");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	names.emplace_back("internal");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
@@ -138,6 +141,8 @@ void DuckDBTablesFunction(ClientContext &context, TableFunctionInput &data_p, Da
 		output.SetValue(col++, count, Value::BIGINT(NumericCast<int64_t>(table.oid)));
 		// comment, LogicalType::VARCHAR
 		output.SetValue(col++, count, Value(table.comment));
+		// tags, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)
+		output.SetValue(col++, count, Value::MAP(table.tags));
 		// internal, LogicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(table.internal));
 		// temporary, LogicalType::BOOLEAN

--- a/src/function/table/system/duckdb_types.cpp
+++ b/src/function/table/system/duckdb_types.cpp
@@ -52,6 +52,9 @@ static unique_ptr<FunctionData> DuckDBTypesBind(ClientContext &context, TableFun
 	names.emplace_back("comment");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	names.emplace_back("internal");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
@@ -167,6 +170,8 @@ void DuckDBTypesFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 		output.SetValue(col++, count, category.empty() ? Value() : Value(category));
 		// comment, VARCHAR
 		output.SetValue(col++, count, Value(type_entry.comment));
+		// tags, MAP
+		output.SetValue(col++, count, Value::MAP(type_entry.tags));
 		// internal, BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(type_entry.internal));
 		// labels, VARCHAR[]

--- a/src/function/table/system/duckdb_views.cpp
+++ b/src/function/table/system/duckdb_views.cpp
@@ -40,6 +40,9 @@ static unique_ptr<FunctionData> DuckDBViewsBind(ClientContext &context, TableFun
 	names.emplace_back("comment");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("tags");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
 	names.emplace_back("internal");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
@@ -100,6 +103,8 @@ void DuckDBViewsFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 		output.SetValue(col++, count, Value::BIGINT(NumericCast<int64_t>(view.oid)));
 		// comment, LogicalType::VARCHARs
 		output.SetValue(col++, count, Value(view.comment));
+		// tags, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)
+		output.SetValue(col++, count, Value::MAP(view.tags));
 		// internal, LogicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(view.internal));
 		// temporary, LogicalType::BOOLEAN

--- a/src/include/duckdb/catalog/catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry.hpp
@@ -54,6 +54,8 @@ public:
 	atomic<transaction_t> timestamp;
 	//! (optional) comment on this entry
 	Value comment;
+	//! (optional) extra data associated with this entry
+	unordered_map<string, string> tags;
 
 private:
 	//! Child entry

--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -177,6 +177,9 @@ public:
 	//! Create a map value with the given entries
 	DUCKDB_API static Value MAP(const LogicalType &key_type, const LogicalType &value_type, vector<Value> keys,
 	                            vector<Value> values);
+	//! Create a map value from a set of key-value pairs
+	DUCKDB_API static Value MAP(const unordered_map<string, string> &kv_pairs);
+
 	//! Create a union value from a selected value and a tag from a set of alternatives.
 	DUCKDB_API static Value UNION(child_list_t<LogicalType> members, uint8_t tag, Value value);
 

--- a/src/include/duckdb/parser/column_definition.hpp
+++ b/src/include/duckdb/parser/column_definition.hpp
@@ -104,6 +104,8 @@ private:
 	unique_ptr<ParsedExpression> expression;
 	//! Comment on this column
 	Value comment;
+	//! Tags on this column
+	unordered_map<string, string> tags;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/parsed_data/create_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_info.hpp
@@ -46,6 +46,8 @@ public:
 	string sql;
 	//! User provided comment
 	Value comment;
+	//! Key-value tags with additional metadata
+	unordered_map<string, string> tags;
 
 public:
 	void Serialize(Serializer &serializer) const override;

--- a/src/include/duckdb/storage/serialization/create_info.json
+++ b/src/include/duckdb/storage/serialization/create_info.json
@@ -49,6 +49,12 @@
         "name": "comment",
         "type": "Value",
         "default": "Value()"
+      },
+      {
+        "id": 108,
+        "name": "tags",
+        "type": "unordered_map<string, string>",
+        "default": "unordered_map<string, string>()"
       }
     ]
   },

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -319,6 +319,12 @@
         "name": "comment",
         "type": "Value",
         "default": "Value()"
+      },
+      {
+        "id": 106,
+        "name": "tags",
+        "type": "unordered_map<string, string>",
+        "default": "unordered_map<string, string>()"
       }
     ],
     "constructor": ["name", "type", "expression", "category"],

--- a/src/parser/column_definition.cpp
+++ b/src/parser/column_definition.cpp
@@ -23,6 +23,7 @@ ColumnDefinition ColumnDefinition::Copy() const {
 	copy.compression_type = compression_type;
 	copy.category = category;
 	copy.comment = comment;
+	copy.tags = tags;
 	return copy;
 }
 

--- a/src/parser/parsed_data/create_info.cpp
+++ b/src/parser/parsed_data/create_info.cpp
@@ -20,6 +20,7 @@ void CreateInfo::CopyProperties(CreateInfo &other) const {
 	other.internal = internal;
 	other.sql = sql;
 	other.comment = comment;
+	other.tags = tags;
 }
 
 unique_ptr<AlterInfo> CreateInfo::GetAlterInfo() const {

--- a/src/storage/serialization/serialize_create_info.cpp
+++ b/src/storage/serialization/serialize_create_info.cpp
@@ -25,6 +25,7 @@ void CreateInfo::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<OnCreateConflict>(105, "on_conflict", on_conflict);
 	serializer.WritePropertyWithDefault<string>(106, "sql", sql);
 	serializer.WritePropertyWithDefault<Value>(107, "comment", comment, Value());
+	serializer.WritePropertyWithDefault<unordered_map<string, string>>(108, "tags", tags, unordered_map<string, string>());
 }
 
 unique_ptr<CreateInfo> CreateInfo::Deserialize(Deserializer &deserializer) {
@@ -36,6 +37,7 @@ unique_ptr<CreateInfo> CreateInfo::Deserialize(Deserializer &deserializer) {
 	auto on_conflict = deserializer.ReadProperty<OnCreateConflict>(105, "on_conflict");
 	auto sql = deserializer.ReadPropertyWithDefault<string>(106, "sql");
 	auto comment = deserializer.ReadPropertyWithDefault<Value>(107, "comment", Value());
+	auto tags = deserializer.ReadPropertyWithDefault<unordered_map<string, string>>(108, "tags", unordered_map<string, string>());
 	deserializer.Set<CatalogType>(type);
 	unique_ptr<CreateInfo> result;
 	switch (type) {
@@ -74,6 +76,7 @@ unique_ptr<CreateInfo> CreateInfo::Deserialize(Deserializer &deserializer) {
 	result->on_conflict = on_conflict;
 	result->sql = std::move(sql);
 	result->comment = comment;
+	result->tags = std::move(tags);
 	return result;
 }
 

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -222,6 +222,7 @@ void ColumnDefinition::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<TableColumnType>(103, "category", category);
 	serializer.WriteProperty<duckdb::CompressionType>(104, "compression_type", compression_type);
 	serializer.WritePropertyWithDefault<Value>(105, "comment", comment, Value());
+	serializer.WritePropertyWithDefault<unordered_map<string, string>>(106, "tags", tags, unordered_map<string, string>());
 }
 
 ColumnDefinition ColumnDefinition::Deserialize(Deserializer &deserializer) {
@@ -232,6 +233,7 @@ ColumnDefinition ColumnDefinition::Deserialize(Deserializer &deserializer) {
 	ColumnDefinition result(std::move(name), std::move(type), std::move(expression), category);
 	deserializer.ReadProperty<duckdb::CompressionType>(104, "compression_type", result.compression_type);
 	deserializer.ReadPropertyWithDefault<Value>(105, "comment", result.comment, Value());
+	deserializer.ReadPropertyWithDefault<unordered_map<string, string>>(106, "tags", result.tags, unordered_map<string, string>());
 	return result;
 }
 

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -848,7 +848,7 @@ TEST_CASE("Test ADBC ConnectionGetTableSchema", "[adbc]") {
 	// Test successful schema return
 	REQUIRE(SUCCESS(
 	    AdbcConnectionGetTableSchema(&adbc_connection, nullptr, "main", "duckdb_indexes", &arrow_schema, &adbc_error)));
-	REQUIRE(arrow_schema.n_children == 13);
+	REQUIRE(arrow_schema.n_children == 14);
 	arrow_schema.release(&arrow_schema);
 
 	// Test Catalog Name
@@ -859,13 +859,13 @@ TEST_CASE("Test ADBC ConnectionGetTableSchema", "[adbc]") {
 
 	REQUIRE(SUCCESS(AdbcConnectionGetTableSchema(&adbc_connection, "memory", "main", "duckdb_indexes", &arrow_schema,
 	                                             &adbc_error)));
-	REQUIRE(arrow_schema.n_children == 13);
+	REQUIRE(arrow_schema.n_children == 14);
 	arrow_schema.release(&arrow_schema);
 
 	// Empty schema should be fine
 	REQUIRE(SUCCESS(
 	    AdbcConnectionGetTableSchema(&adbc_connection, nullptr, "", "duckdb_indexes", &arrow_schema, &adbc_error)));
-	REQUIRE(arrow_schema.n_children == 13);
+	REQUIRE(arrow_schema.n_children == 14);
 	arrow_schema.release(&arrow_schema);
 
 	// Test null and empty table name

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -273,17 +273,23 @@ DUCKDB_EXTENSION_API void loadable_extension_demo_init(duckdb::DatabaseInstance 
 	target_type.SetAlias(alias_name);
 	alias_info->type = target_type;
 
-	catalog.CreateType(client_context, *alias_info);
+	auto type_entry = catalog.CreateType(client_context, *alias_info);
+	type_entry->tags["ext:name"] = "loadable_extension_demo";
+	type_entry->tags["ext:author"] = "DuckDB Labs";
 
 	// Function add point
 	ScalarFunction add_point_func("add_point", {target_type, target_type}, target_type, AddPointFunction);
 	CreateScalarFunctionInfo add_point_info(add_point_func);
-	catalog.CreateFunction(client_context, add_point_info);
+	auto add_point_entry = catalog.CreateFunction(client_context, add_point_info);
+	add_point_entry->tags["ext:name"] = "loadable_extension_demo";
+	add_point_entry->tags["ext:author"] = "DuckDB Labs";
 
 	// Function sub point
 	ScalarFunction sub_point_func("sub_point", {target_type, target_type}, target_type, SubPointFunction);
 	CreateScalarFunctionInfo sub_point_info(sub_point_func);
-	catalog.CreateFunction(client_context, sub_point_info);
+	auto sub_point_entry = catalog.CreateFunction(client_context, sub_point_info);
+	sub_point_entry->tags["ext:name"] = "loadable_extension_demo";
+	sub_point_entry->tags["ext:author"] = "DuckDB Labs";
 
 	// Function sub point
 	ScalarFunction loaded_extensions("loaded_extensions", {}, LogicalType::VARCHAR, LoadedExtensionsFunction);

--- a/test/extension/test_tags.test
+++ b/test/extension/test_tags.test
@@ -13,12 +13,12 @@ statement ok
 LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
 
 query II
-SELECT function_name, tags FROM duckdb_functions() WHERE tags['ext:name'] = ['loadable_extension_demo'] ORDER BY function_name;
+SELECT function_name, tags['ext:author'] FROM duckdb_functions() WHERE tags['ext:name'] = ['loadable_extension_demo'] ORDER BY function_name;
 ----
-add_point	{ext:author=DuckDB Labs, ext:name=loadable_extension_demo}
-sub_point	{ext:author=DuckDB Labs, ext:name=loadable_extension_demo}
+add_point	[DuckDB Labs]
+sub_point	[DuckDB Labs]
 
 query II
-SELECT type_name, tags FROM duckdb_types() WHERE tags['ext:name'] = ['loadable_extension_demo'] ORDER BY type_name;
+SELECT type_name, tags['ext:author'] FROM duckdb_types() WHERE tags['ext:name'] = ['loadable_extension_demo'] ORDER BY type_name;
 ----
-POINT	{ext:author=DuckDB Labs, ext:name=loadable_extension_demo}
+POINT	[DuckDB Labs]

--- a/test/extension/test_tags.test
+++ b/test/extension/test_tags.test
@@ -1,0 +1,24 @@
+# name: test/extension/test_tags.test
+# description: Test querying tagged extension items.
+# group: [extension]
+
+require skip_reload
+
+require notmingw
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
+
+query II
+SELECT function_name, tags FROM duckdb_functions() WHERE tags['ext:name'] = ['loadable_extension_demo'] ORDER BY function_name;
+----
+add_point	{ext:author=DuckDB Labs, ext:name=loadable_extension_demo}
+sub_point	{ext:author=DuckDB Labs, ext:name=loadable_extension_demo}
+
+query II
+SELECT type_name, tags FROM duckdb_types() WHERE tags['ext:name'] = ['loadable_extension_demo'] ORDER BY type_name;
+----
+POINT	{ext:author=DuckDB Labs, ext:name=loadable_extension_demo}


### PR DESCRIPTION
This PR adds support for adding "tags", a map of string key-value pairs, to DuckDB's catalog entries.

Note that this PR does __not__ actually add any syntax or functions to enable users to tag objects through SQL. As of now I am primarily motivated to add this so that extensions can tag the internal catalog entries they add at runtime with metadata that can be used to e.g. identify which extension added a catalog item or provide additional information for tooling such as automatic documentation/reference generation. So even though this does add serialization of tags to the storage, nothing will actually be serialized in practice (unless some naughty extension starts tagging non-internal user-created items)

Some thoughts:

1. Right now tags are `unordered_map<string, string>`. You could make the case that they should store `duckdb::Value`'s instead (like `comment`), but given how I expect tags to be commomly used I think it makes more sense to store them as strings. For example, anytime you want to query the information views (`duckdb_functions()`, `duckdb_types()`, ...) the tags are going to have to be returned as a string anyway (since DuckDB doesn't have a variant type), and I imagine that even if you run some sort of internal routine to search or compare for tags you don't actually want to deal with the comparison semantics of different value types when searching for matching tags (is `1` == `'1'`? do we just stringify or invoke duckdbs cast logic?). If you really want to store a list or struct or something else in a tag value you can always cast it to/from string yourself.

2. I don't know what the eventual syntax should be for adding tags through SQL. PostgreSQL doesn't have tags so we can't just follow what they do. I imagine something like:

```sql
-- set one tag
ALTER TABLE t1 ADD TAG 'K' = 'V';

-- overwrite and set all tags
ALTER TABLE t1 SET TAGS { 'K': ' V' }

-- following the COMMENT ON syntax seems kind of unnatural...
TAG ON t1 IS k = 'v'

-- alternatively, BQ uses this syntax, but we don't really have other "options"
ALTER TABLE t1 SET OPTIONS ( tags = [('k', 'v')]);
```