### PR TITLE
Add configurable thresholds for using nested loop join and merge join

### DIFF
--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -95,6 +95,10 @@ struct ClientConfig {
 	idx_t ordered_aggregate_threshold = (idx_t(1) << 18);
 	//! The number of rows to accumulate before flushing during a partitioned write
 	idx_t partitioned_write_flush_threshold = idx_t(1) << idx_t(19);
+	//! The number of rows we need on either table to choose a nested loop join
+	idx_t nested_loop_join_threshold = 5;
+	//! The number of rows we need on either table to choose a merge join over an IE join
+	idx_t merge_join_threshold = 1000;
 
 	//! The maximum amount of memory to keep buffered in a streaming query result. Default: 1mb.
 	idx_t streaming_buffer_size = 1000000;

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -538,6 +538,25 @@ struct MaximumTempDirectorySize {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct MergeJoinThreshold {
+	static constexpr const char *Name = "merge_join_threshold";
+	static constexpr const char *Description = "The number of rows we need on either table to choose a merge join";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
+struct NestedLoopJoinThreshold {
+	static constexpr const char *Name = "nested_loop_join_threshold";
+	static constexpr const char *Description =
+	    "The number of rows we need on either table to choose a nested loop join";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct OldImplicitCasting {
 	static constexpr const char *Name = "old_implicit_casting";
 	static constexpr const char *Description = "Allow implicit casting to/from VARCHAR";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -103,6 +103,8 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(StreamingBufferSize),
     DUCKDB_GLOBAL(MaximumMemorySetting),
     DUCKDB_GLOBAL(MaximumTempDirectorySize),
+    DUCKDB_LOCAL(MergeJoinThreshold),
+    DUCKDB_LOCAL(NestedLoopJoinThreshold),
     DUCKDB_GLOBAL(OldImplicitCasting),
     DUCKDB_GLOBAL_ALIAS("memory_limit", MaximumMemorySetting),
     DUCKDB_GLOBAL_ALIAS("null_order", DefaultNullOrderSetting),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1207,7 +1207,6 @@ void MergeJoinThreshold::SetLocal(ClientContext &context, const Value &input) {
 
 void MergeJoinThreshold::ResetLocal(ClientContext &context) {
 	ClientConfig::GetConfig(context).merge_join_threshold = ClientConfig().merge_join_threshold;
-	auto &config = ClientConfig::GetConfig(context);
 }
 
 Value MergeJoinThreshold::GetSetting(const ClientContext &context) {
@@ -1225,7 +1224,6 @@ void NestedLoopJoinThreshold::SetLocal(ClientContext &context, const Value &inpu
 
 void NestedLoopJoinThreshold::ResetLocal(ClientContext &context) {
 	ClientConfig::GetConfig(context).nested_loop_join_threshold = ClientConfig().nested_loop_join_threshold;
-	auto &config = ClientConfig::GetConfig(context);
 }
 
 Value NestedLoopJoinThreshold::GetSetting(const ClientContext &context) {

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1198,6 +1198,42 @@ Value MaximumTempDirectorySize::GetSetting(const ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// Merge Join Threshold
+//===--------------------------------------------------------------------===//
+void MergeJoinThreshold::SetLocal(ClientContext &context, const Value &input) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.merge_join_threshold = input.GetValue<int64_t>();
+}
+
+void MergeJoinThreshold::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).merge_join_threshold = ClientConfig().merge_join_threshold;
+	auto &config = ClientConfig::GetConfig(context);
+}
+
+Value MergeJoinThreshold::GetSetting(const ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	return Value::BIGINT(config.merge_join_threshold);
+}
+
+//===--------------------------------------------------------------------===//
+// Nested Loop Join Threshold
+//===--------------------------------------------------------------------===//
+void NestedLoopJoinThreshold::SetLocal(ClientContext &context, const Value &input) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.nested_loop_join_threshold = input.GetValue<int64_t>();
+}
+
+void NestedLoopJoinThreshold::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).nested_loop_join_threshold = ClientConfig().nested_loop_join_threshold;
+	auto &config = ClientConfig::GetConfig(context);
+}
+
+Value NestedLoopJoinThreshold::GetSetting(const ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	return Value::BIGINT(config.nested_loop_join_threshold);
+}
+
+//===--------------------------------------------------------------------===//
 // Old Implicit Casting
 //===--------------------------------------------------------------------===//
 void OldImplicitCasting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -91,6 +91,8 @@ OptionValueSet &GetValueForOption(const string &name) {
 	    {"max_expression_depth", {50}},
 	    {"max_memory", {"4.0 GiB"}},
 	    {"max_temp_directory_size", {"10.0 GiB"}},
+	    {"merge_join_threshold", {73}},
+	    {"nested_loop_join_threshold", {73}},
 	    {"memory_limit", {"4.0 GiB"}},
 	    {"storage_compatibility_version", {"v0.10.0"}},
 	    {"ordered_aggregate_threshold", {Value::UBIGINT(idx_t(1) << 12)}},

--- a/test/sql/join/iejoin/iejoin_issue_6314.test_slow
+++ b/test/sql/join/iejoin/iejoin_issue_6314.test_slow
@@ -3,6 +3,9 @@
 # group: [iejoin]
 
 statement ok
+SET merge_join_threshold=0
+
+statement ok
 create table ota as select timestamp '2019-04-25 14:10:00' + concat(15 * i, ' minutes')::interval as ts,  (i * 5 % 100)::REAL AS val from generate_series(0,167136,1) t(i);
 
 statement ok

--- a/test/sql/join/iejoin/iejoin_issue_6861.test
+++ b/test/sql/join/iejoin/iejoin_issue_6861.test
@@ -8,6 +8,9 @@ PRAGMA enable_verification
 statement ok
 CREATE TABLE test(x INT);
 
+statement ok
+SET merge_join_threshold=0
+
 query II
 SELECT * 
 FROM test AS a, test AS b 

--- a/test/sql/join/iejoin/iejoin_issue_7278.test
+++ b/test/sql/join/iejoin/iejoin_issue_7278.test
@@ -6,6 +6,9 @@ statement ok
 pragma enable_verification
 
 statement ok
+SET merge_join_threshold=0
+
+statement ok
 create table calendar as
 	SELECT
 		start_ts,

--- a/test/sql/join/iejoin/iejoin_projection_maps.test
+++ b/test/sql/join/iejoin/iejoin_projection_maps.test
@@ -11,6 +11,9 @@ statement ok
 SELECT SETSEED(0.8765309);
 
 statement ok
+SET merge_join_threshold=0
+
+statement ok
 CREATE TABLE df AS
     SELECT 
         (random() * 100)::INTEGER + 1 as id,
@@ -28,8 +31,6 @@ FROM df
 
 statement ok
 PRAGMA enable_verification
-
-# mode output_hash
 
 # Test right_projection_map
 foreach prefer False True

--- a/test/sql/join/iejoin/merge_join_switch.test
+++ b/test/sql/join/iejoin/merge_join_switch.test
@@ -1,0 +1,36 @@
+# name: test/sql/join/iejoin/merge_join_switch.test
+# description: Test switching between merge joins/IE joins/nested loop joins based on settings
+# group: [iejoin]
+
+statement ok
+CREATE TABLE bigtbl AS FROM range(1000) t(i);
+
+statement ok
+CREATE TABLE smalltbl AS SELECT i AS low, i + 1 AS high FROM range(100) t(i);
+
+statement ok
+PRAGMA explain_output = 'PHYSICAL_ONLY';
+
+statement ok
+SET merge_join_threshold=0
+
+query II
+EXPLAIN SELECT COUNT(*) FROM bigtbl JOIN smalltbl ON (bigtbl.i BETWEEN low AND high)
+----
+physical_plan	<REGEX>:.*IE_JOIN.*
+
+statement ok
+SET merge_join_threshold=1000
+
+query II
+EXPLAIN SELECT COUNT(*) FROM bigtbl JOIN smalltbl ON (bigtbl.i BETWEEN low AND high)
+----
+physical_plan	<REGEX>:.*MERGE_JOIN.*
+
+statement ok
+SET nested_loop_join_threshold=1000
+
+query II
+EXPLAIN SELECT COUNT(*) FROM bigtbl JOIN smalltbl ON (bigtbl.i BETWEEN low AND high)
+----
+physical_plan	<REGEX>:.*NESTED_LOOP_JOIN.*

--- a/test/sql/join/iejoin/predicate_expressions.test
+++ b/test/sql/join/iejoin/predicate_expressions.test
@@ -5,6 +5,9 @@
 statement ok
 PRAGMA enable_verification
 
+statement ok
+SET merge_join_threshold=0
+
 # Create a range of dates
 statement ok
 create table calendar as SELECT *

--- a/test/sql/join/iejoin/test_iejoin.test
+++ b/test/sql/join/iejoin/test_iejoin.test
@@ -5,6 +5,9 @@
 statement ok
 PRAGMA enable_verification
 
+statement ok
+SET merge_join_threshold=0
+
 # Restrictive tail predicates
 # Use inequalities to prevent future range choice optimisation
 query II

--- a/test/sql/join/iejoin/test_iejoin_east_west.test
+++ b/test/sql/join/iejoin/test_iejoin_east_west.test
@@ -5,6 +5,9 @@
 statement ok
 PRAGMA enable_verification
 
+statement ok
+SET merge_join_threshold=0
+
 # create tables
 statement ok
 CREATE TABLE east AS SELECT * FROM (VALUES

--- a/test/sql/join/iejoin/test_iejoin_events.test
+++ b/test/sql/join/iejoin/test_iejoin_events.test
@@ -10,6 +10,9 @@ require vector_size 1024
 statement ok
 PRAGMA enable_verification
 
+statement ok
+SET merge_join_threshold=0
+
 # Use small 1K table to test Q2 because it melts down the other operators at larger scales
 statement ok
 SELECT SETSEED(0.8675309);

--- a/test/sql/join/iejoin/test_iejoin_null_keys.test
+++ b/test/sql/join/iejoin/test_iejoin_null_keys.test
@@ -6,6 +6,9 @@ statement ok
 pragma enable_verification
 
 statement ok
+SET merge_join_threshold=0
+
+statement ok
 create table tt (x int, y int, z int);
 
 statement ok

--- a/test/sql/join/iejoin/test_iejoin_overlaps.test
+++ b/test/sql/join/iejoin/test_iejoin_overlaps.test
@@ -5,6 +5,9 @@
 statement ok
 PRAGMA enable_verification
 
+statement ok
+SET merge_join_threshold=0
+
 # We read from CSVs to prevent the optimiser from
 # using statistics to decide the join is a NOP
 query II

--- a/test/sql/join/iejoin/test_iejoin_sort_tasks.test_slow
+++ b/test/sql/join/iejoin/test_iejoin_sort_tasks.test_slow
@@ -10,6 +10,9 @@ require 64bit
 statement ok
 PRAGMA verify_parallelism
 
+statement ok
+SET merge_join_threshold=0
+
 # Stream tables with minimal overlap that require merge tasks on both sides.
 query II
 SELECT lhs.begin, rhs.begin


### PR DESCRIPTION
This PR adds the `nested_loop_join_threshold` and `merge_join_threshold` settings - that can be used to configure at which estimated cardinality to switch to using these join types. The `nested_loop_join_threshold ` already existed before internally - but is now configurable. The `merge_join_threshold` setting is new.

The nested loop join and piecewise merge join are usually slower than the more sophisticated joins (e.g. IE join), but can perform better when one of the input tables is very small. In addition, since they avoid materialization they can consume less memory in these scenarios as well.

Usage:

```sql
SET nested_loop_join_threshold=999;
SET merge_join_join_threshold=999;
```