### PR TITLE
Add `histogram_exact` function that adds values to bins only if they match exactly, and add `other` column that contains values that do not fit in any bin

### DIFF
--- a/src/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/src/core_functions/aggregate/nested/binned_histogram.cpp
@@ -124,7 +124,7 @@ struct HistogramBinFunction {
 struct HistogramRange {
 	static constexpr bool EXACT = false;
 
-	template<class T>
+	template <class T>
 	static idx_t GetBin(T value, const unsafe_vector<T> &bin_boundaries) {
 		auto entry = std::lower_bound(bin_boundaries.begin(), bin_boundaries.end(), value);
 		return UnsafeNumericCast<idx_t>(entry - bin_boundaries.begin());
@@ -134,7 +134,7 @@ struct HistogramRange {
 struct HistogramExact {
 	static constexpr bool EXACT = true;
 
-	template<class T>
+	template <class T>
 	static idx_t GetBin(T value, const unsafe_vector<T> &bin_boundaries) {
 		auto entry = std::lower_bound(bin_boundaries.begin(), bin_boundaries.end(), value);
 		if (entry == bin_boundaries.end() || !(*entry == value)) {
@@ -242,7 +242,7 @@ static Value OtherBucketValue(const LogicalType &type) {
 		// for structs we can set all child members to NULL
 		auto &child_types = StructType::GetChildTypes(type);
 		child_list_t<Value> child_list;
-		for(auto &child_type : child_types) {
+		for (auto &child_type : child_types) {
 			child_list.push_back(make_pair(child_type.first, Value(child_type.second)));
 		}
 		return Value::STRUCT(std::move(child_list));
@@ -339,7 +339,7 @@ static AggregateFunction GetHistogramBinFunction(const LogicalType &type) {
 	    nullptr, AggregateFunction::StateDestroy<STATE_TYPE, HistogramBinFunction>);
 }
 
-template<class HIST>
+template <class HIST>
 AggregateFunction GetHistogramBinFunction(const LogicalType &type) {
 	switch (type.InternalType()) {
 	case PhysicalType::BOOL:
@@ -371,7 +371,7 @@ AggregateFunction GetHistogramBinFunction(const LogicalType &type) {
 	}
 }
 
-template<class HIST>
+template <class HIST>
 unique_ptr<FunctionData> HistogramBinBindFunction(ClientContext &context, AggregateFunction &function,
                                                   vector<unique_ptr<Expression>> &arguments) {
 	for (auto &arg : arguments) {
@@ -386,17 +386,19 @@ unique_ptr<FunctionData> HistogramBinBindFunction(ClientContext &context, Aggreg
 
 AggregateFunction HistogramFun::BinnedHistogramFunction() {
 	return AggregateFunction("histogram", {LogicalType::ANY, LogicalType::LIST(LogicalType::ANY)}, LogicalTypeId::MAP,
-	                         nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, HistogramBinBindFunction<HistogramRange>, nullptr);
+	                         nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+	                         HistogramBinBindFunction<HistogramRange>, nullptr);
 }
 
 AggregateFunction HistogramExactFun::GetFunction() {
-	return AggregateFunction("histogram_exact", {LogicalType::ANY, LogicalType::LIST(LogicalType::ANY)}, LogicalTypeId::MAP,
-	                         nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, HistogramBinBindFunction<HistogramExact>, nullptr);
+	return AggregateFunction("histogram_exact", {LogicalType::ANY, LogicalType::LIST(LogicalType::ANY)},
+	                         LogicalTypeId::MAP, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+	                         HistogramBinBindFunction<HistogramExact>, nullptr);
 }
 
 ScalarFunction IsHistogramOtherBinFun::GetFunction() {
-	return ScalarFunction("is_histogram_other_bin", {LogicalType::ANY}, LogicalType::BOOLEAN, IsHistogramOtherBinFunction);
-
+	return ScalarFunction("is_histogram_other_bin", {LogicalType::ANY}, LogicalType::BOOLEAN,
+	                      IsHistogramOtherBinFunction);
 }
 
 } // namespace duckdb

--- a/src/core_functions/aggregate/nested/functions.json
+++ b/src/core_functions/aggregate/nested/functions.json
@@ -8,6 +8,13 @@
         "extra_functions": ["static AggregateFunction GetHistogramUnorderedMap(LogicalType &type);", "static AggregateFunction BinnedHistogramFunction();"]
     },
     {
+        "name": "histogram_exact",
+        "parameters": "arg,bins",
+        "description": "Returns a LIST of STRUCTs with the fields bucket and count matching the buckets exactly.",
+        "example": "histogram_exact(A, [0, 1, 2])",
+        "type": "aggregate_function"
+    },
+    {
         "name": "list",
         "parameters": "arg",
         "description": "Returns a LIST containing all the values of a column.",

--- a/src/core_functions/function_list.cpp
+++ b/src/core_functions/function_list.cpp
@@ -195,6 +195,7 @@ static const StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_SCALAR_FUNCTION_SET(HoursFun),
 	DUCKDB_SCALAR_FUNCTION(InSearchPathFun),
 	DUCKDB_SCALAR_FUNCTION(InstrFun),
+	DUCKDB_SCALAR_FUNCTION(IsHistogramOtherBinFun),
 	DUCKDB_SCALAR_FUNCTION_SET(IsFiniteFun),
 	DUCKDB_SCALAR_FUNCTION_SET(IsInfiniteFun),
 	DUCKDB_SCALAR_FUNCTION_SET(IsNanFun),

--- a/src/core_functions/function_list.cpp
+++ b/src/core_functions/function_list.cpp
@@ -191,6 +191,7 @@ static const StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_SCALAR_FUNCTION(HashFun),
 	DUCKDB_SCALAR_FUNCTION_SET(HexFun),
 	DUCKDB_AGGREGATE_FUNCTION_SET(HistogramFun),
+	DUCKDB_AGGREGATE_FUNCTION(HistogramExactFun),
 	DUCKDB_SCALAR_FUNCTION_SET(HoursFun),
 	DUCKDB_SCALAR_FUNCTION(InSearchPathFun),
 	DUCKDB_SCALAR_FUNCTION(InstrFun),

--- a/src/core_functions/scalar/generic/functions.json
+++ b/src/core_functions/scalar/generic/functions.json
@@ -119,5 +119,12 @@
         "description": "Generates bin_count equi-width bins between the min and max. If enabled nice_rounding makes the numbers more readable/less jagged",
         "example": "equi_width_bins(0, 10, 2, true)",
         "type": "scalar_function_set"
+    },
+    {
+        "name": "is_histogram_other_bin",
+        "parameters": "val",
+        "description": "Whether or not the provided value is the histogram \"other\" bin (used for values not belonging to any provided bin)",
+        "example": "is_histogram_other_bin(v)",
+        "type": "scalar_function"
     }
 ]

--- a/src/include/duckdb/core_functions/aggregate/nested_functions.hpp
+++ b/src/include/duckdb/core_functions/aggregate/nested_functions.hpp
@@ -26,6 +26,15 @@ struct HistogramFun {
 	static AggregateFunction BinnedHistogramFunction();
 };
 
+struct HistogramExactFun {
+	static constexpr const char *Name = "histogram_exact";
+	static constexpr const char *Parameters = "arg,bins";
+	static constexpr const char *Description = "Returns a LIST of STRUCTs with the fields bucket and count matching the buckets exactly.";
+	static constexpr const char *Example = "histogram_exact(A, [0, 1, 2])";
+
+	static AggregateFunction GetFunction();
+};
+
 struct ListFun {
 	static constexpr const char *Name = "list";
 	static constexpr const char *Parameters = "arg";

--- a/src/include/duckdb/core_functions/scalar/generic_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/generic_functions.hpp
@@ -168,4 +168,13 @@ struct EquiWidthBinsFun {
 	static ScalarFunctionSet GetFunctions();
 };
 
+struct IsHistogramOtherBinFun {
+	static constexpr const char *Name = "is_histogram_other_bin";
+	static constexpr const char *Parameters = "val";
+	static constexpr const char *Description = "Whether or not the provided value is the histogram \"other\" bin (used for values not belonging to any provided bin)";
+	static constexpr const char *Example = "is_histogram_other_bin(v)";
+
+	static ScalarFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/test/sql/aggregate/aggregates/histogram_exact.test
+++ b/test/sql/aggregate/aggregates/histogram_exact.test
@@ -1,0 +1,79 @@
+# name: test/sql/aggregate/aggregates/histogram_exact.test
+# description: Test histogram_exact
+# group: [aggregates]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE obs(n BIGINT);
+
+statement ok
+INSERT INTO obs VALUES (0), (5), (7), (12), (20), (23), (24), (25), (26), (28), (31), (34), (36), (41), (47)
+
+# histogram_exact finds exact matches only, and puts everything else into the "other" category
+# the value of the other category depends on the data type of the bin
+# for integer values it is the highest value of the type
+query I
+SELECT histogram_exact(n, [10, 20, 30, 40, 50]) FROM obs
+----
+{10=0, 20=1, 30=0, 40=0, 50=0, 9223372036854775807=14}
+
+# for doubles/dates/timestamps it is infinite
+query I
+SELECT histogram_exact(n::double, [10, 20, 30, 40, 50]) FROM obs
+----
+{10.0=0, 20.0=1, 30.0=0, 40.0=0, 50.0=0, inf=14}
+
+query I
+SELECT histogram_exact((date '2000-01-01' + interval (n) days)::date, [date '2000-01-01' + interval (x) days for x in [10, 20, 30, 40, 50]]) FROM obs
+----
+{2000-01-11=0, 2000-01-21=1, 2000-01-31=0, 2000-02-10=0, 2000-02-20=0, infinity=14}
+
+# for strings it is the empty string
+query I
+SELECT histogram_exact(n::varchar, [10, 20, 30, 40, 50]) FROM obs
+----
+{10=0, 20=1, 30=0, 40=0, 50=0, =14}
+
+# for lists it is an empty list
+query I
+SELECT histogram_exact([n], [[x] for x in [10, 20, 30, 40, 50]]) FROM obs
+----
+{[10]=0, [20]=1, [30]=0, [40]=0, [50]=0, []=14}
+
+# we can use the function "is_histogram_other_bin" to check if it is this other bin
+query II
+SELECT case when is_histogram_other_bin(bin) then '(other values)' else bin::varchar end as bin,
+       count
+FROM (
+	SELECT UNNEST(map_keys(hist)) AS bin, UNNEST(map_values(hist)) AS count
+	FROM (SELECT histogram_exact(n, [10, 20, 30, 40, 50]) AS hist FROM obs)
+)
+----
+10	0
+20	1
+30	0
+40	0
+50	0
+(other values)	14
+
+query II
+SELECT case when is_histogram_other_bin(bin) then '(other values)' else bin::varchar end as bin,
+       count
+FROM (
+	SELECT UNNEST(map_keys(hist)) AS bin, UNNEST(map_values(hist)) AS count
+	FROM (SELECT histogram(n, [10, 20, 30, 40]) AS hist FROM obs)
+)
+----
+10	3
+20	2
+30	5
+40	3
+(other values)	2
+
+# when there are no other values the other bin is omitted from the result
+query I
+SELECT histogram_exact(r, [0, 1, 2, 3]) FROM range(4) t(r);
+----
+{0=1, 1=1, 2=1, 3=1}

--- a/test/sql/aggregate/aggregates/histogram_tpch.test_slow
+++ b/test/sql/aggregate/aggregates/histogram_tpch.test_slow
@@ -20,7 +20,7 @@ FROM lineitem
 {0=1000048, 1=1000447, 2=999171, 3=1000989, 4=1000498, 5=1000060, 6=2}
 
 query I
-SELECT histogram(l_shipdate, list_append(range((SELECT MIN(l_shipdate) FROM lineitem), (SELECT MAX(l_shipdate) FROM lineitem), interval '1' year), 'infinity'::timestamp))
+SELECT histogram(l_shipdate, range((SELECT MIN(l_shipdate) FROM lineitem), (SELECT MAX(l_shipdate) FROM lineitem), interval '1' year))
 FROM lineitem
 ----
 {1992-01-02=17, 1993-01-02=761193, 1994-01-02=908785, 1995-01-02=909464, 1996-01-02=914963, 1997-01-02=913658, 1998-01-02=911349, infinity=681786}
@@ -88,6 +88,22 @@ SELECT bin, count FROM histogram(lineitem, l_returnflag)
 A	1478493
 N	3043852
 R	1478870
+
+# list
+query II
+SELECT bin, count FROM histogram(lineitem, [l_returnflag])
+----
+[A]	1478493
+[N]	3043852
+[R]	1478870
+
+# struct
+query II
+SELECT bin, count FROM histogram(lineitem, {'i': l_returnflag})
+----
+{'i': A}	1478493
+{'i': N}	3043852
+{'i': R}	1478870
 
 # string stress test
 query I nosort histstrings

--- a/test/sql/aggregate/aggregates/test_binned_histogram.test
+++ b/test/sql/aggregate/aggregates/test_binned_histogram.test
@@ -16,11 +16,22 @@ SELECT histogram(n, [10, 20, 30, 40, 50]) FROM obs
 ----
 {10=3, 20=2, 30=5, 40=3, 50=2}
 
+# other values are placed into the other bin
+query I
+SELECT histogram(n, [10, 20, 30, 40]) FROM obs
+----
+{10=3, 20=2, 30=5, 40=3, 9223372036854775807=2}
+
+query I
+SELECT histogram(n::double, [10, 20, 30, 40]) FROM obs
+----
+{10.0=3, 20.0=2, 30.0=5, 40.0=3, inf=2}
+
 # empty bins
 query I
 SELECT histogram(n, []) FROM obs
 ----
-{}
+{9223372036854775807=15}
 
 # bounds that are not sorted
 query I


### PR DESCRIPTION
This PR adds the `histogram_exact` function that gathers exact matches, instead of range matches. In addition, this PR modifies the binned `histogram` function (as well as `histogram_exact`) so that entries that do not fit within a bucket are returned in a "other" bucket - which has as value the highest value for that particular type. The `is_histogram_other_bin` function is also introduced that can be used to check whether or not a value is the `other` value.

```sql
D select histogram(l_extendedprice, [1000, 2000]) from lineitem;
┌──────────────────────────────────────────────────────────┐
│ histogram(l_extendedprice, main.list_value(1000, 2000))  │
│               map(decimal(15,2), ubigint)                │
├──────────────────────────────────────────────────────────┤
│ {1000.00=3086, 2000.00=117370, 9999999999999.99=5880759} │
└──────────────────────────────────────────────────────────┘
D select histogram_exact(l_returnflag, ['N']) from lineitem;
┌─────────────────────────────────────────────────────┐
│ histogram_exact(l_returnflag, main.list_value('N')) │
│                map(varchar, ubigint)                │
├─────────────────────────────────────────────────────┤
│ {N=3043852, =2957363}                               │
└─────────────────────────────────────────────────────┘
```

These functions are used to extend the `histogram` table function to provide better support for non-numeric types by displaying exact matches only for e.g. strings, and showing how many `(other values)` there are that do not belong to this set, e.g.:

```sql
D select * from histogram(lineitem, l_comment);
┌────────────────────────────────────────┬─────────┬──────────────────────────────────────────────────────────────────────────────────┐
│                  bin                   │  count  │                                       bar                                        │
│                varchar                 │ uint64  │                                     varchar                                      │
├────────────────────────────────────────┼─────────┼──────────────────────────────────────────────────────────────────────────────────┤
│  accounts. foxes                       │       2 │                                                                                  │
│ counts cajole evenly? sly orbits boo…  │       3 │                                                                                  │
│ e quickly slyly ironic foxes. unusu    │       1 │                                                                                  │
│ ffily along the sly                    │       1 │                                                                                  │
│ ld deposits aga                        │       1 │                                                                                  │
│ ly pending theo                        │      15 │                                                                                  │
│ pecial excuses nag evenly f            │       2 │                                                                                  │
│ posits. packages x-ray slyly. slyly    │       1 │                                                                                  │
│ riously pe                             │      48 │                                                                                  │
│ se slyly alo                           │       5 │                                                                                  │
│ (other values)                         │ 6001136 │ ████████████████████████████████████████████████████████████████████████████████ │
├────────────────────────────────────────┴─────────┴──────────────────────────────────────────────────────────────────────────────────┤
│ 11 rows                                                                                                                   3 columns │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

This can also be used for numeric/date/timestamp data types using the `sample` technique, e.g.:

```sql
D select * from histogram(lineitem, l_discount, technique := 'sample');
┌────────────────┬────────┬──────────────────────────────────────────────────────────────────────────────────┐
│      bin       │ count  │                                       bar                                        │
│    varchar     │ uint64 │                                     varchar                                      │
├────────────────┼────────┼──────────────────────────────────────────────────────────────────────────────────┤
│ 0.00           │ 544886 │ ███████████████████████████████████████████████████████████████████████████████▊ │
│ 0.01           │ 545834 │ ███████████████████████████████████████████████████████████████████████████████▉ │
│ 0.02           │ 546173 │ ███████████████████████████████████████████████████████████████████████████████▉ │
│ 0.03           │ 545293 │ ███████████████████████████████████████████████████████████████████████████████▊ │
│ 0.04           │ 545545 │ ███████████████████████████████████████████████████████████████████████████████▉ │
│ 0.06           │ 544970 │ ███████████████████████████████████████████████████████████████████████████████▊ │
│ 0.07           │ 546192 │ ███████████████████████████████████████████████████████████████████████████████▉ │
│ 0.08           │ 544803 │ ███████████████████████████████████████████████████████████████████████████████▊ │
│ 0.09           │ 545309 │ ███████████████████████████████████████████████████████████████████████████████▊ │
│ 0.10           │ 545815 │ ███████████████████████████████████████████████████████████████████████████████▉ │
│ (other values) │ 546395 │ ████████████████████████████████████████████████████████████████████████████████ │
├────────────────┴────────┴──────────────────────────────────────────────────────────────────────────────────┤
│ 11 rows                                                                                          3 columns │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

```