### PR TITLE
Fix #13934: use CreateSortKeyWithValidity to correctly handle NULL in all calls to arg_max

### DIFF
--- a/src/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/src/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -192,7 +192,7 @@ struct GenericArgMinMaxState {
 
 	static void PrepareData(Vector &by, idx_t count, Vector &extra_state, UnifiedVectorFormat &result) {
 		OrderModifiers modifiers(ORDER_TYPE, OrderByNullType::NULLS_LAST);
-		CreateSortKeyHelpers::CreateSortKey(by, count, modifiers, extra_state);
+		CreateSortKeyHelpers::CreateSortKeyWithValidity(by, extra_state, modifiers, count);
 		extra_state.ToUnifiedFormat(count, result);
 	}
 };

--- a/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
@@ -6,6 +6,9 @@
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/enums/order_type.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/core_functions/create_sort_key.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
@@ -294,11 +294,8 @@ struct MinMaxFallbackValue {
 
 	static void PrepareData(Vector &input, const idx_t count, EXTRA_STATE &extra_state, UnifiedVectorFormat &format) {
 		const OrderModifiers modifiers(OrderType::ASCENDING, OrderByNullType::NULLS_LAST);
-		CreateSortKeyHelpers::CreateSortKey(input, count, modifiers, extra_state);
+		CreateSortKeyHelpers::CreateSortKeyWithValidity(input, extra_state, modifiers, count);
 		input.Flatten(count);
-		extra_state.Flatten(count);
-		// Ensure the validity vectors match, because we want to ignore nulls
-		FlatVector::Validity(extra_state).Initialize(FlatVector::Validity(input));
 		extra_state.ToUnifiedFormat(count, format);
 	}
 };

--- a/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
@@ -3,6 +3,9 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/storage/arena_allocator.hpp"
 #include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/pair.hpp"
+#include "duckdb/common/types/string_type.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "duckdb/common/vector.hpp"
+#include "duckdb/common/common.hpp"
+#include "duckdb/storage/arena_allocator.hpp"
 #include "duckdb/common/algorithm.hpp"
 
 namespace duckdb {

--- a/test/sql/aggregate/aggregates/test_arg_min_max.test
+++ b/test/sql/aggregate/aggregates/test_arg_min_max.test
@@ -193,3 +193,8 @@ FROM employees;
 1030
 
 endloop
+
+query I
+SELECT max_by(c0, c1) FROM (values (1, null)) t(c0,c1);
+----
+NULL


### PR DESCRIPTION
Fixes #13934 