### PR TITLE
[Dev] Add the ExecutorException class, making use of the EXECUTOR ExceptionType

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -292,6 +292,9 @@ PermissionException::PermissionException(const string &msg) : Exception(Exceptio
 SyntaxException::SyntaxException(const string &msg) : Exception(ExceptionType::SYNTAX, msg) {
 }
 
+ExecutorException::ExecutorException(const string &msg) : Exception(ExceptionType::EXECUTOR, msg) {
+}
+
 ConstraintException::ConstraintException(const string &msg) : Exception(ExceptionType::CONSTRAINT, msg) {
 }
 

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -329,6 +329,16 @@ public:
 	}
 };
 
+class ExecutorException : public Exception {
+public:
+	DUCKDB_API explicit ExecutorException(const string &msg);
+
+	template <typename... ARGS>
+	explicit ExecutorException(const string &msg, ARGS... params)
+	    : ExecutorException(ConstructMessage(msg, params...)) {
+	}
+};
+
 class InvalidConfigurationException : public Exception {
 public:
 	DUCKDB_API explicit InvalidConfigurationException(const string &msg);


### PR DESCRIPTION
Just something I noticed, this is one of the exception types that don't have a dedicated class for it.
I think having a good diversity of exception types is healthy, so the right one can be picked given the context - this makes that easier, than having to write:
```c++
throw duckdb::Exception(duckdb::ExceptionType::EXECUTOR, ss.str());
```
