### PR TITLE
Fix #13537: correctly maintain parameter count when rebinding a prepared statement

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -450,6 +450,7 @@ void ClientContext::RebindPreparedStatement(ClientContextLock &lock, const strin
 	auto new_prepared =
 	    CreatePreparedStatement(lock, query, prepared->unbound_statement->Copy(), parameters.parameters);
 	D_ASSERT(new_prepared->properties.bound_all_parameters);
+	new_prepared->properties.parameter_count = prepared->properties.parameter_count;
 	prepared = std::move(new_prepared);
 	prepared->properties.bound_all_parameters = false;
 }

--- a/test/api/test_prepared_api.cpp
+++ b/test/api/test_prepared_api.cpp
@@ -476,3 +476,23 @@ TEST_CASE("Test ambiguous prepared statement parameter types", "[api]") {
 	result = prep->Execute("hello");
 	REQUIRE(CHECK_COLUMN(result, 0, {"hello"}));
 }
+
+TEST_CASE("Test prepared statements with SET", "[api]") {
+	duckdb::unique_ptr<QueryResult> result;
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.EnableQueryVerification();
+
+	// create a prepared statement and use it to query
+	auto prepare = con.Prepare("SET default_null_order=$1");
+	REQUIRE(prepare->success);
+
+	// too many parameters
+	REQUIRE_FAIL(prepare->Execute("xxx", "yyy"));
+	// too few parameters
+	REQUIRE_FAIL(prepare->Execute());
+	// unsupported setting
+	REQUIRE_FAIL(prepare->Execute("unsupported_mode"));
+	// this works
+	REQUIRE_NO_FAIL(prepare->Execute("NULLS FIRST"));
+}


### PR DESCRIPTION
Fixes #13537