### PR TITLE
Fix #13872: duckdb_result_return_type is not deprecated, and group together deprecated functions

### DIFF
--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -389,15 +389,17 @@ def create_duckdb_h(ext_api_version, function_groups):
                 deprecated_state = True
 
             function_comment = create_function_comment(function)
-            if (
-                function_is_deprecated
-                and '**DEPRECATED**' not in function_comment
-                and '**DEPRECATION NOTICE**' not in function_comment
-            ):
+            function_contains_deprecation_notice = (
+                '**DEPRECATED**' in function_comment or '**DEPRECATION NOTICE**' in function_comment
+            )
+            if function_is_deprecated and not function_contains_deprecation_notice:
                 raise Exception(
                     f"Function {str(function)} is labeled as deprecated but the comment does not indicate this"
                 )
-
+            elif not function_is_deprecated and function_contains_deprecation_notice:
+                raise Exception(
+                    f"Function {str(function)} is not labeled as deprecated but the comment indicates that it is"
+                )
             function_declarations_finished += function_comment
             function_declarations_finished += create_function_declaration(function)
 

--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -388,7 +388,17 @@ def create_duckdb_h(ext_api_version, function_groups):
                 function_declarations_finished += '#ifndef DUCKDB_API_NO_DEPRECATED\n'
                 deprecated_state = True
 
-            function_declarations_finished += create_function_comment(function)
+            function_comment = create_function_comment(function)
+            if (
+                function_is_deprecated
+                and '**DEPRECATED**' not in function_comment
+                and '**DEPRECATION NOTICE**' not in function_comment
+            ):
+                raise Exception(
+                    f"Function {str(function)} is labeled as deprecated but the comment does not indicate this"
+                )
+
+            function_declarations_finished += function_comment
             function_declarations_finished += create_function_declaration(function)
 
             function_declarations_finished += '\n'

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -866,8 +866,8 @@ Returns the number of rows present in the result object.
 * @return The number of rows present in the result object.
 */
 DUCKDB_API idx_t duckdb_row_count(duckdb_result *result);
-#endif
 
+#endif
 /*!
 Returns the number of rows changed by the query stored in the result. This is relevant only for INSERT/UPDATE/DELETE
 queries. For other queries the rows_changed will be 0.
@@ -898,9 +898,7 @@ printf("Data for row %d: %d\n", row, data[row]);
 * @return The column data of the specified column.
 */
 DUCKDB_API void *duckdb_column_data(duckdb_result *result, idx_t col);
-#endif
 
-#ifndef DUCKDB_API_NO_DEPRECATED
 /*!
 **DEPRECATED**: Prefer using `duckdb_result_get_chunk` instead.
 
@@ -923,8 +921,8 @@ if (nullmask[row]) {
 * @return The nullmask of the specified column.
 */
 DUCKDB_API bool *duckdb_nullmask_data(duckdb_result *result, idx_t col);
-#endif
 
+#endif
 /*!
 Returns the error message contained within the result. The error is only set if `duckdb_query` returns `DuckDBError`.
 
@@ -990,6 +988,7 @@ Returns the number of data chunks present in the result.
 */
 DUCKDB_API idx_t duckdb_result_chunk_count(duckdb_result result);
 
+#endif
 /*!
 Returns the return_type of the given result, or DUCKDB_RETURN_TYPE_INVALID on error
 
@@ -998,7 +997,6 @@ Returns the return_type of the given result, or DUCKDB_RETURN_TYPE_INVALID on er
 */
 DUCKDB_API duckdb_result_type duckdb_result_return_type(duckdb_result result);
 
-#endif
 //===--------------------------------------------------------------------===//
 // Safe Fetch Functions
 //===--------------------------------------------------------------------===//
@@ -1663,8 +1661,8 @@ Note that the result must be freed with `duckdb_destroy_result`.
 */
 DUCKDB_API duckdb_state duckdb_execute_prepared_streaming(duckdb_prepared_statement prepared_statement,
                                                           duckdb_result *out_result);
-#endif
 
+#endif
 //===--------------------------------------------------------------------===//
 // Extract Statements
 //===--------------------------------------------------------------------===//
@@ -1754,8 +1752,8 @@ Note that after calling `duckdb_pending_prepared_streaming`, the pending result 
 */
 DUCKDB_API duckdb_state duckdb_pending_prepared_streaming(duckdb_prepared_statement prepared_statement,
                                                           duckdb_pending_result *out_result);
-#endif
 
+#endif
 /*!
 Closes the pending result and de-allocates all memory allocated for the result.
 
@@ -4038,8 +4036,8 @@ It is not known beforehand how many chunks will be returned by this result.
 * @return The resulting data chunk. Returns `NULL` if the result has an error.
 */
 DUCKDB_API duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result);
-#endif
 
+#endif
 /*!
 Fetches a data chunk from a duckdb_result. This function should be called repeatedly until the result is exhausted.
 

--- a/src/include/duckdb/main/capi/header_generation/functions/result_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/result_functions.json
@@ -1,6 +1,5 @@
 {
     "group": "result_functions",
-    "deprecated": true,
     "entries": [
         {
             "name": "duckdb_result_get_chunk",
@@ -15,6 +14,7 @@
                     "name": "chunk_index"
                 }
             ],
+            "deprecated": true,
             "comment": {
                 "description": "**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.\n\nFetches a data chunk from the duckdb_result. This function should be called repeatedly until the result is exhausted.\n\nThe result must be destroyed with `duckdb_destroy_data_chunk`.\n\nThis function supersedes all `duckdb_value` functions, as well as the `duckdb_column_data` and `duckdb_nullmask_data`\nfunctions. It results in significantly better performance, and should be preferred in newer code-bases.\n\nIf this function is used, none of the other result functions can be used and vice versa (i.e. this function cannot be\nmixed with the legacy result functions).\n\nUse `duckdb_result_chunk_count` to figure out how many chunks there are in the result.\n\n",
                 "param_comments": {
@@ -33,6 +33,7 @@
                     "name": "result"
                 }
             ],
+            "deprecated": true,
             "comment": {
                 "description": "**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.\n\nChecks if the type of the internal result is StreamQueryResult.\n\n",
                 "param_comments": {
@@ -50,6 +51,7 @@
                     "name": "result"
                 }
             ],
+            "deprecated": true,
             "comment": {
                 "description": "**DEPRECATION NOTICE**: This method is scheduled for removal in a future release.\n\nReturns the number of data chunks present in the result.\n\n",
                 "param_comments": {


### PR DESCRIPTION
Fixes #13872 

Also add some more safeguards, so that we detect if a function is labeled as deprecated but does not contain this in the comment (and vice versa).