### PR TITLE
Fixup invocation of clang-tidy

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -117,11 +117,14 @@ jobs:
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-tidy && sudo pip3 install pybind11[global] --break-system-packages
 
       - name: Setup Ccache
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: hendrikmuhs/ccache-action@main
         with:
           key: ${{ github.job }}
           save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
       - name: Download clang-tidy-cache
+        if: ${{ github.ref == 'refs/heads/main' }}
         shell: bash
         run: |
           set -e
@@ -137,4 +140,4 @@ jobs:
       - name: Tidy Check Diff
         shell: bash
         if: ${{ github.ref != 'refs/heads/main' }}
-        run: make tidy-check-diff TIDY_BINARY=/tmp/clang-tidy-cache
+        run: make tidy-check-diff


### PR DESCRIPTION
Currently `TIDY_BINARY` env variable is not correctly handled by the underlying python script, resulting in errors like:
```
Failed to get commands: Unable to locate the compiler definition
```
(https://github.com/duckdb/duckdb/actions/runs/10169576034/job/28126851633#step:7:61)

while executing clang-tidy on PRs.

Avoid passing down the parameter, that means not using the cache.
But considering we went from running on all files (about 1 hour) to only touched files (likely a few minutes), this should still be a significant improvement.

Ccache can be brough back properly later, for now restoring to working state.


This has been tested on my fork by submitting a irrelevant PR just to check that errors are correctly detected: https://github.com/carlopi/duckdb/actions/runs/10174915732/job/28141516564#step:7:61