### PR TITLE
[Julia] Only commit transaction on non-error (compat)

### DIFF
--- a/tools/juliapkg/src/transaction.jl
+++ b/tools/juliapkg/src/transaction.jl
@@ -6,9 +6,8 @@ function DBInterface.transaction(f, con::Connection)
     catch
         rollback(con)
         rethrow()
-    finally
-        commit(con)
     end
+    commit(con)
 end
 
 function DBInterface.transaction(f, db::DB)

--- a/tools/juliapkg/src/transaction.jl
+++ b/tools/juliapkg/src/transaction.jl
@@ -7,7 +7,8 @@ function DBInterface.transaction(f, con::Connection)
         rollback(con)
         rethrow()
     end
-    return commit(con)
+    commit(con)
+    return
 end
 
 function DBInterface.transaction(f, db::DB)

--- a/tools/juliapkg/src/transaction.jl
+++ b/tools/juliapkg/src/transaction.jl
@@ -7,7 +7,7 @@ function DBInterface.transaction(f, con::Connection)
         rollback(con)
         rethrow()
     end
-    commit(con)
+    return commit(con)
 end
 
 function DBInterface.transaction(f, db::DB)


### PR DESCRIPTION
This removes an extra error `Execute of query "COMMIT TRANSACTION;" failed: TransactionContext Error: cannot commit - no transaction is active` that would be thrown when an error occurs within the try block and the transaction needs to be rolled back.

Julia <1.8 compatible version of #13048