### PR TITLE
Fix #13602: exit window GetData loop if there are no more tasks available instead of looping until all tasks are finished

### DIFF
--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -761,7 +761,7 @@ bool WindowLocalSourceState::TryAssignTask() {
 bool WindowGlobalSourceState::TryPrepareNextStage() {
 	if (next_task >= tasks.size() || stopped) {
 		// cannot prepare next stage anymore - exit
-		return false;
+		return true;
 	}
 
 	auto task = &tasks[next_task];

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -760,7 +760,6 @@ bool WindowLocalSourceState::TryAssignTask() {
 
 bool WindowGlobalSourceState::TryPrepareNextStage() {
 	if (next_task >= tasks.size() || stopped) {
-		// cannot prepare next stage anymore - exit
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #13602