### PR TITLE
[Python] The GIL should not be held during the bind of a Relation

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyfilesystem.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyfilesystem.hpp
@@ -41,6 +41,7 @@ public:
 private:
 	py::object handle;
 };
+
 class PythonFilesystem : public FileSystem {
 private:
 	const vector<string> protocols;

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1436,15 +1436,18 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunQuery(const py::object &quer
 	shared_ptr<Relation> relation;
 	if (py::none().is(params)) {
 		// FIXME: currently we can't create relations with prepared parameters
-		auto statement_type = last_statement->type;
-		switch (statement_type) {
-		case StatementType::SELECT_STATEMENT: {
-			auto select_statement = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(last_statement));
-			relation = connection.RelationFromQuery(std::move(select_statement), alias);
-			break;
-		}
-		default:
-			break;
+		{
+			py::gil_scoped_release gil;
+			auto statement_type = last_statement->type;
+			switch (statement_type) {
+			case StatementType::SELECT_STATEMENT: {
+				auto select_statement = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(last_statement));
+				relation = connection.RelationFromQuery(std::move(select_statement), alias);
+				break;
+			}
+			default:
+				break;
+			}
 		}
 	}
 

--- a/tools/pythonpkg/tests/fast/test_filesystem.py
+++ b/tools/pythonpkg/tests/fast/test_filesystem.py
@@ -257,3 +257,34 @@ class TestPythonFilesystem:
         # hive partitioning: no cast to int
         duckdb_cursor.execute(query + ', HIVE_PARTITIONING=1' + ', HIVE_TYPES_AUTOCAST=0' + ');')
         assert duckdb_cursor.fetchall() == [(2, '2')]
+
+    def test_parallel_union_by_name(self, tmp_path):
+        import duckdb
+        import pyarrow
+        import pyarrow.parquet
+        import fsspec
+        import fsspec.implementations.local
+
+        table1 = pyarrow.Table.from_pylist(
+            [
+                {'time': 1719568210134107692, 'col1': 1},
+            ]
+        )
+        table1_path = tmp_path / "table1.parquet"
+        pyarrow.parquet.write_table(table1, table1_path)
+
+        table2 = pyarrow.Table.from_pylist(
+            [
+                {'time': 1719568210134107692, 'col1': 1},
+            ]
+        )
+        table2_path = tmp_path / "table2.parquet"
+        pyarrow.parquet.write_table(table2, table2_path)
+
+        c = duckdb.connect()
+        c.register_filesystem(fsspec.implementations.local.LocalFileSystem())
+
+        q = f"SELECT * FROM read_parquet('file://{tmp_path}/table*.parquet', union_by_name = TRUE) ORDER BY time DESC LIMIT 1"
+
+        res = c.sql(q).fetchall()
+        assert res == [(1719568210134107692, 1)]


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2561

During bind, the MultiFileReader would make of the UnionByName::UnionCols method which spins up an executor that then hits the PyFileSystem (with the provided test).

Inside the `fsspec` LocalFileSystem the GIL is released and then grabbed again, but the main thread is still holding the GIL that was grabbed before binding began and is spinlocking until the execution is finished.