### PR TITLE
Fix #12335: avoid calling fsync when writing Parquet files, instead just close the file

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -578,7 +578,7 @@ void ParquetWriter::Finalize() {
 	}
 
 	// flush to disk
-	writer->Sync();
+	writer->Close();
 	writer.reset();
 }
 

--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -65,6 +65,12 @@ void BufferedFileWriter::Flush() {
 	offset = 0;
 }
 
+void BufferedFileWriter::Close() {
+	Flush();
+	handle->Close();
+	handle.reset();
+}
+
 void BufferedFileWriter::Sync() {
 	Flush();
 	handle->Sync();

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -32,7 +32,9 @@ public:
 
 public:
 	DUCKDB_API void WriteData(const_data_ptr_t buffer, idx_t write_size) override;
-	//! Flush the buffer to disk and sync the file to ensure writing is completed
+	//! Flush all changes to the file and then close the file
+	DUCKDB_API void Close();
+	//! Flush all changes and fsync the file to disk
 	DUCKDB_API void Sync();
 	//! Flush the buffer to the file (without sync)
 	DUCKDB_API void Flush();


### PR DESCRIPTION
Fixes #12335

Calling `fsync` is only required when we need all changes synced to disk **without** closing the file, which is generally only required for our main database file. For parquet files we can just close the file instead.