### PR TITLE
Enable unnesting lists of arrays

### DIFF
--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -88,11 +88,17 @@ static void UnnestNull(idx_t start, idx_t end, Vector &result) {
 	for (idx_t i = start; i < end; i++) {
 		validity.SetInvalid(i);
 	}
-	if (result.GetType().InternalType() == PhysicalType::STRUCT) {
-		auto &struct_children = StructVector::GetEntries(result);
+
+	const auto &logical_type = result.GetType();
+	if (logical_type.InternalType() == PhysicalType::STRUCT) {
+		const auto &struct_children = StructVector::GetEntries(result);
 		for (auto &child : struct_children) {
 			UnnestNull(start, end, *child);
 		}
+	} else if (logical_type.InternalType() == PhysicalType::ARRAY) {
+		auto &array_child = ArrayVector::GetEntry(result);
+		auto array_size = ArrayType::GetSize(logical_type);
+		UnnestNull(start * array_size, end * array_size, array_child);
 	}
 }
 
@@ -205,7 +211,17 @@ static void UnnestVector(UnifiedVectorFormat &child_vector_data, Vector &child_v
 		break;
 	}
 	case PhysicalType::ARRAY: {
-		throw NotImplementedException("ARRAY type not supported for UNNEST.");
+		auto array_size = ArrayType::GetSize(child_vector.GetType());
+		auto &source_array = ArrayVector::GetEntry(child_vector);
+		auto &target_array = ArrayVector::GetEntry(result);
+
+		UnnestValidity(child_vector_data, start, end, result);
+
+		UnifiedVectorFormat child_array_data;
+		source_array.ToUnifiedFormat(list_size * array_size, child_array_data);
+		UnnestVector(child_array_data, source_array, list_size * array_size, start * array_size, end * array_size,
+		             target_array);
+		break;
 	}
 	default:
 		throw InternalException("Unimplemented type for UNNEST.");

--- a/test/sql/types/list/unnest_complex_types.test
+++ b/test/sql/types/list/unnest_complex_types.test
@@ -97,3 +97,26 @@ SELECT id, UNNEST(i), UNNEST(j) FROM (VALUES (1, [{'a': [1, 2], 'b': NULL}, {'a'
 3	{'a': [NULL, 4, 5], 'b': test the best unnest fest}	NULL
 3	NULL	NULL
 3	{'a': [6, 7, NULL, 9], 'b': abcd}	NULL
+
+# arrays in lists
+query II
+SELECT id, UNNEST(i) FROM (VALUES (1, [[1,2], [3, 4]]::INT[2][]), (2, [[5, NULL], [7, 8]]::INT[2][]), (3, NULL::INT[2][]), (4, [[9, 10], NULL, [11, 12]]::INT[2][]), (5, []::INT[2][])) tbl(id, i)
+----
+1	[1, 2]
+1	[3, 4]
+2	[5, NULL]
+2	[7, 8]
+4	[9, 10]
+4	NULL
+4	[11, 12]
+
+
+# arrays in structs
+query III
+SELECT id, UNNEST(i) FROM (VALUES (1, {'a': [1,2]::INT[2], 'b': [3, 4]::INT[2]}), (2, {'a': [5, NULL]::INT[2], 'b': [7, 8]::INT[2]}), (3, {'a': NULL::INT[2], 'b': [9, 10]::INT[2]}), (4, {'a': [11, 12]::INT[2], 'b': NULL::INT[2]}), (5, {'a': NULL, 'b': [13, 14]::INT[2]})) tbl(id, i);
+----
+1	[1, 2]	[3, 4]
+2	[5, NULL]	[7, 8]
+3	NULL	[9, 10]
+4	[11, 12]	NULL
+5	NULL	[13, 14]


### PR DESCRIPTION
This PR enables `UNNEST`:ing lists that contains element of the fixed-size array type. This was previously not supported.

E.g. you can now do:
```sql
 SELECT unnest([[1,2,3], NULL, [4,5,6]]::INT[3][]) as lists;
┌────────────┐
│   lists    │
│ integer[3] │
├────────────┤
│ [1, 2, 3]  │
│            │
│ [4, 5, 6]  │
└────────────┘
```
Note that this PR does _not_ enable `UNNEST`:ing arrays themselves, that work still remains for a future PR.
```sql
SELECT unnest([1,2,3]::INT[3]);
Binder Error: UNNEST() can only be applied to lists, structs and NULL
LINE 1: SELECT unnest([1,2,3]::INT[3]);
```