### PR TITLE
Fix several CTE related issues

### DIFF
--- a/src/parser/transform/statement/transform_insert.cpp
+++ b/src/parser/transform/statement/transform_insert.cpp
@@ -42,7 +42,6 @@ unique_ptr<InsertStatement> Transformer::TransformInsert(duckdb_libpgquery::PGIn
 	}
 	if (stmt.selectStmt) {
 		result->select_statement = TransformSelect(stmt.selectStmt, false);
-		result->select_statement->node = TransformMaterializedCTE(std::move(result->select_statement->node));
 	} else {
 		result->default_values = true;
 	}

--- a/src/parser/transform/statement/transform_pivot_stmt.cpp
+++ b/src/parser/transform/statement/transform_pivot_stmt.cpp
@@ -94,7 +94,7 @@ unique_ptr<SQLStatement> Transformer::GenerateCreateEnumStmt(unique_ptr<CreatePi
 	}
 
 	auto select = make_uniq<SelectStatement>();
-	select->node = std::move(subselect);
+	select->node = TransformMaterializedCTE(std::move(subselect));
 	info->query = std::move(select);
 	info->type = LogicalType::INVALID;
 

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -146,7 +146,7 @@ BoundStatement Binder::Bind(SQLStatement &statement) {
 	case StatementType::SELECT_STATEMENT:
 		return Bind(statement.Cast<SelectStatement>());
 	case StatementType::INSERT_STATEMENT:
-		return Bind(statement.Cast<InsertStatement>());
+		return BindWithCTE(statement.Cast<InsertStatement>());
 	case StatementType::COPY_STATEMENT:
 		return Bind(statement.Cast<CopyStatement>(), CopyToType::COPY_TO_FILE);
 	case StatementType::DELETE_STATEMENT:

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -134,7 +134,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				// something is wrong.
 				if (cte.materialized == CTEMaterialize::CTE_MATERIALIZE_ALWAYS) {
 					throw BinderException(
-					    "There is a WITH item named \"%s\", but it cannot be references from this part of the query.",
+					    "There is a WITH item named \"%s\", but it cannot be referenced from this part of the query.",
 					    ref.table_name);
 				}
 

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -129,6 +129,15 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 					// retry with next candidate CTE
 					continue;
 				}
+
+				// If we have found a materialized CTE, but no corresponding CTE binding,
+				// something is wrong.
+				if (cte.materialized == CTEMaterialize::CTE_MATERIALIZE_ALWAYS) {
+					throw BinderException(
+					    "There is a WITH item named \"%s\", but it cannot be references from this part of the query.",
+					    ref.table_name);
+				}
+
 				// Move CTE to subquery and bind recursively
 				SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(cte.query->Copy()));
 				subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;

--- a/test/sql/cte/materialized/test_cte_materialized.test
+++ b/test/sql/cte/materialized/test_cte_materialized.test
@@ -48,11 +48,9 @@ with cte1 as MATERIALIZED (select 42), cte1 as MATERIALIZED (select 42) select *
 ----
 
 # reference to CTE before its actually defined
-query I
+statement error
 with cte3 as MATERIALIZED (select ref2.j as i from cte1 as ref2), cte1 as MATERIALIZED (Select i as j from a), cte2 as MATERIALIZED (select ref.j+1 as k from cte1 as ref) select * from cte2 union all select * FROM cte3;
 ----
-43
-42
 
 # multiple uses of same CTE
 query II

--- a/test/sql/cte/materialized/test_materialized_cte.test
+++ b/test/sql/cte/materialized/test_materialized_cte.test
@@ -75,3 +75,12 @@ WITH t(x) AS MATERIALIZED (SELECT 1),
 ----
 2
 1
+
+statement error
+WITH t0(x) AS MATERIALIZED (
+  SELECT x FROM t1
+), t1(x) AS MATERIALIZED (
+  SELECT 1
+)
+SELECT * FROM t0;
+----

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -130,3 +130,44 @@ from cte
 where alias2 > 0;
 ----
 1	1
