### PR TITLE
Support defining column names in CTAS

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -176,6 +176,24 @@ string TableCatalogEntry::ColumnsToSQL(const ColumnList &columns, const vector<u
 	return ss.str();
 }
 
+string TableCatalogEntry::ColumnNamesToSQL(const ColumnList &columns) {
+	if (columns.empty()) {
+		return "";
+	}
+
+	std::stringstream ss;
+	ss << "(";
+
+	for (auto &column : columns.Logical()) {
+		if (column.Oid() > 0) {
+			ss << ", ";
+		}
+		ss << column.Name();
+	}
+	ss << ")";
+	return ss.str();
+}
+
 string TableCatalogEntry::ToSQL() const {
 	auto create_info = GetInfo();
 	return create_info->ToString();

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -188,7 +188,7 @@ string TableCatalogEntry::ColumnNamesToSQL(const ColumnList &columns) {
 		if (column.Oid() > 0) {
 			ss << ", ";
 		}
-		ss << column.Name();
+		ss << KeywordHelper::WriteOptionallyQuoted(column.Name()) << " ";
 	}
 	ss << ")";
 	return ss.str();

--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -98,6 +98,9 @@ public:
 
 	DUCKDB_API static string ColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints);
 
+	//! Returns the expresioon string list of the column names e.g. (col1, col2, col3)
+	static string ColumnNamesToSQL(const ColumnList &columns);
+
 	//! Returns a list of segment information for this table, if exists
 	virtual vector<ColumnSegmentInfo> GetColumnSegmentInfo();
 

--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -98,7 +98,7 @@ public:
 
 	DUCKDB_API static string ColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints);
 
-	//! Returns the expresioon string list of the column names e.g. (col1, col2, col3)
+	//! Returns the expression string list of the column names e.g. (col1, col2, col3)
 	static string ColumnNamesToSQL(const ColumnList &columns);
 
 	//! Returns a list of segment information for this table, if exists

--- a/src/parser/parsed_data/create_table_info.cpp
+++ b/src/parser/parsed_data/create_table_info.cpp
@@ -47,6 +47,7 @@ string CreateTableInfo::ToString() const {
 	ret += QualifierToString(temporary ? "" : catalog, schema, table);
 
 	if (query != nullptr) {
+		ret += TableCatalogEntry::ColumnNamesToSQL(columns);
 		ret += " AS " + query->ToString();
 	} else {
 		ret += TableCatalogEntry::ColumnsToSQL(columns, constraints) + ";";

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -319,10 +319,30 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 		// construct the set of columns based on the names and types of the query
 		auto &names = query_obj.names;
 		auto &sql_types = query_obj.types;
+		// e.g. create table (col1 ,col2) as QUERY
+		// col1 and col2 are the target_col_names
+		auto target_col_names = base.columns.GetColumnNames();
+		// TODO check  types and target_col_names are mismatch in size
 		D_ASSERT(names.size() == sql_types.size());
 		base.columns.SetAllowDuplicates(true);
-		for (idx_t i = 0; i < names.size(); i++) {
-			base.columns.AddColumn(ColumnDefinition(names[i], sql_types[i]));
+		if (target_col_names.size() > 0) {
+			if (target_col_names.size() > sql_types.size()) {
+				throw BinderException("Target table has more colum names than query result.");
+			} else if (target_col_names.size() < sql_types.size()) {
+				// filled the target_col_names with the name of query names
+				for (idx_t i = target_col_names.size(); i < sql_types.size(); i++) {
+					target_col_names.push_back(names[i]);
+				}
+			}
+			ColumnList new_colums;
+			for (idx_t i = 0; i < target_col_names.size(); i++) {
+				new_colums.AddColumn(ColumnDefinition(target_col_names[i], sql_types[i]));
+			}
+			base.columns = std::move(new_colums);
+		} else {
+			for (idx_t i = 0; i < names.size(); i++) {
+				base.columns.AddColumn(ColumnDefinition(names[i], sql_types[i]));
+			}
 		}
 	} else {
 		SetCatalogLookupCallback([&dependencies, &schema](CatalogEntry &entry) {

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -325,7 +325,7 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 		// TODO check  types and target_col_names are mismatch in size
 		D_ASSERT(names.size() == sql_types.size());
 		base.columns.SetAllowDuplicates(true);
-		if (target_col_names.size() > 0) {
+		if (!target_col_names.empty()) {
 			if (target_col_names.size() > sql_types.size()) {
 				throw BinderException("Target table has more colum names than query result.");
 			} else if (target_col_names.size() < sql_types.size()) {

--- a/test/sql/create/create_as.test
+++ b/test/sql/create/create_as.test
@@ -64,3 +64,45 @@ CREATE TABLE tbl4 IF NOT EXISTS AS SELECT 4;
 statement error
 CREATE OR REPLACE TABLE tbl4 IF NOT EXISTS AS SELECT 4;
 ----
+
+
+### CREATE TABLE t(col1, col2) AS SELECT ... 
+statement ok
+CREATE TABLE tbl4(col1, col2) AS SELECT 1, 'hello';
+
+query II
+SELECT * FROM tbl4;
+----
+1	hello
+
+
+statement ok
+CREATE OR REPLACE TABLE tbl4(col1, col2) AS SELECT 2, 'duck';
+
+query II
+SELECT * FROM tbl4;
+----
+2	duck
+
+
+statement ok
+CREATE TABLE IF NOT EXISTS tbl5(col1, col2) AS SELECT 3, 'database';
+
+query II
+SELECT * FROM tbl5;
+----
+3	database
+
+#colname and query mismatch
+statement ok
+CREATE TABLE tbl6(col1) AS SELECT 4 ,'mismatch';
+
+query II
+SELECT * FROM tbl6;
+----
+4	mismatch
+
+statement error
+CREATE TABLE tbl7(col1, col2) AS SELECT 5;
+----
+Binder Error: Target table has more colum names than query result.

--- a/test/sql/create/create_as.test
+++ b/test/sql/create/create_as.test
@@ -93,6 +93,15 @@ SELECT * FROM tbl5;
 ----
 3	database
 
+# define a column name need quote
+statement ok
+CREATE OR REPLACE TABLE tbl5(col1, "col need ' quote") AS SELECT 3.5, 'quote';
+
+query II
+SELECT * FROM tbl5;
+----
+3.5	quote
+
 #colname and query mismatch
 statement ok
 CREATE TABLE tbl6(col1) AS SELECT 4 ,'mismatch';


### PR DESCRIPTION
Implementing support for explicit column name definition in `CREATE TABLE AS` (CTAS) statements 

```sql 
CREATE TABLE tbl(col1, col2) AS 
SELECT 1, 'hello';
```
| col1 | col2  |
|-----:|-------|
| 1    | hello |

Additionally, this implementation adheres to PostgreSQL behavior when column name definitions and query result counts do not match.
```sql
CREATE TABLE tbl(col1) AS 
SELECT 4 ,'mismatch';
```
| col1 | 'mismatch' |
|-----:|------------|
| 4    | mismatch   |

When the number of defined column names is less than the query result columns, we first use the specified column names, then adopt the query result column names for the remaining columns, starting from where the defined names left off.


```sql
CREATE TABLE tbl(col1, col2) 
AS SELECT 5;
```
**Binder Error: Target table has more colum names than query result.**

