### PR TITLE
[Fix] Improve performance of ART leaf operations

### DIFF
--- a/.github/regression/micro_extended.csv
+++ b/.github/regression/micro_extended.csv
@@ -106,6 +106,7 @@ benchmark/micro/index/create/create_art_varchar_long.benchmark
 benchmark/micro/index/create/create_art_varchar_short.benchmark
 benchmark/micro/index/delete/delete_art.benchmark
 benchmark/micro/index/insert/insert_art.benchmark
+benchmark/micro/index/insert/insert_pk_fk.benchmark
 benchmark/micro/index/point/point_query_with_art.benchmark
 benchmark/micro/index/point/point_query_with_art_and_many_keys.benchmark
 benchmark/micro/index/point/point_query_without_index.benchmark

--- a/benchmark/micro/index/insert/insert_pk_fk.benchmark
+++ b/benchmark/micro/index/insert/insert_pk_fk.benchmark
@@ -1,0 +1,31 @@
+# name: benchmark/micro/index/insert/insert_pk_fk.benchmark
+# description: Insert into multiple indexes
+# group: [insert]
+
+name Insert into PK and FK
+group index
+
+require tpcds
+
+load
+BEGIN TRANSACTION;
+CALL dsdgen(sf=0.01);
+pragma threads=8;
+EXPORT DATABASE '${BENCHMARK_DIR}/sf1data';
+ROLLBACK;
+CREATE TABLE date_dim (d_date_sk Integer Not Null PRIMARY KEY, d_date_id String Not Null, d_date Date Not Null, d_month_seq Integer, d_week_seq Integer, d_quarter_seq Integer, d_year Integer, d_dow Integer, d_moy Integer, d_dom Integer, d_qoy Integer, d_fy_year Integer, d_fy_quarter_seq Integer, d_fy_week_seq Integer, d_day_name String, d_quarter_name String, d_holiday String, d_weekend String, d_following_holiday String, d_first_dom Integer, d_last_dom Integer, d_same_day_ly Integer, d_same_day_lq Integer, d_current_day String, d_current_week String, d_current_month String, d_current_quarter String, d_current_year String);
+CREATE TABLE warehouse (w_warehouse_sk Integer Not Null PRIMARY KEY, w_warehouse_id String Not Null, w_warehouse_name String, w_warehouse_sq_ft Integer, w_street_number String, w_street_name String, w_street_type String, w_suite_number String, w_city String, w_county String, w_state String, w_zip String, w_country String, w_gmt_offset Decimal(5,2));
+CREATE TABLE item (i_item_sk Integer Not Null PRIMARY KEY, i_item_id String Not Null, i_rec_start_date Date, i_rec_end_date Date, i_item_desc String, i_current_price Decimal(7,2), i_wholesale_cost Decimal(7,2), i_brand_id Integer, i_brand String, i_class_id Integer, i_class String, i_category_id Integer, i_category String, i_manufact_id Integer, i_manufact String, i_size String, i_formulation String, i_color String, i_units String, i_container String, i_manager_id Integer, i_product_name String);
+CREATE TABLE inventory (inv_date_sk Integer Not Null REFERENCES date_dim (d_date_sk), inv_item_sk Integer Not Null REFERENCES item (i_item_sk), inv_warehouse_sk Integer Not Null REFERENCES warehouse (w_warehouse_sk), inv_quantity_on_hand Integer);
+
+run
+COPY date_dim FROM '${BENCHMARK_DIR}/sf1data/date_dim.csv' (FORMAT 'csv', header 1, delimiter ',', quote '"');
+COPY item FROM '${BENCHMARK_DIR}/sf1data/item.csv' (FORMAT 'csv', header 1, delimiter ',', quote '"');
+COPY warehouse FROM '${BENCHMARK_DIR}/sf1data/warehouse.csv' (FORMAT 'csv', header 1, delimiter ',', quote '"');
+COPY inventory FROM '${BENCHMARK_DIR}/sf1data/inventory.csv' (FORMAT 'csv', header 1, delimiter ',', quote '"');
+
+cleanup
+CREATE OR REPLACE TABLE date_dim (d_date_sk Integer Not Null PRIMARY KEY, d_date_id String Not Null, d_date Date Not Null, d_month_seq Integer, d_week_seq Integer, d_quarter_seq Integer, d_year Integer, d_dow Integer, d_moy Integer, d_dom Integer, d_qoy Integer, d_fy_year Integer, d_fy_quarter_seq Integer, d_fy_week_seq Integer, d_day_name String, d_quarter_name String, d_holiday String, d_weekend String, d_following_holiday String, d_first_dom Integer, d_last_dom Integer, d_same_day_ly Integer, d_same_day_lq Integer, d_current_day String, d_current_week String, d_current_month String, d_current_quarter String, d_current_year String);
+CREATE OR REPLACE TABLE warehouse (w_warehouse_sk Integer Not Null PRIMARY KEY, w_warehouse_id String Not Null, w_warehouse_name String, w_warehouse_sq_ft Integer, w_street_number String, w_street_name String, w_street_type String, w_suite_number String, w_city String, w_county String, w_state String, w_zip String, w_country String, w_gmt_offset Decimal(5,2));
+CREATE OR REPLACE TABLE item (i_item_sk Integer Not Null PRIMARY KEY, i_item_id String Not Null, i_rec_start_date Date, i_rec_end_date Date, i_item_desc String, i_current_price Decimal(7,2), i_wholesale_cost Decimal(7,2), i_brand_id Integer, i_brand String, i_class_id Integer, i_class String, i_category_id Integer, i_category String, i_manufact_id Integer, i_manufact String, i_size String, i_formulation String, i_color String, i_units String, i_container String, i_manager_id Integer, i_product_name String);
+CREATE OR REPLACE TABLE inventory (inv_date_sk Integer Not Null REFERENCES date_dim (d_date_sk), inv_item_sk Integer Not Null REFERENCES item (i_item_sk), inv_warehouse_sk Integer Not Null REFERENCES warehouse (w_warehouse_sk), inv_quantity_on_hand Integer);

