### PR TITLE
Helper c-api functions for maps and unions (**)

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2938,7 +2938,16 @@ The resulting vector is valid as long as the parent vector is valid.
 * @param tag The tag of the member
 * @return The member vector
 */
-DUCKDB_API duckdb_vector duckdb_union_vector_get_member(duckdb_vector vector, idx_t tag);
+DUCKDB_API duckdb_vector duckdb_union_vector_get_member(duckdb_vector vector, uint8_t tag);
+
+/*!
+Sets the tag of a union vector at the specified index.
+
+* @param vector The vector to alter
+* @param index The row position in the vector to assign the tag to
+* @param tag The tag
+*/
+DUCKDB_API void duckdb_union_vector_set_tag(duckdb_vector vector, idx_t index, uint8_t tag);
 
 //===--------------------------------------------------------------------===//
 // Validity Mask Functions

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2899,6 +2899,47 @@ The resulting vector has the size of the parent vector multiplied by the array s
 */
 DUCKDB_API duckdb_vector duckdb_array_vector_get_child(duckdb_vector vector);
 
+/*!
+Retrieves the keys vector of a map vector.
+
+The resulting vector is valid as long as the parent vector is valid.
+
+* @param vector The vector
+* @return The keys vector
+*/
+DUCKDB_API duckdb_vector duckdb_map_vector_get_keys(duckdb_vector vector);
+
+/*!
+Retrieves the values vector of a map vector.
+
+The resulting vector is valid as long as the parent vector is valid.
+
+* @param vector The vector
+* @return The values vector
+*/
+DUCKDB_API duckdb_vector duckdb_map_vector_get_values(duckdb_vector vector);
+
+/*!
+Retrieves the tags vector of a union vector.
+
+The resulting vector is valid as long as the parent vector is valid.
+
+* @param vector The vector
+* @return The tags vector
+*/
+DUCKDB_API duckdb_vector duckdb_union_vector_get_tags(duckdb_vector vector);
+
+/*!
+Retrieves the member vector of a union vector.
+
+The resulting vector is valid as long as the parent vector is valid.
+
+* @param vector The vector
+* @param tag The tag of the member
+* @return The member vector
+*/
+DUCKDB_API duckdb_vector duckdb_union_vector_get_member(duckdb_vector vector, idx_t tag);
+
 //===--------------------------------------------------------------------===//
 // Validity Mask Functions
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -439,6 +439,7 @@ typedef struct {
 	duckdb_value (*duckdb_create_enum_value)(duckdb_logical_type type, uint64_t value);
 	uint64_t (*duckdb_get_enum_value)(duckdb_value value);
 	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
+<<<<<<< HEAD
 	duckdb_state (*duckdb_appender_add_column)(duckdb_appender appender, const char *name);
 	duckdb_state (*duckdb_appender_clear_columns)(duckdb_appender appender);
 	bool (*duckdb_is_finite_timestamp_s)(duckdb_timestamp_s ts);
@@ -452,6 +453,12 @@ typedef struct {
 	duckdb_timestamp_s (*duckdb_get_timestamp_s)(duckdb_value val);
 	duckdb_timestamp_ms (*duckdb_get_timestamp_ms)(duckdb_value val);
 	duckdb_timestamp_ns (*duckdb_get_timestamp_ns)(duckdb_value val);
+=======
+	duckdb_vector (*duckdb_map_vector_get_keys)(duckdb_vector vector);
+	duckdb_vector (*duckdb_map_vector_get_values)(duckdb_vector vector);
+	duckdb_vector (*duckdb_union_vector_get_tags)(duckdb_vector vector);
+	duckdb_vector (*duckdb_union_vector_get_member)(duckdb_vector vector, idx_t tag);
+>>>>>>> a447060e49 (merged with main)
 } duckdb_ext_api_v0;
 
 //===--------------------------------------------------------------------===//
@@ -841,6 +848,7 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_create_enum_value = duckdb_create_enum_value;
 	result.duckdb_get_enum_value = duckdb_get_enum_value;
 	result.duckdb_get_struct_child = duckdb_get_struct_child;
+<<<<<<< HEAD
 	result.duckdb_appender_add_column = duckdb_appender_add_column;
 	result.duckdb_appender_clear_columns = duckdb_appender_clear_columns;
 	result.duckdb_is_finite_timestamp_s = duckdb_is_finite_timestamp_s;
@@ -854,6 +862,12 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_get_timestamp_s = duckdb_get_timestamp_s;
 	result.duckdb_get_timestamp_ms = duckdb_get_timestamp_ms;
 	result.duckdb_get_timestamp_ns = duckdb_get_timestamp_ns;
+=======
+	result.duckdb_map_vector_get_keys = duckdb_map_vector_get_keys;
+	result.duckdb_map_vector_get_values = duckdb_map_vector_get_values;
+	result.duckdb_union_vector_get_tags = duckdb_union_vector_get_tags;
+	result.duckdb_union_vector_get_member = duckdb_union_vector_get_member;
+>>>>>>> a447060e49 (merged with main)
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -439,7 +439,6 @@ typedef struct {
 	duckdb_value (*duckdb_create_enum_value)(duckdb_logical_type type, uint64_t value);
 	uint64_t (*duckdb_get_enum_value)(duckdb_value value);
 	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
-<<<<<<< HEAD
 	duckdb_state (*duckdb_appender_add_column)(duckdb_appender appender, const char *name);
 	duckdb_state (*duckdb_appender_clear_columns)(duckdb_appender appender);
 	bool (*duckdb_is_finite_timestamp_s)(duckdb_timestamp_s ts);
@@ -453,12 +452,11 @@ typedef struct {
 	duckdb_timestamp_s (*duckdb_get_timestamp_s)(duckdb_value val);
 	duckdb_timestamp_ms (*duckdb_get_timestamp_ms)(duckdb_value val);
 	duckdb_timestamp_ns (*duckdb_get_timestamp_ns)(duckdb_value val);
-=======
 	duckdb_vector (*duckdb_map_vector_get_keys)(duckdb_vector vector);
 	duckdb_vector (*duckdb_map_vector_get_values)(duckdb_vector vector);
 	duckdb_vector (*duckdb_union_vector_get_tags)(duckdb_vector vector);
-	duckdb_vector (*duckdb_union_vector_get_member)(duckdb_vector vector, idx_t tag);
->>>>>>> a447060e49 (merged with main)
+	duckdb_vector (*duckdb_union_vector_get_member)(duckdb_vector vector, uint8_t tag);
+	void (*duckdb_union_vector_set_tag)(duckdb_vector vector, idx_t index, uint8_t tag);
 } duckdb_ext_api_v0;
 
 //===--------------------------------------------------------------------===//
@@ -848,7 +846,6 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_create_enum_value = duckdb_create_enum_value;
 	result.duckdb_get_enum_value = duckdb_get_enum_value;
 	result.duckdb_get_struct_child = duckdb_get_struct_child;
-<<<<<<< HEAD
 	result.duckdb_appender_add_column = duckdb_appender_add_column;
 	result.duckdb_appender_clear_columns = duckdb_appender_clear_columns;
 	result.duckdb_is_finite_timestamp_s = duckdb_is_finite_timestamp_s;
@@ -862,12 +859,11 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_get_timestamp_s = duckdb_get_timestamp_s;
 	result.duckdb_get_timestamp_ms = duckdb_get_timestamp_ms;
 	result.duckdb_get_timestamp_ns = duckdb_get_timestamp_ns;
-=======
 	result.duckdb_map_vector_get_keys = duckdb_map_vector_get_keys;
 	result.duckdb_map_vector_get_values = duckdb_map_vector_get_values;
 	result.duckdb_union_vector_get_tags = duckdb_union_vector_get_tags;
 	result.duckdb_union_vector_get_member = duckdb_union_vector_get_member;
->>>>>>> a447060e49 (merged with main)
+	result.duckdb_union_vector_set_tag = duckdb_union_vector_set_tag;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -24,6 +24,10 @@
         "duckdb_get_timestamp_tz",
         "duckdb_get_timestamp_s",
         "duckdb_get_timestamp_ms",
-        "duckdb_get_timestamp_ns"
+        "duckdb_get_timestamp_ns",
+        "duckdb_map_vector_get_keys",
+        "duckdb_map_vector_get_values",
+        "duckdb_union_vector_get_tags",
+        "duckdb_union_vector_get_member"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -28,6 +28,7 @@
         "duckdb_map_vector_get_keys",
         "duckdb_map_vector_get_values",
         "duckdb_union_vector_get_tags",
-        "duckdb_union_vector_get_member"
+        "duckdb_union_vector_get_member",
+        "duckdb_union_vector_set_tag"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
@@ -242,6 +242,79 @@
                 },
                 "return_value": "The child vector"
             }
