### PR TITLE
Fix idx_t to int64_t implicit conversion flagged by clang-tidy

### DIFF
--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -60,7 +60,7 @@ static idx_t CalculateSliceLength(idx_t begin, idx_t end, INDEX_TYPE step, bool 
 
 struct BlobSliceOperations {
 	static int64_t ValueLength(const string_t &value) {
-		return value.GetSize();
+		return UnsafeNumericCast<int64_t>(value.GetSize());
 	}
 
 	static string_t SliceValue(Vector &result, string_t input, int64_t begin, int64_t end) {


### PR DESCRIPTION
This should fix the errors in the clang-tidy workflow for PR based on feature.