### PR TITLE
Move FIRST/LAST/ANY_VALUE to use sort keys 

### DIFF
--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/core_functions/create_sort_key.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/planner/expression.hpp"
 
@@ -66,7 +67,7 @@ struct FirstFunction : public FirstFunctionBase {
 };
 
 template <bool LAST, bool SKIP_NULLS>
-struct FirstFunctionString : public FirstFunctionBase {
+struct FirstFunctionStringBase : public FirstFunctionBase {
 	template <class STATE>
 	static void SetValue(STATE &state, AggregateInputData &input_data, string_t value, bool is_null) {
 		if (LAST && state.is_set) {
@@ -93,10 +94,28 @@ struct FirstFunctionString : public FirstFunctionBase {
 		}
 	}
 
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &input_data) {
+		if (source.is_set && (LAST || !target.is_set)) {
+			SetValue(target, input_data, source.value, source.is_null);
+		}
+	}
+
+	template <class STATE>
+	static void Destroy(STATE &state, AggregateInputData &) {
+		if (state.is_set && !state.is_null && !state.value.IsInlined()) {
+			delete[] state.value.GetData();
+		}
+	}
+};
+
+template <bool LAST, bool SKIP_NULLS>
+struct FirstFunctionString : FirstFunctionStringBase<LAST, SKIP_NULLS> {
 	template <class INPUT_TYPE, class STATE, class OP>
 	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
 		if (LAST || !state.is_set) {
-			SetValue(state, unary_input.input, input, !unary_input.RowIsValid());
+			FirstFunctionStringBase<LAST, SKIP_NULLS>::template SetValue(state, unary_input.input, input,
+			                                                             !unary_input.RowIsValid());
 		}
 	}
 
@@ -104,13 +123,6 @@ struct FirstFunctionString : public FirstFunctionBase {
 	static void ConstantOperation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input,
 	                              idx_t count) {
 		Operation<INPUT_TYPE, STATE, OP>(state, input, unary_input);
-	}
-
-	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE &target, AggregateInputData &input_data) {
-		if (source.is_set && (LAST || !target.is_set)) {
-			SetValue(target, input_data, source.value, source.is_null);
-		}
 	}
 
 	template <class T, class STATE>
@@ -121,48 +133,14 @@ struct FirstFunctionString : public FirstFunctionBase {
 			target = StringVector::AddStringOrBlob(finalize_data.result, state.value);
 		}
 	}
-
-	template <class STATE>
-	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
-		if (state.is_set && !state.is_null && !state.value.IsInlined()) {
-			delete[] state.value.GetData();
-		}
-	}
-};
-
-struct FirstStateVector {
-	Vector *value;
 };
 
 template <bool LAST, bool SKIP_NULLS>
