### PR TITLE
Support indexes in `COPY DATABASE`

### DIFF
--- a/src/catalog/catalog_entry/duck_index_entry.cpp
+++ b/src/catalog/catalog_entry/duck_index_entry.cpp
@@ -2,7 +2,6 @@
 
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
-#include "duckdb/storage/data_table.hpp"
 
 namespace duckdb {
 

--- a/src/catalog/catalog_entry/duck_index_entry.cpp
+++ b/src/catalog/catalog_entry/duck_index_entry.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/catalog/catalog_entry/duck_index_entry.hpp"
 
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/storage/data_table.hpp"
 
 namespace duckdb {
 
@@ -15,24 +17,26 @@ IndexDataTableInfo::~IndexDataTableInfo() {
 	info->GetIndexes().RemoveIndex(index_name);
 }
 
-DuckIndexEntry::DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &info)
-    : IndexCatalogEntry(catalog, schema, info) {
+DuckIndexEntry::DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &info,
+                               TableCatalogEntry &table_p)
+    : IndexCatalogEntry(catalog, schema, info), initial_index_size(0) {
+	auto &table = table_p.Cast<DuckTableEntry>();
+	auto &storage = table.GetStorage();
+
+	this->info = make_shared_ptr<IndexDataTableInfo>(storage.GetDataTableInfo(), name);
+}
+
+DuckIndexEntry::DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &info,
+                               shared_ptr<IndexDataTableInfo> info_p)
+    : IndexCatalogEntry(catalog, schema, info), info(std::move(info_p)), initial_index_size(0) {
 }
 
 unique_ptr<CatalogEntry> DuckIndexEntry::Copy(ClientContext &context) const {
 	auto info_copy = GetInfo();
 	auto &cast_info = info_copy->Cast<CreateIndexInfo>();
 
-	auto result = make_uniq<DuckIndexEntry>(catalog, schema, cast_info);
-	result->info = info;
+	auto result = make_uniq<DuckIndexEntry>(catalog, schema, cast_info, info);
 	result->initial_index_size = initial_index_size;
-
-	for (auto &expr : expressions) {
-		result->expressions.push_back(expr->Copy());
-	}
-	for (auto &expr : parsed_expressions) {
-		result->parsed_expressions.push_back(expr->Copy());
-	}
 
 	return std::move(result);
 }

--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -244,7 +244,7 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::CreateIndex(CatalogTransaction trans
 		throw CatalogException("An index with the name " + info.index_name + " already exists!");
 	}
 
-	auto index = make_uniq<DuckIndexEntry>(catalog, *this, info);
+	auto index = make_uniq<DuckIndexEntry>(catalog, *this, info, table);
 	auto dependencies = index->dependencies;
 	return AddEntryInternal(transaction, std::move(index), info.on_conflict, dependencies);
 }

--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -3,18 +3,19 @@
 namespace duckdb {
 
 IndexCatalogEntry::IndexCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &info)
