### PR TITLE
Handle extension ABI mismatches in a forward & backward compatible way

### DIFF
--- a/src/include/duckdb/main/extension.hpp
+++ b/src/include/duckdb/main/extension.hpp
@@ -50,6 +50,7 @@ struct ParsedExtensionMetaData {
 	string duckdb_capi_version;
 	string extension_version;
 	string signature;
+	string extension_abi_metadata;
 
 	bool AppearsValid() {
 		return magic_value == EXPECTED_MAGIC_VALUE;

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -124,7 +124,7 @@ public:
 
 	static bool CheckExtensionSignature(FileHandle &handle, ParsedExtensionMetaData &parsed_metadata,
 	                                    const bool allow_community_extensions);
-	static ParsedExtensionMetaData ParseExtensionMetaData(const char *metadata);
+	static ParsedExtensionMetaData ParseExtensionMetaData(const char *metadata) noexcept;
 	static ParsedExtensionMetaData ParseExtensionMetaData(FileHandle &handle);
 
 	//! Get the extension url template, containing placeholders for version, platform and extension name

--- a/src/main/extension.cpp
+++ b/src/main/extension.cpp
@@ -62,7 +62,7 @@ string ParsedExtensionMetaData::GetInvalidMetadataError() {
 			                       DUCKDB_EXTENSION_API_VERSION_MINOR, DUCKDB_EXTENSION_API_VERSION_PATCH);
 		}
 	} else {
-		throw InternalException("Unknown ABI type for extension: " + EnumUtil::ToString(abi_type));
+		throw InternalException("Unknown ABI type for extension: " + extension_abi_metadata);
 	}
 
 	if (engine_platform != platform) {

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -173,7 +173,7 @@ static string FilterZeroAtEnd(string s) {
 	return s;
 }
 
-ParsedExtensionMetaData ExtensionHelper::ParseExtensionMetaData(const char *metadata) {
+ParsedExtensionMetaData ExtensionHelper::ParseExtensionMetaData(const char *metadata) noexcept {
 	ParsedExtensionMetaData result;
 
 	vector<string> metadata_field;
@@ -194,12 +194,18 @@ ParsedExtensionMetaData ExtensionHelper::ParseExtensionMetaData(const char *meta
 
 	result.extension_version = FilterZeroAtEnd(metadata_field[3]);
 
-	result.abi_type = EnumUtil::FromString<ExtensionABIType>(FilterZeroAtEnd(metadata_field[4]));
+	auto extension_abi_metadata = FilterZeroAtEnd(metadata_field[4]);
 
-	if (result.abi_type == ExtensionABIType::C_STRUCT) {
+	if (extension_abi_metadata == "C_STRUCT") {
+		result.abi_type = ExtensionABIType::C_STRUCT;
 		result.duckdb_capi_version = FilterZeroAtEnd(metadata_field[2]);
-	} else if (result.abi_type == ExtensionABIType::CPP) {
+	} else if (extension_abi_metadata == "CPP" || extension_abi_metadata.empty()) {
+		result.abi_type = ExtensionABIType::CPP;
 		result.duckdb_version = FilterZeroAtEnd(metadata_field[2]);
+	} else {
+		result.abi_type = ExtensionABIType::UNKNOWN;
+		result.duckdb_version = "unknown";
+		result.extension_abi_metadata = extension_abi_metadata;
 	}
 
 	result.signature = string(metadata, ParsedExtensionMetaData::FOOTER_SIZE - ParsedExtensionMetaData::SIGNATURE_SIZE);


### PR DESCRIPTION
This PR do not introduces behaviour changes for working paths, but improve error messages when extensions are mixed between different incompatible DuckDB versions.

In particular, opening extensions with no ABI specified still reads them as C++-based extensions, and opening extensions with unknown ABI (say we add more of them later) have the ABI logged to user as part of the error message.

Also moving an implementation function to `noexcept`, should likely be done in more places, but can be done independenlty.