### PR TITLE
Fix for unpivot on zero columns

### DIFF
--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -538,6 +538,9 @@ unique_ptr<SelectNode> Binder::BindUnpivot(Binder &child_binder, PivotRef &ref,
 	for (auto &entry : unpivot.entries) {
 		ExtractUnpivotEntries(child_binder, entry, unpivot_entries);
 	}
+	if (unpivot_entries.empty()) {
+		throw BinderException(ref, "UNPIVOT clause must unpivot on at least one column - zero were provided");
+	}
 
 	case_insensitive_set_t handled_columns;
 	case_insensitive_map_t<string> name_map;

--- a/test/sql/pivot/unpivot_no_columns.test
+++ b/test/sql/pivot/unpivot_no_columns.test
@@ -1,0 +1,14 @@
+# name: test/sql/pivot/unpivot_no_columns.test
+# description: Test UNPIVOT without columns
+# group: [pivot]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table integers(i integer);
+
+statement error
+unpivot integers on columns(* exclude (i));
+----
+UNPIVOT clause must unpivot on at least one column


### PR DESCRIPTION
Provide a helpful error message when unpivoting on zero columns (which can happen when using `COLUMNS(* EXCLUDE ...)`).