### PR TITLE
Internal #2078: Nested Nulls First

### DIFF
--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -477,11 +477,31 @@ idx_t PositionComparator::Final<duckdb::DistinctLessThan>(Vector &left, Vector &
 }
 
 template <>
+idx_t PositionComparator::Final<duckdb::DistinctLessThanNullsFirst>(Vector &left, Vector &right,
+                                                                    const SelectionVector &sel, idx_t count,
+                                                                    optional_ptr<SelectionVector> true_sel,
+                                                                    optional_ptr<SelectionVector> false_sel,
+                                                                    optional_ptr<ValidityMask> null_mask) {
+	// DistinctGreaterThan has NULLs last
+	return VectorOperations::DistinctGreaterThan(right, left, &sel, count, true_sel, false_sel, null_mask);
+}
+
+template <>
 idx_t PositionComparator::Final<duckdb::DistinctGreaterThan>(Vector &left, Vector &right, const SelectionVector &sel,
                                                              idx_t count, optional_ptr<SelectionVector> true_sel,
                                                              optional_ptr<SelectionVector> false_sel,
                                                              optional_ptr<ValidityMask> null_mask) {
 	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, false_sel, null_mask);
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctGreaterThanNullsFirst>(Vector &left, Vector &right,
+                                                                       const SelectionVector &sel, idx_t count,
+                                                                       optional_ptr<SelectionVector> true_sel,
+                                                                       optional_ptr<SelectionVector> false_sel,
+                                                                       optional_ptr<ValidityMask> null_mask) {
+	// DistinctLessThan has NULLs last
+	return VectorOperations::DistinctLessThan(right, left, &sel, count, true_sel, false_sel, null_mask);
 }
 
 using StructEntries = vector<unique_ptr<Vector>>;


### PR DESCRIPTION
Add missing templates for positional comparison
of nested NULLS FIRST inequalities.

fixes: duckdblabs/duckdb-internal#2078