### PR TITLE
Removing upload-artifact@v3

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -95,7 +95,7 @@ jobs:
         zip -j libduckdb-android_${{matrix.arch}}.zip build/release/src/libduckdb*.*  src/include/duckdb.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-android_${{matrix.arch}}.zip
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: duckdb-binaries-android-${{matrix.arch}}
         path: |

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -330,7 +330,7 @@ jobs:
       run: |
         make
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: linux-extensions-64
         path: build/release/repository

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -124,7 +124,7 @@ jobs:
         zip -j libduckdb-src.zip src/amalgamation/duckdb.hpp src/amalgamation/duckdb.cpp src/include/duckdb.h src/include/duckdb_extension.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: duckdb-binaries-linux
         path: |
@@ -176,7 +176,7 @@ jobs:
          zip -j libduckdb-linux-aarch64.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
          ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-aarch64.zip duckdb_cli-linux-aarch64.zip
 
-     - uses: actions/upload-artifact@v3
+     - uses: actions/upload-artifact@v4
        with:
          name: duckdb-binaries-linux-aarch64
          path: |
@@ -230,7 +230,7 @@ jobs:
         signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
         ninja: 1
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: linux-extensions-64
         path: |
@@ -286,7 +286,7 @@ jobs:
           run_autoload_tests: 0
           ninja: 1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: linux-extensions-64-aarch64
           path: |
@@ -346,7 +346,7 @@ jobs:
         pip install cmake-format
         make format-fix
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: extension_entries.hpp
         path: |

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -912,7 +912,7 @@ jobs:
       run: |
         zip -r duckdb-wasm32.zip duckdb-wasm/packages/duckdb-wasm/src/bindings
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: duckdb-wasm32
         path: |
@@ -955,7 +955,7 @@ jobs:
         run: |
           zip -r coverage.zip coverage_html
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -154,7 +154,7 @@ jobs:
         treat_warn_as_error: 0
         ninja: 1
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: manylinux-extensions-x64
         path: |

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -234,7 +234,7 @@ jobs:
         pip install 'cibuildwheel>=2.16.2' build
         python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       if: ${{ matrix.arch == 'x86_64' }}
       with:
         name: manylinux-extensions-x64


### PR DESCRIPTION
GH Actions has deprecated the `upload-artifact@v3` action and emailed me that they will be **failing** starting December 5. This PR updates them to the next version, v4. The only [Breaking Change](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) that could possibly affect us is that "it is no longer possible to upload to the same named Artifact multiple times". I checked but we do not seem to be doing that. 

One possible issue is releases of the 1.1.x branch after December 5, those will likely fail without an update. 