### PR TITLE
Issue #12784: Months Before Days

### DIFF
--- a/extension/icu/icu-dateadd.cpp
+++ b/extension/icu/icu-dateadd.cpp
@@ -101,13 +101,15 @@ timestamp_t ICUCalendarAdd::Operation(timestamp_t timestamp, interval_t interval
 		calendar->add(UCAL_MINUTE, interval_m, status);
 		CalendarAddHour(calendar, interval_h, status);
 
-		calendar->add(UCAL_DATE, interval.days, status);
+		// PG Adds months before days
 		calendar->add(UCAL_MONTH, interval.months, status);
+		calendar->add(UCAL_DATE, interval.days, status);
 	} else {
-		// Add interval fields from highest to lowest (ragged to non-ragged)
+		// PG Adds months before days
 		calendar->add(UCAL_MONTH, interval.months, status);
 		calendar->add(UCAL_DATE, interval.days, status);
 
+		// Add interval fields from highest to lowest (ragged to non-ragged)
 		CalendarAddHour(calendar, interval_h, status);
 		calendar->add(UCAL_MINUTE, interval_m, status);
 		calendar->add(UCAL_SECOND, interval_s, status);

--- a/test/sql/function/timestamp/test_icu_dateadd.test
+++ b/test/sql/function/timestamp/test_icu_dateadd.test
@@ -503,3 +503,17 @@ query I
 SELECT origin + (dst2 - origin) FROM london;
 ----
 2000-10-29 03:00:00+00
+
+# Months before days
+statement ok
+set timezone = 'Asia/Kolkata';
+
+query I
+select ('1920-12-12 01:02:02+05:30'::timestamptz + interval '-1 month 400 day')::timestamptz as r;
+----
+1921-12-17 01:02:02+05:30
+
+query I
+select ('1920-12-12 01:02:02+05:30'::timestamptz + interval '1 month -400 day')::timestamptz as r;
+----
+1919-12-09 01:02:02+05:30


### PR DESCRIPTION
Match Postgres's multi-part INTERVAL addition semantics by adding months befor days.

fixes: duckdb#12784
fixes: duckdblabs/duckdb-internal#2439