### PR TITLE
Avoid recompilations of duckdb when there are no actual changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1400,19 +1400,21 @@ if(NOT DUCKDB_EXPLICIT_PLATFORM)
   set_target_properties(duckdb_platform_binary PROPERTIES OUTPUT_NAME duckdb_platform_binary)
   set_target_properties(duckdb_platform_binary PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                          ${PROJECT_BINARY_DIR})
-  add_custom_target(
-          duckdb_platform ALL
+  add_custom_command(
+          OUTPUT ${PROJECT_BINARY_DIR}/duckdb_platform_out
+          DEPENDS duckdb_platform_binary
           COMMAND duckdb_platform_binary > ${PROJECT_BINARY_DIR}/duckdb_platform_out || ( echo "Provide explicit DUCKDB_PLATFORM=your_target_arch to avoid build-type detection of the platform" && exit 1 )
           WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
           )
-  add_dependencies(duckdb_platform duckdb_platform_binary)
 else()
-  add_custom_target(
-          duckdb_platform ALL
+  add_custom_command(
+          OUTPUT ${PROJECT_BINARY_DIR}/duckdb_platform_out
           COMMAND
-          ${CMAKE_COMMAND} -E echo_append \"${DUCKDB_EXPLICIT_PLATFORM}\" > duckdb_platform_out
+          ${CMAKE_COMMAND} -E echo_append \"${DUCKDB_EXPLICIT_PLATFORM}\" > ${PROJECT_BINARY_DIR}/duckdb_platform_out
+          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
           )
 endif()
+add_custom_target(duckdb_platform DEPENDS ${PROJECT_BINARY_DIR}/duckdb_platform_out)
 
 if(NOT CLANG_TIDY)
   if(${BUILD_UNITTESTS})

--- a/src/main/extension/CMakeLists.txt
+++ b/src/main/extension/CMakeLists.txt
@@ -4,22 +4,28 @@ include_directories(../../../third_party/httplib/)
 # include file and a loader function based on the `DUCKDB_EXTENSION_NAMES`
 # parameter.
 
-# generated_extension_headers.hpp
-configure_file(
-  generated_extension_headers.hpp.in
-  "${PROJECT_BINARY_DIR}/codegen/include/generated_extension_headers.hpp")
-
 get_statically_linked_extensions("${DUCKDB_EXTENSION_NAMES}"
                                  STATICALLY_LINKED_EXTENSIONS)
-foreach(EXT_NAME IN LISTS STATICALLY_LINKED_EXTENSIONS)
-  string(TOUPPER ${EXT_NAME} EXT_NAME_UPPERCASE)
-  if(${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_SHOULD_LINK})
-    set(DUCKDB_EXTENSION_HEADER "${EXT_NAME}_extension.hpp")
-    file(APPEND
-         "${PROJECT_BINARY_DIR}/codegen/include/generated_extension_headers.hpp"
-         "#include \"${DUCKDB_EXTENSION_HEADER}\"\n")
-  endif()
-endforeach()
+if(EXISTS
+   "${PROJECT_BINARY_DIR}/codegen/include/generated_extension_headers.hpp")
+
+else()
+  # generated_extension_headers.hpp
+  configure_file(
+    generated_extension_headers.hpp.in
+    "${PROJECT_BINARY_DIR}/codegen/include/generated_extension_headers.hpp")
+
+  foreach(EXT_NAME IN LISTS STATICALLY_LINKED_EXTENSIONS)
+    string(TOUPPER ${EXT_NAME} EXT_NAME_UPPERCASE)
+    if(${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_SHOULD_LINK})
+      set(DUCKDB_EXTENSION_HEADER "${EXT_NAME}_extension.hpp")
+      file(
+        APPEND
+        "${PROJECT_BINARY_DIR}/codegen/include/generated_extension_headers.hpp"
+        "#include \"${DUCKDB_EXTENSION_HEADER}\"\n")
+    endif()
+  endforeach()
+endif()
 
 # generated_extension_loader.hpp
 set(EXT_LOADER_NAME_LIST "")


### PR DESCRIPTION
Currently on iterative rebuilds a few targets are rebuilt (about 15, but varies with number of extensions compiled)
```bash
GEN=ninja make
.... builds 400+ targets
GEN=ninja make
.... builds 15 targets
GEN=ninja make
.... builds 15 targets
time GEN=ninja make
GEN=ninja make  2.26s user 1.28s system 109% cpu 3.227 total

```


After this PR it should be that if no changes to code or configuration happens, no compilations of linking will be taking place. Only step that will still taking place is the creation of the repository, that needs some more refactoring to remove while keeping functionality the same, but looks to be fast. Still no recompilation/linking happening, only file system.
```bash
GEN=ninja make
.... builds 400+ targets
GEN=ninja make
.... builds 1 target
GEN=ninja make
.... builds 1 target
time GEN=ninja make
GEN=ninja make  0.81s user 0.55s system 95% cpu 1.425 total
```
Of the remaining 0.80 seconds, most of them are spend by CMake to check if everything is up to date, it can likely be improved there at the Makefile level but not certain how.

This is not only on recompilations triggered directly, but even like:
```bash
GEN=ninja make
GEN=ninja make unittest_release
```
would on the second command trigger recompilation of extensions.

----
#### What could go wrong?
This PR should be pretty straightforward, but for the fact that it might uncover pre-existing bugs that might have been hidden by the fact that we were recompiling on every invocation.
This is hypothetical, if that happens `make clean` is always the way forward.