### PR TITLE
Julia - Only commit transaction on non-error

### DIFF
--- a/tools/juliapkg/src/transaction.jl
+++ b/tools/juliapkg/src/transaction.jl
@@ -6,7 +6,7 @@ function DBInterface.transaction(f, con::Connection)
     catch
         rollback(con)
         rethrow()
-    finally
+    else
         commit(con)
     end
 end


### PR DESCRIPTION
This removes an extra error `Execute of query "COMMIT TRANSACTION;" failed: TransactionContext Error: cannot commit - no transaction is active` that would be thrown when an error occurs within the try block and the transaction needs to be rolled back.