### PR TITLE
Improve error on enums

### DIFF
--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -193,7 +193,7 @@ with open(enum_util_source_file, "w") as f:
             # Always use the first string as the enum string
             f.write(f"\tcase {enum_name}::{key}:\n\t\treturn \"{strings[0]}\";\n")
         f.write(
-            '\tdefault:\n\t\tthrow NotImplementedException(StringUtil::Format("Enum value: \'%d\' not implemented", value));\n'
+            f"\tdefault:\n\t\tthrow NotImplementedException(StringUtil::Format(\"Enum value: \'%d\' not implemented in ToChars<{enum_name}>\", value));\n"
         )
         f.write("\t}\n")
         f.write("}\n\n")
@@ -203,7 +203,9 @@ with open(enum_util_source_file, "w") as f:
         for key, strings in enum_members:
             cond = " || ".join([f'StringUtil::Equals(value, "{string}")' for string in strings])
             f.write(f'\tif ({cond}) {{\n\t\treturn {enum_name}::{key};\n\t}}\n')
-        f.write('\tthrow NotImplementedException(StringUtil::Format("Enum value: \'%s\' not implemented", value));\n')
+        f.write(
+            f"\tthrow NotImplementedException(StringUtil::Format(\"Enum value: \'%s\' not implemented in FromString<{enum_name}>\", value));\n"
+        )
 
         f.write("}\n\n")
 

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -155,7 +155,7 @@ const char* EnumUtil::ToChars<AccessMode>(AccessMode value) {
 	case AccessMode::READ_WRITE:
 		return "READ_WRITE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AccessMode>", value));
 	}
 }
 
@@ -173,7 +173,7 @@ AccessMode EnumUtil::FromString<AccessMode>(const char *value) {
 	if (StringUtil::Equals(value, "READ_WRITE")) {
 		return AccessMode::READ_WRITE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AccessMode>", value));
 }
 
 template<>
@@ -184,7 +184,7 @@ const char* EnumUtil::ToChars<AggregateCombineType>(AggregateCombineType value) 
 	case AggregateCombineType::ALLOW_DESTRUCTIVE:
 		return "ALLOW_DESTRUCTIVE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AggregateCombineType>", value));
 	}
 }
 
@@ -196,7 +196,7 @@ AggregateCombineType EnumUtil::FromString<AggregateCombineType>(const char *valu
 	if (StringUtil::Equals(value, "ALLOW_DESTRUCTIVE")) {
 		return AggregateCombineType::ALLOW_DESTRUCTIVE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AggregateCombineType>", value));
 }
 
 template<>
@@ -209,7 +209,7 @@ const char* EnumUtil::ToChars<AggregateHandling>(AggregateHandling value) {
 	case AggregateHandling::FORCE_AGGREGATES:
 		return "FORCE_AGGREGATES";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AggregateHandling>", value));
 	}
 }
 
@@ -224,7 +224,7 @@ AggregateHandling EnumUtil::FromString<AggregateHandling>(const char *value) {
 	if (StringUtil::Equals(value, "FORCE_AGGREGATES")) {
 		return AggregateHandling::FORCE_AGGREGATES;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AggregateHandling>", value));
 }
 
 template<>
@@ -235,7 +235,7 @@ const char* EnumUtil::ToChars<AggregateOrderDependent>(AggregateOrderDependent v
 	case AggregateOrderDependent::NOT_ORDER_DEPENDENT:
 		return "NOT_ORDER_DEPENDENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AggregateOrderDependent>", value));
 	}
 }
 
@@ -247,7 +247,7 @@ AggregateOrderDependent EnumUtil::FromString<AggregateOrderDependent>(const char
 	if (StringUtil::Equals(value, "NOT_ORDER_DEPENDENT")) {
 		return AggregateOrderDependent::NOT_ORDER_DEPENDENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AggregateOrderDependent>", value));
 }
 
 template<>
@@ -258,7 +258,7 @@ const char* EnumUtil::ToChars<AggregateType>(AggregateType value) {
 	case AggregateType::DISTINCT:
 		return "DISTINCT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AggregateType>", value));
 	}
 }
 
@@ -270,7 +270,7 @@ AggregateType EnumUtil::FromString<AggregateType>(const char *value) {
 	if (StringUtil::Equals(value, "DISTINCT")) {
 		return AggregateType::DISTINCT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AggregateType>", value));
 }
 
 template<>
@@ -281,7 +281,7 @@ const char* EnumUtil::ToChars<AlterForeignKeyType>(AlterForeignKeyType value) {
 	case AlterForeignKeyType::AFT_DELETE:
 		return "AFT_DELETE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AlterForeignKeyType>", value));
 	}
 }
 
@@ -293,7 +293,7 @@ AlterForeignKeyType EnumUtil::FromString<AlterForeignKeyType>(const char *value)
 	if (StringUtil::Equals(value, "AFT_DELETE")) {
 		return AlterForeignKeyType::AFT_DELETE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AlterForeignKeyType>", value));
 }
 
 template<>
@@ -304,7 +304,7 @@ const char* EnumUtil::ToChars<AlterScalarFunctionType>(AlterScalarFunctionType v
 	case AlterScalarFunctionType::ADD_FUNCTION_OVERLOADS:
 		return "ADD_FUNCTION_OVERLOADS";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AlterScalarFunctionType>", value));
 	}
 }
 
@@ -316,7 +316,7 @@ AlterScalarFunctionType EnumUtil::FromString<AlterScalarFunctionType>(const char
 	if (StringUtil::Equals(value, "ADD_FUNCTION_OVERLOADS")) {
 		return AlterScalarFunctionType::ADD_FUNCTION_OVERLOADS;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AlterScalarFunctionType>", value));
 }
 
 template<>
@@ -327,7 +327,7 @@ const char* EnumUtil::ToChars<AlterTableFunctionType>(AlterTableFunctionType val
 	case AlterTableFunctionType::ADD_FUNCTION_OVERLOADS:
 		return "ADD_FUNCTION_OVERLOADS";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AlterTableFunctionType>", value));
 	}
 }
 
@@ -339,7 +339,7 @@ AlterTableFunctionType EnumUtil::FromString<AlterTableFunctionType>(const char *
 	if (StringUtil::Equals(value, "ADD_FUNCTION_OVERLOADS")) {
 		return AlterTableFunctionType::ADD_FUNCTION_OVERLOADS;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AlterTableFunctionType>", value));
 }
 
 template<>
@@ -368,7 +368,7 @@ const char* EnumUtil::ToChars<AlterTableType>(AlterTableType value) {
 	case AlterTableType::SET_COLUMN_COMMENT:
 		return "SET_COLUMN_COMMENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AlterTableType>", value));
 	}
 }
 
@@ -407,7 +407,7 @@ AlterTableType EnumUtil::FromString<AlterTableType>(const char *value) {
 	if (StringUtil::Equals(value, "SET_COLUMN_COMMENT")) {
 		return AlterTableType::SET_COLUMN_COMMENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AlterTableType>", value));
 }
 
 template<>
@@ -432,7 +432,7 @@ const char* EnumUtil::ToChars<AlterType>(AlterType value) {
 	case AlterType::SET_COLUMN_COMMENT:
 		return "SET_COLUMN_COMMENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AlterType>", value));
 	}
 }
 
@@ -465,7 +465,7 @@ AlterType EnumUtil::FromString<AlterType>(const char *value) {
 	if (StringUtil::Equals(value, "SET_COLUMN_COMMENT")) {
 		return AlterType::SET_COLUMN_COMMENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AlterType>", value));
 }
 
 template<>
@@ -476,7 +476,7 @@ const char* EnumUtil::ToChars<AlterViewType>(AlterViewType value) {
 	case AlterViewType::RENAME_VIEW:
 		return "RENAME_VIEW";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AlterViewType>", value));
 	}
 }
 
@@ -488,7 +488,7 @@ AlterViewType EnumUtil::FromString<AlterViewType>(const char *value) {
 	if (StringUtil::Equals(value, "RENAME_VIEW")) {
 		return AlterViewType::RENAME_VIEW;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AlterViewType>", value));
 }
 
 template<>
@@ -499,7 +499,7 @@ const char* EnumUtil::ToChars<AppenderType>(AppenderType value) {
 	case AppenderType::PHYSICAL:
 		return "PHYSICAL";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<AppenderType>", value));
 	}
 }
 
@@ -511,7 +511,7 @@ AppenderType EnumUtil::FromString<AppenderType>(const char *value) {
 	if (StringUtil::Equals(value, "PHYSICAL")) {
 		return AppenderType::PHYSICAL;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<AppenderType>", value));
 }
 
 template<>
@@ -532,7 +532,7 @@ const char* EnumUtil::ToChars<ArrowDateTimeType>(ArrowDateTimeType value) {
 	case ArrowDateTimeType::MONTH_DAY_NANO:
 		return "MONTH_DAY_NANO";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ArrowDateTimeType>", value));
 	}
 }
 
@@ -559,7 +559,7 @@ ArrowDateTimeType EnumUtil::FromString<ArrowDateTimeType>(const char *value) {
 	if (StringUtil::Equals(value, "MONTH_DAY_NANO")) {
 		return ArrowDateTimeType::MONTH_DAY_NANO;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ArrowDateTimeType>", value));
 }
 
 template<>
@@ -570,7 +570,7 @@ const char* EnumUtil::ToChars<ArrowOffsetSize>(ArrowOffsetSize value) {
 	case ArrowOffsetSize::LARGE:
 		return "LARGE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ArrowOffsetSize>", value));
 	}
 }
 
@@ -582,7 +582,7 @@ ArrowOffsetSize EnumUtil::FromString<ArrowOffsetSize>(const char *value) {
 	if (StringUtil::Equals(value, "LARGE")) {
 		return ArrowOffsetSize::LARGE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ArrowOffsetSize>", value));
 }
 
 template<>
@@ -599,7 +599,7 @@ const char* EnumUtil::ToChars<ArrowTypeInfoType>(ArrowTypeInfoType value) {
 	case ArrowTypeInfoType::ARRAY:
 		return "ARRAY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ArrowTypeInfoType>", value));
 	}
 }
 
@@ -620,7 +620,7 @@ ArrowTypeInfoType EnumUtil::FromString<ArrowTypeInfoType>(const char *value) {
 	if (StringUtil::Equals(value, "ARRAY")) {
 		return ArrowTypeInfoType::ARRAY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ArrowTypeInfoType>", value));
 }
 
 template<>
@@ -635,7 +635,7 @@ const char* EnumUtil::ToChars<ArrowVariableSizeType>(ArrowVariableSizeType value
 	case ArrowVariableSizeType::VIEW:
 		return "VIEW";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ArrowVariableSizeType>", value));
 	}
 }
 
@@ -653,7 +653,7 @@ ArrowVariableSizeType EnumUtil::FromString<ArrowVariableSizeType>(const char *va
 	if (StringUtil::Equals(value, "VIEW")) {
 		return ArrowVariableSizeType::VIEW;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ArrowVariableSizeType>", value));
 }
 
 template<>
@@ -664,7 +664,7 @@ const char* EnumUtil::ToChars<BinderType>(BinderType value) {
 	case BinderType::VIEW_BINDER:
 		return "VIEW_BINDER";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<BinderType>", value));
 	}
 }
 
@@ -676,7 +676,7 @@ BinderType EnumUtil::FromString<BinderType>(const char *value) {
 	if (StringUtil::Equals(value, "VIEW_BINDER")) {
 		return BinderType::VIEW_BINDER;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<BinderType>", value));
 }
 
 template<>
@@ -689,7 +689,7 @@ const char* EnumUtil::ToChars<BindingMode>(BindingMode value) {
 	case BindingMode::EXTRACT_REPLACEMENT_SCANS:
 		return "EXTRACT_REPLACEMENT_SCANS";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<BindingMode>", value));
 	}
 }
 
@@ -704,7 +704,7 @@ BindingMode EnumUtil::FromString<BindingMode>(const char *value) {
 	if (StringUtil::Equals(value, "EXTRACT_REPLACEMENT_SCANS")) {
 		return BindingMode::EXTRACT_REPLACEMENT_SCANS;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<BindingMode>", value));
 }
 
 template<>
@@ -723,7 +723,7 @@ const char* EnumUtil::ToChars<BitpackingMode>(BitpackingMode value) {
 	case BitpackingMode::FOR:
 		return "FOR";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<BitpackingMode>", value));
 	}
 }
 
