### PR TITLE
[Python] Fix a crash related to handling of the `f_locals`

### DIFF
--- a/tools/pythonpkg/src/python_replacement_scan.cpp
+++ b/tools/pythonpkg/src/python_replacement_scan.cpp
@@ -197,7 +197,7 @@ static unique_ptr<TableRef> ReplaceInternal(ClientContext &context, const string
 	py::gil_scoped_acquire acquire;
 	auto current_frame = py::module::import("inspect").attr("currentframe")();
 
-	auto local_dict = py::reinterpret_borrow<py::dict>(current_frame.attr("f_locals"));
+	auto local_dict = py::cast<py::dict>(current_frame.attr("f_locals"));
 	// search local dictionary
 	if (local_dict) {
 		auto result = TryReplacement(local_dict, table_name, context, current_frame);
@@ -206,7 +206,7 @@ static unique_ptr<TableRef> ReplaceInternal(ClientContext &context, const string
 		}
 	}
 	// search global dictionary
-	auto global_dict = py::reinterpret_borrow<py::dict>(current_frame.attr("f_globals"));
+	auto global_dict = py::cast<py::dict>(current_frame.attr("f_globals"));
 	if (global_dict) {
 		auto result = TryReplacement(global_dict, table_name, context, current_frame);
 		if (result) {


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/2853

This has been tested with `python3.13.0rc2`

Dependencies are installed with: `python3 tools/pythonpkg/scripts/optional_requirements.py`
Build was made with `BUILD_PYTHON=1 make reldebug`
Test was run with `python3 -m pytest tools/pythonpkg/tests/fast`