### PR TITLE
Some expected error messages added

### DIFF
--- a/test/fuzzer/pedro/alter_column_generated.test
+++ b/test/fuzzer/pedro/alter_column_generated.test
@@ -17,10 +17,12 @@ ALTER TABLE t0 ALTER c1 SET NOT NULL;
 statement error
 ALTER TABLE t0 ALTER c0 SET NOT NULL;
 ----
+<REGEX>:Binder Error.*Unsupported constraint.*
 
 statement error
 INSERT INTO t0 VALUES (NULL);
 ----
+<REGEX>:Constraint Error.*NOT NULL.*failed.*
 
 statement ok
 DROP TABLE t0;
@@ -34,4 +36,4 @@ INSERT INTO t0 VALUES (NULL);
 statement error
 ALTER TABLE t0 ALTER c1 SET NOT NULL;
 ----
-
+<REGEX>:Constraint Error.*NOT NULL.*failed.*

--- a/test/fuzzer/pedro/correlated_offset_subquery.test
+++ b/test/fuzzer/pedro/correlated_offset_subquery.test
@@ -8,7 +8,9 @@ PRAGMA enable_verification
 statement error
 SELECT (SELECT 1 OFFSET c0) FROM (VALUES(1)) c0;
 ----
+<REGEX>:Binder Error.*not supported.*
 
 statement error
 SELECT 0 FROM (SELECT 8 c0) WHERE (SELECT 1 LIMIT c0);
 ----
+<REGEX>:Binder Error.*not supported.*

--- a/test/fuzzer/pedro/currval_sequence_dependency.test
+++ b/test/fuzzer/pedro/currval_sequence_dependency.test
@@ -19,7 +19,7 @@ CREATE TABLE t1(c1 INT, CHECK(${fun}('seq')));
 statement error
 DROP SEQUENCE seq;
 ----
-table "t1" depends on index "seq".
+<REGEX>:Dependency Error.*table "t1" depends on index "seq".*
 
 statement ok
 DROP SEQUENCE seq CASCADE;
@@ -28,5 +28,6 @@ DROP SEQUENCE seq CASCADE;
 statement error
 INSERT INTO t1 VALUES (1)
 ----
+<REGEX>:Catalog Error.*t1 does not exist.*
 
 endloop

--- a/test/fuzzer/pedro/index_insert_from_union.test
+++ b/test/fuzzer/pedro/index_insert_from_union.test
@@ -11,14 +11,17 @@ CREATE TABLE t2 (c1 INT, PRIMARY KEY (c1));
 statement error
 INSERT INTO t2 SELECT * FROM (VALUES (2), (2))
 ----
+<REGEX>:Constraint Error.*duplicate key.*
 
 statement error
 INSERT INTO t2 SELECT 2 FROM range(10);
 ----
+<REGEX>:Constraint Error.*duplicate key.*
 
 statement error
 INSERT INTO t2 SELECT 2 UNION ALL SELECT 2;
 ----
+<REGEX>:Constraint Error.*duplicate key.*
 
 statement ok
 BEGIN TRANSACTION

--- a/test/fuzzer/pedro/multiplication_verification.test
+++ b/test/fuzzer/pedro/multiplication_verification.test
@@ -8,6 +8,7 @@ PRAGMA enable_verification
 statement error
 SELECT 1 * (1 < 1);
 ----
+<REGEX>:Binder Error.*No function matches.*
 
 query I
 SELECT 2 * (1 << 2);


### PR DESCRIPTION
This PR adds some expected error messages to the test cases with the empty expected result for `statement error` according to the [issue](https://github.com/duckdblabs/duckdb-internal/issues/2053#event-12874954527).
Changed test cases:
test/extension/test_alias_point.test
test/extension/load_extension.test
test/optimizer/statistics/statistics_case.test
test/optimizer/perfect_ht.test
test/fuzzer/pedro/blob_wrong_optimization.test
test/fuzzer/pedro/currval_sequence_dependency.test
test/fuzzer/pedro/correlated_offset_subquery.test
test/fuzzer/pedro/multiplication_verification.test
test/fuzzer/Pedro/alter_column_generated.test
