### PR TITLE
Propagate collations through functions in a generic manner

### DIFF
--- a/extension/core_functions/scalar/string/starts_with.cpp
+++ b/extension/core_functions/scalar/string/starts_with.cpp
@@ -37,8 +37,10 @@ struct StartsWithOperator {
 };
 
 ScalarFunction StartsWithOperatorFun::GetFunction() {
-	return ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, StartsWithOperator>);
+	ScalarFunction starts_with({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                           ScalarFunction::BinaryFunction<string_t, string_t, bool, StartsWithOperator>);
+	starts_with.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return starts_with;
 }
 
 } // namespace duckdb

--- a/extension/icu/icu_extension.cpp
+++ b/extension/icu/icu_extension.cpp
@@ -154,7 +154,6 @@ static void ICUCollateFunction(DataChunk &args, ExpressionState &state, Vector &
 			str_data[i * 2 + 1] = HEX_TABLE[byte % 16];
 		}
 		str_result.Finalize();
-		// printf("%s: %s\n", input.GetString().c_str(), str_result.GetString().c_str());
 		return str_result;
 	});
 }

--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -1658,6 +1658,25 @@ ForeignKeyType EnumUtil::FromString<ForeignKeyType>(const char *value) {
 	return static_cast<ForeignKeyType>(StringUtil::StringToEnum(GetForeignKeyTypeValues(), 3, "ForeignKeyType", value));
 }
 
