### PR TITLE
Add support for registering custom types through c api

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -556,6 +556,15 @@ typedef void (*duckdb_table_function_init_t)(duckdb_init_info info);
 typedef void (*duckdb_table_function_t)(duckdb_function_info info, duckdb_data_chunk output);
 
 //===--------------------------------------------------------------------===//
+// Custom type types
+//===--------------------------------------------------------------------===//
+
+//! A custom type. Must be destroyed with `duckdb_destroy_custom_type`.
+typedef struct _duckdb_custom_type {
+	void *internal_ptr;
+} * duckdb_custom_type;
+
+//===--------------------------------------------------------------------===//
 // Replacement scan types
 //===--------------------------------------------------------------------===//
 
@@ -2202,6 +2211,14 @@ The result must be destroyed with `duckdb_free`.
 DUCKDB_API char *duckdb_logical_type_get_alias(duckdb_logical_type type);
 
 /*!
+Sets the alias of a duckdb_logical_type.
+
+* @param type The logical type
+* @param alias The alias to set
+*/
+DUCKDB_API void duckdb_logical_type_set_alias(duckdb_logical_type type, const char *alias);
+
+/*!
 Creates a LIST type from its child type.
 The return type must be destroyed with `duckdb_destroy_logical_type`.
 
@@ -2446,6 +2463,45 @@ Destroys the logical type and de-allocates all memory allocated for that type.
 * @param type The logical type to destroy.
 */
 DUCKDB_API void duckdb_destroy_logical_type(duckdb_logical_type *type);
