### PR TITLE
Filter paths before scripts/clang-tidy-diff.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,7 @@ tidy-check-diff:
 	cd build/tidy && \
 	cmake -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_EXTENSIONS=parquet -DBUILD_PYTHON_PKG=TRUE -DBUILD_SHELL=0 ../.. && \
 	cd ../../ && \
-	git diff origin/main | python3 scripts/clang-tidy-diff.py -path build/tidy -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER} ${TIDY_PERFORM_CHECKS} -p1
+	git diff origin/main . ':(exclude)test' ':(exclude)benchmark' ':(exclude)third_party' ':(exclude)src/common/adbc' ':(exclude)src/main/capi' | python3 scripts/clang-tidy-diff.py -path build/tidy -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER} ${TIDY_PERFORM_CHECKS} -p1
 
 tidy-fix:
 	mkdir -p ./build/tidy && \


### PR DESCRIPTION
I am not super happy, since this doubles the paths between what needs to be specified at the CMake level and here. But it's likely fine for now. Unsure if there is a cleaner solution.

This fixes cases like https://github.com/duckdb/duckdb/actions/runs/10176506561/job/28146061153?pr=13203#step:7:73 where a failure is detected even though the touched files should be filtered out.

Equivalent run after with this changes in: https://github.com/carlopi/duckdb/actions/runs/10177417419/job/28148945803 (now some files are checked while files in the `test/` `benchmark/` `src/common/adbc/` and `src/main/capi` are filtered out).