### PR TITLE
Limit the maximum number of vacuum tasks launched during a checkpoint, configurable through `max_vacuum_tasks`

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -269,7 +269,7 @@ struct DBConfigOptions {
 	//!  Whether or not to always write to the WAL file, even if this is not required
 	bool debug_skip_checkpoint_on_commit = false;
 	//! The maximum amount of vacuum tasks to schedule during a checkpoint
-	idx_t max_vacuum_tasks = 32;
+	idx_t max_vacuum_tasks = 100;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -268,6 +268,8 @@ struct DBConfigOptions {
 	idx_t catalog_error_max_schemas = 100;
 	//!  Whether or not to always write to the WAL file, even if this is not required
 	bool debug_skip_checkpoint_on_commit = false;
+	//! The maximum amount of vacuum tasks to schedule during a checkpoint
+	idx_t max_vacuum_tasks = 32;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -603,6 +603,15 @@ struct MaximumTempDirectorySize {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct MaximumVacuumTasks {
+	static constexpr const char *Name = "max_vacuum_tasks";
+	static constexpr const char *Description = "The maximum vacuum tasks to schedule during a checkpoint";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct MergeJoinThreshold {
 	static constexpr const char *Name = "merge_join_threshold";
 	static constexpr const char *Description = "The number of rows we need on either table to choose a merge join";

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -606,7 +606,7 @@ struct MaximumTempDirectorySize {
 struct MaximumVacuumTasks {
 	static constexpr const char *Name = "max_vacuum_tasks";
 	static constexpr const char *Description = "The maximum vacuum tasks to schedule during a checkpoint";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);

--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -38,6 +38,7 @@ public:
 	virtual CheckpointType GetCheckpointType() const = 0;
 
 	TaskScheduler &GetScheduler();
+	DatabaseInstance &GetDatabase();
 
 protected:
 	DuckTableEntry &table;

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -111,6 +111,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(StreamingBufferSize),
     DUCKDB_GLOBAL(MaximumMemorySetting),
     DUCKDB_GLOBAL(MaximumTempDirectorySize),
+    DUCKDB_GLOBAL(MaximumVacuumTasks),
     DUCKDB_LOCAL(MergeJoinThreshold),
     DUCKDB_LOCAL(NestedLoopJoinThreshold),
     DUCKDB_GLOBAL(OldImplicitCasting),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1347,7 +1347,7 @@ Value MaximumTempDirectorySize::GetSetting(const ClientContext &context) {
 // Maximum Vacuum Size
 //===--------------------------------------------------------------------===//
 void MaximumVacuumTasks::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
-	config.options.max_vacuum_tasks = input.GetValue<bool>();
+	config.options.max_vacuum_tasks = input.GetValue<uint64_t>();
 }
 
 void MaximumVacuumTasks::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
@@ -1356,7 +1356,7 @@ void MaximumVacuumTasks::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
 
 Value MaximumVacuumTasks::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
-	return Value::BOOLEAN(config.options.max_vacuum_tasks);
+	return Value::UBIGINT(config.options.max_vacuum_tasks);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -1344,6 +1344,22 @@ Value MaximumTempDirectorySize::GetSetting(const ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// Maximum Vacuum Size
+//===--------------------------------------------------------------------===//
+void MaximumVacuumTasks::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.options.max_vacuum_tasks = input.GetValue<bool>();
+}
+
+void MaximumVacuumTasks::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.max_vacuum_tasks = DBConfig().options.max_vacuum_tasks;
+}
+
+Value MaximumVacuumTasks::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.options.max_vacuum_tasks);
+}
+
+//===--------------------------------------------------------------------===//
 // Merge Join Threshold
 //===--------------------------------------------------------------------===//
 void MergeJoinThreshold::SetLocal(ClientContext &context, const Value &input) {

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -31,7 +31,11 @@ void TableDataWriter::AddRowGroup(RowGroupPointer &&row_group_pointer, unique_pt
 }
 
 TaskScheduler &TableDataWriter::GetScheduler() {
-	return TaskScheduler::GetScheduler(table.ParentCatalog().GetDatabase());
+	return TaskScheduler::GetScheduler(GetDatabase());
+}
+
+DatabaseInstance &TableDataWriter::GetDatabase() {
+	return table.ParentCatalog().GetDatabase();
 }
 
 SingleFileTableDataWriter::SingleFileTableDataWriter(SingleFileCheckpointWriter &checkpoint_manager,

--- a/test/sql/storage/vacuum/vacuum_partial_deletes.test_slow
+++ b/test/sql/storage/vacuum/vacuum_partial_deletes.test_slow
@@ -10,6 +10,9 @@ CREATE TABLE integers(i INTEGER);
 statement ok
 INSERT INTO integers SELECT * FROM range(1000000);
 
+statement ok
+SET max_vacuum_tasks=99
+
 query I
 SELECT SUM(i) FROM integers WHERE i%2<>0
 ----


### PR DESCRIPTION
Currently the vacuum tasks do not yet do optimistic writing, which can lead to large memory (or temp disk) usage if many vacuum jobs are performed at once. This should ideally be resolved differently in the future, but this adds a toggle that can limit the impact of this problem.