### PR TITLE
Add duckdb_result_error_type that returns the exception type of the error

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -194,6 +194,51 @@ typedef enum duckdb_statement_type {
 	DUCKDB_STATEMENT_TYPE_DETACH = 26,
 	DUCKDB_STATEMENT_TYPE_MULTI = 27,
 } duckdb_statement_type;
+//! An enum over DuckDB's different result types.
+typedef enum duckdb_error_type {
+	DUCKDB_ERROR_INVALID = 0,
+	DUCKDB_ERROR_OUT_OF_RANGE = 1,
+	DUCKDB_ERROR_CONVERSION = 2,
+	DUCKDB_ERROR_UNKNOWN_TYPE = 3,
+	DUCKDB_ERROR_DECIMAL = 4,
+	DUCKDB_ERROR_MISMATCH_TYPE = 5,
+	DUCKDB_ERROR_DIVIDE_BY_ZERO = 6,
+	DUCKDB_ERROR_OBJECT_SIZE = 7,
+	DUCKDB_ERROR_INVALID_TYPE = 8,
+	DUCKDB_ERROR_SERIALIZATION = 9,
+	DUCKDB_ERROR_TRANSACTION = 10,
+	DUCKDB_ERROR_NOT_IMPLEMENTED = 11,
+	DUCKDB_ERROR_EXPRESSION = 12,
+	DUCKDB_ERROR_CATALOG = 13,
+	DUCKDB_ERROR_PARSER = 14,
+	DUCKDB_ERROR_PLANNER = 15,
+	DUCKDB_ERROR_SCHEDULER = 16,
+	DUCKDB_ERROR_EXECUTOR = 17,
+	DUCKDB_ERROR_CONSTRAINT = 18,
+	DUCKDB_ERROR_INDEX = 19,
+	DUCKDB_ERROR_STAT = 20,
+	DUCKDB_ERROR_CONNECTION = 21,
+	DUCKDB_ERROR_SYNTAX = 22,
+	DUCKDB_ERROR_SETTINGS = 23,
+	DUCKDB_ERROR_BINDER = 24,
+	DUCKDB_ERROR_NETWORK = 25,
+	DUCKDB_ERROR_OPTIMIZER = 26,
+	DUCKDB_ERROR_NULL_POINTER = 27,
+	DUCKDB_ERROR_IO = 28,
+	DUCKDB_ERROR_INTERRUPT = 29,
+	DUCKDB_ERROR_FATAL = 30,
+	DUCKDB_ERROR_INTERNAL = 31,
+	DUCKDB_ERROR_INVALID_INPUT = 32,
+	DUCKDB_ERROR_OUT_OF_MEMORY = 33,
+	DUCKDB_ERROR_PERMISSION = 34,
+	DUCKDB_ERROR_PARAMETER_NOT_RESOLVED = 35,
+	DUCKDB_ERROR_PARAMETER_NOT_ALLOWED = 36,
+	DUCKDB_ERROR_DEPENDENCY = 37,
+	DUCKDB_ERROR_HTTP = 38,
+	DUCKDB_ERROR_MISSING_EXTENSION = 39,
+	DUCKDB_ERROR_AUTOLOAD = 40,
+	DUCKDB_ERROR_SEQUENCE = 41
+} duckdb_error_type;
 
 //===--------------------------------------------------------------------===//
 // General type definitions
