### PR TITLE
Grab checkpoint lock during storage metadata reads

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -672,6 +672,7 @@ jobs:
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[intraquery]" --no-exit --timeout 600
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[interquery]" --no-exit --timeout 1800
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[interquery]" --no-exit --timeout 1800 --force-storage
+          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[interquery]" --no-exit --timeout 1800 --force-storage --force-reload
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[detailed_profiler]" --no-exit --timeout 600
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow --no-exit --timeout 600
 

--- a/.sanitizer-thread-suppressions.txt
+++ b/.sanitizer-thread-suppressions.txt
@@ -1,6 +1,7 @@
 deadlock:LockClients
 deadlock:RollbackTransaction
 deadlock:Checkpoint
+deadlock:InitializeIndexes
 race:NextInnerJoin
 race:duckdb_moodycamel
 race:duckdb_jemalloc

--- a/src/catalog/duck_catalog.cpp
+++ b/src/catalog/duck_catalog.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/catalog/default/default_schemas.hpp"
 #include "duckdb/function/built_in_functions.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "duckdb/transaction/duck_transaction_manager.hpp"
 #ifndef DISABLE_CORE_FUNCTIONS_EXTENSION
 #include "duckdb/core_functions/core_functions.hpp"
 #endif
@@ -129,10 +130,14 @@ optional_ptr<SchemaCatalogEntry> DuckCatalog::GetSchema(CatalogTransaction trans
 }
 
 DatabaseSize DuckCatalog::GetDatabaseSize(ClientContext &context) {
+	auto &transaction = DuckTransactionManager::Get(db);
+	auto lock = transaction.SharedCheckpointLock();
 	return db.GetStorageManager().GetDatabaseSize();
 }
 
 vector<MetadataBlockInfo> DuckCatalog::GetMetadataInfo(ClientContext &context) {
+	auto &transaction = DuckTransactionManager::Get(db);
+	auto lock = transaction.SharedCheckpointLock();
 	return db.GetStorageManager().GetMetadataInfo();
 }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1433,6 +1433,7 @@ void DataTable::CommitDropTable() {
 // GetColumnSegmentInfo
 //===--------------------------------------------------------------------===//
 vector<ColumnSegmentInfo> DataTable::GetColumnSegmentInfo() {
+	auto lock = GetSharedCheckpointLock();
 	return row_groups->GetColumnSegmentInfo();
 }
 

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -489,7 +489,6 @@ protected:
 };
 
 void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
-
 	auto free_list_blocks = GetFreeListBlocks();
 
 	// now handle the free list

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -489,6 +489,7 @@ protected:
 };
 
 void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
+	lock_guard<mutex> lock(block_lock);
 	// set the iteration count
 	header.iteration = ++iteration_count;
 

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -489,9 +489,6 @@ protected:
 };
 
 void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
-	lock_guard<mutex> lock(block_lock);
-	// set the iteration count
-	header.iteration = ++iteration_count;
 
 	auto free_list_blocks = GetFreeListBlocks();
 
@@ -499,6 +496,11 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 	auto &metadata_manager = GetMetadataManager();
 	// add all modified blocks to the free list: they can now be written to again
 	metadata_manager.MarkBlocksAsModified();
+
+	lock_guard<mutex> lock(block_lock);
+	// set the iteration count
+	header.iteration = ++iteration_count;
+
 	for (auto &block : modified_blocks) {
 		free_list.insert(block);
 		newly_freed_list.insert(block);

--- a/test/sql/parallelism/interquery/concurrent_append_metadata_queries.test
+++ b/test/sql/parallelism/interquery/concurrent_append_metadata_queries.test
@@ -76,10 +76,6 @@ from pragma_table_info('integers');
 
 skipif threadid=0
 statement ok
-from pragma_database_size();
-
-skipif threadid=0
-statement ok
 from duckdb_dependencies();
 
 skipif threadid=0

--- a/test/sql/parallelism/interquery/concurrent_append_metadata_queries.test
+++ b/test/sql/parallelism/interquery/concurrent_append_metadata_queries.test
@@ -70,6 +70,22 @@ skipif threadid=0
 statement ok
 FROM pragma_storage_info('integers');
 
+skipif threadid=0
+statement ok
+from pragma_table_info('integers');
+
+skipif threadid=0
+statement ok
+from pragma_database_size();
+
+skipif threadid=0
+statement ok
+from duckdb_dependencies();
+
+skipif threadid=0
+statement ok
+from duckdb_temporary_files();
+
 endloop
 
 endloop


### PR DESCRIPTION
This fixes an issue when running storage metadata reads (e.g. `PRAGMA metadata_info`). While these queries are read-only, they access a number of storage internals that are normally not accessed. Now that we can checkpoint while threads are reading (since https://github.com/duckdb/duckdb/pull/11918) it is easier to block calls to these functions while checkpoints are running to prevent data races.