### PR TITLE
CIBW_SKIP also musllinux on Python 3.7 or Python 3.8

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -189,7 +189,7 @@ jobs:
     needs: manylinux-extensions-x64
     env:
       CIBW_BUILD: ${{ matrix.python_build}}
-      CIBW_SKIP: '*-musllinux_aarch64'
+      CIBW_SKIP: '*-musllinux_aarch64 cp37-musllinux* cp38-musllinux*'
       CIBW_ARCHS: ${{ matrix.arch == 'aarch64' && 'aarch64' || 'auto64' }}
       CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux }}
       CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: ${{ matrix.manylinux }}


### PR DESCRIPTION
3.8 is end of live, 3.8 close to. This is due to problem connected to https://github.com/numpy/numpy/issues/12016 and https://github.com/pypa/setuptools/issues/3329#issuecomment-1201663383.

Tracked this with @Tishj. Users might still manage to build locally, but we can't reliably build those wheels in CI given requirement on distutils.msvccompiler (on Linux..)