### PR TITLE
[Python] Allow Generators to be passed where List is expected

### DIFF
--- a/tools/pythonpkg/scripts/cache_data.json
+++ b/tools/pythonpkg/scripts/cache_data.json
@@ -551,5 +551,34 @@
         "full_path": "uuid.UUID",
         "name": "UUID",
         "children": []
+    },
+    "collections": {
+        "type": "module",
+        "full_path": "collections",
+        "name": "collections",
+        "children": [
+            "collections.abc"
+        ]
+    },
+    "collections.abc": {
+        "type": "module",
+        "full_path": "collections.abc",
+        "name": "abc",
+        "children": [
+            "collections.abc.Iterable",
+            "collections.abc.Mapping"
+        ]
+    },
+    "collections.abc.Iterable": {
+        "type": "attribute",
+        "full_path": "collections.abc.Iterable",
+        "name": "Iterable",
+        "children": []
+    },
+    "collections.abc.Mapping": {
+        "type": "attribute",
+        "full_path": "collections.abc.Mapping",
+        "name": "Mapping",
+        "children": []
     }
 }

--- a/tools/pythonpkg/scripts/imports.py
+++ b/tools/pythonpkg/scripts/imports.py
@@ -101,3 +101,9 @@ typing._UnionGenericAlias
 import uuid
 
 uuid.UUID
+
+import collections
+import collections.abc
+
+collections.abc.Iterable
+collections.abc.Mapping

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/collections_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/collections_module.hpp
@@ -1,0 +1,46 @@
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb_python/import_cache/modules/collections_module.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb_python/import_cache/python_import_cache_item.hpp"
+
+namespace duckdb {
+
+struct CollectionsAbcCacheItem : public PythonImportCacheItem {
+
+public:
+	static constexpr const char *Name = "collections.abc";
+
+public:
+	CollectionsAbcCacheItem()
+	    : PythonImportCacheItem("collections.abc"), Iterable("Iterable", this), Mapping("Mapping", this) {
+	}
+	~CollectionsAbcCacheItem() override {
+	}
+
+	PythonImportCacheItem Iterable;
+	PythonImportCacheItem Mapping;
+};
+
+struct CollectionsCacheItem : public PythonImportCacheItem {
+
+public:
+	static constexpr const char *Name = "collections";
+
+public:
+	CollectionsCacheItem() : PythonImportCacheItem("collections"), abc() {
+	}
+	~CollectionsCacheItem() override {
+	}
+
+	CollectionsAbcCacheItem abc;
+};
+
+} // namespace duckdb

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache.hpp
@@ -37,6 +37,7 @@ public:
 	TypesCacheItem types;
 	TypingCacheItem typing;
 	UuidCacheItem uuid;
+	CollectionsCacheItem collections;
 
 public:
 	py::handle AddCache(py::object item);

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache_modules.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/python_import_cache_modules.hpp
@@ -12,3 +12,4 @@
 #include "duckdb_python/import_cache/modules/types_module.hpp"
 #include "duckdb_python/import_cache/modules/typing_module.hpp"
 #include "duckdb_python/import_cache/modules/uuid_module.hpp"
+#include "duckdb_python/import_cache/modules/collections_module.hpp"

--- a/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
@@ -29,6 +29,8 @@ struct type_caster<duckdb::vector<Type, SAFE>> : list_caster<duckdb::vector<Type
 
 bool gil_check();
 void gil_assert();
+bool is_list_like(handle obj);
+bool is_dict_like(handle obj);
 
 } // namespace pybind11
 

