### PR TITLE
Issue #12215: AsOf Predicate Pushdown

### DIFF
--- a/src/include/duckdb/planner/operator/logical_comparison_join.hpp
+++ b/src/include/duckdb/planner/operator/logical_comparison_join.hpp
@@ -51,16 +51,16 @@ public:
 	                                              vector<JoinCondition> conditions,
 	                                              vector<unique_ptr<Expression>> arbitrary_expressions);
 
-	static void ExtractJoinConditions(ClientContext &context, JoinType type, unique_ptr<LogicalOperator> &left_child,
-	                                  unique_ptr<LogicalOperator> &right_child, unique_ptr<Expression> condition,
-	                                  vector<JoinCondition> &conditions,
+	static void ExtractJoinConditions(ClientContext &context, JoinType type, JoinRefType ref_type,
+	                                  unique_ptr<LogicalOperator> &left_child, unique_ptr<LogicalOperator> &right_child,
+	                                  unique_ptr<Expression> condition, vector<JoinCondition> &conditions,
 	                                  vector<unique_ptr<Expression>> &arbitrary_expressions);
-	static void ExtractJoinConditions(ClientContext &context, JoinType type, unique_ptr<LogicalOperator> &left_child,
-	                                  unique_ptr<LogicalOperator> &right_child,
+	static void ExtractJoinConditions(ClientContext &context, JoinType type, JoinRefType ref_type,
+	                                  unique_ptr<LogicalOperator> &left_child, unique_ptr<LogicalOperator> &right_child,
 	                                  vector<unique_ptr<Expression>> &expressions, vector<JoinCondition> &conditions,
 	                                  vector<unique_ptr<Expression>> &arbitrary_expressions);
-	static void ExtractJoinConditions(ClientContext &context, JoinType type, unique_ptr<LogicalOperator> &left_child,
-	                                  unique_ptr<LogicalOperator> &right_child,
+	static void ExtractJoinConditions(ClientContext &context, JoinType type, JoinRefType ref_type,
+	                                  unique_ptr<LogicalOperator> &left_child, unique_ptr<LogicalOperator> &right_child,
 	                                  const unordered_set<idx_t> &left_bindings,
 	                                  const unordered_set<idx_t> &right_bindings,
 	                                  vector<unique_ptr<Expression>> &expressions, vector<JoinCondition> &conditions,

--- a/src/optimizer/pushdown/pushdown_cross_product.cpp
+++ b/src/optimizer/pushdown/pushdown_cross_product.cpp
@@ -52,9 +52,9 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 		vector<JoinCondition> conditions;
 		vector<unique_ptr<Expression>> arbitrary_expressions;
 		const auto join_type = JoinType::INNER;
-		LogicalComparisonJoin::ExtractJoinConditions(GetContext(), join_type, op->children[0], op->children[1],
-		                                             left_bindings, right_bindings, join_expressions, conditions,
-		                                             arbitrary_expressions);
+		LogicalComparisonJoin::ExtractJoinConditions(GetContext(), join_type, join_ref_type, op->children[0],
+		                                             op->children[1], left_bindings, right_bindings, join_expressions,
+		                                             conditions, arbitrary_expressions);
 		// create the join from the join conditions
 		return LogicalComparisonJoin::CreateJoin(GetContext(), join_type, join_ref_type, std::move(op->children[0]),
 		                                         std::move(op->children[1]), std::move(conditions),

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -417,8 +417,8 @@ unique_ptr<LogicalOperator> Binder::PlanLateralJoin(unique_ptr<LogicalOperator> 
 	vector<unique_ptr<Expression>> arbitrary_expressions;
 	if (condition) {
 		// extract join conditions, if there are any
-		LogicalComparisonJoin::ExtractJoinConditions(context, join_type, left, right, std::move(condition), conditions,
-		                                             arbitrary_expressions);
+		LogicalComparisonJoin::ExtractJoinConditions(context, join_type, JoinRefType::REGULAR, left, right,
+		                                             std::move(condition), conditions, arbitrary_expressions);
 	}
 
 	auto perform_delim = PerformDuplicateElimination(*this, correlated);

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -20,6 +20,26 @@
 
 namespace duckdb {
 
+//! Only use conditions that are valid for the join ref type
+static bool IsJoinTypeCondition(const JoinRefType ref_type, const ExpressionType expr_type) {
+	switch (ref_type) {
+	case JoinRefType::ASOF:
+		switch (expr_type) {
+		case ExpressionType::COMPARE_EQUAL:
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		case ExpressionType::COMPARE_GREATERTHAN:
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		case ExpressionType::COMPARE_LESSTHAN:
+			return true;
+		default:
+			return false;
+		}
+	default:
+		return true;
+	}
+}
+
 //! Create a JoinCondition from a comparison
 static bool CreateJoinCondition(Expression &expr, const unordered_set<idx_t> &left_bindings,
                                 const unordered_set<idx_t> &right_bindings, vector<JoinCondition> &conditions) {
@@ -47,7 +67,7 @@ static bool CreateJoinCondition(Expression &expr, const unordered_set<idx_t> &le
 }
 
 void LogicalComparisonJoin::ExtractJoinConditions(
-    ClientContext &context, JoinType type, unique_ptr<LogicalOperator> &left_child,
+    ClientContext &context, JoinType type, JoinRefType ref_type, unique_ptr<LogicalOperator> &left_child,
     unique_ptr<LogicalOperator> &right_child, const unordered_set<idx_t> &left_bindings,
     const unordered_set<idx_t> &right_bindings, vector<unique_ptr<Expression>> &expressions,
     vector<JoinCondition> &conditions, vector<unique_ptr<Expression>> &arbitrary_expressions) {
@@ -90,7 +110,8 @@ void LogicalComparisonJoin::ExtractJoinConditions(
 
 		{
 			// comparison, check if we can create a comparison JoinCondition
-			if (CreateJoinCondition(*expr, left_bindings, right_bindings, conditions)) {
+			if (IsJoinTypeCondition(ref_type, expr->type) &&
+			    CreateJoinCondition(*expr, left_bindings, right_bindings, conditions)) {
 				// successfully created the join condition
 				continue;
 			}
@@ -99,7 +120,7 @@ void LogicalComparisonJoin::ExtractJoinConditions(
 	}
 }
 
-void LogicalComparisonJoin::ExtractJoinConditions(ClientContext &context, JoinType type,
+void LogicalComparisonJoin::ExtractJoinConditions(ClientContext &context, JoinType type, JoinRefType ref_type,
                                                   unique_ptr<LogicalOperator> &left_child,
                                                   unique_ptr<LogicalOperator> &right_child,
                                                   vector<unique_ptr<Expression>> &expressions,
@@ -108,11 +129,11 @@ void LogicalComparisonJoin::ExtractJoinConditions(ClientContext &context, JoinTy
 	unordered_set<idx_t> left_bindings, right_bindings;
 	LogicalJoin::GetTableReferences(*left_child, left_bindings);
 	LogicalJoin::GetTableReferences(*right_child, right_bindings);
-	return ExtractJoinConditions(context, type, left_child, right_child, left_bindings, right_bindings, expressions,
-	                             conditions, arbitrary_expressions);
+	return ExtractJoinConditions(context, type, ref_type, left_child, right_child, left_bindings, right_bindings,
+	                             expressions, conditions, arbitrary_expressions);
 }
 
-void LogicalComparisonJoin::ExtractJoinConditions(ClientContext &context, JoinType type,
+void LogicalComparisonJoin::ExtractJoinConditions(ClientContext &context, JoinType type, JoinRefType ref_type,
                                                   unique_ptr<LogicalOperator> &left_child,
                                                   unique_ptr<LogicalOperator> &right_child,
                                                   unique_ptr<Expression> condition, vector<JoinCondition> &conditions,
@@ -121,7 +142,7 @@ void LogicalComparisonJoin::ExtractJoinConditions(ClientContext &context, JoinTy
 	vector<unique_ptr<Expression>> expressions;
 	expressions.push_back(std::move(condition));
 	LogicalFilter::SplitPredicates(expressions);
-	return ExtractJoinConditions(context, type, left_child, right_child, expressions, conditions,
+	return ExtractJoinConditions(context, type, ref_type, left_child, right_child, expressions, conditions,
 	                             arbitrary_expressions);
 }
 
@@ -135,9 +156,6 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(ClientContext &con
 	bool need_to_consider_arbitrary_expressions = true;
 	switch (reftype) {
 	case JoinRefType::ASOF: {
-		if (!arbitrary_expressions.empty()) {
-			throw BinderException("Invalid ASOF JOIN condition");
-		}
 		need_to_consider_arbitrary_expressions = false;
 		auto asof_idx = conditions.size();
 		for (size_t c = 0; c < conditions.size(); ++c) {
@@ -249,7 +267,7 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(ClientContext &con
                                                               unique_ptr<Expression> condition) {
 	vector<JoinCondition> conditions;
 	vector<unique_ptr<Expression>> arbitrary_expressions;
-	LogicalComparisonJoin::ExtractJoinConditions(context, type, left_child, right_child, std::move(condition),
+	LogicalComparisonJoin::ExtractJoinConditions(context, type, reftype, left_child, right_child, std::move(condition),
 	                                             conditions, arbitrary_expressions);
 	return LogicalComparisonJoin::CreateJoin(context, type, reftype, std::move(left_child), std::move(right_child),
 	                                         std::move(conditions), std::move(arbitrary_expressions));

--- a/test/sql/join/asof/test_asof_join.test
+++ b/test/sql/join/asof/test_asof_join.test
@@ -37,6 +37,42 @@ FROM trades t ASOF JOIN prices p
 ----
 2020-01-01 00:00:03	1	42
 
+# Ignore non-join conditions 
+query II
+SELECT p.ts, e.value
+FROM range(0,10) p(ts) ASOF JOIN events0 e
+ON 1 = 1 AND p.ts >= e.begin
+ORDER BY p.ts ASC
+----
+1	0
+2	0
+3	1
+4	1
+5	1
+6	2
+7	2
+8	3
+9	3
+
+query II
+WITH samples AS (
+	SELECT col0 AS starts, col1 AS ends
+	FROM (VALUES
+		(5, 9),
+		(10, 13),
+		(14, 20),
+		(21, 23)
+	)
+)
+SELECT
+      s1.starts as s1_starts,
+      s2.starts as s2_starts,
+FROM samples AS s1 ASOF JOIN samples as s2 ON s2.ends >= (s1.ends - 5)
+WHERE s1_starts <> s2_starts;
+----
+21 	14
+10	5
+
 # Use an ASOF join inside of a correlated subquery
 
 
@@ -51,16 +87,7 @@ FROM range(0,10) p(ts) ASOF JOIN events0 e
 ON p.ts <> e.begin
 ORDER BY p.ts ASC
 ----
-Binder Error: Invalid ASOF JOIN comparison
-
-# Invalid ASOF JOIN condition
-statement error
-SELECT p.ts, e.value
-FROM range(0,10) p(ts) ASOF JOIN events0 e
-ON 1 = 1 AND p.ts >= e.begin
-ORDER BY p.ts ASC
-----
-Binder Error: Invalid ASOF JOIN condition
+Binder Error: Missing ASOF JOIN inequality
 
 # Missing ASOF JOIN inequality
 statement error


### PR DESCRIPTION
Don't split conditions that are not AsOf comparisons.

fixes: duckdb#12215
fixes: duckdblabs/duckdb-internal#2124