### PR TITLE
[Postgres Compatiblity] Support `=>` to supply named parameters to functions

### DIFF
--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -118,6 +118,9 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 					child = std::move(comp.right);
 				}
 			}
+		} else if (!child->alias.empty()) {
+			// <name> => <expression> will set the alias of <expression> to <name>
+			parameter_name = child->alias;
 		}
 		if (bind_type == TableFunctionBindType::TABLE_PARAMETER_FUNCTION && child->type == ExpressionType::SUBQUERY) {
 			D_ASSERT(table_function.functions.Size() == 1);

--- a/test/issues/general/test_2416.test
+++ b/test/issues/general/test_2416.test
@@ -157,7 +157,7 @@ SELECT my_struct_extract_c({a: 1, b: 2, d: 4})
 ----
 
 statement ok
-CREATE MACRO my_specific_struct_extract(field) AS struct_pack(a:= 1, b:= 2, c:= 3, d:= 4)[field]
+CREATE MACRO my_specific_struct_extract(field) AS struct_pack(a => 1, b => 2, c => 3, d => 4)[field]
 
 query T
 SELECT my_specific_struct_extract('c')

--- a/test/sql/aggregate/aggregates/histogram_table_function.test
+++ b/test/sql/aggregate/aggregates/histogram_table_function.test
@@ -26,7 +26,7 @@ statement ok
 INSERT INTO integers FROM range(127)
 
 query II
-SELECT * FROM histogram_values(integers, i, bin_count := 10, technique := 'equi-width')
+SELECT * FROM histogram_values(integers, i, bin_count => 10, technique => 'equi-width')
 ----
 12	13
 25	13

--- a/test/sql/copy/csv/test_null_padding_projection.test
+++ b/test/sql/copy/csv/test_null_padding_projection.test
@@ -46,7 +46,7 @@ NULL	NULL
 # Now let's try with options that give a const value
 query IIIII
 from read_csv('data/csv/nullpadding.csv',null_padding=true, columns={
-'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect = false, ignore_errors = true, filename = true);
+'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect => false, ignore_errors => true, filename => true);
 ----
 10	100	1000	NULL	data/csv/nullpadding.csv
 10	100	1000	10000	data/csv/nullpadding.csv
@@ -55,7 +55,7 @@ from read_csv('data/csv/nullpadding.csv',null_padding=true, columns={
 
 query II
 select a, filename from read_csv('data/csv/nullpadding.csv',null_padding=true, columns={
-'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect = false, ignore_errors = true, filename = true);
+'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect => false, ignore_errors => true, filename => true);
 ----
 10	data/csv/nullpadding.csv
 10	data/csv/nullpadding.csv
@@ -64,7 +64,7 @@ select a, filename from read_csv('data/csv/nullpadding.csv',null_padding=true, c
 
 query I
 select filename from read_csv('data/csv/nullpadding.csv',null_padding=true, columns={
-'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect = false, ignore_errors = true, filename = true);
+'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect => false, ignore_errors => true, filename => true);
 ----
 data/csv/nullpadding.csv
 data/csv/nullpadding.csv
@@ -73,7 +73,7 @@ data/csv/nullpadding.csv
 
 query I
 select a from read_csv('data/csv/nullpadding.csv',null_padding=true, columns={
-'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect = false, ignore_errors = true, filename = true);
+'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect = false, ignore_errors => true, filename => true);
 ----
 10
 10
@@ -84,7 +84,7 @@ select a from read_csv('data/csv/nullpadding.csv',null_padding=true, columns={
 
 query IIII
 select * from read_csv('data/csv/nullpadding.csv',null_padding=true, columns={
-'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect = false, ignore_errors = true)
+'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER'}, auto_detect := false, ignore_errors := true)
 where  b = 100;
 ----
 10	100	1000	NULL
@@ -110,7 +110,7 @@ where a = 10 and d = 10000;
 
 query IIIII
 select * from read_csv('data/csv/nullpadding.csv',null_padding=true, columns={
-'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER', 'e': 'INTEGER'}, auto_detect = false)
+'a': 'INTEGER','b': 'INTEGER','c': 'INTEGER','d': 'INTEGER', 'e': 'INTEGER'}, auto_detect := false)
 ----
 10	100	1000	NULL	NULL
 10	100	1000	10000	NULL


### PR DESCRIPTION
Similar to our own `<name> := <expression>`, Postgres uses a variation of this: `<name> => <expression>` which is required to provide values for named parameters.
With this PR we now support both, this works for both scalar functions and table functions.