### PR TITLE
subtype DBInterface.Connection in julia client

### DIFF
--- a/tools/juliapkg/src/database.jl
+++ b/tools/juliapkg/src/database.jl
@@ -40,7 +40,7 @@ A connection can only run a single query concurrently.
 It is possible to open multiple connections to a single DuckDB database instance.
 Multiple connections can run multiple queries concurrently.
 """
-mutable struct Connection
+mutable struct Connection <: DBInterface.Connection
     db::DuckDBHandle
     handle::duckdb_connection
 

--- a/tools/juliapkg/test/test_basic_queries.jl
+++ b/tools/juliapkg/test/test_basic_queries.jl
@@ -19,6 +19,14 @@ using Tables: partitions
     @test size(df, 1) == 1
     @test df.a == [42]
 
+    # do block syntax to automatically close cursor
+    df = DBInterface.execute(con, "SELECT 42 a") do results
+        return DataFrame(results)
+    end
+    @test names(df) == ["a"]
+    @test size(df, 1) == 1
+    @test df.a == [42]
+
     DBInterface.close!(con)
 end
 


### PR DESCRIPTION
By subtyping the `DBInterface.Connection` type from the julia DBInterface package we gain access to a series of additional methods, in particular the `do block` syntax to automatically close the cursor after the closure in the do block is executed.

I imagine not having this was an oversight as `DuckDB.DB` (unlike `DuckDB.Connection`) was already a subtype of `DBInterface.Connection`.