### PR TITLE
Move Windows workflows from windows-latest (= 2022) to 2019

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -55,7 +55,7 @@ jobs:
  win-release-64:
     # Builds binaries for windows_amd64
     name: Windows (64 Bit)
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v3
       with:
@@ -224,7 +224,7 @@ jobs:
 
  mingw:
      name: MingW (64 Bit)
-     runs-on: windows-latest
+     runs-on: windows-2019
      if: ${{ inputs.skip_tests != 'true' }}
      needs: win-release-64
      steps:
@@ -268,7 +268,7 @@ jobs:
  win-extensions-64:
    # Builds extensions for windows_amd64
    name: Windows Extensions (64-bit)
-   runs-on: windows-latest
+   runs-on: windows-2019
    needs: win-release-64
    steps:
      - name: Keep \n line endings


### PR DESCRIPTION
Connected to https://github.com/actions/runner-images/issues/10004#issuecomment-2153305472