### PR TITLE
Issue 14189: Fix build when threads are disabled

### DIFF
--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -335,8 +335,13 @@ idx_t TaskScheduler::GetEstimatedCPUId() {
 #elif defined(_GNU_SOURCE)
 	auto cpu = sched_getcpu();
 	if (cpu < 0) {
+#ifndef DUCKDB_NO_THREADS
 		// fallback to thread id
 		return (idx_t)std::hash<std::thread::id>()(std::this_thread::get_id());
+#else
+
+		return (idx_t)getpid();
+#endif
 	}
 	return (idx_t)cpu;
 #elif defined(__aarch64__) && defined(__APPLE__)
@@ -345,8 +350,12 @@ idx_t TaskScheduler::GetEstimatedCPUId() {
 	asm volatile("mrs %x0, tpidrro_el0" : "=r"(c)::"memory");
 	return (idx_t)(c & (1 << 3) - 1);
 #else
+#ifndef DUCKDB_NO_THREADS
 	// fallback to thread id
 	return (idx_t)std::hash<std::thread::id>()(std::this_thread::get_id());
+#else
+	return (idx_t)getpid();
+#endif
 #endif
 #endif
 }

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -340,7 +340,7 @@ idx_t TaskScheduler::GetEstimatedCPUId() {
 		return (idx_t)std::hash<std::thread::id>()(std::this_thread::get_id());
 #else
 
-		return (idx_t)getpid();
+		return 0;
 #endif
 	}
 	return (idx_t)cpu;
@@ -354,7 +354,7 @@ idx_t TaskScheduler::GetEstimatedCPUId() {
 	// fallback to thread id
 	return (idx_t)std::hash<std::thread::id>()(std::this_thread::get_id());
 #else
-	return (idx_t)getpid();
+	return 0;
 #endif
 #endif
 #endif


### PR DESCRIPTION
Return 0 for CPU ID if CPU ID cannot be determined and thread ID cannot be used because threads are disabled  - fix issue #14189