### PR TITLE
Allow parquet encryption/decryption keys to be passed in as base64 encoded strings

### DIFF
--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -378,8 +378,7 @@ void ParquetCrypto::AddKey(ClientContext &context, const FunctionParameters &par
 		try {
 			decoded_key = Base64Decode(key);
 		} catch (...) {
-			throw InvalidInputException(
-			    "Invalid AES key. Not a plain AES key NOR a base64 encoded string");
+			throw InvalidInputException("Invalid AES key. Not a plain AES key NOR a base64 encoded string");
 		}
 		if (!AESGCMState::ValidKey(decoded_key)) {
 			throw InvalidInputException(

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -4,6 +4,7 @@
 #include "thrift_tools.hpp"
 
 #ifndef DUCKDB_AMALGAMATION
+#include "duckdb/common/exception/conversion_exception.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/storage/arena_allocator.hpp"
@@ -377,7 +378,7 @@ void ParquetCrypto::AddKey(ClientContext &context, const FunctionParameters &par
 		string decoded_key;
 		try {
 			decoded_key = Base64Decode(key);
-		} catch (...) {
+		} catch (const ConversionException &e) {
 			throw InvalidInputException("Invalid AES key. Not a plain AES key NOR a base64 encoded string");
 		}
 		if (!AESGCMState::ValidKey(decoded_key)) {

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -358,7 +358,7 @@ uint32_t ParquetCrypto::WriteData(TProtocol &oprot, const const_data_ptr_t buffe
 	return etrans.Finalize();
 }
 
-std::string base64decode(const std::string& key) {
+std::string base64decode(const std::string &key) {
 	auto result_size = Blob::FromBase64Size(key);
 	auto output = duckdb::unique_ptr<unsigned char[]>(new unsigned char[result_size]);
 	Blob::FromBase64(key, output.get(), result_size);
@@ -382,8 +382,6 @@ void ParquetCrypto::AddKey(ClientContext &context, const FunctionParameters &par
 		}
 		keys.AddKey(key_name, decoded_key);
 	}
-
-
 }
 
 } // namespace duckdb

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -358,7 +358,7 @@ uint32_t ParquetCrypto::WriteData(TProtocol &oprot, const const_data_ptr_t buffe
 	return etrans.Finalize();
 }
 
-std::string base64_decode(const std::string &key) {
+std::string Base64Decode(const std::string &key) {
 	auto result_size = Blob::FromBase64Size(key);
 	auto output = duckdb::unique_ptr<unsigned char[]>(new unsigned char[result_size]);
 	Blob::FromBase64(key, output.get(), result_size);
@@ -375,7 +375,7 @@ void ParquetCrypto::AddKey(ClientContext &context, const FunctionParameters &par
 		keys.AddKey(key_name, key);
 	} else {
 		// try Base64 decoding
-		std::string decoded_key = base64_decode(key);
+		std::string decoded_key = Base64Decode(key);
 		if (!AESGCMState::ValidKey(decoded_key)) {
 			throw InvalidInputException(
 			    "Invalid AES key. Must have a length of 128, 192, or 256 bits (16, 24, or 32 bytes)");

--- a/extension/parquet/parquet_crypto.cpp
+++ b/extension/parquet/parquet_crypto.cpp
@@ -358,7 +358,7 @@ uint32_t ParquetCrypto::WriteData(TProtocol &oprot, const const_data_ptr_t buffe
 	return etrans.Finalize();
 }
 
-std::string base64decode(const std::string &key) {
+std::string base64_decode(const std::string &key) {
 	auto result_size = Blob::FromBase64Size(key);
 	auto output = duckdb::unique_ptr<unsigned char[]>(new unsigned char[result_size]);
 	Blob::FromBase64(key, output.get(), result_size);
@@ -375,7 +375,7 @@ void ParquetCrypto::AddKey(ClientContext &context, const FunctionParameters &par
 		keys.AddKey(key_name, key);
 	} else {
 		// try Base64 decoding
-		std::string decoded_key = base64decode(key);
+		std::string decoded_key = base64_decode(key);
 		if (!AESGCMState::ValidKey(decoded_key)) {
 			throw InvalidInputException(
 			    "Invalid AES key. Must have a length of 128, 192, or 256 bits (16, 24, or 32 bytes)");

--- a/test/sql/copy/parquet/parquet_encryption.test
+++ b/test/sql/copy/parquet/parquet_encryption.test
@@ -14,7 +14,7 @@ PRAGMA enable_verification
 statement error
 PRAGMA add_parquet_key('my_cool_key', '42')
 ----
-Conversion Error: Could not decode string "42" as base64: length must be a multiple of 4
+Invalid Input Error: Invalid AES key. Not a plain AES key NOR a base64 encoded string
 
 # we dont support this yet
 statement error

--- a/test/sql/copy/parquet/parquet_encryption.test
+++ b/test/sql/copy/parquet/parquet_encryption.test
@@ -14,7 +14,7 @@ PRAGMA enable_verification
 statement error
 PRAGMA add_parquet_key('my_cool_key', '42')
 ----
-Invalid Input Error: Invalid AES key. Must have a length of 128, 192, or 256 bits (16, 24, or 32 bytes)
+Conversion Error: Could not decode string "42" as base64: length must be a multiple of 4
 
 # we dont support this yet
 statement error
@@ -87,3 +87,12 @@ statement error
 SELECT * FROM read_parquet('__TEST_DIR__/unencrypted.parquet', encryption_config={footer_key: 'key256'})
 ----
 Invalid Input Error
+
+# Use Base64 encoded key
+statement ok
+PRAGMA add_parquet_key('key256base64', 'MDEyMzQ1Njc4OTExMjM0NTAxMjM0NTY3ODkxMTIzNDU=')
+
+query I
+SELECT * FROM read_parquet('__TEST_DIR__/encrypted256.parquet', encryption_config={footer_key: 'key256base64'})
+----
+42

--- a/test/sql/copy/parquet/parquet_encryption.test
+++ b/test/sql/copy/parquet/parquet_encryption.test
@@ -10,11 +10,17 @@ require noforcestorage
 statement ok
 PRAGMA enable_verification
 
-# AES key must have one of the three specified lengths
+# AES key must have one of the three specified lengths or be valid Base64
 statement error
 PRAGMA add_parquet_key('my_cool_key', '42')
 ----
 Invalid Input Error: Invalid AES key. Not a plain AES key NOR a base64 encoded string
+
+# Valid Base64 AES key must have one of the three specified lengths
+statement error
+PRAGMA add_parquet_key('my_invalid_duck_key', 'ZHVjaw==')
+----
+Invalid Input Error: Invalid AES key. Must have a length of 128, 192, or 256 bits (16, 24, or 32 bytes)
 
 # we dont support this yet
 statement error


### PR DESCRIPTION
C++ std::string can contain arbitrary byte arrays, so the change to support arbitrary byte array keys is minimal -- just a way to accept them in Base64.