### PR TITLE
Add support for aggregate function overloads to the C API

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -501,7 +501,12 @@ typedef struct _duckdb_aggregate_function {
 	void *internal_ptr;
 } * duckdb_aggregate_function;
 
-//!
+//! A aggregate function set. Must be destroyed with `duckdb_destroy_aggregate_function_set`.
+typedef struct _duckdb_aggregate_function_set {
+	void *internal_ptr;
+} * duckdb_aggregate_function_set;
+
+//! Aggregate state
 typedef struct _duckdb_aggregate_state {
 	void *internal_ptr;
 } * duckdb_aggregate_state;
@@ -2963,6 +2968,45 @@ Report that an error has occurred while executing the aggregate function.
 * @param error The error message
 */
 DUCKDB_API void duckdb_aggregate_function_set_error(duckdb_function_info info, const char *error);
+
+/*!
+Creates a new empty aggregate function set.
+
+The return value should be destroyed with `duckdb_destroy_aggregate_function_set`.
+
+* @return The aggregate function set object.
+*/
+DUCKDB_API duckdb_aggregate_function_set duckdb_create_aggregate_function_set(const char *name);
+
+/*!
+Destroys the given aggregate function set object.
+
+*/
+DUCKDB_API void duckdb_destroy_aggregate_function_set(duckdb_aggregate_function_set *aggregate_function_set);
+
+/*!
+Adds the aggregate function as a new overload to the aggregate function set.
+
+Returns DuckDBError if the function could not be added, for example if the overload already exists.* @param set The
+aggregate function set
+* @param function The function to add
+*/
+DUCKDB_API duckdb_state duckdb_add_aggregate_function_to_set(duckdb_aggregate_function_set set,
+                                                             duckdb_aggregate_function function);
+
+/*!
+Register the aggregate function set within the given connection.
+
+The set requires at least a single valid overload.
+
+If the set is incomplete or a function with this name already exists DuckDBError is returned.
+
+* @param con The connection to register it in.
+* @param set The function set to register
+* @return Whether or not the registration was successful.
+*/
+DUCKDB_API duckdb_state duckdb_register_aggregate_function_set(duckdb_connection con,
+                                                               duckdb_aggregate_function_set set);
 
 //===--------------------------------------------------------------------===//
 // Table Functions

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -323,6 +323,11 @@ typedef struct {
 	void (*duckdb_destroy_scalar_function_set)(duckdb_scalar_function_set *scalar_function_set);
 	duckdb_state (*duckdb_add_scalar_function_to_set)(duckdb_scalar_function_set set, duckdb_scalar_function function);
 	duckdb_state (*duckdb_register_scalar_function_set)(duckdb_connection con, duckdb_scalar_function_set set);
+	duckdb_aggregate_function_set (*duckdb_create_aggregate_function_set)(const char *name);
+	void (*duckdb_destroy_aggregate_function_set)(duckdb_aggregate_function_set *aggregate_function_set);
+	duckdb_state (*duckdb_add_aggregate_function_to_set)(duckdb_aggregate_function_set set,
+	                                                     duckdb_aggregate_function function);
+	duckdb_state (*duckdb_register_aggregate_function_set)(duckdb_connection con, duckdb_aggregate_function_set set);
 	// dev
 	// WARNING! the functions below are not (yet) stable
 
@@ -645,6 +650,10 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_destroy_scalar_function_set = duckdb_destroy_scalar_function_set;
 	result.duckdb_add_scalar_function_to_set = duckdb_add_scalar_function_to_set;
 	result.duckdb_register_scalar_function_set = duckdb_register_scalar_function_set;
+	result.duckdb_create_aggregate_function_set = duckdb_create_aggregate_function_set;
+	result.duckdb_destroy_aggregate_function_set = duckdb_destroy_aggregate_function_set;
+	result.duckdb_add_aggregate_function_to_set = duckdb_add_aggregate_function_to_set;
+	result.duckdb_register_aggregate_function_set = duckdb_register_aggregate_function_set;
 	result.duckdb_create_aggregate_function = duckdb_create_aggregate_function;
 	result.duckdb_destroy_aggregate_function = duckdb_destroy_aggregate_function;
 	result.duckdb_aggregate_function_set_name = duckdb_aggregate_function_set_name;

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/v0.0/v0.0.2.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/v0.0/v0.0.2.json
@@ -58,6 +58,10 @@
         "duckdb_create_scalar_function_set",
         "duckdb_destroy_scalar_function_set",
         "duckdb_add_scalar_function_to_set",
-        "duckdb_register_scalar_function_set"
+        "duckdb_register_scalar_function_set",
+        "duckdb_create_aggregate_function_set",
+        "duckdb_destroy_aggregate_function_set",
+        "duckdb_add_aggregate_function_to_set",
+        "duckdb_register_aggregate_function_set"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/aggregate_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/aggregate_functions.json
@@ -253,6 +253,79 @@
                     "error": "The error message"
                 }
             }
