### PR TITLE
Fix secret manager issue

### DIFF
--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -208,10 +208,13 @@ public:
 	DefaultSecretGenerator(Catalog &catalog, SecretManager &secret_manager, case_insensitive_set_t &persistent_secrets);
 
 public:
+	unique_ptr<CatalogEntry> CreateDefaultEntry(CatalogTransaction transaction, const string &entry_name) override;
 	unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) override;
 	vector<string> GetDefaultEntries() override;
 
 protected:
+	unique_ptr<CatalogEntry> CreateDefaultEntryInternal(const string &entry_name);
+
 	SecretManager &secret_manager;
 	case_insensitive_set_t persistent_secrets;
 };

--- a/test/sql/secrets/create_secret_persistence_no_client_context.test
+++ b/test/sql/secrets/create_secret_persistence_no_client_context.test
@@ -1,0 +1,28 @@
+# name: test/sql/secrets/create_secret_persistence_no_client_context.test
+# description: Test using secret manager in a codepath where no ClientContext is available
+# group: [secrets]
+
+load __TEST_DIR__/create_secret_persistence_no_client_context.db
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+set secret_directory='__TEST_DIR__/create_secret_persistence_error_handling'
+
+# Create an empty HTTP type secret
+statement ok
+CREATE PERSISTENT SECRET s1 ( TYPE HTTP )
+
+restart
+
+statement ok
+set secret_directory='__TEST_DIR__/create_secret_persistence_error_handling'
+
+# Try to install a fake extensions from some bogus url.
+# This will trigger Secret manager initialization in a way where there is no ClientContext available
+# if secret manager is correctly initialized the request will happen and return the correct error. 
+statement error
+INSTALL bogus FROM 'http://not.existent';
+----
+Failed to download extension


### PR DESCRIPTION
Fix issue where secret manager would fail to initialize leading to the error:  `INTERNAL Error: Failed to create default entry for` when trying to install an extensions (which triggers a codepath where there is no ClientContext available)