### PR TITLE
[Dev] Fix issue where the InsertStatement::ToString call destroyed the `alias` of the ValuesList

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -124,6 +124,7 @@ duckdb_extension_load(sqlsmith
         DONT_LINK LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb_sqlsmith
         GIT_TAG f24be8b5b0cd0eeed7541e10cff42d7050771afc
+        APPLY_PATCHES
         )
 
 ################# SUBSTRAIT

--- a/.github/patches/extensions/sqlsmith/insert_statement_to_string.patch
+++ b/.github/patches/extensions/sqlsmith/insert_statement_to_string.patch
@@ -1,0 +1,13 @@
+diff --git a/test/sql/sql_reduce.test b/test/sql/sql_reduce.test
+index 428ae92..af0530f 100644
+--- a/test/sql/sql_reduce.test
++++ b/test/sql/sql_reduce.test
+@@ -48,7 +48,7 @@ INSERT INTO tbl (VALUES (1))
+ INSERT INTO tbl (VALUES (1, 2))
+ INSERT INTO tbl (VALUES (2))
+ INSERT INTO tbl SELECT *
+-INSERT INTO tbl SELECT NULL FROM (VALUES (1, 2))
++INSERT INTO tbl SELECT NULL FROM (VALUES (1, 2)) AS valueslist
+ INSERT INTO tbl SELECT NULL FROM (VALUES (1, 2)) AS valueslist
+ 
+ query I

--- a/src/parser/statement/insert_statement.cpp
+++ b/src/parser/statement/insert_statement.cpp
@@ -98,8 +98,10 @@ string InsertStatement::ToString() const {
 	auto values_list = GetValuesList();
 	if (values_list) {
 		D_ASSERT(!default_values);
+		auto saved_alias = values_list->alias;
 		values_list->alias = string();
 		result += values_list->ToString();
+		values_list->alias = saved_alias;
 	} else if (select_statement) {
 		D_ASSERT(!default_values);
 		result += select_statement->ToString();


### PR DESCRIPTION
This PR fixes #14130