### PR TITLE
When deserializing a function expression - add a cast if the return type does not match instead of failing.

### DIFF
--- a/src/include/duckdb/function/function_serialization.hpp
+++ b/src/include/duckdb/function/function_serialization.hpp
@@ -132,10 +132,6 @@ public:
 		}
 		if (TypeRequiresAssignment(function.return_type)) {
 			function.return_type = std::move(return_type);
-		} else if (function.return_type != return_type) {
-			throw SerializationException(
-			    "Return type mismatch for function in deserialization (deserialized %s, but found %s)", return_type,
-			    function.return_type);
 		}
 		return make_pair(std::move(function), std::move(bind_data));
 	}

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -104,9 +104,14 @@ unique_ptr<Expression> BoundFunctionExpression::Deserialize(Deserializer &deseri
 	auto children = deserializer.ReadProperty<vector<unique_ptr<Expression>>>(201, "children");
 	auto entry = FunctionSerializer::Deserialize<ScalarFunction, ScalarFunctionCatalogEntry>(
 	    deserializer, CatalogType::SCALAR_FUNCTION_ENTRY, children, return_type);
-	auto result = make_uniq<BoundFunctionExpression>(std::move(return_type), std::move(entry.first),
+	auto result = make_uniq<BoundFunctionExpression>(entry.first.return_type, std::move(entry.first),
 	                                                 std::move(children), std::move(entry.second));
 	deserializer.ReadProperty(202, "is_operator", result->is_operator);
+	if (result->return_type != return_type) {
+		// return type mismatch - push a cast
+		auto &context = deserializer.Get<ClientContext &>();
+		return BoundCastExpression::AddCastToType(context, std::move(result), return_type);
+	}
 	return std::move(result);
 }
 

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -104,7 +104,8 @@ unique_ptr<Expression> BoundFunctionExpression::Deserialize(Deserializer &deseri
 	auto children = deserializer.ReadProperty<vector<unique_ptr<Expression>>>(201, "children");
 	auto entry = FunctionSerializer::Deserialize<ScalarFunction, ScalarFunctionCatalogEntry>(
 	    deserializer, CatalogType::SCALAR_FUNCTION_ENTRY, children, return_type);
-	auto result = make_uniq<BoundFunctionExpression>(entry.first.return_type, std::move(entry.first),
+	auto function_return_type = entry.first.return_type;
+	auto result = make_uniq<BoundFunctionExpression>(std::move(function_return_type), std::move(entry.first),
 	                                                 std::move(children), std::move(entry.second));
 	deserializer.ReadProperty(202, "is_operator", result->is_operator);
 	if (result->return_type != return_type) {


### PR DESCRIPTION
This compensates for changes in return type in different DuckDB versions