### PR TITLE
Issue 14275: Fix SQL value function binding when alias has same name

### DIFF
--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -187,7 +187,7 @@ protected:
 	                          const optional_ptr<bind_lambda_function_t> bind_lambda_function,
 	                          const LogicalType &list_child_type);
 
-	virtual unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name);
+	virtual unique_ptr<ParsedExpression> GetSQLValueFunction(ParsedExpression& expr);
 
 	LogicalType ResolveOperatorType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);
 	LogicalType ResolveCoalesceType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -187,7 +187,7 @@ protected:
 	                          const optional_ptr<bind_lambda_function_t> bind_lambda_function,
 	                          const LogicalType &list_child_type);
 
-	virtual unique_ptr<ParsedExpression> GetSQLValueFunction(ParsedExpression& expr);
+	virtual unique_ptr<ParsedExpression> GetSQLValueFunction(ParsedExpression &expr);
 
 	LogicalType ResolveOperatorType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);
 	LogicalType ResolveCoalesceType(OperatorExpression &op, vector<unique_ptr<Expression>> &children);

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -23,7 +23,7 @@ protected:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 
 	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
-	unique_ptr<ParsedExpression> GetSQLValueFunction(const string &column_name) override;
+	unique_ptr<ParsedExpression> GetSQLValueFunction(ParsedExpression& expr) override;
 
 protected:
 	idx_t unnest_level = 0;

--- a/src/include/duckdb/planner/expression_binder/select_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder/select_binder.hpp
@@ -23,7 +23,7 @@ protected:
 	BindResult BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) override;
 
 	bool QualifyColumnAlias(const ColumnRefExpression &colref) override;
-	unique_ptr<ParsedExpression> GetSQLValueFunction(ParsedExpression& expr) override;
+	unique_ptr<ParsedExpression> GetSQLValueFunction(ParsedExpression &expr) override;
 
 protected:
 	idx_t unnest_level = 0;

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -44,7 +44,9 @@ string GetSQLValueFunctionName(const string &column_name) {
 	return string();
 }
 
