### PR TITLE
Fix #14020: fix off-by-one in RLE compression: avoid flushing when last_seen_count == 0 which can happen if a column has exactly 2^16 (65535) repeated values

### DIFF
--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -57,7 +57,9 @@ public:
 			} else {
 				// the values are different
 				// issue the callback on the last value
-				Flush<OP>();
+				if (last_seen_count > 0) {
+					Flush<OP>();
+				}
 
 				// increment the seen_count and put the new value into the RLE slot
 				last_value = data[idx];

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -57,13 +57,14 @@ public:
 			} else {
 				// the values are different
 				// issue the callback on the last value
+				// edge case: if a value has exactly 2^16 repeated values, we can end up here with last_seen_count = 0
 				if (last_seen_count > 0) {
 					Flush<OP>();
+					seen_count++;
 				}
 
 				// increment the seen_count and put the new value into the RLE slot
 				last_value = data[idx];
-				seen_count++;
 				last_seen_count = 1;
 			}
 		} else {

--- a/test/sql/storage/compression/rle/rle_many_repeated.test_slow
+++ b/test/sql/storage/compression/rle/rle_many_repeated.test_slow
@@ -1,0 +1,25 @@
+# name: test/sql/storage/compression/rle/rle_many_repeated.test_slow
+# description: Test forcing RLE as the compression scheme
+# group: [rle]
+
+require vector_size 2048
+
+load __TEST_DIR__/rle_many_repeated.db
+
+statement ok
+PRAGMA force_compression = 'rle'
+
+statement ok
+CREATE TABLE test_rle (a BIGINT);
+
+statement ok
+INSERT INTO test_rle SELECT 3::BIGINT FROM range(0, 65535) UNION ALL SELECT 4::BIGINT FROM range(100000);
+
+statement ok
+CHECKPOINT
+
+query II
+SELECT a, COUNT(*) FROM test_rle GROUP BY ALL
+----
+3	65535
+4	100000


### PR DESCRIPTION
Fixes #14020 