### PR TITLE
Extension installing/updateing fixes

### DIFF
--- a/scripts/run_extension_medata_tests.sh
+++ b/scripts/run_extension_medata_tests.sh
@@ -167,7 +167,7 @@ DUCKDB_PLATFORM=`cat $DUCKDB_BUILD_DIR/duckdb_platform_out`
 ###########################
 ### Populate the minio repositories
 ###########################
-AWS_DEFAULT_REGION=eu-west-1 AWS_ACCESS_KEY_ID=minio_duckdb_user AWS_SECRET_ACCESS_KEY=minio_duckdb_user_password aws --endpoint-url http://duckdb-minio.com:9000 s3 sync $LOCAL_EXTENSION_REPO_UPDATED s3://test-bucket-public/ci-test-repo
+#AWS_DEFAULT_REGION=eu-west-1 AWS_ACCESS_KEY_ID=minio_duckdb_user AWS_SECRET_ACCESS_KEY=minio_duckdb_user_password aws --endpoint-url http://duckdb-minio.com:9000 s3 sync $LOCAL_EXTENSION_REPO_UPDATED s3://test-bucket-public/ci-test-repo
 export REMOTE_EXTENSION_REPO_UPDATED=http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo
 export REMOTE_EXTENSION_REPO_DIRECT_PATH=http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo/$DUCKDB_VERSION/$DUCKDB_PLATFORM
 

--- a/scripts/run_extension_medata_tests.sh
+++ b/scripts/run_extension_medata_tests.sh
@@ -167,7 +167,7 @@ DUCKDB_PLATFORM=`cat $DUCKDB_BUILD_DIR/duckdb_platform_out`
 ###########################
 ### Populate the minio repositories
 ###########################
-#AWS_DEFAULT_REGION=eu-west-1 AWS_ACCESS_KEY_ID=minio_duckdb_user AWS_SECRET_ACCESS_KEY=minio_duckdb_user_password aws --endpoint-url http://duckdb-minio.com:9000 s3 sync $LOCAL_EXTENSION_REPO_UPDATED s3://test-bucket-public/ci-test-repo
+AWS_DEFAULT_REGION=eu-west-1 AWS_ACCESS_KEY_ID=minio_duckdb_user AWS_SECRET_ACCESS_KEY=minio_duckdb_user_password aws --endpoint-url http://duckdb-minio.com:9000 s3 sync $LOCAL_EXTENSION_REPO_UPDATED s3://test-bucket-public/ci-test-repo
 export REMOTE_EXTENSION_REPO_UPDATED=http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo
 export REMOTE_EXTENSION_REPO_DIRECT_PATH=http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo/$DUCKDB_VERSION/$DUCKDB_PLATFORM
 

