### PR TITLE
[StreamQueryResult] Add `ExecuteTask` method to StreamQueryResult

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -48,6 +48,7 @@
 #include "duckdb/common/enums/set_scope.hpp"
 #include "duckdb/common/enums/set_type.hpp"
 #include "duckdb/common/enums/statement_type.hpp"
+#include "duckdb/common/enums/stream_execution_result.hpp"
 #include "duckdb/common/enums/subquery_type.hpp"
 #include "duckdb/common/enums/tableref_type.hpp"
 #include "duckdb/common/enums/undo_flags.hpp"
@@ -6864,6 +6865,54 @@ StrTimeSpecifier EnumUtil::FromString<StrTimeSpecifier>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "WEEK_NUMBER_ISO")) {
 		return StrTimeSpecifier::WEEK_NUMBER_ISO;
+	}
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+}
+
+template<>
+const char* EnumUtil::ToChars<StreamExecutionResult>(StreamExecutionResult value) {
+	switch(value) {
+	case StreamExecutionResult::CHUNK_READY:
+		return "CHUNK_READY";
+	case StreamExecutionResult::CHUNK_NOT_READY:
+		return "CHUNK_NOT_READY";
+	case StreamExecutionResult::EXECUTION_ERROR:
+		return "EXECUTION_ERROR";
+	case StreamExecutionResult::EXECUTION_CANCELLED:
+		return "EXECUTION_CANCELLED";
+	case StreamExecutionResult::BLOCKED:
+		return "BLOCKED";
+	case StreamExecutionResult::NO_TASKS_AVAILABLE:
+		return "NO_TASKS_AVAILABLE";
+	case StreamExecutionResult::EXECUTION_FINISHED:
+		return "EXECUTION_FINISHED";
+	default:
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+	}
+}
+
+template<>
+StreamExecutionResult EnumUtil::FromString<StreamExecutionResult>(const char *value) {
+	if (StringUtil::Equals(value, "CHUNK_READY")) {
+		return StreamExecutionResult::CHUNK_READY;
+	}
+	if (StringUtil::Equals(value, "CHUNK_NOT_READY")) {
+		return StreamExecutionResult::CHUNK_NOT_READY;
+	}
+	if (StringUtil::Equals(value, "EXECUTION_ERROR")) {
+		return StreamExecutionResult::EXECUTION_ERROR;
+	}
+	if (StringUtil::Equals(value, "EXECUTION_CANCELLED")) {
+		return StreamExecutionResult::EXECUTION_CANCELLED;
+	}
+	if (StringUtil::Equals(value, "BLOCKED")) {
+		return StreamExecutionResult::BLOCKED;
+	}
+	if (StringUtil::Equals(value, "NO_TASKS_AVAILABLE")) {
+		return StreamExecutionResult::NO_TASKS_AVAILABLE;
+	}
+	if (StringUtil::Equals(value, "EXECUTION_FINISHED")) {
+		return StreamExecutionResult::EXECUTION_FINISHED;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -302,6 +302,8 @@ enum class StatsInfo : uint8_t;
 
 enum class StrTimeSpecifier : uint8_t;
 
+enum class StreamExecutionResult : uint8_t;
+
 enum class SubqueryType : uint8_t;
 
 enum class TableColumnType : uint8_t;
@@ -751,6 +753,9 @@ const char* EnumUtil::ToChars<StatsInfo>(StatsInfo value);
 
 template<>
 const char* EnumUtil::ToChars<StrTimeSpecifier>(StrTimeSpecifier value);
+
+template<>
+const char* EnumUtil::ToChars<StreamExecutionResult>(StreamExecutionResult value);
 
 template<>
 const char* EnumUtil::ToChars<SubqueryType>(SubqueryType value);
@@ -1223,6 +1228,9 @@ StatsInfo EnumUtil::FromString<StatsInfo>(const char *value);
 
 template<>
 StrTimeSpecifier EnumUtil::FromString<StrTimeSpecifier>(const char *value);
+
+template<>
+StreamExecutionResult EnumUtil::FromString<StreamExecutionResult>(const char *value);
 
 template<>
 SubqueryType EnumUtil::FromString<SubqueryType>(const char *value);

--- a/src/include/duckdb/common/enums/stream_execution_result.hpp
+++ b/src/include/duckdb/common/enums/stream_execution_result.hpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/stream_execution_result.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class StreamExecutionResult : uint8_t {
+	CHUNK_READY,
+	CHUNK_NOT_READY,
+	EXECUTION_ERROR,
+	EXECUTION_CANCELLED,
+	BLOCKED,
+	NO_TASKS_AVAILABLE,
+	EXECUTION_FINISHED
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/buffered_data/batched_buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/batched_buffered_data.hpp
@@ -39,12 +39,13 @@ public:
 	void BlockSink(const InterruptState &blocked_sink, idx_t batch);
 
 	bool ShouldBlockBatch(idx_t batch);
-	bool ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) override;
+	StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock) override;
 	unique_ptr<DataChunk> Scan() override;
 	void UpdateMinBatchIndex(idx_t min_batch_index);
 	bool IsMinimumBatchIndex(lock_guard<mutex> &lock, idx_t batch);
 	void CompleteBatch(idx_t batch);
 	bool BufferIsEmpty();
+	void UnblockSinks() override;
 
 	inline idx_t ReadQueueCapacity() const {
 		return read_queue_capacity;
@@ -55,7 +56,6 @@ public:
 
 private:
 	void ResetReplenishState();
-	void UnblockSinks();
 	void MoveCompletedBatches(lock_guard<mutex> &lock);
 
 private:

--- a/src/include/duckdb/main/buffered_data/buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/buffered_data.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/execution/physical_operator_states.hpp"
 #include "duckdb/common/enums/pending_execution_result.hpp"
+#include "duckdb/common/enums/stream_execution_result.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
@@ -31,14 +32,16 @@ public:
 	virtual ~BufferedData();
 
 public:
-	virtual bool ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) = 0;
+	StreamExecutionResult ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock);
+	virtual StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock) = 0;
 	virtual unique_ptr<DataChunk> Scan() = 0;
