### PR TITLE
Arrow list buffer - suggest setting `arrow_large_buffer_size` to true when regular list buffer size is exceeded

### DIFF
--- a/src/include/duckdb/common/arrow/appender/list_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/list_data.hpp
@@ -74,7 +74,8 @@ public:
 			    (uint64_t)last_offset + list_length > NumericLimits<int32_t>::Maximum()) {
 				throw InvalidInputException(
 				    "Arrow Appender: The maximum combined list offset for regular list buffers is "
-				    "%u but the offset of %lu exceeds this.",
+				    "%u but the offset of %lu exceeds this.\n* SET arrow_large_buffer_size=true to use large list "
+				    "buffers",
 				    NumericLimits<int32_t>::Maximum(), last_offset);
 			}
 			last_offset += list_length;

--- a/src/include/duckdb/common/arrow/appender/list_view_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/list_view_data.hpp
@@ -75,7 +75,8 @@ public:
 			    (uint64_t)last_offset + list_length > NumericLimits<int32_t>::Maximum()) {
 				throw InvalidInputException(
 				    "Arrow Appender: The maximum combined list offset for regular list buffers is "
-				    "%u but the offset of %lu exceeds this.",
+				    "%u but the offset of %lu exceeds this.\n* SET arrow_large_buffer_size=true to use large list "
+				    "buffers",
 				    NumericLimits<int32_t>::Maximum(), last_offset);
 			}
 			offset_data[offset_idx] = last_offset;


### PR DESCRIPTION
This can happen when emitting arrow tables with large lists.