### PR TITLE
Format CSV error messages

### DIFF
--- a/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
@@ -41,7 +41,7 @@ void MatchAndReplace(CSVOption<T> &original, CSVOption<T> &sniffed, const string
 		// We verify that the user input matches the sniffed value
 		if (original != sniffed) {
 			error += "CSV Sniffer: Sniffer detected value different than the user input for the " + name;
-			error += " options \n Set: " + original.FormatValue() + " Sniffed: " + sniffed.FormatValue() + "\n";
+			error += " options \n Set: " + original.FormatValue() + ", Sniffed: " + sniffed.FormatValue() + "\n";
 		}
 	} else {
 		// We replace the value of original with the sniffed value
@@ -228,8 +228,8 @@ SnifferResult CSVSniffer::SniffCSV(bool force_match) {
 			if (set_names.size() == names.size()) {
 				for (idx_t i = 0; i < set_columns.Size(); i++) {
 					if (set_names[i] != names[i]) {
-						header_error += "Column at position: " + to_string(i) + " Set name: " + set_names[i] +
-						                " Sniffed Name: " + names[i] + "\n";
+						header_error += "Column at position: " + to_string(i) + ", Set name: " + set_names[i] +
+						                ", Sniffed Name: " + names[i] + "\n";
 						match = false;
 					}
 				}

--- a/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/header_detection.cpp
@@ -114,9 +114,9 @@ bool CSVSniffer::DetectHeaderWithSetColumn(ClientContext &context, vector<Header
 			return false;
 		}
 		if (best_header_row[i].value != (*set_columns.names)[i]) {
-			error << "Header Mismatch at position:" << i << "\n";
-			error << "Expected Name: \"" << (*set_columns.names)[i] << "\".";
-			error << "Actual Name: \"" << best_header_row[i].value << "\"."
+			error << "Header mismatch at position: " << i << "\n";
+			error << "Expected name: \"" << (*set_columns.names)[i] << "\", ";
+			error << "Actual name: \"" << best_header_row[i].value << "\"."
 			      << "\n";
 			has_header = false;
 			break;

--- a/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_reader_options.cpp
@@ -404,7 +404,7 @@ string CSVReaderOptions::ToString(const string &current_file_path) const {
 	auto &skip_rows = dialect_options.skip_rows;
 
 	auto &header = dialect_options.header;
-	string error = "  file=" + current_file_path + "\n  ";
+	string error = "  file = " + current_file_path + "\n  ";
 	// Let's first print options that can either be set by the user or by the sniffer
 	// delimiter
 	error += FormatOptionLine("delimiter", delimiter);
@@ -427,13 +427,13 @@ string CSVReaderOptions::ToString(const string &current_file_path) const {
 
 	// Now we do options that can only be set by the user, that might hold some general significance
 	// null padding
-	error += "null_padding=" + std::to_string(null_padding) + "\n  ";
+	error += "null_padding = " + std::to_string(null_padding) + "\n  ";
 	// sample_size
-	error += "sample_size=" + std::to_string(sample_size_chunks * STANDARD_VECTOR_SIZE) + "\n  ";
+	error += "sample_size = " + std::to_string(sample_size_chunks * STANDARD_VECTOR_SIZE) + "\n  ";
 	// ignore_errors
-	error += "ignore_errors=" + ignore_errors.FormatValue() + "\n  ";
+	error += "ignore_errors = " + ignore_errors.FormatValue() + "\n  ";
 	// all_varchar
-	error += "all_varchar=" + std::to_string(all_varchar) + "\n";
+	error += "all_varchar = " + std::to_string(all_varchar) + "\n";
 
 	// Add information regarding sniffer mismatches (if any)
 	error += sniffer_user_mismatch_error;


### PR DESCRIPTION
Add some spaces and other seperators.

I spotted in the docs that the formatting of the sniffer's error messages is inconsistent, see https://duckdb.org/docs/data/csv/reading_faulty_csv_files#anatomy-of-a-csv-error

```
  file= people.csv
  delimiter = , (Auto-Detected)
  quote = " (Auto-Detected)
  escape = " (Auto-Detected)
  new_line = \r\n (Auto-Detected)
  header = true (Auto-Detected)
  skip_rows = 0 (Auto-Detected)
  date_format = (DD-MM-YYYY) (Auto-Detected)
  timestamp_format =  (Auto-Detected)
  null_padding=0
  sample_size=20480
  ignore_errors=false
  all_varchar=0
```

This PR adds a bunch of whitespace and also other separators for similar error messages.