### PR TITLE
Sample at least one value for the hyperloglog

### DIFF
--- a/src/storage/statistics/distinct_statistics.cpp
+++ b/src/storage/statistics/distinct_statistics.cpp
@@ -33,10 +33,12 @@ void DistinctStatistics::Update(UnifiedVectorFormat &vdata, const LogicalType &t
 	if (count == 0) {
 		return;
 	}
-	
+
 	total_count += count;
 	if (sample) {
-		count = MinValue<idx_t>(MaxValue<idx_t>(idx_t(SAMPLE_RATE * static_cast<double>(MaxValue<idx_t>(STANDARD_VECTOR_SIZE, count))),1), count);
+		count = MinValue<idx_t>(
+		    MaxValue<idx_t>(idx_t(SAMPLE_RATE * static_cast<double>(MaxValue<idx_t>(STANDARD_VECTOR_SIZE, count))), 1),
+		    count);
 	}
 	sample_count += count;
 

--- a/src/storage/statistics/distinct_statistics.cpp
+++ b/src/storage/statistics/distinct_statistics.cpp
@@ -33,11 +33,10 @@ void DistinctStatistics::Update(UnifiedVectorFormat &vdata, const LogicalType &t
 	if (count == 0) {
 		return;
 	}
-
+	
 	total_count += count;
 	if (sample) {
-		count = MinValue<idx_t>(idx_t(SAMPLE_RATE * static_cast<double>(MaxValue<idx_t>(STANDARD_VECTOR_SIZE, count))),
-		                        count);
+		count = MinValue<idx_t>(MaxValue<idx_t>(idx_t(SAMPLE_RATE * static_cast<double>(MaxValue<idx_t>(STANDARD_VECTOR_SIZE, count))),1), count);
 	}
 	sample_count += count;
 


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/2641

hyper log log wasn't sampling any values, so the distinct value count for the tables was 1, this made the cardinality estimator think every join was basically a cross product. 