### PR TITLE
CLI: Add `ctrll + \`  to insert a newline when editing multiline SQL.

### DIFF
--- a/tools/shell/linenoise/include/terminal.hpp
+++ b/tools/shell/linenoise/include/terminal.hpp
@@ -13,33 +13,34 @@
 namespace duckdb {
 
 enum KEY_ACTION {
-	KEY_NULL = 0,   /* NULL */
-	CTRL_A = 1,     /* Ctrl+a */
-	CTRL_B = 2,     /* Ctrl-b */
-	CTRL_C = 3,     /* Ctrl-c */
-	CTRL_D = 4,     /* Ctrl-d */
-	CTRL_E = 5,     /* Ctrl-e */
-	CTRL_F = 6,     /* Ctrl-f */
-	CTRL_G = 7,     /* Ctrl-g */
-	CTRL_H = 8,     /* Ctrl-h */
-	TAB = 9,        /* Tab */
-	CTRL_J = 10,    /* Ctrl+j*/
-	CTRL_K = 11,    /* Ctrl+k */
-	CTRL_L = 12,    /* Ctrl+l */
-	ENTER = 13,     /* Enter */
-	CTRL_N = 14,    /* Ctrl-n */
-	CTRL_O = 15,    /* Ctrl-O */
-	CTRL_P = 16,    /* Ctrl-p */
-	CTRL_R = 18,    /* Ctrl-r */
-	CTRL_S = 19,    /* Ctrl-s */
-	CTRL_T = 20,    /* Ctrl-t */
-	CTRL_U = 21,    /* Ctrl+u */
-	CTRL_W = 23,    /* Ctrl+w */
-	CTRL_X = 24,    /* Ctrl+x */
-	CTRL_Y = 25,    /* Ctrl+y */
-	CTRL_Z = 26,    /* Ctrl+z */
-	ESC = 27,       /* Escape */
-	BACKSPACE = 127 /* Backspace */
+	KEY_NULL = 0,        /* NULL */
+	CTRL_A = 1,          /* Ctrl+a */
+	CTRL_B = 2,          /* Ctrl-b */
+	CTRL_C = 3,          /* Ctrl-c */
+	CTRL_D = 4,          /* Ctrl-d */
+	CTRL_E = 5,          /* Ctrl-e */
+	CTRL_F = 6,          /* Ctrl-f */
+	CTRL_G = 7,          /* Ctrl-g */
+	CTRL_H = 8,          /* Ctrl-h */
+	TAB = 9,             /* Tab */
+	CTRL_J = 10,         /* Ctrl+j*/
+	CTRL_K = 11,         /* Ctrl+k */
+	CTRL_L = 12,         /* Ctrl+l */
+	ENTER = 13,          /* Enter */
+	CTRL_N = 14,         /* Ctrl-n */
+	CTRL_O = 15,         /* Ctrl-O */
+	CTRL_P = 16,         /* Ctrl-p */
+	CTRL_R = 18,         /* Ctrl-r */
+	CTRL_S = 19,         /* Ctrl-s */
+	CTRL_T = 20,         /* Ctrl-t */
+	CTRL_U = 21,         /* Ctrl+u */
+	CTRL_W = 23,         /* Ctrl+w */
+	CTRL_X = 24,         /* Ctrl+x */
+	CTRL_Y = 25,         /* Ctrl+y */
+	CTRL_Z = 26,         /* Ctrl+z */
+	ESC = 27,            /* Escape */
+	CTRL_BackSlash = 28, /* Ctrl+\ */
+	BACKSPACE = 127      /* Backspace */
 };
 
 enum class EscapeSequence {

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -1218,6 +1218,10 @@ int Linenoise::Edit() {
 			buf[new_len] = '\0';
 			return (int)new_len;
 		}
+		case CTRL_BackSlash: {
+			EditInsertMulti("\r\n");
+			break;
+		}
 		case CTRL_O:
 		case CTRL_G:
 		case CTRL_C: /* ctrl-c */ {


### PR DESCRIPTION
We can currently edit multi-line SQL statements fluently in the DuckDB CLI, which is a great feature. However, if I want to add a new line to the multi-line SQL, I can't simply use `Shift + Enter` (as supported in most modern apps) to insert a newline at the current cursor position. Therefore, I think adding `Ctrl + \` to `Linenoise` for inserting a newline would be a great enhancement.

`Ctrl + \` in ASCII is represented by decimal 28, which is the file separator. I believe we won't use the file separator in command-line usage. 
Other alternative keys for inserting a newline could also be considered:

`Ctrl + ]` (ASCII decimal 29, group separator)
`Ctrl + ^` (ASCII decimal 30, record separator)
`Ctrl + _` (ASCII decimal 31, unit separator)

I prefer Ctrl + \ because: It is close to `Enter`. Mentally,`\` resembles adding \n for a newline.

However, any of the other keys would work as well.




https://github.com/user-attachments/assets/a6c1df8f-5c40-454d-91e5-054203d4d909


