### PR TITLE
Add support for `arg_min(ANY, ANY)`

### DIFF
--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -172,8 +172,6 @@ struct ArgMinMaxBase {
 	}
 };
 
-
-
 struct SpecializedGenericArgMinMaxState {
 	static bool CreateExtraState() {
 		// nop extra state
@@ -185,7 +183,7 @@ struct SpecializedGenericArgMinMaxState {
 	}
 };
 
-template<OrderType ORDER_TYPE>
+template <OrderType ORDER_TYPE>
 struct GenericArgMinMaxState {
 	static Vector CreateExtraState() {
 		return Vector(LogicalType::BLOB);
@@ -198,7 +196,8 @@ struct GenericArgMinMaxState {
 	}
 };
 
-template <typename COMPARATOR, bool IGNORE_NULL, OrderType ORDER_TYPE, class UPDATE_TYPE = SpecializedGenericArgMinMaxState>
+template <typename COMPARATOR, bool IGNORE_NULL, OrderType ORDER_TYPE,
+          class UPDATE_TYPE = SpecializedGenericArgMinMaxState>
 struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR, IGNORE_NULL> {
 	template <class STATE>
 	static void Update(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
@@ -268,7 +267,7 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR, IGNORE_NULL> {
 		auto sort_key_data = FlatVector::GetData<string_t>(sort_key);
 
 		// now assign sort keys
-		for(idx_t i = 0; i < assign_count; i++) {
+		for (idx_t i = 0; i < assign_count; i++) {
 			const auto sidx = sdata.sel->get_index(sel.get_index(i));
 			auto &state = *states[sidx];
 			STATE::template AssignValue<ARG_TYPE>(state.arg, sort_key_data[i]);
@@ -284,7 +283,8 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR, IGNORE_NULL> {
 			STATE::template AssignValue<typename STATE::BY_TYPE>(target.value, source.value);
 			target.arg_null = source.arg_null;
 			if (!target.arg_null) {
-				STATE::template AssignValue<typename STATE::ARG_TYPE>(target.arg, source.arg);;
+				STATE::template AssignValue<typename STATE::ARG_TYPE>(target.arg, source.arg);
+				;
 			}
 			target.is_initialized = true;
 		}
@@ -446,14 +446,14 @@ void AddDecimalArgMinMaxFunctionBy(AggregateFunctionSet &fun, const LogicalType 
 	                                  nullptr, nullptr, nullptr, nullptr, BindDecimalArgMinMax<OP>));
 }
 
-template<class OP>
+template <class OP>
 void AddGenericArgMinMaxFunction(AggregateFunctionSet &fun) {
 	using STATE = ArgMinMaxState<string_t, string_t>;
-	fun.AddFunction(AggregateFunction(
-		    {LogicalType::ANY, LogicalType::ANY}, LogicalType::ANY, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
-		    OP::template Update<STATE>, AggregateFunction::StateCombine<STATE, OP>,
-		    AggregateFunction::StateVoidFinalize<STATE, OP>, nullptr, OP::Bind, AggregateFunction::StateDestroy<STATE, OP>));
-
+	fun.AddFunction(
+	    AggregateFunction({LogicalType::ANY, LogicalType::ANY}, LogicalType::ANY, AggregateFunction::StateSize<STATE>,
+	                      AggregateFunction::StateInitialize<STATE, OP>, OP::template Update<STATE>,
+	                      AggregateFunction::StateCombine<STATE, OP>, AggregateFunction::StateVoidFinalize<STATE, OP>,
+	                      nullptr, OP::Bind, AggregateFunction::StateDestroy<STATE, OP>));
 }
 
 template <class COMPARATOR, bool IGNORE_NULL, OrderType ORDER_TYPE>

--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -180,8 +180,8 @@ struct SpecializedGenericArgMinMaxState {
 		return false;
 	}
 
-	static void PrepareData(Vector &by, idx_t input_count, bool &extra_state, UnifiedVectorFormat &result) {
-		by.ToUnifiedFormat(input_count, result);
+	static void PrepareData(Vector &by, idx_t count, bool &, UnifiedVectorFormat &result) {
+		by.ToUnifiedFormat(count, result);
 	}
 };
 
@@ -191,10 +191,10 @@ struct GenericArgMinMaxState {
 		return Vector(LogicalType::BLOB);
 	}
 
-	static void PrepareData(Vector &by, idx_t input_count, Vector &extra_state, UnifiedVectorFormat &result) {
-		auto modifiers = OrderModifiers(ORDER_TYPE, OrderByNullType::NULLS_LAST);
-		CreateSortKeyHelpers::CreateSortKey(by, input_count, modifiers, extra_state);
-		extra_state.ToUnifiedFormat(input_count, result);
+	static void PrepareData(Vector &by, idx_t count, Vector &extra_state, UnifiedVectorFormat &result) {
+		OrderModifiers modifiers(ORDER_TYPE, OrderByNullType::NULLS_LAST);
+		CreateSortKeyHelpers::CreateSortKey(by, count, modifiers, extra_state);
+		extra_state.ToUnifiedFormat(count, result);
 	}
 };
 
@@ -211,7 +211,7 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR, IGNORE_NULL> {
 		auto &by = inputs[1];
 		UnifiedVectorFormat bdata;
 		auto extra_state = UPDATE_TYPE::CreateExtraState();
-		UPDATE_TYPE::PrepareData(by, input_count, extra_state, bdata);
+		UPDATE_TYPE::PrepareData(by, count, extra_state, bdata);
 		const auto bys = UnifiedVectorFormat::GetData<BY_TYPE>(bdata);
 
 		UnifiedVectorFormat sdata;

--- a/test/sql/aggregate/aggregates/arg_min_max_all_types.test_slow
+++ b/test/sql/aggregate/aggregates/arg_min_max_all_types.test_slow
@@ -1,0 +1,23 @@
+# name: test/sql/aggregate/aggregates/arg_min_max_all_types.test_slow
+# description: Test argmin and argmax operator for all types
+# group: [aggregates]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table all_types as from test_all_types()
+
+foreach col bool tinyint smallint int bigint hugeint uhugeint utinyint usmallint uint ubigint date time timestamp timestamp_s timestamp_ms timestamp_ns time_tz timestamp_tz float double dec_4_1 dec_9_4 dec_18_6 dec38_10 uuid interval varchar blob bit small_enum medium_enum large_enum int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs map union fixed_int_array fixed_varchar_array fixed_nested_int_array fixed_nested_varchar_array fixed_struct_array struct_of_fixed_array fixed_array_of_int_list list_of_fixed_int_array
+
+query I
+SELECT MIN("${col}") IS NOT DISTINCT FROM ARG_MIN("${col}", "${col}") FROM all_types
+----
+true
+
+query I
+SELECT MAX("${col}") IS NOT DISTINCT FROM ARG_MAX("${col}", "${col}") FROM all_types
+----
+true
+
+endloop


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/12525

This PR uses the new sort key implementation to add support for `arg_min(ANY, ANY)` (and friends), so that any type including composite types can be used as both key and value, e.g.:

```sql
CREATE TABLE structs AS SELECT i, {'i': i} s FROM range(100000000) t(i);
D SELECT arg_min(s, s) AS result FROM structs;
┌──────────────────┐
│      result      │
│ struct(i bigint) │
├──────────────────┤
│ {'i': 0}         │
└──────────────────┘

```