+
+/*!
+Creates a new custom type.
+
+* @return The custom type.
+*/
+DUCKDB_API duckdb_custom_type duckdb_create_custom_type();
+
+/*!
+Destroys an custom type.
+
+* @param type The custom type to destroy.
+*/
+DUCKDB_API void duckdb_destroy_custom_type(duckdb_custom_type *type);
+
+/*!
+Sets the base type of an custom type.
+
+* @param type The custom type
+* @param base_type The base type to set
+*/
+DUCKDB_API void duckdb_custom_type_set_base_type(duckdb_custom_type type, duckdb_logical_type base_type);
+
+/*!
+Sets the name of an custom type.
+
+* @param type The custom type
+* @param name The name to set
+*/
+DUCKDB_API void duckdb_custom_type_set_name(duckdb_custom_type type, const char *name);
+
+/*!
+Registers a custom type within the given connection.
+
+* @param con The connection to use
+* @param type The custom type to register
+* @return Whether or not the registration was successful.
+*/
+DUCKDB_API duckdb_state duckdb_register_custom_type(duckdb_connection con, duckdb_custom_type type);
 
 //===--------------------------------------------------------------------===//
 // Data Chunk Interface

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2487,7 +2487,7 @@ Sets the base type of an custom type.
 DUCKDB_API void duckdb_custom_type_set_base_type(duckdb_custom_type type, duckdb_logical_type base_type);
 
 /*!
-Sets the name of an custom type.
+Sets the name of a custom type.
 
 * @param type The custom type
 * @param name The name to set

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -351,6 +351,12 @@ typedef struct {
 	                                                 duckdb_delete_callback_t destroy);
 	void *(*duckdb_aggregate_function_get_extra_info)(duckdb_function_info info);
 	void (*duckdb_aggregate_function_set_error)(duckdb_function_info info, const char *error);
+	duckdb_custom_type (*duckdb_create_custom_type)();
+	void (*duckdb_destroy_custom_type)(duckdb_custom_type *type);
+	duckdb_state (*duckdb_register_custom_type)(duckdb_connection con, duckdb_custom_type type);
+	void (*duckdb_custom_type_set_name)(duckdb_custom_type type, const char *name);
+	void (*duckdb_custom_type_set_base_type)(duckdb_custom_type type, duckdb_logical_type base_type);
+	void (*duckdb_logical_type_set_alias)(duckdb_logical_type type, const char *alias);
 } duckdb_ext_api_v0;
 
 //===--------------------------------------------------------------------===//
@@ -662,6 +668,12 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_aggregate_function_set_extra_info = duckdb_aggregate_function_set_extra_info;
 	result.duckdb_aggregate_function_get_extra_info = duckdb_aggregate_function_get_extra_info;
 	result.duckdb_aggregate_function_set_error = duckdb_aggregate_function_set_error;
+	result.duckdb_create_custom_type = duckdb_create_custom_type;
+	result.duckdb_destroy_custom_type = duckdb_destroy_custom_type;
+	result.duckdb_register_custom_type = duckdb_register_custom_type;
+	result.duckdb_custom_type_set_name = duckdb_custom_type_set_name;
+	result.duckdb_custom_type_set_base_type = duckdb_custom_type_set_base_type;
+	result.duckdb_logical_type_set_alias = duckdb_logical_type_set_alias;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -12,6 +12,12 @@
         "duckdb_aggregate_function_set_special_handling",
         "duckdb_aggregate_function_set_extra_info",
         "duckdb_aggregate_function_get_extra_info",
-        "duckdb_aggregate_function_set_error"
+        "duckdb_aggregate_function_set_error",
+        "duckdb_create_custom_type",
+        "duckdb_destroy_custom_type",
+        "duckdb_register_custom_type",
+        "duckdb_custom_type_set_name",
+        "duckdb_custom_type_set_base_type",
+        "duckdb_logical_type_set_alias"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/logical_type_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/logical_type_interface.json
@@ -37,6 +37,27 @@
             }
         },
         {
+            "name": "duckdb_logical_type_set_alias",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_logical_type",
+                    "name": "type"
+                },
+                {
+                    "type": "const char *",
+                    "name": "alias"
+                }
+            ],
+            "comment": {
+                "description": "Sets the alias of a duckdb_logical_type.\n\n",
+                "param_comments": {
+                    "type": "The logical type",
+                    "alias": "The alias to set"
+                }
+            }
+        },
+        {
             "name": "duckdb_create_list_type",
             "return_type": "duckdb_logical_type",
             "params": [
@@ -540,6 +561,95 @@
                 "param_comments": {
                     "type": "The logical type to destroy."
                 }
+            }
+        },
+        {
+            "name": "duckdb_create_custom_type",
+            "return_type": "duckdb_custom_type",
+            "params": [],
+            "comment": {
+                "description": "Creates a new custom type.\n\n",
+                "return_value": "The custom type."
+            }
+        },
+        {
+            "name": "duckdb_destroy_custom_type",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_custom_type *",
+                    "name": "type"
+                }
+            ],
+            "comment": {
+                "description": "Destroys an custom type.\n\n",
+                "param_comments": {
+                    "type": "The custom type to destroy."
+                }
+            }
+        },
+        {
+            "name": "duckdb_custom_type_set_base_type",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_custom_type",
+                    "name": "type"
+                },
+                {
+                    "type": "duckdb_logical_type",
+                    "name": "base_type"
+                }
+            ],
+            "comment": {
+                "description": "Sets the base type of an custom type.\n\n",
+                "param_comments": {
+                    "type": "The custom type",
+                    "base_type": "The base type to set"
+                }
+            }
+        },
+        {
+            "name": "duckdb_custom_type_set_name",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_custom_type",
+                    "name": "type"
+                },
+                {
+                    "type": "const char *",
+                    "name": "name"
+                }
+            ],
+            "comment": {
+                "description": "Sets the name of an custom type.\n\n",
+                "param_comments": {
+                    "type": "The custom type",
+                    "name": "The name to set"
+                }
+            }
+        },
+        {
+            "name": "duckdb_register_custom_type",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_connection",
+                    "name": "con"
+                },
+                {
+                    "type": "duckdb_custom_type",
+                    "name": "type"
+                }
+            ],
+            "comment": {
+                "description": "Registers a custom type within the given connection.\n\n",
+                "param_comments": {
+                    "con": "The connection to use",
+                    "type": "The custom type to register"
+                },
+                "return_value": "Whether or not the registration was successful."
             }
         }
     ]

--- a/src/include/duckdb/main/capi/header_generation/functions/logical_type_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/logical_type_interface.json
@@ -623,7 +623,7 @@
                 }
             ],
             "comment": {
-                "description": "Sets the name of an custom type.\n\n",
+                "description": "Sets the name of a custom type.\n\n",
                 "param_comments": {
                     "type": "The custom type",
                     "name": "The name to set"

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -550,6 +550,15 @@ typedef void (*duckdb_table_function_init_t)(duckdb_init_info info);
 typedef void (*duckdb_table_function_t)(duckdb_function_info info, duckdb_data_chunk output);
 
 //===--------------------------------------------------------------------===//
+// Custom type types
+//===--------------------------------------------------------------------===//
+
+//! A custom type. Must be destroyed with `duckdb_destroy_custom_type`.
+typedef struct _duckdb_custom_type {
+	void *internal_ptr;
+} * duckdb_custom_type;
+
+//===--------------------------------------------------------------------===//
 // Replacement scan types
 //===--------------------------------------------------------------------===//
 

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -413,6 +413,12 @@ typedef struct {
 	                                                 duckdb_delete_callback_t destroy);
 	void *(*duckdb_aggregate_function_get_extra_info)(duckdb_function_info info);
 	void (*duckdb_aggregate_function_set_error)(duckdb_function_info info, const char *error);
+	duckdb_custom_type (*duckdb_create_custom_type)();
+	void (*duckdb_destroy_custom_type)(duckdb_custom_type *type);
+	duckdb_state (*duckdb_register_custom_type)(duckdb_connection con, duckdb_custom_type type);
+	void (*duckdb_custom_type_set_name)(duckdb_custom_type type, const char *name);
+	void (*duckdb_custom_type_set_base_type)(duckdb_custom_type type, duckdb_logical_type base_type);
+	void (*duckdb_logical_type_set_alias)(duckdb_logical_type type, const char *alias);
 #endif
 
 } duckdb_ext_api_v0;
@@ -750,6 +756,13 @@ typedef struct {
 #define duckdb_table_description_error   duckdb_ext_api.duckdb_table_description_error
 
 // Version dev
+#define duckdb_logical_type_set_alias    duckdb_ext_api.duckdb_logical_type_set_alias
+#define duckdb_create_custom_type        duckdb_ext_api.duckdb_create_custom_type
+#define duckdb_destroy_custom_type       duckdb_ext_api.duckdb_destroy_custom_type
+#define duckdb_custom_type_set_base_type duckdb_ext_api.duckdb_custom_type_set_base_type
+#define duckdb_custom_type_set_name      duckdb_ext_api.duckdb_custom_type_set_name
+#define duckdb_register_custom_type      duckdb_ext_api.duckdb_register_custom_type
+
 #define duckdb_create_aggregate_function               duckdb_ext_api.duckdb_create_aggregate_function
 #define duckdb_destroy_aggregate_function              duckdb_ext_api.duckdb_destroy_aggregate_function
 #define duckdb_aggregate_function_set_name             duckdb_ext_api.duckdb_aggregate_function_set_name

--- a/src/main/capi/logical_types-c.cpp
+++ b/src/main/capi/logical_types-c.cpp
@@ -1,5 +1,16 @@
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/parser/parsed_data/create_type_info.hpp"
+#include "duckdb/common/type_visitor.hpp"
+#include "duckdb/common/helper.hpp"
+
+namespace duckdb {
+
+struct CCustomType {
+	unique_ptr<LogicalType> base_type;
+	string name;
+};
+
+} // namespace duckdb
 
 static bool AssertLogicalTypeId(duckdb_logical_type type, duckdb::LogicalTypeId type_id) {
 	if (!type) {
@@ -341,13 +352,6 @@ duckdb_logical_type duckdb_struct_type_child_type(duckdb_logical_type type, idx_
 	    new duckdb::LogicalType(duckdb::StructType::GetChildType(logical_type, index)));
 }
 
-namespace duckdb {
-struct CCustomType {
-	unique_ptr<LogicalType> base_type;
-	string name;
-};
-} // namespace duckdb
-
 duckdb_custom_type duckdb_create_custom_type() {
 	return reinterpret_cast<duckdb_custom_type>(new duckdb::CCustomType());
 }
@@ -374,7 +378,7 @@ void duckdb_custom_type_set_base_type(duckdb_custom_type type, duckdb_logical_ty
 	}
 	const auto &logical_type = *(reinterpret_cast<duckdb::LogicalType *>(base_type));
 	auto &custom_type = *(reinterpret_cast<duckdb::CCustomType *>(type));
-	custom_type.base_type = duckdb::make_uniq<LogicalType>(logical_type);
+	custom_type.base_type = duckdb::make_uniq<duckdb::LogicalType>(logical_type);
 }
 
 duckdb_state duckdb_register_custom_type(duckdb_connection connection, duckdb_custom_type type) {

--- a/test/api/capi/CMakeLists.txt
+++ b/test/api/capi/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   test_sql_capi
   OBJECT
   capi_aggregate_functions.cpp
+  capi_custom_type.cpp
   capi_scalar_functions.cpp
   capi_table_functions.cpp
   test_capi.cpp

--- a/test/api/capi/capi_custom_type.cpp
+++ b/test/api/capi/capi_custom_type.cpp
@@ -1,0 +1,131 @@
+#include "capi_tester.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+static duckdb_custom_type CAPIGetCustomType(const char *name, duckdb_type duckdb_type) {
+	auto base_type = duckdb_create_logical_type(duckdb_type);
+	duckdb_logical_type_set_alias(base_type, name);
+
+	auto custom_type = duckdb_create_custom_type();
+	duckdb_custom_type_set_name(custom_type, name);
+	duckdb_custom_type_set_base_type(custom_type, base_type);
+
+	duckdb_destroy_logical_type(&base_type);
+
+	return custom_type;
+}
+
+static void CAPIRegisterCustomType(duckdb_connection connection, const char *name, duckdb_type duckdb_type,
+                                   duckdb_state expected_outcome) {
+	duckdb_state status;
+
+	auto custom_type = CAPIGetCustomType(name, duckdb_type);
+
+	status = duckdb_register_custom_type(connection, custom_type);
+	REQUIRE(status == expected_outcome);
+
+	duckdb_destroy_custom_type(&custom_type);
+	duckdb_destroy_custom_type(&custom_type);
+	duckdb_destroy_custom_type(nullptr);
+}
+
+TEST_CASE("Test Custom Type Registration", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	// try to register a custom type with an invalid base type
+	CAPIRegisterCustomType(tester.connection, "NUMBER", DUCKDB_TYPE_INVALID, DuckDBError);
+	// try to register a custom type with a valid base type
+	CAPIRegisterCustomType(tester.connection, "NUMBER", DUCKDB_TYPE_INTEGER, DuckDBSuccess);
+	// try to register it again - this should be an error
+	CAPIRegisterCustomType(tester.connection, "NUMBER", DUCKDB_TYPE_INTEGER, DuckDBError);
+
+	// check that it is in the catalog
+	result = tester.Query("SELECT type_name FROM duckdb_types WHERE type_name = 'NUMBER'");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->row_count() == 1);
+	REQUIRE(result->Fetch<string>(0, 0) == "NUMBER");
+}
+
+TEST_CASE("Test Custom Type Function", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	// Register a custom type (VEC3D) that is between 0 and 1
+	auto element_type = duckdb_create_logical_type(DUCKDB_TYPE_FLOAT);
+	auto vector_type = duckdb_create_array_type(element_type, 3);
+	duckdb_logical_type_set_alias(vector_type, "VEC3D");
+
+	auto custom_type = duckdb_create_custom_type();
+	duckdb_custom_type_set_name(custom_type, "VEC3D");
+	duckdb_custom_type_set_base_type(custom_type, vector_type);
+
+	REQUIRE(duckdb_register_custom_type(tester.connection, custom_type) == DuckDBSuccess);
+
+	// Register a scalar function that adds two vectors
+	auto function = duckdb_create_scalar_function();
+	duckdb_scalar_function_set_name(function, "vec3d_add");
+	duckdb_scalar_function_set_return_type(function, vector_type);
+	duckdb_scalar_function_add_parameter(function, vector_type);
+	duckdb_scalar_function_add_parameter(function, vector_type);
+	duckdb_scalar_function_set_function(function, [](duckdb_function_info info, duckdb_data_chunk input,
+	                                                 duckdb_vector output) {
+		const auto count = duckdb_data_chunk_get_size(input);
+		const auto left_vector = duckdb_data_chunk_get_vector(input, 0);
+		const auto right_vector = duckdb_data_chunk_get_vector(input, 1);
+		const auto left_data = static_cast<float *>(duckdb_vector_get_data(duckdb_array_vector_get_child(left_vector)));
+		const auto right_data =
+		    static_cast<float *>(duckdb_vector_get_data(duckdb_array_vector_get_child(right_vector)));
+		const auto result_data = static_cast<float *>(duckdb_vector_get_data(duckdb_array_vector_get_child(output)));
+
+		for (idx_t i = 0; i < count; i++) {
+			for (idx_t j = 0; j < 3; j++) {
+				const auto idx = i * 3 + j;
+				result_data[idx] = left_data[idx] + right_data[idx];
+			}
+		}
+	});
+
+	REQUIRE(duckdb_register_scalar_function(tester.connection, function) == DuckDBSuccess);
+
+	// Cleanup the custom type and scalar function
+	duckdb_destroy_scalar_function(&function);
+	duckdb_destroy_logical_type(&element_type);
+	duckdb_destroy_logical_type(&vector_type);
+	duckdb_destroy_custom_type(&custom_type);
+
+	// Create a table with the custom type
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE vec3d_table (a VEC3D)"));
+	REQUIRE_NO_FAIL(tester.Query("INSERT INTO vec3d_table VALUES ([1.0, 2.0, 3.0]::FLOAT[3])"));
+	REQUIRE_NO_FAIL(tester.Query("INSERT INTO vec3d_table VALUES ([4.0, 5.0, 6.0]::FLOAT[3])"));
+
+	// Query the table
+	result = tester.Query("SELECT vec3d_add(a, a) FROM vec3d_table");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->row_count() == 2);
+
+	// Check that the result is correct
+	auto chunk = result->FetchChunk(0);
+	auto data = static_cast<float *>(duckdb_vector_get_data(duckdb_array_vector_get_child(chunk->GetVector(0))));
+	REQUIRE(data[0] == 2.0f);
+	REQUIRE(data[1] == 4.0f);
+	REQUIRE(data[2] == 6.0f);
+	REQUIRE(data[3] == 8.0f);
+	REQUIRE(data[4] == 10.0f);
+	REQUIRE(data[5] == 12.0f);
+
+	// But we cant execute the function with a non-VEC3D type
+	result = tester.Query("SELECT vec3d_add([0,0,0]::FLOAT[3], [1,1,1]::FLOAT[3])");
+	REQUIRE_FAIL(result);
+	REQUIRE(result->ErrorType() == DUCKDB_ERROR_BINDER);
+
+	// But we can cast the base type to the custom type
+	result = tester.Query("SELECT vec3d_add(CAST([0,0,0] AS VEC3D), CAST([1,1,1] AS VEC3D))");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->row_count() == 1);
+}


### PR DESCRIPTION
This PR adds support for registering custom types and setting type aliases through the C-API.
The following new functions are added

```c
// Set the alias of a type
void duckdb_logical_type_set_alias(duckdb_logical_type type, const char *alias)

// Create a "custom type" struct used for registering custom types
duckdb_custom_type duckdb_create_custom_type();
// Set the base type of a custom type
void duckdb_custom_type_set_base_type(duckdb_custom_type type, duckdb_logical_type base_type)
// Set the name of a custom type
void duckdb_custom_type_set_name(duckdb_custom_type type, const char *name);
// Register a custom type
duckdb_state duckdb_register_custom_type(duckdb_connection con, duckdb_custom_type type);
// Destroy a custom type struct
void duckdb_destroy_custom_type(duckdb_custom_type *type);
```

One thing that im not sure about: when registering a custom type, the name should _usually_ be the same as the alias given to the base logical type, but im not sure if we want to enforce/handle this automatically behind the scenes in the c-api or if we leave it up to the user. Although we could always add that later (without changing the public facing API).