### PR TITLE
Remove UnsafeNumericCast in create_sort_key

### DIFF
--- a/src/core_functions/scalar/blob/create_sort_key.cpp
+++ b/src/core_functions/scalar/blob/create_sort_key.cpp
@@ -186,10 +186,10 @@ struct SortKeyVarcharOperator {
 	}
 
 	static idx_t Encode(data_ptr_t result, TYPE input) {
-		auto input_data = input.GetDataUnsafe();
+		auto input_data = const_data_ptr_cast(input.GetDataUnsafe());
 		auto input_size = input.GetSize();
 		for (idx_t r = 0; r < input_size; r++) {
-			result[r] = UnsafeNumericCast<data_t>(input_data[r] + 1);
+			result[r] = input_data[r] + 1;
 		}
 		result[input_size] = SortKeyVectorData::STRING_DELIMITER; // null-byte delimiter
 		return input_size + 1;

--- a/test/fuzzer/duckfuzz/create_sort_key_strings.test
+++ b/test/fuzzer/duckfuzz/create_sort_key_strings.test
@@ -1,0 +1,23 @@
+# name: test/fuzzer/duckfuzz/create_sort_key_strings.test
+# description: create_sort_key with string boundaries
+# group: [duckfuzz]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t2(c38 STRUCT(a INTEGER, b VARCHAR));
+
+statement ok
+INSERT INTO t2 VALUES({'a': NULL, 'b': NULL});
+
+statement ok
+INSERT INTO t2 VALUES({'a': 42, 'b': '🦆🦆🦆🦆🦆🦆'});
+
+statement ok
+INSERT INTO t2 VALUES(NULL);
+
+query I
+SELECT any_value(NULL ORDER BY c38 ASC) FROM t2
+----
+NULL


### PR DESCRIPTION
We are encoding into a binary blob here - by reading the data as `char` (which can be signed on some platforms) and casting to unsigned using `UnsafeNumericCast` we can incorrectly trigger an assertion here in debug mode. 

Fixes a fuzzer issue.