### PR TITLE
Use regular extension mechanism for bundling shell and autocomplete

### DIFF
--- a/.github/config/bundled_extensions.cmake
+++ b/.github/config/bundled_extensions.cmake
@@ -20,7 +20,6 @@ duckdb_extension_load(tpch)
 duckdb_extension_load(json)
 duckdb_extension_load(fts)
 duckdb_extension_load(parquet)
-duckdb_extension_load(autocomplete)
 
 #
 ## Extensions that are not linked, but we do want to test them as part of the release build

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -10,12 +10,9 @@ add_definitions(-DUSE_DUCKDB_SHELL_WRAPPER)
 
 include_directories(../../third_party/utf8proc/include)
 
-if(DUCKDB_EXTENSION_AUTOCOMPLETE_SHOULD_LINK)
-  include_directories(../../extension/autocomplete/include)
-  set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES}
-                       ../../extension/autocomplete/autocomplete_extension.cpp)
-  add_definitions(-DSHELL_INLINE_AUTOCOMPLETE)
-endif()
+duckdb_extension_load(shell)
+duckdb_extension_load(autocomplete)
+
 set(SQLITE_API_WRAPPER_FILES shell_extension.cpp sqlite3_api_wrapper.cpp
                              ${ALL_OBJECT_FILES})
 
@@ -40,6 +37,8 @@ add_subdirectory(test)
 add_executable(test_sqlite3_api_wrapper ${SQLITE_TEST_FILES})
 if(WIN32 OR ZOS)
   target_link_libraries(test_sqlite3_api_wrapper sqlite3_api_wrapper_static)
+  target_link_libraries(test_sqlite3_api_wrapper shell_extension)
+  target_link_libraries(test_sqlite3_api_wrapper autocomplete_extension)
 else()
   target_link_libraries(test_sqlite3_api_wrapper sqlite3_api_wrapper)
 endif()

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -14,10 +14,6 @@
 #include "sqlite3_udf_wrapper.hpp"
 #include "udf_struct_sqlite3.h"
 #include "utf8proc_wrapper.hpp"
-#ifdef SHELL_INLINE_AUTOCOMPLETE
-#include "autocomplete_extension.hpp"
-#endif
-#include "shell_extension.hpp"
 
 #include <cassert>
 #include <chrono>
@@ -121,10 +117,6 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
 		    "extensions are disabled by configuration.\nStart the shell with the -unsigned parameter to allow this "
 		    "(e.g. duckdb -unsigned).");
 		pDb->db = make_uniq<DuckDB>(filename, &config);
-#ifdef SHELL_INLINE_AUTOCOMPLETE
-		pDb->db->LoadStaticExtension<AutocompleteExtension>();
-#endif
-		pDb->db->LoadStaticExtension<ShellExtension>();
 		pDb->con = make_uniq<Connection>(*pDb->db);
 	} catch (const Exception &ex) {
 		if (pDb) {


### PR DESCRIPTION
This means autocomplete will now only be packaged when building the Shell.

Regular `SKIP_EXTENSIONS=autocomplete GEN=ninja make` can be used to avoid statically linking the autocomplete extension.