### PR TITLE
Add support for any type to `mode` aggregate

### DIFF
--- a/test/sql/aggregate/aggregates/mode_test_all_types.test_slow
+++ b/test/sql/aggregate/aggregates/mode_test_all_types.test_slow
@@ -1,0 +1,29 @@
+# name: test/sql/aggregate/aggregates/mode_test_all_types.test_slow
+# description: Test mode operator for all types
+# group: [aggregates]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table all_types as from test_all_types()
+
+foreach col bool tinyint smallint int bigint hugeint uhugeint utinyint usmallint uint ubigint date time timestamp timestamp_s timestamp_ms timestamp_ns time_tz timestamp_tz float double dec_4_1 dec_9_4 dec_18_6 dec38_10 uuid interval varchar blob bit small_enum medium_enum large_enum int_array double_array date_array timestamp_array timestamptz_array varchar_array nested_int_array struct struct_of_arrays array_of_structs map union fixed_int_array fixed_varchar_array fixed_nested_int_array fixed_nested_varchar_array fixed_struct_array struct_of_fixed_array fixed_array_of_int_list list_of_fixed_int_array
+
+query I
+SELECT mode IS NOT DISTINCT FROM min_val FROM (
+	SELECT MODE(v) AS mode, MIN(v) AS min_val
+	FROM (SELECT "${col}" AS v FROM all_types UNION ALL SELECT MIN("${col}"), FROM all_types)
+)
+----
+true
+
+query I
+SELECT mode IS NOT DISTINCT FROM max_val FROM (
+	SELECT MODE(v) AS mode, MAX(v) AS max_val
+	FROM (SELECT "${col}" AS v FROM all_types UNION ALL SELECT MAX("${col}"), FROM all_types)
+)
+----
+true
+
+endloop

--- a/test/sql/aggregate/aggregates/mode_tpch.test_slow
+++ b/test/sql/aggregate/aggregates/mode_tpch.test_slow
@@ -22,13 +22,13 @@ SELECT avg(strlen(padded_mode)) FROM
 
 # mode on nested types
 query III
-SELECT mode(l_orderkey), mode([l_orderkey]), mode({'i': l_orderkey}) from lineitem
+SELECT mode(l_shipdate), mode([l_shipdate]), mode({'i': l_shipdate}) from lineitem;
 ----
-245475	[245475]	{'i': 245475}
+1997-06-01	[1997-06-01]	{'i': 1997-06-01}
 
 query IIII
-SELECT l_returnflag, mode(l_orderkey), mode([l_orderkey]), mode({'i': l_orderkey}) from lineitem group by l_returnflag order by l_returnflag
+SELECT l_returnflag, mode(l_shipdate), mode([l_shipdate]), mode({'i': l_shipdate}) from lineitem group by l_returnflag order by l_returnflag
 ----
-A	861223	[861223]	{'i': 861223}
-N	613734	[613734]	{'i': 613734}
-R	123910	[123910]	{'i': 123910}
+A	1995-03-24	[1995-03-24]	{'i': 1995-03-24}
+N	1997-06-01	[1997-06-01]	{'i': 1997-06-01}
+R	1994-08-23	[1994-08-23]	{'i': 1994-08-23}

--- a/test/sql/aggregate/aggregates/mode_tpch.test_slow
+++ b/test/sql/aggregate/aggregates/mode_tpch.test_slow
@@ -20,3 +20,16 @@ SELECT avg(strlen(padded_mode)) FROM
 (SELECT mode(l_comment) OVER (ORDER BY rowid ROWS BETWEEN 5 PRECEDING AND 5 FOLLOWING) AS padded_mode FROM lineitem)
 ----
 26.4927
+
+# mode on nested types
+query III
+SELECT mode(l_orderkey), mode([l_orderkey]), mode({'i': l_orderkey}) from lineitem
+----
+245475	[245475]	{'i': 245475}
+
+query IIII
+SELECT l_returnflag, mode(l_orderkey), mode([l_orderkey]), mode({'i': l_orderkey}) from lineitem group by l_returnflag order by l_returnflag
+----
+A	861223	[861223]	{'i': 861223}
+N	613734	[613734]	{'i': 613734}
+R	123910	[123910]	{'i': 123910}


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/12601

This PR adds support for all types to mode, so that they are no longer converted to varchar, but instead the sort key representation is used. 