### PR TITLE
Nightly CI fixes

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Test
       shell: bash
       run: |
-          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit --timeout 600
+          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit --timeout 1200
 
 
   linux-clang:
@@ -675,50 +675,6 @@ jobs:
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[interquery]" --no-exit --timeout 1800 --force-storage --force-reload
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest "[detailed_profiler]" --no-exit --timeout 600
           python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest test/sql/tpch/tpch_sf01.test_slow --no-exit --timeout 600
-
-
-  threadsan-relassert-all:
-    name: Thread Sanitizer (Relassert + All tests)
-    runs-on: ubuntu-latest
-    needs: linux-memory-leaks
-    env:
-      GEN: ninja
-      EXTENSION_STATIC_BUILD: 1
-      BUILD_ICU: 1
-      BUILD_INET: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_FTS: 1
-      BUILD_VISUALIZER: 1
-      BUILD_JSON: 1
-      BUILD_EXCEL: 1
-      BUILD_JEMALLOC: 1
-      DUCKDB_PLATFORM: linux_amd64
-      TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Install
-      shell: bash
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
-
-    - name: Setup Ccache
-      uses: hendrikmuhs/ccache-action@main
-      with:
-        key: ${{ github.job }}
-        save: ${{ env.CCACHE_SAVE }}
-
-    - name: Build
-      shell: bash
-      run: THREADSAN=1 make relassert
-
-    - name: Test
-      shell: bash
-      run: |
-          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit
 
   vector-sizes:
     name: Vector Sizes

--- a/scripts/coverage_check.sh
+++ b/scripts/coverage_check.sh
@@ -13,8 +13,6 @@ mkdir -p build/coverage
 # run tests
 build/coverage/test/unittest
 build/coverage/test/unittest "[coverage]"
-build/coverage/test/unittest "[intraquery]"
-build/coverage/test/unittest "[interquery]"
 build/coverage/test/unittest "[detailed_profiler]"
 build/coverage/test/unittest test/sql/tpch/tpch_sf01.test_slow
 python3 -m pytest --shell-binary build/coverage/duckdb tools/shell/tests/

--- a/scripts/test_vector_sizes.py
+++ b/scripts/test_vector_sizes.py
@@ -12,7 +12,7 @@ def execute_system_command(cmd):
     retcode = os.system(cmd)
     print(retcode)
     if retcode != 0:
-        raise Exception
+        raise Exception(f"Failed to run command {cmd} - exit code {retcode}")
 
 
 def replace_in_file(fname, regex, replace):


### PR DESCRIPTION
Just increasing some time-outs, removing CI runs that never worked, and removing some tests from coverage because coverage is too slow currently (>6 hours)