### PR TITLE
Added capi functions to create map and union values

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2408,6 +2408,28 @@ Must be destroyed with `duckdb_destroy_value`.
 DUCKDB_API duckdb_value duckdb_create_array_value(duckdb_logical_type type, duckdb_value *values, idx_t value_count);
 
 /*!
+Creates a map value from a map type and two lists of keys and values of length `count`.
+Must be destroyed with `duckdb_destroy_value`.
+
+* @param map_type The type of the map
+* @param keys The keys for the map
+* @param values The values for the map
+* @return The map value, or nullptr, if the child type is `DUCKDB_TYPE_ANY` or `DUCKDB_TYPE_INVALID`.
+*/
+DUCKDB_API duckdb_value duckdb_create_map_value(duckdb_logical_type map_type, duckdb_value keys, duckdb_value values);
+
+/*!
+Creates a union value from a union type, a value, and a tag.
+Must be destroyed with `duckdb_destroy_value`.
+
+* @param union_type The type of the union
+* @param value The value for the union
+* @param tag The tag for the union
+* @return The union value, or nullptr, if the child type is `DUCKDB_TYPE_ANY` or `DUCKDB_TYPE_INVALID`.
+*/
+DUCKDB_API duckdb_value duckdb_create_union_value(duckdb_logical_type union_type, duckdb_value value, idx_t tag);
+
+/*!
 Returns the number of elements in a MAP value.
 
 * @param value The MAP value.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2427,7 +2427,7 @@ Must be destroyed with `duckdb_destroy_value`.
 * @param tag The tag for the union
 * @return The union value, or nullptr, if the child type is `DUCKDB_TYPE_ANY` or `DUCKDB_TYPE_INVALID`.
 */
