### PR TITLE
Use table-level locking when acquiring shared locks

### DIFF
--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -107,7 +107,7 @@ private:
 		weak_ptr<CheckpointLock> checkpoint_lock;
 	};
 	//! Active locks on tables
-	reference_map_t<DataTableInfo, ActiveTableLock> active_locks;
+	reference_map_t<DataTableInfo, unique_ptr<ActiveTableLock>> active_locks;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -102,8 +102,12 @@ private:
 	reference_map_t<RowGroupCollection, shared_ptr<RowGroupCollection>> updated_collections;
 	//! Lock for the active_locks map
 	mutex active_locks_lock;
+	struct ActiveTableLock {
+		mutex checkpoint_lock_mutex; // protects access to the checkpoint_lock field in this class
+		weak_ptr<CheckpointLock> checkpoint_lock;
+	};
 	//! Active locks on tables
-	reference_map_t<DataTableInfo, weak_ptr<CheckpointLock>> active_locks;
+	reference_map_t<DataTableInfo, ActiveTableLock> active_locks;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This is a follow-up to https://github.com/duckdb/duckdb/pull/13712, using a more fine-granular locking approach.

#13712 has fixed an issue where checkpoints together with concurrent queries that referenced the same table multiple times could lead to deadlocks. The locking approach in that PR used a transaction-level lock to coordinate lock acquisition for the same table.

In case of a query having many table scans (for different tables), this could potentially now block all executor threads if only a single table lock could not be acquired (e.g. due to a concurrent checkpoint). One thread would be blocked trying to acquire the checkpoint lock for the given table, and many others on the active_locks_lock (even though they would only be interested in acquiring the checkpoint lock for another table that wasn't being checkpointed).