### PR TITLE
Force aggregate state to be `is_trivially_move_constructible`

### DIFF
--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -255,9 +255,11 @@ public:
 	template <class STATE, class OP, AggregateDestructorType destructor_type = AggregateDestructorType::STANDARD>
 	static void StateInitialize(const AggregateFunction &, data_ptr_t state) {
 		// FIXME: we should remove the "destructor_type" option in the future
+#if !defined(__GNUC__) || (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
 		static_assert(std::is_trivially_move_constructible<STATE>::value ||
 		                  destructor_type == AggregateDestructorType::LEGACY,
 		              "Aggregate state must be trivially move constructible");
+#endif
 		OP::Initialize(*reinterpret_cast<STATE *>(state));
 	}
 

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -255,9 +255,9 @@ public:
 	template <class STATE, class OP, AggregateDestructorType destructor_type = AggregateDestructorType::STANDARD>
 	static void StateInitialize(const AggregateFunction &, data_ptr_t state) {
 		// FIXME: we should remove the "destructor_type" option in the future
-		static_assert(std::is_trivially_destructible<STATE>::value ||
+		static_assert(std::is_trivially_move_constructible<STATE>::value ||
 		                  destructor_type == AggregateDestructorType::LEGACY,
-		              "Aggregate state must be trivially destructible");
+		              "Aggregate state must be trivially move constructible");
 		OP::Initialize(*reinterpret_cast<STATE *>(state));
 	}
 


### PR DESCRIPTION
Follow-up of https://github.com/duckdb/duckdb/pull/14615