### PR TITLE
[Python] Dont use the new `__arrow_c_stream__` for Polars when scanning `DataFrame` or `LazyFrame`

### DIFF
--- a/tools/pythonpkg/src/python_replacement_scan.cpp
+++ b/tools/pythonpkg/src/python_replacement_scan.cpp
@@ -105,8 +105,6 @@ unique_ptr<TableRef> PythonReplacementScan::TryReplacementObject(const py::objec
 		dependency->AddDependency("replacement_cache", PythonDependencyItem::Create(entry));
 		subquery->external_dependency = std::move(dependency);
 		return std::move(subquery);
-	} else if ((arrow_type = DuckDBPyConnection::GetArrowType(entry)) != PyArrowObjectType::Invalid) {
-		CreateArrowScan(name, entry, *table_function, children, client_properties, arrow_type);
 	} else if (PolarsDataFrame::IsDataFrame(entry)) {
 		auto arrow_dataset = entry.attr("to_arrow")();
 		CreateArrowScan(name, arrow_dataset, *table_function, children, client_properties, PyArrowObjectType::Table);
@@ -114,6 +112,8 @@ unique_ptr<TableRef> PythonReplacementScan::TryReplacementObject(const py::objec
 		auto materialized = entry.attr("collect")();
 		auto arrow_dataset = materialized.attr("to_arrow")();
 		CreateArrowScan(name, arrow_dataset, *table_function, children, client_properties, PyArrowObjectType::Table);
+	} else if ((arrow_type = DuckDBPyConnection::GetArrowType(entry)) != PyArrowObjectType::Invalid) {
+		CreateArrowScan(name, entry, *table_function, children, client_properties, arrow_type);
 	} else if ((numpytype = DuckDBPyConnection::IsAcceptedNumpyObject(entry)) != NumpyObjectType::INVALID) {
 		string name = "np_" + StringUtil::GenerateRandomName();
 		py::dict data; // we will convert all the supported format to dict{"key": np.array(value)}.


### PR DESCRIPTION
This PR fixes #13793 

An additional fix might need to be made so executing a relation made from an arrow_scan created from an object that provides the `__arrow_c_stream__` method does not trigger an error.

That currently throws an InternalException which is definitely not great, so that should at the minimal be downgraded to an InvalidInputException.

A further step could be to make it so that these relations can actually be executed multiple times, but that has lower priority in my opinion.