### PR TITLE
Fix duckdb/duckdb#12467 changes to covariance calculation

### DIFF
--- a/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/covar.hpp
@@ -53,16 +53,19 @@ struct CovarOperation {
 		if (target.count == 0) {
 			target = source;
 		} else if (source.count > 0) {
+			const auto count = target.count + source.count;
+			D_ASSERT(count >= target.count); // This is a check that we are not overflowing
 			const auto target_count = static_cast<double>(target.count);
 			const auto source_count = static_cast<double>(source.count);
-			const auto count = static_cast<double>(target_count + source.count);
-			const auto meanx = (source_count * source.meanx + target_count * target.meanx) / count;
-			const auto meany = (source_count * source.meany + target_count * target.meany) / count;
+			const auto total_count = static_cast<double>(count);
+			const auto meanx = (source_count * source.meanx + target_count * target.meanx) / total_count;
+			const auto meany = (source_count * source.meany + target_count * target.meany) / total_count;
 
 			//  Schubert and Gertz SSDBM 2018, equation 21
 			const auto deltax = target.meanx - source.meanx;
 			const auto deltay = target.meany - source.meany;
-			target.co_moment = source.co_moment + target.co_moment + deltax * deltay * static_cast<double>(source.count * target.count) / count;
+			target.co_moment =
+			    source.co_moment + target.co_moment + deltax * deltay * source_count * target_count / total_count;
 			target.meanx = meanx;
 			target.meany = meany;
 			target.count = count;


### PR DESCRIPTION
Problem is that:
```
uint64_t a = ... ;
uint64_t b = ... ;
uint64_t sum = a+b;
uint64_t sum_via_double = (double)a + (double)b;
```
are not necessary the same, and this might lead to loss of precision.

This fixes also a problem detected by OSX nightly CI, where an error:
```
error: implicit conversion turns floating-point number into integer: 'const double' to 'uint64_t' (aka 'unsigned long long') [-Werror,-Wfloat-conversion]
```
would otherwise be thrown.