### PR TITLE
Fix #13120: implement StructFilter::ToExpression

### DIFF
--- a/src/function/scalar/struct/struct_extract.cpp
+++ b/src/function/scalar/struct/struct_extract.cpp
@@ -98,7 +98,7 @@ static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, Scalar
 	}
 
 	bound_function.return_type = std::move(return_type);
-	return make_uniq<StructExtractBindData>(key_index);
+	return StructExtractFun::GetBindData(key_index);
 }
 
 static unique_ptr<FunctionData> StructExtractBindIndex(ClientContext &context, ScalarFunction &bound_function,
@@ -134,7 +134,7 @@ static unique_ptr<FunctionData> StructExtractBindIndex(ClientContext &context, S
 		                      index, struct_children.size());
 	}
 	bound_function.return_type = struct_children[NumericCast<idx_t>(index - 1)].second;
-	return make_uniq<StructExtractBindData>(NumericCast<idx_t>(index - 1));
+	return StructExtractFun::GetBindData(NumericCast<idx_t>(index - 1));
 }
 
 static unique_ptr<BaseStatistics> PropagateStructExtractStats(ClientContext &context, FunctionStatisticsInput &input) {
@@ -144,6 +144,10 @@ static unique_ptr<BaseStatistics> PropagateStructExtractStats(ClientContext &con
 	auto &info = bind_data->Cast<StructExtractBindData>();
 	auto struct_child_stats = StructStats::GetChildStats(child_stats[0]);
 	return struct_child_stats[info.index].ToUnique();
+}
+
+unique_ptr<FunctionData> StructExtractFun::GetBindData(idx_t index) {
+	return make_uniq<StructExtractBindData>(index);
 }
 
 ScalarFunction StructExtractFun::KeyExtractFunction() {

--- a/src/include/duckdb/function/scalar/nested_functions.hpp
+++ b/src/include/duckdb/function/scalar/nested_functions.hpp
@@ -125,6 +125,7 @@ struct StructExtractFun {
 	static ScalarFunction KeyExtractFunction();
 	static ScalarFunction IndexExtractFunction();
 	static ScalarFunctionSet GetFunctions();
+	static unique_ptr<FunctionData> GetBindData(idx_t index);
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 

--- a/test/sql/copy/parquet/hive_partitioning_struct.test
+++ b/test/sql/copy/parquet/hive_partitioning_struct.test
@@ -1,0 +1,27 @@
+# name: test/sql/copy/parquet/hive_partitioning_struct.test
+# description: Test hive partitioning and struct pushdown
+# group: [parquet]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+COPY (SELECT i//50 id, {'a': i} s FROM range(100) t(i)) TO '__TEST_DIR__/hive_partitioned_struct_col' (FORMAT PARQUET, PARTITION_BY (id))
+
+query II
+SELECT * FROM read_parquet('__TEST_DIR__/hive_partitioned_struct_col/**/*.parquet', hive_partitioning=1) WHERE s.a=42
+----
+0	{'a': 42}
+
+# what if the hive types themselves are structs?
+statement ok
+COPY (SELECT i id, {'a': i//2} s FROM range(100) t(i)) TO '__TEST_DIR__/hive_partitioned_struct' (FORMAT PARQUET, PARTITION_BY (s))
+
+query II
+SELECT * FROM read_parquet('__TEST_DIR__/hive_partitioned_struct/**/*.parquet', hive_partitioning=1, hive_types={'s': 'STRUCT(a INT)'}) WHERE s.a=42 ORDER BY ALL
+----
+84	{'a': 42}
+85	{'a': 42}
+


### PR DESCRIPTION
Fixes #13120 

After a rework of how hive partitioned filters work with dynamic filter pushdown we did not implement this method, which caused a regression when using hive partitioning in combination with filters on struct columns