### PR TITLE
Disable `JEMALLOC_HAVE_MADVISE_HUGE` in jemalloc

### DIFF
--- a/extension/jemalloc/jemalloc/README.md
+++ b/extension/jemalloc/jemalloc/README.md
@@ -156,16 +156,15 @@ int strerror_fixed(int err, char *buf, size_t buflen) {
 }
 ```
 
-Add this line
+Edit the following in `pages.c`:
 ```c++
-buf[0] = '2';
-```
-to this function
-```c++
+// explicitly initialize this buffer to prevent reading uninitialized memory if the file is somehow empty
+// 0 is the default setting for linux if it hasn't been changed so that's what we initialize to
+char buf[1] = {'0'};
+// in this function
 static bool
 os_overcommits_proc(void)
 ```
-in `pages.c`.
 
 Almost no symbols are leaked due to `private_namespace.h`.
 The `exported_symbols_check.py` script still found a few, so these lines need to be added to `private_namespace.h`:

--- a/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+++ b/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
@@ -393,9 +393,9 @@
  * Defined if transparent huge pages are supported via the MADV_[NO]HUGEPAGE
  * arguments to madvise(2).
  */
-#ifdef __GLIBC__
-#define JEMALLOC_HAVE_MADVISE_HUGE
-#endif
+// #ifdef __GLIBC__
+// #define JEMALLOC_HAVE_MADVISE_HUGE
+// #endif
 
 /*
  * Methods for purging unused pages differ between operating systems.

--- a/extension/jemalloc/jemalloc/src/pages.c
+++ b/extension/jemalloc/jemalloc/src/pages.c
@@ -649,8 +649,7 @@ os_overcommits_sysctl(void) {
 static bool
 os_overcommits_proc(void) {
 	int fd;
-	char buf[1];
-	buf[0] = '2';
+	char buf[1] = {'0'};
 
 #if defined(JEMALLOC_USE_SYSCALL) && defined(SYS_open)
 	#if defined(O_CLOEXEC)


### PR DESCRIPTION
This led to accessing uninitialized memory on systems that did not have it, and I don't think it's an important setting anyway.

Found by this run: https://github.com/duckdb/duckdb/actions/runs/10587966052/job/29339688673

I've also changed the initialization of a buffer I set in #13564 to match the default on Linux.