### PR TITLE
Issue 14151: Fix conflicting defines on Windows hidden by cmake unity builds

### DIFF
--- a/extension/icu/third_party/icu/common/putil.cpp
+++ b/extension/icu/third_party/icu/common/putil.cpp
@@ -46,11 +46,6 @@
 // First, the platform type. Need this for U_PLATFORM.
 #include "unicode/platform.h"
 
-#if U_PLATFORM == U_PF_MINGW && defined __STRICT_ANSI__
-/* tzset isn't defined in strict ANSI on MinGW. */
-#undef __STRICT_ANSI__
-#endif
-
 /*
  * Cygwin with GCC requires inclusion of time.h after the above disabling strict asci mode statement.
  */

--- a/src/include/duckdb/common/windows_undefs.hpp
+++ b/src/include/duckdb/common/windows_undefs.hpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+// Do not add a header inclusion guard to this file. Otherwise these Win32 macros
+// may get defined and stomp on DuckDB symbols
 
 #ifdef WIN32
 


### PR DESCRIPTION
These two changes fix builds that don't use cmake unity described in issue #14151

1. Remove header inclusion guard in windows_undefs.hpp to insure certain Win32 macros are always undefined - this is okay because all these #undef are guarded by `#ifdef WIN32`

2. Copy deletion of ICU undefine of `__STRICT_ANSI__` from ICU upstream that conflicts with GCC-14 header files - this duplicates https://github.com/unicode-org/icu/pull/3003 - it would be better to pull the latest ICU in but ICU is used in a customized way that would require more effort - also looks like fix won't be released till ICU 75.2 which is not yet released - https://unicode-org.atlassian.net/browse/ICU-22721