### PR TITLE
Partitioned write - keep only up until 100 files open, when this limit is exceeded close the file and create a new file if more data for this partition appears

### DIFF
--- a/benchmark/micro/copy/to_parquet_partition_by_many.benchmark
+++ b/benchmark/micro/copy/to_parquet_partition_by_many.benchmark
@@ -7,6 +7,7 @@ group copy
 
 load
 CREATE TABLE tbl AS SELECT i%1000::INT32 as part_col, i::INT32 FROM range(0,25000000) tbl(i);
+SET partitioned_write_max_open_files=10000;
 
 run
 COPY tbl TO  '${BENCHMARK_DIR}/partitioned_write' (FORMAT parquet, PARTITION_BY part_col, OVERWRITE_OR_IGNORE TRUE);

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -14,6 +14,7 @@ namespace duckdb {
 
 struct PartitionWriteInfo {
 	unique_ptr<GlobalFunctionData> global_state;
+	idx_t active_writes = 0;
 };
 
 struct VectorOfValuesHashFunction {
@@ -44,6 +45,9 @@ template <class T>
 using vector_of_value_map_t = unordered_map<vector<Value>, T, VectorOfValuesHashFunction, VectorOfValuesEquality>;
 
 class CopyToFunctionGlobalState : public GlobalSinkState {
+public:
+	static constexpr idx_t PARTITIONED_WRITE_MAX_OPEN_FILES = 100;
+
 public:
 	explicit CopyToFunctionGlobalState(unique_ptr<GlobalFunctionData> global_state)
 	    : rows_copied(0), last_file_offset(0), global_state(std::move(global_state)) {
@@ -109,16 +113,35 @@ public:
 	                                          const vector<Value> &values) {
 		auto global_lock = lock.GetExclusiveLock();
 		// check if we have already started writing this partition
-		auto entry = active_partitioned_writes.find(values);
-		if (entry != active_partitioned_writes.end()) {
+		auto active_write_entry = active_partitioned_writes.find(values);
+		if (active_write_entry != active_partitioned_writes.end()) {
 			// we have - continue writing in this partition
-			return *entry->second;
+			active_write_entry->second->active_writes++;
+			return *active_write_entry->second;
+		}
+		// check if we need to close any writers before we can continue
+		if (active_partitioned_writes.size() >= PARTITIONED_WRITE_MAX_OPEN_FILES) {
+			// we need to! try to close writers
+			for (auto &entry : active_partitioned_writes) {
+				if (entry.second->active_writes == 0) {
+					// we can evict this entry - evict the partition
+					FinalizePartition(context.client, op, *entry.second);
+					++previous_partitions[entry.first];
+					active_partitioned_writes.erase(entry.first);
+					break;
+				}
+			}
+		}
+		idx_t offset = 0;
+		auto prev_offset = previous_partitions.find(values);
+		if (prev_offset != previous_partitions.end()) {
+			offset = prev_offset->second;
 		}
 		auto &fs = FileSystem::GetFileSystem(context.client);
 		// Create a writer for the current file
 		auto trimmed_path = op.GetTrimmedPath(context.client);
 		string hive_path = GetOrCreateDirectory(op.partition_columns, op.names, values, trimmed_path, fs);
-		string full_path(op.filename_pattern.CreateFilename(fs, hive_path, op.file_extension, 0));
+		string full_path(op.filename_pattern.CreateFilename(fs, hive_path, op.file_extension, offset));
 		if (op.overwrite_mode == CopyOverwriteMode::COPY_APPEND) {
 			// when appending, we first check if the file exists
 			while (fs.FileExists(full_path)) {
@@ -126,7 +149,7 @@ public:
 				if (!op.filename_pattern.HasUUID()) {
 					throw InternalException("CopyOverwriteMode::COPY_APPEND without {uuid} - and file exists");
 				}
-				full_path = op.filename_pattern.CreateFilename(fs, hive_path, op.file_extension, 0);
+				full_path = op.filename_pattern.CreateFilename(fs, hive_path, op.file_extension, offset);
 			}
 		}
 		if (op.return_type == CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST) {
@@ -136,14 +159,21 @@ public:
 		auto info = make_uniq<PartitionWriteInfo>();
 		info->global_state = op.function.copy_to_initialize_global(context.client, *op.bind_data, full_path);
 		auto &result = *info;
+		info->active_writes = 1;
 		// store in active write map
 		active_partitioned_writes.insert(make_pair(values, std::move(info)));
 		return result;
 	}
 
+	void FinishPartitionWrite(PartitionWriteInfo &info) {
+		auto global_lock = lock.GetExclusiveLock();
+		info.active_writes--;
+	}
+
 private:
 	//! The active writes per partition (for partitioned write)
 	vector_of_value_map_t<unique_ptr<PartitionWriteInfo>> active_partitioned_writes;
+	vector_of_value_map_t<idx_t> previous_partitions;
 };
 
 string PhysicalCopyToFile::GetTrimmedPath(ClientContext &context) const {
@@ -219,6 +249,7 @@ public:
 			op.function.copy_to_combine(context, *op.bind_data, *info.global_state, *local_copy_state);
 			local_copy_state.reset();
 			partitions[i].reset();
+			g.FinishPartitionWrite(info);
 		}
 		ResetAppendState();
 	}

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -95,6 +95,8 @@ struct ClientConfig {
 	idx_t ordered_aggregate_threshold = (idx_t(1) << 18);
 	//! The number of rows to accumulate before flushing during a partitioned write
 	idx_t partitioned_write_flush_threshold = idx_t(1) << idx_t(19);
+	//! The amount of rows we can keep open before we close and flush them during a partitioned write
+	idx_t partitioned_write_max_open_files = idx_t(100);
 	//! The number of rows we need on either table to choose a nested loop join
 	idx_t nested_loop_join_threshold = 5;
 	//! The number of rows we need on either table to choose a merge join over an IE join

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -576,6 +576,16 @@ struct PartitionedWriteFlushThreshold {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct PartitionedWriteMaxOpenFiles {
+	static constexpr const char *Name = "partitioned_write_max_open_files";
+	static constexpr const char *Description =
+	    "The maximum amount of files the system can keep open before flushing to disk when writing using PARTITION_BY";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct DefaultBlockAllocSize {
 	static constexpr const char *Name = "default_block_size";
 	static constexpr const char *Description =

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -570,7 +570,7 @@ struct PartitionedWriteFlushThreshold {
 	static constexpr const char *Name = "partitioned_write_flush_threshold";
 	static constexpr const char *Description =
 	    "The threshold in number of rows after which we flush a thread state when writing using PARTITION_BY";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -580,7 +580,7 @@ struct PartitionedWriteMaxOpenFiles {
 	static constexpr const char *Name = "partitioned_write_max_open_files";
 	static constexpr const char *Description =
 	    "The maximum amount of files the system can keep open before flushing to disk when writing using PARTITION_BY";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -138,6 +138,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(DuckDBApiSetting),
     DUCKDB_GLOBAL(CustomUserAgentSetting),
     DUCKDB_LOCAL(PartitionedWriteFlushThreshold),
+    DUCKDB_LOCAL(PartitionedWriteMaxOpenFiles),
     DUCKDB_GLOBAL(DefaultBlockAllocSize),
     DUCKDB_GLOBAL(IndexScanPercentage),
     DUCKDB_GLOBAL(IndexScanMaxCount),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1260,7 +1260,7 @@ void PartitionedWriteFlushThreshold::SetLocal(ClientContext &context, const Valu
 }
 
 Value PartitionedWriteFlushThreshold::GetSetting(const ClientContext &context) {
-	return Value::BIGINT(NumericCast<int64_t>(ClientConfig::GetConfig(context).partitioned_write_flush_threshold));
+	return Value::UBIGINT(ClientConfig::GetConfig(context).partitioned_write_flush_threshold);
 }
 
 //===--------------------------------------------------------------------===//
@@ -1275,7 +1275,7 @@ void PartitionedWriteMaxOpenFiles::SetLocal(ClientContext &context, const Value 
 }
 
 Value PartitionedWriteMaxOpenFiles::GetSetting(const ClientContext &context) {
-	return Value::BIGINT(NumericCast<int64_t>(ClientConfig::GetConfig(context).partitioned_write_max_open_files));
+	return Value::UBIGINT(ClientConfig::GetConfig(context).partitioned_write_max_open_files);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1264,6 +1264,21 @@ Value PartitionedWriteFlushThreshold::GetSetting(const ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// Partitioned Write Flush Threshold
+//===--------------------------------------------------------------------===//
+void PartitionedWriteMaxOpenFiles::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).partitioned_write_max_open_files = ClientConfig().partitioned_write_max_open_files;
+}
+
+void PartitionedWriteMaxOpenFiles::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).partitioned_write_max_open_files = input.GetValue<idx_t>();
+}
+
+Value PartitionedWriteMaxOpenFiles::GetSetting(const ClientContext &context) {
+	return Value::BIGINT(NumericCast<int64_t>(ClientConfig::GetConfig(context).partitioned_write_max_open_files));
+}
+
+//===--------------------------------------------------------------------===//
 // Preferred block allocation size
 //===--------------------------------------------------------------------===//
 void DefaultBlockAllocSize::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -43,7 +43,7 @@ struct OptionValueSet {
 void RequireValueEqual(ConfigurationOption *op, const Value &left, const Value &right, int line);
 #define REQUIRE_VALUE_EQUAL(op, lhs, rhs) RequireValueEqual(op, lhs, rhs, __LINE__)
 
-OptionValueSet &GetValueForOption(const string &name) {
+OptionValueSet GetValueForOption(const string &name, LogicalTypeId type) {
 	static unordered_map<string, OptionValueSet> value_map = {
 	    {"threads", {Value::BIGINT(42), Value::BIGINT(42)}},
 	    {"checkpoint_threshold", {"4.0 GiB"}},
@@ -52,16 +52,11 @@ OptionValueSet &GetValueForOption(const string &name) {
 	    {"default_order", {"desc"}},
 	    {"default_null_order", {"nulls_first"}},
 	    {"disabled_optimizers", {"extension"}},
-	    {"debug_asof_iejoin", {Value(true)}},
-	    {"debug_force_external", {Value(true)}},
-	    {"debug_force_no_cross_product", {Value(true)}},
 	    {"debug_force_external", {Value(true)}},
 	    {"old_implicit_casting", {Value(true)}},
 	    {"prefer_range_joins", {Value(true)}},
 	    {"allow_persistent_secrets", {Value(false)}},
 	    {"secret_directory", {"/tmp/some/path"}},
-	    {"enable_macro_dependencies", {Value(true)}},
-	    {"enable_view_dependencies", {Value(true)}},
 	    {"default_secret_storage", {"custom_storage"}},
 	    {"custom_extension_repository", {"duckdb.org/no-extensions-here", "duckdb.org/no-extensions-here"}},
 	    {"autoinstall_extension_repository", {"duckdb.org/no-extensions-here", "duckdb.org/no-extensions-here"}},
@@ -75,19 +70,13 @@ OptionValueSet &GetValueForOption(const string &name) {
 #else
 	    {"autoinstall_known_extensions", {true}},
 #endif
-	    {"enable_fsst_vectors", {true}},
-	    {"enable_object_cache", {true}},
 	    {"enable_profiling", {"json"}},
-	    {"enable_progress_bar", {true}},
-	    {"errors_as_json", {true}},
 	    {"explain_output", {{"all", "optimized_only", "physical_only"}}},
 	    {"file_search_path", {"test"}},
 	    {"force_compression", {"uncompressed", "Uncompressed"}},
 	    {"home_directory", {"test"}},
 	    {"allow_extensions_metadata_mismatch", {"true"}},
-	    {"integer_division", {true}},
 	    {"extension_directory", {"test"}},
-	    {"immediate_transaction_mode", {true}},
 	    {"max_expression_depth", {50}},
 	    {"max_memory", {"4.0 GiB"}},
 	    {"max_temp_directory_size", {"10.0 GiB"}},
@@ -109,19 +98,26 @@ OptionValueSet &GetValueForOption(const string &name) {
 	    {"progress_bar_time", {0}},
 	    {"temp_directory", {"tmp"}},
 	    {"wal_autocheckpoint", {"4.0 GiB"}},
-	    {"worker_threads", {42}},
-	    {"enable_http_metadata_cache", {true}},
 	    {"force_bitpacking_mode", {"constant"}},
-	    {"arrow_large_buffer_size", {true}},
-	    {"arrow_output_list_view", {true}},
-	    {"produce_arrow_string_view", {true}},
-	    {"enable_http_logging", {true}},
 	    {"http_logging_output", {"my_cool_outputfile"}},
-	    {"produce_arrow_string_view", {true}},
-	    {"allocator_flush_threshold", {"4.0 GiB"}},
-	    {"allocator_background_threads", {true}}};
+	    {"allocator_flush_threshold", {"4.0 GiB"}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {
+		switch (type) {
+		case LogicalTypeId::BOOLEAN:
+			return OptionValueSet(Value::BOOLEAN(true));
+		case LogicalTypeId::TINYINT:
+		case LogicalTypeId::SMALLINT:
+		case LogicalTypeId::INTEGER:
+		case LogicalTypeId::BIGINT:
+		case LogicalTypeId::UTINYINT:
+		case LogicalTypeId::USMALLINT:
+		case LogicalTypeId::UINTEGER:
+		case LogicalTypeId::UBIGINT:
+			return OptionValueSet(Value::Numeric(type, 42));
+		default:
+			break;
+		}
 		REQUIRE(name == "MISSING_FROM_MAP");
 	}
 	return value_map[name];
@@ -196,7 +192,7 @@ TEST_CASE("Test RESET statement for ClientConfig options", "[api]") {
 		// Get the current value of the option
 		auto original_value = op->get_setting(*con.context);
 
-		auto &value_set = GetValueForOption(option.name);
+		auto value_set = GetValueForOption(option.name, option.parameter_type);
 		// verify that at least one value is different
 		bool any_different = false;
 		string options;

--- a/test/sql/copy/parquet/parquet_hive2.test
+++ b/test/sql/copy/parquet/parquet_hive2.test
@@ -15,11 +15,32 @@ insert into orders select i%12+1,i,j from range(360)t(i),range(1000)s(j);
 statement ok
 copy (select 2000+(v//12)y,m,v,j from orders) TO '__TEST_DIR__/orders_m' (FORMAT PARQUET, PARTITION_BY (m));
 
+query IIII
+SELECT AVG(y), AVG(m), AVG(v), AVG(j) FROM '__TEST_DIR__/orders_m/**/*.parquet'
+----
+2014.5	6.5	179.5	499.5
+
 statement ok
 copy (select 2000+(v//12)y,m,v,j from orders) TO '__TEST_DIR__/orders_y' (FORMAT PARQUET, PARTITION_BY (y));
 
-# FIXME - this opens many files concurrently which can lead to out of open file handles depending on your ulimit
-mode skip
+query IIII
+SELECT AVG(y), AVG(m), AVG(v), AVG(j) FROM '__TEST_DIR__/orders_y/**/*.parquet'
+----
+2014.5	6.5	179.5	499.5
 
 statement ok
 copy (select 2000+(v//12)y,m,v,j from orders) TO '__TEST_DIR__/orders_ym' (FORMAT PARQUET,PARTITION_BY (y,m));
+
+query IIII
+SELECT AVG(y), AVG(m), AVG(v), AVG(j) FROM '__TEST_DIR__/orders_ym/**/*.parquet'
+----
+2014.5	6.5	179.5	499.5
+
+# random shuffle
+statement ok
+copy (select 2000+(v//12)y,m,v,j from orders order by random()) TO '__TEST_DIR__/orders_ym_rand' (FORMAT PARQUET,PARTITION_BY (y,m));
+
+query IIII
+SELECT AVG(y), AVG(m), AVG(v), AVG(j) FROM '__TEST_DIR__/orders_ym_rand/**/*.parquet'
+----
+2014.5	6.5	179.5	499.5


### PR DESCRIPTION
This PR reworks the partitioned write to keep only a limited amount of files open. When the limit is exceeded the file is flushed to disk and closed. If new data then pops up for such a partition, we create a new file to write that new data to.

This avoids hitting open file limits and also reduces memory pressure when doing partitioned writes - as files will be fully closed and written to disk periodically instead of kept open until the write is finished.

This is particularly effective when combined with `ORDER BY <partition_keys>` - as when the partition keys are ordered we will not see the same partition key again after we have finished writing it. This allows for a fully streaming write. Previously we would still keep e.g. Parquet metadata of each file in memory until all data was handled - which can end up consuming a large amount of memory when writing many partitions.
