### PR TITLE
Support all types in `histogram` function

### DIFF
--- a/src/core_functions/aggregate/nested/histogram.cpp
+++ b/src/core_functions/aggregate/nested/histogram.cpp
@@ -158,7 +158,6 @@ static void HistogramCombineFunction(Vector &state_vector, Vector &combined, Agg
 template <class OP, class T, class MAP_TYPE>
 static void HistogramFinalizeFunction(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count,
                                       idx_t offset) {
-
 	UnifiedVectorFormat sdata;
 	state_vector.ToUnifiedFormat(count, sdata);
 	auto states = UnifiedVectorFormat::GetData<HistogramAggState<T, MAP_TYPE> *>(sdata);

--- a/src/core_functions/aggregate/nested/histogram.cpp
+++ b/src/core_functions/aggregate/nested/histogram.cpp
@@ -255,7 +255,7 @@ AggregateFunction GetHistogramFunction(const LogicalType &type) {
 	}
 }
 
-template<bool IS_ORDERED = true>
+template <bool IS_ORDERED = true>
 unique_ptr<FunctionData> HistogramBindFunction(ClientContext &context, AggregateFunction &function,
                                                vector<unique_ptr<Expression>> &arguments) {
 
@@ -270,21 +270,15 @@ unique_ptr<FunctionData> HistogramBindFunction(ClientContext &context, Aggregate
 
 AggregateFunctionSet HistogramFun::GetFunctions() {
 	AggregateFunctionSet fun;
-	AggregateFunction histogram_function("histogram", {LogicalType::ANY}, LogicalTypeId::MAP, nullptr,
-	                         nullptr,
-	                         nullptr, nullptr,
-	                         nullptr, nullptr, HistogramBindFunction,
-	                         nullptr);
+	AggregateFunction histogram_function("histogram", {LogicalType::ANY}, LogicalTypeId::MAP, nullptr, nullptr, nullptr,
+	                                     nullptr, nullptr, nullptr, HistogramBindFunction, nullptr);
 	fun.AddFunction(histogram_function);
 	return fun;
 }
 
 AggregateFunction HistogramFun::GetHistogramUnorderedMap(LogicalType &type) {
-	return AggregateFunction("histogram", {LogicalType::ANY}, LogicalTypeId::MAP, nullptr,
-	                         nullptr,
-	                         nullptr, nullptr,
-	                         nullptr, nullptr, HistogramBindFunction<false>,
-	                         nullptr);
+	return AggregateFunction("histogram", {LogicalType::ANY}, LogicalTypeId::MAP, nullptr, nullptr, nullptr, nullptr,
+	                         nullptr, nullptr, HistogramBindFunction<false>, nullptr);
 }
 
 } // namespace duckdb

--- a/src/core_functions/scalar/list/list_aggregates.cpp
+++ b/src/core_functions/scalar/list/list_aggregates.cpp
@@ -486,8 +486,7 @@ static unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, Scala
 
 	// create the unordered map histogram function
 	D_ASSERT(best_function.arguments.size() == 1);
-	auto key_type = best_function.arguments[0];
-	auto aggr_function = HistogramFun::GetHistogramUnorderedMap(key_type);
+	auto aggr_function = HistogramFun::GetHistogramUnorderedMap(child_type);
 	return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, child_type, aggr_function, arguments);
 }
 

