### PR TITLE
Disable cgroup access in Wasm

### DIFF
--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -22,6 +22,9 @@ optional_idx CGroups::GetMemoryLimit(FileSystem &fs) {
 }
 
 optional_idx CGroups::GetCGroupV2MemoryLimit(FileSystem &fs) {
+#ifdef DUCKDB_WASM
+	return optional_idx();
+#else
 	const char *cgroup_self = "/proc/self/cgroup";
 	const char *memory_max = "/sys/fs/cgroup/%s/memory.max";
 
@@ -42,9 +45,13 @@ optional_idx CGroups::GetCGroupV2MemoryLimit(FileSystem &fs) {
 	}
 
 	return ReadCGroupValue(fs, memory_max_path);
+#endif
 }
 
 optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
+#ifdef DUCKDB_WASM
+	return optional_idx();
+#else
 	const char *cgroup_self = "/proc/self/cgroup";
 	const char *memory_limit = "/sys/fs/cgroup/memory/%s/memory.limit_in_bytes";
 
@@ -65,9 +72,13 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 	}
 
 	return ReadCGroupValue(fs, memory_limit_path);
+#endif
 }
 
 string CGroups::ReadCGroupPath(FileSystem &fs, const char *cgroup_file) {
+#ifdef DUCKDB_WASM
+	return "";
+#else
 	auto handle = fs.OpenFile(cgroup_file, FileFlags::FILE_FLAGS_READ);
 	char buffer[1024];
 	auto bytes_read = fs.Read(*handle, buffer, sizeof(buffer) - 1);
@@ -81,9 +92,13 @@ string CGroups::ReadCGroupPath(FileSystem &fs, const char *cgroup_file) {
 	}
 
 	return "";
+#endif
 }
 
 string CGroups::ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file) {
+#ifdef DUCKDB_WASM
+	return "";
+#else
 	auto handle = fs.OpenFile(cgroup_file, FileFlags::FILE_FLAGS_READ);
 	char buffer[1024];
 	auto bytes_read = fs.Read(*handle, buffer, sizeof(buffer) - 1);
@@ -102,9 +117,13 @@ string CGroups::ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file) {
 	}
 
 	return "";
+#endif
 }
 
 optional_idx CGroups::ReadCGroupValue(FileSystem &fs, const char *file_path) {
+#ifdef DUCKDB_WASM
+	return optional_idx();
+#else
 	auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
 	char buffer[100];
 	auto bytes_read = fs.Read(*handle, buffer, 99);
@@ -115,9 +134,14 @@ optional_idx CGroups::ReadCGroupValue(FileSystem &fs, const char *file_path) {
 		return optional_idx(value);
 	}
 	return optional_idx();
+#endif
 }
 
 idx_t CGroups::GetCPULimit(FileSystem &fs, idx_t physical_cores) {
+#ifdef DUCKDB_WASM
+	return physical_cores;
+#else
+
 	static constexpr const char *cpu_max = "/sys/fs/cgroup/cpu.max";
 	static constexpr const char *cfs_quota = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
 	static constexpr const char *cfs_period = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
@@ -159,6 +183,7 @@ idx_t CGroups::GetCPULimit(FileSystem &fs, idx_t physical_cores) {
 	} else {
 		return physical_cores;
 	}
+#endif
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Attempt to read `cgroup` files in Wasm when used in NodeJS on Linux is leading to stack overflow errors.

This PR disable entirely at compile type any attempt to open cgroup files.