### PR TITLE
Restore etag mechanism

### DIFF
--- a/src/execution/operator/helper/physical_load.cpp
+++ b/src/execution/operator/helper/physical_load.cpp
@@ -16,15 +16,23 @@ static void InstallFromRepository(ClientContext &context, const LoadInfo &info) 
 		repository = ExtensionRepository::GetRepositoryByUrl(info.repository);
 	}
 
-	ExtensionHelper::InstallExtension(context, info.filename, info.load_type == LoadType::FORCE_INSTALL, repository,
-	                                  true, info.version);
+	ExtensionInstallOptions options;
+	options.force_install = info.load_type == LoadType::FORCE_INSTALL;
+	options.throw_on_origin_mismatch = true;
+	options.version = info.version;
+	options.repository = repository;
+
+	ExtensionHelper::InstallExtension(context, info.filename, options);
 }
 
 SourceResultType PhysicalLoad::GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const {
 	if (info->load_type == LoadType::INSTALL || info->load_type == LoadType::FORCE_INSTALL) {
 		if (info->repository.empty()) {
-			ExtensionHelper::InstallExtension(context.client, info->filename,
-			                                  info->load_type == LoadType::FORCE_INSTALL, nullptr, true, info->version);
+			ExtensionInstallOptions options;
+			options.force_install = info->load_type == LoadType::FORCE_INSTALL;
+			options.throw_on_origin_mismatch = true;
+			options.version = info->version;
+			ExtensionHelper::InstallExtension(context.client, info->filename, options);
 		} else {
 			InstallFromRepository(context.client, *info);
 		}

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -82,11 +82,11 @@ struct ExtensionInstallOptions {
 	//! Install a specific version of the extension
 	string version;
 
-	//! Overwrite any existing installation
+	//! Overwrite existing installation
 	bool force_install = false;
 	//! Use etags to avoid downloading unchanged extension files
 	bool use_etags = false;
-	//! Throw an error when INSTALL is called on an extension with a different origin than the one that is installed
+	//! Throw an error when installing an extension with a different origin than the one that is installed
 	bool throw_on_origin_mismatch = false;
 };
 

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -76,6 +76,20 @@ struct ExtensionUpdateResult {
 	string installed_version;
 };
 
+struct ExtensionInstallOptions {
+	//! Install from a different repository that the default one
+	optional_ptr<ExtensionRepository> repository;
+	//! Install a specific version of the extension
+	string version;
+
+	//! Overwrite any existing installation
+	bool force_install = false;
+	//! Use etags to avoid downloading unchanged extension files
+	bool use_etags = false;
+	//! Throw an error when INSTALL is called on an extension with a different origin than the one that is installed
+	bool throw_on_origin_mismatch = false;
+};
+
 class ExtensionHelper {
 public:
 	static void LoadAllExtensions(DuckDB &db);
@@ -84,15 +98,9 @@ public:
 
 	//! Install an extension
 	static unique_ptr<ExtensionInstallInfo> InstallExtension(ClientContext &context, const string &extension,
-	                                                         bool force_install,
-	                                                         optional_ptr<ExtensionRepository> repository = nullptr,
-	                                                         bool throw_on_origin_mismatch = false,
-	                                                         const string &version = "");
+	                                                         ExtensionInstallOptions &options);
 	static unique_ptr<ExtensionInstallInfo> InstallExtension(DatabaseInstance &db, FileSystem &fs,
-	                                                         const string &extension, bool force_install,
-	                                                         optional_ptr<ExtensionRepository> repository = nullptr,
-	                                                         bool throw_on_origin_mismatch = false,
-	                                                         const string &version = "");
+	                                                         const string &extension, ExtensionInstallOptions &options);
 	//! Load an extension
 	static void LoadExternalExtension(ClientContext &context, const string &extension);
 	static void LoadExternalExtension(DatabaseInstance &db, FileSystem &fs, const string &extension);
@@ -212,10 +220,11 @@ public:
 	static bool CreateSuggestions(const string &extension_name, string &message);
 
 private:
-	static unique_ptr<ExtensionInstallInfo> InstallExtensionInternal(
-	    DatabaseInstance &db, FileSystem &fs, const string &local_path, const string &extension, bool force_install,
-	    bool throw_on_origin_mismatch, const string &version, optional_ptr<ExtensionRepository> repository,
-	    optional_ptr<HTTPLogger> http_logger = nullptr, optional_ptr<ClientContext> context = nullptr);
+	static unique_ptr<ExtensionInstallInfo> InstallExtensionInternal(DatabaseInstance &db, FileSystem &fs,
+	                                                                 const string &local_path, const string &extension,
+	                                                                 ExtensionInstallOptions &options,
+	                                                                 optional_ptr<HTTPLogger> http_logger = nullptr,
+	                                                                 optional_ptr<ClientContext> context = nullptr);
 	static const vector<string> PathComponents();
 	static string DefaultExtensionFolder(FileSystem &fs);
 	static bool AllowAutoInstall(const string &extension);

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -213,7 +213,9 @@ bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string 
 		if (dbconfig.options.autoinstall_known_extensions) {
 			auto &config = DBConfig::GetConfig(context);
 			auto autoinstall_repo = ExtensionRepository::GetRepositoryByUrl(config.options.autoinstall_extension_repo);
-			ExtensionHelper::InstallExtension(context, extension_name, false, autoinstall_repo, false);
+			ExtensionInstallOptions options;
+			options.repository = autoinstall_repo;
+			ExtensionHelper::InstallExtension(context, extension_name, options);
 		}
 		ExtensionHelper::LoadExternalExtension(context, extension_name);
 		return true;
@@ -232,7 +234,9 @@ bool ExtensionHelper::TryAutoLoadExtension(DatabaseInstance &instance, const str
 		if (dbconfig.options.autoinstall_known_extensions) {
 			auto autoinstall_repo =
 			    ExtensionRepository::GetRepositoryByUrl(dbconfig.options.autoinstall_extension_repo);
-			ExtensionHelper::InstallExtension(instance, fs, extension_name, false, autoinstall_repo, false);
+			ExtensionInstallOptions options;
+			options.repository = autoinstall_repo;
+			ExtensionHelper::InstallExtension(instance, fs, extension_name, options);
 		}
 		ExtensionHelper::LoadExternalExtension(instance, fs, extension_name);
 		return true;
@@ -291,10 +295,15 @@ static ExtensionUpdateResult UpdateExtensionInternal(ClientContext &context, Dat
 	auto repository_from_info = ExtensionRepository::GetRepositoryByUrl(extension_install_info->repository_url);
 	result.repository = repository_from_info.ToReadableString();
 
-	// We force install the full url found in this file, throwing
+	// We force install the full url found in this file, enabling etags to ensure efficient updating
+	ExtensionInstallOptions options;
+	options.repository = repository_from_info;
+	options.force_install = true;
+	options.use_etags = true;
+
 	unique_ptr<ExtensionInstallInfo> install_result;
 	try {
-		install_result = ExtensionHelper::InstallExtension(context, extension_name, true, repository_from_info);
+		install_result = ExtensionHelper::InstallExtension(context, extension_name, options);
 	} catch (std::exception &e) {
 		ErrorData error(e);
 		error.Throw("Extension updating failed when trying to install '" + extension_name + "', original error: ");
@@ -375,7 +384,9 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 		if (dbconfig.options.autoinstall_known_extensions) {
 			//! Get the autoloading repository
 			auto repository = ExtensionRepository::GetRepositoryByUrl(dbconfig.options.autoinstall_extension_repo);
-			ExtensionHelper::InstallExtension(db, *fs, extension_name, false, repository);
+			ExtensionInstallOptions options;
+			options.repository = repository;
+			ExtensionHelper::InstallExtension(db, *fs, extension_name, options);
 		}
 #endif
 		ExtensionHelper::LoadExternalExtension(db, *fs, extension_name);

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -295,7 +295,7 @@ static ExtensionUpdateResult UpdateExtensionInternal(ClientContext &context, Dat
 	auto repository_from_info = ExtensionRepository::GetRepositoryByUrl(extension_install_info->repository_url);
 	result.repository = repository_from_info.ToReadableString();
 
-	// We force install the full url found in this file, enabling etags to ensure efficient updating
+	// Force install the full url found in this file, enabling etags to ensure efficient updating
 	ExtensionInstallOptions options;
 	options.repository = repository_from_info;
 	options.force_install = true;

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -142,24 +142,18 @@ bool ExtensionHelper::CreateSuggestions(const string &extension_name, string &me
 }
 
 unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(DatabaseInstance &db, FileSystem &fs,
-                                                                   const string &extension, bool force_install,
-                                                                   optional_ptr<ExtensionRepository> repository,
-                                                                   bool throw_on_origin_mismatch,
-                                                                   const string &version) {
+                                                                   const string &extension,
+                                                                   ExtensionInstallOptions &options) {
 #ifdef WASM_LOADABLE_EXTENSIONS
 	// Install is currently a no-op
 	return nullptr;
 #endif
 	string local_path = ExtensionDirectory(db, fs);
-	return InstallExtensionInternal(db, fs, local_path, extension, force_install, throw_on_origin_mismatch, version,
-	                                repository);
+	return InstallExtensionInternal(db, fs, local_path, extension, options);
 }
 
 unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(ClientContext &context, const string &extension,
-                                                                   bool force_install,
-                                                                   optional_ptr<ExtensionRepository> repository,
-                                                                   bool throw_on_origin_mismatch,
-                                                                   const string &version) {
+                                                                   ExtensionInstallOptions &options) {
 #ifdef WASM_LOADABLE_EXTENSIONS
 	// Install is currently a no-op
 	return nullptr;
@@ -169,8 +163,7 @@ unique_ptr<ExtensionInstallInfo> ExtensionHelper::InstallExtension(ClientContext
 	string local_path = ExtensionDirectory(context);
 	optional_ptr<HTTPLogger> http_logger =
 	    ClientConfig::GetConfig(context).enable_http_logging ? context.client_data->http_logger.get() : nullptr;
-	return InstallExtensionInternal(db, fs, local_path, extension, force_install, throw_on_origin_mismatch, version,
-	                                repository, http_logger, context);
+	return InstallExtensionInternal(db, fs, local_path, extension, options, http_logger, context);
 }
 
 unsafe_unique_array<data_t> ReadExtensionFileFromDisk(FileSystem &fs, const string &path, idx_t &file_size) {
@@ -272,8 +265,7 @@ static void WriteExtensionFiles(FileSystem &fs, const string &temp_path, const s
 // Install an extension using a filesystem
 static unique_ptr<ExtensionInstallInfo> DirectInstallExtension(DatabaseInstance &db, FileSystem &fs, const string &path,
                                                                const string &temp_path, const string &extension_name,
-                                                               const string &local_extension_path, bool force_install,
-                                                               optional_ptr<ExtensionRepository> repository,
+                                                               const string &local_extension_path, ExtensionInstallOptions &options,
                                                                optional_ptr<ClientContext> context) {
 	string file = fs.ConvertSeparators(path);
 
@@ -325,13 +317,13 @@ static unique_ptr<ExtensionInstallInfo> DirectInstallExtension(DatabaseInstance 
 
 	CheckExtensionMetadataOnInstall(db, extension_decompressed, extension_decompressed_size, info, extension_name);
 
-	if (!repository) {
+	if (!options.repository) {
 		info.mode = ExtensionInstallMode::CUSTOM_PATH;
 		info.full_path = file;
 	} else {
 		info.mode = ExtensionInstallMode::REPOSITORY;
 		info.full_path = file;
-		info.repository_url = repository->path;
+		info.repository_url = options.repository->path;
 	}
 
 	WriteExtensionFiles(fs, temp_path, local_extension_path, extension_decompressed, extension_decompressed_size, info);
@@ -342,8 +334,7 @@ static unique_ptr<ExtensionInstallInfo> DirectInstallExtension(DatabaseInstance 
 #ifndef DUCKDB_DISABLE_EXTENSION_LOAD
 static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db, const string &url,
                                                            const string &extension_name, const string &temp_path,
-                                                           const string &local_extension_path, bool force_install,
-                                                           optional_ptr<ExtensionRepository> repository,
+                                                           const string &local_extension_path, ExtensionInstallOptions &options,
                                                            optional_ptr<HTTPLogger> http_logger) {
 	string no_http = StringUtil::Replace(url, "http://", "");
 
@@ -391,7 +382,7 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 		duckdb_httplib::Headers headers = {
 		    {"User-Agent", StringUtil::Format("%s %s", db.config.UserAgent(), DuckDB::SourceID())}};
 
-		if (install_info && !install_info->etag.empty()) {
+		if (options.use_etags && install_info && !install_info->etag.empty()) {
 			headers.insert({"If-None-Match", StringUtil::Format("%s", install_info->etag)});
 		}
 
@@ -456,10 +447,10 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 		info.etag = res->get_header_value("ETag");
 	}
 
-	if (repository) {
+	if (options.repository) {
 		info.mode = ExtensionInstallMode::REPOSITORY;
 		info.full_path = url;
-		info.repository_url = repository->path;
+		info.repository_url = options.repository->path;
 	} else {
 		info.mode = ExtensionInstallMode::CUSTOM_PATH;
 		info.full_path = url;
@@ -474,23 +465,20 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 
 // Install an extension using a hand-rolled http request
 static unique_ptr<ExtensionInstallInfo> InstallFromRepository(DatabaseInstance &db, FileSystem &fs, const string &url,
-                                                              const string &extension_name,
-                                                              ExtensionRepository &repository, const string &temp_path,
-                                                              const string &local_extension_path, const string &version,
-                                                              bool force_install, optional_ptr<HTTPLogger> http_logger,
+                                                              const string &extension_name, const string &temp_path,
+                                                              const string &local_extension_path, ExtensionInstallOptions &options,
+                                                              optional_ptr<HTTPLogger> http_logger,
                                                               optional_ptr<ClientContext> context) {
-	string url_template = ExtensionHelper::ExtensionUrlTemplate(db, repository, version);
+	string url_template = ExtensionHelper::ExtensionUrlTemplate(db, *options.repository, options.version);
 	string generated_url = ExtensionHelper::ExtensionFinalizeUrlTemplate(url_template, extension_name);
 
 	// Special handling for http repository: avoid using regular filesystem (note: the filesystem is not used here)
-	if (StringUtil::StartsWith(repository.path, "http://")) {
-		return InstallFromHttpUrl(db, generated_url, extension_name, temp_path, local_extension_path, force_install,
-		                          repository, http_logger);
+	if (StringUtil::StartsWith(options.repository->path, "http://")) {
+		return InstallFromHttpUrl(db, generated_url, extension_name, temp_path, local_extension_path, options, http_logger);
 	}
 
 	// Default case, let the FileSystem figure it out
-	return DirectInstallExtension(db, fs, generated_url, temp_path, extension_name, local_extension_path, force_install,
-	                              repository, context);
+	return DirectInstallExtension(db, fs, generated_url, temp_path, extension_name, local_extension_path, options, context);
 }
 
 static bool IsHTTP(const string &path) {
@@ -526,8 +514,7 @@ static void ThrowErrorOnMismatchingExtensionOrigin(FileSystem &fs, const string 
 
 unique_ptr<ExtensionInstallInfo>
 ExtensionHelper::InstallExtensionInternal(DatabaseInstance &db, FileSystem &fs, const string &local_path,
-                                          const string &extension, bool force_install, bool throw_on_origin_mismatch,
-                                          const string &version, optional_ptr<ExtensionRepository> repository,
+                                          const string &extension, ExtensionInstallOptions &options,
                                           optional_ptr<HTTPLogger> http_logger, optional_ptr<ClientContext> context) {
 #ifdef DUCKDB_DISABLE_EXTENSION_LOAD
 	throw PermissionException("Installing external extensions is disabled through a compile time flag");
@@ -540,11 +527,12 @@ ExtensionHelper::InstallExtensionInternal(DatabaseInstance &db, FileSystem &fs, 
 	string local_extension_path = fs.JoinPath(local_path, extension_name + ".duckdb_extension");
 	string temp_path = local_extension_path + ".tmp-" + UUID::ToString(UUID::GenerateRandomUUID());
 
-	if (fs.FileExists(local_extension_path) && !force_install) {
+	if (fs.FileExists(local_extension_path) && !options.force_install) {
 		// File exists: throw error if origin mismatches
-		if (throw_on_origin_mismatch && !db.config.options.allow_extensions_metadata_mismatch &&
+		if (options.throw_on_origin_mismatch && !db.config.options.allow_extensions_metadata_mismatch &&
 		    fs.FileExists(local_extension_path + ".info")) {
-			ThrowErrorOnMismatchingExtensionOrigin(fs, local_extension_path, extension_name, extension, repository);
+			ThrowErrorOnMismatchingExtensionOrigin(fs, local_extension_path, extension_name, extension,
+			                                       options.repository);
 		}
 
 		// File exists, but that's okay, install is now a NOP
@@ -555,29 +543,30 @@ ExtensionHelper::InstallExtensionInternal(DatabaseInstance &db, FileSystem &fs, 
 		fs.RemoveFile(temp_path);
 	}
 
-	if (ExtensionHelper::IsFullPath(extension) && repository) {
+	if (ExtensionHelper::IsFullPath(extension) && options.repository) {
 		throw InvalidInputException("Cannot pass both a repository and a full path url");
 	}
 
 	// Resolve default repository if there is none set
 	ExtensionRepository resolved_repository;
-	if (!ExtensionHelper::IsFullPath(extension) && !repository) {
+	if (!ExtensionHelper::IsFullPath(extension) && !options.repository) {
 		resolved_repository = ExtensionRepository::GetDefaultRepository(db.config);
-		repository = resolved_repository;
+		options.repository = resolved_repository;
 	}
 
 	// Install extension from local, direct url
 	if (ExtensionHelper::IsFullPath(extension) && !IsHTTP(extension)) {
 		LocalFileSystem local_fs;
 		return DirectInstallExtension(db, local_fs, extension, temp_path, extension, local_extension_path,
-		                              force_install, nullptr, context);
+		                              options, context);
 	}
 
 	// Install extension from local url based on a repository (Note that this will install it as a local file)
-	if (repository && !IsHTTP(repository->path)) {
+	if (options.repository && !IsHTTP(options.repository->path)) {
 		LocalFileSystem local_fs;
-		return InstallFromRepository(db, fs, extension, extension_name, *repository, temp_path, local_extension_path,
-		                             version, force_install, http_logger, context);
+		return InstallFromRepository(db, fs, extension, extension_name, temp_path,
+		                             local_extension_path, options, http_logger,
+		                             context);
 	}
 
 #ifdef DISABLE_DUCKDB_REMOTE_INSTALL
@@ -588,18 +577,17 @@ ExtensionHelper::InstallExtensionInternal(DatabaseInstance &db, FileSystem &fs, 
 	if (IsFullPath(extension)) {
 		if (StringUtil::StartsWith(extension, "http://")) {
 			// HTTP takes separate path to avoid dependency on httpfs extension
-			return InstallFromHttpUrl(db, extension, extension_name, temp_path, local_extension_path, force_install,
-			                          nullptr, http_logger);
+			return InstallFromHttpUrl(db, extension, extension_name, temp_path, local_extension_path,
+			                          options, http_logger);
 		}
 
 		// Direct installation from local or remote path
-		return DirectInstallExtension(db, fs, extension, temp_path, extension, local_extension_path, force_install,
-		                              nullptr, context);
+		return DirectInstallExtension(db, fs, extension, temp_path, extension, local_extension_path,
+		                              options, context);
 	}
 
 	// Repository installation
-	return InstallFromRepository(db, fs, extension, extension_name, *repository, temp_path, local_extension_path,
-	                             version, force_install, http_logger, context);
+	return InstallFromRepository(db, fs, extension, extension_name, temp_path, local_extension_path, options, http_logger, context);
 #endif
 #endif
 }

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -453,7 +453,8 @@ ExtensionInitResult ExtensionHelper::InitialLoad(DatabaseInstance &db, FileSyste
 			throw IOException(error);
 		}
 		// the extension load failed - try installing the extension
-		ExtensionHelper::InstallExtension(db, fs, extension, false);
+		ExtensionInstallOptions options;
+		ExtensionHelper::InstallExtension(db, fs, extension, options);
 		// try loading again
 		if (!TryInitialLoad(db, fs, extension, result, error)) {
 			throw IOException(error);

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1695,7 +1695,10 @@ void DuckDBPyConnection::Interrupt() {
 
 void DuckDBPyConnection::InstallExtension(const string &extension, bool force_install) {
 	auto &connection = con.GetConnection();
-	ExtensionHelper::InstallExtension(*connection.context, extension, force_install);
+
+	ExtensionInstallOptions options;
+	options.force_install = force_install;
+	ExtensionHelper::InstallExtension(*connection.context, extension, options);
 }
 
 void DuckDBPyConnection::LoadExtension(const string &extension) {


### PR DESCRIPTION
Thanks @carlopi for the catch, this PR https://github.com/duckdb/duckdb/pull/13700 broke the etag mechanism completely because updating uses force installing internally.

This PR adds another option to extension installing: `use_etags` which needs to be set explicitly. We set this only for the `update extensions` command so a force install will actually redownload regardless of the etag.

Testing this is a bit awkward, we could use the http proxy logs for this, but I feel the added test complexity and fragility is not really worth it here. I tested this PR locally and it seems to work nicely.