### PR TITLE
Add aggregate function support to the C API

### DIFF
--- a/src/common/row_operations/row_aggregate.cpp
+++ b/src/common/row_operations/row_aggregate.cpp
@@ -25,7 +25,7 @@ void RowOperations::InitializeStates(TupleDataLayout &layout, Vector &addresses,
 		for (idx_t i = 0; i < count; ++i) {
 			auto row_idx = sel.get_index(i);
 			auto row = pointers[row_idx];
-			aggr.function.initialize(row + offsets[aggr_idx]);
+			aggr.function.initialize(aggr.function, row + offsets[aggr_idx]);
 		}
 		++aggr_idx;
 	}

--- a/src/core_functions/scalar/list/list_aggregates.cpp
+++ b/src/core_functions/scalar/list/list_aggregates.cpp
@@ -224,7 +224,7 @@ static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vect
 	auto list_entries = UnifiedVectorFormat::GetData<list_entry_t>(lists_data);
 
 	// state_buffer holds the state for each list of this chunk
-	idx_t size = aggr.function.state_size();
+	idx_t size = aggr.function.state_size(aggr.function);
 	auto state_buffer = make_unsafe_uniq_array_uninitialized<data_t>(size * count);
 
 	// state vector for initialize and finalize
@@ -244,7 +244,7 @@ static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vect
 		// initialize the state for this list
 		auto state_ptr = state_buffer.get() + size * i;
 		states[i] = state_ptr;
-		aggr.function.initialize(states[i]);
+		aggr.function.initialize(aggr.function, states[i]);
 
 		auto lists_index = lists_data.sel->get_index(i);
 		const auto &list_entry = list_entries[lists_index];

