### PR TITLE
CI fixes

### DIFF
--- a/test/sql/cte/materialized/test_cte_in_cte_materialized.test
+++ b/test/sql/cte/materialized/test_cte_in_cte_materialized.test
@@ -48,12 +48,13 @@ with cte1 as MATERIALIZED (Select i as j from a) select * from cte1 where j = (w
 ----
 42
 
+require noalternativeverify
+
+# same name, both get materialized with ALTERNATIVE_VERIFY, so we need 'noalternativeverify'
 query I
 with cte as materialized (Select i as j from a) select * from cte where j = (with cte as (select max(j) as j from cte) select j from cte);
 ----
 42
-
-require no_alternative_verify
 
 # refer to same-named CTE in a subquery expression
 statement error

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -47,12 +47,6 @@ statement error
 with cte1 as (select 42), cte1 as (select 42) select * FROM cte1;
 ----
 
-# reference to CTE before its actually defined
-query I
-with cte3 as (select ref2.j as i from cte1 as ref2), cte1 as (Select i as j from a), cte2 as (select ref.j+1 as k from cte1 as ref) select * from cte2 union all select * FROM cte3;
-----
-43
-42
 
 # multiple uses of same CTE
 query II
@@ -177,6 +171,26 @@ WITH RECURSIVE
   t(b) AS MATERIALIZED (
     (WITH helper(c) AS (
       SELECT 5
+    ), h1 AS
+    (SELECT * FROM helper h
+    UNION
+    SELECT 7 FROM helper h)
+    SELECT * FROM h1)
+  )
+SELECT * FROM t ORDER BY b;
+----
+5
+7
+
+require noalternativeverify
+
+# FIXME: this one should work with ALTERNATIVE_VERIFY, but doesn't yet
+# something wrong with binding a CTE inside a recursive CTE
+query I
+WITH RECURSIVE
+  t(b) AS MATERIALIZED (
+    (WITH helper(c) AS (
+      SELECT 5
     )
     SELECT * FROM helper h
     UNION
@@ -188,18 +202,9 @@ SELECT * FROM t ORDER BY b;
 5
 7
 
+# reference to CTE before its actually defined, can't with ALTERNATIVE_VERIFY because everything gets materialized
 query I
-WITH RECURSIVE
-  t(b) AS MATERIALIZED (
-    (WITH helper(c) AS (
-      SELECT 5
-    ), h1 AS
-    (SELECT * FROM helper h
-    UNION
-    SELECT 7 FROM helper h)
-    SELECT * FROM h1)
-  )
-SELECT * FROM t ORDER BY b;
+with cte3 as (select ref2.j as i from cte1 as ref2), cte1 as (Select i as j from a), cte2 as (select ref.j+1 as k from cte1 as ref) select * from cte2 union all select * FROM cte3;
 ----
-5
-7
+43
+42

--- a/test/sql/cte/test_issue_5673.test
+++ b/test/sql/cte/test_issue_5673.test
@@ -17,20 +17,6 @@ insert into orders values (1);
 statement ok
 insert into stg_orders values (1);
 
-statement error
-with
-orders as (
-    select * from stg_orders
-    where ordered_at >= (select max(ordered_at) from orders)
-),
-some_more_logic as (
-    select *
-    from orders
-)
-select * from some_more_logic;
-----
-Binder Error: Circular reference to CTE "orders", There are two possible solutions.
-
 query I
 with
 orders as (
@@ -44,3 +30,20 @@ some_more_logic as (
 select * from some_more_logic;
 ----
 1
+
+require noalternativeverify
+
+# this one needs 'noalternativeverify' otherwise the error message is different
+statement error
+with
+orders as (
+    select * from stg_orders
+    where ordered_at >= (select max(ordered_at) from orders)
+),
+some_more_logic as (
+    select *
+    from orders
+)
+select * from some_more_logic;
+----
+Binder Error: Circular reference to CTE "orders", There are two possible solutions.


### PR DESCRIPTION
Lock before purging jemalloc arenas, which fixes https://github.com/duckdblabs/duckdb-internal/issues/2875 and https://github.com/duckdblabs/duckdb-internal/issues/2916.

Add `require noalternativeverify` to a few CTE related tests, fixes https://github.com/duckdblabs/duckdb-internal/issues/2886