### PR TITLE
Fix #11228 - add support for unsigned integers in printf/format

### DIFF
--- a/src/core_functions/scalar/string/printf.cpp
+++ b/src/core_functions/scalar/string/printf.cpp
@@ -27,15 +27,26 @@ unique_ptr<FunctionData> BindPrintfFunction(ClientContext &context, ScalarFuncti
 	for (idx_t i = 1; i < arguments.size(); i++) {
 		switch (arguments[i]->return_type.id()) {
 		case LogicalTypeId::BOOLEAN:
+			bound_function.arguments.emplace_back(LogicalType::BOOLEAN);
+			break;
 		case LogicalTypeId::TINYINT:
 		case LogicalTypeId::SMALLINT:
 		case LogicalTypeId::INTEGER:
 		case LogicalTypeId::BIGINT:
+			bound_function.arguments.emplace_back(LogicalType::BIGINT);
+			break;
+		case LogicalTypeId::UTINYINT:
+		case LogicalTypeId::USMALLINT:
+		case LogicalTypeId::UINTEGER:
+		case LogicalTypeId::UBIGINT:
+			bound_function.arguments.emplace_back(LogicalType::UBIGINT);
+			break;
 		case LogicalTypeId::FLOAT:
 		case LogicalTypeId::DOUBLE:
+			bound_function.arguments.emplace_back(LogicalType::DOUBLE);
+			break;
 		case LogicalTypeId::VARCHAR:
-			// these types are natively supported
-			bound_function.arguments.push_back(arguments[i]->return_type);
+			bound_function.arguments.push_back(LogicalType::VARCHAR);
 			break;
 		case LogicalTypeId::DECIMAL:
 			// decimal type: add cast to double
@@ -105,28 +116,13 @@ static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &resu
 				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
 				break;
 			}
-			case LogicalTypeId::TINYINT: {
-				auto arg_data = FlatVector::GetData<int8_t>(col);
-				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
-				break;
-			}
-			case LogicalTypeId::SMALLINT: {
-				auto arg_data = FlatVector::GetData<int16_t>(col);
-				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
-				break;
-			}
-			case LogicalTypeId::INTEGER: {
-				auto arg_data = FlatVector::GetData<int32_t>(col);
-				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
-				break;
-			}
 			case LogicalTypeId::BIGINT: {
 				auto arg_data = FlatVector::GetData<int64_t>(col);
 				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
 				break;
 			}
-			case LogicalTypeId::FLOAT: {
-				auto arg_data = FlatVector::GetData<float>(col);
+			case LogicalTypeId::UBIGINT: {
+				auto arg_data = FlatVector::GetData<uint64_t>(col);
 				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
 				break;
 			}

--- a/test/sql/function/string/test_printf.test
+++ b/test/sql/function/string/test_printf.test
@@ -78,6 +78,26 @@ SELECT printf('%s', 120381902481294715712::UHUGEINT)
 ----
 120381902481294715712
 
+query I
+select printf('%x', 255::utinyint);
+----
+ff
+
+query I
+select printf('%x', 65535::usmallint);
+----
+ffff
+
+query I
+select printf('%x', 4294967295::uinteger);
+----
+ffffffff
+
+query I
+select printf('%x', 18446744073709551615::ubigint);
+----
+ffffffffffffffff
+
 # decimal
 query T
 SELECT printf('%.3f', '1.234'::DECIMAL)


### PR DESCRIPTION
Fix #11228

Support unsigned integers (except for `uhugeint`) in printf/format functions