### PR TITLE
[Python] Fix reading strided `datetime` and `timedelta` columns

### DIFF
--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -197,6 +197,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 	D_ASSERT(bind_data.pandas_col->Backend() == PandasColumnBackend::NUMPY);
 	auto &numpy_col = reinterpret_cast<PandasNumpyColumn &>(*bind_data.pandas_col);
 	auto &array = numpy_col.array;
+	auto stride = numpy_col.stride;
 
 	switch (bind_data.numpy_type.type) {
 	case NumpyNullableType::BOOL:
@@ -276,12 +277,13 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 		};
 
 		for (idx_t row = 0; row < count; row++) {
-			auto source_idx = offset + row;
+			auto source_idx = stride / sizeof(int64_t) * (row + offset);
 			if (src_ptr[source_idx] <= NumericLimits<int64_t>::Minimum()) {
 				// pandas Not a Time (NaT)
 				mask.SetInvalid(row);
 				continue;
 			}
+
 			// Direct conversion, we've already matched the numpy type with the equivalent duckdb type
 			auto input = timestamp_t(src_ptr[source_idx]);
 			if (Timestamp::IsFinite(input)) {
@@ -298,7 +300,7 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 		auto &mask = FlatVector::Validity(out);
 
 		for (idx_t row = 0; row < count; row++) {
-			auto source_idx = offset + row;
+			auto source_idx = stride / sizeof(int64_t) * (row + offset);
 			if (src_ptr[source_idx] <= NumericLimits<int64_t>::Minimum()) {
 				// pandas Not a Time (NaT)
 				mask.SetInvalid(row);

--- a/tools/pythonpkg/tests/fast/pandas/test_stride.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_stride.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import duckdb
 import numpy as np
+import datetime
 
 
 class TestPandasStride(object):
@@ -19,6 +20,42 @@ class TestPandasStride(object):
         for col in output_df.columns:
             assert str(output_df[col].dtype) == 'float32'
         pd.testing.assert_frame_equal(expected_df, output_df)
+
+    def test_stride_datetime(self, duckdb_cursor):
+        df = pd.DataFrame({'date': pd.Series(pd.date_range("2024-01-01", freq="D", periods=100))})
+        df = df.loc[::23,]
+
+        roundtrip = duckdb_cursor.sql("select * from df").df()
+        expected = pd.DataFrame(
+            {
+                'date': [
+                    datetime.datetime(2024, 1, 1),
+                    datetime.datetime(2024, 1, 24),
+                    datetime.datetime(2024, 2, 16),
+                    datetime.datetime(2024, 3, 10),
+                    datetime.datetime(2024, 4, 2),
+                ]
+            }
+        )
+        pd.testing.assert_frame_equal(roundtrip, expected)
+
+    def test_stride_timedelta(self, duckdb_cursor):
+        df = pd.DataFrame({'date': [datetime.timedelta(days=i) for i in range(100)]})
+        df = df.loc[::23,]
+
+        roundtrip = duckdb_cursor.sql("select * from df").df()
+        expected = pd.DataFrame(
+            {
+                'date': [
+                    datetime.timedelta(days=0),
+                    datetime.timedelta(days=23),
+                    datetime.timedelta(days=46),
+                    datetime.timedelta(days=69),
+                    datetime.timedelta(days=92),
+                ]
+            }
+        )
+        pd.testing.assert_frame_equal(roundtrip, expected)
 
     def test_stride_fp64(self, duckdb_cursor):
         expected_df = pd.DataFrame(np.arange(20, dtype='float64').reshape(5, 4), columns=["a", "b", "c", "d"])


### PR DESCRIPTION
This PR fixes #12513 

The stride of the column was being ignored, added tests to make sure that won't break in the future