### PR TITLE
[CLI] Add highlighting + limited auto-complete for shell dot commands

### DIFF
--- a/tools/shell/linenoise/include/highlighting.hpp
+++ b/tools/shell/linenoise/include/highlighting.hpp
@@ -42,7 +42,7 @@ public:
 	static const char *GetColorOption(const char *option);
 	static void SetHighlightingColor(HighlightingType type, const char *color);
 
-	static vector<highlightToken> Tokenize(char *buf, size_t len, searchMatch *match = nullptr);
+	static vector<highlightToken> Tokenize(char *buf, size_t len, bool is_dot_command, searchMatch *match);
 	static string HighlightText(char *buf, size_t len, size_t start_pos, size_t end_pos,
 	                            const vector<highlightToken> &tokens);
 };

--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -127,6 +127,7 @@ public:
 	static bool IsNewline(char c);
 	static bool IsWordBoundary(char c);
 	static bool AllWhitespace(const char *z);
+	static bool IsSpace(char c);
 
 	TabCompletion TabComplete() const;
 

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -659,7 +659,7 @@ void Linenoise::EditBackspace() {
 	}
 }
 
-static bool IsSpace(char c) {
+bool Linenoise::IsSpace(char c) {
 	switch (c) {
 	case ' ':
 	case '\r':

--- a/tools/shell/linenoise/rendering.cpp
+++ b/tools/shell/linenoise/rendering.cpp
@@ -127,7 +127,9 @@ static void renderText(size_t &render_pos, char *&buf, size_t &len, size_t pos, 
 			}
 		}
 		if (highlight) {
-			auto tokens = Highlighting::Tokenize(buf, len, match);
+			bool is_dot_command = buf[0] == '.';
+
+			auto tokens = Highlighting::Tokenize(buf, len, is_dot_command, match);
 			highlight_buffer = Highlighting::HighlightText(buf, len, start_pos, cpos, tokens);
 			buf = (char *)highlight_buffer.c_str();
 			len = highlight_buffer.size();
@@ -856,8 +858,9 @@ void Linenoise::RefreshMultiLine() {
 
 	vector<highlightToken> tokens;
 	if (Highlighting::IsEnabled()) {
+		bool is_dot_command = buf[0] == '.';
 		auto match = search_index < search_matches.size() ? &search_matches[search_index] : nullptr;
-		tokens = Highlighting::Tokenize(render_buf, render_len, match);
+		tokens = Highlighting::Tokenize(render_buf, render_len, is_dot_command, match);
 
 		// add error highlighting
 		AddErrorHighlighting(render_start, render_end, tokens);

--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -14208,7 +14208,32 @@ static void linenoise_completion(const char *zLine, linenoiseCompletions *lc){
   char zBuf[1000];
 
   if( nLine>sizeof(zBuf)-30 ) return;
-  if( zLine[0]=='.' || zLine[0]=='#') return;
+  if (zLine[0] == '.') {
+    // auto-complete dot command
+    // look for all completions in the help file
+	for(size_t line_idx = 0; line_idx < ArraySize(azHelp); line_idx++) {
+      const char *line = azHelp[line_idx];
+      if (line[0] != '.') {
+        continue;
+      }
+	  int found_match = 1;
+      size_t line_pos;
+      for(line_pos = 0; !IsSpace(line[line_pos]) && line[line_pos] && line_pos + 1 < sizeof(zBuf); line_pos++) {
+        zBuf[line_pos] = line[line_pos];
+		if (line_pos < nLine && line[line_pos] != zLine[line_pos]) {
+			// only match prefixes for auto-completion, i.e. ".sh" matches ".shell"
+			found_match = 0;
+			break;
+		}
+      }
+      zBuf[line_pos] = '\0';
+      if (found_match && line_pos >= nLine) {
+        linenoiseAddCompletion(lc, zBuf);
+      }
+	}
+    return;
+  }
+  if(zLine[0]=='#') return;
 //  if( i==nLine-1 ) return;
   zSql = sqlite3_mprintf("CALL sql_auto_complete(%Q)", zLine);
   sqlite3 *localDb = NULL;


### PR DESCRIPTION
Dot commands now support auto-complete (e.g. `.re` auto completes to `.read`), and we use separate highlighting for dot commands that highlights the individual components instead of tokenizing them as a SQL string.