### PR TITLE
Internal #2503: Streaming Window Reset

### DIFF
--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -558,6 +558,10 @@ OperatorResultType PhysicalStreamingWindow::Execute(ExecutionContext &context, D
 	}
 
 	auto &delayed = state.delayed;
+	// We can Reset delayed now that no one can be referencing it.
+	if (!delayed.size()) {
+		delayed.Reset();
+	}
 	const idx_t available = delayed.size() + input.size();
 	if (available <= state.lead_count) {
 		//	If we don't have enough to produce a single row,
@@ -569,7 +573,8 @@ OperatorResultType PhysicalStreamingWindow::Execute(ExecutionContext &context, D
 	} else if (delayed.size()) {
 		//	We have enough delayed rows so flush them
 		ExecuteDelayed(context, delayed, input, chunk, gstate_p, state_p);
-		delayed.Reset();
+		// Defer resetting delayed as it may be referenced.
+		delayed.SetCardinality(0);
 		// Come back to process the input
 		return OperatorResultType::HAVE_MORE_OUTPUT;
 	} else {


### PR DESCRIPTION
Don't reset the delayed data while it is still being referenced.

fixes: duckdblabs/duckdb-internal#2503