### PR TITLE
Explicit windows-2019 instead of windows-latest

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -43,7 +43,7 @@ jobs:
   rstats-windows-extensions:
     # Builds extensions for windows_amd64_rtools
     name: R Package Windows (Extensions)
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -53,7 +53,7 @@ jobs:
  win-release-64:
     # Builds binaries for windows_amd64
     name: Windows (64 Bit)
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v4
       with:
@@ -212,7 +212,7 @@ jobs:
 
  mingw:
      name: MingW (64 Bit)
-     runs-on: windows-latest
+     runs-on: windows-2019
      if: ${{ inputs.skip_tests != 'true' }}
      needs: win-release-64
      steps:
@@ -256,7 +256,7 @@ jobs:
  win-extensions-64:
    # Builds extensions for windows_amd64
    name: Windows Extensions (64-bit)
-   runs-on: windows-latest
+   runs-on: windows-2019
    needs: win-release-64
    steps:
      - name: Keep \n line endings
@@ -290,7 +290,7 @@ jobs:
          unittest_script: python3 scripts/run_tests_one_by_one.py ./build/release/test/Release/unittest.exe
 
  win-packaged-upload:
-   runs-on: windows-latest
+   runs-on: windows-2019
    needs:
      - win-release-64
      - win-release-arm64


### PR DESCRIPTION
Using windows-latest meant defaulting to a recent Windows SDK, that caused issues such as https://github.com/duckdb/duckdb/issues/13848 or https://github.com/duckdb/duckdb/issues/13864

Issue is, at his core, that we were depending on a Microsoft Visual C++ Redistributable package that is not installed by default on Windows 2019.

Thanks everyone for reporting this, and @szarnyasg and @Mytherin for helping figuring this out.

This PR provide a way forward for build artifact that will be built, but also allow a blueprint (and the means) on how to rebuild `v1.1.0` release Windows artifacts, that will likely happen tomorrow. This will offer a solution after downloading new artifacts, after we can confirm they work.

Other duckdb repositories might have the same problem, and would need to be reviewed.