### PR TITLE
Fix #12688: Julia SubString handling

### DIFF
--- a/tools/juliapkg/src/statement.jl
+++ b/tools/juliapkg/src/statement.jl
@@ -49,10 +49,11 @@ duckdb_bind_internal(stmt::Stmt, i::Integer, val::DateTime) =
     duckdb_bind_timestamp(stmt.handle, i, value_to_duckdb(val));
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::Missing) = duckdb_bind_null(stmt.handle, i);
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::Nothing) = duckdb_bind_null(stmt.handle, i);
-duckdb_bind_internal(stmt::Stmt, i::Integer, val::AbstractString) = duckdb_bind_varchar(stmt.handle, i, val);
+duckdb_bind_internal(stmt::Stmt, i::Integer, val::AbstractString) =
+    duckdb_bind_varchar_length(stmt.handle, i, val, ncodeunits(val));
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::Vector{UInt8}) = duckdb_bind_blob(stmt.handle, i, val, sizeof(val));
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::WeakRefString{UInt8}) =
-    duckdb_bind_varchar(stmt.handle, i, val.ptr, val.len);
+    duckdb_bind_varchar_length(stmt.handle, i, val.ptr, val.len);
 
 function duckdb_bind_internal(stmt::Stmt, i::Integer, val::Any)
     println(val)

--- a/tools/juliapkg/test/test_basic_queries.jl
+++ b/tools/juliapkg/test/test_basic_queries.jl
@@ -71,6 +71,11 @@ SELECT '🦆🍞🦆'
     @test size(df, 1) == 5
     @test isequal(df.s, ["hello world", missing, "this is a long string", "obligatory mühleisen", "🦆🍞🦆"])
 
+    for s in ["foo", "🦆DB", SubString("foobar", 1, 3), SubString("🦆ling", 1, 6)]
+        results = DBInterface.execute(con, "SELECT length(?) as len", [s])
+        @test only(results).len == 3
+    end
+
     DBInterface.close!(con)
 end
 


### PR DESCRIPTION
Use `duckdb_bind_varchar_length` instead of `duckdb_bind_varchar`, because not all Julia strings are null-terminated.