### PR TITLE
Make `ErrorData::Message()` and `ErrorData::RawMessage()` const

### DIFF
--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -17,10 +17,12 @@ ErrorData::ErrorData(const std::exception &ex) : ErrorData(ex.what()) {
 }
 
 ErrorData::ErrorData(ExceptionType type, const string &message)
-    : initialized(true), type(type), raw_message(SanitizeErrorMessage(message)) {
+    : initialized(true), type(type), raw_message(SanitizeErrorMessage(message)),
+      final_message(ConstructFinalMessage()) {
 }
 
-ErrorData::ErrorData(const string &message) : initialized(true), type(ExceptionType::INVALID), raw_message(string()) {
+ErrorData::ErrorData(const string &message)
+    : initialized(true), type(ExceptionType::INVALID), raw_message(string()), final_message(string()) {
 
 	// parse the constructed JSON
 	if (message.empty() || message[0] != '{') {
@@ -29,11 +31,9 @@ ErrorData::ErrorData(const string &message) : initialized(true), type(ExceptionT
 		if (message == std::bad_alloc().what()) {
 			type = ExceptionType::OUT_OF_MEMORY;
 			raw_message = "Allocation failure";
-			return;
+		} else {
+			raw_message = message;
 		}
-
-		raw_message = message;
-		return;
 	} else {
 		auto info = StringUtil::ParseJSONMap(message);
 		for (auto &entry : info) {
@@ -46,25 +46,26 @@ ErrorData::ErrorData(const string &message) : initialized(true), type(ExceptionT
 			}
 		}
 	}
-}
 
-const string &ErrorData::Message() const {
-	if (final_message.empty()) {
-		if (type != ExceptionType::UNKNOWN_TYPE) {
-			final_message = Exception::ExceptionTypeToString(type) + " ";
-		}
-		final_message += "Error: " + raw_message;
-		if (type == ExceptionType::INTERNAL) {
-			final_message += "\nThis error signals an assertion failure within DuckDB. This usually occurs due to "
-			                 "unexpected conditions or errors in the program's logic.\nFor more information, see "
-			                 "https://duckdb.org/docs/dev/internal_errors";
-		}
-	}
-	return final_message;
+	final_message = ConstructFinalMessage();
 }
 
 string ErrorData::SanitizeErrorMessage(string error) {
 	return StringUtil::Replace(std::move(error), string("\0", 1), "\\0");
+}
+
+string ErrorData::ConstructFinalMessage() const {
+	std::string error;
+	if (type != ExceptionType::UNKNOWN_TYPE) {
+		error = Exception::ExceptionTypeToString(type) + " ";
+	}
+	error += "Error: " + raw_message;
+	if (type == ExceptionType::INTERNAL) {
+		error += "\nThis error signals an assertion failure within DuckDB. This usually occurs due to "
+		         "unexpected conditions or errors in the program's logic.\nFor more information, see "
+		         "https://duckdb.org/docs/dev/internal_errors";
+	}
+	return error;
 }
 
 void ErrorData::Throw(const string &prepended_message) const {
@@ -107,6 +108,7 @@ void ErrorData::AddErrorLocation(const string &query) {
 		return;
 	}
 	raw_message = QueryErrorContext::Format(query, raw_message, std::stoull(entry->second));
+	final_message = ConstructFinalMessage();
 }
 
 void ErrorData::AddQueryLocation(optional_idx query_location) {

--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -48,7 +48,7 @@ ErrorData::ErrorData(const string &message) : initialized(true), type(ExceptionT
 	}
 }
 
-const string &ErrorData::Message() {
+const string &ErrorData::Message() const {
 	if (final_message.empty()) {
 		if (type != ExceptionType::UNKNOWN_TYPE) {
 			final_message = Exception::ExceptionTypeToString(type) + " ";

--- a/src/include/duckdb/common/error_data.hpp
+++ b/src/include/duckdb/common/error_data.hpp
@@ -32,7 +32,9 @@ public:
 	//! Get the internal exception type of the error
 	DUCKDB_API const ExceptionType &Type() const;
 	//! Used in clients like C-API, creates the final message and returns a reference to it
-	DUCKDB_API const string &Message() const;
+	DUCKDB_API const string &Message() const {
+		return final_message;
+	}
 	DUCKDB_API const string &RawMessage() const {
 		return raw_message;
 	}
@@ -61,12 +63,13 @@ private:
 	//! The message the exception was constructed with (does not contain the Exception Type)
 	string raw_message;
 	//! The final message (stored in the preserved error for compatibility reasons with C-API)
-	mutable string final_message;
+	string final_message;
 	//! Extra exception info
 	unordered_map<string, string> extra_info;
 
 private:
 	DUCKDB_API static string SanitizeErrorMessage(string error);
+	DUCKDB_API string ConstructFinalMessage() const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/error_data.hpp
+++ b/src/include/duckdb/common/error_data.hpp
@@ -32,8 +32,8 @@ public:
 	//! Get the internal exception type of the error
 	DUCKDB_API const ExceptionType &Type() const;
 	//! Used in clients like C-API, creates the final message and returns a reference to it
-	DUCKDB_API const string &Message();
-	DUCKDB_API const string &RawMessage() {
+	DUCKDB_API const string &Message() const;
+	DUCKDB_API const string &RawMessage() const {
 		return raw_message;
 	}
 	DUCKDB_API bool operator==(const ErrorData &other) const;
@@ -61,7 +61,7 @@ private:
 	//! The message the exception was constructed with (does not contain the Exception Type)
 	string raw_message;
 	//! The final message (stored in the preserved error for compatibility reasons with C-API)
-	string final_message;
+	mutable string final_message;
 	//! Extra exception info
 	unordered_map<string, string> extra_info;
 


### PR DESCRIPTION
I was writing a few functions the other day that take an `ErrorData` object as argument and call its `Message()` method. I wanted to make the`ErrorData` argument `const`, but this didn't work because `Message()` is not a const method, even though it does not change the visible state of the object. This is because it changes the private member [`final_message`](https://github.com/duckdb/duckdb/blob/cc2dc1d6d4b29b1b20c94e70061de2f441b794a1/src/include/duckdb/common/error_data.hpp#L64).

Since `final_message` is some internal state used for lazy evaluation and changing this field does not affect the logical "constness" of the object, I propose to mark this member as `mutable` and make `RawMessage()`/`Message()` const methods.