### PR TITLE
CREATE TABLE now supports columns with `ENUM[]` types.

### DIFF
--- a/src/include/duckdb/parser/transformer.hpp
+++ b/src/include/duckdb/parser/transformer.hpp
@@ -323,6 +323,8 @@ private:
 	//! Transform a range var into a (schema) qualified name
 	QualifiedName TransformQualifiedName(duckdb_libpgquery::PGRangeVar &root);
 
+	//! Transform a Postgres TypeName string into a LogicalType (non-LIST types)
+	LogicalType TransformTypeNameInternal(duckdb_libpgquery::PGTypeName &name);
 	//! Transform a Postgres TypeName string into a LogicalType
 	LogicalType TransformTypeName(duckdb_libpgquery::PGTypeName &name);
 

--- a/test/sql/create/create_table_with_arraybounds.test
+++ b/test/sql/create/create_table_with_arraybounds.test
@@ -1,0 +1,44 @@
+# name: test/sql/create/create_table_with_arraybounds.test
+# group: [create]
+
+# Create a table with an ENUM[] type
+statement ok
+create table T (
+	vis enum ('hide', 'visible')[]
+);
+
+query I
+select column_type from (describe T);
+----
+ENUM('hide', 'visible')[]
+
+statement ok
+attach ':memory:' as db2;
+
+statement ok
+create schema schema2;
+
+statement ok
+create schema db2.schema3;
+
+statement ok
+create type schema2.foo as VARCHAR;
+
+statement ok
+create type db2.schema3.bar as BOOL;
+
+# Create a table with a USER[] type qualified with a schema
+statement error
+create table B (
+	vis schema2.foo[]
+);
+----
+syntax error at or near
+
+# Create a table with a USER[] type qualified with a schema and a catalog
+statement error
+create table B (
+	vis db2.schema3.bar[]
+);
+----
+syntax error at or near

--- a/test/sql/create/create_table_with_arraybounds.test
+++ b/test/sql/create/create_table_with_arraybounds.test
@@ -1,6 +1,8 @@
 # name: test/sql/create/create_table_with_arraybounds.test
 # group: [create]
 
+require noforcestorage
+
 # Create a table with an ENUM[] type
 statement ok
 create table T (


### PR DESCRIPTION
This PR fixes #14099 

I also noticed that `catalog.schema.user_type` and `schema.user_type` don't support this, and attempted to fix this here directly, but the issue appears to be at the parser level so for now I've just added a test so we're aware of this limitation.

I created another method to deal with all of the base_type logic, letting the arrayBounds be processed in the outer layer, removing a bunch of if/else chains and cleaning up the code because of that.