### PR TITLE
Add support for prefetching multiple adjacent blocks in a single batched read when attaching to remote databases

### DIFF
--- a/src/include/duckdb/function/compression_function.hpp
+++ b/src/include/duckdb/function/compression_function.hpp
@@ -26,6 +26,7 @@ struct ColumnSegmentState;
 
 struct ColumnFetchState;
 struct ColumnScanState;
+struct PrefetchState;
 struct SegmentScanState;
 
 struct AnalyzeState {
@@ -128,6 +129,7 @@ typedef void (*compression_compress_finalize_t)(CompressionState &state);
 //===--------------------------------------------------------------------===//
 // Uncompress / Scan
 //===--------------------------------------------------------------------===//
+typedef void (*compression_init_prefetch_t)(ColumnSegment &segment, PrefetchState &prefetch_state);
 typedef unique_ptr<SegmentScanState> (*compression_init_segment_scan_t)(ColumnSegment &segment);
 
 //! Function prototype used for reading an entire vector (STANDARD_VECTOR_SIZE)
@@ -178,13 +180,14 @@ public:
 	                    compression_revert_append_t revert_append = nullptr,
 	                    compression_serialize_state_t serialize_state = nullptr,
 	                    compression_deserialize_state_t deserialize_state = nullptr,
-	                    compression_cleanup_state_t cleanup_state = nullptr)
+	                    compression_cleanup_state_t cleanup_state = nullptr,
+	                    compression_init_prefetch_t init_prefetch = nullptr)
 	    : type(type), data_type(data_type), init_analyze(init_analyze), analyze(analyze), final_analyze(final_analyze),
 	      init_compression(init_compression), compress(compress), compress_finalize(compress_finalize),
