### PR TITLE
Don't replace unicode spaces within `$$` quotes in query strings

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -95,6 +95,9 @@ regular:
 			quote = query[pos];
 			pos++;
 			goto in_quotes;
+		} else if (query[pos] == '$' && query[pos + 1] == '$') {
+			pos += 2;
+			goto in_dollar_quotes;
 		} else if (query[pos] == '-' && query[pos + 1] == '-') {
 			goto in_comment;
 		}
@@ -109,6 +112,14 @@ in_quotes:
 				continue;
 			}
 			pos++;
+			goto regular;
+		}
+	}
+	goto end;
+in_dollar_quotes:
+	for (; pos + 2 < qsize; pos++) {
+		if (query[pos] == '$' && query[pos + 1] == '$') {
+			pos += 2;
 			goto regular;
 		}
 	}

--- a/test/sql/parser/dollar_quotes_internal_issue2224.test
+++ b/test/sql/parser/dollar_quotes_internal_issue2224.test
@@ -1,0 +1,44 @@
+# name: test/sql/parser/dollar_quotes_internal_issue2224.test
+# description: Unexpected implicit conversion of string literal with full-width space
+# group: [parser]
+
+# we replace unicode spaces in query strings, except if they are quoted
+# internal issue 2224 found that this doesn't work properly for double-dollar quoting
+# lhs is regular space, rhs is a wider unicode space, so this should be false
+query I
+select $$ $$ = $$　$$;
+----
+false
+
+# worked properly before for these quotes
+query I
+select ' ' = '　';
+----
+false
+
+
+query I
+select $$$$ = '';
+----
+true
+
+# just checking if parsing didn't break by fixing the dollar thing
+query I
+select $$$$ = '';
+----
+true
+
+query I
+select '' = $$$$;
+----
+true
+
+query I
+select $$ $$ = $$　$$ or ' ' = '　';
+----
+false
+
+query I
+select ' ' = '　' or $$ $$ = $$　$$;
+----
+false

--- a/test/sql/parser/dollar_quotes_internal_issue2224.test
+++ b/test/sql/parser/dollar_quotes_internal_issue2224.test
@@ -16,12 +16,6 @@ select ' ' = '　';
 ----
 false
 
-
-query I
-select $$$$ = '';
-----
-true
-
 # just checking if parsing didn't break by fixing the dollar thing
 query I
 select $$$$ = '';


### PR DESCRIPTION
Fixes an issue found internally