### PR TITLE
add support for casting 'yes'/'no' strings to boolean values

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -928,11 +928,30 @@ bool TryCast::Operation(string_t input, bool &result, bool strict) {
 	switch (input_size) {
 	case 1: {
 		char c = UnsafeNumericCast<char>(std::tolower(*input_data));
-		if (c == 't' || (!strict && c == '1')) {
+		if (c == 't' || (!strict && c == 'y') || (!strict && c == '1')) {
 			result = true;
 			return true;
-		} else if (c == 'f' || (!strict && c == '0')) {
+		} else if (c == 'f' || (!strict && c == 'n') || (!strict && c == '0')) {
 			result = false;
+			return true;
+		}
+		return false;
+	}
+	case 2: {
+		char n = UnsafeNumericCast<char>(std::tolower(input_data[0]));
+		char o = UnsafeNumericCast<char>(std::tolower(input_data[1]));
+		if (n == 'n' && o == 'o') {
+			result = false;
+			return true;
+		}
+		return false;
+	}
+	case 3: {
+		char y = UnsafeNumericCast<char>(std::tolower(input_data[0]));
+		char e = UnsafeNumericCast<char>(std::tolower(input_data[1]));
+		char s = UnsafeNumericCast<char>(std::tolower(input_data[2]));
+		if (y == 'y' && e == 'e' && s == 's') {
+			result = true;
 			return true;
 		}
 		return false;

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -922,7 +922,7 @@ bool TryCast::Operation(double input, double &result, bool strict) {
 //===--------------------------------------------------------------------===//
 template <>
 bool TryCast::Operation(string_t input, bool &result, bool strict) {
-	auto input_data = reinterpret_cast<const uint8_t*>(input.GetData());
+	auto input_data = reinterpret_cast<const uint8_t *>(input.GetData());
 	auto input_size = input.GetSize();
 
 	switch (input_size) {

--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -922,12 +922,12 @@ bool TryCast::Operation(double input, double &result, bool strict) {
 //===--------------------------------------------------------------------===//
 template <>
 bool TryCast::Operation(string_t input, bool &result, bool strict) {
-	auto input_data = input.GetData();
+	auto input_data = reinterpret_cast<const uint8_t*>(input.GetData());
 	auto input_size = input.GetSize();
 
 	switch (input_size) {
 	case 1: {
-		char c = UnsafeNumericCast<char>(std::tolower(*input_data));
+		unsigned char c = UnsafeNumericCast<uint8_t>(std::tolower(*input_data));
 		if (c == 't' || (!strict && c == 'y') || (!strict && c == '1')) {
 			result = true;
 			return true;
@@ -938,8 +938,8 @@ bool TryCast::Operation(string_t input, bool &result, bool strict) {
 		return false;
 	}
 	case 2: {
-		char n = UnsafeNumericCast<char>(std::tolower(input_data[0]));
-		char o = UnsafeNumericCast<char>(std::tolower(input_data[1]));
+		unsigned char n = UnsafeNumericCast<uint8_t>(std::tolower(input_data[0]));
+		unsigned char o = UnsafeNumericCast<uint8_t>(std::tolower(input_data[1]));
 		if (n == 'n' && o == 'o') {
 			result = false;
 			return true;
@@ -947,9 +947,9 @@ bool TryCast::Operation(string_t input, bool &result, bool strict) {
 		return false;
 	}
 	case 3: {
-		char y = UnsafeNumericCast<char>(std::tolower(input_data[0]));
-		char e = UnsafeNumericCast<char>(std::tolower(input_data[1]));
-		char s = UnsafeNumericCast<char>(std::tolower(input_data[2]));
+		unsigned char y = UnsafeNumericCast<uint8_t>(std::tolower(input_data[0]));
+		unsigned char e = UnsafeNumericCast<uint8_t>(std::tolower(input_data[1]));
+		unsigned char s = UnsafeNumericCast<uint8_t>(std::tolower(input_data[2]));
 		if (y == 'y' && e == 'e' && s == 's') {
 			result = true;
 			return true;
@@ -957,10 +957,10 @@ bool TryCast::Operation(string_t input, bool &result, bool strict) {
 		return false;
 	}
 	case 4: {
-		char t = UnsafeNumericCast<char>(std::tolower(input_data[0]));
-		char r = UnsafeNumericCast<char>(std::tolower(input_data[1]));
-		char u = UnsafeNumericCast<char>(std::tolower(input_data[2]));
-		char e = UnsafeNumericCast<char>(std::tolower(input_data[3]));
+		unsigned char t = UnsafeNumericCast<uint8_t>(std::tolower(input_data[0]));
+		unsigned char r = UnsafeNumericCast<uint8_t>(std::tolower(input_data[1]));
+		unsigned char u = UnsafeNumericCast<uint8_t>(std::tolower(input_data[2]));
+		unsigned char e = UnsafeNumericCast<uint8_t>(std::tolower(input_data[3]));
 		if (t == 't' && r == 'r' && u == 'u' && e == 'e') {
 			result = true;
 			return true;
@@ -968,11 +968,11 @@ bool TryCast::Operation(string_t input, bool &result, bool strict) {
 		return false;
 	}
 	case 5: {
-		char f = UnsafeNumericCast<char>(std::tolower(input_data[0]));
-		char a = UnsafeNumericCast<char>(std::tolower(input_data[1]));
-		char l = UnsafeNumericCast<char>(std::tolower(input_data[2]));
-		char s = UnsafeNumericCast<char>(std::tolower(input_data[3]));
-		char e = UnsafeNumericCast<char>(std::tolower(input_data[4]));
+		unsigned char f = UnsafeNumericCast<uint8_t>(std::tolower(input_data[0]));
+		unsigned char a = UnsafeNumericCast<uint8_t>(std::tolower(input_data[1]));
+		unsigned char l = UnsafeNumericCast<uint8_t>(std::tolower(input_data[2]));
+		unsigned char s = UnsafeNumericCast<uint8_t>(std::tolower(input_data[3]));
+		unsigned char e = UnsafeNumericCast<uint8_t>(std::tolower(input_data[4]));
 		if (f == 'f' && a == 'a' && l == 'l' && s == 's' && e == 'e') {
 			result = false;
 			return true;

--- a/test/sql/cast/test_boolean_cast.test
+++ b/test/sql/cast/test_boolean_cast.test
@@ -15,6 +15,12 @@ SELECT CAST(1=0 AS VARCHAR)
 ----
 false
 
+
+query T
+SELECT CAST(12345 AS BOOLEAN)
+----
+true
+
 query T
 SELECT CAST('true' AS BOOLEAN)
 ----
@@ -27,6 +33,21 @@ SELECT CAST('t' AS BOOLEAN)
 
 query T
 SELECT CAST('TRUE' AS BOOLEAN)
+----
+1
+
+query T
+SELECT CAST('yes' AS BOOLEAN)
+----
+1
+
+query T
+SELECT CAST('YeS' AS BOOLEAN)
+----
+1
+
+query T
+SELECT CAST('y' AS BOOLEAN)
 ----
 1
 
@@ -45,9 +66,37 @@ SELECT CAST('FALSE' AS BOOLEAN)
 ----
 0
 
+query T
+SELECT CAST('no' AS BOOLEAN)
+----
+0
+
+query T
+SELECT CAST('nO' AS BOOLEAN)
+----
+0
+
+query T
+SELECT CAST('n' AS BOOLEAN)
+----
+0
+
 statement error
 SELECT CAST('12345' AS BOOLEAN)
 ----
+
+statement ok
+CREATE TABLE tbl AS SELECT 0 AS yes
+
+query T
+SELECT CAST(yes AS BOOLEAN) FROM tbl
+----
+0
+
+statement error
+SELECT CAST(yes AS BOOLEAN)
+----
+Binder Error: Referenced column "yes" not found in FROM clause!
 
 query T
 SELECT CAST(CAST('12345' AS INTEGER) AS BOOLEAN)


### PR DESCRIPTION
This PR adds support for casting the strings `'yes'` and `'no'` to boolean values (similar to PostgreSQL). It also resolves this [issue](https://github.com/duckdb/duckdb/issues/11925).