### PR TITLE
Add dl functionality for Windows

### DIFF
--- a/src/include/duckdb/common/dl.hpp
+++ b/src/include/duckdb/common/dl.hpp
@@ -24,7 +24,9 @@ namespace duckdb {
 #ifdef _WIN32
 
 inline void *dlopen(const char *file, int mode) {
-	D_ASSERT(file);
+	if (!file) {
+		return (void *)GetModuleHandle(nullptr);
+	}
 	auto fpath = WindowsUtil::UTF8ToUnicode(file);
 	return (void *)LoadLibraryW(fpath.c_str());
 }
@@ -36,6 +38,11 @@ inline void *dlsym(void *handle, const char *name) {
 
 inline std::string GetDLError(void) {
 	return LocalFileSystem::GetLastErrorAsString();
+}
+
+inline void dlclose(void *handle) {
+	D_ASSERT(handle);
+	FreeLibrary((HINSTANCE)handle);
 }
 
 #else


### PR DESCRIPTION
On Windows, when using `dlopen(NULL)` this should return the handle of the main executable, not an error. Also added the missing `dlclose()` functionality.