### PR TITLE
Fix #11921 - varchar -> timestamp casts are not invertible

### DIFF
--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -158,17 +158,7 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 		}
 		break;
 	case LogicalTypeId::VARCHAR:
-		switch (target_type.id()) {
-		case LogicalTypeId::TIMESTAMP:
-		case LogicalTypeId::TIMESTAMP_NS:
-		case LogicalTypeId::TIMESTAMP_MS:
-		case LogicalTypeId::TIMESTAMP_SEC:
-		case LogicalTypeId::TIMESTAMP_TZ:
-			return true;
-		default:
-			return false;
-		}
-		break;
+		return false;
 	default:
 		break;
 	}

--- a/test/sql/optimizer/expression/test_timestamp_offset.test
+++ b/test/sql/optimizer/expression/test_timestamp_offset.test
@@ -1,0 +1,50 @@
+# name: test/sql/optimizer/expression/test_timestamp_offset.test
+# description: Test pushdown of varchars converted to timestamps
+# group: [expression]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create or replace table table1 (
+    timestamp_str varchar
+);
+
+statement ok
+insert into table1 values ('2024-05-03 01:00:00'), ('2024-05-03 01:00:02');
+
+query II
+select timestamp_str, cast(timestamp_str as timestamp)
+from table1
+where cast(timestamp_str as timestamp) > cast('2024-05-03 01:00:00' as timestamp);
+----
+2024-05-03 01:00:02	2024-05-03 01:00:02
+
+statement ok
+truncate table table1;
+
+statement ok
+insert into table1 values ('2024-05-03T01:00:00+00:00'), ('2024-05-03T01:00:02+00:00');
+
+query II
+select timestamp_str, cast(timestamp_str as timestamp)
+from table1
+where cast(timestamp_str as timestamp) > cast('2024-05-03 01:00:00' as timestamp);
+----
+2024-05-03T01:00:02+00:00	2024-05-03 01:00:02
+
+query II
+select timestamp_str, cast(timestamp_str as timestamp)
+from table1
+where cast(timestamp_str as timestamp) > cast('2024-05-03T01:00:00+00:00' as timestamp);
+----
+2024-05-03T01:00:02+00:00	2024-05-03 01:00:02
+
+query II
+select * from (
+    select timestamp_str, cast(timestamp_str as timestamp) as timestamp_column
+    from table1
+)
+where timestamp_column > cast('2024-05-03 01:00:00' as timestamp);
+----
+2024-05-03T01:00:02+00:00	2024-05-03 01:00:02


### PR DESCRIPTION
Fixes #11921

The issue is that the optimizer thought that `VARCHAR -> TIMESTAMP` casts were invertible, i.e. that `v::TIMESTAMP::VARCHAR = v` holds true for all values of `v`. Since we now support parsing of offsets, that is no longer the case, e.g.:

```sql
SELECT '2024-05-03T01:00:02+00:00'::timestamp::varchar AS result;
┌─────────────────────┐
│       result        │
│       varchar       │
├─────────────────────┤
│ 2024-05-03 01:00:02 │
└─────────────────────┘
```

This can lead to the optimizer performing incorrect optimizations leading to the reported issue.
