### PR TITLE
[Dev] Fix failing test in `test_relation_api.cpp`

### DIFF
--- a/test/api/test_relation_api.cpp
+++ b/test/api/test_relation_api.cpp
@@ -101,7 +101,7 @@ TEST_CASE("Test simple relation API", "[relation_api]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {2}));
 
 	// filters can also contain conjunctions
-	REQUIRE_NOTHROW(result = proj->Filter("a=2 OR a=4")->Execute());
+	REQUIRE_NOTHROW(result = proj->Filter("a=2 OR a=4")->Order("1")->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {2, 2, 4, 4}));
 
 	// alias


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/2480

tested with
`STANDARD_VECTOR_SIZE=2 make release`

`./build/release/test/unittest "[relation_api]"`