### PR TITLE
Automatically call `malloc_trim` to reduce unused outstanding allocations

### DIFF
--- a/extension/json/json_functions/json_create.cpp
+++ b/extension/json/json_functions/json_create.cpp
@@ -223,6 +223,12 @@ struct CreateJSONValue<uhugeint_t, string_t> {
 	}
 };
 
+template <class T>
+inline yyjson_mut_val *CreateJSONValueFromJSON(yyjson_mut_doc *doc, const T &value) {
+	return nullptr; // This function should only be called with string_t as template
+}
+
+template <>
 inline yyjson_mut_val *CreateJSONValueFromJSON(yyjson_mut_doc *doc, const string_t &value) {
 	auto value_doc = JSONCommon::ReadDocument(value, JSONCommon::READ_FLAG, &doc->alc);
 	auto result = yyjson_val_mut_copy(doc, value_doc->root);
@@ -273,7 +279,7 @@ static void TemplatedCreateValues(yyjson_mut_doc *doc, yyjson_mut_val *vals[], V
 		if (!value_data.validity.RowIsValid(val_idx)) {
 			vals[i] = yyjson_mut_null(doc);
 		} else if (type_is_json) {
-			vals[i] = CreateJSONValueFromJSON(doc, (string_t &)values[val_idx]);
+			vals[i] = CreateJSONValueFromJSON(doc, values[val_idx]);
 		} else {
 			vals[i] = CreateJSONValue<INPUT_TYPE, TARGET_TYPE>::Operation(doc, values[val_idx]);
 		}

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 
 #include <cstdint>
 
@@ -25,6 +26,10 @@
 
 #ifdef USE_JEMALLOC
 #include "jemalloc_extension.hpp"
+#endif
+
+#ifdef __GLIBC__
+#include <malloc.h>
 #endif
 
 namespace duckdb {
@@ -224,17 +229,40 @@ int64_t Allocator::DecayDelay() {
 }
 
 bool Allocator::SupportsFlush() {
-#ifdef USE_JEMALLOC
+#if defined(USE_JEMALLOC) || defined(__GLIBC__)
 	return true;
 #else
 	return false;
 #endif
 }
 
-void Allocator::ThreadFlush(idx_t threshold) {
-#ifdef USE_JEMALLOC
-	JemallocExtension::ThreadFlush(threshold);
+static void MallocTrim(idx_t pad) {
+#ifdef __GLIBC__
+	static constexpr int64_t TRIM_INTERVAL_MS = 100;
+	static atomic<int64_t> LAST_TRIM_TIMESTAMP_MS {0};
+
+	int64_t last_trim_timestamp_ms = LAST_TRIM_TIMESTAMP_MS.load();
+	const int64_t current_timestamp_ms = Timestamp::GetEpochMs(Timestamp::GetCurrentTimestamp());
+
+	if (current_timestamp_ms - last_trim_timestamp_ms < TRIM_INTERVAL_MS) {
+		return; // We trimmed less than TRIM_INTERVAL_MS ago
+	}
+	if (!std::atomic_compare_exchange_weak(&LAST_TRIM_TIMESTAMP_MS, &last_trim_timestamp_ms, current_timestamp_ms)) {
+		return; // Another thread has updated LAST_TRIM_TIMESTAMP_MS since we loaded it
+	}
+
+	// We succesfully updated LAST_TRIM_TIMESTAMP_MS, we can trim
+	malloc_trim(pad);
 #endif
+}
+
+void Allocator::ThreadFlush(bool allocator_background_threads, idx_t threshold, idx_t thread_count) {
+#ifdef USE_JEMALLOC
+	if (!allocator_background_threads) {
+		JemallocExtension::ThreadFlush(threshold);
+	}
+#endif
+	MallocTrim(thread_count * threshold);
 }
 
 void Allocator::ThreadIdle() {
@@ -247,6 +275,7 @@ void Allocator::FlushAll() {
 #ifdef USE_JEMALLOC
 	JemallocExtension::FlushAll();
 #endif
+	MallocTrim(0);
 }
 
 void Allocator::SetBackgroundThreads(bool enable) {

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -117,7 +117,7 @@ public:
 
 	static bool SupportsFlush();
 	static int64_t DecayDelay();
-	static void ThreadFlush(idx_t threshold);
+	static void ThreadFlush(bool allocator_background_threads, idx_t threshold, idx_t thread_count);
 	static void ThreadIdle();
 	static void FlushAll();
 	static void SetBackgroundThreads(bool enable);

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -10,11 +10,11 @@
 
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/enums/memory_tag.hpp"
+#include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/storage/storage_info.hpp"
-#include "duckdb/common/file_buffer.hpp"
-#include "duckdb/common/enums/memory_tag.hpp"
 
 namespace duckdb {
 class BlockManager;
@@ -23,6 +23,12 @@ class BufferPool;
 class DatabaseInstance;
 
 enum class BlockState : uint8_t { BLOCK_UNLOADED = 0, BLOCK_LOADED = 1 };
+
+enum class BufferDestroyType : uint8_t {
+	DESTROY_BUFFER_WITH_BLOCK = 0,    //! Destroy the buffer with the data when the associated BlockHandle is destroyed
+	DESTROY_BUFFER_UPON_EVICTION = 1, //! Destroy the buffer with the data when it must be evicted to storage
+	DESTROY_BUFFER_UNPON_UNPIN = 2    //! Destroy the buffer with the data immediately when it is unpinned
+};
 
 struct BufferPoolReservation {
 	MemoryTag tag;

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -10,11 +10,11 @@
 
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/common.hpp"
-#include "duckdb/common/enums/memory_tag.hpp"
-#include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/storage/storage_info.hpp"
+#include "duckdb/common/file_buffer.hpp"
+#include "duckdb/common/enums/memory_tag.hpp"
 
 namespace duckdb {
 class BlockManager;
@@ -23,12 +23,6 @@ class BufferPool;
 class DatabaseInstance;
 
 enum class BlockState : uint8_t { BLOCK_UNLOADED = 0, BLOCK_LOADED = 1 };
-
-enum class BufferDestroyType : uint8_t {
-	DESTROY_BUFFER_WITH_BLOCK = 0,    //! Destroy the buffer with the data when the associated BlockHandle is destroyed
-	DESTROY_BUFFER_UPON_EVICTION = 1, //! Destroy the buffer with the data when it must be evicted to storage
-	DESTROY_BUFFER_UNPON_UNPIN = 2    //! Destroy the buffer with the data immediately when it is unpinned
-};
 
 struct BufferPoolReservation {
 	MemoryTag tag;

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -164,12 +164,12 @@ void TaskScheduler::ExecuteForever(atomic<bool> *marker) {
 	shared_ptr<Task> task;
 	// loop until the marker is set to false
 	while (*marker) {
-		if (!Allocator::SupportsFlush() || allocator_background_threads) {
-			// allocator can't flush, or background threads clean up allocations, just start an untimed wait
+		if (!Allocator::SupportsFlush()) {
+			// allocator can't flush, just start an untimed wait
 			queue->semaphore.wait();
 		} else if (!queue->semaphore.wait(INITIAL_FLUSH_WAIT)) {
-			// no background threads, flush this threads outstanding allocations after it was idle for 0.5s
-			Allocator::ThreadFlush(allocator_flush_threshold);
+			// allocator can flush, we flush this threads outstanding allocations after it was idle for 0.5s
+			Allocator::ThreadFlush(allocator_background_threads, allocator_flush_threshold, requested_thread_count);
 			if (!queue->semaphore.wait(Allocator::DecayDelay() * 1000000 - INITIAL_FLUSH_WAIT)) {
 				// in total, the thread was idle for the entire decay delay (note: seconds converted to mus)
 				// mark it as idle and start an untimed wait
@@ -196,7 +196,7 @@ void TaskScheduler::ExecuteForever(atomic<bool> *marker) {
 	}
 	// this thread will exit, flush all of its outstanding allocations
 	if (Allocator::SupportsFlush()) {
-		Allocator::ThreadFlush(0);
+		Allocator::ThreadFlush(allocator_background_threads, 0, requested_thread_count);
 		Allocator::ThreadIdle();
 	}
 #else

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -399,9 +399,6 @@ void StandardBufferManager::Unpin(shared_ptr<BlockHandle> &handle) {
 
 void StandardBufferManager::SetMemoryLimit(idx_t limit) {
 	buffer_pool.SetLimit(limit, InMemoryWarning());
-	if (Allocator::SupportsFlush()) {
-		Allocator::FlushAll();
-	}
 }
 
 void StandardBufferManager::SetSwapLimit(optional_idx limit) {


### PR DESCRIPTION
After attaching and detaching many databases, DuckDB would hold onto many gigabytes of memory on Linux machines. [This is a well-known phenomenon of the GNU allocator](https://www.algolia.com/blog/engineering/when-allocators-are-hoarding-your-precious-memory/). We can release the memory to the OS by calling `malloc_trim`, which brings the memory down to a few KB.

This PR adds `malloc_trim` to our allocation flushing methods to properly release memory to the OS and reduce our RSS.

I've also fixed a compile warning for Linux in `json_create.cpp`.