### PR TITLE
[Python] Remove busy-spin during execution

### DIFF
--- a/src/include/duckdb/main/pending_query_result.hpp
+++ b/src/include/duckdb/main/pending_query_result.hpp
@@ -40,6 +40,8 @@ public:
 	//! The error message can be obtained by calling GetError() on the PendingQueryResult.
 	DUCKDB_API PendingExecutionResult ExecuteTask();
 	DUCKDB_API PendingExecutionResult CheckPulse();
+	//! Halt execution of the thread until a Task is ready to be executed (use with caution)
+	void WaitForTask();
 
 	//! Returns the result of the query as an actual query result.
 	//! This returns (mostly) instantly if ExecuteTask has been called until RESULT_READY was returned.

--- a/src/main/pending_query_result.cpp
+++ b/src/main/pending_query_result.cpp
@@ -74,8 +74,7 @@ unique_ptr<QueryResult> PendingQueryResult::ExecuteInternal(ClientContextLock &l
 	const auto is_finished = allow_stream_result ? IsFinishedOrBlocked : IsFinished;
 	PendingExecutionResult execution_result;
 	while (!is_finished(execution_result = ExecuteTaskInternal(lock))) {
-		if (execution_result == PendingExecutionResult::BLOCKED ||
-		    execution_result == PendingExecutionResult::NO_TASKS_AVAILABLE) {
+		if (execution_result == PendingExecutionResult::BLOCKED) {
 			CheckExecutableInternal(lock);
 			context->WaitForTask(lock, *this);
 		}

--- a/src/main/pending_query_result.cpp
+++ b/src/main/pending_query_result.cpp
@@ -43,6 +43,11 @@ void PendingQueryResult::CheckExecutableInternal(ClientContextLock &lock) {
 	}
 }
 
+void PendingQueryResult::WaitForTask() {
+	auto lock = LockContext();
+	context->WaitForTask(*lock, *this);
+}
+
 PendingExecutionResult PendingQueryResult::ExecuteTask() {
 	auto lock = LockContext();
 	return ExecuteTaskInternal(*lock);

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -481,8 +481,7 @@ unique_ptr<QueryResult> DuckDBPyConnection::CompletePendingQuery(PendingQueryRes
 				throw std::runtime_error("Query interrupted");
 			}
 		}
-		if (execution_result == PendingExecutionResult::BLOCKED ||
-		    execution_result == PendingExecutionResult::NO_TASKS_AVAILABLE) {
+		if (execution_result == PendingExecutionResult::BLOCKED) {
 			pending_query.WaitForTask();
 		}
 	}


### PR DESCRIPTION
This PR is a continuation of #12483 

Because the Python client needs to perform a python-related interrupt signal after every `ExecuteTask` call it has a copy of the `PendingQueryResult::ExecuteInternal` logic, which also suffered from the same busy-spin issue.