### PR TITLE
Parquet: Correctly return min/max string stats if empty

### DIFF
--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -44,6 +44,7 @@ class ColumnWriterStatistics {
 public:
 	virtual ~ColumnWriterStatistics();
 
+	virtual bool HasStats();
 	virtual string GetMin();
 	virtual string GetMax();
 	virtual string GetMinValue();

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -48,9 +48,6 @@ static unique_ptr<BaseStatistics> CreateNumericStats(const LogicalType &type,
 Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type,
                                            const duckdb_parquet::format::SchemaElement &schema_ele,
                                            const std::string &stats) {
-	if (stats.empty()) {
-		return Value();
-	}
 	auto stats_data = const_data_ptr_cast(stats.c_str());
 	switch (type.id()) {
 	case LogicalTypeId::BOOLEAN: {

--- a/test/sql/copy/parquet/parquet_stats.test
+++ b/test/sql/copy/parquet/parquet_stats.test
@@ -186,3 +186,17 @@ statement ok
 select * from parquet_metadata('${parquet_file}');
 
 endloop
+
+# internal issue 2037
+statement ok
+copy (select '' i) to '__TEST_DIR__/test.parquet';
+
+query I
+select i is null c0 from '__TEST_DIR__/test.parquet';
+----
+false
+
+query II
+select stats_min_value is null c0, stats_max_value is null c1 from parquet_metadata('__TEST_DIR__/test.parquet');
+----
+false	false


### PR DESCRIPTION
Fixes an issue found internally