### PR TITLE
[Dev] Remove redundant variable from SQLStatement

### DIFF
--- a/src/common/adbc/adbc.cpp
+++ b/src/common/adbc/adbc.cpp
@@ -792,7 +792,7 @@ AdbcStatusCode StatementExecuteQuery(struct AdbcStatement *statement, struct Arr
 		}
 		duckdb::unique_ptr<duckdb::DataChunk> chunk;
 		auto prepared_statement_params =
-		    reinterpret_cast<duckdb::PreparedStatementWrapper *>(wrapper->statement)->statement->n_param;
+		    reinterpret_cast<duckdb::PreparedStatementWrapper *>(wrapper->statement)->statement->named_param_map.size();
 
 		while ((chunk = result->Fetch()) != nullptr) {
 			if (chunk->size() == 0) {

--- a/src/include/duckdb/main/prepared_statement.hpp
+++ b/src/include/duckdb/main/prepared_statement.hpp
@@ -24,7 +24,7 @@ class PreparedStatement {
 public:
 	//! Create a successfully prepared prepared statement object with the given name
 	DUCKDB_API PreparedStatement(shared_ptr<ClientContext> context, shared_ptr<PreparedStatementData> data,
-	                             string query, idx_t n_param, case_insensitive_map_t<idx_t> named_param_map);
+	                             string query, case_insensitive_map_t<idx_t> named_param_map);
 	//! Create a prepared statement that was not successfully prepared
 	DUCKDB_API explicit PreparedStatement(ErrorData error);
 
@@ -41,9 +41,7 @@ public:
 	bool success;
 	//! The error message (if success = false)
 	ErrorData error;
-	//! The amount of bound parameters
-	idx_t n_param;
-	//! The (optional) named parameters
+	//! The parameter mapping
 	case_insensitive_map_t<idx_t> named_param_map;
 
 public:

--- a/src/include/duckdb/parser/sql_statement.hpp
+++ b/src/include/duckdb/parser/sql_statement.hpp
@@ -33,9 +33,7 @@ public:
 	idx_t stmt_location = 0;
 	//! The statement length within the query string
 	idx_t stmt_length = 0;
-	//! The number of prepared statement parameters (if any)
-	idx_t n_param = 0;
-	//! The map of named parameter to param index (if n_param and any named)
+	//! The map of named parameter to param index
 	case_insensitive_map_t<idx_t> named_param_map;
 	//! The query text that corresponds to this SQL statement
 	string query;

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -90,7 +90,7 @@ idx_t duckdb_nparams(duckdb_prepared_statement prepared_statement) {
 	if (!wrapper || !wrapper->statement || wrapper->statement->HasError()) {
 		return 0;
 	}
-	return wrapper->statement->n_param;
+	return wrapper->statement->named_param_map.size();
 }
 
 static duckdb::string duckdb_parameter_name_internal(duckdb_prepared_statement prepared_statement, idx_t index) {
@@ -98,7 +98,7 @@ static duckdb::string duckdb_parameter_name_internal(duckdb_prepared_statement p
 	if (!wrapper || !wrapper->statement || wrapper->statement->HasError()) {
 		return duckdb::string();
 	}
-	if (index > wrapper->statement->n_param) {
+	if (index > wrapper->statement->named_param_map.size()) {
 		return duckdb::string();
 	}
 	for (auto &item : wrapper->statement->named_param_map) {
@@ -155,10 +155,10 @@ duckdb_state duckdb_bind_value(duckdb_prepared_statement prepared_statement, idx
 	if (!wrapper || !wrapper->statement || wrapper->statement->HasError()) {
 		return DuckDBError;
 	}
-	if (param_idx <= 0 || param_idx > wrapper->statement->n_param) {
+	if (param_idx <= 0 || param_idx > wrapper->statement->named_param_map.size()) {
 		wrapper->statement->error =
 		    duckdb::InvalidInputException("Can not bind to parameter number %d, statement only has %d parameter(s)",
-		                                  param_idx, wrapper->statement->n_param);
+		                                  param_idx, wrapper->statement->named_param_map.size());
 		return DuckDBError;
 	}
 	auto identifier = duckdb_parameter_name_internal(prepared_statement, param_idx);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -650,8 +650,7 @@ unique_ptr<LogicalOperator> ClientContext::ExtractPlan(const string &query) {
 
 unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &lock,
                                                              unique_ptr<SQLStatement> statement) {
-	auto n_param = statement->n_param;
-	auto named_param_map = std::move(statement->named_param_map);
+	auto named_param_map = statement->named_param_map;
 	auto statement_query = statement->query;
 	shared_ptr<PreparedStatementData> prepared_data;
 	auto unbound_statement = statement->Copy();
@@ -659,7 +658,7 @@ unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &
 	    lock, [&]() { prepared_data = CreatePreparedStatement(lock, statement_query, std::move(statement)); }, false);
 	prepared_data->unbound_statement = std::move(unbound_statement);
 	return make_uniq<PreparedStatement>(shared_from_this(), std::move(prepared_data), std::move(statement_query),
-	                                    n_param, std::move(named_param_map));
+	                                    std::move(named_param_map));
 }
 
 unique_ptr<PreparedStatement> ClientContext::Prepare(unique_ptr<SQLStatement> statement) {

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -6,8 +6,8 @@
 namespace duckdb {
 
 PreparedStatement::PreparedStatement(shared_ptr<ClientContext> context, shared_ptr<PreparedStatementData> data_p,
-                                     string query, idx_t n_param, case_insensitive_map_t<idx_t> named_param_map_p)
-    : context(std::move(context)), data(std::move(data_p)), query(std::move(query)), success(true), n_param(n_param),
+                                     string query, case_insensitive_map_t<idx_t> named_param_map_p)
+    : context(std::move(context)), data(std::move(data_p)), query(std::move(query)), success(true),
       named_param_map(std::move(named_param_map_p)) {
 	D_ASSERT(data || !success);
 }

--- a/src/main/prepared_statement_data.cpp
+++ b/src/main/prepared_statement_data.cpp
@@ -81,7 +81,7 @@ bool PreparedStatementData::RequireRebind(ClientContext &context,
 
 void PreparedStatementData::Bind(case_insensitive_map_t<BoundParameterData> values) {
 	// set parameters
-	D_ASSERT(!unbound_statement || unbound_statement->n_param == properties.parameter_count);
+	D_ASSERT(!unbound_statement || unbound_statement->named_param_map.size() == properties.parameter_count);
 	CheckParameterCount(values.size());
 
 	// bind the required values

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -35,7 +35,6 @@ bool Transformer::TransformParseTree(duckdb_libpgquery::PGList *tree, vector<uni
 		if (HasPivotEntries()) {
 			stmt = CreatePivotStatement(std::move(stmt));
 		}
-		stmt->n_param = ParamCount();
 		statements.push_back(std::move(stmt));
 	}
 	return true;
@@ -58,7 +57,6 @@ StackChecker<Transformer> Transformer::StackCheck(idx_t extra_stack) {
 
 unique_ptr<SQLStatement> Transformer::TransformStatement(duckdb_libpgquery::PGNode &stmt) {
 	auto result = TransformStatementInternal(stmt);
-	result->n_param = ParamCount();
 	if (!named_param_map.empty()) {
 		// Avoid overriding a previous move with nothing
 		result->named_param_map = std::move(named_param_map);

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -12,7 +12,7 @@
 namespace duckdb {
 
 BoundStatement Binder::Bind(ExecuteStatement &stmt) {
-	auto parameter_count = stmt.n_param;
+	auto parameter_count = stmt.named_param_map.size();
 
 	// bind the prepared statement
 	auto &client_data = ClientData::Get(context);

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -31,7 +31,7 @@ static void CheckTreeDepth(const LogicalOperator &op, idx_t max_depth, idx_t dep
 
 void Planner::CreatePlan(SQLStatement &statement) {
 	auto &profiler = QueryProfiler::Get(context);
-	auto parameter_count = statement.n_param;
+	auto parameter_count = statement.named_param_map.size();
 
 	BoundParameterMap bound_parameters(parameter_data);
 

--- a/src/verification/prepared_statement_verifier.cpp
+++ b/src/verification/prepared_statement_verifier.cpp
@@ -22,7 +22,6 @@ void PreparedStatementVerifier::Extract() {
 	// replace all the constants from the select statement and replace them with parameter expressions
 	ParsedExpressionIterator::EnumerateQueryNodeChildren(
 	    *select.node, [&](unique_ptr<ParsedExpression> &child) { ConvertConstants(child); });
-	statement->n_param = values.size();
 	for (auto &kv : values) {
 		statement->named_param_map[kv.first] = 0;
 	}

--- a/test/api/test_prepared_api.cpp
+++ b/test/api/test_prepared_api.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Test prepared statements API", "[api]") {
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 	result = prepare->Execute(13);
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
-	REQUIRE(prepare->n_param == 1);
+	REQUIRE(prepare->named_param_map.size() == 1);
 }
 
 TEST_CASE("Test type resolution of function with parameter expressions", "[api]") {
@@ -256,27 +256,27 @@ TEST_CASE("Test prepared statement parameter counting", "[api]") {
 
 	auto p0 = con.Prepare("SELECT 42");
 	REQUIRE(!p0->HasError());
-	REQUIRE(p0->n_param == 0);
+	REQUIRE(p0->named_param_map.empty());
 
 	auto p1 = con.Prepare("SELECT $1::int");
 	REQUIRE(!p1->HasError());
-	REQUIRE(p1->n_param == 1);
+	REQUIRE(p1->named_param_map.size() == 1);
 
 	p1 = con.Prepare("SELECT ?::int");
 	REQUIRE(!p1->HasError());
-	REQUIRE(p1->n_param == 1);
+	REQUIRE(p1->named_param_map.size() == 1);
 
 	auto p2 = con.Prepare("SELECT $1::int");
 	REQUIRE(!p2->HasError());
-	REQUIRE(p2->n_param == 1);
+	REQUIRE(p2->named_param_map.size() == 1);
 
 	auto p3 = con.Prepare("SELECT ?::int, ?::string");
 	REQUIRE(!p3->HasError());
-	REQUIRE(p3->n_param == 2);
+	REQUIRE(p3->named_param_map.size() == 2);
 
 	auto p4 = con.Prepare("SELECT $1::int, $2::string");
 	REQUIRE(!p4->HasError());
-	REQUIRE(p4->n_param == 2);
+	REQUIRE(p4->named_param_map.size() == 2);
 }
 
 TEST_CASE("Test ANALYZE", "[api]") {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -514,7 +514,8 @@ case_insensitive_map_t<BoundParameterData> TransformPreparedParameters(PreparedS
 	if (py::is_list_like(params)) {
 		if (prep.named_param_map.size() != py::len(params)) {
 			if (py::len(params) == 0) {
-				throw InvalidInputException("Expected %d parameters, but none were supplied", prep.named_param_map.size());
+				throw InvalidInputException("Expected %d parameters, but none were supplied",
+				                            prep.named_param_map.size());
 			}
 			throw InvalidInputException("Prepared statement needs %d parameters, %d given", prep.named_param_map.size(),
 			                            py::len(params));

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -512,11 +512,11 @@ case_insensitive_map_t<BoundParameterData> TransformPreparedParameters(PreparedS
                                                                        const py::object &params) {
 	case_insensitive_map_t<BoundParameterData> named_values;
 	if (py::is_list_like(params)) {
-		if (prep.n_param != py::len(params)) {
+		if (prep.named_param_map.size() != py::len(params)) {
 			if (py::len(params) == 0) {
-				throw InvalidInputException("Expected %d parameters, but none were supplied", prep.n_param);
+				throw InvalidInputException("Expected %d parameters, but none were supplied", prep.named_param_map.size());
 			}
-			throw InvalidInputException("Prepared statement needs %d parameters, %d given", prep.n_param,
+			throw InvalidInputException("Prepared statement needs %d parameters, %d given", prep.named_param_map.size(),
 			                            py::len(params));
 		}
 		auto unnamed_values = DuckDBPyConnection::TransformPythonParamList(params);
@@ -1276,7 +1276,7 @@ void DuckDBPyConnection::ExecuteImmediately(vector<unique_ptr<SQLStatement>> sta
 		return;
 	}
 	for (auto &stmt : statements) {
-		if (stmt->n_param != 0) {
+		if (!stmt->named_param_map.empty()) {
 			throw NotImplementedException(
 			    "Prepared parameters are only supported for the last statement, please split your query up into "
 			    "separate 'execute' calls if you want to use prepared parameters");

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -214,7 +214,7 @@ int sqlite3_prepare_v2(sqlite3 *db,           /* Database handle */
 		stmt->query_string = query;
 		stmt->prepared = std::move(prepared);
 		stmt->current_row = -1;
-		for (idx_t i = 0; i < stmt->prepared->n_param; i++) {
+		for (idx_t i = 0; i < stmt->prepared->named_param_map.size(); i++) {
 			stmt->bound_names.push_back("$" + to_string(i + 1));
 			stmt->bound_values.push_back(Value());
 		}
@@ -620,14 +620,14 @@ int sqlite3_bind_parameter_count(sqlite3_stmt *stmt) {
 	if (!stmt) {
 		return 0;
 	}
-	return stmt->prepared->n_param;
+	return stmt->prepared->named_param_map.size();
 }
 
 const char *sqlite3_bind_parameter_name(sqlite3_stmt *stmt, int idx) {
 	if (!stmt) {
 		return nullptr;
 	}
-	if (idx < 1 || idx > (int)stmt->prepared->n_param) {
+	if (idx < 1 || idx > (int)stmt->prepared->named_param_map.size()) {
 		return nullptr;
 	}
 	return stmt->bound_names[idx - 1].c_str();
@@ -649,7 +649,7 @@ int sqlite3_internal_bind_value(sqlite3_stmt *stmt, int idx, Value value) {
 	if (!stmt || !stmt->prepared || stmt->result) {
 		return SQLITE_MISUSE;
 	}
-	if (idx < 1 || idx > (int)stmt->prepared->n_param) {
+	if (idx < 1 || idx > (int)stmt->prepared->named_param_map.size()) {
 		return SQLITE_RANGE;
 	}
 	stmt->bound_values[idx - 1] = value;


### PR DESCRIPTION
I was working on [this](https://github.com/duckdb/duckdb/issues/13193) and noticed this information was duplicated and could be problematic.

In the case of the mentioned issue it is problematic, because `n_param` says 1 while the `named_param_map` is empty.