### PR TITLE
Add repeat(LIST[], INT) that allows repetition of lists similar to how this is allowed in Python

### DIFF
--- a/src/core_functions/scalar/string/repeat.cpp
+++ b/src/core_functions/scalar/string/repeat.cpp
@@ -31,11 +31,55 @@ static void RepeatFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	    });
 }
 
+unique_ptr<FunctionData> RepeatBindFunction(ClientContext &, ScalarFunction &bound_function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+	switch (arguments[0]->return_type.id()) {
+	case LogicalTypeId::UNKNOWN:
+		throw ParameterNotResolvedException();
+	case LogicalTypeId::LIST:
+		break;
+	default:
+		throw NotImplementedException("repeat(list, count) requires a list as parameter");
+	}
+	bound_function.arguments[0] = arguments[0]->return_type;
+	bound_function.return_type = arguments[0]->return_type;
+	return nullptr;
+}
+
+static void RepeatListFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	auto &list_vector = args.data[0];
+	auto &cnt_vector = args.data[1];
+
+	auto &source_child = ListVector::GetEntry(list_vector);
+	auto &result_child = ListVector::GetEntry(result);
+
+	idx_t current_size = ListVector::GetListSize(result);
+	BinaryExecutor::Execute<list_entry_t, int64_t, list_entry_t>(
+	    list_vector, cnt_vector, result, args.size(), [&](list_entry_t list_input, int64_t cnt) {
+		    idx_t copy_count = cnt <= 0 || list_input.length == 0 ? 0 : UnsafeNumericCast<idx_t>(cnt);
+		    idx_t result_length = list_input.length * copy_count;
+		    idx_t new_size = current_size + result_length;
+		    ListVector::Reserve(result, new_size);
+		    list_entry_t result_list;
+		    result_list.offset = current_size;
+		    result_list.length = result_length;
+		    for (idx_t i = 0; i < copy_count; i++) {
+			    // repeat the list contents "cnt" times
+			    VectorOperations::Copy(source_child, result_child, list_input.length, list_input.offset, current_size);
+			    current_size += list_input.length;
+		    }
+		    return result_list;
+	    });
+	ListVector::SetListSize(result, current_size);
+}
+
 ScalarFunctionSet RepeatFun::GetFunctions() {
 	ScalarFunctionSet repeat;
 	for (const auto &type : {LogicalType::VARCHAR, LogicalType::BLOB}) {
 		repeat.AddFunction(ScalarFunction({type, LogicalType::BIGINT}, type, RepeatFunction));
 	}
+	repeat.AddFunction(ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::BIGINT},
+	                                  LogicalType::LIST(LogicalType::ANY), RepeatListFunction, RepeatBindFunction));
 	return repeat;
 }
 

--- a/test/sql/function/list/repeat_list.test
+++ b/test/sql/function/list/repeat_list.test
@@ -1,0 +1,60 @@
+# name: test/sql/function/list/repeat_list.test
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT repeat([1], 10);
+----
+[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+query I
+SELECT repeat([{'x': 1}], 5);
+----
+[{'x': 1}, {'x': 1}, {'x': 1}, {'x': 1}, {'x': 1}]
+
+query I
+SELECT repeat([[1]], 10);
+----
+[[1], [1], [1], [1], [1], [1], [1], [1], [1], [1]]
+
+query I
+SELECT repeat([1, 2], 5);
+----
+[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]
+
+query I
+SELECT repeat([[[], [], [NULL], NULL]], 3);
+----
+[[[], [], [NULL], NULL], [[], [], [NULL], NULL], [[], [], [NULL], NULL]]
+
+query I
+SELECT repeat(['hello', 'thisisalongstring'], 5);
+----
+[hello, thisisalongstring, hello, thisisalongstring, hello, thisisalongstring, hello, thisisalongstring, hello, thisisalongstring]
+
+query I
+SELECT repeat([], 10);
+----
+[]
+
+query I
+SELECT repeat([], -1);
+----
+[]
+
+query I
+SELECT repeat(NULL::INT[], 10);
+----
+NULL
+
+query I
+SELECT repeat(repeat([1], 50), 50) = repeat([1], 2500);
+----
+true
+
+statement error
+SELECT repeat([1], 99999999999999999);
+----
+maximum allowed vector size


### PR DESCRIPTION
Similar to how this is possible for strings, this PR enables `repeat` for lists

```sql
D select repeat([1], 5) AS res;
┌─────────────────┐
│       res       │
│     int32[]     │
├─────────────────┤
│ [1, 1, 1, 1, 1] │
└─────────────────┘
```

This is identical to the multiplication of lists that is supported in Python:

```py
>>> [1] * 5
[1, 1, 1, 1, 1]
```