### PR TITLE
[Arrow] Fix issue where uninitialized memory was being read when scanning empty lists

### DIFF
--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -138,6 +138,12 @@ static ArrowListOffsetData ConvertArrowListOffsetsTemplated(Vector &vector, Arro
 	auto &start_offset = result.start_offset;
 	auto &list_size = result.list_size;
 
+	if (size == 0) {
+		start_offset = 0;
+		list_size = 0;
+		return result;
+	}
+
 	idx_t cur_offset = 0;
 	auto offsets = ArrowBufferData<BUFFER_TYPE>(array, 1) + effective_offset;
 	start_offset = offsets[0];


### PR DESCRIPTION
This PR fixes #14497

I can't produce a test for this other than the reproduction from the issue, which uses pyiceberg.
The problem was obvious though, there are no offsets when the list is empty, so `offsets[0]` accesses uninitialized memory, it no longer does that.