### PR TITLE
Add `can_cast_implicitly` scalar function

### DIFF
--- a/src/core_functions/function_list.cpp
+++ b/src/core_functions/function_list.cpp
@@ -109,6 +109,7 @@ static const StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_AGGREGATE_FUNCTION_SET(BitstringAggFun),
 	DUCKDB_AGGREGATE_FUNCTION(BoolAndFun),
 	DUCKDB_AGGREGATE_FUNCTION(BoolOrFun),
+	DUCKDB_SCALAR_FUNCTION(CanCastImplicitlyFun),
 	DUCKDB_SCALAR_FUNCTION(CardinalityFun),
 	DUCKDB_SCALAR_FUNCTION(CbrtFun),
 	DUCKDB_SCALAR_FUNCTION_SET(CeilFun),

--- a/src/core_functions/scalar/generic/CMakeLists.txt
+++ b/src/core_functions/scalar/generic/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   duckdb_func_generic
   OBJECT
   alias.cpp
+  can_implicitly_cast.cpp
   current_setting.cpp
   error.cpp
   hash.cpp

--- a/src/core_functions/scalar/generic/can_implicitly_cast.cpp
+++ b/src/core_functions/scalar/generic/can_implicitly_cast.cpp
@@ -1,0 +1,40 @@
+#include "duckdb/core_functions/scalar/generic_functions.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/function/cast/cast_function_set.hpp"
+#include "duckdb/function/cast_rules.hpp"
+
+namespace duckdb {
+
+bool CanCastImplicitly(ClientContext &context, const LogicalType &source, const LogicalType &target) {
+	return CastFunctionSet::Get(context).ImplicitCastCost(source, target) >= 0;
+}
+
+static void CanCastImplicitlyFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &context = state.GetContext();
+	bool can_cast_implicitly = CanCastImplicitly(context, args.data[0].GetType(), args.data[1].GetType());
+	auto v = Value::BOOLEAN(can_cast_implicitly);
+	result.Reference(v);
+}
+
+unique_ptr<Expression> BindCanCastImplicitlyExpression(FunctionBindExpressionInput &input) {
+	auto &source_type = input.function.children[0]->return_type;
+	auto &target_type = input.function.children[1]->return_type;
+	if (source_type.id() == LogicalTypeId::UNKNOWN || source_type.id() == LogicalTypeId::SQLNULL ||
+	    target_type.id() == LogicalTypeId::UNKNOWN || target_type.id() == LogicalTypeId::SQLNULL) {
+		// parameter - unknown return type
+		return nullptr;
+	}
+	// emit a constant expression
+	return make_uniq<BoundConstantExpression>(
+	    Value::BOOLEAN(CanCastImplicitly(input.context, source_type, target_type)));
+}
+
+ScalarFunction CanCastImplicitlyFun::GetFunction() {
+	auto fun = ScalarFunction({LogicalType::ANY, LogicalType::ANY}, LogicalType::BOOLEAN, CanCastImplicitlyFunction);
+	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	fun.bind_expression = BindCanCastImplicitlyExpression;
+	return fun;
+}
+
+} // namespace duckdb

--- a/src/core_functions/scalar/generic/functions.json
+++ b/src/core_functions/scalar/generic/functions.json
@@ -57,6 +57,13 @@
         "type": "scalar_function"
     },
     {
+        "name": "can_cast_implicitly",
+        "parameters": "source_type,target_type",
+        "description": "Whether or not we can implicitly cast from the source type to the other type",
+        "example": "can_implicitly_cast(NULL::INTEGER, NULL::BIGINT)",
+        "type": "scalar_function"
+    },
+    {
         "name": "current_query",
         "parameters": "",
         "description": "Returns the current query as a string",

--- a/src/core_functions/scalar/generic/typeof.cpp
+++ b/src/core_functions/scalar/generic/typeof.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/core_functions/scalar/generic_functions.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
 
@@ -7,9 +9,20 @@ static void TypeOfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 	result.Reference(v);
 }
 
+unique_ptr<Expression> BindTypeOfFunctionExpression(FunctionBindExpressionInput &input) {
+	auto &return_type = input.function.children[0]->return_type;
+	if (return_type.id() == LogicalTypeId::UNKNOWN || return_type.id() == LogicalTypeId::SQLNULL) {
+		// parameter - unknown return type
+		return nullptr;
+	}
+	// emit a constant expression
+	return make_uniq<BoundConstantExpression>(Value(return_type.ToString()));
+}
+
 ScalarFunction TypeOfFun::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::ANY}, LogicalType::VARCHAR, TypeOfFunction);
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	// fun.bind_expression = BindTypeOfFunctionExpression;
 	return fun;
 }
 

