### PR TITLE
CI: Trigger actions for labeled discussions

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -1,5 +1,8 @@
 name: Create or Label Mirror Issue
 on:
+  discussion:
+    types:
+      - labeled
   issues:
     types:
       - labeled

--- a/.github/workflows/InternalIssuesUpdateMirror.yml
+++ b/.github/workflows/InternalIssuesUpdateMirror.yml
@@ -1,5 +1,8 @@
 name: Update Mirror Issue
 on:
+  discussion:
+    types:
+      - labeled
   issues:
     types:
       - closed

--- a/.github/workflows/NeedsDocumentation.yml
+++ b/.github/workflows/NeedsDocumentation.yml
@@ -1,5 +1,8 @@
 name: Create Documentation issue for the Needs Documentation label
 on:
+  discussion:
+    types:
+      - labeled
   issues:
     types:
       - labeled


### PR DESCRIPTION
Some discussions such as https://github.com/duckdb/duckdb/discussions/6727 warrant documentation. I would like to label these with `Needs Documentation` to document it. Also, some discussion should warrant further discussion, so `under review` (and occasionally, `reproduced`) could also be helpful to mirror these issues to the internal issue tracker.