### PR TITLE
Move arg_min/arg_max to use sort keys 

### DIFF
--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -241,7 +241,7 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR, IGNORE_NULL> {
 		auto sort_key_data = FlatVector::GetData<string_t>(sort_key);
 
 		// now assign sort keys
-		for(idx_t i = 0; i < assign_count; i++) {
+		for (idx_t i = 0; i < assign_count; i++) {
 			const auto sidx = sdata.sel->get_index(sel.get_index(i));
 			auto &state = *states[sidx];
 			STATE::template AssignValue<ARG_TYPE>(state.arg, sort_key_data[i]);
@@ -257,7 +257,8 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR, IGNORE_NULL> {
 			STATE::template AssignValue<typename STATE::BY_TYPE>(target.value, source.value);
 			target.arg_null = source.arg_null;
 			if (!target.arg_null) {
-				STATE::template AssignValue<typename STATE::ARG_TYPE>(target.arg, source.arg);;
+				STATE::template AssignValue<typename STATE::ARG_TYPE>(target.arg, source.arg);
+				;
 			}
 			target.is_initialized = true;
 		}

--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -175,13 +175,6 @@ struct ArgMinMaxBase {
 template <typename COMPARATOR, bool IGNORE_NULL, OrderType ORDER_TYPE>
 struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR, IGNORE_NULL> {
 	template <class STATE>
-	static void AssignVector(STATE &state, Vector &source, const idx_t idx) {
-		state.DestroyValue(state.arg);
-		OrderModifiers modifier(ORDER_TYPE, OrderByNullType::NULLS_LAST);
-		state.arg = CreateSortKeyHelpers::CreateSortKey(source, idx, modifier);
-	}
-
-	template <class STATE>
 	static void Update(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
 		auto &arg = inputs[0];
 		UnifiedVectorFormat adata;

--- a/src/core_functions/scalar/blob/create_sort_key.cpp
+++ b/src/core_functions/scalar/blob/create_sort_key.cpp
@@ -467,13 +467,6 @@ static void GetSortKeyLength(SortKeyVectorData &vector_data, SortKeyLengthInfo &
 	GetSortKeyLength(vector_data, result, SortKeyChunk(0, vector_data.size));
 }
 
-static void GetSortKeyLength(SortKeyVectorData &vector_data, SortKeyLengthInfo &result, idx_t row) {
-	SortKeyChunk chunk(row, row + 1);
-	chunk.result_index = 0;
-	chunk.has_result_index = true;
-	GetSortKeyLength(vector_data, result, chunk);
-}
-
 //===--------------------------------------------------------------------===//
 // Construct Sort Key
 //===--------------------------------------------------------------------===//
@@ -653,13 +646,6 @@ static void ConstructSortKey(SortKeyVectorData &vector_data, SortKeyConstructInf
 	ConstructSortKeyRecursive(vector_data, SortKeyChunk(0, vector_data.size), info);
 }
 
-static void ConstructSortKey(SortKeyVectorData &vector_data, SortKeyConstructInfo &info, idx_t row) {
-	SortKeyChunk chunk(row, row + 1);
-	chunk.result_index = 0;
-	chunk.has_result_index = true;
-	ConstructSortKeyRecursive(vector_data, chunk, info);
-}
-
 static void PrepareSortData(Vector &result, idx_t size, SortKeyLengthInfo &key_lengths, data_ptr_t *data_pointers) {
 	switch (result.GetType().id()) {
 	case LogicalTypeId::BLOB: {
@@ -741,35 +727,6 @@ void CreateSortKeyHelpers::CreateSortKey(Vector &input, idx_t input_count, Order
 	sort_key_data.push_back(make_uniq<SortKeyVectorData>(input, input_count, order_modifier));
 
 	CreateSortKeyInternal(sort_key_data, modifiers, result, input_count);
-}
-
-string_t CreateSortKeyHelpers::CreateSortKey(Vector &input, idx_t row, OrderModifiers order_modifier) {
-	vector<OrderModifiers> modifiers {order_modifier};
-	vector<unique_ptr<SortKeyVectorData>> sort_key_data;
-	sort_key_data.push_back(make_uniq<SortKeyVectorData>(input, 1ULL, order_modifier));
-
-	// get the sort key length for this row
-	SortKeyLengthInfo key_lengths(1);
-	GetSortKeyLength(*sort_key_data[0], key_lengths, row);
-
-	// allocate space for the sort key
-	data_ptr_t pointers[1];
-	uint32_t sort_key_length = NumericCast<uint32_t>(key_lengths.constant_length + key_lengths.variable_lengths[0]);
-	auto sort_key = make_unsafe_uniq_array<char>(sort_key_length);
-	pointers[0] = data_ptr_cast(sort_key.get());
-
-	// generate the sort key
-	unsafe_vector<idx_t> offsets;
-	offsets.resize(1, 0);
-
-	SortKeyConstructInfo info(order_modifier, offsets, pointers);
-	ConstructSortKey(*sort_key_data[0], info, row);
-
-	if (sort_key_length > string_t::INLINE_BYTES) {
-		return string_t(sort_key.release(), sort_key_length);
-	} else {
-		return string_t(sort_key.get(), sort_key_length);
-	}
 }
 
 static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/src/include/duckdb/core_functions/create_sort_key.hpp
+++ b/src/include/duckdb/core_functions/create_sort_key.hpp
@@ -48,8 +48,6 @@ struct OrderModifiers {
 struct CreateSortKeyHelpers {
 	static void CreateSortKey(Vector &input, idx_t input_count, OrderModifiers modifiers, Vector &result);
 	static void DecodeSortKey(string_t sort_key, Vector &result, idx_t result_idx, OrderModifiers modifiers);
-	//! Create a sort key for a single row from a single vector
-	static string_t CreateSortKey(Vector &input, idx_t row, OrderModifiers modifiers);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/core_functions/create_sort_key.hpp
+++ b/src/include/duckdb/core_functions/create_sort_key.hpp
@@ -48,6 +48,8 @@ struct OrderModifiers {
 struct CreateSortKeyHelpers {
 	static void CreateSortKey(Vector &input, idx_t input_count, OrderModifiers modifiers, Vector &result);
 	static void DecodeSortKey(string_t sort_key, Vector &result, idx_t result_idx, OrderModifiers modifiers);
+	//! Create a sort key for a single row from a single vector
+	static string_t CreateSortKey(Vector &input, idx_t row, OrderModifiers modifiers);
 };
 
 } // namespace duckdb


### PR DESCRIPTION
Follow-up from #12520

This PR reworks the `arg_min/arg_max` functions to move away from the `CreateSortKeyHelpers`. Similarly this improves performance and greatly reduces memory usage. 

```sql
CREATE TABLE structs AS SELECT i, {'i': i} s FROM range(100000000) t(i);
CREATE TABLE lists AS SELECT i, [i, i + 1, i + 2] l FROM range(100000000) t(i);
```

###### Ungrouped

```sql
SELECT arg_min(s, s.i) FROM structs;
SELECT arg_max(s, s.i) FROM structs;

SELECT arg_min(l, i) FROM lists;
SELECT arg_max(l, i) FROM lists;
```

|   aggregate    |  New  | v1.0  |
|----------------|-------|-------|
| struct arg_min | 0.1s  | 0.13s |
| struct arg_max | 0.11s | 0.54s |
| list arg_min   | 0.14s | 0.19s |
| list arg_max   | 0.16s | 0.46s |

###### 10K Groups
```sql
SELECT i%10000 AS grp, ARG_MIN(s, i) FROM structs GROUP BY grp;
SELECT i%10000 AS grp, ARG_MAX(s, i) FROM structs GROUP BY grp;

SELECT i%10000 AS grp, ARG_MIN(l, i) FROM lists GROUP BY grp;
SELECT i%10000 AS grp, ARG_MAX(l, i) FROM lists GROUP BY grp;
```

|   aggregate    |  New  | v1.0  |
|----------------|-------|-------|
| struct arg_min | 0.16s | 0.3s  |
| struct arg_max | 0.3s  | 0.85s |
| list arg_min   | 0.22s | 0.35s |
| list arg_max   | 1.2s  | 0.88s |

###### 10M Groups
```sql
SELECT i%10000000 AS grp, ARG_MIN(s, i) FROM structs GROUP BY grp;
SELECT i%10000000 AS grp, ARG_MAX(s, i) FROM structs GROUP BY grp;

SELECT i%10000000 AS grp, ARG_MIN(l, i) FROM lists GROUP BY grp;
SELECT i%10000000 AS grp, ARG_MAX(l, i) FROM lists GROUP BY grp;
```

|   aggregate    |  New  |  v1.0  |
|----------------|-------|--------|
| struct arg_min | 1.4s  | KILLED |
| struct arg_max | 1.4s  | KILLED |
| list arg_min   | 30.5s | KILLED |
| list arg_max   | 33.2s | KILLED |
