### PR TITLE
Bug in percentage calculation in query_graph

### DIFF
--- a/tools/pythonpkg/duckdb/query_graph/__main__.py
+++ b/tools/pythonpkg/duckdb/query_graph/__main__.py
@@ -195,7 +195,7 @@ def generate_timing_html(graph_json: object, query_timings: object) -> object:
 	<tr>
 			<td>{phase_column}</td>
             <td>{summarized_phase.time}</td>
-            <td>{str(summarized_phase.percentage * 100)[:6]}%</td>
+            <td>{round(summarized_phase.percentage*100,4)}%</td>
     </tr>
 """
     table_body += table_end


### PR DESCRIPTION
The existing code to calculate the percentages shown in the html report `str(summarized_phase.percentage * 100)[:6]` will fail if the number is on the form of 8.09860748592347e-07 or similar. Changed to `round(summarized_phase.percentage,4)` to give a rounded number that is correct.


```python
summarized_phase.percentage = 8.09860748592347e-07
str(summarized_phase.percentage*100)[:6]
>'8.0986'
round(summarized_phase.percentage*100,4)
>0.0001
```