### PR TITLE
[Python UDF] Filter `NULL` values before calling the user defined function

### DIFF
--- a/src/common/vector_operations/vector_copy.cpp
+++ b/src/common/vector_operations/vector_copy.cpp
@@ -35,10 +35,7 @@ static const ValidityMask &ExtractValidityMask(const Vector &v) {
 }
 
 void VectorOperations::Copy(const Vector &source_p, Vector &target, const SelectionVector &sel_p, idx_t source_count,
-                            idx_t source_offset, idx_t target_offset) {
-	D_ASSERT(source_offset <= source_count);
-	D_ASSERT(source_p.GetType() == target.GetType());
-	idx_t copy_count = source_count - source_offset;
+                            idx_t source_offset, idx_t target_offset, idx_t copy_count) {
 
 	SelectionVector owned_sel;
 	const SelectionVector *sel = &sel_p;
@@ -173,7 +170,7 @@ void VectorOperations::Copy(const Vector &source_p, Vector &target, const Select
 		D_ASSERT(source_children.size() == target_children.size());
 		for (idx_t i = 0; i < source_children.size(); i++) {
 			VectorOperations::Copy(*source_children[i], *target_children[i], sel_p, source_count, source_offset,
-			                       target_offset);
+			                       target_offset, copy_count);
 		}
 		break;
 	}