--- a/src/execution/operator/helper/physical_load.cpp
+++ b/src/execution/operator/helper/physical_load.cpp
@@ -17,14 +17,14 @@ static void InstallFromRepository(ClientContext &context, const LoadInfo &info) 
 	}
 
 	ExtensionHelper::InstallExtension(context, info.filename, info.load_type == LoadType::FORCE_INSTALL, repository,
-	                                  info.version);
+	                                  true, info.version);
 }
 
 SourceResultType PhysicalLoad::GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const {
 	if (info->load_type == LoadType::INSTALL || info->load_type == LoadType::FORCE_INSTALL) {
 		if (info->repository.empty()) {
 			ExtensionHelper::InstallExtension(context.client, info->filename,
-			                                  info->load_type == LoadType::FORCE_INSTALL, nullptr, info->version);
+			                                  info->load_type == LoadType::FORCE_INSTALL, nullptr, true, info->version);
 		} else {
 			InstallFromRepository(context.client, *info);
 		}

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -86,11 +86,13 @@ public:
 
 	//! Install an extension
 	static unique_ptr<ExtensionInstallInfo> InstallExtension(ClientContext &context, const string &extension,
-	                                                         bool force_install, optional_ptr<ExtensionRepository> repository = nullptr,
+	                                                         bool force_install,
+	                                                         optional_ptr<ExtensionRepository> repository = nullptr,
 	                                                         bool throw_on_origin_mismatch = false,
 	                                                         const string &version = "");
 	static unique_ptr<ExtensionInstallInfo> InstallExtension(DBConfig &config, FileSystem &fs, const string &extension,
-	                                                         bool force_install, optional_ptr<ExtensionRepository> repository = nullptr,
+	                                                         bool force_install,
+	                                                         optional_ptr<ExtensionRepository> repository = nullptr,
 	                                                         bool throw_on_origin_mismatch = false,
 	                                                         const string &version = "");
 	//! Load an extension
@@ -213,13 +215,10 @@ public:
 	static bool CreateSuggestions(const string &extension_name, string &message);
 
 private:
-	static unique_ptr<ExtensionInstallInfo> InstallExtensionInternal(DBConfig &config, FileSystem &fs,
-	                                                                 const string &local_path, const string &extension,
-	                                                                 bool force_install,  bool throw_on_origin_mismatch,
-	                                                                 const string &version,
-	                                                                 optional_ptr<ExtensionRepository> repository,
-	                                                                 optional_ptr<HTTPLogger> http_logger = nullptr,
-	                                                                 optional_ptr<ClientContext> context = nullptr);
+	static unique_ptr<ExtensionInstallInfo> InstallExtensionInternal(
+	    DBConfig &config, FileSystem &fs, const string &local_path, const string &extension, bool force_install,
+	    bool throw_on_origin_mismatch, const string &version, optional_ptr<ExtensionRepository> repository,
+	    optional_ptr<HTTPLogger> http_logger = nullptr, optional_ptr<ClientContext> context = nullptr);
 	static const vector<string> PathComponents();
 	static string DefaultExtensionFolder(FileSystem &fs);
 	static bool AllowAutoInstall(const string &extension);

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -86,12 +86,12 @@ public:
 
 	//! Install an extension
 	static unique_ptr<ExtensionInstallInfo> InstallExtension(ClientContext &context, const string &extension,
-	                                                         bool force_install,
-	                                                         optional_ptr<ExtensionRepository> repository = nullptr,
+	                                                         bool force_install, optional_ptr<ExtensionRepository> repository = nullptr,
+	                                                         bool throw_on_origin_mismatch = false,
 	                                                         const string &version = "");
 	static unique_ptr<ExtensionInstallInfo> InstallExtension(DBConfig &config, FileSystem &fs, const string &extension,
-	                                                         bool force_install,
-	                                                         optional_ptr<ExtensionRepository> repository = nullptr,
+	                                                         bool force_install, optional_ptr<ExtensionRepository> repository = nullptr,
+	                                                         bool throw_on_origin_mismatch = false,
 	                                                         const string &version = "");
 	//! Load an extension
 	static void LoadExternalExtension(ClientContext &context, const string &extension);
@@ -215,7 +215,8 @@ public:
 private:
 	static unique_ptr<ExtensionInstallInfo> InstallExtensionInternal(DBConfig &config, FileSystem &fs,
 	                                                                 const string &local_path, const string &extension,
-	                                                                 bool force_install, const string &version,
+	                                                                 bool force_install,  bool throw_on_origin_mismatch,
+	                                                                 const string &version,
 	                                                                 optional_ptr<ExtensionRepository> repository,
 	                                                                 optional_ptr<HTTPLogger> http_logger = nullptr,
 	                                                                 optional_ptr<ClientContext> context = nullptr);

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -323,26 +323,6 @@ vector<ExtensionUpdateResult> ExtensionHelper::UpdateExtensions(DatabaseInstance
 	});
 #endif
 
