### PR TITLE
[Dev] Fix an issue causing ExecuteTask to do much more work than intended

### DIFF
--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -241,8 +241,12 @@ public:
 	bool caching_supported;
 
 public:
+	//! This Execute will prevent small chunks from entering the pipeline, buffering them until a bigger chunk is
+	//! created.
 	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
 	                           GlobalOperatorState &gstate, OperatorState &state) const final;
+	//! FinalExecute is used here to send out the remainder of the chunk (< STANDARD_VECTOR_SIZE) that we still had
+	//! cached.
 	OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk, GlobalOperatorState &gstate,
 	                                        OperatorState &state) const final;
 

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -39,11 +39,14 @@ public:
 
 public:
 	bool Next() {
-		if (processed >= maximum_to_process) {
+		if (IsDepleted()) {
 			return false;
 		}
 		processed++;
 		return true;
+	}
+	bool IsDepleted() const {
+		return processed >= maximum_to_process;
 	}
 
 private:

--- a/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -34,7 +34,7 @@ enum class PipelineExecuteResult {
 
 class ExecutionBudget {
 public:
-	ExecutionBudget(idx_t maximum) : processed(0), maximum_to_process(maximum) {
+	explicit ExecutionBudget(idx_t maximum) : processed(0), maximum_to_process(maximum) {
 	}
 
 public:

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -104,6 +104,7 @@ bool PipelineExecutor::TryFlushCachingOperators(ExecutionBudget &chunk_budget) {
 			return false;
 		}
 		case OperatorResultType::HAVE_MORE_OUTPUT: {
+			D_ASSERT(chunk_budget.IsDepleted());
 			// The chunk budget was used up, pushing the chunk through the pipeline created more chunks
 			// we need to continue this the next time Execute is called.
 			return false;

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -213,6 +213,7 @@ PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
 				if (remaining_sink_chunk) {
 					return PipelineExecuteResult::INTERRUPTED;
 				} else {
+					D_ASSERT(chunk_budget.IsDepleted());
 					return PipelineExecuteResult::NOT_FINISHED;
 				}
 			}

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -436,6 +436,34 @@ TEST_CASE("Test fetch API with big results", "[api][.]") {
 	VerifyStreamResult(std::move(result));
 }
 
+TEST_CASE("Test TryFlushCachingOperators interrupted ExecutePushInternal", "[api][.]") {
+	DuckDB db;
+	Connection con(db);
+
+	con.Query("create table tbl as select 100000 a from range(2) t(a);");
+	con.Query("pragma threads=1");
+
+	// Use PhysicalCrossProduct with a very low amount of produced tuples, this caches the result in the
+	// CachingOperatorState This gets flushed with FinalExecute in PipelineExecutor::TryFlushCachingOperator
+	auto pending_query = con.PendingQuery("select unnest(range(a.a)) from tbl a, tbl b;");
+
+	// Through `unnest(range(a.a.))` this FinalExecute multiple chunks, more than the ExecutionBudget can handle with
+	// PROCESS_PARTIAL
+	pending_query->ExecuteTask();
+
+	// query the connection as normal after
+	auto res = pending_query->Execute();
+	REQUIRE(!res->HasError());
+	auto &materialized_res = res->Cast<MaterializedQueryResult>();
+	auto initial_tuples = 2 * 2;
+	REQUIRE(materialized_res.RowCount() == initial_tuples * 100000);
+	for (idx_t i = 0; i < initial_tuples; i++) {
+		for (idx_t j = 0; j < 100000; j++) {
+			REQUIRE(materialized_res.GetValue<int64_t>(0, (i * 100000) + j) == j);
+		}
+	}
+}
+
 TEST_CASE("Test streaming query during stack unwinding", "[api]") {
 	DuckDB db;
 	Connection con(db);

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -459,7 +459,8 @@ TEST_CASE("Test TryFlushCachingOperators interrupted ExecutePushInternal", "[api
 	REQUIRE(materialized_res.RowCount() == initial_tuples * 100000);
 	for (idx_t i = 0; i < initial_tuples; i++) {
 		for (idx_t j = 0; j < 100000; j++) {
-			REQUIRE(materialized_res.GetValue<int64_t>(0, (i * 100000) + j) == j);
+			auto value = static_cast<idx_t>(materialized_res.GetValue<int64_t>(0, (i * 100000) + j));
+			REQUIRE(value == j);
 		}
 	}
 }

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -455,7 +455,7 @@ TEST_CASE("Test TryFlushCachingOperators interrupted ExecutePushInternal", "[api
 	auto res = pending_query->Execute();
 	REQUIRE(!res->HasError());
 	auto &materialized_res = res->Cast<MaterializedQueryResult>();
-	auto initial_tuples = 2 * 2;
+	idx_t initial_tuples = 2 * 2;
 	REQUIRE(materialized_res.RowCount() == initial_tuples * 100000);
 	for (idx_t i = 0; i < initial_tuples; i++) {
 		for (idx_t j = 0; j < 100000; j++) {


### PR DESCRIPTION
This PR makes `ExecutePushInternal` respect the `max_chunks` set in the call to `PipelineExecutor::Execute(idx_t max_chunks)`

When running DuckDB inside an environment where the control over received signals (like SIGINT) is not instant (like Python or Postgres), we rely on ExecuteTask to return after doing a small amount of processing work.

In the DuckDB CLI this problem was not apparent because SIGINT is handled and `Interrupt()` is called instantly, which is respected by the execution.
This problem only appeared because the `interrupt` flag could not be set as the application was first waiting for ExecuteTask to return.