### PR TITLE
fix: ArrowSchemaMetadata::GetOption to return empty string instead of raising exception if key is not found.

### DIFF
--- a/src/common/arrow/schema_metadata.cpp
+++ b/src/common/arrow/schema_metadata.cpp
@@ -56,9 +56,6 @@ ArrowSchemaMetadata ArrowSchemaMetadata::MetadataFromName(const string &extensio
 }
 
 bool ArrowSchemaMetadata::HasExtension() {
-	if (metadata_map.find(ARROW_EXTENSION_NAME) == metadata_map.end()) {
-		return false;
-	}
 	auto arrow_extension = GetOption(ArrowSchemaMetadata::ARROW_EXTENSION_NAME);
 	// FIXME: We are currently ignoring the ogc extensions
 	return !arrow_extension.empty() && !StringUtil::StartsWith(arrow_extension, "ogc");

--- a/src/common/arrow/schema_metadata.cpp
+++ b/src/common/arrow/schema_metadata.cpp
@@ -36,7 +36,12 @@ void ArrowSchemaMetadata::AddOption(const string &key, const string &value) {
 	metadata_map[key] = value;
 }
 string ArrowSchemaMetadata::GetOption(const string &key) const {
-	return metadata_map.at(key);
+	auto it = metadata_map.find(key);
+	if (it != metadata_map.end()) {
+		return it->second;
+	} else {
+		return "";
+	}
 }
 
 string ArrowSchemaMetadata::GetExtensionName() const {


### PR DESCRIPTION
This method was documented to return the empty string if the key was not found, but in actuality it was calling .at() on the unordered_map which raised an exception.  This PR fixes this behavior to return the empty string if the key is not found.