### PR TITLE
CSV Sniffer - Error Messages

### DIFF
--- a/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
@@ -207,8 +207,6 @@ SnifferResult CSVSniffer::SniffCSV(bool force_match) {
 				}
 			}
 		}
-		auto error = CSVError::SniffingErrorFoundErrors(options.file_path);
-		error_handler->Error(error);
 	}
 	D_ASSERT(best_sql_types_candidates_per_column_idx.size() == names.size());
 	// We are done, Set the CSV Options in the reference. Construct and return the result.

--- a/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
@@ -207,7 +207,7 @@ SnifferResult CSVSniffer::SniffCSV(bool force_match) {
 				}
 			}
 		}
-		auto error = CSVError::SniffingError(options.file_path);
+		auto error = CSVError::SniffingErrorFoundErrors(options.file_path);
 		error_handler->Error(error);
 	}
 	D_ASSERT(best_sql_types_candidates_per_column_idx.size() == names.size());

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -34,6 +34,50 @@ vector<char> DialectCandidates::GetDefaultComment() {
 	return {'#', '\0'};
 }
 
+string DialectCandidates::Print() {
+	std::ostringstream search_space;
+
+	search_space << "Delimiter Candidates: ";
+	for (idx_t i = 0; i < delim_candidates.size(); i++) {
+		search_space << "\'" << delim_candidates[i] << "\'";
+		if (i < delim_candidates.size() - 1) {
+			search_space << ", ";
+		}
+	}
+	search_space << "\n";
+	search_space << "Quote/Escape Candidates: ";
+	for (uint8_t i = 0; i < static_cast<uint8_t>(quoterule_candidates.size()); i++) {
+		auto quote_candidate = quote_candidates_map[i];
+		auto escape_candidate = escape_candidates_map[i];
+		for (idx_t j = 0; j < quote_candidate.size(); j++) {
+			for (idx_t k = 0; k < escape_candidate.size(); k++) {
+				search_space << "[\'" << quote_candidate[j] << "\',\'" << escape_candidate[k] << "\']";
+				if (k < escape_candidate.size() - 1) {
+					search_space << ",";
+				}
+			}
+			if (j < quote_candidate.size() - 1) {
+				search_space << ",";
+			}
+		}
+		if (i < quoterule_candidates.size() - 1) {
+			search_space << ",";
+		}
+	}
+	search_space << "\n";
+
+	search_space << "Comment Candidates: ";
+	for (idx_t i = 0; i < comment_candidates.size(); i++) {
+		search_space << "\'" << comment_candidates[i] << "\'";
+		if (i < comment_candidates.size() - 1) {
+			search_space << ", ";
+		}
+	}
+	search_space << "\n";
+
+	return search_space.str();
+}
+
 DialectCandidates::DialectCandidates(const CSVStateMachineOptions &options) {
 	// assert that quotes escapes and rules have equal size
 	auto default_quote = GetDefaultQuote();
@@ -474,7 +518,7 @@ void CSVSniffer::DetectDialect() {
 
 	// if no dialect candidate was found, we throw an exception
 	if (candidates.empty()) {
-		auto error = CSVError::SniffingError(buffer_manager->GetFilePath());
+		auto error = CSVError::DialectSniffingError(options, dialect_candidates.Print());
 		error_handler->Error(error);
 	}
 }

--- a/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
@@ -193,7 +193,9 @@ CSVSniffer::DetectHeaderInternal(ClientContext &context, vector<HeaderValue> &be
 	// If null-padding is not allowed and there is a mismatch between our header candidate and the number of columns
 	// We can't detect the dialect/type options properly
 	if (!options.null_padding && best_sql_types_candidates_per_column_idx.size() != best_header_row.size()) {
-		auto error = CSVError::SniffingError(options.file_path);
+		auto error =
+		    CSVError::HeaderSniffingError(options, best_header_row, best_sql_types_candidates_per_column_idx.size(),
+		                                  state_machine.dialect_options.state_machine_options.delimiter.GetValue());
 		error_handler.Error(error);
 	}
 	bool all_varchar = true;

--- a/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
@@ -272,7 +272,7 @@ void CSVSniffer::InitializeDateAndTimeStampDetection(CSVStateMachine &candidate,
 }
 
 void CSVSniffer::DetectDateAndTimeStampFormats(CSVStateMachine &candidate, const LogicalType &sql_type,
-                                               const string &separator, string_t &dummy_val) {
+                                               const string &separator, const string_t &dummy_val) {
 	// If it is the first time running date/timestamp detection we must initialize the format variables
 	InitializeDateAndTimeStampDetection(candidate, separator, sql_type);
 	// generate date format candidates the first time through
@@ -413,9 +413,10 @@ void CSVSniffer::DetectTypes() {
 
 		// it's good if the dialect creates more non-varchar columns, but only if we sacrifice < 30% of
 		// best_num_cols.
-		if (varchar_cols<min_varchar_cols &&static_cast<double>(info_sql_types_candidates.size())>(
-		        static_cast<double>(max_columns_found) * 0.7) &&
-		    (!options.ignore_errors.GetValue() || candidate->error_handler->errors.size() < min_errors)) {
+		if (!best_candidate ||
+		    (varchar_cols<min_varchar_cols &&static_cast<double>(info_sql_types_candidates.size())>(
+		         static_cast<double>(max_columns_found) * 0.7) &&
+		     (!options.ignore_errors.GetValue() || candidate->error_handler->errors.size() < min_errors))) {
 			min_errors = candidate->error_handler->errors.size();
 			best_header_row.clear();
 			// we have a new best_options candidate
@@ -439,10 +440,6 @@ void CSVSniffer::DetectTypes() {
 				}
 			}
 		}
-	}
-	if (!best_candidate) {
-		auto error = CSVError::SniffingError(options.file_path);
-		error_handler->Error(error, true);
 	}
 	// Assert that it's all good at this point.
 	D_ASSERT(best_candidate && !best_format_candidates.empty());

--- a/src/execution/operator/csv_scanner/util/csv_error.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_error.cpp
@@ -174,20 +174,6 @@ CSVError CSVError::LineSizeError(const CSVReaderOptions &options, idx_t actual_s
 	                how_to_fix_it.str(), current_path);
 }
 
-CSVError CSVError::SniffingError(const string &file_path) {
-	std::ostringstream error;
-	// Which column
-	error << "aeouhuae";
-	return CSVError(error.str(), SNIFFING, {});
-}
-
-CSVError CSVError::SniffingErrorFoundErrors(const string &file_path) {
-	std::ostringstream error;
-	// Which column
-	error << "aeouhuae";
-	return CSVError(error.str(), SNIFFING, {});
-}
-
 CSVError CSVError::HeaderSniffingError(const CSVReaderOptions &options, const vector<HeaderValue> &best_header_row,
                                        idx_t column_count, char delimiter) {
 	std::ostringstream error;
@@ -293,7 +279,8 @@ CSVError CSVError::DialectSniffingError(const CSVReaderOptions &options, const s
 	if (!options.null_padding) {
 		error << "* Enable null padding (null_padding=true) to pad missing columns with NULL values" << '\n';
 	}
-	error << "* Check you are using the correct file compression, otherwise set it (e.g., compression = \'zstd\')" << '\n';
+	error << "* Check you are using the correct file compression, otherwise set it (e.g., compression = \'zstd\')"
+	      << '\n';
 
 	return CSVError(error.str(), SNIFFING, {});
 }

--- a/src/execution/operator/csv_scanner/util/csv_error.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_error.cpp
@@ -177,8 +177,14 @@ CSVError CSVError::LineSizeError(const CSVReaderOptions &options, idx_t actual_s
 CSVError CSVError::SniffingError(const string &file_path) {
 	std::ostringstream error;
 	// Which column
-	error << "Error when sniffing file \"" << file_path << "\"." << '\n';
-	error << "CSV options could not be auto-detected. Consider setting parser options manually." << '\n';
+	error << "aeouhuae";
+	return CSVError(error.str(), SNIFFING, {});
+}
+
+CSVError CSVError::SniffingErrorFoundErrors(const string &file_path) {
+	std::ostringstream error;
+	// Which column
+	error << "aeouhuae";
 	return CSVError(error.str(), SNIFFING, {});
 }
 
@@ -287,6 +293,8 @@ CSVError CSVError::DialectSniffingError(const CSVReaderOptions &options, const s
 	if (!options.null_padding) {
 		error << "* Enable null padding (null_padding=true) to pad missing columns with NULL values" << '\n';
 	}
+	error << "* Check you are using the correct file compression, otherwise set it (e.g., compression = \'zstd\')" << '\n';
+
 	return CSVError(error.str(), SNIFFING, {});
 }
 

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_reader_options.hpp"
+#include "duckdb/execution/operator/csv_scanner/header_value.hpp"
 
 namespace duckdb {
 
@@ -67,6 +68,9 @@ public:
 	static CSVError SniffingError(const string &file_path);
 	//! Produces an error message for a dialect sniffing error.
 	static CSVError DialectSniffingError(const CSVReaderOptions &options, const string &search_space);
+	//! Produces an error message for a header sniffing error.
+	static CSVError HeaderSniffingError(const CSVReaderOptions &options, const vector<HeaderValue> &best_header_row,
+	                                    idx_t column_count, char delimiter);
 	//! Produces error messages for unterminated quoted values
 	static CSVError UnterminatedQuotesError(const CSVReaderOptions &options, idx_t current_column,
 	                                        LinesPerBoundary error_info, string &csv_row, idx_t row_byte_position,

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
@@ -64,10 +64,6 @@ public:
 	//! Produces error for when the line size exceeds the maximum line size option
 	static CSVError LineSizeError(const CSVReaderOptions &options, idx_t actual_size, LinesPerBoundary error_info,
 	                              string &csv_row, idx_t byte_position, const string &current_path);
-	//! Produces error for when the sniffer couldn't find viable options
-	static CSVError SniffingError(const string &file_path);
-	static CSVError SniffingErrorFoundErrors(const string &file_path);
-
 	//! Produces an error message for a dialect sniffing error.
 	static CSVError DialectSniffingError(const CSVReaderOptions &options, const string &search_space);
 	//! Produces an error message for a header sniffing error.

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
@@ -65,6 +65,8 @@ public:
 	                              string &csv_row, idx_t byte_position, const string &current_path);
 	//! Produces error for when the sniffer couldn't find viable options
 	static CSVError SniffingError(const string &file_path);
+	//! Produces an error message for a dialect sniffing error.
+	static CSVError DialectSniffingError(const CSVReaderOptions &options, const string &search_space);
 	//! Produces error messages for unterminated quoted values
 	static CSVError UnterminatedQuotesError(const CSVReaderOptions &options, idx_t current_column,
 	                                        LinesPerBoundary error_info, string &csv_row, idx_t row_byte_position,

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
@@ -66,6 +66,8 @@ public:
 	                              string &csv_row, idx_t byte_position, const string &current_path);
 	//! Produces error for when the sniffer couldn't find viable options
 	static CSVError SniffingError(const string &file_path);
+	static CSVError SniffingErrorFoundErrors(const string &file_path);
+
 	//! Produces an error message for a dialect sniffing error.
 	static CSVError DialectSniffingError(const CSVReaderOptions &options, const string &search_space);
 	//! Produces an error message for a header sniffing error.

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "duckdb/common/typedefs.hpp"
-#include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
@@ -81,12 +80,12 @@ public:
 	                            string &csv_row, idx_t row_byte_position, optional_idx byte_position,
 	                            const string &current_path);
 
-	idx_t GetBoundaryIndex() {
+	idx_t GetBoundaryIndex() const {
 		return error_info.boundary_idx;
 	}
 
 	//! We might want to remove newline in errors if we are doing them for the rejects tables
-	void RemoveNewLine(string &error);
+	static void RemoveNewLine(string &error);
 
 	//! Actual error message
 	string error_message;
@@ -96,15 +95,15 @@ public:
 	//! 3. Options that generated the error
 	string full_error_message;
 	//! Error Type
-	CSVErrorType type;
+	CSVErrorType type {};
 	//! Column Index where error happened
-	idx_t column_idx;
+	idx_t column_idx {};
 	//! Original CSV row where error happened
 	string csv_row;
 	//! Line information regarding this error
 	LinesPerBoundary error_info;
 	//! Byte position of where the row starts
-	idx_t row_byte_position;
+	idx_t row_byte_position {};
 	//! Byte Position where error occurred.
 	optional_idx byte_position;
 };
@@ -125,7 +124,7 @@ public:
 	//! Set of errors
 	map<LinesPerBoundary, vector<CSVError>> errors;
 
-	idx_t GetMaxLineLength() {
+	idx_t GetMaxLineLength() const {
 		return max_line_length;
 	}
 	void DontPrintErrorLine() {
@@ -135,9 +134,9 @@ public:
 private:
 	//! Private methods should always be locked by parent method.
 	//! If we should print the line of an error
-	bool PrintLineNumber(CSVError &error);
+	bool PrintLineNumber(const CSVError &error) const;
 	//! Method that actually throws the error
-	void ThrowError(CSVError csv_error);
+	void ThrowError(const CSVError &csv_error);
 	//! If we processed all boundaries before the one that error-ed
 	bool CanGetLine(idx_t boundary_index);
 	//! Return the 1-indexed line number

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/execution/operator/csv_scanner/quote_rules.hpp"
 #include "duckdb/execution/operator/csv_scanner/column_count_scanner.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_schema.hpp"
+#include "duckdb/execution/operator/csv_scanner/header_value.hpp"
 
 namespace duckdb {
 struct DateTimestampSniffing {
@@ -104,19 +105,6 @@ struct SetColumns {
 		// Unacceptable
 		return true;
 	}
-};
-
-struct HeaderValue {
-	HeaderValue() : is_null(true) {
-	}
-	explicit HeaderValue(const string_t value_p) {
-		value = value_p.GetString();
-	}
-	bool IsNull() {
-		return is_null;
-	}
-	bool is_null = false;
-	string value;
 };
 
 //! Sniffer that detects Header, Dialect and Types of CSV Files

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
@@ -184,14 +184,15 @@ private:
 	void DetectTypes();
 	//! Change the date format for the type to the string
 	//! Try to cast a string value to the specified sql type
-	void SetDateFormat(CSVStateMachine &candidate, const string &format_specifier, const LogicalTypeId &sql_type);
+	static void SetDateFormat(CSVStateMachine &candidate, const string &format_specifier,
+	                          const LogicalTypeId &sql_type);
 
 	//! Function that initialized the necessary variables used for date and timestamp detection
 	void InitializeDateAndTimeStampDetection(CSVStateMachine &candidate, const string &separator,
 	                                         const LogicalType &sql_type);
 	//! Functions that performs detection for date and timestamp formats
 	void DetectDateAndTimeStampFormats(CSVStateMachine &candidate, const LogicalType &sql_type, const string &separator,
-	                                   string_t &dummy_val);
+	                                   const string_t &dummy_val);
 	//! Sniffs the types from a data chunk
 	void SniffTypes(DataChunk &data_chunk, CSVStateMachine &state_machine,
 	                unordered_map<idx_t, vector<LogicalType>> &info_sql_types_candidates, idx_t start_idx_detection);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
@@ -47,6 +47,8 @@ struct DialectCandidates {
 
 	static vector<char> GetDefaultComment();
 
+	string Print();
+
 	//! Candidates for the delimiter
 	vector<char> delim_candidates;
 	//! Candidates for the comment

--- a/src/include/duckdb/execution/operator/csv_scanner/header_value.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/header_value.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/operator/csv_scanner/header_value.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types/string_type.hpp"
+
+namespace duckdb {
+struct HeaderValue {
+	HeaderValue() : is_null(true) {
+	}
+	explicit HeaderValue(const string_t value_p) {
+		value = value_p.GetString();
+	}
+	bool IsNull() {
+		return is_null;
+	}
+	bool is_null = false;
+	string value;
+};
+} // namespace duckdb

--- a/test/sql/copy/csv/auto/test_auto_column_type_opt.test
+++ b/test/sql/copy/csv/auto/test_auto_column_type_opt.test
@@ -10,31 +10,37 @@ PRAGMA enable_verification
 statement error
 select * from read_csv('data/csv/test/multi_column_string.csv',  COLUMN_TYPES=STRUCT_PACK(a := 'INTEGER'))
 ----
+Columns with names: "a" do not exist in the CSV File
 
 # Test non-struct throws
 statement error
 select * from read_csv_auto('data/csv/test/multi_column_string.csv',  COLUMN_TYPES=1)
 ----
+COLUMN_TYPES requires a struct or list as input
 
 # Test empty throws
 statement error
 select * from read_csv_auto('data/csv/test/multi_column_string.csv',  COLUMN_TYPES=STRUCT_PACK())
 ----
+Can't pack nothing into a struct
 
 # Test funky type throws
 statement error
 select * from read_csv_auto('data/csv/test/multi_column_string.csv',  COLUMN_TYPES=STRUCT_PACK(a := 'BLA'))
 ----
+Type with name BLA does not exist!
 
 # Test funky name throws
 statement error
 select * from read_csv_auto('data/csv/test/multi_column_string.csv',  COLUMN_TYPES=STRUCT_PACK(bla := 'INTEGER'))
 ----
+Columns with names: "bla" do not exist in the CSV File
 
 # Test wrong type throws
 statement error
 select * from read_csv_auto('data/csv/test/multi_column_string.csv',  COLUMN_TYPES=STRUCT_PACK(column3 := 'INTEGER'))
 ----
+This type was either manually set or derived from an existing table. Select a different type to correctly parse this column.
 
 # Test 1st column defined
 query I

--- a/test/sql/copy/csv/auto/test_fallback_all_varchar.test
+++ b/test/sql/copy/csv/auto/test_fallback_all_varchar.test
@@ -27,6 +27,7 @@ loop i 1 100
 statement error
 CREATE TABLE test AS SELECT * FROM read_csv_auto ('data/csv/auto/test_fallback.csv', SAMPLE_SIZE=1);
 ----
+Column TestDoubleError is being converted as type DOUBLE
 
 endloop
 # CSV file with irregularity in first column, small sample size and fallback activated

--- a/test/sql/copy/csv/code_cov/csv_dialect_detection.test
+++ b/test/sql/copy/csv/code_cov/csv_dialect_detection.test
@@ -18,4 +18,4 @@ SELECT * from read_csv_auto('data/csv/escape.csv', header = 0)
 statement error
 SELECT * from read_csv_auto('data/csv/no_opt.csv', delim = ';')
 ----
-CSV options could not be auto-detected. Consider setting parser options manually.
+It was not possible to automatically detect the CSV Parsing dialect

--- a/test/sql/copy/csv/csv_external_access.test
+++ b/test/sql/copy/csv/csv_external_access.test
@@ -17,23 +17,28 @@ SET enable_external_access=false;
 statement error
 SELECT * FROM read_csv('data/csv/test/date.csv', columns = {'d': 'DATE'});
 ----
+Scanning read_csv files is disabled through configuration
 
 statement error
 SELECT * FROM read_csv_auto('data/csv/test/date.csv');
 ----
+Scanning read_csv_auto files is disabled through configuration
 
 statement error
 COPY date_test FROM 'data/csv/test/date.csv';
 ----
+COPY FROM is disabled by configuration
 
 statement error
 COPY date_test TO '__TEST_DIR__/date.csv'
 ----
+COPY TO is disabled by configuration
 
 # we also can't just enable external access again
 statement error
 SET enable_external_access=true;
 ----
+Cannot change enable_external_access setting while database is running
 
 # sniffer also respects external access flag
 statement error

--- a/test/sql/copy/csv/csv_hive_filename_union.test
+++ b/test/sql/copy/csv/csv_hive_filename_union.test
@@ -58,6 +58,7 @@ xxx	42
 statement error
 select * from read_csv_auto(['data/csv/hive-partitioning/mismatching_contents/part=1/test.csv', 'data/csv/hive-partitioning/mismatching_contents/part=2/test.csv'])  order by 1
 ----
+If you are trying to read files with different schemas, try setting union_by_name=True
 
 query III
 select a, b, c from read_csv_auto('data/csv/hive-partitioning/mismatching_contents/*/*.csv', UNION_BY_NAME=1)  order by 2 NULLS LAST

--- a/test/sql/copy/csv/csv_names.test
+++ b/test/sql/copy/csv/csv_names.test
@@ -56,6 +56,7 @@ read_csv_auto column_names/names can only be supplied once
 statement error
 select l_orderkey, l_partkey, column02, column03 from read_csv_auto('data/csv/real/lineitem_sample.csv', names=42) LIMIT 1;
 ----
+Failed to cast value: Unimplemented type for cast (INTEGER -> VARCHAR[])
 
 # duplicate names
 statement error

--- a/test/sql/copy/csv/glob/copy_csv_glob.test
+++ b/test/sql/copy/csv/glob/copy_csv_glob.test
@@ -29,4 +29,5 @@ SELECT * FROM dates ORDER BY 1
 statement error
 COPY dates FROM read_csv('data/csv/glob/*/a*a.csv', auto_detect=1)
 ----
+syntax error at or near "'data/csv/glob/*/a*a.csv'"
 

--- a/test/sql/copy/csv/glob/copy_csv_glob_s3.test
+++ b/test/sql/copy/csv/glob/copy_csv_glob_s3.test
@@ -69,5 +69,6 @@ SELECT * FROM dates ORDER BY 1
 statement error
 COPY dates FROM read_csv('s3://test-bucket/copy_csv_glob_s3/copy/*/a*a.csv', auto_detect=1)
 ----
+No files found that match the pattern
 
 endloop

--- a/test/sql/copy/csv/glob/read_csv_glob.test
+++ b/test/sql/copy/csv/glob/read_csv_glob.test
@@ -104,6 +104,7 @@ SELECT a, b LIKE '%a1.csv%' FROM read_csv('data/csv/*/a?/a*.csv', filename=1) t1
 statement error
 SELECT * FROM read_csv('data/csv/glob/*/*.csv') ORDER BY 1
 ----
+Schema mismatch between globbed files.
 
 # forcing string parsing works
 query I
@@ -171,14 +172,17 @@ SELECT COUNT(*) FROM glob('data//csv///glob///*//////*.csv')
 statement error
 SELECT * FROM read_csv('data/csv/glob/*/a*a.csv') ORDER BY 1
 ----
+No files found that match the pattern "data/csv/glob/*/a*a.csv"
 
 statement error
 SELECT * FROM read_csv(['data/csv/glob/*/a*a.csv']) ORDER BY 1
 ----
+No files found that match the pattern "data/csv/glob/*/a*a.csv"
 
 statement error
 SELECT * FROM read_csv_auto(['data/csv/glob/*/a*a.csv']) ORDER BY 1
 ----
+No files found that match the pattern "data/csv/glob/*/a*a.csv"
 
 query I
 SELECT COUNT(*) FROM glob('data/csv/glob/*/a*a.csv')

--- a/test/sql/copy/csv/maximum_line_size.test_slow
+++ b/test/sql/copy/csv/maximum_line_size.test_slow
@@ -12,6 +12,7 @@ CREATE TABLE test (a INTEGER, b VARCHAR, c INTEGER);
 statement error
 insert into test select * from read_csv('data/csv/test/test_long_line.csv', columns={'a': 'INTEGER',  'b': 'VARCHAR', 'c': 'INTEGER'}, maximum_line_size=0);
 ----
+Maximum line size of 0 bytes exceeded. Actual Size:10006 bytes.
 
 # Single line too long
 # "a".repeat(2 * 1024 * 1024 + 10);

--- a/test/sql/copy/csv/null_padding_big.test
+++ b/test/sql/copy/csv/null_padding_big.test
@@ -49,9 +49,9 @@ require notwindows
 statement error
 SELECT COUNT(*) FROM read_csv_auto('data/csv/nullpadding_big_mixed.csv', buffer_size=55)
 ----
-CSV options could not be auto-detected. Consider setting parser options manually.
+It was not possible to automatically detect the CSV Parsing dialect
 
 statement error
 SELECT COUNT(*) FROM read_csv_auto('data/csv/nullpadding_big_mixed.csv', buffer_size=55, null_padding=False)
 ----
-CSV options could not be auto-detected. Consider setting parser options manually.
+It was not possible to automatically detect the CSV Parsing dialect

--- a/test/sql/copy/csv/overwrite/test_copy_overwrite.test
+++ b/test/sql/copy/csv/overwrite/test_copy_overwrite.test
@@ -50,6 +50,7 @@ SELECT * FROM test ORDER BY 1;
 statement error
 COPY (SELECT i FROM range(1) tbl(i) UNION ALL SELECT concat('hello', i)::INT i FROM range(1) tbl(i)) to '__TEST_DIR__/overwrite.csv';
 ----
+Could not convert string 'hello0' to INT32
 
 statement ok
 DELETE FROM test;
@@ -70,6 +71,7 @@ SELECT * FROM test ORDER BY 1;
 statement error
 COPY (SELECT i FROM range(1) tbl(i) UNION ALL SELECT concat('hello', i)::INT i FROM range(1) tbl(i)) to '__TEST_DIR__/overwrite.csv' (USE_TMP_FILE FALSE);
 ----
+Could not convert string 'hello0' to INT32
 
 query I
 SELECT * FROM '__TEST_DIR__/overwrite.csv';

--- a/test/sql/copy/csv/test_comment_option.test
+++ b/test/sql/copy/csv/test_comment_option.test
@@ -103,7 +103,7 @@ select SkipRows, Comment FROM sniff_csv('data/csv/comments/invalid_rows.csv');
 statement error
 select count(*) FROM 'data/csv/comments/error.csv';
 ----
-CSV options could not be auto-detected.
+It was not possible to automatically detect the CSV Parsing dialect
 
 query I
 select count(*) FROM read_csv('data/csv/comments/error.csv', ignore_errors = true);

--- a/test/sql/copy/csv/test_compression_flag.test
+++ b/test/sql/copy/csv/test_compression_flag.test
@@ -55,7 +55,7 @@ DROP TABLE lineitem
 statement error
 COPY lineitem FROM 'data/csv/test/test_comp.csv.gz' COMPRESSION 'none';
 ----
-
+syntax error at or near "COMPRESSION"
 
 statement ok
 CREATE TABLE lineitem AS SELECT * FROM read_csv_auto('data/csv/test/test_comp.csv.gzz', compression='gzip');

--- a/test/sql/copy/csv/test_copy.test
+++ b/test/sql/copy/csv/test_copy.test
@@ -57,6 +57,7 @@ CREATE TABLE test_too_few_rows (a INTEGER, b INTEGER, c VARCHAR, d INTEGER);
 statement error
 COPY test_too_few_rows FROM '__TEST_DIR__/test2.csv' (NULL_PADDING 0);
 ----
+It was not possible to automatically detect the CSV Parsing dialect
 
 # create CSV file from query
 query I
@@ -106,64 +107,77 @@ SELECT * FROM test4 ORDER BY 1 LIMIT 3;
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (SEP ',', HEADER 0.2);
 ----
+"header" expects a boolean value (e.g. TRUE or 1)
 
 # empty delimiter
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (SEP);
 ----
+"sep" expects a single argument as a string value
 
 # number as delimiter
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (SEP 1);
 ----
+"sep" expects a string argument!
 
 # multiple format options
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (FORMAT 'csv', FORMAT 'json');
 ----
+Copy Function with name "json" is not in the catalog, but it exists in the json extension.
 
 # number as escape string
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ESCAPE 1);
 ----
+"escape" expects a string argument!
 
 # no escape string
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ESCAPE);
 ----
+"escape" expects a single argument as a string value
 
 # number as quote string
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (QUOTE 1);
 ----
+"quote" expects a string argument!
 
 # no quote string
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (QUOTE);
 ----
+"quote" expects a single argument as a string value
 
 # no format string
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (FORMAT);
 ----
+Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'
 
 # encoding must not be empty and must have the correct parameter type and value
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ENCODING);
 ----
+"encoding" expects a single argument as a string value
 
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ENCODING 42);
 ----
+"encoding" expects a string argument!
 
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (ENCODING 'utf-42');
 ----
+Copy is only supported for UTF-8 encoded files, ENCODING 'UTF-8'
 
 # don't allow for non-existant copy options
 statement error
 COPY test4 (a,c) FROM '__TEST_DIR__/test4.csv' (MAGIC '42');
 ----
+Unrecognized option for CSV reader "magic"
 
 # Try new_line option
 query I
@@ -244,6 +258,7 @@ COPY test FROM 'data/csv/test/test_pipe.csv' (SEPARATOR '|');
 statement error
 COPY test FROM 'data/csv/test/too_many_values.csv';
 ----
+It was not possible to automatically detect the CSV Parsing dialect
 
 # test default null string
 query I
@@ -255,6 +270,7 @@ COPY test FROM 'data/csv/test/test_null_csv.csv' DELIMITER '|';
 statement error
 COPY test FROM 'data/csv/test/invalid_utf.csv' DELIMITER '|';
 ----
+Invalid unicode (byte sequence mismatch) detected.
 
 # empty file
 statement ok

--- a/test/sql/copy/csv/test_copy.test
+++ b/test/sql/copy/csv/test_copy.test
@@ -263,7 +263,7 @@ CREATE TABLE empty_table (a INTEGER, b INTEGER, c VARCHAR(10));
 statement error
 COPY empty_table FROM 'data/csv/test/empty.csv' (HEADER 0);
 ----
-CSV options could not be auto-detected. Consider setting parser options manually.
+It was not possible to automatically detect the CSV Parsing dialect
 
 
 # unterminated quotes

--- a/test/sql/copy/csv/test_copy_null.test
+++ b/test/sql/copy/csv/test_copy_null.test
@@ -77,24 +77,29 @@ SELECT * FROM test_null_option ORDER BY 1 LIMIT 3;
 statement error
 COPY test_null_option FROM 'data/csv/test/test_null_option.csv' (NULL null);
 ----
+syntax error at or near "null"
 
 # delimiter must not appear in the NULL specification
 statement error
 COPY test_null_option FROM 'data/csv/test/test_null_option.csv' (NULL 'null,', DELIMITER ',');
 ----
+DELIMITER must not appear in the NULL specification and vice versa
 
 statement error
 COPY test_null_option FROM 'data/csv/test/test_null_option.csv' (DELIMITER 'null', NULL 'null');
 ----
+The delimiter option cannot exceed a size of 1 byte.
 
 statement error
 COPY test_null_option FROM 'data/csv/test/test_null_option.csv' (DELIMITER 'null', NULL 'nu');
 ----
+The delimiter option cannot exceed a size of 1 byte.
 
 # no parameter type
 statement error
 COPY test_null_option FROM 'data/csv/test/test_null_option.csv' (NULL);
 ----
+CSV Reader function option null requires a non-empty list of possible null strings (varchar) as input
 
 # empty integer column with non-default NULL string
 statement ok
@@ -103,6 +108,7 @@ CREATE TABLE test_null_option_2 (col_a INTEGER, col_b INTEGER, col_c VARCHAR(10)
 statement error
 COPY test_null_option_2 FROM 'data/csv/test/test_null_option.csv' (NULL 'null');
 ----
+It was not possible to automatically detect the CSV Parsing dialect
 
 # test COPY ... TO ...
 # implicitly using default NULL value

--- a/test/sql/copy/csv/test_csv_httpfs_prepared.test
+++ b/test/sql/copy/csv/test_csv_httpfs_prepared.test
@@ -30,6 +30,7 @@ DEALLOCATE boaz_bug
 statement error
 EXECUTE boaz_bug
 ----
+Prepared statement "boaz_bug" does not exist
 
 # Recreate prepared statement with different file
 

--- a/test/sql/copy/csv/test_csv_wrong_file.test_slow
+++ b/test/sql/copy/csv/test_csv_wrong_file.test_slow
@@ -18,4 +18,4 @@ restart
 statement error
 from read_csv('__TEST_DIR__/test_csv_tpch.db')
 ----
-CSV options could not be auto-detected. Consider setting parser options manually.
+It was not possible to automatically detect the CSV Parsing dialect

--- a/test/sql/copy/csv/test_dateformat.test
+++ b/test/sql/copy/csv/test_dateformat.test
@@ -95,6 +95,7 @@ SELECT * FROM new_timestamps ORDER BY 1
 statement error
 COPY dates FROM 'data/csv/test/dateformat.csv' (HEADER 0, DATEFORMAT '%')
 ----
+Could not parse DATEFORMAT: Trailing format character %
 
 statement error
 COPY timestamps FROM 'data/csv/test/timestampformat.csv' (HEADER 0, DELIMITER '|', TIMESTAMPFORMAT '%')

--- a/test/sql/copy/csv/test_force_not_null.test
+++ b/test/sql/copy/csv/test_force_not_null.test
@@ -42,25 +42,30 @@ SELECT * FROM test ORDER BY 1;
 statement error
 COPY test TO 'data/csv/test/force_not_null.csv' (FORCE_NOT_NULL (col_b), NULL 'test', HEADER 0);
 ----
+ Unrecognized option CSV writer "force_not_null"
 
 # FORCE_NOT_NULL must not be empty and must have the correct parameter type
 statement error
 COPY test FROM 'data/csv/test/force_not_null.csv' (FORCE_NOT_NULL, NULL 'test');
 ----
+"force_not_null" expects a column list or * as parameter
 
 statement error
 COPY test FROM 'data/csv/test/force_not_null.csv' (FORCE_NOT_NULL 42, NULL 'test');
 ----
+"force_not_null" expected to find 42, but it was not found in the table
 
 # test using a column in FORCE_NOT_NULL that is not set as output, but that is a column of the table
 statement error
 COPY test (col_b, col_a) FROM 'data/csv/test/force_not_null_reordered.csv' (FORCE_NOT_NULL (col_c, col_b));
 ----
+"force_not_null" expected to find col_c, but it was not found in the table
 
 # test using a column in FORCE_NOT_NULL that is not a column of the table
 statement error
 COPY test FROM 'data/csv/test/force_not_null_reordered.csv' (FORCE_NOT_NULL (col_c, col_d));
 ----
+"force_not_null" expected to find col_d, but it was not found in the table
 
 # FORCE_NOT_NULL fails on integer columns with NULL values, but only if there are null values
 query I

--- a/test/sql/copy/csv/test_force_quote.test
+++ b/test/sql/copy/csv/test_force_quote.test
@@ -69,23 +69,28 @@ SELECT * FROM test2
 statement error
 COPY test (col_b, col_a) TO '__TEST_DIR__/test_reorder.csv' (FORCE_QUOTE (col_c, col_b));
 ----
+"force_quote" expected to find col_c, but it was not found in the table
 
 # test using a column in FORCE_QUOTE that is not a column of the table
 statement error
 COPY test TO '__TEST_DIR__/test_reorder.csv' (FORCE_QUOTE (col_c, col_d));
 ----
+"force_quote" expected to find col_d, but it was not found in the table
 
 # FORCE_QUOTE is only supported in COPY ... TO ...
 statement error
 COPY test FROM '__TEST_DIR__/test_reorder.csv' (FORCE_QUOTE (col_c, col_d));
 ----
+Unrecognized option for CSV reader "force_quote"
 
 # FORCE_QUOTE must not be empty and must have the correct parameter type
 statement error
 COPY test TO '__TEST_DIR__/test_reorder.csv' (FORCE_QUOTE);
 ----
+"force_quote" expects a column list or * as parameter
 
 statement error
 COPY test TO '__TEST_DIR__/test_reorder.csv' (FORCE_QUOTE 42);
 ----
+"force_quote" expected to find 42, but it was not found in the table
 

--- a/test/sql/copy/csv/test_ignore_errors.test
+++ b/test/sql/copy/csv/test_ignore_errors.test
@@ -71,7 +71,7 @@ COPY integers FROM 'data/csv/test/error_too_many.csv' (HEADER, IGNORE_ERRORS, SA
 statement error
 COPY integers FROM 'data/csv/test/error_too_many.csv' (HEADER)
 ----
-CSV options could not be auto-detected. Consider setting parser options manually.
+It was not possible to automatically detect the CSV Parsing dialect
 
 # too many columns provided
 query II

--- a/test/sql/copy/csv/test_ignore_errors.test
+++ b/test/sql/copy/csv/test_ignore_errors.test
@@ -15,6 +15,7 @@ COPY integers FROM 'data/csv/test/error_too_little.csv' (HEADER, IGNORE_ERRORS, 
 statement error
 COPY integers FROM 'data/csv/test/error_too_little.csv' (HEADER, NULL_PADDING FALSE)
 ----
+It was not possible to automatically detect the CSV Parsing dialect
 
 # not enough columns provided
 query II
@@ -35,6 +36,7 @@ INSERT INTO integers SELECT * FROM read_csv('data/csv/test/error_too_little.csv'
 statement error
 INSERT INTO integers SELECT * FROM read_csv('data/csv/test/error_too_little.csv', columns={'i': 'INTEGER'}, null_padding=0)
 ----
+table integers has 2 columns but 1 values were supplied
 
 # not enough columns provided
 query II
@@ -55,6 +57,7 @@ COPY integers FROM 'data/csv/test/error_too_little_single.csv' (HEADER, IGNORE_E
 statement error
 COPY integers FROM 'data/csv/test/error_too_little_single.csv' (HEADER, NULL_PADDING 0)
 ----
+It was not possible to automatically detect the CSV Parsing dialect
 
 # not enough columns provided, single value
 query II
@@ -92,6 +95,7 @@ COPY integers FROM 'data/csv/test/error_invalid_type.csv' (HEADER, IGNORE_ERRORS
 statement error
 COPY integers FROM 'data/csv/test/error_invalid_type.csv' (HEADER)
 ----
+This type was either manually set or derived from an existing table. Select a different type to correctly parse this column.
 
 # too many columns provided
 query II

--- a/test/sql/copy/csv/test_ignore_errors_end_of_chunk.test
+++ b/test/sql/copy/csv/test_ignore_errors_end_of_chunk.test
@@ -41,7 +41,7 @@ COPY integers FROM 'data/csv/test/error_too_little_end_of_filled_chunk.csv' (HEA
 statement error
 COPY integers FROM 'data/csv/test/error_too_little_end_of_filled_chunk.csv' (HEADER, NULL_PADDING 0)
 ----
-CSV options could not be auto-detected. Consider setting parser options manually.
+It was not possible to automatically detect the CSV Parsing dialect
 
 # not enough columns provided
 query II

--- a/test/sql/copy/csv/test_read_csv.test
+++ b/test/sql/copy/csv/test_read_csv.test
@@ -68,4 +68,5 @@ SELECT l_partkey, RTRIM(l_comment) FROM lineitem WHERE l_orderkey=1 ORDER BY l_l
 statement error
 SELECT * FROM read_csv('data/csv/real/lineitem_sample.csv', sep='|', columns=STRUCT_PACK(l_orderkey := 5))
 ----
+read_csv requires a type specification as string
 

--- a/test/sql/copy/csv/test_sniff_csv_options.test
+++ b/test/sql/copy/csv/test_sniff_csv_options.test
@@ -12,7 +12,7 @@ require notwindows
 statement error
 FROM sniff_csv('data/csv/real/lineitem_sample.csv', delim = ',');
 ----
-CSV options could not be auto-detected. Consider setting parser options manually.
+It was not possible to automatically detect the CSV Parsing dialect
 
 # Test user giving options that are also sniffed
 

--- a/test/sql/copy/csv/zstd_crash.test
+++ b/test/sql/copy/csv/zstd_crash.test
@@ -11,6 +11,7 @@ require no_extension_autoloading
 statement error
 CREATE TABLE test_zst AS SELECT * FROM read_csv('data/csv/broken/test.csv.zst', AUTO_DETECT=TRUE);
 ----
+Attempting to open a compressed file, but the compression type is not supported
 
 statement ok
 CREATE TABLE test_zst(a INTEGER, b INTEGER, c INTEGER, d VARCHAR, e VARCHAR);
@@ -19,22 +20,27 @@ CREATE TABLE test_zst(a INTEGER, b INTEGER, c INTEGER, d VARCHAR, e VARCHAR);
 statement error
 COPY test_zst FROM 'data/csv/broken/test.csv.zst' (COMPRESSION ZSTD);
 ----
+Attempting to open a compressed file, but the compression type is not supported
 
 statement error
 COPY test_zst FROM 'data/csv/broken/test.csv.zst' (COMPRESSION GZIP);
 ----
+Input is not a GZIP stream
 
 statement error
 COPY test_zst FROM 'data/csv/broken/test.csv.zst' (COMPRESSION NONE);
 ----
+* Check you are using the correct file compression, otherwise set it (e.g., compression = 'zstd')
 
 statement error
 COPY test_zst FROM 'data/csv/broken/test.csv.zst' (COMPRESSION INFER);
 ----
+Attempting to open a compressed file, but the compression type is not supported
 
 statement error
 COPY test_zst FROM 'data/csv/broken/test.csv.zst' (COMPRESSION UNKNOWN);
 ----
+Unrecognized file compression type "UNKNOWN"
 
 # zstd works once we load the parquet extension
 require parquet
@@ -49,6 +55,7 @@ COPY test_zst FROM 'data/csv/broken/test.csv.zst' (COMPRESSION ZSTD, AUTO_DETECT
 statement error
 COPY test_zst FROM 'data/csv/lineitem1k.tbl.gz' (COMPRESSION ZSTD);
 ----
+Unknown frame descriptor
 
 # we can read/write a ZSTD file also without the extension if we specify the compression type
 statement ok


### PR DESCRIPTION
This PR improves the sniffer error message, has some code improvements for the CSVError class, and revisits all empty `statement error` statements from CSV Sql tests.

As an example for a dialect detection error:

```sql
FROM read_csv('data/csv/no_opt.csv', delim = ';')
```

Old Message:
```
Invalid Input Error: Error when sniffing file "data/csv/no_opt.csv".
CSV options could not be auto-detected. Consider setting parser options manually.
```

New Message:
```
Invalid Input Error: Error when sniffing file "data/csv/no_opt.csv".
It was not possible to automatically detect the CSV Parsing dialect
The search space used was:
Delimiter Candidates: ';'
Quote/Escape Candidates: ['"','"'],['"','\0'],['"','''],['"','\'],[''','\'],['\0','\0']
Comment Candidates: '#', '\0'
Possible fixes:
* Delimiter is set to ';'. Consider unsetting it.
* Set quote (e.g., quote='"')
* Set escape (e.g., escape='"')
* Set comment (e.g., comment='#')
* Set skip (skip=${n}) to skip ${n} lines at the top of the file
* Enable ignore errors (ignore_errors=true) to ignore potential errors
* Enable null padding (null_padding=true) to pad missing columns with NULL values
```
