### PR TITLE
[Dev] Add `segment_size` to `pragma_storage_info`

### DIFF
--- a/src/function/table/system/pragma_storage_info.cpp
+++ b/src/function/table/system/pragma_storage_info.cpp
@@ -76,6 +76,9 @@ static unique_ptr<FunctionData> PragmaStorageInfoBind(ClientContext &context, Ta
 	names.emplace_back("block_offset");
 	return_types.emplace_back(LogicalType::BIGINT);
 
+	names.emplace_back("segment_size");
+	return_types.emplace_back(LogicalType::BIGINT);
+
 	names.emplace_back("segment_info");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
@@ -132,7 +135,9 @@ static void PragmaStorageInfoFunction(ClientContext &context, TableFunctionInput
 		if (entry.persistent) {
 			output.SetValue(col_idx++, count, Value::BIGINT(entry.block_id));
 			output.SetValue(col_idx++, count, Value::BIGINT(NumericCast<int64_t>(entry.block_offset)));
+			output.SetValue(col_idx++, count, Value::BIGINT(NumericCast<int64_t>(entry.segment_size)));
 		} else {
+			output.SetValue(col_idx++, count, Value());
 			output.SetValue(col_idx++, count, Value());
 			output.SetValue(col_idx++, count, Value());
 		}

--- a/src/include/duckdb/storage/table/column_segment.hpp
+++ b/src/include/duckdb/storage/table/column_segment.hpp
@@ -78,8 +78,11 @@ public:
 	//! Skip a scan forward to the row_index specified in the scan state
 	void Skip(ColumnScanState &state);
 
-	// The maximum size of the buffer (in bytes)
+	//! The maximum size of the buffer (in bytes)
 	idx_t SegmentSize() const;
+	//! The storage footprint of this segment (in bytes)
+	idx_t BlockUsage() const;
+	void UpdateBlockUsage(idx_t block_usage);
 	//! Resize the block
 	void Resize(idx_t segment_size);
 
@@ -154,6 +157,8 @@ private:
 	idx_t offset;
 	//! The allocated segment size, which is bounded by Storage::BLOCK_SIZE
 	idx_t segment_size;
+	//! The bytes of the block occupied by this segments data
+	idx_t block_usage = 0;
 	//! Storage associated with the compressed segment
 	unique_ptr<CompressedSegmentState> segment_state;
 };

--- a/src/include/duckdb/storage/table_storage_info.hpp
+++ b/src/include/duckdb/storage/table_storage_info.hpp
@@ -32,6 +32,7 @@ struct ColumnSegmentInfo {
 	bool persistent;
 	block_id_t block_id;
 	idx_t block_offset;
+	idx_t segment_size;
 	string segment_info;
 };
 

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -174,6 +174,7 @@ void ColumnCheckpointState::FlushSegment(unique_ptr<ColumnSegment> segment, idx_
 		segment->ConvertToPersistent(nullptr, INVALID_BLOCK);
 	}
 
+	segment->UpdateBlockUsage(segment_size);
 	// construct the data pointer
 	DataPointer data_pointer(segment->stats.statistics.Copy());
 	data_pointer.block_pointer.block_id = block_id;

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -827,6 +827,7 @@ void ColumnData::GetColumnSegmentInfo(idx_t row_group_index, vector<idx_t> col_p
 			column_info.persistent = true;
 			column_info.block_id = segment->GetBlockId();
 			column_info.block_offset = segment->GetBlockOffset();
+			column_info.segment_size = segment->BlockUsage();
 		} else {
 			column_info.persistent = false;
 		}

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -154,6 +154,14 @@ idx_t ColumnSegment::SegmentSize() const {
 	return segment_size;
 }
 
+idx_t ColumnSegment::BlockUsage() const {
+	return block_usage;
+}
+
+void ColumnSegment::UpdateBlockUsage(idx_t block_usage_p) {
+	block_usage = block_usage_p;
+}
+
 void ColumnSegment::Resize(idx_t new_size) {
 	D_ASSERT(new_size > segment_size);
 	D_ASSERT(offset == 0);

--- a/test/sql/storage/compression/bitpacking/bitpacking_compression_ratio.test_slow
+++ b/test/sql/storage/compression/bitpacking/bitpacking_compression_ratio.test_slow
@@ -22,7 +22,10 @@ statement ok
 PRAGMA force_bitpacking_mode='constant'
 
 statement ok
-CREATE TABLE test_bitpacked AS SELECT (i//119000::INT64)::INT64 AS i FROM range(0, 120000000) tbl(i);
+set variable dataset_size = 120_000_000;
+
+statement ok
+CREATE TABLE test_bitpacked AS SELECT (i//119000::INT64)::INT64 AS i FROM range(getvariable('dataset_size')) tbl(i);
 
 statement ok
 checkpoint
@@ -31,7 +34,7 @@ statement ok
 PRAGMA force_compression='uncompressed'
 
 statement ok
-CREATE TABLE test_uncompressed AS SELECT i::INT64 FROM range(0, 120000000) tbl(i);
+CREATE TABLE test_uncompressed AS SELECT i::INT64 FROM range(getvariable('dataset_size')) tbl(i);
 
 statement ok
 checkpoint
@@ -44,14 +47,42 @@ query I
 SELECT compression FROM pragma_storage_info('test_uncompressed') WHERE segment_type != 'VALIDITY' AND compression != 'Uncompressed';
 ----
 
-query II
-select (uncompressed::FLOAT / bitpacked::FLOAT) > 700, (uncompressed::FLOAT / bitpacked::FLOAT) < 1000 FROM (
-    select
-        (select count(distinct block_id) from pragma_storage_info('test_bitpacked') where segment_type not in('VARCHAR', 'VALIDITY')) as bitpacked,
-        (select count(distinct block_id) from pragma_storage_info('test_uncompressed') where segment_type not in('VARCHAR', 'VALIDITY')) as uncompressed
-)
+statement ok
+CREATE TYPE test_result AS UNION (
+    ok BOOL,
+    err STRUCT(
+        uncompressed HUGEINT,
+        compressed HUGEINT,
+        allowed_minimum_ratio INT,
+        allowed_maximum_ratio INT,
+        actual_ratio FLOAT
+    )
+);
+
+statement ok
+set variable min_ratio = 900;
+set variable max_ratio = 1000;
+
+query I
+SELECT
+    CASE 
+        WHEN (uncompressed::FLOAT / compressed::FLOAT) > getvariable('min_ratio') AND (uncompressed::FLOAT / compressed::FLOAT) < getvariable('max_ratio')
+            THEN True::test_result
+        ELSE {
+            'uncompressed': uncompressed,
+            'compressed': compressed,
+            'allowed_minimum_ratio': getvariable('min_ratio'),
+            'allowed_maximum_ratio': getvariable('max_ratio'),
+            'actual_ratio': uncompressed::FLOAT / compressed::FLOAT
+        }::test_result
+    END
+FROM (
+    SELECT
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_bitpacked') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS compressed,
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_uncompressed') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS uncompressed
+) AS blocks_tbl;
 ----
-True	True
+true
 
 statement ok
 drop table test_bitpacked;
@@ -70,7 +101,7 @@ statement ok
 PRAGMA force_bitpacking_mode='constant_delta'
 
 statement ok
-CREATE TABLE test_bitpacked AS SELECT i::INT64 AS i FROM range(0, 120000000) tbl(i);
+CREATE TABLE test_bitpacked AS SELECT i::INT64 AS i FROM range(0, getvariable('dataset_size')) tbl(i);
 
 statement ok
 checkpoint
@@ -79,7 +110,7 @@ statement ok
 PRAGMA force_compression='uncompressed'
 
 statement ok
-CREATE TABLE test_uncompressed AS SELECT i::INT64 AS i FROM range(0, 120000000) tbl(i);
+CREATE TABLE test_uncompressed AS SELECT i::INT64 AS i FROM range(0, getvariable('dataset_size')) tbl(i);
 
 statement ok
 checkpoint
@@ -95,14 +126,30 @@ SELECT compression FROM pragma_storage_info('test_uncompressed') WHERE segment_t
 statement ok
 checkpoint
 
-query II
-select (uncompressed::FLOAT / bitpacked::FLOAT) > 600, (uncompressed::FLOAT / bitpacked::FLOAT) < 800 FROM (
-    select
-        (select count(distinct block_id) from pragma_storage_info('test_bitpacked') where segment_type not in('VARCHAR', 'VALIDITY')) as bitpacked,
-        (select count(distinct block_id) from pragma_storage_info('test_uncompressed') where segment_type not in('VARCHAR', 'VALIDITY')) as uncompressed
-)
+statement ok
+set variable min_ratio = 800;
+set variable max_ratio = 850;
+
+query I
+SELECT
+    CASE 
+        WHEN (uncompressed::FLOAT / compressed::FLOAT) > getvariable('min_ratio') AND (uncompressed::FLOAT / compressed::FLOAT) < getvariable('max_ratio')
+            THEN True::test_result
+        ELSE {
+            'uncompressed': uncompressed,
+            'compressed': compressed,
+            'allowed_minimum_ratio': getvariable('min_ratio'),
+            'allowed_maximum_ratio': getvariable('max_ratio'),
+            'actual_ratio': uncompressed::FLOAT / compressed::FLOAT
+        }::test_result
+    END
+FROM (
+    SELECT
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_bitpacked') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS compressed,
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_uncompressed') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS uncompressed
+) AS blocks_tbl;
 ----
-True	True
+true
 
 statement ok
 drop table test_bitpacked;
@@ -121,7 +168,7 @@ statement ok
 PRAGMA force_bitpacking_mode='delta_for'
 
 statement ok
-CREATE TABLE test_bitpacked AS SELECT i//2::INT64 AS i FROM range(0, 120000000) tbl(i);
+CREATE TABLE test_bitpacked AS SELECT i//2::INT64 AS i FROM range(getvariable('dataset_size')) tbl(i);
 
 statement ok
 checkpoint
@@ -130,7 +177,7 @@ statement ok
 PRAGMA force_compression='uncompressed'
 
 statement ok
-CREATE TABLE test_uncompressed AS SELECT i AS i FROM range(0, 120000000) tbl(i);
+CREATE TABLE test_uncompressed AS SELECT i AS i FROM range(getvariable('dataset_size')) tbl(i);
 
 statement ok
 checkpoint
@@ -146,14 +193,30 @@ SELECT compression FROM pragma_storage_info('test_uncompressed') WHERE segment_t
 statement ok
 checkpoint
 
-query II
-select (uncompressed::FLOAT / bitpacked::FLOAT) > 50, (uncompressed::FLOAT / bitpacked::FLOAT) < 60 FROM (
-    select
-        (select count(distinct block_id) from pragma_storage_info('test_bitpacked') where segment_type not in('VARCHAR', 'VALIDITY')) as bitpacked,
-        (select count(distinct block_id) from pragma_storage_info('test_uncompressed') where segment_type not in('VARCHAR', 'VALIDITY')) as uncompressed
-)
+statement ok
+set variable min_ratio = 50;
+set variable max_ratio = 60;
+
+query I
+SELECT
+    CASE 
+        WHEN (uncompressed::FLOAT / compressed::FLOAT) > getvariable('min_ratio') AND (uncompressed::FLOAT / compressed::FLOAT) < getvariable('max_ratio')
+            THEN True::test_result
+        ELSE {
+            'uncompressed': uncompressed,
+            'compressed': compressed,
+            'allowed_minimum_ratio': getvariable('min_ratio'),
+            'allowed_maximum_ratio': getvariable('max_ratio'),
+            'actual_ratio': uncompressed::FLOAT / compressed::FLOAT
+        }::test_result
+    END
+FROM (
+    SELECT
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_bitpacked') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS compressed,
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_uncompressed') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS uncompressed
+) AS blocks_tbl;
 ----
-True	True
+true
 
 statement ok
 drop table test_bitpacked;
@@ -172,7 +235,7 @@ statement ok
 PRAGMA force_bitpacking_mode='for'
 
 statement ok
-CREATE TABLE test_bitpacked AS SELECT i%2::INT64 AS i FROM range(0, 120000000) tbl(i);
+CREATE TABLE test_bitpacked AS SELECT i%2::INT64 AS i FROM range(getvariable('dataset_size')) tbl(i);
 
 statement ok
 checkpoint
@@ -181,7 +244,7 @@ statement ok
 PRAGMA force_compression='uncompressed'
 
 statement ok
-CREATE TABLE test_uncompressed AS SELECT i::INT64 AS i FROM range(0, 120000000) tbl(i);
+CREATE TABLE test_uncompressed AS SELECT i::INT64 AS i FROM range(getvariable('dataset_size')) tbl(i);
 
 statement ok
 checkpoint
@@ -197,14 +260,30 @@ SELECT compression FROM pragma_storage_info('test_uncompressed') WHERE segment_t
 statement ok
 checkpoint
 
-query II
-select (uncompressed::FLOAT / bitpacked::FLOAT) > 50, (uncompressed::FLOAT / bitpacked::FLOAT) < 60 FROM (
-    select
-        (select count(distinct block_id) from pragma_storage_info('test_bitpacked') where segment_type not in('VARCHAR', 'VALIDITY')) as bitpacked,
-        (select count(distinct block_id) from pragma_storage_info('test_uncompressed') where segment_type not in('VARCHAR', 'VALIDITY')) as uncompressed
-)
+statement ok
+set variable min_ratio = 50;
+set variable max_ratio = 60;
+
+query I
+SELECT
+    CASE 
+        WHEN (uncompressed::FLOAT / compressed::FLOAT) > getvariable('min_ratio') AND (uncompressed::FLOAT / compressed::FLOAT) < getvariable('max_ratio')
+            THEN True::test_result
+        ELSE {
+            'uncompressed': uncompressed,
+            'compressed': compressed,
+            'allowed_minimum_ratio': getvariable('min_ratio'),
+            'allowed_maximum_ratio': getvariable('max_ratio'),
+            'actual_ratio': uncompressed::FLOAT / compressed::FLOAT
+        }::test_result
+    END
+FROM (
+    SELECT
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_bitpacked') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS compressed,
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_uncompressed') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS uncompressed
+) AS blocks_tbl;
 ----
-True	True
+true
 
 statement ok
 drop table test_bitpacked;
@@ -235,14 +314,29 @@ statement ok
 checkpoint
 
 # assert compression ratio >2 wich should be achieved for even the smallest types for this data
-query II
-select (uncompressed::FLOAT / bitpacked::FLOAT) > 2, CAST(1 as ${type}) FROM (
-    select
-        (select count(distinct block_id) from pragma_storage_info('test_bitpacked') where segment_type not in('VARCHAR', 'VALIDITY')) as bitpacked,
-        (select count(distinct block_id) from pragma_storage_info('test_uncompressed') where segment_type not in('VARCHAR', 'VALIDITY')) as uncompressed
-)
+statement ok
+set variable min_ratio = 2;
+
+query I
+SELECT
+    CASE 
+        WHEN (uncompressed::FLOAT / compressed::FLOAT) > getvariable('min_ratio')
+            THEN True::test_result
+        ELSE {
+            'uncompressed': uncompressed,
+            'compressed': compressed,
+            'allowed_minimum_ratio': getvariable('min_ratio'),
+            'allowed_maximum_ratio': -1,
+            'actual_ratio': uncompressed::FLOAT / compressed::FLOAT
+        }::test_result
+    END
+FROM (
+    SELECT
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_bitpacked') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS compressed,
+        (SELECT sum(segment_size) FROM pragma_storage_info('test_uncompressed') WHERE segment_type NOT IN ('VARCHAR', 'VALIDITY')) AS uncompressed
+) AS blocks_tbl;
 ----
-1	1
+true
 
 statement ok
 drop table test_bitpacked


### PR DESCRIPTION
This PR adds `segment_size` to `pragma_storage_info`, this cleanly communicates how much data is actually written by a compression algorithm.

The previous method of calculating this was to measure the distinct block_ids used and comparing those against another table.
This new method isn't entirely equivalent to the old method, as some fragmentation could cause blocks to not get fully used (when a block is >= 80% full it's no longer considered a suitable partial block to append to).

But in the compression ratio tests we usually increase the generated tuple count to counteract this noise anyways, measuring the actual footprint is probably a welcome change (?)

---------------------

Segments get updated / created in quite a couple different places. We already have `segment_size` which seems to always get ceilinged up to the block size, that I didn't want to mess with.