### PR TITLE
Decimal downcast limit check

### DIFF
--- a/src/common/types/hugeint.cpp
+++ b/src/common/types/hugeint.cpp
@@ -77,19 +77,6 @@ bool Hugeint::TryNegate(hugeint_t input, hugeint_t &result) {
 	return true;
 }
 
-hugeint_t Hugeint::Pow(uint8_t base_p, uint8_t exponent) {
-	hugeint_t base = base_p;
-	hugeint_t result = 1;
-	while (exponent > 0) {
-		if (exponent % 2 == 1) {
-			result *= base;
-		}
-		base *= base;
-		exponent /= 2;
-	}
-	return result;
-}
-
 hugeint_t Hugeint::Abs(hugeint_t n) {
 	if (n < 0) {
 		return Hugeint::Negate(n);

--- a/src/common/types/hugeint.cpp
+++ b/src/common/types/hugeint.cpp
@@ -77,6 +77,19 @@ bool Hugeint::TryNegate(hugeint_t input, hugeint_t &result) {
 	return true;
 }
 
+hugeint_t Hugeint::Pow(uint8_t base_p, uint8_t exponent) {
+	hugeint_t base = base_p;
+	hugeint_t result = 1;
+	while (exponent > 0) {
+		if (exponent % 2 == 1) {
+			result *= base;
+		}
+		base *= base;
+		exponent /= 2;
+	}
+	return result;
+}
+
 hugeint_t Hugeint::Abs(hugeint_t n) {
 	if (n < 0) {
 		return Hugeint::Negate(n);

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -231,51 +231,6 @@ static bool DecimalToStringCast(Vector &source, Vector &result, idx_t count, Cas
 	UnaryExecutor::GenericExecute<SRC, string_t, StringCastFromDecimalOperator>(source, result, count, (void *)&input);
 	return true;
 }
-// void RoundDecimal() {
-// 	int32_t round_value = IntegerValue::Get(val);
-// 	uint8_t target_scale;
-// 	auto width = DecimalType::GetWidth(decimal_type);
-// 	auto scale = DecimalType::GetScale(decimal_type);
-// 	if (round_value < 0) {
-// 		target_scale = 0;
-// 		switch (decimal_type.InternalType()) {
-// 		case PhysicalType::INT16:
-// 			bound_function.function = DecimalRoundNegativePrecisionFunction<int16_t, NumericHelper>;
-// 			break;
-// 		case PhysicalType::INT32:
-// 			bound_function.function = DecimalRoundNegativePrecisionFunction<int32_t, NumericHelper>;
-// 			break;
-// 		case PhysicalType::INT64:
-// 			bound_function.function = DecimalRoundNegativePrecisionFunction<int64_t, NumericHelper>;
-// 			break;
-// 		default:
-// 			bound_function.function = DecimalRoundNegativePrecisionFunction<hugeint_t, Hugeint>;
-// 			break;
-// 		}
-// 	} else {
-// 		if (round_value >= (int32_t)scale) {
-// 			// if round_value is bigger than or equal to scale we do nothing
-// 			bound_function.function = ScalarFunction::NopFunction;
-// 			target_scale = scale;
-// 		} else {
-// 			target_scale = NumericCast<uint8_t>(round_value);
-// 			switch (decimal_type.InternalType()) {
-// 			case PhysicalType::INT16:
-// 				bound_function.function = DecimalRoundPositivePrecisionFunction<int16_t, NumericHelper>;
-// 				break;
-// 			case PhysicalType::INT32:
-// 				bound_function.function = DecimalRoundPositivePrecisionFunction<int32_t, NumericHelper>;
-// 				break;
-// 			case PhysicalType::INT64:
-// 				bound_function.function = DecimalRoundPositivePrecisionFunction<int64_t, NumericHelper>;
-// 				break;
-// 			default:
-// 				bound_function.function = DecimalRoundPositivePrecisionFunction<hugeint_t, Hugeint>;
-// 				break;
-// 			}
-// 		}
-// 	}
-// }
 
 BoundCastInfo DefaultCasts::DecimalCastSwitch(BindCastInput &input, const LogicalType &source,
                                               const LogicalType &target) {

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -117,7 +117,7 @@ struct DecimalScaleDownOperator {
 // This function detects if we can scale a decimal down to another.
 template <class INPUT_TYPE>
 bool CanScaleDownDecimal(INPUT_TYPE input, DecimalScaleInput<INPUT_TYPE> &data) {
-	int64_t divisor = static_cast<int64_t>(pow(10, data.source_scale));
+	int64_t divisor = UnsafeNumericCast<int64_t>(NumericHelper::POWERS_OF_TEN[data.source_scale]);
 	auto value = input % divisor;
 	auto rounded_input = input;
 	if (rounded_input < 0) {
@@ -130,8 +130,8 @@ bool CanScaleDownDecimal(INPUT_TYPE input, DecimalScaleInput<INPUT_TYPE> &data) 
 	return rounded_input < data.limit && rounded_input > -data.limit;
 }
 
-bool CanScaleDownDecimal(hugeint_t input, DecimalScaleInput<hugeint_t> &data) {
-	auto divisor = Hugeint::Pow(10, data.source_scale);
+bool CanScaleDownDecimal(hugeint_t input, const DecimalScaleInput<hugeint_t> &data) {
+	auto divisor = UnsafeNumericCast<hugeint_t>(Hugeint::POWERS_OF_TEN[data.source_scale]);
 	hugeint_t value = input % divisor;
 	hugeint_t rounded_input = input;
 	if (rounded_input < 0) {

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -130,7 +130,9 @@ bool CanScaleDownDecimal(INPUT_TYPE input, DecimalScaleInput<INPUT_TYPE> &data) 
 	return rounded_input < data.limit && rounded_input > -data.limit;
 }
 
-bool CanScaleDownDecimal(hugeint_t input, const DecimalScaleInput<hugeint_t> &data) {
+
+template <>
+bool CanScaleDownDecimal<hugeint_t>(hugeint_t input, DecimalScaleInput<hugeint_t> &data) {
 	auto divisor = UnsafeNumericCast<hugeint_t>(Hugeint::POWERS_OF_TEN[data.source_scale]);
 	hugeint_t value = input % divisor;
 	hugeint_t rounded_input = input;

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -130,7 +130,6 @@ bool CanScaleDownDecimal(INPUT_TYPE input, DecimalScaleInput<INPUT_TYPE> &data) 
 	return rounded_input < data.limit && rounded_input > -data.limit;
 }
 
-
 template <>
 bool CanScaleDownDecimal<hugeint_t>(hugeint_t input, DecimalScaleInput<hugeint_t> &data) {
 	auto divisor = UnsafeNumericCast<hugeint_t>(Hugeint::POWERS_OF_TEN[data.source_scale]);

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -114,18 +114,27 @@ struct DecimalScaleDownOperator {
 	}
 };
 
+// This function detects if we can scale a decimal down to another.
+template <class INPUT_TYPE>
+bool CanScaleDownDecimal(INPUT_TYPE input, DecimalScaleInput<INPUT_TYPE> &data) {
+	int64_t divisor = static_cast<int64_t>(pow(10, data.source_scale));
+	auto value = input % divisor;
+	auto rounded_input = input;
+	if (rounded_input < 0){
+		rounded_input*=-1;
+		value *=-1;
+	}
+	if (value >= divisor/2){
+		rounded_input+=divisor;
+	}
+	return rounded_input < data.limit && rounded_input > -data.limit;
+}
+
 struct DecimalScaleDownCheckOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
-		auto data = (DecimalScaleInput<INPUT_TYPE> *)dataptr;
-		// Calculate the divisor as 10^x to extract the last x digits
-		int64_t divisor = static_cast<int64_t>(pow(10, data->source_scale));
-		auto value = input % divisor;
-		auto rounded_input = input;
-		if (value >= divisor/2){
-			rounded_input+=divisor;
-		}
-		if (rounded_input >= data->limit || rounded_input <= -data->limit) {
+		auto data = static_cast<DecimalScaleInput<INPUT_TYPE> *>(dataptr);
+		if (!CanScaleDownDecimal(input,*data)) {
 			auto error = StringUtil::Format("Casting value \"%s\" to type %s failed: value is out of range!",
 			                                Decimal::ToString(input, data->source_width, data->source_scale),
 			                                data->result.GetType().ToString());

--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -120,12 +120,26 @@ bool CanScaleDownDecimal(INPUT_TYPE input, DecimalScaleInput<INPUT_TYPE> &data) 
 	int64_t divisor = static_cast<int64_t>(pow(10, data.source_scale));
 	auto value = input % divisor;
 	auto rounded_input = input;
-	if (rounded_input < 0){
-		rounded_input*=-1;
-		value *=-1;
+	if (rounded_input < 0) {
+		rounded_input *= -1;
+		value *= -1;
 	}
-	if (value >= divisor/2){
-		rounded_input+=divisor;
+	if (value >= divisor / 2) {
+		rounded_input += divisor;
+	}
+	return rounded_input < data.limit && rounded_input > -data.limit;
+}
+
+bool CanScaleDownDecimal(hugeint_t input, DecimalScaleInput<hugeint_t> &data) {
+	auto divisor = Hugeint::Pow(10, data.source_scale);
+	hugeint_t value = input % divisor;
+	hugeint_t rounded_input = input;
+	if (rounded_input < 0) {
+		rounded_input *= -1;
+		value *= -1;
+	}
+	if (value >= divisor / 2) {
+		rounded_input += divisor;
 	}
 	return rounded_input < data.limit && rounded_input > -data.limit;
 }
@@ -134,7 +148,7 @@ struct DecimalScaleDownCheckOperator {
 	template <class INPUT_TYPE, class RESULT_TYPE>
 	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
 		auto data = static_cast<DecimalScaleInput<INPUT_TYPE> *>(dataptr);
-		if (!CanScaleDownDecimal(input,*data)) {
+		if (!CanScaleDownDecimal(input, *data)) {
 			auto error = StringUtil::Format("Casting value \"%s\" to type %s failed: value is out of range!",
 			                                Decimal::ToString(input, data->source_width, data->source_scale),
 			                                data->result.GetType().ToString());

--- a/src/include/duckdb/common/types/hugeint.hpp
+++ b/src/include/duckdb/common/types/hugeint.hpp
@@ -128,7 +128,7 @@ public:
 
 	static int Sign(hugeint_t n);
 	static hugeint_t Abs(hugeint_t n);
-
+	static hugeint_t Pow(uint8_t base, uint8_t exponent);
 	// comparison operators
 	// note that everywhere here we intentionally use bitwise ops
 	// this is because they seem to be consistently much faster (benchmarked on a Macbook Pro)

--- a/src/include/duckdb/common/types/hugeint.hpp
+++ b/src/include/duckdb/common/types/hugeint.hpp
@@ -128,7 +128,6 @@ public:
 
 	static int Sign(hugeint_t n);
 	static hugeint_t Abs(hugeint_t n);
-	static hugeint_t Pow(uint8_t base, uint8_t exponent);
 	// comparison operators
 	// note that everywhere here we intentionally use bitwise ops
 	// this is because they seem to be consistently much faster (benchmarked on a Macbook Pro)

--- a/test/sql/types/decimal/decimal_exception.test
+++ b/test/sql/types/decimal/decimal_exception.test
@@ -24,3 +24,21 @@ statement error
 select cast(9.99 as decimal(1,0));
 ----
 Casting value "9.99" to type DECIMAL(1,0) failed: value is out of range!
+
+query I
+select cast(9.49 as decimal(1,0));
+----
+9
+
+statement error
+select cast(9.5 as decimal(1,0));
+----
+Casting value "9.5" to type DECIMAL(1,0) failed: value is out of range!
+
+
+statement error
+select cast(-9.99 as decimal(1,0));
+----
+Casting value "9.99" to type DECIMAL(1,0) failed: value is out of range!
+
+# Test biggest values

--- a/test/sql/types/decimal/decimal_exception.test
+++ b/test/sql/types/decimal/decimal_exception.test
@@ -5,20 +5,20 @@
 statement ok
 PRAGMA enable_verification
 
-#statement error
-#select cast('9.99' as decimal(1,0));
-#----
-#Could not convert string "9.99" to DECIMAL(1,0)
-#
-#statement error
-#select cast(9.99::float as decimal(1,0));
-#----
-#Could not cast value
-#
-#statement error
-#select cast(9.99::double as decimal(1,0));
-#----
-#Could not cast value
+statement error
+select cast('9.99' as decimal(1,0));
+----
+Could not convert string "9.99" to DECIMAL(1,0)
+
+statement error
+select cast(9.99::float as decimal(1,0));
+----
+Could not cast value
+
+statement error
+select cast(9.99::double as decimal(1,0));
+----
+Could not cast value
 
 statement error
 select cast(9.99 as decimal(1,0));

--- a/test/sql/types/decimal/decimal_exception.test
+++ b/test/sql/types/decimal/decimal_exception.test
@@ -5,40 +5,60 @@
 statement ok
 PRAGMA enable_verification
 
+#statement error
+#select cast('9.99' as decimal(1,0));
+#----
+#Could not convert string "9.99" to DECIMAL(1,0)
+#
+#statement error
+#select cast(9.99::float as decimal(1,0));
+#----
+#Could not cast value
+#
+#statement error
+#select cast(9.99::double as decimal(1,0));
+#----
+#Could not cast value
+#
+#statement error
+#select cast(9.99 as decimal(1,0));
+#----
+#Casting value "9.99" to type DECIMAL(1,0) failed: value is out of range!
+#
+#query I
+#select cast(9.49 as decimal(1,0));
+#----
+#9
+#
+#statement error
+#select cast(9.5 as decimal(1,0));
+#----
+#Casting value "9.5" to type DECIMAL(1,0) failed: value is out of range!
+#
+#
+#statement error
+#select cast(-9.99 as decimal(1,0));
+#----
+#Casting value "-9.99" to type DECIMAL(1,0) failed: value is out of range!
+#
+#statement error
+#select cast(-9.5 as decimal(1,0));
+#----
+#Casting value "-9.5" to type DECIMAL(1,0) failed: value is out of range!
+#
+#query I
+#select cast(-9.01 as decimal(1,0));
+#----
+#-9
+#
+## Test lots of decimal cases
+#statement error
+#select cast(-9.999999999 as decimal(1,0));
+#----
+#Casting value "-9.999999999" to type DECIMAL(1,0) failed: value is out of range!
+
+# Test big values
 statement error
-select cast('9.99' as decimal(1,0));
+select cast(9.9999999999999999999999999999999 as decimal(1,0));
 ----
-Could not convert string "9.99" to DECIMAL(1,0)
-
-statement error
-select cast(9.99::float as decimal(1,0));
-----
-Could not cast value
-
-statement error
-select cast(9.99::double as decimal(1,0));
-----
-Could not cast value
-
-statement error
-select cast(9.99 as decimal(1,0));
-----
-Casting value "9.99" to type DECIMAL(1,0) failed: value is out of range!
-
-query I
-select cast(9.49 as decimal(1,0));
-----
-9
-
-statement error
-select cast(9.5 as decimal(1,0));
-----
-Casting value "9.5" to type DECIMAL(1,0) failed: value is out of range!
-
-
-statement error
-select cast(-9.99 as decimal(1,0));
-----
-Casting value "9.99" to type DECIMAL(1,0) failed: value is out of range!
-
-# Test biggest values
+Casting value "-9.999999999" to type DECIMAL(1,0) failed: value is out of range!

--- a/test/sql/types/decimal/decimal_exception.test
+++ b/test/sql/types/decimal/decimal_exception.test
@@ -5,60 +5,65 @@
 statement ok
 PRAGMA enable_verification
 
-#statement error
-#select cast('9.99' as decimal(1,0));
-#----
-#Could not convert string "9.99" to DECIMAL(1,0)
-#
-#statement error
-#select cast(9.99::float as decimal(1,0));
-#----
-#Could not cast value
-#
-#statement error
-#select cast(9.99::double as decimal(1,0));
-#----
-#Could not cast value
-#
-#statement error
-#select cast(9.99 as decimal(1,0));
-#----
-#Casting value "9.99" to type DECIMAL(1,0) failed: value is out of range!
-#
-#query I
-#select cast(9.49 as decimal(1,0));
-#----
-#9
-#
-#statement error
-#select cast(9.5 as decimal(1,0));
-#----
-#Casting value "9.5" to type DECIMAL(1,0) failed: value is out of range!
-#
-#
-#statement error
-#select cast(-9.99 as decimal(1,0));
-#----
-#Casting value "-9.99" to type DECIMAL(1,0) failed: value is out of range!
-#
-#statement error
-#select cast(-9.5 as decimal(1,0));
-#----
-#Casting value "-9.5" to type DECIMAL(1,0) failed: value is out of range!
-#
-#query I
-#select cast(-9.01 as decimal(1,0));
-#----
-#-9
-#
-## Test lots of decimal cases
-#statement error
-#select cast(-9.999999999 as decimal(1,0));
-#----
-#Casting value "-9.999999999" to type DECIMAL(1,0) failed: value is out of range!
+statement error
+select cast('9.99' as decimal(1,0));
+----
+Could not convert string "9.99" to DECIMAL(1,0)
 
-# Test big values
+statement error
+select cast(9.99::float as decimal(1,0));
+----
+Could not cast value
+
+statement error
+select cast(9.99::double as decimal(1,0));
+----
+Could not cast value
+
+statement error
+select cast(9.99 as decimal(1,0));
+----
+Casting value "9.99" to type DECIMAL(1,0) failed: value is out of range!
+
+query I
+select cast(9.49 as decimal(1,0));
+----
+9
+
+statement error
+select cast(9.5 as decimal(1,0));
+----
+Casting value "9.5" to type DECIMAL(1,0) failed: value is out of range!
+
+
+statement error
+select cast(-9.99 as decimal(1,0));
+----
+Casting value "-9.99" to type DECIMAL(1,0) failed: value is out of range!
+
+statement error
+select cast(-9.5 as decimal(1,0));
+----
+Casting value "-9.5" to type DECIMAL(1,0) failed: value is out of range!
+
+query I
+select cast(-9.01 as decimal(1,0));
+----
+-9
+
+# Test lots of decimal cases
+statement error
+select cast(-9.999999999 as decimal(1,0));
+----
+Casting value "-9.999999999" to type DECIMAL(1,0) failed: value is out of range!
+
+# Test hugeint values
 statement error
 select cast(9.9999999999999999999999999999999 as decimal(1,0));
 ----
-Casting value "-9.999999999" to type DECIMAL(1,0) failed: value is out of range!
+Casting value "9.9999999999999999999999999999999" to type DECIMAL(1,0) failed: value is out of range!
+
+statement error
+select cast(-9.9999999999999999999999999999999 as decimal(1,0));
+----
+Casting value "-9.9999999999999999999999999999999" to type DECIMAL(1,0) failed: value is out of range!

--- a/test/sql/types/decimal/decimal_exception.test
+++ b/test/sql/types/decimal/decimal_exception.test
@@ -5,23 +5,22 @@
 statement ok
 PRAGMA enable_verification
 
-statement error
-select cast('9.99' as decimal(1,0));
-----
-Could not convert string "9.99" to DECIMAL(1,0)
-
-statement error
-select cast(9.99::float as decimal(1,0));
-----
-Could not cast value
-
-statement error
-select cast(9.99::double as decimal(1,0));
-----
-Could not cast value
-
-#FIXME: This requires implementing ROUND for Decimals, and checking Decimal Scale Down
 #statement error
-#select cast(9.99 as decimal(1,0));
+#select cast('9.99' as decimal(1,0));
 #----
-#Casting value "9.99" to type DECIMAL(1,0) failed: value is out of range!
+#Could not convert string "9.99" to DECIMAL(1,0)
+#
+#statement error
+#select cast(9.99::float as decimal(1,0));
+#----
+#Could not cast value
+#
+#statement error
+#select cast(9.99::double as decimal(1,0));
+#----
+#Could not cast value
+
+statement error
+select cast(9.99 as decimal(1,0));
+----
+Casting value "9.99" to type DECIMAL(1,0) failed: value is out of range!


### PR DESCRIPTION
This PR implements downcast checking for decimal -> decimal and throws an error if the result does not fit.

It also implements a `Pow()` function to `hugeint_t`.