### PR TITLE
[build] Fix binaries version for linux arm64

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -68,6 +68,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
+        fetch-depth: 0
         ref: ${{ inputs.git_ref }}
 
     - uses: ./.github/actions/manylinux_2014_setup


### PR DESCRIPTION
Noticed in this conversation: https://github.com/duckdb/duckdb/issues/13506#issuecomment-2327748060

Due to restructuring, currently linux binaries for arm64 platform where built without the relevant git history being present, and that's currently used as fall back to decide both version and hash formatting.

There was a warning in the build logs:
```
fatal: No names found, cannot describe anything.
CMake Warning at CMakeLists.txt:296 (message):
-- GIT_COMMIT_HASH has lenght 7 different than the expected 10
  git is available (at /usr/local/bin/git) but has failed to execute
  'describe --tags --long', likely due to shallow clone.  Consider providing
  explicit OVERRIDE_GIT_DESCRIBE or clone with tags.  Continuing with dummy
  version v0.0.1
```
Before prompt would be like:
```
v0.0.1 367aa8d
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D 
```
After (not same commit, but that's irrelevant)
```
v1.0.1-dev5143 1e883cd4d8
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D 
```

but we should find a way either to detect the warning (say bumping to error in CI) / force no warning altogether in CI runs or better check the resulting binaries.

For now fixing the problem, thinking as a proper solution up next.