### PR TITLE
[CSV Reader] Fix when reading overbuffer values of csv files with extra delimiter

### DIFF
--- a/data/csv/customer.4.csv
+++ b/data/csv/customer.4.csv
@@ -1,0 +1,3 @@
+750001|Customer#000750001|ocIz 2S9MsEyfkL|6|16-182-876-9496|4522.76|FURNITURE|dolites alongside of the furiously pending theodolites affix closely idly bold instruction|
+750002|Customer#000750002|Y9eOW Ena8pVx|15|25-241-686-3974|1969.87|BUILDING|ide of the slyly express hockey players. slyly ironic dependencies boost furiou|
+750003|Customer#000750003|cte0X8NikvycBgab3xucIg4UxnoWdhKsR|5|15-756-536-2351|6508.12|HOUSEHOLD| carefully express excuses sublate slyly carefully ironic pinto beans. requests at t|

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1140,7 +1140,7 @@ void StringValueScanner::ProcessOverbufferValue() {
 	}
 	bool skip_value = false;
 	if (result.projecting_columns) {
-		if (!result.projected_columns[result.cur_col_id]) {
+		if (!result.projected_columns[result.cur_col_id] && result.cur_col_id != result.number_of_columns) {
 			result.cur_col_id++;
 			skip_value = true;
 		}
@@ -1388,7 +1388,7 @@ void StringValueScanner::FinalizeChunkProcess() {
 		}
 		bool moved = MoveToNextBuffer();
 		if (cur_buffer_handle) {
-			if (moved && result.cur_col_id < result.number_of_columns && result.cur_col_id > 0) {
+			if (moved && result.cur_col_id > 0) {
 				ProcessExtraRow();
 			} else if (!moved) {
 				ProcessExtraRow();

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
@@ -118,11 +118,6 @@ public:
 	void ErrorIfNeeded();
 	//! Inserts a finished error info
 	void Insert(idx_t boundary_idx, idx_t rows);
-	//! Method that actually throws the error
-	void ThrowError(CSVError csv_error);
-	//! If we processed all boundaries before the one that error-ed
-	bool CanGetLine(idx_t boundary_index);
-	//! Return the 1-indexed line number
 	idx_t GetLine(const LinesPerBoundary &error_info);
 	void NewMaxLineSize(idx_t scan_line_size);
 	//! Returns true if there are any errors
@@ -138,8 +133,15 @@ public:
 	}
 
 private:
+	//! Private methods should always be locked by parent method.
 	//! If we should print the line of an error
 	bool PrintLineNumber(CSVError &error);
+	//! Method that actually throws the error
+	void ThrowError(CSVError csv_error);
+	//! If we processed all boundaries before the one that error-ed
+	bool CanGetLine(idx_t boundary_index);
+	//! Return the 1-indexed line number
+	idx_t GetLineInternal(const LinesPerBoundary &error_info);
 	//! CSV Error Handler Mutex
 	mutex main_mutex;
 	//! Map of <boundary indexes> -> lines read

--- a/test/sql/copy/csv/test_missing_row.test
+++ b/test/sql/copy/csv/test_missing_row.test
@@ -1,0 +1,13 @@
+# name: test/sql/copy/csv/test_missing_row.test
+# description: Test scan over multiple files with mismatching schemas
+# group: [csv]
+
+statement ok
+PRAGMA enable_verification
+
+query IIIIIIII
+FROM read_csv('data/csv/customer.4.csv', auto_detect=false, delim='|', quote='"', escape='"', new_line='\n', skip=0, header=false,  columns = {'c_custkey': 'BIGINT', 'c_name': 'VARCHAR', 'c_address': 'VARCHAR', 'c_nationkey': 'INTEGER', 'c_phone': 'VARCHAR', 'c_acctbal': 'DECIMAL(15, 2)', 'c_mktsegment': 'VARCHAR', 'c_comment': 'VARCHAR'}, parallel=true, buffer_size = 300);
+----
+750001	Customer#000750001	ocIz 2S9MsEyfkL	6	16-182-876-9496	4522.76	FURNITURE	dolites alongside of the furiously pending theodolites affix closely idly bold instruction
+750002	Customer#000750002	Y9eOW Ena8pVx	15	25-241-686-3974	1969.87	BUILDING	ide of the slyly express hockey players. slyly ironic dependencies boost furiou
+750003	Customer#000750003	cte0X8NikvycBgab3xucIg4UxnoWdhKsR	5	15-756-536-2351	6508.12	HOUSEHOLD	 carefully express excuses sublate slyly carefully ironic pinto beans. requests at t


### PR DESCRIPTION
This PR has a fix to properly read overbuffer rows of files that have one extra delimiter.

Although not directly related to this problem, I've also encountered a race condition on the CSV Error Handler, and fixed that.

Fix: #13047