### PR TITLE
Avoid throwing on failure to open extensions's .info file (when force installing)

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -358,7 +358,15 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 	{
 		auto fs = FileSystem::CreateLocal();
 		if (fs->FileExists(local_extension_path + ".info")) {
-			install_info = ExtensionInstallInfo::TryReadInfoFile(*fs, local_extension_path + ".info", extension_name);
+			try {
+				install_info =
+				    ExtensionInstallInfo::TryReadInfoFile(*fs, local_extension_path + ".info", extension_name);
+			} catch (...) {
+				if (!options.force_install) {
+					// We are going to rewrite the file anyhow, so this is fine
+					throw;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Idea is that if `.info` files ends up being corrupt, you will be stuck in a loop like:
```
duckdb -c "FORCE INSTALL x"
IO Error: Failed to read info file for 'x' extension: ...
....
Try reinstalling the extension using 'FORCE INSTALL x;'
```

And given in the force_install codepath (that is either in case of `FORCE INSTALL` or in case of `UPDATE EXTENSIONS`) the info file will be rewritten in any case I think this is OK, and there is no need to notify user that this happened.
In the LOAD codepath this will still be visible, we only need a way to get unblocked (yes, removing the file works, but it's not super cool).

Note that we could also just avoid the read (but only in the case of proper `FORCE INSTALL`), but I wanted avoid yet another slightly different codepath.