### PR TITLE
Propagate schema in CreateIndexInfo

### DIFF
--- a/src/parser/parsed_data/create_index_info.cpp
+++ b/src/parser/parsed_data/create_index_info.cpp
@@ -8,9 +8,9 @@ CreateIndexInfo::CreateIndexInfo() : CreateInfo(CatalogType::INDEX_ENTRY, INVALI
 }
 
 CreateIndexInfo::CreateIndexInfo(const duckdb::CreateIndexInfo &info)
-    : CreateInfo(CatalogType::INDEX_ENTRY), table(info.table), index_name(info.index_name), options(info.options),
-      index_type(info.index_type), constraint_type(info.constraint_type), column_ids(info.column_ids),
-      scan_types(info.scan_types), names(info.names) {
+    : CreateInfo(CatalogType::INDEX_ENTRY, info.schema), table(info.table), index_name(info.index_name),
+      options(info.options), index_type(info.index_type), constraint_type(info.constraint_type),
+      column_ids(info.column_ids), scan_types(info.scan_types), names(info.names) {
 }
 
 static void RemoveTableQualificationRecursive(unique_ptr<ParsedExpression> &expr, const string &table_name) {

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -588,6 +588,7 @@ unique_ptr<LogicalOperator> DuckCatalog::BindCreateIndex(Binder &binder, CreateS
 	create_index_info->scan_types.emplace_back(LogicalType::ROW_TYPE);
 	create_index_info->names = get.names;
 	create_index_info->column_ids = column_ids;
+	create_index_info->schema = table.schema.name;
 	auto &bind_data = get.bind_data->Cast<TableScanBindData>();
 	bind_data.is_create_index = true;
 	get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);


### PR DESCRIPTION
https://github.com/duckdb/duckdb/commit/3b8ded3c7dd640f6d82e2a8fb79b6de9f24bcf92 fixes index creation to respect use schema commands. However, the schema information does not end up in `CreateIndexInfo`, where e.g. a rebind could find it.

This PR sets `create_index_info->schema` in `DuckCatalog::BindCreateIndex` according to the TableCatalogEntry it receives.
It also fixes the copy constructor of CreateIndexInfo to propagate the schema.