### PR TITLE
Avoid throwing InternalException on reading secret

### DIFF
--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -110,9 +110,9 @@ unique_ptr<BaseSecret> SecretManager::DeserializeSecret(Deserializer &deserializ
 
 	auto function_entry = LookupFunctionInternal(type, provider);
 	if (!function_entry) {
-		throw InternalException(
-		    "Attempted to deserialize secret (type: '%s', provider: '%s') which does not have any functions registered",
-		    type, provider);
+		throw IOException("Attempted to deserialize secret (type: '%s', provider: '%s', path: '%s') which does not "
+		                  "have any functions registered",
+		                  type, provider, secret_path);
 	}
 
 	return deserialized_type.deserializer(deserializer, {scope, type, provider, name},


### PR DESCRIPTION
Secrets are basically untrusted input, even if they come from future versions of DuckDB that might have changed the availably types / providers. As such it's fine to throw a recoverable exception here.

Connected to the comment to #14332 at https://github.com/duckdb/duckdb/pull/14332/files#r1797295669.