### PR TITLE
change max_queries number back to 2000

### DIFF
--- a/scripts/run_fuzzer.py
+++ b/scripts/run_fuzzer.py
@@ -103,7 +103,7 @@ if dry:
 else:
     current_errors = fuzzer_helper.extract_github_issues(shell, perform_checks)
 
-max_queries = 10
+max_queries = 2000
 last_query_log_file = 'sqlsmith.log'
 complete_log_file = 'sqlsmith.complete.log'
 


### PR DESCRIPTION
This change snuck into feature when attempting to allow the fuzzer to fuzz multi-statements

Original max_queries value was 2000.

https://github.com/duckdb/duckdb/pull/12278/files#diff-e44f37b867e40bb24fe5c0aaf3afd2e5342267d03fb20c2b652821de3b88cb75R106