### PR TITLE
13810 unnest cross join error

### DIFF
--- a/src/optimizer/join_order/relation_manager.cpp
+++ b/src/optimizer/join_order/relation_manager.cpp
@@ -85,6 +85,7 @@ static bool OperatorNeedsRelation(LogicalOperatorType op_type) {
 	case LogicalOperatorType::LOGICAL_PROJECTION:
 	case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
 	case LogicalOperatorType::LOGICAL_GET:
+	case LogicalOperatorType::LOGICAL_UNNEST:
 	case LogicalOperatorType::LOGICAL_DELIM_GET:
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
 	case LogicalOperatorType::LOGICAL_WINDOW:

--- a/test/optimizer/joins/cross_join_and_unnest_dont_work.test
+++ b/test/optimizer/joins/cross_join_and_unnest_dont_work.test
@@ -4,5 +4,11 @@
 
 
 statement ok
-SELECT y + z AS c FROM (SELECT y, unnest([x]) AS z FROM (SELECT 1 as x), (SELECT 1 as y))
+SELECT y + z AS c
+FROM (
+	SELECT y, unnest([x]) AS z
+	FROM
+		(SELECT 1 as x),
+		(SELECT 1 as y)
+	)
  WHERE c > 0;

--- a/test/optimizer/joins/cross_join_and_unnest_dont_work.test
+++ b/test/optimizer/joins/cross_join_and_unnest_dont_work.test
@@ -1,0 +1,8 @@
+# name: test/optimizer/joins/cross_join_and_unnest_dont_work.test
+# description: Internal issue
+# group: [joins]
+
+
+statement ok
+SELECT y + z AS c FROM (SELECT y, unnest([x]) AS z FROM (SELECT 1 as x), (SELECT 1 as y))
+ WHERE c > 0;

--- a/test/optimizer/joins/cross_join_and_unnest_dont_work.test
+++ b/test/optimizer/joins/cross_join_and_unnest_dont_work.test
@@ -2,7 +2,6 @@
 # description: Internal issue
 # group: [joins]
 
-
 statement ok
 SELECT y + z AS c
 FROM (


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/2979

The original plan with no optimization looks like this 
```
┌───────────────────────────┐
│         PROJECTION        │
│    ────────────────────   │
│             c             │
│                           │
│          ~0 Rows          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│           FILTER          │
│    ────────────────────   │
│    ((y + z) > CAST(0 AS   │
│          INTEGER))        │
│                           │
│          ~0 Rows          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│             y             │
│             z             │
│                           │
│          ~0 Rows          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│           UNNEST          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│       CROSS_PRODUCT       ├──────────────┐
└─────────────┬─────────────┘              │
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         PROJECTION        ││         PROJECTION        │
│    ────────────────────   ││    ────────────────────   │
│             x             ││             y             │
│                           ││                           │
│          ~1 Rows          ││          ~1 Rows          │
└─────────────┬─────────────┘└─────────────┬─────────────┘
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│         DUMMY_SCAN        ││         DUMMY_SCAN        │
└───────────────────────────┘└───────────────────────────┘
```

The UNNEST has an index, and is a blocking operator (I think?). The filter above it is extracted so that it can be used as a potential join filter. The problem here is that the filter has bindings from the unnest, so when we attempt to use it to join the two tables, the join order optimizer will throw an error because the filter bindings (which are only available above the unnest) are not available below the unnest. 

The solution I have for this is to optimize everything below the unnest separately. In the future I may want to implement a pushdown/pullup unnest optimizer to find the best place to put an unnest. 