### PR TITLE
small fix to extension origin checks and direct installing over http

### DIFF
--- a/test/extension/update_extensions_ci.test
+++ b/test/extension/update_extensions_ci.test
@@ -37,6 +37,9 @@ require-env LOCAL_EXTENSION_DIR_INFO_INCORRECT_VERSION
 # Address on a minio server that has the LOCAL_EXTENSION_REPO_UPDATED copied to it
 require-env REMOTE_EXTENSION_REPO_UPDATED
 
+# Direct path with version and platform, for testing http direct install
+require-env REMOTE_EXTENSION_REPO_DIRECT_PATH
+
 # Parquet is statically loaded for this test
 require parquet
 
@@ -237,34 +240,6 @@ FORCE INSTALL '${DIRECT_INSTALL_DIR}/json.duckdb_extension';
 ----
 Also, the file was built for the platform 'test_platform', but we can only load extensions built for platform
 
-# Now we allow mismatching metadata
-statement ok
-set allow_extensions_metadata_mismatch=true;
-
-# Meaning that now it works
-statement ok
-FORCE INSTALL '${DIRECT_INSTALL_DIR}/json.duckdb_extension';
-
-# We can even load it
-statement ok
-LOAD json;
-
-restart
-
-# However, when signed unsigned extensions are not allowed, things are different
-statement ok
-set allow_unsigned_extensions=false
-
-# Installing is still fine
-statement ok
-FORCE INSTALL '${DIRECT_INSTALL_DIR}/json.duckdb_extension';
-
-# But loading is not
-statement error
-LOAD json;
-----
- Also, the file was built for the platform 'test_platform', but we can only load extensions built for platform
-
 restart
 
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
@@ -294,3 +269,89 @@ query IIIII
 UPDATE EXTENSIONS
 ----
 inet	http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo	NO_UPDATE_AVAILABLE	v0.0.2	v0.0.2
+
+# Rerunning install with matching origin is a NOP and totally fine
+statement ok
+install inet from '${REMOTE_EXTENSION_REPO_UPDATED}'
+
+# Direct installing the same extension is now not allowed
+statement error
+install '${REMOTE_EXTENSION_REPO_DIRECT_PATH}/inet.duckdb_extension.gz'
+----
+Invalid Input Error: Installing extension 'inet' failed. The extension is already installed but the origin is different.
+Currently installed extension is from repository 'http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo', while the extension to be installed is from custom_path
+
+# Installing the same extension from a different repository is also not allowed
+statement error
+install '${REMOTE_EXTENSION_REPO_DIRECT_PATH}/inet.duckdb_extension.gz' FROM './dummy_repo'
+----
+Invalid Input Error: Installing extension 'inet' failed. The extension is already installed but the origin is different.
+Currently installed extension is from repository 'http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo', while the extension to be installed is from repository './dummy_repo'.
+To solve this rerun this command with `FORCE INSTALL`
+
+# We can circumvent this by disabling metadata checks
+statement ok
+set allow_extensions_metadata_mismatch=true;
+
+# Note that this is a NOP
+statement ok
+install '${REMOTE_EXTENSION_REPO_DIRECT_PATH}/inet.duckdb_extension.gz'
+
+# inet still the same
+query IIII
+SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where installed and extension_name != 'jemalloc' and extension_name != 'parquet'
+----
+inet	REPOSITORY	http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo	v0.0.2
+
+# now we force install to override
+statement ok
+force install '${REMOTE_EXTENSION_REPO_DIRECT_PATH}/inet.duckdb_extension.gz'
+
+# inet is now from a custom path
+query IIII
+SELECT extension_name, install_mode, parse_filename(installed_from), extension_version FROM duckdb_extensions() where installed and extension_name != 'jemalloc' and extension_name != 'parquet'
+----
+inet	CUSTOM_PATH	inet.duckdb_extension.gz	v0.0.2
+
+# Other way around is fine and still a nop for now
+statement ok
+install inet from '${REMOTE_EXTENSION_REPO_UPDATED}'
+
+query IIII
+SELECT extension_name, install_mode, parse_filename(installed_from), extension_version FROM duckdb_extensions() where installed and extension_name != 'jemalloc' and extension_name != 'parquet'
+----
+inet	CUSTOM_PATH	inet.duckdb_extension.gz	v0.0.2
+
+### Tests with allow_unsigned extensions = false
+restart
+
+statement ok
+set extension_directory='${LOCAL_EXTENSION_DIR}'
+
+# Now we allow mismatching metadata
+statement ok
+set allow_extensions_metadata_mismatch=true;
+
+# Meaning that now it works
+statement ok
+FORCE INSTALL '${DIRECT_INSTALL_DIR}/json.duckdb_extension';
+
+# We can even load it
+statement ok
+LOAD json;
+
+restart
+
+# However, when signed unsigned extensions are not allowed, things are different
+statement ok
+set allow_unsigned_extensions=false
+
+# Installing is still fine
+statement ok
+FORCE INSTALL '${DIRECT_INSTALL_DIR}/json.duckdb_extension';
+
+# But loading is not
+statement error
+LOAD json;
+----
+ Also, the file was built for the platform 'test_platform', but we can only load extensions built for platform


### PR DESCRIPTION
This fixes:
- direct install from http path would crash due to optional pointer not being checked
- small improvement to origin check on installing extensions (where we throw if the origin of an extension is different from the one already installed)
    - allow circumventing check with `allow_extensions_metadata_mismatch`
    - also check when overriding repository with custom path

note that there are more checks possible: but i've left those to future work.