### PR TITLE
[Dev] Skip `test_run_pandas_with_tz` on pandas <2.0.0

### DIFF
--- a/tools/pythonpkg/tests/fast/pandas/test_pandas_timestamp.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_pandas_timestamp.py
@@ -4,9 +4,11 @@ import pytest
 
 from datetime import datetime
 from pytz import timezone
+from conftest import pandas_2_or_higher
 
 
 @pytest.mark.parametrize('timezone', ['UTC', 'CET', 'Asia/Kathmandu'])
+@pytest.mark.skipif(not pandas_2_or_higher(), reason="Pandas <2.0.0 does not support timezones in the metadata string")
 def test_run_pandas_with_tz(timezone):
     con = duckdb.connect()
     con.execute(f"SET TimeZone = '{timezone}'")


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2463