### PR TITLE
Fix url link of `our installation page` to avoid `Connection not secure`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information on using DuckDB, please refer to the [DuckDB documentation]
 
 ## Installation
 
-If you want to install DuckDB, please see [our installation page](https://www.duckdb.org/docs/installation) for instructions.
+If you want to install DuckDB, please see [our installation page](https://duckdb.org/docs/installation) for instructions.
 
 ## Data Import
 


### PR DESCRIPTION
This issue pertains to [duckdb-web](https://github.com/duckdb/duckdb-web) issue but fixed the link first.

## Issue Description:

I navigated to the DuckDB Installation page from the README, and encountered a Connection not secure error.

## Steps to Reproduce:

- Access the DuckDB Installation page via the [our installation page](https://www.duckdb.org/docs/installation) link in the README.
- Observe the `Connection not secure error`.

## Browsers Tested:

- Firefox
-  Firefox Developer Edition
- Chrome
- Chrome App

## Results:

- The error occurs on Firefox, Firefox Developer Edition, and the Chrome App.
- No issues were observed when testing with the Chrome browser.

## Expected Behavior:

The link of DuckDB Installation page should be secure.