### PR TITLE
[Appender] Support appending to table with generated columns

### DIFF
--- a/src/include/duckdb/main/table_description.hpp
+++ b/src/include/duckdb/main/table_description.hpp
@@ -13,12 +13,26 @@
 namespace duckdb {
 
 struct TableDescription {
+public:
 	//! The schema of the table
 	string schema;
 	//! The table name of the table
 	string table;
 	//! The columns of the table
 	vector<ColumnDefinition> columns;
+
+public:
+	idx_t PhysicalColumnCount() const {
+		idx_t count = 0;
+		for (auto &column : columns) {
+			if (column.Generated()) {
+				continue;
+			}
+			count++;
+		}
+		D_ASSERT(count != 0);
+		return count;
+	}
 };
 
 } // namespace duckdb

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -62,6 +62,9 @@ Appender::Appender(Connection &con, const string &schema_name, const string &tab
 	}
 	vector<optional_ptr<const ParsedExpression>> defaults;
 	for (auto &column : description->columns) {
+		if (column.Generated()) {
+			continue;
+		}
 		types.push_back(column.Type());
 		defaults.push_back(column.HasDefaultValue() ? &column.DefaultValue() : nullptr);
 	}


### PR DESCRIPTION
This PR fixes #14343 

The chunk we create and fill for a table in the Appender should not contain Vectors for generated columns, these are added later in the LocalAppend call.

Now they are ignored and no longer cause a "Call to EndRow before all columns have been appended to!" error.