### PR TITLE
Add != operators on string_t and interval_t

### DIFF
--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -40,6 +40,9 @@ struct interval_t { // NOLINT
 
 		return lmonths == rmonths && ldays == rdays && lmicros == rmicros;
 	}
+	inline bool operator!=(const interval_t &right) const {
+		return !(*this == right);
+	}
 
 	inline bool operator>(const interval_t &right) const {
 		const auto &left = *this;

--- a/src/include/duckdb/common/types/string_type.hpp
+++ b/src/include/duckdb/common/types/string_type.hpp
@@ -209,6 +209,10 @@ public:
 		return StringComparisonOperators::Equals(*this, r);
 	}
 
+	bool operator!=(const string_t &r) const {
+		return !(*this == r);
+	}
+
 	bool operator>(const string_t &r) const {
 		return StringComparisonOperators::GreaterThan(*this, r);
 	}


### PR DESCRIPTION
New operators are implemented as inverse of operator==.

Note that for other types they are supported, for some reason those two were missing.