### PR TITLE
Fix for joins and FSST on 32-bit configurations

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Test
         shell: bash
-        run: build/release/test/unittest "*"
+        run: build/release/test/unittest
 
   linux-tarball:
      name: Python 3 Tarball

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -434,11 +434,11 @@ idx_t JoinHashTable::PrepareKeys(DataChunk &keys, vector<TupleDataVectorFormat> 
 	return added_count;
 }
 
-static void StorePointer(data_ptr_t pointer, data_ptr_t target) {
+static void StorePointer(const_data_ptr_t pointer, data_ptr_t target) {
 	Store<uint64_t>(reinterpret_cast<uint64_t>(pointer), target);
 }
 
-static data_ptr_t LoadPointer(data_ptr_t source) {
+static data_ptr_t LoadPointer(const_data_ptr_t source) {
 	return reinterpret_cast<data_ptr_t>(Load<uint64_t>(source));
 }
 
@@ -614,7 +614,11 @@ static void InsertHashesLoop(atomic<ht_entry_t> entries[], Vector &row_locations
 				occupied = entry.IsOccupied();
 
 				// condition for incrementing the ht_offset: occupied and row_salt does not match -> move to next entry
-				if (!occupied || entry.GetSalt() == salt) {
+				if (!occupied) {
+					break;
+				}
+				Printer::PrintF("Compare salt %llu with salt %llu", entry.GetSalt(), salt);
+				if (entry.GetSalt() == salt) {
 					break;
 				}
 

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -485,8 +485,11 @@ static inline data_ptr_t InsertRowToEntry(atomic<ht_entry_t> &entry, const data_
 		// if we are not in parallel mode, we can just do the operation without any checks
 		ht_entry_t current_entry = entry.load(std::memory_order_relaxed);
 		data_ptr_t current_row_pointer = current_entry.GetPointerOrNull();
+		Printer::PrintF("Storing pointer %llu", reinterpret_cast<uint64_t>(current_row_pointer));
 		StorePointer(current_row_pointer, row_ptr_to_insert + pointer_offset);
+		Printer::PrintF("Trying to set pointer %llu, salt %llu", reinterpret_cast<uint64_t>(row_ptr_to_insert), salt);
 		entry = ht_entry_t::GetDesiredEntry(row_ptr_to_insert, salt);
+		Printer::PrintF("Setting entry to pointer %llu, salt %llu", reinterpret_cast<uint64_t>(entry.load().GetPointer()), entry.load().GetSalt());
 		return nullptr;
 	}
 }

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -485,11 +485,8 @@ static inline data_ptr_t InsertRowToEntry(atomic<ht_entry_t> &entry, const data_
 		// if we are not in parallel mode, we can just do the operation without any checks
 		ht_entry_t current_entry = entry.load(std::memory_order_relaxed);
 		data_ptr_t current_row_pointer = current_entry.GetPointerOrNull();
-		// Printer::PrintF("Storing pointer %llu", reinterpret_cast<uintptr_t>(current_row_pointer));
 		StorePointer(current_row_pointer, row_ptr_to_insert + pointer_offset);
-		// Printer::PrintF("Trying to set pointer %llu, salt %llu", reinterpret_cast<uintptr_t>(row_ptr_to_insert), salt);
 		entry = ht_entry_t::GetDesiredEntry(row_ptr_to_insert, salt);
-		// Printer::PrintF("Setting entry to pointer %llu, salt %llu", reinterpret_cast<uintptr_t>(entry.load().GetPointer()), entry.load().GetSalt());
 		return nullptr;
 	}
 }
@@ -620,7 +617,6 @@ static void InsertHashesLoop(atomic<ht_entry_t> entries[], Vector &row_locations
 				if (!occupied) {
 					break;
 				}
-				// Printer::PrintF("Compare salt %llu with salt %llu", entry.GetSalt(), salt);
 				if (entry.GetSalt() == salt) {
 					break;
 				}

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -435,11 +435,11 @@ idx_t JoinHashTable::PrepareKeys(DataChunk &keys, vector<TupleDataVectorFormat> 
 }
 
 static void StorePointer(const_data_ptr_t pointer, data_ptr_t target) {
-	Store<uint64_t>(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pointer)), target);
+	Store<uint64_t>(cast_pointer_to_uint64(pointer), target);
 }
 
 static data_ptr_t LoadPointer(const_data_ptr_t source) {
-	return reinterpret_cast<data_ptr_t>(static_cast<uintptr_t>(Load<uint64_t>(source)));
+	return cast_uint64_to_pointer(Load<uint64_t>(source));
 }
 
 //! If we consider to insert into an entry we expct to be empty, if it was filled in the meantime the insert will not
@@ -485,11 +485,11 @@ static inline data_ptr_t InsertRowToEntry(atomic<ht_entry_t> &entry, const data_
 		// if we are not in parallel mode, we can just do the operation without any checks
 		ht_entry_t current_entry = entry.load(std::memory_order_relaxed);
 		data_ptr_t current_row_pointer = current_entry.GetPointerOrNull();
-		Printer::PrintF("Storing pointer %llu", reinterpret_cast<uintptr_t>(current_row_pointer));
+		// Printer::PrintF("Storing pointer %llu", reinterpret_cast<uintptr_t>(current_row_pointer));
 		StorePointer(current_row_pointer, row_ptr_to_insert + pointer_offset);
-		Printer::PrintF("Trying to set pointer %llu, salt %llu", reinterpret_cast<uintptr_t>(row_ptr_to_insert), salt);
+		// Printer::PrintF("Trying to set pointer %llu, salt %llu", reinterpret_cast<uintptr_t>(row_ptr_to_insert), salt);
 		entry = ht_entry_t::GetDesiredEntry(row_ptr_to_insert, salt);
-		Printer::PrintF("Setting entry to pointer %llu, salt %llu", reinterpret_cast<uintptr_t>(entry.load().GetPointer()), entry.load().GetSalt());
+		// Printer::PrintF("Setting entry to pointer %llu, salt %llu", reinterpret_cast<uintptr_t>(entry.load().GetPointer()), entry.load().GetSalt());
 		return nullptr;
 	}
 }
