### PR TITLE
Feature #1272: Windowed Quantile Tree

### DIFF
--- a/src/include/duckdb/core_functions/aggregate/quantile_sort_tree.hpp
+++ b/src/include/duckdb/core_functions/aggregate/quantile_sort_tree.hpp
@@ -250,7 +250,6 @@ struct QuantileSortTree : public MergeSortTree<IDX, IDX> {
 	explicit QuantileSortTree(Elements &&lowest_level) {
 		BaseTree::Allocate(lowest_level.size());
 		BaseTree::LowestLevel() = std::move(lowest_level);
-		BaseTree::Build();
 	}
 
 	template <class INPUT_TYPE>
@@ -289,8 +288,11 @@ struct QuantileSortTree : public MergeSortTree<IDX, IDX> {
 
 	template <typename INPUT_TYPE, typename RESULT_TYPE, bool DISCRETE>
 	RESULT_TYPE WindowScalar(const INPUT_TYPE *data, const SubFrames &frames, const idx_t n, Vector &result,
-	                         const QuantileValue &q) const {
+	                         const QuantileValue &q) {
 		D_ASSERT(n > 0);
+
+		//	Thread safe and idempotent.
+		BaseTree::Build();
 
 		//	Find the interpolated indicies within the frame
 		Interpolator<DISCRETE> interp(q, n, false);
@@ -308,8 +310,11 @@ struct QuantileSortTree : public MergeSortTree<IDX, IDX> {
 
 	template <typename INPUT_TYPE, typename CHILD_TYPE, bool DISCRETE>
 	void WindowList(const INPUT_TYPE *data, const SubFrames &frames, const idx_t n, Vector &list, const idx_t lidx,
-	                const QuantileBindData &bind_data) const {
+	                const QuantileBindData &bind_data) {
 		D_ASSERT(n > 0);
+
+		//	Thread safe and idempotent.
+		BaseTree::Build();
 
 		// Result is a constant LIST<CHILD_TYPE> with a fixed length
 		auto ldata = FlatVector::GetData<list_entry_t>(list);


### PR DESCRIPTION
Use the new thread-safe Build method to parallelise tree construction. We can call it on every row because it has a quick exit and it is thread-safe.

This is the only custom window init function that
allocates a large data structure, so the PR effecively parallelises the construction step of custom windowed aggregates, and shows how to parallelise any future complex aggregates without any API changes.