### PR TITLE
Make client reuse threadsafe

### DIFF
--- a/extension/httpfs/hffs.cpp
+++ b/extension/httpfs/hffs.cpp
@@ -55,8 +55,8 @@ static string ParseNextUrlFromLinkHeader(const string &link_header_content) {
 
 HFFileHandle::~HFFileHandle() {};
 
-void HFFileHandle::InitializeClient(optional_ptr<ClientContext> client_context) {
-	http_client = HTTPFileSystem::GetClient(this->http_params, parsed_url.endpoint.c_str(), this);
+unique_ptr<duckdb_httplib_openssl::Client> HFFileHandle::CreateClient(optional_ptr<ClientContext> client_context) {
+	return HTTPFileSystem::GetClient(this->http_params, parsed_url.endpoint.c_str(), this);
 }
 
 string HuggingFaceFileSystem::ListHFRequest(ParsedHFUrl &url, HTTPParams &http_params, string &next_page_url,

--- a/extension/httpfs/include/hffs.hpp
+++ b/extension/httpfs/include/hffs.hpp
@@ -62,7 +62,7 @@ public:
 	}
 	~HFFileHandle() override;
 
-	void InitializeClient(optional_ptr<ClientContext> client_context) override;
+	unique_ptr<duckdb_httplib_openssl::Client> CreateClient(optional_ptr<ClientContext> client_context) override;
 
 protected:
 	ParsedHFUrl parsed_url;

--- a/extension/httpfs/include/httpfs.hpp
+++ b/extension/httpfs/include/httpfs.hpp
@@ -58,6 +58,20 @@ struct HTTPParams {
 	static HTTPParams ReadFrom(optional_ptr<FileOpener> opener);
 };
 
+class HTTPClientCache {
+public:
+	//! Get a client from the client cache
+	unique_ptr<duckdb_httplib_openssl::Client> GetClient();
+	//! Store a client in the cache for reuse
+	void StoreClient(unique_ptr<duckdb_httplib_openssl::Client> client);
+
+protected:
+	//! The cached clients
+	vector<unique_ptr<duckdb_httplib_openssl::Client>> clients;
+	//! Lock to fetch a client
+	mutex lock;
+};
+
 class HTTPFileHandle : public FileHandle {
 public:
 	HTTPFileHandle(FileSystem &fs, const string &path, FileOpenFlags flags, const HTTPParams &params);
@@ -66,7 +80,8 @@ public:
 	virtual void Initialize(optional_ptr<FileOpener> opener);
 
 	// We keep an http client stored for connection reuse with keep-alive headers
-	duckdb::unique_ptr<duckdb_httplib_openssl::Client> http_client;
+	HTTPClientCache client_cache;
+
 	optional_ptr<HTTPLogger> http_logger;
 
 	const HTTPParams http_params;
@@ -94,12 +109,18 @@ public:
 
 	void AddHeaders(HeaderMap &map);
 
+	// Get a Client to run requests over
+	unique_ptr<duckdb_httplib_openssl::Client> GetClient(optional_ptr<ClientContext> client_context);
+	// Return the client for re-use
+	void StoreClient(unique_ptr<duckdb_httplib_openssl::Client> client);
+
 public:
 	void Close() override {
 	}
 
 protected:
-	virtual void InitializeClient(optional_ptr<ClientContext> client_context);
+	//! Create a new Client
+	virtual unique_ptr<duckdb_httplib_openssl::Client> CreateClient(optional_ptr<ClientContext> client_context);
 };
 
 class HTTPFileSystem : public FileSystem {

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -165,7 +165,7 @@ protected:
 	atomic<bool> uploader_has_error {false};
 	std::exception_ptr upload_exception;
 
-	void InitializeClient(optional_ptr<ClientContext> client_context) override;
+	unique_ptr<duckdb_httplib_openssl::Client> CreateClient(optional_ptr<ClientContext> client_context) override;
 
 	//! Rethrow IO Exception originating from an upload thread
 	void RethrowIOError() {

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -334,11 +334,11 @@ void S3FileHandle::Close() {
 	}
 }
 
-void S3FileHandle::InitializeClient(optional_ptr<ClientContext> client_context) {
+unique_ptr<duckdb_httplib_openssl::Client> S3FileHandle::CreateClient(optional_ptr<ClientContext> client_context) {
 	auto parsed_url = S3FileSystem::S3UrlParse(path, this->auth_params);
 
 	string proto_host_port = parsed_url.http_proto + parsed_url.host;
-	http_client = HTTPFileSystem::GetClient(this->http_params, proto_host_port.c_str(), this);
+	return HTTPFileSystem::GetClient(this->http_params, proto_host_port.c_str(), this);
 }
 
 // Opens the multipart upload and returns the ID

--- a/src/execution/operator/csv_scanner/scanner/csv_schema.cpp
+++ b/src/execution/operator/csv_scanner/scanner/csv_schema.cpp
@@ -62,7 +62,7 @@ bool CSVSchema::Empty() const {
 
 bool CSVSchema::SchemasMatch(string &error_message, vector<string> &names, vector<LogicalType> &types,
                              const string &cur_file_path) {
-	D_ASSERT(names.size() == types.size() && !names.empty());
+	D_ASSERT(names.size() == types.size());
 	bool match = true;
 	unordered_map<string, TypeIdxPair> current_schema;
 	for (idx_t i = 0; i < names.size(); i++) {

--- a/test/extension/autoloading_filesystems.test
+++ b/test/extension/autoloading_filesystems.test
@@ -42,4 +42,4 @@ SET s3_endpoint='false_endpoint';
 statement error
 SELECT * FROM 's3://some-bucket/a-file.csv'
 ----
-Could not establish Could not establish connection error for HTTP HEAD 'https://some-bucket.false_endpoint/a-file.csv'
+Could not establish connection error for HTTP HEAD to 'https://some-bucket.false_endpoint/a-file.csv'

--- a/test/extension/autoloading_filesystems.test
+++ b/test/extension/autoloading_filesystems.test
@@ -42,4 +42,4 @@ SET s3_endpoint='false_endpoint';
 statement error
 SELECT * FROM 's3://some-bucket/a-file.csv'
 ----
-Could not establish connection error for HTTP HEAD to 'https://some-bucket.false_endpoint/a-file.csv'
+Could not establish Could not establish connection error for HTTP HEAD 'https://some-bucket.false_endpoint/a-file.csv'

--- a/test/sql/copy/csv/glob/read_csv_glob_s3.test
+++ b/test/sql/copy/csv/glob/read_csv_glob_s3.test
@@ -103,7 +103,6 @@ SELECT * FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/[aei]*/*.csv', co
 2019-08-15
 2019-08-25
 3
-NULL
 
 query II
 SELECT a, b LIKE '%a_.csv' FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob/[aei]*/*.csv', columns=STRUCT_PACK(d := 'STRING'), filename=1) t(a,b) ORDER BY 1
@@ -120,7 +119,6 @@ SELECT a, b LIKE '%a_.csv' FROM read_csv('s3://test-bucket/read_csv_glob_s3/glob
 2019-08-15	0
 2019-08-25	0
 3	0
-NULL	0
 
 # test glob parsing
 query I

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -119,7 +119,7 @@ Unable to connect to URL "http://test-bucket-public.
 statement error
 SELECT i FROM "http://test-bucket-public.duckdb-minio-non-existent-host.com:9000/root-dir/non-existent-file-ljaslkjdas.parquet" LIMIT 3
 ----
-Could not establish connection error for HTTP HEAD 'http://test-bucket-public.
+Could not establish connection error for HTTP HEAD to 'http://test-bucket-public.
 
 # S3 errors should throw on
 statement error

--- a/test/sql/copy/s3/download_config.test
+++ b/test/sql/copy/s3/download_config.test
@@ -119,7 +119,7 @@ Unable to connect to URL "http://test-bucket-public.
 statement error
 SELECT i FROM "http://test-bucket-public.duckdb-minio-non-existent-host.com:9000/root-dir/non-existent-file-ljaslkjdas.parquet" LIMIT 3
 ----
-Connection error for HTTP HEAD to 'http://test-bucket-public.
+Could not establish connection error for HTTP HEAD 'http://test-bucket-public.
 
 # S3 errors should throw on
 statement error

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -118,7 +118,7 @@ set s3_endpoint='s3.some.random.endpoint.com';
 statement error
 SELECT * FROM '${prefix}test-bucket/whatever.parquet';
 ----
-Connection error for HTTP HEAD to 'http://test-bucket.s3.some.random.endpoint.com/whatever.parquet'
+Could not establish connection error for HTTP HEAD 'http://test-bucket.s3.some.random.endpoint.com/whatever.parquet'
 
 statement ok
 set s3_endpoint='${DUCKDB_S3_ENDPOINT}'

--- a/test/sql/copy/s3/url_encode.test
+++ b/test/sql/copy/s3/url_encode.test
@@ -118,7 +118,7 @@ set s3_endpoint='s3.some.random.endpoint.com';
 statement error
 SELECT * FROM '${prefix}test-bucket/whatever.parquet';
 ----
-Could not establish connection error for HTTP HEAD 'http://test-bucket.s3.some.random.endpoint.com/whatever.parquet'
+Could not establish connection error for HTTP HEAD to 'http://test-bucket.s3.some.random.endpoint.com/whatever.parquet'
 
 statement ok
 set s3_endpoint='${DUCKDB_S3_ENDPOINT}'

--- a/test/sql/secrets/create_secret.test_slow
+++ b/test/sql/secrets/create_secret.test_slow
@@ -51,7 +51,7 @@ secret_scope_1	s3	[s3://b1]
 statement error
 FROM 's3://b1/test.csv'
 ----
-Connection error for HTTP HEAD to 'https://b1.invalid-on-purpose-2/test.csv'
+Could not establish connection error for HTTP HEAD 'https://b1.invalid-on-purpose-2/test.csv'
 
 # Now confirm we can also set multiple scopes
 statement ok
@@ -70,4 +70,4 @@ secret_scope_2	s3	[s3://b2, s3://b3]
 statement error
 FROM 's3://b2/test.csv'
 ----
-Connection error for HTTP HEAD to 'https://b2.invalid-on-purpose-3/test.csv'
+Could not establish connection error for HTTP HEAD 'https://b2.invalid-on-purpose-3/test.csv'

--- a/test/sql/secrets/create_secret.test_slow
+++ b/test/sql/secrets/create_secret.test_slow
@@ -51,7 +51,7 @@ secret_scope_1	s3	[s3://b1]
 statement error
 FROM 's3://b1/test.csv'
 ----
-Could not establish connection error for HTTP HEAD 'https://b1.invalid-on-purpose-2/test.csv'
+Could not establish connection error for HTTP HEAD to 'https://b1.invalid-on-purpose-2/test.csv'
 
 # Now confirm we can also set multiple scopes
 statement ok
@@ -70,4 +70,4 @@ secret_scope_2	s3	[s3://b2, s3://b3]
 statement error
 FROM 's3://b2/test.csv'
 ----
-Could not establish connection error for HTTP HEAD 'https://b2.invalid-on-purpose-3/test.csv'
+Could not establish connection error for HTTP HEAD to 'https://b2.invalid-on-purpose-3/test.csv'


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/12719  by making HTTPlib client re-use threadsafe.
The problem was that filehandles are shared between threads when attaching DuckDB databases over S3. Now clients are reused by storing them in a pool of clients in each filehandle that is protected with a lock.

What this means is that now this happens
- Thread A makes a request using a HTTPClient which leaves the connection open
- Thread A stores the httpclient with the still open connection in the filehandle when its request is done
- Thread B now wants to make a request, it fetches the HTTPClient that Thread A stored for reuse
- Thread B can now make a requests on the still open connection initiated by Thread A.

Some notable facts:
- Clients are refreshed on HTTP retries
- There is no global limit on the amount of connections that can be open: We can still run into OS connection limits if calling code opens a lot of filehandles and/or uses a lot of threads to read. This can be solved by disabling connection keepalive using the `http_keep_alive` option
