### PR TITLE
Apply extension patches via 'patch' instead of 'git apply'

### DIFF
--- a/scripts/apply_extension_patches.py
+++ b/scripts/apply_extension_patches.py
@@ -38,9 +38,7 @@ print(f"Resetting patches in {directory}\n")
 subprocess.run(["git", "log"], check=True)
 subprocess.run(["git", "clean", "-f"], check=True)
 subprocess.run(["git", "reset", "--hard", "HEAD"], check=True)
-# Apply each patch file using git apply
+# Apply each patch file using patch
 for patch in patches:
     print(f"Applying patch: {patch}\n")
-    subprocess.run(
-        ["git", "apply", "--ignore-space-change", "--ignore-whitespace", os.path.join(directory, patch)], check=True
-    )
+    subprocess.run(["patch", "-p1", "--forward", "-i", os.path.join(directory, patch)], check=True)


### PR DESCRIPTION
Idea is that even when submodules are not being fetched from git (say folder populated independently), this should work the same.

duckdb-wasm already moved to using patch unix command, CI here should only test that current workflows are not impacted.