### PR TITLE
Fix partitions on wide tables

### DIFF
--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -40,7 +40,9 @@ function _close_result(result::QueryResult)
     return
 end
 
-mutable struct ColumnConversionData{ChunksT <: Union{Vector{DataChunk}, Tuple{DataChunk}}}
+const DataChunks = Union{Vector{DataChunk}, Tuple{DataChunk}}
+
+mutable struct ColumnConversionData{ChunksT <: DataChunks}
     chunks::ChunksT
     col_idx::Int64
     logical_type::LogicalType
@@ -571,6 +573,15 @@ function convert_column(column_data::ColumnConversionData)
     return convert_column_loop(column_data, conversion_func, internal_type, target_type, conversion_loop_func)
 end
 
+function convert_columns(q::QueryResult, chunks::DataChunks, column_count::Integer = duckdb_column_count(q.handle))
+    return NamedTuple{Tuple(q.names)}(ntuple(column_count) do i
+        j = Int64(i)
+        logical_type = LogicalType(duckdb_column_logical_type(q.handle, j))
+        column_data = ColumnConversionData(chunks, j, logical_type, nothing)
+        return convert_column(column_data)
+    end)
+end
+
 function Tables.columns(q::QueryResult)
     if q.tbl === missing
         if q.chunk_index != 1
@@ -581,7 +592,6 @@ function Tables.columns(q::QueryResult)
             )
         end
         # gather all the data chunks
-        column_count = duckdb_column_count(q.handle)
         chunks::Vector{DataChunk} = []
         while true
             # fetch the next chunk
@@ -593,11 +603,7 @@ function Tables.columns(q::QueryResult)
             push!(chunks, chunk)
         end
 
-        q.tbl = NamedTuple{Tuple(q.names)}(ntuple(column_count) do i
-            logical_type = LogicalType(duckdb_column_logical_type(q.handle, i))
-            column_data = ColumnConversionData(chunks, i, logical_type, nothing)
-            return convert_column(column_data)
-        end)
+        q.tbl = convert_columns(q, chunks)
     end
     return Tables.CopiedColumns(q.tbl)
 end
@@ -828,13 +834,7 @@ function next_chunk(iter::QueryResultChunkIterator)
         return nothing
     end
 
-    return QueryResultChunk(
-        NamedTuple{Tuple(iter.q.names)}(ntuple(iter.column_count) do i
-            logical_type = LogicalType(duckdb_column_logical_type(iter.q.handle, i))
-            column_data = ColumnConversionData((chunk,), i, logical_type, nothing)
-            return convert_column(column_data)
-        end)
-    )
+    return QueryResultChunk(convert_columns(iter.q, (chunk,), iter.column_count))
 end
 
 Base.iterate(iter::QueryResultChunkIterator) = iterate(iter, 0x0000000000000001)

--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -819,7 +819,7 @@ Tables.schema(chunk::QueryResultChunk) = Tables.Schema(chunk.q.names, chunk.q.ty
 
 struct QueryResultChunkIterator
     q::QueryResult
-    column_count::UInt64
+    column_count::Int64
 end
 
 function next_chunk(iter::QueryResultChunkIterator)

--- a/tools/juliapkg/test/test_basic_queries.jl
+++ b/tools/juliapkg/test/test_basic_queries.jl
@@ -149,5 +149,18 @@ end
     chunks_it = partitions(result)
     chunks = collect(chunks_it)
     @test length(chunks) == 2
+
+    DuckDB.execute(
+        con,
+        """
+CREATE TABLE large (x1 INT, x2 INT, x3 INT, x4 INT, x5 INT, x6 INT, x7 INT, x8 INT, x9 INT, x10 INT, x11 INT);
+"""
+    )
+    DuckDB.execute(con, "INSERT INTO large VALUES (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);")
+    result = DBInterface.execute(con, "SELECT * FROM large ;")
+    chunks_it = partitions(result)
+    chunks = collect(chunks_it)
+    @test length(chunks) == 1
+
     DBInterface.close!(con)
 end


### PR DESCRIPTION
On main branch, `Tables.partitions` fails on table with more than 10 columns. The (somewhat convoluted) reason is that julia `ntuple` function when fed a `UInt64` as second argument, casts it to `Int` only if it is `<= 10` (see https://github.com/JuliaLang/julia/issues/55790). This works in our favor for small `n` (number of columns), as the function `ColumnConversionData` expects a `Int`, not a `UInt64`, but for larger `n` attempting to collect a `Tables.partitions` fails.

The first commits is a minimal fix + test, whereas the second commit also adds a small refactor to simplify code and make it more robust to this.