### PR TITLE
Fix #13993 - avoid disabling optimizers for SET VARIABLE

### DIFF
--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -95,7 +95,10 @@ void Optimizer::RunBuiltInOptimizers() {
 	case LogicalOperatorType::LOGICAL_CREATE_SECRET:
 	case LogicalOperatorType::LOGICAL_EXTENSION_OPERATOR:
 		// skip optimizing simple & often-occurring plans unaffected by rewrites
-		return;
+		if (plan->children.empty()) {
+			return;
+		}
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
Fixes #13993 

We need to run optimizers on `SET` if it has child nodes, since `SET VARIABLE` can run on subqueries. 