### PR TITLE
Detect catalog changes on DROP IF EXISTS

### DIFF
--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -540,6 +540,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientCon
 	}
 	if (rebind == RebindQueryInfo::ATTEMPT_TO_REBIND) {
 		RebindPreparedStatement(lock, query, prepared, parameters);
+		CheckIfPreparedStatementIsExecutable(*prepared); // rerun this too as modified_databases might have changed
 	}
 	return PendingPreparedStatementInternal(lock, prepared, parameters);
 }

--- a/src/planner/binder/statement/bind_drop.cpp
+++ b/src/planner/binder/statement/bind_drop.cpp
@@ -35,6 +35,11 @@ BoundStatement Binder::Bind(DropStatement &stmt) {
 	case CatalogType::TABLE_ENTRY:
 	case CatalogType::TYPE_ENTRY: {
 		BindSchemaOrCatalog(stmt.info->catalog, stmt.info->schema);
+		auto catalog = Catalog::GetCatalogEntry(context, stmt.info->catalog);
+		if (catalog) {
+			// mark catalog as accessed
+			properties.RegisterDBRead(*catalog, context);
+		}
 		auto entry = Catalog::GetEntry(context, stmt.info->type, stmt.info->catalog, stmt.info->schema, stmt.info->name,
 		                               stmt.info->if_not_found);
 		if (!entry) {

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -422,6 +422,10 @@ idx_t DuckTransactionManager::GetCatalogVersion(Transaction &transaction_p) {
 void DuckTransactionManager::PushCatalogEntry(Transaction &transaction_p, duckdb::CatalogEntry &entry,
                                               duckdb::data_ptr_t extra_data, duckdb::idx_t extra_data_size) {
 	auto &transaction = transaction_p.Cast<DuckTransaction>();
+	if (!db.IsSystem() && !db.IsTemporary() && transaction.IsReadOnly()) {
+		throw InternalException("Attempting to do catalog changes on a transaction that is read-only - "
+		                        "this should not be possible");
+	}
 	transaction.catalog_version = ++last_uncommitted_catalog_version;
 	transaction.PushCatalogEntry(entry, extra_data, extra_data_size);
 }

--- a/test/api/test_prepared_api.cpp
+++ b/test/api/test_prepared_api.cpp
@@ -496,3 +496,15 @@ TEST_CASE("Test prepared statements with SET", "[api]") {
 	// this works
 	REQUIRE_NO_FAIL(prepare->Execute("NULLS FIRST"));
 }
+
+TEST_CASE("Test prepared statements that require rebind", "[api]") {
+	DuckDB db(nullptr);
+	Connection con1(db);
+	con1.EnableQueryVerification();
+
+	auto prepared = con1.Prepare("DROP TABLE IF EXISTS t1");
+
+	Connection con2(db);
+	REQUIRE_NO_FAIL(con2.Query("CREATE OR REPLACE TABLE t1 (c1 varchar)"));
+	REQUIRE_NO_FAIL(prepared->Execute());
+}


### PR DESCRIPTION
Fixes a bug where prepared statements of DROP IF EXISTS could run into an `INTERNAL Error: Attempting to commit a transaction that is read-only but has made changes - this should not be possible`. The problem is that in case the table does not exist during bind, the catalog access is not even registered as catalog READ access, and hence catalog change detection cannot kick in (triggering rebind).