### PR TITLE
Compressed materialization for joins

### DIFF
--- a/src/include/duckdb/optimizer/compressed_materialization.hpp
+++ b/src/include/duckdb/optimizer/compressed_materialization.hpp
@@ -74,6 +74,10 @@ typedef column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map_t;
 //! The CompressedMaterialization optimizer compressed columns using projections, based on available statistics,
 //! but only if the data enters a materializing operator
 class CompressedMaterialization {
+private:
+	static constexpr idx_t JOIN_BUILD_CARDINALITY_THRESHOLD = 1048576;
+	static constexpr double JOIN_CARDINALITY_RATIO_THRESHOLD = 8;
+
 public:
 	CompressedMaterialization(Optimizer &optimizer, LogicalOperator &root, statistics_map_t &statistics_map);
 
@@ -82,11 +86,13 @@ public:
 private:
 	//! Compress materializing operators
 	void CompressAggregate(unique_ptr<LogicalOperator> &op);
+	void CompressComparisonJoin(unique_ptr<LogicalOperator> &op);
 	void CompressDistinct(unique_ptr<LogicalOperator> &op);
 	void CompressOrder(unique_ptr<LogicalOperator> &op);
 
 	//! Update statistics after compressing
 	void UpdateAggregateStats(unique_ptr<LogicalOperator> &op);
+	void UpdateComparisonJoinStats(unique_ptr<LogicalOperator> &op);
 	void UpdateOrderStats(unique_ptr<LogicalOperator> &op);
 
 	//! Adds bindings referenced in expression to referenced_bindings

--- a/src/include/duckdb/optimizer/compressed_materialization.hpp
+++ b/src/include/duckdb/optimizer/compressed_materialization.hpp
@@ -75,6 +75,7 @@ typedef column_binding_map_t<unique_ptr<BaseStatistics>> statistics_map_t;
 //! but only if the data enters a materializing operator
 class CompressedMaterialization {
 private:
+	//! Somewhat defensive constants that try to limit when compressed materialization is triggered for joins
 	static constexpr idx_t JOIN_BUILD_CARDINALITY_THRESHOLD = 1048576;
 	static constexpr double JOIN_CARDINALITY_RATIO_THRESHOLD = 8;
 

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -81,6 +81,7 @@ void CompressedMaterialization::Compress(unique_ptr<LogicalOperator> &op) {
 
 	switch (op->type) {
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
 	case LogicalOperatorType::LOGICAL_DISTINCT:
 	case LogicalOperatorType::LOGICAL_ORDER_BY:
 		break;
@@ -94,6 +95,9 @@ void CompressedMaterialization::Compress(unique_ptr<LogicalOperator> &op) {
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
 		CompressAggregate(op);
 		break;
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+		CompressComparisonJoin(op);
+		break;
 	case LogicalOperatorType::LOGICAL_DISTINCT:
 		CompressDistinct(op);
 		break;
@@ -101,7 +105,7 @@ void CompressedMaterialization::Compress(unique_ptr<LogicalOperator> &op) {
 		CompressOrder(op);
 		break;
 	default:
-		return;
+		break;
 	}
 }
 

--- a/src/optimizer/compressed_materialization/CMakeLists.txt
+++ b/src/optimizer/compressed_materialization/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library_unity(
   duckdb_optimizer_compressed_materialization OBJECT compress_aggregate.cpp
-  compress_distinct.cpp compress_order.cpp)
+  compress_comparison_join.cpp compress_distinct.cpp compress_order.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES}
     $<TARGET_OBJECTS:duckdb_optimizer_compressed_materialization>

--- a/src/optimizer/compressed_materialization/compress_comparison_join.cpp
+++ b/src/optimizer/compressed_materialization/compress_comparison_join.cpp
@@ -1,0 +1,152 @@
+#include "duckdb/optimizer/compressed_materialization.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
+
+namespace duckdb {
+
+static void PopulateBindingMap(CompressedMaterializationInfo &info, const vector<ColumnBinding> &bindings_out,
+                               const vector<LogicalType> &types, LogicalOperator &op_in) {
+	const auto bindings_in = op_in.GetColumnBindings();
+	for (const auto &binding : bindings_in) {
+		// Joins do not change bindings, input binding is output binding
+		for (idx_t col_idx_out = 0; col_idx_out < bindings_out.size(); col_idx_out++) {
+			const auto &binding_out = bindings_out[col_idx_out];
+			if (binding_out == binding) {
+				// This one is projected out, add it to map
+				info.binding_map.emplace(binding, CMBindingInfo(binding_out, types[col_idx_out]));
+			}
+		}
+	}
+}
+
+void CompressedMaterialization::CompressComparisonJoin(unique_ptr<LogicalOperator> &op) {
+	auto &join = op->Cast<LogicalComparisonJoin>();
+	if (join.join_type == JoinType::MARK) {
+		// Tricky to get bindings right. RHS binding stays the same even though it changes type. Skip for now
+		return;
+	}
+
+	auto &left_child = *join.children[0];
+	auto &right_child = *join.children[1];
+
+#ifndef DEBUG
+	// In debug mode, we always apply compressed materialization to joins regardless of cardinalities,
+	// so that it is well-tested. In release mode, we require build cardinality > JOIN_BUILD_CARDINALITY_THRESHOLD,
+	// and we require the join cardinality divided by the build cardinality < JOIN_CARDINALITY_RATIO_THRESHOLD,
+	// so that we don't end up doing many more decompressions than compressions
+	const auto build_cardinality = right_child.has_estimated_cardinality ? right_child.estimated_cardinality
+	                                                                     : right_child.EstimateCardinality(context);
+	const auto join_cardinality =
+	    join.has_estimated_cardinality ? join.estimated_cardinality : join.EstimateCardinality(context);
+	const double ratio = static_cast<double>(join_cardinality) / static_cast<double>(build_cardinality);
+	if (build_cardinality < JOIN_BUILD_CARDINALITY_THRESHOLD || ratio > JOIN_CARDINALITY_RATIO_THRESHOLD) {
+		return;
+	}
+#endif
+
+	// Find all bindings referenced by non-colref expressions in the conditions
+	// These are excluded from compression by projection
+	// But we can try to compress the expression directly
+	column_binding_set_t probe_compress_bindings;
+	column_binding_set_t referenced_bindings;
+	for (const auto &condition : join.conditions) {
+		if (join.conditions.size() == 1 && join.type != LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+			// We only try to compress the join condition cols if there's one join condition
+			// Else it gets messy with the stats if one column shows up in multiple conditions
+			if (condition.left->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF &&
+			    condition.right->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+				// Both are bound column refs, see if both can be compressed generically to the same type
+				auto &lhs_colref = condition.left->Cast<BoundColumnRefExpression>();
+				auto &rhs_colref = condition.right->Cast<BoundColumnRefExpression>();
+				auto lhs_it = statistics_map.find(lhs_colref.binding);
+				auto rhs_it = statistics_map.find(rhs_colref.binding);
+				if (lhs_it != statistics_map.end() && rhs_it != statistics_map.end() && lhs_it->second &&
+				    rhs_it->second) {
+					// For joins we need to compress both using the same statistics, otherwise comparisons don't work
+					auto merged_stats = lhs_it->second->Copy();
+					merged_stats.Merge(*rhs_it->second);
+
+					// If one can be compressed, both can (same stats)
+					auto compress_expr = GetCompressExpression(condition.left->Copy(), merged_stats);
+					if (compress_expr) {
+						D_ASSERT(GetCompressExpression(condition.right->Copy(), merged_stats));
+						// This will be compressed generically, but we have to merge the stats
+						lhs_it->second->Merge(merged_stats);
+						rhs_it->second->Merge(merged_stats);
+						probe_compress_bindings.insert(lhs_colref.binding);
+						continue;
+					}
+				}
+			}
+		}
+		GetReferencedBindings(*condition.left, referenced_bindings);
+		GetReferencedBindings(*condition.right, referenced_bindings);
+	}
+
+	if (join.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		for (auto &dec : join.duplicate_eliminated_columns) {
+			GetReferencedBindings(*dec, referenced_bindings);
+		}
+	}
+
+	// We mark the probe-side bindings that do not show up in the join condition as "referenced"
+	// We don't want to compress these because they are streamed
+	const auto probe_bindings = left_child.GetColumnBindings();
+	for (auto &binding : probe_bindings) {
+		if (probe_compress_bindings.find(binding) == probe_compress_bindings.end()) {
+			referenced_bindings.insert(binding);
+		}
+	}
+
+	// Create info for compression
+	CompressedMaterializationInfo info(*op, {0, 1}, referenced_bindings);
+
+	const auto bindings_out = join.GetColumnBindings();
+	const auto &types = join.types;
+	PopulateBindingMap(info, bindings_out, types, left_child);
+	PopulateBindingMap(info, bindings_out, types, right_child);
+
+	// Now try to compress
+	CreateProjections(op, info);
+
+	// Update join statistics
+	UpdateComparisonJoinStats(op);
+}
+
+void CompressedMaterialization::UpdateComparisonJoinStats(unique_ptr<LogicalOperator> &op) {
+	if (op->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+		return;
+	}
+
+	// Update join stats if compressed
+	auto &compressed_join = op->children[0]->Cast<LogicalComparisonJoin>();
+	if (compressed_join.join_stats.empty()) {
+		return; // Nothing to update
+	}
+
+	for (idx_t condition_idx = 0; condition_idx < compressed_join.conditions.size(); condition_idx++) {
+		auto &condition = compressed_join.conditions[condition_idx];
+		if (condition.left->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF ||
+		    condition.right->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+			continue; // We definitely didn't compress these, nothing changed
+		}
+		if (condition_idx * 2 >= compressed_join.join_stats.size()) {
+			break;
+		}
+
+		auto &lhs_colref = condition.left->Cast<BoundColumnRefExpression>();
+		auto &rhs_colref = condition.right->Cast<BoundColumnRefExpression>();
+		auto &lhs_join_stats = compressed_join.join_stats[condition_idx * 2];
+		auto &rhs_join_stats = compressed_join.join_stats[condition_idx * 2 + 1];
+		auto lhs_it = statistics_map.find(lhs_colref.binding);
+		auto rhs_it = statistics_map.find(rhs_colref.binding);
+		if (lhs_it != statistics_map.end() && lhs_it->second) {
+			lhs_join_stats = lhs_it->second->ToUnique();
+		}
+		if (rhs_it != statistics_map.end() && rhs_it->second) {
+			rhs_join_stats = rhs_it->second->ToUnique();
+		}
+	}
+}
+
+} // namespace duckdb

--- a/src/optimizer/compressed_materialization/compress_comparison_join.cpp
+++ b/src/optimizer/compressed_materialization/compress_comparison_join.cpp
@@ -32,8 +32,8 @@ void CompressedMaterialization::CompressComparisonJoin(unique_ptr<LogicalOperato
 #ifndef DEBUG
 	// In debug mode, we always apply compressed materialization to joins regardless of cardinalities,
 	// so that it is well-tested. In release mode, we require build cardinality > JOIN_BUILD_CARDINALITY_THRESHOLD,
-	// and we require the join cardinality divided by the build cardinality < JOIN_CARDINALITY_RATIO_THRESHOLD,
-	// so that we don't end up doing many more decompressions than compressions
+	// and we require join_cardinality / build_cardinality < JOIN_CARDINALITY_RATIO_THRESHOLD,
+	// so that we don't end up doing many more decompressions than compressions and hurting performance
 	const auto build_cardinality = right_child.has_estimated_cardinality ? right_child.estimated_cardinality
 	                                                                     : right_child.EstimateCardinality(context);
 	const auto join_cardinality =

--- a/test/api/test_results.cpp
+++ b/test/api/test_results.cpp
@@ -198,7 +198,7 @@ TEST_CASE("Issue #9417", "[api][.]") {
 	DBConfig config;
 	config.options.allow_unsigned_extensions = true;
 
-	DuckDB db("issue_replication.db", &config);
+	DuckDB db(TestCreatePath("issue_replication.db"), &config);
 	Connection con(db);
 	auto result = con.SendQuery("with max_period as ("
 	                            "            select max(reporting_date) as max_record\n"


### PR DESCRIPTION
I initially wanted to add this in https://github.com/duckdb/duckdb/pull/7644 but ended up scrapping it because I wanted to do too many things in a single PR and had to scope it down. I saved the code, though, which works with some minor modifications!

So, this PR adds support to compress the build-side of `LogicalComparisonJoin` based on available statistics to reduce memory footprint. I've added some constants to prevent this from triggering too eagerly (some good old "defensive programming"), to reduce the chances of performance regressions when everything fits in main memory. We can expect a similar compression ratio as with aggregation/order by, which can prevent/reduce the need for spilling intermediates to storage.