### PR TITLE
add missing virtual destructor

### DIFF
--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -14,6 +14,9 @@
 
 namespace duckdb {
 
+MultiFileReaderGlobalState::~MultiFileReaderGlobalState() {
+}
+
 MultiFileReader::~MultiFileReader() {
 }
 

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -52,6 +52,7 @@ struct MultiFileReaderBindData {
 struct MultiFileReaderGlobalState {
 	MultiFileReaderGlobalState(vector<LogicalType> extra_columns_p, optional_ptr<const MultiFileList> file_list_p)
 	    : extra_columns(std::move(extra_columns_p)), file_list(file_list_p) {};
+	virtual ~MultiFileReaderGlobalState();
 
 	//! extra columns that will be produced during scanning
 	const vector<LogicalType> extra_columns;


### PR DESCRIPTION
Fix error in extensions that override the MultiFileReaderGlobalState