### PR TITLE
Add projection pushdown support for DISTINCT ON and ORDER BY

### DIFF
--- a/projection_pushdown/README.md
+++ b/projection_pushdown/README.md
@@ -1,0 +1,3 @@
+# projection_pushdown
+Fix projection pushdown in duckdb. 
+As per https://github.com/duckdb/duckdb/issues/10214

--- a/projection_pushdown/cpp/CMakeLists.txt
+++ b/projection_pushdown/cpp/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Set the minimum required CMake version
+cmake_minimum_required(VERSION 3.12)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_COMPILER g++)
+project(test_query)
+
+# DuckDB
+set(DUCKDB_DIR "/home/cjoy/src/duckdb/build/debug/src")
+set(DUCKDB_INCLUDE_DIR "/home/cjoy/src/duckdb/src/include")
+# Check if the libduckdb library is found
+find_library(DUCKDB_LIB duckdb PATHS ${DUCKDB_DIR})
+if(NOT DUCKDB_LIB)
+    message(FATAL_ERROR "libduckdb not found. Please check the DUCKDB_DIR environment variable.")
+else()
+    message(STATUS "libduckdb found at ${DUCKDB_LIB}")
+endif()
+
+add_executable(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+
+# Specify include and link directories
+target_include_directories(${PROJECT_NAME} PRIVATE ${DUCKDB_INCLUDE_DIR} ${DUCKDB_DIR})
+
+# Link the DuckDB library
+target_link_libraries(${PROJECT_NAME} PRIVATE ${DUCKDB_DIR}/libduckdb.so)

--- a/projection_pushdown/cpp/main.cpp
+++ b/projection_pushdown/cpp/main.cpp
@@ -43,6 +43,13 @@ void explain_query(duckdb::Connection &con, const string &qry_str) {
     }
 }
 
+/*
+
+Example demonstrating slow performance from https://github.com/duckdb/duckdb/issues/10214
+Projection pushdown on DISTINCT ON doesn't work
+
+*/
+
 void test1(void) {
     DuckDB db(nullptr);
     Connection con(db);

--- a/projection_pushdown/cpp/main.cpp
+++ b/projection_pushdown/cpp/main.cpp
@@ -1,0 +1,133 @@
+#include <iostream>
+#include "duckdb.hpp"
+
+using namespace std;
+using namespace std::chrono;
+using namespace duckdb;
+
+void print_query(duckdb::Connection &con, const string &qry_str) {
+    auto result = con.Query(qry_str);
+    if (result->HasError()) {
+        cout << result->GetError();
+    } else {
+        cout << result->ToString() << endl;
+    }
+}
+
+void time_query(duckdb::Connection &con, const string &qry_str) {
+    // Get starting timepoint
+    auto start = high_resolution_clock::now();
+
+    // Call the function
+    auto result = con.Query(qry_str);
+
+    // Get ending timepoint
+    auto stop = high_resolution_clock::now();
+
+    // Get duration. Substart timepoints to
+    // get duration. To cast it to proper unit
+    // use duration cast method
+    auto duration = duration_cast<microseconds>(stop - start);
+
+    cout << "Time taken by query: "
+         << duration.count() << " microseconds" << endl;
+}
+
+void explain_query(duckdb::Connection &con, const string &qry_str) {
+    con.Query("SET explain_output = 'all';");
+    auto result = con.Query(string("EXPLAIN ") + qry_str);
+    if (result->HasError()) {
+        cout << result->GetError();
+    } else {
+        cout << result->ToString() << endl;
+    }
+}
+
+int main(void) {
+    DuckDB db(nullptr);
+    Connection con(db);
+
+    // create a table
+    int ncol = 10;
+    int nrow = 10;
+    stringstream tbl;
+    tbl << "CREATE TABLE push_d (";
+    for(int i=0; i<ncol; i++) {
+        if(i > 0) {
+            tbl << ", ";
+        }
+        tbl << "col" << i << " INTEGER";
+    }
+    tbl << ")";
+    // cout << tbl.str() << endl;
+    con.Query(tbl.str());
+
+    // insert rows into the table
+    stringstream rowstr;
+    rowstr << "INSERT INTO push_d VALUES ";
+    for(int row=0; row<nrow; row++) {
+        rowstr << "(";
+        for(int col=0; col<ncol; col++) {
+            if(col >0) {
+                rowstr << ",";
+            }
+            rowstr << row*ncol + col;
+        }
+        rowstr << "), ";
+    }
+    // cout << rowstr.str() << endl;
+    con.Query(rowstr.str());
+
+    // cout << "Example Table:" << endl;
+    // print_query(con, "SELECT * FROM push_d");
+
+    /*
+    string query_template =
+            "SELECT col0\n"
+            "FROM \n"
+            "(\n"
+            "    SELECT \n"
+            "    DISTINCT ON (floor(col0))\n"
+            "    {columns}\n"
+            "    FROM push_d\n"
+            "    ORDER by col0 DESC\n"
+            ")";
+    */
+
+    string query_template =
+            "SELECT col0\n"
+            "FROM \n"
+            "(\n"
+            "    SELECT \n"
+            "    DISTINCT ON (floor(col0)) \n"
+            "    {columns}\n"
+            "    FROM push_d\n"
+            "    ORDER by col1 DESC\n)";
+            // ") ORDER by col1 DESC ";
+
+    string param = "{columns}";
+    string qry_col0 = string(query_template).replace(query_template.find(param),param.length(),"col0");
+    string qry_col_star = string(query_template).replace(query_template.find(param),param.length(),"col0, col1, col2");
+
+    // cout << "Query:\n" << qry_col_star << endl;
+
+    print_query(con, qry_col_star);
+
+
+    //cout << "Explain col0:" << endl;
+    //explain_query(con, qry_col0);
+    //cout << "\n";
+    cout << "Explain *:" << endl;
+    explain_query(con, qry_col_star);
+
+
+    //cout << "Time col0:" << endl;
+    //time_query(con, qry_col0);
+    cout << "\n";
+    cout << "Time using *:" << endl;
+    time_query(con, qry_col_star);
+    return 0;
+}
+
+
+

--- a/projection_pushdown/cpp/main.cpp
+++ b/projection_pushdown/cpp/main.cpp
@@ -43,7 +43,7 @@ void explain_query(duckdb::Connection &con, const string &qry_str) {
     }
 }
 
