### PR TITLE
Add HTML and Graphviz support for explain analyze

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -5959,6 +5959,10 @@ const char* EnumUtil::ToChars<ProfilerPrintFormat>(ProfilerPrintFormat value) {
 		return "QUERY_TREE_OPTIMIZER";
 	case ProfilerPrintFormat::NO_OUTPUT:
 		return "NO_OUTPUT";
+	case ProfilerPrintFormat::HTML:
+		return "HTML";
+	case ProfilerPrintFormat::GRAPHVIZ:
+		return "GRAPHVIZ";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<ProfilerPrintFormat>", value));
 	}
@@ -5977,6 +5981,12 @@ ProfilerPrintFormat EnumUtil::FromString<ProfilerPrintFormat>(const char *value)
 	}
 	if (StringUtil::Equals(value, "NO_OUTPUT")) {
 		return ProfilerPrintFormat::NO_OUTPUT;
+	}
+	if (StringUtil::Equals(value, "HTML")) {
+		return ProfilerPrintFormat::HTML;
+	}
+	if (StringUtil::Equals(value, "GRAPHVIZ")) {
+		return ProfilerPrintFormat::GRAPHVIZ;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<ProfilerPrintFormat>", value));
 }

--- a/src/include/duckdb/common/enums/profiler_format.hpp
+++ b/src/include/duckdb/common/enums/profiler_format.hpp
@@ -12,6 +12,6 @@
 
 namespace duckdb {
 
-enum class ProfilerPrintFormat : uint8_t { QUERY_TREE, JSON, QUERY_TREE_OPTIMIZER, NO_OUTPUT };
+enum class ProfilerPrintFormat : uint8_t { QUERY_TREE, JSON, QUERY_TREE_OPTIMIZER, NO_OUTPUT, HTML, GRAPHVIZ };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer.hpp
@@ -30,6 +30,8 @@ public:
 	virtual bool UsesRawKeyNames() {
 		return false;
 	}
+	virtual void Render(const ProfilingNode &op, std::ostream &ss) {
+	}
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/tree_renderer/graphviz_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/graphviz_tree_renderer.hpp
@@ -35,7 +35,7 @@ public:
 
 	void Render(const LogicalOperator &op, std::ostream &ss);
 	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss);
+	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
 	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;

--- a/src/include/duckdb/common/tree_renderer/html_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/html_tree_renderer.hpp
@@ -35,7 +35,7 @@ public:
 
 	void Render(const LogicalOperator &op, std::ostream &ss);
 	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss);
+	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
 	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;

--- a/src/include/duckdb/common/tree_renderer/json_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/json_tree_renderer.hpp
@@ -35,7 +35,7 @@ public:
 
 	void Render(const LogicalOperator &op, std::ostream &ss);
 	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss);
+	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
 	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;

--- a/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
@@ -84,7 +84,7 @@ public:
 
 	void Render(const LogicalOperator &op, std::ostream &ss);
 	void Render(const PhysicalOperator &op, std::ostream &ss);
-	void Render(const ProfilingNode &op, std::ostream &ss);
+	void Render(const ProfilingNode &op, std::ostream &ss) override;
 	void Render(const Pipeline &op, std::ostream &ss);
 
 	void ToStreamInternal(RenderTree &root, std::ostream &ss) override;

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -115,6 +115,7 @@ public:
 private:
 	unique_ptr<ProfilingNode> CreateTree(const PhysicalOperator &root, profiler_settings_t settings, idx_t depth = 0);
 	void Render(const ProfilingNode &node, std::ostream &str) const;
+	string RenderDisabledMessage(ProfilerPrintFormat format) const;
 
 public:
 	DUCKDB_API bool IsEnabled() const;
@@ -147,6 +148,7 @@ public:
 	//! return the printed as a string. Unlike ToString, which is always formatted as a string,
 	//! the return value is formatted based on the current print format (see GetPrintFormat()).
 	DUCKDB_API string ToString(ExplainFormat format = ExplainFormat::DEFAULT) const;
+	DUCKDB_API string ToString(ProfilerPrintFormat format) const;
 
 	static InsertionOrderPreservingMap<string> JSONSanitize(const InsertionOrderPreservingMap<string> &input);
 	static string JSONSanitize(const string &text);
@@ -209,6 +211,7 @@ private:
 	//! Check whether or not an operator type requires query profiling. If none of the ops in a query require profiling
 	//! no profiling information is output.
 	bool OperatorRequiresProfiling(PhysicalOperatorType op_type);
