### PR TITLE
In scalar macro functions - allow creation of the macro if a ParameterNotResolvedException is thrown - and throw this when using macro bindings in table functions

### DIFF
--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -20,11 +20,16 @@ BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression>
 	// try binding as a lambda parameter
 	auto &col_ref = expr_ptr->Cast<ColumnRefExpression>();
 	if (!col_ref.IsQualified()) {
-		auto lambda_ref = LambdaRefExpression::FindMatchingBinding(lambda_bindings, col_ref.GetName());
+		auto column_name = col_ref.GetName();
+		auto lambda_ref = LambdaRefExpression::FindMatchingBinding(lambda_bindings, column_name);
 		if (lambda_ref) {
 			return BindLambdaReference(lambda_ref->Cast<LambdaRefExpression>(), depth);
 		}
+		if (binder.macro_binding && binder.macro_binding->HasMatchingBinding(column_name)) {
+			throw ParameterNotResolvedException();
+		}
 	}
+	auto query_location = col_ref.query_location;
 	auto column_names = col_ref.column_names;
 	auto result_name = StringUtil::Join(column_names, ".");
 	if (!table_function_name.empty()) {
@@ -32,8 +37,9 @@ BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression>
 		auto result = BindCorrelatedColumns(expr_ptr, ErrorData("error"));
 		if (!result.HasError()) {
 			// it is a lateral join parameter - this is not supported in this type of table function
-			throw BinderException("Table function \"%s\" does not support lateral join column parameters - cannot use "
-			                      "column \"%s\" in this context",
+			throw BinderException(query_location,
+			                      "Table function \"%s\" does not support lateral join column parameters - cannot use "
+			                      "column \"%s\" in this context.\nThe function only supports literals as parameters.",
 			                      table_function_name, result_name);
 		}
 	}

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/table_binding.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 

--- a/test/sql/catalog/function/macro_query_table.test
+++ b/test/sql/catalog/function/macro_query_table.test
@@ -1,0 +1,35 @@
+# name: test/sql/catalog/function/macro_query_table.test
+# description: Test using a scalar macro with the query_table function
+# group: [function]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create macro min_from_tbl(tbl, col) as (select min(col) from query_table(tbl::VARCHAR));
+
+statement ok
+create table integers as from range(100) t(i)
+
+query I
+SELECT min_from_tbl(integers, i)
+----
+0
+
+# column does not exist
+statement error
+SELECT min_from_tbl(integers, k)
+----
+not found in FROM clause
+
+# table does not exist
+statement error
+SELECT min_from_tbl(integers2, i)
+----
+Table with name integers2 does not exist
+
+# using a non-scalar parameter is not supported
+statement error
+SELECT min_from_tbl(tbl_name, i) from (values ('integers')) t(tbl_name);
+----
+tbl_name


### PR DESCRIPTION
This allows parameters in macros to be used in table functions, as long as the parameters are literals at query time. For example:

```sql
D create macro min_parquet(parquet_file, column_name) as (select min(column_name) from read_parquet(parquet_file));
D select min_parquet(data.parquet, id) as id;
┌──────────────────────────────────────┐
│                  id                  │
│               varchar                │
├──────────────────────────────────────┤
│ 00000418-df28-4e81-9410-15c92916dd5d │
└──────────────────────────────────────┘

``` 
