### PR TITLE
Fix logic error in `TemporaryMemoryManager`

### DIFF
--- a/test/sql/join/external/many_external_joins.test_slow
+++ b/test/sql/join/external/many_external_joins.test_slow
@@ -19,7 +19,7 @@ SET memory_limit='500mb';
 
 # disable the join order optimizer to be sure we probe all HTs in a single pipeline
 statement ok
-SET disabled_optimizers TO 'join_order';
+SET disabled_optimizers TO 'join_order,build_side_probe_side';
 
 # we shouldn't run out of memory
 query IIIII


### PR DESCRIPTION
I don't think this PR makes any difference in how memory is assigned, but there was a logic error that needed to be fixed.