### PR TITLE
[Dev] Fix breakage caused by adjusting `duckdb.h` directly

### DIFF
--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -210,7 +210,8 @@ typedef enum duckdb_error_type {
 	DUCKDB_ERROR_HTTP = 38,
 	DUCKDB_ERROR_MISSING_EXTENSION = 39,
 	DUCKDB_ERROR_AUTOLOAD = 40,
-	DUCKDB_ERROR_SEQUENCE = 41
+	DUCKDB_ERROR_SEQUENCE = 41,
+	DUCKDB_INVALID_CONFIGURATION = 42
 } duckdb_error_type;
 
 //===--------------------------------------------------------------------===//


### PR DESCRIPTION
`make generate-files` should no longer cause an unwanted diff on `main`