### PR TITLE
Fix array segment fetch offset

### DIFF
--- a/test/sql/types/nested/array/array_rowgroup.test
+++ b/test/sql/types/nested/array/array_rowgroup.test
@@ -1,0 +1,13 @@
+# name: test/sql/types/nested/array/array_rowgroup.test
+# group: [array]
+
+statement ok
+create table arrays(id int primary key, a int[3]);
+
+statement ok
+insert into arrays select i, [i, i + 1, i +2] from range(200000) t(i);
+
+query II
+select * from arrays where id=150000;
+----
+150000	[150000, 150001, 150002]


### PR DESCRIPTION
Followup to #12639. After going through a bit of a wild-goose-chase, this should finally close: https://github.com/duckdb/duckdb_vss/issues/16