### PR TITLE
[Dev] Add getters/setters for the 'column_ids' of a `LogicalGet`

### DIFF
--- a/.github/patches/extensions/substrait/private_column_ids.patch
+++ b/.github/patches/extensions/substrait/private_column_ids.patch
@@ -1,0 +1,13 @@
+diff --git a/src/to_substrait.cpp b/src/to_substrait.cpp
+index ece0f5d..468fa36 100644
+--- a/src/to_substrait.cpp
++++ b/src/to_substrait.cpp
+@@ -1188,7 +1188,7 @@ substrait::Rel *DuckDBToSubstrait::TransformGet(LogicalOperator &dop) {
+ 		auto select = new substrait::Expression_MaskExpression_StructSelect();
+ 		for (auto col_idx : dget.projection_ids) {
+ 			auto struct_item = select->add_struct_items();
+-			struct_item->set_field((int32_t)dget.column_ids[col_idx]);
++			struct_item->set_field((int32_t)dget.GetColumnIds()[col_idx]);
+ 			// FIXME do we need to set the child? if yes, to what?
+ 		}
+ 		projection->set_allocated_select(select);

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -226,8 +226,8 @@ static void BindExtraColumns(TableCatalogEntry &table, LogicalGet &get, LogicalP
 			update.expressions.push_back(make_uniq<BoundColumnRefExpression>(
 			    column.Type(), ColumnBinding(proj.table_index, proj.expressions.size())));
 			proj.expressions.push_back(make_uniq<BoundColumnRefExpression>(
-			    column.Type(), ColumnBinding(get.table_index, get.column_ids.size())));
-			get.column_ids.push_back(check_column_id.index);
+			    column.Type(), ColumnBinding(get.table_index, get.GetColumnIds().size())));
+			get.AddColumnId(check_column_id.index);
 			update.columns.push_back(check_column_id);
 		}
 	}