--- a/src/core_functions/scalar/list/list_aggregates.cpp
+++ b/src/core_functions/scalar/list/list_aggregates.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/core_functions/create_sort_key.hpp"
 
 namespace duckdb {
 
@@ -93,16 +94,23 @@ struct StateVector {
 
 struct FinalizeValueFunctor {
 	template <class T>
-	static Value FinalizeValue(T first) {
-		return Value::CreateValue(first);
+	static void HistogramFinalize(T value, Vector &result, idx_t offset) {
+		FlatVector::GetData<T>(result)[offset] = value;
 	}
 };
 
 struct FinalizeStringValueFunctor {
 	template <class T>
-	static Value FinalizeValue(T first) {
-		string_t value = first;
-		return Value::CreateValue(value);
+	static void HistogramFinalize(T value, Vector &result, idx_t offset) {
+		FlatVector::GetData<string_t>(result)[offset] = StringVector::AddStringOrBlob(result, value);
+	}
+};
+
+struct FinalizeGenericValueFunctor {
+	template <class T>
+	static void HistogramFinalize(T value, Vector &result, idx_t offset) {
+		CreateSortKeyHelpers::DecodeSortKey(value, result, offset,
+		                                    OrderModifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST));
 	}
 };
 
@@ -115,32 +123,44 @@ struct AggregateFunctor {
 struct DistinctFunctor {
 	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
 	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
-
 		UnifiedVectorFormat sdata;
 		state_vector.ToUnifiedFormat(count, sdata);
-		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+		auto states = UnifiedVectorFormat::GetData<HistogramAggState<T, MAP_TYPE> *>(sdata);
 
-		auto result_data = FlatVector::GetData<list_entry_t>(result);
-
-		idx_t offset = 0;
+		auto old_len = ListVector::GetListSize(result);
+		idx_t new_entries = 0;
+		// figure out how much space we need
 		for (idx_t i = 0; i < count; i++) {
+			auto &state = *states[sdata.sel->get_index(i)];
+			if (!state.hist) {
+				continue;
+			}
+			new_entries += state.hist->size();
+		}
+		// reserve space in the list vector
+		ListVector::Reserve(result, old_len + new_entries);
+		auto &child_elements = ListVector::GetEntry(result);
+		auto list_entries = FlatVector::GetData<list_entry_t>(result);
 
-			auto state = states[sdata.sel->get_index(i)];
-			result_data[i].offset = offset;
-
-			if (!state->hist) {
-				result_data[i].length = 0;
+		idx_t current_offset = old_len;
+		for (idx_t i = 0; i < count; i++) {
+			const auto rid = i;
+			auto &state = *states[sdata.sel->get_index(i)];
+			auto &list_entry = list_entries[rid];
+			list_entry.offset = current_offset;
+			if (!state.hist) {
+				list_entry.length = 0;
 				continue;
 			}
 
-			result_data[i].length = state->hist->size();
-			offset += state->hist->size();
-
-			for (auto &entry : *state->hist) {
-				Value bucket_value = OP::template FinalizeValue<T>(entry.first);
-				ListVector::PushBack(result, bucket_value);
+			for (auto &entry : *state.hist) {
+				OP::template HistogramFinalize<T>(entry.first, child_elements, current_offset);
+				current_offset++;
 			}
+			list_entry.length = current_offset - list_entry.offset;
 		}
+		D_ASSERT(current_offset == old_len + new_entries);
+		ListVector::SetListSize(result, current_offset);
 		result.Verify(count);
 	}
 };
@@ -148,13 +168,11 @@ struct DistinctFunctor {
 struct UniqueFunctor {
 	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
 	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
-
 		UnifiedVectorFormat sdata;
 		state_vector.ToUnifiedFormat(count, sdata);
-		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+		auto states = UnifiedVectorFormat::GetData<HistogramAggState<T, MAP_TYPE> *>(sdata);
 
 		auto result_data = FlatVector::GetData<uint64_t>(result);
-
 		for (idx_t i = 0; i < count; i++) {
 
 			auto state = states[sdata.sel->get_index(i)];
@@ -163,7 +181,6 @@ struct UniqueFunctor {
 				result_data[i] = 0;
 				continue;
 			}
-
 			result_data[i] = state->hist->size();
 		}
 		result.Verify(count);
@@ -305,49 +322,12 @@ static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vect
 			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::INT32:
-			if (key_type.id() == LogicalTypeId::DATE) {
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, date_t>(
-				    result, state_vector.state_vector, count);
-			} else {
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
-				    result, state_vector.state_vector, count);
-			}
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::INT64:
-			switch (key_type.id()) {
-			case LogicalTypeId::TIME:
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, dtime_t>(
-				    result, state_vector.state_vector, count);
-				break;
-			case LogicalTypeId::TIME_TZ:
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, dtime_tz_t>(
-				    result, state_vector.state_vector, count);
-				break;
-			case LogicalTypeId::TIMESTAMP:
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, timestamp_t>(
-				    result, state_vector.state_vector, count);
-				break;
-			case LogicalTypeId::TIMESTAMP_MS:
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, timestamp_ms_t>(
-				    result, state_vector.state_vector, count);
-				break;
-			case LogicalTypeId::TIMESTAMP_NS:
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, timestamp_ns_t>(
-				    result, state_vector.state_vector, count);
-				break;
-			case LogicalTypeId::TIMESTAMP_SEC:
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, timestamp_sec_t>(
-				    result, state_vector.state_vector, count);
-				break;
-			case LogicalTypeId::TIMESTAMP_TZ:
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, timestamp_tz_t>(
-				    result, state_vector.state_vector, count);
-				break;
-			default:
-				FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
-				    result, state_vector.state_vector, count);
-				break;
-			}
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
 			break;
 		case PhysicalType::FLOAT:
 			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, float>(
@@ -362,7 +342,9 @@ static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vect
 			    result, state_vector.state_vector, count);
 			break;
 		default:
-			throw InternalException("Unimplemented histogram aggregate");
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeGenericValueFunctor, string>(
+			    result, state_vector.state_vector, count);
+			break;
 		}
 	}
 

--- a/test/sql/aggregate/aggregates/histogram_test_all_types.test_slow
+++ b/test/sql/aggregate/aggregates/histogram_test_all_types.test_slow
@@ -1,0 +1,21 @@
+# name: test/sql/aggregate/aggregates/histogram_test_all_types.test_slow
+# description: Test histogram operator for all types
+# group: [aggregates]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table all_types as from test_all_types()
+
+foreach col bool tinyint smallint int bigint hugeint uhugeint utinyint usmallint uint ubigint date time timestamp timestamp_s timestamp_ms timestamp_ns time_tz timestamp_tz float double dec_4_1 dec_9_4 dec_18_6 dec38_10 uuid interval varchar blob bit small_enum medium_enum large_enum int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs map union fixed_int_array fixed_varchar_array fixed_nested_int_array fixed_nested_varchar_array fixed_struct_array struct_of_fixed_array fixed_array_of_int_list list_of_fixed_int_array
+
+query II
+SELECT histogram[min], histogram[max] FROM (
+	SELECT HISTOGRAM("${col}") histogram, MIN("${col}") min, MAX("${col}") max
+	FROM all_types
+)
+----
+[1]	[1]
+
+endloop

--- a/test/sql/aggregate/aggregates/test_histogram.test
+++ b/test/sql/aggregate/aggregates/test_histogram.test
@@ -143,4 +143,4 @@ INSERT INTO enums VALUES ('happy'), ('ok')
 query I
 SELECT histogram(e) FROM enums
 ----
-{happy=1, ok=1}
+{ok=1, happy=1}

--- a/test/sql/function/list/aggregates/types.test
+++ b/test/sql/function/list/aggregates/types.test
@@ -391,7 +391,7 @@ SELECT list_aggr([{'a': 1}], '${func_name}')
 endloop
 
 # list, struct, any other result
-foreach func_name approx_count_distinct count entropy array_agg list  string_agg group_concat
+foreach func_name approx_count_distinct count entropy array_agg list string_agg group_concat histogram
 
 statement ok
 SELECT list_aggr([[1]], '${func_name}')
@@ -404,7 +404,7 @@ endloop
 # statement error for NESTED types
 
 # list, struct
-foreach func_name avg favg bit_and bit_or bit_xor bool_and bool_or histogram kurtosis mad product sem skewness sum fsum sumKahan kahan_sum var_samp var_pop stddev stddev_pop variance stddev_samp
+foreach func_name avg favg bit_and bit_or bit_xor bool_and bool_or kurtosis mad product sem skewness sum fsum sumKahan kahan_sum var_samp var_pop stddev stddev_pop variance stddev_samp
 
 statement error
 SELECT list_aggr([[1]], '${func_name}')

--- a/test/sql/function/list/list_distinct.test
+++ b/test/sql/function/list/list_distinct.test
@@ -45,14 +45,10 @@ No function matches
 
 # test incorrect parameter type
 
-foreach type boolean varchar tinyint smallint integer bigint hugeint uhugeint utinyint usmallint uinteger ubigint float double decimal(4,1) decimal(9,4) decimal(18,6) decimal(38,10) date time timestamp timestamp_s timestamp_ms timestamp_ns timetz timestamptz interval blob
-
 statement error
-SELECT list_distinct(NULL::${type})
+SELECT list_distinct(NULL::boolean)
 ----
 No function matches
-
-endloop
 
 # other tests
 

--- a/test/sql/function/list/list_distinct.test
+++ b/test/sql/function/list/list_distinct.test
@@ -265,31 +265,6 @@ SELECT list_sort(list_distinct(['a', 'b、c', 'a']))
 statement ok
 CREATE TABLE all_types AS SELECT * FROM test_all_types();
 
-# unsupported histogram types
-foreach colname bool tinyint smallint int bigint utinyint usmallint uint ubigint date time timestamp timestamp_s timestamp_ms timestamp_ns time_tz timestamp_tz float double dec_4_1 dec_9_4 uuid interval varchar small_enum medium_enum large_enum
-
+# list distinct is supported for all types
 statement ok
-select list_distinct(["${colname}"]) FROM all_types;
-
-endloop
-
-# we support histogram for the min/max values of these types
-foreach colname hugeint dec_18_6 dec38_10
-
-statement ok
-select list_distinct(["${colname}"]) FROM all_types;
-
-endloop
-
-statement ok
-select list_distinct(["blob"]) FROM all_types;
-
-# we don't support histogram for nested types
-foreach colname int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs map
-
-statement error
-select list_distinct(["${colname}"]) FROM all_types;
-----
-Not implemented Error
-
-endloop
+SELECT list_distinct([COLUMNS(*)]) FROM all_types;

--- a/test/sql/function/list/list_intersect.test
+++ b/test/sql/function/list/list_intersect.test
@@ -48,10 +48,11 @@ insert into list_of_list values (NULL, NULL);
 statement ok
 insert into list_of_list values ([[1 , 2, 3], NULL, [3, 2, 1]], [[ 2, 3, 4], NULL, [1, 2, 3]]);
 
-statement error
+query I
 select ${f}(l1, l2) from list_of_list;
 ----
-Not implemented
+NULL
+[[1, 2, 3]]
 
 statement ok
 drop table list_of_list;

--- a/test/sql/function/list/list_unique.test
+++ b/test/sql/function/list/list_unique.test
@@ -38,14 +38,9 @@ SELECT list_unique([1, 2], 2)
 ----
 
 # test incorrect parameter type
-
-foreach type boolean varchar tinyint smallint integer bigint hugeint utinyint usmallint uinteger ubigint uhugeint float double decimal(4,1) decimal(9,4) decimal(18,6) decimal(38,10) date time timestamp timestamp_s timestamp_ms timestamp_ns timetz timestamptz interval blob
-
 statement error
-SELECT list_unique(NULL::${type})
+SELECT list_unique(NULL::tinyint)
 ----
-
-endloop
 
 # other tests
 


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/12520

This PR uses the newly introduced decoding of sort keys to extend the `histogram` function to support all types. In addition, we do some clean-up by no longer using `Value` or `ListVector::PushBack` in the finalization of the histogram and instead directly appending to the underlying lists. This improves performance somewhat for larger histograms - but generally the (unordered) map insertions are still the bottleneck.

As the histogram function is also used internally by several list functions (e.g. `list_distinct`, `list_unique`) those functions now also support all types, e.g. this now works:

```sql
D select list_distinct([{'i': 42}, {'i': 84}, {'i': 42}]) AS result;
┌────────────────────────┐
│         result         │
│  struct(i integer)[]   │
├────────────────────────┤
│ [{'i': 84}, {'i': 42}] │
└────────────────────────┘
```