### PR TITLE
Get the current setting in the database file opener

### DIFF
--- a/src/include/duckdb/main/database_file_opener.hpp
+++ b/src/include/duckdb/main/database_file_opener.hpp
@@ -22,7 +22,7 @@ public:
 	}
 
 	SettingLookupResult TryGetCurrentSetting(const string &key, Value &result) override {
-		return SettingLookupResult();
+		return db.TryGetCurrentSetting(key, result);
 	}
 
 	optional_ptr<ClientContext> TryGetClientContext() override {


### PR DESCRIPTION
Allows correctly fetching settings from the file opener during `ATTACH` of databases