### PR TITLE
Fix pointer indirection in pyrelation.cpp

### DIFF
--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -935,7 +935,7 @@ duckdb::pyarrow::Table DuckDBPyRelation::ToArrowTableInternal(idx_t batch_size, 
 		if (!rel) {
 			return py::none();
 		}
-		auto &config = ClientConfig::GetConfig(*rel->context.GetContext());
+		auto &config = ClientConfig::GetConfig(*rel->context->GetContext());
 		ScopedConfigSetting scoped_setting(
 		    config,
 		    [&batch_size](ClientConfig &config) {


### PR DESCRIPTION
I am not sure how it could compile in some platforms (basic Python CI) but not in others (Pyodide, that is clang-based emscripten)

Connected to https://github.com/duckdb/duckdb/pull/14319

For example: https://github.com/duckdb/duckdb/actions/runs/11372106923/job/31635971994?pr=14402#step:8:13491
```
        src/pyrelation.cpp:938:56: error: ‘class duckdb::shared_ptr<duckdb::ClientContextWrapper>’ has no member named ‘GetContext’
          938 |   auto &config = ClientConfig::GetConfig(*rel->context.GetContext());
              |                                                        ^~~~~~~~~~
```