+        },
+        {
+            "name": "duckdb_map_vector_get_keys",
+            "return_type": "duckdb_vector",
+            "params": [
+                {
+                    "type": "duckdb_vector",
+                    "name": "vector"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the keys vector of a map vector.\n\nThe resulting vector is valid as long as the parent vector is valid.\n\n",
+                "param_comments": {
+                    "vector": "The vector"
+                },
+                "return_value": "The keys vector"
+            }
+        },
+        {
+            "name": "duckdb_map_vector_get_values",
+            "return_type": "duckdb_vector",
+            "params": [
+                {
+                    "type": "duckdb_vector",
+                    "name": "vector"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the values vector of a map vector.\n\nThe resulting vector is valid as long as the parent vector is valid.\n\n",
+                "param_comments": {
+                    "vector": "The vector"
+                },
+                "return_value": "The values vector"
+            }
+        },
+        {
+            "name": "duckdb_union_vector_get_tags",
+            "return_type": "duckdb_vector",
+            "params": [
+                {
+                    "type": "duckdb_vector",
+                    "name": "vector"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the tags vector of a union vector.\n\nThe resulting vector is valid as long as the parent vector is valid.\n\n",
+                "param_comments": {
+                    "vector": "The vector"
+                },
+                "return_value": "The tags vector"
+            }
+        },
+        {
+            "name": "duckdb_union_vector_get_member",
+            "return_type": "duckdb_vector",
+            "params": [
+                {
+                    "type": "duckdb_vector",
+                    "name": "vector"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "tag"
+                }
+            ],
+            "comment": {
+                "description": "Retrieves the member vector of a union vector.\n\nThe resulting vector is valid as long as the parent vector is valid.\n\n",
+                "param_comments": {
+                    "vector": "The vector",
+                    "tag": "The tag of the member"
+                },
+                "return_value": "The member vector"
+            }
         }
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/vector_interface.json
@@ -303,7 +303,7 @@
                     "name": "vector"
                 },
                 {
-                    "type": "idx_t",
+                    "type": "uint8_t",
                     "name": "tag"
                 }
             ],
@@ -314,6 +314,32 @@
                     "tag": "The tag of the member"
                 },
                 "return_value": "The member vector"
