### PR TITLE
[Python] Fix issue with `native` UDFs returning STRUCT items

### DIFF
--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -87,45 +87,17 @@ Value TransformDictionaryToStruct(const PyDictionary &dict, const LogicalType &t
 	}
 
 	case_insensitive_map_t<idx_t> key_mapping;
-	if (struct_target) {
-		if (StructType::IsUnnamed(target_type)) {
-			for (idx_t i = 0; i < struct_keys.size(); i++) {
-				key_mapping[struct_keys[i]] = i;
-			}
-		} else {
-			// Register which key belongs to which index
-			case_insensitive_map_t<idx_t> expected_keys;
-			auto &child_types = StructType::GetChildTypes(target_type);
-
-			D_ASSERT(child_types.size() == struct_keys.size());
-
-			for (idx_t i = 0; i < child_types.size(); i++) {
-				auto &child_type = child_types[i];
-				auto &key = child_type.first;
-				expected_keys[key] = i;
-			}
-
-			for (idx_t i = 0; i < struct_keys.size(); i++) {
-				auto it = expected_keys.find(struct_keys[i]);
-				if (it == expected_keys.end()) {
-					throw InvalidInputException(
-					    "Key \"%s\" present in the STRUCT result was not found in the target type: %s", struct_keys[i],
-					    target_type.ToString());
-				}
-				key_mapping[struct_keys[i]] = it->second;
-			}
-		}
+	for (idx_t i = 0; i < struct_keys.size(); i++) {
+		key_mapping[struct_keys[i]] = i;
 	}
 
-	// FIXME: above we figure out which type should be used for which key
-	// but we still create the STRUCT Value with a different field order than expected
-	// resulting in a reordering later - we can probably reorder here directly.
 	child_list_t<Value> struct_values;
 	for (idx_t i = 0; i < dict.len; i++) {
-		auto &child_type =
-		    struct_target ? StructType::GetChildType(target_type, key_mapping[struct_keys[i]]) : LogicalType::UNKNOWN;
-		auto val = TransformPythonValue(dict.values.attr("__getitem__")(i), child_type);
-		struct_values.emplace_back(make_pair(std::move(struct_keys[i]), std::move(val)));
+		auto &key = struct_target ? StructType::GetChildName(target_type, i) : struct_keys[i];
+		auto value_index = key_mapping[key];
+		auto &child_type = struct_target ? StructType::GetChildType(target_type, i) : LogicalType::UNKNOWN;
+		auto val = TransformPythonValue(dict.values.attr("__getitem__")(value_index), child_type);
+		struct_values.emplace_back(make_pair(std::move(key), std::move(val)));
 	}
 	return Value::STRUCT(std::move(struct_values));
 }
@@ -633,7 +605,7 @@ Value TransformPythonValue(py::handle ele, const LogicalType &target_type, bool 
 		PyDictionary dict = PyDictionary(py::reinterpret_borrow<py::object>(ele));
 		switch (target_type.id()) {
 		case LogicalTypeId::STRUCT:
-			return TransformDictionaryToStruct(dict, target_type).DefaultCastAs(target_type);
+			return TransformDictionaryToStruct(dict, target_type);
 		case LogicalTypeId::MAP:
 			return TransformDictionaryToMap(dict, target_type);
 		default:

--- a/tools/pythonpkg/tests/fast/udf/test_scalar_native.py
+++ b/tools/pythonpkg/tests/fast/udf/test_scalar_native.py
@@ -169,7 +169,7 @@ class TestNativeUDF(object):
     def test_structs(self):
         def add_extra_column(original):
             original['a'] = 200
-            original['bb'] = 0
+            original['c'] = 0
             return original
 
         con = duckdb.connect()
@@ -192,11 +192,16 @@ class TestNativeUDF(object):
         res.fetchall()
 
         def swap_keys(dict):
+            reversed_keys = list(dict.keys())[::-1]  # Reverse the keys
+            keys = list(dict.keys())  # Original keys
             result = {}
-            reversed_keys = list(dict.keys())
-            reversed_keys.reverse()
-            for item in reversed_keys:
-                result[item] = dict[item]
+
+            halfway = len(keys) // 2
+            for i in range(halfway):
+                item1 = reversed_keys[i]
+                item2 = keys[i]
+                result[item1] = dict[item2]
+                result[item2] = dict[item1]
             return result
 
         con.create_function(
@@ -211,3 +216,32 @@ class TestNativeUDF(object):
         """
         ).fetchall()
         assert res == [({'a': 'answer_to_life', 'b': 42},)]
+
+    def test_struct_different_field_order(self, duckdb_cursor):
+        def example():
+            return {
+                "country": "country",
+                "postal_code": "postal_code",
+                "state": "state",
+                "city": "city",
+                "street2": "street2",
+                "street1": "street1",
+            }
+
+        # The order in which the fields are provided is intentionally different
+        return_type = """
+        STRUCT(
+            "street1" STRING,
+            "street2" STRING,
+            "city" STRING,
+            "state" STRING,
+            "postal_code" STRING,
+            "country" STRING
+        )
+        """
+
+        duckdb_cursor.create_function("example", example, return_type=return_type)
+
+        (res,) = duckdb_cursor.sql("SELECT example()").fetchone()
+        for key, val in res.items():
+            assert key == val


### PR DESCRIPTION
This PR fixes #13135

Similar to the behavior enabled by <https://github.com/duckdb/duckdb/pull/10537> this PR allows the keys in the provided dictionary to differ from that in the given target.

As shown by the issue this was previously ignored and assumed to always match.