### PR TITLE
Constrain size of estimated cardinality returned when operator is not initialized

### DIFF
--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -74,7 +74,7 @@ ClientContext &Pipeline::GetClientContext() {
 
 bool Pipeline::GetProgress(double &current_percentage, idx_t &source_cardinality) {
 	D_ASSERT(source);
-	source_cardinality = source->estimated_cardinality;
+	source_cardinality = MinValue<idx_t>(source->estimated_cardinality, 1ULL << 48ULL);
 	if (!initialized) {
 		current_percentage = 0;
 		return true;


### PR DESCRIPTION
This fixes an assertion trigger in `relassert` builds where very large cardinalities returned could lead to unsigned integers overflowing in the progress bar computation prior to the actual cardinalities being known.