### PR TITLE
Avoid schema changes with IF NOT EXISTS

### DIFF
--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -122,10 +122,6 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::AddEntryInternal(CatalogTransaction 
 	if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
 		auto old_entry = set.GetEntry(transaction, entry_name);
 		if (old_entry) {
-			if (old_entry->type != entry_type) {
-				throw CatalogException("Existing object %s is of type %s, trying to replace with type %s", entry_name,
-				                       CatalogTypeToString(old_entry->type), CatalogTypeToString(entry_type));
-			}
 			return nullptr;
 		}
 	}
@@ -326,7 +322,7 @@ void DuckSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 		throw InternalException("Failed to drop entry \"%s\" - entry could not be found", info.name);
 	}
 	if (existing_entry->type != info.type) {
-		throw CatalogException("Existing object %s is of type %s, trying to replace with type %s", info.name,
+		throw CatalogException("Existing object %s is of type %s, trying to drop type %s", info.name,
 		                       CatalogTypeToString(existing_entry->type), CatalogTypeToString(info.type));
 	}
 

--- a/test/catalog/test_catalog_version.cpp
+++ b/test/catalog/test_catalog_version.cpp
@@ -44,6 +44,29 @@ TEST_CASE("Test catalog versioning", "[catalog]") {
 		REQUIRE(catalog.GetCatalogVersion(*con1.context) == 2);
 	});
 
+	// The following should not increment the version
+	REQUIRE_NO_FAIL(con1.Query("CREATE TABLE IF NOT EXISTS foo3 as SELECT 42"));
+
+	con1.context->RunFunctionInTransaction([&]() {
+		auto &catalog = Catalog::GetCatalog(*con1.context, "");
+		REQUIRE(catalog.GetCatalogVersion(*con1.context) == 2);
+	});
+
+	REQUIRE_NO_FAIL(con1.Query("CREATE SCHEMA IF NOT EXISTS my_schema"));
+
+	con1.context->RunFunctionInTransaction([&]() {
+		auto &catalog = Catalog::GetCatalog(*con1.context, "");
+		REQUIRE(catalog.GetCatalogVersion(*con1.context) == 3);
+	});
+
+	// The following should not increment the version
+	REQUIRE_NO_FAIL(con1.Query("CREATE SCHEMA IF NOT EXISTS my_schema"));
+
+	con1.context->RunFunctionInTransaction([&]() {
+		auto &catalog = Catalog::GetCatalog(*con1.context, "");
+		REQUIRE(catalog.GetCatalogVersion(*con1.context) == 3);
+	});
+
 	// check catalog version of system catalog
 	con1.context->RunFunctionInTransaction([&]() {
 		auto &catalog = Catalog::GetCatalog(*con1.context, "system");

--- a/test/sql/catalog/test_if_not_exists.test
+++ b/test/sql/catalog/test_if_not_exists.test
@@ -14,15 +14,14 @@ CREATE TABLE IF NOT EXISTS integers2 AS SELECT 42
 statement ok
 CREATE TABLE IF NOT EXISTS integers2 AS SELECT 42
 
-statement error
+# similar to Postgres, treat as NOOP if the entry exists but the type is different
+statement ok
 CREATE VIEW IF NOT EXISTS integers2 AS SELECT 42
-----
-Existing object integers2 is of type Table, trying to replace with type View
 
 statement error
 DROP VIEW IF EXISTS integers
 ----
-Existing object integers is of type Table, trying to replace with type View
+Catalog Error: Existing object integers is of type Table, trying to drop type View
 
 statement ok
 DROP TABLE IF EXISTS integers

--- a/test/sql/catalog/test_if_not_exists.test
+++ b/test/sql/catalog/test_if_not_exists.test
@@ -14,6 +14,16 @@ CREATE TABLE IF NOT EXISTS integers2 AS SELECT 42
 statement ok
 CREATE TABLE IF NOT EXISTS integers2 AS SELECT 42
 
+statement error
+CREATE VIEW IF NOT EXISTS integers2 AS SELECT 42
+----
+Existing object integers2 is of type Table, trying to replace with type View
+
+statement error
+DROP VIEW IF EXISTS integers
+----
+Existing object integers is of type Table, trying to replace with type View
+
 statement ok
 DROP TABLE IF EXISTS integers
 

--- a/test/sql/create/create_or_replace.test
+++ b/test/sql/create/create_or_replace.test
@@ -12,6 +12,14 @@ statement ok
 CREATE OR REPLACE TABLE integers(i INTEGER, j INTEGER)
 
 statement ok
+CREATE VIEW integers2 AS SELECT 42
+
+statement error
+CREATE OR REPLACE TABLE integers2(i INTEGER)
+----
+Catalog Error: integers2 is not an table
+
+statement ok
 CREATE TABLE IF NOT EXISTS integers(i INTEGER)
 
 statement ok


### PR DESCRIPTION
We've noticed that repeated calls of `CREATE TABLE IF NOT EXISTS` for the same table were causing catalog versions to go up (causing rebinds for other queries). As ORMs are frequently using this pattern to ensure that a table / schema exists before inserting data (i.e. packaging the CREATE TABLE IF NOT EXISTS into the same TX as the INSERT statement), this led to rebinds happening all the time.