### PR TITLE
[Arrow] Support consuming an "arrow_array_stream" PyCapsule

### DIFF
--- a/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
@@ -30,32 +30,10 @@ void VerifyArrowDatasetLoaded() {
 	}
 }
 
-PyArrowObjectType GetArrowType(const py::handle &obj) {
-	D_ASSERT(py::gil_check());
-	auto &import_cache = *DuckDBPyConnection::ImportCache();
-	// First Verify Lib Types
-	auto table_class = import_cache.pyarrow.Table();
-	auto record_batch_reader_class = import_cache.pyarrow.RecordBatchReader();
-	if (py::isinstance(obj, table_class)) {
-		return PyArrowObjectType::Table;
-	} else if (py::isinstance(obj, record_batch_reader_class)) {
-		return PyArrowObjectType::RecordBatchReader;
-	}
-	// Then Verify dataset types
-	auto dataset_class = import_cache.pyarrow.dataset.Dataset();
-	auto scanner_class = import_cache.pyarrow.dataset.Scanner();
-
-	if (py::isinstance(obj, scanner_class)) {
-		return PyArrowObjectType::Scanner;
-	} else if (py::isinstance(obj, dataset_class)) {
-		return PyArrowObjectType::Dataset;
-	}
-	return PyArrowObjectType::Invalid;
-}
-
 py::object PythonTableArrowArrayStreamFactory::ProduceScanner(py::object &arrow_scanner, py::handle &arrow_obj_handle,
                                                               ArrowStreamParameters &parameters,
                                                               const ClientProperties &client_properties) {
+	D_ASSERT(!py::isinstance<py::capsule>(arrow_obj_handle));
 	ArrowSchemaWrapper schema;
 	PythonTableArrowArrayStreamFactory::GetSchemaInternal(arrow_obj_handle, schema);
 	vector<string> unused_names;
@@ -90,7 +68,19 @@ unique_ptr<ArrowArrayStreamWrapper> PythonTableArrowArrayStreamFactory::Produce(
 	auto factory = static_cast<PythonTableArrowArrayStreamFactory *>(reinterpret_cast<void *>(factory_ptr)); // NOLINT
 	D_ASSERT(factory->arrow_object);
 	py::handle arrow_obj_handle(factory->arrow_object);
-	auto arrow_object_type = GetArrowType(arrow_obj_handle);
+	auto arrow_object_type = DuckDBPyConnection::GetArrowType(arrow_obj_handle);
+
+	if (arrow_object_type == PyArrowObjectType::PyCapsule) {
+		auto res = make_uniq<ArrowArrayStreamWrapper>();
+		auto capsule = py::reinterpret_borrow<py::capsule>(arrow_obj_handle);
+		auto stream = capsule.get_pointer<struct ArrowArrayStream>();
+		if (!stream->release) {
+			throw InternalException("ArrowArrayStream was released by another thread/library");
+		}
+		res->arrow_array_stream = *stream;
+		stream->release = nullptr;
+		return res;
+	}
 
 	auto &import_cache = *DuckDBPyConnection::ImportCache();
 	py::object scanner;
@@ -133,11 +123,21 @@ unique_ptr<ArrowArrayStreamWrapper> PythonTableArrowArrayStreamFactory::Produce(
 }
 
 void PythonTableArrowArrayStreamFactory::GetSchemaInternal(py::handle arrow_obj_handle, ArrowSchemaWrapper &schema) {
+	if (py::isinstance<py::capsule>(arrow_obj_handle)) {
+		auto capsule = py::reinterpret_borrow<py::capsule>(arrow_obj_handle);
+		auto stream = capsule.get_pointer<struct ArrowArrayStream>();
+		if (!stream->release) {
+			throw InternalException("ArrowArrayStream was released by another thread/library");
+		}
+		stream->get_schema(stream, &schema.arrow_schema);
+		return;
+	}
+
 	auto table_class = py::module::import("pyarrow").attr("Table");
 	if (py::isinstance(arrow_obj_handle, table_class)) {
 		auto obj_schema = arrow_obj_handle.attr("schema");
 		auto export_to_c = obj_schema.attr("_export_to_c");
-		export_to_c(reinterpret_cast<uint64_t>(&schema));
+		export_to_c(reinterpret_cast<uint64_t>(&schema.arrow_schema));
 		return;
 	}
 

--- a/tools/pythonpkg/src/include/duckdb_python/arrow/arrow_array_stream.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/arrow/arrow_array_stream.hpp
@@ -50,7 +50,7 @@ public:
 
 } // namespace pyarrow
 
-enum class PyArrowObjectType { Invalid, Table, RecordBatchReader, Scanner, Dataset };
+enum class PyArrowObjectType { Invalid, Table, RecordBatchReader, Scanner, Dataset, PyCapsule };
 
 void TransformDuckToArrowChunk(ArrowSchema &arrow_schema, ArrowArray &data, py::list &batches);
 

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -314,6 +314,7 @@ public:
 
 	static bool IsPandasDataframe(const py::object &object);
 	static bool IsPolarsDataframe(const py::object &object);
+	static PyArrowObjectType GetArrowType(const py::handle &obj);
 	static bool IsAcceptedArrowObject(const py::object &object);
 	static NumpyObjectType IsAcceptedNumpyObject(const py::object &object);
 

--- a/tools/pythonpkg/src/python_replacement_scan.cpp
+++ b/tools/pythonpkg/src/python_replacement_scan.cpp
@@ -15,7 +15,8 @@
 namespace duckdb {
 
 static void CreateArrowScan(const string &name, py::object entry, TableFunctionRef &table_function,
-                            vector<unique_ptr<ParsedExpression>> &children, ClientProperties &client_properties) {
+                            vector<unique_ptr<ParsedExpression>> &children, ClientProperties &client_properties,
+                            PyArrowObjectType type) {
 	auto stream_factory = make_uniq<PythonTableArrowArrayStreamFactory>(entry.ptr(), client_properties);
 	auto stream_factory_produce = PythonTableArrowArrayStreamFactory::Produce;
 	auto stream_factory_get_schema = PythonTableArrowArrayStreamFactory::GetSchema;
@@ -24,7 +25,13 @@ static void CreateArrowScan(const string &name, py::object entry, TableFunctionR
 	children.push_back(make_uniq<ConstantExpression>(Value::POINTER(CastPointerToValue(stream_factory_produce))));
 	children.push_back(make_uniq<ConstantExpression>(Value::POINTER(CastPointerToValue(stream_factory_get_schema))));
 
-	table_function.function = make_uniq<FunctionExpression>("arrow_scan", std::move(children));
+	if (type == PyArrowObjectType::PyCapsule) {
+		// Disable projection+filter pushdown
+		table_function.function = make_uniq<FunctionExpression>("arrow_scan_dumb", std::move(children));
+	} else {
+		table_function.function = make_uniq<FunctionExpression>("arrow_scan", std::move(children));
+	}
+
 	auto dependency = make_uniq<ExternalDependency>();
 	auto dependency_item = PythonDependencyItem::Create(make_uniq<RegisteredArrow>(std::move(stream_factory), entry));
 	dependency->AddDependency("replacement_cache", std::move(dependency_item));
@@ -60,11 +67,12 @@ unique_ptr<TableRef> PythonReplacementScan::TryReplacementObject(const py::objec
 	auto client_properties = context.GetClientProperties();
 	auto table_function = make_uniq<TableFunctionRef>();
 	vector<unique_ptr<ParsedExpression>> children;
-	NumpyObjectType numpytype; // Identify the type of accepted numpy objects.
+	NumpyObjectType numpytype;
+	PyArrowObjectType arrow_type;
 	if (DuckDBPyConnection::IsPandasDataframe(entry)) {
 		if (PandasDataFrame::IsPyArrowBacked(entry)) {
 			auto table = PandasDataFrame::ToArrowTable(entry);
-			CreateArrowScan(name, table, *table_function, children, client_properties);
+			CreateArrowScan(name, table, *table_function, children, client_properties, PyArrowObjectType::Table);
 		} else {
 			string name = "df_" + StringUtil::GenerateRandomName();
 			auto new_df = PandasScanFunction::PandasReplaceCopiedNames(entry);
@@ -75,8 +83,8 @@ unique_ptr<TableRef> PythonReplacementScan::TryReplacementObject(const py::objec
 			dependency->AddDependency("copy", PythonDependencyItem::Create(new_df));
 			table_function->external_dependency = std::move(dependency);
 		}
-	} else if (DuckDBPyConnection::IsAcceptedArrowObject(entry)) {
-		CreateArrowScan(name, entry, *table_function, children, client_properties);
+	} else if ((arrow_type = DuckDBPyConnection::GetArrowType(entry)) != PyArrowObjectType::Invalid) {
+		CreateArrowScan(name, entry, *table_function, children, client_properties, arrow_type);
 	} else if (DuckDBPyRelation::IsRelation(entry)) {
 		auto pyrel = py::cast<DuckDBPyRelation *>(entry);
 		if (!pyrel->CanBeRegisteredBy(context)) {
@@ -95,11 +103,11 @@ unique_ptr<TableRef> PythonReplacementScan::TryReplacementObject(const py::objec
 		return std::move(subquery);
 	} else if (PolarsDataFrame::IsDataFrame(entry)) {
 		auto arrow_dataset = entry.attr("to_arrow")();
-		CreateArrowScan(name, arrow_dataset, *table_function, children, client_properties);
+		CreateArrowScan(name, arrow_dataset, *table_function, children, client_properties, PyArrowObjectType::Table);
 	} else if (PolarsDataFrame::IsLazyFrame(entry)) {
 		auto materialized = entry.attr("collect")();
 		auto arrow_dataset = materialized.attr("to_arrow")();
-		CreateArrowScan(name, arrow_dataset, *table_function, children, client_properties);
+		CreateArrowScan(name, arrow_dataset, *table_function, children, client_properties, PyArrowObjectType::Table);
 	} else if ((numpytype = DuckDBPyConnection::IsAcceptedNumpyObject(entry)) != NumpyObjectType::INVALID) {
 		string name = "np_" + StringUtil::GenerateRandomName();
 		py::dict data; // we will convert all the supported format to dict{"key": np.array(value)}.

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_pycapsule.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_pycapsule.py
@@ -1,0 +1,23 @@
+import duckdb
+import pytest
+import os
+
+pl = pytest.importorskip("polars")
+
+
+def polars_supports_capsule():
+    from packaging.version import Version
+
+    return Version(pl.__version__) >= Version('1.4.1')
+
+
+@pytest.mark.skipif(
+    not polars_supports_capsule(), reason='Polars version does not support the Arrow PyCapsule interface'
+)
+class TestArrowPyCapsule(object):
+    def test_polars_pycapsule_scan(self, duckdb_cursor):
+        df = pl.DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8]})
+        capsule = df.__arrow_c_stream__()
+
+        res = duckdb_cursor.sql("select * from capsule")
+        assert res.fetchall() == [(1, 5), (2, 6), (3, 7), (4, 8)]

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_replacement_scan.py
@@ -32,6 +32,12 @@ class TestArrowReplacementScan(object):
         rel = duckdb_cursor.sql("select * from capsule where a > 3 and a < 5")
         assert rel.fetchall() == [(4,)]
 
+        tbl = pa.Table.from_pydict({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9], 'd': [10, 11, 12]})
+        capsule = tbl.__arrow_c_stream__()
+
+        rel = duckdb_cursor.sql("select b, d from capsule")
+        assert rel.fetchall() == [(i, i + 6) for i in range(4, 7)]
+
     def test_arrow_table_replacement_scan_view(self, duckdb_cursor):
 
         parquet_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'userdata1.parquet')

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_replacement_scan.py
@@ -3,19 +3,13 @@ import pytest
 import os
 import pandas as pd
 
-try:
-    import pyarrow.parquet as pq
-    import pyarrow.dataset as ds
-
-    can_run = True
-except:
-    can_run = False
+pa = pytest.importorskip("pyarrow")
+pq = pytest.importorskip("pyarrow.parquet")
+ds = pytest.importorskip("pyarrow.dataset")
 
 
 class TestArrowReplacementScan(object):
     def test_arrow_table_replacement_scan(self, duckdb_cursor):
-        if not can_run:
-            return
 
         parquet_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'userdata1.parquet')
         userdata_parquet_table = pq.read_table(parquet_filename)
@@ -27,9 +21,18 @@ class TestArrowReplacementScan(object):
             assert con.execute("select count(*) from userdata_parquet_table").fetchone() == (1000,)
             assert con.execute("select count(*) from df").fetchone() == (1000,)
 
+    def test_arrow_pycapsule_replacement_scan(self, duckdb_cursor):
+        tbl = pa.Table.from_pydict({'a': [1, 2, 3, 4, 5, 6, 7, 8, 9]})
+        capsule = tbl.__arrow_c_stream__()
+
+        rel = duckdb_cursor.sql("select * from capsule")
+        assert rel.fetchall() == [(i,) for i in range(1, 10)]
+
+        capsule = tbl.__arrow_c_stream__()
+        rel = duckdb_cursor.sql("select * from capsule where a > 3 and a < 5")
+        assert rel.fetchall() == [(4,)]
+
     def test_arrow_table_replacement_scan_view(self, duckdb_cursor):
-        if not can_run:
-            return
 
         parquet_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'userdata1.parquet')
         userdata_parquet_table = pq.read_table(parquet_filename)
@@ -42,8 +45,6 @@ class TestArrowReplacementScan(object):
             assert con.execute("select count(*) from x").fetchone()
 
     def test_arrow_dataset_replacement_scan(self, duckdb_cursor):
-        if not can_run:
-            return
         parquet_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'userdata1.parquet')
         userdata_parquet_table = pq.read_table(parquet_filename)
         userdata_parquet_dataset = ds.dataset(parquet_filename)

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_replacement_scan.py
@@ -38,6 +38,16 @@ class TestArrowReplacementScan(object):
         rel = duckdb_cursor.sql("select b, d from capsule")
         assert rel.fetchall() == [(i, i + 6) for i in range(4, 7)]
 
+        with pytest.raises(duckdb.InvalidInputException, match='The ArrowArrayStream was already released'):
+            rel = duckdb_cursor.sql("select b, d from capsule")
+
+        schema_obj = tbl.schema
+        schema_capsule = schema_obj.__arrow_c_schema__()
+        with pytest.raises(
+            duckdb.InvalidInputException, match="""Expected a 'arrow_array_stream' PyCapsule, got: arrow_schema"""
+        ):
+            rel = duckdb_cursor.sql("select b, d from schema_capsule")
+
     def test_arrow_table_replacement_scan_view(self, duckdb_cursor):
 
         parquet_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'userdata1.parquet')


### PR DESCRIPTION
This PR implements https://github.com/duckdb/duckdb/discussions/10716

This allows consuming arrow array streams from PyCapsules, which do not necessarily have to be created by `pyarrow`.

For regular arrow scans we use `pyarrow` to perform filter pushdown on the stream, constructing a scanner to do so.
When scanning from a PyCapsule we disable this so no interaction with `pyarrow` is required.