### PR TITLE
[Python][Arrow] Cast to `py::bytes` when dealing with BLOB in filter pushdown

### DIFF
--- a/src/include/duckdb/planner/table_filter.hpp
+++ b/src/include/duckdb/planner/table_filter.hpp
@@ -45,6 +45,7 @@ public:
 	//! Returns true if the statistics indicate that the segment can contain values that satisfy that filter
 	virtual FilterPropagateResult CheckStatistics(BaseStatistics &stats) = 0;
 	virtual string ToString(const string &column_name) = 0;
+	string DebugToString();
 	virtual unique_ptr<TableFilter> Copy() const = 0;
 	virtual bool Equals(const TableFilter &other) const {
 		return filter_type != other.filter_type;

--- a/src/planner/table_filter.cpp
+++ b/src/planner/table_filter.cpp
@@ -26,6 +26,10 @@ void TableFilterSet::PushFilter(idx_t column_index, unique_ptr<TableFilter> filt
 	}
 }
 
+string TableFilter::DebugToString() {
+	return ToString("c0");
+}
+
 void DynamicTableFilterSet::ClearFilters(const PhysicalOperator &op) {
 	lock_guard<mutex> l(lock);
 	filters.erase(op);

--- a/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
@@ -272,7 +272,7 @@ py::object GetScalar(Value &constant, const string &timezone_config, const Arrow
 	case LogicalTypeId::VARCHAR:
 		return dataset_scalar(constant.ToString());
 	case LogicalTypeId::BLOB:
-		return dataset_scalar(constant.GetValueUnsafe<string>());
+		return dataset_scalar(py::bytes(constant.GetValueUnsafe<string>()));
 	case LogicalTypeId::DECIMAL: {
 		py::object date_type = py::module_::import("pyarrow").attr("decimal128");
 		uint8_t width;

--- a/tools/pythonpkg/tests/fast/arrow/test_14344.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_14344.py
@@ -1,0 +1,25 @@
+import duckdb
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+import hashlib
+
+
+def test_14344(duckdb_cursor):
+    my_table = pa.Table.from_pydict({"foo": pa.array([hashlib.sha256("foo".encode()).digest()], type=pa.binary())})
+    my_table2 = pa.Table.from_pydict(
+        {"foo": pa.array([hashlib.sha256("foo".encode()).digest()], type=pa.binary()), "a": ["123"]}
+    )
+
+    res = duckdb_cursor.sql(
+        f"""
+		SELECT
+			my_table2.* EXCLUDE (foo)
+		FROM
+			my_table
+		LEFT JOIN
+			my_table2
+		USING (foo)
+	"""
+    ).fetchall()
+    assert res == [('123',)]


### PR DESCRIPTION
This PR fixes #14344 

I've also included a small change to TableFilter, using ToString is impossible when debugging, as `ToString("c0")` would complain about `c0` not being a `std::string`

DebugToString inserts a bogus default column name so the method can be called.