### PR TITLE
Add missing TransformCTE extraction to TransformRecursiveCTE

### DIFF
--- a/src/parser/query_node/recursive_cte_node.cpp
+++ b/src/parser/query_node/recursive_cte_node.cpp
@@ -6,6 +6,7 @@ namespace duckdb {
 
 string RecursiveCTENode::ToString() const {
 	string result;
+	result = cte_map.ToString();
 	result += "(" + left->ToString() + ")";
 	result += " UNION ";
 	if (union_all) {

--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -110,6 +110,10 @@ unique_ptr<SelectStatement> Transformer::TransformRecursiveCTE(duckdb_libpgquery
 		auto &result = select->node->Cast<RecursiveCTENode>();
 		result.ctename = string(cte.ctename);
 		result.union_all = stmt.all;
+		if (stmt.withClause) {
+			auto with_clause = PGPointerCast<duckdb_libpgquery::PGWithClause>(stmt.withClause);
+			TransformCTE(*with_clause, result.cte_map);
+		}
 		result.left = TransformSelectNode(*PGPointerCast<duckdb_libpgquery::PGSelectStmt>(stmt.larg));
 		result.right = TransformSelectNode(*PGPointerCast<duckdb_libpgquery::PGSelectStmt>(stmt.rarg));
 		result.aliases = info.aliases;

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -183,7 +183,7 @@ WITH RECURSIVE
     SELECT 7
     )
   )
-SELECT * FROM t;
+SELECT * FROM t ORDER BY b;
 ----
 5
 7
@@ -199,7 +199,7 @@ WITH RECURSIVE
     SELECT 7 FROM helper h)
     SELECT * FROM h1)
   )
-SELECT * FROM t;
+SELECT * FROM t ORDER BY b;
 ----
 5
 7

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -171,3 +171,35 @@ SELECT * FROM s AS _(x) ORDER BY x;
 5
 6
 7
+
+query I
+WITH RECURSIVE
+  t(b) AS MATERIALIZED (
+    (WITH helper(c) AS (
+      SELECT 5
+    )
+    SELECT * FROM helper h
+    UNION
+    SELECT 7
+    )
+  )
+SELECT * FROM t;
+----
+5
+7
+
+query I
+WITH RECURSIVE
+  t(b) AS MATERIALIZED (
+    (WITH helper(c) AS (
+      SELECT 5
+    ), h1 AS
+    (SELECT * FROM helper h
+    UNION
+    SELECT 7 FROM helper h)
+    SELECT * FROM h1)
+  )
+SELECT * FROM t;
+----
+5
+7


### PR DESCRIPTION
Without this PR it is possible to execute the following query:

```sql
WITH
  t(b) AS MATERIALIZED (
    (WITH helper(c) AS (
      SELECT 5
    )
    SELECT * FROM helper h
    UNION
    SELECT 7
    )
  )
SELECT * FROM t;
```

However, if the `WITH`-clause is marked as `RECURSIVE`, `TransformCTE` takes a different code path which did not extract the `WITH`-clause within `t`. Therefore, CTE `helper` could not be found. This is an _unholy interaction_ between `WITH RECURSIVE`, `UNION`, and a nested `WITH`.

```sql
WITH RECURSIVE
  t(b) AS MATERIALIZED (
    (WITH helper(c) AS (
      SELECT 5
    )
    SELECT * FROM helper h
    UNION
    SELECT 7
    )
  )
SELECT * FROM t;
```

This PR adds the necessary extraction.