-int main(void) {
+void test1(void) {
     DuckDB db(nullptr);
     Connection con(db);
 
@@ -81,7 +81,7 @@ int main(void) {
     // cout << "Example Table:" << endl;
     // print_query(con, "SELECT * FROM push_d");
 
-    /*
+
     string query_template =
             "SELECT col0\n"
             "FROM \n"
@@ -92,42 +92,70 @@ int main(void) {
             "    FROM push_d\n"
             "    ORDER by col0 DESC\n"
             ")";
-    */
 
-    string query_template =
-            "SELECT col0\n"
-            "FROM \n"
-            "(\n"
-            "    SELECT \n"
-            "    DISTINCT ON (floor(col0)) \n"
-            "    {columns}\n"
-            "    FROM push_d\n"
-            "    ORDER by col1 DESC\n)";
-            // ") ORDER by col1 DESC ";
 
     string param = "{columns}";
     string qry_col0 = string(query_template).replace(query_template.find(param),param.length(),"col0");
-    string qry_col_star = string(query_template).replace(query_template.find(param),param.length(),"col0, col1, col2");
+    string qry_col_star = string(query_template).replace(query_template.find(param),param.length(),"*");
 
     // cout << "Query:\n" << qry_col_star << endl;
 
     print_query(con, qry_col_star);
 
 
-    //cout << "Explain col0:" << endl;
-    //explain_query(con, qry_col0);
-    //cout << "\n";
+    cout << "Explain col0:" << endl;
+    explain_query(con, qry_col0);
+    cout << "\n";
     cout << "Explain *:" << endl;
     explain_query(con, qry_col_star);
 
 
-    //cout << "Time col0:" << endl;
-    //time_query(con, qry_col0);
+    cout << "Time col0:" << endl;
+    time_query(con, qry_col0);
     cout << "\n";
     cout << "Time using *:" << endl;
     time_query(con, qry_col_star);
-    return 0;
 }
 
+/* test_10087.test
+ *
+ * statement ok
+CREATE TABLE t0(c1 INT);
+
+statement ok
+INSERT INTO t0(c1) VALUES (1);
+
+statement ok
+CREATE VIEW v0(c0, c1, c2) AS SELECT '1', true, t0.c1 FROM t0 ORDER BY -1-2 LIMIT 2;
+
+statement ok
+SELECT v0.c2 FROM v0 WHERE (NOT (v0.c1 IS NOT NULL));
+ */
+
+// Based on test_10087.test
+void test2(void) {
+    DuckDB db(nullptr);
+    Connection con(db);
+
+    string qry1 = "CREATE TABLE t0(c1 INT);";
+    con.Query(qry1);
+
+    string qry2 = "INSERT INTO t0(c1) VALUES (1);";
+    con.Query(qry2);
+
+    string qry3 = "CREATE VIEW v0(c0, c1, c2) AS SELECT '1', true, t0.c1 FROM t0 ORDER BY -1-2 LIMIT 2;";
+    con.Query(qry3);
+
+    string qry4 = "SELECT v0.c2 FROM v0 WHERE (NOT (v0.c1 IS NOT NULL));";
+    explain_query(con, qry4);
+    print_query(con, qry4);
+}
+
+
+int main(void) {
+    test1();
+    // test2();
+    return 0;
+}
 
 

--- a/projection_pushdown/pushdown_test.py
+++ b/projection_pushdown/pushdown_test.py
@@ -1,3 +1,6 @@
+# Example demonstrating slow performance from https://github.com/duckdb/duckdb/issues/10214
+# Projection pushdown on DISTINCT ON doesn't work
+
 import pandas as pd
 import numpy as np
 import duckdb
@@ -28,4 +31,4 @@ for columns in ['col0', '*',]:
     for row in range(2):
         print(expl.iloc[row, 0])
         print(expl.iloc[row, 1])
-# print(f"The results are equal: {results['*'].equals(results['col0'])}")
+print(f"The results are equal: {results['*'].equals(results['col0'])}")

--- a/projection_pushdown/pushdown_test.py
+++ b/projection_pushdown/pushdown_test.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import numpy as np
+import duckdb
+from time import perf_counter
+
+duckdb.query("SET explain_output = 'all';")
+
+n = 100_000
+columns = 10
+pd_df = pd.DataFrame({f'col{i}': 1000 * np.random.sample(n) for i in range(columns)})
+query = """
+SELECT col0
+FROM 
+(
+    SELECT 
+    DISTINCT ON (floor(col0))
+    {columns}
+    FROM pd_df
+    ORDER by col0 DESC
+)
+"""
+results = dict()
+for columns in ['col0', '*',]:
+    start = perf_counter()
+    results[columns] = duckdb.query(query.format(columns=columns)).df()
+    print(f'The query using `{columns}` took {perf_counter() - start} s')
+    expl = duckdb.query("EXPLAIN " + query.format(columns=columns)).df()
+    for row in range(2):
+        print(expl.iloc[row, 0])
+        print(expl.iloc[row, 1])
+# print(f"The results are equal: {results['*'].equals(results['col0'])}")

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -177,12 +177,18 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 					order.projections.push_back(col_idx);
 				}
 			}
