### PR TITLE
Fix issues in checkpointing of nested data

### DIFF
--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -417,6 +417,9 @@ void RowGroupCollection::FinalizeAppend(TransactionData transaction, TableAppend
 			continue;
 		}
 		auto &local_stats = state.stats.GetStats(*local_stats_lock, col_idx);
+		if (!local_stats.HasDistinctStats()) {
+			continue;
+		}
 		global_stats.DistinctStats().Merge(local_stats.DistinctStats());
 	}
 

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -812,6 +812,7 @@ public:
 				if (scan_chunk.size() == 0) {
 					break;
 				}
+				scan_chunk.Flatten();
 				idx_t remaining = scan_chunk.size();
 				while (remaining > 0) {
 					idx_t append_count =


### PR DESCRIPTION
* Fix distinct stats merge - correctly skip if local stats do not have distinct stats
* Flatten vector after scan in VacuumTask to prevent flattening using fewer rows later on in the Append causing issues with nested vectors