### PR TITLE
ThreadSanitizer: Avoid spurious data race in InsertMatchesAndIncrementMisses

### DIFF
--- a/.sanitizer-thread-suppressions.txt
+++ b/.sanitizer-thread-suppressions.txt
@@ -1,4 +1,5 @@
 deadlock:InitializeIndexes
+race:InsertMatchesAndIncrementMisses
 race:NextInnerJoin
 race:NextRightSemiOrAntiJoin
 race:duckdb_moodycamel


### PR DESCRIPTION
In InsertMatchesAndIncrementMisses there is a custom optimization that relies on invariants not visible to ThreadSanitizer, we can as well add to list of spurious data races.