### PR TITLE
Resolve leaking of cursors in the Python interface

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -44,6 +44,7 @@ public:
 	shared_ptr<DuckDB> database;
 	unique_ptr<Connection> connection;
 	unique_ptr<DuckDBPyRelation> result;
+	shared_ptr<DuckDBPyConnection> parent;
 	vector<shared_ptr<DuckDBPyConnection>> cursors;
 	unordered_map<string, shared_ptr<Relation>> temporary_views;
 	std::mutex py_connection_lock;

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -44,8 +44,8 @@ public:
 	shared_ptr<DuckDB> database;
 	unique_ptr<Connection> connection;
 	unique_ptr<DuckDBPyRelation> result;
-	shared_ptr<DuckDBPyConnection> parent;
-	vector<shared_ptr<DuckDBPyConnection>> cursors;
+	// shared_ptr<DuckDBPyConnection> parent;
+	vector<weak_ptr<DuckDBPyConnection>> cursors;
 	unordered_map<string, shared_ptr<Relation>> temporary_views;
 	std::mutex py_connection_lock;
 	//! MemoryFileSystem used to temporarily store file-like objects for reading

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1387,7 +1387,8 @@ void DuckDBPyConnection::Close() {
 	if (parent) {
 		auto myself = shared_from_this();
 		auto it = std::find(parent->cursors.begin(), parent->cursors.end(), myself);
-		if (it != parent->cursors.end()) parent->cursors.erase(it);
+		if (it != parent->cursors.end())
+			parent->cursors.erase(it);
 	}
 }
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1379,18 +1379,22 @@ void DuckDBPyConnection::Close() {
 	database = nullptr;
 	temporary_views.clear();
 	// https://peps.python.org/pep-0249/#Connection.close
-	for (auto &cur : cursors) {
-		cur->parent = nullptr; // prevent Close to remove this element
-		cur->Close();
+	for (auto cur : cursors) {
+		// cur->parent = nullptr; // prevent Close to remove this element
+		auto cur_ptr = cur.lock();
+		if (cur_ptr)
+			cur_ptr->Close();
 	}
 	registered_functions.clear();
 	cursors.clear();
+	/*
 	if (parent) {
 		auto myself = shared_from_this();
 		auto it = std::find(parent->cursors.begin(), parent->cursors.end(), myself);
 		if (it != parent->cursors.end())
 			parent->cursors.erase(it);
 	}
+	*/
 }
 
 void DuckDBPyConnection::Interrupt() {
@@ -1416,7 +1420,7 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Cursor() {
 	auto res = make_shared_ptr<DuckDBPyConnection>();
 	res->database = database;
 	res->connection = make_uniq<Connection>(*res->database);
-	res->parent = shared_from_this();
+	// res->parent = shared_from_this();
 	cursors.push_back(res);
 	return res;
 }
@@ -1513,7 +1517,7 @@ void CreateNewInstance(DuckDBPyConnection &res, const string &database, DBConfig
 	config.replacement_scans.emplace_back(PythonReplacementScan::Replace);
 	res.database = instance_cache.CreateInstance(database, config, cache_instance);
 	res.connection = make_uniq<Connection>(*res.database);
-	res.parent = nullptr;
+	// res.parent = nullptr;
 	auto &context = *res.connection->context;
 	PandasScanFunction scan_fun;
 	CreateTableFunctionInfo scan_info(scan_fun);
@@ -1568,7 +1572,7 @@ static shared_ptr<DuckDBPyConnection> FetchOrCreateInstance(const string &databa
 		return res;
 	}
 	res->connection = make_uniq<Connection>(*res->database);
-	res->parent = nullptr;
+	// res->parent = nullptr;
 	return res;
 }
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1380,6 +1380,7 @@ void DuckDBPyConnection::Close() {
 	temporary_views.clear();
 	// https://peps.python.org/pep-0249/#Connection.close
 	for (auto &cur : cursors) {
+		cur->parent = nullptr; // prevent Close to remove this element
 		cur->Close();
 	}
 	registered_functions.clear();


### PR DESCRIPTION
The current Python interface duplicates the current DuckDBPyConnection when the Cursor-function is invoked. For memory tracking this new DuckDBPyConnection is added to the vector of cursors of the current or "actual" DuckDBPyConnection. When the cursor is closed, it will be handled as if the DuckDBPyConnection is closed, it processes all child cursors.

This fails because the DuckDBPyConnection was added to the parent cursors vector, and since the "actual" DuckDBPyConnection is never closed, the vector grows until going out of memory.

This code introduces a parent per DuckDBPyConnection which allows the Cursor-close function to remove itself from the parent's cursors vector.

Fixed #10223

Virtually zero production code experience with C++, hence it found the cause of the memory leak using heaptrack, this is a working proposal. 