### PR TITLE
Only bind to SQL value functions if there is no alias with this name present we can bind to instead

### DIFF
--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -186,7 +186,7 @@ protected:
 	                          const optional_ptr<bind_lambda_function_t> bind_lambda_function,
 	                          const LogicalType &list_child_type);
 
-	static unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name);
+	virtual unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name);
 
 	LogicalType ResolveOperatorType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);
 	LogicalType ResolveCoalesceType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -22,6 +22,7 @@ protected:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 
 	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
+	unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name) override;
 
 protected:
 	idx_t unnest_level = 0;

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -8,6 +8,15 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
     : BaseSelectBinder(binder, context, node, info) {
 }
 
+unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(const string &column_name) {
+	auto alias_entry = node.bind_state.alias_map.find(column_name);
+	if (alias_entry != node.bind_state.alias_map.end()) {
+		// don't replace SQL value functions if they are in the alias map
+		return nullptr;
+	}
+	return ExpressionBinder::GetSQLValueFunction(column_name);
+}
+
 BindResult SelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {
 	// first try to bind the column reference regularly
 	auto result = BaseSelectBinder::BindColumnRef(expr_ptr, depth, root_expression);

--- a/test/sql/parser/test_value_functions.test
+++ b/test/sql/parser/test_value_functions.test
@@ -56,3 +56,16 @@ group by one
 having max(cast('1000-05-01 00:00:00' as timestamp))  <= current_timestamp;
 ----
 1	1000-05-01 00:00:00
+
+query II
+select a as "b", "b" + 1 from (VALUES (84), (42)) t(a) ORDER BY ALL;
+----
+42	43
+84	85
+
+# value function conflict in ORDER BY
+query I
+select a as "CURRENT_TIMESTAMP" from (VALUES (84), (42)) t(a) order by "CURRENT_TIMESTAMP" + 1;
+----
+42
+84


### PR DESCRIPTION
Fixes an issue where aliases like `CURRENT_TIMESTAMP` would behave differently from regular aliases in the select list or oder by clause