### PR TITLE
[Python] Use an `ArrowQueryResult` in `FetchArrowTable` when possible.

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyresult.hpp
@@ -60,11 +60,7 @@ public:
 	const vector<LogicalType> &GetTypes();
 
 private:
-	py::list FetchAllArrowChunks(idx_t rows_per_batch, bool to_polars);
-
 	void FillNumpy(py::dict &res, idx_t col_idx, NumpyResultConversion &conversion, const char *name);
-
-	bool FetchArrowChunk(ChunkScanState &scan_state, py::list &batches, idx_t rows_per_batch, bool to_polars);
 
 	PandasDataFrame FrameFromNumpy(bool date_as_object, const py::handle &o);
 


### PR DESCRIPTION
ArrowQueryResult can't be fetched incrementally, so this relies on the fact that the query is executed and the result is then fetched in its entirety.

This path will be used when `sql` was used to create a DuckDBPyRelation and `polars` or `arrow` was then used to fully consume the result into a polars DataFrame or a pyarrow ArrowTable respectively.