### PR TITLE
[Dev] Optimize `ValidityMask` when reading from a `ColumnDataCollection`

### DIFF
--- a/src/common/types/column/column_data_collection.cpp
+++ b/src/common/types/column/column_data_collection.cpp
@@ -401,7 +401,7 @@ static void TemplatedColumnDataCopy(ColumnDataMetaData &meta_data, const Unified
 
 		auto base_ptr = segment.allocator->GetDataPointer(append_state.current_chunk_state, current_segment.block_id,
 		                                                  current_segment.offset);
-		auto validity_data = ColumnDataCollectionSegment::GetValidityPointer(base_ptr, OP::TypeSize());
+		auto validity_data = ColumnDataCollectionSegment::GetValidityPointerForWriting(base_ptr, OP::TypeSize());
 
 		ValidityMask result_validity(validity_data);
 		if (current_segment.count == 0) {
@@ -517,7 +517,7 @@ void ColumnDataCopy<string_t>(ColumnDataMetaData &meta_data, const UnifiedVector
 		auto &current_segment = segment.GetVectorData(current_index);
 		auto base_ptr = segment.allocator->GetDataPointer(append_state.current_chunk_state, current_segment.block_id,
 		                                                  current_segment.offset);
-		auto validity_data = ColumnDataCollectionSegment::GetValidityPointer(base_ptr, sizeof(string_t));
+		auto validity_data = ColumnDataCollectionSegment::GetValidityPointerForWriting(base_ptr, sizeof(string_t));
 		ValidityMask target_validity(validity_data);
 		if (current_segment.count == 0) {
 			// first time appending to this vector

--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -14,8 +14,29 @@ idx_t ColumnDataCollectionSegment::GetDataSize(idx_t type_size) {
 	return AlignValue(type_size * STANDARD_VECTOR_SIZE);
 }
 
-validity_t *ColumnDataCollectionSegment::GetValidityPointer(data_ptr_t base_ptr, idx_t type_size) {
+validity_t *ColumnDataCollectionSegment::GetValidityPointerForWriting(data_ptr_t base_ptr, idx_t type_size) {
 	return reinterpret_cast<validity_t *>(base_ptr + GetDataSize(type_size));
+}
+
+validity_t *ColumnDataCollectionSegment::GetValidityPointer(data_ptr_t base_ptr, idx_t type_size, idx_t count) {
+	auto validity_mask = reinterpret_cast<validity_t *>(base_ptr + GetDataSize(type_size));
+
+	// Optimized check to see if all entries are valid
+	for (idx_t i = 0; i < (count / ValidityMask::BITS_PER_VALUE); i++) {
+		if (!ValidityMask::AllValid(validity_mask[i])) {
+			return validity_mask;
+		}
+	}
+	if ((count % ValidityMask::BITS_PER_VALUE) != 0) {
+		auto entry = validity_mask[(count / ValidityMask::BITS_PER_VALUE)];
+		for (idx_t i = 0; i < (count % ValidityMask::BITS_PER_VALUE); i++) {
+			if (!ValidityMask::RowIsValid(entry, i)) {
+				return validity_mask;
+			}
+		}
+	}
+	// All entries are valid, no need to initialize the validity mask
+	return nullptr;
 }
 
 VectorDataIndex ColumnDataCollectionSegment::AllocateVectorInternal(const LogicalType &type, ChunkMetaData &chunk_meta,
@@ -141,7 +162,7 @@ idx_t ColumnDataCollectionSegment::ReadVectorInternal(ChunkManagementState &stat
 	auto &vdata = GetVectorData(vector_index);
 
 	auto base_ptr = allocator->GetDataPointer(state, vdata.block_id, vdata.offset);
-	auto validity_data = GetValidityPointer(base_ptr, type_size);
+	auto validity_data = GetValidityPointer(base_ptr, type_size, vdata.count);
 	if (!vdata.next_data.IsValid() && state.properties != ColumnDataScanProperties::DISALLOW_ZERO_COPY) {
 		// no next data, we can do a zero-copy read of this vector
 		FlatVector::SetData(result, base_ptr);
@@ -169,7 +190,7 @@ idx_t ColumnDataCollectionSegment::ReadVectorInternal(ChunkManagementState &stat
 	while (next_index.IsValid()) {
 		auto &current_vdata = GetVectorData(next_index);
 		base_ptr = allocator->GetDataPointer(state, current_vdata.block_id, current_vdata.offset);
-		validity_data = GetValidityPointer(base_ptr, type_size);
+		validity_data = GetValidityPointer(base_ptr, type_size, current_vdata.count);
 		if (type_size > 0) {
 			memcpy(target_data + current_offset * type_size, base_ptr, current_vdata.count * type_size);
 		}

--- a/src/common/types/validity_mask.cpp
+++ b/src/common/types/validity_mask.cpp
@@ -114,6 +114,10 @@ void ValidityMask::CopySel(const ValidityMask &other, const SelectionVector &sel
 }
 
 void ValidityMask::SliceInPlace(const ValidityMask &other, idx_t target_offset, idx_t source_offset, idx_t count) {
+	if (AllValid() && other.AllValid()) {
+		// Both validity masks are uninitialized, nothing to do
+		return;
+	}
 	EnsureWritable();
 	const idx_t ragged = count % BITS_PER_VALUE;
 	const idx_t entire_units = count / BITS_PER_VALUE;

--- a/src/include/duckdb/common/types/column/column_data_collection_segment.hpp
+++ b/src/include/duckdb/common/types/column/column_data_collection_segment.hpp
@@ -137,7 +137,8 @@ public:
 	void Verify();
 
 	static idx_t GetDataSize(idx_t type_size);
-	static validity_t *GetValidityPointer(data_ptr_t base_ptr, idx_t type_size);
+	static validity_t *GetValidityPointerForWriting(data_ptr_t base_ptr, idx_t type_size);
+	static validity_t *GetValidityPointer(data_ptr_t base_ptr, idx_t type_size, idx_t count);
 
 private:
 	idx_t ReadVectorInternal(ChunkManagementState &state, VectorDataIndex vector_index, Vector &result);


### PR DESCRIPTION
When we serialize the ColumnDataCollection, we will write the `validity_t *validity_mask` regardless of the validity being uninitialized or not.
We do this because it's difficult to keep track of the validity status when appending multiple Vectors.

When we read this back however, we receive a ValidityMask that returns false for `AllValid` which could be costly as most execution paths of the engine have optimized paths for `AllValid()` being true.

Now we'll efficiently check the validity mask when reading and replace it will nullptr if all entries are valid, enabling the `AllValid() == true` optimized path for these vectors.