### PR TITLE
GetWALIfExists: Avoid eagerly creating WAL file

### DIFF
--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -119,6 +119,8 @@ protected:
 	unique_ptr<WriteAheadLog> wal;
 	//! Whether or not the database is opened in read-only mode
 	bool read_only;
+	//! Whether WAL file might exists, or it's guaranteed to not be there
+	bool wal_file_might_exists {true};
 	//! When loading a database, we do not yet set the wal-field. Therefore, GetWriteAheadLog must
 	//! return nullptr when loading a database
 	bool load_complete = false;

--- a/src/include/duckdb/storage/storage_manager.hpp
+++ b/src/include/duckdb/storage/storage_manager.hpp
@@ -83,6 +83,7 @@ public:
 	idx_t GetWALSize();
 	//! Gets the WAL of the StorageManager, or nullptr, if there is no WAL.
 	optional_ptr<WriteAheadLog> GetWAL();
+	optional_ptr<WriteAheadLog> GetWALIfExists();
 	//! Deletes the WAL file, and resets the unique pointer.
 	void ResetWAL();
 

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -36,7 +36,12 @@ static TemporaryBufferSize SizeToTemporaryBufferSize(const idx_t size) {
 }
 
 static idx_t TemporaryBufferSizeToSize(const TemporaryBufferSize size) {
-	D_ASSERT(TemporaryBufferSizeIsValid(size));
+	// Silence a compiler warning turned error on TemporaryBufferSizeIsValid not being used
+	{
+		const bool res = TemporaryBufferSizeIsValid(size);
+		(void)res;
+		D_ASSERT(res);
+	}
 	return static_cast<idx_t>(size);
 }
 


### PR DESCRIPTION
This skips side effect of actually creating a WAL file when calling `GetWALSize()`.
This should have negligible effect, given in most cases this is delayed, but cleans it up a bit.

Workflow where this does makes a minor differences, is for example something like:
```sql
duckdb file.db -c "CREATE TABLE T AS SELECT 42;"
```
to create a DuckDB file with no wal, and then:
```
duckdb file.db -c "CHECKPOINT;"
```

Before this PR, this would create a WAL file, after this not.

----

I tried to check using MacOS's Instruments System Call Traces, and after copy pasting the logs to files `log_A` and `log_B`:

```sql
SELECT 'log_A', count(*) FROM read_csv('log_A') UNION ALL SELECT 'log_B', count(*) FROM read_csv('log_B');
```
```
┌─────────┬──────────────┐
│ 'log_A' │ count_star() │
│ varchar │    int64     │
├─────────┼──────────────┤
│ log_A   │          440 │
│ log_B   │          421 │
└─────────┴──────────────┘
```
```sql
FROM
    (SELECT Signature, count(*) as count FROM read_csv('log_A') GROUP BY Signature) AS A,
    (SELECT Signature, count(*) as count FROM read_csv('log_B') GROUP BY Signature) AS B
    WHERE A.Signature = B.Signature AND A.count != B.count;
```
```
┌──────────────────────────────────────────┬───────┬──────────────────────────────────────────┬───────┐
│                Signature                 │ count │                Signature                 │ count │
│                 varchar                  │ int64 │                 varchar                  │ int64 │
├──────────────────────────────────────────┼───────┼──────────────────────────────────────────┼───────┤
│ mach_vm_deallocate_trap                  │    18 │ mach_vm_deallocate_trap                  │    17 │
│ mach_vm_map_trap                         │    27 │ mach_vm_map_trap                         │    21 │
│ access(path, amode:F_OK) = 0 (reachable) │     5 │ access(path, amode:F_OK) = 0 (reachable) │     3 │
└──────────────────────────────────────────┴───────┴──────────────────────────────────────────┴───────┘
```
(these accounts only for 9 differences, but I am too lazy to figure out how to join better)