### PR TITLE
Add Lock to access of current_boundary in Global CSV Reader

### DIFF
--- a/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
+++ b/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
@@ -41,6 +41,11 @@ CSVGlobalState::CSVGlobalState(ClientContext &context_p, const shared_ptr<CSVBuf
 	    make_shared_ptr<CSVBufferUsage>(*file_scans.back()->buffer_manager, current_boundary.GetBufferIdx());
 }
 
+bool CSVGlobalState::IsDone() const {
+	lock_guard<mutex> parallel_lock(main_mutex);
+	return current_boundary.done;
+};
+
 double CSVGlobalState::GetProgress(const ReadCSVData &bind_data_p) const {
 	lock_guard<mutex> parallel_lock(main_mutex);
 	idx_t total_files = bind_data.files.size();

--- a/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
+++ b/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
@@ -44,7 +44,7 @@ CSVGlobalState::CSVGlobalState(ClientContext &context_p, const shared_ptr<CSVBuf
 bool CSVGlobalState::IsDone() const {
 	lock_guard<mutex> parallel_lock(main_mutex);
 	return current_boundary.done;
-};
+}
 
 double CSVGlobalState::GetProgress(const ReadCSVData &bind_data_p) const {
 	lock_guard<mutex> parallel_lock(main_mutex);

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -205,7 +205,7 @@ unique_ptr<LocalTableFunctionState> ReadCSVInitLocal(ExecutionContext &context, 
 		return nullptr;
 	}
 	auto &global_state = global_state_p->Cast<CSVGlobalState>();
-	if (global_state.current_boundary.done) {
+	if (global_state.IsDone()) {
 		// nothing to do
 		return nullptr;
 	}

--- a/src/include/duckdb/execution/operator/csv_scanner/global_csv_state.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/global_csv_state.hpp
@@ -40,8 +40,8 @@ struct CSVGlobalState : public GlobalTableFunctionState {
 
 	//! Calculates the Max Threads that will be used by this CSV Reader
 	idx_t MaxThreads() const override;
-	//! We hold information on the current scanner boundary
-	CSVIterator current_boundary;
+
+	bool IsDone() const;
 
 private:
 	//! Reference to the client context that created this scan
@@ -76,6 +76,8 @@ private:
 	shared_ptr<CSVBufferUsage> current_buffer_in_use;
 
 	unordered_map<idx_t, idx_t> threads_per_file;
+	//! We hold information on the current scanner boundary
+	CSVIterator current_boundary;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
Fix: https://github.com/duckdblabs/duckdb-internal/issues/2919