### PR TITLE
CLI: Fix for .mode markdown rendering after refactor

### DIFF
--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -105,9 +105,14 @@ public:
 	}
 
 	void RenderHeader(ColumnarResult &result) override {
+		state.Print(GetRowStart());
 		for (idx_t i = 0; i < result.column_count; i++) {
+			if (i > 0) {
+				state.Print(GetColumnSeparator());
+			}
 			RenderAlignedValue(result, i);
 		}
+		state.Print(GetRowSeparator());
 		state.PrintMarkdownSeparator(result.column_count, "|", result.types, result.column_width);
 	}
 

--- a/tools/shell/tests/shell_rendering.py
+++ b/tools/shell/tests/shell_rendering.py
@@ -30,3 +30,13 @@ def test_right_align(shell):
 
     result = test.run()
     result.check_stdout("│   100 │")
+
+def test_markdown(shell):
+    test = (
+        ShellTest(shell)
+        .statement(".mode markdown")
+        .statement("select 42 a, 'hello' str")
+    )
+
+    result = test.run()
+    result.check_stdout("| a  |  str  |")


### PR DESCRIPTION
We were not adding separators correctly after the refactor