### PR TITLE
[CI] Diff against the right remote + branch in `Regressions.yml` - `Regression Test new micro benchmark`

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -16,7 +16,7 @@ on:
       - '!.github/workflows/Regression.yml'
 
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -130,12 +130,10 @@ jobs:
         python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/csv.csv --verbose --threads=2
 
     - name: Regression Test new micro benchmark
-      if: github.event_name == 'pull_request'
+      if: always()
       shell: bash
       run: |
-        target_branch="${{ github.event.pull_request.base.ref }}"
-
-        git diff --name-only $target_branch | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
+        git diff --name-only $BASE_BRANCH | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
         if [ $(wc -l < .github/regression/updated_micro_benchmarks.csv) -gt 0 ]; then
           echo "Detected the following modified benchmarks. Running a regression test"
           cat .github/regression/updated_micro_benchmarks.csv

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -16,7 +16,7 @@ on:
       - '!.github/workflows/Regression.yml'
 
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'tools/**'
@@ -138,7 +138,7 @@ jobs:
         git remote add base ${{ github.event.pull_request.base.repo.html_url }}
         git fetch base
 
-        git diff --name-only base/$target_branch | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
+        git diff --name-only "base/$target_branch" | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
         if [ $(wc -l < .github/regression/updated_micro_benchmarks.csv) -gt 0 ]; then
           echo "Detected the following modified benchmarks. Running a regression test"
           cat .github/regression/updated_micro_benchmarks.csv

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -130,10 +130,12 @@ jobs:
         python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/csv.csv --verbose --threads=2
 
     - name: Regression Test new micro benchmark
-      if: always()
+      if: github.event_name == 'pull_request'
       shell: bash
       run: |
-        git diff --name-only origin/main | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
+        target_branch="${{ github.event.pull_request.base.ref }}"
+
+        git diff --name-only $target_branch | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
         if [ $(wc -l < .github/regression/updated_micro_benchmarks.csv) -gt 0 ]; then
           echo "Detected the following modified benchmarks. Running a regression test"
           cat .github/regression/updated_micro_benchmarks.csv

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -135,7 +135,10 @@ jobs:
       run: |
         target_branch="${{ github.event.pull_request.base.ref }}"
 
-        git diff --name-only $target_branch | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
+        git remote add base ${{ github.event.pull_request.base.repo.html_url }}
+        git fetch base/$target_branch
+
+        git diff --name-only base/$target_branch | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
         if [ $(wc -l < .github/regression/updated_micro_benchmarks.csv) -gt 0 ]; then
           echo "Detected the following modified benchmarks. Running a regression test"
           cat .github/regression/updated_micro_benchmarks.csv

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -136,7 +136,7 @@ jobs:
         target_branch="${{ github.event.pull_request.base.ref }}"
 
         git remote add base ${{ github.event.pull_request.base.repo.html_url }}
-        git fetch base/$target_branch
+        git fetch base
 
         git diff --name-only base/$target_branch | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
         if [ $(wc -l < .github/regression/updated_micro_benchmarks.csv) -gt 0 ]; then

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -130,10 +130,12 @@ jobs:
         python scripts/regression_test_runner.py --old=duckdb/build/release/benchmark/benchmark_runner --new=build/release/benchmark/benchmark_runner --benchmarks=.github/regression/csv.csv --verbose --threads=2
 
     - name: Regression Test new micro benchmark
-      if: always()
+      if: github.event_name == 'pull_request'
       shell: bash
       run: |
-        git diff --name-only $BASE_BRANCH | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
+        target_branch="${{ github.event.pull_request.base.ref }}"
+
+        git diff --name-only $target_branch | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
         if [ $(wc -l < .github/regression/updated_micro_benchmarks.csv) -gt 0 ]; then
           echo "Detected the following modified benchmarks. Running a regression test"
           cat .github/regression/updated_micro_benchmarks.csv


### PR DESCRIPTION
This PR aims to fix CI of PRs made to `feature`:

```
Run git diff --name-only origin/main | (grep "benchmark/micro/*" || true) > .github/regression/updated_micro_benchmarks.csv
Detected the following modified benchmarks. Running a regression test
benchmark/micro/csv/ignore_errors.benchmark
benchmark/micro/csv/multiple_small_files.benchmark
benchmark/micro/csv/time_type.benchmark
benchmark/micro/result_collection/batched_stream_query.benchmark
```

```
benchmark/micro/csv/ignore_errors.benchmark
Old timing: 2.205773
New timing: Failed to run benchmark benchmark/micro/csv/ignore_errors.benchmark

benchmark/micro/csv/multiple_small_files.benchmark
Old timing: 0.244721
New timing: Failed to run benchmark benchmark/micro/csv/multiple_small_files.benchmark

benchmark/micro/csv/time_type.benchmark
Old timing: 0.921153
New timing: Failed to run benchmark benchmark/micro/csv/time_type.benchmark

benchmark/micro/result_collection/batched_stream_query.benchmark
Old timing: 7.897132
New timing: Failed to run benchmark benchmark/micro/result_collection/batched_stream_query.benchmark
```

By only running this job if the event is a PR, and diffing against the target branch instead of hardcoding this to `main`