### PR TITLE
Add duckdb_param_logical_type

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1467,7 +1467,7 @@ Returns `DUCKDB_TYPE_INVALID` if the parameter index is out of range or the stat
 
 * @param prepared_statement The prepared statement.
 * @param param_idx The parameter index.
-* @return The parameter type
+* @return The parameter logical type
 */
 DUCKDB_API duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1476,6 +1476,8 @@ Returns the parameter logical type for the parameter at the given index.
 
 Returns `nullptr` if the parameter index is out of range or the statement was not successfully prepared.
 
+The return type of this call should be destroyed with `duckdb_destroy_logical_type`.
+
 * @param prepared_statement The prepared statement.
 * @param param_idx The parameter index.
 * @return The parameter logical type

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1472,6 +1472,17 @@ Returns `DUCKDB_TYPE_INVALID` if the parameter index is out of range or the stat
 DUCKDB_API duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 
 /*!
+Returns the parameter logical type for the parameter at the given index.
+
+Returns `nullptr` if the parameter index is out of range or the statement was not successfully prepared.
+
+* @param prepared_statement The prepared statement.
+* @param param_idx The parameter index.
+* @return The parameter type
+*/
+DUCKDB_API duckdb_logical_type duckdb_param_logical_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
+
+/*!
 Clear the params bind to the prepared statement.
 */
 DUCKDB_API duckdb_state duckdb_clear_bindings(duckdb_prepared_statement prepared_statement);

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -1467,7 +1467,7 @@ Returns `DUCKDB_TYPE_INVALID` if the parameter index is out of range or the stat
 
 * @param prepared_statement The prepared statement.
 * @param param_idx The parameter index.
-* @return The parameter logical type
+* @return The parameter type
 */
 DUCKDB_API duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 
@@ -1478,7 +1478,7 @@ Returns `nullptr` if the parameter index is out of range or the statement was no
 
 * @param prepared_statement The prepared statement.
 * @param param_idx The parameter index.
-* @return The parameter type
+* @return The parameter logical type
 */
 DUCKDB_API duckdb_logical_type duckdb_param_logical_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -431,6 +431,7 @@ typedef struct {
 	                                                    const char *schema, const char *table,
 	                                                    duckdb_table_description *out);
 	char *(*duckdb_table_description_get_column_name)(duckdb_table_description table_description, idx_t index);
+	duckdb_logical_type (*duckdb_param_logical_type)(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 } duckdb_ext_api_v0;
 
 //===--------------------------------------------------------------------===//
@@ -812,6 +813,7 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_appender_create_ext = duckdb_appender_create_ext;
 	result.duckdb_table_description_create_ext = duckdb_table_description_create_ext;
 	result.duckdb_table_description_get_column_name = duckdb_table_description_get_column_name;
