### PR TITLE
More nightly test fixes

### DIFF
--- a/scripts/run_extension_medata_tests.sh
+++ b/scripts/run_extension_medata_tests.sh
@@ -53,6 +53,12 @@ else
   duckdb_extension_load(json DONT_LINK EXTENSION_VERSION v0.0.1)
   duckdb_extension_load(tpch DONT_LINK EXTENSION_VERSION v0.0.1)
   duckdb_extension_load(tpcds DONT_LINK EXTENSION_VERSION v0.0.1)
+  duckdb_extension_load(inet
+      GIT_URL https://github.com/duckdb/duckdb_inet
+      GIT_TAG eca867b2517af06eabc89ccd6234266e9a7d6d71
+      INCLUDE_DIR src/include
+      EXTENSION_VERSION v0.0.1
+      )
 EOL
 
   # Build the extensions using the first config
@@ -63,7 +69,7 @@ EOL
   DUCKDB_PLATFORM=`cat $DUCKDB_BUILD_DIR/duckdb_platform_out`
 
   # Install the extension from the initial config
-  $DUCKDB_BUILD_DIR/duckdb -unsigned -c "set extension_directory='$LOCAL_EXTENSION_DIR'; set custom_extension_repository='$LOCAL_EXTENSION_REPO_UPDATED'; install tpch; install json;"
+  $DUCKDB_BUILD_DIR/duckdb -unsigned -c "set extension_directory='$LOCAL_EXTENSION_DIR'; set custom_extension_repository='$LOCAL_EXTENSION_REPO_UPDATED'; install tpch; install json; INSTALL inet;"
 
   # Install tpcds directly
   cp $DUCKDB_BUILD_DIR/extension/tpcds/tpcds.duckdb_extension $DIRECT_INSTALL_DIR/tpcds.duckdb_extension
@@ -73,13 +79,19 @@ EOL
   cat > $TEST_DIR/extension_config_after.cmake <<EOL
   duckdb_extension_load(json DONT_LINK EXTENSION_VERSION v0.0.1)
   duckdb_extension_load(tpch DONT_LINK EXTENSION_VERSION v0.0.2)
+  duckdb_extension_load(inet
+      GIT_URL https://github.com/duckdb/duckdb_inet
+      GIT_TAG eca867b2517af06eabc89ccd6234266e9a7d6d71
+      INCLUDE_DIR src/include
+      EXTENSION_VERSION v0.0.2
+   )
 EOL
 
   # Build the extensions using the second config
   LOCAL_EXTENSION_REPO=$LOCAL_EXTENSION_REPO_UPDATED EXTENSION_CONFIGS=$TEST_DIR/extension_config_after.cmake BUILD_EXTENSIONS_ONLY=1 make debug
 
   # For good measure, we also gzip one of the files in the repo to ensure we can do both gzipped and non gzipped
-  gzip -1 $LOCAL_EXTENSION_REPO_UPDATED/$DUCKDB_VERSION/$DUCKDB_PLATFORM/tpch.duckdb_extension
+  gzip -1 $LOCAL_EXTENSION_REPO_UPDATED/$DUCKDB_VERSION/$DUCKDB_PLATFORM/inet.duckdb_extension
 
   ##########################################
   ### Second repo: Incorrect DuckDB platform

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -220,11 +220,11 @@ Allocator &Allocator::DefaultAllocator() {
 	return *DefaultAllocatorReference();
 }
 
-int64_t Allocator::DecayDelay() {
+optional_idx Allocator::DecayDelay() {
 #ifdef USE_JEMALLOC
 	return JemallocExtension::DecayDelay();
 #else
-	return NumericLimits<int64_t>::Maximum();
+	return optional_idx();
 #endif
 }
 

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/optional_idx.hpp"
 
 namespace duckdb {
 class Allocator;
@@ -116,7 +117,7 @@ public:
 	DUCKDB_API static shared_ptr<Allocator> &DefaultAllocatorReference();
 
 	static bool SupportsFlush();
-	static int64_t DecayDelay();
+	static optional_idx DecayDelay();
 	static void ThreadFlush(bool allocator_background_threads, idx_t threshold, idx_t thread_count);
 	static void ThreadIdle();
 	static void FlushAll();

--- a/src/include/duckdb/storage/block.hpp
+++ b/src/include/duckdb/storage/block.hpp
@@ -34,6 +34,7 @@ struct BlockPointer {
 
 	block_id_t block_id;
 	uint32_t offset;
+	uint32_t unused_padding {0};
 
 	bool IsValid() const {
 		return block_id != INVALID_BLOCK;
@@ -51,6 +52,7 @@ struct MetaBlockPointer {
 
 	idx_t block_pointer;
 	uint32_t offset;
+	uint32_t unused_padding {0};
 
 	bool IsValid() const {
 		return block_pointer != DConstants::INVALID_INDEX;

--- a/test/fuzzer/duckfuzz/null_arguments.test
+++ b/test/fuzzer/duckfuzz/null_arguments.test
@@ -31,18 +31,7 @@ SELECT NULL FROM read_parquet('__TEST_DIR__/test_null_args.parquet', filename = 
 <REGEX>:.*Cannot use NULL.*
 
 statement error
-WITH t10 (c6, c7, c8, c9) AS
-	(
-		SELECT DISTINCT c1, c2
-		FROM nation AS t5(c1, c2, c3, c4)
-		ORDER BY c4 NULLS FIRST, c2 ASC NULLS LAST, c1 DESC LIMIT 2445
-	)
-SELECT 7827, 7591, c13, TRY_CAST(1414 AS DATE)
 FROM read_ndjson(NULL, filename := NULL) AS t14(c11, c12, c13)
-PIVOT (list_median((NOT c3)) FOR
-(rank() OVER (PARTITION BY c7 ROWS BETWEEN CURRENT ROW AND
-	(c1 IN ("first"(c11), COLUMNS(*), 5251, c12, 4034, c7, c3, list_sem(c2))) FOLLOWING))
-IN ('2262-04-11 23:47:16.854775806'::TIMESTAMP_NS, 5050)) WHERE inet_server_addr() OFFSET #3;
 ----
 <REGEX>:.*Cannot use NULL.*
 

--- a/test/sql/aggregate/aggregates/binning.test
+++ b/test/sql/aggregate/aggregates/binning.test
@@ -2,6 +2,8 @@
 # description: Test binning functions
 # group: [aggregates]
 
+require 64bit
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/aggregate/aggregates/histogram_table_function.test
+++ b/test/sql/aggregate/aggregates/histogram_table_function.test
@@ -2,6 +2,8 @@
 # description: Test the histogram table function
 # group: [aggregates]
 
+require 64bit
+
 statement ok
 pragma enable_verification
 


### PR DESCRIPTION
* Explicitly define padding in 12-byte structs to align them to 16-bytes consistently, also on 32-bit platforms
* In extension update test, install inet again but do it from a remote source
* Use `optional_idx`  for `Allocator::DecayDelay`, and correctly handle the scenario where it is not set (due to jemalloc not being available)
* Simplify test to avoid `table not missing` failure when using alternative verify