### PR TITLE
Switch to shared pointer for multfilelists

### DIFF
--- a/.github/patches/extensions/delta/multifilereader_shared_ptr.patch
+++ b/.github/patches/extensions/delta/multifilereader_shared_ptr.patch
@@ -1,0 +1,32 @@
+diff --git a/src/functions/delta_scan.cpp b/src/functions/delta_scan.cpp
+index 23482f1..968f116 100644
+--- a/src/functions/delta_scan.cpp
++++ b/src/functions/delta_scan.cpp
+@@ -599,12 +599,12 @@ void DeltaMultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_optio
+     }
+ }
+ 
+-unique_ptr<MultiFileList> DeltaMultiFileReader::CreateFileList(ClientContext &context, const vector<string>& paths, FileGlobOptions options) {
++shared_ptr<MultiFileList> DeltaMultiFileReader::CreateFileList(ClientContext &context, const vector<string>& paths, FileGlobOptions options) {
+     if (paths.size() != 1) {
+         throw BinderException("'delta_scan' only supports single path as input");
+     }
+ 
+-    return make_uniq<DeltaSnapshot>(context, paths[0]);
++    return make_shared_ptr<DeltaSnapshot>(context, paths[0]);
+ }
+ 
+ // Generate the correct Selection Vector Based on the Raw delta KernelBoolSlice dv and the row_id_column
+diff --git a/src/include/functions/delta_scan.hpp b/src/include/functions/delta_scan.hpp
+index 23c937d..84220f9 100644
+--- a/src/include/functions/delta_scan.hpp
++++ b/src/include/functions/delta_scan.hpp
+@@ -105,7 +105,7 @@ struct DeltaMultiFileReaderGlobalState : public MultiFileReaderGlobalState {
+ struct DeltaMultiFileReader : public MultiFileReader {
+     static unique_ptr<MultiFileReader> CreateInstance(const TableFunction &table_function);
+     //! Return a DeltaSnapshot
+-    unique_ptr<MultiFileList> CreateFileList(ClientContext &context, const vector<string> &paths,
++    shared_ptr<MultiFileList> CreateFileList(ClientContext &context, const vector<string> &paths,
+                    FileGlobOptions options) override;
+ 
+     //! Override the regular parquet bind using the MultiFileReader Bind. The bind from these are what DuckDB's file

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -519,7 +519,7 @@ public:
 
 	static unique_ptr<FunctionData> ParquetScanBindInternal(ClientContext &context,
 	                                                        unique_ptr<MultiFileReader> multi_file_reader,
-	                                                        unique_ptr<MultiFileList> file_list,
+	                                                        shared_ptr<MultiFileList> file_list,
 	                                                        vector<LogicalType> &return_types, vector<string> &names,
 	                                                        ParquetOptions parquet_options) {
 		auto result = make_uniq<ParquetReadBindData>();

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -15,7 +15,7 @@ namespace duckdb {
 
 struct ParquetMetaDataBindData : public TableFunctionData {
 	vector<LogicalType> return_types;
-	unique_ptr<MultiFileList> file_list;
+	shared_ptr<MultiFileList> file_list;
 	unique_ptr<MultiFileReader> multi_file_reader;
 };
 

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -78,7 +78,7 @@ vector<string> MultiFileReader::ParsePaths(const Value &input) {
 	}
 }
 
-unique_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context, const vector<string> &paths,
+shared_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context, const vector<string> &paths,
                                                           FileGlobOptions options) {
 	auto &config = DBConfig::GetConfig(context);
 	if (!config.options.enable_external_access) {
@@ -93,7 +93,7 @@ unique_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context
 	return std::move(res);
 }
 
-unique_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context, const Value &input,
+shared_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context, const Value &input,
                                                           FileGlobOptions options) {
 	auto paths = ParsePaths(input);
 	return CreateFileList(context, paths, options);

--- a/src/function/table/glob.cpp
+++ b/src/function/table/glob.cpp
@@ -8,7 +8,7 @@
 namespace duckdb {
 
 struct GlobFunctionBindData : public TableFunctionData {
-	unique_ptr<MultiFileList> file_list;
+	shared_ptr<MultiFileList> file_list;
 };
 
 static unique_ptr<FunctionData> GlobFunctionBind(ClientContext &context, TableFunctionBindInput &input,

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -132,11 +132,11 @@ struct MultiFileReader {
 	//! Parse a Value containing 1 or more paths into a vector of paths. Note: no expansion is performed here
 	DUCKDB_API virtual vector<string> ParsePaths(const Value &input);
 	//! Create a MultiFileList from a vector of paths. Any globs will be expanded using the default filesystem
-	DUCKDB_API virtual unique_ptr<MultiFileList>
+	DUCKDB_API virtual shared_ptr<MultiFileList>
 	CreateFileList(ClientContext &context, const vector<string> &paths,
 	               FileGlobOptions options = FileGlobOptions::DISALLOW_EMPTY);
 	//! Shorthand for ParsePaths + CreateFileList
-	DUCKDB_API unique_ptr<MultiFileList> CreateFileList(ClientContext &context, const Value &input,
+	DUCKDB_API shared_ptr<MultiFileList> CreateFileList(ClientContext &context, const Value &input,
 	                                                    FileGlobOptions options = FileGlobOptions::DISALLOW_EMPTY);
 
 	//! Parse the named parameters of a multi-file reader


### PR DESCRIPTION
Reasoning is that we want to be able to share the MultiFileLists between scans. MultiFileList can be expensive to create. (for example reading a delta table over the network)

In delta I am working on the concept of attach "single-table-catalogs" for delta tables. This would allow us to cache the MultiFileList in the DeltaCatalog or in the DeltaTransaction.