### PR TITLE
[PySpark] - Allow create dataframe from a list of dicts

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/sql/session.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/session.py
@@ -169,7 +169,7 @@ class SparkSession:
 
             if isinstance(data[0], dict):
                 if not names:
-                    keys = [key for row in data[:10] for key in row.keys()]
+                    keys = [key for row in data for key in row.keys()]
                     seen = set()
                     names = [
                         name for name in keys if not (name in seen or seen.add(name))

--- a/tools/pythonpkg/tests/fast/spark/test_spark_dataframe.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_dataframe.py
@@ -14,9 +14,6 @@ from duckdb.experimental.spark.sql.types import (
     ArrayType,
     MapType,
 )
-from duckdb.experimental.spark.sql.functions import col, struct, when
-import duckdb
-import re
 
 from duckdb.experimental.spark.errors import PySparkValueError, PySparkTypeError
 
@@ -162,6 +159,22 @@ class TestDataFrame(object):
 
     def test_df_from_name_list(self, spark):
         df = spark.createDataFrame([(42, True), (21, False)], ['a', 'b'])
+        res = df.collect()
+        assert res == [Row(a=42, b=True), Row(a=21, b=False)]
+
+    def test_df_from_dict(self, spark):
+        df = spark.createDataFrame([{'a': 42, 'b': True}, {'b': False, 'a': 21}])
+        res = df.collect()
+        assert res == [Row(a=42, b=True), Row(a=21, b=False)]
+
+    def test_df_from_dict_with_schema(self, spark):
+        schema = StructType([StructField('a', LongType()), StructField('b', BooleanType())])
+        df = spark.createDataFrame([{'a': 42, 'b': True}, {'b': False, 'a': 21}], schema)
+        res = df.collect()
+        assert res == [Row(a=42, b=True), Row(a=21, b=False)]
+
+    def test_df_from_dict_with_name_list(self, spark):
+        df = spark.createDataFrame([{'a': 42, 'b': True}, {'b': False, 'a': 21}], ['a', 'b'])
         res = df.collect()
         assert res == [Row(a=42, b=True), Row(a=21, b=False)]
 


### PR DESCRIPTION
PySpark support create an dataframe from a list of dictionary.

In fact I don’t know how many records pyspark reads before define the available columns, int this case i used a magic number of 10, so getting the 10 firsts n records available.