### PR TITLE
[C-API] Fix leak in `duckdb_create_config`

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -591,6 +591,9 @@ The duckdb_config must be destroyed using 'duckdb_destroy_config'
 
 This will always succeed unless there is a malloc failure.
 
+Note that `duckdb_destroy_config` should always be called on the resulting config, even if the function returns
+`DuckDBError`.
+
 * out_config: The result configuration object.
 * returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
 */

--- a/src/main/capi/config-c.cpp
+++ b/src/main/capi/config-c.cpp
@@ -10,9 +10,10 @@ duckdb_state duckdb_create_config(duckdb_config *out_config) {
 	if (!out_config) {
 		return DuckDBError;
 	}
-	auto config = new DBConfig();
-	*out_config = reinterpret_cast<duckdb_config>(config);
 	try {
+		*out_config = nullptr;
+		auto config = new DBConfig();
+		*out_config = reinterpret_cast<duckdb_config>(config);
 		config->SetOptionByName("duckdb_api", "capi");
 	} catch (...) { // LCOV_EXCL_START
 		return DuckDBError;

--- a/src/main/capi/config-c.cpp
+++ b/src/main/capi/config-c.cpp
@@ -10,14 +10,13 @@ duckdb_state duckdb_create_config(duckdb_config *out_config) {
 	if (!out_config) {
 		return DuckDBError;
 	}
-	DBConfig *config;
+	auto config = new DBConfig();
+	*out_config = reinterpret_cast<duckdb_config>(config);
 	try {
-		config = new DBConfig();
 		config->SetOptionByName("duckdb_api", "capi");
 	} catch (...) { // LCOV_EXCL_START
 		return DuckDBError;
 	} // LCOV_EXCL_STOP
-	*out_config = reinterpret_cast<duckdb_config>(config);
 	return DuckDBSuccess;
 }
 


### PR DESCRIPTION
I was going through the `create` code after realizing that our design for `create` dictates that objects should be created even when DuckDBError is returned and noticed a potential leak.

I don't think this can ever happen, the `try-catch` around this action seems just out of precaution, but it can be a leak if this would throw.
We allocate memory in the `try` block and never free it in the `catch` block

-----------

The comment in `duckdb.h` states:
```
/*!
Initializes an empty configuration object that can be used to provide start-up options for the DuckDB instance
through `duckdb_open_ext`.
The duckdb_config must be destroyed using 'duckdb_destroy_config'

This will always succeed unless there is a malloc failure.

* out_config: The result configuration object.
* returns: `DuckDBSuccess` on success or `DuckDBError` on failure.
*/
```

This does not mention that `destroy` should be called even if DuckDBError is returned, which differs from other `create` methods, that might not be desired behavior?