### PR TITLE
[Dev] Change internals of `StringUtil::GenerateRandomName`

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -27,9 +27,8 @@ string StringUtil::GenerateRandomName(idx_t length) {
 	std::uniform_int_distribution<> dis(0, 15);
 
 	std::stringstream ss;
-	ss << std::hex;
 	for (idx_t i = 0; i < length; i++) {
-		ss << dis(gen);
+		ss << "0123456789abcdef"[dis(gen)];
 	}
 	return ss.str();
 }


### PR DESCRIPTION
This PR fixes #12541 

The crash has been traced down to the use of `std::hex`.
I've replaced it with a hex character string.

```py
import socketify
import duckdb

duckdb.sql("select 42").fetchall()
```