### PR TITLE
Modify create_art_varchar.benchmark so it passes weekly regressions

### DIFF
--- a/benchmark/micro/index/create/create_art_varchar.benchmark
+++ b/benchmark/micro/index/create/create_art_varchar.benchmark
@@ -8,10 +8,9 @@ group art
 load
 CREATE TABLE art AS
     SELECT rpad(((i * 95823983533) % 86000000)::VARCHAR, 10, '-') AS id
-        FROM range(7200000) tbl(i);
+        FROM range(3600000) tbl(i);
 INSERT INTO art (SELECT * FROM art);
 INSERT INTO art (SELECT * FROM art);
-SET memory_limit='8GB';
 
 run
 CREATE INDEX idx ON art USING ART(id);


### PR DESCRIPTION
Currently the benchmark causes the weekly regressions to fail due to a timeout. 

With these changes the benchmark passes.

(This issue)[https://github.com/duckdblabs/duckdb-internal/issues/2855] explains that the benchmark now takes ~2x as long, so I changed range(7200000) to range(3600000)