### PR TITLE
UHUGEINT support in arrow_converter

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -122,6 +122,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		child.format = "f";
 		break;
 	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UHUGEINT:
 		child.format = "d:38,0";
 		break;
 	case LogicalTypeId::DOUBLE:

--- a/test/api/capi/test_capi_arrow.cpp
+++ b/test/api/capi/test_capi_arrow.cpp
@@ -1,6 +1,7 @@
 #include "capi_tester.hpp"
 #include "duckdb/common/arrow/arrow_appender.hpp"
 #include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/main/capi/capi_internal.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -160,8 +161,12 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 	}
 
 	SECTION("test unsupported type") {
-		auto state = duckdb_query_arrow(tester.connection, "SELECT 0::UHUGEINT", &arrow_result);
+		auto state = duckdb_query_arrow(tester.connection, "SELECT 1", &arrow_result);
 		REQUIRE(state == DuckDBSuccess);
+
+		// artificially inject an invalid type into the result
+		auto wrapper = reinterpret_cast<ArrowResultWrapper *>(arrow_result);
+		wrapper->result->types[0] = LogicalType(LogicalTypeId::INVALID);
 
 		ArrowSchema arrow_schema;
 		arrow_schema.Init();


### PR DESCRIPTION
Add a case in `arrow_converter.cpp` for UHUGEINT. As with HUGEINT, just serialize it as a DECIMAL(38,0).

Without this case, DuckDB Wasm, which relies on Arrow, would error for any query result that included a UHUGEINT column. Other scenarios using Arrow conversion would likely hit a similar error.

Note that DECIMAL(38,0) cannot fit the largest (absolute) values of HUGEINT or UHUGEINT, which are 39 digits:
`2**127-1`=`170141183460469231731687303715884105728`
`2**128-1`=`340282366920938463463374607431768211455`
This change does not address this issue.

Additionally, serializing the unsigned type UHUGEINT as a DECIMAL, which is a signed type, will likely cause large positive UHUGEINTs to be interpreted as negative numbers by clients using this converter. This change doesn't address that issue, either. (A client that knows what type to expect can convert the signed value to an unsigned one.)

Finally, since HUGEINTs, and now UHUGEINTs, are serialized the same as (real) DECIMAL(38,0) values, clients cannot recover the original DuckDB data type without out-of-band information. This change does not address that issue, either.