### PR TITLE
Simplify binding of CALL statement

### DIFF
--- a/src/planner/binder/statement/bind_call.cpp
+++ b/src/planner/binder/statement/bind_call.cpp
@@ -16,7 +16,11 @@ BoundStatement Binder::Bind(CallStatement &stmt) {
 	select_node->select_list.push_back(make_uniq<StarExpression>());
 	select_node->from_table = std::move(table_function);
 	select_statement.node = std::move(select_node);
-	return Bind(select_statement);
+
+	auto result = Bind(select_statement);
+	auto &properties = GetStatementProperties();
+	properties.allow_stream_result = false;
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planner/binder/statement/bind_call.cpp
+++ b/src/planner/binder/statement/bind_call.cpp
@@ -1,33 +1,22 @@
-#include "duckdb/planner/binder.hpp"
 #include "duckdb/parser/statement/call_statement.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
-#include "duckdb/planner/tableref/bound_table_function.hpp"
+#include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/tableref/bound_table_function.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
 
 namespace duckdb {
 
 BoundStatement Binder::Bind(CallStatement &stmt) {
-	BoundStatement result;
-
-	TableFunctionRef ref;
-	ref.function = std::move(stmt.function);
-
-	auto bound_func = Bind(ref);
-	auto &bound_table_func = bound_func->Cast<BoundTableFunction>();
-	;
-	auto &get = bound_table_func.get->Cast<LogicalGet>();
-	D_ASSERT(get.returned_types.size() > 0);
-	for (idx_t i = 0; i < get.returned_types.size(); i++) {
-		get.AddColumnId(i);
-	}
-
-	result.types = get.returned_types;
-	result.names = get.names;
-	result.plan = CreatePlan(*bound_func);
-
-	auto &properties = GetStatementProperties();
-	properties.return_type = StatementReturnType::QUERY_RESULT;
-	return result;
+	SelectStatement select_statement;
+	auto select_node = make_uniq<SelectNode>();
+	auto table_function = make_uniq<TableFunctionRef>();
+	table_function->function = std::move(stmt.function);
+	select_node->select_list.push_back(make_uniq<StarExpression>());
+	select_node->from_table = std::move(table_function);
+	select_statement.node = std::move(select_node);
+	return Bind(select_statement);
 }
 
 } // namespace duckdb

--- a/test/sql/table_function/test_range_function.test
+++ b/test/sql/table_function/test_range_function.test
@@ -16,6 +16,20 @@ SELECT * FROM range(0, 10, 1)
 8
 9
 
+query I
+CALL range(10)
+----
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
 # generate_series is similar to range, but has inclusive bounds (for postgres compatibility)
 query I
 SELECT * FROM generate_series(0, 10, 1)


### PR DESCRIPTION
`CALL [function]` is equivalent to `SELECT * FROM [function]`. Instead of duplicating binding logic we should just bind it as the latter, which is simpler and less error prone.