+	result.duckdb_param_logical_type = duckdb_param_logical_type;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -3,6 +3,7 @@
     "entries": [
         "duckdb_appender_create_ext",
         "duckdb_table_description_create_ext",
-        "duckdb_table_description_get_column_name"
+        "duckdb_table_description_get_column_name",
+		"duckdb_param_logical_type"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -4,6 +4,6 @@
         "duckdb_appender_create_ext",
         "duckdb_table_description_create_ext",
         "duckdb_table_description_get_column_name",
-		"duckdb_param_logical_type"
+        "duckdb_param_logical_type"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/prepared_statements.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/prepared_statements.json
@@ -135,7 +135,7 @@
                 }
             ],
             "comment": {
-                "description": "Returns the parameter logical type for the parameter at the given index.\n\nReturns `nullptr` if the parameter index is out of range or the statement was not successfully prepared.\n\n",
+                "description": "Returns the parameter logical type for the parameter at the given index.\n\nReturns `nullptr` if the parameter index is out of range or the statement was not successfully prepared.\n\nThe return type of this call should be destroyed with `duckdb_destroy_logical_type`.\n\n",
                 "param_comments": {
                     "prepared_statement": "The prepared statement.",
                     "param_idx": "The parameter index."

--- a/src/include/duckdb/main/capi/header_generation/functions/prepared_statements.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/prepared_statements.json
@@ -122,6 +122,28 @@
             }
         },
         {
+            "name": "duckdb_param_logical_type",
+            "return_type": "duckdb_type",
+            "params": [
+                {
+                    "type": "duckdb_prepared_statement",
+                    "name": "prepared_statement"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "param_idx"
+                }
+            ],
+            "comment": {
+                "description": "Returns the parameter logical type for the parameter at the given index.\n\nReturns `nullptr` if the parameter index is out of range or the statement was not successfully prepared.\n\n",
+                "param_comments": {
+                    "prepared_statement": "The prepared statement.",
+                    "param_idx": "The parameter index."
+                },
+                "return_value": "The parameter logical type"
+            }
+        },
+        {
             "name": "duckdb_clear_bindings",
             "return_type": "duckdb_state",
             "params": [

--- a/src/include/duckdb/main/capi/header_generation/functions/prepared_statements.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/prepared_statements.json
@@ -123,7 +123,7 @@
         },
         {
             "name": "duckdb_param_logical_type",
-            "return_type": "duckdb_type",
+            "return_type": "duckdb_logical_type",
             "params": [
                 {
                     "type": "duckdb_prepared_statement",

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -495,6 +495,7 @@ typedef struct {
 	                                                    const char *schema, const char *table,
 	                                                    duckdb_table_description *out);
 	char *(*duckdb_table_description_get_column_name)(duckdb_table_description table_description, idx_t index);
+	duckdb_logical_type (*duckdb_param_logical_type)(duckdb_prepared_statement prepared_statement, idx_t param_idx);
 #endif
 
 } duckdb_ext_api_v0;
@@ -880,6 +881,7 @@ typedef struct {
 #define duckdb_appender_create_ext               duckdb_ext_api.duckdb_appender_create_ext
 #define duckdb_table_description_create_ext      duckdb_ext_api.duckdb_table_description_create_ext
 #define duckdb_table_description_get_column_name duckdb_ext_api.duckdb_table_description_get_column_name
+#define duckdb_param_logical_type                duckdb_ext_api.duckdb_param_logical_type
 
 //===--------------------------------------------------------------------===//
 // Struct Global Macros

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -878,10 +878,10 @@ typedef struct {
 #define duckdb_destroy_cast_function                duckdb_ext_api.duckdb_destroy_cast_function
 
 // Version dev
+#define duckdb_param_logical_type                duckdb_ext_api.duckdb_param_logical_type
 #define duckdb_appender_create_ext               duckdb_ext_api.duckdb_appender_create_ext
 #define duckdb_table_description_create_ext      duckdb_ext_api.duckdb_table_description_create_ext
 #define duckdb_table_description_get_column_name duckdb_ext_api.duckdb_table_description_get_column_name
-#define duckdb_param_logical_type                duckdb_ext_api.duckdb_param_logical_type
 
 //===--------------------------------------------------------------------===//
 // Struct Global Macros

--- a/src/main/capi/prepared-c.cpp
+++ b/src/main/capi/prepared-c.cpp
@@ -122,22 +122,16 @@ const char *duckdb_parameter_name(duckdb_prepared_statement prepared_statement, 
 }
 
 duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_t param_idx) {
-	auto wrapper = reinterpret_cast<PreparedStatementWrapper *>(prepared_statement);
-	if (!wrapper || !wrapper->statement || wrapper->statement->HasError()) {
+	auto logical_type = duckdb_param_logical_type(prepared_statement, param_idx);
+	if (!logical_type) {
 		return DUCKDB_TYPE_INVALID;
 	}
-	LogicalType param_type;
-	auto identifier = std::to_string(param_idx);
-	if (wrapper->statement->data->TryGetType(identifier, param_type)) {
-		return ConvertCPPTypeToC(param_type);
-	}
-	// The value_map is gone after executing the prepared statement
-	// See if this is the case and we still have a value registered for it
-	auto it = wrapper->values.find(identifier);
-	if (it != wrapper->values.end()) {
-		return ConvertCPPTypeToC(it->second.return_type.id());
-	}
-	return DUCKDB_TYPE_INVALID;
+
+	auto type = duckdb_get_type_id(logical_type);
+
+	duckdb_destroy_logical_type(&logical_type);
+
+	return type;
 }
 
 duckdb_logical_type duckdb_param_logical_type(duckdb_prepared_statement prepared_statement, idx_t param_idx) {


### PR DESCRIPTION
Add a new function to the C API for getting prepared statement parameter logical type. Related to https://github.com/duckdb/duckdb/discussions/14476