### PR TITLE
Add delta to CI

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -46,7 +46,7 @@ endif()
 ################# DELTA
 # MinGW build is not available, and our current manylinux ci does not have enough storage space to run the rust build
 # for Delta
-if (NOT MINGW AND NOT DUCKDB_EXPLICIT_PLATFORM STREQUAL linux_amd64_gcc4)
+if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux")
     duckdb_extension_load(delta
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_delta

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -50,7 +50,7 @@ if (NOT MINGW AND NOT DUCKDB_EXPLICIT_PLATFORM STREQUAL linux_amd64_gcc4)
     duckdb_extension_load(delta
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_delta
-            GIT_TAG v0.1.0
+            GIT_TAG 0b981978e8450a43f3b0bfdb84d382d61afbb1d0
     )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -44,11 +44,13 @@ if (NOT MINGW)
 endif()
 
 ################# DELTA
-if (NOT MINGW)
+# MinGW build is not available, and our current manylinux ci does not have enough storage space to run the rust build
+# for Delta
+if (NOT MINGW AND NOT DUCKDB_EXPLICIT_PLATFORM STREQUAL linux_amd64_gcc4)
     duckdb_extension_load(delta
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_delta
-            GIT_TAG 0b981978e8450a43f3b0bfdb84d382d61afbb1d0
+            GIT_TAG v0.1.0
     )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -43,6 +43,15 @@ if (NOT MINGW)
             )
 endif()
 
+################# DELTA
+if (NOT MINGW)
+    duckdb_extension_load(delta
+            LOAD_TESTS
+            GIT_URL https://github.com/duckdb/duckdb_delta
+            GIT_TAG 0b981978e8450a43f3b0bfdb84d382d61afbb1d0
+    )
+endif()
+
 ################# EXCEL
 duckdb_extension_load(excel
     LOAD_TESTS

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -218,8 +218,9 @@ jobs:
 
     - name: Configure OpenSSL for Rust
       run: |
-        echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
-        echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
+        echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/x64-linux" >> $GITHUB_ENV
+        echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/x64-linux" >> $GITHUB_ENV
+        echo "OPENSSL_INCLUDE_DIR=`pwd`/build/release/vcpkg_installed/x64-linux/include" >> $GITHUB_ENV
         echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
 
     - uses: ./.github/actions/build_extensions
@@ -272,8 +273,9 @@ jobs:
 
       - name: Configure OpenSSL for Rust
         run: |
-          echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
+          echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/arm64-linux" >> $GITHUB_ENV
+          echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/arm64-linux" >> $GITHUB_ENV
+          echo "OPENSSL_INCLUDE_DIR=`pwd`/build/release/vcpkg_installed/arm64-linux/include" >> $GITHUB_ENV
           echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
 
       - uses: ./.github/actions/build_extensions

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -213,6 +213,15 @@ jobs:
         ccache: 1
         git_ref: ${{ inputs.git_ref }}
 
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Configure OpenSSL for Rust
+      run: |
+        echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
+        echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
+        echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
+
     - uses: ./.github/actions/build_extensions
       with:
         vcpkg_target_triplet: x64-linux
@@ -255,6 +264,17 @@ jobs:
           aarch64_cross_compile: 1
           ccache: 1
           git_ref: ${{ inputs.git_ref }}
+
+      - name: Setup Rust for cross compilation
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Configure OpenSSL for Rust
+        run: |
+          echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
+          echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
+          echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
 
       - uses: ./.github/actions/build_extensions
         with:

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -233,6 +233,11 @@ jobs:
           key: ${{ github.job }}-${{ matrix.label }}
           save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
 
+      - name: Install Rust cross compile dependency
+        if: ${{ matrix.osx_arch == 'x86_64'}}
+        run: |
+          rustup target add x86_64-apple-darwin
+
       - uses: ./.github/actions/build_extensions
         with:
           treat_warn_as_error: 0

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -142,6 +142,7 @@ jobs:
 
     - uses: ./.github/actions/build_extensions
       with:
+        duckdb_arch: linux_amd64_gcc4
         vcpkg_target_triplet: x64-linux
         post_install: rm build/release/src/libduckdb*
         deploy_as: linux_amd64_gcc4

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -140,18 +140,6 @@ jobs:
         python_alias: 1
         openssl: 1
 
-    - name: Setup Rust for manylinux (dtolnay/rust-toolchain doesn't work due to curl being old here)
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-    - name: Configure OpenSSL for Rust
-      run: |
-        echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/x64-linux" >> $GITHUB_ENV
-        echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/x64-linux" >> $GITHUB_ENV
-        echo "OPENSSL_INCLUDE_DIR=`pwd`/build/release/vcpkg_installed/x64-linux/include" >> $GITHUB_ENV
-        echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
-
     - uses: ./.github/actions/build_extensions
       with:
         vcpkg_target_triplet: x64-linux

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -142,7 +142,6 @@ jobs:
 
     - uses: ./.github/actions/build_extensions
       with:
-        duckdb_arch: linux_amd64_gcc4
         vcpkg_target_triplet: x64-linux
         post_install: rm build/release/src/libduckdb*
         deploy_as: linux_amd64_gcc4

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -140,6 +140,17 @@ jobs:
         python_alias: 1
         openssl: 1
 
+    - name: Setup Rust for manylinux (dtolnay/rust-toolchain doesn't work due to curl being old here)
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Configure OpenSSL for Rust
+      run: |
+        echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
+        echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
+        echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
+
     - uses: ./.github/actions/build_extensions
       with:
         vcpkg_target_triplet: x64-linux

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -147,8 +147,9 @@ jobs:
 
     - name: Configure OpenSSL for Rust
       run: |
-        echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
-        echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
+        echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/x64-linux" >> $GITHUB_ENV
+        echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/x64-linux" >> $GITHUB_ENV
+        echo "OPENSSL_INCLUDE_DIR=`pwd`/build/release/vcpkg_installed/x64-linux/include" >> $GITHUB_ENV
         echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
 
     - uses: ./.github/actions/build_extensions

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -274,6 +274,9 @@ jobs:
        with:
          python-version: '3.12'
 
+     - name: Setup Rust
+       uses: dtolnay/rust-toolchain@stable
+
      - uses: ./.github/actions/build_extensions
        with:
          vcpkg_target_triplet: x64-windows-static-md


### PR DESCRIPTION
This PR adds the delta extension to duckdb/duckdb CI.

I have skipped the linux builds for now meaning that this won't be available in nightlies on Linux platforms. The reason is that this CI jobs runs out of disk space. The proper solution to this is to refactor our extension CI to use the workflow from the [extension ci tools](https://github.com/duckdb/extension-ci-tools) allowing us to be a bit more flexible. However achieving this will require us to have reliable build caching, because otherwise we rebuild duckdb per extension which seems excessive. Alternatively we can consider the hacky way to just split the out of tree extensions in a part1 and part2 for now.



