### PR TITLE
Small improvements to secret manager

### DIFF
--- a/extension/httpfs/create_secret_functions.cpp
+++ b/extension/httpfs/create_secret_functions.cpp
@@ -193,7 +193,6 @@ unique_ptr<BaseSecret> CreateBearerTokenFunctions::CreateBearerSecretFromConfig(
                                                                                 CreateSecretInput &input) {
 	string token;
 
-	auto token_input = input.options.find("token");
 	for (const auto &named_param : input.options) {
 		auto lower_name = StringUtil::Lower(named_param.first);
 		if (lower_name == "token") {
@@ -245,6 +244,12 @@ CreateBearerTokenFunctions::CreateHuggingFaceSecretFromCredentialChain(ClientCon
 
 	// Step 4: Check the default path
 	auto token = TryReadTokenFile("~/.cache/huggingface/token", "", false);
-	return CreateSecretFunctionInternal(context, input, token);
+
+	if (!token.empty()) {
+		return CreateSecretFunctionInternal(context, input, token);
+	}
+
+	// Return nullptr to indicate failure to automatically create a secret
+	return nullptr;
 }
 } // namespace duckdb

--- a/src/execution/operator/helper/physical_create_secret.cpp
+++ b/src/execution/operator/helper/physical_create_secret.cpp
@@ -10,10 +10,17 @@ SourceResultType PhysicalCreateSecret::GetData(ExecutionContext &context, DataCh
 	auto &client = context.client;
 	auto &secret_manager = SecretManager::Get(client);
 
-	secret_manager.CreateSecret(client, info);
+	auto result = secret_manager.CreateSecret(client, info);
 
-	chunk.SetValue(0, 0, true);
-	chunk.SetCardinality(1);
+	if (result) {
+		chunk.SetValue(0, 0, true);
+		chunk.SetValue(1, 0, result->secret->ToMapValueShort());
+		chunk.SetCardinality(1);
+	} else {
+		chunk.SetValue(0, 0, false);
+		chunk.SetValue(1, 0, Value());
+		chunk.SetCardinality(1);
+	}
 
 	return SourceResultType::FINISHED;
 }

--- a/src/function/table/system/duckdb_secrets.cpp
+++ b/src/function/table/system/duckdb_secrets.cpp
@@ -67,8 +67,8 @@ static unique_ptr<FunctionData> DuckDBSecretsBind(ClientContext &context, TableF
 	names.emplace_back("scope");
 	return_types.emplace_back(LogicalType::LIST(LogicalType::VARCHAR));
 
-	names.emplace_back("secret_string");
-	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("secret_map");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
 
 	return std::move(result);
 }
@@ -113,7 +113,7 @@ void DuckDBSecretsFunction(ClientContext &context, TableFunctionInput &data_p, D
 		output.SetValue(3, count, Value(secret_entry.persist_type == SecretPersistType::PERSISTENT));
 		output.SetValue(4, count, Value(secret_entry.storage_mode));
 		output.SetValue(5, count, Value::LIST(LogicalType::VARCHAR, scope_value));
-		output.SetValue(6, count, secret.ToString(bind_data.redact));
+		output.SetValue(6, count, secret.ToMapValue(bind_data.redact));
 
 		data.offset++;
 		count++;

--- a/src/include/duckdb/execution/operator/helper/physical_create_secret.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_create_secret.hpp
@@ -20,7 +20,9 @@ public:
 
 public:
 	PhysicalCreateSecret(CreateSecretInfo info_p, idx_t estimated_cardinality)
-	    : PhysicalOperator(PhysicalOperatorType::CREATE_SECRET, {LogicalType::BOOLEAN}, estimated_cardinality),
+	    : PhysicalOperator(PhysicalOperatorType::CREATE_SECRET,
+	                       {LogicalType::BOOLEAN, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)},
+	                       estimated_cardinality),
 	      info(std::move(info_p)) {
 	}
 

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -100,6 +100,10 @@ public:
 	virtual int64_t MatchScore(const string &path) const;
 	//! Prints the secret as a string
 	virtual string ToString(SecretDisplayType mode = SecretDisplayType::REDACTED) const;
+	//! Returns the secret as a Map Value. Used in printing the secret
+	virtual Value ToMapValue(SecretDisplayType mode = SecretDisplayType::REDACTED) const;
+	//! Returns a shortened version of the Map value, to print to screen on secret creation
+	virtual Value ToMapValueShort(SecretDisplayType mode = SecretDisplayType::REDACTED) const;
 	//! Serialize this secret
 	virtual void Serialize(Serializer &serializer) const;
 
@@ -168,9 +172,11 @@ public:
 		redact_keys = std::move(secret.redact_keys);
 		serializable = true;
 	};
+	//! Returns the secret as a Map Value. Used in printing the secret
+	Value ToMapValue(SecretDisplayType mode = SecretDisplayType::REDACTED) const override;
+	//! Returns a shortened version of the Map value, to print to screen on secret creation
+	Value ToMapValueShort(SecretDisplayType mode = SecretDisplayType::REDACTED) const override;
 
-	//! Print the secret as a key value map in the format 'key1=value;key2=value2'
-	string ToString(SecretDisplayType mode = SecretDisplayType::REDACTED) const override;
 	void Serialize(Serializer &serializer) const override;
 
 	//! Tries to get the value at key <key>, depending on error_on_missing will throw or return Value()

--- a/src/include/duckdb/planner/operator/logical_create_secret.hpp
+++ b/src/include/duckdb/planner/operator/logical_create_secret.hpp
@@ -38,6 +38,10 @@ public:
 protected:
 	void ResolveTypes() override {
 		types.emplace_back(LogicalType::BOOLEAN);
+		types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	}
+	vector<ColumnBinding> GetColumnBindings() override {
+		return {ColumnBinding(0, 0), ColumnBinding(0, 1)};
 	}
 };
 } // namespace duckdb

