### PR TITLE
Remove most BUILD_ options for extensions, using CORE_EXTENSIONS

### DIFF
--- a/.github/workflows/ExtendedTests.yml
+++ b/.github/workflows/ExtendedTests.yml
@@ -32,9 +32,7 @@ jobs:
        CXX: clang++
        GEN: ninja
        BUILD_BENCHMARK: 1
-       BUILD_TPCH: 1
-       BUILD_TPCDS: 1
-       BUILD_HTTPFS: 1
+       CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
      steps:
      - uses: actions/checkout@v4
@@ -114,9 +112,7 @@ jobs:
        CXX: clang++
        GEN: ninja
        BUILD_BENCHMARK: 1
-       BUILD_TPCH: 1
-       BUILD_TPCDS: 1
-       BUILD_HTTPFS: 1
+       CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
      steps:
      - uses: actions/checkout@v4
@@ -195,10 +191,8 @@ jobs:
        CXX: g++
        GEN: ninja
        BUILD_BENCHMARK: 1
-       BUILD_TPCH: 1
-       BUILD_TPCDS: 1
-       BUILD_HTTPFS: 1
        BUILD_JEMALLOC: 1
+       CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
      steps:
        - uses: actions/checkout@v4
@@ -282,10 +276,8 @@ jobs:
        CXX: g++
        GEN: ninja
        BUILD_BENCHMARK: 1
-       BUILD_TPCH: 1
-       BUILD_TPCDS: 1
-       BUILD_HTTPFS: 1
        BUILD_JEMALLOC: 1
+       CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
      steps:
        - uses: actions/checkout@v4

--- a/.github/workflows/ExtraTests.yml
+++ b/.github/workflows/ExtraTests.yml
@@ -18,10 +18,8 @@ jobs:
     CXX: g++-10
     GEN: ninja
     BUILD_BENCHMARK: 1
-    BUILD_TPCH: 1
-    BUILD_TPCDS: 1
-    BUILD_HTTPFS: 1
     BUILD_JEMALLOC: 1
+    CORE_EXTENSIONS: "tpcd;tpcds;httpfs"
 
   steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Build DuckDB
         shell: bash
         run: |
-            BUILD_TPCH=1 BUILD_ICU=1 BUILD_JEMALLOC=1 make
+            CORE_EXTENSIONS="tpch;icu" BUILD_JEMALLOC=1 make
 
       - name: Run Tests
         shell: bash

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -448,4 +448,4 @@ jobs:
         shell: bash
         run: |
           mkdir -p build/release
