### PR TITLE
Serialization: add CustomData and better support for integrating with extensions

### DIFF
--- a/src/include/duckdb/common/serializer/binary_deserializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_deserializer.hpp
@@ -57,10 +57,6 @@ public:
 		return stream;
 	}
 
-	void SetSerializationData(const SerializationData &other) {
-		data = other;
-	}
-
 private:
 	ReadStream &stream;
 	idx_t nesting_level = 0;

--- a/src/include/duckdb/common/serializer/binary_deserializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_deserializer.hpp
@@ -57,6 +57,14 @@ public:
 		return stream;
 	}
 
+	DeserializationData &GetSerializationData() {
+		return data;
+	}
+
+	void SetSerializationData(const DeserializationData &other) {
+		data = other;
+	}
+
 private:
 	ReadStream &stream;
 	idx_t nesting_level = 0;

--- a/src/include/duckdb/common/serializer/binary_deserializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_deserializer.hpp
@@ -57,11 +57,7 @@ public:
 		return stream;
 	}
 
-	DeserializationData &GetSerializationData() {
-		return data;
-	}
-
-	void SetSerializationData(const DeserializationData &other) {
+	void SetSerializationData(const SerializationData &other) {
 		data = other;
 	}
 

--- a/src/include/duckdb/common/serializer/binary_serializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_serializer.hpp
@@ -69,14 +69,6 @@ public:
 		OnObjectEnd();
 	}
 
-	SerializationData &GetSerializationData() {
-		return data;
-	}
-
-	void SetSerializationData(const SerializationData &other) {
-		data = other;
-	}
-
 protected:
 	//-------------------------------------------------------------------------
 	// Nested Type Hooks

--- a/src/include/duckdb/common/serializer/binary_serializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_serializer.hpp
@@ -8,11 +8,11 @@
 
 #pragma once
 
-#include "duckdb/common/serializer/serializer.hpp"
-#include "duckdb/common/serializer/write_stream.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/serializer/encoding_util.hpp"
-#include "duckdb/common/serializer/deserialization_data.hpp"
+#include "duckdb/common/serializer/serialization_data.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/write_stream.hpp"
 
 namespace duckdb {
 
@@ -69,11 +69,11 @@ public:
 		OnObjectEnd();
 	}
 
