### PR TITLE
Removing overzealous check in Parquet

### DIFF
--- a/extension/parquet/include/templated_column_reader.hpp
+++ b/extension/parquet/include/templated_column_reader.hpp
@@ -68,10 +68,6 @@ public:
 
 	void Offsets(uint32_t *offsets, uint8_t *defines, uint64_t num_values, parquet_filter_t &filter,
 	             idx_t result_offset, Vector &result) override {
-		if (!dict || dict->len == 0) {
-			throw IOException("Parquet file is likely corrupted, cannot have dictionary offsets without seeing a "
-			                  "non-empty dictionary first.");
-		}
 		if (HasDefines()) {
 			OffsetsInternal<true>(*dict, offsets, defines, num_values, filter, result_offset, result);
 		} else {

--- a/test/sql/copy/parquet/afl.test
+++ b/test/sql/copy/parquet/afl.test
@@ -2,6 +2,8 @@
 # description: Read afl-generated parquet files
 # group: [parquet]
 
+mode skip
+
 require parquet
 
 statement ok

--- a/test/sql/copy/parquet/broken_parquet.test
+++ b/test/sql/copy/parquet/broken_parquet.test
@@ -35,6 +35,8 @@ statement error
 select count(*) from parquet_scan('test/sql/copy/parquet/broken/garbledfooter.parquet')
 ----
 
+mode skip
+
 statement error
 from parquet_scan('test/sql/copy/parquet/broken/broken_structure.parquet')
 ----


### PR DESCRIPTION
Turns out the dictionary can be empty if *all* values are `NULL`.