### PR TITLE
Manage `enable_external_access` at the FileSystem level, and add `allowed_paths` and `allowed_directories` option

### DIFF
--- a/scripts/settings_scripts/config.py
+++ b/scripts/settings_scripts/config.py
@@ -100,12 +100,19 @@ class Setting:
 
     # validate and return the correct type format
     def _get_sql_type(self, sql_type) -> str:
+        if sql_type.endswith('[]'):
+            # recurse into child-element
+            sub_type = self._get_sql_type(sql_type[:-2])
+            return sql_type
         if sql_type in SQL_TYPE_MAP:
             return sql_type
         raise ValueError(f"Invalid SQL type: '{sql_type}' - supported types are {', '.join(SQL_TYPE_MAP.keys())}")
 
     # validate and return the cpp input type
     def _get_setting_type(self, type) -> str:
+        if type.endswith('[]'):
+            subtype = self._get_setting_type(type[:-2])
+            return "vector<" + subtype + ">"
         return SQL_TYPE_MAP[type]
 
     # validate and return the correct type format

--- a/scripts/settings_scripts/update_settings_header_file.py
+++ b/scripts/settings_scripts/update_settings_header_file.py
@@ -17,7 +17,7 @@ def extract_declarations(setting) -> str:
         f"    using RETURN_TYPE = {setting.return_type};\n"
         f"    static constexpr const char *Name = \"{setting.name}\";\n"
         f"    static constexpr const char *Description = \"{setting.description}\";\n"
-        f"    static constexpr const LogicalTypeId InputType = LogicalTypeId::{setting.sql_type};\n"
+        f"    static constexpr const char *InputType = \"{setting.sql_type}\";\n"
     )
     if setting.scope == "GLOBAL" or setting.scope == "GLOBAL_LOCAL":
         definition += f"    static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);\n"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library_unity(
   multi_file_list.cpp
   multi_file_reader.cpp
   error_data.cpp
+  opener_file_system.cpp
   printer.cpp
   radix_partitioning.cpp
   re2_regex.cpp

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -80,10 +80,6 @@ vector<string> MultiFileReader::ParsePaths(const Value &input) {
 
 shared_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context, const vector<string> &paths,
                                                           FileGlobOptions options) {
-	auto &config = DBConfig::GetConfig(context);
-	if (!config.options.enable_external_access) {
-		throw PermissionException("Scanning %s files is disabled through configuration", function_name);
-	}
 	vector<string> result_files;
 
 	auto res = make_uniq<GlobMultiFileList>(context, paths, options);

--- a/src/common/opener_file_system.cpp
+++ b/src/common/opener_file_system.cpp
@@ -10,8 +10,7 @@ void OpenerFileSystem::VerifyNoOpener(optional_ptr<FileOpener> opener) {
 		throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
 	}
 }
-
-void OpenerFileSystem::VerifyFSAccessAllowed(const string &path) {
+void OpenerFileSystem::VerifyCanAccessFileInternal(const string &path, FileType type) {
 	auto opener = GetOpener();
 	if (!opener) {
 		return;
@@ -21,10 +20,18 @@ void OpenerFileSystem::VerifyFSAccessAllowed(const string &path) {
 		return;
 	}
 	auto &config = db->config;
-	if (!config.CanAccessFile(path)) {
-		throw PermissionException("Cannot access file \"%s\" - file system operations are disabled by configuration",
-		                          path);
+	if (!config.CanAccessFile(path, type)) {
+		throw PermissionException("Cannot access %s \"%s\" - file system operations are disabled by configuration",
+		                          type == FileType::FILE_TYPE_DIR ? "directory" : "file", path);
 	}
+}
+
+void OpenerFileSystem::VerifyCanAccessFile(const string &path) {
+	VerifyCanAccessFileInternal(path, FileType::FILE_TYPE_REGULAR);
+}
+
+void OpenerFileSystem::VerifyCanAccessDirectory(const string &path) {
+	VerifyCanAccessFileInternal(path, FileType::FILE_TYPE_DIR);
 }
 
 } // namespace duckdb

--- a/src/common/opener_file_system.cpp
+++ b/src/common/opener_file_system.cpp
@@ -1,0 +1,30 @@
+#include "duckdb/common/opener_file_system.hpp"
+#include "duckdb/common/file_opener.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/config.hpp"
+
+namespace duckdb {
+
+void OpenerFileSystem::VerifyNoOpener(optional_ptr<FileOpener> opener) {
+	if (opener) {
+		throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
+	}
+}
+
+void OpenerFileSystem::VerifyFSAccessAllowed(const string &path) {
+	auto opener = GetOpener();
+	if (!opener) {
+		return;
+	}
+	auto db = opener->TryGetDatabase();
+	if (!db) {
+		return;
+	}
+	auto &config = db->config;
+	if (!config.CanAccessFile(path)) {
+		throw PermissionException("Cannot access file \"%s\" - file system operations are disabled by configuration",
+		                          path);
+	}
+}
+
+} // namespace duckdb

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -77,6 +77,20 @@
         ]
     },
     {
+        "name": "allowed_directories",
+        "description": "List of directories/prefixes that are ALWAYS allowed to be queried - even when enable_external_access is false",
+        "type": "VARCHAR[]",
+        "scope": "global",
+        "custom_implementation": true
+    },
+    {
+        "name": "allowed_paths",
+        "description": "List of files that are ALWAYS allowed to be queried - even when enable_external_access is false",
+        "type": "VARCHAR[]",
+        "scope": "global",
+        "custom_implementation": true
+    },
+    {
         "name": "arrow_large_buffer_size",
         "description": "If arrow buffers for strings, blobs, uuids and bits should be exported using large buffers",
         "type": "BOOLEAN",

--- a/src/execution/operator/helper/physical_set.cpp
+++ b/src/execution/operator/helper/physical_set.cpp
@@ -48,7 +48,7 @@ SourceResultType PhysicalSet::GetData(ExecutionContext &context, DataChunk &chun
 		}
 	}
 
-	Value input_val = value.CastAs(context.client, option->parameter_type);
+	Value input_val = value.CastAs(context.client, DBConfig::ParseLogicalType(option->parameter_type));
 	switch (variable_scope) {
 	case SetScope::GLOBAL: {
 		if (!option->set_global) {

--- a/src/execution/physical_plan/plan_export.cpp
+++ b/src/execution/physical_plan/plan_export.cpp
@@ -6,7 +6,6 @@
 namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExport &op) {
-	auto &config = DBConfig::GetConfig(context);
 	auto export_node = make_uniq<PhysicalExport>(op.types, op.function, std::move(op.copy_info),
 	                                             op.estimated_cardinality, op.exported_tables);
 	// plan the underlying copy statements, if any

--- a/src/execution/physical_plan/plan_export.cpp
+++ b/src/execution/physical_plan/plan_export.cpp
@@ -7,9 +7,6 @@ namespace duckdb {
 
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExport &op) {
 	auto &config = DBConfig::GetConfig(context);
-	if (!config.options.enable_external_access) {
-		throw PermissionException("Export is disabled through configuration");
-	}
 	auto export_node = make_uniq<PhysicalExport>(op.types, op.function, std::move(op.copy_info),
 	                                             op.estimated_cardinality, op.exported_tables);
 	// plan the underlying copy statements, if any

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -139,9 +139,6 @@ string PragmaPlatform(ClientContext &context, const FunctionParameters &paramete
 
 string PragmaImportDatabase(ClientContext &context, const FunctionParameters &parameters) {
 	auto &config = DBConfig::GetConfig(context);
-	if (!config.options.enable_external_access) {
-		throw PermissionException("Import is disabled through configuration");
-	}
 	auto &fs = FileSystem::GetFileSystem(context);
 
 	string final_query;

--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -138,7 +138,6 @@ string PragmaPlatform(ClientContext &context, const FunctionParameters &paramete
 }
 
 string PragmaImportDatabase(ClientContext &context, const FunctionParameters &parameters) {
-	auto &config = DBConfig::GetConfig(context);
 	auto &fs = FileSystem::GetFileSystem(context);
 
 	string final_query;

--- a/src/function/table/sniff_csv.cpp
+++ b/src/function/table/sniff_csv.cpp
@@ -36,7 +36,6 @@ static unique_ptr<GlobalTableFunctionState> CSVSniffInitGlobal(ClientContext &co
 static unique_ptr<FunctionData> CSVSniffBind(ClientContext &context, TableFunctionBindInput &input,
                                              vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_uniq<CSVSniffFunctionData>();
-	auto &config = DBConfig::GetConfig(context);
 	result->path = input.inputs[0].ToString();
 	auto it = input.named_parameters.find("auto_detect");
 	if (it != input.named_parameters.end()) {

--- a/src/function/table/sniff_csv.cpp
+++ b/src/function/table/sniff_csv.cpp
@@ -37,9 +37,6 @@ static unique_ptr<FunctionData> CSVSniffBind(ClientContext &context, TableFuncti
                                              vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_uniq<CSVSniffFunctionData>();
 	auto &config = DBConfig::GetConfig(context);
-	if (!config.options.enable_external_access) {
-		throw PermissionException("sniff_csv is disabled through configuration");
-	}
 	result->path = input.inputs[0].ToString();
 	auto it = input.named_parameters.find("auto_detect");
 	if (it != input.named_parameters.end()) {

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -54,7 +54,7 @@ unique_ptr<GlobalTableFunctionState> DuckDBSettingsInit(ClientContext &context, 
 		value.name = option->name;
 		value.value = option->get_setting(context).ToString();
 		value.description = option->description;
-		value.input_type = EnumUtil::ToString(option->parameter_type);
+		value.input_type = option->parameter_type;
 		value.scope = EnumUtil::ToString(scope);
 
 		result->settings.push_back(std::move(value));

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -18,27 +18,8 @@ public:
 	virtual FileSystem &GetFileSystem() const = 0;
 	virtual optional_ptr<FileOpener> GetOpener() const = 0;
 
-	void VerifyNoOpener(optional_ptr<FileOpener> opener) {
-		if (opener) {
-			throw InternalException("OpenerFileSystem cannot take an opener - the opener is pushed automatically");
-		}
-	}
-
-	void VerifyFSAccessAllowed(const string &path) {
-		auto opener = GetOpener();
-		if (!opener) {
-			return;
-		}
-		auto db = opener->TryGetDatabase();
-		if (!db) {
-			return;
-		}
-		auto &config = db->config;
-		if (!config.CanAccessFile(path)) {
-			throw PermissionException(
-			    "Cannot access file \"%s\" - file system operations are disabled by configuration", path);
-		}
-	}
+	void VerifyNoOpener(optional_ptr<FileOpener> opener);
+	void VerifyFSAccessAllowed(const string &path);
 
 	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
 	                                optional_ptr<FileOpener> opener = nullptr) override {

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -35,7 +35,8 @@ public:
 		}
 		auto &config = db->config;
 		if (!config.CanAccessFile(path)) {
-			throw PermissionException("Cannot access file \"%s\" - file system operations are disabled by configuration", path);
+			throw PermissionException(
+			    "Cannot access file \"%s\" - file system operations are disabled by configuration", path);
 		}
 	}
 

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -19,12 +19,13 @@ public:
 	virtual optional_ptr<FileOpener> GetOpener() const = 0;
 
 	void VerifyNoOpener(optional_ptr<FileOpener> opener);
-	void VerifyFSAccessAllowed(const string &path);
+	void VerifyCanAccessDirectory(const string &path);
+	void VerifyCanAccessFile(const string &path);
 
 	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
 	                                optional_ptr<FileOpener> opener = nullptr) override {
 		VerifyNoOpener(opener);
-		VerifyFSAccessAllowed(path);
+		VerifyCanAccessFile(path);
 		return GetFileSystem().OpenFile(path, flags, GetOpener());
 	}
 
@@ -64,32 +65,32 @@ public:
 
 	bool DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
-		VerifyFSAccessAllowed(directory);
+		VerifyCanAccessDirectory(directory);
 		return GetFileSystem().DirectoryExists(directory, GetOpener());
 	}
 	void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
-		VerifyFSAccessAllowed(directory);
+		VerifyCanAccessDirectory(directory);
 		return GetFileSystem().CreateDirectory(directory, GetOpener());
 	}
 
 	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
-		VerifyFSAccessAllowed(directory);
+		VerifyCanAccessDirectory(directory);
 		return GetFileSystem().RemoveDirectory(directory, GetOpener());
 	}
 
 	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
 	               FileOpener *opener = nullptr) override {
 		VerifyNoOpener(opener);
-		VerifyFSAccessAllowed(directory);
+		VerifyCanAccessDirectory(directory);
 		return GetFileSystem().ListFiles(directory, callback, GetOpener().get());
 	}
 
 	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
-		VerifyFSAccessAllowed(source);
-		VerifyFSAccessAllowed(target);
+		VerifyCanAccessFile(source);
+		VerifyCanAccessFile(target);
 		GetFileSystem().MoveFile(source, target, GetOpener());
 	}
 
@@ -103,7 +104,7 @@ public:
 
 	bool FileExists(const string &filename, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
-		VerifyFSAccessAllowed(filename);
+		VerifyCanAccessFile(filename);
 		return GetFileSystem().FileExists(filename, GetOpener());
 	}
 
@@ -113,7 +114,7 @@ public:
 	}
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
-		VerifyFSAccessAllowed(filename);
+		VerifyCanAccessFile(filename);
 		GetFileSystem().RemoveFile(filename, GetOpener());
 	}
 
@@ -123,7 +124,7 @@ public:
 
 	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override {
 		VerifyNoOpener(opener);
-		VerifyFSAccessAllowed(path);
+		VerifyCanAccessFile(path);
 		return GetFileSystem().Glob(path, GetOpener().get());
 	}
 
@@ -150,6 +151,9 @@ public:
 	vector<string> ListSubSystems() override {
 		return GetFileSystem().ListSubSystems();
 	}
+
+private:
+	void VerifyCanAccessFileInternal(const string &path, FileType type);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -24,9 +24,25 @@ public:
 		}
 	}
 
+	void VerifyFSAccessAllowed(const string &path) {
+		auto opener = GetOpener();
+		if (!opener) {
+			return;
+		}
+		auto db = opener->TryGetDatabase();
+		if (!db) {
+			return;
+		}
+		auto &config = db->config;
+		if (!config.CanAccessFile(path)) {
+			throw PermissionException("Cannot access file \"%s\" - file system operations are disabled by configuration", path);
+		}
+	}
+
 	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
 	                                optional_ptr<FileOpener> opener = nullptr) override {
 		VerifyNoOpener(opener);
+		VerifyFSAccessAllowed(path);
 		return GetFileSystem().OpenFile(path, flags, GetOpener());
 	}
 
@@ -66,26 +82,32 @@ public:
 
 	bool DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
+		VerifyFSAccessAllowed(directory);
 		return GetFileSystem().DirectoryExists(directory, GetOpener());
 	}
 	void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