-struct FirstVectorFunction {
-	template <class STATE>
-	static void Initialize(STATE &state) {
-		state.value = nullptr;
-	}
+struct FirstVectorFunction : FirstFunctionStringBase<LAST, SKIP_NULLS> {
+	using STATE = FirstState<string_t>;
 
-	template <class STATE>
-	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
-		if (state.value) {
-			delete state.value;
-		}
-	}
-	static bool IgnoreNull() {
-		return SKIP_NULLS;
-	}
-
-	template <class STATE>
-	static void SetValue(STATE &state, Vector &input, const idx_t idx) {
-		if (!state.value) {
-			state.value = new Vector(input.GetType());
-			state.value->SetVectorType(VectorType::CONSTANT_VECTOR);
-		}
-		sel_t selv = UnsafeNumericCast<sel_t>(idx);
-		SelectionVector sel(&selv);
-		VectorOperations::Copy(input, *state.value, sel, 1, 0, 0);
-	}
-
-	static void Update(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
+	static void Update(Vector inputs[], AggregateInputData &input_data, idx_t input_count, Vector &state_vector,
+	                   idx_t count) {
 		auto &input = inputs[0];
 		UnifiedVectorFormat idata;
 		input.ToUnifiedFormat(count, idata);
@@ -170,32 +148,59 @@ struct FirstVectorFunction {
 		UnifiedVectorFormat sdata;
 		state_vector.ToUnifiedFormat(count, sdata);
 
-		auto states = UnifiedVectorFormat::GetData<FirstStateVector *>(sdata);
+		sel_t assign_sel[STANDARD_VECTOR_SIZE];
+		idx_t assign_count = 0;
+
+		auto states = UnifiedVectorFormat::GetData<STATE *>(sdata);
 		for (idx_t i = 0; i < count; i++) {
 			const auto idx = idata.sel->get_index(i);
-			if (SKIP_NULLS && !idata.validity.RowIsValid(idx)) {
+			bool is_null = !idata.validity.RowIsValid(idx);
+			if (SKIP_NULLS && is_null) {
 				continue;
 			}
 			auto &state = *states[sdata.sel->get_index(i)];
-			if (LAST || !state.value) {
-				SetValue(state, input, i);
+			if (!LAST && state.is_set) {
+				continue;
 			}
+			assign_sel[assign_count++] = NumericCast<sel_t>(i);
 		}
-	}
+		if (assign_count == 0) {
+			// fast path - nothing to set
+			return;
+		}
 
-	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
-		if (source.value && (LAST || !target.value)) {
-			SetValue(target, *source.value, 0);
+		Vector sort_key(LogicalType::BLOB);
+		OrderModifiers modifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST);
+		// slice with a selection vector and generate sort keys
+		if (assign_count == input_count) {
+			CreateSortKeyHelpers::CreateSortKey(input, input_count, modifiers, sort_key);
+		} else {
+			SelectionVector sel(assign_sel);
+			Vector sliced_input(input, sel, assign_count);
+			CreateSortKeyHelpers::CreateSortKey(sliced_input, assign_count, modifiers, sort_key);
+		}
+		auto sort_key_data = FlatVector::GetData<string_t>(sort_key);
+
+		// now assign sort keys
+		for (idx_t i = 0; i < assign_count; i++) {
+			const auto sidx = sdata.sel->get_index(assign_sel[i]);
+			bool is_null = !idata.validity.RowIsValid(assign_sel[i]);
+			auto &state = *states[sidx];
+			if (!LAST && state.is_set) {
+				continue;
+			}
+			FirstFunctionStringBase<LAST, SKIP_NULLS>::template SetValue<STATE>(state, input_data, sort_key_data[i],
+			                                                                    is_null);
 		}
 	}
 
 	template <class STATE>
 	static void Finalize(STATE &state, AggregateFinalizeData &finalize_data) {
-		if (!state.value) {
+		if (!state.is_set || state.is_null) {
 			finalize_data.ReturnNull();
 		} else {
-			VectorOperations::Copy(*state.value, finalize_data.result, 1, 0, finalize_data.result_idx);
+			CreateSortKeyHelpers::DecodeSortKey(state.value, finalize_data.result, finalize_data.result_idx,
+			                                    OrderModifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST));
 		}
 	}
 
@@ -276,11 +281,11 @@ static AggregateFunction GetFirstFunction(const LogicalType &type) {
 		}
 	default: {
 		using OP = FirstVectorFunction<LAST, SKIP_NULLS>;
-		return AggregateFunction({type}, type, AggregateFunction::StateSize<FirstStateVector>,
-		                         AggregateFunction::StateInitialize<FirstStateVector, OP>, OP::Update,
-		                         AggregateFunction::StateCombine<FirstStateVector, OP>,
-		                         AggregateFunction::StateVoidFinalize<FirstStateVector, OP>, nullptr, OP::Bind,
-		                         AggregateFunction::StateDestroy<FirstStateVector, OP>, nullptr, nullptr);
+		using STATE = FirstState<string_t>;
+		return AggregateFunction(
+		    {type}, type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+		    OP::Update, AggregateFunction::StateCombine<STATE, OP>, AggregateFunction::StateVoidFinalize<STATE, OP>,
+		    nullptr, OP::Bind, LAST ? AggregateFunction::StateDestroy<STATE, OP> : nullptr, nullptr, nullptr);
 	}
 	}
 }

--- a/test/sql/aggregate/aggregates/first_test_all_types.test_slow
+++ b/test/sql/aggregate/aggregates/first_test_all_types.test_slow
@@ -1,0 +1,22 @@
+# name: test/sql/aggregate/aggregates/first_test_all_types.test_slow
+# description: Test the first aggregate on all types
+# group: [aggregates]
+
+statement ok
+pragma enable_verification
+
+# verify that first produces the same result as limit 1 for all types
+statement ok
+CREATE TABLE all_types AS FROM test_all_types();
+
+query I nosort all_types_first
+SELECT * FROM all_types LIMIT 1
+
+query I nosort all_types_first
+SELECT FIRST(COLUMNS(*)) FROM all_types
+
+query I nosort all_types_last
+SELECT * FROM all_types LIMIT 1 OFFSET 2
+
+query I nosort all_types_last
+SELECT LAST(COLUMNS(*)) FROM all_types


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/12520

Fixes https://github.com/duckdb/duckdb/issues/12480

Similar to https://github.com/duckdb/duckdb/pull/12525 - this PR reworks the first/last/any_value functions to move away from the CreateSortKeyHelpers. Similarly this improves performance and greatly reduces memory usage. Performance/memory improvements are very similar to https://github.com/duckdb/duckdb/pull/12525.