### PR TITLE
Install .ipp files in addition to the usual .hpp files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,7 +116,8 @@ else()
     DIRECTORY "${PROJECT_SOURCE_DIR}/src/include/duckdb"
     DESTINATION "${INSTALL_INCLUDE_DIR}"
     FILES_MATCHING
-    PATTERN "*.hpp")
+    PATTERN "*.hpp"
+    PATTERN "*.ipp")
   install(FILES "${PROJECT_SOURCE_DIR}/src/include/duckdb.hpp"
                 "${PROJECT_SOURCE_DIR}/src/include/duckdb.h"
           DESTINATION "${INSTALL_INCLUDE_DIR}")


### PR DESCRIPTION
Installs `duckdb/common/*.ipp`, which are included by `duckdb/common/shared_ptr.hpp`.

Fixes #12197.