### PR TITLE
Feature #1272: Windowed Distinct Tree

### DIFF
--- a/src/execution/window_segment_tree.cpp
+++ b/src/execution/window_segment_tree.cpp
@@ -1873,7 +1873,7 @@ void WindowDistinctSortTree::Build(WindowDistinctAggregatorGlobalState &gdsink) 
 	for (idx_t level_nr = 0; level_nr < zipped_tree.tree.size(); ++level_nr) {
 		auto &zipped_level = zipped_tree.tree[level_nr].first;
 		vector<ElementType> level;
-		level.reserve(zipped_level.size());
+		level.resize(zipped_level.size());
 
 		for (idx_t i = 0; i < zipped_level.size(); i += level_width) {
 			//	Reset the combine state
@@ -1886,7 +1886,7 @@ void WindowDistinctSortTree::Build(WindowDistinctAggregatorGlobalState &gdsink) 
 
 				//	Update this state (if it matches)
 				const auto prev_idx = std::get<0>(zipped_level[j]);
-				level.emplace_back(prev_idx);
+				level[j] = prev_idx;
 				if (prev_idx < i + 1) {
 					updates[nupdate] = curr_state;
 					//	input_idx


### PR DESCRIPTION
* Move aggregate allocation to the WindowDistinctAggregatorGlobalState constructor.
* Move level start allocation to the WindowDistinctAggregatorGlobalState constructor.
* Index aggregate level elements instead of emplacing.
* Preallocate aggregate tree levels.
* Restrict update/combine to level ranges.
* Move tree aggregation variables to local state.
* Break out level run computation into a separate method.
* Multi-threaded aggregation tasks.

This should be the last piece of the project for now. The remaining work would be finer grained threading, which is gated on the coming sort swizzling work.