### PR TITLE
fix for the issue 2698

### DIFF
--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -647,7 +647,7 @@ static void ToJSONFunctionInternal(const StructNames &names, Vector &input, cons
 		}
 	}
 
-	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR || count == 1) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 	}
 }

--- a/test/fuzzer/duckfuzz/fuzzer_issue_2698.test
+++ b/test/fuzzer/duckfuzz/fuzzer_issue_2698.test
@@ -1,6 +1,6 @@
 # name: test/fuzzer/duckfuzz/fuzzer_issue_2698.test
 # description: Test fuzzyduck
-# group: [fuzzyduck]
+# group: [duckfuzz]
 
 require json
 

--- a/test/fuzzer/duckfuzz/fuzzer_issue_2698.test
+++ b/test/fuzzer/duckfuzz/fuzzer_issue_2698.test
@@ -1,0 +1,12 @@
+# name: test/fuzzer/duckfuzz/fuzzer_issue_2698.test
+# description: Test fuzzyduck
+# group: [fuzzyduck]
+
+require json
+
+statement ok
+create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types() limit 0;
+
+query I
+SELECT (TRY_CAST(5572 AS INTEGER[3][3]) BETWEEN json(c48) AND NULL) FROM all_types AS t51(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50);
+----


### PR DESCRIPTION
This PR should fix the fuzzer [issue](https://github.com/duckdb/duckdb-fuzzer/issues/2698).

@Maxxen helped me find out that the assertion failed because it received a vector of an unexpected type (expected VectorType::CONSTANT_VECTOR, but got VectorType::FLAT_VECTOR) and provided me with the fix.