### PR TITLE
fix maximum_threads test inside containers

### DIFF
--- a/test/api/test_threads.cpp
+++ b/test/api/test_threads.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
+#include "duckdb/common/virtual_file_system.hpp"
 
 #include <thread>
 
@@ -60,7 +61,8 @@ TEST_CASE("Test database maximum_threads argument", "[api]") {
 	// FIXME: not yet
 	{
 		DuckDB db(nullptr);
-		REQUIRE(db.NumberOfThreads() == std::thread::hardware_concurrency());
+		auto file_system = make_uniq<VirtualFileSystem>();
+		REQUIRE(db.NumberOfThreads() == DBConfig().GetSystemMaxThreads(*file_system));
 	}
 	// but we can set another value
 	{
@@ -112,8 +114,9 @@ TEST_CASE("Test external threads", "[api]") {
 	REQUIRE(db.NumberOfThreads() == 13);
 
 	con.Query("RESET threads");
-	REQUIRE(config.options.maximum_threads == std::thread::hardware_concurrency());
-	REQUIRE(db.NumberOfThreads() == std::thread::hardware_concurrency());
+	auto file_system = make_uniq<VirtualFileSystem>();
+	REQUIRE(config.options.maximum_threads == DBConfig().GetSystemMaxThreads(*file_system));
+	REQUIRE(db.NumberOfThreads() == DBConfig().GetSystemMaxThreads(*file_system));
 }
 
 #ifdef DUCKDB_NO_THREADS


### PR DESCRIPTION
when running inside container, the cgroup cpu.max is used as maximum_threads