### PR TITLE
[Dev] Make`Executor::ResultCollectorIsBlocked` less trigger-happy

### DIFF
--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -97,6 +97,8 @@ public:
 
 	//! Whether or not the root of the pipeline is a result collector object
 	bool HasResultCollector();
+	//! Whether or not the root of the pipeline is a streaming result collector object
+	bool HasStreamingResultCollector();
 	//! Returns the query result - can only be used if `HasResultCollector` returns true
 	unique_ptr<QueryResult> GetResult();
 

--- a/src/include/duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_buffered_batch_collector.hpp
@@ -44,6 +44,10 @@ public:
 	bool ParallelSink() const override {
 		return true;
 	}
+
+	bool IsStreaming() const override {
+		return true;
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/helper/physical_buffered_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_buffered_collector.hpp
@@ -32,6 +32,9 @@ public:
 
 	bool ParallelSink() const override;
 	bool SinkOrderDependent() const override;
+	bool IsStreaming() const override {
+		return true;
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/helper/physical_result_collector.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_result_collector.hpp
@@ -45,6 +45,12 @@ public:
 	bool IsSource() const override {
 		return true;
 	}
+
+public:
+	//! Whether this is a streaming result collector
+	virtual bool IsStreaming() const {
+		return false;
+	}
 };
 
 } // namespace duckdb

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -464,7 +464,7 @@ void Executor::RescheduleTask(shared_ptr<Task> &task_p) {
 }
 
 bool Executor::ResultCollectorIsBlocked() {
-	if (!HasResultCollector()) {
+	if (!HasStreamingResultCollector()) {
 		return false;
 	}
 	if (completed_pipelines + 1 != total_pipelines) {
@@ -675,6 +675,14 @@ bool Executor::GetPipelinesProgress(double &current_progress, uint64_t &current_
 
 bool Executor::HasResultCollector() {
 	return physical_plan->type == PhysicalOperatorType::RESULT_COLLECTOR;
+}
+
+bool Executor::HasStreamingResultCollector() {
+	if (!HasResultCollector()) {
+		return false;
+	}
+	auto &result_collector = physical_plan->Cast<PhysicalResultCollector>();
+	return result_collector.IsStreaming();
 }
 
 unique_ptr<QueryResult> Executor::GetResult() {


### PR DESCRIPTION
Fixes an issue caused by #12636 

We have a CI run that generically blocks any Sink operation, this also makes the non-streaming result collector block, which is unexpected.
To account for this, we make sure that `ResultCollectorIsBlocked` only returns true if the result collector is a streaming result collector.