### PR TITLE
Disallow ordering by non-integer literal by default - and add the setting order_by_non_integer_literal to revert to the previous behavior

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -265,6 +265,8 @@ struct DBConfigOptions {
 	bool debug_skip_checkpoint_on_commit = false;
 	//! Use IEE754-compliant floating point operations (returning NAN instead of errors/NULL)
 	bool ieee_floating_point_ops = true;
+	//! Allow ordering by non-integer literals - ordering by such literals has no effect
+	bool order_by_non_integer_literal = false;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -604,6 +604,16 @@ struct OldImplicitCasting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct OrderByNonIntegerLiteral {
+	static constexpr const char *Name = "order_by_non_integer_literal";
+	static constexpr const char *Description =
+	    "Allow ordering by non-integer literals - ordering by such literals has no effect";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct PartitionedWriteFlushThreshold {
 	static constexpr const char *Name = "partitioned_write_flush_threshold";
 	static constexpr const char *Description =

--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -22,8 +22,8 @@ struct SelectBindState;
 //! The ORDER binder is responsible for binding an expression within the ORDER BY clause of a SQL statement
 class OrderBinder {
 public:
-	OrderBinder(vector<Binder *> binders, SelectBindState &bind_state);
-	OrderBinder(vector<Binder *> binders, SelectNode &node, SelectBindState &bind_state);
+	OrderBinder(vector<reference<Binder>> binders, SelectBindState &bind_state);
+	OrderBinder(vector<reference<Binder>> binders, SelectNode &node, SelectBindState &bind_state);
 
 public:
 	unique_ptr<Expression> Bind(unique_ptr<ParsedExpression> expr);
@@ -31,7 +31,7 @@ public:
 	bool HasExtraList() const {
 		return extra_list;
 	}
-	const vector<Binder *> &GetBinders() const {
+	const vector<reference<Binder>> &GetBinders() const {
 		return binders;
 	}
 
@@ -43,7 +43,7 @@ private:
 	optional_idx TryGetProjectionReference(ParsedExpression &expr) const;
 
 private:
-	vector<Binder *> binders;
+	vector<reference<Binder>> binders;
 	optional_ptr<vector<unique_ptr<ParsedExpression>>> extra_list;
 	SelectBindState &bind_state;
 };

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -113,6 +113,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(OldImplicitCasting),
     DUCKDB_GLOBAL_ALIAS("memory_limit", MaximumMemorySetting),
     DUCKDB_GLOBAL_ALIAS("null_order", DefaultNullOrderSetting),
+    DUCKDB_GLOBAL(OrderByNonIntegerLiteral),
     DUCKDB_LOCAL(OrderedAggregateThreshold),
     DUCKDB_GLOBAL(PasswordSetting),
     DUCKDB_LOCAL(PerfectHashThresholdSetting),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1346,6 +1346,22 @@ Value OldImplicitCasting::GetSetting(const ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// Old Implicit Casting
+//===--------------------------------------------------------------------===//
+void OrderByNonIntegerLiteral::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.options.order_by_non_integer_literal = input.GetValue<bool>();
+}
+
+void OrderByNonIntegerLiteral::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.order_by_non_integer_literal = DBConfig().options.order_by_non_integer_literal;
+}
+
+Value OrderByNonIntegerLiteral::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.options.order_by_non_integer_literal);
+}
+
+//===--------------------------------------------------------------------===//
 // Partitioned Write Flush Threshold
 //===--------------------------------------------------------------------===//
 void PartitionedWriteFlushThreshold::ResetLocal(ClientContext &context) {

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -149,7 +149,7 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 					if (!config.options.order_by_non_integer_literal) {
 						throw BinderException(
 						    *order.expression,
-						    "ORDER BY non-integer literal has no effect\nuse SET order_by_non_integer_literal=true to "
+						    "ORDER BY non-integer literal has no effect.\n* SET order_by_non_integer_literal=true to "
 						    "allow this behavior.\n\nPerhaps you misplaced ORDER BY; ORDER BY must appear "
 						    "after all regular arguments of the aggregate.");
 					}

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -140,6 +140,13 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 	// Bind the ORDER BYs, if any
 	if (aggr.order_bys && !aggr.order_bys->orders.empty()) {
 		for (auto &order : aggr.order_bys->orders) {
+			if (order.expression->type == ExpressionType::VALUE_CONSTANT) {
+				throw BinderException(*order.expression,
+				                      "ORDER BY in aggregate does not support ordering by literals - cannot "
+				                      "ORDER BY literal %s\n\nPerhaps you misplaced ORDER BY; ORDER BY must appear "
+				                      "after all regular arguments of the aggregate.",
+				                      order.expression->ToString());
+			}
 			aggregate_binder.BindChild(order.expression, 0, error);
 		}
 	}

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
@@ -16,8 +17,6 @@
 #include "duckdb/planner/expression_binder/base_select_binder.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
-
-#include <duckdb/parser/expression/constant_expression.hpp>
 
 namespace duckdb {
 

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -201,7 +201,7 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 #endif
 			for (auto &order_node : order.orders) {
 				vector<unique_ptr<ParsedExpression>> order_list;
-				order_binders[0]->ExpandStarExpression(std::move(order_node.expression), order_list);
+				order_binders[0].get().ExpandStarExpression(std::move(order_node.expression), order_list);
 
 				auto type = config.ResolveOrder(order_node.type);
 				auto null_order = config.ResolveNullOrder(type, order_node.null_order);
@@ -453,7 +453,7 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 	}
 
 	// now bind all the result modifiers; including DISTINCT and ORDER BY targets
-	OrderBinder order_binder({this}, statement, bind_state);
+	OrderBinder order_binder({*this}, statement, bind_state);
 	PrepareModifiers(order_binder, statement, *result);
 
 	vector<unique_ptr<ParsedExpression>> unbound_groups;

--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -247,7 +247,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(SetOperationNode &statement) {
 			GatherAliases(*result, bind_state, reorder_idx);
 		}
 		// now we perform the actual resolution of the ORDER BY/DISTINCT expressions
-		OrderBinder order_binder({result->left_binder.get(), result->right_binder.get()}, bind_state);
+		OrderBinder order_binder({*result->left_binder, *result->right_binder}, bind_state);
 		PrepareModifiers(order_binder, statement, *result);
 	}
 

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -61,7 +61,7 @@ optional_idx OrderBinder::TryGetProjectionReference(ParsedExpression &expr) cons
 			// this is disabled by default (matching Postgres) - but we can control this with a setting
 			auto &config = DBConfig::GetConfig(binders[0].get().context);
 			if (!config.options.order_by_non_integer_literal) {
-				throw BinderException(expr, "ORDER BY non-integer literal has no effect\nuse SET "
+				throw BinderException(expr, "ORDER BY non-integer literal has no effect.\n* SET "
 				                            "order_by_non_integer_literal=true to allow this behavior.");
 			}
 			break;

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -16,10 +16,10 @@
 
 namespace duckdb {
 
-OrderBinder::OrderBinder(vector<Binder *> binders, SelectBindState &bind_state)
+OrderBinder::OrderBinder(vector<reference<Binder>> binders, SelectBindState &bind_state)
     : binders(std::move(binders)), extra_list(nullptr), bind_state(bind_state) {
 }
-OrderBinder::OrderBinder(vector<Binder *> binders, SelectNode &node, SelectBindState &bind_state)
+OrderBinder::OrderBinder(vector<reference<Binder>> binders, SelectNode &node, SelectBindState &bind_state)
     : binders(std::move(binders)), bind_state(bind_state) {
 	this->extra_list = &node.select_list;
 }
@@ -55,9 +55,14 @@ optional_idx OrderBinder::TryGetProjectionReference(ParsedExpression &expr) cons
 		auto &constant = expr.Cast<ConstantExpression>();
 		// ORDER BY a constant
 		if (!constant.value.type().IsIntegral()) {
-			// non-integral expression, we just leave the constant here.
+			// non-integral expression
 			// ORDER BY <constant> has no effect
-			// CONTROVERSIAL: maybe we should throw an error
+			// this is disabled by default (matching Postgres) - but we can control this with a setting
+			auto &config = DBConfig::GetConfig(binders[0].get().context);
+			if (!config.options.order_by_non_integer_literal) {
+				throw BinderException(expr, "ORDER BY non-integer literal has no effect\nuse SET "
+				                            "order_by_non_integer_literal=true to allow this behavior.");
+			}
 			break;
 		}
 		// INTEGER constant: we use the integer as an index into the select list (e.g. ORDER BY 1)
@@ -143,7 +148,7 @@ unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {
 	// general case
 	// first bind the table names of this entry
 	for (auto &binder : binders) {
-		ExpressionBinder::QualifyColumnNames(*binder, expr);
+		ExpressionBinder::QualifyColumnNames(binder.get(), expr);
 	}
 	// first check if the ORDER BY clause already points to an entry in the projection list
 	auto entry = bind_state.projection_map.find(*expr);

--- a/src/planner/expression_binder/order_binder.cpp
+++ b/src/planner/expression_binder/order_binder.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/planner/expression_binder/select_bind_state.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/common/pair.hpp"
 
 namespace duckdb {

--- a/test/issues/rigger/assertion_scale.test
+++ b/test/issues/rigger/assertion_scale.test
@@ -14,6 +14,14 @@ CREATE TABLE t0(c0 DOUBLE, c1 DOUBLE);;
 statement ok
 INSERT INTO t0 VALUES(0.0,-1570504255.0);
 
+statement error
+CREATE VIEW v0(c0, c1) AS SELECT 888938716, '' FROM t0 GROUP BY t0.rowid, t0.rowid, t0.c1 ORDER BY 0.9507538105182436 OFFSET 686929302;
+----
+ORDER BY non-integer literal has no effect
+
+statement ok
+SET order_by_non_integer_literal=true
+
 statement ok
 CREATE VIEW v0(c0, c1) AS SELECT 888938716, '' FROM t0 GROUP BY t0.rowid, t0.rowid, t0.c1 ORDER BY 0.9507538105182436 OFFSET 686929302;
 

--- a/test/issues/rigger/test_544.test
+++ b/test/issues/rigger/test_544.test
@@ -15,8 +15,15 @@ INSERT INTO t0(c0) VALUES (0);
 statement ok
 CREATE VIEW v0(c0) AS SELECT 1 FROM t0;
 
+statement error
+SELECT * FROM v0 ORDER BY 'a';
+----
+ORDER BY non-integer literal has no effect
+
+statement ok
+SET order_by_non_integer_literal=true
+
 query I
 SELECT * FROM v0 ORDER BY 'a';
 ----
 1
-

--- a/test/sql/aggregate/distinct/grouped/string_agg.test
+++ b/test/sql/aggregate/distinct/grouped/string_agg.test
@@ -53,3 +53,11 @@ ORDER BY 1
 2	3	/,-,+	3
 3	1	/	1
 4	3	NULL	3
+
+statement error
+SELECT g, STRING_AGG(DISTINCT y ORDER BY y, ',' ) FILTER (WHERE g < 4)
+FROM strings
+GROUP BY g
+ORDER BY 1
+----
+ORDER BY in aggregate does not support ordering by literals

--- a/test/sql/aggregate/distinct/grouped/string_agg.test
+++ b/test/sql/aggregate/distinct/grouped/string_agg.test
@@ -55,9 +55,23 @@ ORDER BY 1
 4	3	NULL	3
 
 statement error
-SELECT g, STRING_AGG(DISTINCT y ORDER BY y, ',' ) FILTER (WHERE g < 4)
+SELECT g, STRING_AGG(DISTINCT y ORDER BY y, '_' ) FILTER (WHERE g < 4)
 FROM strings
 GROUP BY g
 ORDER BY 1
 ----
-ORDER BY in aggregate does not support ordering by literals
+ORDER BY non-integer literal has no effect
+
+statement ok
+SET order_by_non_integer_literal=true
+
+query II
+SELECT g, STRING_AGG(DISTINCT y ORDER BY y, '_' ) FILTER (WHERE g < 4)
+FROM strings
+GROUP BY g
+ORDER BY 1
+----
+1	-,/
+2	+,-,/
+3	/
+4	NULL

--- a/test/sql/copy/parquet/batched_write/batch_memory_usage.test
+++ b/test/sql/copy/parquet/batched_write/batch_memory_usage.test
@@ -11,7 +11,7 @@ statement ok
 COPY (SELECT uuid()::VARCHAR as varchar, uuid() AS uuid FROM range(10000000) t(i)) TO '__TEST_DIR__/random_uuids.parquet'
 
 statement ok
-SET memory_limit='500MB'
+SET memory_limit='750MB'
 
 statement ok
 COPY '__TEST_DIR__/random_uuids.parquet' TO '__TEST_DIR__/random_uuids_copy.parquet';

--- a/test/sql/order/test_order_by.test
+++ b/test/sql/order/test_order_by.test
@@ -177,3 +177,19 @@ SELECT a-10 AS k FROM test UNION SELECT a-11 AS l FROM test ORDER BY a-11;
 1
 2
 3
+
+# order by non-integer literal
+statement error
+SELECT a FROM test ORDER BY 'hello world', a
+----
+ORDER BY non-integer literal has no effect
+
+statement ok
+SET order_by_non_integer_literal=true
+
+query I
+SELECT a FROM test ORDER BY 'hello world', a
+----
+11
+12
+13

--- a/test/sql/order/test_order_by_exceptions.test
+++ b/test/sql/order/test_order_by_exceptions.test
@@ -17,8 +17,16 @@ SELECT a FROM test ORDER BY 2
 ----
 <REGEX>:Binder Error:.*term out of range.*
 
-# ORDER BY constant works, but does nothing
+# ORDER BY constant returns an error
 # CONTROVERSIAL: works in SQLite but not in Postgres
+statement error
+SELECT a FROM test ORDER BY 'hello', a
+----
+ORDER BY non-integer literal has no effect
+
+statement ok
+SET order_by_non_integer_literal=true
+
 query I
 SELECT a FROM test ORDER BY 'hello', a
 ----

--- a/test/sql/subquery/scalar/array_order_subquery.test
+++ b/test/sql/subquery/scalar/array_order_subquery.test
@@ -92,9 +92,11 @@ SELECT ARRAY
 ----
 ORDER term out of range
 
-statement ok
+statement error
 SELECT ARRAY
   (SELECT 1 UNION ALL
    SELECT 2 UNION ALL
    SELECT 3
    ORDER by 'hello world') AS new_array;
+----
+ORDER BY non-integer literal has no effect


### PR DESCRIPTION

Ordering by non-integer literals has no effect. Postgres does not allow it:

```sql
postgres=# select 42 order by 'hello world';
-- ERROR:  non-integer constant in ORDER BY
-- LINE 1: select 42 order by 'hello world';
--                            ^
```

We currently follow SQLite and allow it by discarding the literal. However, this can lead to confusing situations, particularly in ordered aggregates. See #13520

This PR modifies the system to by default reject this:

```sql
select 42 order by 'hello world';
-- Binder Error: ORDER BY non-integer literal has no effect.
-- * SET order_by_non_integer_literal=true to allow this behavior.
-- LINE 1: select 42 order by 'hello world';
--                            ^

```

When using an `ORDER BY` in an aggregate we also additionally provide information about what likely went wrong:


```sql
D select string_agg(str order by str, '_') from (values ('hello'), ('abc')) t(str);
-- Binder Error: ORDER BY non-integer literal has no effect.
-- * SET order_by_non_integer_literal=true to allow this behavior.

-- Perhaps you misplaced ORDER BY; ORDER BY must appear after all regular arguments of the aggregate.
-- LINE 1: select string_agg(str order by str, '_') from (values ('hello'), ('abc')) t...
--                                             ^
```

The `order_by_non_integer_literal`  setting can be used to revert the previous behavior:

```sql
SET order_by_non_integer_literal=true;
SELECT 42 ORDER BY 'hello world';
┌───────┐
│  42   │
│ int32 │
├───────┤
│    42 │
└───────┘
SELECT string_agg(str ORDER BY str, '_') AS result FROM (values ('hello'), ('abc')) t(str);
┌───────────┐
│  result   │
│  varchar  │
├───────────┤
│ abc,hello │
└───────────┘
```
