### PR TITLE
Fix #13666: avoid executing table in-out functions in parallel when executing on a single input

### DIFF
--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -213,4 +213,13 @@ bool PhysicalTableScan::Equals(const PhysicalOperator &other_p) const {
 	return true;
 }
 
+bool PhysicalTableScan::ParallelSource() const {
+	if (!function.function) {
+		// table in-out functions cannot be executed in parallel as part of a PhysicalTableScan
+		// since they have only a single input row
+		return false;
+	}
+	return true;
+}
+
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -66,9 +66,7 @@ public:
 	bool IsSource() const override {
 		return true;
 	}
-	bool ParallelSource() const override {
-		return true;
-	}
+	bool ParallelSource() const override;
 
 	bool SupportsBatchIndex() const override {
 		return function.get_batch_index != nullptr;

--- a/test/sql/types/list/unnest_aggregate.test
+++ b/test/sql/types/list/unnest_aggregate.test
@@ -1,0 +1,11 @@
+# name: test/sql/types/list/unnest_aggregate.test
+# description: Test unnest semantics with NULL and empty lists
+# group: [list]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT SUM(a) FROM UNNEST(RANGE(1, 11)) t(a);
+----
+55

--- a/test/sql/types/list/unnest_aggregate.test
+++ b/test/sql/types/list/unnest_aggregate.test
@@ -9,3 +9,12 @@ query I
 SELECT SUM(a) FROM UNNEST(RANGE(1, 11)) t(a);
 ----
 55
+
+statement ok
+create or replace function rnv(a,b) as (select a + b * pi());
+
+query I
+select rnv(0, 1) from unnest( range(0,2) );
+----
+3.141592653589793
+3.141592653589793


### PR DESCRIPTION
Fixes #13666
Fixes #13664 
Fixes #13639

As part of https://github.com/duckdb/duckdb/pull/12431 we added support for executing table in-out functions as regular table scans if their parameters are literals, to keep query plans more readable and keep plans backwards compatible. However, if parameters are literal - we cannot execute these in parallel as there is only a single row to operate on. We were incorrectly scheduling multiple threads to work on the same table in-out function, that would lead to duplicate results being emitted by each thread. This PR fixes the issue by disabling parallelism in this scenario.