### PR TITLE
[DependencyManager] Don't block `ADD COLUMN` statements if there are dependencies.

### DIFF
--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -513,6 +513,9 @@ void DependencyManager::AlterObject(CatalogTransaction transaction, CatalogEntry
 				disallow_alter = false;
 				break;
 			}
+			case AlterTableType::ADD_COLUMN: {
+				disallow_alter = false;
+			}
 			default:
 				break;
 			}

--- a/test/fuzzer/pedro/alter_dependency_conflict.test
+++ b/test/fuzzer/pedro/alter_dependency_conflict.test
@@ -10,15 +10,11 @@ CREATE TABLE t4 (c0 DATE, c3 VARCHAR(10));
 statement ok
 CREATE INDEX i2 ON t4 (c3);
 
-# Catalog Error: Cannot alter entry "t4" because there are entries that depend on it.
-statement error
-ALTER TABLE t4 ADD c1 BLOB;
-----
-Cannot alter entry "t4" because there are entries that depend on it.
-
-# the table should still be in a usable state after the alter
 statement ok
-INSERT INTO t4 VALUES (NULL, NULL)
+ALTER TABLE t4 ADD c1 BLOB;
+
+statement ok
+INSERT INTO t4 VALUES (NULL, NULL, NULL)
 
 statement ok
 START TRANSACTION;

--- a/test/sql/catalog/dependencies/add_column_to_table_referenced_by_fk.test
+++ b/test/sql/catalog/dependencies/add_column_to_table_referenced_by_fk.test
@@ -1,0 +1,33 @@
+# name: test/sql/catalog/dependencies/add_column_to_table_referenced_by_fk.test
+# group: [dependencies]
+
+statement ok
+pragma enable_verification;
+
+statement ok
+create table tbl(a varchar primary key);
+
+statement ok
+create table tbl2(
+	a varchar,
+	foreign key (a) references tbl(a)
+)
+
+statement ok
+insert into tbl values('abc');
+
+statement ok
+insert into tbl2 values ('abc');
+
+statement ok
+alter table tbl add column b integer default 5;
+
+query II
+select * from tbl;
+----
+abc	5
+
+query I
+select * from tbl2;
+----
+abc

--- a/test/sql/catalog/dependencies/add_column_to_table_referenced_by_macro.test
+++ b/test/sql/catalog/dependencies/add_column_to_table_referenced_by_macro.test
@@ -1,0 +1,27 @@
+# name: test/sql/catalog/dependencies/add_column_to_table_referenced_by_macro.test
+# group: [dependencies]
+
+statement ok
+pragma enable_verification;
+
+statement ok
+create table tbl(a varchar default 'abc');
+
+statement ok
+insert into tbl values(DEFAULT);
+
+statement ok
+create macro mcr() as table select * from tbl;
+
+query I
+select * from mcr();
+----
+abc
+
+statement ok
+alter table tbl add column b integer default 5;
+
+query II
+select * from mcr();
+----
+abc	5

--- a/test/sql/catalog/dependencies/add_column_to_table_referenced_by_view.test
+++ b/test/sql/catalog/dependencies/add_column_to_table_referenced_by_view.test
@@ -1,0 +1,27 @@
+# name: test/sql/catalog/dependencies/add_column_to_table_referenced_by_view.test
+# group: [dependencies]
+
+statement ok
+pragma enable_verification;
+
+statement ok
+create table tbl(a varchar default 'abc');
+
+statement ok
+insert into tbl values(DEFAULT);
+
+statement ok
+create view vw as select * from tbl;
+
+query I
+select * from vw;
+----
+abc
+
+statement ok
+alter table tbl add column b integer default 5;
+
+statement error
+select * from vw;
+----
+Contents of view were altered: types don't match! Expected [VARCHAR], but found [VARCHAR, INTEGER] instead

--- a/test/sql/catalog/dependencies/change_type_of_table_column_referenced_by_index.test
+++ b/test/sql/catalog/dependencies/change_type_of_table_column_referenced_by_index.test
@@ -1,0 +1,16 @@
+# name: test/sql/catalog/dependencies/change_type_of_table_column_referenced_by_index.test
+# group: [dependencies]
+
+statement ok
+pragma enable_verification;
+
+statement ok
+create table tbl(a varchar, b integer);
+
+statement ok
+create index idx on tbl(a);
+
+statement error
+alter table tbl alter a set type integer;
+----
+Catalog Error: Cannot change the type of this column: an index depends on it!

--- a/test/sql/catalog/dependencies/remove_table_column_referenced_by_index.test
+++ b/test/sql/catalog/dependencies/remove_table_column_referenced_by_index.test
@@ -1,0 +1,16 @@
+# name: test/sql/catalog/dependencies/remove_table_column_referenced_by_index.test
+# group: [dependencies]
+
+statement ok
+pragma enable_verification;
+
+statement ok
+create table tbl(a varchar, b integer);
+
+statement ok
+create index idx on tbl(a);
+
+statement error
+alter table tbl drop column a;
+----
+Catalog Error: Cannot drop this column: an index depends on it!

--- a/test/sql/catalog/dependencies/rename_table_column_referenced_by_index.test
+++ b/test/sql/catalog/dependencies/rename_table_column_referenced_by_index.test
@@ -1,0 +1,16 @@
+# name: test/sql/catalog/dependencies/rename_table_column_referenced_by_index.test
+# group: [dependencies]
+
+statement ok
+pragma enable_verification;
+
+statement ok
+create table tbl(a varchar);
+
+statement ok
+create index idx on tbl(a);
+
+statement error
+alter table tbl rename a to b;
+----
+Cannot alter entry "tbl" because there are entries that depend on it.

--- a/test/sql/catalog/dependencies/rename_view_referenced_by_table_macro.test
+++ b/test/sql/catalog/dependencies/rename_view_referenced_by_table_macro.test
@@ -1,0 +1,27 @@
+# name: test/sql/catalog/dependencies/rename_view_referenced_by_table_macro.test
+# group: [dependencies]
+
+statement ok
+pragma enable_verification;
+
+# Create a table so our view has something to reference
+statement ok
+create table tbl (a varchar);
+
+# Create the view
+statement ok
+create view vw as select * from tbl;
+
+# Create a table macro that references the view
+statement ok
+create macro static_table() as table select * from vw;
+
+# Rename the view (Postgres 16.0 does not block this ALTER)
+statement ok
+alter view vw rename to vw2;
+
+# Our table macro now errors
+statement error
+select * from static_table();
+----
+Catalog Error: Table with name vw does not exist!

--- a/test/sql/catalog/dependencies/set_default_of_table_column_referenced_by_index.test
+++ b/test/sql/catalog/dependencies/set_default_of_table_column_referenced_by_index.test
@@ -1,0 +1,17 @@
+# name: test/sql/catalog/dependencies/set_default_of_table_column_referenced_by_index.test
+# group: [dependencies]
+
+statement ok
+pragma enable_verification;
+
+statement ok
+create table tbl(a varchar, b integer);
+
+statement ok
+create index idx on tbl(a);
+
+statement error
+alter table tbl alter a set default 'test';
+----
+Dependency Error: Cannot alter entry "tbl" because there are entries that depend on it.
+


### PR DESCRIPTION
This PR fixes #12217 

In https://github.com/duckdb/duckdb/pull/11524 we fixed a bug that was causing dependencies to not be created for Foreign Key Constraints

Because that introduces a dependency that didn't exist previously however, this highlighted a problem in our dependency manager checks which was too strict.

After investigation I feel confident in allowing the ADD COLUMN alter statement even though there are dependencies, nothing should be affected negatively by allowing this.