### PR TITLE
fix julia partitions for streaming result

### DIFF
--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -873,7 +873,6 @@ function nextDataChunk(q::QueryResult)::Union{Missing, DataChunk}
         if get_size(chunk) == 0
             return missing
         end
-        return chunk
     else
         chunk_count = duckdb_result_chunk_count(q.handle[])
         if q.chunk_index > chunk_count

--- a/tools/juliapkg/test/test_basic_queries.jl
+++ b/tools/juliapkg/test/test_basic_queries.jl
@@ -145,10 +145,17 @@ end
 @testset "Test chunked response" begin
     con = DBInterface.connect(DuckDB.DB)
     DBInterface.execute(con, "CREATE TABLE chunked_table AS SELECT * FROM range(2049)")
-    result = DBInterface.execute(con, "SELECT * FROM chunked_table ;")
+    result = DBInterface.execute(con, "SELECT * FROM chunked_table;")
     chunks_it = partitions(result)
     chunks = collect(chunks_it)
     @test length(chunks) == 2
+    @test_throws DuckDB.NotImplementedException collect(chunks_it)
+
+    result = DBInterface.execute(con, "SELECT * FROM chunked_table;", DuckDB.StreamResult)
+    chunks_it = partitions(result)
+    chunks = collect(chunks_it)
+    @test length(chunks) == 2
+    @test_throws DuckDB.NotImplementedException collect(chunks_it)
 
     DuckDB.execute(
         con,


### PR DESCRIPTION
Previously, calling `nextDataChunk` on a streaming result failed to update the `chunk_index`. This in turn caused the check to prevent double iteration on `Tables.partitions(q::QueryResult)` to fail for streaming data.

Now the `chunk_index` is always updated after a successful `nextDataChunk` call. I've added tests that iterating partitions works when it should and throws `NotImplementedException` if one attempts to iterate twice.