### PR TITLE
Add read_metadata function: read_blob equivalent that never fetches content

### DIFF
--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -281,6 +281,7 @@ void BuiltinFunctions::RegisterTableFunctions() {
 	RepeatRowTableFunction::RegisterFunction(*this);
 	CSVSnifferFunction::RegisterFunction(*this);
 	ReadBlobFunction::RegisterFunction(*this);
+	ReadMetadataFunction::RegisterFunction(*this);
 	ReadTextFunction::RegisterFunction(*this);
 }
 

--- a/src/include/duckdb/function/table/range.hpp
+++ b/src/include/duckdb/function/table/range.hpp
@@ -45,6 +45,10 @@ struct ReadBlobFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct ReadMetadataFunction {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct ReadTextFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/test/sql/table_function/read_text_and_blob.test
+++ b/test/sql/table_function/read_text_and_blob.test
@@ -12,6 +12,11 @@ SELECT COUNT(*) FROM read_blob('test/sql/table_function/files/*');
 ----
 4
 
+query I
+SELECT COUNT(*) FROM read_metadata('test/sql/table_function/files/*');
+----
+4
+
 query IIII
 SELECT * FROM read_text('test/sql/table_function/files/nonexistentfile.txt') ORDER BY ALL;
 ----
@@ -25,6 +30,16 @@ SELECT parse_path(filename) FROM read_text(['test/sql/table_function/files/one.t
 ----
 [test, sql, table_function, files, one.txt]
 [test, sql, table_function, files, two.txt]
+
+statement error
+SELECT parse_path(filename), size, content FROM read_metadata('test/sql/table_function/files/four.blob');
+----
+Binder Error: Referenced column "content" not found in FROM clause
+
+query II
+SELECT parse_path(filename), size FROM read_metadata('test/sql/table_function/files/four.blob');
+----
+[test, sql, table_function, files, four.blob]	178
 
 query III
 SELECT parse_path(filename), size, content FROM read_blob('test/sql/table_function/files/four.blob');


### PR DESCRIPTION
This has been discussed a few times, like:
https://github.com/duckdb/duckdb/discussions/11823
https://github.com/duckdb/duckdb/discussions/10761
https://github.com/duckdb/duckdb/discussions/11990

This is basically a shorthand for `SELECT * EXCLUDE content FROM read_blob("")`, original logic does the heavy -lifting but here it should be even more explicitly that only cheap to compute file information are queried.