### PR TITLE
Fix regex_string_split to handle empty string characters

### DIFF
--- a/src/core_functions/scalar/string/string_split.cpp
+++ b/src/core_functions/scalar/string/string_split.cpp
@@ -1,3 +1,6 @@
+#include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/core_functions/scalar/string_functions.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/function/scalar/regexp.hpp"
 #include "duckdb/common/re2_regex.hpp"
 

--- a/src/core_functions/scalar/string/string_split.cpp
+++ b/src/core_functions/scalar/string/string_split.cpp
@@ -87,11 +87,15 @@ struct ConstantRegexpStringSplit {
 
 		idx_t list_idx = 0;
 		idx_t current_offset = 0;
+#ifndef NDEBUG
 		auto num_of_matches = matches.size();
+#endif
 		for (auto &m : matches) {
 			// if match's length == 0 and its position is at the beginning or the end of the entry, skip it
 			if (!m.length(0) && (m.position(0) == 0 || m.position(0) == input_size)) {
+#ifndef NDEBUG
 				num_of_matches--;
+#endif
 				continue;
 			}
 			D_ASSERT(current_offset <= input_size);

--- a/test/sql/function/list/list_reverse.test
+++ b/test/sql/function/list/list_reverse.test
@@ -139,7 +139,7 @@ statement ok
 INSERT INTO palindromes VALUES ('racecar'), ('civic'), ('defied'), ('repaper'), ('kayak'), ('rotator'), ('tattarrattat'), ('saippuakivikauppias'), ('malayalam');
 
 query I
-SELECT list_aggr(${f}(str_split(s, '')), 'string_agg', '') FROM palindromes ORDER BY s;
+SELECT list_aggr(${f}(string_split_regex(s, '')), 'string_agg', '') FROM palindromes ORDER BY s;
 ----
 civic
 deifed

--- a/test/sql/function/string/regexp_split_to_table.test
+++ b/test/sql/function/string/regexp_split_to_table.test
@@ -28,3 +28,4 @@ SELECT regexp_split_to_table('axbyc', '[x|y]'), 42
 a	42
 b	42
 c	42
+

--- a/test/sql/function/string/test_split_part.test
+++ b/test/sql/function/string/test_split_part.test
@@ -63,7 +63,17 @@ select split_part('','',1)
 query T
 select split_part('a,b,c','',3)
 ----
-b
+(empty)
+
+query T
+select split_part('abc','',1)
+----
+abc
+
+query T
+select split_part('abc','',2)
+----
+(empty)
 
 query T
 select split_part('',',',1)

--- a/test/sql/function/string/test_string_split.test
+++ b/test/sql/function/string/test_string_split.test
@@ -124,6 +124,11 @@ SELECT UNNEST(string_split('', 'delim'))
 (empty)
 
 query T
+SELECT UNNEST(string_split('🦆🦆🦆🦆🦆', NULL))
+----
+🦆🦆🦆🦆🦆
+
+query T
 SELECT UNNEST(string_split('🦆🦆🦆🦆🦆', ''))
 ----
 🦆🦆🦆🦆🦆
@@ -416,6 +421,32 @@ SELECT UNNEST(string_split_regex('ab cd', '\b(\w+)\b'));
 (empty)
  
 (empty)
+
+query T
+SELECT UNNEST(string_split_regex('ab cd', '$'));
+----
+ab cd
+
+query T
+SELECT UNNEST(string_split_regex('ab cd', '^'));
+----
+ab cd
+
+query T
+select UNNEST(string_split_regex('ab cd', ' '));
+----
+ab
+cd
+
+query T
+SELECT UNNEST(string_split_regex('ab cd', '^\b'));
+----
+ab cd
+
+query T
+SELECT UNNEST(string_split_regex('ab cd', '^$'));
+----
+ab cd
 
 # \z matches empty string at end of text
 query T

--- a/test/sql/function/string/test_string_split.test
+++ b/test/sql/function/string/test_string_split.test
@@ -5,17 +5,54 @@
 statement ok
 PRAGMA enable_verification
 
-# test unnesting of null values a bit
 query T
-SELECT string_split(NULL, NULL)
+select string_split('babcb', 'b');
 ----
-NULL
+[, a, c, ]
 
 query T
-SELECT * FROM (VALUES (string_split('hello world', ' ')), (string_split(NULL, ' ')), (string_split('a b c', NULL)), (string_split('a b c', ' '))) tbl(i)
+select UNNEST(string_split('abc', ','))
+----
+abc
+
+query T
+select UNNEST(string_split('1,2,3,4,,6', ','))
+----
+1
+2
+3
+4
+(empty)
+6
+
+query T
+select UNNEST(string_split('1|2|3', '|'))
+----
+1
+2
+3
+
+query T
+select UNNEST(string_split('1|2|3|', '|'))
+----
+1
+2
+3
+(empty)
+
+query T
+select UNNEST(string_split('1||2|3||', '||'))
+----
+1
+2|3
+(empty)
+
+query T
+SELECT * FROM (VALUES (string_split('hello world', ' ')), (string_split(NULL, ' ')), (string_split('', ' ')), (string_split('a b c', NULL)), (string_split('a b c', ' '))) tbl(i)
 ----
 [hello, world]
 NULL
+[]
 [a b c]
 [a, b, c]
 
@@ -45,16 +82,6 @@ SELECT UNNEST(string_split('üüüüü', '◌̈'))
 
 query T
 SELECT UNNEST(string_split('üüüüü', '◌'))
-----
-üüüüü
-
-query T
-SELECT UNNEST(string_split_regex('üüüüü', '◌̈'))
-----
-üüüüü
-
-query T
-SELECT UNNEST(string_split_regex('üüüüü', '◌'))
 ----
 üüüüü
 
@@ -97,29 +124,9 @@ SELECT UNNEST(string_split('', 'delim'))
 (empty)
 
 query T
-SELECT UNNEST(string_split('aaaaa', ''))
-----
-a
-a
-a
-a
-a
-
-query T
 SELECT UNNEST(string_split('🦆🦆🦆🦆🦆', ''))
 ----
-🦆
-🦆
-🦆
-🦆
-🦆
-
-query T
-SELECT UNNEST(string_split('abab', 'b'))
-----
-a
-a
-(empty)
+🦆🦆🦆🦆🦆
 
 query T
 SELECT UNNEST(string_split('🦆b🦆b', 'b'))
@@ -166,73 +173,32 @@ b🦆🦆bb🦆🦆
 🦆🦆bb🦆🦆b
 🦆b🦆b🦆b🦆b🦆
 
+# empty string delimeter
 query T
-SELECT UNNEST(string_split_regex('a1a11a111a', '[0-9]+'))
+SELECT UNNEST(string_split('abcde', ''))
 ----
-a
-a
-a
-a
+abcde
+
+# test unnesting of null values a bit
+query T
+SELECT string_split(NULL, NULL)
+----
+NULL
 
 query T
-SELECT UNNEST(string_split_regex('aaaaa', ''))
+SELECT string_split('', NULL)
 ----
-a
-a
-a
-a
-a
-
+[]
 
 query T
-SELECT UNNEST(string_split_regex('a a  a   a', '\s+'))
+SELECT string_split(NULL, '')
 ----
-a
-a
-a
-a
+NULL
 
 query T
-SELECT UNNEST(string_split('aaaaa', NULL))
+SELECT string_split('', NULL)
 ----
-aaaaa
-
-# taken from postgres string_to_array tests
-query T
-select UNNEST(string_split('1|2|3', '|'))
-----
-1
-2
-3
-
-query T
-select UNNEST(string_split('1|2|3|', '|'))
-----
-1
-2
-3
-(empty)
-
-query T
-select UNNEST(string_split('1||2|3||', '||'))
-----
-1
-2|3
-(empty)
-
-query T
-select UNNEST(string_split('1|2|3', ''))
-----
-1
-|
-2
-|
-3
-
-query T
-select UNNEST(string_split('', '|'))
-----
-(empty)
+[]
 
 query T
 select UNNEST(string_split('1|2|3', NULL))
@@ -245,11 +211,268 @@ select string_split(NULL, '|') IS NULL
 1
 
 query T
-select UNNEST(string_split('abc', ''))
+SELECT string_split('', '')
+----
+[]
+
+# test incorrect usage
+statement error
+select string_split()
+----
+
+statement error
+select string_split('a')
+----
+
+
+# regexp string split
+query T
+select string_split_regex('babcb', 'b');
+----
+[, a, c, ]
+
+query T
+select UNNEST(string_split_regex('abcd', '(b)'));
+----
+a
+cd
+
+query T
+SELECT string_split_regex('a a a a a', ' ')
+----
+[a, a, a, a, a]
+
+query T
+SELECT UNNEST(string_split_regex('a1a11a111a', '[0-9]+'))
+----
+a
+a
+a
+a
+
+query T
+select UNNEST(string_split_regex('a1b', '\d'))
 ----
 a
 b
-c
+
+query T
+select UNNEST(string_split_regex('a1b', '\\d'))
+----
+a1b
+
+query T
+select UNNEST(string_split_regex('a1b', '(\d)'))
+----
+a
+b
+
+query T
+select UNNEST(string_split_regex('a1b', e'\d'))
+----
+a1b
+
+query T
+select UNNEST(string_split_regex('xyz', '[x]'))
+----
+(empty)
+yz
+
+query T
+select UNNEST(string_split_regex('wΩν', '[^\p{Greek}]'))
+----
+(empty)
+Ων
+
+query T
+select UNNEST(string_split_regex('1|2|3', '|'))
+----
+1
+|
+2
+|
+3
+
+query T
+SELECT UNNEST(string_split_regex('üüüüü', '◌̈'))
+----
+üüüüü
+
+query T
+SELECT UNNEST(string_split_regex('üüüüü', '◌'))
+----
+üüüüü
+
+# empty string regex patterns
+query T
+SELECT string_split_regex('a', '')
+----
+[a]
+
+query T
+SELECT string_split_regex('abc', '')
+----
+[a, b, c]
+
+
+query T
+SELECT string_split_regex('abc', '^a|^ab')
+----
+[, bc]
+
+
+query T
+SELECT UNNEST(string_split_regex('🦆', ''))
+----
+🦆
+
+query T
+SELECT UNNEST(string_split_regex('🦆🦆🦆🦆🦆', ''))
+----
+🦆
+🦆
+🦆
+🦆
+🦆
+
+query T
+SELECT string_split_regex('∯', '')
+----
+[∯]
+
+# ^ matches empty string at beginning of text
+query T
+SELECT string_split_regex('ab', '^\w')
+----
+[, b]
+
+query T
+SELECT string_split_regex('ab', '^')
+----
+[ab]
+
+# $ matches empty string at end of text (like \z not \Z)
+query T
+SELECT string_split_regex('ab', '\w$')
+----
+[a, ]
+
+query T
+SELECT string_split_regex('ab', '$')
+----
+[ab]
+
+# \A  matches at beginning of text
+query T
+SELECT UNNEST(string_split_regex('ab cd', '\A\w'))
+----
+(empty)
+b cd
+
+query T
+SELECT UNNEST(string_split_regex('ab cd', '\A'))
+----
+ab cd
+
+# \b matches ASCII word boundary
+query T
+select string_split_regex('ab cd', '\b');
+----
+[ab,  , cd]
+
+query T
+select UNNEST(string_split_regex('ab cd', '\\b'));
+----
+ab cd
+
+# \B matches not at ASCII word boundary
+query T
+SELECT UNNEST(string_split_regex('ab cd', '\B'))
+----
+a
+b c
+d
+
+query T
+select string_split_regex('\bhello\b', '\b');
+----
+[\, bhello, \, b]
+
+query T
+select string_split('\bhello\b', '\b');
+----
+[, hello, ]
+
+query T
+select UNNEST(string_split_regex('\bhello\b', '\\b'));
+----
+(empty)
+hello
+(empty)
+
+query T
+SELECT UNNEST(string_split_regex('ab cd', '\b(\w+)\b'));
+----
+(empty)
+ 
+(empty)
+
+# \z matches empty string at end of text
+query T
+SELECT UNNEST(string_split_regex('aaa', '\w\z'))
+----
+aa
+(empty)
+
+query T
+SELECT UNNEST(string_split_regex('aaaaa', '\z'))
+----
+aaaaa
+
+# \y - (not supported)
+statement error
+select UNNEST(string_split_regex('ab cd', '\y'));
+----
+Invalid Input Error: invalid escape sequence: \y
+
+# \Z - (not supported)
+statement error
+SELECT UNNEST(string_split_regex('aaaaa', '\Z'))
+----
+Invalid Input Error: invalid escape sequence: \Z
+
+# \g - (not supported)
+statement error
+SELECT UNNEST(string_split_regex('ab cd', '\g'))
+----
+Invalid Input Error: invalid escape sequence: \g
+
+# \G - (not supported)
+statement error
+SELECT UNNEST(string_split_regex('ab cd', '\G'))
+----
+Invalid Input Error: invalid escape sequence: \G
+
+query T
+SELECT UNNEST(string_split_regex('🦆a🦆a', 'a'))
+----
+🦆
+🦆
+(empty)
+
+query T
+SELECT UNNEST(string_split_regex('🦆', '🦆'))
+----
+(empty)
+(empty)
+
+query T
+SELECT UNNEST(string_split_regex('a a  a   a', '\s+'))
+----
+a
+a
+a
+a
 
 query T
 select UNNEST(string_split_regex('abc', '(|abc)'))
@@ -265,11 +488,6 @@ select UNNEST(string_split_regex('abc', '(abc|)'))
 (empty)
 
 query T
-select UNNEST(string_split('abc', ','))
-----
-abc
-
-query T
 select UNNEST(string_split_regex('abc', '(,|abc)'))
 ----
 (empty)
@@ -280,16 +498,6 @@ select UNNEST(string_split_regex('abc', '(abc|,)'))
 ----
 (empty)
 (empty)
-
-query T
-select UNNEST(string_split('1,2,3,4,,6', ','))
-----
-1
-2
-3
-4
-(empty)
-6
 
 query T
 select UNNEST(string_split_regex('1,2,3,4,,6', '(,|)'))
@@ -304,7 +512,6 @@ select UNNEST(string_split_regex('1,2,3,4,,6', '(,|)'))
 (empty)
 (empty)
 6
-
 
 query T
 select UNNEST(string_split_regex('1,2,3,4,,6', '(|,)'))
@@ -342,16 +549,12 @@ select UNNEST(string_split_regex('1,2,3,4,*,6', '(\*|,)'))
 (empty)
 6
 
-# test incorrect usage
-statement error
-select string_split()
+query T
+SELECT UNNEST(string_split_regex('', ''))
 ----
+(empty)
 
-statement error
-select string_split('a')
-----
-
-# incorrect regex
+# test incorrect regex
 statement error
 SELECT string_split_regex(a, '[') FROM test ORDER BY a;
 ----

--- a/test/sql/function/string/test_string_split.test
+++ b/test/sql/function/string/test_string_split.test
@@ -310,9 +310,9 @@ SELECT string_split_regex('a', '')
 [a]
 
 query T
-SELECT string_split_regex('abc', '')
+SELECT string_split_regex('abcde', '')
 ----
-[a, b, c]
+[a, b, c, d, e]
 
 
 query T

--- a/test/sql/storage/compression/string/big_strings.test
+++ b/test/sql/storage/compression/string/big_strings.test
@@ -32,7 +32,7 @@ statement ok
 checkpoint
 
 query III
-SELECT list_aggr(str_split(a,''),'min'), list_aggr(str_split(a,''),'min'), strlen(a)  from normal_string
+SELECT list_aggr(string_split_regex(a,''),'min'), list_aggr(string_split_regex(a,''),'min'), strlen(a)  from normal_string
 ----
 a	a	3900
 b	b	3900
@@ -61,7 +61,7 @@ statement ok
 checkpoint
 
 query III
-SELECT list_aggr(str_split(a,''),'min'), list_aggr(str_split(a,''),'min'), strlen(a)  from big_string
+SELECT list_aggr(string_split_regex(a,''),'min'), list_aggr(string_split_regex(a,''),'min'), strlen(a)  from big_string
 ----
 a	a	8000
 b	b	8000


### PR DESCRIPTION
This PR, in combination with PR #13108, resolves bug #10811 by updating the `regex_string_split` function to handle empty string characters correctly. New test cases have also been added.

Previously, the `Split` function was incorrectly matching individual characters when using boundary markers like `\b` by continuing the search from the remaining portion of the input string after each match. For that, an offset mechanism has been introduced, allowing the function to search for matches without modifying the input string.

**Note**: A new check has been added to determine if the delimiter matches an empty string or a word boundary before starting the split process. If the delimiter is an empty string char, the function will first find all matches and then split the string at each match. This check ensures that the additional functionality is only triggered when needed, preventing unnecessary overhead for other delimiters.