### PR TITLE
Add new extensions to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,11 +20,13 @@ body:
             * [Arrow extension](https://github.com/duckdb/duckdb_arrow/issues/new)
             * [AWS extension](https://github.com/duckdb/duckdb_aws/issues/new)
             * [Azure extension](https://github.com/duckdb/duckdb_azure/issues/new)
+            * [Delta extension](https://github.com/duckdb/duckdb_delta/issues/new)
             * [Iceberg extension](https://github.com/duckdb/duckdb_iceberg/issues/new)
             * [MySQL extension](https://github.com/duckdb/duckdb_mysql/issues/new)
             * [Postgres scanner](https://github.com/duckdb/postgres_scanner/issues/new)
             * [Spatial extension](https://github.com/duckdb/duckdb_spatial/issues/new)
             * [SQLite scanner](https://github.com/duckdb/sqlite_scanner/issues/new)
+            * [VSS extension](https://github.com/duckdb/duckdb_vss/issues/new)
           * Connectors:
             * [dbt-duckdb](https://github.com/duckdb/dbt-duckdb)
 


### PR DESCRIPTION
This PR adds new extensions to the issue to help users open issues in the respective repository of the extension (instead of opening an extension in the main DuckDB repository).