-    : StandardEntry(CatalogType::INDEX_ENTRY, schema, catalog, std::move(info.index_name)), sql(std::move(info.sql)),
-      options(std::move(info.options)), index_type(info.index_type), index_constraint_type(info.constraint_type),
-      column_ids(std::move(info.column_ids)) {
+    : StandardEntry(CatalogType::INDEX_ENTRY, schema, catalog, info.index_name), sql(info.sql), options(info.options),
+      index_type(info.index_type), index_constraint_type(info.constraint_type), column_ids(info.column_ids) {
 
 	this->temporary = info.temporary;
-	this->dependencies = std::move(info.dependencies);
-	this->comment = std::move(info.comment);
+	this->dependencies = info.dependencies;
+	this->comment = info.comment;
 	for (auto &expr : expressions) {
-		expressions.push_back(std::move(expr));
+		D_ASSERT(expr);
+		expressions.push_back(expr->Copy());
 	}
 	for (auto &parsed_expr : info.parsed_expressions) {
-		parsed_expressions.push_back(std::move(parsed_expr));
+		D_ASSERT(parsed_expr);
+		parsed_expressions.push_back(parsed_expr->Copy());
 	}
 }
 

--- a/src/execution/operator/persistent/physical_copy_database.cpp
+++ b/src/execution/operator/persistent/physical_copy_database.cpp
@@ -49,7 +49,10 @@ SourceResultType PhysicalCopyDatabase::GetData(ExecutionContext &context, DataCh
 			catalog.CreateTable(context.client, *bound_info);
 			break;
 		}
-		case CatalogType::INDEX_ENTRY:
+		case CatalogType::INDEX_ENTRY: {
+			catalog.CreateIndex(context.client, create_info->Cast<CreateIndexInfo>());
+			break;
+		}
 		default:
 			throw NotImplementedException("Entry type %s not supported in PhysicalCopyDatabase",
 			                              CatalogTypeToString(create_info->type));

--- a/src/execution/operator/schema/physical_create_art_index.cpp
+++ b/src/execution/operator/schema/physical_create_art_index.cpp
@@ -178,11 +178,6 @@ SinkFinalizeType PhysicalCreateARTIndex::Finalize(Pipeline &pipeline, Event &eve
 	auto &index = index_entry->Cast<DuckIndexEntry>();
 	index.initial_index_size = state.global_index->GetInMemorySize();
 
-	index.info = make_shared_ptr<IndexDataTableInfo>(storage.GetDataTableInfo(), index.name);
-	for (auto &parsed_expr : info->parsed_expressions) {
-		index.parsed_expressions.push_back(parsed_expr->Copy());
-	}
-
 	// add index to storage
 	storage.AddIndex(std::move(state.global_index));
 	return SinkFinalizeType::READY;

--- a/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
@@ -27,13 +27,14 @@ struct IndexDataTableInfo {
 class DuckIndexEntry : public IndexCatalogEntry {
 public:
 	//! Create a DuckIndexEntry
-	DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &info);
+	DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &info, TableCatalogEntry &table);
+	DuckIndexEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateIndexInfo &info,
+	               shared_ptr<IndexDataTableInfo> storage_info);
 
 	unique_ptr<CatalogEntry> Copy(ClientContext &context) const override;
 
 	//! The indexed table information
 	shared_ptr<IndexDataTableInfo> info;
-
 	//! We need the initial size of the index after the CREATE INDEX statement,
 	//! as it is necessary to determine the auto checkpoint threshold
 	idx_t initial_index_size;

--- a/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_index_entry.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
 
 namespace duckdb {
+class TableCatalogEntry;
 
 //! Wrapper class to allow copying a DuckIndexEntry (for altering the DuckIndexEntry metadata such as comments)
 struct IndexDataTableInfo {

--- a/src/include/duckdb/catalog/catalog_entry/index_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/index_catalog_entry.hpp
@@ -50,9 +50,9 @@ public:
 	virtual string GetTableName() const = 0;
 
 	//! Returns true, if this index is UNIQUE
-	bool IsUnique();
+	bool IsUnique() const;
 	//! Returns true, if this index is a PRIMARY KEY
-	bool IsPrimary();
+	bool IsPrimary() const;
 };
 
 } // namespace duckdb

--- a/test/sql/copy_database/copy_database_index.test
+++ b/test/sql/copy_database/copy_database_index.test
@@ -22,6 +22,31 @@ CREATE INDEX i_index ON test(a)
 statement ok
 INSERT INTO test VALUES (42, 88, 'hello');
 
-statement error
-COPY FROM DATABASE db1 TO memory
+query II
+explain SELECT * FROM db1.test WHERE a=42
 ----
+physical_plan	<REGEX>:.*INDEX_SCAN.*
+
+statement ok
+COPY FROM DATABASE db1 TO memory
+
+statement ok
+USE memory
+
+query III
+SELECT * FROM test WHERE a=42
+----
+42	88	hello
+
+query II
+explain SELECT * FROM test WHERE a=42
+----
+physical_plan	<!REGEX>:.*INDEX_SCAN.*
+
+statement ok
+DROP INDEX i_index
+
+query II
+explain SELECT * FROM test WHERE a=42
+----
+physical_plan	<!REGEX>:.*INDEX_SCAN.*


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/12329

This PR implements support for indexes in `COPY DATABASE`. It also cleans up index creation by moving everything that is required to create an index into the `DuckIndexEntry` constructor - previously this would not correctly instantiate the index fully which is why this was unsupported to begin with.