### PR TITLE
Account for _tagged_ dollar-quoted strings when stripping unicode spaces

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -107,7 +107,7 @@ regular:
 			pos++;
 			goto in_quotes;
 		} else if (query[pos] == '$' &&
-		           (query[pos] == '$' || IsValidDollarQuotedStringTagFirstChar(static_cast<char>(query[pos])))) {
+		           (query[pos + 1] == '$' || IsValidDollarQuotedStringTagFirstChar(static_cast<char>(query[pos])))) {
 			// (optionally tagged) dollar-quoted string
 			auto start = &query[++pos];
 			for (; pos + 2 < qsize; pos++) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -42,12 +42,13 @@ static bool ReplaceUnicodeSpaces(const string &query, string &new_query, vector<
 	return true;
 }
 
-static bool IsValidDollarQuotedStringTagFirstChar(const char &c) {
+static bool IsValidDollarQuotedStringTagFirstChar(const unsigned char &c) {
 	// the first character can be between A-Z, a-z, or \200 - \377
-	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '\200' && c <= '\377');
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+	       (c >= static_cast<unsigned char>('\200') && c <= static_cast<unsigned char>('\377'));
 }
 
-static bool IsValidDollarQuotedStringTagSubsequentChar(const char &c) {
+static bool IsValidDollarQuotedStringTagSubsequentChar(const unsigned char &c) {
 	// subsequent characters can also be between 0-9
 	return IsValidDollarQuotedStringTagFirstChar(c) || (c >= '0' && c <= '9');
 }
@@ -107,7 +108,7 @@ regular:
 			pos++;
 			goto in_quotes;
 		} else if (query[pos] == '$' &&
-		           (query[pos + 1] == '$' || IsValidDollarQuotedStringTagFirstChar(static_cast<char>(query[pos])))) {
+		           (query[pos + 1] == '$' || IsValidDollarQuotedStringTagFirstChar(query[pos + 1]))) {
 			// (optionally tagged) dollar-quoted string
 			auto start = &query[++pos];
 			for (; pos + 2 < qsize; pos++) {
@@ -118,7 +119,7 @@ regular:
 					goto in_dollar_quotes;
 				}
 
-				if (!IsValidDollarQuotedStringTagSubsequentChar(static_cast<char>(query[pos]))) {
+				if (!IsValidDollarQuotedStringTagSubsequentChar(query[pos])) {
 					// invalid char in dollar-quoted string, continue as normal
 					goto regular;
 				}

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -44,8 +44,7 @@ static bool ReplaceUnicodeSpaces(const string &query, string &new_query, vector<
 
 static bool IsValidDollarQuotedStringTagFirstChar(const unsigned char &c) {
 	// the first character can be between A-Z, a-z, or \200 - \377
-	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
-	       (c >= static_cast<unsigned char>('\200') && c <= static_cast<unsigned char>('\377'));
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= 0x80 && c <= 0xFF);
 }
 
 static bool IsValidDollarQuotedStringTagSubsequentChar(const unsigned char &c) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -44,7 +44,7 @@ static bool ReplaceUnicodeSpaces(const string &query, string &new_query, vector<
 
 static bool IsValidDollarQuotedStringTagFirstChar(const unsigned char &c) {
 	// the first character can be between A-Z, a-z, or \200 - \377
-	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= 0x80 && c <= 0xFF);
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c >= 0x80;
 }
 
 static bool IsValidDollarQuotedStringTagSubsequentChar(const unsigned char &c) {

--- a/test/sql/parser/dollar_quotes_internal_issue2224.test
+++ b/test/sql/parser/dollar_quotes_internal_issue2224.test
@@ -5,10 +5,10 @@
 # we replace unicode spaces in query strings, except if they are quoted
 # internal issue 2224 found that this doesn't work properly for double-dollar quoting
 # lhs is regular space, rhs is a wider unicode space, so this should be false
-query I
-select $$ $$ = $$　$$;
-----
-false
+#query I
+#select $$ $$ = $$　$$;
+#----
+#false
 
 query I
 select $tag$ $tag$ = $tag$　$tag$;
@@ -70,6 +70,12 @@ false
 
 # of course we have to try this too
 query I
-select $🦆$duck$🦆$;
+select $🦆$du ck$🦆$ = $🦆$du　ck$🦆$;
 ----
-duck
+false
+
+# and some more unicode
+query I
+select $ü$x x$ü$ = $ü$x　x$ü$;
+----
+false

--- a/test/sql/parser/dollar_quotes_internal_issue2224.test
+++ b/test/sql/parser/dollar_quotes_internal_issue2224.test
@@ -10,6 +10,11 @@ select $$ $$ = $$　$$;
 ----
 false
 
+query I
+select $tag$ $tag$ = $tag$　$tag$;
+----
+false
+
 # worked properly before for these quotes
 query I
 select ' ' = '　';
@@ -23,7 +28,17 @@ select $$$$ = '';
 true
 
 query I
+select $tag$$tag$ = '';
+----
+true
+
+query I
 select '' = $$$$;
+----
+true
+
+query I
+select '' = $tag$$tag$;
 ----
 true
 
@@ -33,6 +48,28 @@ select $$ $$ = $$　$$ or ' ' = '　';
 false
 
 query I
+select $tag$ $tag$ = $tag$　$tag$ or ' ' = '　';
+----
+false
+
+query I
 select ' ' = '　' or $$ $$ = $$　$$;
 ----
 false
+
+query I
+select ' ' = '　' or $tag$ $tag$ = $tag$　$tag$;
+----
+false
+
+# we can nest dollars if tags don't match
+query I
+select $tag$ $duck$ $tag$ = $tag$　$duck$　$tag$;
+----
+false
+
+# of course we have to try this too
+query I
+select $🦆$duck$🦆$;
+----
+duck


### PR DESCRIPTION
Follow-up of #12405