### PR TITLE
fix: Initialize atomic class member

### DIFF
--- a/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
+++ b/src/include/duckdb/core_functions/aggregate/minmax_n_helpers.hpp
@@ -40,6 +40,8 @@ struct HeapEntry<string_t> {
 	HeapEntry(HeapEntry &&other) noexcept {
 		if (other.value.IsInlined()) {
 			value = other.value;
+			capacity = 0;
+			allocated_data = nullptr;
 		} else {
 			capacity = other.capacity;
 			allocated_data = other.allocated_data;

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -19,7 +19,7 @@
 namespace duckdb {
 
 Connection::Connection(DatabaseInstance &database)
-    : context(make_shared_ptr<ClientContext>(database.shared_from_this())) {
+    : context(make_shared_ptr<ClientContext>(database.shared_from_this())), warning_cb(nullptr) {
 	ConnectionManager::Get(database).AddConnection(*context);
 #ifdef DEBUG
 	EnableProfiling();

--- a/src/planner/binder/query_node/plan_setop.cpp
+++ b/src/planner/binder/query_node/plan_setop.cpp
@@ -132,7 +132,7 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSetOperationNode &node) {
 	                                node.right_binder->has_unplanned_dependent_joins;
 
 	// create actual logical ops for setops
-	LogicalOperatorType logical_type;
+	LogicalOperatorType logical_type = LogicalOperatorType::LOGICAL_INVALID;
 	switch (node.setop_type) {
 	case SetOperationType::UNION:
 	case SetOperationType::UNION_BY_NAME:


### PR DESCRIPTION
CRAN flags this error with gcc14 like this. I believe it's legit.

Constructing an object of this class and then applying the move constructor would, in theory, access uninitialized memory. The enumeration of system headers is confusing, but the crucial part is `inlined from ‘duckdb::Connection::Connection(duckdb::Connection&&)’ at duckdb/src/main/connection.cpp:35:11:` .

Check link: https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/duckdb-00check.html

Detailed log: https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/duckdb-00install.html

I wonder if replicating this strict check here would be feasible and useful.

I'm working around in the R package (patch 0008) and can remove when this is merged.

```
g++-14 -std=gnu++17 -I"/home/hornik/tmp/R.check/r-devel-gcc/Work/build/include" -DNDEBUG -Iinclude -I../inst/include -DDUCKDB_DISABLE_PRINT -DDUCKDB_R_BUILD -DBROTLI_ENCODER_CLEANUP_ON_OOM -Iduckdb/src/include -Iduckdb/third_party/concurrentqueue -Iduckdb/third_party/fast_float -Iduckdb/third_party/fastpforlib -Iduckdb/third_party/fmt/include -Iduckdb/third_party/fsst -Iduckdb/third_party/httplib -Iduckdb/third_party/hyperloglog -Iduckdb/third_party/jaro_winkler -Iduckdb/third_party/jaro_winkler/details -Iduckdb/third_party/libpg_query -Iduckdb/third_party/libpg_query/include -Iduckdb/third_party/lz4 -Iduckdb/third_party/brotli/include -Iduckdb/third_party/brotli/common -Iduckdb/third_party/brotli/dec -Iduckdb/third_party/brotli/enc -Iduckdb/third_party/mbedtls -Iduckdb/third_party/mbedtls/include -Iduckdb/third_party/mbedtls/library -Iduckdb/third_party/miniz -Iduckdb/third_party/pcg -Iduckdb/third_party/re2 -Iduckdb/third_party/skiplist -Iduckdb/third_party/tdigest -Iduckdb/third_party/utf8proc -Iduckdb/third_party/utf8proc/include -Iduckdb/third_party/yyjson/include -Iduckdb/extension/parquet/include -Iduckdb/third_party/parquet -Iduckdb/third_party/thrift -Iduckdb/third_party/lz4 -Iduckdb/third_party/brotli/include -Iduckdb/third_party/brotli/common -Iduckdb/third_party/brotli/dec -Iduckdb/third_party/brotli/enc -Iduckdb/third_party/snappy -Iduckdb/third_party/zstd/include -Iduckdb/third_party/mbedtls -Iduckdb/third_party/mbedtls/include -I../inst/include -Iduckdb -DDUCKDB_EXTENSION_PARQUET_LINKED -DDUCKDB_BUILD_LIBRARY  -I/usr/local/include -D_FORTIFY_SOURCE=3   -fpic  -g -O2 -Wall -pedantic -mtune=native   -c duckdb/ub_src_main.cpp -o duckdb/ub_src_main.o
In file included from /usr/include/c++/14/bits/new_allocator.h:36,
                 from /usr/include/x86_64-linux-gnu/c++/14/bits/c++allocator.h:33,
                 from /usr/include/c++/14/bits/allocator.h:46,
                 from /usr/include/c++/14/memory:65,
                 from duckdb/src/include/duckdb/common/constants.hpp:11,
                 from duckdb/src/include/duckdb/common/helper.hpp:11,
                 from duckdb/src/include/duckdb/common/allocator.hpp:12,
                 from duckdb/src/include/duckdb/common/types/data_chunk.hpp:11,
                 from duckdb/src/include/duckdb/main/appender.hpp:11,
                 from duckdb/src/main/appender.cpp:1,
                 from duckdb/ub_src_main.cpp:1:
In function ‘std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = void (*)(__cxx11::basic_string<char>)]’,
    inlined from ‘duckdb::Connection::Connection(duckdb::Connection&&)’ at duckdb/src/main/connection.cpp:35:11:
/usr/include/c++/14/bits/move.h:222:11: warning: ‘((void (**)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >))this)[2]’ is used uninitialized [-Wuninitialized]
  222 |       _Tp __tmp = _GLIBCXX_MOVE(__a);
      |           ^~~~~
```