### PR TITLE
[Dev] Remove busy-spin from `ClientContext::ExecuteTaskInternal`

### DIFF
--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -16,6 +16,8 @@
 #include "duckdb/execution/task_error_manager.hpp"
 #include "duckdb/parallel/pipeline.hpp"
 
+#include <condition_variable>
+
 namespace duckdb {
 class ClientContext;
 class DataChunk;
@@ -49,6 +51,8 @@ public:
 
 	void CancelTasks();
 	PendingExecutionResult ExecuteTask(bool dry_run = false);
+	void WaitForTask();
+	void SignalTaskRescheduled();
 
 	void Reset();
 
@@ -164,6 +168,10 @@ private:
 
 	//! Task that have been descheduled
 	unordered_map<Task *, shared_ptr<Task>> to_be_rescheduled_tasks;
+	//! The lock for task_reschedule
+	mutex task_reschedule_lock;
+	//! The semaphore to signal task rescheduling
+	std::condition_variable task_reschedule;
 
 	//! Currently alive executor tasks
 	atomic<idx_t> executor_tasks;

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -111,6 +111,7 @@ public:
 	}
 
 private:
+	//! Check if the streaming query result is waiting to be fetched from, must hold the 'executor_lock'
 	bool ResultCollectorIsBlocked();
 	void InitializeInternal(PhysicalOperator &physical_plan);
 

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -52,7 +52,7 @@ public:
 	void CancelTasks();
 	PendingExecutionResult ExecuteTask(bool dry_run = false);
 	void WaitForTask();
-	void SignalTaskRescheduled();
+	void SignalTaskRescheduled(lock_guard<mutex> &);
 
 	void Reset();
 
@@ -168,8 +168,6 @@ private:
 
 	//! Task that have been descheduled
 	unordered_map<Task *, shared_ptr<Task>> to_be_rescheduled_tasks;
-	//! The lock for task_reschedule
-	mutex task_reschedule_lock;
 	//! The semaphore to signal task rescheduling
 	std::condition_variable task_reschedule;
 

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -244,6 +244,8 @@ private:
 	void BeginQueryInternal(ClientContextLock &lock, const string &query);
 	ErrorData EndQueryInternal(ClientContextLock &lock, bool success, bool invalidate_transaction);
 
+	//! Wait until a task is available to execute
+	void WaitForTask(ClientContextLock &lock, BaseQueryResult &result);
 	PendingExecutionResult ExecuteTaskInternal(ClientContextLock &lock, BaseQueryResult &result, bool dry_run = false);
 
 	unique_ptr<PendingQueryResult> PendingStatementOrPreparedStatementInternal(

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -532,11 +532,16 @@ unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientCon
 	return PendingPreparedStatementInternal(lock, prepared, parameters);
 }
 
+void ClientContext::WaitForTask(ClientContextLock &lock, BaseQueryResult &result) {
+	active_query->executor->WaitForTask();
+}
+
 PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &lock, BaseQueryResult &result,
                                                           bool dry_run) {
 	D_ASSERT(active_query);
 	D_ASSERT(active_query->IsOpenResult(result));
 	bool invalidate_transaction = true;
+	WaitForTask(lock, result);
 	try {
 		auto query_result = active_query->executor->ExecuteTask(dry_run);
 		if (active_query->progress_bar) {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -541,7 +541,6 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 	D_ASSERT(active_query);
 	D_ASSERT(active_query->IsOpenResult(result));
 	bool invalidate_transaction = true;
-	WaitForTask(lock, result);
 	try {
 		auto query_result = active_query->executor->ExecuteTask(dry_run);
 		if (active_query->progress_bar) {

--- a/src/main/pending_query_result.cpp
+++ b/src/main/pending_query_result.cpp
@@ -66,6 +66,7 @@ PendingExecutionResult PendingQueryResult::ExecuteTaskInternal(ClientContextLock
 unique_ptr<QueryResult> PendingQueryResult::ExecuteInternal(ClientContextLock &lock) {
 	CheckExecutableInternal(lock);
 	// Busy wait while execution is not finished
+
 	if (allow_stream_result) {
 		while (!IsFinishedOrBlocked(ExecuteTaskInternal(lock))) {
 		}

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/parallel/thread_context.hpp"
 
 #include <algorithm>
+#include <chrono>
 
 namespace duckdb {
 
@@ -431,6 +432,7 @@ void Executor::SignalTaskRescheduled(lock_guard<mutex> &) {
 }
 
 void Executor::WaitForTask() {
+	static constexpr std::chrono::milliseconds WAIT_TIME = std::chrono::milliseconds(20);
 	std::unique_lock<mutex> l(executor_lock);
 	if (to_be_rescheduled_tasks.empty()) {
 		return;
@@ -439,7 +441,7 @@ void Executor::WaitForTask() {
 		return;
 	}
 
-	task_reschedule.wait(l);
+	task_reschedule.wait_for(l, WAIT_TIME);
 }
 
 void Executor::RescheduleTask(shared_ptr<Task> &task_p) {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -438,12 +438,6 @@ void Executor::WaitForTask() {
 	if (ResultCollectorIsBlocked()) {
 		return;
 	}
-	auto &scheduler = TaskScheduler::GetScheduler(context);
-	auto active_threads = NumericCast<idx_t>(scheduler.NumberOfThreads());
-	if (to_be_rescheduled_tasks.size() + 1 >= active_threads) {
-		// All tasks are blocked, the main thread *has* to pick up a task to unblock them
-		return;
-	}
 
 	task_reschedule.wait(l);
 }


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2258

We introduce a `condition_variable` that gets waited on when there are blocked tasks.
This removes the busy-spin that was taking up CPU cycles while all tasks are blocked.

As a result this does mean that when any task is blocked, the calling thread will not participate in the execution until a task gets unblocked, which might have some impact on parallelization in certain situations.