### PR TITLE
Issue #13813: TIMETZ Uninvertible Casts

### DIFF
--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -170,6 +170,7 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 		break;
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::BIT:
+	case LogicalTypeId::TIME_TZ:
 		return false;
 	default:
 		break;

--- a/test/sql/types/time/test_time_tz_icu.test
+++ b/test/sql/types/time/test_time_tz_icu.test
@@ -1,0 +1,39 @@
+# name: test/sql/types/time/test_time_tz_icu.test
+# description: Test TIMETZ cat invertilbility
+# group: [time]
+
+require icu
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SET Calendar='gregorian';
+
+statement ok
+SET TimeZone='Asia/Singapore';
+
+statement ok
+CREATE OR REPLACE TABLE single(c0 TIME WITH TIME ZONE);
+
+statement ok
+INSERT INTO single(c0) VALUES ('12:34:56');
+
+query III
+SELECT 
+	c0, 
+	c0::TIME AS t,
+	c0::TIME::TIMETZ AS tz,
+FROM single;
+----
+12:34:56+08	12:34:56	12:34:56+00
+
+query IIII
+SELECT 
+	(c0::TIME = '12:34:56') AS e,
+	(c0::TIME <> '12:34:56') AS u,
+	(c0::TIME IN ('12:34:56')) AS i,
+	(c0::TIME NOT IN ('12:34:56')) AS n,
+FROM single;
+----
+1	0	1	0


### PR DESCRIPTION
TIMETZ => TIME => TIMETZ does not round trip because the first cast loses the offset. The reverse does round trip because the offset will be 0.

fixes: duckdb/duckdb#13813
fixes: duckdblabs/duckdb-internal#2986