### PR TITLE
[Upsert] Fix issues surfaced by mixing in virtual columns

### DIFF
--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -295,7 +295,7 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 			auto entry = specified_columns.find(col.Name());
 			if (entry != specified_columns.end()) {
 				// column was specified, set to the index
-				insert.on_conflict_filter.insert(col.Oid());
+				insert.on_conflict_filter.insert(col.Physical().index);
 			}
 		}
 		bool index_references_columns = false;
@@ -353,8 +353,12 @@ void Binder::BindOnConflictClause(LogicalInsert &insert, TableCatalogEntry &tabl
 	// add a bind context entry for it
 	auto excluded_index = GenerateTableIndex();
 	insert.excluded_table_index = excluded_index;
-	auto table_column_names = columns.GetColumnNames();
-	auto table_column_types = columns.GetColumnTypes();
+	vector<string> table_column_names;
+	vector<LogicalType> table_column_types;
+	for (auto &col : columns.Physical()) {
+		table_column_names.push_back(col.Name());
+		table_column_types.push_back(col.Type());
+	}
 	bind_context.AddGenericBinding(excluded_index, "excluded", table_column_names, table_column_types);
 
 	if (on_conflict.condition) {

--- a/test/sql/upsert/test_generated_column.test
+++ b/test/sql/upsert/test_generated_column.test
@@ -1,0 +1,48 @@
+# name: test/sql/upsert/test_generated_column.test
+# group: [upsert]
+
+# SET expression targets b (located after the virtual column)
+
+statement ok
+CREATE TABLE t1 (
+	a CHAR NOT NULL,
+	c CHAR GENERATED ALWAYS AS (a) VIRTUAL,
+	b INT,
+);
+
+statement ok
+CREATE UNIQUE INDEX t1_idx ON t1 (a);
+
+statement ok
+INSERT INTO t1 VALUES ('a', 1) ON CONFLICT(a) DO UPDATE SET b = excluded.b;
+
+statement ok
+INSERT INTO t1 VALUES ('a', 1) ON CONFLICT(a) DO UPDATE SET b = excluded.b;
+
+query III
+select * from t1;
+----
+a	a	1
+
+# The ON CONFLICT (a) is logically located after the virtual column
+
+statement ok
+CREATE TABLE t2 (
+	b INT,
+	c CHAR GENERATED ALWAYS AS (a) VIRTUAL,
+	a CHAR NOT NULL,
+);
+
+statement ok
+CREATE UNIQUE INDEX t2_idx ON t2 (a);
+
+statement ok
+INSERT INTO t2 VALUES (1, 'a') ON CONFLICT(a) DO UPDATE SET b = excluded.b;
+
+statement ok
+INSERT INTO t2 VALUES (1, 'a') ON CONFLICT(a) DO UPDATE SET b = excluded.b;
+
+query III
+select * from t1;
+----
+a	a	1


### PR DESCRIPTION
This PR fixes #13471

Virtual columns are not at play in INSERT statements, they are calculated later. Because of this we need to base our indices off of PhysicalIndex rather than LogicalIndex.

- Use PhysicalIndex in the ON CONFLICT binding logic
- Get the types+names from the Physical columns when creating the base table binding for the "excluded" table referenced by the DO UPDATE SET expressions.