### PR TITLE
Make mysql_scanner auto-loadable, and add mysql/postgres secrets

### DIFF
--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -683,7 +683,9 @@ static constexpr ExtensionEntry EXTENSION_SECRET_TYPES[] = {{"s3", "httpfs"},
                                                             {"gcs", "httpfs"},
                                                             {"azure", "azure"},
                                                             {"huggingface", "httpfs"},
-                                                            {"bearer", "httpfs"}
+                                                            {"bearer", "httpfs"},
+                                                            {"mysql", "mysql_scanner"},
+                                                            {"postgres", "postgres_scanner"}
 }; // EXTENSION_SECRET_TYPES
 
 
@@ -701,7 +703,9 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {{"s3/config", "h
                                                                 {"azure/service_principal", "azure"},
                                                                 {"huggingface/config", "httfps"},
                                                                 {"huggingface/credential_chain", "httpfs"},
-                                                                {"bearer/config", "httpfs"}
+                                                                {"bearer/config", "httpfs"},
+                                                                {"mysql/config", "mysql_scanner"},
+                                                                {"postgres/config", "postgres_scanner"}
 }; // EXTENSION_SECRET_PROVIDERS
 
 static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
@@ -716,6 +720,7 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "inet",
     "icu",
     "json",
+    "mysql_scanner",
     "parquet",
     "sqlite_scanner",
     "sqlsmith",

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1036,8 +1036,10 @@ static constexpr ExtensionEntry EXTENSION_FILE_CONTAINS[] = {{".parquet?", "parq
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
 static constexpr ExtensionEntry EXTENSION_SECRET_TYPES[] = {
-    {"s3", "httpfs"},   {"r2", "httpfs"},          {"gcs", "httpfs"},
-    {"azure", "azure"}, {"huggingface", "httpfs"}, {"bearer", "httpfs"}}; // EXTENSION_SECRET_TYPES
+    {"s3", "httpfs"},           {"r2", "httpfs"},
+    {"gcs", "httpfs"},          {"azure", "azure"},
+    {"huggingface", "httpfs"},  {"bearer", "httpfs"},
+    {"mysql", "mysql_scanner"}, {"postgres", "postgres_scanner"}}; // EXTENSION_SECRET_TYPES
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
@@ -1054,12 +1056,13 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"azure/service_principal", "azure"},
     {"huggingface/config", "httfps"},
     {"huggingface/credential_chain", "httpfs"},
-    {"bearer/config", "httpfs"}}; // EXTENSION_SECRET_PROVIDERS
+    {"bearer/config", "httpfs"},
+    {"mysql/config", "mysql_scanner"},
+    {"postgres/config", "postgres_scanner"}}; // EXTENSION_SECRET_PROVIDERS
 
 static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
-    "aws",   "azure",   "autocomplete",   "core_functions", "delta",
-    "excel", "fts",     "httpfs",         "inet",           "icu",
-    "json",  "parquet", "sqlite_scanner", "sqlsmith",       "postgres_scanner",
+    "aws",   "azure", "autocomplete", "core_functions", "delta",   "excel",          "fts",      "httpfs",
+    "inet",  "icu",   "json",         "mysql_scanner",  "parquet", "sqlite_scanner", "sqlsmith", "postgres_scanner",
     "tpcds", "tpch"}; // END_OF_AUTOLOADABLE_EXTENSIONS
 
 } // namespace duckdb


### PR DESCRIPTION
[Postgres](https://github.com/duckdb/postgres_scanner/blob/03eaed75f0ec5500609b7a97aa05468493b229d1/src/postgres_extension.cpp#L76) and [MySQL](https://github.com/duckdb/duckdb_mysql/blob/f2a15013fb4559e1591e977c1c023aa0a369c6f3/src/mysql_extension.cpp#L22) have secrets now as well - the extension auto-loader needs to be aware of these. 