### PR TITLE
Move _rtools platform to be equivalent to _mingw

### DIFF
--- a/.github/config/distribution_matrix.json
+++ b/.github/config/distribution_matrix.json
@@ -39,7 +39,7 @@
         "vcpkg_triplet": "x64-windows-static-md"
       },
       {
-        "duckdb_arch": "windows_amd64_rtools",
+        "duckdb_arch": "windows_amd64_mingw",
         "vcpkg_triplet": "x64-mingw-static"
       }
     ]

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -62,8 +62,8 @@ jobs:
 
       - uses: ./.github/actions/build_extensions
         with:
-          deploy_as: windows_amd64_rtools
-          duckdb_arch: windows_amd64_rtools
+          deploy_as: windows_amd64_mingw
+          duckdb_arch: windows_amd64_mingw
           vcpkg_target_triplet: x64-mingw-static
           treat_warn_as_error: 0
           s3_id: ${{ secrets.S3_ID }}

--- a/src/include/duckdb/common/platform.hpp
+++ b/src/include/duckdb/common/platform.hpp
@@ -48,9 +48,9 @@ std::string DuckDBPlatform() { // NOLINT: allow definition in header
 #ifdef __MINGW32__
 	postfix = "_mingw";
 #endif
-// this is used for the windows R builds which use a separate build environment
+// this is used for the windows R builds which use `mingw` equivalent extensions
 #ifdef DUCKDB_PLATFORM_RTOOLS
-	postfix = "_rtools";
+	postfix = "_mingw";
 #endif
 	return os + "_" + arch + postfix;
 }


### PR DESCRIPTION
Context is that @taniabogatsch is working on adding support for Windows for the go-duckdb driver, we tested go on Windows and rtools extensions work correctly, given R and Go on Windows are basically the same platform, so given `rtools` seems pretty specific, we decided the path forward is simplifying platforms, merging `mingw` and `rtools`.

Merging this PR will also allow to trigger a build of extensions for DuckDB v1.1.2 to be produced with the `_mingw` platform, and that should allow experimenting with this and possibly already shipping Go on Windows.

This is expected to go in full effect only with nightly versions, and to be released on 1.2.0.

Pinging @krlmlr, that works on duckdb R integration, although I would imagine this should just work. Positive impact would be that with more users for ex-`rtools` now `mingw` platform the requests for support for extensions can have more weight.

This will need documentation, and possibly worth mentioning in the next release notes.