-DUCKDB_API duckdb_value duckdb_create_union_value(duckdb_logical_type union_type, duckdb_value value, idx_t tag);
+DUCKDB_API duckdb_value duckdb_create_union_value(duckdb_logical_type union_type, duckdb_value value, uint8_t tag);
 
 /*!
 Returns the number of elements in a MAP value.

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -406,6 +406,8 @@ typedef struct {
 	duckdb_state (*duckdb_append_varchar_length)(duckdb_appender appender, const char *val, idx_t length);
 	duckdb_state (*duckdb_append_blob)(duckdb_appender appender, const void *data, idx_t length);
 	duckdb_state (*duckdb_append_null)(duckdb_appender appender);
+	duckdb_value (*duckdb_create_map_value)(duckdb_logical_type map_type, duckdb_value keys, duckdb_value values);
+	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, duckdb_value value, idx_t tag);
 	// These functions have been deprecated and may be removed in future versions of DuckDB
 
 	idx_t (*duckdb_row_count)(duckdb_result *result);
@@ -828,6 +830,8 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_append_varchar_length = duckdb_append_varchar_length;
 	result.duckdb_append_blob = duckdb_append_blob;
 	result.duckdb_append_null = duckdb_append_null;
+	result.duckdb_create_map_value = duckdb_create_map_value;
+	result.duckdb_create_union_value = duckdb_create_union_value;
 	result.duckdb_row_count = duckdb_row_count;
 	result.duckdb_column_data = duckdb_column_data;
 	result.duckdb_nullmask_data = duckdb_nullmask_data;

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -407,7 +407,7 @@ typedef struct {
 	duckdb_state (*duckdb_append_blob)(duckdb_appender appender, const void *data, idx_t length);
 	duckdb_state (*duckdb_append_null)(duckdb_appender appender);
 	duckdb_value (*duckdb_create_map_value)(duckdb_logical_type map_type, duckdb_value keys, duckdb_value values);
-	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, duckdb_value value, idx_t tag);
+	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, duckdb_value value, uint8_t tag);
 	// These functions have been deprecated and may be removed in future versions of DuckDB
 
 	idx_t (*duckdb_row_count)(duckdb_result *result);

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -1,0 +1,31 @@
+{
+    "version": "dev",
+    "entries": [
+        "duckdb_appender_create_ext",
+        "duckdb_table_description_create_ext",
+        "duckdb_table_description_get_column_name",
+        "duckdb_param_logical_type",
+        "duckdb_is_null_value",
+        "duckdb_create_null_value",
+        "duckdb_get_list_size",
+        "duckdb_get_list_child",
+        "duckdb_create_enum_value",
+        "duckdb_get_enum_value",
+        "duckdb_get_struct_child",
+        "duckdb_appender_add_column",
+        "duckdb_appender_clear_columns",
+        "duckdb_is_finite_timestamp_s",
+        "duckdb_is_finite_timestamp_ms",
+        "duckdb_is_finite_timestamp_ns",
+        "duckdb_create_timestamp_tz",
+        "duckdb_create_timestamp_s",
+        "duckdb_create_timestamp_ms",
+        "duckdb_create_timestamp_ns",
+        "duckdb_get_timestamp_tz",
+        "duckdb_get_timestamp_s",
+        "duckdb_get_timestamp_ms",
+        "duckdb_get_timestamp_ns",
+        "duckdb_create_map_value",
+        "duckdb_create_union_value"
+    ]
+}

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/v1.2/v1.2.0.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/v1.2/v1.2.0.json
@@ -357,6 +357,8 @@
         "duckdb_append_varchar",
         "duckdb_append_varchar_length",
         "duckdb_append_blob",
-        "duckdb_append_null"
+        "duckdb_append_null",
+        "duckdb_create_map_value",
+        "duckdb_create_union_value"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -1091,6 +1091,60 @@
             }
         },
         {
+            "name": "duckdb_create_map_value",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_logical_type",
+                    "name": "map_type"
+                },
+                {
+                    "type": "duckdb_value",
+                    "name": "keys"
+                },
+                {
+                    "type": "duckdb_value",
+                    "name": "values"
+                }
+            ],
+            "comment": {
+                "description": "Creates a map value from a map type and two lists of keys and values of length `count`.\nMust be destroyed with `duckdb_destroy_value`.\n\n",
+                "param_comments": {
+                    "map_type": "The type of the map",
+                    "keys": "The keys for the map",
+                    "values": "The values for the map"
+                },
+                "return_value": "The map value, or nullptr, if the child type is `DUCKDB_TYPE_ANY` or `DUCKDB_TYPE_INVALID`."
+            }
+        },
+        {
+            "name": "duckdb_create_union_value",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_logical_type",
+                    "name": "union_type"
+                },
+                {
+                    "type": "duckdb_value",
+                    "name": "value"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "tag"
+                }
+            ],
+            "comment": {
+                "description": "Creates a union value from a union type, a value, and a tag.\nMust be destroyed with `duckdb_destroy_value`.\n\n",
+                "param_comments": {
+                    "union_type": "The type of the union",
+                    "value": "The value for the union",
+                    "tag": "The tag for the union"
+                },
+                "return_value": "The union value, or nullptr, if the child type is `DUCKDB_TYPE_ANY` or `DUCKDB_TYPE_INVALID`."
+            }
+        },
+        {
             "name": "duckdb_get_map_size",
             "return_type": "idx_t",
             "params": [

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -1130,7 +1130,7 @@
                     "name": "value"
                 },
                 {
-                    "type": "idx_t",
+                    "type": "uint8_t",
                     "name": "tag"
                 }
             ],

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -471,7 +471,7 @@ typedef struct {
 	duckdb_state (*duckdb_append_blob)(duckdb_appender appender, const void *data, idx_t length);
 	duckdb_state (*duckdb_append_null)(duckdb_appender appender);
 	duckdb_value (*duckdb_create_map_value)(duckdb_logical_type map_type, duckdb_value keys, duckdb_value values);
-	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, duckdb_value value, idx_t tag);
+	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, duckdb_value value, uint8_t tag);
 #endif
 
 // These functions have been deprecated and may be removed in future versions of DuckDB

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -470,6 +470,8 @@ typedef struct {
 	duckdb_state (*duckdb_append_varchar_length)(duckdb_appender appender, const char *val, idx_t length);
 	duckdb_state (*duckdb_append_blob)(duckdb_appender appender, const void *data, idx_t length);
 	duckdb_state (*duckdb_append_null)(duckdb_appender appender);
+	duckdb_value (*duckdb_create_map_value)(duckdb_logical_type map_type, duckdb_value keys, duckdb_value values);
+	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, duckdb_value value, idx_t tag);
 #endif
 
 // These functions have been deprecated and may be removed in future versions of DuckDB
@@ -697,6 +699,8 @@ typedef struct {
 #define duckdb_create_struct_value                     duckdb_ext_api.duckdb_create_struct_value
 #define duckdb_create_list_value                       duckdb_ext_api.duckdb_create_list_value
 #define duckdb_create_array_value                      duckdb_ext_api.duckdb_create_array_value
+#define duckdb_create_map_value                        duckdb_ext_api.duckdb_create_map_value
+#define duckdb_create_union_value                      duckdb_ext_api.duckdb_create_union_value
 #define duckdb_get_map_size                            duckdb_ext_api.duckdb_get_map_size
 #define duckdb_get_map_key                             duckdb_ext_api.duckdb_get_map_key
 #define duckdb_get_map_value                           duckdb_ext_api.duckdb_get_map_value

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -446,7 +446,7 @@ duckdb_value duckdb_create_map_value(duckdb_logical_type map_type, duckdb_value 
 	return WrapValue(map_value);
 }
 
-duckdb_value duckdb_create_union_value(duckdb_logical_type union_type, duckdb_value value, idx_t tag) {
+duckdb_value duckdb_create_union_value(duckdb_logical_type union_type, duckdb_value value, uint8_t tag) {
 	if (!union_type || !value) {
 		return nullptr;
 	}
@@ -469,7 +469,7 @@ duckdb_value duckdb_create_union_value(duckdb_logical_type union_type, duckdb_va
 	auto members = duckdb::UnionType::CopyMemberTypes(logical_type);
 	duckdb::Value *union_value = new duckdb::Value;
 	try {
-		*union_value = duckdb::Value::UNION(members, (uint8_t)tag, UnwrapValue(value));
+		*union_value = duckdb::Value::UNION(members, tag, UnwrapValue(value));
 	} catch (...) {
 		delete union_value;
 		return nullptr;


### PR DESCRIPTION
Added
```
duckdb_value duckdb_create_map_value(
    duckdb_logical_type map_type,
    duckdb_value keys,
    duckdb_value values);

duckdb_value duckdb_create_union_value(
    duckdb_logical_type union_type,
    duckdb_value value, uint8_t tag);
```