### PR TITLE
Operators the Optimizer can skip

### DIFF
--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -89,6 +89,11 @@ unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan
 
 	switch (plan_p->type) {
 	case LogicalOperatorType::LOGICAL_TRANSACTION:
+	case LogicalOperatorType::LOGICAL_PRAGMA:
+	case LogicalOperatorType::LOGICAL_SET:
+	case LogicalOperatorType::LOGICAL_UPDATE_EXTENSIONS:
+	case LogicalOperatorType::LOGICAL_CREATE_SECRET:
+	case LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR:
 		return plan_p; // skip optimizing simple & often-occurring plans unaffected by rewrites
 	default:
 		break;


### PR DESCRIPTION
I'm sure there are others. But whenever I debug the optimizer, pragma/set statements always slow down the debugging process, so I thought I would add them to the list of skippable operators.