### PR TITLE
Preserve operator in `BindWithCTE`

### DIFF
--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/database.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/subquery_expression.hpp"
 #include "duckdb/parser/parsed_expression_iterator.hpp"
@@ -21,7 +22,6 @@
 #include "duckdb/planner/operator/logical_sample.hpp"
 #include "duckdb/planner/query_node/list.hpp"
 #include "duckdb/planner/tableref/list.hpp"
-#include "duckdb/main/database.hpp"
 
 #include <algorithm>
 
@@ -134,10 +134,8 @@ BoundStatement Binder::BindWithCTE(T &statement) {
 		}
 		MoveCorrelatedExpressions(*tail.child_binder);
 
-		// extract operator below root operation
-		auto plan = std::move(bound_statement.plan->children[0]);
-		bound_statement.plan->children.clear();
-		bound_statement.plan->children.push_back(CreatePlan(*bound_cte, std::move(plan)));
+		auto plan = std::move(bound_statement.plan);
+		bound_statement.plan = CreatePlan(*bound_cte, std::move(plan));
 	} else {
 		bound_statement = Bind(statement.template Cast<T>());
 	}

--- a/test/sql/cte/materialized/internal_3004.test
+++ b/test/sql/cte/materialized/internal_3004.test
@@ -1,0 +1,31 @@
+# name: test/sql/cte/materialized/internal_3004.test
+# description: INTERNAL Error: Attempted to access index 1 within vector of size 1 -> harlequin internal code, CTE related
+# group: [materialized]
+
+statement ok
+with
+    system_types as (
+        select distinct
+            type_name as label,
+            'type' as type_label,
+            1000 as priority,
+            null as context
+        from duckdb_types()
+        where database_name = 'system'
+    ),
+    custom_types as (
+        select distinct
+            type_name as label,
+            'type' as type_label,
+            1000 as priority,
+            schema_name as context
+        from duckdb_types()
+        where
+            database_name not in ('system', 'temp')
+            and type_name not in (select label from system_types)
+    )
+select *
+from system_types
+union all
+select *
+from custom_types


### PR DESCRIPTION
Not sure how this didn't cause any issues before, but `BindWithCTE` swallowed an operator. This PR fixes that.