### PR TITLE
Fix #14600: use UUID to generate unique pivot enum names

### DIFF
--- a/src/parser/transform/statement/transform_pivot_stmt.cpp
+++ b/src/parser/transform/statement/transform_pivot_stmt.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/result_modifier.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
+#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -168,7 +169,6 @@ unique_ptr<QueryNode> Transformer::TransformPivotStatement(duckdb_libpgquery::PG
 	// generate CREATE TYPE statements for each of the columns that do not have an IN list
 	bool is_pivot = !pivot->unpivots;
 	auto columns = TransformPivotList(*pivot->columns, is_pivot);
-	auto pivot_idx = PivotEntryCount();
 	for (idx_t c = 0; c < columns.size(); c++) {
 		auto &col = columns[c];
 		if (!col.pivot_enum.empty() || !col.entries.empty()) {
@@ -177,7 +177,7 @@ unique_ptr<QueryNode> Transformer::TransformPivotStatement(duckdb_libpgquery::PG
 		if (col.pivot_expressions.size() != 1) {
 			throw InternalException("PIVOT statement with multiple names in pivot entry!?");
 		}
-		auto enum_name = "__pivot_enum_" + std::to_string(pivot_idx) + "_" + std::to_string(c);
+		auto enum_name = "__pivot_enum_" + UUID::ToString(UUID::GenerateRandomUUID());
 
 		auto new_select = make_uniq<SelectNode>();
 		ExtractCTEsRecursive(new_select->cte_map);

--- a/tools/pythonpkg/tests/fast/relational_api/test_pivot.py
+++ b/tools/pythonpkg/tests/fast/relational_api/test_pivot.py
@@ -1,0 +1,18 @@
+import duckdb
+import pytest
+from duckdb import ColumnExpression
+
+
+class TestPivot(object):
+    def test_pivot_issue_14600(self, duckdb_cursor):
+        duckdb_cursor.sql(
+            "create table input_data as select unnest(['u','v','w']) as a, unnest(['x','y','z']) as b, unnest([1,2,3]) as c;"
+        )
+        pivot_1 = duckdb_cursor.query("pivot input_data on a using max(c) group by b;")
+        pivot_2 = duckdb_cursor.query("pivot input_data on b using max(c) group by a;")
+        pivot_1.create("pivot_1")
+        pivot_2.create("pivot_2")
+        pivot_1_tbl = duckdb_cursor.table("pivot_1")
+        pivot_2_tbl = duckdb_cursor.table("pivot_2")
+        assert set(pivot_1.columns) == set(pivot_1_tbl.columns)
+        assert set(pivot_2.columns) == set(pivot_2_tbl.columns)


### PR DESCRIPTION
Fixes #14600