### PR TITLE
Fix data race when writing GeoParquet

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -1210,47 +1210,6 @@ public:
 };
 
 //===--------------------------------------------------------------------===//
-// Geometry Column Writer
-//===--------------------------------------------------------------------===//
-// This class just wraps another column writer, but also calculates the extent
-// of the geometry column by updating the geodata object with every written
-// vector.
-template <class WRITER_IMPL>
-class GeometryColumnWriter : public WRITER_IMPL {
-	GeoParquetColumnMetadata geo_data;
-	GeoParquetColumnMetadataWriter geo_data_writer;
-	string column_name;
-
-public:
-	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override {
-		// Just write normally
-		WRITER_IMPL::Write(state, vector, count);
-
-		// And update the geodata object
-		geo_data_writer.Update(geo_data, vector, count);
-	}
-	void FinalizeWrite(ColumnWriterState &state) override {
-		WRITER_IMPL::FinalizeWrite(state);
-
-		// Add the geodata object to the writer
-		this->writer.GetGeoParquetData().geometry_columns[column_name] = geo_data;
-	}
-
-public:
-	GeometryColumnWriter(ClientContext &context, ParquetWriter &writer, idx_t schema_idx, vector<string> schema_path_p,
-	                     idx_t max_repeat, idx_t max_define, bool can_have_nulls, string name)
-	    : WRITER_IMPL(writer, schema_idx, std::move(schema_path_p), max_repeat, max_define, can_have_nulls),
-	      geo_data_writer(context), column_name(std::move(name)) {
-
-		auto &geo_data = writer.GetGeoParquetData();
-		if (geo_data.primary_geometry_column.empty()) {
-			// Set the first column to the primary column
-			geo_data.primary_geometry_column = column_name;
-		}
-	}
-};
-
-//===--------------------------------------------------------------------===//
 // String Column Writer
 //===--------------------------------------------------------------------===//
 class StringStatisticsState : public ColumnWriterStatistics {
@@ -1561,6 +1520,58 @@ private:
 		return double(state.estimated_plain_size) /
 		       double(state.estimated_rle_pages_size + state.estimated_dict_page_size);
 	}
+};
+
+//===--------------------------------------------------------------------===//
+// WKB Column Writer
+//===--------------------------------------------------------------------===//
+// Used to store the metadata for a WKB-encoded geometry column when writing
+// GeoParquet files.
+class WKBColumnWriterState final : public StringColumnWriterState {
+public:
+	WKBColumnWriterState(ClientContext &context, duckdb_parquet::format::RowGroup &row_group, idx_t col_idx)
+	    : StringColumnWriterState(row_group, col_idx), geo_data(), geo_data_writer(context) {
+	}
+
+	GeoParquetColumnMetadata geo_data;
+	GeoParquetColumnMetadataWriter geo_data_writer;
+};
+
+class WKBColumnWriter final : public StringColumnWriter {
+public:
+	WKBColumnWriter(ClientContext &context_p, ParquetWriter &writer, idx_t schema_idx, vector<string> schema_path_p,
+	                idx_t max_repeat, idx_t max_define, bool can_have_nulls, string name)
+	    : StringColumnWriter(writer, schema_idx, std::move(schema_path_p), max_repeat, max_define, can_have_nulls),
+	      column_name(std::move(name)), context(context_p) {
+
+		this->writer.GetGeoParquetData().RegisterGeometryColumn(column_name);
+	}
+
+	unique_ptr<ColumnWriterState> InitializeWriteState(duckdb_parquet::format::RowGroup &row_group) override {
+		auto result = make_uniq<WKBColumnWriterState>(context, row_group, row_group.columns.size());
+		RegisterToRowGroup(row_group);
+		return std::move(result);
+	}
+	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override {
+		StringColumnWriter::Write(state, vector, count);
+
+		auto &geo_state = state.Cast<WKBColumnWriterState>();
+		geo_state.geo_data_writer.Update(geo_state.geo_data, vector, count);
+	}
+
+	void FinalizeWrite(ColumnWriterState &state) override {
+		StringColumnWriter::FinalizeWrite(state);
+
+		// Add the geodata object to the writer
+		const auto &geo_state = state.Cast<WKBColumnWriterState>();
+
+		// Merge this state's geo column data with the writer's geo column data
+		writer.GetGeoParquetData().FlushColumnMeta(column_name, geo_state.geo_data);
+	}
+
+private:
+	string column_name;
+	ClientContext &context;
 };
 
 //===--------------------------------------------------------------------===//
