### PR TITLE
Push dynamically generated join filters through `UNION`, `UNNEST` and `AGGREGATE`

### DIFF
--- a/benchmark/tpch/join/join_filter_pushdown_union.benchmark
+++ b/benchmark/tpch/join/join_filter_pushdown_union.benchmark
@@ -1,0 +1,21 @@
+# name: benchmark/tpch/join/join_filter_pushdown_union.benchmark
+# description: Join filter pushdown
+# group: [join]
+
+name Join Filter Pushdown (Union)
+group join
+subgroup tpch
+
+require tpch
+
+cache tpch_sf1.duckdb
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT * from (from lineitem union from lineitem) WHERE l_orderkey=(SELECT MAX(l_orderkey) FROM lineitem) ORDER BY ALL
+
+result IIIIIIIIIIIIIIII
+6000000	32255	2256	1	5.00	5936.25	0.04	0.03	N	O	1996-11-02	1996-11-19	1996-12-01	TAKE BACK RETURN	MAIL	riously pe
+6000000	96127	6128	2	28.00	31447.36	0.01	0.02	N	O	1996-09-22	1996-10-01	1996-10-21	NONE	AIR	pecial excuses nag evenly f

--- a/benchmark/tpch/join/join_filter_pushdown_union_all.benchmark
+++ b/benchmark/tpch/join/join_filter_pushdown_union_all.benchmark
@@ -1,0 +1,23 @@
+# name: benchmark/tpch/join/join_filter_pushdown_union_all.benchmark
+# description: Join filter pushdown
+# group: [join]
+
+name Join Filter Pushdown (Union All)
+group join
+subgroup tpch
+
+require tpch
+
+cache tpch_sf1.duckdb
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT * from (from lineitem union all from lineitem) WHERE l_orderkey=(SELECT MAX(l_orderkey) FROM lineitem) ORDER BY ALL
+
+result IIIIIIIIIIIIIIII
+6000000	32255	2256	1	5.00	5936.25	0.04	0.03	N	O	1996-11-02	1996-11-19	1996-12-01	TAKE BACK RETURN	MAIL	riously pe
+6000000	32255	2256	1	5.00	5936.25	0.04	0.03	N	O	1996-11-02	1996-11-19	1996-12-01	TAKE BACK RETURN	MAIL	riously pe
+6000000	96127	6128	2	28.00	31447.36	0.01	0.02	N	O	1996-09-22	1996-10-01	1996-10-21	NONE	AIR	pecial excuses nag evenly f
+6000000	96127	6128	2	28.00	31447.36	0.01	0.02	N	O	1996-09-22	1996-10-01	1996-10-21	NONE	AIR	pecial excuses nag evenly f

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -102,7 +102,9 @@ unique_ptr<JoinFilterGlobalState> JoinFilterPushdownInfo::GetGlobalState(ClientC
                                                                          const PhysicalOperator &op) const {
 	// clear any previously set filters
 	// we can have previous filters for this operator in case of e.g. recursive CTEs
-	dynamic_filters->ClearFilters(op);
+	for (auto &info : probe_info) {
+		info.dynamic_filters->ClearFilters(op);
+	}
 	auto result = make_uniq<JoinFilterGlobalState>();
 	result->global_aggregate_state =
 	    make_uniq<GlobalUngroupedAggregateState>(BufferAllocator::Get(context), min_max_aggregates);
@@ -278,11 +280,11 @@ unique_ptr<LocalSinkState> PhysicalHashJoin::GetLocalSinkState(ExecutionContext 
 
 void JoinFilterPushdownInfo::Sink(DataChunk &chunk, JoinFilterLocalState &lstate) const {
 	// if we are pushing any filters into a probe-side, compute the min/max over the columns that we are pushing
-	for (idx_t pushdown_idx = 0; pushdown_idx < filters.size(); pushdown_idx++) {
-		auto &pushdown = filters[pushdown_idx];
+	for (idx_t pushdown_idx = 0; pushdown_idx < join_condition.size(); pushdown_idx++) {
+		auto join_condition_idx = join_condition[pushdown_idx];
 		for (idx_t i = 0; i < 2; i++) {
 			idx_t aggr_idx = pushdown_idx * 2 + i;
-			lstate.local_aggregate_state->Sink(chunk, pushdown.join_condition, aggr_idx);
+			lstate.local_aggregate_state->Sink(chunk, join_condition_idx, aggr_idx);
 		}
 	}
 }
@@ -572,34 +574,36 @@ void JoinFilterPushdownInfo::PushFilters(JoinFilterGlobalState &gstate, const Ph
 	gstate.global_aggregate_state->Finalize(final_min_max);
 
 	// create a filter for each of the aggregates
-	for (idx_t filter_idx = 0; filter_idx < filters.size(); filter_idx++) {
-		auto &filter = filters[filter_idx];
-		auto filter_col_idx = filter.probe_column_index.column_index;
-		auto min_idx = filter_idx * 2;
-		auto max_idx = min_idx + 1;
+	for (idx_t filter_idx = 0; filter_idx < join_condition.size(); filter_idx++) {
+		for (auto &info : probe_info) {
+			auto filter_col_idx = info.columns[filter_idx].probe_column_index.column_index;
+			auto min_idx = filter_idx * 2;
+			auto max_idx = min_idx + 1;
 
-		auto min_val = final_min_max.data[min_idx].GetValue(0);
-		auto max_val = final_min_max.data[max_idx].GetValue(0);
-		if (min_val.IsNull() || max_val.IsNull()) {
-			// min/max is NULL
-			// this can happen in case all values in the RHS column are NULL, but they are still pushed into the hash
-			// table e.g. because they are part of a RIGHT join
-			continue;
+			auto min_val = final_min_max.data[min_idx].GetValue(0);
+			auto max_val = final_min_max.data[max_idx].GetValue(0);
+			if (min_val.IsNull() || max_val.IsNull()) {
+				// min/max is NULL
+				// this can happen in case all values in the RHS column are NULL, but they are still pushed into the
+				// hash table e.g. because they are part of a RIGHT join
+				continue;
+			}
+			if (Value::NotDistinctFrom(min_val, max_val)) {
+				// min = max - generate an equality filter
+				auto constant_filter = make_uniq<ConstantFilter>(ExpressionType::COMPARE_EQUAL, std::move(min_val));
+				info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(constant_filter));
+			} else {
+				// min != max - generate a range filter
+				auto greater_equals =
+				    make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(min_val));
+				info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(greater_equals));
+				auto less_equals =
+				    make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(max_val));
+				info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(less_equals));
+			}
+			// not null filter
+			info.dynamic_filters->PushFilter(op, filter_col_idx, make_uniq<IsNotNullFilter>());
 		}
-		if (Value::NotDistinctFrom(min_val, max_val)) {
-			// min = max - generate an equality filter
-			auto constant_filter = make_uniq<ConstantFilter>(ExpressionType::COMPARE_EQUAL, std::move(min_val));
-			dynamic_filters->PushFilter(op, filter_col_idx, std::move(constant_filter));
-		} else {
-			// min != max - generate a range filter
-			auto greater_equals =
-			    make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(min_val));
-			dynamic_filters->PushFilter(op, filter_col_idx, std::move(greater_equals));
-			auto less_equals = make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(max_val));
-			dynamic_filters->PushFilter(op, filter_col_idx, std::move(less_equals));
-		}
-		// not null filter
-		dynamic_filters->PushFilter(op, filter_col_idx, make_uniq<IsNotNullFilter>());
 	}
 }
 

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -19,8 +19,6 @@ struct GlobalUngroupedAggregateState;
 struct LocalUngroupedAggregateState;
 
 struct JoinFilterPushdownColumn {
-	//! The join condition from which this filter pushdown is generated
-	idx_t join_condition;
 	//! The probe column index to which this filter should be applied
 	ColumnBinding probe_column_index;
 };