@@ -747,7 +747,7 @@ BitpackingMode EnumUtil::FromString<BitpackingMode>(const char *value) {
 	if (StringUtil::Equals(value, "FOR")) {
 		return BitpackingMode::FOR;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<BitpackingMode>", value));
 }
 
 template<>
@@ -758,7 +758,7 @@ const char* EnumUtil::ToChars<BlockState>(BlockState value) {
 	case BlockState::BLOCK_LOADED:
 		return "BLOCK_LOADED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<BlockState>", value));
 	}
 }
 
@@ -770,7 +770,7 @@ BlockState EnumUtil::FromString<BlockState>(const char *value) {
 	if (StringUtil::Equals(value, "BLOCK_LOADED")) {
 		return BlockState::BLOCK_LOADED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<BlockState>", value));
 }
 
 template<>
@@ -785,7 +785,7 @@ const char* EnumUtil::ToChars<CAPIResultSetType>(CAPIResultSetType value) {
 	case CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED:
 		return "CAPI_RESULT_TYPE_DEPRECATED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CAPIResultSetType>", value));
 	}
 }
 
@@ -803,7 +803,7 @@ CAPIResultSetType EnumUtil::FromString<CAPIResultSetType>(const char *value) {
 	if (StringUtil::Equals(value, "CAPI_RESULT_TYPE_DEPRECATED")) {
 		return CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CAPIResultSetType>", value));
 }
 
 template<>
@@ -834,7 +834,7 @@ const char* EnumUtil::ToChars<CSVState>(CSVState value) {
 	case CSVState::COMMENT:
 		return "COMMENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CSVState>", value));
 	}
 }
 
@@ -876,7 +876,7 @@ CSVState EnumUtil::FromString<CSVState>(const char *value) {
 	if (StringUtil::Equals(value, "COMMENT")) {
 		return CSVState::COMMENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CSVState>", value));
 }
 
 template<>
@@ -889,7 +889,7 @@ const char* EnumUtil::ToChars<CTEMaterialize>(CTEMaterialize value) {
 	case CTEMaterialize::CTE_MATERIALIZE_NEVER:
 		return "CTE_MATERIALIZE_NEVER";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CTEMaterialize>", value));
 	}
 }
 
@@ -904,7 +904,7 @@ CTEMaterialize EnumUtil::FromString<CTEMaterialize>(const char *value) {
 	if (StringUtil::Equals(value, "CTE_MATERIALIZE_NEVER")) {
 		return CTEMaterialize::CTE_MATERIALIZE_NEVER;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CTEMaterialize>", value));
 }
 
 template<>
@@ -917,7 +917,7 @@ const char* EnumUtil::ToChars<CatalogLookupBehavior>(CatalogLookupBehavior value
 	case CatalogLookupBehavior::NEVER_LOOKUP:
 		return "NEVER_LOOKUP";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CatalogLookupBehavior>", value));
 	}
 }
 
@@ -932,7 +932,7 @@ CatalogLookupBehavior EnumUtil::FromString<CatalogLookupBehavior>(const char *va
 	if (StringUtil::Equals(value, "NEVER_LOOKUP")) {
 		return CatalogLookupBehavior::NEVER_LOOKUP;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CatalogLookupBehavior>", value));
 }
 
 template<>
@@ -985,7 +985,7 @@ const char* EnumUtil::ToChars<CatalogType>(CatalogType value) {
 	case CatalogType::DEPENDENCY_ENTRY:
 		return "DEPENDENCY_ENTRY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CatalogType>", value));
 	}
 }
 
@@ -1060,7 +1060,7 @@ CatalogType EnumUtil::FromString<CatalogType>(const char *value) {
 	if (StringUtil::Equals(value, "DEPENDENCY_ENTRY")) {
 		return CatalogType::DEPENDENCY_ENTRY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CatalogType>", value));
 }
 
 template<>
@@ -1075,7 +1075,7 @@ const char* EnumUtil::ToChars<CheckpointAbort>(CheckpointAbort value) {
 	case CheckpointAbort::DEBUG_ABORT_AFTER_FREE_LIST_WRITE:
 		return "DEBUG_ABORT_AFTER_FREE_LIST_WRITE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CheckpointAbort>", value));
 	}
 }
 
@@ -1093,7 +1093,7 @@ CheckpointAbort EnumUtil::FromString<CheckpointAbort>(const char *value) {
 	if (StringUtil::Equals(value, "DEBUG_ABORT_AFTER_FREE_LIST_WRITE")) {
 		return CheckpointAbort::DEBUG_ABORT_AFTER_FREE_LIST_WRITE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CheckpointAbort>", value));
 }
 
 template<>
@@ -1106,7 +1106,7 @@ const char* EnumUtil::ToChars<ChunkInfoType>(ChunkInfoType value) {
 	case ChunkInfoType::EMPTY_INFO:
 		return "EMPTY_INFO";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ChunkInfoType>", value));
 	}
 }
 
@@ -1121,7 +1121,7 @@ ChunkInfoType EnumUtil::FromString<ChunkInfoType>(const char *value) {
 	if (StringUtil::Equals(value, "EMPTY_INFO")) {
 		return ChunkInfoType::EMPTY_INFO;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ChunkInfoType>", value));
 }
 
 template<>
@@ -1134,7 +1134,7 @@ const char* EnumUtil::ToChars<ColumnDataAllocatorType>(ColumnDataAllocatorType v
 	case ColumnDataAllocatorType::HYBRID:
 		return "HYBRID";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ColumnDataAllocatorType>", value));
 	}
 }
 
@@ -1149,7 +1149,7 @@ ColumnDataAllocatorType EnumUtil::FromString<ColumnDataAllocatorType>(const char
 	if (StringUtil::Equals(value, "HYBRID")) {
 		return ColumnDataAllocatorType::HYBRID;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ColumnDataAllocatorType>", value));
 }
 
 template<>
@@ -1162,7 +1162,7 @@ const char* EnumUtil::ToChars<ColumnDataScanProperties>(ColumnDataScanProperties
 	case ColumnDataScanProperties::DISALLOW_ZERO_COPY:
 		return "DISALLOW_ZERO_COPY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ColumnDataScanProperties>", value));
 	}
 }
 
@@ -1177,7 +1177,7 @@ ColumnDataScanProperties EnumUtil::FromString<ColumnDataScanProperties>(const ch
 	if (StringUtil::Equals(value, "DISALLOW_ZERO_COPY")) {
 		return ColumnDataScanProperties::DISALLOW_ZERO_COPY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ColumnDataScanProperties>", value));
 }
 
 template<>
@@ -1188,7 +1188,7 @@ const char* EnumUtil::ToChars<ColumnSegmentType>(ColumnSegmentType value) {
 	case ColumnSegmentType::PERSISTENT:
 		return "PERSISTENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ColumnSegmentType>", value));
 	}
 }
 
@@ -1200,7 +1200,7 @@ ColumnSegmentType EnumUtil::FromString<ColumnSegmentType>(const char *value) {
 	if (StringUtil::Equals(value, "PERSISTENT")) {
 		return ColumnSegmentType::PERSISTENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ColumnSegmentType>", value));
 }
 
 template<>
@@ -1213,7 +1213,7 @@ const char* EnumUtil::ToChars<CompressedMaterializationDirection>(CompressedMate
 	case CompressedMaterializationDirection::DECOMPRESS:
 		return "DECOMPRESS";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CompressedMaterializationDirection>", value));
 	}
 }
 
@@ -1228,7 +1228,7 @@ CompressedMaterializationDirection EnumUtil::FromString<CompressedMaterializatio
 	if (StringUtil::Equals(value, "DECOMPRESS")) {
 		return CompressedMaterializationDirection::DECOMPRESS;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CompressedMaterializationDirection>", value));
 }
 
 template<>
@@ -1261,7 +1261,7 @@ const char* EnumUtil::ToChars<CompressionType>(CompressionType value) {
 	case CompressionType::COMPRESSION_COUNT:
 		return "COMPRESSION_COUNT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CompressionType>", value));
 	}
 }
 
@@ -1306,7 +1306,7 @@ CompressionType EnumUtil::FromString<CompressionType>(const char *value) {
 	if (StringUtil::Equals(value, "COMPRESSION_COUNT")) {
 		return CompressionType::COMPRESSION_COUNT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CompressionType>", value));
 }
 
 template<>
@@ -1317,7 +1317,7 @@ const char* EnumUtil::ToChars<ConflictManagerMode>(ConflictManagerMode value) {
 	case ConflictManagerMode::THROW:
 		return "THROW";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ConflictManagerMode>", value));
 	}
 }
 
@@ -1329,7 +1329,7 @@ ConflictManagerMode EnumUtil::FromString<ConflictManagerMode>(const char *value)
 	if (StringUtil::Equals(value, "THROW")) {
 		return ConflictManagerMode::THROW;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ConflictManagerMode>", value));
 }
 
 template<>
@@ -1346,7 +1346,7 @@ const char* EnumUtil::ToChars<ConstraintType>(ConstraintType value) {
 	case ConstraintType::FOREIGN_KEY:
 		return "FOREIGN_KEY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ConstraintType>", value));
 	}
 }
 
@@ -1367,7 +1367,7 @@ ConstraintType EnumUtil::FromString<ConstraintType>(const char *value) {
 	if (StringUtil::Equals(value, "FOREIGN_KEY")) {
 		return ConstraintType::FOREIGN_KEY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ConstraintType>", value));
 }
 
 template<>
@@ -1378,7 +1378,7 @@ const char* EnumUtil::ToChars<CopyFunctionReturnType>(CopyFunctionReturnType val
 	case CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST:
 		return "CHANGED_ROWS_AND_FILE_LIST";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CopyFunctionReturnType>", value));
 	}
 }
 
@@ -1390,7 +1390,7 @@ CopyFunctionReturnType EnumUtil::FromString<CopyFunctionReturnType>(const char *
 	if (StringUtil::Equals(value, "CHANGED_ROWS_AND_FILE_LIST")) {
 		return CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CopyFunctionReturnType>", value));
 }
 
 template<>
@@ -1405,7 +1405,7 @@ const char* EnumUtil::ToChars<CopyOverwriteMode>(CopyOverwriteMode value) {
 	case CopyOverwriteMode::COPY_APPEND:
 		return "COPY_APPEND";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CopyOverwriteMode>", value));
 	}
 }
 
@@ -1423,7 +1423,7 @@ CopyOverwriteMode EnumUtil::FromString<CopyOverwriteMode>(const char *value) {
 	if (StringUtil::Equals(value, "COPY_APPEND")) {
 		return CopyOverwriteMode::COPY_APPEND;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CopyOverwriteMode>", value));
 }
 
 template<>
@@ -1434,7 +1434,7 @@ const char* EnumUtil::ToChars<CopyToType>(CopyToType value) {
 	case CopyToType::EXPORT_DATABASE:
 		return "EXPORT_DATABASE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<CopyToType>", value));
 	}
 }
 
@@ -1446,7 +1446,7 @@ CopyToType EnumUtil::FromString<CopyToType>(const char *value) {
 	if (StringUtil::Equals(value, "EXPORT_DATABASE")) {
 		return CopyToType::EXPORT_DATABASE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<CopyToType>", value));
 }
 
 template<>
@@ -1461,7 +1461,7 @@ const char* EnumUtil::ToChars<DataFileType>(DataFileType value) {
 	case DataFileType::PARQUET_FILE:
 		return "PARQUET_FILE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<DataFileType>", value));
 	}
 }
 
@@ -1479,7 +1479,7 @@ DataFileType EnumUtil::FromString<DataFileType>(const char *value) {
 	if (StringUtil::Equals(value, "PARQUET_FILE")) {
 		return DataFileType::PARQUET_FILE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<DataFileType>", value));
 }
 
 template<>
@@ -1536,7 +1536,7 @@ const char* EnumUtil::ToChars<DatePartSpecifier>(DatePartSpecifier value) {
 	case DatePartSpecifier::INVALID:
 		return "INVALID";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<DatePartSpecifier>", value));
 	}
 }
 
@@ -1617,7 +1617,7 @@ DatePartSpecifier EnumUtil::FromString<DatePartSpecifier>(const char *value) {
 	if (StringUtil::Equals(value, "INVALID")) {
 		return DatePartSpecifier::INVALID;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<DatePartSpecifier>", value));
 }
 
 template<>
@@ -1630,7 +1630,7 @@ const char* EnumUtil::ToChars<DebugInitialize>(DebugInitialize value) {
 	case DebugInitialize::DEBUG_ONE_INITIALIZE:
 		return "DEBUG_ONE_INITIALIZE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<DebugInitialize>", value));
 	}
 }
 
