### PR TITLE
CLI .changes: use sqlite3_changes64 and sqlite3_totalchanges64 to prevent overflows

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -19537,8 +19537,8 @@ static int runOneSqlLine(ShellState *p, char *zSql, FILE *in, int startline){
     }
     return 1;
   }else if( ShellHasFlag(p, SHFLG_CountChanges) ){
-    raw_printf(p->out, "changes: %3d   total_changes: %d\n",
-            sqlite3_changes(p->db), sqlite3_total_changes(p->db));
+    raw_printf(p->out, "changes: %3lld   total_changes: %lld\n",
+            sqlite3_changes64(p->db), sqlite3_total_changes64(p->db));
   }
   return 0;
 }

--- a/tools/sqlite3_api_wrapper/include/duckdb_shell_wrapper.h
+++ b/tools/sqlite3_api_wrapper/include/duckdb_shell_wrapper.h
@@ -27,6 +27,7 @@
 #define sqlite3_busy_handler           duckdb_shell_sqlite3_busy_handler
 #define sqlite3_busy_timeout           duckdb_shell_sqlite3_busy_timeout
 #define sqlite3_changes                duckdb_shell_sqlite3_changes
+#define sqlite3_changes64              duckdb_shell_sqlite3_changes64
 #define sqlite3_clear_bindings         duckdb_shell_sqlite3_clear_bindings
 #define sqlite3_close                  duckdb_shell_sqlite3_close
 #define sqlite3_collation_needed       duckdb_shell_sqlite3_collation_needed
@@ -142,6 +143,7 @@
 #define sqlite3_test_control           duckdb_shell_sqlite3_test_control
 #define sqlite3_threadsafe             duckdb_shell_sqlite3_threadsafe
 #define sqlite3_total_changes          duckdb_shell_sqlite3_total_changes
+#define sqlite3_total_changes64        duckdb_shell_sqlite3_total_changes64
 #define sqlite3_trace                  duckdb_shell_sqlite3_trace
 #define sqlite3_trace_v2               duckdb_shell_sqlite3_trace_v2
 #define sqlite3_unlock_notify          duckdb_shell_sqlite3_unlock_notify

--- a/tools/sqlite3_api_wrapper/include/sqlite3.h
+++ b/tools/sqlite3_api_wrapper/include/sqlite3.h
@@ -2488,6 +2488,7 @@ SQLITE_API void sqlite3_set_last_insert_rowid(sqlite3*,sqlite3_int64);
 ** </ul>
 */
 SQLITE_API int sqlite3_changes(sqlite3*);
+SQLITE_API sqlite3_int64 sqlite3_changes64(sqlite3*);
 
 /*
 ** CAPI3REF: Total Number Of Rows Modified
@@ -2525,6 +2526,7 @@ SQLITE_API int sqlite3_changes(sqlite3*);
 ** </ul>
 */
 SQLITE_API int sqlite3_total_changes(sqlite3*);
+SQLITE_API sqlite3_int64 sqlite3_total_changes64(sqlite3*);
 
 /*
 ** CAPI3REF: Interrupt A Long-Running Query

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -897,7 +897,15 @@ int sqlite3_changes(sqlite3 *db) {
 	return db->last_changes;
 }
 
+sqlite3_int64 sqlite3_changes64(sqlite3 *db) {
+	return db->last_changes;
+}
+
 int sqlite3_total_changes(sqlite3 *db) {
+	return db->total_changes;
+}
+
+sqlite3_int64 sqlite3_total_changes64(sqlite3 *db) {
 	return db->total_changes;
 }
 


### PR DESCRIPTION
Fixes #12757 

Likely has been fixed in upstream SQLite as well but our shell is based on an older version that doesn't have this fix