### PR TITLE
Feature #1272: Windowed DISTINCT Sort

### DIFF
--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -1403,7 +1403,6 @@ public:
 	class DistinctSortTree;
 
 	WindowDistinctAggregatorGlobalState(const WindowDistinctAggregator &aggregator, idx_t group_count);
-	~WindowDistinctAggregatorGlobalState() override;
 
 	void Finalize(const FrameStats &stats);
 
@@ -1421,24 +1420,22 @@ public:
 	unique_ptr<DistinctSortTree> merge_sort_tree;
 
 	//! The actual window segment tree: an array of aggregate states that represent all the intermediate nodes
-	unsafe_unique_array<data_t> levels_flat_native;
+	WindowAggregateStates levels_flat_native;
 	//! For each level, the starting location in the levels_flat_native array
 	vector<idx_t> levels_flat_start;
-
-	//! The total number of internal nodes of the tree, stored in levels_flat_native
-	idx_t internal_nodes;
 };
 
-WindowDistinctAggregatorGlobalState::WindowDistinctAggregatorGlobalState(const WindowDistinctAggregator &aggregator_p,
+WindowDistinctAggregatorGlobalState::WindowDistinctAggregatorGlobalState(const WindowDistinctAggregator &aggregator,
                                                                          idx_t group_count)
-    : WindowAggregatorGlobalState(aggregator_p, group_count), context(aggregator_p.context) {
+    : WindowAggregatorGlobalState(aggregator, group_count), context(aggregator.context),
+      levels_flat_native(aggregator.aggr) {
 	payload_types.emplace_back(LogicalType::UBIGINT);
 
 	//	1:	functionComputePrevIdcs(𝑖𝑛)
 	//	2:		sorted ← []
 	//	We sort the aggregate arguments and use the partition index as a tie-breaker.
 	//	TODO: Use a hash table?
-	sort_types = aggregator_p.arg_types;
+	sort_types = aggregator.arg_types;
 	for (const auto &type : payload_types) {
 		sort_types.emplace_back(type);
 	}
@@ -1455,29 +1452,6 @@ WindowDistinctAggregatorGlobalState::WindowDistinctAggregatorGlobalState(const W
 	global_sort = make_uniq<GlobalSortState>(BufferManager::GetBufferManager(context), orders, payload_layout);
 
 	memory_per_thread = PhysicalOperator::GetMaxThreadMemory(context);
-}
-
-WindowDistinctAggregatorGlobalState::~WindowDistinctAggregatorGlobalState() {
-	const auto &aggr = aggregator.aggr;
-	if (!aggr.function.destructor) {
-		// nothing to destroy
-		return;
-	}
-	AggregateInputData aggr_input_data(aggr.GetFunctionData(), allocator);
-	// call the destructor for all the intermediate states
-	data_ptr_t address_data[STANDARD_VECTOR_SIZE];
-	Vector addresses(LogicalType::POINTER, data_ptr_cast(address_data));
-	idx_t count = 0;
-	for (idx_t i = 0; i < internal_nodes; i++) {
-		address_data[count++] = data_ptr_t(levels_flat_native.get() + i * aggregator.state_size);
-		if (count == STANDARD_VECTOR_SIZE) {
-			aggr.function.destructor(addresses, aggr_input_data, count);
-			count = 0;
-		}
-	}
-	if (count > 0) {
-		aggr.function.destructor(addresses, aggr_input_data, count);
-	}
 }
 
 class WindowDistinctAggregatorLocalState : public WindowAggregatorState {
@@ -1675,8 +1649,6 @@ WindowDistinctAggregatorGlobalState::DistinctSortTree::DistinctSortTree(ZippedEl
 	auto &aggr = gdsink.aggregator.aggr;
 	auto &allocator = gdsink.allocator;
 	auto &inputs = gdsink.inputs;
-	const auto state_size = gdsink.aggregator.state_size;
-	auto &internal_nodes = gdsink.internal_nodes;
 	auto &levels_flat_native = gdsink.levels_flat_native;
 	auto &levels_flat_start = gdsink.levels_flat_start;
 
@@ -1702,11 +1674,11 @@ WindowDistinctAggregatorGlobalState::DistinctSortTree::DistinctSortTree(ZippedEl
 	// compute space required to store aggregation states of merge sort tree
 	// this is one aggregate state per entry per level
 	MergeSortTree<ZippedTuple> zipped_tree(std::move(prev_idcs));
-	internal_nodes = 0;
+	idx_t internal_nodes = 0;
 	for (idx_t level_nr = 0; level_nr < zipped_tree.tree.size(); ++level_nr) {
 		internal_nodes += zipped_tree.tree[level_nr].first.size();
 	}
-	levels_flat_native = make_unsafe_uniq_array_uninitialized<data_t>(internal_nodes * state_size);
+	levels_flat_native.Initialize(internal_nodes);
 	levels_flat_start.push_back(0);
 	idx_t levels_flat_offset = 0;
 
@@ -1724,8 +1696,7 @@ WindowDistinctAggregatorGlobalState::DistinctSortTree::DistinctSortTree(ZippedEl
 			auto next_limit = MinValue<idx_t>(zipped_level.size(), i + level_width);
 			for (auto j = i; j < next_limit; ++j) {
 				//	Initialise the next aggregate
-				auto curr_state = levels_flat_native.get() + (levels_flat_offset++ * state_size);
-				aggr.function.initialize(curr_state);
+				auto curr_state = levels_flat_native.GetStatePtr(levels_flat_offset++);
 
 				//	Update this state (if it matches)
 				const auto prev_idx = std::get<0>(zipped_level[j]);
@@ -1795,13 +1766,12 @@ void WindowDistinctAggregatorLocalState::FlushStates() {
 
 void WindowDistinctAggregatorLocalState::Evaluate(const WindowDistinctAggregatorGlobalState &gdstate,
                                                   const DataChunk &bounds, Vector &result, idx_t count, idx_t row_idx) {
-	auto ldata = FlatVector::GetData<data_ptr_t>(statel);
+	auto ldata = FlatVector::GetData<const_data_ptr_t>(statel);
 	auto pdata = FlatVector::GetData<data_ptr_t>(statep);
 
 	const auto &merge_sort_tree = *gdstate.merge_sort_tree;
-	const auto running_aggs = gdstate.levels_flat_native.get();
+	const auto &levels_flat_native = gdstate.levels_flat_native;
 	const auto exclude_mode = gdstate.aggregator.exclude_mode;
-	const auto state_size = statef.state_size;
 
 	//	Build the finalise vector that just points to the result states
 	statef.Initialize(count);
@@ -1818,7 +1788,7 @@ void WindowDistinctAggregatorLocalState::Evaluate(const WindowDistinctAggregator
 				                                    //	Find the source aggregate
 				                                    // Buffer a merge of the indicated state into the current state
 				                                    const auto agg_idx = gdstate.levels_flat_start[level] + run_pos - 1;
-				                                    const auto running_agg = running_aggs + agg_idx * state_size;
+				                                    const auto running_agg = levels_flat_native.GetStatePtr(agg_idx);
 				                                    pdata[flush_count] = agg_state;
 				                                    ldata[flush_count++] = running_agg;
 				                                    if (flush_count >= STANDARD_VECTOR_SIZE) {

--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -1548,8 +1548,7 @@ void WindowDistinctAggregator::Finalize(WindowAggregatorState &gsink, WindowAggr
 	auto &gdsink = gsink.Cast<WindowDistinctAggregatorGlobalState>();
 	auto &ldstate = lstate.Cast<WindowDistinctAggregatorLocalState>();
 
-	//	Single threaded Combine for now
-	lock_guard<mutex> gestate_guard(gdsink.lock);
+	//	AddLocalState is thread-safe
 	gdsink.global_sort->AddLocalState(ldstate.local_sort);
 
 	//	Last one out turns off the lights!


### PR DESCRIPTION
* Convert the tree internals to use the state management object instead of rolling their own.
* Remove the unneeded lock around local sorting. This lets the threads sort their local states in parallel before the merge.
