### PR TITLE
[Extension Dev] Forward declare re2 in `hive_partitioning.hpp`

### DIFF
--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -20,7 +20,7 @@
 
 namespace duckdb_re2 {
 class RE2;
-};
+} // namespace duckdb_re2
 
 namespace duckdb {
 

--- a/src/include/duckdb/common/hive_partitioning.hpp
+++ b/src/include/duckdb/common/hive_partitioning.hpp
@@ -14,10 +14,13 @@
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/table_filter.hpp"
-#include "re2/re2.h"
 
 #include <iostream>
 #include <sstream>
+
+namespace duckdb_re2 {
+class RE2;
+};
 
 namespace duckdb {
 


### PR DESCRIPTION
Working from an extension, I discovered this issue when including `extension_util.hpp`

```
In file included from third_party/duckdb/src/include/duckdb/main/extension_util.hpp:14:
In file included from third_party/duckdb/src/include/duckdb/main/secret/secret.hpp:13:
In file included from third_party/duckdb/src/include/duckdb/common/serializer/deserializer.hpp:18:
In file included from third_party/duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp:19:
In file included from third_party/duckdb/src/include/duckdb/common/multi_file_reader_options.hpp:13:
third_party/duckdb/src/include/duckdb/common/hive_partitioning.hpp:17:10: fatal error: 're2/re2.h' file not found
#include "re2/re2.h"
```

Apart from this likely being an issue in my extension build command, this issue can be avoided altogether by forward declaring re2, so it's only required when actually making use of the re2 library.