### PR TITLE
throw binder error for comment on system catalog

### DIFF
--- a/src/planner/binder/statement/bind_simple.cpp
+++ b/src/planner/binder/statement/bind_simple.cpp
@@ -35,6 +35,9 @@ BoundStatement Binder::Bind(AlterStatement &stmt) {
 	if (entry) {
 		D_ASSERT(!entry->deleted);
 		auto &catalog = entry->ParentCatalog();
+		if (catalog.IsSystemCatalog()) {
+			throw BinderException("Can not comment on System Catalog entries");
+		}
 		if (!entry->temporary) {
 			// we can only alter temporary tables/views in read-only mode
 			properties.modified_databases.insert(catalog.GetName());

--- a/test/sql/catalog/comment_on.test
+++ b/test/sql/catalog/comment_on.test
@@ -18,6 +18,11 @@ COMMENT ON TABLE hahahoehoe IS 'blablabloebloe'
 ----
 Catalog Error: Table with name hahahoehoe does not exist!
 
+statement error
+COMMENT ON FUNCTION add IS 'foobar'
+----
+Can not comment on System Catalog entries
+
 ### Comment on Tables
 statement ok
 CREATE TABLE test_table as SELECT 1 as test_table_column


### PR DESCRIPTION
prevents an internal exception from being thrown later down the line