### PR TITLE
[CSV Reader] Bug-fix related to skip parameter over vector size in the sniffer

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
@@ -60,7 +60,7 @@ CSVIterator &BaseScanner::GetIterator() {
 	return iterator;
 }
 
-void BaseScanner::SetIterator(const CSVIterator &it){
+void BaseScanner::SetIterator(const CSVIterator &it) {
 	iterator = it;
 }
 

--- a/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
@@ -41,9 +41,7 @@ bool BaseScanner::FinishedFile() {
 	return iterator.pos.buffer_pos + 1 == cur_buffer_handle->actual_size;
 }
 
-void BaseScanner::SkipCSVRows() {
-	idx_t rows_to_skip =
-	    state_machine->dialect_options.skip_rows.GetValue() + state_machine->dialect_options.header.GetValue();
+void BaseScanner::SkipCSVRows(idx_t rows_to_skip) {
 	if (rows_to_skip == 0) {
 		return;
 	}
@@ -65,6 +63,10 @@ void BaseScanner::Reset() {
 
 CSVIterator &BaseScanner::GetIterator() {
 	return iterator;
+}
+
+void BaseScanner::SetIterator(const CSVIterator &it){
+	iterator = it;
 }
 
 ScannerResult &BaseScanner::ParseChunk() {

--- a/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
@@ -1,5 +1,7 @@
-#include "duckdb/execution/operator/csv_scanner/csv_sniffer.hpp"
 #include "duckdb/execution/operator/csv_scanner/base_scanner.hpp"
+
+#include "duckdb/execution/operator/csv_scanner/csv_sniffer.hpp"
+#include "duckdb/execution/operator/csv_scanner/skip_scanner.hpp"
 
 namespace duckdb {
 
@@ -37,6 +39,23 @@ bool BaseScanner::FinishedFile() {
 	}
 	// If yes, are we in the last position?
 	return iterator.pos.buffer_pos + 1 == cur_buffer_handle->actual_size;
+}
+
+void BaseScanner::SkipCSVRows() {
+	idx_t rows_to_skip =
+	    state_machine->dialect_options.skip_rows.GetValue() + state_machine->dialect_options.header.GetValue();
+	if (rows_to_skip == 0) {
+		return;
+	}
+	SkipScanner row_skipper(buffer_manager, state_machine, error_handler, rows_to_skip);
+	row_skipper.ParseChunk();
+	iterator.pos.buffer_pos = row_skipper.GetIteratorPosition();
+	if (row_skipper.state_machine->options.dialect_options.state_machine_options.new_line ==
+	        NewLineIdentifier::CARRY_ON &&
+	    row_skipper.states.states[1] == CSVState::CARRIAGE_RETURN) {
+		iterator.pos.buffer_pos++;
+	}
+	lines_read += row_skipper.GetLinesRead();
 }
 
 void BaseScanner::Reset() {

--- a/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/base_scanner.cpp
@@ -56,11 +56,6 @@ void BaseScanner::SkipCSVRows(idx_t rows_to_skip) {
 	lines_read += row_skipper.GetLinesRead();
 }
 
-void BaseScanner::Reset() {
-	iterator.SetCurrentPositionToBoundary();
-	lines_read = 0;
-}
-
 CSVIterator &BaseScanner::GetIterator() {
 	return iterator;
 }

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1291,7 +1291,7 @@ void StringValueScanner::SetStart() {
 		// This CSV is not from auto-detect, so we don't know where exactly it starts
 		// Hence we potentially have to skip empty lines and headers.
 		SkipBOM();
-		SkipCSVRows();
+		SkipCSVRows(state_machine->dialect_options.skip_rows.GetValue() + state_machine->dialect_options.header.GetValue());
 		if (result.store_line_size) {
 			result.error_handler.NewMaxLineSize(iterator.pos.buffer_pos);
 		}

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1291,7 +1291,8 @@ void StringValueScanner::SetStart() {
 		// This CSV is not from auto-detect, so we don't know where exactly it starts
 		// Hence we potentially have to skip empty lines and headers.
 		SkipBOM();
-		SkipCSVRows(state_machine->dialect_options.skip_rows.GetValue() + state_machine->dialect_options.header.GetValue());
+		SkipCSVRows(state_machine->dialect_options.skip_rows.GetValue() +
+		            state_machine->dialect_options.header.GetValue());
 		if (result.store_line_size) {
 			result.error_handler.NewMaxLineSize(iterator.pos.buffer_pos);
 		}

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1231,26 +1231,6 @@ void StringValueScanner::SkipBOM() {
 	}
 }
 
-void StringValueScanner::SkipCSVRows() {
-	idx_t rows_to_skip =
-	    state_machine->dialect_options.skip_rows.GetValue() + state_machine->dialect_options.header.GetValue();
-	if (rows_to_skip == 0) {
-		return;
-	}
-	SkipScanner row_skipper(buffer_manager, state_machine, error_handler, rows_to_skip);
-	row_skipper.ParseChunk();
-	iterator.pos.buffer_pos = row_skipper.GetIteratorPosition();
-	if (row_skipper.state_machine->options.dialect_options.state_machine_options.new_line ==
-	        NewLineIdentifier::CARRY_ON &&
-	    row_skipper.states.states[1] == CSVState::CARRIAGE_RETURN) {
-		iterator.pos.buffer_pos++;
-	}
-	if (result.store_line_size) {
-		result.error_handler.NewMaxLineSize(iterator.pos.buffer_pos);
-	}
-	lines_read += row_skipper.GetLinesRead();
-}
-
 void StringValueScanner::SkipUntilNewLine() {
 	// Now skip until next newline
 	if (state_machine->options.dialect_options.state_machine_options.new_line.GetValue() ==
@@ -1312,6 +1292,9 @@ void StringValueScanner::SetStart() {
 		// Hence we potentially have to skip empty lines and headers.
 		SkipBOM();
 		SkipCSVRows();
+		if (result.store_line_size) {
+			result.error_handler.NewMaxLineSize(iterator.pos.buffer_pos);
+		}
 		return;
 	}
 	// We have to look for a new line that fits our schema

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -90,13 +90,13 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
                                          idx_t &best_consistent_rows, idx_t &prev_padding_count) {
 	// The sniffed_column_counts variable keeps track of the number of columns found for each row
 	auto &sniffed_column_counts = scanner->ParseChunk();
+	idx_t dirty_notes = 0;
 	if (sniffed_column_counts.error) {
 		// This candidate has an error (i.e., over maximum line size or never unquoting quoted values)
 		return;
 	}
-	idx_t start_row = options.dialect_options.skip_rows.GetValue();
 	idx_t consistent_rows = 0;
-	idx_t num_cols = sniffed_column_counts.result_position == 0 ? 1 : sniffed_column_counts[start_row];
+	idx_t num_cols = sniffed_column_counts.result_position == 0 ? 1 : sniffed_column_counts[0];
 	idx_t padding_count = 0;
 	bool allow_padding = options.null_padding;
 	if (sniffed_column_counts.result_position > rows_read) {
@@ -107,7 +107,7 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 		// Not acceptable
 		return;
 	}
-	for (idx_t row = start_row; row < sniffed_column_counts.result_position; row++) {
+	for (idx_t row = 0; row < sniffed_column_counts.result_position; row++) {
 		if (set_columns.IsCandidateUnacceptable(sniffed_column_counts[row], options.null_padding,
 		                                        options.ignore_errors.GetValue(),
 		                                        sniffed_column_counts.last_value_always_empty)) {
@@ -122,7 +122,7 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 			padding_count = 0;
 			// we use the maximum amount of num_cols that we find
 			num_cols = sniffed_column_counts[row];
-			start_row = row;
+			dirty_notes = row;
 			consistent_rows = 1;
 
 		} else if (num_cols >= sniffed_column_counts[row]) {
@@ -148,7 +148,7 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 
 	// If the number of rows is consistent with the calculated value after accounting for skipped rows and the
 	// start row.
-	bool rows_consistent = consistent_rows + (start_row - options.dialect_options.skip_rows.GetValue()) ==
+	bool rows_consistent = consistent_rows + (dirty_notes - options.dialect_options.skip_rows.GetValue()) ==
 	                       sniffed_column_counts.result_position - options.dialect_options.skip_rows.GetValue();
 	// If there are more than one consistent row.
 	bool more_than_one_row = (consistent_rows > 1);
@@ -158,7 +158,7 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 
 	// If the start position is valid.
 	bool start_good = !candidates.empty() &&
-	                  (start_row <= candidates.front()->GetStateMachine().dialect_options.skip_rows.GetValue());
+	                  (dirty_notes <= candidates.front()->GetStateMachine().dialect_options.skip_rows.GetValue());
 
 	// If padding happened but it is not allowed.
 	bool invalid_padding = !allow_padding && padding_count > 0;
@@ -186,8 +186,12 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 		best_consistent_rows = consistent_rows;
 		max_columns_found = num_cols;
 		prev_padding_count = padding_count;
+		if (dirty_notes != 0 && options.dialect_options.skip_rows.IsSetByUser()){
+			// If skip rows is set by user and we found dirty notes, this is not a suitable candidate
+			return;
+		}
 		if (!options.null_padding && !options.ignore_errors.GetValue()) {
-			sniffing_state_machine.dialect_options.skip_rows = start_row;
+			sniffing_state_machine.dialect_options.skip_rows = dirty_notes;
 		} else {
 			sniffing_state_machine.dialect_options.skip_rows = options.dialect_options.skip_rows.GetValue();
 		}
@@ -212,7 +216,7 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 		}
 		if (!same_quote_is_candidate) {
 			if (!options.null_padding && !options.ignore_errors.GetValue()) {
-				sniffing_state_machine.dialect_options.skip_rows = start_row;
+				sniffing_state_machine.dialect_options.skip_rows = dirty_notes;
 			} else {
 				sniffing_state_machine.dialect_options.skip_rows = options.dialect_options.skip_rows.GetValue();
 			}
@@ -307,9 +311,21 @@ NewLineIdentifier CSVSniffer::DetectNewLineDelimiter(CSVBufferManager &buffer_ma
 	return NewLineIdentifier::SINGLE;
 }
 
-void CSVSniffer::SkipLines(ColumnCountScanner &first_scanner){
-	if (options.dialect_options.skip_rows.IsSetByUser()){
+void CSVSniffer::SkipLines(vector<unique_ptr<ColumnCountScanner>> &csv_state_machines){
+	if(csv_state_machines.empty()){
 		return;
+	}
+	auto &first_scanner = *csv_state_machines[0];
+	// We figure out the iterator position for the first scanner
+	if (options.dialect_options.skip_rows.IsSetByUser()){
+		first_scanner.SkipCSVRows(options.dialect_options.skip_rows.GetValue());
+	}
+	// The iterator position is the same regardless of the scanner configuration, hence we apply the same iterator
+	// To the remaining scanners
+	const auto first_iterator = first_scanner.GetIterator();
+	for (idx_t i = 1; i < csv_state_machines.size(); i++){
+		auto& cur_scanner = *csv_state_machines[i];
+		cur_scanner.SetIterator(first_iterator);
 	}
 }
 
@@ -346,10 +362,9 @@ void CSVSniffer::DetectDialect() {
 	// Step 2: Generate state machines
 	GenerateStateMachineSearchSpace(csv_state_machines, delim_candidates, quoterule_candidates, quote_candidates_map,
 	                                escape_candidates_map);
+	SkipLines(csv_state_machines);
 	// Step 3: Analyze all candidates on the first chunk
 	for (auto &state_machine : csv_state_machines) {
-//		state_machine->RefineCandidateNextChunkeset();
-
 		AnalyzeDialectCandidate(std::move(state_machine), rows_read, best_consistent_rows, prev_padding_count);
 	}
 	// Step 4: Loop over candidates and find if they can still produce good results for the remaining chunks

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -307,6 +307,12 @@ NewLineIdentifier CSVSniffer::DetectNewLineDelimiter(CSVBufferManager &buffer_ma
 	return NewLineIdentifier::SINGLE;
 }
 
+void CSVSniffer::SkipLines(ColumnCountScanner &first_scanner){
+	if (options.dialect_options.skip_rows.IsSetByUser()){
+		return;
+	}
+}
+
 // Dialect Detection consists of five steps:
 // 1. Generate a search space of all possible dialects
 // 2. Generate a state machine for each dialect
@@ -342,7 +348,8 @@ void CSVSniffer::DetectDialect() {
 	                                escape_candidates_map);
 	// Step 3: Analyze all candidates on the first chunk
 	for (auto &state_machine : csv_state_machines) {
-		state_machine->Reset();
+//		state_machine->RefineCandidateNextChunkeset();
+
 		AnalyzeDialectCandidate(std::move(state_machine), rows_read, best_consistent_rows, prev_padding_count);
 	}
 	// Step 4: Loop over candidates and find if they can still produce good results for the remaining chunks

--- a/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
@@ -414,8 +414,7 @@ void CSVSniffer::DetectTypes() {
 		// it's good if the dialect creates more non-varchar columns, but only if we sacrifice < 30% of
 		// best_num_cols.
 		if (varchar_cols<min_varchar_cols &&static_cast<double>(info_sql_types_candidates.size())>(
-		        static_cast<double>(max_columns_found) *
-		                                                                                           0.7) &&
+		        static_cast<double>(max_columns_found) * 0.7) &&
 		    (!options.ignore_errors.GetValue() || candidate->error_handler->errors.size() < min_errors)) {
 			min_errors = candidate->error_handler->errors.size();
 			best_header_row.clear();

--- a/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
@@ -413,7 +413,8 @@ void CSVSniffer::DetectTypes() {
 
 		// it's good if the dialect creates more non-varchar columns, but only if we sacrifice < 30% of
 		// best_num_cols.
-		if (varchar_cols<min_varchar_cols &&static_cast<double>(info_sql_types_candidates.size())>(max_columns_found *
+		if (varchar_cols<min_varchar_cols &&static_cast<double>(info_sql_types_candidates.size())>(
+		        static_cast<double>(max_columns_found) *
 		                                                                                           0.7) &&
 		    (!options.ignore_errors.GetValue() || candidate->error_handler->errors.size() < min_errors)) {
 			min_errors = candidate->error_handler->errors.size();

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -94,7 +94,7 @@ int64_t CSVReaderOptions::GetSkipRows() const {
 }
 
 void CSVReaderOptions::SetSkipRows(int64_t skip_rows) {
-	if (skip_rows < 0){
+	if (skip_rows < 0) {
 		throw InvalidInputException("skip_rows option from read_csv scanner, must be equal or higher than 0");
 	}
 	dialect_options.skip_rows.Set(NumericCast<idx_t>(skip_rows));

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -94,6 +94,9 @@ int64_t CSVReaderOptions::GetSkipRows() const {
 }
 
 void CSVReaderOptions::SetSkipRows(int64_t skip_rows) {
+	if (skip_rows < 0){
+		throw InvalidInputException("skip_rows option from read_csv scanner, must be equal or higher than 0");
+	}
 	dialect_options.skip_rows.Set(NumericCast<idx_t>(skip_rows));
 }
 

--- a/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
@@ -116,6 +116,9 @@ protected:
 	//! Initializes the scanner
 	virtual void Initialize();
 
+	//! Skips Notes, notes are dirty lines on top of the file, before the actual data
+	void SkipCSVRows();
+
 	inline bool ContainsZeroByte(uint64_t v) {
 		return (v - UINT64_C(0x0101010101010101)) & ~(v)&UINT64_C(0x8080808080808080);
 	}

--- a/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
@@ -99,7 +99,6 @@ public:
 	//! notes are dirty lines on top of the file, before the actual data
 	void SkipCSVRows(idx_t rows_to_skip);
 
-
 protected:
 	//! Boundaries of this scanner
 	CSVIterator iterator;

--- a/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
@@ -52,10 +52,10 @@ public:
 	                     shared_ptr<CSVFileScan> csv_file_scan = nullptr, CSVIterator iterator = {});
 
 	virtual ~BaseScanner() = default;
+
 	//! Returns true if the scanner is finished
 	bool FinishedFile();
-	//! Resets the scanner
-	void Reset();
+
 	//! Parses data into a output_chunk
 	virtual ScannerResult &ParseChunk();
 

--- a/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
@@ -64,6 +64,8 @@ public:
 
 	CSVIterator &GetIterator();
 
+	void SetIterator(const CSVIterator &it);
+
 	idx_t GetBoundaryIndex() {
 		return iterator.GetBoundaryIdx();
 	}
@@ -93,6 +95,11 @@ public:
 
 	bool ever_quoted = false;
 
+	//! Skips Notes and/or parts of the data, starting from the top.
+	//! notes are dirty lines on top of the file, before the actual data
+	void SkipCSVRows(idx_t rows_to_skip);
+
+
 protected:
 	//! Boundaries of this scanner
 	CSVIterator iterator;
@@ -115,9 +122,6 @@ protected:
 	//! Internal Functions used to perform the parsing
 	//! Initializes the scanner
 	virtual void Initialize();
-
-	//! Skips Notes, notes are dirty lines on top of the file, before the actual data
-	void SkipCSVRows();
 
 	inline bool ContainsZeroByte(uint64_t v) {
 		return (v - UINT64_C(0x0101010101010101)) & ~(v)&UINT64_C(0x8080808080808080);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
@@ -139,6 +139,10 @@ private:
 	                                     const vector<QuoteRule> &quoterule_candidates,
 	                                     const unordered_map<uint8_t, vector<char>> &quote_candidates_map,
 	                                     const unordered_map<uint8_t, vector<char>> &escape_candidates_map);
+	//! 2.1 If the user set a number of lines to skip, make sure we skip them
+	//! We skip from the first scanner and then apply information on the remaining scanners.
+	void SkipLines(ColumnCountScanner &first_scanner);
+
 	//! 3. Analyzes if dialect candidate is a good candidate to be considered, if so, it adds it to the candidates
 	void AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner>, idx_t &rows_read, idx_t &best_consistent_rows,
 	                             idx_t &prev_padding_count);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
@@ -141,7 +141,7 @@ private:
 	                                     const unordered_map<uint8_t, vector<char>> &escape_candidates_map);
 	//! 2.1 If the user set a number of lines to skip, make sure we skip them
 	//! We skip from the first scanner and then apply information on the remaining scanners.
-	void SkipLines(ColumnCountScanner &first_scanner);
+	void SkipLines(vector<unique_ptr<ColumnCountScanner>> &csv_state_machines);
 
 	//! 3. Analyzes if dialect candidate is a good candidate to be considered, if so, it adds it to the candidates
 	void AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner>, idx_t &rows_read, idx_t &best_consistent_rows,

--- a/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/string_value_scanner.hpp
@@ -297,9 +297,6 @@ private:
 	//! BOM skipping (https://en.wikipedia.org/wiki/Byte_order_mark)
 	void SkipBOM();
 
-	//! Skips Notes, notes are dirty lines on top of the file, before the actual data
-	void SkipCSVRows();
-
 	void SkipUntilNewLine();
 
 	void SetStart();

--- a/test/sql/copy/csv/glob/read_csv_glob.test
+++ b/test/sql/copy/csv/glob/read_csv_glob.test
@@ -5,93 +5,93 @@
 statement ok
 PRAGMA enable_verification
 
-# simple globbing
-query I
-SELECT * FROM read_csv('test/sql/copy/csv/data/glob/a?/*.csv') ORDER BY 1
-----
-2019-06-05
-2019-06-15
-2019-06-25
-2019-07-05
-2019-07-15
-2019-07-25
-2019-08-05
-2019-08-15
-2019-08-25
-
-query I
-SELECT * FROM read_csv('test/sql/copy/csv/data/glob/a?/a*.csv') ORDER BY 1
-----
-2019-06-05
-2019-06-15
-2019-06-25
-2019-07-05
-2019-07-15
-2019-07-25
-
-# list parameter
-query I
-SELECT * FROM read_csv(['test/sql/copy/csv/data/glob/a1/a1.csv', 'test/sql/copy/csv/data/glob/a2/a2.csv']) ORDER BY 1
-----
-2019-06-05
-2019-06-15
-2019-06-25
-2019-07-05
-2019-07-15
-2019-07-25
-
-query I
-SELECT * FROM read_csv_auto(['test/sql/copy/csv/data/glob/a1/a1.csv', 'test/sql/copy/csv/data/glob/a2/a2.csv']) ORDER BY 1
-----
-2019-06-05
-2019-06-15
-2019-06-25
-2019-07-05
-2019-07-15
-2019-07-25
-
-# multiple globs
-query I
-SELECT * FROM read_csv(['test/sql/copy/csv/data/glob/a?/a*.csv', 'test/sql/copy/csv/data/glob/a?/a*.csv']) ORDER BY 1
-----
-2019-06-05
-2019-06-05
-2019-06-15
-2019-06-15
-2019-06-25
-2019-06-25
-2019-07-05
-2019-07-05
-2019-07-15
-2019-07-15
-2019-07-25
-2019-07-25
-
-# more asterisks for directories
-query I
-SELECT * FROM read_csv('test/sql/*/*/data/*/a?/a*.csv') ORDER BY 1
-----
-2019-06-05
-2019-06-15
-2019-06-25
-2019-07-05
-2019-07-15
-2019-07-25
-
-query II
-SELECT a, b LIKE '%a1.csv%' FROM read_csv('test/sql/*/*/data/*/a?/a*.csv', filename=1) t1(a,b) ORDER BY 1
-----
-2019-06-05	1
-2019-06-15	1
-2019-06-25	1
-2019-07-05	0
-2019-07-15	0
-2019-07-25	0
-
-# read-csv auto fails here because of a type mismatch: most files contain dates, but one file contains integers
-statement error
-SELECT * FROM read_csv('test/sql/copy/csv/data/glob/*/*.csv') ORDER BY 1
-----
+## simple globbing
+#query I
+#SELECT * FROM read_csv('test/sql/copy/csv/data/glob/a?/*.csv') ORDER BY 1
+#----
+#2019-06-05
+#2019-06-15
+#2019-06-25
+#2019-07-05
+#2019-07-15
+#2019-07-25
+#2019-08-05
+#2019-08-15
+#2019-08-25
+#
+#query I
+#SELECT * FROM read_csv('test/sql/copy/csv/data/glob/a?/a*.csv') ORDER BY 1
+#----
+#2019-06-05
+#2019-06-15
+#2019-06-25
+#2019-07-05
+#2019-07-15
+#2019-07-25
+#
+## list parameter
+#query I
+#SELECT * FROM read_csv(['test/sql/copy/csv/data/glob/a1/a1.csv', 'test/sql/copy/csv/data/glob/a2/a2.csv']) ORDER BY 1
+#----
+#2019-06-05
+#2019-06-15
+#2019-06-25
+#2019-07-05
+#2019-07-15
+#2019-07-25
+#
+#query I
+#SELECT * FROM read_csv_auto(['test/sql/copy/csv/data/glob/a1/a1.csv', 'test/sql/copy/csv/data/glob/a2/a2.csv']) ORDER BY 1
+#----
+#2019-06-05
+#2019-06-15
+#2019-06-25
+#2019-07-05
+#2019-07-15
+#2019-07-25
+#
+## multiple globs
+#query I
+#SELECT * FROM read_csv(['test/sql/copy/csv/data/glob/a?/a*.csv', 'test/sql/copy/csv/data/glob/a?/a*.csv']) ORDER BY 1
+#----
+#2019-06-05
+#2019-06-05
+#2019-06-15
+#2019-06-15
+#2019-06-25
+#2019-06-25
+#2019-07-05
+#2019-07-05
+#2019-07-15
+#2019-07-15
+#2019-07-25
+#2019-07-25
+#
+## more asterisks for directories
+#query I
+#SELECT * FROM read_csv('test/sql/*/*/data/*/a?/a*.csv') ORDER BY 1
+#----
+#2019-06-05
+#2019-06-15
+#2019-06-25
+#2019-07-05
+#2019-07-15
+#2019-07-25
+#
+#query II
+#SELECT a, b LIKE '%a1.csv%' FROM read_csv('test/sql/*/*/data/*/a?/a*.csv', filename=1) t1(a,b) ORDER BY 1
+#----
+#2019-06-05	1
+#2019-06-15	1
+#2019-06-25	1
+#2019-07-05	0
+#2019-07-15	0
+#2019-07-25	0
+#
+## read-csv auto fails here because of a type mismatch: most files contain dates, but one file contains integers
+#statement error
+#SELECT * FROM read_csv('test/sql/copy/csv/data/glob/*/*.csv') ORDER BY 1
+#----
 
 # forcing string parsing works
 query I

--- a/test/sql/copy/csv/glob/read_csv_glob.test
+++ b/test/sql/copy/csv/glob/read_csv_glob.test
@@ -5,93 +5,93 @@
 statement ok
 PRAGMA enable_verification
 
-## simple globbing
-#query I
-#SELECT * FROM read_csv('test/sql/copy/csv/data/glob/a?/*.csv') ORDER BY 1
-#----
-#2019-06-05
-#2019-06-15
-#2019-06-25
-#2019-07-05
-#2019-07-15
-#2019-07-25
-#2019-08-05
-#2019-08-15
-#2019-08-25
-#
-#query I
-#SELECT * FROM read_csv('test/sql/copy/csv/data/glob/a?/a*.csv') ORDER BY 1
-#----
-#2019-06-05
-#2019-06-15
-#2019-06-25
-#2019-07-05
-#2019-07-15
-#2019-07-25
-#
-## list parameter
-#query I
-#SELECT * FROM read_csv(['test/sql/copy/csv/data/glob/a1/a1.csv', 'test/sql/copy/csv/data/glob/a2/a2.csv']) ORDER BY 1
-#----
-#2019-06-05
-#2019-06-15
-#2019-06-25
-#2019-07-05
-#2019-07-15
-#2019-07-25
-#
-#query I
-#SELECT * FROM read_csv_auto(['test/sql/copy/csv/data/glob/a1/a1.csv', 'test/sql/copy/csv/data/glob/a2/a2.csv']) ORDER BY 1
-#----
-#2019-06-05
-#2019-06-15
-#2019-06-25
-#2019-07-05
-#2019-07-15
-#2019-07-25
-#
-## multiple globs
-#query I
-#SELECT * FROM read_csv(['test/sql/copy/csv/data/glob/a?/a*.csv', 'test/sql/copy/csv/data/glob/a?/a*.csv']) ORDER BY 1
-#----
-#2019-06-05
-#2019-06-05
-#2019-06-15
-#2019-06-15
-#2019-06-25
-#2019-06-25
-#2019-07-05
-#2019-07-05
-#2019-07-15
-#2019-07-15
-#2019-07-25
-#2019-07-25
-#
-## more asterisks for directories
-#query I
-#SELECT * FROM read_csv('test/sql/*/*/data/*/a?/a*.csv') ORDER BY 1
-#----
-#2019-06-05
-#2019-06-15
-#2019-06-25
-#2019-07-05
-#2019-07-15
-#2019-07-25
-#
-#query II
-#SELECT a, b LIKE '%a1.csv%' FROM read_csv('test/sql/*/*/data/*/a?/a*.csv', filename=1) t1(a,b) ORDER BY 1
-#----
-#2019-06-05	1
-#2019-06-15	1
-#2019-06-25	1
-#2019-07-05	0
-#2019-07-15	0
-#2019-07-25	0
-#
-## read-csv auto fails here because of a type mismatch: most files contain dates, but one file contains integers
-#statement error
-#SELECT * FROM read_csv('test/sql/copy/csv/data/glob/*/*.csv') ORDER BY 1
-#----
+# simple globbing
+query I
+SELECT * FROM read_csv('test/sql/copy/csv/data/glob/a?/*.csv') ORDER BY 1
+----
+2019-06-05
+2019-06-15
+2019-06-25
+2019-07-05
+2019-07-15
+2019-07-25
+2019-08-05
+2019-08-15
+2019-08-25
+
+query I
+SELECT * FROM read_csv('test/sql/copy/csv/data/glob/a?/a*.csv') ORDER BY 1
+----
+2019-06-05
+2019-06-15
+2019-06-25
+2019-07-05
+2019-07-15
+2019-07-25
+
+# list parameter
+query I
+SELECT * FROM read_csv(['test/sql/copy/csv/data/glob/a1/a1.csv', 'test/sql/copy/csv/data/glob/a2/a2.csv']) ORDER BY 1
+----
+2019-06-05
+2019-06-15
+2019-06-25
+2019-07-05
+2019-07-15
+2019-07-25
+
+query I
+SELECT * FROM read_csv_auto(['test/sql/copy/csv/data/glob/a1/a1.csv', 'test/sql/copy/csv/data/glob/a2/a2.csv']) ORDER BY 1
+----
+2019-06-05
+2019-06-15
+2019-06-25
+2019-07-05
+2019-07-15
+2019-07-25
+
+# multiple globs
+query I
+SELECT * FROM read_csv(['test/sql/copy/csv/data/glob/a?/a*.csv', 'test/sql/copy/csv/data/glob/a?/a*.csv']) ORDER BY 1
+----
+2019-06-05
+2019-06-05
+2019-06-15
+2019-06-15
+2019-06-25
+2019-06-25
+2019-07-05
+2019-07-05
+2019-07-15
+2019-07-15
+2019-07-25
+2019-07-25
+
+# more asterisks for directories
+query I
+SELECT * FROM read_csv('test/sql/*/*/data/*/a?/a*.csv') ORDER BY 1
+----
+2019-06-05
+2019-06-15
+2019-06-25
+2019-07-05
+2019-07-15
+2019-07-25
+
+query II
+SELECT a, b LIKE '%a1.csv%' FROM read_csv('test/sql/*/*/data/*/a?/a*.csv', filename=1) t1(a,b) ORDER BY 1
+----
+2019-06-05	1
+2019-06-15	1
+2019-06-25	1
+2019-07-05	0
+2019-07-15	0
+2019-07-25	0
+
+# read-csv auto fails here because of a type mismatch: most files contain dates, but one file contains integers
+statement error
+SELECT * FROM read_csv('test/sql/copy/csv/data/glob/*/*.csv') ORDER BY 1
+----
 
 # forcing string parsing works
 query I

--- a/test/sql/copy/csv/test_skip.test
+++ b/test/sql/copy/csv/test_skip.test
@@ -6,14 +6,14 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-copy (from range(10000)) to 'skip.csv';
+copy (from range(10000)) to '__TEST_DIR__/skip.csv' (HEADER 0);
 
 query I
-select count(*) from read_csv('skip.csv', skip=3000);
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=3000);
 ----
 7000
 
 query I
-select * from read_csv('skip.csv', skip=3000) order by all limit 1;
+select * from read_csv('__TEST_DIR__/skip.csv', skip=3000) order by all limit 1;
 ----
 3000

--- a/test/sql/copy/csv/test_skip.test
+++ b/test/sql/copy/csv/test_skip.test
@@ -8,12 +8,115 @@ PRAGMA enable_verification
 statement ok
 copy (from range(10000)) to '__TEST_DIR__/skip.csv' (HEADER 0);
 
+foreach auto_detect true false
+
+# Test -1
+statement error
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=-1, auto_detect = ${auto_detect}, columns = {'i': 'INTEGER'});
+----
+skip_rows option from read_csv scanner, must be equal or higher than 0
+
+# Test 0
 query I
-select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=3000);
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=0, auto_detect = ${auto_detect}, columns = {'i': 'INTEGER'});
+----
+10000
+
+# Test 3000
+query I
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=3000, auto_detect = ${auto_detect}, columns = {'i': 'INTEGER'});
 ----
 7000
 
 query I
-select * from read_csv('__TEST_DIR__/skip.csv', skip=3000) order by all limit 1;
+select * from read_csv('__TEST_DIR__/skip.csv', skip=3000, auto_detect = ${auto_detect}, columns = {'i': 'INTEGER'}) order by all limit 1;
 ----
 3000
+
+# Test 9999
+query I
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=9999, auto_detect = ${auto_detect}, columns = {'i': 'INTEGER'});
+----
+1
+
+query I
+select * from read_csv('__TEST_DIR__/skip.csv', skip=9999, auto_detect = ${auto_detect}, columns = {'i': 'INTEGER'}) order by all limit 1;
+----
+9999
+
+# test 10001
+query I
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=10001, auto_detect = ${auto_detect}, columns = {'i': 'INTEGER'});
+----
+0
+
+# Test 11000
+query I
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=11000, auto_detect = ${auto_detect}, columns = {'i': 'INTEGER'});
+----
+0
+
+endloop
+
+# Test sniff_csv function, exclude prompt since this is path dependent
+query IIIIIIIIII
+SELECT * EXCLUDE (prompt) from sniff_csv('__TEST_DIR__/skip.csv',skip=3000)
+----
+,	"	"	\n	3000	false	[{'name': column0, 'type': BIGINT}]	NULL	NULL	skip=3000
+
+query IIIIIIIIII
+SELECT * EXCLUDE (prompt) from sniff_csv('__TEST_DIR__/skip.csv',skip=11000)
+----
+,	"	"	\n	11000	0	[{'name': column0, 'type': VARCHAR}]	NULL	NULL	skip=11000
+
+# Test with different buffer sizes
+
+loop buffer_size 5 10
+
+# Test -1
+statement error
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=-1, buffer_size=${buffer_size});
+----
+skip_rows option from read_csv scanner, must be equal or higher than 0
+
+# Test 0
+query I
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=0, buffer_size=${buffer_size});
+----
+10000
+
+# Test 3000
+query I
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=3000, buffer_size=${buffer_size});
+----
+7000
+
+query I
+select * from read_csv('__TEST_DIR__/skip.csv', skip=3000, buffer_size=${buffer_size}) order by all limit 1;
+----
+3000
+
+# Test 9999
+query I
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=9999, buffer_size=${buffer_size});
+----
+1
+
+query I
+select * from read_csv('__TEST_DIR__/skip.csv', skip=9999, buffer_size=${buffer_size}) order by all limit 1;
+----
+9999
+
+# test 10001
+query I
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=10001, buffer_size=${buffer_size});
+----
+0
+
+# Test 11000
+query I
+select count(*) from read_csv('__TEST_DIR__/skip.csv', skip=11000, buffer_size=${buffer_size});
+----
+0
+
+endloop

--- a/test/sql/copy/csv/test_skip.test
+++ b/test/sql/copy/csv/test_skip.test
@@ -8,7 +8,12 @@ PRAGMA enable_verification
 statement ok
 copy (from range(10000)) to 'skip.csv';
 
-#query I
-#select count(*) from read_csv('skip.csv', skip=3000);
-#----
-#1
+query I
+select count(*) from read_csv('skip.csv', skip=3000);
+----
+7000
+
+query I
+select * from read_csv('skip.csv', skip=3000) order by all limit 1;
+----
+3000

--- a/test/sql/copy/csv/test_skip.test
+++ b/test/sql/copy/csv/test_skip.test
@@ -71,6 +71,10 @@ SELECT * EXCLUDE (prompt) from sniff_csv('__TEST_DIR__/skip.csv',skip=11000)
 
 # Test with different buffer sizes
 
+# There is currently a limitation on skip if the number of rows to be skipped go over a buffer boundary
+
+mode skip
+
 loop buffer_size 5 10
 
 # Test -1

--- a/test/sql/copy/csv/test_skip.test
+++ b/test/sql/copy/csv/test_skip.test
@@ -1,0 +1,14 @@
+# name: test/sql/copy/csv/test_skip.test
+# description: Test that the skip option works for csv files
+# group: [csv]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+copy (from range(10000)) to 'skip.csv';
+
+#query I
+#select count(*) from read_csv('skip.csv', skip=3000);
+#----
+#1


### PR DESCRIPTION
This PR fixes: https://github.com/duckdblabs/duckdb-internal/issues/2079

While adding tests for it, I've noticed that Skip is also currently limited by CSV buffer boundaries, the fix for this is a bit more convoluted, but I'm currently working on it on a different branch.