### PR TITLE
Use jaro winkler similarity for finding similar entries in catalog

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -62,7 +62,6 @@ static vector<string> ComputeSuggestions(vector<AutoCompleteCandidate> available
 		} else {
 			score += StringUtil::SimilarityScore(str, prefix);
 		}
-		D_ASSERT(score >= 0);
 		scores.emplace_back(str, score);
 	}
 	auto results = StringUtil::TopNStrings(scores, 20, 999);

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -364,7 +364,7 @@ SimilarCatalogEntry Catalog::SimilarEntryInSchemas(ClientContext &context, const
 			// no similar entry found
 			continue;
 		}
-		if (!result.Found() || result.distance > entry.distance) {
+		if (!result.Found() || result.score < entry.score) {
 			result = entry;
 			result.schema = &schema;
 		}
@@ -628,11 +628,10 @@ CatalogException Catalog::CreateMissingEntryException(ClientContext &context, co
 
 	// entries in other schemas get a penalty
 	// however, if there is an exact match in another schema, we will always show it
-	static constexpr const idx_t UNSEEN_PENALTY = 2;
+	static constexpr const double UNSEEN_PENALTY = 0.2;
 	auto unseen_entry = SimilarEntryInSchemas(context, entry_name, type, unseen_schemas);
 	string did_you_mean;
-	if (unseen_entry.Found() &&
-	    (unseen_entry.distance == 0 || unseen_entry.distance + UNSEEN_PENALTY < entry.distance)) {
+	if (unseen_entry.Found() && (unseen_entry.score == 1.0 || unseen_entry.score - UNSEEN_PENALTY > entry.score)) {
 		// the closest matching entry requires qualification as it is not in the default search path
 		// check how to minimally qualify this entry
 		auto catalog_name = unseen_entry.schema->catalog.GetName();

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -626,9 +626,13 @@ CatalogException Catalog::CreateMissingEntryException(ClientContext &context, co
 		return CatalogException(error_message);
 	}
 
+	// entries in other schemas get a penalty
+	// however, if there is an exact match in another schema, we will always show it
+	static constexpr const idx_t UNSEEN_PENALTY = 2;
 	auto unseen_entry = SimilarEntryInSchemas(context, entry_name, type, unseen_schemas);
 	string did_you_mean;
-	if (unseen_entry.Found() && unseen_entry.distance < entry.distance) {
+	if (unseen_entry.Found() &&
+	    (unseen_entry.distance == 0 || unseen_entry.distance + UNSEEN_PENALTY < entry.distance)) {
 		// the closest matching entry requires qualification as it is not in the default search path
 		// check how to minimally qualify this entry
 		auto catalog_name = unseen_entry.schema->catalog.GetName();

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -30,9 +30,9 @@ SimilarCatalogEntry SchemaCatalogEntry::GetSimilarEntry(CatalogTransaction trans
                                                         const string &name) {
 	SimilarCatalogEntry result;
 	Scan(transaction.GetContext(), type, [&](CatalogEntry &entry) {
-		auto ldist = StringUtil::SimilarityScore(entry.name, name);
-		if (ldist < result.distance) {
-			result.distance = ldist;
+		auto entry_score = StringUtil::SimilarityRating(entry.name, name);
+		if (entry_score > result.score) {
+			result.score = entry_score;
 			result.name = entry.name;
 		}
 	});

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -507,9 +507,9 @@ SimilarCatalogEntry CatalogSet::SimilarEntry(CatalogTransaction transaction, con
 
 	SimilarCatalogEntry result;
 	for (auto &kv : map.Entries()) {
-		auto ldist = StringUtil::SimilarityScore(kv.first, name);
-		if (ldist < result.distance) {
-			result.distance = ldist;
+		auto entry_score = StringUtil::SimilarityRating(kv.first, name);
+		if (entry_score > result.score) {
+			result.score = entry_score;
 			result.name = kv.first;
 		}
 	}

--- a/src/core_functions/scalar/union/union_extract.cpp
+++ b/src/core_functions/scalar/union/union_extract.cpp
@@ -88,7 +88,7 @@ static unique_ptr<FunctionData> UnionExtractBind(ClientContext &context, ScalarF
 		for (idx_t i = 0; i < union_member_count; i++) {
 			candidates.push_back(UnionType::GetMemberName(arguments[0]->return_type, i));
 		}
-		auto closest_settings = StringUtil::TopNLevenshtein(candidates, key);
+		auto closest_settings = StringUtil::TopNJaroWinkler(candidates, key);
 		auto message = StringUtil::CandidatesMessage(closest_settings, "Candidate Entries");
 		throw BinderException("Could not find key \"%s\" in union\n%s", key, message);
 	}

--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -92,7 +92,7 @@ static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, Scalar
 		for (auto &struct_child : struct_children) {
 			candidates.push_back(struct_child.first);
 		}
-		auto closest_settings = StringUtil::TopNLevenshtein(candidates, key);
+		auto closest_settings = StringUtil::TopNJaroWinkler(candidates, key);
 		auto message = StringUtil::CandidatesMessage(closest_settings, "Candidate Entries");
 		throw BinderException("Could not find key \"%s\" in struct\n%s", key, message);
 	}

--- a/src/include/duckdb/catalog/similar_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/similar_catalog_entry.hpp
@@ -18,8 +18,8 @@ class SchemaCatalogEntry;
 struct SimilarCatalogEntry {
 	//! The entry name. Empty if absent
 	string name;
-	//! The distance to the given name.
-	idx_t distance = idx_t(-1);
+	//! The similarity score of the given name (between 0.0 and 1.0, higher is better)
+	double score = 0.0;
 	//! The schema of the entry.
 	optional_ptr<SchemaCatalogEntry> schema;
 

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/pair.hpp"
 #include "duckdb/common/set.hpp"
 #include "duckdb/common/vector.hpp"
 
@@ -228,17 +229,28 @@ public:
 	//! with an equal penalty of 3, "depdelay_minutes" is closer to "depdelay" than to "pg_am"
 	DUCKDB_API static idx_t LevenshteinDistance(const string &s1, const string &s2, idx_t not_equal_penalty = 1);
 
-	//! Returns the similarity score between two strings
+	//! Returns the similarity score between two strings (edit distance metric - lower is more similar)
 	DUCKDB_API static idx_t SimilarityScore(const string &s1, const string &s2);
+	//! Returns a normalized similarity rating between 0.0 - 1.0 (higher is more similar)
+	DUCKDB_API static double SimilarityRating(const string &s1, const string &s2);
 	//! Get the top-n strings (sorted by the given score distance) from a set of scores.
+	//! The scores should be normalized between 0.0 and 1.0, where 1.0 is the highest score
 	//! At least one entry is returned (if there is one).
-	//! Strings are only returned if they have a score less than the threshold.
-	DUCKDB_API static vector<string> TopNStrings(vector<std::pair<string, idx_t>> scores, idx_t n = 5,
+	//! Strings are only returned if they have a score higher than the threshold.
+	DUCKDB_API static vector<string> TopNStrings(vector<pair<string, double>> scores, idx_t n = 5,
+	                                             double threshold = 0.5);
+	//! DEPRECATED: old TopNStrings method that uses the levenshtein distance metric instead of the normalized 0.0 - 1.0
+	//! rating
+	DUCKDB_API static vector<string> TopNStrings(const vector<pair<string, idx_t>> &scores, idx_t n = 5,
 	                                             idx_t threshold = 5);
 	//! Computes the levenshtein distance of each string in strings, and compares it to target, then returns TopNStrings
 	//! with the given params.
 	DUCKDB_API static vector<string> TopNLevenshtein(const vector<string> &strings, const string &target, idx_t n = 5,
 	                                                 idx_t threshold = 5);
+	//! Computes the jaro winkler distance of each string in strings, and compares it to target, then returns
+	//! TopNStrings with the given params.
+	DUCKDB_API static vector<string> TopNJaroWinkler(const vector<string> &strings, const string &target, idx_t n = 5,
+	                                                 double threshold = 0.5);
 	DUCKDB_API static string CandidatesMessage(const vector<string> &candidates,
 	                                           const string &candidate = "Candidate bindings");
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -122,7 +122,7 @@ bool ExtensionHelper::CreateSuggestions(const string &extension_name, string &me
 	for (idx_t ext_count = ExtensionHelper::ExtensionAliasCount(), i = 0; i < ext_count; i++) {
 		candidates.emplace_back(ExtensionHelper::GetExtensionAlias(i).alias);
 	}
-	auto closest_extensions = StringUtil::TopNLevenshtein(candidates, lowercase_extension_name);
+	auto closest_extensions = StringUtil::TopNJaroWinkler(candidates, lowercase_extension_name);
 	message = StringUtil::CandidatesMessage(closest_extensions, "Candidate extensions");
 	for (auto &closest : closest_extensions) {
 		if (closest == lowercase_extension_name) {

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -45,11 +45,11 @@ string BindContext::GetMatchingBinding(const string &column_name) {
 }
 
 vector<string> BindContext::GetSimilarBindings(const string &column_name) {
-	vector<pair<string, idx_t>> scores;
+	vector<pair<string, double>> scores;
 	for (auto &kv : bindings) {
 		auto binding = kv.second.get();
 		for (auto &name : binding->names) {
-			idx_t distance = StringUtil::SimilarityScore(name, column_name);
+			double distance = StringUtil::SimilarityRating(name, column_name);
 			scores.emplace_back(binding->alias + "." + name, distance);
 		}
 	}
@@ -246,7 +246,7 @@ optional_ptr<Binding> BindContext::GetBinding(const string &name, ErrorData &out
 			candidates.push_back(kv.first);
 		}
 		string candidate_str =
-		    StringUtil::CandidatesMessage(StringUtil::TopNLevenshtein(candidates, name), "Candidate tables");
+		    StringUtil::CandidatesMessage(StringUtil::TopNJaroWinkler(candidates, name), "Candidate tables");
 		out_error = ErrorData(ExceptionType::BINDER,
 		                      StringUtil::Format("Referenced table \"%s\" not found!%s", name, candidate_str));
 		return nullptr;

--- a/test/sql/binder/similar_to.test
+++ b/test/sql/binder/similar_to.test
@@ -1,5 +1,5 @@
 # name: test/sql/binder/similar_to.test
-# description: Test table alias with single quotes
+# description: Test similar to suggestions
 # group: [binder]
 
 statement ok

--- a/test/sql/binder/similar_to.test
+++ b/test/sql/binder/similar_to.test
@@ -21,13 +21,44 @@ depdelay_minutes
 statement ok
 CREATE TABLE lineitem(i INTEGER);
 
-# Commenting for now to allow CI to pass
-# statement error
-# SELECT * FROM li
-# ----
-# lineitem
+statement error
+SELECT * FROM li
+----
+lineitem
 
 statement error
 SELECT * FROM lineitem_long
 ----
 lineitem
+
+statement error
+select jaro_winkler_('x', 'y');
+----
+jaro_winkler_similarity
+
+# check entries in other schemas
+statement ok
+create schema s1;
+
+statement ok
+create table s1.my_lineitem(i int);
+
+# exact match: show it
+statement error
+select * from my_lineitem;
+----
+s1.my_lineitem
+
+# we prefer the current schema even if another schema has a slightly better match
+statement error
+select * from m_lineitem;
+----
+lineitem
+
+statement ok
+create table s1.orders(i int)
+
+statement error
+select * from ord
+----
+s1.orders


### PR DESCRIPTION

When a catalog entry is not found, we try to helpfully offer a recommended alternative, e.g.:

```sql
D select arg_mi(42,84);
-- Catalog Error: Scalar Function with name arg_mi does not exist!
-- Did you mean "arg_min"?
-- LINE 1: select arg_mi(42,84);
--                ^
```

This currently uses the [levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) on candidate catalog entries. While this works reasonably well, the levenshtein distance has a shortcoming in that it does not really work well on entries that have different lengths - as the edit distance metric used penalizes extra characters in the same manner as *different* characters. As a result, strings of similar length are almost always shown over what we would consider "more similar" strings.

For example, in the current release:

```sql
D select jaro_winkler('a', 'b');
-- Catalog Error: Scalar Function with name jaro_winkler does not exist!
-- Did you mean "arg_min"?
-- LINE 1: select jaro_winkler('a', 'b');
--                ^
```

Most likely the user meant either the functions `jaro_winkler_similarity`, or `jaro_similarity`. However, the levenshtein metric considers the more similarity sized `arg_min` as more similar:

```sql
D select levenshtein('jaro_winkler', 'arg_min') as levenshtein;
┌─────────────┐
│ levenshtein │
│    int64    │
├─────────────┤
│           7 │
└─────────────┘
D select levenshtein('jaro_winkler', 'jaro_similarity') as levenshtein;
┌─────────────┐
│ levenshtein │
│    int64    │
├─────────────┤
│           7 │
└─────────────┘
D select levenshtein('jaro_winkler', 'jaro_winkler_similarity') as levenshtein;
┌─────────────┐
│ levenshtein │
│    int64    │
├─────────────┤
│          11 │
└─────────────┘
```

The [jaro-winkler similarity](https://en.wikipedia.org/wiki/Jaro–Winkler_distance) is instead designed towards preferring matching prefixes, which makes the matches much more natural. Here's some examples of previous and new suggestions:


| Query  | Old Suggestion | New Suggestion  |
|--------|----------------|-----------------|
| lea    | era            | least           |
| jaro   | bar            | jaro_similarity |
| hist   | list           | histogram       |
| to_min | min            | to_minutes      |
