### PR TITLE
[Dev] Don't fail `make generate-files` if the python code generation fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ generate-files:
 	python3 scripts/generate_functions.py
 	python3 scripts/generate_serialization.py
 	python3 scripts/generate_enum_util.py
-	python3 tools/pythonpkg/scripts/generate_connection_code.py
+	-@python3 tools/pythonpkg/scripts/generate_connection_code.py || echo "Warning: generate_connection_code.py failed, libclang==16.0.6 is required to perform this step"
 	./scripts/generate_micro_extended.sh
 # Run the formatter again after (re)generating the files
 	$(MAKE) format-main

--- a/tools/pythonpkg/scripts/generate_connection_wrapper_methods.py
+++ b/tools/pythonpkg/scripts/generate_connection_wrapper_methods.py
@@ -1,7 +1,18 @@
 import os
 import json
-from get_cpp_methods import get_methods, FunctionParam, ConnectionMethod
+
+# Requires `python3 -m pip install libclang==16.0.6`
+from get_cpp_methods import test_clang, get_methods, FunctionParam, ConnectionMethod
 from typing import List, Tuple
+
+if not test_clang():
+    print(
+        """'generate_connection_wrapper_methods.py' skipped because of a Clang error.
+This is likely caused by not having, or not having the right version of 'libclang' installed.
+You can ignore this warning if you made no changes to Python code, it should not be ignored in CI.
+"""
+    )
+    exit(0)
 
 os.chdir(os.path.dirname(__file__))
 

--- a/tools/pythonpkg/scripts/get_cpp_methods.py
+++ b/tools/pythonpkg/scripts/get_cpp_methods.py
@@ -1,3 +1,4 @@
+# Requires `python3 -m pip install libclang==16.0.6`
 import clang.cindex
 import os
 

--- a/tools/pythonpkg/scripts/get_cpp_methods.py
+++ b/tools/pythonpkg/scripts/get_cpp_methods.py
@@ -54,6 +54,8 @@ class ConnectionMethod:
 
 
 def traverse(class_name, node, methods_dict):
+    import clang.cindex
+
     if node.kind == clang.cindex.CursorKind.STRUCT_DECL or node.kind == clang.cindex.CursorKind.CLASS_DECL:
         if node.spelling != class_name:
             return

--- a/tools/pythonpkg/scripts/get_cpp_methods.py
+++ b/tools/pythonpkg/scripts/get_cpp_methods.py
@@ -1,4 +1,4 @@
-# Requires `python3 -m pip install libclang==16.0.6`
+import clang.cindex
 import os
 
 from typing import List, Dict
@@ -8,31 +8,13 @@ scripts_folder = os.path.dirname(os.path.abspath(__file__))
 file_contents: str = ''
 
 
-def test_clang():
-    try:
-        import clang.cindex
-    except ImportError:
-        return False
-    from clang.cindex import TranslationUnitLoadError, Index
-
-    try:
-        index = Index.create()
-        path = get_path('DuckDBPyConnection')
-        index.parse(path, args=['-std=c++11'])
-    except TranslationUnitLoadError:
-        return False
-    return True
-
-
 def load_content(path):
     global file_contents
     with open(path, 'r') as file:
         file_contents = file.read()
 
 
-def get_string(input: "clang.cindex.SourceRange") -> str:
-    import clang.cindex
-
+def get_string(input: clang.cindex.SourceRange) -> str:
     return file_contents[input.start.offset : input.end.offset]
 
 
@@ -54,8 +36,6 @@ class ConnectionMethod:
 
 
 def traverse(class_name, node, methods_dict):
-    import clang.cindex
-
     if node.kind == clang.cindex.CursorKind.STRUCT_DECL or node.kind == clang.cindex.CursorKind.CLASS_DECL:
         if node.spelling != class_name:
             return
@@ -73,24 +53,17 @@ def traverse(class_name, node, methods_dict):
             traverse(class_name, child, methods_dict)
 
 
-def get_path(class_name: str) -> str:
+def get_methods(class_name: str) -> Dict[str, ConnectionMethod]:
     CLASSES = {
         'DuckDBPyConnection': os.path.join(
             scripts_folder, '..', 'src', 'include', 'duckdb_python', 'pyconnection', 'pyconnection.hpp'
         ),
         'DuckDBPyRelation': os.path.join(scripts_folder, '..', 'src', 'include', 'duckdb_python', 'pyrelation.hpp'),
     }
-    path = CLASSES[class_name]
-    return path
-
-
-def get_methods(class_name: str) -> Dict[str, ConnectionMethod]:
-    import clang.cindex
-
     # Create a dictionary to store method names and prototypes
     methods_dict = {}
 
-    path = get_path(class_name)
+    path = CLASSES[class_name]
     load_content(path)
 
     index = clang.cindex.Index.create()


### PR DESCRIPTION
For the python code gen we sadly require `libclang`, and it seems only `libclang 16.0.6` is working, I've made that more explicit in the code and also made it so that not having `libclang` or having the wrong version of `libclang` installed no longer constitutes an error, but just prints a warning.

Output contains:
```
Traceback (most recent call last):
  File "/Users/thijs/DuckDBLabs/duckdb/tools/pythonpkg/scripts/generate_connection_code.py", line 3, in <module>
    import generate_connection_wrapper_methods
  File "/Users/thijs/DuckDBLabs/duckdb/tools/pythonpkg/scripts/generate_connection_wrapper_methods.py", line 5, in <module>
    from get_cpp_methods import test_clang, get_methods, FunctionParam, ConnectionMethod
  File "/Users/thijs/DuckDBLabs/duckdb/tools/pythonpkg/scripts/get_cpp_methods.py", line 1, in <module>
    import clang.cindex
ModuleNotFoundError: No module named 'clang'
Warning: generate_connection_code.py failed, libclang==16.0.6 is required to perform this step
```

If `libclang` is not installed

If the wrong version is installed:
```
Traceback (most recent call last):
  File "/Users/thijs/DuckDBLabs/duckdb/tools/pythonpkg/scripts/generate_connection_code.py", line 3, in <module>
    import generate_connection_wrapper_methods
  File "/Users/thijs/DuckDBLabs/duckdb/tools/pythonpkg/scripts/generate_connection_wrapper_methods.py", line 5, in <module>
    from get_cpp_methods import test_clang, get_methods, FunctionParam, ConnectionMethod
ImportError: cannot import name 'test_clang' from 'get_cpp_methods' (/Users/thijs/DuckDBLabs/duckdb/tools/pythonpkg/scripts/get_cpp_methods.py)
Warning: generate_connection_code.py failed, libclang==16.0.6 is required to perform this step
```