### PR TITLE
Bump minimum required cmake version

### DIFF
--- a/scripts/append_metadata.cmake
+++ b/scripts/append_metadata.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...3.29)
+cmake_minimum_required(VERSION 3.15...3.29)
 
 # Usage: cmake -DEXTENSION=path/to/extension.duckdb_extension -DPLATFORM_FILE=README.md -DDUCKDB_VERSION=tag1 -DEXTENSION_VERSION=tag2 -P scripts/append_metadata.cmake
 # Currently hardcoded to host up to 8 fields


### PR DESCRIPTION
append_metadata.cmake uses the string(REPEAT) command which was only introduced in cmake 3.15 (https://cmake.org/cmake/help/v3.15/command/string.html)