### PR TITLE
[Python][Dev] Fix tests relying on undefined `exec` behavior

### DIFF
--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -8,21 +8,13 @@ pd = pytest.importorskip("pandas")
 
 
 def using_table(con, to_scan, object_name):
-    local_scope = {
-        'con': con,
-        object_name: to_scan,
-        'object_name': object_name
-	}
+    local_scope = {'con': con, object_name: to_scan, 'object_name': object_name}
     exec(f"result = con.table(object_name)", globals(), local_scope)
     return local_scope["result"]
 
 
 def using_sql(con, to_scan, object_name):
-    local_scope = {
-        'con': con,
-        object_name: to_scan,
-        'object_name': object_name
-	}
+    local_scope = {'con': con, object_name: to_scan, 'object_name': object_name}
     exec(f"result = con.sql('select * from \"{object_name}\"')", globals(), local_scope)
     return local_scope["result"]
 

--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -8,13 +8,23 @@ pd = pytest.importorskip("pandas")
 
 
 def using_table(con, to_scan, object_name):
-    exec(f"{object_name} = to_scan")
-    return con.table(object_name)
+    local_scope = {
+        'con': con,
+        object_name: to_scan,
+        'object_name': object_name
+	}
+    exec(f"result = con.table(object_name)", globals(), local_scope)
+    return local_scope["result"]
 
 
 def using_sql(con, to_scan, object_name):
-    exec(f"{object_name} = to_scan")
-    return con.sql(f"select * from to_scan")
+    local_scope = {
+        'con': con,
+        object_name: to_scan,
+        'object_name': object_name
+	}
+    exec(f"result = con.sql('select * from \"{object_name}\"')", globals(), local_scope)
+    return local_scope["result"]
 
 
 # Fetch methods


### PR DESCRIPTION
It seems `exec` can't directly make changes in the current frame that are reflected on the frame after `exec` ends.
This breaks on 3.13, instead we're moving the replacement scan into the `exec` call so the frame is definitely available.

These tests are testing how replacement scans behave on names that are keywords in DuckDB, which is why `exec` is used to programmatically create variables with these names (might be a little over engineered but the tests are easily extendable)