### PR TITLE
Table locks - always grab table locks through the transaction interface 

### DIFF
--- a/src/include/duckdb/transaction/commit_state.hpp
+++ b/src/include/duckdb/transaction/commit_state.hpp
@@ -23,7 +23,7 @@ struct UpdateInfo;
 
 class CommitState {
 public:
-	explicit CommitState(transaction_t commit_id);
+	explicit CommitState(DuckTransaction &transaction, transaction_t commit_id);
 
 public:
 	void CommitEntry(UndoFlags type, data_ptr_t data);
@@ -33,6 +33,7 @@ private:
 	void CommitEntryDrop(CatalogEntry &entry, data_ptr_t extra_data);
 
 private:
+	DuckTransaction &transaction;
 	transaction_t commit_id;
 };
 

--- a/src/include/duckdb/transaction/commit_state.hpp
+++ b/src/include/duckdb/transaction/commit_state.hpp
@@ -14,6 +14,7 @@
 namespace duckdb {
 class CatalogEntry;
 class DataChunk;
+class DuckTransaction;
 class WriteAheadLog;
 class ClientContext;
 

--- a/src/include/duckdb/transaction/rollback_state.hpp
+++ b/src/include/duckdb/transaction/rollback_state.hpp
@@ -13,6 +13,7 @@
 namespace duckdb {
 class DataChunk;
 class DataTable;
+class DuckTransaction;
 class WriteAheadLog;
 
 class RollbackState {

--- a/src/include/duckdb/transaction/rollback_state.hpp
+++ b/src/include/duckdb/transaction/rollback_state.hpp
@@ -17,11 +17,13 @@ class WriteAheadLog;
 
 class RollbackState {
 public:
-	RollbackState() {
-	}
+	explicit RollbackState(DuckTransaction &transaction);
 
 public:
 	void RollbackEntry(UndoFlags type, data_ptr_t data);
+
+private:
+	DuckTransaction &transaction;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -36,7 +36,7 @@ public:
 	};
 
 public:
-	explicit UndoBuffer(ClientContext &context);
+	explicit UndoBuffer(DuckTransaction &transaction, ClientContext &context);
 
 	//! Reserve space for an entry of the specified type and length in the undo
 	//! buffer
@@ -58,6 +58,7 @@ public:
 	void Rollback() noexcept;
 
 private:
+	DuckTransaction &transaction;
 	ArenaAllocator allocator;
 
 private:

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/storage/arena_allocator.hpp"
 
 namespace duckdb {
+class DuckTransaction;
 class StorageCommitState;
 class WriteAheadLog;
 

--- a/src/include/duckdb/transaction/wal_write_state.hpp
+++ b/src/include/duckdb/transaction/wal_write_state.hpp
@@ -14,6 +14,7 @@
 namespace duckdb {
 class CatalogEntry;
 class DataChunk;
+class DuckTransaction;
 class WriteAheadLog;
 class ClientContext;
 

--- a/src/include/duckdb/transaction/wal_write_state.hpp
+++ b/src/include/duckdb/transaction/wal_write_state.hpp
@@ -23,7 +23,8 @@ struct UpdateInfo;
 
 class WALWriteState {
 public:
-	explicit WALWriteState(WriteAheadLog &log, optional_ptr<StorageCommitState> commit_state);
+	explicit WALWriteState(DuckTransaction &transaction, WriteAheadLog &log,
+	                       optional_ptr<StorageCommitState> commit_state);
 
 public:
 	void CommitEntry(UndoFlags type, data_ptr_t data);
@@ -36,6 +37,7 @@ private:
 	void WriteUpdate(UpdateInfo &info);
 
 private:
+	DuckTransaction &transaction;
 	WriteAheadLog &log;
 	optional_ptr<StorageCommitState> commit_state;
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -223,28 +223,18 @@ TableIOManager &TableIOManager::Get(DataTable &table) {
 //===--------------------------------------------------------------------===//
 // Scan
 //===--------------------------------------------------------------------===//
-void DataTable::InitializeScan(TableScanState &state, const vector<column_t> &column_ids,
-                               TableFilterSet *table_filters) {
-	if (!state.checkpoint_lock) {
-		state.checkpoint_lock = make_shared_ptr<CheckpointLock>(info->checkpoint_lock.GetSharedLock());
-	}
-	state.Initialize(column_ids, table_filters);
-	row_groups->InitializeScan(state.table_state, column_ids, table_filters);
-}
-
 void DataTable::InitializeScan(DuckTransaction &transaction, TableScanState &state, const vector<column_t> &column_ids,
                                TableFilterSet *table_filters) {
 	state.checkpoint_lock = transaction.SharedLockTable(*info);
 	auto &local_storage = LocalStorage::Get(transaction);
-	InitializeScan(state, column_ids, table_filters);
+	state.Initialize(column_ids, table_filters);
+	row_groups->InitializeScan(state.table_state, column_ids, table_filters);
 	local_storage.InitializeScan(*this, state.local_state, table_filters);
 }
 
-void DataTable::InitializeScanWithOffset(TableScanState &state, const vector<column_t> &column_ids, idx_t start_row,
-                                         idx_t end_row) {
-	if (!state.checkpoint_lock) {
-		state.checkpoint_lock = make_shared_ptr<CheckpointLock>(info->checkpoint_lock.GetSharedLock());
-	}
+void DataTable::InitializeScanWithOffset(DuckTransaction &transaction, TableScanState &state,
+                                         const vector<column_t> &column_ids, idx_t start_row, idx_t end_row) {
+	state.checkpoint_lock = transaction.SharedLockTable(*info);
 	state.Initialize(column_ids);
 	row_groups->InitializeScanWithOffset(state.table_state, column_ids, start_row, end_row);
 }
@@ -891,7 +881,8 @@ void DataTable::FinalizeAppend(DuckTransaction &transaction, TableAppendState &s
 	row_groups->FinalizeAppend(transaction, state);
 }
 
-void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::function<void(DataChunk &chunk)> &function) {
+void DataTable::ScanTableSegment(DuckTransaction &transaction, idx_t row_start, idx_t count,
+                                 const std::function<void(DataChunk &chunk)> &function) {
 	if (count == 0) {
 		return;
 	}
@@ -909,7 +900,7 @@ void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::functi
 
 	CreateIndexScanState state;
 
-	InitializeScanWithOffset(state, column_ids, row_start, row_start + count);
+	InitializeScanWithOffset(transaction, state, column_ids, row_start, row_start + count);
 	auto row_start_aligned = state.table_state.row_group->start + state.table_state.vector_index * STANDARD_VECTOR_SIZE;
 
 	idx_t current_row = row_start_aligned;
@@ -951,7 +942,7 @@ void DataTable::MergeStorage(RowGroupCollection &data, TableIndexList &,
 	row_groups->Verify();
 }
 
-void DataTable::WriteToLog(WriteAheadLog &log, idx_t row_start, idx_t count,
+void DataTable::WriteToLog(DuckTransaction &transaction, WriteAheadLog &log, idx_t row_start, idx_t count,
                            optional_ptr<StorageCommitState> commit_state) {
 	log.WriteSetTable(info->schema, info->table);
 	if (commit_state) {
@@ -973,7 +964,7 @@ void DataTable::WriteToLog(WriteAheadLog &log, idx_t row_start, idx_t count,
 			}
 		}
 	}
-	ScanTableSegment(row_start, count, [&](DataChunk &chunk) { log.WriteInsert(chunk); });
+	ScanTableSegment(transaction, row_start, count, [&](DataChunk &chunk) { log.WriteInsert(chunk); });
 }
 
 void DataTable::CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count) {
@@ -987,7 +978,7 @@ void DataTable::RevertAppendInternal(idx_t start_row) {
 	row_groups->RevertAppendInternal(start_row);
 }
 
-void DataTable::RevertAppend(idx_t start_row, idx_t count) {
+void DataTable::RevertAppend(DuckTransaction &transaction, idx_t start_row, idx_t count) {
 	lock_guard<mutex> lock(append_lock);
 
 	// revert any appends to indexes
@@ -996,7 +987,7 @@ void DataTable::RevertAppend(idx_t start_row, idx_t count) {
 		row_t row_data[STANDARD_VECTOR_SIZE];
 		Vector row_identifiers(LogicalType::ROW_TYPE, data_ptr_cast(row_data));
 		idx_t scan_count = MinValue<idx_t>(count, row_groups->GetTotalRows() - start_row);
-		ScanTableSegment(start_row, scan_count, [&](DataChunk &chunk) {
+		ScanTableSegment(transaction, start_row, scan_count, [&](DataChunk &chunk) {
 			for (idx_t i = 0; i < chunk.size(); i++) {
 				row_data[i] = NumericCast<row_t>(current_row_base + i);
 			}

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -19,7 +19,8 @@
 
 namespace duckdb {
 
-CommitState::CommitState(transaction_t commit_id) : commit_id(commit_id) {
+CommitState::CommitState(DuckTransaction &transaction_p, transaction_t commit_id)
+    : transaction(transaction_p), commit_id(commit_id) {
 }
 
 void CommitState::CommitEntryDrop(CatalogEntry &entry, data_ptr_t dataptr) {
@@ -197,7 +198,7 @@ void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::INSERT_TUPLE: {
 		auto info = reinterpret_cast<AppendInfo *>(data);
 		// revert this append
-		info->table->RevertAppend(info->start_row, info->count);
+		info->table->RevertAppend(transaction, info->start_row, info->count);
 		break;
 	}
 	case UndoFlags::DELETE_TUPLE: {

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -32,8 +32,8 @@ TransactionData::TransactionData(transaction_t transaction_id_p, transaction_t s
 DuckTransaction::DuckTransaction(DuckTransactionManager &manager, ClientContext &context_p, transaction_t start_time,
                                  transaction_t transaction_id, idx_t catalog_version_p)
     : Transaction(manager, context_p), start_time(start_time), transaction_id(transaction_id), commit_id(0),
-      highest_active_query(0), catalog_version(catalog_version_p), transaction_manager(manager), undo_buffer(context_p),
-      storage(make_uniq<LocalStorage>(context_p, *this)) {
+      highest_active_query(0), catalog_version(catalog_version_p), transaction_manager(manager),
+      undo_buffer(*this, context_p), storage(make_uniq<LocalStorage>(context_p, *this)) {
 }
 
 DuckTransaction::~DuckTransaction() {

--- a/src/transaction/rollback_state.cpp
+++ b/src/transaction/rollback_state.cpp
@@ -13,6 +13,9 @@
 
 namespace duckdb {
 
+RollbackState::RollbackState(DuckTransaction &transaction_p) : transaction(transaction_p) {
+}
+
 void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 	switch (type) {
 	case UndoFlags::CATALOG_ENTRY: {
@@ -25,7 +28,7 @@ void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
 	case UndoFlags::INSERT_TUPLE: {
 		auto info = reinterpret_cast<AppendInfo *>(data);
 		// revert the append in the base table
-		info->table->RevertAppend(info->start_row, info->count);
+		info->table->RevertAppend(transaction, info->start_row, info->count);
 		break;
 	}
 	case UndoFlags::DELETE_TUPLE: {

--- a/src/transaction/wal_write_state.cpp
+++ b/src/transaction/wal_write_state.cpp
@@ -22,8 +22,9 @@
 
 namespace duckdb {
 
-WALWriteState::WALWriteState(WriteAheadLog &log, optional_ptr<StorageCommitState> commit_state)
-    : log(log), commit_state(commit_state), current_table_info(nullptr) {
+WALWriteState::WALWriteState(DuckTransaction &transaction_p, WriteAheadLog &log,
+                             optional_ptr<StorageCommitState> commit_state)
+    : transaction(transaction_p), log(log), commit_state(commit_state), current_table_info(nullptr) {
 }
 
 void WALWriteState::SwitchTable(DataTableInfo *table_info, UndoFlags new_op) {
@@ -259,7 +260,7 @@ void WALWriteState::CommitEntry(UndoFlags type, data_ptr_t data) {
 		// append:
 		auto info = reinterpret_cast<AppendInfo *>(data);
 		if (!info->table->IsTemporary()) {
-			info->table->WriteToLog(log, info->start_row, info->count, commit_state.get());
+			info->table->WriteToLog(transaction, log, info->start_row, info->count, commit_state.get());
 		}
 		break;
 	}


### PR DESCRIPTION
This is a follow-up PR from https://github.com/duckdb/duckdb/pull/13712 that removes the code-paths that grabbed the table lock through a different manner, avoiding the transaction-level interface. Looking at the code this seems to only be used in the WAL - so it's unlikely this would actually cause problems, but it's better to clean up this code path entirely so it doesn't get accidentally used in the future.