### PR TITLE
Bump GitHub workflows to their latest versions

### DIFF
--- a/.github/workflows/CheckIssueForCodeFormatting.yml
+++ b/.github/workflows/CheckIssueForCodeFormatting.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Check issue for code formatting
         run: |
           echo "$ISSUE_BODY" >> issue-text.md

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -44,7 +44,7 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
       GEN: ninja
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -108,7 +108,7 @@ jobs:
       TIDY_CHECKS: ${{ inputs.explicit_checks && inputs.explicit_checks || '' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/DockerTests.yml
+++ b/.github/workflows/DockerTests.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}

--- a/.github/workflows/DraftMe.yml
+++ b/.github/workflows/DraftMe.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: pr/

--- a/.github/workflows/DraftPR.yml
+++ b/.github/workflows/DraftPR.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/ExtendedTests.yml
+++ b/.github/workflows/ExtendedTests.yml
@@ -37,13 +37,13 @@ jobs:
        BUILD_HTTPFS: 1
 
      steps:
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@v4
        with:
          fetch-depth: 0
 
      - uses: actions/setup-python@v5
        with:
-         python-version: '3.11'
+         python-version: '3.12'
 
      - name: Install
        shell: bash
@@ -119,13 +119,13 @@ jobs:
        BUILD_HTTPFS: 1
 
      steps:
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@v4
        with:
          fetch-depth: 0
 
      - uses: actions/setup-python@v5
        with:
-         python-version: '3.11'
+         python-version: '3.12'
 
      - name: Install
        shell: bash
@@ -201,13 +201,13 @@ jobs:
        BUILD_JEMALLOC: 1
 
      steps:
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@v4
          with:
            fetch-depth: 0
 
        - uses: actions/setup-python@v5
          with:
-           python-version: '3.11'
+           python-version: '3.12'
 
        - name: Install
          shell: bash
@@ -288,13 +288,13 @@ jobs:
        BUILD_JEMALLOC: 1
 
      steps:
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@v4
          with:
            fetch-depth: 0
 
        - uses: actions/setup-python@v5
          with:
-           python-version: '3.11'
+           python-version: '3.12'
 
        - name: Install
          shell: bash

--- a/.github/workflows/ExtensionTrigger.yml
+++ b/.github/workflows/ExtensionTrigger.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Trigger Substrait Extension
       run: |

--- a/.github/workflows/ExtraTests.yml
+++ b/.github/workflows/ExtraTests.yml
@@ -24,7 +24,7 @@ jobs:
     BUILD_JEMALLOC: 1
 
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -39,7 +39,7 @@ jobs:
     name: Julia Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -75,11 +75,11 @@ jobs:
           - isRelease: false
             version: '1.6'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -47,7 +47,7 @@ jobs:
       GEN: ninja
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
       RUN_SLOW_VERIFIERS: 1
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install
       shell: bash
@@ -151,7 +151,7 @@ jobs:
       BUILD_EXTENSIONS: "inet"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install
       shell: bash
@@ -189,7 +189,7 @@ jobs:
       GEN: ninja
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install
       shell: bash

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -48,7 +48,7 @@ jobs:
       TREAT_WARNINGS_AS_ERRORS: 1
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
@@ -106,7 +106,7 @@ jobs:
       GEN: ninja
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
@@ -180,7 +180,7 @@ jobs:
           zip -j libduckdb-osx-universal.zip build/release/src/libduckdb*.dylib src/amalgamation/duckdb.hpp src/include/duckdb.h
           ./scripts/upload-assets-to-staging.sh github_release libduckdb-osx-universal.zip duckdb_cli-osx-universal.zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: duckdb-binaries-osx
           path: |
@@ -215,7 +215,7 @@ jobs:
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}

