### PR TITLE
function chaining alias in where clause

### DIFF
--- a/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/column_alias_binder.hpp
@@ -23,6 +23,8 @@ public:
 
 	bool BindAlias(ExpressionBinder &enclosing_binder, unique_ptr<ParsedExpression> &expr_ptr, idx_t depth,
 	               bool root_expression, BindResult &result);
+	// Check if the column reference is an SELECT item alias.
+	bool QualifyColumnAlias(const ColumnRefExpression &colref);
 
 private:
 	SelectBindState &bind_state;

--- a/src/include/duckdb/planner/expression_binder/where_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/where_binder.hpp
@@ -24,6 +24,7 @@ protected:
 	                          bool root_expression = false) override;
 
 	string UnsupportedAggregateMessage() override;
+	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
 
 private:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression);

--- a/src/planner/expression_binder/column_alias_binder.cpp
+++ b/src/planner/expression_binder/column_alias_binder.cpp
@@ -43,4 +43,11 @@ bool ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, unique_ptr
 	return true;
 }
 
+bool ColumnAliasBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
+	if (!colref.IsQualified()) {
+		return bind_state.alias_map.find(colref.column_names[0]) != bind_state.alias_map.end();
+	}
+	return false;
+}
+
 } // namespace duckdb

--- a/src/planner/expression_binder/where_binder.cpp
+++ b/src/planner/expression_binder/where_binder.cpp
@@ -43,4 +43,11 @@ string WhereBinder::UnsupportedAggregateMessage() {
 	return "WHERE clause cannot contain aggregates!";
 }
 
+bool WhereBinder::QualifyColumnAlias(const ColumnRefExpression &colref) {
+	if (column_alias_binder) {
+		return column_alias_binder->QualifyColumnAlias(colref);
+	}
+	return false;
+}
+
 } // namespace duckdb

--- a/test/sql/binder/test_function_chainging_alias.test
+++ b/test/sql/binder/test_function_chainging_alias.test
@@ -2,8 +2,6 @@
 # description: referencing an alias or a function chaining alias that exists earlier on
 # group: [binder]
 
-#              in the SELECT clause (Issue #7190)
-
 statement ok
 PRAGMA enable_verification
 
@@ -91,3 +89,43 @@ query III
 EXECUTE v1('Hello World', 'test function chainging')
 ----
 [hello, world]	[TEST, FUNCTION, CHAINGING]	[hello, world, TEST, FUNCTION, CHAINGING]
+
+statement ok
+INSERT INTO varchars VALUES ('Another longggggg String');
+
+# alias in where clause
+query IIII
+SELECT  v.split(' ') strings,
+        strings.apply(x -> x.lower()).filter(x -> x[1] == 't' or x[1] == 'a') lower,
+        strings.apply(x -> x.upper()).filter(x -> x[1] == 'T' or x[1] == 'A') upper,
+        lower + upper  as mix_case_srings
+FROM varchars
+WHERE mix_case_srings[1] = 'test'
+----
+[Test, Function, Chainging, Alias]	[test, alias]	[TEST, ALIAS]	[test, alias, TEST, ALIAS]
+
+
+query IIII
+SELECT  v.split(' ') strings,
+        strings.apply(x -> x.lower()).filter(x -> x[1] == 't' or x[1] == 'a') lower,
+        strings.apply(x -> x.upper()).filter(x -> x[1] == 'T' or x[1] == 'A') upper,
+        lower + upper  as mix_case_srings
+FROM varchars
+WHERE mix_case_srings[1] = 'another'
+----
+[Another, longggggg, String]	[another]	[ANOTHER]	[another, ANOTHER]
+
+# CTE with function chaining alias
+query II
+with test as (
+    select 'woot' as my_column
+)
+from test
+select 
+    my_column.substr(2) as partial_woot,
+    partial_woot.substr(2) as more_partially_woot
+where 
+    more_partially_woot = 'ot'
+;
+----
+oot	ot


### PR DESCRIPTION
fix #11854

```sql
with test as (
    select 'woot' as my_column
)
from test
select 
    my_column.substr(2) as partial_woot,
    partial_woot.substr(2) as more_partially_woot
where 
    more_partially_woot = 'ot'
;
 
 
 ┌──────────────┬─────────────────────┐
│ partial_woot │ more_partially_woot │
│   varchar    │       varchar       │
├──────────────┼─────────────────────┤
│ oot          │ ot                  │
└──────────────┴─────────────────────┘

```