### PR TITLE
Extend least/greatest to support all types, and always return the same type as its input types

### DIFF
--- a/src/core_functions/scalar/generic/least.cpp
+++ b/src/core_functions/scalar/generic/least.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/core_functions/scalar/generic_functions.hpp"
+#include "duckdb/core_functions/create_sort_key.hpp"
 
 namespace duckdb {
 
@@ -11,58 +12,121 @@ struct LeastOperator {
 	}
 };
 
-template <class T, class OP, bool IS_STRING = false>
+struct LeastGreatestSortKeyState : public FunctionLocalState {
+	explicit LeastGreatestSortKeyState(idx_t column_count)
+	    : intermediate(LogicalType::BLOB), modifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST) {
+		vector<LogicalType> types;
+		// initialize sort key chunk
+		for (idx_t i = 0; i < column_count; i++) {
+			types.push_back(LogicalType::BLOB);
+		}
+		sort_keys.Initialize(Allocator::DefaultAllocator(), types);
+	}
+
+	DataChunk sort_keys;
+	Vector intermediate;
+	OrderModifiers modifiers;
+};
+
+unique_ptr<FunctionLocalState> LeastGreatestSortKeyInit(ExpressionState &state, const BoundFunctionExpression &expr,
+                                                        FunctionData *bind_data) {
+	return make_uniq<LeastGreatestSortKeyState>(expr.children.size());
+}
+
+template <bool STRING>
+struct StandardLeastGreatest {
+	static constexpr bool IS_STRING = STRING;
+
+	static DataChunk &Prepare(DataChunk &args, ExpressionState &) {
+		return args;
+	}
+
+	static Vector &TargetVector(Vector &result, ExpressionState &) {
+		return result;
+	}
+
+	static void FinalizeResult(idx_t rows, bool result_has_value[], Vector &result, ExpressionState &) {
+		auto &result_mask = FlatVector::Validity(result);
+		for (idx_t i = 0; i < rows; i++) {
+			if (!result_has_value[i]) {
+				result_mask.SetInvalid(i);
+			}
+		}
+	}
+};
+
+struct SortKeyLeastGreatest {
+	static constexpr bool IS_STRING = false;
+
+	static DataChunk &Prepare(DataChunk &args, ExpressionState &state) {
+		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<LeastGreatestSortKeyState>();
+		lstate.sort_keys.Reset();
+		for (idx_t c_idx = 0; c_idx < args.ColumnCount(); c_idx++) {
+			CreateSortKeyHelpers::CreateSortKey(args.data[c_idx], args.size(), lstate.modifiers,
+			                                    lstate.sort_keys.data[c_idx]);
+		}
+		lstate.sort_keys.SetCardinality(args.size());
+		return lstate.sort_keys;
+	}
+
+	static Vector &TargetVector(Vector &result, ExpressionState &state) {
+		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<LeastGreatestSortKeyState>();
+		return lstate.intermediate;
+	}
+
+	static void FinalizeResult(idx_t rows, bool result_has_value[], Vector &result, ExpressionState &state) {
+		auto &lstate = ExecuteFunctionState::GetFunctionState(state)->Cast<LeastGreatestSortKeyState>();
+		auto result_keys = FlatVector::GetData<string_t>(lstate.intermediate);
+		auto &result_mask = FlatVector::Validity(result);
+		for (idx_t i = 0; i < rows; i++) {
+			if (!result_has_value[i]) {
+				result_mask.SetInvalid(i);
+			} else {
+				CreateSortKeyHelpers::DecodeSortKey(result_keys[i], result, i, lstate.modifiers);
+			}
+		}
+	}
+};
+
+template <class T, class OP, class BASE_OP = StandardLeastGreatest<false>>
 static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	if (args.ColumnCount() == 1) {
 		// single input: nop
 		result.Reference(args.data[0]);
 		return;
 	}
+	auto &input = BASE_OP::Prepare(args, state);
+	auto &result_vector = BASE_OP::TargetVector(result, state);
+
 	auto result_type = VectorType::CONSTANT_VECTOR;
