### PR TITLE
[C-API] Catch exception in `duckdb_execute_prepared`

### DIFF
--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -338,7 +338,11 @@ duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statemen
 		return DuckDBError;
 	}
 
-	auto result = wrapper->statement->Execute(wrapper->values, false);
+	try {
+		auto result = wrapper->statement->Execute(wrapper->values, false);
+	} catch (...) {
+		return DuckDBError;
+	}
 	return DuckDBTranslateResult(std::move(result), out_result);
 }
 

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -338,8 +338,9 @@ duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statemen
 		return DuckDBError;
 	}
 
+	duckdb::unique_ptr<duckdb::QueryResult> result;
 	try {
-		auto result = wrapper->statement->Execute(wrapper->values, false);
+		result = wrapper->statement->Execute(wrapper->values, false);
 	} catch (...) {
 		return DuckDBError;
 	}


### PR DESCRIPTION
This PR fixes #12406 

The call to `PendingQueryResult::Execute` *could* throw an exception if multiple threads are using the same connection.

I've tried to create such a scenario in a test but couldn't get it to trigger.

If another thread starts a query in between the creation of the PendingQueryResult and the call to Execute, this would trigger the exception
```c++
unique_ptr<QueryResult> PreparedStatement::Execute(case_insensitive_map_t<Value> &named_values,
                                                   bool allow_stream_result) {
	auto pending = PendingQuery(named_values, allow_stream_result);
	if (pending->HasError()) {
		return make_uniq<MaterializedQueryResult>(pending->GetErrorObject());
	}
	return pending->Execute();
}
```
That's a very small window