--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           ls -lah ./tools/pythonpkg/dist/*.whl
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pyodide-python${{ matrix.version.python }}
           if-no-files-found: error

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -45,7 +45,7 @@ jobs:
     name: R Package Windows (Extensions)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}

--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -53,11 +53,11 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ${{ env.DUCKDB_SRC }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ env.DUCKDB_R_REPO }}
           path: ${{ env.DUCKDB_R_SRC }}

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -50,7 +50,7 @@ jobs:
     BUILD_JEMALLOC: 1
 
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -141,7 +141,7 @@ jobs:
     BUILD_TPCDS: 1
 
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -220,13 +220,13 @@ jobs:
     GEN: ninja
 
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install
       shell: bash
@@ -289,7 +289,7 @@ jobs:
     BUILD_HTTPFS: 1
 
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -17,13 +17,13 @@ jobs:
    runs-on: ubuntu-latest
    if: ${{ inputs.target_git_describe != '' }}
    steps:
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@v4
        with:
          fetch-depth: 0
 
      - uses: actions/setup-python@v4
        with:
-         python-version: '3.10'
+         python-version: '3.12'
 
      - name: Install
        shell: bash

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we need tags for the ubiquity build script to run without errors
           fetch-depth: '0'
@@ -83,7 +83,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we need tags for the ubiquity build script to run without errors
           fetch-depth: '0'
@@ -91,7 +91,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Prepare Package
         run: python3 tools/swift/create_package.py tools/swift

--- a/.github/workflows/SwiftRelease.yml
+++ b/.github/workflows/SwiftRelease.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we need tags for the ubiquity build script to run without errors
           fetch-depth: '0'
@@ -27,7 +27,7 @@ jobs:
           path: 'source-repo'
 
       - name: Checkout Target Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ env.TARGET_REPO }}
           ref: ${{ env.TARGET_REF }}

--- a/.github/workflows/TwineUpload.yml
+++ b/.github/workflows/TwineUpload.yml
@@ -18,13 +18,13 @@ jobs:
       runs-on: ubuntu-latest
 
       steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install
         shell: bash

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -36,7 +36,7 @@ jobs:
       DUCKDB_PLATFORM: "${{ matrix.duckdb_wasm_arch }}"
 
     steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   ref: ${{ inputs.duckdb_wasm_ref }}
                   fetch-depth: 0
@@ -85,7 +85,7 @@ jobs:
                 DUCKDB_PLATFORM=wasm_threads DUCKDB_WASM_LOADABLE_EXTENSIONS="signed" GEN=ninja ./scripts/wasm_build_lib.sh relsize coi
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: duckdb_extensions_${{ env.DUCKDB_PLATFORM }}
                   path: build/extension_repository/${{ inputs.duckdb_ref }}/${{ env.DUCKDB_PLATFORM }}
@@ -100,9 +100,9 @@ jobs:
       matrix:
         duckdb_arch: ${{ fromJSON(github.event.inputs.platforms) }}
     steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                 name: duckdb_extensions_${{ matrix.duckdb_arch }}
                 path: build/to_be_deployed/${{ inputs.duckdb_ref }}/${{ matrix.duckdb_arch }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -55,7 +55,7 @@ jobs:
     name: Windows (64 Bit)
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
@@ -111,7 +111,7 @@ jobs:
         zip -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: duckdb-binaries-windows
         path: |
@@ -130,7 +130,7 @@ jobs:
     needs: win-release-64
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ inputs.git_ref }}
@@ -170,7 +170,7 @@ jobs:
    needs: win-release-64
 
    steps:
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@v4
        with:
          fetch-depth: 0
          ref: ${{ inputs.git_ref }}
@@ -203,7 +203,7 @@ jobs:
          zip -j libduckdb-windows-arm64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
          ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-arm64.zip duckdb_cli-windows-arm64.zip
 
-     - uses: actions/upload-artifact@v3
+     - uses: actions/upload-artifact@v4
        with:
          name: duckdb-binaries-windows
          path: |
@@ -216,7 +216,7 @@ jobs:
      if: ${{ inputs.skip_tests != 'true' }}
      needs: win-release-64
      steps:
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@v4
          with:
            ref: ${{ inputs.git_ref }}
        - uses: msys2/setup-msys2@v2
@@ -265,7 +265,7 @@ jobs:
          git config --global core.autocrlf false
          git config --global core.eol lf
 
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@v4
        with:
          fetch-depth: 0
          ref: ${{ inputs.git_ref }}

--- a/.github/workflows/_extension_client_tests.yml
+++ b/.github/workflows/_extension_client_tests.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get install -y -qq ninja-build
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Build DuckDB Python client
         run: make debug_python

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -44,7 +44,7 @@ jobs:
         dry-run: false
         sanitizer: ${{ matrix.sanitizer }}
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts-${{ matrix.sanitizer }}


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding the output of [deprecation warnings](https://github.com/duckdb/duckdb/actions/runs/10354793343).