### PR TITLE
#14487 Bug when referencing json object in query_graph.

### DIFF
--- a/tools/pythonpkg/duckdb/query_graph/__main__.py
+++ b/tools/pythonpkg/duckdb/query_graph/__main__.py
@@ -167,7 +167,7 @@ def generate_tree_recursive(json_graph: object) -> str:
 def generate_timing_html(graph_json: object, query_timings: object) -> object:
     json_graph = json.loads(graph_json)
     gather_timing_information(json_graph, query_timings)
-    total_time = float(json_graph['children'][0]['operator_timing'])
+    total_time = query_timings.get_sum_of_all_timings()
     table_head = """
 	<table class=\"styled-table\"> 
 		<thead>
@@ -181,7 +181,7 @@ def generate_timing_html(graph_json: object, query_timings: object) -> object:
     table_body = "<tbody>"
     table_end = "</tbody></table>"
 
-    execution_time = query_timings.get_sum_of_all_timings()
+    execution_time = float(json_graph['latency'])
 
     all_phases = query_timings.get_phases()
     query_timings.add_node_timing(NodeTiming("TOTAL TIME", total_time))

--- a/tools/pythonpkg/duckdb/query_graph/__main__.py
+++ b/tools/pythonpkg/duckdb/query_graph/__main__.py
@@ -167,7 +167,7 @@ def generate_tree_recursive(json_graph: object) -> str:
 def generate_timing_html(graph_json: object, query_timings: object) -> object:
     json_graph = json.loads(graph_json)
     gather_timing_information(json_graph, query_timings)
-    total_time = query_timings.get_sum_of_all_timings()
+    total_time = float(json_graph['children'][0]['operator_timing'])
     table_head = """
 	<table class=\"styled-table\"> 
 		<thead>

--- a/tools/pythonpkg/duckdb/query_graph/__main__.py
+++ b/tools/pythonpkg/duckdb/query_graph/__main__.py
@@ -167,7 +167,7 @@ def generate_tree_recursive(json_graph: object) -> str:
 def generate_timing_html(graph_json: object, query_timings: object) -> object:
     json_graph = json.loads(graph_json)
     gather_timing_information(json_graph, query_timings)
-    total_time = float(json_graph['operator_timing'])
+    total_time = query_timings.get_sum_of_all_timings()
     table_head = """
 	<table class=\"styled-table\"> 
 		<thead>


### PR DESCRIPTION
Fixed bug with generate_timing_html() where it tries to access a json key that does not exist (`total_time = float(json_graph['operator_timing'])`).

~~Since an object with the total time is created at the line before, by iterating over `json_graph['children'][0]` I make use of that, i.e `total_time = query_timings.get_sum_of_all_timings()` rather than `total_time = float(json_graph['children'][0])` in case the json object is more nested than expected. It makes more sense to let the existing methods handle any logic.~~

**Edit:** 

So I think both total_time and execution time was wrongly implemented, by going over how these numbers are used and trying to piece them together with the definitions in the documentation.

`Total_time` seems to be meant to be the same the sum of `operator_time`, found with `query_timings.get_sum_of_all_timings()`
Execution time seems to be the same as latency (`The total elapsed query execution time.`). 

In code:

`total_time = query_timings.get_sum_of_all_timings()`
`execution_time = json_graph['latency']`

The reasoning for this is that using latency for `total_time` gives weird percentages (since it will be smaller than the individual parts in many cases), and using `query_timings.get_sum_of_all_timings()` for `total_time` makes `execution_time` and `total_time` equal. 

Using `json_graph['children'][0]['operator_time']` gives a wrong number in case there is more operators than one at this level. 

I think the documentation and code (json output compilation) should reflect each other better so there are proper definitions of everything in the query_graph report. I.e that Execution time is renamed to latency or vice versa. 

I also see there are some missing logic in the query_graph, handling if any fields are not outputted by using custom profile settings. I can gladly rewrite the code to better reflect what we see in the documentation, for instance calling execution time Total elapsed query execution time or similar, and calling total time cumulative operator time or similar. Even adding a link directly to the duckdb documentation for profiling in the report could be considered.

Issue: https://github.com/duckdb/duckdb/issues/14487

I flag this as ready for review to get some feedback here. Doing the CLI explain analyze shows that the "total time" used there is equal to `execution_time = json_graph['latency']`, so it is possible that things needs a bit of renaming or that I got it wrong. With some feedback I will fix it.  