@@ -836,6 +881,15 @@ The result of this function must not be freed. It will be cleaned up when `duckd
 * returns: The error of the result.
 */
 DUCKDB_API const char *duckdb_result_error(duckdb_result *result);
+
+/*!
+Returns the result error type contained within the result. The error is only set if `duckdb_query` returns
+`DuckDBError`.
+
+* result: The result object to fetch the error from.
+* returns: The error type of the result.
+*/
+DUCKDB_API duckdb_error_type duckdb_result_error_type(duckdb_result *result);
 
 //===--------------------------------------------------------------------===//
 // Result Functions

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -464,6 +464,7 @@ duckdb_error_type CAPIErrorType(ExceptionType type) {
 	case ExceptionType::SEQUENCE:
 		return DUCKDB_ERROR_SEQUENCE;
 	}
+	return DUCKDB_ERROR_INVALID;
 }
 
 } // namespace duckdb

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -377,6 +377,95 @@ bool DeprecatedMaterializeResult(duckdb_result *result) {
 	return true;
 }
 
+duckdb_error_type CAPIErrorType(ExceptionType type) {
+	switch (type) {
+	case ExceptionType::INVALID:
+		return DUCKDB_ERROR_INVALID;
+	case ExceptionType::OUT_OF_RANGE:
+		return DUCKDB_ERROR_OUT_OF_RANGE;
+	case ExceptionType::CONVERSION:
+		return DUCKDB_ERROR_CONVERSION;
+	case ExceptionType::UNKNOWN_TYPE:
+		return DUCKDB_ERROR_UNKNOWN_TYPE;
+	case ExceptionType::DECIMAL:
+		return DUCKDB_ERROR_DECIMAL;
+	case ExceptionType::MISMATCH_TYPE:
+		return DUCKDB_ERROR_MISMATCH_TYPE;
+	case ExceptionType::DIVIDE_BY_ZERO:
+		return DUCKDB_ERROR_DIVIDE_BY_ZERO;
+	case ExceptionType::OBJECT_SIZE:
+		return DUCKDB_ERROR_OBJECT_SIZE;
+	case ExceptionType::INVALID_TYPE:
+		return DUCKDB_ERROR_INVALID_TYPE;
+	case ExceptionType::SERIALIZATION:
+		return DUCKDB_ERROR_SERIALIZATION;
+	case ExceptionType::TRANSACTION:
+		return DUCKDB_ERROR_TRANSACTION;
+	case ExceptionType::NOT_IMPLEMENTED:
+		return DUCKDB_ERROR_NOT_IMPLEMENTED;
+	case ExceptionType::EXPRESSION:
+		return DUCKDB_ERROR_EXPRESSION;
+	case ExceptionType::CATALOG:
+		return DUCKDB_ERROR_CATALOG;
+	case ExceptionType::PARSER:
+		return DUCKDB_ERROR_PARSER;
+	case ExceptionType::PLANNER:
+		return DUCKDB_ERROR_PLANNER;
+	case ExceptionType::SCHEDULER:
+		return DUCKDB_ERROR_SCHEDULER;
+	case ExceptionType::EXECUTOR:
+		return DUCKDB_ERROR_EXECUTOR;
+	case ExceptionType::CONSTRAINT:
+		return DUCKDB_ERROR_CONSTRAINT;
+	case ExceptionType::INDEX:
+		return DUCKDB_ERROR_INDEX;
+	case ExceptionType::STAT:
+		return DUCKDB_ERROR_STAT;
+	case ExceptionType::CONNECTION:
+		return DUCKDB_ERROR_CONNECTION;
+	case ExceptionType::SYNTAX:
+		return DUCKDB_ERROR_SYNTAX;
+	case ExceptionType::SETTINGS:
+		return DUCKDB_ERROR_SETTINGS;
+	case ExceptionType::BINDER:
+		return DUCKDB_ERROR_BINDER;
+	case ExceptionType::NETWORK:
+		return DUCKDB_ERROR_NETWORK;
+	case ExceptionType::OPTIMIZER:
+		return DUCKDB_ERROR_OPTIMIZER;
+	case ExceptionType::NULL_POINTER:
+		return DUCKDB_ERROR_NULL_POINTER;
+	case ExceptionType::IO:
+		return DUCKDB_ERROR_IO;
+	case ExceptionType::INTERRUPT:
+		return DUCKDB_ERROR_INTERRUPT;
+	case ExceptionType::FATAL:
+		return DUCKDB_ERROR_FATAL;
+	case ExceptionType::INTERNAL:
+		return DUCKDB_ERROR_INTERNAL;
+	case ExceptionType::INVALID_INPUT:
+		return DUCKDB_ERROR_INVALID_INPUT;
+	case ExceptionType::OUT_OF_MEMORY:
+		return DUCKDB_ERROR_OUT_OF_MEMORY;
+	case ExceptionType::PERMISSION:
+		return DUCKDB_ERROR_PERMISSION;
+	case ExceptionType::PARAMETER_NOT_RESOLVED:
+		return DUCKDB_ERROR_PARAMETER_NOT_RESOLVED;
+	case ExceptionType::PARAMETER_NOT_ALLOWED:
+		return DUCKDB_ERROR_PARAMETER_NOT_ALLOWED;
+	case ExceptionType::DEPENDENCY:
+		return DUCKDB_ERROR_DEPENDENCY;
+	case ExceptionType::HTTP:
+		return DUCKDB_ERROR_HTTP;
+	case ExceptionType::MISSING_EXTENSION:
+		return DUCKDB_ERROR_MISSING_EXTENSION;
+	case ExceptionType::AUTOLOAD:
+		return DUCKDB_ERROR_AUTOLOAD;
+	case ExceptionType::SEQUENCE:
+		return DUCKDB_ERROR_SEQUENCE;
+	}
+}
+
 } // namespace duckdb
 
 static void DuckdbDestroyColumn(duckdb_column column, idx_t count) {
@@ -511,6 +600,17 @@ const char *duckdb_result_error(duckdb_result *result) {
 	}
 	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result->internal_data));
 	return !result_data.result->HasError() ? nullptr : result_data.result->GetError().c_str();
+}
+
+duckdb_error_type duckdb_result_error_type(duckdb_result *result) {
+	if (!result || !result->internal_data) {
+		return DUCKDB_ERROR_INVALID;
+	}
+	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result->internal_data));
+	if (!result_data.result->HasError()) {
+		return DUCKDB_ERROR_INVALID;
+	}
+	return duckdb::CAPIErrorType(result_data.result->GetErrorType());
 }
 
 idx_t duckdb_result_chunk_count(duckdb_result result) {

--- a/test/api/capi/test_capi.cpp
+++ b/test/api/capi/test_capi.cpp
@@ -127,6 +127,7 @@ TEST_CASE("Basic test of C API", "[capi]") {
 	REQUIRE(duckdb_result_error(nullptr) == nullptr);
 	REQUIRE(duckdb_nullmask_data(nullptr, 0) == nullptr);
 	REQUIRE(duckdb_column_data(nullptr, 0) == nullptr);
+	REQUIRE(duckdb_result_error_type(nullptr) == DUCKDB_ERROR_INVALID);
 }
 
 TEST_CASE("Test different types of C API", "[capi]") {

--- a/test/include/capi_tester.hpp
+++ b/test/include/capi_tester.hpp
@@ -66,12 +66,14 @@ public:
 		success = (duckdb_query(connection, query.c_str(), &result) == DuckDBSuccess);
 		if (!success) {
 			REQUIRE(ErrorMessage() != nullptr);
+			REQUIRE(ErrorType() != DUCKDB_ERROR_INVALID);
 		}
 	}
 	void QueryPrepared(duckdb_prepared_statement statement) {
 		success = duckdb_execute_prepared(statement, &result) == DuckDBSuccess;
 		if (!success) {
 			REQUIRE(ErrorMessage() != nullptr);
+			REQUIRE(ErrorType() != DUCKDB_ERROR_INVALID);
 		}
 	}
 
@@ -133,6 +135,9 @@ public:
 
 	const char *ErrorMessage() {
 		return duckdb_result_error(&result);
+	}
+	duckdb_error_type ErrorType() {
+		return duckdb_result_error_type(&result);
 	}
 
 	string ColumnName(idx_t col) {


### PR DESCRIPTION
This adds the following C API function:

```cpp
duckdb_error_type duckdb_result_error_type(duckdb_result *result);
```

This returns the underlying `ExceptionType`. 