### PR TITLE
fix incorrect int32 appender

### DIFF
--- a/tools/juliapkg/Project.toml
+++ b/tools/juliapkg/Project.toml
@@ -1,7 +1,7 @@
 name = "DuckDB"
 uuid = "d2f5444f-75bc-4fdf-ac35-56f514c445e1"
 authors = ["Mark Raasveldt <mark@duckdblabs.com", "Hannes Mühleisen <hannes@duckdblabs.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"

--- a/tools/juliapkg/src/api.jl
+++ b/tools/juliapkg/src/api.jl
@@ -2610,7 +2610,7 @@ Append an int32_t value to the appender.
 DUCKDB_API duckdb_state duckdb_append_int32(duckdb_appender appender, int32_t value);
 """
 function duckdb_append_int32(appender, value)
-    return ccall((:duckdb_append_int16, libduckdb), duckdb_state, (duckdb_appender, Int32), appender, value)
+    return ccall((:duckdb_append_int32, libduckdb), duckdb_state, (duckdb_appender, Int32), appender, value)
 end
 
 """

--- a/tools/juliapkg/test/test_appender.jl
+++ b/tools/juliapkg/test/test_appender.jl
@@ -81,6 +81,7 @@ end
         (; col_name = :timestamp, duck_type = "TIMESTAMP", append_value = Dates.DateTime("1970-01-02T01:23:45.678")),
         (; col_name = :missingval, duck_type = "INTEGER", append_value = missing),
         (; col_name = :nothingval, duck_type = "INTEGER", append_value = nothing, ref_value = missing),
+        (; col_name = :largeval, duck_type = "INTEGER", append_value = Int32(2^16)),
         (; col_name = :uuid, duck_type = "UUID", append_value = uuid),
         (; col_name = :varchar, duck_type = "VARCHAR", append_value = "Foo")
     ]


### PR DESCRIPTION
Fix #12946

This PR fixes a bug in the julia client, where `Int32` values are incorrectly truncated modulo `Int16` by the appender, which is problematic for large `Int32` values (see #12946 for a more thorough description).

The fix seemed trivial so I've made a PR with the fix and added tests (the extra tests would fail on the current main branch). I've also bumped the patch number of the julia pkg version: it would be great to get a new release with the patch if that's possible