### PR TITLE
Cas strong

### DIFF
--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -247,8 +247,8 @@ static void MallocTrim(idx_t pad) {
 	if (current_timestamp_ms - last_trim_timestamp_ms < TRIM_INTERVAL_MS) {
 		return; // We trimmed less than TRIM_INTERVAL_MS ago
 	}
-	if (!LAST_TRIM_TIMESTAMP_MS.atomic_compare_exchange_strong(last_trim_timestamp_ms, current_timestamp_ms,
-	                                                           std::memory_order_acquire, std::memory_order_relaxed)) {
+	if (!LAST_TRIM_TIMESTAMP_MS.compare_exchange_strong(last_trim_timestamp_ms, current_timestamp_ms,
+	                                                    std::memory_order_acquire, std::memory_order_relaxed)) {
 		return; // Another thread has updated LAST_TRIM_TIMESTAMP_MS since we loaded it
 	}
 

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -242,12 +242,13 @@ static void MallocTrim(idx_t pad) {
 	static atomic<int64_t> LAST_TRIM_TIMESTAMP_MS {0};
 
 	int64_t last_trim_timestamp_ms = LAST_TRIM_TIMESTAMP_MS.load();
-	const int64_t current_timestamp_ms = Timestamp::GetEpochMs(Timestamp::GetCurrentTimestamp());
+	int64_t current_timestamp_ms = Timestamp::GetEpochMs(Timestamp::GetCurrentTimestamp());
 
 	if (current_timestamp_ms - last_trim_timestamp_ms < TRIM_INTERVAL_MS) {
 		return; // We trimmed less than TRIM_INTERVAL_MS ago
 	}
-	if (!std::atomic_compare_exchange_weak(&LAST_TRIM_TIMESTAMP_MS, &last_trim_timestamp_ms, current_timestamp_ms)) {
+	if (!LAST_TRIM_TIMESTAMP_MS.atomic_compare_exchange_strong(last_trim_timestamp_ms, current_timestamp_ms,
+	                                                           std::memory_order_acquire, std::memory_order_relaxed)) {
 		return; // Another thread has updated LAST_TRIM_TIMESTAMP_MS since we loaded it
 	}
 

--- a/src/include/duckdb/common/atomic.hpp
+++ b/src/include/duckdb/common/atomic.hpp
@@ -11,5 +11,17 @@
 #include <atomic>
 
 namespace duckdb {
+
 using std::atomic;
-}
+
+//! NOTE: When repeatedly trying to atomically set a value in a loop, you can use as the loop condition:
+//! * std::atomic_compare_exchange_weak
+//! * std::atomic::compare_exchange_weak
+//! If not used as a loop condition, use:
+//! * std::atomic_compare_exchange_strong
+//! * std::atomic::compare_exchange_strong
+//! If this is not done correctly, we may get correctness issues when using older compiler versions (see: issue #14389)
+//! Performance may be optimized using std::memory_order, but NOT at the cost of correctness.
+//! For correct examples of this, see concurrentqueue.h
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/ht_entry.hpp
+++ b/src/include/duckdb/execution/ht_entry.hpp
@@ -21,10 +21,10 @@ namespace duckdb {
 */
 struct ht_entry_t { // NOLINT
 public:
-	//! Upper 12 bits are salt
-	static constexpr const hash_t SALT_MASK = 0xFFF0000000000000;
-	//! Lower 52 bits are the pointer
-	static constexpr const hash_t POINTER_MASK = 0x000FFFFFFFFFFFFF;
+	//! Upper 16 bits are salt
+	static constexpr const hash_t SALT_MASK = 0xFFFF000000000000;
+	//! Lower 48 bits are the pointer
+	static constexpr const hash_t POINTER_MASK = 0x0000FFFFFFFFFFFF;
 
 	explicit inline ht_entry_t(hash_t value_p) noexcept : value(value_p) {
 	}

--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -50,9 +50,9 @@ public:
 	~MetadataManager();
 
 	MetadataHandle AllocateHandle();
-	MetadataHandle Pin(MetadataPointer pointer);
+	MetadataHandle Pin(const MetadataPointer &pointer);
 
-	MetaBlockPointer GetDiskPointer(MetadataPointer pointer, uint32_t offset = 0);
+	MetaBlockPointer GetDiskPointer(const MetadataPointer &pointer, uint32_t offset = 0);
 	MetadataPointer FromDiskPointer(MetaBlockPointer pointer);
 	MetadataPointer RegisterDiskPointer(MetaBlockPointer pointer);
 

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -50,7 +50,7 @@ MetadataHandle MetadataManager::AllocateHandle() {
 	return Pin(pointer);
 }
 
-MetadataHandle MetadataManager::Pin(MetadataPointer pointer) {
+MetadataHandle MetadataManager::Pin(const MetadataPointer &pointer) {
 	D_ASSERT(pointer.index < METADATA_BLOCK_COUNT);
 	auto &block = blocks[UnsafeNumericCast<int64_t>(pointer.block_index)];
 
@@ -111,7 +111,7 @@ void MetadataManager::AddAndRegisterBlock(MetadataBlock block) {
 	AddBlock(std::move(block), true);
 }
 
-MetaBlockPointer MetadataManager::GetDiskPointer(MetadataPointer pointer, uint32_t offset) {
+MetaBlockPointer MetadataManager::GetDiskPointer(const MetadataPointer &pointer, uint32_t offset) {
 	idx_t block_pointer = idx_t(pointer.block_index);
 	block_pointer |= idx_t(pointer.index) << 56ULL;
 	return MetaBlockPointer(block_pointer, offset);


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/14389 and reverts #14173 (bringing back the salt).

Although I don't think this should affect correctness (from cppreference.com):
> When a compare-and-exchange is in a loop, the weak version will yield better performance on some platforms. When a weak compare-and-exchange would require a loop and a strong one would not, the strong one is preferable.

This gave us correctness issues with older GCC versions (< 10.x) on ARM64. We rarely use CAS operations, so this isn't a big diff. I've added `std::memory_order` to improve the performance (copying the usage in `concurrentqueue.h`). Since it is difficult to programmatically disable "incorrect" usage, I've added a comment in `atomic.hpp` that describes the issue.

I've also changed usage of `MetadataPointer` to a const reference since older GCC versions were throwing a warning.