### PR TITLE
Create file with O_EXCL flag set.

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -57,6 +57,8 @@ constexpr FileOpenFlags FileFlags::FILE_FLAGS_APPEND;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_PRIVATE;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_PARALLEL_ACCESS;
+constexpr FileOpenFlags FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
+constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_EXISTS;
 
 void FileOpenFlags::Verify() {
 #ifdef DEBUG
@@ -66,6 +68,8 @@ void FileOpenFlags::Verify() {
 	    (flags & FileOpenFlags::FILE_FLAGS_FILE_CREATE) || (flags & FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
 	bool is_private = (flags & FileOpenFlags::FILE_FLAGS_PRIVATE);
 	bool null_if_not_exists = flags & FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
+	bool exclusive_create = flags & FileOpenFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
+	bool null_if_exists = flags & FileOpenFlags::FILE_FLAGS_NULL_IF_EXISTS;
 
 	// require either READ or WRITE (or both)
 	D_ASSERT(is_read || is_write);
@@ -80,6 +84,10 @@ void FileOpenFlags::Verify() {
 	D_ASSERT(!is_private || is_create);
 	// FILE_FLAGS_NULL_IF_NOT_EXISTS cannot be combined with CREATE/CREATE_NEW
 	D_ASSERT(!(null_if_not_exists && is_create));
+	// FILE_FLAGS_EXCLUSIVE_CREATE only can be combined with CREATE/CREATE_NEW
+	D_ASSERT(!exclusive_create || is_create);
+	// FILE_FLAGS_NULL_IF_EXISTS only can be set with EXCLUSIVE_CREATE
+	D_ASSERT(!null_if_exists || exclusive_create);
 #endif
 }
 

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -333,11 +333,18 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 		filesec = 0666;
 	}
 
+	if (flags.ExclusiveCreate()) {
+		open_flags |= O_EXCL;
+	}
+
 	// Open the file
 	int fd = open(path.c_str(), open_flags, filesec);
 
 	if (fd == -1) {
 		if (flags.ReturnNullIfNotExists() && errno == ENOENT) {
+			return nullptr;
+		}
+		if (flags.ReturnNullIfExists() && errno == EEXIST) {
 			return nullptr;
 		}
 		throw IOException("Cannot open file \"%s\": %s", {{"errno", std::to_string(errno)}}, path, strerror(errno));

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -26,6 +26,8 @@ public:
 	static constexpr idx_t FILE_FLAGS_PRIVATE = idx_t(1 << 6);
 	static constexpr idx_t FILE_FLAGS_NULL_IF_NOT_EXISTS = idx_t(1 << 7);
 	static constexpr idx_t FILE_FLAGS_PARALLEL_ACCESS = idx_t(1 << 8);
+	static constexpr idx_t FILE_FLAGS_EXCLUSIVE_CREATE = idx_t(1 << 9);
+	static constexpr idx_t FILE_FLAGS_NULL_IF_EXISTS = idx_t(1 << 10);
 
 public:
 	FileOpenFlags() = default;
@@ -99,6 +101,12 @@ public:
 	inline bool RequireParallelAccess() const {
 		return flags & FILE_FLAGS_PARALLEL_ACCESS;
 	}
+	inline bool ExclusiveCreate() const {
+		return flags & FILE_FLAGS_EXCLUSIVE_CREATE;
+	}
+	inline bool ReturnNullIfExists() const {
+		return flags & FILE_FLAGS_NULL_IF_EXISTS;
+	}
 
 private:
 	idx_t flags = 0;
@@ -129,6 +137,11 @@ public:
 	//! Multiple threads may perform reads and writes in parallel
 	static constexpr FileOpenFlags FILE_FLAGS_PARALLEL_ACCESS =
 	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS);
+	//! Ensure that this call creates the file, throw is file exists
+	static constexpr FileOpenFlags FILE_FLAGS_EXCLUSIVE_CREATE =
+	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_EXCLUSIVE_CREATE);
+	//!  Return NULL if the file exist instead of throwing an error
+	static constexpr FileOpenFlags FILE_FLAGS_NULL_IF_EXISTS = FileOpenFlags(FileOpenFlags::FILE_FLAGS_NULL_IF_EXISTS);
 };
 
 } // namespace duckdb


### PR DESCRIPTION
When O_EXCL is used WITH O_CREAT open will fail if file exists. If flag `FILE_FLAGS_NULL_IF_EXISTS` is used opening will return nullptr instead of throwing error.