### PR TITLE
Window Task Scheduling: avoid blocking tasks during GETDATA

### DIFF
--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -76,18 +76,17 @@ public:
 				stage = WindowGroupStage::FINALIZE;
 				return true;
 			}
-			break;
+			return false;
 		case WindowGroupStage::FINALIZE:
 			if (finalized == blocks) {
 				stage = WindowGroupStage::GETDATA;
 				return true;
 			}
-			break;
+			return false;
 		default:
-			break;
+			// never block in GETDATA
+			return true;
 		}
-
-		return false;
 	}
 
 	//! The hash partition data
@@ -899,11 +898,6 @@ SourceResultType PhysicalWindow::GetData(ExecutionContext &context, DataChunk &c
 	gsource.returned += chunk.size();
 
 	if (chunk.size() == 0) {
-		lock_guard<mutex> guard(gsource.lock);
-		for (auto &state : gsource.blocked_tasks) {
-			state.Callback();
-		}
-		gsource.blocked_tasks.clear();
 		return SourceResultType::FINISHED;
 	}
 	return SourceResultType::HAVE_MORE_OUTPUT;


### PR DESCRIPTION
Blocking tasks during `GETDATA` means we can have one thread blocking, while another thread returns a chunk. This can lead to issues as control might never be returned to `PhysicalWindow::GetData` if the operator is short-circuited due to e.g. a `LIMIT` clause. To ensure this does not happen we only block during the other phases (`SINK`, `FINALIZE`).