### PR TITLE
[Fix] Set the dirty flag when splitting a prefix

### DIFF
--- a/src/execution/index/art/prefix.cpp
+++ b/src/execution/index/art/prefix.cpp
@@ -251,7 +251,7 @@ void Prefix::Reduce(ART &art, Node &node, const idx_t pos) {
 GateStatus Prefix::Split(ART &art, reference<Node> &node, Node &child, const uint8_t pos) {
 	D_ASSERT(node.get().HasMetadata());
 
-	Prefix prefix(art, node);
+	Prefix prefix(art, node, true);
 
 	// The split is at the last prefix byte. Decrease the count and return.
 	if (pos + 1 == Count(art)) {

--- a/test/sql/attach/attach_index.test
+++ b/test/sql/attach/attach_index.test
@@ -8,10 +8,10 @@ require noforcestorage
 require skip_reload
 
 statement ok
-ATTACH '__TEST_DIR__/index_db.db'
+ATTACH '__TEST_DIR__/attach_index_db.db'
 
 statement ok
-USE index_db
+USE attach_index_db
 
 statement ok
 CREATE TABLE tbl_a (a_id INTEGER PRIMARY KEY, value VARCHAR NOT NULL)
@@ -20,13 +20,13 @@ statement ok
 CREATE INDEX idx_tbl_a ON tbl_a (value)
 
 statement ok
-INSERT INTO tbl_a VALUES(1, 'x')
+INSERT INTO tbl_a VALUES (1, 'x')
 
 statement ok
-INSERT INTO tbl_a VALUES(2, 'y')
+INSERT INTO tbl_a VALUES (2, 'y')
 
 query II
-SELECT * FROM tbl_a WHERE a_id=2
+SELECT * FROM tbl_a WHERE a_id = 2
 ----
 2	y
 
@@ -34,12 +34,12 @@ statement ok
 USE memory
 
 statement ok
-DETACH index_db
+DETACH attach_index_db
 
 statement ok
-ATTACH '__TEST_DIR__/index_db.db'
+ATTACH '__TEST_DIR__/attach_index_db.db'
 
 query II
-SELECT * FROM index_db.tbl_a WHERE a_id=2
+SELECT * FROM attach_index_db.tbl_a WHERE a_id = 2
 ----
 2	y

--- a/test/sql/index/art/storage/test_art_duckdb_versions.test
+++ b/test/sql/index/art/storage/test_art_duckdb_versions.test
@@ -119,11 +119,6 @@ SELECT i FROM idx_tbl WHERE i = 11
 
 # now try to break it
 
-query I
-SELECT used_blocks < 2621440 / get_block_size('test_art_import') FROM pragma_database_size();
-----
-1
-
 statement ok
 INSERT INTO idx_tbl SELECT range, range, range FROM range(300000);
 


### PR DESCRIPTION
In addition to the `Prefix` fix, I removed the following query from `test_art_duckdb_versions.test`.
```sql
query I
SELECT used_blocks < 2621440 / get_block_size('test_art_import') FROM pragma_database_size();
----
1
```
With `LATEST_STORAGE=1`, we get a slight increase in storage size. When importing the database, we pass the WAL auto checkpoint flag, which leads to `used_blocks != 0`. I.e., the CI nightly test failure was expected behavior.

Addresses https://github.com/duckdblabs/duckdb-internal/issues/2885