### PR TITLE
Turn InternalException into NotImplementedException in COPY FROM DATABASE

### DIFF
--- a/src/execution/operator/persistent/physical_copy_database.cpp
+++ b/src/execution/operator/persistent/physical_copy_database.cpp
@@ -49,8 +49,9 @@ SourceResultType PhysicalCopyDatabase::GetData(ExecutionContext &context, DataCh
 			catalog.CreateTable(context.client, *bound_info);
 			break;
 		}
+		case CatalogType::INDEX_ENTRY:
 		default:
-			throw InternalException("Entry type not supported in PhysicalCopyDatabase");
+			throw NotImplementedException("Entry type %s not supported in PhysicalCopyDatabase", CatalogTypeToString(create_info->type));
 		}
 	}
 	return SourceResultType::FINISHED;

--- a/src/execution/operator/persistent/physical_copy_database.cpp
+++ b/src/execution/operator/persistent/physical_copy_database.cpp
@@ -51,7 +51,8 @@ SourceResultType PhysicalCopyDatabase::GetData(ExecutionContext &context, DataCh
 		}
 		case CatalogType::INDEX_ENTRY:
 		default:
-			throw NotImplementedException("Entry type %s not supported in PhysicalCopyDatabase", CatalogTypeToString(create_info->type));
+			throw NotImplementedException("Entry type %s not supported in PhysicalCopyDatabase",
+			                              CatalogTypeToString(create_info->type));
 		}
 	}
 	return SourceResultType::FINISHED;

--- a/test/sql/copy_database/copy_database_index.test
+++ b/test/sql/copy_database/copy_database_index.test
@@ -1,0 +1,27 @@
+# name: test/sql/copy_database/copy_database_index.test
+# description: Test COPY DATABASE with indexes
+# group: [copy_database]
+
+require noforcestorage
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH DATABASE ':memory:' AS db1;
+
+statement ok
+USE db1
+
+statement ok
+CREATE TABLE test(a INTEGER, b INTEGER, c VARCHAR(10));
+
+statement ok
+CREATE INDEX i_index ON test(a)
+
+statement ok
+INSERT INTO test VALUES (42, 88, 'hello');
+
+statement error
+COPY FROM DATABASE db1 TO memory
+----


### PR DESCRIPTION
This can be triggered from indexes - since we don't support copying indexes currently, this should be a `NotImplementedException` instead.