### PR TITLE
[Fix] Skip lazy WAL creation test for alternative verification

### DIFF
--- a/test/sql/storage/wal/wal_lazy_creation.test
+++ b/test/sql/storage/wal/wal_lazy_creation.test
@@ -1,28 +1,38 @@
 # name: test/sql/storage/wal/wal_lazy_creation.test
-# description: Verify the WAL is lazily created when attaching
+# description: Verify the WAL is lazily created when attaching.
 # group: [wal]
+
+# If we enable alternative verification, then we disable checkpointing on shutdown.
+# Thus, we'll keep the WAL alive when detaching the database.
+require noalternativeverify
 
 require noforcestorage
 
 require skip_reload
 
 statement ok
-ATTACH '__TEST_DIR__/attach_no_wal.db'
+ATTACH '__TEST_DIR__/attach_no_wal.db';
 
 statement ok
-CREATE TABLE attach_no_wal.integers(i INTEGER)
+CREATE TABLE attach_no_wal.integers(i INTEGER);
 
 statement ok
 INSERT INTO attach_no_wal.integers FROM range(10000);
 
 statement ok
-DETACH attach_no_wal
+DETACH attach_no_wal;
 
 statement ok
-ATTACH '__TEST_DIR__/attach_no_wal.db'
+ATTACH '__TEST_DIR__/attach_no_wal.db';
 
-# verify we don't have a WAL after attaching
+# Verify that we don't have a WAL after attaching.
 query I
-SELECT COUNT(*) FROM glob('__TEST_DIR__/attach_no_wal.db.wal')
+SELECT COUNT(*) FROM glob('__TEST_DIR__/attach_no_wal.db.wal');
 ----
 0
+
+# Verify that we checkpointed the WAL.
+query I
+SELECT COUNT(*) FROM attach_no_wal.integers;
+----
+10000


### PR DESCRIPTION
**Changes**
- Added `require noalternativeverify`.
- Added an additional statement to the test to ensure the data in the storage is correct.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/2116.