### PR TITLE
[C API] Add duckdb_scalar_function_set_volatile that allows changing FunctionStability of a scalar function

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2397,6 +2397,14 @@ Sets the NULL handling of the scalar function to SPECIAL_HANDLING.
 DUCKDB_API void duckdb_scalar_function_set_special_handling(duckdb_scalar_function scalar_function);
 
 /*!
+Sets the Function Stability of the scalar function to VOLATILE, indicating the function should be re-run for every row.
+This limits optimization that can be performed for the function.
+
+* scalar_function: The scalar function
+*/
+DUCKDB_API void duckdb_scalar_function_set_volatile(duckdb_scalar_function function);
+
+/*!
 Adds a parameter to the scalar function.
 
 * @param scalar_function The scalar function.

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -113,6 +113,14 @@ void duckdb_scalar_function_set_special_handling(duckdb_scalar_function function
 	scalar_function.null_handling = duckdb::FunctionNullHandling::SPECIAL_HANDLING;
 }
 
+void duckdb_scalar_function_set_volatile(duckdb_scalar_function function) {
+	if (!function) {
+		return;
+	}
+	auto &scalar_function = GetCScalarFunction(function);
+	scalar_function.stability = duckdb::FunctionStability::VOLATILE;
+}
+
 void duckdb_scalar_function_add_parameter(duckdb_scalar_function function, duckdb_logical_type type) {
 	if (!function || !type) {
 		return;

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -296,6 +296,9 @@ static void CAPIRegisterANYFun(duckdb_connection connection, const char *name, d
 
 	// Set special null handling.
 	duckdb_scalar_function_set_special_handling(function);
+	duckdb_scalar_function_set_volatile(function);
+	duckdb_scalar_function_set_special_handling(nullptr);
+	duckdb_scalar_function_set_volatile(nullptr);
 
 	// set the return type uto bigint
 	auto return_type = duckdb_create_logical_type(DUCKDB_TYPE_UBIGINT);


### PR DESCRIPTION
Fixes #13128

Unless functions are marked as `Volatile` it is assumed that functions return the same output given the same input, which allows several optimizations to take place and short-circuit execution of the function for every row. This PR exposes this setting in the C API using the `duckdb_scalar_function_set_volatile` function:

```c
void duckdb_scalar_function_set_volatile(duckdb_scalar_function function);
```