### PR TITLE
Fix #14249: return NAN when dividened is 0

### DIFF
--- a/src/core_functions/aggregate/distributive/skew.cpp
+++ b/src/core_functions/aggregate/distributive/skew.cpp
@@ -62,7 +62,7 @@ struct SkewnessOperation {
 		}
 		double div = std::sqrt(p);
 		if (div == 0) {
-			finalize_data.ReturnNull();
+			target = NAN;
 			return;
 		}
 		double temp1 = std::sqrt(n * (n - 1)) / (n - 2);

--- a/src/core_functions/aggregate/regression/regr_intercept.cpp
+++ b/src/core_functions/aggregate/regression/regr_intercept.cpp
@@ -45,6 +45,10 @@ struct RegrInterceptOperation {
 			return;
 		}
 		RegrSlopeOperation::Finalize<T, RegrSlopeState>(state.slope, target, finalize_data);
+		if (Value::IsNan(target)) {
+			finalize_data.ReturnNull();
+			return;
+		}
 		auto x_avg = state.sum_x / state.count;
 		auto y_avg = state.sum_y / state.count;
 		target = y_avg - target * x_avg;

--- a/src/include/duckdb/core_functions/aggregate/algebraic/corr.hpp
+++ b/src/include/duckdb/core_functions/aggregate/algebraic/corr.hpp
@@ -58,11 +58,7 @@ struct CorrOperation {
 			if (!Value::DoubleIsFinite(std_y)) {
 				throw OutOfRangeException("STDDEV_POP for Y is out of range!");
 			}
-			if (std_x * std_y == 0) {
-				finalize_data.ReturnNull();
-				return;
-			}
-			target = cov / (std_x * std_y);
+			target = std_x * std_y != 0 ? cov / (std_x * std_y) : NAN;
 		}
 	}
 

--- a/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
+++ b/src/include/duckdb/core_functions/aggregate/regression/regr_slope.hpp
@@ -46,11 +46,7 @@ struct RegrSlopeOperation {
 			if (!Value::DoubleIsFinite(var_pop)) {
 				throw OutOfRangeException("VARPOP is out of range!");
 			}
-			if (var_pop == 0) {
-				finalize_data.ReturnNull();
-				return;
-			}
-			target = cov / var_pop;
+			target = var_pop != 0 ? cov / var_pop : NAN;
 		}
 	}
 

--- a/test/sql/aggregate/aggregates/test_corr.test
+++ b/test/sql/aggregate/aggregates/test_corr.test
@@ -18,7 +18,7 @@ NULL
 query I
 select corr(1,1)
 ----
-NULL
+NAN
 
 statement error
 select corr(*)

--- a/test/sql/aggregate/aggregates/test_regression.test
+++ b/test/sql/aggregate/aggregates/test_regression.test
@@ -72,7 +72,7 @@ NULL
 query I
 select regr_slope(1,1)
 ----
-NULL
+NAN
 
 statement error
 select regr_slope(*)

--- a/test/sql/aggregate/aggregates/test_skewness.test
+++ b/test/sql/aggregate/aggregates/test_skewness.test
@@ -28,7 +28,7 @@ select skewness(*)
 query I
 select skewness (10) from range (5)
 ----
-NULL
+NAN
 
 #Empty Table
 query I

--- a/test/sql/function/list/aggregates/skewness.test
+++ b/test/sql/function/list/aggregates/skewness.test
@@ -19,6 +19,11 @@ CREATE TABLE skew AS SELECT LIST(10) AS i FROM range(5) t1(i)
 query I
 select list_skewness (i) from skew
 ----
+NAN
+
+query I
+select list_skewness ([1,2])
+----
 NULL
 
 # out of range


### PR DESCRIPTION
This pr try to fix #14249 , and in addtion I found skewness may also need such modification.