### PR TITLE
Make test random output ordered

### DIFF
--- a/test/issues/general/test_14232.test
+++ b/test/issues/general/test_14232.test
@@ -67,7 +67,8 @@ WHERE t1c IN (SELECT t2c
 FROM t2
 WHERE t1a = t2a)
 GROUP BY t1a,
-t1b
+t1b,
+ORDER BY t1a
 ----
 t1b	8
 t1c	8


### PR DESCRIPTION
In test case `test/issues/general/test_14232.test`,  the output order is  not matched with expected result