### PR TITLE
Respect limit during join order

### DIFF
--- a/benchmark/micro/join/join_order_optimizer_should_respect_limit.benchmark
+++ b/benchmark/micro/join/join_order_optimizer_should_respect_limit.benchmark
@@ -1,0 +1,13 @@
+# name: benchmark/micro/join/join_order_optimizer_should_respect_limit.benchmark
+# description: If a constant value limit operator exists, is should have influence on the estimated cardinality
+# group: [join]
+
+name join limit
+group join
+
+load
+create table t_left as select (random() * 1000000000)::INT a from range(400000);
+create table t_right as select range b from range(1000000000);
+
+run
+select * from t_left, (select * from t_right limit 10000) where a = b;

--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -133,7 +133,7 @@ static bool HasNonReorderableChild(LogicalOperator &op) {
 	return tmp->children.empty();
 }
 
-static void ModifyStatsIfLimit(LogicalOperator *limit_op, RelationStats &stats) {
+static void ModifyStatsIfLimit(optional_ptr<LogicalOperator> limit_op, RelationStats &stats) {
 	if (!limit_op) {
 		return;
 	}
@@ -146,7 +146,7 @@ static void ModifyStatsIfLimit(LogicalOperator *limit_op, RelationStats &stats) 
 bool RelationManager::ExtractJoinRelations(LogicalOperator &input_op,
                                            vector<reference<LogicalOperator>> &filter_operators,
                                            optional_ptr<LogicalOperator> parent) {
-	LogicalOperator *op = &input_op;
+	optional_ptr<LogicalOperator> op = &input_op;
 	vector<reference<LogicalOperator>> datasource_filters;
 	optional_ptr<LogicalOperator> limit_op = nullptr;
 	// pass through single child operators

--- a/test/optimizer/joins/get_cardinality_from_limit.test
+++ b/test/optimizer/joins/get_cardinality_from_limit.test
@@ -9,7 +9,7 @@ statement ok
 create table t_right as select range b from range(10000000);
 
 statement ok
-pragma explain_output='optimized_only'g
+pragma explain_output='optimized_only';
 
 query II
 explain select * from t_left, (select * from t_right limit 10000) where a = b;

--- a/test/optimizer/joins/get_cardinality_from_limit.test
+++ b/test/optimizer/joins/get_cardinality_from_limit.test
@@ -1,0 +1,15 @@
+# name: test/optimizer/joins/get_cardinality_from_limit.test
+# description: when a limit is encountered, use the limit to know the cardinality
+# group: [joins]
+
+statement ok
+create table t_left as select (random() * 10000000)::INT a from range(40000);
+
+statement ok
+create table t_right as select range b from range(10000000);
+
+statement ok
+pragma explain_output='optimized_only'
+
+
+

--- a/test/optimizer/joins/get_cardinality_from_limit.test
+++ b/test/optimizer/joins/get_cardinality_from_limit.test
@@ -9,8 +9,12 @@ statement ok
 create table t_right as select range b from range(10000000);
 
 statement ok
-pragma explain_output='optimized_only'
+pragma explain_output='optimized_only'g
 
+query II
+explain select * from t_left, (select * from t_right limit 10000) where a = b;
+----
+logical_opt	<REGEX>:.*SEQ_SCAN.*LIMIT.*SEQ_SCAN.*
 
 
 

--- a/test/optimizer/joins/get_cardinality_from_limit.test
+++ b/test/optimizer/joins/get_cardinality_from_limit.test
@@ -13,3 +13,5 @@ pragma explain_output='optimized_only'
 
 
 
+
+


### PR DESCRIPTION
while iterating through the relations, check to see if a limit is encountered. If so modify the estimated cardinality of the added relation accordingly. 

Right now this only includes the case where the limit val is constant, but this logic can most likely be expanded to include cases where it is a percentage as well. 

No attention is paid to the offset value. My thinking is that the limit value is what is important to the optimizer when choosing a build side and estimating the cardinality of a join. If someone thinks otherwise please let me know