### PR TITLE
Fix clang-format version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ This project and everyone participating in it is governed by a [Code of Conduct]
 
 * Use tabs for indentation, spaces for alignment.
 * Lines should not exceed 120 columns.
-* To make sure the formatting is consistent, please use version 10.0.1, installable through `python3 -m pip install clang-format==10.0.1.1`
+* To make sure the formatting is consistent, please use version 11.0.1, installable through `python3 -m pip install clang-format==11.0.1` or `pipx install clang-format==11.0.1`.
 * `clang_format` and `black` enforce these rules automatically, use `make format-fix` to run the formatter.
 * The project also comes with an [`.editorconfig` file](https://editorconfig.org/) that corresponds to these rules.
 


### PR DESCRIPTION
The version of clang-format recommended in `CONTRIBUTING.md` was not the
same as recommended by `scripts/format.py`. This fixes `CONTRIBUTING.md`
and also mentions installing it through `pipx`, since that is now the
only way Ubuntu 24.04 (and other recent OSes) recommend installing
global python packages.
