### PR TITLE
Internal #3251: DateDiff Across Epoch

### DIFF
--- a/src/core_functions/scalar/date/date_diff.cpp
+++ b/src/core_functions/scalar/date/date_diff.cpp
@@ -28,6 +28,14 @@ struct DateDiff {
 		    });
 	}
 
+	//	We need to truncate down, not towards 0
+	static inline int64_t Truncate(int64_t value, int64_t units) {
+		return (value + (value < 0)) / units - (value < 0);
+	}
+	static inline int64_t Diff(int64_t start, int64_t end, int64_t units) {
+		return Truncate(end, units) - Truncate(start, units);
+	}
+
 	struct YearOperator {
 		template <class TA, class TB, class TR>
 		static inline TR Operation(TA startdate, TB enddate) {
@@ -204,30 +212,28 @@ template <>
 int64_t DateDiff::MillisecondsOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
 	D_ASSERT(Timestamp::IsFinite(startdate));
 	D_ASSERT(Timestamp::IsFinite(enddate));
-	return Timestamp::GetEpochMs(enddate) - Timestamp::GetEpochMs(startdate);
+	return Diff(startdate.value, enddate.value, Interval::MICROS_PER_MSEC);
 }
 
 template <>
 int64_t DateDiff::SecondsOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
 	D_ASSERT(Timestamp::IsFinite(startdate));
 	D_ASSERT(Timestamp::IsFinite(enddate));
-	return Timestamp::GetEpochSeconds(enddate) - Timestamp::GetEpochSeconds(startdate);
+	return Diff(startdate.value, enddate.value, Interval::MICROS_PER_SEC);
 }
 
 template <>
 int64_t DateDiff::MinutesOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
 	D_ASSERT(Timestamp::IsFinite(startdate));
 	D_ASSERT(Timestamp::IsFinite(enddate));
-	return Timestamp::GetEpochSeconds(enddate) / Interval::SECS_PER_MINUTE -
-	       Timestamp::GetEpochSeconds(startdate) / Interval::SECS_PER_MINUTE;
+	return Diff(startdate.value, enddate.value, Interval::MICROS_PER_MINUTE);
 }
 
 template <>
 int64_t DateDiff::HoursOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
 	D_ASSERT(Timestamp::IsFinite(startdate));
 	D_ASSERT(Timestamp::IsFinite(enddate));
-	return Timestamp::GetEpochSeconds(enddate) / Interval::SECS_PER_HOUR -
-	       Timestamp::GetEpochSeconds(startdate) / Interval::SECS_PER_HOUR;
+	return Diff(startdate.value, enddate.value, Interval::MICROS_PER_HOUR);
 }
 
 // TIME specialisations

--- a/test/sql/function/timestamp/test_date_diff_epoch.test
+++ b/test/sql/function/timestamp/test_date_diff_epoch.test
@@ -1,0 +1,66 @@
+# name: test/sql/function/timestamp/test_date_diff_epoch.test
+# description: Test equal period timestamp diffs across the Unix epoch
+# group: [timestamp]
+
+statement ok
+PRAGMA enable_verification
+
+query III
+SELECT 
+	start_ts, 
+	end_ts, 
+	DATEDIFF('day', start_ts, end_ts) AS dd_hour 
+FROM VALUES (
+	'1970-01-03 12:12:12'::TIMESTAMP, 
+	'1969-12-25 05:05:05'::TIMESTAMP
+	) x(start_ts, end_ts);
+----
+1970-01-03 12:12:12	1969-12-25 05:05:05	-9
+
+query III
+SELECT 
+	start_ts, 
+	end_ts, 
+	DATEDIFF('hour', start_ts, end_ts) AS dd_hour 
+FROM VALUES (
+	'1970-01-01 12:12:12'::TIMESTAMP, 
+	'1969-12-31 05:05:05'::TIMESTAMP
+	) x(start_ts, end_ts);
+----
+1970-01-01 12:12:12	1969-12-31 05:05:05	-31
+
+query III
+SELECT 
+	start_ts, 
+	end_ts, 
+	DATEDIFF('minute', start_ts, end_ts) AS dd_minute 
+FROM VALUES (
+	'1970-01-01 00:12:12'::TIMESTAMP, 
+	'1969-12-31 23:05:05'::TIMESTAMP
+	) x(start_ts, end_ts);
+----
+1970-01-01 00:12:12	1969-12-31 23:05:05	-67
+
+query III
+SELECT 
+	start_ts, 
+	end_ts, 
+	DATEDIFF('second', start_ts, end_ts) AS dd_second 
+FROM VALUES (
+	'1970-01-01 00:00:12.456'::TIMESTAMP, 
+	'1969-12-31 23:59:05.123'::TIMESTAMP
+	) x(start_ts, end_ts);
+----
+1970-01-01 00:00:12.456	1969-12-31 23:59:05.123	-67
+
+query III
+SELECT 
+	start_ts, 
+	end_ts, 
+	DATEDIFF('millisecond', start_ts, end_ts) AS dd_second 
+FROM VALUES (
+	'1970-01-01 00:00:12.456789'::TIMESTAMP, 
+	'1969-12-31 23:59:05.123456'::TIMESTAMP
+	) x(start_ts, end_ts);
+----
+1970-01-01 00:00:12.456789	1969-12-31 23:59:05.123456	-67333


### PR DESCRIPTION
Integer division in C++ rounds towards 0, not down. This was impacting all resolutions hour and below.

fixes: duckdblabs/duckdb-internal#3251