### PR TITLE
Rename FORCE_CHECKPOINT to ALWAYS_CHECKPOINT

### DIFF
--- a/src/include/duckdb/common/enums/checkpoint_type.hpp
+++ b/src/include/duckdb/common/enums/checkpoint_type.hpp
@@ -22,8 +22,8 @@ enum class CheckpointWALAction {
 enum class CheckpointAction {
 	//! Checkpoint only if a checkpoint is required (i.e. the WAL has data in it that can be flushed)
 	CHECKPOINT_IF_REQUIRED,
-	//! Force a checkpoint regardless of whether or not there is data in the WAL to flush
-	FORCE_CHECKPOINT
+	//! Always checkpoint regardless of whether or not there is data in the WAL to flush
+	ALWAYS_CHECKPOINT
 };
 
 enum class CheckpointType {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -297,7 +297,7 @@ void SingleFileStorageManager::CreateCheckpoint(CheckpointOptions options) {
 		db.GetStorageExtension()->OnCheckpointStart(db, options);
 	}
 	auto &config = DBConfig::Get(db);
-	if (GetWALSize() > 0 || config.options.force_checkpoint || options.action == CheckpointAction::FORCE_CHECKPOINT) {
+	if (GetWALSize() > 0 || config.options.force_checkpoint || options.action == CheckpointAction::ALWAYS_CHECKPOINT) {
 		// we only need to checkpoint if there is anything in the WAL
 		try {
 			SingleFileCheckpointWriter checkpointer(db, *block_manager, options.type);

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -280,7 +280,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 		tlock.unlock();
 		// checkpoint the database to disk
 		CheckpointOptions options;
-		options.action = CheckpointAction::FORCE_CHECKPOINT;
+		options.action = CheckpointAction::ALWAYS_CHECKPOINT;
 		options.type = checkpoint_decision.type;
 		auto &storage_manager = db.GetStorageManager();
 		storage_manager.CreateCheckpoint(options);


### PR DESCRIPTION
`FORCE CHECKPOINT` currently has two meanings - renaming this enum to `ALWAYS_CHECKPOINT` adds clarity