### PR TITLE
Pass 'Unsecure_node_version' to allow node16 for a bit longer

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -64,6 +64,7 @@ jobs:
       DEBUG_STACKTRACE: 1
       FORCE_WARN_UNUSED: 1
       DUCKDB_RUN_PARALLEL_CSV_TESTS: 1
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
     - name: Handrolled checkout
@@ -131,7 +132,6 @@ jobs:
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip
 
     - uses: actions/upload-artifact@v3
-      if: ${{ false }}
       with:
         name: duckdb-binaries-linux
         path: |
@@ -141,8 +141,7 @@ jobs:
  linux-release-aarch64:
    # Builds binaries for linux_arm64
    name: Linux (aarch64)
-   # if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
-   if: ${{ false }}
+   if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
    runs-on: ubuntu-latest
    needs: linux-release-64
    container: ubuntu:18.04
@@ -155,6 +154,7 @@ jobs:
      TREAT_WARNINGS_AS_ERRORS: 1
      FORCE_WARN_UNUSED: 1
      DUCKDB_PLATFORM: linux_arm64
+     ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
    steps:
      - uses: actions/checkout@v3
@@ -184,7 +184,6 @@ jobs:
          ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-aarch64.zip duckdb_cli-linux-aarch64.zip
 
      - uses: actions/upload-artifact@v3
-       if: ${{ false }}
        with:
          name: duckdb-binaries-linux-aarch64
          path: |
@@ -197,9 +196,10 @@ jobs:
     # Builds extensions for linux_amd64
     name: Linux Extensions (x64)
     runs-on: ubuntu-latest
-    if: ${{ false }}
     container: ubuntu:18.04
     needs: linux-release-64
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
     - uses: actions/checkout@v3
@@ -236,11 +236,12 @@ jobs:
  linux-extensions-64-aarch64:
     # Builds extensions for linux_arm64
     name: Linux Extensions (aarch64)
-    # if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
-    if: ${{ false }}
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     needs: linux-release-64
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -117,7 +117,6 @@ jobs:
    manylinux-extensions-x64:
     name: Linux Extensions (linux_amd64_gcc4)
     runs-on: ubuntu-latest
-    if: false
     container: quay.io/pypa/manylinux2014_x86_64
     needs: linux-python3-9
     env:
@@ -185,6 +184,7 @@ jobs:
             python_build: 'cp311-*'
           - isRelease: false
             arch: aarch64
+    needs: manylinux-extensions-x64
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
       CIBW_SKIP: '*-musllinux_aarch64'
@@ -230,6 +230,12 @@ jobs:
       run: |
         pip install 'cibuildwheel>=2.16.2' build
         python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"
+
+    - uses: actions/download-artifact@v3
+      if: ${{ matrix.arch == 'x86_64' }}
+      with:
+        name: manylinux-extensions-x64
+        path: tools/pythonpkg
 
     - name: List extensions to be tested
       shell: bash
@@ -454,7 +460,6 @@ jobs:
       - osx-python3
       - win-python3
       - linux-python3
-      - manylinux-extensions-x64
     # Note that want to run this by default ONLY if no override_git_describe is provided
     # This means we are not staging a release
     if: (( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' )) && (( inputs.override_git_describe == '' )) && (( github.repository == 'duckdb/duckdb' ))

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -121,6 +121,7 @@ jobs:
     needs: linux-python3-9
     env:
       GEN: ninja
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Revert of https://github.com/duckdb/duckdb/pull/12891, that removed some LinuxRelease.yml tests
Revert of https://github.com/duckdb/duckdb/pull/12895, that removed Python.yml extension building.

This is NOT a long term solution, but only a bridge to buy some time.

Context: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/