### PR TITLE
Fix a bug in column collection copying of fixed-size (nested) arrays

### DIFF
--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -684,7 +684,7 @@ void ColumnDataCopyArray(ColumnDataMetaData &meta_data, const UnifiedVectorForma
 			auto source_idx = source_data.sel->get_index(offset + i);
 			if (!source_data.validity.RowIsValid(source_idx)) {
 				for (idx_t j = 0; j < array_size; j++) {
-					child_vector_data.validity.SetInvalid(source_idx * array_size + j);
+					child_vector_data.validity.SetInvalid(i * array_size + j);
 				}
 			}
 		}

--- a/test/fuzzer/duckfuzz/nested_array_cast.test
+++ b/test/fuzzer/duckfuzz/nested_array_cast.test
@@ -1,0 +1,24 @@
+# name: test/fuzzer/duckfuzz/nested_array_cast.test
+# description: Repeat row with NULL argument
+# group: [duckfuzz]
+
+#
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table fuu (i INTEGER[3]);
+
+statement ok
+insert into fuu VALUES ([1, 2, 3]);
+
+statement ok
+select TRY_CAST(i AS VARCHAR[3][3]) FROM fuu;
+#
+#
+# original issue https://github.com/duckdb/duckdb-fuzzer/issues/2691
+statement ok
+create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
+
+statement ok
+SELECT TRY_CAST(c47 AS VARCHAR[3][3]) FROM all_types AS t51(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50)


### PR DESCRIPTION
Fixes 
- https://github.com/duckdb/duckdb-fuzzer/issues/2691

(I think), @Maxxen please double check the change in indexing from `source_idx` to `i`. I think it needs to be `i` because the new child does not inherit the selection vector and we otherwise end up with non-NULL entries in the child that should be NULL as found in the fuzzer issue.