### PR TITLE
Fix #11837: use internal physical type for FIRST/LAST/ANY_VALUE instead of logical type

### DIFF
--- a/.github/regression/micro_extended.csv
+++ b/.github/regression/micro_extended.csv
@@ -1,3 +1,4 @@
+benchmark/micro/aggregate/any_value_uuid.benchmark
 benchmark/micro/aggregate/bitstring_aggregate.benchmark
 benchmark/micro/aggregate/bitwise_aggregate.benchmark
 benchmark/micro/aggregate/grouped_distinct.benchmark

--- a/benchmark/micro/aggregate/any_value_uuid.benchmark
+++ b/benchmark/micro/aggregate/any_value_uuid.benchmark
@@ -1,0 +1,13 @@
+# name: benchmark/micro/aggregate/any_value_uuid.benchmark
+# description: ANY_VALUE(uuid) over a bunch of uuids
+# group: [aggregate]
+
+name Any Value (UUID)
+group aggregate
+
+load
+CREATE TABLE t AS SELECT uuid() AS uuid FROM range(100000000) tbl(i);
+
+run
+SELECT ANY_VALUE(uuid) FROM t;
+


### PR DESCRIPTION
Fixes #11837

This prevents us from having to do a fallback to the slower case for fixed length types that were not explicitly mentioned (e.g. `UUID`)