### PR TITLE
Fix build error when compiling with -DDISABLE_EXTENSION_LOAD=1

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -335,6 +335,7 @@ static unique_ptr<ExtensionInstallInfo> DirectInstallExtension(DBConfig &config,
 	return make_uniq<ExtensionInstallInfo>(info);
 }
 
+#ifndef DUCKDB_DISABLE_EXTENSION_LOAD
 static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DBConfig &config, const string &url,
                                                            const string &extension_name, const string &temp_path,
                                                            const string &local_extension_path, bool force_install,
@@ -506,6 +507,7 @@ static void ThrowErrorOnMismatchingExtensionOrigin(FileSystem &fs, const string 
 		}
 	}
 }
+#endif // DUCKDB_DISABLE_EXTENSION_LOAD
 
 unique_ptr<ExtensionInstallInfo>
 ExtensionHelper::InstallExtensionInternal(DBConfig &config, FileSystem &fs, const string &local_path,

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -32,6 +32,7 @@ static T LoadFunctionFromDLL(void *dll, const string &function_name, const strin
 	}
 	return (T)function;
 }
+#endif
 
 static void ComputeSHA256String(const string &to_hash, string *res) {
 	// Invoke MbedTls function to actually compute sha256
@@ -57,7 +58,6 @@ static void ComputeSHA256FileSegment(FileHandle *handle, const idx_t start, cons
 
 	*res = state.Finalize();
 }
-#endif
 
 static string FilterZeroAtEnd(string s) {
 	while (!s.empty() && s.back() == '\0') {


### PR DESCRIPTION
The flag disables loading & installing extensions at run-time. It was broken sometime between v0.8x and v1.0x. 
This fix reviews the sections of code referred when the flag is in-place.

Fix https://github.com/duckdb/duckdb/issues/12911 