### PR TITLE
[Python][Jupyter] Don't use `ExplainFormat::HTML` for `explain('analyze')`

### DIFF
--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -1481,8 +1481,8 @@ void DuckDBPyRelation::Print(const Optional<py::int_> &max_width, const Optional
 	py::print(py::str(ToStringInternal(config, invalidate_cache)));
 }
 
-static ExplainFormat GetExplainFormat() {
-	if (DuckDBPyConnection::IsJupyter()) {
+static ExplainFormat GetExplainFormat(ExplainType type) {
+	if (DuckDBPyConnection::IsJupyter() && type != ExplainType::EXPLAIN_ANALYZE) {
 		return ExplainFormat::HTML;
 	} else {
 		return ExplainFormat::DEFAULT;
@@ -1502,7 +1502,7 @@ string DuckDBPyRelation::Explain(ExplainType type) {
 	AssertRelation();
 	py::gil_scoped_release release;
 
-	auto explain_format = GetExplainFormat();
+	auto explain_format = GetExplainFormat(type);
 	auto res = rel->Explain(type, explain_format);
 	D_ASSERT(res->type == duckdb::QueryResultType::MATERIALIZED_RESULT);
 	auto &materialized = res->Cast<MaterializedQueryResult>();


### PR DESCRIPTION
This PR fixes #13926

For Jupyter we use the HTMLTreeRenderer (equivalent to `EXPLAIN(FORMAT HTML)` when `rel.explain()` is used.

The HTML format is not implemented for `EXPLAIN ANALYZE` which causes an error to be thrown.
Now we no longer use the HTML format when `analyze` is provided to `rel.explain()`