### PR TITLE
fix: standardize usage of LogicalType::ROW_TYPE for COLUMN_IDENTIFIER_ROW_ID

### DIFF
--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -159,7 +159,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 		vector<unique_ptr<Expression>> expressions;
 		for (auto &column_id : column_ids) {
 			if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
-				types.emplace_back(LogicalType::BIGINT);
+				types.emplace_back(LogicalType::ROW_TYPE);
 				expressions.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(0)));
 			} else {
 				auto type = op.returned_types[column_id];

--- a/src/planner/table_binding.cpp
+++ b/src/planner/table_binding.cpp
@@ -202,8 +202,7 @@ BindResult TableBinding::Bind(ColumnRefExpression &colref, idx_t depth) {
 	// fetch the type of the column
 	LogicalType col_type;
 	if (column_index == COLUMN_IDENTIFIER_ROW_ID) {
-		// row id: BIGINT type
-		col_type = LogicalType::BIGINT;
+		col_type = LogicalType::ROW_TYPE;
 	} else {
 		// normal column: fetch type from base column
 		col_type = types[column_index];


### PR DESCRIPTION
Updated two instances where LogicalType::BIGINT was mistakenly used instead of ROW_TYPE when handling the COLUMN_IDENTIFIER_ROW_ID pseudo-column. This change aligns the code with the rest of the project for consistency and clarity.