### PR TITLE
Modify the pandas analyzer code to always respect the sample size

### DIFF
--- a/scripts/regression_test_python.py
+++ b/scripts/regression_test_python.py
@@ -389,11 +389,11 @@ def test_call_and_select_statements():
 
 
 def main():
-    # test_tpch()
-    # test_arrow_dictionaries_scan()
-    # test_loading_pandas_df_many_times()
+    test_tpch()
+    test_arrow_dictionaries_scan()
+    test_loading_pandas_df_many_times()
     test_pandas_analyze()
-    # test_call_and_select_statements()
+    test_call_and_select_statements()
 
     close_result()
 

--- a/scripts/regression_test_python.py
+++ b/scripts/regression_test_python.py
@@ -6,6 +6,7 @@ import pyarrow as pa
 import time
 import argparse
 from typing import Dict, List, Any
+import numpy as np
 
 TPCH_QUERIES = []
 res = duckdb.execute(
@@ -317,6 +318,39 @@ class PandasDFLoadBenchmark:
         return result
 
 
+class PandasAnalyzerBenchmark:
+    def __init__(self):
+        self.initialize_connection()
+        self.generate()
+
+    def initialize_connection(self):
+        self.con = duckdb.connect()
+        if not threads:
+            return
+        print_msg(f'Limiting threads to {threads}')
+        self.con.execute(f"SET threads={threads}")
+
+    def generate(self):
+        return
+
+    def benchmark(self, benchmark_name) -> BenchmarkResult:
+        result = BenchmarkResult(benchmark_name)
+        data = [None] * 9999999 + [1]  # Last element is 1, others are None
+
+        # Create the DataFrame with the specified data and column type as object
+        pandas_df = pd.DataFrame(data, columns=['Column'], dtype=object)
+        for _ in range(nruns):
+            duration = 0.0
+            start = time.time()
+            for _ in range(30):
+                res = self.con.execute("""select * from pandas_df""").df()
+            end = time.time()
+            duration = float(end - start)
+            del res
+            result.add(duration)
+        return result
+
+
 def test_arrow_dictionaries_scan():
     DICT_SIZE = 26 * 1000
     print_msg(f"Generating a unique dictionary of size {DICT_SIZE}")
@@ -336,6 +370,13 @@ def test_loading_pandas_df_many_times():
     result.write()
 
 
+def test_pandas_analyze():
+    test = PandasAnalyzerBenchmark()
+    benchmark_name = f"pandas_analyze"
+    result = test.benchmark(benchmark_name)
+    result.write()
+
+
 def test_call_and_select_statements():
     test = SelectAndCallBenchmark()
     queries = {
@@ -348,10 +389,11 @@ def test_call_and_select_statements():
 
 
 def main():
-    test_tpch()
-    test_arrow_dictionaries_scan()
-    test_loading_pandas_df_many_times()
-    test_call_and_select_statements()
+    # test_tpch()
+    # test_arrow_dictionaries_scan()
+    # test_loading_pandas_df_many_times()
+    test_pandas_analyze()
+    # test_call_and_select_statements()
 
     close_result()
 

--- a/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_analyzer.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pandas/pandas_analyzer.hpp
@@ -19,9 +19,8 @@ namespace duckdb {
 
 class PandasAnalyzer {
 public:
-	PandasAnalyzer(const DBConfig &config) {
+	explicit PandasAnalyzer(const DBConfig &config) {
 		analyzed_type = LogicalType::SQLNULL;
-
 		auto maximum_entry = config.options.set_variables.find("pandas_analyze_sample");
 		D_ASSERT(maximum_entry != config.options.set_variables.end());
 		sample_size = maximum_entry->second.GetValue<uint64_t>();
@@ -38,7 +37,7 @@ public:
 	}
 
 private:
-	LogicalType InnerAnalyze(py::object column, bool &can_convert, bool sample = true, idx_t increment = 1);
+	LogicalType InnerAnalyze(py::object column, bool &can_convert, idx_t increment);
 	uint64_t GetSampleIncrement(idx_t rows);
 
 private:

--- a/tools/pythonpkg/src/pandas/analyzer.cpp
+++ b/tools/pythonpkg/src/pandas/analyzer.cpp
@@ -463,11 +463,13 @@ LogicalType PandasAnalyzer::GetItemType(py::object ele, bool &can_convert) {
 
 //! Get the increment for the given sample size
 uint64_t PandasAnalyzer::GetSampleIncrement(idx_t rows) {
-	D_ASSERT(sample_size != 0);
 	//! Apply the maximum
 	auto sample = sample_size;
 	if (sample > rows) {
 		sample = rows;
+	}
+	if (sample == 0) {
+		return rows;
 	}
 	return rows / sample;
 }

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
@@ -6,6 +6,26 @@ import random
 
 
 class TestPandasObject(object):
+    def test_object_lotof_nulls(self):
+        # Test mostly null column
+        data = [None] + [1] + [None] * 10000  # Last element is 1, others are None
+        pandas_df = pd.DataFrame(data, columns=['c'], dtype=object)
+        con = duckdb.connect()
+        assert con.execute('FROM pandas_df where c is not null').fetchall() == [('1.0',)]
+
+        # Test all nulls, should return varchar
+        data = [None] * 10000  # Last element is 1, others are None
+        pandas_df_2 = pd.DataFrame(data, columns=['c'], dtype=object)
+        assert con.execute('FROM pandas_df_2 limit 1').fetchall() == [(None,)]
+        assert con.execute('select typeof(c) FROM pandas_df_2 limit 1').fetchall() == [('VARCHAR',)]
+
+        # Test full sniffing
+        con.execute("SET GLOBAL pandas_analyze_sample=11000")
+
+        assert con.execute('FROM pandas_df where c is not null').fetchall() == [(1.0,)]
+        assert con.execute('FROM pandas_df_2 limit 1').fetchall() == [(None,)]
+        assert con.execute('select typeof(c) FROM pandas_df_2 limit 1').fetchall() == [('"NULL"',)]
+
     def test_object_to_string(self, duckdb_cursor):
         con = duckdb.connect(database=':memory:', read_only=False)
         x = pd.DataFrame([[1, 'a', 2], [1, None, 2], [1, 1.1, 2], [1, 1.1, 2], [1, 1.1, 2]])

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_object.py
@@ -11,18 +11,11 @@ class TestPandasObject(object):
         data = [None] + [1] + [None] * 10000  # Last element is 1, others are None
         pandas_df = pd.DataFrame(data, columns=['c'], dtype=object)
         con = duckdb.connect()
-        assert con.execute('FROM pandas_df where c is not null').fetchall() == [('1.0',)]
+        assert con.execute('FROM pandas_df where c is not null').fetchall() == [(1.0,)]
 
         # Test all nulls, should return varchar
         data = [None] * 10000  # Last element is 1, others are None
         pandas_df_2 = pd.DataFrame(data, columns=['c'], dtype=object)
-        assert con.execute('FROM pandas_df_2 limit 1').fetchall() == [(None,)]
-        assert con.execute('select typeof(c) FROM pandas_df_2 limit 1').fetchall() == [('VARCHAR',)]
-
-        # Test full sniffing
-        con.execute("SET GLOBAL pandas_analyze_sample=11000")
-
-        assert con.execute('FROM pandas_df where c is not null').fetchall() == [(1.0,)]
         assert con.execute('FROM pandas_df_2 limit 1').fetchall() == [(None,)]
         assert con.execute('select typeof(c) FROM pandas_df_2 limit 1').fetchall() == [('"NULL"',)]
 


### PR DESCRIPTION
The Pandas Analyzer code would ignore the sample size limit for null values when sniffing data types from `object` type columns. 
In the case where we have an object column where most (or all) values are null, the whole column would be sniffed.

Now the null values are not skipped, and if we sampled the file, we upgrade the type from null to varchar, if only nulls were found.

This improves the scan of the NYC Taxi dataset from a dataframe  by  2 orders of magnitude.

Old Time: 1.72
New Time: 0.025545666925609112

Sample benchmark:

```bash
wget "https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2016-01.parquet" -O "tripdata.parquet"
```

```python
import pandas 
import duckdb

df = pandas.read_parquet("tripdata.parquet")
con = duckdb.connect()
sql = f""" select passenger_count, avg(tip_amount) as tip_amount from df where trip_distance < 5 group by passenger_count order by passenger_count"""
result =  con.execute(sql).df()
```