### PR TITLE
Release CSV Blocks when acquiring new blocks if single threaded

### DIFF
--- a/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
@@ -4,8 +4,9 @@
 namespace duckdb {
 
 CSVBufferManager::CSVBufferManager(ClientContext &context_p, const CSVReaderOptions &options, const string &file_path_p,
-                                   const idx_t file_idx_p)
-    : context(context_p), file_idx(file_idx_p), file_path(file_path_p), buffer_size(CSVBuffer::CSV_BUFFER_SIZE) {
+                                   const idx_t file_idx_p, bool per_file_single_threaded_p)
+    : context(context_p), file_idx(file_idx_p), file_path(file_path_p), buffer_size(CSVBuffer::CSV_BUFFER_SIZE),
+      per_file_single_threaded(per_file_single_threaded_p) {
 	D_ASSERT(!file_path.empty());
 	file_handle = ReadCSV::OpenCSV(file_path, options.compression, context);
 	is_pipe = file_handle->IsPipe();
@@ -71,7 +72,7 @@ shared_ptr<CSVBufferHandle> CSVBufferManager::GetBuffer(const idx_t pos) {
 			done = true;
 		}
 	}
-	if (pos != 0 && (sniffing || file_handle->CanSeek())) {
+	if (pos != 0 && (sniffing || file_handle->CanSeek() || per_file_single_threaded)) {
 		// We don't need to unpin the buffers here if we are not sniffing since we
 		// control it per-thread on the scan
 		if (cached_buffers[pos - 1]) {

--- a/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
+++ b/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
@@ -5,8 +5,8 @@ namespace duckdb {
 
 CSVBufferManager::CSVBufferManager(ClientContext &context_p, const CSVReaderOptions &options, const string &file_path_p,
                                    const idx_t file_idx_p, bool per_file_single_threaded_p)
-    : context(context_p), file_idx(file_idx_p), file_path(file_path_p), buffer_size(CSVBuffer::CSV_BUFFER_SIZE),
-      per_file_single_threaded(per_file_single_threaded_p) {
+    : context(context_p), per_file_single_threaded(per_file_single_threaded_p), file_idx(file_idx_p),
+      file_path(file_path_p), buffer_size(CSVBuffer::CSV_BUFFER_SIZE) {
 	D_ASSERT(!file_path.empty());
 	file_handle = ReadCSV::OpenCSV(file_path, options.compression, context);
 	is_pipe = file_handle->IsPipe();

--- a/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
@@ -43,7 +43,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, shared_ptr<CSVBufferManager> bu
 
 CSVFileScan::CSVFileScan(ClientContext &context, const string &file_path_p, const CSVReaderOptions &options_p,
                          const idx_t file_idx_p, const ReadCSVData &bind_data, const vector<column_t> &column_ids,
-                         const vector<LogicalType> &file_schema)
+                         const vector<LogicalType> &file_schema, bool per_file_single_threaded)
     : file_path(file_path_p), file_idx(file_idx_p),
       error_handler(make_shared_ptr<CSVErrorHandler>(options_p.ignore_errors.GetValue())), options(options_p) {
 	auto multi_file_reader = MultiFileReader::CreateDefault("CSV Scan");
@@ -76,7 +76,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, const string &file_path_p, cons
 	}
 
 	// Initialize Buffer Manager
-	buffer_manager = make_shared_ptr<CSVBufferManager>(context, options, file_path, file_idx);
+	buffer_manager = make_shared_ptr<CSVBufferManager>(context, options, file_path, file_idx, per_file_single_threaded);
 	// Initialize On Disk and Size of file
 	on_disk_file = buffer_manager->file_handle->OnDiskFile();
 	file_size = buffer_manager->file_handle->FileSize();

--- a/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
+++ b/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
@@ -22,7 +22,7 @@ CSVGlobalState::CSVGlobalState(ClientContext &context_p, const shared_ptr<CSVBuf
 	} else {
 		// If not we need to construct it for the first file
 		file_scans.emplace_back(
-		    make_uniq<CSVFileScan>(context, files[0], options, 0U, bind_data, column_ids, file_schema));
+		    make_uniq<CSVFileScan>(context, files[0], options, 0U, bind_data, column_ids, file_schema, false));
 	};
 	// There are situations where we only support single threaded scanning
 	bool many_csv_files = files.size() > 1 && files.size() > system_threads * 2;
@@ -68,7 +68,7 @@ unique_ptr<StringValueScanner> CSVGlobalState::Next(optional_ptr<StringValueScan
 		} else {
 			lock_guard<mutex> parallel_lock(main_mutex);
 			file_scans.emplace_back(make_shared_ptr<CSVFileScan>(context, bind_data.files[cur_idx], bind_data.options,
-			                                                     cur_idx, bind_data, column_ids, file_schema));
+			                                                     cur_idx, bind_data, column_ids, file_schema, true));
 			current_file = file_scans.back();
 		}
 		if (previous_scanner) {
@@ -113,7 +113,7 @@ unique_ptr<StringValueScanner> CSVGlobalState::Next(optional_ptr<StringValueScan
 			// If we have a next file we have to construct the file scan for that
 			file_scans.emplace_back(make_shared_ptr<CSVFileScan>(context, bind_data.files[current_file_idx],
 			                                                     bind_data.options, current_file_idx, bind_data,
-			                                                     column_ids, file_schema));
+			                                                     column_ids, file_schema, false));
 			// And re-start the boundary-iterator
 			auto buffer_size = file_scans.back()->buffer_manager->GetBuffer(0)->actual_size;
 			current_boundary = CSVIterator(current_file_idx, 0, 0, 0, buffer_size);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_buffer_manager.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_buffer_manager.hpp
@@ -22,7 +22,7 @@ class CSVStateMachine;
 class CSVBufferManager {
 public:
 	CSVBufferManager(ClientContext &context, const CSVReaderOptions &options, const string &file_path,
-	                 const idx_t file_idx);
+	                 const idx_t file_idx, bool per_file_single_threaded = false);
 	//! Returns a buffer from a buffer id (starting from 0). If it's in the auto-detection then we cache new buffers
 	//! Otherwise we remove them from the cache if they are already there, or just return them bypassing the cache.
 	shared_ptr<CSVBufferHandle> GetBuffer(const idx_t buffer_idx);
@@ -48,6 +48,7 @@ public:
 	ClientContext &context;
 	idx_t skip_rows = 0;
 	bool sniffing = false;
+	const bool per_file_single_threaded;
 
 private:
 	//! Reads next buffer in reference to cached_buffers.front()

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -27,7 +27,7 @@ public:
 	//! Path to this file
 	CSVFileScan(ClientContext &context, const string &file_path, const CSVReaderOptions &options, const idx_t file_idx,
 	            const ReadCSVData &bind_data, const vector<column_t> &column_ids,
-	            const vector<LogicalType> &file_schema);
+	            const vector<LogicalType> &file_schema, bool per_file_single_threaded);
 
 	CSVFileScan(ClientContext &context, const string &file_name, CSVReaderOptions &options);
 

--- a/test/sql/copy/csv/test_lineitem_gz.test
+++ b/test/sql/copy/csv/test_lineitem_gz.test
@@ -1,0 +1,38 @@
+# name: test/sql/copy/csv/test_lineitem_gz.test
+# description: Test small memory limit on gzipped csv files
+# group: [csv]
+
+# No way CI can handle this
+mode skip
+
+statement ok
+PRAGMA enable_verification
+
+
+require tpch
+
+statement ok
+CALL dbgen(sf=10);
+
+statement ok
+copy lineitem to '__TEST_DIR__/lineitem1.csv.gz'
+
+statement ok
+set memory_limit='32gb';
+
+# Run it over 50 TPCHs
+query I
+select count(*) from read_csv([
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz',
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz',
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz',
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz',
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz',
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz',
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz',
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz',
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz',
+'__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz','__TEST_DIR__/lineitem1.csv.gz'
+]);
+----
+0

--- a/test/sql/pragma/output.json
+++ b/test/sql/pragma/output.json
@@ -1,1 +1,0 @@
-{ "result": "error" }

--- a/test/sql/pragma/output.json
+++ b/test/sql/pragma/output.json
@@ -1,0 +1,1 @@
+{ "result": "error" }


### PR DESCRIPTION
This PR uses the same strategy when doing single-threaded per file scans for block releases as the sniffer or if the file is seak-able.

I've added a test for it, but it already makes my MacBook a space heater, so I'm fully sure CI can't handle it. Hence, I added the `mode skip`.

Fix: #12389 