+        },
+        {
+            "name": "duckdb_create_aggregate_function_set",
+            "return_type": "duckdb_aggregate_function_set",
+            "params": [
+                {
+                    "type": "const char*",
+                    "name": "name"
+                }
+            ],
+            "comment": {
+                "description": "Creates a new empty aggregate function set.\n\nThe return value should be destroyed with `duckdb_destroy_aggregate_function_set`.\n\n",
+                "return_value": "The aggregate function set object."
+            }
+        },
+        {
+            "name": "duckdb_destroy_aggregate_function_set",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_aggregate_function_set *",
+                    "name": "aggregate_function_set"
+                }
+            ],
+            "comment": {
+                "description": "Destroys the given aggregate function set object.\n\n",
+                "param_comments": {
+                    "aggregate_function": "The aggregate function set to destroy"
+                }
+            }
+        },
+        {
+            "name": "duckdb_add_aggregate_function_to_set",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_aggregate_function_set",
+                    "name": "set"
+                },
+                {
+                    "type": "duckdb_aggregate_function",
+                    "name": "function"
+                }
+            ],
+            "comment": {
+                "description": "Adds the aggregate function as a new overload to the aggregate function set.\n\nReturns DuckDBError if the function could not be added, for example if the overload already exists.",
+                "param_comments": {
+                    "set": "The aggregate function set",
+                    "function": "The function to add"
+                }
+            }
+        },
+        {
+            "name": "duckdb_register_aggregate_function_set",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_connection",
+                    "name": "con"
+                },
+                {
+                    "type": "duckdb_aggregate_function_set",
+                    "name": "set"
+                }
+            ],
+            "comment": {
+                "description": "Register the aggregate function set within the given connection.\n\nThe set requires at least a single valid overload.\n\nIf the set is incomplete or a function with this name already exists DuckDBError is returned.\n\n",
+                "param_comments": {
+                    "con": "The connection to register it in.",
+                    "set": "The function set to register"
+                },
+                "return_value": "Whether or not the registration was successful."
+            }
         }
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -495,7 +495,12 @@ typedef struct _duckdb_aggregate_function {
 	void *internal_ptr;
 } * duckdb_aggregate_function;
 
