### PR TITLE
Add fallback for thread count if jemalloc cannot identify

### DIFF
--- a/extension/jemalloc/include/malloc_ncpus.h
+++ b/extension/jemalloc/include/malloc_ncpus.h
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// malloc_ncpus.h
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MALLOC_NCPUS_H
+#define MALLOC_NCPUS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+unsigned duckdb_malloc_ncpus();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MALLOC_NCPUS_H

--- a/extension/jemalloc/jemalloc/README.md
+++ b/extension/jemalloc/jemalloc/README.md
@@ -65,6 +65,8 @@ Add this to `jemalloc.h`:
 We also supply our own config string in `jemalloc.c`.
 Define this just after the `#include`s.
 ```c++
+#include "malloc_ncpus.h"
+
 #define JE_MALLOC_CONF_BUFFER_SIZE 200
 char JE_MALLOC_CONF_BUFFER[JE_MALLOC_CONF_BUFFER_SIZE];
 ```
@@ -74,6 +76,9 @@ JEMALLOC_ATTR(constructor)
 static void
 jemalloc_constructor(void) {
 	unsigned long long cpu_count = malloc_ncpus();
+	if (cpu_count == 0) {
+		cpu_count = duckdb_malloc_ncpus();
+	}
 	unsigned long long bgt_count = cpu_count / 16;
 	if (bgt_count == 0) {
 		bgt_count = 1;

--- a/extension/jemalloc/jemalloc/src/jemalloc.c
+++ b/extension/jemalloc/jemalloc/src/jemalloc.c
@@ -25,6 +25,8 @@
 #include "jemalloc/internal/thread_event.h"
 #include "jemalloc/internal/util.h"
 
+#include "malloc_ncpus.h"
+
 /******************************************************************************/
 /* Data. */
 
@@ -4270,6 +4272,9 @@ JEMALLOC_ATTR(constructor)
 static void
 jemalloc_constructor(void) {
 	unsigned long long cpu_count = malloc_ncpus();
+	if (cpu_count == 0) {
+		cpu_count = duckdb_malloc_ncpus();
+	}
 	unsigned long long bgt_count = cpu_count / 16;
 	if (bgt_count == 0) {
 		bgt_count = 1;

--- a/extension/jemalloc/jemalloc_extension.cpp
+++ b/extension/jemalloc/jemalloc_extension.cpp
@@ -3,6 +3,9 @@
 
 #include "duckdb/common/allocator.hpp"
 #include "jemalloc/jemalloc.h"
+#include "malloc_ncpus.h"
+
+#include <thread>
 
 namespace duckdb {
 
@@ -113,6 +116,10 @@ std::string JemallocExtension::Version() const {
 } // namespace duckdb
 
 extern "C" {
+
+unsigned duckdb_malloc_ncpus() {
+	return duckdb::NumericCast<unsigned>(std::thread::hardware_concurrency());
+}
 
 DUCKDB_EXTENSION_API void jemalloc_init(duckdb::DatabaseInstance &db) {
 	duckdb::DuckDB db_wrapper(db);

--- a/extension/jemalloc/jemalloc_extension.cpp
+++ b/extension/jemalloc/jemalloc_extension.cpp
@@ -118,7 +118,11 @@ std::string JemallocExtension::Version() const {
 extern "C" {
 
 unsigned duckdb_malloc_ncpus() {
+#ifdef DUCKDB_NO_THREADS
+	return 1
+#else
 	return duckdb::NumericCast<unsigned>(std::thread::hardware_concurrency());
+#endif
 }
 
 DUCKDB_EXTENSION_API void jemalloc_init(duckdb::DatabaseInstance &db) {


### PR DESCRIPTION
Should hopefully fix https://github.com/duckdb/duckdb/issues/14636 (can't test on that hardware).