-	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
 		if (args.data[col_idx].GetVectorType() != VectorType::CONSTANT_VECTOR) {
 			// non-constant input: result is not a constant vector
 			result_type = VectorType::FLAT_VECTOR;
 		}
-		if (IS_STRING) {
+		if (BASE_OP::IS_STRING) {
 			// for string vectors we add a reference to the heap of the children
-			StringVector::AddHeapReference(result, args.data[col_idx]);
+			StringVector::AddHeapReference(result_vector, input.data[col_idx]);
 		}
 	}
 
-	auto result_data = FlatVector::GetData<T>(result);
-	auto &result_mask = FlatVector::Validity(result);
-	// copy over the first column
-	bool result_has_value[STANDARD_VECTOR_SIZE];
-	{
-		UnifiedVectorFormat vdata;
-		args.data[0].ToUnifiedFormat(args.size(), vdata);
-		auto input_data = UnifiedVectorFormat::GetData<T>(vdata);
-		for (idx_t i = 0; i < args.size(); i++) {
-			auto vindex = vdata.sel->get_index(i);
-			if (vdata.validity.RowIsValid(vindex)) {
-				result_data[i] = input_data[vindex];
-				result_has_value[i] = true;
-			} else {
-				result_has_value[i] = false;
-			}
-		}
-	}
-	// now handle the remainder of the columns
-	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
-		if (args.data[col_idx].GetVectorType() == VectorType::CONSTANT_VECTOR &&
-		    ConstantVector::IsNull(args.data[col_idx])) {
+	auto result_data = FlatVector::GetData<T>(result_vector);
+	bool result_has_value[STANDARD_VECTOR_SIZE] {false};
+	// perform the operation column-by-column
+	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
+		if (input.data[col_idx].GetVectorType() == VectorType::CONSTANT_VECTOR &&
+		    ConstantVector::IsNull(input.data[col_idx])) {
 			// ignore null vector
 			continue;
 		}
 
 		UnifiedVectorFormat vdata;
-		args.data[col_idx].ToUnifiedFormat(args.size(), vdata);
+		input.data[col_idx].ToUnifiedFormat(input.size(), vdata);
 
 		auto input_data = UnifiedVectorFormat::GetData<T>(vdata);
 		if (!vdata.validity.AllValid()) {
 			// potential new null entries: have to check the null mask
-			for (idx_t i = 0; i < args.size(); i++) {
+			for (idx_t i = 0; i < input.size(); i++) {
 				auto vindex = vdata.sel->get_index(i);
 				if (vdata.validity.RowIsValid(vindex)) {
 					// not a null entry: perform the operation and add to new set
@@ -75,7 +139,7 @@ static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vecto
 			}
 		} else {
 			// no new null entries: only need to perform the operation
-			for (idx_t i = 0; i < args.size(); i++) {
+			for (idx_t i = 0; i < input.size(); i++) {
 				auto vindex = vdata.sel->get_index(i);
 
 				auto ivalue = input_data[vindex];
@@ -86,51 +150,86 @@ static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vecto
 			}
 		}
 	}
-	for (idx_t i = 0; i < args.size(); i++) {
-		if (!result_has_value[i]) {
-			result_mask.SetInvalid(i);
-		}
-	}
+	BASE_OP::FinalizeResult(input.size(), result_has_value, result, state);
 	result.SetVectorType(result_type);
 }
 
-template <typename T, class OP>
-ScalarFunction GetLeastGreatestFunction(const LogicalType &type) {
-	return ScalarFunction({type}, type, LeastGreatestFunction<T, OP>, nullptr, nullptr, nullptr, nullptr, type,
-	                      FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING);
+template <class OP>
+unique_ptr<FunctionData> BindLeastGreatest(ClientContext &context, ScalarFunction &bound_function,
+                                           vector<unique_ptr<Expression>> &arguments) {
+	LogicalType child_type = ExpressionBinder::GetExpressionReturnType(*arguments[0]);
+	for (idx_t i = 1; i < arguments.size(); i++) {
+		auto arg_type = ExpressionBinder::GetExpressionReturnType(*arguments[i]);
+		if (!LogicalType::TryGetMaxLogicalType(context, child_type, arg_type, child_type)) {
+			throw BinderException(arguments[i]->query_location,
+			                      "Cannot combine types of %s and %s - an explicit cast is required",
+			                      child_type.ToString(), arg_type.ToString());
+		}
+	}
+	switch (child_type.id()) {
+	case LogicalTypeId::UNKNOWN:
+		throw ParameterNotResolvedException();
+	case LogicalTypeId::INTEGER_LITERAL:
+		child_type = IntegerLiteral::GetType(child_type);
+		break;
+	default:
+		break;
+	}
+	switch (child_type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		bound_function.function = LeastGreatestFunction<int8_t, OP>;
+		break;
+	case PhysicalType::INT16:
+		bound_function.function = LeastGreatestFunction<int16_t, OP>;
+		break;
+	case PhysicalType::INT32:
+		bound_function.function = LeastGreatestFunction<int32_t, OP>;
+		break;
+	case PhysicalType::INT64:
+		bound_function.function = LeastGreatestFunction<int64_t, OP>;
+		break;
+	case PhysicalType::INT128:
+		bound_function.function = LeastGreatestFunction<hugeint_t, OP>;
+		break;
+	case PhysicalType::DOUBLE:
+		bound_function.function = LeastGreatestFunction<double, OP>;
+		break;
+	case PhysicalType::VARCHAR:
+		bound_function.function = LeastGreatestFunction<string_t, OP, StandardLeastGreatest<true>>;
+		break;
+	default:
+		// fallback with sort keys
+		bound_function.function = LeastGreatestFunction<string_t, OP, SortKeyLeastGreatest>;
+		bound_function.init_local_state = LeastGreatestSortKeyInit;
+		break;
+	}
+	bound_function.arguments[0] = child_type;
+	bound_function.varargs = child_type;
+	bound_function.return_type = child_type;
+	return nullptr;
+}
+
+template <class OP>
+ScalarFunction GetLeastGreatestFunction() {
+	return ScalarFunction({LogicalType::ANY}, LogicalType::ANY, nullptr, BindLeastGreatest<OP>, nullptr, nullptr,
+	                      nullptr, LogicalType::ANY, FunctionStability::CONSISTENT,
+	                      FunctionNullHandling::SPECIAL_HANDLING);
 }
 
 template <class OP>
 static ScalarFunctionSet GetLeastGreatestFunctions() {
 	ScalarFunctionSet fun_set;
-	fun_set.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::BIGINT, LeastGreatestFunction<int64_t, OP>,
-	                                   nullptr, nullptr, nullptr, nullptr, LogicalType::BIGINT,
-	                                   FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-	fun_set.AddFunction(ScalarFunction(
-	    {LogicalType::HUGEINT}, LogicalType::HUGEINT, LeastGreatestFunction<hugeint_t, OP>, nullptr, nullptr, nullptr,
-	    nullptr, LogicalType::HUGEINT, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-	fun_set.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE, LeastGreatestFunction<double, OP>,
-	                                   nullptr, nullptr, nullptr, nullptr, LogicalType::DOUBLE,
-	                                   FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-	fun_set.AddFunction(ScalarFunction(
-	    {LogicalType::VARCHAR}, LogicalType::VARCHAR, LeastGreatestFunction<string_t, OP, true>, nullptr, nullptr,
-	    nullptr, nullptr, LogicalType::VARCHAR, FunctionStability::CONSISTENT, FunctionNullHandling::SPECIAL_HANDLING));
-
-	fun_set.AddFunction(GetLeastGreatestFunction<timestamp_t, OP>(LogicalType::TIMESTAMP));
-	fun_set.AddFunction(GetLeastGreatestFunction<time_t, OP>(LogicalType::TIME));
-	fun_set.AddFunction(GetLeastGreatestFunction<date_t, OP>(LogicalType::DATE));
-
-	fun_set.AddFunction(GetLeastGreatestFunction<timestamp_t, OP>(LogicalType::TIMESTAMP_TZ));
-	fun_set.AddFunction(GetLeastGreatestFunction<time_t, OP>(LogicalType::TIME_TZ));
+	fun_set.AddFunction(GetLeastGreatestFunction<OP>());
 	return fun_set;
 }
 
 ScalarFunctionSet LeastFun::GetFunctions() {
-	return GetLeastGreatestFunctions<duckdb::LessThan>();
+	return GetLeastGreatestFunctions<LessThan>();
 }
 
 ScalarFunctionSet GreatestFun::GetFunctions() {
-	return GetLeastGreatestFunctions<duckdb::GreaterThan>();
+	return GetLeastGreatestFunctions<GreaterThan>();
 }
 
 } // namespace duckdb

--- a/src/core_functions/scalar/generic/least.cpp
+++ b/src/core_functions/scalar/generic/least.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/core_functions/scalar/generic_functions.hpp"
 #include "duckdb/core_functions/create_sort_key.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
 

--- a/test/sql/function/generic/least_greatest_enum.test
+++ b/test/sql/function/generic/least_greatest_enum.test
@@ -1,0 +1,14 @@
+# name: test/sql/function/generic/least_greatest_enum.test
+# description: Test LEAST/GREATEST with enum values
+# group: [generic]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TYPE t AS ENUM ('z','y','x');
+
+query II
+SELECT greatest('x'::t, 'z'::t), 'x'::t > 'z'::t;
+----
+x	1

--- a/test/sql/function/generic/least_greatest_types.test
+++ b/test/sql/function/generic/least_greatest_types.test
@@ -1,0 +1,20 @@
+# name: test/sql/function/generic/least_greatest_types.test
+# description: Test LEAST/GREATEST with all types
+# group: [generic]
+
+statement ok
+CREATE TABLE all_types AS FROM test_all_types()
+
+foreach col <all_types_columns>
+
+query I
+SELECT LEAST((SELECT MAX("${col}") FROM all_types), (SELECT MIN("${col}") FROM all_types)) IS NOT DISTINCT FROM (SELECT MIN("${col}") FROM all_types)
+----
+true
+
+query I
+SELECT GREATEST((SELECT MAX("${col}") FROM all_types), (SELECT MIN("${col}") FROM all_types)) IS NOT DISTINCT FROM (SELECT MAX("${col}") FROM all_types)
+----
+true
+
+endloop

--- a/test/sql/function/generic/test_least_greatest.test
+++ b/test/sql/function/generic/test_least_greatest.test
@@ -104,7 +104,7 @@ infinity
 statement error
 SELECT LEAST(DATE '1992-01-01', 'hello', 123)
 ----
-No function matches
+Cannot combine types
 
 # tables
 statement ok
@@ -163,3 +163,7 @@ SELECT LEAST(REPEAT(i::VARCHAR, 20), j::VARCHAR) FROM t1;
 1
 33333333333333333333
 
+query I
+SELECT greatest(CAST(52392441565678.308 AS DECIMAL(17,3)), CAST(52392441565678.308 AS DECIMAL(17,3)));
+----
+52392441565678.308


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/11606

This PR reworks the `least/greatest` functions so that they support all types, instead of the currently (limited) set of types. As seen in the given issue, implicit casting can lead to incorrect results for certain types for these functions. After this rework we maintain the original types. We try to combine types if they are different according to our implicit cast rules, or throw an error if this is not possible. Sort keys are used for types that are not natively supported.

After this PR `least/greatest` can be used for all types, similar to how we can use min/max or comparison operations for all types, e.g.:

```sql
D select least([1], [2]) as result;
┌─────────┐
│ result  │
│ int32[] │
├─────────┤
│ [1]     │
└─────────┘
```
