### PR TITLE
Add `enable_macro_dependencies` which defaults to false

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -210,6 +210,8 @@ struct DBConfigOptions {
 	bool enable_fsst_vectors = false;
 	//! Enable VIEWs to create dependencies
 	bool enable_view_dependencies = false;
+	//! Enable macros to create dependencies
+	bool enable_macro_dependencies = false;
 	//! Start transactions immediately in all attached databases - instead of lazily when a database is referenced
 	bool immediate_transaction_mode = false;
 	//! Debug setting - how to initialize  blocks in the storage layer when allocating

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -206,6 +206,16 @@ struct EnableExternalAccessSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct EnableMacrosDependencies {
+	static constexpr const char *Name = "enable_macro_dependencies";
+	static constexpr const char *Description =
+	    "Enable created MACROs to create dependencies on the referenced objects (such as tables)";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct EnableViewDependencies {
 	static constexpr const char *Name = "enable_view_dependencies";
 	static constexpr const char *Description =

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -94,6 +94,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ForceBitpackingModeSetting),
     DUCKDB_LOCAL(HomeDirectorySetting),
     DUCKDB_LOCAL(LogQueryPathSetting),
+    DUCKDB_GLOBAL(EnableMacrosDependencies),
     DUCKDB_GLOBAL(EnableViewDependencies),
     DUCKDB_GLOBAL(LockConfigurationSetting),
     DUCKDB_GLOBAL(ImmediateTransactionModeSetting),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -438,6 +438,22 @@ Value EnableExternalAccessSetting::GetSetting(const ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// Enable Macro Dependencies
+//===--------------------------------------------------------------------===//
+void EnableMacrosDependencies::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.options.enable_macro_dependencies = input.GetValue<bool>();
+}
+
+void EnableMacrosDependencies::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.enable_macro_dependencies = DBConfig().options.enable_macro_dependencies;
+}
+
+Value EnableMacrosDependencies::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.options.enable_macro_dependencies);
+}
+
+//===--------------------------------------------------------------------===//
 // Enable View Dependencies
 //===--------------------------------------------------------------------===//
 void EnableViewDependencies::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -60,6 +60,7 @@ OptionValueSet &GetValueForOption(const string &name) {
 	    {"prefer_range_joins", {Value(true)}},
 	    {"allow_persistent_secrets", {Value(false)}},
 	    {"secret_directory", {"/tmp/some/path"}},
+	    {"enable_macro_dependencies", {Value(true)}},
 	    {"enable_view_dependencies", {Value(true)}},
 	    {"default_secret_storage", {"custom_storage"}},
 	    {"custom_extension_repository", {"duckdb.org/no-extensions-here", "duckdb.org/no-extensions-here"}},

--- a/test/sql/catalog/function/test_cross_catalog_macros.test
+++ b/test/sql/catalog/function/test_cross_catalog_macros.test
@@ -1,0 +1,14 @@
+# name: test/sql/catalog/function/test_cross_catalog_macros.test
+# description: Test cross-catalog dependencies in macros
+# group: [function]
+
+statement ok
+CREATE MACRO my_first_macro() AS (84)
+
+statement ok
+CREATE TEMPORARY MACRO my_second_macro() AS my_first_macro() + 42;
+
+query I
+SELECT my_second_macro()
+----
+126

--- a/test/sql/catalog/function/test_cross_catalog_macros.test
+++ b/test/sql/catalog/function/test_cross_catalog_macros.test
@@ -2,6 +2,8 @@
 # description: Test cross-catalog dependencies in macros
 # group: [function]
 
+require skip_reload
+
 statement ok
 CREATE MACRO my_first_macro() AS (84)
 

--- a/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
+++ b/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
@@ -5,6 +5,9 @@ statement ok
 set storage_compatibility_version='latest'
 
 statement ok
+set enable_macro_dependencies=true
+
+statement ok
 pragma enable_verification;
 
 statement ok

--- a/test/sql/catalog/function/test_recursive_macro_no_dependency.test
+++ b/test/sql/catalog/function/test_recursive_macro_no_dependency.test
@@ -1,9 +1,6 @@
-# name: test/sql/catalog/function/test_recursive_macro.test
+# name: test/sql/catalog/function/test_recursive_macro_no_dependency.test
 # description: Test recursive macros
 # group: [function]
-
-statement ok
-set enable_macro_dependencies=true
 
 statement ok
 CREATE MACRO "sum"(x) AS (CASE WHEN sum(x) IS NULL THEN 0 ELSE sum(x) END);
@@ -42,10 +39,8 @@ create macro m1(a) as a+1;
 statement ok
 create macro m2(a) as m1(a)+1;
 
-statement error
+statement ok
 create or replace macro m1(a) as m2(a)+1;
-----
-Catalog Error: CREATE OR REPLACE is not allowed to depend on itself
 
 # also table macros
 statement ok
@@ -54,7 +49,5 @@ create macro m3(a) as a+1;
 statement ok
 create macro m4(a) as table select m3(a);
 
-statement error
+statement ok
 create or replace macro m3(a) as (from m4(42));
-----
-Catalog Error: CREATE OR REPLACE is not allowed to depend on itself


### PR DESCRIPTION
Fixes #12272 

Similar to https://github.com/duckdb/duckdb/pull/12209, these dependencies were introduced on purpose - but this turns out to break certain workflows. As such we now hide the behavior behind a setting that defaults to the old behavior (no dependencies).