### PR TITLE
Issue #13602: Window Test Race

### DIFF
--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -353,7 +353,7 @@ public:
 		return !stopped && next_task < tasks.size();
 	}
 	bool HasUnfinishedTasks() const {
-		return !stopped && finished < tasks.size();
+		return !stopped.load() && finished.load() < tasks.size();
 	}
 	//! Try to advance the group stage
 	bool TryPrepareNextStage();


### PR DESCRIPTION
Add load() calls to to HasUnfinishedTasks.
This seems to fix the problem (which is
the function sometimes always returning true)
but I don't understand why.

fixes: duckdb#13602
fixes: duckdblabs/duckdb-internal#2895