### PR TITLE
Add support for fetching cardinality estimation and stats through a multifilelist

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -746,6 +746,12 @@ public:
 
 	static unique_ptr<NodeStatistics> ParquetCardinality(ClientContext &context, const FunctionData *bind_data) {
 		auto &data = bind_data->Cast<ParquetReadBindData>();
+
+		auto file_list_cardinality_estimate = data.file_list->GetCardinality(context);
+		if (file_list_cardinality_estimate) {
+			return file_list_cardinality_estimate;
+		}
+
 		return make_uniq<NodeStatistics>(data.initial_file_cardinality * data.file_list->GetTotalFileCount());
 	}
 

--- a/src/common/multi_file_list.cpp
+++ b/src/common/multi_file_list.cpp
@@ -130,6 +130,10 @@ unique_ptr<MultiFileList> MultiFileList::ComplexFilterPushdown(ClientContext &co
 	return nullptr;
 }
 
+unique_ptr<NodeStatistics> MultiFileList::GetCardinality(ClientContext &context) {
+	return nullptr;
+}
+
 string MultiFileList::GetFirstFile() {
 	return GetFile(0);
 }

--- a/src/include/duckdb/common/multi_file_list.hpp
+++ b/src/include/duckdb/common/multi_file_list.hpp
@@ -79,9 +79,12 @@ public:
 	virtual unique_ptr<MultiFileList> ComplexFilterPushdown(ClientContext &context,
 	                                                        const MultiFileReaderOptions &options, LogicalGet &get,
 	                                                        vector<unique_ptr<Expression>> &filters);
+
 	virtual vector<string> GetAllFiles() = 0;
 	virtual FileExpandResult GetExpandResult() = 0;
 	virtual idx_t GetTotalFileCount() = 0;
+
+	virtual unique_ptr<NodeStatistics> GetCardinality(ClientContext &context);
 
 protected:
 	//! Get the i-th expanded file


### PR DESCRIPTION
This will allow overriding the default cardinality estimation for multi file parquet scans in the delta extension to allow efficient cardinality estimation based on delta-kernel provided metadata.