### PR TITLE
Fix foreign key lookups from different search path

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -519,7 +519,7 @@ void DataTable::VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk,
 	}
 
 	auto &table_entry_ptr =
-	    Catalog::GetEntry<TableCatalogEntry>(context, INVALID_CATALOG, bfk.info.schema, bfk.info.table);
+	    Catalog::GetEntry<TableCatalogEntry>(context, db.GetName(), bfk.info.schema, bfk.info.table);
 	// make the data chunk to check
 	vector<LogicalType> types;
 	for (auto &col : table_entry_ptr.GetColumns().Physical()) {

--- a/test/sql/attach/attach_foreign_key.test
+++ b/test/sql/attach/attach_foreign_key.test
@@ -14,3 +14,25 @@ statement error
 CREATE TABLE db1.song(songid INTEGER, songartist INTEGER, songalbum TEXT, songname TEXT, FOREIGN KEY(songartist, songalbum) REFERENCES album(artistid, albumname));
 ----
 across different schemas or catalogs
+
+statement ok
+USE db1;
+
+statement ok
+CREATE TABLE album(artistid INTEGER, albumname TEXT, albumcover TEXT, UNIQUE (artistid, albumname));
+
+statement ok
+INSERT INTO album VALUES (1, 'A', 'A_cover'), (2, 'B', 'B_cover'), (3, 'C', 'C_cover'), (4, 'D', 'D_cover');
+
+statement ok
+CREATE TABLE song(songid INTEGER, songartist INTEGER, songalbum TEXT, songname TEXT, FOREIGN KEY(songartist, songalbum) REFERENCES album(artistid, albumname));
+
+statement ok
+ATTACH DATABASE ':memory:' AS db2;
+
+statement ok
+USE db2;
+
+# check that foreign key is correctly resolved even when different catalog search path is used
+statement ok
+INSERT INTO db1.song VALUES (11, 1, 'A', 'A_song'), (12, 2, 'B', 'B_song'), (13, 3, 'C', 'C_song');


### PR DESCRIPTION
Foreign key lookups are resolved using the current search path rather than the correct catalog.

Take the following example:

```
D attach ':memory:' as db1;
D attach ':memory:' as db2;
D use db1;
D CREATE TABLE pk_integers(i INTEGER PRIMARY KEY);
D INSERT INTO pk_integers VALUES (1), (2), (3);
D CREATE TABLE fk_integers(j INTEGER, FOREIGN KEY (j) REFERENCES pk_integers(i));
D use db2;
D INSERT INTO db1.fk_integers VALUES (1), (2);
Catalog Error: Table with name pk_integers does not exist!
Did you mean "db1.pk_integers"?
```

This PR fixes the issue by using the catalog of the table that has the foreign key constraint rather than going by search path.