### PR TITLE
Fix #12874: regard bind fail qualified column as StructExtract

### DIFF
--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -18,28 +18,28 @@ BindResult SelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, i
 	// binding failed
 	// check in the alias map
 	auto &colref = (expr_ptr.get())->Cast<ColumnRefExpression>();
-		auto &bind_state = node.bind_state;
-		auto alias_entry = node.bind_state.alias_map.find(colref.column_names[0]);
-		if (alias_entry != node.bind_state.alias_map.end()) {
-			// found entry!
-			auto index = alias_entry->second;
-			if (index >= node.bound_column_count) {
-				throw BinderException("Column \"%s\" referenced that exists in the SELECT clause - but this column "
-				                      "cannot be referenced before it is defined",
-				                      colref.column_names[0]);
-			}
-			if (bind_state.AliasHasSubquery(index)) {
-				throw BinderException("Alias \"%s\" referenced in a SELECT clause - but the expression has a subquery."
-				                      " This is not yet supported.",
-				                      colref.column_names[0]);
-			}
-			auto copied_expression = node.bind_state.BindAlias(index);
-			for (idx_t i = 1; i < colref.column_names.size(); i++) {
-				copied_expression = CreateStructExtract(std::move(copied_expression), colref.column_names[i]);
-			}
-			result = BindExpression(copied_expression, depth, false);
-			return result;
+	auto &bind_state = node.bind_state;
+	auto alias_entry = node.bind_state.alias_map.find(colref.column_names[0]);
+	if (alias_entry != node.bind_state.alias_map.end()) {
+		// found entry!
+		auto index = alias_entry->second;
+		if (index >= node.bound_column_count) {
+			throw BinderException("Column \"%s\" referenced that exists in the SELECT clause - but this column "
+			                      "cannot be referenced before it is defined",
+			                      colref.column_names[0]);
 		}
+		if (bind_state.AliasHasSubquery(index)) {
+			throw BinderException("Alias \"%s\" referenced in a SELECT clause - but the expression has a subquery."
+			                      " This is not yet supported.",
+			                      colref.column_names[0]);
+		}
+		auto copied_expression = node.bind_state.BindAlias(index);
+		for (idx_t i = 1; i < colref.column_names.size(); i++) {
+			copied_expression = CreateStructExtract(std::move(copied_expression), colref.column_names[i]);
+		}
+		result = BindExpression(copied_expression, depth, false);
+		return result;
+	}
 	// entry was not found in the alias map: return the original error
 	return result;
 }

--- a/test/sql/types/nested/struct/test_struct.test
+++ b/test/sql/types/nested/struct/test_struct.test
@@ -96,6 +96,21 @@ SELECT e, STRUCT_EXTRACT(STRUCT_PACK(xx := e//2), 'xx')*2 as s FROM struct_data 
 5	4
 6	6
 
+query III
+SELECT {field1: 1, field2: 2} as strct, strct.field1, strct.field2
+----
+{'field1': 1, 'field2': 2}	1	2
+
+query III
+SELECT {field1: 1, field2: 2} as strct, strct['field1'], strct['field2']
+----
+{'field1': 1, 'field2': 2}	1	2
+
+query IIII
+SELECT {field1: {a: 11, b: 12}, field2: 2} as strct, strct.field1, strct.field2, strct.field1.a
+----
+{'field1': {'a': 11, 'b': 12}, 'field2': 2}	{'a': 11, 'b': 12}	2	11
+
 query II
 SELECT e, STRUCT_EXTRACT(STRUCT_PACK(xx := e, yy := g), 'xx') as ee FROM struct_data ORDER BY e DESC
 ----

--- a/test/sql/types/nested/struct/test_struct.test
+++ b/test/sql/types/nested/struct/test_struct.test
@@ -111,10 +111,10 @@ SELECT {field1: 1, field2: 2} as strct, strct.field1, strct.field3
 ----
 Binder Error: Could not find key "field3" in struct
 
-query IIII
-SELECT {field1: {a: 11, b: 12}, field2: 2} as strct, strct.field1, strct.field2, strct.field1.a
+query IIIIII
+SELECT {field1: {a: 11, b: 12}, field2: 2} as strct, strct.field1, strct.field2, strct['field1'].a, strct.field1['a'], strct.field1.a
 ----
-{'field1': {'a': 11, 'b': 12}, 'field2': 2}	{'a': 11, 'b': 12}	2	11
+{'field1': {'a': 11, 'b': 12}, 'field2': 2}	{'a': 11, 'b': 12}	2	11	11	11
 
 query IIII
 SELECT STRUCT_PACK(field1:= STRUCT_PACK(a:= 11, b:= 12), field2:= 2) as strct, strct.field1, strct.field2, strct.field1.a

--- a/test/sql/types/nested/struct/test_struct.test
+++ b/test/sql/types/nested/struct/test_struct.test
@@ -106,8 +106,18 @@ SELECT {field1: 1, field2: 2} as strct, strct['field1'], strct['field2']
 ----
 {'field1': 1, 'field2': 2}	1	2
 
+statement error
+SELECT {field1: 1, field2: 2} as strct, strct.field1, strct.field3
+----
+Binder Error: Could not find key "field3" in struct
+
 query IIII
 SELECT {field1: {a: 11, b: 12}, field2: 2} as strct, strct.field1, strct.field2, strct.field1.a
+----
+{'field1': {'a': 11, 'b': 12}, 'field2': 2}	{'a': 11, 'b': 12}	2	11
+
+query IIII
+SELECT STRUCT_PACK(field1:= STRUCT_PACK(a:= 11, b:= 12), field2:= 2) as strct, strct.field1, strct.field2, strct.field1.a
 ----
 {'field1': {'a': 11, 'b': 12}, 'field2': 2}	{'a': 11, 'b': 12}	2	11
 


### PR DESCRIPTION
This pr try to fix #12874, treat `a.b`  as `StructExtract` when bind fail