### PR TITLE
For compressed deletes in the undo buffer - count the actual size that will be written to the WAL when determining the auto-checkpoint threshold

### DIFF
--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -123,9 +123,14 @@ UndoBufferProperties UndoBuffer::GetProperties() {
 		case UndoFlags::UPDATE_TUPLE:
 			properties.has_updates = true;
 			break;
-		case UndoFlags::DELETE_TUPLE:
+		case UndoFlags::DELETE_TUPLE: {
+			auto info = reinterpret_cast<DeleteInfo *>(data);
+			if (info->is_consecutive) {
+				properties.estimated_size += sizeof(row_t) * info->count;
+			}
 			properties.has_deletes = true;
 			break;
+		}
 		case UndoFlags::CATALOG_ENTRY: {
 			properties.has_catalog_changes = true;
 

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/transaction/rollback_state.hpp"
 #include "duckdb/execution/index/bound_index.hpp"
 #include "duckdb/transaction/wal_write_state.hpp"
+#include "duckdb/transaction/delete_info.hpp"
 
 namespace duckdb {
 constexpr uint32_t UNDO_ENTRY_HEADER_SIZE = sizeof(UndoFlags) + sizeof(uint32_t);

--- a/test/sql/storage/large_delete_wal.test_slow
+++ b/test/sql/storage/large_delete_wal.test_slow
@@ -1,0 +1,26 @@
+# name: test/sql/storage/large_delete_wal.test_slow
+# description: Test large deletes with a WAL
+# group: [storage]
+
+# load the DB from disk
+load __TEST_DIR__/large_delete_wal.db
+
+statement ok
+SET checkpoint_threshold='1MB'
+
+# 10M rows
+statement ok
+CREATE TABLE test AS FROM range(10000000)
+
+statement ok
+CHECKPOINT
+
+# delete all data
+statement ok
+DELETE FROM test
+
+# verify nothing is written to the WAL
+query I
+select wal_size from pragma_database_size();
+----
+0 bytes


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/11470

Fixes an issue where large bulk deletes were triggering large WAL writes because the system would incorrectly assume the WAL writes would be small 

