### PR TITLE
Fix #12190: add SYSTEM to set of reserved database names

### DIFF
--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -82,7 +82,7 @@ bool AttachedDatabase::IsReadOnly() const {
 }
 
 bool AttachedDatabase::NameIsReserved(const string &name) {
-	return name == DEFAULT_SCHEMA || name == TEMP_CATALOG;
+	return name == DEFAULT_SCHEMA || name == TEMP_CATALOG || name == SYSTEM_CATALOG;
 }
 
 string AttachedDatabase::ExtractDatabaseName(const string &dbpath, FileSystem &fs) {

--- a/test/sql/attach/attach_reserved.test
+++ b/test/sql/attach/attach_reserved.test
@@ -18,6 +18,16 @@ CREATE TABLE temp_db.integers(i INTEGER);
 statement ok
 DETACH temp_db;
 
+# attach a new database called temp
+statement ok
+ATTACH DATABASE '__TEST_DIR__/system.db';
+
+statement ok
+CREATE TABLE system_db.integers(i INTEGER);
+
+statement ok
+DETACH system_db;
+
 # explicitly selecting these aliases leads to an error
 statement error
 ATTACH DATABASE ':memory:' AS temp;
@@ -26,5 +36,10 @@ reserved name
 
 statement error
 ATTACH DATABASE ':memory:' AS main;
+----
+reserved name
+
+statement error
+ATTACH DATABASE ':memory:' AS system;
 ----
 reserved name


### PR DESCRIPTION
Fixes #12190 

Follow-up from https://github.com/duckdb/duckdb/pull/11020, also add `system` to the set of reserved catalog names.