### PR TITLE
[PySpark] Fix filter type checking and isin column expression return type

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/sql/column.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/column.py
@@ -240,7 +240,7 @@ class Column:
             Tuple,
             [_get_expr(c) for c in cols],
         )
-        return self.expr.isin(*cols)
+        return Column(self.expr.isin(*cols))
 
     # logistic operators
     def __eq__(  # type: ignore[override]

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
@@ -360,7 +360,15 @@ class DataFrame:
         |  2|Alice|
         +---+-----+
         """
-        cond = condition.expr if isinstance(condition, Column) else condition
+        if isinstance(condition, Column):
+            cond = condition.expr
+        elif isinstance(condition, str):
+            cond = condition
+        else:
+            raise PySparkTypeError(
+                error_class="NOT_COLUMN_OR_STR",
+                message_parameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+            )
         rel = self.relation.filter(cond)
         return DataFrame(rel, self.session)
 

--- a/tools/pythonpkg/tests/fast/spark/test_spark_filter.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_filter.py
@@ -15,6 +15,7 @@ from duckdb.experimental.spark.sql.types import (
     MapType,
 )
 from duckdb.experimental.spark.sql.functions import col, struct, when, lit, array_contains
+from duckdb.experimental.spark.errors import PySparkTypeError
 import duckdb
 import re
 
@@ -170,3 +171,9 @@ class TestDataFrameFilter(object):
                 gender='M',
             ),
         ]
+
+    def test_invalid_condition_type(self, spark):
+        df = spark.createDataFrame([(1, "A")], ["A", "B"])
+
+        with pytest.raises(PySparkTypeError):
+            df = df.filter(dict(a=1))


### PR DESCRIPTION
PR fixes type checking for PySpark Dataframe.filter/where functions and replicates the same logic from original Apache Spark PySpark API. 
It also fixes return type of Column.isin function for consistency (otherwise unit tests are failing due to new type checking)