### PR TITLE
[CHORE]: Fix minor SQL test case

### DIFF
--- a/test/optimizer/statistics/statistics_between.test
+++ b/test/optimizer/statistics/statistics_between.test
@@ -132,6 +132,20 @@ SELECT i BETWEEN -1 AND 0 FROM (SELECT * FROM integers LIMIT 10) integers(i);
 0
 0
 
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY;
+
+# wide between: both are always true, entire filter can be pruned. (happens during physical planning).
+# see https://github.com/duckdb/duckdb-fuzzer/issues/1357
+# https://github.com/duckdb/duckdb-fuzzer/issues/1358
+query II
+EXPLAIN SELECT * FROM (SELECT * FROM integers LIMIT 10) integers(i) WHERE i BETWEEN 0 AND 10;
+----
+physical_plan	<!REGEX>:.*FILTER.*
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
 # now insert a null value
 statement ok
 INSERT INTO integers VALUES (NULL)
@@ -141,6 +155,12 @@ query II
 EXPLAIN SELECT * FROM (SELECT * FROM integers LIMIT 10) integers(i) WHERE i BETWEEN -1 AND 0;
 ----
 logical_opt	<REGEX>:.*EMPTY_RESULT.*
+
+# between is always false or null: we can still prune the entire filter
+query II
+EXPLAIN SELECT * FROM (SELECT * FROM integers LIMIT 10) integers(i) WHERE i BETWEEN -1 AND 0;
+----
+logical_opt	<!REGEX>:.*FILTER.*
 
 # however, if used in a select clause, we can only replace it with a constant_or_null clause
 query II
@@ -173,13 +193,3 @@ SELECT * FROM (SELECT * FROM integers LIMIT 10) integers(i) WHERE i BETWEEN 0 AN
 2
 3
 
-statement ok
-PRAGMA explain_output = PHYSICAL_ONLY;
-
-# wide between: both are always true, entire filter can be pruned. (happens during physical planning).
-# see https://github.com/duckdb/duckdb-fuzzer/issues/1357
-# https://github.com/duckdb/duckdb-fuzzer/issues/1358
-query II
-EXPLAIN SELECT * FROM (SELECT * FROM integers LIMIT 10) integers(i) WHERE i BETWEEN 0 AND 10;
-----
-physical_plan	<!REGEX>:.*FILTER*

--- a/test/optimizer/statistics/statistics_between.test
+++ b/test/optimizer/statistics/statistics_between.test
@@ -192,4 +192,3 @@ SELECT * FROM (SELECT * FROM integers LIMIT 10) integers(i) WHERE i BETWEEN 0 AN
 1
 2
 3
-


### PR DESCRIPTION
closes https://github.com/duckdblabs/duckdb-internal/issues/2482

In the linked PR, the test was moved to the bottom of the `statistics_between.test` test file. However, it seems like the regex was incorrectly copied. This PR should fix that. [Original PR that moved the test](https://github.com/duckdb/duckdb/pull/10553)

