### PR TITLE
Case-insensitive `NULL` casting in `VARCHAR` -> `STRUCT` casts

### DIFF
--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -4,7 +4,9 @@ namespace duckdb {
 
 // ------- Helper functions for splitting string nested types  -------
 static bool IsNull(const char *buf, idx_t start_pos, Vector &child, idx_t row_idx) {
-	if (buf[start_pos] == 'N' && buf[start_pos + 1] == 'U' && buf[start_pos + 2] == 'L' && buf[start_pos + 3] == 'L') {
+	if ((buf[start_pos] == 'N' || buf[start_pos] == 'n') && (buf[start_pos + 1] == 'U' || buf[start_pos + 1] == 'u') &&
+	    (buf[start_pos + 2] == 'L' || buf[start_pos + 2] == 'l') &&
+	    (buf[start_pos + 3] == 'L' || buf[start_pos + 3] == 'l')) {
 		FlatVector::SetNull(child, row_idx, true);
 		return true;
 	}

--- a/test/sql/types/struct/struct_cast.test
+++ b/test/sql/types/struct/struct_cast.test
@@ -112,3 +112,43 @@ SELECT s::ROW(i BIGINT, j ROW(a BIGINT, b VARCHAR)) FROM nested_structs
 {'i': 1, 'j': {'a': 2, 'b': NULL}}
 {'i': 1, 'j': NULL}
 NULL
+
+# Issue #12939, NULL used to be case-sensitive
+# Testing all permutations for fun
+query I
+SELECT col::STRUCT(duck INT)
+FROM VALUES
+    ('{"duck": null}'),
+    ('{"duck": nulL}'),
+    ('{"duck": nuLl}'),
+    ('{"duck": nuLL}'),
+    ('{"duck": nUll}'),
+    ('{"duck": nUlL}'),
+    ('{"duck": nULl}'),
+    ('{"duck": nULL}'),
+    ('{"duck": Null}'),
+    ('{"duck": NulL}'),
+    ('{"duck": NuLl}'),
+    ('{"duck": NuLL}'),
+    ('{"duck": NUll}'),
+    ('{"duck": NUlL}'),
+    ('{"duck": NULl}'),
+    ('{"duck": NULL}'),
+AS tab(col)
+----
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}
+{'duck': NULL}


### PR DESCRIPTION
Although #12939 is not a bug, it did uncover a bug, which is that `NULL`s within `VARCHAR`s would not be properly cast to if they were not all-uppercase `NULL`. This PR fixes that by making this case-insensitive, like it is in our parser:
```sql
D select {duck:null} s;
┌──────────────────────┐
│          s           │
│ struct(duck integer) │
├──────────────────────┤
│ {'duck': NULL}       │
└──────────────────────┘
```
We can now also do this:
```sql
D select '{duck:null}'::struct(duck int) s;
┌──────────────────────┐
│          s           │
│ struct(duck integer) │
├──────────────────────┤
│ {'duck': NULL}       │
└──────────────────────┘
```
Which would have resulted in this error before:
```sql
D select '{duck:null}'::struct(duck int) s;
Conversion Error: Could not convert string 'null' to INT32
LINE 1: select '{duck:null}'::struct(duck int) s;
                            ^
```