### PR TITLE
Fix: remove is_probe_in_domain

### DIFF
--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -117,10 +117,6 @@ void CheckForPerfectJoinOpt(LogicalComparisonJoin &op, PerfectHashJoinStats &joi
 	if (join_state.build_range > MAX_BUILD_SIZE) {
 		return;
 	}
-	if (NumericStats::Min(stats_build) <= NumericStats::Min(stats_probe) &&
-	    NumericStats::Max(stats_probe) <= NumericStats::Max(stats_build)) {
-		join_state.is_probe_in_domain = true;
-	}
 	join_state.is_build_small = true;
 	return;
 }

--- a/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
+++ b/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
@@ -26,7 +26,6 @@ struct PerfectHashJoinStats {
 	Value probe_max;
 	bool is_build_small = false;
 	bool is_build_dense = false;
-	bool is_probe_in_domain = false;
 	idx_t build_range = 0;
 	idx_t estimated_cardinality = 0;
 };


### PR DESCRIPTION
The is_probe_in_domain field in perfect hashjoin is redundant and invalid and needs to be deleted.

related issue https://github.com/duckdb/duckdb/issues/14085