### PR TITLE
[PySpark] Add autocompletion for column names to dataframes

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
@@ -560,6 +560,11 @@ class DataFrame:
         """
         return [f.name for f in self.schema.fields]
 
+    def _ipython_key_completions_(self) -> List[str]:
+        # Provides tab-completion for column names in PySpark DataFrame
+        # when accessed in bracket notation, e.g. df['<TAB>]
+        return self.columns
+
     def join(
         self,
         other: "DataFrame",
@@ -786,7 +791,7 @@ class DataFrame:
                 raise PySparkTypeError(
                     error_class="NOT_COLUMN_OR_STR",
                     message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
-                )           
+                )
         # Filter out the columns that don't exist in the relation
         exclude = [x for x in exclude if x in self.relation.columns]
         expr = StarExpression(exclude=exclude)

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
@@ -12,6 +12,7 @@ from typing import (
     overload,
 )
 import uuid
+from keyword import iskeyword
 
 import duckdb
 from duckdb import ColumnExpression, Expression, StarExpression
@@ -564,6 +565,11 @@ class DataFrame:
         # Provides tab-completion for column names in PySpark DataFrame
         # when accessed in bracket notation, e.g. df['<TAB>]
         return self.columns
+
+    def __dir__(self) -> List[str]:
+        out = set(super().__dir__())
+        out.update(c for c in self.columns if c.isidentifier() and not iskeyword(c))
+        return sorted(out)
 
     def join(
         self,


### PR DESCRIPTION
Adds autocompletion for column names when they are accessed on a dataframe with bracket notation (`df["<TAB>`) or dot notation (`df.<TAB>`). Tested in VS Code and Ipython:

VSCode:
<img width="585" alt="image" src="https://github.com/user-attachments/assets/411ef865-31f6-4d81-bb1f-9886d7138fdf">

<img width="649" alt="image" src="https://github.com/user-attachments/assets/36f1b87d-0f77-4d92-95cc-81a9fe9a9a0c">


IPython:


https://github.com/user-attachments/assets/6b318f70-81eb-44b5-80fd-ea8b8954885f




