### PR TITLE
[PySpark] Add functions covar_pop, covar_samp, call_functions, endswith, startswith, exp, factorial, log2, ln, degrees, radians, atan, atan2, tan, round, bround

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2187,3 +2187,32 @@ def degrees(col: "ColumnOrName") -> Column:
     """
     return _invoke_function_over_columns("degrees", col)
 
+
+
+def radians(col: "ColumnOrName") -> Column:
+    """
+    Converts an angle measured in degrees to an approximately equivalent angle
+    measured in radians.
+
+    .. versionadded:: 2.1.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        angle in degrees
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        angle in radians, as if computed by `java.lang.Math.toRadians()`
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(radians(lit(180))).first()
+    Row(RADIANS(180)=3.14159...)
+    """
+    return _invoke_function_over_columns("radians", col)

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2037,3 +2037,35 @@ def covar_samp(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     [Row(c=0.0)]
     """
     return _invoke_function_over_columns("covar_samp", col1, col2)
+
+
+def exp(col: "ColumnOrName") -> Column:
+    """
+    Computes the exponential of the given value.
+
+    .. versionadded:: 1.4.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        column to calculate exponential for.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        exponential of the given value.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(exp(lit(0))).show()
+    +------+
+    |EXP(0)|
+    +------+
+    |   1.0|
+    +------+
+    """
+    return _invoke_function_over_columns("exp", col)

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2216,3 +2216,71 @@ def radians(col: "ColumnOrName") -> Column:
     Row(RADIANS(180)=3.14159...)
     """
     return _invoke_function_over_columns("radians", col)
+
+
+def atan(col: "ColumnOrName") -> Column:
+    """
+    Compute inverse tangent of the input column.
+
+    .. versionadded:: 1.4.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        inverse tangent of `col`, as if computed by `java.lang.Math.atan()`
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(atan(df.id)).show()
+    +--------+
+    |ATAN(id)|
+    +--------+
+    |     0.0|
+    +--------+
+    """
+    return _invoke_function_over_columns("atan", col)
+
+
+def atan2(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]) -> Column:
+    """
+    .. versionadded:: 1.4.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col1 : str, :class:`~pyspark.sql.Column` or float
+        coordinate on y-axis
+    col2 : str, :class:`~pyspark.sql.Column` or float
+        coordinate on x-axis
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the `theta` component of the point
+        (`r`, `theta`)
+        in polar coordinates that corresponds to the point
+        (`x`, `y`) in Cartesian coordinates,
+        as if computed by `java.lang.Math.atan2()`
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(atan2(lit(1), lit(2))).first()
+    Row(ATAN2(1, 2)=0.46364...)
+    """
+    def lit_or_column(x: Union["ColumnOrName", float]) -> Column:
+        if isinstance(x, (int, float)):
+            return lit(x)
+        return x
+    return _invoke_function_over_columns("atan2", lit_or_column(col1), lit_or_column(col2))

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2128,3 +2128,31 @@ def log2(col: "ColumnOrName") -> Column:
     +----+
     """
     return _invoke_function_over_columns("log2", col)
+
+
+def ln(col: "ColumnOrName") -> Column:
+    """Returns the natural logarithm of the argument.
+
+    .. versionadded:: 3.5.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        a column to calculate logariphm for.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        natural logarithm of given value.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([(4,)], ['a'])
+    >>> df.select(ln('a')).show()
+    +------------------+
+    |             ln(a)|
+    +------------------+
+    |1.3862943611198906|
+    +------------------+
+    """
+    return _invoke_function_over_columns("ln", col)

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2313,3 +2313,33 @@ def tan(col: "ColumnOrName") -> Column:
     Row(TAN(0.78539...)=0.99999...)
     """
     return _invoke_function_over_columns("tan", col)
+
+
+def round(col: "ColumnOrName", scale: int = 0) -> Column:
+    """
+    Round the given value to `scale` decimal places using HALF_UP rounding mode if `scale` >= 0
+    or at integral part when `scale` < 0.
+
+    .. versionadded:: 1.5.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        input column to round.
+    scale : int optional default 0
+        scale value.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        rounded values.
+
+    Examples
+    --------
+    >>> spark.createDataFrame([(2.5,)], ['a']).select(round('a', 0).alias('r')).collect()
+    [Row(r=3.0)]
+    """
+    return _invoke_function_over_columns("round", col, lit(scale))

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2156,3 +2156,34 @@ def ln(col: "ColumnOrName") -> Column:
     +------------------+
     """
     return _invoke_function_over_columns("ln", col)