@@ -1645,7 +1645,7 @@ DebugInitialize EnumUtil::FromString<DebugInitialize>(const char *value) {
 	if (StringUtil::Equals(value, "DEBUG_ONE_INITIALIZE")) {
 		return DebugInitialize::DEBUG_ONE_INITIALIZE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<DebugInitialize>", value));
 }
 
 template<>
@@ -1662,7 +1662,7 @@ const char* EnumUtil::ToChars<DefaultOrderByNullType>(DefaultOrderByNullType val
 	case DefaultOrderByNullType::NULLS_LAST_ON_ASC_FIRST_ON_DESC:
 		return "NULLS_LAST_ON_ASC_FIRST_ON_DESC";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<DefaultOrderByNullType>", value));
 	}
 }
 
@@ -1683,7 +1683,7 @@ DefaultOrderByNullType EnumUtil::FromString<DefaultOrderByNullType>(const char *
 	if (StringUtil::Equals(value, "NULLS_LAST_ON_ASC_FIRST_ON_DESC")) {
 		return DefaultOrderByNullType::NULLS_LAST_ON_ASC_FIRST_ON_DESC;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<DefaultOrderByNullType>", value));
 }
 
 template<>
@@ -1694,7 +1694,7 @@ const char* EnumUtil::ToChars<DependencyEntryType>(DependencyEntryType value) {
 	case DependencyEntryType::DEPENDENT:
 		return "DEPENDENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<DependencyEntryType>", value));
 	}
 }
 
@@ -1706,7 +1706,7 @@ DependencyEntryType EnumUtil::FromString<DependencyEntryType>(const char *value)
 	if (StringUtil::Equals(value, "DEPENDENT")) {
 		return DependencyEntryType::DEPENDENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<DependencyEntryType>", value));
 }
 
 template<>
@@ -1719,7 +1719,7 @@ const char* EnumUtil::ToChars<DeprecatedIndexType>(DeprecatedIndexType value) {
 	case DeprecatedIndexType::EXTENSION:
 		return "EXTENSION";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<DeprecatedIndexType>", value));
 	}
 }
 
@@ -1734,7 +1734,7 @@ DeprecatedIndexType EnumUtil::FromString<DeprecatedIndexType>(const char *value)
 	if (StringUtil::Equals(value, "EXTENSION")) {
 		return DeprecatedIndexType::EXTENSION;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<DeprecatedIndexType>", value));
 }
 
 template<>
@@ -1747,7 +1747,7 @@ const char* EnumUtil::ToChars<DestroyBufferUpon>(DestroyBufferUpon value) {
 	case DestroyBufferUpon::UNPIN:
 		return "UNPIN";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<DestroyBufferUpon>", value));
 	}
 }
 
@@ -1762,7 +1762,7 @@ DestroyBufferUpon EnumUtil::FromString<DestroyBufferUpon>(const char *value) {
 	if (StringUtil::Equals(value, "UNPIN")) {
 		return DestroyBufferUpon::UNPIN;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<DestroyBufferUpon>", value));
 }
 
 template<>
@@ -1773,7 +1773,7 @@ const char* EnumUtil::ToChars<DistinctType>(DistinctType value) {
 	case DistinctType::DISTINCT_ON:
 		return "DISTINCT_ON";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<DistinctType>", value));
 	}
 }
 
@@ -1785,7 +1785,7 @@ DistinctType EnumUtil::FromString<DistinctType>(const char *value) {
 	if (StringUtil::Equals(value, "DISTINCT_ON")) {
 		return DistinctType::DISTINCT_ON;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<DistinctType>", value));
 }
 
 template<>
@@ -1802,7 +1802,7 @@ const char* EnumUtil::ToChars<ErrorType>(ErrorType value) {
 	case ErrorType::INVALID:
 		return "INVALID";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ErrorType>", value));
 	}
 }
 
@@ -1823,7 +1823,7 @@ ErrorType EnumUtil::FromString<ErrorType>(const char *value) {
 	if (StringUtil::Equals(value, "INVALID")) {
 		return ErrorType::INVALID;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ErrorType>", value));
 }
 
 template<>
@@ -1836,7 +1836,7 @@ const char* EnumUtil::ToChars<ExceptionFormatValueType>(ExceptionFormatValueType
 	case ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING:
 		return "FORMAT_VALUE_TYPE_STRING";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExceptionFormatValueType>", value));
 	}
 }
 
@@ -1851,7 +1851,7 @@ ExceptionFormatValueType EnumUtil::FromString<ExceptionFormatValueType>(const ch
 	if (StringUtil::Equals(value, "FORMAT_VALUE_TYPE_STRING")) {
 		return ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExceptionFormatValueType>", value));
 }
 
 template<>
@@ -1944,7 +1944,7 @@ const char* EnumUtil::ToChars<ExceptionType>(ExceptionType value) {
 	case ExceptionType::INVALID_CONFIGURATION:
 		return "INVALID_CONFIGURATION";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExceptionType>", value));
 	}
 }
 
@@ -2079,7 +2079,7 @@ ExceptionType EnumUtil::FromString<ExceptionType>(const char *value) {
 	if (StringUtil::Equals(value, "INVALID_CONFIGURATION")) {
 		return ExceptionType::INVALID_CONFIGURATION;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExceptionType>", value));
 }
 
 template<>
@@ -2096,7 +2096,7 @@ const char* EnumUtil::ToChars<ExplainFormat>(ExplainFormat value) {
 	case ExplainFormat::GRAPHVIZ:
 		return "GRAPHVIZ";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExplainFormat>", value));
 	}
 }
 
@@ -2117,7 +2117,7 @@ ExplainFormat EnumUtil::FromString<ExplainFormat>(const char *value) {
 	if (StringUtil::Equals(value, "GRAPHVIZ")) {
 		return ExplainFormat::GRAPHVIZ;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExplainFormat>", value));
 }
 
 template<>
@@ -2130,7 +2130,7 @@ const char* EnumUtil::ToChars<ExplainOutputType>(ExplainOutputType value) {
 	case ExplainOutputType::PHYSICAL_ONLY:
 		return "PHYSICAL_ONLY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExplainOutputType>", value));
 	}
 }
 
@@ -2145,7 +2145,7 @@ ExplainOutputType EnumUtil::FromString<ExplainOutputType>(const char *value) {
 	if (StringUtil::Equals(value, "PHYSICAL_ONLY")) {
 		return ExplainOutputType::PHYSICAL_ONLY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExplainOutputType>", value));
 }
 
 template<>
@@ -2156,7 +2156,7 @@ const char* EnumUtil::ToChars<ExplainType>(ExplainType value) {
 	case ExplainType::EXPLAIN_ANALYZE:
 		return "EXPLAIN_ANALYZE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExplainType>", value));
 	}
 }
 
@@ -2168,7 +2168,7 @@ ExplainType EnumUtil::FromString<ExplainType>(const char *value) {
 	if (StringUtil::Equals(value, "EXPLAIN_ANALYZE")) {
 		return ExplainType::EXPLAIN_ANALYZE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExplainType>", value));
 }
 
 template<>
@@ -2181,7 +2181,7 @@ const char* EnumUtil::ToChars<ExponentType>(ExponentType value) {
 	case ExponentType::NEGATIVE:
 		return "NEGATIVE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExponentType>", value));
 	}
 }
 
@@ -2196,7 +2196,7 @@ ExponentType EnumUtil::FromString<ExponentType>(const char *value) {
 	if (StringUtil::Equals(value, "NEGATIVE")) {
 		return ExponentType::NEGATIVE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExponentType>", value));
 }
 
 template<>
@@ -2283,7 +2283,7 @@ const char* EnumUtil::ToChars<ExpressionClass>(ExpressionClass value) {
 	case ExpressionClass::BOUND_EXPANDED:
 		return "BOUND_EXPANDED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExpressionClass>", value));
 	}
 }
 
@@ -2409,7 +2409,7 @@ ExpressionClass EnumUtil::FromString<ExpressionClass>(const char *value) {
 	if (StringUtil::Equals(value, "BOUND_EXPANDED")) {
 		return ExpressionClass::BOUND_EXPANDED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExpressionClass>", value));
 }
 
 template<>
@@ -2554,7 +2554,7 @@ const char* EnumUtil::ToChars<ExpressionType>(ExpressionType value) {
 	case ExpressionType::BOUND_EXPANDED:
 		return "BOUND_EXPANDED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExpressionType>", value));
 	}
 }
 
@@ -2767,7 +2767,7 @@ ExpressionType EnumUtil::FromString<ExpressionType>(const char *value) {
 	if (StringUtil::Equals(value, "BOUND_EXPANDED")) {
 		return ExpressionType::BOUND_EXPANDED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExpressionType>", value));
 }
 
 template<>
@@ -2780,7 +2780,7 @@ const char* EnumUtil::ToChars<ExtensionABIType>(ExtensionABIType value) {
 	case ExtensionABIType::C_STRUCT:
 		return "C_STRUCT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExtensionABIType>", value));
 	}
 }
 
@@ -2795,7 +2795,7 @@ ExtensionABIType EnumUtil::FromString<ExtensionABIType>(const char *value) {
 	if (StringUtil::Equals(value, "C_STRUCT")) {
 		return ExtensionABIType::C_STRUCT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExtensionABIType>", value));
 }
 
 template<>
@@ -2812,7 +2812,7 @@ const char* EnumUtil::ToChars<ExtensionInstallMode>(ExtensionInstallMode value) 
 	case ExtensionInstallMode::NOT_INSTALLED:
 		return "NOT_INSTALLED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExtensionInstallMode>", value));
 	}
 }
 
@@ -2833,7 +2833,7 @@ ExtensionInstallMode EnumUtil::FromString<ExtensionInstallMode>(const char *valu
 	if (StringUtil::Equals(value, "NOT_INSTALLED")) {
 		return ExtensionInstallMode::NOT_INSTALLED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExtensionInstallMode>", value));
 }
 
 template<>
@@ -2846,7 +2846,7 @@ const char* EnumUtil::ToChars<ExtensionLoadResult>(ExtensionLoadResult value) {
 	case ExtensionLoadResult::NOT_LOADED:
 		return "NOT_LOADED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExtensionLoadResult>", value));
 	}
 }
 
@@ -2861,7 +2861,7 @@ ExtensionLoadResult EnumUtil::FromString<ExtensionLoadResult>(const char *value)
 	if (StringUtil::Equals(value, "NOT_LOADED")) {
 		return ExtensionLoadResult::NOT_LOADED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExtensionLoadResult>", value));
 }
 
 template<>
@@ -2884,7 +2884,7 @@ const char* EnumUtil::ToChars<ExtensionUpdateResultTag>(ExtensionUpdateResultTag
 	case ExtensionUpdateResultTag::UPDATED:
 		return "UPDATED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExtensionUpdateResultTag>", value));
 	}
 }
 
@@ -2914,7 +2914,7 @@ ExtensionUpdateResultTag EnumUtil::FromString<ExtensionUpdateResultTag>(const ch
 	if (StringUtil::Equals(value, "UPDATED")) {
 		return ExtensionUpdateResultTag::UPDATED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExtensionUpdateResultTag>", value));
 }
 
 template<>
@@ -2925,7 +2925,7 @@ const char* EnumUtil::ToChars<ExtraDropInfoType>(ExtraDropInfoType value) {
 	case ExtraDropInfoType::SECRET_INFO:
 		return "SECRET_INFO";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExtraDropInfoType>", value));
 	}
 }
 
@@ -2937,7 +2937,7 @@ ExtraDropInfoType EnumUtil::FromString<ExtraDropInfoType>(const char *value) {
 	if (StringUtil::Equals(value, "SECRET_INFO")) {
 		return ExtraDropInfoType::SECRET_INFO;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExtraDropInfoType>", value));
 }
 
 template<>
@@ -2968,7 +2968,7 @@ const char* EnumUtil::ToChars<ExtraTypeInfoType>(ExtraTypeInfoType value) {
 	case ExtraTypeInfoType::INTEGER_LITERAL_TYPE_INFO:
 		return "INTEGER_LITERAL_TYPE_INFO";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ExtraTypeInfoType>", value));
 	}
 }
 
