### PR TITLE
Fix #13380: fix cast fail when do InClauseSimplificationRule

### DIFF
--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -25,7 +25,8 @@ unique_ptr<Expression> InClauseSimplificationRule::Apply(LogicalOperator &op, ve
 	}
 	//! Here we check if we can apply the expression on the constant side
 	auto target_type = cast_expression.source_type();
-	if (!BoundCastExpression::CastIsInvertible(cast_expression.return_type, target_type)) {
+	if (!BoundCastExpression::CastIsInvertible(cast_expression.return_type, target_type) ||
+	    !BoundCastExpression::CastIsInvertible(target_type, cast_expression.return_type)) {
 		return nullptr;
 	}
 	vector<unique_ptr<BoundConstantExpression>> cast_list;

--- a/test/sql/optimizer/expression/test_in_clause_simplification.test
+++ b/test/sql/optimizer/expression/test_in_clause_simplification.test
@@ -1,0 +1,22 @@
+# name: test/sql/optimizer/expression/test_in_clause_simplification.test
+# group: [expression]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t1(c0 TIMESTAMP)
+
+statement ok
+INSERT INTO t1(c0) VALUES ('2024-08-09 14:48:00')
+
+
+query I
+SELECT (CAST(t1.c0 AS DATE) IN ('2024-08-09')) FROM t1
+----
+true
+
+query I
+SELECT NOT (CAST(t1.c0 AS DATE) IN ('2024-08-09')) FROM t1
+----
+false


### PR DESCRIPTION
This pr try to fix #13380. `cast_expression` shouldn't convert to `cast_expression.child` directly when only **cast_expression.return_type => cast_expression.source_type()** is Invertible. 