### PR TITLE
Fix some warnings found while compiling duckdb-node

### DIFF
--- a/extension/parquet/include/parquet_rle_bp_decoder.hpp
+++ b/extension/parquet/include/parquet_rle_bp_decoder.hpp
@@ -66,7 +66,7 @@ public:
 			return 0;
 		}
 		uint8_t ret = 1;
-		while (((idx_t)(1u << ret) - 1) < val) {
+		while ((((idx_t)1u << (idx_t)ret) - 1) < val) {
 			ret++;
 		}
 		return ret;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -637,8 +637,7 @@ uint32_t ParquetReader::ReadData(duckdb_apache::thrift::protocol::TProtocol &ipr
 const ParquetRowGroup &ParquetReader::GetGroup(ParquetReaderScanState &state) {
 	auto file_meta_data = GetFileMetadata();
 	D_ASSERT(state.current_group >= 0 && (idx_t)state.current_group < state.group_idx_list.size());
-	D_ASSERT(state.group_idx_list[state.current_group] >= 0 &&
-	         state.group_idx_list[state.current_group] < file_meta_data->row_groups.size());
+	D_ASSERT(state.group_idx_list[state.current_group] < file_meta_data->row_groups.size());
 	return file_meta_data->row_groups[state.group_idx_list[state.current_group]];
 }
 

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -465,7 +465,7 @@ void ParquetWriter::PrepareRowGroup(ColumnDataCollection &buffer, PreparedRowGro
 // Validation code adapted from Impala
 static void ValidateOffsetInFile(const string &filename, idx_t col_idx, idx_t file_length, idx_t offset,
                                  const string &offset_name) {
-	if (offset < 0 || offset >= file_length) {
+	if (offset >= file_length) {
 		throw IOException("File '%s': metadata is corrupt. Column %d has invalid "
 		                  "%s (offset=%llu file_size=%llu).",
 		                  filename, col_idx, offset_name, offset, file_length);


### PR DESCRIPTION
Minor local code clean up, and a fix for a corner case (unsure if that actually might turn out to be a problem in practice), but probably worth cleaning once I saw them.