### PR TITLE
Add support for scalar function overloads to the C API

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -485,6 +485,11 @@ typedef struct _duckdb_scalar_function {
 	void *internal_ptr;
 } * duckdb_scalar_function;
 
+//! A scalar function set. Must be destroyed with `duckdb_destroy_scalar_function_set`.
+typedef struct _duckdb_scalar_function_set {
+	void *internal_ptr;
+} * duckdb_scalar_function_set;
+
 //! The main function of the scalar function.
 typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
 
@@ -2699,9 +2704,9 @@ The return value should be destroyed with `duckdb_destroy_scalar_function`.
 DUCKDB_API duckdb_scalar_function duckdb_create_scalar_function();
 
 /*!
-Destroys the given table function object.
+Destroys the given scalar function object.
 
-* @param scalar_function The table function to destroy
+* @param scalar_function The scalar function to destroy
 */
 DUCKDB_API void duckdb_destroy_scalar_function(duckdb_scalar_function *scalar_function);
 
@@ -2759,7 +2764,7 @@ DUCKDB_API void duckdb_scalar_function_set_return_type(duckdb_scalar_function sc
 /*!
 Assigns extra information to the scalar function that can be fetched during binding, etc.
 
-* @param scalar_function The table function
+* @param scalar_function The scalar function
 * @param extra_info The extra information
 * @param destroy The callback that will be called to destroy the bind data (if any)
 */
@@ -2767,7 +2772,7 @@ DUCKDB_API void duckdb_scalar_function_set_extra_info(duckdb_scalar_function sca
                                                       duckdb_delete_callback_t destroy);
 
 /*!
-Sets the main function of the table function.
+Sets the main function of the scalar function.
 
 * @param scalar_function The scalar function
 * @param function The function
@@ -2803,6 +2808,44 @@ Report that an error has occurred while executing the scalar function.
 * @param error The error message
 */
 DUCKDB_API void duckdb_scalar_function_set_error(duckdb_function_info info, const char *error);
+
+/*!
+Creates a new empty scalar function set.
+
+The return value should be destroyed with `duckdb_destroy_scalar_function_set`.
+
+* @return The scalar function set object.
+*/
+DUCKDB_API duckdb_scalar_function_set duckdb_create_scalar_function_set(const char *name);
+
+/*!
+Destroys the given scalar function set object.
+
+*/
+DUCKDB_API void duckdb_destroy_scalar_function_set(duckdb_scalar_function_set *scalar_function_set);
+
+/*!
+Adds the scalar function as a new overload to the scalar function set.
+
+Returns DuckDBError if the function could not be added, for example if the overload already exists.* @param set The
+scalar function set
+* @param function The function to add
+*/
+DUCKDB_API duckdb_state duckdb_add_scalar_function_to_set(duckdb_scalar_function_set set,
+                                                          duckdb_scalar_function function);
+
+/*!
+Register the scalar function set within the given connection.
+
+The set requires at least a single valid overload.
+
+If the set is incomplete or a function with this name already exists DuckDBError is returned.
+
+* @param con The connection to register it in.
+* @param set The function set to register
+* @return Whether or not the registration was successful.
+*/
+DUCKDB_API duckdb_state duckdb_register_scalar_function_set(duckdb_connection con, duckdb_scalar_function_set set);
 
 //===--------------------------------------------------------------------===//
 // Aggregate Functions

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -319,6 +319,10 @@ typedef struct {
 	duckdb_interval (*duckdb_get_interval)(duckdb_value val);
 	duckdb_logical_type (*duckdb_get_value_type)(duckdb_value val);
 	duckdb_blob (*duckdb_get_blob)(duckdb_value val);
+	duckdb_scalar_function_set (*duckdb_create_scalar_function_set)(const char *name);
+	void (*duckdb_destroy_scalar_function_set)(duckdb_scalar_function_set *scalar_function_set);
+	duckdb_state (*duckdb_add_scalar_function_to_set)(duckdb_scalar_function_set set, duckdb_scalar_function function);
+	duckdb_state (*duckdb_register_scalar_function_set)(duckdb_connection con, duckdb_scalar_function_set set);
 	// dev
 	// WARNING! the functions below are not (yet) stable
 
@@ -637,6 +641,10 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_get_interval = duckdb_get_interval;
 	result.duckdb_get_value_type = duckdb_get_value_type;
 	result.duckdb_get_blob = duckdb_get_blob;
+	result.duckdb_create_scalar_function_set = duckdb_create_scalar_function_set;
+	result.duckdb_destroy_scalar_function_set = duckdb_destroy_scalar_function_set;
+	result.duckdb_add_scalar_function_to_set = duckdb_add_scalar_function_to_set;
+	result.duckdb_register_scalar_function_set = duckdb_register_scalar_function_set;
 	result.duckdb_create_aggregate_function = duckdb_create_aggregate_function;
 	result.duckdb_destroy_aggregate_function = duckdb_destroy_aggregate_function;
 	result.duckdb_aggregate_function_set_name = duckdb_aggregate_function_set_name;

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/v0.0/v0.0.2.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/v0.0/v0.0.2.json
@@ -54,6 +54,10 @@
         "duckdb_get_timestamp",
         "duckdb_get_interval",
         "duckdb_get_value_type",
-        "duckdb_get_blob"
+        "duckdb_get_blob",
+        "duckdb_create_scalar_function_set",
+        "duckdb_destroy_scalar_function_set",
+        "duckdb_add_scalar_function_to_set",
+        "duckdb_register_scalar_function_set"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/scalar_functions.json
@@ -21,9 +21,9 @@
                 }
             ],
             "comment": {
-                "description": "Destroys the given table function object.\n\n",
+                "description": "Destroys the given scalar function object.\n\n",
                 "param_comments": {
-                    "scalar_function": "The table function to destroy"
+                    "scalar_function": "The scalar function to destroy"
                 }
             }
         },
