### PR TITLE
Avoid clang-tidy-diff to check Python sources or extension folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,7 @@ tidy-check-diff:
 	cd build/tidy && \
 	cmake -DCLANG_TIDY=1 -DDISABLE_UNITY=1 -DBUILD_EXTENSIONS=parquet -DBUILD_PYTHON_PKG=TRUE -DBUILD_SHELL=0 ../.. && \
 	cd ../../ && \
-	git diff origin/main . ':(exclude)test' ':(exclude)benchmark' ':(exclude)third_party' ':(exclude)src/common/adbc' ':(exclude)src/main/capi' | python3 scripts/clang-tidy-diff.py -path build/tidy -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER} ${TIDY_PERFORM_CHECKS} -p1
+	git diff origin/main . ':(exclude)tools' ':(exclude)extension' ':(exclude)test' ':(exclude)benchmark' ':(exclude)third_party' ':(exclude)src/common/adbc' ':(exclude)src/main/capi' | python3 scripts/clang-tidy-diff.py -path build/tidy -quiet ${TIDY_THREAD_PARAMETER} ${TIDY_BINARY_PARAMETER} ${TIDY_PERFORM_CHECKS} -p1
 
 tidy-fix:
 	mkdir -p ./build/tidy && \


### PR DESCRIPTION
This should fix spurious errors like: https://github.com/duckdb/duckdb/actions/runs/10180824415/job/28159638617?pr=13202#step:7:98
```
23837 warnings and 1 error generated.
/home/runner/work/duckdb/duckdb/tools/pythonpkg/src/pyrelation.cpp:1:10: error: 'duckdb_python/pybind11/pybind_wrapper.hpp' file not found [clang-diagnostic-error]
Error while processing /home/runner/work/duckdb/duckdb/tools/pythonpkg/src/pyrelation.cpp.

    1 | #include "duckdb_python/pybind11/pybind_wrapper.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Note that clang-tidy already is NOT working in the tools/pythonpkg directory, I am not sure whether we want to bring that back that behaviour.

I have tested this by adding a narrowing double -> int implicit cast, that was not flagged in by `make tidy-check` and after this PR is not flagged also by `make tidy-check-diff`.

For now making so that behaviour is the same between checks on nightly and checks on PRs.