### PR TITLE
Adds C APIs for accessing filter pushdown and filter prune

### DIFF
--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -66,6 +66,7 @@ ORIGINAL_FUNCTION_GROUP_ORDER = [
     'table_function_bind',
     'table_function_init',
     'table_function',
+    'table_filters',
     'replacement_scans',
     'profiling_info',
     'appender',

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -244,7 +244,6 @@ typedef enum duckdb_table_filter_type {
 //! An enum over DuckDB's different table filter comparison types.
 typedef enum duckdb_table_filter_comparison_type {
 	DUCKDB_TABLE_FILTER_COMPARE_EQUAL = 0,
-	DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_START = 0,
 	DUCKDB_TABLE_FILTER_COMPARE_NOTEQUAL = 1,
 	DUCKDB_TABLE_FILTER_COMPARE_LESSTHAN = 2,
 	DUCKDB_TABLE_FILTER_COMPARE_GREATERTHAN = 3,
@@ -256,9 +255,10 @@ typedef enum duckdb_table_filter_comparison_type {
 	DUCKDB_TABLE_FILTER_COMPARE_BETWEEN = 9,
 	DUCKDB_TABLE_FILTER_COMPARE_NOT_BETWEEN = 10,
 	DUCKDB_TABLE_FILTER_COMPARE_NOT_DISTINCT_FROM = 11,
-	DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_END = 11,
 	DUCKDB_TABLE_FILTER_COMPARE_INVALID = 12
 } duckdb_table_filter_comparison_type;
+#define DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_START DUCKDB_TABLE_FILTER_COMPARE_EQUAL
+#define DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_END   DUCKDB_TABLE_FILTER_COMPARE_NOT_DISTINCT_FROM
 
 //===--------------------------------------------------------------------===//
 // General type definitions

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -3394,9 +3394,7 @@ DUCKDB_API void duckdb_table_function_set_function(duckdb_table_function table_f
 /*!
 Sets whether or not the given table function supports projection pushdown.
 
-If this is set to true, the system will provide a list of all required columns in the `init` stage through
-the `duckdb_init_get_column_count` and `duckdb_init_get_column_index` functions.
-If this is set to false (the default), the system will expect all columns to be projected.
+Set to false by default.
 
 * @param table_function The table function
 * @param pushdown True if the table function supports projection pushdown, false otherwise.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -231,6 +231,34 @@ typedef enum duckdb_error_type {
 } duckdb_error_type;
 //! An enum over DuckDB's different cast modes.
 typedef enum duckdb_cast_mode { DUCKDB_CAST_NORMAL = 0, DUCKDB_CAST_TRY = 1 } duckdb_cast_mode;
+//! An enum over DuckDB's different table filter types.
+typedef enum duckdb_table_filter_type {
+	DUCKDB_TABLE_FILTER_CONSTANT_COMPARISON = 0,
+	DUCKDB_TABLE_FILTER_IS_NULL = 1,
+	DUCKDB_TABLE_FILTER_IS_NOT_NULL = 2,
+	DUCKDB_TABLE_FILTER_CONJUNCTION_OR = 3,
+	DUCKDB_TABLE_FILTER_CONJUNCTION_AND = 4,
+	DUCKDB_TABLE_FILTER_STRUCT_EXTRACT = 5,
+	DUCKDB_TABLE_FILTER_INVALID = 6
+} duckdb_table_filter_type;
+//! An enum over DuckDB's different table filter comparison types.
+typedef enum duckdb_table_filter_comparison_type {
+	DUCKDB_TABLE_FILTER_COMPARE_EQUAL = 0,
+	DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_START = 0,
+	DUCKDB_TABLE_FILTER_COMPARE_NOTEQUAL = 1,
+	DUCKDB_TABLE_FILTER_COMPARE_LESSTHAN = 2,
+	DUCKDB_TABLE_FILTER_COMPARE_GREATERTHAN = 3,
+	DUCKDB_TABLE_FILTER_COMPARE_LESSTHANOREQUALTO = 4,
+	DUCKDB_TABLE_FILTER_COMPARE_GREATERTHANOREQUALTO = 5,
+	DUCKDB_TABLE_FILTER_COMPARE_IN = 6,
+	DUCKDB_TABLE_FILTER_COMPARE_NOT_IN = 7,
+	DUCKDB_TABLE_FILTER_COMPARE_DISTINCT_FROM = 8,
+	DUCKDB_TABLE_FILTER_COMPARE_BETWEEN = 9,
+	DUCKDB_TABLE_FILTER_COMPARE_NOT_BETWEEN = 10,
+	DUCKDB_TABLE_FILTER_COMPARE_NOT_DISTINCT_FROM = 11,
+	DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_END = 11,
+	DUCKDB_TABLE_FILTER_COMPARE_INVALID = 12
+} duckdb_table_filter_comparison_type;
 
 //===--------------------------------------------------------------------===//
 // General type definitions
@@ -637,6 +665,20 @@ typedef struct _duckdb_arrow_schema {
 typedef struct _duckdb_arrow_array {
 	void *internal_ptr;
 } * duckdb_arrow_array;
+
+//===--------------------------------------------------------------------===//
+// Table function filter types
+//===--------------------------------------------------------------------===//
+
+//! Holds a set of table filters.
+typedef struct _duckdb_table_filters {
+	void *internal_ptr;
+} * duckdb_table_filters;
+
+//! Holds a table filter.
+typedef struct _duckdb_table_filter {
+	void *internal_ptr;
+} * duckdb_table_filter;
 
 //===--------------------------------------------------------------------===//
 // DuckDB extension access
@@ -3362,6 +3404,27 @@ If this is set to false (the default), the system will expect all columns to be 
 DUCKDB_API void duckdb_table_function_supports_projection_pushdown(duckdb_table_function table_function, bool pushdown);
 
 /*!
+Sets whether or not the given table function supports filter pushdown.
+
+If this is set to true, the system will provide a list of all required columns in the `init` stage through
+the `duckdb_init_get_column_count` and `duckdb_init_get_column_index` functions.
+This is set to false by default.
+
+* @param table_function The table function
+* @param pushdown True if the table function supports filter pushdown, false otherwise.
+*/
+DUCKDB_API void duckdb_table_function_supports_filter_pushdown(duckdb_table_function table_function, bool pushdown);
+
+/*!
+Sets whether or not the given table function supports filter pruning.
+
+This is set to false by default.
+
+* @param table_function The table function
+*/
+DUCKDB_API void duckdb_table_function_supports_filter_prune(duckdb_table_function table_function, bool prune);
+
+/*!
 Register the table function object within the given connection.
 
 The function requires at least a name, a bind function, an init function and a main function.
@@ -3519,6 +3582,14 @@ Report that an error has occurred while calling init.
 */
 DUCKDB_API void duckdb_init_set_error(duckdb_init_info info, const char *error);
 
+/*!
+Returns the table filters.
+
+* @param info The info object
+* @return The table filters
+*/
+DUCKDB_API duckdb_table_filters duckdb_init_get_table_filters(duckdb_init_info info);
+
 //===--------------------------------------------------------------------===//
 // Table Function
 //===--------------------------------------------------------------------===//
@@ -3565,6 +3636,102 @@ Report that an error has occurred while executing the function.
 * @param error The error message
 */
 DUCKDB_API void duckdb_function_set_error(duckdb_function_info info, const char *error);
+
+//===--------------------------------------------------------------------===//
+// Table Filters
+//===--------------------------------------------------------------------===//
+
+/*!
+Returns the number of table filters.
+
+* @param filters The table filters
+* @return The number of table filters
+*/
+DUCKDB_API idx_t duckdb_table_filters_size(duckdb_table_filters filters);
+
+/*!
+Returns the table filter at the specified index.
+
+* @param filters The table filters
+* @param filter_index The index of the filter
+* @return The table filter
+*/
+DUCKDB_API duckdb_table_filter duckdb_table_filters_get_filter(duckdb_table_filters filters, idx_t filter_index);
+
+/*!
+Returns the type of the table filter
+
+* @param filter The table filter
+* @return The type of the table filter
+*/
+DUCKDB_API duckdb_table_filter_type duckdb_table_filter_get_type(duckdb_table_filter filter);
+
+/*!
+Returns the number of children of the table filter
+
+* @param filter The table filter
+* @return The number of children of the table filter
+*/
+DUCKDB_API idx_t duckdb_table_filter_get_children_count(duckdb_table_filter filter);
+
+/*!
+Returns the child of the table filter at the specified index
+
+* @param filter The table filter
+* @param child_index The index of the child
+* @return The child of the table filter
+*/
+DUCKDB_API duckdb_table_filter duckdb_table_filter_get_child(duckdb_table_filter filter, idx_t child_index);
+
+/*!
+Returns the comparison type of the table filter
+
+Only valid for filters of type DUCKDB_TABLE_FILTER_CONSTANT_COMPARISON
+
+* @param filter The table filter
+* @return The comparison type of the table filter
+*/
+DUCKDB_API duckdb_table_filter_comparison_type duckdb_table_filter_get_comparison_type(duckdb_table_filter filter);
+
+/*!
+Returns the constant value of the table filter
+
+Only valid for filters of type DUCKDB_TABLE_FILTER_CONSTANT_COMPARISON
+
+* @param filter The table filter
+* @return The constant value of the table filter
+*/
+DUCKDB_API duckdb_value duckdb_table_filter_get_constant(duckdb_table_filter filter);
+
+/*!
+Returns the index of the struct child in the parent struct
+
+Only valid for filters of type DUCKDB_TABLE_FILTER_STRUCT_EXTRACT
+
+* @param filter The table filter
+* @return The index of the struct child in the parent struct
+*/
+DUCKDB_API idx_t duckdb_table_filter_get_struct_child_index(duckdb_table_filter filter);
+
+/*!
+Returns the name of the struct child in the parent struct
+
+Only valid for filters of type DUCKDB_TABLE_FILTER_STRUCT_EXTRACT
+
+* @param filter The table filter
+* @return The name of the struct child in the parent struct
+*/
+DUCKDB_API const char *duckdb_table_filter_get_struct_child_name(duckdb_table_filter filter);
+
+/*!
+Returns the filter of the struct child in the parent struct
+
+Only valid for filters of type DUCKDB_TABLE_FILTER_STRUCT_EXTRACT
+
+* @param filter The table filter
+* @return The filter of the struct child in the parent struct
+*/
+DUCKDB_API duckdb_table_filter duckdb_table_filter_get_struct_child_filter(duckdb_table_filter filter);
 
 //===--------------------------------------------------------------------===//
 // Replacement Scans

--- a/src/include/duckdb/main/capi/capi_internal.hpp
+++ b/src/include/duckdb/main/capi/capi_internal.hpp
@@ -84,4 +84,9 @@ idx_t GetCTypeSize(duckdb_type type);
 duckdb_state DuckDBTranslateResult(unique_ptr<QueryResult> result, duckdb_result *out);
 bool DeprecatedMaterializeResult(duckdb_result *result);
 duckdb_statement_type StatementTypeToC(duckdb::StatementType statement_type);
+duckdb_table_filter_type TableFilterTypeToC(duckdb::TableFilterType filter_type);
+duckdb::TableFilterType TableFilterTypeFromC(duckdb_table_filter_type filter_type);
+duckdb_table_filter_comparison_type TableFilterComparisonTypeToC(duckdb::ExpressionType comparison_type);
+duckdb::ExpressionType TableFilterComparisonTypeFromC(duckdb_table_filter_comparison_type comparison_type);
+
 } // namespace duckdb

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -452,6 +452,19 @@ typedef struct {
 	duckdb_timestamp_s (*duckdb_get_timestamp_s)(duckdb_value val);
 	duckdb_timestamp_ms (*duckdb_get_timestamp_ms)(duckdb_value val);
 	duckdb_timestamp_ns (*duckdb_get_timestamp_ns)(duckdb_value val);
+	void (*duckdb_table_function_supports_filter_pushdown)(duckdb_table_function table_function, bool pushdown);
+	void (*duckdb_table_function_supports_filter_prune)(duckdb_table_function table_function, bool prune);
+	duckdb_table_filters (*duckdb_init_get_table_filters)(duckdb_init_info info);
+	idx_t (*duckdb_table_filters_size)(duckdb_table_filters filters);
+	duckdb_table_filter (*duckdb_table_filters_get_filter)(duckdb_table_filters filters, idx_t filter_index);
+	duckdb_table_filter_type (*duckdb_table_filter_get_type)(duckdb_table_filter filter);
+	idx_t (*duckdb_table_filter_get_children_count)(duckdb_table_filter filter);
+	duckdb_table_filter (*duckdb_table_filter_get_child)(duckdb_table_filter filter, idx_t child_index);
+	duckdb_table_filter_comparison_type (*duckdb_table_filter_get_comparison_type)(duckdb_table_filter filter);
+	duckdb_value (*duckdb_table_filter_get_constant)(duckdb_table_filter filter);
+	idx_t (*duckdb_table_filter_get_struct_child_index)(duckdb_table_filter filter);
+	const char *(*duckdb_table_filter_get_struct_child_name)(duckdb_table_filter filter);
+	duckdb_table_filter (*duckdb_table_filter_get_struct_child_filter)(duckdb_table_filter filter);
 } duckdb_ext_api_v0;
 
 //===--------------------------------------------------------------------===//
@@ -854,6 +867,19 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_get_timestamp_s = duckdb_get_timestamp_s;
 	result.duckdb_get_timestamp_ms = duckdb_get_timestamp_ms;
 	result.duckdb_get_timestamp_ns = duckdb_get_timestamp_ns;
+	result.duckdb_table_function_supports_filter_pushdown = duckdb_table_function_supports_filter_pushdown;
+	result.duckdb_table_function_supports_filter_prune = duckdb_table_function_supports_filter_prune;
+	result.duckdb_init_get_table_filters = duckdb_init_get_table_filters;
+	result.duckdb_table_filters_size = duckdb_table_filters_size;
+	result.duckdb_table_filters_get_filter = duckdb_table_filters_get_filter;
+	result.duckdb_table_filter_get_type = duckdb_table_filter_get_type;
+	result.duckdb_table_filter_get_children_count = duckdb_table_filter_get_children_count;
+	result.duckdb_table_filter_get_child = duckdb_table_filter_get_child;
+	result.duckdb_table_filter_get_comparison_type = duckdb_table_filter_get_comparison_type;
+	result.duckdb_table_filter_get_constant = duckdb_table_filter_get_constant;
+	result.duckdb_table_filter_get_struct_child_index = duckdb_table_filter_get_struct_child_index;
+	result.duckdb_table_filter_get_struct_child_name = duckdb_table_filter_get_struct_child_name;
+	result.duckdb_table_filter_get_struct_child_filter = duckdb_table_filter_get_struct_child_filter;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -24,6 +24,19 @@
         "duckdb_get_timestamp_tz",
         "duckdb_get_timestamp_s",
         "duckdb_get_timestamp_ms",
-        "duckdb_get_timestamp_ns"
+        "duckdb_get_timestamp_ns",
+        "duckdb_table_function_supports_filter_pushdown",
+        "duckdb_table_function_supports_filter_prune",
+        "duckdb_init_get_table_filters",
+        "duckdb_table_filters_size",
+        "duckdb_table_filters_get_filter",
+        "duckdb_table_filter_get_type",
+        "duckdb_table_filter_get_children_count",
+        "duckdb_table_filter_get_child",
+        "duckdb_table_filter_get_comparison_type",
+        "duckdb_table_filter_get_constant",
+        "duckdb_table_filter_get_struct_child_index",
+        "duckdb_table_filter_get_struct_child_name",
+        "duckdb_table_filter_get_struct_child_filter"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/table_filters.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_filters.json
@@ -1,0 +1,186 @@
+{
+    "group": "table_filters",
+    "deprecated": false,
+    "entries": [
+        {
+            "name": "duckdb_table_filters_size",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_table_filters",
+                    "name": "filters"
+                }
+            ],
+            "comment": {
+                "description": "Returns the number of table filters.\n\n",
+                "param_comments": {
+                    "filters": "The table filters"
+                },
+                "return_value": "The number of table filters"
+            }
+        },
+        {
+            "name": "duckdb_table_filters_get_filter",
+            "return_type": "duckdb_table_filter",
+            "params": [
+                {
+                    "type": "duckdb_table_filters",
+                    "name": "filters"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "filter_index"
+                }
+            ],
+            "comment": {
+                "description": "Returns the table filter at the specified index.\n\n",
+                "param_comments": {
+                    "filters": "The table filters",
+                    "filter_index": "The index of the filter"
+                },
+                "return_value": "The table filter"
+            }
+        },
+        {
+            "name": "duckdb_table_filter_get_type",
+            "return_type": "duckdb_table_filter_type",
+            "params": [
+                {
+                    "type": "duckdb_table_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the type of the table filter\n\n",
+                "param_comments": {
+                    "filter": "The table filter"
+                },
+                "return_value": "The type of the table filter"
+            }
+        },
+        {
+            "name": "duckdb_table_filter_get_children_count",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_table_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the number of children of the table filter\n\n",
+                "param_comments": {
+                    "filter": "The table filter"
+                },
+                "return_value": "The number of children of the table filter"
+            }
+        },
+        {
+            "name": "duckdb_table_filter_get_child",
+            "return_type": "duckdb_table_filter",
+            "params": [
+                {
+                    "type": "duckdb_table_filter",
+                    "name": "filter"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "child_index"
+                }
+            ],
+            "comment": {
+                "description": "Returns the child of the table filter at the specified index\n\n",
+                "param_comments": {
+                    "filter": "The table filter",
+                    "child_index": "The index of the child"
+                },
+                "return_value": "The child of the table filter"
+            }
+        },
+        {
+            "name": "duckdb_table_filter_get_comparison_type",
+            "return_type": "duckdb_table_filter_comparison_type",
+            "params": [
+                {
+                    "type": "duckdb_table_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the comparison type of the table filter\n\nOnly valid for filters of type DUCKDB_TABLE_FILTER_CONSTANT_COMPARISON\n\n",
+                "param_comments": {
+                    "filter": "The table filter"
+                },
+                "return_value": "The comparison type of the table filter"
+            }
+        },
+        {
+            "name": "duckdb_table_filter_get_constant",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_table_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the constant value of the table filter\n\nOnly valid for filters of type DUCKDB_TABLE_FILTER_CONSTANT_COMPARISON\n\n",
+                "param_comments": {
+                    "filter": "The table filter"
+                },
+                "return_value": "The constant value of the table filter"
+            }
+        },
+        {
+            "name": "duckdb_table_filter_get_struct_child_index",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_table_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the index of the struct child in the parent struct\n\nOnly valid for filters of type DUCKDB_TABLE_FILTER_STRUCT_EXTRACT\n\n",
+                "param_comments": {
+                    "filter": "The table filter"
+                },
+                "return_value": "The index of the struct child in the parent struct"
+            }
+        },
+        {
+            "name": "duckdb_table_filter_get_struct_child_name",
+            "return_type": "const char *",
+            "params": [
+                {
+                    "type": "duckdb_table_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the name of the struct child in the parent struct\n\nOnly valid for filters of type DUCKDB_TABLE_FILTER_STRUCT_EXTRACT\n\n",
+                "param_comments": {
+                    "filter": "The table filter"
+                },
+                "return_value": "The name of the struct child in the parent struct"
+            }
+        },
+        {
+            "name": "duckdb_table_filter_get_struct_child_filter",
+            "return_type": "duckdb_table_filter",
+            "params": [
+                {
+                    "type": "duckdb_table_filter",
+                    "name": "filter"
+                }
+            ],
+            "comment": {
+                "description": "Returns the filter of the struct child in the parent struct\n\nOnly valid for filters of type DUCKDB_TABLE_FILTER_STRUCT_EXTRACT\n\n",
+                "param_comments": {
+                    "filter": "The table filter"
+                },
+                "return_value": "The filter of the struct child in the parent struct"
+            }
+        }
+    ]
+}

--- a/src/include/duckdb/main/capi/header_generation/functions/table_function_init.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_function_init.json
@@ -142,6 +142,23 @@
                     "error": "The error message"
                 }
             }
