### PR TITLE
Out-Of-Core Updates & Deletes

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -4307,6 +4307,8 @@ const char* EnumUtil::ToChars<MemoryTag>(MemoryTag value) {
 		return "ALLOCATOR";
 	case MemoryTag::EXTENSION:
 		return "EXTENSION";
+	case MemoryTag::TRANSACTION:
+		return "TRANSACTION";
 	default:
 		throw NotImplementedException(StringUtil::Format("Enum value: '%d' not implemented in ToChars<MemoryTag>", value));
 	}
@@ -4349,6 +4351,9 @@ MemoryTag EnumUtil::FromString<MemoryTag>(const char *value) {
 	}
 	if (StringUtil::Equals(value, "EXTENSION")) {
 		return MemoryTag::EXTENSION;
+	}
+	if (StringUtil::Equals(value, "TRANSACTION")) {
+		return MemoryTag::TRANSACTION;
 	}
 	throw NotImplementedException(StringUtil::Format("Enum value: '%s' not implemented in FromString<MemoryTag>", value));
 }

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1503,8 +1503,13 @@ string Value::ToSQLString() const {
 	case LogicalTypeId::BLOB:
 		return "'" + ToString() + "'::" + type_.ToString();
 	case LogicalTypeId::VARCHAR:
-	case LogicalTypeId::ENUM:
+	case LogicalTypeId::ENUM: {
+		auto str_val = ToString();
+		if (str_val.size() == 1 && str_val[0] == '\0') {
+			return "chr(0)";
+		}
 		return "'" + StringUtil::Replace(ToString(), "'", "''") + "'";
+	}
 	case LogicalTypeId::STRUCT: {
 		bool is_unnamed = StructType::IsUnnamed(type_);
 		string ret = is_unnamed ? "(" : "{";

--- a/src/include/duckdb/common/enums/memory_tag.hpp
+++ b/src/include/duckdb/common/enums/memory_tag.hpp
@@ -24,9 +24,10 @@ enum class MemoryTag : uint8_t {
 	OVERFLOW_STRINGS = 8,
 	IN_MEMORY_TABLE = 9,
 	ALLOCATOR = 10,
-	EXTENSION = 11
+	EXTENSION = 11,
+	TRANSACTION = 12
 };
 
-static constexpr const idx_t MEMORY_TAG_COUNT = 12;
+static constexpr const idx_t MEMORY_TAG_COUNT = 13;
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/arena_allocator.hpp
+++ b/src/include/duckdb/storage/arena_allocator.hpp
@@ -25,6 +25,7 @@ struct ArenaChunk {
 };
 
 class ArenaAllocator {
+public:
 	static constexpr const idx_t ARENA_ALLOCATOR_INITIAL_CAPACITY = 2048;
 	static constexpr const idx_t ARENA_ALLOCATOR_MAX_CAPACITY = 1ULL << 24ULL; // 16MB
 

--- a/src/include/duckdb/storage/buffer_manager.hpp
+++ b/src/include/duckdb/storage/buffer_manager.hpp
@@ -59,6 +59,7 @@ public:
 	virtual shared_ptr<BlockHandle> RegisterTransientMemory(const idx_t size, const idx_t block_size);
 	//! Returns a new block of memory that is smaller than the block size setting.
 	virtual shared_ptr<BlockHandle> RegisterSmallMemory(const idx_t size);
+	virtual shared_ptr<BlockHandle> RegisterSmallMemory(MemoryTag tag, const idx_t size);
 
 	virtual DUCKDB_API Allocator &GetBufferAllocator();
 	virtual DUCKDB_API void ReserveMemory(idx_t size);

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -49,7 +49,7 @@ public:
 	//! Registers an in-memory buffer that cannot be unloaded until it is destroyed.
 	//! This buffer can be small (smaller than the block size of the temporary block manager).
 	//! Unpin and Pin are NOPs on this block of memory.
-	shared_ptr<BlockHandle> RegisterSmallMemory(const idx_t size) final;
+	shared_ptr<BlockHandle> RegisterSmallMemory(MemoryTag tag, const idx_t size) final;
 
 	idx_t GetUsedMemory() const final;
 	idx_t GetMaxMemory() const final;

--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/storage/storage_lock.hpp"
 #include "duckdb/storage/statistics/segment_statistics.hpp"
 #include "duckdb/common/types/string_heap.hpp"
+#include "duckdb/transaction/undo_buffer_allocator.hpp"
 
 namespace duckdb {
 class ColumnData;

--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -19,7 +19,7 @@ class DataTable;
 class Vector;
 struct UpdateInfo;
 struct UpdateNode;
-struct UpdateNodeData;
+struct UndoBufferAllocator;
 
 class UpdateSegment {
 public:
@@ -65,16 +65,16 @@ private:
 	StringHeap heap;
 
 public:
-	typedef void (*initialize_update_function_t)(UpdateInfo *base_info, Vector &base_data, UpdateInfo *update_info,
+	typedef void (*initialize_update_function_t)(UpdateInfo &base_info, Vector &base_data, UpdateInfo &update_info,
 	                                             Vector &update, const SelectionVector &sel);
-	typedef void (*merge_update_function_t)(UpdateInfo *base_info, Vector &base_data, UpdateInfo *update_info,
+	typedef void (*merge_update_function_t)(UpdateInfo &base_info, Vector &base_data, UpdateInfo &update_info,
 	                                        Vector &update, row_t *ids, idx_t count, const SelectionVector &sel);
-	typedef void (*fetch_update_function_t)(transaction_t start_time, transaction_t transaction_id, UpdateInfo *info,
+	typedef void (*fetch_update_function_t)(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info,
 	                                        Vector &result);
-	typedef void (*fetch_committed_function_t)(UpdateInfo *info, Vector &result);
-	typedef void (*fetch_committed_range_function_t)(UpdateInfo *info, idx_t start, idx_t end, idx_t result_offset,
+	typedef void (*fetch_committed_function_t)(UpdateInfo &info, Vector &result);
+	typedef void (*fetch_committed_range_function_t)(UpdateInfo &info, idx_t start, idx_t end, idx_t result_offset,
 	                                                 Vector &result);
-	typedef void (*fetch_row_function_t)(transaction_t start_time, transaction_t transaction_id, UpdateInfo *info,
+	typedef void (*fetch_row_function_t)(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info,
 	                                     idx_t row_idx, Vector &result, idx_t result_idx);
 	typedef void (*rollback_update_function_t)(UpdateInfo &base_info, UpdateInfo &rollback_info);
 	typedef idx_t (*statistics_update_function_t)(UpdateSegment *segment, SegmentStatistics &stats, Vector &update,
@@ -91,20 +91,18 @@ private:
 	statistics_update_function_t statistics_update_function;
 
 private:
-	optional_ptr<UpdateNodeData> GetUpdateNode(idx_t vector_idx) const;
+	UndoBufferPointer GetUpdateNode(idx_t vector_idx) const;
 	void InitializeUpdateInfo(idx_t vector_idx);
 	void InitializeUpdateInfo(UpdateInfo &info, row_t *ids, const SelectionVector &sel, idx_t count, idx_t vector_index,
 	                          idx_t vector_offset);
 };
 
-struct UpdateNodeData {
-	unique_ptr<UpdateInfo> info;
-	unsafe_unique_array<sel_t> tuples;
-	unsafe_unique_array<data_t> tuple_data;
-};
-
 struct UpdateNode {
-	vector<unique_ptr<UpdateNodeData>> info;
+	explicit UpdateNode(BufferManager &manager);
+	~UpdateNode();
+
+	UndoBufferAllocator allocator;
+	vector<UndoBufferPointer> info;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/transaction/transaction.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/common/error_data.hpp"
+#include "duckdb/transaction/undo_buffer.hpp"
 
 namespace duckdb {
 class CheckpointLock;

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -59,7 +59,7 @@ public:
 	bool AutomaticCheckpoint(AttachedDatabase &db, const UndoBufferProperties &properties);
 
 	//! Rollback
-	void Rollback() noexcept;
+	ErrorData Rollback();
 	//! Cleanup the undo buffer
 	void Cleanup(transaction_t lowest_active_transaction);
 

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -69,7 +69,7 @@ public:
 	                idx_t base_row);
 	void PushSequenceUsage(SequenceCatalogEntry &entry, const SequenceData &data);
 	void PushAppend(DataTable &table, idx_t row_start, idx_t row_count);
-	UpdateInfo *CreateUpdateInfo(idx_t type_size, idx_t entries);
+	UndoBufferReference CreateUpdateInfo(idx_t type_size, idx_t entries);
 
 	bool IsDuckTransaction() const override {
 		return true;

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -31,7 +31,7 @@ public:
 	//! Commit the given transaction
 	ErrorData CommitTransaction(ClientContext &context, Transaction &transaction) override;
 	//! Rollback the given transaction
-	void RollbackTransaction(Transaction &transaction) override;
+	ErrorData RollbackTransaction(Transaction &transaction) override;
 
 	void Checkpoint(ClientContext &context, bool force = false) override;
 

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -14,6 +14,7 @@
 
 namespace duckdb {
 class DuckTransaction;
+struct UndoBufferProperties;
 
 //! The Transaction Manager is responsible for creating and managing
 //! transactions

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -31,7 +31,7 @@ public:
 	//! Commit the given transaction
 	ErrorData CommitTransaction(ClientContext &context, Transaction &transaction) override;
 	//! Rollback the given transaction
-	ErrorData RollbackTransaction(Transaction &transaction) override;
+	void RollbackTransaction(Transaction &transaction) override;
 
 	void Checkpoint(ClientContext &context, bool force = false) override;
 

--- a/src/include/duckdb/transaction/transaction.hpp
+++ b/src/include/duckdb/transaction/transaction.hpp
@@ -10,10 +10,9 @@
 
 #include "duckdb/catalog/catalog_entry/sequence_catalog_entry.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/transaction/undo_buffer.hpp"
-#include "duckdb/common/atomic.hpp"
 #include "duckdb/transaction/transaction_data.hpp"
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/atomic.hpp"
 
 namespace duckdb {
 class SequenceCatalogEntry;

--- a/src/include/duckdb/transaction/transaction_manager.hpp
+++ b/src/include/duckdb/transaction/transaction_manager.hpp
@@ -36,7 +36,7 @@ public:
 	//! Commit the given transaction. Returns a non-empty error message on failure.
 	virtual ErrorData CommitTransaction(ClientContext &context, Transaction &transaction) = 0;
 	//! Rollback the given transaction
-	virtual ErrorData RollbackTransaction(Transaction &transaction) = 0;
+	virtual void RollbackTransaction(Transaction &transaction) = 0;
 
 	virtual void Checkpoint(ClientContext &context, bool force = false) = 0;
 

--- a/src/include/duckdb/transaction/transaction_manager.hpp
+++ b/src/include/duckdb/transaction/transaction_manager.hpp
@@ -36,7 +36,7 @@ public:
 	//! Commit the given transaction. Returns a non-empty error message on failure.
 	virtual ErrorData CommitTransaction(ClientContext &context, Transaction &transaction) = 0;
 	//! Rollback the given transaction
-	virtual void RollbackTransaction(Transaction &transaction) = 0;
+	virtual ErrorData RollbackTransaction(Transaction &transaction) = 0;
 
 	virtual void Checkpoint(ClientContext &context, bool force = false) = 0;
 

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -27,7 +27,8 @@ struct UndoBufferProperties {
 };
 
 struct UndoBufferEntry {
-	explicit UndoBufferEntry(BufferManager &buffer_manager) : buffer_manager(buffer_manager) {}
+	explicit UndoBufferEntry(BufferManager &buffer_manager) : buffer_manager(buffer_manager) {
+	}
 
 	BufferManager &buffer_manager;
 	shared_ptr<BlockHandle> block;
@@ -38,8 +39,10 @@ struct UndoBufferEntry {
 };
 
 struct UndoBufferReference {
-	UndoBufferReference() : entry(nullptr), position(0) {}
-	UndoBufferReference(UndoBufferEntry &entry_p, BufferHandle handle_p, idx_t position) : entry(&entry_p), handle(std::move(handle_p)), position(position) {
+	UndoBufferReference() : entry(nullptr), position(0) {
+	}
+	UndoBufferReference(UndoBufferEntry &entry_p, BufferHandle handle_p, idx_t position)
+	    : entry(&entry_p), handle(std::move(handle_p)), position(position) {
 	}
 
 	optional_ptr<UndoBufferEntry> entry;
@@ -49,7 +52,7 @@ struct UndoBufferReference {
 	data_ptr_t Ptr() {
 		return handle.Ptr() + position;
 	}
-	bool IsSet() const{
+	bool IsSet() const {
 		return entry;
 	}
 
@@ -57,8 +60,10 @@ struct UndoBufferReference {
 };
 
 struct UndoBufferPointer {
-	UndoBufferPointer() : entry(nullptr), position(0) {}
-	UndoBufferPointer(UndoBufferEntry &entry_p, idx_t position) : entry(&entry_p), position(position) { }
+	UndoBufferPointer() : entry(nullptr), position(0) {
+	}
+	UndoBufferPointer(UndoBufferEntry &entry_p, idx_t position) : entry(&entry_p), position(position) {
+	}
 
 	UndoBufferEntry *entry;
 	idx_t position;

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -58,7 +58,7 @@ public:
 	void RevertCommit(UndoBuffer::IteratorState &iterator_state, transaction_t transaction_id);
 	//! Rollback the changes made in this UndoBuffer: should be called on
 	//! rollback
-	void Rollback() noexcept;
+	void Rollback();
 
 private:
 	DuckTransaction &transaction;

--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/enums/undo_flags.hpp"
+#include "duckdb/transaction/undo_buffer_allocator.hpp"
 
 namespace duckdb {
 class BufferManager;
@@ -24,64 +25,6 @@ struct UndoBufferProperties {
 	bool has_deletes = false;
 	bool has_catalog_changes = false;
 	bool has_dropped_entries = false;
-};
-
-struct UndoBufferEntry {
-	explicit UndoBufferEntry(BufferManager &buffer_manager) : buffer_manager(buffer_manager) {
-	}
-
-	BufferManager &buffer_manager;
-	shared_ptr<BlockHandle> block;
-	idx_t position = 0;
-	idx_t capacity = 0;
-	unique_ptr<UndoBufferEntry> next;
-	optional_ptr<UndoBufferEntry> prev;
-};
-
-struct UndoBufferReference {
-	UndoBufferReference() : entry(nullptr), position(0) {
-	}
-	UndoBufferReference(UndoBufferEntry &entry_p, BufferHandle handle_p, idx_t position)
-	    : entry(&entry_p), handle(std::move(handle_p)), position(position) {
-	}
-
-	optional_ptr<UndoBufferEntry> entry;
-	BufferHandle handle;
-	idx_t position;
-
-	data_ptr_t Ptr() {
-		return handle.Ptr() + position;
-	}
-	bool IsSet() const {
-		return entry;
-	}
-
-	UndoBufferPointer GetBufferPointer();
-};
-
-struct UndoBufferPointer {
-	UndoBufferPointer() : entry(nullptr), position(0) {
-	}
-	UndoBufferPointer(UndoBufferEntry &entry_p, idx_t position) : entry(&entry_p), position(position) {
-	}
-
-	UndoBufferEntry *entry;
-	idx_t position;
-
-	UndoBufferReference Pin() const;
-	bool IsSet() const {
-		return entry;
-	}
-};
-
-struct UndoBufferAllocator {
-	explicit UndoBufferAllocator(BufferManager &buffer_manager);
-
-	UndoBufferReference Allocate(idx_t alloc_len);
-
-	BufferManager &buffer_manager;
-	unique_ptr<UndoBufferEntry> head;
-	optional_ptr<UndoBufferEntry> tail;
 };
 
 //! The undo buffer of a transaction is used to hold previous versions of tuples

--- a/src/include/duckdb/transaction/undo_buffer_allocator.hpp
+++ b/src/include/duckdb/transaction/undo_buffer_allocator.hpp
@@ -10,7 +10,6 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/storage/buffer/buffer_handle.hpp"
-#include "duckdb/storage/arena_allocator.hpp"
 
 namespace duckdb {
 class BufferManager;
@@ -68,15 +67,13 @@ struct UndoBufferPointer {
 };
 
 struct UndoBufferAllocator {
-	explicit UndoBufferAllocator(BufferManager &buffer_manager,
-	                             idx_t initial_capacity = ArenaAllocator::ARENA_ALLOCATOR_INITIAL_CAPACITY);
+	explicit UndoBufferAllocator(BufferManager &buffer_manager);
 
 	UndoBufferReference Allocate(idx_t alloc_len);
 
 	BufferManager &buffer_manager;
 	unique_ptr<UndoBufferEntry> head;
 	optional_ptr<UndoBufferEntry> tail;
-	idx_t allocate_capacity;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/undo_buffer_allocator.hpp
+++ b/src/include/duckdb/transaction/undo_buffer_allocator.hpp
@@ -76,5 +76,4 @@ struct UndoBufferAllocator {
 	optional_ptr<UndoBufferEntry> tail;
 };
 
-
 } // namespace duckdb

--- a/src/include/duckdb/transaction/undo_buffer_allocator.hpp
+++ b/src/include/duckdb/transaction/undo_buffer_allocator.hpp
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/transaction/undo_buffer_allocator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/storage/buffer/buffer_handle.hpp"
+
+namespace duckdb {
+class BufferManager;
+class BlockHandle;
+struct UndoBufferEntry;
+struct UndoBufferPointer;
+
+struct UndoBufferEntry {
+	explicit UndoBufferEntry(BufferManager &buffer_manager) : buffer_manager(buffer_manager) {
+	}
+	~UndoBufferEntry();
+
+	BufferManager &buffer_manager;
+	shared_ptr<BlockHandle> block;
+	idx_t position = 0;
+	idx_t capacity = 0;
+	unique_ptr<UndoBufferEntry> next;
+	optional_ptr<UndoBufferEntry> prev;
+};
+
+struct UndoBufferReference {
+	UndoBufferReference() : entry(nullptr), position(0) {
+	}
+	UndoBufferReference(UndoBufferEntry &entry_p, BufferHandle handle_p, idx_t position)
+	    : entry(&entry_p), handle(std::move(handle_p)), position(position) {
+	}
+
+	optional_ptr<UndoBufferEntry> entry;
+	BufferHandle handle;
+	idx_t position;
+
+	data_ptr_t Ptr() {
+		return handle.Ptr() + position;
+	}
+	bool IsSet() const {
+		return entry;
+	}
+
+	UndoBufferPointer GetBufferPointer();
+};
+
+struct UndoBufferPointer {
+	UndoBufferPointer() : entry(nullptr), position(0) {
+	}
+	UndoBufferPointer(UndoBufferEntry &entry_p, idx_t position) : entry(&entry_p), position(position) {
+	}
+
+	UndoBufferEntry *entry;
+	idx_t position;
+
+	UndoBufferReference Pin() const;
+	bool IsSet() const {
+		return entry;
+	}
+};
+
+struct UndoBufferAllocator {
+	explicit UndoBufferAllocator(BufferManager &buffer_manager);
+
+	UndoBufferReference Allocate(idx_t alloc_len);
+
+	BufferManager &buffer_manager;
+	unique_ptr<UndoBufferEntry> head;
+	optional_ptr<UndoBufferEntry> tail;
+};
+
+
+} // namespace duckdb

--- a/src/include/duckdb/transaction/undo_buffer_allocator.hpp
+++ b/src/include/duckdb/transaction/undo_buffer_allocator.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/storage/buffer/buffer_handle.hpp"
+#include "duckdb/storage/arena_allocator.hpp"
 
 namespace duckdb {
 class BufferManager;
@@ -67,13 +68,15 @@ struct UndoBufferPointer {
 };
 
 struct UndoBufferAllocator {
-	explicit UndoBufferAllocator(BufferManager &buffer_manager);
+	UndoBufferAllocator(BufferManager &buffer_manager,
+	                    idx_t initial_capacity = ArenaAllocator::ARENA_ALLOCATOR_INITIAL_CAPACITY);
 
 	UndoBufferReference Allocate(idx_t alloc_len);
 
 	BufferManager &buffer_manager;
 	unique_ptr<UndoBufferEntry> head;
 	optional_ptr<UndoBufferEntry> tail;
+	idx_t allocate_capacity;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/undo_buffer_allocator.hpp
+++ b/src/include/duckdb/transaction/undo_buffer_allocator.hpp
@@ -68,8 +68,8 @@ struct UndoBufferPointer {
 };
 
 struct UndoBufferAllocator {
-	UndoBufferAllocator(BufferManager &buffer_manager,
-	                    idx_t initial_capacity = ArenaAllocator::ARENA_ALLOCATOR_INITIAL_CAPACITY);
+	explicit UndoBufferAllocator(BufferManager &buffer_manager,
+	                             idx_t initial_capacity = ArenaAllocator::ARENA_ALLOCATOR_INITIAL_CAPACITY);
 
 	UndoBufferReference Allocate(idx_t alloc_len);
 

--- a/src/include/duckdb/transaction/update_info.hpp
+++ b/src/include/duckdb/transaction/update_info.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/types/validity_mask.hpp"
+#include "duckdb/transaction/undo_buffer_allocator.hpp"
 #include "duckdb/common/atomic.hpp"
 
 namespace duckdb {

--- a/src/include/duckdb/transaction/update_info.hpp
+++ b/src/include/duckdb/transaction/update_info.hpp
@@ -35,22 +35,32 @@ struct UpdateInfo {
 	//! The data of the tuples
 	data_ptr_t tuple_data;
 	//! The previous update info (or nullptr if it is the base)
-	UpdateInfo *prev;
+	UndoBufferPointer prev;
 	//! The next update info in the chain (or nullptr if it is the last)
-	UpdateInfo *next;
+	UndoBufferPointer next;
+
+	bool AppliesToTransaction(transaction_t start_time, transaction_t transaction_id) {
+		// these tuples were either committed AFTER this transaction started or are not committed yet, use
+		// tuples stored in this version
+		return version_number > start_time && version_number != transaction_id;
+	}
 
 	//! Loop over the update chain and execute the specified callback on all UpdateInfo's that are relevant for that
 	//! transaction in-order of newest to oldest
 	template <class T>
-	static void UpdatesForTransaction(UpdateInfo *current, transaction_t start_time, transaction_t transaction_id,
+	static void UpdatesForTransaction(UpdateInfo &current, transaction_t start_time, transaction_t transaction_id,
 	                                  T &&callback) {
-		while (current) {
-			if (current->version_number > start_time && current->version_number != transaction_id) {
-				// these tuples were either committed AFTER this transaction started or are not committed yet, use
-				// tuples stored in this version
-				callback(current);
+		if (current.AppliesToTransaction(start_time, transaction_id)) {
+			callback(current);
+		}
+		auto update_ptr = current.next;
+		while (update_ptr.IsSet()) {
+			auto pin = update_ptr.Pin();
+			auto &info = Get(pin);
+			if (info.AppliesToTransaction(start_time, transaction_id)) {
+				callback(info);
 			}
-			current = current->next;
+			update_ptr = info.next;
 		}
 	}
 
@@ -58,6 +68,13 @@ struct UpdateInfo {
 	string ToString();
 	void Print();
 	void Verify();
+	bool HasPrev() const;
+	bool HasNext() const;
+	static UpdateInfo &Get(UndoBufferReference &entry);
+	//! Returns the total allocation size for an UpdateInfo entry, together with space for the tuple data
+	static idx_t GetAllocSize(idx_t type_size);
+	//! Initialize an UpdateInfo struct that has been allocated using GetAllocSize (i.e. has extra space after it)
+	static void Initialize(UpdateInfo &info, transaction_t transaction_id);
 };
 
 } // namespace duckdb

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -13,6 +13,10 @@ shared_ptr<BlockHandle> BufferManager::RegisterTransientMemory(const idx_t size,
 }
 
 shared_ptr<BlockHandle> BufferManager::RegisterSmallMemory(const idx_t size) {
+	return RegisterSmallMemory(MemoryTag::BASE_TABLE, size);
+}
+
+shared_ptr<BlockHandle> BufferManager::RegisterSmallMemory(MemoryTag tag, const idx_t size) {
 	throw NotImplementedException("This type of BufferManager can not create 'small-memory' blocks");
 }
 

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -600,7 +600,6 @@ static void CheckForConflicts(UndoBufferPointer next_ptr, TransactionData transa
 	while (next_ptr.IsSet()) {
 		auto pin = next_ptr.Pin();
 		auto &info = UpdateInfo::Get(pin);
-		auto tuples = info.GetTuples();
 		if (info.version_number == transaction.transaction_id) {
 			// this UpdateInfo belongs to the current transaction, set it in the node
 			node_ref = std::move(pin);
@@ -608,6 +607,7 @@ static void CheckForConflicts(UndoBufferPointer next_ptr, TransactionData transa
 			// potential conflict, check that tuple ids do not conflict
 			// as both ids and info->tuples are sorted, this is similar to a merge join
 			idx_t i = 0, j = 0;
+			auto tuples = info.GetTuples();
 			while (true) {
 				auto id = ids[sel.get_index(i)] - offset;
 				if (id == tuples[j]) {
@@ -627,6 +627,7 @@ static void CheckForConflicts(UndoBufferPointer next_ptr, TransactionData transa
 				}
 			}
 		}
+		next_ptr = info.next;
 	}
 }
 

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -88,7 +88,7 @@ bool UpdateInfo::HasNext() const {
 }
 
 idx_t UpdateInfo::GetAllocSize(idx_t type_size) {
-	return sizeof(UpdateInfo) + (sizeof(sel_t) + type_size) * STANDARD_VECTOR_SIZE;
+	return AlignValue<idx_t>(sizeof(UpdateInfo) + (sizeof(sel_t) + type_size) * STANDARD_VECTOR_SIZE);
 }
 
 void UpdateInfo::Initialize(UpdateInfo &info, transaction_t transaction_id) {
@@ -209,9 +209,11 @@ void UpdateSegment::FetchUpdates(TransactionData transaction, idx_t vector_index
 	fetch_update_function(transaction.start_time, transaction.transaction_id, UpdateInfo::Get(pin), result);
 }
 
-UpdateNode::UpdateNode(BufferManager &manager) : allocator(manager) {}
+UpdateNode::UpdateNode(BufferManager &manager) : allocator(manager) {
+}
 
-UpdateNode::~UpdateNode() {}
+UpdateNode::~UpdateNode() {
+}
 
 //===--------------------------------------------------------------------===//
 // Fetch Committed
@@ -576,8 +578,8 @@ void UpdateSegment::CleanupUpdate(UpdateInfo &info) {
 //===--------------------------------------------------------------------===//
 // Check for conflicts in update
 //===--------------------------------------------------------------------===//
-static void CheckForConflicts(UndoBufferPointer next_ptr, TransactionData transaction, row_t *ids, const SelectionVector &sel,
-                              idx_t count, row_t offset, UndoBufferReference &node_ref) {
+static void CheckForConflicts(UndoBufferPointer next_ptr, TransactionData transaction, row_t *ids,
+                              const SelectionVector &sel, idx_t count, row_t offset, UndoBufferReference &node_ref) {
 	if (!next_ptr.IsSet()) {
 		return;
 	}
@@ -1176,7 +1178,8 @@ void UpdateSegment::Update(TransactionData transaction, idx_t column_index, Vect
 		auto &base_info = UpdateInfo::Get(root_pin);
 
 		UndoBufferReference node_ref;
-		CheckForConflicts(base_info.next, transaction, ids, sel, count, UnsafeNumericCast<row_t>(vector_offset), node_ref);
+		CheckForConflicts(base_info.next, transaction, ids, sel, count, UnsafeNumericCast<row_t>(vector_offset),
+		                  node_ref);
 
 		// there are no conflicts - continue with the update
 		unsafe_unique_array<char> update_info_data;

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/storage/table/column_data.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/update_info.hpp"
+#include "duckdb/transaction/undo_buffer.hpp"
 
 #include <algorithm>
 

--- a/src/transaction/CMakeLists.txt
+++ b/src/transaction/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library_unity(
   duck_transaction_manager.cpp
   duck_transaction.cpp
   meta_transaction.cpp
+  undo_buffer_allocator.cpp
   undo_buffer.cpp
   transaction_context.cpp
   transaction.cpp

--- a/src/transaction/cleanup_state.cpp
+++ b/src/transaction/cleanup_state.cpp
@@ -54,7 +54,6 @@ void CleanupState::CleanupEntry(UndoFlags type, data_ptr_t data) {
 
 void CleanupState::CleanupUpdate(UpdateInfo &info) {
 	// remove the update info from the update chain
-	// first obtain an exclusive lock on the segment
 	info.segment->CleanupUpdate(info);
 }
 

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -247,9 +247,14 @@ ErrorData DuckTransaction::Commit(AttachedDatabase &db, transaction_t new_commit
 	}
 }
 
-void DuckTransaction::Rollback() noexcept {
-	storage->Rollback();
-	undo_buffer.Rollback();
+ErrorData DuckTransaction::Rollback() {
+	try {
+		storage->Rollback();
+		undo_buffer.Rollback();
+		return ErrorData();
+	} catch (std::exception &ex) {
+		return ErrorData(ex);
+	}
 }
 
 void DuckTransaction::Cleanup(transaction_t lowest_active_transaction) {

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -74,10 +74,18 @@ void TransactionContext::Rollback(optional_ptr<ErrorData> error) {
 	}
 	auto transaction = std::move(current_transaction);
 	ClearTransaction();
-	transaction->Rollback();
+	ErrorData rollback_error;
+	try {
+		transaction->Rollback();
+	} catch (std::exception &ex) {
+		rollback_error = ErrorData(ex);
+	}
 	// Notify any registered state of transaction rollback
 	for (auto const &s : context.registered_state->States()) {
 		s->TransactionRollback(*transaction, context, error);
+	}
+	if (rollback_error.HasError()) {
+		rollback_error.Throw();
 	}
 }
 

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -22,52 +22,6 @@ UndoBuffer::UndoBuffer(DuckTransaction &transaction_p, ClientContext &context_p)
     : transaction(transaction_p), allocator(BufferManager::GetBufferManager(context_p)) {
 }
 
-UndoBufferPointer UndoBufferReference::GetBufferPointer() {
-	return UndoBufferPointer(*entry, position);
-}
-
-UndoBufferReference UndoBufferPointer::Pin() const {
-	if (!entry) {
-		throw InternalException("UndoBufferPointer::Pin called but no entry was found");
-	}
-	D_ASSERT(entry->capacity >= position);
-	auto handle = entry->buffer_manager.Pin(entry->block);
-	return UndoBufferReference(*entry, std::move(handle), position);
-}
-
-UndoBufferAllocator::UndoBufferAllocator(BufferManager &buffer_manager) : buffer_manager(buffer_manager) {
-}
-
-UndoBufferReference UndoBufferAllocator::Allocate(idx_t alloc_len) {
-	D_ASSERT(!head || head->position <= head->capacity);
-	BufferHandle handle;
-	if (!head || head->position + alloc_len > head->capacity) {
-		// no space in current head - allocate a new block
-		idx_t capacity = Storage::DEFAULT_BLOCK_SIZE;
-		if (capacity < alloc_len) {
-			capacity = NextPowerOfTwo(alloc_len);
-		}
-		auto entry = make_uniq<UndoBufferEntry>(buffer_manager);
-		handle = buffer_manager.Allocate(MemoryTag::TRANSACTION, capacity, false);
-		entry->block = handle.GetBlockHandle();
-		entry->capacity = capacity;
-		entry->position = 0;
-		// add block to the chain
-		if (head) {
-			head->prev = entry.get();
-			entry->next = std::move(head);
-		} else {
-			tail = entry.get();
-		}
-		head = std::move(entry);
-	} else {
-		handle = buffer_manager.Pin(head->block);
-	}
-	idx_t current_position = head->position;
-	head->position += alloc_len;
-	return UndoBufferReference(*head, std::move(handle), current_position);
-}
-
 UndoBufferReference UndoBuffer::CreateEntry(UndoFlags type, idx_t len) {
 	idx_t alloc_len = AlignValue<idx_t>(len + UNDO_ENTRY_HEADER_SIZE);
 	auto handle = allocator.Allocate(alloc_len);

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -199,7 +199,7 @@ void UndoBuffer::RevertCommit(UndoBuffer::IteratorState &end_state, transaction_
 	IterateEntries(start_state, end_state, [&](UndoFlags type, data_ptr_t data) { state.RevertCommit(type, data); });
 }
 
-void UndoBuffer::Rollback() noexcept {
+void UndoBuffer::Rollback() {
 	// rollback needs to be performed in reverse
 	RollbackState state(transaction);
 	ReverseIterateEntries([&](UndoFlags type, data_ptr_t data) { state.RollbackEntry(type, data); });

--- a/src/transaction/undo_buffer_allocator.cpp
+++ b/src/transaction/undo_buffer_allocator.cpp
@@ -1,0 +1,60 @@
+#include "duckdb/transaction/undo_buffer_allocator.hpp"
+#include "duckdb/storage/buffer_manager.hpp"
+
+namespace duckdb {
+
+UndoBufferEntry::~UndoBufferEntry() {
+	if (next) {
+		auto current_next = std::move(next);
+		while (current_next) {
+			current_next = std::move(current_next->next);
+		}
+	}
+}
+UndoBufferPointer UndoBufferReference::GetBufferPointer() {
+	return UndoBufferPointer(*entry, position);
+}
+
+UndoBufferReference UndoBufferPointer::Pin() const {
+	if (!entry) {
+		throw InternalException("UndoBufferPointer::Pin called but no entry was found");
+	}
+	D_ASSERT(entry->capacity >= position);
+	auto handle = entry->buffer_manager.Pin(entry->block);
+	return UndoBufferReference(*entry, std::move(handle), position);
+}
+
+UndoBufferAllocator::UndoBufferAllocator(BufferManager &buffer_manager) : buffer_manager(buffer_manager) {
+}
+
+UndoBufferReference UndoBufferAllocator::Allocate(idx_t alloc_len) {
+	D_ASSERT(!head || head->position <= head->capacity);
+	BufferHandle handle;
+	if (!head || head->position + alloc_len > head->capacity) {
+		// no space in current head - allocate a new block
+		idx_t capacity = Storage::DEFAULT_BLOCK_SIZE;
+		if (capacity < alloc_len) {
+			capacity = NextPowerOfTwo(alloc_len);
+		}
+		auto entry = make_uniq<UndoBufferEntry>(buffer_manager);
+		handle = buffer_manager.Allocate(MemoryTag::TRANSACTION, capacity, false);
+		entry->block = handle.GetBlockHandle();
+		entry->capacity = capacity;
+		entry->position = 0;
+		// add block to the chain
+		if (head) {
+			head->prev = entry.get();
+			entry->next = std::move(head);
+		} else {
+			tail = entry.get();
+		}
+		head = std::move(entry);
+	} else {
+		handle = buffer_manager.Pin(head->block);
+	}
+	idx_t current_position = head->position;
+	head->position += alloc_len;
+	return UndoBufferReference(*head, std::move(handle), current_position);
+}
+
+}

--- a/src/transaction/undo_buffer_allocator.cpp
+++ b/src/transaction/undo_buffer_allocator.cpp
@@ -24,8 +24,7 @@ UndoBufferReference UndoBufferPointer::Pin() const {
 	return UndoBufferReference(*entry, std::move(handle), position);
 }
 
-UndoBufferAllocator::UndoBufferAllocator(BufferManager &buffer_manager, idx_t initial_capacity)
-    : buffer_manager(buffer_manager), allocate_capacity(initial_capacity) {
+UndoBufferAllocator::UndoBufferAllocator(BufferManager &buffer_manager) : buffer_manager(buffer_manager) {
 }
 
 UndoBufferReference UndoBufferAllocator::Allocate(idx_t alloc_len) {
@@ -33,22 +32,14 @@ UndoBufferReference UndoBufferAllocator::Allocate(idx_t alloc_len) {
 	BufferHandle handle;
 	if (!head || head->position + alloc_len > head->capacity) {
 		// no space in current head - allocate a new block
-		idx_t capacity = allocate_capacity;
+		// FIXME: we might want to allocate less than the block size in initial allocations
+		idx_t capacity = buffer_manager.GetBlockSize();
 		if (capacity < alloc_len) {
 			capacity = NextPowerOfTwo(alloc_len);
 		}
-		auto block_size = buffer_manager.GetBlockSize();
-		// double the allocate capacity, but not past the block size
-		allocate_capacity =
-		    MinValue<idx_t>(buffer_manager.GetBlockSize(), MaxValue<idx_t>(capacity, allocate_capacity * 2));
 		auto entry = make_uniq<UndoBufferEntry>(buffer_manager);
-		if (capacity < block_size) {
-			entry->block = buffer_manager.RegisterSmallMemory(MemoryTag::TRANSACTION, capacity);
-			handle = buffer_manager.Pin(entry->block);
-		} else {
-			handle = buffer_manager.Allocate(MemoryTag::TRANSACTION, capacity, false);
-			entry->block = handle.GetBlockHandle();
-		}
+		handle = buffer_manager.Allocate(MemoryTag::TRANSACTION, capacity, false);
+		entry->block = handle.GetBlockHandle();
 		entry->capacity = capacity;
 		entry->position = 0;
 		// add block to the chain

--- a/src/transaction/undo_buffer_allocator.cpp
+++ b/src/transaction/undo_buffer_allocator.cpp
@@ -57,4 +57,4 @@ UndoBufferReference UndoBufferAllocator::Allocate(idx_t alloc_len) {
 	return UndoBufferReference(*head, std::move(handle), current_position);
 }
 
-}
+} // namespace duckdb

--- a/test/sql/aggregate/aggregates/first_memory_usage.test_slow
+++ b/test/sql/aggregate/aggregates/first_memory_usage.test_slow
@@ -5,7 +5,7 @@
 load __TEST_DIR__/first_memory_usage.db
 
 statement ok
-set memory_limit='400mb';
+set memory_limit='500mb';
 
 # this query uses the first() aggregate, which used to use too much memory (it did redundant allocation in Combine)
 # we also limit the number of threads in RadixPartitionedHashtable to limit memory usage when close to the limit

--- a/test/sql/index/art/memory/test_art_linear.test_slow
+++ b/test/sql/index/art/memory/test_art_linear.test_slow
@@ -48,8 +48,11 @@ statement ok
 UPDATE empty SET usage = (SELECT mem_to_bytes(current.memory_usage) FROM pragma_database_size() AS current);
 
 query I
-SELECT mem_to_bytes(current.memory_usage) == empty.usage
-FROM pragma_database_size() current, empty;
+SELECT case when base.usage >= empty.usage * 5
+	then true
+	else concat('Memory usage ', base.usage, ' is >= than 5 * empty usage ', empty.usage)::UNION(error VARCHAR, b BOOLEAN)
+	end
+FROM base, empty;
 ----
 true
 
@@ -83,12 +86,6 @@ true
 statement ok
 DROP TABLE t;
 
-query I
-SELECT mem_to_bytes(current.memory_usage) == empty.usage
-FROM pragma_database_size() current, empty;
-----
-true
-
 # create a table with a primary key and store the memory usage
 # now verify that the memory drops, but this time drop the whole table instead of deleting entries from it
 
@@ -107,12 +104,6 @@ FROM base, pragma_database_size() current;
 
 statement ok
 DROP TABLE t
-
-query I
-SELECT mem_to_bytes(current.memory_usage) == empty.usage
-FROM pragma_database_size() current, empty;
-----
-true
 
 # create a table with a primary key and store the memory usage
 # verify that the memory decreases by approximately half when deleting half the entries

--- a/test/sql/index/art/vacuum/test_art_vacuum_strings.test_slow
+++ b/test/sql/index/art/vacuum/test_art_vacuum_strings.test_slow
@@ -68,10 +68,16 @@ statement ok
 INSERT INTO t SELECT (range * 4) || 'I am' || (range * 4) || 'a long not' || (range * 4) || 'inlined string' || (range * 4) FROM range(100000) AS range;
 
 query I
-SELECT mem_to_bytes(current.memory_usage) > 4 * base.usage AND mem_to_bytes(current.memory_usage) < 7 * base.usage
+SELECT
+case
+when mem_to_bytes(current.memory_usage) > 4 * base.usage AND mem_to_bytes(current.memory_usage) <= 8 * base.usage
+then true
+else
+concat('current mem usage not between 4X and 7X base (current ', current.memory_usage, ', base ', base.usage, ')')::union(err varchar, b bool)
+end
 FROM base, pragma_database_size() current;
 ----
-1
+true
 
 # store the current size of the DB
 statement ok

--- a/test/sql/storage/temp_directory/max_swap_space_error.test
+++ b/test/sql/storage/temp_directory/max_swap_space_error.test
@@ -52,9 +52,8 @@ query I
 select "size" from duckdb_temporary_files()
 ----
 
-# 6 blocks
 statement ok
-set max_temp_directory_size='1536KiB'
+set max_temp_directory_size='4MB'
 
 statement ok
 pragma threads=2;
@@ -69,31 +68,31 @@ CREATE OR REPLACE TABLE t2 AS SELECT * FROM range(200000);
 
 # When we increase the size to 2400000 bytes of BIGINT data (9.1 blocks) this errors
 statement error
-CREATE OR REPLACE TABLE t2 AS SELECT * FROM range(300000);
+CREATE OR REPLACE TABLE t2 AS SELECT * FROM range(1000000);
 ----
 failed to offload data block
 
 query I
-SELECT "size" FROM duckdb_temporary_files();
+SELECT CASE WHEN "size" > 1000000 THEN true ELSE CONCAT('Expected size 1000000, but got ', "size")::UNION(msg VARCHAR, b BOOLEAN) END FROM duckdb_temporary_files();
 ----
-1572864
+true
 
-# Lower the limit
+# Cannot lower the limit
 statement error
 set max_temp_directory_size='256KiB'
 ----
-failed to adjust the 'max_temp_directory_size', currently used space (1.5 MiB) exceeds the new limit (256.0 KiB)
+exceeds the new limit
 
-# Lower the limit
+# Cannot lower the limit
 statement error
 set max_temp_directory_size='256KiB'
 ----
-failed to adjust the 'max_temp_directory_size', currently used space (1.5 MiB) exceeds the new limit (256.0 KiB)
+exceeds the new limit
 
 query I
 select current_setting('max_temp_directory_size')
 ----
-1.5 MiB
+3.8 MiB
 
 statement ok
 set max_temp_directory_size='2550KiB'

--- a/test/sql/storage/update/larger_than_memory_update.test
+++ b/test/sql/storage/update/larger_than_memory_update.test
@@ -1,0 +1,41 @@
+# name: test/sql/storage/update/larger_than_memory_update.test
+# description: Test larger than memory updates
+# group: [update]
+
+require skip_reload
+
+require noforcestorage
+
+statement ok
+ATTACH '__TEST_DIR__/larger_than_memory_update.db'
+
+statement ok
+CREATE TABLE integers AS FROM range(1000000) t(i);
+
+statement ok
+SET memory_limit='8MB';
+
+query II
+SELECT COUNT(*), SUM(i) FROM integers
+----
+1000000	499999500000
+
+query I
+UPDATE integers SET i=i+1;
+----
+1000000
+
+query II
+SELECT COUNT(*), SUM(i) FROM integers
+----
+1000000	500000500000
+
+query I
+UPDATE integers SET i=i+1 WHERE i%2=0;
+----
+500000
+
+query II
+SELECT COUNT(*), SUM(i) FROM integers
+----
+1000000	500001000000

--- a/test/sql/storage/update/larger_than_memory_update.test_slow
+++ b/test/sql/storage/update/larger_than_memory_update.test_slow
@@ -10,6 +10,7 @@ CREATE TABLE integers AS FROM range(10000000) t(i);
 statement ok
 SET threads=1
 
+# 10M bigints is ~75MB uncompressed
 statement ok
 SET memory_limit='8MB';
 
@@ -37,3 +38,14 @@ query II
 SELECT COUNT(*), SUM(i) FROM integers
 ----
 10000000	50000010000000
+
+statement ok
+BEGIN
+
+query I
+UPDATE integers SET i=i+1;
+----
+10000000
+
+statement ok
+ROLLBACK

--- a/test/sql/storage/update/larger_than_memory_update.test_slow
+++ b/test/sql/storage/update/larger_than_memory_update.test_slow
@@ -1,16 +1,14 @@
-# name: test/sql/storage/update/larger_than_memory_update.test
+# name: test/sql/storage/update/larger_than_memory_update.test_slow
 # description: Test larger than memory updates
 # group: [update]
 
-require skip_reload
-
-require noforcestorage
+load __TEST_DIR__/larger_than_memory_update.db
 
 statement ok
-ATTACH '__TEST_DIR__/larger_than_memory_update.db'
+CREATE TABLE integers AS FROM range(10000000) t(i);
 
 statement ok
-CREATE TABLE integers AS FROM range(1000000) t(i);
+SET threads=1
 
 statement ok
 SET memory_limit='8MB';
@@ -18,24 +16,24 @@ SET memory_limit='8MB';
 query II
 SELECT COUNT(*), SUM(i) FROM integers
 ----
-1000000	499999500000
+10000000	49999995000000
 
 query I
 UPDATE integers SET i=i+1;
 ----
-1000000
+10000000
 
 query II
 SELECT COUNT(*), SUM(i) FROM integers
 ----
-1000000	500000500000
+10000000	50000005000000
 
 query I
 UPDATE integers SET i=i+1 WHERE i%2=0;
 ----
-500000
+5000000
 
 query II
 SELECT COUNT(*), SUM(i) FROM integers
 ----
-1000000	500001000000
+10000000	50000010000000

--- a/test/sql/storage/update/larger_than_memory_update_transactions.test_slow
+++ b/test/sql/storage/update/larger_than_memory_update_transactions.test_slow
@@ -1,0 +1,57 @@
+# name: test/sql/storage/update/larger_than_memory_update_transactions.test_slow
+# description: Test larger than memory updates with transactions
+# group: [update]
+
+require skip_reload
+
+load __TEST_DIR__/larger_than_memory_update_transactions.db
+
+statement ok
+SET threads=1
+
+statement ok
+CREATE TABLE integers AS FROM range(10000000) t(i);
+
+statement ok
+SET memory_limit='12MB';
+
+statement ok con1
+BEGIN
+
+query II con1
+SELECT COUNT(*), SUM(i) FROM integers
+----
+10000000	49999995000000
+
+query I
+UPDATE integers SET i=i+1;
+----
+10000000
+
+query II con1
+SELECT COUNT(*), SUM(i) FROM integers
+----
+10000000	49999995000000
+
+query II
+SELECT COUNT(*), SUM(i) FROM integers
+----
+10000000	50000005000000
+
+query I
+UPDATE integers SET i=i+1 WHERE i%2=0;
+----
+5000000
+
+query II con1
+SELECT COUNT(*), SUM(i) FROM integers
+----
+10000000	49999995000000
+
+query II
+SELECT COUNT(*), SUM(i) FROM integers
+----
+10000000	50000010000000
+
+statement ok con1
+ROLLBACK

--- a/test/sql/storage/update/larger_than_memory_update_transactions.test_slow
+++ b/test/sql/storage/update/larger_than_memory_update_transactions.test_slow
@@ -12,8 +12,9 @@ SET threads=1
 statement ok
 CREATE TABLE integers AS FROM range(10000000) t(i);
 
+# 10M bigints is ~75MB uncompressed
 statement ok
-SET memory_limit='12MB';
+SET memory_limit='16MB';
 
 statement ok con1
 BEGIN


### PR DESCRIPTION
This PR makes it possible to run `UPDATE` and `DELETE` statements where the changeset introduced by the `UPDATE` or `DELETE` exceeds memory. This can happen when running an `UPDATE` that updates a very large table, or by running a `DELETE` that deletes many non-contiguous rows (as contiguous deletes, such as what happens when running `DELETE FROM tbl`, use far less memory as per https://github.com/duckdb/duckdb/pull/11470).

The way this works is that the `UndoBuffer`, which previously used an `ArenaAllocator`, is now modified to use buffer-managed blocks.

* For regular operations, that is actually rather straightforward. When creating new entries we append to the `UndoBuffer` - only requiring us to pin the final block.
* During a commit, rollback or clean-up of a transaction we do a full scan of the `UndoBuffer`. These scans only require us to pin individual blocks.

The main challenge is in `UPDATE` statements.

#### UpdateInfo rework

The reason updates are challenging is that the `UPDATE` statements internally use a linked list, which was previously built using pointers. This PR reworks the `UpdateInfo` struct to instead hold `UndoBufferPointer` entries - which are essentially a reference to an undo-buffer allocated block plus an offset. The `UpdateSegment` class is reworked so that we correctly pin and unpin the `UpdateInfo` entries when we need to traverse the linked list.

The `tuple_data` and `tuples` arrays, that specify which values are updated for which rows, are also no longer pointers (as these pointers can become invalidated if a buffer-managed block is evicted). Instead, we enforce that an `UpdateInfo` struct is always allocated in the following manner:

```
[UpdateInfo][TUPLES (sel_t[max])][DATA (T[max])]
```

We can then access the tuples and the data by looking forward past the struct to where these arrays reside.
 
#### Performance

My main consideration with this change was performance - as we no longer "just" follow pointers but instead need to pin and unpin whenever we use updates. However, after profiling, this does not seem to be a bottleneck. This is likely because the `UpdateInfo` already operates on a per-vector level, so we are only introducing an additional pin/unpin for every vector. Since these are designed to be lightweight when the data fits in memory, the performance impact in this scenario is minimal. In fact, because of our previous change of making the `UpdateInfo` always reside in contiguous memory, performance seems to have improved slightly.


```sql
CREATE TABLE integers(i INT);
INSERT INTO integers FROM range(10000000);
UPDATE integers SET i=i+1;
# old: 0.23s, new: 0.19s

# read from updated values
BEGIN;
UPDATE integers SET i=i+1;
FROM integers;
# old: 0.015s~, new: 0.015s~

# update lineitem
CALL dbgen(sf=1);
UPDATE lineitem SET l_comment=concat(l_comment, l_comment);
# old: 1.0s, new: 0.97s
```