@@ -620,7 +620,7 @@ static void InsertHashesLoop(atomic<ht_entry_t> entries[], Vector &row_locations
 				if (!occupied) {
 					break;
 				}
-				Printer::PrintF("Compare salt %llu with salt %llu", entry.GetSalt(), salt);
+				// Printer::PrintF("Compare salt %llu with salt %llu", entry.GetSalt(), salt);
 				if (entry.GetSalt() == salt) {
 					break;
 				}

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -435,11 +435,11 @@ idx_t JoinHashTable::PrepareKeys(DataChunk &keys, vector<TupleDataVectorFormat> 
 }
 
 static void StorePointer(const_data_ptr_t pointer, data_ptr_t target) {
-	Store<uint64_t>(reinterpret_cast<uint64_t>(pointer), target);
+	Store<uint64_t>(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pointer)), target);
 }
 
 static data_ptr_t LoadPointer(const_data_ptr_t source) {
-	return reinterpret_cast<data_ptr_t>(Load<uint64_t>(source));
+	return reinterpret_cast<data_ptr_t>(static_cast<uintptr_t>(Load<uint64_t>(source)));
 }
 
 //! If we consider to insert into an entry we expct to be empty, if it was filled in the meantime the insert will not
@@ -485,11 +485,11 @@ static inline data_ptr_t InsertRowToEntry(atomic<ht_entry_t> &entry, const data_
 		// if we are not in parallel mode, we can just do the operation without any checks
 		ht_entry_t current_entry = entry.load(std::memory_order_relaxed);
 		data_ptr_t current_row_pointer = current_entry.GetPointerOrNull();
-		Printer::PrintF("Storing pointer %llu", reinterpret_cast<uint64_t>(current_row_pointer));
+		Printer::PrintF("Storing pointer %llu", reinterpret_cast<uintptr_t>(current_row_pointer));
 		StorePointer(current_row_pointer, row_ptr_to_insert + pointer_offset);
-		Printer::PrintF("Trying to set pointer %llu, salt %llu", reinterpret_cast<uint64_t>(row_ptr_to_insert), salt);
+		Printer::PrintF("Trying to set pointer %llu, salt %llu", reinterpret_cast<uintptr_t>(row_ptr_to_insert), salt);
 		entry = ht_entry_t::GetDesiredEntry(row_ptr_to_insert, salt);
-		Printer::PrintF("Setting entry to pointer %llu, salt %llu", reinterpret_cast<uint64_t>(entry.load().GetPointer()), entry.load().GetSalt());
+		Printer::PrintF("Setting entry to pointer %llu, salt %llu", reinterpret_cast<uintptr_t>(entry.load().GetPointer()), entry.load().GetSalt());
 		return nullptr;
 	}
 }

--- a/src/include/duckdb/common/typedefs.hpp
+++ b/src/include/duckdb/common/typedefs.hpp
@@ -63,7 +63,18 @@ const unsigned char *const_uchar_ptr_cast(const SRC *src) { // NOLINT: naming
 
 template <class SRC>
 uintptr_t CastPointerToValue(SRC *src) {
-	return uintptr_t(src);
+	return reinterpret_cast<uintptr_t>(src);
 }
+
+template <class SRC>
+uint64_t cast_pointer_to_uint64(SRC *src) {
+	return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(src));
+}
+
+template <class SRC = data_t>
+SRC *cast_uint64_to_pointer(uint64_t value) {
+	return reinterpret_cast<SRC *>(static_cast<uintptr_t>(value));
+}
+
 
 } // namespace duckdb