+            }
+        },
+        {
+            "name": "duckdb_union_vector_set_tag",
+            "return_type": "void",
+            "params": [
+                {
+                    "type": "duckdb_vector",
+                    "name": "vector"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "index"
+                },
+                {
+                    "type": "uint8_t",
+                    "name": "tag"
+                }
+            ],
+            "comment": {
+                "description": "Sets the tag of a union vector at the specified index.\n\n",
+                "param_comments": {
+                    "vector": "The vector to alter",
+                    "index": "The row position in the vector to assign the tag to",
+                    "tag": "The tag"
+                }
             }
         }
     ]

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -503,6 +503,7 @@ typedef struct {
 	duckdb_value (*duckdb_create_enum_value)(duckdb_logical_type type, uint64_t value);
 	uint64_t (*duckdb_get_enum_value)(duckdb_value value);
 	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
+<<<<<<< HEAD
 	duckdb_state (*duckdb_appender_add_column)(duckdb_appender appender, const char *name);
 	duckdb_state (*duckdb_appender_clear_columns)(duckdb_appender appender);
 	bool (*duckdb_is_finite_timestamp_s)(duckdb_timestamp_s ts);
@@ -516,6 +517,12 @@ typedef struct {
 	duckdb_timestamp_s (*duckdb_get_timestamp_s)(duckdb_value val);
 	duckdb_timestamp_ms (*duckdb_get_timestamp_ms)(duckdb_value val);
 	duckdb_timestamp_ns (*duckdb_get_timestamp_ns)(duckdb_value val);
+=======
+	duckdb_vector (*duckdb_map_vector_get_keys)(duckdb_vector vector);
+	duckdb_vector (*duckdb_map_vector_get_values)(duckdb_vector vector);
+	duckdb_vector (*duckdb_union_vector_get_tags)(duckdb_vector vector);
+	duckdb_vector (*duckdb_union_vector_get_member)(duckdb_vector vector, idx_t tag);
+>>>>>>> a447060e49 (merged with main)
 #endif
 
 } duckdb_ext_api_v0;
@@ -917,6 +924,10 @@ typedef struct {
 #define duckdb_create_enum_value                 duckdb_ext_api.duckdb_create_enum_value
 #define duckdb_get_enum_value                    duckdb_ext_api.duckdb_get_enum_value
 #define duckdb_get_struct_child                  duckdb_ext_api.duckdb_get_struct_child
+#define duckdb_map_vector_get_keys               duckdb_ext_api.duckdb_map_vector_get_keys
+#define duckdb_map_vector_get_values             duckdb_ext_api.duckdb_map_vector_get_values
+#define duckdb_union_vector_get_tags             duckdb_ext_api.duckdb_union_vector_get_tags
+#define duckdb_union_vector_get_member           duckdb_ext_api.duckdb_union_vector_get_member
 #define duckdb_appender_create_ext               duckdb_ext_api.duckdb_appender_create_ext
 #define duckdb_appender_add_column               duckdb_ext_api.duckdb_appender_add_column
 #define duckdb_appender_clear_columns            duckdb_ext_api.duckdb_appender_clear_columns

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -503,7 +503,6 @@ typedef struct {
 	duckdb_value (*duckdb_create_enum_value)(duckdb_logical_type type, uint64_t value);
 	uint64_t (*duckdb_get_enum_value)(duckdb_value value);
 	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
-<<<<<<< HEAD
 	duckdb_state (*duckdb_appender_add_column)(duckdb_appender appender, const char *name);
 	duckdb_state (*duckdb_appender_clear_columns)(duckdb_appender appender);
 	bool (*duckdb_is_finite_timestamp_s)(duckdb_timestamp_s ts);
@@ -517,12 +516,11 @@ typedef struct {
 	duckdb_timestamp_s (*duckdb_get_timestamp_s)(duckdb_value val);
 	duckdb_timestamp_ms (*duckdb_get_timestamp_ms)(duckdb_value val);
 	duckdb_timestamp_ns (*duckdb_get_timestamp_ns)(duckdb_value val);
-=======
 	duckdb_vector (*duckdb_map_vector_get_keys)(duckdb_vector vector);
 	duckdb_vector (*duckdb_map_vector_get_values)(duckdb_vector vector);
 	duckdb_vector (*duckdb_union_vector_get_tags)(duckdb_vector vector);
-	duckdb_vector (*duckdb_union_vector_get_member)(duckdb_vector vector, idx_t tag);
->>>>>>> a447060e49 (merged with main)
+	duckdb_vector (*duckdb_union_vector_get_member)(duckdb_vector vector, uint8_t tag);
+	void (*duckdb_union_vector_set_tag)(duckdb_vector vector, idx_t index, uint8_t tag);
 #endif
 
 } duckdb_ext_api_v0;
@@ -928,6 +926,7 @@ typedef struct {
 #define duckdb_map_vector_get_values             duckdb_ext_api.duckdb_map_vector_get_values
 #define duckdb_union_vector_get_tags             duckdb_ext_api.duckdb_union_vector_get_tags
 #define duckdb_union_vector_get_member           duckdb_ext_api.duckdb_union_vector_get_member
+#define duckdb_union_vector_set_tag              duckdb_ext_api.duckdb_union_vector_set_tag
 #define duckdb_appender_create_ext               duckdb_ext_api.duckdb_appender_create_ext
 #define duckdb_appender_add_column               duckdb_ext_api.duckdb_appender_add_column
 #define duckdb_appender_clear_columns            duckdb_ext_api.duckdb_appender_clear_columns

--- a/src/main/capi/data_chunk-c.cpp
+++ b/src/main/capi/data_chunk-c.cpp
@@ -174,6 +174,53 @@ duckdb_vector duckdb_array_vector_get_child(duckdb_vector vector) {
 	return reinterpret_cast<duckdb_vector>(&duckdb::ArrayVector::GetEntry(*v));
 }
 
+duckdb_vector duckdb_map_vector_get_keys(duckdb_vector vector) {
+	if (!vector) {
+		return nullptr;
+	}
+	auto v = reinterpret_cast<duckdb::Vector *>(vector);
+	if (v->GetType().id() != duckdb::LogicalTypeId::MAP) {
+		return nullptr;
+	}
+	return reinterpret_cast<duckdb_vector>(&duckdb::MapVector::GetKeys(*v));
+}
+
+duckdb_vector duckdb_map_vector_get_values(duckdb_vector vector) {
+	if (!vector) {
+		return nullptr;
+	}
+	auto v = reinterpret_cast<duckdb::Vector *>(vector);
+	if (v->GetType().id() != duckdb::LogicalTypeId::MAP) {
+		return nullptr;
+	}
+	return reinterpret_cast<duckdb_vector>(&duckdb::MapVector::GetValues(*v));
+}
+
+duckdb_vector duckdb_union_vector_get_tags(duckdb_vector vector) {
+	if (!vector) {
+		return nullptr;
+	}
+	auto v = reinterpret_cast<duckdb::Vector *>(vector);
+	if (v->GetType().id() != duckdb::LogicalTypeId::UNION) {
+		return nullptr;
+	}
+	return reinterpret_cast<duckdb_vector>(&duckdb::UnionVector::GetTags(*v));
+}
+
+duckdb_vector duckdb_union_vector_get_member(duckdb_vector vector, idx_t tag) {
+	if (!vector) {
+		return nullptr;
+	}
+	auto v = reinterpret_cast<duckdb::Vector *>(vector);
+	if (v->GetType().id() != duckdb::LogicalTypeId::UNION) {
+		return nullptr;
+	}
+	if (tag > duckdb::UnionType::GetMemberCount(v->GetType()) - 1) {
+		return nullptr;
+	}
+	return reinterpret_cast<duckdb_vector>(&duckdb::UnionVector::GetMember(*v, tag));
+}
+
 bool duckdb_validity_row_is_valid(uint64_t *validity, idx_t row) {
 	if (!validity) {
 		return true;

--- a/src/main/capi/data_chunk-c.cpp
+++ b/src/main/capi/data_chunk-c.cpp
@@ -1,7 +1,7 @@
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
-#include "duckdb/common/type_visitor.hpp"
 
 #include <string.h>
 
@@ -207,7 +207,7 @@ duckdb_vector duckdb_union_vector_get_tags(duckdb_vector vector) {
 	return reinterpret_cast<duckdb_vector>(&duckdb::UnionVector::GetTags(*v));
 }
 
-duckdb_vector duckdb_union_vector_get_member(duckdb_vector vector, idx_t tag) {
+duckdb_vector duckdb_union_vector_get_member(duckdb_vector vector, uint8_t tag) {
 	if (!vector) {
 		return nullptr;
 	}
@@ -219,6 +219,35 @@ duckdb_vector duckdb_union_vector_get_member(duckdb_vector vector, idx_t tag) {
 		return nullptr;
 	}
 	return reinterpret_cast<duckdb_vector>(&duckdb::UnionVector::GetMember(*v, tag));
+}
+
+void duckdb_union_vector_set_tag(duckdb_vector vector, idx_t index, uint8_t tag) {
+	if (!vector) {
+		return;
+	}
+	auto v = reinterpret_cast<duckdb::Vector *>(vector);
+	if (v->GetType().id() != duckdb::LogicalTypeId::UNION) {
+		return;
+	}
+
+	// Set the tag
+	auto &tags = duckdb::UnionVector::GetTags(*v);
+	auto tag_v = duckdb::Value::UTINYINT(tag);
+	tags.SetValue(index, tag_v);
+
+	// Set the corresponding member as valid
+	auto &child = duckdb::UnionVector::GetMember(*v, tag);
+	duckdb::FlatVector::SetNull(child, index, false);
+
+	// Set every member to NULL except for the one that is set
+	// This recursively sets all children to NULL as well
+	for (idx_t i = 0; i < duckdb::UnionType::GetMemberCount(v->GetType()); i++) {
+		if (i == tag) {
+			continue;
+		}
+		auto &child = duckdb::UnionVector::GetMember(*v, i);
+		duckdb::FlatVector::SetNull(child, index, true);
+	}
 }
 
 bool duckdb_validity_row_is_valid(uint64_t *validity, idx_t row) {

--- a/test/api/capi/test_capi_data_chunk.cpp
+++ b/test/api/capi/test_capi_data_chunk.cpp
@@ -656,4 +656,7 @@ TEST_CASE("Test union vector set tag function", "[capi]") {
 	REQUIRE(duckdb_validity_row_is_valid(validity2, 0));
 
 	duckdb_destroy_data_chunk(&chunk);
+	duckdb_destroy_logical_type(&union_type);
+	duckdb_destroy_logical_type(&mtypes[0]);
+	duckdb_destroy_logical_type(&mtypes[1]);
 }


### PR DESCRIPTION
While Maps are internally lists of structs (key, val) and Unions are Structs and hence can be accessed directly just using the existing exposed C-API functions, these helpers make it more obvious to an API user who may not know the internal representation of these types.

```c
duckdb_vector duckdb_map_vector_get_keys(duckdb_vector vector);
duckdb_vector duckdb_map_vector_get_values(duckdb_vector vector);
duckdb_vector duckdb_union_vector_get_tags(duckdb_vector vector);
duckdb_vector duckdb_union_vector_get_member(duckdb_vector vector, uint8_t tag);
void duckdb_union_vector_set_tag(duckdb_vector vector, idx_t index, uint8_t tag);
```

`duckdb_union_vector_set_tag` sets the tag on a union vector at the requested index AND marks all the other member vectors at the same index invalid. This is related to this [discussion](https://github.com/duckdb/duckdb/discussions/14655).

@Tishj @samansmink @Mytherin I botched my previous PR while I was attempting to resolve merge conflicts :(. This is the previous PR (https://github.com/duckdb/duckdb/pull/14554).

Hopefully third time is the charm! Apologies for the rework.
