### PR TITLE
CI fixes: unused variable & toolchain version

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -125,7 +125,7 @@ runs:
       run: |
         mkdir overlay_triplets
         cp $OVERLAY_TRIPLET_SRC $OVERLAY_TRIPLET_DST
-        echo "set(VCPKG_PLATFORM_TOOLSET_VERSION "14.38")" >> $OVERLAY_TRIPLET_DST
+        echo "set(VCPKG_PLATFORM_TOOLSET_VERSION "14.39")" >> $OVERLAY_TRIPLET_DST
 
     - name: Set Openssl dir
       if: inputs.openssl_path != ''

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -251,6 +251,7 @@ void SingleFileStorageCommitState::FlushCommit() {
 	if (log) {
 		// flush the WAL if any changes were made
 		if (log->GetTotalWritten() > initial_written) {
+			(void)checkpoint;
 			D_ASSERT(!checkpoint);
 			D_ASSERT(!log->skip_writing);
 			log->Flush();


### PR DESCRIPTION
Two unconnected minor fixes, one a unused variable that throws a warning (then error), one bumping a toolchain version while the proper solution is looked at.