### PR TITLE
[Dev] `enable_verification` now serializes for compatibility version `'latest'`

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -93,6 +93,7 @@ class SerializationCompatibility {
 public:
 	static SerializationCompatibility FromString(const string &input);
 	static SerializationCompatibility Default();
+	static SerializationCompatibility Latest();
 
 public:
 	bool Compare(idx_t property_version) const;
@@ -102,6 +103,8 @@ public:
 	string duckdb_version;
 	//! The max version that should be serialized
 	idx_t serialization_version;
+	//! Whether this was set by a manual SET/PRAGMA or default
+	bool manually_set;
 
 protected:
 	SerializationCompatibility() = default;

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -494,15 +494,26 @@ SerializationCompatibility SerializationCompatibility::FromString(const string &
 	SerializationCompatibility result;
 	result.duckdb_version = input;
 	result.serialization_version = serialization_version.GetIndex();
+	result.manually_set = true;
 	return result;
 }
 
 SerializationCompatibility SerializationCompatibility::Default() {
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
-	return FromString("latest");
+	auto res = FromString("latest");
+	res.manually_set = false;
+	return res;
 #else
-	return FromString("v0.10.2");
+	auto res = FromString("v0.10.2");
+	res.manually_set = false;
+	return res;
 #endif
+}
+
+SerializationCompatibility SerializationCompatibility::Latest() {
+	auto res = FromString("latest");
+	res.manually_set = false;
+	return res;
 }
 
 bool SerializationCompatibility::Compare(idx_t property_version) const {

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -158,9 +158,20 @@ static bool OperatorSupportsSerialization(LogicalOperator &op) {
 
 void Planner::VerifyPlan(ClientContext &context, unique_ptr<LogicalOperator> &op,
                          optional_ptr<bound_parameter_map_t> map) {
+	auto &config = DBConfig::GetConfig(context);
 #ifdef DUCKDB_ALTERNATIVE_VERIFY
-	// if alternate verification is enabled we run the original operator
-	return;
+	{
+		auto &serialize_comp = config.options.serialization_compatibility;
+		auto latest_version = SerializationCompatibility::Latest();
+		if (serialize_comp.manually_set &&
+		    serialize_comp.serialization_version != latest_version.serialization_version) {
+			// Serialization should not be skipped, this test relies on the serialization to remove certain fields for
+			// compatibility with older versions. This might change behavior, not doing this might make this test fail.
+		} else {
+			// if alternate verification is enabled we run the original operator
+			return;
+		}
+	}
 #endif
 	if (!op || !ClientConfig::GetConfig(context).verify_serializer) {
 		return;
@@ -175,9 +186,15 @@ void Planner::VerifyPlan(ClientContext &context, unique_ptr<LogicalOperator> &op
 	// format (de)serialization of this operator
 	try {
 		MemoryStream stream;
-		auto &config = DBConfig::GetConfig(context);
+
 		SerializationOptions options;
-		options.serialization_compatibility = config.options.serialization_compatibility;
+		if (config.options.serialization_compatibility.manually_set) {
+			// Override the default of 'latest' if this was manually set (for testing, mostly)
+			options.serialization_compatibility = config.options.serialization_compatibility;
+		} else {
+			options.serialization_compatibility = SerializationCompatibility::Latest();
+		}
+
 		BinarySerializer::Serialize(*op, stream, options);
 		stream.Rewind();
 		bound_parameter_map_t parameters;


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2076

`enable_verification` turns on `verify_serializer`, which serializes+deserializes the plan before execution.
This uses the same `storage_compatibility_version` as checkpointing, which is `v0.10.2`.
That changes behavior, because we deliberately lose data when we serialize for 0.10.2, so it can be read by an older version.

`ALTERNATIVE_VERIFY` causes the serialization+deserialization to be skipped entirely in VerifyPlan.
That results in tests that are marked with a `storage_compatibility_version` that is not `'latest'` to have different behavior if that compile flag was set.

### Behavior changes

`VerifyPlan` now uses `'latest'` `storage_compatibility_version` unless it was manually set:
```
statement ok
set storage_compatibility_version='v0.10.2'
```

`ALTERNATIVE_VERIFY` does not skip serialization+deserialization anymore in `VerifyPlan` if the `storage_compatibility_version` was manually set to a version that is not `'latest'`, so the behavior is now the same as without `ALTERNATIVE_VERIFY` for those tests.