### PR TITLE
Minor refactor for window_executor

### DIFF
--- a/src/execution/window_executor.cpp
+++ b/src/execution/window_executor.cpp
@@ -309,7 +309,7 @@ static idx_t FindOrderedRangeBound(const WindowInputColumn &over, const OrderTyp
 
 struct WindowBoundariesState {
 	static inline bool IsScalar(const unique_ptr<Expression> &expr) {
-		return expr ? expr->IsScalar() : true;
+		return !expr || expr->IsScalar();
 	}
 
 	static inline bool BoundaryNeedsPeer(const WindowBoundary &boundary) {
@@ -1121,8 +1121,6 @@ public:
 public:
 	// state of aggregator
 	unique_ptr<WindowAggregatorState> aggregator_state;
-
-	void NextRank(idx_t partition_begin, idx_t peer_begin, idx_t row_idx);
 };
 
 unique_ptr<WindowExecutorLocalState>


### PR DESCRIPTION
1. Simplify `IsScalar` check in `WindowBoundariesState`
2. NextRank should stay in `WindowPeerState` for `WindowRankExecutor`, we needn't keep this in `WindowAggregateExecutorLocalState`