### PR TITLE
Move Linux 32 test from Nightly to LinuxRelease

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -432,7 +432,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p build/release
-          (cd build/release && cmake -G "Ninja" -DSTATIC_LIBCPP=1 -DBUILD_EXTENSIONS='icu;parquet;fts;json' -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
+          (cd build/release && cmake -G "Ninja" -DSTATIC_LIBCPP=1 -DBUILD_EXTENSIONS='icu;parquet;fts;json' -DSKIP_EXTENSIONS="jemalloc" -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
 
       - name: Test
         shell: bash

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -405,3 +405,35 @@ jobs:
       run:  |
           python scripts/amalgamation.py --extended
           clang++ -std=c++17 -Isrc/amalgamation src/amalgamation/duckdb.cpp -emit-llvm -S -O0
+
+ linux-release-32:
+    name: Linux (32 Bit)
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux2014_x86_64
+    needs: linux-release-64
+    env:
+      CC: /usr/bin/gcc
+      CXX: /usr/bin/g++
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/manylinux_2014_setup
+        with:
+          ninja-build: 1
+          ccache: 1
+          glibc32: 1
+          gcc_4_8: 1 # Note: we run this job on the older gcc 4.8 toolchain
+
+      - name: Build
+        shell: bash
+        run: |
+          mkdir -p build/release
+          (cd build/release && cmake -G "Ninja" -DSTATIC_LIBCPP=1 -DBUILD_EXTENSIONS='icu;parquet;fts;json' -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
+
+      - name: Test
+        shell: bash
+        run: build/release/test/unittest "*"

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -175,38 +175,6 @@ jobs:
         CXX: /usr/bin/g++
         GEN: ninja
 
-  linux-release-32:
-    name: Linux (32 Bit)
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64
-    needs: linux-memory-leaks
-    env:
-      CC: /usr/bin/gcc
-      CXX: /usr/bin/g++
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/manylinux_2014_setup
-        with:
-          ninja-build: 1
-          ccache: 1
-          glibc32: 1
-          gcc_4_8: 1 # Note: we run this job on the older gcc 4.8 toolchain
-
-      - name: Build
-        shell: bash
-        run: |
-          mkdir -p build/release
-          (cd build/release && cmake -G "Ninja" -DSTATIC_LIBCPP=1 -DBUILD_EXTENSIONS='icu;parquet;fts;json' -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
-
-      - name: Test
-        shell: bash
-        run: build/release/test/unittest "*"
-
   linux-tarball:
      name: Python 3 Tarball
      runs-on: ubuntu-20.04


### PR DESCRIPTION
Connected to https://github.com/duckdb/duckdb/pull/13030 and https://github.com/duckdb/duckdb/pull/11513.

Currently I believe GCC 4.8 is not tested in regular CI, that means that incompatibilities are found only later after PRs have been merged.

I think it could make sense to move at least a GCC 4.8 job to regular CI, this looks lightweight enough and allows to test also another not-properly tested semi-common cause for errors: compilation to 32 bit platforms.

NightlyTests is expeceted to have a bunch of unconnected failures, but given it's only removing one part of the workflow the only test that matters is whether yaml is fine (and it is).

Linux 32 bit tests has a few problems:
* if compiled with jemalloc it segfault on startup -> jemalloc has been temporarily removed
* 76 tests are now giving wrong results -> those are serious enough that I will leave them in place

I am not sure of what's better here, adding an `|| true` to the unittester invokation (so it avoid red crosses in unconnected PRs) or leave it in place and we have to sort this out.