### PR TITLE
Add support for `file://` prefix

### DIFF
--- a/test/sql/copy/csv/csv_enum.test
+++ b/test/sql/copy/csv/csv_enum.test
@@ -9,7 +9,7 @@ statement ok
 CREATE TYPE bla AS ENUM ('Y', 'N');
 
 query I
-select * from read_csv_auto('data/csv/response.csv', header = 0)
+select * from read_csv_auto('file://data/csv/response.csv', header = 0)
 ----
 Y
 Y


### PR DESCRIPTION
Closes #13669 and [duckdb_iceberg#38](https://github.com/duckdb/duckdb_iceberg/issues/38)

First-time contributor, help is appreciated! 

Open questions
* Is `LocalFileSystem::Glob` the right place to implement this? 
* Should `CanHandleFile` be overwritten? (like in the [hf example](https://github.com/duckdb/duckdb/pull/11831/files#diff-92c476e8ce6f3e801d4f25a09fedb86bd92dccb61a2be58f7ca658132c6043ebR34))
* Where to put tests for this?

### Testing
```
make debug
./build/debug/test/unittest test/sql/copy/csv/csv_enum.test
```

### References
* `hf://` support #11831
* `tar://` support https://github.com/search?q=repo%3AMaxxen%2Fduckdb_tarfs+tar%3A%2F%2F&type=code
* [`delta_scan` support for `file://`](https://github.com/duckdb/duckdb/blob/49a28e32aa68d6d9595612da185d75896571fc74/extension/delta/src/functions/delta_scan.cpp#L140-L163)