### PR TITLE
fix: make ArrowArrayWrapper::GetNextChunk() virtual 

### DIFF
--- a/src/include/duckdb/common/arrow/arrow_wrapper.hpp
+++ b/src/include/duckdb/common/arrow/arrow_wrapper.hpp
@@ -53,7 +53,7 @@ public:
 
 	const char *GetError();
 
-	~ArrowArrayStreamWrapper();
+	virtual ~ArrowArrayStreamWrapper();
 	ArrowArrayStreamWrapper() {
 		arrow_array_stream.release = nullptr;
 	}

--- a/src/include/duckdb/common/arrow/arrow_wrapper.hpp
+++ b/src/include/duckdb/common/arrow/arrow_wrapper.hpp
@@ -49,7 +49,7 @@ public:
 public:
 	void GetSchema(ArrowSchemaWrapper &schema);
 
-	shared_ptr<ArrowArrayWrapper> GetNextChunk();
+	virtual shared_ptr<ArrowArrayWrapper> GetNextChunk();
 
 	const char *GetError();
 


### PR DESCRIPTION
I'd like to throw a custom exception rather than the one that is generated by `arrow_scan` if an error happens when scanning Arrow data, without this method being marked as `virtual` I cannot override it in a subclass.

Can we please get this in the bug fix release?