### PR TITLE
add duckdb_bind_timestamp_tz function to C API

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1358,6 +1358,12 @@ DUCKDB_API duckdb_state duckdb_bind_timestamp(duckdb_prepared_statement prepared
                                               duckdb_timestamp val);
 
 /*!
+Binds a duckdb_timestamp value to the prepared statement at the specified index.
+*/
+DUCKDB_API duckdb_state duckdb_bind_timestamp_tz(duckdb_prepared_statement prepared_statement, idx_t param_idx,
+                                                 duckdb_timestamp val);
+
+/*!
 Binds a duckdb_interval value to the prepared statement at the specified index.
 */
 DUCKDB_API duckdb_state duckdb_bind_interval(duckdb_prepared_statement prepared_statement, idx_t param_idx,

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -280,6 +280,12 @@ duckdb_state duckdb_bind_timestamp(duckdb_prepared_statement prepared_statement,
 	return duckdb_bind_value(prepared_statement, param_idx, (duckdb_value)&value);
 }
 
+duckdb_state duckdb_bind_timestamp_tz(duckdb_prepared_statement prepared_statement, idx_t param_idx,
+                                      duckdb_timestamp val) {
+	auto value = Value::TIMESTAMPTZ(timestamp_t(val.micros));
+	return duckdb_bind_value(prepared_statement, param_idx, (duckdb_value)&value);
+}
+
 duckdb_state duckdb_bind_interval(duckdb_prepared_statement prepared_statement, idx_t param_idx, duckdb_interval val) {
 	auto value = Value::INTERVAL(val.months, val.days, val.micros);
 	return duckdb_bind_value(prepared_statement, param_idx, (duckdb_value)&value);

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -206,6 +206,14 @@ TEST_CASE("Test prepared statements in C API", "[capi]") {
 	duckdb_free(value);
 	duckdb_destroy_result(&res);
 
+	duckdb_bind_timestamp_tz(stmt, 1, duckdb_to_timestamp(ts));
+	status = duckdb_execute_prepared(stmt, &res);
+	REQUIRE(status == DuckDBSuccess);
+	value = duckdb_value_varchar(&res, 0, 0);
+	REQUIRE(string(value) == "1992-09-03 12:22:33.1234+00");
+	duckdb_free(value);
+	duckdb_destroy_result(&res);
+
 	duckdb_interval interval;
 	interval.months = 3;
 	interval.days = 0;


### PR DESCRIPTION
I always get a little turned around with timestamp and timestamptz, and timezones in general, but I think a `duckdb_bind_timestamp_tz` makes sense when binding to a timestamptz column.

If I using the existing `duckdb_bind_timestamp` function and bind `1716267776000000` to a timestamptz column, it'll store a different value than if I write `1716267776000000` directly to the vector. This doesn't seem right.