@@ -3010,7 +3010,7 @@ ExtraTypeInfoType EnumUtil::FromString<ExtraTypeInfoType>(const char *value) {
 	if (StringUtil::Equals(value, "INTEGER_LITERAL_TYPE_INFO")) {
 		return ExtraTypeInfoType::INTEGER_LITERAL_TYPE_INFO;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ExtraTypeInfoType>", value));
 }
 
 template<>
@@ -3023,7 +3023,7 @@ const char* EnumUtil::ToChars<FileBufferType>(FileBufferType value) {
 	case FileBufferType::TINY_BUFFER:
 		return "TINY_BUFFER";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<FileBufferType>", value));
 	}
 }
 
@@ -3038,7 +3038,7 @@ FileBufferType EnumUtil::FromString<FileBufferType>(const char *value) {
 	if (StringUtil::Equals(value, "TINY_BUFFER")) {
 		return FileBufferType::TINY_BUFFER;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<FileBufferType>", value));
 }
 
 template<>
@@ -3053,7 +3053,7 @@ const char* EnumUtil::ToChars<FileCompressionType>(FileCompressionType value) {
 	case FileCompressionType::ZSTD:
 		return "ZSTD";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<FileCompressionType>", value));
 	}
 }
 
@@ -3071,7 +3071,7 @@ FileCompressionType EnumUtil::FromString<FileCompressionType>(const char *value)
 	if (StringUtil::Equals(value, "ZSTD")) {
 		return FileCompressionType::ZSTD;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<FileCompressionType>", value));
 }
 
 template<>
@@ -3084,7 +3084,7 @@ const char* EnumUtil::ToChars<FileExpandResult>(FileExpandResult value) {
 	case FileExpandResult::MULTIPLE_FILES:
 		return "MULTIPLE_FILES";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<FileExpandResult>", value));
 	}
 }
 
@@ -3099,7 +3099,7 @@ FileExpandResult EnumUtil::FromString<FileExpandResult>(const char *value) {
 	if (StringUtil::Equals(value, "MULTIPLE_FILES")) {
 		return FileExpandResult::MULTIPLE_FILES;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<FileExpandResult>", value));
 }
 
 template<>
@@ -3110,7 +3110,7 @@ const char* EnumUtil::ToChars<FileGlobOptions>(FileGlobOptions value) {
 	case FileGlobOptions::ALLOW_EMPTY:
 		return "ALLOW_EMPTY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<FileGlobOptions>", value));
 	}
 }
 
@@ -3122,7 +3122,7 @@ FileGlobOptions EnumUtil::FromString<FileGlobOptions>(const char *value) {
 	if (StringUtil::Equals(value, "ALLOW_EMPTY")) {
 		return FileGlobOptions::ALLOW_EMPTY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<FileGlobOptions>", value));
 }
 
 template<>
@@ -3135,7 +3135,7 @@ const char* EnumUtil::ToChars<FileLockType>(FileLockType value) {
 	case FileLockType::WRITE_LOCK:
 		return "WRITE_LOCK";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<FileLockType>", value));
 	}
 }
 
@@ -3150,7 +3150,7 @@ FileLockType EnumUtil::FromString<FileLockType>(const char *value) {
 	if (StringUtil::Equals(value, "WRITE_LOCK")) {
 		return FileLockType::WRITE_LOCK;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<FileLockType>", value));
 }
 
 template<>
@@ -3167,7 +3167,7 @@ const char* EnumUtil::ToChars<FilterPropagateResult>(FilterPropagateResult value
 	case FilterPropagateResult::FILTER_FALSE_OR_NULL:
 		return "FILTER_FALSE_OR_NULL";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<FilterPropagateResult>", value));
 	}
 }
 
@@ -3188,7 +3188,7 @@ FilterPropagateResult EnumUtil::FromString<FilterPropagateResult>(const char *va
 	if (StringUtil::Equals(value, "FILTER_FALSE_OR_NULL")) {
 		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<FilterPropagateResult>", value));
 }
 
 template<>
@@ -3201,7 +3201,7 @@ const char* EnumUtil::ToChars<ForeignKeyType>(ForeignKeyType value) {
 	case ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE:
 		return "FK_TYPE_SELF_REFERENCE_TABLE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ForeignKeyType>", value));
 	}
 }
 
@@ -3216,7 +3216,7 @@ ForeignKeyType EnumUtil::FromString<ForeignKeyType>(const char *value) {
 	if (StringUtil::Equals(value, "FK_TYPE_SELF_REFERENCE_TABLE")) {
 		return ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ForeignKeyType>", value));
 }
 
 template<>
@@ -3227,7 +3227,7 @@ const char* EnumUtil::ToChars<FunctionNullHandling>(FunctionNullHandling value) 
 	case FunctionNullHandling::SPECIAL_HANDLING:
 		return "SPECIAL_HANDLING";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<FunctionNullHandling>", value));
 	}
 }
 
@@ -3239,7 +3239,7 @@ FunctionNullHandling EnumUtil::FromString<FunctionNullHandling>(const char *valu
 	if (StringUtil::Equals(value, "SPECIAL_HANDLING")) {
 		return FunctionNullHandling::SPECIAL_HANDLING;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<FunctionNullHandling>", value));
 }
 
 template<>
@@ -3252,7 +3252,7 @@ const char* EnumUtil::ToChars<FunctionStability>(FunctionStability value) {
 	case FunctionStability::CONSISTENT_WITHIN_QUERY:
 		return "CONSISTENT_WITHIN_QUERY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<FunctionStability>", value));
 	}
 }
 
@@ -3267,7 +3267,7 @@ FunctionStability EnumUtil::FromString<FunctionStability>(const char *value) {
 	if (StringUtil::Equals(value, "CONSISTENT_WITHIN_QUERY")) {
 		return FunctionStability::CONSISTENT_WITHIN_QUERY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<FunctionStability>", value));
 }
 
 template<>
@@ -3278,7 +3278,7 @@ const char* EnumUtil::ToChars<GateStatus>(GateStatus value) {
 	case GateStatus::GATE_SET:
 		return "GATE_SET";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<GateStatus>", value));
 	}
 }
 
@@ -3290,7 +3290,7 @@ GateStatus EnumUtil::FromString<GateStatus>(const char *value) {
 	if (StringUtil::Equals(value, "GATE_SET")) {
 		return GateStatus::GATE_SET;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<GateStatus>", value));
 }
 
 template<>
@@ -3301,7 +3301,7 @@ const char* EnumUtil::ToChars<HLLStorageType>(HLLStorageType value) {
 	case HLLStorageType::HLL_V2:
 		return "HLL_V2";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<HLLStorageType>", value));
 	}
 }
 
@@ -3313,7 +3313,7 @@ HLLStorageType EnumUtil::FromString<HLLStorageType>(const char *value) {
 	if (StringUtil::Equals(value, "HLL_V2")) {
 		return HLLStorageType::HLL_V2;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<HLLStorageType>", value));
 }
 
 template<>
@@ -3328,7 +3328,7 @@ const char* EnumUtil::ToChars<IndexConstraintType>(IndexConstraintType value) {
 	case IndexConstraintType::FOREIGN:
 		return "FOREIGN";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<IndexConstraintType>", value));
 	}
 }
 
@@ -3346,7 +3346,7 @@ IndexConstraintType EnumUtil::FromString<IndexConstraintType>(const char *value)
 	if (StringUtil::Equals(value, "FOREIGN")) {
 		return IndexConstraintType::FOREIGN;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<IndexConstraintType>", value));
 }
 
 template<>
@@ -3357,7 +3357,7 @@ const char* EnumUtil::ToChars<InsertColumnOrder>(InsertColumnOrder value) {
 	case InsertColumnOrder::INSERT_BY_NAME:
 		return "INSERT_BY_NAME";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<InsertColumnOrder>", value));
 	}
 }
 
@@ -3369,7 +3369,7 @@ InsertColumnOrder EnumUtil::FromString<InsertColumnOrder>(const char *value) {
 	if (StringUtil::Equals(value, "INSERT_BY_NAME")) {
 		return InsertColumnOrder::INSERT_BY_NAME;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<InsertColumnOrder>", value));
 }
 
 template<>
@@ -3382,7 +3382,7 @@ const char* EnumUtil::ToChars<InterruptMode>(InterruptMode value) {
 	case InterruptMode::BLOCKING:
 		return "BLOCKING";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<InterruptMode>", value));
 	}
 }
 
@@ -3397,7 +3397,7 @@ InterruptMode EnumUtil::FromString<InterruptMode>(const char *value) {
 	if (StringUtil::Equals(value, "BLOCKING")) {
 		return InterruptMode::BLOCKING;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<InterruptMode>", value));
 }
 
 template<>
@@ -3416,7 +3416,7 @@ const char* EnumUtil::ToChars<JoinRefType>(JoinRefType value) {
 	case JoinRefType::DEPENDENT:
 		return "DEPENDENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<JoinRefType>", value));
 	}
 }
 
@@ -3440,7 +3440,7 @@ JoinRefType EnumUtil::FromString<JoinRefType>(const char *value) {
 	if (StringUtil::Equals(value, "DEPENDENT")) {
 		return JoinRefType::DEPENDENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<JoinRefType>", value));
 }
 
 template<>
@@ -3469,7 +3469,7 @@ const char* EnumUtil::ToChars<JoinType>(JoinType value) {
 	case JoinType::RIGHT_ANTI:
 		return "RIGHT_ANTI";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<JoinType>", value));
 	}
 }
 
@@ -3508,7 +3508,7 @@ JoinType EnumUtil::FromString<JoinType>(const char *value) {
 	if (StringUtil::Equals(value, "RIGHT_ANTI")) {
 		return JoinType::RIGHT_ANTI;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<JoinType>", value));
 }
 
 template<>
@@ -3523,7 +3523,7 @@ const char* EnumUtil::ToChars<KeywordCategory>(KeywordCategory value) {
 	case KeywordCategory::KEYWORD_COL_NAME:
 		return "KEYWORD_COL_NAME";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<KeywordCategory>", value));
 	}
 }
 
@@ -3541,7 +3541,7 @@ KeywordCategory EnumUtil::FromString<KeywordCategory>(const char *value) {
 	if (StringUtil::Equals(value, "KEYWORD_COL_NAME")) {
 		return KeywordCategory::KEYWORD_COL_NAME;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<KeywordCategory>", value));
 }
 
 template<>
@@ -3558,7 +3558,7 @@ const char* EnumUtil::ToChars<LimitNodeType>(LimitNodeType value) {
 	case LimitNodeType::EXPRESSION_PERCENTAGE:
 		return "EXPRESSION_PERCENTAGE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<LimitNodeType>", value));
 	}
 }
 
@@ -3579,7 +3579,7 @@ LimitNodeType EnumUtil::FromString<LimitNodeType>(const char *value) {
 	if (StringUtil::Equals(value, "EXPRESSION_PERCENTAGE")) {
 		return LimitNodeType::EXPRESSION_PERCENTAGE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<LimitNodeType>", value));
 }
 
 template<>
@@ -3592,7 +3592,7 @@ const char* EnumUtil::ToChars<LoadType>(LoadType value) {
 	case LoadType::FORCE_INSTALL:
 		return "FORCE_INSTALL";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<LoadType>", value));
 	}
 }
 
@@ -3607,7 +3607,7 @@ LoadType EnumUtil::FromString<LoadType>(const char *value) {
 	if (StringUtil::Equals(value, "FORCE_INSTALL")) {
 		return LoadType::FORCE_INSTALL;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<LoadType>", value));
 }
 
 template<>
@@ -3736,7 +3736,7 @@ const char* EnumUtil::ToChars<LogicalOperatorType>(LogicalOperatorType value) {
 	case LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR:
 		return "LOGICAL_EXTENSION_OPERATOR";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<LogicalOperatorType>", value));
 	}
 }
 
@@ -3925,7 +3925,7 @@ LogicalOperatorType EnumUtil::FromString<LogicalOperatorType>(const char *value)
 	if (StringUtil::Equals(value, "LOGICAL_EXTENSION_OPERATOR")) {
 		return LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<LogicalOperatorType>", value));
 }
 
 template<>
@@ -4026,7 +4026,7 @@ const char* EnumUtil::ToChars<LogicalTypeId>(LogicalTypeId value) {
 	case LogicalTypeId::ARRAY:
 		return "ARRAY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<LogicalTypeId>", value));
 	}
 }
 
