### PR TITLE
[Arrow] Fix scanning of BOOL columns when offsets are involved

### DIFF
--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -765,14 +765,12 @@ static void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowArraySca
 	case LogicalTypeId::BOOLEAN: {
 		//! Arrow bit-packs boolean values
 		//! Lets first figure out where we are in the source array
-		auto src_ptr = ArrowBufferData<uint8_t>(array, 1) +
-		               GetEffectiveOffset(array, NumericCast<int64_t>(parent_offset), scan_state, nested_offset) / 8;
+		auto effective_offset =
+		    GetEffectiveOffset(array, NumericCast<int64_t>(parent_offset), scan_state, nested_offset);
+		auto src_ptr = ArrowBufferData<uint8_t>(array, 1) + effective_offset / 8;
 		auto tgt_ptr = (uint8_t *)FlatVector::GetData(vector);
 		int src_pos = 0;
-		idx_t cur_bit = scan_state.chunk_offset % 8;
-		if (nested_offset != -1) {
-			cur_bit = NumericCast<idx_t>(nested_offset % 8);
-		}
+		idx_t cur_bit = effective_offset % 8;
 		for (idx_t row = 0; row < size; row++) {
 			if ((src_ptr[src_pos] & (1 << cur_bit)) == 0) {
 				tgt_ptr[row] = 0;

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_offsets.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_offsets.py
@@ -671,3 +671,17 @@ class TestArrowOffsets(object):
             assert res[0] == None
         else:
             assert res[0]['a'][-1] == '131072'
+
+    def test_bools_with_offset(self, duckdb_cursor):
+        bools = [False, False, False, False, True, False, False, False, False, False]
+        bool_array = pa.array(bools, type=pa.bool_())
+
+        # Create schema using the same fields as the C++ version
+        schema = pa.schema([pa.field("bools", pa.bool_())])
+
+        # Create a RecordBatch with the arrays
+        record_batch = pa.RecordBatch.from_arrays([bool_array], schema=schema)
+
+        temp_record = record_batch.slice(4, 1)
+        res = duckdb_cursor.sql("select bools from temp_record").fetchall()
+        assert res == [(True,)]


### PR DESCRIPTION
This PR fixes #14386

Offsets were not used correctly, now they are