+		VerifyFSAccessAllowed(directory);
 		return GetFileSystem().CreateDirectory(directory, GetOpener());
 	}
 
 	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
+		VerifyFSAccessAllowed(directory);
 		return GetFileSystem().RemoveDirectory(directory, GetOpener());
 	}
 
 	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
 	               FileOpener *opener = nullptr) override {
 		VerifyNoOpener(opener);
+		VerifyFSAccessAllowed(directory);
 		return GetFileSystem().ListFiles(directory, callback, GetOpener().get());
 	}
 
 	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
+		VerifyFSAccessAllowed(source);
+		VerifyFSAccessAllowed(target);
 		GetFileSystem().MoveFile(source, target, GetOpener());
 	}
 
@@ -99,6 +121,7 @@ public:
 
 	bool FileExists(const string &filename, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
+		VerifyFSAccessAllowed(filename);
 		return GetFileSystem().FileExists(filename, GetOpener());
 	}
 
@@ -108,6 +131,7 @@ public:
 	}
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
+		VerifyFSAccessAllowed(filename);
 		GetFileSystem().RemoveFile(filename, GetOpener());
 	}
 
@@ -117,6 +141,7 @@ public:
 
 	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override {
 		VerifyNoOpener(opener);
+		VerifyFSAccessAllowed(path);
 		return GetFileSystem().Glob(path, GetOpener().get());
 	}
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -70,7 +70,7 @@ typedef Value (*get_setting_function_t)(const ClientContext &context);
 struct ConfigurationOption {
 	const char *name;
 	const char *description;
-	LogicalTypeId parameter_type;
+	const char *parameter_type;
 	set_global_function_t set_global;
 	set_local_function_t set_local;
 	reset_global_function_t reset_global;
@@ -350,6 +350,8 @@ public:
 	DUCKDB_API void ResetOption(DatabaseInstance *db, const ConfigurationOption &option);
 	DUCKDB_API void SetOption(const string &name, Value value);
 	DUCKDB_API void ResetOption(const string &name);
+	static LogicalType ParseLogicalType(const string &type);
+
 
 	DUCKDB_API void CheckLock(const string &name);
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -352,7 +352,6 @@ public:
 	DUCKDB_API void ResetOption(const string &name);
 	static LogicalType ParseLogicalType(const string &type);
 
-
 	DUCKDB_API void CheckLock(const string &name);
 
 	DUCKDB_API static idx_t ParseMemoryLimit(const string &arg);

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -391,6 +391,9 @@ public:
 	}
 
 	bool CanAccessFile(const string &path);
+	void AddAllowedDirectory(const string &path);
+	void AddAllowedPath(const string &path);
+	string SanitizeAllowedPath(const string &path) const;
 
 private:
 	unique_ptr<CompressionFunctionSet> compression_functions;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -390,7 +390,7 @@ public:
 		return OP::GetSetting(context);
 	}
 
-	bool CanAccessFile(const string &path);
+	bool CanAccessFile(const string &path, FileType type);
 	void AddAllowedDirectory(const string &path);
 	void AddAllowedPath(const string &path);
 	string SanitizeAllowedPath(const string &path) const;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -272,6 +272,10 @@ struct DBConfigOptions {
 	bool debug_skip_checkpoint_on_commit = false;
 	//! The maximum amount of vacuum tasks to schedule during a checkpoint
 	idx_t max_vacuum_tasks = 100;
+	//! Paths that are explicitly allowed, even if enable_external_access is false
+	unordered_set<string> allowed_paths;
+	//! Directories that are explicitly allowed, even if enable_external_access is false
+	set<string> allowed_directories;
 
 	bool operator==(const DBConfigOptions &other) const;
 };