-          (cd build/release && cmake -G "Ninja" -DSTATIC_LIBCPP=1 -DBUILD_EXTENSIONS='icu;parquet;fts;json' -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
+          (cd build/release && cmake -G "Ninja" -DSTATIC_LIBCPP=1 -DCORE_EXTENSIONS='icu;parquet;fts;json' -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -94,14 +94,8 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_ICU: 1
-      BUILD_PARQUET: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_FTS: 1
-      BUILD_JSON: 1
       BUILD_JEMALLOC: 1
-      BUILD_EXTENSIONS: ""
+      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json"
       RUN_SLOW_VERIFIERS: 1
 
     steps:
@@ -139,13 +133,8 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_ICU: 1
-      BUILD_PARQUET: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_FTS: 1
-      BUILD_JSON: 1
       BUILD_JEMALLOC: 1
+      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -71,13 +71,8 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_ICU: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_FTS: 1
-      BUILD_JSON: 1
       BUILD_JEMALLOC: 1
-      CORE_EXTENSIONS: "inet"
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
       DISABLE_SANITIZER: 1
       CRASH_ON_ASSERT: 1
       RUN_SLOW_VERIFIERS: 1
@@ -114,12 +109,9 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_ICU: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_JSON: 1
-      SMALLER_BINARY: 1
       BUILD_JEMALLOC: 1
+      CORE_EXTENSIONS: "icu;tpch;tpcds;json"
+      SMALLER_BINARY: 1
     steps:
     - uses: actions/checkout@v3
       with:
@@ -158,7 +150,7 @@ jobs:
       CXX: /home/runner/work/llvm/bin/clang++
       LD: /home/runner/work/llvm/bin/ld.lld
       EXTENSION_STATIC_BUILD: 1
-      BUILD_JSON: 1
+      CORE_EXTENSIONS: "json"
       TREAT_WARNINGS_AS_ERRORS: 1
 
     steps:
@@ -477,7 +469,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: BUILD_TPCH=1 make
+        run: CORE_EXTENSIONS="tpch" make
 
       - name: Start Minio
         shell: bash
@@ -501,13 +493,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_ICU: 1
-      BUILD_PARQUET: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_FTS: 1
-      BUILD_JSON: 1
-      CORE_EXTENSIONS: "inet"
+      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
       DISABLE_STRING_INLINE: 1
       DESTROY_UNPINNED_BLOCKS: 1
       ALTERNATIVE_VERIFY: 1
@@ -544,10 +530,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_PARQUET: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_JSON: 1
+      CORE_EXTENSIONS: "parquet;json;tpch;tpcds"
       LATEST_STORAGE: 1
       BLOCK_VERIFICATION: 1
 
@@ -597,13 +580,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_ICU: 1
-      BUILD_PARQUET: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_FTS: 1
-      BUILD_JSON: 1
-      CORE_EXTENSIONS: "inet"
+      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
       VERIFY_VECTOR: ${{ matrix.vector_type }}
 
     steps:
@@ -637,13 +614,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_ICU: 1
-      BUILD_PARQUET: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_FTS: 1
-      BUILD_JSON: 1
-      CORE_EXTENSIONS: "inet"
+      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
       FORCE_ASYNC_SINK_SOURCE: 1
 
     steps:
@@ -678,10 +649,8 @@ jobs:
      CXX: g++-10
      GEN: ninja
      BUILD_BENCHMARK: 1
-     BUILD_TPCH: 1
-     BUILD_TPCDS: 1
-     BUILD_HTTPFS: 1
      BUILD_JEMALLOC: 1
+     CORE_EXTENSIONS: "tpch;tpcds;httpfs"
 
    steps:
      - name: Checkout
@@ -761,13 +730,8 @@ jobs:
       CC: clang
       CXX: clang++
       GEN: ninja
-      BUILD_ICU: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_FTS: 1
-      BUILD_JSON: 1
       BUILD_JEMALLOC: 1
-      CORE_EXTENSIONS: "inet"
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
       TSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-thread-suppressions.txt
 
     steps:
@@ -844,8 +808,7 @@ jobs:
       CXX: g++-10
       GEN: ninja
       BLOCK_ALLOC_SIZE: 16384
-      BUILD_JSON: 1
-      BUILD_PARQUET: 1
+      CORE_EXTENSIONS: "json;parquet"
 
     steps:
       - uses: actions/checkout@v3
@@ -1007,11 +970,7 @@ jobs:
     name: Linux HTTPFS
     runs-on: ubuntu-20.04
     env:
-      BUILD_HTTPFS: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_PARQUET: 1
-      BUILD_JSON: 1
+      CORE_EXTENSIONS: "json;parquet;tpch;tpcds;httpfs"
       S3_TEST_SERVER_AVAILABLE: 1
       AWS_DEFAULT_REGION: eu-west-1
       AWS_ACCESS_KEY_ID: minio_duckdb_user

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -234,7 +234,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p build/release
-          (cd build/release && cmake -G "Ninja" -DSTATIC_LIBCPP=1 -DBUILD_EXTENSIONS='icu;parquet;fts;json' -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
+          (cd build/release && cmake -G "Ninja" -DSTATIC_LIBCPP=1 -DCORE_EXTENSIONS='icu;parquet;fts;json' -DFORCE_32_BIT=1 -DCMAKE_BUILD_TYPE=Release ../.. && cmake --build .)
 
       - name: Test
         shell: bash

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -43,12 +43,8 @@ jobs:
       CXX: g++-10
       GEN: ninja
       BUILD_BENCHMARK: 1
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_HTTPFS: 1
       BUILD_JEMALLOC: 1
-      BUILD_JSON: 1
-      CORE_EXTENSIONS: "inet"
+      CORE_EXTENSIONS: "json;tpch;tpcds;httpfs;inet"
 
     steps:
       - uses: actions/checkout@v4
@@ -148,8 +144,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
+      CORE_EXTENSIONS: "tpch;tpcds"
 
     steps:
       - uses: actions/checkout@v4
@@ -229,10 +224,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_TPCH: 1
-      BUILD_TPCDS: 1
-      BUILD_JSON: 1
-      BUILD_PARQUET: 1
+      CORE_EXTENSIONS: "tpch;tpcds;json;parquet"
       EXTENSION_STATIC_BUILD: 1
     steps:
       - uses: actions/checkout@v4
@@ -274,8 +266,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      BUILD_TPCH: 1
-      BUILD_HTTPFS: 1
+      CORE_EXTENSIONS: "tpch;httpfs"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -239,7 +239,7 @@ jobs:
        - name: Build
          shell: msys2 {0}
          run: |
-           cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DBUILD_EXTENSIONS=parquet -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE"
+           cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCORE_EXTENSIONS='parquet' -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE"
            cmake --build . --config Release 
 
        - name: Test

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -40,15 +40,8 @@ jobs:
       run: cov-analysis-linux64/bin/cov-build --dir cov-int make
       env:
         PYTHON_USER_SPACE: 1
-        BUILD_PYTHON: 1
-        BUILD_AUTOCOMPLETE: 1
-        BUILD_ICU: 1
-        BUILD_TPCDS: 1
-        BUILD_TCPE: 1
-        BUILD_FTS: 1
-        BUILD_HTTPFS: 1
-        BUILD_JSON: 1
-        CORE_EXTENSIONS: "inet"
+        BUILD_TPCE: 1
+        CORE_EXTENSIONS: "autocomplete;icu;tpcds;tpch;fts;httpfs;json;inet"
 
     - name: Upload the result
       run: |


### PR DESCRIPTION
Only exception is `BUILD_JEMALLOC`, given jemalloc is special in many regards.

Plan is to do first a round on this, then adding a warning to use those in Makefile, then moving the warning to error.

This might need a couple of iterations, to clean up on ancillary repos (like the docs) but getting there.

Proper heavy lifting is done by CORE_EXTENSIONS option, introduced in https://github.com/duckdb/duckdb/pull/13116.

Once this is in, moving extensions out of tree should become simpler and one more difference removed between in and out of tree.