### PR TITLE
Python 3.7 tests are particularly brittle, we will keep building wheels but avoid testing them

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -52,7 +52,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
-  CIBW_TEST_SKIP: ${{ inputs.skip_tests == 'true' && '*-*' || '' }}
+  CIBW_TEST_SKIP: ${{ inputs.skip_tests == 'true' && '*-*' || 'cp37-*' }}
 
 jobs:
 #  This is just a sanity check of Python 3.9 running with Arrow


### PR DESCRIPTION
Discussed with @Mytherin, Python 3.7 is end of life already, we keep the support just since it seems weird to remove what currently is working (but keeps generating noise).