### PR TITLE
Mark correct database as modified in CreateIndex

### DIFF
--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -613,9 +613,6 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 	case CatalogType::INDEX_ENTRY: {
 		auto &base = stmt.info->Cast<CreateIndexInfo>();
 
-		auto catalog = BindCatalog(base.catalog);
-		properties.modified_databases.insert(catalog);
-
 		// visit the table reference
 		auto table_ref = make_uniq<BaseTableRef>();
 		table_ref->catalog_name = base.catalog;
@@ -631,6 +628,8 @@ BoundStatement Binder::Bind(CreateStatement &stmt) {
 		if (table.temporary) {
 			stmt.info->temporary = true;
 		}
+		properties.modified_databases.insert(table.catalog.GetName());
+
 		// create a plan over the bound table
 		auto plan = CreatePlan(*bound_table);
 		if (plan->type != LogicalOperatorType::LOGICAL_GET) {

--- a/test/sql/attach/attach_create_index.test
+++ b/test/sql/attach/attach_create_index.test
@@ -1,0 +1,14 @@
+# name: test/sql/attach/attach_create_index.test
+# description: Test create index on an attached database with an alias
+# group: [attach]
+
+require skip_reload
+
+statement ok
+ATTACH '' AS tmp;
+
+statement ok
+CREATE TABLE tmp.t1(id int);
+
+statement ok
+CREATE INDEX idx ON tmp.t1(id);


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/2102

The index itself does not contain a catalog reference - only the table does. As such, we need to get the catalog from the table. 