### PR TITLE
Fixes for RegexFindAll function errors and multibyte character support

### DIFF
--- a/src/common/re2_regex.cpp
+++ b/src/common/re2_regex.cpp
@@ -13,50 +13,57 @@ Regex::Regex(const std::string &pattern, RegexOptions options) {
 	regex = duckdb::make_shared_ptr<duckdb_re2::RE2>(StringPiece(pattern), o);
 }
 
-bool RegexSearchInternal(const char *input, Match &match, const Regex &r, RE2::Anchor anchor, size_t start,
-                         size_t end) {
-	auto &regex = r.GetRegex();
+bool RegexSearchInternal(const char *input_data, size_t input_size, Match &match, const RE2 &regex, RE2::Anchor anchor,
+                         size_t start, size_t end) {
 	duckdb::vector<StringPiece> target_groups;
 	auto group_count = duckdb::UnsafeNumericCast<size_t>(regex.NumberOfCapturingGroups() + 1);
 	target_groups.resize(group_count);
 	match.groups.clear();
-	if (!regex.Match(StringPiece(input), start, end, anchor, target_groups.data(),
+	if (!regex.Match(StringPiece(input_data, input_size), start, end, anchor, target_groups.data(),
 	                 duckdb::UnsafeNumericCast<int>(group_count))) {
 		return false;
 	}
 	for (auto &group : target_groups) {
 		GroupMatch group_match;
 		group_match.text = group.ToString();
-		group_match.position = group.data() != nullptr ? duckdb::NumericCast<uint32_t>(group.data() - input) : 0;
+		group_match.position = group.data() != nullptr ? duckdb::NumericCast<uint32_t>(group.data() - input_data) : 0;
 		match.groups.emplace_back(group_match);
 	}
 	return true;
 }
 
 bool RegexSearch(const std::string &input, Match &match, const Regex &regex) {
-	return RegexSearchInternal(input.c_str(), match, regex, RE2::UNANCHORED, 0, input.size());
+	auto input_sz = input.size();
+	return RegexSearchInternal(input.c_str(), input_sz, match, regex.GetRegex(), RE2::UNANCHORED, 0, input_sz);
 }
 
 bool RegexMatch(const std::string &input, Match &match, const Regex &regex) {
-	return RegexSearchInternal(input.c_str(), match, regex, RE2::ANCHOR_BOTH, 0, input.size());
+	auto input_sz = input.size();
+	return RegexSearchInternal(input.c_str(), input_sz, match, regex.GetRegex(), RE2::ANCHOR_BOTH, 0, input_sz);
 }
 
 bool RegexMatch(const char *start, const char *end, Match &match, const Regex &regex) {
-	return RegexSearchInternal(start, match, regex, RE2::ANCHOR_BOTH, 0,
-	                           duckdb::UnsafeNumericCast<size_t>(end - start));
+	auto sz = duckdb::UnsafeNumericCast<size_t>(end - start);
+	return RegexSearchInternal(start, sz, match, regex.GetRegex(), RE2::ANCHOR_BOTH, 0, sz);
 }
 
 bool RegexMatch(const std::string &input, const Regex &regex) {
 	Match nop_match;
-	return RegexSearchInternal(input.c_str(), nop_match, regex, RE2::ANCHOR_BOTH, 0, input.size());
+	auto input_sz = input.size();
+	return RegexSearchInternal(input.c_str(), input_sz, nop_match, regex.GetRegex(), RE2::ANCHOR_BOTH, 0, input_sz);
 }
 
 duckdb::vector<Match> RegexFindAll(const std::string &input, const Regex &regex) {
+	return RegexFindAll(input.c_str(), input.size(), regex.GetRegex());
+}
+
+duckdb::vector<Match> RegexFindAll(const char *input_data, size_t input_size, const RE2 &regex) {
 	duckdb::vector<Match> matches;
 	size_t position = 0;
 	Match match;
-	while (RegexSearchInternal(input.c_str(), match, regex, RE2::UNANCHORED, position, input.size())) {
-		position += match.position(0) + match.length(0);
+	while (RegexSearchInternal(input_data, input_size, match, regex, RE2::UNANCHORED, position, input_size)) {
+		auto match_length = (match.length(0)) : match.length(0) ? 1;
+		position = match.position(0) + match_length;
 		matches.emplace_back(match);
 	}
 	return matches;

--- a/src/common/re2_regex.cpp
+++ b/src/common/re2_regex.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector.hpp"
 #include <memory>
 
@@ -81,8 +82,8 @@ duckdb::vector<Match> RegexFindAll(const char *input_data, size_t input_size, co
 		} else { // match.length(0) == 0
 			auto next_char_length = GetMultibyteCharLength(input_data[match.position(0)]);
 			if (!next_char_length) {
-				// invalid UTF-8 leading byte
-				return duckdb::vector<Match>();
+				throw duckdb::InvalidInputException("Invalid UTF-8 leading byte at position " +
+				                                    std::to_string(match.position(0) + 1));
 			}
 			if (match.position(0) + next_char_length < input_size) {
 				position = match.position(0) + next_char_length;

--- a/src/include/duckdb/common/re2_regex.hpp
+++ b/src/include/duckdb/common/re2_regex.hpp
@@ -70,5 +70,5 @@ DUCKDB_API bool RegexMatch(const std::string &input, Match &match, const Regex &
 DUCKDB_API bool RegexMatch(const char *start, const char *end, Match &match, const Regex &regex);
 DUCKDB_API bool RegexMatch(const std::string &input, const Regex &regex);
 DUCKDB_API duckdb::vector<Match> RegexFindAll(const std::string &input, const Regex &regex);
-
+DUCKDB_API duckdb::vector<Match> RegexFindAll(const char *input_data, size_t input_size, const RE2 &regex);
 } // namespace duckdb_re2


### PR DESCRIPTION
This PR addresses two issues with the `RegexFindAll` function:
1. Corrected out-of-range position errors and potential segfaults when the entry string had more than two matches. That was because of the `position += ...` in the code.
2. Fixed infinite loops when the function gets empty string delimiters.

Additionally, the function now supports multibyte characters.

**Note**: These issues had not caused failures previously because this specific functionality hadn’t been used in these cases so far. However, they may arise when `RegexFindAll` is used in the `string_split` function.