### PR TITLE
Remove all reinterpret casts from the transformer

### DIFF
--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -257,9 +257,8 @@ private:
 	//===--------------------------------------------------------------------===//
 	// Constraints transform
 	//===--------------------------------------------------------------------===//
-	unique_ptr<Constraint> TransformConstraint(duckdb_libpgquery::PGListCell *cell);
-
-	unique_ptr<Constraint> TransformConstraint(duckdb_libpgquery::PGListCell *cell, ColumnDefinition &column,
+	unique_ptr<Constraint> TransformConstraint(duckdb_libpgquery::PGListCell &cell);
+	unique_ptr<Constraint> TransformConstraint(duckdb_libpgquery::PGListCell &cell, ColumnDefinition &column,
 	                                           idx_t index);
 
 	//===--------------------------------------------------------------------===//

--- a/src/parser/transform/constraint/transform_constraint.cpp
+++ b/src/parser/transform/constraint/transform_constraint.cpp
@@ -5,16 +5,12 @@
 
 namespace duckdb {
 
-static void ParseSchemaTableNameFK(duckdb_libpgquery::PGRangeVar *input, ForeignKeyInfo &fk_info) {
-	if (input->catalogname) {
+static void ParseSchemaTableNameFK(duckdb_libpgquery::PGRangeVar &input, ForeignKeyInfo &fk_info) {
+	if (input.catalogname) {
 		throw ParserException("FOREIGN KEY constraints cannot be defined cross-database");
 	}
-	if (input->schemaname) {
-		fk_info.schema = input->schemaname;
-	} else {
-		fk_info.schema = "";
-	};
-	fk_info.table = input->relname;
+	fk_info.schema = input.schemaname ? input.schemaname : "";
+	fk_info.table = input.relname;
 }
 
 static bool ForeignKeyActionSupported(char action) {
@@ -33,28 +29,34 @@ static bool ForeignKeyActionSupported(char action) {
 }
 
 static unique_ptr<ForeignKeyConstraint>
-TransformForeignKeyConstraint(duckdb_libpgquery::PGConstraint *constraint,
+TransformForeignKeyConstraint(duckdb_libpgquery::PGConstraint &constraint,
                               optional_ptr<const string> override_fk_column = nullptr) {
-	D_ASSERT(constraint);
-	if (!ForeignKeyActionSupported(constraint->fk_upd_action) ||
-	    !ForeignKeyActionSupported(constraint->fk_del_action)) {
+	if (!ForeignKeyActionSupported(constraint.fk_upd_action) || !ForeignKeyActionSupported(constraint.fk_del_action)) {
 		throw ParserException("FOREIGN KEY constraints cannot use CASCADE, SET NULL or SET DEFAULT");
 	}
+
 	ForeignKeyInfo fk_info;
 	fk_info.type = ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
-	ParseSchemaTableNameFK(constraint->pktable, fk_info);
-	vector<string> pk_columns, fk_columns;
+	ParseSchemaTableNameFK(*constraint.pktable, fk_info);
+
+	vector<string> pk_columns;
+	vector<string> fk_columns;
+
 	if (override_fk_column) {
-		D_ASSERT(!constraint->fk_attrs);
+		D_ASSERT(!constraint.fk_attrs);
 		fk_columns.emplace_back(*override_fk_column);
-	} else if (constraint->fk_attrs) {
-		for (auto kc = constraint->fk_attrs->head; kc; kc = kc->next) {
-			fk_columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
+
+	} else if (constraint.fk_attrs) {
+		for (auto kc = constraint.fk_attrs->head; kc; kc = kc->next) {
+			auto value = Transformer::PGPointerCast<duckdb_libpgquery::PGValue>(kc->data.ptr_value);
+			fk_columns.emplace_back(value->val.str);
 		}
 	}
-	if (constraint->pk_attrs) {
-		for (auto kc = constraint->pk_attrs->head; kc; kc = kc->next) {
-			pk_columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
+
+	if (constraint.pk_attrs) {
+		for (auto kc = constraint.pk_attrs->head; kc; kc = kc->next) {
+			auto value = Transformer::PGPointerCast<duckdb_libpgquery::PGValue>(kc->data.ptr_value);
+			pk_columns.emplace_back(value->val.str);
 		}
 	}
 	if (!pk_columns.empty() && pk_columns.size() != fk_columns.size()) {
@@ -66,9 +68,11 @@ TransformForeignKeyConstraint(duckdb_libpgquery::PGConstraint *constraint,
 	return make_uniq<ForeignKeyConstraint>(pk_columns, fk_columns, std::move(fk_info));
 }
 
-unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGListCell *cell) {
-	auto constraint = reinterpret_cast<duckdb_libpgquery::PGConstraint *>(cell->data.ptr_value);
+unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGListCell &cell) {
+
+	auto constraint = PGPointerCast<duckdb_libpgquery::PGConstraint>(cell.data.ptr_value);
 	D_ASSERT(constraint);
+
 	switch (constraint->contype) {
 	case duckdb_libpgquery::PG_CONSTR_UNIQUE:
 	case duckdb_libpgquery::PG_CONSTR_PRIMARY: {
@@ -78,7 +82,8 @@ unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGLis
 		}
 		vector<string> columns;
 		for (auto kc = constraint->keys->head; kc; kc = kc->next) {
-			columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
+			auto value = PGPointerCast<duckdb_libpgquery::PGValue>(kc->data.ptr_value);
+			columns.emplace_back(value->val.str);
 		}
 		return make_uniq<UniqueConstraint>(columns, is_primary_key);
 	}
@@ -90,17 +95,18 @@ unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGLis
 		return make_uniq<CheckConstraint>(TransformExpression(constraint->raw_expr));
 	}
 	case duckdb_libpgquery::PG_CONSTR_FOREIGN:
-		return TransformForeignKeyConstraint(constraint);
-
+		return TransformForeignKeyConstraint(*constraint.get());
 	default:
 		throw NotImplementedException("Constraint type not handled yet!");
 	}
 }
 
-unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGListCell *cell, ColumnDefinition &column,
+unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGListCell &cell, ColumnDefinition &column,
                                                         idx_t index) {
-	auto constraint = reinterpret_cast<duckdb_libpgquery::PGConstraint *>(cell->data.ptr_value);
+
+	auto constraint = PGPointerCast<duckdb_libpgquery::PGConstraint>(cell.data.ptr_value);
 	D_ASSERT(constraint);
+
 	switch (constraint->contype) {
 	case duckdb_libpgquery::PG_CONSTR_NOTNULL:
 		return make_uniq<NotNullConstraint>(LogicalIndex(index));
@@ -133,7 +139,7 @@ unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGLis
 		}
 		return nullptr;
 	case duckdb_libpgquery::PG_CONSTR_FOREIGN:
-		return TransformForeignKeyConstraint(constraint, &column.Name());
+		return TransformForeignKeyConstraint(*constraint.get(), &column.Name());
 	default:
 		throw NotImplementedException("Constraint not implemented!");
 	}

--- a/src/parser/transform/helpers/transform_alias.cpp
+++ b/src/parser/transform/helpers/transform_alias.cpp
@@ -8,7 +8,8 @@ vector<string> Transformer::TransformStringList(duckdb_libpgquery::PGList *list)
 		return result;
 	}
 	for (auto node = list->head; node != nullptr; node = node->next) {
-		result.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(node->data.ptr_value)->val.str);
+		auto value = PGPointerCast<duckdb_libpgquery::PGValue>(node->data.ptr_value);
+		result.emplace_back(value->val.str);
 	}
 	return result;
 }

--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -42,8 +42,8 @@ void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause &de_with_clause, 
 		auto &cte = *PGPointerCast<duckdb_libpgquery::PGCommonTableExpr>(cte_ele->data.ptr_value);
 		if (cte.aliascolnames) {
 			for (auto node = cte.aliascolnames->head; node != nullptr; node = node->next) {
-				info->aliases.emplace_back(
-				    reinterpret_cast<duckdb_libpgquery::PGValue *>(node->data.ptr_value)->val.str);
+				auto value = PGPointerCast<duckdb_libpgquery::PGValue>(node->data.ptr_value);
+				info->aliases.emplace_back(value->val.str);
 			}
 		}
 		// lets throw some errors on unsupported features early

--- a/src/parser/transform/helpers/transform_orderby.cpp
+++ b/src/parser/transform/helpers/transform_orderby.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
-#include "duckdb/parser/expression/star_expression.hpp"
 
 namespace duckdb {
 
@@ -11,35 +11,38 @@ bool Transformer::TransformOrderBy(duckdb_libpgquery::PGList *order, vector<Orde
 	}
 
 	for (auto node = order->head; node != nullptr; node = node->next) {
-		auto temp = reinterpret_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value);
-		if (temp->type == duckdb_libpgquery::T_PGSortBy) {
-			OrderType type;
-			OrderByNullType null_order;
-			auto sort = reinterpret_cast<duckdb_libpgquery::PGSortBy *>(temp);
-			auto target = sort->node;
-			if (sort->sortby_dir == duckdb_libpgquery::PG_SORTBY_DEFAULT) {
-				type = OrderType::ORDER_DEFAULT;
-			} else if (sort->sortby_dir == duckdb_libpgquery::PG_SORTBY_ASC) {
-				type = OrderType::ASCENDING;
-			} else if (sort->sortby_dir == duckdb_libpgquery::PG_SORTBY_DESC) {
-				type = OrderType::DESCENDING;
-			} else {
-				throw NotImplementedException("Unimplemented order by type");
-			}
-			if (sort->sortby_nulls == duckdb_libpgquery::PG_SORTBY_NULLS_DEFAULT) {
-				null_order = OrderByNullType::ORDER_DEFAULT;
-			} else if (sort->sortby_nulls == duckdb_libpgquery::PG_SORTBY_NULLS_FIRST) {
-				null_order = OrderByNullType::NULLS_FIRST;
-			} else if (sort->sortby_nulls == duckdb_libpgquery::PG_SORTBY_NULLS_LAST) {
-				null_order = OrderByNullType::NULLS_LAST;
-			} else {
-				throw NotImplementedException("Unimplemented order by type");
-			}
-			auto order_expression = TransformExpression(target);
-			result.emplace_back(type, null_order, std::move(order_expression));
-		} else {
-			throw NotImplementedException("ORDER BY list member type %d\n", temp->type);
+		auto temp_node = PGPointerCast<duckdb_libpgquery::PGNode>(node->data.ptr_value);
+		if (temp_node->type != duckdb_libpgquery::T_PGSortBy) {
+			throw NotImplementedException("ORDER BY list member type %d\n", temp_node->type);
 		}
+
+		OrderType type;
+		OrderByNullType null_order;
+		auto sort = PGCast<duckdb_libpgquery::PGSortBy>(*temp_node.get());
+		auto target = sort.node;
+
+		if (sort.sortby_dir == duckdb_libpgquery::PG_SORTBY_DEFAULT) {
+			type = OrderType::ORDER_DEFAULT;
+		} else if (sort.sortby_dir == duckdb_libpgquery::PG_SORTBY_ASC) {
+			type = OrderType::ASCENDING;
+		} else if (sort.sortby_dir == duckdb_libpgquery::PG_SORTBY_DESC) {
+			type = OrderType::DESCENDING;
+		} else {
+			throw NotImplementedException("Unimplemented order by type");
+		}
+
+		if (sort.sortby_nulls == duckdb_libpgquery::PG_SORTBY_NULLS_DEFAULT) {
+			null_order = OrderByNullType::ORDER_DEFAULT;
+		} else if (sort.sortby_nulls == duckdb_libpgquery::PG_SORTBY_NULLS_FIRST) {
+			null_order = OrderByNullType::NULLS_FIRST;
+		} else if (sort.sortby_nulls == duckdb_libpgquery::PG_SORTBY_NULLS_LAST) {
+			null_order = OrderByNullType::NULLS_LAST;
+		} else {
+			throw NotImplementedException("Unimplemented order by type");
+		}
+
+		auto order_expression = TransformExpression(target);
+		result.emplace_back(type, null_order, std::move(order_expression));
 	}
 	return true;
 }

--- a/src/parser/transform/statement/transform_alter_table.cpp
+++ b/src/parser/transform/statement/transform_alter_table.cpp
@@ -11,47 +11,47 @@ OnEntryNotFound Transformer::TransformOnEntryNotFound(bool missing_ok) {
 }
 
 unique_ptr<AlterStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlterTableStmt &stmt) {
-	D_ASSERT(stmt.relation);
 
+	D_ASSERT(stmt.relation);
 	if (stmt.cmds->length != 1) {
 		throw ParserException("Only one ALTER command per statement is supported");
 	}
 
 	auto result = make_uniq<AlterStatement>();
-	auto qname = TransformQualifiedName(*stmt.relation);
+	auto qualified_name = TransformQualifiedName(*stmt.relation);
 
-	// first we check the type of ALTER
+	// Check the ALTER type.
 	for (auto c = stmt.cmds->head; c != nullptr; c = c->next) {
-		auto command = reinterpret_cast<duckdb_libpgquery::PGAlterTableCmd *>(lfirst(c));
-		AlterEntryData data(qname.catalog, qname.schema, qname.name, TransformOnEntryNotFound(stmt.missing_ok));
-		// TODO: Include more options for command->subtype
+
+		auto command = PGPointerCast<duckdb_libpgquery::PGAlterTableCmd>(c->data.ptr_value);
+		AlterEntryData data(qualified_name.catalog, qualified_name.schema, qualified_name.name,
+		                    TransformOnEntryNotFound(stmt.missing_ok));
+
 		switch (command->subtype) {
 		case duckdb_libpgquery::PG_AT_AddColumn: {
-			auto cdef = PGPointerCast<duckdb_libpgquery::PGColumnDef>(command->def);
-
+			auto column_def = PGPointerCast<duckdb_libpgquery::PGColumnDef>(command->def);
 			if (stmt.relkind != duckdb_libpgquery::PG_OBJECT_TABLE) {
 				throw ParserException("Adding columns is only supported for tables");
 			}
-			if (cdef->category == duckdb_libpgquery::COL_GENERATED) {
+			if (column_def->category == duckdb_libpgquery::COL_GENERATED) {
 				throw ParserException("Adding generated columns after table creation is not supported yet");
 			}
-			auto centry = TransformColumnDefinition(*cdef);
 
-			if (cdef->constraints) {
-				for (auto constr = cdef->constraints->head; constr != nullptr; constr = constr->next) {
-					auto constraint = TransformConstraint(constr, centry, 0);
+			auto column_entry = TransformColumnDefinition(*column_def);
+			if (column_def->constraints) {
+				for (auto constr = column_def->constraints->head; constr != nullptr; constr = constr->next) {
+					auto constraint = TransformConstraint(*constr, column_entry, 0);
 					if (!constraint) {
 						continue;
 					}
 					throw ParserException("Adding columns with constraints not yet supported");
 				}
 			}
-			result->info = make_uniq<AddColumnInfo>(std::move(data), std::move(centry), command->missing_ok);
+			result->info = make_uniq<AddColumnInfo>(std::move(data), std::move(column_entry), command->missing_ok);
 			break;
 		}
 		case duckdb_libpgquery::PG_AT_DropColumn: {
-			bool cascade = command->behavior == duckdb_libpgquery::PG_DROP_CASCADE;
-
+			auto cascade = command->behavior == duckdb_libpgquery::PG_DROP_CASCADE;
 			if (stmt.relkind != duckdb_libpgquery::PG_OBJECT_TABLE) {
 				throw ParserException("Dropping columns is only supported for tables");
 			}
@@ -60,7 +60,6 @@ unique_ptr<AlterStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlte
 		}
 		case duckdb_libpgquery::PG_AT_ColumnDefault: {
 			auto expr = TransformExpression(command->def);
-
 			if (stmt.relkind != duckdb_libpgquery::PG_OBJECT_TABLE) {
 				throw ParserException("Alter column's default is only supported for tables");
 			}
@@ -68,21 +67,21 @@ unique_ptr<AlterStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlte
 			break;
 		}
 		case duckdb_libpgquery::PG_AT_AlterColumnType: {
-			auto cdef = PGPointerCast<duckdb_libpgquery::PGColumnDef>(command->def);
-			auto column_definition = TransformColumnDefinition(*cdef);
-			unique_ptr<ParsedExpression> expr;
+			auto column_def = PGPointerCast<duckdb_libpgquery::PGColumnDef>(command->def);
+			auto column_entry = TransformColumnDefinition(*column_def);
 
+			unique_ptr<ParsedExpression> expr;
 			if (stmt.relkind != duckdb_libpgquery::PG_OBJECT_TABLE) {
 				throw ParserException("Alter column's type is only supported for tables");
 			}
-			if (cdef->raw_default) {
-				expr = TransformExpression(cdef->raw_default);
+			if (column_def->raw_default) {
+				expr = TransformExpression(column_def->raw_default);
 			} else {
-				auto colref = make_uniq<ColumnRefExpression>(command->name);
-				expr = make_uniq<CastExpression>(column_definition.Type(), std::move(colref));
+				auto col_ref = make_uniq<ColumnRefExpression>(command->name);
+				expr = make_uniq<CastExpression>(column_entry.Type(), std::move(col_ref));
 			}
-			result->info = make_uniq<ChangeColumnTypeInfo>(std::move(data), command->name, column_definition.Type(),
-			                                               std::move(expr));
+			result->info =
+			    make_uniq<ChangeColumnTypeInfo>(std::move(data), command->name, column_entry.Type(), std::move(expr));
 			break;
 		}
 		case duckdb_libpgquery::PG_AT_SetNotNull: {
@@ -98,7 +97,6 @@ unique_ptr<AlterStatement> Transformer::TransformAlter(duckdb_libpgquery::PGAlte
 			throw NotImplementedException("No support for that ALTER TABLE option yet!");
 		}
 	}
-
 	return result;
 }
 

--- a/src/parser/transform/statement/transform_create_table.cpp
+++ b/src/parser/transform/statement/transform_create_table.cpp
@@ -1,9 +1,9 @@
-#include "duckdb/parser/statement/create_statement.hpp"
-#include "duckdb/parser/parsed_data/create_table_info.hpp"
-#include "duckdb/parser/transformer.hpp"
+#include "duckdb/catalog/catalog_entry/table_column_type.hpp"
 #include "duckdb/parser/constraint.hpp"
 #include "duckdb/parser/expression/collate_expression.hpp"
-#include "duckdb/catalog/catalog_entry/table_column_type.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/parser/transformer.hpp"
 
 namespace duckdb {
 
@@ -101,7 +101,7 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery:
 			auto centry = TransformColumnDefinition(*cdef);
 			if (cdef->constraints) {
 				for (auto constr = cdef->constraints->head; constr != nullptr; constr = constr->next) {
-					auto constraint = TransformConstraint(constr, centry, info->columns.LogicalColumnCount());
+					auto constraint = TransformConstraint(*constr, centry, info->columns.LogicalColumnCount());
 					if (constraint) {
 						info->constraints.push_back(std::move(constraint));
 					}
@@ -112,7 +112,7 @@ unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery:
 			break;
 		}
 		case duckdb_libpgquery::T_PGConstraint: {
-			info->constraints.push_back(TransformConstraint(c));
+			info->constraints.push_back(TransformConstraint(*c));
 			break;
 		}
 		default:

--- a/src/parser/transform/statement/transform_update.cpp
+++ b/src/parser/transform/statement/transform_update.cpp
@@ -1,5 +1,5 @@
-#include "duckdb/parser/statement/update_statement.hpp"
 #include "duckdb/parser/statement/update_extensions_statement.hpp"
+#include "duckdb/parser/statement/update_statement.hpp"
 #include "duckdb/parser/transformer.hpp"
 
 namespace duckdb {
@@ -7,13 +7,14 @@ namespace duckdb {
 unique_ptr<UpdateSetInfo> Transformer::TransformUpdateSetInfo(duckdb_libpgquery::PGList *target_list,
                                                               duckdb_libpgquery::PGNode *where_clause) {
 	auto result = make_uniq<UpdateSetInfo>();
-
 	auto root = target_list;
+
 	for (auto cell = root->head; cell != nullptr; cell = cell->next) {
 		auto target = PGPointerCast<duckdb_libpgquery::PGResTarget>(cell->data.ptr_value);
 		result->columns.emplace_back(target->name);
 		result->expressions.push_back(TransformExpression(target->val));
 	}
+
 	result->condition = TransformExpression(where_clause);
 	return result;
 }
@@ -21,21 +22,20 @@ unique_ptr<UpdateSetInfo> Transformer::TransformUpdateSetInfo(duckdb_libpgquery:
 unique_ptr<UpdateStatement> Transformer::TransformUpdate(duckdb_libpgquery::PGUpdateStmt &stmt) {
 	auto result = make_uniq<UpdateStatement>();
 	if (stmt.withClause) {
-		TransformCTE(*PGPointerCast<duckdb_libpgquery::PGWithClause>(stmt.withClause), result->cte_map);
+		auto with_clause = PGPointerCast<duckdb_libpgquery::PGWithClause>(stmt.withClause);
+		TransformCTE(*with_clause, result->cte_map);
 	}
 
 	result->table = TransformRangeVar(*stmt.relation);
 	if (stmt.fromClause) {
 		result->from_table = TransformFrom(stmt.fromClause);
 	}
-
 	result->set_info = TransformUpdateSetInfo(stmt.targetList, stmt.whereClause);
 
 	// Grab and transform the returning columns from the parser.
 	if (stmt.returningList) {
 		TransformExpressionList(*stmt.returningList, result->returning_list);
 	}
-
 	return result;
 }
 
@@ -46,14 +46,13 @@ Transformer::TransformUpdateExtensions(duckdb_libpgquery::PGUpdateExtensionsStmt
 
 	if (stmt.extensions) {
 		auto column_list = PGPointerCast<duckdb_libpgquery::PGList>(stmt.extensions);
-		for (auto c = column_list->head; c != nullptr; c = lnext(c)) {
-			auto extension = reinterpret_cast<duckdb_libpgquery::PGValue *>(c->data.ptr_value)->val.str;
-			info->extensions_to_update.emplace_back(extension);
+		for (auto c = column_list->head; c != nullptr; c = c->next) {
+			auto value = PGPointerCast<duckdb_libpgquery::PGValue>(c->data.ptr_value);
+			info->extensions_to_update.emplace_back(value->val.str);
 		}
 	}
 
 	result->info = std::move(info);
-
 	return result;
 }
 

--- a/src/parser/transform/statement/transform_vacuum.cpp
+++ b/src/parser/transform/statement/transform_vacuum.cpp
@@ -3,7 +3,7 @@
 
 namespace duckdb {
 
-VacuumOptions ParseOptions(int options) {
+VacuumOptions ParseOptions(const int32_t options) {
 	VacuumOptions result;
 	if (options & duckdb_libpgquery::PGVacuumOption::PG_VACOPT_VACUUM) {
 		result.vacuum = true;
@@ -43,8 +43,8 @@ unique_ptr<SQLStatement> Transformer::TransformVacuum(duckdb_libpgquery::PGVacuu
 	if (stmt.va_cols) {
 		D_ASSERT(result->info->has_table);
 		for (auto col_node = stmt.va_cols->head; col_node != nullptr; col_node = col_node->next) {
-			result->info->columns.emplace_back(
-			    reinterpret_cast<duckdb_libpgquery::PGValue *>(col_node->data.ptr_value)->val.str);
+			auto value = PGPointerCast<duckdb_libpgquery::PGValue>(col_node->data.ptr_value);
+			result->info->columns.emplace_back(value->val.str);
 		}
 	}
 	return std::move(result);

--- a/src/parser/transform/tableref/transform_join.cpp
+++ b/src/parser/transform/tableref/transform_join.cpp
@@ -39,14 +39,14 @@ unique_ptr<TableRef> Transformer::TransformJoin(duckdb_libpgquery::PGJoinExpr &r
 		result->ref_type = JoinRefType::POSITIONAL;
 		break;
 	}
-	default: {
+	default:
 		throw NotImplementedException("Join type %d not supported\n", root.jointype);
 	}
-	}
 
-	// Check the type of left arg and right arg before transform
+	// Check the type of the left and right argument before transforming.
 	result->left = TransformTableRefNode(*root.larg);
 	result->right = TransformTableRefNode(*root.rarg);
+
 	switch (root.joinreftype) {
 	case duckdb_libpgquery::PG_JOIN_NATURAL:
 		result->ref_type = JoinRefType::NATURAL;
@@ -57,32 +57,38 @@ unique_ptr<TableRef> Transformer::TransformJoin(duckdb_libpgquery::PGJoinExpr &r
 	default:
 		break;
 	}
+
 	SetQueryLocation(*result, root.location);
 	if (root.usingClause && root.usingClause->length > 0) {
-		// usingClause is a list of strings
+		// usingClause is a list of strings.
 		for (auto node = root.usingClause->head; node != nullptr; node = node->next) {
-			auto target = reinterpret_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value);
+			auto target = PGPointerCast<duckdb_libpgquery::PGNode>(node->data.ptr_value);
 			D_ASSERT(target->type == duckdb_libpgquery::T_PGString);
-			auto column_name = string(reinterpret_cast<duckdb_libpgquery::PGValue *>(target)->val.str);
-			result->using_columns.push_back(column_name);
+			auto value = PGCast<duckdb_libpgquery::PGValue>(*target.get());
+			result->using_columns.push_back(string(value.val.str));
 		}
 		return std::move(result);
 	}
 
-	if (!root.quals && result->using_columns.empty() && result->ref_type == JoinRefType::REGULAR) { // CROSS PRODUCT
+	// Check if this is a cross product.
+	if (!root.quals && result->using_columns.empty() && result->ref_type == JoinRefType::REGULAR) {
 		result->ref_type = JoinRefType::CROSS;
 	}
 	result->condition = TransformExpression(root.quals);
+
 	if (root.alias) {
-		// join with an alias - wrap it in a subquery
+		// This is a join with an alias, so we wrap it in a subquery.
 		auto select_node = make_uniq<SelectNode>();
 		select_node->select_list.push_back(make_uniq<StarExpression>());
 		select_node->from_table = std::move(result);
+
 		auto select = make_uniq<SelectStatement>();
 		select->node = std::move(select_node);
+
 		auto subquery = make_uniq<SubqueryRef>(std::move(select));
 		SetQueryLocation(*subquery, root.location);
-		// apply the alias to that subquery
+
+		// Apply the alias to the subquery.
 		subquery->alias = TransformAlias(root.alias, subquery->column_name_alias);
 		return std::move(subquery);
 	}


### PR DESCRIPTION
Additionally, this PR contains a few rewrites of some (older) transformer code.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/2105.