### PR TITLE
Add method for decoding sort keys, and use this in min/max for arbitrary types

### DIFF
--- a/src/common/types/blob.cpp
+++ b/src/common/types/blob.cpp
@@ -77,15 +77,14 @@ bool Blob::TryGetBlobSize(string_t str, idx_t &str_len, CastParameters &paramete
 	for (idx_t i = 0; i < len; i++) {
 		if (data[i] == '\\') {
 			if (i + 3 >= len) {
-				string error = "Invalid hex escape code encountered in string -> blob conversion: "
-				               "unterminated escape code at end of blob";
+				string error = StringUtil::Format("Invalid hex escape code encountered in string -> blob conversion of string \"%s\": unterminated escape code at end of blob", str.GetString());
 				HandleCastError::AssignError(error, parameters);
 				return false;
 			}
 			if (data[i + 1] != 'x' || Blob::HEX_MAP[data[i + 2]] < 0 || Blob::HEX_MAP[data[i + 3]] < 0) {
 				string error =
-				    StringUtil::Format("Invalid hex escape code encountered in string -> blob conversion: %s",
-				                       string(const_char_ptr_cast(data) + i, 4));
+				    StringUtil::Format("Invalid hex escape code encountered in string -> blob conversion of string \"%s\": %s",
+				                       str.GetString(), string(const_char_ptr_cast(data) + i, 4));
 				HandleCastError::AssignError(error, parameters);
 				return false;
 			}
@@ -94,8 +93,8 @@ bool Blob::TryGetBlobSize(string_t str, idx_t &str_len, CastParameters &paramete
 		} else if (data[i] <= 127) {
 			str_len++;
 		} else {
-			string error = "Invalid byte encountered in STRING -> BLOB conversion. All non-ascii characters "
-			               "must be escaped with hex codes (e.g. \\xAA)";
+			string error = StringUtil::Format("Invalid byte encountered in STRING -> BLOB conversion of string \"%s\". All non-ascii characters "
+			               "must be escaped with hex codes (e.g. \\xAA)", str.GetString());
 			HandleCastError::AssignError(error, parameters);
 			return false;
 		}

--- a/src/common/types/blob.cpp
+++ b/src/common/types/blob.cpp
@@ -77,14 +77,16 @@ bool Blob::TryGetBlobSize(string_t str, idx_t &str_len, CastParameters &paramete
 	for (idx_t i = 0; i < len; i++) {
 		if (data[i] == '\\') {
 			if (i + 3 >= len) {
-				string error = StringUtil::Format("Invalid hex escape code encountered in string -> blob conversion of string \"%s\": unterminated escape code at end of blob", str.GetString());
+				string error = StringUtil::Format("Invalid hex escape code encountered in string -> blob conversion of "
+				                                  "string \"%s\": unterminated escape code at end of blob",
+				                                  str.GetString());
 				HandleCastError::AssignError(error, parameters);
 				return false;
 			}
 			if (data[i + 1] != 'x' || Blob::HEX_MAP[data[i + 2]] < 0 || Blob::HEX_MAP[data[i + 3]] < 0) {
-				string error =
-				    StringUtil::Format("Invalid hex escape code encountered in string -> blob conversion of string \"%s\": %s",
-				                       str.GetString(), string(const_char_ptr_cast(data) + i, 4));
+				string error = StringUtil::Format(
+				    "Invalid hex escape code encountered in string -> blob conversion of string \"%s\": %s",
+				    str.GetString(), string(const_char_ptr_cast(data) + i, 4));
 				HandleCastError::AssignError(error, parameters);
 				return false;
 			}
@@ -93,8 +95,10 @@ bool Blob::TryGetBlobSize(string_t str, idx_t &str_len, CastParameters &paramete
 		} else if (data[i] <= 127) {
 			str_len++;
 		} else {
-			string error = StringUtil::Format("Invalid byte encountered in STRING -> BLOB conversion of string \"%s\". All non-ascii characters "
-			               "must be escaped with hex codes (e.g. \\xAA)", str.GetString());
+			string error = StringUtil::Format(
+			    "Invalid byte encountered in STRING -> BLOB conversion of string \"%s\". All non-ascii characters "
+			    "must be escaped with hex codes (e.g. \\xAA)",
+			    str.GetString());
 			HandleCastError::AssignError(error, parameters);
 			return false;
 		}

--- a/src/core_functions/aggregate/distributive/minmax.cpp
+++ b/src/core_functions/aggregate/distributive/minmax.cpp
@@ -214,7 +214,7 @@ struct MaxOperationString : public StringMinMaxBase {
 	}
 };
 
-template<OrderType ORDER_TYPE>
+template <OrderType ORDER_TYPE>
 struct VectorMinMaxBase {
 	static bool IgnoreNull() {
 		return true;
@@ -248,7 +248,8 @@ struct VectorMinMaxBase {
 	}
 
 	template <class STATE, class OP>
-	static void Update(Vector inputs[], AggregateInputData &input_data, idx_t input_count, Vector &state_vector, idx_t count) {
+	static void Update(Vector inputs[], AggregateInputData &input_data, idx_t input_count, Vector &state_vector,
+	                   idx_t count) {
 		auto &input = inputs[0];
 
 		Vector sort_key(LogicalType::BLOB);
@@ -303,7 +304,8 @@ struct VectorMinMaxBase {
 		if (!state.isset) {
 			finalize_data.ReturnNull();
 		} else {
-			CreateSortKeyHelpers::DecodeSortKey(state.value, finalize_data.result, finalize_data.result_idx, OrderModifiers(ORDER_TYPE, OrderByNullType::NULLS_LAST));
+			CreateSortKeyHelpers::DecodeSortKey(state.value, finalize_data.result, finalize_data.result_idx,
+			                                    OrderModifiers(ORDER_TYPE, OrderByNullType::NULLS_LAST));
 		}
 	}
 
@@ -315,13 +317,9 @@ struct VectorMinMaxBase {
 	}
 };
 
-struct MinOperationVector : VectorMinMaxBase<OrderType::ASCENDING> {
+struct MinOperationVector : VectorMinMaxBase<OrderType::ASCENDING> {};
 
-};
-
-struct MaxOperationVector : VectorMinMaxBase<OrderType::DESCENDING> {
-
-};
+struct MaxOperationVector : VectorMinMaxBase<OrderType::DESCENDING> {};
 
 template <class OP>
 unique_ptr<FunctionData> BindDecimalMinMax(ClientContext &context, AggregateFunction &function,

--- a/src/core_functions/aggregate/distributive/minmax.cpp
+++ b/src/core_functions/aggregate/distributive/minmax.cpp
@@ -300,18 +300,17 @@ struct VectorMinMaxBase {
 
 	template <class STATE>
 	static void Finalize(STATE &state, AggregateFinalizeData &finalize_data) {
-		auto target_data = FlatVector::GetData<string_t>(finalize_data.result);
 		if (!state.isset) {
 			finalize_data.ReturnNull();
 		} else {
-			target_data[finalize_data.result_idx] = StringVector::AddStringOrBlob(finalize_data.result, state.value);
+			CreateSortKeyHelpers::DecodeSortKey(state.value, finalize_data.result, finalize_data.result_idx, OrderModifiers(ORDER_TYPE, OrderByNullType::NULLS_LAST));
 		}
 	}
 
 	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
 	                                     vector<unique_ptr<Expression>> &arguments) {
 		function.arguments[0] = arguments[0]->return_type;
-		function.return_type = LogicalType::BLOB;
+		function.return_type = arguments[0]->return_type;
 		return nullptr;
 	}
 };

--- a/src/core_functions/scalar/blob/create_sort_key.cpp
+++ b/src/core_functions/scalar/blob/create_sort_key.cpp
@@ -682,7 +682,7 @@ static void FinalizeSortData(Vector &result, idx_t size) {
 	case LogicalTypeId::BIGINT: {
 		auto result_data = FlatVector::GetData<int64_t>(result);
 		for (idx_t r = 0; r < size; r++) {
-			result_data[r] = BSwap<int64_t>(result_data[r]);
+			result_data[r] = BSwap(result_data[r]);
 		}
 		break;
 	}

--- a/src/core_functions/scalar/blob/create_sort_key.cpp
+++ b/src/core_functions/scalar/blob/create_sort_key.cpp
@@ -816,6 +816,8 @@ void DecodeSortKeyList(DecodeSortKeyData &decode_data, SortKeyVectorData &vector
 		// now decode the entry
 		DecodeSortKeyRecursive(decode_data, *vector_data.child_data[0], child_vector, new_list_size - 1);
 	}
+	// skip the list delimiter
+	decode_data.position++;
 	// set the list_entry_t information and update the list size
 	list_data[result_idx].length = new_list_size - start_list_size;
 	list_data[result_idx].offset = start_list_size;
@@ -827,9 +829,9 @@ void DecodeSortKeyArray(DecodeSortKeyData &decode_data, SortKeyVectorData &vecto
 	auto validity_byte = decode_data.data[decode_data.position];
 	decode_data.position++;
 	if (validity_byte == vector_data.null_byte) {
-		// entire list is NULL
+		// entire array is NULL
+		// note that we still read the child elements
 		FlatVector::Validity(result).SetInvalid(result_idx);
-		return;
 	}
 	// array is valid - decode child elements
 	// arrays need to encode exactly array_size child elements
@@ -854,6 +856,8 @@ void DecodeSortKeyArray(DecodeSortKeyData &decode_data, SortKeyVectorData &vecto
 		// now decode the entry
 		DecodeSortKeyRecursive(decode_data, *vector_data.child_data[0], child_vector, child_start + found_elements - 1);
 	}
+	// skip the list delimiter
+	decode_data.position++;
 	if (found_elements != array_size) {
 		throw InvalidInputException("Failed to decode array - found %d elements but expected %d", found_elements, array_size);
 	}

--- a/src/include/duckdb/common/bswap.hpp
+++ b/src/include/duckdb/common/bswap.hpp
@@ -25,22 +25,24 @@ namespace duckdb {
 	            (((uint64_t)(x)&0x00000000ff000000ull) << 8) | (((uint64_t)(x)&0x0000000000ff0000ull) << 24) |         \
 	            (((uint64_t)(x)&0x000000000000ff00ull) << 40) | (((uint64_t)(x)&0x00000000000000ffull) << 56)))
 
-template <class T>
-static inline T BSwap(const T &x) {
-	static_assert(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8,
-	              "Size of type must be 1, 2, 4, or 8 for BSwap");
-	if (sizeof(T) == 1) {
-		return x;
-	} else if (sizeof(T) == 2) {
-		return BSWAP16(x);
-	} else if (sizeof(T) == 4) {
-		// this check is superfluous as the branch is not taken for small return types but the compiler does not realize
-		// that
-		return UnsafeNumericCast<T>(BSWAP32(x));
-	} else {
-		// see above
-		return UnsafeNumericCast<T>(BSWAP64(x));
-	}
+static inline uint8_t BSwap(const uint8_t &x) {
+	return x;
+}
+
+static inline uint16_t BSwap(const uint16_t &x) {
+	return BSWAP16(x);
+}
+
+static inline uint32_t BSwap(const uint32_t &x) {
+	return BSWAP32(x);
+}
+
+static inline uint64_t BSwap(const uint64_t &x) {
+	return BSWAP64(x);
+}
+
+static inline int64_t BSwap(const int64_t &x) {
+	return static_cast<int64_t>(BSWAP64(x));
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/radix.hpp
+++ b/src/include/duckdb/common/radix.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/common/limits.hpp"
 
 #include <cfloat>
 #include <cstring> // strlen() on Solaris
@@ -88,13 +89,13 @@ public:
 	static inline float DecodeFloat(uint32_t input) {
 		// nan
 		if (input == UINT_MAX) {
-			return NAN;
+			return std::numeric_limits<float>::quiet_NaN();
 		}
 		if (input == UINT_MAX - 1) {
-			return INFINITY;
+			return std::numeric_limits<float>::infinity();
 		}
 		if (input == 0) {
-			return -INFINITY;
+			return -std::numeric_limits<float>::infinity();
 		}
 		float result;
 		if (input & (1U << 31)) {
@@ -139,13 +140,13 @@ public:
 	static inline double DecodeDouble(uint64_t input) {
 		// nan
 		if (input == ULLONG_MAX) {
-			return NAN;
+			return std::numeric_limits<double>::quiet_NaN();
 		}
 		if (input == ULLONG_MAX - 1) {
-			return INFINITY;
+			return std::numeric_limits<double>::infinity();
 		}
 		if (input == 0) {
-			return -INFINITY;
+			return -std::numeric_limits<double>::infinity();
 		}
 		double result;
 		if (input & (1ULL << 63)) {

--- a/src/include/duckdb/common/radix.hpp
+++ b/src/include/duckdb/common/radix.hpp
@@ -113,6 +113,11 @@ public:
 		}
 		return buff;
 	}
+private:
+	template<class T>
+	static void EncodeSigned(data_ptr_t dataptr, T value);
+	template<class T>
+	static T DecodeSigned(const_data_ptr_t input);
 };
 
 template <>
@@ -120,36 +125,33 @@ inline void Radix::EncodeData(data_ptr_t dataptr, bool value) {
 	Store<uint8_t>(value ? 1 : 0, dataptr);
 }
 
+template<class T>
+void Radix::EncodeSigned(data_ptr_t dataptr, T value) {
+	using UNSIGNED = typename MakeUnsigned<T>::type;
+	UNSIGNED bytes;
+	Store<T>(value, data_ptr_cast(&bytes));
+	Store<UNSIGNED>(BSwap(bytes), dataptr);
+	dataptr[0] = FlipSign(dataptr[0]);
+}
+
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, int8_t value) {
-	uint8_t bytes; // dance around signedness conversion check
-	Store<int8_t>(value, data_ptr_cast(&bytes));
-	Store<uint8_t>(bytes, dataptr);
-	dataptr[0] = FlipSign(dataptr[0]);
+	EncodeSigned<int8_t>(dataptr, value);
 }
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, int16_t value) {
-	uint16_t bytes;
-	Store<int16_t>(value, data_ptr_cast(&bytes));
-	Store<uint16_t>(BSwap<uint16_t>(bytes), dataptr);
-	dataptr[0] = FlipSign(dataptr[0]);
+	EncodeSigned<int16_t>(dataptr, value);
 }
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, int32_t value) {
-	uint32_t bytes;
-	Store<int32_t>(value, data_ptr_cast(&bytes));
-	Store<uint32_t>(BSwap<uint32_t>(bytes), dataptr);
-	dataptr[0] = FlipSign(dataptr[0]);
+	EncodeSigned<int32_t>(dataptr, value);
 }
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, int64_t value) {
-	uint64_t bytes;
-	Store<int64_t>(value, data_ptr_cast(&bytes));
-	Store<uint64_t>(BSwap<uint64_t>(bytes), dataptr);
-	dataptr[0] = FlipSign(dataptr[0]);
+	EncodeSigned<int64_t>(dataptr, value);
 }
 
 template <>
@@ -159,17 +161,17 @@ inline void Radix::EncodeData(data_ptr_t dataptr, uint8_t value) {
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, uint16_t value) {
-	Store<uint16_t>(BSwap<uint16_t>(value), dataptr);
+	Store<uint16_t>(BSwap(value), dataptr);
 }
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, uint32_t value) {
-	Store<uint32_t>(BSwap<uint32_t>(value), dataptr);
+	Store<uint32_t>(BSwap(value), dataptr);
 }
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, uint64_t value) {
-	Store<uint64_t>(BSwap<uint64_t>(value), dataptr);
+	Store<uint64_t>(BSwap(value), dataptr);
 }
 
 template <>
@@ -187,13 +189,13 @@ inline void Radix::EncodeData(data_ptr_t dataptr, uhugeint_t value) {
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, float value) {
 	uint32_t converted_value = EncodeFloat(value);
-	Store<uint32_t>(BSwap<uint32_t>(converted_value), dataptr);
+	Store<uint32_t>(BSwap(converted_value), dataptr);
 }
 
 template <>
 inline void Radix::EncodeData(data_ptr_t dataptr, double value) {
 	uint64_t converted_value = EncodeDouble(value);
-	Store<uint64_t>(BSwap<uint64_t>(converted_value), dataptr);
+	Store<uint64_t>(BSwap(converted_value), dataptr);
 }
 
 template <>
@@ -207,32 +209,38 @@ inline void Radix::EncodeData(data_ptr_t dataptr, interval_t value) {
 
 template <>
 inline bool Radix::DecodeData(const_data_ptr_t input) {
-	throw InternalException("FIXME Radix::DecodeData");
+	return Load<uint8_t>(input) != 0;
+}
+
+template<class T>
+T Radix::DecodeSigned(const_data_ptr_t input) {
+	using UNSIGNED = typename MakeUnsigned<T>::type;
+	UNSIGNED bytes = Load<UNSIGNED>(input);
+	auto bytes_data = data_ptr_cast(&bytes);
+	bytes_data[0] = FlipSign(bytes_data[0]);
+	T result;
+	Store<UNSIGNED>(BSwap(bytes), data_ptr_cast(&result));
+	return result;
 }
 
 template <>
 inline int8_t Radix::DecodeData(const_data_ptr_t input) {
-	throw InternalException("FIXME Radix::DecodeData");
+	return DecodeSigned<int8_t>(input);
 }
 
 template <>
 inline int16_t Radix::DecodeData(const_data_ptr_t input) {
-	throw InternalException("FIXME Radix::DecodeData");
+	return DecodeSigned<int16_t>(input);
 }
 
 template <>
 inline int32_t Radix::DecodeData(const_data_ptr_t input) {
-	throw InternalException("FIXME Radix::DecodeData");
+	return DecodeSigned<int32_t>(input);
 }
 
 template <>
 inline int64_t Radix::DecodeData(const_data_ptr_t input) {
-	uint64_t bytes = Load<uint64_t>(input);
-	auto bytes_data = data_ptr_cast(&bytes);
-	bytes_data[0] = FlipSign(bytes_data[0]);
-	int64_t result;
-	Store<uint64_t>(BSwap<uint64_t>(bytes), data_ptr_cast(&result));
-	return result;
+	return DecodeSigned<int64_t>(input);
 }
 
 template <>

--- a/src/include/duckdb/common/radix.hpp
+++ b/src/include/duckdb/common/radix.hpp
@@ -37,6 +37,11 @@ public:
 		throw NotImplementedException("Cannot create data from this type");
 	}
 
+	template <class T>
+	static inline T DecodeData(const_data_ptr_t input) {
+		throw NotImplementedException("Cannot read data from this type");
+	}
+
 	static inline void EncodeStringDataPrefix(data_ptr_t dataptr, string_t value, idx_t prefix_len) {
 		auto len = value.GetSize();
 		memcpy(dataptr, value.GetData(), MinValue(len, prefix_len));
@@ -198,6 +203,81 @@ inline void Radix::EncodeData(data_ptr_t dataptr, interval_t value) {
 	EncodeData<int32_t>(dataptr, value.days);
 	dataptr += sizeof(value.days);
 	EncodeData<int64_t>(dataptr, value.micros);
+}
+
+template <>
+inline bool Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline int8_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline int16_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline int32_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline int64_t Radix::DecodeData(const_data_ptr_t input) {
+	uint64_t bytes = Load<uint64_t>(input);
+	auto bytes_data = data_ptr_cast(&bytes);
+	bytes_data[0] = FlipSign(bytes_data[0]);
+	int64_t result;
+	Store<uint64_t>(BSwap<uint64_t>(bytes), data_ptr_cast(&result));
+	return result;
+}
+
+template <>
+inline uint8_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline uint16_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline uint32_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline uint64_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline hugeint_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline uhugeint_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline float Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline double Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
+}
+
+template <>
+inline interval_t Radix::DecodeData(const_data_ptr_t input) {
+	throw InternalException("FIXME Radix::DecodeData");
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/radix.hpp
+++ b/src/include/duckdb/common/radix.hpp
@@ -56,12 +56,12 @@ public:
 
 	static inline uint32_t EncodeFloat(float x) {
 		uint32_t buff;
-        //! zero
-        if (x == 0) {
-            buff = 0;
-            buff |= (1u << 31);
-            return buff;
-        }
+		//! zero
+		if (x == 0) {
+			buff = 0;
+			buff |= (1u << 31);
+			return buff;
+		}
 
 		// nan
 		if (Value::IsNan(x)) {
@@ -160,9 +160,9 @@ public:
 	}
 
 private:
-	template<class T>
+	template <class T>
 	static void EncodeSigned(data_ptr_t dataptr, T value);
-	template<class T>
+	template <class T>
 	static T DecodeSigned(const_data_ptr_t input);
 };
 
@@ -171,7 +171,7 @@ inline void Radix::EncodeData(data_ptr_t dataptr, bool value) {
 	Store<uint8_t>(value ? 1 : 0, dataptr);
 }
 
-template<class T>
+template <class T>
 void Radix::EncodeSigned(data_ptr_t dataptr, T value) {
 	using UNSIGNED = typename MakeUnsigned<T>::type;
 	UNSIGNED bytes;
@@ -258,7 +258,7 @@ inline bool Radix::DecodeData(const_data_ptr_t input) {
 	return Load<uint8_t>(input) != 0;
 }
 
-template<class T>
+template <class T>
 T Radix::DecodeSigned(const_data_ptr_t input) {
 	using UNSIGNED = typename MakeUnsigned<T>::type;
 	UNSIGNED bytes = Load<UNSIGNED>(input);

--- a/src/include/duckdb/core_functions/create_sort_key.hpp
+++ b/src/include/duckdb/core_functions/create_sort_key.hpp
@@ -10,7 +10,6 @@
 
 #include "duckdb/function/function_set.hpp"
 
-
 namespace duckdb {
 
 struct OrderModifiers {

--- a/src/include/duckdb/core_functions/create_sort_key.hpp
+++ b/src/include/duckdb/core_functions/create_sort_key.hpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/core_functions/create_sort_key.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/function_set.hpp"
+
+
+namespace duckdb {
+
+struct OrderModifiers {
+	OrderModifiers(OrderType order_type, OrderByNullType null_type) : order_type(order_type), null_type(null_type) {
+	}
+
+	OrderType order_type;
+	OrderByNullType null_type;
+
+	bool operator==(const OrderModifiers &other) const {
+		return order_type == other.order_type && null_type == other.null_type;
+	}
+
+	static OrderModifiers Parse(const string &val) {
+		auto lcase = StringUtil::Replace(StringUtil::Lower(val), "_", " ");
+		OrderType order_type;
+		if (StringUtil::StartsWith(lcase, "asc")) {
+			order_type = OrderType::ASCENDING;
+		} else if (StringUtil::StartsWith(lcase, "desc")) {
+			order_type = OrderType::DESCENDING;
+		} else {
+			throw BinderException("create_sort_key modifier must start with either ASC or DESC");
+		}
+		OrderByNullType null_type;
+		if (StringUtil::EndsWith(lcase, "nulls first")) {
+			null_type = OrderByNullType::NULLS_FIRST;
+		} else if (StringUtil::EndsWith(lcase, "nulls last")) {
+			null_type = OrderByNullType::NULLS_LAST;
+		} else {
+			throw BinderException("create_sort_key modifier must end with either NULLS FIRST or NULLS LAST");
+		}
+		return OrderModifiers(order_type, null_type);
+	}
+};
+
+struct CreateSortKeyHelpers {
+	static void CreateSortKey(Vector &input, idx_t input_count, OrderModifiers modifiers, Vector &result);
+	static void DecodeSortKey(string_t sort_key, Vector &result, idx_t result_idx, OrderModifiers modifiers);
+};
+
+} // namespace duckdb

--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -975,8 +975,7 @@ TEST_CASE("Test ADBC Substrait", "[adbc]") {
 
 	// Broken Plan
 	REQUIRE(!SUCCESS(AdbcStatementSetSubstraitPlan(&adbc_statement, plan, 5, &adbc_error)));
-	REQUIRE(std::strcmp(adbc_error.message, "Conversion Error: Invalid hex escape code encountered in string -> blob "
-	                                        "conversion: unterminated escape code at end of blob") == 0);
+	REQUIRE(StringUtil::Contains(adbc_error.message, "unterminated escape code at end of blob"));
 
 	REQUIRE(SUCCESS(AdbcStatementRelease(&adbc_statement, &adbc_error)));
 	REQUIRE(SUCCESS(AdbcConnectionRelease(&adbc_connection, &adbc_error)));

--- a/test/sql/function/list/aggregates/min_nested.test
+++ b/test/sql/function/list/aggregates/min_nested.test
@@ -2,10 +2,6 @@
 # description: Test the list_min aggregate function
 # group: [aggregates]
 
-# structs with blobs
-
-mode skip
-
 # structs
 statement ok
 CREATE TABLE structs AS SELECT {'i': i} s FROM range(1000) t(i);
@@ -59,6 +55,24 @@ query II
 SELECT MIN(s), MAX(s) FROM varchar_structs;
 ----
 {'i': \0}	{'i': zzzzz\0}
+
+# structs with blobs
+statement ok
+CREATE TABLE blob_structs AS SELECT {'i': concat('long_prefix_', '\x', 16+i%239)::blob} s FROM range(1000) t(i);
+
+query II
+SELECT MIN(s), MAX(s) FROM blob_structs;
+----
+{'i': long_prefix_\x100}	{'i': long_prefix_\x99}
+
+# null bytes
+statement ok
+INSERT INTO blob_structs VALUES ({'i': '\x00z\x00\x00z\x00zzzz\x00'::blob}), ({'i': 'zzzzzz\x01\x01\x01\x00\x01\x01\x00'::blob})
+
+query II
+SELECT MIN(s), MAX(s) FROM blob_structs;
+----
+{'i': \x00z\x00\x00z\x00zzzz\x00}	{'i': zzzzzz\x01\x01\x01\x00\x01\x01\x00}
 
 
 

--- a/test/sql/function/list/aggregates/min_nested.test
+++ b/test/sql/function/list/aggregates/min_nested.test
@@ -74,17 +74,104 @@ SELECT MIN(s), MAX(s) FROM blob_structs;
 ----
 {'i': \x00z\x00\x00z\x00zzzz\x00}	{'i': zzzzzz\x01\x01\x01\x00\x01\x01\x00}
 
+# multi-member structs
+statement ok
+CREATE TABLE multi_member_struct AS SELECT {'i': (1000-i)//5, 'j': i} s FROM range(1000) t(i);
 
+query II
+SELECT MIN(s), MAX(s) FROM multi_member_struct;
+----
+{'i': 0, 'j': 996}	{'i': 200, 'j': 0}
 
-
-# NULLs
-
-# structs with multiple elements
 # lists
-# structs with lists
+statement ok
+CREATE TABLE lists AS SELECT case when i<500 then [i, i + 1, i + 2] else [i, 0] end AS l FROM range(1000) t(i);
+
+query II
+SELECT MIN(l), MAX(l) FROM lists;
+----
+[0, 1, 2]	[999, 0]
+
+# empty list and null entries
+statement ok
+INSERT INTO lists VALUES ([]), (NULL), ([NULL, NULL, NULL]);
+
+query II
+SELECT MIN(l), MAX(l) FROM lists;
+----
+[]	[NULL, NULL, NULL]
+
 # lists with structs
+statement ok
+CREATE TABLE list_with_structs AS SELECT case when i<500 then [{'i': i}, {'i': i + 1}, {'i': i + 2}] else [{'i': i}, {'i': 0}] end AS l FROM range(1000) t(i);
+
+query II
+SELECT MIN(l), MAX(l) FROM list_with_structs;
+----
+[{'i': 0}, {'i': 1}, {'i': 2}]	[{'i': 999}, {'i': 0}]
+
+# null within a struct
+statement ok
+INSERT INTO list_with_structs VALUES ([{'i': NULL}, {'i': 100}, NULL, {'i': NULL}]);
+
+query II
+SELECT MIN(l), MAX(l) FROM list_with_structs;
+----
+[{'i': 0}, {'i': 1}, {'i': 2}]	[{'i': NULL}, {'i': 100}, NULL, {'i': NULL}]
+
+# empty list and null entries
+statement ok
+INSERT INTO list_with_structs VALUES ([]), (NULL), ([NULL, NULL, NULL]);
+
+query II
+SELECT MIN(l), MAX(l) FROM list_with_structs;
+----
+[]	[NULL, NULL, NULL]
+
+# list with multi member struct
+statement ok
+CREATE TABLE list_multi_member_struct AS SELECT [NULL, {'i': (1000-i)//5, 'j': i}, NULL] l FROM range(1000) t(i);
+
+query II
+SELECT MIN(l), MAX(l) FROM list_multi_member_struct;
+----
+[NULL, {'i': 0, 'j': 996}, NULL]	[NULL, {'i': 200, 'j': 0}, NULL]
+
+# nulls at different levels
+statement ok
+INSERT INTO list_multi_member_struct VALUES ([{'i': NULL, 'j': 42}]), ([NULL, NULL, {'i': 84, 'j': NULL}])
+
+query II
+SELECT MIN(l), MAX(l) FROM list_multi_member_struct;
+----
+[{'i': NULL, 'j': 42}]	[NULL, NULL, {'i': 84, 'j': NULL}]
+
+# struct with lists
+statement ok
+CREATE TABLE struct_with_lists AS SELECT {'i': case when i<500 then [i, i + 1, i + 2] else [i, 0] end} AS s FROM range(1000) t(i);
+
+query II
+SELECT MIN(s), MAX(s) FROM struct_with_lists;
+----
+{'i': [0, 1, 2]}	{'i': [999, 0]}
+
+# empty list and null entries
+statement ok
+INSERT INTO struct_with_lists VALUES ({'i': []}), (NULL), ({'i': [NULL, NULL, NULL]})
+
+query II
+SELECT MIN(s), MAX(s) FROM struct_with_lists;
+----
+{'i': []}	{'i': [NULL, NULL, NULL]}
+
+statement ok
+INSERT INTO struct_with_lists VALUES ({'i': NULL})
+
+query I
+SELECT MAX(s) FROM struct_with_lists;
+----
+{'i': NULL}
+
 # arrays
-# structs with arrays
-# all mixed
 
 # test_all_types?

--- a/test/sql/function/list/aggregates/min_nested.test
+++ b/test/sql/function/list/aggregates/min_nested.test
@@ -1,0 +1,76 @@
+# name: test/sql/function/list/aggregates/min_nested.test
+# description: Test the list_min aggregate function
+# group: [aggregates]
+
+# structs with blobs
+
+mode skip
+
+# structs
+statement ok
+CREATE TABLE structs AS SELECT {'i': i} s FROM range(1000) t(i);
+
+query II
+SELECT MIN(s), MAX(s) FROM structs;
+----
+{'i': 0}	{'i': 999}
+
+# larger values
+statement ok
+INSERT INTO structs VALUES ({'i': 99999999});
+
+query II
+SELECT MIN(s), MAX(s) FROM structs;
+----
+{'i': 0}	{'i': 99999999}
+
+# limits
+statement ok
+INSERT INTO structs VALUES ({'i': -9223372036854775808}), ({'i': 9223372036854775807});
+
+query II
+SELECT MIN(s), MAX(s) FROM structs;
+----
+{'i': -9223372036854775808}	{'i': 9223372036854775807}
+
+# null values
+statement ok
+INSERT INTO structs VALUES ({'i': NULL}), (NULL)
+
+query II
+SELECT MIN(s), MAX(s) FROM structs;
+----
+{'i': -9223372036854775808}	{'i': NULL}
+
+# structs with varchars
+statement ok
+CREATE TABLE varchar_structs AS SELECT {'i': concat('long_prefix_', i)} s FROM range(1000) t(i);
+
+query II
+SELECT MIN(s), MAX(s) FROM varchar_structs;
+----
+{'i': long_prefix_0}	{'i': long_prefix_999}
+
+# null bytes
+statement ok
+INSERT INTO varchar_structs VALUES ({'i': chr(0)}), ({'i': 'zzzzz' || chr(0)})
+
+query II
+SELECT MIN(s), MAX(s) FROM varchar_structs;
+----
+{'i': \0}	{'i': zzzzz\0}
+
+
+
+
+# NULLs
+
+# structs with multiple elements
+# lists
+# structs with lists
+# lists with structs
+# arrays
+# structs with arrays
+# all mixed
+
+# test_all_types?

--- a/test/sql/function/list/aggregates/min_nested.test
+++ b/test/sql/function/list/aggregates/min_nested.test
@@ -173,5 +173,19 @@ SELECT MAX(s) FROM struct_with_lists;
 {'i': NULL}
 
 # arrays
+statement ok
+CREATE TABLE arrays AS SELECT (case when i<500 then [i, i + 1, i + 2] else [i, 0, 0] end)::BIGINT[3] AS l FROM range(1000) t(i);
 
-# test_all_types?
+query II
+SELECT MIN(l), MAX(l) FROM arrays;
+----
+[0, 1, 2]	[999, 0, 0]
+
+# null entries
+statement ok
+INSERT INTO arrays VALUES (NULL), ([NULL, NULL, NULL]);
+
+query II
+SELECT MIN(l), MAX(l) FROM arrays;
+----
+[0, 1, 2]	[NULL, NULL, NULL]

--- a/test/sql/function/list/aggregates/minmax_all_types.test_slow
+++ b/test/sql/function/list/aggregates/minmax_all_types.test_slow
@@ -1,0 +1,24 @@
+# name: test/sql/function/list/aggregates/minmax_all_types.test_slow
+# description: Test the min/max functions on all types
+# group: [aggregates]
+
+statement ok
+pragma enable_verification
+
+# verify that min/max produces the same results as ORDER BY .. LIMIT 1 for all types
+statement ok
+CREATE TABLE all_types AS FROM test_all_types();
+
+foreach col bool tinyint smallint int bigint hugeint uhugeint utinyint usmallint uint ubigint date time timestamp timestamp_s timestamp_ms timestamp_ns time_tz timestamp_tz float double dec_4_1 dec_9_4 dec_18_6 dec38_10 uuid interval varchar blob bit small_enum medium_enum large_enum int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs map union fixed_int_array fixed_varchar_array fixed_nested_int_array fixed_nested_varchar_array fixed_struct_array struct_of_fixed_array fixed_array_of_int_list list_of_fixed_int_array
+
+query I
+SELECT MIN({'val': "${col}"}).val IS NOT DISTINCT FROM (SELECT "${col}" FROM all_types ORDER BY "${col}" LIMIT 1) FROM all_types WHERE bool IS NOT NULL
+----
+true
+
+query I
+SELECT MAX({'val': "${col}"}).val IS NOT DISTINCT FROM (SELECT "${col}" FROM all_types ORDER BY "${col}" DESC LIMIT 1) FROM all_types WHERE bool IS NOT NULL
+----
+true
+
+endloop

--- a/test/sql/function/list/aggregates/minmax_nested.test
+++ b/test/sql/function/list/aggregates/minmax_nested.test
@@ -1,6 +1,9 @@
-# name: test/sql/function/list/aggregates/min_nested.test
-# description: Test the list_min aggregate function
+# name: test/sql/function/list/aggregates/minmax_nested.test
+# description: Test the min/max functions on complex nested types aggregate function
 # group: [aggregates]
+
+statement ok
+pragma enable_verification
 
 # structs
 statement ok
@@ -189,3 +192,36 @@ query II
 SELECT MIN(l), MAX(l) FROM arrays;
 ----
 [0, 1, 2]	[NULL, NULL, NULL]
+
+# floats
+statement ok
+CREATE TABLE float_values(f FLOAT);
+
+statement ok
+INSERT INTO float_values VALUES ('0'), ('-3.4e38'), ('3.4e38'), ('nan'), ('inf'), ('-inf')
+
+query II
+SELECT f, (SELECT MIN({'v': x}) FROM (VALUES (f)) t(x)) FROM float_values;
+----
+0.0	{'v': 0.0}
+-3.4e+38	{'v': -3.4e+38}
+3.4e+38	{'v': 3.4e+38}
+nan	{'v': nan}
+inf	{'v': inf}
+-inf	{'v': -inf}
+
+statement ok
+CREATE TABLE double_values(d DOUBLE);
+
+statement ok
+INSERT INTO double_values VALUES ('0'), ('-1e308'), ('1e308'), ('nan'), ('inf'), ('-inf')
+
+query II
+SELECT d, (SELECT MIN({'v': x}) FROM (VALUES (d)) t(x)) FROM double_values;
+----
+0.0	{'v': 0.0}
+-1e+308	{'v': -1e+308}
+1e+308	{'v': 1e+308}
+nan	{'v': nan}
+inf	{'v': inf}
+-inf	{'v': -inf}


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/10321 added the `create_sort_key` method, which allows us to take any input type, and create a binary-comparable `BLOB` according to a set of ordering constraints (e.g. `ASCENDING/DESCENDING/NULLS FIRST/NULLS LAST`). This PR adds the inverse - `DecodeSortKey` - albeit not as a scalar function but only for internal usage. This function allows us to take any binary blob created by the `create_sort_key` method, and reconstruct the original values that were ingested.

This method has multiple uses - but for this PR the primary use case is for this combination of functions to work as a fallback mechanism for types we do not specialize on. As DuckDB supports arbitrarily composible types (in the form of lists, structs, maps, that can all be nested) - we cannot specialize on every type - yet there are functions that need to work on every type (e.g. `MIN/MAX`). By using the sort keys, we only need to implement these methods for the `BLOB` type - after which we can support all types through e.g. `decode_sort_key(FUNCTION(create_sort_key(...)))`. This allows us to more easily add support for all types in a reasonably efficient manner (although not as efficient as specializing directly of course).

In this PR we switch the fallback implementation of `MIN/MAX` to use the new sort keys. The old fallback implementation constructed a `Vector` in the aggregate state that would hold only a single element, and used vector operations (e.g. `VectorOperations::Copy`) to assign elements to the aggregate. The sorting key implementation is significantly more performant - as the vector methods are not designed to operate on individual elements. In addition, this fallback method is also far more memory efficient, particularly when running the min/max operations on many groups, as vectors are designed to hold large arrays. 

Below are some benchmarks running min/max over structs/lists. We can see the large increase in performance, especially as the number of groups increases. The old implementation would also be killed by the OOM killer when running with many groups - which the new implementation does not suffer from.


###### Ungrouped
```sql
CREATE TABLE structs AS SELECT {'i': i} s FROM range(100000000) t(i);
SELECT MIN(s), MAX(s) FROM structs;

CREATE TABLE lists AS SELECT [i, i + 1, i + 2] l FROM range(100000000) t(i);
SELECT MIN(l), MAX(l) FROM lists;
```
|  Type   | v1.0.0 |  New  |
|---------|--------|-------|
| Structs | 1.50s  | 0.44s |
| Lists   | 1.64s  | 1.48s |

###### 10K Groups

```sql
CREATE TABLE structs AS SELECT i%10000 AS grp, {'i': i} s FROM range(100000000) t(i);
SELECT grp, MIN(s), MAX(s) FROM structs GROUP BY grp;

CREATE TABLE lists AS SELECT i%10000 AS grp, [i, i + 1, i + 2] l FROM range(100000000) t(i);
SELECT grp, MIN(l), MAX(l) FROM lists GROUP BY grp;
```

|  Type   | v1.0.0 |  New  |
|---------|--------|-------|
| Structs | 4.4s   | 0.44s |
| Lists   | 9.4s   | 2.1s  |

###### 10M Groups

```sql
CREATE TABLE structs AS SELECT i%10000000 AS grp, {'i': i} s FROM range(100000000) t(i);
SELECT grp, MIN(s), MAX(s) FROM structs GROUP BY grp;

CREATE TABLE lists AS SELECT i%10000000 AS grp, [i, i + 1, i + 2] l FROM range(100000000) t(i);
SELECT grp, MIN(l), MAX(l) FROM lists GROUP BY grp;
```

|  Type   | v1.0.0 | New  |
|---------|--------|------|
| Structs | KILLED | 2.0s |
| Lists   | KILLED | 64s  |

CC @lnkuiper @hawkfish 