### PR TITLE
Switch in-tree DuckDB extension to use DuckDB's semver tag

### DIFF
--- a/.github/config/bundled_extensions.cmake
+++ b/.github/config/bundled_extensions.cmake
@@ -14,14 +14,14 @@
 #
 ## Extensions that are linked
 #
-duckdb_extension_load(icu)
-duckdb_extension_load(tpch)
-duckdb_extension_load(json)
-duckdb_extension_load(fts)
-duckdb_extension_load(parquet)
-duckdb_extension_load(autocomplete)
+duckdb_extension_load(icu EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(tpch EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(json EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(fts EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(parquet EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(autocomplete EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
 
 #
 ## Extensions that are not linked, but we do want to test them as part of the release build
 #
-duckdb_extension_load(tpcds DONT_LINK)
+duckdb_extension_load(tpcds DONT_LINK EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})

--- a/.github/config/in_tree_extensions.cmake
+++ b/.github/config/in_tree_extensions.cmake
@@ -5,14 +5,14 @@
 #   EXTENSION_CONFIGS=.github/config/in_tree_extensions.cmake make
 #
 
-duckdb_extension_load(autocomplete)
-duckdb_extension_load(fts)
-duckdb_extension_load(httpfs)
-duckdb_extension_load(icu)
-duckdb_extension_load(json)
-duckdb_extension_load(parquet)
-duckdb_extension_load(tpcds)
-duckdb_extension_load(tpch)
+duckdb_extension_load(autocomplete EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(fts EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(httpfs EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(icu EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(json EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(parquet EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(tpcds EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(tpch EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
 
 # Test extension for the upcoming C CAPI extensions
 duckdb_extension_load(demo_capi DONT_LINK)

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -8,12 +8,12 @@
 # The local file is also loaded by the DuckDB CMake build but ignored by version control.
 
 # Parquet is loaded by default on every build as its a essential part of DuckDB
-duckdb_extension_load(parquet)
+duckdb_extension_load(parquet EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
 
 # The Linux allocator has issues so we use jemalloc, but only on x86 because page sizes are fixed at 4KB.
 # Configuring jemalloc properly for 32bit is a hassle, and not worth it so we only enable on 64bit
 # If page sizes vary for an architecture (e.g., arm64), we cannot create a portable binary due to jemalloc config
 # FIXME: after configuring the jemalloc config, jemalloc should work on arm64 again (should try at some point)
 if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND (OS_ARCH STREQUAL "amd64" OR OS_ARCH STREQUAL "i386") AND NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS)
-    duckdb_extension_load(jemalloc)
+    duckdb_extension_load(jemalloc EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
 endif()


### PR DESCRIPTION
This PR changes the in-tree DuckDB extensions to use DuckDB's semver tag.

### Changes
Before this PR, on a stable (tagged) duckdb version you would get:
```
D select extension_version from duckdb_extensions() where extension_name='parquet';
┌───────────────────┐
│ extension_version │
│      varchar      │
├───────────────────┤
│ 1f98600c2c            │
└───────────────────┘
D pragma version;
┌─────────────────┬────────────┐
│ library_version │ source_id  │
│     varchar     │  varchar   │
├─────────────────┼────────────┤
│ v1.0.0          │ 1f98600c2c │
└─────────────────┴────────────┘
```

After this PR you will get:
```
D select extension_version from duckdb_extensions() where extension_name='parquet';
┌───────────────────┐
│ extension_version │
│      varchar      │
├───────────────────┤
│ v1.0.0            │
└───────────────────┘
D pragma version;
┌─────────────────┬────────────┐
│ library_version │ source_id  │
│     varchar     │  varchar   │
├─────────────────┼────────────┤
│ v1.0.0          │ 1f98600c2c │
└─────────────────┴────────────┘
```

### Context
In order to provide some structure to help users understand the phases of stability that can be expected from an extension, I would like to make some new guidelines for extension versioning for `core` extensions. Extensions will be able to move up in stability level, but never down.

I want to define 3 levels of stability, in increasing order of stability:
1. **unstable**:  versioned using the short commit hash
2. **pre-release**: (using semver v0 tag: `v0.<y>.<z>`)
3. **stable**: (using semver stable tag `v<x>.<y>.<z>` where `x > 0`)

The idea here is that extensions start out as **unstable**. This indicates an extension should be handled with some care:
- APIs may change (functions removed, parameters changed, types changed, etc)
- the latest available version can change at any time, and might even be reverted to an earlier version without any warning

Next phase will be **pre-release**. Extensions that are in pre-release mode will only be pushed into the `core` repository using tagged releases. These releases should be available on Github, with a release that explains what changes were made in that release. For in-tree extensions this will just be the DuckDB releases, out-of-tree extensions will need to do their own (e.g. https://github.com/duckdb/duckdb_delta/releases/tag/v0.1.0)

Final phase is **stable** where extensions are tagged with v1.0.0 or higher. Extensions with this tag should ensure that [semver](https://semver.org/) stability guidelines are followed. In general this will mean that things like function signature, types, etc. should be stable and only be changed when bumping a major version.

### Why this change
If we want to move to a slightly more mature versioning schema for our extensions, I feel this change better matches the above guidelines: all of the current in-tree extensions should be stable enough for us to make this commitment AFAICT.

### Discussion:
- Do you agree with versioning scheme proposed above?
- Do you agree with the fact that this means we basically promise to have all the in-tree extensions API-stable from now on? (if not, which ones should be reverted to **unstable**?)

### Follow-up
- Deploy extensions at their versioned paths 
- update docs explaining the stability of core extensions
