### PR TITLE
[Fix] Apply array multiplier to child vector when slicing by offset

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -204,7 +204,9 @@ void Vector::Slice(const Vector &other, idx_t offset, idx_t end) {
 		auto &child_vec = ArrayVector::GetEntry(new_vector);
 		auto &other_child_vec = ArrayVector::GetEntry(other);
 		D_ASSERT(ArrayType::GetSize(GetType()) == ArrayType::GetSize(other.GetType()));
-		child_vec.Slice(other_child_vec, offset, end);
+		const auto array_size = ArrayType::GetSize(GetType());
+		// We need to slice the child vector with the multiplied offset and end
+		child_vec.Slice(other_child_vec, offset * array_size, end * array_size);
 		new_vector.validity.Slice(other.validity, offset, end - offset);
 		Reference(new_vector);
 	} else {

--- a/test/sql/types/nested/array/array_list_aggregate.test
+++ b/test/sql/types/nested/array/array_list_aggregate.test
@@ -1,0 +1,14 @@
+# name: test/sql/types/nested/array/array_list_aggregate.test
+# group: [array]
+
+statement ok
+CREATE TABLE t1 (a INT, b INT, c INT);
+
+statement ok
+INSERT INTO t1 VALUES (1,2,3), (4,5,6);
+
+query I
+SELECT list(array_value(a,b,c) ORDER By b) FROM t1 GROUP by c;
+----
+[[1, 2, 3]]
+[[4, 5, 6]]


### PR DESCRIPTION
Fixes an issue reported on the discord.

This used to produce the wrong result:
```sql
CREATE TABLE t1 (a INT, b INT, c INT);
INSERT INTO t1 VALUES (1,2,3), (4,5,6);
SELECT list(array_value(a,b,c) ORDER By b) FROM t1 GROUP by c;
┌───────────────────────────────────────┐
│ list(array_value(a, b, c) ORDER BY b) │
│             integer[3][]              │
├───────────────────────────────────────┤
│ [[1, 2, 3]]                           │
│ [[2, 3, 4]]                           │
└───────────────────────────────────────┘ 
-- ^ Wrong! the elements in the second array are jumbled!
```

Turns out we didn't apply the array multiplier to the child vector when slicing a vector using by offset/end and instead just sliced by the parent offset.