### PR TITLE
Rework `BlockHandle` to no longer have friend classes, and rework `ConvertToPersistent` so it fails if there are active outstanding pins

### DIFF
--- a/src/execution/index/fixed_size_buffer.cpp
+++ b/src/execution/index/fixed_size_buffer.cpp
@@ -117,10 +117,12 @@ void FixedSizeBuffer::Serialize(PartialBlockManager &partial_block_manager, cons
 		allocation.partial_block = std::move(p_block_for_index);
 	}
 
-	partial_block_manager.RegisterPartialBlock(std::move(allocation));
-
 	// resetting this buffer
 	buffer_handle.Destroy();
+
+	// register the partial block
+	partial_block_manager.RegisterPartialBlock(std::move(allocation));
+
 	block_handle = block_manager.RegisterBlock(block_pointer.block_id);
 	D_ASSERT(block_handle->BlockId() < MAXIMUM_BLOCK);
 

--- a/src/include/duckdb/common/file_buffer.hpp
+++ b/src/include/duckdb/common/file_buffer.hpp
@@ -32,8 +32,6 @@ public:
 	virtual ~FileBuffer();
 
 	Allocator &allocator;
-	//! The type of the buffer
-	FileBufferType type;
 	//! The buffer that users can write to
 	data_ptr_t buffer;
 	//! The size of the portion that users can write to, this is equivalent to internal_size - BLOCK_HEADER_SIZE
@@ -46,6 +44,10 @@ public:
 	void Write(FileHandle &handle, uint64_t location);
 
 	void Clear();
+
+	FileBufferType GetBufferType() const {
+		return type;
+	}
 
 	// Same rules as the constructor. We will add room for a header, in additio to
 	// the requested user bytes. We will then sector-align the result.
@@ -68,6 +70,8 @@ public:
 	void Initialize(DebugInitialize info);
 
 protected:
