### PR TITLE
TIMETZ group by: collations now no longer always return VARCHAR

### DIFF
--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -488,7 +488,7 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 				// but also push a first(x) aggregate in case x is selected (uncollated)
 				info.collated_groups[i] = result->aggregates.size();
 
-				auto first_fun = FirstFun::GetFunction(LogicalType::VARCHAR);
+				auto first_fun = FirstFun::GetFunction(bound_expr_ref.return_type);
 				vector<unique_ptr<Expression>> first_children;
 				// FIXME: would be better to just refer to this expression, but for now we copy
 				first_children.push_back(bound_expr_ref.Copy());

--- a/test/sql/function/timetz/timetz_group_by.test
+++ b/test/sql/function/timetz/timetz_group_by.test
@@ -4,6 +4,8 @@
 
 require icu
 
+require no_extension_autoloading
+
 statement ok
 create table time_testtz as select i::timetz as t from generate_series(TIMESTAMPtz '2001-04-10', TIMESTAMPtz '2001-04-11', INTERVAL 30 MINUTE) as t(i);
 

--- a/test/sql/function/timetz/timetz_group_by.test
+++ b/test/sql/function/timetz/timetz_group_by.test
@@ -1,0 +1,13 @@
+# name: test/sql/function/timetz/timetz_group_by.test
+# description: Test grouping by TIMETZ
+# group: [timetz]
+
+require icu
+
+statement ok
+create table time_testtz as select i::timetz as t from generate_series(TIMESTAMPtz '2001-04-10', TIMESTAMPtz '2001-04-11', INTERVAL 30 MINUTE) as t(i);
+
+query I
+SELECT TYPEOF(t) FROM (select t from time_testtz group by t) LIMIT 1
+----
+TIME WITH TIME ZONE


### PR DESCRIPTION
This prevents `TIMETZ` from being converted to `VARCHAR` when used in a `GROUP BY` expression