### PR TITLE
[CI] Invert operations on OSX.yml, deploying nightly artifacts before test

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -136,24 +136,6 @@ jobs:
         shell: bash
         run: ./build/release/duckdb -c "PRAGMA platform;"
 
-      - name: Unit Test
-        shell: bash
-        if: ${{ inputs.skip_tests != 'true' }}
-        run: make allunit
-
-      - name: Tools Tests
-        shell: bash
-        if: ${{ inputs.skip_tests != 'true' }}
-        run: |
-          python -m pytest tools/shell/tests --shell-binary build/release/duckdb
-
-      - name: Examples
-        shell: bash
-        if: ${{ inputs.skip_tests != 'true' }}
-        run: |
-          (cd examples/embedded-c; make)
-          (cd examples/embedded-c++; make)
-
         #     from https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development
       - name: Sign Binaries
         shell: bash
@@ -186,6 +168,24 @@ jobs:
           path: |
             libduckdb-osx-universal.zip
             duckdb_cli-osx-universal.zip
+
+      - name: Unit Test
+        shell: bash
+        if: ${{ inputs.skip_tests != 'true' }}
+        run: make allunit
+
+      - name: Tools Tests
+        shell: bash
+        if: ${{ inputs.skip_tests != 'true' }}
+        run: |
+          python -m pytest tools/shell/tests --shell-binary build/release/duckdb
+
+      - name: Examples
+        shell: bash
+        if: ${{ inputs.skip_tests != 'true' }}
+        run: |
+          (cd examples/embedded-c; make)
+          (cd examples/embedded-c++; make)
 
   xcode-extensions:
     # Builds extensions for osx_arm64 and osx_amd64


### PR DESCRIPTION
Currently there is some not yet identified error that makes so nightly run are broken for OSX, and that do not publish nightly artifacts to be tried.

This PR inverts this, given failure might be not relevant (say networking or other sources of noise).