### PR TITLE
Move pyodide from repository_dispatch to NightlyTests.yml

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -838,3 +838,7 @@ jobs:
           name: coverage
           path: coverage.zip
           if-no-files-found: error
+
+  pyodide:
+    uses: ./.github/workflows/Pyodide.yml
+    secrets: inherit

--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -16,7 +16,6 @@ on:
         type: string
       skip_tests:
         type: string
-  repository_dispatch:
   push:
     branches:
       - "**"


### PR DESCRIPTION
There is no actually change but for the fact the nightly report has to be looked up elsewhere.

Reduces noise, since Pyodide CI failures are not as serious as failing to build regular binaries or extensions.