### PR TITLE
Fix parameters passed down to other workflows in OnTag.yml

### DIFF
--- a/.github/workflows/OnTag.yml
+++ b/.github/workflows/OnTag.yml
@@ -13,10 +13,10 @@ jobs:
     uses: ./.github/workflows/TwineUpload.yml
     secrets: inherit
     with:
-      override_git_describe: ${{ inputs.override_git_describe || github.event.release.tag_name }}
+      override_git_describe: ${{ inputs.override_git_describe || github.ref_name }}
 
   staged_upload:
     uses: ./.github/workflows/StagedUpload.yml
     secrets: inherit
     with:
-      override_git_describe: ${{ inputs.override_git_describe || github.event.release.tag_name }}
+      override_git_describe: ${{ inputs.override_git_describe || github.ref_name }}


### PR DESCRIPTION
On v1.0.0 an empty parameter was passed down, then requiring a manual trigger.

Just worth fixing since we saw this.