### PR TITLE
Skip polars test in 3.7 due to missing PanicException

### DIFF
--- a/tools/pythonpkg/tests/fast/arrow/test_polars.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_polars.py
@@ -1,5 +1,6 @@
 import duckdb
 import pytest
+import sys
 
 pl = pytest.importorskip("polars")
 arrow = pytest.importorskip("pyarrow")
@@ -66,6 +67,7 @@ class TestPolars(object):
         res = duckdb_cursor.read_json(string).pl()
         assert str(res['entry'][0][0]) == "{'content': {'ManagedSystem': {'test': None}}}"
 
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="Polars PanicException is not supported in earlier versions")
     def test_polars_from_json_error(self, duckdb_cursor):
         from io import StringIO
 


### PR DESCRIPTION
This is only visible in Python 3.7, as shown by recent failures on nightly like https://github.com/duckdb/duckdb/actions/runs/10985700746

CI here is mostly checking the test syntax, more complete tests are here: https://github.com/carlopi/duckdb/actions/runs/10987525598/job/30502510946