### PR TITLE
[bufferpool] Fix PurgeAgedBlocksInternal() evictions

### DIFF
--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -342,7 +342,7 @@ idx_t BufferPool::PurgeAgedBlocksInternal(EvictionQueue &queue, uint32_t max_age
 		bool is_fresh = handle->lru_timestamp_msec >= limit && handle->lru_timestamp_msec <= now;
 		purged_bytes += handle->GetMemoryUsage();
 		handle->Unload();
-        // Return false to stop iterating if the current block is_fresh
+		// Return false to stop iterating if the current block is_fresh
 		return !is_fresh;
 	});
 	return purged_bytes;

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -342,7 +342,8 @@ idx_t BufferPool::PurgeAgedBlocksInternal(EvictionQueue &queue, uint32_t max_age
 		bool is_fresh = handle->lru_timestamp_msec >= limit && handle->lru_timestamp_msec <= now;
 		purged_bytes += handle->GetMemoryUsage();
 		handle->Unload();
-		return is_fresh;
+        // Return false to stop iterating if the current block is_fresh
+		return !is_fresh;
 	});
 	return purged_bytes;
 }


### PR DESCRIPTION
The eviction queue expects the lambda to return true to continue and false to exit: https://github.com/duckdb/duckdb/blob/aed52f5cabe34075c53bcec4407e297124c8d336/src/storage/buffer/buffer_pool.cpp#L378

https://github.com/duckdb/duckdb/blob/aed52f5cabe34075c53bcec4407e297124c8d336/src/storage/buffer/buffer_pool.cpp#L345 unfortunately we are returning true when is_fresh. This PR fixes this. 