### PR TITLE
Fix checkouts

### DIFF
--- a/.github/actions/ubuntu_18_setup/action.yml
+++ b/.github/actions/ubuntu_18_setup/action.yml
@@ -16,6 +16,9 @@ inputs:
   ccache:
     description: 'Install ccache'
     default: 0
+  git_ref:
+    description: 'git reference to checkout'
+    default: ''
 
 runs:
   using: "composite"
@@ -48,6 +51,7 @@ runs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
 
     - name: Install CMake 3.21
       shell: bash

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -166,6 +166,7 @@ jobs:
        with:
         ccache: 1
         aarch64_cross_compile: 1
+        git_ref: ${{ inputs.git_ref }}
 
      - name: Checkout (again)
        shell: bash
@@ -224,6 +225,7 @@ jobs:
         vcpkg: 1
         openssl: 1
         ccache: 1
+        git_ref: ${{ inputs.git_ref }}
 
     - name: Checkout (again)
       shell: bash
@@ -268,6 +270,7 @@ jobs:
           openssl: 1
           aarch64_cross_compile: 1
           ccache: 1
+          git_ref: ${{ inputs.git_ref }}
 
       - name: Checkout (again)
         shell: bash

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -168,10 +168,6 @@ jobs:
         aarch64_cross_compile: 1
         git_ref: ${{ inputs.git_ref }}
 
-     - name: Checkout (again)
-       shell: bash
-       run: git checkout ${{ inputs.git_ref }}
-
      - name: Install unixODBC
        shell: bash
        run: | # we need an x86 odbc_config tool to run cmake. fun.
@@ -227,10 +223,6 @@ jobs:
         ccache: 1
         git_ref: ${{ inputs.git_ref }}
 
-    - name: Checkout (again)
-      shell: bash
-      run: git checkout ${{ inputs.git_ref }}
-
     - uses: ./.github/actions/build_extensions
       with:
         vcpkg_target_triplet: x64-linux
@@ -271,10 +263,6 @@ jobs:
           aarch64_cross_compile: 1
           ccache: 1
           git_ref: ${{ inputs.git_ref }}
-
-      - name: Checkout (again)
-        shell: bash
-        run: git checkout ${{ inputs.git_ref }}
 
       - uses: ./.github/actions/build_extensions
         with:


### PR DESCRIPTION
Proper fix to https://github.com/duckdb/duckdb/pull/12308, that at the moment was not workable due to layered checkouts and need to execute a specific commit CI.

Now it should be safe to remove the third checkout, correctly propagating information.