### PR TITLE
Issue #12464: Windowed Order By All

### DIFF
--- a/src/parser/transform/expression/transform_function.cpp
+++ b/src/parser/transform/expression/transform_function.cpp
@@ -27,6 +27,11 @@ void Transformer::TransformWindowDef(duckdb_libpgquery::PGWindowDef &window_spec
 			throw ParserException("Cannot override ORDER BY clause of window \"%s\"", window_name);
 		}
 		TransformOrderBy(window_spec.orderClause, expr.orders);
+		for (auto &order : expr.orders) {
+			if (order.expression->GetExpressionType() == ExpressionType::STAR) {
+				throw ParserException("Cannot ORDER BY ALL in a window expression");
+			}
+		}
 	}
 }
 

--- a/test/sql/window/test_order_by_all.test
+++ b/test/sql/window/test_order_by_all.test
@@ -1,0 +1,16 @@
+# name: test/sql/window/test_order_by_all.test
+# description: Window Order By All
+# group: [window]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+SELECT i, j, ROW_NUMBER() OVER (ORDER BY ALL) AS rn
+FROM (
+    SELECT i ,j
+    FROM generate_series(1, 5) s(i)
+    CROSS JOIN generate_series(1, 2) t(j)
+) t;
+----
+Cannot ORDER BY ALL in a window expression


### PR DESCRIPTION
Don't allow `ORDER BY ALL` in `OVER` clauses.

fixes: duckdb#12464
fixes: duckdblabs/duckdb-internal#2260