--- a/src/execution/operator/aggregate/aggregate_object.cpp
+++ b/src/execution/operator/aggregate/aggregate_object.cpp
@@ -16,13 +16,13 @@ AggregateObject::AggregateObject(AggregateFunction function, FunctionData *bind_
 
 AggregateObject::AggregateObject(BoundAggregateExpression *aggr)
     : AggregateObject(aggr->function, aggr->bind_info.get(), aggr->children.size(),
-                      AlignValue(aggr->function.state_size()), aggr->aggr_type, aggr->return_type.InternalType(),
-                      aggr->filter.get()) {
+                      AlignValue(aggr->function.state_size(aggr->function)), aggr->aggr_type,
+                      aggr->return_type.InternalType(), aggr->filter.get()) {
 }
 
 AggregateObject::AggregateObject(const BoundWindowExpression &window)
     : AggregateObject(*window.aggregate, window.bind_info.get(), window.children.size(),
-                      AlignValue(window.aggregate->state_size()),
+                      AlignValue(window.aggregate->state_size(*window.aggregate)),
                       window.distinct ? AggregateType::DISTINCT : AggregateType::NON_DISTINCT,
                       window.return_type.InternalType(), window.filter_expr.get()) {
 }

--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -34,9 +34,9 @@ public:
 			auto &aggregate = *wexpr.aggregate;
 			bind_data = wexpr.bind_info.get();
 			dtor = aggregate.destructor;
-			state.resize(aggregate.state_size());
+			state.resize(aggregate.state_size(aggregate));
 			state_ptr = state.data();
-			aggregate.initialize(state.data());
+			aggregate.initialize(aggregate, state.data());
 			for (auto &child : wexpr.children) {
 				arg_types.push_back(child->return_type);
 				executor.AddExpression(*child);

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -44,8 +44,8 @@ UngroupedAggregateState::UngroupedAggregateState(const vector<unique_ptr<Express
 		auto &aggregate = aggregate_expressions[i];
 		D_ASSERT(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 		auto &aggr = aggregate->Cast<BoundAggregateExpression>();
-		auto state = make_unsafe_uniq_array_uninitialized<data_t>(aggr.function.state_size());
-		aggr.function.initialize(state.get());
+		auto state = make_unsafe_uniq_array_uninitialized<data_t>(aggr.function.state_size(aggr.function));
+		aggr.function.initialize(aggr.function, state.get());
 		aggregate_data.push_back(std::move(state));
 		bind_data.push_back(aggr.bind_info.get());
 		destructors.push_back(aggr.function.destructor);

--- a/src/execution/operator/projection/physical_pivot.cpp
+++ b/src/execution/operator/projection/physical_pivot.cpp
@@ -20,8 +20,8 @@ PhysicalPivot::PhysicalPivot(vector<LogicalType> types_p, unique_ptr<PhysicalOpe
 	for (auto &aggr_expr : bound_pivot.aggregates) {
 		auto &aggr = aggr_expr->Cast<BoundAggregateExpression>();
 		// for each aggregate, initialize an empty aggregate state and finalize it immediately
-		auto state = make_unsafe_uniq_array<data_t>(aggr.function.state_size());
-		aggr.function.initialize(state.get());
+		auto state = make_unsafe_uniq_array<data_t>(aggr.function.state_size(aggr.function));
+		aggr.function.initialize(aggr.function, state.get());
 		Vector state_vector(Value::POINTER(CastPointerToValue(state.get())));
 		Vector result_vector(aggr_expr->return_type);
 		AggregateInputData aggr_input_data(aggr.bind_info.get(), allocator);

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -878,8 +878,8 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 			for (idx_t i = 0; i < op.aggregates.size(); i++) {
 				D_ASSERT(op.aggregates[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
 				auto &aggr = op.aggregates[i]->Cast<BoundAggregateExpression>();
-				auto aggr_state = make_unsafe_uniq_array_uninitialized<data_t>(aggr.function.state_size());
-				aggr.function.initialize(aggr_state.get());
+				auto aggr_state = make_unsafe_uniq_array_uninitialized<data_t>(aggr.function.state_size(aggr.function));
+				aggr.function.initialize(aggr.function, aggr_state.get());
 
 				AggregateInputData aggr_input_data(aggr.bind_info.get(), allocator);
 				Vector state_vector(Value::POINTER(CastPointerToValue(aggr_state.get())));

--- a/src/function/CMakeLists.txt
+++ b/src/function/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(table)
 add_library_unity(
   duckdb_function
   OBJECT
+  aggregate_function.cpp
   built_in_functions.cpp
   cast_rules.cpp
   compression_config.cpp

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -1,0 +1,8 @@
+#include "duckdb/function/aggregate_function.hpp"
+
+namespace duckdb {
+
+AggregateFunctionInfo::~AggregateFunctionInfo() {
+}
+
+} // namespace duckdb

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -81,7 +81,7 @@ static void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, V
 	auto &local_state = ExecuteFunctionState::GetFunctionState(state_p)->Cast<FinalizeState>();
 	local_state.allocator.Reset();
 
-	D_ASSERT(bind_data.state_size == bind_data.aggr.state_size());
+	D_ASSERT(bind_data.state_size == bind_data.aggr.state_size(bind_data.aggr));
 	D_ASSERT(input.data.size() == 1);
 	D_ASSERT(input.data[0].GetType().id() == LogicalTypeId::AGGREGATE_STATE);
 	auto aligned_state_size = AlignValue(bind_data.state_size);
@@ -101,7 +101,7 @@ static void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, V
 		} else {
 			// create a dummy state because finalize does not understand NULLs in its input
 			// we put the NULL back in explicitly below
-			bind_data.aggr.initialize(data_ptr_cast(target_ptr));
+			bind_data.aggr.initialize(bind_data.aggr, data_ptr_cast(target_ptr));
 		}
 		state_vec_ptr[i] = data_ptr_cast(target_ptr);
 	}
@@ -122,7 +122,7 @@ static void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Ve
 	auto &local_state = ExecuteFunctionState::GetFunctionState(state_p)->Cast<CombineState>();
 	local_state.allocator.Reset();
 
-	D_ASSERT(bind_data.state_size == bind_data.aggr.state_size());
+	D_ASSERT(bind_data.state_size == bind_data.aggr.state_size(bind_data.aggr));
 
 	D_ASSERT(input.data.size() == 2);
 	D_ASSERT(input.data[0].GetType().id() == LogicalTypeId::AGGREGATE_STATE);
@@ -248,14 +248,14 @@ static unique_ptr<FunctionData> BindAggregateState(ClientContext &context, Scala
 		bound_function.return_type = arg_return_type;
 	}
 
-	return make_uniq<ExportAggregateBindData>(bound_aggr, bound_aggr.state_size());
+	return make_uniq<ExportAggregateBindData>(bound_aggr, bound_aggr.state_size(bound_aggr));
 }
 
 static void ExportAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
                                     idx_t offset) {
 	D_ASSERT(offset == 0);
 	auto &bind_data = aggr_input_data.bind_data->Cast<ExportAggregateFunctionBindData>();
-	auto state_size = bind_data.aggregate->function.state_size();
+	auto state_size = bind_data.aggregate->function.state_size(bind_data.aggregate->function);
 	auto blob_ptr = FlatVector::GetData<string_t>(result);
 	auto addresses_ptr = FlatVector::GetData<data_ptr_t>(state);
 	for (idx_t row_idx = 0; row_idx < count; row_idx++) {

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1208,7 +1208,7 @@ DUCKDB_API uint32_t duckdb_string_t_length(duckdb_string_t string);
 Returns a pointer to the string data of a string_t
 
 */
-DUCKDB_API const char *duckdb_string_t_data(duckdb_string_t string);
+DUCKDB_API const char *duckdb_string_t_data(duckdb_string_t *string);
 
 //===--------------------------------------------------------------------===//
 // Date/Time/Timestamp Helpers

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -529,9 +529,9 @@ typedef struct _duckdb_aggregate_state {
 } * duckdb_aggregate_state;
 
 //! Returns the aggregate state size
-typedef idx_t (*duckdb_aggregate_state_size)(void);
+typedef idx_t (*duckdb_aggregate_state_size)(duckdb_function_info info);
 //! Initialize the aggregate state
-typedef void (*duckdb_aggregate_init_t)(duckdb_aggregate_state state);
+typedef void (*duckdb_aggregate_init_t)(duckdb_function_info info, duckdb_aggregate_state state);
 //! Destroy aggregate state (optional)
 typedef void (*duckdb_aggregate_destroy_t)(duckdb_aggregate_state *states, idx_t count);
 //! Update a set of aggregate states with new values

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1198,6 +1198,18 @@ This means that the data of the string does not have a separate allocation.
 */
 DUCKDB_API bool duckdb_string_is_inlined(duckdb_string_t string);
 
+/*!
+Returns the string length of a string_t
+
+*/
+DUCKDB_API uint32_t duckdb_string_t_length(duckdb_string_t string);
+
+/*!
+Returns a pointer to the string data of a string_t
+
+*/
+DUCKDB_API const char *duckdb_string_t_data(duckdb_string_t string);
+
 //===--------------------------------------------------------------------===//
 // Date/Time/Timestamp Helpers
 //===--------------------------------------------------------------------===//
@@ -2581,6 +2593,13 @@ If the function is incomplete or a function with this name already exists DuckDB
 */
 DUCKDB_API duckdb_state duckdb_register_aggregate_function(duckdb_connection con,
                                                            duckdb_aggregate_function aggregate_function);
+
+/*!
+Sets the NULL handling of the aggregate function to SPECIAL_HANDLING.
+
+* aggregate_function: The aggregate function
+*/
+DUCKDB_API void duckdb_aggregate_function_set_special_handling(duckdb_aggregate_function aggregate_function);
 
 /*!
 Assigns extra information to the scalar function that can be fetched during binding, etc.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -369,13 +369,13 @@ typedef struct {
 	char *name;
 #else
 	// deprecated, use duckdb_column_data
-	void *__deprecated_data;
+	void *deprecated_data;
 	// deprecated, use duckdb_nullmask_data
-	bool *__deprecated_nullmask;
+	bool *deprecated_nullmask;
 	// deprecated, use duckdb_column_type
-	duckdb_type __deprecated_type;
+	duckdb_type deprecated_type;
 	// deprecated, use duckdb_column_name
-	char *__deprecated_name;
+	char *deprecated_name;
 #endif
 	void *internal_data;
 } duckdb_column;
@@ -383,7 +383,7 @@ typedef struct {
 //! A vector to a specified column in a data chunk. Lives as long as the
 //! data chunk lives, i.e., must not be destroyed.
 typedef struct _duckdb_vector {
-	void *__vctr;
+	void *internal_ptr;
 } * duckdb_vector;
 
 //===--------------------------------------------------------------------===//
@@ -415,85 +415,85 @@ typedef struct {
 	char *error_message;
 #else
 	// deprecated, use duckdb_column_count
-	idx_t __deprecated_column_count;
+	idx_t deprecated_column_count;
 	// deprecated, use duckdb_row_count
-	idx_t __deprecated_row_count;
+	idx_t deprecated_row_count;
 	// deprecated, use duckdb_rows_changed
-	idx_t __deprecated_rows_changed;
+	idx_t deprecated_rows_changed;
 	// deprecated, use duckdb_column_*-family of functions
-	duckdb_column *__deprecated_columns;
+	duckdb_column *deprecated_columns;
 	// deprecated, use duckdb_result_error
-	char *__deprecated_error_message;
+	char *deprecated_error_message;
 #endif
 	void *internal_data;
 } duckdb_result;
 
 //! A database object. Should be closed with `duckdb_close`.
 typedef struct _duckdb_database {
-	void *__db;
+	void *internal_ptr;
 } * duckdb_database;
 
 //! A connection to a duckdb database. Must be closed with `duckdb_disconnect`.
 typedef struct _duckdb_connection {
-	void *__conn;
+	void *internal_ptr;
 } * duckdb_connection;
 
 //! A prepared statement is a parameterized query that allows you to bind parameters to it.
 //! Must be destroyed with `duckdb_destroy_prepare`.
 typedef struct _duckdb_prepared_statement {
-	void *__prep;
+	void *internal_ptr;
 } * duckdb_prepared_statement;
 
 //! Extracted statements. Must be destroyed with `duckdb_destroy_extracted`.
 typedef struct _duckdb_extracted_statements {
-	void *__extrac;
+	void *internal_ptr;
 } * duckdb_extracted_statements;
 
 //! The pending result represents an intermediate structure for a query that is not yet fully executed.
 //! Must be destroyed with `duckdb_destroy_pending`.
 typedef struct _duckdb_pending_result {
-	void *__pend;
+	void *internal_ptr;
 } * duckdb_pending_result;
 
 //! The appender enables fast data loading into DuckDB.
 //! Must be destroyed with `duckdb_appender_destroy`.
 typedef struct _duckdb_appender {
-	void *__appn;
+	void *internal_ptr;
 } * duckdb_appender;
 
 //! The table description allows querying info about the table.
 //! Must be destroyed with `duckdb_table_description_destroy`.
 typedef struct _duckdb_table_description {
-	void *__tabledesc;
+	void *internal_ptr;
 } * duckdb_table_description;
 
 //! Can be used to provide start-up options for the DuckDB instance.
 //! Must be destroyed with `duckdb_destroy_config`.
 typedef struct _duckdb_config {
-	void *__cnfg;
+	void *internal_ptr;
 } * duckdb_config;
 
 //! Holds an internal logical type.
 //! Must be destroyed with `duckdb_destroy_logical_type`.
 typedef struct _duckdb_logical_type {
-	void *__lglt;
+	void *internal_ptr;
 } * duckdb_logical_type;
 
 //! Contains a data chunk from a duckdb_result.
 //! Must be destroyed with `duckdb_destroy_data_chunk`.
 typedef struct _duckdb_data_chunk {
-	void *__dtck;
+	void *internal_ptr;
 } * duckdb_data_chunk;
 
 //! Holds a DuckDB value, which wraps a type.
 //! Must be destroyed with `duckdb_destroy_value`.
 typedef struct _duckdb_value {
-	void *__val;
+	void *internal_ptr;
 } * duckdb_value;
 
 //! Holds a recursive tree that matches the query plan.
 typedef struct _duckdb_profiling_info {
-	void *__prof;
+	void *internal_ptr;
 } * duckdb_profiling_info;
 
 //===--------------------------------------------------------------------===//
@@ -501,7 +501,7 @@ typedef struct _duckdb_profiling_info {
 //===--------------------------------------------------------------------===//
 //! Additional function info. When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_function_info {
-	void *__val;
+	void *internal_ptr;
 } * duckdb_function_info;
 
 //===--------------------------------------------------------------------===//
@@ -509,7 +509,7 @@ typedef struct _duckdb_function_info {
 //===--------------------------------------------------------------------===//
 //! A scalar function. Must be destroyed with `duckdb_destroy_scalar_function`.
 typedef struct _duckdb_scalar_function {
-	void *__val;
+	void *internal_ptr;
 } * duckdb_scalar_function;
 
 //! The main function of the scalar function.
@@ -520,12 +520,12 @@ typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_
 //===--------------------------------------------------------------------===//
 //! An aggregate function. Must be destroyed with `duckdb_destroy_aggregate_function`.
 typedef struct _duckdb_aggregate_function {
-	void *__val;
+	void *internal_ptr;
 } * duckdb_aggregate_function;
 
 //!
 typedef struct _duckdb_aggregate_state {
-	void *__val;
+	void *internal_ptr;
 } * duckdb_aggregate_state;
 
 //! Returns the aggregate state size
@@ -551,17 +551,17 @@ typedef void (*duckdb_aggregate_finalize_t)(duckdb_function_info info, duckdb_ag
 #ifndef DUCKDB_NO_EXTENSION_FUNCTIONS
 //! A table function. Must be destroyed with `duckdb_destroy_table_function`.
 typedef struct _duckdb_table_function {
-	void *__val;
+	void *internal_ptr;
 } * duckdb_table_function;
 
 //! The bind info of the function. When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_bind_info {
-	void *__val;
+	void *internal_ptr;
 } * duckdb_bind_info;
 
 //! Additional function init info. When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_init_info {
-	void *__val;
+	void *internal_ptr;
 } * duckdb_init_info;
 
 //! The bind function of the table function.
@@ -579,7 +579,7 @@ typedef void (*duckdb_table_function_t)(duckdb_function_info info, duckdb_data_c
 
 //! Additional replacement scan info. When setting this info, it is necessary to pass a destroy-callback function.
 typedef struct _duckdb_replacement_scan_info {
-	void *__val;
+	void *internal_ptr;
 } * duckdb_replacement_scan_info;
 
 //! A replacement scan function that can be added to a database.
@@ -592,22 +592,22 @@ typedef void (*duckdb_replacement_callback_t)(duckdb_replacement_scan_info info,
 
 //! Holds an arrow query result. Must be destroyed with `duckdb_destroy_arrow`.
 typedef struct _duckdb_arrow {
-	void *__arrw;
+	void *internal_ptr;
 } * duckdb_arrow;
 
 //! Holds an arrow array stream. Must be destroyed with `duckdb_destroy_arrow_stream`.
 typedef struct _duckdb_arrow_stream {
-	void *__arrwstr;
+	void *internal_ptr;
 } * duckdb_arrow_stream;
 
 //! Holds an arrow schema. Remember to release the respective ArrowSchema object.
 typedef struct _duckdb_arrow_schema {
-	void *__arrs;
+	void *internal_ptr;
 } * duckdb_arrow_schema;
 
 //! Holds an arrow array. Remember to release the respective ArrowArray object.
 typedef struct _duckdb_arrow_array {
-	void *__arra;
+	void *internal_ptr;
 } * duckdb_arrow_array;
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -42,9 +42,9 @@ struct WindowPartitionInput {
 };
 
 //! The type used for sizing hashed aggregate function states
-typedef idx_t (*aggregate_size_t)();
+typedef idx_t (*aggregate_size_t)(const AggregateFunction &function);
 //! The type used for initializing hashed aggregate function states
-typedef void (*aggregate_initialize_t)(data_ptr_t state);
+typedef void (*aggregate_initialize_t)(const AggregateFunction &function, data_ptr_t state);
 //! The type used for updating hashed aggregate functions
 typedef void (*aggregate_update_t)(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count,
                                    Vector &state, idx_t count);
@@ -228,12 +228,12 @@ public:
 
 public:
 	template <class STATE>
-	static idx_t StateSize() {
+	static idx_t StateSize(const AggregateFunction &) {
 		return sizeof(STATE);
 	}
 
 	template <class STATE, class OP>
-	static void StateInitialize(data_ptr_t state) {
+	static void StateInitialize(const AggregateFunction &, data_ptr_t state) {
 		OP::Initialize(*reinterpret_cast<STATE *>(state));
 	}
 

--- a/src/include/duckdb/main/capi/cast/generic.hpp
+++ b/src/include/duckdb/main/capi/cast/generic.hpp
@@ -23,7 +23,7 @@ RESULT_TYPE GetInternalCValue(duckdb_result *result, idx_t col, idx_t row) {
 	if (!CanFetchValue(result, col, row)) {
 		return FetchDefaultValue::Operation<RESULT_TYPE>();
 	}
-	switch (result->__deprecated_columns[col].__deprecated_type) {
+	switch (result->deprecated_columns[col].deprecated_type) {
 	case DUCKDB_TYPE_BOOLEAN:
 		return TryCastCInternal<bool, RESULT_TYPE, OP>(result, col, row);
 	case DUCKDB_TYPE_TINYINT:

--- a/src/include/duckdb/main/capi/cast/utils.hpp
+++ b/src/include/duckdb/main/capi/cast/utils.hpp
@@ -25,8 +25,8 @@ T UnsafeFetchFromPtr(void *pointer) {
 
 template <class T>
 void *UnsafeFetchPtr(duckdb_result *result, idx_t col, idx_t row) {
-	D_ASSERT(row < result->__deprecated_row_count);
-	return (void *)&(((T *)result->__deprecated_columns[col].__deprecated_data)[row]);
+	D_ASSERT(row < result->deprecated_row_count);
+	return (void *)&(((T *)result->deprecated_columns[col].deprecated_data)[row]);
 }
 
 template <class T>

--- a/src/main/capi/CMakeLists.txt
+++ b/src/main/capi/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(cast)
 add_library_unity(
   duckdb_main_capi
   OBJECT
+  aggregate_function-c.cpp
   appender-c.cpp
   arrow-c.cpp
   config-c.cpp

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -212,6 +212,14 @@ duckdb_state duckdb_register_aggregate_function(duckdb_connection connection, du
 	return DuckDBSuccess;
 }
 
+void duckdb_aggregate_function_set_special_handling(duckdb_aggregate_function function) {
+	if (!function) {
+		return;
+	}
+	auto &aggregate_function = GetCAggregateFunction(function);
+	aggregate_function.null_handling = duckdb::FunctionNullHandling::SPECIAL_HANDLING;
+}
+
 void duckdb_aggregate_function_set_extra_info(duckdb_aggregate_function function, void *extra_info,
                                               duckdb_delete_callback_t destroy) {
 	if (!function || !extra_info) {

--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -1,0 +1,240 @@
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/type_visitor.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/function/function.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/capi/capi_internal.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+struct CAggregateFunctionInfo : public AggregateFunctionInfo {
+	~CAggregateFunctionInfo() override {
+		if (extra_info && delete_callback) {
+			delete_callback(extra_info);
+		}
+		extra_info = nullptr;
+		delete_callback = nullptr;
+	}
+
+	duckdb_aggregate_update_t update = nullptr;
+	duckdb_aggregate_combine_t combine = nullptr;
+	duckdb_aggregate_finalize_t finalize = nullptr;
+	duckdb_aggregate_destroy_t destroy = nullptr;
+	duckdb_function_info extra_info = nullptr;
+	duckdb_delete_callback_t delete_callback = nullptr;
+	bool success = true;
+	string error;
+};
+
+struct CAggregateFunctionBindData : public FunctionData {
+	explicit CAggregateFunctionBindData(CAggregateFunctionInfo &info) : info(info) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<CAggregateFunctionBindData>(info);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<CAggregateFunctionBindData>();
+		return info.extra_info == other.info.extra_info && info.update == other.info.update &&
+		       info.combine == other.info.combine && info.finalize == other.info.finalize;
+	}
+
+	CAggregateFunctionInfo &info;
+};
+
+duckdb::AggregateFunction &GetCAggregateFunction(duckdb_aggregate_function function) {
+	return *reinterpret_cast<duckdb::AggregateFunction *>(function);
+}
+
+unique_ptr<FunctionData> CAPIAggregateBind(ClientContext &context, AggregateFunction &function,
+                                           vector<unique_ptr<Expression>> &arguments) {
+	auto &info = function.function_info->Cast<CAggregateFunctionInfo>();
+	return make_uniq<CAggregateFunctionBindData>(info);
+}
+
+void CAPIAggregateUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, Vector &state,
+                         idx_t count) {
+	DataChunk chunk;
+	for (idx_t c = 0; c < input_count; c++) {
+		inputs[c].Flatten(count);
+		chunk.data.emplace_back(inputs[c]);
+	}
+	chunk.SetCardinality(count);
+
+	auto &bind_data = aggr_input_data.bind_data->Cast<CAggregateFunctionBindData>();
+	auto state_data = FlatVector::GetData<duckdb_aggregate_state>(state);
+	auto c_input_chunk = reinterpret_cast<duckdb_data_chunk>(&chunk);
+	auto c_function_info = reinterpret_cast<duckdb_function_info>(&bind_data.info);
+	bind_data.info.update(c_function_info, c_input_chunk, state_data);
+	if (!bind_data.info.success) {
+		throw InvalidInputException(bind_data.info.error);
+	}
+}
+
+void CAPIAggregateCombine(Vector &state, Vector &combined, AggregateInputData &aggr_input_data, idx_t count) {
+	state.Flatten(count);
+	auto &bind_data = aggr_input_data.bind_data->Cast<CAggregateFunctionBindData>();
+	auto input_state_data = FlatVector::GetData<duckdb_aggregate_state>(state);
+	auto result_state_data = FlatVector::GetData<duckdb_aggregate_state>(combined);
+	auto c_function_info = reinterpret_cast<duckdb_function_info>(&bind_data.info);
+	bind_data.info.combine(c_function_info, input_state_data, result_state_data, count);
+	if (!bind_data.info.success) {
+		throw InvalidInputException(bind_data.info.error);
+	}
+}
+
+// typedef void (*duckdb_aggregate_finalize_t)(duckdb_function_info info, duckdb_aggregate_state *source, duckdb_vector
+// result, idx_t count);
+
+void CAPIAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+                           idx_t offset) {
+	state.Flatten(count);
+	auto &bind_data = aggr_input_data.bind_data->Cast<CAggregateFunctionBindData>();
+	auto input_state_data = FlatVector::GetData<duckdb_aggregate_state>(state);
+	auto result_vector = reinterpret_cast<duckdb_vector>(&result);
+	auto c_function_info = reinterpret_cast<duckdb_function_info>(&bind_data.info);
+	bind_data.info.finalize(c_function_info, input_state_data, result_vector, count, offset);
+	if (!bind_data.info.success) {
+		throw InvalidInputException(bind_data.info.error);
+	}
+}
+
+void CAPIAggregateDestructor(Vector &state, AggregateInputData &aggr_input_data, idx_t count) {
+	auto &bind_data = aggr_input_data.bind_data->Cast<CAggregateFunctionBindData>();
+	auto input_state_data = FlatVector::GetData<duckdb_aggregate_state>(state);
+	bind_data.info.destroy(input_state_data, count);
+}
+
+} // namespace duckdb
+
+using duckdb::GetCAggregateFunction;
+
+duckdb_aggregate_function duckdb_create_aggregate_function() {
+	auto function = new duckdb::AggregateFunction("", {}, duckdb::LogicalType::INVALID, nullptr, nullptr,
+	                                              duckdb::CAPIAggregateUpdate, duckdb::CAPIAggregateCombine,
+	                                              duckdb::CAPIAggregateFinalize, nullptr, duckdb::CAPIAggregateBind);
+	function->function_info = duckdb::make_shared_ptr<duckdb::CAggregateFunctionInfo>();
+	return reinterpret_cast<duckdb_aggregate_function>(function);
+}
+
+void duckdb_destroy_aggregate_function(duckdb_aggregate_function *function) {
+	if (function && *function) {
+		auto aggregate_function = reinterpret_cast<duckdb::AggregateFunction *>(*function);
+		delete aggregate_function;
+		*function = nullptr;
+	}
+}
+
+void duckdb_aggregate_function_set_name(duckdb_aggregate_function function, const char *name) {
+	if (!function || !name) {
+		return;
+	}
+	auto &aggregate_function = GetCAggregateFunction(function);
+	aggregate_function.name = name;
+}
+
+void duckdb_aggregate_function_add_parameter(duckdb_aggregate_function function, duckdb_logical_type type) {
+	if (!function || !type) {
+		return;
+	}
+	auto &aggregate_function = GetCAggregateFunction(function);
+	auto logical_type = reinterpret_cast<duckdb::LogicalType *>(type);
+	aggregate_function.arguments.push_back(*logical_type);
+}
+
+void duckdb_aggregate_function_set_return_type(duckdb_aggregate_function function, duckdb_logical_type type) {
+	if (!function || !type) {
+		return;
+	}
+	auto &aggregate_function = GetCAggregateFunction(function);
+	auto logical_type = reinterpret_cast<duckdb::LogicalType *>(type);
+	aggregate_function.return_type = *logical_type;
+}
+
+void duckdb_aggregate_function_set_functions(duckdb_aggregate_function function, duckdb_aggregate_state_size state_size,
+                                             duckdb_aggregate_init_t state_init, duckdb_aggregate_update_t update,
+                                             duckdb_aggregate_combine_t combine, duckdb_aggregate_finalize_t finalize) {
+	if (!function || !state_size || !state_init || !update || !combine || !finalize) {
+		return;
+	}
+	auto &aggregate_function = GetCAggregateFunction(function);
+	aggregate_function.initialize = reinterpret_cast<duckdb::aggregate_initialize_t>(state_init);
+	aggregate_function.state_size = state_size;
+	auto &function_info = aggregate_function.function_info->Cast<duckdb::CAggregateFunctionInfo>();
+	function_info.update = update;
+	function_info.combine = combine;
+	function_info.finalize = finalize;
+}
+
+void duckdb_aggregate_function_set_destructor(duckdb_aggregate_function function, duckdb_aggregate_destroy_t destroy) {
+	if (!function || !destroy) {
+		return;
+	}
+	auto &aggregate_function = GetCAggregateFunction(function);
+	auto &function_info = aggregate_function.function_info->Cast<duckdb::CAggregateFunctionInfo>();
+	function_info.destroy = destroy;
+	aggregate_function.destructor = duckdb::CAPIAggregateDestructor;
+}
+
+duckdb_state duckdb_register_aggregate_function(duckdb_connection connection, duckdb_aggregate_function function) {
+	if (!connection || !function) {
+		return DuckDBError;
+	}
+	auto &aggregate_function = GetCAggregateFunction(function);
+	auto &info = aggregate_function.function_info->Cast<duckdb::CAggregateFunctionInfo>();
+
+	if (aggregate_function.name.empty() || !info.update || !info.combine || !info.finalize) {
+		return DuckDBError;
+	}
+	if (duckdb::TypeVisitor::Contains(aggregate_function.return_type, duckdb::LogicalTypeId::INVALID) ||
+	    duckdb::TypeVisitor::Contains(aggregate_function.return_type, duckdb::LogicalTypeId::ANY)) {
+		return DuckDBError;
+	}
+	for (const auto &argument : aggregate_function.arguments) {
+		if (duckdb::TypeVisitor::Contains(argument, duckdb::LogicalTypeId::INVALID)) {
+			return DuckDBError;
+		}
+	}
+
+	try {
+		auto con = reinterpret_cast<duckdb::Connection *>(connection);
+		con->context->RunFunctionInTransaction([&]() {
+			auto &catalog = duckdb::Catalog::GetSystemCatalog(*con->context);
+			duckdb::CreateAggregateFunctionInfo sf_info(aggregate_function);
+			catalog.CreateFunction(*con->context, sf_info);
+		});
+	} catch (...) {
+		return DuckDBError;
+	}
+	return DuckDBSuccess;
+}
+
+void duckdb_aggregate_function_set_extra_info(duckdb_aggregate_function function, void *extra_info,
+                                              duckdb_delete_callback_t destroy) {
+	if (!function || !extra_info) {
+		return;
+	}
+	auto &aggregate_function = GetCAggregateFunction(function);
+	auto &function_info = aggregate_function.function_info->Cast<duckdb::CAggregateFunctionInfo>();
+	function_info.extra_info = static_cast<duckdb_function_info>(extra_info);
+	function_info.delete_callback = destroy;
+}
+
+duckdb::CAggregateFunctionInfo &GetCAggregateFunctionInfo(duckdb_function_info info) {
+	D_ASSERT(info);
+	return *reinterpret_cast<duckdb::CAggregateFunctionInfo *>(info);
+}
+
+void *duckdb_aggregate_function_get_extra_info(duckdb_function_info info_p) {
+	auto &info = GetCAggregateFunctionInfo(info_p);
+	return info.extra_info;
+}
+
+void duckdb_aggregate_function_set_error(duckdb_function_info info_p, const char *error) {
+	auto &info = GetCAggregateFunctionInfo(info_p);
+	info.error = error;
+	info.success = false;
+}

--- a/src/main/capi/cast/utils-c.cpp
+++ b/src/main/capi/cast/utils-c.cpp
@@ -81,7 +81,7 @@ bool CanUseDeprecatedFetch(duckdb_result *result, idx_t col, idx_t row) {
 	if (!duckdb::DeprecatedMaterializeResult(result)) {
 		return false;
 	}
-	if (col >= result->__deprecated_column_count || row >= result->__deprecated_row_count) {
+	if (col >= result->deprecated_column_count || row >= result->deprecated_row_count) {
 		return false;
 	}
 	return true;
@@ -91,7 +91,7 @@ bool CanFetchValue(duckdb_result *result, idx_t col, idx_t row) {
 	if (!CanUseDeprecatedFetch(result, col, row)) {
 		return false;
 	}
-	if (result->__deprecated_columns[col].__deprecated_nullmask[row]) {
+	if (result->deprecated_columns[col].deprecated_nullmask[row]) {
 		return false;
 	}
 	return true;

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -303,9 +303,9 @@ uint32_t duckdb_string_t_length(duckdb_string_t string_p) {
 	return static_cast<uint32_t>(string.GetSize());
 }
 
-const char *duckdb_string_t_data(duckdb_string_t string_p) {
+const char *duckdb_string_t_data(duckdb_string_t *string_p) {
 	static_assert(sizeof(duckdb_string_t) == sizeof(duckdb::string_t),
 	              "duckdb_string_t should have the same memory layout as duckdb::string_t");
-	auto &string = *reinterpret_cast<duckdb::string_t *>(&string_p);
+	auto &string = *reinterpret_cast<duckdb::string_t *>(string_p);
 	return string.GetData();
 }

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -292,6 +292,20 @@ idx_t duckdb_vector_size() {
 bool duckdb_string_is_inlined(duckdb_string_t string_p) {
 	static_assert(sizeof(duckdb_string_t) == sizeof(duckdb::string_t),
 	              "duckdb_string_t should have the same memory layout as duckdb::string_t");
-	auto &string = *(duckdb::string_t *)(&string_p);
+	auto &string = *reinterpret_cast<duckdb::string_t *>(&string_p);
 	return string.IsInlined();
+}
+
+uint32_t duckdb_string_t_length(duckdb_string_t string_p) {
+	static_assert(sizeof(duckdb_string_t) == sizeof(duckdb::string_t),
+	              "duckdb_string_t should have the same memory layout as duckdb::string_t");
+	auto &string = *reinterpret_cast<duckdb::string_t *>(&string_p);
+	return static_cast<uint32_t>(string.GetSize());
+}
+
+const char *duckdb_string_t_data(duckdb_string_t string_p) {
+	static_assert(sizeof(duckdb_string_t) == sizeof(duckdb::string_t),
+	              "duckdb_string_t should have the same memory layout as duckdb::string_t");
+	auto &string = *reinterpret_cast<duckdb::string_t *>(&string_p);
+	return string.GetData();
 }

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -358,8 +358,7 @@ bool DeprecatedMaterializeResult(duckdb_result *result) {
 	}
 
 	result->deprecated_row_count = materialized.RowCount();
-	if (result->deprecated_row_count > 0 &&
-	    materialized.properties.return_type == StatementReturnType::CHANGED_ROWS) {
+	if (result->deprecated_row_count > 0 && materialized.properties.return_type == StatementReturnType::CHANGED_ROWS) {
 		// update total changes
 		auto row_changes = materialized.GetValue(0, 0);
 		if (!row_changes.IsNull() && row_changes.DefaultTryCastAs(LogicalType::BIGINT)) {

--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -126,7 +126,7 @@ struct CDecimalConverter : public CBaseConverter {
 template <class SRC, class DST = SRC, class OP = CStandardConverter>
 void WriteData(duckdb_column *column, ColumnDataCollection &source, const vector<column_t> &column_ids) {
 	idx_t row = 0;
-	auto target = (DST *)column->__deprecated_data;
+	auto target = (DST *)column->deprecated_data;
 	for (auto &input : source.Chunks(column_ids)) {
 		auto source = FlatVector::GetData<SRC>(input.data[0]);
 		auto &mask = FlatVector::Validity(input.data[0]);
@@ -145,20 +145,20 @@ duckdb_state deprecated_duckdb_translate_column(MaterializedQueryResult &result,
 	D_ASSERT(!result.HasError());
 	auto &collection = result.Collection();
 	idx_t row_count = collection.Count();
-	column->__deprecated_nullmask = (bool *)duckdb_malloc(sizeof(bool) * collection.Count());
+	column->deprecated_nullmask = (bool *)duckdb_malloc(sizeof(bool) * collection.Count());
 
-	auto type_size = GetCTypeSize(column->__deprecated_type);
+	auto type_size = GetCTypeSize(column->deprecated_type);
 	if (type_size == 0) {
 		for (idx_t row_id = 0; row_id < row_count; row_id++) {
-			column->__deprecated_nullmask[row_id] = false;
+			column->deprecated_nullmask[row_id] = false;
 		}
 		// Unsupported type, e.g., a LIST. By returning DuckDBSuccess here,
 		// we allow filling other columns, and return NULL for all unsupported types.
 		return DuckDBSuccess;
 	}
 
-	column->__deprecated_data = duckdb_malloc(type_size * row_count);
-	if (!column->__deprecated_nullmask || !column->__deprecated_data) { // LCOV_EXCL_START
+	column->deprecated_data = duckdb_malloc(type_size * row_count);
+	if (!column->deprecated_nullmask || !column->deprecated_data) { // LCOV_EXCL_START
 		// malloc failure
 		return DuckDBError;
 	} // LCOV_EXCL_STOP
@@ -169,7 +169,7 @@ duckdb_state deprecated_duckdb_translate_column(MaterializedQueryResult &result,
 		idx_t row = 0;
 		for (auto &input : collection.Chunks(column_ids)) {
 			for (idx_t k = 0; k < input.size(); k++) {
-				column->__deprecated_nullmask[row++] = FlatVector::IsNull(input.data[0], k);
+				column->deprecated_nullmask[row++] = FlatVector::IsNull(input.data[0], k);
 			}
 		}
 	}
@@ -302,13 +302,13 @@ duckdb_state DuckDBTranslateResult(unique_ptr<QueryResult> result_p, duckdb_resu
 
 	if (result.HasError()) {
 		// write the error message
-		out->__deprecated_error_message = (char *)result.GetError().c_str(); // NOLINT
+		out->deprecated_error_message = (char *)result.GetError().c_str(); // NOLINT
 		return DuckDBError;
 	}
 	// copy the data
 	// first write the metadata
-	out->__deprecated_column_count = result.ColumnCount();
-	out->__deprecated_rows_changed = 0;
+	out->deprecated_column_count = result.ColumnCount();
+	out->deprecated_rows_changed = 0;
 	return DuckDBSuccess;
 }
 
@@ -335,8 +335,8 @@ bool DeprecatedMaterializeResult(duckdb_result *result) {
 	// materialize as deprecated result set
 	result_data->result_set_type = CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED;
 	auto column_count = result_data->result->ColumnCount();
-	result->__deprecated_columns = (duckdb_column *)duckdb_malloc(sizeof(duckdb_column) * column_count);
-	if (!result->__deprecated_columns) { // LCOV_EXCL_START
+	result->deprecated_columns = (duckdb_column *)duckdb_malloc(sizeof(duckdb_column) * column_count);
+	if (!result->deprecated_columns) { // LCOV_EXCL_START
 		// malloc failure
 		return DuckDBError;
 	} // LCOV_EXCL_STOP
@@ -351,25 +351,25 @@ bool DeprecatedMaterializeResult(duckdb_result *result) {
 
 	// convert the result to a materialized result
 	// zero initialize the columns (so we can cleanly delete it in case a malloc fails)
-	memset(result->__deprecated_columns, 0, sizeof(duckdb_column) * column_count);
+	memset(result->deprecated_columns, 0, sizeof(duckdb_column) * column_count);
 	for (idx_t i = 0; i < column_count; i++) {
-		result->__deprecated_columns[i].__deprecated_type = ConvertCPPTypeToC(result_data->result->types[i]);
-		result->__deprecated_columns[i].__deprecated_name = (char *)result_data->result->names[i].c_str(); // NOLINT
+		result->deprecated_columns[i].deprecated_type = ConvertCPPTypeToC(result_data->result->types[i]);
+		result->deprecated_columns[i].deprecated_name = (char *)result_data->result->names[i].c_str(); // NOLINT
 	}
 
-	result->__deprecated_row_count = materialized.RowCount();
-	if (result->__deprecated_row_count > 0 &&
+	result->deprecated_row_count = materialized.RowCount();
+	if (result->deprecated_row_count > 0 &&
 	    materialized.properties.return_type == StatementReturnType::CHANGED_ROWS) {
 		// update total changes
 		auto row_changes = materialized.GetValue(0, 0);
 		if (!row_changes.IsNull() && row_changes.DefaultTryCastAs(LogicalType::BIGINT)) {
-			result->__deprecated_rows_changed = NumericCast<idx_t>(row_changes.GetValue<int64_t>());
+			result->deprecated_rows_changed = NumericCast<idx_t>(row_changes.GetValue<int64_t>());
 		}
 	}
 
 	// Now write the data and skip any unsupported columns.
 	for (idx_t col = 0; col < column_count; col++) {
-		auto state = deprecated_duckdb_translate_column(materialized, &result->__deprecated_columns[col], col);
+		auto state = deprecated_duckdb_translate_column(materialized, &result->deprecated_columns[col], col);
 		if (state != DuckDBSuccess) {
 			return false;
 		}
@@ -470,37 +470,37 @@ duckdb_error_type CAPIErrorType(ExceptionType type) {
 } // namespace duckdb
 
 static void DuckdbDestroyColumn(duckdb_column column, idx_t count) {
-	if (column.__deprecated_data) {
-		if (column.__deprecated_type == DUCKDB_TYPE_VARCHAR) {
+	if (column.deprecated_data) {
+		if (column.deprecated_type == DUCKDB_TYPE_VARCHAR) {
 			// varchar, delete individual strings
-			auto data = reinterpret_cast<char **>(column.__deprecated_data);
+			auto data = reinterpret_cast<char **>(column.deprecated_data);
 			for (idx_t i = 0; i < count; i++) {
 				if (data[i]) {
 					duckdb_free(data[i]);
 				}
 			}
-		} else if (column.__deprecated_type == DUCKDB_TYPE_BLOB) {
+		} else if (column.deprecated_type == DUCKDB_TYPE_BLOB) {
 			// blob, delete individual blobs
-			auto data = reinterpret_cast<duckdb_blob *>(column.__deprecated_data);
+			auto data = reinterpret_cast<duckdb_blob *>(column.deprecated_data);
 			for (idx_t i = 0; i < count; i++) {
 				if (data[i].data) {
 					duckdb_free((void *)data[i].data);
 				}
 			}
 		}
-		duckdb_free(column.__deprecated_data);
+		duckdb_free(column.deprecated_data);
 	}
-	if (column.__deprecated_nullmask) {
-		duckdb_free(column.__deprecated_nullmask);
+	if (column.deprecated_nullmask) {
+		duckdb_free(column.deprecated_nullmask);
 	}
 }
 
 void duckdb_destroy_result(duckdb_result *result) {
-	if (result->__deprecated_columns) {
-		for (idx_t i = 0; i < result->__deprecated_column_count; i++) {
-			DuckdbDestroyColumn(result->__deprecated_columns[i], result->__deprecated_row_count);
+	if (result->deprecated_columns) {
+		for (idx_t i = 0; i < result->deprecated_column_count; i++) {
+			DuckdbDestroyColumn(result->deprecated_columns[i], result->deprecated_row_count);
 		}
-		duckdb_free(result->__deprecated_columns);
+		duckdb_free(result->deprecated_columns);
 	}
 	if (result->internal_data) {
 		auto result_data = reinterpret_cast<duckdb::DuckDBResultData *>(result->internal_data);
@@ -561,7 +561,7 @@ idx_t duckdb_rows_changed(duckdb_result *result) {
 	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result->internal_data));
 	if (result_data.result_set_type == duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED) {
 		// not a materialized result
-		return result->__deprecated_rows_changed;
+		return result->deprecated_rows_changed;
 	}
 	auto &materialized = reinterpret_cast<duckdb::MaterializedQueryResult &>(*result_data.result);
 	if (materialized.properties.return_type != duckdb::StatementReturnType::CHANGED_ROWS) {
@@ -576,23 +576,23 @@ idx_t duckdb_rows_changed(duckdb_result *result) {
 }
 
 void *duckdb_column_data(duckdb_result *result, idx_t col) {
-	if (!result || col >= result->__deprecated_column_count) {
+	if (!result || col >= result->deprecated_column_count) {
 		return nullptr;
 	}
 	if (!duckdb::DeprecatedMaterializeResult(result)) {
 		return nullptr;
 	}
-	return result->__deprecated_columns[col].__deprecated_data;
+	return result->deprecated_columns[col].deprecated_data;
 }
 
 bool *duckdb_nullmask_data(duckdb_result *result, idx_t col) {
-	if (!result || col >= result->__deprecated_column_count) {
+	if (!result || col >= result->deprecated_column_count) {
 		return nullptr;
 	}
 	if (!duckdb::DeprecatedMaterializeResult(result)) {
 		return nullptr;
 	}
-	return result->__deprecated_columns[col].__deprecated_nullmask;
+	return result->deprecated_columns[col].deprecated_nullmask;
 }
 
 const char *duckdb_result_error(duckdb_result *result) {

--- a/src/main/capi/scalar_function-c.cpp
+++ b/src/main/capi/scalar_function-c.cpp
@@ -22,6 +22,13 @@ struct CScalarFunctionInfo : public ScalarFunctionInfo {
 	duckdb_scalar_function_t function = nullptr;
 	duckdb_function_info extra_info = nullptr;
 	duckdb_delete_callback_t delete_callback = nullptr;
+};
+
+struct CScalarExecuteInfo {
+	explicit CScalarExecuteInfo(CScalarFunctionInfo &info) : info(info) {
+	}
+
+	CScalarFunctionInfo &info;
 	bool success = true;
 	string error;
 };
@@ -59,10 +66,12 @@ void CAPIScalarFunction(DataChunk &input, ExpressionState &state, Vector &result
 	input.Flatten();
 	auto c_input = reinterpret_cast<duckdb_data_chunk>(&input);
 	auto c_result = reinterpret_cast<duckdb_vector>(&result);
-	auto c_function_info = reinterpret_cast<duckdb_function_info>(&c_bind_info.info);
+
+	CScalarExecuteInfo exec_info(c_bind_info.info);
+	auto c_function_info = reinterpret_cast<duckdb_function_info>(&exec_info);
 	c_bind_info.info.function(c_function_info, c_input, c_result);
-	if (!c_bind_info.info.success) {
-		throw InvalidInputException(c_bind_info.info.error);
+	if (!exec_info.success) {
+		throw InvalidInputException(exec_info.error);
 	}
 	if (all_const) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
@@ -139,24 +148,24 @@ void duckdb_scalar_function_set_return_type(duckdb_scalar_function function, duc
 	scalar_function.return_type = *logical_type;
 }
 
-duckdb::CScalarFunctionInfo &GetCScalarFunctionInfo(duckdb_function_info info) {
+duckdb::CScalarExecuteInfo &GetCScalarExecInfo(duckdb_function_info info) {
 	D_ASSERT(info);
-	return *reinterpret_cast<duckdb::CScalarFunctionInfo *>(info);
+	return *reinterpret_cast<duckdb::CScalarExecuteInfo *>(info);
 }
 
 void *duckdb_scalar_function_get_extra_info(duckdb_function_info info) {
 	if (!info) {
 		return nullptr;
 	}
-	auto &scalar_function = GetCScalarFunctionInfo(info);
-	return scalar_function.extra_info;
+	auto &scalar_function = GetCScalarExecInfo(info);
+	return scalar_function.info.extra_info;
 }
 
 void duckdb_scalar_function_set_error(duckdb_function_info info, const char *error) {
 	if (!info || !error) {
 		return;
 	}
-	auto &scalar_function = GetCScalarFunctionInfo(info);
+	auto &scalar_function = GetCScalarExecInfo(info);
 	scalar_function.error = error;
 	scalar_function.success = false;
 }

--- a/src/main/capi/value-c.cpp
+++ b/src/main/capi/value-c.cpp
@@ -158,7 +158,7 @@ duckdb_string duckdb_value_string_internal(duckdb_result *result, idx_t col, idx
 }
 
 duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row) {
-	if (CanFetchValue(result, col, row) && result->__deprecated_columns[col].__deprecated_type == DUCKDB_TYPE_BLOB) {
+	if (CanFetchValue(result, col, row) && result->deprecated_columns[col].deprecated_type == DUCKDB_TYPE_BLOB) {
 		auto internal_result = UnsafeFetch<duckdb_blob>(result, col, row);
 
 		duckdb_blob result_blob;
@@ -174,5 +174,5 @@ bool duckdb_value_is_null(duckdb_result *result, idx_t col, idx_t row) {
 	if (!CanUseDeprecatedFetch(result, col, row)) {
 		return false;
 	}
-	return result->__deprecated_columns[col].__deprecated_nullmask[row];
+	return result->deprecated_columns[col].deprecated_nullmask[row];
 }

--- a/test/api/capi/CMakeLists.txt
+++ b/test/api/capi/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library_unity(
   test_sql_capi
   OBJECT
+  capi_aggregate_functions.cpp
   capi_scalar_functions.cpp
   capi_table_functions.cpp
   test_capi.cpp

--- a/test/api/capi/capi_aggregate_functions.cpp
+++ b/test/api/capi/capi_aggregate_functions.cpp
@@ -8,11 +8,11 @@ struct WeightedSumState {
 	uint64_t count;
 };
 
-idx_t WeightedSumSize() {
+idx_t WeightedSumSize(duckdb_function_info info) {
 	return sizeof(WeightedSumState);
 }
 
-void WeightedSumInit(duckdb_aggregate_state state_p) {
+void WeightedSumInit(duckdb_function_info info, duckdb_aggregate_state state_p) {
 	auto state = reinterpret_cast<WeightedSumState *>(state_p);
 	state->sum = 0;
 	state->count = 0;
@@ -140,11 +140,11 @@ struct RepeatedStringAggState {
 	idx_t size;
 };
 
-idx_t RepeatedStringAggSize() {
+idx_t RepeatedStringAggSize(duckdb_function_info info) {
 	return sizeof(RepeatedStringAggState);
 }
 
-void RepeatedStringAggInit(duckdb_aggregate_state state_p) {
+void RepeatedStringAggInit(duckdb_function_info info, duckdb_aggregate_state state_p) {
 	auto state = reinterpret_cast<RepeatedStringAggState *>(state_p);
 	state->data = nullptr;
 	state->size = 0;

--- a/test/api/capi/capi_aggregate_functions.cpp
+++ b/test/api/capi/capi_aggregate_functions.cpp
@@ -163,7 +163,7 @@ void RepeatedStringAggUpdate(duckdb_function_info info, duckdb_data_chunk input,
 	for (idx_t i = 0; i < row_count; i++) {
 		if (duckdb_validity_row_is_valid(input_validity, i) && duckdb_validity_row_is_valid(weight_validity, i)) {
 			auto length = duckdb_string_t_length(input_data[i]);
-			auto data = duckdb_string_t_data(input_data[i]);
+			auto data = duckdb_string_t_data(input_data + i);
 			auto weight = weight_data[i];
 			auto new_data = (char *)malloc(state[i]->size + length * weight + 1);
 			if (state[i]->size > 0) {

--- a/test/api/capi/capi_aggregate_functions.cpp
+++ b/test/api/capi/capi_aggregate_functions.cpp
@@ -161,24 +161,29 @@ void RepeatedStringAggUpdate(duckdb_function_info info, duckdb_data_chunk input,
 	auto weight_data = static_cast<int64_t *>(duckdb_vector_get_data(weight_vector));
 	auto weight_validity = duckdb_vector_get_validity(weight_vector);
 	for (idx_t i = 0; i < row_count; i++) {
-		if (duckdb_validity_row_is_valid(input_validity, i) && duckdb_validity_row_is_valid(weight_validity, i)) {
-			auto length = duckdb_string_t_length(input_data[i]);
-			auto data = duckdb_string_t_data(input_data + i);
-			auto weight = weight_data[i];
-			auto new_data = (char *)malloc(state[i]->size + length * weight + 1);
-			if (state[i]->size > 0) {
-				memcpy((void *)(new_data), state[i]->data, state[i]->size);
-				free((void *)(state[i]->data));
-			}
-			idx_t offset = state[i]->size;
-			for (idx_t rep_idx = 0; rep_idx < weight; rep_idx++) {
-				memcpy((void *)(new_data + offset), data, length);
-				offset += length;
-			}
-			state[i]->data = new_data;
-			state[i]->size = offset;
-			state[i]->data[state[i]->size] = '\0';
+		if (!duckdb_validity_row_is_valid(input_validity, i) || !duckdb_validity_row_is_valid(weight_validity, i)) {
+			continue;
 		}
+		auto length = duckdb_string_t_length(input_data[i]);
+		auto data = duckdb_string_t_data(input_data + i);
+		auto weight = weight_data[i];
+		auto new_data = (char *)malloc(state[i]->size + length * weight + 1);
+		if (state[i]->size > 0) {
+			memcpy((void *)(new_data), state[i]->data, state[i]->size);
+			free((void *)(state[i]->data));
+		}
+		if (weight < 0) {
+			duckdb_aggregate_function_set_error(info, "Weight must be >= 0");
+			return;
+		}
+		idx_t offset = state[i]->size;
+		for (idx_t rep_idx = 0; rep_idx < static_cast<idx_t>(weight); rep_idx++) {
+			memcpy((void *)(new_data + offset), data, length);
+			offset += length;
+		}
+		state[i]->data = new_data;
+		state[i]->size = offset;
+		state[i]->data[state[i]->size] = '\0';
 	}
 }
 
@@ -282,6 +287,8 @@ TEST_CASE("Test String Aggregate Function", "[capi]") {
 	result = tester.Query("SELECT repeated_string_agg(NULL, 2)");
 	REQUIRE_NO_FAIL(*result);
 	REQUIRE(result->IsNull(0, 0));
+
+	REQUIRE_FAIL(tester.Query("SELECT repeated_string_agg('x', -1)"));
 
 	result = tester.Query(
 	    "SELECT repeated_string_agg(CASE WHEN i%10=0 THEN i::VARCHAR ELSE '' END, 2) FROM range(100) t(i)");

--- a/test/api/capi/capi_aggregate_functions.cpp
+++ b/test/api/capi/capi_aggregate_functions.cpp
@@ -248,6 +248,8 @@ void RepeatedStringAggUpdate(duckdb_function_info info, duckdb_data_chunk input,
 		auto new_data = (char *)malloc(state[i]->size + length * weight + 1);
 		if (state[i]->size > 0) {
 			memcpy((void *)(new_data), state[i]->data, state[i]->size);
+		}
+		if (state[i]->data) {
 			free((void *)(state[i]->data));
 		}
 		if (weight < 0) {

--- a/test/api/capi/capi_aggregate_functions.cpp
+++ b/test/api/capi/capi_aggregate_functions.cpp
@@ -245,16 +245,16 @@ void RepeatedStringAggUpdate(duckdb_function_info info, duckdb_data_chunk input,
 		auto length = duckdb_string_t_length(input_data[i]);
 		auto data = duckdb_string_t_data(input_data + i);
 		auto weight = weight_data[i];
+		if (weight < 0) {
+			duckdb_aggregate_function_set_error(info, "Weight must be >= 0");
+			return;
+		}
 		auto new_data = (char *)malloc(state[i]->size + length * weight + 1);
 		if (state[i]->size > 0) {
 			memcpy((void *)(new_data), state[i]->data, state[i]->size);
 		}
 		if (state[i]->data) {
 			free((void *)(state[i]->data));
-		}
-		if (weight < 0) {
-			duckdb_aggregate_function_set_error(info, "Weight must be >= 0");
-			return;
 		}
 		idx_t offset = state[i]->size;
 		for (idx_t rep_idx = 0; rep_idx < static_cast<idx_t>(weight); rep_idx++) {

--- a/test/api/capi/capi_aggregate_functions.cpp
+++ b/test/api/capi/capi_aggregate_functions.cpp
@@ -1,0 +1,129 @@
+#include "capi_tester.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+struct WeightedSumState {
+	int64_t sum;
+	uint64_t count;
+};
+
+idx_t WeightedSumSize() {
+	return sizeof(WeightedSumState);
+}
+
+void WeightedSumInit(duckdb_aggregate_state state_p) {
+	auto state = reinterpret_cast<WeightedSumState *>(state_p);
+	state->sum = 0;
+	state->count = 0;
+}
+
+void WeightedSumUpdate(duckdb_function_info info, duckdb_data_chunk input, duckdb_aggregate_state *states) {
+	auto state = reinterpret_cast<WeightedSumState **>(states);
+	auto row_count = duckdb_data_chunk_get_size(input);
+	auto input_vector = duckdb_data_chunk_get_vector(input, 0);
+	auto input_data = static_cast<int64_t *>(duckdb_vector_get_data(input_vector));
+	auto input_validity = duckdb_vector_get_validity(input_vector);
+
+	auto weight_vector = duckdb_data_chunk_get_vector(input, 1);
+	auto weight_data = static_cast<int64_t *>(duckdb_vector_get_data(weight_vector));
+	auto weight_validity = duckdb_vector_get_validity(weight_vector);
+	for (idx_t i = 0; i < row_count; i++) {
+		if (duckdb_validity_row_is_valid(input_validity, i) && duckdb_validity_row_is_valid(weight_validity, i)) {
+			state[i]->sum += input_data[i] * weight_data[i];
+			state[i]->count++;
+		}
+	}
+}
+
+void WeightedSumCombine(duckdb_function_info info, duckdb_aggregate_state *source_p, duckdb_aggregate_state *target_p,
+                        idx_t count) {
+	auto source = reinterpret_cast<WeightedSumState **>(source_p);
+	auto target = reinterpret_cast<WeightedSumState **>(target_p);
+
+	for (idx_t i = 0; i < count; i++) {
+		target[i]->sum += source[i]->sum;
+		target[i]->count += source[i]->count;
+	}
+}
+
+void WeightedSumFinalize(duckdb_function_info info, duckdb_aggregate_state *source_p, duckdb_vector result, idx_t count,
+                         idx_t offset) {
+	auto source = reinterpret_cast<WeightedSumState **>(source_p);
+	auto result_data = static_cast<int64_t *>(duckdb_vector_get_data(result));
+	duckdb_vector_ensure_validity_writable(result);
+	auto result_validity = duckdb_vector_get_validity(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		if (source[i]->count == 0) {
+			duckdb_validity_set_row_invalid(result_validity, offset + i);
+		} else {
+			result_data[offset + i] = source[i]->sum;
+		}
+	}
+}
+
+static void CAPIRegisterWeightedSum(duckdb_connection connection, const char *name, duckdb_state expected_outcome) {
+	duckdb_state status;
+
+	// create a scalar function
+	auto function = duckdb_create_aggregate_function();
+	duckdb_aggregate_function_set_name(nullptr, name);
+	duckdb_aggregate_function_set_name(function, nullptr);
+	duckdb_aggregate_function_set_name(function, name);
+	duckdb_aggregate_function_set_name(function, name);
+
+	// add a two double parameters
+	auto type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+	duckdb_aggregate_function_add_parameter(nullptr, type);
+	duckdb_aggregate_function_add_parameter(function, nullptr);
+	duckdb_aggregate_function_add_parameter(function, type);
+	duckdb_aggregate_function_add_parameter(function, type);
+
+	// set the return type to double
+	duckdb_aggregate_function_set_return_type(nullptr, type);
+	duckdb_aggregate_function_set_return_type(function, nullptr);
+	duckdb_aggregate_function_set_return_type(function, type);
+	duckdb_destroy_logical_type(&type);
+
+	// set up the function
+	duckdb_aggregate_function_set_functions(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+	duckdb_aggregate_function_set_functions(function, nullptr, nullptr, nullptr, nullptr, nullptr);
+	duckdb_aggregate_function_set_functions(function, WeightedSumSize, WeightedSumInit, WeightedSumUpdate,
+	                                        WeightedSumCombine, WeightedSumFinalize);
+
+	// register and cleanup
+	status = duckdb_register_aggregate_function(connection, function);
+	REQUIRE(status == expected_outcome);
+
+	duckdb_destroy_aggregate_function(&function);
+	duckdb_destroy_aggregate_function(&function);
+	duckdb_destroy_aggregate_function(nullptr);
+}
+
+TEST_CASE("Test Aggregate Functions C API", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	CAPIRegisterWeightedSum(tester.connection, "my_weighted_sum", DuckDBSuccess);
+	// try to register it again - this should be an error
+	CAPIRegisterWeightedSum(tester.connection, "my_weighted_sum", DuckDBError);
+
+	// now call it
+	result = tester.Query("SELECT my_weighted_sum(40, 2)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 80);
+
+	result = tester.Query("SELECT my_weighted_sum(40, NULL)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->IsNull(0, 0));
+
+	result = tester.Query("SELECT my_weighted_sum(NULL, 2)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->IsNull(0, 0));
+
+	result = tester.Query("SELECT my_weighted_sum(i, 2) FROM range(100) t(i)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 9900);
+}

--- a/test/api/capi/capi_aggregate_functions.cpp
+++ b/test/api/capi/capi_aggregate_functions.cpp
@@ -279,6 +279,8 @@ void RepeatedStringAggCombine(duckdb_function_info info, duckdb_aggregate_state 
 		auto new_data = (char *)malloc(target[i]->size + source[i]->size + 1);
 		if (target[i]->size > 0) {
 			memcpy((void *)new_data, target[i]->data, target[i]->size);
+		}
+		if (target[i]->data) {
 			free((void *)target[i]->data);
 		}
 		memcpy((void *)(new_data + target[i]->size), source[i]->data, source[i]->size);

--- a/test/api/udf_function/udf_functions_to_test.hpp
+++ b/test/api/udf_function/udf_functions_to_test.hpp
@@ -442,12 +442,12 @@ struct UDFSum {
 	} sum_state_t;
 
 	template <class STATE>
-	static idx_t StateSize() {
+	static idx_t StateSize(const AggregateFunction &function) {
 		return sizeof(STATE);
 	}
 
 	template <class STATE>
-	static void Initialize(data_ptr_t state) {
+	static void Initialize(const AggregateFunction &function, data_ptr_t state) {
 		((STATE *)state)->value = 0;
 		((STATE *)state)->isset = false;
 	}


### PR DESCRIPTION
This PR adds initial support for aggregate functions to the C API. This allows aggregate functions to be defined and registered using only the C API, which in turn will enable these functions to be added using other APIs that build on top of the C API (e.g. Rust or Go).

These are the added callbacks that allow for creating and registering a function:

```cpp
duckdb_aggregate_function duckdb_create_aggregate_function();
void duckdb_destroy_aggregate_function(duckdb_aggregate_function *aggregate_function);
void duckdb_aggregate_function_set_name(duckdb_aggregate_function aggregate_function, const char *name);
void duckdb_aggregate_function_add_parameter(duckdb_aggregate_function aggregate_function,
                                                        duckdb_logical_type type);
void duckdb_aggregate_function_set_return_type(duckdb_aggregate_function aggregate_function,
                                                          duckdb_logical_type type);
void duckdb_aggregate_function_set_functions(duckdb_aggregate_function aggregate_function,
                                                        duckdb_aggregate_state_size state_size,
                                                        duckdb_aggregate_init_t state_init,
                                                        duckdb_aggregate_update_t update,
                                                        duckdb_aggregate_combine_t combine,
                                                        duckdb_aggregate_finalize_t finalize);
void duckdb_aggregate_function_set_destructor(duckdb_aggregate_function aggregate_function,
                                                         duckdb_aggregate_destroy_t destroy);
duckdb_state duckdb_register_aggregate_function(duckdb_connection con,
                                                           duckdb_aggregate_function aggregate_function);
void duckdb_aggregate_function_set_special_handling(duckdb_aggregate_function aggregate_function);
void duckdb_aggregate_function_set_extra_info(duckdb_aggregate_function aggregate_function, void *extra_info,
                                                         duckdb_delete_callback_t destroy);
void *duckdb_aggregate_function_get_extra_info(duckdb_function_info info);
void duckdb_aggregate_function_set_error(duckdb_function_info info, const char *error);
```

The C API aggregate functions themselves need to implement five different callbacks, plus one optional callback (for destroying any allocated state):

```cpp
//! Returns the aggregate state size
typedef idx_t (*duckdb_aggregate_state_size)(duckdb_function_info info);
//! Initialize the aggregate state
typedef void (*duckdb_aggregate_init_t)(duckdb_function_info info, duckdb_aggregate_state state);
//! Destroy aggregate state (optional)
typedef void (*duckdb_aggregate_destroy_t)(duckdb_aggregate_state *states, idx_t count);
//! Update a set of aggregate states with new values
typedef void (*duckdb_aggregate_update_t)(duckdb_function_info info, duckdb_data_chunk input,
                                          duckdb_aggregate_state *states);
//! Combine aggregate states
typedef void (*duckdb_aggregate_combine_t)(duckdb_function_info info, duckdb_aggregate_state *source,
                                           duckdb_aggregate_state *target, idx_t count);
//! Finalize aggregate states into a result vector
typedef void (*duckdb_aggregate_finalize_t)(duckdb_function_info info, duckdb_aggregate_state *source,
                                            duckdb_vector result, idx_t count, idx_t offset);
```