--- a/src/include/duckdb/common/typedefs.hpp
+++ b/src/include/duckdb/common/typedefs.hpp
@@ -76,5 +76,4 @@ SRC *cast_uint64_to_pointer(uint64_t value) {
 	return reinterpret_cast<SRC *>(static_cast<uintptr_t>(value));
 }
 
-
 } // namespace duckdb

--- a/src/include/duckdb/execution/ht_entry.hpp
+++ b/src/include/duckdb/execution/ht_entry.hpp
@@ -82,7 +82,7 @@ public:
 	}
 
 	static inline ht_entry_t GetDesiredEntry(const data_ptr_t &pointer, const hash_t &salt) {
-		auto desired = reinterpret_cast<uint64_t>(pointer) | (salt & SALT_MASK);
+		auto desired = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pointer)) | (salt & SALT_MASK);
 		return ht_entry_t(desired);
 	}
 

--- a/src/include/duckdb/execution/ht_entry.hpp
+++ b/src/include/duckdb/execution/ht_entry.hpp
@@ -59,12 +59,12 @@ public:
 	}
 
 	// Returns the salt, leaves upper salt bits intact, sets lower bits to all 1's
-	static inline hash_t ExtractSalt(const hash_t &hash) {
+	static inline hash_t ExtractSalt(hash_t hash) {
 		return hash | POINTER_MASK;
 	}
 
 	// Returns the salt, leaves upper salt bits intact, sets lower bits to all 0's
-	static inline hash_t ExtractSaltWithNulls(const hash_t &hash) {
+	static inline hash_t ExtractSaltWithNulls(hash_t hash) {
 		return hash & SALT_MASK;
 	}
 

--- a/src/include/duckdb/execution/ht_entry.hpp
+++ b/src/include/duckdb/execution/ht_entry.hpp
@@ -40,22 +40,22 @@ public:
 	// Returns a pointer based on the stored value without checking cell occupancy.
 	// This can return a nullptr if the cell is not occupied.
 	inline data_ptr_t GetPointerOrNull() const {
-		return reinterpret_cast<data_ptr_t>(static_cast<uintptr_t>(value & POINTER_MASK));
+		return cast_uint64_to_pointer(value & POINTER_MASK);
 	}
 
 	// Returns a pointer based on the stored value if the cell is occupied
 	inline data_ptr_t GetPointer() const {
 		D_ASSERT(IsOccupied());
-		return reinterpret_cast<data_ptr_t>(static_cast<uintptr_t>(value & POINTER_MASK));
+		return cast_uint64_to_pointer(value & POINTER_MASK);
 	}
 
 	inline void SetPointer(const data_ptr_t &pointer) {
 		// Pointer shouldn't use upper bits
-		D_ASSERT((static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pointer)) & SALT_MASK) == 0);
+		D_ASSERT((cast_pointer_to_uint64(pointer) & SALT_MASK) == 0);
 		// Value should have all 1's in the pointer area
 		D_ASSERT((value & POINTER_MASK) == POINTER_MASK);
 		// Set upper bits to 1 in pointer so the salt stays intact
-		value &= static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pointer)) | SALT_MASK;
+		value &= cast_pointer_to_uint64(pointer) | SALT_MASK;
 	}
 
 	// Returns the salt, leaves upper salt bits intact, sets lower bits to all 1's
@@ -82,7 +82,7 @@ public:
 	}
 
 	static inline ht_entry_t GetDesiredEntry(const data_ptr_t &pointer, const hash_t &salt) {
-		auto desired = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pointer)) | (salt & SALT_MASK);
+		auto desired = cast_pointer_to_uint64(pointer) | (salt & SALT_MASK);
 		return ht_entry_t(desired);
 	}
 

