### PR TITLE
[Python] Convert ENUM to `np.array` instead of `pd.Categorical` for `fetchnumpy`

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_result_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/numpy/numpy_result_conversion.hpp
@@ -24,6 +24,9 @@ public:
 	py::object ToArray(idx_t col_idx) {
 		return owned_data[col_idx].ToArray();
 	}
+	bool ToPandas() const {
+		return pandas;
+	}
 
 private:
 	void Resize(idx_t new_capacity);
@@ -32,6 +35,7 @@ private:
 	vector<ArrayWrapper> owned_data;
 	idx_t count;
 	idx_t capacity;
+	bool pandas;
 };
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/numpy/array_wrapper.cpp
+++ b/tools/pythonpkg/src/numpy/array_wrapper.cpp
@@ -665,7 +665,8 @@ void ArrayWrapper::Append(idx_t current_offset, Vector &input, idx_t source_size
 		} else {
 			throw InternalException("Size not supported on ENUM types");
 		}
-	} break;
+		break;
+	}
 	case LogicalTypeId::BOOLEAN:
 		may_have_null = ConvertColumnRegular<bool>(append_data);
 		break;

--- a/tools/pythonpkg/src/numpy/numpy_result_conversion.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_result_conversion.cpp
@@ -5,7 +5,7 @@ namespace duckdb {
 
 NumpyResultConversion::NumpyResultConversion(const vector<LogicalType> &types, idx_t initial_capacity,
                                              const ClientProperties &client_properties, bool pandas)
-    : count(0), capacity(0) {
+    : count(0), capacity(0), pandas(pandas) {
 	owned_data.reserve(types.size());
 	for (auto &type : types) {
 		owned_data.emplace_back(type, client_properties, pandas);

--- a/tools/pythonpkg/src/pyresult.cpp
+++ b/tools/pythonpkg/src/pyresult.cpp
@@ -175,6 +175,9 @@ void DuckDBPyResult::FillNumpy(py::dict &res, idx_t col_idx, NumpyResultConversi
 		res[name] = py::module::import("pandas")
 		                .attr("Categorical")
 		                .attr("from_codes")(conversion.ToArray(col_idx), py::arg("dtype") = categories_type[col_idx]);
+		if (!conversion.ToPandas()) {
+			res[name] = res[name].attr("to_numpy")();
+		}
 	} else {
 		res[name] = conversion.ToArray(col_idx);
 	}

--- a/tools/pythonpkg/tests/fast/types/test_numpy.py
+++ b/tools/pythonpkg/tests/fast/types/test_numpy.py
@@ -26,3 +26,9 @@ class TestNumpyDatetime64(object):
         res1 = duckdb_con.execute("select * from test").fetchnumpy()
         date_value = {'date': np.array(['2263-02-28'], dtype='datetime64[us]')}
         assert res1 == date_value
+
+    def test_numpy_enum_conversion(self, duckdb_cursor):
+        arr = np.array(['a', 'b', 'c'])
+        rel = duckdb_cursor.sql("select * from arr")
+        res = rel.fetchnumpy()['column0']
+        np.testing.assert_equal(res, arr)


### PR DESCRIPTION
This PR fixes #12721 