### PR TITLE
Fix #12293 - accept NULL values in generate_series with timestamp

### DIFF
--- a/test/api/test_get_table_names.cpp
+++ b/test/api/test_get_table_names.cpp
@@ -90,6 +90,11 @@ TEST_CASE("Test GetTableNames", "[api]") {
 	REQUIRE(table_names.size() == 1);
 	REQUIRE(table_names.count("df"));
 
+	// generate_series
+	table_names = con.GetTableNames("with series_generator as (select * from generate_series(TIMESTAMP '2001-04-10', "
+	                                "TIMESTAMP '2001-04-11', INTERVAL 1 HOUR)) select * from series_generator");
+	REQUIRE(table_names.empty());
+
 	if (!db.ExtensionIsLoaded("tpch")) {
 		return;
 	}

--- a/test/fuzzer/duckfuzz/generate_null_timestamp.test
+++ b/test/fuzzer/duckfuzz/generate_null_timestamp.test
@@ -5,8 +5,7 @@
 statement ok
 PRAGMA enable_verification
 
-statement error
+query I
 SELECT NULL 
 FROM generate_series(CAST('294247-01-10 04:00:54.775806' AS TIMESTAMP), NULL, NULL) AS t3(c1, c2)
 ----
-RANGE with NULL argument is not supported

--- a/test/sql/table_function/range_timestamp.test
+++ b/test/sql/table_function/range_timestamp.test
@@ -115,6 +115,17 @@ SELECT COUNT(*) FROM generate_series(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP 
 ----
 10228
 
+# null values result in no rows
+query I
+SELECT COUNT(*) FROM range(NULL, TIMESTAMP '1992-12-31 12:00:00', INTERVAL '1 MONTH') tbl(d)
+----
+0
+
+query I
+SELECT COUNT(*) FROM generate_series(NULL, TIMESTAMP '1992-12-31 12:00:00', INTERVAL '1 MONTH') tbl(d)
+----
+0
+
 # zero interval not supported
 statement error
 SELECT d FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1992-12-31 12:00:00', INTERVAL '0 MONTH') tbl(d)


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/12293
