### PR TITLE
Fix extension size increase

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -222,6 +222,7 @@ jobs:
     BUILD_TPCDS: 1
     BUILD_JSON: 1
     BUILD_PARQUET: 1
+    EXTENSION_STATIC_BUILD: 1
   steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -211,6 +211,50 @@ jobs:
            echo "Storage bump detected, all good!"
         fi
 
+ regression-test-binary-size:
+  name: Regression test binary size
+  runs-on: ubuntu-20.04
+  env:
+    CC: gcc-10
+    CXX: g++-10
+    GEN: ninja
+    BUILD_TPCH: 1
+    BUILD_TPCDS: 1
+    BUILD_JSON: 1
+    BUILD_PARQUET: 1
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install
+      shell: bash
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build && pip install requests
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
+    - name: Build
+      shell: bash
+      run: |
+        make
+        git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
+        cd duckdb
+        make
+        cd ..
+
+    - name: Regression Test Extension binary size
+      shell: bash
+      run: |
+        python scripts/regression_test_extension_size.py --old 'duckdb/build/release/extension' --new build/release/extension --expect json,parquet,tpch,tpcds
+
  regression-test-python:
   name: Regression Test (Python Client)
   runs-on: ubuntu-20.04

--- a/scripts/regression_test_extension_size.py
+++ b/scripts/regression_test_extension_size.py
@@ -63,15 +63,15 @@ for extension in matching_extensions:
     old_size = os.path.getsize(old_extensions[extension])
     new_size = os.path.getsize(new_extensions[extension])
 
-    if new_size / old_size > (1.0 + regression_threshold_percentage):
+    print(f" - checking '{extension}': old size={old_size}, new_size={new_size}")
+
+    if new_size / (old_size + 0.1) > (1.0 + regression_threshold_percentage):
         check_passed = False
         error_message += f" - Extension '{extension}' was bigger than expected {new_size}\n"
         error_message += f"   - old size: {old_size}\n"
         error_message += f"   - new size: {new_size}\n"
 
-print(
-    f"Checking extension size for {matching_extensions} are within the threshold of '{regression_threshold_percentage}'"
-)
+print()
 if not check_passed:
     print("Extension size regression check failed:\n")
     print(error_message)

