### PR TITLE
fix: improve C scalar functions API

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2358,6 +2358,23 @@ If the function is incomplete or a function with this name already exists DuckDB
 * returns: Whether or not the registration was successful.
 */
 DUCKDB_API duckdb_state duckdb_register_scalar_function(duckdb_connection con, duckdb_scalar_function scalar_function);
+
+/*!
+Retrieves the extra info of the function as set in `duckdb_scalar_function_set_extra_info`.
+
+* info: The info object
+* returns: The extra info
+*/
+DUCKDB_API void *duckdb_scalar_function_get_extra_info(duckdb_function_info info);
+
+/*!
+Report that an error has occurred while executing the scalar function.
+
+* info: The info object
+* error: The error message
+*/
+DUCKDB_API void duckdb_scalar_function_set_error(duckdb_function_info info, const char *error);
+
 //===--------------------------------------------------------------------===//
 // Table Functions
 //===--------------------------------------------------------------------===//

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -105,7 +105,7 @@ TEST_CASE("Test Scalar Functions C API", "[capi]") {
 }
 
 void ReturnStringInfo(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
-	auto extra_info = string((const char *)info);
+	auto extra_info = string((const char *)duckdb_scalar_function_get_extra_info(info));
 	// get the total number of rows in this chunk
 	idx_t input_size = duckdb_data_chunk_get_size(input);
 	// extract the two input vectors


### PR DESCRIPTION
Address two problems with the scalar function C API:

1. Scalar functions didn't have a way to report errors and raise exceptions.

2. Scalar functions were passed the extra_info pointer if it set as the first argument to the function, which differed from table functions.

Change the C api for scalar functions such that the function is invoked with a pointer to the CScalarFunctionInfo rather than just a pointer to the extra_info that the user may have set.

Add `duckdb_scalar_function_get_extra_info()` to retrieve the extra_info pointer.

Add `duckdb_scalar_function_set_error()` to allow a scalar function to indicate an error has occurred and an exception should be thrown.

Rather than passing the extra_info directly to the the function