### PR TITLE
Do not depend on manylinux extension in Python's CI

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -117,6 +117,7 @@ jobs:
    manylinux-extensions-x64:
     name: Linux Extensions (linux_amd64_gcc4)
     runs-on: ubuntu-latest
+    if: false
     container: quay.io/pypa/manylinux2014_x86_64
     needs: linux-python3-9
     env:
@@ -184,7 +185,6 @@ jobs:
             python_build: 'cp311-*'
           - isRelease: false
             arch: aarch64
-    needs: manylinux-extensions-x64
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
       CIBW_SKIP: '*-musllinux_aarch64'
@@ -230,12 +230,6 @@ jobs:
       run: |
         pip install 'cibuildwheel>=2.16.2' build
         python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"
-
-    - uses: actions/download-artifact@v3
-      if: ${{ matrix.arch == 'x86_64' }}
-      with:
-        name: manylinux-extensions-x64
-        path: tools/pythonpkg
 
     - name: List extensions to be tested
       shell: bash
@@ -460,6 +454,7 @@ jobs:
       - osx-python3
       - win-python3
       - linux-python3
+      - manylinux-extensions-x64
     # Note that want to run this by default ONLY if no override_git_describe is provided
     # This means we are not staging a release
     if: (( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' )) && (( inputs.override_git_describe == '' )) && (( github.repository == 'duckdb/duckdb' ))


### PR DESCRIPTION
Avoid publishing Python wheels for now, given they are not functional on Linux

Similar to https://github.com/duckdb/duckdb/pull/12891, where we avoid CI that we know will fail.

This requires a bigger rework connected to manylinux / containerized builds, but that should not block regular testing of PRs.