### PR TITLE
Call StringVector::AddString here for when inlining is disabled

### DIFF
--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -375,7 +375,7 @@ static void BoundedToAsciiFunc(DataChunk &args, ExpressionState &state, Vector &
 		}
 		string s;
 		s.push_back(static_cast<char>(input));
-		return string_t(s);
+		return StringVector::AddString(result, s);
 	});
 }
 


### PR DESCRIPTION
Fixes an issue in the nightly tests