### PR TITLE
Issue #14398: Lead Shift Defaults

### DIFF
--- a/src/execution/window_executor.cpp
+++ b/src/execution/window_executor.cpp
@@ -1671,23 +1671,23 @@ void WindowLeadLagExecutor::EvaluateInternal(WindowExecutorGlobalState &gstate, 
 		// else offset is zero, so don't move.
 
 		if (can_shift) {
+			const auto target_limit = MinValue(partition_end[i], row_end) - row_idx;
 			if (!delta) {
 				//	Copy source[index:index+width] => result[i:]
 				const auto index = NumericCast<idx_t>(val_idx);
 				const auto source_limit = partition_end[i] - index;
-				const auto target_limit = MinValue(partition_end[i], row_end) - row_idx;
 				const auto width = MinValue(source_limit, target_limit);
 				auto &source = payload_collection.data[0];
 				VectorOperations::Copy(source, result, index + width, index, i);
 				i += width;
 				row_idx += width;
 			} else if (wexpr.default_expr) {
-				const auto width = MinValue(delta, count - i);
+				const auto width = MinValue(delta, target_limit);
 				llstate.leadlag_default.CopyCell(result, i, width);
 				i += width;
 				row_idx += width;
 			} else {
-				for (idx_t nulls = MinValue(delta, count - i); nulls--; ++i, ++row_idx) {
+				for (idx_t nulls = MinValue(delta, target_limit); nulls--; ++i, ++row_idx) {
 					FlatVector::SetNull(result, i, true);
 				}
 			}

--- a/test/sql/window/test_lead_lag.test
+++ b/test/sql/window/test_lead_lag.test
@@ -44,3 +44,64 @@ order by id, t
 3	5	-2	NULL
 3	-1	0	NULL
 3	NULL	10	5
+
+# Shifted lead optimisation with hash collisions
+statement ok
+CREATE TABLE issue14398 (date DATE, "group" INT, count INT, status STRING);
+
+statement ok
+INSERT INTO issue14398 VALUES
+('2024-01-01', 1, 1000, 'ordered'),
+('2024-02-01', 1, 1000, 'dispatched'),
+('2024-03-01', 1, 1000, 'dispatched'),
+('2024-01-01', 2, 2000, 'ordered'),
+('2024-02-01', 2, 2000, 'ordered'),
+('2024-03-01', 2, 2000, 'ordered'),
+('2024-01-01', 3, 3000, 'ordered'),
+('2024-02-01', 3, 3000, 'ordered'),
+('2024-03-01', 3, 3000, 'late'),
+('2024-01-01', 4, 4000, 'ordered'),
+('2024-02-01', 4, 4000, 'ordered'),
+('2024-03-01', 4, 4000, 'ordered'),
+('2024-01-01', 5, 5000, 'ordered'),
+('2024-02-01', 5, 5000, 'late'),
+('2024-03-01', 5, 5000, 'ordered'),
+('2024-01-01', 6, 1000, 'dispatched'),
+('2024-02-01', 6, 1000, 'dispatched'),
+('2024-03-01', 6, 1000, 'dispatched'),
+('2024-01-01', 7, 1000, 'late'),
+('2024-02-01', 7, 1000, 'dispatched'),
+('2024-03-01', 7, 1000, 'dispatched');
+
+query IIIIII
+SELECT
+  "t0"."date",
+  "t0"."group",
+  "t0"."count",
+  "t0"."status",
+  LEAD("t0"."date", 2) OVER (PARTITION BY "t0"."group" ORDER BY "t0"."date" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "end_date",
+  LEAD("t0"."status", 2) OVER (PARTITION BY "t0"."group" ORDER BY "t0"."date" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "end_status"
+FROM "issue14398" AS "t0"
+ORDER BY 2, 1
+----
+2024-01-01	1	1000	ordered	2024-03-01	dispatched
+2024-02-01	1	1000	dispatched	NULL	NULL
+2024-03-01	1	1000	dispatched	NULL	NULL
+2024-01-01	2	2000	ordered	2024-03-01	ordered
+2024-02-01	2	2000	ordered	NULL	NULL
+2024-03-01	2	2000	ordered	NULL	NULL
+2024-01-01	3	3000	ordered	2024-03-01	late
+2024-02-01	3	3000	ordered	NULL	NULL
+2024-03-01	3	3000	late	NULL	NULL
+2024-01-01	4	4000	ordered	2024-03-01	ordered
+2024-02-01	4	4000	ordered	NULL	NULL
+2024-03-01	4	4000	ordered	NULL	NULL
+2024-01-01	5	5000	ordered	2024-03-01	ordered
+2024-02-01	5	5000	late	NULL	NULL
+2024-03-01	5	5000	ordered	NULL	NULL
+2024-01-01	6	1000	dispatched	2024-03-01	dispatched
+2024-02-01	6	1000	dispatched	NULL	NULL
+2024-03-01	6	1000	dispatched	NULL	NULL
+2024-01-01	7	1000	late	2024-03-01	dispatched
+2024-02-01	7	1000	dispatched	NULL	NULL
+2024-03-01	7	1000	dispatched	NULL	NULL


### PR DESCRIPTION
Clamp the range of shifted defaults/NULLs to the end of the partition, not the end of the chunk.

fixes: duckdb#14398
fixes: duckdblabs/duckdb-internal#3300