### PR TITLE
Use LossyNumericCast while reading memory limits

### DIFF
--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -439,7 +439,7 @@ idx_t DBConfig::ParseMemoryLimit(const string &arg) {
 		throw ParserException("Unknown unit for memory_limit: %s (expected: KB, MB, GB, TB for 1000^i units or KiB, "
 		                      "MiB, GiB, TiB for 1024^i unites)");
 	}
-	return NumericCast<idx_t>(static_cast<double>(multiplier) * limit);
+	return LossyNumericCast<idx_t>(static_cast<double>(multiplier) * limit);
 }
 
 idx_t DBConfig::ParseMemoryLimitSlurm(const string &arg) {
@@ -472,7 +472,7 @@ idx_t DBConfig::ParseMemoryLimitSlurm(const string &arg) {
 		return NumericLimits<idx_t>::Maximum();
 	}
 
-	return NumericCast<idx_t>(static_cast<double>(multiplier) * limit);
+	return LossyNumericCast<idx_t>(static_cast<double>(multiplier) * limit);
 }
 
 // Right now we only really care about access mode when comparing DBConfigs

--- a/test/sql/pragma/test_memory_limit.test
+++ b/test/sql/pragma/test_memory_limit.test
@@ -42,6 +42,9 @@ statement ok
 PRAGMA memory_limit='1.0 gb'
 
 statement ok
+PRAGMA memory_limit='488.2 MiB'
+
+statement ok
 PRAGMA memory_limit='1.0 gigabytes'
 
 # M and MB = megabyte


### PR DESCRIPTION
Otherwise nightly will fail with `SET memory_limit = '488.2 MiB';` due to lossy cast to integer.