### PR TITLE
[C-API] Properly handle exceptions caused by name collisions in `duckdb_register_table_function`

### DIFF
--- a/src/main/capi/table_function-c.cpp
+++ b/src/main/capi/table_function-c.cpp
@@ -284,13 +284,17 @@ duckdb_state duckdb_register_table_function(duckdb_connection connection, duckdb
 	if (tf->name.empty() || !info->bind || !info->init || !info->function) {
 		return DuckDBError;
 	}
-	con->context->RunFunctionInTransaction([&]() {
-		auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
-		duckdb::CreateTableFunctionInfo tf_info(*tf);
+	try {
+		con->context->RunFunctionInTransaction([&]() {
+			auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
+			duckdb::CreateTableFunctionInfo tf_info(*tf);
 
-		// create the function in the catalog
-		catalog.CreateTableFunction(*con->context, tf_info);
-	});
+			// create the function in the catalog
+			catalog.CreateTableFunction(*con->context, tf_info);
+		});
+	} catch (...) { // LCOV_EXCL_START
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
 	return DuckDBSuccess;
 }
 

--- a/test/api/capi/capi_table_functions.cpp
+++ b/test/api/capi/capi_table_functions.cpp
@@ -79,6 +79,7 @@ static duckdb_state capi_register_table_function(duckdb_connection connection, c
 	// register and cleanup
 	status = duckdb_register_table_function(connection, function);
 	if (status == DuckDBError) {
+		duckdb_destroy_table_function(&function);
 		return status;
 	}
 


### PR DESCRIPTION
This PR fixes #12248 

We were not catching exceptions thrown by the C++ register call, now we do