-	      init_scan(init_scan), scan_vector(scan_vector), scan_partial(scan_partial), fetch_row(fetch_row), skip(skip),
-	      init_segment(init_segment), init_append(init_append), append(append), finalize_append(finalize_append),
-	      revert_append(revert_append), serialize_state(serialize_state), deserialize_state(deserialize_state),
-	      cleanup_state(cleanup_state) {
+	      init_prefetch(init_prefetch), init_scan(init_scan), scan_vector(scan_vector), scan_partial(scan_partial),
+	      fetch_row(fetch_row), skip(skip), init_segment(init_segment), init_append(init_append), append(append),
+	      finalize_append(finalize_append), revert_append(revert_append), serialize_state(serialize_state),
+	      deserialize_state(deserialize_state), cleanup_state(cleanup_state) {
 	}
 
 	//! Compression type
@@ -213,6 +216,8 @@ public:
 	//! compress_finalize is called after
 	compression_compress_finalize_t compress_finalize;
 
+	//! Initialize prefetch state with required I/O data to scan this segment
+	compression_init_prefetch_t init_prefetch;
 	//! init_scan is called to set up the scan state
 	compression_init_segment_scan_t init_scan;
 	//! scan_vector scans an entire vector using the scan state

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -69,6 +69,10 @@ public:
 	virtual idx_t TotalBlocks() = 0;
 	//! Returns the number of free blocks
 	virtual idx_t FreeBlocks() = 0;
+	//! Whether or not the attached database is a remote file (e.g. attached over s3/https)
+	virtual bool IsRemote() {
+		return false;
+	}
 
 	//! Truncate the underlying database file after a checkpoint
 	virtual void Truncate();

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -54,6 +54,8 @@ public:
 	virtual idx_t GetMetaBlock() = 0;
 	//! Read the content of the block from disk
 	virtual void Read(Block &block) = 0;
+	//! Read the content of the block from disk
+	virtual void ReadBlocks(FileBuffer &buffer, block_id_t start_block, idx_t block_count) = 0;
 	//! Writes the block to disk
 	virtual void Write(FileBuffer &block, block_id_t block_id) = 0;
 	//! Writes the block to disk

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -73,6 +73,8 @@ public:
 	virtual bool IsRemote() {
 		return false;
 	}
+	//! Whether or not the attached database is in-memory
+	virtual bool InMemory() = 0;
 
 	//! Truncate the underlying database file after a checkpoint
 	virtual void Truncate();

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -107,7 +107,7 @@ public:
 
 private:
 	static BufferHandle Load(shared_ptr<BlockHandle> &handle, unique_ptr<FileBuffer> buffer = nullptr);
-	void LoadFromBuffer(data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer);
+	static BufferHandle LoadFromBuffer(shared_ptr<BlockHandle> &handle, data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer);
 	unique_ptr<FileBuffer> UnloadAndTakeBlock();
 	void Unload();
 	bool CanUnload();

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -107,6 +107,7 @@ public:
 
 private:
 	static BufferHandle Load(shared_ptr<BlockHandle> &handle, unique_ptr<FileBuffer> buffer = nullptr);
+	void LoadFromBuffer(data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer);
 	unique_ptr<FileBuffer> UnloadAndTakeBlock();
 	void Unload();
 	bool CanUnload();

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -107,7 +107,8 @@ public:
 
 private:
 	static BufferHandle Load(shared_ptr<BlockHandle> &handle, unique_ptr<FileBuffer> buffer = nullptr);
-	static BufferHandle LoadFromBuffer(shared_ptr<BlockHandle> &handle, data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer);
+	static BufferHandle LoadFromBuffer(shared_ptr<BlockHandle> &handle, data_ptr_t data,
+	                                   unique_ptr<FileBuffer> reusable_buffer);
 	unique_ptr<FileBuffer> UnloadAndTakeBlock();
 	void Unload();
 	bool CanUnload();

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -39,6 +39,8 @@ public:
 	//! Reallocate an in-memory buffer that is pinned.
 	virtual void ReAllocate(shared_ptr<BlockHandle> &handle, idx_t block_size) = 0;
 	virtual BufferHandle Pin(shared_ptr<BlockHandle> &handle) = 0;
+	//! Prefetch a series of blocks. Note that this is a performance suggestion.
+	virtual void Prefetch(vector<shared_ptr<BlockHandle>> &handles) = 0;
 	virtual void Unpin(shared_ptr<BlockHandle> &handle) = 0;
 
 	//! Returns the currently allocated memory

--- a/src/include/duckdb/storage/in_memory_block_manager.hpp
+++ b/src/include/duckdb/storage/in_memory_block_manager.hpp
@@ -59,6 +59,9 @@ public:
 	void WriteHeader(DatabaseHeader header) override {
 		throw InternalException("Cannot perform IO in in-memory database - WriteHeader!");
 	}
+	bool InMemory() override {
+		return true;
+	}
 	idx_t TotalBlocks() override {
 		throw InternalException("Cannot perform IO in in-memory database - TotalBlocks!");
 	}

--- a/src/include/duckdb/storage/in_memory_block_manager.hpp
+++ b/src/include/duckdb/storage/in_memory_block_manager.hpp
@@ -50,6 +50,9 @@ public:
 	void Read(Block &block) override {
 		throw InternalException("Cannot perform IO in in-memory database - Read!");
 	}
+	void ReadBlocks(FileBuffer &buffer, block_id_t start_block, idx_t block_count) override {
+		throw InternalException("Cannot perform IO in in-memory database - ReadBlocks!");
+	}
 	void Write(FileBuffer &block, block_id_t block_id) override {
 		throw InternalException("Cannot perform IO in in-memory database - Write!");
 	}

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -76,6 +76,8 @@ public:
 	idx_t TotalBlocks() override;
 	//! Returns the number of free blocks
 	idx_t FreeBlocks() override;
+	//! Whether or not the attached database is a remote file
+	bool IsRemote() override;
 
 private:
 	//! Loads the free list of the file.

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -72,6 +72,9 @@ public:
 	//! Truncate the underlying database file after a checkpoint
 	void Truncate() override;
 
+	bool InMemory() override {
+		return false;
+	}
 	//! Returns the number of total blocks
 	idx_t TotalBlocks() override;
 	//! Returns the number of free blocks

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -63,6 +63,8 @@ public:
 	idx_t GetMetaBlock() override;
 	//! Read the content of the block from disk
 	void Read(Block &block) override;
+	//! Read the content of a range of blocks into a buffer
+	void ReadBlocks(FileBuffer &buffer, block_id_t start_block, idx_t block_count) override;
 	//! Write the given block to disk
 	void Write(FileBuffer &block, block_id_t block_id) override;
 	//! Write the header to disk, this is the final step of the checkpointing process
@@ -84,6 +86,8 @@ private:
 
 	void ReadAndChecksum(FileBuffer &handle, uint64_t location) const;
 	void ChecksumAndWrite(FileBuffer &handle, uint64_t location) const;
+
+	idx_t GetBlockLocation(block_id_t block_id);
 
 	//! Return the blocks to which we will write the free list and modified blocks
 	vector<MetadataHandle> GetFreeListBlocks();

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -143,7 +143,9 @@ protected:
 	//! overwrites the data within with garbage. Any readers that do not hold the pin will notice
 	void VerifyZeroReaders(shared_ptr<BlockHandle> &handle);
 
-	void BatchRead(vector<shared_ptr<BlockHandle>> &handles, const map<block_id_t, idx_t> &load_map, block_id_t first_block, block_id_t last_block);
+	void BatchRead(vector<shared_ptr<BlockHandle>> &handles, const map<block_id_t, idx_t> &load_map,
+	               block_id_t first_block, block_id_t last_block);
+
 protected:
 	// These are stored here because temp_directory creation is lazy
 	// so we need to store information related to the temporary directory before it's created

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -65,6 +65,7 @@ public:
 	void ReAllocate(shared_ptr<BlockHandle> &handle, idx_t block_size) final;
 
 	BufferHandle Pin(shared_ptr<BlockHandle> &handle) final;
+	void Prefetch(vector<shared_ptr<BlockHandle>> &handles) final;
 	void Unpin(shared_ptr<BlockHandle> &handle) final;
 
 	//! Set a new memory limit to the buffer manager, throws an exception if the new limit is too low and not enough
@@ -142,6 +143,7 @@ protected:
 	//! overwrites the data within with garbage. Any readers that do not hold the pin will notice
 	void VerifyZeroReaders(shared_ptr<BlockHandle> &handle);
 
+	void BatchRead(vector<shared_ptr<BlockHandle>> &handles, const map<block_id_t, idx_t> &load_map, block_id_t first_block, block_id_t last_block);
 protected:
 	// These are stored here because temp_directory creation is lazy
 	// so we need to store information related to the temporary directory before it's created

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -28,6 +28,7 @@ public:
 	void SetStart(idx_t new_start) override;
 	bool CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 
+	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) override;
 	void InitializeScan(ColumnScanState &state) override;
 	void InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) override;
 

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -26,11 +26,11 @@ class RowGroup;
 class RowGroupWriter;
 class TableDataWriter;
 class TableStorageInfo;
-struct TransactionData;
-struct TableScanOptions;
-
 struct DataTableInfo;
+struct PrefetchState;
 struct RowGroupWriteInfo;
