### PR TITLE
Maintain prepared statement parameter types explicitly instead of converting into literals

### DIFF
--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/main/appender.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/planner/expression/bound_parameter_data.hpp"
 
 #include <cstring>
 #include <cassert>
@@ -33,7 +34,7 @@ struct DatabaseData {
 
 struct PreparedStatementWrapper {
 	//! Map of name -> values
-	case_insensitive_map_t<Value> values;
+	case_insensitive_map_t<BoundParameterData> values;
 	unique_ptr<PreparedStatement> statement;
 };
 

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -10,24 +10,25 @@
 
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_set.hpp"
-#include "duckdb/common/enums/pending_execution_result.hpp"
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/deque.hpp"
+#include "duckdb/common/enums/pending_execution_result.hpp"
+#include "duckdb/common/enums/prepared_statement_mode.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/winapi.hpp"
+#include "duckdb/main/client_config.hpp"
+#include "duckdb/main/client_context_state.hpp"
+#include "duckdb/main/client_properties.hpp"
+#include "duckdb/main/external_dependencies.hpp"
+#include "duckdb/main/pending_query_result.hpp"
 #include "duckdb/main/prepared_statement.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/main/table_description.hpp"
 #include "duckdb/transaction/transaction_context.hpp"
-#include "duckdb/main/pending_query_result.hpp"
-#include "duckdb/common/atomic.hpp"
-#include "duckdb/main/client_config.hpp"
-#include "duckdb/main/external_dependencies.hpp"
-#include "duckdb/common/error_data.hpp"
-#include "duckdb/common/enums/prepared_statement_mode.hpp"
-#include "duckdb/main/client_properties.hpp"
-#include "duckdb/main/client_context_state.hpp"
-#include "duckdb/main/settings.hpp"
+#include "duckdb/planner/expression/bound_parameter_data.hpp"
 
 namespace duckdb {
 class Appender;
@@ -52,7 +53,7 @@ class ClientContextState;
 
 struct PendingQueryParameters {
 	//! Prepared statement parameters (if any)
-	optional_ptr<case_insensitive_map_t<Value>> parameters;
+	optional_ptr<case_insensitive_map_t<BoundParameterData>> parameters;
 	//! Whether or not a stream result should be allowed
 	bool allow_stream_result = false;
 };
@@ -142,7 +143,8 @@ public:
 	//! It is possible that the prepared statement will be re-bound. This will generally happen if the catalog is
 	//! modified in between the prepared statement being bound and the prepared statement being run.
 	DUCKDB_API unique_ptr<QueryResult> Execute(const string &query, shared_ptr<PreparedStatementData> &prepared,
-	                                           case_insensitive_map_t<Value> &values, bool allow_stream_result = true);
+	                                           case_insensitive_map_t<BoundParameterData> &values,
+	                                           bool allow_stream_result = true);
 	DUCKDB_API unique_ptr<QueryResult> Execute(const string &query, shared_ptr<PreparedStatementData> &prepared,
 	                                           const PendingQueryParameters &parameters);
 
@@ -227,7 +229,7 @@ private:
 	//! Internally prepare a SQL statement. Caller must hold the context_lock.
 	shared_ptr<PreparedStatementData>
 	CreatePreparedStatement(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
-	                        optional_ptr<case_insensitive_map_t<Value>> values = nullptr,
+	                        optional_ptr<case_insensitive_map_t<BoundParameterData>> values = nullptr,
 	                        PreparedStatementMode mode = PreparedStatementMode::PREPARE_ONLY);
 	unique_ptr<PendingQueryResult> PendingStatementInternal(ClientContextLock &lock, const string &query,
 	                                                        unique_ptr<SQLStatement> statement,
@@ -268,7 +270,7 @@ private:
 
 	shared_ptr<PreparedStatementData>
 	CreatePreparedStatementInternal(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
-	                                optional_ptr<case_insensitive_map_t<Value>> values);
+	                                optional_ptr<case_insensitive_map_t<BoundParameterData>> values);
 
 private:
 	//! Lock on using the ClientContext in parallel

--- a/src/include/duckdb/main/prepared_statement.hpp
+++ b/src/include/duckdb/main/prepared_statement.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/main/pending_query_result.hpp"
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/planner/expression/bound_parameter_data.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -76,14 +77,14 @@ public:
 	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(vector<Value> &values, bool allow_stream_result = true);
 
 	//! Create a pending query result of the prepared statement with the given set named arguments
-	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(case_insensitive_map_t<Value> &named_values,
+	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(case_insensitive_map_t<BoundParameterData> &named_values,
 	                                                       bool allow_stream_result = true);
 
 	//! Execute the prepared statement with the given set of values
 	DUCKDB_API unique_ptr<QueryResult> Execute(vector<Value> &values, bool allow_stream_result = true);
 
 	//! Execute the prepared statement with the given set of named+unnamed values
-	DUCKDB_API unique_ptr<QueryResult> Execute(case_insensitive_map_t<Value> &named_values,
+	DUCKDB_API unique_ptr<QueryResult> Execute(case_insensitive_map_t<BoundParameterData> &named_values,
 	                                           bool allow_stream_result = true);
 
 	//! Execute the prepared statement with the given set of arguments

--- a/src/include/duckdb/main/prepared_statement_data.hpp
+++ b/src/include/duckdb/main/prepared_statement_data.hpp
@@ -52,9 +52,9 @@ public:
 public:
 	void CheckParameterCount(idx_t parameter_count);
 	//! Whether or not the prepared statement data requires the query to rebound for the given parameters
-	bool RequireRebind(ClientContext &context, optional_ptr<case_insensitive_map_t<Value>> values);
+	bool RequireRebind(ClientContext &context, optional_ptr<case_insensitive_map_t<BoundParameterData>> values);
 	//! Bind a set of values to the prepared statement data
-	DUCKDB_API void Bind(case_insensitive_map_t<Value> values);
+	DUCKDB_API void Bind(case_insensitive_map_t<BoundParameterData> values);
 	//! Get the expected SQL Type of the bound parameter
 	DUCKDB_API LogicalType GetType(const string &identifier);
 	//! Try to get the expected SQL Type of the bound parameter

--- a/src/include/duckdb/planner/expression/bound_parameter_data.hpp
+++ b/src/include/duckdb/planner/expression/bound_parameter_data.hpp
@@ -19,6 +19,8 @@ public:
 	}
 	explicit BoundParameterData(Value val) : value(std::move(val)), return_type(value.type()) {
 	}
+	BoundParameterData(Value val, LogicalType type_p) : value(std::move(val)), return_type(std::move(type_p)) {
+	}
 
 private:
 	Value value;

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -135,7 +135,7 @@ duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_
 	// See if this is the case and we still have a value registered for it
 	auto it = wrapper->values.find(identifier);
 	if (it != wrapper->values.end()) {
-		return ConvertCPPTypeToC(it->second.type());
+		return ConvertCPPTypeToC(it->second.return_type.id());
 	}
 	return DUCKDB_TYPE_INVALID;
 }
@@ -162,7 +162,7 @@ duckdb_state duckdb_bind_value(duckdb_prepared_statement prepared_statement, idx
 		return DuckDBError;
 	}
 	auto identifier = duckdb_parameter_name_internal(prepared_statement, param_idx);
-	wrapper->values[identifier] = *value;
+	wrapper->values[identifier] = duckdb::BoundParameterData(*value);
 	return DuckDBSuccess;
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -310,7 +310,7 @@ static bool IsExplainAnalyze(SQLStatement *statement) {
 shared_ptr<PreparedStatementData>
 ClientContext::CreatePreparedStatementInternal(ClientContextLock &lock, const string &query,
                                                unique_ptr<SQLStatement> statement,
-                                               optional_ptr<case_insensitive_map_t<Value>> values) {
+                                               optional_ptr<case_insensitive_map_t<BoundParameterData>> values) {
 	StatementType statement_type = statement->type;
 	auto result = make_shared_ptr<PreparedStatementData>(statement_type);
 
@@ -369,7 +369,8 @@ ClientContext::CreatePreparedStatementInternal(ClientContextLock &lock, const st
 
 shared_ptr<PreparedStatementData>
 ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
-                                       optional_ptr<case_insensitive_map_t<Value>> values, PreparedStatementMode mode) {
+                                       optional_ptr<case_insensitive_map_t<BoundParameterData>> values,
+                                       PreparedStatementMode mode) {
 	// check if any client context state could request a rebind
 	bool can_request_rebind = false;
 	for (auto const &s : registered_state) {
@@ -420,7 +421,7 @@ QueryProgress ClientContext::GetQueryProgress() {
 }
 
 void BindPreparedStatementParameters(PreparedStatementData &statement, const PendingQueryParameters &parameters) {
-	case_insensitive_map_t<Value> owned_values;
+	case_insensitive_map_t<BoundParameterData> owned_values;
 	if (parameters.parameters) {
 		auto &params = *parameters.parameters;
 		for (auto &val : params) {
@@ -712,7 +713,8 @@ unique_ptr<QueryResult> ClientContext::Execute(const string &query, shared_ptr<P
 }
 
 unique_ptr<QueryResult> ClientContext::Execute(const string &query, shared_ptr<PreparedStatementData> &prepared,
-                                               case_insensitive_map_t<Value> &values, bool allow_stream_result) {
+                                               case_insensitive_map_t<BoundParameterData> &values,
+                                               bool allow_stream_result) {
 	PendingQueryParameters parameters;
 	parameters.parameters = &values;
 	parameters.allow_stream_result = allow_stream_result;

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -68,7 +68,7 @@ case_insensitive_map_t<LogicalType> PreparedStatement::GetExpectedParameterTypes
 	return expected_types;
 }
 
-unique_ptr<QueryResult> PreparedStatement::Execute(case_insensitive_map_t<Value> &named_values,
+unique_ptr<QueryResult> PreparedStatement::Execute(case_insensitive_map_t<BoundParameterData> &named_values,
                                                    bool allow_stream_result) {
 	auto pending = PendingQuery(named_values, allow_stream_result);
 	if (pending->HasError()) {
@@ -86,15 +86,15 @@ unique_ptr<QueryResult> PreparedStatement::Execute(vector<Value> &values, bool a
 }
 
 unique_ptr<PendingQueryResult> PreparedStatement::PendingQuery(vector<Value> &values, bool allow_stream_result) {
-	case_insensitive_map_t<Value> named_values;
+	case_insensitive_map_t<BoundParameterData> named_values;
 	for (idx_t i = 0; i < values.size(); i++) {
 		auto &val = values[i];
-		named_values[std::to_string(i + 1)] = val;
+		named_values[std::to_string(i + 1)] = BoundParameterData(val);
 	}
 	return PendingQuery(named_values, allow_stream_result);
 }
 
-unique_ptr<PendingQueryResult> PreparedStatement::PendingQuery(case_insensitive_map_t<Value> &named_values,
+unique_ptr<PendingQueryResult> PreparedStatement::PendingQuery(case_insensitive_map_t<BoundParameterData> &named_values,
                                                                bool allow_stream_result) {
 	if (!success) {
 		auto exception = InvalidInputException("Attempting to execute an unsuccessfully prepared statement!");

--- a/src/planner/binder/expression/bind_parameter_expression.cpp
+++ b/src/planner/binder/expression/bind_parameter_expression.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/parser/expression/parameter_expression.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
@@ -19,10 +20,13 @@ BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, idx_t dep
 	if (param_data_it != parameter_data.end()) {
 		// it has! emit a constant directly
 		auto &data = param_data_it->second;
+		auto return_type = binder.parameters->GetReturnType(parameter_id);
 		auto constant = make_uniq<BoundConstantExpression>(data.GetValue());
 		constant->alias = expr.alias;
-		constant->return_type = binder.parameters->GetReturnType(parameter_id);
-		return BindResult(std::move(constant));
+		constant->return_type = return_type;
+
+		auto cast = BoundCastExpression::AddCastToType(context, std::move(constant), return_type);
+		return BindResult(std::move(cast));
 	}
 
 	auto bound_parameter = binder.parameters->BindParameterExpression(expr);

--- a/src/planner/binder/expression/bind_parameter_expression.cpp
+++ b/src/planner/binder/expression/bind_parameter_expression.cpp
@@ -21,10 +21,13 @@ BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, idx_t dep
 		// it has! emit a constant directly
 		auto &data = param_data_it->second;
 		auto return_type = binder.parameters->GetReturnType(parameter_id);
+		bool is_literal =
+		    return_type.id() == LogicalTypeId::INTEGER_LITERAL || return_type.id() == LogicalTypeId::STRING_LITERAL;
 		auto constant = make_uniq<BoundConstantExpression>(data.GetValue());
 		constant->alias = expr.alias;
-		constant->return_type = return_type;
-
+		if (is_literal) {
+			return BindResult(std::move(constant));
+		}
 		auto cast = BoundCastExpression::AddCastToType(context, std::move(constant), return_type);
 		return BindResult(std::move(cast));
 	}

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 
 namespace duckdb {
 
@@ -30,24 +31,39 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 
 	auto &mapped_named_values = stmt.named_values;
 	// bind any supplied parameters
-	case_insensitive_map_t<Value> bind_values;
+	case_insensitive_map_t<BoundParameterData> bind_values;
 	auto constant_binder = Binder::CreateBinder(context);
 	constant_binder->SetCanContainNulls(true);
 	for (auto &pair : mapped_named_values) {
+		bool is_literal = pair.second->type == ExpressionType::VALUE_CONSTANT;
+
 		ConstantBinder cbinder(*constant_binder, context, "EXECUTE statement");
 		auto bound_expr = cbinder.Bind(pair.second);
-
-		Value value = ExpressionExecutor::EvaluateScalar(context, *bound_expr, true);
-		bind_values[pair.first] = std::move(value);
+		BoundParameterData parameter_data;
+		if (is_literal) {
+			auto &constant = bound_expr->Cast<BoundConstantExpression>();
+			LogicalType return_type;
+			if (constant.return_type == LogicalTypeId::VARCHAR &&
+			    StringType::GetCollation(constant.return_type).empty()) {
+				return_type = LogicalTypeId::STRING_LITERAL;
+			} else if (constant.return_type.IsIntegral()) {
+				return_type = LogicalType::INTEGER_LITERAL(constant.value);
+			} else {
+				return_type = constant.value.type();
+			}
+			parameter_data = BoundParameterData(std::move(constant.value), std::move(return_type));
+		} else {
+			auto value = ExpressionExecutor::EvaluateScalar(context, *bound_expr, true);
+			parameter_data = BoundParameterData(std::move(value));
+		}
+		bind_values[pair.first] = std::move(parameter_data);
 	}
 	unique_ptr<LogicalOperator> rebound_plan;
 
 	if (prepared->RequireRebind(context, &bind_values)) {
 		// catalog was modified or statement does not have clear types: rebind the statement before running the execute
 		Planner prepared_planner(context);
-		for (auto &pair : bind_values) {
-			prepared_planner.parameter_data.emplace(std::make_pair(pair.first, BoundParameterData(pair.second)));
-		}
+		prepared_planner.parameter_data = bind_values;
 		prepared = prepared_planner.PrepareSQLStatement(entry->second->unbound_statement->Copy());
 		rebound_plan = std::move(prepared_planner.plan);
 		D_ASSERT(prepared->properties.bound_all_parameters);

--- a/test/api/capi/test_capi_prepared.cpp
+++ b/test/api/capi/test_capi_prepared.cpp
@@ -385,6 +385,30 @@ TEST_CASE("Test prepared statements with named parameters in C API", "[capi]") {
 	duckdb_destroy_prepare(&stmt);
 }
 
+TEST_CASE("Maintain prepared statement types", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+	duckdb_result res;
+	duckdb_prepared_statement stmt = nullptr;
+	duckdb_state status;
+
+	// open the database in in-memory mode
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	status = duckdb_prepare(tester.connection, "select cast(111 as short) * $1", &stmt);
+	REQUIRE(status == DuckDBSuccess);
+	REQUIRE(stmt != nullptr);
+
+	status = duckdb_bind_int64(stmt, 1, 1665);
+	REQUIRE(status == DuckDBSuccess);
+
+	status = duckdb_execute_prepared(stmt, &res);
+	REQUIRE(status == DuckDBSuccess);
+	REQUIRE(duckdb_value_int64(&res, 0, 0) == 184815);
+	duckdb_destroy_result(&res);
+	duckdb_destroy_prepare(&stmt);
+}
+
 TEST_CASE("Prepared streaming result", "[capi]") {
 	CAPITester tester;
 

--- a/test/sql/prepared/prepare_maintain_types.test
+++ b/test/sql/prepared/prepare_maintain_types.test
@@ -8,6 +8,23 @@ PRAGMA enable_verification
 statement ok
 prepare v1 as select cast(111 as short) * $1;
 
+# literals adapt to the type
+statement error
+execute v1(1665);
+----
+Overflow
+
+statement error
+execute v1('1665');
+----
+Overflow
+
+# explicit casts force the type to be used
+statement error
+execute v1('1665'::VARCHAR);
+----
+No function matches the given name and argument types
+
 query I
 execute v1(1665::BIGINT);
 ----

--- a/test/sql/prepared/prepare_maintain_types.test
+++ b/test/sql/prepared/prepare_maintain_types.test
@@ -1,0 +1,19 @@
+# name: test/sql/prepared/prepare_maintain_types.test
+# description: Maintain PREPARE parameter types
+# group: [prepared]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+prepare v1 as select cast(111 as short) * $1;
+
+query I
+execute v1(1665::BIGINT);
+----
+184815
+
+statement error
+execute v1(1665::SHORT);
+----
+Overflow

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -26,6 +26,7 @@
 #include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
+struct BoundParameterData;
 
 enum class PythonEnvironmentType { NORMAL, INTERACTIVE, JUPYTER };
 
@@ -207,7 +208,7 @@ public:
 	static shared_ptr<DuckDBPyConnection> Connect(const string &database, bool read_only, const py::dict &config);
 
 	static vector<Value> TransformPythonParamList(const py::handle &params);
-	static case_insensitive_map_t<Value> TransformPythonParamDict(const py::dict &params);
+	static case_insensitive_map_t<BoundParameterData> TransformPythonParamDict(const py::dict &params);
 
 	void RegisterFilesystem(AbstractFileSystem filesystem);
 	void UnregisterFilesystem(const py::str &name);

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -524,7 +524,8 @@ py::list TransformNamedParameters(const case_insensitive_map_t<idx_t> &named_par
 	return new_params;
 }
 
-case_insensitive_map_t<BoundParameterData> TransformPreparedParameters(PreparedStatement &prep, const py::object &params) {
+case_insensitive_map_t<BoundParameterData> TransformPreparedParameters(PreparedStatement &prep,
+                                                                       const py::object &params) {
 	case_insensitive_map_t<BoundParameterData> named_values;
 	if (py::is_list_like(params)) {
 		if (prep.n_param != py::len(params)) {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -524,8 +524,8 @@ py::list TransformNamedParameters(const case_insensitive_map_t<idx_t> &named_par
 	return new_params;
 }
 
-case_insensitive_map_t<Value> TransformPreparedParameters(PreparedStatement &prep, const py::object &params) {
-	case_insensitive_map_t<Value> named_values;
+case_insensitive_map_t<BoundParameterData> TransformPreparedParameters(PreparedStatement &prep, const py::object &params) {
+	case_insensitive_map_t<BoundParameterData> named_values;
 	if (py::is_list_like(params)) {
 		if (prep.n_param != py::len(params)) {
 			throw InvalidInputException("Prepared statement needs %d parameters, %d given", prep.n_param,
@@ -535,7 +535,7 @@ case_insensitive_map_t<Value> TransformPreparedParameters(PreparedStatement &pre
 		for (idx_t i = 0; i < unnamed_values.size(); i++) {
 			auto &value = unnamed_values[i];
 			auto identifier = std::to_string(i + 1);
-			named_values[identifier] = std::move(value);
+			named_values[identifier] = BoundParameterData(std::move(value));
 		}
 	} else if (py::is_dict_like(params)) {
 		auto dict = py::cast<py::dict>(params);
@@ -1616,13 +1616,13 @@ vector<Value> DuckDBPyConnection::TransformPythonParamList(const py::handle &par
 	return args;
 }
 
-case_insensitive_map_t<Value> DuckDBPyConnection::TransformPythonParamDict(const py::dict &params) {
-	case_insensitive_map_t<Value> args;
+case_insensitive_map_t<BoundParameterData> DuckDBPyConnection::TransformPythonParamDict(const py::dict &params) {
+	case_insensitive_map_t<BoundParameterData> args;
 
 	for (auto pair : params) {
 		auto &key = pair.first;
 		auto &value = pair.second;
-		args[std::string(py::str(key))] = TransformPythonValue(value, LogicalType::UNKNOWN, false);
+		args[std::string(py::str(key))] = BoundParameterData(TransformPythonValue(value, LogicalType::UNKNOWN, false));
 	}
 	return args;
 }


### PR DESCRIPTION
This PR modifies the way prepared statement parameters work so that the original types are maintained, instead of directly converting them to literals. The reason this is necessary is the new binding rules for literals (https://github.com/duckdb/duckdb/pull/10115, https://github.com/duckdb/duckdb/pull/10194) can cause confusing results otherwise as the user-provided type will be ignored. For example, in the current version:

```sql
D prepare v1 as select 111::short * $1;
D execute v1(1000::bigint);
-- Out of Range Error: Overflow in multiplication of INT16 (111 * 1000)!
```

The problem is that we convert `1000` to an integer literal, which then adapts to the short type on the other side, causing the overflow error.

This PR changes the behavior so that the type is preserved in the `BoundParameterData`, leading to the following behavior:

```sql
D prepare v1 as select 111::short * $1;
D execute v1(1000);
Out of Range Error: Overflow in multiplication of INT16 (111 * 1000)!
D execute v1(1000::bigint);
┌────────┐
│  res   │
│ int64  │
├────────┤
│ 111000 │
└────────┘
```

This is now consistent again with substituting the actual expression where the prepared statement parameter is:

```sql
D select 111::short * 1000;
Out of Range Error: Overflow in multiplication of INT16 (111 * 1000)!
D select 111::short * 1000::bigint AS res;
┌────────┐
│  res   │
│ int64  │
├────────┤
│ 111000 │
└────────┘

```
