### PR TITLE
[Python] Fix a bug with `python_scan_all_frames` reaching the bottom of the frame stack

### DIFF
--- a/tools/pythonpkg/src/python_replacement_scan.cpp
+++ b/tools/pythonpkg/src/python_replacement_scan.cpp
@@ -225,6 +225,9 @@ static unique_ptr<TableRef> ReplaceInternal(ClientContext &context, const string
 			}
 		}
 		current_frame = current_frame.attr("f_back");
+		if (py::none().is(current_frame)) {
+			break;
+		}
 	} while (scan_all_frames && (has_locals || has_globals));
 	return nullptr;
 }

--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -165,6 +165,12 @@ class TestReplacementScan(object):
         assert type(pyrel3) == duckdb.DuckDBPyRelation
         assert pyrel3.fetchall() == [(142,), (184,)]
 
+    def test_replacement_scan_not_found(self):
+        con = duckdb.connect()
+        con.execute("set python_scan_all_frames=true")
+        with pytest.raises(duckdb.CatalogException, match='Table with name non_existant does not exist'):
+            res = con.sql("select * from non_existant").fetchall()
+
     def test_replacement_scan_alias(self):
         con = duckdb.connect()
         pyrel1 = con.query('from (values (1, 2)) t(i, j)')


### PR DESCRIPTION
This PR fixes #14179

Reaching the bottom of the frame stack (`currentframe.f_back` returns None) was not being detected, causing a python exception instead of reporting a catalog exception.