+struct TableScanOptions;
+struct TransactionData;
 
 struct ColumnCheckpointInfo {
 	ColumnCheckpointInfo(RowGroupWriteInfo &info, idx_t column_idx) : info(info), column_idx(column_idx) {
@@ -88,6 +88,8 @@ public:
 	//! Whether or not we can scan an entire vector
 	virtual ScanVectorType GetVectorScanType(ColumnScanState &state, idx_t scan_count);
 
+	//! Initialize prefetch state with required I/O data for the next N rows
+	virtual void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows);
 	//! Initialize a scan of the column
 	virtual void InitializeScan(ColumnScanState &state);
 	//! Initialize a scan starting at the specified offset
@@ -102,6 +104,7 @@ public:
 
 	virtual void ScanCommittedRange(idx_t row_group_start, idx_t offset_in_row_group, idx_t count, Vector &result);
 	virtual idx_t ScanCount(ColumnScanState &state, Vector &result, idx_t count);
+
 	//! Select
 	virtual void Select(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
 	                    SelectionVector &sel, idx_t &count, const TableFilter &filter);

--- a/src/include/duckdb/storage/table/column_segment.hpp
+++ b/src/include/duckdb/storage/table/column_segment.hpp
@@ -31,6 +31,7 @@ class TableFilter;
 struct ColumnFetchState;
 struct ColumnScanState;
 struct ColumnAppendState;
+struct PrefetchState;
 
 enum class ColumnSegmentType : uint8_t { TRANSIENT, PERSISTENT };
 //! TableFilter represents a filter pushed down into the table scan.
@@ -63,6 +64,7 @@ public:
 	                                                        idx_t segment_size = Storage::BLOCK_SIZE);
 
 public:
+	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state);
 	void InitializeScan(ColumnScanState &state);
 	//! Scan one vector from this segment
 	void Scan(ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset, ScanVectorType scan_type);

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -28,6 +28,7 @@ public:
 	void SetStart(idx_t new_start) override;
 	bool CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 
+	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) override;
 	void InitializeScan(ColumnScanState &state) override;
 	void InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) override;
 

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -204,7 +204,7 @@ struct PrefetchState {
 
 	void AddBlock(shared_ptr<BlockHandle> block);
 
-	map<block_id_t, shared_ptr<BlockHandle>> blocks;
+	vector<shared_ptr<BlockHandle>> blocks;
 };
 
 class CreateIndexScanState : public TableScanState {

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/map.hpp"
 #include "duckdb/storage/buffer/buffer_handle.hpp"
 #include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/common/enums/scan_options.hpp"
@@ -196,6 +197,14 @@ struct ParallelTableScanState {
 	ParallelCollectionScanState local_state;
 	//! Shared lock over the checkpoint to prevent checkpoints while reading
 	unique_ptr<StorageLockKey> checkpoint_lock;
+};
+
+struct PrefetchState {
+	~PrefetchState();
+
+	void AddBlock(shared_ptr<BlockHandle> block);
+
+	map<block_id_t, shared_ptr<BlockHandle>> blocks;
 };
 
 class CreateIndexScanState : public TableScanState {

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -27,6 +27,7 @@ public:
 	bool CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 
 	ScanVectorType GetVectorScanType(ColumnScanState &state, idx_t scan_count) override;
+	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) override;
 	void InitializeScan(ColumnScanState &state) override;
 	void InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) override;
 

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -29,6 +29,7 @@ public:
 	bool CheckZonemap(ColumnScanState &state, TableFilter &filter) override;
 	idx_t GetMaxEntry() override;
 
+	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) override;
 	void InitializeScan(ColumnScanState &state) override;
 	void InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) override;
 

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -70,13 +70,14 @@ unique_ptr<Block> AllocateBlock(BlockManager &block_manager, unique_ptr<FileBuff
 	}
 }
 
