### PR TITLE
Prefer aliases over column-value functions in `GROUP BY`, and prefer error message when alias is used in an expression

### DIFF
--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -129,6 +129,7 @@ public:
 	static bool ContainsType(const LogicalType &type, LogicalTypeId target);
 	static LogicalType ExchangeType(const LogicalType &type, LogicalTypeId target, LogicalType new_type);
 
+	virtual bool TryBindAlias(ColumnRefExpression &colref, bool root_expression, BindResult &result);
 	virtual bool QualifyColumnAlias(const ColumnRefExpression &colref);
 
 	//! Bind the given expression. Unlike Bind(), this does *not* mute the given ParsedExpression.
@@ -166,7 +167,7 @@ protected:
 	BindResult BindExpression(CaseExpression &expr, idx_t depth);
 	BindResult BindExpression(CollateExpression &expr, idx_t depth);
 	BindResult BindExpression(CastExpression &expr, idx_t depth);
-	BindResult BindExpression(ColumnRefExpression &expr, idx_t depth);
+	BindResult BindExpression(ColumnRefExpression &expr, idx_t depth, bool root_expression);
 	BindResult BindExpression(LambdaRefExpression &expr, idx_t depth);
 	BindResult BindExpression(ComparisonExpression &expr, idx_t depth);
 	BindResult BindExpression(ConjunctionExpression &expr, idx_t depth);

--- a/src/include/duckdb/planner/expression_binder/group_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/group_binder.hpp
@@ -35,6 +35,7 @@ protected:
 	BindResult BindSelectRef(idx_t entry);
 	BindResult BindColumnRef(ColumnRefExpression &expr);
 	BindResult BindConstant(ConstantExpression &expr);
+	bool TryBindAlias(ColumnRefExpression &colref, bool root_expression, BindResult &result) override;
 
 	SelectNode &node;
 	SelectBindState &bind_state;

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -412,7 +412,7 @@ BindResult ExpressionBinder::BindExpression(LambdaRefExpression &lambda_ref, idx
 	return (*lambda_bindings)[lambda_ref.lambda_idx].Bind(lambda_ref, depth);
 }
 
-BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_t depth) {
+BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_t depth, bool root_expression) {
 	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES) {
 		return BindResult(make_uniq<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
 	}
@@ -421,6 +421,14 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 	auto expr = QualifyColumnName(col_ref_p, error);
 	if (!expr) {
 		if (!col_ref_p.IsQualified()) {
+			// column was not found
+			// first try to bind it as an alias
+			BindResult alias_result;
+			auto found_alias = TryBindAlias(col_ref_p, root_expression, alias_result);
+			if (found_alias) {
+				return alias_result;
+			}
+
 			// column was not found - check if it is a SQL value function
 			auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
 			if (value_function) {

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -66,7 +66,7 @@ BindResult ExpressionBinder::BindExpression(unique_ptr<ParsedExpression> &expr, 
 	case ExpressionClass::COLLATE:
 		return BindExpression(expr_ref.Cast<CollateExpression>(), depth);
 	case ExpressionClass::COLUMN_REF:
-		return BindExpression(expr_ref.Cast<ColumnRefExpression>(), depth);
+		return BindExpression(expr_ref.Cast<ColumnRefExpression>(), depth, root_expression);
 	case ExpressionClass::LAMBDA_REF:
 		return BindExpression(expr_ref.Cast<LambdaRefExpression>(), depth);
 	case ExpressionClass::COMPARISON:
@@ -388,6 +388,10 @@ BindResult ExpressionBinder::BindUnsupportedExpression(ParsedExpression &expr, i
 
 bool ExpressionBinder::IsUnnestFunction(const string &function_name) {
 	return function_name == "unnest" || function_name == "unlist";
+}
+
+bool ExpressionBinder::TryBindAlias(ColumnRefExpression &colref, bool root_expression, BindResult &result) {
+	return false;
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -79,6 +79,26 @@ BindResult GroupBinder::BindConstant(ConstantExpression &constant) {
 	return BindSelectRef(index - 1);
 }
 
+bool GroupBinder::TryBindAlias(ColumnRefExpression &colref, bool root_expression, BindResult &result) {
+	// failed to bind the column and the node is the root expression with depth = 0
+	// check if refers to an alias in the select clause
+	auto &alias_name = colref.GetColumnName();
+	auto entry = bind_state.alias_map.find(alias_name);
+	if (entry == bind_state.alias_map.end()) {
+		// no matching alias found
+		return false;
+	}
+	if (!root_expression) {
+		result = BindResult(BinderException(colref, "Alias with name \"%s\" exists, but aliases cannot be used as part of an expression in the GROUP BY", alias_name));
+		return true;
+	}
+	result = BindResult(BindSelectRef(entry->second));
+	if (!result.HasError()) {
+		group_alias_map[alias_name] = bind_index;
+	}
+	return true;
+}
+
 BindResult GroupBinder::BindColumnRef(ColumnRefExpression &colref) {
 	// columns in GROUP BY clauses:
 	// FIRST refer to the original tables, and
@@ -86,26 +106,7 @@ BindResult GroupBinder::BindColumnRef(ColumnRefExpression &colref) {
 	// THEN if no match is found, refer to outer queries
 
 	// first try to bind to the base columns (original tables)
-	auto result = ExpressionBinder::BindExpression(colref, 0);
-	if (result.HasError()) {
-		if (colref.IsQualified()) {
-			// explicit table name: not an alias reference
-			return result;
-		}
-		// failed to bind the column and the node is the root expression with depth = 0
-		// check if refers to an alias in the select clause
-		auto alias_name = colref.column_names[0];
-		auto entry = bind_state.alias_map.find(alias_name);
-		if (entry == bind_state.alias_map.end()) {
-			// no matching alias found
-			return result;
-		}
-		result = BindResult(BindSelectRef(entry->second));
-		if (!result.HasError()) {
-			group_alias_map[alias_name] = bind_index;
-		}
-	}
-	return result;
+	return ExpressionBinder::BindExpression(colref, 0, true);
 }
 
 } // namespace duckdb

--- a/src/planner/expression_binder/group_binder.cpp
+++ b/src/planner/expression_binder/group_binder.cpp
@@ -89,7 +89,10 @@ bool GroupBinder::TryBindAlias(ColumnRefExpression &colref, bool root_expression
 		return false;
 	}
 	if (!root_expression) {
-		result = BindResult(BinderException(colref, "Alias with name \"%s\" exists, but aliases cannot be used as part of an expression in the GROUP BY", alias_name));
+		result = BindResult(BinderException(
+		    colref,
+		    "Alias with name \"%s\" exists, but aliases cannot be used as part of an expression in the GROUP BY",
+		    alias_name));
 		return true;
 	}
 	result = BindResult(BindSelectRef(entry->second));

--- a/test/sql/aggregate/group/test_group_by.test
+++ b/test/sql/aggregate/group/test_group_by.test
@@ -187,6 +187,7 @@ NULL	NULL	NULL
 statement error
 SELECT 1 AS k, SUM(i) FROM integers GROUP BY k+1 ORDER BY 2;
 ----
+aliases cannot be used as part of an expression in the GROUP BY
 
 # group by column refs should be recognized, even if one uses an explicit table specifier and the other does not
 query IR

--- a/test/sql/binder/column_value_alias_group.test
+++ b/test/sql/binder/column_value_alias_group.test
@@ -1,0 +1,42 @@
+# name: test/sql/binder/column_value_alias_group.test
+# description: Test using column value aliases as groups
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table test(a int);
+
+statement ok
+insert into test values (2), (1), (3);
+
+# group by user
+query I rowsort
+select a as "user" from test group by "user";
+----
+1
+2
+3
+
+# having
+query I
+select a as "user" from test group by "user" having "user"=1;
+----
+1
+
+# order by user
+query I
+select a as "user" from test order by "user";
+----
+1
+2
+3
+
+# group by AND order by user
+query I
+select a as "user" from test group by "user" order by "user";
+----
+1
+2
+3


### PR DESCRIPTION
Fixes an issue where column-value functions (such as `user` or `current_timestamp`) were preferred over aliases in a `GROUP BY`, causing odd behavior. In addition, this PR also improves the error message in case an alias is used in an expression in a `GROUP BY` which is not supported.