### PR TITLE
Optimistic writes: flush the last row group in all scenarios

### DIFF
--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -526,6 +526,8 @@ SinkCombineResultType PhysicalInsert::Combine(ExecutionContext &context, Operato
 		storage.FinalizeLocalAppend(gstate.append_state);
 	} else {
 		// we have written rows to disk optimistically - merge directly into the transaction-local storage
+		lstate.writer->WriteLastRowGroup(*lstate.local_collection);
+
 		gstate.table.GetStorage().LocalMerge(context.client, *lstate.local_collection);
 		gstate.table.GetStorage().FinalizeOptimisticWriter(context.client, *lstate.writer);
 	}


### PR DESCRIPTION
When optimistically writing data to disk - there were a few scenarios in which we would not optimistically write row groups:

* For batch insert, when the batches were approximately as large as our internal row group size, we would not always flush them as the `CollectionMerger` would have a collection with a single `ColumnDataCollection` in it
* For regular insert, we would not flush the last row group in `Combine`

For regular insertions, this would not have a large impact as most data would still be written optimistically - but for the optimistic WAL write added in https://github.com/duckdb/duckdb/pull/13372 we need **all** row groups written in sequence to be optimistically written out. By not flushing all row groups, large WAL files would still be created.