### PR TITLE
better CE for comparisons that use `=`, `!=`, `<`, `<=`, `>`, `>=`. 

### DIFF
--- a/src/include/duckdb/optimizer/join_order/cardinality_estimator.hpp
+++ b/src/include/duckdb/optimizer/join_order/cardinality_estimator.hpp
@@ -88,6 +88,7 @@ public:
 class CardinalityEstimator {
 public:
 	static constexpr double DEFAULT_SEMI_ANTI_SELECTIVITY = 5;
+	static constexpr double DEFAULT_LT_GT_MULTIPLIER = 2.5;
 	explicit CardinalityEstimator() {};
 
 private:

--- a/src/optimizer/join_order/cardinality_estimator.cpp
+++ b/src/optimizer/join_order/cardinality_estimator.cpp
@@ -8,9 +8,6 @@
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/storage/data_table.hpp"
 
-#include <duckdb/common/sort/duckdb_pdqsort.hpp>
-#include <duckdb/parser/expression/comparison_expression.hpp>
-
 namespace duckdb {
 
 // The filter was made on top of a logical sample or other projection,

--- a/test/optimizer/joins/better_ce_estimates_for_bad_join_conditions.test
+++ b/test/optimizer/joins/better_ce_estimates_for_bad_join_conditions.test
@@ -1,0 +1,18 @@
+# name: test/optimizer/joins/better_ce_estimates_for_bad_join_conditions.test
+# description: In the join order optimizer queries need to have the correct bindings
+# group: [joins]
+
+statement ok
+create table t1 as select range::Varchar id, (range%700)::VARCHAR name_ from range(2_000);
+
+statement ok
+create table t2 as select range::Varchar id, (range%700)::VARCHAR name_ from range(2_000);
+
+statement ok
+create table t3 as select (range%2_000)::Varchar t1_id_FK, (range%2_000)::Varchar t2_id_FK from range(8_000);
+
+
+query II
+explain select count(*) from t1, t2, t3 where t1.name_ != t2.name_ and t3.t1_id_FK = t1.id and t3.t2_id_FK = t2.id;
+----
+physical_plan	<!REGEX>:.*NESTED_LOOP_JOIN.*


### PR DESCRIPTION
Fixes: https://github.com/duckdblabs/duckdb-internal/issues/2557

The solution is pretty basic, it just inspects the comparison type and adjusts the cardinality based on the checked comparisons.

Most joins are an `=` or `NOT_DISTINCT_FROM` and our CE is pretty good when it is that kind of a comparison. For other comparison types, however, we severely underestimate (since we used to always assume an `=`). This prevents the situation in the mentioned issue, where a `!=` comparison gets pushed down as a join condition, when that is not desirable at all. 

In the future, this step to inspect the comparison can be a completely separate module for CE, but for now I think this is a nice way to prevent cases where an assumed FK=PK produces an egregiously bad plan