### PR TITLE
fix USE not affecting tables referenced after the ON keyword in CREATE INDEX #13643

### DIFF
--- a/src/parser/parsed_data/create_index_info.cpp
+++ b/src/parser/parsed_data/create_index_info.cpp
@@ -4,7 +4,7 @@
 
 namespace duckdb {
 
-CreateIndexInfo::CreateIndexInfo() : CreateInfo(CatalogType::INDEX_ENTRY) {
+CreateIndexInfo::CreateIndexInfo() : CreateInfo(CatalogType::INDEX_ENTRY, INVALID_SCHEMA) {
 }
 
 CreateIndexInfo::CreateIndexInfo(const duckdb::CreateIndexInfo &info)

--- a/test/sql/create/create_index_on_issue_13643.test
+++ b/test/sql/create/create_index_on_issue_13643.test
@@ -1,0 +1,21 @@
+# name: test/sql/create/create_index_on_issue_13643.test
+# description: Issue #13643 - USE not affecting tables referenced after the ON keyword in CREATE INDEX
+# group: [create]
+
+statement ok
+CREATE SCHEMA db0;
+
+statement ok
+USE db0;
+
+statement ok
+CREATE TABLE t0 (a BIGINT PRIMARY KEY, b INT, c INT);
+
+statement ok
+CREATE INDEX t0_idx ON t0 (b);
+
+statement ok
+CREATE UNIQUE INDEX t0_uidx ON t0 (c);
+
+statement ok
+CREATE UNIQUE INDEX t0_uidx2 ON db0.t0 (c);


### PR DESCRIPTION
fix #13643  by handling it similarly to CREATE VIEW https://github.com/duckdb/duckdb/blob/7691b57aa1ef638c4b825c388b1bd2877a4e8ec4/src/parser/parsed_data/create_view_info.cpp#L11


