### PR TITLE
Quantile: Fix variable used only in D_ASSERT

### DIFF
--- a/src/core_functions/aggregate/holistic/quantile.cpp
+++ b/src/core_functions/aggregate/holistic/quantile.cpp
@@ -352,8 +352,7 @@ struct QuantileListFallback : QuantileOperation {
 		auto ridx = ListVector::GetListSize(finalize_data.result);
 		ListVector::Reserve(finalize_data.result, ridx + bind_data.quantiles.size());
 
-		auto v_t = state.v.data();
-		D_ASSERT(v_t);
+		D_ASSERT(state.v.data());
 
 		auto &entry = target;
 		entry.offset = ridx;


### PR DESCRIPTION
Fixes errors in CI connected to amalgamation such as: https://github.com/carlopi/duckdb/actions/runs/9615483390/job/26522791959#step:10:26

Possibly `v_t` can be removed entirely, unsure.