### PR TITLE
support INTERVAL with the AVG aggregate function

### DIFF
--- a/src/include/duckdb/core_functions/aggregate/sum_helpers.hpp
+++ b/src/include/duckdb/core_functions/aggregate/sum_helpers.hpp
@@ -11,6 +11,9 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/operator/add.hpp"
+#include "duckdb/common/operator/multiply.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
 
 namespace duckdb {
 
@@ -139,6 +142,20 @@ struct AddToHugeint {
 				state.value += addition;
 			}
 		}
+	}
+};
+
+struct IntervalAdd {
+	template <class STATE, class T>
+	static void AddNumber(STATE &state, T input) {
+		state.value = AddOperator::Operation<interval_t, interval_t, interval_t>(state.value, input);
+	}
+
+	template <class STATE, class T>
+	static void AddConstant(STATE &state, T input, idx_t count) {
+		const auto count64 = Cast::Operation<idx_t, int64_t>(count);
+		input = MultiplyOperator::Operation<interval_t, int64_t, interval_t>(input, count64);
+		state.value = AddOperator::Operation<interval_t, interval_t, interval_t>(state.value, input);
 	}
 };
 

--- a/test/sql/aggregate/aggregates/test_avg.test
+++ b/test/sql/aggregate/aggregates/test_avg.test
@@ -56,6 +56,18 @@ SELECT AVG(i) FROM integers WHERE i > 100
 ----
 NULL
 
+statement ok
+CREATE TABLE intervals(itvl INTERVAL)
+
+statement ok
+INSERT INTO intervals VALUES ('1 day'), ('30 days'), ('30 days'), ('30 days'), ('30 days')
+
+query II
+SELECT AVG(itvl), AVG(DISTINCT itvl) FROM intervals
+----
+24 days
+15 days
+
 # invalid use of average
 statement error
 SELECT AVG()


### PR DESCRIPTION
```sql
CREATE TABLE intervals AS
SELECT interval_value AS intvl
FROM (
    VALUES 
        ('1 hour'::interval),
        ('2 hours'::interval),
        ('3 hours'::interval),
        ('4 hours'::interval),
        ('5 hours'::interval)
) AS t(interval_value);
```

```sql
SELECT avg(intvl) FROM intervals;

┌────────────┐
│ avg(intvl) │
│  interval  │
├────────────┤
│ 03:00:00   │
└────────────┘
```

Using intervals with the AVG aggregate function is particularly valuable in calculating average age or duration metrics
e.g.

```sql
SELECT
    EXTRACT(DOW FROM created_at) AS day_of_week,
    AVG(AGE(merged_at, created_at)) AS avg_merge_duration,
    COUNT(*) AS pr_count
FROM
    kafka
WHERE
    merged_at IS NOT NULL
GROUP BY
    EXTRACT(DOW FROM created_at)
ORDER BY
    day_of_week;
```

I understand that @hawkfish has expertise in date and time-related pull requests. Any feedback would be helpful.
I will add a SUM aggregate in the following PR.