### PR TITLE
[PySpark] Implement UDFRegistration.register method on PySpark api

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/sql/session.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/session.py
@@ -241,7 +241,7 @@ class SparkSession:
 
     @property
     def udf(self) -> UDFRegistration:
-        return UDFRegistration()
+        return UDFRegistration(self)
 
     @property
     def version(self) -> str:

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/udf.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/udf.py
@@ -1,8 +1,36 @@
 # https://sparkbyexamples.com/pyspark/pyspark-udf-user-defined-function/
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
+
+from .types import DataType
+
+if TYPE_CHECKING:
+    from .session import SparkSession
+
+DataTypeOrString = Union[DataType, str]
+UserDefinedFunctionLike = TypeVar("UserDefinedFunctionLike")
 
 
 class UDFRegistration:
-    def __init__(self):
+    def __init__(self, sparkSession: "SparkSession"):
+        self.sparkSession = sparkSession
+
+    def register(
+        self,
+        name: str,
+        f: Union[Callable[..., Any], "UserDefinedFunctionLike"],
+        returnType: Optional["DataTypeOrString"] = None,
+    ) -> "UserDefinedFunctionLike":
+        self.sparkSession.conn.create_function(name, f, return_type=returnType)
+
+    def registerJavaFunction(
+        self,
+        name: str,
+        javaClassName: str,
+        returnType: Optional["DataTypeOrString"] = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def registerJavaUDAF(self, name: str, javaClassName: str) -> None:
         raise NotImplementedError
 
 

--- a/tools/pythonpkg/tests/fast/spark/test_spark_session.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_session.py
@@ -73,5 +73,4 @@ class TestSparkSession(object):
         df = spark.table('tbl')
 
     def test_udf(self, spark):
-        with pytest.raises(NotImplementedError):
-            udf_registration = spark.udf
+        udf_registration = spark.udf

--- a/tools/pythonpkg/tests/fast/spark/test_spark_udf.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_udf.py
@@ -1,0 +1,13 @@
+import pytest
+
+_ = pytest.importorskip("duckdb.experimental.spark")
+
+
+class TestSparkUDF(object):
+    def test_udf_register(self, spark):
+
+        def to_upper_fn(s: str) -> str:
+            return s.upper()
+
+        spark.udf.register("to_upper_fn", to_upper_fn)
+        assert spark.sql("select to_upper_fn('quack') as vl").collect()[0].vl == "QUACK"


### PR DESCRIPTION
Was implementd the method `register` on `UDFRegistration` to support the usage of custom python functions when using the pyspark api