### PR TITLE
Correctly render EXPLAIN EXECUTE - use op.GetChildren() instead of hard-coding special cases

### DIFF
--- a/src/common/render_tree.cpp
+++ b/src/common/render_tree.cpp
@@ -41,29 +41,13 @@ public:
 
 template <>
 bool TreeChildrenIterator::HasChildren(const PhysicalOperator &op) {
-	switch (op.type) {
-	case PhysicalOperatorType::LEFT_DELIM_JOIN:
-	case PhysicalOperatorType::RIGHT_DELIM_JOIN:
-	case PhysicalOperatorType::POSITIONAL_SCAN:
-		return true;
-	default:
-		return !op.children.empty();
-	}
+	return !op.GetChildren().empty();
 }
 template <>
 void TreeChildrenIterator::Iterate(const PhysicalOperator &op,
                                    const std::function<void(const PhysicalOperator &child)> &callback) {
-	for (auto &child : op.children) {
-		callback(*child);
-	}
-	if (op.type == PhysicalOperatorType::LEFT_DELIM_JOIN || op.type == PhysicalOperatorType::RIGHT_DELIM_JOIN) {
-		auto &delim = op.Cast<PhysicalDelimJoin>();
-		callback(*delim.join);
-	} else if ((op.type == PhysicalOperatorType::POSITIONAL_SCAN)) {
-		auto &pscan = op.Cast<PhysicalPositionalScan>();
-		for (auto &table : pscan.child_tables) {
-			callback(*table);
-		}
+	for (auto &child : op.GetChildren()) {
+		callback(child);
 	}
 }
 

--- a/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/src/execution/operator/scan/physical_positional_scan.cpp
@@ -208,4 +208,12 @@ bool PhysicalPositionalScan::Equals(const PhysicalOperator &other_p) const {
 	return true;
 }
 
+vector<const_reference<PhysicalOperator>> PhysicalPositionalScan::GetChildren() const {
+	auto result = PhysicalOperator::GetChildren();
+	for (auto &entry : child_tables) {
+		result.push_back(*entry);
+	}
+	return result;
+}
+
 } // namespace duckdb

--- a/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
@@ -30,6 +30,7 @@ public:
 
 public:
 	bool Equals(const PhysicalOperator &other) const override;
+	vector<const_reference<PhysicalOperator>> GetChildren() const override;
 
 public:
 	unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,

--- a/test/sql/explain/explain_execute.test
+++ b/test/sql/explain/explain_execute.test
@@ -1,0 +1,20 @@
+# name: test/sql/explain/explain_execute.test
+# description: Test explain
+# group: [explain]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER, j INTEGER)
+
+statement ok
+INSERT INTO integers VALUES (1, 1), (2, 2), (3, 3), (NULL, NULL)
+
+statement ok
+PREPARE query AS SELECT * FROM integers
+
+query II
+EXPLAIN EXECUTE query
+----
+physical_plan	<REGEX>:.*SEQ_SCAN.*


### PR DESCRIPTION
Fixes an issue where `EXPLAIN EXECUTE [prepared_statement]` would not render the child nodes correctly