### PR TITLE
Allow self-reported error code escape hatch for extensions

### DIFF
--- a/src/main/extension.cpp
+++ b/src/main/extension.cpp
@@ -42,6 +42,10 @@ string ParsedExtensionMetaData::GetInvalidMetadataError() {
 	}
 
 	string result;
+	if (extension_version.size() >= 1 && extension_version[0] == '-') {
+		result += StringUtil::Format("The file is not a valid DuckDB extension, with self-reported error code: '%s'.",
+		                             PrettyPrintString(extension_version.substr(1)));
+	}
 	if (engine_version != duckdb_version) {
 		result += StringUtil::Format("The file was built for DuckDB version '%s', but we can only load extensions "
 		                             "built for DuckDB version '%s'.",

--- a/src/main/extension.cpp
+++ b/src/main/extension.cpp
@@ -42,7 +42,7 @@ string ParsedExtensionMetaData::GetInvalidMetadataError() {
 	}
 
 	string result;
-	if (extension_version.size() >= 1 && extension_version[0] == '-') {
+	if (!extension_version.empty() && extension_version[0] == '-') {
 		result += StringUtil::Format("The file is not a valid DuckDB extension, with self-reported error code: '%s'.",
 		                             PrettyPrintString(extension_version.substr(1)));
 	}


### PR DESCRIPTION
This is not the best / more proper solution, but should allow extension repositories an escape hatch IF within the current infrastructure to declare that a given extension is not available in a more direct way.

Currently failures are due to 404 on http requests, example:
```
D INSTALL 'not_existing';
HTTP Error: Failed to download extension "not_existing" at URL "http://extensions.duckdb.org/7c74a471ee/osx_arm64/not_existing.duckdb_extension.gz"

Candidate extensions: "inet"
```
or the local version a file system failure:
```
D INSTALL 'not_existing.duckdb_extension';
IO Error: Failed to copy local extension "not_existing.duckdb_extension" at PATH "not_existing.duckdb_extension"
```

Idea is allowing repository maintainers that want do to so to add special files that share somehow metadata structure, and can be recognized by duckdb as such, but are marked as defective and contain a brief error message.
```
D INSTALL 'test.duckdb_extension';
IO Error: Failed to install 'test.duckdb_extension'
The file is not a valid DuckDB extension, with self-reported error code: 'only a test file'.
```

Note that thanks to checks introduced in the extension uploading PR the INSTALL does fail, and the file is NOT saved locally, so if the status of a given extension is changed (say an unsupported platform will later become supported), it's just a matter of swapping out the bogus extension with the proper one.

I think improved user experience (errors are actual errors, and small messages can also attached) and almost no cost (1 GET request in the case of HTTP endpoint is payed both if successful or not) might justify considering this PR.

Idea would be for extension repositories to be initialized (say at the start of a nightly build) with placeholder extensions with some error message, and then swapped out when ready. This would make so that any request (say azure on R) is always successful BUT the error message is more precise, and can be for example "not supported platform".

## To test
Checkout duckdb at this commit (gh pr checkout #12237 --repo duckdb/duckdb)
```
GEN=ninja make
cmake -DEXTENSION=test.duckdb_extension -DPLATFORM_FILE=build/release/duckdb_platform_out -DDUCKDB_VERSION="7c74a471ee" -DEXTENSION_VERSION="-only a test file" -DNULL_FILE=scripts/null.txt -P scripts/append_metadata.cmake
./build/release/duckdb -c "INSTALL 'test.duckdb_extension'"
```
should result in
```
IO Error: Failed to install 'test.duckdb_extension'
The file is not a valid DuckDB extension, with self-reported error code: 'only a test file'.
```

## Implementation
Implementation is very hacky: restrict extension version to be starting with NOT a '-', and if so reiterprets the bytes 1-31 of extension_version as error message.
Note that given extensions are tied to a single duckdb version, future versions can improve and use a better mechanics to achieve the same user interaction.