### PR TITLE
Test fixes for new arrow release

### DIFF
--- a/tools/pythonpkg/tests/arrow_canonical_extensions.py
+++ b/tools/pythonpkg/tests/arrow_canonical_extensions.py
@@ -3,38 +3,6 @@ import pytest
 pa = pytest.importorskip("pyarrow")
 
 
-class UuidType(pa.ExtensionType):
-    def __init__(self):
-        pa.ExtensionType.__init__(self, pa.binary(16), "arrow.uuid")
-
-    def __arrow_ext_serialize__(self):
-        # since we don't have a parameterized type, we don't need extra
-        # metadata to be deserialized
-        return b''
-
-    @classmethod
-    def __arrow_ext_deserialize__(self, storage_type, serialized):
-        # return an instance of this subclass given the serialized
-        # metadata.
-        return UuidType()
-
-
-class JSONType(pa.ExtensionType):
-    def __init__(self):
-        pa.ExtensionType.__init__(self, pa.string(), "arrow.json")
-
-    def __arrow_ext_serialize__(self):
-        # since we don't have a parameterized type, we don't need extra
-        # metadata to be deserialized
-        return b''
-
-    @classmethod
-    def __arrow_ext_deserialize__(self, storage_type, serialized):
-        # return an instance of this subclass given the serialized
-        # metadata.
-        return JSONType()
-
-
 class UHugeIntType(pa.ExtensionType):
     def __init__(self):
         pa.ExtensionType.__init__(self, pa.binary(16), "duckdb.uhugeint")

--- a/tools/pythonpkg/tests/fast/arrow/test_canonical_extensions.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_canonical_extensions.py
@@ -5,9 +5,10 @@ import json
 from uuid import UUID
 import datetime
 
-pa = pytest.importorskip('pyarrow')
+pa = pytest.importorskip('pyarrow', '18.0.0')
 
 from arrow_canonical_extensions import UHugeIntType, HugeIntType, VarIntType
+
 
 """
     These fixtures make sure that the extension_type is registered at the start of the function,

--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -8,13 +8,15 @@ pd = pytest.importorskip("pandas")
 
 
 def using_table(con, to_scan, object_name):
-    exec(f"{object_name} = to_scan")
-    return con.table(object_name)
+    local_scope = {'con': con, object_name: to_scan, 'object_name': object_name}
+    exec(f"result = con.table(object_name)", globals(), local_scope)
+    return local_scope["result"]
 
 
 def using_sql(con, to_scan, object_name):
-    exec(f"{object_name} = to_scan")
-    return con.sql(f"select * from to_scan")
+    local_scope = {'con': con, object_name: to_scan, 'object_name': object_name}
+    exec(f"result = con.sql('select * from \"{object_name}\"')", globals(), local_scope)
+    return local_scope["result"]
 
 
 # Fetch methods

--- a/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
+++ b/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
@@ -2,7 +2,7 @@ import duckdb
 import pytest
 
 pd = pytest.importorskip("pandas")
-pa = pytest.importorskip("pyarrow")
+pa = pytest.importorskip('pyarrow', '18.0.0')
 from typing import Union
 import pyarrow.compute as pc
 import uuid

--- a/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
+++ b/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
@@ -12,7 +12,6 @@ import cmath
 from typing import NamedTuple, Any, List
 
 from duckdb.typing import *
-from arrow_canonical_extensions import UuidType
 
 
 class Candidate(NamedTuple):
@@ -164,8 +163,6 @@ class TestUDFNullFiltering(object):
     )
     @pytest.mark.parametrize('udf_type', ['arrow', 'native'])
     def test_null_filtering(self, duckdb_cursor, table_data: dict, test_type: Candidate, udf_type):
-        if test_type.type == UUID:
-            pa.register_extension_type(UuidType())
         null_count = sum([1 for x in list(zip(*table_data.values())) if any([y == None for y in x])])
         row_count = len(table_data)
         table_data = {
@@ -202,8 +199,6 @@ class TestUDFNullFiltering(object):
         assert len(result) == row_count
         # Only the non-null tuples should have been seen by the UDF
         assert my_func.count == row_count - null_count
-        if test_type.type == UUID:
-            pa.unregister_extension_type("arrow.uuid")
 
     @pytest.mark.parametrize(
         'table_data',

--- a/tools/pythonpkg/tests/fast/udf/test_scalar.py
+++ b/tools/pythonpkg/tests/fast/udf/test_scalar.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 pd = pytest.importorskip("pandas")
-pa = pytest.importorskip("pyarrow")
+pa = pytest.importorskip('pyarrow', '18.0.0')
 from typing import Union
 import pyarrow.compute as pc
 import uuid

--- a/tools/pythonpkg/tests/fast/udf/test_scalar.py
+++ b/tools/pythonpkg/tests/fast/udf/test_scalar.py
@@ -13,7 +13,7 @@ import cmath
 
 from duckdb.typing import *
 
-from arrow_canonical_extensions import UuidType, HugeIntType
+from arrow_canonical_extensions import HugeIntType
 
 
 def make_annotated_function(type):
@@ -70,9 +70,7 @@ class TestScalarUDF(object):
 
         con = duckdb.connect()
         con.create_function('test', test_function, type=function_type)
-        if type == UUID:
-            pa.register_extension_type(UuidType())
-        elif type == HUGEINT:
+        if type == HUGEINT:
             pa.register_extension_type(HugeIntType())
         # Single value
         res = con.execute(f"select test(?::{str(type)})", [value]).fetchall()
@@ -123,9 +121,7 @@ class TestScalarUDF(object):
         table_rel = con.table('tbl')
         res = table_rel.project('test(x)').fetchall()
         assert res[0][0] == value
-        if type == UUID:
-            pa.unregister_extension_type("arrow.uuid")
-        elif type == HUGEINT:
+        if type == HUGEINT:
             pa.unregister_extension_type("duckdb.hugeint")
 
     @pytest.mark.parametrize('udf_type', ['arrow', 'native'])


### PR DESCRIPTION
PyArrow 18 comes with the canonical extensions pre-registered. Hence, this new behavior breaks a lot of our test suit that would take care of registering/ensuring correctness. This PR fixes our CI by adjusting our tests.