### PR TITLE
Implemented `list_extract` with `VectorOperations::Copy`

### DIFF
--- a/benchmark/micro/list/list_extract.benchmark
+++ b/benchmark/micro/list/list_extract.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/list/list_extract.benchmark
+# description: Benchmark for the list_extract function
+# group: [list]
+
+name list_extract micro
+group micro
+subgroup list
+
+load
+CREATE TABLE t1 as SELECT range(0,1000) as l FROM range(0,10000) as r(e);
+
+run
+SELECT sum(list_extract(l, 500)) FROM t1;
+
+result I
+4990000

--- a/benchmark/micro/list/list_extract_null.benchmark
+++ b/benchmark/micro/list/list_extract_null.benchmark
@@ -1,0 +1,16 @@
+# name: benchmark/micro/list/list_extract_null.benchmark
+# description: Benchmark for the list_extract function
+# group: [list]
+
+name list_extract micro
+group micro
+subgroup list
+
+load
+CREATE TABLE t1 as SELECT list_transform(range(0,1000), a -> if(e % a = 0, null, a)) as l FROM range(0,10000) as r(e);
+
+run
+SELECT count(list_extract(l, 5)) FROM t1;
+
+result I
+7500

--- a/benchmark/micro/list/list_extract_struct.benchmark
+++ b/benchmark/micro/list/list_extract_struct.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/list/list_extract_struct.benchmark
+# description: Benchmark for the list_extract function
+# group: [list]
+
+name list_extract micro
+group micro
+subgroup list
+
+load
+CREATE TABLE t1 as SELECT list_transform(range(0,1000), x -> {'foo': x, 'bar': (-x)::VARCHAR}) as l
+FROM range(0,10000) as r(e);
+
+run
+SELECT sum(list_extract(l, 500).foo) FROM t1;
+
+result I
+4990000