--- a/src/include/duckdb/execution/ht_entry.hpp
+++ b/src/include/duckdb/execution/ht_entry.hpp
@@ -40,22 +40,22 @@ public:
 	// Returns a pointer based on the stored value without checking cell occupancy.
 	// This can return a nullptr if the cell is not occupied.
 	inline data_ptr_t GetPointerOrNull() const {
-		return reinterpret_cast<data_ptr_t>(value & POINTER_MASK);
+		return reinterpret_cast<data_ptr_t>(static_cast<uintptr_t>(value & POINTER_MASK));
 	}
 
 	// Returns a pointer based on the stored value if the cell is occupied
 	inline data_ptr_t GetPointer() const {
 		D_ASSERT(IsOccupied());
-		return reinterpret_cast<data_ptr_t>(value & POINTER_MASK);
+		return reinterpret_cast<data_ptr_t>(static_cast<uintptr_t>(value & POINTER_MASK));
 	}
 
 	inline void SetPointer(const data_ptr_t &pointer) {
 		// Pointer shouldn't use upper bits
-		D_ASSERT((reinterpret_cast<uint64_t>(pointer) & SALT_MASK) == 0);
+		D_ASSERT((static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pointer)) & SALT_MASK) == 0);
 		// Value should have all 1's in the pointer area
 		D_ASSERT((value & POINTER_MASK) == POINTER_MASK);
 		// Set upper bits to 1 in pointer so the salt stays intact
-		value &= reinterpret_cast<uint64_t>(pointer) | SALT_MASK;
+		value &= static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pointer)) | SALT_MASK;
 	}
 
 	// Returns the salt, leaves upper salt bits intact, sets lower bits to all 1's

--- a/third_party/fsst/fsst.h
+++ b/third_party/fsst/fsst.h
@@ -53,7 +53,7 @@
 #define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
 #define __ORDER_LITTLE_ENDIAN__ 2
 #include <intrin.h>
-static inline int __builtin_ctzl(unsigned long long x) {
+static inline int __builtin_ctzll(unsigned long long x) {
 #  ifdef _WIN64
 	unsigned long ret;
     _BitScanForward64(&ret, x);
@@ -184,7 +184,7 @@ duckdb_fsst_decompress(
          code = strIn[posIn++]; FSST_UNALIGNED_STORE(strOut+posOut, symbol[code]); posOut += len[code]; 
          code = strIn[posIn++]; FSST_UNALIGNED_STORE(strOut+posOut, symbol[code]); posOut += len[code]; 
      } else { 
-         unsigned long firstEscapePos=static_cast<unsigned long>(__builtin_ctzl((unsigned long long) escapeMask)>>3);
+         unsigned long firstEscapePos=static_cast<unsigned long>(__builtin_ctzll((unsigned long long) escapeMask)>>3);
          switch(firstEscapePos) { /* Duff's device */
          case 3: code = strIn[posIn++]; FSST_UNALIGNED_STORE(strOut+posOut, symbol[code]); posOut += len[code];
 			 DUCKDB_FSST_EXPLICIT_FALLTHROUGH;

--- a/third_party/fsst/libfsst.hpp
+++ b/third_party/fsst/libfsst.hpp
@@ -381,7 +381,7 @@ struct Counters {
       // read 16-bits single symbol counter, split into two 8-bits numbers (count1Low, count1High), while skipping over zeros
 	   u64 high = fsst_unaligned_load(&count1High[pos1]);
 
-      u32 zero = high?(__builtin_ctzl(high)>>3):7UL; // number of zero bytes
+      u32 zero = high?(__builtin_ctzll(high)>>3):7UL; // number of zero bytes
       high = (high >> (zero << 3)) & 255; // advance to nonzero counter
       if (((pos1 += zero) >= FSST_CODE_MAX) || !high) // SKIP! advance pos2
          return 0; // all zero
@@ -395,7 +395,7 @@ struct Counters {
 	  u64 high = fsst_unaligned_load(&count2High[pos1][pos2>>1]);
       high >>= ((pos2&1) << 2); // odd pos2: ignore the lowest 4 bits & we see only 15 counters
 
-      u32 zero = high?(__builtin_ctzl(high)>>2):(15UL-(pos2&1UL)); // number of zero 4-bits counters
+      u32 zero = high?(__builtin_ctzll(high)>>2):(15UL-(pos2&1UL)); // number of zero 4-bits counters
       high = (high >> (zero << 2)) & 15;  // advance to nonzero counter
       if (((pos2 += zero) >= FSST_CODE_MAX) || !high) // SKIP! advance pos2
          return 0UL; // all zero


### PR DESCRIPTION
This PR fixes a number of issues when running DuckDB on a 32-bit operating system:

* The new hash join code incorrectly dealt with 32-bit pointers - we need to explicitly convert them to `uint64_t` when storing them in the hash table at various locations
* `reinterpret_cast<uint64_t>(pointer)` is incorrect on a 32-bit system, we need to do `static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pointer))`. I've added helper functions for these (`cast_uint64_to_pointer` and `cast_pointer_to_uint64`)
* `unsigned long` and `unsigned long long` are different on 32-bit systems, so we need to use `__builtin_ctzll` and not `__builtin_ctzl` 