### PR TITLE
Rework arena allocator allocation policy - and increase pivot threshold

### DIFF
--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -109,7 +109,7 @@ struct ClientConfig {
 	idx_t pivot_limit = 100000;
 
 	//! The threshold at which we switch from using filtered aggregates to LIST with a dedicated pivot operator
-	idx_t pivot_filter_threshold = 10;
+	idx_t pivot_filter_threshold = 20;
 
 	//! Whether or not the "/" division operator defaults to integer division or floating point division
 	bool integer_division = false;

--- a/src/include/duckdb/storage/arena_allocator.hpp
+++ b/src/include/duckdb/storage/arena_allocator.hpp
@@ -26,6 +26,7 @@ struct ArenaChunk {
 
 class ArenaAllocator {
 	static constexpr const idx_t ARENA_ALLOCATOR_INITIAL_CAPACITY = 2048;
+	static constexpr const idx_t ARENA_ALLOCATOR_MAX_CAPACITY = 1ULL << 24ULL; // 16MB
 
 public:
 	DUCKDB_API explicit ArenaAllocator(Allocator &allocator, idx_t initial_capacity = ARENA_ALLOCATOR_INITIAL_CAPACITY);
@@ -62,7 +63,7 @@ public:
 private:
 	//! Internal allocator that is used by the arena allocator
 	Allocator &allocator;
-	idx_t current_capacity;
+	idx_t initial_capacity;
 	unsafe_unique_ptr<ArenaChunk> head;
 	ArenaChunk *tail;
 	//! An allocator wrapper using this arena allocator

--- a/src/storage/arena_allocator.cpp
+++ b/src/storage/arena_allocator.cpp
@@ -50,11 +50,10 @@ static data_ptr_t ArenaAllocateReallocate(PrivateAllocatorData *private_data, da
 // Arena Allocator
 //===--------------------------------------------------------------------===//
 ArenaAllocator::ArenaAllocator(Allocator &allocator, idx_t initial_capacity)
-    : allocator(allocator), arena_allocator(ArenaAllocatorAllocate, ArenaAllocatorFree, ArenaAllocateReallocate,
+    : allocator(allocator), initial_capacity(initial_capacity), arena_allocator(ArenaAllocatorAllocate, ArenaAllocatorFree, ArenaAllocateReallocate,
                                             make_uniq<ArenaAllocatorData>(*this)) {
 	head = nullptr;
 	tail = nullptr;
-	current_capacity = initial_capacity;
 }
 
 ArenaAllocator::~ArenaAllocator() {
@@ -63,10 +62,28 @@ ArenaAllocator::~ArenaAllocator() {
 data_ptr_t ArenaAllocator::Allocate(idx_t len) {
 	D_ASSERT(!head || head->current_position <= head->maximum_size);
 	if (!head || head->current_position + len > head->maximum_size) {
-		do {
-			current_capacity *= 2;
-		} while (current_capacity < len);
-		auto new_chunk = make_unsafe_uniq<ArenaChunk>(allocator, current_capacity);
+		idx_t capacity;
+		// start off with either (1) initial capacity (if we have no block) or (2) capacity of the previous block
+		if (!head) {
+			capacity = initial_capacity;
+		} else {
+			capacity = head->maximum_size;
+		}
+		// capacity of the previous block can be bigger than the max capacity if we allocate len > max capacity
+		// for new blocks - try to set it back to the max capacity
+		if (capacity > ARENA_ALLOCATOR_MAX_CAPACITY) {
+			capacity = ARENA_ALLOCATOR_MAX_CAPACITY;
+		}
+		// if we are below the max capacity - double the size of the block
+		if (capacity < ARENA_ALLOCATOR_MAX_CAPACITY) {
+			capacity *= 2;
+		}
+		// we double the size until we can fit `len`
+		// this is generally only relevant if len is very large
+		while(capacity < len) {
+			capacity *= 2;
+		}
+		auto new_chunk = make_unsafe_uniq<ArenaChunk>(allocator, capacity);
 		if (head) {
 			head->prev = new_chunk.get();
 			new_chunk->next = std::move(head);
@@ -74,7 +91,7 @@ data_ptr_t ArenaAllocator::Allocate(idx_t len) {
 			tail = new_chunk.get();
 		}
 		head = std::move(new_chunk);
-		allocated_size += current_capacity;
+		allocated_size += capacity;
 	}
 	D_ASSERT(head->current_position + len <= head->maximum_size);
 	auto result = head->data.get() + head->current_position;
@@ -142,7 +159,6 @@ void ArenaAllocator::Reset() {
 void ArenaAllocator::Destroy() {
 	head = nullptr;
 	tail = nullptr;
-	current_capacity = ARENA_ALLOCATOR_INITIAL_CAPACITY;
 	allocated_size = 0;
 }
 
@@ -150,7 +166,7 @@ void ArenaAllocator::Move(ArenaAllocator &other) {
 	D_ASSERT(!other.head);
 	other.tail = tail;
 	other.head = std::move(head);
-	other.current_capacity = current_capacity;
+	other.initial_capacity = initial_capacity;
 	other.allocated_size = allocated_size;
 	Destroy();
 }

--- a/src/storage/arena_allocator.cpp
+++ b/src/storage/arena_allocator.cpp
@@ -50,8 +50,9 @@ static data_ptr_t ArenaAllocateReallocate(PrivateAllocatorData *private_data, da
 // Arena Allocator
 //===--------------------------------------------------------------------===//
 ArenaAllocator::ArenaAllocator(Allocator &allocator, idx_t initial_capacity)
-    : allocator(allocator), initial_capacity(initial_capacity), arena_allocator(ArenaAllocatorAllocate, ArenaAllocatorFree, ArenaAllocateReallocate,
-                                            make_uniq<ArenaAllocatorData>(*this)) {
+    : allocator(allocator), initial_capacity(initial_capacity),
+      arena_allocator(ArenaAllocatorAllocate, ArenaAllocatorFree, ArenaAllocateReallocate,
+                      make_uniq<ArenaAllocatorData>(*this)) {
 	head = nullptr;
 	tail = nullptr;
 }
@@ -80,7 +81,7 @@ data_ptr_t ArenaAllocator::Allocate(idx_t len) {
 		}
 		// we double the size until we can fit `len`
 		// this is generally only relevant if len is very large
-		while(capacity < len) {
+		while (capacity < len) {
 			capacity *= 2;
 		}
 		auto new_chunk = make_unsafe_uniq<ArenaChunk>(allocator, capacity);


### PR DESCRIPTION
This PR reworks the arena allocator allocation policy. Previously we would always double the previous allocation size. While this makes sense initially (when doubling from e.g. 4KB -> 8KB, etc), always doubling the capacity means we can end up doing very large allocations, which can then (unnecessarily) fail. This PR caps the natural doubling that occurs at 16MB instead - after which we keep on allocating 16MB chunks. 

This also fixes an issue where `current_capacity` had to be reset but was not reset in all situations (in particular in `ArenaAllocator::Reset`). This could lead to the allocation threshold getting very large if arena allocators were reset and re-used repeatedly in certain scenarios which could lead to unnecessary OOM errors.

Unrelated - this PR also increases the `pivot_threshold` from 10 to 20, which was found to be a better switch-over point.



