### PR TITLE
Temporary remove delta (that currently builds only on OSX anyhow)

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -45,13 +45,13 @@ endif()
 ################# DELTA
 # MinGW build is not available, and our current manylinux ci does not have enough storage space to run the rust build
 # for Delta
-if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT WIN32)
-    duckdb_extension_load(delta
-            LOAD_TESTS
-            GIT_URL https://github.com/duckdb/duckdb_delta
-            GIT_TAG db45fc29f21c3638cd417c3a79394912465db84e
-    )
-endif()
+#if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT WIN32)
+#    duckdb_extension_load(delta
+#            LOAD_TESTS
+#            GIT_URL https://github.com/duckdb/duckdb_delta
+#            GIT_TAG db45fc29f21c3638cd417c3a79394912465db84e
+#    )
+#endif()
 
 ################# EXCEL
 duckdb_extension_load(excel


### PR DESCRIPTION
OSX builds, the only ones where this is used are failing, going to figure out compilation problem there first.

Given currently we rely on extension CI anyhow, and current status is broken, removing is more sane.