--- a/scripts/regression_test_extension_size.py
+++ b/scripts/regression_test_extension_size.py
@@ -1,0 +1,80 @@
+import os
+import argparse
+import subprocess
+import tempfile
+from pathlib import Path
+
+# the threshold at which we consider something a regression (percentage)
+regression_threshold_percentage = 0.20
+
+parser = argparse.ArgumentParser(description='Generate TPC-DS reference results from Postgres.')
+parser.add_argument(
+    '--old', dest='old_extension_dir', action='store', help='Path to the old extension dir', required=True
+)
+parser.add_argument(
+    '--new', dest='new_extension_dir', action='store', help='Path to the new extension dir', required=True
+)
+parser.add_argument(
+    '--expect',
+    dest='expected_extensions_raw',
+    action='store',
+    help='Comma separated list of expected extensions',
+    required=True,
+)
+
+args = parser.parse_args()
+
+
+expected_extensions = args.expected_extensions_raw.split(',')
+
+exit_code = 0
+
+
+def parse_extensions(dir):
+    result = {}
+
+    for root, dirs, files in os.walk(dir):
+        for filename in files:
+            if filename.endswith(".duckdb_extension"):
+                result[Path(filename).stem] = os.path.join(root, filename)
+
+    # Check all expected extensions are there
+    for expected_extension in expected_extensions:
+        if expected_extension not in result.keys():
+            print(f"Did not find expected extension {expected_extension} in {dir}")
+            exit(1)
+
+    return result
+
+
+old_extensions = parse_extensions(args.old_extension_dir)
+new_extensions = parse_extensions(args.new_extension_dir)
+
+matching_extensions = []
+
+for extension in old_extensions.keys():
+    if extension in new_extensions:
+        matching_extensions.append(extension)
+
+check_passed = True
+error_message = ""
+
+for extension in matching_extensions:
+    old_size = os.path.getsize(old_extensions[extension])
+    new_size = os.path.getsize(new_extensions[extension])
+
+    if new_size / old_size > (1.0 + regression_threshold_percentage):
+        check_passed = False
+        error_message += f" - Extension '{extension}' was bigger than expected {new_size}\n"
+        error_message += f"   - old size: {old_size}\n"
+        error_message += f"   - new size: {new_size}\n"
+
+print(
+    f"Checking extension size for {matching_extensions} are within the threshold of '{regression_threshold_percentage}'"
+)
+if not check_passed:
+    print("Extension size regression check failed:\n")
+    print(error_message)
+    exit(1)
+else:
+    print(f"All extensions passed the check!")

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -631,7 +631,7 @@ struct duckdb_extension_access {
 	//! Fetch the database from duckdb to register extensions to
 	duckdb_database *(*get_database)(duckdb_extension_info info);
 	//! Fetch the API
-	void *(*get_api)(duckdb_extension_info info, const char *version);
+	const void *(*get_api)(duckdb_extension_info info, const char *version);
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -627,7 +627,7 @@ struct duckdb_extension_access {
 	//! Fetch the database from duckdb to register extensions to
 	duckdb_database *(*get_database)(duckdb_extension_info info);
 	//! Fetch the API
-	void *(*get_api)(duckdb_extension_info info, const char *version);
+	const void *(*get_api)(duckdb_extension_info info, const char *version);
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -59,7 +59,7 @@ public:
 	DUCKDB_API ValidChecker &GetValidChecker();
 	DUCKDB_API void SetExtensionLoaded(const string &extension_name, ExtensionInstallInfo &install_info);
 
-	DUCKDB_API const duckdb_ext_api_v0 &GetExtensionAPIV0();
+	DUCKDB_API const duckdb_ext_api_v0 GetExtensionAPIV0();
 
 	idx_t NumberOfThreads();
 

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -59,6 +59,8 @@ public:
 	DUCKDB_API ValidChecker &GetValidChecker();
 	DUCKDB_API void SetExtensionLoaded(const string &extension_name, ExtensionInstallInfo &install_info);
 
+	// Note: this function is virtual to ensure extensions that have a copy of DuckDB linked in will receive the correct
+	//       function pointers into the DatabaseInstance that loaads them instead of their copies of DuckDB static lib
 	DUCKDB_API const duckdb_ext_api_v0 GetExtensionAPIV0();
 
 	idx_t NumberOfThreads();
@@ -95,7 +97,7 @@ private:
 	unique_ptr<DatabaseFileSystem> db_file_system;
 	shared_ptr<DatabaseCacheEntry> db_cache_entry;
 
-	unique_ptr<duckdb_ext_api_v0> extension_api_v0;
+	duckdb_ext_api_v0 (*create_api_v0)();
 };
 
 //! The database object. This object holds the catalog and all the

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -59,8 +59,6 @@ public:
 	DUCKDB_API ValidChecker &GetValidChecker();
 	DUCKDB_API void SetExtensionLoaded(const string &extension_name, ExtensionInstallInfo &install_info);
 
-	// Note: this function is virtual to ensure extensions that have a copy of DuckDB linked in will receive the correct
-	//       function pointers into the DatabaseInstance that loaads them instead of their copies of DuckDB static lib
 	DUCKDB_API const duckdb_ext_api_v0 GetExtensionAPIV0();
 
 	idx_t NumberOfThreads();

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/main/valid_checker.hpp"
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/main/extension.hpp"
+#include "duckdb/main/capi/extension_api.hpp"
 #include "duckdb/main/extension_install_info.hpp"
 #include "duckdb/main/settings.hpp"
 
@@ -58,6 +59,8 @@ public:
 	DUCKDB_API ValidChecker &GetValidChecker();
 	DUCKDB_API void SetExtensionLoaded(const string &extension_name, ExtensionInstallInfo &install_info);
 
+	DUCKDB_API const duckdb_ext_api_v0 &GetExtensionAPIV0();
+
 	idx_t NumberOfThreads();
 
 	DUCKDB_API static DatabaseInstance &GetDatabase(ClientContext &context);
@@ -91,6 +94,8 @@ private:
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
 	shared_ptr<DatabaseCacheEntry> db_cache_entry;
+
+	unique_ptr<duckdb_ext_api_v0> extension_api_v0;
 };
 
 //! The database object. This object holds the catalog and all the

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -25,6 +25,7 @@
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
+#include "duckdb/main/capi/extension_api.hpp"
 
 #ifndef DUCKDB_NO_THREADS
 #include "duckdb/common/thread.hpp"
