### PR TITLE
[Dev] Make (previously implicit) assertion explicit for DuckTransactionManager

### DIFF
--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -27,6 +27,10 @@ DuckTransactionManager::DuckTransactionManager(AttachedDatabase &db) : Transacti
 	current_transaction_id = TRANSACTION_ID_START;
 	lowest_active_id = TRANSACTION_ID_START;
 	lowest_active_start = MAX_TRANSACTION_ID;
+	if (!db.GetCatalog().IsDuckCatalog()) {
+		// Specifically the StorageManager of the DuckCatalog is relied on, with `db.GetStorageManager`
+		throw InternalException("DuckTransactionManager should only be created together with a DuckCatalog");
+	}
 }
 
 DuckTransactionManager::~DuckTransactionManager() {


### PR DESCRIPTION
This will likely make the problem hit by #13022 surface much sooner

When creating a StorageExtension the extension has to provide a TransactionManager.
It is easy to reach for the regular DuckTransactionManager here, but that won't work because this expects the AttachedDatabase to have created the `unique_ptr<StorageManager> storage;` which will *only* happen for DuckCatalog's