### PR TITLE
[METRICS] Small fixes

### DIFF
--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1644,13 +1644,9 @@ void ProfilingModeSetting::SetLocal(ClientContext &context, const Value &input) 
 	if (parameter == "standard") {
 		config.enable_profiler = true;
 		config.enable_detailed_profiling = false;
-		config.emit_profiler_output = true;
-		config.profiler_settings = ClientConfig().profiler_settings;
 	} else if (parameter == "detailed") {
 		config.enable_profiler = true;
 		config.enable_detailed_profiling = true;
-		config.emit_profiler_output = true;
-		config.profiler_settings = ClientConfig().profiler_settings;
 
 		// add optimizer settings to the profiler settings
 		auto optimizer_settings = MetricsUtils::GetOptimizerMetrics();

--- a/test/sql/pragma/test_custom_optimizer_profiling.test
+++ b/test/sql/pragma/test_custom_optimizer_profiling.test
@@ -194,6 +194,9 @@ true
 
 # test if all phase timings are added when detailed profiling is on
 statement ok
+RESET custom_profiling_settings;
+
+statement ok
 SET profiling_mode = 'detailed';
 
 statement ok
@@ -252,6 +255,9 @@ SELECT unnest(res) from (
 "QUERY_NAME": "true"
 
 # Test if phase timings are not added if detailed mode is off
+statement ok
+RESET custom_profiling_settings;
+
 statement ok
 PRAGMA profiling_mode = 'standard';
 

--- a/test/sql/pragma/test_custom_optimizer_profiling.test
+++ b/test/sql/pragma/test_custom_optimizer_profiling.test
@@ -148,50 +148,6 @@ FROM metrics_output;
 ----
 true
 
-# Test Physical Plan and Planner Metrics
-statement ok
-PRAGMA custom_profiling_settings='{"PLANNER": "true", "PHYSICAL_PLANNER": "true"}'
-
-statement ok
-select unnest(['Maia', 'Thijs', 'Mark', 'Hannes', 'Tom', 'Max', 'Carlo', 'Sam', 'Tania']) as names order by random();
-
-statement ok
-PRAGMA disable_profiling
-
-query I rowsort
-SELECT unnest(res) from (
-	select current_setting('custom_profiling_settings') as raw_setting,
-	raw_setting.trim('{}') as setting,
-	string_split(setting, ', ') as res
-)
-----
-"PHYSICAL_PLANNER": "true"
-"PLANNER": "true"
-
-# test if physical planner and planner actually record timings
-statement ok
-CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM 'test/sql/pragma/output.json';
-
-query I
-SELECT 
-CASE 
-    WHEN physical_planner > 0 THEN 'true'
-    ELSE 'false'
-END
-FROM metrics_output;
-----
-true
-
-query I
-SELECT 
-CASE 
-    WHEN planner > 0 THEN 'true'
-    ELSE 'false'
-END
-FROM metrics_output;
-----
-true
-
 # test if all phase timings are added when detailed profiling is on
 statement ok
 RESET custom_profiling_settings;

--- a/test/sql/pragma/test_custom_optimizer_profiling.test_slow
+++ b/test/sql/pragma/test_custom_optimizer_profiling.test_slow
@@ -1,0 +1,76 @@
+# name: test/sql/pragma/test_custom_optimizer_profiling.test_slow
+# description: Test slow PRAGMA custom_profiling_settings with optimizers 
+# group: [pragma]
+
+require json
+
+# Test PHYSICAL_PLANNER and PLANNER with a big query tree
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = 'test/sql/pragma/output.json';
+
+statement ok
+PRAGMA custom_profiling_settings='{"PLANNER": "true", "PHYSICAL_PLANNER": "true"}'
+
+loop i 0 8
+
+statement ok
+CREATE TABLE t${i}(a int);
+
+statement ok
+INSERT INTO t${i} VALUES (1);
+
+endloop
+
+statement ok
+SELECT t1.a
+FROM t1
+JOIN t2 ON t1.a = t2.a
+JOIN t3 ON t2.a = t3.a
+JOIN t4 ON t3.a = t4.a
+JOIN t5 ON t4.a = t5.a
+JOIN t6 ON t5.a = t6.a
+JOIN t7 ON t6.a = t7.a
+;
+
+statement ok
+PRAGMA disable_profiling
+
+query I rowsort
+SELECT unnest(res) from (
+	select current_setting('custom_profiling_settings') as raw_setting,
+	raw_setting.trim('{}') as setting,
+	string_split(setting, ', ') as res
+)
+----
+"PHYSICAL_PLANNER": "true"
+"PLANNER": "true"
+
+# test if physical planner and planner actually record timings
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM 'test/sql/pragma/output.json';
+
+query I
+SELECT 
+CASE 
+    WHEN physical_planner > 0 THEN 'true'
+    ELSE 'false'
+END
+FROM metrics_output;
+----
+true
+
+query I
+SELECT 
+CASE 
+    WHEN planner > 0 THEN 'true'
+    ELSE 'false'
+END
+FROM metrics_output;
+----
+true

--- a/test/sql/pragma/test_custom_optimizer_profiling.test_slow
+++ b/test/sql/pragma/test_custom_optimizer_profiling.test_slow
@@ -1,5 +1,5 @@
 # name: test/sql/pragma/test_custom_optimizer_profiling.test_slow
-# description: Test slow PRAGMA custom_profiling_settings with optimizers 
+# description: Test slow PRAGMA custom_profiling_settings with optimizers
 # group: [pragma]
 
 require json


### PR DESCRIPTION
Some small metrics-related fixes:
- `PRAGMA enable_profiling = 'no_output'` combined with `PRAGMA profiling_mode = 'detailed'` no longer prints an extra new line
- The test for `Physical Plan` and `Planner` metrics now creates a larger physical plan, so the `Physical Plan` timer always produces a time larger than zero