### PR TITLE
[Python] Fix replacement scans incorrectly finding duckdb connection method objects

### DIFF
--- a/tools/pythonpkg/scripts/cache_data.json
+++ b/tools/pythonpkg/scripts/cache_data.json
@@ -502,7 +502,8 @@
         "name": "types",
         "children": [
             "types.UnionType",
-            "types.GenericAlias"
+            "types.GenericAlias",
+            "types.BuiltinFunctionType"
         ]
     },
     "types.UnionType": {
@@ -515,6 +516,12 @@
         "type": "attribute",
         "full_path": "types.GenericAlias",
         "name": "GenericAlias",
+        "children": []
+    },
+    "types.BuiltinFunctionType": {
+        "type": "attribute",
+        "full_path": "types.BuiltinFunctionType",
+        "name": "BuiltinFunctionType",
         "children": []
     },
     "typing": {

--- a/tools/pythonpkg/scripts/imports.py
+++ b/tools/pythonpkg/scripts/imports.py
@@ -92,6 +92,7 @@ import types
 
 types.UnionType
 types.GenericAlias
+types.BuiltinFunctionType
 
 import typing
 

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/types_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/types_module.hpp
@@ -20,13 +20,15 @@ public:
 
 public:
 	TypesCacheItem()
-	    : PythonImportCacheItem("types"), UnionType("UnionType", this), GenericAlias("GenericAlias", this) {
+	    : PythonImportCacheItem("types"), UnionType("UnionType", this), GenericAlias("GenericAlias", this),
+	      BuiltinFunctionType("BuiltinFunctionType", this) {
 	}
 	~TypesCacheItem() override {
 	}
 
 	PythonImportCacheItem UnionType;
 	PythonImportCacheItem GenericAlias;
+	PythonImportCacheItem BuiltinFunctionType;
 };
 
 } // namespace duckdb

--- a/tools/pythonpkg/tests/fast/api/test_duckdb_connection.py
+++ b/tools/pythonpkg/tests/fast/api/test_duckdb_connection.py
@@ -320,6 +320,14 @@ class TestDuckDBConnection(object):
     def test_interrupt(self):
         assert None != duckdb.interrupt
 
+    def test_wrap_shadowing(self):
+        pd = NumpyPandas()
+        import duckdb
+
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        res = duckdb.sql("from df").fetchall()
+        assert res == [(1,), (2,), (3,)]
+
     def test_wrap_coverage(self):
         con = duckdb.default_connection
 


### PR DESCRIPTION
This PR fixes #11945 

What happens is that our wrapper for the DuckDBPyConnection methods that enable the use of the `duckdb` module as a connection, is adding these methods as variables to the frame's global dict

The replacement scan traverses the frames, stopping when it finds a variable with the right name
This then caused an error because these objects are not suitable for replacement scans.

We now skip these method objects when we come across them.