### PR TITLE
[Python] Add check for 'params' to `table_function`

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1100,6 +1100,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::TableFunction(const string &fna
 	if (params.is_none()) {
 		params = py::list();
 	}
+	if (!py::isinstance<py::list>(params)) {
+		throw InvalidInputException("'params' has to be a list of parameters");
+	}
 	if (!connection) {
 		throw ConnectionException("Connection has already been closed");
 	}

--- a/tools/pythonpkg/tests/fast/relational_api/test_table_function.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_table_function.py
@@ -1,0 +1,17 @@
+import duckdb
+import pytest
+import os
+
+script_path = os.path.dirname(__file__)
+
+
+class TestTableFunction(object):
+    def test_table_function(self, duckdb_cursor):
+        path = os.path.join(script_path, '..', 'data/integers.csv')
+        rel = duckdb_cursor.table_function('read_csv', [path])
+        res = rel.fetchall()
+        assert res == [(1, 10, 0), (2, 50, 30)]
+
+        # Provide only a string as argument, should error, needs a list
+        with pytest.raises(duckdb.InvalidInputException, match=r"'params' has to be a list of parameters"):
+            rel = duckdb_cursor.table_function('read_csv', path)


### PR DESCRIPTION
Without this fix, the provided test that is supposed to error will instead cause a BinderException because the string gets parsed into 60 separate 1-length strings

```
duckdb.duckdb.BinderException: Binder Error: No function matches the given name and argument types 'read_csv(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR)'. You might need to add explicit type casts.
        Candidate functions:
        read_csv(VARCHAR, delim : VARCHAR, dateformat : VARCHAR, column_names : VARCHAR[], sep : VARCHAR, hive_partitioning : BOOLEAN, header : BOOLEAN, escape : VARCHAR, allow_quoted_nulls : BOOLEAN, maximum_line_size : VARCHAR, new_line : VARCHAR, columns : ANY, rejects_limit : BIGINT, force_not_null : VARCHAR[], timestampformat : VARCHAR, auto_detect : BOOLEAN, sample_size : BIGINT, auto_type_candidates : ANY, nullstr : ANY, normalize_names : BOOLEAN, rejects_table : VARCHAR, column_types : ANY, skip : BIGINT, types : ANY, max_line_size : VARCHAR, quote : VARCHAR, rejects_scan : VARCHAR, ignore_errors : BOOLEAN, compression : VARCHAR, names : VARCHAR[], store_rejects : BOOLEAN, all_varchar : BOOLEAN, buffer_size : UBIGINT, decimal_separator : VARCHAR, parallel : BOOLEAN, null_padding : BOOLEAN, dtypes : ANY, filename : ANY, union_by_name : BOOLEAN, hive_types : ANY, hive_types_autocast : BOOLEAN)
        read_csv(VARCHAR[], hive_types_autocast : BOOLEAN, hive_types : ANY, union_by_name : BOOLEAN, filename : ANY, dtypes : ANY, null_padding : BOOLEAN, parallel : BOOLEAN, decimal_separator : VARCHAR, buffer_size : UBIGINT, all_varchar : BOOLEAN, store_rejects : BOOLEAN, names : VARCHAR[], compression : VARCHAR, ignore_errors : BOOLEAN, rejects_scan : VARCHAR, quote : VARCHAR, max_line_size : VARCHAR, types : ANY, skip : BIGINT, column_types : ANY, rejects_table : VARCHAR, normalize_names : BOOLEAN, nullstr : ANY, auto_type_candidates : ANY, sample_size : BIGINT, auto_detect : BOOLEAN, timestampformat : VARCHAR, force_not_null : VARCHAR[], rejects_limit : BIGINT, columns : ANY, new_line : VARCHAR, maximum_line_size : VARCHAR, allow_quoted_nulls : BOOLEAN, escape : VARCHAR, header : BOOLEAN, hive_partitioning : BOOLEAN, sep : VARCHAR, column_names : VARCHAR[], dateformat : VARCHAR, delim : VARCHAR)
```