-//!
+//! A aggregate function set. Must be destroyed with `duckdb_destroy_aggregate_function_set`.
+typedef struct _duckdb_aggregate_function_set {
+	void *internal_ptr;
+} * duckdb_aggregate_function_set;
+
+//! Aggregate state
 typedef struct _duckdb_aggregate_state {
 	void *internal_ptr;
 } * duckdb_aggregate_state;

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -383,6 +383,11 @@ typedef struct {
 	void (*duckdb_destroy_scalar_function_set)(duckdb_scalar_function_set *scalar_function_set);
 	duckdb_state (*duckdb_add_scalar_function_to_set)(duckdb_scalar_function_set set, duckdb_scalar_function function);
 	duckdb_state (*duckdb_register_scalar_function_set)(duckdb_connection con, duckdb_scalar_function_set set);
+	duckdb_aggregate_function_set (*duckdb_create_aggregate_function_set)(const char *name);
+	void (*duckdb_destroy_aggregate_function_set)(duckdb_aggregate_function_set *aggregate_function_set);
+	duckdb_state (*duckdb_add_aggregate_function_to_set)(duckdb_aggregate_function_set set,
+	                                                     duckdb_aggregate_function function);
+	duckdb_state (*duckdb_register_aggregate_function_set)(duckdb_connection con, duckdb_aggregate_function_set set);
 #endif
 
 #ifdef DUCKDB_EXTENSION_API_VERSION_DEV // dev
@@ -731,6 +736,11 @@ typedef struct {
 #define duckdb_destroy_scalar_function_set          duckdb_ext_api.duckdb_destroy_scalar_function_set
 #define duckdb_add_scalar_function_to_set           duckdb_ext_api.duckdb_add_scalar_function_to_set
 #define duckdb_register_scalar_function_set         duckdb_ext_api.duckdb_register_scalar_function_set
+
+#define duckdb_create_aggregate_function_set   duckdb_ext_api.duckdb_create_aggregate_function_set
+#define duckdb_destroy_aggregate_function_set  duckdb_ext_api.duckdb_destroy_aggregate_function_set
+#define duckdb_add_aggregate_function_to_set   duckdb_ext_api.duckdb_add_aggregate_function_to_set
+#define duckdb_register_aggregate_function_set duckdb_ext_api.duckdb_register_aggregate_function_set
 
 #define duckdb_get_profiling_info             duckdb_ext_api.duckdb_get_profiling_info
 #define duckdb_profiling_info_get_value       duckdb_ext_api.duckdb_profiling_info_get_value

--- a/test/api/capi/capi_aggregate_functions.cpp
+++ b/test/api/capi/capi_aggregate_functions.cpp
@@ -25,13 +25,24 @@ void WeightedSumUpdate(duckdb_function_info info, duckdb_data_chunk input, duckd
 	auto input_data = static_cast<int64_t *>(duckdb_vector_get_data(input_vector));
 	auto input_validity = duckdb_vector_get_validity(input_vector);
 
-	auto weight_vector = duckdb_data_chunk_get_vector(input, 1);
-	auto weight_data = static_cast<int64_t *>(duckdb_vector_get_data(weight_vector));
-	auto weight_validity = duckdb_vector_get_validity(weight_vector);
-	for (idx_t i = 0; i < row_count; i++) {
-		if (duckdb_validity_row_is_valid(input_validity, i) && duckdb_validity_row_is_valid(weight_validity, i)) {
-			state[i]->sum += input_data[i] * weight_data[i];
-			state[i]->count++;
+	if (duckdb_data_chunk_get_column_count(input) == 1) {
+		// single argument
+		for (idx_t i = 0; i < row_count; i++) {
+			if (duckdb_validity_row_is_valid(input_validity, i)) {
+				state[i]->sum += input_data[i];
+				state[i]->count++;
+			}
+		}
+	} else {
+		// two arguments
+		auto weight_vector = duckdb_data_chunk_get_vector(input, 1);
+		auto weight_data = static_cast<int64_t *>(duckdb_vector_get_data(weight_vector));
+		auto weight_validity = duckdb_vector_get_validity(weight_vector);
+		for (idx_t i = 0; i < row_count; i++) {
+			if (duckdb_validity_row_is_valid(input_validity, i) && duckdb_validity_row_is_valid(weight_validity, i)) {
+				state[i]->sum += input_data[i] * weight_data[i];
+				state[i]->count++;
+			}
 		}
 	}
 }
@@ -63,9 +74,8 @@ void WeightedSumFinalize(duckdb_function_info info, duckdb_aggregate_state *sour
 	}
 }
 
-static void CAPIRegisterWeightedSum(duckdb_connection connection, const char *name, duckdb_state expected_outcome) {
-	duckdb_state status;
-
+static duckdb_aggregate_function CAPIGetAggregateFunction(duckdb_connection connection, const char *name,
+                                                          idx_t parameter_count = 2) {
 	// create a scalar function
 	auto function = duckdb_create_aggregate_function();
 	duckdb_aggregate_function_set_name(nullptr, name);
@@ -77,8 +87,9 @@ static void CAPIRegisterWeightedSum(duckdb_connection connection, const char *na
 	auto type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
 	duckdb_aggregate_function_add_parameter(nullptr, type);
 	duckdb_aggregate_function_add_parameter(function, nullptr);
-	duckdb_aggregate_function_add_parameter(function, type);
-	duckdb_aggregate_function_add_parameter(function, type);
+	for (idx_t idx = 0; idx < parameter_count; idx++) {
+		duckdb_aggregate_function_add_parameter(function, type);
+	}
 
 	// set the return type to bigint
 	duckdb_aggregate_function_set_return_type(nullptr, type);
@@ -91,7 +102,14 @@ static void CAPIRegisterWeightedSum(duckdb_connection connection, const char *na
 	duckdb_aggregate_function_set_functions(function, nullptr, nullptr, nullptr, nullptr, nullptr);
 	duckdb_aggregate_function_set_functions(function, WeightedSumSize, WeightedSumInit, WeightedSumUpdate,
 	                                        WeightedSumCombine, WeightedSumFinalize);
+	return function;
+}
 
+static void CAPIRegisterWeightedSum(duckdb_connection connection, const char *name, duckdb_state expected_outcome) {
+	duckdb_state status;
+
+	// create a scalar function
+	auto function = CAPIGetAggregateFunction(connection, name);
 	// register and cleanup
 	status = duckdb_register_aggregate_function(connection, function);
 	REQUIRE(status == expected_outcome);
@@ -376,4 +394,47 @@ TEST_CASE("Test String Aggregate Function", "[capi]") {
 	    "SELECT repeated_string_agg(CASE WHEN i%10=0 THEN i::VARCHAR ELSE '' END, 2) FROM range(100) t(i)");
 	REQUIRE_NO_FAIL(*result);
 	REQUIRE(result->Fetch<string>(0, 0) == "00101020203030404050506060707080809090");
+}
+
+static void CAPIRegisterWeightedSumOverloads(duckdb_connection connection, const char *name,
+                                             duckdb_state expected_outcome) {
+	duckdb_state status;
+
+	auto function_set = duckdb_create_aggregate_function_set(name);
+	// create a scalar function with 2 parameters
+	auto function = CAPIGetAggregateFunction(connection, name, 1);
+	duckdb_add_aggregate_function_to_set(function_set, function);
+	duckdb_destroy_aggregate_function(&function);
+
+	// create a scalar function with 3 parameters
+	function = CAPIGetAggregateFunction(connection, name, 2);
+	duckdb_add_aggregate_function_to_set(function_set, function);
+	duckdb_destroy_aggregate_function(&function);
+
+	// register and cleanup
+	status = duckdb_register_aggregate_function_set(connection, function_set);
+	REQUIRE(status == expected_outcome);
+
+	duckdb_destroy_aggregate_function_set(&function_set);
+	duckdb_destroy_aggregate_function_set(&function_set);
+	duckdb_destroy_aggregate_function_set(nullptr);
+}
+
+TEST_CASE("Test Aggregate Function Overloads C API", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+	CAPIRegisterWeightedSumOverloads(tester.connection, "my_weighted_sum", DuckDBSuccess);
+	// try to register it again - this should be an error
+	CAPIRegisterWeightedSumOverloads(tester.connection, "my_weighted_sum", DuckDBError);
+
+	// now call it
+	result = tester.Query("SELECT my_weighted_sum(40)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 40);
+
+	result = tester.Query("SELECT my_weighted_sum(40, 2)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 80);
 }


### PR DESCRIPTION
This PR introduces a number of new callbacks that allow for registering aggregate function overloads in the C API:

```cpp
duckdb_aggregate_function_set (*duckdb_create_aggregate_function_set)(const char *name);
void (*duckdb_destroy_aggregate_function_set)(duckdb_aggregate_function_set *aggregate_function_set);
duckdb_state (*duckdb_add_aggregate_function_to_set)(duckdb_aggregate_function_set set,
                                                     duckdb_aggregate_function function);
duckdb_state (*duckdb_register_aggregate_function_set)(duckdb_connection con, duckdb_aggregate_function_set set);
```