### PR TITLE
Fix #12569: avoid truncating zeros that matter in format function

### DIFF
--- a/test/sql/function/string/test_format.test
+++ b/test/sql/function/string/test_format.test
@@ -95,6 +95,11 @@ select format('{:.2}', 0.00023404094995959);
 ----
 0.00023
 
+query I
+select format('{:.3}', 0.0);
+----
+0.00
+
 # incorrect number of parameters
 # too few parameters
 statement error

--- a/test/sql/function/string/test_format.test
+++ b/test/sql/function/string/test_format.test
@@ -90,6 +90,11 @@ select format('{:b}', 123456789)
 ----
 111010110111100110100010101
 
+query I
+select format('{:.2}', 0.00023404094995959);
+----
+0.00023
+
 # incorrect number of parameters
 # too few parameters
 statement error

--- a/third_party/fmt/include/fmt/format.h
+++ b/third_party/fmt/include/fmt/format.h
@@ -1116,7 +1116,7 @@ template <typename Char> class float_writer {
       // 1234e-6 -> 0.001234
       *it++ = static_cast<Char>('0');
       int num_zeros = -full_exp;
-      if (specs_.precision >= 0 && specs_.precision < num_zeros)
+      if (num_digits_ == 0 && specs_.precision >= 0 && specs_.precision < num_zeros)
         num_zeros = specs_.precision;
       int num_digits = num_digits_;
       if (!specs_.trailing_zeros)


### PR DESCRIPTION
Fixes #12569