### PR TITLE
[Dev] Further optimize the CDC ValidityMask deserialization

### DIFF
--- a/src/common/types/column/column_data_collection_segment.cpp
+++ b/src/common/types/column/column_data_collection_segment.cpp
@@ -27,12 +27,12 @@ validity_t *ColumnDataCollectionSegment::GetValidityPointer(data_ptr_t base_ptr,
 			return validity_mask;
 		}
 	}
+
 	if ((count % ValidityMask::BITS_PER_VALUE) != 0) {
-		auto entry = validity_mask[(count / ValidityMask::BITS_PER_VALUE)];
-		for (idx_t i = 0; i < (count % ValidityMask::BITS_PER_VALUE); i++) {
-			if (!ValidityMask::RowIsValid(entry, i)) {
-				return validity_mask;
-			}
+		// Create a mask with the lower `bits_to_check` bits set to 1
+		validity_t mask = (1ULL << (count % ValidityMask::BITS_PER_VALUE)) - 1;
+		if ((validity_mask[(count / ValidityMask::BITS_PER_VALUE)] & mask) != mask) {
+			return validity_mask;
 		}
 	}
 	// All entries are valid, no need to initialize the validity mask


### PR DESCRIPTION
This PR implements the suggestion made by [Richard](https://github.com/duckdb/duckdb/pull/14416#discussion_r1805481889)

When a `validity_t` is used for < `ValidityMask::BITS_PER_VALUE` values, the least significant bits are set, i.e if `ValidityMask::BITS_PER_VALUE` was 8

5 values uses :
`xxx4 3210`

For that we can construct the mask:
`0001 1111`

To check that all bits are set for those values

Given that `ValidityMask::BITS_PER_VALUE` is 64, we save 1<=n<64 function calls by doing this