### PR TITLE
Avoid signed integer overflow in sequence generation

### DIFF
--- a/src/common/vector_operations/generators.cpp
+++ b/src/common/vector_operations/generators.cpp
@@ -18,7 +18,7 @@ void TemplatedGenerateSequence(Vector &result, idx_t count, int64_t start, int64
 	}
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<T>(result);
-	auto value = (T)start;
+	auto value = T(start);
 	for (idx_t i = 0; i < count; i++) {
 		if (i > 0) {
 			value += increment;
@@ -44,12 +44,6 @@ void VectorOperations::GenerateSequence(Vector &result, idx_t count, int64_t sta
 	case PhysicalType::INT64:
 		TemplatedGenerateSequence<int64_t>(result, count, start, increment);
 		break;
-	case PhysicalType::FLOAT:
-		TemplatedGenerateSequence<float>(result, count, start, increment);
-		break;
-	case PhysicalType::DOUBLE:
-		TemplatedGenerateSequence<double>(result, count, start, increment);
-		break;
 	default:
 		throw NotImplementedException("Unimplemented type for generate sequence");
 	}
@@ -64,10 +58,10 @@ void TemplatedGenerateSequence(Vector &result, idx_t count, const SelectionVecto
 	}
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<T>(result);
-	auto value = (T)start;
+	auto value = static_cast<uint64_t>(start);
 	for (idx_t i = 0; i < count; i++) {
-		auto idx = UnsafeNumericCast<int64_t>(sel.get_index(i));
-		result_data[idx] = UnsafeNumericCast<T>(value + increment * idx);
+		auto idx = sel.get_index(i);
+		result_data[idx] = static_cast<T>(value + static_cast<uint64_t>(increment) * idx);
 	}
 }
 
@@ -88,12 +82,6 @@ void VectorOperations::GenerateSequence(Vector &result, idx_t count, const Selec
 		break;
 	case PhysicalType::INT64:
 		TemplatedGenerateSequence<int64_t>(result, count, sel, start, increment);
-		break;
-	case PhysicalType::FLOAT:
-		TemplatedGenerateSequence<float>(result, count, sel, start, increment);
-		break;
-	case PhysicalType::DOUBLE:
-		TemplatedGenerateSequence<double>(result, count, sel, start, increment);
 		break;
 	default:
 		throw NotImplementedException("Unimplemented type for generate sequence");

--- a/src/core_functions/scalar/string/chr.cpp
+++ b/src/core_functions/scalar/string/chr.cpp
@@ -30,7 +30,7 @@ static void ChrFunction(DataChunk &args, ExpressionState &state, Vector &result)
 	int utf8_bytes;
 	UnaryExecutor::Execute<int32_t, string_t>(code_vec, result, args.size(), [&](int32_t input) {
 		ChrOperator::GetCodepoint(input, c, utf8_bytes);
-		return StringVector::AddString(result, &c[0], utf8_bytes);
+		return StringVector::AddString(result, &c[0], UnsafeNumericCast<uint32_t>(utf8_bytes));
 	});
 }
 #endif


### PR DESCRIPTION
Instead turn it into an unsigned integer overflow which has defined wrapping behavior.