### PR TITLE
duckdb_*() tags to go from MAP(VARCHAR,VARCHAR) to VARCHAR

### DIFF
--- a/src/function/table/system/duckdb_functions.cpp
+++ b/src/function/table/system/duckdb_functions.cpp
@@ -50,7 +50,7 @@ static unique_ptr<FunctionData> DuckDBFunctionsBind(ClientContext &context, Tabl
 	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("tags");
-	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("return_type");
 	return_types.emplace_back(LogicalType::VARCHAR);
@@ -473,8 +473,8 @@ bool ExtractFunctionData(FunctionEntry &entry, idx_t function_idx, DataChunk &ou
 	// comment, LogicalType::VARCHAR
 	output.SetValue(col++, output_offset, entry.comment);
 
-	// tags, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)
-	output.SetValue(col++, output_offset, Value::MAP(entry.tags));
+	// tags, VARCHAR
+	output.SetValue(col++, output_offset, Value(Value::MAP(entry.tags).ToString()));
 
 	// return_type, LogicalType::VARCHAR
 	output.SetValue(col++, output_offset, OP::GetReturnType(function, function_idx));

--- a/src/function/table/system/duckdb_indexes.cpp
+++ b/src/function/table/system/duckdb_indexes.cpp
@@ -46,7 +46,7 @@ static unique_ptr<FunctionData> DuckDBIndexesBind(ClientContext &context, TableF
 	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("tags");
-	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("is_unique");
 	return_types.emplace_back(LogicalType::BOOLEAN);
@@ -112,8 +112,8 @@ void DuckDBIndexesFunction(ClientContext &context, TableFunctionInput &data_p, D
 		output.SetValue(col++, count, Value::BIGINT(NumericCast<int64_t>(table_entry.oid)));
 		// comment, VARCHAR
 		output.SetValue(col++, count, Value(index.comment));
-		// tags, MAP
-		output.SetValue(col++, count, Value::MAP(index.tags));
+		// tags, VARCHAR
+		output.SetValue(col++, count, Value(Value::MAP(index.tags).ToString()));
 		// is_unique, BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(index.IsUnique()));
 		// is_primary, BOOLEAN

--- a/src/function/table/system/duckdb_schemas.cpp
+++ b/src/function/table/system/duckdb_schemas.cpp
@@ -34,7 +34,7 @@ static unique_ptr<FunctionData> DuckDBSchemasBind(ClientContext &context, TableF
 	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("tags");
-	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("internal");
 	return_types.emplace_back(LogicalType::BOOLEAN);
@@ -78,8 +78,8 @@ void DuckDBSchemasFunction(ClientContext &context, TableFunctionInput &data_p, D
 		output.SetValue(col++, count, Value(entry.name));
 		// "comment", PhysicalType::VARCHAR
 		output.SetValue(col++, count, Value(entry.comment));
-		// "tags", MAP(VARCHAR, VARCHAR)
-		output.SetValue(col++, count, Value::MAP(entry.tags));
+		// "tags", VARCHAR
+		output.SetValue(col++, count, Value(Value::MAP(entry.tags).ToString()));
 		// "internal", PhysicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(entry.internal));
 		// "sql", PhysicalType::VARCHAR

--- a/src/function/table/system/duckdb_sequences.cpp
+++ b/src/function/table/system/duckdb_sequences.cpp
@@ -42,7 +42,7 @@ static unique_ptr<FunctionData> DuckDBSequencesBind(ClientContext &context, Tabl
 	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("tags");
-	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("temporary");
 	return_types.emplace_back(LogicalType::BOOLEAN);
@@ -112,8 +112,8 @@ void DuckDBSequencesFunction(ClientContext &context, TableFunctionInput &data_p,
 		output.SetValue(col++, count, Value::BIGINT(NumericCast<int64_t>(seq.oid)));
 		// comment, VARCHAR
 		output.SetValue(col++, count, Value(seq.comment));
-		// tags, MAP(VARCHAR, VARCHAR)
-		output.SetValue(col++, count, Value::MAP(seq.tags));
+		// tags, VARCHAR
+		output.SetValue(col++, count, Value(Value::MAP(seq.tags).ToString()));
 		// temporary, BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(seq.temporary));
 		// start_value, BIGINT

--- a/src/function/table/system/duckdb_tables.cpp
+++ b/src/function/table/system/duckdb_tables.cpp
@@ -45,7 +45,7 @@ static unique_ptr<FunctionData> DuckDBTablesBind(ClientContext &context, TableFu
 	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("tags");
-	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("internal");
 	return_types.emplace_back(LogicalType::BOOLEAN);
@@ -141,8 +141,8 @@ void DuckDBTablesFunction(ClientContext &context, TableFunctionInput &data_p, Da
 		output.SetValue(col++, count, Value::BIGINT(NumericCast<int64_t>(table.oid)));
 		// comment, LogicalType::VARCHAR
 		output.SetValue(col++, count, Value(table.comment));
-		// tags, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)
-		output.SetValue(col++, count, Value::MAP(table.tags));
+		// tags, VARCHAR
+		output.SetValue(col++, count, Value(Value::MAP(table.tags).ToString()));
 		// internal, LogicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(table.internal));
 		// temporary, LogicalType::BOOLEAN

--- a/src/function/table/system/duckdb_types.cpp
+++ b/src/function/table/system/duckdb_types.cpp
@@ -53,7 +53,7 @@ static unique_ptr<FunctionData> DuckDBTypesBind(ClientContext &context, TableFun
 	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("tags");
-	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("internal");
 	return_types.emplace_back(LogicalType::BOOLEAN);
@@ -170,8 +170,8 @@ void DuckDBTypesFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 		output.SetValue(col++, count, category.empty() ? Value() : Value(category));
 		// comment, VARCHAR
 		output.SetValue(col++, count, Value(type_entry.comment));
-		// tags, MAP
-		output.SetValue(col++, count, Value::MAP(type_entry.tags));
+		// tags, VARCHAR
+		output.SetValue(col++, count, Value(Value::MAP(type_entry.tags).ToString()));
 		// internal, BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(type_entry.internal));
 		// labels, VARCHAR[]

--- a/src/function/table/system/duckdb_views.cpp
+++ b/src/function/table/system/duckdb_views.cpp
@@ -41,7 +41,7 @@ static unique_ptr<FunctionData> DuckDBViewsBind(ClientContext &context, TableFun
 	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("tags");
-	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	return_types.emplace_back(LogicalType::VARCHAR);
 
 	names.emplace_back("internal");
 	return_types.emplace_back(LogicalType::BOOLEAN);
@@ -103,8 +103,8 @@ void DuckDBViewsFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 		output.SetValue(col++, count, Value::BIGINT(NumericCast<int64_t>(view.oid)));
 		// comment, LogicalType::VARCHARs
 		output.SetValue(col++, count, Value(view.comment));
-		// tags, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)
-		output.SetValue(col++, count, Value::MAP(view.tags));
+		// tags, VARCHAR
+		output.SetValue(col++, count, Value(Value::MAP(view.tags).ToString()));
 		// internal, LogicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(view.internal));
 		// temporary, LogicalType::BOOLEAN

--- a/test/extension/test_tags.test
+++ b/test/extension/test_tags.test
@@ -10,15 +10,18 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
+CREATE MACRO tag_extract(a,b) AS list_first((a::MAP(VARCHAR,VARCHAR))[b]);
+
+statement ok
 LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
 
 query II
-SELECT function_name, tags['ext:author'] FROM duckdb_functions() WHERE tags['ext:name'] = ['loadable_extension_demo'] ORDER BY function_name;
+SELECT function_name, tag_extract(tags, 'ext:author') FROM duckdb_functions() WHERE tag_extract(tags,'ext:name') = 'loadable_extension_demo' ORDER BY function_name;
 ----
-add_point	[DuckDB Labs]
-sub_point	[DuckDB Labs]
+add_point	DuckDB Labs
+sub_point	DuckDB Labs
 
 query II
-SELECT type_name, tags['ext:author'] FROM duckdb_types() WHERE tags['ext:name'] = ['loadable_extension_demo'] ORDER BY type_name;
+SELECT type_name, tag_extract(tags, 'ext:author') FROM duckdb_types() WHERE tag_extract(tags, 'ext:name') = 'loadable_extension_demo' ORDER BY type_name;
 ----
-POINT	[DuckDB Labs]
+POINT	DuckDB Labs


### PR DESCRIPTION
Support for nested types are not completely obvious to support, and I feel types of `FROM duckdb_functions()` should be as plain as possible, and `MAP(VARCHAR, VARCHAR)` can be transformed without information loss to `VARCHAR` and back.

Original issue I bumped against is that MAP support in duckdb-wasm shell is not present (see issue), but I think this might be a more general problem, say if those results are saved to CSV or JSON typing information are lost, or say as output of duckdb-python's `fetchmany()`:
```bash
python3
>>> import duckdb
>>> duckdb.sql("SELECT tags FROM duckdb_functions()").fetchmany()
[({'key': [], 'value': []},)]
>>> duckdb.sql("SELECT tags::VARCHAR FROM duckdb_functions()").fetchmany()
[('{}',)]
```

I think forcing type to be VARCHAR, while accesses are performed via casting to MAP(VARCHAR, VARCHAR) might be somewhat better here.
Note that those columns where introduced in 0.10.3 (I should have raised this in the PR), and I believe there are no actual uses (yet) of the tags outside duckdb_spatial's documentation where, I just noticed, it marshal data to JSON first and then into STRUCT(key VARCHAR, value VARCHAR)[] (see https://github.com/duckdb/duckdb_spatial/blob/main/generate_function_reference.py#L21).
Also, spatial documentation is currently run manually, so I believe this to have no impact on existing workflows.

I would propose to keep it to a macro like:
```
CREATE MACRO tag_extract(a,b) AS list_first((a::MAP(VARCHAR,VARCHAR))[b]);
```
defined where needed. I had not added this to duckdb since it can for now defined where useful (possibly with a different semantic) or it can be considered for a future docs-related extension.