### PR TITLE
Fix secret test failure

### DIFF
--- a/test/sql/secrets/create_secret_persistence_no_client_context.test
+++ b/test/sql/secrets/create_secret_persistence_no_client_context.test
@@ -8,7 +8,7 @@ statement ok
 PRAGMA enable_verification;
 
 statement ok
-set secret_directory='__TEST_DIR__/create_secret_persistence_error_handling'
+set secret_directory='__TEST_DIR__/create_secret_persistence_no_client_context'
 
 # Create an empty HTTP type secret
 statement ok
@@ -17,7 +17,7 @@ CREATE PERSISTENT SECRET s1 ( TYPE HTTP )
 restart
 
 statement ok
-set secret_directory='__TEST_DIR__/create_secret_persistence_error_handling'
+set secret_directory='__TEST_DIR__/create_secret_persistence_no_client_context'
 
 # Try to install a fake extensions from some bogus url.
 # This will trigger Secret manager initialization in a way where there is no ClientContext available

--- a/test/sql/secrets/create_secret_r2.test
+++ b/test/sql/secrets/create_secret_r2.test
@@ -8,7 +8,7 @@ PRAGMA enable_verification;
 require httpfs
 
 statement ok
-set secret_directory='__TEST_DIR__'
+set secret_directory='__TEST_DIR__/create_secret_r2'
 
 # R2 is secrets will instead of requiring manually constructing the endpoint of <ACCOUNT_ID>.r2.cloudflarestorage.com,
 # use the account_id to configure it. Also the region is not required at all. Also the scope defaults to r2://


### PR DESCRIPTION
The persistent secret directory used in tests should be unique, convention is now just the name of the test which makes it easy to find the right test in the tmp test dir when debugging.

Perhaps we could look into doing this automatically later, to reduce chance of copy errors like this, but that could also be confusing