### PR TITLE
chore: update EXTENSION_SECRET_TYPES to reflect user-facing supported secret types

### DIFF
--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -507,7 +507,7 @@ def write_header(data: ExtensionData):
                                                                 {"gcs", "httpfs"},
                                                                 {"azure", "azure"},
                                                                 {"huggingface", "httpfs"},
-                                                                {"bearer", "httpfs"}
+                                                                {"http", ""}}
     }; // EXTENSION_SECRET_TYPES
                                                                 
                                                                 

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -526,7 +526,7 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"azure/service_principal", "azure"},
     {"huggingface/config", "httfps"},
     {"huggingface/credential_chain", "httpfs"},
-    {"bearer/config", "httpfs"}}; // EXTENSION_SECRET_PROVIDERS
+    {"http/config", "httpfs"}}; // EXTENSION_SECRET_PROVIDERS
 
 static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "aws",   "azure", "autocomplete", "delta",   "excel",          "fts",      "httpfs",

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -509,7 +509,7 @@ static constexpr ExtensionEntry EXTENSION_FILE_CONTAINS[] = {{".parquet?", "parq
 // TODO: automate by passing though to script via duckdb
 static constexpr ExtensionEntry EXTENSION_SECRET_TYPES[] = {
     {"s3", "httpfs"},   {"r2", "httpfs"},          {"gcs", "httpfs"},
-    {"azure", "azure"}, {"huggingface", "httpfs"}, {"http", "httpfs"}}; // EXTENSION_SECRET_TYPES
+    {"azure", "azure"}, {"huggingface", "httpfs"}, {"http", ""}}; // EXTENSION_SECRET_TYPES
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb
@@ -526,7 +526,7 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"azure/service_principal", "azure"},
     {"huggingface/config", "httfps"},
     {"huggingface/credential_chain", "httpfs"},
-    {"http/config", "httpfs"}}; // EXTENSION_SECRET_PROVIDERS
+    {"bearer/config", "httpfs"}}; // EXTENSION_SECRET_PROVIDERS
 
 static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "aws",   "azure", "autocomplete", "delta",   "excel",          "fts",      "httpfs",

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -509,7 +509,7 @@ static constexpr ExtensionEntry EXTENSION_FILE_CONTAINS[] = {{".parquet?", "parq
 // TODO: automate by passing though to script via duckdb
 static constexpr ExtensionEntry EXTENSION_SECRET_TYPES[] = {
     {"s3", "httpfs"},   {"r2", "httpfs"},          {"gcs", "httpfs"},
-    {"azure", "azure"}, {"huggingface", "httpfs"}, {"bearer", "httpfs"}}; // EXTENSION_SECRET_TYPES
+    {"azure", "azure"}, {"huggingface", "httpfs"}, {"http", "httpfs"}}; // EXTENSION_SECRET_TYPES
 
 // Note: these are currently hardcoded in scripts/generate_extensions_function.py
 // TODO: automate by passing though to script via duckdb


### PR DESCRIPTION
`bearer` doesn't seem to be a secret type users can use today to create secret as but http is. So updating `EXTENSION_SECRET_TYPES` to reflect this. 