### PR TITLE
Add HTTP error code to extension install failures

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -366,8 +366,8 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DBConfig &config, con
 			message += "\nAre you using a development build? In this case, extensions might not (yet) be uploaded.";
 		}
 		if (res.error() == duckdb_httplib::Error::Success) {
-			throw HTTPException(res.value(), "Failed to download extension \"%s\" at URL \"%s%s\"\n%s", extension_name,
-			                    url_base, url_local_part, message);
+			throw HTTPException(res.value(), "Failed to download extension \"%s\" at URL \"%s%s\" (HTTP %n)\n%s",
+			                    extension_name, url_base, url_local_part, res->status, message);
 		} else {
 			throw IOException("Failed to download extension \"%s\" at URL \"%s%s\"\n%s (ERROR %s)", extension_name,
 			                  url_base, url_local_part, message, to_string(res.error()));


### PR DESCRIPTION
This keeps logic unchanged, but gives visibility to HTTP error code.

Before:
```
D INSTALL asdasdasdasd;
HTTP Error: Failed to download extension "asdasdasdasd" at URL "http://extensions.duckdb.org/v1.0.0/osx_arm64/asdasdasdasd.duckdb_extension.gz"
```

After:
```
D INSTALL asdasdasdasd;
HTTP Error: Failed to download extension "asdasdasdasd" at URL "http://extensions.duckdb.org/f9238f4b6b/osx_arm64/asdasdasdasd.duckdb_extension.gz" (HTTP 403)
```