@@ -384,6 +388,8 @@ public:
 		std::lock_guard<mutex> lock(config_lock);
 		return OP::GetSetting(context);
 	}
+
+	bool CanAccessFile(const string &path);
 
 private:
 	unique_ptr<CompressionFunctionSet> compression_functions;

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -84,6 +84,8 @@ public:
 	bool HasDefaultDatabase() {
 		return !default_database.empty();
 	}
+	//! Gets a list of all attached database paths
+	vector<string> GetAttachedDatabasePaths();
 
 private:
 	//! Returns a database with a specified path

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -64,7 +64,7 @@ struct AccessModeSetting {
 	using RETURN_TYPE = AccessMode;
 	static constexpr const char *Name = "access_mode";
 	static constexpr const char *Description = "Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
@@ -75,7 +75,7 @@ struct AllocatorBackgroundThreadsSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "allocator_background_threads";
 	static constexpr const char *Description = "Whether to enable the allocator background thread.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
@@ -88,7 +88,7 @@ struct AllocatorBulkDeallocationFlushThresholdSetting {
 	static constexpr const char *Name = "allocator_bulk_deallocation_flush_threshold";
 	static constexpr const char *Description =
 	    "If a bulk deallocation larger than this occurs, flush outstanding allocations.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -99,7 +99,7 @@ struct AllocatorFlushThresholdSetting {
 	static constexpr const char *Name = "allocator_flush_threshold";
 	static constexpr const char *Description =
 	    "Peak allocation threshold at which to flush the allocator after completing a task.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -109,7 +109,7 @@ struct AllowCommunityExtensionsSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "allow_community_extensions";
 	static constexpr const char *Description = "Allow to load community built extensions";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
@@ -121,7 +121,7 @@ struct AllowExtensionsMetadataMismatchSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "allow_extensions_metadata_mismatch";
 	static constexpr const char *Description = "Allow to load extensions with not compatible metadata";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -132,7 +132,7 @@ struct AllowPersistentSecretsSetting {
 	static constexpr const char *Name = "allow_persistent_secrets";
 	static constexpr const char *Description =
 	    "Allow the creation of persistent secrets, that are stored and loaded on restarts";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -142,7 +142,7 @@ struct AllowUnredactedSecretsSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "allow_unredacted_secrets";
 	static constexpr const char *Description = "Allow printing unredacted secrets";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
@@ -154,11 +154,33 @@ struct AllowUnsignedExtensionsSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "allow_unsigned_extensions";
 	static constexpr const char *Description = "Allow to load extensions with invalid or missing signatures";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
 	static bool OnGlobalReset(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
+struct AllowedDirectoriesSetting {
+	using RETURN_TYPE = vector<string>;
+	static constexpr const char *Name = "allowed_directories";
+	static constexpr const char *Description = "List of directories/prefixes that are ALWAYS allowed to be queried - "
+	                                           "even when enable_external_access is false";
+	static constexpr const char *InputType = "VARCHAR[]";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
+struct AllowedPathsSetting {
+	using RETURN_TYPE = vector<string>;
+	static constexpr const char *Name = "allowed_paths";
+	static constexpr const char *Description =
+	    "List of files that are ALWAYS allowed to be queried - even when enable_external_access is false";
+	static constexpr const char *InputType = "VARCHAR[]";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
 };
 
@@ -167,7 +189,7 @@ struct ArrowLargeBufferSizeSetting {
 	static constexpr const char *Name = "arrow_large_buffer_size";
 	static constexpr const char *Description =
 	    "If arrow buffers for strings, blobs, uuids and bits should be exported using large buffers";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -179,7 +201,7 @@ struct ArrowLosslessConversionSetting {
 	static constexpr const char *Description =
 	    "Whenever a DuckDB type does not have a clear native or canonical extension match in Arrow, export the types "
 	    "with a duckdb.type_name extension name.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -190,7 +212,7 @@ struct ArrowOutputListViewSetting {
 	static constexpr const char *Name = "arrow_output_list_view";
 	static constexpr const char *Description =
 	    "If export to arrow format should use ListView as the physical layout for LIST columns";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -201,7 +223,7 @@ struct AutoinstallExtensionRepositorySetting {
 	static constexpr const char *Name = "autoinstall_extension_repository";
 	static constexpr const char *Description =
 	    "Overrides the custom endpoint for extension installation on autoloading";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -212,7 +234,7 @@ struct AutoinstallKnownExtensionsSetting {
 	static constexpr const char *Name = "autoinstall_known_extensions";
 	static constexpr const char *Description =
 	    "Whether known extensions are allowed to be automatically installed when a query depends on them";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -223,7 +245,7 @@ struct AutoloadKnownExtensionsSetting {
 	static constexpr const char *Name = "autoload_known_extensions";
 	static constexpr const char *Description =
 	    "Whether known extensions are allowed to be automatically loaded when a query depends on them";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -234,7 +256,7 @@ struct CatalogErrorMaxSchemasSetting {
 	static constexpr const char *Name = "catalog_error_max_schemas";
 	static constexpr const char *Description =
 	    "The maximum number of schemas the system will scan for \"did you mean...\" style errors in the catalog";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -245,7 +267,7 @@ struct CheckpointThresholdSetting {
 	static constexpr const char *Name = "checkpoint_threshold";
 	static constexpr const char *Description =
 	    "The WAL size threshold at which to automatically trigger a checkpoint (e.g. 1GB)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -255,7 +277,7 @@ struct CustomExtensionRepositorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "custom_extension_repository";
 	static constexpr const char *Description = "Overrides the custom endpoint for remote extension installation";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -265,7 +287,7 @@ struct CustomProfilingSettingsSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "custom_profiling_settings";
 	static constexpr const char *Description = "Accepts a JSON enabling custom metrics";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -275,7 +297,7 @@ struct CustomUserAgentSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "custom_user_agent";
 	static constexpr const char *Description = "Metadata from DuckDB callers";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -285,7 +307,7 @@ struct DebugAsofIejoinSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "debug_asof_iejoin";
 	static constexpr const char *Description = "DEBUG SETTING: force use of IEJoin to implement AsOf joins";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -296,7 +318,7 @@ struct DebugCheckpointAbortSetting {
 	static constexpr const char *Name = "debug_checkpoint_abort";
 	static constexpr const char *Description =
 	    "DEBUG SETTING: trigger an abort while checkpointing for testing purposes";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -307,7 +329,7 @@ struct DebugForceExternalSetting {
 	static constexpr const char *Name = "debug_force_external";
 	static constexpr const char *Description =
 	    "DEBUG SETTING: force out-of-core computation for operators that support it, used for testing";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -318,7 +340,7 @@ struct DebugForceNoCrossProductSetting {
 	static constexpr const char *Name = "debug_force_no_cross_product";
 	static constexpr const char *Description =
 	    "DEBUG SETTING: Force disable cross product generation when hyper graph isn't connected, used for testing";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -328,7 +350,7 @@ struct DebugSkipCheckpointOnCommitSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "debug_skip_checkpoint_on_commit";
 	static constexpr const char *Description = "DEBUG SETTING: skip checkpointing on commit";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -338,7 +360,7 @@ struct DebugWindowModeSetting {
 	using RETURN_TYPE = WindowAggregationMode;
 	static constexpr const char *Name = "debug_window_mode";
 	static constexpr const char *Description = "DEBUG SETTING: switch window mode to use";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -349,7 +371,7 @@ struct DefaultBlockSizeSetting {
 	static constexpr const char *Name = "default_block_size";
 	static constexpr const char *Description =
 	    "The default block size for new duckdb database files (new as-in, they do not yet exist).";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -359,7 +381,7 @@ struct DefaultCollationSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "default_collation";
 	static constexpr const char *Description = "The collation setting used when none is specified";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static void SetLocal(ClientContext &context, const Value &parameter);
@@ -371,7 +393,7 @@ struct DefaultNullOrderSetting {
 	using RETURN_TYPE = DefaultOrderByNullType;
 	static constexpr const char *Name = "default_null_order";
 	static constexpr const char *Description = "Null ordering used when none is specified (NULLS_FIRST or NULLS_LAST)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -381,7 +403,7 @@ struct DefaultOrderSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "default_order";
 	static constexpr const char *Description = "The order type used when none is specified (ASC or DESC)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -391,7 +413,7 @@ struct DefaultSecretStorageSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "default_secret_storage";
 	static constexpr const char *Description = "Allows switching the default storage for secrets";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -401,7 +423,7 @@ struct DisabledFilesystemsSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "disabled_filesystems";
 	static constexpr const char *Description = "Disable specific file systems preventing access (e.g. LocalFileSystem)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -411,7 +433,7 @@ struct DisabledOptimizersSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "disabled_optimizers";
 	static constexpr const char *Description = "DEBUG SETTING: disable a specific set of optimizers (comma separated)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -421,7 +443,7 @@ struct DuckDBAPISetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "duckdb_api";
 	static constexpr const char *Description = "DuckDB API surface";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -433,7 +455,7 @@ struct EnableExternalAccessSetting {
 	static constexpr const char *Description =
 	    "Allow the database to access external state (through e.g. loading/installing modules, COPY TO/FROM, CSV "
 	    "readers, pandas replacement scans, etc)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
@@ -446,7 +468,7 @@ struct EnableFSSTVectorsSetting {
 	static constexpr const char *Name = "enable_fsst_vectors";
 	static constexpr const char *Description =
 	    "Allow scans on FSST compressed segments to emit compressed vectors to utilize late decompression";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -456,7 +478,7 @@ struct EnableHTTPLoggingSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "enable_http_logging";
 	static constexpr const char *Description = "Enables HTTP logging";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -466,7 +488,7 @@ struct EnableHTTPMetadataCacheSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "enable_http_metadata_cache";
 	static constexpr const char *Description = "Whether or not the global http metadata is used to cache HTTP metadata";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -477,7 +499,7 @@ struct EnableMacroDependenciesSetting {
 	static constexpr const char *Name = "enable_macro_dependencies";
 	static constexpr const char *Description =
 	    "Enable created MACROs to create dependencies on the referenced objects (such as tables)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -487,7 +509,7 @@ struct EnableObjectCacheSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "enable_object_cache";
 	static constexpr const char *Description = "Whether or not object cache is used to cache e.g. Parquet metadata";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -498,7 +520,7 @@ struct EnableProfilingSetting {
 	static constexpr const char *Name = "enable_profiling";
 	static constexpr const char *Description =
 	    "Enables profiling, and sets the output format (JSON, QUERY_TREE, QUERY_TREE_OPTIMIZER)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -509,7 +531,7 @@ struct EnableProgressBarSetting {
 	static constexpr const char *Name = "enable_progress_bar";
 	static constexpr const char *Description =
 	    "Enables the progress bar, printing progress to the terminal for long queries";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static bool OnLocalSet(ClientContext &context, const Value &input);
@@ -522,7 +544,7 @@ struct EnableProgressBarPrintSetting {
 	static constexpr const char *Name = "enable_progress_bar_print";
 	static constexpr const char *Description =
 	    "Controls the printing of the progress bar, when 'enable_progress_bar' is true";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -533,7 +555,7 @@ struct EnableViewDependenciesSetting {
 	static constexpr const char *Name = "enable_view_dependencies";
 	static constexpr const char *Description =
 	    "Enable created VIEWs to create dependencies on the referenced objects (such as tables)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -543,7 +565,7 @@ struct ErrorsAsJSONSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "errors_as_json";
 	static constexpr const char *Description = "Output error messages as structured JSON instead of as a raw string";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -553,7 +575,7 @@ struct ExplainOutputSetting {
 	using RETURN_TYPE = ExplainOutputType;
 	static constexpr const char *Name = "explain_output";
 	static constexpr const char *Description = "Output of EXPLAIN statements (ALL, OPTIMIZED_ONLY, PHYSICAL_ONLY)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -563,7 +585,7 @@ struct ExtensionDirectorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "extension_directory";
 	static constexpr const char *Description = "Set the directory to store extensions in";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -573,7 +595,7 @@ struct ExternalThreadsSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "external_threads";
 	static constexpr const char *Description = "The number of external threads that work on DuckDB tasks.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
@@ -585,7 +607,7 @@ struct FileSearchPathSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "file_search_path";
 	static constexpr const char *Description = "A comma separated list of directories to search for input files";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -595,7 +617,7 @@ struct ForceBitpackingModeSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "force_bitpacking_mode";
 	static constexpr const char *Description = "DEBUG SETTING: forces a specific bitpacking mode";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -605,7 +627,7 @@ struct ForceCompressionSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "force_compression";
 	static constexpr const char *Description = "DEBUG SETTING: forces a specific compression method to be used";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -615,7 +637,7 @@ struct HomeDirectorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "home_directory";
 	static constexpr const char *Description = "Sets the home directory used by the system";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -626,7 +648,7 @@ struct HTTPLoggingOutputSetting {
 	static constexpr const char *Name = "http_logging_output";
 	static constexpr const char *Description =
 	    "The file to which HTTP logging output should be saved, or empty to print to the terminal";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -636,7 +658,7 @@ struct HTTPProxySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "http_proxy";
 	static constexpr const char *Description = "HTTP proxy host";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -646,7 +668,7 @@ struct HTTPProxyPasswordSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "http_proxy_password";
 	static constexpr const char *Description = "Password for HTTP proxy";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -656,7 +678,7 @@ struct HTTPProxyUsernameSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "http_proxy_username";
 	static constexpr const char *Description = "Username for HTTP proxy";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -667,7 +689,7 @@ struct IEEEFloatingPointOpsSetting {
 	static constexpr const char *Name = "ieee_floating_point_ops";
 	static constexpr const char *Description =
 	    "Use IEE754-compliant floating point operations (returning NAN instead of errors/NULL).";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -678,7 +700,7 @@ struct ImmediateTransactionModeSetting {
 	static constexpr const char *Name = "immediate_transaction_mode";
 	static constexpr const char *Description =
 	    "Whether transactions should be started lazily when needed, or immediately when BEGIN TRANSACTION is called";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -690,7 +712,7 @@ struct IndexScanMaxCountSetting {
 	static constexpr const char *Description =
 	    "The maximum index scan count sets a threshold for index scans. If fewer than MAX(index_scan_max_count, "
 	    "index_scan_percentage * total_row_count) rows match, we perform an index scan instead of a table scan.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -702,7 +724,7 @@ struct IndexScanPercentageSetting {
 	static constexpr const char *Description =
 	    "The index scan percentage sets a threshold for index scans. If fewer than MAX(index_scan_max_count, "
 	    "index_scan_percentage * total_row_count) rows match, we perform an index scan instead of a table scan.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::DOUBLE;
+	static constexpr const char *InputType = "DOUBLE";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static bool OnGlobalSet(DatabaseInstance *db, DBConfig &config, const Value &input);
@@ -714,7 +736,7 @@ struct IntegerDivisionSetting {
 	static constexpr const char *Name = "integer_division";
 	static constexpr const char *Description =
 	    "Whether or not the / operator defaults to integer division, or to floating point division";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -724,7 +746,7 @@ struct LockConfigurationSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "lock_configuration";
 	static constexpr const char *Description = "Whether or not the configuration can be altered";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -735,7 +757,7 @@ struct LogQueryPathSetting {
 	static constexpr const char *Name = "log_query_path";
 	static constexpr const char *Description =
 	    "Specifies the path to which queries should be logged (default: NULL, queries are not logged)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -747,7 +769,7 @@ struct MaxExpressionDepthSetting {
 	static constexpr const char *Description =
 	    "The maximum expression depth limit in the parser. WARNING: increasing this setting and using very deep "
 	    "expressions might lead to stack overflow errors.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -757,7 +779,7 @@ struct MaxMemorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "max_memory";
 	static constexpr const char *Description = "The maximum memory of the system (e.g. 1GB)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -768,7 +790,7 @@ struct MaxTempDirectorySizeSetting {
 	static constexpr const char *Name = "max_temp_directory_size";
 	static constexpr const char *Description =
 	    "The maximum amount of data stored inside the 'temp_directory' (when set) (e.g. 1GB)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -778,7 +800,7 @@ struct MaxVacuumTasksSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "max_vacuum_tasks";
 	static constexpr const char *Description = "The maximum vacuum tasks to schedule during a checkpoint.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -788,7 +810,7 @@ struct MergeJoinThresholdSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "merge_join_threshold";
 	static constexpr const char *Description = "The number of rows we need on either table to choose a merge join";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -799,7 +821,7 @@ struct NestedLoopJoinThresholdSetting {
 	static constexpr const char *Name = "nested_loop_join_threshold";
 	static constexpr const char *Description =
 	    "The number of rows we need on either table to choose a nested loop join";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -809,7 +831,7 @@ struct OldImplicitCastingSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "old_implicit_casting";
 	static constexpr const char *Description = "Allow implicit casting to/from VARCHAR";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -820,7 +842,7 @@ struct OrderByNonIntegerLiteralSetting {
 	static constexpr const char *Name = "order_by_non_integer_literal";
 	static constexpr const char *Description =
 	    "Allow ordering by non-integer literals - ordering by such literals has no effect.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -830,7 +852,7 @@ struct OrderedAggregateThresholdSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "ordered_aggregate_threshold";
 	static constexpr const char *Description = "The number of rows to accumulate before sorting, used for tuning";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static bool OnLocalSet(ClientContext &context, const Value &input);
@@ -842,7 +864,7 @@ struct PartitionedWriteFlushThresholdSetting {
 	static constexpr const char *Name = "partitioned_write_flush_threshold";
 	static constexpr const char *Description =
 	    "The threshold in number of rows after which we flush a thread state when writing using PARTITION_BY";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -853,7 +875,7 @@ struct PartitionedWriteMaxOpenFilesSetting {
 	static constexpr const char *Name = "partitioned_write_max_open_files";
 	static constexpr const char *Description =
 	    "The maximum amount of files the system can keep open before flushing to disk when writing using PARTITION_BY";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -863,7 +885,7 @@ struct PasswordSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "password";
 	static constexpr const char *Description = "The password to use. Ignored for legacy compatibility.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -873,7 +895,7 @@ struct PerfectHtThresholdSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "perfect_ht_threshold";
 	static constexpr const char *Description = "Threshold in bytes for when to use a perfect hash table";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -884,7 +906,7 @@ struct PivotFilterThresholdSetting {
 	static constexpr const char *Name = "pivot_filter_threshold";
 	static constexpr const char *Description =
 	    "The threshold to switch from using filtered aggregates to LIST with a dedicated pivot operator";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -894,7 +916,7 @@ struct PivotLimitSetting {
 	using RETURN_TYPE = idx_t;
 	static constexpr const char *Name = "pivot_limit";
 	static constexpr const char *Description = "The maximum number of pivot columns in a pivot statement";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::UBIGINT;
+	static constexpr const char *InputType = "UBIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -904,7 +926,7 @@ struct PreferRangeJoinsSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "prefer_range_joins";
 	static constexpr const char *Description = "Force use of range joins with mixed predicates";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -915,7 +937,7 @@ struct PreserveIdentifierCaseSetting {
 	static constexpr const char *Name = "preserve_identifier_case";
 	static constexpr const char *Description =
 	    "Whether or not to preserve the identifier case, instead of always lowercasing all non-quoted identifiers";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -927,7 +949,7 @@ struct PreserveInsertionOrderSetting {
 	static constexpr const char *Description =
 	    "Whether or not to preserve insertion order. If set to false the system is allowed to re-order any results "
 	    "that do not contain ORDER BY clauses.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -938,7 +960,7 @@ struct ProduceArrowStringViewSetting {
 	static constexpr const char *Name = "produce_arrow_string_view";
 	static constexpr const char *Description =
 	    "If strings should be produced by DuckDB in Utf8View format instead of Utf8";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -949,7 +971,7 @@ struct ProfileOutputSetting {
 	static constexpr const char *Name = "profile_output";
 	static constexpr const char *Description =
 	    "The file to which profile output should be saved, or empty to print to the terminal";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -959,7 +981,7 @@ struct ProfilingModeSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "profiling_mode";
 	static constexpr const char *Description = "The profiling mode (STANDARD or DETAILED)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -970,7 +992,7 @@ struct ProgressBarTimeSetting {
 	static constexpr const char *Name = "progress_bar_time";
 	static constexpr const char *Description =
 	    "Sets the time (in milliseconds) how long a query needs to take before we start printing a progress bar";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
+	static constexpr const char *InputType = "BIGINT";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -981,7 +1003,7 @@ struct ScalarSubqueryErrorOnMultipleRowsSetting {
 	static constexpr const char *Name = "scalar_subquery_error_on_multiple_rows";
 	static constexpr const char *Description =
 	    "When a scalar subquery returns multiple rows - return a random row instead of returning an error.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static constexpr const char *InputType = "BOOLEAN";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -992,7 +1014,7 @@ struct SchemaSetting {
 	static constexpr const char *Name = "schema";
 	static constexpr const char *Description =
 	    "Sets the default search schema. Equivalent to setting search_path to a single value.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -1003,7 +1025,7 @@ struct SearchPathSetting {
 	static constexpr const char *Name = "search_path";
 	static constexpr const char *Description =
 	    "Sets the default catalog search path as a comma-separated list of values";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -1013,7 +1035,7 @@ struct SecretDirectorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "secret_directory";
 	static constexpr const char *Description = "Set the directory to which persistent secrets are stored";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -1023,7 +1045,7 @@ struct StorageCompatibilityVersionSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "storage_compatibility_version";
 	static constexpr const char *Description = "Serialize on checkpoint with compatibility for a given duckdb version";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -1034,7 +1056,7 @@ struct StreamingBufferSizeSetting {
 	static constexpr const char *Name = "streaming_buffer_size";
 	static constexpr const char *Description =
 	    "The maximum memory to buffer between fetching from a streaming result (e.g. 1GB)";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);
 	static Value GetSetting(const ClientContext &context);
@@ -1044,7 +1066,7 @@ struct TempDirectorySetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "temp_directory";
 	static constexpr const char *Description = "Set the directory to which to write temp files";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -1054,7 +1076,7 @@ struct ThreadsSetting {
 	using RETURN_TYPE = int64_t;
 	static constexpr const char *Name = "threads";
 	static constexpr const char *Description = "The number of total threads used by the system.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::BIGINT;
+	static constexpr const char *InputType = "BIGINT";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
@@ -1064,7 +1086,7 @@ struct UsernameSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "username";
 	static constexpr const char *Description = "The username to use. Ignored for legacy compatibility.";
-	static constexpr const LogicalTypeId InputType = LogicalTypeId::VARCHAR;
+	static constexpr const char *InputType = "VARCHAR";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -571,10 +571,16 @@ const string DBConfig::UserAgent() const {
 	return user_agent;
 }
 
-bool DBConfig::CanAccessFile(const string &path) {
+bool DBConfig::CanAccessFile(const string &input_path) {
 	if (options.enable_external_access) {
 		// all external access is allowed
 		return true;
+	}
+	auto path_sep = file_system->PathSeparator(input_path);
+	string path = input_path;
+	if (path_sep != "/") {
+		// allowed_directories/allowed_path always uses forward slashes regardless of the OS
+		path = StringUtil::Replace(path, path_sep, "/");
 	}
 	if (options.allowed_paths.count(path) > 0) {
 		// path is explicitly allowed
@@ -601,7 +607,6 @@ bool DBConfig::CanAccessFile(const string &path) {
 		// no common prefix found - path is not inside an allowed directory
 		return false;
 	}
-	auto path_sep = file_system->PathSeparator(path);
 	D_ASSERT(StringUtil::EndsWith(prefix, path_sep));
 	// path is inside an allowed directory - HOWEVER, we could still exit the allowed directory using ".."
 	// we check if we ever exit the allowed directory using ".." by looking at the path fragments

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -345,7 +345,9 @@ void DBConfig::SetDefaultMaxMemory() {
 }
 
 void DBConfig::SetDefaultTempDirectory() {
-	if (DBConfig::IsInMemoryDatabase(options.database_path.c_str())) {
+	if (!options.use_temporary_directory) {
+		options.temporary_directory = string();
+	} else if (DBConfig::IsInMemoryDatabase(options.database_path.c_str())) {
 		options.temporary_directory = ".tmp";
 	} else {
 		options.temporary_directory = options.database_path + ".tmp";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -597,7 +597,7 @@ void DBConfig::AddAllowedPath(const string &path) {
 	options.allowed_paths.insert(allowed_path);
 }
 
-bool DBConfig::CanAccessFile(const string &input_path) {
+bool DBConfig::CanAccessFile(const string &input_path, FileType type) {
 	if (options.enable_external_access) {
 		// all external access is allowed
 		return true;
@@ -610,6 +610,12 @@ bool DBConfig::CanAccessFile(const string &input_path) {
 	if (options.allowed_directories.empty()) {
 		// no prefix directories specified
 		return false;
+	}
+	if (type == FileType::FILE_TYPE_DIR) {
+		// make sure directories end with a /
+		if (!StringUtil::EndsWith(path, "/")) {
+			path += "/";
+		}
 	}
 	auto start_bound = options.allowed_directories.lower_bound(path);
 	if (start_bound != options.allowed_directories.begin()) {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -284,14 +284,14 @@ LogicalType DBConfig::ParseLogicalType(const string &type) {
 	if (StringUtil::EndsWith(type, "()")) {
 		if (type != "STRUCT()") {
 			throw InternalException("Error while generating extension function overloads - expected STRUCT(), not %s",
-									type);
+			                        type);
 		}
 		return LogicalType::STRUCT({});
 	}
 	auto type_id = TransformStringToLogicalTypeId(type);
 	if (type_id == LogicalTypeId::USER) {
 		throw InternalException("Error while generating extension function overloads - unrecognized logical type %s",
-								type);
+		                        type);
 	}
 	return type_id;
 }
@@ -591,7 +591,7 @@ bool DBConfig::CanAccessFile(const string &path) {
 	auto end_bound = options.allowed_directories.upper_bound(path);
 
 	string prefix;
-	for(auto it = start_bound; it != end_bound; ++it) {
+	for (auto it = start_bound; it != end_bound; ++it) {
 		if (StringUtil::StartsWith(path, *it)) {
 			prefix = *it;
 			break;

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -400,7 +400,7 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 		config.options.database_path.clear();
 	}
 
-	if (new_config.options.temporary_directory.empty() && !new_config.options.use_temporary_directory) {
+	if (new_config.options.temporary_directory.empty()) {
 		config.SetDefaultTempDirectory();
 	}
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -402,8 +402,8 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 	if (database_path) {
 		config.options.database_path = database_path;
 		if (!config.options.enable_external_access) {
-			config.options.allowed_paths.insert(database_path);
-			config.options.allowed_paths.insert(database_path + string(".wal"));
+			config.AddAllowedPath(database_path);
+			config.AddAllowedPath(database_path + string(".wal"));
 		}
 	} else {
 		config.options.database_path.clear();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -401,10 +401,6 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 
 	if (database_path) {
 		config.options.database_path = database_path;
-		if (!config.options.enable_external_access) {
-			config.AddAllowedPath(database_path);
-			config.AddAllowedPath(database_path + string(".wal"));
-		}
 	} else {
 		config.options.database_path.clear();
 	}
@@ -421,6 +417,10 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 		config.file_system = std::move(new_config.file_system);
 	} else {
 		config.file_system = make_uniq<VirtualFileSystem>();
+	}
+	if (database_path && !config.options.enable_external_access) {
+		config.AddAllowedPath(database_path);
+		config.AddAllowedPath(database_path + string(".wal"));
 	}
 	if (new_config.secret_manager) {
 		config.secret_manager = std::move(new_config.secret_manager);

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -275,11 +275,6 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 	create_api_v0 = CreateAPIv0Wrapper;
 
-	if (user_config && !user_config->options.use_temporary_directory) {
-		// temporary directories explicitly disabled
-		config.options.temporary_directory = string();
-	}
-
 	db_file_system = make_uniq<DatabaseFileSystem>(*this);
 	db_manager = make_uniq<DatabaseManager>(*this);
 	if (config.buffer_manager) {
@@ -405,7 +400,7 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 		config.options.database_path.clear();
 	}
 
-	if (new_config.options.temporary_directory.empty()) {
+	if (new_config.options.temporary_directory.empty() && !new_config.options.use_temporary_directory) {
 		config.SetDefaultTempDirectory();
 	}
 
@@ -421,6 +416,9 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 	if (database_path && !config.options.enable_external_access) {
 		config.AddAllowedPath(database_path);
 		config.AddAllowedPath(database_path + string(".wal"));
+		if (!config.options.temporary_directory.empty()) {
+			config.AddAllowedDirectory(config.options.temporary_directory);
+		}
 	}
 	if (new_config.secret_manager) {
 		config.secret_manager = std::move(new_config.secret_manager);

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -401,6 +401,10 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 
 	if (database_path) {
 		config.options.database_path = database_path;
+		if (!config.options.enable_external_access) {
+			config.options.allowed_paths.insert(database_path);
+			config.options.allowed_paths.insert(database_path + string(".wal"));
+		}
 	} else {
 		config.options.database_path.clear();
 	}

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -137,7 +137,7 @@ void DatabaseManager::EraseDatabasePath(const string &path) {
 vector<string> DatabaseManager::GetAttachedDatabasePaths() {
 	lock_guard<mutex> path_lock(db_paths_lock);
 	vector<string> paths;
-	for(auto &path : db_paths) {
+	for (auto &path : db_paths) {
 		paths.push_back(path);
 	}
 	return paths;

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -134,6 +134,15 @@ void DatabaseManager::EraseDatabasePath(const string &path) {
 	}
 }
 
+vector<string> DatabaseManager::GetAttachedDatabasePaths() {
+	lock_guard<mutex> path_lock(db_paths_lock);
+	vector<string> paths;
+	for(auto &path : db_paths) {
+		paths.push_back(path);
+	}
+	return paths;
+}
+
 void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, const DBConfig &config,
                                       AttachOptions &options) {
 

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -195,7 +195,7 @@ void AllowedDirectoriesSetting::SetGlobal(DatabaseInstance *db, DBConfig &config
 	}
 	config.options.allowed_directories.clear();
 	auto &list = ListValue::GetChildren(input);
-	for(auto &val : list) {
+	for (auto &val : list) {
 		auto allowed_directory = val.GetValue<string>();
 		if (allowed_directory.empty()) {
 			throw InvalidInputException("Cannot provide an empty string for allowed_directory");
@@ -219,7 +219,7 @@ void AllowedDirectoriesSetting::ResetGlobal(DatabaseInstance *db, DBConfig &conf
 Value AllowedDirectoriesSetting::GetSetting(const ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
 	vector<Value> allowed_directories;
-	for(auto &dir : config.options.allowed_directories) {
+	for (auto &dir : config.options.allowed_directories) {
 		allowed_directories.emplace_back(dir);
 	}
 	return Value::LIST(LogicalType::VARCHAR, std::move(allowed_directories));
@@ -600,7 +600,7 @@ bool EnableExternalAccessSetting::OnGlobalSet(DatabaseInstance *db, DBConfig &co
 		// we are turning off external access - add any already attached databases to the list of accepted paths
 		auto &db_manager = DatabaseManager::Get(*db);
 		auto attached_paths = db_manager.GetAttachedDatabasePaths();
-		for(auto &path : attached_paths) {
+		for (auto &path : attached_paths) {
 			config.options.allowed_paths.insert(path);
 			config.options.allowed_paths.insert(path + ".wal");
 		}

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -205,6 +205,10 @@ void AllowedDirectoriesSetting::SetGlobal(DatabaseInstance *db, DBConfig &config
 		if (!StringUtil::EndsWith(allowed_directory, path_sep)) {
 			allowed_directory += path_sep;
 		}
+		// make sure allowed_directory always uses forward slashes regardless of the OS
+		if (path_sep != "/") {
+			allowed_directory = StringUtil::Replace(allowed_directory, path_sep, "/");
+		}
 		config.options.allowed_directories.insert(allowed_directory);
 	}
 }
@@ -235,7 +239,13 @@ void AllowedPathsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, cons
 	config.options.allowed_paths.clear();
 	auto &list = ListValue::GetChildren(input);
 	for (auto &val : list) {
-		config.options.allowed_paths.insert(val.GetValue<string>());
+		auto allowed_path = val.GetValue<string>();
+		auto path_sep = config.file_system->PathSeparator(allowed_path);
+		// make sure allowed_path always uses forward slashes regardless of the OS
+		if (path_sep != "/") {
+			allowed_path = StringUtil::Replace(allowed_path, path_sep, "/");
+		}
+		config.options.allowed_paths.insert(allowed_path);
 	}
 }
 

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -29,12 +29,6 @@ static bool GetBooleanArg(ClientContext &context, const vector<Value> &arg) {
 }
 
 BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) {
-	// COPY TO a file
-	auto &config = DBConfig::GetConfig(context);
-	if (!config.options.enable_external_access) {
-		throw PermissionException("COPY TO is disabled by configuration");
-	}
-
 	// lookup the format in the catalog
 	auto &copy_function =
 	    Catalog::GetEntry<CopyFunctionCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, stmt.info->format);
@@ -272,10 +266,6 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) 
 }
 
 BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
-	auto &config = DBConfig::GetConfig(context);
-	if (!config.options.enable_external_access) {
-		throw PermissionException("COPY FROM is disabled by configuration");
-	}
 	BoundStatement result;
 	result.types = {LogicalType::BIGINT};
 	result.names = {"Count"};
@@ -284,7 +274,7 @@ BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
 		throw ParserException("COPY FROM requires a table name to be specified");
 	}
 	// COPY FROM a file
-	// generate an insert statement for the the to-be-inserted table
+	// generate an insert statement for the to-be-inserted table
 	InsertStatement insert;
 	insert.table = stmt.info->table;
 	insert.schema = stmt.info->schema;

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -159,10 +159,6 @@ unique_ptr<LogicalOperator> Binder::UnionOperators(vector<unique_ptr<LogicalOper
 
 BoundStatement Binder::Bind(ExportStatement &stmt) {
 	// COPY TO a file
-	auto &config = DBConfig::GetConfig(context);
-	if (!config.options.enable_external_access) {
-		throw PermissionException("COPY TO is disabled through configuration");
-	}
 	BoundStatement result;
 	result.types = {LogicalType::BOOLEAN};
 	result.names = {"Success"};

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -157,11 +157,6 @@ void SingleFileStorageManager::LoadDatabase(StorageOptions storage_options) {
 
 	auto &fs = FileSystem::Get(db);
 	auto &config = DBConfig::Get(db);
-	if (!config.options.enable_external_access) {
-		if (!db.IsInitialDatabase()) {
-			throw PermissionException("Attaching on-disk databases is disabled through configuration");
-		}
-	}
 
 	StorageManagerOptions options;
 	options.read_only = read_only;

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -132,6 +132,8 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 bool OptionIsExcludedFromTest(const string &name) {
 	static unordered_set<string> excluded_options = {
 	    "access_mode",
+	    "allowed_directories",
+	    "allowed_paths",
 	    "schema",
 	    "search_path",
 	    "debug_window_mode",

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -43,7 +43,7 @@ struct OptionValueSet {
 void RequireValueEqual(ConfigurationOption *op, const Value &left, const Value &right, int line);
 #define REQUIRE_VALUE_EQUAL(op, lhs, rhs) RequireValueEqual(op, lhs, rhs, __LINE__)
 
-OptionValueSet GetValueForOption(const string &name, LogicalTypeId type) {
+OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	static unordered_map<string, OptionValueSet> value_map = {
 	    {"threads", {Value::BIGINT(42), Value::BIGINT(42)}},
 	    {"checkpoint_threshold", {"4.0 GiB"}},
@@ -109,7 +109,7 @@ OptionValueSet GetValueForOption(const string &name, LogicalTypeId type) {
 	    {"allocator_bulk_deallocation_flush_threshold", {"4.0 GiB"}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {
-		switch (type) {
+		switch (type.id()) {
 		case LogicalTypeId::BOOLEAN:
 			return OptionValueSet(Value::BOOLEAN(true));
 		case LogicalTypeId::TINYINT:
@@ -197,8 +197,9 @@ TEST_CASE("Test RESET statement for ClientConfig options", "[api]") {
 
 		// Get the current value of the option
 		auto original_value = op->get_setting(*con.context);
+		auto parameter_type = DBConfig::ParseLogicalType(option.parameter_type);
 
-		auto value_set = GetValueForOption(option.name, option.parameter_type);
+		auto value_set = GetValueForOption(option.name, parameter_type);
 		// verify that at least one value is different
 		bool any_different = false;
 		string options;
@@ -221,7 +222,7 @@ TEST_CASE("Test RESET statement for ClientConfig options", "[api]") {
 		}
 		for (auto &value_pair : value_set.pairs) {
 			// Get the new value for the option
-			auto input = value_pair.input.DefaultCastAs(op->parameter_type);
+			auto input = value_pair.input.DefaultCastAs(parameter_type);
 			// Set the new option
 			if (op->set_local) {
 				op->set_local(*con.context, input);

--- a/test/sql/attach/attach_enable_external_access.test
+++ b/test/sql/attach/attach_enable_external_access.test
@@ -31,4 +31,4 @@ CHECKPOINT a2
 statement error
 ATTACH '__TEST_DIR__/attach_access3.db' AS a2
 ----
-disabled by configuration
+Permission Error

--- a/test/sql/attach/attach_enable_external_access.test
+++ b/test/sql/attach/attach_enable_external_access.test
@@ -1,6 +1,6 @@
 # name: test/sql/attach/attach_enable_external_access.test
 # description: enable_external_access with attached  databases
-# group: [storage]
+# group: [attach]
 
 require skip_reload
 

--- a/test/sql/attach/attach_enable_external_access.test
+++ b/test/sql/attach/attach_enable_external_access.test
@@ -1,0 +1,34 @@
+# name: test/sql/attach/attach_enable_external_access.test
+# description: enable_external_access with attached  databases
+# group: [storage]
+
+require skip_reload
+
+# attach multiple different databases
+statement ok
+ATTACH '__TEST_DIR__/attach_access1.db' AS a1
+
+statement ok
+ATTACH '__TEST_DIR__/attach_access2.db' AS a2
+
+statement ok
+SET enable_external_access=false
+
+# we can modify any database that was attached prior to
+statement ok
+CREATE TABLE a1.test (a INTEGER PRIMARY KEY, b INTEGER);
+
+statement ok
+CHECKPOINT a1
+
+# however, we cannot attach new database files
+statement ok
+CREATE TABLE a2.test (a INTEGER PRIMARY KEY, b INTEGER);
+
+statement ok
+CHECKPOINT a2
+
+statement error
+ATTACH '__TEST_DIR__/attach_access3.db' AS a2
+----
+disabled by configuration

--- a/test/sql/attach/attach_external_access.test
+++ b/test/sql/attach/attach_external_access.test
@@ -14,4 +14,4 @@ ATTACH ':memory:' AS db1
 statement error
 ATTACH 'mydb.db' AS db2
 ----
-Attaching on-disk databases is disabled through configuration
+Permission Error

--- a/test/sql/copy/csv/csv_external_access.test
+++ b/test/sql/copy/csv/csv_external_access.test
@@ -17,22 +17,22 @@ SET enable_external_access=false;
 statement error
 SELECT * FROM read_csv('data/csv/test/date.csv', columns = {'d': 'DATE'});
 ----
-Scanning read_csv files is disabled through configuration
+Permission Error
 
 statement error
 SELECT * FROM read_csv_auto('data/csv/test/date.csv');
 ----
-Scanning read_csv_auto files is disabled through configuration
+Permission Error
 
 statement error
 COPY date_test FROM 'data/csv/test/date.csv';
 ----
-COPY FROM is disabled by configuration
+Permission Error
 
 statement error
 COPY date_test TO '__TEST_DIR__/date.csv'
 ----
-COPY TO is disabled by configuration
+Permission Error
 
 # we also can't just enable external access again
 statement error
@@ -44,4 +44,4 @@ Cannot change enable_external_access setting while database is running
 statement error
 FROM sniff_csv('data/csv/test/date.csv');
 ----
-Permission Error: sniff_csv is disabled through configuration
+Permission Error

--- a/test/sql/settings/allowed_directories.test
+++ b/test/sql/settings/allowed_directories.test
@@ -1,6 +1,6 @@
 # name: test/sql/settings/allowed_directories.test
 # description: Test allowed_directories setting together with enable_external_access = false
-# group: [storage]
+# group: [settings]
 
 require skip_reload
 

--- a/test/sql/settings/allowed_directories.test
+++ b/test/sql/settings/allowed_directories.test
@@ -4,6 +4,13 @@
 
 require skip_reload
 
+# enable_external_access = false disables extension loading
+require no_extension_autoloading
+
+require parquet
+
+require json
+
 # we can set allowed_directories as much as we want
 statement ok
 SET allowed_directories=['data/csv/glob']
@@ -173,10 +180,7 @@ IMPORT DATABASE 'export_test'
 ----
 Permission Error
 
-
 # we can read parquet/json files
-require parquet
-
 query II
 SELECT * FROM 'data/parquet-testing/glob/t1.parquet'
 ----
@@ -186,8 +190,6 @@ statement error
 SELECT * FROM 'data/parquet-testing/aws2.parquet'
 ----
 Permission Error
-
-require json
 
 query II
 SELECT * FROM 'data/parquet-testing/glob/t1.parquet'

--- a/test/sql/settings/allowed_directories.test
+++ b/test/sql/settings/allowed_directories.test
@@ -102,7 +102,7 @@ Permission Error
 
 # we can also glob allowed directories
 query I
-SELECT * FROM glob('data/csv/glob/*.csv')
+SELECT replace(fname, '\', '/') as fname FROM glob('data/csv/glob/*.csv') t(fname)
 ----
 data/csv/glob/f_1.csv
 data/csv/glob/f_2.csv

--- a/test/sql/settings/allowed_directories.test
+++ b/test/sql/settings/allowed_directories.test
@@ -1,0 +1,195 @@
+# name: test/sql/settings/allowed_directories.test
+# description: Test allowed_directories setting together with enable_external_access = false
+# group: [storage]
+
+require skip_reload
+
+# we can set allowed_directories as much as we want
+statement ok
+SET allowed_directories=['data/csv/glob']
+
+statement ok
+RESET allowed_directories
+
+statement ok
+SET allowed_directories=['data/csv/glob', 'data/parquet-testing/glob', 'data/json', '__TEST_DIR__']
+
+statement ok
+SET enable_external_access=false
+
+# ...until enable_external_access is false
+statement error
+RESET allowed_directories
+----
+Cannot change allowed_directories when enable_external_access is disabled
+
+statement error
+SET allowed_directories=[]
+----
+Cannot change allowed_directories when enable_external_access is disabled
+
+# we can read CSV files from the allowed_directories
+query III
+SELECT * FROM 'data/csv/glob/f_1.csv'
+----
+1	alice	alice@email.com
+2	eve	eve@email.com
+3r	bob	NULL
+
+# also within contained directories
+query I
+SELECT * FROM 'data/csv/glob/a1/a1.csv'
+----
+2019-06-05
+2019-06-15
+2019-06-25
+
+# we can also use "..", as long as we remain inside our directory
+query III
+SELECT * FROM 'data/csv/glob/a1/../f_1.csv'
+----
+1	alice	alice@email.com
+2	eve	eve@email.com
+3r	bob	NULL
+
+# and we can use ./
+query III
+SELECT * FROM 'data/csv/glob/./f_1.csv'
+----
+1	alice	alice@email.com
+2	eve	eve@email.com
+3r	bob	NULL
+
+# we cannot read files that are not in the allowed directories
+statement error
+SELECT * FROM 'data/csv/all_quotes.csv'
+----
+Permission Error
+
+# also not through usage of ".."
+statement error
+SELECT * FROM 'data/csv/glob/../all_quotes.csv'
+----
+Permission Error
+
+# //.. edge case
+statement error
+SELECT * FROM 'data/csv/glob//../all_quotes.csv'
+----
+Permission Error
+
+statement error
+SELECT * FROM 'data/csv/glob/a1/../../all_quotes.csv'
+----
+Permission Error
+
+# we can also sniff csv files
+statement ok
+SELECT * FROM sniff_csv('data/csv/glob/f_1.csv')
+
+# but not outside of allowed directories
+statement error
+SELECT * FROM sniff_csv('data/csv/all_quotes.csv')
+----
+Permission Error
+
+# we can also glob allowed directories
+query I
+SELECT * FROM glob('data/csv/glob/*.csv')
+----
+data/csv/glob/f_1.csv
+data/csv/glob/f_2.csv
+data/csv/glob/f_3.csv
+
+statement error
+SELECT * FROM glob('data/csv/**.csv')
+----
+Permission Error
+
+# we can write to our test dir
+statement ok
+COPY (SELECT 42 i) TO '__TEST_DIR__/permission_test.csv' (FORMAT csv)
+
+statement ok
+CREATE TABLE integers(i INT);
+
+statement ok
+COPY integers FROM '__TEST_DIR__/permission_test.csv'
+
+query I
+FROM integers
+----
+42
+
+# but not to other directories
+statement error
+COPY (SELECT 42 i) TO 'permission_test.csv' (FORMAT csv)
+----
+Permission Error
+
+statement error
+COPY integers FROM 'permission_test.csv'
+----
+Permission Error
+
+# we can attach databases in allowed directories
+statement ok
+ATTACH '__TEST_DIR__/attached_dir.db' AS a1
+
+statement ok
+CREATE TABLE a1.integers(i INTEGER);
+
+# but not in other directories
+statement error
+ATTACH 'test.db'
+----
+Permission Error
+
+# we cannot load or install extensions with enable_external access
+statement error
+LOAD my_ext
+----
+Permission Error
+
+statement error
+INSTALL my_ext
+----
+Permission Error
+
+# export/import also work with allowed_directories
+statement ok
+EXPORT DATABASE a1 TO '__TEST_DIR__/export_test'
+
+statement error
+EXPORT DATABASE a1 TO 'export_test'
+----
+Permission Error
+
+statement ok
+IMPORT DATABASE '__TEST_DIR__/export_test'
+
+statement error
+IMPORT DATABASE 'export_test'
+----
+Permission Error
+
+
+# we can read parquet/json files
+require parquet
+
+query II
+SELECT * FROM 'data/parquet-testing/glob/t1.parquet'
+----
+1	a
+
+statement error
+SELECT * FROM 'data/parquet-testing/aws2.parquet'
+----
+Permission Error
+
+require json
+
+query II
+SELECT * FROM 'data/parquet-testing/glob/t1.parquet'
+----
+1	a

--- a/test/sql/settings/allowed_paths.test
+++ b/test/sql/settings/allowed_paths.test
@@ -1,6 +1,6 @@
 # name: test/sql/settings/allowed_paths.test
 # description: Test allowed_paths setting together with enable_external_access = false
-# group: [storage]
+# group: [settings]
 
 require skip_reload
 

--- a/test/sql/settings/allowed_paths.test
+++ b/test/sql/settings/allowed_paths.test
@@ -1,0 +1,54 @@
+# name: test/sql/settings/allowed_paths.test
+# description: Test allowed_paths setting together with enable_external_access = false
+# group: [storage]
+
+require skip_reload
+
+# we can set allowed_directories as much as we want
+statement ok
+SET allowed_paths=['data/csv/glob/f_1.csv']
+
+statement ok
+RESET allowed_paths
+
+statement ok
+SET allowed_paths=['data/csv/glob/f_1.csv', '__TEST_DIR__/allowed_file.csv']
+
+statement ok
+SET enable_external_access=false
+
+# ...until enable_external_access is false
+statement error
+RESET allowed_paths
+----
+Cannot change allowed_paths when enable_external_access is disabled
+
+statement error
+SET allowed_paths=[]
+----
+Cannot change allowed_paths when enable_external_access is disabled
+
+# we can read our allowed files
+query III
+SELECT * FROM 'data/csv/glob/f_1.csv'
+----
+1	alice	alice@email.com
+2	eve	eve@email.com
+3r	bob	NULL
+
+# but not files that are not allowed
+statement error
+SELECT * FROM 'data/csv/glob/a1/a1.csv'
+----
+Permission Error
+
+# we can also write to our allowed file
+statement ok
+COPY (SELECT 42 i) TO '__TEST_DIR__/allowed_file.csv'
+
+# but not to not-allowed files
+statement error
+COPY (SELECT 42 i) TO '__TEST_DIR__/not_allowed_file.csv'
+----
+Permission Error
+

--- a/test/sql/settings/allowed_paths.test
+++ b/test/sql/settings/allowed_paths.test
@@ -4,6 +4,9 @@
 
 require skip_reload
 
+# enable_external_access = false disables extension loading
+require no_extension_autoloading
+
 # we can set allowed_directories as much as we want
 statement ok
 SET allowed_paths=['data/csv/glob/f_1.csv']

--- a/test/sql/storage/storage_enable_external_access.test
+++ b/test/sql/storage/storage_enable_external_access.test
@@ -1,0 +1,27 @@
+# name: test/sql/storage/storage_enable_external_access.test
+# description: enable_external_access with persistent databases
+# group: [storage]
+
+require skip_reload
+
+# load the DB from disk
+load __TEST_DIR__/external_access_test.db
+
+statement ok
+SET enable_external_access=false
+
+# verify that we can still modify the currently attached database if enable_external_access is disabled
+statement ok
+CREATE TABLE test (a INTEGER PRIMARY KEY, b INTEGER);
+
+statement ok
+INSERT INTO test VALUES (11, 22), (13, 22);
+
+query II
+SELECT * FROM test ORDER BY a
+----
+11	22
+13	22
+
+statement ok
+CHECKPOINT

--- a/test/sql/storage/temp_directory/temp_directory_enable_external_access.test
+++ b/test/sql/storage/temp_directory/temp_directory_enable_external_access.test
@@ -1,0 +1,28 @@
+# name: test/sql/storage/temp_directory/temp_directory_enable_external_access.test
+# group: [temp_directory]
+
+require block_size 262144
+
+statement ok
+SET temp_directory='__TEST_DIR__/test_temp_dir'
+
+statement ok
+SET memory_limit = '8MB';
+
+statement ok
+SET enable_external_access=false
+
+# cannot modify the temp directory when enable_external_access is set
+statement error
+SET temp_directory='__TEST_DIR__/new_temp_dir'
+----
+disabled by configuration
+
+statement error
+RESET temp_directory
+----
+disabled by configuration
+
+# 10M row table with 8B rows -> 80MB uncompressed - this requires the temp directory
+statement ok
+CREATE TEMPORARY TABLE tbl AS FROM range(10_000_000)


### PR DESCRIPTION
Previously we would check `enable_external_access` in specific functions - e.g. we would prevent users from calling `read_csv` if `enable_external_access` was set to false. As illustrated by [this issue](https://github.com/duckdb/duckdb/security/advisories/GHSA-w2gf-jxc9-pf2q) this is error prone. This PR reworks `enable_external_access` by instead disallowing the usage of file system operations (opening of files, as well as creating/removing files/directories, or checking if they exist).

#### allowed_paths/allowed_directories
`enable_external_access` allows any databases *that were attached prior to the flag being set* to be operated on as usual, e.g. the following needs to work:

```sql
ATTACH 'file.db';
SET enable_external_access=false;
CREATE TABLE file.tbl(i INT);
INSERT INTO file.tbl VALUES (42);
```

This means that `enable_external_access` cannot block *all* file-system operations. Instead, we need to allow operations on *certain files*. In particular:

* For every attached database file, we allow operations on the database file and the corresponding `WAL` file
* We allow operations on the `temp_directory`, if any is set

Rather than making this a special case, these settings are user-extensible using the **allowed_directories** and the **allowed_paths** setting. We can read them from `duckdb_settings`

|       name                   |                                     description                                                  |
|---------------------|----------------------------------------------------------------------------------------------------------------|
| allowed_directories | List of directories/prefixes that are ALWAYS allowed to be queried - even when enable_external_access is false |
| allowed_paths       | List of files that are ALWAYS allowed to be queried - even when enable_external_access is false                |

```sql
ATTACH 'file.db';
SET enable_external_access=false;
SELECT name, value FROM duckdb_settings() WHERE name LIKE 'allowed%';
┌─────────────────────┬────────────────────────┐
│        name         │         value          │
│       varchar       │        varchar         │
├─────────────────────┼────────────────────────┤
│ allowed_directories │ []                     │
│ allowed_paths       │ [file.db.wal, file.db] │
└─────────────────────┴────────────────────────┘
```

We can set them using `SET` commands, but only **before** `enable_external_access` is disabled

```sql
SET allowed_directories=['/tmp/'];
SET enable_external_access=false;
SELECT name, value FROM duckdb_settings() WHERE name LIKE 'allowed%';
┌─────────────────────┬─────────┐
│        name         │  value  │
│       varchar       │ varchar │
├─────────────────────┼─────────┤
│ allowed_directories │ [/tmp/] │
│ allowed_paths       │ []      │
└─────────────────────┴─────────┘

SET allowed_directories=['/tmp/', 'new_dir'];
Invalid Input Error: Cannot change allowed_directories when enable_external_access is disabled
```

#### Remote-Only Querying

One potential use-case for these settings is that we can enable remote-only querying, while disabling local file-system operations. For example:

```sql
SET allowed_directories=['http://', 'https://'];
SET enable_external_access=false;
FROM read_csv('test.csv');
-- Permission Error: Cannot access file "test.csv" - file system operations are disabled by configuration
FROM read_csv('https://duckdb-public-gzip-test.s3.us-east-2.amazonaws.com/test.csv');
┌─────────┬─────────┐
│  'foo'  │  'bar'  │
│ varchar │ varchar │
├─────────┼─────────┤
│ foo     │ bar     │
└─────────┴─────────┘
```

#### Extensions

Extensions that use the DuckDB file-system to do I/O will automatically respect the `enable_external_access` and `allowed_paths/allowed_directories` flags. However, extensions can also do their own I/O using a different file-system implementation/layer. As such, we cannot guarantee that extensions correctly respect the `enable_external_access` setting - particularly for community extensions.
