### PR TITLE
Allow duplicate table aliases in the table binder

### DIFF
--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -167,8 +167,14 @@ public:
 
 	optional_ptr<Binding> GetBinding(const BindingAlias &alias, ErrorData &out_error);
 
+	optional_ptr<Binding> GetBinding(const BindingAlias &alias, const string &column_name, ErrorData &out_error);
+
+	//! Get all bindings that match a specific binding alias - returns an error if none match
+	vector<reference<Binding>> GetBindings(const BindingAlias &alias, ErrorData &out_error);
+
 private:
 	void AddBinding(unique_ptr<Binding> binding);
+	static string AmbiguityException(const BindingAlias &alias, const vector<reference<Binding>> &bindings);
 
 private:
 	Binder &binder;

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -605,15 +605,7 @@ optional_ptr<Binding> Binder::GetMatchingBinding(const string &catalog_name, con
 		binding = optional_ptr<Binding>(macro_binding.get());
 	} else {
 		BindingAlias alias(catalog_name, schema_name, table_name);
-		binding = bind_context.GetBinding(alias, error);
-	}
-
-	if (!binding) {
-		return nullptr;
-	}
-	if (!binding->HasMatchingBinding(column_name)) {
-		error = binding->ColumnNotFoundError(column_name);
-		return nullptr;
+		binding = bind_context.GetBinding(alias, column_name, error);
 	}
 	return binding;
 }

--- a/test/sql/binder/duplicate_alias.test
+++ b/test/sql/binder/duplicate_alias.test
@@ -1,0 +1,40 @@
+# name: test/sql/binder/duplicate_alias.test
+# description: Duplicate table aliases
+# group: [binder]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table t(i int);
+
+statement ok
+INSERT INTO t VALUES (42);
+
+# this works - since no column is referenced there is no ambiguity
+query I
+SELECT COUNT(*) FROM t, t
+----
+1
+
+# this works - all columns can be uniquely identified - no ambiguity
+query II
+SELECT * FROM (SELECT 42 x) t, (SELECT 84 y) t
+----
+42	84
+
+query II
+SELECT t.x, t.y FROM (SELECT 42 x) t, (SELECT 84 y) t
+----
+42	84
+
+statement error
+SELECT t.z FROM (SELECT 42 x) t, (SELECT 84 y) t
+----
+does not have a column named
+
+# this does not work - "t" is ambiguous
+statement error
+SELECT t.i FROM t, t
+----
+duplicate alias "t"

--- a/test/sql/binder/separate_schema_tables.test
+++ b/test/sql/binder/separate_schema_tables.test
@@ -147,12 +147,12 @@ SELECT * FROM tbl, s1.tbl, s2.tbl, s3.tbl
 1	10	100	1000
 
 statement error
-SELECT tbl.i FROM s1.tbl, s2.tbl
+SELECT tbl.col FROM s1.tbl, s2.tbl
 ----
 s1.tbl or s2.TBL
 
 statement error
-SELECT tbl.i FROM s1.tbl, s2.tbl, s3.tbl
+SELECT tbl.col FROM s1.tbl, s2.tbl, s3.tbl
 ----
 s1.tbl, s2.TBL or s3.Tbl
 

--- a/test/sql/upsert/upsert_aliased.test
+++ b/test/sql/upsert/upsert_aliased.test
@@ -87,4 +87,4 @@ select * from tbl;
 statement error
 insert into tbl as excluded values (8,3) on conflict (j) do update set i = 5;
 ----
-Binder Error: Duplicate alias "excluded" in query!
+Ambiguous reference to table "excluded"


### PR DESCRIPTION
This PR changes the way that we deal with duplicate table aliases in the binder. Previously, we would throw an exception when a duplicate binding was registered - which is the same behavior that Postgres has, i.e.:

```sql
select * from (select 42) t, (select 84) t;
-- Binder Error: Duplicate alias "t" in query!
```

This is not strictly necessary - however. A duplicate alias is only a problem if there is a *conflict*. For example, the following query has no ambiguity, and hence can be safely executed (and SQLite can execute it):

```sql
select count(*) from (select 42) t, (select 84) t;
```

After this PR - we can execute this query. Instead, an error is thrown when there is ambiguity when binding a column. For example, this throws an error:

```sql
select t.x from (select 42 x) t, (select 84 x) t;
-- Binder Error: Ambiguous reference to table "t" (duplicate alias "t", explicitly alias one of the tables using "AS my_alias")
```

But this now works, since there is no ambiguity:

```sql
D select t.x from (select 42 x) t, (select 84 y) t;
┌───────┐
│   x   │
│ int32 │
├───────┤
│    42 │
└───────┘
```


