### PR TITLE
Minor fixes for vsize=2 tests

### DIFF
--- a/test/extension/test_custom_type_modifier.test
+++ b/test/extension/test_custom_type_modifier.test
@@ -55,7 +55,7 @@ INSERT INTO t2 VALUES (100), (500);
 
 # Example of function inspecting both arguments type property to return a new type
 query II
-SELECT bounded_add(t1.i, t2.i) as s, typeof(s) FROM t1, t2;
+SELECT bounded_add(t1.i, t2.i) as s, typeof(s) FROM t1, t2 ORDER BY 1;
 ----
 197	BOUNDED(700)
 198	BOUNDED(700)

--- a/test/sql/attach/attach_huggingface_index.test
+++ b/test/sql/attach/attach_huggingface_index.test
@@ -4,6 +4,9 @@
 
 require skip_reload
 
+# database is written with vector size of 2048
+require vector_size 2048
+
 unzip data/storage/huggingface_index.db.gz __TEST_DIR__/huggingface_index.db
 
 statement ok

--- a/test/sql/attach/attach_icu_collation.test
+++ b/test/sql/attach/attach_icu_collation.test
@@ -6,6 +6,9 @@ require skip_reload
 
 require no_extension_autoloading
 
+# database is written with vector size of 2048
+require vector_size 2048
+
 unzip data/storage/german_collation.db.gz __TEST_DIR__/german_collation.db
 
 statement ok

--- a/test/sql/copy/csv/auto/test_type_detection.test
+++ b/test/sql/copy/csv/auto/test_type_detection.test
@@ -2,6 +2,8 @@
 # description: Test csv type detection
 # group: [auto]
 
+require vector_size 2048
+
 # a CSV file with many strings
 statement ok
 CREATE TABLE test AS SELECT * FROM read_csv_auto ('test/sql/copy/csv/data/auto/large_mixed_data.csv', SAMPLE_SIZE=-1);

--- a/test/sql/copy/csv/test_big_header.test
+++ b/test/sql/copy/csv/test_big_header.test
@@ -2,6 +2,8 @@
 # description: Test big header
 # group: [csv]
 
+require vector_size 2048
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy/csv/test_column_inconsistencies.test
+++ b/test/sql/copy/csv/test_column_inconsistencies.test
@@ -2,6 +2,8 @@
 # description: Test bug from issue 10273
 # group: [csv]
 
+require vector_size 2048
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/storage/icu_collation.test
+++ b/test/sql/storage/icu_collation.test
@@ -6,6 +6,9 @@ require skip_reload
 
 require no_extension_autoloading
 
+# database file is written with vsize = 2048
+require vector_size 2048
+
 unzip data/storage/german_collation.db.gz __TEST_DIR__/icu_collation.db
 
 load __TEST_DIR__/icu_collation.db readonly

--- a/test/sql/storage/temp_directory/max_swap_space_error.test
+++ b/test/sql/storage/temp_directory/max_swap_space_error.test
@@ -8,6 +8,9 @@ require noforcestorage
 # this test performs many comparisons against the default block size of 256KiB
 require block_size 262144
 
+# temp directory usage changes with vector size
+require vector_size 2048
+
 # Set a temp_directory to offload data
 statement ok
 set temp_directory='__TEST_DIR__/max_swap_space_reached'


### PR DESCRIPTION
Skip tests that are known not to work with vsize = 2 (CSV auto-detection or reading databases created with higher vsize)