@@ -39,11 +37,18 @@ struct JoinFilterLocalState {
 	unique_ptr<LocalUngroupedAggregateState> local_aggregate_state;
 };
 
-struct JoinFilterPushdownInfo {
+struct JoinFilterPushdownFilter {
 	//! The dynamic table filter set where to push filters into
 	shared_ptr<DynamicTableFilterSet> dynamic_filters;
-	//! The filters that we should generate
-	vector<JoinFilterPushdownColumn> filters;
+	//! The columns for which we should generate filters
+	vector<JoinFilterPushdownColumn> columns;
+};
+
+struct JoinFilterPushdownInfo {
+	//! The join condition indexes for which we compute the min/max aggregates
+	vector<idx_t> join_condition;
+	//! The probes to push the filter into
+	vector<JoinFilterPushdownFilter> probe_info;
 	//! Min/Max aggregates
 	vector<unique_ptr<Expression>> min_max_aggregates;
 

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -1,18 +1,111 @@
 #include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
+
+#include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
+#include "duckdb/execution/operator/join/physical_comparison_join.hpp"
+#include "duckdb/function/aggregate/distributive_functions.hpp"
+#include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
-#include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
-#include "duckdb/planner/expression/bound_columnref_expression.hpp"
-#include "duckdb/function/aggregate/distributive_functions.hpp"
-#include "duckdb/optimizer/optimizer.hpp"
-#include "duckdb/function/function_binder.hpp"
-#include "duckdb/execution/operator/join/physical_comparison_join.hpp"
-#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+
+#include <duckdb/planner/operator/logical_set_operation.hpp>
 
 namespace duckdb {
 
 JoinFilterPushdownOptimizer::JoinFilterPushdownOptimizer(Optimizer &optimizer) : optimizer(optimizer) {
+}
+
+void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdownColumn> columns,
+                                  JoinFilterPushdownInfo &pushdown_info) {
+	auto &probe_child = op;
+	switch (probe_child.type) {
+	case LogicalOperatorType::LOGICAL_LIMIT:
+	case LogicalOperatorType::LOGICAL_FILTER:
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+	case LogicalOperatorType::LOGICAL_TOP_N:
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		// does not affect probe side - recurse into left child
+		// FIXME: we can probably recurse into more operators here (e.g. window, unnest)
+		GenerateJoinFiltersRecursive(*probe_child.children[0], std::move(columns), pushdown_info);
+		break;
+	case LogicalOperatorType::LOGICAL_UNION: {
+		auto &setop = probe_child.Cast<LogicalSetOperation>();
+		// union
+		// check if the filters apply to this table index
+		for (auto &filter : columns) {
+			if (filter.probe_column_index.table_index != setop.table_index) {
+				// the filter does not apply to the union - bail-out
+				return;
+			}
+		}
+		for (auto &child : probe_child.children) {
+			// rewrite the filters for each of the children of the union
+			vector<JoinFilterPushdownColumn> child_columns;
+			auto child_bindings = child->GetColumnBindings();
+			child_columns.reserve(columns.size());
+			for (auto &child_column : columns) {
+				JoinFilterPushdownColumn new_col;
+				new_col.probe_column_index = child_bindings[child_column.probe_column_index.column_index];
+				child_columns.push_back(new_col);
+			}
+			// then recurse into the child
+			GenerateJoinFiltersRecursive(*child, std::move(child_columns), pushdown_info);
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_GET: {
+		// found LogicalGet
+		auto &get = probe_child.Cast<LogicalGet>();
+		if (!get.function.filter_pushdown) {
+			// filter pushdown is not supported - no need to consider this node
+			return;
+		}
+		for (auto &filter : columns) {
+			if (filter.probe_column_index.table_index != get.table_index) {
+				// the filter does not apply to the probe side here - bail-out
+				return;
+			}
+		}
+		// pushdown info can be applied to this LogicalGet - push the dynamic table filter set
+		if (!get.dynamic_filters) {
+			get.dynamic_filters = make_shared_ptr<DynamicTableFilterSet>();
+		}
+
+		JoinFilterPushdownFilter get_filter;
+		get_filter.dynamic_filters = get.dynamic_filters;
+		get_filter.columns = std::move(columns);
+		pushdown_info.probe_info.push_back(std::move(get_filter));
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		// projection - check if we all of the expressions are only column references
+		auto &proj = probe_child.Cast<LogicalProjection>();
+		for (auto &filter : columns) {
+			if (filter.probe_column_index.table_index != proj.table_index) {
+				// index does not belong to this projection - bail-out
+				break;
+			}
+			auto &expr = *proj.expressions[filter.probe_column_index.column_index];
+			if (expr.type != ExpressionType::BOUND_COLUMN_REF) {
+				// not a simple column ref - bail-out
+				break;
+			}
+			// column-ref - pass through the new column binding
+			auto &colref = expr.Cast<BoundColumnRefExpression>();
+			filter.probe_column_index = colref.binding;
+		}
+		GenerateJoinFiltersRecursive(*probe_child.children[0], std::move(columns), pushdown_info);
+		break;
+	}
+	default:
+		// unsupported child type
+		break;
+	}
 }
 
 void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &join) {
@@ -35,6 +128,8 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 	// re-order conditions here - otherwise this will happen later on and invalidate the indexes we generate
 	PhysicalComparisonJoin::ReorderConditions(join.conditions);
 	auto pushdown_info = make_uniq<JoinFilterPushdownInfo>();
+
+	vector<JoinFilterPushdownColumn> pushdown_columns;
 	for (idx_t cond_idx = 0; cond_idx < join.conditions.size(); cond_idx++) {
 		auto &cond = join.conditions[cond_idx];
 		if (cond.comparison != ExpressionType::COMPARE_EQUAL) {
@@ -54,80 +149,32 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 			continue;
 		}
 		JoinFilterPushdownColumn pushdown_col;
-		pushdown_col.join_condition = cond_idx;
-
 		auto &colref = cond.left->Cast<BoundColumnRefExpression>();
 		pushdown_col.probe_column_index = colref.binding;
-		pushdown_info->filters.push_back(pushdown_col);
+		pushdown_columns.push_back(pushdown_col);
+
+		pushdown_info->join_condition.push_back(cond_idx);
 	}
-	if (pushdown_info->filters.empty()) {
+	if (pushdown_columns.empty()) {
 		// could not generate any filters - bail-out
 		return;
 	}
-	// find the child LogicalGet (if possible)
-	reference<LogicalOperator> probe_source(*join.children[0]);
-	while (probe_source.get().type != LogicalOperatorType::LOGICAL_GET) {
-		auto &probe_child = probe_source.get();
-		switch (probe_child.type) {
-		case LogicalOperatorType::LOGICAL_LIMIT:
-		case LogicalOperatorType::LOGICAL_FILTER:
-		case LogicalOperatorType::LOGICAL_ORDER_BY:
-		case LogicalOperatorType::LOGICAL_TOP_N:
-		case LogicalOperatorType::LOGICAL_DISTINCT:
-		case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
-		case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
-			// does not affect probe side - continue into left child
-			// FIXME: we can probably recurse into more operators here (e.g. window, set operation, unnest)
-			probe_source = *probe_child.children[0];
-			break;
-		case LogicalOperatorType::LOGICAL_PROJECTION: {
-			// projection - check if we all of the expressions are only column references
-			auto &proj = probe_source.get().Cast<LogicalProjection>();
-			for (auto &filter : pushdown_info->filters) {
-				if (filter.probe_column_index.table_index != proj.table_index) {
-					// index does not belong to this projection - bail-out
-					return;
-				}
-				auto &expr = *proj.expressions[filter.probe_column_index.column_index];
-				if (expr.type != ExpressionType::BOUND_COLUMN_REF) {
-					// not a simple column ref - bail-out
-					return;
-				}
-				// column-ref - pass through the new column binding
-				auto &colref = expr.Cast<BoundColumnRefExpression>();
-				filter.probe_column_index = colref.binding;
-			}
-			probe_source = *probe_child.children[0];
-			break;
-		}
-		default:
-			// unsupported child type
-			return;
-		}
-	}
-	// found the LogicalGet
-	auto &get = probe_source.get().Cast<LogicalGet>();
-	if (!get.function.filter_pushdown) {
-		// filter pushdown is not supported - bail-out
+	// recurse the query tree to find the LogicalGets in which we can push the filter info
+	GenerateJoinFiltersRecursive(*join.children[0], pushdown_columns, *pushdown_info);
+
+	if (pushdown_info->probe_info.empty()) {
+		// no table sources found in which we can push down filters
 		return;
 	}
-	for (auto &filter : pushdown_info->filters) {
-		if (filter.probe_column_index.table_index != get.table_index) {
-			// the filter does not apply to the probe side here - bail-out
-			return;
-		}
-	}
-	// pushdown can be performed
-
 	// set up the min/max aggregates for each of the filters
 	vector<AggregateFunction> aggr_functions;
 	aggr_functions.push_back(MinFun::GetFunction());
 	aggr_functions.push_back(MaxFun::GetFunction());
-	for (auto &filter : pushdown_info->filters) {
+	for (auto &join_condition : pushdown_info->join_condition) {
 		for (auto &aggr : aggr_functions) {
 			FunctionBinder function_binder(optimizer.GetContext());
 			vector<unique_ptr<Expression>> aggr_children;
-			aggr_children.push_back(join.conditions[filter.join_condition].right->Copy());
+			aggr_children.push_back(join.conditions[join_condition].right->Copy());
 			auto aggr_expr = function_binder.BindAggregateFunction(aggr, std::move(aggr_children), nullptr,
 			                                                       AggregateType::NON_DISTINCT);
 			if (aggr_expr->children.size() != 1) {
@@ -137,12 +184,6 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 			pushdown_info->min_max_aggregates.push_back(std::move(aggr_expr));
 		}
 	}
-	// set up the dynamic filters (if we don't have any yet)
-	if (!get.dynamic_filters) {
-		get.dynamic_filters = make_shared_ptr<DynamicTableFilterSet>();
-	}
-	pushdown_info->dynamic_filters = get.dynamic_filters;
-
 	// set up the filter pushdown in the join itself
 	join.filter_pushdown = std::move(pushdown_info);
 }

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -56,6 +56,8 @@ void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdown
 		GenerateJoinFiltersRecursive(*probe_child.children[0], std::move(columns), pushdown_info);
 		break;
 	}
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_INTERSECT:
 	case LogicalOperatorType::LOGICAL_UNION: {
 		auto &setop = probe_child.Cast<LogicalSetOperation>();
 		// union
@@ -78,6 +80,11 @@ void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdown
 			}
 			// then recurse into the child
 			GenerateJoinFiltersRecursive(*child, std::move(child_columns), pushdown_info);
+
+			// for EXCEPT we can only recurse into the first (left) child
+			if (probe_child.type == LogicalOperatorType::LOGICAL_EXCEPT) {
+				break;
+			}
 		}
 		break;
 	}

--- a/test/sql/join/pushdown/pushdown_join_subquery.test
+++ b/test/sql/join/pushdown/pushdown_join_subquery.test
@@ -98,3 +98,37 @@ SELECT * FROM (SELECT i AS k, UNNEST(l) AS i FROM lists) JOIN (SELECT MAX(i) AS 
 497	999	999
 NULL	999	999
 499	999	999
+
+# set operations
+# union
+query II
+SELECT * FROM (FROM integers UNION ALL FROM integers) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----
+999	999
+999	999
+
+query II
+SELECT * FROM (FROM integers UNION FROM integers) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----
+999	999
+
+# intersect
+query II
+SELECT * FROM (FROM integers INTERSECT FROM integers) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----
+999	999
+
+query II
+SELECT * FROM (FROM integers INTERSECT ALL FROM integers) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----
+999	999
+
+# except
+query II
+SELECT * FROM (FROM integers EXCEPT (SELECT 42)) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----
+999	999
+
+query II
+SELECT * FROM ((SELECT 999 i) EXCEPT FROM integers) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----

--- a/test/sql/join/pushdown/pushdown_join_subquery.test
+++ b/test/sql/join/pushdown/pushdown_join_subquery.test
@@ -55,3 +55,46 @@ query III
 SELECT * FROM (SELECT i + 2 AS i, i AS k FROM integers) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
 ----
 999	997	999
+
+# group by with join on grouping column
+query II
+SELECT * FROM (SELECT i FROM integers GROUP BY i) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----
+999	999
+
+# group by with join on aggregate
+query III
+SELECT * FROM (SELECT (1000 - i) AS grp, SUM(i) AS i FROM integers GROUP BY grp) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----
+1	999	999
+
+# distinct
+query II
+SELECT * FROM (SELECT DISTINCT i FROM integers) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----
+999	999
+
+# window
+query IIII
+SELECT * FROM (SELECT i + 2 AS i, i AS k, row_number() over () as rownum FROM integers) JOIN (SELECT MAX(i) AS max_i FROM integers) ON i=max_i
+----
+999	997	998	999
+
+statement ok
+CREATE TABLE lists AS SELECT CASE WHEN i%2=0 THEN NULL ELSE i END AS i, [500 + i, 500 + i + 1, 500 + i + 2] l FROM range(1000) t(i)
+
+# unnest where filter applies to non-unnest column
+query III
+SELECT * FROM (SELECT i, UNNEST(l) AS l FROM lists) JOIN (SELECT MAX(i) AS max_i FROM lists) ON i=max_i
+----
+999	1499	999
+999	1500	999
+999	1501	999
+
+# unnest where filter applies to unnest column
+query III
+SELECT * FROM (SELECT i AS k, UNNEST(l) AS i FROM lists) JOIN (SELECT MAX(i) AS max_i FROM lists) ON i=max_i
+----
+497	999	999
+NULL	999	999
+499	999	999


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/12908

Allow dynamically generated join filters to be pushed through `UNION`, `UNNEST` and `AGGREGATE` nodes in the plan.

For `UNION`, this means we need to potentially push filters into multiple table scans. For example, in this case we push the filter into both scans over `lineitem`:

```sql
CREATE VIEW double_lineitem AS
FROM lineitem
UNION ALL
FROM lineitem;

SELECT *
FROM double_lineitem
WHERE l_orderkey=(SELECT MAX(l_orderkey) FROM lineitem) ORDER BY ALL
```

We can push filters through aggregates as well, as long as the filters are on grouping columns. However, in this case, the pipeline dependencies are not correctly set up yet to ensure the join upstream is executed before the aggregate - meaning the filter has no effect yet as the aggregate is computed before we know which rows we can filter out (CC @lnkuiper perhaps something you want to look into at some point). 