### PR TITLE
Add storage callbacks for checkpoint start and end

### DIFF
--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -54,6 +54,11 @@ public:
 	DatabaseInstance &GetDatabase() {
 		return db;
 	}
+
+	optional_ptr<StorageExtension> GetStorageExtension() {
+		return storage_extension;
+	}
+
 	const string &GetName() const {
 		return name;
 	}
@@ -74,6 +79,7 @@ private:
 	unique_ptr<TransactionManager> transaction_manager;
 	AttachedDatabaseType type;
 	optional_ptr<Catalog> parent_catalog;
+	optional_ptr<StorageExtension> storage_extension;
 	bool is_initial_database = false;
 	bool is_closed = false;
 };

--- a/src/include/duckdb/storage/storage_extension.hpp
+++ b/src/include/duckdb/storage/storage_extension.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/access_mode.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "storage_manager.hpp"
 
 namespace duckdb {
 class AttachedDatabase;
@@ -39,6 +40,12 @@ public:
 	shared_ptr<StorageExtensionInfo> storage_info;
 
 	virtual ~StorageExtension() {
+	}
+
+	virtual void OnCheckpointStart(AttachedDatabase &db, CheckpointOptions checkpoint_options) {
+	}
+
+	virtual void OnCheckpointEnd(AttachedDatabase &db, CheckpointOptions checkpoint_options) {
 	}
 };
 

--- a/src/include/duckdb/storage/storage_extension.hpp
+++ b/src/include/duckdb/storage/storage_extension.hpp
@@ -11,7 +11,7 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/access_mode.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
-#include "storage_manager.hpp"
+#include "duckdb/storage/storage_manager.hpp"
 
 namespace duckdb {
 class AttachedDatabase;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -41,14 +41,15 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 	internal = true;
 }
 
-AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension,
+AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, StorageExtension &storage_extension_p,
                                    ClientContext &context, string name_p, const AttachInfo &info,
                                    AccessMode access_mode)
-    : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p) {
+    : CatalogEntry(CatalogType::DATABASE_ENTRY, catalog_p, std::move(name_p)), db(db), parent_catalog(&catalog_p),
+      storage_extension(&storage_extension_p) {
 	type = access_mode == AccessMode::READ_ONLY ? AttachedDatabaseType::READ_ONLY_DATABASE
 	                                            : AttachedDatabaseType::READ_WRITE_DATABASE;
-	catalog =
-	    storage_extension.attach(storage_extension.storage_info.get(), context, *this, name, *info.Copy(), access_mode);
+	catalog = storage_extension->attach(storage_extension->storage_info.get(), context, *this, name, *info.Copy(),
+	                                    access_mode);
 	if (!catalog) {
 		throw InternalException("AttachedDatabase - attach function did not return a catalog");
 	}
@@ -57,7 +58,7 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, Sto
 		storage = make_uniq<SingleFileStorageManager>(*this, info.path, access_mode == AccessMode::READ_ONLY);
 	}
 	transaction_manager =
-	    storage_extension.create_transaction_manager(storage_extension.storage_info.get(), *this, *catalog);
+	    storage_extension->create_transaction_manager(storage_extension->storage_info.get(), *this, *catalog);
 	if (!transaction_manager) {
 		throw InternalException(
 		    "AttachedDatabase - create_transaction_manager function did not return a transaction manager");

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -14,7 +14,7 @@
 #include "duckdb/storage/single_file_block_manager.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
 
-#include <duckdb/storage/storage_extension.hpp>
+#include "duckdb/storage/storage_extension.hpp"
 
 namespace duckdb {
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -1,18 +1,20 @@
 #include "duckdb/storage/storage_manager.hpp"
-#include "duckdb/storage/checkpoint_manager.hpp"
-#include "duckdb/storage/in_memory_block_manager.hpp"
-#include "duckdb/storage/single_file_block_manager.hpp"
-#include "duckdb/storage/object_cache.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/file_system.hpp"
-#include "duckdb/main/database.hpp"
-#include "duckdb/main/client_context.hpp"
-#include "duckdb/function/function.hpp"
-#include "duckdb/transaction/transaction_manager.hpp"
 #include "duckdb/common/serializer/buffered_file_reader.hpp"
+#include "duckdb/function/function.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
 #include "duckdb/main/database_manager.hpp"
+#include "duckdb/storage/checkpoint_manager.hpp"
+#include "duckdb/storage/in_memory_block_manager.hpp"
+#include "duckdb/storage/object_cache.hpp"
+#include "duckdb/storage/single_file_block_manager.hpp"
+#include "duckdb/transaction/transaction_manager.hpp"
+
+#include <duckdb/storage/storage_extension.hpp>
 
 namespace duckdb {
 
@@ -283,6 +285,9 @@ void SingleFileStorageManager::CreateCheckpoint(CheckpointOptions options) {
 	if (InMemory() || read_only || !load_complete) {
 		return;
 	}
+	if (db.GetStorageExtension()) {
+		db.GetStorageExtension()->OnCheckpointStart(db, options);
+	}
 	auto &config = DBConfig::Get(db);
 	if (GetWALSize() > 0 || config.options.force_checkpoint || options.action == CheckpointAction::FORCE_CHECKPOINT) {
 		// we only need to checkpoint if there is anything in the WAL
@@ -296,6 +301,10 @@ void SingleFileStorageManager::CreateCheckpoint(CheckpointOptions options) {
 	}
 	if (options.wal_action == CheckpointWALAction::DELETE_WAL) {
 		ResetWAL();
+	}
+
+	if (db.GetStorageExtension()) {
+		db.GetStorageExtension()->OnCheckpointEnd(db, options);
 	}
 }
 


### PR DESCRIPTION
This PR adds callback to the StorageExtension, allowing extensions to be notified when a checkpoint starts and ends. 

This is useful for extension that use the standard duckdb storage manager, but need to do some administration when ever a new version of the main file is persisted. 