### PR TITLE
Fixup StagedUpload invocation via workflow_call

### DIFF
--- a/.github/workflows/OnTag.yml
+++ b/.github/workflows/OnTag.yml
@@ -19,4 +19,4 @@ jobs:
     uses: ./.github/workflows/StagedUpload.yml
     secrets: inherit
     with:
-      override_git_describe: ${{ inputs.override_git_describe || github.ref_name }}
+      target_git_describe: ${{ inputs.override_git_describe || github.ref_name }}

--- a/.github/workflows/StagedUpload.yml
+++ b/.github/workflows/StagedUpload.yml
@@ -2,7 +2,7 @@ name: Staged Upload
 on:
   workflow_call:
     inputs:
-      override_git_describe:
+      target_git_describe:
         type: string
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This is ever relevant to automatically trigger publication of Github release artifacts on tagging of DuckDB version.