### PR TITLE
Add JSON Logical Type metadata to parquet writer

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -169,11 +169,11 @@ Type::type ParquetWriter::DuckDBTypeToParquetType(const LogicalType &duckdb_type
 
 void ParquetWriter::SetSchemaProperties(const LogicalType &duckdb_type, duckdb_parquet::SchemaElement &schema_ele) {
 	if (duckdb_type.IsJSONType()) {
-    schema_ele.converted_type = ConvertedType::JSON;
-    schema_ele.__isset.converted_type = true;
-    schema_ele.__isset.logicalType = true;
-    schema_ele.logicalType.__set_JSON(duckdb_parquet::JsonType());
-    return;
+		schema_ele.converted_type = ConvertedType::JSON;
+		schema_ele.__isset.converted_type = true;
+		schema_ele.__isset.logicalType = true;
+		schema_ele.logicalType.__set_JSON(duckdb_parquet::JsonType());
+		return;
 	}
 	switch (duckdb_type.id()) {
 	case LogicalTypeId::TINYINT:

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -169,8 +169,13 @@ Type::type ParquetWriter::DuckDBTypeToParquetType(const LogicalType &duckdb_type
 
 void ParquetWriter::SetSchemaProperties(const LogicalType &duckdb_type, duckdb_parquet::SchemaElement &schema_ele) {
 	if (duckdb_type.IsJSONType()) {
-		schema_ele.converted_type = ConvertedType::JSON;
-		schema_ele.__isset.converted_type = true;
+        schema_ele.converted_type = ConvertedType::JSON;
+        schema_ele.__isset.converted_type = true;
+
+        // Set logical type to JsonType
+        schema_ele.__isset.logicalType = true;
+        schema_ele.logicalType.__set_JSON(duckdb_parquet::JsonType());
+        return;
 		return;
 	}
 	switch (duckdb_type.id()) {

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -169,14 +169,11 @@ Type::type ParquetWriter::DuckDBTypeToParquetType(const LogicalType &duckdb_type
 
 void ParquetWriter::SetSchemaProperties(const LogicalType &duckdb_type, duckdb_parquet::SchemaElement &schema_ele) {
 	if (duckdb_type.IsJSONType()) {
-        schema_ele.converted_type = ConvertedType::JSON;
-        schema_ele.__isset.converted_type = true;
-
-        // Set logical type to JsonType
-        schema_ele.__isset.logicalType = true;
-        schema_ele.logicalType.__set_JSON(duckdb_parquet::JsonType());
-        return;
-		return;
+    schema_ele.converted_type = ConvertedType::JSON;
+    schema_ele.__isset.converted_type = true;
+    schema_ele.__isset.logicalType = true;
+    schema_ele.logicalType.__set_JSON(duckdb_parquet::JsonType());
+    return;
 	}
 	switch (duckdb_type.id()) {
 	case LogicalTypeId::TINYINT:


### PR DESCRIPTION
### Summary of Change
This simply changes the parquet extension to write `JsonType()` to the LogicalType metadata field. Without it, the parquet files that DuckDB generates cannot be used with Redshift in conjunction with [`COPY FROM... SERIALIZETOJSON ` SQL to load JSON columns into super columns](https://docs.aws.amazon.com/redshift/latest/dg/ingest-super.html). I wouldn't be surprised if there are other parquet readers that will misinterpret the type without that metadata. 