### PR TITLE
Fix trouble to compile with MSVC

### DIFF
--- a/third_party/libpg_query/postgres_parser.cpp
+++ b/third_party/libpg_query/postgres_parser.cpp
@@ -40,7 +40,8 @@ bool PostgresParser::IsKeyword(const std::string &text) {
 
 vector<duckdb_libpgquery::PGKeyword> PostgresParser::KeywordList() {
 	// FIXME: because of this, we might need to change the libpg_query library to use duckdb::vector
-	return duckdb_libpgquery::keyword_list();
+	vector<duckdb_libpgquery::PGKeyword> tmp(duckdb_libpgquery::keyword_list());
+	return std::move(tmp);
 }
 
 void PostgresParser::SetPreserveIdentifierCase(bool preserve) {

--- a/third_party/libpg_query/postgres_parser.cpp
+++ b/third_party/libpg_query/postgres_parser.cpp
@@ -40,7 +40,7 @@ bool PostgresParser::IsKeyword(const std::string &text) {
 
 vector<duckdb_libpgquery::PGKeyword> PostgresParser::KeywordList() {
 	// FIXME: because of this, we might need to change the libpg_query library to use duckdb::vector
-	return std::forward<vector<duckdb_libpgquery::PGKeyword> >(duckdb_libpgquery::keyword_list());
+	return duckdb_libpgquery::keyword_list();
 }
 
 void PostgresParser::SetPreserveIdentifierCase(bool preserve) {


### PR DESCRIPTION
Remove std::forward here since MSVC does not compile with it. It issues a cryptic error message:

...\duckdb-src\third_party\libpg_query\postgres_parser.cpp(43): error C2243: 'type cast': conversion from 'std::vector<duckdb_libpgquery::PGKeyword,std::allocator<duckdb_libpgquery::PGKeyword>> *' to '_Ty &&' exists, but is inaccessible
          with
          [
              _Ty=duckdb::vector<duckdb_libpgquery::PGKeyword,true>
          ]

But the real problem seems to be that std::forward should not really be used here.

See: https://github.com/duckdb/duckdb/discussions/12487