### PR TITLE
Fix #12870 - improve error message when encountering schema mismatches in COPY tbl FROM file.parquet

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -1046,14 +1046,33 @@ idx_t CastColumnReader::Read(uint64_t num_values, parquet_filter_t &filter, data
 	bool all_succeeded = VectorOperations::DefaultTryCast(intermediate_vector, result, amount, &error_message);
 	if (!all_succeeded) {
 		string extended_error;
-		extended_error =
-		    StringUtil::Format("In file \"%s\" the column \"%s\" has type %s, but we are trying to read it as type %s.",
-		                       reader.file_name, schema.name, intermediate_vector.GetType(), result.GetType());
-		extended_error += "\nThis can happen when reading multiple Parquet files. The schema information is taken from "
-		                  "the first Parquet file by default. Possible solutions:\n";
-		extended_error += "* Enable the union_by_name=True option to combine the schema of all Parquet files "
-		                  "(duckdb.org/docs/data/multiple_files/combining_schemas)\n";
-		extended_error += "* Use a COPY statement to automatically derive types from an existing table.";
+		if (!reader.table_columns.empty()) {
+			// COPY .. FROM
+			extended_error = StringUtil::Format(
+			    "In file \"%s\" the column \"%s\" has type %s, but we are trying to load it into column ",
+			    reader.file_name, schema.name, intermediate_vector.GetType());
+			if (FileIdx() < reader.table_columns.size()) {
+				extended_error += "\"" + reader.table_columns[FileIdx()] + "\" ";
+			}
+			extended_error += StringUtil::Format("with type %s.", result.GetType());
+			extended_error += "\nThis means the Parquet schema does not match the schema of the table.";
+			extended_error += "\nPossible solutions:";
+			extended_error += "\n* Insert by name instead of by position using \"INSERT INTO tbl BY NAME SELECT * FROM "
+			                  "read_parquet(...)\"";
+			extended_error += "\n* Manually specify which columns to insert using \"INSERT INTO tbl SELECT ... FROM "
+			                  "read_parquet(...)\"";
+		} else {
+			// read_parquet() with multiple files
+			extended_error = StringUtil::Format(
+			    "In file \"%s\" the column \"%s\" has type %s, but we are trying to read it as type %s.",
+			    reader.file_name, schema.name, intermediate_vector.GetType(), result.GetType());
+			extended_error +=
+			    "\nThis can happen when reading multiple Parquet files. The schema information is taken from "
+			    "the first Parquet file by default. Possible solutions:\n";
+			extended_error += "* Enable the union_by_name=True option to combine the schema of all Parquet files "
+			                  "(duckdb.org/docs/data/multiple_files/combining_schemas)\n";
+			extended_error += "* Use a COPY statement to automatically derive types from an existing table.";
+		}
 		throw ConversionException(
 		    "In Parquet reader of file \"%s\": failed to cast column \"%s\" from type %s to %s: %s\n\n%s",
 		    reader.file_name, schema.name, intermediate_vector.GetType(), result.GetType(), error_message,

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -135,6 +135,8 @@ public:
 	idx_t file_row_number_idx = DConstants::INVALID_INDEX;
 	//! Parquet schema for the generated columns
 	vector<duckdb_parquet::format::SchemaElement> generated_column_schema;
+	//! Table column names - set when using COPY tbl FROM file.parquet
+	vector<string> table_columns;
 
 public:
 	void InitializeScan(ClientContext &context, ParquetReaderScanState &state, vector<idx_t> groups_to_read);

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -32,8 +32,9 @@ static const StorageVersionInfo storage_version_info[] = {
 // END OF STORAGE VERSION INFO
 
 // START OF SERIALIZATION VERSION INFO
-static const SerializationVersionInfo serialization_version_info[] = {
-    {"v0.10.0", 1}, {"v0.10.1", 1}, {"v0.10.2", 1}, {"latest", 2}, {nullptr, 0}};
+static const SerializationVersionInfo serialization_version_info[] = {{"v0.10.0", 1}, {"v0.10.1", 1}, {"v0.10.2", 1},
+                                                                      {"v0.10.3", 2}, {"v1.0.0", 2},  {"v1.1.0", 3},
+                                                                      {"latest", 3},  {nullptr, 0}};
 // END OF SERIALIZATION VERSION INFO
 
 optional_idx GetStorageVersion(const char *version_string) {

--- a/test/sql/copy/parquet/parquet_copy_type_mismatch.test
+++ b/test/sql/copy/parquet/parquet_copy_type_mismatch.test
@@ -1,0 +1,43 @@
+# name: test/sql/copy/parquet/parquet_copy_type_mismatch.test
+# description: Test error message when COPY FROM finds a type mismatch
+# group: [parquet]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SET storage_compatibility_version='latest'
+
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+COPY (SELECT DATE '1992-01-01' d) TO '__TEST_DIR__/single_date.parquet' (FORMAT parquet);
+
+statement error
+COPY integers FROM '__TEST_DIR__/single_date.parquet'
+----
+the column "d" has type DATE, but we are trying to load it into column "i" with type INTEGER
+
+statement ok
+COPY (SELECT DATE '1992-01-01' d, 42 k) TO '__TEST_DIR__/too_many_columns.parquet' (FORMAT parquet);
+
+statement error
+COPY integers FROM '__TEST_DIR__/too_many_columns.parquet'
+----
+Table schema: i INTEGER
+
+# multiple files with different schema
+statement ok
+COPY (SELECT 42 i) TO '__TEST_DIR__/f2.parquet' (FORMAT parquet);
+
+statement ok
+COPY (SELECT date '1992-01-01' d, 84 i) TO '__TEST_DIR__/f1.parquet' (FORMAT parquet);
+
+# result here depends on globbing order
+statement maybe
+COPY integers FROM '__TEST_DIR__/f*.parquet' (FORMAT parquet);
+----
+column count mismatch: expected 1 columns but found 2


### PR DESCRIPTION
Fix #12870

This PR improves the error message when there are schema mismatches when copying from Parquet files into a table.

e.g.:
```sql
D create table integers(i int);
D copy (select date '1992-01-01' d) to date.parquet;
D copy integers from date.parquet;
```

```
Conversion Error: In Parquet reader of file "date.parquet": failed to cast column "d" from type DATE to INTEGER: Unimplemented type for cast (DATE -> INTEGER)

In file "date.parquet" the column "d" has type DATE, but we are trying to load it into column "i" with type INTEGER.
This means the Parquet schema does not match the schema of the table.
Possible solutions:
* Insert by name instead of by position using "INSERT INTO tbl BY NAME SELECT * FROM read_parquet(...)"
* Manually specify which columns to insert using "INSERT INTO tbl SELECT ... FROM read_parquet(...)"
```

This requires an extra field in the `ParquetBindData`. In order to not break forwards compatibility we up the storage serialization version, and only serialize this extra field when the new storage serialization version is used.