### PR TITLE
Prefetch metadata blocks for remote files

### DIFF
--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -68,6 +68,7 @@ public:
 	void ClearModifiedBlocks(const vector<MetaBlockPointer> &pointers);
 
 	vector<MetadataBlockInfo> GetMetadataInfo() const;
+	vector<shared_ptr<BlockHandle>> GetBlocks() const;
 	idx_t BlockCount();
 
 	void Write(WriteStream &sink);

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -243,6 +243,12 @@ void SingleFileCheckpointReader::LoadFromStorage() {
 		return;
 	}
 
+	if (block_manager.IsRemote()) {
+		auto metadata_blocks = metadata_manager.GetBlocks();
+		auto &buffer_manager = BufferManager::GetBufferManager(storage.GetDatabase());
+		buffer_manager.Prefetch(metadata_blocks);
+	}
+
 	// create the MetadataReader to read from the storage
 	MetadataReader reader(metadata_manager, meta_block);
 	auto transaction = CatalogTransaction::GetSystemTransaction(catalog.GetDatabase());

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -315,6 +315,14 @@ vector<MetadataBlockInfo> MetadataManager::GetMetadataInfo() const {
 	return result;
 }
 
+vector<shared_ptr<BlockHandle>> MetadataManager::GetBlocks() const {
+	vector<shared_ptr<BlockHandle>> result;
+	for (auto &entry : blocks) {
+		result.push_back(entry.second.block);
+	}
+	return result;
+}
+
 block_id_t MetadataManager::PeekNextBlockId() {
 	return block_manager.PeekFreeBlockId();
 }


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/12413

Batch prefetch metadata blocks when reading from remote files. Metadata blocks are often close together, and large databases can have many blocks (e.g. `>50` blocks). By prefetching them we can avoid performing many individual requests at start-up/while querying.