--- a/src/common/multi_file_list.cpp
+++ b/src/common/multi_file_list.cpp
@@ -14,7 +14,8 @@
 namespace duckdb {
 
 MultiFilePushdownInfo::MultiFilePushdownInfo(LogicalGet &get)
-    : table_index(get.table_index), column_names(get.names), column_ids(get.column_ids), extra_info(get.extra_info) {
+    : table_index(get.table_index), column_names(get.names), column_ids(get.GetColumnIds()),
+      extra_info(get.extra_info) {
 }
 
 MultiFilePushdownInfo::MultiFilePushdownInfo(idx_t table_index, const vector<string> &column_names,

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -12,7 +12,7 @@
 
 namespace duckdb {
 
-unique_ptr<TableFilterSet> CreateTableFilterSet(TableFilterSet &table_filters, vector<column_t> &column_ids) {
+unique_ptr<TableFilterSet> CreateTableFilterSet(TableFilterSet &table_filters, const vector<column_t> &column_ids) {
 	// create the table filter map
 	auto table_filter_set = make_uniq<TableFilterSet>();
 	for (auto &table_filter : table_filters.filters) {

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -33,6 +33,7 @@ unique_ptr<TableFilterSet> CreateTableFilterSet(TableFilterSet &table_filters, v
 }
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
+	auto &column_ids = op.GetColumnIds();
 	if (!op.children.empty()) {
 		auto child_node = CreatePlan(std::move(op.children[0]));
 		// this is for table producing functions that consume subquery results
@@ -66,7 +67,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 			child_node = std::move(proj);
 		}
 
-		auto node = make_uniq<PhysicalTableInOutFunction>(op.types, op.function, std::move(op.bind_data), op.column_ids,
+		auto node = make_uniq<PhysicalTableInOutFunction>(op.types, op.function, std::move(op.bind_data), column_ids,
 		                                                  op.estimated_cardinality, std::move(op.projected_input));
 		node->children.push_back(std::move(child_node));
 		return std::move(node);
@@ -77,7 +78,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 
 	unique_ptr<TableFilterSet> table_filters;
 	if (!op.table_filters.filters.empty()) {
-		table_filters = CreateTableFilterSet(op.table_filters, op.column_ids);
+		table_filters = CreateTableFilterSet(op.table_filters, column_ids);
 	}
 
 	if (op.function.dependency) {
@@ -86,15 +87,14 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 	// create the table scan node
 	if (!op.function.projection_pushdown) {
 		// function does not support projection pushdown
-		auto node =
-		    make_uniq<PhysicalTableScan>(op.returned_types, op.function, std::move(op.bind_data), op.returned_types,
-		                                 op.column_ids, vector<column_t>(), op.names, std::move(table_filters),
-		                                 op.estimated_cardinality, op.extra_info, std::move(op.parameters));
+		auto node = make_uniq<PhysicalTableScan>(
+		    op.returned_types, op.function, std::move(op.bind_data), op.returned_types, column_ids, vector<column_t>(),
+		    op.names, std::move(table_filters), op.estimated_cardinality, op.extra_info, std::move(op.parameters));
 		// first check if an additional projection is necessary
-		if (op.column_ids.size() == op.returned_types.size()) {
+		if (column_ids.size() == op.returned_types.size()) {
 			bool projection_necessary = false;
-			for (idx_t i = 0; i < op.column_ids.size(); i++) {
-				if (op.column_ids[i] != i) {
+			for (idx_t i = 0; i < column_ids.size(); i++) {
+				if (column_ids[i] != i) {
 					projection_necessary = true;
 					break;
 				}
@@ -109,7 +109,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		// push a projection on top that does the projection
 		vector<LogicalType> types;
 		vector<unique_ptr<Expression>> expressions;
-		for (auto &column_id : op.column_ids) {
+		for (auto &column_id : column_ids) {
 			if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
 				types.emplace_back(LogicalType::BIGINT);
 				expressions.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(0)));
@@ -126,7 +126,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		return std::move(projection);
 	} else {
 		auto node = make_uniq<PhysicalTableScan>(op.types, op.function, std::move(op.bind_data), op.returned_types,
-		                                         op.column_ids, op.projection_ids, op.names, std::move(table_filters),
+		                                         column_ids, op.projection_ids, op.names, std::move(table_filters),
 		                                         op.estimated_cardinality, op.extra_info, std::move(op.parameters));
 		node->dynamic_filters = op.dynamic_filters;
 		return std::move(node);

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -278,10 +278,11 @@ static void RewriteIndexExpression(Index &index, LogicalGet &get, Expression &ex
 		// bound column ref: rewrite to fit in the current set of bound column ids
 		bound_colref.binding.table_index = get.table_index;
 		auto &column_ids = index.GetColumnIds();
+		auto &get_column_ids = get.GetColumnIds();
 		column_t referenced_column = column_ids[bound_colref.binding.column_index];
 		// search for the referenced column in the set of column_ids
-		for (idx_t i = 0; i < get.column_ids.size(); i++) {
-			if (get.column_ids[i] == referenced_column) {
+		for (idx_t i = 0; i < get_column_ids.size(); i++) {
+			if (get_column_ids[i] == referenced_column) {
 				bound_colref.binding.column_index = i;
 				return;
 			}

--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -47,7 +47,7 @@ public:
 
 	void GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback);
 	bool HasFilters();
-	TableFilterSet GenerateTableScanFilters(vector<idx_t> &column_ids);
+	TableFilterSet GenerateTableScanFilters(const vector<idx_t> &column_ids);
 	// vector<unique_ptr<TableFilter>> GenerateZonemapChecks(vector<idx_t> &column_ids, vector<unique_ptr<TableFilter>>
 	// &pushed_filters);
 

--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -35,8 +35,6 @@ public:
 	vector<LogicalType> returned_types;
 	//! The names of ALL columns that can be returned by the table function
 	vector<string> names;
-	//! Bound column IDs
-	vector<column_t> column_ids;
 	//! Columns that are used outside of the scan
 	vector<idx_t> projection_ids;
 	//! Filters pushed down for table scan
@@ -63,6 +61,9 @@ public:
 	optional_ptr<TableCatalogEntry> GetTable() const;
 
 public:
+	void AddColumnIds(vector<column_t> &&column_ids);
+	void AddColumnId(column_t column_id);
+	vector<column_t> &GetColumnIds();
 	vector<ColumnBinding> GetColumnBindings() override;
 	idx_t EstimateCardinality(ClientContext &context) override;
 
@@ -80,5 +81,9 @@ protected:
 
 private:
 	LogicalGet();
+
+private:
+	//! Bound column IDs
+	vector<column_t> column_ids;
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -63,7 +63,9 @@ public:
 public:
 	void SetColumnIds(vector<column_t> &&column_ids);
 	void AddColumnId(column_t column_id);
-	vector<column_t> &GetColumnIds();
+	void ClearColumnIds();
+	const vector<column_t> &GetColumnIds() const;
+	vector<column_t> &GetMutableColumnIds();
 	vector<ColumnBinding> GetColumnBindings() override;
 	idx_t EstimateCardinality(ClientContext &context) override;
 

--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -61,7 +61,7 @@ public:
 	optional_ptr<TableCatalogEntry> GetTable() const;
 
 public:
-	void AddColumnIds(vector<column_t> &&column_ids);
+	void SetColumnIds(vector<column_t> &&column_ids);
 	void AddColumnId(column_t column_id);
 	vector<column_t> &GetColumnIds();
 	vector<ColumnBinding> GetColumnBindings() override;

--- a/src/optimizer/build_probe_side_optimizer.cpp
+++ b/src/optimizer/build_probe_side_optimizer.cpp
@@ -12,7 +12,7 @@ static void GetRowidBindings(LogicalOperator &op, vector<ColumnBinding> &binding
 	if (op.type == LogicalOperatorType::LOGICAL_GET) {
 		auto &get = op.Cast<LogicalGet>();
 		auto get_bindings = get.GetColumnBindings();
-		auto column_ids = get.column_ids;
+		auto &column_ids = get.GetColumnIds();
 		if (std::find(column_ids.begin(), column_ids.end(), DConstants::INVALID_INDEX) != column_ids.end()) {
 			for (auto &binding : get_bindings) {
 				bindings.push_back(binding);

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -435,7 +435,7 @@ static unique_ptr<TableFilter> PushDownFilterIntoExpr(const Expression &expr, un
 	return inner_filter;
 }
 
-TableFilterSet FilterCombiner::GenerateTableScanFilters(vector<idx_t> &column_ids) {
+TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<idx_t> &column_ids) {
 	TableFilterSet table_filters;
 	//! First, we figure the filters that have constant expressions that we can push down to the table scan
 	for (auto &constant_value : constant_values) {

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -77,15 +77,16 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 	}
 
 	// first push back basic distinct counts for each column (if we have them).
-	for (idx_t i = 0; i < get.column_ids.size(); i++) {
+	auto &column_ids = get.GetColumnIds();
+	for (idx_t i = 0; i < column_ids.size(); i++) {
 		bool have_distinct_count_stats = false;
 		if (get.function.statistics) {
-			column_statistics = get.function.statistics(context, get.bind_data.get(), get.column_ids[i]);
+			column_statistics = get.function.statistics(context, get.bind_data.get(), column_ids[i]);
 			if (column_statistics && have_catalog_table_statistics) {
 				auto distinct_count = MaxValue((idx_t)1, column_statistics->GetDistinctCount());
 				auto column_distinct_count = DistinctCount({distinct_count, true});
 				return_stats.column_distinct_count.push_back(column_distinct_count);
-				return_stats.column_names.push_back(name + "." + get.names.at(get.column_ids.at(i)));
+				return_stats.column_names.push_back(name + "." + get.names.at(column_ids.at(i)));
 				have_distinct_count_stats = true;
 			}
 		}
@@ -96,8 +97,8 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 			auto column_distinct_count = DistinctCount({cardinality_after_filters, false});
 			return_stats.column_distinct_count.push_back(column_distinct_count);
 			auto column_name = string("column");
-			if (get.column_ids.at(i) < get.names.size()) {
-				column_name = get.names.at(get.column_ids.at(i));
+			if (column_ids.at(i) < get.names.size()) {
+				column_name = get.names.at(column_ids.at(i));
 			}
 			return_stats.column_names.push_back(get.GetName() + "." + column_name);
 		}

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -53,7 +53,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 
 	//! We generate the table filters that will be executed during the table scan
 	//! Right now this only executes simple AND filters
-	get.table_filters = combiner.GenerateTableScanFilters(get.column_ids);
+	get.table_filters = combiner.GenerateTableScanFilters(get.GetColumnIds());
 
 	// //! For more complex filters if all filters to a column are constants we generate a min max boundary used to
 	// check

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -246,7 +246,7 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			for (auto col_sel_idx : col_sel) {
 				column_ids.push_back(final_column_ids[col_sel_idx]);
 			}
-			get.AddColumnIds(std::move(column_ids));
+			get.SetColumnIds(std::move(column_ids));
 
 			if (get.function.filter_prune) {
 				// Now set the projection cols by matching the "selection vector" that excludes filter columns

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -206,9 +206,11 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 				return;
 			}
 
+			auto &final_column_ids = get.GetColumnIds();
+
 			// Create "selection vector" of all column ids
 			vector<idx_t> proj_sel;
-			for (idx_t col_idx = 0; col_idx < get.column_ids.size(); col_idx++) {
+			for (idx_t col_idx = 0; col_idx < final_column_ids.size(); col_idx++) {
 				proj_sel.push_back(col_idx);
 			}
 			// Create a copy that we can use to match ids later
@@ -220,8 +222,8 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			// being projected out
 			for (auto &filter : get.table_filters.filters) {
 				optional_idx index;
-				for (idx_t i = 0; i < get.column_ids.size(); i++) {
-					if (get.column_ids[i] == filter.first) {
+				for (idx_t i = 0; i < final_column_ids.size(); i++) {
+					if (final_column_ids[i] == filter.first) {
 						index = i;
 						break;
 					}
@@ -242,9 +244,9 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			vector<column_t> column_ids;
 			column_ids.reserve(col_sel.size());
 			for (auto col_sel_idx : col_sel) {
-				column_ids.push_back(get.column_ids[col_sel_idx]);
+				column_ids.push_back(final_column_ids[col_sel_idx]);
 			}
-			get.column_ids = std::move(column_ids);
+			get.AddColumnIds(std::move(column_ids));
 
 			if (get.function.filter_prune) {
 				// Now set the projection cols by matching the "selection vector" that excludes filter columns
@@ -260,11 +262,11 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 				}
 			}
 
-			if (get.column_ids.empty()) {
+			if (final_column_ids.empty()) {
 				// this generally means we are only interested in whether or not anything exists in the table (e.g.
 				// EXISTS(SELECT * FROM tbl)) in this case, we just scan the row identifier column as it means we do not
 				// need to read any of the columns
-				get.column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+				get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
 			}
 		}
 		return;

--- a/src/optimizer/statistics/operator/propagate_get.cpp
+++ b/src/optimizer/statistics/operator/propagate_get.cpp
@@ -39,8 +39,9 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 		// no column statistics to get
 		return std::move(node_stats);
 	}
-	for (idx_t i = 0; i < get.column_ids.size(); i++) {
-		auto stats = get.function.statistics(context, get.bind_data.get(), get.column_ids[i]);
+	auto &column_ids = get.GetColumnIds();
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		auto stats = get.function.statistics(context, get.bind_data.get(), column_ids[i]);
 		if (stats) {
 			ColumnBinding binding(get.table_index, i);
 			statistics_map.insert(make_pair(binding, std::move(stats)));
@@ -55,13 +56,13 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet 
 
 	for (auto &table_filter_column : column_indexes) {
 		idx_t column_index;
-		for (column_index = 0; column_index < get.column_ids.size(); column_index++) {
-			if (get.column_ids[column_index] == table_filter_column) {
+		for (column_index = 0; column_index < column_ids.size(); column_index++) {
+			if (column_ids[column_index] == table_filter_column) {
 				break;
 			}
 		}
-		D_ASSERT(column_index < get.column_ids.size());
-		D_ASSERT(get.column_ids[column_index] == table_filter_column);
+		D_ASSERT(column_index < column_ids.size());
+		D_ASSERT(column_ids[column_index] == table_filter_column);
 
 		// find the stats
 		ColumnBinding stats_binding(get.table_index, column_index);

--- a/src/planner/binder/query_node/plan_setop.cpp
+++ b/src/planner/binder/query_node/plan_setop.cpp
@@ -28,19 +28,19 @@ unique_ptr<LogicalOperator> Binder::CastLogicalOperatorToTypes(vector<LogicalTyp
 		if (node->children.size() == 1 && node->children[0]->type == LogicalOperatorType::LOGICAL_GET) {
 			// If this projection only has one child and that child is a logical get we can try to pushdown types
 			auto &logical_get = node->children[0]->Cast<LogicalGet>();
+			auto &column_ids = logical_get.GetColumnIds();
 			if (logical_get.function.type_pushdown) {
 				unordered_map<idx_t, LogicalType> new_column_types;
 				bool do_pushdown = true;
 				for (idx_t i = 0; i < op->expressions.size(); i++) {
 					if (op->expressions[i]->type == ExpressionType::BOUND_COLUMN_REF) {
 						auto &col_ref = op->expressions[i]->Cast<BoundColumnRefExpression>();
-						if (new_column_types.find(logical_get.column_ids[col_ref.binding.column_index]) !=
-						    new_column_types.end()) {
+						if (new_column_types.find(column_ids[col_ref.binding.column_index]) != new_column_types.end()) {
 							// Only one reference per column is accepted
 							do_pushdown = false;
 							break;
 						}
-						new_column_types[logical_get.column_ids[col_ref.binding.column_index]] = target_types[i];
+						new_column_types[column_ids[col_ref.binding.column_index]] = target_types[i];
 					} else {
 						do_pushdown = false;
 						break;

--- a/src/planner/binder/statement/bind_call.cpp
+++ b/src/planner/binder/statement/bind_call.cpp
@@ -18,7 +18,7 @@ BoundStatement Binder::Bind(CallStatement &stmt) {
 	auto &get = bound_table_func.get->Cast<LogicalGet>();
 	D_ASSERT(get.returned_types.size() > 0);
 	for (idx_t i = 0; i < get.returned_types.size(); i++) {
-		get.column_ids.push_back(i);
+		get.AddColumnId(i);
 	}
 
 	result.types = get.returned_types;

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -330,7 +330,7 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 	auto get = make_uniq<LogicalGet>(GenerateTableIndex(), copy_function.function.copy_from_function,
 	                                 std::move(function_data), bound_insert.expected_types, expected_names);
 	for (idx_t i = 0; i < bound_insert.expected_types.size(); i++) {
-		get->column_ids.push_back(i);
+		get->AddColumnId(i);
 	}
 	insert_statement.plan->children.push_back(std::move(get));
 	result.plan = std::move(insert_statement.plan);

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -572,7 +572,7 @@ unique_ptr<LogicalOperator> DuckCatalog::BindCreateIndex(Binder &binder, CreateS
 	create_index_info->column_ids = column_ids;
 	auto &bind_data = get.bind_data->Cast<TableScanBindData>();
 	bind_data.is_create_index = true;
-	column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
 
 	// the logical CREATE INDEX also needs all fields to scan the referenced table
 	auto result = make_uniq<LogicalCreateIndex>(std::move(create_index_info), std::move(expressions), table);

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -560,7 +560,8 @@ unique_ptr<LogicalOperator> DuckCatalog::BindCreateIndex(Binder &binder, CreateS
 	}
 
 	auto create_index_info = unique_ptr_cast<CreateInfo, CreateIndexInfo>(std::move(stmt.info));
-	for (auto &column_id : get.column_ids) {
+	auto &column_ids = get.GetColumnIds();
+	for (auto &column_id : column_ids) {
 		if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
 			throw BinderException("Cannot create an index on the rowid!");
 		}
@@ -568,10 +569,10 @@ unique_ptr<LogicalOperator> DuckCatalog::BindCreateIndex(Binder &binder, CreateS
 	}
 	create_index_info->scan_types.emplace_back(LogicalType::ROW_TYPE);
 	create_index_info->names = get.names;
-	create_index_info->column_ids = get.column_ids;
+	create_index_info->column_ids = column_ids;
 	auto &bind_data = get.bind_data->Cast<TableScanBindData>();
 	bind_data.is_create_index = true;
-	get.column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
 
 	// the logical CREATE INDEX also needs all fields to scan the referenced table
 	auto result = make_uniq<LogicalCreateIndex>(std::move(create_index_info), std::move(expressions), table);

--- a/src/planner/binder/statement/bind_delete.cpp
+++ b/src/planner/binder/statement/bind_delete.cpp
@@ -74,9 +74,10 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 	del->AddChild(std::move(root));
 
 	// set up the delete expression
-	del->expressions.push_back(make_uniq<BoundColumnRefExpression>(
-	    LogicalType::ROW_TYPE, ColumnBinding(get.table_index, get.column_ids.size())));
-	get.column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	auto &column_ids = get.GetColumnIds();
+	del->expressions.push_back(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::ROW_TYPE, ColumnBinding(get.table_index, column_ids.size())));
+	get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
 
 	if (!stmt.returning_list.empty()) {
 		del->return_chunk = true;

--- a/src/planner/binder/statement/bind_extension.cpp
+++ b/src/planner/binder/statement/bind_extension.cpp
@@ -23,8 +23,7 @@ BoundStatement Binder::Bind(ExtensionStatement &stmt) {
 	auto &get = result.plan->Cast<LogicalGet>();
 	result.names = get.names;
 	result.types = get.returned_types;
-	auto &column_ids = get.GetColumnIds();
-	column_ids.clear();
+	get.ClearColumnIds();
 	for (idx_t i = 0; i < get.returned_types.size(); i++) {
 		get.AddColumnId(i);
 	}

--- a/src/planner/binder/statement/bind_extension.cpp
+++ b/src/planner/binder/statement/bind_extension.cpp
@@ -23,9 +23,10 @@ BoundStatement Binder::Bind(ExtensionStatement &stmt) {
 	auto &get = result.plan->Cast<LogicalGet>();
 	result.names = get.names;
 	result.types = get.returned_types;
-	get.column_ids.clear();
+	auto &column_ids = get.GetColumnIds();
+	column_ids.clear();
 	for (idx_t i = 0; i < get.returned_types.size(); i++) {
-		get.column_ids.push_back(i);
+		get.AddColumnId(i);
 	}
 	return result;
 }

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -131,9 +131,10 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 	table.BindUpdateConstraints(*this, *get, *proj, *update, context);
 
 	// finally add the row id column to the projection list
-	proj->expressions.push_back(make_uniq<BoundColumnRefExpression>(
-	    LogicalType::ROW_TYPE, ColumnBinding(get->table_index, get->column_ids.size())));
-	get->column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	auto &column_ids = get->GetColumnIds();
+	proj->expressions.push_back(
+	    make_uniq<BoundColumnRefExpression>(LogicalType::ROW_TYPE, ColumnBinding(get->table_index, column_ids.size())));
+	get->AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
 
 	// set the projection as child of the update node and finalize the result
 	update->AddChild(std::move(proj));

--- a/src/planner/binder/statement/bind_vacuum.cpp
+++ b/src/planner/binder/statement/bind_vacuum.cpp
@@ -64,10 +64,11 @@ void Binder::BindVacuumTable(LogicalVacuum &vacuum, unique_ptr<LogicalOperator> 
 
 	auto &get = table_scan->Cast<LogicalGet>();
 
-	D_ASSERT(select_list.size() == get.column_ids.size());
-	D_ASSERT(info.columns.size() == get.column_ids.size());
-	for (idx_t i = 0; i < get.column_ids.size(); i++) {
-		vacuum.column_id_map[i] = table.GetColumns().LogicalToPhysical(LogicalIndex(get.column_ids[i])).index;
+	auto &column_ids = get.GetColumnIds();
+	D_ASSERT(select_list.size() == column_ids.size());
+	D_ASSERT(info.columns.size() == column_ids.size());
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		vacuum.column_id_map[i] = table.GetColumns().LogicalToPhysical(LogicalIndex(column_ids[i])).index;
 	}
 
 	auto projection = make_uniq<LogicalProjection>(GenerateTableIndex(), std::move(select_list));

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -238,7 +238,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 
 		auto logical_get = make_uniq<LogicalGet>(table_index, scan_function, std::move(bind_data),
 		                                         std::move(return_types), std::move(return_names));
-		bind_context.AddBaseTable(table_index, alias, table_names, table_types, logical_get->column_ids,
+		bind_context.AddBaseTable(table_index, alias, table_names, table_types, logical_get->GetColumnIds(),
 		                          logical_get->GetTable().get());
 		return make_uniq_base<BoundTableRef, BoundBaseTableRef>(table, std::move(logical_get));
 	}

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -238,7 +238,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 
 		auto logical_get = make_uniq<LogicalGet>(table_index, scan_function, std::move(bind_data),
 		                                         std::move(return_types), std::move(return_names));
-		bind_context.AddBaseTable(table_index, alias, table_names, table_types, logical_get->GetColumnIds(),
+		bind_context.AddBaseTable(table_index, alias, table_names, table_types, logical_get->GetMutableColumnIds(),
 		                          logical_get->GetTable().get());
 		return make_uniq_base<BoundTableRef, BoundBaseTableRef>(table, std::move(logical_get));
 	}

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -236,14 +236,14 @@ unique_ptr<LogicalOperator> Binder::BindTableFunctionInternal(TableFunction &tab
 	get->named_parameters = named_parameters;
 	get->input_table_types = input_table_types;
 	get->input_table_names = input_table_names;
+	auto &column_ids = get->GetColumnIds();
 	if (table_function.in_out_function && !table_function.projection_pushdown) {
-		get->column_ids.reserve(return_types.size());
 		for (idx_t i = 0; i < return_types.size(); i++) {
-			get->column_ids.push_back(i);
+			get->AddColumnId(i);
 		}
 	}
 	// now add the table function to the bind context so its columns can be bound
-	bind_context.AddTableFunction(bind_index, function_name, return_names, return_types, get->column_ids,
+	bind_context.AddTableFunction(bind_index, function_name, return_names, return_types, column_ids,
 	                              get->GetTable().get());
 	return std::move(get);
 }

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -236,14 +236,13 @@ unique_ptr<LogicalOperator> Binder::BindTableFunctionInternal(TableFunction &tab
 	get->named_parameters = named_parameters;
 	get->input_table_types = input_table_types;
 	get->input_table_names = input_table_names;
-	auto &column_ids = get->GetColumnIds();
 	if (table_function.in_out_function && !table_function.projection_pushdown) {
 		for (idx_t i = 0; i < return_types.size(); i++) {
 			get->AddColumnId(i);
 		}
 	}
 	// now add the table function to the bind context so its columns can be bound
-	bind_context.AddTableFunction(bind_index, function_name, return_names, return_types, column_ids,
+	bind_context.AddTableFunction(bind_index, function_name, return_names, return_types, get->GetMutableColumnIds(),
 	                              get->GetTable().get());
 	return std::move(get);
 }

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -54,7 +54,7 @@ string LogicalGet::ParamsToString() const {
 	return result + "\n" + function.to_string(bind_data.get());
 }
 
-void LogicalGet::AddColumnIds(vector<column_t> &&column_ids) {
+void LogicalGet::SetColumnIds(vector<column_t> &&column_ids) {
 	this->column_ids = std::move(column_ids);
 }
 

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -62,7 +62,15 @@ void LogicalGet::AddColumnId(column_t column_id) {
 	column_ids.push_back(column_id);
 }
 
-vector<column_t> &LogicalGet::GetColumnIds() {
+void LogicalGet::ClearColumnIds() {
+	column_ids.clear();
+}
+
+const vector<column_t> &LogicalGet::GetColumnIds() const {
+	return column_ids;
+}
+
+vector<column_t> &LogicalGet::GetMutableColumnIds() {
 	return column_ids;
 }
 

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -54,6 +54,18 @@ string LogicalGet::ParamsToString() const {
 	return result + "\n" + function.to_string(bind_data.get());
 }
 
+void LogicalGet::AddColumnIds(vector<column_t> &&column_ids) {
+	column_ids = std::move(column_ids);
+}
+
+void LogicalGet::AddColumnId(column_t column_id) {
+	column_ids.push_back(column_id);
+}
+
+vector<column_t> &LogicalGet::GetColumnIds() {
+	return column_ids;
+}
+
 vector<ColumnBinding> LogicalGet::GetColumnBindings() {
 	if (column_ids.empty()) {
 		return {ColumnBinding(table_index, 0)};

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -55,7 +55,7 @@ string LogicalGet::ParamsToString() const {
 }
 
 void LogicalGet::AddColumnIds(vector<column_t> &&column_ids) {
-	column_ids = std::move(column_ids);
+	this->column_ids = std::move(column_ids);
 }
 
 void LogicalGet::AddColumnId(column_t column_id) {


### PR DESCRIPTION
This is being edited in various places, with no real way to track them or find examples easily in the code (as the `column_ids` name is used in quite a couple places)

I've made the `vector<column_t> column_ids;` private, introducing `GetColumnIds`, `GetMutableColumnIds`, `SetColumnIds` and `AddColumnId`.

`GetColumnIds` returns a `const vector<column_t> &`
Only in two places do we actually need `GetMutableColumnIds`, I think being explicit about this is an improvement.

In a couple other places I was able to add the missing `const` to fix the issues.

-----------------

Inspiration for this PR is that I was working on pushing a LogicalProjection onto a LogicalGet, using the `GetColumnBindings` method, which uses the `column_ids` vector - which is empty at construction.

Not being able to find out where this should be populated