### PR TITLE
Icu autoloading on overloads

### DIFF
--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -510,6 +510,52 @@ def write_header(data: ExtensionData):
                                                                 {"bearer", "httpfs"}
     }; // EXTENSION_SECRET_TYPES
                                                                 
+// Note: these are currently hardcoded in scripts/generate_extensions_function.py
+// TODO: automate by passing though to script via duckdb
+static constexpr ExtensionEntry EXTENSION_OVERLOADS[] = {{"age", "icu"},
+                                                         {"century", "icu"},
+                                                         {"date_diff", "icu"},
+                                                         {"date_part", "icu"},
+                                                         {"date_sub", "icu"},
+                                                         {"date_trunc", "icu"},
+                                                         {"datediff", "icu"},
+                                                         {"datepart", "icu"},
+                                                         {"datesub", "icu"},
+                                                         {"datetrunc", "icu"},
+                                                         {"day", "icu"},
+                                                         {"dayname", "icu"},
+                                                         {"dayofmonth", "icu"},
+                                                         {"dayofweek", "icu"},
+                                                         {"dayofyear", "icu"},
+                                                         {"decade", "icu"},
+                                                         {"epoch", "icu"},
+                                                         {"era", "icu"},
+                                                         {"generate_series", "icu"},
+                                                         {"hour", "icu"},
+                                                         {"isodow", "icu"},
+                                                         {"isoyear", "icu"},
+                                                         {"julian", "icu"},
+                                                         {"last_day", "icu"},
+                                                         {"microsecond", "icu"},
+                                                         {"millennium", "icu"},
+                                                         {"millisecond", "icu"},
+                                                         {"minute", "icu"},
+                                                         {"month", "icu"},
+                                                         {"monthname", "icu"},
+                                                         {"quarter", "icu"},
+                                                         {"range", "icu"},
+                                                         {"second", "icu"},
+                                                         {"strftime", "icu"},
+                                                         {"time_bucket", "icu"},
+                                                         {"timezone", "icu"},
+                                                         {"timezone_hour", "icu"},
+                                                         {"timezone_minute", "icu"},
+                                                         {"week", "icu"},
+                                                         {"weekday", "icu"},
+                                                         {"weekofyear", "icu"},
+                                                         {"year", "icu"},
+                                                         {"yearweek", "icu"}
+}; // EXTENSION_OVERLOADS
                                                                 
     // Note: these are currently hardcoded in scripts/generate_extensions_function.py
     // TODO: automate by passing though to script via duckdb

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -797,6 +797,14 @@ CatalogEntry &Catalog::GetEntry(ClientContext &context, CatalogType type, const 
 optional_ptr<CatalogEntry> Catalog::GetEntry(ClientContext &context, CatalogType type, const string &catalog,
                                              const string &schema, const string &name, OnEntryNotFound if_not_found,
                                              QueryErrorContext error_context) {
+	{
+		auto extension_name = ExtensionHelper::FindExtensionInEntries(name, EXTENSION_OVERLOADS);
+		if (!context.GetHasTriedAutoLoading(extension_name)) {
+			TryAutoLoad(context, extension_name);
+			context.SetHasTriedAutoLoading(extension_name);
+		}
+	}
+
 	auto result = TryLookupEntry(context, type, catalog, schema, name, if_not_found, error_context);
 
 	// Try autoloading extension to resolve lookup

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -773,6 +773,14 @@ CatalogEntryLookup Catalog::TryLookupEntry(ClientContext &context, CatalogType t
 optional_ptr<CatalogEntry> Catalog::GetEntry(ClientContext &context, CatalogType type, const string &schema_name,
                                              const string &name, OnEntryNotFound if_not_found,
                                              QueryErrorContext error_context) {
+	{
+		auto extension_name = ExtensionHelper::FindExtensionInEntries(name, EXTENSION_OVERLOADS);
+		if (!context.GetHasTriedAutoLoading(extension_name)) {
+			TryAutoLoad(context, extension_name);
+			context.SetHasTriedAutoLoading(extension_name);
+		}
+	}
+
 	auto lookup_entry = TryLookupEntry(context, type, schema_name, name, if_not_found, error_context);
 
 	// Try autoloading extension to resolve lookup

--- a/src/common/exception/binder_exception.cpp
+++ b/src/common/exception/binder_exception.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/function.hpp"
+#include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
 
@@ -24,7 +25,7 @@ BinderException BinderException::ColumnNotFound(const string &name, const vector
 }
 
 BinderException BinderException::NoMatchingFunction(const string &name, const vector<LogicalType> &arguments,
-                                                    const vector<string> &candidates) {
+                                                    const vector<string> &candidates, const ClientContext &context) {
 	auto extra_info = Exception::InitializeExtraInfo("NO_MATCHING_FUNCTION", optional_idx());
 	// no matching function was found, throw an error
 	string call_str = Function::CallToString(name, arguments);

--- a/src/common/exception/binder_exception.cpp
+++ b/src/common/exception/binder_exception.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension_entries.hpp"
+#include "duckdb/main/extension_helper.hpp"
 
 namespace duckdb {
 
@@ -33,6 +35,16 @@ BinderException BinderException::NoMatchingFunction(const string &name, const ve
 	for (auto &candidate : candidates) {
 		candidate_str += "\t" + candidate + "\n";
 	}
+
+	{
+		auto extension_name = ExtensionHelper::FindExtensionInEntries(name, EXTENSION_OVERLOADS);
+		if (context.GetHasTriedAutoLoading(extension_name)) {
+			candidate_str += "\nImplicit installing and loading of '" + extension_name +
+			                 "' failed.\nExplcitly `INSTALL " + extension_name + "; LOAD " + extension_name +
+			                 ";` might provide relevant overloads.\n";
+		}
+	}
+
 	extra_info["name"] = name;
 	extra_info["call"] = call_str;
 	if (!candidates.empty()) {

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -107,7 +107,7 @@ vector<idx_t> FunctionBinder::BindFunctionsFromArguments(const string &name, Fun
 		for (auto &f : functions.functions) {
 			candidates.push_back(f.ToString());
 		}
-		error = ErrorData(BinderException::NoMatchingFunction(name, arguments, candidates));
+		error = ErrorData(BinderException::NoMatchingFunction(name, arguments, candidates, context));
 		return candidate_functions;
 	}
 	candidate_functions.push_back(best_function.GetIndex());

--- a/src/include/duckdb/common/exception/binder_exception.hpp
+++ b/src/include/duckdb/common/exception/binder_exception.hpp
@@ -13,6 +13,8 @@
 
 namespace duckdb {
 
+class ClientContext;
+
 class BinderException : public Exception {
 public:
 	DUCKDB_API explicit BinderException(const string &msg, const unordered_map<string, string> &extra_info);
@@ -45,7 +47,7 @@ public:
 	static BinderException ColumnNotFound(const string &name, const vector<string> &similar_bindings,
 	                                      QueryErrorContext context = QueryErrorContext());
 	static BinderException NoMatchingFunction(const string &name, const vector<LogicalType> &arguments,
-	                                          const vector<string> &candidates);
+	                                          const vector<string> &candidates, const ClientContext &context);
 	static BinderException Unsupported(ParsedExpression &expr, const string &message);
 };
 

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -78,6 +78,11 @@ public:
 	shared_ptr<DatabaseInstance> db;
 	//! Whether or not the query is interrupted
 	atomic<bool> interrupted;
+
+private:
+	atomic<bool> tried_autoloading_icu {false};
+
+public:
 	//! Set of optional states (e.g. Caches) that can be held by the ClientContext
 	unique_ptr<RegisteredStateManager> registered_state;
 	//! The client configuration
@@ -88,6 +93,17 @@ public:
 	TransactionContext transaction;
 
 public:
+	bool GetHasTriedAutoLoading(const string &extension_name) const {
+		if (extension_name == "icu") {
+			return tried_autoloading_icu;
+		}
+		return false;
+	}
+	void SetHasTriedAutoLoading(const string &extension_name) {
+		if (extension_name == "icu") {
+			tried_autoloading_icu = true;
+		}
+	}
 	MetaTransaction &ActiveTransaction() {
 		return transaction.ActiveTransaction();
 	}

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -497,6 +497,54 @@ static constexpr ExtensionEntry EXTENSION_FILE_CONTAINS[] = {{".parquet?", "parq
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
+static constexpr ExtensionEntry EXTENSION_OVERLOADS[] = {{"age", "icu"},
+                                                         {"century", "icu"},
+                                                         {"date_diff", "icu"},
+                                                         {"date_part", "icu"},
+                                                         {"date_sub", "icu"},
+                                                         {"date_trunc", "icu"},
+                                                         {"datediff", "icu"},
+                                                         {"datepart", "icu"},
+                                                         {"datesub", "icu"},
+                                                         {"datetrunc", "icu"},
+                                                         {"day", "icu"},
+                                                         {"dayname", "icu"},
+                                                         {"dayofmonth", "icu"},
+                                                         {"dayofweek", "icu"},
+                                                         {"dayofyear", "icu"},
+                                                         {"decade", "icu"},
+                                                         {"epoch", "icu"},
+                                                         {"era", "icu"},
+                                                         {"generate_series", "icu"},
+                                                         {"hour", "icu"},
+                                                         {"isodow", "icu"},
+                                                         {"isoyear", "icu"},
+                                                         {"julian", "icu"},
+                                                         {"last_day", "icu"},
+                                                         {"microsecond", "icu"},
+                                                         {"millennium", "icu"},
+                                                         {"millisecond", "icu"},
+                                                         {"minute", "icu"},
+                                                         {"month", "icu"},
+                                                         {"monthname", "icu"},
+                                                         {"quarter", "icu"},
+                                                         {"range", "icu"},
+                                                         {"second", "icu"},
+                                                         {"strftime", "icu"},
+                                                         {"time_bucket", "icu"},
+                                                         {"timezone", "icu"},
+                                                         {"timezone_hour", "icu"},
+                                                         {"timezone_minute", "icu"},
+                                                         {"week", "icu"},
+                                                         {"weekday", "icu"},
+                                                         {"weekofyear", "icu"},
+                                                         {"year", "icu"},
+                                                         {"yearweek", "icu"}
+
+}; // EXTENSION_OVERLOADS
+
+// Note: these are currently hardcoded in scripts/generate_extensions_function.py
+// TODO: automate by passing though to script via duckdb
 static constexpr ExtensionEntry EXTENSION_SECRET_TYPES[] = {
     {"s3", "httpfs"},   {"r2", "httpfs"},          {"gcs", "httpfs"},
     {"azure", "azure"}, {"huggingface", "httpfs"}, {"bearer", "httpfs"}}; // EXTENSION_SECRET_TYPES


### PR DESCRIPTION
Current autoloading logic works like:

1. do a lookup for a function name
2. if empty result set, lookup in EXTENSION_FUNCTIONS (or EXTENSION_COPY_FUNCTIONS, or EXTENSION_TYPES, or EXTENSION_COLLATIONS, depending on type)
3. do another lookup

This fails for functions where overloads are provided in extensions, since the first step would succeed, leading to no autoloading.

The problem is inherently not super nice, since either we blindly perform autoloading (and might do so N times, paying potentially lag), or when we will eventually realize we might need overloads we will miss context (and we might also not be able to decide on the overload in the same way before and after load).

Only proper solution is performing Autoloading in the same place it's done now also for some overloads.

#### Solving ICU autoloading problems
The most visible source of problems here, and the one meant to be solved by this PR, are ICU overloads.

This is both since ICU is one of the few autoloadable extensions to provide a lots of autoloads, and since ICU is statically linked-in by default in most platforms, but NOT shipped by default in DuckDB-Wasm.

Current solution to support same syntax locally and on the Web is, in most cases, just force a load of ICU on startup. While this works, it's unnecessary slow AND partially defeats the purpose of autoloading. 

#### Solution
A list of functions in the ICU extensions that provide overloads to already existing functions has been compiled by a logic like:
```
CREATE TABLE OLD as FROM SELECT count(*), function_name FROM duckdb_functions() GROUP BY function_name;
INSTALL icu;
LOAD icu;
CREATE TABLE NEW as FROM SELECT count(*), function_name FROM duckdb_functions() GROUP BY function_name;
FROM OLD,NEW WHERE OLD.function_name = NEW.function_name AND #1 != #3;
```

Then when such a function is found, TryAutoLoading is performed on ICU.
Given no information is given back to the user on failures, this is only attempted once per instance. This is to mitigate performing one INSTALL request for every query with a `timezone` (say on a commit with no ICU available remotely).

On failure to find an overloads, the error message will show that autoloading has been attempted (at some previous point), but given context on the actual error has been lost, a generic error message inviting to explicitly INSTALL and LOAD will be shown.

#### Demo
Current behaviour
```
D select now() at time zone 'PST';
Binder Error: No function matches the given name and argument types 'timezone(STRING_LITERAL, TIMESTAMP WITH TIME ZONE)'. You might need to add explicit type casts.
	Candidate functions:
	timezone(DATE) -> BIGINT
	timezone(TIMESTAMP) -> BIGINT
	timezone(INTERVAL) -> BIGINT
	timezone(INTERVAL, TIME WITH TIME ZONE) -> TIME WITH TIME ZONE

LINE 1: select now() at time zone 'PST';
                     ^
```

Current when autoloading works:
```
D select now() at time zone 'PST';
┌─────────────────────────────┐
│ main.timezone('PST', now()) │
│          timestamp          │
├─────────────────────────────┤
│ 2024-09-03 05:21:24.425     │
└─────────────────────────────┘
```

Current when autoloading fails:
```
D select now() at time zone 'PST';
Binder Error: No function matches the given name and argument types 'timezone(STRING_LITERAL, TIMESTAMP WITH TIME ZONE)'. You might need to add explicit type casts.
	Candidate functions:
	timezone(DATE) -> BIGINT
	timezone(TIMESTAMP) -> BIGINT
	timezone(INTERVAL) -> BIGINT
	timezone(INTERVAL, TIME WITH TIME ZONE) -> TIME WITH TIME ZONE

Implicit installing and loading of 'icu' failed.
Explcitly `INSTALL icu; LOAD icu;` might provide relevant overloads.

LINE 1: select now() at time zone 'PST';
                     ^
```


#### Limitiations
The main limitation is that this currently works only for ICU. Generalizing this is viable, requires both compiling list of overloads (ideally to be done dynamically) and to provide a more general mechanism to register extension for which TryAutoLoading has been tried in ClientContext (removing tried_autoloading_icu and using a map from autoloadable extensions names)
The same mechanism can also be used to improve other cases where TryAutoLoading is used, so that repeated failures are avoided. For example, I think the spatial+parquet interaction might incur in 1 request per parquet file if the requests are failing. This has not been raised yet, but eventually might need fixing. Similar cases might exist elsewhere, but haven't looked too hard.

#### How to move forward
Goal of this PR is offer a way forward for duckdb-wasm, so the target on ICU. This also means has basically no effect on distributed binaries that links in ICU, given in that case ICU will already be available in any case.

I would like to use this in duckdb-wasm, one way would be to merge this in duckdb, unsure whether main or feature.
I can also work with this merged into feature, and applying this as a patch on top of duckdb v1.1.0.

Once this logic will be moved to duckdb-wasm (either as part of duckdb or as a patch), this solves https://github.com/duckdb/duckdb-wasm/issues/1770 and various similar issues raised over time.