### PR TITLE
Specialize `list_value` for primitive types for significantly improved performance

### DIFF
--- a/.github/regression/micro_extended.csv
+++ b/.github/regression/micro_extended.csv
@@ -164,6 +164,7 @@ benchmark/micro/list/column_data_collection_copy/unnest.benchmark
 benchmark/micro/list/list_few_rows.benchmark
 benchmark/micro/list/list_many_rows.benchmark
 benchmark/micro/list/list_order_by.benchmark
+benchmark/micro/list/list_value.benchmark
 benchmark/micro/list/string_split.benchmark
 benchmark/micro/list/string_split_regexp.benchmark
 benchmark/micro/list/string_split_unicode.benchmark

--- a/benchmark/micro/list/list_order_by.benchmark
+++ b/benchmark/micro/list/list_order_by.benchmark
@@ -2,7 +2,7 @@
 # description: Ordered LIST aggregation
 # group: [list]
 
-name String Split Regexp
+name List Order By
 group micro
 subgroup list
 

--- a/benchmark/micro/list/list_value.benchmark
+++ b/benchmark/micro/list/list_value.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/list/list_value.benchmark
+# description: LIST_VALUE performance
+# group: [list]
+
+name List Value
+group micro
+subgroup list
+
+load
+CREATE TABLE uuids AS SELECT uuid() AS uuid FROM range(100000000) tbl(i) UNION ALL SELECT UUID '00000000-0000-0000-0000-000000000000';
+
+run
+SELECT MIN(l::VARCHAR) FROM (SELECT [uuid] AS l FROM uuids)
+
+result I
+[00000000-0000-0000-0000-000000000000]

