### PR TITLE
fix(parquet): two-complement zeroes check on FIXED_BYTE_ARRAY encoded DECIMAL (#12621)

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -133,7 +133,7 @@ jobs:
       if: always()
       shell: bash
       run: |
-        git diff --name-only main | (grep "benchmark/micro/*.benchmark" || true) > .github/regression/updated_micro_benchmarks.csv
+        (git diff --name-only main -- "benchmark/micro/**/*.benchmark" || ls "benchmark/micro/**/*.benchmark") > .github/regression/updated_micro_benchmarks.csv
         if [ $(wc -l < .github/regression/updated_micro_benchmarks.csv) -gt 0 ]; then
           echo "Detected the following modified benchmarks. Running a regression test"
           cat .github/regression/updated_micro_benchmarks.csv

--- a/extension/parquet/include/parquet_decimal_utils.hpp
+++ b/extension/parquet/include/parquet_decimal_utils.hpp
@@ -32,6 +32,9 @@ public:
 		if (size > sizeof(PHYSICAL_TYPE)) {
 			for (idx_t i = sizeof(PHYSICAL_TYPE); i < size; i++) {
 				auto byte = *(pointer + (size - i - 1));
+				if (!positive) {
+					byte ^= 0xFF;
+				}
 				if (byte != 0) {
 					throw InvalidInputException("Invalid decimal encoding in Parquet file");
 				}

--- a/test/sql/copy/parquet/parquet_12621.test
+++ b/test/sql/copy/parquet/parquet_12621.test
@@ -1,0 +1,12 @@
+# name: test/sql/copy/parquet/parquet_12621.test
+# description: Issue #12621: Parquet read : Invalid decimal encoding in Parquet file
+# group: [parquet]
+
+require parquet
+
+query I
+select *
+from read_parquet('data/parquet-testing/issue12621.parquet')
+limit 1;
+----
+0.0000


### PR DESCRIPTION
… 

If a DECIMAL is encoded in a FIXED_BYTE_ARRAY, the stored value can be smaller that the array size, for example as a INT64 (8B) stored in a 16B FIXED_BYTE_ARRAY. In these case also the zero-bytes should be checked as two-complement.