### PR TITLE
Fix CTEFilterPusher optimization

### DIFF
--- a/test/sql/cte/materialized/cte_filter_pusher.test
+++ b/test/sql/cte/materialized/cte_filter_pusher.test
@@ -1,0 +1,23 @@
+# name: test/sql/cte/materialized/cte_filter_pusher.test
+# description: Test that the cte_filter_pusher optimizer works
+# group: [materialized]
+
+query I
+WITH
+  a(x) AS MATERIALIZED (
+    SELECT *
+    FROM   generate_series(1, 10)
+  ),
+  b(x) AS MATERIALIZED (
+    SELECT *
+    FROM   a
+    WHERE  x < 8
+  )
+SELECT *
+FROM   b
+WHERE  x % 3 = 1
+ORDER BY x;
+----
+1
+4
+7


### PR DESCRIPTION
The `CTEFilterPusher` introduced with PR #12290 did not work as expected. _E.g._ the following query would crash the system:

```sql
WITH
  a(x) AS MATERIALIZED (
    SELECT *
    FROM   generate_series(1, 10)
  ),
  b(x) AS MATERIALIZED (
    SELECT *
    FROM   a
    WHERE  x < 8
  )
SELECT *
FROM   b
WHERE  x % 3 = 1;
```

The problem was, that `FindCandidates` only performs a single pass over the plan tree (which in principle would be great!). The following step `PushFilterIntoCTE`, however, invalidated a bunch of references stored in the `cte_info_map`.

Instead of a single pass over the tree, my proposed change collects all CTEs once, and builds the `cte_info_map` for each CTE separately. Therefore all references are valid when passed down to `PushFilterIntoCTE`. Downside is that we have to traverse the plan tree multiple times. Maybe you (@lnkuiper, @Mytherin ?) have some ideas on how to fix that. But on a positive note, it fixes the problem 😄