### PR TITLE
Fix parallel creation and destruction of instances through the `DBInstanceCache`

### DIFF
--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -28,6 +28,7 @@ class ObjectCache;
 struct AttachInfo;
 struct AttachOptions;
 class DatabaseFileSystem;
+struct DatabaseCacheEntry;
 
 struct ExtensionInfo {
 	bool is_loaded;
@@ -71,6 +72,7 @@ public:
 	                                                    const AttachOptions &options);
 
 	void AddExtensionInfo(const string &name, const ExtensionLoadedInfo &info);
+	void SetDatabaseCacheEntry(shared_ptr<DatabaseCacheEntry> entry);
 
 private:
 	void Initialize(const char *path, DBConfig *config);
@@ -87,6 +89,7 @@ private:
 	unordered_map<string, ExtensionInfo> loaded_extensions_info;
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
+	shared_ptr<DatabaseCacheEntry> db_cache_entry;
 };
 
 //! The database object. This object holds the catalog and all the

--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -26,7 +26,8 @@ struct DBInstanceCacheEntry {
 
 class DBInstanceCache {
 public:
-	DBInstanceCache() {}
+	DBInstanceCache() {
+	}
 
 	//! Either returns an existing entry, or creates and caches a new DB Instance
 	unique_ptr<DBInstanceCacheEntry> GetOrCreate(const string &database, DBConfig &config_dict, bool cache_instance);

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -24,6 +24,7 @@
 #include "duckdb/execution/index/index_type_set.hpp"
 #include "duckdb/main/database_file_opener.hpp"
 #include "duckdb/planner/collation_binding.hpp"
+#include "duckdb/main/db_instance_cache.hpp"
 
 #ifndef DUCKDB_NO_THREADS
 #include "duckdb/common/thread.hpp"
@@ -65,11 +66,13 @@ DatabaseInstance::~DatabaseInstance() {
 	scheduler.reset();
 	db_manager.reset();
 	buffer_manager.reset();
-	// finally, flush allocations and disable the background thread
+	// flush allocations and disable the background thread
 	if (Allocator::SupportsFlush()) {
 		Allocator::FlushAll();
 	}
 	Allocator::SetBackgroundThreads(false);
+	// after all destruction is complete clear the cache entry
+	db_cache_entry.reset();
 }
 
 BufferManager &BufferManager::GetBufferManager(DatabaseInstance &db) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -95,6 +95,10 @@ const DatabaseInstance &DatabaseInstance::GetDatabase(const ClientContext &conte
 	return *context.db;
 }
 
+void DatabaseInstance::SetDatabaseCacheEntry(shared_ptr<DatabaseCacheEntry> entry) {
+	db_cache_entry = std::move(entry);
+}
+
 DatabaseManager &DatabaseInstance::GetDatabaseManager() {
 	if (!db_manager) {
 		throw InternalException("Missing DB manager");

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -3,15 +3,16 @@
 
 namespace duckdb {
 
-DBInstanceCacheEntry::DBInstanceCacheEntry(DBInstanceCache &cache, shared_ptr<DuckDB> database_p) :
-	cache(cache), database(std::move(database_p)) {}
+DBInstanceCacheEntry::DBInstanceCacheEntry(DBInstanceCache &cache, shared_ptr<DuckDB> database_p)
+    : cache(cache), database(std::move(database_p)) {
+}
 
 DBInstanceCacheEntry::~DBInstanceCacheEntry() {
 	cache.DropInstance(std::move(database));
 }
 
-
-string GetDBAbsolutePath(const string &database_p, FileSystem &fs) {auto database = FileSystem::ExpandPath(database_p, nullptr);
+string GetDBAbsolutePath(const string &database_p, FileSystem &fs) {
+	auto database = FileSystem::ExpandPath(database_p, nullptr);
 	if (database.empty()) {
 		return IN_MEMORY_PATH;
 	}
@@ -97,7 +98,8 @@ shared_ptr<DuckDB> DBInstanceCache::GetOrCreateInstance(const string &database, 
 	return CreateInstanceInternal(database, config_dict, cache_instance);
 }
 
-unique_ptr<DBInstanceCacheEntry> DBInstanceCache::GetOrCreate(const string &database, DBConfig &config_dict, bool cache_instance) {
+unique_ptr<DBInstanceCacheEntry> DBInstanceCache::GetOrCreate(const string &database, DBConfig &config_dict,
+                                                              bool cache_instance) {
 	auto db = GetOrCreateInstance(database, config_dict, cache_instance);
 	return make_uniq<DBInstanceCacheEntry>(*this, std::move(db));
 }

--- a/src/main/db_instance_cache.cpp
+++ b/src/main/db_instance_cache.cpp
@@ -3,8 +3,7 @@
 
 namespace duckdb {
 
-DatabaseCacheEntry::DatabaseCacheEntry(const shared_ptr<DuckDB> &database_p)
-    : database(database_p) {
+DatabaseCacheEntry::DatabaseCacheEntry(const shared_ptr<DuckDB> &database_p) : database(database_p) {
 }
 
 DatabaseCacheEntry::~DatabaseCacheEntry() {
@@ -49,7 +48,7 @@ shared_ptr<DuckDB> DBInstanceCache::GetInstanceInternal(const string &database, 
 		// if the database does not exist, but the cache entry still exists, the database is being shut down
 		// we need to wait until the database is fully shut down to safely proceed
 		// we do this here using a busy spin
-		while(cache_entry) {
+		while (cache_entry) {
 			// clear our cache entry
 			cache_entry.reset();
 			// try to lock it again

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_API_OBJECTS
     test_api.cpp
     test_config.cpp
     test_custom_allocator.cpp
+    test_instance_cache.cpp
     test_results.cpp
     test_reset.cpp
     test_get_table_names.cpp

--- a/test/api/test_instance_cache.cpp
+++ b/test/api/test_instance_cache.cpp
@@ -11,7 +11,7 @@ using namespace std;
 static void background_thread_connect(DBInstanceCache *instance_cache, std::string *path) {
 	try {
 		DBConfig config;
-		auto connection = instance_cache->GetOrCreate(*path, config, true);
+		auto connection = instance_cache->GetOrCreateInstance(*path, config, true);
 		connection.reset();
 	} catch (std::exception &ex) {
 		FAIL(ex.what());
@@ -25,7 +25,7 @@ TEST_CASE("Test parallel connection and destruction of connections with database
 		auto path = TestCreatePath("instance_cache_parallel.db");
 
 		DBConfig config;
-		auto shared_db = instance_cache.GetOrCreate(path, config, true);
+		auto shared_db = instance_cache.GetOrCreateInstance(path, config, true);
 
 		thread background_thread(background_thread_connect, &instance_cache, &path);
 		shared_db.reset();

--- a/test/api/test_instance_cache.cpp
+++ b/test/api/test_instance_cache.cpp
@@ -11,7 +11,7 @@ using namespace std;
 static void background_thread_connect(DBInstanceCache *instance_cache, std::string *path) {
 	try {
 		DBConfig config;
-		auto connection = instance_cache->GetOrCreateInstance(*path, config, true);
+		auto connection = instance_cache->GetOrCreate(*path, config, true);
 		connection.reset();
 	} catch(std::exception &ex) {
 		FAIL(ex.what());
@@ -21,14 +21,17 @@ static void background_thread_connect(DBInstanceCache *instance_cache, std::stri
 TEST_CASE("Test parallel connection and destruction of connections with database instance cache", "[api][.]") {
 	DBInstanceCache instance_cache;
 
-	auto path = TestCreatePath("instance_cache_parallel.db");
+	for(idx_t i = 0; i < 100; i++) {
+		auto path = TestCreatePath("instance_cache_parallel.db");
 
-	DBConfig config;
-	auto shared_db = instance_cache.GetOrCreateInstance(path, config, true);
+		DBConfig config;
+		auto shared_db = instance_cache.GetOrCreate(path, config, true);
 
 
-	thread background_thread(background_thread_connect, &instance_cache, &path);
-	shared_db.reset();
-	background_thread.join();
-	REQUIRE(1);
+		thread background_thread(background_thread_connect, &instance_cache, &path);
+		shared_db.reset();
+		background_thread.join();
+		TestDeleteFile(path);
+		REQUIRE(1);
+	}
 }

--- a/test/api/test_instance_cache.cpp
+++ b/test/api/test_instance_cache.cpp
@@ -13,7 +13,7 @@ static void background_thread_connect(DBInstanceCache *instance_cache, std::stri
 		DBConfig config;
 		auto connection = instance_cache->GetOrCreate(*path, config, true);
 		connection.reset();
-	} catch(std::exception &ex) {
+	} catch (std::exception &ex) {
 		FAIL(ex.what());
 	}
 }
@@ -21,12 +21,11 @@ static void background_thread_connect(DBInstanceCache *instance_cache, std::stri
 TEST_CASE("Test parallel connection and destruction of connections with database instance cache", "[api][.]") {
 	DBInstanceCache instance_cache;
 
-	for(idx_t i = 0; i < 100; i++) {
+	for (idx_t i = 0; i < 100; i++) {
 		auto path = TestCreatePath("instance_cache_parallel.db");
 
 		DBConfig config;
 		auto shared_db = instance_cache.GetOrCreate(path, config, true);
-
 
 		thread background_thread(background_thread_connect, &instance_cache, &path);
 		shared_db.reset();

--- a/test/api/test_instance_cache.cpp
+++ b/test/api/test_instance_cache.cpp
@@ -1,0 +1,34 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/main/db_instance_cache.hpp"
+
+#include <chrono>
+#include <thread>
+
+using namespace duckdb;
+using namespace std;
+
+static void background_thread_connect(DBInstanceCache *instance_cache, std::string *path) {
+	try {
+		DBConfig config;
+		auto connection = instance_cache->GetOrCreateInstance(*path, config, true);
+		connection.reset();
+	} catch(std::exception &ex) {
+		FAIL(ex.what());
+	}
+}
+
+TEST_CASE("Test parallel connection and destruction of connections with database instance cache", "[api][.]") {
+	DBInstanceCache instance_cache;
+
+	auto path = TestCreatePath("instance_cache_parallel.db");
+
+	DBConfig config;
+	auto shared_db = instance_cache.GetOrCreateInstance(path, config, true);
+
+
+	thread background_thread(background_thread_connect, &instance_cache, &path);
+	shared_db.reset();
+	background_thread.join();
+	REQUIRE(1);
+}

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -7,10 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-
 #include "duckdb_python/arrow/arrow_array_stream.hpp"
 #include "duckdb.hpp"
-#include "duckdb/main/db_instance_cache.hpp"
 #include "duckdb_python/pybind11/pybind_wrapper.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb_python/import_cache/python_import_cache.hpp"
@@ -51,16 +49,16 @@ public:
 
 public:
 	DuckDB &GetDatabase() {
-		if (!db_entry) {
+		if (!database) {
 			ThrowConnectionException();
 		}
-		return *db_entry->database;
+		return *database;
 	}
 	const DuckDB &GetDatabase() const {
-		if (!db_entry) {
+		if (!database) {
 			ThrowConnectionException();
 		}
-		return *db_entry->database;
+		return *database;
 	}
 	Connection &GetConnection() {
 		if (!connection) {
@@ -93,14 +91,14 @@ public:
 	}
 
 public:
-	void SetDatabase(unique_ptr<DBInstanceCacheEntry> db) {
-		db_entry = std::move(db);
+	void SetDatabase(shared_ptr<DuckDB> db) {
+		database = std::move(db);
 	}
 	void SetDatabase(ConnectionGuard &con) {
-		if (!con.db_entry) {
+		if (!con.database) {
 			ThrowConnectionException();
 		}
-		db_entry = con.db_entry->Copy();
+		database = con.database;
 	}
 	void SetConnection(unique_ptr<Connection> con) {
 		connection = std::move(con);
@@ -115,7 +113,7 @@ private:
 	}
 
 private:
-	unique_ptr<DBInstanceCacheEntry> db_entry;
+	shared_ptr<DuckDB> database;
 	unique_ptr<Connection> connection;
 	unique_ptr<DuckDBPyRelation> result;
 };

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1579,7 +1579,7 @@ static shared_ptr<DuckDBPyConnection> FetchOrCreateInstance(const string &databa
 	auto res = make_shared_ptr<DuckDBPyConnection>();
 	bool cache_instance = database_path != ":memory:" && !database_path.empty();
 	config.replacement_scans.emplace_back(PythonReplacementScan::Replace);
-	auto database = instance_cache.GetOrCreate(database_path, config, cache_instance, InstantiateNewInstance);
+	auto database = instance_cache.GetOrCreateInstance(database_path, config, cache_instance, InstantiateNewInstance);
 	res->con.SetDatabase(std::move(database));
 	res->con.SetConnection(make_uniq<Connection>(res->con.GetDatabase()));
 	return res;

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -57,6 +57,7 @@
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/main/relation/materialized_relation.hpp"
 #include "duckdb/main/relation/query_relation.hpp"
+#include "duckdb/main/extension_util.hpp"
 
 #include <random>
 
@@ -1533,24 +1534,6 @@ case_insensitive_map_t<Value> TransformPyConfigDict(const py::dict &py_config_di
 	return config_dict;
 }
 
-void CreateNewInstance(DuckDBPyConnection &res, const string &database, DBConfig &config) {
-	// We don't cache unnamed memory instances (i.e., :memory:)
-	bool cache_instance = database != ":memory:" && !database.empty();
-	config.replacement_scans.emplace_back(PythonReplacementScan::Replace);
-	res.con.SetDatabase(instance_cache.CreateInstance(database, config, cache_instance));
-	res.con.SetConnection(make_uniq<Connection>(res.con.GetDatabase()));
-	auto &context = *res.con.GetConnection().context;
-	PandasScanFunction scan_fun;
-	CreateTableFunctionInfo scan_info(scan_fun);
-	MapFunction map_fun;
-	CreateTableFunctionInfo map_info(map_fun);
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	context.transaction.BeginTransaction();
-	catalog.CreateTableFunction(context, &scan_info);
-	catalog.CreateTableFunction(context, &map_info);
-	context.transaction.Commit();
-}
-
 static bool HasJupyterProgressBarDependencies() {
 	auto &import_cache = *DuckDBPyConnection::ImportCache();
 	if (!import_cache.ipywidgets()) {
@@ -1584,14 +1567,19 @@ static void SetDefaultConfigArguments(ClientContext &context) {
 	context.config.display_create_func = JupyterProgressBarDisplay::Create;
 }
 
+void InstantiateNewInstance(DuckDB &db) {
+	auto &db_instance = *db.instance;
+	PandasScanFunction scan_fun;
+	MapFunction map_fun;
+	ExtensionUtil::RegisterFunction(db_instance, scan_fun);
+	ExtensionUtil::RegisterFunction(db_instance, map_fun);
+}
+
 static shared_ptr<DuckDBPyConnection> FetchOrCreateInstance(const string &database_path, DBConfig &config) {
 	auto res = make_shared_ptr<DuckDBPyConnection>();
-	auto database = instance_cache.GetInstance(database_path, config);
-	if (!database) {
-		//! No cached database, we must create a new instance
-		CreateNewInstance(*res, database_path, config);
-		return res;
-	}
+	bool cache_instance = database_path != ":memory:" && !database_path.empty();
+	config.replacement_scans.emplace_back(PythonReplacementScan::Replace);
+	auto database = instance_cache.GetOrCreate(database_path, config, cache_instance, InstantiateNewInstance);
 	res->con.SetDatabase(std::move(database));
 	res->con.SetConnection(make_uniq<Connection>(res->con.GetDatabase()));
 	return res;


### PR DESCRIPTION
Fix parallel creation and destruction of instances through the `DBInstanceCache`

The `DBInstanceCache` (introduced in https://github.com/duckdb/duckdb/pull/4414) performs de-duplication of database connections that are opened towards the same database file on disk. This is used in various clients (e.g. the Python client and the JDBC/ODBC clients).

The `DBInstanceCache` contains weak pointers to database instances. As a result, when the database object is destroyed, the entry is automatically removed from the database instance cache.

One issue with this approach is that the instance being destroyed (and thus being removed from the database instance cache) is separate from the full destruction of the instance. As a result, when the `DBInstanceCache` is used in parallel, it is possible for a database entry to be removed from the cache before the destruction has fully completed. When used in parallel, this can lead to a situation where we would try to open a new database, even though the old one has not fully closed. This can then cause issues on Windows where we would run into file locking issues as the old file handle would still be open.

This PR fixes this by, instead of storing a `weak_ptr` directly to the `DatabaseInstance`, storing a `weak_ptr` to a `DatabaseCacheEntry`. The `DatabaseInstance` itself holds the `shared_ptr` to the `DatabaseCacheEntry`. When the database instance is destroyed - the `DatabaseCacheEntry` is explicitly destroyed only at the very end after the entire shutdown process has completed. In `DBInstanceCache::GetInstanceInternal` - we can then detect the scenario where a database instance is *in process* of being destroyed, as we can observe that the weak pointer to the `DatabaseInstance` is invalid, while the pointer to the `DatabaseCacheEntry` is still valid. In this scenario, we then do a busy loop that waits until the `DatabaseCacheEntry` is destroyed which ensures we wait until the database instance has fully closed.

#### Python Client

In the Python client this race condition was a bit more egregious as the individual `GetInstance` and `CreateInstance` methods were used, instead of the combined `GetOrCreateInstance` that safely performs both operations behind a lock. The reason for this behavior was that the Python client needed to register a number of methods on instance creation. We rewrite the Python client to use `GetOrCreateInstance` by introducing a new `on_create` callback to the `DBInstanceCache`. This is then used by the Python client to register the necessary functions.

We should likely deprecate the public `GetInstance`/`CreateInstance` methods entirely.