### PR TITLE
Extension install locks

### DIFF
--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -296,8 +296,12 @@ public:
 	}
 	void Release() {
 		if (handle) {
-			fs.RemoveFile(path);
 			handle.reset();
+			try {
+				fs.RemoveFile(path);
+			} catch (...) {
+				// Failure to remove file are mostly OK
+			}
 		}
 	}
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -278,6 +278,7 @@ public:
 	DUCKDB_API ~DBConfig();
 
 	mutex config_lock;
+	mutex extensions_install_lock;
 	//! Replacement table scans are automatically attempted when a table name cannot be found in the schema
 	vector<ReplacementScan> replacement_scans;
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -243,6 +243,8 @@ static void CheckExtensionMetadataOnInstall(DBConfig &config, void *in_buffer, i
 //   3. Crash after extension move: extension is now uninstalled, new metadata file present
 static void WriteExtensionFiles(FileSystem &fs, const string &temp_path, const string &local_extension_path,
                                 void *in_buffer, idx_t file_size, ExtensionInstallInfo &info) {
+	FileBasedLock lock(fs, local_extension_path + ".lock", 1000);
+
 	// Write extension to tmp file
 	WriteExtensionFileToDisk(fs, temp_path, in_buffer, file_size);
 
@@ -263,6 +265,8 @@ static void WriteExtensionFiles(FileSystem &fs, const string &temp_path, const s
 
 	fs.MoveFile(metadata_tmp_path, metadata_file_path);
 	fs.MoveFile(temp_path, local_extension_path);
+
+	lock.Release();
 }
 
 // Install an extension using a filesystem


### PR DESCRIPTION
Add locking to make extension folder changes connected to installing extensions atomic in 2 cases:

#### Multiple parallel connections installing extensions
A mutex-based lock ensures only 1 given connection at a time can modify extensions files.
I am not positive this was an actual problem, I would assume so but I have to say I have not build a test scenario where this becomes a problem. To be reviewed, relevant commit can otherwise not be merged

#### Multiple duckdb processes
A file-based lock relying on file-system process-based exclusive locks to make sure only a given process is going to write into `name.duckdb_extension` and `name.duckdb_extension.info`

This has been tested by building a loadable extension, via adding `duckdb_extension_load(fts DONT_LINK)`, adding sleep(100) to the `WriteExtensionFiles` function, then performing on parallel duckdb processes: `FORCE INSTALL fts FROM 'build/release/repository'`, that is basically the same setup from the bug report in https://github.com/duckdb/duckdb/issues/12589:
```bash
#!/usr/bin/env bash

for i in $(seq 1 10); do
  duckdb -cmd 'install httpfs; install postgres;' :memory: &
done

sleep 10
```
Fixes https://github.com/duckdb/duckdb/issues/12589 

FileBasedLock can be considered for other system-wide resources like persistent secrets, where the problem is basically the same.

#### Multiple duckdb instances within the same process: NOT solved
This has not been touched as part as this PR.

I think only proper way would requires global state to be solved, we might consider having a mechanism to make multiple duckdb-instances in the same process aware of each other, but that requires a bigger rework / some thinking.

One idea could be adding some API like:
```c++
duckdb_global_state* CreateDuckDBGlobalState();
duckdb_status RegisterToDuckDBGlobalState(duckdb_global_state *state, /*params....*/);
```
Where it becomes responsibility of whoever embeds duckdb to register all of them to make safe for them to independently update and access global files in the `.duckdb` folder.

Current solution for this is separate the folders that are accesses by setting them to custom values.