### PR TITLE
Support REGEX matches expected error message

### DIFF
--- a/test/extension/load_extension.test
+++ b/test/extension/load_extension.test
@@ -12,14 +12,17 @@ PRAGMA enable_verification
 statement error
 LOAD 'asdf';
 ----
+<REGEX>:.*IO Error: Extension.*not found.*
 
 statement error
 LOAD 'Makefile';
 ----
+<REGEX>:.*IO Error: Extension.*not found.*
 
 statement error
 LOAD NULL;
 ----
+<REGEX>:.*Parser Error: syntax error.*
 
 statement ok
 LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
@@ -50,6 +53,7 @@ QUACK
 statement error
 QUAC
 ----
+<REGEX>:.*Parser Error:.*
 
 statement error
 QUACK NOT QUACK

--- a/test/extension/test_alias_point.test
+++ b/test/extension/test_alias_point.test
@@ -40,10 +40,12 @@ SELECT sub_point(({'x': 2, 'y': 3})::POINT, ({'x': 3, 'y': 4})::POINT)
 statement error
 SELECT add_point(pt, pt) from points;
 ----
+<REGEX>:.*Binder Error:.*No function matches the given name and argument type.*
 
 statement error
 SELECT sub_point(pt, pt) from points;
 ----
+<REGEX>:.*Binder Error:.*No function matches the given name and argument type.*
 
 query I
 SELECT add_point(point, point) from points;

--- a/test/optimizer/statistics/statistics_case.test
+++ b/test/optimizer/statistics/statistics_case.test
@@ -28,6 +28,7 @@ logical_opt	<!REGEX>:.*EMPTY_RESULT.*
 statement error
 SELECT 123::TINYINT + (CASE WHEN i=2 THEN (i+1)::TINYINT ELSE (i+2)::TINYINT END) FROM integers;
 ----
+<REGEX>:.*Out of Range Error:.*Overflow in addition.*
 
 # this does not
 query I

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -547,7 +547,7 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 	}
 	auto resString = result.ToString();
 	bool regex_matches = RE2::FullMatch(result.ToString(), re);
-	if (regex_matches == want_match) {
+	if (regex_matches && regex_matches == want_match) {
 		return true;
 	}
 	return false;

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -296,6 +296,8 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 				auto resString = result.ToString();
 				bool regex_matches = RE2::FullMatch(result.ToString(), re);
 				if (regex_matches == want_match) {
+					string success_log = StringUtil::Format("CheckStatementResult: %s:%d", statement.file_name, statement.query_line);
+					REQUIRE(success_log.c_str());
 					return true;
 				}
 

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -533,7 +533,7 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 
 bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string rvalue_str) {
 	bool want_match = StringUtil::StartsWith(rvalue_str, "<REGEX>:");
-	string regex_str = StringUtil::Replace(StringUtil::Replace(rvalue_str, "<REGEX>:", ""), "!<REGEX>:", "");
+	string regex_str = StringUtil::Replace(rvalue_str, "<REGEX>:", "");
 	RE2::Options options;
 	options.set_dot_nl(true);
 	RE2 re(regex_str, options);

--- a/test/sqlite/result_helper.hpp
+++ b/test/sqlite/result_helper.hpp
@@ -27,13 +27,13 @@ public:
 	                      duckdb::unique_ptr<MaterializedQueryResult> owned_result);
 	bool CheckStatementResult(const Statement &statement, ExecuteContext &context,
 	                          duckdb::unique_ptr<MaterializedQueryResult> owned_result);
-
 	string SQLLogicTestConvertValue(Value value, LogicalType sql_type, bool original_sqlite_test);
 	void DuckDBConvertResult(MaterializedQueryResult &result, bool original_sqlite_test, vector<string> &out_result);
 
 	static bool ResultIsHash(const string &result);
 	static bool ResultIsFile(string result);
 
+	bool CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string rvalue_str);
 	bool CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string lvalue_str,
 	                   string rvalue_str, idx_t current_row, idx_t current_column, vector<string> &values,
 	                   idx_t expected_column_count, bool row_wise, vector<string> &result_values);

--- a/test/sqlite/result_helper.hpp
+++ b/test/sqlite/result_helper.hpp
@@ -33,7 +33,7 @@ public:
 	static bool ResultIsHash(const string &result);
 	static bool ResultIsFile(string result);
 
-	bool CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string rvalue_str);
+	bool MatchesRegex(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string rvalue_str);
 	bool CompareValues(SQLLogicTestLogger &logger, MaterializedQueryResult &result, string lvalue_str,
 	                   string rvalue_str, idx_t current_row, idx_t current_column, vector<string> &values,
 	                   idx_t expected_column_count, bool row_wise, vector<string> &result_values);


### PR DESCRIPTION
New variation of CompareValues() to match expected error messages in a format of regex like this:
```
statement error
LOAD 'Makefile';
----
<REGEX>:.*IO Error: Extension.*not found.*

statement error
LOAD NULL;
----
<REGEX>:.*Parser Error: syntax error.* ```