### PR TITLE
Avoid short-circuiting to cut on TABLE_IN_OUT_FUNCTION

### DIFF
--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -36,9 +36,6 @@ static TableFunctionBindType GetTableFunctionBindType(TableFunctionCatalogEntry 
 			break;
 		}
 	}
-	if (all_scalar) {
-		return TableFunctionBindType::STANDARD_TABLE_FUNCTION;
-	}
 	// if we have non-scalar parameters - we need to look at the function definition to decide how to bind
 	// if a function does not have an in_out_function defined, we need to bind as a standard table function regardless
 	bool has_in_out_function = false;
@@ -59,6 +56,10 @@ static TableFunctionBindType GetTableFunctionBindType(TableFunctionCatalogEntry 
 			throw InternalException("Function \"%s\" has neither in_out_function nor function defined",
 			                        table_function.name);
 		}
+	}
+	if (all_scalar) {
+		return has_in_out_function ? TableFunctionBindType::TABLE_IN_OUT_FUNCTION
+		                           : TableFunctionBindType::STANDARD_TABLE_FUNCTION;
 	}
 	if (has_table_parameter) {
 		if (table_function.functions.Size() != 1) {

--- a/test/sql/function/table/unnest_range_in_out.test
+++ b/test/sql/function/table/unnest_range_in_out.test
@@ -1,0 +1,25 @@
+# name: test/sql/function/table/unnest_range_in_out.test
+# description: Test on unnest(range) being in-out function
+# group: [table]
+
+query I
+select (select pi()) from range(0,2);
+----
+3.141592653589793
+3.141592653589793
+
+query I
+select (select pi()) from unnest( range(0,2) );
+----
+3.141592653589793
+3.141592653589793
+
+query I
+SELECT sum(a) FROM RANGE(1, 2) _ (a);
+----
+1
+
+query I
+SELECT sum(a) FROM unnest(RANGE(1, 2)) _ (a);
+----
+1


### PR DESCRIPTION
Attempt at fixing https://github.com/duckdb/duckdb/issues/13664 and https://github.com/duckdb/duckdb/issues/13666, and adding test checking that.

This is more a draft / experiment, I am not really comfortable with the code changes without some more backing, opening as a draft to get feedback.
Based on the investigation by @cpcloud in https://github.com/duckdb/duckdb/issues/13666#issuecomment-2322903801 (thanks!).