### PR TITLE
VectorOperations::Copy - fast path when copying an aligned flat validity mask into a flat vector

### DIFF
--- a/src/common/types/validity_mask.cpp
+++ b/src/common/types/validity_mask.cpp
@@ -94,6 +94,24 @@ bool ValidityMask::IsAligned(idx_t count) {
 	return count % BITS_PER_VALUE == 0;
 }
 
+void ValidityMask::CopySel(const ValidityMask &other, const SelectionVector &sel, idx_t source_offset,
+                           idx_t target_offset, idx_t copy_count) {
+	if (!other.IsMaskSet() && !IsMaskSet()) {
+		// no need to copy anything if neither has any null values
+		return;
+	}
+
+	if (!sel.IsSet() && IsAligned(source_offset) && IsAligned(target_offset)) {
+		// common case where we are shifting into an aligned mask using a flat vector
+		SliceInPlace(other, target_offset, source_offset, copy_count);
+		return;
+	}
+	for (idx_t i = 0; i < copy_count; i++) {
+		auto source_idx = sel.get_index(source_offset + i);
+		Set(target_offset + i, other.RowIsValid(source_idx));
+	}
+}
+
 void ValidityMask::SliceInPlace(const ValidityMask &other, idx_t target_offset, idx_t source_offset, idx_t count) {
 	EnsureWritable();
 	if (IsAligned(source_offset) && IsAligned(target_offset)) {
@@ -101,8 +119,13 @@ void ValidityMask::SliceInPlace(const ValidityMask &other, idx_t target_offset, 
 		auto source_validity = other.GetData();
 		auto source_offset_entries = EntryCount(source_offset);
 		auto target_offset_entries = EntryCount(target_offset);
-		memcpy(target_validity + target_offset_entries, source_validity + source_offset_entries,
-		       sizeof(validity_t) * EntryCount(count));
+		if (!source_validity) {
+			// if source has no validity mask - set all bytes to 1
+			memset(target_validity + target_offset_entries, 0xFF, sizeof(validity_t) * EntryCount(count));
+		} else {
+			memcpy(target_validity + target_offset_entries, source_validity + source_offset_entries,
+			       sizeof(validity_t) * EntryCount(count));
+		}
 		return;
 	} else if (IsAligned(target_offset)) {
 		//	Simple common case where we are shifting into an aligned mask (e.g., 0 in Slice above)

--- a/src/common/types/validity_mask.cpp
+++ b/src/common/types/validity_mask.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/serializer/write_stream.hpp"
 #include "duckdb/common/serializer/read_stream.hpp"
+#include "duckdb/common/types/selection_vector.hpp"
 
 namespace duckdb {
 

--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -23,7 +23,7 @@ static void TemplatedCopy(const Vector &source, const SelectionVector &sel, Vect
 	}
 }
 
-static const ValidityMask &CopyValidityMask(const Vector &v) {
+static const ValidityMask &ExtractValidityMask(const Vector &v) {
 	switch (v.GetVectorType()) {
 	case VectorType::FLAT_VECTOR:
 		return FlatVector::Validity(v);
@@ -101,25 +101,8 @@ void VectorOperations::Copy(const Vector &source_p, Vector &target, const Select
 			tmask.Set(target_offset + i, valid);
 		}
 	} else {
-		auto &smask = CopyValidityMask(*source);
-		if (smask.IsMaskSet() || tmask.IsMaskSet()) {
-			for (idx_t i = 0; i < copy_count; i++) {
-				auto idx = sel->get_index(source_offset + i);
-
-				if (smask.RowIsValid(idx)) {
-					// set valid
-					if (!tmask.AllValid()) {
-						tmask.SetValidUnsafe(target_offset + i);
-					}
-				} else {
-					// set invalid
-					if (tmask.AllValid()) {
-						tmask.Initialize();
-					}
-					tmask.SetInvalidUnsafe(target_offset + i);
-				}
-			}
-		}
+		auto &smask = ExtractValidityMask(*source);
+		tmask.CopySel(smask, *sel, source_offset, target_offset, copy_count);
 	}
 
 	D_ASSERT(sel);

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -111,6 +111,9 @@ public:
 	inline sel_t &operator[](idx_t index) const {
 		return sel_vector[index];
 	}
+	inline bool IsSet() const {
+		return sel_vector;
+	}
 	void Verify(idx_t count, idx_t vector_size) const;
 
 private:

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/vector_size.hpp"
 
 namespace duckdb {
+struct SelectionVector;
 struct ValidityMask;
 
 template <typename V>
@@ -339,6 +340,8 @@ public:
 	DUCKDB_API idx_t TargetCount();
 	DUCKDB_API void SliceInPlace(const ValidityMask &other, idx_t target_offset, idx_t source_offset, idx_t count);
 	DUCKDB_API void Slice(const ValidityMask &other, idx_t source_offset, idx_t count);
+	DUCKDB_API void CopySel(const ValidityMask &other, const SelectionVector &sel, idx_t source_offset,
+	                        idx_t target_offset, idx_t count);
 	DUCKDB_API void Combine(const ValidityMask &other, idx_t count);
 	DUCKDB_API string ToString(idx_t count) const;
 


### PR DESCRIPTION
Improves performance of `VectorOperations::Copy` in common scenarios