### PR TITLE
[Dev] Include aliases for RETURNING list expressions in `ToString`

### DIFF
--- a/src/parser/statement/insert_statement.cpp
+++ b/src/parser/statement/insert_statement.cpp
@@ -156,7 +156,11 @@ string InsertStatement::ToString() const {
 			if (i > 0) {
 				result += ", ";
 			}
-			result += returning_list[i]->ToString();
+			auto column = returning_list[i]->ToString();
+			if (!returning_list[i]->alias.empty()) {
+				column += StringUtil::Format(" AS %s", KeywordHelper::WriteOptionallyQuoted(returning_list[i]->alias));
+			}
+			result += column;
 		}
 	}
 	return result;


### PR DESCRIPTION
This PR fixes #14523