### PR TITLE
Avoid checking if wal is set directly and call GetWALSize instead - a WAL might be present even if wal is not set

### DIFF
--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -73,8 +73,11 @@ public:
 	void ResetWAL();
 
 	//! Returns the database file path
-	string GetDBPath() {
+	string GetDBPath() const {
 		return path;
+	}
+	bool IsLoaded() const {
+		return load_complete;
 	}
 	//! The path to the WAL, derived from the database file path
 	string GetWALPath();

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -280,7 +280,7 @@ bool SingleFileStorageManager::IsCheckpointClean(MetaBlockPointer checkpoint_id)
 }
 
 void SingleFileStorageManager::CreateCheckpoint(CheckpointOptions options) {
-	if (InMemory() || read_only) {
+	if (InMemory() || read_only || !load_complete) {
 		return;
 	}
 	auto &config = DBConfig::Get(db);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -280,7 +280,7 @@ bool SingleFileStorageManager::IsCheckpointClean(MetaBlockPointer checkpoint_id)
 }
 
 void SingleFileStorageManager::CreateCheckpoint(CheckpointOptions options) {
-	if (InMemory() || read_only || !wal) {
+	if (InMemory() || read_only) {
 		return;
 	}
 	auto &config = DBConfig::Get(db);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -61,6 +61,7 @@ int64_t StorageManager::GetWALSize() {
 		return 0;
 	}
 	if (!wal->Initialized()) {
+		D_ASSERT(!FileSystem::Get(db).FileExists(GetWALPath()));
 		return 0;
 	}
 	return wal->GetWriter().GetFileSize();
@@ -71,23 +72,22 @@ optional_ptr<WriteAheadLog> StorageManager::GetWAL() {
 		return nullptr;
 	}
 
-	if (wal) {
-		return wal.get();
-	}
+	if (!wal) {
+		auto wal_path = GetWALPath();
+		wal = make_uniq<WriteAheadLog>(db, wal_path);
 
-	auto wal_path = GetWALPath();
-	wal = make_uniq<WriteAheadLog>(db, wal_path);
-
-	// If the WAL file exists, then we initialize it.
-	if (FileSystem::Get(db).FileExists(wal_path)) {
-		wal->Initialize();
+		// If the WAL file exists, then we initialize it.
+		if (FileSystem::Get(db).FileExists(wal_path)) {
+			wal->Initialize();
+		}
 	}
 	return wal.get();
 }
 
 void StorageManager::ResetWAL() {
-	if (wal) {
-		wal->Delete();
+	auto wal_ptr = GetWAL();
+	if (wal_ptr) {
+		wal_ptr->Delete();
 	}
 	wal.reset();
 }

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -86,6 +86,9 @@ DuckTransactionManager::CanCheckpoint(DuckTransaction &transaction, unique_ptr<S
 	if (storage_manager.InMemory()) {
 		return CheckpointDecision("in memory db");
 	}
+	if (!storage_manager.IsLoaded()) {
+		return CheckpointDecision("cannot checkpoint while loading");
+	}
 	if (!transaction.AutomaticCheckpoint(db, undo_properties)) {
 		return CheckpointDecision("no reason to automatically checkpoint");
 	}


### PR DESCRIPTION
Otherwise explicit `CHECKPOINT` calls might be ignored even if there is a WAL that should be checkpointed