### PR TITLE
avoid unnecessary file list materialization when pruning readers

### DIFF
--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -255,6 +255,11 @@ struct MultiFileReader {
 	static void PruneReaders(BIND_DATA &data, MultiFileList &file_list) {
 		unordered_set<string> file_set;
 
+		// Avoid materializing the file list if there's nothing to prune
+		if (!data.initial_reader && data.union_readers.empty()) {
+			return;
+		}
+
 		for (const auto &file : file_list.Files()) {
 			file_set.insert(file);
 		}


### PR DESCRIPTION
File list materialization can be expensive and should be done only when necessary