### PR TITLE
[Dev] Mention non-unique indexes in UPSERT `DO UPDATE SET` error

### DIFF
--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -201,7 +201,7 @@ void Binder::BindDoUpdateSetExpressions(const string &table_alias, LogicalInsert
 	for (idx_t i = 0; i < logical_column_ids.size(); i++) {
 		auto &column = logical_column_ids[i];
 		if (indexed_columns.count(column)) {
-			throw BinderException("Can not assign to column '%s' because it has a UNIQUE/PRIMARY KEY constraint",
+			throw BinderException("Can not assign to column '%s' because it has a UNIQUE/PRIMARY KEY constraint or is referenced by an INDEX",
 			                      column_names[i]);
 		}
 	}
@@ -312,7 +312,7 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 			// Same as before, this is essentially a no-op, turning this into a DO THROW instead
 			// But since this makes no logical sense, it's probably better to throw an error
 			throw BinderException(
-			    "The specified columns as conflict target are not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT");
+			    "The specified columns as conflict target are not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT or INDEX");
 		}
 	} else {
 		// When omitting the conflict target, the ON CONFLICT applies to every UNIQUE/PRIMARY KEY on the table

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -201,7 +201,8 @@ void Binder::BindDoUpdateSetExpressions(const string &table_alias, LogicalInsert
 	for (idx_t i = 0; i < logical_column_ids.size(); i++) {
 		auto &column = logical_column_ids[i];
 		if (indexed_columns.count(column)) {
-			throw BinderException("Can not assign to column '%s' because it has a UNIQUE/PRIMARY KEY constraint or is referenced by an INDEX",
+			throw BinderException("Can not assign to column '%s' because it has a UNIQUE/PRIMARY KEY constraint or is "
+			                      "referenced by an INDEX",
 			                      column_names[i]);
 		}
 	}
@@ -311,8 +312,8 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 		if (!index_references_columns) {
 			// Same as before, this is essentially a no-op, turning this into a DO THROW instead
 			// But since this makes no logical sense, it's probably better to throw an error
-			throw BinderException(
-			    "The specified columns as conflict target are not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT or INDEX");
+			throw BinderException("The specified columns as conflict target are not referenced by a UNIQUE/PRIMARY KEY "
+			                      "CONSTRAINT or INDEX");
 		}
 	} else {
 		// When omitting the conflict target, the ON CONFLICT applies to every UNIQUE/PRIMARY KEY on the table

--- a/test/sql/upsert/upsert_explicit_index.test
+++ b/test/sql/upsert/upsert_explicit_index.test
@@ -21,3 +21,20 @@ select * from tbl;
 ----
 5	10
 3	2
+
+statement ok
+drop table tbl cascade;
+
+statement ok
+create table tbl (i integer PRIMARY KEY, j integer);
+
+statement ok
+insert into tbl values (42, 21), (21, 42);
+
+statement ok
+create index my_index on tbl(j);
+
+statement error
+insert into tbl values (42, 20) on conflict do update set j = 30
+----
+Can not assign to column 'j' because it has a UNIQUE/PRIMARY KEY constraint or is referenced by an INDEX


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2743

Because of the currently expected limitation that INDEXes don't support UPDATE statements, targeting a column that is referenced by an INDEX (even if that INDEX is not UNIQUE) is not supported and will throw an exception.