### PR TITLE
Initialize (potentially) empty buffer

### DIFF
--- a/extension/jemalloc/jemalloc/README.md
+++ b/extension/jemalloc/jemalloc/README.md
@@ -156,6 +156,17 @@ int strerror_fixed(int err, char *buf, size_t buflen) {
 }
 ```
 
+Add this line
+```c++
+buf[0] = '2';
+```
+to this function
+```c++
+static bool
+os_overcommits_proc(void)
+```
+in `pages.c`.
+
 Almost no symbols are leaked due to `private_namespace.h`.
 The `exported_symbols_check.py` script still found a few, so these lines need to be added to `private_namespace.h`:
 ```c++

--- a/extension/jemalloc/jemalloc/src/pages.c
+++ b/extension/jemalloc/jemalloc/src/pages.c
@@ -650,6 +650,7 @@ static bool
 os_overcommits_proc(void) {
 	int fd;
 	char buf[1];
+	buf[0] = '2';
 
 #if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_open)
 	#if defined(O_CLOEXEC)


### PR DESCRIPTION
CI found this issue here https://github.com/duckdblabs/duckdb-internal/issues/2852