-unique_ptr<ParsedExpression> ExpressionBinder::GetSQLValueFunction(const string &column_name) {
+unique_ptr<ParsedExpression> ExpressionBinder::GetSQLValueFunction(ParsedExpression& expr) {
+	auto& col = dynamic_cast<ColumnRefExpression&>(expr);
+	const auto& column_name = col.GetColumnName();
 	auto value_function = GetSQLValueFunctionName(column_name);
 	if (value_function.empty()) {
 		return nullptr;
@@ -430,7 +432,7 @@ BindResult ExpressionBinder::BindExpression(ColumnRefExpression &col_ref_p, idx_
 			}
 
 			// column was not found - check if it is a SQL value function
-			auto value_function = GetSQLValueFunction(col_ref_p.GetColumnName());
+			auto value_function = GetSQLValueFunction(col_ref_p);
 			if (value_function) {
 				return BindExpression(value_function, depth);
 			}

--- a/src/planner/binder/expression/bind_columnref_expression.cpp
+++ b/src/planner/binder/expression/bind_columnref_expression.cpp
@@ -44,9 +44,9 @@ string GetSQLValueFunctionName(const string &column_name) {
 	return string();
 }
 
-unique_ptr<ParsedExpression> ExpressionBinder::GetSQLValueFunction(ParsedExpression& expr) {
-	auto& col = dynamic_cast<ColumnRefExpression&>(expr);
-	const auto& column_name = col.GetColumnName();
+unique_ptr<ParsedExpression> ExpressionBinder::GetSQLValueFunction(ParsedExpression &expr) {
+	auto &col = dynamic_cast<ColumnRefExpression &>(expr);
+	const auto &column_name = col.GetColumnName();
 	auto value_function = GetSQLValueFunctionName(column_name);
 	if (value_function.empty()) {
 		return nullptr;

--- a/src/planner/expression_binder/constant_binder.cpp
+++ b/src/planner/expression_binder/constant_binder.cpp
@@ -13,7 +13,7 @@ BindResult ConstantBinder::BindExpression(unique_ptr<ParsedExpression> &expr_ptr
 	case ExpressionClass::COLUMN_REF: {
 		auto &colref = expr.Cast<ColumnRefExpression>();
 		if (!colref.IsQualified()) {
-			auto value_function = GetSQLValueFunction(colref.GetColumnName());
+			auto value_function = GetSQLValueFunction(colref);
 			if (value_function) {
 				expr_ptr = std::move(value_function);
 				return BindExpression(expr_ptr, depth, root_expression);

--- a/src/planner/expression_binder/having_binder.cpp
+++ b/src/planner/expression_binder/having_binder.cpp
@@ -35,7 +35,7 @@ BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, i
 			return BindLambdaReference(lambda_ref->Cast<LambdaRefExpression>(), depth);
 		}
 		// column was not found - check if it is a SQL value function
-		auto value_function = GetSQLValueFunction(col_ref.GetColumnName());
+		auto value_function = GetSQLValueFunction(col_ref);
 		if (value_function) {
 			return BindExpression(value_function, depth);
 		}

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -8,10 +8,10 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
     : BaseSelectBinder(binder, context, node, info) {
 }
 
-unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(ParsedExpression& expr) {
-	auto& col = dynamic_cast<ColumnRefExpression&>(expr);
-	const auto& column_name = col.GetColumnName();
-	if(column_name == col.alias) {
+unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(ParsedExpression &expr) {
+	auto &col = dynamic_cast<ColumnRefExpression &>(expr);
+	const auto &column_name = col.GetColumnName();
+	if (column_name == col.alias) {
 		return ExpressionBinder::GetSQLValueFunction(expr);
 	}
 	auto alias_entry = node.bind_state.alias_map.find(column_name);

--- a/src/planner/expression_binder/select_binder.cpp
+++ b/src/planner/expression_binder/select_binder.cpp
@@ -8,13 +8,18 @@ SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNo
     : BaseSelectBinder(binder, context, node, info) {
 }
 
-unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(const string &column_name) {
+unique_ptr<ParsedExpression> SelectBinder::GetSQLValueFunction(ParsedExpression& expr) {
+	auto& col = dynamic_cast<ColumnRefExpression&>(expr);
+	const auto& column_name = col.GetColumnName();
+	if(column_name == col.alias) {
+		return ExpressionBinder::GetSQLValueFunction(expr);
+	}
 	auto alias_entry = node.bind_state.alias_map.find(column_name);
 	if (alias_entry != node.bind_state.alias_map.end()) {
 		// don't replace SQL value functions if they are in the alias map
 		return nullptr;
 	}
-	return ExpressionBinder::GetSQLValueFunction(column_name);
+	return ExpressionBinder::GetSQLValueFunction(expr);
 }
 
 BindResult SelectBinder::BindColumnRef(unique_ptr<ParsedExpression> &expr_ptr, idx_t depth, bool root_expression) {

--- a/src/planner/expression_binder/table_function_binder.cpp
+++ b/src/planner/expression_binder/table_function_binder.cpp
@@ -45,7 +45,7 @@ BindResult TableFunctionBinder::BindColumnReference(unique_ptr<ParsedExpression>
 		}
 	}
 
-	auto value_function = ExpressionBinder::GetSQLValueFunction(column_names.back());
+	auto value_function = ExpressionBinder::GetSQLValueFunction(col_ref);
 	if (value_function) {
 		return BindExpression(value_function, depth, root_expression);
 	}

--- a/test/sql/parser/test_value_functions.test
+++ b/test/sql/parser/test_value_functions.test
@@ -69,3 +69,10 @@ select a as "CURRENT_TIMESTAMP" from (VALUES (84), (42)) t(a) order by "CURRENT_
 ----
 42
 84
+
+# issue 14275: sql value function aliased to itself
+statement ok
+select current_timestamp as current_timestamp;
+
+statement ok
+select current_user as current_user;


### PR DESCRIPTION
Change `GetSQLValueFunction` to take `ColumnRefExpression` - as `ParsedExpression` - so lookup in `alias_map` can be skipped if column is aliased to its own name.

This works but I'm sure there's a better duckdb way of doing it

Fixes issue #14275