### PR TITLE
Issue #13250: Zero Time Buckets

### DIFF
--- a/test/sql/function/timestamp/test_icu_time_bucket_timestamptz.test
+++ b/test/sql/function/timestamp/test_icu_time_bucket_timestamptz.test
@@ -1169,6 +1169,11 @@ statement error
 select time_bucket('1 microseconds'::interval, '294247-01-10 04:00:54.775+00'::timestamptz);
 ----
 
+statement error
+SELECT TIME_BUCKET(CAST('0.' AS INTERVAL), CAST('2000-01-01 00:00:00+00' AS TIMESTAMPTZ));
+----
+Can't bucket using zero days
+
 query I
 select time_bucket('1 microseconds'::interval, '294247-01-10 04:00:54.774999+00'::timestamptz);
 ----


### PR DESCRIPTION
Throw an error if we try to bucket with a zero-width interval.

fixes: duckdb/duckdb#13250
fixes: duckdblabs/duckdb-internal#2669