### PR TITLE
Add native `list_has_any` implementation

### DIFF
--- a/benchmark/micro/list/list_has_any.benchmark
+++ b/benchmark/micro/list/list_has_any.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/list/list_has_any.benchmark
+# description: Benchmark for the list_has_any function
+# group: [list]
+
+name list_has_any micro
+group micro
+subgroup list
+
+load
+CREATE TABLE t1 as SELECT range(s, s + 3000) as l1, range(s + 1499, s + 3000) as l2 FROM range(0, 3000) r(s);
+
+run
+SELECT bool_and(list_has_any(l1, l2)) FROM t1;
+
+result I
+true

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -114,10 +114,6 @@ static const DefaultMacro internal_macros[] = {
     {DEFAULT_SCHEMA, "list_intersect", {"l1", "l2", nullptr}, "list_filter(list_distinct(l1), (variable_intersect) -> list_contains(l2, variable_intersect))"},
     {DEFAULT_SCHEMA, "array_intersect", {"l1", "l2", nullptr}, "list_intersect(l1, l2)"},
 
-    {DEFAULT_SCHEMA, "list_has_any", {"l1", "l2", nullptr}, "CASE WHEN l1 IS NULL THEN NULL WHEN l2 IS NULL THEN NULL WHEN len(list_filter(l1, (variable_has_any) -> list_contains(l2, variable_has_any))) > 0 THEN true ELSE false END"},
-    {DEFAULT_SCHEMA, "array_has_any", {"l1", "l2", nullptr}, "list_has_any(l1, l2)" },
-    {DEFAULT_SCHEMA, "&&", {"l1", "l2", nullptr}, "list_has_any(l1, l2)" }, // "&&" is the operator for "list_has_any
-
     {DEFAULT_SCHEMA, "list_has_all", {"l1", "l2", nullptr}, "CASE WHEN l1 IS NULL THEN NULL WHEN l2 IS NULL THEN NULL WHEN len(list_filter(l2, (variable_has_all) -> list_contains(l1, variable_has_all))) = len(list_filter(l2, variable_has_all -> variable_has_all IS NOT NULL)) THEN true ELSE false END"},
     {DEFAULT_SCHEMA, "array_has_all", {"l1", "l2", nullptr}, "list_has_all(l1, l2)" },
     {DEFAULT_SCHEMA, "@>", {"l1", "l2", nullptr}, "list_has_all(l1, l2)" }, // "@>" is the operator for "list_has_all

--- a/src/core_functions/function_list.cpp
+++ b/src/core_functions/function_list.cpp
@@ -50,6 +50,7 @@ namespace duckdb {
 static const StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_SCALAR_FUNCTION(FactorialOperatorFun),
 	DUCKDB_SCALAR_FUNCTION_SET(BitwiseAndFun),
+	DUCKDB_SCALAR_FUNCTION_ALIAS(ListHasAnyFunAlias),
 	DUCKDB_SCALAR_FUNCTION(PowOperatorFun),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(ListInnerProductFunAlias),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(ListDistanceFunAlias),
@@ -85,6 +86,7 @@ static const StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(ArrayDotProductFun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(ArrayFilterFun),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(ArrayGradeUpFun),
+	DUCKDB_SCALAR_FUNCTION_ALIAS(ArrayHasAnyFun),
 	DUCKDB_SCALAR_FUNCTION_SET(ArrayInnerProductFun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(ArrayReduceFun),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(ArrayReverseSortFun),
@@ -227,6 +229,7 @@ static const StaticFunctionDefinition internal_functions[] = {
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(ListDotProductFun),
 	DUCKDB_SCALAR_FUNCTION(ListFilterFun),
 	DUCKDB_SCALAR_FUNCTION_SET(ListGradeUpFun),
+	DUCKDB_SCALAR_FUNCTION(ListHasAnyFun),
 	DUCKDB_SCALAR_FUNCTION_SET(ListInnerProductFun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(ListPackFun),
 	DUCKDB_SCALAR_FUNCTION(ListReduceFun),

--- a/src/core_functions/scalar/list/CMakeLists.txt
+++ b/src/core_functions/scalar/list/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library_unity(
   flatten.cpp
   list_aggregates.cpp
   list_filter.cpp
+  list_has_any.cpp
   list_sort.cpp
   list_distance.cpp
   list_cosine_similarity.cpp

--- a/src/core_functions/scalar/list/functions.json
+++ b/src/core_functions/scalar/list/functions.json
@@ -144,7 +144,7 @@
     {
         "name": "list_has_any",
         "parameters": "l1, l2",
-        "description": "Returns true if any elements exist is both lists",
+        "description": "Returns true if the lists have any element in common. NULLs are ignored.",
         "example": "list_has_any([1, 2, 3], [2, 3, 4])",
         "type": "scalar_function",
         "aliases": ["array_has_any", "&&"]

--- a/src/core_functions/scalar/list/functions.json
+++ b/src/core_functions/scalar/list/functions.json
@@ -140,5 +140,13 @@
         "description": "Identical to list_value, but generated as part of unpivot for better error messages",
         "example": "unpivot_list(4, 5, 6)",
         "type": "scalar_function"
+    },
+    {
+        "name": "list_has_any",
+        "parameters": "l1, l2",
+        "description": "Returns true if any elements exist is both lists",
+        "example": "list_has_any([1, 2, 3], [2, 3, 4])",
+        "type": "scalar_function",
+        "aliases": ["array_has_any", "&&"]
     }
 ]

--- a/src/core_functions/scalar/list/list_has_any.cpp
+++ b/src/core_functions/scalar/list/list_has_any.cpp
@@ -1,8 +1,8 @@
 #include "duckdb/core_functions/lambda_functions.hpp"
 #include "duckdb/core_functions/scalar/list_functions.hpp"
+#include "duckdb/core_functions/create_sort_key.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
-
-#include <duckdb/common/string_map_set.hpp>
+#include "duckdb/common/string_map_set.hpp"
 
 namespace duckdb {
 

--- a/src/core_functions/scalar/list/list_has_any.cpp
+++ b/src/core_functions/scalar/list/list_has_any.cpp
@@ -41,9 +41,9 @@ static void ListHasAnyFunction(DataChunk &args, ExpressionState &, Vector &resul
 	Vector l_sortkey_vec(LogicalType::BLOB, l_size);
 	Vector r_sortkey_vec(LogicalType::BLOB, r_size);
 
-	const OrderModifiers order_modifies(OrderType::ASCENDING, OrderByNullType::NULLS_LAST);
-	CreateSortKeyHelpers::CreateSortKey(ListVector::GetEntry(l_vec), l_size, order_modifies, l_sortkey_vec);
-	CreateSortKeyHelpers::CreateSortKey(ListVector::GetEntry(r_vec), r_size, order_modifies, r_sortkey_vec);
+	const OrderModifiers order_modifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST);
+	CreateSortKeyHelpers::CreateSortKey(ListVector::GetEntry(l_vec), l_size, order_modifiers, l_sortkey_vec);
+	CreateSortKeyHelpers::CreateSortKey(ListVector::GetEntry(r_vec), r_size, order_modifiers, r_sortkey_vec);
 
 	const auto l_validity_ptr = &FlatVector::Validity(ListVector::GetEntry(l_vec));
 	const auto r_validity_ptr = &FlatVector::Validity(ListVector::GetEntry(r_vec));

--- a/src/core_functions/scalar/list/list_has_any.cpp
+++ b/src/core_functions/scalar/list/list_has_any.cpp
@@ -1,0 +1,99 @@
+#include "duckdb/core_functions/lambda_functions.hpp"
+#include "duckdb/core_functions/scalar/list_functions.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+
+#include <duckdb/common/string_map_set.hpp>
+
+namespace duckdb {
+
+static unique_ptr<FunctionData> ListHasAnyBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+
+	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
+	arguments[1] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[1]));
+
+	const auto left_type = ListType::GetChildType(arguments[0]->return_type);
+	const auto right_type = ListType::GetChildType(arguments[1]->return_type);
+
+	if (left_type != LogicalType::SQLNULL && right_type != LogicalType::SQLNULL && left_type != right_type) {
+		throw BinderException("ListHasAny: left and right list types must be the same, got '%s' and '%s'",
+		                      left_type.ToString(), right_type.ToString());
+	}
+
+	return nullptr;
+}
+
+static void ListHasAnyFunction(DataChunk &args, ExpressionState &, Vector &result) {
+
+	auto &l_vec = args.data[0];
+	auto &r_vec = args.data[1];
+
+	if (ListType::GetChildType(l_vec.GetType()) == LogicalType::SQLNULL ||
+	    ListType::GetChildType(r_vec.GetType()) == LogicalType::SQLNULL) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::GetData<bool>(result)[0] = false;
+		return;
+	}
+
+	const auto l_size = ListVector::GetListSize(l_vec);
+	const auto r_size = ListVector::GetListSize(r_vec);
+
+	Vector l_sortkey_vec(LogicalType::BLOB, l_size);
+	Vector r_sortkey_vec(LogicalType::BLOB, r_size);
+
+	const OrderModifiers order_modifies(OrderType::ASCENDING, OrderByNullType::NULLS_LAST);
+	CreateSortKeyHelpers::CreateSortKey(ListVector::GetEntry(l_vec), l_size, order_modifies, l_sortkey_vec);
+	CreateSortKeyHelpers::CreateSortKey(ListVector::GetEntry(r_vec), r_size, order_modifies, r_sortkey_vec);
+
+	const auto l_validity_ptr = &FlatVector::Validity(ListVector::GetEntry(l_vec));
+	const auto r_validity_ptr = &FlatVector::Validity(ListVector::GetEntry(r_vec));
+
+	const auto l_ptr = FlatVector::GetData<string_t>(l_sortkey_vec);
+	const auto r_ptr = FlatVector::GetData<string_t>(r_sortkey_vec);
+
+	string_set_t set;
+
+	BinaryExecutor::Execute<list_entry_t, list_entry_t, bool>(
+	    l_vec, r_vec, result, args.size(), [&](const list_entry_t &l_val, const list_entry_t &r_val) {
+		    // Short circuit if either list is empty
+		    if (l_val.length == 0 || r_val.length == 0) {
+			    return false;
+		    }
+
+		    auto build_ptr = l_ptr;
+		    auto probe_ptr = r_ptr;
+		    auto build_val = l_val;
+		    auto probe_val = r_val;
+
+		    auto build_validity = l_validity_ptr;
+		    auto probe_validity = r_validity_ptr;
+
+		    // Use the smaller list to build the set
+		    if (probe_val.length < build_val.length) {
+			    std::swap(build_ptr, probe_ptr);
+			    std::swap(build_val, probe_val);
+			    std::swap(build_validity, probe_validity);
+		    }
+
+		    set.clear();
+		    for (auto i = build_val.offset; i < build_val.offset + build_val.length; i++) {
+			    if (build_validity->RowIsValid(i)) {
+				    set.insert(build_ptr[i]);
+			    }
+		    }
+		    for (auto i = probe_val.offset; i < probe_val.offset + probe_val.length; i++) {
+			    if (probe_validity->RowIsValid(i) && set.find(probe_ptr[i]) != set.end()) {
+				    return true;
+			    }
+		    }
+		    return false;
+	    });
+}
+
+ScalarFunction ListHasAnyFun::GetFunction() {
+	ScalarFunction fun({LogicalType::LIST(LogicalType::ANY), LogicalType::LIST(LogicalType::ANY)}, LogicalType::BOOLEAN,
+	                   ListHasAnyFunction, ListHasAnyBind);
+	return fun;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/core_functions/scalar/list_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/list_functions.hpp
@@ -324,7 +324,7 @@ struct UnpivotListFun {
 struct ListHasAnyFun {
 	static constexpr const char *Name = "list_has_any";
 	static constexpr const char *Parameters = "l1, l2";
-	static constexpr const char *Description = "Returns true if any elements exist is both lists";
+	static constexpr const char *Description = "Returns true if the lists have any element in common. NULLs are ignored.";
 	static constexpr const char *Example = "list_has_any([1, 2, 3], [2, 3, 4])";
 
 	static ScalarFunction GetFunction();

--- a/src/include/duckdb/core_functions/scalar/list_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/list_functions.hpp
@@ -321,4 +321,25 @@ struct UnpivotListFun {
 	static ScalarFunction GetFunction();
 };
 
+struct ListHasAnyFun {
+	static constexpr const char *Name = "list_has_any";
+	static constexpr const char *Parameters = "l1, l2";
+	static constexpr const char *Description = "Returns true if any elements exist is both lists";
+	static constexpr const char *Example = "list_has_any([1, 2, 3], [2, 3, 4])";
+
+	static ScalarFunction GetFunction();
+};
+
+struct ArrayHasAnyFun {
+	using ALIAS = ListHasAnyFun;
+
+	static constexpr const char *Name = "array_has_any";
+};
+
+struct ListHasAnyFunAlias {
+	using ALIAS = ListHasAnyFun;
+
+	static constexpr const char *Name = "&&";
+};
+
 } // namespace duckdb


### PR DESCRIPTION
This PR implements the `list_has_any` function natively instead of having it be provided by a default macro. 

I haven't run any benchmarks, but this implementation "sort-key" serializes both lists and hashes the smaller list into a `string_set_t` before probing with the larger list, which should at least bring down the theoretical complexity from `n * m` to `n + m`, even if the sort-key serialization has some overhead.

The main motivation for implementing this as a function instead of a macro is to free up the `&&` alias for use in extensions (spatial) as macros can't be overloaded (or shadowed by a function as macros seem to bind stronger).