### PR TITLE
WAL - when dropping a table, also delete any transaction local storage associated with that table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,6 +402,9 @@ format-changes:
 format-main:
 	python3 scripts/format.py main --fix --noconfirm
 
+format-feature:
+	python3 scripts/format.py feature --fix --noconfirm
+
 third_party/sqllogictest:
 	git clone --depth=1 --branch hawkfish-statistical-rounding https://github.com/cwida/sqllogictest.git third_party/sqllogictest
 

--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -35,6 +35,7 @@
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 
 namespace duckdb {
 

--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -126,6 +126,7 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::AddEntryInternal(CatalogTransaction 
 				throw CatalogException("Existing object %s is of type %s, trying to replace with type %s", entry_name,
 				                       CatalogTypeToString(old_entry->type), CatalogTypeToString(entry_type));
 			}
+			OnDropEntry(transaction, *old_entry);
 			(void)set.DropEntry(transaction, entry_name, false, entry->internal);
 		}
 	}
@@ -319,15 +320,12 @@ void DuckSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 
 	vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;
 	if (existing_entry->type == CatalogType::TABLE_ENTRY) {
-		// if we have transaction local insertions for this table - clear them
-		auto &table_entry = existing_entry->Cast<TableCatalogEntry>();
-		auto &local_storage = LocalStorage::Get(DuckTransaction::Get(context, catalog));
-		local_storage.DropTable(table_entry.GetStorage());
-
 		// if there is a foreign key constraint, get that information
+		auto &table_entry = existing_entry->Cast<TableCatalogEntry>();
 		FindForeignKeyInformation(table_entry, AlterForeignKeyType::AFT_DELETE, fk_arrays);
 	}
 
+	OnDropEntry(transaction, *existing_entry);
 	if (!set.DropEntry(transaction, info.name, info.cascade, info.allow_drop_internal)) {
 		throw InternalException("Could not drop element because of an internal error");
 	}
@@ -337,6 +335,19 @@ void DuckSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 		// alter primary key table
 		Alter(transaction, *fk_arrays[i]);
 	}
+}
+
+void DuckSchemaEntry::OnDropEntry(CatalogTransaction transaction, CatalogEntry &entry) {
+	if (!transaction.transaction) {
+		return;
+	}
+	if (entry.type != CatalogType::TABLE_ENTRY) {
+		return;
+	}
+	// if we have transaction local insertions for this table - clear them
+	auto &table_entry = entry.Cast<TableCatalogEntry>();
+	auto &local_storage = LocalStorage::Get(transaction.transaction->Cast<DuckTransaction>());
+	local_storage.DropTable(table_entry.GetStorage());
 }
 
 optional_ptr<CatalogEntry> DuckSchemaEntry::GetEntry(CatalogTransaction transaction, CatalogType type,

--- a/src/include/duckdb/catalog/catalog_entry/duck_schema_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_schema_entry.hpp
@@ -69,6 +69,9 @@ public:
 	void Verify(Catalog &catalog) override;
 
 private:
+	void OnDropEntry(CatalogTransaction transaction, CatalogEntry &entry);
+
+private:
 	//! Get the catalog set for the specified type
 	CatalogSet &GetCatalogSet(CatalogType type);
 };

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -141,6 +141,7 @@ public:
 	bool ChangesMade() noexcept;
 	idx_t EstimatedSize();
 
+	void DropTable(DataTable &table);
 	bool Find(DataTable &table);
 
 	idx_t AddedRows(DataTable &table);

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -52,6 +52,8 @@ public:
 	vector<unique_ptr<OptimisticDataWriter>> optimistic_writers;
 	//! Whether or not storage was merged
 	bool merged_storage = false;
+	//! Whether or not the storage was dropped
+	bool is_dropped = false;
 
 public:
 	void InitializeScan(CollectionScanState &state, optional_ptr<TableFilterSet> table_filters = nullptr);

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -508,6 +508,11 @@ idx_t LocalStorage::AddedRows(DataTable &table) {
 	return storage->row_groups->GetTotalRows() - storage->deleted_rows;
 }
 
+void LocalStorage::DropTable(DataTable &table) {
+	auto table_storage = table_manager.MoveEntry(table);
+	table_storage.reset();
+}
+
 void LocalStorage::MoveStorage(DataTable &old_dt, DataTable &new_dt) {
 	// check if there are any pending appends for the old version of the table
 	auto new_storage = table_manager.MoveEntry(old_dt);

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -436,6 +436,9 @@ void LocalStorage::Update(DataTable &table, Vector &row_ids, const vector<Physic
 }
 
 void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
+	if (storage.is_dropped) {
+		return;
+	}
 	if (storage.row_groups->GetTotalRows() <= storage.deleted_rows) {
 		return;
 	}
@@ -509,8 +512,11 @@ idx_t LocalStorage::AddedRows(DataTable &table) {
 }
 
 void LocalStorage::DropTable(DataTable &table) {
-	auto table_storage = table_manager.MoveEntry(table);
-	table_storage.reset();
+	auto storage = table_manager.GetStorage(table);
+	if (!storage) {
+		return;
+	}
+	storage->is_dropped = true;
 }
 
 void LocalStorage::MoveStorage(DataTable &old_dt, DataTable &new_dt) {

--- a/test/sql/storage/wal/wal_create_insert_drop.test
+++ b/test/sql/storage/wal/wal_create_insert_drop.test
@@ -28,6 +28,12 @@ commit;
 
 restart
 
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET checkpoint_threshold='999999GB';
+
 query I
 SELECT * FROM bla
 ----

--- a/test/sql/storage/wal/wal_create_insert_drop.test
+++ b/test/sql/storage/wal/wal_create_insert_drop.test
@@ -57,4 +57,51 @@ commit;
 restart
 
 statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET checkpoint_threshold='999999GB';
+
+statement ok
+begin
+
+statement ok
 create table bla as select 84;
+
+statement ok
+alter table bla rename to bla2
+
+statement ok
+commit
+
+restart
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET checkpoint_threshold='999999GB';
+
+query I
+from bla2
+----
+84
+
+statement ok
+begin
+
+statement ok
+create or replace table bla as select 84;
+
+statement ok
+create or replace table bla as select 42;
+
+statement ok
+commit
+
+restart
+
+query I
+from bla
+----
+42

--- a/test/sql/storage/wal/wal_create_insert_drop.test
+++ b/test/sql/storage/wal/wal_create_insert_drop.test
@@ -1,0 +1,54 @@
+# name: test/sql/storage/wal/wal_create_insert_drop.test
+# description: Test serialization of CHECK constraint
+# group: [wal]
+
+# load the DB from disk
+load __TEST_DIR__/wal_create_insert_drop.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET checkpoint_threshold='999999GB';
+
+statement ok
+begin
+
+statement ok
+create table bla as select 42;
+
+statement ok
+drop table bla;
+
+statement ok
+create table bla as select 84;
+
+statement ok
+commit;
+
+restart
+
+query I
+SELECT * FROM bla
+----
+84
+
+statement ok
+drop table bla
+
+statement ok
+begin
+
+statement ok
+create table bla as select 42;
+
+statement ok
+drop table bla;
+
+statement ok
+commit;
+
+restart
+
+statement ok
+create table bla as select 84;


### PR DESCRIPTION
This prevents the WAL replay from incorrectly writing out buffered data **after** the table has already been dropped, which could otherwise cause a WAL replay error.