### PR TITLE
Clean-up distinct statistics - add hashes cache add the Append and Vacuum layers, and remove unnecessary lock

### DIFF
--- a/src/include/duckdb/storage/statistics/column_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/column_statistics.hpp
@@ -24,7 +24,7 @@ public:
 
 	void Merge(ColumnStatistics &other);
 
-	void UpdateDistinctStatistics(Vector &v, idx_t count);
+	void UpdateDistinctStatistics(Vector &v, idx_t count, Vector &hashes);
 
 	BaseStatistics &Statistics();
 

--- a/src/include/duckdb/storage/statistics/distinct_statistics.hpp
+++ b/src/include/duckdb/storage/statistics/distinct_statistics.hpp
@@ -34,8 +34,8 @@ public:
 
 	unique_ptr<DistinctStatistics> Copy() const;
 
-	void Update(Vector &update, idx_t count, bool sample = true);
-	void Update(UnifiedVectorFormat &update_data, const LogicalType &ptype, idx_t count, bool sample = true);
+	void UpdateSample(Vector &new_data, idx_t count, Vector &hashes);
+	void Update(Vector &new_data, idx_t count, Vector &hashes);
 
 	string ToString() const;
 	idx_t GetCount() const;
@@ -46,12 +46,13 @@ public:
 	static unique_ptr<DistinctStatistics> Deserialize(Deserializer &deserializer);
 
 private:
+	void UpdateInternal(Vector &update, idx_t count, Vector &hashes);
+
+private:
 	//! For distinct statistics we sample the input to speed up insertions
 	static constexpr double BASE_SAMPLE_RATE = 0.1;
 	//! For integers, we sample more: likely to be join keys (and hashing is cheaper than, e.g., strings)
 	static constexpr double INTEGRAL_SAMPLE_RATE = 0.3;
-	//! For concurrent access
-	mutable mutex lock;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -72,6 +72,8 @@ struct TableAppendState {
 	TransactionData transaction;
 	//! Table statistics
 	TableStatistics stats;
+	//! Cached hash vector
+	Vector hashes;
 };
 
 struct ConstraintState {

--- a/src/storage/statistics/column_statistics.cpp
+++ b/src/storage/statistics/column_statistics.cpp
@@ -44,12 +44,12 @@ void ColumnStatistics::SetDistinct(unique_ptr<DistinctStatistics> distinct) {
 	this->distinct_stats = std::move(distinct);
 }
 
-void ColumnStatistics::UpdateDistinctStatistics(Vector &v, idx_t count) {
+void ColumnStatistics::UpdateDistinctStatistics(Vector &v, idx_t count, Vector &hashes) {
 	if (!distinct_stats) {
 		return;
 	}
-	// We sample for non-integral types to save cost, and because integers are more likely to be join keys
-	distinct_stats->Update(v, count);
+	// we use a sample to update the distinct statistics for performance reasons
+	distinct_stats->UpdateSample(v, count, hashes);
 }
 
 shared_ptr<ColumnStatistics> ColumnStatistics::Copy() const {

--- a/src/storage/statistics/distinct_statistics.cpp
+++ b/src/storage/statistics/distinct_statistics.cpp
@@ -15,7 +15,6 @@ DistinctStatistics::DistinctStatistics(unique_ptr<HyperLogLog> log, idx_t sample
 }
 
 unique_ptr<DistinctStatistics> DistinctStatistics::Copy() const {
-	lock_guard<mutex> guard(lock);
 	return make_uniq<DistinctStatistics>(log->Copy(), sample_count, total_count);
 }
 
@@ -25,26 +24,28 @@ void DistinctStatistics::Merge(const DistinctStatistics &other) {
 	total_count += other.total_count;
 }
 
-void DistinctStatistics::Update(Vector &v, idx_t count, bool sample) {
+void DistinctStatistics::UpdateSample(Vector &new_data, idx_t count, Vector &hashes) {
 	total_count += count;
-	if (sample) {
-		const auto original_count = count;
-		const auto sample_rate = v.GetType().IsIntegral() ? INTEGRAL_SAMPLE_RATE : BASE_SAMPLE_RATE;
-		// Sample up to 'sample_rate' of STANDARD_VECTOR_SIZE of this vector (at least 1)
-		count = MaxValue<idx_t>(LossyNumericCast<idx_t>(sample_rate * static_cast<double>(STANDARD_VECTOR_SIZE)), 1);
-		// But never more than the original count
-		count = MinValue<idx_t>(count, original_count);
-	}
+	const auto original_count = count;
+	const auto sample_rate = new_data.GetType().IsIntegral() ? INTEGRAL_SAMPLE_RATE : BASE_SAMPLE_RATE;
+	// Sample up to 'sample_rate' of STANDARD_VECTOR_SIZE of this vector (at least 1)
+	count = MaxValue<idx_t>(LossyNumericCast<idx_t>(sample_rate * static_cast<double>(STANDARD_VECTOR_SIZE)), 1);
+	// But never more than the original count
+	count = MinValue<idx_t>(count, original_count);
+
+	UpdateInternal(new_data, count, hashes);
+}
+
+void DistinctStatistics::Update(Vector &new_data, idx_t count, Vector &hashes) {
+	total_count += count;
+	UpdateInternal(new_data, count, hashes);
+}
+
+void DistinctStatistics::UpdateInternal(Vector &new_data, idx_t count, Vector &hashes) {
 	sample_count += count;
+	VectorOperations::Hash(new_data, hashes, count);
 
-	lock_guard<mutex> guard(lock);
-	Vector hash_vec(LogicalType::HASH, count);
-	VectorOperations::Hash(v, hash_vec, count);
-
-	UnifiedVectorFormat vdata;
-	v.ToUnifiedFormat(count, vdata);
-
-	log->Update(v, hash_vec, count);
+	log->Update(new_data, hashes, count);
 }
 
 string DistinctStatistics::ToString() const {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -310,7 +310,8 @@ void RowGroupCollection::Fetch(TransactionData transaction, DataChunk &result, c
 // Append
 //===--------------------------------------------------------------------===//
 TableAppendState::TableAppendState()
-    : row_group_append_state(*this), total_append_count(0), start_row_group(nullptr), transaction(0, 0) {
+    : row_group_append_state(*this), total_append_count(0), start_row_group(nullptr), transaction(0, 0),
+      hashes(LogicalType::HASH) {
 }
 
 TableAppendState::~TableAppendState() {
@@ -398,7 +399,8 @@ bool RowGroupCollection::Append(DataChunk &chunk, TableAppendState &state) {
 	state.current_row += row_t(total_append_count);
 	auto local_stats_lock = state.stats.GetLock();
 	for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
-		state.stats.GetStats(*local_stats_lock, col_idx).UpdateDistinctStatistics(chunk.data[col_idx], chunk.size());
+		auto &column_stats = state.stats.GetStats(*local_stats_lock, col_idx);
+		column_stats.UpdateDistinctStatistics(chunk.data[col_idx], chunk.size(), state.hashes);
 	}
 	return new_row_group;
 }


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/14570, bringing back the hash caches at a more appropriate layer, and removing the unnecessary locks