### PR TITLE
[Dev] Add `query` to QueryRelation for logging

### DIFF
--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -149,7 +149,7 @@ public:
 	DUCKDB_API shared_ptr<Relation> RelationFromQuery(const string &query, const string &alias = "queryrelation",
 	                                                  const string &error = "Expected a single SELECT statement");
 	DUCKDB_API shared_ptr<Relation> RelationFromQuery(unique_ptr<SelectStatement> select_stmt,
-	                                                  const string &alias = "queryrelation");
+	                                                  const string &alias = "queryrelation", const string &query = "");
 
 	//! Returns a substrait BLOB from a valid query
 	DUCKDB_API string GetSubstrait(const string &query);

--- a/src/include/duckdb/main/relation/query_relation.hpp
+++ b/src/include/duckdb/main/relation/query_relation.hpp
@@ -16,10 +16,12 @@ class SelectStatement;
 
 class QueryRelation : public Relation {
 public:
-	QueryRelation(const shared_ptr<ClientContext> &context, unique_ptr<SelectStatement> select_stmt, string alias);
+	QueryRelation(const shared_ptr<ClientContext> &context, unique_ptr<SelectStatement> select_stmt, string alias,
+	              const string &query = "");
 	~QueryRelation() override;
 
 	unique_ptr<SelectStatement> select_stmt;
+	string query;
 	string alias;
 	vector<ColumnDefinition> columns;
 

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -288,8 +288,9 @@ shared_ptr<Relation> Connection::RelationFromQuery(const string &query, const st
 	return RelationFromQuery(QueryRelation::ParseStatement(*context, query, error), alias);
 }
 
-shared_ptr<Relation> Connection::RelationFromQuery(unique_ptr<SelectStatement> select_stmt, const string &alias) {
-	return make_shared_ptr<QueryRelation>(context, std::move(select_stmt), alias);
+shared_ptr<Relation> Connection::RelationFromQuery(unique_ptr<SelectStatement> select_stmt, const string &alias,
+                                                   const string &query_p) {
+	return make_shared_ptr<QueryRelation>(context, std::move(select_stmt), alias, query_p);
 }
 
 void Connection::BeginTransaction() {

--- a/src/main/relation/query_relation.cpp
+++ b/src/main/relation/query_relation.cpp
@@ -14,9 +14,12 @@
 namespace duckdb {
 
 QueryRelation::QueryRelation(const shared_ptr<ClientContext> &context, unique_ptr<SelectStatement> select_stmt_p,
-                             string alias_p)
-    : Relation(context, RelationType::QUERY_RELATION), select_stmt(std::move(select_stmt_p)),
+                             string alias_p, const string &query_p)
+    : Relation(context, RelationType::QUERY_RELATION), select_stmt(std::move(select_stmt_p)), query(std::move(query_p)),
       alias(std::move(alias_p)) {
+	if (query.empty()) {
+		query = select_stmt->ToString();
+	}
 	context->TryBindRelation(*this, this->columns);
 }
 

--- a/src/main/relation/query_relation.cpp
+++ b/src/main/relation/query_relation.cpp
@@ -15,7 +15,7 @@ namespace duckdb {
 
 QueryRelation::QueryRelation(const shared_ptr<ClientContext> &context, unique_ptr<SelectStatement> select_stmt_p,
                              string alias_p, const string &query_p)
-    : Relation(context, RelationType::QUERY_RELATION), select_stmt(std::move(select_stmt_p)), query(std::move(query_p)),
+    : Relation(context, RelationType::QUERY_RELATION), select_stmt(std::move(select_stmt_p)), query(query_p),
       alias(std::move(alias_p)) {
 	if (query.empty()) {
 		query = select_stmt->ToString();

--- a/src/parser/statement/relation_statement.cpp
+++ b/src/parser/statement/relation_statement.cpp
@@ -1,9 +1,14 @@
 #include "duckdb/parser/statement/relation_statement.hpp"
+#include "duckdb/main/relation/query_relation.hpp"
 
 namespace duckdb {
 
 RelationStatement::RelationStatement(shared_ptr<Relation> relation_p)
     : SQLStatement(StatementType::RELATION_STATEMENT), relation(std::move(relation_p)) {
+	if (relation->type == RelationType::QUERY_RELATION) {
+		auto &query_relation = relation->Cast<QueryRelation>();
+		query = query_relation.query;
+	}
 }
 
 unique_ptr<SQLStatement> RelationStatement::Copy() const {

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -1331,8 +1331,8 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Query(const string &view_name, co
 	auto &statement = *parser.statements[0];
 	if (statement.type == StatementType::SELECT_STATEMENT) {
 		auto select_statement = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
-		auto query_relation =
-		    make_shared_ptr<QueryRelation>(rel->context.GetContext(), std::move(select_statement), "query_relation");
+		auto query_relation = make_shared_ptr<QueryRelation>(rel->context.GetContext(), std::move(select_statement),
+		                                                     sql_query, "query_relation");
 		return make_uniq<DuckDBPyRelation>(std::move(query_relation));
 	} else if (IsDescribeStatement(statement)) {
 		auto query = PragmaShow(view_name);


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2537

I've tried to be as unintrusive as possible here so R and other clients that rely on the Relation API are unaffected.
SelectStatement should support `ToString` in all scenarios.

This PR should add minimal overhead to the construction of a QueryRelation, the `query` string is forwarded to `RelationStatement` which makes it available to the ActiveQueryContext