-void BlockHandle::LoadFromBuffer(data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer) {
-	D_ASSERT(state != BlockState::BLOCK_LOADED);
+BufferHandle BlockHandle::LoadFromBuffer(shared_ptr<BlockHandle> &handle, data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer) {
+	D_ASSERT(handle->state != BlockState::BLOCK_LOADED);
 	// copy over the data into the block from the file buffer
-	auto block = AllocateBlock(block_manager, std::move(reusable_buffer), block_id);
+	auto block = AllocateBlock(handle->block_manager, std::move(reusable_buffer), handle->block_id);
 	memcpy(block->InternalBuffer(), data, block->AllocSize());
-	buffer = std::move(block);
-	state = BlockState::BLOCK_LOADED;
+	handle->buffer = std::move(block);
+	handle->state = BlockState::BLOCK_LOADED;
+	return BufferHandle(handle, handle->buffer.get());
 }
 
 BufferHandle BlockHandle::Load(shared_ptr<BlockHandle> &handle, unique_ptr<FileBuffer> reusable_buffer) {

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -70,6 +70,15 @@ unique_ptr<Block> AllocateBlock(BlockManager &block_manager, unique_ptr<FileBuff
 	}
 }
 
+void BlockHandle::LoadFromBuffer(data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer) {
+	D_ASSERT(state != BlockState::BLOCK_LOADED);
+	// copy over the data into the block from the file buffer
+	auto block = AllocateBlock(block_manager, std::move(reusable_buffer), block_id);
+	memcpy(block->InternalBuffer(), data, block->AllocSize());
+	buffer = std::move(block);
+	state = BlockState::BLOCK_LOADED;
+}
+
 BufferHandle BlockHandle::Load(shared_ptr<BlockHandle> &handle, unique_ptr<FileBuffer> reusable_buffer) {
 	if (handle->state == BlockState::BLOCK_LOADED) {
 		// already loaded

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -70,7 +70,8 @@ unique_ptr<Block> AllocateBlock(BlockManager &block_manager, unique_ptr<FileBuff
 	}
 }
 
-BufferHandle BlockHandle::LoadFromBuffer(shared_ptr<BlockHandle> &handle, data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer) {
+BufferHandle BlockHandle::LoadFromBuffer(shared_ptr<BlockHandle> &handle, data_ptr_t data,
+                                         unique_ptr<FileBuffer> reusable_buffer) {
 	D_ASSERT(handle->state != BlockState::BLOCK_LOADED);
 	// copy over the data into the block from the file buffer
 	auto block = AllocateBlock(handle->block_manager, std::move(reusable_buffer), handle->block_id);

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -126,6 +126,10 @@ struct FixedSizeScanState : public SegmentScanState {
 	BufferHandle handle;
 };
 
+void FixedSizeInitPrefetch(ColumnSegment &segment, PrefetchState &prefetch_state) {
+	prefetch_state.AddBlock(segment.block);
+}
+
 unique_ptr<SegmentScanState> FixedSizeInitScan(ColumnSegment &segment) {
 	auto result = make_uniq<FixedSizeScanState>();
 	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
@@ -260,7 +264,7 @@ CompressionFunction FixedSizeGetFunction(PhysicalType data_type) {
 	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
 	                           FixedSizeInitScan, FixedSizeScan<T>, FixedSizeScanPartial<T>, FixedSizeFetchRow<T>,
 	                           UncompressedFunctions::EmptySkip, nullptr, FixedSizeInitAppend,
-	                           FixedSizeAppend<T, APPENDER>, FixedSizeFinalizeAppend<T>, nullptr);
+	                           FixedSizeAppend<T, APPENDER>, FixedSizeFinalizeAppend<T>, nullptr, nullptr, nullptr, nullptr, FixedSizeInitPrefetch);
 }
 
 CompressionFunction FixedSizeUncompressed::GetFunction(PhysicalType data_type) {

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -264,7 +264,8 @@ CompressionFunction FixedSizeGetFunction(PhysicalType data_type) {
 	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
 	                           FixedSizeInitScan, FixedSizeScan<T>, FixedSizeScanPartial<T>, FixedSizeFetchRow<T>,
 	                           UncompressedFunctions::EmptySkip, nullptr, FixedSizeInitAppend,
-	                           FixedSizeAppend<T, APPENDER>, FixedSizeFinalizeAppend<T>, nullptr, nullptr, nullptr, nullptr, FixedSizeInitPrefetch);
+	                           FixedSizeAppend<T, APPENDER>, FixedSizeFinalizeAppend<T>, nullptr, nullptr, nullptr,
+	                           nullptr, FixedSizeInitPrefetch);
 }
 
 CompressionFunction FixedSizeUncompressed::GetFunction(PhysicalType data_type) {

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -126,10 +126,6 @@ struct FixedSizeScanState : public SegmentScanState {
 	BufferHandle handle;
 };
 
-void FixedSizeInitPrefetch(ColumnSegment &segment, PrefetchState &prefetch_state) {
-	prefetch_state.AddBlock(segment.block);
-}
-
 unique_ptr<SegmentScanState> FixedSizeInitScan(ColumnSegment &segment) {
 	auto result = make_uniq<FixedSizeScanState>();
 	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
@@ -264,8 +260,7 @@ CompressionFunction FixedSizeGetFunction(PhysicalType data_type) {
 	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
 	                           FixedSizeInitScan, FixedSizeScan<T>, FixedSizeScanPartial<T>, FixedSizeFetchRow<T>,
 	                           UncompressedFunctions::EmptySkip, nullptr, FixedSizeInitAppend,
-	                           FixedSizeAppend<T, APPENDER>, FixedSizeFinalizeAppend<T>, nullptr, nullptr, nullptr,
-	                           nullptr, FixedSizeInitPrefetch);
+	                           FixedSizeAppend<T, APPENDER>, FixedSizeFinalizeAppend<T>);
 }
 
 CompressionFunction FixedSizeUncompressed::GetFunction(PhysicalType data_type) {

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -68,7 +68,7 @@ void UncompressedStringInitPrefetch(ColumnSegment &segment, PrefetchState &prefe
 	if (segment_state) {
 		auto &state = segment_state->Cast<UncompressedStringSegmentState>();
 		auto &block_manager = segment.GetBlockManager();
-		for(auto &block_id : state.on_disk_blocks) {
+		for (auto &block_id : state.on_disk_blocks) {
 			auto block_handle = state.GetHandle(block_manager, block_id);
 			prefetch_state.AddBlock(block_handle);
 		}

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -436,10 +436,38 @@ unique_ptr<Block> SingleFileBlockManager::CreateBlock(block_id_t block_id, FileB
 	return result;
 }
 
+idx_t SingleFileBlockManager::GetBlockLocation(block_id_t block_id) {
+	return BLOCK_START + NumericCast<idx_t>(block_id) * Storage::BLOCK_ALLOC_SIZE;
+}
+
 void SingleFileBlockManager::Read(Block &block) {
 	D_ASSERT(block.id >= 0);
 	D_ASSERT(std::find(free_list.begin(), free_list.end(), block.id) == free_list.end());
-	ReadAndChecksum(block, BLOCK_START + NumericCast<idx_t>(block.id) * Storage::BLOCK_ALLOC_SIZE);
+	ReadAndChecksum(block, GetBlockLocation(block.id));
+}
+
+void SingleFileBlockManager::ReadBlocks(FileBuffer &buffer, block_id_t start_block, idx_t block_count) {
+	D_ASSERT(start_block >= 0);
+	D_ASSERT(block_count >= 1);
+
+	// read the buffer from disk
+	auto location = GetBlockLocation(start_block);
+	buffer.Read(*handle, location);
+
+	// for each of the blocks - verify the checksum
+	auto ptr = buffer.InternalBuffer();
+	for(idx_t i = 0; i < block_count; i++) {
+	// compute the checksum
+		auto start_ptr = ptr + i * Storage::BLOCK_ALLOC_SIZE;
+		auto stored_checksum = Load<uint64_t>(start_ptr);
+		uint64_t computed_checksum = Checksum(start_ptr + Storage::BLOCK_HEADER_SIZE, Storage::BLOCK_SIZE);
+		// verify the checksum
+		if (stored_checksum != computed_checksum) {
+			throw IOException("Corrupt database file: computed checksum %llu does not match stored checksum %llu in block "
+			                  "at location %llu",
+			                  computed_checksum, stored_checksum, location + i * Storage::BLOCK_ALLOC_SIZE);
+		}
+	}
 }
 
 void SingleFileBlockManager::Write(FileBuffer &buffer, block_id_t block_id) {

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -206,12 +206,12 @@ void StandardBufferManager::BatchRead(vector<shared_ptr<BlockHandle>> &handles, 
 	auto &block_manager = handles[0]->block_manager;
 	idx_t block_count = NumericCast<idx_t>(last_block - first_block + 1);
 #ifndef DUCKDB_ALTERNATIVE_VERIFY
-	// if (block_count == 1) {
-	// 	// prefetching with block_count == 1 has no effect since we can't batch reads
-	// 	// skip the prefetch in this case
-	//  // we do it anyway if alternative_verify is on for extra testing
-	// 	return;
-	// }
+	if (block_count == 1) {
+		// prefetching with block_count == 1 has no performance impact since we can't batch reads
+		// skip the prefetch in this case
+		// we do it anyway if alternative_verify is on for extra testing
+		return;
+	}
 #endif
 
 	// allocate a buffer to hold the data of all of the blocks

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -201,7 +201,8 @@ void StandardBufferManager::ReAllocate(shared_ptr<BlockHandle> &handle, idx_t bl
 	handle->ResizeBuffer(block_size, memory_delta);
 }
 
-void StandardBufferManager::BatchRead(vector<shared_ptr<BlockHandle>> &handles, const map<block_id_t, idx_t> &load_map, block_id_t first_block, block_id_t last_block) {
+void StandardBufferManager::BatchRead(vector<shared_ptr<BlockHandle>> &handles, const map<block_id_t, idx_t> &load_map,
+                                      block_id_t first_block, block_id_t last_block) {
 	auto &block_manager = handles[0]->block_manager;
 	idx_t block_count = NumericCast<idx_t>(last_block - first_block + 1);
 	if (block_count == 1) {
@@ -216,7 +217,7 @@ void StandardBufferManager::BatchRead(vector<shared_ptr<BlockHandle>> &handles, 
 	block_manager.ReadBlocks(intermediate_buffer.GetFileBuffer(), first_block, block_count);
 
 	// the blocks are read - now we need to assign them to the individual blocks
-	for(idx_t block_idx = 0; block_idx < block_count; block_idx++) {
+	for (idx_t block_idx = 0; block_idx < block_count; block_idx++) {
 		block_id_t block_id = first_block + NumericCast<block_id_t>(block_idx);
 		auto entry = load_map.find(block_id);
 		D_ASSERT(entry != load_map.end()); // if we allow gaps we might not return true here
@@ -239,7 +240,8 @@ void StandardBufferManager::BatchRead(vector<shared_ptr<BlockHandle>> &handles, 
 				reservation.Resize(0);
 				continue;
 			}
-			auto block_ptr = intermediate_buffer.GetFileBuffer().InternalBuffer() + block_idx * Storage::BLOCK_ALLOC_SIZE;
+			auto block_ptr =
+			    intermediate_buffer.GetFileBuffer().InternalBuffer() + block_idx * Storage::BLOCK_ALLOC_SIZE;
 			buf = BlockHandle::LoadFromBuffer(handle, block_ptr, std::move(reusable_buffer));
 			handle->readers = 1;
 			handle->memory_charge = std::move(reservation);
@@ -250,7 +252,7 @@ void StandardBufferManager::BatchRead(vector<shared_ptr<BlockHandle>> &handles, 
 void StandardBufferManager::Prefetch(vector<shared_ptr<BlockHandle>> &handles) {
 	// figure out which set of blocks we should load
 	map<block_id_t, idx_t> to_be_loaded;
-	for(idx_t block_idx = 0; block_idx < handles.size(); block_idx++) {
+	for (idx_t block_idx = 0; block_idx < handles.size(); block_idx++) {
 		auto &handle = handles[block_idx];
 		lock_guard<mutex> lock(handle->lock);
 		if (handle->state != BlockState::BLOCK_LOADED) {
@@ -265,7 +267,7 @@ void StandardBufferManager::Prefetch(vector<shared_ptr<BlockHandle>> &handles) {
 	// iterate over the blocks and perform bulk reads
 	block_id_t first_block = -1;
 	block_id_t previous_block_id = -1;
-	for(auto &entry : to_be_loaded) {
+	for (auto &entry : to_be_loaded) {
 		if (previous_block_id < 0) {
 			// this the first block we are seeing
 			first_block = entry.first;

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -201,6 +201,89 @@ void StandardBufferManager::ReAllocate(shared_ptr<BlockHandle> &handle, idx_t bl
 	handle->ResizeBuffer(block_size, memory_delta);
 }
 
+void StandardBufferManager::BatchRead(vector<shared_ptr<BlockHandle>> &handles, const map<block_id_t, idx_t> &load_map, block_id_t first_block, block_id_t last_block) {
+	auto &block_manager = handles[0]->block_manager;
+	idx_t block_count = NumericCast<idx_t>(last_block - first_block + 1);
+	if (block_count == 1) {
+		// prefetching with block_count == 1 has no effect since we can't batch reads
+		// skip the prefetch in this case
+		return;
+	}
+
+	// allocate a buffer to hold the data of all of the blocks
+	auto intermediate_buffer = Allocate(MemoryTag::BASE_TABLE, block_count * Storage::BLOCK_ALLOC_SIZE);
+	// perform a batch read of the blocks into the buffer
+	block_manager.ReadBlocks(intermediate_buffer.GetFileBuffer(), first_block, block_count);
+
+	// the blocks are read - now we need to assign them to the individual blocks
+	for(idx_t block_idx = 0; block_idx < block_count; block_idx++) {
+		block_id_t block_id = first_block + NumericCast<block_id_t>(block_idx);
+		auto entry = load_map.find(block_id);
+		D_ASSERT(entry != load_map.end()); // if we allow gaps we might not return true here
+		auto &handle = handles[entry->second];
+
+		// reserve memory for the block
+		idx_t required_memory = handle->memory_usage;
+		unique_ptr<FileBuffer> reusable_buffer;
+		auto reservation =
+		    EvictBlocksOrThrow(handle->tag, required_memory, &reusable_buffer, "failed to pin block of size %s%s",
+		                       StringUtil::BytesToHumanReadableString(required_memory));
+		// now load the block from the buffer
+		lock_guard<mutex> lock(handle->lock);
+		if (handle->state == BlockState::BLOCK_LOADED) {
+			// the block is loaded already by another thread - free up the reservation and continue
+			reservation.Resize(0);
+			continue;
+		}
+		auto block_ptr = intermediate_buffer.GetFileBuffer().InternalBuffer() + block_idx * Storage::BLOCK_ALLOC_SIZE;
+		handle->LoadFromBuffer(block_ptr, std::move(reusable_buffer));
+	}
+}
+
+void StandardBufferManager::Prefetch(vector<shared_ptr<BlockHandle>> &handles) {
+	// ignore any blocks that are loaded
+	// bulk
+	// initialize blocks with read data
+	// should we keep locks on all handles while we read?
+	// -> as long as we lock in increasing order this should always work (right?)
+	map<block_id_t, idx_t> to_be_loaded;
+	for(idx_t block_idx = 0; block_idx < handles.size(); block_idx++) {
+		auto &handle = handles[block_idx];
+		lock_guard<mutex> lock(handle->lock);
+		if (handle->state != BlockState::BLOCK_LOADED) {
+			// need to load this block - add it to the map
+			to_be_loaded.insert(make_pair(handle->BlockId(), block_idx));
+		}
+	}
+	if (to_be_loaded.empty()) {
+		// nothing to fetch
+		return;
+	}
+	// iterate over the blocks and perform bulk reads
+	block_id_t first_block = -1;
+	block_id_t previous_block_id = -1;
+	for(auto &entry : to_be_loaded) {
+		if (previous_block_id < 0) {
+			// this the first block we are seeing
+			first_block = entry.first;
+			previous_block_id = first_block;
+		} else if (previous_block_id + 1 == entry.first) {
+			// this block is adjacent to the previous block - add it to the batch read
+			previous_block_id = entry.first;
+		} else {
+			// this block is not adjacent to the previous block
+			// perform the batch read for the previous batch
+			BatchRead(handles, to_be_loaded, first_block, previous_block_id);
+
+			// set the first_block and previous_block_id to the current block
+			first_block = entry.first;
+			previous_block_id = entry.first;
+		}
+	}
+	// batch read the final batch
+	BatchRead(handles, to_be_loaded, first_block, previous_block_id);
+}
+
 BufferHandle StandardBufferManager::Pin(shared_ptr<BlockHandle> &handle) {
 	idx_t required_memory;
 	{

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -205,11 +205,14 @@ void StandardBufferManager::BatchRead(vector<shared_ptr<BlockHandle>> &handles, 
                                       block_id_t first_block, block_id_t last_block) {
 	auto &block_manager = handles[0]->block_manager;
 	idx_t block_count = NumericCast<idx_t>(last_block - first_block + 1);
-	if (block_count == 1) {
-		// prefetching with block_count == 1 has no effect since we can't batch reads
-		// skip the prefetch in this case
-		return;
-	}
+#ifndef DUCKDB_ALTERNATIVE_VERIFY
+	// if (block_count == 1) {
+	// 	// prefetching with block_count == 1 has no effect since we can't batch reads
+	// 	// skip the prefetch in this case
+	//  // we do it anyway if alternative_verify is on for extra testing
+	// 	return;
+	// }
+#endif
 
 	// allocate a buffer to hold the data of all of the blocks
 	auto intermediate_buffer = Allocate(MemoryTag::BASE_TABLE, block_count * Storage::BLOCK_SIZE);

--- a/src/storage/table/array_column_data.cpp
+++ b/src/storage/table/array_column_data.cpp
@@ -30,6 +30,13 @@ bool ArrayColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) 
 	return false;
 }
 
+void ArrayColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {
+	ColumnData::InitializePrefetch(prefetch_state, scan_state, rows);
+	validity.InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
+	auto array_size = ArrayType::GetSize(type);
+	child_column->InitializePrefetch(prefetch_state, scan_state.child_states[1], rows * array_size);
+}
+
 void ArrayColumnData::InitializeScan(ColumnScanState &state) {
 	// initialize the validity segment
 	D_ASSERT(state.child_states.size() == 2);

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -96,6 +96,12 @@ ColumnSegment::~ColumnSegment() {
 //===--------------------------------------------------------------------===//
 // Scan
 //===--------------------------------------------------------------------===//
+void ColumnSegment::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &) {
+	if (function.get().init_prefetch) {
+		function.get().init_prefetch(*this, prefetch_state);
+	}
+}
+
 void ColumnSegment::InitializeScan(ColumnScanState &state) {
 	state.scan_state = function.get().init_scan(*this);
 }

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -97,8 +97,14 @@ ColumnSegment::~ColumnSegment() {
 // Scan
 //===--------------------------------------------------------------------===//
 void ColumnSegment::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &) {
+	if (!block || block->BlockId() >= MAXIMUM_BLOCK) {
+		// not an on-disk block
+		return;
+	}
 	if (function.get().init_prefetch) {
 		function.get().init_prefetch(*this, prefetch_state);
+	} else {
+		prefetch_state.AddBlock(block);
 	}
 }
 

--- a/src/storage/table/list_column_data.cpp
+++ b/src/storage/table/list_column_data.cpp
@@ -29,6 +29,20 @@ bool ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
 	return false;
 }
 
+void ListColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {
+	ColumnData::InitializePrefetch(prefetch_state, scan_state, rows);
+	validity.InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
+
+	// we can't know how many rows we need to prefetch for the child of this list without looking at the actual data
+	// we make an estimation by looking at how many rows the child column has versus this column
+	// e.g if the child column has 10K rows, and we have 1K rows, we estimate that each list has 10 elements
+	idx_t rows_per_list = 1;
+	if (child_column->count > this->count && this->count > 0) {
+		rows_per_list = child_column->count / this->count;
+	}
+	child_column->InitializePrefetch(prefetch_state, scan_state.child_states[1], rows * rows_per_list);
+}
+
 void ListColumnData::InitializeScan(ColumnScanState &state) {
 	ColumnData::InitializeScan(state);
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -485,17 +485,23 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 		} else {
 			count = max_count;
 		}
-		// FIXME - if we are scanning an on-disk OR remote file only (remote file only most likely)
-		PrefetchState prefetch_state;
-		for (idx_t i = 0; i < column_ids.size(); i++) {
-			const auto &column = column_ids[i];
-			if (column != COLUMN_IDENTIFIER_ROW_ID) {
-				GetColumn(column).InitializePrefetch(prefetch_state, state.column_scans[i], max_count);
-			}
-		}
+#ifndef DUCKDB_ALTERNATIVE_VERIFY
 		auto &block_manager = GetBlockManager();
-		auto &buffer_manager = block_manager.buffer_manager;
-		buffer_manager.Prefetch(prefetch_state.blocks);
+		// in regular operation we only prefetch from remote file systems
+		// when alternative verify is set, we always prefetch for testing purposes
+		if (block_manager.IsRemote())
+#endif
+		{
+			PrefetchState prefetch_state;
+			for (idx_t i = 0; i < column_ids.size(); i++) {
+				const auto &column = column_ids[i];
+				if (column != COLUMN_IDENTIFIER_ROW_ID) {
+					GetColumn(column).InitializePrefetch(prefetch_state, state.column_scans[i], max_count);
+				}
+			}
+			auto &buffer_manager = block_manager.buffer_manager;
+			buffer_manager.Prefetch(prefetch_state.blocks);
+		}
 
 		if (count == max_count && !table_filters) {
 			// scan all vectors completely: full scan without deletions or table filters

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -484,6 +484,16 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 		} else {
 			count = max_count;
 		}
+		// FIXME - if we are scanning an on-disk OR remote file only (remote file only most likely)
+#ifdef DUCKDB_ALTERNATIVE_VERIFY
+		PrefetchState prefetch_state;
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			const auto &column = column_ids[i];
+			if (column != COLUMN_IDENTIFIER_ROW_ID) {
+				GetColumn(column).InitializePrefetch(prefetch_state, state.column_scans[i], max_count);
+			}
+		}
+#endif
 		if (count == max_count && !table_filters) {
 			// scan all vectors completely: full scan without deletions or table filters
 			for (idx_t i = 0; i < column_ids.size(); i++) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -485,11 +485,13 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 		} else {
 			count = max_count;
 		}
-#ifndef DUCKDB_ALTERNATIVE_VERIFY
 		auto &block_manager = GetBlockManager();
-		// in regular operation we only prefetch from remote file systems
-		// when alternative verify is set, we always prefetch for testing purposes
+#ifndef DUCKDB_ALTERNATIVE_VERIFY
+		// // in regular operation we only prefetch from remote file systems
+		// // when alternative verify is set, we always prefetch for testing purposes
 		if (block_manager.IsRemote())
+#else
+		if (!block_manager.InMemory())
 #endif
 		{
 			PrefetchState prefetch_state;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -473,7 +473,7 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 				// nothing to scan for this vector, skip the entire vector
 				NextVector(state);
 				continue;
-				}
+			}
 		} else if (TYPE == TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED) {
 			count = state.row_group->GetCommittedSelVector(transaction.start_time, transaction.transaction_id,
 			                                               state.vector_index, valid_sel, max_count);
@@ -485,7 +485,7 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 		} else {
 			count = max_count;
 		}
-		// FIXME - if we are scanning a remote file only
+		// FIXME - if we are scanning an on-disk OR remote file only (remote file only most likely)
 		PrefetchState prefetch_state;
 		for (idx_t i = 0; i < column_ids.size(); i++) {
 			const auto &column = column_ids[i];
@@ -493,6 +493,7 @@ void RowGroup::TemplatedScan(TransactionData transaction, CollectionScanState &s
 				GetColumn(column).InitializePrefetch(prefetch_state, state.column_scans[i], max_count);
 			}
 		}
+		auto &block_manager = GetBlockManager();
 		auto &buffer_manager = block_manager.buffer_manager;
 		buffer_manager.Prefetch(prefetch_state.blocks);
 

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -141,8 +141,7 @@ bool CollectionScanState::ScanCommitted(DataChunk &result, TableScanType type) {
 PrefetchState::~PrefetchState() {}
 
 void PrefetchState::AddBlock(shared_ptr<BlockHandle> block) {
-	auto block_id = block->BlockId();
-	blocks.insert(make_pair(block_id, std::move(block)));
+	blocks.push_back(std::move(block));
 }
 
 } // namespace duckdb

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -138,4 +138,11 @@ bool CollectionScanState::ScanCommitted(DataChunk &result, TableScanType type) {
 	return false;
 }
 
+PrefetchState::~PrefetchState() {}
+
+void PrefetchState::AddBlock(shared_ptr<BlockHandle> block) {
+	auto block_id = block->BlockId();
+	blocks.insert(make_pair(block_id, std::move(block)));
+}
+
 } // namespace duckdb

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -138,7 +138,8 @@ bool CollectionScanState::ScanCommitted(DataChunk &result, TableScanType type) {
 	return false;
 }
 
-PrefetchState::~PrefetchState() {}
+PrefetchState::~PrefetchState() {
+}
 
 void PrefetchState::AddBlock(shared_ptr<BlockHandle> block) {
 	blocks.push_back(std::move(block));

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -60,6 +60,11 @@ bool StandardColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filte
 	}
 }
 
+void StandardColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {
+	ColumnData::InitializePrefetch(prefetch_state, scan_state, rows);
+	validity.InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
+}
+
 void StandardColumnData::InitializeScan(ColumnScanState &state) {
 	ColumnData::InitializeScan(state);
 

--- a/src/storage/table/struct_column_data.cpp
+++ b/src/storage/table/struct_column_data.cpp
@@ -68,6 +68,13 @@ idx_t StructColumnData::GetMaxEntry() {
 	return sub_columns[0]->GetMaxEntry();
 }
 
+void StructColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {
+	validity.InitializePrefetch(prefetch_state, scan_state.child_states[0], rows);
+	for (idx_t i = 0; i < sub_columns.size(); i++) {
+		sub_columns[i]->InitializePrefetch(prefetch_state, scan_state.child_states[i + 1], rows);
+	}
+}
+
 void StructColumnData::InitializeScan(ColumnScanState &state) {
 	D_ASSERT(state.child_states.size() == sub_columns.size() + 1);
 	state.row_index = 0;

--- a/test/sql/attach/attach_s3_tpch.test_slow
+++ b/test/sql/attach/attach_s3_tpch.test_slow
@@ -55,3 +55,20 @@ PRAGMA tpch(${i})
 <FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
 
 endloop
+
+statement ok
+USE memory
+
+statement ok
+DETACH db
+
+statement ok
+ATTACH 's3://test-bucket/presigned/lineitem_sf1.db' AS db (READONLY 1);
+
+statement ok
+USE db
+
+query IIIIIIIIIIIIIIII
+select count(distinct columns(*)) from lineitem;
+----
+1500000	200000	10000	7	50	933900	11	9	3	2	2526	2466	2554	4	7	3610733


### PR DESCRIPTION
In regular operation, DuckDB reads individual `256KB` blocks using `read` calls. When operating on a local file system, that granularity works well, as 256KB is large enough to the point where the system call overhead is negligible.

When reading from remote files (e.g. when using `ATTACH` to read a file over e.g. HTTP or S3), each read call invokes a network request. As such, when connecting to a server with a high latency, reading 256KB chunks at a time is often smaller than optimal. 

This PR introduces batched prefetching. When reading data, if we are requesting multiple blocks at once that are adjacent, we will group read calls in order to reduce the amount of round-trips we are making. For example, if we are reading data from blocks `1, 2, 3`, instead of reading them individually, we will send one request that fetches all 3 blocks at once.

To facilitate this - this PR introduces the `InitializePrefetch` method for `ColumnData`, and the optional `init_prefetch` compression function overload. These inform the upper layer which blocks need to be fetched (without actually fetching them). The upper layer (currently in `RowGroup::TemplatedScan`) can then look at these blocks and choose to perform a more optimized read.

### Benchmark

Consider the following data set, that has a lot of adjacent blocks due to the large strings. 

```sql
ATTACH 'https://huggingface.co/datasets/HuggingFaceFW/fineweb/resolve/refs%2Fconvert%2Fduckdb/sample-10BT/train/partial-index.duckdb' as fw;
SET threads=1;
SELECT text FROM fw.data LIMIT 5;
```

Running the following query results in the following performance improvement:

| v1.0.0 | New  |
|--------|------|
| 11.8s  | 0.7s |

Note that the performance improvement largely depends on how adjacent blocks are in a file.


### Future Improvements
Currently we only do batch loads if there are no gaps (i.e. if we query blocks `1` and `3`, they will be turned into adjacent requests) - in the future we hope to address these to further improve performance. In addition, we only do batch loads during data querying - we can likely use this method to speed up the initial `ATTACH` further as well.
