### PR TITLE
chore: remove wheel dependency

### DIFF
--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
 	"setuptools>=60",
 	"setuptools_scm>=6.4",
 	"pybind11>=2.6.0",
-	"wheel>=0.38.0"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This has never been required; setuptools declares it in `get_requries_for_build_wheel`, and modern versions of setuptools no longer use it at all.