### PR TITLE
Fix extension version to DUCKDB_NORMALIZED_VERSION for in-tree extensions

### DIFF
--- a/.github/config/bundled_extensions.cmake
+++ b/.github/config/bundled_extensions.cmake
@@ -14,14 +14,14 @@
 #
 ## Extensions that are linked
 #
-duckdb_extension_load(icu EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(tpch EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(json EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(fts EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(parquet EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(autocomplete EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(icu)
+duckdb_extension_load(tpch)
+duckdb_extension_load(json)
+duckdb_extension_load(fts)
+duckdb_extension_load(parquet)
+duckdb_extension_load(autocomplete)
 
 #
 ## Extensions that are not linked, but we do want to test them as part of the release build
 #
-duckdb_extension_load(tpcds DONT_LINK EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(tpcds DONT_LINK)

--- a/.github/config/in_tree_extensions.cmake
+++ b/.github/config/in_tree_extensions.cmake
@@ -5,14 +5,14 @@
 #   EXTENSION_CONFIGS=.github/config/in_tree_extensions.cmake make
 #
 
-duckdb_extension_load(autocomplete EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(fts EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(httpfs EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(icu EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(json EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(parquet EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(tpcds EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
-duckdb_extension_load(tpch EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(autocomplete)
+duckdb_extension_load(fts)
+duckdb_extension_load(httpfs)
+duckdb_extension_load(icu)
+duckdb_extension_load(json)
+duckdb_extension_load(parquet)
+duckdb_extension_load(tpcds)
+duckdb_extension_load(tpch)
 
 # Test extension for the upcoming C CAPI extensions
 duckdb_extension_load(demo_capi DONT_LINK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1138,7 +1138,7 @@ function(duckdb_extension_load NAME)
   else()
     # For in-tree extensions of the default path, we set the extension version to GIT_COMMIT_HASH by default
     if ("${duckdb_extension_load_EXTENSION_VERSION}" STREQUAL "")
-      set(duckdb_extension_load_EXTENSION_VERSION ${GIT_COMMIT_HASH})
+      set(duckdb_extension_load_EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
     endif()
 
     # Local extension, default path

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -8,12 +8,12 @@
 # The local file is also loaded by the DuckDB CMake build but ignored by version control.
 
 # Parquet is loaded by default on every build as its a essential part of DuckDB
-duckdb_extension_load(parquet EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+duckdb_extension_load(parquet)
 
 # The Linux allocator has issues so we use jemalloc, but only on x86 because page sizes are fixed at 4KB.
 # Configuring jemalloc properly for 32bit is a hassle, and not worth it so we only enable on 64bit
 # If page sizes vary for an architecture (e.g., arm64), we cannot create a portable binary due to jemalloc config
 # FIXME: after configuring the jemalloc config, jemalloc should work on arm64 again (should try at some point)
 if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND (OS_ARCH STREQUAL "amd64" OR OS_ARCH STREQUAL "i386") AND NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS)
-    duckdb_extension_load(jemalloc EXTENSION_VERSION ${DUCKDB_NORMALIZED_VERSION})
+    duckdb_extension_load(jemalloc)
 endif()


### PR DESCRIPTION
Spin off of the comment here: https://github.com/duckdb/duckdb/pull/13591#issuecomment-2314721929, keeping the same logic but making it work in a wider range of cases.

#### On current main
```
git checkout main
git tag v1.0.1
BUILD_JSON=1 BUILD_PARQUET=1 GEN=ninja make
git tag -d v1.0.1
```
here parquet gets the version as `v1.0.1`, while JSON gets the commit's hash.

#### After this PR
```
git checkout fix_extension_version_to_normalized
git tag v1.0.1
BUILD_JSON=1 BUILD_PARQUET=1 GEN=ninja make
git tag -d v1.0.1
```
Both extensions do get `v1.0.1`.

This introduces no changes if not on releases.
Mostly relevant for statically linked extensions when CMake file with configurations are provided externally OR when extensions are specified with `BUILD_JSON=1` (like it's done in the brew build).

We might want to tighten/unify the ways to add extensions-in, but I think having the same uniform behaviour does makes sense.