### PR TITLE
[Nightly] Fix for arrow appending fixed size lists

### DIFF
--- a/src/common/arrow/appender/fixed_size_list_data.cpp
+++ b/src/common/arrow/appender/fixed_size_list_data.cpp
@@ -19,7 +19,7 @@ void ArrowFixedSizeListData::Append(ArrowAppendData &append_data, Vector &input,
 	input.ToUnifiedFormat(input_size, format);
 	idx_t size = to - from;
 	AppendValidity(append_data, format, from, to);
-
+	input.Flatten(input_size);
 	auto array_size = ArrayType::GetSize(input.GetType());
 	auto &child_vector = ArrayVector::GetEntry(input);
 	auto &child_data = *append_data.child_data[0];


### PR DESCRIPTION
Basically we make sure to flatten the arrays before conversion.
Fix for when running the arrow conversion tests with a `VERIFY_VECTOR=dictionary_expression` build