@@ -4173,7 +4173,7 @@ LogicalTypeId EnumUtil::FromString<LogicalTypeId>(const char *value) {
 	if (StringUtil::Equals(value, "ARRAY")) {
 		return LogicalTypeId::ARRAY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<LogicalTypeId>", value));
 }
 
 template<>
@@ -4186,7 +4186,7 @@ const char* EnumUtil::ToChars<LookupResultType>(LookupResultType value) {
 	case LookupResultType::LOOKUP_NULL:
 		return "LOOKUP_NULL";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<LookupResultType>", value));
 	}
 }
 
@@ -4201,7 +4201,7 @@ LookupResultType EnumUtil::FromString<LookupResultType>(const char *value) {
 	if (StringUtil::Equals(value, "LOOKUP_NULL")) {
 		return LookupResultType::LOOKUP_NULL;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<LookupResultType>", value));
 }
 
 template<>
@@ -4214,7 +4214,7 @@ const char* EnumUtil::ToChars<MacroType>(MacroType value) {
 	case MacroType::SCALAR_MACRO:
 		return "SCALAR_MACRO";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<MacroType>", value));
 	}
 }
 
@@ -4229,7 +4229,7 @@ MacroType EnumUtil::FromString<MacroType>(const char *value) {
 	if (StringUtil::Equals(value, "SCALAR_MACRO")) {
 		return MacroType::SCALAR_MACRO;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<MacroType>", value));
 }
 
 template<>
@@ -4246,7 +4246,7 @@ const char* EnumUtil::ToChars<MapInvalidReason>(MapInvalidReason value) {
 	case MapInvalidReason::INVALID_PARAMS:
 		return "INVALID_PARAMS";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<MapInvalidReason>", value));
 	}
 }
 
@@ -4267,7 +4267,7 @@ MapInvalidReason EnumUtil::FromString<MapInvalidReason>(const char *value) {
 	if (StringUtil::Equals(value, "INVALID_PARAMS")) {
 		return MapInvalidReason::INVALID_PARAMS;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<MapInvalidReason>", value));
 }
 
 template<>
@@ -4298,7 +4298,7 @@ const char* EnumUtil::ToChars<MemoryTag>(MemoryTag value) {
 	case MemoryTag::EXTENSION:
 		return "EXTENSION";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<MemoryTag>", value));
 	}
 }
 
@@ -4340,7 +4340,7 @@ MemoryTag EnumUtil::FromString<MemoryTag>(const char *value) {
 	if (StringUtil::Equals(value, "EXTENSION")) {
 		return MemoryTag::EXTENSION;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<MemoryTag>", value));
 }
 
 template<>
@@ -4351,7 +4351,7 @@ const char* EnumUtil::ToChars<MetaPipelineType>(MetaPipelineType value) {
 	case MetaPipelineType::JOIN_BUILD:
 		return "JOIN_BUILD";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<MetaPipelineType>", value));
 	}
 }
 
@@ -4363,7 +4363,7 @@ MetaPipelineType EnumUtil::FromString<MetaPipelineType>(const char *value) {
 	if (StringUtil::Equals(value, "JOIN_BUILD")) {
 		return MetaPipelineType::JOIN_BUILD;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<MetaPipelineType>", value));
 }
 
 template<>
@@ -4454,7 +4454,7 @@ const char* EnumUtil::ToChars<MetricsType>(MetricsType value) {
 	case MetricsType::OPTIMIZER_MATERIALIZED_CTE:
 		return "OPTIMIZER_MATERIALIZED_CTE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<MetricsType>", value));
 	}
 }
 
@@ -4586,7 +4586,7 @@ MetricsType EnumUtil::FromString<MetricsType>(const char *value) {
 	if (StringUtil::Equals(value, "OPTIMIZER_MATERIALIZED_CTE")) {
 		return MetricsType::OPTIMIZER_MATERIALIZED_CTE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<MetricsType>", value));
 }
 
 template<>
@@ -4613,7 +4613,7 @@ const char* EnumUtil::ToChars<NType>(NType value) {
 	case NType::NODE_256_LEAF:
 		return "NODE_256_LEAF";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<NType>", value));
 	}
 }
 
@@ -4649,7 +4649,7 @@ NType EnumUtil::FromString<NType>(const char *value) {
 	if (StringUtil::Equals(value, "NODE_256_LEAF")) {
 		return NType::NODE_256_LEAF;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<NType>", value));
 }
 
 template<>
@@ -4664,7 +4664,7 @@ const char* EnumUtil::ToChars<NewLineIdentifier>(NewLineIdentifier value) {
 	case NewLineIdentifier::SINGLE_R:
 		return "SINGLE_R";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<NewLineIdentifier>", value));
 	}
 }
 
@@ -4682,7 +4682,7 @@ NewLineIdentifier EnumUtil::FromString<NewLineIdentifier>(const char *value) {
 	if (StringUtil::Equals(value, "SINGLE_R")) {
 		return NewLineIdentifier::SINGLE_R;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<NewLineIdentifier>", value));
 }
 
 template<>
@@ -4697,7 +4697,7 @@ const char* EnumUtil::ToChars<OnConflictAction>(OnConflictAction value) {
 	case OnConflictAction::REPLACE:
 		return "REPLACE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OnConflictAction>", value));
 	}
 }
 
@@ -4715,7 +4715,7 @@ OnConflictAction EnumUtil::FromString<OnConflictAction>(const char *value) {
 	if (StringUtil::Equals(value, "REPLACE")) {
 		return OnConflictAction::REPLACE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OnConflictAction>", value));
 }
 
 template<>
@@ -4730,7 +4730,7 @@ const char* EnumUtil::ToChars<OnCreateConflict>(OnCreateConflict value) {
 	case OnCreateConflict::ALTER_ON_CONFLICT:
 		return "ALTER_ON_CONFLICT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OnCreateConflict>", value));
 	}
 }
 
@@ -4748,7 +4748,7 @@ OnCreateConflict EnumUtil::FromString<OnCreateConflict>(const char *value) {
 	if (StringUtil::Equals(value, "ALTER_ON_CONFLICT")) {
 		return OnCreateConflict::ALTER_ON_CONFLICT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OnCreateConflict>", value));
 }
 
 template<>
@@ -4759,7 +4759,7 @@ const char* EnumUtil::ToChars<OnEntryNotFound>(OnEntryNotFound value) {
 	case OnEntryNotFound::RETURN_NULL:
 		return "RETURN_NULL";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OnEntryNotFound>", value));
 	}
 }
 
@@ -4771,7 +4771,7 @@ OnEntryNotFound EnumUtil::FromString<OnEntryNotFound>(const char *value) {
 	if (StringUtil::Equals(value, "RETURN_NULL")) {
 		return OnEntryNotFound::RETURN_NULL;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OnEntryNotFound>", value));
 }
 
 template<>
@@ -4782,7 +4782,7 @@ const char* EnumUtil::ToChars<OperatorFinalizeResultType>(OperatorFinalizeResult
 	case OperatorFinalizeResultType::FINISHED:
 		return "FINISHED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OperatorFinalizeResultType>", value));
 	}
 }
 
@@ -4794,7 +4794,7 @@ OperatorFinalizeResultType EnumUtil::FromString<OperatorFinalizeResultType>(cons
 	if (StringUtil::Equals(value, "FINISHED")) {
 		return OperatorFinalizeResultType::FINISHED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OperatorFinalizeResultType>", value));
 }
 
 template<>
@@ -4809,7 +4809,7 @@ const char* EnumUtil::ToChars<OperatorResultType>(OperatorResultType value) {
 	case OperatorResultType::BLOCKED:
 		return "BLOCKED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OperatorResultType>", value));
 	}
 }
 
@@ -4827,7 +4827,7 @@ OperatorResultType EnumUtil::FromString<OperatorResultType>(const char *value) {
 	if (StringUtil::Equals(value, "BLOCKED")) {
 		return OperatorResultType::BLOCKED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OperatorResultType>", value));
 }
 
 template<>
@@ -4882,7 +4882,7 @@ const char* EnumUtil::ToChars<OptimizerType>(OptimizerType value) {
 	case OptimizerType::MATERIALIZED_CTE:
 		return "MATERIALIZED_CTE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OptimizerType>", value));
 	}
 }
 
@@ -4960,7 +4960,7 @@ OptimizerType EnumUtil::FromString<OptimizerType>(const char *value) {
 	if (StringUtil::Equals(value, "MATERIALIZED_CTE")) {
 		return OptimizerType::MATERIALIZED_CTE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OptimizerType>", value));
 }
 
 template<>
@@ -4975,7 +4975,7 @@ const char* EnumUtil::ToChars<OrderByNullType>(OrderByNullType value) {
 	case OrderByNullType::NULLS_LAST:
 		return "NULLS_LAST";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OrderByNullType>", value));
 	}
 }
 
@@ -4993,7 +4993,7 @@ OrderByNullType EnumUtil::FromString<OrderByNullType>(const char *value) {
 	if (StringUtil::Equals(value, "NULLS_LAST") || StringUtil::Equals(value, "NULLS LAST")) {
 		return OrderByNullType::NULLS_LAST;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OrderByNullType>", value));
 }
 
 template<>
@@ -5006,7 +5006,7 @@ const char* EnumUtil::ToChars<OrderPreservationType>(OrderPreservationType value
 	case OrderPreservationType::FIXED_ORDER:
 		return "FIXED_ORDER";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OrderPreservationType>", value));
 	}
 }
 
@@ -5021,7 +5021,7 @@ OrderPreservationType EnumUtil::FromString<OrderPreservationType>(const char *va
 	if (StringUtil::Equals(value, "FIXED_ORDER")) {
 		return OrderPreservationType::FIXED_ORDER;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OrderPreservationType>", value));
 }
 
 template<>
@@ -5036,7 +5036,7 @@ const char* EnumUtil::ToChars<OrderType>(OrderType value) {
 	case OrderType::DESCENDING:
 		return "DESCENDING";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OrderType>", value));
 	}
 }
 
@@ -5054,7 +5054,7 @@ OrderType EnumUtil::FromString<OrderType>(const char *value) {
 	if (StringUtil::Equals(value, "DESCENDING") || StringUtil::Equals(value, "DESC")) {
 		return OrderType::DESCENDING;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OrderType>", value));
 }
 
 template<>
@@ -5065,7 +5065,7 @@ const char* EnumUtil::ToChars<OutputStream>(OutputStream value) {
 	case OutputStream::STREAM_STDERR:
 		return "STREAM_STDERR";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<OutputStream>", value));
 	}
 }
 
@@ -5077,7 +5077,7 @@ OutputStream EnumUtil::FromString<OutputStream>(const char *value) {
 	if (StringUtil::Equals(value, "STREAM_STDERR")) {
 		return OutputStream::STREAM_STDERR;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<OutputStream>", value));
 }
 
 template<>
@@ -5118,7 +5118,7 @@ const char* EnumUtil::ToChars<ParseInfoType>(ParseInfoType value) {
 	case ParseInfoType::UPDATE_EXTENSIONS_INFO:
 		return "UPDATE_EXTENSIONS_INFO";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ParseInfoType>", value));
 	}
 }
 
@@ -5175,7 +5175,7 @@ ParseInfoType EnumUtil::FromString<ParseInfoType>(const char *value) {
 	if (StringUtil::Equals(value, "UPDATE_EXTENSIONS_INFO")) {
 		return ParseInfoType::UPDATE_EXTENSIONS_INFO;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ParseInfoType>", value));
 }
 
 template<>
@@ -5188,7 +5188,7 @@ const char* EnumUtil::ToChars<ParserExtensionResultType>(ParserExtensionResultTy
 	case ParserExtensionResultType::DISPLAY_EXTENSION_ERROR:
 		return "DISPLAY_EXTENSION_ERROR";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ParserExtensionResultType>", value));
 	}
 }
 
@@ -5203,7 +5203,7 @@ ParserExtensionResultType EnumUtil::FromString<ParserExtensionResultType>(const 
 	if (StringUtil::Equals(value, "DISPLAY_EXTENSION_ERROR")) {
 		return ParserExtensionResultType::DISPLAY_EXTENSION_ERROR;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ParserExtensionResultType>", value));
 }
 
 template<>
@@ -5222,7 +5222,7 @@ const char* EnumUtil::ToChars<PartitionSortStage>(PartitionSortStage value) {
 	case PartitionSortStage::FINISHED:
 		return "FINISHED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<PartitionSortStage>", value));
 	}
 }
 
