### PR TITLE
Move to latest duckdb-wasm (fixing COI compilation)

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -24,7 +24,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  DUCKDB_WASM_VERSION: "66a481954b89a046cb7c48c448163ea5e9179199"
+  DUCKDB_WASM_VERSION: "cf2048bd6d669ffa05c56d7d453e09e99de8b87e"
   CCACHE_SAVE: ${{ github.repository != 'duckdb/duckdb' }}
   BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref, '_feature') && 'feature' || 'main') }}
 


### PR DESCRIPTION
This fixes the nightly test, that test main duckdb vs a fixed duckdb-wasm version.

Bumping to current main for duckdb-wasm to incorporate https://github.com/duckdb/duckdb-wasm/pull/1803