### PR TITLE
Improve logic for remote extension install on Windows

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -268,15 +268,20 @@ static unique_ptr<ExtensionInstallInfo> DirectInstallExtension(DatabaseInstance 
                                                                const string &local_extension_path,
                                                                ExtensionInstallOptions &options,
                                                                optional_ptr<ClientContext> context) {
-	string file = fs.ConvertSeparators(path);
-
-	// Try autoloading httpfs for loading extensions over https
-	if (context) {
-		auto &db = DatabaseInstance::GetDatabase(*context);
-		if (StringUtil::StartsWith(path, "https://") && !db.ExtensionIsLoaded("httpfs") &&
-		    db.config.options.autoload_known_extensions) {
-			ExtensionHelper::AutoLoadExtension(*context, "httpfs");
+	string extension;
+	string file;
+	if (fs.IsRemoteFile(path, extension)) {
+		file = path;
+		// Try autoloading httpfs for loading extensions over https
+		if (context) {
+			auto &db = DatabaseInstance::GetDatabase(*context);
+			if (extension == "httpfs" && !db.ExtensionIsLoaded("httpfs") &&
+			    db.config.options.autoload_known_extensions) {
+				ExtensionHelper::AutoLoadExtension(*context, "httpfs");
+			}
 		}
+	} else {
+		file = fs.ConvertSeparators(path);
 	}
 
 	// Check if file exists


### PR DESCRIPTION
Converting the path before checking for remote file will lead to strange results otherwise