### PR TITLE
Fix #14212: mention correct query component when using literal in DISTINCT ON

### DIFF
--- a/src/include/duckdb/planner/expression_binder/order_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/order_binder.hpp
@@ -37,6 +37,9 @@ public:
 
 	unique_ptr<Expression> CreateExtraReference(unique_ptr<ParsedExpression> expr);
 
+	//! Sets the query component, for error messages
+	void SetQueryComponent(string component = string());
+
 private:
 	unique_ptr<Expression> CreateProjectionReference(ParsedExpression &expr, const idx_t index);
 	unique_ptr<Expression> BindConstant(ParsedExpression &expr);
@@ -46,6 +49,7 @@ private:
 	vector<reference<Binder>> binders;
 	optional_ptr<vector<unique_ptr<ParsedExpression>>> extra_list;
 	SelectBindState &bind_state;
+	string query_component = "ORDER BY";
 };
 
 } // namespace duckdb

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -140,6 +140,7 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 					    make_uniq<ConstantExpression>(Value::INTEGER(UnsafeNumericCast<int32_t>(1 + i))));
 				}
 			}
+			order_binder.SetQueryComponent("DISTINCT ON");
 			for (auto &distinct_on_target : distinct.distinct_on_targets) {
 				auto expr = BindOrderExpression(order_binder, std::move(distinct_on_target));
 				if (!expr) {
@@ -147,10 +148,13 @@ void Binder::PrepareModifiers(OrderBinder &order_binder, QueryNode &statement, B
 				}
 				bound_distinct->target_distincts.push_back(std::move(expr));
 			}
+			order_binder.SetQueryComponent();
+
 			bound_modifier = std::move(bound_distinct);
 			break;
 		}
 		case ResultModifierType::ORDER_MODIFIER: {
+
 			auto &order = mod->Cast<OrderModifier>();
 			auto bound_order = make_uniq<BoundOrderModifier>();
 			auto &config = DBConfig::GetConfig(context);

--- a/test/sql/aggregate/distinct/test_distinct_on.test
+++ b/test/sql/aggregate/distinct/test_distinct_on.test
@@ -131,3 +131,23 @@ statement error
 SELECT DISTINCT ON (2) i FROM integers
 ----
 Binder Error: ORDER term out of range - should be between 1 and 1
+
+# DISTINCT ON constant returns an error
+statement error
+SELECT DISTINCT ON(i, 'literal') i FROM integers
+----
+DISTINCT ON non-integer literal has no effect
+
+statement ok
+SET order_by_non_integer_literal=true
+
+query I
+SELECT DISTINCT ON(i, 'literal') i FROM integers ORDER BY ALL
+----
+2
+4
+
+statement error
+PREPARE v1 AS select distinct on (?) 42;
+----
+Parameter not supported in DISTINCT ON clause


### PR DESCRIPTION
Fixes #14212