### PR TITLE
Fixes for LogicalType::ANY and fixed_size_map

### DIFF
--- a/src/include/duckdb/common/fixed_size_map.hpp
+++ b/src/include/duckdb/common/fixed_size_map.hpp
@@ -125,7 +125,7 @@ public:
 		auto end = map.end();
 		while (*this < end) {
 			const auto &entry = map.occupied.GetValidityEntryUnsafe(entry_idx);
-			if (entry == ~occupied_mask::ValidityBuffer::MAX_ENTRY) {
+			if (entry == static_cast<uint8_t>(~occupied_mask::ValidityBuffer::MAX_ENTRY)) {
 				// Entire entry is unoccupied, skip
 				if (entry_idx == end.entry_idx) {
 					// This is the last entry

--- a/src/main/capi/data_chunk-c.cpp
+++ b/src/main/capi/data_chunk-c.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 #include <string.h>
 
@@ -11,6 +12,10 @@ duckdb_data_chunk duckdb_create_data_chunk(duckdb_logical_type *column_types, id
 	duckdb::vector<duckdb::LogicalType> types;
 	for (idx_t i = 0; i < column_count; i++) {
 		auto logical_type = reinterpret_cast<duckdb::LogicalType *>(column_types[i]);
+		if (duckdb::TypeVisitor::Contains(*logical_type, duckdb::LogicalTypeId::INVALID) ||
+		    duckdb::TypeVisitor::Contains(*logical_type, duckdb::LogicalTypeId::ANY)) {
+			return nullptr;
+		}
 		types.push_back(*logical_type);
 	}
 

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 static duckdb_value WrapValue(duckdb::Value *list_value) {
 	return reinterpret_cast<duckdb_value>(list_value);
@@ -61,6 +62,10 @@ duckdb_value duckdb_create_struct_value(duckdb_logical_type type, duckdb_value *
 	if (logical_type.id() != duckdb::LogicalTypeId::STRUCT) {
 		return nullptr;
 	}
+	if (duckdb::TypeVisitor::Contains(logical_type, duckdb::LogicalTypeId::INVALID) ||
+	    duckdb::TypeVisitor::Contains(logical_type, duckdb::LogicalTypeId::ANY)) {
+		return nullptr;
+	}
 
 	auto count = duckdb::StructType::GetChildCount(logical_type);
 	duckdb::vector<duckdb::Value> unwrapped_values;
@@ -87,6 +92,10 @@ duckdb_value duckdb_create_list_value(duckdb_logical_type type, duckdb_value *va
 	}
 	auto &logical_type = UnwrapType(type);
 	duckdb::vector<duckdb::Value> unwrapped_values;
+	if (duckdb::TypeVisitor::Contains(logical_type, duckdb::LogicalTypeId::INVALID) ||
+	    duckdb::TypeVisitor::Contains(logical_type, duckdb::LogicalTypeId::ANY)) {
+		return nullptr;
+	}
 
 	for (idx_t i = 0; i < value_count; i++) {
 		auto value = values[i];
@@ -113,6 +122,10 @@ duckdb_value duckdb_create_array_value(duckdb_logical_type type, duckdb_value *v
 		return nullptr;
 	}
 	auto &logical_type = UnwrapType(type);
+	if (duckdb::TypeVisitor::Contains(logical_type, duckdb::LogicalTypeId::INVALID) ||
+	    duckdb::TypeVisitor::Contains(logical_type, duckdb::LogicalTypeId::ANY)) {
+		return nullptr;
+	}
 	duckdb::vector<duckdb::Value> unwrapped_values;
 
 	for (idx_t i = 0; i < value_count; i++) {


### PR DESCRIPTION
* `LogicalType::ANY` in the C API currently relies on catching an `InternalException` to deal with invalid types in various places. This does not work with `CRASH_ON_ASSERT` (which breaks my local workflow) - and we shouldn't be throwing internal exceptions ever anyway. This PR fixes it so we detect invalid types up-front instead.
* Adds a static cast to the `fixed_size_map` as this causes warnings on some CI runs otherwise