+	virtual void UnblockSinks() = 0;
 	shared_ptr<ClientContext> GetContext() {
 		return context.lock();
 	}
 	bool Closed() const {
 		if (context.expired()) {
-			return false;
+			return true;
 		}
 		auto c = context.lock();
 		return c == nullptr;

--- a/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/simple_buffered_data.hpp
@@ -31,14 +31,12 @@ public:
 	void Append(const DataChunk &chunk);
 	void BlockSink(const InterruptState &blocked_sink);
 	bool BufferIsFull();
-	bool ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) override;
+	void UnblockSinks() override;
+	StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock) override;
 	unique_ptr<DataChunk> Scan() override;
 	inline idx_t BufferSize() const {
 		return buffer_size;
 	}
-
-private:
-	void UnblockSinks();
 
 private:
 	//! Our handles to reschedule the blocked sink tasks

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -48,6 +48,7 @@ class ScalarFunctionCatalogEntry;
 struct ActiveQueryContext;
 struct ParserOptions;
 class SimpleBufferedData;
+class BufferedData;
 struct ClientData;
 class ClientContextState;
 
@@ -62,6 +63,7 @@ struct PendingQueryParameters {
 //! during execution
 class ClientContext : public enable_shared_from_this<ClientContext> {
 	friend class PendingQueryResult;  // LockContext
+	friend class BufferedData;        // ExecuteTaskInternal
 	friend class SimpleBufferedData;  // ExecuteTaskInternal
 	friend class BatchedBufferedData; // ExecuteTaskInternal
 	friend class StreamQueryResult;   // LockContext

--- a/src/include/duckdb/main/stream_query_result.hpp
+++ b/src/include/duckdb/main/stream_query_result.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/common/queue.hpp"
+#include "duckdb/common/enums/stream_execution_result.hpp"
 #include "duckdb/main/buffered_data/simple_buffered_data.hpp"
 
 namespace duckdb {
@@ -38,6 +39,9 @@ public:
 	DUCKDB_API ~StreamQueryResult() override;
 
 public:
+	static bool IsChunkReady(StreamExecutionResult result);
+	//! Executes a single task within the final pipeline, returning whether or not a chunk is ready to be fetched
+	DUCKDB_API StreamExecutionResult ExecuteTask();
 	//! Fetches a DataChunk from the query result.
 	DUCKDB_API unique_ptr<DataChunk> FetchRaw() override;
 	//! Converts the QueryResult to a string
@@ -54,6 +58,7 @@ public:
 	shared_ptr<ClientContext> context;
 
 private:
+	StreamExecutionResult ExecuteTaskInternal(ClientContextLock &lock);
 	unique_ptr<DataChunk> FetchInternal(ClientContextLock &lock);
 	unique_ptr<ClientContextLock> LockContext();
 	void CheckExecutableInternal(ClientContextLock &lock);

--- a/src/include/duckdb/main/stream_query_result.hpp
+++ b/src/include/duckdb/main/stream_query_result.hpp
@@ -40,6 +40,8 @@ public:
 
 public:
 	static bool IsChunkReady(StreamExecutionResult result);
+	//! Reschedules the tasks that work on producing a result chunk, returning when at least one task can be executed
+	DUCKDB_API void WaitForTask();
 	//! Executes a single task within the final pipeline, returning whether or not a chunk is ready to be fetched
 	DUCKDB_API StreamExecutionResult ExecuteTask();
 	//! Fetches a DataChunk from the query result.

--- a/src/main/buffered_data/batched_buffered_data.cpp
+++ b/src/main/buffered_data/batched_buffered_data.cpp
@@ -125,37 +125,43 @@ void BatchedBufferedData::UpdateMinBatchIndex(idx_t min_batch_index) {
 	MoveCompletedBatches(lock);
 }
 
-bool BatchedBufferedData::ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock) {
-	if (Closed()) {
-		return false;
+StreamExecutionResult BatchedBufferedData::ExecuteTaskInternal(StreamQueryResult &result,
+                                                               ClientContextLock &context_lock) {
+	auto cc = context.lock();
+	if (!cc) {
+		return StreamExecutionResult::EXECUTION_CANCELLED;
+	}
+
+	if (!BufferIsEmpty()) {
+		// The buffer isn't empty yet, just return
+		return StreamExecutionResult::CHUNK_READY;
 	}
 	// Unblock any pending sinks if the buffer isnt full
 	UnblockSinks();
-	if (!BufferIsEmpty()) {
-		// The buffer isn't empty yet, just return
-		return true;
-	}
-	auto cc = context.lock();
-	if (!cc) {
-		return false;
-	}
 	// Let the executor run until the buffer is no longer empty
-	PendingExecutionResult execution_result;
-	while (!PendingQueryResult::IsExecutionFinished(execution_result = cc->ExecuteTaskInternal(context_lock, result))) {
-		if (!BufferIsEmpty()) {
-			break;
-		}
-		if (execution_result == PendingExecutionResult::BLOCKED ||
-		    execution_result == PendingExecutionResult::RESULT_READY) {
-			// Check if we need to unblock more sinks to reach the buffer size
-			UnblockSinks();
-			cc->WaitForTask(context_lock, result);
-		}
+	auto execution_result = cc->ExecuteTaskInternal(context_lock, result);
+	if (!BufferIsEmpty()) {
+		return StreamExecutionResult::CHUNK_READY;
+	}
+	if (execution_result == PendingExecutionResult::BLOCKED ||
+	    execution_result == PendingExecutionResult::RESULT_READY) {
+		return StreamExecutionResult::BLOCKED;
 	}
 	if (result.HasError()) {
 		Close();
 	}
-	return execution_result != PendingExecutionResult::EXECUTION_ERROR;
+	switch (execution_result) {
+	case PendingExecutionResult::NO_TASKS_AVAILABLE:
+	case PendingExecutionResult::RESULT_NOT_READY:
+		return StreamExecutionResult::CHUNK_NOT_READY;
+	case PendingExecutionResult::EXECUTION_FINISHED:
+		return StreamExecutionResult::EXECUTION_FINISHED;
+	case PendingExecutionResult::EXECUTION_ERROR:
+		return StreamExecutionResult::EXECUTION_ERROR;
+	default:
+		throw InternalException("No conversion from PendingExecutionResult (%s) -> StreamExecutionResult",
+		                        EnumUtil::ToString(execution_result));
+	}
 }
 
 void BatchedBufferedData::CompleteBatch(idx_t batch) {

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -53,6 +53,12 @@ StreamExecutionResult StreamQueryResult::ExecuteTask() {
 	return ExecuteTaskInternal(*lock);
 }
 
+void StreamQueryResult::WaitForTask() {
+	auto lock = LockContext();
+	buffered_data->UnblockSinks();
+	context->WaitForTask(*lock, *this);
+}
+
 static bool ExecutionErrorOccurred(StreamExecutionResult result) {
 	if (result == StreamExecutionResult::EXECUTION_CANCELLED) {
 		return true;

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -120,6 +120,27 @@ unique_ptr<DataChunk> StreamQueryResult::FetchRaw() {
 	return chunk;
 }
 
+#ifdef DUCKDB_ALTERNATIVE_VERIFY
+static unique_ptr<DataChunk> AlternativeFetch(StreamQueryResult &stream_result) {
+	// We first use StreamQueryResult::ExecuteTask until IsChunkReady becomes true
+	// then call Fetch
+	StreamExecutionResult execution_result;
+	while (!StreamQueryResult::IsChunkReady(execution_result = stream_result.ExecuteTask())) {
+		if (execution_result == StreamExecutionResult::BLOCKED) {
+			stream_result.WaitForTask();
+		}
+	}
+	if (execution_result == StreamExecutionResult::EXECUTION_CANCELLED) {
+		throw InvalidInputException("The execution of the query was cancelled before it could finish, likely "
+		                            "caused by executing a different query");
+	}
+	if (execution_result == StreamExecutionResult::EXECUTION_ERROR) {
+		stream_result.ThrowError();
+	}
+	return stream_result.Fetch();
+}
+#endif
+
 unique_ptr<MaterializedQueryResult> StreamQueryResult::Materialize() {
 	if (HasError() || !context) {
 		return make_uniq<MaterializedQueryResult>(GetErrorObject());
@@ -129,7 +150,11 @@ unique_ptr<MaterializedQueryResult> StreamQueryResult::Materialize() {
 	ColumnDataAppendState append_state;
 	collection->InitializeAppend(append_state);
 	while (true) {
+#ifdef DUCKDB_ALTERNATIVE_VERIFY
+		auto chunk = AlternativeFetch(*this);
+#else
 		auto chunk = Fetch();
+#endif
 		if (!chunk || chunk->size() == 0) {
 			break;
 		}

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -45,7 +45,7 @@ unique_ptr<ClientContextLock> StreamQueryResult::LockContext() {
 }
 
 StreamExecutionResult StreamQueryResult::ExecuteTaskInternal(ClientContextLock &lock) {
-	return StreamExecutionResult::CHUNK_READY;
+	return buffered_data->ExecuteTaskInternal(*this, lock);
 }
 
 StreamExecutionResult StreamQueryResult::ExecuteTask() {

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb_python/numpy/array_wrapper.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/enums/stream_execution_result.hpp"
 #include "duckdb_python/arrow/arrow_export_utils.hpp"
 #include "duckdb/main/chunk_scan_state/query_result.hpp"
 
@@ -62,6 +63,28 @@ unique_ptr<DataChunk> DuckDBPyResult::FetchNext(QueryResult &query_result) {
 	    !query_result.Cast<StreamQueryResult>().IsOpen()) {
 		result_closed = true;
 		return nullptr;
+	}
+	if (query_result.type == QueryResultType::STREAM_RESULT) {
+		auto &stream_result = query_result.Cast<StreamQueryResult>();
+		StreamExecutionResult execution_result;
+		while (!StreamQueryResult::IsChunkReady(execution_result = stream_result.ExecuteTask())) {
+			{
+				py::gil_scoped_acquire gil;
+				if (PyErr_CheckSignals() != 0) {
+					throw std::runtime_error("Query interrupted");
+				}
+			}
+			if (execution_result == StreamExecutionResult::BLOCKED) {
+				stream_result.WaitForTask();
+			}
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_CANCELLED) {
+			throw InvalidInputException("The execution of the query was cancelled before it could finish, likely "
+			                            "caused by executing a different query");
+		}
+		if (execution_result == StreamExecutionResult::EXECUTION_ERROR) {
+			stream_result.ThrowError();
+		}
 	}
 	auto chunk = query_result.Fetch();
 	if (query_result.HasError()) {


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2344

### PendingQueryResult

PendingQueryResult starts up execution, and provides an `ExecuteTask` method to pick up a Task and (partially) process it, returning an enum indicating the state of the execution:
```c++
enum class PendingExecutionResult : uint8_t {
	RESULT_READY,
	RESULT_NOT_READY,
	EXECUTION_ERROR,
	BLOCKED,
	NO_TASKS_AVAILABLE,
	EXECUTION_FINISHED
};
```

This allows the user to periodically call `ExecuteTask` until `RESULT_READY` is returned, meaning the QueryResult is ready and can be instantly retrieved with a call to `Execute`.

### Materialized vs Streaming

When a MaterializedQueryResult is created, the entire pipeline will have completed.
For a StreamQueryResult this is not the case, and the final pipeline hasn't completed yet.

To get a DataChunk from the QueryResult, the QueryResult provides a `Fetch` interface.
Again, for a MaterializedQueryResult this is instant because the entire result is already materialized and ready to be consumed.

On a StreamQueryResult, calling Fetch will execute the final pipeline until a DataChunk worth of tuples are ready or the execution has finished.
Like any pipeline, this final pipeline could be heavy and possibly block if it's waiting on IO for example.

### ExecuteTask

This is where `StreamQueryResult::ExecuteTask` comes in, like the PendingQueryResult variant, it picks up a Task to partially process, returning an enum indicating the state of the execution:
```c++
enum class StreamExecutionResult : uint8_t {
	CHUNK_READY,
	CHUNK_NOT_READY,
	EXECUTION_ERROR,
	EXECUTION_CANCELLED,
	BLOCKED,
	NO_TASKS_AVAILABLE,
	EXECUTION_FINISHED
};
```

If `CHUNK_READY` is returned, Fetch can be called to immediately retrieve the chunk that is waiting to be fetched.

### WaitForTask

Similar to <https://github.com/duckdb/duckdb/pull/12483>, the StreamQueryResult also has `WaitForTask` that should be used in the event where `BLOCKED` is returned (also shown in the example mentioned below)

### Example Usage

An example of this can be seen in `tools/pythonpkg/src/pyresult.cpp` at the bottom of the list of changed files in this PR