+	//! The type of the buffer
+	FileBufferType type;
 	//! The pointer to the internal buffer that will be read or written, including the buffer header
 	data_ptr_t internal_buffer;
 	//! The aligned size as passed to the constructor. This is the size that is read or written to disk.

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -17,6 +17,7 @@
 
 namespace duckdb {
 class BlockHandle;
+class BufferHandle;
 class BufferManager;
 class ClientContext;
 class DatabaseInstance;
@@ -86,6 +87,8 @@ public:
 	//! Register a block with the given block id in the base file
 	shared_ptr<BlockHandle> RegisterBlock(block_id_t block_id);
 	//! Convert an existing in-memory buffer into a persistent disk-backed block
+	shared_ptr<BlockHandle> ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block,
+	                                            BufferHandle old_handle);
 	shared_ptr<BlockHandle> ConvertToPersistent(block_id_t block_id, shared_ptr<BlockHandle> old_block);
 
 	void UnregisterBlock(BlockHandle &block);

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -57,7 +57,6 @@ struct TempBufferPoolReservation : BufferPoolReservation {
 
 class BlockHandle : public enable_shared_from_this<BlockHandle> {
 	friend class BlockManager;
-	friend class BufferHandle;
 	friend class BufferManager;
 	friend class StandardBufferManager;
 	friend class BufferPool;

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -77,13 +77,7 @@ public:
 		return block_id;
 	}
 
-	void ResizeBuffer(idx_t block_size, int64_t memory_delta) {
-		D_ASSERT(buffer);
-		// resize and adjust current memory
-		buffer->Resize(block_size);
-		memory_usage = NumericCast<idx_t>(NumericCast<int64_t>(memory_usage) + memory_delta);
-		D_ASSERT(memory_usage == buffer->AllocSize());
-	}
+	void ResizeBuffer(idx_t block_size, int64_t memory_delta);
 
 	int32_t Readers() const {
 		return readers;
@@ -147,9 +141,9 @@ private:
 	//! The block id of the block
 	const block_id_t block_id;
 	//! Memory tag
-	MemoryTag tag;
+	const MemoryTag tag;
 	//! File buffer type
-	FileBufferType buffer_type;
+	const FileBufferType buffer_type;
 	//! Pointer to loaded data (if any)
 	unique_ptr<FileBuffer> buffer;
 	//! Internal eviction sequence number

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -122,18 +122,22 @@ public:
 	}
 
 	void SetEvictionQueueIndex(const idx_t index) {
-		D_ASSERT(!eviction_queue_idx.IsValid());                  // Cannot overwrite
-		D_ASSERT(buffer->type == FileBufferType::MANAGED_BUFFER); // MANAGED_BUFFER only (at least, for now)
+		D_ASSERT(!eviction_queue_idx.IsValid());                     // Cannot overwrite
+		D_ASSERT(GetBufferType() == FileBufferType::MANAGED_BUFFER); // MANAGED_BUFFER only (at least, for now)
 		eviction_queue_idx = index;
 	}
 
-private:
+	FileBufferType GetBufferType() const {
+		return buffer_type;
+	}
+
 	BufferHandle Load(unique_ptr<FileBuffer> buffer = nullptr);
 	BufferHandle LoadFromBuffer(data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer);
 	unique_ptr<FileBuffer> UnloadAndTakeBlock();
 	void Unload();
 	bool CanUnload();
 
+private:
 	//! The block-level lock
 	mutex lock;
 	//! Whether or not the block is loaded/unloaded
@@ -144,6 +148,8 @@ private:
 	const block_id_t block_id;
 	//! Memory tag
 	MemoryTag tag;
+	//! File buffer type
+	FileBufferType buffer_type;
 	//! Pointer to loaded data (if any)
 	unique_ptr<FileBuffer> buffer;
 	//! Internal eviction sequence number

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -57,7 +57,6 @@ struct TempBufferPoolReservation : BufferPoolReservation {
 
 class BlockHandle : public enable_shared_from_this<BlockHandle> {
 	friend class BlockManager;
-	friend struct BufferEvictionNode;
 	friend class BufferHandle;
 	friend class BufferManager;
 	friend class StandardBufferManager;
@@ -73,8 +72,12 @@ public:
 	BlockManager &block_manager;
 
 public:
-	block_id_t BlockId() {
+	block_id_t BlockId() const {
 		return block_id;
+	}
+
+	idx_t EvictionSequenceNumber() const {
+		return eviction_seq_num;
 	}
 
 	void ResizeBuffer(idx_t block_size, int64_t memory_delta);

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -58,8 +58,6 @@ struct TempBufferPoolReservation : BufferPoolReservation {
 using BlockLock = unique_lock<mutex>;
 
 class BlockHandle : public enable_shared_from_this<BlockHandle> {
-	friend class BlockManager;
-
 public:
 	BlockHandle(BlockManager &block_manager, block_id_t block_id, MemoryTag tag);
 	BlockHandle(BlockManager &block_manager, block_id_t block_id, MemoryTag tag, unique_ptr<FileBuffer> buffer,
@@ -174,6 +172,8 @@ public:
 	//! Note that while this method does not require a lock, whether or not a block can be unloaded can change if the
 	//! lock is not held
 	bool CanUnload() const;
+
+	void ConvertToPersistent(BlockLock &, BlockHandle &new_block, unique_ptr<FileBuffer> new_buffer);
 
 private:
 	void VerifyMutex(unique_lock<mutex> &l) const;

--- a/src/include/duckdb/storage/buffer/block_handle.hpp
+++ b/src/include/duckdb/storage/buffer/block_handle.hpp
@@ -57,7 +57,6 @@ struct TempBufferPoolReservation : BufferPoolReservation {
 
 class BlockHandle : public enable_shared_from_this<BlockHandle> {
 	friend class BlockManager;
-	friend class BufferManager;
 	friend class StandardBufferManager;
 	friend class BufferPool;
 	friend struct EvictionQueue;

--- a/src/include/duckdb/storage/buffer/buffer_handle.hpp
+++ b/src/include/duckdb/storage/buffer/buffer_handle.hpp
@@ -18,7 +18,7 @@ class FileBuffer;
 class BufferHandle {
 public:
 	DUCKDB_API BufferHandle();
-	DUCKDB_API explicit BufferHandle(shared_ptr<BlockHandle> handle);
+	DUCKDB_API explicit BufferHandle(shared_ptr<BlockHandle> handle, optional_ptr<FileBuffer> node);
 	DUCKDB_API ~BufferHandle();
 	// disable copy constructors
 	BufferHandle(const BufferHandle &other) = delete;

--- a/src/include/duckdb/storage/compression/alp/alp_compress.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_compress.hpp
@@ -210,8 +210,7 @@ public:
 		// Store the offset to the end of metadata (to be used as a backwards pointer in decoding)
 		Store<uint32_t>(NumericCast<uint32_t>(total_segment_size), dataptr);
 
-		handle.Destroy();
-		checkpoint_state.FlushSegment(std::move(current_segment), total_segment_size);
+		checkpoint_state.FlushSegment(std::move(current_segment), std::move(handle), total_segment_size);
 		data_bytes_used = 0;
 		vectors_flushed = 0;
 	}

--- a/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
@@ -226,8 +226,7 @@ public:
 		// Store the Dictionary
 		memcpy((void *)dataptr, (void *)state.left_parts_dict, actual_dictionary_size_bytes);
 
-		handle.Destroy();
-		checkpoint_state.FlushSegment(std::move(current_segment), total_segment_size);
+		checkpoint_state.FlushSegment(std::move(current_segment), std::move(handle), total_segment_size);
 		data_bytes_used = 0;
 		vectors_flushed = 0;
 	}

--- a/src/include/duckdb/storage/standard_buffer_manager.hpp
+++ b/src/include/duckdb/storage/standard_buffer_manager.hpp
@@ -148,7 +148,7 @@ protected:
 
 	//! When the BlockHandle reaches 0 readers, this creates a new FileBuffer for this BlockHandle and
 	//! overwrites the data within with garbage. Any readers that do not hold the pin will notice
-	void VerifyZeroReaders(shared_ptr<BlockHandle> &handle);
+	void VerifyZeroReaders(BlockLock &l, shared_ptr<BlockHandle> &handle);
 
 	void BatchRead(vector<shared_ptr<BlockHandle>> &handles, const map<block_id_t, idx_t> &load_map,
 	               block_id_t first_block, block_id_t last_block);

--- a/src/include/duckdb/storage/table/column_checkpoint_state.hpp
+++ b/src/include/duckdb/storage/table/column_checkpoint_state.hpp
@@ -40,7 +40,8 @@ protected:
 public:
 	virtual unique_ptr<BaseStatistics> GetStatistics();
 
-	virtual void FlushSegment(unique_ptr<ColumnSegment> segment, idx_t segment_size);
+	virtual void FlushSegmentInternal(unique_ptr<ColumnSegment> segment, idx_t segment_size);
+	virtual void FlushSegment(unique_ptr<ColumnSegment> segment, BufferHandle handle, idx_t segment_size);
 	virtual PersistentColumnData ToPersistentData();
 
 	PartialBlockManager &GetPartialBlockManager() {

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -201,4 +201,19 @@ bool BlockHandle::CanUnload() const {
 	return true;
 }
 
+void BlockHandle::ConvertToPersistent(BlockLock &l, BlockHandle &new_block, unique_ptr<FileBuffer> new_buffer) {
+	VerifyMutex(l);
+
+	// move the data from the old block into data for the new block
+	new_block.state = BlockState::BLOCK_LOADED;
+	new_block.buffer = std::move(new_buffer);
+	new_block.memory_usage = memory_usage.load();
+	new_block.memory_charge = std::move(memory_charge);
+
+	// clear out the buffer data from this block
+	buffer.reset();
+	state = BlockState::BLOCK_UNLOADED;
+	memory_usage = 0;
+}
+
 } // namespace duckdb

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -72,6 +72,14 @@ unique_ptr<Block> AllocateBlock(BlockManager &block_manager, unique_ptr<FileBuff
 	}
 }
 
+void BlockHandle::ResizeBuffer(idx_t block_size, int64_t memory_delta) {
+	D_ASSERT(buffer);
+	// resize and adjust current memory
+	buffer->Resize(block_size);
+	memory_usage = NumericCast<idx_t>(NumericCast<int64_t>(memory_usage) + memory_delta);
+	D_ASSERT(memory_usage == buffer->AllocSize());
+}
+
 BufferHandle BlockHandle::LoadFromBuffer(data_ptr_t data, unique_ptr<FileBuffer> reusable_buffer) {
 	D_ASSERT(state != BlockState::BLOCK_LOADED);
 	// copy over the data into the block from the file buffer

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -12,7 +12,7 @@ namespace duckdb {
 BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, MemoryTag tag)
     : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), buffer_type(FileBufferType::BLOCK),
       buffer(nullptr), eviction_seq_num(0), destroy_buffer_upon(DestroyBufferUpon::BLOCK),
-      memory_charge(tag, block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr) {
+      memory_charge(tag, block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr), eviction_queue_idx(DConstants::INVALID_INDEX) {
 	eviction_seq_num = 0;
 	state = BlockState::BLOCK_UNLOADED;
 	memory_usage = block_manager.GetBlockAllocSize();
@@ -23,7 +23,7 @@ BlockHandle::BlockHandle(BlockManager &block_manager, block_id_t block_id_p, Mem
                          BufferPoolReservation &&reservation)
     : block_manager(block_manager), readers(0), block_id(block_id_p), tag(tag), buffer_type(buffer_p->GetBufferType()),
       eviction_seq_num(0), destroy_buffer_upon(destroy_buffer_upon_p),
-      memory_charge(tag, block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr) {
+      memory_charge(tag, block_manager.buffer_manager.GetBufferPool()), unswizzled(nullptr), eviction_queue_idx(DConstants::INVALID_INDEX) {
 	buffer = std::move(buffer_p);
 	state = BlockState::BLOCK_LOADED;
 	memory_usage = block_size;

--- a/src/storage/buffer/block_handle.cpp
+++ b/src/storage/buffer/block_handle.cpp
@@ -87,14 +87,14 @@ BufferHandle BlockHandle::LoadFromBuffer(data_ptr_t data, unique_ptr<FileBuffer>
 	memcpy(block->InternalBuffer(), data, block->AllocSize());
 	buffer = std::move(block);
 	state = BlockState::BLOCK_LOADED;
-	return BufferHandle(shared_from_this());
+	return BufferHandle(shared_from_this(), buffer.get());
 }
 
 BufferHandle BlockHandle::Load(unique_ptr<FileBuffer> reusable_buffer) {
 	if (state == BlockState::BLOCK_LOADED) {
 		// already loaded
 		D_ASSERT(buffer);
-		return BufferHandle(shared_from_this());
+		return BufferHandle(shared_from_this(), buffer.get());
 	}
 
 	if (block_id < MAXIMUM_BLOCK) {
@@ -109,7 +109,7 @@ BufferHandle BlockHandle::Load(unique_ptr<FileBuffer> reusable_buffer) {
 		}
 	}
 	state = BlockState::BLOCK_LOADED;
-	return BufferHandle(shared_from_this());
+	return BufferHandle(shared_from_this(), buffer.get());
 }
 
 unique_ptr<FileBuffer> BlockHandle::UnloadAndTakeBlock() {

--- a/src/storage/buffer/block_manager.cpp
+++ b/src/storage/buffer/block_manager.cpp
@@ -48,7 +48,7 @@ shared_ptr<BlockHandle> BlockManager::ConvertToPersistent(block_id_t block_id, s
 	// move the data from the old block into data for the new block
 	new_block->state = BlockState::BLOCK_LOADED;
 	new_block->buffer = ConvertBlock(block_id, *old_block->buffer);
-	new_block->memory_usage = old_block->memory_usage;
+	new_block->memory_usage = old_block->memory_usage.load();
 	new_block->memory_charge = std::move(old_block->memory_charge);
 
 	// clear the old buffer and unload it

--- a/src/storage/buffer/buffer_handle.cpp
+++ b/src/storage/buffer/buffer_handle.cpp
@@ -7,8 +7,8 @@ namespace duckdb {
 BufferHandle::BufferHandle() : handle(nullptr), node(nullptr) {
 }
 
-BufferHandle::BufferHandle(shared_ptr<BlockHandle> handle_p)
-    : handle(std::move(handle_p)), node(handle ? handle->buffer.get() : nullptr) {
+BufferHandle::BufferHandle(shared_ptr<BlockHandle> handle_p, optional_ptr<FileBuffer> node_p)
+    : handle(std::move(handle_p)), node(node_p) {
 }
 
 BufferHandle::BufferHandle(BufferHandle &&other) noexcept : node(nullptr) {

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -239,7 +239,7 @@ bool BufferPool::AddToEvictionQueue(shared_ptr<BlockHandle> &handle) {
 }
 
 EvictionQueue &BufferPool::GetEvictionQueueForBlockHandle(const BlockHandle &handle) {
-	const auto &handle_buffer_type = handle.buffer->type;
+	const auto &handle_buffer_type = handle.GetBufferType();
 
 	// Get offset into eviction queues for this FileBufferType
 	idx_t queue_index = 0;

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -355,16 +355,17 @@ idx_t BufferPool::PurgeAgedBlocks(uint32_t max_age_sec) {
 
 idx_t BufferPool::PurgeAgedBlocksInternal(EvictionQueue &queue, uint32_t max_age_sec, int64_t now, int64_t limit) {
 	idx_t purged_bytes = 0;
-	queue.IterateUnloadableBlocks([&](BufferEvictionNode &node, const shared_ptr<BlockHandle> &handle, BlockLock &lock) {
-		// We will unload this block regardless. But stop the iteration immediately afterward if this
-		// block is younger than the age threshold.
-		auto lru_timestamp_msec = handle->GetLRUTimestamp();
-		bool is_fresh = lru_timestamp_msec >= limit && lru_timestamp_msec <= now;
-		purged_bytes += handle->GetMemoryUsage();
-		handle->Unload(lock);
-		// Return false to stop iterating if the current block is_fresh
-		return !is_fresh;
-	});
+	queue.IterateUnloadableBlocks(
+	    [&](BufferEvictionNode &node, const shared_ptr<BlockHandle> &handle, BlockLock &lock) {
+		    // We will unload this block regardless. But stop the iteration immediately afterward if this
+		    // block is younger than the age threshold.
+		    auto lru_timestamp_msec = handle->GetLRUTimestamp();
+		    bool is_fresh = lru_timestamp_msec >= limit && lru_timestamp_msec <= now;
+		    purged_bytes += handle->GetMemoryUsage();
+		    handle->Unload(lock);
+		    // Return false to stop iterating if the current block is_fresh
+		    return !is_fresh;
+	    });
 	return purged_bytes;
 }
 

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -16,7 +16,7 @@ BufferEvictionNode::BufferEvictionNode(weak_ptr<BlockHandle> handle_p, idx_t evi
 }
 
 bool BufferEvictionNode::CanUnload(BlockHandle &handle_p) {
-	if (handle_sequence_number != handle_p.eviction_seq_num) {
+	if (handle_sequence_number != handle_p.EvictionSequenceNumber()) {
 		// handle was used in between
 		return false;
 	}

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -552,9 +552,8 @@ public:
 
 		// Store the offset of the metadata of the first group (which is at the highest address).
 		Store<idx_t>(metadata_offset + metadata_size, base_ptr);
-		handle.Destroy();
 
-		state.FlushSegment(std::move(current_segment), total_segment_size);
+		state.FlushSegment(std::move(current_segment), std::move(handle), total_segment_size);
 	}
 
 	void Finalize() {

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -259,7 +259,7 @@ public:
 
 		auto segment_size = Finalize();
 		auto &state = checkpointer.GetCheckpointState();
-		state.FlushSegment(std::move(current_segment), segment_size);
+		state.FlushSegment(std::move(current_segment), std::move(current_handle), segment_size);
 
 		if (!final) {
 			CreateEmptySegment(next_start);

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -80,7 +80,10 @@ void UncompressedCompressState::FlushSegment(idx_t segment_size) {
 		segment_state.overflow_writer->Flush();
 		segment_state.overflow_writer.reset();
 	}
-	state.FlushSegment(std::move(current_segment), segment_size);
+	append_state.child_appends.clear();
+	append_state.append_state.reset();
+	append_state.lock.reset();
+	state.FlushSegmentInternal(std::move(current_segment), segment_size);
 }
 
 void UncompressedCompressState::Finalize(idx_t segment_size) {

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -314,7 +314,7 @@ public:
 
 		auto segment_size = Finalize();
 		auto &state = checkpointer.GetCheckpointState();
-		state.FlushSegment(std::move(current_segment), segment_size);
+		state.FlushSegment(std::move(current_segment), std::move(current_handle), segment_size);
 
 		if (!final) {
 			CreateEmptySegment(next_start);

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -205,7 +205,7 @@ struct RLECompressState : public CompressionState {
 		handle.Destroy();
 
 		auto &state = checkpointer.GetCheckpointState();
-		state.FlushSegment(std::move(current_segment), total_segment_size);
+		state.FlushSegment(std::move(current_segment), std::move(handle), total_segment_size);
 	}
 
 	void Finalize() {

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -185,7 +185,7 @@ void MetadataManager::Flush() {
 		D_ASSERT(kv.first == block.block_id);
 		if (block.block->BlockId() >= MAXIMUM_BLOCK) {
 			// temporary block - convert to persistent
-			block.block = block_manager.ConvertToPersistent(kv.first, std::move(block.block));
+			block.block = block_manager.ConvertToPersistent(kv.first, std::move(block.block), std::move(handle));
 		} else {
 			// already a persistent block - only need to write it
 			D_ASSERT(block.block->BlockId() == block.block_id);

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -387,11 +387,11 @@ void StandardBufferManager::Unpin(shared_ptr<BlockHandle> &handle) {
 	bool purge = false;
 	{
 		lock_guard<mutex> lock(handle->lock);
-		if (!handle->buffer || handle->buffer->type == FileBufferType::TINY_BUFFER) {
+		if (!handle->buffer || handle->GetBufferType() == FileBufferType::TINY_BUFFER) {
 			return;
 		}
 		D_ASSERT(handle->readers > 0);
-		handle->readers--;
+		--handle->readers;
 		if (handle->readers == 0) {
 			VerifyZeroReaders(handle);
 			if (handle->MustAddToEvictionQueue()) {

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -385,7 +385,7 @@ void StandardBufferManager::VerifyZeroReaders(shared_ptr<BlockHandle> &handle) {
 void StandardBufferManager::Unpin(shared_ptr<BlockHandle> &handle) {
 	bool purge = false;
 	{
-		lock_guard<mutex> lock(handle->lock);
+		auto lock = handle->GetLock();
 		if (!handle->buffer || handle->GetBufferType() == FileBufferType::TINY_BUFFER) {
 			return;
 		}
@@ -396,7 +396,7 @@ void StandardBufferManager::Unpin(shared_ptr<BlockHandle> &handle) {
 			if (handle->MustAddToEvictionQueue()) {
 				purge = buffer_pool.AddToEvictionQueue(handle);
 			} else {
-				handle->Unload();
+				handle->Unload(lock);
 			}
 		}
 	}

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -112,7 +112,12 @@ void PartialBlockForCheckpoint::Clear() {
 	segments.clear();
 }
 
-void ColumnCheckpointState::FlushSegment(unique_ptr<ColumnSegment> segment, idx_t segment_size) {
+void ColumnCheckpointState::FlushSegment(unique_ptr<ColumnSegment> segment, BufferHandle handle, idx_t segment_size) {
+	handle.Destroy();
+	FlushSegmentInternal(std::move(segment), segment_size);
+}
+
+void ColumnCheckpointState::FlushSegmentInternal(unique_ptr<ColumnSegment> segment, idx_t segment_size) {
 	auto block_size = partial_block_manager.GetBlockManager().GetBlockSize();
 	D_ASSERT(segment_size <= block_size);
 

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -402,7 +402,7 @@ void ReplayIndexData(AttachedDatabase &db, BinaryDeserializer &deserializer, Ind
 			// Convert the buffer handle to a persistent block and store the block id.
 			if (!deserialize_only) {
 				auto block_id = block_manager->GetFreeBlockId();
-				block_manager->ConvertToPersistent(block_id, std::move(block_handle));
+				block_manager->ConvertToPersistent(block_id, std::move(block_handle), std::move(buffer_handle));
 				data_info.block_pointers[j].block_id = block_id;
 			}
 		}


### PR DESCRIPTION
This PR reworks the `BlockHandle` class to remove all of the friend classes, and instead use a less error-prone interface that requires passing the `BlockLock` into the methods when accessing members that require locks (e.g. the buffer or memory usage fields).

In addition, we rework the `ConvertToPersistent` method so that it throws an error when there are active readers, and fix cases where this was the case. In all of the cases where this happened the handle would have been destroyed shortly after the `ConvertToPersistent` was completed anyway. 