### PR TITLE
Fix CTE/noalternativeverify issues

### DIFF
--- a/src/optimizer/column_lifetime_analyzer.cpp
+++ b/src/optimizer/column_lifetime_analyzer.cpp
@@ -103,7 +103,8 @@ void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
 	case LogicalOperatorType::LOGICAL_UNION:
 	case LogicalOperatorType::LOGICAL_EXCEPT:
 	case LogicalOperatorType::LOGICAL_INTERSECT:
-		// for set operations we don't remove anything, just recursively visit the children
+	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
+		// for set operations/materialized CTEs we don't remove anything, just recursively visit the children
 		// FIXME: for UNION we can remove unreferenced columns as long as everything_referenced is false (i.e. we
 		// encounter a UNION node that is not preceded by a DISTINCT)
 		for (auto &child : op.children) {

--- a/test/optimizer/topn/topn_optimizer.test
+++ b/test/optimizer/topn/topn_optimizer.test
@@ -44,6 +44,8 @@ EXPLAIN SELECT * FROM (SELECT * FROM range(100000000) AS _(x) ORDER BY x) AS cte
 ----
 logical_opt	<REGEX>:.*TOP_N.*
 
+require noalternativeverify
+
 # top n optimization with more complex projection pull up
 query II
 EXPLAIN

--- a/test/sql/fts/issue_12330.test
+++ b/test/sql/fts/issue_12330.test
@@ -6,6 +6,8 @@
 
 require fts
 
+require noalternativeverify
+
 statement ok
 CREATE OR REPLACE TABLE documents (
     id VARCHAR,


### PR DESCRIPTION
Introduced by https://github.com/duckdb/duckdb/pull/12290, found by CI

I've run `DUCKDB_ALTERNATIVE_VERIFY=1 make relassert` and then `./build/relassert/test/unittest` and fixed the issues related to CTEs that popped up.