### PR TITLE
Linux Extensions CI: Attempt at fix missing dependencies

### DIFF
--- a/.github/actions/ubuntu_18_setup/action.yml
+++ b/.github/actions/ubuntu_18_setup/action.yml
@@ -27,7 +27,7 @@ runs:
         apt-get install -y -qq software-properties-common
         add-apt-repository ppa:git-core/ppa
         apt-get update -y -qq
-        apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client pkg-config
+        apt-get install -y -qq --fix-missing ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client pkg-config
 
     - name: Install
       shell: bash


### PR DESCRIPTION
Error mode that this fixes is like:
```
There’s nothing that PPA owners can do about this for now, as the key is fully controlled internally by Launchpad.
 More info: https://launchpad.net/~git-core/+archive/ubuntu/ppa
Hit:1 http://security.ubuntu.com/ubuntu bionic-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu bionic InRelease
Hit:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
Get:5 http://ppa.launchpad.net/git-core/ppa/ubuntu bionic InRelease [21.5 kB]
Get:6 http://ppa.launchpad.net/git-core/ppa/ubuntu bionic/main amd64 Packages [3174 B]
Fetched 24.7 kB in 1s (28.5 kB/s)
Reading package lists...
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/make_4.1-9.1ubuntu1_amd64.deb  Undetermined Error [IP: 185.125.190.36 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Just adding `--fix-missing` should not change behaviour but for more resilience in case of fluctuations in the force.