### PR TITLE
Switch floating point division and modulo to use IEEE semantics for division by zero by default, and add ieee_floating_point_ops setting that can be used to revert back to old behavior

### DIFF
--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -953,12 +953,24 @@ static scalar_function_t GetBinaryFunctionIgnoreZero(PhysicalType type) {
 	}
 }
 
+template <class OP>
+unique_ptr<FunctionData> BindBinaryFloatingPoint(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	auto &config = DBConfig::GetConfig(context);
+	if (config.options.ieee_floating_point_ops) {
+		bound_function.function = GetScalarBinaryFunction<OP>(bound_function.return_type.InternalType());
+	} else {
+		bound_function.function = GetBinaryFunctionIgnoreZero<OP>(bound_function.return_type.InternalType());
+	}
+	return nullptr;
+}
+
 void DivideFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet fp_divide("/");
-	fp_divide.AddFunction(ScalarFunction({LogicalType::FLOAT, LogicalType::FLOAT}, LogicalType::FLOAT,
-	                                     GetBinaryFunctionIgnoreZero<DivideOperator>(PhysicalType::FLOAT)));
-	fp_divide.AddFunction(ScalarFunction({LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE,
-	                                     GetBinaryFunctionIgnoreZero<DivideOperator>(PhysicalType::DOUBLE)));
+	fp_divide.AddFunction(ScalarFunction({LogicalType::FLOAT, LogicalType::FLOAT}, LogicalType::FLOAT, nullptr,
+	                                     BindBinaryFloatingPoint<DivideOperator>));
+	fp_divide.AddFunction(ScalarFunction({LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, nullptr,
+	                                     BindBinaryFloatingPoint<DivideOperator>));
 	fp_divide.AddFunction(
 	    ScalarFunction({LogicalType::INTERVAL, LogicalType::BIGINT}, LogicalType::INTERVAL,
 	                   BinaryScalarFunctionIgnoreZero<interval_t, int64_t, interval_t, DivideOperator>));
@@ -1001,14 +1013,12 @@ unique_ptr<FunctionData> BindDecimalModulo(ClientContext &context, ScalarFunctio
 
 template <>
 float ModuloOperator::Operation(float left, float right) {
-	D_ASSERT(right != 0);
 	auto result = std::fmod(left, right);
 	return result;
 }
 
 template <>
 double ModuloOperator::Operation(double left, double right) {
-	D_ASSERT(right != 0);
 	auto result = std::fmod(left, right);
 	return result;
 }
@@ -1024,7 +1034,9 @@ hugeint_t ModuloOperator::Operation(hugeint_t left, hugeint_t right) {
 void ModFun::RegisterFunction(BuiltinFunctions &set) {
 	ScalarFunctionSet functions("%");
 	for (auto &type : LogicalType::Numeric()) {
-		if (type.id() == LogicalTypeId::DECIMAL) {
+		if (type.id() == LogicalTypeId::FLOAT || type.id() == LogicalTypeId::DOUBLE) {
+			functions.AddFunction(ScalarFunction({type, type}, type, nullptr, BindBinaryFloatingPoint<ModuloOperator>));
+		} else if (type.id() == LogicalTypeId::DECIMAL) {
 			functions.AddFunction(ScalarFunction({type, type}, type, nullptr, BindDecimalModulo<ModuloOperator>));
 		} else {
 			functions.AddFunction(

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -263,6 +263,8 @@ struct DBConfigOptions {
 	idx_t catalog_error_max_schemas = 100;
 	//!  Whether or not to always write to the WAL file, even if this is not required
 	bool debug_skip_checkpoint_on_commit = false;
+	//! Use IEE754-compliant floating point operations (returning NAN instead of errors/NULL)
+	bool ieee_floating_point_ops = true;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -516,6 +516,16 @@ struct LockConfigurationSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct IEEEFloatingPointOpsSetting {
+	static constexpr const char *Name = "ieee_floating_point_ops";
+	static constexpr const char *Description =
+	    "Use IEE754-compliant floating point operations (returning NAN instead of errors/NULL)";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct ImmediateTransactionModeSetting {
 	static constexpr const char *Name = "immediate_transaction_mode";
 	static constexpr const char *Description =

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -101,6 +101,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(EnableMacrosDependencies),
     DUCKDB_GLOBAL(EnableViewDependencies),
     DUCKDB_GLOBAL(LockConfigurationSetting),
+    DUCKDB_GLOBAL(IEEEFloatingPointOpsSetting),
     DUCKDB_GLOBAL(ImmediateTransactionModeSetting),
     DUCKDB_LOCAL(IntegerDivisionSetting),
     DUCKDB_LOCAL(MaximumExpressionDepthSetting),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1126,6 +1126,22 @@ Value LockConfigurationSetting::GetSetting(const ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// IEEE Floating Points
+//===--------------------------------------------------------------------===//
+void IEEEFloatingPointOpsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.options.ieee_floating_point_ops = BooleanValue::Get(input);
+}
+
+void IEEEFloatingPointOpsSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.ieee_floating_point_ops = DBConfig().options.ieee_floating_point_ops;
+}
+
+Value IEEEFloatingPointOpsSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.options.ieee_floating_point_ops);
+}
+
+//===--------------------------------------------------------------------===//
 // Immediate Transaction Mode
 //===--------------------------------------------------------------------===//
 void ImmediateTransactionModeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/planner/binder/statement/bind_summarize.cpp
+++ b/src/planner/binder/statement/bind_summarize.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/case_expression.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/tableref/showref.hpp"

--- a/src/planner/binder/statement/bind_summarize.cpp
+++ b/src/planner/binder/statement/bind_summarize.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
+#include "duckdb/parser/expression/comparison_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/case_expression.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -95,6 +95,7 @@ OptionValueSet GetValueForOption(const string &name, LogicalTypeId type) {
 	    {"profile_output", {"test"}},
 	    {"profiling_mode", {"detailed"}},
 	    {"enable_progress_bar_print", {false}},
+	    {"ieee_floating_point_ops", {false}},
 	    {"progress_bar_time", {0}},
 	    {"temp_directory", {"tmp"}},
 	    {"wal_autocheckpoint", {"4.0 GiB"}},

--- a/test/issues/rigger/complex_division.test
+++ b/test/issues/rigger/complex_division.test
@@ -6,6 +6,9 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
+SET ieee_floating_point_ops=false;
+
+statement ok
 BEGIN TRANSACTION;
 
 statement ok

--- a/test/issues/rigger/division_by_zero_null.test
+++ b/test/issues/rigger/division_by_zero_null.test
@@ -6,6 +6,9 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
+SET ieee_floating_point_ops=false;
+
+statement ok
 BEGIN TRANSACTION;
 
 statement ok

--- a/test/sql/function/numeric/test_fdiv_fmod.test
+++ b/test/sql/function/numeric/test_fdiv_fmod.test
@@ -6,6 +6,9 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
+SET ieee_floating_point_ops=false;
+
+statement ok
 CREATE TABLE rs(x DOUBLE, y INTEGER)
 
 statement ok

--- a/test/sql/optimizer/expression/test_nop_arithmetic.test
+++ b/test/sql/optimizer/expression/test_nop_arithmetic.test
@@ -118,6 +118,9 @@ SELECT 0 / a FROM test
 NULL
 NULL
 
+statement ok
+SET ieee_floating_point_ops=false;
+
 query I
 SELECT 0 / rowid FROM test
 ----

--- a/test/sql/types/float/ieee_floating_points.test
+++ b/test/sql/types/float/ieee_floating_points.test
@@ -1,0 +1,62 @@
+# name: test/sql/types/float/ieee_floating_points.test
+# description: Test usage of the INF value
+# group: [float]
+
+statement ok
+PRAGMA enable_verification
+
+foreach type FLOAT DOUBLE
+
+statement ok
+CREATE OR REPLACE TABLE tbl(val ${type})
+
+statement ok
+INSERT INTO tbl VALUES (1), (-1), (0), ('nan'), ('inf')
+
+# division by zero
+query II
+SELECT val, val / 0::${type} FROM tbl
+----
+1.0	inf
+-1.0	-inf
+0.0	nan
+nan	nan
+inf	inf
+
+# modulo by zero
+query II
+SELECT val, val % 0::${type} FROM tbl
+----
+1.0	nan
+-1.0	nan
+0.0	nan
+nan	nan
+inf	nan
+
+statement ok
+SET ieee_floating_point_ops = false;
+
+# division by zero
+query II
+SELECT val, val / 0::${type} FROM tbl
+----
+1.0	NULL
+-1.0	NULL
+0.0	NULL
+nan	NULL
+inf	NULL
+
+# modulo by zero
+query II
+SELECT val, val % 0::${type} FROM tbl
+----
+1.0	NULL
+-1.0	NULL
+0.0	NULL
+nan	NULL
+inf	NULL
+
+statement ok
+SET ieee_floating_point_ops = true;
+
+endloop

--- a/test/sql/types/null/test_null.test
+++ b/test/sql/types/null/test_null.test
@@ -34,6 +34,9 @@ SELECT 1 + (NULL + NULL)
 ----
 NULL
 
+statement ok
+SET ieee_floating_point_ops=false;
+
 # division by zero
 query I
 SELECT 4 / 0


### PR DESCRIPTION
Implements https://github.com/duckdb/duckdb/discussions/10956

This PR changes the behavior of floating point division/modulo by zero to by default follow IEEE-754 semantics, i.e. the following results are returned:

|   expr   | result |
|----------|-------:|
| 1.0 / 0  | inf    |
| 1.0 / -0  | -inf   |
| -1.0 / 0 | -inf   |
| -1.0 / -0 | inf    |
| 0.0 / 0  | nan    |
| 0.0 / -0  | nan    |
| nan / -0  | nan    |
| nan / 0  | nan    |
| inf / 0  | inf    |
| inf / -0  | -inf   |

Previously all of these would return `NULL`.

The `ieee_floating_point_ops`  setting is added which can be used to return to the previous behavior, by setting this to `false`.

```sql
SET ieee_floating_point_ops=false;
```

e.g.:

```sql
D select 1.0 / 0.0 AS result;
┌────────┐
│ result │
│ double │
├────────┤
│    inf │
└────────┘
D SET ieee_floating_point_ops=false;
D select 1.0 / 0.0 AS result;
┌────────┐
│ result │
│ double │
├────────┤
│   NULL │
└────────┘

```