### PR TITLE
Count nulls when detecting JSON structure

### DIFF
--- a/extension/json/include/json_structure.hpp
+++ b/extension/json/include/json_structure.hpp
@@ -19,7 +19,7 @@ struct StrpTimeFormat;
 struct JSONStructureNode {
 public:
 	JSONStructureNode();
-	JSONStructureNode(yyjson_val *key_p, yyjson_val *val_p, const bool ignore_errors);
+	JSONStructureNode(yyjson_val *key_p, yyjson_val *val_p, bool ignore_errors);
 
 	//! Disable copy constructors
 	JSONStructureNode(const JSONStructureNode &other) = delete;
@@ -31,7 +31,7 @@ public:
 	JSONStructureDescription &GetOrCreateDescription(LogicalTypeId type);
 
 	bool ContainsVarchar() const;
-	void InitializeCandidateTypes(const idx_t max_depth, const bool convert_strings_to_integers, idx_t depth = 0);
+	void InitializeCandidateTypes(idx_t max_depth, bool convert_strings_to_integers, idx_t depth = 0);
 	void RefineCandidateTypes(yyjson_val *vals[], idx_t val_count, Vector &string_vector, ArenaAllocator &allocator,
 	                          DateFormatMap &date_format_map);
 
@@ -43,14 +43,15 @@ private:
 	void RefineCandidateTypesString(yyjson_val *vals[], idx_t val_count, Vector &string_vector,
 	                                DateFormatMap &date_format_map);
 	void EliminateCandidateTypes(idx_t vec_count, Vector &string_vector, DateFormatMap &date_format_map);
-	bool EliminateCandidateFormats(idx_t vec_count, Vector &string_vector, Vector &result_vector,
+	bool EliminateCandidateFormats(idx_t vec_count, Vector &string_vector, const Vector &result_vector,
 	                               vector<StrpTimeFormat> &formats);
 
 public:
-	duckdb::unique_ptr<string> key;
+	unique_ptr<string> key;
 	bool initialized = false;
 	vector<JSONStructureDescription> descriptions;
 	idx_t count;
+	idx_t null_count;
 };
 
 struct JSONStructureDescription {
@@ -64,7 +65,7 @@ public:
 	JSONStructureDescription &operator=(JSONStructureDescription &&) noexcept;
 
 	JSONStructureNode &GetOrCreateChild();
-	JSONStructureNode &GetOrCreateChild(yyjson_val *key, yyjson_val *val, const bool ignore_errors);
+	JSONStructureNode &GetOrCreateChild(yyjson_val *key, yyjson_val *val, bool ignore_errors);
 
 public:
 	//! Type of this description
@@ -80,11 +81,10 @@ public:
 
 struct JSONStructure {
 public:
-	static void ExtractStructure(yyjson_val *val, JSONStructureNode &node, const bool ignore_errors);
-	static LogicalType StructureToType(ClientContext &context, const JSONStructureNode &node, const idx_t max_depth,
-	                                   const double field_appearance_threshold, idx_t map_inference_threshold,
-	                                   idx_t depth = 0, idx_t sample_count = DConstants::INVALID_INDEX,
-	                                   const LogicalType &null_type = LogicalType::JSON());
+	static void ExtractStructure(yyjson_val *val, JSONStructureNode &node, bool ignore_errors);
+	static LogicalType StructureToType(ClientContext &context, const JSONStructureNode &node, idx_t max_depth,
+	                                   double field_appearance_threshold, idx_t map_inference_threshold,
+	                                   idx_t depth = 0, const LogicalType &null_type = LogicalType::JSON());
 };
 
 } // namespace duckdb

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -9,11 +9,11 @@
 
 namespace duckdb {
 
-static inline bool IsNumeric(LogicalTypeId type) {
+static bool IsNumeric(LogicalTypeId type) {
 	return type == LogicalTypeId::DOUBLE || type == LogicalTypeId::UBIGINT || type == LogicalTypeId::BIGINT;
 }
 
-static inline LogicalTypeId MaxNumericType(LogicalTypeId &a, LogicalTypeId &b) {
+static LogicalTypeId MaxNumericType(const LogicalTypeId &a, const LogicalTypeId &b) {
 	D_ASSERT(a != b);
 	if (a == LogicalTypeId::DOUBLE || b == LogicalTypeId::DOUBLE) {
 		return LogicalTypeId::DOUBLE;
@@ -21,31 +21,34 @@ static inline LogicalTypeId MaxNumericType(LogicalTypeId &a, LogicalTypeId &b) {
 	return LogicalTypeId::BIGINT;
 }
 
-JSONStructureNode::JSONStructureNode() : initialized(false), count(0) {
+JSONStructureNode::JSONStructureNode() : count(0), null_count(0) {
 }
 
 JSONStructureNode::JSONStructureNode(yyjson_val *key_p, yyjson_val *val_p, const bool ignore_errors)
-    : key(make_uniq<string>(unsafe_yyjson_get_str(key_p), unsafe_yyjson_get_len(key_p))), initialized(false), count(0) {
+    : JSONStructureNode() {
 	D_ASSERT(yyjson_is_str(key_p));
+	key = make_uniq<string>(unsafe_yyjson_get_str(key_p));
 	JSONStructure::ExtractStructure(val_p, *this, ignore_errors);
 }
 
+static void SwapJSONStructureNode(JSONStructureNode &a, JSONStructureNode &b) noexcept {
+	std::swap(a.key, b.key);
+	std::swap(a.initialized, b.initialized);
+	std::swap(a.descriptions, b.descriptions);
+	std::swap(a.count, b.count);
+	std::swap(a.null_count, b.null_count);
+}
+
 JSONStructureNode::JSONStructureNode(JSONStructureNode &&other) noexcept {
-	std::swap(key, other.key);
-	std::swap(initialized, other.initialized);
-	std::swap(descriptions, other.descriptions);
-	std::swap(count, other.count);
+	SwapJSONStructureNode(*this, other);
 }
 
 JSONStructureNode &JSONStructureNode::operator=(JSONStructureNode &&other) noexcept {
-	std::swap(key, other.key);
-	std::swap(initialized, other.initialized);
-	std::swap(descriptions, other.descriptions);
-	std::swap(count, other.count);
+	SwapJSONStructureNode(*this, other);
 	return *this;
 }
 
-JSONStructureDescription &JSONStructureNode::GetOrCreateDescription(LogicalTypeId type) {
+JSONStructureDescription &JSONStructureNode::GetOrCreateDescription(const LogicalTypeId type) {
 	if (descriptions.empty()) {
 		// Empty, just put this type in there
 		descriptions.emplace_back(type);
@@ -68,7 +71,8 @@ JSONStructureDescription &JSONStructureNode::GetOrCreateDescription(LogicalTypeI
 	for (auto &description : descriptions) {
 		if (type == description.type) {
 			return description;
-		} else if (is_numeric && IsNumeric(description.type)) {
+		}
+		if (is_numeric && IsNumeric(description.type)) {
 			description.type = MaxNumericType(type, description.type);
 			return description;
 		}
@@ -97,7 +101,7 @@ bool JSONStructureNode::ContainsVarchar() const {
 }
 
 void JSONStructureNode::InitializeCandidateTypes(const idx_t max_depth, const bool convert_strings_to_integers,
-                                                 idx_t depth) {
+                                                 const idx_t depth) {
 	if (depth >= max_depth) {
 		return;
 	}
@@ -122,7 +126,7 @@ void JSONStructureNode::InitializeCandidateTypes(const idx_t max_depth, const bo
 	}
 }
 
-void JSONStructureNode::RefineCandidateTypes(yyjson_val *vals[], idx_t val_count, Vector &string_vector,
+void JSONStructureNode::RefineCandidateTypes(yyjson_val *vals[], const idx_t val_count, Vector &string_vector,
                                              ArenaAllocator &allocator, DateFormatMap &date_format_map) {
 	if (descriptions.size() != 1) {
 		// We can't refine types if we have more than 1 description (yet), defaults to JSON type for now
@@ -144,7 +148,7 @@ void JSONStructureNode::RefineCandidateTypes(yyjson_val *vals[], idx_t val_count
 	}
 }
 
-void JSONStructureNode::RefineCandidateTypesArray(yyjson_val *vals[], idx_t val_count, Vector &string_vector,
+void JSONStructureNode::RefineCandidateTypesArray(yyjson_val *vals[], const idx_t val_count, Vector &string_vector,
                                                   ArenaAllocator &allocator, DateFormatMap &date_format_map) {
 	D_ASSERT(descriptions.size() == 1 && descriptions[0].type == LogicalTypeId::LIST);
 	auto &desc = descriptions[0];
@@ -175,7 +179,7 @@ void JSONStructureNode::RefineCandidateTypesArray(yyjson_val *vals[], idx_t val_
 	child.RefineCandidateTypes(child_vals, total_list_size, string_vector, allocator, date_format_map);
 }
 
-void JSONStructureNode::RefineCandidateTypesObject(yyjson_val *vals[], idx_t val_count, Vector &string_vector,
+void JSONStructureNode::RefineCandidateTypesObject(yyjson_val *vals[], const idx_t val_count, Vector &string_vector,
                                                    ArenaAllocator &allocator, DateFormatMap &date_format_map) {
 	D_ASSERT(descriptions.size() == 1 && descriptions[0].type == LogicalTypeId::STRUCT);
 	auto &desc = descriptions[0];
@@ -188,22 +192,21 @@ void JSONStructureNode::RefineCandidateTypesObject(yyjson_val *vals[], idx_t val
 		    reinterpret_cast<yyjson_val **>(allocator.AllocateAligned(val_count * sizeof(yyjson_val *))));
 	}
 
-	idx_t found_key_count;
-	auto found_keys = reinterpret_cast<bool *>(allocator.AllocateAligned(sizeof(bool) * child_count));
+	const auto found_keys = reinterpret_cast<bool *>(allocator.AllocateAligned(sizeof(bool) * child_count));
 
 	const auto &key_map = desc.key_map;
 	size_t idx, max;
 	yyjson_val *child_key, *child_val;
 	for (idx_t i = 0; i < val_count; i++) {
 		if (vals[i] && !unsafe_yyjson_is_null(vals[i])) {
-			found_key_count = 0;
+			idx_t found_key_count = 0;
 			memset(found_keys, false, child_count);
 
 			D_ASSERT(yyjson_is_obj(vals[i]));
 			yyjson_obj_foreach(vals[i], idx, max, child_key, child_val) {
 				D_ASSERT(yyjson_is_str(child_key));
-				auto key_ptr = unsafe_yyjson_get_str(child_key);
-				auto key_len = unsafe_yyjson_get_len(child_key);
+				const auto key_ptr = unsafe_yyjson_get_str(child_key);
+				const auto key_len = unsafe_yyjson_get_len(child_key);
 				auto it = key_map.find({key_ptr, key_len});
 				D_ASSERT(it != key_map.end());
 				const auto child_idx = it->second;
@@ -233,7 +236,7 @@ void JSONStructureNode::RefineCandidateTypesObject(yyjson_val *vals[], idx_t val
 	}
 }
 
-void JSONStructureNode::RefineCandidateTypesString(yyjson_val *vals[], idx_t val_count, Vector &string_vector,
+void JSONStructureNode::RefineCandidateTypesString(yyjson_val *vals[], const idx_t val_count, Vector &string_vector,
                                                    DateFormatMap &date_format_map) {
 	D_ASSERT(descriptions.size() == 1 && descriptions[0].type == LogicalTypeId::VARCHAR);
 	if (descriptions[0].candidate_types.empty()) {
@@ -244,7 +247,7 @@ void JSONStructureNode::RefineCandidateTypesString(yyjson_val *vals[], idx_t val
 	EliminateCandidateTypes(val_count, string_vector, date_format_map);
 }
 
-void JSONStructureNode::EliminateCandidateTypes(idx_t vec_count, Vector &string_vector,
+void JSONStructureNode::EliminateCandidateTypes(const idx_t vec_count, Vector &string_vector,
                                                 DateFormatMap &date_format_map) {
 	D_ASSERT(descriptions.size() == 1 && descriptions[0].type == LogicalTypeId::VARCHAR);
 	auto &description = descriptions[0];
@@ -298,12 +301,12 @@ bool TryParse(Vector &string_vector, StrpTimeFormat &format, const idx_t count) 
 	return true;
 }
 
-bool JSONStructureNode::EliminateCandidateFormats(idx_t vec_count, Vector &string_vector, Vector &result_vector,
-                                                  vector<StrpTimeFormat> &formats) {
+bool JSONStructureNode::EliminateCandidateFormats(const idx_t vec_count, Vector &string_vector,
+                                                  const Vector &result_vector, vector<StrpTimeFormat> &formats) {
 	D_ASSERT(descriptions.size() == 1 && descriptions[0].type == LogicalTypeId::VARCHAR);
 	const auto type = result_vector.GetType().id();
 	for (idx_t i = formats.size(); i != 0; i--) {
-		idx_t actual_index = i - 1;
+		const idx_t actual_index = i - 1;
 		auto &format = formats[actual_index];
 		bool success;
 		switch (type) {
@@ -326,21 +329,22 @@ bool JSONStructureNode::EliminateCandidateFormats(idx_t vec_count, Vector &strin
 	return false;
 }
 
-JSONStructureDescription::JSONStructureDescription(LogicalTypeId type_p) : type(type_p) {
+JSONStructureDescription::JSONStructureDescription(const LogicalTypeId type_p) : type(type_p) {
+}
+
+static void SwapJSONStructureDescription(JSONStructureDescription &a, JSONStructureDescription &b) noexcept {
+	std::swap(a.type, b.type);
+	std::swap(a.key_map, b.key_map);
+	std::swap(a.children, b.children);
+	std::swap(a.candidate_types, b.candidate_types);
 }
 
 JSONStructureDescription::JSONStructureDescription(JSONStructureDescription &&other) noexcept {
-	std::swap(type, other.type);
-	std::swap(key_map, other.key_map);
-	std::swap(children, other.children);
-	std::swap(candidate_types, other.candidate_types);
+	SwapJSONStructureDescription(*this, other);
 }
 
 JSONStructureDescription &JSONStructureDescription::operator=(JSONStructureDescription &&other) noexcept {
-	std::swap(type, other.type);
-	std::swap(key_map, other.key_map);
-	std::swap(children, other.children);
-	std::swap(candidate_types, other.candidate_types);
+	SwapJSONStructureDescription(*this, other);
 	return *this;
 }
 
@@ -358,8 +362,8 @@ JSONStructureNode &JSONStructureDescription::GetOrCreateChild(yyjson_val *key, y
 	D_ASSERT(yyjson_is_str(key));
 	// Check if there is already a child with the same key
 	idx_t child_idx;
-	JSONKey temp_key {unsafe_yyjson_get_str(key), unsafe_yyjson_get_len(key)};
-	auto it = key_map.find(temp_key);
+	const JSONKey temp_key {unsafe_yyjson_get_str(key), unsafe_yyjson_get_len(key)};
+	const auto it = key_map.find(temp_key);
 	if (it == key_map.end()) { // Didn't find, create a new child
 		child_idx = children.size();
 		children.emplace_back(key, val, ignore_errors);
@@ -373,7 +377,7 @@ JSONStructureNode &JSONStructureDescription::GetOrCreateChild(yyjson_val *key, y
 	return children[child_idx];
 }
 
-static inline void ExtractStructureArray(yyjson_val *arr, JSONStructureNode &node, const bool ignore_errors) {
+static void ExtractStructureArray(yyjson_val *arr, JSONStructureNode &node, const bool ignore_errors) {
 	D_ASSERT(yyjson_is_arr(arr));
 	auto &description = node.GetOrCreateDescription(LogicalTypeId::LIST);
 	auto &child = description.GetOrCreateChild();
@@ -385,7 +389,7 @@ static inline void ExtractStructureArray(yyjson_val *arr, JSONStructureNode &nod
 	}
 }
 
-static inline void ExtractStructureObject(yyjson_val *obj, JSONStructureNode &node, const bool ignore_errors) {
+static void ExtractStructureObject(yyjson_val *obj, JSONStructureNode &node, const bool ignore_errors) {
 	D_ASSERT(yyjson_is_obj(obj));
 	auto &description = node.GetOrCreateDescription(LogicalTypeId::STRUCT);
 
@@ -411,7 +415,7 @@ static inline void ExtractStructureObject(yyjson_val *obj, JSONStructureNode &no
 	}
 }
 
-static inline void ExtractStructureVal(yyjson_val *val, JSONStructureNode &node) {
+static void ExtractStructureVal(yyjson_val *val, JSONStructureNode &node) {
 	D_ASSERT(!yyjson_is_arr(val) && !yyjson_is_obj(val));
 	node.GetOrCreateDescription(JSONCommon::ValTypeToLogicalTypeId(val));
 }
@@ -422,7 +426,12 @@ void JSONStructure::ExtractStructure(yyjson_val *val, JSONStructureNode &node, c
 	}
 
 	node.count++;
-	switch (yyjson_get_tag(val)) {
+	const auto tag = yyjson_get_tag(val);
+	if (tag == (YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE)) {
+		node.null_count++;
+	}
+
+	switch (tag) {
 	case YYJSON_TYPE_ARR | YYJSON_SUBTYPE_NONE:
 		return ExtractStructureArray(val, node, ignore_errors);
 	case YYJSON_TYPE_OBJ | YYJSON_SUBTYPE_NONE:
@@ -439,19 +448,19 @@ JSONStructureNode ExtractStructureInternal(yyjson_val *val, const bool ignore_er
 }
 
 //! Forward declaration for recursion
-static inline yyjson_mut_val *ConvertStructure(const JSONStructureNode &node, yyjson_mut_doc *doc);
+static yyjson_mut_val *ConvertStructure(const JSONStructureNode &node, yyjson_mut_doc *doc);
 
-static inline yyjson_mut_val *ConvertStructureArray(const JSONStructureNode &node, yyjson_mut_doc *doc) {
+static yyjson_mut_val *ConvertStructureArray(const JSONStructureNode &node, yyjson_mut_doc *doc) {
 	D_ASSERT(node.descriptions.size() == 1 && node.descriptions[0].type == LogicalTypeId::LIST);
 	const auto &desc = node.descriptions[0];
 	D_ASSERT(desc.children.size() == 1);
 
-	auto arr = yyjson_mut_arr(doc);
+	const auto arr = yyjson_mut_arr(doc);
 	yyjson_mut_arr_append(arr, ConvertStructure(desc.children[0], doc));
 	return arr;
 }
 
-static inline yyjson_mut_val *ConvertStructureObject(const JSONStructureNode &node, yyjson_mut_doc *doc) {
+static yyjson_mut_val *ConvertStructureObject(const JSONStructureNode &node, yyjson_mut_doc *doc) {
 	D_ASSERT(node.descriptions.size() == 1 && node.descriptions[0].type == LogicalTypeId::STRUCT);
 	auto &desc = node.descriptions[0];
 	if (desc.children.empty()) {
@@ -459,7 +468,7 @@ static inline yyjson_mut_val *ConvertStructureObject(const JSONStructureNode &no
 		return yyjson_mut_str(doc, LogicalType::JSON_TYPE_NAME);
 	}
 
-	auto obj = yyjson_mut_obj(doc);
+	const auto obj = yyjson_mut_obj(doc);
 	for (auto &child : desc.children) {
 		D_ASSERT(child.key);
 		yyjson_mut_obj_add(obj, yyjson_mut_strn(doc, child.key->c_str(), child.key->length()),
@@ -468,7 +477,7 @@ static inline yyjson_mut_val *ConvertStructureObject(const JSONStructureNode &no
 	return obj;
 }
 
-static inline yyjson_mut_val *ConvertStructure(const JSONStructureNode &node, yyjson_mut_doc *doc) {
+static yyjson_mut_val *ConvertStructure(const JSONStructureNode &node, yyjson_mut_doc *doc) {
 	if (node.descriptions.empty()) {
 		return yyjson_mut_str(doc, JSONCommon::TYPE_STRING_NULL);
 	}
@@ -487,7 +496,7 @@ static inline yyjson_mut_val *ConvertStructure(const JSONStructureNode &node, yy
 	}
 }
 
-static inline string_t JSONStructureFunction(yyjson_val *val, yyjson_alc *alc, Vector &) {
+static string_t JSONStructureFunction(yyjson_val *val, yyjson_alc *alc, Vector &) {
 	return JSONCommon::WriteVal<yyjson_mut_val>(
 	    ConvertStructure(ExtractStructureInternal(val, true), yyjson_mut_doc_new(alc)), alc);
 }
@@ -510,14 +519,14 @@ ScalarFunctionSet JSONFunctions::GetStructureFunction() {
 
 static LogicalType StructureToTypeArray(ClientContext &context, const JSONStructureNode &node, const idx_t max_depth,
                                         const double field_appearance_threshold, const idx_t map_inference_threshold,
-                                        idx_t depth, const idx_t sample_count, const LogicalType &null_type) {
+                                        const idx_t depth, const LogicalType &null_type) {
 	D_ASSERT(node.descriptions.size() == 1 && node.descriptions[0].type == LogicalTypeId::LIST);
 	const auto &desc = node.descriptions[0];
 	D_ASSERT(desc.children.size() == 1);
 
 	return LogicalType::LIST(JSONStructure::StructureToType(context, desc.children[0], max_depth,
 	                                                        field_appearance_threshold, map_inference_threshold,
-	                                                        depth + 1, desc.children[0].count, null_type));
+	                                                        depth + 1, null_type));
 }
 
 static void MergeNodes(JSONStructureNode &merged, const JSONStructureNode &node, const idx_t max_depth,
@@ -528,6 +537,7 @@ static void MergeNodes(JSONStructureNode &merged, const JSONStructureNode &node,
 	}
 
 	merged.count += node.count;
+	merged.null_count += node.null_count;
 	for (const auto &desc : node.descriptions) {
 		D_ASSERT(desc.type != LogicalTypeId::INVALID);
 		switch (desc.type) {
@@ -665,10 +675,11 @@ static double CalculateTypeSimilarity(const LogicalType &merged, const LogicalTy
 }
 
 static bool IsStructureInconsistent(const JSONStructureDescription &desc, const idx_t sample_count,
-                                    const double field_appearance_threshold) {
+                                    const idx_t null_count, const double field_appearance_threshold) {
+	D_ASSERT(sample_count > null_count);
 	double total_child_counts = 0;
 	for (const auto &child : desc.children) {
-		total_child_counts += static_cast<double>(child.count) / static_cast<double>(sample_count);
+		total_child_counts += static_cast<double>(child.count) / static_cast<double>(sample_count - null_count);
 	}
 	const auto avg_occurrence = total_child_counts / static_cast<double>(desc.children.size());
 	return avg_occurrence < field_appearance_threshold;
@@ -682,12 +693,12 @@ static LogicalType GetMergedType(ClientContext &context, const JSONStructureDesc
 		MergeNodes(merged, child, max_depth, depth + 1);
 	}
 	return JSONStructure::StructureToType(context, merged, max_depth, field_appearance_threshold,
-	                                      map_inference_threshold, depth + 1, merged.count, null_type);
+	                                      map_inference_threshold, depth + 1, null_type);
 }
 
 static LogicalType StructureToTypeObject(ClientContext &context, const JSONStructureNode &node, const idx_t max_depth,
                                          const double field_appearance_threshold, const idx_t map_inference_threshold,
-                                         idx_t depth, const idx_t sample_count, const LogicalType &null_type) {
+                                         const idx_t depth, const LogicalType &null_type) {
 	D_ASSERT(node.descriptions.size() == 1 && node.descriptions[0].type == LogicalTypeId::STRUCT);
 	auto &desc = node.descriptions[0];
 
@@ -698,7 +709,7 @@ static LogicalType StructureToTypeObject(ClientContext &context, const JSONStruc
 	}
 
 	// If it's an inconsistent object we also just do MAP with the best-possible, recursively-merged value type
-	if (IsStructureInconsistent(desc, sample_count, field_appearance_threshold)) {
+	if (IsStructureInconsistent(desc, node.count, node.null_count, field_appearance_threshold)) {
 		return LogicalType::MAP(LogicalType::VARCHAR,
 		                        GetMergedType(context, desc, max_depth, field_appearance_threshold,
 		                                      map_inference_threshold, depth + 1, null_type));
@@ -709,9 +720,9 @@ static LogicalType StructureToTypeObject(ClientContext &context, const JSONStruc
 	child_types.reserve(desc.children.size());
 	for (auto &child : desc.children) {
 		D_ASSERT(child.key);
-		child_types.emplace_back(
-		    *child.key, JSONStructure::StructureToType(context, child, max_depth, field_appearance_threshold,
-		                                               map_inference_threshold, depth + 1, sample_count, null_type));
+		child_types.emplace_back(*child.key,
+		                         JSONStructure::StructureToType(context, child, max_depth, field_appearance_threshold,
+		                                                        map_inference_threshold, depth + 1, null_type));
 	}
 
 	// If we have many children and all children have similar-enough types we infer map
@@ -752,7 +763,7 @@ static LogicalType StructureToTypeString(const JSONStructureNode &node) {
 
 LogicalType JSONStructure::StructureToType(ClientContext &context, const JSONStructureNode &node, const idx_t max_depth,
                                            const double field_appearance_threshold, const idx_t map_inference_threshold,
-                                           idx_t depth, idx_t sample_count, const LogicalType &null_type) {
+                                           const idx_t depth, const LogicalType &null_type) {
 	if (depth >= max_depth) {
 		return LogicalType::JSON();
 	}
@@ -762,16 +773,15 @@ LogicalType JSONStructure::StructureToType(ClientContext &context, const JSONStr
 	if (node.descriptions.size() != 1) { // Inconsistent types, so we resort to JSON
 		return LogicalType::JSON();
 	}
-	sample_count = sample_count == DConstants::INVALID_INDEX ? node.count : sample_count;
 	auto &desc = node.descriptions[0];
 	D_ASSERT(desc.type != LogicalTypeId::INVALID);
 	switch (desc.type) {
 	case LogicalTypeId::LIST:
 		return StructureToTypeArray(context, node, max_depth, field_appearance_threshold, map_inference_threshold,
-		                            depth, sample_count, null_type);
+		                            depth, null_type);
 	case LogicalTypeId::STRUCT:
 		return StructureToTypeObject(context, node, max_depth, field_appearance_threshold, map_inference_threshold,
-		                             depth, sample_count, null_type);
+		                             depth, null_type);
 	case LogicalTypeId::VARCHAR:
 		return StructureToTypeString(node);
 	case LogicalTypeId::UBIGINT:

--- a/test/sql/json/issues/issue12861.test
+++ b/test/sql/json/issues/issue12861.test
@@ -1,0 +1,30 @@
+# name: test/sql/json/issues/issue12861.test
+# description: Test issue 12861 - Autodetected type of nested JSON field in read_json_auto depends on amount of null values in input
+# group: [issues]
+
+require json
+
+statement ok
+create table tbl (test struct(one bigint, two varchar));
+
+statement ok
+insert into tbl values ({'one': 1, 'two': 2}), (null)
+
+statement ok
+copy tbl to '__TEST_DIR__/fewnulls.json'
+
+statement ok
+insert into tbl select null from range(9)
+
+statement ok
+copy tbl to '__TEST_DIR__/manynulls.json'
+
+query I
+select typeof(test) from '__TEST_DIR__/fewnulls.json' limit 1
+----
+STRUCT(one BIGINT, two VARCHAR)
+
+query I
+select typeof(test) from '__TEST_DIR__/manynulls.json' limit 1
+----
+STRUCT(one BIGINT, two VARCHAR)


### PR DESCRIPTION
This PR fixes issue #12861 and cleans up the json_structure source code a bit.

Counts `null`s when auto-detecting JSON schema and takes these out of the equation when converting to a DuckDB type.