### PR TITLE
When referencing optimistically-written blocks in the WAL, we need to fsync the main database file before writing the WAL to ensure all changes have made it to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,4 +352,4 @@ extension_external
 .venv-pyodide
 
 test/sql/pragma/output.json
-
+tools/pythonpkg/duckdb_build/

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -78,6 +78,8 @@ public:
 	//! Whether or not the attached database is in-memory
 	virtual bool InMemory() = 0;
 
+	//! Sync changes made to the block manager
+	virtual void FileSync() = 0;
 	//! Truncate the underlying database file after a checkpoint
 	virtual void Truncate();
 

--- a/src/include/duckdb/storage/in_memory_block_manager.hpp
+++ b/src/include/duckdb/storage/in_memory_block_manager.hpp
@@ -65,6 +65,9 @@ public:
 	bool InMemory() override {
 		return true;
 	}
+	void FileSync() override {
+		throw InternalException("Cannot perform IO in in-memory database - FileSync!");
+	}
 	idx_t TotalBlocks() override {
 		throw InternalException("Cannot perform IO in in-memory database - TotalBlocks!");
 	}

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -71,6 +71,8 @@ public:
 	void Write(FileBuffer &block, block_id_t block_id) override;
 	//! Write the header to disk, this is the final step of the checkpointing process
 	void WriteHeader(DatabaseHeader header) override;
+	//! Sync changes to the underlying file
+	void FileSync() override;
 	//! Truncate the underlying database file after a checkpoint
 	void Truncate() override;
 

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -41,6 +41,9 @@ public:
 	                             unique_ptr<PersistentCollectionData> row_group_data) = 0;
 	virtual optional_ptr<PersistentCollectionData> GetRowGroupData(DataTable &table, idx_t start_index,
 	                                                               idx_t &count) = 0;
+	virtual bool HasRowGroupData() {
+		return false;
+	}
 };
 
 struct CheckpointOptions {

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -638,6 +638,10 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 	TrimFreeBlocks();
 }
 
+void SingleFileBlockManager::FileSync() {
+	handle->Sync();
+}
+
 void SingleFileBlockManager::TrimFreeBlocks() {
 	if (DBConfig::Get(db).options.trim_free_blocks) {
 		for (auto itr = newly_freed_list.begin(); itr != newly_freed_list.end(); ++itr) {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -255,6 +255,7 @@ public:
 	void AddRowGroupData(DataTable &table, idx_t start_index, idx_t count,
 	                     unique_ptr<PersistentCollectionData> row_group_data) override;
 	optional_ptr<PersistentCollectionData> GetRowGroupData(DataTable &table, idx_t start_index, idx_t &count) override;
+	bool HasRowGroupData() override;
 
 private:
 	idx_t initial_wal_size = 0;
@@ -327,6 +328,10 @@ optional_ptr<PersistentCollectionData> SingleFileStorageCommitState::GetRowGroup
 	}
 	count = start_entry->second.count;
 	return start_entry->second.row_group_data.get();
+}
+
+bool SingleFileStorageCommitState::HasRowGroupData() {
+	return !optimistically_written_data.empty();
 }
 
 unique_ptr<StorageCommitState> SingleFileStorageManager::GenStorageCommitState(WriteAheadLog &wal) {


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/13372