### PR TITLE
MatchRegex() fixed to do not return false positive result

### DIFF
--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -531,7 +531,7 @@ bool TestResultHelper::MatchesRegex(SQLLogicTestLogger &logger, MaterializedQuer
 	}
 	auto resString = result.ToString();
 	bool regex_matches = RE2::FullMatch(result.ToString(), re);
-	if (regex_matches == want_match) {
+	if (regex_matches && regex_matches == want_match) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
closes https://github.com/duckdblabs/duckdb-internal/issues/2217

MatchRegex() was returning true, when the expected message doesn't start with the <REGEX> tag and doesn't match the actual message's text at the same time.
