### PR TITLE
Use Binder::BindCreateTableCheckpoint in WAL ReplayCreateTable

### DIFF
--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -348,7 +348,7 @@ void WriteAheadLogDeserializer::ReplayCreateTable() {
 	// bind the constraints to the table again
 	auto binder = Binder::CreateBinder(context);
 	auto &schema = catalog.GetSchema(context, info->schema);
-	auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);
+	auto bound_info = Binder::BindCreateTableCheckpoint(std::move(info), schema);
 
 	catalog.CreateTable(context, *bound_info);
 }


### PR DESCRIPTION
This postpones binding of e.g. default values similar to how this is done for checkpoint replay