### PR TITLE
[Arrow] Only produce 'arrow.json' Extension types when `arrow_lossless_conversion` is enabled.

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -166,7 +166,7 @@ void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, co
 		break;
 	}
 	case LogicalTypeId::VARCHAR:
-		if (type.IsJSONType()) {
+		if (type.IsJSONType() && options.arrow_lossless_conversion) {
 			auto schema_metadata = ArrowSchemaMetadata::MetadataFromName("arrow.json");
 			root_holder.metadata_info.emplace_back(schema_metadata.SerializeMetadata());
 			child.metadata = root_holder.metadata_info.back().get();

--- a/tools/pythonpkg/tests/fast/arrow/test_canonical_extensions.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_canonical_extensions.py
@@ -10,13 +10,93 @@ pa = pytest.importorskip('pyarrow')
 from arrow_canonical_extensions import UuidType, JSONType, UHugeIntType, HugeIntType
 
 
+class UuidTypeWrong(pa.ExtensionType):
+    def __init__(self):
+        pa.ExtensionType.__init__(self, pa.binary(4), "arrow.uuid")
+
+    def __arrow_ext_serialize__(self):
+        # since we don't have a parameterized type, we don't need extra
+        # metadata to be deserialized
+        return b''
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        # return an instance of this subclass given the serialized
+        # metadata.
+        return UuidTypeWrong()
+
+
+class JSONTypeWrong(pa.ExtensionType):
+    def __init__(self):
+        pa.ExtensionType.__init__(self, pa.int32(), "arrow.json")
+
+    def __arrow_ext_serialize__(self):
+        # since we don't have a parameterized type, we don't need extra
+        # metadata to be deserialized
+        return b''
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        # return an instance of this subclass given the serialized
+        # metadata.
+        return JSONTypeWrong()
+
+
+"""
+    These fixtures make sure that the extension_type is registered at the start of the function,
+    and unregistered at the end.
+    
+    No matter if an error occurred or the function ended early for whatever reason
+"""
+
+
+@pytest.fixture(scope='function')
+def arrow_duckdb_hugeint():
+    pa.register_extension_type(HugeIntType())
+    yield
+    pa.unregister_extension_type("duckdb.hugeint")
+
+
+@pytest.fixture(scope='function')
+def arrow_duckdb_uhugeint():
+    pa.register_extension_type(UHugeIntType())
+    yield
+    pa.unregister_extension_type("duckdb.uhugeint")
+
+
+@pytest.fixture(scope='function')
+def arrow_json():
+    pa.register_extension_type(JSONType())
+    yield
+    pa.unregister_extension_type("arrow.json")
+
+
+@pytest.fixture(scope='function')
+def arrow_json_wrong():
+    pa.register_extension_type(JSONTypeWrong())
+    yield
+    pa.unregister_extension_type("arrow.json")
+
+
+@pytest.fixture(scope='function')
+def arrow_uuid():
+    pa.register_extension_type(UuidType())
+    yield
+    pa.unregister_extension_type("arrow.uuid")
+
+
+@pytest.fixture(scope='function')
+def arrow_uuid_wrong():
+    pa.register_extension_type(UuidTypeWrong())
+    yield
+    pa.unregister_extension_type("arrow.uuid")
+
+
 class TestCanonicalExtensionTypes(object):
 
-    def test_uuid(self):
+    def test_uuid(self, arrow_uuid):
         duckdb_cursor = duckdb.connect()
         duckdb_cursor.execute("SET arrow_lossless_conversion = true")
-
-        pa.register_extension_type(UuidType())
 
         storage_array = pa.array([uuid.uuid4().bytes for _ in range(4)], pa.binary(16))
         uuid_type = UuidType()
@@ -28,13 +108,9 @@ class TestCanonicalExtensionTypes(object):
 
         assert duck_arrow.equals(arrow_table)
 
-        pa.unregister_extension_type("arrow.uuid")
-
-    def test_uuid_from_duck(self):
+    def test_uuid_from_duck(self, arrow_uuid):
         duckdb_cursor = duckdb.connect()
         duckdb_cursor.execute("SET arrow_lossless_conversion = true")
-
-        pa.register_extension_type(UuidType())
 
         arrow_table = duckdb_cursor.execute("select uuid from test_all_types()").fetch_arrow_table()
 
@@ -59,28 +135,9 @@ class TestCanonicalExtensionTypes(object):
         ]
         assert duckdb_cursor.execute("FROM arrow_table").fetchall() == [(UUID('00000000-0000-0000-0000-000000000100'),)]
 
-        pa.unregister_extension_type("arrow.uuid")
-
-    def test_uuid_exception(self):
-        class UuidTypeWrong(pa.ExtensionType):
-            def __init__(self):
-                pa.ExtensionType.__init__(self, pa.binary(4), "arrow.uuid")
-
-            def __arrow_ext_serialize__(self):
-                # since we don't have a parameterized type, we don't need extra
-                # metadata to be deserialized
-                return b''
-
-            @classmethod
-            def __arrow_ext_deserialize__(self, storage_type, serialized):
-                # return an instance of this subclass given the serialized
-                # metadata.
-                return UuidTypeWrong()
-
+    def test_uuid_exception(self, arrow_uuid_wrong):
         duckdb_cursor = duckdb.connect()
         duckdb_cursor.execute("SET arrow_lossless_conversion = true")
-
-        pa.register_extension_type(UuidTypeWrong())
 
         storage_array = pa.array(['aaaa'], pa.binary(4))
         uuid_type = UuidTypeWrong()
@@ -91,11 +148,7 @@ class TestCanonicalExtensionTypes(object):
         with pytest.raises(duckdb.InvalidInputException, match="arrow.uuid must be a fixed-size binary of 16 bytes"):
             duck_arrow = duckdb_cursor.execute('FROM arrow_table').arrow()
 
-        pa.unregister_extension_type("arrow.uuid")
-
-    def test_json(self, duckdb_cursor):
-        pa.register_extension_type(JSONType())
-
+    def test_json(self, duckdb_cursor, arrow_json):
         data = {"name": "Pedro", "age": 28, "car": "VW Fox"}
 
         # Convert dictionary to JSON string
@@ -107,30 +160,12 @@ class TestCanonicalExtensionTypes(object):
 
         arrow_table = pa.Table.from_arrays([storage_array], names=['json_col'])
 
+        duckdb_cursor.execute("SET arrow_lossless_conversion = true")
         duck_arrow = duckdb_cursor.execute('FROM arrow_table').arrow()
 
         assert duck_arrow.equals(arrow_table)
 
-        pa.unregister_extension_type("arrow.json")
-
-    def test_json_throw(self, duckdb_cursor):
-        class JSONTypeWrong(pa.ExtensionType):
-            def __init__(self):
-                pa.ExtensionType.__init__(self, pa.int32(), "arrow.json")
-
-            def __arrow_ext_serialize__(self):
-                # since we don't have a parameterized type, we don't need extra
-                # metadata to be deserialized
-                return b''
-
-            @classmethod
-            def __arrow_ext_deserialize__(self, storage_type, serialized):
-                # return an instance of this subclass given the serialized
-                # metadata.
-                return JSONTypeWrong()
-
-        pa.register_extension_type(JSONTypeWrong())
-
+    def test_json_throw(self, duckdb_cursor, arrow_json_wrong):
         storage_array = pa.array([32], pa.int32())
         json_type = JSONTypeWrong()
         storage_array = json_type.wrap_array(storage_array)
@@ -139,7 +174,6 @@ class TestCanonicalExtensionTypes(object):
 
         with pytest.raises(duckdb.InvalidInputException, match="arrow.json must be of a varchar format "):
             duck_arrow = duckdb_cursor.execute('FROM arrow_table').arrow()
-        pa.unregister_extension_type("arrow.json")
 
     def test_uuid_no_def(self):
         duckdb_cursor = duckdb.connect()
@@ -181,9 +215,7 @@ class TestCanonicalExtensionTypes(object):
             (None,),
         ]
 
