### PR TITLE
Move android CI to only run during nightly CI triggers

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -23,24 +23,14 @@ on:
       - '!main'
       - '!feature'
     paths-ignore:
-      - '**.md'
-      - 'tools/**'
-      - '!tools/odbc/**'
-      - '!tools/shell/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
+      - '**'
       - '!.github/workflows/Android.yml'
-
   pull_request:
     types: [opened, reopened, ready_for_review]
     paths-ignore:
-      - '**.md'
-      - 'tools/**'
-      - '!tools/odbc/**'
-      - '!tools/shell/**'
-      - '.github/patches/duckdb-wasm/**'
-      - '.github/workflows/**'
+      - '**'
       - '!.github/workflows/Android.yml'
+      - '!.github/patches/duckdb-wasm/**'
 
 
 concurrency:


### PR DESCRIPTION
This seems to fail sporadically due to GH actions related mysteries, and I think there's not a sufficient need to run this every PR.