### PR TITLE
Iterate over py::list objects by value instead of by reference.

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -115,11 +115,59 @@ jobs:
         # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
         cibuildwheel --output-dir wheelhouse --config-file pyproject.toml duckdb_tarball
 
+   linux-pypy3-10:
+    name: PyPy 3.10 Linux
+    runs-on: ubuntu-20.04
+    needs: linux-python3-9
+
+    env:
+      CIBW_BUILD: 'pp310-manylinux_x86_64'
+      CIBW_TEST_SKIP: 'pp310-*'
+      PYTEST_TIMEOUT: '600'
+      CIBW_ENVIRONMENT: 'OVERRIDE_GIT_DESCRIBE=${{ inputs.override_git_describe }}'
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 'pypy-3.10'
+
+    - name: Install
+      shell: bash
+      run: pip install 'cibuildwheel>=2.16.2' build
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
+    - name: Build source dist
+      shell: bash
+      working-directory: tools/pythonpkg
+      run: |
+        pyproject-build . --sdist
+        mkdir duckdb_tarball && tar xvf dist/duckdb-*.tar.gz --strip-components=1 -C duckdb_tarball
+
+    - name: Build
+      shell: bash
+      working-directory: tools/pythonpkg
+      run: |
+        export DISTUTILS_C_COMPILER_LAUNCHER=ccache
+        # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
+        cibuildwheel --output-dir wheelhouse --config-file pyproject.toml duckdb_tarball
+
    manylinux-extensions-x64:
     name: Linux Extensions (linux_amd64_gcc4)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
-    needs: linux-python3-9
+    needs:
+      - linux-python3-9
+      - linux-pypy3-10
     env:
       GEN: ninja
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/tools/pythonpkg/src/dataframe.cpp
+++ b/tools/pythonpkg/src/dataframe.cpp
@@ -38,7 +38,7 @@ bool PandasDataFrame::IsPyArrowBacked(const py::handle &df) {
 	}
 
 	auto arrow_dtype = import_cache.pandas.ArrowDtype();
-	for (auto &dtype : dtypes) {
+	for (auto dtype : dtypes) {
 		if (py::isinstance(dtype, arrow_dtype)) {
 			return true;
 		}

--- a/tools/pythonpkg/src/path_like.cpp
+++ b/tools/pythonpkg/src/path_like.cpp
@@ -84,7 +84,7 @@ PathLike PathLike::Create(const py::object &object, DuckDBPyConnection &connecti
 	PathLikeProcessor processor(connection, import_cache);
 	if (py::isinstance<py::list>(object)) {
 		auto list = py::list(object);
-		for (auto &item : list) {
+		for (auto item : list) {
 			processor.AddFile(py::reinterpret_borrow<py::object>(item));
 		}
 	} else {

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -446,7 +446,7 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::ExecuteMany(const py::object 
 
 	unique_ptr<QueryResult> query_result;
 	// Execute once for every set of parameters that are provided
-	for (auto &parameters : outer_list) {
+	for (auto parameters : outer_list) {
 		auto params = py::reinterpret_borrow<py::object>(parameters);
 		query_result = ExecuteInternal(*prep, std::move(params));
 	}
@@ -1119,7 +1119,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(const py::object &name_
 		} else if (py::is_list_like(dtype)) {
 			vector<Value> list_values;
 			py::list dtype_list = dtype;
-			for (auto &child : dtype_list) {
+			for (auto child : dtype_list) {
 				shared_ptr<DuckDBPyType> sql_type;
 				if (!py::try_cast(child, sql_type)) {
 					throw py::value_error("The types provided to 'dtype' have to be DuckDBPyType");
@@ -1149,7 +1149,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(const py::object &name_
 		}
 		vector<Value> names;
 		py::list names_list = names_p;
-		for (auto &elem : names_list) {
+		for (auto elem : names_list) {
 			if (!py::isinstance<py::str>(elem)) {
 				throw InvalidInputException("read_csv 'names' list has to consist of only strings");
 			}
@@ -1166,7 +1166,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadCSV(const py::object &name_
 			null_values.push_back(Value(py::str(na_values)));
 		} else {
 			py::list null_list = na_values;
-			for (auto &elem : null_list) {
+			for (auto elem : null_list) {
 				if (!py::isinstance<py::str>(elem)) {
 					throw InvalidInputException("read_csv 'na_values' list has to consist of only strings");
 				}

--- a/tools/pythonpkg/src/pyconnection/type_creation.cpp
+++ b/tools/pythonpkg/src/pyconnection/type_creation.cpp
@@ -23,7 +23,7 @@ static child_list_t<LogicalType> GetChildList(const py::object &container) {
 	if (py::isinstance<py::list>(container)) {
 		const py::list &fields = container;
 		idx_t i = 1;
-		for (auto &item : fields) {
+		for (auto item : fields) {
 			shared_ptr<DuckDBPyType> pytype;
 			if (!py::try_cast<shared_ptr<DuckDBPyType>>(item, pytype)) {
 				string actual_type = py::str(item.get_type());

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -121,7 +121,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::ProjectFromTypes(const py::object
 	auto list = py::list(obj);
 	vector<LogicalType> types_filter;
 	// Collect the list of types specified that will be our filter
-	for (auto &item : list) {
+	for (auto item : list) {
 		LogicalType type;
 		if (py::isinstance<py::str>(item)) {
 			string type_str = py::str(item);
@@ -231,7 +231,7 @@ vector<unique_ptr<ParsedExpression>> GetExpressions(ClientContext &context, cons
 	if (py::is_list_like(expr)) {
 		vector<unique_ptr<ParsedExpression>> expressions;
 		auto aggregate_list = py::list(expr);
-		for (auto &item : aggregate_list) {
+		for (auto item : aggregate_list) {
 			shared_ptr<DuckDBPyExpression> py_expr;
 			if (!py::try_cast<shared_ptr<DuckDBPyExpression>>(item, py_expr)) {
 				throw InvalidInputException("Please provide arguments of type Expression!");
@@ -1301,7 +1301,7 @@ void DuckDBPyRelation::ToCSV(const string &filename, const py::object &sep, cons
 		}
 		vector<Value> partition_by_values;
 		const py::list &partition_fields = partition_by;
-		for (auto &field : partition_fields) {
+		for (auto field : partition_fields) {
 			if (!py::isinstance<py::str>(field)) {
 				throw InvalidInputException("to_csv only accepts 'partition_by' as a list of strings");
 			}

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -425,7 +425,7 @@ public:
 			}
 		}
 		idx_t i = 0;
-		for (auto &param : params) {
+		for (auto param : params) {
 			auto type = py::cast<shared_ptr<DuckDBPyType>>(param);
 			parameters[i++] = type->Type();
 		}

--- a/tools/pythonpkg/src/typing/pytype.cpp
+++ b/tools/pythonpkg/src/typing/pytype.cpp
@@ -195,7 +195,7 @@ static bool IsMapType(const py::tuple &args) {
 	if (args.size() != 2) {
 		return false;
 	}
-	for (auto &arg : args) {
+	for (auto arg : args) {
 		if (GetTypeObjectType(arg) == PythonTypeObject::INVALID) {
 			return false;
 		}


### PR DESCRIPTION
`py::list` iterator has two implementations depending if pybind11 is compiled for cpython or pypy. For cpython the iterator returns essentially `PyObject*`, so taking a reference is not needed. For pypy, returned object is a temporary, so it requires that iteration happens by value instead of reference. Currently it's the only problem for building duckdb for pypy.