--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -53,7 +53,7 @@ void Node::Free(ART &art, Node &node) {
 		return Prefix::Free(art, node);
 	case NType::LEAF:
 		// iterative
-		return Leaf::Free(art, node);
+		return Leaf::FreeChain(art, node);
 	case NType::NODE_4:
 		Node4::Free(art, node);
 		break;

--- a/src/include/duckdb/execution/index/art/leaf.hpp
+++ b/src/include/duckdb/execution/index/art/leaf.hpp
@@ -47,7 +47,9 @@ public:
 	static void New(ART &art, reference<Node> &node, const row_t *row_ids, idx_t count);
 	//! Get a new leaf node without any data
 	static Leaf &New(ART &art, Node &node);
-	//! Free the leaf (chain)
+	//! Free the leaf chain starting at node.
+	static void FreeChain(ART &art, Node &node);
+	//! Free the leaf.
 	static void Free(ART &art, Node &node);
 
 	//! Initializes a merge by incrementing the buffer IDs of the leaf (chain)
@@ -76,8 +78,6 @@ public:
 private:
 	//! Moves the inlined row ID onto a leaf
 	static void MoveInlinedToLeaf(ART &art, Node &node);
-	//! Appends the row ID to this leaf, or creates a subsequent leaf, if this node is full
-	Leaf &Append(ART &art, const row_t row_id);
 };
 
 } // namespace duckdb


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/7565.

This PR contains changes to improve ART leaf performance.
- [x] Append row IDs to the head of a leaf chain instead of the tail.
- [x] Merge leaf chains directly without copying row IDs.
- [ ] Move non-full leaves to the front during `remove`.
- [ ] Attempt low-effort defragmentation during `remove` by merging two adjacent leaf nodes, if possible.
- [ ] Remove memory safety checks from performance-critical code paths.
- [ ] Potentially remove the hash lookup of fixed-size buffers.