### PR TITLE
[CI] Remove pyarrow version lock

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -244,7 +244,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
-        pip install numpy pytest pandas mypy psutil "pyarrow<=11.0.0"
+        pip install numpy pytest pandas mypy psutil pyarrow
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2310

At some point we introduced this lock because pyarrow 12+ had a bug that was causing our CI to fail.