### PR TITLE
[Python] Fix bug where `enable_external_access` was not being respected by the replacement scan

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1436,9 +1436,7 @@ case_insensitive_map_t<Value> TransformPyConfigDict(const py::dict &py_config_di
 void CreateNewInstance(DuckDBPyConnection &res, const string &database, DBConfig &config) {
 	// We don't cache unnamed memory instances (i.e., :memory:)
 	bool cache_instance = database != ":memory:" && !database.empty();
-	if (config.options.enable_external_access) {
-		config.replacement_scans.emplace_back(PythonReplacementScan::Replace);
-	}
+	config.replacement_scans.emplace_back(PythonReplacementScan::Replace);
 	res.database = instance_cache.CreateInstance(database, config, cache_instance);
 	res.connection = make_uniq<Connection>(*res.database);
 	auto &context = *res.connection->context;

--- a/tools/pythonpkg/src/python_replacement_scan.cpp
+++ b/tools/pythonpkg/src/python_replacement_scan.cpp
@@ -182,6 +182,11 @@ unique_ptr<TableRef> PythonReplacementScan::Replace(ClientContext &context, Repl
                                                     optional_ptr<ReplacementScanData> data) {
 	auto &table_name = input.table_name;
 
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.options.enable_external_access) {
+		return nullptr;
+	}
+
 	auto &table_ref = input.ref;
 	if (table_ref.external_dependency) {
 		auto dependency_item = table_ref.external_dependency->GetDependency("replacement_cache");

--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -125,6 +125,38 @@ class TestReplacementScan(object):
         ):
             con.execute("select count(*) from random_object").fetchone()
 
+    def test_replacement_disabled(self):
+        df = pd.DataFrame({'a': [1, 2, 3]})
+        # Create regular connection, not disabled
+        con = duckdb.connect()
+        res = con.sql("select * from df").fetchall()
+        assert res == [(1,), (2,), (3,)]
+
+        ## disable external access
+        con.execute("set enable_external_access=false")
+        with pytest.raises(duckdb.CatalogException, match='Table with name df does not exist!'):
+            res = con.sql("select * from df").fetchall()
+        with pytest.raises(
+            duckdb.InvalidInputException, match='Cannot change enable_external_access setting while database is running'
+        ):
+            con.execute("set enable_external_access=true")
+
+        # Create connection with external access disabled
+        con = duckdb.connect(config={'enable_external_access': False})
+        with pytest.raises(duckdb.CatalogException, match='Table with name df does not exist!'):
+            res = con.sql("select * from df").fetchall()
+
+        # Create regular connection, disable inbetween creation and execution
+        con = duckdb.connect()
+        rel = con.sql("select * from df")
+
+        con.execute("set enable_external_access=false")
+
+        with pytest.raises(
+            duckdb.InvalidInputException, match='Attempting to execute an unsuccessful or closed pending query result'
+        ):
+            res = rel.fetchall()
+
     def test_replacement_of_cross_connection_relation(self):
         con1 = duckdb.connect(':memory:')
         con2 = duckdb.connect(':memory:')


### PR DESCRIPTION
This PR fixes #12114

Check the config setting before the replacement scan happens.