### PR TITLE
[Python] Skip the PandasAnalyzer if dtype is `'string'`

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_type.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_type.hpp
@@ -42,6 +42,7 @@ enum class NumpyNullableType : uint8_t {
 	//! Extension Types
 	//! ------------------------------------------------------------
 	CATEGORY, //! category
+	STRING,   //! string
 };
 
 struct NumpyType {

--- a/tools/pythonpkg/src/numpy/numpy_bind.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_bind.cpp
@@ -36,8 +36,7 @@ void NumpyBind::Bind(const ClientContext &context, py::handle df, vector<PandasC
 			bind_data.pandas_col = make_uniq<PandasNumpyColumn>(py::array(column.attr("astype")("float32")));
 			bind_data.numpy_type.type = NumpyNullableType::FLOAT_32;
 			duckdb_col_type = NumpyToLogicalType(bind_data.numpy_type);
-		} else if (bind_data.numpy_type.type == NumpyNullableType::OBJECT &&
-		           string(py::str(df_types[col_idx])) == "string") {
+		} else if (bind_data.numpy_type.type == NumpyNullableType::STRING) {
 			bind_data.numpy_type.type = NumpyNullableType::CATEGORY;
 			// here we call numpy.unique
 			// this function call will return the unique values of a given array

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -340,7 +340,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 
 			// Get the pointer to the object
 			PyObject *val = src_ptr[source_idx];
-			if (bind_data.numpy_type.type == NumpyNullableType::OBJECT && !py::isinstance<py::str>(val)) {
+			if (!py::isinstance<py::str>(val)) {
 				if (val == Py_None) {
 					out_mask.SetInvalid(row);
 					continue;

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -317,11 +317,13 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 		}
 		break;
 	}
+	case NumpyNullableType::STRING:
 	case NumpyNullableType::OBJECT: {
-		//! We have determined the underlying logical type of this object column
 		// Get the source pointer of the numpy array
 		auto src_ptr = (PyObject **)array.data(); // NOLINT
-		if (out.GetType().id() != LogicalTypeId::VARCHAR) {
+		const bool is_object_col = bind_data.numpy_type.type == NumpyNullableType::OBJECT;
+		if (is_object_col && out.GetType().id() != LogicalTypeId::VARCHAR) {
+			//! We have determined the underlying logical type of this object column
 			return NumpyScan::ScanObjectColumn(src_ptr, numpy_col.stride, count, offset, out);
 		}
 

--- a/tools/pythonpkg/src/numpy/type.cpp
+++ b/tools/pythonpkg/src/numpy/type.cpp
@@ -55,6 +55,9 @@ static NumpyNullableType ConvertNumpyTypeInternal(const string &col_type_str) {
 	if (col_type_str == "float64" || col_type_str == "Float64") {
 		return NumpyNullableType::FLOAT_64;
 	}
+	if (col_type_str == "string") {
+		return NumpyNullableType::STRING;
+	}
 	if (col_type_str == "object" || col_type_str == "string") {
 		//! this better be castable to strings
 		return NumpyNullableType::OBJECT;
@@ -134,6 +137,8 @@ LogicalType NumpyToLogicalType(const NumpyType &col_type) {
 		return LogicalType::FLOAT;
 	case NumpyNullableType::FLOAT_64:
 		return LogicalType::DOUBLE;
+	case NumpyNullableType::STRING:
+		return LogicalType::VARCHAR;
 	case NumpyNullableType::OBJECT:
 		return LogicalType::VARCHAR;
 	case NumpyNullableType::TIMEDELTA:

--- a/tools/pythonpkg/src/numpy/type.cpp
+++ b/tools/pythonpkg/src/numpy/type.cpp
@@ -58,8 +58,7 @@ static NumpyNullableType ConvertNumpyTypeInternal(const string &col_type_str) {
 	if (col_type_str == "string") {
 		return NumpyNullableType::STRING;
 	}
-	if (col_type_str == "object" || col_type_str == "string") {
-		//! this better be castable to strings
+	if (col_type_str == "object") {
 		return NumpyNullableType::OBJECT;
 	}
 	if (col_type_str == "timedelta64[ns]") {

--- a/tools/pythonpkg/src/pandas/analyzer.cpp
+++ b/tools/pythonpkg/src/pandas/analyzer.cpp
@@ -518,9 +518,6 @@ bool PandasAnalyzer::Analyze(py::object column) {
 			type = GetItemType(obj, can_convert);
 		}
 	}
-	if (type == LogicalType::SQLNULL) {
-		type = LogicalType(LogicalTypeId::VARCHAR);
-	}
 	if (can_convert) {
 		analyzed_type = type;
 	}

--- a/tools/pythonpkg/src/pandas/analyzer.cpp
+++ b/tools/pythonpkg/src/pandas/analyzer.cpp
@@ -518,6 +518,9 @@ bool PandasAnalyzer::Analyze(py::object column) {
 			type = GetItemType(obj, can_convert);
 		}
 	}
+	if (type == LogicalType::SQLNULL) {
+		type = LogicalType(LogicalTypeId::VARCHAR);
+	}
 	if (can_convert) {
 		analyzed_type = type;
 	}

--- a/tools/pythonpkg/src/pandas/scan.cpp
+++ b/tools/pythonpkg/src/pandas/scan.cpp
@@ -95,9 +95,12 @@ unique_ptr<FunctionData> PandasScanFunction::PandasScanBind(ClientContext &conte
 
 	shared_ptr<DependencyItem> dependency_item;
 	if (ref.external_dependency) {
-		// This was created during the replacement scan (see python_replacement_scan.cpp)
+		// This was created during the replacement scan if this was a pandas DataFrame (see python_replacement_scan.cpp)
 		dependency_item = ref.external_dependency->GetDependency("copy");
-		D_ASSERT(dependency_item);
+		if (!dependency_item) {
+			// This was created during the replacement if this was a numpy scan
+			dependency_item = ref.external_dependency->GetDependency("data");
+		}
 	}
 
 	auto get_fun = df.attr("__getitem__");

--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_na.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_na.py
@@ -2,6 +2,7 @@ import numpy as np
 import datetime
 import duckdb
 import pytest
+from conftest import NumpyPandas, ArrowPandas
 
 
 def assert_nullness(items, null_indices):
@@ -13,6 +14,18 @@ def assert_nullness(items, null_indices):
 
 
 class TestPandasNA(object):
+    @pytest.mark.parametrize('rows', [100, duckdb.__standard_vector_size__, 5000, 1000000])
+    @pytest.mark.parametrize('pd', [NumpyPandas(), ArrowPandas()])
+    def test_pandas_string_null(self, duckdb_cursor, rows, pd):
+        df: pd.DataFrame = pd.DataFrame(index=np.arange(rows))
+        df["string_column"] = pd.Series(dtype="string")
+        e_df_rel = duckdb_cursor.from_df(df)
+        assert e_df_rel.types == ['VARCHAR']
+        roundtrip = e_df_rel.df()
+        assert roundtrip['string_column'].dtype == 'object'
+        expected = pd.DataFrame({'string_column': [None for _ in range(rows)]})
+        pd.testing.assert_frame_equal(expected, roundtrip)
+
     def test_pandas_na(self, duckdb_cursor):
         pd = pytest.importorskip('pandas', minversion='1.0.0', reason='Support for pandas.NA has not been added yet')
         # DataFrame containing a single pd.NA


### PR DESCRIPTION
This PR fixes #12507 

To explain why this is not fixable for `object`:
`object` can be *anything*, so we analyze it to figure out what it actually is.
If we only encounter NULL, we return the SQLNULL type, the binder is not a huge fan of that so it turns it into INTEGER.
That is what gets shown with `DuckDBPyRelation.types`.

When turning this back into a DataFrame (calling `.df()` on the created DuckDBPyRelation), we are dealing with an INTEGER column, with all nulls.
This creates a `np.ma.array` with everything masked.
Pandas decides to convert that into a column containing NaN with `float64` as dtype