### PR TITLE
[CLI] Limit history size to 100MB, and avoid writing invalid UTF8 to the CLI history

### DIFF
--- a/tools/shell/linenoise/history.cpp
+++ b/tools/shell/linenoise/history.cpp
@@ -3,6 +3,7 @@
 #include "terminal.hpp"
 #include "duckdb_shell_wrapper.h"
 #include "sqlite3.h"
+#include "utf8proc_wrapper.hpp"
 #include <sys/stat.h>
 
 namespace duckdb {

--- a/tools/shell/linenoise/history.cpp
+++ b/tools/shell/linenoise/history.cpp
@@ -51,6 +51,10 @@ void History::RemoveLastEntry() {
 }
 
 int History::Add(const char *line) {
+	return History::Add(line, strlen(line));
+}
+
+int History::Add(const char *line, idx_t len) {
 	char *linecopy;
 
 	if (history_max_len == 0) {
@@ -71,6 +75,11 @@ int History::Add(const char *line) {
 		return 0;
 	}
 
+	if (!Utf8Proc::IsValid(line, len)) {
+		// don't add invalid UTF8 to history
+		return 0;
+	}
+
 	/* Add an heap allocated copy of the line in the history.
 	 * If we reached the max length, remove the older line. */
 	if (!Terminal::IsMultiline()) {
@@ -85,30 +94,7 @@ int History::Add(const char *line) {
 			}
 		}
 	} else {
-		// replace all '\n' with '\r\n'
-		idx_t replaced_newline_count = 0;
-		idx_t len;
-		for (len = 0; line[len]; len++) {
-			if (line[len] == '\r' && line[len + 1] == '\n') {
-				// \r\n - skip past the \n
-				len++;
-			} else if (line[len] == '\n') {
-				replaced_newline_count++;
-			}
-		}
-		linecopy = (char *)malloc((len + replaced_newline_count + 1) * sizeof(char));
-		idx_t pos = 0;
-		for (len = 0; line[len]; len++) {
-			if (line[len] == '\r' && line[len + 1] == '\n') {
-				// \r\n - skip past the \n
-				linecopy[pos++] = '\r';
-				len++;
-			} else if (line[len] == '\n') {
-				linecopy[pos++] = '\r';
-			}
-			linecopy[pos++] = line[len];
-		}
-		linecopy[pos] = '\0';
+		linecopy = strdup(line);
 	}
 	if (history_len == history_max_len) {
 		free(history[0]);
@@ -183,27 +169,141 @@ int History::Save(const char *filename) {
 	return 0;
 }
 
-int History::Load(const char *filename) {
-	FILE *fp = fopen(filename, "r");
-	char buf[LINENOISE_MAX_LINE + 1];
-	buf[LINENOISE_MAX_LINE] = '\0';
+struct LineReader {
+	static constexpr idx_t LINE_BUFFER_SIZE = LINENOISE_MAX_LINE * 2ULL;
 
-	if (fp == nullptr) {
+public:
+	LineReader() : fp(nullptr), filename(nullptr), end_of_file(false), position(0), capacity(0), total_read(0) {
+		line_buffer[LINENOISE_MAX_LINE] = '\0';
+		data_buffer[LINE_BUFFER_SIZE] = '\0';
+	}
+
+	bool Init(const char *filename_p) {
+		filename = filename_p;
+		fp = fopen(filename, "r");
+		return fp;
+	}
+
+	void Close() {
+		if (fp) {
+			fclose(fp);
+			fp = nullptr;
+		}
+	}
+
+	const char *GetLine() {
+		return line_buffer;
+	}
+
+	bool NextLine() {
+		idx_t line_size = 0;
+		while (true) {
+			// find the next newline in the current buffer (if any)
+			idx_t i;
+			for (i = position; i < capacity; i++) {
+				if (data_buffer[i] == '\r' || data_buffer[i] == '\n') {
+					break;
+				}
+			}
+			// copy over the data and move to the next byte
+			idx_t read_count = i - position;
+			if (line_size + read_count > LINENOISE_MAX_LINE) {
+				// exceeded max line size
+				// move on to next line and don't add to history
+				// skip to next newline
+				bool found_next_newline = false;
+				while (!found_next_newline && capacity > 0) {
+					for (i = position; i < capacity; i++) {
+						if (data_buffer[i] == '\r' || data_buffer[i] == '\n') {
+							found_next_newline = true;
+							break;
+						}
+					}
+					if (!found_next_newline) {
+						// read more data
+						FillBuffer();
+					}
+				}
+				if (!found_next_newline) {
+					// no newline found - skip
+					return false;
+				}
+				// newline found - adjust position and read next line
+				position = i + 1;
+				if (data_buffer[i] == '\r' && data_buffer[i + 1] == '\n') {
+					// \r\n - skip the next byte as well
+					position++;
+				}
+				continue;
+			}
+			memcpy(line_buffer + line_size, data_buffer + position, read_count);
+			line_size += read_count;
+
+			if (i < capacity) {
+				// we're still within the buffer - this means we found a newline in the buffer
+				line_buffer[line_size] = '\0';
+				position = i + 1;
+				if (data_buffer[i] == '\r' && data_buffer[i + 1] == '\n') {
+					// \r\n - skip the next byte as well
+					position++;
+				}
+				if (line_size == 0 || !Utf8Proc::IsValid(line_buffer, line_size)) {
+					// line is empty OR not valid UTF8
+					// move on to next line and don't add to history
+					line_size = 0;
+					continue;
+				}
+				return true;
+			}
+			// we need to read more data - fill up the buffer
+			FillBuffer();
+			if (capacity == 0) {
+				// no more data available - return true if there is anything we copied over (i.e. part of the next line)
+				return line_size > 0;
+			}
+		}
+	}
+
+	void FillBuffer() {
+		if (end_of_file || !fp) {
+			return;
+		}
+		size_t read_data = fread(data_buffer, 1, LINE_BUFFER_SIZE, fp);
+		position = 0;
+		capacity = read_data;
+		total_read += read_data;
+
+		if (read_data == 0) {
+			end_of_file = true;
+		}
+		if (total_read >= LINENOISE_MAX_HISTORY) {
+			fprintf(stderr, "History file \"%s\" exceeds maximum history file size of %d MB - skipping full load\n",
+			        filename, LINENOISE_MAX_HISTORY / 1024 / 1024);
+			capacity = 0;
+			end_of_file = true;
+		}
+	}
+
+private:
+	FILE *fp;
+	const char *filename;
+	char line_buffer[LINENOISE_MAX_LINE + 1];
+	char data_buffer[LINE_BUFFER_SIZE + 1];
+	bool end_of_file;
+	idx_t position;
+	idx_t capacity;
+	idx_t total_read;
+};
+
+int History::Load(const char *filename) {
+	LineReader reader;
+	if (!reader.Init(filename)) {
 		return -1;
 	}
 
 	std::string result;
-	while (fgets(buf, LINENOISE_MAX_LINE, fp) != nullptr) {
-		char *p;
-
-		// strip the newline first
-		p = strchr(buf, '\r');
-		if (!p) {
-			p = strchr(buf, '\n');
-		}
-		if (p) {
-			*p = '\0';
-		}
+	while (reader.NextLine()) {
+		auto buf = reader.GetLine();
 		if (result.empty() && buf[0] == '.') {
 			// if the first character is a dot this is a dot command
 			// add the full line to the history
@@ -214,14 +314,14 @@ int History::Load(const char *filename) {
 		result += buf;
 		if (sqlite3_complete(result.c_str())) {
 			// this line contains a full SQL statement - add it to the history
-			History::Add(result.c_str());
+			History::Add(result.c_str(), result.size());
 			result = std::string();
 			continue;
 		}
 		// the result does not contain a full SQL statement - add a newline deliminator and move on to the next line
 		result += "\r\n";
 	}
-	fclose(fp);
+	reader.Close();
 
 	history_file = strdup(filename);
 	return 0;

--- a/tools/shell/linenoise/include/history.hpp
+++ b/tools/shell/linenoise/include/history.hpp
@@ -20,6 +20,7 @@ public:
 	static void Overwrite(idx_t index, const char *new_entry);
 	static void RemoveLastEntry();
 	static int Add(const char *line);
+	static int Add(const char *line, idx_t len);
 	static int SetMaxLength(idx_t len);
 	static int Save(const char *filename);
 	static int Load(const char *filename);

--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -14,7 +14,7 @@
 #include "linenoise.h"
 
 #define LINENOISE_MAX_LINE    204800
-#define LINENOISE_MAX_HISTORY 536870912
+#define LINENOISE_MAX_HISTORY 104857600
 #define LINENOISE_EDITOR
 
 namespace duckdb {

--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -13,7 +13,8 @@
 #include "terminal.hpp"
 #include "linenoise.h"
 
-#define LINENOISE_MAX_LINE 204800
+#define LINENOISE_MAX_LINE    204800
+#define LINENOISE_MAX_HISTORY 536870912
 #define LINENOISE_EDITOR
 
 namespace duckdb {


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/12350

This PR addresses the issues raised there by:

(1) limiting the amount of bytes read from the history file. If we encounter more than 100MB a warning will be printed and loading of the history file will be aborted, e.g.:

```bash
export DUCKDB_HISTORY=/Users/myth/Programs/duckdb/taxi.db   
build/reldebug/duckdb
# History file "/Users/myth/Programs/duckdb/taxi.db" exceeds maximum history file size of 100 MB - skipping full load
```

(2) prevents adding invalid UTF8 to the history entirely, and skips reading invalid UTF8 during history deserialization. This prevents issues where e.g. calling `.read <bigbinary>` will pollute the history with garbage.