@@ -2234,8 +2245,8 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 	schema_path.push_back(name);
 
 	if (type.id() == LogicalTypeId::BLOB && type.GetAlias() == "WKB_BLOB") {
-		return make_uniq<GeometryColumnWriter<StringColumnWriter>>(context, writer, schema_idx, std::move(schema_path),
-		                                                           max_repeat, max_define, can_have_nulls, name);
+		return make_uniq<WKBColumnWriter>(context, writer, schema_idx, std::move(schema_path), max_repeat, max_define,
+		                                  can_have_nulls, name);
 	}
 
 	switch (type.id()) {

--- a/extension/parquet/include/geo_parquet.hpp
+++ b/extension/parquet/include/geo_parquet.hpp
@@ -115,7 +115,7 @@ public:
 	void Update(GeoParquetColumnMetadata &meta, Vector &vector, idx_t count);
 };
 
-struct GeoParquetFileMetadata {
+class GeoParquetFileMetadata {
 public:
 	// Try to read GeoParquet metadata. Returns nullptr if not found, invalid or the required spatial extension is not
 	// available.
@@ -123,17 +123,21 @@ public:
 	                                                  ClientContext &context);
 	void Write(duckdb_parquet::format::FileMetaData &file_meta_data) const;
 
-public:
-	// Default to 1.1.0 for now
-	string version = "1.1.0";
-	string primary_geometry_column;
-	unordered_map<string, GeoParquetColumnMetadata> geometry_columns;
+	void FlushColumnMeta(const string &column_name, const GeoParquetColumnMetadata &meta);
+	const unordered_map<string, GeoParquetColumnMetadata> &GetColumnMeta() const;
 
 	unique_ptr<ColumnReader> CreateColumnReader(ParquetReader &reader, const LogicalType &logical_type,
 	                                            const duckdb_parquet::format::SchemaElement &s_ele, idx_t schema_idx_p,
 	                                            idx_t max_define_p, idx_t max_repeat_p, ClientContext &context);
 
 	bool IsGeometryColumn(const string &column_name) const;
+	void RegisterGeometryColumn(const string &column_name);
+
+private:
+	mutex write_lock;
+	string version = "1.1.0";
+	string primary_geometry_column;
+	unordered_map<string, GeoParquetColumnMetadata> geometry_columns;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
When writing GeoParquet, we stored the column-level auxiliary geoparquet statistics/metadata directly in the `GeometryColumnWriter`, which is not thread safe, causing issues when multiple row-groups are written concurrently. 

This PR moves the column-level geoparquet metadata from the `ColumnWriter` into the associated `ColumnWriterState`, and also introduces a write-lock on the file-level geoparquet metadata struct so that the threads don't race each other when flushing the stats after finishing a row group.

Additionally I've changed the `GeometryColumnWriter` into a `WKBColumnWriter` that directly subclasses the `StringColumnWriter` instead of trying to template the base class as that is significantly messier to do when we also need to wrap the associated state.  This makes the code a bit cleaner, and makes sense given that the WKB geometry encoding is the only one we support right now anyway. I've also realized that the implementation for the other encodings is going to end up different enough that there is probably no point in trying to generalize all the geoparquet specific encoding logic into a common base class anyway. 

Closes: #13914