### PR TITLE
Etag if none match for extension install

### DIFF
--- a/src/include/duckdb/main/extension_install_info.hpp
+++ b/src/include/duckdb/main/extension_install_info.hpp
@@ -37,6 +37,8 @@ public:
 	string repository_url;
 	//! (optional) Version of the extension
 	string version;
+	//! (optional) ETag of last fetched resource
+	string etag;
 
 	void Serialize(Serializer &serializer) const;
 

--- a/src/include/duckdb/storage/serialization/extension_install_info.json
+++ b/src/include/duckdb/storage/serialization/extension_install_info.json
@@ -24,6 +24,11 @@
         "id": 103,
         "name": "version",
         "type": "string"
+      },
+      {
+        "id": 104,
+        "name": "etag",
+        "type": "string"
       }
     ]
   }

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -378,6 +378,9 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DBConfig &config, con
 	ExtensionInstallInfo info;
 	CheckExtensionMetadataOnInstall(config, (void *)decompressed_body.data(), decompressed_body.size(), info,
 	                                extension_name);
+	if (res->has_header("ETag")) {
+		info.etag = res->get_header_value("ETag");
+	}
 
 	if (repository) {
 		info.mode = ExtensionInstallMode::REPOSITORY;

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -356,7 +356,22 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DBConfig &config, con
 	duckdb_httplib::Headers headers = {
 	    {"User-Agent", StringUtil::Format("%s %s", config.UserAgent(), DuckDB::SourceID())}};
 
+	unique_ptr<ExtensionInstallInfo> install_info;
+	{
+		auto fs = FileSystem::CreateLocal();
+		if (fs->FileExists(local_extension_path + ".info")) {
+			install_info = ExtensionInstallInfo::TryReadInfoFile(*fs, local_extension_path + ".info", extension_name);
+		}
+		if (install_info && !install_info->etag.empty()) {
+			headers.insert({"If-None-Match", StringUtil::Format("%s", install_info->etag)});
+		}
+	}
+
 	auto res = cli.Get(url_local_part.c_str(), headers);
+
+	if (install_info && res && res->status == 304) {
+		return install_info;
+	}
 
 	if (!res || res->status != 200) {
 		// create suggestions

--- a/src/storage/serialization/serialize_extension_install_info.cpp
+++ b/src/storage/serialization/serialize_extension_install_info.cpp
@@ -14,6 +14,7 @@ void ExtensionInstallInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(101, "full_path", full_path);
 	serializer.WritePropertyWithDefault<string>(102, "repository_url", repository_url);
 	serializer.WritePropertyWithDefault<string>(103, "version", version);
+	serializer.WritePropertyWithDefault<string>(104, "etag", etag);
 }
 
 unique_ptr<ExtensionInstallInfo> ExtensionInstallInfo::Deserialize(Deserializer &deserializer) {
@@ -22,6 +23,7 @@ unique_ptr<ExtensionInstallInfo> ExtensionInstallInfo::Deserialize(Deserializer 
 	deserializer.ReadPropertyWithDefault<string>(101, "full_path", result->full_path);
 	deserializer.ReadPropertyWithDefault<string>(102, "repository_url", result->repository_url);
 	deserializer.ReadPropertyWithDefault<string>(103, "version", result->version);
+	deserializer.ReadPropertyWithDefault<string>(104, "etag", result->etag);
 	return result;
 }
 


### PR DESCRIPTION
This changes significantly the latency of `UPDATE EXTENSIONS` by avoiding downloading payloads that we know to be copies of existing ones.
Very unscientific test goes from about 1 second / extension to 50ms / extension.

Unsure where this should be filed, I'd prefer main but it's debatable.

Note that given extensions (and their informations) are stored separately per-version, changing info serialisation has no effects.