### PR TITLE
Executor profiler fix

### DIFF
--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -669,7 +669,10 @@ void Executor::ThrowException() {
 }
 
 void Executor::Flush(ThreadContext &tcontext) {
-	profiler->Flush(tcontext.profiler);
+	auto global_profiler = profiler;
+	if (global_profiler) {
+		global_profiler->Flush(tcontext.profiler);
+	}
 }
 
 bool Executor::GetPipelinesProgress(double &current_progress, uint64_t &current_cardinality,


### PR DESCRIPTION
Follow-up fix from #13260

Profiling information might be flushed after the executor is already reset as we now do it from different background tasks. This could sometimes lead to an internal exception as the shared_ptr would be `NULL`. This PR addresses this by making `Executor::Flush` correctly check that the profiler is still around before flushing.