### PR TITLE
Add pragma extension versions

### DIFF
--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -125,7 +125,8 @@ string PragmaVersion(ClientContext &context, const FunctionParameters &parameter
 }
 
 string PragmaExtensionVersions(ClientContext &context, const FunctionParameters &parameters) {
-	return "select extension_name, extension_version, install_mode, installed_from from duckdb_extensions() where installed";
+	return "select extension_name, extension_version, install_mode, installed_from from duckdb_extensions() where "
+	       "installed";
 }
 
 string PragmaPlatform(ClientContext &context, const FunctionParameters &parameters) {

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -128,10 +128,6 @@ string PragmaExtensionVersions(ClientContext &context, const FunctionParameters 
 	return "select extension_name, extension_version, install_mode, installed_from from duckdb_extensions() where installed";
 }
 
-string PragmaBugReportInfo(ClientContext &context, const FunctionParameters &parameters) {
-	return "pragma extension_versions; pragma version; pragma platform;";
-}
-
 string PragmaPlatform(ClientContext &context, const FunctionParameters &parameters) {
 	return "SELECT * FROM pragma_platform();";
 }

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -124,6 +124,14 @@ string PragmaVersion(ClientContext &context, const FunctionParameters &parameter
 	return "SELECT * FROM pragma_version();";
 }
 
+string PragmaExtensionVersions(ClientContext &context, const FunctionParameters &parameters) {
+	return "select extension_name, extension_version, install_mode, installed_from from duckdb_extensions() where installed";
+}
+
+string PragmaBugReportInfo(ClientContext &context, const FunctionParameters &parameters) {
+	return "pragma extension_versions; pragma version; pragma platform;";
+}
+
 string PragmaPlatform(ClientContext &context, const FunctionParameters &parameters) {
 	return "SELECT * FROM pragma_platform();";
 }
@@ -203,6 +211,7 @@ void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
 	set.AddFunction(PragmaFunction::PragmaStatement("collations", PragmaCollations));
 	set.AddFunction(PragmaFunction::PragmaCall("show", PragmaShow, {LogicalType::VARCHAR}));
 	set.AddFunction(PragmaFunction::PragmaStatement("version", PragmaVersion));
+	set.AddFunction(PragmaFunction::PragmaStatement("extension_versions", PragmaExtensionVersions));
 	set.AddFunction(PragmaFunction::PragmaStatement("platform", PragmaPlatform));
 	set.AddFunction(PragmaFunction::PragmaStatement("database_size", PragmaDatabaseSize));
 	set.AddFunction(PragmaFunction::PragmaStatement("functions", PragmaFunctionsQuery));

--- a/test/sql/pragma/test_pragma_version.test
+++ b/test/sql/pragma/test_pragma_version.test
@@ -24,3 +24,6 @@ query I
 SELECT count(*) FROM pragma_version() WHERE library_version LIKE 'v%';
 ----
 1
+
+statement ok
+pragma extension_versions;


### PR DESCRIPTION
The problem is that its not always easy for a user to determine which extensions are involved in a bug. Additionally, release cycles of extensions are increasingly out of sync with DuckDB. Therefore I think we can improve the quality of our bugreports asking every user for the all extension versions along with the duckdb version. To make this easy to read for us I think we can just ask users to run a few pragmas and paste the output in a code block. This will provide us with:
- platform
- duckdb version
- extension
    - version
    - repo (core, core_nightly, community, custom)
    - statically linked/dynamically loaded 

Basically with this PR, we can ask for users to run the following three pragmas to get all relevant info for a bug report:

```SQL
 pragma platform;
 pragma version;
 pragma extension_versions;
 ```
 In my case:
 ```
 ┌───────────┐
│ platform  │
│  varchar  │
├───────────┤
│ osx_arm64 │
└───────────┘
┌─────────────────┬────────────┐
│ library_version │ source_id  │
│     varchar     │  varchar   │
├─────────────────┼────────────┤
│ v1.0.1-dev2991  │ 85a82d86aa │
└─────────────────┴────────────┘
┌────────────────┬───────────────────┬───────────────────┬────────────────┐
│ extension_name │ extension_version │   install_mode    │ installed_from │
│    varchar     │      varchar      │      varchar      │    varchar     │
├────────────────┼───────────────────┼───────────────────┼────────────────┤
│ httpfs         │ 85a82d86aa        │ STATICALLY_LINKED │                │
│ parquet        │ 85a82d86aa        │ STATICALLY_LINKED │                │
│ shell          │                   │ STATICALLY_LINKED │                │
└────────────────┴───────────────────┴───────────────────┴────────────────┘
```

Asking this ahead of any bugreports will allow us to quickly determine what version the bugreport was on. Additionally, our bug report template should probably ask to run `UPDATE EXTENSIONS`. I can pick this up with @szarnyasg as followup.

An even cooler follow-up would be to have a `CREATE BUGREPORT` statement in DuckDB that prefills all these fields by automatically opening your browser with this info prefilled.