### PR TITLE
Correctly add profiling information from finalize events to operator timings in EXPLAIN ANALYZE

### DIFF
--- a/.github/patches/extensions/vss/default_block_size.patch
+++ b/.github/patches/extensions/vss/default_block_size.patch
@@ -1,5 +1,5 @@
 diff --git a/src/hnsw/hnsw_index.cpp b/src/hnsw/hnsw_index.cpp
-index 6878607..f662803 100644
+index 012a8ea..a4b4923 100644
 --- a/src/hnsw/hnsw_index.cpp
 +++ b/src/hnsw/hnsw_index.cpp
 @@ -14,7 +14,7 @@ namespace duckdb {
@@ -11,3 +11,35 @@ index 6878607..f662803 100644
  	static constexpr const idx_t BLOCK_DATA_SIZE = BLOCK_SIZE - sizeof(IndexPointer);
  	static_assert(BLOCK_SIZE > sizeof(IndexPointer), "Block size must be larger than the size of an IndexPointer");
  
+diff --git a/src/hnsw/hnsw_index_physical_create.cpp b/src/hnsw/hnsw_index_physical_create.cpp
+index fa771c0..7327663 100644
+--- a/src/hnsw/hnsw_index_physical_create.cpp
++++ b/src/hnsw/hnsw_index_physical_create.cpp
+@@ -34,6 +34,9 @@ PhysicalCreateHNSWIndex::PhysicalCreateHNSWIndex(LogicalOperator &op, TableCatal
+ //-------------------------------------------------------------
+ class CreateHNSWIndexGlobalState final : public GlobalSinkState {
+ public:
++	CreateHNSWIndexGlobalState(const PhysicalOperator &op_p) : op(op_p) {}
++
++	const PhysicalOperator &op;
+ 	//! Global index to be added to the table
+ 	unique_ptr<HNSWIndex> global_index;
+ 
+@@ -51,7 +54,7 @@ public:
+ };
+ 
+ unique_ptr<GlobalSinkState> PhysicalCreateHNSWIndex::GetGlobalSinkState(ClientContext &context) const {
+-	auto gstate = make_uniq<CreateHNSWIndexGlobalState>();
++	auto gstate = make_uniq<CreateHNSWIndexGlobalState>(*this);
+ 
+ 	vector<LogicalType> data_types = {unbound_expressions[0]->return_type, LogicalType::ROW_TYPE};
+ 	gstate->collection = make_uniq<ColumnDataCollection>(BufferManager::GetBufferManager(context), data_types);
+@@ -131,7 +134,7 @@ class HNSWIndexConstructTask final : public ExecutorTask {
+ public:
+ 	HNSWIndexConstructTask(shared_ptr<Event> event_p, ClientContext &context, CreateHNSWIndexGlobalState &gstate_p,
+ 	                       size_t thread_id_p)
+-	    : ExecutorTask(context, std::move(event_p)), gstate(gstate_p), thread_id(thread_id_p), local_scan_state() {
++	    : ExecutorTask(context, std::move(event_p), gstate_p.op), gstate(gstate_p), thread_id(thread_id_p), local_scan_state() {
+ 		// Initialize the scan chunk
+ 		gstate.collection->InitializeScanChunk(scan_chunk);
+ 	}

--- a/src/common/sort/partition_state.cpp
+++ b/src/common/sort/partition_state.cpp
@@ -579,8 +579,8 @@ PartitionGlobalMergeStates::PartitionGlobalMergeStates(PartitionGlobalSinkState 
 class PartitionMergeTask : public ExecutorTask {
 public:
 	PartitionMergeTask(shared_ptr<Event> event_p, ClientContext &context_p, PartitionGlobalMergeStates &hash_groups_p,
-	                   PartitionGlobalSinkState &gstate)
-	    : ExecutorTask(context_p, std::move(event_p)), local_state(gstate), hash_groups(hash_groups_p) {
+	                   PartitionGlobalSinkState &gstate, const PhysicalOperator &op)
+	    : ExecutorTask(context_p, std::move(event_p), op), local_state(gstate), hash_groups(hash_groups_p) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
@@ -680,7 +680,7 @@ void PartitionMergeEvent::Schedule() {
 
 	vector<shared_ptr<Task>> merge_tasks;
 	for (idx_t tnum = 0; tnum < num_threads; tnum++) {
-		merge_tasks.emplace_back(make_uniq<PartitionMergeTask>(shared_from_this(), context, merge_states, gstate));
+		merge_tasks.emplace_back(make_uniq<PartitionMergeTask>(shared_from_this(), context, merge_states, gstate, op));
 	}
 	SetTasks(std::move(merge_tasks));
 }

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -299,7 +299,7 @@ SinkFinalizeType PhysicalWindow::Finalize(Pipeline &pipeline, Event &event, Clie
 	}
 
 	// Schedule all the sorts for maximum thread utilisation
-	auto new_event = make_shared_ptr<PartitionMergeEvent>(*state.global_partition, pipeline);
+	auto new_event = make_shared_ptr<PartitionMergeEvent>(*state.global_partition, pipeline, *this);
 	event.InsertEvent(std::move(new_event));
 
 	return SinkFinalizeType::READY;

--- a/src/execution/operator/join/physical_asof_join.cpp
+++ b/src/execution/operator/join/physical_asof_join.cpp
@@ -169,7 +169,7 @@ SinkFinalizeType PhysicalAsOfJoin::Finalize(Pipeline &pipeline, Event &event, Cl
 	}
 
 	// Schedule all the sorts for maximum thread utilisation
-	auto new_event = make_shared_ptr<PartitionMergeEvent>(gstate.rhs_sink, pipeline);
+	auto new_event = make_shared_ptr<PartitionMergeEvent>(gstate.rhs_sink, pipeline, *this);
 	event.InsertEvent(std::move(new_event));
 
 	return SinkFinalizeType::READY;

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -87,13 +87,13 @@ public:
 		lhs_layout.Initialize(op.children[0]->types);
 		vector<BoundOrderByNode> lhs_order;
 		lhs_order.emplace_back(op.lhs_orders[0].Copy());
-		tables[0] = make_uniq<GlobalSortedTable>(context, lhs_order, lhs_layout);
+		tables[0] = make_uniq<GlobalSortedTable>(context, lhs_order, lhs_layout, op);
 
 		RowLayout rhs_layout;
 		rhs_layout.Initialize(op.children[1]->types);
 		vector<BoundOrderByNode> rhs_order;
 		rhs_order.emplace_back(op.rhs_orders[0].Copy());
-		tables[1] = make_uniq<GlobalSortedTable>(context, rhs_order, rhs_layout);
+		tables[1] = make_uniq<GlobalSortedTable>(context, rhs_order, rhs_layout, op);
 	}
 
 	IEJoinGlobalState(IEJoinGlobalState &prev)
@@ -389,7 +389,7 @@ IEJoinUnion::IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, Sorte
 	vector<BoundOrderByNode> orders;
 	orders.emplace_back(order1.type, order1.null_order, std::move(ref));
 
-	l1 = make_uniq<SortedTable>(context, orders, payload_layout);
+	l1 = make_uniq<SortedTable>(context, orders, payload_layout, op);
 
 	// LHS has positive rids
 	ExpressionExecutor l_executor(context);
@@ -432,7 +432,7 @@ IEJoinUnion::IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, Sorte
 	ExpressionExecutor executor(context);
 	executor.AddExpression(*orders[0].expression);
 
-	l2 = make_uniq<SortedTable>(context, orders, payload_layout);
+	l2 = make_uniq<SortedTable>(context, orders, payload_layout, op);
 	for (idx_t base = 0, block_idx = 0; block_idx < l1->BlockCount(); ++block_idx) {
 		base += AppendKey(*l1, executor, *l2, 1, NumericCast<int64_t>(base), block_idx);
 	}

--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -76,7 +76,7 @@ public:
 		rhs_layout.Initialize(op.children[1]->types);
 		vector<BoundOrderByNode> rhs_order;
 		rhs_order.emplace_back(op.rhs_orders[0].Copy());
-		table = make_uniq<GlobalSortedTable>(context, rhs_order, rhs_layout);
+		table = make_uniq<GlobalSortedTable>(context, rhs_order, rhs_layout, op);
 	}
 
 	inline idx_t Count() const {

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -59,9 +59,9 @@ void PhysicalRangeJoin::LocalSortedTable::Sink(DataChunk &input, GlobalSortState
 }
 
 PhysicalRangeJoin::GlobalSortedTable::GlobalSortedTable(ClientContext &context, const vector<BoundOrderByNode> &orders,
-                                                        RowLayout &payload_layout)
-    : global_sort_state(BufferManager::GetBufferManager(context), orders, payload_layout), has_null(0), count(0),
-      memory_per_thread(0) {
+                                                        RowLayout &payload_layout, const PhysicalOperator &op_p)
+    : op(op_p), global_sort_state(BufferManager::GetBufferManager(context), orders, payload_layout), has_null(0),
+      count(0), memory_per_thread(0) {
 	D_ASSERT(orders.size() == 1);
 
 	// Set external (can be forced with the PRAGMA)
@@ -91,7 +91,7 @@ public:
 
 public:
 	RangeJoinMergeTask(shared_ptr<Event> event_p, ClientContext &context, GlobalSortedTable &table)
-	    : ExecutorTask(context, std::move(event_p)), context(context), table(table) {
+	    : ExecutorTask(context, std::move(event_p), table.op), context(context), table(table) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {

--- a/src/execution/operator/order/physical_order.cpp
+++ b/src/execution/operator/order/physical_order.cpp
@@ -22,9 +22,10 @@ PhysicalOrder::PhysicalOrder(vector<LogicalType> types, vector<BoundOrderByNode>
 class OrderGlobalSinkState : public GlobalSinkState {
 public:
 	OrderGlobalSinkState(BufferManager &buffer_manager, const PhysicalOrder &order, RowLayout &payload_layout)
-	    : global_sort_state(buffer_manager, order.orders, payload_layout) {
+	    : order(order), global_sort_state(buffer_manager, order.orders, payload_layout) {
 	}
 
+	const PhysicalOrder &order;
 	//! Global sort state
 	GlobalSortState global_sort_state;
 	//! Memory usage per thread
@@ -112,8 +113,9 @@ SinkCombineResultType PhysicalOrder::Combine(ExecutionContext &context, Operator
 
 class PhysicalOrderMergeTask : public ExecutorTask {
 public:
-	PhysicalOrderMergeTask(shared_ptr<Event> event_p, ClientContext &context, OrderGlobalSinkState &state)
-	    : ExecutorTask(context, std::move(event_p)), context(context), state(state) {
+	PhysicalOrderMergeTask(shared_ptr<Event> event_p, ClientContext &context, OrderGlobalSinkState &state,
+	                       const PhysicalOperator &op_p)
+	    : ExecutorTask(context, std::move(event_p), op_p), context(context), state(state) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
@@ -132,11 +134,12 @@ private:
 
 class OrderMergeEvent : public BasePipelineEvent {
 public:
-	OrderMergeEvent(OrderGlobalSinkState &gstate_p, Pipeline &pipeline_p)
-	    : BasePipelineEvent(pipeline_p), gstate(gstate_p) {
+	OrderMergeEvent(OrderGlobalSinkState &gstate_p, Pipeline &pipeline_p, const PhysicalOperator &op_p)
+	    : BasePipelineEvent(pipeline_p), gstate(gstate_p), op(op_p) {
 	}
 
 	OrderGlobalSinkState &gstate;
+	const PhysicalOperator &op;
 
 public:
 	void Schedule() override {
@@ -148,7 +151,7 @@ public:
 
 		vector<shared_ptr<Task>> merge_tasks;
 		for (idx_t tnum = 0; tnum < num_threads; tnum++) {
-			merge_tasks.push_back(make_uniq<PhysicalOrderMergeTask>(shared_from_this(), context, gstate));
+			merge_tasks.push_back(make_uniq<PhysicalOrderMergeTask>(shared_from_this(), context, gstate, op));
 		}
 		SetTasks(std::move(merge_tasks));
 	}
@@ -187,7 +190,7 @@ SinkFinalizeType PhysicalOrder::Finalize(Pipeline &pipeline, Event &event, Clien
 void PhysicalOrder::ScheduleMergeTasks(Pipeline &pipeline, Event &event, OrderGlobalSinkState &state) {
 	// Initialize global sort state for a round of merging
 	state.global_sort_state.InitializeMergeRound();
-	auto new_event = make_shared_ptr<OrderMergeEvent>(state, pipeline);
+	auto new_event = make_shared_ptr<OrderMergeEvent>(state, pipeline, state.order);
 	event.InsertEvent(std::move(new_event));
 }
 

--- a/src/include/duckdb/common/sort/partition_state.hpp
+++ b/src/include/duckdb/common/sort/partition_state.hpp
@@ -232,12 +232,13 @@ public:
 
 class PartitionMergeEvent : public BasePipelineEvent {
 public:
-	PartitionMergeEvent(PartitionGlobalSinkState &gstate_p, Pipeline &pipeline_p)
-	    : BasePipelineEvent(pipeline_p), gstate(gstate_p), merge_states(gstate_p) {
+	PartitionMergeEvent(PartitionGlobalSinkState &gstate_p, Pipeline &pipeline_p, const PhysicalOperator &op_p)
+	    : BasePipelineEvent(pipeline_p), gstate(gstate_p), merge_states(gstate_p), op(op_p) {
 	}
 
 	PartitionGlobalSinkState &gstate;
 	PartitionGlobalMergeStates merge_states;
+	const PhysicalOperator &op;
 
 public:
 	void Schedule() override;

--- a/src/include/duckdb/execution/operator/join/physical_range_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_range_join.hpp
@@ -50,7 +50,8 @@ public:
 
 	class GlobalSortedTable {
 	public:
-		GlobalSortedTable(ClientContext &context, const vector<BoundOrderByNode> &orders, RowLayout &payload_layout);
+		GlobalSortedTable(ClientContext &context, const vector<BoundOrderByNode> &orders, RowLayout &payload_layout,
+		                  const PhysicalOperator &op);
 
 		inline idx_t Count() const {
 			return count;
@@ -77,6 +78,8 @@ public:
 		//! Schedules tasks to merge sort the current child's data during a Finalize phase
 		void ScheduleMergeTasks(Pipeline &pipeline, Event &event);
 
+		//! The hosting operator
+		const PhysicalOperator &op;
 		GlobalSortState global_sort_state;
 		//! Whether or not the RHS has NULL values
 		atomic<idx_t> has_null;

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -29,6 +29,7 @@
 namespace duckdb {
 class ClientContext;
 class ExpressionExecutor;
+class ProfilingNode;
 class PhysicalOperator;
 class SQLStatement;
 

--- a/src/include/duckdb/parallel/executor_task.hpp
+++ b/src/include/duckdb/parallel/executor_task.hpp
@@ -12,13 +12,14 @@
 #include "duckdb/parallel/event.hpp"
 
 namespace duckdb {
+class ThreadContext;
 
 //! Execute a task within an executor, including exception handling
 //! This should be used within queries
 class ExecutorTask : public Task {
 public:
 	ExecutorTask(Executor &executor, shared_ptr<Event> event);
-	ExecutorTask(ClientContext &context, shared_ptr<Event> event);
+	ExecutorTask(ClientContext &context, shared_ptr<Event> event, const PhysicalOperator &op);
 	~ExecutorTask() override;
 
 public:
@@ -28,6 +29,8 @@ public:
 public:
 	Executor &executor;
 	shared_ptr<Event> event;
+	unique_ptr<ThreadContext> thread_context;
+	optional_ptr<const PhysicalOperator> op;
 
 public:
 	virtual TaskExecutionResult ExecuteTask(TaskExecutionMode mode) = 0;

--- a/src/include/duckdb/parallel/executor_task.hpp
+++ b/src/include/duckdb/parallel/executor_task.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/parallel/event.hpp"
 
 namespace duckdb {
+class PhysicalOperator;
 class ThreadContext;
 
 //! Execute a task within an executor, including exception handling

--- a/src/include/duckdb/parallel/executor_task.hpp
+++ b/src/include/duckdb/parallel/executor_task.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/parallel/task.hpp"
 #include "duckdb/parallel/event.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 
 namespace duckdb {
 class PhysicalOperator;


### PR DESCRIPTION
Previously timings of finalize tasks (such as finalizing hash tables, merge rounds in order by, etc) were not included in the `EXPLAIN ANALYZE`. These tasks can take a considerable amount of time depending on the workload. This PR extends the `ExecutorTask` so it correctly measures the timing and adds it to the corresponding operator.