--- a/benchmark/micro/list/list_extract_struct_null.benchmark
+++ b/benchmark/micro/list/list_extract_struct_null.benchmark
@@ -1,0 +1,17 @@
+# name: benchmark/micro/list/list_extract_struct_null.benchmark
+# description: Benchmark for the list_extract function
+# group: [list]
+
+name list_extract micro
+group micro
+subgroup list
+
+load
+CREATE TABLE t1 as SELECT list_transform(range(0,1000), x -> if(e % x = 0, null, {'foo': x, 'bar': (-x)::VARCHAR})) as l
+FROM range(0,10000) as r(e);
+
+run
+SELECT sum(list_extract(l, 500).foo) FROM t1;
+
+result I
+4979521

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -70,6 +70,7 @@ static void ExecuteListExtract(Vector &result, Vector &list, Vector &offsets, co
 		const auto offsets_index = offsets_data.sel->get_index(i);
 
 		if (!list_data.validity.RowIsValid(list_index) || !offsets_data.validity.RowIsValid(offsets_index)) {
+			invalid_offsets.push_back(i);
 			sel.set_index(i, 0);
 			continue;
 		}

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -19,15 +19,12 @@ static optional_idx TryGetChildOffset(const list_entry_t &list_entry, const int6
 	}
 
 	const auto index_offset = (offset > 0) ? offset - 1 : offset;
-
 	if (index_offset < 0) {
-		const auto signed_list_offset = UnsafeNumericCast<int64_t>(list_entry.offset);
 		const auto signed_list_length = UnsafeNumericCast<int64_t>(list_entry.length);
-		if (signed_list_offset + signed_list_length + index_offset < 0) {
+		if (signed_list_length + index_offset < 0) {
 			return optional_idx::Invalid();
 		}
-		const auto wrapped_offset = UnsafeNumericCast<idx_t>(signed_list_offset + signed_list_length + index_offset);
-		return optional_idx(wrapped_offset);
+		return optional_idx(list_entry.offset + UnsafeNumericCast<idx_t>(signed_list_length + index_offset));
 	}
 
 	const auto unsigned_offset = UnsafeNumericCast<idx_t>(index_offset);

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -20,30 +20,24 @@ static optional_idx TryGetChildOffset(const list_entry_t &list_entry, const int6
 
 	const auto index_offset = (offset > 0) ? offset - 1 : offset;
 
-	idx_t wrapped_offset;
-
 	if (index_offset < 0) {
 		const auto signed_list_offset = UnsafeNumericCast<int64_t>(list_entry.offset);
 		const auto signed_list_length = UnsafeNumericCast<int64_t>(list_entry.length);
 		if (signed_list_offset + signed_list_length + index_offset < 0) {
 			return optional_idx::Invalid();
 		}
-		wrapped_offset = UnsafeNumericCast<idx_t>(signed_list_offset + signed_list_length + index_offset);
-	} else {
-		wrapped_offset = UnsafeNumericCast<idx_t>(index_offset);
+		const auto wrapped_offset = UnsafeNumericCast<idx_t>(signed_list_offset + signed_list_length + index_offset);
+		return optional_idx(wrapped_offset);
 	}
 
-	// Larger than the list?
-	if (wrapped_offset >= list_entry.length) {
+	const auto unsigned_offset = UnsafeNumericCast<idx_t>(index_offset);
+
+	// Check that the offset is within the list
+	if (unsigned_offset >= list_entry.length) {
 		return optional_idx::Invalid();
 	}
 
-	// Larger than the maximum index?
-	if (wrapped_offset > NumericLimits<idx_t>::Maximum() - list_entry.offset) {
-		return optional_idx::Invalid();
-	}
-
-	return optional_idx(list_entry.offset + wrapped_offset);
+	return optional_idx(list_entry.offset + unsigned_offset);
 }
 
 static void ExecuteListExtract(Vector &result, Vector &list, Vector &offsets, const idx_t count) {

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -1,160 +1,49 @@
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/string_util.hpp"
-
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/parser/expression/bound_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
 
 namespace duckdb {
 
-template <class T, bool HEAP_REF = false, bool VALIDITY_ONLY = false>
-void ListExtractTemplate(idx_t count, UnifiedVectorFormat &list_data, UnifiedVectorFormat &offsets_data,
-                         Vector &child_vector, idx_t list_size, Vector &result) {
-	UnifiedVectorFormat child_format;
-	child_vector.ToUnifiedFormat(list_size, child_format);
-
-	T *result_data;
-
-	result.SetVectorType(VectorType::FLAT_VECTOR);
-	if (!VALIDITY_ONLY) {
-		result_data = FlatVector::GetData<T>(result);
-	}
-	auto &result_mask = FlatVector::Validity(result);
-
-	// heap-ref once
-	if (HEAP_REF) {
-		StringVector::AddHeapReference(result, child_vector);
+static optional_idx TryGetChildOffset(const list_entry_t &list_entry, const int64_t offset) {
+	// 1-based indexing
+	if (offset == 0) {
+		return optional_idx::Invalid();
 	}
 
-	// this is lifted from ExecuteGenericLoop because we can't push the list child data into this otherwise
-	// should have gone with GetValue perhaps
-	auto child_data = UnifiedVectorFormat::GetData<T>(child_format);
-	for (idx_t i = 0; i < count; i++) {
-		auto list_index = list_data.sel->get_index(i);
-		auto offsets_index = offsets_data.sel->get_index(i);
-		if (!list_data.validity.RowIsValid(list_index)) {
-			result_mask.SetInvalid(i);
-			continue;
+	const auto index_offset = (offset > 0) ? offset - 1 : offset;
+
+	idx_t wrapped_offset;
+
+	if (index_offset < 0) {
+		const auto signed_list_offset = UnsafeNumericCast<int64_t>(list_entry.offset);
+		const auto signed_list_length = UnsafeNumericCast<int64_t>(list_entry.length);
+		if (signed_list_offset + signed_list_length + index_offset < 0) {
+			return optional_idx::Invalid();
 		}
-		if (!offsets_data.validity.RowIsValid(offsets_index)) {
-			result_mask.SetInvalid(i);
-			continue;
-		}
-		auto list_entry = (UnifiedVectorFormat::GetData<list_entry_t>(list_data))[list_index];
-		auto offsets_entry = (UnifiedVectorFormat::GetData<int64_t>(offsets_data))[offsets_index];
+		wrapped_offset = UnsafeNumericCast<idx_t>(signed_list_offset + signed_list_length + index_offset);
+	} else {
+		wrapped_offset = UnsafeNumericCast<idx_t>(index_offset);
+	}
 
-		// 1-based indexing
-		if (offsets_entry == 0) {
-			result_mask.SetInvalid(i);
-			continue;
-		}
-		offsets_entry = (offsets_entry > 0) ? offsets_entry - 1 : offsets_entry;
+	// Larger than the list?
+	if (wrapped_offset >= list_entry.length) {
+		return optional_idx::Invalid();
+	}
 
-		idx_t child_offset;
-		if (offsets_entry < 0) {
-			if (offsets_entry < -int64_t(list_entry.length)) {
-				result_mask.SetInvalid(i);
-				continue;
-			}
-			child_offset = UnsafeNumericCast<idx_t>(UnsafeNumericCast<int64_t>(list_entry.offset + list_entry.length) +
-			                                        offsets_entry);
-		} else {
-			if ((idx_t)offsets_entry >= list_entry.length) {
-				result_mask.SetInvalid(i);
-				continue;
-			}
-			child_offset = UnsafeNumericCast<idx_t>(UnsafeNumericCast<int64_t>(list_entry.offset) + offsets_entry);
-		}
-		auto child_index = child_format.sel->get_index(child_offset);
-		if (child_format.validity.RowIsValid(child_index)) {
-			if (!VALIDITY_ONLY) {
-				result_data[i] = child_data[child_index];
-			}
-		} else {
-			result_mask.SetInvalid(i);
-		}
+	// Larger than the maximum index?
+	if (wrapped_offset > NumericLimits<idx_t>::Maximum() - list_entry.offset) {
+		return optional_idx::Invalid();
 	}
-	if (count == 1) {
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	}
-}
-static void ExecuteListExtractInternal(const idx_t count, UnifiedVectorFormat &list, UnifiedVectorFormat &offsets,
-                                       Vector &child_vector, idx_t list_size, Vector &result) {
-	D_ASSERT(child_vector.GetType() == result.GetType());
-	switch (result.GetType().InternalType()) {
-	case PhysicalType::BOOL:
-	case PhysicalType::INT8:
-		ListExtractTemplate<int8_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::INT16:
-		ListExtractTemplate<int16_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::INT32:
-		ListExtractTemplate<int32_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::INT64:
-		ListExtractTemplate<int64_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::INT128:
-		ListExtractTemplate<hugeint_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::UINT8:
-		ListExtractTemplate<uint8_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::UINT16:
-		ListExtractTemplate<uint16_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::UINT32:
-		ListExtractTemplate<uint32_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::UINT64:
-		ListExtractTemplate<uint64_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::UINT128:
-		ListExtractTemplate<uhugeint_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::FLOAT:
-		ListExtractTemplate<float>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::DOUBLE:
-		ListExtractTemplate<double>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::VARCHAR:
-		ListExtractTemplate<string_t, true>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::INTERVAL:
-		ListExtractTemplate<interval_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	case PhysicalType::STRUCT: {
-		auto &entries = StructVector::GetEntries(child_vector);
-		auto &result_entries = StructVector::GetEntries(result);
-		D_ASSERT(entries.size() == result_entries.size());
-		// extract the child entries of the struct
-		for (idx_t i = 0; i < entries.size(); i++) {
-			ExecuteListExtractInternal(count, list, offsets, *entries[i], list_size, *result_entries[i]);
-		}
-		// extract the validity mask
-		ListExtractTemplate<bool, false, true>(count, list, offsets, child_vector, list_size, result);
-		break;
-	}
-	case PhysicalType::LIST: {
-		// nested list: we have to reference the child
-		auto &child_child_list = ListVector::GetEntry(child_vector);
 
-		ListVector::GetEntry(result).Reference(child_child_list);
-		ListVector::SetListSize(result, ListVector::GetListSize(child_vector));
-		ListExtractTemplate<list_entry_t>(count, list, offsets, child_vector, list_size, result);
-		break;
-	}
-	default:
-		throw NotImplementedException("Unimplemented type for LIST_EXTRACT");
-	}
+	return optional_idx(list_entry.offset + wrapped_offset);
 }
 
 static void ExecuteListExtract(Vector &result, Vector &list, Vector &offsets, const idx_t count) {
@@ -164,8 +53,51 @@ static void ExecuteListExtract(Vector &result, Vector &list, Vector &offsets, co
 
 	list.ToUnifiedFormat(count, list_data);
 	offsets.ToUnifiedFormat(count, offsets_data);
-	ExecuteListExtractInternal(count, list_data, offsets_data, ListVector::GetEntry(list),
-	                           ListVector::GetListSize(list), result);
+
+	const auto list_ptr = UnifiedVectorFormat::GetData<list_entry_t>(list_data);
+	const auto offsets_ptr = UnifiedVectorFormat::GetData<int64_t>(offsets_data);
+
+	UnifiedVectorFormat child_data;
+	auto &child_vector = ListVector::GetEntry(list);
+	auto child_count = ListVector::GetListSize(list);
+	child_vector.ToUnifiedFormat(child_count, child_data);
+
+	SelectionVector sel(count);
+	vector<idx_t> invalid_offsets;
+
+	for (idx_t i = 0; i < count; i++) {
+		const auto list_index = list_data.sel->get_index(i);
+		const auto offsets_index = offsets_data.sel->get_index(i);
+
+		if (!list_data.validity.RowIsValid(list_index) || !offsets_data.validity.RowIsValid(offsets_index)) {
+			sel.set_index(i, 0);
+			continue;
+		}
+
+		const auto child_offset = TryGetChildOffset(list_ptr[list_index], offsets_ptr[offsets_index]);
+
+		if (!child_offset.IsValid()) {
+			invalid_offsets.push_back(i);
+			sel.set_index(i, 0);
+			continue;
+		}
+
+		const auto child_idx = child_data.sel->get_index(child_offset.GetIndex());
+		sel.set_index(i, child_idx);
+	}
+
+	VectorOperations::Copy(child_vector, result, sel, count, 0, 0);
+
+	// Copy:ing the vectors also copies the validity mask, so we set the rows with invalid offsets (0) to false here.
+	for (const auto &invalid_idx : invalid_offsets) {
+		FlatVector::SetNull(result, invalid_idx, true);
+	}
+
+	if (count == 1 || (list.GetVectorType() == VectorType::CONSTANT_VECTOR &&
+	                   offsets.GetVectorType() == VectorType::CONSTANT_VECTOR)) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+
 	result.Verify(count);
 }
 
@@ -179,13 +111,6 @@ static void ExecuteStringExtract(Vector &result, Vector &input_vector, Vector &s
 static void ListExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	D_ASSERT(args.ColumnCount() == 2);
 	auto count = args.size();
-
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	for (idx_t i = 0; i < args.ColumnCount(); i++) {
-		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			result.SetVectorType(VectorType::FLAT_VECTOR);
-		}
-	}
 
 	Vector &base = args.data[0];
 	Vector &subscript = args.data[1];

--- a/test/sql/types/nested/list/test_list_extract.test
+++ b/test/sql/types/nested/list/test_list_extract.test
@@ -194,3 +194,40 @@ query I
 SELECT list_extract([1, 2, 3], -9223372036854775808);
 ----
 NULL
+
+statement ok
+CREATE TABLE list_array_table(a int[3][]);
+
+statement ok
+INSERT INTO list_array_table VALUES ([[1,2,3], NULL, [4,5,6]]);
+
+query I
+SELECT list_extract(a, 1) FROM list_array_table;
+----
+[1, 2, 3]
+
+query I
+SELECT list_extract(a, 2) FROM list_array_table;
+----
+NULL
+
+query I
+SELECT list_extract(a, 3) FROM list_array_table;
+----
+[4, 5, 6]
+
+query I
+SELECT list_extract(a, 4) FROM list_array_table;
+----
+NULL
+
+query I
+SELECT list_extract(a, -1) FROM list_array_table;
+----
+[4, 5, 6]
+
+query I
+SELECT list_extract(a, 0) FROM list_array_table;
+----
+NULL
+


### PR DESCRIPTION
This PR changes the implementation of `list_extract` to use a selection vector combined with a call to `VectorOperations::Copy` instead of using a ad-hoc templated switch case that basically more or less reimplements copy anyway.

This has the benefit of reducing code duplication and bloat slightly, but the primary motivation to implement this was to enable support for extracting list-of-arrays, which was previously not possible. The initial attempt at supporting that ended up looking a lot like copy, which made me realize that it could be generalized for all types if we just used copy instead.