+
+# recursive CTE and a non-recursive CTE with except
+query I
+WITH RECURSIVE t AS (
+  SELECT 1 AS a
+    UNION ALL
+  SELECT a+1
+  FROM t
+  WHERE a < 10
+), s AS (
+  (VALUES (5), (6), (7), (8), (9), (10), (11), (12), (13), (42))
+  EXCEPT
+  TABLE t
+)
+SELECT * FROM s AS _(x) ORDER BY x;
+----
+11
+12
+13
+42
+
+# recursive CTE with except in recursive part (but not as a recursive anchor)
+query I
+WITH RECURSIVE t AS (
+  select 1 as a
+  union all
+  (select a+1
+  from t
+  where a < 10
+  	except
+  SELECT 4)
+), s AS (
+  (values (5), (6), (7))
+  except
+  table t
+)
+SELECT * FROM s AS _(x) ORDER BY x;
+----
+5
+6
+7


### PR DESCRIPTION
This PR fixes several issues related to recursive and materialized CTEs.

1. Materialized CTEs did not work properly with `INSERT` statements.

2. `TransformRecursiveCTE` was too restrictive

```sql
WITH RECURSIVE t AS (
  SELECT 1 AS a
    UNION ALL
  SELECT a+1
  FROM t
  WHERE a < 10
), s AS (
  (VALUES (5), (6), (7), (8), (9), (10), (11), (12), (13), (42))
  EXCEPT  -- (**)
  TABLE t
)
SELECT * FROM s AS _(x) ORDER BY x;
```

The `EXCEPT -- (**)` was interpreted as a recursive set operation, which clearly is not the case. This query can now be executed, which was not possible before.

---

3. Materialized CTEs were sometimes inlined and thereby duplicated
```sql
WITH t0(x) AS MATERIALIZED (
  SELECT x FROM t1
), t1(x) AS MATERIALIZED (
  SELECT 1
)
SELECT * FROM t0;
```

_E.g._ the query above was happily accepted by the system. However, eventhough both CTEs are materialized, `t1` still appeared twice in the query plan. A new check and exception in `bind_basetableref.cpp` now prevents this from happening.

The plan before this PR:

```
┌───────────────────────────┐                                                          
│            CTE            │                                                          
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │                                                          
│             t0            ├──────────────┐                                           
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │              │                                           
│           idx: 0          │              │                                           
└─────────────┬─────────────┘              │                                                                        
┌─────────────┴─────────────┐┌─────────────┴─────────────┐                             
│         PROJECTION        ││            CTE            │                             
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   ││   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │                             
│             1             ││             t1            ├──────────────┐              
│                           ││   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │              │              
│                           ││          idx: 14          │              │              
└─────────────┬─────────────┘└─────────────┬─────────────┘              │                                           
┌─────────────┴─────────────┐┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         DUMMY_SCAN        ││         PROJECTION        ││          CTE_SCAN         │
│                           ││   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   ││   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│                           ││             1             ││           idx: 0          │
└───────────────────────────┘└─────────────┬─────────────┘└───────────────────────────┘                             
                             ┌─────────────┴─────────────┐                             
                             │         DUMMY_SCAN        │                             
                             └───────────────────────────┘ 
```

Instead of essentially giving up and throwing an exception, the system could as well perform a dependency analysis to reorder the materialized CTEs. Which could then result in the correct plan:

```
┌───────────────────────────┐                                                          
│            CTE            │                                                          
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │                                                          
│             t1            ├──────────────┐                                           
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │              │                                           
│           idx: 0          │              │                                           
└─────────────┬─────────────┘              │                                                                        
┌─────────────┴─────────────┐┌─────────────┴─────────────┐                             
│         PROJECTION        ││            CTE            │                             
│   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   ││   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │                             
│             1             ││             t0            ├──────────────┐              
│                           ││   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │              │              
│                           ││           idx: 8          │              │              
└─────────────┬─────────────┘└─────────────┬─────────────┘              │                                           
┌─────────────┴─────────────┐┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         DUMMY_SCAN        ││          CTE_SCAN         ││          CTE_SCAN         │
│                           ││   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   ││   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│                           ││           idx: 0          ││           idx: 8          │
└───────────────────────────┘└───────────────────────────┘└───────────────────────────┘
```

However, this is not part of this PR. For now, it is best (I think) to throw an exception.

4. Fix PIVOT statements after materialized CTE fixes.
  The changes to fix (3) broke MATERIALIZED CTEs in PIVOT statements. This has been fixed.