### PR TITLE
Internal #2361: Window ROWS Overflow

### DIFF
--- a/src/execution/window_executor.cpp
+++ b/src/execution/window_executor.cpp
@@ -461,18 +461,20 @@ void WindowBoundariesState::Update(const idx_t row_idx, const WindowInputColumn 
 		int64_t computed_start;
 		if (!TrySubtractOperator::Operation(static_cast<int64_t>(row_idx), boundary_start.GetCell<int64_t>(chunk_idx),
 		                                    computed_start)) {
-			throw OutOfRangeException("Overflow computing ROWS PRECEDING start");
+			window_start = partition_start;
+		} else {
+			window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 		}
-		window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 		break;
 	}
 	case WindowBoundary::EXPR_FOLLOWING_ROWS: {
 		int64_t computed_start;
 		if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx), boundary_start.GetCell<int64_t>(chunk_idx),
 		                               computed_start)) {
-			throw OutOfRangeException("Overflow computing ROWS FOLLOWING start");
+			window_start = partition_end;
+		} else {
+			window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 		}
-		window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 		break;
 	}
 	case WindowBoundary::EXPR_PRECEDING_RANGE: {
@@ -513,18 +515,20 @@ void WindowBoundariesState::Update(const idx_t row_idx, const WindowInputColumn 
 		int64_t computed_start;
 		if (!TrySubtractOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx),
 		                                    computed_start)) {
-			throw OutOfRangeException("Overflow computing ROWS PRECEDING end");
+			window_end = partition_end;
+		} else {
+			window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 		}
-		window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 		break;
 	}
 	case WindowBoundary::EXPR_FOLLOWING_ROWS: {
 		int64_t computed_start;
 		if (!TryAddOperator::Operation(int64_t(row_idx + 1), boundary_end.GetCell<int64_t>(chunk_idx),
 		                               computed_start)) {
-			throw OutOfRangeException("Overflow computing ROWS FOLLOWING end");
+			window_end = partition_end;
+		} else {
+			window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 		}
-		window_end = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 		break;
 	}
 	case WindowBoundary::EXPR_PRECEDING_RANGE: {

--- a/src/execution/window_executor.cpp
+++ b/src/execution/window_executor.cpp
@@ -471,7 +471,7 @@ void WindowBoundariesState::Update(const idx_t row_idx, const WindowInputColumn 
 		int64_t computed_start;
 		if (!TryAddOperator::Operation(static_cast<int64_t>(row_idx), boundary_start.GetCell<int64_t>(chunk_idx),
 		                               computed_start)) {
-			window_start = partition_end;
+			window_start = partition_start;
 		} else {
 			window_start = UnsafeNumericCast<idx_t>(MaxValue<int64_t>(computed_start, 0));
 		}

--- a/test/fuzzer/duckfuzz/window_negate_stats.test
+++ b/test/fuzzer/duckfuzz/window_negate_stats.test
@@ -5,8 +5,11 @@
 statement ok
 create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
 
-statement error
+query I
 SELECT max(c32) FILTER (WHERE c24) OVER (PARTITION BY c21 ROWS BETWEEN c5 PRECEDING AND CURRENT ROW) 
 FROM all_types AS t43(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42)
+ORDER BY ALL NULLS LAST
 ----
-Out of Range Error: Overflow computing ROWS PRECEDING start
+[]
+[42.0, nan, inf, -inf, NULL, -42.0]
+NULL

--- a/test/fuzzer/sqlsmith/window-rows-overflow.test
+++ b/test/fuzzer/sqlsmith/window-rows-overflow.test
@@ -3,7 +3,7 @@
 # group: [sqlsmith]
 
 statement ok
-create table all_types as 
+create table all_types as
 	select * exclude(
 		small_enum,
 		medium_enum,
@@ -11,7 +11,7 @@ create table all_types as
 	)
 from test_all_types();
 
-statement error
+query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
@@ -19,9 +19,11 @@ SELECT nth_value(1929, 42) OVER (
 )
 FROM all_types;
 ----
-Out of Range Error: Overflow computing ROWS PRECEDING start
+NULL
+NULL
+NULL
 
-statement error
+query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
@@ -29,9 +31,11 @@ SELECT nth_value(1929, 42) OVER (
 )
 FROM all_types;
 ----
-Out of Range Error: Overflow computing ROWS PRECEDING end
+NULL
+NULL
+NULL
 
-statement error
+query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
@@ -39,9 +43,11 @@ SELECT nth_value(1929, 42) OVER (
 )
 FROM all_types;
 ----
-Out of Range Error: Overflow computing ROWS FOLLOWING start
+NULL
+NULL
+NULL
 
-statement error
+query I
 SELECT nth_value(1929, 42) OVER (
 	PARTITION BY (
 		"usmallint" > "smallint"
@@ -49,4 +55,6 @@ SELECT nth_value(1929, 42) OVER (
 )
 FROM all_types;
 ----
-Out of Range Error: Overflow computing ROWS FOLLOWING end
+NULL
+NULL
+NULL


### PR DESCRIPTION
Just clamp overflows instead of throwing.
Fix begin/end mixup.

fixes: duckdblabs/duckdb-internal#2361