@@ -5246,7 +5246,7 @@ PartitionSortStage EnumUtil::FromString<PartitionSortStage>(const char *value) {
 	if (StringUtil::Equals(value, "FINISHED")) {
 		return PartitionSortStage::FINISHED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<PartitionSortStage>", value));
 }
 
 template<>
@@ -5259,7 +5259,7 @@ const char* EnumUtil::ToChars<PartitionedColumnDataType>(PartitionedColumnDataTy
 	case PartitionedColumnDataType::HIVE:
 		return "HIVE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<PartitionedColumnDataType>", value));
 	}
 }
 
@@ -5274,7 +5274,7 @@ PartitionedColumnDataType EnumUtil::FromString<PartitionedColumnDataType>(const 
 	if (StringUtil::Equals(value, "HIVE")) {
 		return PartitionedColumnDataType::HIVE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<PartitionedColumnDataType>", value));
 }
 
 template<>
@@ -5285,7 +5285,7 @@ const char* EnumUtil::ToChars<PartitionedTupleDataType>(PartitionedTupleDataType
 	case PartitionedTupleDataType::RADIX:
 		return "RADIX";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<PartitionedTupleDataType>", value));
 	}
 }
 
@@ -5297,7 +5297,7 @@ PartitionedTupleDataType EnumUtil::FromString<PartitionedTupleDataType>(const ch
 	if (StringUtil::Equals(value, "RADIX")) {
 		return PartitionedTupleDataType::RADIX;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<PartitionedTupleDataType>", value));
 }
 
 template<>
@@ -5316,7 +5316,7 @@ const char* EnumUtil::ToChars<PendingExecutionResult>(PendingExecutionResult val
 	case PendingExecutionResult::EXECUTION_FINISHED:
 		return "EXECUTION_FINISHED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<PendingExecutionResult>", value));
 	}
 }
 
@@ -5340,7 +5340,7 @@ PendingExecutionResult EnumUtil::FromString<PendingExecutionResult>(const char *
 	if (StringUtil::Equals(value, "EXECUTION_FINISHED")) {
 		return PendingExecutionResult::EXECUTION_FINISHED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<PendingExecutionResult>", value));
 }
 
 template<>
@@ -5503,7 +5503,7 @@ const char* EnumUtil::ToChars<PhysicalOperatorType>(PhysicalOperatorType value) 
 	case PhysicalOperatorType::CREATE_SECRET:
 		return "CREATE_SECRET";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<PhysicalOperatorType>", value));
 	}
 }
 
@@ -5743,7 +5743,7 @@ PhysicalOperatorType EnumUtil::FromString<PhysicalOperatorType>(const char *valu
 	if (StringUtil::Equals(value, "CREATE_SECRET")) {
 		return PhysicalOperatorType::CREATE_SECRET;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<PhysicalOperatorType>", value));
 }
 
 template<>
@@ -5792,7 +5792,7 @@ const char* EnumUtil::ToChars<PhysicalType>(PhysicalType value) {
 	case PhysicalType::INVALID:
 		return "INVALID";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<PhysicalType>", value));
 	}
 }
 
@@ -5861,7 +5861,7 @@ PhysicalType EnumUtil::FromString<PhysicalType>(const char *value) {
 	if (StringUtil::Equals(value, "INVALID")) {
 		return PhysicalType::INVALID;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<PhysicalType>", value));
 }
 
 template<>
@@ -5872,7 +5872,7 @@ const char* EnumUtil::ToChars<PragmaType>(PragmaType value) {
 	case PragmaType::PRAGMA_CALL:
 		return "PRAGMA_CALL";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<PragmaType>", value));
 	}
 }
 
@@ -5884,7 +5884,7 @@ PragmaType EnumUtil::FromString<PragmaType>(const char *value) {
 	if (StringUtil::Equals(value, "PRAGMA_CALL")) {
 		return PragmaType::PRAGMA_CALL;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<PragmaType>", value));
 }
 
 template<>
@@ -5899,7 +5899,7 @@ const char* EnumUtil::ToChars<PreparedParamType>(PreparedParamType value) {
 	case PreparedParamType::INVALID:
 		return "INVALID";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<PreparedParamType>", value));
 	}
 }
 
@@ -5917,7 +5917,7 @@ PreparedParamType EnumUtil::FromString<PreparedParamType>(const char *value) {
 	if (StringUtil::Equals(value, "INVALID")) {
 		return PreparedParamType::INVALID;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<PreparedParamType>", value));
 }
 
 template<>
@@ -5928,7 +5928,7 @@ const char* EnumUtil::ToChars<PreparedStatementMode>(PreparedStatementMode value
 	case PreparedStatementMode::PREPARE_AND_EXECUTE:
 		return "PREPARE_AND_EXECUTE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<PreparedStatementMode>", value));
 	}
 }
 
@@ -5940,7 +5940,7 @@ PreparedStatementMode EnumUtil::FromString<PreparedStatementMode>(const char *va
 	if (StringUtil::Equals(value, "PREPARE_AND_EXECUTE")) {
 		return PreparedStatementMode::PREPARE_AND_EXECUTE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<PreparedStatementMode>", value));
 }
 
 template<>
@@ -5955,7 +5955,7 @@ const char* EnumUtil::ToChars<ProfilerPrintFormat>(ProfilerPrintFormat value) {
 	case ProfilerPrintFormat::NO_OUTPUT:
 		return "NO_OUTPUT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ProfilerPrintFormat>", value));
 	}
 }
 
@@ -5973,7 +5973,7 @@ ProfilerPrintFormat EnumUtil::FromString<ProfilerPrintFormat>(const char *value)
 	if (StringUtil::Equals(value, "NO_OUTPUT")) {
 		return ProfilerPrintFormat::NO_OUTPUT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ProfilerPrintFormat>", value));
 }
 
 template<>
@@ -5990,7 +5990,7 @@ const char* EnumUtil::ToChars<QuantileSerializationType>(QuantileSerializationTy
 	case QuantileSerializationType::DECIMAL_CONTINUOUS_LIST:
 		return "DECIMAL_CONTINUOUS_LIST";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<QuantileSerializationType>", value));
 	}
 }
 
@@ -6011,7 +6011,7 @@ QuantileSerializationType EnumUtil::FromString<QuantileSerializationType>(const 
 	if (StringUtil::Equals(value, "DECIMAL_CONTINUOUS_LIST")) {
 		return QuantileSerializationType::DECIMAL_CONTINUOUS_LIST;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<QuantileSerializationType>", value));
 }
 
 template<>
@@ -6028,7 +6028,7 @@ const char* EnumUtil::ToChars<QueryNodeType>(QueryNodeType value) {
 	case QueryNodeType::CTE_NODE:
 		return "CTE_NODE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<QueryNodeType>", value));
 	}
 }
 
@@ -6049,7 +6049,7 @@ QueryNodeType EnumUtil::FromString<QueryNodeType>(const char *value) {
 	if (StringUtil::Equals(value, "CTE_NODE")) {
 		return QueryNodeType::CTE_NODE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<QueryNodeType>", value));
 }
 
 template<>
@@ -6064,7 +6064,7 @@ const char* EnumUtil::ToChars<QueryResultType>(QueryResultType value) {
 	case QueryResultType::ARROW_RESULT:
 		return "ARROW_RESULT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<QueryResultType>", value));
 	}
 }
 
@@ -6082,7 +6082,7 @@ QueryResultType EnumUtil::FromString<QueryResultType>(const char *value) {
 	if (StringUtil::Equals(value, "ARROW_RESULT")) {
 		return QueryResultType::ARROW_RESULT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<QueryResultType>", value));
 }
 
 template<>
@@ -6095,7 +6095,7 @@ const char* EnumUtil::ToChars<QuoteRule>(QuoteRule value) {
 	case QuoteRule::NO_QUOTES:
 		return "NO_QUOTES";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<QuoteRule>", value));
 	}
 }
 
@@ -6110,7 +6110,7 @@ QuoteRule EnumUtil::FromString<QuoteRule>(const char *value) {
 	if (StringUtil::Equals(value, "NO_QUOTES")) {
 		return QuoteRule::NO_QUOTES;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<QuoteRule>", value));
 }
 
 template<>
@@ -6173,7 +6173,7 @@ const char* EnumUtil::ToChars<RelationType>(RelationType value) {
 	case RelationType::DELIM_GET_RELATION:
 		return "DELIM_GET_RELATION";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<RelationType>", value));
 	}
 }
 
@@ -6263,7 +6263,7 @@ RelationType EnumUtil::FromString<RelationType>(const char *value) {
 	if (StringUtil::Equals(value, "DELIM_GET_RELATION")) {
 		return RelationType::DELIM_GET_RELATION;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<RelationType>", value));
 }
 
 template<>
@@ -6274,7 +6274,7 @@ const char* EnumUtil::ToChars<RenderMode>(RenderMode value) {
 	case RenderMode::COLUMNS:
 		return "COLUMNS";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<RenderMode>", value));
 	}
 }
 
@@ -6286,7 +6286,7 @@ RenderMode EnumUtil::FromString<RenderMode>(const char *value) {
 	if (StringUtil::Equals(value, "COLUMNS")) {
 		return RenderMode::COLUMNS;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<RenderMode>", value));
 }
 
 template<>
@@ -6301,7 +6301,7 @@ const char* EnumUtil::ToChars<ResultModifierType>(ResultModifierType value) {
 	case ResultModifierType::LIMIT_PERCENT_MODIFIER:
 		return "LIMIT_PERCENT_MODIFIER";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ResultModifierType>", value));
 	}
 }
 
@@ -6319,7 +6319,7 @@ ResultModifierType EnumUtil::FromString<ResultModifierType>(const char *value) {
 	if (StringUtil::Equals(value, "LIMIT_PERCENT_MODIFIER")) {
 		return ResultModifierType::LIMIT_PERCENT_MODIFIER;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ResultModifierType>", value));
 }
 
 template<>
@@ -6332,7 +6332,7 @@ const char* EnumUtil::ToChars<SampleMethod>(SampleMethod value) {
 	case SampleMethod::RESERVOIR_SAMPLE:
 		return "Reservoir";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SampleMethod>", value));
 	}
 }
 
@@ -6347,7 +6347,7 @@ SampleMethod EnumUtil::FromString<SampleMethod>(const char *value) {
 	if (StringUtil::Equals(value, "Reservoir")) {
 		return SampleMethod::RESERVOIR_SAMPLE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SampleMethod>", value));
 }
 
 template<>
@@ -6360,7 +6360,7 @@ const char* EnumUtil::ToChars<SampleType>(SampleType value) {
 	case SampleType::RESERVOIR_PERCENTAGE_SAMPLE:
 		return "RESERVOIR_PERCENTAGE_SAMPLE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SampleType>", value));
 	}
 }
 
@@ -6375,7 +6375,7 @@ SampleType EnumUtil::FromString<SampleType>(const char *value) {
 	if (StringUtil::Equals(value, "RESERVOIR_PERCENTAGE_SAMPLE")) {
 		return SampleType::RESERVOIR_PERCENTAGE_SAMPLE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SampleType>", value));
 }
 
 template<>
@@ -6386,7 +6386,7 @@ const char* EnumUtil::ToChars<ScanType>(ScanType value) {
 	case ScanType::PARQUET:
 		return "PARQUET";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ScanType>", value));
 	}
 }
 
@@ -6398,7 +6398,7 @@ ScanType EnumUtil::FromString<ScanType>(const char *value) {
 	if (StringUtil::Equals(value, "PARQUET")) {
 		return ScanType::PARQUET;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ScanType>", value));
 }
 
 template<>
@@ -6409,7 +6409,7 @@ const char* EnumUtil::ToChars<SecretDisplayType>(SecretDisplayType value) {
 	case SecretDisplayType::UNREDACTED:
 		return "UNREDACTED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SecretDisplayType>", value));
 	}
 }
 
@@ -6421,7 +6421,7 @@ SecretDisplayType EnumUtil::FromString<SecretDisplayType>(const char *value) {
 	if (StringUtil::Equals(value, "UNREDACTED")) {
 		return SecretDisplayType::UNREDACTED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SecretDisplayType>", value));
 }
 
 template<>
@@ -6434,7 +6434,7 @@ const char* EnumUtil::ToChars<SecretPersistType>(SecretPersistType value) {
 	case SecretPersistType::PERSISTENT:
 		return "PERSISTENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SecretPersistType>", value));
 	}
 }
 
