### PR TITLE
Optimistic write to WAL: we cannot optimistically write block pointers if there are indexes

### DIFF
--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -308,6 +308,10 @@ void SingleFileStorageCommitState::AddRowGroupData(DataTable &table, idx_t start
 		// cannot serialize optimistic block pointers if in-memory updates exist
 		return;
 	}
+	if (table.HasIndexes()) {
+		// cannot serialize optimistic block pointers if the table has indexes
+		return;
+	}
 	auto &entries = optimistically_written_data[table];
 	auto entry = entries.find(start_index);
 	if (entry != entries.end()) {


### PR DESCRIPTION
CC @taniabogatsch 

Follow-up fix from https://github.com/duckdb/duckdb/pull/13372, similar to https://github.com/duckdb/duckdb/pull/13577

We could make this work by inserting into the indexes in `WriteAheadLogDeserializer::ReplayRowGroupData` - but for now we just disable this if there are indexes in the table.