### PR TITLE
Fix JSON extension Cmake

### DIFF
--- a/extension/json/CMakeLists.txt
+++ b/extension/json/CMakeLists.txt
@@ -35,6 +35,7 @@ set(JSON_EXTENSION_FILES
 build_static_extension(json ${JSON_EXTENSION_FILES})
 set(PARAMETERS "-warnings")
 build_loadable_extension(json ${PARAMETERS} ${JSON_EXTENSION_FILES})
+target_link_libraries(json_loadable_extension duckdb_yyjson)
 
 install(
   TARGETS json_extension


### PR DESCRIPTION
Building JSON as loadable extension without DuckDB statically linked in needs this to make sense.

Found while builiding extensions for Wasm.