### PR TITLE
[Bitstring] Add implicit cast to VARCHAR

### DIFF
--- a/src/function/cast_rules.cpp
+++ b/src/function/cast_rules.cpp
@@ -283,6 +283,15 @@ static int64_t ImplicitCastVarint(const LogicalType &to) {
 	}
 }
 
+static int64_t ImplicitCastBitstring(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::VARCHAR:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
 bool LogicalTypeIsValid(const LogicalType &type) {
 	switch (type.id()) {
 	case LogicalTypeId::STRUCT:
@@ -577,6 +586,8 @@ int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) 
 		return ImplicitCastTimestamp(to);
 	case LogicalTypeId::VARINT:
 		return ImplicitCastVarint(to);
+	case LogicalTypeId::BIT:
+		return ImplicitCastBitstring(to);
 	default:
 		return -1;
 	}

--- a/test/sql/cast/test_bit_cast.test
+++ b/test/sql/cast/test_bit_cast.test
@@ -425,3 +425,11 @@ query I
 SELECT NULL::BIT::INT;
 ----
 NULL
+
+
+#                  (implicit) BIT -> VARCHAR
+# ---------------------------------------------------
+query I
+SELECT bitstring('1010'::BITSTRING, 7);
+----
+0001010

--- a/test/sql/types/enum/test_enum_to_numbers.test
+++ b/test/sql/types/enum/test_enum_to_numbers.test
@@ -261,15 +261,29 @@ statement ok
 drop table t2;
 
 statement ok
-create type enum_bits as enum ('11001010110', '110', '0101001010101', 'some enum val that cannot be cast to bit');
+create type enum_bits as enum(
+	'11001010110',
+	'110',
+	'0101001010101',
+	'some enum val that cannot be cast to bit'
+);
 
 statement ok
-create table t1 as select * from values ('110010'::BIT), ('110'::BIT), ('110110110011'::BIT) t(a);
+create table t1 as select * from values
+	('110010'::BIT),
+	('110'::BIT),
+	('110110110011'::BIT)
+t(a);
 
 statement ok
-create table t2 as select * from values ('11001010110'::enum_bits), ('110'::enum_bits), ('0101001010101'::enum_bits), ('some enum val that cannot be cast to bit'::enum_bits) t(b);
+create table t2 as select * from values
+	('11001010110'::enum_bits),
+	('110'::enum_bits),
+	('0101001010101'::enum_bits),
+	('some enum val that cannot be cast to bit'::enum_bits)
+t(b);
 
-statement error
+# Because both enum and bit have implicit casts to VARCHAR,
+# both are cast to VARCHAR when the enum has a value that can not be converted to BIT
+statement ok
 select count(*) from t1, t2 where t1.a = t2.b;
-----
-Conversion Error


### PR DESCRIPTION
This PR fixes #14216

The bitstring function accepts a VARCHAR, when given a BIT this failed. This will now pass as BIT is implicitly converted to VARCHAR when necessary.