### PR TITLE
When vacuuming, immediately checkpoint the vacuumed row groups instead of scheduling a checkpoint task

### DIFF
--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -99,7 +99,8 @@ public:
 
 	void InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state,
 	                           vector<SegmentNode<RowGroup>> &segments);
-	bool ScheduleVacuumTasks(CollectionCheckpointState &checkpoint_state, VacuumState &state, idx_t segment_idx);
+	bool ScheduleVacuumTasks(CollectionCheckpointState &checkpoint_state, VacuumState &state, idx_t segment_idx,
+	                         bool schedule_vacuum);
 	unique_ptr<CheckpointTask> GetCheckpointTask(CollectionCheckpointState &checkpoint_state, idx_t segment_idx);
 
 	void CommitDropColumn(idx_t index);

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -33,6 +33,7 @@ class MetadataManager;
 struct VacuumState;
 struct CollectionCheckpointState;
 struct PersistentCollectionData;
+class CheckpointTask;
 
 class RowGroupCollection {
 public:
@@ -99,7 +100,7 @@ public:
 	void InitializeVacuumState(CollectionCheckpointState &checkpoint_state, VacuumState &state,
 	                           vector<SegmentNode<RowGroup>> &segments);
 	bool ScheduleVacuumTasks(CollectionCheckpointState &checkpoint_state, VacuumState &state, idx_t segment_idx);
-	void ScheduleCheckpointTask(CollectionCheckpointState &checkpoint_state, idx_t segment_idx);
+	unique_ptr<CheckpointTask> GetCheckpointTask(CollectionCheckpointState &checkpoint_state, idx_t segment_idx);
 
 	void CommitDropColumn(idx_t index);
 	void CommitDropTable();

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -903,7 +903,7 @@ bool RowGroupCollection::ScheduleVacuumTasks(CollectionCheckpointState &checkpoi
 		D_ASSERT(!checkpoint_state.segments[segment_idx].node);
 		return false;
 	}
-	if (schedule_vacuum) {
+	if (!schedule_vacuum) {
 		return false;
 	}
 	idx_t merge_rows;


### PR DESCRIPTION
This fixes an issue where if we are vacuuming many row groups, the system was first vacuuming everything into in-memory row groups, followed by checkpointing them later on. By directly executing the checkpoint we can checkpoint the row groups while they are still fresh in-memory, and we avoid having to keep them in-memory for an extended period of time.

This partially alleviates the need for the max_vacuum_tasks introduced in https://github.com/duckdb/duckdb/pull/13811 - although having a limit is likely still a good idea.