+        },
+        {
+            "name": "duckdb_init_get_table_filters",
+            "return_type": "duckdb_table_filters",
+            "params": [
+                {
+                    "type": "duckdb_init_info",
+                    "name": "info"
+                }
+            ],
+            "comment": {
+                "description": "Returns the table filters.\n\n",
+                "param_comments": {
+                    "info": "The info object"
+                },
+                "return_value": "The table filters"
+            }
         }
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/table_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_functions.json
@@ -219,7 +219,7 @@
                 }
             ],
             "comment": {
-                "description": "Sets whether or not the given table function supports projection pushdown.\n\nIf this is set to true, the system will provide a list of all required columns in the `init` stage through\nthe `duckdb_init_get_column_count` and `duckdb_init_get_column_index` functions.\nIf this is set to false (the default), the system will expect all columns to be projected.\n\n",
+                "description": "Sets whether or not the given table function supports projection pushdown.\n\nSet to false by default.\n\n",
                 "param_comments": {
                     "table_function": "The table function",
                     "pushdown": "True if the table function supports projection pushdown, false otherwise."

--- a/src/include/duckdb/main/capi/header_generation/functions/table_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/table_functions.json
@@ -227,6 +227,48 @@
             }
         },
         {
+            "name": "duckdb_table_function_supports_filter_pushdown",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_table_function",
+                    "name": "table_function"
+                },
+                {
+                    "type": "bool",
+                    "name": "pushdown"
+                }
+            ],
+            "comment": {
+                "description": "Sets whether or not the given table function supports filter pushdown.\n\nIf this is set to true, the system will provide a list of all required columns in the `init` stage through\nthe `duckdb_init_get_column_count` and `duckdb_init_get_column_index` functions.\nThis is set to false by default.\n\n",
+                "param_comments": {
+                    "table_function": "The table function",
+                    "pushdown": "True if the table function supports filter pushdown, false otherwise."
+                }
+            }
+        },
+        {
+            "name": "duckdb_table_function_supports_filter_prune",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_table_function",
+                    "name": "table_function"
+                },
+                {
+                    "type": "bool",
+                    "name": "prune"
+                }
+            ],
+            "comment": {
+                "description": "Sets whether or not the given table function supports filter pruning.\n\nThis is set to false by default.\n\n",
+                "param_comments": {
+                    "table_function": "The table function",
+                    "pushdown": "True if the table function supports filter pruning, false otherwise."
+                }
+            }
+        },
+        {
             "name": "duckdb_register_table_function",
             "return_type": "duckdb_state",
             "params": [

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -228,6 +228,34 @@ typedef enum duckdb_cast_mode {
 	DUCKDB_CAST_NORMAL = 0,
 	DUCKDB_CAST_TRY = 1
 } duckdb_cast_mode;
+//! An enum over DuckDB's different table filter types.
+typedef enum duckdb_table_filter_type {
+	DUCKDB_TABLE_FILTER_CONSTANT_COMPARISON = 0,
+	DUCKDB_TABLE_FILTER_IS_NULL = 1,
+	DUCKDB_TABLE_FILTER_IS_NOT_NULL = 2,
+	DUCKDB_TABLE_FILTER_CONJUNCTION_OR = 3,
+	DUCKDB_TABLE_FILTER_CONJUNCTION_AND = 4,
+	DUCKDB_TABLE_FILTER_STRUCT_EXTRACT = 5,
+	DUCKDB_TABLE_FILTER_INVALID = 6
+} duckdb_table_filter_type;
+//! An enum over DuckDB's different table filter comparison types.
+typedef enum duckdb_table_filter_comparison_type {
+	DUCKDB_TABLE_FILTER_COMPARE_EQUAL = 0,
+	DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_START = 0,
+	DUCKDB_TABLE_FILTER_COMPARE_NOTEQUAL = 1,
+	DUCKDB_TABLE_FILTER_COMPARE_LESSTHAN = 2,
+	DUCKDB_TABLE_FILTER_COMPARE_GREATERTHAN = 3,
+	DUCKDB_TABLE_FILTER_COMPARE_LESSTHANOREQUALTO = 4,
+	DUCKDB_TABLE_FILTER_COMPARE_GREATERTHANOREQUALTO = 5,
+	DUCKDB_TABLE_FILTER_COMPARE_IN = 6,
+	DUCKDB_TABLE_FILTER_COMPARE_NOT_IN = 7,
+	DUCKDB_TABLE_FILTER_COMPARE_DISTINCT_FROM = 8,
+	DUCKDB_TABLE_FILTER_COMPARE_BETWEEN = 9,
+	DUCKDB_TABLE_FILTER_COMPARE_NOT_BETWEEN = 10,
+	DUCKDB_TABLE_FILTER_COMPARE_NOT_DISTINCT_FROM = 11,
+	DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_END = 11,
+	DUCKDB_TABLE_FILTER_COMPARE_INVALID = 12
+} duckdb_table_filter_comparison_type;
 
 //===--------------------------------------------------------------------===//
 // General type definitions
@@ -633,6 +661,20 @@ typedef struct _duckdb_arrow_schema {
 typedef struct _duckdb_arrow_array {
 	void *internal_ptr;
 } * duckdb_arrow_array;
+
+//===--------------------------------------------------------------------===//
+// Table function filter types
+//===--------------------------------------------------------------------===//
+
+//! Holds a set of table filters.
+typedef struct _duckdb_table_filters {
+	void *internal_ptr;
+} * duckdb_table_filters;
+
+//! Holds a table filter.
+typedef struct _duckdb_table_filter {
+	void *internal_ptr;
+} * duckdb_table_filter;
 
 //===--------------------------------------------------------------------===//
 // DuckDB extension access

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -241,7 +241,6 @@ typedef enum duckdb_table_filter_type {
 //! An enum over DuckDB's different table filter comparison types.
 typedef enum duckdb_table_filter_comparison_type {
 	DUCKDB_TABLE_FILTER_COMPARE_EQUAL = 0,
-	DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_START = 0,
 	DUCKDB_TABLE_FILTER_COMPARE_NOTEQUAL = 1,
 	DUCKDB_TABLE_FILTER_COMPARE_LESSTHAN = 2,
 	DUCKDB_TABLE_FILTER_COMPARE_GREATERTHAN = 3,
@@ -253,9 +252,10 @@ typedef enum duckdb_table_filter_comparison_type {
 	DUCKDB_TABLE_FILTER_COMPARE_BETWEEN = 9,
 	DUCKDB_TABLE_FILTER_COMPARE_NOT_BETWEEN = 10,
 	DUCKDB_TABLE_FILTER_COMPARE_NOT_DISTINCT_FROM = 11,
-	DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_END = 11,
 	DUCKDB_TABLE_FILTER_COMPARE_INVALID = 12
 } duckdb_table_filter_comparison_type;
+#define DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_START DUCKDB_TABLE_FILTER_COMPARE_EQUAL
+#define DUCKDB_TABLE_FILTER_COMPARE_BOUNDARY_END DUCKDB_TABLE_FILTER_COMPARE_NOT_DISTINCT_FROM
 
 //===--------------------------------------------------------------------===//
 // General type definitions

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -516,6 +516,19 @@ typedef struct {
 	duckdb_timestamp_s (*duckdb_get_timestamp_s)(duckdb_value val);
 	duckdb_timestamp_ms (*duckdb_get_timestamp_ms)(duckdb_value val);
 	duckdb_timestamp_ns (*duckdb_get_timestamp_ns)(duckdb_value val);
+	void (*duckdb_table_function_supports_filter_pushdown)(duckdb_table_function table_function, bool pushdown);
+	void (*duckdb_table_function_supports_filter_prune)(duckdb_table_function table_function, bool prune);
+	duckdb_table_filters (*duckdb_init_get_table_filters)(duckdb_init_info info);
+	idx_t (*duckdb_table_filters_size)(duckdb_table_filters filters);
+	duckdb_table_filter (*duckdb_table_filters_get_filter)(duckdb_table_filters filters, idx_t filter_index);
+	duckdb_table_filter_type (*duckdb_table_filter_get_type)(duckdb_table_filter filter);
+	idx_t (*duckdb_table_filter_get_children_count)(duckdb_table_filter filter);
+	duckdb_table_filter (*duckdb_table_filter_get_child)(duckdb_table_filter filter, idx_t child_index);
+	duckdb_table_filter_comparison_type (*duckdb_table_filter_get_comparison_type)(duckdb_table_filter filter);
+	duckdb_value (*duckdb_table_filter_get_constant)(duckdb_table_filter filter);
+	idx_t (*duckdb_table_filter_get_struct_child_index)(duckdb_table_filter filter);
+	const char *(*duckdb_table_filter_get_struct_child_name)(duckdb_table_filter filter);
+	duckdb_table_filter (*duckdb_table_filter_get_struct_child_filter)(duckdb_table_filter filter);
 #endif
 
 } duckdb_ext_api_v0;
@@ -898,30 +911,43 @@ typedef struct {
 #define duckdb_destroy_cast_function                duckdb_ext_api.duckdb_destroy_cast_function
 
 // Version dev
-#define duckdb_is_finite_timestamp_s             duckdb_ext_api.duckdb_is_finite_timestamp_s
-#define duckdb_is_finite_timestamp_ms            duckdb_ext_api.duckdb_is_finite_timestamp_ms
-#define duckdb_is_finite_timestamp_ns            duckdb_ext_api.duckdb_is_finite_timestamp_ns
-#define duckdb_param_logical_type                duckdb_ext_api.duckdb_param_logical_type
-#define duckdb_create_timestamp_tz               duckdb_ext_api.duckdb_create_timestamp_tz
-#define duckdb_create_timestamp_s                duckdb_ext_api.duckdb_create_timestamp_s
-#define duckdb_create_timestamp_ms               duckdb_ext_api.duckdb_create_timestamp_ms
-#define duckdb_create_timestamp_ns               duckdb_ext_api.duckdb_create_timestamp_ns
-#define duckdb_get_timestamp_tz                  duckdb_ext_api.duckdb_get_timestamp_tz
-#define duckdb_get_timestamp_s                   duckdb_ext_api.duckdb_get_timestamp_s
-#define duckdb_get_timestamp_ms                  duckdb_ext_api.duckdb_get_timestamp_ms
-#define duckdb_get_timestamp_ns                  duckdb_ext_api.duckdb_get_timestamp_ns
-#define duckdb_is_null_value                     duckdb_ext_api.duckdb_is_null_value
-#define duckdb_create_null_value                 duckdb_ext_api.duckdb_create_null_value
-#define duckdb_get_list_size                     duckdb_ext_api.duckdb_get_list_size
-#define duckdb_get_list_child                    duckdb_ext_api.duckdb_get_list_child
-#define duckdb_create_enum_value                 duckdb_ext_api.duckdb_create_enum_value
-#define duckdb_get_enum_value                    duckdb_ext_api.duckdb_get_enum_value
-#define duckdb_get_struct_child                  duckdb_ext_api.duckdb_get_struct_child
-#define duckdb_appender_create_ext               duckdb_ext_api.duckdb_appender_create_ext
-#define duckdb_appender_add_column               duckdb_ext_api.duckdb_appender_add_column
-#define duckdb_appender_clear_columns            duckdb_ext_api.duckdb_appender_clear_columns
-#define duckdb_table_description_create_ext      duckdb_ext_api.duckdb_table_description_create_ext
-#define duckdb_table_description_get_column_name duckdb_ext_api.duckdb_table_description_get_column_name
+#define duckdb_is_finite_timestamp_s                   duckdb_ext_api.duckdb_is_finite_timestamp_s
+#define duckdb_is_finite_timestamp_ms                  duckdb_ext_api.duckdb_is_finite_timestamp_ms
+#define duckdb_is_finite_timestamp_ns                  duckdb_ext_api.duckdb_is_finite_timestamp_ns
+#define duckdb_param_logical_type                      duckdb_ext_api.duckdb_param_logical_type
+#define duckdb_create_timestamp_tz                     duckdb_ext_api.duckdb_create_timestamp_tz
+#define duckdb_create_timestamp_s                      duckdb_ext_api.duckdb_create_timestamp_s
+#define duckdb_create_timestamp_ms                     duckdb_ext_api.duckdb_create_timestamp_ms
+#define duckdb_create_timestamp_ns                     duckdb_ext_api.duckdb_create_timestamp_ns
+#define duckdb_get_timestamp_tz                        duckdb_ext_api.duckdb_get_timestamp_tz
+#define duckdb_get_timestamp_s                         duckdb_ext_api.duckdb_get_timestamp_s
+#define duckdb_get_timestamp_ms                        duckdb_ext_api.duckdb_get_timestamp_ms
+#define duckdb_get_timestamp_ns                        duckdb_ext_api.duckdb_get_timestamp_ns
+#define duckdb_is_null_value                           duckdb_ext_api.duckdb_is_null_value
+#define duckdb_create_null_value                       duckdb_ext_api.duckdb_create_null_value
+#define duckdb_get_list_size                           duckdb_ext_api.duckdb_get_list_size
+#define duckdb_get_list_child                          duckdb_ext_api.duckdb_get_list_child
+#define duckdb_create_enum_value                       duckdb_ext_api.duckdb_create_enum_value
+#define duckdb_get_enum_value                          duckdb_ext_api.duckdb_get_enum_value
+#define duckdb_get_struct_child                        duckdb_ext_api.duckdb_get_struct_child
+#define duckdb_table_function_supports_filter_pushdown duckdb_ext_api.duckdb_table_function_supports_filter_pushdown
+#define duckdb_table_function_supports_filter_prune    duckdb_ext_api.duckdb_table_function_supports_filter_prune
+#define duckdb_init_get_table_filters                  duckdb_ext_api.duckdb_init_get_table_filters
+#define duckdb_table_filters_size                      duckdb_ext_api.duckdb_table_filters_size
+#define duckdb_table_filters_get_filter                duckdb_ext_api.duckdb_table_filters_get_filter
+#define duckdb_table_filter_get_type                   duckdb_ext_api.duckdb_table_filter_get_type
+#define duckdb_table_filter_get_children_count         duckdb_ext_api.duckdb_table_filter_get_children_count
+#define duckdb_table_filter_get_child                  duckdb_ext_api.duckdb_table_filter_get_child
+#define duckdb_table_filter_get_comparison_type        duckdb_ext_api.duckdb_table_filter_get_comparison_type
+#define duckdb_table_filter_get_constant               duckdb_ext_api.duckdb_table_filter_get_constant
+#define duckdb_table_filter_get_struct_child_index     duckdb_ext_api.duckdb_table_filter_get_struct_child_index
+#define duckdb_table_filter_get_struct_child_name      duckdb_ext_api.duckdb_table_filter_get_struct_child_name
+#define duckdb_table_filter_get_struct_child_filter    duckdb_ext_api.duckdb_table_filter_get_struct_child_filter
+#define duckdb_appender_create_ext                     duckdb_ext_api.duckdb_appender_create_ext
+#define duckdb_appender_add_column                     duckdb_ext_api.duckdb_appender_add_column
+#define duckdb_appender_clear_columns                  duckdb_ext_api.duckdb_appender_clear_columns
+#define duckdb_table_description_create_ext            duckdb_ext_api.duckdb_table_description_create_ext
+#define duckdb_table_description_get_column_name       duckdb_ext_api.duckdb_table_description_get_column_name
 
 //===--------------------------------------------------------------------===//
 // Struct Global Macros

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -280,6 +280,108 @@ duckdb_statement_type StatementTypeToC(duckdb::StatementType statement_type) {
 	}
 }
 
+duckdb_table_filter_type TableFilterTypeToC(duckdb::TableFilterType filter_type) {
+	switch (filter_type) {
+	case duckdb::TableFilterType::CONSTANT_COMPARISON:
+		return DUCKDB_TABLE_FILTER_CONSTANT_COMPARISON;
+	case duckdb::TableFilterType::IS_NULL:
+		return DUCKDB_TABLE_FILTER_IS_NULL;
+	case duckdb::TableFilterType::IS_NOT_NULL:
+		return DUCKDB_TABLE_FILTER_IS_NOT_NULL;
+	case duckdb::TableFilterType::CONJUNCTION_OR:
+		return DUCKDB_TABLE_FILTER_CONJUNCTION_OR;
+	case duckdb::TableFilterType::CONJUNCTION_AND:
+		return DUCKDB_TABLE_FILTER_CONJUNCTION_AND;
+	case duckdb::TableFilterType::STRUCT_EXTRACT:
+		return DUCKDB_TABLE_FILTER_STRUCT_EXTRACT;
+	default:
+		return DUCKDB_TABLE_FILTER_INVALID;
+	}
+}
+
+duckdb::TableFilterType TableFilterTypeFromC(duckdb_table_filter_type filter_type) {
+	switch (filter_type) {
+	case DUCKDB_TABLE_FILTER_CONSTANT_COMPARISON:
+		return duckdb::TableFilterType::CONSTANT_COMPARISON;
+	case DUCKDB_TABLE_FILTER_IS_NULL:
+		return duckdb::TableFilterType::IS_NULL;
+	case DUCKDB_TABLE_FILTER_IS_NOT_NULL:
+		return duckdb::TableFilterType::IS_NOT_NULL;
+	case DUCKDB_TABLE_FILTER_CONJUNCTION_OR:
+		return duckdb::TableFilterType::CONJUNCTION_OR;
+	case DUCKDB_TABLE_FILTER_CONJUNCTION_AND:
+		return duckdb::TableFilterType::CONJUNCTION_AND;
+	case DUCKDB_TABLE_FILTER_STRUCT_EXTRACT:
+		return duckdb::TableFilterType::STRUCT_EXTRACT;
+	default: // LCOV_EXCL_START
+		D_ASSERT(0);
+		return duckdb::TableFilterType::CONSTANT_COMPARISON;
+	} // LCOV_EXCL_STOP
+}
+
+duckdb_table_filter_comparison_type TableFilterComparisonTypeToC(duckdb::ExpressionType comparison_type) {
+	switch (comparison_type) {
+	case duckdb::ExpressionType::COMPARE_EQUAL:
+		return DUCKDB_TABLE_FILTER_COMPARE_EQUAL;
+	case duckdb::ExpressionType::COMPARE_NOTEQUAL:
+		return DUCKDB_TABLE_FILTER_COMPARE_NOTEQUAL;
+	case duckdb::ExpressionType::COMPARE_LESSTHAN:
+		return DUCKDB_TABLE_FILTER_COMPARE_LESSTHAN;
+	case duckdb::ExpressionType::COMPARE_GREATERTHAN:
+		return DUCKDB_TABLE_FILTER_COMPARE_GREATERTHAN;
+	case duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return DUCKDB_TABLE_FILTER_COMPARE_LESSTHANOREQUALTO;
+	case duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return DUCKDB_TABLE_FILTER_COMPARE_GREATERTHANOREQUALTO;
+	case duckdb::ExpressionType::COMPARE_IN:
+		return DUCKDB_TABLE_FILTER_COMPARE_IN;
+	case duckdb::ExpressionType::COMPARE_NOT_IN:
+		return DUCKDB_TABLE_FILTER_COMPARE_NOT_IN;
+	case duckdb::ExpressionType::COMPARE_DISTINCT_FROM:
+		return DUCKDB_TABLE_FILTER_COMPARE_DISTINCT_FROM;
+	case duckdb::ExpressionType::COMPARE_BETWEEN:
+		return DUCKDB_TABLE_FILTER_COMPARE_BETWEEN;
+	case duckdb::ExpressionType::COMPARE_NOT_BETWEEN:
+		return DUCKDB_TABLE_FILTER_COMPARE_NOT_BETWEEN;
+	case duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		return DUCKDB_TABLE_FILTER_COMPARE_NOT_DISTINCT_FROM;
+	default:
+		return DUCKDB_TABLE_FILTER_COMPARE_INVALID;
+	}
+}
+
+duckdb::ExpressionType TableFilterComparisonTypeFromC(duckdb_table_filter_comparison_type comparison_type) {
+	switch (comparison_type) {
+	case DUCKDB_TABLE_FILTER_COMPARE_EQUAL:
+		return duckdb::ExpressionType::COMPARE_EQUAL;
+	case DUCKDB_TABLE_FILTER_COMPARE_NOTEQUAL:
+		return duckdb::ExpressionType::COMPARE_NOTEQUAL;
+	case DUCKDB_TABLE_FILTER_COMPARE_LESSTHAN:
+		return duckdb::ExpressionType::COMPARE_LESSTHAN;
+	case DUCKDB_TABLE_FILTER_COMPARE_GREATERTHAN:
+		return duckdb::ExpressionType::COMPARE_GREATERTHAN;
+	case DUCKDB_TABLE_FILTER_COMPARE_LESSTHANOREQUALTO:
+		return duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO;
+	case DUCKDB_TABLE_FILTER_COMPARE_GREATERTHANOREQUALTO:
+		return duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+	case DUCKDB_TABLE_FILTER_COMPARE_IN:
+		return duckdb::ExpressionType::COMPARE_IN;
+	case DUCKDB_TABLE_FILTER_COMPARE_NOT_IN:
+		return duckdb::ExpressionType::COMPARE_NOT_IN;
+	case DUCKDB_TABLE_FILTER_COMPARE_DISTINCT_FROM:
+		return duckdb::ExpressionType::COMPARE_DISTINCT_FROM;
+	case DUCKDB_TABLE_FILTER_COMPARE_BETWEEN:
+		return duckdb::ExpressionType::COMPARE_BETWEEN;
+	case DUCKDB_TABLE_FILTER_COMPARE_NOT_BETWEEN:
+		return duckdb::ExpressionType::COMPARE_NOT_BETWEEN;
+	case DUCKDB_TABLE_FILTER_COMPARE_NOT_DISTINCT_FROM:
+		return duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+	default: // LCOV_EXCL_START
+		D_ASSERT(0);
+		return duckdb::ExpressionType::INVALID;
+	} // LCOV_EXCL_STOP
+}
+
 } // namespace duckdb
 
 void *duckdb_malloc(size_t size) {


### PR DESCRIPTION
For Table functions

- Added a new C-API section called `table_filters`
- Defined necessary enums and helper functions
- Defined `duckdb_table_filters` and `duckdb_table_filter` types for the C API
- Added tests for the new API functions

API functions added:
```
"duckdb_table_function_supports_filter_pushdown",
"duckdb_table_function_supports_filter_prune",
"duckdb_init_get_table_filters",
"duckdb_table_filters_size",
"duckdb_table_filters_get_filter",
"duckdb_table_filter_get_type",
"duckdb_table_filter_get_children_count",
"duckdb_table_filter_get_child",
"duckdb_table_filter_get_comparison_type",
"duckdb_table_filter_get_constant",
"duckdb_table_filter_get_struct_child_index",
"duckdb_table_filter_get_struct_child_name",
"duckdb_table_filter_get_struct_child_filter"
```