@@ -6449,7 +6449,7 @@ SecretPersistType EnumUtil::FromString<SecretPersistType>(const char *value) {
 	if (StringUtil::Equals(value, "PERSISTENT")) {
 		return SecretPersistType::PERSISTENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SecretPersistType>", value));
 }
 
 template<>
@@ -6468,7 +6468,7 @@ const char* EnumUtil::ToChars<SequenceInfo>(SequenceInfo value) {
 	case SequenceInfo::SEQ_OWN:
 		return "SEQ_OWN";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SequenceInfo>", value));
 	}
 }
 
@@ -6492,7 +6492,7 @@ SequenceInfo EnumUtil::FromString<SequenceInfo>(const char *value) {
 	if (StringUtil::Equals(value, "SEQ_OWN")) {
 		return SequenceInfo::SEQ_OWN;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SequenceInfo>", value));
 }
 
 template<>
@@ -6509,7 +6509,7 @@ const char* EnumUtil::ToChars<SetOperationType>(SetOperationType value) {
 	case SetOperationType::UNION_BY_NAME:
 		return "UNION_BY_NAME";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SetOperationType>", value));
 	}
 }
 
@@ -6530,7 +6530,7 @@ SetOperationType EnumUtil::FromString<SetOperationType>(const char *value) {
 	if (StringUtil::Equals(value, "UNION_BY_NAME")) {
 		return SetOperationType::UNION_BY_NAME;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SetOperationType>", value));
 }
 
 template<>
@@ -6547,7 +6547,7 @@ const char* EnumUtil::ToChars<SetScope>(SetScope value) {
 	case SetScope::VARIABLE:
 		return "VARIABLE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SetScope>", value));
 	}
 }
 
@@ -6568,7 +6568,7 @@ SetScope EnumUtil::FromString<SetScope>(const char *value) {
 	if (StringUtil::Equals(value, "VARIABLE")) {
 		return SetScope::VARIABLE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SetScope>", value));
 }
 
 template<>
@@ -6579,7 +6579,7 @@ const char* EnumUtil::ToChars<SetType>(SetType value) {
 	case SetType::RESET:
 		return "RESET";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SetType>", value));
 	}
 }
 
@@ -6591,7 +6591,7 @@ SetType EnumUtil::FromString<SetType>(const char *value) {
 	if (StringUtil::Equals(value, "RESET")) {
 		return SetType::RESET;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SetType>", value));
 }
 
 template<>
@@ -6606,7 +6606,7 @@ const char* EnumUtil::ToChars<SettingScope>(SettingScope value) {
 	case SettingScope::INVALID:
 		return "INVALID";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SettingScope>", value));
 	}
 }
 
@@ -6624,7 +6624,7 @@ SettingScope EnumUtil::FromString<SettingScope>(const char *value) {
 	if (StringUtil::Equals(value, "INVALID")) {
 		return SettingScope::INVALID;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SettingScope>", value));
 }
 
 template<>
@@ -6635,7 +6635,7 @@ const char* EnumUtil::ToChars<ShowType>(ShowType value) {
 	case ShowType::DESCRIBE:
 		return "DESCRIBE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ShowType>", value));
 	}
 }
 
@@ -6647,7 +6647,7 @@ ShowType EnumUtil::FromString<ShowType>(const char *value) {
 	if (StringUtil::Equals(value, "DESCRIBE")) {
 		return ShowType::DESCRIBE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ShowType>", value));
 }
 
 template<>
@@ -6666,7 +6666,7 @@ const char* EnumUtil::ToChars<SimplifiedTokenType>(SimplifiedTokenType value) {
 	case SimplifiedTokenType::SIMPLIFIED_TOKEN_COMMENT:
 		return "SIMPLIFIED_TOKEN_COMMENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SimplifiedTokenType>", value));
 	}
 }
 
@@ -6690,7 +6690,7 @@ SimplifiedTokenType EnumUtil::FromString<SimplifiedTokenType>(const char *value)
 	if (StringUtil::Equals(value, "SIMPLIFIED_TOKEN_COMMENT")) {
 		return SimplifiedTokenType::SIMPLIFIED_TOKEN_COMMENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SimplifiedTokenType>", value));
 }
 
 template<>
@@ -6701,7 +6701,7 @@ const char* EnumUtil::ToChars<SinkCombineResultType>(SinkCombineResultType value
 	case SinkCombineResultType::BLOCKED:
 		return "BLOCKED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SinkCombineResultType>", value));
 	}
 }
 
@@ -6713,7 +6713,7 @@ SinkCombineResultType EnumUtil::FromString<SinkCombineResultType>(const char *va
 	if (StringUtil::Equals(value, "BLOCKED")) {
 		return SinkCombineResultType::BLOCKED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SinkCombineResultType>", value));
 }
 
 template<>
@@ -6726,7 +6726,7 @@ const char* EnumUtil::ToChars<SinkFinalizeType>(SinkFinalizeType value) {
 	case SinkFinalizeType::BLOCKED:
 		return "BLOCKED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SinkFinalizeType>", value));
 	}
 }
 
@@ -6741,7 +6741,7 @@ SinkFinalizeType EnumUtil::FromString<SinkFinalizeType>(const char *value) {
 	if (StringUtil::Equals(value, "BLOCKED")) {
 		return SinkFinalizeType::BLOCKED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SinkFinalizeType>", value));
 }
 
 template<>
@@ -6752,7 +6752,7 @@ const char* EnumUtil::ToChars<SinkNextBatchType>(SinkNextBatchType value) {
 	case SinkNextBatchType::BLOCKED:
 		return "BLOCKED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SinkNextBatchType>", value));
 	}
 }
 
@@ -6764,7 +6764,7 @@ SinkNextBatchType EnumUtil::FromString<SinkNextBatchType>(const char *value) {
 	if (StringUtil::Equals(value, "BLOCKED")) {
 		return SinkNextBatchType::BLOCKED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SinkNextBatchType>", value));
 }
 
 template<>
@@ -6777,7 +6777,7 @@ const char* EnumUtil::ToChars<SinkResultType>(SinkResultType value) {
 	case SinkResultType::BLOCKED:
 		return "BLOCKED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SinkResultType>", value));
 	}
 }
 
@@ -6792,7 +6792,7 @@ SinkResultType EnumUtil::FromString<SinkResultType>(const char *value) {
 	if (StringUtil::Equals(value, "BLOCKED")) {
 		return SinkResultType::BLOCKED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SinkResultType>", value));
 }
 
 template<>
@@ -6805,7 +6805,7 @@ const char* EnumUtil::ToChars<SourceResultType>(SourceResultType value) {
 	case SourceResultType::BLOCKED:
 		return "BLOCKED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SourceResultType>", value));
 	}
 }
 
@@ -6820,7 +6820,7 @@ SourceResultType EnumUtil::FromString<SourceResultType>(const char *value) {
 	if (StringUtil::Equals(value, "BLOCKED")) {
 		return SourceResultType::BLOCKED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SourceResultType>", value));
 }
 
 template<>
@@ -6833,7 +6833,7 @@ const char* EnumUtil::ToChars<StatementReturnType>(StatementReturnType value) {
 	case StatementReturnType::NOTHING:
 		return "NOTHING";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<StatementReturnType>", value));
 	}
 }
 
@@ -6848,7 +6848,7 @@ StatementReturnType EnumUtil::FromString<StatementReturnType>(const char *value)
 	if (StringUtil::Equals(value, "NOTHING")) {
 		return StatementReturnType::NOTHING;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<StatementReturnType>", value));
 }
 
 template<>
@@ -6915,7 +6915,7 @@ const char* EnumUtil::ToChars<StatementType>(StatementType value) {
 	case StatementType::UPDATE_EXTENSIONS_STATEMENT:
 		return "UPDATE_EXTENSIONS_STATEMENT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<StatementType>", value));
 	}
 }
 
@@ -7011,7 +7011,7 @@ StatementType EnumUtil::FromString<StatementType>(const char *value) {
 	if (StringUtil::Equals(value, "UPDATE_EXTENSIONS_STATEMENT")) {
 		return StatementType::UPDATE_EXTENSIONS_STATEMENT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<StatementType>", value));
 }
 
 template<>
@@ -7030,7 +7030,7 @@ const char* EnumUtil::ToChars<StatisticsType>(StatisticsType value) {
 	case StatisticsType::ARRAY_STATS:
 		return "ARRAY_STATS";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<StatisticsType>", value));
 	}
 }
 
@@ -7054,7 +7054,7 @@ StatisticsType EnumUtil::FromString<StatisticsType>(const char *value) {
 	if (StringUtil::Equals(value, "ARRAY_STATS")) {
 		return StatisticsType::ARRAY_STATS;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<StatisticsType>", value));
 }
 
 template<>
@@ -7071,7 +7071,7 @@ const char* EnumUtil::ToChars<StatsInfo>(StatsInfo value) {
 	case StatsInfo::CAN_HAVE_NULL_AND_VALID_VALUES:
 		return "CAN_HAVE_NULL_AND_VALID_VALUES";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<StatsInfo>", value));
 	}
 }
 
@@ -7092,7 +7092,7 @@ StatsInfo EnumUtil::FromString<StatsInfo>(const char *value) {
 	if (StringUtil::Equals(value, "CAN_HAVE_NULL_AND_VALID_VALUES")) {
 		return StatsInfo::CAN_HAVE_NULL_AND_VALID_VALUES;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<StatsInfo>", value));
 }
 
 template<>
@@ -7171,7 +7171,7 @@ const char* EnumUtil::ToChars<StrTimeSpecifier>(StrTimeSpecifier value) {
 	case StrTimeSpecifier::WEEK_NUMBER_ISO:
 		return "WEEK_NUMBER_ISO";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<StrTimeSpecifier>", value));
 	}
 }
 
@@ -7285,7 +7285,7 @@ StrTimeSpecifier EnumUtil::FromString<StrTimeSpecifier>(const char *value) {
 	if (StringUtil::Equals(value, "WEEK_NUMBER_ISO")) {
 		return StrTimeSpecifier::WEEK_NUMBER_ISO;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<StrTimeSpecifier>", value));
 }
 
 template<>
@@ -7306,7 +7306,7 @@ const char* EnumUtil::ToChars<StreamExecutionResult>(StreamExecutionResult value
 	case StreamExecutionResult::EXECUTION_FINISHED:
 		return "EXECUTION_FINISHED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<StreamExecutionResult>", value));
 	}
 }
 
@@ -7333,7 +7333,7 @@ StreamExecutionResult EnumUtil::FromString<StreamExecutionResult>(const char *va
 	if (StringUtil::Equals(value, "EXECUTION_FINISHED")) {
 		return StreamExecutionResult::EXECUTION_FINISHED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<StreamExecutionResult>", value));
 }
 
 template<>
@@ -7350,7 +7350,7 @@ const char* EnumUtil::ToChars<SubqueryType>(SubqueryType value) {
 	case SubqueryType::ANY:
 		return "ANY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<SubqueryType>", value));
 	}
 }
 
@@ -7371,7 +7371,7 @@ SubqueryType EnumUtil::FromString<SubqueryType>(const char *value) {
 	if (StringUtil::Equals(value, "ANY")) {
 		return SubqueryType::ANY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<SubqueryType>", value));
 }
 
 template<>
@@ -7382,7 +7382,7 @@ const char* EnumUtil::ToChars<TableColumnType>(TableColumnType value) {
 	case TableColumnType::GENERATED:
 		return "GENERATED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TableColumnType>", value));
 	}
 }
 
@@ -7394,7 +7394,7 @@ TableColumnType EnumUtil::FromString<TableColumnType>(const char *value) {
 	if (StringUtil::Equals(value, "GENERATED")) {
 		return TableColumnType::GENERATED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TableColumnType>", value));
 }
 
 template<>
@@ -7413,7 +7413,7 @@ const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value) {
 	case TableFilterType::STRUCT_EXTRACT:
 		return "STRUCT_EXTRACT";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TableFilterType>", value));
 	}
 }
 
