### PR TITLE
fix parquet cardinality when first file is empty

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -853,7 +853,8 @@ public:
 			return file_list_cardinality_estimate;
 		}
 
-		return make_uniq<NodeStatistics>(data.initial_file_cardinality * data.file_list->GetTotalFileCount());
+		return make_uniq<NodeStatistics>(MaxValue(data.initial_file_cardinality, (idx_t)1) *
+		                                 data.file_list->GetTotalFileCount());
 	}
 
 	static idx_t ParquetScanMaxThreads(ClientContext &context, const FunctionData *bind_data) {


### PR DESCRIPTION
Parquet scan func uses the first file for binding data, it will result to 0 `ParquetCardinality` if the 1st file has empty row, which impact performance significantly.

Steps to reproduce:
```
SET threads TO 16;
CREATE or replace VIEW t1 AS ( select * from read_parquet([ 'empty.parquet', 'non-empty.parquet' ], union_by_name=True ));
CREATE or replace VIEW t2 AS ( select * from read_parquet([ 'non-empty.parquet' ], union_by_name=True ));
select * from t1 join t2 on t1.id similar to t2.id;
```