### PR TITLE
[Nightly-Bug] [CSV Reader] Use strings on header detection

### DIFF
--- a/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
@@ -114,10 +114,10 @@ bool CSVSniffer::DetectHeaderWithSetColumn(ClientContext &context, vector<Header
 		if (best_header_row[i].IsNull()) {
 			return false;
 		}
-		if (best_header_row[i].value.GetString() != (*set_columns.names)[i]) {
+		if (best_header_row[i].value != (*set_columns.names)[i]) {
 			error << "Header Mismatch at position:" << i << "\n";
 			error << "Expected Name: \"" << (*set_columns.names)[i] << "\".";
-			error << "Actual Name: \"" << best_header_row[i].value.GetString() << "\"."
+			error << "Actual Name: \"" << best_header_row[i].value << "\"."
 			      << "\n";
 			has_header = false;
 			break;
@@ -240,7 +240,7 @@ CSVSniffer::DetectHeaderInternal(ClientContext &context, vector<HeaderValue> &be
 
 		// get header names from CSV
 		for (idx_t col = 0; col < best_header_row.size(); col++) {
-			string col_name = best_header_row[col].value.GetString();
+			string &col_name = best_header_row[col].value;
 
 			// generate name if field is empty
 			if (EmptyHeader(col_name, best_header_row[col].is_null, options.normalize_names)) {

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
@@ -80,13 +80,13 @@ struct HeaderValue {
 	HeaderValue() : is_null(true) {
 	}
 	explicit HeaderValue(const string_t value_p) {
-		value = value_p;
+		value = value_p.GetString();
 	}
 	bool IsNull() {
 		return is_null;
 	}
 	bool is_null = false;
-	string_t value {};
+	string value;
 };
 
 //! Sniffer that detects Header, Dialect and Types of CSV Files


### PR DESCRIPTION
We were keeping a string_t value for header detection, but for longer strings, if the block is invalidated, it wouldn't be possible to access the original pointer.

Changing it to a string resolves the issue.