### PR TITLE
Feature: Use is_probe_in_domain to avoid min max judgment.

### DIFF
--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -238,7 +238,7 @@ void PerfectHashJoinExecutor::TemplatedFillSelectionVectorProbe(Vector &source, 
 	auto min_value = perfect_join_statistics.build_min.GetValueUnsafe<T>();
 	auto max_value = perfect_join_statistics.build_max.GetValueUnsafe<T>();
 
-	auto set_result = [&](idx_t i, idx_t sel_idx, int input_value) {
+	auto set_result = [&](idx_t i, idx_t sel_idx, T input_value) {
 		if (perfect_join_statistics.is_probe_in_domain || (min_value <= input_value && input_value <= max_value)) {
 			auto idx = (idx_t)(input_value - min_value); // subtract min value to get the idx position
 			                                             // check for matches in the build

--- a/src/execution/operator/join/perfect_hash_join_executor.cpp
+++ b/src/execution/operator/join/perfect_hash_join_executor.cpp
@@ -238,7 +238,7 @@ void PerfectHashJoinExecutor::TemplatedFillSelectionVectorProbe(Vector &source, 
 	auto min_value = perfect_join_statistics.build_min.GetValueUnsafe<T>();
 	auto max_value = perfect_join_statistics.build_max.GetValueUnsafe<T>();
 
-	auto set_result = [&](idx_t i, idx_t sel_idx, T input_value) {
+	auto set_result = [&](idx_t i, idx_t &sel_idx, T input_value) {
 		if (perfect_join_statistics.is_probe_in_domain || (min_value <= input_value && input_value <= max_value)) {
 			auto idx = (idx_t)(input_value - min_value); // subtract min value to get the idx position
 			                                             // check for matches in the build

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -117,6 +117,9 @@ void CheckForPerfectJoinOpt(LogicalComparisonJoin &op, PerfectHashJoinStats &joi
 	if (join_state.build_range > MAX_BUILD_SIZE) {
 		return;
 	}
+	if (stats_build->min <= stats_probe->min && stats_probe->max <= stats_build->max) {
+		join_state.is_probe_in_domain = true;
+	}
 	join_state.is_build_small = true;
 	return;
 }

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -117,7 +117,8 @@ void CheckForPerfectJoinOpt(LogicalComparisonJoin &op, PerfectHashJoinStats &joi
 	if (join_state.build_range > MAX_BUILD_SIZE) {
 		return;
 	}
-	if (stats_build->min <= stats_probe->min && stats_probe->max <= stats_build->max) {
+	if (NumericStats::Min(stats_build) <= NumericStats::Min(stats_probe) &&
+	    NumericStats::Max(stats_probe) <= NumericStats::Max(stats_build)) {
 		join_state.is_probe_in_domain = true;
 	}
 	join_state.is_build_small = true;

--- a/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
+++ b/src/include/duckdb/execution/operator/join/perfect_hash_join_executor.hpp
@@ -26,6 +26,7 @@ struct PerfectHashJoinStats {
 	Value probe_max;
 	bool is_build_small = false;
 	bool is_build_dense = false;
+	bool is_probe_in_domain = false;
 	idx_t build_range = 0;
 	idx_t estimated_cardinality = 0;
 };


### PR DESCRIPTION
Perfect hash join has two optimizations:

1. Reduce duplicate code and extract lambda
2. Use the previously redundant field is_probe_in_domain to short-circuit judgment.