### PR TITLE
[CSV Sniffer] Slight change of rules for dialect detection

### DIFF
--- a/data/csv/auto/mock_duckdb_test_data.csv
+++ b/data/csv/auto/mock_duckdb_test_data.csv
@@ -1,0 +1,10 @@
+id,name,age,sex,state
+1,James,30,M,AL
+2,Jill,32,F,CO
+3,Lyla,35,F
+4,John,34,M,AS
+5,Matthew,31,M,
+6,Oliver,33,M,CA,extra_record
+7,Olivia,36,F,OR
+8,James,37,M,AZ
+9,Titus,38,M,WY

--- a/src/execution/operator/csv_scanner/scanner/column_count_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/column_count_scanner.cpp
@@ -28,6 +28,11 @@ idx_t ColumnCountResult::GetMostFrequentColumnCount() const {
 		if (rpc.second > current_max) {
 			current_max = rpc.second;
 			column_count = rpc.first;
+		} else if (rpc.second == current_max) {
+			// We pick the largest to untie
+			if (rpc.first > column_count) {
+				column_count = rpc.first;
+			}
 		}
 	}
 	return column_count;

--- a/src/execution/operator/csv_scanner/scanner/column_count_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/column_count_scanner.cpp
@@ -12,8 +12,25 @@ void ColumnCountResult::AddValue(ColumnCountResult &result, idx_t buffer_pos) {
 }
 
 inline void ColumnCountResult::InternalAddRow() {
-	column_counts[result_position].number_of_columns = current_column_count + 1;
+	const idx_t column_count = current_column_count + 1;
+	column_counts[result_position].number_of_columns = column_count;
+	rows_per_column_count[column_count]++;
 	current_column_count = 0;
+}
+
+idx_t ColumnCountResult::GetMostFrequentColumnCount() const {
+	if (rows_per_column_count.empty()) {
+		return 1;
+	}
+	idx_t column_count = 0;
+	idx_t current_max = 0;
+	for (auto &rpc : rows_per_column_count) {
+		if (rpc.second > current_max) {
+			current_max = rpc.second;
+			column_count = rpc.first;
+		}
+	}
+	return column_count;
 }
 
 bool ColumnCountResult::AddRow(ColumnCountResult &result, idx_t buffer_pos) {

--- a/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
@@ -221,13 +221,16 @@ SnifferResult CSVSniffer::SniffCSV(bool force_match) {
 			// If the header exists it should match
 			string header_error = "The Column names set by the user do not match the ones found by the sniffer. \n";
 			auto &set_names = *set_columns.names;
-			for (idx_t i = 0; i < set_columns.Size(); i++) {
-				if (set_names[i] != names[i]) {
-					header_error += "Column at position: " + to_string(i) + " Set name: " + set_names[i] +
-					                " Sniffed Name: " + names[i] + "\n";
-					match = false;
+			if (set_names.size() == names.size()) {
+				for (idx_t i = 0; i < set_columns.Size(); i++) {
+					if (set_names[i] != names[i]) {
+						header_error += "Column at position: " + to_string(i) + " Set name: " + set_names[i] +
+						                " Sniffed Name: " + names[i] + "\n";
+						match = false;
+					}
 				}
 			}
+
 			if (!match) {
 				error += header_error;
 			}
@@ -235,15 +238,18 @@ SnifferResult CSVSniffer::SniffCSV(bool force_match) {
 		match = true;
 		string type_error = "The Column types set by the user do not match the ones found by the sniffer. \n";
 		auto &set_types = *set_columns.types;
-		for (idx_t i = 0; i < set_columns.Size(); i++) {
-			if (set_types[i] != detected_types[i]) {
-				type_error += "Column at position: " + to_string(i) + " Set type: " + set_types[i].ToString() +
-				              " Sniffed type: " + detected_types[i].ToString() + "\n";
-				detected_types[i] = set_types[i];
-				manually_set[i] = true;
-				match = false;
+		if (detected_types.size() == set_columns.Size()) {
+			for (idx_t i = 0; i < set_columns.Size(); i++) {
+				if (set_types[i] != detected_types[i]) {
+					type_error += "Column at position: " + to_string(i) + " Set type: " + set_types[i].ToString() +
+					              " Sniffed type: " + detected_types[i].ToString() + "\n";
+					detected_types[i] = set_types[i];
+					manually_set[i] = true;
+					match = false;
+				}
 			}
 		}
+
 		if (!match) {
 			error += type_error;
 		}

--- a/src/include/duckdb/execution/operator/csv_scanner/column_count_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/column_count_scanner.hpp
@@ -41,7 +41,8 @@ public:
 	bool error = false;
 	idx_t result_position = 0;
 	bool cur_line_starts_as_comment = false;
-
+	//! How many rows fit a given column count
+	map<idx_t, idx_t> rows_per_column_count;
 	//! Adds a Value to the result
 	static inline void AddValue(ColumnCountResult &result, idx_t buffer_pos);
 	//! Adds a Row to the result
@@ -56,6 +57,9 @@ public:
 	static inline bool UnsetComment(ColumnCountResult &result, idx_t buffer_pos);
 
 	static inline void SetComment(ColumnCountResult &result, idx_t buffer_pos);
+
+	//! Returns the column count
+	idx_t GetMostFrequentColumnCount() const;
 
 	inline void InternalAddRow();
 };

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_sniffer.hpp
@@ -56,7 +56,7 @@ struct DialectCandidates {
 	//! Candidates for the comment
 	vector<char> comment_candidates;
 	//! Quote-Rule Candidates
-	vector<QuoteRule> quoterule_candidates;
+	vector<QuoteRule> quote_rule_candidates;
 	//! Candidates for the quote option
 	unordered_map<uint8_t, vector<char>> quote_candidates_map;
 	//! Candidates for the escape option
@@ -181,7 +181,7 @@ private:
 	void RefineCandidates();
 
 	//! Checks if candidate still produces good values for the next chunk
-	bool RefineCandidateNextChunk(ColumnCountScanner &candidate);
+	bool RefineCandidateNextChunk(ColumnCountScanner &candidate) const;
 
 	//! ------------------------------------------------------//
 	//! ------------------- Type Detection ------------------ //

--- a/test/sql/copy/csv/auto/test_csv_auto.test
+++ b/test/sql/copy/csv/auto/test_csv_auto.test
@@ -8,6 +8,22 @@ PRAGMA enable_verification
 statement ok 
 PRAGMA verify_parallelism
 
+query I
+select columns FROM sniff_csv('data/csv/auto/mock_duckdb_test_data.csv', ignore_errors = true);
+----
+[{'name': id, 'type': BIGINT}, {'name': name, 'type': VARCHAR}, {'name': age, 'type': BIGINT}, {'name': sex, 'type': VARCHAR}, {'name': state, 'type': VARCHAR}]
+
+query IIIII
+FROM read_csv('data/csv/auto/mock_duckdb_test_data.csv', ignore_errors = true)
+----
+1	James	30	M	AL
+2	Jill	32	F	CO
+4	John	34	M	AS
+5	Matthew	31	M	NULL
+7	Olivia	36	F	OR
+8	James	37	M	AZ
+9	Titus	38	M	WY
+
 statement error
 select * from read_csv_auto('data/csv/dates.csv', auto_detect=false, delim=',', quote='"', columns={'a': 'VARCHAR'})
 ----

--- a/test/sql/copy/csv/rejects/csv_rejects_read.test
+++ b/test/sql/copy/csv/rejects/csv_rejects_read.test
@@ -251,6 +251,7 @@ DROP TABLE reject_errors;
 statement ok
 DROP TABLE reject_scans;
 
+
 # Test rejects table with comments
 statement ok
 FROM read_csv('data/csv/comments/error.csv', store_rejects = true, comment = '#');
@@ -269,16 +270,16 @@ DROP TABLE reject_errors;
 statement ok
 DROP TABLE reject_scans;
 
-query III
+query II
 FROM read_csv('data/csv/error.csv', store_rejects=1);
 ----
-true	true	true
+true	false
 
 query IIIIIIII
 SELECT * EXCLUDE (scan_id, file_id) FROM reject_errors ORDER BY column_name;
 ----
-4	36	39	1	column1	MISSING COLUMNS	yes	Expected Number of Columns: 3 Found: 1
-4	36	39	2	column2	MISSING COLUMNS	yes	Expected Number of Columns: 3 Found: 2
+4	36	39	1	column2	MISSING COLUMNS	yes	Expected Number of Columns: 2 Found: 1
+3	24	31	3	NULL	TOO MANY COLUMNS	yes,yes,yes	Expected Number of Columns: 2 Found: 3
 
 statement ok
 DROP TABLE reject_errors;


### PR DESCRIPTION
When `ignore_errors=true, null_padding = false`. we pick the number of columns as the most frequent option.

In case of a tie, we pick the higher number.

Fix: #14001