### PR TITLE
FALLOC_FL_PUNCH_HOLE requires GLIBC 2.18 or above - check for this using an #ifdef

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -486,7 +486,7 @@ int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_byte
 bool LocalFileSystem::Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) {
 #if defined(__linux__)
 	// FALLOC_FL_PUNCH_HOLE requires glibc 2.18 or up
-#if __GLIBC__ < 2 || __GLIBC_MINOR__ < 18
+#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 18)
 	return false;
 #else
 	int fd = handle.Cast<UnixFileHandle>().fd;

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -485,9 +485,14 @@ int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_byte
 
 bool LocalFileSystem::Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) {
 #if defined(__linux__)
+	// FALLOC_FL_PUNCH_HOLE requires glibc 2.18 or up
+#if __GLIBC__ < 2 || __GLIBC_MINOR__ < 18
+	return false;
+#else
 	int fd = handle.Cast<UnixFileHandle>().fd;
 	int res = fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, offset_bytes, length_bytes);
 	return res == 0;
+#endif
 #else
 	return false;
 #endif


### PR DESCRIPTION
See https://man7.org/linux/man-pages/man2/fallocate.2.html