### PR TITLE
Silence `jemalloc_write` in non-debug mode

### DIFF
--- a/extension/jemalloc/jemalloc/README.md
+++ b/extension/jemalloc/jemalloc/README.md
@@ -166,6 +166,20 @@ static bool
 os_overcommits_proc(void)
 ```
 
+Modify this function to only print in DEBUG mode in `malloc_io.c`.
+```c++
+void
+malloc_write(const char *s) {
+#ifdef DEBUG
+	if (je_malloc_message != NULL) {
+		je_malloc_message(NULL, s);
+	} else {
+		wrtmessage(NULL, s);
+	}
+#endif
+}
+```
+
 Almost no symbols are leaked due to `private_namespace.h`.
 The `exported_symbols_check.py` script still found a few, so these lines need to be added to `private_namespace.h`:
 ```c++

--- a/extension/jemalloc/jemalloc/src/malloc_io.c
+++ b/extension/jemalloc/jemalloc/src/malloc_io.c
@@ -79,11 +79,13 @@ JEMALLOC_EXPORT void	(*je_malloc_message)(void *, const char *s);
  */
 void
 malloc_write(const char *s) {
+#ifdef DEBUG
 	if (je_malloc_message != NULL) {
 		je_malloc_message(NULL, s);
 	} else {
 		wrtmessage(NULL, s);
 	}
+#endif
 }
 
 /*


### PR DESCRIPTION
A message popped up when running DuckDB in docker, which we ideally only want to see in debug mode.