### PR TITLE
Test with recent threadsanitizer

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -674,11 +674,11 @@ jobs:
 
   threadsan:
     name: Thread Sanitizer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: linux-memory-leaks
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: clang
+      CXX: clang++
       GEN: ninja
       BUILD_ICU: 1
       BUILD_TPCH: 1
@@ -696,7 +696,7 @@ jobs:
 
     - name: Install
       shell: bash
-      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main


### PR DESCRIPTION
Move threadsanitizer to use clang instead of gcc-10.

This seems to solve one the probem tracked down by @Tishj in https://github.com/duckdb/duckdb/pull/13115, where spurious detection around `condition_variable`'s wait logic are now not flagged anymore.

I think in case of sanitizers or similar tools, moving to more recent versions makes sense, since tools will improve (both what is detected and number of false positives).