### PR TITLE
Add custom conversions between '' and ExtensionABIType::CPP

### DIFF
--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -33,6 +33,9 @@ overrides = {
     },
     "SampleMethod": {"SYSTEM_SAMPLE": "System", "BERNOULLI_SAMPLE": "Bernoulli", "RESERVOIR_SAMPLE": "Reservoir"},
     "TableReferenceType": {"EMPTY_FROM": "EMPTY"},
+    "ExtensionABIType": {
+        "CPP": ["CPP", ""],
+    },
 }
 
 

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -2789,7 +2789,7 @@ ExtensionABIType EnumUtil::FromString<ExtensionABIType>(const char *value) {
 	if (StringUtil::Equals(value, "UNKNOWN")) {
 		return ExtensionABIType::UNKNOWN;
 	}
-	if (StringUtil::Equals(value, "CPP")) {
+	if (StringUtil::Equals(value, "CPP") || StringUtil::Equals(value, "")) {
 		return ExtensionABIType::CPP;
 	}
 	if (StringUtil::Equals(value, "C_STRUCT")) {


### PR DESCRIPTION
This solves problems such as https://github.com/duckdb/duckdb_vss/issues/28, where loading an older extension (such as the one built for v1.0.0) would result in an error message like:
```
Not implemented Error: Enum value: '' not implemented
```
instead of the expected:
```
Invalid Input Error: Failed to load 'path/to/extension_name.duckdb_extension', The file was built for DuckDB version 'v1.0.0', but we can only load extensions built for DuckDB version 'xyz'.
```

Note that in both cases the extension is NOT compatible, and this will be triggered only by problematic cases.
Also this is not completely solved in all cases, namely duckdb with this PR reading an extension coming from the future that would use a new (and so unseen) enum. That will come next, ideally together with tests, but first fixing this and rework will come next.