### PR TITLE
By default attach remote databases as READ_ONLY

### DIFF
--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -102,6 +102,12 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 			throw MissingExtensionException("Attaching path '%s' requires extension '%s' to be loaded", path,
 			                                extension);
 		}
+		if (access_mode == AccessMode::AUTOMATIC) {
+			// Attaching of remote files gets bumped to READ_ONLY
+			// This is due to the fact that on most (all?) remote files writes to DB are not available
+			// and having this raised later is not super helpful
+			access_mode = AccessMode::READ_ONLY;
+		}
 	}
 
 	// get the database type and attach the database

--- a/test/sql/attach/attach_remote.test
+++ b/test/sql/attach/attach_remote.test
@@ -8,3 +8,8 @@ statement error
 ATTACH 'https://duckdb.org/non_existing.db' AS db2 (READ_ONLY)
 ----
 IO Error: Cannot open database "https://duckdb.org/non_existing.db" in read-only mode: database does not exist
+
+statement error
+ATTACH 'https://duckdb.org/non_existing.db' AS db2
+----
+IO Error: Cannot open database "https://duckdb.org/non_existing.db" in read-only mode: database does not exist

--- a/test/sql/attach/attach_remote.test
+++ b/test/sql/attach/attach_remote.test
@@ -13,3 +13,8 @@ statement error
 ATTACH 'https://duckdb.org/non_existing.db' AS db2
 ----
 IO Error: Cannot open database "https://duckdb.org/non_existing.db" in read-only mode: database does not exist
+
+statement error
+ATTACH 'https://duckdb.org/non_existing.db' AS db2 (READ_WRITE)
+----
+Not implemented Error: Writing to HTTP files not implemented


### PR DESCRIPTION
This PR buids on top of https://github.com/duckdb/duckdb/pull/12393.

Currently there are 3 flavours of attach:
```
ATTACH 'path/to/file.db' (READ_ONLY);
ATTACH 'path/to/file.db' (READ_WRITE);
ATTACH 'path/to/file.db';           // this behaves as READ_WRITE
```
Read only, read and write, and automatic.
Currently automatic behaves equivalent to read-and-write, but for remote files this has little sense, also given that currently most remote file-system abstraction are not really working for DuckDB files.

This PR changes so that `ATTACH 'path/to/file.db';` behaves as READ_WRITE when the file is local or READ_ONLY when the file is remote.

Note that explicitly specifying the AttachMode keeps whatever semantic is requested.

This improves quality of errors like:
```
LOAD httpfs;
ATTACH 'https://duckdb.org/non_existing.db';
Not implemented Error: Writing to HTTP files not implemented
```
will now become:
```
LOAD httpfs;
ATTACH 'https://duckdb.org/non_existing.db';
IO Error: Cannot open database "https://duckdb.org/non_existing.db" in read-only mode: database does not exist
```
or
```
LOAD httpfs;
ATTACH 'https://blobs.duckdb.org/databases/stations.duckdb' AS stations_db;
DROP TABLE stations_db.stations;
TransactionContext Error: Failed to commit: Writing to HTTP files not implemented
```
(error is thrown only when committing) will now become
```
LOAD httpfs;
ATTACH 'https://blobs.duckdb.org/databases/stations.duckdb' AS stations_db;
DROP TABLE stations_db.stations;
Invalid Input Error: Cannot execute statement of type "DROP" on database "stations_db" which is attached in read-only mode!
```

I included the explicit `LOAD httpfs`, that is needed in duckdb 1.0.0, but has been since fixed.

PR is very limited, and can arguably be seen as bug-fixing / quality of life, but that might be a stretch.