### PR TITLE
Disable fixed size map in `PartitionedTupleData`

### DIFF
--- a/src/common/types/row/partitioned_tuple_data.cpp
+++ b/src/common/types/row/partitioned_tuple_data.cpp
@@ -42,6 +42,7 @@ void PartitionedTupleData::Append(PartitionedTupleDataAppendState &state, DataCh
 }
 
 bool PartitionedTupleData::UseFixedSizeMap() const {
+	return false;
 	return MaxPartitionIndex() < PartitionedTupleDataAppendState::MAP_THRESHOLD;
 }
 


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/duckdb/duckdb/pull/12931 (pending an actual fix)