### PR TITLE
Optimistic write to WAL: cannot write block pointers if we have in-memory updates to transaction local storage

### DIFF
--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -224,11 +224,13 @@ struct PersistentColumnData {
 	PhysicalType physical_type;
 	vector<DataPointer> pointers;
 	vector<PersistentColumnData> child_columns;
+	bool has_updates = false;
 
 	void Serialize(Serializer &serializer) const;
 	static PersistentColumnData Deserialize(Deserializer &deserializer);
 	void DeserializeField(Deserializer &deserializer, field_id_t field_idx, const char *field_name,
 	                      const LogicalType &type);
+	bool HasUpdates() const;
 };
 
 struct PersistentRowGroupData {
@@ -249,6 +251,7 @@ struct PersistentRowGroupData {
 
 	void Serialize(Serializer &serializer) const;
 	static PersistentRowGroupData Deserialize(Deserializer &deserializer);
+	bool HasUpdates() const;
 };
 
 struct PersistentCollectionData {
@@ -265,6 +268,7 @@ struct PersistentCollectionData {
 
 	void Serialize(Serializer &serializer) const;
 	static PersistentCollectionData Deserialize(Deserializer &deserializer);
+	bool HasUpdates() const;
 };
 
 } // namespace duckdb

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -304,6 +304,10 @@ void SingleFileStorageCommitState::FlushCommit() {
 
 void SingleFileStorageCommitState::AddRowGroupData(DataTable &table, idx_t start_index, idx_t count,
                                                    unique_ptr<PersistentCollectionData> row_group_data) {
+	if (row_group_data->HasUpdates()) {
+		// cannot serialize optimistic block pointers if in-memory updates exist
+		return;
+	}
 	auto &entries = optimistically_written_data[table];
 	auto entry = entries.find(start_index);
 	if (entry != entries.end()) {

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -632,6 +632,9 @@ PersistentColumnData::~PersistentColumnData() {
 }
 
 void PersistentColumnData::Serialize(Serializer &serializer) const {
+	if (has_updates) {
+		throw InternalException("Column data with updates cannot be serialized");
+	}
 	serializer.WritePropertyWithDefault(100, "data_pointers", pointers);
 	if (child_columns.empty()) {
 		// validity column
@@ -685,6 +688,18 @@ PersistentColumnData PersistentColumnData::Deserialize(Deserializer &deserialize
 	return result;
 }
 
+bool PersistentColumnData::HasUpdates() const {
+	if (has_updates) {
+		return true;
+	}
+	for (auto &child_col : child_columns) {
+		if (child_col.HasUpdates()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 PersistentRowGroupData::PersistentRowGroupData(vector<LogicalType> types_p) : types(std::move(types_p)) {
 }
 
@@ -708,6 +723,15 @@ PersistentRowGroupData PersistentRowGroupData::Deserialize(Deserializer &deseria
 	return data;
 }
 
+bool PersistentRowGroupData::HasUpdates() const {
+	for (auto &col : column_data) {
+		if (col.HasUpdates()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void PersistentCollectionData::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty(100, "row_groups", row_group_data);
 }
@@ -718,8 +742,19 @@ PersistentCollectionData PersistentCollectionData::Deserialize(Deserializer &des
 	return data;
 }
 
+bool PersistentCollectionData::HasUpdates() const {
+	for (auto &row_group : row_group_data) {
+		if (row_group.HasUpdates()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 PersistentColumnData ColumnData::Serialize() {
-	return PersistentColumnData(type.InternalType(), GetDataPointers());
+	PersistentColumnData result(type.InternalType(), GetDataPointers());
+	result.has_updates = HasUpdates();
+	return result;
 }
 
 shared_ptr<ColumnData> ColumnData::Deserialize(BlockManager &block_manager, DataTableInfo &info, idx_t column_index,

--- a/test/sql/storage/optimistic_write/optimistic_write_update_wal.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_update_wal.test_slow
@@ -1,0 +1,56 @@
+# name: test/sql/storage/optimistic_write/optimistic_write_update_wal.test_slow
+# description: Test optimistic write with updates in transaction-local storage going to the WAL
+# group: [optimistic_write]
+
+# load the DB from disk
+load __TEST_DIR__/optimistic_write_update_wal.db
+
+statement ok
+CREATE TABLE test (a INTEGER);
+
+statement ok
+SET checkpoint_threshold='1GB'
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO test SELECT * FROM range(1000000)
+
+statement ok
+UPDATE test SET a=500000 WHERE a=0
+
+statement ok
+COMMIT
+
+query I
+SELECT SUM(a) FROM test
+----
+500000000000
+
+restart
+
+query I
+SELECT SUM(a) FROM test
+----
+500000000000
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO test SELECT * FROM range(1000000)
+
+statement ok
+UPDATE test SET a=500000 WHERE a=0
+
+statement ok
+ROLLBACK
+
+query I
+SELECT SUM(a) FROM test
+----
+500000000000


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/13372

We cannot write block pointers to optimistically written transaction-local data to the WAL if we have updated that transaction-local data, as the updates are not reflected in the on-disk contents. Instead, we fall back to the old method of writing the actual data to the WAL.