### PR TITLE
Small C Extension API changes

### DIFF
--- a/extension/demo_capi/capi_demo.cpp
+++ b/extension/demo_capi/capi_demo.cpp
@@ -2,5 +2,9 @@
 #include "add_numbers.h"
 
 DUCKDB_EXTENSION_ENTRYPOINT(duckdb_connection connection, duckdb_extension_info info, duckdb_extension_access *access) {
+	// Register a demo function
 	RegisterAddNumbersFunction(connection);
+
+	// Return true to indicate succesful initialization
+	return true;
 }

--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -613,7 +613,7 @@ def create_duckdb_ext_h(
     duckdb_ext_h += f"""// This goes in the c/c++ file containing the entrypoint (handle
 #define DUCKDB_EXTENSION_GLOBAL {DUCKDB_EXT_API_STRUCT_TYPENAME} {DUCKDB_EXT_API_VAR_NAME} = {{0}};
 // Initializes the C Extension API: First thing to call in the extension entrypoint
-#define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version) {DUCKDB_EXT_API_STRUCT_TYPENAME} * res = ({DUCKDB_EXT_API_STRUCT_TYPENAME} *)access->get_api(info, minimum_api_version); if (!res) {{return;}}; {DUCKDB_EXT_API_VAR_NAME} = *res;
+#define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version) {DUCKDB_EXT_API_STRUCT_TYPENAME} * res = ({DUCKDB_EXT_API_STRUCT_TYPENAME} *)access->get_api(info, minimum_api_version); if (!res) {{return false;}}; {DUCKDB_EXT_API_VAR_NAME} = *res;
 """
     duckdb_ext_h += f"""
 // Place in global scope of any C/C++ file that needs to access the extension API
@@ -629,33 +629,34 @@ def create_duckdb_ext_h(
 
 // Main entrypoint: opens (and closes) a connection automatically for the extension to register its functionality through 
 #define DUCKDB_EXTENSION_ENTRYPOINT\
-	DUCKDB_EXTENSION_GLOBAL static void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(duckdb_connection connection, duckdb_extension_info info, duckdb_extension_access *access);\
+	DUCKDB_EXTENSION_GLOBAL static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(duckdb_connection connection, duckdb_extension_info info, duckdb_extension_access *access);\
 	    DUCKDB_EXTENSION_EXTERN_C_GUARD_OPEN\
-	    DUCKDB_EXTENSION_API void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api)(\
+	    DUCKDB_EXTENSION_API bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api)(\
 	    duckdb_extension_info info, duckdb_extension_access *access) {\
 		DUCKDB_EXTENSION_API_INIT(info, access, DUCKDB_EXTENSION_API_VERSION_STRING);\
 		duckdb_database *db = access->get_database(info);\
 		duckdb_connection conn;\
 		if (duckdb_connect(*db, &conn) == DuckDBError) {\
 			access->set_error(info, "Failed to open connection to database");\
-			return;\
+			return false;\
 		}\
-		DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(conn, info, access);\
+		auto init_result = DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(conn, info, access);\
 		duckdb_disconnect(&conn);\
+		return init_result;\
 	}\
-	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)
+	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)
 
 // Custom entrypoint: just forwards the info and access
 #define DUCKDB_EXTENSION_ENTRYPOINT_CUSTOM\
-	DUCKDB_EXTENSION_GLOBAL static void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(\
+	DUCKDB_EXTENSION_GLOBAL static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(\
 	    duckdb_extension_info info, duckdb_extension_access *access);\
 	    DUCKDB_EXTENSION_EXTERN_C_GUARD_OPEN\
-	    DUCKDB_EXTENSION_API void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api)(\
+	    DUCKDB_EXTENSION_API bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api)(\
 	    duckdb_extension_info info, duckdb_extension_access *access) {\
 		DUCKDB_EXTENSION_API_INIT(info, access, DUCKDB_EXTENSION_API_VERSION_STRING);\
-		DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(info, access);\
+		return DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(infpo, access);\
 	}\
-	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)
+	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)
 #endif
     """
 

--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -654,7 +654,7 @@ def create_duckdb_ext_h(
 	    DUCKDB_EXTENSION_API bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api)(\
 	    duckdb_extension_info info, duckdb_extension_access *access) {\
 		DUCKDB_EXTENSION_API_INIT(info, access, DUCKDB_EXTENSION_API_VERSION_STRING);\
-		return DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(infpo, access);\
+		return DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)(info, access);\
 	}\
 	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME,_init_c_api_internal)
 #endif

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -874,7 +874,7 @@ typedef struct {
 #define DUCKDB_EXTENSION_API_INIT(info, access, minimum_api_version)                                                   \
 	duckdb_ext_api_v0 *res = (duckdb_ext_api_v0 *)access->get_api(info, minimum_api_version);                          \
 	if (!res) {                                                                                                        \
-		return;                                                                                                        \
+		return false;                                                                                                  \
 	};                                                                                                                 \
 	duckdb_ext_api = *res;
 
@@ -892,30 +892,31 @@ typedef struct {
 // Main entrypoint: opens (and closes) a connection automatically for the extension to register its functionality
 // through
 #define DUCKDB_EXTENSION_ENTRYPOINT                                                                                    \
-	DUCKDB_EXTENSION_GLOBAL static void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(            \
+	DUCKDB_EXTENSION_GLOBAL static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(            \
 	    duckdb_connection connection, duckdb_extension_info info, duckdb_extension_access * access);                   \
-	DUCKDB_EXTENSION_EXTERN_C_GUARD_OPEN DUCKDB_EXTENSION_API void DUCKDB_EXTENSION_GLUE(                              \
+	DUCKDB_EXTENSION_EXTERN_C_GUARD_OPEN DUCKDB_EXTENSION_API bool DUCKDB_EXTENSION_GLUE(                              \
 	    DUCKDB_EXTENSION_NAME, _init_c_api)(duckdb_extension_info info, duckdb_extension_access * access) {            \
 		DUCKDB_EXTENSION_API_INIT(info, access, DUCKDB_EXTENSION_API_VERSION_STRING);                                  \
 		duckdb_database *db = access->get_database(info);                                                              \
 		duckdb_connection conn;                                                                                        \
 		if (duckdb_connect(*db, &conn) == DuckDBError) {                                                               \
 			access->set_error(info, "Failed to open connection to database");                                          \
-			return;                                                                                                    \
+			return false;                                                                                              \
 		}                                                                                                              \
-		DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(conn, info, access);                        \
+		auto init_result = DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(conn, info, access);     \
 		duckdb_disconnect(&conn);                                                                                      \
+		return init_result;                                                                                            \
 	}                                                                                                                  \
-	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)
+	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)
 
 // Custom entrypoint: just forwards the info and access
 #define DUCKDB_EXTENSION_ENTRYPOINT_CUSTOM                                                                             \
-	DUCKDB_EXTENSION_GLOBAL static void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(            \
+	DUCKDB_EXTENSION_GLOBAL static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(            \
 	    duckdb_extension_info info, duckdb_extension_access * access);                                                 \
-	DUCKDB_EXTENSION_EXTERN_C_GUARD_OPEN DUCKDB_EXTENSION_API void DUCKDB_EXTENSION_GLUE(                              \
+	DUCKDB_EXTENSION_EXTERN_C_GUARD_OPEN DUCKDB_EXTENSION_API bool DUCKDB_EXTENSION_GLUE(                              \
 	    DUCKDB_EXTENSION_NAME, _init_c_api)(duckdb_extension_info info, duckdb_extension_access * access) {            \
 		DUCKDB_EXTENSION_API_INIT(info, access, DUCKDB_EXTENSION_API_VERSION_STRING);                                  \
-		DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(info, access);                              \
+		return DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)(info, access);                       \
 	}                                                                                                                  \
-	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static void DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)
+	DUCKDB_EXTENSION_EXTERN_C_GUARD_CLOSE static bool DUCKDB_EXTENSION_GLUE(DUCKDB_EXTENSION_NAME, _init_c_api_internal)
 #endif

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -69,7 +69,7 @@ struct ExtensionAccess {
 
 		if (error) {
 			load_state.has_error = true;
-			load_state.error_data = ErrorData(ExceptionType::UNKNOWN_TYPE, error);
+			load_state.error_data = ErrorData(error);
 		} else {
 			load_state.has_error = true;
 			load_state.error_data = ErrorData(

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -67,8 +67,15 @@ struct ExtensionAccess {
 	static void SetError(duckdb_extension_info info, const char *error) {
 		auto &load_state = DuckDBExtensionLoadState::Get(info);
 
-		load_state.has_error = true;
-		load_state.error_data = ErrorData(ExceptionType::UNKNOWN_TYPE, error);
+		if (error) {
+			load_state.has_error = true;
+			load_state.error_data = ErrorData(ExceptionType::UNKNOWN_TYPE, error);
+		} else {
+			load_state.has_error = true;
+			load_state.error_data = ErrorData(
+			    ExceptionType::UNKNOWN_TYPE,
+			    "Extension has indicated an error occured during initialization, but did not set an error message.");
+		}
 	}
 
 	//! Called by the extension get a pointer to the database that is loading it

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -545,7 +545,7 @@ void ExtensionHelper::LoadExternalExtension(DatabaseInstance &db, FileSystem &fs
 		    "Extension '%s' failed to initialize but did not return an error. This indicates an "
 		    "error in the extension: C API extensions should return a boolean `true` to indicate succesful "
 		    "initialization. "
-		    "This means that the Extension may be partially intialized resulting in an inconsistent state of DuckDB.",
+		    "This means that the Extension may be partially initialized resulting in an inconsistent state of DuckDB.",
 		    extension);
 	}
 


### PR DESCRIPTION
### entrypoint returns boolean
This is a minor change to the C Extension API entrypoint: instead of returning void and relying on an extension calling `extension_access->set_error`, we now require extensions to explicitly return true indicating the initialization process was successful. This makes things a bit more pleasant during development because DuckDB will then throw if somehow the initialization process returned early but failed to set an error message:

```
FATAL Error: Extension 'demo_capi' failed to initialize but did not return an error. This indicates an error in the extension: C API extensions should return a boolean `true` to indicate succesful initialization. This means that the Extension may be partially intialized resulting in an inconsistent state of DuckDB.
```

### `extension_access->set_error` can take nullptr
Extensions can now call `extension_access->set_error` with a nullptr for the error message. DuckDB will then just throw a generic error:
```
Error: An error was thrown during initialization of the extension 'demo_capi': Extension has indicated an error occured during initialization, but did not set an error message.
```