### PR TITLE
add method to check whether julia connection is open

### DIFF
--- a/tools/juliapkg/src/database.jl
+++ b/tools/juliapkg/src/database.jl
@@ -108,7 +108,9 @@ DBInterface.connect(db::DB) = Connection(db.handle)
 DBInterface.close!(db::DB) = close_database(db)
 DBInterface.close!(con::Connection) = _close_connection(con)
 Base.close(db::DB) = close_database(db)
+Base.close(con::Connection) = _close_connection(con)
 Base.isopen(db::DB) = db.handle.handle != C_NULL
+Base.isopen(con::Connection) = con.handle != C_NULL
 
 Base.show(io::IO, db::DuckDB.DB) = print(io, string("DuckDB.DB(", "\"$(db.handle.file)\"", ")"))
 Base.show(io::IO, con::DuckDB.Connection) = print(io, string("DuckDB.Connection(", "\"$(con.db.file)\"", ")"))

--- a/tools/juliapkg/test/test_connection.jl
+++ b/tools/juliapkg/test/test_connection.jl
@@ -7,6 +7,11 @@
     DBInterface.close!(con)
     DBInterface.close!(con)
     @test 1 == 1
+
+    con = DBInterface.connect(DuckDB.DB, ":memory:")
+    @test isopen(con)
+    close(con)
+    @test !isopen(con)
 end
 
 @testset "Test opening a bogus directory" begin


### PR DESCRIPTION
This PR adds methods (previously implemented only for `DuckDB.DB`) to check whether a connection is open using `Base.isopen` and to close it using `Base.close`. It is consistent with `DuckDB.DB` and is also what other julia DB packages do (e.g. [MySQL.jl](https://github.com/JuliaDatabases/MySQL.jl/blob/9d61afbc137284b830b259a873f50c028c30615b/src/MySQL.jl#L306)).