### PR TITLE
Add test_collate_pivot: used to fail in 1.0.0, add to avoid regressions

### DIFF
--- a/test/sql/collate/test_collate_pivot.test
+++ b/test/sql/collate/test_collate_pivot.test
@@ -1,0 +1,47 @@
+# name: test/sql/collate/test_collate_pivot.test
+# description: Test collation and PIVOT
+# group: [collate]
+
+statement ok
+PRAGMA default_collation=NOACCENT;
+
+statement ok
+CREATE TABLE Cities (
+    Country VARCHAR, Name VARCHAR, Year INTEGER, Population INTEGER
+);
+
+statement ok
+INSERT INTO Cities VALUES ('NL', 'Amsterdam', 2010, 1005);
+
+statement ok
+INSERT INTO Cities VALUES ('NL', 'Amsterdam', 2011, 1065);
+
+statement ok
+INSERT INTO Cities VALUES ('NL', 'Amsterdam', 2012, 1158);
+
+statement ok
+INSERT INTO Cities VALUES ('US', 'Seattle', 2013, 564);
+
+statement ok
+INSERT INTO Cities VALUES ('US', 'Seattle', 2014, 608);
+
+statement ok
+INSERT INTO Cities VALUES ('US', 'Seattle', 2015, 738);
+
+statement ok
+INSERT INTO Cities VALUES ('US', 'New York City', 2016, 8015);
+
+statement ok
+INSERT INTO Cities VALUES ('US', 'New York City', 2017, 8175);
+
+statement ok
+INSERT INTO Cities VALUES ('US', 'New York City', 2018, 8772);
+
+statement ok
+INSERT INTO Cities VALUES ('US', 'New York City', 2019, 8772);
+
+statement ok
+INSERT INTO Cities VALUES ('US', 'New York City', 2020, 8772);
+
+statement ok
+PIVOT Cities ON Year USING sum(Population);


### PR DESCRIPTION
Raised by a duckdb-wasm user on https://discord.duckdb.org/, adding test to check this keeps working, but I think this is already fixed.

Workaround in duckdb v1.0.0 is removing the line `PRAGMA default_collation=NOACCENT;`

This might be covered by other tests already, unsure if worth adding, PR is to check this actually works in tested configurations, and to be considered as addition.