### PR TITLE
More descriptive Parquet created_by with version and source hash

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -350,7 +350,8 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
 	file_meta_data.version = 1;
 
 	file_meta_data.__isset.created_by = true;
-	file_meta_data.created_by = "DuckDB";
+	file_meta_data.created_by =
+	    StringUtil::Format("DuckDB version %s (build %s)", DuckDB::LibraryVersion(), DuckDB::SourceID());
 
 	file_meta_data.schema.resize(1);
 


### PR DESCRIPTION
Now looks like this `DuckDB version v1.0.1-dev5504 (build 86723c9912)` instead of just `DuckDB`. At least gives others the chance to special-case their reader if we ever have a bad writer bug.

The [spec](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L1178-L1182) says

```
  /** String for application that wrote this file.  This should be in the format
   * <Application> version <App Version> (build <App Build Hash>).
   * e.g. impala version 1.0 (build 6cf94d29b2b7115df4de2c06e2ab4326d721eb55)
   **/
```

so we're now compliant FWIW