@@ -56,6 +57,7 @@ DBConfig::~DBConfig() {
 
 DatabaseInstance::DatabaseInstance() {
 	config.is_user_config = false;
+	create_api_v0 = nullptr;
 }
 
 DatabaseInstance::~DatabaseInstance() {
@@ -267,12 +269,12 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	Configure(*config_ptr, database_path);
 
+	create_api_v0 = CreateAPIv0;
+
 	if (user_config && !user_config->options.use_temporary_directory) {
 		// temporary directories explicitly disabled
 		config.options.temporary_directory = string();
 	}
-
-	extension_api_v0 = make_uniq<duckdb_ext_api_v0>(CreateAPIv0());
 
 	db_file_system = make_uniq<DatabaseFileSystem>(*this);
 	db_manager = make_uniq<DatabaseManager>(*this);
@@ -507,7 +509,7 @@ ValidChecker &DatabaseInstance::GetValidChecker() {
 }
 
 const duckdb_ext_api_v0 DatabaseInstance::GetExtensionAPIV0() {
-	return *extension_api_v0;
+	return create_api_v0();
 }
 
 ValidChecker &ValidChecker::Get(DatabaseInstance &db) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -506,7 +506,7 @@ ValidChecker &DatabaseInstance::GetValidChecker() {
 	return db_validity;
 }
 
-const duckdb_ext_api_v0 &DatabaseInstance::GetExtensionAPIV0() {
+const duckdb_ext_api_v0 DatabaseInstance::GetExtensionAPIV0() {
 	return *extension_api_v0;
 }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -272,6 +272,8 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 		config.options.temporary_directory = string();
 	}
 
+	extension_api_v0 = make_uniq<duckdb_ext_api_v0>(CreateAPIv0());
+
 	db_file_system = make_uniq<DatabaseFileSystem>(*this);
 	db_manager = make_uniq<DatabaseManager>(*this);
 	if (config.buffer_manager) {
@@ -502,6 +504,10 @@ SettingLookupResult DatabaseInstance::TryGetCurrentSetting(const std::string &ke
 
 ValidChecker &DatabaseInstance::GetValidChecker() {
 	return db_validity;
+}
+
+const duckdb_ext_api_v0 &DatabaseInstance::GetExtensionAPIV0() {
+	return *extension_api_v0;
 }
 
 ValidChecker &ValidChecker::Get(DatabaseInstance &db) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -509,6 +509,7 @@ ValidChecker &DatabaseInstance::GetValidChecker() {
 }
 
 const duckdb_ext_api_v0 DatabaseInstance::GetExtensionAPIV0() {
+	D_ASSERT(create_api_v0);
 	return create_api_v0();
 }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -260,6 +260,10 @@ void DatabaseInstance::LoadExtensionSettings() {
 	}
 }
 
+static duckdb_ext_api_v0 CreateAPIv0Wrapper() {
+	return CreateAPIv0();
+}
+
 void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_config) {
 	DBConfig default_config;
 	DBConfig *config_ptr = &default_config;
@@ -269,7 +273,7 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	Configure(*config_ptr, database_path);
 
-	create_api_v0 = CreateAPIv0;
+	create_api_v0 = CreateAPIv0Wrapper;
 
 	if (user_config && !user_config->options.use_temporary_directory) {
 		// temporary directories explicitly disabled

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -48,7 +48,7 @@ struct DuckDBExtensionLoadState {
 
 	//! The function pointer struct passed to the extension. The extension is expected to copy this struct during
 	//! initialization
-	const duckdb_ext_api_v0 *api_struct;
+	duckdb_ext_api_v0 api_struct;
 
 	//! Error handling
 	bool has_error = false;
@@ -107,8 +107,8 @@ struct ExtensionAccess {
 			return nullptr;
 		}
 
-		load_state.api_struct = &load_state.db.GetExtensionAPIV0();
-		return load_state.api_struct;
+		load_state.api_struct = load_state.db.GetExtensionAPIV0();
+		return &load_state.api_struct;
 	}
 };
 

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -48,7 +48,7 @@ struct DuckDBExtensionLoadState {
 
 	//! The function pointer struct passed to the extension. The extension is expected to copy this struct during
 	//! initialization
-	duckdb_ext_api_v0 api_struct;
+	const duckdb_ext_api_v0 *api_struct;
 
 	//! Error handling
 	bool has_error = false;
@@ -91,7 +91,7 @@ struct ExtensionAccess {
 	}
 
 	//! Called by the extension get a pointer the correctly versioned extension C API struct.
-	static void *GetAPI(duckdb_extension_info info, const char *version) {
+	static const void *GetAPI(duckdb_extension_info info, const char *version) {
 
 		string version_string = version;
 		idx_t major, minor, patch;
@@ -106,8 +106,9 @@ struct ExtensionAccess {
 			              "Unsupported C CAPI version detected during extension initialization: " + string(version));
 			return nullptr;
 		}
-		load_state.api_struct = CreateAPIv0();
-		return &load_state.api_struct;
+
+		load_state.api_struct = &load_state.db.GetExtensionAPIV0();
+		return load_state.api_struct;
 	}
 };
 


### PR DESCRIPTION
In v1.1.0, the addition of the C Extension API has caused the extension binaries to increase quite significantly:

name | v1.0.0 uncompressed | v1.1.0 uncompressed
-- | -- | --
json | 29M | 77M
spatial | 55M | 110M
sqlite | 27M | 77M
prql | 18M | 40M

The reason is that due to the way we build extensions, we statically link duckdb in its entirety into the extension binary, then rely on the linker being able to prune the unused parts. What this means is that its quite easy unknowingly link in significant parts of DuckDB causing the extension binary to significantly grow.

This is precisely what happened when someone (possibly me) wrote some code that produces a struct containing all C API function pointers. Since the C API touches a lot of things throughout DuckDB this prevented the linker from being able to prune much.

The solution is to generate the struct of function pointers centrally in the DatabaseInstance, then hand out pointers to those.

@Mytherin I think we have 2 options: either put this behind a lock and lazily initialize, or initialize this in `DatabaseInstance::Initialize` then pass const pointers, I went with the latter.

Also I added a regression test for this that tests the size of `[json,parquet,tpch,tpcds]`. (theshold for check failure is currently at 20%).
