### PR TITLE
[Python] fix build when BUILD_HTTPFS set

### DIFF
--- a/extension/httpfs/httpfs_config.py
+++ b/extension/httpfs/httpfs_config.py
@@ -10,6 +10,13 @@ source_files = [
     os.path.sep.join(x.split('/'))
     for x in [
         'extension/httpfs/' + s
-        for s in ['create_secret_functions.cpp', 'httpfs_extension.cpp', 'httpfs.cpp', 's3fs.cpp', 'crypto.cpp']
+        for s in [
+            'create_secret_functions.cpp',
+            'crypto.cpp',
+            'hffs.cpp',
+            'httpfs.cpp',
+            'httpfs_extension.cpp',
+            's3fs.cpp',
+        ]
     ]
 ]


### PR DESCRIPTION
add hffs.cpp to the list of sources when building the duckdb python module. This allows the module to load when building with BUILD_HTTPFS rather than failing due to unresolved symbols (duckdb::HuggingFaceFileSystem)

fixes:
```console
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <lambda>
  File "/nix/store/c7ycrgwv039nqglbif98yggx211sdbcl-python3-3.12.3/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/nix/store/z7j5c19rh7r6ilh7qdhw0zn199fqnkbv-python3.12-duckdb-0.10.3/lib/python3.12/site-packages/duckdb/__init__.py", line 4, in <module>
    import duckdb.functional as functional
  File "/nix/store/z7j5c19rh7r6ilh7qdhw0zn199fqnkbv-python3.12-duckdb-0.10.3/lib/python3.12/site-packages/duckdb/functional/__init__.py", line 1, in <module>
    from duckdb.duckdb.functional import (
ImportError: /nix/store/z7j5c19rh7r6ilh7qdhw0zn199fqnkbv-python3.12-duckdb-0.10.3/lib/python3.12/site-packages/duckdb/duckdb.cpython-312-x86_64-linux-gnu.so: undefined symbol: _ZTVN6duckdb21HuggingFaceFileSystemE
```