@@ -7437,7 +7437,7 @@ TableFilterType EnumUtil::FromString<TableFilterType>(const char *value) {
 	if (StringUtil::Equals(value, "STRUCT_EXTRACT")) {
 		return TableFilterType::STRUCT_EXTRACT;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TableFilterType>", value));
 }
 
 template<>
@@ -7468,7 +7468,7 @@ const char* EnumUtil::ToChars<TableReferenceType>(TableReferenceType value) {
 	case TableReferenceType::DELIM_GET:
 		return "DELIM_GET";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TableReferenceType>", value));
 	}
 }
 
@@ -7510,7 +7510,7 @@ TableReferenceType EnumUtil::FromString<TableReferenceType>(const char *value) {
 	if (StringUtil::Equals(value, "DELIM_GET")) {
 		return TableReferenceType::DELIM_GET;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TableReferenceType>", value));
 }
 
 template<>
@@ -7527,7 +7527,7 @@ const char* EnumUtil::ToChars<TableScanType>(TableScanType value) {
 	case TableScanType::TABLE_SCAN_LATEST_COMMITTED_ROWS:
 		return "TABLE_SCAN_LATEST_COMMITTED_ROWS";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TableScanType>", value));
 	}
 }
 
@@ -7548,7 +7548,7 @@ TableScanType EnumUtil::FromString<TableScanType>(const char *value) {
 	if (StringUtil::Equals(value, "TABLE_SCAN_LATEST_COMMITTED_ROWS")) {
 		return TableScanType::TABLE_SCAN_LATEST_COMMITTED_ROWS;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TableScanType>", value));
 }
 
 template<>
@@ -7559,7 +7559,7 @@ const char* EnumUtil::ToChars<TaskExecutionMode>(TaskExecutionMode value) {
 	case TaskExecutionMode::PROCESS_PARTIAL:
 		return "PROCESS_PARTIAL";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TaskExecutionMode>", value));
 	}
 }
 
@@ -7571,7 +7571,7 @@ TaskExecutionMode EnumUtil::FromString<TaskExecutionMode>(const char *value) {
 	if (StringUtil::Equals(value, "PROCESS_PARTIAL")) {
 		return TaskExecutionMode::PROCESS_PARTIAL;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TaskExecutionMode>", value));
 }
 
 template<>
@@ -7586,7 +7586,7 @@ const char* EnumUtil::ToChars<TaskExecutionResult>(TaskExecutionResult value) {
 	case TaskExecutionResult::TASK_BLOCKED:
 		return "TASK_BLOCKED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TaskExecutionResult>", value));
 	}
 }
 
@@ -7604,7 +7604,7 @@ TaskExecutionResult EnumUtil::FromString<TaskExecutionResult>(const char *value)
 	if (StringUtil::Equals(value, "TASK_BLOCKED")) {
 		return TaskExecutionResult::TASK_BLOCKED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TaskExecutionResult>", value));
 }
 
 template<>
@@ -7617,7 +7617,7 @@ const char* EnumUtil::ToChars<TimestampCastResult>(TimestampCastResult value) {
 	case TimestampCastResult::ERROR_NON_UTC_TIMEZONE:
 		return "ERROR_NON_UTC_TIMEZONE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TimestampCastResult>", value));
 	}
 }
 
@@ -7632,7 +7632,7 @@ TimestampCastResult EnumUtil::FromString<TimestampCastResult>(const char *value)
 	if (StringUtil::Equals(value, "ERROR_NON_UTC_TIMEZONE")) {
 		return TimestampCastResult::ERROR_NON_UTC_TIMEZONE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TimestampCastResult>", value));
 }
 
 template<>
@@ -7645,7 +7645,7 @@ const char* EnumUtil::ToChars<TransactionModifierType>(TransactionModifierType v
 	case TransactionModifierType::TRANSACTION_READ_WRITE:
 		return "TRANSACTION_READ_WRITE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TransactionModifierType>", value));
 	}
 }
 
@@ -7660,7 +7660,7 @@ TransactionModifierType EnumUtil::FromString<TransactionModifierType>(const char
 	if (StringUtil::Equals(value, "TRANSACTION_READ_WRITE")) {
 		return TransactionModifierType::TRANSACTION_READ_WRITE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TransactionModifierType>", value));
 }
 
 template<>
@@ -7675,7 +7675,7 @@ const char* EnumUtil::ToChars<TransactionType>(TransactionType value) {
 	case TransactionType::ROLLBACK:
 		return "ROLLBACK";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TransactionType>", value));
 	}
 }
 
@@ -7693,7 +7693,7 @@ TransactionType EnumUtil::FromString<TransactionType>(const char *value) {
 	if (StringUtil::Equals(value, "ROLLBACK")) {
 		return TransactionType::ROLLBACK;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TransactionType>", value));
 }
 
 template<>
@@ -7710,7 +7710,7 @@ const char* EnumUtil::ToChars<TupleDataPinProperties>(TupleDataPinProperties val
 	case TupleDataPinProperties::ALREADY_PINNED:
 		return "ALREADY_PINNED";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<TupleDataPinProperties>", value));
 	}
 }
 
@@ -7731,7 +7731,7 @@ TupleDataPinProperties EnumUtil::FromString<TupleDataPinProperties>(const char *
 	if (StringUtil::Equals(value, "ALREADY_PINNED")) {
 		return TupleDataPinProperties::ALREADY_PINNED;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<TupleDataPinProperties>", value));
 }
 
 template<>
@@ -7750,7 +7750,7 @@ const char* EnumUtil::ToChars<UndoFlags>(UndoFlags value) {
 	case UndoFlags::SEQUENCE_VALUE:
 		return "SEQUENCE_VALUE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<UndoFlags>", value));
 	}
 }
 
@@ -7774,7 +7774,7 @@ UndoFlags EnumUtil::FromString<UndoFlags>(const char *value) {
 	if (StringUtil::Equals(value, "SEQUENCE_VALUE")) {
 		return UndoFlags::SEQUENCE_VALUE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<UndoFlags>", value));
 }
 
 template<>
@@ -7793,7 +7793,7 @@ const char* EnumUtil::ToChars<UnionInvalidReason>(UnionInvalidReason value) {
 	case UnionInvalidReason::NULL_TAG:
 		return "NULL_TAG";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<UnionInvalidReason>", value));
 	}
 }
 
@@ -7817,7 +7817,7 @@ UnionInvalidReason EnumUtil::FromString<UnionInvalidReason>(const char *value) {
 	if (StringUtil::Equals(value, "NULL_TAG")) {
 		return UnionInvalidReason::NULL_TAG;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<UnionInvalidReason>", value));
 }
 
 template<>
@@ -7826,7 +7826,7 @@ const char* EnumUtil::ToChars<VectorAuxiliaryDataType>(VectorAuxiliaryDataType v
 	case VectorAuxiliaryDataType::ARROW_AUXILIARY:
 		return "ARROW_AUXILIARY";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<VectorAuxiliaryDataType>", value));
 	}
 }
 
@@ -7835,7 +7835,7 @@ VectorAuxiliaryDataType EnumUtil::FromString<VectorAuxiliaryDataType>(const char
 	if (StringUtil::Equals(value, "ARROW_AUXILIARY")) {
 		return VectorAuxiliaryDataType::ARROW_AUXILIARY;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<VectorAuxiliaryDataType>", value));
 }
 
 template<>
@@ -7862,7 +7862,7 @@ const char* EnumUtil::ToChars<VectorBufferType>(VectorBufferType value) {
 	case VectorBufferType::ARRAY_BUFFER:
 		return "ARRAY_BUFFER";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<VectorBufferType>", value));
 	}
 }
 
@@ -7898,7 +7898,7 @@ VectorBufferType EnumUtil::FromString<VectorBufferType>(const char *value) {
 	if (StringUtil::Equals(value, "ARRAY_BUFFER")) {
 		return VectorBufferType::ARRAY_BUFFER;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<VectorBufferType>", value));
 }
 
 template<>
@@ -7915,7 +7915,7 @@ const char* EnumUtil::ToChars<VectorType>(VectorType value) {
 	case VectorType::SEQUENCE_VECTOR:
 		return "SEQUENCE_VECTOR";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<VectorType>", value));
 	}
 }
 
@@ -7936,7 +7936,7 @@ VectorType EnumUtil::FromString<VectorType>(const char *value) {
 	if (StringUtil::Equals(value, "SEQUENCE_VECTOR")) {
 		return VectorType::SEQUENCE_VECTOR;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<VectorType>", value));
 }
 
 template<>
@@ -7963,7 +7963,7 @@ const char* EnumUtil::ToChars<VerificationType>(VerificationType value) {
 	case VerificationType::INVALID:
 		return "INVALID";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<VerificationType>", value));
 	}
 }
 
@@ -7999,7 +7999,7 @@ VerificationType EnumUtil::FromString<VerificationType>(const char *value) {
 	if (StringUtil::Equals(value, "INVALID")) {
 		return VerificationType::INVALID;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<VerificationType>", value));
 }
 
 template<>
@@ -8012,7 +8012,7 @@ const char* EnumUtil::ToChars<VerifyExistenceType>(VerifyExistenceType value) {
 	case VerifyExistenceType::DELETE_FK:
 		return "DELETE_FK";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<VerifyExistenceType>", value));
 	}
 }
 
@@ -8027,7 +8027,7 @@ VerifyExistenceType EnumUtil::FromString<VerifyExistenceType>(const char *value)
 	if (StringUtil::Equals(value, "DELETE_FK")) {
 		return VerifyExistenceType::DELETE_FK;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<VerifyExistenceType>", value));
 }
 
 template<>
@@ -8088,7 +8088,7 @@ const char* EnumUtil::ToChars<WALType>(WALType value) {
 	case WALType::WAL_FLUSH:
 		return "WAL_FLUSH";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<WALType>", value));
 	}
 }
 
@@ -8175,7 +8175,7 @@ WALType EnumUtil::FromString<WALType>(const char *value) {
 	if (StringUtil::Equals(value, "WAL_FLUSH")) {
 		return WALType::WAL_FLUSH;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<WALType>", value));
 }
 
 template<>
@@ -8188,7 +8188,7 @@ const char* EnumUtil::ToChars<WindowAggregationMode>(WindowAggregationMode value
 	case WindowAggregationMode::SEPARATE:
 		return "SEPARATE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<WindowAggregationMode>", value));
 	}
 }
 
@@ -8203,7 +8203,7 @@ WindowAggregationMode EnumUtil::FromString<WindowAggregationMode>(const char *va
 	if (StringUtil::Equals(value, "SEPARATE")) {
 		return WindowAggregationMode::SEPARATE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<WindowAggregationMode>", value));
 }
 
 template<>
@@ -8228,7 +8228,7 @@ const char* EnumUtil::ToChars<WindowBoundary>(WindowBoundary value) {
 	case WindowBoundary::EXPR_FOLLOWING_RANGE:
 		return "EXPR_FOLLOWING_RANGE";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<WindowBoundary>", value));
 	}
 }
 
@@ -8261,7 +8261,7 @@ WindowBoundary EnumUtil::FromString<WindowBoundary>(const char *value) {
 	if (StringUtil::Equals(value, "EXPR_FOLLOWING_RANGE")) {
 		return WindowBoundary::EXPR_FOLLOWING_RANGE;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<WindowBoundary>", value));
 }
 
 template<>
@@ -8276,7 +8276,7 @@ const char* EnumUtil::ToChars<WindowExcludeMode>(WindowExcludeMode value) {
 	case WindowExcludeMode::TIES:
 		return "TIES";
 	default:
-		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented", value));
+		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<WindowExcludeMode>", value));
 	}
 }
 
@@ -8294,7 +8294,7 @@ WindowExcludeMode EnumUtil::FromString<WindowExcludeMode>(const char *value) {
 	if (StringUtil::Equals(value, "TIES")) {
 		return WindowExcludeMode::TIES;
 	}
-	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented", value));
+	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<WindowExcludeMode>", value));
 }
 
 }


### PR DESCRIPTION
Moving the error messages in cases of missing enum case to be more verbose, given this has basically no additional cost but grants some more information on what the system is doing at the moment the exception is thrown.

Before (using a bug that will be independently fixed in the meantime as example):
```
D LOAD '~/.duckdb/extensions/v1.0.0/osx_arm64/spatial.duckdb_extension';
Not implemented Error: Enum value: '' not implemented
```
After:
```
D LOAD '~/.duckdb/extensions/v1.0.0/osx_arm64/spatial.duckdb_extension';
Not implemented Error: Enum value: '' not implemented in FromString<ExtensionABIType>
```
```