### PR TITLE
[Fix] list_reduce and list_resize fixes

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1546,6 +1546,7 @@ void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count)
 	if (type.InternalType() == PhysicalType::STRUCT) {
 		auto &child_types = StructType::GetChildTypes(type);
 		D_ASSERT(!child_types.empty());
+
 		// create a selection vector of the non-null entries of the struct vector
 		auto &children = StructVector::GetEntries(*vector);
 		D_ASSERT(child_types.size() == children.size());

--- a/src/core_functions/scalar/struct/struct_pack.cpp
+++ b/src/core_functions/scalar/struct/struct_pack.cpp
@@ -18,7 +18,7 @@ static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &
 #endif
 	bool all_const = true;
 	auto &child_entries = StructVector::GetEntries(result);
-	for (size_t i = 0; i < args.ColumnCount(); i++) {
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
 		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
 			all_const = false;
 		}
@@ -26,7 +26,6 @@ static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &
 		child_entries[i]->Reference(args.data[i]);
 	}
 	result.SetVectorType(all_const ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
-
 	result.Verify(args.size());
 }
 

--- a/src/include/duckdb/core_functions/lambda_functions.hpp
+++ b/src/include/duckdb/core_functions/lambda_functions.hpp
@@ -104,7 +104,6 @@ public:
 			// get the list column entries
 			list_column.ToUnifiedFormat(row_count, list_column_format);
 			list_entries = UnifiedVectorFormat::GetData<list_entry_t>(list_column_format);
-
 			child_vector = &ListVector::GetEntry(list_column);
 
 			// get the lambda column data for all other input vectors

--- a/test/sql/function/list/lambdas/reduce.test
+++ b/test/sql/function/list/lambdas/reduce.test
@@ -1,4 +1,4 @@
-# name: test/sql/function/list/lambdas/reduce.test_slow
+# name: test/sql/function/list/lambdas/reduce.test
 # description: Test list_reduce function
 # group: [lambdas]
 
