### PR TITLE
[Fix ART] Correct prefix transformation

### DIFF
--- a/test/sql/index/art/scan/test_art_scan_coverage.test
+++ b/test/sql/index/art/scan/test_art_scan_coverage.test
@@ -104,3 +104,21 @@ SELECT c0 FROM t0_varchar WHERE t0_varchar.c0 <= 'a';
 ----
 a
 a
+
+# Issue #13842
+
+statement ok
+CREATE TABLE  t0_scan(c0 DATE);
+
+statement ok
+INSERT INTO t0_scan(c0) VALUES ('1970-01-02'), ('1970-01-02'), ('1970-01-03');
+
+statement ok
+CREATE INDEX t0i0 ON t0_scan(c0 DESC);
+
+query I
+SELECT c0 FROM t0_scan WHERE '1970-01-03' >= t0_scan.c0 ORDER BY c0;
+----
+1970-01-02
+1970-01-02
+1970-01-03

--- a/test/sql/index/art/storage/test_art_import.test
+++ b/test/sql/index/art/storage/test_art_import.test
@@ -15,10 +15,10 @@ statement ok
 INSERT INTO tracking values ('a', 0,0,0);
 
 statement ok
-create index nflid_idx on tracking (nflid)
+CREATE INDEX nflid_idx ON tracking (nflid)
 
 statement ok
-create unique index tracking_key_idx on tracking (gameId, playId, frameId, nflId)
+CREATE UNIQUE INDEX tracking_key_idx ON tracking (gameId, playId, frameId, nflId)
 
 statement ok
 EXPORT DATABASE '__TEST_DIR__/index';

--- a/test/sql/index/art/storage/test_art_import_export.test
+++ b/test/sql/index/art/storage/test_art_import_export.test
@@ -2,12 +2,12 @@
 # description: Test the export and import of the ART
 # group: [storage]
 
-statement ok
-PRAGMA enable_verification
-
-# issue 4126
+# Issue #4126
 
 load __TEST_DIR__/test_art_export.db
+
+statement ok
+PRAGMA enable_verification
 
 statement ok
 CREATE TABLE raw(

--- a/test/sql/index/art/storage/test_art_storage.test
+++ b/test/sql/index/art/storage/test_art_storage.test
@@ -2,10 +2,10 @@
 # description: Test ART storage
 # group: [storage]
 
+load __TEST_DIR__/test_index.db
+
 statement ok
 PRAGMA enable_verification
-
-load __TEST_DIR__/test_index.db
 
 statement ok
 CREATE TABLE integers(i integer,j integer)

--- a/test/sql/index/art/storage/test_art_storage_long_prefixes.test
+++ b/test/sql/index/art/storage/test_art_storage_long_prefixes.test
@@ -1,0 +1,48 @@
+# name: test/sql/index/art/storage/test_art_storage_long_prefixes.test
+# description: Test ART storage with long prefixes
+# group: [storage]
+
+load __TEST_DIR__/test_art_load.db
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET wal_autocheckpoint = '10GB';
+
+statement ok
+CREATE TABLE history(id TEXT, type TEXT, PRIMARY KEY(id, type));
+
+statement ok
+INSERT INTO history(id, type) VALUES ('5_create_aaaaaaaaaaa_mapping', 'sql');
+
+statement ok
+CHECKPOINT
+
+# Original issue #3019
+
+load __TEST_DIR__/test_art_load_original.db
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown;
+
+statement ok
+SET wal_autocheckpoint = '10GB';
+
+statement ok
+CREATE TABLE history(id TEXT, type TEXT, PRIMARY KEY(id, type));
+
+statement ok
+INSERT INTO history(id, type) VALUES ('m0001_initialize', 'sql');
+
+statement ok
+INSERT INTO history(id, type) VALUES ('m0005_create_aaaaaaaaaaa_mapping_table', 'sql');
+
+statement ok
+CHECKPOINT


### PR DESCRIPTION
The recent release introduced variable prefix sizes in indexes. To stay forwards compatible with older DuckDB versions, we currently still transform prefixes to their deprecated length when persisting a DB. The bug was caused by prefixes exceeding the `DEPRECATED_COUNT` of 15 bytes.

Most scenarios would take the `fast path` (`prefix size <= DEPRECATED_COUNT`) in `Prefix::TransformToDeprecated`. Here, the non-fast path did not adjust the original node `node = new_node;`. Also, `ref` would reference the overwritten `ptr`. 

Fixes https://github.com/duckdb/duckdb/issues/13854.
Fixes https://github.com/duckdb/duckdb/issues/13842.
Might also address https://github.com/duckdb/duckdb/issues/13834.