### PR TITLE
[Dev] Remove unnecessary parameter from BufferHandle constructor

### DIFF
--- a/src/include/duckdb/storage/buffer/buffer_handle.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_handle.hpp
@@ -18,7 +18,7 @@ class FileBuffer;
 class BufferHandle {
 public:
 	DUCKDB_API BufferHandle();
-	DUCKDB_API BufferHandle(shared_ptr<BlockHandle> handle, FileBuffer *node);
+	DUCKDB_API BufferHandle(shared_ptr<BlockHandle> handle);
 	DUCKDB_API ~BufferHandle();
 	// disable copy constructors
 	BufferHandle(const BufferHandle &other) = delete;
@@ -53,7 +53,7 @@ private:
 	//! The block handle
 	shared_ptr<BlockHandle> handle;
 	//! The managed buffer node
-	FileBuffer *node;
+	optional_ptr<FileBuffer> node;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/buffer/buffer_handle.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_handle.hpp
@@ -18,7 +18,7 @@ class FileBuffer;
 class BufferHandle {
 public:
 	DUCKDB_API BufferHandle();
-	DUCKDB_API BufferHandle(shared_ptr<BlockHandle> handle);
+	DUCKDB_API explicit BufferHandle(shared_ptr<BlockHandle> handle);
 	DUCKDB_API ~BufferHandle();
 	// disable copy constructors
 	BufferHandle(const BufferHandle &other) = delete;

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -79,14 +79,14 @@ BufferHandle BlockHandle::LoadFromBuffer(shared_ptr<BlockHandle> &handle, data_p
 	memcpy(block->InternalBuffer(), data, block->AllocSize());
 	handle->buffer = std::move(block);
 	handle->state = BlockState::BLOCK_LOADED;
-	return BufferHandle(handle, handle->buffer.get());
+	return BufferHandle(handle);
 }
 
 BufferHandle BlockHandle::Load(shared_ptr<BlockHandle> &handle, unique_ptr<FileBuffer> reusable_buffer) {
 	if (handle->state == BlockState::BLOCK_LOADED) {
 		// already loaded
 		D_ASSERT(handle->buffer);
-		return BufferHandle(handle, handle->buffer.get());
+		return BufferHandle(handle);
 	}
 
 	auto &block_manager = handle->block_manager;
@@ -103,7 +103,7 @@ BufferHandle BlockHandle::Load(shared_ptr<BlockHandle> &handle, unique_ptr<FileB
 		}
 	}
 	handle->state = BlockState::BLOCK_LOADED;
-	return BufferHandle(handle, handle->buffer.get());
+	return BufferHandle(handle);
 }
 
 unique_ptr<FileBuffer> BlockHandle::UnloadAndTakeBlock() {

--- a/src/storage/buffer/buffer_handle.cpp
+++ b/src/storage/buffer/buffer_handle.cpp
@@ -7,8 +7,8 @@ namespace duckdb {
 BufferHandle::BufferHandle() : handle(nullptr), node(nullptr) {
 }
 
-BufferHandle::BufferHandle(shared_ptr<BlockHandle> handle_p, FileBuffer *node_p)
-    : handle(std::move(handle_p)), node(node_p) {
+BufferHandle::BufferHandle(shared_ptr<BlockHandle> handle_p)
+    : handle(std::move(handle_p)), node(handle ? handle->buffer.get() : nullptr) {
 }
 
 BufferHandle::BufferHandle(BufferHandle &&other) noexcept : node(nullptr) {


### PR DESCRIPTION
Just something I noticed while working on something related to the buffer manager.

BufferHandle takes a BlockHandle and a FileBuffer pointer, but it's a raw pointer so unless the lifetime is guaranteed by an outside scope, providing anything other than the `handle->buffer.get()` can cause a heap use after free issue.

Tracing back the lineage, this originates from an age before we had `BlockHandle`: https://github.com/Mytherin/duckdb/commit/7251a5537934e91408c4b78863442b35ee1671e9#diff-bf94710a9036c38ee30044ac99f5752dc2bddfda44cd3f82992d992501f3d956