### PR TITLE
Add support for pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1559,3 +1559,34 @@ if(EXISTS ${CMAKE_CONFIG_TEMPLATE} AND EXISTS ${CMAKE_CONFIG_VERSION_TEMPLATE})
           "${PROJECT_BINARY_DIR}/DuckDBConfigVersion.cmake"
     DESTINATION "${INSTALL_CMAKE_DIR}")
 endif()
+
+# Only write the pkg-config package if the templates exist
+set(PKG_CONFIG_TEMPLATE "${CMAKE_CURRENT_SOURCE_DIR}/duckdb.pc.in")
+if(EXISTS ${PKG_CONFIG_TEMPLATE})
+
+  # Prepare variables for duckdb.pc
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PKG_CONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+  else()
+    set(PKG_CONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+  endif()
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(PKG_CONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+  else()
+    set(PKG_CONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+  endif()
+  # Remove "v"
+  string(SUBSTRING "${DUCKDB_VERSION}" 1 -1 PKG_CONFIG_VERSION)
+  set(PKG_CONFIG_LIBS "")
+  foreach(DUCKDB_SYSTEM_LIB ${DUCKDB_SYSTEM_LIBS})
+    string(APPEND PKG_CONFIG_LIBS " -l${DUCKDB_SYSTEM_LIB}")
+  endforeach()
+
+  # Configure pkg-config package
+  configure_file(${PKG_CONFIG_TEMPLATE} "${PROJECT_BINARY_DIR}/duckdb.pc" @ONLY)
+
+  # Install the pkg-config package
+  install(
+    FILES "${PROJECT_BINARY_DIR}/duckdb.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+endif()

--- a/duckdb.pc.in
+++ b/duckdb.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@PKG_CONFIG_INCLUDEDIR@
+libdir=@PKG_CONFIG_LIBDIR@
+
+Name: DuckDB
+Description: An in-process SQL OLAP database management system.
+Version: @PKG_CONFIG_VERSION@
+Libs: -L${libdir} -lduckdb@PKG_CONFIG_LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
DuckDB provides CMake package. It's useful to detect link options from projects that use CMake, Meson and so on as a build system. But there are build systems that don't support CMake package but support pkg-config.

pkg-config support is useful for projects that use those build systems.

This PR targets only libduckdb.so. libduckdb_static.a support is out-of-scope of this PR.