### PR TITLE
Issue #12351: implicit cast to `TIMESTAMP_MS`, `TIMESTAMP_S`, `TIMESTAMP_NS` from `DATE` values

### DIFF
--- a/src/function/cast_rules.cpp
+++ b/src/function/cast_rules.cpp
@@ -212,6 +212,9 @@ static int64_t ImplicitCastDate(const LogicalType &to) {
 	switch (to.id()) {
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_SEC:
 		return TargetTypeCost(to);
 	default:
 		return -1;

--- a/test/sql/types/date/date_implicit_cast.test
+++ b/test/sql/types/date/date_implicit_cast.test
@@ -5,50 +5,21 @@
 statement ok
 PRAGMA enable_verification
 
+foreach type timestamp timestamp_ms timestamp_ns timestamp_s
+
 statement ok
-CREATE TABLE timestamps(ts TIMESTAMP)
+CREATE TABLE timestamps(ts ${type})
 
 statement ok
 INSERT INTO timestamps VALUES ('1993-08-14 00:00:00'), ('1993-08-15 01:01:02'), ('1993-08-16 00:00:00')
 
 query I
-SELECT * FROM  timestamps WHERE ts >= date '1993-08-15'
+SELECT * FROM timestamps WHERE ts >= date '1993-08-15'
 ----
 1993-08-15 01:01:02
 1993-08-16 00:00:00
 
 statement ok
-CREATE TABLE timestamps_ms(ts TIMESTAMP_MS)
+DROP TABLE timestamps
 
-statement ok
-INSERT INTO timestamps_ms VALUES ('1993-08-14 00:00:00'), ('1993-08-15 01:01:02'), ('1993-08-16 00:00:00')
-
-query I
-SELECT * FROM  timestamps_ms WHERE ts >= date '1993-08-15'
-----
-1993-08-15 01:01:02
-1993-08-16 00:00:00
-
-statement ok
-CREATE TABLE timestamps_ns(ts TIMESTAMP_NS)
-
-statement ok
-INSERT INTO timestamps_ns VALUES ('1993-08-14 00:00:00'), ('1993-08-15 01:01:02'), ('1993-08-16 00:00:00')
-
-query I
-SELECT * FROM  timestamps_ns WHERE ts >= date '1993-08-15'
-----
-1993-08-15 01:01:02
-1993-08-16 00:00:00
-
-statement ok
-CREATE TABLE timestamps_sec(ts TIMESTAMP_S)
-
-statement ok
-INSERT INTO timestamps_sec VALUES ('1993-08-14 00:00:00'), ('1993-08-15 01:01:02'), ('1993-08-16 00:00:00')
-
-query I
-SELECT * FROM  timestamps_sec WHERE ts >= date '1993-08-15'
-----
-1993-08-15 01:01:02
-1993-08-16 00:00:00
+endloop

--- a/test/sql/types/date/date_implicit_cast.test
+++ b/test/sql/types/date/date_implicit_cast.test
@@ -1,0 +1,54 @@
+# name: test/sql/types/date/date_implicit_cast.test
+# description: Test date implicit casts
+# group: [date]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE timestamps(ts TIMESTAMP)
+
+statement ok
+INSERT INTO timestamps VALUES ('1993-08-14 00:00:00'), ('1993-08-15 01:01:02'), ('1993-08-16 00:00:00')
+
+query I
+SELECT * FROM  timestamps WHERE ts >= date '1993-08-15'
+----
+1993-08-15 01:01:02
+1993-08-16 00:00:00
+
+statement ok
+CREATE TABLE timestamps_ms(ts TIMESTAMP_MS)
+
+statement ok
+INSERT INTO timestamps_ms VALUES ('1993-08-14 00:00:00'), ('1993-08-15 01:01:02'), ('1993-08-16 00:00:00')
+
+query I
+SELECT * FROM  timestamps_ms WHERE ts >= date '1993-08-15'
+----
+1993-08-15 01:01:02
+1993-08-16 00:00:00
+
+statement ok
+CREATE TABLE timestamps_ns(ts TIMESTAMP_NS)
+
+statement ok
+INSERT INTO timestamps_ns VALUES ('1993-08-14 00:00:00'), ('1993-08-15 01:01:02'), ('1993-08-16 00:00:00')
+
+query I
+SELECT * FROM  timestamps_ns WHERE ts >= date '1993-08-15'
+----
+1993-08-15 01:01:02
+1993-08-16 00:00:00
+
+statement ok
+CREATE TABLE timestamps_sec(ts TIMESTAMP_S)
+
+statement ok
+INSERT INTO timestamps_sec VALUES ('1993-08-14 00:00:00'), ('1993-08-15 01:01:02'), ('1993-08-16 00:00:00')
+
+query I
+SELECT * FROM  timestamps_sec WHERE ts >= date '1993-08-15'
+----
+1993-08-15 01:01:02
+1993-08-16 00:00:00


### PR DESCRIPTION
Added implicit cast to `TIMESTAMP_MS`, `TIMESTAMP_S`, `TIMESTAMP_NS` from `DATE` values.
Related #12351