### PR TITLE
Fix #13805: throw a more descriptive error message when an on-disk file is referenced using a replacement scan for an unsupported file format

### DIFF
--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -202,7 +202,9 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				return replacement_scan_bind_result;
 			}
 		}
-		if (StringUtil::Contains(full_path, ".")) {
+		auto &config = DBConfig::GetConfig(context);
+		if (context.config.use_replacement_scans && config.options.enable_external_access &&
+		    StringUtil::Contains(full_path, ".")) {
 			auto &fs = FileSystem::GetFileSystem(context);
 			if (fs.FileExists(full_path)) {
 				throw BinderException(

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -202,6 +202,15 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 				return replacement_scan_bind_result;
 			}
 		}
+		if (StringUtil::Contains(full_path, ".")) {
+			auto &fs = FileSystem::GetFileSystem(context);
+			if (fs.FileExists(full_path)) {
+				throw BinderException(
+				    "No extension found that is capable of reading the file \"%s\"\n* If this file is a supported file "
+				    "format you can explicitly use the reader functions, such as read_csv, read_json or read_parquet",
+				    full_path);
+			}
+		}
 
 		// could not find an alternative: bind again to get the error
 		(void)entry_retriever.GetEntry(CatalogType::TABLE_ENTRY, ref.catalog_name, ref.schema_name, ref.table_name,

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -204,7 +204,7 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 		}
 		auto &config = DBConfig::GetConfig(context);
 		if (context.config.use_replacement_scans && config.options.enable_external_access &&
-		    StringUtil::Contains(full_path, ".")) {
+		    ExtensionHelper::IsFullPath(full_path)) {
 			auto &fs = FileSystem::GetFileSystem(context);
 			if (fs.FileExists(full_path)) {
 				throw BinderException(

--- a/test/sql/copy/parquet/replacement_scan_custom_extension.test
+++ b/test/sql/copy/parquet/replacement_scan_custom_extension.test
@@ -1,0 +1,21 @@
+# name: test/sql/copy/parquet/replacement_scan_custom_extension.test
+# description: Test unknown extensions in replacement scans
+# group: [parquet]
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+COPY (SELECT 42 a) to '__TEST_DIR__/lists.my_file_extension' (FORMAT PARQUET);
+
+statement error
+FROM '__TEST_DIR__/lists.my_file_extension';
+----
+No extension found that is capable of reading the file
+
+query I
+FROM read_parquet('__TEST_DIR__/lists.my_file_extension')
+----
+42


### PR DESCRIPTION
Fixes #13805 

We now throw the following error:

```sql
select * from "CMakeLists.txt";
-- Binder Error: No extension found that is capable of reading the file "CMakeLists.txt"
-- * If this file is a supported file format you can explicitly use the reader functions, such as read_csv, read_json or read_parquet
```