### PR TITLE
[Spark API] Fix group by compatibility issues

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
@@ -732,8 +732,11 @@ class DataFrame:
         """
         from .group import GroupedData, Grouping
 
-        groups = Grouping(*cols)
-        return GroupedData(groups, self)
+        if len(cols) == 1 and isinstance(cols[0], list):
+            columns = cols[0]
+        else:
+            columns = cols
+        return GroupedData(Grouping(*columns), self)
 
     @property
     def write(self) -> DataFrameWriter:

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/group.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/group.py
@@ -16,33 +16,36 @@
 #
 
 from ..exception import ContributionsAcceptedError
-from typing import Callable, TYPE_CHECKING, overload, Dict, Union
+from typing import Callable, TYPE_CHECKING, overload, Dict, Union, List
 
 from .column import Column
 from .session import SparkSession
 from .dataframe import DataFrame
 from .functions import _to_column
 from ._typing import ColumnOrName
+from .types import NumericType
 
 if TYPE_CHECKING:
     from ._typing import LiteralType
 
 __all__ = ["GroupedData", "Grouping"]
 
+def _api_internal(self: "GroupedData", name: str, *cols: str) -> DataFrame:
+    expressions = ",".join(list(cols))
+    group_by = str(self._grouping) if self._grouping else ""
+    projections = self._grouping.get_columns()
+    jdf = getattr(self._df.relation, "apply")(
+        function_name=name,  # aggregate function
+        function_aggr=expressions,  # inputs to aggregate
+        group_expr=group_by,  # groups
+        projected_columns=projections,  # projections
+    )
+    return DataFrame(jdf, self.session)
 
 def df_varargs_api(f: Callable[..., DataFrame]) -> Callable[..., DataFrame]:
     def _api(self: "GroupedData", *cols: str) -> DataFrame:
         name = f.__name__
-        expressions = ",".join(list(cols))
-        group_by = str(self._grouping)
-        projections = self._grouping.get_columns()
-        jdf = getattr(self._df.relation, "apply")(
-            function_name=name,  # aggregate function
-            function_aggr=expressions,  # inputs to aggregate
-            group_expr=group_by,  # groups
-            projected_columns=projections,  # projections
-        )
-        return DataFrame(jdf, self.session)
+        return _api_internal(self, name, *cols)
 
     _api.__name__ = f.__name__
     _api.__doc__ = f.__doc__
@@ -126,9 +129,8 @@ class GroupedData:
             column names. Non-numeric columns are ignored.
         """
 
-    @df_varargs_api
     def avg(self, *cols: str) -> DataFrame:
-        """Computes average values for each numeric columns for each group.
+        doc = """Computes average values for each numeric columns for each group.
 
         :func:`mean` is an alias for :func:`avg`.
 
@@ -171,6 +173,17 @@ class GroupedData:
         |     5.0|      110.0|
         +--------+-----------+
         """
+        columns = list(*cols)
+        if len(columns) == 0:
+            schema = self._df.schema
+            # Take only the numeric types of the relation
+            columns: List[str] = [x.name for x in schema.fields if isinstance(x.dataType, NumericType)]
+        def _api(self: "GroupedData", *cols: str) -> DataFrame:
+            return _api_internal(self, "avg", *cols)
+
+        _api.__name__ = "avg"
+        _api.__doc__ = doc
+        return _api(self, *columns)
 
     @df_varargs_api
     def max(self, *cols: str) -> DataFrame:

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/group.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/group.py
@@ -88,7 +88,6 @@ class GroupedData:
     def __repr__(self) -> str:
         return str(self._df)
 
-    @df_varargs_api
     def count(self) -> DataFrame:
         """Counts the number of records for each group.
 
@@ -116,6 +115,7 @@ class GroupedData:
         |  Bob|    2|
         +-----+-----+
         """
+        return _api_internal(self, "count").withColumnRenamed('count_star()', 'count')
 
     @df_varargs_api
     def mean(self, *cols: str) -> DataFrame:
@@ -130,7 +130,7 @@ class GroupedData:
         """
 
     def avg(self, *cols: str) -> DataFrame:
-        doc = """Computes average values for each numeric columns for each group.
+        """Computes average values for each numeric columns for each group.
 
         :func:`mean` is an alias for :func:`avg`.
 
@@ -173,17 +173,12 @@ class GroupedData:
         |     5.0|      110.0|
         +--------+-----------+
         """
-        columns = list(*cols)
+        columns = list(cols)
         if len(columns) == 0:
             schema = self._df.schema
             # Take only the numeric types of the relation
             columns: List[str] = [x.name for x in schema.fields if isinstance(x.dataType, NumericType)]
-        def _api(self: "GroupedData", *cols: str) -> DataFrame:
-            return _api_internal(self, "avg", *cols)
-
-        _api.__name__ = "avg"
-        _api.__doc__ = doc
-        return _api(self, *columns)
+        return _api_internal(self, "avg", *columns)
 
     @df_varargs_api
     def max(self, *cols: str) -> DataFrame:

--- a/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
@@ -44,7 +44,7 @@ class TestDataFrameGroupBy(object):
         res = df2.collect()
         assert (
             str(res)
-            == "[Row(department='Finance', count_star()=4), Row(department='Marketing', count_star()=2), Row(department='Sales', count_star()=3)]"
+            == "[Row(department='Finance', count=4), Row(department='Marketing', count=2), Row(department='Sales', count=3)]"
         )
 
         df2 = df.groupBy("department").min("salary").sort("department")
@@ -115,3 +115,20 @@ class TestDataFrameGroupBy(object):
             str(res)
             == "[Row(department='Finance', sum_salary=351000, avg_salary=87750.0, sum_bonus=81000, max_bonus=24000), Row(department='Sales', sum_salary=257000, avg_salary=85666.66666666667, sum_bonus=53000, max_bonus=23000)]"
         )
+
+    def test_group_by_empty(self, spark):
+        df = spark.createDataFrame(
+            [(2, 1.0, "1"), (2, 2.0, "2"), (2, 3.0, "3"), (5, 4.0, "4")], schema=["age", "extra", "name"]
+        )
+
+        res = df.groupBy().avg().collect()
+        assert str(res) == "[Row(avg(age)=2.75, avg(extra)=2.5)]"
+
+        res = df.groupBy(["name", "age"]).count().sort("name").collect()
+        assert (
+            str(res)
+            == "[Row(name='1', age=2, count=1), Row(name='2', age=2, count=1), Row(name='3', age=2, count=1), Row(name='4', age=5, count=1)]"
+        )
+
+        res = df.groupBy("name").count().columns
+        assert res == ['name', 'count']


### PR DESCRIPTION
This PR fixes #12986

1. `avg` without expressions selects all columns of the relation that inherit from NumericType
2. Column produced from `count` is renamed from `count_star()` to `count`
3. `groupBy` now accepts a `list` of columns as argument to the constructor.