### PR TITLE
Use Slurm env vars to manage cpu and memory allocation if run inside Slurm HPC job 

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library_unity(
   assert.cpp
   bind_helpers.cpp
   box_renderer.cpp
-  cgroup.cpp
+  cgroups.cpp
   compressed_file_system.cpp
   constants.cpp
   checksum.cpp

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library_unity(
   assert.cpp
   bind_helpers.cpp
   box_renderer.cpp
+  cgroup.cpp
   compressed_file_system.cpp
   constants.cpp
   checksum.cpp

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -1,0 +1,164 @@
+#include "duckdb/common/cgroups.hpp"
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/limits.hpp"
+#include "duckdb/common/types/cast_helpers.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
+
+#include <cinttypes>
+
+namespace duckdb {
+
+optional_idx CGroups::GetMemoryLimit(FileSystem &fs) {
+	// First, try cgroup v2
+	auto cgroup_v2_limit = GetCGroupV2MemoryLimit(fs);
+	if (cgroup_v2_limit.IsValid()) {
+		return cgroup_v2_limit;
+	}
+
+	// If cgroup v2 fails, try cgroup v1
+	return GetCGroupV1MemoryLimit(fs);
+}
+
+optional_idx CGroups::GetCGroupV2MemoryLimit(FileSystem &fs) {
+	const char *CGROUP_SELF = "/proc/self/cgroup";
+	const char *MEMORY_MAX = "/sys/fs/cgroup/%s/memory.max";
+
+	if (!fs.FileExists(CGROUP_SELF)) {
+		return optional_idx();
+	}
+
+	string cgroup_path = ReadCGroupPath(fs, CGROUP_SELF);
+	if (cgroup_path.empty()) {
+		return optional_idx();
+	}
+
+	char memory_max_path[256];
+	snprintf(memory_max_path, sizeof(memory_max_path), MEMORY_MAX, cgroup_path.c_str());
+
+	if (!fs.FileExists(memory_max_path)) {
+		return optional_idx();
+	}
+
+	return ReadCGroupValue(fs, memory_max_path);
+}
+
+optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
+	const char *CGROUP_SELF = "/proc/self/cgroup";
+	const char *MEMORY_LIMIT = "/sys/fs/cgroup/memory/%s/memory.limit_in_bytes";
+
+	if (!fs.FileExists(CGROUP_SELF)) {
+		return optional_idx();
+	}
+
+	string memory_cgroup_path = ReadMemoryCGroupPath(fs, CGROUP_SELF);
+	if (memory_cgroup_path.empty()) {
+		return optional_idx();
+	}
+
+	char memory_limit_path[256];
+	snprintf(memory_limit_path, sizeof(memory_limit_path), MEMORY_LIMIT, memory_cgroup_path.c_str());
+
+	if (!fs.FileExists(memory_limit_path)) {
+		return optional_idx();
+	}
+
+	return ReadCGroupValue(fs, memory_limit_path);
+}
+
+string CGroups::ReadCGroupPath(FileSystem &fs, const char *cgroup_file) {
+	auto handle = fs.OpenFile(cgroup_file, FileFlags::FILE_FLAGS_READ);
+	char buffer[1024];
+	idx_t bytes_read = fs.Read(*handle, buffer, sizeof(buffer) - 1);
+	buffer[bytes_read] = '\0';
+
+	// For cgroup v2, we're looking for a single line with "0::/path"
+	string content(buffer);
+	auto pos = content.find("::");
+	if (pos != string::npos) {
+		return content.substr(pos + 2);
+	}
+
+	return "";
+}
+
+string CGroups::ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file) {
+	auto handle = fs.OpenFile(cgroup_file, FileFlags::FILE_FLAGS_READ);
+	char buffer[1024];
+	idx_t bytes_read = fs.Read(*handle, buffer, sizeof(buffer) - 1);
+	buffer[bytes_read] = '\0';
+
+	// For cgroup v1, we're looking for a line with "memory:/path"
+	string content(buffer);
+	size_t pos = 0;
+	string line;
+	while ((pos = content.find('\n')) != string::npos) {
+		line = content.substr(0, pos);
+		if (line.find("memory:") == 0) {
+			return line.substr(line.find(':') + 1);
+		}
+		content.erase(0, pos + 1);
+	}
+
+	return "";
+}
+
+optional_idx CGroups::ReadCGroupValue(FileSystem &fs, const char *file_path) {
+	auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
+	char buffer[100];
+	idx_t bytes_read = fs.Read(*handle, buffer, 99);
+	buffer[bytes_read] = '\0';
+
+	idx_t value;
+	if (TryCast::Operation<string_t, idx_t>(string_t(buffer), value)) {
+		return optional_idx(value);
+	}
+	return optional_idx();
+}
+
+idx_t CGroups::GetCPULimit(FileSystem &fs, idx_t physical_cores) {
+	static constexpr const char *CPU_MAX = "/sys/fs/cgroup/cpu.max";
+	static constexpr const char *CFS_QUOTA = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
+	static constexpr const char *CFS_PERIOD = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+
+	int64_t quota, period;
+	char byte_buffer[1000];
+	unique_ptr<FileHandle> handle;
+	int64_t read_bytes;
+
+	if (fs.FileExists(CPU_MAX)) {
+		// cgroup v2
+		handle = fs.OpenFile(CPU_MAX, FileFlags::FILE_FLAGS_READ);
+		read_bytes = fs.Read(*handle, (void *)byte_buffer, 999);
+		byte_buffer[read_bytes] = '\0';
+		if (std::sscanf(byte_buffer, "%" SCNd64 " %" SCNd64 "", &quota, &period) != 2) {
+			return physical_cores;
+		}
+	} else if (fs.FileExists(CFS_QUOTA) && fs.FileExists(CFS_PERIOD)) {
+		// cgroup v1
+		handle = fs.OpenFile(CFS_QUOTA, FileFlags::FILE_FLAGS_READ);
+		read_bytes = fs.Read(*handle, (void *)byte_buffer, 999);
+		byte_buffer[read_bytes] = '\0';
+		if (std::sscanf(byte_buffer, "%" SCNd64 "", &quota) != 1) {
+			return physical_cores;
+		}
+
+		handle = fs.OpenFile(CFS_PERIOD, FileFlags::FILE_FLAGS_READ);
+		read_bytes = fs.Read(*handle, (void *)byte_buffer, 999);
+		byte_buffer[read_bytes] = '\0';
+		if (std::sscanf(byte_buffer, "%" SCNd64 "", &period) != 1) {
+			return physical_cores;
+		}
+	} else {
+		// No cgroup quota
+		return physical_cores;
+	}
+	if (quota > 0 && period > 0) {
+		return idx_t(std::ceil((double)quota / (double)period));
+	} else {
+		return physical_cores;
+	}
+}
+
+} // namespace duckdb

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -22,20 +22,20 @@ optional_idx CGroups::GetMemoryLimit(FileSystem &fs) {
 }
 
 optional_idx CGroups::GetCGroupV2MemoryLimit(FileSystem &fs) {
-	const char *CGROUP_SELF = "/proc/self/cgroup";
-	const char *MEMORY_MAX = "/sys/fs/cgroup/%s/memory.max";
+	const char *cgroup_self = "/proc/self/cgroup";
+	const char *memory_max = "/sys/fs/cgroup/%s/memory.max";
 
-	if (!fs.FileExists(CGROUP_SELF)) {
+	if (!fs.FileExists(cgroup_self)) {
 		return optional_idx();
 	}
 
-	string cgroup_path = ReadCGroupPath(fs, CGROUP_SELF);
+	string cgroup_path = ReadCGroupPath(fs, cgroup_self);
 	if (cgroup_path.empty()) {
 		return optional_idx();
 	}
 
 	char memory_max_path[256];
-	snprintf(memory_max_path, sizeof(memory_max_path), MEMORY_MAX, cgroup_path.c_str());
+	snprintf(memory_max_path, sizeof(memory_max_path), memory_max, cgroup_path.c_str());
 
 	if (!fs.FileExists(memory_max_path)) {
 		return optional_idx();
@@ -45,14 +45,14 @@ optional_idx CGroups::GetCGroupV2MemoryLimit(FileSystem &fs) {
 }
 
 optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
-	const char *CGROUP_SELF = "/proc/self/cgroup";
+	const char *cgroup_self = "/proc/self/cgroup";
 	const char *MEMORY_LIMIT = "/sys/fs/cgroup/memory/%s/memory.limit_in_bytes";
 
-	if (!fs.FileExists(CGROUP_SELF)) {
+	if (!fs.FileExists(cgroup_self)) {
 		return optional_idx();
 	}
 
-	string memory_cgroup_path = ReadMemoryCGroupPath(fs, CGROUP_SELF);
+	string memory_cgroup_path = ReadMemoryCGroupPath(fs, cgroup_self);
 	if (memory_cgroup_path.empty()) {
 		return optional_idx();
 	}
@@ -118,33 +118,33 @@ optional_idx CGroups::ReadCGroupValue(FileSystem &fs, const char *file_path) {
 }
 
 idx_t CGroups::GetCPULimit(FileSystem &fs, idx_t physical_cores) {
-	static constexpr const char *CPU_MAX = "/sys/fs/cgroup/cpu.max";
-	static constexpr const char *CFS_QUOTA = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
-	static constexpr const char *CFS_PERIOD = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+	static constexpr const char *cpu_max = "/sys/fs/cgroup/cpu.max";
+	static constexpr const char *cfs_quota = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
+	static constexpr const char *cfs_period = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
 
 	int64_t quota, period;
 	char byte_buffer[1000];
 	unique_ptr<FileHandle> handle;
 	int64_t read_bytes;
 
-	if (fs.FileExists(CPU_MAX)) {
+	if (fs.FileExists(cpu_max)) {
 		// cgroup v2
-		handle = fs.OpenFile(CPU_MAX, FileFlags::FILE_FLAGS_READ);
+		handle = fs.OpenFile(cpu_max, FileFlags::FILE_FLAGS_READ);
 		read_bytes = fs.Read(*handle, (void *)byte_buffer, 999);
 		byte_buffer[read_bytes] = '\0';
 		if (std::sscanf(byte_buffer, "%" SCNd64 " %" SCNd64 "", &quota, &period) != 2) {
 			return physical_cores;
 		}
-	} else if (fs.FileExists(CFS_QUOTA) && fs.FileExists(CFS_PERIOD)) {
+	} else if (fs.FileExists(cfs_quota) && fs.FileExists(cfs_period)) {
 		// cgroup v1
-		handle = fs.OpenFile(CFS_QUOTA, FileFlags::FILE_FLAGS_READ);
+		handle = fs.OpenFile(cfs_quota, FileFlags::FILE_FLAGS_READ);
 		read_bytes = fs.Read(*handle, (void *)byte_buffer, 999);
 		byte_buffer[read_bytes] = '\0';
 		if (std::sscanf(byte_buffer, "%" SCNd64 "", &quota) != 1) {
 			return physical_cores;
 		}
 
-		handle = fs.OpenFile(CFS_PERIOD, FileFlags::FILE_FLAGS_READ);
+		handle = fs.OpenFile(cfs_period, FileFlags::FILE_FLAGS_READ);
 		read_bytes = fs.Read(*handle, (void *)byte_buffer, 999);
 		byte_buffer[read_bytes] = '\0';
 		if (std::sscanf(byte_buffer, "%" SCNd64 "", &period) != 1) {

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -46,7 +46,7 @@ optional_idx CGroups::GetCGroupV2MemoryLimit(FileSystem &fs) {
 
 optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 	const char *cgroup_self = "/proc/self/cgroup";
-	const char *MEMORY_LIMIT = "/sys/fs/cgroup/memory/%s/memory.limit_in_bytes";
+	const char *memory_limit = "/sys/fs/cgroup/memory/%s/memory.limit_in_bytes";
 
 	if (!fs.FileExists(cgroup_self)) {
 		return optional_idx();
@@ -58,7 +58,7 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 	}
 
 	char memory_limit_path[256];
-	snprintf(memory_limit_path, sizeof(memory_limit_path), MEMORY_LIMIT, memory_cgroup_path.c_str());
+	snprintf(memory_limit_path, sizeof(memory_limit_path), memory_limit, memory_cgroup_path.c_str());
 
 	if (!fs.FileExists(memory_limit_path)) {
 		return optional_idx();

--- a/src/include/duckdb/common/cgroups.hpp
+++ b/src/include/duckdb/common/cgroups.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/file_system.hpp"
 
 namespace duckdb {
@@ -24,7 +25,6 @@ private:
 	static string ReadCGroupPath(FileSystem &fs, const char *cgroup_file);
 	static string ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file);
 	static optional_idx ReadCGroupValue(FileSystem &fs, const char *file_path);
-	static idx_t CGroupBandwidthQuota(FileSystem &fs, idx_t physical_cores);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/cgroups.hpp
+++ b/src/include/duckdb/common/cgroups.hpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/cgroups.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/file_system.hpp"
+
+namespace duckdb {
+
+class CGroups {
+public:
+	static optional_idx GetMemoryLimit(FileSystem &fs);
+	static idx_t GetCPULimit(FileSystem &fs, idx_t physical_cores);
+
+private:
+	static optional_idx GetCGroupV2MemoryLimit(FileSystem &fs);
+	static optional_idx GetCGroupV1MemoryLimit(FileSystem &fs);
+	static string ReadCGroupPath(FileSystem &fs, const char *cgroup_file);
+	static string ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file);
+	static optional_idx ReadCGroupValue(FileSystem &fs, const char *file_path);
+	static idx_t CGroupBandwidthQuota(FileSystem &fs, idx_t physical_cores);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -326,7 +326,6 @@ public:
 	DUCKDB_API void CheckLock(const string &name);
 
 	DUCKDB_API static idx_t ParseMemoryLimit(const string &arg);
-	DUCKDB_API static idx_t ParseMemoryLimitSlurm(const string &arg);
 
 	//! Returns the list of possible compression functions for the physical type.
 	DUCKDB_API vector<reference<CompressionFunction>> GetCompressionFunctions(const PhysicalType physical_type);
@@ -341,6 +340,8 @@ public:
 	DUCKDB_API CollationBinding &GetCollationBinding();
 	DUCKDB_API IndexTypeSet &GetIndexTypes();
 	static idx_t GetSystemMaxThreads(FileSystem &fs);
+	static idx_t GetSystemAvailableMemory(FileSystem &fs);
+	static idx_t ParseMemoryLimitSlurm(const string &arg);
 	void SetDefaultMaxMemory();
 	void SetDefaultTempDirectory();
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/allocator.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/cgroups.hpp"
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/access_mode.hpp"
 #include "duckdb/common/enums/compression_type.hpp"

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -326,6 +326,7 @@ public:
 	DUCKDB_API void CheckLock(const string &name);
 
 	DUCKDB_API static idx_t ParseMemoryLimit(const string &arg);
+	DUCKDB_API static idx_t ParseMemoryLimitSlurm(const string &arg);
 
 	//! Returns the list of possible compression functions for the physical type.
 	DUCKDB_API vector<reference<CompressionFunction>> GetCompressionFunctions(const PhysicalType physical_type);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -294,12 +294,14 @@ IndexTypeSet &DBConfig::GetIndexTypes() {
 }
 
 void DBConfig::SetDefaultMaxMemory() {
-    auto memory = FileSystem::GetSystemAvailableMemory();
-    if (!memory.IsValid()) {
-        options.maximum_memory = DBConfigOptions().maximum_memory;
-        return;
+    auto memory = GetSystemAvailableMemory(*file_system);
+    if (memory == DBConfigOptions().maximum_memory) {
+        // If GetSystemAvailableMemory returned the default, use it as is
+        options.maximum_memory = memory;
+    } else {
+        // Otherwise, use 80% of the available memory
+        options.maximum_memory = memory * 8 / 10;
     }
-    options.maximum_memory = memory.GetIndex() * 8 / 10;
 }
 
 void DBConfig::SetDefaultTempDirectory() {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -294,25 +294,25 @@ IndexTypeSet &DBConfig::GetIndexTypes() {
 }
 
 void DBConfig::SetDefaultMaxMemory() {
-    const char* slurm_mem_per_node = getenv("SLURM_MEM_PER_NODE");
-    const char* slurm_mem_per_cpu = getenv("SLURM_MEM_PER_CPU");
-    const char* slurm_cpu_on_node = getenv("SLURM_CPU_ON_NODE");
-    if (slurm_mem_per_node) {
-        options.maximum_memory = ParseMemoryLimitSlurm(slurm_mem_per_node) * 8 / 10;
-        return;
-    } else if (slurm_mem_per_cpu && slurm_cpu_on_node) {
-        idx_t mem_per_cpu = ParseMemoryLimitSlurm(slurm_mem_per_cpu);
-        idx_t num_threads = std::stoi(slurm_cpu_on_node);
-        options.maximum_memory = mem_per_cpu * num_threads * 8 / 10;
-        return;
-    } else {
-        auto memory = FileSystem::GetAvailableMemory();
-        if (!memory.IsValid()) {
-            options.maximum_memory = DBConfigOptions().maximum_memory;
-            return;
-        }
-        options.maximum_memory = memory.GetIndex() * 8 / 10;
-    }
+	const char *slurm_mem_per_node = getenv("SLURM_MEM_PER_NODE");
+	const char *slurm_mem_per_cpu = getenv("SLURM_MEM_PER_CPU");
+	const char *slurm_cpu_on_node = getenv("SLURM_CPU_ON_NODE");
+	if (slurm_mem_per_node) {
+		options.maximum_memory = ParseMemoryLimitSlurm(slurm_mem_per_node) * 8 / 10;
+		return;
+	} else if (slurm_mem_per_cpu && slurm_cpu_on_node) {
+		idx_t mem_per_cpu = ParseMemoryLimitSlurm(slurm_mem_per_cpu);
+		idx_t num_threads = std::stoi(slurm_cpu_on_node);
+		options.maximum_memory = mem_per_cpu * num_threads * 8 / 10;
+		return;
+	} else {
+		auto memory = FileSystem::GetAvailableMemory();
+		if (!memory.IsValid()) {
+			options.maximum_memory = DBConfigOptions().maximum_memory;
+			return;
+		}
+		options.maximum_memory = memory.GetIndex() * 8 / 10;
+	}
 }
 
 void DBConfig::SetDefaultTempDirectory() {
@@ -388,18 +388,18 @@ idx_t CGroupBandwidthQuota(idx_t physical_cores, FileSystem &fs) {
 
 idx_t DBConfig::GetSystemMaxThreads(FileSystem &fs) {
 #ifdef DUCKDB_NO_THREADS
-    return 1;
+	return 1;
 #else
-    idx_t physical_cores = std::thread::hardware_concurrency();
-    #ifdef __linux__
-        if (const char* slurm_cpus = getenv("SLURM_CPUS_ON_NODE")) {
-            return std::max<idx_t>(std::stoi(slurm_cpus), 1);
-        }
-		auto cores_available_per_period = CGroupBandwidthQuota(physical_cores, fs);
-        return MaxValue<idx_t>(cores_available_per_period, 1);
-    #else
-        return physical_cores;
-    #endif
+	idx_t physical_cores = std::thread::hardware_concurrency();
+#ifdef __linux__
+	if (const char *slurm_cpus = getenv("SLURM_CPUS_ON_NODE")) {
+		return std::max<idx_t>(std::stoi(slurm_cpus), 1);
+	}
+	auto cores_available_per_period = CGroupBandwidthQuota(physical_cores, fs);
+	return MaxValue<idx_t>(cores_available_per_period, 1);
+#else
+	return physical_cores;
+#endif
 #endif
 }
 
@@ -466,36 +466,36 @@ idx_t DBConfig::ParseMemoryLimit(const string &arg) {
 }
 
 idx_t DBConfig::ParseMemoryLimitSlurm(const string &arg) {
-    if (arg.empty()) {
-        return 0;
-    }
+	if (arg.empty()) {
+		return 0;
+	}
 
-    string number_str = arg;
-    idx_t multiplier = 1000LL * 1000LL; // Default to MB if no unit specified
+	string number_str = arg;
+	idx_t multiplier = 1000LL * 1000LL; // Default to MB if no unit specified
 
-    // Check for SLURM-style suffixes
-    if (arg.back() == 'K' || arg.back() == 'k') {
-        number_str = arg.substr(0, arg.size() - 1);
-        multiplier = 1000LL;
-    } else if (arg.back() == 'M' || arg.back() == 'm') {
-        number_str = arg.substr(0, arg.size() - 1);
-        multiplier = 1000LL * 1000LL;
-    } else if (arg.back() == 'G' || arg.back() == 'g') {
-        number_str = arg.substr(0, arg.size() - 1);
-        multiplier = 1000LL * 1000LL * 1000LL;
-    } else if (arg.back() == 'T' || arg.back() == 't') {
-        number_str = arg.substr(0, arg.size() - 1);
-        multiplier = 1000LL * 1000LL * 1000LL * 1000LL;
-    }
+	// Check for SLURM-style suffixes
+	if (arg.back() == 'K' || arg.back() == 'k') {
+		number_str = arg.substr(0, arg.size() - 1);
+		multiplier = 1000LL;
+	} else if (arg.back() == 'M' || arg.back() == 'm') {
+		number_str = arg.substr(0, arg.size() - 1);
+		multiplier = 1000LL * 1000LL;
+	} else if (arg.back() == 'G' || arg.back() == 'g') {
+		number_str = arg.substr(0, arg.size() - 1);
+		multiplier = 1000LL * 1000LL * 1000LL;
+	} else if (arg.back() == 'T' || arg.back() == 't') {
+		number_str = arg.substr(0, arg.size() - 1);
+		multiplier = 1000LL * 1000LL * 1000LL * 1000LL;
+	}
 
-    // Parse the number
-    double limit = Cast::Operation<string_t, double>(string_t(number_str));
+	// Parse the number
+	double limit = Cast::Operation<string_t, double>(string_t(number_str));
 
-    if (limit < 0) {
-        return NumericLimits<idx_t>::Maximum();
-    }
+	if (limit < 0) {
+		return NumericLimits<idx_t>::Maximum();
+	}
 
-    return NumericCast<idx_t>(multiplier * limit);
+	return NumericCast<idx_t>(multiplier * limit);
 }
 
 // Right now we only really care about access mode when comparing DBConfigs

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -296,13 +296,13 @@ IndexTypeSet &DBConfig::GetIndexTypes() {
 void DBConfig::SetDefaultMaxMemory() {
 	const char *slurm_mem_per_node = getenv("SLURM_MEM_PER_NODE");
 	const char *slurm_mem_per_cpu = getenv("SLURM_MEM_PER_CPU");
-	const char *slurm_cpu_on_node = getenv("SLURM_CPU_ON_NODE");
+	const char *slurm_cpus_on_node = getenv("SLURM_CPUS_ON_NODE");
 	if (slurm_mem_per_node) {
 		options.maximum_memory = ParseMemoryLimitSlurm(slurm_mem_per_node) * 8 / 10;
 		return;
-	} else if (slurm_mem_per_cpu && slurm_cpu_on_node) {
+	} else if (slurm_mem_per_cpu && slurm_cpus_on_node) {
 		idx_t mem_per_cpu = ParseMemoryLimitSlurm(slurm_mem_per_cpu);
-		idx_t num_threads = std::stoi(slurm_cpu_on_node);
+		idx_t num_threads = std::stoi(slurm_cpus_on_node);
 		options.maximum_memory = mem_per_cpu * num_threads * 8 / 10;
 		return;
 	} else {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/main/config.hpp"
 
+#include "duckdb/common/cgroups.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/string_util.hpp"

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -294,14 +294,14 @@ IndexTypeSet &DBConfig::GetIndexTypes() {
 }
 
 void DBConfig::SetDefaultMaxMemory() {
-    auto memory = GetSystemAvailableMemory(*file_system);
-    if (memory == DBConfigOptions().maximum_memory) {
-        // If GetSystemAvailableMemory returned the default, use it as is
-        options.maximum_memory = memory;
-    } else {
-        // Otherwise, use 80% of the available memory
-        options.maximum_memory = memory * 8 / 10;
-    }
+	auto memory = GetSystemAvailableMemory(*file_system);
+	if (memory == DBConfigOptions().maximum_memory) {
+		// If GetSystemAvailableMemory returned the default, use it as is
+		options.maximum_memory = memory;
+	} else {
+		// Otherwise, use 80% of the available memory
+		options.maximum_memory = memory * 8 / 10;
+	}
 }
 
 void DBConfig::SetDefaultTempDirectory() {
@@ -377,40 +377,40 @@ idx_t CGroupBandwidthQuota(idx_t physical_cores, FileSystem &fs) {
 
 idx_t DBConfig::GetSystemMaxThreads(FileSystem &fs) {
 #ifdef DUCKDB_NO_THREADS
-    return 1;
+	return 1;
 #else
-    idx_t physical_cores = std::thread::hardware_concurrency();
+	idx_t physical_cores = std::thread::hardware_concurrency();
 #ifdef __linux__
-    if (const char *slurm_cpus = getenv("SLURM_CPUS_ON_NODE")) {
-        idx_t slurm_threads;
-        if (TryCast::Operation<string_t, idx_t>(string_t(slurm_cpus), slurm_threads)) {
-            return MaxValue<idx_t>(slurm_threads, 1);
-        }
-    }
-    auto cores_available_per_period = CGroupBandwidthQuota(physical_cores, fs);
-    return MaxValue<idx_t>(cores_available_per_period, 1);
+	if (const char *slurm_cpus = getenv("SLURM_CPUS_ON_NODE")) {
+		idx_t slurm_threads;
+		if (TryCast::Operation<string_t, idx_t>(string_t(slurm_cpus), slurm_threads)) {
+			return MaxValue<idx_t>(slurm_threads, 1);
+		}
+	}
+	auto cores_available_per_period = CGroupBandwidthQuota(physical_cores, fs);
+	return MaxValue<idx_t>(cores_available_per_period, 1);
 #else
-    return physical_cores;
+	return physical_cores;
 #endif
 #endif
 }
 
 idx_t DBConfig::GetSystemAvailableMemory(FileSystem &fs) {
-    const char *slurm_mem_per_node = getenv("SLURM_MEM_PER_NODE");
-    const char *slurm_mem_per_cpu = getenv("SLURM_MEM_PER_CPU");
-    if (slurm_mem_per_node) {
-        return ParseMemoryLimitSlurm(slurm_mem_per_node);
-    } else if (slurm_mem_per_cpu) {
-        idx_t mem_per_cpu = ParseMemoryLimitSlurm(slurm_mem_per_cpu);
-        idx_t num_threads = GetSystemMaxThreads(fs);
-        return mem_per_cpu * num_threads;
-    } else {
-        auto memory = FileSystem::GetAvailableMemory();
-        if (!memory.IsValid()) {
-            return DBConfigOptions().maximum_memory;
-        }
-        return memory.GetIndex();
-    }
+	const char *slurm_mem_per_node = getenv("SLURM_MEM_PER_NODE");
+	const char *slurm_mem_per_cpu = getenv("SLURM_MEM_PER_CPU");
+	if (slurm_mem_per_node) {
+		return ParseMemoryLimitSlurm(slurm_mem_per_node);
+	} else if (slurm_mem_per_cpu) {
+		idx_t mem_per_cpu = ParseMemoryLimitSlurm(slurm_mem_per_cpu);
+		idx_t num_threads = GetSystemMaxThreads(fs);
+		return mem_per_cpu * num_threads;
+	} else {
+		auto memory = FileSystem::GetAvailableMemory();
+		if (!memory.IsValid()) {
+			return DBConfigOptions().maximum_memory;
+		}
+		return memory.GetIndex();
+	}
 }
 
 idx_t DBConfig::ParseMemoryLimit(const string &arg) {


### PR DESCRIPTION
Use Slurm env vars SLURM_CPU_ON_NODE, SLURM_MEM_PER_NODE, SLURM_MEM_PER_CPU to allocate CPU and memory resources if DuckDB is run inside a Slurm job on an HPC cluster