### PR TITLE
Check vector type in GetVectorScanType to avoid concurrent race when updating validity

### DIFF
--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -88,7 +88,7 @@ public:
 	//! Whether or not the column has any updates
 	bool HasUpdates() const;
 	//! Whether or not we can scan an entire vector
-	virtual ScanVectorType GetVectorScanType(ColumnScanState &state, idx_t scan_count);
+	virtual ScanVectorType GetVectorScanType(ColumnScanState &state, idx_t scan_count, Vector &result);
 
 	//! Initialize prefetch state with required I/O data for the next N rows
 	virtual void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows);

--- a/src/include/duckdb/storage/table/standard_column_data.hpp
+++ b/src/include/duckdb/storage/table/standard_column_data.hpp
@@ -25,7 +25,7 @@ public:
 public:
 	void SetStart(idx_t new_start) override;
 
-	ScanVectorType GetVectorScanType(ColumnScanState &state, idx_t scan_count) override;
+	ScanVectorType GetVectorScanType(ColumnScanState &state, idx_t scan_count, Vector &result) override;
 	void InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) override;
 	void InitializeScan(ColumnScanState &state) override;
 	void InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) override;

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -92,7 +92,10 @@ void ColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx)
 	state.last_offset = 0;
 }
 
-ScanVectorType ColumnData::GetVectorScanType(ColumnScanState &state, idx_t scan_count) {
+ScanVectorType ColumnData::GetVectorScanType(ColumnScanState &state, idx_t scan_count, Vector &result) {
+	if (result.GetVectorType() != VectorType::FLAT_VECTOR) {
+		return ScanVectorType::SCAN_ENTIRE_VECTOR;
+	}
 	if (HasUpdates()) {
 		// if we have updates we need to merge in the updates
 		// always need to scan flat vectors
@@ -230,7 +233,7 @@ void ColumnData::UpdateInternal(TransactionData transaction, idx_t column_index,
 template <bool SCAN_COMMITTED, bool ALLOW_UPDATES>
 idx_t ColumnData::ScanVector(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
                              idx_t target_scan) {
-	auto scan_type = GetVectorScanType(state, target_scan);
+	auto scan_type = GetVectorScanType(state, target_scan, result);
 	auto scan_count = ScanVector(state, result, target_scan, scan_type);
 	if (scan_type != ScanVectorType::SCAN_ENTIRE_VECTOR) {
 		// if we are scanning an entire vector we cannot have updates

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -21,16 +21,16 @@ void StandardColumnData::SetStart(idx_t new_start) {
 	validity.SetStart(new_start);
 }
 
-ScanVectorType StandardColumnData::GetVectorScanType(ColumnScanState &state, idx_t scan_count) {
+ScanVectorType StandardColumnData::GetVectorScanType(ColumnScanState &state, idx_t scan_count, Vector &result) {
 	// if either the current column data, or the validity column data requires flat vectors, we scan flat vectors
-	auto scan_type = ColumnData::GetVectorScanType(state, scan_count);
+	auto scan_type = ColumnData::GetVectorScanType(state, scan_count, result);
 	if (scan_type == ScanVectorType::SCAN_FLAT_VECTOR) {
 		return ScanVectorType::SCAN_FLAT_VECTOR;
 	}
 	if (state.child_states.empty()) {
 		return scan_type;
 	}
-	return validity.GetVectorScanType(state.child_states[0], scan_count);
+	return validity.GetVectorScanType(state.child_states[0], scan_count, result);
 }
 
 void StandardColumnData::InitializePrefetch(PrefetchState &prefetch_state, ColumnScanState &scan_state, idx_t rows) {


### PR DESCRIPTION
When scanning a column, `GetVectorScanType` needs to be consistent between the validity column data and the top-level column data, otherwise an `InternalException` is thrown. As the return value of `GetVectorScanType` changes based on whether or not updates are found, this could cause an issue if an update was performed in between the scan of the top-level column data and the validity column data. This PR resolves that by checking if the result vector type was already set to a non-flat vector.