### PR TITLE
[Dev] Add exclusion for `pybind11` internal `_pybind11_conduit_v1_` method

### DIFF
--- a/tools/pythonpkg/tests/fast/api/test_duckdb_connection.py
+++ b/tools/pythonpkg/tests/fast/api/test_duckdb_connection.py
@@ -8,6 +8,8 @@ pa = pytest.importorskip("pyarrow")
 def is_dunder_method(method_name: str) -> bool:
     if len(method_name) < 4:
         return False
+    if method_name.startswith('_pybind11'):
+        return True
     return method_name[:2] == '__' and method_name[:-3:-1] == '__'
 
 


### PR DESCRIPTION
Recently pybind11 added a new internal method and did not prefix it with `__` so we have to add an explicit exclusion for it.