@@ -164,7 +164,7 @@
             "comment": {
                 "description": "Assigns extra information to the scalar function that can be fetched during binding, etc.\n\n",
                 "param_comments": {
-                    "scalar_function": "The table function",
+                    "scalar_function": "The scalar function",
                     "extra_info": "The extra information",
                     "destroy": "The callback that will be called to destroy the bind data (if any)"
                 }
@@ -184,7 +184,7 @@
                 }
             ],
             "comment": {
-                "description": "Sets the main function of the table function.\n\n",
+                "description": "Sets the main function of the scalar function.\n\n",
                 "param_comments": {
                     "scalar_function": "The scalar function",
                     "function": "The function"
@@ -249,6 +249,79 @@
                     "info": "The info object.",
                     "error": "The error message"
                 }
+            }
+        },
+        {
+            "name": "duckdb_create_scalar_function_set",
+            "return_type": "duckdb_scalar_function_set",
+            "params": [
+                {
+                    "type": "const char*",
+                    "name": "name"
+                }
+            ],
+            "comment": {
+                "description": "Creates a new empty scalar function set.\n\nThe return value should be destroyed with `duckdb_destroy_scalar_function_set`.\n\n",
+                "return_value": "The scalar function set object."
+            }
+        },
+        {
+            "name": "duckdb_destroy_scalar_function_set",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_scalar_function_set *",
+                    "name": "scalar_function_set"
+                }
+            ],
+            "comment": {
+                "description": "Destroys the given scalar function set object.\n\n",
+                "param_comments": {
+                    "scalar_function": "The scalar function set to destroy"
+                }
+            }
+        },
+        {
+            "name": "duckdb_add_scalar_function_to_set",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_scalar_function_set",
+                    "name": "set"
+                },
+                {
+                    "type": "duckdb_scalar_function",
+                    "name": "function"
+                }
+            ],
+            "comment": {
+                "description": "Adds the scalar function as a new overload to the scalar function set.\n\nReturns DuckDBError if the function could not be added, for example if the overload already exists.",
+                "param_comments": {
+                    "set": "The scalar function set",
+                    "function": "The function to add"
+                }
+            }
+        },
+        {
+            "name": "duckdb_register_scalar_function_set",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_connection",
+                    "name": "con"
+                },
+                {
+                    "type": "duckdb_scalar_function_set",
+                    "name": "set"
+                }
+            ],
+            "comment": {
+                "description": "Register the scalar function set within the given connection.\n\nThe set requires at least a single valid overload.\n\nIf the set is incomplete or a function with this name already exists DuckDBError is returned.\n\n",
+                "param_comments": {
+                    "con": "The connection to register it in.",
+                    "set": "The function set to register"
+                },
+                "return_value": "Whether or not the registration was successful."
             }
         }
     ]

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -479,6 +479,11 @@ typedef struct _duckdb_scalar_function {
 	void *internal_ptr;
 } * duckdb_scalar_function;
 