@@ -351,37 +351,6 @@ SELECT list_reduce(n, (x, y) -> list_pack(list_reduce(x, (l, m) -> list_pack(lis
 [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 NULL
 [[NULL, 60], [70, NULL], [NULL, NULL]]
-
-# very large lists
-
-statement ok
-CREATE TABLE large_lists AS SELECT range % 4 g, list(range) l FROM range(10000) GROUP BY range % 4;
-
-query I
-SELECT list_reduce(l, (x, y) -> least(x, y)) FROM large_lists ORDER BY g;
-----
-0
-1
-2
-3
-
-query I
-SELECT list_reduce(l, (x, y) -> x + y) FROM large_lists ORDER BY g;
-----
-12495000
-12497500
-12500000
-12502500
-
-# very large table
-
-statement ok
-CREATE TABLE large_table AS SELECT list_reduce(range(5000), (x, y) -> x + y) as l FROM range(1000);
-
-query I
-SELECT count(*) from large_table where l = 12497500;
-----
-1000
 
 # list_reduce in where clause
 

--- a/test/sql/function/list/lambdas/reduce_on_larger_data.test_slow
+++ b/test/sql/function/list/lambdas/reduce_on_larger_data.test_slow
@@ -1,0 +1,34 @@
+# name: test/sql/function/list/lambdas/reduce_on_larger_data.test_slow
+# description: Test list_reduce function on larger data
+# group: [lambdas]
+
+# large lists
+
+statement ok
+CREATE TABLE large_lists AS SELECT range % 4 g, list(range) l FROM range(10000) GROUP BY range % 4;
+
+query I
+SELECT list_reduce(l, (x, y) -> least(x, y)) FROM large_lists ORDER BY g;
+----
+0
+1
+2
+3
+
+query I
+SELECT list_reduce(l, (x, y) -> x + y) FROM large_lists ORDER BY g;
+----
+12495000
+12497500
+12500000
+12502500
+
+# large table
+
+statement ok
+CREATE TABLE large_table AS SELECT list_reduce(range(5000), (x, y) -> x + y) as l FROM range(1000);
+
+query I
+SELECT count(*) from large_table where l = 12497500;
+----
+1000

--- a/test/sql/types/nested/list/test_list_functions_with_null_structs.test
+++ b/test/sql/types/nested/list/test_list_functions_with_null_structs.test
@@ -9,7 +9,7 @@ statement ok
 CREATE TABLE struct_data(str STRUCT(val VARCHAR)[]);
 
 statement ok
-INSERT INTO struct_data values (NULL);
+INSERT INTO struct_data VALUES (NULL);
 
 query I
 SELECT list_resize(str, 1) FROM struct_data;
@@ -40,7 +40,7 @@ NULL
 
 endloop
 
-# Add another nesting level.
+# NULL in a STRUCT.
 
 statement ok
 CREATE TABLE nested_struct_data(str STRUCT(str_nested STRUCT(val VARCHAR))[]);
@@ -58,18 +58,32 @@ SELECT list_filter(str, x -> x.str_nested IS NULL) FROM nested_struct_data;
 ----
 [NULL]
 
-# Add another list level.
+# Two list nesting levels.
 
 statement ok
 CREATE TABLE struct_data_two_lists(str STRUCT(val VARCHAR)[][]);
 
 statement ok
-INSERT INTO struct_data_two_lists values (NULL);
+INSERT INTO struct_data_two_lists VALUES (NULL);
 
 query I
 SELECT flatten(str) FROM struct_data_two_lists;
 ----
 NULL
+
+# Nested STRUCTs.
+
+statement ok
+CREATE TABLE many_structs_data(str1 STRUCT(val VARCHAR, str2 STRUCT(val INT[]))[]);
+
+statement ok
+INSERT INTO many_structs_data VALUES (NULL), ([{'val': 'hello', 'str2': NULL}, (NULL, NULL), {'val': 'world', 'str2': {'val': [1, 2]}}]);
+
+query I
+SELECT list_reduce(str1, (a, b) -> a) FROM many_structs_data;
+----
+NULL
+{'val': hello, 'str2': NULL}
 
 # Original issue.
 

--- a/test/sql/types/nested/list/test_list_functions_with_null_structs.test
+++ b/test/sql/types/nested/list/test_list_functions_with_null_structs.test
@@ -1,0 +1,151 @@
+# name: test/sql/types/nested/list/test_list_functions_with_null_structs.test
+# description: Test correctly reserving the child vector size in the presence of NULL.
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE struct_data(str STRUCT(val VARCHAR)[]);
+
+statement ok
+INSERT INTO struct_data values (NULL);
+
+query I
+SELECT list_resize(str, 1) FROM struct_data;
+----
+NULL
+
+query I
+SELECT list_reduce(str, (a, b) -> a) FROM struct_data;
+----
+NULL
+
+query I
+SELECT str[1] FROM struct_data;
+----
+NULL
+
+query I
+SELECT list_aggregate(str, 'count') FROM struct_data;
+----
+NULL
+
+foreach f array_pop_back array_pop_front len list_any_value list_distinct list_grade_up list_reverse_sort list_reverse list_sort list_unique
+
+query I
+SELECT ${f}(str) FROM struct_data;
+----
+NULL
+
+endloop
+
+# Add another nesting level.
+
+statement ok
+CREATE TABLE nested_struct_data(str STRUCT(str_nested STRUCT(val VARCHAR))[]);
+
+statement ok
+INSERT INTO nested_struct_data VALUES ([NULL]);
+
+query I
+SELECT list_transform(str, x -> x) FROM nested_struct_data;
+----
+[NULL]
+
+query I
+SELECT list_filter(str, x -> x.str_nested IS NULL) FROM nested_struct_data;
+----
+[NULL]
+
+# Add another list level.
+
+statement ok
+CREATE TABLE struct_data_two_lists(str STRUCT(val VARCHAR)[][]);
+
+statement ok
+INSERT INTO struct_data_two_lists values (NULL);
+
+query I
+SELECT flatten(str) FROM struct_data_two_lists;
+----
+NULL
+
+# Original issue.
+
+query IIIII
+WITH foo AS (
+    SELECT str.reduce((a, b) -> a) AS str FROM struct_data
+)
+SELECT str, str.val, str.val = '', str.val IS NULL, str IS NULL FROM foo;
+----
+NULL	NULL	NULL	true	true
+
+statement ok
+CREATE TABLE filter_data(foo text[]);
+
+statement ok
+INSERT INTO filter_data VALUES
+    (['some value']),
+    (['some value', 'other value']),
+    (['some value', 'other value', 'some value']),
+    (['some value', 'other value', 'some value', 'other value']),
+    (['some value', 'other value', 'some value', 'other value', 'some value']),
+    (['some value', 'other value', 'some value', 'other value', 'some value', 'other value']),
+    (['some value', 'other value', 'some value', 'other value', 'some value', 'other value', 'some value']);
+
+query II
+with
+    transformed as (
+        select
+            foo.list_transform(
+                x -> struct_pack(val := x, conflict := false)
+            ).reduce(
+                (res, x) -> case
+                    when res.conflict then res
+                    when res.val = x.val then res
+                    else struct_pack(val := null, conflict := true)
+                end
+            ) as result
+        from filter_data
+    )
+select
+    result,
+    result.val = ''
+from transformed
+;
+----
+{'val': some value, 'conflict': false}	false
+{'val': NULL, 'conflict': true}	NULL
+{'val': NULL, 'conflict': true}	NULL
+{'val': NULL, 'conflict': true}	NULL
+{'val': NULL, 'conflict': true}	NULL
+{'val': NULL, 'conflict': true}	NULL
+{'val': NULL, 'conflict': true}	NULL
+
+query II
+with
+    data_(foo) as (values
+        (null::text[]),
+        (['a', 'b', 'c'])
+    ), transformed as (
+        select
+            foo.list_transform(
+                x -> struct_pack(val := x, conflict := false)
+            ).reduce(
+                (res, x) -> case
+                    when res.conflict then res
+                    when res.val = x.val then res
+                    else struct_pack(val := null, conflict := true)
+                end
+            ) as result
+        from data_
+    )
+select
+    result,
+    result.val = ''
+from transformed
+;
+----
+NULL	NULL
+{'val': NULL, 'conflict': true}	NULL

--- a/test/sql/types/nested/list/test_list_functions_with_null_structs.test
+++ b/test/sql/types/nested/list/test_list_functions_with_null_structs.test
@@ -95,25 +95,19 @@ INSERT INTO filter_data VALUES
     (['some value', 'other value', 'some value', 'other value', 'some value', 'other value', 'some value']);
 
 query II
-with
-    transformed as (
-        select
-            foo.list_transform(
+WITH transformed AS (
+	SELECT foo.list_transform(
                 x -> struct_pack(val := x, conflict := false)
             ).reduce(
-                (res, x) -> case
-                    when res.conflict then res
-                    when res.val = x.val then res
-                    else struct_pack(val := null, conflict := true)
-                end
-            ) as result
-        from filter_data
+                (res, x) -> CASE
+                    WHEN res.conflict THEN res
+                    WHEN res.val = x.val THEN res
+                    ELSE struct_pack(val := null, conflict := true)
+					END
+            ) AS result
+        FROM filter_data
     )
-select
-    result,
-    result.val = ''
-from transformed
-;
+SELECT result, result.val = '' FROM transformed;
 ----
 {'val': some value, 'conflict': false}	false
 {'val': NULL, 'conflict': true}	NULL
@@ -124,28 +118,21 @@ from transformed
 {'val': NULL, 'conflict': true}	NULL
 
 query II
-with
-    data_(foo) as (values
-        (null::text[]),
-        (['a', 'b', 'c'])
-    ), transformed as (
-        select
+WITH data_(foo) AS (VALUES (null::text[]), (['a', 'b', 'c'])
+    ), transformed AS (
+        SELECT
             foo.list_transform(
                 x -> struct_pack(val := x, conflict := false)
             ).reduce(
-                (res, x) -> case
-                    when res.conflict then res
-                    when res.val = x.val then res
-                    else struct_pack(val := null, conflict := true)
-                end
-            ) as result
-        from data_
+                (res, x) -> CASE
+                    WHEN res.conflict THEN res
+                    WHEN res.val = x.val THEN res
+                    ELSE struct_pack(val := null, conflict := true)
+                	END
+            ) AS result
+        FROM data_
     )
-select
-    result,
-    result.val = ''
-from transformed
-;
+SELECT result, result.val = '' FROM transformed;
 ----
 NULL	NULL
 {'val': NULL, 'conflict': true}	NULL


### PR DESCRIPTION
This fixes three issues.

- `list_resize` failed due to a `NULL` row and a `new_size > 0`: we did not resize the child vector.
- `list_reduce` failed due to a `NULL STRUCT`: we did not set the child vectors to invalid.
- `list_reduce` failed due to repeated references in the loop: we would not persist beyond two iterations. 

Fixes https://github.com/duckdb/duckdb/issues/13444.