### PR TITLE
Only slice initialized vectors in `PhysicalHashAggregate::SinkDistinctGrouping`

### DIFF
--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -319,15 +319,17 @@ void PhysicalHashAggregate::SinkDistinctGrouping(ExecutionContext &context, Data
 			for (idx_t group_idx = 0; group_idx < grouped_aggregate_data.groups.size(); group_idx++) {
 				auto &group = grouped_aggregate_data.groups[group_idx];
 				auto &bound_ref = group->Cast<BoundReferenceExpression>();
-				filtered_input.data[bound_ref.index].Reference(chunk.data[bound_ref.index]);
+				auto &col = filtered_input.data[bound_ref.index];
+				col.Reference(chunk.data[bound_ref.index]);
+				col.Slice(sel_vec, count);
 			}
 			for (idx_t child_idx = 0; child_idx < aggregate.children.size(); child_idx++) {
 				auto &child = aggregate.children[child_idx];
 				auto &bound_ref = child->Cast<BoundReferenceExpression>();
-
-				filtered_input.data[bound_ref.index].Reference(chunk.data[bound_ref.index]);
+				auto &col = filtered_input.data[bound_ref.index];
+				col.Reference(chunk.data[bound_ref.index]);
+				col.Slice(sel_vec, count);
 			}
-			filtered_input.Slice(sel_vec, count);
 			filtered_input.SetCardinality(count);
 
 			radix_table.Sink(context, filtered_input, sink_input, empty_chunk, empty_filter);

--- a/test/issues/general/test_14232.test
+++ b/test/issues/general/test_14232.test
@@ -59,7 +59,7 @@ INSERT INTO t2 (t2a, t2b, t2c, t2d, t2e, t2f, t2g, t2h, t2i) VALUES
 ('t1f', 19, NULL, 19, 17.0, 25, 26.00, '2014-10-04 01:01:00', '2014-10-04'),
 ('t1b', NULL, 16, 19, 17.0, 25, 26.00, '2014-05-04 01:01:00', NULL)
 
-query II
+query II rowsort
 SELECT t1a,
 t1b
 FROM t1

--- a/test/issues/general/test_14286.test
+++ b/test/issues/general/test_14286.test
@@ -1,0 +1,16 @@
+# name: test/issues/general/test_14286.test
+# description: Issue 14286 - An error was encountered using both distinct and struct
+# group: [general]
+
+statement ok
+select
+    category,
+    array_agg(distinct name) filter(where id != 5)            as a_list,
+    array_agg(name)          filter(where id != 5)            as b_list,
+    array_agg({'id': id, 'name': name, 'catetory': category}) as c_list
+from (
+    select 1 as id, '大熊猫' as name, '熊' as category union all
+    select 2 as id, '大熊猫' as name, '猫' as category union all
+    select 3 as id, '小熊猫' as name, '猫' as category
+) t
+group by category;


### PR DESCRIPTION
Fixes #14286

Also adds `rowsort` to a different test because it's not deterministic