+	ExplainFormat GetExplainFormat(ProfilerPrintFormat format) const;
 };
 
 } // namespace duckdb

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -50,11 +50,7 @@ Connection::~Connection() {
 
 string Connection::GetProfilingInformation(ProfilerPrintFormat format) {
 	auto &profiler = QueryProfiler::Get(*context);
-	if (format == ProfilerPrintFormat::JSON) {
-		return profiler.ToJSON();
-	} else {
-		return profiler.QueryTreeToString();
-	}
+	return profiler.ToString(format);
 }
 
 optional_ptr<ProfilingNode> Connection::GetProfilingTree() {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -8,13 +8,12 @@
 #include "duckdb/common/tree_renderer/text_tree_renderer.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/execution/operator/helper/physical_execute.hpp"
+#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
-
 #include "yyjson.hpp"
 
 #include <algorithm>
@@ -46,8 +45,31 @@ ProfilerPrintFormat QueryProfiler::GetPrintFormat(ExplainFormat format) const {
 		return ProfilerPrintFormat::QUERY_TREE;
 	case ExplainFormat::JSON:
 		return ProfilerPrintFormat::JSON;
+	case ExplainFormat::HTML:
+		return ProfilerPrintFormat::HTML;
+	case ExplainFormat::GRAPHVIZ:
+		return ProfilerPrintFormat::GRAPHVIZ;
 	default:
 		throw NotImplementedException("No mapping from ExplainFormat::%s to ProfilerPrintFormat",
+		                              EnumUtil::ToString(format));
+	}
+}
+
+ExplainFormat QueryProfiler::GetExplainFormat(ProfilerPrintFormat format) const {
+	switch (format) {
+	case ProfilerPrintFormat::QUERY_TREE:
+	case ProfilerPrintFormat::QUERY_TREE_OPTIMIZER:
+		return ExplainFormat::TEXT;
+	case ProfilerPrintFormat::JSON:
+		return ExplainFormat::JSON;
+	case ProfilerPrintFormat::HTML:
+		return ExplainFormat::HTML;
+	case ProfilerPrintFormat::GRAPHVIZ:
+		return ExplainFormat::GRAPHVIZ;
+	case ProfilerPrintFormat::NO_OUTPUT:
+		throw InternalException("Should not attempt to get ExplainFormat for ProfilerPrintFormat::NO_OUTPUT");
+	default:
+		throw NotImplementedException("No mapping from ProfilePrintFormat::%s to ExplainFormat",
 		                              EnumUtil::ToString(format));
 	}
 }
@@ -238,7 +260,13 @@ void QueryProfiler::EndQuery() {
 }
 
 string QueryProfiler::ToString(ExplainFormat explain_format) const {
-	const auto format = GetPrintFormat(explain_format);
+	return ToString(GetPrintFormat(explain_format));
+}
+
+string QueryProfiler::ToString(ProfilerPrintFormat format) const {
+	if (!IsEnabled()) {
+		return RenderDisabledMessage(format);
+	}
 	switch (format) {
 	case ProfilerPrintFormat::QUERY_TREE:
 	case ProfilerPrintFormat::QUERY_TREE_OPTIMIZER:
@@ -247,6 +275,22 @@ string QueryProfiler::ToString(ExplainFormat explain_format) const {
 		return ToJSON();
 	case ProfilerPrintFormat::NO_OUTPUT:
 		return "";
+	case ProfilerPrintFormat::HTML:
+	case ProfilerPrintFormat::GRAPHVIZ: {
+		// checking the tree to ensure the query is really empty
+		// the query string is empty when a logical plan is deserialized
+		if (query_info.query_name.empty() && !root) {
+			return "";
+		}
+		auto renderer = TreeRenderer::CreateRenderer(GetExplainFormat(format));
+		std::stringstream str;
+		auto &info = root->GetProfilingInfo();
+		if (info.Enabled(MetricsType::OPERATOR_TIMING)) {
+			info.metrics[MetricsType::OPERATOR_TIMING] = main_query.Elapsed();
+		}
+		renderer->Render(*root, str);
+		return str.str();
+	}
 	default:
 		throw InternalException("Unknown ProfilerPrintFormat \"%s\"", EnumUtil::ToString(format));
 	}
@@ -530,10 +574,6 @@ void PrintPhaseTimingsToStream(std::ostream &ss, const ProfilingInfo &info, idx_
 }
 
 void QueryProfiler::QueryTreeToStream(std::ostream &ss) const {
-	if (!IsEnabled()) {
-		ss << "Query profiling is disabled. Use 'PRAGMA enable_profiling;' to enable profiling!";
-		return;
-	}
 	ss << "┌─────────────────────────────────────┐\n";
 	ss << "│┌───────────────────────────────────┐│\n";
 	ss << "││    Query Profiling Information    ││\n";
@@ -649,10 +689,6 @@ string QueryProfiler::ToJSON() const {
 	auto result_obj = yyjson_mut_obj(doc);
 	yyjson_mut_doc_set_root(doc, result_obj);
 
-	if (!IsEnabled()) {
-		yyjson_mut_obj_add_str(doc, result_obj, "result", "disabled");
-		return StringifyAndFree(doc, result_obj);
-	}
 	if (query_info.query_name.empty() && !root) {
 		yyjson_mut_obj_add_str(doc, result_obj, "result", "empty");
 		return StringifyAndFree(doc, result_obj);
@@ -733,6 +769,40 @@ unique_ptr<ProfilingNode> QueryProfiler::CreateTree(const PhysicalOperator &root
 		node->AddChild(std::move(child_node));
 	}
 	return node;
+}
+
+string QueryProfiler::RenderDisabledMessage(ProfilerPrintFormat format) const {
+	switch (format) {
+	case ProfilerPrintFormat::NO_OUTPUT:
+		return "";
+	case ProfilerPrintFormat::QUERY_TREE:
+	case ProfilerPrintFormat::QUERY_TREE_OPTIMIZER:
+		return "Query profiling is disabled. Use 'PRAGMA enable_profiling;' to enable profiling!";
+	case ProfilerPrintFormat::HTML:
+		return R"(
+				<!DOCTYPE html>
+                <html lang="en"><head/><body>
+                  Query profiling is disabled. Use 'PRAGMA enable_profiling;' to enable profiling!
+                </body></html>
+			)";
+	case ProfilerPrintFormat::GRAPHVIZ:
+		return R"(
+				digraph G {
+				    node [shape=box, style=rounded, fontname="Courier New", fontsize=10];
+				    node_0_0 [label="Query profiling is disabled. Use 'PRAGMA enable_profiling;' to enable profiling!"];
+				}
+			)";
+	case ProfilerPrintFormat::JSON: {
+		auto doc = yyjson_mut_doc_new(nullptr);
+		auto result_obj = yyjson_mut_obj(doc);
+		yyjson_mut_doc_set_root(doc, result_obj);
+
+		yyjson_mut_obj_add_str(doc, result_obj, "result", "disabled");
+		return StringifyAndFree(doc, result_obj);
+	}
+	default:
+		throw InternalException("Unknown ProfilerPrintFormat \"%s\"", EnumUtil::ToString(format));
+	}
 }
 
 void QueryProfiler::Initialize(const PhysicalOperator &root_op) {

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -703,6 +703,10 @@ void EnableProfilingSetting::SetLocal(ClientContext &context, const Value &input
 	} else if (parameter == "no_output") {
 		config.profiler_print_format = ProfilerPrintFormat::NO_OUTPUT;
 		config.emit_profiler_output = false;
+	} else if (parameter == "html") {
+		config.profiler_print_format = ProfilerPrintFormat::HTML;
+	} else if (parameter == "graphviz") {
+		config.profiler_print_format = ProfilerPrintFormat::GRAPHVIZ;
 	} else {
 		throw ParserException(
 		    "Unrecognized print format %s, supported formats: [json, query_tree, query_tree_optimizer, no_output]",
@@ -724,6 +728,10 @@ Value EnableProfilingSetting::GetSetting(const ClientContext &context) {
 		return Value("query_tree_optimizer");
 	case ProfilerPrintFormat::NO_OUTPUT:
 		return Value("no_output");
+	case ProfilerPrintFormat::HTML:
+		return Value("html");
+	case ProfilerPrintFormat::GRAPHVIZ:
+		return Value("graphviz");
 	default:
 		throw InternalException("Unsupported profiler print format");
 	}

--- a/test/sql/explain/test_explain_analyze.test
+++ b/test/sql/explain/test_explain_analyze.test
@@ -80,3 +80,13 @@ statement error
 SELECT * FROM read_csv('__TEST_DIR__/test.json', columns={'json': 'VARCHAR'}, sep='🦆');
 ----
 The delimiter option cannot exceed a size of 1 byte.
+
+query II
+EXPLAIN (ANALYZE, FORMAT graphviz) SELECT SUM(i) FROM integers
+----
+analyzed_plan	<REGEX>:.+EXPLAIN_ANALYZE.*
+
+query II
+EXPLAIN (ANALYZE, FORMAT html) SELECT SUM(i) FROM integers
+----
+analyzed_plan	<REGEX>:.+<div class="title">EXPLAIN_ANALYZE</div>.*


### PR DESCRIPTION
HTML and Graphviz were only supported for explain output, not explain analyze. This PR adds support for explain analyze as well. In addition, the total query elapsed time is written into the root (Query) node so that it is available in the rendered html or graphviz output.