### PR TITLE
Fix warning on unannotated fallthrough

### DIFF
--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -515,6 +515,7 @@ void DependencyManager::AlterObject(CatalogTransaction transaction, CatalogEntry
 			}
 			case AlterTableType::ADD_COLUMN: {
 				disallow_alter = false;
+				break;
 			}
 			default:
 				break;


### PR DESCRIPTION
Fixes a nightly CI failure (https://github.com/duckdb/duckdb/actions/runs/9239271976/job/25418247433#step:6:195) 
```
/Users/runner/work/duckdb/duckdb/src/catalog/dependency_manager.cpp:519:4: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
```

Logic is unchanged but for avoiding the warning.