--- a/src/core_functions/scalar/generic/typeof.cpp
+++ b/src/core_functions/scalar/generic/typeof.cpp
@@ -22,7 +22,7 @@ unique_ptr<Expression> BindTypeOfFunctionExpression(FunctionBindExpressionInput 
 ScalarFunction TypeOfFun::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::ANY}, LogicalType::VARCHAR, TypeOfFunction);
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
-	// fun.bind_expression = BindTypeOfFunctionExpression;
+	fun.bind_expression = BindTypeOfFunctionExpression;
 	return fun;
 }
 

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -359,10 +359,10 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_f
 	unique_ptr<Expression> result;
 	auto result_func = make_uniq<BoundFunctionExpression>(std::move(return_type), std::move(bound_function),
 	                                                      std::move(children), std::move(bind_info), is_operator);
-	if (bound_function.bind_expression) {
+	if (result_func->function.bind_expression) {
 		// if a bind_expression callback is registered - call it and emit the resulting expression
 		FunctionBindExpressionInput input(result_func->bind_info.get(), *result_func);
-		result = bound_function.bind_expression(input);
+		result = result_func->function.bind_expression(input);
 	}
 	if (!result) {
 		result = std::move(result_func);

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -361,7 +361,7 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_f
 	                                                      std::move(children), std::move(bind_info), is_operator);
 	if (bound_function.bind_expression) {
 		// if a bind_expression callback is registered - call it and emit the resulting expression
-		FunctionBindExpressionInput input(result_func->bind_info.get(), *result_func);
+		FunctionBindExpressionInput input(context, result_func->bind_info.get(), *result_func);
 		result = bound_function.bind_expression(input);
 	}
 	if (!result) {

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/function/scalar/generic_functions.hpp"
 
 namespace duckdb {
 
@@ -338,9 +339,9 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunctionCatalogE
 	return BindScalarFunction(bound_function, std::move(children), is_operator, binder);
 }
 
-unique_ptr<BoundFunctionExpression> FunctionBinder::BindScalarFunction(ScalarFunction bound_function,
-                                                                       vector<unique_ptr<Expression>> children,
-                                                                       bool is_operator, optional_ptr<Binder> binder) {
+unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_function,
+                                                          vector<unique_ptr<Expression>> children, bool is_operator,
+                                                          optional_ptr<Binder> binder) {
 	unique_ptr<FunctionData> bind_info;
 	if (bound_function.bind) {
 		bind_info = bound_function.bind(context, bound_function, children);
@@ -355,8 +356,18 @@ unique_ptr<BoundFunctionExpression> FunctionBinder::BindScalarFunction(ScalarFun
 
 	// now create the function
 	auto return_type = bound_function.return_type;
-	return make_uniq<BoundFunctionExpression>(std::move(return_type), std::move(bound_function), std::move(children),
-	                                          std::move(bind_info), is_operator);
+	unique_ptr<Expression> result;
+	auto result_func = make_uniq<BoundFunctionExpression>(std::move(return_type), std::move(bound_function),
+	                                                      std::move(children), std::move(bind_info), is_operator);
+	if (bound_function.bind_expression) {
+		// if a bind_expression callback is registered - call it and emit the resulting expression
+		FunctionBindExpressionInput input(result_func->bind_info.get(), *result_func);
+		result = bound_function.bind_expression(input);
+	}
+	if (!result) {
+		result = std::move(result_func);
+	}
+	return result;
 }
 
 unique_ptr<BoundAggregateExpression> FunctionBinder::BindAggregateFunction(AggregateFunction bound_function,

--- a/src/function/scalar_function.cpp
+++ b/src/function/scalar_function.cpp
@@ -16,8 +16,8 @@ ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, Logic
     : BaseScalarFunction(std::move(name), std::move(arguments), std::move(return_type), side_effects,
                          std::move(varargs), null_handling),
       function(std::move(function)), bind(bind), init_local_state(init_local_state), dependency(dependency),
-      statistics(statistics), bind_lambda(bind_lambda), get_modified_databases(nullptr), serialize(nullptr),
-      deserialize(nullptr) {
+      statistics(statistics), bind_lambda(bind_lambda), bind_expression(nullptr), get_modified_databases(nullptr),
+      serialize(nullptr), deserialize(nullptr) {
 }
 
 ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,

--- a/src/include/duckdb/core_functions/scalar/generic_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/generic_functions.hpp
@@ -87,6 +87,15 @@ struct TypeOfFun {
 	static ScalarFunction GetFunction();
 };
 
+struct CanCastImplicitlyFun {
+	static constexpr const char *Name = "can_cast_implicitly";
+	static constexpr const char *Parameters = "source_type,target_type";
+	static constexpr const char *Description = "Whether or not we can implicitly cast from the source type to the other type";
+	static constexpr const char *Example = "can_implicitly_cast(NULL::INTEGER, NULL::BIGINT)";
+
+	static ScalarFunction GetFunction();
+};
+
 struct CurrentQueryFun {
 	static constexpr const char *Name = "current_query";
 	static constexpr const char *Parameters = "";

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -57,10 +57,10 @@ public:
 	                                                     bool is_operator = false,
 	                                                     optional_ptr<Binder> binder = nullptr);
 
-	DUCKDB_API unique_ptr<BoundFunctionExpression> BindScalarFunction(ScalarFunction bound_function,
-	                                                                  vector<unique_ptr<Expression>> children,
-	                                                                  bool is_operator = false,
-	                                                                  optional_ptr<Binder> binder = nullptr);
+	DUCKDB_API unique_ptr<Expression> BindScalarFunction(ScalarFunction bound_function,
+	                                                     vector<unique_ptr<Expression>> children,
+	                                                     bool is_operator = false,
+	                                                     optional_ptr<Binder> binder = nullptr);
 
 	DUCKDB_API unique_ptr<BoundAggregateExpression>
 	BindAggregateFunction(AggregateFunction bound_function, vector<unique_ptr<Expression>> children,

--- a/src/include/duckdb/function/scalar/generic_functions.hpp
+++ b/src/include/duckdb/function/scalar/generic_functions.hpp
@@ -11,6 +11,8 @@
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/function/built_in_functions.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
 
 namespace duckdb {
 class BoundFunctionExpression;

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -76,10 +76,12 @@ struct FunctionModifiedDatabasesInput {
 };
 
 struct FunctionBindExpressionInput {
-	FunctionBindExpressionInput(optional_ptr<FunctionData> bind_data_p, BoundFunctionExpression &function_p)
-	    : bind_data(bind_data_p), function(function_p) {
+	FunctionBindExpressionInput(ClientContext &context_p, optional_ptr<FunctionData> bind_data_p,
+	                            BoundFunctionExpression &function_p)
+	    : context(context_p), bind_data(bind_data_p), function(function_p) {
 	}
 
+	ClientContext &context;
 	optional_ptr<FunctionData> bind_data;
 	BoundFunctionExpression &function;
 };

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -75,6 +75,15 @@ struct FunctionModifiedDatabasesInput {
 	unordered_set<string> &modified_databases;
 };
 
+struct FunctionBindExpressionInput {
+	FunctionBindExpressionInput(optional_ptr<FunctionData> bind_data_p, BoundFunctionExpression &function_p)
+	    : bind_data(bind_data_p), function(function_p) {
+	}
+
+	optional_ptr<FunctionData> bind_data;
+	BoundFunctionExpression &function;
+};
+
 //! The scalar function type
 typedef std::function<void(DataChunk &, ExpressionState &, Vector &)> scalar_function_t;
 //! The type to bind the scalar function and to create the function data
@@ -96,6 +105,9 @@ typedef void (*get_modified_databases_t)(FunctionModifiedDatabasesInput &input);
 typedef void (*function_serialize_t)(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
                                      const ScalarFunction &function);
 typedef unique_ptr<FunctionData> (*function_deserialize_t)(Deserializer &deserializer, ScalarFunction &function);
+
+//! The type to bind lambda-specific parameter types
+typedef unique_ptr<Expression> (*function_bind_expression_t)(FunctionBindExpressionInput &input);
 
 class ScalarFunction : public BaseScalarFunction { // NOLINT: work-around bug in clang-tidy
 public:
@@ -128,6 +140,8 @@ public:
 	function_statistics_t statistics;
 	//! The lambda bind function (if any)
 	bind_lambda_function_t bind_lambda;
+	//! Function to bind the result function expression directly (if any)
+	function_bind_expression_t bind_expression;
 	//! Gets the modified databases (if any)
 	get_modified_databases_t get_modified_databases;
 

--- a/test/sql/copy/csv/rejects/csv_rejects_flush_cast.test
+++ b/test/sql/copy/csv/rejects/csv_rejects_flush_cast.test
@@ -7,15 +7,15 @@ require skip_reload
 # Test will fail on windows because byte_position is slightly different due to \r\n instead of \n
 require notwindows
 
-query III
-SELECT typeof(first(a)), typeof(first(b)), COUNT(*) FROM read_csv(
+query IIIII
+SELECT first(a), first(b), typeof(first(a)), typeof(first(b)), COUNT(*) FROM read_csv(
     'data/csv/error/flush_cast.csv',
     columns = {'a': 'DATE', 'b': 'VARCHAR'},
     store_rejects = true,
     delim = ',',
     dateformat = '%d-%m-%Y');
 ----
-DATE	VARCHAR	2811
+2001-09-25	 bla	DATE	VARCHAR	2811
 
 query IIIIIIIII
 SELECT * EXCLUDE (scan_id) FROM reject_errors order by all;

--- a/test/sql/copy/hive_types.test_slow
+++ b/test/sql/copy/hive_types.test_slow
@@ -30,7 +30,7 @@ select typeof(season),typeof(director),typeof(aired) from read_parquet('__TEST_D
 SMALLINT	VARCHAR	DATE
 
 statement error
-select typeof(season),typeof(director),typeof(aired) from read_parquet('__TEST_DIR__/partition/**/*.parquet', hive_types={'season':date}) limit 1;
+select season,director,aired from read_parquet('__TEST_DIR__/partition/**/*.parquet', hive_types={'season':date}) limit 1;
 ----
 Invalid Input Error: Unable to cast 
 

--- a/test/sql/function/generic/can_cast_implicitly.test
+++ b/test/sql/function/generic/can_cast_implicitly.test
@@ -1,0 +1,31 @@
+# name: test/sql/function/generic/can_cast_implicitly.test
+# description: Test CASE in a conditional statement
+# group: [generic]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE tbl AS SELECT * FROM range(10) tbl(i)
+
+# can cast bigint -> bigint implicitly
+query I
+SELECT can_cast_implicitly(i, NULL::BIGINT) FROM tbl LIMIT 1
+----
+true
+
+query I
+SELECT can_cast_implicitly(i, NULL::HUGEINT) FROM tbl LIMIT 1
+----
+true
+
+# cannot cast bigint -> int implicitly
+query I
+SELECT can_cast_implicitly(i, NULL::INTEGER) FROM tbl LIMIT 1
+----
+false
+
+query I
+SELECT can_cast_implicitly(i, NULL::VARCHAR) FROM tbl LIMIT 1
+----
+false

--- a/test/sql/types/numeric/combinations/decimal_combinations.test
+++ b/test/sql/types/numeric/combinations/decimal_combinations.test
@@ -46,11 +46,11 @@ DECIMAL
 
 # HUGEINT sets width to 38+scale, so it will never fit into DECIMAL
 statement error
-select (typeof([(SELECT min from hugeint_limits), 1.00005])::VARCHAR)[:7]
+select [(SELECT min from hugeint_limits), 1.00005]
 ----
 
 statement error
-select (typeof([(SELECT max from hugeint_limits), 1.00005])::VARCHAR)[:7]
+select [(SELECT max from hugeint_limits), 1.00005]
 ----
 
 endloop


### PR DESCRIPTION
Includes https://github.com/duckdb/duckdb/pull/12580

This PR implements the `can_cast_implicitly` function that, given a source and target type, returns whether or not the source can be implicitly cast to the target. Usage:

```sql
D select can_cast_implicitly(NULL::INT, NULL::BIGINT) AS can_cast;
┌──────────┐
│ can_cast │
│ boolean  │
├──────────┤
│ true     │
└──────────┘
D select can_cast_implicitly(NULL::DOUBLE, NULL::BIGINT) AS can_cast;
┌──────────┐
│ can_cast │
│ boolean  │
├──────────┤
│ false    │
└──────────┘
-- or using a column/expression from a table directly
D select can_cast_implicitly(l_orderkey, NULL::BIGINT) AS can_cast FROM lineitem LIMIT 1;
┌──────────┐
│ can_cast │
│ boolean  │
├──────────┤
│ true     │
└──────────┘
```

Similar to `typeof` this is turned into a constant at bind time to allow efficient usage in macros. 