--- a/tools/pythonpkg/src/pybind11/pybind_wrapper.cpp
+++ b/tools/pythonpkg/src/pybind11/pybind_wrapper.cpp
@@ -1,5 +1,6 @@
 #include "duckdb_python/pybind11/pybind_wrapper.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb_python/pyconnection/pyconnection.hpp"
 
 namespace pybind11 {
 
@@ -13,6 +14,26 @@ void gil_assert() {
 	if (!gil_check()) {
 		throw duckdb::InternalException("The GIL should be held for this operation, but it's not!");
 	}
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+bool is_list_like(handle obj) {
+	if (isinstance<str>(obj) || isinstance<bytes>(obj)) {
+		return false;
+	}
+	if (is_dict_like(obj)) {
+		return false;
+	}
+	auto &import_cache = *duckdb::DuckDBPyConnection::ImportCache();
+	auto iterable = import_cache.collections.abc.Iterable();
+	return isinstance(obj, iterable);
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+bool is_dict_like(handle obj) {
+	auto &import_cache = *duckdb::DuckDBPyConnection::ImportCache();
+	auto mapping = import_cache.collections.abc.Mapping();
+	return isinstance(obj, mapping);
 }
 
 } // namespace pybind11

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -441,7 +441,7 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::ExecuteMany(const py::object 
 
 	auto prep = PrepareQuery(std::move(last_statement));
 
-	if (!py::isinstance<py::list>(params_p)) {
+	if (!py::is_list_like(params_p)) {
 		throw InvalidInputException("executemany requires a list of parameter sets to be provided");
 	}
 	auto outer_list = py::list(params_p);
@@ -526,7 +526,7 @@ py::list TransformNamedParameters(const case_insensitive_map_t<idx_t> &named_par
 
 case_insensitive_map_t<Value> TransformPreparedParameters(PreparedStatement &prep, const py::object &params) {
 	case_insensitive_map_t<Value> named_values;
-	if (py::isinstance<py::list>(params) || py::isinstance<py::tuple>(params)) {
+	if (py::is_list_like(params)) {
 		if (prep.n_param != py::len(params)) {
 			throw InvalidInputException("Prepared statement needs %d parameters, %d given", prep.n_param,
 			                            py::len(params));
@@ -537,7 +537,7 @@ case_insensitive_map_t<Value> TransformPreparedParameters(PreparedStatement &pre
 			auto identifier = std::to_string(i + 1);
 			named_values[identifier] = std::move(value);
 		}
-	} else if (py::isinstance<py::dict>(params)) {
+	} else if (py::is_dict_like(params)) {
 		auto dict = py::cast<py::dict>(params);
 		named_values = DuckDBPyConnection::TransformPythonParamDict(dict);
 	} else {
@@ -749,7 +749,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadJSON(const string &name, co
 	named_parameter_map_t options;
 
 	if (!py::none().is(columns)) {
-		if (!py::isinstance<py::dict>(columns)) {
+		if (!py::is_dict_like(columns)) {
 			throw BinderException("read_json only accepts 'columns' as a dict[str, str]");
 		}
 		py::dict columns_dict = columns;
@@ -871,7 +871,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(
 	}
 
 	if (!py::none().is(dtype)) {
-		if (py::isinstance<py::dict>(dtype)) {
+		if (py::is_dict_like(dtype)) {
 			child_list_t<Value> struct_fields;
 			py::dict dtype_dict = dtype;
 			for (auto &kv : dtype_dict) {
@@ -883,7 +883,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(
 			}
 			auto dtype_struct = Value::STRUCT(std::move(struct_fields));
 			bind_parameters["dtypes"] = std::move(dtype_struct);
-		} else if (py::isinstance<py::list>(dtype)) {
+		} else if (py::is_list_like(dtype)) {
 			vector<Value> list_values;
 			py::list dtype_list = dtype;
 			for (auto &child : dtype_list) {
@@ -911,7 +911,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(
 	}
 
 	if (!py::none().is(names_p)) {
-		if (!py::isinstance<py::list>(names_p)) {
+		if (!py::is_list_like(names_p)) {
 			throw InvalidInputException("read_csv only accepts 'names' as a list of strings");
 		}
 		vector<Value> names;
@@ -927,7 +927,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(
 
 	if (!py::none().is(na_values)) {
 		vector<Value> null_values;
-		if (!py::isinstance<py::str>(na_values) && !py::isinstance<py::list>(na_values)) {
+		if (!py::isinstance<py::str>(na_values) && !py::is_list_like(na_values)) {
 			throw InvalidInputException("read_csv only accepts 'na_values' as a string or a list of strings");
 		} else if (py::isinstance<py::str>(na_values)) {
 			null_values.push_back(Value(py::str(na_values)));
@@ -1163,7 +1163,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::TableFunction(const string &fna
 	if (params.is_none()) {
 		params = py::list();
 	}
-	if (!py::isinstance<py::list>(params)) {
+	if (!py::is_list_like(params)) {
 		throw InvalidInputException("'params' has to be a list of parameters");
 	}
 	if (!connection) {
@@ -1723,7 +1723,7 @@ NumpyObjectType DuckDBPyConnection::IsAcceptedNumpyObject(const py::object &obje
 		default:
 			return NumpyObjectType::INVALID;
 		}
-	} else if (py::isinstance<py::dict>(object)) {
+	} else if (py::is_dict_like(object)) {
 		int dim = -1;
 		for (auto item : py::cast<py::dict>(object)) {
 			if (!IsValidNumpyDimensions(item.second, dim)) {
@@ -1731,7 +1731,7 @@ NumpyObjectType DuckDBPyConnection::IsAcceptedNumpyObject(const py::object &obje
 			}
 		}
 		return NumpyObjectType::DICT;
-	} else if (py::isinstance<py::list>(object)) {
+	} else if (py::is_list_like(object)) {
 		int dim = -1;
 		for (auto item : py::cast<py::list>(object)) {
 			if (!IsValidNumpyDimensions(item, dim)) {

--- a/tools/pythonpkg/tests/fast/api/test_duckdb_execute.py
+++ b/tools/pythonpkg/tests/fast/api/test_duckdb_execute.py
@@ -60,3 +60,15 @@ class TestDuckDBExecute(object):
             """,
                 (99,),
             )
+
+    def test_execute_many_generator(self, duckdb_cursor):
+        to_insert = [[1], [2], [3]]
+
+        def to_insert_from_generator(what):
+            for x in what:
+                yield x
+
+        gen = to_insert_from_generator(to_insert)
+        duckdb_cursor.execute("CREATE TABLE unittest_generator (a INTEGER);")
+        duckdb_cursor.executemany("INSERT into unittest_generator (a) VALUES (?)", gen)
+        assert duckdb_cursor.table('unittest_generator').fetchall() == [(1,), (2,), (3,)]


### PR DESCRIPTION
This PR fixes #12543 

Allow duck-typing of List and Dict in a couple places, including `executemany`