### PR TITLE
feature(spark): add base64 and unbase64 function

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -2374,6 +2374,7 @@ def bround(col: "ColumnOrName", scale: int = 0) -> Column:
     """
     return _invoke_function_over_columns("round_even", col, lit(scale))
 
+
 def hex(col: "ColumnOrName") -> Column:
     """
     Computes hex value of the given column, which could be :class:`~pyspark.sql.types.StringType`, :class:`~pyspark.sql.types.BinaryType`, :class:`~pyspark.sql.types.IntegerType` or :class:`~pyspark.sql.types.LongType`.
@@ -2400,6 +2401,7 @@ def hex(col: "ColumnOrName") -> Column:
     """
     return _invoke_function_over_columns("hex", col)
 
+
 def unhex(col: "ColumnOrName") -> Column:
     """
     Inverse of hex. Interprets each pair of characters as a hexadecimal number and converts to the byte representation of number. column and returns it as a binary column.
@@ -2425,3 +2427,75 @@ def unhex(col: "ColumnOrName") -> Column:
     [Row(unhex(a)=bytearray(b'ABC'))]
     """
     return _invoke_function_over_columns("unhex", col)
+
+
+def base64(col: "ColumnOrName") -> Column:
+    """
+    Computes the BASE64 encoding of a binary column and returns it as a string column.
+
+    .. versionadded:: 1.5.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to work on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        BASE64 encoding of string value.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame(["Spark", "PySpark", "Pandas API"], "STRING")
+    >>> df.select(base64("value")).show()
+    +----------------+
+    |   base64(value)|
+    +----------------+
+    |        U3Bhcms=|
+    |    UHlTcGFyaw==|
+    |UGFuZGFzIEFQSQ==|
+    +----------------+
+    """
+    if isinstance(col,str):
+        col = Column(ColumnExpression(col))
+    return _invoke_function_over_columns("base64", col.cast("BLOB"))
+
+
+def unbase64(col: "ColumnOrName") -> Column:
+    """
+    Decodes a BASE64 encoded string column and returns it as a binary column.
+
+    .. versionadded:: 1.5.0
+
+    .. versionchanged:: 3.4.0
+        Supports Spark Connect.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to work on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        encoded string value.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame(["U3Bhcms=",
+    ...                            "UHlTcGFyaw==",
+    ...                            "UGFuZGFzIEFQSQ=="], "STRING")
+    >>> df.select(unbase64("value")).show()
+    +--------------------+
+    |     unbase64(value)|
+    +--------------------+
+    |    [53 70 61 72 6B]|
+    |[50 79 53 70 61 7...|
+    |[50 61 6E 64 61 7...|
+    +--------------------+
+    """
+    return _invoke_function_over_columns("from_base64", col)

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_base64.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_base64.py
@@ -1,0 +1,43 @@
+import pytest
+
+_ = pytest.importorskip("duckdb.experimental.spark")
+
+from spark_namespace.sql import functions as F
+
+
+class TestSparkFunctionsBase64(object):
+    def test_base64(self, spark):
+        data = [
+            ("quack",),
+        ]
+        res = (
+            spark.createDataFrame(data, ["firstColumn"])
+            .withColumn("encoded_value", F.base64(F.col("firstColumn")))
+            .select("encoded_value")
+            .collect()
+        )
+        assert res[0].encoded_value == "cXVhY2s="
+
+    def test_base64ColString(self, spark):
+        data = [
+            ("quack",),
+        ]
+        res = (
+            spark.createDataFrame(data, ["firstColumn"])
+            .withColumn("encoded_value", F.base64("firstColumn"))
+            .select("encoded_value")
+            .collect()
+        )
+        assert res[0].encoded_value == "cXVhY2s="
+
+    def test_unbase64(self, spark):
+        data = [
+            ("cXVhY2s=",),
+        ]
+        res = (
+            spark.createDataFrame(data, ["firstColumn"])
+            .withColumn("decoded_value", F.unbase64(F.col("firstColumn")))
+            .select("decoded_value")
+            .collect()
+        )
+        assert res[0].decoded_value == b'quack'


### PR DESCRIPTION
Adds pyspark [base64](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.base64.html) and [unbase64](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.unbase64.html) functions

This is my first pull request to this project so please let me know if I need to change anything.