### PR TITLE
Improve SqlStatement::ToString for UPDATE and DELETE statement to include alias of RETURNING clause

### DIFF
--- a/src/parser/statement/delete_statement.cpp
+++ b/src/parser/statement/delete_statement.cpp
@@ -43,7 +43,11 @@ string DeleteStatement::ToString() const {
 			if (i > 0) {
 				result += ", ";
 			}
-			result += returning_list[i]->ToString();
+			auto column = returning_list[i]->ToString();
+			if (!returning_list[i]->alias.empty()) {
+				column += StringUtil::Format(" AS %s", KeywordHelper::WriteOptionallyQuoted(returning_list[i]->alias));
+			}
+			result += column;
 		}
 	}
 	return result;

--- a/src/parser/statement/update_statement.cpp
+++ b/src/parser/statement/update_statement.cpp
@@ -65,7 +65,11 @@ string UpdateStatement::ToString() const {
 			if (i > 0) {
 				result += ", ";
 			}
-			result += returning_list[i]->ToString();
+			auto column = returning_list[i]->ToString();
+			if (!returning_list[i]->alias.empty()) {
+				column += StringUtil::Format(" AS %s", KeywordHelper::WriteOptionallyQuoted(returning_list[i]->alias));
+			}
+			result += column;
 		}
 	}
 	return result;

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -736,3 +736,22 @@ TEST_CASE("Test a logical execute still has types after an optimization pass", "
 	REQUIRE((query_plan->types.size() == 1));
 	REQUIRE((query_plan->types[0].id() == LogicalTypeId::INTEGER));
 }
+
+TEST_CASE("Test SqlStatement::ToString for UPDATE, INSERT, DELETE statements with alias of RETURNING clause", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	std::string sql;
+	con.Query("CREATE TABLE test(id INT);");
+
+	sql = "INSERT INTO test (id) VALUES (1) RETURNING id AS inserted";
+	auto stmts = con.ExtractStatements(sql);
+	REQUIRE(stmts[0]->ToString() == "INSERT INTO test (id ) (VALUES (1)) RETURNING id AS inserted");
+
+	sql = "UPDATE test SET id = 1 RETURNING id AS updated";
+	stmts = con.ExtractStatements(sql);
+	REQUIRE(stmts[0]->ToString() == sql);
+
+	sql = "DELETE FROM test WHERE (id = 1) RETURNING id AS deleted";
+	stmts = con.ExtractStatements(sql);
+	REQUIRE(stmts[0]->ToString() == sql);
+}


### PR DESCRIPTION
Fixes issue #14740