### PR TITLE
Fix #13471: use LogicalColumnCount() instead of PhysicalColumnCount()…

### DIFF
--- a/src/execution/column_binding_resolver.cpp
+++ b/src/execution/column_binding_resolver.cpp
@@ -111,7 +111,7 @@ void ColumnBindingResolver::VisitOperator(LogicalOperator &op) {
 		if (insert_op.action_type != OnConflictAction::THROW) {
 			// Get the bindings from the children
 			VisitOperatorChildren(op);
-			auto column_count = insert_op.table.GetColumns().PhysicalColumnCount();
+			auto column_count = insert_op.table.GetColumns().LogicalColumnCount();
 			auto dummy_bindings = LogicalOperator::GenerateColumnBindings(insert_op.excluded_table_index, column_count);
 			// Now insert our dummy bindings at the start of the bindings,
 			// so the first 'column_count' indices of the chunk are reserved for our 'excluded' columns


### PR DESCRIPTION
Fix #13471: use LogicalColumnCount() instead of PhysicalColumnCount() when resolving column references