### PR TITLE
feat: add duckdb_get_timestamp()

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1761,6 +1761,14 @@ The result must be destroyed with `duckdb_free`.
 DUCKDB_API char *duckdb_get_varchar(duckdb_value value);
 
 /*!
+Obtains a timestamp_t of the given value.
+
+* value: The value
+* returns: The timestamp value, or 0 if no conversion is possible.
+*/
+DUCKDB_API int64_t duckdb_get_timestamp(duckdb_value value);
+
+/*!
 Obtains an int64 of the given value.
 
 * value: The value

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -53,6 +53,14 @@ int64_t duckdb_get_int64(duckdb_value value) {
 	return duckdb::BigIntValue::Get(*val);
 }
 
+int64_t duckdb_get_timestamp(duckdb_value value) {
+	auto val = reinterpret_cast<duckdb::Value *>(value);
+	if (!val->DefaultTryCastAs(duckdb::LogicalType::TIMESTAMP)) {
+		return 0;
+	}
+	return duckdb::TimestampValue::Get(*val).value;
+}
+
 duckdb_value duckdb_create_struct_value(duckdb_logical_type type, duckdb_value *values) {
 	if (!type || !values) {
 		return nullptr;


### PR DESCRIPTION
Extend the C API with `duckdb_get_timestamp()` that obtains a `timestamp_t` from a `duckdb_value`.  If the value cannot be converted to a timestamp it returns zero just like `duckdb_get_int64()`.