### PR TITLE
Fixes clang conversion warnings

### DIFF
--- a/src/core_functions/aggregate/distributive/entropy.cpp
+++ b/src/core_functions/aggregate/distributive/entropy.cpp
@@ -50,11 +50,12 @@ struct EntropyFunctionBase {
 
 	template <class T, class STATE>
 	static void Finalize(STATE &state, T &target, AggregateFinalizeData &finalize_data) {
-		double count = state.count;
+		double count = static_cast<double>(state.count);
 		if (state.distinct) {
 			double entropy = 0;
 			for (auto &val : *state.distinct) {
-				entropy += (val.second / count) * log2(count / val.second);
+				double val_sec = static_cast<double>(val.second);
+				entropy += (val_sec / count) * log2(count / val_sec);
 			}
 			target = entropy;
 		} else {

--- a/src/core_functions/aggregate/holistic/mode.cpp
+++ b/src/core_functions/aggregate/holistic/mode.cpp
@@ -262,8 +262,8 @@ struct ModeFunction {
 		if (!state.frequency_map) {
 			state.frequency_map = new typename STATE::Counts;
 		}
-		const double tau = .25;
-		if (state.nonzero <= tau * state.frequency_map->size() || prevs.back().end <= frames.front().start ||
+		const size_t tau_inverse = 4; // tau==0.25
+		if (state.nonzero <= (state.frequency_map->size() / tau_inverse) || prevs.back().end <= frames.front().start ||
 		    frames.back().end <= prevs.front().start) {
 			state.Reset();
 			// for f ∈ F do

--- a/src/include/duckdb/common/types/datetime.hpp
+++ b/src/include/duckdb/common/types/datetime.hpp
@@ -24,7 +24,7 @@ struct dtime_t { // NOLINT
 		return micros;
 	}
 	explicit inline operator double() const {
-		return micros;
+		return static_cast<double>(micros);
 	}
 
 	// comparison operators

--- a/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
@@ -62,8 +62,7 @@ struct CovarOperation {
 			//  Schubert and Gertz SSDBM 2018, equation 21
 			const auto deltax = target.meanx - source.meanx;
 			const auto deltay = target.meany - source.meany;
-			target.co_moment = source.co_moment + target.co_moment +
-			                   deltax * deltay * static_cast<double>(source.count * target.count) / count;
+			target.co_moment = source.co_moment + target.co_moment + deltax * deltay * static_cast<double>(source.count * target.count) / count;
 			target.meanx = meanx;
 			target.meany = meany;
 			target.count = count;

--- a/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
@@ -32,7 +32,7 @@ struct CovarOperation {
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
 		// update running mean and d^2
-		const uint64_t n = ++(state.count);
+		const double n = static_cast<double>(++(state.count));
 
 		const double dx = (x - state.meanx);
 		const double meanx = state.meanx + dx / n;
@@ -53,15 +53,17 @@ struct CovarOperation {
 		if (target.count == 0) {
 			target = source;
 		} else if (source.count > 0) {
-			const auto count = target.count + source.count;
-			const auto meanx = (source.count * source.meanx + target.count * target.meanx) / count;
-			const auto meany = (source.count * source.meany + target.count * target.meany) / count;
+			const auto target_count = static_cast<double>(target.count);
+			const auto source_count = static_cast<double>(source.count);
+			const auto count = static_cast<double>(target_count + source.count);
+			const auto meanx = (source_count * source.meanx + target_count * target.meanx) / count;
+			const auto meany = (source_count * source.meany + target_count * target.meany) / count;
 
 			//  Schubert and Gertz SSDBM 2018, equation 21
 			const auto deltax = target.meanx - source.meanx;
 			const auto deltay = target.meany - source.meany;
-			target.co_moment =
-			    source.co_moment + target.co_moment + deltax * deltay * source.count * target.count / count;
+			target.co_moment = source.co_moment + target.co_moment +
+			                   deltax * deltay * static_cast<double>(source.count * target.count) / count;
 			target.meanx = meanx;
 			target.meany = meany;
 			target.count = count;

--- a/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
@@ -40,7 +40,7 @@ struct STDDevBaseOperation {
 
 		state.mean = new_mean;
 		state.dsquared = new_dsquared;
-
+		
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
@@ -49,7 +49,8 @@ struct STDDevBaseOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
@@ -60,13 +61,15 @@ struct STDDevBaseOperation {
 		if (target.count == 0) {
 			target = source;
 		} else if (source.count > 0) {
-			const auto count = target.count + source.count;
-			const auto mean = (source.count * source.mean + target.count * target.mean) / count;
+			const double target_count = static_cast<double>(target.count);
+			const double source_count = static_cast<double>(source.count);
+			const auto count = target_count + source_count;
+			const auto mean = (source_count * source.mean + target_count * target.mean) / count;
 			const auto delta = source.mean - target.mean;
-			target.dsquared =
-			    source.dsquared + target.dsquared + delta * delta * source.count * target.count / count;
+			target.dsquared = source.dsquared + target.dsquared +
+			                  delta * delta * static_cast<double>(source.count * target.count) / count;
 			target.mean = mean;
-			target.count = count;
+			target.count = static_cast<decltype(target.count)>(count);
 		}
 	}
 

--- a/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
@@ -49,8 +49,7 @@ struct STDDevBaseOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
-	                              idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
@@ -66,8 +65,7 @@ struct STDDevBaseOperation {
 			const auto count = target_count + source_count;
 			const auto mean = (source_count * source.mean + target_count * target.mean) / count;
 			const auto delta = source.mean - target.mean;
-			target.dsquared = source.dsquared + target.dsquared +
-			                  delta * delta * static_cast<double>(source.count * target.count) / count;
+			target.dsquared = source.dsquared + target.dsquared + delta * delta * static_cast<double>(source.count * target.count) / count;
 			target.mean = mean;
 			target.count = static_cast<decltype(target.count)>(count);
 		}


### PR DESCRIPTION
Hi,
when I compile duckdb with clang 16/17.06, I get several conversion warnings like the following:

> duckdb/src/include/duckdb/common/types/datetime.hpp:27:10: warning: implicit conversion from 'const int64_t' (aka 'const long') to 'double' may lose precision [-Wimplicit-int-float-conversion]
[build]    27 |                 return micros;
[build]       |                 ~~~~~~ ^~~~~~
[build] 1 warning generated.

Since this warning is in a header file, it occurs sadly a lot during compilation. The log gets a bit confusing with all these false positives.

This PR silences some of the warnings by making the cast explicit. It is focused on headers and templates which generate most of it (especially the one in the example "datetime.hpp"). It reduces the warning count from 529 to 129.

The remaining warnings seems to be better suited for another PR, as they are kinda unrelated, except sharing the same warning category.

I also tried to achieve the same numerical stability as before.