### PR TITLE
Add Pyodide 0.26.1 (corresponding to Python 3.12)

### DIFF
--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -44,9 +44,11 @@ jobs:
           - python: "3.10"
             pyodide-build: "0.22.1"
             node: "16"
+            other_deps: "'pydantic<2'"
           - python: "3.11"
             pyodide-build: "0.25.1"
             node: "18"
+            other_deps: "'pydantic<2'"
           - python: "3.12"
             pyodide-build: "0.26.1"
             node: "20"
@@ -76,7 +78,7 @@ jobs:
         with:
           python-version: ${{ matrix.version.python }}
 
-      - run: pip install 'pyodide-build==${{ matrix.version.pyodide-build }}' 'pydantic<2'
+      - run: pip install 'pyodide-build==${{ matrix.version.pyodide-build }}' ${{ matrix.version.other_deps }}
 
       - name: get emscripten version
         id: emscripten-version

--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -115,14 +115,6 @@ jobs:
           source .venv-pyodide/bin/activate
           pip install ./tools/pythonpkg/dist/*.whl
 
-      - name: run tests using pyodide
-        if: ${{ inputs.skip_tests != 'true' }}
-        run: |
-          source .venv-pyodide/bin/activate
-          python -m pytest ./tools/pythonpkg/tests
-        env:
-          TZ: UTC
-
       - name: Wheel sizes
         run: |
           ls -lah ./tools/pythonpkg/dist/*.whl
@@ -133,6 +125,14 @@ jobs:
           if-no-files-found: error
           path: |
             ./tools/pythonpkg/dist/*.whl
+
+      - name: run tests using pyodide
+        if: ${{ inputs.skip_tests != 'true' }}
+        run: |
+          source .venv-pyodide/bin/activate
+          python -m pytest ./tools/pythonpkg/tests
+        env:
+          TZ: UTC
 
       - name: Deploy
         env:

--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -47,6 +47,9 @@ jobs:
           - python: "3.11"
             pyodide-build: "0.25.1"
             node: "18"
+          - python: "3.12"
+            pyodide-build: "0.26.1"
+            node: "20"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/include/duckdb/parallel/task_scheduler.hpp
+++ b/src/include/duckdb/parallel/task_scheduler.hpp
@@ -81,7 +81,8 @@ public:
 
 	//! Get the number of the CPU on which the calling thread is currently executing.
 	//! Fallback to calling thread id if CPU number is not available.
-	static idx_t GetCurrentCPU();
+	//! Result do not need to be exact 'return 0' is a valid fallback strategy
+	static idx_t GetEstimatedCPUId();
 
 private:
 	void RelaunchThreadsInternal(int32_t n);

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -305,9 +305,11 @@ void TaskScheduler::YieldThread() {
 #endif
 }
 
-idx_t TaskScheduler::GetCurrentCPU() {
+idx_t TaskScheduler::GetEstimatedCPUId() {
 #if defined(EMSCRIPTEN)
-	return 1;
+	// FIXME: Wasm + multithreads can likely be implemented as
+	//   return return (idx_t)std::hash<std::thread::id>()(std::this_thread::get_id());
+	return 0;
 #else
 	// this code comes from jemalloc
 #if defined(_WIN32)

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -306,6 +306,9 @@ void TaskScheduler::YieldThread() {
 }
 
 idx_t TaskScheduler::GetCurrentCPU() {
+#if defined(EMSCRIPTEN)
+	return 1;
+#else
 	// this code comes from jemalloc
 #if defined(_WIN32)
 	return (idx_t)GetCurrentProcessorNumber();
@@ -324,6 +327,7 @@ idx_t TaskScheduler::GetCurrentCPU() {
 #else
 	// fallback to thread id
 	return (idx_t)std::hash<std::thread::id>()(std::this_thread::get_id());
+#endif
 #endif
 }
 

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -414,7 +414,7 @@ void BufferPool::MemoryUsage::UpdateUsedMemory(MemoryTag tag, int64_t size) {
 		// Get corresponding cache slot based on current CPU core index
 		// Two threads may access the same cache simultaneously,
 		// ensuring correctness through atomic operations
-		auto cache_idx = (idx_t)TaskScheduler::GetCurrentCPU() % MEMORY_USAGE_CACHE_COUNT;
+		auto cache_idx = (idx_t)TaskScheduler::GetEstimatedCPUId() % MEMORY_USAGE_CACHE_COUNT;
 		auto &cache = memory_usage_caches[cache_idx];
 		auto new_tag_size = cache[tag_idx].fetch_add(size, std::memory_order_relaxed) + size;
 		if ((idx_t)AbsValue(new_tag_size) >= MEMORY_USAGE_CACHE_THRESHOLD) {


### PR DESCRIPTION
One change that I made to core is renaming `GetCurrentCPU` to `GetEstimatedCPUId`, this is due to the fact Emscripten (+ multithreaded) it's not super trivial to get that number, and if the return is only approximate anyway, I think it should be clearly stated in the function name that it should NOT be relied to return the actual current CPU.

The implementation `return 0;` is fine in single threaded Wasm, but then I realized also in multithreaded case, or wherever the thread infrastructure might be too heavy.

I might need to swap EMSCRIPTEN + multithreaded to use `return (idx_t)std::hash<std::thread::id>()(std::this_thread::get_id());`, that would make more sense. I added a `FIXME` about that.