### PR TITLE
Allow extensions to optionally add own description (on load)

### DIFF
--- a/src/function/table/system/duckdb_extensions.cpp
+++ b/src/function/table/system/duckdb_extensions.cpp
@@ -156,6 +156,15 @@ unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context
 		}
 	}
 
+	for (auto &p : db.LoadedExtensionsExtraData()) {
+		auto &ext_name = p.first;
+		auto &ext_info = p.second;
+		auto entry = installed_extensions.find(ext_name);
+		if (entry != installed_extensions.end()) {
+			entry->second.description = ext_info.description;
+		}
+	}
+
 	result->entries.reserve(installed_extensions.size());
 	for (auto &kv : installed_extensions) {
 		result->entries.push_back(std::move(kv.second));

--- a/src/function/table/system/duckdb_extensions.cpp
+++ b/src/function/table/system/duckdb_extensions.cpp
@@ -138,30 +138,32 @@ unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context
 #endif
 
 	// Finally, we check the list of currently loaded extensions
-	auto &loaded_extensions = db.LoadedExtensionsData();
-	for (auto &e : loaded_extensions) {
-		auto &ext_name = e.first;
-		auto &ext_info = e.second;
-		auto entry = installed_extensions.find(ext_name);
-		if (entry == installed_extensions.end() || !entry->second.installed) {
-			ExtensionInformation &info = installed_extensions[ext_name];
-			info.name = ext_name;
-			info.loaded = true;
-			info.extension_version = ext_info.version;
-			info.installed = ext_info.mode == ExtensionInstallMode::STATICALLY_LINKED;
-			info.install_mode = ext_info.mode;
-		} else {
-			entry->second.loaded = true;
-			entry->second.extension_version = ext_info.version;
+	auto &extensions = db.GetExtensions();
+	for (auto &e : extensions) {
+		if (!e.second.is_loaded) {
+			continue;
 		}
-	}
-
-	for (auto &p : db.LoadedExtensionsExtraData()) {
-		auto &ext_name = p.first;
-		auto &ext_info = p.second;
-		auto entry = installed_extensions.find(ext_name);
-		if (entry != installed_extensions.end()) {
-			entry->second.description = ext_info.description;
+		auto &ext_name = e.first;
+		auto &ext_data = e.second;
+		if (auto &ext_install_info = ext_data.install_info) {
+			auto entry = installed_extensions.find(ext_name);
+			if (entry == installed_extensions.end() || !entry->second.installed) {
+				ExtensionInformation &info = installed_extensions[ext_name];
+				info.name = ext_name;
+				info.loaded = true;
+				info.extension_version = ext_install_info->version;
+				info.installed = ext_install_info->mode == ExtensionInstallMode::STATICALLY_LINKED;
+				info.install_mode = ext_install_info->mode;
+			} else {
+				entry->second.loaded = true;
+				entry->second.extension_version = ext_install_info->version;
+			}
+		}
+		if (auto &ext_load_info = ext_data.load_info) {
+			auto entry = installed_extensions.find(ext_name);
+			if (entry != installed_extensions.end()) {
+				entry->second.description = ext_load_info->description;
+			}
 		}
 	}
 

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -58,12 +58,17 @@ public:
 
 	DUCKDB_API const unordered_set<string> &LoadedExtensions();
 	DUCKDB_API const unordered_map<string, ExtensionInstallInfo> &LoadedExtensionsData();
+	DUCKDB_API const unordered_map<string, ExtensionLoadedInfo> &LoadedExtensionsExtraData() {
+		return loaded_extensions_extra_data;
+	}
 	DUCKDB_API bool ExtensionIsLoaded(const string &name);
 
 	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) const;
 
 	unique_ptr<AttachedDatabase> CreateAttachedDatabase(ClientContext &context, const AttachInfo &info,
 	                                                    const AttachOptions &options);
+
+	void AddExtensionInfo(const string &name, const ExtensionLoadedInfo &info);
 
 private:
 	void Initialize(const char *path, DBConfig *config);
@@ -79,6 +84,7 @@ private:
 	unique_ptr<ConnectionManager> connection_manager;
 	unordered_set<string> loaded_extensions;
 	unordered_map<string, ExtensionInstallInfo> loaded_extensions_data;
+	unordered_map<string, ExtensionLoadedInfo> loaded_extensions_extra_data;
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
 };

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -29,6 +29,12 @@ struct AttachInfo;
 struct AttachOptions;
 class DatabaseFileSystem;
 
+struct ExtensionInfo {
+	bool is_loaded;
+	unique_ptr<ExtensionInstallInfo> install_info;
+	unique_ptr<ExtensionLoadedInfo> load_info;
+};
+
 class DatabaseInstance : public enable_shared_from_this<DatabaseInstance> {
 	friend class DuckDB;
 
@@ -56,11 +62,7 @@ public:
 	DUCKDB_API static DatabaseInstance &GetDatabase(ClientContext &context);
 	DUCKDB_API static const DatabaseInstance &GetDatabase(const ClientContext &context);
 
-	DUCKDB_API const unordered_set<string> &LoadedExtensions();
-	DUCKDB_API const unordered_map<string, ExtensionInstallInfo> &LoadedExtensionsData();
-	DUCKDB_API const unordered_map<string, ExtensionLoadedInfo> &LoadedExtensionsExtraData() {
-		return loaded_extensions_extra_data;
-	}
+	DUCKDB_API const unordered_map<string, ExtensionInfo> &GetExtensions();
 	DUCKDB_API bool ExtensionIsLoaded(const string &name);
 
 	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) const;
@@ -82,9 +84,7 @@ private:
 	unique_ptr<TaskScheduler> scheduler;
 	unique_ptr<ObjectCache> object_cache;
 	unique_ptr<ConnectionManager> connection_manager;
-	unordered_set<string> loaded_extensions;
-	unordered_map<string, ExtensionInstallInfo> loaded_extensions_data;
-	unordered_map<string, ExtensionLoadedInfo> loaded_extensions_extra_data;
+	unordered_map<string, ExtensionInfo> loaded_extensions_info;
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
 };

--- a/src/include/duckdb/main/extension_install_info.hpp
+++ b/src/include/duckdb/main/extension_install_info.hpp
@@ -27,6 +27,10 @@ enum class ExtensionInstallMode : uint8_t {
 	NOT_INSTALLED = 4
 };
 
+struct ExtensionLoadedInfo {
+	string description;
+};
+
 class ExtensionInstallInfo {
 public:
 	//! How the extension was installed

--- a/src/include/duckdb/main/extension_util.hpp
+++ b/src/include/duckdb/main/extension_util.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/parser/parsed_data/create_type_info.hpp"
+#include "duckdb/main/extension_install_info.hpp"
 
 namespace duckdb {
 struct CreateMacroInfo;
@@ -22,6 +23,8 @@ class DatabaseInstance;
 //! The ExtensionUtil class contains methods that are useful for extensions
 class ExtensionUtil {
 public:
+	//! Register a new DuckDB extension
+	DUCKDB_API static void RegisterExtension(DatabaseInstance &db, const string &name, const ExtensionLoadedInfo &info);
 	//! Register a new scalar function - throw an exception if the function already exists
 	DUCKDB_API static void RegisterFunction(DatabaseInstance &db, ScalarFunction function);
 	//! Register a new scalar function set - throw an exception if the function already exists

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -403,6 +403,10 @@ const unordered_set<std::string> &DatabaseInstance::LoadedExtensions() {
 	return loaded_extensions;
 }
 
+void DatabaseInstance::AddExtensionInfo(const string &name, const ExtensionLoadedInfo &info) {
+	loaded_extensions_extra_data[name] = info;
+}
+
 const unordered_map<std::string, ExtensionInstallInfo> &DatabaseInstance::LoadedExtensionsData() {
 	return loaded_extensions_data;
 }

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -399,16 +399,12 @@ idx_t DatabaseInstance::NumberOfThreads() {
 	return NumericCast<idx_t>(scheduler->NumberOfThreads());
 }
 
-const unordered_set<std::string> &DatabaseInstance::LoadedExtensions() {
-	return loaded_extensions;
+const unordered_map<string, ExtensionInfo> &DatabaseInstance::GetExtensions() {
+	return loaded_extensions_info;
 }
 
 void DatabaseInstance::AddExtensionInfo(const string &name, const ExtensionLoadedInfo &info) {
-	loaded_extensions_extra_data[name] = info;
-}
-
-const unordered_map<std::string, ExtensionInstallInfo> &DatabaseInstance::LoadedExtensionsData() {
-	return loaded_extensions_data;
+	loaded_extensions_info[name].load_info = make_uniq<ExtensionLoadedInfo>(info);
 }
 
 idx_t DuckDB::NumberOfThreads() {
@@ -417,7 +413,8 @@ idx_t DuckDB::NumberOfThreads() {
 
 bool DatabaseInstance::ExtensionIsLoaded(const std::string &name) {
 	auto extension_name = ExtensionHelper::GetExtensionName(name);
-	return loaded_extensions.find(extension_name) != loaded_extensions.end();
+	auto it = loaded_extensions_info.find(extension_name);
+	return it != loaded_extensions_info.end() && it->second.is_loaded;
 }
 
 bool DuckDB::ExtensionIsLoaded(const std::string &name) {
@@ -426,8 +423,8 @@ bool DuckDB::ExtensionIsLoaded(const std::string &name) {
 
 void DatabaseInstance::SetExtensionLoaded(const string &name, ExtensionInstallInfo &install_info) {
 	auto extension_name = ExtensionHelper::GetExtensionName(name);
-	loaded_extensions.insert(extension_name);
-	loaded_extensions_data.insert({extension_name, install_info});
+	loaded_extensions_info[extension_name].is_loaded = true;
+	loaded_extensions_info[extension_name].install_info = make_uniq<ExtensionInstallInfo>(install_info);
 
 	auto &callbacks = DBConfig::GetConfig(*this).extension_callbacks;
 	for (auto &callback : callbacks) {

--- a/src/main/extension/extension_util.cpp
+++ b/src/main/extension/extension_util.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/main/database.hpp"
 
 namespace duckdb {
 

--- a/src/main/extension/extension_util.cpp
+++ b/src/main/extension/extension_util.cpp
@@ -10,11 +10,18 @@
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/parser/parsed_data/create_collation_info.hpp"
+#include "duckdb/main/extension_install_info.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 
 namespace duckdb {
+
+void ExtensionUtil::RegisterExtension(DatabaseInstance &db, const string &name,
+                                      const ExtensionLoadedInfo &description) {
+
+	db.AddExtensionInfo(name, description);
+}
 
 void ExtensionUtil::RegisterFunction(DatabaseInstance &db, ScalarFunctionSet set) {
 	D_ASSERT(!set.name.empty());

--- a/tools/sqlite3_api_wrapper/shell_extension.cpp
+++ b/tools/sqlite3_api_wrapper/shell_extension.cpp
@@ -28,6 +28,8 @@ unique_ptr<FunctionData> GetEnvBind(ClientContext &context, ScalarFunction &boun
 }
 
 void ShellExtension::Load(DuckDB &db) {
+	ExtensionUtil::RegisterExtension(*db.instance, "shell", {"Adds CLI-specific support and functionalities"});
+
 	ExtensionUtil::RegisterFunction(*db.instance, ScalarFunction("getenv", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
 	                                                             GetEnvFunction, GetEnvBind));
 }


### PR DESCRIPTION
This allows extensions to opt-in and provide their own description, to be later fetched from example like (after this PR):
```
D FROM duckdb_extensions() WHERE extension_name == 'shell';
┌────────────────┬─────────┬───────────┬──────────────┬───────────────────────────────────────────────┬───────────┬───────────────────┬───────────────────┬────────────────┐
│ extension_name │ loaded  │ installed │ install_path │                  description                  │  aliases  │ extension_version │   install_mode    │ installed_from │
│    varchar     │ boolean │  boolean  │   varchar    │                    varchar                    │ varchar[] │      varchar      │      varchar      │    varchar     │
├────────────────┼─────────┼───────────┼──────────────┼───────────────────────────────────────────────┼───────────┼───────────────────┼───────────────────┼────────────────┤
│ shell          │ true    │ true      │              │ Adds CLI-specific support and functionalities │ []        │                   │ STATICALLY_LINKED │                │
└────────────────┴─────────┴───────────┴──────────────┴───────────────────────────────────────────────┴───────────┴───────────────────┴───────────────────┴────────────────┘
```
versus current behaviour of:
```
D FROM duckdb_extensions() WHERE extension_name == 'shell';
┌────────────────┬─────────┬───────────┬──────────────┬─────────────┬───────────┬───────────────────┬───────────────────┬────────────────┐
│ extension_name │ loaded  │ installed │ install_path │ description │  aliases  │ extension_version │   install_mode    │ installed_from │
│    varchar     │ boolean │  boolean  │   varchar    │   varchar   │ varchar[] │      varchar      │      varchar      │    varchar     │
├────────────────┼─────────┼───────────┼──────────────┼─────────────┼───────────┼───────────────────┼───────────────────┼────────────────┤
│ shell          │ true    │ true      │              │             │ []        │                   │ STATICALLY_LINKED │                │
└────────────────┴─────────┴───────────┴──────────────┴─────────────┴───────────┴───────────────────┴───────────────────┴────────────────┘
```

Information is NOT propagated to ExtensionInstalInfo struct / file, so this is visible only for loaded extensions.

Allowing extensions to register their descriptions provide already some functionality and exposed an additional API to extension.
I would propose to review (as a follow up), whether it should be considered to persist to the extension_name.duckdb_extension.info file, but that can build on top of the capability provided here.