### PR TITLE
[Python] Fix issue in the SQLLogicTestRunner implementation

### DIFF
--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -779,6 +779,7 @@ class SQLLogicContext:
                 self.runner.delete_database(dbpath)
         else:
             dbpath = ""
+        self.runner.loaded_databases.add(dbpath)
 
         # set up the config file
         additional_config = {}

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -90,6 +90,10 @@ class SQLLogicTestExecutor(SQLLogicRunner):
         self.test = test
         self.original_sqlite_test = self.test.is_sqlite_test()
 
+        test_directory = TEST_DIRECTORY_PATH
+        if os.path.exists(test_directory):
+            shutil.rmtree(test_directory, ignore_errors=True)
+
         # Top level keywords
         keywords = {'__TEST_DIR__': self.get_test_directory(), '__WORKING_DIRECTORY__': os.getcwd()}
 

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -90,10 +90,6 @@ class SQLLogicTestExecutor(SQLLogicRunner):
         self.test = test
         self.original_sqlite_test = self.test.is_sqlite_test()
 
-        test_directory = TEST_DIRECTORY_PATH
-        if os.path.exists(test_directory):
-            shutil.rmtree(test_directory, ignore_errors=True)
-
         # Top level keywords
         keywords = {'__TEST_DIR__': self.get_test_directory(), '__WORKING_DIRECTORY__': os.getcwd()}
 
@@ -165,6 +161,8 @@ def main():
         file_paths = [os.path.relpath(path, test_directory) for path in file_paths]
 
     start_offset = args.start_offset
+
+    file_paths = ['test/sql/attach/attach_wal_alter.test', 'test/fuzzer/pedro/pushdown_error.test']
 
     total_tests = len(file_paths)
     for i, file_path in enumerate(file_paths):

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -162,8 +162,6 @@ def main():
 
     start_offset = args.start_offset
 
-    file_paths = ['test/sql/attach/attach_wal_alter.test', 'test/fuzzer/pedro/pushdown_error.test']
-
     total_tests = len(file_paths)
     for i, file_path in enumerate(file_paths):
         if file_path in executor.SKIPPED_TESTS:


### PR DESCRIPTION
This PR fixes an issue we caught internally

The cause of this issue is:
```
'__TEST_DIR__/wal_crash.db'
```

Both these tests create this file
`test/sql/attach/attach_wal_alter.test`
`test/fuzzer/pedro/pushdown_error.test`

One of them is created with LOAD so the runner is aware and can delete the file afterwards.
That does highlight a future problem though:

If both of these were created with ATTACH, the runner would have no idea and can't clean up the db files after the test completes.
Leaving the side effects of the test, which could have impact on another test

