### PR TITLE
[Python] Don't allow construction of DuckDBPyType from empty Dict type

### DIFF
--- a/tools/pythonpkg/src/typing/pytype.cpp
+++ b/tools/pythonpkg/src/typing/pytype.cpp
@@ -270,6 +270,9 @@ static LogicalType FromGenericAlias(const py::object &obj) {
 static LogicalType FromDictionary(const py::object &obj) {
 	auto dict = py::reinterpret_steal<py::dict>(obj);
 	child_list_t<LogicalType> children;
+	if (dict.size() == 0) {
+		throw InvalidInputException("Could not convert empty dictionary to a duckdb STRUCT type");
+	}
 	children.reserve(dict.size());
 	for (auto &item : dict) {
 		auto &name_p = item.first;

--- a/tools/pythonpkg/tests/fast/test_type.py
+++ b/tools/pythonpkg/tests/fast/test_type.py
@@ -88,6 +88,12 @@ class TestType(object):
         type = duckdb.struct_type([BIGINT, BOOLEAN])
         assert str(type) == 'STRUCT(v1 BIGINT, v2 BOOLEAN)'
 
+    def test_incomplete_struct_type(self):
+        with pytest.raises(
+            duckdb.InvalidInputException, match='Could not convert empty dictionary to a duckdb STRUCT type'
+        ):
+            type = duckdb.typing.DuckDBPyType(dict())
+
     def test_map_type(self):
         type = duckdb.map_type(duckdb.sqltype("BIGINT"), duckdb.sqltype("DECIMAL(10, 2)"))
         assert str(type) == 'MAP(BIGINT, DECIMAL(10,2))'


### PR DESCRIPTION
This PR fixes #14211