### PR TITLE
Add const char* versions of Prepare and Query

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -104,6 +104,7 @@ public:
 	//! Issue a query, returning a QueryResult. The QueryResult can be either a StreamQueryResult or a
 	//! MaterializedQueryResult. The StreamQueryResult will only be returned in the case of a successful SELECT
 	//! statement.
+	DUCKDB_API unique_ptr<QueryResult> Query(const char *query, bool allow_stream_result);
 	DUCKDB_API unique_ptr<QueryResult> Query(const string &query, bool allow_stream_result);
 	DUCKDB_API unique_ptr<QueryResult> Query(unique_ptr<SQLStatement> statement, bool allow_stream_result);
 
@@ -131,6 +132,7 @@ public:
 	DUCKDB_API unique_ptr<QueryResult> Execute(const shared_ptr<Relation> &relation);
 
 	//! Prepare a query
+	DUCKDB_API unique_ptr<PreparedStatement> Prepare(const char *query);
 	DUCKDB_API unique_ptr<PreparedStatement> Prepare(const string &query);
 	//! Directly prepare a SQL statement
 	DUCKDB_API unique_ptr<PreparedStatement> Prepare(unique_ptr<SQLStatement> statement);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -674,6 +674,10 @@ unique_ptr<PreparedStatement> ClientContext::Prepare(unique_ptr<SQLStatement> st
 	}
 }
 
+unique_ptr<PreparedStatement> ClientContext::Prepare(const char *query) {
+	return Prepare(string(query));
+}
+
 unique_ptr<PreparedStatement> ClientContext::Prepare(const string &query) {
 	auto lock = LockContext();
 	// prepare the query
@@ -906,6 +910,10 @@ unique_ptr<QueryResult> ClientContext::Query(unique_ptr<SQLStatement> statement,
 		return ErrorResult<MaterializedQueryResult>(pending_query->GetErrorObject());
 	}
 	return pending_query->Execute();
+}
+
+unique_ptr<QueryResult> ClientContext::Query(const char *query, bool allow_stream_result) {
+	return Query(string(query), allow_stream_result);
 }
 
 unique_ptr<QueryResult> ClientContext::Query(const string &query, bool allow_stream_result) {


### PR DESCRIPTION
In pg_duckdb we work mostly with `char*` instead of `string` due to the Postgres being written in C instead of C++. So whenever we want to execute a query in DuckDB that query is not of the `string` type. This adds methods to `ClientContext` to allow executing such queries without first having to convert them to a `string`.
