### PR TITLE
Fix minor duckdb_extensions table function bug

### DIFF
--- a/src/function/table/system/duckdb_extensions.cpp
+++ b/src/function/table/system/duckdb_extensions.cpp
@@ -144,13 +144,12 @@ unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context
 		auto &ext_info = e.second;
 		auto entry = installed_extensions.find(ext_name);
 		if (entry == installed_extensions.end() || !entry->second.installed) {
-			ExtensionInformation info;
+			ExtensionInformation &info = installed_extensions[ext_name];
 			info.name = ext_name;
 			info.loaded = true;
 			info.extension_version = ext_info.version;
 			info.installed = ext_info.mode == ExtensionInstallMode::STATICALLY_LINKED;
 			info.install_mode = ext_info.mode;
-			installed_extensions[ext_name] = std::move(info);
 		} else {
 			entry->second.loaded = true;
 			entry->second.extension_version = ext_info.version;

--- a/src/function/table/system/duckdb_extensions.cpp
+++ b/src/function/table/system/duckdb_extensions.cpp
@@ -125,7 +125,7 @@ unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context
 		if (entry == installed_extensions.end()) {
 			installed_extensions[info.name] = std::move(info);
 		} else {
-			if (!entry->second.loaded) {
+			if (entry->second.install_mode != ExtensionInstallMode::STATICALLY_LINKED) {
 				entry->second.file_path = info.file_path;
 				entry->second.install_mode = info.install_mode;
 				entry->second.installed_from = info.installed_from;

--- a/test/extension/duckdb_extensions.test
+++ b/test/extension/duckdb_extensions.test
@@ -1,0 +1,47 @@
+# name: test/extension/duckdb_extensions.test
+# description: Tests for the duckdb_extensions() table function
+# group: [extension]
+
+# This test assumes icu and json to be available in the LOCAL_EXTENSION_REPO and NOT linked into duckdb statically
+# -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
+require-env LOCAL_EXTENSION_REPO
+
+require no_extension_autoloading
+
+statement ok
+PRAGMA enable_verification
+
+# Set the repository to the correct one
+statement ok
+set custom_extension_repository='${LOCAL_EXTENSION_REPO}'
+
+# Ensure we have a clean extension directory without any preinstalled extensions
+statement ok
+set extension_directory='__TEST_DIR__/duckdb_extensions'
+
+require json
+
+# json is statically linked
+query II
+SELECT extension_name, install_mode from duckdb_extensions() where extension_name='json'
+----
+json	STATICALLY_LINKED
+
+# now we install json (happens when users install extensions that are also statically loaded)
+statement ok
+install json
+
+# json still shown as statically linked
+query II
+SELECT extension_name, install_mode from duckdb_extensions() where extension_name='json'
+----
+json	STATICALLY_LINKED
+
+statement ok
+load json
+
+# json still shown as statically linked
+query II
+SELECT extension_name, install_mode from duckdb_extensions() where extension_name='json'
+----
+json	STATICALLY_LINKED

--- a/test/sql/extensions/description_is_valid.test
+++ b/test/sql/extensions/description_is_valid.test
@@ -1,0 +1,19 @@
+# name: test/sql/extensions/description_is_valid.test
+# description: Test version metadata on load
+# group: [extensions]
+
+require inet
+
+statement ok
+SET autoinstall_known_extensions=true;
+
+statement ok
+SET autoload_known_extensions=true;
+
+statement ok
+LOAD inet;
+
+query I
+SELECT description FROM duckdb_extensions() WHERE extension_name == 'inet';
+----
+Adds support for IP-related data types and functions


### PR DESCRIPTION
Not really a bug, but more quite confusing. Thanks @carlopi for the catch!

When running:
```SQL
install parquet
from duckdb_extensions()
select install_path, install_mode from duckdb_extensions() where extension_name='parquet';
```

this would show:
```
┌──────────────────────────────────────────────────────────────────────────┬──────────────┐
│                               install_path                               │ install_mode │
│                                 varchar                                  │   varchar    │
├──────────────────────────────────────────────────────────────────────────┼──────────────┤
│ /Users/sam/.duckdb/extensions/v0.10.3/osx_arm64/parquet.duckdb_extension │ REPOSITORY   │
└──────────────────────────────────────────────────────────────────────────┴──────────────┘
```

Now I changed this instead to show:

```
┌──────────────┬───────────────────┐
│ install_path │   install_mode    │
│   varchar    │      varchar      │
├──────────────┼───────────────────┤
│ (BUILT-IN)   │ STATICALLY_LINKED │
└──────────────┴───────────────────┘
```

which is technically equally correct because its both installed and statically linked. I would say the fact that its statically linked is more in line with how it should behave.

In general we should probably make the install of a statically linked extension a NOP altogether as this is now just a waste of bandwidth anyway

Also added fix from @carlopi that fixes an issue where the description of the extension would disappear after loading it