### PR TITLE
Fix for multifilereader extra_columns feature

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -651,7 +651,13 @@ public:
 		bool require_extra_columns =
 		    result->multi_file_reader_state && result->multi_file_reader_state->RequiresExtraColumns();
 		if (input.CanRemoveFilterColumns() || require_extra_columns) {
-			result->projection_ids = input.projection_ids;
+			if (!input.projection_ids.empty()) {
+				result->projection_ids = input.projection_ids;
+			} else {
+				result->projection_ids.resize(input.column_ids.size());
+				iota(begin(result->projection_ids), end(result->projection_ids), 0);
+			}
+
 			const auto table_types = bind_data.types;
 			for (const auto &col_idx : input.column_ids) {
 				if (IsRowIdColumnId(col_idx)) {


### PR DESCRIPTION
The MultiFileReader can register "extra_colums" which will be avaiable in the FinalizeChunk step, but should be filtered out.

There's a bug where the code relied on input.projection_ids to be set. This small fix changes that to ensure that the column filtering step is performed also when there are no projection ids set in the `TableFunctionInitInput`