### PR TITLE
copy to operator still write schema for empty rows

### DIFF
--- a/test/sql/copy/parquet/writer/test_parquet_write.test
+++ b/test/sql/copy/parquet/writer/test_parquet_write.test
@@ -12,7 +12,7 @@ SELECT * FROM parquet_scan('__TEST_DIR__/scalar.parquet');
 ----
 42
 
-# empty result set
+# empty result set, single thread
 statement ok
 CREATE TABLE empty(i INTEGER)
 
@@ -21,5 +21,17 @@ COPY (SELECT * FROM empty) TO '__TEST_DIR__/empty.parquet' (FORMAT 'parquet')
 
 query I
 SELECT COUNT(*) FROM parquet_scan('__TEST_DIR__/empty.parquet')
+----
+0
+
+statement ok
+SET threads=4;
+
+# empty result set, multi thread
+statement ok
+COPY (SELECT * FROM empty) TO '__TEST_DIR__/empty_multithread' (FORMAT 'parquet', PER_THREAD_OUTPUT True)
+
+query I
+SELECT COUNT(*) FROM parquet_scan('__TEST_DIR__/empty_multithread/*.parquet')
 ----
 0


### PR DESCRIPTION
physical_copy_to operator currently skip empty source when using multi thread writing, in this case, recording the schema to filesystem might be a better way, as we still need the info instead of nothing. This also aligns with the behaviour of single thread writing.