### PR TITLE
[TemporaryFileManager] Fix bug causing sizes of `.block` files to not be counted towards `max_temp_directory_size`

### DIFF
--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -525,8 +525,9 @@ void StandardBufferManager::DeleteTemporaryFile(block_id_t id) {
 	if (fs.FileExists(path)) {
 		auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
 		auto content_size = handle->GetFileSize();
-		temporary_directory.handle->GetTempFile().DecreaseSizeOnDisk(content_size);
+		handle.reset();
 		fs.RemoveFile(path);
+		temporary_directory.handle->GetTempFile().DecreaseSizeOnDisk(content_size);
 	}
 }
 

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -472,6 +472,7 @@ void StandardBufferManager::WriteTemporaryBuffer(MemoryTag tag, block_id_t block
 	// Create the file and write the size followed by the buffer contents.
 	auto &fs = FileSystem::GetFileSystem(db);
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+	temporary_directory.handle->GetTempFile().IncreaseSizeOnDisk(buffer.size + sizeof(idx_t));
 	handle->Write(&buffer.size, sizeof(idx_t), 0);
 	buffer.Write(*handle, sizeof(idx_t));
 }
@@ -522,6 +523,9 @@ void StandardBufferManager::DeleteTemporaryFile(block_id_t id) {
 	auto &fs = FileSystem::GetFileSystem(db);
 	auto path = GetTemporaryPath(id);
 	if (fs.FileExists(path)) {
+		auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
+		auto content_size = handle->GetFileSize();
+		temporary_directory.handle->GetTempFile().DecreaseSizeOnDisk(content_size);
 		fs.RemoveFile(path);
 	}
 }

--- a/test/sql/storage/temp_directory/offloading_block_files.test_slow
+++ b/test/sql/storage/temp_directory/offloading_block_files.test_slow
@@ -1,0 +1,27 @@
+# name: test/sql/storage/temp_directory/offloading_block_files.test_slow
+# group: [temp_directory]
+
+load __TEST_DIR__/my_peristent_db.db
+
+statement ok
+create table counting2 as
+  from range(100) t1(i)
+      cross join range(100) t2(j)
+      cross join range(100) t3(k)
+      cross join range(100) t4(l)
+      cross join range(5) t5(m)
+      select
+          row_number() over () as i,
+          random() as random_value
+  ;
+
+statement ok
+SET max_temp_directory_size = '1GB';
+
+statement ok
+SET memory_limit = '1GB';
+
+statement error
+select * from counting2 order by random_value;
+----
+Out of Memory Error: failed to offload data block of size

--- a/test/sql/storage/temp_directory/offloading_block_files.test_slow
+++ b/test/sql/storage/temp_directory/offloading_block_files.test_slow
@@ -1,7 +1,7 @@
 # name: test/sql/storage/temp_directory/offloading_block_files.test_slow
 # group: [temp_directory]
 
-load __TEST_DIR__/my_peristent_db.db
+load __TEST_DIR__/offloading_block_files.db
 
 statement ok
 create table counting2 as


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2663

`TemporaryFileManager` manages the creation and resizing of `.tmp` files consisting of blocks of data with a fixed size.
`.block` files are created for anything that does not match this fixed block size, these are now properly counted towards the `size_on_disk` of the TemporaryFileManager.

