### PR TITLE
Issue #12941: Window Constant Results

### DIFF
--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -312,7 +312,13 @@ void WindowConstantAggregator::Evaluate(const WindowAggregatorState &gsink, Wind
 
 	//	Flush the last partition
 	if (matched) {
-		VectorOperations::Copy(results, result, lcstate.matches, matched, 0, target_offset);
+		// Optimize constant result
+		if (target_offset == 0 && matched == count) {
+			VectorOperations::Copy(results, result, lcstate.matches, 1, 0, target_offset);
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		} else {
+			VectorOperations::Copy(results, result, lcstate.matches, matched, 0, target_offset);
+		}
 	}
 }
 


### PR DESCRIPTION
WindowConstantAggregator should return a constant vector when only one aggregate is in range.

fixes: duckdb#12941
fixes: duckdblabs/duckdb-internal#2509