### PR TITLE
CLI: Replace \n with \r\n again in history again

### DIFF
--- a/tools/shell/linenoise/history.cpp
+++ b/tools/shell/linenoise/history.cpp
@@ -95,7 +95,30 @@ int History::Add(const char *line, idx_t len) {
 			}
 		}
 	} else {
-		linecopy = strdup(line);
+		// replace all '\n' with '\r\n'
+		idx_t replaced_newline_count = 0;
+		idx_t len;
+		for (len = 0; line[len]; len++) {
+			if (line[len] == '\r' && line[len + 1] == '\n') {
+				// \r\n - skip past the \n
+				len++;
+			} else if (line[len] == '\n') {
+				replaced_newline_count++;
+			}
+		}
+		linecopy = (char *)malloc((len + replaced_newline_count + 1) * sizeof(char));
+		idx_t pos = 0;
+		for (len = 0; line[len]; len++) {
+			if (line[len] == '\r' && line[len + 1] == '\n') {
+				// \r\n - skip past the \n
+				linecopy[pos++] = '\r';
+				len++;
+			} else if (line[len] == '\n') {
+				linecopy[pos++] = '\r';
+			}
+			linecopy[pos++] = line[len];
+		}
+		linecopy[pos] = '\0';
 	}
 	if (history_len == history_max_len) {
 		free(history[0]);


### PR DESCRIPTION
This reverts to previous behavior - I mistakenly thought we didn't need to do this anymore now that we support all newline types in the history file, but it is still necessary to keep history with `\r\n` newlines in-memory as other code in the CLI relies on that behavior