### PR TITLE
[Python] Fix lifetime issue with MaterializedRelation

### DIFF
--- a/src/include/duckdb/main/relation/materialized_relation.hpp
+++ b/src/include/duckdb/main/relation/materialized_relation.hpp
@@ -16,7 +16,8 @@ namespace duckdb {
 
 class MaterializedDependency : public DependencyItem {
 public:
-	MaterializedDependency(unique_ptr<ColumnDataCollection> &&collection_p) : collection(std::move(collection_p)) {
+	explicit MaterializedDependency(unique_ptr<ColumnDataCollection> &&collection_p)
+	    : collection(std::move(collection_p)) {
 	}
 	~MaterializedDependency() override {};
 

--- a/src/include/duckdb/main/relation/materialized_relation.hpp
+++ b/src/include/duckdb/main/relation/materialized_relation.hpp
@@ -10,7 +10,6 @@
 
 #include "duckdb/main/relation.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
-#include "duckdb/main/external_dependencies.hpp"
 
 namespace duckdb {
 
@@ -28,7 +27,6 @@ public:
 	string GetAlias() override;
 	unique_ptr<TableRef> GetTableRef() override;
 	unique_ptr<QueryNode> GetQueryNode() override;
-	shared_ptr<DependencyItem> GetMaterializedDependency();
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/relation/materialized_relation.hpp
+++ b/src/include/duckdb/main/relation/materialized_relation.hpp
@@ -14,23 +14,13 @@
 
 namespace duckdb {
 
-class MaterializedDependency : public DependencyItem {
-public:
-	explicit MaterializedDependency(unique_ptr<ColumnDataCollection> &&collection_p)
-	    : collection(std::move(collection_p)) {
-	}
-	~MaterializedDependency() override {};
-
-public:
-	unique_ptr<ColumnDataCollection> collection;
-};
-
 class MaterializedRelation : public Relation {
 public:
 	MaterializedRelation(const shared_ptr<ClientContext> &context, unique_ptr<ColumnDataCollection> &&collection,
 	                     vector<string> names, string alias = "materialized");
 	vector<ColumnDefinition> columns;
 	string alias;
+	shared_ptr<ColumnDataCollection> collection;
 
 public:
 	const vector<ColumnDefinition> &Columns() override;

--- a/src/include/duckdb/main/relation/materialized_relation.hpp
+++ b/src/include/duckdb/main/relation/materialized_relation.hpp
@@ -10,17 +10,24 @@
 
 #include "duckdb/main/relation.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
+#include "duckdb/main/external_dependencies.hpp"
 
 namespace duckdb {
+
+class MaterializedDependency : public DependencyItem {
+public:
+	MaterializedDependency(unique_ptr<ColumnDataCollection> &&collection_p) : collection(std::move(collection_p)) {
+	}
+	~MaterializedDependency() override {};
+
+public:
+	unique_ptr<ColumnDataCollection> collection;
+};
 
 class MaterializedRelation : public Relation {
 public:
 	MaterializedRelation(const shared_ptr<ClientContext> &context, unique_ptr<ColumnDataCollection> &&collection,
 	                     vector<string> names, string alias = "materialized");
-	MaterializedRelation(const shared_ptr<ClientContext> &context, const string &values, vector<string> names,
-	                     string alias = "materialized");
-
-	unique_ptr<ColumnDataCollection> collection;
 	vector<ColumnDefinition> columns;
 	string alias;
 
@@ -30,6 +37,7 @@ public:
 	string GetAlias() override;
 	unique_ptr<TableRef> GetTableRef() override;
 	unique_ptr<QueryNode> GetQueryNode() override;
+	shared_ptr<DependencyItem> GetMaterializedDependency();
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/tableref/column_data_ref.hpp
+++ b/src/include/duckdb/parser/tableref/column_data_ref.hpp
@@ -21,19 +21,19 @@ public:
 	static constexpr const TableReferenceType TYPE = TableReferenceType::COLUMN_DATA;
 
 public:
-	explicit ColumnDataRef(shared_ptr<MaterializedDependency> collection) : TableRef(TableReferenceType::COLUMN_DATA) {
-		external_dependency = make_shared_ptr<ExternalDependency>();
-		external_dependency->AddDependency("materialized", std::move(collection));
+	explicit ColumnDataRef(shared_ptr<ColumnDataCollection> collection)
+	    : TableRef(TableReferenceType::COLUMN_DATA), collection(std::move(collection)) {
 	}
-	ColumnDataRef(shared_ptr<MaterializedDependency> collection, vector<string> expected_names)
-	    : TableRef(TableReferenceType::COLUMN_DATA), expected_names(std::move(expected_names)) {
-		external_dependency = make_shared_ptr<ExternalDependency>();
-		external_dependency->AddDependency("materialized", std::move(collection));
+	ColumnDataRef(shared_ptr<ColumnDataCollection> collection, vector<string> expected_names)
+	    : TableRef(TableReferenceType::COLUMN_DATA), expected_names(std::move(expected_names)),
+	      collection(std::move(collection)) {
 	}
 
 public:
 	//! The set of expected names
 	vector<string> expected_names;
+	//! The collection to scan
+	shared_ptr<ColumnDataCollection> collection;
 
 public:
 	string ToString() const override;

--- a/src/include/duckdb/parser/tableref/column_data_ref.hpp
+++ b/src/include/duckdb/parser/tableref/column_data_ref.hpp
@@ -11,25 +11,27 @@
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/common/optionally_owned_ptr.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/main/relation/materialized_relation.hpp"
 
 namespace duckdb {
+
 //! Represents a TableReference to a materialized result
 class ColumnDataRef : public TableRef {
 public:
 	static constexpr const TableReferenceType TYPE = TableReferenceType::COLUMN_DATA;
 
 public:
-	explicit ColumnDataRef(ColumnDataCollection &collection)
-	    : TableRef(TableReferenceType::COLUMN_DATA), collection(collection) {
+	explicit ColumnDataRef(shared_ptr<MaterializedDependency> collection) : TableRef(TableReferenceType::COLUMN_DATA) {
+		external_dependency = make_shared_ptr<ExternalDependency>();
+		external_dependency->AddDependency("materialized", std::move(collection));
 	}
-	ColumnDataRef(vector<string> expected_names, optionally_owned_ptr<ColumnDataCollection> collection_p)
-	    : TableRef(TableReferenceType::COLUMN_DATA), collection(std::move(collection_p)),
-	      expected_names(std::move(expected_names)) {
+	ColumnDataRef(shared_ptr<MaterializedDependency> collection, vector<string> expected_names)
+	    : TableRef(TableReferenceType::COLUMN_DATA), expected_names(std::move(expected_names)) {
+		external_dependency = make_shared_ptr<ExternalDependency>();
+		external_dependency->AddDependency("materialized", std::move(collection));
 	}
 
 public:
-	//! (optionally owned) materialized column data
-	optionally_owned_ptr<ColumnDataCollection> collection;
 	//! The set of expected names
 	vector<string> expected_names;
 
@@ -43,4 +45,5 @@ public:
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<TableRef> Deserialize(Deserializer &source);
 };
+
 } // namespace duckdb

--- a/src/include/duckdb/parser/tableref/column_data_ref.hpp
+++ b/src/include/duckdb/parser/tableref/column_data_ref.hpp
@@ -11,7 +11,6 @@
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/common/optionally_owned_ptr.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
-#include "duckdb/main/relation/materialized_relation.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/storage/serialization/tableref.json
+++ b/src/include/duckdb/storage/serialization/tableref.json
@@ -161,7 +161,19 @@
     "class": "ColumnDataRef",
     "base": "TableRef",
     "enum": "COLUMN_DATA",
-	"custom_implementation": true
+    "members": [
+      {
+        "id": 200,
+        "name": "expected_names",
+        "type": "vector<string>"
+      },
+      {
+        "id": 202,
+        "name": "collection",
+        "type": "shared_ptr<ColumnDataCollection>"
+      }
+    ],
+    "constructor": ["collection", "expected_names"]
   },
   {
     "class": "PivotRef",

--- a/src/include/duckdb/storage/serialization/tableref.json
+++ b/src/include/duckdb/storage/serialization/tableref.json
@@ -161,19 +161,7 @@
     "class": "ColumnDataRef",
     "base": "TableRef",
     "enum": "COLUMN_DATA",
-    "members": [
-      {
-        "id": 200,
-        "name": "expected_names",
-        "type": "vector<string>"
-      },
-      {
-        "id": 202,
-        "name": "collection",
-        "type": "optionally_owned_ptr<ColumnDataCollection>"
-      }
-    ],
-    "constructor": ["expected_names", "collection"]
+	"custom_implementation": true
   },
   {
     "class": "PivotRef",

--- a/src/main/relation/create_view_relation.cpp
+++ b/src/main/relation/create_view_relation.cpp
@@ -9,9 +9,6 @@ CreateViewRelation::CreateViewRelation(shared_ptr<Relation> child_p, string view
                                        bool temporary_p)
     : Relation(child_p->context, RelationType::CREATE_VIEW_RELATION), child(std::move(child_p)),
       view_name(std::move(view_name_p)), replace(replace_p), temporary(temporary_p) {
-	if (child->type == RelationType::MATERIALIZED_RELATION) {
-		throw NotImplementedException("Creating a VIEW from a MaterializedRelation is not supported");
-	}
 	context.GetContext()->TryBindRelation(*this, this->columns);
 }
 
@@ -20,9 +17,6 @@ CreateViewRelation::CreateViewRelation(shared_ptr<Relation> child_p, string sche
     : Relation(child_p->context, RelationType::CREATE_VIEW_RELATION), child(std::move(child_p)),
       schema_name(std::move(schema_name_p)), view_name(std::move(view_name_p)), replace(replace_p),
       temporary(temporary_p) {
-	if (child->type == RelationType::MATERIALIZED_RELATION) {
-		throw NotImplementedException("Creating a VIEW from a MaterializedRelation is not supported");
-	}
 	context.GetContext()->TryBindRelation(*this, this->columns);
 }
 

--- a/src/parser/tableref/column_data_ref.cpp
+++ b/src/parser/tableref/column_data_ref.cpp
@@ -52,15 +52,6 @@ bool ColumnDataRef::Equals(const TableRef &other_p) const {
 	return true;
 }
 
-void ColumnDataRef::Serialize(Serializer &serializer) const {
-	throw NotImplementedException(
-	    "ColumnDataRef is made as part of a MaterializedRelation and should never be serialized");
-}
-
-unique_ptr<TableRef> ColumnDataRef::Deserialize(Deserializer &source) {
-	throw InternalException("Can not be serialized");
-}
-
 unique_ptr<TableRef> ColumnDataRef::Copy() {
 	auto result = make_uniq<ColumnDataRef>(collection, expected_names);
 	CopyProperties(*result);

--- a/src/parser/tableref/column_data_ref.cpp
+++ b/src/parser/tableref/column_data_ref.cpp
@@ -16,13 +16,8 @@ bool ColumnDataRef::Equals(const TableRef &other_p) const {
 		return false;
 	}
 	auto &other = other_p.Cast<ColumnDataRef>();
-
-	auto &collection_a = collection;
-	auto &collection_b = other.collection;
-
-	auto expected_types = collection_a->Types();
-	auto other_expected_types = collection_b->Types();
-
+	auto expected_types = collection->Types();
+	auto other_expected_types = other.collection->Types();
 	if (expected_types.size() != other_expected_types.size()) {
 		return false;
 	}
@@ -45,8 +40,7 @@ bool ColumnDataRef::Equals(const TableRef &other_p) const {
 		}
 	}
 	string unused;
-
-	if (!ColumnDataCollection::ResultEquals(*collection_a, *collection_b, unused, true)) {
+	if (!ColumnDataCollection::ResultEquals(*collection, *other.collection, unused, true)) {
 		return false;
 	}
 	return true;

--- a/src/parser/tableref/column_data_ref.cpp
+++ b/src/parser/tableref/column_data_ref.cpp
@@ -7,9 +7,7 @@
 namespace duckdb {
 
 string ColumnDataRef::ToString() const {
-	auto dependency_item = external_dependency->GetDependency("materialized");
-	auto &materialized_dependency = dependency_item->Cast<MaterializedDependency>();
-	auto result = materialized_dependency.collection->ToString();
+	auto result = collection->ToString();
 	return BaseToString(result, expected_names);
 }
 
@@ -19,13 +17,8 @@ bool ColumnDataRef::Equals(const TableRef &other_p) const {
 	}
 	auto &other = other_p.Cast<ColumnDataRef>();
 
-	auto dependency_item_a = external_dependency->GetDependency("materialized");
-	auto &materialized_a = dependency_item_a->Cast<MaterializedDependency>();
-	auto &collection_a = materialized_a.collection;
-
-	auto dependency_item_b = other.external_dependency->GetDependency("materialized");
-	auto &materialized_b = dependency_item_b->Cast<MaterializedDependency>();
-	auto &collection_b = materialized_b.collection;
+	auto &collection_a = collection;
+	auto &collection_b = other.collection;
 
 	auto expected_types = collection_a->Types();
 	auto other_expected_types = collection_b->Types();
@@ -69,9 +62,7 @@ unique_ptr<TableRef> ColumnDataRef::Deserialize(Deserializer &source) {
 }
 
 unique_ptr<TableRef> ColumnDataRef::Copy() {
-	auto dependency_item = external_dependency->GetDependency("materialized");
-	auto materialized_dependency = shared_ptr_cast<DependencyItem, MaterializedDependency>(std::move(dependency_item));
-	auto result = make_uniq<ColumnDataRef>(materialized_dependency, expected_names);
+	auto result = make_uniq<ColumnDataRef>(collection, expected_names);
 	CopyProperties(*result);
 	return std::move(result);
 }

--- a/src/planner/binder/tableref/bind_column_data_ref.cpp
+++ b/src/planner/binder/tableref/bind_column_data_ref.cpp
@@ -6,11 +6,9 @@
 namespace duckdb {
 
 unique_ptr<BoundTableRef> Binder::Bind(ColumnDataRef &ref) {
-	auto dependency_item = ref.external_dependency->GetDependency("materialized");
-	auto &materialized_dependency = dependency_item->Cast<MaterializedDependency>();
-
-	auto types = materialized_dependency.collection->Types();
-	auto result = make_uniq<BoundColumnDataRef>(*materialized_dependency.collection);
+	auto &collection = *ref.collection;
+	auto types = collection.Types();
+	auto result = make_uniq<BoundColumnDataRef>(collection);
 	result->bind_index = GenerateTableIndex();
 	bind_context.AddGenericBinding(result->bind_index, ref.alias, ref.expected_names, types);
 	return unique_ptr_cast<BoundColumnDataRef, BoundTableRef>(std::move(result));

--- a/src/planner/binder/tableref/bind_column_data_ref.cpp
+++ b/src/planner/binder/tableref/bind_column_data_ref.cpp
@@ -6,8 +6,11 @@
 namespace duckdb {
 
 unique_ptr<BoundTableRef> Binder::Bind(ColumnDataRef &ref) {
-	auto types = ref.collection->Types();
-	auto result = make_uniq<BoundColumnDataRef>(std::move(ref.collection));
+	auto dependency_item = ref.external_dependency->GetDependency("materialized");
+	auto &materialized_dependency = dependency_item->Cast<MaterializedDependency>();
+
+	auto types = materialized_dependency.collection->Types();
+	auto result = make_uniq<BoundColumnDataRef>(*materialized_dependency.collection);
 	result->bind_index = GenerateTableIndex();
 	bind_context.AddGenericBinding(result->bind_index, ref.alias, ref.expected_names, types);
 	return unique_ptr_cast<BoundColumnDataRef, BoundTableRef>(std::move(result));

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -76,19 +76,6 @@ unique_ptr<TableRef> BaseTableRef::Deserialize(Deserializer &deserializer) {
 	return std::move(result);
 }
 
-void ColumnDataRef::Serialize(Serializer &serializer) const {
-	TableRef::Serialize(serializer);
-	serializer.WritePropertyWithDefault<vector<string>>(200, "expected_names", expected_names);
-	serializer.WritePropertyWithDefault<optionally_owned_ptr<ColumnDataCollection>>(202, "collection", collection);
-}
-
-unique_ptr<TableRef> ColumnDataRef::Deserialize(Deserializer &deserializer) {
-	auto expected_names = deserializer.ReadPropertyWithDefault<vector<string>>(200, "expected_names");
-	auto collection = deserializer.ReadPropertyWithDefault<optionally_owned_ptr<ColumnDataCollection>>(202, "collection");
-	auto result = duckdb::unique_ptr<ColumnDataRef>(new ColumnDataRef(std::move(expected_names), std::move(collection)));
-	return std::move(result);
-}
-
 void EmptyTableRef::Serialize(Serializer &serializer) const {
 	TableRef::Serialize(serializer);
 }

--- a/src/storage/serialization/serialize_tableref.cpp
+++ b/src/storage/serialization/serialize_tableref.cpp
@@ -76,6 +76,19 @@ unique_ptr<TableRef> BaseTableRef::Deserialize(Deserializer &deserializer) {
 	return std::move(result);
 }
 
+void ColumnDataRef::Serialize(Serializer &serializer) const {
+	TableRef::Serialize(serializer);
+	serializer.WritePropertyWithDefault<vector<string>>(200, "expected_names", expected_names);
+	serializer.WritePropertyWithDefault<shared_ptr<ColumnDataCollection>>(202, "collection", collection);
+}
+
+unique_ptr<TableRef> ColumnDataRef::Deserialize(Deserializer &deserializer) {
+	auto expected_names = deserializer.ReadPropertyWithDefault<vector<string>>(200, "expected_names");
+	auto collection = deserializer.ReadPropertyWithDefault<shared_ptr<ColumnDataCollection>>(202, "collection");
+	auto result = duckdb::unique_ptr<ColumnDataRef>(new ColumnDataRef(std::move(collection), std::move(expected_names)));
+	return std::move(result);
+}
+
 void EmptyTableRef::Serialize(Serializer &serializer) const {
 	TableRef::Serialize(serializer);
 }

--- a/tools/pythonpkg/tests/fast/test_relation.py
+++ b/tools/pythonpkg/tests/fast/test_relation.py
@@ -552,7 +552,6 @@ class TestRelation(object):
         rel = duckdb_cursor.sql("select * from test")
         res = rel.fetchall()
         assert res == [([2], ['Alice'])]
-        res = duckdb_cursor.sql("select * from vw").fetchone()
 
     def test_serialized_materialized_relation(self, tmp_database):
         con = duckdb.connect(tmp_database)

--- a/tools/pythonpkg/tests/fast/test_relation.py
+++ b/tools/pythonpkg/tests/fast/test_relation.py
@@ -521,16 +521,17 @@ class TestRelation(object):
         assert res == [('0',), ('1',), ('2',), ('3',), ('4',), ('5',), ('6',), ('7',), ('8',), ('9',)]
 
     def test_materialized_relation_view(self, duckdb_cursor):
-        with pytest.raises(
-            duckdb.NotImplementedException, match='Creating a VIEW from a MaterializedRelation is not supported'
-        ):
+        def create_view(duckdb_cursor):
             duckdb_cursor.sql(
                 """
                 create table tbl(a varchar);
                 insert into tbl values ('test') returning *
             """
             ).to_view('vw')
-            res = duckdb_cursor.sql("select * from vw").fetchone()
+
+        create_view(duckdb_cursor)
+        res = duckdb_cursor.sql("select * from vw").fetchone()
+        assert res == ('test',)
 
     def test_materialized_relation_view2(self, duckdb_cursor):
         # This creates a MaterializedRelation

--- a/tools/pythonpkg/tests/fast/test_relation.py
+++ b/tools/pythonpkg/tests/fast/test_relation.py
@@ -474,7 +474,8 @@ class TestRelation(object):
         limited_rel = rel.limit(50)
         assert len(limited_rel.fetchall()) == 50
 
-        materialized_one = duckdb_cursor.sql("call range(10)").project(
+        # Using parameters also results in a MaterializedRelation
+        materialized_one = duckdb_cursor.sql("select * from range(?)", params=[10]).project(
             ColumnExpression('range').cast(str).alias('range')
         )
         materialized_two = duckdb_cursor.sql("call repeat('a', 5)")

--- a/tools/pythonpkg/tests/fast/test_relation.py
+++ b/tools/pythonpkg/tests/fast/test_relation.py
@@ -465,11 +465,8 @@ class TestRelation(object):
         ):
             rel.insert([1, 2, 3, 4])
 
-        with pytest.raises(
-            duckdb.NotImplementedException, match='Creating a VIEW from a MaterializedRelation is not supported'
-        ):
-            query_rel = rel.query('x', "select 42 from x where column0 != 42")
-            assert query_rel.fetchall() == []
+        query_rel = rel.query('x', "select 42 from x where column0 != 42")
+        assert query_rel.fetchall() == []
 
         distinct_rel = rel.distinct()
         assert distinct_rel.fetchall() == [(42, 'test', 'this is a long string', True)]


### PR DESCRIPTION
This PR fixes #12987 

The ColumnDataCollection (CDC) was stored in the MaterializedRelation, and the produced ColumnDataRef has a reference to this CDC.

We previously blocked creating views from MaterializedRelations (#12163) but this did not take into account nested relations, such as `ProjectionRelation`, which is the case here.
```py
import duckdb

rel = duckdb.sql("select * from (values ($1, $2))", params=[
    (2,),
    ("Alice",)
])

rel = rel.project("col0, col1")

rel.create_view("test", True)
rel = duckdb.sql("select * from test")
rel.show()
```

I've changed the ownership semantics here to fix the issue and removed the previously put in limitation.
The MaterializedRelation no longer owns the CDC, instead it is stored in the ExternalDependency, as a MaterializedDependency.

We recently made it so that TableRefs can have an ExternalDependency.
Because of this, the created VIEW will contain the ColumnDataRef that will keep the CDC alive through its ExternalDependency.

----------------------

This could also be achieved through a regular shared_ptr I think, which might be cleaner than involving the ExternalDependency mechanism into this