--- a/src/main/secret/secret.cpp
+++ b/src/main/secret/secret.cpp
@@ -30,40 +30,91 @@ void BaseSecret::SerializeBaseSecret(Serializer &serializer) const {
 }
 
 string BaseSecret::ToString(SecretDisplayType display_type) const {
-	return "";
+	return ToMapValue().ToString();
+}
+
+Value BaseSecret::ToMapValue(SecretDisplayType display_type) const {
+	return Value();
+}
+
+Value BaseSecret::ToMapValueShort(SecretDisplayType display_type) const {
+	return Value();
 }
 
 void BaseSecret::Serialize(Serializer &serializer) const {
 	throw InternalException("Attempted to serialize secret without serialize");
 }
 
-string KeyValueSecret::ToString(SecretDisplayType mode) const {
-	string result;
+Value KeyValueSecret::ToMapValue(SecretDisplayType mode) const {
+	vector<Value> keys;
+	vector<Value> values;
 
-	result += "name=" + name + ";";
-	result += "type=" + type + ";";
-	result += "provider=" + provider + ";";
-	result += string("serializable=") + (serializable ? "true" : "false") + ";";
-	result += "scope=";
+	// Name
+	keys.push_back("name");
+	values.push_back(name);
+
+	// Type
+	keys.push_back("type");
+	values.push_back(type);
+
+	// Provider
+	keys.push_back("provider");
+	values.push_back(provider);
+
+	// Serializable
+	keys.push_back("serializable");
+	values.push_back((serializable ? "true" : "false"));
+
+	// Scope
+	keys.push_back("scope");
+	string scope_string;
 	for (const auto &scope_it : prefix_paths) {
-		result += scope_it + ",";
+		scope_string += scope_it + ",";
 	}
-	result = result.substr(0, result.size() - 1);
-	result += ";";
+	scope_string = scope_string.substr(0, scope_string.size() - 1);
+	values.push_back(scope_string);
+
+	// Contents of secret_map
 	for (auto it = secret_map.begin(); it != secret_map.end(); it++) {
-		result.append(it->first);
-		result.append("=");
+		keys.push_back(it->first);
 		if (mode == SecretDisplayType::REDACTED && redact_keys.find(it->first) != redact_keys.end()) {
-			result.append("redacted");
+			values.push_back("redacted");
 		} else {
-			result.append(it->second.ToString());
-		}
-		if (it != --secret_map.end()) {
-			result.append(";");
+			values.push_back(it->second.ToString());
 		}
 	}
 
-	return result;
+	return Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, keys, values);
+}
+
+Value KeyValueSecret::ToMapValueShort(SecretDisplayType mode) const {
+	vector<Value> keys;
+	vector<Value> values;
+
+	// Name
+	keys.push_back("name");
+	values.push_back(name);
+
+	// Types
+	keys.push_back("type");
+	values.push_back(type);
+
+	// Contents of secret_map
+	for (auto it = secret_map.begin(); it != secret_map.end(); it++) {
+		// We only print keys that have a value to print in the short version
+		if (it->second.ToString().empty()) {
+			continue;
+		}
+
+		keys.push_back(it->first);
+		if (mode == SecretDisplayType::REDACTED && redact_keys.find(it->first) != redact_keys.end()) {
+			values.push_back("redacted");
+		} else {
+			values.push_back(it->second.ToString());
+		}
+	}
+
+	return Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, keys, values);
 }
 
 // FIXME: use serialization scripts

