### PR TITLE
Set max vector size to 128GB instead of 4GB

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -398,10 +398,11 @@ void Vector::Resize(idx_t cur_size, idx_t new_size) {
 			auto old_size = cur_size * data_to_resize.type_size * data_to_resize.nested_multiplier * sizeof(data_t);
 			auto target_size = new_size * data_to_resize.type_size * data_to_resize.nested_multiplier * sizeof(data_t);
 
-			// We have an upper limit of 4GB for a single vector
-			if (target_size > NumericLimits<uint32_t>::Maximum()) {
-				throw OutOfRangeException("Cannot resize vector to %lld bytes: maximum allowed vector size is 4GB",
-				                          target_size);
+			// We have an upper limit of 128GB for a single vector
+			if (target_size > DConstants::MAX_VECTOR_SIZE) {
+				throw OutOfRangeException("Cannot resize vector to %s: maximum allowed vector size is %s",
+				                          StringUtil::BytesToHumanReadableString(target_size),
+				                          StringUtil::BytesToHumanReadableString(DConstants::MAX_VECTOR_SIZE));
 			}
 
 			auto new_data = make_unsafe_uniq_array<data_t>(target_size);

--- a/src/include/duckdb/common/constants.hpp
+++ b/src/include/duckdb/common/constants.hpp
@@ -57,6 +57,8 @@ extern const double PI;
 struct DConstants {
 	//! The value used to signify an invalid index entry
 	static constexpr const idx_t INVALID_INDEX = idx_t(-1);
+	//! The total maximum vector size (128GB)
+	static constexpr const idx_t MAX_VECTOR_SIZE = 1ULL << 37ULL;
 };
 
 struct LogicalIndex {

--- a/test/sql/function/list/list_resize.test
+++ b/test/sql/function/list/list_resize.test
@@ -306,7 +306,7 @@ Conversion Error: Type INT32 with value -1 can't be cast because the value is ou
 statement error
 SELECT LIST_RESIZE([1, 2, 3], 9999999999999999999);
 ----
-Out of Range Error: Cannot resize vector to 3106511852580896764 bytes: maximum allowed vector size is 4GB
+maximum allowed vector size
 
 endloop
 


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/12028 introduced a 4GB limit to vectors as an upper bound as part of allocation hardening - this can reasonably be reached with valid queries using e.g. a `LIST()` aggregate. It is also triggered in a few places in our CI when doing vector verification. This PR ups the limit to vector size limit to 128GB instead. 