### PR TITLE
Fewer system calls in LocalFileSystem::ListFiles

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -612,10 +612,6 @@ void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener
 
 bool LocalFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
                                 FileOpener *opener) {
-	if (!DirectoryExists(directory, opener)) {
-		return false;
-	}
-
 	auto dir = opendir(directory.c_str());
 	if (!dir) {
 		return false;
@@ -634,11 +630,11 @@ bool LocalFileSystem::ListFiles(const string &directory, const std::function<voi
 		}
 		// now stat the file to figure out if it is a regular file or directory
 		string full_path = JoinPath(directory, name);
-		if (access(full_path.c_str(), 0) != 0) {
+		struct stat status;
+		auto res = stat(full_path.c_str(), &status);
+		if (res != 0) {
 			continue;
 		}
-		struct stat status;
-		stat(full_path.c_str(), &status);
 		if (!(status.st_mode & S_IFREG) && !(status.st_mode & S_IFDIR)) {
 			// not a file or directory: skip
 			continue;


### PR DESCRIPTION
In `LocalFileSystem::ListFiles` there are a few too many syscalls that are not actually required for correctness.

* We would call `DirectoryExists`, followed by `opendir` - but [opendir](https://man7.org/linux/man-pages/man3/opendir.3.html) already returns a `nullptr` if the directory does not exist.
* We would call `access` with `F_OK` (literal 0) to test for the existence of a file followed by `stat`, but [stat](https://linux.die.net/man/2/stat) returns `-1` if the file does not exist.

Removing these syscalls speeds up globbing by around ~10% on my macbook:

```sql
select count(*) from glob('**');
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│        70452 │
└──────────────┘
-- new: 0.62s, old: 0.7s
```