### PR TITLE
add the number of filtered files to explain

### DIFF
--- a/src/common/hive_partitioning.cpp
+++ b/src/common/hive_partitioning.cpp
@@ -144,6 +144,9 @@ void HivePartitioning::ApplyFiltersToFileList(ClientContext &context, vector<str
 
 	D_ASSERT(filters.size() >= pruned_filters.size());
 
+	get.extra_info.total_files = files.size();
+	get.extra_info.filtered_files = pruned_files.size();
+
 	filters = std::move(pruned_filters);
 	files = std::move(pruned_files);
 }

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -144,7 +144,8 @@ string PhysicalTableScan::ParamsToString() const {
 		result += "\n[INFOSEPARATOR]\n";
 		result += "File Filters: " + extra_info.file_filters;
 		if (extra_info.filtered_files.IsValid() && extra_info.total_files.IsValid()) {
-			result += StringUtil::Format("\nScanning: %llu/%llu files", extra_info.filtered_files.GetIndex(), extra_info.total_files.GetIndex());
+			result += StringUtil::Format("\nScanning: %llu/%llu files", extra_info.filtered_files.GetIndex(),
+			                             extra_info.total_files.GetIndex());
 		}
 	}
 

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -143,7 +143,11 @@ string PhysicalTableScan::ParamsToString() const {
 	if (!extra_info.file_filters.empty()) {
 		result += "\n[INFOSEPARATOR]\n";
 		result += "File Filters: " + extra_info.file_filters;
+		if (extra_info.filtered_files.IsValid() && extra_info.total_files.IsValid()) {
+			result += StringUtil::Format("\nScanning: %llu/%llu files", extra_info.filtered_files.GetIndex(), extra_info.total_files.GetIndex());
+		}
 	}
+
 	result += "\n[INFOSEPARATOR]\n";
 	result += StringUtil::Format("EC: %llu", estimated_cardinality);
 	return result;

--- a/src/include/duckdb/common/extra_operator_info.hpp
+++ b/src/include/duckdb/common/extra_operator_info.hpp
@@ -20,8 +20,20 @@ public:
 	ExtraOperatorInfo() : file_filters("") {
 	}
 	ExtraOperatorInfo(ExtraOperatorInfo &extra_info) : file_filters(extra_info.file_filters) {
+		if (extra_info.total_files.IsValid()) {
+			total_files = extra_info.total_files.GetIndex();
+		}
+		if (extra_info.filtered_files.IsValid()) {
+			filtered_files = extra_info.filtered_files.GetIndex();
+		}
 	}
+
+	//! Filters that have been pushed down into the main file list
 	string file_filters;
+	//! Total size of file list
+	optional_idx total_files;
+	//! Size of file list after applying filters
+	optional_idx filtered_files;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -42,7 +42,7 @@ public:
 	vector<string> names;
 	//! The table filters
 	unique_ptr<TableFilterSet> table_filters;
-	//! Currently stores any filters applied to file names (as strings)
+	//! Currently stores info related to filters pushed down into MultiFileLists
 	ExtraOperatorInfo extra_info;
 
 public:

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -44,7 +44,8 @@ string LogicalGet::ParamsToString() const {
 		result += "\n[INFOSEPARATOR]\n";
 		result += "File Filters: " + extra_info.file_filters;
 		if (extra_info.filtered_files.IsValid() && extra_info.total_files.IsValid()) {
-			result += StringUtil::Format("\nScanning: %llu/%llu files", extra_info.filtered_files.GetIndex(), extra_info.total_files.GetIndex());
+			result += StringUtil::Format("\nScanning: %llu/%llu files", extra_info.filtered_files.GetIndex(),
+			                             extra_info.total_files.GetIndex());
 		}
 	}
 	if (!function.to_string) {

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -43,6 +43,9 @@ string LogicalGet::ParamsToString() const {
 	if (!extra_info.file_filters.empty()) {
 		result += "\n[INFOSEPARATOR]\n";
 		result += "File Filters: " + extra_info.file_filters;
+		if (extra_info.filtered_files.IsValid() && extra_info.total_files.IsValid()) {
+			result += StringUtil::Format("\nScanning: %llu/%llu files", extra_info.filtered_files.GetIndex(), extra_info.total_files.GetIndex());
+		}
 	}
 	if (!function.to_string) {
 		return result;

--- a/test/sql/copy/partitioned/hive_filter_pushdown.test
+++ b/test/sql/copy/partitioned/hive_filter_pushdown.test
@@ -42,12 +42,12 @@ physical_plan	<!REGEX>:.*PARQUET_SCAN.*File Filters:.*
 query II
 explain SELECT * FROM parquet_scan('__TEST_DIR__/hive_pushdown_bug/*/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=1) where c=500;
 ----
-physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(c = 500\).*
+physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(c = 500\).*Scanning: 1\/10 files.*
 
 query II
 explain SELECT * FROM parquet_scan('__TEST_DIR__/hive_pushdown_bug/*/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=1) where c=500 and b='20';
 ----
-physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(c = 500\).*
+physical_plan	<REGEX>:.*PARQUET_SCAN.*File Filters: \(c = 500\).*Scanning: 1\/10 files.*
 
 # File Filters show up in read csv auto for hive partitioned csv files. 
 statement ok
@@ -56,7 +56,7 @@ COPY (SELECT i::VARCHAR as a, (i*10)::VARCHAR as b, (i*100)::VARCHAR as c from r
 query II
 explain SELECT * FROM read_csv_auto('__TEST_DIR__/hive_pushdown_bug_csv/*/*.csv', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=1, names=['a','b','c']) where c=500;
 ----
-physical_plan	<REGEX>:.*READ_CSV_AUTO.*File Filters: \(c = 500\).*
+physical_plan	<REGEX>:.*READ_CSV_AUTO.*File Filters: \(c = 500\).*Scanning: 1\/10 files.*
 
 # same for json paritioned files
 #statement ok


### PR DESCRIPTION
continuation of https://github.com/duckdb/duckdb/pull/7986

Adds and extra piece of information that can be set by MultiFileReaders: 
- the total number of files
- the number of files after applying filters

Resulting output may look like:
```
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│       PARQUET_SCAN        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│             c             │
│             a             │
│             b             │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│Filters: a='9' AND a IS NOT│
│            NULL           │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│  File Filters: (c < 301)  │
│    Scanning: 4/10 files   │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│           EC: 1           │
└───────────────────────────┘ 
```

This is useful for analyzing scans across many files where the list can be filtered, eg.:
- large hive-partitioned tables
- large Delta tables
- large Iceberg tables
- large s3-based globs with filename based filters

I mostly added this feature though because I want to be able to conveniently test this in the Delta extension, where we currently have filter pushdown into the file list but can't nicely test it.