### PR TITLE
Add support for APPEND argument to hive partitioned write

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1362,6 +1362,8 @@ const char* EnumUtil::ToChars<CopyOverwriteMode>(CopyOverwriteMode value) {
 		return "COPY_OVERWRITE";
 	case CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE:
 		return "COPY_OVERWRITE_OR_IGNORE";
+	case CopyOverwriteMode::COPY_APPEND:
+		return "COPY_APPEND";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
 	}
@@ -1377,6 +1379,9 @@ CopyOverwriteMode EnumUtil::FromString<CopyOverwriteMode>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "COPY_OVERWRITE_OR_IGNORE")) {
 		return CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
+	}
+	if (StringUtil::Equals(value, "COPY_APPEND")) {
+		return CopyOverwriteMode::COPY_APPEND;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/common/filename_pattern.cpp
+++ b/src/common/filename_pattern.cpp
@@ -10,6 +10,7 @@ void FilenamePattern::SetFilenamePattern(const string &pattern) {
 	base = pattern;
 
 	pos = base.find(id_format);
+	uuid = false;
 	if (pos != string::npos) {
 		base = StringUtil::Replace(base, id_format, "");
 		uuid = false;

--- a/src/include/duckdb/common/enums/copy_overwrite_mode.hpp
+++ b/src/include/duckdb/common/enums/copy_overwrite_mode.hpp
@@ -13,6 +13,11 @@
 
 namespace duckdb {
 
-enum class CopyOverwriteMode : uint8_t { COPY_ERROR_ON_CONFLICT = 0, COPY_OVERWRITE = 1, COPY_OVERWRITE_OR_IGNORE = 2 };
+enum class CopyOverwriteMode : uint8_t {
+	COPY_ERROR_ON_CONFLICT = 0,
+	COPY_OVERWRITE = 1,
+	COPY_OVERWRITE_OR_IGNORE = 2,
+	COPY_APPEND = 3
+};
 
 } // namespace duckdb

--- a/src/include/duckdb/common/filename_pattern.hpp
+++ b/src/include/duckdb/common/filename_pattern.hpp
@@ -30,6 +30,10 @@ public:
 	void Serialize(Serializer &serializer) const;
 	static FilenamePattern Deserialize(Deserializer &deserializer);
 
+	bool HasUUID() const {
+		return uuid;
+	}
+
 private:
 	string base;
 	idx_t pos;

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -62,6 +62,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 	optional_idx file_size_bytes;
 	vector<idx_t> partition_cols;
 	bool seen_overwrite_mode = false;
+	bool seen_filepattern = false;
 
 	CopyFunctionBindInput bind_input(*stmt.info);
 
@@ -75,9 +76,9 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 		if (loption == "use_tmp_file") {
 			use_tmp_file = GetBooleanArg(context, option.second);
 			user_set_use_tmp_file = true;
-		} else if (loption == "overwrite_or_ignore" || loption == "overwrite") {
+		} else if (loption == "overwrite_or_ignore" || loption == "overwrite" || loption == "append") {
 			if (seen_overwrite_mode) {
-				throw BinderException("Can only set one of OVERWRITE_OR_IGNORE or OVERWRITE");
+				throw BinderException("Can only set one of OVERWRITE_OR_IGNORE, OVERWRITE or APPEND");
 			}
 			seen_overwrite_mode = true;
 
@@ -87,6 +88,11 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 					overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
 				} else if (loption == "overwrite") {
 					overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE;
+				} else if (loption == "append") {
+					if (!seen_filepattern) {
+						filename_pattern.SetFilenamePattern("{uuid}");
+					}
+					overwrite_mode = CopyOverwriteMode::COPY_APPEND;
 				}
 			}
 		} else if (loption == "filename_pattern") {
@@ -95,6 +101,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 			}
 			filename_pattern.SetFilenamePattern(
 			    option.second[0].CastAs(context, LogicalType::VARCHAR).GetValue<string>());
+			seen_filepattern = true;
 		} else if (loption == "file_extension") {
 			if (option.second.empty()) {
 				throw IOException("FILE_EXTENSION cannot be empty");
@@ -120,6 +127,9 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
 		} else {
 			stmt.info->options[option.first] = option.second;
 		}
+	}
+	if (overwrite_mode == CopyOverwriteMode::COPY_APPEND && !filename_pattern.HasUUID()) {
+		throw BinderException("APPEND mode requires a {uuid} label in filename_pattern");
 	}
 	if (user_set_use_tmp_file && per_thread_output) {
 		throw NotImplementedException("Can't combine USE_TMP_FILE and PER_THREAD_OUTPUT for COPY");

--- a/test/sql/copy/partitioned/hive_partition_append.test
+++ b/test/sql/copy/partitioned/hive_partition_append.test
@@ -1,0 +1,63 @@
+# name: test/sql/copy/partitioned/hive_partition_append.test
+# description: test APPEND mode for hive partitioned write
+# group: [partitioned]
+
+require parquet
+
+statement ok
+CREATE TABLE sensor_data(ts TIMESTAMP, value INT);
+
+statement ok
+INSERT INTO sensor_data VALUES
+   (TIMESTAMP '2000-01-01 01:02:03', 42),
+   (TIMESTAMP '2000-02-01 01:02:03', 100),
+   (TIMESTAMP '2000-03-01 12:11:10', 1000)
+;
+
+statement ok
+COPY (SELECT YEAR(ts) AS year, MONTH(ts) AS month, * FROM sensor_data)
+TO '__TEST_DIR__/partitioned_append' (FORMAT PARQUET, PARTITION_BY (year, month), APPEND);
+
+query III
+SELECT year, month, SUM(value) FROM '__TEST_DIR__/partitioned_append/**/*.parquet' GROUP BY ALL ORDER BY ALL
+----
+2000	1	42
+2000	2	100
+2000	3	1000
+
+statement ok
+DELETE FROM sensor_data;
+
+statement ok
+INSERT INTO sensor_data VALUES
+   (TIMESTAMP '2000-01-01 02:02:03', 62),
+   (TIMESTAMP '2000-03-01 13:11:10', 50)
+;
+
+statement ok
+COPY (SELECT YEAR(ts) AS year, MONTH(ts) AS month, * FROM sensor_data)
+TO '__TEST_DIR__/partitioned_append' (FORMAT PARQUET, PARTITION_BY (year, month), APPEND, FILENAME_PATTERN 'my_pattern_{uuid}');
+
+query III
+SELECT year, month, SUM(value) FROM '__TEST_DIR__/partitioned_append/**/*.parquet' GROUP BY ALL ORDER BY ALL
+----
+2000	1	104
+2000	2	100
+2000	3	1050
+
+statement ok
+COPY (SELECT YEAR(ts) AS year, MONTH(ts) AS month, * FROM sensor_data)
+TO '__TEST_DIR__/partitioned_append' (FORMAT PARQUET, PARTITION_BY (year, month), FILENAME_PATTERN 'my_pattern_{uuid}', APPEND);
+
+query III
+SELECT year, month, SUM(value) FROM '__TEST_DIR__/partitioned_append/**/*.parquet' GROUP BY ALL ORDER BY ALL
+----
+2000	1	166
+2000	2	100
+2000	3	1100
+
+statement error
+COPY (SELECT YEAR(ts) AS year, MONTH(ts) AS month, * FROM sensor_data)
+TO '__TEST_DIR__/partitioned_append' (FORMAT PARQUET, PARTITION_BY (year, month), APPEND, FILENAME_PATTERN 'my_pattern_without_uuid');
+----
+APPEND mode requires a {uuid} label in filename_pattern

--- a/test/sql/copy/partitioned/hive_partitioning_overwrite.test
+++ b/test/sql/copy/partitioned/hive_partitioning_overwrite.test
@@ -44,4 +44,4 @@ SELECT * FROM '__TEST_DIR__/overwrite_test2/**/*.parquet'
 statement error
 COPY (SELECT 84 AS part_col) TO '__TEST_DIR__/overwrite_test' (FORMAT PARQUET, PARTITION_BY (part_col), OVERWRITE 1, OVERWRITE_OR_IGNORE 1);
 ----
-Can only set one of OVERWRITE_OR_IGNORE or OVERWRITE
+OVERWRITE


### PR DESCRIPTION
This PR adds support for the `APPEND` flag to the hive partitioned write, usage:

```cpp
COPY sensor_data TO 'partitioned_append' (FORMAT PARQUET, PARTITION_BY (year, month), APPEND);
```

This is mostly similar to `OVERWRITE_OR_IGNORE, FILENAME_PATTERN '{uuid}'`, but includes an extra check for when the file already exists and then re-generates the UUID in the rare event that it does.
