### PR TITLE
ExecutorTask: flush before finalizing task

### DIFF
--- a/src/parallel/executor_task.cpp
+++ b/src/parallel/executor_task.cpp
@@ -17,10 +17,10 @@ ExecutorTask::ExecutorTask(ClientContext &context, shared_ptr<Event> event_p, co
 }
 
 ExecutorTask::~ExecutorTask() {
-	executor.UnregisterTask();
 	if (thread_context) {
 		executor.Flush(*thread_context);
 	}
+	executor.UnregisterTask();
 }
 
 void ExecutorTask::Deschedule() {


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/13260

We need to flush the intermediate thread state to the profiler before we unregister the task - otherwise the query can be terminated before we flush to the profiler.