### PR TITLE
Fix casts logic

### DIFF
--- a/src/core_functions/scalar/math/numeric.cpp
+++ b/src/core_functions/scalar/math/numeric.cpp
@@ -516,7 +516,7 @@ struct RoundOperatorPrecision {
 				return input;
 			}
 		}
-		return UnsafeNumericCast<TR>(rounded_value);
+		return LossyNumericCast<TR>(rounded_value);
 	}
 };
 
@@ -527,7 +527,7 @@ struct RoundOperator {
 		if (std::isinf(rounded_value) || std::isnan(rounded_value)) {
 			return input;
 		}
-		return UnsafeNumericCast<TR>(rounded_value);
+		return LossyNumericCast<TR>(rounded_value);
 	}
 };
 

--- a/src/include/duckdb/common/numeric_utils.hpp
+++ b/src/include/duckdb/common/numeric_utils.hpp
@@ -138,17 +138,17 @@ TO UnsafeNumericCast(FROM in) {
 template <class TO>
 TO UnsafeNumericCast(double val) {
 #ifdef DEBUG
-	return LossyNumericCast<TO>(val);
-#endif
 	return NumericCast<TO>(val);
+#endif
+	return LossyNumericCast<TO>(val);
 }
 
 template <class TO>
 TO UnsafeNumericCast(float val) {
 #ifdef DEBUG
-	return LossyNumericCast<TO>(val);
-#endif
 	return NumericCast<TO>(val);
+#endif
+	return LossyNumericCast<TO>(val);
 }
 
 } // namespace duckdb

--- a/test/sql/types/decimal/test_decimal_ops.test
+++ b/test/sql/types/decimal/test_decimal_ops.test
@@ -370,3 +370,8 @@ query I
 SELECT (SELECT '1.0'::DECIMAL(2,1));
 ----
 1.0
+
+query I
+SELECT ROUND(CAST(CAST('-100.3' AS DECIMAL(18, 1)) AS REAL), 1);
+----
+-100.3


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/13226

Couple of mistakes on top of each other, independent, fixed both.

Brief recap on the situation of the casts AFTER this PR:

* NumericCast is a checked cast, meaning that, roughly speaking, it should be invertible
* UnsafeNumericCast is equivalent to NumericCast when DEBUG or it's a static_cast
* LossyNumericCast, that takes only float/double (for now, probably will be expanded for all types) is equivalent to static_cast

Note that UnsafeNumericCast is still requires to be information preserving, but will not be checked in the configuration we care the most that is Release.