### PR TITLE
ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION:false for Android and Nightly

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -52,6 +52,7 @@ jobs:
         arch: [ armeabi-v7a, arm64-v8a ]
 
     env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       ENABLE_EXTENSION_AUTOLOADING: 1
       ENABLE_EXTENSION_AUTOINSTALL: 1
       GEN: ninja

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -154,6 +154,8 @@ jobs:
     needs: linux-memory-leaks
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
     - uses: actions/checkout@v3
       with:
@@ -181,6 +183,7 @@ jobs:
     env:
       CC: /usr/bin/gcc
       CXX: /usr/bin/g++
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - uses: actions/checkout@v3
@@ -252,6 +255,7 @@ jobs:
         GEN: ninja
         DUCKDEBUG: 1
         ASAN_OPTIONS: detect_leaks=0
+        ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
      steps:
      - uses: actions/checkout@v3


### PR DESCRIPTION
Also here, temporary workaround, but better to have those run that just fail CI and skip running the tests.

Follow up of https://github.com/duckdb/duckdb/pull/12922