### PR TITLE
GCC 4.8: add noexpr to 2 constructors

### DIFF
--- a/src/include/duckdb/common/optional_ptr.hpp
+++ b/src/include/duckdb/common/optional_ptr.hpp
@@ -17,7 +17,7 @@ namespace duckdb {
 template <class T>
 class optional_ptr { // NOLINT: mimic std casing
 public:
-	optional_ptr() : ptr(nullptr) {
+	optional_ptr() noexcept : ptr(nullptr) {
 	}
 	optional_ptr(T *ptr_p) : ptr(ptr_p) { // NOLINT: allow implicit creation from pointer
 	}

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -21,7 +21,7 @@ struct MetaBlockPointer;
 
 class RowVersionManager {
 public:
-	explicit RowVersionManager(idx_t start);
+	explicit RowVersionManager(idx_t start) noexcept;
 
 	idx_t GetStart() {
 		return start;

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -7,7 +7,7 @@
 
 namespace duckdb {
 
-RowVersionManager::RowVersionManager(idx_t start) : start(start), has_changes(false) {
+RowVersionManager::RowVersionManager(idx_t start) noexcept : start(start), has_changes(false) {
 }
 
 void RowVersionManager::SetStart(idx_t new_start) {


### PR DESCRIPTION
Adding noexcept should be handy to have in any case, but it might be required (depending on compiler / standard library) when using atomic<T>.

We might consider a review of where constructor might be noexcept, given on some standard libraries it might speed up constructions of vector<T> a bit, says the internet, but that's left for the future, for now bringing back that functionality.

Given that basically the same error has popped out recently, and the Linux 32 run is somewhat fast, I think it could make sense to have that moved as part of standard CI.
Problem: currently Linux 32 CI fails for unrelated reasons during tests, so that to separate PR.