### PR TITLE
fix: remove http prefix from proxy value when present

### DIFF
--- a/src/common/http_util.cpp
+++ b/src/common/http_util.cpp
@@ -6,7 +6,11 @@
 namespace duckdb {
 
 void HTTPUtil::ParseHTTPProxyHost(string &proxy_value, string &hostname_out, idx_t &port_out, idx_t default_port) {
-	auto proxy_split = StringUtil::Split(proxy_value, ":");
+	auto sanitized_proxy_value = proxy_value;
+	if (StringUtil::StartsWith(proxy_value, "http://")) {
+		sanitized_proxy_value = proxy_value.substr(7);
+	}
+	auto proxy_split = StringUtil::Split(sanitized_proxy_value, ":");
 	if (proxy_split.size() == 1) {
 		hostname_out = proxy_split[0];
 		port_out = default_port;

--- a/test/sql/copy/s3/http_proxy.test
+++ b/test/sql/copy/s3/http_proxy.test
@@ -64,6 +64,15 @@ FROM 's3://test-bucket/proxy-test/test.parquet'
 ----
 value-1
 
+# And try the working one with an 'http://' prefix.
+statement ok
+set http_proxy='http://${HTTP_PROXY_PUBLIC}'
+
+query I
+FROM 's3://test-bucket/proxy-test/test.parquet'
+----
+value-1
+
 # Now we revert to the failing one
 statement ok
 set http_proxy='blabla:1337'


### PR DESCRIPTION
DuckDB currently throws the following [error](https://github.com/duckdb/duckdb/blob/main/src/common/http_util.cpp#L21) for http_proxy values formatted as `http://<proxy_fqdn>:<proxy_port>`:

`InvalidInputException("Failed to parse http_proxy '%s' into a host and port", proxy_value)`

This PR creates a copy of the `proxy_value` argument within `HTTPUtil::ParseHTTPProxyHost` and removes the `http://` prefix if it is present before parsing the hostname and port. It also includes a unit test to cover this new condition.