--- a/src/main/secret/secret.cpp
+++ b/src/main/secret/secret.cpp
@@ -91,14 +91,6 @@ Value KeyValueSecret::ToMapValueShort(SecretDisplayType mode) const {
 	vector<Value> keys;
 	vector<Value> values;
 
-	// Name
-	keys.push_back("name");
-	values.push_back(name);
-
-	// Types
-	keys.push_back("type");
-	values.push_back(type);
-
 	// Contents of secret_map
 	for (auto it = secret_map.begin(); it != secret_map.end(); it++) {
 		// We only print keys that have a value to print in the short version

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -230,8 +230,7 @@ unique_ptr<SecretEntry> SecretManager::CreateSecret(ClientContext &context, cons
 	auto secret = function_lookup->function(context, function_input);
 
 	if (!secret) {
-		throw InternalException("CreateSecretFunction for type: '%s' and provider: '%s' did not return a secret!",
-		                        info.type, info.provider);
+		return nullptr;
 	}
 
 	// Register the secret at the secret_manager
@@ -283,8 +282,8 @@ BoundStatement SecretManager::BindCreateSecret(CatalogTransaction transaction, C
 	}
 
 	BoundStatement result;
-	result.names = {"Success"};
-	result.types = {LogicalType::BOOLEAN};
+	result.names = {"Success", "Secret"};
+	result.types = {LogicalType::BOOLEAN, LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR)};
 	result.plan = make_uniq<LogicalCreateSecret>(std::move(bound_info));
 	return result;
 }

--- a/test/sql/secrets/create_secret_hffs.test
+++ b/test/sql/secrets/create_secret_hffs.test
@@ -31,9 +31,9 @@ CREATE SECRET hf2 (
     PROVIDER 'credential_chain'
 )
 
+# Note that we skip the hf2 secret here: it might have been created or not, depending on the current environment 
 query IIII
-SELECT name, type, provider, scope FROM duckdb_secrets() order by name;
+SELECT name, type, provider, scope FROM duckdb_secrets() where name != 'hf2' order by name;
 ----
 b1	bearer	config	[]
 hf1	huggingface	config	[hf://]
-hf2	huggingface	credential_chain	[hf://]

--- a/test/sql/secrets/create_secret_s3_duckdb_settings.test_slow
+++ b/test/sql/secrets/create_secret_s3_duckdb_settings.test_slow
@@ -96,14 +96,13 @@ scoped_secret_3	s3	[s3://bucket2/this/path/takes/other/creds/]
 # Check the endpoints are actually set
 # secrets of type x
 query I
-select
-    list_filter(split(secret_string,';'), x -> starts_with(x, 'endpoint'))[1]
+select secret_map['endpoint']
 from duckdb_secrets() order by name;
 ----
-endpoint=global-invalid-domain
-endpoint=bucket1-invalid-domain
-endpoint=bucket2-invalid-domain
-endpoint=bucket2-path-invalid-domain
+[global-invalid-domain]
+[bucket1-invalid-domain]
+[bucket2-invalid-domain]
+[bucket2-path-invalid-domain]
 
 # Note: the settings from the provider can still be overridden
 statement ok
@@ -121,8 +120,7 @@ CREATE SECRET overridden_region_secret (
 )
 
 query I
-select
-    list_filter(split(secret_string,';'), x -> starts_with(x, 'region'))[1]
+select secret_map['region']
 from duckdb_secrets() where name='overridden_region_secret';
 ----
-region=overridden-region
+[overridden-region]

--- a/test/sql/secrets/create_secret_s3_serialization.test
+++ b/test/sql/secrets/create_secret_s3_serialization.test
@@ -65,7 +65,7 @@ s3	gcs	config	[s3://my_gcs_scope]
 
 # Note: this query prints the tokens as an unredacted string
 query I nosort secret_to_string
-select secret_string from duckdb_secrets(redact=false) order by type;
+select secret_map from duckdb_secrets(redact=false) order by type;
 ----
 
 restart
@@ -95,5 +95,5 @@ s3	gcs	config	[s3://my_gcs_scope]
 
 # Note: this query prints the tokens as an unredacted string
 query I nosort secret_to_string
-select secret_string from duckdb_secrets(redact=false) order by type;
+select secret_map from duckdb_secrets(redact=false) order by type;
 ----

--- a/test/sql/secrets/create_secret_storage_backends.test
+++ b/test/sql/secrets/create_secret_storage_backends.test
@@ -55,7 +55,7 @@ statement ok
 CREATE SECRET temp_s2 ( TYPE s3 );
 
 query IIIIII
-SELECT * EXCLUDE (secret_string) FROM duckdb_secrets() ORDER BY name
+SELECT * EXCLUDE (secret_map) FROM duckdb_secrets() ORDER BY name
 ----
 perm_s1	s3	config	true	local_file	[s3://, s3n://, s3a://]
 perm_s2	s3	config	true	local_file	[s3://, s3n://, s3a://]
@@ -93,7 +93,7 @@ statement ok
 CREATE PERSISTENT SECRET s2 ( TYPE S3 )
 
 query IIIIII
-SELECT * EXCLUDE (secret_string) FROM duckdb_secrets() ORDER BY name
+SELECT * EXCLUDE (secret_map) FROM duckdb_secrets() ORDER BY name
 ----
 perm_s1	s3	config	true	local_file	[s3://, s3n://, s3a://]
 perm_s2	s3	config	true	local_file	[s3://, s3n://, s3a://]


### PR DESCRIPTION
- secret providers can now return a nullptr to indicate secret creation failed
- `secret_string` field in `duckdb_secret()` is now `secret_map` of type `MAP(VARCHAR, VARCHAR)`
- secret contents (in redacted form) are now printed on secret creation to better communicate to user what secret has been created: especially for `credential_chain` providers this is helpful.