-		}
-		for (auto &child : op.children) {
-			RemoveUnusedColumns remove(binder, context);
-            remove.VisitOperatorExpressions(op);
-			remove.column_references.insert(column_references.begin(), column_references.end()); // add parent references
-            remove.VisitOperator(*child);
+
+			for (auto &child : op.children) {
+				RemoveUnusedColumns remove(binder, context);
+				remove.VisitOperatorExpressions(op);
+				remove.column_references.insert(column_references.begin(), column_references.end()); // add parent references
+				remove.VisitOperator(*child);
+			}
+		} else {
+			for (auto &child : op.children) {
+				RemoveUnusedColumns remove(binder, context, true);
+				remove.VisitOperator(*child);
+			}
 		}
 		return;
 	case LogicalOperatorType::LOGICAL_PROJECTION: {

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_set_operation.hpp"
 #include "duckdb/planner/operator/logical_simple.hpp"
+#include "duckdb/planner/operator/logical_distinct.hpp"
 
 namespace duckdb {
 
@@ -297,9 +298,14 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_DISTINCT: {
 		// distinct, all projected columns are used for the DISTINCT computation
 		// mark all columns as used and continue to the children
-		// FIXME: DISTINCT with expression list does not implicitly reference everything
-		everything_referenced = true;
-		break;
+        auto &distinct_op = op.Cast<LogicalDistinct>();
+		if(distinct_op.distinct_targets.empty()) {
+            everything_referenced = true;
+        } else {
+            // DISTINCT with expression list does not implicitly reference everything
+            // pass through existing everything_referenced state
+        }
+        break;
 	}
 	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE: {
 		everything_referenced = true;

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -185,7 +185,8 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			for (auto &child : op.children) {
 				RemoveUnusedColumns remove(binder, context);
 				remove.VisitOperatorExpressions(op);
-				remove.column_references.insert(column_references.begin(), column_references.end()); // add parent references
+				remove.column_references.insert(column_references.begin(),
+				                                column_references.end()); // add parent references
 				remove.VisitOperator(*child);
 			}
 		} else {
@@ -308,14 +309,14 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_DISTINCT: {
 		// distinct, all projected columns are used for the DISTINCT computation
 		// mark all columns as used and continue to the children
-        auto &distinct_op = op.Cast<LogicalDistinct>();
-		if(distinct_op.distinct_targets.empty()) {
-            everything_referenced = true;
-        } else {
-            // DISTINCT with expression list does not implicitly reference everything
-            // pass through existing everything_referenced state
-        }
-        break;
+		auto &distinct_op = op.Cast<LogicalDistinct>();
+		if (distinct_op.distinct_targets.empty()) {
+			everything_referenced = true;
+		} else {
+			// DISTINCT with expression list does not implicitly reference everything
+			// pass through existing everything_referenced state
+		}
+		break;
 	}
 	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE: {
 		everything_referenced = true;

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -178,6 +178,8 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 				}
 			}
 
+			// This seems to break when we have columns that are constant expressions like '1' or true.
+			// I think we want to add 'all_bindings' to the child column_references but I am not sure.
 			for (auto &child : op.children) {
 				RemoveUnusedColumns remove(binder, context);
 				remove.VisitOperatorExpressions(op);

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -178,8 +178,10 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			}
 		}
 		for (auto &child : op.children) {
-			RemoveUnusedColumns remove(binder, context, true);
-			remove.VisitOperator(*child);
+			RemoveUnusedColumns remove(binder, context);
+            remove.VisitOperatorExpressions(op);
+			remove.column_references.insert(column_references.begin(), column_references.end()); // add parent references
+            remove.VisitOperator(*child);
 		}
 		return;
 	case LogicalOperatorType::LOGICAL_PROJECTION: {

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -179,7 +179,9 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			}
 
 			// This seems to break when we have columns that are constant expressions like '1' or true.
-			// I think we want to add 'all_bindings' to the child column_references but I am not sure.
+			// I'm not sure what the solution is.
+			// Maybe add all_bindings here (somehow).
+			// Or, need to update lower code so that unused expressions can be omitted.
 			for (auto &child : op.children) {
 				RemoveUnusedColumns remove(binder, context);
 				remove.VisitOperatorExpressions(op);


### PR DESCRIPTION
This is related to https://github.com/duckdb/duckdb/issues/10214. The underlying issue is that projection pushdown is not supported for DISTINCT ON and ORDER BY.

Here I am hoping to improve duckdb by adding projection pushdown support for these cases, but I could use a little help.

DISTINCT ON seems easy to fix, we just need to enable a check for it as far as I can tell.
ORDER BY is harder. I have a change, below, where I enable projection pushdown for order by which works for most cases. But, it breaks down when we have constant expression like '1', true, etc. that are not used at a higher level. The optimizer tries to remove these, but then lower level bindings still seem to want the bindings. I could use some help in how to handle this.

The code in the folder projection_pushdown is for illustration and debugging since I wasn't certain how to trace through the unit tests. It will be removed in the final PR.