+
+
+def degrees(col: "ColumnOrName") -> Column:
+    """
+    Converts an angle measured in radians to an approximately equivalent angle
+    measured in degrees.
+
+    .. versionadded:: 2.1.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        angle in radians
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        angle in degrees, as if computed by `java.lang.Math.toDegrees()`
+
+    Examples
+    --------
+    >>> import math
+    >>> df = spark.range(1)
+    >>> df.select(degrees(lit(math.pi))).first()
+    Row(DEGREES(3.14159...)=180.0)
+    """
+    return _invoke_function_over_columns("degrees", col)
+

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2343,3 +2343,33 @@ def round(col: "ColumnOrName", scale: int = 0) -> Column:
     [Row(r=3.0)]
     """
     return _invoke_function_over_columns("round", col, lit(scale))
+
+
+def bround(col: "ColumnOrName", scale: int = 0) -> Column:
+    """
+    Round the given value to `scale` decimal places using HALF_EVEN rounding mode if `scale` >= 0
+    or at integral part when `scale` < 0.
+
+    .. versionadded:: 2.0.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        input column to round.
+    scale : int optional default 0
+        scale value.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        rounded values.
+
+    Examples
+    --------
+    >>> spark.createDataFrame([(2.5,)], ['a']).select(bround('a', 0).alias('r')).collect()
+    [Row(r=2.0)]
+    """
+    return _invoke_function_over_columns("round_even", col, lit(scale))

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -1832,3 +1832,70 @@ def acos(col: "ColumnOrName") -> Column:
     +--------+
     """
     return _invoke_function_over_columns("acos", col)
