### PR TITLE
[Python] Add `python_scan_all_frames` to opt-in to scanning all frames (< 1.1 behavior)

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1945,6 +1945,10 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const py::object &dat
 	config.AddExtensionOption("python_enable_replacements",
 	                          "Whether variables visible to the current stack should be used for replacement scans.",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(true));
+	config.AddExtensionOption(
+	    "python_scan_all_frames",
+	    "If set, restores the old behavior of scanning all preceding frames to locate the referenced variable.",
+	    LogicalType::BOOLEAN, Value::BOOLEAN(false));
 	if (!DuckDBPyConnection::IsJupyter()) {
 		config_dict["duckdb_api"] = Value("python");
 	} else {

--- a/tools/pythonpkg/src/python_replacement_scan.cpp
+++ b/tools/pythonpkg/src/python_replacement_scan.cpp
@@ -194,25 +194,38 @@ static unique_ptr<TableRef> ReplaceInternal(ClientContext &context, const string
 		return nullptr;
 	}
 
-	py::gil_scoped_acquire acquire;
-	auto current_frame = py::module::import("inspect").attr("currentframe")();
+	lookup_result = context.TryGetCurrentSetting("python_scan_all_frames", result);
+	D_ASSERT((bool)lookup_result);
+	auto scan_all_frames = result.GetValue<bool>();
 
-	auto local_dict = py::cast<py::dict>(current_frame.attr("f_locals"));
-	// search local dictionary
-	if (local_dict) {
-		auto result = TryReplacement(local_dict, table_name, context, current_frame);
-		if (result) {
-			return result;
+	py::gil_scoped_acquire acquire;
+	py::object current_frame = py::module::import("inspect").attr("currentframe")();
+
+	bool has_locals = false;
+	bool has_globals = false;
+	do {
+		py::object local_dict_p = current_frame.attr("f_locals");
+		has_locals = !py::none().is(local_dict_p);
+		if (has_locals) {
+			// search local dictionary
+			auto local_dict = py::cast<py::dict>(local_dict_p);
+			auto result = TryReplacement(local_dict, table_name, context, current_frame);
+			if (result) {
+				return result;
+			}
 		}
-	}
-	// search global dictionary
-	auto global_dict = py::cast<py::dict>(current_frame.attr("f_globals"));
-	if (global_dict) {
-		auto result = TryReplacement(global_dict, table_name, context, current_frame);
-		if (result) {
-			return result;
+		py::object global_dict_p = current_frame.attr("f_globals");
+		has_globals = !py::none().is(global_dict_p);
+		if (has_globals) {
+			auto global_dict = py::cast<py::dict>(global_dict_p);
+			// search global dictionary
+			auto result = TryReplacement(global_dict, table_name, context, current_frame);
+			if (result) {
+				return result;
+			}
 		}
-	}
+		current_frame = current_frame.attr("f_back");
+	} while (scan_all_frames && (has_locals || has_globals));
 	return nullptr;
 }
 

--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -122,10 +122,6 @@ class TestReplacementScan(object):
                 duckdb_cursor.sql("select * from df")
             duckdb_cursor.execute("set python_enable_replacements=true")
             with pytest.raises(duckdb.CatalogException, match='Table with name df does not exist'):
-                # We set the depth to look for local variables to 1 so it's still not found because it wasn't defined in this function
-                duckdb_cursor.sql("select * from df")
-            duckdb_cursor.execute("set python_enable_replacements=true")
-            with pytest.raises(duckdb.CatalogException, match='Table with name df does not exist'):
                 # Here it's still not found, because it's not visible to this frame
                 duckdb_cursor.sql("select * from df")
 
@@ -135,6 +131,23 @@ class TestReplacementScan(object):
             rel = duckdb_cursor.sql("select * from df")
             res = rel.fetchall()
             assert res == [(4,), (5,), (6,)]
+
+        inner_func(duckdb_cursor)
+
+    def test_scan_local_unlimited(self, duckdb_cursor):
+        df = pd.DataFrame({'a': [1, 2, 3]})
+
+        def inner_func(duckdb_cursor):
+            duckdb_cursor.execute("set python_enable_replacements=true")
+            with pytest.raises(duckdb.CatalogException, match='Table with name df does not exist'):
+                # We set the depth to look for local variables to 1 so it's still not found because it wasn't defined in this function
+                duckdb_cursor.sql("select * from df")
+            duckdb_cursor.execute("set python_scan_all_frames=true")
+            # Now we can find 'df' because we also scan the previous frame(s)
+            rel = duckdb_cursor.sql("select * from df")
+
+            res = rel.fetchall()
+            assert res == [(1,), (2,), (3,)]
 
         inner_func(duckdb_cursor)
 


### PR DESCRIPTION
This PR fixes #13836

Using `con.execute("set python_scan_all_frames=true")` we will scan all frames again when performing a replacement scan.
Meaning that if `df` is not defined in the current scope, but it is defined in the previous scope (or deeper), then it will still be found if this setting is flipped to true.