### PR TITLE
[Fix] Incorrect allocation size in temporary file management

### DIFF
--- a/scripts/test_block_sizes.py
+++ b/scripts/test_block_sizes.py
@@ -9,9 +9,6 @@ def execute_system_command(cmd):
         raise Exception
 
 
-current_dir = os.getcwd()
-build_dir = os.path.join(os.getcwd(), 'build', 'release')
-
 # run the fast tests and all storage-related tests
 # with a block size of 16KB and a standard vector size
 block_size = 16384

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -48,7 +48,7 @@ struct Storage {
 	//! The maximum block allocation size. This is the maximum size currently supported by duckdb.
 	constexpr static idx_t MAX_BLOCK_ALLOC_SIZE = 262144ULL;
 	//! The default block header size for blocks written to storage.
-	constexpr static idx_t DEFAULT_BLOCK_HEADER_SIZE = sizeof(uint64_t);
+	constexpr static idx_t DEFAULT_BLOCK_HEADER_SIZE = sizeof(idx_t);
 	//! The default block size.
 	constexpr static idx_t DEFAULT_BLOCK_SIZE = DEFAULT_BLOCK_ALLOC_SIZE - DEFAULT_BLOCK_HEADER_SIZE;
 

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -475,7 +475,7 @@ void StandardBufferManager::WriteTemporaryBuffer(MemoryTag tag, block_id_t block
 	// Create the file and write the size followed by the buffer contents.
 	auto &fs = FileSystem::GetFileSystem(db);
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
-	temporary_directory.handle->GetTempFile().IncreaseSizeOnDisk(buffer.size + sizeof(idx_t));
+	temporary_directory.handle->GetTempFile().IncreaseSizeOnDisk(buffer.AllocSize() + sizeof(idx_t));
 	handle->Write(&buffer.size, sizeof(idx_t), 0);
 	buffer.Write(*handle, sizeof(idx_t));
 }
@@ -523,6 +523,8 @@ void StandardBufferManager::DeleteTemporaryFile(block_id_t id) {
 		temporary_directory.handle->GetTempFile().DeleteTemporaryBuffer(id);
 		return;
 	}
+
+	// The file is not in the shared pool of files.
 	auto &fs = FileSystem::GetFileSystem(db);
 	auto path = GetTemporaryPath(id);
 	if (fs.FileExists(path)) {


### PR DESCRIPTION
The nightly block size run found an underflow in temporary memory management. With blocks and, consequently, files that are not `DEFAULT_BLOCK_ALLOC_SIZE,` we incorrectly set the disk size to `buffer.size`. As we later obtain the file's entire size, we need to use `buffer.AllocSize()` instead.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/2578.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/2535.