### PR TITLE
Avoid adding a suffix to Parquet files when doing a partitioned write

### DIFF
--- a/src/function/table/copy_csv.cpp
+++ b/src/function/table/copy_csv.cpp
@@ -172,6 +172,21 @@ static unique_ptr<FunctionData> WriteCSVBind(ClientContext &context, CopyFunctio
 	}
 	bind_data->Finalize();
 
+	switch (bind_data->options.compression) {
+	case FileCompressionType::GZIP:
+		if (!StringUtil::EndsWith(input.file_extension, ".gz")) {
+			input.file_extension += ".gz";
+		}
+		break;
+	case FileCompressionType::ZSTD:
+		if (!StringUtil::EndsWith(input.file_extension, ".zst")) {
+			input.file_extension += ".zst";
+		}
+		break;
+	default:
+		break;
+	}
+
 	auto expressions = CreateCastExpressions(*bind_data, context, names, sql_types);
 	bind_data->cast_expressions = std::move(expressions);
 

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -127,21 +127,6 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) 
 				return_type = CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST;
 			}
 		} else {
-			if (loption == "compression") {
-				if (option.second.empty()) {
-					// This can't be empty
-					throw BinderException("COMPRESSION option, in the file scanner, can't be empty. It should be set "
-					                      "to AUTO, UNCOMPRESSED, GZIP, SNAPPY or ZSTD. Depending on the file format.");
-				}
-				auto parameter = StringUtil::Lower(option.second[0].ToString());
-				if (parameter == "gzip" && !StringUtil::EndsWith(bind_input.file_extension, ".gz")) {
-					// We just add .gz
-					bind_input.file_extension += ".gz";
-				} else if (parameter == "zstd" && !StringUtil::EndsWith(bind_input.file_extension, ".zst")) {
-					// We just add .zst
-					bind_input.file_extension += ".zst";
-				}
-			}
 			stmt.info->options[option.first] = option.second;
 		}
 	}

--- a/test/sql/copy/partitioned/hive_partition_compression.test
+++ b/test/sql/copy/partitioned/hive_partition_compression.test
@@ -1,0 +1,25 @@
+# name: test/sql/copy/partitioned/hive_partition_compression.test
+# description: Test we can round-trip partitioned compressed Parquet files
+# group: [partitioned]
+
+statement ok
+PRAGMA enable_verification
+
+require parquet
+
+statement ok
+CREATE TABLE test AS VALUES ('a', 'foo', 1), ('a', 'foo', 2), ('a', 'bar', 1), ('b', 'bar', 1);
+
+statement ok
+COPY (FROM test) TO '__TEST_DIR__/hive_partition_compress' (FORMAT parquet, COMPRESSION 'gzip', PARTITION_BY ('col0', 'col1'));
+
+# Specify Compression
+query III
+FROM read_parquet('__TEST_DIR__/hive_partition_compress/*/*/*.parquet')
+ORDER BY ALL
+----
+a	bar	1
+a	foo	1
+a	foo	2
+b	bar	1
+


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/11903

We should not add the `.gz` or `.zst` extensions to Parquet files as the compression is done internally. Instead, we move the suffix adding logic to the CSV writer itself.