### PR TITLE
Mark unspecialized C++ `Append` template as delete

### DIFF
--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -59,9 +59,7 @@ public:
 
 	// Append functions
 	template <class T>
-	void Append(T value) {
-		throw InternalException("Undefined type for Appender::Append!");
-	}
+	void Append(T value) = delete;
 
 	DUCKDB_API void Append(const char *value, uint32_t length);
 


### PR DESCRIPTION
The current implementation of `duckdb::Appender::Append<T>` raises a runtime error if `Append` isn't specialized for `T` - this can be moved up to a compile-time check by marking the unspecialized template as `delete`.