### PR TITLE
Support thousand separator for floating point numbers

### DIFF
--- a/test/sql/function/string/test_format_extensions.test
+++ b/test/sql/function/string/test_format_extensions.test
@@ -69,11 +69,30 @@ select format('{:tss}', 123456789)
 ----
 123s456s789
 
-# and for floats?
-statement error
+# thousands separator for floats
+query I
 select format('{:,}', 123456789.123)
 ----
-Thousand separators are not supported for floating point numbers
+123,456,789.123
+
+query I
+select format('{:_}', 123456789.123)
+----
+123_456_789.123
+
+query I
+select printf('%,.3f', 123456.789::DOUBLE)
+----
+123,456.789
+
+foreach val 1.724e12 1.7e12 1.72456e12 1.723456e11 1.724567e12 1.234e4
+
+query I
+select printf('%,.f', ${val}::double) = printf('%,d', ${val}::bigint);
+----
+true
+
+endloop
 
 statement error
 select format('{:t}', 123456789)

--- a/third_party/fmt/include/fmt/format.h
+++ b/third_party/fmt/include/fmt/format.h
@@ -982,6 +982,7 @@ struct float_specs {
   int precision;
   float_format format : 8;
   sign_t sign : 8;
+  char thousand_sep : 8;
   bool upper : 1;
   bool locale : 1;
   bool percent : 1;
@@ -1038,8 +1039,33 @@ template <typename Char> class float_writer {
     }
     if (num_digits_ <= full_exp) {
       // 1234e7 -> 12340000000[.0+]
-      it = copy_str<Char>(digits_, digits_ + num_digits_, it);
-      it = std::fill_n(it, full_exp - num_digits_, static_cast<Char>('0'));
+      if (specs_.thousand_sep != '\0' && full_exp > 3) {
+        // thousand separator
+        // we need to print the thousand separator every 3 digits
+        // the loop is essentially write 3 digits, write the thousand separator
+        // the exception is the first batch of digits which are 1-3 digits
+        int digit_count = full_exp % 3 == 0 ? 3 : full_exp % 3;
+        for(int i = 0; i < full_exp; i += digit_count, digit_count = 3) {
+          if (i > 0) {
+            *it++ = specs_.thousand_sep;
+          }
+          if (i < num_digits_) {
+            // we still need to write digits
+            int write_count = std::min<int>(num_digits_ - i, digit_count);
+            it = copy_str<Char>(digits_ + i, digits_ + i + write_count, it);
+            if (write_count < digit_count) {
+              // write any trailing zeros that belong to this batch
+              it = std::fill_n(it, digit_count - write_count, static_cast<Char>('0'));
+            }
+          } else {
+            // we only need to write trailing zeros
+            it = std::fill_n(it, digit_count, static_cast<Char>('0'));
+          }
+        }
+      } else {
+        it = copy_str<Char>(digits_, digits_ + num_digits_, it);
+        it = std::fill_n(it, full_exp - num_digits_, static_cast<Char>('0'));
+      }
       if (specs_.trailing_zeros) {
         *it++ = decimal_point_;
         int num_zeros = specs_.precision - full_exp;
@@ -1056,7 +1082,21 @@ template <typename Char> class float_writer {
       }
     } else if (full_exp > 0) {
       // 1234e-2 -> 12.34[0+]
-      it = copy_str<Char>(digits_, digits_ + full_exp, it);
+      if (specs_.thousand_sep != '\0' && full_exp > 3) {
+        // thousand separator
+        // we need to print the thousand separator every 3 digits
+        // the loop is essentially write 3 digits, write the thousand separator
+        // the exception is the first batch of digits which are 1-3 digits
+        int digit_count = full_exp % 3 == 0 ? 3 : full_exp % 3;
+        for(int i = 0; i < full_exp; i += digit_count, digit_count = 3) {
+          if (i > 0) {
+            *it++ = specs_.thousand_sep;
+          }
+          it = copy_str<Char>(digits_ + i, digits_ + i + digit_count, it);
+        }
+      } else {
+        it = copy_str<Char>(digits_, digits_ + full_exp, it);
+      }
       if (!specs_.trailing_zeros) {
         // Remove trailing zeros.
         int num_digits = num_digits_;
@@ -1165,10 +1205,7 @@ FMT_CONSTEXPR float_specs parse_float_type_spec(
     const basic_format_specs<Char>& specs, ErrorHandler&& eh = {}) {
 
   auto result = float_specs();
-    if (specs.thousands != '\0') {
-      eh.on_error("Thousand separators are not supported for floating point numbers");
-      return result;
-    }
+  result.thousand_sep = specs.thousands;
   result.trailing_zeros = specs.alt;
   switch (specs.type) {
   case 0:
@@ -1664,8 +1701,15 @@ template <typename Range> class basic_writer {
       --exp;  // Adjust decimal place position.
     }
     fspecs.precision = precision;
-    char_type point = fspecs.locale ? decimal_point<char_type>(locale_)
-                                    : static_cast<char_type>('.');
+    char_type point;
+    if (fspecs.locale) {
+      point = decimal_point<char_type>(locale_);
+    } else if (fspecs.thousand_sep == '.') {
+      // if the thousand separator is a point, we automatically switch the decimal separator to comma
+      point =static_cast<char_type>(',');
+    } else {
+      point = static_cast<char_type>('.');
+    }
     write_padded(specs, float_writer<char_type>(buffer.data(),
                                                 static_cast<int>(buffer.size()),
                                                 exp, fspecs, point));


### PR DESCRIPTION
Implements https://github.com/duckdb/duckdb/issues/11657

Example usage:

```sql
select printf('%,.2f', 123456789.456);
┌────────────────────────────────┐
│ printf('%,.2f', 123456789.456) │
│            varchar             │
├────────────────────────────────┤
│ 123,456,789.46                 │
└────────────────────────────────┘
```