### PR TITLE
[Dev] StreamQueryResult internals cleanup

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4894,6 +4894,8 @@ const char* EnumUtil::ToChars<PendingExecutionResult>(PendingExecutionResult val
 		return "BLOCKED";
 	case PendingExecutionResult::NO_TASKS_AVAILABLE:
 		return "NO_TASKS_AVAILABLE";
+	case PendingExecutionResult::EXECUTION_FINISHED:
+		return "EXECUTION_FINISHED";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
 	}
@@ -4915,6 +4917,9 @@ PendingExecutionResult EnumUtil::FromString<PendingExecutionResult>(const char *
 	}
 	if (StringUtil::Equals(value, "NO_TASKS_AVAILABLE")) {
 		return PendingExecutionResult::NO_TASKS_AVAILABLE;
+	}
+	if (StringUtil::Equals(value, "EXECUTION_FINISHED")) {
+		return PendingExecutionResult::EXECUTION_FINISHED;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/include/duckdb/common/enums/pending_execution_result.hpp
+++ b/src/include/duckdb/common/enums/pending_execution_result.hpp
@@ -17,7 +17,8 @@ enum class PendingExecutionResult : uint8_t {
 	RESULT_NOT_READY,
 	EXECUTION_ERROR,
 	BLOCKED,
-	NO_TASKS_AVAILABLE
+	NO_TASKS_AVAILABLE,
+	EXECUTION_FINISHED
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/buffered_data/batched_buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/batched_buffered_data.hpp
@@ -39,7 +39,7 @@ public:
 	void BlockSink(const InterruptState &blocked_sink, idx_t batch);
 
 	bool ShouldBlockBatch(idx_t batch);
-	PendingExecutionResult ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) override;
+	bool ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) override;
 	unique_ptr<DataChunk> Scan() override;
 	void UpdateMinBatchIndex(idx_t min_batch_index);
 	bool IsMinimumBatchIndex(lock_guard<mutex> &lock, idx_t batch);

--- a/src/include/duckdb/main/buffered_data/buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/buffered_data.hpp
@@ -31,7 +31,7 @@ public:
 	virtual ~BufferedData();
 
 public:
