### PR TITLE
[DependencyManager] Don't enforce that dependencies share the same catalog

### DIFF
--- a/src/catalog/dependency_list.cpp
+++ b/src/catalog/dependency_list.cpp
@@ -79,17 +79,6 @@ bool LogicalDependencyList::Contains(CatalogEntry &entry_p) {
 	return set.count(logical_entry);
 }
 
-void LogicalDependencyList::VerifyDependencies(Catalog &catalog, const string &name) {
-	for (auto &dep : set) {
-		if (dep.catalog != catalog.GetName()) {
-			throw DependencyException(
-			    "Error adding dependency for object \"%s\" - dependency \"%s\" is in catalog "
-			    "\"%s\", which does not match the catalog \"%s\".\nCross catalog dependencies are not supported.",
-			    name, dep.entry.name, dep.catalog, catalog.GetName());
-		}
-	}
-}
-
 const LogicalDependencyList::create_info_set_t &LogicalDependencyList::Set() const {
 	return set;
 }

--- a/src/catalog/dependency_manager.cpp
+++ b/src/catalog/dependency_manager.cpp
@@ -263,19 +263,9 @@ void DependencyManager::CreateDependencies(CatalogTransaction transaction, const
 	}
 
 	const auto object_info = GetLookupProperties(object);
-	// check for each object in the sources if they were not deleted yet
-	for (auto &dependency : dependencies.Set()) {
-		if (dependency.catalog != object.ParentCatalog().GetName()) {
-			throw DependencyException(
-			    "Error adding dependency for object \"%s\" - dependency \"%s\" is in catalog "
-			    "\"%s\", which does not match the catalog \"%s\".\nCross catalog dependencies are not supported.",
-			    object.name, dependency.entry.name, dependency.catalog, object.ParentCatalog().GetName());
-		}
-	}
-
 	// add the object to the dependents_map of each object that it depends on
 	for (auto &dependency : dependencies.Set()) {
-		DependencyInfo info {/*dependent = */ DependencyDependent {GetLookupProperties(object), dependency_flags},
+		DependencyInfo info {/*dependent = */ DependencyDependent {object_info, dependency_flags},
 		                     /*subject = */ DependencySubject {dependency.entry, DependencySubjectFlags()}};
 		CreateDependency(transaction, info);
 	}

--- a/src/include/duckdb/catalog/dependency_list.hpp
+++ b/src/include/duckdb/catalog/dependency_list.hpp
@@ -57,7 +57,6 @@ public:
 	DUCKDB_API bool Contains(CatalogEntry &entry);
 
 public:
-	DUCKDB_API void VerifyDependencies(Catalog &catalog, const string &name);
 	void Serialize(Serializer &serializer) const;
 	static LogicalDependencyList Deserialize(Deserializer &deserializer);
 	bool operator==(const LogicalDependencyList &other) const;

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -322,13 +322,7 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 			base.columns.AddColumn(ColumnDefinition(names[i], sql_types[i]));
 		}
 	} else {
-		SetCatalogLookupCallback([&dependencies, &schema](CatalogEntry &entry) {
-			if (&schema.ParentCatalog() != &entry.ParentCatalog()) {
-				// Don't register dependencies between catalogs
-				return;
-			}
-			dependencies.AddDependency(entry);
-		});
+		SetCatalogLookupCallback([&dependencies](CatalogEntry &entry) { dependencies.AddDependency(entry); });
 		CreateColumnDependencyManager(*result);
 		// bind the generated column expressions
 		BindGeneratedColumns(*result);
@@ -351,7 +345,6 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 		}
 		BindLogicalType(column.TypeMutable(), &result->schema.catalog);
 	}
-	result->dependencies.VerifyDependencies(schema.catalog, result->Base().table);
 
 	auto &properties = GetStatementProperties();
 	properties.allow_stream_result = false;

--- a/test/fuzzer/pedro/temp_sequence_reconnect.test
+++ b/test/fuzzer/pedro/temp_sequence_reconnect.test
@@ -18,16 +18,11 @@ CREATE TABLE t1 (c1 INT, CHECK(nextval('t1')));
 statement ok
 CREATE TEMP SEQUENCE t1;
 
-statement error
+statement ok
 ALTER TABLE t1 ADD c0 INT;
-----
-Cross catalog dependencies are not supported
 
 statement ok
 DROP SEQUENCE temp.t1
-
-statement ok
-ALTER TABLE t1 ADD c0 INT;
 
 reconnect
 

--- a/test/sql/attach/attach_sequence.test
+++ b/test/sql/attach/attach_sequence.test
@@ -13,7 +13,7 @@ CREATE SEQUENCE seq;
 statement error
 CREATE TABLE db1.integers(i INTEGER DEFAULT nextval('seq'))
 ----
-Cross catalog dependencies are not supported
+TransactionContext Error: Attempting to write to database "db1" in a transaction that has already modified database "memory" - a single transaction can only write to a single attached database.
 
 statement ok
 CREATE SEQUENCE db1.seq

--- a/test/sql/catalog/dependencies/temp_to_main_catalog_dependency.test
+++ b/test/sql/catalog/dependencies/temp_to_main_catalog_dependency.test
@@ -1,0 +1,17 @@
+# name: test/sql/catalog/dependencies/temp_to_main_catalog_dependency.test
+# group: [dependencies]
+
+statement ok
+CREATE MACRO m1() AS (SELECT 1 AS x);
+
+statement ok
+CREATE OR REPLACE TEMP MACRO m2() AS (SELECT m1() AS y);
+
+statement ok
+drop macro m1;
+
+statement ok
+create temp macro m1() as (select 2 as y);
+
+statement ok
+CREATE OR REPLACE TEMP MACRO m2() AS (SELECT m1() AS y);


### PR DESCRIPTION
This PR fixes #12272

It's a bit of a bandaid fix, but it's enabling behavior we probably don't want to remove(?).

What happens is that we recently added enforcement that dependencies and the object that is establishing the dependency have to share a catalog.

This makes it an error when objects created in `main` are depending on objects in the `temp` catalog (which is where we store TEMPORARY objects)

---------

When we remove this enforcement we are now creating the dependency in the catalog of the object that is establishing the dependency.
That might pose a problem because the object the DependencyCatalogEntry is referring to is expected to live in the same catalog, but instead it doesn't exist there

I haven't found something that breaks when we remove this enforcement, but it is something to be mindful of, because I'm pretty sure there will be *something* that breaks.