### PR TITLE
Fix INET type BETWEEN operation

### DIFF
--- a/src/execution/expression_executor/execute_between.cpp
+++ b/src/execution/expression_executor/execute_between.cpp
@@ -81,6 +81,9 @@ static idx_t BetweenLoopTypeSwitch(Vector &input, Vector &lower, Vector &upper, 
 	case PhysicalType::INTERVAL:
 		return TernaryExecutor::Select<interval_t, interval_t, interval_t, OP>(input, lower, upper, sel, count,
 		                                                                       true_sel, false_sel);
+	case PhysicalType::INET:
+		return TernaryExecutor::Select<string_t, string_t, string_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                 false_sel);
 	default:
 		throw InvalidTypeException(input.GetType(), "Invalid type for BETWEEN");
 	}

--- a/src/planner/expression/bound_between_expression.cpp
+++ b/src/planner/expression/bound_between_expression.cpp
@@ -15,6 +15,10 @@ BoundBetweenExpression::BoundBetweenExpression(unique_ptr<Expression> input, uni
 }
 
 string BoundBetweenExpression::ToString() const {
+	if (input->return_type.id() == LogicalTypeId::INET) {
+		return input->ToString() + " BETWEEN " + lower->ToString() + (lower_inclusive ? " (inclusive)" : " (exclusive)") +
+		       " AND " + upper->ToString() + (upper_inclusive ? " (inclusive)" : " (exclusive)");
+	}
 	return BetweenExpression::ToString<BoundBetweenExpression, Expression>(*this);
 }
 

--- a/test/sql/functions/inet_between.test
+++ b/test/sql/functions/inet_between.test
@@ -1,0 +1,22 @@
+# Test for BETWEEN operation with INET type
+
+# Create a table with INET type column
+CREATE TABLE test (ip INET);
+
+# Insert values into the table
+INSERT INTO test VALUES ('10.10.10.1'), ('10.10.10.2'), ('10.10.10.3');
+
+# Select all rows
+SELECT * FROM test;
+
+# Test BETWEEN operation with INET type
+SELECT * FROM test WHERE ip BETWEEN '10.10.10.1'::INET AND '10.10.10.3'::INET;
+
+# Test BETWEEN operation with INET type (exclusive)
+SELECT * FROM test WHERE ip > '10.10.10.1'::INET AND ip < '10.10.10.3'::INET;
+
+# Test BETWEEN operation with INET type (lower inclusive, upper exclusive)
+SELECT * FROM test WHERE ip >= '10.10.10.1'::INET AND ip < '10.10.10.3'::INET;
+
+# Test BETWEEN operation with INET type (lower exclusive, upper inclusive)
+SELECT * FROM test WHERE ip > '10.10.10.1'::INET AND ip <= '10.10.10.3'::INET;


### PR DESCRIPTION
Fixes #10947

Add support for BETWEEN operation with INET type.

* Modify `src/execution/expression_executor/execute_between.cpp` to add a new case for `PhysicalType::INET` in `BetweenLoopTypeSwitch` function.
* Modify `src/planner/expression/bound_between_expression.cpp` to handle INET type in `BoundBetweenExpression` class and update `ToString` function.
* Add a new test file `test/sql/functions/inet_between.test` with test cases for BETWEEN operation with INET type.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/duckdb/duckdb/issues/10947?shareId=86706506-6871-43a5-95ad-678a718cae3a).