### PR TITLE
[Relation API] Dont push DISTINCT modifier for EXCEPT/INTERSECT ALL

### DIFF
--- a/src/main/relation/setop_relation.cpp
+++ b/src/main/relation/setop_relation.cpp
@@ -17,7 +17,7 @@ SetOpRelation::SetOpRelation(shared_ptr<Relation> left_p, shared_ptr<Relation> r
 
 unique_ptr<QueryNode> SetOpRelation::GetQueryNode() {
 	auto result = make_uniq<SetOperationNode>();
-	if (setop_type == SetOperationType::EXCEPT || setop_type == SetOperationType::INTERSECT) {
+	if (!setop_all) {
 		result->modifiers.push_back(make_uniq<DistinctModifier>());
 	}
 	result->left = left->GetQueryNode();

--- a/test/api/test_relation_api.cpp
+++ b/test/api/test_relation_api.cpp
@@ -16,7 +16,7 @@ TEST_CASE("Test simple relation API", "[relation_api]") {
 
 	// create some tables
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
-	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1), (2), (3)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1), (2), (3), (1), (2), (3)"));
 
 	// simple projection
 	REQUIRE_NOTHROW(tbl = con.Table("integers"));
@@ -102,7 +102,7 @@ TEST_CASE("Test simple relation API", "[relation_api]") {
 
 	// filters can also contain conjunctions
 	REQUIRE_NOTHROW(result = proj->Filter("a=2 OR a=4")->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {2, 4}));
+	REQUIRE(CHECK_COLUMN(result, 0, {2, 2, 4, 4}));
 
 	// alias
 	REQUIRE_NOTHROW(result = proj->Project("a + 1")->Alias("bla")->Execute());
@@ -110,9 +110,9 @@ TEST_CASE("Test simple relation API", "[relation_api]") {
 
 	// now test ordering
 	REQUIRE_NOTHROW(result = proj->Order("a DESC")->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {4, 2}));
+	REQUIRE(CHECK_COLUMN(result, 0, {4, 4, 2, 2}));
 	REQUIRE_NOTHROW(result = proj->Order(duckdb::vector<string> {"a DESC", "a ASC"})->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {4, 2}));
+	REQUIRE(CHECK_COLUMN(result, 0, {4, 4, 2, 2}));
 
 	// top n
 	REQUIRE_NOTHROW(result = proj->Order("a")->Limit(1)->Execute());
@@ -122,24 +122,24 @@ TEST_CASE("Test simple relation API", "[relation_api]") {
 
 	// test set operations
 	REQUIRE_NOTHROW(result = tbl->Union(tbl)->Order("i")->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {1, 1, 2, 2, 3, 3}));
+	REQUIRE(CHECK_COLUMN(result, 0, {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3}));
 	REQUIRE_NOTHROW(result = tbl->Except(tbl)->Order("i")->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {}));
 	REQUIRE_NOTHROW(result = tbl->Intersect(tbl)->Order("i")->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {1, 2, 3}));
+	REQUIRE(CHECK_COLUMN(result, 0, {1, 1, 2, 2, 3, 3}));
 	REQUIRE_NOTHROW(result = tbl->Except(tbl->Filter("i=2"))->Order("i")->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {1, 3}));
+	REQUIRE(CHECK_COLUMN(result, 0, {1, 1, 3, 3}));
 	REQUIRE_NOTHROW(result = tbl->Intersect(tbl->Filter("i=2"))->Order("i")->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {2}));
+	REQUIRE(CHECK_COLUMN(result, 0, {2, 2}));
 
 	// set operations with projections
 	REQUIRE_NOTHROW(proj = tbl->Project("i::TINYINT AS i, i::SMALLINT, i::BIGINT, i::VARCHAR"));
 	REQUIRE_NOTHROW(proj2 = tbl->Project("(i+10)::TINYINT, (i+10)::SMALLINT, (i+10)::BIGINT, (i+10)::VARCHAR"));
 	REQUIRE_NOTHROW(result = proj->Union(proj2)->Order("i")->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {1, 2, 3, 11, 12, 13}));
-	REQUIRE(CHECK_COLUMN(result, 1, {1, 2, 3, 11, 12, 13}));
-	REQUIRE(CHECK_COLUMN(result, 2, {1, 2, 3, 11, 12, 13}));
-	REQUIRE(CHECK_COLUMN(result, 3, {"1", "2", "3", "11", "12", "13"}));
+	REQUIRE(CHECK_COLUMN(result, 0, {1, 1, 2, 2, 3, 3, 11, 11, 12, 12, 13, 13}));
+	REQUIRE(CHECK_COLUMN(result, 1, {1, 1, 2, 2, 3, 3, 11, 11, 12, 12, 13, 13}));
+	REQUIRE(CHECK_COLUMN(result, 2, {1, 1, 2, 2, 3, 3, 11, 11, 12, 12, 13, 13}));
+	REQUIRE(CHECK_COLUMN(result, 3, {"1", "1", "2", "2", "3", "3", "11", "11", "12", "12", "13", "13"}));
 
 	// distinct
 	REQUIRE_NOTHROW(result = tbl->Union(tbl)->Union(tbl)->Distinct()->Order("1")->Execute());
@@ -260,8 +260,8 @@ TEST_CASE("Test combinations of set operations", "[relation_api]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {1, 2, 3}));
 	REQUIRE(CHECK_COLUMN(result, 1, {10, 5, 4}));
 	REQUIRE_NOTHROW(result = vunion->Intersect(vunion)->Order("1")->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {1, 2, 3}));
-	REQUIRE(CHECK_COLUMN(result, 1, {10, 5, 4}));
+	REQUIRE(CHECK_COLUMN(result, 0, {1, 1, 2, 2, 3, 3}));
+	REQUIRE(CHECK_COLUMN(result, 1, {10, 10, 5, 5, 4, 4}));
 	REQUIRE_NOTHROW(result = vunion->Except(vunion)->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {}));
 	REQUIRE(CHECK_COLUMN(result, 1, {}));

--- a/tools/pythonpkg/tests/fast/test_relation.py
+++ b/tools/pythonpkg/tests/fast/test_relation.py
@@ -514,7 +514,7 @@ class TestRelation(object):
 
         except_rel = unioned_rel.except_(materialized_one)
         res = except_rel.fetchall()
-        assert res == [('a',)]
+        assert res == [tuple('a') for _ in range(5)]
 
         intersect_rel = unioned_rel.intersect(materialized_one).order('range')
         res = intersect_rel.fetchall()


### PR DESCRIPTION
This PR fixes #12592 

The ALL variation of a SET OPERATION should have bag semantics.
Previously we pushed a DISTINCT for all except/intersect SetOpRelations, presumably this is because `setop_all` did not exist at the time.