### PR TITLE
Fix #12225: revert OVERWRITE_OR_IGNORE to previous behavior, move new behavior to OVERWRITE flag

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/common/enums/catalog_lookup_behavior.hpp"
 #include "duckdb/common/enums/catalog_type.hpp"
 #include "duckdb/common/enums/compression_type.hpp"
+#include "duckdb/common/enums/copy_overwrite_mode.hpp"
 #include "duckdb/common/enums/cte_materialize.hpp"
 #include "duckdb/common/enums/date_part_specifier.hpp"
 #include "duckdb/common/enums/debug_initialize.hpp"
@@ -1302,6 +1303,34 @@ ConstraintType EnumUtil::FromString<ConstraintType>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "FOREIGN_KEY")) {
 		return ConstraintType::FOREIGN_KEY;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<CopyOverwriteMode>(CopyOverwriteMode value) {
+	switch(value) {
+	case CopyOverwriteMode::COPY_ERROR_ON_CONFLICT:
+		return "COPY_ERROR_ON_CONFLICT";
+	case CopyOverwriteMode::COPY_OVERWRITE:
+		return "COPY_OVERWRITE";
+	case CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE:
+		return "COPY_OVERWRITE_OR_IGNORE";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+CopyOverwriteMode EnumUtil::FromString<CopyOverwriteMode>(const char *value) {
+	if (StringUtil::Equals(value, "COPY_ERROR_ON_CONFLICT")) {
+		return CopyOverwriteMode::COPY_ERROR_ON_CONFLICT;
+	}
+	if (StringUtil::Equals(value, "COPY_OVERWRITE")) {
+		return CopyOverwriteMode::COPY_OVERWRITE;
+	}
+	if (StringUtil::Equals(value, "COPY_OVERWRITE_OR_IGNORE")) {
+		return CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -228,11 +228,15 @@ unique_ptr<LocalSinkState> PhysicalCopyToFile::GetLocalSinkState(ExecutionContex
 	return std::move(res);
 }
 
-void CheckDirectory(FileSystem &fs, const string &file_path, bool overwrite) {
-	if (fs.IsRemoteFile(file_path) && overwrite) {
-		// we only remove files for local file systems
-		// as remote file systems (e.g. S3) do not support RemoveFile
+void CheckDirectory(FileSystem &fs, const string &file_path, CopyOverwriteMode overwrite_mode) {
+	if (overwrite_mode == CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE) {
+		// with overwrite or ignore we fully ignore the presence of any files instead of erasing them
 		return;
+	}
+	if (fs.IsRemoteFile(file_path) && overwrite_mode == CopyOverwriteMode::COPY_OVERWRITE) {
+		// we can only remove files for local file systems currently
+		// as remote file systems (e.g. S3) do not support RemoveFile
+		throw NotImplementedException("OVERWRITE is not supported for remote file systems");
 	}
 	vector<string> file_list;
 	vector<string> directory_list;
@@ -251,13 +255,12 @@ void CheckDirectory(FileSystem &fs, const string &file_path, bool overwrite) {
 	if (file_list.empty()) {
 		return;
 	}
-	if (overwrite) {
+	if (overwrite_mode == CopyOverwriteMode::COPY_OVERWRITE) {
 		for (auto &file : file_list) {
 			fs.RemoveFile(file);
 		}
 	} else {
-		throw IOException("Directory \"%s\" is not empty! Enable OVERWRITE_OR_IGNORE option to force writing",
-		                  file_path);
+		throw IOException("Directory \"%s\" is not empty! Enable OVERWRITE option to overwrite files", file_path);
 	}
 }
 
@@ -272,11 +275,11 @@ unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext
 				throw IOException("Cannot write to \"%s\" - it exists and is a file, not a directory!", file_path);
 			} else {
 				// for local files we can remove the file if OVERWRITE_OR_IGNORE is enabled
-				if (overwrite_or_ignore) {
+				if (overwrite_mode == CopyOverwriteMode::COPY_OVERWRITE) {
 					fs.RemoveFile(file_path);
 				} else {
 					throw IOException("Cannot write to \"%s\" - it exists and is a file, not a directory! Enable "
-					                  "OVERWRITE_OR_IGNORE option to force writing",
+					                  "OVERWRITE option to overwrite the file",
 					                  file_path);
 				}
 			}
@@ -285,7 +288,7 @@ unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext
 		if (!fs.DirectoryExists(file_path)) {
 			fs.CreateDirectory(file_path);
 		} else {
-			CheckDirectory(fs, file_path, overwrite_or_ignore);
+			CheckDirectory(fs, file_path, overwrite_mode);
 		}
 
 		auto state = make_uniq<CopyToFunctionGlobalState>(nullptr);

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -17,7 +17,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 		op.file_path = fs.JoinPath(path, "tmp_" + base);
 	}
 	if (op.per_thread_output || op.file_size_bytes.IsValid() || op.partition_output || !op.partition_columns.empty() ||
-	    op.overwrite_or_ignore) {
+	    op.overwrite_mode != CopyOverwriteMode::COPY_ERROR_ON_CONFLICT) {
 		// hive-partitioning/per-thread output does not care about insertion order, and does not support batch indexes
 		preserve_insertion_order = false;
 		supports_batch_index = false;
@@ -42,7 +42,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile
 	auto copy = make_uniq<PhysicalCopyToFile>(op.types, op.function, std::move(op.bind_data), op.estimated_cardinality);
 	copy->file_path = op.file_path;
 	copy->use_tmp_file = op.use_tmp_file;
-	copy->overwrite_or_ignore = op.overwrite_or_ignore;
+	copy->overwrite_mode = op.overwrite_mode;
 	copy->filename_pattern = op.filename_pattern;
 	copy->file_extension = op.file_extension;
 	copy->per_thread_output = op.per_thread_output;

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -98,6 +98,8 @@ enum class ConflictManagerMode : uint8_t;
 
 enum class ConstraintType : uint8_t;
 
+enum class CopyOverwriteMode : uint8_t;
+
 enum class DataFileType : uint8_t;
 
 enum class DatePartSpecifier : uint8_t;
@@ -433,6 +435,9 @@ const char* EnumUtil::ToChars<ConflictManagerMode>(ConflictManagerMode value);
 
 template<>
 const char* EnumUtil::ToChars<ConstraintType>(ConstraintType value);
+
+template<>
+const char* EnumUtil::ToChars<CopyOverwriteMode>(CopyOverwriteMode value);
 
 template<>
 const char* EnumUtil::ToChars<DataFileType>(DataFileType value);
@@ -887,6 +892,9 @@ ConflictManagerMode EnumUtil::FromString<ConflictManagerMode>(const char *value)
 
 template<>
 ConstraintType EnumUtil::FromString<ConstraintType>(const char *value);
+
+template<>
+CopyOverwriteMode EnumUtil::FromString<CopyOverwriteMode>(const char *value);
 
 template<>
 DataFileType EnumUtil::FromString<DataFileType>(const char *value);

--- a/src/include/duckdb/common/enums/copy_overwrite_mode.hpp
+++ b/src/include/duckdb/common/enums/copy_overwrite_mode.hpp
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/copy_overwrite_mode.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+enum class CopyOverwriteMode : uint8_t { COPY_ERROR_ON_CONFLICT = 0, COPY_OVERWRITE = 1, COPY_OVERWRITE_OR_IGNORE = 2 };
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/parser/parsed_data/copy_info.hpp"
+#include "duckdb/common/enums/copy_overwrite_mode.hpp"
 
 namespace duckdb {
 
@@ -31,7 +32,7 @@ public:
 	bool use_tmp_file;
 	FilenamePattern filename_pattern;
 	string file_extension;
-	bool overwrite_or_ignore;
+	CopyOverwriteMode overwrite_mode;
 	bool parallel;
 	bool per_thread_output;
 	optional_idx file_size_bytes;

--- a/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
+++ b/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/common/enums/copy_overwrite_mode.hpp"
 
 namespace duckdb {
 
@@ -33,7 +34,7 @@ public:
 	bool use_tmp_file;
 	FilenamePattern filename_pattern;
 	string file_extension;
-	bool overwrite_or_ignore;
+	CopyOverwriteMode overwrite_mode;
 	bool per_thread_output;
 	optional_idx file_size_bytes;
 

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -55,12 +55,13 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	}
 
 	bool use_tmp_file = true;
-	bool overwrite_or_ignore = false;
+	CopyOverwriteMode overwrite_mode = CopyOverwriteMode::COPY_ERROR_ON_CONFLICT;
 	FilenamePattern filename_pattern;
 	bool user_set_use_tmp_file = false;
 	bool per_thread_output = false;
 	optional_idx file_size_bytes;
 	vector<idx_t> partition_cols;
+	bool seen_overwrite_mode = false;
 
 	CopyFunctionBindInput bind_input(*stmt.info);
 
@@ -74,8 +75,20 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 		if (loption == "use_tmp_file") {
 			use_tmp_file = GetBooleanArg(context, option.second);
 			user_set_use_tmp_file = true;
-		} else if (loption == "overwrite_or_ignore") {
-			overwrite_or_ignore = GetBooleanArg(context, option.second);
+		} else if (loption == "overwrite_or_ignore" || loption == "overwrite") {
+			if (seen_overwrite_mode) {
+				throw BinderException("Can only set one of OVERWRITE_OR_IGNORE or OVERWRITE");
+			}
+			seen_overwrite_mode = true;
+
+			auto boolean = GetBooleanArg(context, option.second);
+			if (boolean) {
+				if (loption == "overwrite_or_ignore") {
+					overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
+				} else if (loption == "overwrite") {
+					overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE;
+				}
+			}
 		} else if (loption == "filename_pattern") {
 			if (option.second.empty()) {
 				throw IOException("FILENAME_PATTERN cannot be empty");
@@ -146,7 +159,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	auto copy = make_uniq<LogicalCopyToFile>(copy_function.function, std::move(function_data), std::move(stmt.info));
 	copy->file_path = file_path;
 	copy->use_tmp_file = use_tmp_file;
-	copy->overwrite_or_ignore = overwrite_or_ignore;
+	copy->overwrite_mode = overwrite_mode;
 	copy->filename_pattern = filename_pattern;
 	copy->file_extension = bind_input.file_extension;
 	copy->per_thread_output = per_thread_output;

--- a/src/planner/operator/logical_copy_to_file.cpp
+++ b/src/planner/operator/logical_copy_to_file.cpp
@@ -13,7 +13,7 @@ void LogicalCopyToFile::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty(200, "file_path", file_path);
 	serializer.WriteProperty(201, "use_tmp_file", use_tmp_file);
 	serializer.WriteProperty(202, "filename_pattern", filename_pattern);
-	serializer.WriteProperty(203, "overwrite_or_ignore", overwrite_or_ignore);
+	serializer.WriteProperty(203, "overwrite_or_ignore", overwrite_mode);
 	serializer.WriteProperty(204, "per_thread_output", per_thread_output);
 	serializer.WriteProperty(205, "partition_output", partition_output);
 	serializer.WriteProperty(206, "partition_columns", partition_columns);
@@ -39,7 +39,7 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(Deserializer &deseria
 	auto file_path = deserializer.ReadProperty<string>(200, "file_path");
 	auto use_tmp_file = deserializer.ReadProperty<bool>(201, "use_tmp_file");
 	auto filename_pattern = deserializer.ReadProperty<FilenamePattern>(202, "filename_pattern");
-	auto overwrite_or_ignore = deserializer.ReadProperty<bool>(203, "overwrite_or_ignore");
+	auto overwrite_mode = deserializer.ReadProperty<CopyOverwriteMode>(203, "overwrite_mode");
 	auto per_thread_output = deserializer.ReadProperty<bool>(204, "per_thread_output");
 	auto partition_output = deserializer.ReadProperty<bool>(205, "partition_output");
 	auto partition_columns = deserializer.ReadProperty<vector<idx_t>>(206, "partition_columns");
@@ -86,7 +86,7 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(Deserializer &deseria
 	result->use_tmp_file = use_tmp_file;
 	result->filename_pattern = filename_pattern;
 	result->file_extension = file_extension;
-	result->overwrite_or_ignore = overwrite_or_ignore;
+	result->overwrite_mode = overwrite_mode;
 	result->per_thread_output = per_thread_output;
 	result->partition_output = partition_output;
 	result->partition_columns = partition_columns;

--- a/test/sql/copy/format_uuid.test
+++ b/test/sql/copy/format_uuid.test
@@ -61,6 +61,7 @@ SELECT * FROM '__TEST_DIR__/part/a=9/leading_????????-????-4???-????-???????????
 query III sort
 SELECT * FROM '__TEST_DIR__/part/a=9/leading_????????-????-4???-????-????????????*.parquet';
 ----
+9	18	81
 9	27	729
 
 # Test without a specified format name for the outputfile.
@@ -77,6 +78,8 @@ SELECT * FROM '__TEST_DIR__/part/a=9/data_[0-9]*.parquet';
 query III sort
 SELECT * FROM '__TEST_DIR__/part/a=9/*.parquet';
 ----
+9	18	81
+9	27	729
 9	36	6561
 
 # Test where the FILENAME_PATTERN does not contain "{i}" or "{uuid}". 
@@ -93,6 +96,9 @@ SELECT * FROM '__TEST_DIR__/part/a=9/basename[0-9]*.parquet';
 query III sort
 SELECT * FROM '__TEST_DIR__/part/a=9/*.parquet';
 ----
+9	18	81
+9	27	729
+9	36	6561
 9	45	59049
 
 # Test without the overwrite_or_ignore param, that tries to add a file to an existing directory

--- a/test/sql/copy/partitioned/hive_partitioning_overwrite.test
+++ b/test/sql/copy/partitioned/hive_partitioning_overwrite.test
@@ -40,3 +40,8 @@ query I
 SELECT * FROM '__TEST_DIR__/overwrite_test2/**/*.parquet'
 ----
 84
+
+statement error
+COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE 1, OVERWRITE_OR_IGNORE 1);
+----
+Can only set one of OVERWRITE_OR_IGNORE or OVERWRITE

--- a/test/sql/copy/partitioned/hive_partitioning_overwrite.test
+++ b/test/sql/copy/partitioned/hive_partitioning_overwrite.test
@@ -12,11 +12,11 @@ COPY (SELECT 42 AS part_col) TO '__TEST_DIR__/overwrite_test' (FORMAT PARQUET, P
 statement error
 COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test' (FORMAT PARQUET, PARTITION_BY (part_col));
 ----
-Enable OVERWRITE_OR_IGNORE option to force writing
+Enable OVERWRITE option to overwrite files
 
 # test the overwrite setting
 statement ok
-COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE_OR_IGNORE 1);
+COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE 1);
 
 # the old file (with part_col=42) should now be removed
 query I
@@ -34,7 +34,7 @@ COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET, 
 it exists and is a file
 
 statement ok
-COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE_OR_IGNORE 1);
+COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test2' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE 1);
 
 query I
 SELECT * FROM '__TEST_DIR__/overwrite_test2/**/*.parquet'

--- a/test/sql/copy/s3/s3_hive_partition.test
+++ b/test/sql/copy/s3/s3_hive_partition.test
@@ -98,3 +98,7 @@ EXPLAIN select a from read_csv_auto('s3://test-bucket/hive-partitioning/filter-t
 ----
 physical_plan	<REGEX>:.*FILTER.*(a < 4).*READ_CSV_AUTO.*File Filters: \(CAST\(c AS.*INTEGER\) = 500\).*
 
+statement error
+COPY (SELECT * FROM t1) TO 's3://test-bucket/hive-partitioning/filter-test-parquet' (FORMAT PARQUET, PARTITION_BY c, OVERWRITE);
+----
+OVERWRITE is not supported for remote file systems

--- a/tools/pythonpkg/tests/fast/api/test_to_csv.py
+++ b/tools/pythonpkg/tests/fast/api/test_to_csv.py
@@ -218,7 +218,7 @@ class TestToCSV(object):
         )
         rel = duckdb.from_df(df)
         rel.to_csv(temp_file_name, header=True, partition_by=["c_category_1"])
-        with pytest.raises(duckdb.IOException, match="Enable OVERWRITE_OR_IGNORE option to force writing"):
+        with pytest.raises(duckdb.IOException, match="OVERWRITE"):
             rel.to_csv(temp_file_name, header=True, partition_by=["c_category_1"])
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])


### PR DESCRIPTION
Fixes #12225

This PR reverts `OVERWRITE_OR_IGNORE` to the previous behavior where files are overwritten if they exist, or ignored (left alone) if they do not. The new behavior introduced in https://github.com/duckdb/duckdb/pull/11787 is instead moved to a new flag (`OVERWRITE`). The new flag is more explicit in what it does, and is also explicitly disabled for remote file systems (e.g. S3) where we don't support removing files yet.