### PR TITLE
Fix #14077: correctly reset next pointer when reconstructing new row group segment tree after vacuum

### DIFF
--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -145,6 +145,7 @@ public:
 		}
 		SegmentNode<T> node;
 		segment->index = nodes.size();
+		segment->next = nullptr;
 		node.row_start = segment->start;
 		node.node = std::move(segment);
 		nodes.push_back(std::move(node));

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -958,12 +958,13 @@ bool RowGroupCollection::ScheduleVacuumTasks(CollectionCheckpointState &checkpoi
 //===--------------------------------------------------------------------===//
 unique_ptr<CheckpointTask> RowGroupCollection::GetCheckpointTask(CollectionCheckpointState &checkpoint_state,
                                                                  idx_t segment_idx) {
+	Printer::PrintF("Schedule checkpoint task segment idx %llu", segment_idx);
 	return make_uniq<CheckpointTask>(checkpoint_state, segment_idx);
 }
 
 void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &global_stats) {
-	auto segments = row_groups->MoveSegments();
 	auto l = row_groups->Lock();
+	auto segments = row_groups->MoveSegments(l);
 
 	CollectionCheckpointState checkpoint_state(*this, writer, segments, global_stats);
 

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -958,7 +958,6 @@ bool RowGroupCollection::ScheduleVacuumTasks(CollectionCheckpointState &checkpoi
 //===--------------------------------------------------------------------===//
 unique_ptr<CheckpointTask> RowGroupCollection::GetCheckpointTask(CollectionCheckpointState &checkpoint_state,
                                                                  idx_t segment_idx) {
-	Printer::PrintF("Schedule checkpoint task segment idx %llu", segment_idx);
 	return make_uniq<CheckpointTask>(checkpoint_state, segment_idx);
 }
 

--- a/test/sql/storage/delete/delete_final_row_group.test
+++ b/test/sql/storage/delete/delete_final_row_group.test
@@ -1,0 +1,42 @@
+# name: test/sql/storage/delete/delete_final_row_group.test
+# description: Test deleting the final row groups of a table
+# group: [delete]
+
+load __TEST_DIR__/delete_final_row_group.db
+
+statement ok
+CREATE TABLE integers AS SELECT * FROM range(0, 10000000) t(i);
+
+query I
+DELETE FROM integers WHERE i>=5000000
+----
+5000000
+
+query II
+SELECT COUNT(*), SUM(i) FROM integers
+----
+5000000	12499997500000
+
+
+statement ok
+ALTER TABLE integers ADD COLUMN j INTEGER
+
+query III
+SELECT COUNT(*), SUM(i), SUM(j) FROM integers
+----
+5000000	12499997500000	NULL
+
+statement ok
+UPDATE integers SET j=i+1
+
+query III
+SELECT COUNT(*), SUM(i), SUM(j) FROM integers
+----
+5000000	12499997500000	12500002500000
+
+restart
+
+query III
+SELECT COUNT(*), SUM(i), SUM(j) FROM integers
+----
+5000000	12499997500000	12500002500000

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -507,7 +507,7 @@ void UnzipCommand::ExecuteInternal(ExecuteContext &context) const {
 			break;
 		}
 
-		vfs.Write(*output_file, compressed_buffer.get(), BUFFER_SIZE);
+		vfs.Write(*output_file, compressed_buffer.get(), bytes_read);
 	}
 }
 

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -492,14 +492,6 @@ void UnzipCommand::ExecuteInternal(ExecuteContext &context) const {
 		throw CatalogException("Cannot open the file \"%s\"", input_path);
 	}
 
-	// read the compressed data from the file
-	int64_t file_size = vfs.GetFileSize(*compressed_file_handle);
-	std::unique_ptr<char[]> compressed_buffer(new char[BUFFER_SIZE]);
-	int64_t bytes_read = vfs.Read(*compressed_file_handle, compressed_buffer.get(), BUFFER_SIZE);
-	if (bytes_read < file_size) {
-		throw CatalogException("Cannot read the file \"%s\"", input_path);
-	}
-
 	// output
 	FileOpenFlags out_flags(FileOpenFlags::FILE_FLAGS_FILE_CREATE | FileOpenFlags::FILE_FLAGS_WRITE);
 	auto output_file = vfs.OpenFile(extraction_path, out_flags);
@@ -507,9 +499,15 @@ void UnzipCommand::ExecuteInternal(ExecuteContext &context) const {
 		throw CatalogException("Cannot open the file \"%s\"", extraction_path);
 	}
 
-	int64_t bytes_written = vfs.Write(*output_file, compressed_buffer.get(), BUFFER_SIZE);
-	if (bytes_written < file_size) {
-		throw CatalogException("Cannot write the file \"%s\"", extraction_path);
+	// read the compressed data from the file
+	while (true) {
+		std::unique_ptr<char[]> compressed_buffer(new char[BUFFER_SIZE]);
+		int64_t bytes_read = vfs.Read(*compressed_file_handle, compressed_buffer.get(), BUFFER_SIZE);
+		if (bytes_read == 0) {
+			break;
+		}
+
+		vfs.Write(*output_file, compressed_buffer.get(), BUFFER_SIZE);
 	}
 }
 


### PR DESCRIPTION
Fixes #14077 