-	virtual PendingExecutionResult ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) = 0;
+	virtual bool ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) = 0;
 	virtual unique_ptr<DataChunk> Scan() = 0;
 	shared_ptr<ClientContext> GetContext() {
 		return context.lock();

--- a/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
@@ -31,7 +31,7 @@ public:
 	void Append(const DataChunk &chunk);
 	void BlockSink(const InterruptState &blocked_sink);
 	bool BufferIsFull();
-	PendingExecutionResult ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) override;
+	bool ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) override;
 	unique_ptr<DataChunk> Scan() override;
 	inline idx_t BufferSize() const {
 		return buffer_size;

--- a/src/include/duckdb/main/pending_query_result.hpp
+++ b/src/include/duckdb/main/pending_query_result.hpp
@@ -51,7 +51,6 @@ public:
 
 	//! Function to determine whether execution is considered finished
 	DUCKDB_API static bool IsFinished(PendingExecutionResult result);
-	DUCKDB_API static bool IsFinishedOrBlocked(PendingExecutionResult result);
 
 private:
 	shared_ptr<ClientContext> context;

--- a/src/include/duckdb/main/pending_query_result.hpp
+++ b/src/include/duckdb/main/pending_query_result.hpp
@@ -50,7 +50,8 @@ public:
 	DUCKDB_API void Close();
 
 	//! Function to determine whether execution is considered finished
-	DUCKDB_API static bool IsFinished(PendingExecutionResult result);
+	DUCKDB_API static bool IsResultReady(PendingExecutionResult result);
+	DUCKDB_API static bool IsExecutionFinished(PendingExecutionResult result);
 
 private:
 	shared_ptr<ClientContext> context;

--- a/src/main/buffered_data/batched_buffered_data.cpp
+++ b/src/main/buffered_data/batched_buffered_data.cpp
@@ -145,7 +145,8 @@ bool BatchedBufferedData::ReplenishBuffer(StreamQueryResult &result, ClientConte
 		if (!BufferIsEmpty()) {
 			break;
 		}
-		if (execution_result == PendingExecutionResult::BLOCKED) {
+		if (execution_result == PendingExecutionResult::BLOCKED ||
+		    execution_result == PendingExecutionResult::RESULT_READY) {
 			// Check if we need to unblock more sinks to reach the buffer size
 			UnblockSinks();
 			cc->WaitForTask(context_lock, result);

--- a/src/main/buffered_data/batched_buffered_data.cpp
+++ b/src/main/buffered_data/batched_buffered_data.cpp
@@ -141,7 +141,7 @@ bool BatchedBufferedData::ReplenishBuffer(StreamQueryResult &result, ClientConte
 	}
 	// Let the executor run until the buffer is no longer empty
 	PendingExecutionResult execution_result;
-	while (!PendingQueryResult::IsFinished(execution_result = cc->ExecuteTaskInternal(context_lock, result))) {
+	while (!PendingQueryResult::IsExecutionFinished(execution_result = cc->ExecuteTaskInternal(context_lock, result))) {
 		if (!BufferIsEmpty()) {
 			break;
 		}

--- a/src/main/buffered_data/batched_buffered_data.cpp
+++ b/src/main/buffered_data/batched_buffered_data.cpp
@@ -129,6 +129,8 @@ bool BatchedBufferedData::ReplenishBuffer(StreamQueryResult &result, ClientConte
 	if (Closed()) {
 		return false;
 	}
+	// Unblock any pending sinks if the buffer isnt full
+	UnblockSinks();
 	if (!BufferIsEmpty()) {
 		// The buffer isn't empty yet, just return
 		return true;
@@ -137,8 +139,6 @@ bool BatchedBufferedData::ReplenishBuffer(StreamQueryResult &result, ClientConte
 	if (!cc) {
 		return false;
 	}
-	// Unblock any pending sinks if the buffer isnt full
-	UnblockSinks();
 	// Let the executor run until the buffer is no longer empty
 	PendingExecutionResult execution_result;
 	while (!PendingQueryResult::IsFinished(execution_result = cc->ExecuteTaskInternal(context_lock, result))) {

--- a/src/main/buffered_data/simple_buffered_data.cpp
+++ b/src/main/buffered_data/simple_buffered_data.cpp
@@ -63,7 +63,8 @@ bool SimpleBufferedData::ReplenishBuffer(StreamQueryResult &result, ClientContex
 		if (buffered_count >= BufferSize()) {
 			break;
 		}
-		if (execution_result == PendingExecutionResult::BLOCKED) {
+		if (execution_result == PendingExecutionResult::BLOCKED ||
+		    execution_result == PendingExecutionResult::RESULT_READY) {
 			// Check if we need to unblock more sinks to reach the buffer size
 			UnblockSinks();
 			cc->WaitForTask(context_lock, result);

--- a/src/main/buffered_data/simple_buffered_data.cpp
+++ b/src/main/buffered_data/simple_buffered_data.cpp
@@ -59,7 +59,7 @@ bool SimpleBufferedData::ReplenishBuffer(StreamQueryResult &result, ClientContex
 	UnblockSinks();
 	// Let the executor run until the buffer is no longer empty
 	PendingExecutionResult execution_result;
-	while (!PendingQueryResult::IsFinished(execution_result = cc->ExecuteTaskInternal(context_lock, result))) {
+	while (!PendingQueryResult::IsExecutionFinished(execution_result = cc->ExecuteTaskInternal(context_lock, result))) {
 		if (buffered_count >= BufferSize()) {
 			break;
 		}

--- a/src/main/capi/pending-c.cpp
+++ b/src/main/capi/pending-c.cpp
@@ -116,9 +116,10 @@ duckdb_pending_state duckdb_pending_execute_task(duckdb_pending_result pending_r
 		return DUCKDB_PENDING_ERROR;
 	}
 	switch (return_value) {
-	case PendingExecutionResult::BLOCKED:
+	case PendingExecutionResult::EXECUTION_FINISHED:
 	case PendingExecutionResult::RESULT_READY:
 		return DUCKDB_PENDING_RESULT_READY;
+	case PendingExecutionResult::BLOCKED:
 	case PendingExecutionResult::NO_TASKS_AVAILABLE:
 		return DUCKDB_PENDING_NO_TASKS_AVAILABLE;
 	case PendingExecutionResult::RESULT_NOT_READY:

--- a/src/main/capi/pending-c.cpp
+++ b/src/main/capi/pending-c.cpp
@@ -131,15 +131,15 @@ duckdb_pending_state duckdb_pending_execute_task(duckdb_pending_result pending_r
 bool duckdb_pending_execution_is_finished(duckdb_pending_state pending_state) {
 	switch (pending_state) {
 	case DUCKDB_PENDING_RESULT_READY:
-		return PendingQueryResult::IsFinished(PendingExecutionResult::RESULT_READY);
+		return PendingQueryResult::IsResultReady(PendingExecutionResult::RESULT_READY);
 	case DUCKDB_PENDING_NO_TASKS_AVAILABLE:
-		return PendingQueryResult::IsFinished(PendingExecutionResult::NO_TASKS_AVAILABLE);
+		return PendingQueryResult::IsResultReady(PendingExecutionResult::NO_TASKS_AVAILABLE);
 	case DUCKDB_PENDING_RESULT_NOT_READY:
-		return PendingQueryResult::IsFinished(PendingExecutionResult::RESULT_NOT_READY);
+		return PendingQueryResult::IsResultReady(PendingExecutionResult::RESULT_NOT_READY);
 	case DUCKDB_PENDING_ERROR:
-		return PendingQueryResult::IsFinished(PendingExecutionResult::EXECUTION_ERROR);
+		return PendingQueryResult::IsResultReady(PendingExecutionResult::EXECUTION_ERROR);
 	default:
-		return PendingQueryResult::IsFinished(PendingExecutionResult::EXECUTION_ERROR);
+		return PendingQueryResult::IsResultReady(PendingExecutionResult::EXECUTION_ERROR);
 	}
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -544,7 +544,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 	try {
 		auto query_result = active_query->executor->ExecuteTask(dry_run);
 		if (active_query->progress_bar) {
-			auto is_finished = PendingQueryResult::IsFinishedOrBlocked(query_result);
+			auto is_finished = PendingQueryResult::IsFinished(query_result);
 			active_query->progress_bar->Update(is_finished);
 			query_progress = active_query->progress_bar->GetDetailedQueryProgress();
 		}

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -544,7 +544,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 	try {
 		auto query_result = active_query->executor->ExecuteTask(dry_run);
 		if (active_query->progress_bar) {
-			auto is_finished = PendingQueryResult::IsFinished(query_result);
+			auto is_finished = PendingQueryResult::IsResultReady(query_result);
 			active_query->progress_bar->Update(is_finished);
 			query_progress = active_query->progress_bar->GetDetailedQueryProgress();
 		}

--- a/src/main/pending_query_result.cpp
+++ b/src/main/pending_query_result.cpp
@@ -71,9 +71,8 @@ PendingExecutionResult PendingQueryResult::ExecuteTaskInternal(ClientContextLock
 unique_ptr<QueryResult> PendingQueryResult::ExecuteInternal(ClientContextLock &lock) {
 	CheckExecutableInternal(lock);
 
-	const auto is_finished = allow_stream_result ? IsFinishedOrBlocked : IsFinished;
 	PendingExecutionResult execution_result;
-	while (!is_finished(execution_result = ExecuteTaskInternal(lock))) {
+	while (!IsFinished(execution_result = ExecuteTaskInternal(lock))) {
 		if (execution_result == PendingExecutionResult::BLOCKED) {
 			CheckExecutableInternal(lock);
 			context->WaitForTask(lock, *this);
@@ -102,11 +101,6 @@ void PendingQueryResult::Close() {
 
 bool PendingQueryResult::IsFinished(PendingExecutionResult result) {
 	return (result == PendingExecutionResult::RESULT_READY || result == PendingExecutionResult::EXECUTION_ERROR);
-}
-
-bool PendingQueryResult::IsFinishedOrBlocked(PendingExecutionResult result) {
-	return (result == PendingExecutionResult::RESULT_READY || result == PendingExecutionResult::EXECUTION_ERROR ||
-	        result == PendingExecutionResult::BLOCKED);
 }
 
 } // namespace duckdb

--- a/src/main/pending_query_result.cpp
+++ b/src/main/pending_query_result.cpp
@@ -72,7 +72,7 @@ unique_ptr<QueryResult> PendingQueryResult::ExecuteInternal(ClientContextLock &l
 	CheckExecutableInternal(lock);
 
 	PendingExecutionResult execution_result;
-	while (!IsFinished(execution_result = ExecuteTaskInternal(lock))) {
+	while (!IsResultReady(execution_result = ExecuteTaskInternal(lock))) {
 		if (execution_result == PendingExecutionResult::BLOCKED) {
 			CheckExecutableInternal(lock);
 			context->WaitForTask(lock, *this);
@@ -99,8 +99,12 @@ void PendingQueryResult::Close() {
 	context.reset();
 }
 
-bool PendingQueryResult::IsFinished(PendingExecutionResult result) {
-	return (result == PendingExecutionResult::RESULT_READY || result == PendingExecutionResult::EXECUTION_ERROR);
+bool PendingQueryResult::IsResultReady(PendingExecutionResult result) {
+	return (IsExecutionFinished(result) || result == PendingExecutionResult::RESULT_READY);
+}
+
+bool PendingQueryResult::IsExecutionFinished(PendingExecutionResult result) {
+	return (result == PendingExecutionResult::EXECUTION_FINISHED || result == PendingExecutionResult::EXECUTION_ERROR);
 }
 
 } // namespace duckdb

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -49,8 +49,7 @@ unique_ptr<DataChunk> StreamQueryResult::FetchInternal(ClientContextLock &lock) 
 	unique_ptr<DataChunk> chunk;
 	try {
 		// fetch the chunk and return it
-		auto res = buffered_data->ReplenishBuffer(*this, lock);
-		if (res == PendingExecutionResult::EXECUTION_ERROR) {
+		if (!buffered_data->ReplenishBuffer(*this, lock)) {
 			return chunk;
 		}
 		chunk = buffered_data->Scan();

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -502,7 +502,7 @@ bool Executor::ExecutionIsFinished() {
 PendingExecutionResult Executor::ExecuteTask(bool dry_run) {
 	// Only executor should return NO_TASKS_AVAILABLE
 	D_ASSERT(execution_result != PendingExecutionResult::NO_TASKS_AVAILABLE);
-	if (execution_result != PendingExecutionResult::RESULT_NOT_READY) {
+	if (execution_result != PendingExecutionResult::RESULT_NOT_READY && ExecutionIsFinished()) {
 		return execution_result;
 	}
 	// check if there are any incomplete pipelines

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -566,7 +566,7 @@ PendingExecutionResult Executor::ExecuteTask(bool dry_run) {
 		execution_result = PendingExecutionResult::EXECUTION_ERROR;
 		ThrowException();
 	} // LCOV_EXCL_STOP
-	execution_result = PendingExecutionResult::RESULT_READY;
+	execution_result = PendingExecutionResult::EXECUTION_FINISHED;
 	return execution_result;
 }
 

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -464,6 +464,9 @@ void Executor::RescheduleTask(shared_ptr<Task> &task_p) {
 }
 
 bool Executor::ResultCollectorIsBlocked() {
+	if (!HasResultCollector()) {
+		return false;
+	}
 	if (completed_pipelines + 1 != total_pipelines) {
 		// The result collector is always in the last pipeline
 		return false;

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -466,7 +466,7 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::ExecuteMany(const py::object 
 
 unique_ptr<QueryResult> DuckDBPyConnection::CompletePendingQuery(PendingQueryResult &pending_query) {
 	PendingExecutionResult execution_result;
-	while (!PendingQueryResult::IsFinished(execution_result = pending_query.ExecuteTask())) {
+	while (!PendingQueryResult::IsResultReady(execution_result = pending_query.ExecuteTask())) {
 		{
 			py::gil_scoped_acquire gil;
 			if (PyErr_CheckSignals() != 0) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -464,17 +464,9 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::ExecuteMany(const py::object 
 	return shared_from_this();
 }
 
-static std::function<bool(PendingExecutionResult)> FinishedCondition(PendingQueryResult &pending_query) {
-	if (pending_query.AllowStreamResult()) {
-		return PendingQueryResult::IsFinishedOrBlocked;
-	}
-	return PendingQueryResult::IsFinished;
-}
-
 unique_ptr<QueryResult> DuckDBPyConnection::CompletePendingQuery(PendingQueryResult &pending_query) {
 	PendingExecutionResult execution_result;
-	auto is_finished = FinishedCondition(pending_query);
-	while (!is_finished(execution_result = pending_query.ExecuteTask())) {
+	while (!PendingQueryResult::IsFinished(execution_result = pending_query.ExecuteTask())) {
 		{
 			py::gil_scoped_acquire gil;
 			if (PyErr_CheckSignals() != 0) {

--- a/tools/pythonpkg/tests/fast/api/test_duckdb_execute.py
+++ b/tools/pythonpkg/tests/fast/api/test_duckdb_execute.py
@@ -40,6 +40,8 @@ class TestDuckDBExecute(object):
                 yield min(2048, rowcount - count)
                 count += 2048
 
+        # FIXME: perhaps we want to test with different buffer sizes?
+        # duckdb_cursor.execute("set streaming_buffer_size='1mb'")
         duckdb_cursor.execute(f"create table tbl as from range({rowcount})")
         duckdb_cursor.execute("select * from tbl")
         for rows in generator(rowcount):

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_batch_index.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_batch_index.py
@@ -3,18 +3,11 @@ import pytest
 import pandas as pd
 import duckdb
 
-try:
-    import pyarrow as pa
-
-    can_run = True
-except:
-    can_run = False
+pa = pytest.importorskip("pyarrow")
 
 
 class TestArrowBatchIndex(object):
     def test_arrow_batch_index(self, duckdb_cursor):
-        if not can_run:
-            return
         con = duckdb.connect()
         df = con.execute('SELECT * FROM range(10000000) t(i)').df()
         arrow_tbl = pa.Table.from_pandas(df)


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2258

Previously we introduced `PendingExecutionResult::BLOCKED` to signal that the StreamQueryResult was ready.
This couldn't use `PendingExecutionResult::RESULT_READY` because that was synonymous with "execution finished".

Using `BLOCKED` for this is a bit of a misnomer and definitely confusing, so I went back and took a different route.
I separate RESULT_READY from EXECUTION_FINISHED, now RESULT_READY can also be used for the StreamQueryResult.

### PendingExecutionResult changes

- `PendingExecutionResult::BLOCKED`
This is now returned when no task is available and there are one or more blocked tasks waiting to be rescheduled.

- `PendingExecutionResult::RESULT_READY`
This has been untangled from "execution finished", for the MaterializedResult these are still synonymous, `PendingQueryResult::IsResultReady` also checks for `EXECUTION_FINISHED`

- `PendingExecutionResult::EXECUTION_FINISHED`
This is returned when `completed_pipelines >= total_pipelines` and no error occurred.
Previously this returned `RESULT_READY`

### Changes for users of `PendingQueryResult::ExecuteTask`

Before:
```c++
PendingExecutionResult execution_result;
auto is_finished = pending_query.AllowStreamResult() ? PendingQueryResult::IsFinishedOrBlocked : PendingQueryResult::IsFinished;
while (!is_finished(execution_result = pending_query.ExecuteTask())) {
	...
}
```

After:
```c++
PendingExecutionResult execution_result;
auto is_finished = PendingQueryResult::IsResultReady;
while (!is_finished(execution_result = pending_query.ExecuteTask())) {
	...
}
```

### Other changes

WaitForTask is now used in the stream query result to avoid busy-spinning in `QueryResult::Fetch` while the worker threads are working on producing a chunk to return.