### PR TITLE
Implement #4318: add overload for pg_get_constraintdef

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -58,7 +58,8 @@ static const DefaultMacro internal_macros[] = {
 
 	// various postgres system functions
 	{"pg_catalog", "pg_get_viewdef", {"oid", nullptr}, "(select sql from duckdb_views() v where v.view_oid=oid)"},
-	{"pg_catalog", "pg_get_constraintdef", {"constraint_oid", "pretty_bool", nullptr}, "(select constraint_text from duckdb_constraints() d_constraint where d_constraint.table_oid=constraint_oid//1000000 and d_constraint.constraint_index=constraint_oid%1000000)"},
+	{"pg_catalog", "pg_get_constraintdef", {"constraint_oid", nullptr}, "(select constraint_text from duckdb_constraints() d_constraint where d_constraint.table_oid=constraint_oid//1000000 and d_constraint.constraint_index=constraint_oid%1000000)"},
+	{"pg_catalog", "pg_get_constraintdef", {"constraint_oid", "pretty_bool", nullptr}, "pg_get_constraintdef(constraint_oid)"},
 	{"pg_catalog", "pg_get_expr", {"pg_node_tree", "relation_oid", nullptr}, "pg_node_tree"},
 	{"pg_catalog", "format_pg_type", {"logical_type", "type_name", nullptr}, "case upper(logical_type) when 'FLOAT' then 'float4' when 'DOUBLE' then 'float8' when 'DECIMAL' then 'numeric' when 'ENUM' then lower(type_name) when 'VARCHAR' then 'varchar' when 'BLOB' then 'bytea' when 'TIMESTAMP' then 'timestamp' when 'TIME' then 'time' when 'TIMESTAMP WITH TIME ZONE' then 'timestamptz' when 'TIME WITH TIME ZONE' then 'timetz' when 'SMALLINT' then 'int2' when 'INTEGER' then 'int4' when 'BIGINT' then 'int8' when 'BOOLEAN' then 'bool' else lower(logical_type) end"},
 	{"pg_catalog", "format_type", {"type_oid", "typemod", nullptr}, "(select format_pg_type(logical_type, type_name) from duckdb_types() t where t.type_oid=type_oid) || case when typemod>0 then concat('(', typemod//1000, ',', typemod%1000, ')') else '' end"},

--- a/test/sql/pg_catalog/sqlalchemy.test
+++ b/test/sql/pg_catalog/sqlalchemy.test
@@ -212,7 +212,7 @@ FROM
 	t.oid = (SELECT MIN(table_oid) FROM duckdb_tables) and ix.indisprimary = 't'
 ORDER BY a.attnum
 
-mode skip
+
 # get_pk_constraint, >= v8.4
 statement ok
 SELECT a.attname
@@ -224,8 +224,6 @@ FROM pg_attribute a JOIN (
 	) k ON a.attnum=k.attnum
 WHERE a.attrelid = (SELECT MIN(table_oid) FROM duckdb_tables)
 ORDER BY k.ord
-
-mode unskip
 
 # get_foreign_keys
 statement ok
@@ -330,21 +328,23 @@ WHERE
 	pgd.objsubid = 0 AND
 	pgd.objoid = (SELECT MIN(table_oid) FROM duckdb_tables)
 
-# get_check_constraints
-mode skip
 
-# FIXME: pg_get_constraintdef overload
 statement ok
+CREATE TABLE check_constraint_tbl (
+	i INTEGER CHECK (i < 42)
+);
+
+# get_check_constraints
+query II
 SELECT
 	cons.conname as name,
 	pg_get_constraintdef(cons.oid) as src
 FROM
 	pg_catalog.pg_constraint cons
 WHERE
-	cons.conrelid = (SELECT MIN(table_oid) FROM duckdb_tables) AND
 	cons.contype = 'c'
-
-mode unskip
+----
+CHECK((i < 42))	CHECK((i < 42))
 
 # load_enums
 query IIII


### PR DESCRIPTION
Implements #4318 

Now that we support macro overloads (since https://github.com/duckdb/duckdb/pull/13062) we can implement this overload as well, enabling additional SQLAlchemy functionality.