### PR TITLE
SingleFileBlockManager::MarkBlockAsUsed - also erase from newly_freed_list to ensure trim does not prune blocks that are in-use

### DIFF
--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -376,8 +376,9 @@ void SingleFileBlockManager::MarkBlockAsUsed(block_id_t block_id) {
 		}
 		max_block++;
 	} else if (free_list.find(block_id) != free_list.end()) {
-		// block is currently int he free list - erase
+		// block is currently in the free list - erase
 		free_list.erase(block_id);
+		newly_freed_list.erase(block_id);
 	} else {
 		// block is already in use - increase reference count
 		IncreaseBlockReferenceCountInternal(block_id);


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/3289