### PR TITLE
Less salt

### DIFF
--- a/src/include/duckdb/execution/ht_entry.hpp
+++ b/src/include/duckdb/execution/ht_entry.hpp
@@ -21,10 +21,10 @@ namespace duckdb {
 */
 struct ht_entry_t { // NOLINT
 public:
-	//! Upper 16 bits are salt
-	static constexpr const hash_t SALT_MASK = 0xFFFF000000000000;
-	//! Lower 48 bits are the pointer
-	static constexpr const hash_t POINTER_MASK = 0x0000FFFFFFFFFFFF;
+	//! Upper 12 bits are salt
+	static constexpr const hash_t SALT_MASK = 0xFFF0000000000000;
+	//! Lower 52 bits are the pointer
+	static constexpr const hash_t POINTER_MASK = 0x000FFFFFFFFFFFFF;
 
 	explicit inline ht_entry_t(hash_t value_p) noexcept : value(value_p) {
 	}


### PR DESCRIPTION
Apparently ARM64v8 uses 52, not 48 bits for the pointer (not all versions of ARM64v8, but just some). We could also `#ifdef` our way around this but this seems fine. It reduces the effectiveness of the salt by 16x sadly, but it's still reduces the chance of having to chase the pointer even when keys are different by 4096x (was 65536x).

Fixes https://github.com/duckdb/duckdb/issues/14140