### PR TITLE
Pull up filters from and through explicit joins

### DIFF
--- a/src/optimizer/filter_pullup.cpp
+++ b/src/optimizer/filter_pullup.cpp
@@ -1,5 +1,9 @@
 #include "duckdb/optimizer/filter_pullup.hpp"
 
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/operator/logical_any_join.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
 

--- a/test/fuzzer/duckfuzz/semi_join_has_correct_left_right_relations.test
+++ b/test/fuzzer/duckfuzz/semi_join_has_correct_left_right_relations.test
@@ -1,5 +1,5 @@
 # name: test/fuzzer/duckfuzz/semi_join_has_correct_left_right_relations.test
-# description: create_sort_key with string boundaries
+# description: Test that semi joins have correct left/right columns
 # group: [duckfuzz]
 
 statement ok
@@ -36,6 +36,17 @@ FROM   all_types
 ----
 <REGEX>:.*Conversion Error:.*
 
+# This one should throw a Conversion Error. However, FilterPullup now pulls up an unsatisfiable join filter,
+# * there's a lot of those in this query: "... INNER JOIN ... ON (NULL)"
+# so that part of the plan is never executed, and we just get a empty result
+query I
+SELECT NULL FROM main.all_types AS ref_0 INNER JOIN main.all_types AS ref_1 INNER JOIN main.all_types AS ref_2 ON ((SELECT NULL)) INNER JOIN main.all_types ON ((SELECT NULL)) ON (NULL) INNER JOIN main.all_types AS ref_4 ON (ref_4."varchar") INNER JOIN main.all_types AS ref_5 ON (EXISTS(SELECT 79 AS c0 FROM main.all_types AS ref_6 INNER JOIN main.all_types AS ref_7 INNER JOIN main.all_types ON (NULL) ON ((EXISTS(SELECT ref_2.uint AS c0, ref_4."time" AS c1 FROM main.all_types AS ref_9 WHERE (ref_2."varchar" ~~~ ref_5."varchar")) AND (ref_1."varchar" !~~* ref_7."varchar"))) , (SELECT ref_6.utinyint AS c0, (SELECT bit_or(ubigint) FROM main.all_types) AS c1, ref_5.fixed_varchar_array AS c2, ref_10."union" AS c3 FROM main.all_types AS ref_10 WHERE (ref_2."varchar" !~~* ref_0."varchar") LIMIT 159) AS subq_0 WHERE 0 LIMIT 67)) LEFT JOIN main.all_types AS ref_11 ON ((ref_1."time" = ref_11."time")) LIMIT 115
+----
+
+
+# When we disable FilterPullup, we get the expected error
+statement ok
+set disabled_optimizers to 'filter_pullup'
 
 statement error
 SELECT NULL FROM main.all_types AS ref_0 INNER JOIN main.all_types AS ref_1 INNER JOIN main.all_types AS ref_2 ON ((SELECT NULL)) INNER JOIN main.all_types ON ((SELECT NULL)) ON (NULL) INNER JOIN main.all_types AS ref_4 ON (ref_4."varchar") INNER JOIN main.all_types AS ref_5 ON (EXISTS(SELECT 79 AS c0 FROM main.all_types AS ref_6 INNER JOIN main.all_types AS ref_7 INNER JOIN main.all_types ON (NULL) ON ((EXISTS(SELECT ref_2.uint AS c0, ref_4."time" AS c1 FROM main.all_types AS ref_9 WHERE (ref_2."varchar" ~~~ ref_5."varchar")) AND (ref_1."varchar" !~~* ref_7."varchar"))) , (SELECT ref_6.utinyint AS c0, (SELECT bit_or(ubigint) FROM main.all_types) AS c1, ref_5.fixed_varchar_array AS c2, ref_10."union" AS c3 FROM main.all_types AS ref_10 WHERE (ref_2."varchar" !~~* ref_0."varchar") LIMIT 159) AS subq_0 WHERE 0 LIMIT 67)) LEFT JOIN main.all_types AS ref_11 ON ((ref_1."time" = ref_11."time")) LIMIT 115

--- a/test/optimizer/pullup_filters.test
+++ b/test/optimizer/pullup_filters.test
@@ -80,3 +80,46 @@ EXPLAIN SELECT * FROM (SELECT * FROM vals1, vals2 INTERSECT SELECT * FROM vals1,
 ----
 physical_plan	<REGEX>:((.*=3.*=5.*=3.*=5.*)|(.*=5.*=3.*=5.*=3.*))
 
+statement ok
+create table orders as select range o_orderkey from range(10)
+
+statement ok
+create table lineitem as select range % 10 l_orderkey from range(100)
+
+# down here we test that we can pull filters out of explicitly joined relations (using JOIN syntax rather than WHERE)
+
+# even though we are explicitly joining on l_orderkey both times,
+# we can derive that o1.o_orderkey = o2.o_orderkey
+# once we've derived this, the join order optimizer finds it should join o1 with o2 before joining with lineitem
+# rather than joining lineitem with o1 and o2 directly
+# so we should see lineitem first in the regex, and then 2x orders (deeper because joined first)
+
+statement ok
+PRAGMA explain_output='OPTIMIZED_ONLY'
+
+query II
+explain
+select count(*)
+from lineitem l
+join orders o1
+on (l.l_orderkey = o1.o_orderkey)
+join orders o2
+on (l.l_orderkey = o2.o_orderkey)
+----
+logical_opt	<REGEX>:.*lineitem.*orders.*orders.*
+
+# if we disable the FilterPullup, we get the original join order again:
+# orders first (joined last), then lineitem, then orders
+statement ok
+set disabled_optimizers to 'filter_pullup'
+
+query II
+explain
+select count(*)
+from lineitem l
+join orders o1
+on (l.l_orderkey = o1.o_orderkey)
+join orders o2
+on (l.l_orderkey = o2.o_orderkey)
+----
+logical_opt	<REGEX>:.*orders.*lineitem.*orders.*


### PR DESCRIPTION
We can specify the same query equivalently either as:
```sql
select count(*)
from lineitem l,
     orders o1,
     orders o2
where l.l_orderkey = o1.o_orderkey
  and l.l_orderkey = o2.o_orderkey
```
Or as:
```sql
select count(*)
from lineitem l
join orders o1
on (l.l_orderkey = o1.o_orderkey)
join orders o2
on (l.l_orderkey = o2.o_orderkey)
```
In the first query, we would derive that `o1.o_orderkey = o2.o_orderkey` and join `o1` and `o2` first. In the second case, we wouldn't derive this because we didn't pull the condition out of explicitly `JOIN`ed relations, and we'd end up with a different (worse) join order.

This PR fixes this by pulling these conditions up out of `LogicalComparisonJoin` and `LogicalAnyJoin` in `FilterPullup`.