### PR TITLE
docs: tweak explanation of median for even cardinality inputs

### DIFF
--- a/extension/core_functions/aggregate/holistic/functions.json
+++ b/extension/core_functions/aggregate/holistic/functions.json
@@ -16,7 +16,7 @@
     {
         "name": "median",
         "parameters": "x",
-        "description": "Returns the middle value of the set. NULL values are ignored. For even value counts, quantitative values are averaged and ordinal values return the lower value.",
+        "description": "Returns the middle value of the set. NULL values are ignored. For even value counts, interpolate-able types (numeric, date/time) return the average of the two middle values. Non-interpolate-able types (everything else) return the lower of the two middle values.",
         "example": "median(x)",
         "type": "aggregate_function_set"
     },

--- a/extension/core_functions/include/core_functions/aggregate/holistic_functions.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/holistic_functions.hpp
@@ -36,7 +36,7 @@ struct MadFun {
 struct MedianFun {
 	static constexpr const char *Name = "median";
 	static constexpr const char *Parameters = "x";
-	static constexpr const char *Description = "Returns the middle value of the set. NULL values are ignored. For even value counts, quantitative values are averaged and ordinal values return the lower value.";
+	static constexpr const char *Description = "Returns the middle value of the set. NULL values are ignored. For even value counts, interpolate-able types (numeric, date/time) return the average of the two middle values. Non-interpolate-able types (everything else) return the lower of the two middle values.";
 	static constexpr const char *Example = "median(x)";
 
 	static AggregateFunctionSet GetFunctions();


### PR DESCRIPTION
Instead of qualitative/quantitative, I think we should be more direct and list the actual types.

Also, just a little more word-smithing to be explicit that we are only referring to the two middle values. This change I am less convinced is a good idea, but I still think it's a positive.

Related to https://github.com/duckdb/duckdb/issues/13655