--- a/src/core_functions/scalar/list/list_value.cpp
+++ b/src/core_functions/scalar/list/list_value.cpp
@@ -12,20 +12,20 @@
 namespace duckdb {
 
 struct ListValueAssign {
-	template<class T>
+	template <class T>
 	static T Assign(const T &input, Vector &result) {
 		return input;
 	}
 };
 
 struct ListValueStringAssign {
-	template<class T>
+	template <class T>
 	static T Assign(const T &input, Vector &result) {
 		return StringVector::AddString(result, input);
 	}
 };
 
-template<class T, class OP=ListValueAssign>
+template <class T, class OP = ListValueAssign>
 static void TemplatedListValueFunction(DataChunk &args, Vector &result) {
 	idx_t list_size = args.ColumnCount();
 	ListVector::Reserve(result, args.size() * list_size);
@@ -35,8 +35,8 @@ static void TemplatedListValueFunction(DataChunk &args, Vector &result) {
 	auto &child_validity = FlatVector::Validity(list_child);
 
 	auto unified_format = args.ToUnifiedFormat();
-	for(idx_t r = 0; r < args.size(); r++) {
-		for(idx_t c = 0; c < list_size; c++) {
+	for (idx_t r = 0; r < args.size(); r++) {
+		for (idx_t c = 0; c < list_size; c++) {
 			auto input_idx = unified_format[c].sel->get_index(r);
 			auto result_idx = r * list_size + c;
 			auto input_data = UnifiedVectorFormat::GetData<T>(unified_format[c]);
@@ -54,14 +54,14 @@ static void TemplatedListValueFunction(DataChunk &args, Vector &result) {
 
 static void TemplatedListValueFunctionFallback(DataChunk &args, Vector &result) {
 	auto &child_type = ListType::GetChildType(result.GetType());
-   auto result_data = FlatVector::GetData<list_entry_t>(result);
-   for (idx_t i = 0; i < args.size(); i++) {
-           result_data[i].offset = ListVector::GetListSize(result);
-           for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
-                   auto val = args.GetValue(col_idx, i).DefaultCastAs(child_type);
-                   ListVector::PushBack(result, val);
-           }
-           result_data[i].length = args.ColumnCount();
+	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	for (idx_t i = 0; i < args.size(); i++) {
+		result_data[i].offset = ListVector::GetListSize(result);
+		for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+			auto val = args.GetValue(col_idx, i).DefaultCastAs(child_type);
+			ListVector::PushBack(result, val);
+		}
+		result_data[i].length = args.ColumnCount();
 	}
 }
 
@@ -82,7 +82,7 @@ static void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &r
 		return;
 	}
 	auto &result_type = result.GetType();
-	switch(result_type.InternalType()) {
+	switch (result_type.InternalType()) {
 	case PhysicalType::BOOL:
 	case PhysicalType::INT8:
 		TemplatedListValueFunction<int8_t>(args, result);

--- a/src/core_functions/scalar/list/list_value.cpp
+++ b/src/core_functions/scalar/list/list_value.cpp
@@ -11,27 +11,126 @@
 
 namespace duckdb {
 
+struct ListValueAssign {
+	template<class T>
+	static T Assign(const T &input, Vector &result) {
+		return input;
+	}
+};
+
+struct ListValueStringAssign {
+	template<class T>
+	static T Assign(const T &input, Vector &result) {
+		return StringVector::AddString(result, input);
+	}
+};
+
+template<class T, class OP=ListValueAssign>
+static void TemplatedListValueFunction(DataChunk &args, Vector &result) {
+	idx_t list_size = args.ColumnCount();
+	ListVector::Reserve(result, args.size() * list_size);
+	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	auto &list_child = ListVector::GetEntry(result);
+	auto child_data = FlatVector::GetData<T>(list_child);
+	auto &child_validity = FlatVector::Validity(list_child);
+
+	auto unified_format = args.ToUnifiedFormat();
+	for(idx_t r = 0; r < args.size(); r++) {
+		for(idx_t c = 0; c < list_size; c++) {
+			auto input_idx = unified_format[c].sel->get_index(r);
+			auto result_idx = r * list_size + c;
+			auto input_data = UnifiedVectorFormat::GetData<T>(unified_format[c]);
+			if (unified_format[c].validity.RowIsValid(input_idx)) {
+				child_data[result_idx] = OP::template Assign<T>(input_data[input_idx], list_child);
+			} else {
+				child_validity.SetInvalid(result_idx);
+			}
+		}
+		result_data[r].offset = r * list_size;
+		result_data[r].length = list_size;
+	}
+	ListVector::SetListSize(result, args.size() * list_size);
+}
+
+static void TemplatedListValueFunctionFallback(DataChunk &args, Vector &result) {
+	auto &child_type = ListType::GetChildType(result.GetType());
+   auto result_data = FlatVector::GetData<list_entry_t>(result);
+   for (idx_t i = 0; i < args.size(); i++) {
+           result_data[i].offset = ListVector::GetListSize(result);
+           for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+                   auto val = args.GetValue(col_idx, i).DefaultCastAs(child_type);
+                   ListVector::PushBack(result, val);
+           }
+           result_data[i].length = args.ColumnCount();
+	}
+}
+
 static void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
-	auto &child_type = ListType::GetChildType(result.GetType());
-
 	result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	for (idx_t i = 0; i < args.ColumnCount(); i++) {
 		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
 			result.SetVectorType(VectorType::FLAT_VECTOR);
 		}
 	}
-
-	auto result_data = FlatVector::GetData<list_entry_t>(result);
-	for (idx_t i = 0; i < args.size(); i++) {
-		result_data[i].offset = ListVector::GetListSize(result);
-		for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
-			auto val = args.GetValue(col_idx, i).DefaultCastAs(child_type);
-			ListVector::PushBack(result, val);
-		}
-		result_data[i].length = args.ColumnCount();
+	if (args.ColumnCount() == 0) {
+		// no columns - early out - result is a constant empty list
+		auto result_data = FlatVector::GetData<list_entry_t>(result);
+		result_data[0].length = 0;
+		result_data[0].offset = 0;
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		return;
 	}
-	result.Verify(args.size());
+	auto &result_type = result.GetType();
+	switch(result_type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedListValueFunction<int8_t>(args, result);
+		break;
+	case PhysicalType::INT16:
+		TemplatedListValueFunction<int16_t>(args, result);
+		break;
+	case PhysicalType::INT32:
+		TemplatedListValueFunction<int32_t>(args, result);
+		break;
+	case PhysicalType::INT64:
+		TemplatedListValueFunction<int64_t>(args, result);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedListValueFunction<uint8_t>(args, result);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedListValueFunction<uint16_t>(args, result);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedListValueFunction<uint32_t>(args, result);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedListValueFunction<uint64_t>(args, result);
+		break;
+	case PhysicalType::INT128:
+		TemplatedListValueFunction<hugeint_t>(args, result);
+		break;
+	case PhysicalType::UINT128:
+		TemplatedListValueFunction<uhugeint_t>(args, result);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedListValueFunction<float>(args, result);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedListValueFunction<double>(args, result);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedListValueFunction<interval_t>(args, result);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedListValueFunction<string_t, ListValueStringAssign>(args, result);
+		break;
+	default: {
+		TemplatedListValueFunctionFallback(args, result);
+		break;
+	}
+	}
 }
 
 template <bool IS_UNPIVOT = false>


### PR DESCRIPTION
This PR specializes `list_value` for primitive types, greatly speeding it up over the `Value` based method used previously. For example:

```sql
create table integers as from range(10000000) t(i);
create table lists as select [i] from integers;
```

| v1.0.0 |  New  |
|--------|-------|
| 0.94s  | 0.15s |

#### Longer Lists

```sql
create table lists as select [i, i + 1, i + 2, i + 3] from integers;
```

| v1.0.0 |  New  |
|--------|-------|
| 3.63s  | 0.33s |