### PR TITLE
Fix HTTPFS tests

### DIFF
--- a/test/sql/copy/s3/README.md
+++ b/test/sql/copy/s3/README.md
@@ -12,6 +12,10 @@ brew install docker --cask
 
 Then open `/Applications/Docker`. Note that the first time you open the application you need to go to the `Applications` folder, right-click `Docker` and select `open`.
 
+### Setting Up Docker
+
+In order to finish setting up Docker, you need to open the Docker application, and login to your Docker account. Create a Docker account if you do not have one and finish setting up.
+
 ### Running Minio
 
 Run the `install_s3_test_server` script. This requires root. This makes a few changes to your system, specifically to `/etc/hosts` to set up a few redirect interfaces to localhost. This only needs to be run once.

--- a/test/sql/copy/s3/hive_partitioned_write_s3.test
+++ b/test/sql/copy/s3/hive_partitioned_write_s3.test
@@ -83,8 +83,13 @@ prefix-1	3	7
 prefix-1	0	9
 
 # Test partitioning by all
-statement ok
+statement error
 COPY test TO 's3://test-bucket/partitioned3' (FORMAT PARQUET, PARTITION_BY '*', OVERWRITE_OR_IGNORE TRUE);
+----
+No column to write as all columns are specified as partition columns
+
+statement ok
+COPY test TO 's3://test-bucket/partitioned3' (FORMAT PARQUET, PARTITION_BY '*', OVERWRITE_OR_IGNORE TRUE, WRITE_PARTITION_COLUMNS 1);
 
 query I
 SELECT min(value2_col) as min_val

--- a/test/sql/copy/s3/s3_hive_partition.test
+++ b/test/sql/copy/s3/s3_hive_partition.test
@@ -94,7 +94,7 @@ physical_plan	<REGEX>:.*PARQUET_SCAN.*Filters:.*a<4 AND a IS NOT.*NULL.*File Fil
 
 # There should be Table Filters (id < 50) and file filters (c = 500)
 query II
-EXPLAIN select a from read_csv_auto('s3://test-bucket/hive-partitioning/filter-test-csv/*/*.csv', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0, columns={'a': 'INT', 'b':'INT', 'c':'INT'}) where c=500 and a < 4;
+EXPLAIN select a from read_csv_auto('s3://test-bucket/hive-partitioning/filter-test-csv/*/*.csv', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where c=500 and a < 4;
 ----
 physical_plan	<REGEX>:.*FILTER.*(a < 4).*READ_CSV_AUTO.*File Filters:.* \(CAST\(c AS.*INTEGER\) = 500\).*
 


### PR DESCRIPTION
Test fixes after the change to hive-partitioned writes where we no longer write partition columns by default.