### PR TITLE
Fix #10961 - in the HAVING clause - in case of column name conflicts, bind to aliases instead of to ungrouped columns

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -104,6 +104,7 @@ duckdb_extension_load(spatial
     GIT_TAG 4107eb788f933c9e268b52f6f927a6b36b9ea440
     INCLUDE_DIR spatial/include
     TEST_DIR test/sql
+    APPLY_PATCHES
     )
 
 ################# SQLITE_SCANNER

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -107,7 +107,7 @@ public:
 	//! Returns a qualified column reference from a column reference with column_names.size() > 2
 	unique_ptr<ParsedExpression> QualifyColumnNameWithManyDots(ColumnRefExpression &col_ref, ErrorData &error);
 	//! Returns a qualified column reference from a column reference
-	unique_ptr<ParsedExpression> QualifyColumnName(ColumnRefExpression &col_ref, ErrorData &error);
+	virtual unique_ptr<ParsedExpression> QualifyColumnName(ColumnRefExpression &col_ref, ErrorData &error);
 	//! Enables special-handling of lambda parameters by tracking them in the lambda_params vector
 	void QualifyColumnNamesInLambda(FunctionExpression &function, vector<unordered_set<string>> &lambda_params);
 	//! Recursively qualifies the column references in the (children) of the expression. Passes on the
@@ -116,6 +116,7 @@ public:
 	                        const bool within_function_expression = false);
 	//! Entry point for qualifying the column references of the expression
 	static void QualifyColumnNames(Binder &binder, unique_ptr<ParsedExpression> &expr);
+	static void QualifyColumnNames(ExpressionBinder &binder, unique_ptr<ParsedExpression> &expr);
 
 	static bool PushCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type);
 	static void TestCollation(ClientContext &context, const string &collation);

--- a/src/include/duckdb/planner/expression_binder/having_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/having_binder.hpp
@@ -25,6 +25,8 @@ protected:
 	BindResult BindWindow(WindowExpression &expr, idx_t depth) override;
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 
+	unique_ptr<ParsedExpression> QualifyColumnName(ColumnRefExpression &col_ref, ErrorData &error) override;
+
 private:
 	ColumnAliasBinder column_alias_binder;
 	AggregateHandling aggregate_handling;

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -534,8 +534,8 @@ void BindContext::AddBaseTable(idx_t index, const string &alias, const vector<st
 void BindContext::AddBaseTable(idx_t index, const string &alias, const vector<string> &names,
                                const vector<LogicalType> &types, vector<column_t> &bound_column_ids,
                                const string &table_name) {
-	AddBinding(
-	    make_uniq<TableBinding>(alias.empty() ? table_name : alias, types, names, bound_column_ids, nullptr, index));
+	AddBinding(make_uniq<TableBinding>(alias.empty() ? table_name : alias, types, names, bound_column_ids, nullptr,
+	                                   index, true));
 }
 
 void BindContext::AddTableFunction(idx_t index, const string &alias, const vector<string> &names,

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -218,6 +218,11 @@ void ExpressionBinder::QualifyColumnNames(Binder &binder, unique_ptr<ParsedExpre
 	where_binder.QualifyColumnNames(expr, lambda_params);
 }
 
+void ExpressionBinder::QualifyColumnNames(ExpressionBinder &expression_binder, unique_ptr<ParsedExpression> &expr) {
+	vector<unordered_set<string>> lambda_params;
+	expression_binder.QualifyColumnNames(expr, lambda_params);
+}
+
 unique_ptr<ParsedExpression> ExpressionBinder::CreateStructExtract(unique_ptr<ParsedExpression> base,
                                                                    const string &field_name) {
 

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -514,7 +514,7 @@ unique_ptr<BoundQueryNode> Binder::BindSelectNode(SelectNode &statement, unique_
 	// bind the HAVING clause, if any
 	if (statement.having) {
 		HavingBinder having_binder(*this, context, *result, info, statement.aggregate_handling);
-		ExpressionBinder::QualifyColumnNames(*this, statement.having);
+		ExpressionBinder::QualifyColumnNames(having_binder, statement.having);
 		result->having = having_binder.Bind(statement.having);
 	}
 

--- a/test/sql/aggregate/having/having_alias.test
+++ b/test/sql/aggregate/having/having_alias.test
@@ -1,0 +1,39 @@
+# name: test/sql/aggregate/having/having_alias.test
+# description: Test aliases in the HAVING clause
+# group: [having]
+
+statement ok
+PRAGMA enable_verification
+
+query II
+SELECT b, sum(a) AS a
+FROM (VALUES (1, 0), (1, 1)) t(a, b)
+GROUP BY b
+HAVING a > 0
+ORDER BY ALL
+----
+0	1
+1	1
+
+# if a reference is both a group and an alias, we prefer to bind to the group
+statement ok
+create table t1(a int);
+
+statement ok
+insert into t1 values (42), (84);
+
+query I
+select a+1 as a from t1 group by a having a=42;
+----
+43
+
+statement ok
+create table t2(a int);
+
+statement ok
+insert into t2 values (42), (84), (42);
+
+query II
+select a as b, sum(a) as a from t2 group by b having a=42;
+----
+42	84

--- a/test/sql/binder/test_having_alias.test
+++ b/test/sql/binder/test_having_alias.test
@@ -46,15 +46,20 @@ SELECT COUNT(i) AS j FROM integers HAVING j=5;
 ----
 5
 
-# These don't work since i in HAVING refers the column instead of the alias
-# (SQLite says: 'Error: a GROUP BY clause is required before HAVING')
-statement error
+
+query I
 SELECT COUNT(i) AS i FROM integers HAVING i=5;
 ----
+5
 
-statement error
+query I
+SELECT COUNT(i) AS i FROM integers GROUP BY i HAVING i=5;
+----
+
+query I
 SELECT COUNT(i) AS i FROM integers HAVING i=5 ORDER BY i;
 ----
+5
 
 # use the same alias multiple times
 query I


### PR DESCRIPTION
Fixes #10961 