### PR TITLE
Add work-around for R client table function initialization back in under a config setting

### DIFF
--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -118,13 +118,13 @@ private:
 	void InitializeInternal(PhysicalOperator &physical_plan);
 
 	void ScheduleEvents(const vector<shared_ptr<MetaPipeline>> &meta_pipelines);
-	static void ScheduleEventsInternal(ScheduleEventData &event_data);
+	void ScheduleEventsInternal(ScheduleEventData &event_data);
 
 	static void VerifyScheduledEvents(const ScheduleEventData &event_data);
 	static void VerifyScheduledEventsInternal(const idx_t i, const vector<reference<Event>> &vertices,
 	                                          vector<bool> &visited, vector<bool> &recursion_stack);
 
-	static void SchedulePipeline(const shared_ptr<MetaPipeline> &pipeline, ScheduleEventData &event_data);
+	void SchedulePipeline(const shared_ptr<MetaPipeline> &pipeline, ScheduleEventData &event_data);
 
 	bool NextExecutor();
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -250,6 +250,10 @@ struct DBConfigOptions {
 	//! If fewer than MAX(index_scan_max_count, index_scan_percentage * total_row_count)
 	// rows match, we perform an index scan instead of a table scan.
 	idx_t index_scan_max_count = STANDARD_VECTOR_SIZE;
+	//! Whether or not we initialize table functions in the main thread
+	//! This is a work-around that exists for certain clients (specifically R)
+	//! Because those clients do not like it when threads other than the main thread call into R, for e.g., arrow scans
+	bool initialize_in_main_thread = false;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -149,6 +149,12 @@ void Executor::SchedulePipeline(const shared_ptr<MetaPipeline> &meta_pipeline, S
 
 	// set up the dependencies within this MetaPipeline
 	for (auto &pipeline : pipelines) {
+		auto &config = DBConfig::GetConfig(context);
+		auto source = pipeline->GetSource();
+		if (source->type == PhysicalOperatorType::TABLE_SCAN && config.options.initialize_in_main_thread) {
+			// this is a work-around for the R client that requires the init to be called in the main thread
+			pipeline->ResetSource(true);
+		}
 		auto dependencies = meta_pipeline->GetDependencies(*pipeline);
 		if (!dependencies) {
 			continue;


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/12947

The join-filter pushdown needs the source initialization to be postponed so that we have the dynamically pushed down filters available when the probe is initialized. This conflicts with a work-around we need for the R client where we need to initialize all scans in the main thread as R's stack-depth detection algorithm does not deal well with multi-threading. In order to reconcile this we add a flag `initialize_in_main_thread` that can be set in the R client.

Note that setting this flag effectively disables dynamic join filter pushdown.