### PR TITLE
Issue #12600: Batched LEAD/LAG

### DIFF
--- a/src/include/duckdb/execution/window_executor.hpp
+++ b/src/include/duckdb/execution/window_executor.hpp
@@ -58,7 +58,7 @@ struct WindowInputExpression {
 		return FlatVector::IsNull(chunk.data[0], i);
 	}
 
-	inline void CopyCell(Vector &target, idx_t target_offset) const {
+	inline void CopyCell(Vector &target, idx_t target_offset, idx_t width = 1) const {
 		D_ASSERT(!chunk.data.empty());
 		auto &source = chunk.data[0];
 		auto source_offset = scalar ? 0 : target_offset;


### PR DESCRIPTION
Implement batch copying for constant LEAD/LAG.
This gives only marginal improvements,
but they are [positive for all types tested](https://public.tableau.com/views/StreamingLead/Dashboard1?:language=en-US&:sid=&:display_count=n&:origin=viz_share_link).
