### PR TITLE
Fixing unchecked malloc() calls in Parser and elsewhere

### DIFF
--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -173,7 +173,11 @@ data_ptr_t Allocator::DefaultAllocate(PrivateAllocatorData *private_data, idx_t 
 #ifdef USE_JEMALLOC
 	return JemallocExtension::Allocate(private_data, size);
 #else
-	return data_ptr_cast(malloc(size));
+	auto default_allocate_result = malloc(size);
+	if (!default_allocate_result) {
+		throw std::bad_alloc();
+	}
+	return data_ptr_cast(default_allocate_result);
 #endif
 }
 

--- a/src/common/serializer/memory_stream.cpp
+++ b/src/common/serializer/memory_stream.cpp
@@ -2,8 +2,12 @@
 
 namespace duckdb {
 
-MemoryStream::MemoryStream(idx_t capacity)
-    : position(0), capacity(capacity), owns_data(true), data(static_cast<data_ptr_t>(malloc(capacity))) {
+MemoryStream::MemoryStream(idx_t capacity) : position(0), capacity(capacity), owns_data(true) {
+	auto data_malloc_result = malloc(capacity);
+	if (!data_malloc_result) {
+		throw std::bad_alloc();
+	}
+	data = static_cast<data_ptr_t>(data_malloc_result);
 }
 
 MemoryStream::MemoryStream(data_ptr_t buffer, idx_t capacity)
@@ -25,7 +29,6 @@ void MemoryStream::WriteData(const_data_ptr_t source, idx_t write_size) {
 			throw SerializationException("Failed to serialize: not enough space in buffer to fulfill write request");
 		}
 	}
-
 	memcpy(data + position, source, write_size);
 	position += write_size;
 }


### PR DESCRIPTION
long-standing item from back of my mind - found using malloc failure testing, which we should build out more.