@@ -265,6 +262,14 @@ void VectorOperations::Copy(const Vector &source_p, Vector &target, const Select
 	if (target_vector_type != VectorType::FLAT_VECTOR) {
 		target.SetVectorType(target_vector_type);
 	}
+}
+
+void VectorOperations::Copy(const Vector &source_p, Vector &target, const SelectionVector &sel_p, idx_t source_count,
+                            idx_t source_offset, idx_t target_offset) {
+	D_ASSERT(source_offset <= source_count);
+	D_ASSERT(source_p.GetType() == target.GetType());
+	idx_t copy_count = source_count - source_offset;
+	VectorOperations::Copy(source_p, target, sel_p, source_count, source_offset, target_offset, copy_count);
 }
 
 void VectorOperations::Copy(const Vector &source, Vector &target, idx_t source_count, idx_t source_offset,

--- a/src/include/duckdb/common/vector_operations/vector_operations.hpp
+++ b/src/include/duckdb/common/vector_operations/vector_operations.hpp
@@ -192,6 +192,8 @@ struct VectorOperations {
 	                 idx_t target_offset);
 	static void Copy(const Vector &source, Vector &target, const SelectionVector &sel, idx_t source_count,
 	                 idx_t source_offset, idx_t target_offset);
+	static void Copy(const Vector &source, Vector &target, const SelectionVector &sel, idx_t source_count,
+	                 idx_t source_offset, idx_t target_offset, idx_t copy_count);
 
 	// Copy the data of <source> to the target location, setting null values to
 	// NullValue<T>. Used to store data without separate NULL mask.

--- a/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
@@ -79,7 +79,7 @@ template <class T>
 bool try_cast(const handle &object, T &result) {
 	try {
 		result = cast<T>(object);
-	} catch (cast_error &) {
+	} catch (pybind11::cast_error &) {
 		return false;
 	}
 	return true;

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -201,7 +201,7 @@ static scalar_function_t CreateVectorizedFunction(PyObject *function, PythonExce
 			for (idx_t i = 0; i < input_size; i++) {
 				// Fill the gaps with the previous index
 				inverted.set_index(i, src_index);
-				if (src_index < count && selvec.get_index(src_index) == i) {
+				if (src_index + 1 < count && selvec.get_index(src_index) == i) {
 					src_index++;
 				}
 			}

--- a/tools/pythonpkg/src/typing/pytype.cpp
+++ b/tools/pythonpkg/src/typing/pytype.cpp
@@ -127,6 +127,9 @@ static bool FromNumpyType(const py::object &type, LogicalType &result) {
 	auto obj = type();
 	// We convert these to string because the underlying physical
 	// types of a numpy type aren't consistent on every platform
+	if (!py::hasattr(obj, "dtype")) {
+		return false;
+	}
 	string type_str = py::str(obj.attr("dtype"));
 	if (type_str == "bool") {
 		result = LogicalType::BOOLEAN;
@@ -185,7 +188,7 @@ static LogicalType FromType(const py::type &obj) {
 		return result;
 	}
 
-	throw py::type_error("Could not convert from unknown 'type' to DuckDBPyType");
+	throw py::cast_error("Could not convert from unknown 'type' to DuckDBPyType");
 }
 
 static bool IsMapType(const py::tuple &args) {

--- a/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
+++ b/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
@@ -1,0 +1,72 @@
+import duckdb
+import pytest
+
+pd = pytest.importorskip("pandas")
+pa = pytest.importorskip("pyarrow")
+from typing import Union
+import pyarrow.compute as pc
+
+from duckdb.typing import *
+
+
+class TestUDFNullFiltering(object):
+    @pytest.mark.parametrize(
+        'table_data',
+        [
+            ['12', None, '42'],
+            [None, '42', None],
+            ['12', None, None],
+            [None, None, '42'],
+            [None, None, None],
+        ],
+    )
+    def test_null_filtering_native(self, duckdb_cursor, table_data):
+        null_count = sum([1 for x in table_data if not x])
+        row_count = len(table_data)
+
+        df = pd.DataFrame({'a': table_data})
+        duckdb_cursor.execute("create table tbl as select * FROM df")
+
+        def my_native_func(x):
+            my_native_func.count += 1
+            return int(x)
+
+        my_native_func.count = 0
+        duckdb_cursor.create_function('other_test', my_native_func, [str], int)
+        result = duckdb_cursor.sql("select other_test(a::VARCHAR) from tbl").fetchall()
+        assert result == [tuple([int(x)]) if x else (None,) for x in table_data]
+        assert len(result) == row_count
+        # Only the non-null tuples should have been seen by the UDF
+        assert my_native_func.count == row_count - null_count
+
+    @pytest.mark.parametrize(
+        'table_data',
+        [
+            ['12', None, '42'],
+            [None, '42', None],
+            ['12', None, None],
+            [None, None, '42'],
+            [None, None, None],
+        ],
+    )
+    def test_null_filtering_vectorized(self, duckdb_cursor, table_data):
+        null_count = sum([1 for x in table_data if not x])
+        row_count = len(table_data)
+
+        df = pd.DataFrame({'a': table_data})
+        duckdb_cursor.execute("create table tbl as select * FROM df")
+
+        def my_vectorized_func(column):
+            python_array = column.to_pylist()
+            my_vectorized_func.count += len(python_array)
+            transformed_array = [int(value) for value in python_array]
+            arrow_array = pa.array(transformed_array, type=pa.int64())
+            return arrow_array
+
+        my_vectorized_func.count = 0
+        duckdb_cursor.create_function('other_test', my_vectorized_func, [str], int, type='arrow')
+        result = duckdb_cursor.sql("select other_test(a::VARCHAR) from tbl").fetchall()
+        assert result == [tuple([int(x)]) if x else (None,) for x in table_data]
+        assert len(result) == row_count
+        # Only the non-null tuples should have been seen by the UDF
+        assert my_vectorized_func.count == row_count - null_count

--- a/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
+++ b/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
@@ -5,71 +5,139 @@ pd = pytest.importorskip("pandas")
 pa = pytest.importorskip("pyarrow")
 from typing import Union
 import pyarrow.compute as pc
+import uuid
+import datetime
+import numpy as np
+import cmath
+from typing import NamedTuple, Any
 
 from duckdb.typing import *
+
+
+class Candidate(NamedTuple):
+    type: duckdb.typing.DuckDBPyType
+    variant_one: Any
+    variant_two: Any
+
+
+def get_layout():
+    return (
+        [
+            ['x', None, 'y'],
+            [None, 'y', None],
+            ['x', None, None],
+            [None, None, 'y'],
+            [None, None, None],
+        ],
+    )
+
+
+def get_types():
+    return [
+        Candidate(TINYINT, -42, -21),
+        Candidate(SMALLINT, -512, -256),
+        Candidate(INTEGER, -131072, -65536),
+        Candidate(
+            BIGINT,
+            -17179869184,
+            -8589934592,
+        ),
+        Candidate(
+            UTINYINT,
+            254,
+            127,
+        ),
+        Candidate(
+            USMALLINT,
+            65535,
+            32767,
+        ),
+        Candidate(
+            UINTEGER,
+            4294967295,
+            2147483647,
+        ),
+        Candidate(UBIGINT, 18446744073709551615, 9223372036854776000),
+        Candidate(HUGEINT, 18446744073709551616, 9223372036854776000),
+        Candidate(VARCHAR, 'long_string_test', 'smallstring'),
+        Candidate(
+            UUID, uuid.UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'), uuid.UUID('ffffffff-ffff-ffff-ffff-000000000000')
+        ),
+        Candidate(
+            FLOAT,
+            0.12246409803628922,
+            0.24492819607257843,
+        ),
+        Candidate(
+            DOUBLE,
+            123142.12312416293784721232344,
+            246284.2462483259,
+        ),
+        Candidate(DATE, datetime.date(2005, 3, 11), datetime.date(1989, 1, 7)),
+        Candidate(TIMESTAMP, datetime.datetime(2009, 2, 13, 11, 5, 53), datetime.datetime(1989, 11, 20, 5, 3, 25)),
+        Candidate(
+            TIME,
+            datetime.time(14, 1, 12),
+            datetime.time(6, 3, 6),
+        ),
+        Candidate(
+            BLOB,
+            b'\xF6\x96\xB0\x85',
+            b'\x85\xB0\x96\xF6',
+        ),
+        Candidate(
+            INTERVAL,
+            datetime.timedelta(days=30969, seconds=999, microseconds=999999),
+            datetime.timedelta(days=786, seconds=53, microseconds=651),
+        ),
+        Candidate(
+            BOOLEAN,
+            True,
+            False,
+        ),
+        Candidate(
+            duckdb.struct_type(['BIGINT[]', 'VARCHAR[]']),
+            {'v1': [1, 2, 3], 'v2': ['a', 'non-inlined string', 'duckdb']},
+            {'v1': [5, 4, 3, 2, 1], 'v2': ['non-inlined-string', 'a', 'b', 'c', 'duckdb']},
+        ),
+        Candidate(duckdb.list_type('VARCHAR'), ['the', 'duck', 'non-inlined string'], ['non-inlined-string', 'test']),
+    ]
 
 
 class TestUDFNullFiltering(object):
     @pytest.mark.parametrize(
         'table_data',
-        [
-            ['12', None, '42'],
-            [None, '42', None],
-            ['12', None, None],
-            [None, None, '42'],
-            [None, None, None],
-        ],
+        get_layout(),
     )
-    def test_null_filtering_native(self, duckdb_cursor, table_data):
-        null_count = sum([1 for x in table_data if not x])
-        row_count = len(table_data)
-
-        df = pd.DataFrame({'a': table_data})
-        duckdb_cursor.execute("create table tbl as select * FROM df")
-
-        def my_native_func(x):
-            my_native_func.count += 1
-            return int(x)
-
-        my_native_func.count = 0
-        duckdb_cursor.create_function('other_test', my_native_func, [str], int)
-        result = duckdb_cursor.sql("select other_test(a::VARCHAR) from tbl").fetchall()
-        assert result == [tuple([int(x)]) if x else (None,) for x in table_data]
-        assert len(result) == row_count
-        # Only the non-null tuples should have been seen by the UDF
-        assert my_native_func.count == row_count - null_count
-
     @pytest.mark.parametrize(
-        'table_data',
-        [
-            ['12', None, '42'],
-            [None, '42', None],
-            ['12', None, None],
-            [None, None, '42'],
-            [None, None, None],
-        ],
+        'test_type',
+        get_types(),
     )
-    def test_null_filtering_vectorized(self, duckdb_cursor, table_data):
+    @pytest.mark.parametrize('udf_type', ['arrow', 'native'])
+    def test_null_filtering(self, duckdb_cursor, table_data, test_type: Candidate, udf_type):
         null_count = sum([1 for x in table_data if not x])
         row_count = len(table_data)
+        table_data = [
+            None if not x else test_type.variant_one if x == 'x' else test_type.variant_two for x in table_data
+        ]
 
         df = pd.DataFrame({'a': table_data})
         duckdb_cursor.execute("create table tbl as select * FROM df")
 
-        def my_vectorized_func(column):
-            python_array = column.to_pylist()
-            my_vectorized_func.count += len(python_array)
-            transformed_array = [int(value) for value in python_array]
-            arrow_array = pa.array(transformed_array, type=pa.int64())
-            return arrow_array
+        def my_func(x):
+            if udf_type == 'arrow':
+                my_func.count += len(x)
+            else:
+                my_func.count += 1
+            return x
 
-        my_vectorized_func.count = 0
-        duckdb_cursor.create_function('other_test', my_vectorized_func, [str], int, type='arrow')
-        result = duckdb_cursor.sql("select other_test(a::VARCHAR) from tbl").fetchall()
-        assert result == [tuple([int(x)]) if x else (None,) for x in table_data]
+        my_func.count = 0
+        duckdb_cursor.create_function('test', my_func, [test_type.type], test_type.type, type=udf_type)
+        result = duckdb_cursor.sql(f"select test(a::{test_type.type}) from tbl").fetchall()
+        assert result == [(x,) for x in table_data]
         assert len(result) == row_count
         # Only the non-null tuples should have been seen by the UDF
-        assert my_vectorized_func.count == row_count - null_count
+        assert my_func.count == row_count - null_count
 
     @pytest.mark.parametrize(
         'table_data',

--- a/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
+++ b/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
@@ -9,7 +9,7 @@ import uuid
 import datetime
 import numpy as np
 import cmath
-from typing import NamedTuple, Any
+from typing import NamedTuple, Any, List
 
 from duckdb.typing import *
 
@@ -20,16 +20,41 @@ class Candidate(NamedTuple):
     variant_two: Any
 
 
-def get_layout():
-    return (
-        [
-            ['x', None, 'y'],
-            [None, 'y', None],
-            ['x', None, None],
-            [None, None, 'y'],
-            [None, None, None],
-        ],
-    )
+def layout(index: int):
+    return [
+        ['x', 'x', 'y'],
+        ['x', None, 'y'],
+        [None, 'y', None],
+        ['x', None, None],
+        [None, None, 'y'],
+        [None, None, None],
+    ][index]
+
+
+def get_table_data():
+    def add_variations(data, index: int):
+        data.extend(
+            [
+                {
+                    'a': layout(index),
+                    'b': layout(0),
+                    'c': layout(0),
+                },
+                {
+                    'a': layout(0),
+                    'b': layout(0),
+                    'c': layout(index),
+                },
+            ]
+        )
+
+    data = []
+    add_variations(data, 1)
+    add_variations(data, 2)
+    add_variations(data, 3)
+    add_variations(data, 4)
+    add_variations(data, 5)
+    return data
 
 
 def get_types():
@@ -58,7 +83,6 @@ def get_types():
             2147483647,
         ),
         Candidate(UBIGINT, 18446744073709551615, 9223372036854776000),
-        Candidate(HUGEINT, 18446744073709551616, 9223372036854776000),
         Candidate(VARCHAR, 'long_string_test', 'smallstring'),
         Candidate(
             UUID, uuid.UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'), uuid.UUID('ffffffff-ffff-ffff-ffff-000000000000')
@@ -104,37 +128,74 @@ def get_types():
     ]
 
 
+def construct_query(tuples) -> str:
+    def construct_values_list(row, start_param_idx):
+        parameter_count = len(row)
+        parameters = [f'${x+start_param_idx}' for x in range(parameter_count)]
+        parameters = '(' + ', '.join(parameters) + ')'
+        return parameters
+
+    row_size = len(tuples[0])
+    values_list = [construct_values_list(x, 1 + (i * row_size)) for i, x in enumerate(tuples)]
+    values_list = ', '.join(values_list)
+
+    query = f"""
+        select * from (values {values_list})
+    """
+    return query
+
+
+def construct_parameters(tuples, dbtype):
+    parameters = []
+    for row in tuples:
+        parameters.extend(list([duckdb.Value(x, dbtype) for x in row]))
+    return parameters
+
+
 class TestUDFNullFiltering(object):
     @pytest.mark.parametrize(
         'table_data',
-        get_layout(),
+        get_table_data(),
     )
     @pytest.mark.parametrize(
         'test_type',
         get_types(),
     )
     @pytest.mark.parametrize('udf_type', ['arrow', 'native'])
-    def test_null_filtering(self, duckdb_cursor, table_data, test_type: Candidate, udf_type):
-        null_count = sum([1 for x in table_data if not x])
+    def test_null_filtering(self, duckdb_cursor, table_data: dict, test_type: Candidate, udf_type):
+        null_count = sum([1 for x in list(zip(*table_data.values())) if any([y == None for y in x])])
         row_count = len(table_data)
-        table_data = [
-            None if not x else test_type.variant_one if x == 'x' else test_type.variant_two for x in table_data
-        ]
+        table_data = {
+            key: [None if not x else test_type.variant_one if x == 'x' else test_type.variant_two for x in value]
+            for key, value in table_data.items()
+        }
 
-        df = pd.DataFrame({'a': table_data})
-        duckdb_cursor.execute("create table tbl as select * FROM df")
+        tuples = list(zip(*table_data.values()))
+        query = construct_query(tuples)
+        parameters = construct_parameters(tuples, test_type.type)
+        rel = duckdb_cursor.sql(query + " t(a, b, c)", params=parameters)
+        rel.to_table('tbl')
+        rel.show()
 
-        def my_func(x):
+        def my_func(*args):
             if udf_type == 'arrow':
-                my_func.count += len(x)
+                my_func.count += len(args[0])
             else:
                 my_func.count += 1
-            return x
+            return args[0]
+
+        def create_parameters(table_data, dbtype):
+            return ", ".join(f'{key}::{dbtype}' for key in list(table_data.keys()))
 
         my_func.count = 0
-        duckdb_cursor.create_function('test', my_func, [test_type.type], test_type.type, type=udf_type)
-        result = duckdb_cursor.sql(f"select test(a::{test_type.type}) from tbl").fetchall()
-        assert result == [(x,) for x in table_data]
+        duckdb_cursor.create_function('test', my_func, None, test_type.type, type=udf_type)
+        query = f"select test({create_parameters(table_data, test_type.type)}) from tbl"
+        result = duckdb_cursor.sql(query).fetchall()
+
+        expected_output = [
+            (t[0],) if not any(x == None for x in t) else (None,) for t in list(zip(*table_data.values()))
+        ]
+        assert result == expected_output
         assert len(result) == row_count
         # Only the non-null tuples should have been seen by the UDF
         assert my_func.count == row_count - null_count


### PR DESCRIPTION
This PR fixes #13138 

This only applies to UDFs that use the default null handling (default behavior).

For both `native` and `arrow` UDF types, nulls are filtered out of the input that is sent to the user defined function.
On return to DuckDB the created result is converted to a DataChunk and the rows that were filtered out are replaced with NULL in the final result.

DuckDB side input:
```
┌─────────┐
│    a    │
│ varchar │
├─────────┤
│ 12      │
│ NULL    │
│ 42      │
└─────────┘
```

Received data by the UDF:
```
┌─────────┐
│    a    │
│ varchar │
├─────────┤
│ 12      │
│ 42      │
└─────────┘
```

In this example:
The resulting row produced by the UDF at (0 indexed) row 1 will be placed at row 2 in the final result.