### PR TITLE
chore: add check to make sure it's git repo before executing git cmd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -999,8 +999,8 @@ endmacro()
 # This function sets OUTPUT_VAR to the VERSION using DuckDB's standard versioning convention (using WORKING_DIR)
 # TODO: unify this with the base DuckDB logic (note that this is slightly different as it has ReleaseCandidate tag support
 function(duckdb_extension_generate_version OUTPUT_VAR WORKING_DIR)
-  find_package(Git)
-  if(Git_FOUND)
+  find_package(Git QUIET)
+  if(Git_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
     execute_process(
             COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
             WORKING_DIRECTORY ${WORKING_DIR}


### PR DESCRIPTION
We've seen issues where `duckdb_extension_generate_version` is called when the directory is not a git repo and that results in an error that looks like below:
```
#40 16.21 -- Found Git: /usr/bin/git (found version "2.34.1") 
[921](https://github.com/motherduckdb/mono/actions/runs/10254464263/job/28369332071?pr=5675#step:5:934)
#40 16.21 fatal: not a git repository (or any of the parent directories): .git
[922](https://github.com/motherduckdb/mono/actions/runs/10254464263/job/28369332071?pr=5675#step:5:935)
#40 16.21 CMake Error at /hybrid-core/server/duckdb/CMakeLists.txt:978 (message):
[923](https://github.com/motherduckdb/mono/actions/runs/10254464263/job/28369332071?pr=5675#step:5:936)
#40 16.21   git is available (at /usr/bin/git) but has failed to execute 'log -1
[924](https://github.com/motherduckdb/mono/actions/runs/10254464263/job/28369332071?pr=5675#step:5:937)
#40 16.21   --format=%h'.
```
Adding a check to make sure that the directory is a git repo before jumping into running the Git cmd allows the project to be compiled without us needing to make some custom hack (like [this one](https://github.com/motherduckdb/duckdb_delta/commit/ab14c07b2820e2d48c6ac118faea5c783e7f522d)) to circumvent the error.