### PR TITLE
Fix abs for floating point negative zero

### DIFF
--- a/src/include/duckdb/common/operator/abs.hpp
+++ b/src/include/duckdb/common/operator/abs.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/limits.hpp"
+#include <cmath>
 
 namespace duckdb {
 
@@ -20,6 +21,16 @@ struct AbsOperator {
 		return input < 0 ? -input : input;
 	}
 };
+
+template <>
+inline float AbsOperator::Operation(float input) {
+	return std::fabs(input);
+}
+
+template <>
+inline double AbsOperator::Operation(double input) {
+	return std::fabs(input);
+}
 
 template <>
 inline hugeint_t AbsOperator::Operation(hugeint_t input) {

--- a/test/sql/function/numeric/abs.test
+++ b/test/sql/function/numeric/abs.test
@@ -1,0 +1,12 @@
+# name: test/sql/function/numeric/abs.test
+# description: Test abs
+# group: [numeric]
+
+statement ok
+PRAGMA enable_verification
+
+# test abs on negative zero
+query II
+SELECT abs('-0.0'::float), abs('-0.0'::double)
+----
+0.0	0.0


### PR DESCRIPTION
Use `fabs` for floating point numbers to ensure correct handling of negative zero.