### PR TITLE
Internal #2429: Shifted LEAD NULLs

### DIFF
--- a/src/execution/window_executor.cpp
+++ b/src/execution/window_executor.cpp
@@ -1585,7 +1585,7 @@ void WindowLeadLagExecutor::EvaluateInternal(WindowExecutorGlobalState &gstate, 
 				i += delta;
 				row_idx += delta;
 			} else {
-				for (; delta--; ++i, ++row_idx) {
+				for (idx_t nulls = MinValue(delta, count - i); nulls--; ++i, ++row_idx) {
 					FlatVector::SetNull(result, i, true);
 				}
 			}


### PR DESCRIPTION
Don't set NULLs past the end of the chunk when shifting.

fixes: duckdblabs/duckdb-internal#2429