### PR TITLE
Fix incorrect overflow in left shift of unsigned number

### DIFF
--- a/src/core_functions/scalar/operators/bitwise.cpp
+++ b/src/core_functions/scalar/operators/bitwise.cpp
@@ -206,11 +206,10 @@ ScalarFunctionSet BitwiseNotFun::GetFunctions() {
 //===--------------------------------------------------------------------===//
 // << [bitwise_left_shift]
 //===--------------------------------------------------------------------===//
-
 struct BitwiseShiftLeftOperator {
 	template <class TA, class TB, class TR>
 	static inline TR Operation(TA input, TB shift) {
-		TA max_shift = TA(sizeof(TA) * 8);
+		TA max_shift = TA(sizeof(TA) * 8) + (NumericLimits<TA>::IsSigned() ? 0 : 1);
 		if (input < 0) {
 			throw OutOfRangeException("Cannot left-shift negative number %s", NumericHelper::ToString(input));
 		}

--- a/test/sql/function/operator/test_bitwise_ops.test
+++ b/test/sql/function/operator/test_bitwise_ops.test
@@ -65,3 +65,18 @@ statement error
 SELECT 2.0 << 1
 ----
 
+# unsigned numbers
+query IIII
+SELECT 1::UTINYINT << 7, 1::USMALLINT << 15, 1::UINT32 << 31, 1::UBIGINT << 63
+----
+128	32768	2147483648	9223372036854775808
+
+statement error
+SELECT 1::UINT32 << 32
+----
+Overflow in left shift
+
+statement error
+SELECT 2::UINT32 << 31
+----
+Overflow in left shift


### PR DESCRIPTION
Unsigned numbers can be left-shifted by one more number, e.g. this should work (but currently throws an exception):

```sql
select 1::UINT32 << 31;
```