### PR TITLE
[Python] Fix issue related to the GIL when using `execute` with multiple statements

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1396,6 +1396,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(const py::object &name_
 
 void DuckDBPyConnection::ExecuteImmediately(vector<unique_ptr<SQLStatement>> statements) {
 	auto &connection = con.GetConnection();
+	py::gil_scoped_release release;
 	if (statements.empty()) {
 		return;
 	}

--- a/tools/pythonpkg/tests/fast/api/test_duckdb_execute.py
+++ b/tools/pythonpkg/tests/fast/api/test_duckdb_execute.py
@@ -74,3 +74,14 @@ class TestDuckDBExecute(object):
         duckdb_cursor.execute("CREATE TABLE unittest_generator (a INTEGER);")
         duckdb_cursor.executemany("INSERT into unittest_generator (a) VALUES (?)", gen)
         assert duckdb_cursor.table('unittest_generator').fetchall() == [(1,), (2,), (3,)]
+
+    def test_execute_multiple_statements(self, duckdb_cursor):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({'a': [5, 6, 7, 8]})
+        sql = """
+            select * from df;
+            select * from VALUES (1),(2),(3),(4) t(a);
+        """
+        duckdb_cursor.execute(sql)
+        res = duckdb_cursor.fetchall()
+        assert res == [(1,), (2,), (3,), (4,)]


### PR DESCRIPTION
This PR fixes #13863 

When multiple statements are provided to `con.execute`, all the statements except the last one are "executed immediately", whereas the last statement goes through a slightly different path as prepared parameters might need to be injected before it gets executed.

The `ExecuteImmediately` path did not release the GIL before entering the bind+execution phase, which is what caused this error.