### PR TITLE
[Dev] Override a couple virtual destructors from base classes

### DIFF
--- a/src/common/types/vector_cache.cpp
+++ b/src/common/types/vector_cache.cpp
@@ -43,7 +43,10 @@ public:
 			break;
 		}
 	}
+	~VectorCacheBuffer() override {
+	}
 
+public:
 	void ResetFromCache(Vector &result, const buffer_ptr<VectorBuffer> &buffer) {
 		D_ASSERT(type == result.GetType());
 		auto internal_type = type.InternalType();

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -148,6 +148,8 @@ public:
 	explicit DictionaryBuffer(idx_t count = STANDARD_VECTOR_SIZE)
 	    : VectorBuffer(VectorBufferType::DICTIONARY_BUFFER), sel_vector(count) {
 	}
+	~DictionaryBuffer() override {
+	}
 
 public:
 	const SelectionVector &GetSelVector() const {
@@ -168,6 +170,8 @@ class VectorStringBuffer : public VectorBuffer {
 public:
 	VectorStringBuffer();
 	explicit VectorStringBuffer(VectorBufferType type);
+	~VectorStringBuffer() override {
+	}
 
 public:
 	string_t AddString(const char *data, idx_t len) {

--- a/src/include/duckdb/storage/compression/alp/alp_compress.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_compress.hpp
@@ -40,6 +40,8 @@ public:
 		//! Combinations found on the analyze step are needed for compression
 		state.best_k_combinations = analyze_state->state.best_k_combinations;
 	}
+	~AlpCompressionState() override {
+	}
 
 	ColumnDataCheckpointer &checkpointer;
 	CompressionFunction &function;

--- a/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
@@ -48,6 +48,8 @@ public:
 		       actual_dictionary_size_bytes);
 		CreateEmptySegment(checkpointer.GetRowGroup().start);
 	}
+	~AlpRDCompressionState() override {
+	}
 
 	ColumnDataCheckpointer &checkpointer;
 	CompressionFunction &function;

--- a/src/include/duckdb/storage/table/array_column_data.hpp
+++ b/src/include/duckdb/storage/table/array_column_data.hpp
@@ -18,7 +18,10 @@ class ArrayColumnData : public ColumnData {
 public:
 	ArrayColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, idx_t start_row,
 	                LogicalType type, optional_ptr<ColumnData> parent = nullptr);
+	~ArrayColumnData() override {
+	}
 
+public:
 	//! The child-column of the list
 	unique_ptr<ColumnData> child_column;
 	//! The validity column data of the struct

--- a/src/include/duckdb/storage/table/list_column_data.hpp
+++ b/src/include/duckdb/storage/table/list_column_data.hpp
@@ -18,7 +18,10 @@ class ListColumnData : public ColumnData {
 public:
 	ListColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, idx_t start_row,
 	               LogicalType type, optional_ptr<ColumnData> parent = nullptr);
+	~ListColumnData() override {
+	}
 
+public:
 	//! The child-column of the list
 	unique_ptr<ColumnData> child_column;
 	//! The validity column data of the struct

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -18,7 +18,10 @@ class StandardColumnData : public ColumnData {
 public:
 	StandardColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, idx_t start_row,
 	                   LogicalType type, optional_ptr<ColumnData> parent = nullptr);
+	~StandardColumnData() override {
+	}
 
+public:
 	//! The validity column data
 	ValidityColumnData validity;
 

--- a/src/include/duckdb/storage/table/struct_column_data.hpp
+++ b/src/include/duckdb/storage/table/struct_column_data.hpp
@@ -18,7 +18,10 @@ class StructColumnData : public ColumnData {
 public:
 	StructColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, idx_t start_row,
 	                 LogicalType type, optional_ptr<ColumnData> parent = nullptr);
+	~StructColumnData() override {
+	}
 
+public:
 	//! The sub-columns of the struct
 	vector<unique_ptr<ColumnData>> sub_columns;
 	//! The validity column data of the struct

--- a/src/include/duckdb/storage/table/validity_column_data.hpp
+++ b/src/include/duckdb/storage/table/validity_column_data.hpp
@@ -17,6 +17,8 @@ class ValidityColumnData : public ColumnData {
 public:
 	ValidityColumnData(BlockManager &block_manager, DataTableInfo &info, idx_t column_index, idx_t start_row,
 	                   ColumnData &parent);
+	~ValidityColumnData() override {
+	}
 
 public:
 	FilterPropagateResult CheckZonemap(ColumnScanState &state, TableFilter &filter) override;

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -383,6 +383,8 @@ public:
 		auto &config = DBConfig::GetConfig(checkpointer.GetDatabase());
 		state.mode = config.options.force_bitpacking_mode;
 	}
+	~BitpackingCompressState() override {
+	}
 
 	ColumnDataCheckpointer &checkpointer;
 	CompressionFunction &function;

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -15,6 +15,8 @@ namespace duckdb {
 class DictionaryCompressionState : public CompressionState {
 public:
 	explicit DictionaryCompressionState(const CompressionInfo &info) : CompressionState(info) {};
+	~DictionaryCompressionState() override {
+	}
 
 public:
 	bool UpdateState(Vector &scan_vector, idx_t count) {

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -42,8 +42,12 @@ idx_t FixedSizeFinalAnalyze(AnalyzeState &state_p) {
 // Compress
 //===--------------------------------------------------------------------===//
 struct UncompressedCompressState : public CompressionState {
+public:
 	UncompressedCompressState(ColumnDataCheckpointer &checkpointer, const CompressionInfo &info);
+	~UncompressedCompressState() override {
+	}
 
+public:
 	ColumnDataCheckpointer &checkpointer;
 	unique_ptr<ColumnSegment> current_segment;
 	ColumnAppendState append_state;

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -128,7 +128,6 @@ struct RLECompressState : public CompressionState {
 			state->WriteValue(value, count, is_null);
 		}
 	};
-
 	idx_t MaxRLECount() {
 		auto entry_size = sizeof(T) + sizeof(rle_count_t);
 		return (info.GetBlockSize() - RLEConstants::RLE_HEADER_SIZE) / entry_size;
@@ -141,6 +140,8 @@ struct RLECompressState : public CompressionState {
 
 		state.dataptr = (void *)this;
 		max_rle_count = MaxRLECount();
+	}
+	~RLECompressState() override {
 	}
 
 	void CreateEmptySegment(idx_t row_start) {

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -159,13 +159,18 @@ void UncompressedStringStorage::StringFetchRow(ColumnSegment &segment, ColumnFet
 // Append
 //===--------------------------------------------------------------------===//
 struct SerializedStringSegmentState : public ColumnSegmentState {
+public:
 	SerializedStringSegmentState() {
 	}
 	explicit SerializedStringSegmentState(vector<block_id_t> blocks_p) : blocks(std::move(blocks_p)) {
 	}
+	~SerializedStringSegmentState() override {
+	}
 
+public:
 	vector<block_id_t> blocks;
 
+public:
 	void Serialize(Serializer &serializer) const override {
 		serializer.WriteProperty(1, "overflow_blocks", blocks);
 	}


### PR DESCRIPTION
With my (perhaps limited) understanding of C++, not overriding a virtual destructor causes the members added by the derived class to not be destroyed when `delete` is called on the object as a `<base class> *`

Perhaps this is added implicitly somehow, but it can't hurt to be explicit about it