### PR TITLE
Fix for vector size 2 tests

### DIFF
--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -143,7 +143,7 @@ void DataChunk::Copy(DataChunk &other, idx_t offset) const {
 void DataChunk::Copy(DataChunk &other, const SelectionVector &sel, const idx_t source_count, const idx_t offset) const {
 	D_ASSERT(ColumnCount() == other.ColumnCount());
 	D_ASSERT(other.size() == 0);
-	D_ASSERT((offset + source_count) <= size());
+	D_ASSERT(source_count <= size());
 
 	for (idx_t i = 0; i < ColumnCount(); i++) {
 		D_ASSERT(other.data[i].GetVectorType() == VectorType::FLAT_VECTOR);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1054,10 +1054,11 @@ void Vector::Flatten(idx_t count) {
 	case VectorType::SEQUENCE_VECTOR: {
 		int64_t start, increment, sequence_count;
 		SequenceVector::GetSequence(*this, start, increment, sequence_count);
+		auto seq_count = NumericCast<idx_t>(sequence_count);
 
-		buffer = VectorBuffer::CreateStandardVector(GetType());
+		buffer = VectorBuffer::CreateStandardVector(GetType(), MaxValue<idx_t>(STANDARD_VECTOR_SIZE, seq_count));
 		data = buffer->GetData();
-		VectorOperations::GenerateSequence(*this, NumericCast<idx_t>(sequence_count), start, increment);
+		VectorOperations::GenerateSequence(*this, seq_count, start, increment);
 		break;
 	}
 	default:

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -390,9 +390,9 @@ void ART::GenerateKeyVectors(ArenaAllocator &allocator, DataChunk &input, Vector
 	GenerateKeys<>(allocator, input, keys);
 
 	DataChunk row_id_chunk;
-	row_id_chunk.Initialize(Allocator::DefaultAllocator(), vector<LogicalType> {LogicalType::ROW_TYPE}, keys.size());
+	row_id_chunk.Initialize(Allocator::DefaultAllocator(), vector<LogicalType> {LogicalType::ROW_TYPE}, input.size());
 	row_id_chunk.data[0].Reference(row_ids);
-	row_id_chunk.SetCardinality(keys.size());
+	row_id_chunk.SetCardinality(input.size());
 	GenerateKeys<>(allocator, row_id_chunk, row_id_keys);
 }
 

--- a/src/function/table/system/test_vector_types.cpp
+++ b/src/function/table/system/test_vector_types.cpp
@@ -211,7 +211,8 @@ struct TestVectorSequence {
 		static constexpr const idx_t SEQ_CARDINALITY = 3;
 
 		auto result = make_uniq<DataChunk>();
-		result->Initialize(Allocator::DefaultAllocator(), info.types, MaxValue<idx_t>(SEQ_CARDINALITY, STANDARD_VECTOR_SIZE));
+		result->Initialize(Allocator::DefaultAllocator(), info.types,
+		                   MaxValue<idx_t>(SEQ_CARDINALITY, STANDARD_VECTOR_SIZE));
 
 		for (idx_t c = 0; c < info.types.size(); c++) {
 			if (info.types[c].id() == LogicalTypeId::MAP) {
@@ -225,7 +226,7 @@ struct TestVectorSequence {
 		info.entries.push_back(std::move(result));
 #else
 		// vsize = 2, split into two smaller data chunks
-		for(idx_t offset = 0; offset < SEQ_CARDINALITY; offset += STANDARD_VECTOR_SIZE) {
+		for (idx_t offset = 0; offset < SEQ_CARDINALITY; offset += STANDARD_VECTOR_SIZE) {
 			auto new_result = make_uniq<DataChunk>();
 			new_result->Initialize(Allocator::DefaultAllocator(), info.types);
 

--- a/src/function/table/system/test_vector_types.cpp
+++ b/src/function/table/system/test_vector_types.cpp
@@ -165,6 +165,9 @@ struct TestVectorSequence {
 		case LogicalTypeId::UINTEGER:
 		case LogicalTypeId::UBIGINT:
 			result.Sequence(3, 2, 3);
+#if STANDARD_VECTOR_SIZE <= 2
+			result.Flatten(3);
+#endif
 			return;
 		default:
 			break;
@@ -205,9 +208,10 @@ struct TestVectorSequence {
 	}
 
 	static void Generate(TestVectorInfo &info) {
-#if STANDARD_VECTOR_SIZE > 2
+		static constexpr const idx_t SEQ_CARDINALITY = 3;
+
 		auto result = make_uniq<DataChunk>();
-		result->Initialize(Allocator::DefaultAllocator(), info.types);
+		result->Initialize(Allocator::DefaultAllocator(), info.types, MaxValue<idx_t>(SEQ_CARDINALITY, STANDARD_VECTOR_SIZE));
 
 		for (idx_t c = 0; c < info.types.size(); c++) {
 			if (info.types[c].id() == LogicalTypeId::MAP) {
@@ -216,8 +220,20 @@ struct TestVectorSequence {
 			}
 			GenerateVector(info, info.types[c], result->data[c]);
 		}
-		result->SetCardinality(3);
+		result->SetCardinality(SEQ_CARDINALITY);
+#if STANDARD_VECTOR_SIZE > 2
 		info.entries.push_back(std::move(result));
+#else
+		// vsize = 2, split into two smaller data chunks
+		for(idx_t offset = 0; offset < SEQ_CARDINALITY; offset += STANDARD_VECTOR_SIZE) {
+			auto new_result = make_uniq<DataChunk>();
+			new_result->Initialize(Allocator::DefaultAllocator(), info.types);
+
+			idx_t copy_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, SEQ_CARDINALITY - offset);
+			result->Copy(*new_result, *FlatVector::IncrementalSelectionVector(), offset + copy_count, offset);
+
+			info.entries.push_back(std::move(new_result));
+		}
 #endif
 	}
 };

--- a/test/api/test_relation_api.cpp
+++ b/test/api/test_relation_api.cpp
@@ -380,7 +380,7 @@ TEST_CASE("Test crossproduct relation", "[relation_api]") {
 
 	// run cross product
 	vcross = v1->CrossProduct(v2);
-	REQUIRE_NOTHROW(result = vcross->Order("v1.i")->Execute());
+	REQUIRE_NOTHROW(result = vcross->Order("v1.i, v2.i")->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {1, 1, 1, 2, 2, 2, 3, 3, 3}));
 	REQUIRE(CHECK_COLUMN(result, 1, {10, 10, 10, 5, 5, 5, 4, 4, 4}));
 	REQUIRE(CHECK_COLUMN(result, 2, {1, 2, 3, 1, 2, 3, 1, 2, 3}));

--- a/test/sql/types/nested/list/list_aggregates.test
+++ b/test/sql/types/nested/list/list_aggregates.test
@@ -34,10 +34,10 @@ SELECT * FROM (VALUES
 	(NULL)
 ) tbl(i);
 
-query III
-select min(i), max(i), first(i) from list_int;
+query II
+select min(i), max(i) from list_int;
 ----
-[1]	[NULL, NULL]	[1]
+[1]	[NULL, NULL]
 
 query I
 select first([i]) from range(10) tbl(i);

--- a/test/sql/types/nested/struct/struct_aggregates.test
+++ b/test/sql/types/nested/struct/struct_aggregates.test
@@ -34,6 +34,15 @@ SELECT * FROM (VALUES
 	(NULL)
 ) tbl(i);
 
+query II
+select min(i), max(i), from struct_int;
+----
+{'x': 1, 'y': 0}	{'x': NULL, 'y': NULL}
+
+# single thread for vsize=2
+statement ok
+set threads=1
+
 query III
 select min(i), max(i), first(i) from struct_int;
 ----


### PR DESCRIPTION
* Use correct count in ART::GenerateKeyVectors
* In `test_vector_types`, generate the same data also with vsize=2 - we convert the sequence vectors into a multiple flat vectors instead
* Fix several tests to have deterministic output