### PR TITLE
FIX: Discrepancy Between Count and Sum Queries in SQL

### DIFF
--- a/src/common/vector_operations/comparison_operators.cpp
+++ b/src/common/vector_operations/comparison_operators.cpp
@@ -167,7 +167,8 @@ static void NestedComparisonExecutor(Vector &left, Vector &right, Vector &result
 		auto &result_validity = ConstantVector::Validity(result);
 		SelectionVector true_sel(1);
 		auto match_count = ComparisonSelector::Select<OP>(left, right, nullptr, 1, &true_sel, nullptr, result_validity);
-		// since we are dealing with nested types where the values are not NULL, the result is always valid (i.e true or false)
+		// since we are dealing with nested types where the values are not NULL, the result is always valid (i.e true or
+		// false)
 		result_validity.SetAllValid(1);
 		auto result_data = ConstantVector::GetData<bool>(result);
 		result_data[0] = match_count > 0;

--- a/src/common/vector_operations/comparison_operators.cpp
+++ b/src/common/vector_operations/comparison_operators.cpp
@@ -167,6 +167,8 @@ static void NestedComparisonExecutor(Vector &left, Vector &right, Vector &result
 		auto &result_validity = ConstantVector::Validity(result);
 		SelectionVector true_sel(1);
 		auto match_count = ComparisonSelector::Select<OP>(left, right, nullptr, 1, &true_sel, nullptr, result_validity);
+		// since we are dealing with nested types where the values are not NULL, the result is always valid (i.e true or false)
+		result_validity.SetAllValid(1);
 		auto result_data = ConstantVector::GetData<bool>(result);
 		result_data[0] = match_count > 0;
 		return;

--- a/test/optimizer/misc/test_count_and_sum.test
+++ b/test/optimizer/misc/test_count_and_sum.test
@@ -1,0 +1,33 @@
+# name: test/optimizer/misc/test_count_and_sum.test
+# description: Arithmetic simplification test
+# group: [misc]
+
+statement ok
+DROP VIEW IF EXISTS v0;
+
+statement ok
+CREATE TABLE t0 (c0 TEXT);
+
+statement ok
+CREATE TABLE t1 (c1 TEXT);
+
+statement ok
+CREATE VIEW v0 AS
+SELECT t0.c0
+FROM t1
+LEFT JOIN t0 ON t1.c1 = t0.c0;
+
+statement ok
+INSERT INTO t1(c1) VALUES ('example_value');
+
+query I nosort result_1
+SELECT COUNT(*)
+FROM v0
+WHERE (CURRENT_DATE, c0) != (CAST(NULL AS TEXT), '0');
+----
+
+
+query I nosort result_1
+SELECT SUM(CASE WHEN (CURRENT_DATE, c0) != (CAST(NULL AS TEXT), '0') THEN 1 ELSE 0 END)
+FROM v0;
+----

--- a/test/sql/types/struct/unnamed_struct_comparison.test
+++ b/test/sql/types/struct/unnamed_struct_comparison.test
@@ -25,7 +25,7 @@ select 1 from values (struct_pack(k := NULL)) t(a) where 1 <> a.k;
 query I
 select [NULL, 6] <> [6, 5];
 ----
-NULL
+true
 
 
 query I


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/3388

If a nested comparison happens between two constant vectors, where both values are note NULL, then the result must always be True or False. This follows Postgres syntax. Is also related to https://github.com/duckdb/duckdb/pull/14094

Changing the unnamed structure comparison test also follows Postgres syntax

```
select (NULL, 6)  <> (6, 5);
```
outputs
```
?column? 
----------
 t
(1 row)
```