### PR TITLE
Shell: add .sql suffix to temporary file created with \e

### DIFF
--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -1521,9 +1521,9 @@ bool Linenoise::EditBufferWithEditor(const char *editor) {
 #endif
 	string temporary_file_name;
 #ifndef WIN32
-	temporary_file_name = string(tmpdir) + "/duckdb.edit." + std::to_string(getpid());
+	temporary_file_name = string(tmpdir) + "/duckdb.edit." + std::to_string(getpid()) + ".sql";
 #else
-	temporary_file_name = string(tmpdir) + "duckdb.edit." + std::to_string(getpid());
+	temporary_file_name = string(tmpdir) + "duckdb.edit." + std::to_string(getpid()) + ".sql";
 #endif
 
 	FILE *f = fopen(temporary_file_name.c_str(), "w+");


### PR DESCRIPTION
Allows editors to easily provide proper highlighting