### PR TITLE
More formatting and fix to stddev

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -108,8 +108,6 @@ ignored_directories = [
     os.path.join('extension', 'tpcds', 'dsdgen'),
     os.path.join('extension', 'jemalloc', 'jemalloc'),
     os.path.join('extension', 'icu', 'third_party'),
-    os.path.join('src', 'include', 'duckdb', 'core_functions', 'aggregate'),
-    os.path.join('src', 'include', 'duckdb', 'core_functions', 'scalar'),
     os.path.join('tools', 'nodejs', 'src', 'duckdb'),
 ]
 format_all = False

--- a/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
@@ -60,15 +60,17 @@ struct STDDevBaseOperation {
 		if (target.count == 0) {
 			target = source;
 		} else if (source.count > 0) {
+			const auto count = target.count + source.count;
+			D_ASSERT(count >= target.count); // This is a check that we are not overflowing
 			const double target_count = static_cast<double>(target.count);
 			const double source_count = static_cast<double>(source.count);
-			const auto count = target_count + source_count;
-			const auto mean = (source_count * source.mean + target_count * target.mean) / count;
+			const double total_count = static_cast<double>(count);
+			const auto mean = (source_count * source.mean + target_count * target.mean) / total_count;
 			const auto delta = source.mean - target.mean;
-			target.dsquared = source.dsquared + target.dsquared +
-			                  delta * delta * static_cast<double>(source.count * target.count) / count;
+			target.dsquared =
+			    source.dsquared + target.dsquared + delta * delta * source_count * target_count / total_count;
 			target.mean = mean;
-			target.count = static_cast<decltype(target.count)>(count);
+			target.count = count;
 		}
 	}
 

--- a/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/stddev.hpp
@@ -40,7 +40,6 @@ struct STDDevBaseOperation {
 
 		state.mean = new_mean;
 		state.dsquared = new_dsquared;
-		
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
@@ -49,7 +48,8 @@ struct STDDevBaseOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE, class OP>
-	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input, idx_t count) {
+	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
+	                              idx_t count) {
 		for (idx_t i = 0; i < count; i++) {
 			Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
 		}
@@ -65,7 +65,8 @@ struct STDDevBaseOperation {
 			const auto count = target_count + source_count;
 			const auto mean = (source_count * source.mean + target_count * target.mean) / count;
 			const auto delta = source.mean - target.mean;
-			target.dsquared = source.dsquared + target.dsquared + delta * delta * static_cast<double>(source.count * target.count) / count;
+			target.dsquared = source.dsquared + target.dsquared +
+			                  delta * delta * static_cast<double>(source.count * target.count) / count;
 			target.mean = mean;
 			target.count = static_cast<decltype(target.count)>(count);
 		}

--- a/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
+++ b/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
@@ -26,7 +26,7 @@ struct RegrSlopeOperation {
 
 	template <class A_TYPE, class B_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const A_TYPE &y, const B_TYPE &x, AggregateBinaryInput &idata) {
-		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, y, x,idata);
+		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(state.cov_pop, y, x, idata);
 		STDDevBaseOperation::Execute<A_TYPE, StddevState>(state.var_pop, x);
 	}
 


### PR DESCRIPTION
Connected to https://github.com/duckdb/duckdb/pull/12515, fixing a similar problem and enabling format-fix to run also on headers files for core_functions.

Formatting failure on covariance is handled as part of https://github.com/duckdb/duckdb/pull/12515, so that CI failure is expected, and has not be handled to avoid conflicts between PRs.