### PR TITLE
Keep track of user-provided configuration options, and compare them as well for database instance caching purposes

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -224,6 +224,8 @@ struct DBConfigOptions {
 	bool immediate_transaction_mode = false;
 	//! Debug setting - how to initialize  blocks in the storage layer when allocating
 	DebugInitialize debug_initialize = DebugInitialize::NO_INITIALIZE;
+	//! The set of user-provided options
+	case_insensitive_map_t<Value> user_options;
 	//! The set of unrecognized (other) options
 	unordered_map<string, Value> unrecognized_options;
 	//! Whether or not the configuration settings can be altered
@@ -353,13 +355,14 @@ public:
 
 	OrderType ResolveOrder(OrderType order_type) const;
 	OrderByNullType ResolveNullOrder(OrderType order_type, OrderByNullType null_type) const;
-	const std::string UserAgent() const;
+	const string UserAgent() const;
 
 private:
 	unique_ptr<CompressionFunctionSet> compression_functions;
 	unique_ptr<CastFunctionSet> cast_functions;
 	unique_ptr<CollationBinding> collation_bindings;
 	unique_ptr<IndexTypeSet> index_types;
+	bool is_user_config = true;
 };
 
 } // namespace duckdb

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -195,6 +195,11 @@ void DBConfig::SetOption(const ConfigurationOption &option, const Value &value) 
 }
 
 void DBConfig::SetOptionByName(const string &name, const Value &value) {
+	if (is_user_config) {
+		// for user config we just set the option in the `user_options`
+		options.user_options[name] = value;
+		return;
+	}
 	auto option = DBConfig::GetOptionByName(name);
 	if (option) {
 		SetOption(*option, value);
@@ -451,7 +456,7 @@ idx_t DBConfig::ParseMemoryLimit(const string &arg) {
 
 // Right now we only really care about access mode when comparing DBConfigs
 bool DBConfigOptions::operator==(const DBConfigOptions &other) const {
-	return other.access_mode == access_mode;
+	return other.access_mode == access_mode && other.user_options == user_options;
 }
 
 bool DBConfig::operator==(const DBConfig &other) {
@@ -487,7 +492,7 @@ OrderByNullType DBConfig::ResolveNullOrder(OrderType order_type, OrderByNullType
 	}
 }
 
-const std::string DBConfig::UserAgent() const {
+const string DBConfig::UserAgent() const {
 	auto user_agent = GetDefaultUserAgent();
 
 	if (!options.duckdb_api.empty()) {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -198,7 +198,6 @@ void DBConfig::SetOptionByName(const string &name, const Value &value) {
 	if (is_user_config) {
 		// for user config we just set the option in the `user_options`
 		options.user_options[name] = value;
-		return;
 	}
 	auto option = DBConfig::GetOptionByName(name);
 	if (option) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -55,6 +55,7 @@ DBConfig::~DBConfig() {
 }
 
 DatabaseInstance::DatabaseInstance() {
+	config.is_user_config = false;
 }
 
 DatabaseInstance::~DatabaseInstance() {
@@ -341,7 +342,12 @@ Allocator &Allocator::Get(AttachedDatabase &db) {
 void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path) {
 	config.options = new_config.options;
 
-	if (new_config.options.duckdb_api.empty()) {
+	config.options.unrecognized_options.clear();
+	// configure the user-provided options
+	for (auto &entry : config.options.user_options) {
+		config.SetOptionByName(entry.first, entry.second);
+	}
+	if (config.options.duckdb_api.empty()) {
 		config.SetOptionByName("duckdb_api", "cpp");
 	}
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -342,7 +342,6 @@ Allocator &Allocator::Get(AttachedDatabase &db) {
 void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path) {
 	config.options = new_config.options;
 
-	config.options.unrecognized_options.clear();
 	// configure the user-provided options
 	for (auto &entry : config.options.user_options) {
 		config.SetOptionByName(entry.first, entry.second);

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -342,10 +342,6 @@ Allocator &Allocator::Get(AttachedDatabase &db) {
 void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path) {
 	config.options = new_config.options;
 
-	// configure the user-provided options
-	for (auto &entry : config.options.user_options) {
-		config.SetOptionByName(entry.first, entry.second);
-	}
 	if (config.options.duckdb_api.empty()) {
 		config.SetOptionByName("duckdb_api", "cpp");
 	}

--- a/tools/pythonpkg/tests/fast/test_many_con_same_file.py
+++ b/tools/pythonpkg/tests/fast/test_many_con_same_file.py
@@ -73,3 +73,14 @@ def test_diff_config():
         con2 = duckdb.connect("test.db", True)
     con1.close()
     del con1
+
+
+def test_diff_config_extended():
+    con1 = duckdb.connect("test.db", config={'null_order': 'NULLS FIRST'})
+    with pytest.raises(
+        duckdb.ConnectionException,
+        match="Can't open a connection to same database file with a different configuration than existing connections",
+    ):
+        con2 = duckdb.connect("test.db")
+    con1.close()
+    del con1


### PR DESCRIPTION
When opening a new connection to an existing database we need the configuration to match, otherwise the configuration settings are silently discarded which can lead to odd behavior. Previously we would only compare `access_mode`. However, we would prefer to compare all user-provided configuration settings. 

This PR enables this behavior by keeping all user-provided settings in a new dictionary - `user_options`. When `SetOptionByName` is called for a `DBConfig` that does not belong to a database directly, options are only added to the `user_options` instead of being directly processed. When a database is initialized, we store the `user_options`. If the `user_options` provided in a following connection differ, the connection is refused.