### PR TITLE
[Python] Use non-owning references to hold created cursors

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -44,7 +44,7 @@ public:
 	shared_ptr<DuckDB> database;
 	unique_ptr<Connection> connection;
 	unique_ptr<DuckDBPyRelation> result;
-	vector<shared_ptr<DuckDBPyConnection>> cursors;
+	vector<weak_ptr<DuckDBPyConnection>> cursors;
 	unordered_map<string, shared_ptr<Relation>> temporary_views;
 	std::mutex py_connection_lock;
 	//! MemoryFileSystem used to temporarily store file-like objects for reading

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1380,7 +1380,12 @@ void DuckDBPyConnection::Close() {
 	temporary_views.clear();
 	// https://peps.python.org/pep-0249/#Connection.close
 	for (auto &cur : cursors) {
-		cur->Close();
+		auto cursor = cur.lock();
+		if (!cursor) {
+			// The cursor has already been closed
+			continue;
+		}
+		cursor->Close();
 	}
 	registered_functions.clear();
 	cursors.clear();

--- a/tools/pythonpkg/tests/fast/api/test_duckdb_connection.py
+++ b/tools/pythonpkg/tests/fast/api/test_duckdb_connection.py
@@ -69,6 +69,21 @@ class TestDuckDBConnection(object):
             # 'tbl' no longer exists
             duckdb.table("tbl")
 
+    def test_cursor_lifetime(self):
+        con = duckdb.connect()
+
+        def use_cursors():
+            cursors = []
+            for _ in range(10):
+                cursors.append(con.cursor())
+
+            for cursor in cursors:
+                print("closing cursor")
+                cursor.close()
+
+        use_cursors()
+        con.close()
+
     def test_df(self):
         ref = [([1, 2, 3],)]
         duckdb.execute("select [1,2,3]")


### PR DESCRIPTION
This PR fixes #12702

By using a weak_ptr, the parent connection will no longer prevent the cursor from getting cleaned up