### PR TITLE
[C API] Add SQLNULL to the duckdb types

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -133,6 +133,8 @@ typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_ANY = 34,
 	// duckdb_varint
 	DUCKDB_TYPE_VARINT = 35,
+	// SQLNULL type
+	DUCKDB_TYPE_SQLNULL = 36,
 } duckdb_type;
 //! An enum over the returned state of different functions.
 typedef enum duckdb_state { DuckDBSuccess = 0, DuckDBError = 1 } duckdb_state;

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -127,6 +127,8 @@ typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_ANY = 34,
 	// duckdb_varint
 	DUCKDB_TYPE_VARINT = 35,
+	// SQLNULL type
+	DUCKDB_TYPE_SQLNULL = 36,
 } duckdb_type;
 //! An enum over the returned state of different functions.
 typedef enum duckdb_state { DuckDBSuccess = 0, DuckDBError = 1 } duckdb_state;

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -74,6 +74,8 @@ LogicalTypeId ConvertCTypeToCPP(duckdb_type c_type) {
 		return LogicalTypeId::TIMESTAMP_TZ;
 	case DUCKDB_TYPE_ANY:
 		return LogicalTypeId::ANY;
+	case DUCKDB_TYPE_SQLNULL:
+		return LogicalTypeId::SQLNULL;
 	default: // LCOV_EXCL_START
 		D_ASSERT(0);
 		return LogicalTypeId::INVALID;
@@ -154,6 +156,8 @@ duckdb_type ConvertCPPTypeToC(const LogicalType &sql_type) {
 		return DUCKDB_TYPE_ARRAY;
 	case LogicalTypeId::ANY:
 		return DUCKDB_TYPE_ANY;
+	case LogicalTypeId::SQLNULL:
+		return DUCKDB_TYPE_SQLNULL;
 	default: // LCOV_EXCL_START
 		D_ASSERT(0);
 		return DUCKDB_TYPE_INVALID;

--- a/test/api/capi/test_capi_any_invalid_type.cpp
+++ b/test/api/capi/test_capi_any_invalid_type.cpp
@@ -17,7 +17,10 @@ TEST_CASE("Test logical type creation with unsupported types", "[capi]") {
 	}
 }
 
-TEST_CASE("Test INVALID and ANY", "[capi]") {
+TEST_CASE("Test INVALID, ANY and SQLNULL", "[capi]") {
+	auto sql_null_type = duckdb_create_logical_type(DUCKDB_TYPE_SQLNULL);
+	duckdb_destroy_logical_type(&sql_null_type);
+
 	auto any_type = duckdb_create_logical_type(DUCKDB_TYPE_ANY);
 	auto invalid_type = duckdb_create_logical_type(DUCKDB_TYPE_INVALID);
 


### PR DESCRIPTION
Without `SQLNULL`, scalar functions with `ANY` parameters incorrectly return `INVALID` as the vector's type or hit the respective assertion.
```cpp
duckdb_type ConvertCPPTypeToC(const LogicalType &sql_type) {
	switch (sql_type.id()) {
	case LogicalTypeId::INVALID:
...
		return DUCKDB_TYPE_ARRAY;
	case LogicalTypeId::ANY:
		return DUCKDB_TYPE_ANY;
	default: // LCOV_EXCL_START
		D_ASSERT(0);
		return DUCKDB_TYPE_INVALID;
	} // LCOV_EXCL_STOP
}
```