### PR TITLE
Use lowercase in 'html' output mode

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -11600,22 +11600,22 @@ static int shell_callback(
     }
     case MODE_Html: {
       if( p->cnt++==0 && p->showHeader ){
-        raw_printf(p->out,"<TR>");
+        raw_printf(p->out,"<tr>");
         for(i=0; i<nArg; i++){
-          raw_printf(p->out,"<TH>");
+          raw_printf(p->out,"<th>");
           output_html_string(p->out, azCol[i]);
-          raw_printf(p->out,"</TH>\n");
+          raw_printf(p->out,"</th>\n");
         }
-        raw_printf(p->out,"</TR>\n");
+        raw_printf(p->out,"</tr>\n");
       }
       if( azArg==0 ) break;
-      raw_printf(p->out,"<TR>");
+      raw_printf(p->out,"<tr>");
       for(i=0; i<nArg; i++){
-        raw_printf(p->out,"<TD>");
+        raw_printf(p->out,"<td>");
         output_html_string(p->out, azArg[i] ? azArg[i] : p->nullValue);
-        raw_printf(p->out,"</TD>\n");
+        raw_printf(p->out,"</td>\n");
       }
-      raw_printf(p->out,"</TR>\n");
+      raw_printf(p->out,"</tr>\n");
       break;
     }
     case MODE_Tcl: {

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -612,7 +612,7 @@ def test_mode_html(shell):
         .statement("SELECT NULL, 42, 'fourty-two', 42.0;")
     )
     result = test.run()
-    result.check_stdout('<TD>fourty-two</TD>')
+    result.check_stdout('<td>fourty-two</td>')
 
 # Original comment: FIXME sqlite3_column_blob
 def test_mode_insert(shell):


### PR DESCRIPTION
In modern HTML code, [developers normally use lowercase names](https://www.w3schools.com/html/html5_syntax.asp). This PR changes the `.mode html` output's printing method (originally adopted from SQLite) to follow this convention.