### PR TITLE
Only remove the first occurrence of extension prefix

### DIFF
--- a/src/main/database_path_and_type.cpp
+++ b/src/main/database_path_and_type.cpp
@@ -8,8 +8,8 @@ namespace duckdb {
 void DBPathAndType::ExtractExtensionPrefix(string &path, string &db_type) {
 	auto extension = ExtensionHelper::ExtractExtensionPrefixFromPath(path);
 	if (!extension.empty()) {
-		// path is prefixed with an extension - remove it
-		path = StringUtil::Replace(path, extension + ":", "");
+		// path is prefixed with an extension - remove the first occurence of it
+		path = path.substr(extension.length() + 1);
 		db_type = ExtensionHelper::ApplyExtensionAlias(extension);
 	}
 }


### PR DESCRIPTION
An extension prefix is found when a given path is prefixed by some string followed by ':'. Then all occurrences of this prefix are removed from the path.

For instance, `ext:db` becomes `db`.
The problem is when we have `ext:myext:db`, the path will change to `mydb`, which is not an intended database name from the user.

To prevent this, this PR only removes the first occurrence of the extension prefix.