### PR TITLE
make force install actually force install in presence of etags

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -391,7 +391,7 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 		duckdb_httplib::Headers headers = {
 		    {"User-Agent", StringUtil::Format("%s %s", db.config.UserAgent(), DuckDB::SourceID())}};
 
-		if (install_info && !install_info->etag.empty()) {
+		if (!force_install && install_info && !install_info->etag.empty()) {
 			headers.insert({"If-None-Match", StringUtil::Format("%s", install_info->etag)});
 		}
 


### PR DESCRIPTION
The etag mechanism introduced by https://github.com/duckdb/duckdb/pull/12333 which aims to make the `UPDATE EXTENSIONS` mechanism much faster by checking the etags should probably be disabled when using `FORCE INSTALL`

This also fixes the  `Extension updating test` CI job that is now failing on main