### PR TITLE
Fix CMake for when folders are not git folders via `git rev-parse --is-inside-work-tree`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1002,6 +1002,14 @@ function(duckdb_extension_generate_version OUTPUT_VAR WORKING_DIR)
   find_package(Git)
   if(Git_FOUND)
     execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --is-inside-work-tree
+            WORKING_DIRECTORY ${WORKING_DIR}
+            OUTPUT_VARIABLE IS_IN_GIT_DIR
+            ERROR_QUIET
+    )
+  endif()
+  if (IS_IN_GIT_DIR)
+    execute_process(
             COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
             WORKING_DIRECTORY ${WORKING_DIR}
             RESULT_VARIABLE GIT_RESULT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1075,7 +1075,7 @@ function(duckdb_extension_load NAME)
   elseif (NOT "${duckdb_extension_load_SOURCE_DIR}" STREQUAL "")
     # Version detection
     if ("${duckdb_extension_load_EXTENSION_VERSION}" STREQUAL "")
-      duckdb_extension_generate_version(EXT_VERSION ${CMAKE_CURRENT_LIST_DIR})
+      duckdb_extension_generate_version(EXT_VERSION ${duckdb_extension_load_SOURCE_DIR})
     else()
       set(EXT_VERSION ${duckdb_extension_load_EXTENSION_VERSION})
     endif()


### PR DESCRIPTION
More polished version of https://github.com/duckdb/duckdb/pull/13314.

2 fixes: passing down the proper WORKING_DIR and check ERROR code to decide whether a folder is a GIT folder or not.

I tested this locally, CI here should mostly test that no regressions are introduced.

This PR makes so that when `git` is available BUT a given folder is downloaded without setting up git repository it should still work (but with an empty EXTENSION_VERSION.