### PR TITLE
CI: Fix and simplify 'needs reproducible example' labelling

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -27,7 +27,17 @@ jobs:
     steps:
       - name: Add comment
         run: |
-          gh issue comment ${{ github.event.issue.number }} --body-file .github/workflows/needs-reproducible-example-comment.md
+          cat > needs-reproducible-example-comment.md << EOF
+          Thanks for opening this issue in the DuckDB issue tracker! To resolve this issue, our team needs a reproducible example. This includes:
+
+          * A source code snippet which reproduces the issue.
+          * The snippet should be self-contained, i.e., it should contain all imports and should use relative paths instead of hard coded paths (please avoid \`/Users/JohnDoe/...`).
+          * A lot of issues can be reproduced with plain SQL code executed in the [DuckDB command line client](https://duckdb.org/docs/api/cli/overview). If you can provide such an example, it greatly simplifies the reproduction process and likely results in a faster fix.
+          * If the script needs additional data, please share the data as a CSV, JSON, or Parquet file. Unfortunately, we cannot fix issues that can only be reproduced with a confidential data set. [Support contracts](https://duckdblabs.com/#support) allow sharing confidential data with the core DuckDB team under NDA.
+
+          For more detailed guidelines on how to create reproducible examples, please visit Stack Overflow's [“Minimal, Reproducible Example”](https://stackoverflow.com/help/minimal-reproducible-example) page.
+          EOF
+          gh issue comment ${{ github.event.issue.number }} --body-file needs-reproducible-example-comment.md
 
   create_or_label_mirror_issue:
     if: github.event.label.name == 'reproduced' || github.event.label.name == 'under review'

--- a/.github/workflows/needs-reproducible-example-comment.md
+++ b/.github/workflows/needs-reproducible-example-comment.md
@@ -1,8 +1,0 @@
-Thanks for opening this issue in the DuckDB issue tracker! To resolve this issue, our team needs a reproducible example. This includes:
-
-* A source code snippet which reproduces the issue.
-* The snippet should be self-contained, i.e., it should contain all imports and should use relative paths instead of hard coded paths (please avoid `/Users/JohnDoe/...`).
-* A lot of issues can be reproduced with plain SQL code executed in the [DuckDB command line client](https://duckdb.org/docs/api/cli/overview). If you can provide such an example, it greatly simplifies the reproduction process and likely results in a faster fix.
-* If the script needs additional data, please share the data as a CSV, JSON, or Parquet file. Unfortunately, we cannot fix issues that can only be reproduced with a confidential data set. [Support contracts](https://duckdblabs.com/#support) allow sharing confidential data with the core DuckDB team under NDA.
-
-For more detailed guidelines on how to create reproducible examples, please visit Stack Overflow's [“Minimal, Reproducible Example”](https://stackoverflow.com/help/minimal-reproducible-example) page.


### PR DESCRIPTION
Followup of #14598. Apparently the `issue` jobs cannot read the files in the repo, so I moved the comment text to the script.