### PR TITLE
More Nightly CI Fixes

### DIFF
--- a/scripts/coverage_check.sh
+++ b/scripts/coverage_check.sh
@@ -25,4 +25,4 @@ lcov --config-file .github/workflows/lcovrc --remove coverage.info $(< .github/w
 genhtml -o coverage_html lcov.info
 
 # check that coverage passes threshold
-python3 scripts/check_coverage.py
+# python3 scripts/check_coverage.py

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -23,7 +23,9 @@ parser.add_argument('--profile', action='store_true', help='Enable profiling')
 parser.add_argument('--no-assertions', action='store_false', help='Disable assertions')
 parser.add_argument('--time_execution', action='store_true', help='Measure and print the execution time of each test')
 parser.add_argument('--list', action='store_true', help='Print the list of tests to run')
-parser.add_argument('--print-interval', action='store', help='Prints "Still running..." every N seconds', default=300.0, type=float)
+parser.add_argument(
+    '--print-interval', action='store', help='Prints "Still running..." every N seconds', default=300.0, type=float
+)
 parser.add_argument(
     '--timeout',
     action='store',
@@ -102,6 +104,7 @@ def parse_assertions(stdout):
 
 is_active = False
 
+
 def print_interval_background(interval):
     global is_active
     current_ticker = 0.0
@@ -111,6 +114,7 @@ def print_interval_background(interval):
         if current_ticker >= interval:
             print("Still running...")
             current_ticker = 0
+
 
 for test_number, test_case in enumerate(test_cases):
     if not profile:

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -1,6 +1,7 @@
 import sys
 import subprocess
 import time
+import threading
 
 import argparse
 
@@ -22,6 +23,7 @@ parser.add_argument('--profile', action='store_true', help='Enable profiling')
 parser.add_argument('--no-assertions', action='store_false', help='Disable assertions')
 parser.add_argument('--time_execution', action='store_true', help='Measure and print the execution time of each test')
 parser.add_argument('--list', action='store_true', help='Print the list of tests to run')
+parser.add_argument('--print-interval', action='store', help='Prints "Still running..." every N seconds', default=300.0, type=float)
 parser.add_argument(
     '--timeout',
     action='store',
@@ -98,9 +100,27 @@ def parse_assertions(stdout):
     return "ERROR"
 
 
+is_active = False
+
+def print_interval_background(interval):
+    global is_active
+    current_ticker = 0.0
+    while is_active:
+        time.sleep(0.1)
+        current_ticker += 0.1
+        if current_ticker >= interval:
+            print("Still running...")
+            current_ticker = 0
+
 for test_number, test_case in enumerate(test_cases):
     if not profile:
         print(f"[{test_number}/{test_count}]: {test_case}", end="", flush=True)
+
+    # start the background thread
+    is_active = True
+    background_print_thread = threading.Thread(target=print_interval_background, args=[args.print_interval])
+    background_print_thread.start()
+
     start = time.time()
     try:
         res = subprocess.run(
@@ -114,6 +134,10 @@ for test_number, test_case in enumerate(test_cases):
     stdout = res.stdout.decode('utf8')
     stderr = res.stderr.decode('utf8')
     end = time.time()
+
+    # joint he background print thread
+    is_active = False
+    background_print_thread.join()
 
     additional_data = ""
     if assertions:

--- a/test/sql/attach/attach_huggingface_index.test
+++ b/test/sql/attach/attach_huggingface_index.test
@@ -7,6 +7,8 @@ require skip_reload
 # database is written with vector size of 2048
 require vector_size 2048
 
+require block_size 262144
+
 unzip data/storage/huggingface_index.db.gz __TEST_DIR__/huggingface_index.db
 
 statement ok

--- a/test/sql/attach/attach_icu_collation.test
+++ b/test/sql/attach/attach_icu_collation.test
@@ -9,6 +9,8 @@ require no_extension_autoloading
 # database is written with vector size of 2048
 require vector_size 2048
 
+require block_size 262144
+
 unzip data/storage/german_collation.db.gz __TEST_DIR__/german_collation.db
 
 statement ok

--- a/test/sql/storage/icu_collation.test
+++ b/test/sql/storage/icu_collation.test
@@ -9,6 +9,8 @@ require no_extension_autoloading
 # database file is written with vsize = 2048
 require vector_size 2048
 
+require block_size 262144
+
 unzip data/storage/german_collation.db.gz __TEST_DIR__/icu_collation.db
 
 load __TEST_DIR__/icu_collation.db readonly

--- a/test/sql/upsert/upsert_conflict_in_different_chunk.test
+++ b/test/sql/upsert/upsert_conflict_in_different_chunk.test
@@ -17,7 +17,7 @@ statement ok
 INSERT INTO inserts VALUES (1, 'hello'), (1, 'world');
 
 # We cannot perform on-conflict handling in the same chunk. This is a known limitation.
-statement error
+statement maybe
 INSERT OR REPLACE INTO create_or_replace SELECT i, s FROM inserts;
 ----
 PRIMARY KEY or UNIQUE constraint violated

--- a/test/sql/window/test_window_fusion.test
+++ b/test/sql/window/test_window_fusion.test
@@ -82,7 +82,7 @@ select
 	l_orderkey, 
 	sum(l_extendedprice) over(), 
 from lineitem 
-order by l_partkey, l_orderkey
+order by l_partkey, l_orderkey, l_extendedprice
 ----
 29733.00	1	2883	1314442.00
 1802.00	1	5121	1314442.00
@@ -133,8 +133,8 @@ order by l_partkey, l_orderkey
 17138.00	2	46913	1314442.00
 31570.00	2	50499	1314442.00
 37884.00	2	54086	1314442.00
-26158.00	2	54436	1314442.00
 4510.00	2	54436	1314442.00
+26158.00	2	54436	1314442.00
 3608.00	2	54630	1314442.00
 41492.00	2	55136	1314442.00
 
@@ -145,7 +145,7 @@ select
 	l_orderkey, 
 	sum(l_extendedprice) over(order by l_partkey), 
 from lineitem 
-order by l_partkey, l_orderkey
+order by l_partkey, l_orderkey, l_extendedprice
 ----
 29733.00	1	2883	607274.00
 1802.00	1	5121	607274.00
@@ -196,8 +196,8 @@ order by l_partkey, l_orderkey
 17138.00	2	46913	1314442.00
 31570.00	2	50499	1314442.00
 37884.00	2	54086	1314442.00
-26158.00	2	54436	1314442.00
 4510.00	2	54436	1314442.00
+26158.00	2	54436	1314442.00
 3608.00	2	54630	1314442.00
 41492.00	2	55136	1314442.00
 
@@ -208,7 +208,7 @@ select
 	l_orderkey, 
 	sum(l_extendedprice) over(order by l_partkey, l_orderkey), 
 from lineitem 
-order by l_partkey, l_orderkey
+order by l_partkey, l_orderkey, l_extendedprice desc
 ----
 29733.00	1	2883	29733.00
 1802.00	1	5121	31535.00
@@ -271,7 +271,7 @@ select
 	l_orderkey, 
 	sum(l_extendedprice) over(order by l_partkey, l_orderkey desc), 
 from lineitem 
-order by l_partkey, l_orderkey
+order by l_partkey, l_orderkey, l_extendedprice desc
 ----
 29733.00	1	2883	607274.00
 1802.00	1	5121	577541.00
@@ -338,7 +338,7 @@ select
 	sum(l_extendedprice) over(order by l_partkey, l_orderkey), 
 	sum(l_extendedprice) over(order by l_partkey, l_orderkey desc), 
 from lineitem 
-order by l_partkey, l_orderkey
+order by l_partkey, l_orderkey, l_extendedprice desc
 ----
 29733.00	1	2883	1314442.00	607274.00	29733.00	607274.00
 1802.00	1	5121	1314442.00	607274.00	31535.00	577541.00
@@ -406,7 +406,7 @@ select
 	l_orderkey, 
 	sum(l_extendedprice) over(partition by l_partkey),
 from lineitem 
-order by l_partkey, l_orderkey
+order by l_partkey, l_orderkey, l_extendedprice desc
 ----
 29733.00	1	2883	607274.00
 1802.00	1	5121	607274.00
@@ -469,7 +469,7 @@ select
 	l_orderkey, 
 	sum(l_extendedprice) over(partition by l_partkey order by l_orderkey),
 from lineitem 
-order by l_partkey, l_orderkey
+order by l_partkey, l_orderkey, l_extendedprice desc
 ----
 29733.00	1	2883	29733.00
 1802.00	1	5121	31535.00


### PR DESCRIPTION
* For `run_tests_one_by_one.py`, add a print every `N` seconds (default 300) to prevent Github Actions from killing CI runners on slow tests
* Add `require block_size 262144` to new tests that read pre-generated database files
* Add full ordering to `test_window_fusion`
* Use `statement maybe` for upsert test - similar to what we do in `test/sql/upsert/upsert_distinct_bug.test` - upserts currently fail if there are duplicates WITHIN a vector, verification passes change the way vectors are laid out internally which then make this succeed instead
* No longer check coverage against expected coverage, instead just use the coverage run to generate coverage files we can look at