### PR TITLE
feat(iejoin): use sort to replace binary search in iejoin

### DIFF
--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -389,9 +389,9 @@ IEJoinUnion::IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, Sorte
 	auto ref = make_uniq<BoundReferenceExpression>(order1.expression->return_type, 0U);
 	vector<BoundOrderByNode> orders;
 	orders.emplace_back(order1.type, order1.null_order, std::move(ref));
-	// The goal is to make i (from the left table) < j (from the right table).
-	// If value[i] and value[j] match the condition 1,
-	// add a column from_left to solve the problem when there exist multiple equal values in l1.
+	// The goal is to make i (from the left table) < j (from the right table),
+	// if value[i] and value[j] match the condition 1.
+	// Add a column from_left to solve the problem when there exist multiple equal values in l1.
 	// If the operator is loose inequality, make t1.from_left (== true) sort BEFORE t2.from_left (== false).
 	// Otherwise, make t1.from_left sort (== true) sort AFTER t2.from_left (== false).
 	// For example, if t1.time <= t2.time

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -1,18 +1,19 @@
 #include "duckdb/execution/operator/join/physical_iejoin.hpp"
 
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/common/row_operations/row_operations.hpp"
 #include "duckdb/common/sort/sort.hpp"
 #include "duckdb/common/sort/sorted_block.hpp"
+#include "duckdb/common/thread.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/event.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
-#include "duckdb/common/atomic.hpp"
-#include "duckdb/common/thread.hpp"
 
 namespace duckdb {
 
@@ -388,18 +389,41 @@ IEJoinUnion::IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, Sorte
 	auto ref = make_uniq<BoundReferenceExpression>(order1.expression->return_type, 0U);
 	vector<BoundOrderByNode> orders;
 	orders.emplace_back(order1.type, order1.null_order, std::move(ref));
+	// our target is to make i (from left table) < j (from right table) if value[i] and value[j] match the condition 1
+	// add a column from_left to solve the problem when exists multiple equal values
+	// in l1 if the operator is loose inequality, let the left index (from_left is true) in front of right index
+	// otherwise, let the left index (from_left is true) in behind of left index (from_left is false)
+	// for example, t1.time <= t2.time
+	// | value     | 1     | 1     | 1     | 1     |
+	// | --------- | ----- | ----- | ----- | ----- |
+	// | from_left | T(l2) | T(l2) | F(r1) | F(r2) |
+	// if t1.time < t2.time
+	// | value     | 1     | 1     | 1     | 1     |
+	// | --------- | ----- | ----- | ----- | ----- |
+	// | from_left | F(r2) | F(r1) | T(l2) | T(l1) |
+	// according to this order request, if i < j then value\[i\](from left table) and value\[j\](from right table) match
+	// the condition(t1.time <= t2.time or t1.time < t2.time)
+	auto from_left = make_uniq<BoundConstantExpression>(Value::BOOLEAN(true));
+	orders.emplace_back(SBIterator::ComparisonValue(cmp1) == 0 ? OrderType::DESCENDING : OrderType::ASCENDING,
+	                    OrderByNullType::ORDER_DEFAULT, std::move(from_left));
 
 	l1 = make_uniq<SortedTable>(context, orders, payload_layout, op);
 
 	// LHS has positive rids
 	ExpressionExecutor l_executor(context);
 	l_executor.AddExpression(*order1.expression);
+	// add const column true
+	auto left_const = make_uniq<BoundConstantExpression>(Value::BOOLEAN(true));
+	l_executor.AddExpression(*left_const);
 	l_executor.AddExpression(*order2.expression);
 	AppendKey(t1, l_executor, *l1, 1, 1, b1);
 
 	// RHS has negative rids
 	ExpressionExecutor r_executor(context);
 	r_executor.AddExpression(*op.rhs_orders[0].expression);
+	// add const column flase
+	auto right_const = make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
+	r_executor.AddExpression(*right_const);
 	r_executor.AddExpression(*op.rhs_orders[1].expression);
 	AppendKey(t2, r_executor, *l1, -1, -1, b2);
 
@@ -463,53 +487,6 @@ IEJoinUnion::IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, Sorte
 	(void)NextRow();
 }
 
-idx_t IEJoinUnion::SearchL1(idx_t pos) {
-	// Perform an exponential search in the appropriate direction
-	op1->SetIndex(pos);
-
-	idx_t step = 1;
-	auto hi = pos;
-	auto lo = pos;
-	if (!op1->cmp) {
-		// Scan left for loose inequality
-		lo -= MinValue(step, lo);
-		step *= 2;
-		off1->SetIndex(lo);
-		while (lo > 0 && op1->Compare(*off1)) {
-			hi = lo;
-			lo -= MinValue(step, lo);
-			step *= 2;
-			off1->SetIndex(lo);
-		}
-	} else {
-		// Scan right for strict inequality
-		hi += MinValue(step, n - hi);
-		step *= 2;
-		off1->SetIndex(hi);
-		while (hi < n && !op1->Compare(*off1)) {
-			lo = hi;
-			hi += MinValue(step, n - hi);
-			step *= 2;
-			off1->SetIndex(hi);
-		}
-	}
-
-	// Binary search the target area
-	while (lo < hi) {
-		const auto mid = lo + (hi - lo) / 2;
-		off1->SetIndex(mid);
-		if (op1->Compare(*off1)) {
-			hi = mid;
-		} else {
-			lo = mid + 1;
-		}
-	}
-
-	off1->SetIndex(lo);
-
-	return lo;
-}
-
 bool IEJoinUnion::NextRow() {
 	for (; i < n; ++i) {
 		// 12. pos ← P[i]
@@ -539,7 +516,7 @@ bool IEJoinUnion::NextRow() {
 		// Find the leftmost off1 where L1[pos] op1 L1[off1..n]
 		// These are the rows that satisfy the op1 condition
 		// and that is where we should start scanning B from
-		j = SearchL1(pos);
+		j = pos;
 
 		return true;
 	}

--- a/src/execution/operator/join/physical_range_join.cpp
+++ b/src/execution/operator/join/physical_range_join.cpp
@@ -62,7 +62,6 @@ PhysicalRangeJoin::GlobalSortedTable::GlobalSortedTable(ClientContext &context, 
                                                         RowLayout &payload_layout, const PhysicalOperator &op_p)
     : op(op_p), global_sort_state(BufferManager::GetBufferManager(context), orders, payload_layout), has_null(0),
       count(0), memory_per_thread(0) {
-	D_ASSERT(orders.size() == 1);
 
 	// Set external (can be forced with the PRAGMA)
 	auto &config = ClientConfig::GetConfig(context);


### PR DESCRIPTION
Add a boolean column when sorting l1 table can replace binary search for equal values.
There is an example in comments.

https://github.com/duckdb/duckdb/blob/19dec0f06f46a6f57e47e8d9b9a11f4431d0c6d9/src/execution/operator/join/physical_iejoin.cpp#L392-L405

It will be helpful when there is lots of equal values. I use the same dataset as [iejoin blog](https://duckdb.org/2022/05/27/iejoin.html#optimisation-measurements).  The iejoin cost reduces from 2.61s -> 1.55s.

You can run the bench by run ```bash compare.sh``` at [this branch](https://github.com/my-vegetable-has-exploded/duckdb/blob/ie-sort-bench)