### PR TITLE
Minor fixes for DuckDB-Wasm

### DIFF
--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -65,9 +65,9 @@ jobs:
               run: |
                  cd submodules/duckdb
                  git checkout ${{ github.event.inputs.duckdb_ref }}
-                 git apply ../../duckdb.patch
                  cd ../..
-                 cp .github/config/extension_config_wasm.cmake submodules/duckdb/extension/extension_config.cmake
+                 make apply_patches
+                 cp extension_config_wasm.cmake submodules/duckdb/extension/extension_config.cmake
 
             - name: Build Wasm module MVP
               if: ${{ matrix.duckdb_wasm_arch == 'wasm_mvp' }}

--- a/src/include/duckdb/common/file_open_flags.hpp
+++ b/src/include/duckdb/common/file_open_flags.hpp
@@ -107,6 +107,9 @@ public:
 	inline bool ReturnNullIfExists() const {
 		return flags & FILE_FLAGS_NULL_IF_EXISTS;
 	}
+	inline idx_t GetFlagsInternal() const {
+		return flags;
+	}
 
 private:
 	idx_t flags = 0;

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -464,6 +464,7 @@ void Executor::SignalTaskRescheduled(lock_guard<mutex> &) {
 }
 
 void Executor::WaitForTask() {
+#ifndef DUCKDB_NO_THREADS
 	static constexpr std::chrono::milliseconds WAIT_TIME_MS = std::chrono::milliseconds(WAIT_TIME);
 	std::unique_lock<mutex> l(executor_lock);
 	if (to_be_rescheduled_tasks.empty()) {
@@ -476,6 +477,7 @@ void Executor::WaitForTask() {
 
 	blocked_thread_time++;
 	task_reschedule.wait_for(l, WAIT_TIME_MS);
+#endif
 }
 
 void Executor::RescheduleTask(shared_ptr<Task> &task_p) {


### PR DESCRIPTION
Fix extension building workflow, add function to clean up duckdb-wasm's code a bit, and skip sleeping when single threaded.