### PR TITLE
Making error messages more clear for new line delimiter errors

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4311,12 +4311,14 @@ NType EnumUtil::FromString<NType>(const char *value) {
 template<>
 const char* EnumUtil::ToChars<NewLineIdentifier>(NewLineIdentifier value) {
 	switch(value) {
-	case NewLineIdentifier::SINGLE:
-		return "SINGLE";
+	case NewLineIdentifier::SINGLE_N:
+		return "SINGLE_N";
 	case NewLineIdentifier::CARRY_ON:
 		return "CARRY_ON";
 	case NewLineIdentifier::NOT_SET:
 		return "NOT_SET";
+	case NewLineIdentifier::SINGLE_R:
+		return "SINGLE_R";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
 	}
@@ -4324,14 +4326,17 @@ const char* EnumUtil::ToChars<NewLineIdentifier>(NewLineIdentifier value) {
 
 template<>
 NewLineIdentifier EnumUtil::FromString<NewLineIdentifier>(const char *value) {
-	if (StringUtil::Equals(value, "SINGLE")) {
-		return NewLineIdentifier::SINGLE;
+	if (StringUtil::Equals(value, "SINGLE_N")) {
+		return NewLineIdentifier::SINGLE_N;
 	}
 	if (StringUtil::Equals(value, "CARRY_ON")) {
 		return NewLineIdentifier::CARRY_ON;
 	}
 	if (StringUtil::Equals(value, "NOT_SET")) {
 		return NewLineIdentifier::NOT_SET;
+	}
+	if (StringUtil::Equals(value, "SINGLE_R")) {
+		return NewLineIdentifier::SINGLE_R;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
 }

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -326,7 +326,10 @@ NewLineIdentifier CSVSniffer::DetectNewLineDelimiter(CSVBufferManager &buffer_ma
 	if (carriage_return && n) {
 		return NewLineIdentifier::CARRY_ON;
 	}
-	return NewLineIdentifier::SINGLE;
+	if (carriage_return) {
+		return NewLineIdentifier::SINGLE_R;
+	}
+	return NewLineIdentifier::SINGLE_N;
 }
 
 // Dialect Detection consists of five steps:

--- a/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
+++ b/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
@@ -199,7 +199,8 @@ CSVStateMachineCache::CSVStateMachineCache() {
 			for (const auto &delimiter : default_delimiter) {
 				const auto &escape_candidates = default_escape[static_cast<uint8_t>(quoterule)];
 				for (const auto &escape : escape_candidates) {
-					Insert({delimiter, quote, escape, NewLineIdentifier::SINGLE});
+					Insert({delimiter, quote, escape, NewLineIdentifier::SINGLE_N});
+					Insert({delimiter, quote, escape, NewLineIdentifier::SINGLE_R});
 					Insert({delimiter, quote, escape, NewLineIdentifier::CARRY_ON});
 				}
 			}

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -135,8 +135,10 @@ NewLineIdentifier CSVReaderOptions::GetNewline() const {
 }
 
 void CSVReaderOptions::SetNewline(const string &input) {
-	if (input == "\\n" || input == "\\r") {
-		dialect_options.state_machine_options.new_line.Set(NewLineIdentifier::SINGLE);
+	if (input == "\\n") {
+		dialect_options.state_machine_options.new_line.Set(NewLineIdentifier::SINGLE_N);
+	} else if (input == "\\r") {
+		dialect_options.state_machine_options.new_line.Set(NewLineIdentifier::SINGLE_R);
 	} else if (input == "\\r\\n") {
 		dialect_options.state_machine_options.new_line.Set(NewLineIdentifier::CARRY_ON);
 	} else {

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_option.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_option.hpp
@@ -13,9 +13,11 @@
 namespace duckdb {
 
 enum class NewLineIdentifier : uint8_t {
-	SINGLE = 1,   // Either \r or \n
+	SINGLE_N = 1, // \n
 	CARRY_ON = 2, // \r\n
-	NOT_SET = 3
+	NOT_SET = 3,
+	SINGLE_R = 4 // \r
+
 };
 
 class Serializer;
@@ -131,8 +133,10 @@ private:
 
 	std::string FormatValueInternal(const NewLineIdentifier &val) const {
 		switch (val) {
-		case NewLineIdentifier::SINGLE:
+		case NewLineIdentifier::SINGLE_N:
 			return "\\n";
+		case NewLineIdentifier::SINGLE_R:
+			return "\\r";
 		case NewLineIdentifier::CARRY_ON:
 			return "\\r\\n";
 		case NewLineIdentifier::NOT_SET:

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_reader_options.hpp
@@ -171,8 +171,10 @@ struct CSVReaderOptions {
 
 	string NewLineIdentifierToString() {
 		switch (dialect_options.state_machine_options.new_line.GetValue()) {
-		case NewLineIdentifier::SINGLE:
+		case NewLineIdentifier::SINGLE_N:
 			return "\\n";
+		case NewLineIdentifier::SINGLE_R:
+			return "\\r";
 		case NewLineIdentifier::CARRY_ON:
 			return "\\r\\n";
 		default:

--- a/test/sql/copy/csv/test_wrong_newline_delimiter.test
+++ b/test/sql/copy/csv/test_wrong_newline_delimiter.test
@@ -1,0 +1,26 @@
+# name: test/sql/copy/csv/test_wrong_newline_delimiter.test
+# description: Test error messages printing exact newline delimiters
+# group: [csv]
+
+statement ok
+PRAGMA enable_verification
+
+statement error
+FROM read_csv('data/csv/timestamp.csv', columns = {'a': 'BIGINT'}, new_line= '\r')
+----
+new_line = \r (Set By User)
+
+statement error
+FROM read_csv('data/csv/timestamp.csv', columns = {'a': 'BIGINT'}, new_line= '\n')
+----
+new_line = \n (Set By User)
+
+statement error
+FROM read_csv('data/csv/timestamp.csv', columns = {'a': 'BIGINT'}, new_line= '\r\n')
+----
+new_line = \r\n (Set By User)
+
+statement error
+FROM read_csv('data/csv/timestamp.csv', columns = {'a': 'BIGINT'}, new_line= '\n\r')
+----
+This is not accepted as a newline: \n\r


### PR DESCRIPTION
Fix: #13007