### PR TITLE
allow external cardinality information (e.g. from iceberg)

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -93,6 +93,7 @@ struct ParquetOptions {
 
 	MultiFileReaderOptions file_options;
 	vector<ParquetColumnDefinition> schema;
+	size_t explicit_cardinality = 0;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -93,7 +93,7 @@ struct ParquetOptions {
 
 	MultiFileReaderOptions file_options;
 	vector<ParquetColumnDefinition> schema;
-	size_t explicit_cardinality = 0;
+	idx_t explicit_cardinality = 0;
 
 public:
 	void Serialize(Serializer &serializer) const;

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -70,7 +70,7 @@ struct ParquetReadBindData : public TableFunctionData {
 	// These come from the initial_reader, but need to be stored in case the initial_reader is removed by a filter
 	idx_t initial_file_cardinality;
 	idx_t initial_file_row_groups;
-	idx_t explicit_cardinality = 0; // can be set to inject exterior knowledge on total cardinality (e.g. from a data lake)
+	idx_t explicit_cardinality = 0; // can be set to inject exterior cardinality knowledge (e.g. from a data lake)
 	ParquetOptions parquet_options;
 	MultiFileReaderBindData reader_bind;
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -70,7 +70,7 @@ struct ParquetReadBindData : public TableFunctionData {
 	// These come from the initial_reader, but need to be stored in case the initial_reader is removed by a filter
 	idx_t initial_file_cardinality;
 	idx_t initial_file_row_groups;
-	idx_t explicit_cardinality; // can be set to inject exterior knowledge on total cardinality (e.g. from a data lake)
+	idx_t explicit_cardinality = 0; // can be set to inject exterior knowledge on total cardinality (e.g. from a data lake)
 	ParquetOptions parquet_options;
 	MultiFileReaderBindData reader_bind;
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -70,8 +70,8 @@ struct ParquetReadBindData : public TableFunctionData {
 	// These come from the initial_reader, but need to be stored in case the initial_reader is removed by a filter
 	idx_t initial_file_cardinality;
 	idx_t initial_file_row_groups;
+	idx_t explicit_cardinality; // can be set to inject exterior knowledge on total cardinality (e.g. from a data lake)
 	ParquetOptions parquet_options;
-
 	MultiFileReaderBindData reader_bind;
 
 	void Initialize(shared_ptr<ParquetReader> reader) {
@@ -395,6 +395,7 @@ public:
 		table_function.named_parameters["file_row_number"] = LogicalType::BOOLEAN;
 		table_function.named_parameters["debug_use_openssl"] = LogicalType::BOOLEAN;
 		table_function.named_parameters["compression"] = LogicalType::VARCHAR;
+		table_function.named_parameters["explicit_cardinality"] = LogicalType::UBIGINT;
 		table_function.named_parameters["schema"] =
 		    LogicalType::MAP(LogicalType::INTEGER, LogicalType::STRUCT({{{"name", LogicalType::VARCHAR},
 		                                                                 {"type", LogicalType::VARCHAR},
@@ -545,7 +546,11 @@ public:
 			result->reader_bind = result->multi_file_reader->BindReader<ParquetReader>(
 			    context, result->types, result->names, *result->file_list, *result, parquet_options);
 		}
-
+		if (parquet_options.explicit_cardinality) {
+			auto file_count = result->file_list->GetTotalFileCount();
+			result->explicit_cardinality = parquet_options.explicit_cardinality;
+			result->initial_file_cardinality = result->explicit_cardinality / (file_count ? file_count : 1);
+		}
 		if (return_types.empty()) {
 			// no expected types - just copy the types
 			return_types = result->types;
@@ -618,6 +623,8 @@ public:
 
 				// cannot be combined with hive_partitioning=true, so we disable auto-detection
 				parquet_options.file_options.auto_detect_hive_partitioning = false;
+			} else if (loption == "explicit_cardinality") {
+				parquet_options.explicit_cardinality = UBigIntValue::Get(kv.second);
 			} else if (loption == "encryption_config") {
 				parquet_options.encryption_config = ParquetEncryptionConfig::Create(context, kv.second);
 			}
@@ -847,12 +854,13 @@ public:
 
 	static unique_ptr<NodeStatistics> ParquetCardinality(ClientContext &context, const FunctionData *bind_data) {
 		auto &data = bind_data->Cast<ParquetReadBindData>();
-
+		if (data.explicit_cardinality) {
+			return make_uniq<NodeStatistics>(data.explicit_cardinality);
+		}
 		auto file_list_cardinality_estimate = data.file_list->GetCardinality(context);
 		if (file_list_cardinality_estimate) {
 			return file_list_cardinality_estimate;
 		}
-
 		return make_uniq<NodeStatistics>(MaxValue(data.initial_file_cardinality, (idx_t)1) *
 		                                 data.file_list->GetTotalFileCount());
 	}


### PR DESCRIPTION
add a new named_parameter for the parquet_scan() called "explicit_cardinality"

this ubigint is the exact cardinality of the parquet_scan(), which can span multiple files that one may know from external metadata

like the "schema" named_parameter, it is not really public, but intended for duckdb_iceberg