### PR TITLE
Write zero-length list offsets for NULL values when serializing vectors

### DIFF
--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -133,9 +133,7 @@ for test_number, test_case in enumerate(test_cases):
         test_cmd = [unittest_program, test_case]
         if args.valgrind:
             test_cmd = ['valgrind'] + test_cmd
-        res = subprocess.run(test_cmd,
-             stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout
-        )
+        res = subprocess.run(test_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout)
     except subprocess.TimeoutExpired as e:
         print(" (TIMED OUT)", flush=True)
         fail()

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -33,6 +33,9 @@ parser.add_argument(
     default=3600,
     type=valid_timeout,
 )
+parser.add_argument(
+    '--valgrind', action='store_true', help='Run the tests with valgrind', default=False
+)
 
 args, extra_args = parser.parse_known_args()
 
@@ -127,8 +130,11 @@ for test_number, test_case in enumerate(test_cases):
 
     start = time.time()
     try:
-        res = subprocess.run(
-            [unittest_program, test_case], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout
+        test_cmd = [unittest_program, test_case]
+        if args.valgrind:
+            test_cmd = ['valgrind'] + test_cmd
+        res = subprocess.run(test_cmd,
+             stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout
         )
     except subprocess.TimeoutExpired as e:
         print(" (TIMED OUT)", flush=True)

--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -33,9 +33,7 @@ parser.add_argument(
     default=3600,
     type=valid_timeout,
 )
-parser.add_argument(
-    '--valgrind', action='store_true', help='Run the tests with valgrind', default=False
-)
+parser.add_argument('--valgrind', action='store_true', help='Run the tests with valgrind', default=False)
 
 args, extra_args = parser.parse_known_args()
 

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1158,8 +1158,13 @@ void Vector::Serialize(Serializer &serializer, idx_t count) {
 			for (idx_t i = 0; i < count; i++) {
 				auto idx = vdata.sel->get_index(i);
 				auto source = source_array[idx];
-				entries[i].offset = source.offset;
-				entries[i].length = source.length;
+				if (vdata.validity.RowIsValid(idx)) {
+					entries[i].offset = source.offset;
+					entries[i].length = source.length;
+				} else {
+					entries[i].offset = 0;
+					entries[i].length = 0;
+				}
 			}
 			serializer.WriteProperty(104, "list_size", list_size);
 			serializer.WriteList(105, "entries", count, [&](Serializer::List &list, idx_t i) {


### PR DESCRIPTION
Fixes an issue found by valgrind

Note that this is not actually a correctness issue - since offsets where values are `NULL` will be ignored - but it is a good idea not to serialize uninitialized memory in general.