### PR TITLE
[Parquet] Allow opt-in prefetch metadata optimistically read in 1 request

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -1754,6 +1754,9 @@ void ParquetExtension::Load(DuckDB &db) {
 	    "enable_geoparquet_conversion",
 	    "Attempt to decode/encode geometry data in/as GeoParquet files if the spatial extension is present.",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(true));
+	config.AddExtensionOption("prefetch_metadata_bytes", "Optimistically prefetch that many bytes of parquet metadata.",
+	                          LogicalType::UBIGINT, Value(4088));
+	// Default is so that 4088 + 8 bytes that 4KB are always read on the first GET
 }
 
 std::string ParquetExtension::Name() {

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -1755,8 +1755,8 @@ void ParquetExtension::Load(DuckDB &db) {
 	    "Attempt to decode/encode geometry data in/as GeoParquet files if the spatial extension is present.",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(true));
 	config.AddExtensionOption("prefetch_metadata_bytes", "Optimistically prefetch that many bytes of parquet metadata.",
-	                          LogicalType::UBIGINT, Value(4088));
-	// Default is so that 4088 + 8 bytes that 4KB are always read on the first GET
+	                          LogicalType::UBIGINT, Value(0));
+	// prefetch_metadata_bytes to be opt-in only
 }
 
 std::string ParquetExtension::Name() {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -70,9 +70,9 @@ LoadMetadata(ClientContext &context, Allocator &allocator, FileHandle &file_hand
 		throw InvalidInputException("File '%s' too small to be a Parquet file", file_handle.path);
 	}
 
-	Value value;
+	Value value = 0;
 	context.TryGetCurrentSetting("prefetch_metadata_bytes", value);
-	const idx_t prefetch_metadata_bytes_option = UBigIntValue::Get(value);
+	const idx_t prefetch_metadata_bytes_option = value.GetValue<uint64_t>();
 
 	const idx_t requested_footer_size = std::min((idx_t)file_size, prefetch_metadata_bytes_option + 8);
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -112,12 +112,14 @@ LoadMetadata(ClientContext &context, Allocator &allocator, FileHandle &file_hand
 
 	auto metadata_pos = file_size - (footer_len + 8);
 	transport.SetLocation(metadata_pos);
-	if (metadata_pos < file_size - requested_footer_size) {
+	if (prefetch_metadata_bytes_option > 0 && metadata_pos < file_size - requested_footer_size) {
 		// metadata exceed the prefetch_metadata_bytes_option value
 		// Another request is needed
 		transport.ClearPrefetch();
 		transport.Prefetch(metadata_pos, footer_len);
 		// Note that this is not super clean, since some bytes will be requested twice
+	} else {
+		transport.Prefetch(metadata_pos, footer_len);
 	}
 
 	auto metadata = make_uniq<FileMetaData>();

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -967,6 +967,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"pg_use_binary_copy", "postgres_scanner"},
     {"pg_use_ctid_scan", "postgres_scanner"},
     {"prefetch_all_parquet_files", "parquet"},
+    {"prefetch_metadata_bytes", "parquet"},
     {"s3_access_key_id", "httpfs"},
     {"s3_endpoint", "httpfs"},
     {"s3_region", "httpfs"},

--- a/test/parquet/parquet_long_string_stats.test
+++ b/test/parquet/parquet_long_string_stats.test
@@ -9,6 +9,9 @@ require parquet
 statement ok
 pragma enable_object_cache;
 
+statement ok
+SET prefetch_metadata_bytes = 0;
+
 # the constant comparison that is pushed down is longer than DuckDB's 8 bytes that are used in StringStatistics
 # its prefix is equal to the max up to the last byte
 # previously, we would read 5.4MB to figure our that we can prune the entire file

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -10,6 +10,11 @@ PRAGMA enable_verification
 statement ok
 COPY (SELECT 42::INTEGER i) TO '__TEST_DIR__/integers.parquet' (FIELD_IDS {i: 0})
 
+foreach bytes_prefetched 0 10 100 1000 4088 10000 100000
+
+statement ok
+SET prefetch_metadata_bytes = ${bytes_prefetched};
+
 statement error
 SELECT *
 FROM read_parquet('__TEST_DIR__/integers.parquet', schema=map{})
@@ -35,6 +40,8 @@ FROM read_parquet('__TEST_DIR__/*.parquet', schema=map {
                   }, hive_partitioning=true)
 ----
 Binder Error: Parquet schema cannot be combined with union_by_name=true or hive_partitioning=true
+
+endloop
 
 statement ok
 COPY (
@@ -64,6 +71,11 @@ COPY (
 ) TO '__TEST_DIR__/partitioned2' (FIELD_IDS {i1: 5, i3: 3, i4: 2, i5: 1}, PARTITION_BY i1, FORMAT parquet)
 ----
 Binder Error: Column name "i1" specified in FIELD_IDS not found. Consider using WRITE_PARTITION_COLUMNS if this column is a partition column. Available column names:
+
+foreach bytes_prefetched 0 10 100 1000 4088 10000 100000
+
+statement ok
+SET prefetch_metadata_bytes = ${bytes_prefetched};
 
 # cannot duplicate field_ids
 statement error
@@ -144,9 +156,16 @@ FROM read_parquet('__TEST_DIR__/integers.parquet', schema=map {
 ----
 Conversion Error
 
+endloop
+
 # if we don't supply a field id, we can't refer to it using the schema parameter
 statement ok
 COPY (SELECT 42::INTEGER i) TO '__TEST_DIR__/integers.parquet'
+
+foreach bytes_prefetched 0 10 100 1000 4088 10000 100000
+
+statement ok
+SET prefetch_metadata_bytes = ${bytes_prefetched};
 
 query II
 SELECT *
@@ -157,11 +176,18 @@ FROM read_parquet('__TEST_DIR__/integers.parquet', schema=map {
 ----
 NULL	43
 
+endloop
+
 # let's spice it up with more columns
 statement ok
 COPY (
     SELECT 1 i1, 3 i3, 4 i4, 5 i5
 ) TO '__TEST_DIR__/integers.parquet' (FIELD_IDS {i1: 5, i3: 3, i4: 2, i5: 1})
+
+foreach bytes_prefetched 0 10 100 1000 4088 10000 100000
+
+statement ok
+SET prefetch_metadata_bytes = ${bytes_prefetched};
 
 # this is purposely a bit confusing but we're:
 # 1. deleting field id 2
@@ -228,10 +254,17 @@ FROM read_parquet('__TEST_DIR__/integers.parquet', schema=map {
 ----
 5	integers.parquet
 
+endloop
+
 statement ok
 COPY (
     SELECT range % 4 g, range i FROM range(1000)
 ) TO '__TEST_DIR__/integers.parquet' (FIELD_IDS {g: 33, i: 42})
+
+foreach bytes_prefetched 0 10 100 1000 4088 10000 100000
+
+statement ok
+SET prefetch_metadata_bytes = ${bytes_prefetched};
 
 # let's also do a query with a filter and a downcast
 query II
@@ -245,6 +278,8 @@ GROUP BY my_cool_group
 ----
 2	125000
 
+endloop
+
 # also test multi-file reading with different field ids
 statement ok
 COPY (
@@ -255,6 +290,11 @@ statement ok
 COPY (
     SELECT 1 j1, 3 j3, 4 j4, 5 j5
 ) TO '__TEST_DIR__/multifile2.parquet' (FIELD_IDS {j1: 1, j3: 2, j4: 3, j5: 4})
+
+foreach bytes_prefetched 0 10 100 1000 4088 10000 100000
+
+statement ok
+SET prefetch_metadata_bytes = ${bytes_prefetched};
 
 query IIIII
 SELECT i1, i3, i4, i5, filename[-18:]
@@ -268,3 +308,5 @@ ORDER BY filename
 ----
 5	3	2	1	multifile1.parquet
 1	4	5	NULL	multifile2.parquet
+
+endloop

--- a/test/sql/copy/parquet/test_parquet_force_download.test
+++ b/test/sql/copy/parquet/test_parquet_force_download.test
@@ -9,6 +9,9 @@ require httpfs
 require tpch
 
 statement ok
+SET prefetch_metadata_bytes = 0;
+
+statement ok
 SET force_download=true;
 
 query II


### PR DESCRIPTION
Currently to read parquet metadata we issue 2 separate reads to the underlying filesystem.
First to read `[size-8, size)`, second to read `[size-8-metadata_len, size-8)`.
`metadata_len` is known only after the first read, so this is optimal in number of bytes read.

What if the goal would be optimizing number of reads?
The ranges are consecutive, so with an oracle we could read `[size-8-metadata_len, size)` in one go.

We miss the oracle, but the second best thing is optimistically read `[size-X, size)`.
When `metadata_len + 8 <= X`, we are done, otherwise a second read needs to be issued.

Here we provide users with a prefetch_metadata_bytes option to configure what behaviour they prefer.
0 -> no optimisitic prefetch, always 2 reads
X -> X+8 bytes are optimistically prefetched, this might result in a single read of lenght X+8, or 2 reads of total lenght X+8 + metadata_len

Tradeoffs if prefetch_metadata_bytes is provided are as follow:

| X  |  bytes first read | bytes second read | num reads | total number of bytes |
|----|-------------------|-------------------|-----------|-----------------------|
| 0  |  8  | metadata_len | 2 | 8 + metadata_len |
| 4088 (assume >= metadata_len) | 4096 | - | 1 | 4096 |
| 4088 (if < metadata_len) | 4096 | metadata_len | 2 | 4096 + metadata_len |

```
SET prefetch_metadata_bytes=0;
--- no prefetch in place  <---- the default
SET prefetch_metadata_bytes=10000;
--- 10000 + 8 bytes fetched on the first request
SET prefetch_metadata_bytes=4088;
--- 4088 + 8 = 4096 bytes fetched on the first request
```

Default is still kept at 0, that means that if setting is not touched exact same behaviour of now is kept, but users or API have a way to experiment with the setting.

---

Optimal value of the setting will vary a lot between configurations given it's a tradeoff between latency, bandwidth, and to some degree expected distribution of the length of parquet metadata. A description of some values of the bandwidth-delay product are https://en.wikipedia.org/wiki/Bandwidth-delay_product.
I measured some parquet files I had at hand, and 4088 seems to cover most hive partitioned files I had at hand, but I have not (yet) found proper data on what's the distribution here.

To me 4K looks to be a OK-ish default, but for now this is prosed as opt-in only, so default is 0.

----

Then I performed some benchmarks, conducted on the work MacOs machine via executing
```sql
SET prefetch_metadata_bytes=4088;
FROM parquet_metadata('s3://duckdb-blobs/*.parquet');
```
on a loop (counting startup and all), using hyperfine switching between defaults.
```
Benchmark 1: ./build/release/duckdb -c "SET prefetch_metadata_bytes=0; FROM parquet_metadata(\"s3://duckdb-blobs/*.parquet\");"
  Time (mean ± σ):      2.716 s ±  0.124 s    [User: 0.909 s, System: 0.022 s]
  Range (min … max):    2.579 s …  2.967 s    10 runs

Benchmark 2: ./build/release/duckdb -c "SET prefetch_metadata_bytes=1000; FROM parquet_metadata(\"s3://duckdb-blobs/*.parquet\");"
  Time (mean ± σ):      2.483 s ±  0.086 s    [User: 0.814 s, System: 0.022 s]
  Range (min … max):    2.347 s …  2.607 s    10 runs

Benchmark 3: ./build/release/duckdb -c "SET prefetch_metadata_bytes=4088; FROM parquet_metadata(\"s3://duckdb-blobs/*.parquet\");"
  Time (mean ± σ):      2.224 s ±  0.046 s    [User: 0.337 s, System: 0.021 s]
  Range (min … max):    2.142 s …  2.271 s    10 runs

Benchmark 4: ./build/release/duckdb -c "SET prefetch_metadata_bytes=18000; FROM parquet_metadata(\"s3://duckdb-blobs/*.parquet\");"
  Time (mean ± σ):      2.216 s ±  0.114 s    [User: 0.450 s, System: 0.022 s]
  Range (min … max):    2.063 s …  2.459 s    10 runs

Benchmark 5: ./build/release/duckdb -c "SET prefetch_metadata_bytes=100000; FROM parquet_metadata(\"s3://duckdb-blobs/*.parquet\");"
  Time (mean ± σ):      2.864 s ±  0.074 s    [User: 0.220 s, System: 0.026 s]
  Range (min … max):    2.778 s …  2.974 s    10 runs
```

This seems to confirm the intuition that 4K is about right.

The behaviour is the same between local and remote data. This is expected to be noticeable only over the network, on the same machine its likely negligible either way.

Note that an optimisation on this, that is avoiding re-reading overlapping ranges, is left for the next iteration, since I haven't found a unintrusive way to make it happen. Once that's implemented, possibly via BufferedFileHandles in duckdb, the 2-request path should improve a bit.