### PR TITLE
Add operator hook for sink progress

### DIFF
--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -129,6 +129,11 @@ public:
 	//! Returns the current progress percentage, or a negative value if progress bars are not supported
 	virtual double GetProgress(ClientContext &context, GlobalSourceState &gstate) const;
 
+	//! Returns the current progress percentage, or a negative value if progress bars are not supported
+	virtual double GetSinkProgress(ClientContext &context, GlobalSinkState &gstate, double source_progress) const {
+		return source_progress;
+	}
+
 public:
 	// Sink interface
 

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -81,6 +81,7 @@ bool Pipeline::GetProgress(double &current_percentage, idx_t &source_cardinality
 	}
 	auto &client = executor.context;
 	current_percentage = source->GetProgress(client, *source_state);
+	current_percentage = sink->GetSinkProgress(client, *sink->sink_state, current_percentage);
 	return current_percentage >= 0;
 }
 


### PR DESCRIPTION
Allow sink operators to adjust the progress bar by (optionally) taking the source progress into account.