### PR TITLE
Tidy Check to do complete run also on feature

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -117,14 +117,14 @@ jobs:
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-tidy && sudo pip3 install pybind11[global] --break-system-packages
 
       - name: Setup Ccache
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
         uses: hendrikmuhs/ccache-action@main
         with:
           key: ${{ github.job }}
           save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
 
       - name: Download clang-tidy-cache
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
         shell: bash
         run: |
           set -e
@@ -134,10 +134,10 @@ jobs:
 
       - name: Tidy Check
         shell: bash
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
         run: make tidy-check TIDY_BINARY=/tmp/clang-tidy-cache
 
       - name: Tidy Check Diff
         shell: bash
-        if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/feature' }}
         run: make tidy-check-diff


### PR DESCRIPTION
Connected to conversation at https://github.com/duckdb/duckdb/pull/14384#issuecomment-2416199641.

Basically logic after the PR will be as follow:

on `main` or `feature`: do complete check
else: do check only the diff.

Note that feature is not triggered automatically (not even on nightly), so this will have no difference as is, but allows this to be triggered manually and check the results.

Independently to be reviewed what should run on nightly.