-	for (const auto &extension : db.LoadedExtensions()) {
-		if (seen_extensions.find(extension) != seen_extensions.end()) {
-			const auto &loaded_extension_data = db.LoadedExtensionsData();
-			const auto &loaded_install_info = loaded_extension_data.find(extension);
-
-			ExtensionUpdateResult statically_loaded_ext_result;
-
-			if (loaded_install_info == loaded_extension_data.end()) {
-				statically_loaded_ext_result.tag = ExtensionUpdateResultTag::UNKNOWN;
-			} else if (loaded_install_info->second.mode == ExtensionInstallMode::STATICALLY_LINKED) {
-				statically_loaded_ext_result.tag = ExtensionUpdateResultTag::STATICALLY_LOADED;
-				statically_loaded_ext_result.installed_version = loaded_install_info->second.version;
-			} else {
-				statically_loaded_ext_result.tag = ExtensionUpdateResultTag::UNKNOWN;
-			}
-
-			result.push_back(std::move(statically_loaded_ext_result));
-		}
-	}
-
 	return result;
 }
 

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -213,7 +213,7 @@ bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string 
 		if (dbconfig.options.autoinstall_known_extensions) {
 			auto &config = DBConfig::GetConfig(context);
 			auto autoinstall_repo = ExtensionRepository::GetRepositoryByUrl(config.options.autoinstall_extension_repo);
-			ExtensionHelper::InstallExtension(context, extension_name, false, autoinstall_repo);
+			ExtensionHelper::InstallExtension(context, extension_name, false, autoinstall_repo, false);
 		}
 		ExtensionHelper::LoadExternalExtension(context, extension_name);
 		return true;

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -143,11 +143,13 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(DBConfig &con
 	return nullptr;
 #endif
 	string local_path = ExtensionDirectory(config, fs);
-	return InstallExtensionInternal(config, fs, local_path, extension, force_install, throw_on_origin_mismatch, version, repository);
+	return InstallExtensionInternal(config, fs, local_path, extension, force_install, throw_on_origin_mismatch, version,
+	                                repository);
 }
 
 unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(ClientContext &context, const string &extension,
-                                                                   bool force_install, optional_ptr<ExtensionRepository> repository,
+                                                                   bool force_install,
+                                                                   optional_ptr<ExtensionRepository> repository,
                                                                    bool throw_on_origin_mismatch,
                                                                    const string &version) {
 #ifdef WASM_LOADABLE_EXTENSIONS
@@ -159,8 +161,8 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(ClientContext
 	string local_path = ExtensionDirectory(context);
 	optional_ptr<HTTPLogger> http_logger =
 	    ClientConfig::GetConfig(context).enable_http_logging ? context.client_data->http_logger.get() : nullptr;
-	return InstallExtensionInternal(db_config, fs, local_path, extension, force_install, throw_on_origin_mismatch, version,
-	                                repository, http_logger, context);
+	return InstallExtensionInternal(db_config, fs, local_path, extension, force_install, throw_on_origin_mismatch,
+	                                version, repository, http_logger, context);
 }
 
 unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, const string &path, idx_t &file_size) {
@@ -447,8 +449,7 @@ static void ThrowErrorOnMismatchingExtensionOrigin(FileSystem &fs, const string 
 unique_ptr<ExtensionInstallInfo>
 ExtensionHelper::InstallExtensionInternal(DBConfig &config, FileSystem &fs, const string &local_path,
                                           const string &extension, bool force_install, bool throw_on_origin_mismatch,
-                                          const string &version,
-                                          optional_ptr<ExtensionRepository> repository,
+                                          const string &version, optional_ptr<ExtensionRepository> repository,
                                           optional_ptr<HTTPLogger> http_logger, optional_ptr<ClientContext> context) {
 #ifdef DUCKDB_DISABLE_EXTENSION_LOAD
 	throw PermissionException("Installing external extensions is disabled through a compile time flag");
@@ -463,7 +464,8 @@ ExtensionHelper::InstallExtensionInternal(DBConfig &config, FileSystem &fs, cons
 
 	if (fs.FileExists(local_extension_path) && !force_install) {
 		// File exists: throw error if origin mismatches
-		if (throw_on_origin_mismatch && !config.options.allow_extensions_metadata_mismatch && fs.FileExists(local_extension_path + ".info")) {
+		if (throw_on_origin_mismatch && !config.options.allow_extensions_metadata_mismatch &&
+		    fs.FileExists(local_extension_path + ".info")) {
 			ThrowErrorOnMismatchingExtensionOrigin(fs, local_extension_path, extension_name, extension, repository);
 		}
 

--- a/test/extension/update_extensions_ci.test
+++ b/test/extension/update_extensions_ci.test
@@ -325,6 +325,37 @@ SELECT extension_name, install_mode, parse_filename(installed_from), extension_v
 ----
 inet	CUSTOM_PATH	inet.duckdb_extension.gz	v0.0.2
 
+statement ok
+set allow_extensions_metadata_mismatch=false;
+
+### Now we test autoloading: it should be unaffected by error messages 
+statement ok
+set autoload_known_extensions=true
+
+statement ok
+set autoinstall_known_extensions=true
+
+# Set a non-existent autoinstall repo
+statement ok
+set autoinstall_extension_repository='hocus_pocus_this_is_bogus'
+
+statement ok
+set custom_extension_repository='hocus_pocus_this_is_bogus'
+
+statement ok
+FORCE INSTALL tpcds FROM '${LOCAL_EXTENSION_REPO_UPDATED}';
+
+# Note: this would trigger the origin check normally, but now 
+statement ok
+from tpcds_queries();
+
+# The file should be from the custom path, NOT the autoinstall repo
+query IIII
+SELECT extension_name, install_mode, parse_filename(installed_from), extension_version FROM duckdb_extensions() where installed and extension_name != 'jemalloc' and extension_name != 'parquet'
+----
+inet	CUSTOM_PATH	inet.duckdb_extension.gz	v0.0.2
+tpcds	REPOSITORY	repository	v0.0.1
+
 ### Tests with allow_unsigned extensions = false
 restart
 

--- a/test/extension/update_extensions_ci.test
+++ b/test/extension/update_extensions_ci.test
@@ -69,6 +69,9 @@ SELECT extension_name, install_mode, installed_from, extension_version FROM duck
 ----
 tpcds	CUSTOM_PATH	./build/extension_metadata_test_data/direct_install/tpcds.duckdb_extension	v0.0.1
 
+statement ok
+load tpcds
+
 # Same here
 query IIIII
 UPDATE EXTENSIONS


### PR DESCRIPTION
Fixes for 2 issues with the latest extension changes in v0.10.3:

### Autoloading broken when extensions are installed from non-core repositories
In v0.10.3, when you `INSTALL azure FROM core_nightly` but not load it, and then call `FROM 'az://blabla.parquet'` autoloading will fail because autoloading relies on INSTALL being a NOP when the extension is already installed and a origin check was recently added that will throw when `INSTALL xxx` is called where `xxx` is already installed but from a different repository.

The fix is to only run this check when executing literal `INSTALL` statements, not when autoloading


### Empty lines in `UPDATE EXTENSIONS`
Update extensions would print empty lines when called with extensions loaded. 

for example:
```
D update extensions;
┌────────────────┬────────────┬─────────────────────┬──────────────────┬─────────────────┐
│ extension_name │ repository │    update_result    │ previous_version │ current_version │
│    varchar     │  varchar   │       varchar       │     varchar      │     varchar     │
├────────────────┼────────────┼─────────────────────┼──────────────────┼─────────────────┤
│ httpfs         │ core       │ NO_UPDATE_AVAILABLE │ 70fd6a8a24       │ 70fd6a8a24      │
│ delta          │ core       │ NO_UPDATE_AVAILABLE │ 04c61e4          │ 04c61e4         │
│                │            │ UNKNOWN             │                  │                 │
│                │            │ UNKNOWN             │                  │                 │
└────────────────┴────────────┴─────────────────────┴──────────────────┴─────────────────┘
```

This was due to some dead code that I somehow missed during testing. The code is removed and some test cases are added to confirm it now prints the correct result 