### PR TITLE
Add catalog_error_max_schemas setting that toggles how many schemas we look at for "did you mean..." style error messages

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -562,10 +562,19 @@ CatalogException Catalog::CreateMissingEntryException(ClientContext &context, co
 	reference_set_t<SchemaCatalogEntry> unseen_schemas;
 	auto &db_manager = DatabaseManager::Get(context);
 	auto databases = db_manager.GetDatabases(context);
+	auto &config = DBConfig::GetConfig(context);
+
+	auto max_schema_count = config.options.catalog_error_max_schemas;
 	for (auto database : databases) {
+		if (unseen_schemas.size() >= max_schema_count) {
+			break;
+		}
 		auto &catalog = database.get().GetCatalog();
 		auto current_schemas = catalog.GetAllSchemas(context);
 		for (auto &current_schema : current_schemas) {
+			if (unseen_schemas.size() >= max_schema_count) {
+				break;
+			}
 			unseen_schemas.insert(current_schema.get());
 		}
 	}

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -259,6 +259,8 @@ struct DBConfigOptions {
 	//! This is a work-around that exists for certain clients (specifically R)
 	//! Because those clients do not like it when threads other than the main thread call into R, for e.g., arrow scans
 	bool initialize_in_main_thread = false;
+	//! The maximum number of schemas we will look through for "did you mean..." style errors in the catalog
+	idx_t catalog_error_max_schemas = 100;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -62,6 +62,16 @@ struct AllowPersistentSecrets {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct CatalogErrorMaxSchema {
+	static constexpr const char *Name = "catalog_error_max_schemas";
+	static constexpr const char *Description =
+	    "The maximum number of schemas the system will scan for \"did you mean...\" style errors in the catalog";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct CheckpointThresholdSetting {
 	static constexpr const char *Name = "checkpoint_threshold";
 	static constexpr const char *Description =

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -59,6 +59,7 @@ bool DBConfigOptions::debug_print_bindings = false;
 static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(AccessModeSetting),
     DUCKDB_GLOBAL(AllowPersistentSecrets),
+    DUCKDB_GLOBAL(CatalogErrorMaxSchema),
     DUCKDB_GLOBAL(CheckpointThresholdSetting),
     DUCKDB_GLOBAL(DebugCheckpointAbort),
     DUCKDB_GLOBAL(StorageCompatibilityVersion),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -79,6 +79,22 @@ Value AllowPersistentSecrets::GetSetting(const ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// Access Mode
+//===--------------------------------------------------------------------===//
+void CatalogErrorMaxSchema::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.options.catalog_error_max_schemas = UBigIntValue::Get(input);
+}
+
+void CatalogErrorMaxSchema::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.catalog_error_max_schemas = DBConfig().options.catalog_error_max_schemas;
+}
+
+Value CatalogErrorMaxSchema::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::UBIGINT(config.options.catalog_error_max_schemas);
+}
+
+//===--------------------------------------------------------------------===//
 // Checkpoint Threshold
 //===--------------------------------------------------------------------===//
 void CheckpointThresholdSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/test/sql/attach/attach_did_you_mean.test
+++ b/test/sql/attach/attach_did_you_mean.test
@@ -30,6 +30,18 @@ SELECT * FROM blablabla;
 ----
 Did you mean "db1.myschema.blablabla"
 
+statement ok
+SET catalog_error_max_schemas=0
+
+# did you mean... error is skipped if max schemas is set to 0
+statement error
+SELECT * FROM blablabla;
+----
+Table with name blablabla does not exist
+
+statement ok
+RESET catalog_error_max_schemas
+
 # what if we switch the default database?
 statement ok
 USE db1


### PR DESCRIPTION
When we have thousands of attached databases, these errors can take a long time to generate otherwise. This setting allows us to limit how many schemas we look through.