### PR TITLE
Fix LinuxRelease.yml after bump to Node 20

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -66,7 +66,7 @@ jobs:
       DUCKDB_RUN_PARALLEL_CSV_TESTS: 1
 
     steps:
-    - name: Build
+    - name: Handrolled checkout
       shell: bash
       env:
         REPO_NAME: ${{ github.repository }}

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -66,10 +66,16 @@ jobs:
       DUCKDB_RUN_PARALLEL_CSV_TESTS: 1
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        ref: ${{ inputs.git_ref }}
+    - name: Build
+      shell: bash
+      env:
+        REPO_NAME: ${{ github.repository }}
+        REPO_REF: ${{ inputs.git_ref }}
+      run: |
+        git config --global --add safe.directory $(pwd)
+        git clone https://github.com/$REPO_NAME .
+        git fetch
+        git checkout $REPO_REF
 
     - uses: ./.github/actions/manylinux_2014_setup
       with:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -80,7 +80,7 @@ jobs:
     - uses: ./.github/actions/manylinux_2014_setup
       with:
         ninja-build: 1
-        ccache: 1
+        ccache: 0
         python_alias: 1
         aws-cli: 1
 


### PR DESCRIPTION
Bump on image means Node 20 is the default to run JS-based actions, that means we need to hand-roll action-checkout (that looks doable) and remove ccache (implementing this is not trivial, left as exercize).