### PR TITLE
Duck extension catalog

### DIFF
--- a/src/include/duckdb/catalog/duck_catalog.hpp
+++ b/src/include/duckdb/catalog/duck_catalog.hpp
@@ -58,6 +58,9 @@ public:
 
 	DUCKDB_API bool InMemory() override;
 	DUCKDB_API string GetDBPath() override;
+	virtual string GetExtensionName() {
+		return "";
+	}
 
 private:
 	DUCKDB_API void DropSchema(CatalogTransaction transaction, DropInfo &info);

--- a/src/include/duckdb/storage/magic_bytes.hpp
+++ b/src/include/duckdb/storage/magic_bytes.hpp
@@ -22,7 +22,7 @@ enum class DataFileType : uint8_t {
 
 class MagicBytes {
 public:
-	static DataFileType CheckMagicBytes(FileSystem &fs, const string &path);
+	static DataFileType CheckMagicBytes(FileSystem &fs, const string &path, string &extension);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -39,6 +39,7 @@ public:
 	FileOpenFlags GetFileFlags(bool create_new) const;
 	void CreateNewDatabase();
 	void LoadExistingDatabase();
+	static string GetDBExtensionType(FileHandle &handle);
 
 	//! Creates a new Block using the specified block_id and returns a pointer
 	unique_ptr<Block> ConvertBlock(block_id_t block_id, FileBuffer &source_buffer) override;

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -37,7 +37,7 @@ public:
 	SingleFileBlockManager(AttachedDatabase &db, string path, StorageManagerOptions options);
 
 	FileOpenFlags GetFileFlags(bool create_new) const;
-	void CreateNewDatabase();
+	void CreateNewDatabase(const string &extension_type = "");
 	void LoadExistingDatabase();
 	static string GetDBExtensionType(FileHandle &handle);
 

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -74,9 +74,14 @@ struct MainHeader {
 	string LibraryGitHash() {
 		return string(char_ptr_cast(library_git_hash), 0, MAX_VERSION_SIZE);
 	}
+	string OptionalExtensionName() {
+		return string(char_ptr_cast(optional_extension_name), 0, MAX_VERSION_SIZE);
+	}
 
 	void Write(WriteStream &ser);
 	static MainHeader Read(ReadStream &source);
+
+	data_t optional_extension_name[MAX_VERSION_SIZE];
 
 private:
 	data_t library_git_desc[MAX_VERSION_SIZE];

--- a/src/main/database_path_and_type.cpp
+++ b/src/main/database_path_and_type.cpp
@@ -16,11 +16,12 @@ void DBPathAndType::ExtractExtensionPrefix(string &path, string &db_type) {
 
 void DBPathAndType::CheckMagicBytes(FileSystem &fs, string &path, string &db_type) {
 	// if there isn't - check the magic bytes of the file (if any)
-	auto file_type = MagicBytes::CheckMagicBytes(fs, path);
+	string extension = "";
+	auto file_type = MagicBytes::CheckMagicBytes(fs, path, extension);
 	if (file_type == DataFileType::SQLITE_FILE) {
 		db_type = "sqlite";
 	} else {
-		db_type = "";
+		db_type = extension;
 	}
 }
 

--- a/src/storage/magic_bytes.cpp
+++ b/src/storage/magic_bytes.cpp
@@ -1,10 +1,10 @@
 #include "duckdb/storage/magic_bytes.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/storage/storage_info.hpp"
-
+#include "duckdb/storage/single_file_block_manager.hpp"
 namespace duckdb {
 
-DataFileType MagicBytes::CheckMagicBytes(FileSystem &fs, const string &path) {
+DataFileType MagicBytes::CheckMagicBytes(FileSystem &fs, const string &path, string &extension) {
 	if (path.empty() || path == IN_MEMORY_PATH) {
 		return DataFileType::DUCKDB_FILE;
 	}
@@ -24,6 +24,7 @@ DataFileType MagicBytes::CheckMagicBytes(FileSystem &fs, const string &path) {
 		return DataFileType::PARQUET_FILE;
 	}
 	if (memcmp(buffer + MainHeader::MAGIC_BYTE_OFFSET, MainHeader::MAGIC_BYTES, MainHeader::MAGIC_BYTE_SIZE) == 0) {
+		extension = SingleFileBlockManager::GetDBExtensionType(*handle);
 		return DataFileType::DUCKDB_FILE;
 	}
 	return DataFileType::FILE_DOES_NOT_EXIST;

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -171,7 +171,7 @@ FileOpenFlags SingleFileBlockManager::GetFileFlags(bool create_new) const {
 	return result;
 }
 
-void SingleFileBlockManager::CreateNewDatabase() {
+void SingleFileBlockManager::CreateNewDatabase(const string &extension_name) {
 	auto flags = GetFileFlags(true);
 
 	// open the RDBMS handle
@@ -186,6 +186,10 @@ void SingleFileBlockManager::CreateNewDatabase() {
 	main_header.version_number = VERSION_NUMBER;
 	memset(main_header.flags, 0, sizeof(uint64_t) * 4);
 
+	memset(main_header.optional_extension_name, 0, 32);
+	for (idx_t i = 0; i < extension_name.size(); i++) {
+		main_header.optional_extension_name[i] = static_cast<data_t>(extension_name[i]);
+	}
 	SerializeHeaderStructure<MainHeader>(main_header, header_buffer.buffer);
 	// now write the header to the file
 	ChecksumAndWrite(header_buffer, 0);

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -37,6 +37,7 @@ void MainHeader::Write(WriteStream &ser) {
 	}
 	SerializeVersionNumber(ser, DuckDB::LibraryVersion());
 	SerializeVersionNumber(ser, DuckDB::SourceID());
+	SerializeVersionNumber(ser, OptionalExtensionName());
 }
 
 void MainHeader::CheckMagicBytes(FileHandle &handle) {
@@ -87,6 +88,7 @@ MainHeader MainHeader::Read(ReadStream &source) {
 	}
 	DeserializeVersionNumber(source, header.library_git_desc);
 	DeserializeVersionNumber(source, header.library_git_hash);
+	DeserializeVersionNumber(source, header.optional_extension_name);
 	return header;
 }
 
@@ -218,6 +220,13 @@ void SingleFileBlockManager::CreateNewDatabase() {
 	iteration_count = 0;
 	active_header = 1;
 	max_block = 0;
+}
+
+string SingleFileBlockManager::GetDBExtensionType(FileHandle &handle) {
+	data_t main_header_bytes[128];
+	handle.Read(main_header_bytes, 128, 8);
+	auto t = DeserializeHeaderStructure<MainHeader>(main_header_bytes);
+	return t.OptionalExtensionName();
 }
 
 void SingleFileBlockManager::LoadExistingDatabase() {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -178,7 +178,7 @@ void SingleFileStorageManager::LoadDatabase() {
 
 		// initialize the block manager while creating a new db file
 		auto sf_block_manager = make_uniq<SingleFileBlockManager>(db, path, options);
-		sf_block_manager->CreateNewDatabase();
+		sf_block_manager->CreateNewDatabase(Catalog::GetCatalog(db).Cast<DuckCatalog>().GetExtensionName());
 		block_manager = std::move(sf_block_manager);
 		table_io_manager = make_uniq<SingleFileTableIOManager>(*block_manager);
 	} else {


### PR DESCRIPTION
I concretised an idea I had, filing the PR since it's more tangible.

## What
Store in the header of DuckDB file that a DB file belongs to a given extension type, that is needed to have it loaded before proceeding.

## Why
While requiring extension should not be strictly needed to access the data (also thanks to autoloading), there might be cases where an extensions want to use power of DuckDB file format but having (if they do not opt out) user autoload a given extension on ATTACH.
End user side is like:
```
ATTACH 'file.db';
```
where you have no information that the stored data will require a given extension, to read metadata present in the file header, that say is `my_ext_name` and then logically following the same codepath as:
```
ATTACH 'file.db' (TYPE my_ext_name);
```
This transformation can always be avoided user side by explicitly specifying the TYPE Like `ATTACH 'file.db' (TYPE duckdb)`.

Currently you need to rely on external metadata to know that `file.db` might not be completely functional if a given extension is missing.

## But why?
I can mainly see 2 use cases:
* extensions that expand not yet so well compartimentalized duckdb components (e.g. VSS might be an example here that can benefit from this).
* storage compatibility layers extensions, where we might want to be able to create compatibility-extensions (say a file created by a future duckdb version but still readable IF a compatibility extension is present) or anyhow being able to backport future development as DuckDB version 1.0 DBs.

## How
Adding a metadata field at the current end of the MainHeader for database files.

## Structure
Commit 1 is whatever is needed for the READ part, so possibly that can also be considered for inclusion separately.
Commit 2 is the infrastructure for producing the metadata.

## Extension side
This requires, to be of actual use, for the target extension to subscribe to the StorageExtension API with default functions like for VSS adding this infrastructure (note that Attach and CreateTransactionManager are here default, but for the fact that Attach returns a DuckVSSCatalog that overrides GetExtensionName():
```
class DuckVSSCatalog : public DuckCatalog {
public:
       explicit DuckVSSCatalog(AttachedDatabase &db) : DuckCatalog(db) {
       }
       string GetExtensionName() override {
               return "vss";
       }
       ~DuckVSSCatalog() override  {
       }
};

static duckdb::unique_ptr<Catalog> VSSAttach(StorageExtensionInfo *storage_info, ClientContext &context,
                                        AttachedDatabase &db, const string &name, AttachInfo &info,
                                        AccessMode access_mode) {
       info.options["type"] = "vss"; // possibly not needed, unsure
       return make_uniq<DuckVSSCatalog>(db);
}

static duckdb::unique_ptr<TransactionManager> VSSCreateTransactionManager(StorageExtensionInfo *storage_info,
                                                                     AttachedDatabase &db, Catalog &catalog) {
        return make_uniq<DuckTransactionManager>(db);
}
VSSStorageExtension::VSSStorageExtension() {
       attach = VSSAttach;
       create_transaction_manager = VSSCreateTransactionManager;
}

 static void LoadInternal(DatabaseInstance &instance) {
       //other logic
       
       auto &config = DBConfig::GetConfig(instance);
       config.storage_extensions["vss"] = make_uniq<VSSStorageExtension>();
 }
```

This possibly allows even more complex interactions, but this is already quite powerful.