### PR TITLE
Fix #13824: min() max() varchar column use default collation

### DIFF
--- a/src/core_functions/aggregate/distributive/minmax.cpp
+++ b/src/core_functions/aggregate/distributive/minmax.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/types/null_value.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
@@ -330,7 +331,7 @@ unique_ptr<FunctionData> BindMinMax(ClientContext &context, AggregateFunction &f
                                     vector<unique_ptr<Expression>> &arguments) {
 	if (arguments[0]->return_type.id() == LogicalTypeId::VARCHAR) {
 		auto str_collation = StringType::GetCollation(arguments[0]->return_type);
-		if (!str_collation.empty()) {
+		if (!str_collation.empty() || !DBConfig::GetConfig(context).options.collation.empty()) {
 			// If aggr function is min/max and uses collations, replace bound_function with arg_min/arg_max
 			// to make sure the result's correctness.
 			string function_name = function.name == "min" ? "arg_min" : "arg_max";

--- a/test/issues/general/test_13824.test
+++ b/test/issues/general/test_13824.test
@@ -1,0 +1,37 @@
+# name: test/issues/general/test_13824.test
+# description: min() and max() should use default collation
+# group: [general]
+
+require icu
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table test(id int, name text)
+
+statement ok
+insert into test values (1, 'a'), (2, 'b'), (3, 'c'), (4, 'A'), (5, 'G'), (6, 'd')
+
+query I
+select min(name) from test
+----
+A
+
+query I
+select max(name) from test
+----
+d
+
+statement ok
+set default_collation = 'EN_US';
+
+query I
+select min(name) from test
+----
+a
+
+query I
+select max(name) from test
+----
+G


### PR DESCRIPTION
this pr try to fix #13824 , use  default collation when execute min() or max() 