-    def test_uuid_udf_registered(self, duckdb_cursor):
-        pa.register_extension_type(UuidType())
-
+    def test_uuid_udf_registered(self, arrow_uuid):
         def test_function(x):
             print(x.type.__class__)
             return x
@@ -194,19 +226,17 @@ class TestCanonicalExtensionTypes(object):
         rel = con.sql("select ? as x", params=[uuid.UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')])
         rel.project("test(x) from t").fetchall()
 
-        pa.unregister_extension_type("arrow.uuid")
-
     def test_uuid_udf_unregistered(self):
-        duckdb_cursor = duckdb.connect()
-        duckdb_cursor.execute("SET arrow_lossless_conversion = true")
+        con = duckdb.connect()
+        con.execute("SET arrow_lossless_conversion = true")
 
         def test_function(x):
             print(x.type.__class__)
             return x
 
-        duckdb_cursor.create_function('test', test_function, ['UUID'], 'UUID', type='arrow')
+        con.create_function('test', test_function, ['UUID'], 'UUID', type='arrow')
 
-        rel = duckdb_cursor.sql("select ? as x", params=[uuid.UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')])
+        rel = con.sql("select ? as x", params=[uuid.UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')])
         with pytest.raises(duckdb.Error, match="It seems that you are using the UUID arrow canonical extension"):
             rel.project("test(x) from t").fetchall()
 
@@ -219,10 +249,8 @@ class TestCanonicalExtensionTypes(object):
                 return b''
 
             @classmethod
-            def __arrow_ext_deserialize__(self, storage_type, serialized):
+            def __arrow_ext_deserialize__(cls, storage_type, serialized):
                 return UuidTypeWrong()
-
-                pa.register_extension_type(UuidType())
 
         storage_array = pa.array(['pedro'], pa.binary(5))
         my_type = MyType()
@@ -233,12 +261,10 @@ class TestCanonicalExtensionTypes(object):
         with pytest.raises(duckdb.NotImplementedException, match=" Arrow Type with extension name: pedro.binary"):
             duck_arrow = duckdb_cursor.execute('FROM arrow_table').arrow()
 
-    def test_hugeint(self):
-        duckdb_cursor = duckdb.connect()
+    def test_hugeint(self, arrow_duckdb_hugeint):
+        con = duckdb.connect()
 
-        duckdb_cursor.execute("SET arrow_lossless_conversion = true")
-
-        pa.register_extension_type(HugeIntType())
+        con.execute("SET arrow_lossless_conversion = true")
 
         storage_array = pa.array([b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'], pa.binary(16))
         hugeint_type = HugeIntType()
@@ -246,19 +272,15 @@ class TestCanonicalExtensionTypes(object):
 
         arrow_table = pa.Table.from_arrays([storage_array], names=['numbers'])
 
-        assert duckdb_cursor.execute('FROM arrow_table').fetchall() == [(-1,)]
+        assert con.execute('FROM arrow_table').fetchall() == [(-1,)]
 
-        assert duckdb_cursor.execute('FROM arrow_table').arrow().equals(arrow_table)
+        assert con.execute('FROM arrow_table').arrow().equals(arrow_table)
 
-        duckdb_cursor.execute("SET arrow_lossless_conversion = false")
+        con.execute("SET arrow_lossless_conversion = false")
 
-        assert not duckdb_cursor.execute('FROM arrow_table').arrow().equals(arrow_table)
+        assert not con.execute('FROM arrow_table').arrow().equals(arrow_table)
 
-        pa.unregister_extension_type("duckdb.hugeint")
-
-    def test_uhugeint(self, duckdb_cursor):
-        pa.register_extension_type(UHugeIntType())
-
+    def test_uhugeint(self, duckdb_cursor, arrow_duckdb_uhugeint):
         storage_array = pa.array([b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'], pa.binary(16))
         uhugeint_type = UHugeIntType()
         storage_array = uhugeint_type.wrap_array(storage_array)
@@ -267,25 +289,23 @@ class TestCanonicalExtensionTypes(object):
 
         assert duckdb_cursor.execute('FROM arrow_table').fetchall() == [(340282366920938463463374607431768211455,)]
 
-        pa.unregister_extension_type("duckdb.uhugeint")
-
     def test_bit(self):
-        duckdb_cursor = duckdb.connect()
+        con = duckdb.connect()
 
-        res_blob = duckdb_cursor.execute("SELECT '0101011'::BIT str FROM range(5) tbl(i)").arrow()
+        res_blob = con.execute("SELECT '0101011'::BIT str FROM range(5) tbl(i)").arrow()
 
-        duckdb_cursor.execute("SET arrow_lossless_conversion = true")
+        con.execute("SET arrow_lossless_conversion = true")
 
-        res_bit = duckdb_cursor.execute("SELECT '0101011'::BIT str FROM range(5) tbl(i)").arrow()
+        res_bit = con.execute("SELECT '0101011'::BIT str FROM range(5) tbl(i)").arrow()
 
-        assert duckdb_cursor.execute("FROM res_blob").fetchall() == [
+        assert con.execute("FROM res_blob").fetchall() == [
             (b'\x01\xab',),
             (b'\x01\xab',),
             (b'\x01\xab',),
             (b'\x01\xab',),
             (b'\x01\xab',),
         ]
-        assert duckdb_cursor.execute("FROM res_bit").fetchall() == [
+        assert con.execute("FROM res_bit").fetchall() == [
             ('0101011',),
             ('0101011',),
             ('0101011',),
@@ -294,15 +314,15 @@ class TestCanonicalExtensionTypes(object):
         ]
 
     def test_timetz(self):
-        duckdb_cursor = duckdb.connect()
+        con = duckdb.connect()
 
-        res_time = duckdb_cursor.execute("SELECT '02:30:00+04'::TIMETZ str FROM range(1) tbl(i)").arrow()
+        res_time = con.execute("SELECT '02:30:00+04'::TIMETZ str FROM range(1) tbl(i)").arrow()
 
-        duckdb_cursor.execute("SET arrow_lossless_conversion = true")
+        con.execute("SET arrow_lossless_conversion = true")
 
-        res_tz = duckdb_cursor.execute("SELECT '02:30:00+04'::TIMETZ str FROM range(1) tbl(i)").arrow()
+        res_tz = con.execute("SELECT '02:30:00+04'::TIMETZ str FROM range(1) tbl(i)").arrow()
 
-        assert duckdb_cursor.execute("FROM res_time").fetchall() == [(datetime.time(2, 30),)]
-        assert duckdb_cursor.execute("FROM res_tz").fetchall() == [
+        assert con.execute("FROM res_time").fetchall() == [(datetime.time(2, 30),)]
+        assert con.execute("FROM res_tz").fetchall() == [
             (datetime.time(2, 30, tzinfo=datetime.timezone(datetime.timedelta(seconds=14400))),)
         ]

--- a/tools/pythonpkg/tests/fast/arrow/test_polars.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_polars.py
@@ -57,3 +57,19 @@ class TestPolars(object):
             duckdb.InvalidInputException, match='Provided table/dataframe must have at least one column'
         ):
             duckdb_cursor.sql("from polars_empty_df")
+
+    def test_polars_from_json(self, duckdb_cursor):
+        from io import StringIO
+
+        duckdb_cursor.sql("set arrow_lossless_conversion=false")
+        string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
+        res = duckdb_cursor.read_json(string).pl()
+        assert str(res['entry'][0][0]) == "{'content': {'ManagedSystem': {'test': None}}}"
+
+    def test_polars_from_json_error(self, duckdb_cursor):
+        from io import StringIO
+
+        duckdb_cursor.sql("set arrow_lossless_conversion=true")
+        string = StringIO("""{"entry":[{"content":{"ManagedSystem":{"test":null}}}]}""")
+        with pytest.raises(pl.exceptions.PanicException):
+            res = duckdb_cursor.read_json(string).pl()


### PR DESCRIPTION
This PR fixes #13967

Adding the `arrow.json` extension type metadata to the produced ArrowSchema should be guarded by the (currently opt-in)`arrow_lossless_conversion` flag, which it wasn't.
