### PR TITLE
Avoid unnecessarily copying child expression when binding COLLATE statements

### DIFF
--- a/src/planner/binder/expression/bind_collate_expression.cpp
+++ b/src/planner/binder/expression/bind_collate_expression.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/parser/expression/collate_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 
@@ -18,9 +19,9 @@ BindResult ExpressionBinder::BindExpression(CollateExpression &expr, idx_t depth
 		throw BinderException("collations are only supported for type varchar");
 	}
 	// Validate the collation, but don't use it
-	auto child_copy = child->Copy();
+	auto collation_test = make_uniq_base<Expression, BoundConstantExpression>(Value(child->return_type));
 	auto collation_type = LogicalType::VARCHAR_COLLATION(expr.collation);
-	PushCollation(context, child_copy, collation_type);
+	PushCollation(context, collation_test, collation_type);
 	child->return_type = collation_type;
 	return BindResult(std::move(child));
 }

--- a/test/sql/collate/collate_subquery.test
+++ b/test/sql/collate/collate_subquery.test
@@ -1,0 +1,22 @@
+# name: test/sql/collate/collate_subquery.test
+# description: Test collate statement over a subquery
+# group: [collate]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table t0(c1 varchar);
+
+statement ok
+insert into t0 values ('XXX');
+
+query I
+select (select c1 from t0) collate nocase;
+----
+XXX
+
+query I
+select (select c1 from t0) collate nocase='xxx';
+----
+true


### PR DESCRIPTION
In this code path we are only testing the collation - and making a copy is both an unnecessary cost and prevents it from working for expressions that we can't copy (e.g. subqueries)