+//! A scalar function set. Must be destroyed with `duckdb_destroy_scalar_function_set`.
+typedef struct _duckdb_scalar_function_set {
+	void *internal_ptr;
+} * duckdb_scalar_function_set;
+
 //! The main function of the scalar function.
 typedef void (*duckdb_scalar_function_t)(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output);
 

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -379,6 +379,10 @@ typedef struct {
 	duckdb_interval (*duckdb_get_interval)(duckdb_value val);
 	duckdb_logical_type (*duckdb_get_value_type)(duckdb_value val);
 	duckdb_blob (*duckdb_get_blob)(duckdb_value val);
+	duckdb_scalar_function_set (*duckdb_create_scalar_function_set)(const char *name);
+	void (*duckdb_destroy_scalar_function_set)(duckdb_scalar_function_set *scalar_function_set);
+	duckdb_state (*duckdb_add_scalar_function_to_set)(duckdb_scalar_function_set set, duckdb_scalar_function function);
+	duckdb_state (*duckdb_register_scalar_function_set)(duckdb_connection con, duckdb_scalar_function_set set);
 #endif
 
 #ifdef DUCKDB_EXTENSION_API_VERSION_DEV // dev
@@ -723,6 +727,10 @@ typedef struct {
 #define duckdb_scalar_function_set_volatile         duckdb_ext_api.duckdb_scalar_function_set_volatile
 #define duckdb_scalar_function_get_extra_info       duckdb_ext_api.duckdb_scalar_function_get_extra_info
 #define duckdb_scalar_function_set_error            duckdb_ext_api.duckdb_scalar_function_set_error
+#define duckdb_create_scalar_function_set           duckdb_ext_api.duckdb_create_scalar_function_set
+#define duckdb_destroy_scalar_function_set          duckdb_ext_api.duckdb_destroy_scalar_function_set
+#define duckdb_add_scalar_function_to_set           duckdb_ext_api.duckdb_add_scalar_function_to_set
+#define duckdb_register_scalar_function_set         duckdb_ext_api.duckdb_register_scalar_function_set
 
 #define duckdb_get_profiling_info             duckdb_ext_api.duckdb_get_profiling_info
 #define duckdb_profiling_info_get_value       duckdb_ext_api.duckdb_profiling_info_get_value

--- a/test/api/capi/capi_scalar_functions.cpp
+++ b/test/api/capi/capi_scalar_functions.cpp
@@ -59,10 +59,8 @@ void AddVariadicNumbersTogether(duckdb_function_info, duckdb_data_chunk input, d
 	}
 }
 
-static void CAPIRegisterAddition(duckdb_connection connection, const char *name, duckdb_state expected_outcome) {
-	duckdb_state status;
-
-	// create a scalar function
+static duckdb_scalar_function CAPIGetScalarFunction(duckdb_connection connection, const char *name,
+                                                    idx_t parameter_count = 2) {
 	auto function = duckdb_create_scalar_function();
 	duckdb_scalar_function_set_name(nullptr, name);
 	duckdb_scalar_function_set_name(function, nullptr);
@@ -73,8 +71,9 @@ static void CAPIRegisterAddition(duckdb_connection connection, const char *name,
 	auto type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
 	duckdb_scalar_function_add_parameter(nullptr, type);
 	duckdb_scalar_function_add_parameter(function, nullptr);
-	duckdb_scalar_function_add_parameter(function, type);
-	duckdb_scalar_function_add_parameter(function, type);
+	for (idx_t idx = 0; idx < parameter_count; idx++) {
+		duckdb_scalar_function_add_parameter(function, type);
+	}
 
 	// set the return type to bigint
 	duckdb_scalar_function_set_return_type(nullptr, type);
@@ -86,6 +85,14 @@ static void CAPIRegisterAddition(duckdb_connection connection, const char *name,
 	duckdb_scalar_function_set_function(nullptr, AddVariadicNumbersTogether);
 	duckdb_scalar_function_set_function(function, nullptr);
 	duckdb_scalar_function_set_function(function, AddVariadicNumbersTogether);
+	return function;
+}
+
+static void CAPIRegisterAddition(duckdb_connection connection, const char *name, duckdb_state expected_outcome) {
+	duckdb_state status;
+
+	// create a scalar function
+	auto function = CAPIGetScalarFunction(connection, name);
 
 	// register and cleanup
 	status = duckdb_register_scalar_function(connection, function);
@@ -336,4 +343,54 @@ TEST_CASE("Test Scalar Functions - variadic number of ANY parameters", "[capi]")
 	result = tester.Query("SELECT my_null_count()");
 	REQUIRE_NO_FAIL(*result);
 	REQUIRE(result->Fetch<uint64_t>(0, 0) == 0);
+}
+
+static void CAPIRegisterAdditionOverloads(duckdb_connection connection, const char *name,
+                                          duckdb_state expected_outcome) {
+	duckdb_state status;
+
+	auto function_set = duckdb_create_scalar_function_set(name);
+	// create a scalar function with 2 parameters
+	auto function = CAPIGetScalarFunction(connection, name, 2);
+	duckdb_add_scalar_function_to_set(function_set, function);
+	duckdb_destroy_scalar_function(&function);
+
+	// create a scalar function with 3 parameters
+	function = CAPIGetScalarFunction(connection, name, 3);
+	duckdb_add_scalar_function_to_set(function_set, function);
+	duckdb_destroy_scalar_function(&function);
+
+	// register and cleanup
+	status = duckdb_register_scalar_function_set(connection, function_set);
+	REQUIRE(status == expected_outcome);
+
+	duckdb_destroy_scalar_function_set(&function_set);
+	duckdb_destroy_scalar_function_set(&function_set);
+	duckdb_destroy_scalar_function_set(nullptr);
+}
+
+TEST_CASE("Test Scalar Function Overloads C API", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	CAPIRegisterAdditionOverloads(tester.connection, "my_addition", DuckDBSuccess);
+	// try to register it again - this should be an error
+	CAPIRegisterAdditionOverloads(tester.connection, "my_addition", DuckDBError);
+
+	// now call it
+	result = tester.Query("SELECT my_addition(40, 2)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 42);
+
+	result = tester.Query("SELECT my_addition(40, 2, 2)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 44);
+
+	// call it over a vector of values
+	result = tester.Query("SELECT my_addition(1000000, i, i) FROM range(10000) t(i)");
+	REQUIRE_NO_FAIL(*result);
+	for (idx_t row = 0; row < 10000; row++) {
+		REQUIRE(result->Fetch<int64_t>(0, row) == static_cast<int64_t>(1000000 + row + row));
+	}
 }


### PR DESCRIPTION
This PR introduces a number of new callbacks that allow for registering scalar function overloads in the C API:

```cpp
duckdb_scalar_function_set (*duckdb_create_scalar_function_set)(const char *name);
void (*duckdb_destroy_scalar_function_set)(duckdb_scalar_function_set *scalar_function_set);
duckdb_state (*duckdb_add_scalar_function_to_set)(duckdb_scalar_function_set set, duckdb_scalar_function function);
duckdb_state (*duckdb_register_scalar_function_set)(duckdb_connection con, duckdb_scalar_function_set set);
```