### PR TITLE
Use --always option of git describe for extension tags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -978,7 +978,7 @@ function(duckdb_extension_generate_version OUTPUT_VAR WORKING_DIR)
       message(FATAL_ERROR "git is available (at ${GIT_EXECUTABLE}) but has failed to execute 'log -1 --format=%h'.")
     endif()
     execute_process(
-            COMMAND ${GIT_EXECUTABLE} describe --tags
+            COMMAND ${GIT_EXECUTABLE} describe --tags --always
             WORKING_DIRECTORY ${WORKING_DIR}
             RESULT_VARIABLE GIT_RESULT
             OUTPUT_VARIABLE GIT_DESCRIBE


### PR DESCRIPTION
This defaults back to short hash instead of printing 'fatal error' on missing tags