### PR TITLE
[Python Dev] Make `cursor` creation threadsafe, perform compaction on the internal vector

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -123,14 +123,18 @@ struct DuckDBPyConnection : public enable_shared_from_this<DuckDBPyConnection> {
 private:
 	class Cursors {
 	public:
-		Cursors() {}
+		Cursors() {
+		}
+
 	public:
 		void AddCursor(shared_ptr<DuckDBPyConnection> conn);
 		void ClearCursors();
+
 	private:
 		mutex lock;
 		vector<weak_ptr<DuckDBPyConnection>> cursors;
 	};
+
 public:
 	ConnectionGuard con;
 	Cursors cursors;

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -120,9 +120,20 @@ private:
 };
 
 struct DuckDBPyConnection : public enable_shared_from_this<DuckDBPyConnection> {
+private:
+	class Cursors {
+	public:
+		Cursors() {}
+	public:
+		void AddCursor(shared_ptr<DuckDBPyConnection> conn);
+		void ClearCursors();
+	private:
+		mutex lock;
+		vector<weak_ptr<DuckDBPyConnection>> cursors;
+	};
 public:
 	ConnectionGuard con;
-	vector<weak_ptr<DuckDBPyConnection>> cursors;
+	Cursors cursors;
 	std::mutex py_connection_lock;
 	//! MemoryFileSystem used to temporarily store file-like objects for reading
 	shared_ptr<ModifiedMemoryFileSystem> internal_object_filesystem;


### PR DESCRIPTION
This PR fixes #10223 

If the connection was passed to a thread with the intent of creating a cursor in the thread, this could cause a problem as the vector where the cursors are stored in was not protected against that.

If `cursor` is called many times in the programs execution, the vector in the parent connection that stores the cursors could grow unbounded, now cursors that have already been closed will get cleaned up when a new cursor is created.