### PR TITLE
Add `bind_expression` callback to scalar function, and use it to turn `typeof` into a `BoundConstantExpression` 

### DIFF
--- a/src/core_functions/scalar/generic/typeof.cpp
+++ b/src/core_functions/scalar/generic/typeof.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/core_functions/scalar/generic_functions.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
 
@@ -7,9 +9,20 @@ static void TypeOfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	result.Reference(v);
 }
 
+unique_ptr<Expression> BindTypeOfFunctionExpression(FunctionBindExpressionInput &input) {
+	auto &return_type = input.function.children[0]->return_type;
+	if (return_type.id() == LogicalTypeId::UNKNOWN || return_type.id() == LogicalTypeId::SQLNULL) {
+		// parameter - unknown return type
+		return nullptr;
+	}
+	// emit a constant expression
+	return make_uniq<BoundConstantExpression>(Value(return_type.ToString()));
+}
+
 ScalarFunction TypeOfFun::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::ANY}, LogicalType::VARCHAR, TypeOfFunction);
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	// fun.bind_expression = BindTypeOfFunctionExpression;
 	return fun;
 }
 

--- a/src/core_functions/scalar/generic/typeof.cpp
+++ b/src/core_functions/scalar/generic/typeof.cpp
@@ -22,7 +22,7 @@ unique_ptr<Expression> BindTypeOfFunctionExpression(FunctionBindExpressionInput 
 ScalarFunction TypeOfFun::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::ANY}, LogicalType::VARCHAR, TypeOfFunction);
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
-	// fun.bind_expression = BindTypeOfFunctionExpression;
+	fun.bind_expression = BindTypeOfFunctionExpression;
 	return fun;
 }
 

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -359,10 +359,10 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_f
 	unique_ptr<Expression> result;
 	auto result_func = make_uniq<BoundFunctionExpression>(std::move(return_type), std::move(bound_function),
 	                                                      std::move(children), std::move(bind_info), is_operator);
