### PR TITLE
[Dev] Change tests: np.NaN -> np.nan

### DIFF
--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_na.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_na.py
@@ -28,17 +28,17 @@ class TestPandasNA(object):
         items = [x[0] for x in [y for y in res]]
         assert_nullness(items, [null_index])
 
-        # Test if pd.NA behaves the same as np.NaN once converted
+        # Test if pd.NA behaves the same as np.nan once converted
         nan_df = pd.DataFrame(
             {
                 'a': [
                     1.123,
                     5.23234,
-                    np.NaN,
+                    np.nan,
                     7234.0000124,
                     0.000000124,
                     0000000000000.0000001,
-                    np.NaN,
+                    np.nan,
                     -2342349234.00934580345,
                 ]
             }

--- a/tools/pythonpkg/tests/fast/test_all_types.py
+++ b/tools/pythonpkg/tests/fast/test_all_types.py
@@ -396,15 +396,15 @@ class TestAllTypes(object):
             ),
             # Enums don't have a numpy equivalent and yield pandas Categorical.
             'small_enum': pd.Categorical(
-                ['DUCK_DUCK_ENUM', 'GOOSE', np.NaN],
+                ['DUCK_DUCK_ENUM', 'GOOSE', np.nan],
                 ordered=True,
             ),
             'medium_enum': pd.Categorical(
-                ['enum_0', 'enum_299', np.NaN],
+                ['enum_0', 'enum_299', np.nan],
                 ordered=True,
             ),
             'large_enum': pd.Categorical(
-                ['enum_0', 'enum_69999', np.NaN],
+                ['enum_0', 'enum_69999', np.nan],
                 ordered=True,
             ),
             # The following types don't have a numpy equivalent and yield


### PR DESCRIPTION
`np.NaN` as an alias was deprecated in NumPy 2.0.0, use `np.nan` instead