### PR TITLE
Fix shared_ptr issues in RowGroup and add locks to WAL initialization

### DIFF
--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -74,7 +74,9 @@ private:
 	//! The RowGroupCollection this row-group is a part of
 	reference<RowGroupCollection> collection;
 	//! The version info of the row_group (inserted and deleted tuple info)
-	shared_ptr<RowVersionManager> version_info;
+	atomic<optional_ptr<RowVersionManager>> version_info;
+	//! The owned version info of the row_group (inserted and deleted tuple info)
+	shared_ptr<RowVersionManager> owned_version_info;
 	//! The column data of the row_group
 	vector<shared_ptr<ColumnData>> columns;
 
@@ -168,8 +170,9 @@ public:
 	static RowGroupPointer Deserialize(Deserializer &deserializer);
 
 private:
-	shared_ptr<RowVersionManager> GetVersionInfo();
+	optional_ptr<RowVersionManager> GetVersionInfo();
 	shared_ptr<RowVersionManager> GetOrCreateVersionInfoPtr();
+	shared_ptr<RowVersionManager> GetOrCreateVersionInfoInternal();
 
 	ColumnData &GetColumn(storage_t c);
 	idx_t GetColumnCount() const;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -173,6 +173,7 @@ private:
 	optional_ptr<RowVersionManager> GetVersionInfo();
 	shared_ptr<RowVersionManager> GetOrCreateVersionInfoPtr();
 	shared_ptr<RowVersionManager> GetOrCreateVersionInfoInternal();
+	void SetVersionInfo(shared_ptr<RowVersionManager> version);
 
 	ColumnData &GetColumn(storage_t c);
 	idx_t GetColumnCount() const;

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -168,8 +168,8 @@ public:
 	static RowGroupPointer Deserialize(Deserializer &deserializer);
 
 private:
-	shared_ptr<RowVersionManager> &GetVersionInfo();
-	shared_ptr<RowVersionManager> &GetOrCreateVersionInfoPtr();
+	shared_ptr<RowVersionManager> GetVersionInfo();
+	shared_ptr<RowVersionManager> GetOrCreateVersionInfoPtr();
 
 	ColumnData &GetColumn(storage_t c);
 	idx_t GetColumnCount() const;

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -116,6 +116,7 @@ public:
 
 protected:
 	AttachedDatabase &database;
+	mutex wal_lock;
 	unique_ptr<BufferedFileWriter> writer;
 	string wal_path;
 	atomic<idx_t> wal_size;

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -270,6 +270,7 @@ unique_ptr<RowGroup> RowGroup::AlterType(RowGroupCollection &new_collection, con
 		if (i == changed_idx) {
 			// this is the altered column: use the new column
 			row_group->columns.push_back(std::move(column_data));
+			column_data.reset();
 		} else {
 			// this column was not altered: use the data directly
 			row_group->columns.push_back(cols[i]);

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -26,12 +26,13 @@
 namespace duckdb {
 
 RowGroup::RowGroup(RowGroupCollection &collection_p, idx_t start, idx_t count)
-    : SegmentBase<RowGroup>(start, count), collection(collection_p), allocation_size(0) {
+    : SegmentBase<RowGroup>(start, count), collection(collection_p), version_info(nullptr), allocation_size(0) {
 	Verify();
 }
 
 RowGroup::RowGroup(RowGroupCollection &collection_p, RowGroupPointer pointer)
-    : SegmentBase<RowGroup>(pointer.row_start, pointer.tuple_count), collection(collection_p), allocation_size(0) {
+    : SegmentBase<RowGroup>(pointer.row_start, pointer.tuple_count), collection(collection_p), version_info(nullptr),
+      allocation_size(0) {
 	// deserialize the columns
 	if (pointer.data_pointers.size() != collection_p.GetTypes().size()) {
 		throw IOException("Row group column count is unaligned with table column count. Corrupt file?");

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -652,7 +652,7 @@ void RowGroup::ScanCommitted(CollectionScanState &state, DataChunk &result, Tabl
 	}
 }
 
-shared_ptr<RowVersionManager> &RowGroup::GetVersionInfo() {
+shared_ptr<RowVersionManager> RowGroup::GetVersionInfo() {
 	if (!HasUnloadedDeletes()) {
 		// deletes are loaded - return the version info
 		return version_info;
@@ -668,7 +668,7 @@ shared_ptr<RowVersionManager> &RowGroup::GetVersionInfo() {
 	return version_info;
 }
 
-shared_ptr<RowVersionManager> &RowGroup::GetOrCreateVersionInfoPtr() {
+shared_ptr<RowVersionManager> RowGroup::GetOrCreateVersionInfoPtr() {
 	auto vinfo = GetVersionInfo();
 	if (!vinfo) {
 		lock_guard<mutex> lock(row_group_lock);

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -54,14 +54,14 @@ idx_t WriteAheadLog::GetWALSize() {
 }
 
 idx_t WriteAheadLog::GetTotalWritten() {
-	if (!writer) {
+	if (!Initialized()) {
 		return 0;
 	}
 	return writer->GetTotalWritten();
 }
 
 void WriteAheadLog::Truncate(idx_t size) {
-	if (!writer) {
+	if (!Initialized()) {
 		return;
 	}
 	writer->Truncate(size);
@@ -69,7 +69,7 @@ void WriteAheadLog::Truncate(idx_t size) {
 }
 
 void WriteAheadLog::Delete() {
-	if (!writer) {
+	if (!Initialized()) {
 		return;
 	}
 	writer.reset();

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -31,6 +31,7 @@ BufferedFileWriter &WriteAheadLog::Initialize() {
 	if (initialized) {
 		return *writer;
 	}
+	lock_guard<mutex> lock(wal_lock);
 	if (!writer) {
 		writer = make_uniq<BufferedFileWriter>(FileSystem::Get(database), wal_path,
 		                                       FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE |


### PR DESCRIPTION
Fixes issues found by thread sanitizer. `shared_ptr` objects *themselves* cannot be safely shared across threads on all implementations. Instead, we use an atomic pointer for atomic access, and the shared pointer is only modified behind a lock.