### PR TITLE
Force error on CSV Sniffer Failure

### DIFF
--- a/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/type_detection.cpp
@@ -488,7 +488,7 @@ void CSVSniffer::DetectTypes() {
 	if (!best_candidate) {
 		DialectCandidates dialect_candidates(options.dialect_options.state_machine_options);
 		auto error = CSVError::SniffingError(options, dialect_candidates.Print());
-		error_handler->Error(error);
+		error_handler->Error(error, true);
 	}
 	// Assert that it's all good at this point.
 	D_ASSERT(best_candidate && !best_format_candidates.empty());


### PR DESCRIPTION
Closes #14626 

If there's a failure parsing the CSV Type stop the parsing.

Before the change
```
INTERNAL Error: Attempted to dereference unique_ptr that is NULL!
This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
For more information, see https://duckdb.org/docs/dev/internal_errors
```

With the new change

```
D create or replace table t as
  from read_csv('a.csv',
     header=false,
     quote='"',
     escape = '"',
     sep=',',
     ignore_errors=true);
Invalid Input Error: Error when sniffing file "a.csv".
It was not possible to automatically detect the CSV Parsing dialect/types
The search space used was:
Delimiter Candidates: ','
Quote/Escape Candidates: ['"','"'],['"','\0'],['"',''']
Comment Candidates: '#', '\0'
Possible fixes:
* Delimiter is set to ','. Consider unsetting it.
* Quote is set to '"'. Consider unsetting it.
* Escape is set to '"'. Consider unsetting it.
* Set comment (e.g., comment='#')
* Set skip (skip=${n}) to skip ${n} lines at the top of the file
* Enable null padding (null_padding=true) to pad missing columns with NULL values
* Check you are using the correct file compression, otherwise set it (e.g., compression = 'zstd')
```