### PR TITLE
Issue #12412: AsOf Filter Push

### DIFF
--- a/src/optimizer/filter_pullup.cpp
+++ b/src/optimizer/filter_pullup.cpp
@@ -38,7 +38,12 @@ unique_ptr<LogicalOperator> FilterPullup::PullupJoin(unique_ptr<LogicalOperator>
 
 	switch (join.join_type) {
 	case JoinType::INNER:
-		return PullupInnerJoin(std::move(op));
+		if (op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN) {
+			//	We can only move filters through the left side of AsOf joins.
+			return PullupFromLeft(std::move(op));
+		} else {
+			return PullupInnerJoin(std::move(op));
+		}
 	case JoinType::LEFT:
 	case JoinType::ANTI:
 	case JoinType::SEMI: {

--- a/src/optimizer/pushdown/pushdown_cross_product.cpp
+++ b/src/optimizer/pushdown/pushdown_cross_product.cpp
@@ -34,7 +34,13 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<Logi
 				left_pushdown.filters.push_back(std::move(f));
 			} else if (side == JoinSide::RIGHT) {
 				// bindings match right side: push into right
-				right_pushdown.filters.push_back(std::move(f));
+				if (join_ref_type == JoinRefType::ASOF) {
+					// AsOf is really a table lookup, so we don't push filters
+					// down into the lookup (right) table
+					join_expressions.push_back(std::move(f->filter));
+				} else {
+					right_pushdown.filters.push_back(std::move(f));
+				}
 			} else {
 				D_ASSERT(side == JoinSide::BOTH || side == JoinSide::NONE);
 				// bindings match both: turn into join condition

--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -76,7 +76,9 @@ void LogicalComparisonJoin::ExtractJoinConditions(
 		auto total_side = JoinSide::GetJoinSide(*expr, left_bindings, right_bindings);
 		if (total_side != JoinSide::BOTH) {
 			// join condition does not reference both sides, add it as filter under the join
-			if (type == JoinType::LEFT && total_side == JoinSide::RIGHT) {
+			// BUT don't push right side filters into AsOf because it is really a table lookup
+			// and we shouldn't remove anything from the table.
+			if (type == JoinType::LEFT && total_side == JoinSide::RIGHT && ref_type != JoinRefType::ASOF) {
 				// filter is on RHS and the join is a LEFT OUTER join, we can push it in the right child
 				if (right_child->type != LogicalOperatorType::LOGICAL_FILTER) {
 					// not a filter yet, push a new empty filter

--- a/test/sql/join/asof/test_asof_join_pushdown.test
+++ b/test/sql/join/asof/test_asof_join_pushdown.test
@@ -43,3 +43,39 @@ ASOF LEFT JOIN (
 ----
 0 	0	0.0	0.0
 1 	0	NULL	0.0
+
+query II
+WITH t as (
+    SELECT
+        t1.col0 AS left_val,
+        t2.col0 AS right_val,
+    FROM
+        (VALUES (0), (5), (10), (15)) AS t1
+        ASOF JOIN (VALUES (1), (6), (11), (16)) AS t2
+        ON t2.col0 > t1.col0
+)
+SELECT *
+FROM t
+WHERE right_val BETWEEN 3 AND 12
+ORDER BY ALL
+----
+5	6
+10	11
+
+query II
+WITH t as (
+    SELECT
+        t1.col0 AS left_val,
+        t2.col0 AS right_val,
+    FROM
+        (VALUES (0), (5), (10), (15)) AS t1
+        ASOF LEFT JOIN (VALUES (1), (6), (11), (16)) AS t2
+        ON t2.col0 > t1.col0
+)
+SELECT *
+FROM t
+WHERE right_val BETWEEN 3 AND 12
+ORDER BY ALL
+----
+5	6
+10	11


### PR DESCRIPTION
Don't push or pull filters through the right side of AsOf joins. AsOf is a table lookup, so we shouldn't mess with the table.

fixes: duckdb#12412
fixes: duckdblabs/duckdb-internal#2235