### PR TITLE
More defensive programming in RowVersionManager::CleanupAppend

### DIFF
--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -145,6 +145,7 @@ void RowVersionManager::CleanupAppend(transaction_t lowest_active_transaction, i
 		}
 		if (!vector_info[vector_idx]) {
 			// already vacuumed - skip
+			continue;
 		}
 		auto &info = *vector_info[vector_idx];
 		// if we wrote the entire chunk info try to compress it

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -139,11 +139,11 @@ void RowVersionManager::CleanupAppend(transaction_t lowest_active_transaction, i
 	for (idx_t vector_idx = start_vector_idx; vector_idx <= end_vector_idx; vector_idx++) {
 		idx_t vcount =
 		    vector_idx == end_vector_idx ? row_group_end - end_vector_idx * STANDARD_VECTOR_SIZE : STANDARD_VECTOR_SIZE;
-		auto &info = *vector_info[vector_idx];
-		if (vcount != STANDARD_VECTOR_SIZE) {
+		if (vcount != STANDARD_VECTOR_SIZE || !vector_info[vector_idx]) {
 			// not written fully - skip
 			continue;
 		}
+		auto &info = *vector_info[vector_idx];
 		// if we wrote the entire chunk info try to compress it
 		unique_ptr<ChunkInfo> new_info;
 		auto cleanup = info.Cleanup(lowest_active_transaction, new_info);

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -139,9 +139,12 @@ void RowVersionManager::CleanupAppend(transaction_t lowest_active_transaction, i
 	for (idx_t vector_idx = start_vector_idx; vector_idx <= end_vector_idx; vector_idx++) {
 		idx_t vcount =
 		    vector_idx == end_vector_idx ? row_group_end - end_vector_idx * STANDARD_VECTOR_SIZE : STANDARD_VECTOR_SIZE;
-		if (vcount != STANDARD_VECTOR_SIZE || !vector_info[vector_idx]) {
+		if (vcount != STANDARD_VECTOR_SIZE) {
 			// not written fully - skip
 			continue;
+		}
+		if (!vector_info[vector_idx]) {
+			// already vacuumed - skip
 		}
 		auto &info = *vector_info[vector_idx];
 		// if we wrote the entire chunk info try to compress it


### PR DESCRIPTION
This fixes an issue where an `InternalException` could be thrown by concurrent connections ingesting small amounts of rows, as they could end up vacuuming the same vector info.