### PR TITLE
Fix #13200: Transactions that update tables need to keep the underlying row group collection alive to ensure we can safely clean-up

### DIFF
--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/reference_map.hpp"
 
 namespace duckdb {
+class RowGroupCollection;
 class RowVersionManager;
 class DuckTransactionManager;
 class StorageLockKey;
@@ -76,6 +77,8 @@ public:
 		return write_lock.get();
 	}
 
+	void UpdateCollection(shared_ptr<RowGroupCollection> &collection);
+
 private:
 	DuckTransactionManager &transaction_manager;
 	//! The undo buffer is used to store old versions of rows that are updated
@@ -89,6 +92,8 @@ private:
 	mutex sequence_lock;
 	//! Map of all sequences that were used during the transaction and the value they had in this transaction
 	reference_map_t<SequenceCatalogEntry, reference<SequenceValue>> sequence_usage;
+	//! Collections that are updated by this transaction
+	reference_map_t<RowGroupCollection, shared_ptr<RowGroupCollection>> updated_collections;
 };
 
 } // namespace duckdb

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1335,13 +1335,14 @@ void DataTable::Update(TableUpdateState &state, ClientContext &context, Vector &
 
 	// otherwise global storage
 	if (n_global_update > 0) {
+		auto &transaction = DuckTransaction::Get(context, db);
 		updates_slice.Slice(updates, sel_global_update, n_global_update);
 		updates_slice.Flatten();
 		row_ids_slice.Slice(row_ids, sel_global_update, n_global_update);
 		row_ids_slice.Flatten(n_global_update);
 
-		row_groups->Update(DuckTransaction::Get(context, db), FlatVector::GetData<row_t>(row_ids_slice), column_ids,
-		                   updates_slice);
+		transaction.UpdateCollection(row_groups);
+		row_groups->Update(transaction, FlatVector::GetData<row_t>(row_ids_slice), column_ids, updates_slice);
 	}
 }
 

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -142,6 +142,16 @@ void DuckTransaction::PushSequenceUsage(SequenceCatalogEntry &sequence, const Se
 	}
 }
 
+void DuckTransaction::UpdateCollection(shared_ptr<RowGroupCollection> &collection) {
+	auto collection_ref = reference<RowGroupCollection>(*collection);
+	auto entry = updated_collections.find(collection_ref);
+	if (entry != updated_collections.end()) {
+		// already exists
+		return;
+	}
+	updated_collections.insert(make_pair(collection_ref, collection));
+}
+
 bool DuckTransaction::ChangesMade() {
 	return undo_buffer.ChangesMade() || storage->ChangesMade();
 }

--- a/test/sql/parallelism/interquery/concurrent_update_drop.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_update_drop.test_slow
@@ -1,0 +1,21 @@
+# name: test/sql/parallelism/interquery/concurrent_update_drop.test_slow
+# description: Test concurrent updates and drops
+# group: [interquery]
+
+statement ok
+CREATE TABLE t1(i INTEGER)
+
+statement ok
+INSERT INTO t1 VALUES (1), (2), (3)
+
+concurrentloop threadid 0 2
+
+onlyif threadid=0
+statement ok
+UPDATE t1 SET i = 4 WHERE i = 2
+
+onlyif threadid=1
+statement ok
+DROP TABLE t1
+
+endloop


### PR DESCRIPTION
Fixes #13200 

Clean-up of transactions with updates is postponed as other transactions can still rely on the old values that are present in the update segments. This clean-up could run into problems if another transaction would drop the table in the mean-time. In order to ensure the clean-up can safely proceed, we keep a reference to the row group collection for any transaction that does an update.