### PR TITLE
[Benchmark Runner] Add `--disable-timeout` flag

### DIFF
--- a/benchmark/include/benchmark.hpp
+++ b/benchmark/include/benchmark.hpp
@@ -29,8 +29,6 @@ struct BenchmarkState {
 //! new benchmarks
 class Benchmark {
 	constexpr static size_t DEFAULT_NRUNS = 5;
-	constexpr static size_t DEFAULT_TIMEOUT = 30;
-
 	Benchmark(Benchmark &) = delete;
 
 public:
@@ -87,8 +85,8 @@ public:
 		return DEFAULT_NRUNS;
 	}
 	//! The timeout for this benchmark (in seconds)
-	virtual size_t Timeout() {
-		return DEFAULT_TIMEOUT;
+	virtual optional_idx Timeout(const BenchmarkConfiguration &config) {
+		return config.timeout_duration;
 	}
 };
 

--- a/benchmark/include/benchmark_configuration.hpp
+++ b/benchmark/include/benchmark_configuration.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/optional_idx.hpp"
 
 namespace duckdb {
 
@@ -19,9 +20,14 @@ enum class BenchmarkMetaType { NONE, INFO, QUERY };
 enum class BenchmarkProfileInfo { NONE, NORMAL, DETAILED };
 
 struct BenchmarkConfiguration {
+public:
+	constexpr static size_t DEFAULT_TIMEOUT = 30;
+
+public:
 	string name_pattern {};
 	BenchmarkMetaType meta = BenchmarkMetaType::NONE;
 	BenchmarkProfileInfo profile_info = BenchmarkProfileInfo::NONE;
+	optional_idx timeout_duration = optional_idx(DEFAULT_TIMEOUT);
 };
 
 } // namespace duckdb

--- a/benchmark/micro/append_mix.cpp
+++ b/benchmark/micro/append_mix.cpp
@@ -62,7 +62,7 @@ using namespace duckdb;
 	string BenchmarkInfo() override {                                                                                  \
 		return "Append 10M rows to a table using an Appender";                                                         \
 	}                                                                                                                  \
-	size_t Timeout() override {                                                                                        \
+	optional_idx Timeout(const BenchmarkConfiguration &config) override {                                              \
 		return 600;                                                                                                    \
 	}
 


### PR DESCRIPTION
I was trying to profile something and ran into a timeout, so I figured I'd add this option.
I assume this will be useful for others as well