### PR TITLE
[Fix] Silent constraint violation error when destroying the appender in the C API

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2578,11 +2578,10 @@ The error message should not be freed. It will be de-allocated when `duckdb_appe
 DUCKDB_API const char *duckdb_appender_error(duckdb_appender appender);
 
 /*!
-Flush the appender to the table, forcing the cache of the appender to be cleared and the data to be appended to the
-base table.
-
-This should generally not be used unless you know what you are doing. Instead, call `duckdb_appender_destroy` when you
-are done with the appender.
+Flush the appender to the table, forcing the cache of the appender to be cleared. If flushing the data triggers a
+constraint violation or any other error, then all data is invalidated, and this function returns DuckDBError.
+It is not possible to append more values. Call duckdb_appender_error to obtain the error message followed by
+duckdb_appender_destroy to destroy the invalidated appender.
 
 * appender: The appender to flush.
 * returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
@@ -2590,9 +2589,10 @@ are done with the appender.
 DUCKDB_API duckdb_state duckdb_appender_flush(duckdb_appender appender);
 
 /*!
-Close the appender, flushing all intermediate state in the appender to the table and closing it for further appends.
-
-This is generally not necessary. Call `duckdb_appender_destroy` instead.
+Closes the appender by flushing all intermediate states and closing it for further appends. If flushing the data
+triggers a constraint violation or any other error, then all data is invalidated, and this function returns DuckDBError.
+Call duckdb_appender_error to obtain the error message followed by duckdb_appender_destroy to destroy the invalidated
+appender.
 
 * appender: The appender to flush and close.
 * returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
@@ -2600,8 +2600,11 @@ This is generally not necessary. Call `duckdb_appender_destroy` instead.
 DUCKDB_API duckdb_state duckdb_appender_close(duckdb_appender appender);
 
 /*!
-Close the appender and destroy it. Flushing all intermediate state in the appender to the table, and de-allocating
-all memory associated with the appender.
+Closes the appender by flushing all intermediate states to the table and destroying it. By destroying it, this function
+de-allocates all memory associated with the appender. If flushing the data triggers a constraint violation,
+then all data is invalidated, and this function returns DuckDBError. Due to the destruction of the appender, it is no
+longer possible to obtain the specific error message with duckdb_appender_error. Therefore, call duckdb_appender_close
+before destroying the appender, if you need insights into the specific error.
 
 * appender: The appender to flush, close and destroy.
 * returns: `DuckDBSuccess` on success or `DuckDBError` on failure.

--- a/src/main/capi/appender-c.cpp
+++ b/src/main/capi/appender-c.cpp
@@ -42,13 +42,13 @@ duckdb_state duckdb_appender_destroy(duckdb_appender *appender) {
 	if (!appender || !*appender) {
 		return DuckDBError;
 	}
-	duckdb_appender_close(*appender);
+	auto state = duckdb_appender_close(*appender);
 	auto wrapper = reinterpret_cast<AppenderWrapper *>(*appender);
 	if (wrapper) {
 		delete wrapper;
 	}
 	*appender = nullptr;
-	return DuckDBSuccess;
+	return state;
 }
 
 template <class FUN>
@@ -67,7 +67,7 @@ duckdb_state duckdb_appender_run_function(duckdb_appender appender, FUN &&functi
 		wrapper->error = error.RawMessage();
 		return DuckDBError;
 	} catch (...) { // LCOV_EXCL_START
-		wrapper->error = "Unknown error";
+		wrapper->error = "Unknown appender error.";
 		return DuckDBError;
 	} // LCOV_EXCL_STOP
 	return DuckDBSuccess;
@@ -199,6 +199,7 @@ duckdb_state duckdb_append_varchar(duckdb_appender appender, const char *val) {
 duckdb_state duckdb_append_varchar_length(duckdb_appender appender, const char *val, idx_t length) {
 	return duckdb_append_internal<string_t>(appender, string_t(val, duckdb::UnsafeNumericCast<uint32_t>(length)));
 }
+
 duckdb_state duckdb_append_blob(duckdb_appender appender, const void *data, idx_t length) {
 	auto value = duckdb::Value::BLOB((duckdb::const_data_ptr_t)data, length);
 	return duckdb_append_internal<duckdb::Value>(appender, value);

--- a/test/api/capi/test_capi_appender.cpp
+++ b/test/api/capi/test_capi_appender.cpp
@@ -4,6 +4,12 @@
 using namespace duckdb;
 using namespace std;
 
+void TestAppenderError(duckdb_appender &appender, const string &expected) {
+	auto error = duckdb_appender_error(appender);
+	REQUIRE(error != nullptr);
+	REQUIRE(duckdb::StringUtil::Contains(error, expected));
+}
+
 void AssertDecimalValueMatches(duckdb::unique_ptr<CAPIResult> &result, duckdb_decimal expected) {
 	duckdb_decimal actual;
 
@@ -167,64 +173,56 @@ TEST_CASE("Test appender statements in C API", "[capi]") {
 	duckdb::unique_ptr<CAPIResult> result;
 	duckdb_state status;
 
-	// open the database in in-memory mode
 	REQUIRE(tester.OpenDatabase(nullptr));
-
 	tester.Query("CREATE TABLE test (i INTEGER, d double, s string)");
 	duckdb_appender appender;
 
-	status = duckdb_appender_create(tester.connection, nullptr, "nonexistant-table", &appender);
-	REQUIRE(status == DuckDBError);
+	// Creating the table with an unknown table fails, but creates an appender object.
+	REQUIRE(duckdb_appender_create(tester.connection, nullptr, "unknown_table", &appender) == DuckDBError);
 	REQUIRE(appender != nullptr);
-	REQUIRE(duckdb_appender_error(appender) != nullptr);
-	REQUIRE(duckdb_appender_destroy(&appender) == DuckDBSuccess);
+	TestAppenderError(appender, "could not be found");
+
+	// Flushing, closing, or destroying the appender also fails due to its invalid table.
+	REQUIRE(duckdb_appender_close(appender) == DuckDBError);
+	TestAppenderError(appender, "could not be found");
+
+	// Any data is still destroyed, so there are no leaks, even if duckdb_appender_destroy returns DuckDBError.
+	REQUIRE(duckdb_appender_destroy(&appender) == DuckDBError);
 	REQUIRE(duckdb_appender_destroy(nullptr) == DuckDBError);
 
-	status = duckdb_appender_create(tester.connection, nullptr, "test", nullptr);
-	REQUIRE(status == DuckDBError);
+	// Appender creation also fails if not providing an appender object.
+	REQUIRE(duckdb_appender_create(tester.connection, nullptr, "test", nullptr) == DuckDBError);
 
-	status = duckdb_appender_create(tester.connection, nullptr, "test", &appender);
-	REQUIRE(status == DuckDBSuccess);
+	// Now, create a valid appender.
+	REQUIRE(duckdb_appender_create(tester.connection, nullptr, "test", &appender) == DuckDBSuccess);
 	REQUIRE(duckdb_appender_error(appender) == nullptr);
 
-	status = duckdb_appender_begin_row(appender);
-	REQUIRE(status == DuckDBSuccess);
+	// Start appending rows.
+	REQUIRE(duckdb_appender_begin_row(appender) == DuckDBSuccess);
+	REQUIRE(duckdb_append_int32(appender, 42) == DuckDBSuccess);
+	REQUIRE(duckdb_append_double(appender, 4.2) == DuckDBSuccess);
+	REQUIRE(duckdb_append_varchar(appender, "Hello, World") == DuckDBSuccess);
 
-	status = duckdb_append_int32(appender, 42);
-	REQUIRE(status == DuckDBSuccess);
+	// Exceed the column count.
+	REQUIRE(duckdb_append_int32(appender, 42) == DuckDBError);
+	TestAppenderError(appender, "Too many appends for chunk");
 
-	status = duckdb_append_double(appender, 4.2);
-	REQUIRE(status == DuckDBSuccess);
+	// Finish and flush the row.
+	REQUIRE(duckdb_appender_end_row(appender) == DuckDBSuccess);
+	REQUIRE(duckdb_appender_flush(appender) == DuckDBSuccess);
 
-	status = duckdb_append_varchar(appender, "Hello, World");
-	REQUIRE(status == DuckDBSuccess);
+	// Next row.
+	REQUIRE(duckdb_appender_begin_row(appender) == DuckDBSuccess);
+	REQUIRE(duckdb_append_int32(appender, 42) == DuckDBSuccess);
+	REQUIRE(duckdb_append_double(appender, 4.2) == DuckDBSuccess);
 
-	// out of cols here
-	status = duckdb_append_int32(appender, 42);
-	REQUIRE(status == DuckDBError);
-
-	status = duckdb_appender_end_row(appender);
-	REQUIRE(status == DuckDBSuccess);
-
-	status = duckdb_appender_flush(appender);
-	REQUIRE(status == DuckDBSuccess);
-
-	status = duckdb_appender_begin_row(appender);
-	REQUIRE(status == DuckDBSuccess);
-
-	status = duckdb_append_int32(appender, 42);
-	REQUIRE(status == DuckDBSuccess);
-
-	status = duckdb_append_double(appender, 4.2);
-	REQUIRE(status == DuckDBSuccess);
-
-	// not enough cols here
-	status = duckdb_appender_end_row(appender);
-	REQUIRE(status == DuckDBError);
+	// Missing column.
+	REQUIRE(duckdb_appender_end_row(appender) == DuckDBError);
 	REQUIRE(duckdb_appender_error(appender) != nullptr);
+	TestAppenderError(appender, "Call to EndRow before all rows have been appended to");
 
-	status = duckdb_append_varchar(appender, "Hello, World");
-	REQUIRE(status == DuckDBSuccess);
+	// Append the missing column.
+	REQUIRE(duckdb_append_varchar(appender, "Hello, World") == DuckDBSuccess);
 
 	// out of cols here
 	status = duckdb_append_int32(appender, 42);

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -458,3 +458,74 @@ TEST_CASE("Test DataChunk populate ArrayVector in C API", "[capi]") {
 	duckdb_destroy_logical_type(&array_type);
 	duckdb_destroy_logical_type(&elem_type);
 }
+
+TEST_CASE("Test PK violation in the C API appender", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE(duckdb_vector_size() == STANDARD_VECTOR_SIZE);
+
+	// Create column types.
+	const idx_t COLUMN_COUNT = 1;
+	duckdb_logical_type types[COLUMN_COUNT];
+	types[0] = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+
+	// Create data chunk.
+	auto data_chunk = duckdb_create_data_chunk(types, COLUMN_COUNT);
+	auto bigint_vector = duckdb_data_chunk_get_vector(data_chunk, 0);
+	auto int64_ptr = reinterpret_cast<int64_t *>(duckdb_vector_get_data(bigint_vector));
+	int64_ptr[0] = 42;
+	int64_ptr[1] = 42;
+	duckdb_data_chunk_set_size(data_chunk, 2);
+
+	// Use the appender to append the data chunk.
+	tester.Query("CREATE TABLE test(i BIGINT PRIMARY KEY)");
+	duckdb_appender appender;
+	REQUIRE(duckdb_appender_create(tester.connection, nullptr, "test", &appender) == DuckDBSuccess);
+
+	// We only flush when destroying the appender. Thus, we expect this to succeed, as we only
+	// detect constraint violations when flushing the results.
+	REQUIRE(duckdb_append_data_chunk(appender, data_chunk) == DuckDBSuccess);
+
+	// duckdb_appender_close attempts to flush the data and fails.
+	auto state = duckdb_appender_close(appender);
+	REQUIRE(state == DuckDBError);
+	auto error = duckdb_appender_error(appender);
+	REQUIRE(duckdb::StringUtil::Contains(error, "PRIMARY KEY or UNIQUE constraint violated"));
+
+	// Destroy the appender despite the error to avoid leaks.
+	state = duckdb_appender_destroy(&appender);
+	REQUIRE(state == DuckDBError);
+
+	// Clean-up.
+	duckdb_destroy_data_chunk(&data_chunk);
+	for (idx_t i = 0; i < COLUMN_COUNT; i++) {
+		duckdb_destroy_logical_type(&types[i]);
+	}
+
+	// Ensure that no rows were appended.
+	result = tester.Query("SELECT * FROM test;");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->row_count() == 0);
+
+	// Try again by appending rows and flushing.
+	REQUIRE(duckdb_appender_create(tester.connection, nullptr, "test", &appender) == DuckDBSuccess);
+	REQUIRE(duckdb_appender_begin_row(appender) == DuckDBSuccess);
+	REQUIRE(duckdb_append_int64(appender, 42) == DuckDBSuccess);
+	REQUIRE(duckdb_appender_end_row(appender) == DuckDBSuccess);
+	REQUIRE(duckdb_appender_begin_row(appender) == DuckDBSuccess);
+	REQUIRE(duckdb_append_int64(appender, 42) == DuckDBSuccess);
+	REQUIRE(duckdb_appender_end_row(appender) == DuckDBSuccess);
+
+	state = duckdb_appender_flush(appender);
+	REQUIRE(state == DuckDBError);
+	error = duckdb_appender_error(appender);
+	REQUIRE(duckdb::StringUtil::Contains(error, "PRIMARY KEY or UNIQUE constraint violated"));
+	REQUIRE(duckdb_appender_destroy(&appender) == DuckDBError);
+
+	// Ensure that only the last row was appended.
+	result = tester.Query("SELECT * FROM test;");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->row_count() == 0);
+}


### PR DESCRIPTION
Before this PR, we advised users against using `duckdb_appender_flush` and `duckdb_appender_close` instead of `duckdb_appender_destroy`. However, we did not return `DuckDBError`, if `duckdb_appender_destroy` failed to close the appender. Furthermore, getting insights into any error when appending the internal data is impossible with `duckdb_appender_destroy`, as it also destroys the wrapper to access that error.

**Changes and fixes in this PR**
- Encourage users to use `duckdb_appender_flush` or `duckdb_appender_close` before `duckdb_appender_destroy` to retrieve a possible `DuckDBError`.
- Return `DuckDBError` if `duckdb_appender_close` fails during `duckdb_appender_destroy.` This ensures that any error does not stay silent.
- Updating an existing test and adding a new test to ensure that constraint violations don't go unnoticed.