-	DeserializationData &GetSerializationData() {
+	SerializationData &GetSerializationData() {
 		return data;
 	}
 
-	void SetSerializationData(const DeserializationData &other) {
+	void SetSerializationData(const SerializationData &other) {
 		data = other;
 	}
 
@@ -121,7 +121,7 @@ private:
 	WriteStream &stream;
 
 protected:
-	duckdb::DeserializationData data;
+	duckdb::SerializationData data;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/serializer/binary_serializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_serializer.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/serializer/write_stream.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/serializer/encoding_util.hpp"
+#include "duckdb/common/serializer/deserialization_data.hpp"
 
 namespace duckdb {
 
@@ -68,6 +69,14 @@ public:
 		OnObjectEnd();
 	}
 
+	DeserializationData &GetSerializationData() {
+		return data;
+	}
+
+	void SetSerializationData(const DeserializationData &other) {
+		data = other;
+	}
+
 protected:
 	//-------------------------------------------------------------------------
 	// Nested Type Hooks
@@ -110,6 +119,9 @@ protected:
 private:
 	vector<DebugState> debug_stack;
 	WriteStream &stream;
+
+protected:
+	duckdb::DeserializationData data;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/serializer/deserialization_data.hpp
+++ b/src/include/duckdb/common/serializer/deserialization_data.hpp
@@ -11,6 +11,10 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/stack.hpp"
 #include "duckdb/planner/bound_parameter_map.hpp"
+#include "duckdb/common/enums/catalog_type.hpp"
+#include "duckdb/common/enums/compression_type.hpp"
+#include "duckdb/common/enums/expression_type.hpp"
+#include "duckdb/common/enums/logical_operator_type.hpp"
 
 namespace duckdb {
 class ClientContext;

--- a/src/include/duckdb/common/serializer/deserializer.hpp
+++ b/src/include/duckdb/common/serializer/deserializer.hpp
@@ -169,6 +169,10 @@ public:
 		return data;
 	}
 
+	void SetSerializationData(const SerializationData &other) {
+		data = other;
+	}
+
 	template <class FUNC>
 	void ReadList(const field_id_t field_id, const char *tag, FUNC func) {
 		OnPropertyBegin(field_id, tag);

--- a/src/include/duckdb/common/serializer/deserializer.hpp
+++ b/src/include/duckdb/common/serializer/deserializer.hpp
@@ -9,12 +9,12 @@
 #pragma once
 
 #include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/serializer/serialization_data.hpp"
 #include "duckdb/common/serializer/serialization_traits.hpp"
-#include "duckdb/common/serializer/deserialization_data.hpp"
 #include "duckdb/common/types/string_type.hpp"
+#include "duckdb/common/uhugeint.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
-#include "duckdb/common/uhugeint.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_reader_options.hpp"
 
 namespace duckdb {
@@ -22,7 +22,7 @@ namespace duckdb {
 class Deserializer {
 protected:
 	bool deserialize_enum_from_string = false;
-	DeserializationData data;
+	SerializationData data;
 
 public:
 	virtual ~Deserializer() {
@@ -163,6 +163,10 @@ public:
 	template <class T>
 	void Unset() {
 		return data.Unset<T>();
+	}
+
+	SerializationData &GetSerializationData() {
+		return data;
 	}
 
 	template <class FUNC>

--- a/src/include/duckdb/common/serializer/serialization_data.hpp
+++ b/src/include/duckdb/common/serializer/serialization_data.hpp
@@ -23,7 +23,7 @@ class DatabaseInstance;
 class CompressionInfo;
 enum class ExpressionType : uint8_t;
 
-struct DeserializationData {
+struct SerializationData {
 	struct CustomData {
 		virtual ~CustomData() = default;
 	};
@@ -48,7 +48,7 @@ struct DeserializationData {
 	template <class T>
 	inline void AssertNotEmpty(const stack<T> &e) {
 		if (e.empty()) {
-			throw InternalException("DeserializationData - unexpected empty stack");
+			throw InternalException("SerializationData - unexpected empty stack");
 		}
 	}
 
@@ -61,7 +61,7 @@ struct DeserializationData {
 		}
 		auto &stack = iter->second;
 		if (stack.empty()) {
-			throw duckdb::InternalException("DeserializationData - unexpected empty stack for %s", type);
+			throw duckdb::InternalException("SerializationData - unexpected empty stack for %s", type);
 		}
 		return dynamic_cast<T &>(stack.top().get());
 	}
@@ -79,148 +79,148 @@ struct DeserializationData {
 };
 
 template <>
-inline void DeserializationData::Set(ExpressionType type) {
+inline void SerializationData::Set(ExpressionType type) {
 	enums.push(idx_t(type));
 }
 
 template <>
-inline ExpressionType DeserializationData::Get() {
+inline ExpressionType SerializationData::Get() {
 	AssertNotEmpty(enums);
 	return ExpressionType(enums.top());
 }
 
 template <>
-inline void DeserializationData::Unset<ExpressionType>() {
+inline void SerializationData::Unset<ExpressionType>() {
 	AssertNotEmpty(enums);
 	enums.pop();
 }
 
 template <>
-inline void DeserializationData::Set(LogicalOperatorType type) {
+inline void SerializationData::Set(LogicalOperatorType type) {
 	enums.push(idx_t(type));
 }
 
 template <>
-inline LogicalOperatorType DeserializationData::Get() {
+inline LogicalOperatorType SerializationData::Get() {
 	AssertNotEmpty(enums);
 	return LogicalOperatorType(enums.top());
 }
 
 template <>
-inline void DeserializationData::Unset<LogicalOperatorType>() {
+inline void SerializationData::Unset<LogicalOperatorType>() {
 	AssertNotEmpty(enums);
 	enums.pop();
 }
 
 template <>
-inline void DeserializationData::Set(CompressionType type) {
+inline void SerializationData::Set(CompressionType type) {
 	enums.push(idx_t(type));
 }
 
 template <>
-inline CompressionType DeserializationData::Get() {
+inline CompressionType SerializationData::Get() {
 	AssertNotEmpty(enums);
 	return CompressionType(enums.top());
 }
 
 template <>
-inline void DeserializationData::Unset<CompressionType>() {
+inline void SerializationData::Unset<CompressionType>() {
 	AssertNotEmpty(enums);
 	enums.pop();
 }
 
 template <>
-inline void DeserializationData::Set(CatalogType type) {
+inline void SerializationData::Set(CatalogType type) {
 	enums.push(idx_t(type));
 }
 
 template <>
-inline CatalogType DeserializationData::Get() {
+inline CatalogType SerializationData::Get() {
 	AssertNotEmpty(enums);
 	return CatalogType(enums.top());
 }
 
 template <>
-inline void DeserializationData::Unset<CatalogType>() {
+inline void SerializationData::Unset<CatalogType>() {
 	AssertNotEmpty(enums);
 	enums.pop();
 }
 
 template <>
-inline void DeserializationData::Set(ClientContext &context) {
+inline void SerializationData::Set(ClientContext &context) {
 	contexts.emplace(context);
 }
 
 template <>
-inline ClientContext &DeserializationData::Get() {
+inline ClientContext &SerializationData::Get() {
 	AssertNotEmpty(contexts);
 	return contexts.top();
 }
 
 template <>
-inline void DeserializationData::Unset<ClientContext>() {
+inline void SerializationData::Unset<ClientContext>() {
 	AssertNotEmpty(contexts);
 	contexts.pop();
 }
 
 template <>
-inline void DeserializationData::Set(DatabaseInstance &db) {
+inline void SerializationData::Set(DatabaseInstance &db) {
 	databases.emplace(db);
 }
 
 template <>
-inline DatabaseInstance &DeserializationData::Get() {
+inline DatabaseInstance &SerializationData::Get() {
 	AssertNotEmpty(databases);
 	return databases.top();
 }
 
 template <>
-inline void DeserializationData::Unset<DatabaseInstance>() {
+inline void SerializationData::Unset<DatabaseInstance>() {
 	AssertNotEmpty(databases);
 	databases.pop();
 }
 
 template <>
-inline void DeserializationData::Set(bound_parameter_map_t &context) {
+inline void SerializationData::Set(bound_parameter_map_t &context) {
 	parameter_data.emplace(context);
 }
 
 template <>
-inline bound_parameter_map_t &DeserializationData::Get() {
+inline bound_parameter_map_t &SerializationData::Get() {
 	AssertNotEmpty(parameter_data);
 	return parameter_data.top();
 }
 
 template <>
-inline void DeserializationData::Unset<bound_parameter_map_t>() {
+inline void SerializationData::Unset<bound_parameter_map_t>() {
 	AssertNotEmpty(parameter_data);
 	parameter_data.pop();
 }
 
 template <>
-inline void DeserializationData::Set(LogicalType &type) {
+inline void SerializationData::Set(LogicalType &type) {
 	types.emplace(type);
 }
 
 template <>
-inline void DeserializationData::Unset<LogicalType>() {
+inline void SerializationData::Unset<LogicalType>() {
 	AssertNotEmpty(types);
 	types.pop();
 }
 
 template <>
-inline void DeserializationData::Set(const LogicalType &type) {
+inline void SerializationData::Set(const LogicalType &type) {
 	types.emplace(type);
 }
 
 template <>
-inline const LogicalType &DeserializationData::Get() {
+inline const LogicalType &SerializationData::Get() {
 	AssertNotEmpty(types);
 	return types.top();
 }
 
 template <>
-inline void DeserializationData::Unset<const LogicalType>() {
+inline void SerializationData::Unset<const LogicalType>() {
 	AssertNotEmpty(types);
 	types.pop();
 }

--- a/src/include/duckdb/common/serializer/serialization_data.hpp
+++ b/src/include/duckdb/common/serializer/serialization_data.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/common/serializer/deserialization_data.hpp
+// duckdb/common/serializer/serialization_data.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -226,18 +226,18 @@ inline void SerializationData::Unset<const LogicalType>() {
 }
 
 template <>
-inline void DeserializationData::Set(const CompressionInfo &compression_info) {
+inline void SerializationData::Set(const CompressionInfo &compression_info) {
 	compression_infos.emplace(compression_info);
 }
 
 template <>
-inline const CompressionInfo &DeserializationData::Get() {
+inline const CompressionInfo &SerializationData::Get() {
 	AssertNotEmpty(compression_infos);
 	return compression_infos.top();
 }
 
 template <>
-inline void DeserializationData::Unset<const CompressionInfo>() {
+inline void SerializationData::Unset<const CompressionInfo>() {
 	AssertNotEmpty(compression_infos);
 	compression_infos.pop();
 }

--- a/src/include/duckdb/common/serializer/serializer.hpp
+++ b/src/include/duckdb/common/serializer/serializer.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/serializer/serialization_traits.hpp"
+#include "duckdb/common/serializer/serialization_data.hpp"
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/uhugeint.hpp"
@@ -34,6 +35,7 @@ public:
 class Serializer {
 protected:
 	SerializationOptions options;
+	SerializationData data;
 
 public:
 	virtual ~Serializer() {
@@ -65,6 +67,14 @@ public:
 	};
 
 public:
+	SerializationData &GetSerializationData() {
+		return data;
+	}
+
+	void SetSerializationData(const SerializationData &other) {
+		data = other;
+	}
+
 	// Serialize a value
 	template <class T>
 	void WriteProperty(const field_id_t field_id, const char *tag, const T &value) {


### PR DESCRIPTION
Adding `CustomData` to `SerializationData` to support the serialization of customized data for extensions.