### PR TITLE
Disable website docs CI run

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -212,28 +212,3 @@ jobs:
     - name: Test
       shell: bash
       run: valgrind ./build/debug/test/unittest test/sql/tpch/tpch_sf001.test_slow
-
- docs:
-    name: Website Docs
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-    runs-on: ubuntu-20.04
-    needs: linux-debug
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Clone Website
-      shell: bash
-      run: git clone https://github.com/duckdb/duckdb-web
-
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.9'
-
-    - name: Package
-      shell: bash
-      run: |
-        cd duckdb-web
-        python3 scripts/generate_docs.py ..


### PR DESCRIPTION
This CI run is now failing because the `generate_docs` script is missing from the `duckdb-web` repo. I wonder if this CI run should still be run here in the first place? CC @szarnyasg 