-	if (bound_function.bind_expression) {
+	if (result_func->function.bind_expression) {
 		// if a bind_expression callback is registered - call it and emit the resulting expression
 		FunctionBindExpressionInput input(result_func->bind_info.get(), *result_func);
-		result = bound_function.bind_expression(input);
+		result = result_func->function.bind_expression(input);
 	}
 	if (!result) {
 		result = std::move(result_func);

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/function/scalar/generic_functions.hpp"
 
 namespace duckdb {
 
@@ -338,9 +339,9 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunctionCatalogE
 	return BindScalarFunction(bound_function, std::move(children), is_operator, binder);
 }
 
-unique_ptr<BoundFunctionExpression> FunctionBinder::BindScalarFunction(ScalarFunction bound_function,
-                                                                       vector<unique_ptr<Expression>> children,
-                                                                       bool is_operator, optional_ptr<Binder> binder) {
+unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_function,
+                                                          vector<unique_ptr<Expression>> children, bool is_operator,
+                                                          optional_ptr<Binder> binder) {
 	unique_ptr<FunctionData> bind_info;
 	if (bound_function.bind) {
 		bind_info = bound_function.bind(context, bound_function, children);
@@ -355,8 +356,18 @@ unique_ptr<BoundFunctionExpression> FunctionBinder::BindScalarFunction(ScalarFun
 
 	// now create the function
 	auto return_type = bound_function.return_type;
-	return make_uniq<BoundFunctionExpression>(std::move(return_type), std::move(bound_function), std::move(children),
-	                                          std::move(bind_info), is_operator);
+	unique_ptr<Expression> result;
+	auto result_func = make_uniq<BoundFunctionExpression>(std::move(return_type), std::move(bound_function),
+	                                                      std::move(children), std::move(bind_info), is_operator);
+	if (bound_function.bind_expression) {
+		// if a bind_expression callback is registered - call it and emit the resulting expression
+		FunctionBindExpressionInput input(result_func->bind_info.get(), *result_func);
+		result = bound_function.bind_expression(input);
+	}
+	if (!result) {
+		result = std::move(result_func);
+	}
+	return result;
 }
 
 unique_ptr<BoundAggregateExpression> FunctionBinder::BindAggregateFunction(AggregateFunction bound_function,

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -16,8 +16,8 @@ ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, Logic
     : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type), side_effects,
                          std::move(varargs), null_handling),
       function(std::move(function)), bind(bind), init_local_state(init_local_state), dependency(dependency),
-      statistics(statistics), bind_lambda(bind_lambda), get_modified_databases(nullptr), serialize(nullptr),
-      deserialize(nullptr) {
+      statistics(statistics), bind_lambda(bind_lambda), bind_expression(nullptr), get_modified_databases(nullptr),
+      serialize(nullptr), deserialize(nullptr) {
 }
 
 ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -57,10 +57,10 @@ public:
 	                                                     bool is_operator = false,
 	                                                     optional_ptr<Binder> binder = nullptr);
 
-	DUCKDB_API unique_ptr<BoundFunctionExpression> BindScalarFunction(ScalarFunction bound_function,
-	                                                                  vector<unique_ptr<Expression>> children,
-	                                                                  bool is_operator = false,
-	                                                                  optional_ptr<Binder> binder = nullptr);
+	DUCKDB_API unique_ptr<Expression> BindScalarFunction(ScalarFunction bound_function,
+	                                                     vector<unique_ptr<Expression>> children,
+	                                                     bool is_operator = false,
+	                                                     optional_ptr<Binder> binder = nullptr);
 
 	DUCKDB_API unique_ptr<BoundAggregateExpression>
 	BindAggregateFunction(AggregateFunction bound_function, vector<unique_ptr<Expression>> children,

--- a/src/include/duckdb/function/scalar/generic_functions.hpp
+++ b/src/include/duckdb/function/scalar/generic_functions.hpp
@@ -11,6 +11,8 @@
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/function/built_in_functions.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
 
 namespace duckdb {
 class BoundFunctionExpression;

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -75,6 +75,15 @@ struct FunctionModifiedDatabasesInput {
 	unordered_set<string> &modified_databases;
 };
 
+struct FunctionBindExpressionInput {
+	FunctionBindExpressionInput(optional_ptr<FunctionData> bind_data_p, BoundFunctionExpression &function_p)
+	    : bind_data(bind_data_p), function(function_p) {
+	}
+
+	optional_ptr<FunctionData> bind_data;
+	BoundFunctionExpression &function;
+};
+
 //! The scalar function type
 typedef std::function<void(DataChunk &, ExpressionState &, Vector &)> scalar_function_t;
 //! The type to bind the scalar function and to create the function data
@@ -96,6 +105,9 @@ typedef void (*get_modified_databases_t)(FunctionModifiedDatabasesInput &input);
 typedef void (*function_serialize_t)(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
                                      const ScalarFunction &function);
 typedef unique_ptr<FunctionData> (*function_deserialize_t)(Deserializer &deserializer, ScalarFunction &function);
+
+//! The type to bind lambda-specific parameter types
+typedef unique_ptr<Expression> (*function_bind_expression_t)(FunctionBindExpressionInput &input);
 
 class ScalarFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
 public:
@@ -128,6 +140,8 @@ public:
 	function_statistics_t statistics;
 	//! The lambda bind function (if any)
 	bind_lambda_function_t bind_lambda;
+	//! Function to bind the result function expression directly (if any)
+	function_bind_expression_t bind_expression;
 	//! Gets the modified databases (if any)
 	get_modified_databases_t get_modified_databases;
 

--- a/test/sql/copy/csv/rejects/csv_rejects_flush_cast.test
+++ b/test/sql/copy/csv/rejects/csv_rejects_flush_cast.test
@@ -7,15 +7,15 @@ require skip_reload
 # Test will fail on windows because byte_position is slightly different due to \r\n instead of \n
 require notwindows
 
-query III
-SELECT typeof(first(a)), typeof(first(b)), COUNT(*) FROM read_csv(
+query IIIII
+SELECT first(a), first(b), typeof(first(a)), typeof(first(b)), COUNT(*) FROM read_csv(
     'data/csv/error/flush_cast.csv',
     columns = {'a': 'DATE', 'b': 'VARCHAR'},
     store_rejects = true,
     delim = ',',
     dateformat = '%d-%m-%Y');
 ----
-DATE	VARCHAR	2811
+2001-09-25	 bla	DATE	VARCHAR	2811
 
 query IIIIIIIII
 SELECT * EXCLUDE (scan_id) FROM reject_errors order by all;

--- a/test/sql/copy/hive_types.test_slow
+++ b/test/sql/copy/hive_types.test_slow
@@ -30,7 +30,7 @@ select typeof(season),typeof(director),typeof(aired) from read_parquet('__TEST_D
 SMALLINT	VARCHAR	DATE
 
 statement error
-select typeof(season),typeof(director),typeof(aired) from read_parquet('__TEST_DIR__/partition/**/*.parquet', hive_types={'season':date}) limit 1;
+select season,director,aired from read_parquet('__TEST_DIR__/partition/**/*.parquet', hive_types={'season':date}) limit 1;
 ----
 Invalid Input Error: Unable to cast 
 

--- a/test/sql/types/numeric/combinations/decimal_combinations.test
+++ b/test/sql/types/numeric/combinations/decimal_combinations.test
@@ -46,11 +46,11 @@ DECIMAL
 
 # HUGEINT sets width to 38+scale, so it will never fit into DECIMAL
 statement error
-select (typeof([(SELECT min from hugeint_limits), 1.00005])::VARCHAR)[:7]
+select [(SELECT min from hugeint_limits), 1.00005]
 ----
 
 statement error
-select (typeof([(SELECT max from hugeint_limits), 1.00005])::VARCHAR)[:7]
+select [(SELECT max from hugeint_limits), 1.00005]
 ----
 
 endloop


### PR DESCRIPTION
This PR adds a new callback to scalar functions - `bind_expression`. This callback can be used post-bind to modify the resulting `BoundFunctionExpression`, and also turn it into a different expression if desired. The callback is as follows:

```cpp
struct FunctionBindExpressionInput {
	optional_ptr<FunctionData> bind_data;
	BoundFunctionExpression &function;
};
typedef unique_ptr<Expression> (*function_bind_expression_t)(FunctionBindExpressionInput &input);
```

#### typeof constant

The `typeof` function is extended to use this callback to turn itself into a `BoundConstantExpression`. This can be seen in the `EXPLAIN` plan, e.g.:

```sql
explain select typeof(l_orderkey) from lineitem;
┌───────────────────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          'BIGINT'         │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│         SEQ_SCAN          │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          lineitem         │
└───────────────────────────┘    
```

Whereas in previous versions:

```sql
D explain select typeof(l_orderkey) from lineitem;
┌───────────────────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│     typeof(l_orderkey)    │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│         SEQ_SCAN          │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          lineitem         │
└───────────────────────────┘                             
```

The reason this is useful is that `typeof` is a function that returns a constant - but the system is not aware of that in the current version. As such, code that branches on the type of an expression cannot be flattened/simplified. For example, in the old implementation, when doing a `CASE` that filters based on `typeof` - we can see that both aggregates are computed as the system does not realize that `typeof` is really a constant function:

```sql
EXPLAIN
SELECT 
    CASE
    WHEN typeof(MIN(l_orderkey))='BIGINT'
    THEN MIN(l_orderkey)
    ELSE MAX(l_orderkey)
    END AS result
FROM lineitem;
┌───────────────────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│           result          │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│    UNGROUPED_AGGREGATE    │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          min(#0)          │
│          max(#1)          │
└─────────────┬─────────────┘                                             
┌─────────────┴─────────────┐
│         SEQ_SCAN          │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          lineitem         │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│         l_orderkey        │
└───────────────────────────┘                             

```

In the new implementation, we can see that the `MAX` function is stripped/removed entirely:

```sql
┌───────────────────────────┐
│    UNGROUPED_AGGREGATE    │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          min(#0)          │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│         PROJECTION        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│         l_orderkey        │
└─────────────┬─────────────┘                             
┌─────────────┴─────────────┐
│         SEQ_SCAN          │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│          lineitem         │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│         l_orderkey        │
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│       EC: 149996355       │
└───────────────────────────┘                             
```

### Macros

While such branching might seem odd in regular SQL, it is rather useful for (table) macros in which we do not know the types of the input arguments. By allowing the pruning of expression trees that will never be executed at compile time we can write macros that adapt to the input type much more effectively. 
