### PR TITLE
[Metadata] Populate the `expressions` column of `duckdb_indexes`

### DIFF
--- a/src/function/table/system/duckdb_indexes.cpp
+++ b/src/function/table/system/duckdb_indexes.cpp
@@ -75,6 +75,12 @@ unique_ptr<GlobalTableFunctionState> DuckDBIndexesInit(ClientContext &context, T
 	return std::move(result);
 }
 
+Value GetIndexExpressions(IndexCatalogEntry &index) {
+	auto create_info = index.GetInfo();
+	auto &create_index_info = create_info->Cast<CreateIndexInfo>();
+	return Value(create_index_info.ExpressionsToString());
+}
+
 void DuckDBIndexesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &data = data_p.global_state->Cast<DuckDBIndexesData>();
 	if (data.offset >= data.entries.size()) {
@@ -119,7 +125,7 @@ void DuckDBIndexesFunction(ClientContext &context, TableFunctionInput &data_p, D
 		// is_primary, BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(index.IsPrimary()));
 		// expressions, VARCHAR
-		output.SetValue(col++, count, Value());
+		output.SetValue(col++, count, GetIndexExpressions(index));
 		// sql, VARCHAR
 		auto sql = index.ToSQL();
 		output.SetValue(col++, count, sql.empty() ? Value() : Value(std::move(sql)));

--- a/src/function/table/system/duckdb_indexes.cpp
+++ b/src/function/table/system/duckdb_indexes.cpp
@@ -86,7 +86,7 @@ Value GetIndexExpressions(IndexCatalogEntry &index) {
 	for (auto &item : vec) {
 		content.push_back(Value(item));
 	}
-	return Value::LIST(std::move(content));
+	return Value::LIST(LogicalType::VARCHAR, std::move(content));
 }
 
 void DuckDBIndexesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {

--- a/src/include/duckdb/parser/parsed_data/create_index_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_index_info.hpp
@@ -48,6 +48,7 @@ public:
 	DUCKDB_API unique_ptr<CreateInfo> Copy() const override;
 
 	string ToString() const override;
+	vector<string> ExpressionsToList() const;
 	string ExpressionsToString() const;
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<CreateInfo> Deserialize(Deserializer &deserializer);

--- a/src/include/duckdb/parser/parsed_data/create_index_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_index_info.hpp
@@ -48,6 +48,7 @@ public:
 	DUCKDB_API unique_ptr<CreateInfo> Copy() const override;
 
 	string ToString() const override;
+	string ExpressionsToString() const;
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<CreateInfo> Deserialize(Deserializer &deserializer);
 };

--- a/src/parser/parsed_data/create_index_info.cpp
+++ b/src/parser/parsed_data/create_index_info.cpp
@@ -27,14 +27,12 @@ static void RemoveTableQualificationRecursive(unique_ptr<ParsedExpression> &expr
 	}
 }
 
-string CreateIndexInfo::ExpressionsToString() const {
-	string result;
+vector<string> CreateIndexInfo::ExpressionsToList() const {
+	vector<string> list;
+
 	for (idx_t i = 0; i < parsed_expressions.size(); i++) {
 		auto &expr = parsed_expressions[i];
 		auto copy = expr->Copy();
-		if (i > 0) {
-			result += ", ";
-		}
 		// column ref expressions are qualified with the table name
 		// we need to remove them to reproduce the original query
 		RemoveTableQualificationRecursive(copy, table);
@@ -48,12 +46,17 @@ string CreateIndexInfo::ExpressionsToString() const {
 			}
 		}
 		if (add_parenthesis) {
-			result += StringUtil::Format("(%s)", copy->ToString());
+			list.push_back(StringUtil::Format("(%s)", copy->ToString()));
 		} else {
-			result += StringUtil::Format("%s", copy->ToString());
+			list.push_back(StringUtil::Format("%s", copy->ToString()));
 		}
 	}
-	return result;
+	return list;
+}
+
+string CreateIndexInfo::ExpressionsToString() const {
+	auto list = ExpressionsToList();
+	return StringUtil::Join(list, ", ");
 }
 
 string CreateIndexInfo::ToString() const {

--- a/src/parser/parsed_data/create_index_info.cpp
+++ b/src/parser/parsed_data/create_index_info.cpp
@@ -27,27 +27,8 @@ static void RemoveTableQualificationRecursive(unique_ptr<ParsedExpression> &expr
 	}
 }
 
-string CreateIndexInfo::ToString() const {
+string CreateIndexInfo::ExpressionsToString() const {
 	string result;
-
-	result += "CREATE";
-	D_ASSERT(constraint_type == IndexConstraintType::UNIQUE || constraint_type == IndexConstraintType::NONE);
-	if (constraint_type == IndexConstraintType::UNIQUE) {
-		result += " UNIQUE";
-	}
-	result += " INDEX ";
-	if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
-		result += "IF NOT EXISTS ";
-	}
-	result += KeywordHelper::WriteOptionallyQuoted(index_name);
-	result += " ON ";
-	result += QualifierToString(temporary ? "" : catalog, schema, table);
-	if (index_type != "ART") {
-		result += " USING ";
-		result += KeywordHelper::WriteOptionallyQuoted(index_type);
-		result += " ";
-	}
-	result += "(";
 	for (idx_t i = 0; i < parsed_expressions.size(); i++) {
 		auto &expr = parsed_expressions[i];
 		auto copy = expr->Copy();
@@ -72,6 +53,31 @@ string CreateIndexInfo::ToString() const {
 			result += StringUtil::Format("%s", copy->ToString());
 		}
 	}
+	return result;
+}
+
+string CreateIndexInfo::ToString() const {
+	string result;
+
+	result += "CREATE";
+	D_ASSERT(constraint_type == IndexConstraintType::UNIQUE || constraint_type == IndexConstraintType::NONE);
+	if (constraint_type == IndexConstraintType::UNIQUE) {
+		result += " UNIQUE";
+	}
+	result += " INDEX ";
+	if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
+		result += "IF NOT EXISTS ";
+	}
+	result += KeywordHelper::WriteOptionallyQuoted(index_name);
+	result += " ON ";
+	result += QualifierToString(temporary ? "" : catalog, schema, table);
+	if (index_type != "ART") {
+		result += " USING ";
+		result += KeywordHelper::WriteOptionallyQuoted(index_type);
+		result += " ";
+	}
+	result += "(";
+	result += ExpressionsToString();
 	result += ")";
 	if (!options.empty()) {
 		result += " WITH (";

--- a/test/sql/table_function/duckdb_indexes.test
+++ b/test/sql/table_function/duckdb_indexes.test
@@ -17,4 +17,4 @@ SELECT * FROM duckdb_indexes;
 query I
 select expressions from duckdb_indexes where table_name = 'integers';
 ----
-((j + 1)), k
+[((j + 1)), k]

--- a/test/sql/table_function/duckdb_indexes.test
+++ b/test/sql/table_function/duckdb_indexes.test
@@ -13,3 +13,8 @@ SELECT * FROM duckdb_indexes();
 
 statement ok nosort duckdb_col
 SELECT * FROM duckdb_indexes;
+
+query I
+select expressions from duckdb_indexes where table_name = 'integers';
+----
+((j + 1)), k


### PR DESCRIPTION
This PR fixes #13414 

In ToSQL we already create the expression list, I've moved this logic out into a separate function and we now use that to create the `expressions` column.