### PR TITLE
Prevent unnecessary usage of `std::string` in `list` aggregate - and use more efficient `memcpy` for batched copy

### DIFF
--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -262,9 +262,11 @@ static void WriteDataToVarcharSegment(const ListSegmentFunctions &functions, Are
 
 	// write the characters to the linked list of child segments
 	auto child_segments = Load<LinkedList>(data_ptr_cast(GetListChildData(segment)));
-	for (char &c : str_entry.GetString()) {
-		auto child_segment = GetSegment(functions.child_functions.back(), allocator, child_segments);
-		auto data = GetPrimitiveData<char>(child_segment);
+	auto str_data = str_entry.GetData();
+	auto child_segment = GetSegment(functions.child_functions.back(), allocator, child_segments);
+	auto data = GetPrimitiveData<char>(child_segment);
+	for (idx_t i = 0; i < str_entry.GetSize(); i++) {
+		auto c = str_data[i];
 		data[child_segment->count] = c;
 		child_segment->count++;
 		child_segments.total_capacity++;

--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -250,7 +250,7 @@ static void WriteDataToVarcharSegment(const ListSegmentFunctions &functions, Are
 		Store<uint64_t>(0, data_ptr_cast(str_length_data + segment->count));
 		return;
 	}
-	string_t str_entry = UnifiedVectorFormat::GetData<string_t>(input_data.unified)[sel_entry_idx];
+	auto &str_entry = UnifiedVectorFormat::GetData<string_t>(input_data.unified)[sel_entry_idx];
 	auto str_data = str_entry.GetData();
 	idx_t str_size = str_entry.GetSize();
 	Store<uint64_t>(str_size, data_ptr_cast(str_length_data + segment->count));

--- a/src/common/types/list_segment.cpp
+++ b/src/common/types/list_segment.cpp
@@ -258,7 +258,7 @@ static void WriteDataToVarcharSegment(const ListSegmentFunctions &functions, Are
 	// write the characters to the linked list of child segments
 	auto child_segments = Load<LinkedList>(data_ptr_cast(GetListChildData(segment)));
 	idx_t current_offset = 0;
-	while(current_offset < str_size) {
+	while (current_offset < str_size) {
 		auto child_segment = GetSegment(functions.child_functions.back(), allocator, child_segments);
 		auto data = GetPrimitiveData<char>(child_segment);
 		idx_t copy_count = MinValue<idx_t>(str_size - current_offset, child_segment->capacity - child_segment->count);
@@ -414,7 +414,7 @@ static void ReadDataFromVarcharSegment(const ListSegmentFunctions &, const ListS
 		auto result_data = result_str.GetDataWriteable();
 		// copy over the data
 		idx_t current_offset = 0;
-		while(current_offset < str_length) {
+		while (current_offset < str_length) {
 			if (!linked_child_list.first_segment) {
 				throw InternalException("Insufficient data to read string");
 			}


### PR DESCRIPTION
The `list` aggregate for string values has a few places where strings are not handled as efficiently as possible:

* It would call `string_t::GetString()` to construct a `std::string`, only to iterate over the characters. This triggers an unnecessary allocation/copy.
* It would do a character-by-character copy, calling `GetSegment` and incrementing several counters for every character.
* In Finalize, we would first accumulate into a `std::string`, and then slice data from that string

This PR reworks the accumulation to do a batched `memcpy` instead by looking at how many characters can be copied (`min(capacity - count, remaining_bytes)`) - and incrementing the counters all at once.

This speeds up accumulation of many larger strings by around ~40%.

```sql
select avg(len(comment_list)) from ( select l_orderkey, list(l_comment) comment_list from lineitem group by all);
```
| v1.0  |  New  |
|-------|-------|
| 7.5s | 4.4s |

