### PR TITLE
Use iterator buffer position when storing buffer handles

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/scanner_boundary.cpp
+++ b/src/execution/operator/csv_scanner/scanner/scanner_boundary.cpp
@@ -89,7 +89,7 @@ idx_t CSVIterator::GetFileIdx() const {
 }
 
 idx_t CSVIterator::GetBufferIdx() const {
-	return boundary.buffer_idx;
+	return pos.buffer_idx;
 }
 
 idx_t CSVIterator::GetBoundaryIdx() const {

--- a/test/sql/copy/csv/test_12314.test_slow
+++ b/test/sql/copy/csv/test_12314.test_slow
@@ -1,0 +1,15 @@
+# name: test/sql/copy/csv/test_12314.test_slow
+# description: Test CSV reading for issue 12314
+# group: [csv]
+
+require httpfs
+
+statement error
+from read_csv('https://github.com/duckdb/duckdb-data/releases/download/v1.0/sample_data_12314.csv.gz',HEADER = 1,  PARALLEL=false);
+----
+Change the maximum length size, e.g., max_line_size=2097408
+
+query I
+select count(*) from read_csv('https://github.com/duckdb/duckdb-data/releases/download/v1.0/sample_data_12314.csv.gz',HEADER = 1, PARALLEL=false , max_line_size=2097408);
+----
+26238


### PR DESCRIPTION
This PR fixes a bug related to storing buffer handles for error handling in the single-threaded version of the CSV Reader.

Fix: #12314