### PR TITLE
Copy From Database - create a balanced UNION ALL tree instead of a depth-first union all tree to avoid stack overflows

### DIFF
--- a/src/planner/binder/statement/bind_copy_database.cpp
+++ b/src/planner/binder/statement/bind_copy_database.cpp
@@ -54,7 +54,7 @@ unique_ptr<LogicalOperator> Binder::BindCopyDatabaseData(Catalog &source_catalog
 	ExportEntries entries;
 	PhysicalExport::ExtractEntries(context, source_schemas, entries);
 
-	unique_ptr<LogicalOperator> result;
+	vector<unique_ptr<LogicalOperator>> insert_nodes;
 	for (auto &table_ref : entries.tables) {
 		auto &table = table_ref.get().Cast<TableCatalogEntry>();
 		// generate the insert statement
@@ -82,17 +82,10 @@ unique_ptr<LogicalOperator> Binder::BindCopyDatabaseData(Catalog &source_catalog
 		insert_stmt.select_statement = std::move(select_stmt);
 		auto bound_insert = Bind(insert_stmt);
 		auto insert_plan = std::move(bound_insert.plan);
-		if (result) {
-			// use UNION ALL to combine the individual copy statements into a single node
-			auto copy_union =
-			    make_uniq<LogicalSetOperation>(GenerateTableIndex(), 1U, std::move(insert_plan), std::move(result),
-			                                   LogicalOperatorType::LOGICAL_UNION, true, false);
-			result = std::move(copy_union);
-		} else {
-			result = std::move(insert_plan);
-		}
+		insert_nodes.push_back(std::move(insert_plan));
 	}
-	if (!result) {
+	unique_ptr<LogicalOperator> result;
+	if (insert_nodes.empty()) {
 		vector<LogicalType> result_types;
 		result_types.push_back(LogicalType::BIGINT);
 		vector<unique_ptr<Expression>> expression_list;
@@ -101,6 +94,23 @@ unique_ptr<LogicalOperator> Binder::BindCopyDatabaseData(Catalog &source_catalog
 		expressions.push_back(std::move(expression_list));
 		result = make_uniq<LogicalExpressionGet>(GenerateTableIndex(), std::move(result_types), std::move(expressions));
 		result->children.push_back(make_uniq<LogicalDummyScan>(GenerateTableIndex()));
+	} else {
+		// use UNION ALL to combine the individual copy statements into a single node
+		while (insert_nodes.size() > 1) {
+			vector<unique_ptr<LogicalOperator>> new_nodes;
+			for (idx_t i = 0; i < insert_nodes.size(); i += 2) {
+				if (i + 1 == insert_nodes.size()) {
+					new_nodes.push_back(std::move(insert_nodes[i]));
+				} else {
+					auto copy_union = make_uniq<LogicalSetOperation>(
+					    GenerateTableIndex(), 1U, std::move(insert_nodes[i]), std::move(insert_nodes[i + 1]),
+					    LogicalOperatorType::LOGICAL_UNION, true, false);
+					new_nodes.push_back(std::move(copy_union));
+				}
+			}
+			insert_nodes = std::move(new_nodes);
+		}
+		result = std::move(insert_nodes[0]);
 	}
 	return result;
 }


### PR DESCRIPTION
`COPY FROM DATABASE` creates a number of `INSERT` statements, unified through `UNION ALL` operators to execute this as a single plan. This PR reworks how these union all statements are created to create a balanced tree instead of a depth-first tree, leading to a much less deep tree. This avoids stack overflows later on when copying databases with many tables.