### PR TITLE
Skip empty files in single-threaded CSV reader

### DIFF
--- a/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
+++ b/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
@@ -72,25 +72,29 @@ double CSVGlobalState::GetProgress(const ReadCSVData &bind_data_p) const {
 unique_ptr<StringValueScanner> CSVGlobalState::Next(optional_ptr<StringValueScanner> previous_scanner) {
 	if (single_threaded) {
 		idx_t cur_idx;
-		{
+		shared_ptr<CSVFileScan> current_file;
+		do {
+			{
+				lock_guard<mutex> parallel_lock(main_mutex);
+				cur_idx = last_file_idx++;
+				if (cur_idx >= bind_data.files.size()) {
+					return nullptr;
+				}
+				if (cur_idx == 0) {
+					D_ASSERT(!previous_scanner);
+					current_file = file_scans.front();
+					return make_uniq<StringValueScanner>(scanner_idx++, current_file->buffer_manager,
+					                                     current_file->state_machine, current_file->error_handler,
+					                                     current_file, false, current_boundary);
+				}
+			}
+			auto file_scan = make_shared_ptr<CSVFileScan>(context, bind_data.files[cur_idx], bind_data.options, cur_idx,
+			                                              bind_data, column_ids, file_schema, true);
 			lock_guard<mutex> parallel_lock(main_mutex);
-			cur_idx = last_file_idx++;
-			if (cur_idx >= bind_data.files.size()) {
-				return nullptr;
-			}
-			if (cur_idx == 0) {
-				D_ASSERT(!previous_scanner);
-				auto current_file = file_scans.front();
-				return make_uniq<StringValueScanner>(scanner_idx++, current_file->buffer_manager,
-				                                     current_file->state_machine, current_file->error_handler,
-				                                     current_file, false, current_boundary);
-			}
-		}
-		auto file_scan = make_shared_ptr<CSVFileScan>(context, bind_data.files[cur_idx], bind_data.options, cur_idx,
-		                                              bind_data, column_ids, file_schema, true);
+			file_scans.emplace_back(std::move(file_scan));
+			current_file = file_scans.back();
+		} while (current_file->file_size == 0);
 		lock_guard<mutex> parallel_lock(main_mutex);
-		file_scans.emplace_back(std::move(file_scan));
-		auto current_file = file_scans.back();
 		current_boundary = current_file->start_iterator;
 		current_boundary.SetCurrentBoundaryToPosition(single_threaded);
 		current_buffer_in_use =

--- a/test/sql/copy/csv/glob/read_csv_glob.test
+++ b/test/sql/copy/csv/glob/read_csv_glob.test
@@ -274,3 +274,11 @@ statement error
 SELECT * FROM read_csv_auto(NULL::VARCHAR[]) ORDER BY 1
 ----
 NULL
+
+statement ok
+SET threads=1;
+
+statement error
+FROM read_csv('data/csv/glob/*/*.csv');
+----
+Schema mismatch between globbed files.


### PR DESCRIPTION
Fix: https://github.com/duckdblabs/duckdb-internal/issues/2825