### PR TITLE
Fix unused variable, resolve warning turned error in the amalgamation CI

### DIFF
--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -112,6 +112,7 @@ bool ExpressionContainsColumnRef(Expression &expression) {
 		// Here you have a filter on a single column in a table. Return a binding for the column
 		// being filtered on so the filter estimator knows what HLL count to pull
 		auto &colref = expression.Cast<BoundColumnRefExpression>();
+		(void)colref.depth;
 		D_ASSERT(colref.depth == 0);
 		D_ASSERT(colref.binding.table_index != DConstants::INVALID_INDEX);
 		// map the base table index to the relation index used by the JoinOrderOptimizer


### PR DESCRIPTION
This solves the fact that OSX CI nightly is not publishing extensions / artifacts due to this failure.