+
+
+def call_function(funcName: str, *cols: "ColumnOrName") -> Column:
+    """
+    Call a SQL function.
+
+    .. versionadded:: 3.5.0
+
+    Parameters
+    ----------
+    funcName : str
+        function name that follows the SQL identifier syntax (can be quoted, can be qualified)
+    cols : :class:`~pyspark.sql.Column` or str
+        column names or :class:`~pyspark.sql.Column`\\s to be used in the function
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        result of executed function.
+
+    Examples
+    --------
+    >>> from pyspark.sql.functions import call_udf, col
+    >>> from pyspark.sql.types import IntegerType, StringType
+    >>> df = spark.createDataFrame([(1, "a"),(2, "b"), (3, "c")],["id", "name"])
+    >>> _ = spark.udf.register("intX2", lambda i: i * 2, IntegerType())
+    >>> df.select(call_function("intX2", "id")).show()
+    +---------+
+    |intX2(id)|
+    +---------+
+    |        2|
+    |        4|
+    |        6|
+    +---------+
+    >>> _ = spark.udf.register("strX2", lambda s: s * 2, StringType())
+    >>> df.select(call_function("strX2", col("name"))).show()
+    +-----------+
+    |strX2(name)|
+    +-----------+
+    |         aa|
+    |         bb|
+    |         cc|
+    +-----------+
+    >>> df.select(call_function("avg", col("id"))).show()
+    +-------+
+    |avg(id)|
+    +-------+
+    |    2.0|
+    +-------+
+    >>> _ = spark.sql("CREATE FUNCTION custom_avg AS 'test.org.apache.spark.sql.MyDoubleAvg'")
+    ... # doctest: +SKIP
+    >>> df.select(call_function("custom_avg", col("id"))).show()
+    ... # doctest: +SKIP
+    +------------------------------------+
+    |spark_catalog.default.custom_avg(id)|
+    +------------------------------------+
+    |                               102.0|
+    +------------------------------------+
+    >>> df.select(call_function("spark_catalog.default.custom_avg", col("id"))).show()
+    ... # doctest: +SKIP
+    +------------------------------------+
+    |spark_catalog.default.custom_avg(id)|
+    +------------------------------------+
+    |                               102.0|
+    +------------------------------------+
+    """
+    return _invoke_function_over_columns(funcName, *cols)

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2069,3 +2069,31 @@ def exp(col: "ColumnOrName") -> Column:
     +------+
     """
     return _invoke_function_over_columns("exp", col)
+
+
+def factorial(col: "ColumnOrName") -> Column:
+    """
+    Computes the factorial of the given value.
+
+    .. versionadded:: 1.5.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        a column to calculate factorial for.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        factorial of given value.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([(5,)], ['n'])
+    >>> df.select(factorial(df.n).alias('f')).collect()
+    [Row(f=120)]
+    """
+    return _invoke_function_over_columns("factorial", col)

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -1057,6 +1057,43 @@ def ltrim(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("ltrim", col)
 
 
+def endswith(str: "ColumnOrName", suffix: "ColumnOrName") -> Column:
+    """
+    Returns a boolean. The value is True if str ends with suffix.
+    Returns NULL if either input expression is NULL. Otherwise, returns False.
+    Both str or suffix must be of STRING or BINARY type.
+
+    .. versionadded:: 3.5.0
+
+    Parameters
+    ----------
+    str : :class:`~pyspark.sql.Column` or str
+        A column of string.
+    suffix : :class:`~pyspark.sql.Column` or str
+        A column of string, the suffix.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([("Spark SQL", "Spark",)], ["a", "b"])
+    >>> df.select(endswith(df.a, df.b).alias('r')).collect()
+    [Row(r=False)]
+
+    >>> df = spark.createDataFrame([("414243", "4243",)], ["e", "f"])
+    >>> df = df.select(to_binary("e").alias("e"), to_binary("f").alias("f"))
+    >>> df.printSchema()
+    root
+     |-- e: binary (nullable = true)
+     |-- f: binary (nullable = true)
+    >>> df.select(endswith("e", "f"), endswith("f", "e")).show()
+    +--------------+--------------+
+    |endswith(e, f)|endswith(f, e)|
+    +--------------+--------------+
+    |          true|         false|
+    +--------------+--------------+
+    """
+    return _invoke_function_over_columns("ends_with", str, suffix)
+
+
 def length(col: "ColumnOrName") -> Column:
     """Computes the character length of string data or number of bytes of binary data.
     The length of character data includes the trailing spaces. The length of binary data

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -1899,3 +1899,35 @@ def call_function(funcName: str, *cols: "ColumnOrName") -> Column:
     +------------------------------------+
     """
     return _invoke_function_over_columns(funcName, *cols)
+
+
+def covar_pop(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
+    """Returns a new :class:`~pyspark.sql.Column` for the population covariance of ``col1`` and
+    ``col2``.
+
+    .. versionadded:: 2.0.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col1 : :class:`~pyspark.sql.Column` or str
+        first column to calculate covariance.
+    col1 : :class:`~pyspark.sql.Column` or str
+        second column to calculate covariance.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        covariance of these two column values.
+
+    Examples
+    --------
+    >>> a = [1] * 10
+    >>> b = [1] * 10
+    >>> df = spark.createDataFrame(zip(a, b), ["a", "b"])
+    >>> df.agg(covar_pop("a", "b").alias('c')).collect()
+    [Row(c=0.0)]
+    """
+    return _invoke_function_over_columns("covar_pop", col1, col2)

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -1094,6 +1094,43 @@ def endswith(str: "ColumnOrName", suffix: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("ends_with", str, suffix)
 
 
+def startswith(str: "ColumnOrName", prefix: "ColumnOrName") -> Column:
+    """
+    Returns a boolean. The value is True if str starts with prefix.
+    Returns NULL if either input expression is NULL. Otherwise, returns False.
+    Both str or prefix must be of STRING or BINARY type.
+
+    .. versionadded:: 3.5.0
+
+    Parameters
+    ----------
+    str : :class:`~pyspark.sql.Column` or str
+        A column of string.
+    prefix : :class:`~pyspark.sql.Column` or str
+        A column of string, the prefix.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([("Spark SQL", "Spark",)], ["a", "b"])
+    >>> df.select(startswith(df.a, df.b).alias('r')).collect()
+    [Row(r=True)]
+
+    >>> df = spark.createDataFrame([("414243", "4142",)], ["e", "f"])
+    >>> df = df.select(to_binary("e").alias("e"), to_binary("f").alias("f"))
+    >>> df.printSchema()
+    root
+     |-- e: binary (nullable = true)
+     |-- f: binary (nullable = true)
+    >>> df.select(startswith("e", "f"), startswith("f", "e")).show()
+    +----------------+----------------+
+    |startswith(e, f)|startswith(f, e)|
+    +----------------+----------------+
+    |            true|           false|
+    +----------------+----------------+
+    """
+    return _invoke_function_over_columns("starts_with", str, prefix)
+
+
 def length(col: "ColumnOrName") -> Column:
     """Computes the character length of string data or number of bytes of binary data.
     The length of character data includes the trailing spaces. The length of binary data

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -1091,7 +1091,7 @@ def endswith(str: "ColumnOrName", suffix: "ColumnOrName") -> Column:
     |          true|         false|
     +--------------+--------------+
     """
-    return _invoke_function_over_columns("ends_with", str, suffix)
+    return _invoke_function_over_columns("suffix", str, suffix)
 
 
 def startswith(str: "ColumnOrName", prefix: "ColumnOrName") -> Column:

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -1931,3 +1931,35 @@ def covar_pop(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     [Row(c=0.0)]
     """
     return _invoke_function_over_columns("covar_pop", col1, col2)
