### PR TITLE
Fix crash in the shell caused by printing blobs that failed to cast

### DIFF
--- a/tools/shell/shell.c
+++ b/tools/shell/shell.c
@@ -11694,8 +11694,12 @@ static int shell_callback(
           }
         }else if( aiType && aiType[i]==SQLITE_BLOB && p->pStmt ){
           const void *pBlob = sqlite3_column_blob(p->pStmt, i);
-          int nBlob = sqlite3_column_bytes(p->pStmt, i);
-          output_hex_blob(p->out, pBlob, nBlob);
+          if(pBlob) {
+          	int nBlob = sqlite3_column_bytes(p->pStmt, i);
+          	output_hex_blob(p->out, pBlob, nBlob);
+          } else {
+	        utf8_printf(p->out,"NULL");
+          }
         }else if( isNumber(azArg[i], 0) ){
           utf8_printf(p->out,"%s", azArg[i]);
         }else if( ShellHasFlag(p, SHFLG_Newlines) ){

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -1071,13 +1071,13 @@ int sqlite3_column_bytes(sqlite3_stmt *pStmt, int iCol) {
 
 	// checks if the current column is initialized
 	if (!pStmt->current_text) {
-		if (!sqlite3_column_text(pStmt, iCol) && !sqlite3_column_blob(pStmt, iCol)) {
+		if (!sqlite3_column_text(pStmt, iCol) || !sqlite3_column_blob(pStmt, iCol)) {
 			return 0;
 		}
 	}
 	sqlite3_string_buffer *col_text = &pStmt->current_text[iCol];
 	if (!col_text->data) {
-		if (!sqlite3_column_text(pStmt, iCol) && !sqlite3_column_blob(pStmt, iCol)) {
+		if (!sqlite3_column_text(pStmt, iCol) || !sqlite3_column_blob(pStmt, iCol)) {
 			return 0;
 		}
 		col_text = &pStmt->current_text[iCol];

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -1071,13 +1071,13 @@ int sqlite3_column_bytes(sqlite3_stmt *pStmt, int iCol) {
 
 	// checks if the current column is initialized
 	if (!pStmt->current_text) {
-		if (!sqlite3_column_text(pStmt, iCol) || !sqlite3_column_blob(pStmt, iCol)) {
+		if (!sqlite3_column_text(pStmt, iCol) && !sqlite3_column_blob(pStmt, iCol)) {
 			return 0;
 		}
 	}
 	sqlite3_string_buffer *col_text = &pStmt->current_text[iCol];
 	if (!col_text->data) {
-		if (!sqlite3_column_text(pStmt, iCol) || !sqlite3_column_blob(pStmt, iCol)) {
+		if (!sqlite3_column_text(pStmt, iCol) && !sqlite3_column_blob(pStmt, iCol)) {
 			return 0;
 		}
 		col_text = &pStmt->current_text[iCol];

--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -482,6 +482,10 @@ int sqlite3_column_type(sqlite3_stmt *pStmt, int iCol) {
 	if (column_type.IsJSONType()) {
 		return 0; // Does not need to be surrounded in quotes like VARCHAR
 	}
+	if (column_type.HasAlias()) {
+		// Use the text representation for aliased types
+		return SQLITE_TEXT;
+	}
 	switch (column_type.id()) {
 	case LogicalTypeId::BOOLEAN:
 	case LogicalTypeId::TINYINT:


### PR DESCRIPTION
When using the (undocumented) `.dump` command in the shell, while opening a database that contains blob-aliased types provided by an extension that is unloaded, the CLI would crash as the shell would detect a value to be present, but the the unknown type would fail to cast to BLOB (as the extension, and thus any cast functions are not available) and return a nullptr.

I've modified the shell and the sqlite3 api wrapper to handle this case, but I'm not sure if this is the best fix or what the intended behavior should be when interacting with unknown types from the sqlite api. If we were to fall-back into a reinterpret cast, im not sure that's desirable when casting within the `sqlite3_column_has_value` as the type check then become essentially meaningless. Also there is no guarantee that the extension in question actually provides a valid reverse cast from the underlying type (e.g. BLOB) to the extension type even when loaded. It feels like the only sane thing is to either error out or turn all unknown types to NULL.

Closes https://github.com/duckdb/duckdb_spatial/issues/391