### PR TITLE
acosh: Change example to avoid returning NaN

### DIFF
--- a/src/core_functions/scalar/math/functions.json
+++ b/src/core_functions/scalar/math/functions.json
@@ -297,7 +297,7 @@
         "name": "acosh",
         "parameters": "x",
         "description": "Computes the inverse hyperbolic cos of x",
-        "example": "acosh(0.5)",
+        "example": "acosh(2.3)",
         "type": "scalar_function"
     },
     {

--- a/src/include/duckdb/core_functions/scalar/math_functions.hpp
+++ b/src/include/duckdb/core_functions/scalar/math_functions.hpp
@@ -427,7 +427,7 @@ struct AcoshFun {
 	static constexpr const char *Name = "acosh";
 	static constexpr const char *Parameters = "x";
 	static constexpr const char *Description = "Computes the inverse hyperbolic cos of x";
-	static constexpr const char *Example = "acosh(0.5)";
+	static constexpr const char *Example = "acosh(2.3)";
 
 	static ScalarFunction GetFunction();
 };


### PR DESCRIPTION
#13346 added `acosh` along with other hyperbolic trigonometric functions. The current `acosh` example uses a value that falls outside of the function's domain. In Postgres, this returns and error, while in DuckDB it returns a NaN:

```sql
postgres=# select acosh(0.5);
ERROR:  input is out of range
```

```sql
D select acosh(0.5);
┌────────────┐
│ acosh(0.5) │
│   double   │
├────────────┤
│        nan │
└────────────┘
```

This PR changes the example.