### PR TITLE
[Copy Database] Don't include generated columns in the copied data

### DIFF
--- a/test/sql/copy_database/copy_database_gen_col.test
+++ b/test/sql/copy_database/copy_database_gen_col.test
@@ -1,0 +1,27 @@
+# name: test/sql/copy_database/copy_database_gen_col.test
+# group: [copy_database]
+
+load __TEST_DIR__/mydb.db
+
+statement ok
+pragma enable_verification;
+
+statement ok
+CREATE TABLE test (x INT, y AS (x + 100));
+
+statement ok
+insert into test VALUES (42);
+
+statement ok
+FROM test;
+
+statement ok
+ATTACH '__TEST_DIR__/myotherdb.db';
+
+statement ok
+COPY FROM DATABASE mydb TO myotherdb;
+
+query II
+select * from myotherdb.test;
+----
+42	142

--- a/test/sql/copy_database/copy_database_gen_col.test
+++ b/test/sql/copy_database/copy_database_gen_col.test
@@ -1,6 +1,8 @@
 # name: test/sql/copy_database/copy_database_gen_col.test
 # group: [copy_database]
 
+require skip_reload
+
 load __TEST_DIR__/mydb.db
 
 statement ok


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2274

Previously, generated columns were being included in the copied data, which caused an issue on the import into the destination database.