### PR TITLE
Fix query_graph tool for #14290

### DIFF
--- a/tools/pythonpkg/duckdb/query_graph/__main__.py
+++ b/tools/pythonpkg/duckdb/query_graph/__main__.py
@@ -167,7 +167,7 @@ def generate_tree_recursive(json_graph: object) -> str:
 def generate_timing_html(graph_json: object, query_timings: object) -> object:
     json_graph = json.loads(graph_json)
     gather_timing_information(json_graph, query_timings)
-    total_time = float(json_graph['operator_timing'])
+    total_time = float(json_graph.get('operator_timing') or json_graph.get('latency'))
     table_head = """
 	<table class=\"styled-table\"> 
 		<thead>


### PR DESCRIPTION
#14290 changes the timing field from `operator_timing` to `latency` for the root node. This follows that change to make the query_graph tool work again.