### PR TITLE
Fix #12286 - in the MetadataManager, prefer to allocate new blocks if the next free block id is smaller than the currently used metadata block

### DIFF
--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -39,6 +39,7 @@ public:
 	virtual unique_ptr<Block> CreateBlock(block_id_t block_id, FileBuffer *source_buffer) = 0;
 	//! Return the next free block id
 	virtual block_id_t GetFreeBlockId() = 0;
+	virtual block_id_t PeekFreeBlockId() = 0;
 	//! Returns whether or not a specified block is the root block
 	virtual bool IsRootBlock(MetaBlockPointer root) = 0;
 	//! Mark a block as "free"; free blocks are immediately added to the free list and can be immediately overwritten

--- a/src/include/duckdb/storage/in_memory_block_manager.hpp
+++ b/src/include/duckdb/storage/in_memory_block_manager.hpp
@@ -29,6 +29,9 @@ public:
 	block_id_t GetFreeBlockId() override {
 		throw InternalException("Cannot perform IO in in-memory database - GetFreeBlockId!");
 	}
+	block_id_t PeekFreeBlockId() override {
+		throw InternalException("Cannot perform IO in in-memory database - PeekFreeBlockId!");
+	}
 	bool IsRootBlock(MetaBlockPointer root) override {
 		throw InternalException("Cannot perform IO in in-memory database - IsRootBlock!");
 	}

--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -81,6 +81,7 @@ protected:
 
 protected:
 	block_id_t AllocateNewBlock();
+	block_id_t PeekNextBlockId();
 	block_id_t GetNextBlockId();
 
 	void AddBlock(MetadataBlock new_block, bool if_exists = false);

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -49,6 +49,8 @@ public:
 	unique_ptr<Block> CreateBlock(block_id_t block_id, FileBuffer *source_buffer) override;
 	//! Return the next free block id
 	block_id_t GetFreeBlockId() override;
+	//! Check the next free block id - but do not assign or allocate it
+	block_id_t PeekFreeBlockId() override;
 	//! Returns whether or not a specified block is the root block
 	bool IsRootBlock(MetaBlockPointer root) override;
 	//! Mark a block as free (immediately re-writeable)

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -26,7 +26,7 @@ MetadataHandle MetadataManager::AllocateHandle() {
 			break;
 		}
 	}
-	if (free_block == INVALID_BLOCK) {
+	if (free_block == INVALID_BLOCK || free_block > PeekNextBlockId()) {
 		free_block = AllocateNewBlock();
 	}
 	D_ASSERT(free_block != INVALID_BLOCK);
@@ -313,6 +313,10 @@ vector<MetadataBlockInfo> MetadataManager::GetMetadataInfo() const {
 	std::sort(result.begin(), result.end(),
 	          [](const MetadataBlockInfo &a, const MetadataBlockInfo &b) { return a.block_id < b.block_id; });
 	return result;
+}
+
+block_id_t MetadataManager::PeekNextBlockId() {
+	return block_manager.PeekFreeBlockId();
 }
 
 block_id_t MetadataManager::GetNextBlockId() {

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -348,6 +348,15 @@ block_id_t SingleFileBlockManager::GetFreeBlockId() {
 	return block;
 }
 
+block_id_t SingleFileBlockManager::PeekFreeBlockId() {
+	lock_guard<mutex> lock(block_lock);
+	if (!free_list.empty()) {
+		return *free_list.begin();
+	} else {
+		return max_block;
+	}
+}
+
 void SingleFileBlockManager::MarkBlockAsFree(block_id_t block_id) {
 	lock_guard<mutex> lock(block_lock);
 	D_ASSERT(block_id >= 0);

--- a/test/sql/storage/relocate_metadata.test_slow
+++ b/test/sql/storage/relocate_metadata.test_slow
@@ -1,0 +1,53 @@
+# name: test/sql/storage/relocate_metadata.test_slow
+# description: Verify that metadata is relocated to allow the database to free up space
+# group: [storage]
+
+# load the DB from disk
+load __TEST_DIR__/relocate_metadata.db
+
+statement ok
+CREATE TABLE test (x INT, y AS (x + 100));
+
+statement ok
+insert into test select range FROM range(100000000);
+
+statement ok
+delete from test where x % 10 = 7;
+
+statement ok
+delete from test where x % 10 = 6;
+
+statement ok
+delete from test where x % 10 = 5;
+
+statement ok
+delete from test where x % 10 = 4;
+
+statement ok
+delete from test where x % 10 = 3;
+
+statement ok
+delete from test where x % 10 = 2;
+
+statement ok
+delete from test where x % 10 = 1;
+
+statement ok
+delete from test where x % 10 = 0;
+
+statement ok
+delete from test where x % 10 = 8;
+
+statement ok
+delete from test where x % 10 = 9;
+
+statement ok
+drop table test;
+
+statement ok
+checkpoint
+
+query I
+SELECT MAX(block_id)<5 FROM pragma_metadata_info();
+----
+true


### PR DESCRIPTION
Fixes #12286

This PR changes the logic for allocating new handles in the MetadataManager. Previously, we would always prefer to use blocks within existing metadata blocks if possible. While this is more space efficient - it can in certain cases prevent the vacuum from reducing the database size.

In particular in #12286, there exists a metadata block at a far location in the file (`block_id 677`, or at position `~175MB`), e.g.:

```
D select * from pragma_metadata_info();
┌──────────┬──────────────┬─────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ block_id │ total_blocks │ free_blocks │                                                                              free_list                                                                               │
│  int64   │    int64     │    int64    │                                                                               int64[]                                                                                │
├──────────┼──────────────┼─────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│      677 │           64 │          57 │ [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,…  │
└──────────┴──────────────┴─────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

When checkpointing, the current implementation prefers to keep on using that block - which also means the block will never be freed or moved.

This PR modifies this behavior to instead check if there are free blocks available in the file that are located prior to this block.  If there are, we prefer to write new metadata blocks to those blocks instead. This will cause metadata blocks further into the file to be freed up, which allows the space to be reclaimed.

Below is the database size for the queries in the given dataset, as we can see the database now reverts back to an empty database after the tables are dropped:

```sql
CREATE TABLE test (x INT, y AS (x + 100));
insert into test select range FROM range(1000000000);
delete from test where x % 10 = 7;   --dbfile size : 170MB
delete from test where x % 10 = 6;   --dbfile size : 329MB
delete from test where x % 10 = 5;   --dbfile size : 363MB
delete from test where x % 10 = 4;   --dbfile size : 362MB
delete from test where x % 10 = 3;   --dbfile size : 511MB
delete from test where x % 10 = 2;   --dbfile size : 510MB
delete from test where x % 10 = 1;   --dbfile size : 204MB
delete from test where x % 10 = 0;   --dbfile size : 233MB
delete from test where x % 10 = 8;   --dbfile size : 82MB
delete from test where x % 10 = 9;   --dbfile size : 82MB
drop table test;                     --dbfile size: 268KB
```

