### PR TITLE
[Relation] ViewRelation could be created without an alias

### DIFF
--- a/src/include/duckdb/main/relation/view_relation.hpp
+++ b/src/include/duckdb/main/relation/view_relation.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 class ViewRelation : public Relation {
 public:
 	ViewRelation(const shared_ptr<ClientContext> &context, string schema_name, string view_name);
-	ViewRelation(const shared_ptr<ClientContext> &context, unique_ptr<TableRef> ref);
+	ViewRelation(const shared_ptr<ClientContext> &context, unique_ptr<TableRef> ref, const string &view_name);
 
 	string schema_name;
 	string view_name;

--- a/src/main/relation/view_relation.cpp
+++ b/src/main/relation/view_relation.cpp
@@ -16,6 +16,7 @@ ViewRelation::ViewRelation(const shared_ptr<ClientContext> &context, string sche
 ViewRelation::ViewRelation(const shared_ptr<ClientContext> &context, unique_ptr<TableRef> ref, const string &view_name)
     : Relation(context, RelationType::VIEW_RELATION), view_name(view_name), premade_tableref(std::move(ref)) {
 	context->TryBindRelation(*this, this->columns);
+	premade_tableref->alias = view_name;
 }
 
 unique_ptr<QueryNode> ViewRelation::GetQueryNode() {

--- a/src/main/relation/view_relation.cpp
+++ b/src/main/relation/view_relation.cpp
@@ -13,8 +13,8 @@ ViewRelation::ViewRelation(const shared_ptr<ClientContext> &context, string sche
 	context->TryBindRelation(*this, this->columns);
 }
 
-ViewRelation::ViewRelation(const shared_ptr<ClientContext> &context, unique_ptr<TableRef> ref)
-    : Relation(context, RelationType::VIEW_RELATION), premade_tableref(std::move(ref)) {
+ViewRelation::ViewRelation(const shared_ptr<ClientContext> &context, unique_ptr<TableRef> ref, const string &view_name)
+    : Relation(context, RelationType::VIEW_RELATION), view_name(view_name), premade_tableref(std::move(ref)) {
 	context->TryBindRelation(*this, this->columns);
 }
 
@@ -36,6 +36,7 @@ unique_ptr<TableRef> ViewRelation::GetTableRef() {
 }
 
 string ViewRelation::GetAlias() {
+	D_ASSERT(!view_name.empty());
 	return view_name;
 }
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -664,7 +664,7 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::RegisterPythonObject(const st
 	auto &connection = con.GetConnection();
 	auto &client = *connection.context;
 	auto object = PythonReplacementScan::ReplacementObject(python_object, name, client);
-	auto view_rel = make_shared_ptr<ViewRelation>(connection.context, std::move(object));
+	auto view_rel = make_shared_ptr<ViewRelation>(connection.context, std::move(object), name);
 	bool replace = registered_objects.count(name);
 	view_rel->CreateView(name, replace, true);
 	registered_objects.insert(name);
@@ -1242,7 +1242,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDF(const PandasDataFrame &v
 	}
 	auto tableref = PythonReplacementScan::ReplacementObject(value, name, *connection.context);
 	D_ASSERT(tableref);
-	auto rel = make_shared_ptr<ViewRelation>(connection.context, std::move(tableref))->Alias(name);
+	auto rel = make_shared_ptr<ViewRelation>(connection.context, std::move(tableref), name);
 	return make_uniq<DuckDBPyRelation>(std::move(rel));
 }
 
@@ -1306,7 +1306,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromArrow(py::object &arrow_obj
 	}
 	auto tableref = PythonReplacementScan::ReplacementObject(arrow_object, name, *connection.context);
 	D_ASSERT(tableref);
-	auto rel = make_shared_ptr<ViewRelation>(connection.context, std::move(tableref))->Alias(name);
+	auto rel = make_shared_ptr<ViewRelation>(connection.context, std::move(tableref), name);
 	return make_uniq<DuckDBPyRelation>(std::move(rel));
 }
 


### PR DESCRIPTION
This PR fixes an issue introduced by <https://github.com/duckdb/duckdb/pull/12625>

`Relation::GetAlias` should never return an empty string, this wasn't honored by the ViewRelation when created from a tableref.