### PR TITLE
Fix #13933: disable join filter pushdown when a join is performed over collated columns

### DIFF
--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -342,7 +342,7 @@ void LocalUngroupedAggregateState::Sink(DataChunk &payload_chunk, idx_t payload_
 #endif
 	auto &aggregate = state.aggregate_expressions[aggr_idx]->Cast<BoundAggregateExpression>();
 	idx_t payload_cnt = aggregate.children.size();
-	D_ASSERT(payload_cnt == 0 || payload_idx + payload_cnt < payload_chunk.data.size());
+	D_ASSERT(payload_idx + payload_cnt <= payload_chunk.data.size());
 	auto start_of_input = payload_cnt == 0 ? nullptr : &payload_chunk.data[payload_idx];
 	AggregateInputData aggr_input_data(state.bind_data[aggr_idx], allocator);
 	aggregate.function.simple_update(start_of_input, aggr_input_data, payload_cnt, state.aggregate_data[aggr_idx].get(),

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -342,6 +342,7 @@ void LocalUngroupedAggregateState::Sink(DataChunk &payload_chunk, idx_t payload_
 #endif
 	auto &aggregate = state.aggregate_expressions[aggr_idx]->Cast<BoundAggregateExpression>();
 	idx_t payload_cnt = aggregate.children.size();
+	D_ASSERT(payload_idx + payload_cnt < payload_chunk.data.size());
 	auto start_of_input = payload_cnt == 0 ? nullptr : &payload_chunk.data[payload_idx];
 	AggregateInputData aggr_input_data(state.bind_data[aggr_idx], allocator);
 	aggregate.function.simple_update(start_of_input, aggr_input_data, payload_cnt, state.aggregate_data[aggr_idx].get(),

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -342,7 +342,7 @@ void LocalUngroupedAggregateState::Sink(DataChunk &payload_chunk, idx_t payload_
 #endif
 	auto &aggregate = state.aggregate_expressions[aggr_idx]->Cast<BoundAggregateExpression>();
 	idx_t payload_cnt = aggregate.children.size();
-	D_ASSERT(payload_idx + payload_cnt < payload_chunk.data.size());
+	D_ASSERT(payload_cnt == 0 || payload_idx + payload_cnt < payload_chunk.data.size());
 	auto start_of_input = payload_cnt == 0 ? nullptr : &payload_chunk.data[payload_idx];
 	AggregateInputData aggr_input_data(state.bind_data[aggr_idx], allocator);
 	aggregate.function.simple_update(start_of_input, aggr_input_data, payload_cnt, state.aggregate_data[aggr_idx].get(),

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -118,11 +118,6 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 		}
 	}
 	// pushdown can be performed
-	// set up the dynamic filters (if we don't have any yet)
-	if (!get.dynamic_filters) {
-		get.dynamic_filters = make_shared_ptr<DynamicTableFilterSet>();
-	}
-	pushdown_info->dynamic_filters = get.dynamic_filters;
 
 	// set up the min/max aggregates for each of the filters
 	vector<AggregateFunction> aggr_functions;
@@ -135,9 +130,18 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 			aggr_children.push_back(join.conditions[filter.join_condition].right->Copy());
 			auto aggr_expr = function_binder.BindAggregateFunction(aggr, std::move(aggr_children), nullptr,
 			                                                       AggregateType::NON_DISTINCT);
+			if (aggr_expr->children.size() != 1) {
+				// min/max with collation - not supported
+				return;
+			}
 			pushdown_info->min_max_aggregates.push_back(std::move(aggr_expr));
 		}
 	}
+	// set up the dynamic filters (if we don't have any yet)
+	if (!get.dynamic_filters) {
+		get.dynamic_filters = make_shared_ptr<DynamicTableFilterSet>();
+	}
+	pushdown_info->dynamic_filters = get.dynamic_filters;
 
 	// set up the filter pushdown in the join itself
 	join.filter_pushdown = std::move(pushdown_info);

--- a/test/sql/collate/collate_filter_pushdown.test
+++ b/test/sql/collate/collate_filter_pushdown.test
@@ -1,0 +1,23 @@
+# name: test/sql/collate/collate_filter_pushdown.test
+# description: Test collation interacting with filter pushdown
+# group: [collate]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t0(c0 BOOLEAN, PRIMARY KEY(c0));
+
+statement ok
+CREATE TABLE t63(c0 VARCHAR COLLATE C, PRIMARY KEY(c0));
+
+statement ok
+insert into t0(c0) values (0.7);
+
+statement ok
+insert into t63(c0) values ('1');
+
+query I
+SELECT t63.c0 FROM t0 NATURAL LEFT JOIN t63;
+----
+NULL


### PR DESCRIPTION
Fixes #13933

The issue is that when binding `min/max` with a collation, the aggregate would be transformed into `arg_min/arg_max` instead. This expects two input columns rather than a single input column - which then caused problems as the join filter pushdown only passed in a single column. This PR disables join filter pushdown in this scenario (when joining on collated columns).