+
+
+def covar_samp(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
+    """Returns a new :class:`~pyspark.sql.Column` for the sample covariance of ``col1`` and
+    ``col2``.
+
+    .. versionadded:: 2.0.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col1 : :class:`~pyspark.sql.Column` or str
+        first column to calculate covariance.
+    col1 : :class:`~pyspark.sql.Column` or str
+        second column to calculate covariance.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        sample covariance of these two column values.
+
+    Examples
+    --------
+    >>> a = [1] * 10
+    >>> b = [1] * 10
+    >>> df = spark.createDataFrame(zip(a, b), ["a", "b"])
+    >>> df.agg(covar_samp("a", "b").alias('c')).collect()
+    [Row(c=0.0)]
+    """
+    return _invoke_function_over_columns("covar_samp", col1, col2)

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2097,3 +2097,34 @@ def factorial(col: "ColumnOrName") -> Column:
     [Row(f=120)]
     """
     return _invoke_function_over_columns("factorial", col)
+
+
+def log2(col: "ColumnOrName") -> Column:
+    """Returns the base-2 logarithm of the argument.
+
+    .. versionadded:: 1.5.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        a column to calculate logariphm for.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        logariphm of given value.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([(4,)], ['a'])
+    >>> df.select(log2('a').alias('log2')).show()
+    +----+
+    |log2|
+    +----+
+    | 2.0|
+    +----+
+    """
+    return _invoke_function_over_columns("log2", col)

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2284,3 +2284,32 @@ def atan2(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]
             return lit(x)
         return x
     return _invoke_function_over_columns("atan2", lit_or_column(col1), lit_or_column(col2))
+
+
+def tan(col: "ColumnOrName") -> Column:
+    """
+    Computes tangent of the input column.
+
+    .. versionadded:: 1.4.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        angle in radians
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        tangent of the given value, as if computed by `java.lang.Math.tan()`
+
+    Examples
+    --------
+    >>> import math
+    >>> df = spark.range(1)
+    >>> df.select(tan(lit(math.radians(45)))).first()
+    Row(TAN(0.78539...)=0.99999...)
+    """
+    return _invoke_function_over_columns("tan", col)

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_miscellaneous.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_miscellaneous.py
@@ -1,0 +1,30 @@
+import pytest
+
+_ = pytest.importorskip("duckdb.experimental.spark")
+from duckdb.experimental.spark.sql import functions as F
+from duckdb.experimental.spark.sql.types import Row
+
+
+class TestsSparkFunctionsMiscellaneous:
+    def test_call_function(self, spark):
+        data = [
+            (-1, 2),
+            (4, 3),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn", "secondColumn"])
+
+        # Test with 2 columns as arguments
+        df = df.withColumn("greatest_value", F.call_function("greatest", F.col("firstColumn"), F.col("secondColumn")))
+        res = df.select("greatest_value").collect()
+        assert res == [
+            Row(greatest_value=2),
+            Row(greatest_value=4),
+        ]
+
+        # Test with 1 column as argument
+        df = df.withColumn("abs_value", F.call_function("abs", F.col("firstColumn")))
+        res = df.select("abs_value").collect()
+        assert res == [
+            Row(abs_value=1),
+            Row(abs_value=4),
+        ]

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -166,3 +166,14 @@ class TestSparkFunctionsNumeric(object):
         res = df.select("degrees_value").collect()
         round(res[0].degrees_value, 2) == 180
         res[1].degrees_value == 0
+
+    def test_radians(self, spark):
+        data = [
+            (180,),
+            (0,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = df.withColumn("radians_value", F.radians(F.col("firstColumn")))
+        res = df.select("radians_value").collect()
+        round(res[0].radians_value, 2) == 3.14
+        res[1].radians_value == 0

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -132,7 +132,6 @@ class TestSparkFunctionsNumeric(object):
             Row(factorial_value=120),
         ]
 
-
     def test_log2(self, spark):
         data = [
             (4,),

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -213,3 +213,14 @@ class TestSparkFunctionsNumeric(object):
         res = df2.select("atan2_value_lit_col").collect()
         round(res[0].atan2_value_lit_col, 2) == 0.79
         res[1].atan2_value_lit_col == 0
+
+    def test_tan(self, spark):
+        data = [
+            (0,),
+            (1,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = df.withColumn("tan_value", F.tan(F.col("firstColumn")))
+        res = df.select("tan_value").collect()
+        res[0].tan_value == 0
+        round(res[1].tan_value, 2) == 1.56

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -119,3 +119,16 @@ class TestSparkFunctionsNumeric(object):
         round(res[0].exp_value, 2) == 2
         res[1].exp_value == 1
 
+    def test_factorial(self, spark):
+        data = [
+            (4,),
+            (5,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = df.withColumn("factorial_value", F.factorial(F.col("firstColumn")))
+        res = df.select("factorial_value").collect()
+        assert res == [
+            Row(factorial_value=24),
+            Row(factorial_value=120),
+        ]
+

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -107,3 +107,15 @@ class TestSparkFunctionsNumeric(object):
         assert len(res) == 2
         assert res[0].acos_value == pytest.approx(0.0)
         assert res[1].acos_value == pytest.approx(3.141592653589793)
+
+    def test_exp(self, spark):
+        data = [
+            (0.693,),
+            (0,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = df.withColumn("exp_value", F.exp(F.col("firstColumn")))
+        res = df.select("exp_value").collect()
+        round(res[0].exp_value, 2) == 2
+        res[1].exp_value == 1
+

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -224,3 +224,21 @@ class TestSparkFunctionsNumeric(object):
         res = df.select("tan_value").collect()
         res[0].tan_value == 0
         round(res[1].tan_value, 2) == 1.56
+
+    def test_round(self, spark):
+        data = [
+            (11.15,),
+            (2.9,),
+            # Test with this that HALF_UP rounding method is used and not HALF_EVEN
+            (2.5,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = (df.withColumn("round_value", F.round("firstColumn"))
+            .withColumn("round_value_1", F.round(F.col("firstColumn"), 1))
+            .withColumn("round_value_minus_1", F.round("firstColumn", -1)))
+        res = df.select("round_value", "round_value_1", "round_value_minus_1").collect()
+        assert res == [
+            Row(round_value=11, round_value_1=11.2, round_value_minus_1=10),
+            Row(round_value=3, round_value_1=2.9, round_value_minus_1=0),
+            Row(round_value=3, round_value_1=2.5, round_value_minus_1=0),
+        ]

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -242,3 +242,21 @@ class TestSparkFunctionsNumeric(object):
             Row(round_value=3, round_value_1=2.9, round_value_minus_1=0),
             Row(round_value=3, round_value_1=2.5, round_value_minus_1=0),
         ]
+
+    def test_bround(self, spark):
+        data = [
+            (11.15,),
+            (2.9,),
+            # Test with this that HALF_EVEN rounding method is used and not HALF_UP
+            (2.5,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = (df.withColumn("round_value", F.bround(F.col("firstColumn")))
+            .withColumn("round_value_1", F.bround(F.col("firstColumn"), 1))
+            .withColumn("round_value_minus_1", F.bround(F.col("firstColumn"), -1)))
+        res = df.select("round_value", "round_value_1", "round_value_minus_1").collect()
+        assert res == [
+            Row(round_value=11, round_value_1=11.2, round_value_minus_1=10),
+            Row(round_value=3, round_value_1=2.9, round_value_minus_1=0),
+            Row(round_value=2, round_value_1=2.5, round_value_minus_1=0),
+        ]

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -233,9 +233,11 @@ class TestSparkFunctionsNumeric(object):
             (2.5,),
         ]
         df = spark.createDataFrame(data, ["firstColumn"])
-        df = (df.withColumn("round_value", F.round("firstColumn"))
+        df = (
+            df.withColumn("round_value", F.round("firstColumn"))
             .withColumn("round_value_1", F.round(F.col("firstColumn"), 1))
-            .withColumn("round_value_minus_1", F.round("firstColumn", -1)))
+            .withColumn("round_value_minus_1", F.round("firstColumn", -1))
+        )
         res = df.select("round_value", "round_value_1", "round_value_minus_1").collect()
         assert res == [
             Row(round_value=11, round_value_1=11.2, round_value_minus_1=10),
@@ -251,9 +253,11 @@ class TestSparkFunctionsNumeric(object):
             (2.5,),
         ]
         df = spark.createDataFrame(data, ["firstColumn"])
-        df = (df.withColumn("round_value", F.bround(F.col("firstColumn")))
+        df = (
+            df.withColumn("round_value", F.bround(F.col("firstColumn")))
             .withColumn("round_value_1", F.bround(F.col("firstColumn"), 1))
-            .withColumn("round_value_minus_1", F.bround(F.col("firstColumn"), -1)))
+            .withColumn("round_value_minus_1", F.bround(F.col("firstColumn"), -1))
+        )
         res = df.select("round_value", "round_value_1", "round_value_minus_1").collect()
         assert res == [
             Row(round_value=11, round_value_1=11.2, round_value_minus_1=10),

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -155,3 +155,14 @@ class TestSparkFunctionsNumeric(object):
         res = df.select("ln_value").collect()
         round(res[0].ln_value, 2) == 1
         res[1].ln_value == 0
+
+    def test_degrees(self, spark):
+        data = [
+            (3.14159,),
+            (0,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = df.withColumn("degrees_value", F.degrees(F.col("firstColumn")))
+        res = df.select("degrees_value").collect()
+        round(res[0].degrees_value, 2) == 180
+        res[1].degrees_value == 0

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -145,3 +145,14 @@ class TestSparkFunctionsNumeric(object):
             Row(log2_value=2.0),
             Row(log2_value=3.0),
         ]
+
+    def test_ln(self, spark):
+        data = [
+            (2.718,),
+            (1,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = df.withColumn("ln_value", F.ln(F.col("firstColumn")))
+        res = df.select("ln_value").collect()
+        round(res[0].ln_value, 2) == 1
+        res[1].ln_value == 0

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -177,3 +177,39 @@ class TestSparkFunctionsNumeric(object):
         res = df.select("radians_value").collect()
         round(res[0].radians_value, 2) == 3.14
         res[1].radians_value == 0
+
+    def test_atan(self, spark):
+        data = [
+            (1,),
+            (0,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = df.withColumn("atan_value", F.atan(F.col("firstColumn")))
+        res = df.select("atan_value").collect()
+        round(res[0].atan_value, 2) == 0.79
+        res[1].atan_value == 0
+
+    def test_atan2(self, spark):
+        data = [
+            (1, 1),
+            (0, 0),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn", "secondColumn"])
+
+        # Both columns
+        df2 = df.withColumn("atan2_value", F.atan2(F.col("firstColumn"), "secondColumn"))
+        res = df2.select("atan2_value").collect()
+        round(res[0].atan2_value, 2) == 0.79
+        res[1].atan2_value == 0
+
+        # Both literals
+        df2 = df.withColumn("atan2_value_lit", F.atan2(1, 1))
+        res = df2.select("atan2_value_lit").collect()
+        round(res[0].atan2_value_lit, 2) == 0.79
+        round(res[1].atan2_value_lit, 2) == 0.79
+
+        # One literal, one column
+        df2 = df.withColumn("atan2_value_lit_col", F.atan2(1.0, F.col("secondColumn")))
+        res = df2.select("atan2_value_lit_col").collect()
+        round(res[0].atan2_value_lit_col, 2) == 0.79
+        res[1].atan2_value_lit_col == 0

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_numeric.py
@@ -132,3 +132,16 @@ class TestSparkFunctionsNumeric(object):
             Row(factorial_value=120),
         ]
 
+
+    def test_log2(self, spark):
+        data = [
+            (4,),
+            (8,),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn"])
+        df = df.withColumn("log2_value", F.log2(F.col("firstColumn")))
+        res = df.select("log2_value").collect()
+        assert res == [
+            Row(log2_value=2.0),
+            Row(log2_value=3.0),
+        ]

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_string.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_string.py
@@ -83,3 +83,16 @@ class TestSparkFunctionsString(object):
             Row(rtrimmed=" firstRowFirstColumn"),
             Row(rtrimmed=" 2ndRowFirstColumn"),
         ]
+
+    def test_endswith(self, spark):
+        data = [
+            ("firstRowFirstColumn", "Column"),
+            ("2ndRowFirstColumn", "column"),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn", "secondColumn"])
+        df = df.withColumn("endswith", F.endswith(F.col("firstColumn"), F.col("secondColumn")))
+        res = df.select("endswith").collect()
+        assert res == [
+            Row(endswith=True),
+            Row(endswith=False),
+        ]

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_string.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_string.py
@@ -96,3 +96,16 @@ class TestSparkFunctionsString(object):
             Row(endswith=True),
             Row(endswith=False),
         ]
+
+    def test_startswith(self, spark):
+        data = [
+            ("firstRowFirstColumn", "irst"),
+            ("2ndRowFirstColumn", "2nd"),
+        ]
+        df = spark.createDataFrame(data, ["firstColumn", "secondColumn"])
+        df = df.withColumn("startswith", F.startswith(F.col("firstColumn"), F.col("secondColumn")))
+        res = df.select("startswith").collect()
+        assert res == [
+            Row(startswith=False),
+            Row(startswith=True),
+        ]

--- a/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
@@ -15,7 +15,18 @@ from duckdb.experimental.spark.sql.types import (
     MapType,
 )
 from duckdb.experimental.spark.sql.functions import col, struct, when, lit, array_contains
-from duckdb.experimental.spark.sql.functions import sum, avg, max, min, mean, count, any_value, approx_count_distinct, covar_pop, covar_samp
+from duckdb.experimental.spark.sql.functions import (
+    sum,
+    avg,
+    max,
+    min,
+    mean,
+    count,
+    any_value,
+    approx_count_distinct,
+    covar_pop,
+    covar_samp,
+)
 
 
 class TestDataFrameGroupBy(object):

--- a/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
@@ -128,7 +128,10 @@ class TestDataFrameGroupBy(object):
             ],
             schema=["age", "other_variable", "group"],
         )
-        df2 = df.groupBy("group").agg(covar_pop("age", "other_variable").alias("covar_pop"), covar_samp("age", "other_variable").alias("covar_samp"))
+        df2 = df.groupBy("group").agg(
+            covar_pop("age", "other_variable").alias("covar_pop"),
+            covar_samp("age", "other_variable").alias("covar_samp"),
+        )
         res = df2.collect()
         assert str(res) == "[Row(group='a', covar_pop=1.5, covar_samp=2.0)]"
 

--- a/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
@@ -15,7 +15,7 @@ from duckdb.experimental.spark.sql.types import (
     MapType,
 )
 from duckdb.experimental.spark.sql.functions import col, struct, when, lit, array_contains
-from duckdb.experimental.spark.sql.functions import sum, avg, max, min, mean, count, any_value, approx_count_distinct
+from duckdb.experimental.spark.sql.functions import sum, avg, max, min, mean, count, any_value, approx_count_distinct, covar_pop
 
 
 class TestDataFrameGroupBy(object):
@@ -118,6 +118,19 @@ class TestDataFrameGroupBy(object):
             str(res)
             == "[Row(department='Finance', sum_salary=351000, avg_salary=87750.0, sum_bonus=81000, max_bonus=24000, any_state='CA'), Row(department='Sales', sum_salary=257000, avg_salary=85666.66666666667, sum_bonus=53000, max_bonus=23000, any_state='NY')]"
         )
+
+        df = spark.createDataFrame(
+            [
+                (1, 1, "a"),
+                (2, 2, "a"),
+                (2, 3, "a"),
+                (5, 4, "a"),
+            ],
+            schema=["age", "other_variable", "group"],
+        )
+        df2 = df.groupBy("group").agg(covar_pop("age", "other_variable"))
+        res = df2.collect()
+        assert str(res) == "[Row(group='a', covar_pop(age, other_variable)=1.5)]"
 
     def test_group_by_empty(self, spark):
         df = spark.createDataFrame(

--- a/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_group_by.py
@@ -15,7 +15,7 @@ from duckdb.experimental.spark.sql.types import (
     MapType,
 )
 from duckdb.experimental.spark.sql.functions import col, struct, when, lit, array_contains
-from duckdb.experimental.spark.sql.functions import sum, avg, max, min, mean, count, any_value, approx_count_distinct, covar_pop
+from duckdb.experimental.spark.sql.functions import sum, avg, max, min, mean, count, any_value, approx_count_distinct, covar_pop, covar_samp
 
 
 class TestDataFrameGroupBy(object):
@@ -128,9 +128,9 @@ class TestDataFrameGroupBy(object):
             ],
             schema=["age", "other_variable", "group"],
         )
-        df2 = df.groupBy("group").agg(covar_pop("age", "other_variable"))
+        df2 = df.groupBy("group").agg(covar_pop("age", "other_variable").alias("covar_pop"), covar_samp("age", "other_variable").alias("covar_samp"))
         res = df2.collect()
-        assert str(res) == "[Row(group='a', covar_pop(age, other_variable)=1.5)]"
+        assert str(res) == "[Row(group='a', covar_pop=1.5, covar_samp=2.0)]"
 
     def test_group_by_empty(self, spark):
         df = spark.createDataFrame(


### PR DESCRIPTION
I'll just keep creating new small PRs (e.g. #14347). Let me know if you'd prefer less frequent but larger ones.