### PR TITLE
Python: Avoid packaging for both 3.7 on OSX and MacOS 11

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -279,7 +279,7 @@ jobs:
       runs-on: macos-latest
       strategy:
        matrix:
-        python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
+        python_build: [cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
       needs: linux-python3-9
       env:
         CIBW_BUILD: ${{ matrix.python_build}}

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -285,6 +285,7 @@ jobs:
         CIBW_BUILD: ${{ matrix.python_build}}
         CIBW_ARCHS: 'x86_64 universal2 arm64'
         CIBW_TEST_COMMAND: 'python -m pytest {project}/tests/fast  --verbose'
+        CIBW_ENVIRONMENT: 'MACOSX_DEPLOYMENT_TARGET=12.0'
         DUCKDB_BUILD_UNITY: 1
 
       steps:


### PR DESCRIPTION
Tested on my fork, produces wheels that require MacOS 12.0, that means MacOS 11 is supported only building from source. Same for Python 3.7.