### PR TITLE
Proper NULL handling in special json extraction functions

### DIFF
--- a/extension/json/json_functions/json_extract.cpp
+++ b/extension/json/json_functions/json_extract.cpp
@@ -6,9 +6,17 @@ static inline string_t ExtractFromVal(yyjson_val *val, yyjson_alc *alc, Vector &
 	return JSONCommon::WriteVal<yyjson_val>(val, alc);
 }
 
-static inline string_t ExtractStringFromVal(yyjson_val *val, yyjson_alc *alc, Vector &, ValidityMask &, idx_t) {
-	return yyjson_is_str(val) ? string_t(unsafe_yyjson_get_str(val), unsafe_yyjson_get_len(val))
-	                          : JSONCommon::WriteVal<yyjson_val>(val, alc);
+static inline string_t ExtractStringFromVal(yyjson_val *val, yyjson_alc *alc, Vector &, ValidityMask &mask, idx_t idx) {
+	switch (yyjson_get_tag(val)) {
+	case YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE:
+		mask.SetInvalid(idx);
+		return string_t {};
+	case YYJSON_TYPE_STR | YYJSON_SUBTYPE_NOESC:
+	case YYJSON_TYPE_STR | YYJSON_SUBTYPE_NONE:
+		return string_t(unsafe_yyjson_get_str(val), unsafe_yyjson_get_len(val));
+	default:
+		return JSONCommon::WriteVal<yyjson_val>(val, alc);
+	}
 }
 
 static void ExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/extension/json/json_functions/json_value.cpp
+++ b/extension/json/json_functions/json_value.cpp
@@ -4,6 +4,7 @@ namespace duckdb {
 
 static inline string_t ValueFromVal(yyjson_val *val, yyjson_alc *alc, Vector &, ValidityMask &mask, idx_t idx) {
 	switch (yyjson_get_tag(val)) {
+	case YYJSON_TYPE_NULL | YYJSON_SUBTYPE_NONE:
 	case YYJSON_TYPE_ARR | YYJSON_SUBTYPE_NONE:
 	case YYJSON_TYPE_OBJ | YYJSON_SUBTYPE_NONE:
 		mask.SetInvalid(idx);
@@ -22,12 +23,12 @@ static void ValueManyFunction(DataChunk &args, ExpressionState &state, Vector &r
 }
 
 static void GetValueFunctionsInternal(ScalarFunctionSet &set, const LogicalType &input_type) {
-	set.AddFunction(ScalarFunction({input_type, LogicalType::BIGINT}, LogicalType::JSON(), ValueFunction,
+	set.AddFunction(ScalarFunction({input_type, LogicalType::BIGINT}, LogicalType::VARCHAR, ValueFunction,
 	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
-	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::JSON(), ValueFunction,
+	set.AddFunction(ScalarFunction({input_type, LogicalType::VARCHAR}, LogicalType::VARCHAR, ValueFunction,
 	                               JSONReadFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
 	set.AddFunction(ScalarFunction({input_type, LogicalType::LIST(LogicalType::VARCHAR)},
-	                               LogicalType::LIST(LogicalType::JSON()), ValueManyFunction,
+	                               LogicalType::LIST(LogicalType::VARCHAR), ValueManyFunction,
 	                               JSONReadManyFunctionData::Bind, nullptr, nullptr, JSONFunctionLocalState::Init));
 }
 

--- a/test/sql/json/scalar/test_json_extract.test
+++ b/test/sql/json/scalar/test_json_extract.test
@@ -363,4 +363,4 @@ null
 query I
 select '{"duck":null}'->>'$.duck'
 ----
-null
+NULL

--- a/test/sql/json/scalar/test_json_extract.test
+++ b/test/sql/json/scalar/test_json_extract.test
@@ -352,3 +352,15 @@ query I
 select '{"\"du\nck\"": 42}'->('$."\"du' || chr(10) || 'ck\""');
 ----
 42
+
+# json_extract gets the JSON null (PostgreSQL behavior)
+query I
+select '{"duck":null}'->'$.duck'
+----
+null
+
+# json_extract_string gets a SQL NULL (PostgreSQL behavior)
+query I
+select '{"duck":null}'->>'$.duck'
+----
+null

--- a/test/sql/json/scalar/test_json_value.test
+++ b/test/sql/json/scalar/test_json_value.test
@@ -7,11 +7,11 @@ require json
 statement ok
 pragma enable_verification
 
-# should go to our NULL
+# unlike JSON extract, this goes our NULL
 query T
 select json_value('{"foo": null}', '$.foo')
 ----
-null
+NULL
 
 query T
 select json_value('{"foo": null}', '$.foo.bar')
@@ -21,12 +21,12 @@ NULL
 query T
 select json_value('null', '$')
 ----
-null
+NULL
 
 query T
 select json_value('[null]', '$[0]')
 ----
-null
+NULL
 
 query T
 select json_value('{"my_field": {"my_nested_field": ["goose", "duck"]}}', '/my_field/my_nested_field/1')


### PR DESCRIPTION
Following a [comment here](https://github.com/duckdb/duckdb/pull/13481#issuecomment-2360050486), I've decided to take a closer look at the `NULL` handling and return types of JSON extraction functions in PostgreSQL and BigQuery, and found that we were inconsistent:
1. While `json_extract`/`->` should return a JSON `null` value when doing, e.g., `SELECT '{"duck": null}'->'duck';`, `json_extract_string`/`->>`/`json_value` should return a SQL `NULL` value.
2. The return type of `json_value` should be `VARCHAR`, not `JSON`.

Both points were not implemented correctly in DuckDB, which this PR fixes.