### PR TITLE
Fix dsdgen args

### DIFF
--- a/extension/tpcds/tpcds_extension.cpp
+++ b/extension/tpcds/tpcds_extension.cpp
@@ -29,6 +29,9 @@ static duckdb::unique_ptr<FunctionData> DsdgenBind(ClientContext &context, Table
                                                    vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_uniq<DSDGenFunctionData>();
 	for (auto &kv : input.named_parameters) {
+		if (kv.second.IsNull()) {
+			throw BinderException("Cannot use NULL as function argument");
+		}
 		if (kv.first == "sf") {
 			result->sf = kv.second.GetValue<double>();
 		} else if (kv.first == "catalog") {

--- a/extension/tpch/tpch_extension.cpp
+++ b/extension/tpch/tpch_extension.cpp
@@ -33,6 +33,9 @@ static duckdb::unique_ptr<FunctionData> DbgenBind(ClientContext &context, TableF
                                                   vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_uniq<DBGenFunctionData>();
 	for (auto &kv : input.named_parameters) {
+		if (kv.second.IsNull()) {
+			throw BinderException("Cannot use NULL as function argument");
+		}
 		if (kv.first == "sf") {
 			result->sf = DoubleValue::Get(kv.second);
 		} else if (kv.first == "catalog") {

--- a/src/function/table/query_function.cpp
+++ b/src/function/table/query_function.cpp
@@ -17,6 +17,11 @@ static unique_ptr<SubqueryRef> ParseSubquery(const string &query, const ParserOp
 }
 
 static void UnionTablesQuery(TableFunctionBindInput &input, string &query) {
+	for (auto &input_val : input.inputs) {
+		if (input_val.IsNull()) {
+			throw BinderException("Cannot use NULL as function argument");
+		}
+	}
 	string by_name = (input.inputs.size() == 2 &&
 	                  (input.inputs[1].type().id() == LogicalTypeId::BOOLEAN && input.inputs[1].GetValue<bool>()))
 	                     ? "BY NAME "

--- a/test/fuzzer/duckfuzz/fuzzer_issue_2980.test
+++ b/test/fuzzer/duckfuzz/fuzzer_issue_2980.test
@@ -1,0 +1,8 @@
+# name: test/fuzzer/duckfuzz/fuzzer_issue_2980.test
+# description: NULL in query Table function not allows
+# group: [duckfuzz]
+
+statement error
+SELECT DISTINCT NULL FROM query_table(NULL, NULL) AS t6(c1, c2, c3, c4, c5) , region AS t10(c7, c8, c9) HAVING TRY_CAST(c3 AS STRUCT(a INTEGER, b VARCHAR)[3]) QUALIFY (c3 BETWEEN c8 AND (c4 BETWEEN c4 AND c5));
+----
+<REGEX>:.*Cannot use NULL.*

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -80,7 +80,7 @@ SELECT * FROM query('WITH a(i) AS (SELECT 1) SELECT a1.i AS i1, a2.i AS i2 FROM 
 statement error
 SELECT * FROM query(NULL);
 ----
-Parser Error: syntax error at or near "NULL"
+<REGEX>:Parser Error.*NULL.*
 
 statement error
 SELECT * FROM query(' ');
@@ -170,7 +170,7 @@ No function matches the given name and argument types 'query_table()'.
 statement error
 FROM query_table(NULL);
 ----
-Catalog Error: Table with name NULL does not exist!
+<REGEX>:.*Cannot use NULL.*
 
 statement error
 FROM query_table([]);

--- a/test/sql/tpcds/tpcds_options.test_slow
+++ b/test/sql/tpcds/tpcds_options.test_slow
@@ -49,3 +49,15 @@ CALL dsdgen(sf=0.01, catalog='db1', schema='test_schema');
 
 statement ok
 SELECT COUNT(*) FROM db1.test_schema.call_center
+
+statement error
+Call dsdgen(sf=NULL);
+<REGEX>:.*Cannot use NULL.*
+
+statement error
+Call dsdgen(catalog=NULL);
+<REGEX>:.*Cannot use NULL.*
+
+statement error
+Call dsdgen(sf=1, suffix=NULL);
+<REGEX>:.*Cannot use NULL.*

--- a/test/sql/tpch/test_tpch_options.test_slow
+++ b/test/sql/tpch/test_tpch_options.test_slow
@@ -15,6 +15,15 @@ CALL dbgen(sf=0.01, children=2);
 ----
 Step must be defined when children are defined
 
+statement error
+call dbgen(sf=NULL);
+----
+<REGEX>:.*Cannot use NULL.*
+
+statement error
+call dbgen(sf=1, catalog=NULL);
+----
+<REGEX>:.*Cannot use NULL.*
 
 statement ok
 CALL dbgen(sf=1, children =100, step = 0);
@@ -171,3 +180,5 @@ select count (*) from (SELECT * FROM db1.test_schema.${tpch_tbl} EXCEPT SELECT *
 0
 
 endloop
+
+


### PR DESCRIPTION
should fix the followin
https://github.com/duckdb/duckdb-fuzzer/issues/3236
https://github.com/duckdb/duckdb-fuzzer/issues/2986
https://github.com/duckdb/duckdb-fuzzer/issues/2980
https://github.com/duckdb/duckdb-fuzzer/issues/3073
https://github.com/duckdb/duckdb-fuzzer/issues/2954
https://github.com/duckdb/duckdb-fuzzer/issues/2816
https://github.com/duckdb/duckdb-fuzzer/issues/3238

If you don't check for NULL early enough, then the calls to `StringValue::Get(kv.second);` will throw an internal error