### PR TITLE
[Relation] Disable creating a VIEW from a MaterializedRelation

### DIFF
--- a/src/main/relation/create_view_relation.cpp
+++ b/src/main/relation/create_view_relation.cpp
@@ -9,6 +9,9 @@ CreateViewRelation::CreateViewRelation(shared_ptr<Relation> child_p, string view
                                        bool temporary_p)
     : Relation(child_p->context, RelationType::CREATE_VIEW_RELATION), child(std::move(child_p)),
       view_name(std::move(view_name_p)), replace(replace_p), temporary(temporary_p) {
+	if (child->type == RelationType::MATERIALIZED_RELATION) {
+		throw NotImplementedException("Creating a VIEW from a MaterializedRelation is not supported");
+	}
 	context.GetContext()->TryBindRelation(*this, this->columns);
 }
 
@@ -17,6 +20,9 @@ CreateViewRelation::CreateViewRelation(shared_ptr<Relation> child_p, string sche
     : Relation(child_p->context, RelationType::CREATE_VIEW_RELATION), child(std::move(child_p)),
       schema_name(std::move(schema_name_p)), view_name(std::move(view_name_p)), replace(replace_p),
       temporary(temporary_p) {
+	if (child->type == RelationType::MATERIALIZED_RELATION) {
+		throw NotImplementedException("Creating a VIEW from a MaterializedRelation is not supported");
+	}
 	context.GetContext()->TryBindRelation(*this, this->columns);
 }
 

--- a/src/main/relation/materialized_relation.cpp
+++ b/src/main/relation/materialized_relation.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/operator/logical_column_data_get.hpp"
 #include "duckdb/parser/tableref/column_data_ref.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/common/exception.hpp"
 
 namespace duckdb {
 

--- a/tools/pythonpkg/tests/fast/test_relation.py
+++ b/tools/pythonpkg/tests/fast/test_relation.py
@@ -466,8 +466,11 @@ class TestRelation(object):
         ):
             rel.insert([1, 2, 3, 4])
 
-        query_rel = rel.query('x', "select 42 from x where column0 != 42")
-        assert query_rel.fetchall() == []
+        with pytest.raises(
+            duckdb.NotImplementedException, match='Creating a VIEW from a MaterializedRelation is not supported'
+        ):
+            query_rel = rel.query('x', "select 42 from x where column0 != 42")
+            assert query_rel.fetchall() == []
 
         distinct_rel = rel.distinct()
         assert distinct_rel.fetchall() == [(42, 'test', 'this is a long string', True)]
@@ -517,3 +520,18 @@ class TestRelation(object):
         intersect_rel = unioned_rel.intersect(materialized_one).order('range')
         res = intersect_rel.fetchall()
         assert res == [('0',), ('1',), ('2',), ('3',), ('4',), ('5',), ('6',), ('7',), ('8',), ('9',)]
+
+    def test_materialized_relation_view(self, duckdb_cursor):
+        with pytest.raises(
+            duckdb.NotImplementedException, match='Creating a VIEW from a MaterializedRelation is not supported'
+        ):
+            duckdb_cursor.sql(
+                """
+                create table tbl(a varchar);
+                insert into tbl values ('test');
+                SELECT
+                    *
+                FROM tbl
+            """
+            ).to_view('vw')
+            res = duckdb_cursor.sql("select * from vw").fetchone()


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb/issues/11927

The MaterializedRelation, introduced by https://github.com/duckdb/duckdb/pull/11835 is a bit of a special case, because unlike other relations, it doesn't contain parsed sql to be executed, it contains the data directly.

It creates ColumnDataRef TableRefs when queried, these objects rely on the ColumnDataCollection, which is owned by the MaterializedRelation, to stay alive during execution.

When a VIEW is created from a Relation, the QueryNode (containing the TableRef) is copied, losing this guarantee.
In the future we'll probably apply a fix to this adding a dependency on the MaterializedRelation so the VIEW will keep the data it relies on alive.

For now we opt to disable it because the reproduction is quite easy to hit

### Internals

`SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(view_catalog_entry.query->Copy()));` causes `ColumnDataRef::Copy` to get hit, because the `optionally_owned_ptr` in the original is non-owning, the copy is *also* non-owning.
But it looks like later on the ColumnDataCollection referenced by the ColumnDataRef copy is entirely empty, it does not crash so it doesn't look like a heap-use-after-free but the column data collection still got cleaned up somehow