+const StringUtil::EnumStringLiteral *GetFunctionCollationHandlingValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(FunctionCollationHandling::PROPAGATE_COLLATIONS), "PROPAGATE_COLLATIONS" },
+		{ static_cast<uint32_t>(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS), "PUSH_COMBINABLE_COLLATIONS" },
+		{ static_cast<uint32_t>(FunctionCollationHandling::IGNORE_COLLATIONS), "IGNORE_COLLATIONS" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<FunctionCollationHandling>(FunctionCollationHandling value) {
+	return StringUtil::EnumToString(GetFunctionCollationHandlingValues(), 3, "FunctionCollationHandling", static_cast<uint32_t>(value));
+}
+
+template<>
+FunctionCollationHandling EnumUtil::FromString<FunctionCollationHandling>(const char *value) {
+	return static_cast<FunctionCollationHandling>(StringUtil::StringToEnum(GetFunctionCollationHandlingValues(), 3, "FunctionCollationHandling", value));
+}
+
 const StringUtil::EnumStringLiteral *GetFunctionNullHandlingValues() {
 	static constexpr StringUtil::EnumStringLiteral values[] {
 		{ static_cast<uint32_t>(FunctionNullHandling::DEFAULT_NULL_HANDLING), "DEFAULT_NULL_HANDLING" },

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -76,7 +76,8 @@ BaseScalarFunction::BaseScalarFunction(string name_p, vector<LogicalType> argume
                                        FunctionStability stability, LogicalType varargs_p,
                                        FunctionNullHandling null_handling)
     : SimpleFunction(std::move(name_p), std::move(arguments_p), std::move(varargs_p)),
-      return_type(std::move(return_type_p)), stability(stability), null_handling(null_handling) {
+      return_type(std::move(return_type_p)), stability(stability), null_handling(null_handling),
+      collation_handling(FunctionCollationHandling::PROPAGATE_COLLATIONS) {
 }
 
 BaseScalarFunction::~BaseScalarFunction() {

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -99,7 +99,7 @@ void BuiltinFunctions::Initialize() {
 
 	// initialize collations
 	AddCollation("nocase", LowerFun::GetFunction(), true);
-	AddCollation("noaccent", StripAccentsFun::GetFunction());
+	AddCollation("noaccent", StripAccentsFun::GetFunction(), true);
 	AddCollation("nfc", NFCNormalizeFun::GetFunction());
 
 	RegisterExtensionOverloads();

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -437,6 +437,7 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_f
                                                           vector<unique_ptr<Expression>> children, bool is_operator,
                                                           optional_ptr<Binder> binder) {
 	unique_ptr<FunctionData> bind_info;
+
 	if (bound_function.bind) {
 		bind_info = bound_function.bind(context, bound_function, children);
 	}

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -356,13 +356,14 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunctionCatalogE
 	return BindScalarFunction(bound_function, std::move(children), is_operator, binder);
 }
 
-void PropagateCollations(ClientContext &context, ScalarFunction &bound_function, vector<unique_ptr<Expression>> &children) {
+void PropagateCollations(ClientContext &context, ScalarFunction &bound_function,
+                         vector<unique_ptr<Expression>> &children) {
 	if (bound_function.return_type.id() != LogicalTypeId::VARCHAR || bound_function.return_type.HasAlias()) {
 		// we only propagate collations for VARCHAR columns
 		return;
 	}
 	string collation;
-	for(auto &arg : children) {
+	for (auto &arg : children) {
 		if (arg->return_type.id() != LogicalTypeId::VARCHAR || arg->return_type.HasAlias()) {
 			// not a varchar column
 			continue;
@@ -381,7 +382,7 @@ void PropagateCollations(ClientContext &context, ScalarFunction &bound_function,
 	// propagate the collation
 	auto collation_type = LogicalType::VARCHAR_COLLATION(collation);
 	bound_function.return_type = collation_type;
-	for(auto &arg : children) {
+	for (auto &arg : children) {
 		if (arg->return_type.id() != LogicalTypeId::VARCHAR || arg->return_type.HasAlias()) {
 			// not a varchar column
 			continue;
@@ -392,13 +393,14 @@ void PropagateCollations(ClientContext &context, ScalarFunction &bound_function,
 
 void PushCollations(ClientContext &context, vector<unique_ptr<Expression>> &children) {
 	// push collations
-	for(auto &arg : children) {
+	for (auto &arg : children) {
 		ExpressionBinder::PushCollation(context, arg, arg->return_type);
 	}
 }
 
-void HandleCollations(ClientContext &context, ScalarFunction &bound_function, vector<unique_ptr<Expression>> &children) {
-	switch(bound_function.collation_handling) {
+void HandleCollations(ClientContext &context, ScalarFunction &bound_function,
+                      vector<unique_ptr<Expression>> &children) {
+	switch (bound_function.collation_handling) {
 	case FunctionCollationHandling::IGNORE_COLLATIONS:
 		// explicitly ignoring collation handling
 		break;

--- a/src/function/function_binder.cpp
+++ b/src/function/function_binder.cpp
@@ -356,6 +356,66 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunctionCatalogE
 	return BindScalarFunction(bound_function, std::move(children), is_operator, binder);
 }
 
+void PropagateCollations(ClientContext &context, ScalarFunction &bound_function, vector<unique_ptr<Expression>> &children) {
+	if (bound_function.return_type.id() != LogicalTypeId::VARCHAR || bound_function.return_type.HasAlias()) {
+		// we only propagate collations for VARCHAR columns
+		return;
+	}
+	string collation;
+	for(auto &arg : children) {
+		if (arg->return_type.id() != LogicalTypeId::VARCHAR || arg->return_type.HasAlias()) {
+			// not a varchar column
+			continue;
+		}
+		auto child_collation = StringType::GetCollation(arg->return_type);
+		if (collation.empty()) {
+			collation = child_collation;
+		} else if (!child_collation.empty() && collation != child_collation) {
+			throw BinderException("Cannot combine types with different collation!");
+		}
+	}
+	if (collation.empty()) {
+		// no collation to propagate
+		return;
+	}
+	// propagate the collation
+	auto collation_type = LogicalType::VARCHAR_COLLATION(collation);
+	bound_function.return_type = collation_type;
+	for(auto &arg : children) {
+		if (arg->return_type.id() != LogicalTypeId::VARCHAR || arg->return_type.HasAlias()) {
+			// not a varchar column
+			continue;
+		}
+		arg->return_type = collation_type;
+	}
+}
+
+void PushCollations(ClientContext &context, vector<unique_ptr<Expression>> &children) {
+	// push collations
+	for(auto &arg : children) {
+		ExpressionBinder::PushCollation(context, arg, arg->return_type);
+	}
+}
+
+void HandleCollations(ClientContext &context, ScalarFunction &bound_function, vector<unique_ptr<Expression>> &children) {
+	switch(bound_function.collation_handling) {
+	case FunctionCollationHandling::IGNORE_COLLATIONS:
+		// explicitly ignoring collation handling
+		break;
+	case FunctionCollationHandling::PROPAGATE_COLLATIONS:
+		// propagate collations to the return type
+		PropagateCollations(context, bound_function, children);
+		break;
+	case FunctionCollationHandling::PUSH_COLLATIONS:
+		// first propagate, then push collations to the children
+		PropagateCollations(context, bound_function, children);
+		PushCollations(context, children);
+		break;
+	default:
+		throw InternalException("Unrecognized collation handling");
+	}
+}
+
 unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_function,
                                                           vector<unique_ptr<Expression>> children, bool is_operator,
                                                           optional_ptr<Binder> binder) {
@@ -368,10 +428,11 @@ unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_f
 		FunctionModifiedDatabasesInput input(bind_info, properties);
 		bound_function.get_modified_databases(context, input);
 	}
+	HandleCollations(context, bound_function, children);
+
 	// check if we need to add casts to the children
 	CastToFunctionArguments(bound_function, children);
 
-	// now create the function
 	auto return_type = bound_function.return_type;
 	unique_ptr<Expression> result;
 	auto result_func = make_uniq<BoundFunctionExpression>(std::move(return_type), std::move(bound_function),

--- a/src/function/scalar/string/contains.cpp
+++ b/src/function/scalar/string/contains.cpp
@@ -155,6 +155,7 @@ struct ContainsOperator {
 ScalarFunction GetStringContains() {
 	ScalarFunction string_fun("contains", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
 	                          ScalarFunction::BinaryFunction<string_t, string_t, bool, ContainsOperator>);
+	string_fun.collation_handling = FunctionCollationHandling::PUSH_COLLATIONS;
 	return string_fun;
 }
 

--- a/src/function/scalar/string/contains.cpp
+++ b/src/function/scalar/string/contains.cpp
@@ -155,7 +155,7 @@ struct ContainsOperator {
 ScalarFunction GetStringContains() {
 	ScalarFunction string_fun("contains", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
 	                          ScalarFunction::BinaryFunction<string_t, string_t, bool, ContainsOperator>);
-	string_fun.collation_handling = FunctionCollationHandling::PUSH_COLLATIONS;
+	string_fun.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
 	return string_fun;
 }
 

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -207,6 +207,11 @@ static unique_ptr<FunctionData> LikeBindFunction(ClientContext &context, ScalarF
                                                  vector<unique_ptr<Expression>> &arguments) {
 	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
 	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
+	for (auto &arg : arguments) {
+		if (arg->return_type.id() == LogicalTypeId::VARCHAR && !StringType::GetCollation(arg->return_type).empty()) {
+			return nullptr;
+		}
+	}
 	if (arguments[1]->IsFoldable()) {
 		Value pattern_str = ExpressionExecutor::EvaluateScalar(context, *arguments[1]);
 		return LikeMatcher::CreateLikeMatcher(pattern_str.ToString());
@@ -514,49 +519,69 @@ static void RegularLikeFunction(DataChunk &input, ExpressionState &state, Vector
 }
 
 ScalarFunction NotLikeFun::GetFunction() {
-	return ScalarFunction("!~~", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                      RegularLikeFunction<NotLikeOperator, true>, LikeBindFunction);
+	ScalarFunction not_like("!~~", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                        RegularLikeFunction<NotLikeOperator, true>, LikeBindFunction);
+	not_like.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return not_like;
 }
 
 ScalarFunction GlobPatternFun::GetFunction() {
-	return ScalarFunction("~~~", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, GlobOperator>);
+	ScalarFunction glob("~~~", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                    ScalarFunction::BinaryFunction<string_t, string_t, bool, GlobOperator>);
+	glob.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return glob;
 }
 
 ScalarFunction ILikeFun::GetFunction() {
-	return ScalarFunction("~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, ILikeOperator>, nullptr, nullptr,
-	                      ILikePropagateStats<ILikeOperatorASCII>);
+	ScalarFunction ilike("~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                     ScalarFunction::BinaryFunction<string_t, string_t, bool, ILikeOperator>, nullptr, nullptr,
+	                     ILikePropagateStats<ILikeOperatorASCII>);
+	ilike.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return ilike;
 }
 
 ScalarFunction NotILikeFun::GetFunction() {
-	return ScalarFunction("!~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, NotILikeOperator>, nullptr, nullptr,
-	                      ILikePropagateStats<NotILikeOperatorASCII>);
+	ScalarFunction not_ilike("!~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                         ScalarFunction::BinaryFunction<string_t, string_t, bool, NotILikeOperator>, nullptr,
+	                         nullptr, ILikePropagateStats<NotILikeOperatorASCII>);
+	not_ilike.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return not_ilike;
 }
 
 ScalarFunction LikeFun::GetFunction() {
-	return ScalarFunction("~~", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
-	                      RegularLikeFunction<LikeOperator, false>, LikeBindFunction);
+	ScalarFunction like("~~", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                    RegularLikeFunction<LikeOperator, false>, LikeBindFunction);
+	like.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return like;
 }
 
 ScalarFunction NotLikeEscapeFun::GetFunction() {
-	return ScalarFunction("not_like_escape", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                      LogicalType::BOOLEAN, LikeEscapeFunction<NotLikeEscapeOperator>);
+	ScalarFunction not_like_escape("not_like_escape",
+	                               {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                               LogicalType::BOOLEAN, LikeEscapeFunction<NotLikeEscapeOperator>);
+	not_like_escape.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return not_like_escape;
 }
 
 ScalarFunction IlikeEscapeFun::GetFunction() {
-	return ScalarFunction("ilike_escape", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                      LogicalType::BOOLEAN, LikeEscapeFunction<ILikeEscapeOperator>);
+	ScalarFunction ilike_escape("ilike_escape", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                            LogicalType::BOOLEAN, LikeEscapeFunction<ILikeEscapeOperator>);
+	ilike_escape.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return ilike_escape;
 }
 
 ScalarFunction NotIlikeEscapeFun::GetFunction() {
-	return ScalarFunction("not_ilike_escape", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                      LogicalType::BOOLEAN, LikeEscapeFunction<NotILikeEscapeOperator>);
+	ScalarFunction not_ilike_escape("not_ilike_escape",
+	                                {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                LogicalType::BOOLEAN, LikeEscapeFunction<NotILikeEscapeOperator>);
+	not_ilike_escape.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return not_ilike_escape;
 }
 ScalarFunction LikeEscapeFun::GetFunction() {
-	return ScalarFunction("like_escape", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                      LogicalType::BOOLEAN, LikeEscapeFunction<LikeEscapeOperator>);
+	ScalarFunction like_escape("like_escape", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                           LogicalType::BOOLEAN, LikeEscapeFunction<LikeEscapeOperator>);
+	like_escape.collation_handling = FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS;
+	return like_escape;
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -166,6 +166,8 @@ enum class FilterPropagateResult : uint8_t;
 
 enum class ForeignKeyType : uint8_t;
 
+enum class FunctionCollationHandling : uint8_t;
+
 enum class FunctionNullHandling : uint8_t;
 
 enum class FunctionStability : uint8_t;
@@ -567,6 +569,9 @@ const char* EnumUtil::ToChars<FilterPropagateResult>(FilterPropagateResult value
 
 template<>
 const char* EnumUtil::ToChars<ForeignKeyType>(ForeignKeyType value);
+
+template<>
+const char* EnumUtil::ToChars<FunctionCollationHandling>(FunctionCollationHandling value);
 
 template<>
 const char* EnumUtil::ToChars<FunctionNullHandling>(FunctionNullHandling value);
@@ -1069,6 +1074,9 @@ FilterPropagateResult EnumUtil::FromString<FilterPropagateResult>(const char *va
 
 template<>
 ForeignKeyType EnumUtil::FromString<ForeignKeyType>(const char *value);
+
+template<>
+FunctionCollationHandling EnumUtil::FromString<FunctionCollationHandling>(const char *value);
 
 template<>
 FunctionNullHandling EnumUtil::FromString<FunctionNullHandling>(const char *value);

--- a/src/include/duckdb/common/enums/collation_type.hpp
+++ b/src/include/duckdb/common/enums/collation_type.hpp
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/collation_type.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+enum class CollationType { ALL_COLLATIONS, COMBINABLE_COLLATIONS };
+
+} // namespace duckdb

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -44,10 +44,15 @@ enum class FunctionNullHandling : uint8_t { DEFAULT_NULL_HANDLING = 0, SPECIAL_H
 //! VOLATILE                -> the result of this function might change per row (e.g. RANDOM())
 enum class FunctionStability : uint8_t { CONSISTENT = 0, VOLATILE = 1, CONSISTENT_WITHIN_QUERY = 2 };
 //! How to handle collations
-//! PROPAGATE_COLLATIONS    -> this function combines collation from its inputs and emits them again (default behavior)
-//! PUSH_COLLATIONS         -> collations are executed for the input arguments, and collations are propagated
-//! IGNORE_COLLATIONS       -> collations are completely ignored by the function
-enum class FunctionCollationHandling : uint8_t { PROPAGATE_COLLATIONS = 0, PUSH_COLLATIONS = 1, IGNORE_COLLATIONS = 2 };
+//! PROPAGATE_COLLATIONS        -> this function combines collation from its inputs and emits them again (default
+//! behavior) PUSH_COMBINABLE_COLLATIONS  -> combinable collations are executed for the input arguments, and collations
+//! are propagated. non-combinable collations are ignored IGNORE_COLLATIONS           -> collations are completely
+//! ignored by the function
+enum class FunctionCollationHandling : uint8_t {
+	PROPAGATE_COLLATIONS = 0,
+	PUSH_COMBINABLE_COLLATIONS = 1,
+	IGNORE_COLLATIONS = 2
+};
 
 struct FunctionData {
 	DUCKDB_API virtual ~FunctionData();

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -44,10 +44,9 @@ enum class FunctionNullHandling : uint8_t { DEFAULT_NULL_HANDLING = 0, SPECIAL_H
 //! VOLATILE                -> the result of this function might change per row (e.g. RANDOM())
 enum class FunctionStability : uint8_t { CONSISTENT = 0, VOLATILE = 1, CONSISTENT_WITHIN_QUERY = 2 };
 //! How to handle collations
-//! PROPAGATE_COLLATIONS        -> this function combines collation from its inputs and emits them again (default
-//! behavior) PUSH_COMBINABLE_COLLATIONS  -> combinable collations are executed for the input arguments, and collations
-//! are propagated. non-combinable collations are ignored IGNORE_COLLATIONS           -> collations are completely
-//! ignored by the function
+//! PROPAGATE_COLLATIONS        -> this function combines collation from its inputs and emits them again (default)
+//! PUSH_COMBINABLE_COLLATIONS  -> combinable collations are executed for the input arguments
+//! IGNORE_COLLATIONS           -> collations are completely ignored by the function
 enum class FunctionCollationHandling : uint8_t {
 	PROPAGATE_COLLATIONS = 0,
 	PUSH_COMBINABLE_COLLATIONS = 1,

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -43,6 +43,11 @@ enum class FunctionNullHandling : uint8_t { DEFAULT_NULL_HANDLING = 0, SPECIAL_H
 //!                            but the result might change across queries (e.g. NOW(), CURRENT_TIME)
 //! VOLATILE                -> the result of this function might change per row (e.g. RANDOM())
 enum class FunctionStability : uint8_t { CONSISTENT = 0, VOLATILE = 1, CONSISTENT_WITHIN_QUERY = 2 };
+//! How to handle collations
+//! PROPAGATE_COLLATIONS    -> this function combines collation from its inputs and emits them again (default behavior)
+//! PUSH_COLLATIONS         -> collations are executed for the input arguments, and collations are propagated
+//! IGNORE_COLLATIONS       -> collations are completely ignored by the function
+enum class FunctionCollationHandling : uint8_t { PROPAGATE_COLLATIONS = 0, PUSH_COLLATIONS = 1, IGNORE_COLLATIONS = 2 };
 
 struct FunctionData {
 	DUCKDB_API virtual ~FunctionData();
@@ -159,6 +164,8 @@ public:
 	FunctionStability stability;
 	//! How this function handles NULL values
 	FunctionNullHandling null_handling;
+	//! Collation handling of the function
+	FunctionCollationHandling collation_handling;
 
 public:
 	DUCKDB_API hash_t Hash() const;

--- a/src/include/duckdb/planner/collation_binding.hpp
+++ b/src/include/duckdb/planner/collation_binding.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/function/cast/default_casts.hpp"
+#include "duckdb/common/enums/collation_type.hpp"
 
 namespace duckdb {
 struct MapCastInfo;
@@ -16,7 +17,7 @@ struct MapCastNode;
 struct DBConfig;
 
 typedef bool (*try_push_collation_t)(ClientContext &context, unique_ptr<Expression> &source,
-                                     const LogicalType &sql_type);
+                                     const LogicalType &sql_type, CollationType type);
 
 struct CollationCallback {
 	explicit CollationCallback(try_push_collation_t try_push_collation_p) : try_push_collation(try_push_collation_p) {
@@ -34,8 +35,8 @@ public:
 	DUCKDB_API static CollationBinding &Get(DatabaseInstance &db);
 
 	DUCKDB_API void RegisterCollation(CollationCallback callback);
-	DUCKDB_API bool PushCollation(ClientContext &context, unique_ptr<Expression> &source,
-	                              const LogicalType &sql_type) const;
+	DUCKDB_API bool PushCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
+	                              CollationType type) const;
 
 private:
 	vector<CollationCallback> collations;

--- a/src/include/duckdb/planner/expression_binder.hpp
+++ b/src/include/duckdb/planner/expression_binder.hpp
@@ -22,6 +22,7 @@
 #include "duckdb/planner/expression/bound_lambda_expression.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/planner/column_binding.hpp"
+#include "duckdb/common/enums/collation_type.hpp"
 
 namespace duckdb {
 
@@ -118,7 +119,8 @@ public:
 	static void QualifyColumnNames(Binder &binder, unique_ptr<ParsedExpression> &expr);
 	static void QualifyColumnNames(ExpressionBinder &binder, unique_ptr<ParsedExpression> &expr);
 
-	static bool PushCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type);
+	static bool PushCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
+	                          CollationType type = CollationType::ALL_COLLATIONS);
 	static void TestCollation(ClientContext &context, const string &collation);
 
 	BindResult BindCorrelatedColumns(unique_ptr<ParsedExpression> &expr, ErrorData error_message);

--- a/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -16,9 +16,9 @@
 namespace duckdb {
 
 bool ExpressionBinder::PushCollation(ClientContext &context, unique_ptr<Expression> &source,
-                                     const LogicalType &sql_type) {
+                                     const LogicalType &sql_type, CollationType type) {
 	auto &collation_binding = CollationBinding::Get(context);
-	return collation_binding.PushCollation(context, source, sql_type);
+	return collation_binding.PushCollation(context, source, sql_type, type);
 }
 
 void ExpressionBinder::TestCollation(ClientContext &context, const string &collation) {

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -8,7 +8,8 @@
 
 namespace duckdb {
 
-bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type) {
+bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
+                          CollationType type) {
 	if (sql_type.id() != LogicalTypeId::VARCHAR) {
 		// only VARCHAR columns require collation
 		return false;
@@ -44,6 +45,10 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 	}
 	for (auto &entry : entries) {
 		auto &collation_entry = entry.get();
+		if (!collation_entry.combinable && type == CollationType::COMBINABLE_COLLATIONS) {
+			// not a combinable collation - ignore
+			return false;
+		}
 		vector<unique_ptr<Expression>> children;
 		children.push_back(std::move(source));
 
@@ -54,7 +59,8 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 	return true;
 }
 
-bool PushTimeTZCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type) {
+bool PushTimeTZCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
+                         CollationType) {
 	if (sql_type.id() != LogicalTypeId::TIME_TZ) {
 		return false;
 	}
@@ -86,9 +92,9 @@ void CollationBinding::RegisterCollation(CollationCallback callback) {
 }
 
 bool CollationBinding::PushCollation(ClientContext &context, unique_ptr<Expression> &source,
-                                     const LogicalType &sql_type) const {
+                                     const LogicalType &sql_type, CollationType type) const {
 	for (auto &collation : collations) {
-		if (collation.try_push_collation(context, source, sql_type)) {
+		if (collation.try_push_collation(context, source, sql_type, type)) {
 			// successfully pushed a collation
 			return true;
 		}

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -31,7 +31,12 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto splits = StringUtil::Split(StringUtil::Lower(collation), ".");
 	vector<reference<CollateCatalogEntry>> entries;
+	unordered_set<string> collations;
 	for (auto &collation_argument : splits) {
+		if (collations.count(collation_argument)) {
+			// we already applied this collation
+			continue;
+		}
 		auto &collation_entry = catalog.GetEntry<CollateCatalogEntry>(context, DEFAULT_SCHEMA, collation_argument);
 		if (collation_entry.combinable) {
 			entries.insert(entries.begin(), collation_entry);
@@ -42,6 +47,7 @@ bool PushVarcharCollation(ClientContext &context, unique_ptr<Expression> &source
 			}
 			entries.push_back(collation_entry);
 		}
+		collations.insert(collation_argument);
 	}
 	for (auto &entry : entries) {
 		auto &collation_entry = entry.get();

--- a/test/sql/collate/collate_like.test
+++ b/test/sql/collate/collate_like.test
@@ -1,0 +1,98 @@
+# name: test/sql/collate/collate_like.test
+# description: Test collations in the LIKE clause
+# group: [collate]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT 'a' LIKE 'A' COLLATE NOCASE
+----
+true
+
+query I
+SELECT 'a' NOT LIKE 'A' COLLATE NOCASE
+----
+false
+
+query I
+SELECT 'A' COLLATE NOCASE LIKE 'a'
+----
+true
+
+# like optimization rules
+query I
+SELECT 'a' LIKE 'A%' COLLATE NOCASE
+----
+true
+
+query I
+SELECT 'A' COLLATE NOCASE LIKE '%A' COLLATE NOCASE
+----
+true
+
+query I
+SELECT 'a' COLLATE NOCASE LIKE '%A%' COLLATE NOCASE
+----
+true
+
+query I
+SELECT 'OX' COLLATE NOACCENT.NOCASE LIKE 'ö%'
+----
+true
+
+#### Testing LIKE with collated columns
+statement ok
+CREATE TABLE t1 (c1 VARCHAR, pattern VARCHAR)
+
+statement ok
+INSERT INTO t1 VALUES('A', 'a'),('a', 'A'),('AAAA', 'AaAa'),('aaaa', 'baba')
+
+query I
+SELECT c1 FROM t1 WHERE c1 LIKE pattern
+----
+
+query I
+SELECT c1 FROM t1 WHERE c1 LIKE pattern COLLATE NOCASE
+----
+A
+a
+AAAA
+
+# like escape
+query I
+SELECT 'a%ö' COLLATE NOACCENT LIKE 'a$%ö' ESCAPE '$'
+----
+true
+
+query I
+SELECT 'a%ö' COLLATE NOACCENT NOT LIKE 'a$%ö' ESCAPE '$'
+----
+false
+
+# ilike
+query I
+SELECT 'oX' ILIKE 'Ö%'
+----
+false
+
+query I
+SELECT 'OX' COLLATE NOACCENT ILIKE 'ö%'
+----
+true
+
+query I
+SELECT 'öX' COLLATE NOACCENT NOT ILIKE 'Ö%'
+----
+false
+
+# glob
+query I
+SELECT 'oX' GLOB 'O*'
+----
+false
+
+query I
+SELECT 'oX' COLLATE NOCASE GLOB 'O*'
+----
+true

--- a/test/sql/collate/icu_collation_propagation.test
+++ b/test/sql/collate/icu_collation_propagation.test
@@ -98,3 +98,9 @@ query I
 select a from tbl where starts_with(b collate de, '>>>>>o') order by all
 ----
 o
+
+query I
+select a from tbl where b collate de like '%>o<%' order by all
+----
+o
+

--- a/test/sql/collate/icu_collation_propagation.test
+++ b/test/sql/collate/icu_collation_propagation.test
@@ -1,0 +1,100 @@
+# name: test/sql/collate/icu_collation_propagation.test
+# description: Test collations with string functions
+# group: [collate]
+
+statement ok
+create table tbl (a varchar, b varchar);
+
+statement ok
+insert into tbl values ('ö', '>>>>>ö<<<<<'), ('o', '>>>>>o<<<<<'), ('p', '>>>>>p<<<<<');
+
+require icu
+
+# test propagation of collation through string functions
+query I
+select concat(a collate de, a) from tbl order by all;
+----
+oo
+öö
+pp
+
+query I
+select lower(a collate de) from tbl order by all;
+----
+o
+ö
+p
+
+query I
+select upper(a collate de) from tbl order by all;
+----
+O
+Ö
+P
+
+query I
+select trim(b collate de, '<>') from tbl order by all
+----
+o
+ö
+p
+
+query I
+select ltrim(b collate de, '<>') from tbl order by all
+----
+o<<<<<
+ö<<<<<
+p<<<<<
+
+query I
+select rtrim(b collate de, '<>') from tbl order by all
+----
+>>>>>o
+>>>>>ö
+>>>>>p
+
+query I
+select repeat(a collate de, 10) from tbl order by all;
+----
+oooooooooo
+öööööööööö
+pppppppppp
+
+query I
+select left(b collate de, 6) from tbl order by all;
+----
+>>>>>o
+>>>>>ö
+>>>>>p
+
+query I
+select right(b collate de, 6) from tbl order by all;
+----
+o<<<<<
+ö<<<<<
+p<<<<<
+
+query I
+select right(left(b collate de, 6), 1) from tbl order by all;
+----
+o
+ö
+p
+
+query I
+select reverse(a collate de) from tbl order by all;
+----
+o
+ö
+p
+
+# test application of collation
+query I
+select a from tbl where contains(b collate de, 'o') order by all
+----
+o
+
+query I
+select a from tbl where starts_with(b collate de, '>>>>>o') order by all
+----
+o

--- a/test/sql/collate/test_collation_propagation.test
+++ b/test/sql/collate/test_collation_propagation.test
@@ -1,0 +1,106 @@
+# name: test/issues/general/test_9854.test
+# description: Issue 1091: Functions don't check or pass collation.
+# group: [general]
+
+statement ok
+create table tbl (a varchar, b varchar);
+
+statement ok
+insert into tbl values ('ö', '>>>>>ö<<<<<'), ('o', '>>>>>o<<<<<'), ('p', '>>>>>p<<<<<');
+
+# test propagation of collation through string functions
+query I
+select concat(a collate noaccent, a) from tbl order by all;
+----
+öö
+oo
+pp
+
+query I
+select lower(a collate noaccent) from tbl order by all;
+----
+ö
+o
+p
+
+query I
+select upper(a collate noaccent) from tbl order by all;
+----
+Ö
+O
+P
+
+query I
+select trim(b collate noaccent, '<>') from tbl order by all
+----
+ö
+o
+p
+
+query I
+select ltrim(b collate noaccent, '<>') from tbl order by all
+----
+ö<<<<<
+o<<<<<
+p<<<<<
+
+query I
+select rtrim(b collate noaccent, '<>') from tbl order by all
+----
+>>>>>ö
+>>>>>o
+>>>>>p
+
+query I
+select repeat(a collate noaccent, 10) from tbl order by all;
+----
+öööööööööö
+oooooooooo
+pppppppppp
+
+query I
+select left(b collate noaccent, 6) from tbl order by all;
+----
+>>>>>ö
+>>>>>o
+>>>>>p
+
+query I
+select right(b collate noaccent, 6) from tbl order by all;
+----
+ö<<<<<
+o<<<<<
+p<<<<<
+
+query I
+select right(left(b collate noaccent, 6), 1) from tbl order by all;
+----
+ö
+o
+p
+
+query I
+select reverse(a collate noaccent) from tbl order by all;
+----
+ö
+o
+p
+
+# test application of collation
+query I
+select a from tbl where contains(b collate noaccent, 'o') order by all
+----
+o
+ös
+
+query I
+select a from tbl where starts_with(b collate noaccent, 'o') order by all
+----
+o
+ö
+
+query I
+select a from tbl where ends_with(b collate noaccent, 'o') order by all
+----
+o
+ö

--- a/test/sql/collate/test_collation_propagation.test
+++ b/test/sql/collate/test_collation_propagation.test
@@ -1,12 +1,17 @@
-# name: test/issues/general/test_9854.test
-# description: Issue 1091: Functions don't check or pass collation.
-# group: [general]
+# name: test/sql/collate/test_collation_propagation.test
+# description: Test collations with string functions.
+# group: [collate]
 
 statement ok
 create table tbl (a varchar, b varchar);
 
 statement ok
 insert into tbl values ('ö', '>>>>>ö<<<<<'), ('o', '>>>>>o<<<<<'), ('p', '>>>>>p<<<<<');
+
+query I
+select a from tbl where contains(b collate nocase, 'O') order by all
+----
+o
 
 # test propagation of collation through string functions
 query I
@@ -86,21 +91,26 @@ select reverse(a collate noaccent) from tbl order by all;
 o
 p
 
-# test application of collation
+# test pushing collations
 query I
 select a from tbl where contains(b collate noaccent, 'o') order by all
-----
-o
-ös
-
-query I
-select a from tbl where starts_with(b collate noaccent, 'o') order by all
 ----
 o
 ö
 
 query I
-select a from tbl where ends_with(b collate noaccent, 'o') order by all
+select a from tbl where contains(b, 'ö' collate noaccent) order by all
+----
+o
+ö
+
+query I
+select a from tbl where contains(b collate nocase, 'O') order by all
+----
+o
+
+query I
+select a from tbl where starts_with(b collate noaccent, '>>>>>o') order by all
 ----
 o
 ö

--- a/test/sql/collate/test_icu_collate.test
+++ b/test/sql/collate/test_icu_collate.test
@@ -47,10 +47,12 @@ SELECT * FROM strings WHERE 'goethe' > s COLLATE NOCASE.de ORDER BY 1
 Gabel
 Göbel
 
-# but not with NOACCENT
-statement error
+# and with NOACCENT
+query I
 SELECT * FROM strings WHERE 'goethe' > s COLLATE NOACCENT.de ORDER BY 1
 ----
+Gabel
+Göbel
 
 # japanese collation
 statement ok

--- a/test/sql/collate/test_icu_collate.test
+++ b/test/sql/collate/test_icu_collate.test
@@ -145,12 +145,8 @@ aAàÀáÁâÂãÃäÄåÅ
 bB
 zZ
 
-statement error
+statement ok
 SELECT 'Á' COLLATE "ICU_NOACCENT.NOACCENT"
-----
-Binder Error: Cannot combine collation types "icu_noaccent" and "noaccent"
 
-statement error
+statement ok
 SELECT 'Á' COLLATE "NOACCENT.ICU_NOACCENT"
-----
-Binder Error: Cannot combine collation types "noaccent" and "icu_noaccent"

--- a/test/sql/collate/test_unsupported_collations.test
+++ b/test/sql/collate/test_unsupported_collations.test
@@ -12,10 +12,9 @@ statement error
 CREATE TABLE collate_test(s INTEGER COLLATE blabla)
 ----
 
-# cannot combine these collations
-statement error
+# we can combine multiple of the same collation
+statement ok
 CREATE TABLE collate_test(s VARCHAR COLLATE NOACCENT.NOACCENT)
-----
 
 statement error
 CREATE TABLE collate_test(s VARCHAR COLLATE 1)
@@ -28,4 +27,3 @@ CREATE TABLE collate_test(s VARCHAR COLLATE 'hello')
 statement error
 PRAGMA default_collation='blabla'
 ----
-


### PR DESCRIPTION
Supersedes https://github.com/duckdb/duckdb/pull/12359

This PR adds a new property to functions - `FunctionCollationHandling`. This can be used to handle collations across different functions in an easy way. There are three settings:

* **PROPAGATE_COLLATIONS (default)**: Propagate collations, but do not apply them. This means that if the function returns `VARCHAR`, and any of the input arguments are `VARCHAR`, the return type will inherit the collations of the input arguments.
* **PUSH_COMBINABLE_COLLATIONS**: Propagates collations and applies **combinable** collations prior to calling the function. Combinable collations are "simple" collations like `nocase` and `noaccent`, but not `icu` collations that are more complex.
* **IGNORE_COLLATIONS**: Ignore collations entirely.

`PUSH_COMBINABLE_COLLATIONS` is used for various functions, e.g. `contains`, `starts_with`, `glob`, `like`, etc:

```sql
D SELECT 'hello' COLLATE NOCASE LIKE '%HEL%' AS result;
┌─────────┐
│ result  │
│ boolean │
├─────────┤
│ true    │
└─────────┘
```
 
