### PR TITLE
Correctly deal with continued operation after reading a truncated WAL, and clean up WAL handling logic in storage manager

### DIFF
--- a/src/common/serializer/buffered_file_writer.cpp
+++ b/src/common/serializer/buffered_file_writer.cpp
@@ -21,7 +21,7 @@ idx_t BufferedFileWriter::GetFileSize() {
 	return NumericCast<idx_t>(fs.GetFileSize(*handle)) + offset;
 }
 
-idx_t BufferedFileWriter::GetTotalWritten() {
+idx_t BufferedFileWriter::GetTotalWritten() const {
 	return total_written + offset;
 }
 

--- a/src/include/duckdb/common/serializer/buffered_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/buffered_file_writer.hpp
@@ -43,7 +43,7 @@ public:
 	//! Truncate the size to a previous size (given that size <= GetFileSize())
 	DUCKDB_API void Truncate(idx_t size);
 
-	DUCKDB_API idx_t GetTotalWritten();
+	DUCKDB_API idx_t GetTotalWritten() const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -38,7 +38,7 @@ class TransactionManager;
 class WriteAheadLogDeserializer;
 struct PersistentCollectionData;
 
-enum class WALInitState { UNINITIALIZED, UNINITIALIZED_REQUIRES_TRUNCATE, INITIALIZED };
+enum class WALInitState { NO_WAL, UNINITIALIZED, UNINITIALIZED_REQUIRES_TRUNCATE, INITIALIZED };
 
 //! The WriteAheadLog (WAL) is a log that is used to provide durability. Prior
 //! to committing a transaction it writes the changes the transaction made to
@@ -48,7 +48,7 @@ class WriteAheadLog {
 public:
 	//! Initialize the WAL in the specified directory
 	explicit WriteAheadLog(AttachedDatabase &database, const string &wal_path, idx_t wal_size = 0ULL,
-	                       WALInitState state = WALInitState::UNINITIALIZED);
+	                       WALInitState state = WALInitState::NO_WAL);
 	virtual ~WriteAheadLog();
 
 public:
@@ -58,7 +58,7 @@ public:
 	//! Gets the total bytes written to the WAL since startup
 	idx_t GetWALSize() const;
 	//! Gets the total bytes written to the WAL since startup
-	idx_t GetTotalWritten();
+	idx_t GetTotalWritten() const;
 
 	//! A WAL is initialized, if a writer to a file exists.
 	bool Initialized() const;

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -162,13 +162,29 @@ private:
 //===--------------------------------------------------------------------===//
 // Replay
 //===--------------------------------------------------------------------===//
-bool WriteAheadLog::Replay(AttachedDatabase &database, unique_ptr<FileHandle> handle) {
+unique_ptr<WriteAheadLog> WriteAheadLog::Replay(FileSystem &fs, AttachedDatabase &db, const string &wal_path) {
+	auto handle = fs.OpenFile(wal_path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+	if (!handle) {
+		// WAL does not exist - instantiate an empty WAL
+		return make_uniq<WriteAheadLog>(db, wal_path);
+	}
+	auto wal_handle = ReplayInternal(db, std::move(handle));
+	if (wal_handle) {
+		return wal_handle;
+	}
+	// replay returning NULL indicates we can nuke the WAL entirely - but only if this is not a read-only connection
+	if (!db.IsReadOnly()) {
+		fs.RemoveFile(wal_path);
+	}
+	return make_uniq<WriteAheadLog>(db, wal_path);
+}
+unique_ptr<WriteAheadLog> WriteAheadLog::ReplayInternal(AttachedDatabase &database, unique_ptr<FileHandle> handle) {
 	Connection con(database.GetDatabase());
 	auto wal_path = handle->GetPath();
 	BufferedFileReader reader(FileSystem::Get(database), std::move(handle));
 	if (reader.Finished()) {
-		// WAL is empty
-		return false;
+		// WAL file exists but it is empty - we can delete the file
+		return nullptr;
 	}
 
 	con.BeginTransaction();
@@ -203,7 +219,7 @@ bool WriteAheadLog::Replay(AttachedDatabase &database, unique_ptr<FileHandle> ha
 		if (manager.IsCheckpointClean(checkpoint_state.checkpoint_id)) {
 			// the contents of the WAL have already been checkpointed
 			// we can safely truncate the WAL and ignore its contents
-			return true;
+			return nullptr;
 		}
 	}
 
@@ -216,15 +232,19 @@ bool WriteAheadLog::Replay(AttachedDatabase &database, unique_ptr<FileHandle> ha
 	// replay the WAL
 	// note that everything is wrapped inside a try/catch block here
 	// there can be errors in WAL replay because of a corrupt WAL file
+	idx_t successful_offset = 0;
+	bool all_succeeded = false;
 	try {
 		while (true) {
 			// read the current entry
 			auto deserializer = WriteAheadLogDeserializer::Open(state, reader);
 			if (deserializer.ReplayEntry()) {
 				con.Commit();
+				successful_offset = reader.offset;
 				// check if the file is exhausted
 				if (reader.Finished()) {
 					// we finished reading the file: break
+					all_succeeded = true;
 					break;
 				}
 				con.BeginTransaction();
@@ -246,7 +266,8 @@ bool WriteAheadLog::Replay(AttachedDatabase &database, unique_ptr<FileHandle> ha
 		con.Query("ROLLBACK");
 		throw;
 	} // LCOV_EXCL_STOP
-	return false;
+	auto init_state = all_succeeded ? WALInitState::UNINITIALIZED : WALInitState::UNINITIALIZED_REQUIRES_TRUNCATE;
+	return make_uniq<WriteAheadLog>(database, wal_path, successful_offset, init_state);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/write_ahead_log.cpp
+++ b/src/storage/write_ahead_log.cpp
@@ -52,6 +52,7 @@ BufferedFileWriter &WriteAheadLog::Initialize() {
 
 //! Gets the total bytes written to the WAL since startup
 idx_t WriteAheadLog::GetWALSize() const {
+	D_ASSERT(init_state != WALInitState::NO_WAL || wal_size == 0);
 	return wal_size;
 }
 
@@ -63,6 +64,10 @@ idx_t WriteAheadLog::GetTotalWritten() const {
 }
 
 void WriteAheadLog::Truncate(idx_t size) {
+	if (init_state == WALInitState::NO_WAL) {
+		// no WAL to truncate
+		return;
+	}
 	if (!Initialized()) {
 		init_state = WALInitState::UNINITIALIZED_REQUIRES_TRUNCATE;
 		wal_size = size;

--- a/test/sql/storage/wal_torn_write.cpp
+++ b/test/sql/storage/wal_torn_write.cpp
@@ -62,6 +62,57 @@ TEST_CASE("Test torn WAL writes", "[storage][.]") {
 	DeleteDatabase(storage_database);
 }
 
+TEST_CASE("Test torn WAL writes followed by successful commits", "[storage][.]") {
+	auto config = GetTestConfig();
+	duckdb::unique_ptr<QueryResult> result;
+	auto storage_database = TestCreatePath("storage_test");
+	auto storage_wal = storage_database + ".wal";
+
+	LocalFileSystem lfs;
+	config->options.checkpoint_wal_size = idx_t(-1);
+	config->options.checkpoint_on_shutdown = false;
+	config->options.abort_on_wal_failure = false;
+	idx_t wal_size_one_table;
+	// obtain the size of the WAL when writing one table, and then when writing two tables
+	DeleteDatabase(storage_database);
+	{
+		DuckDB db(storage_database, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE A (a INTEGER);"));
+		wal_size_one_table = GetWALFileSize(lfs, storage_wal);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE B (a INTEGER);"));
+	}
+	DeleteDatabase(storage_database);
+
+	DeleteDatabase(storage_database);
+	{
+		DuckDB db(storage_database, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE A (a INTEGER);"));
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE B (a INTEGER);"));
+	}
+	TruncateWAL(lfs, storage_wal, wal_size_one_table + 17);
+	{
+		// reload and make sure table A is there, and table B is not there
+		DuckDB db(storage_database, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("FROM A"));
+		REQUIRE_FAIL(con.Query("FROM B"));
+
+		// create table C
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE C (a INTEGER);"));
+	}
+	{
+		// reload and make sure table A and C are there, and table B is not
+		DuckDB db(storage_database, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("FROM A"));
+		REQUIRE_FAIL(con.Query("FROM B"));
+		REQUIRE_NO_FAIL(con.Query("FROM C"));
+	}
+	DeleteDatabase(storage_database);
+}
+
 static void FlipWALByte(FileSystem &fs, const string &path, idx_t byte_pos) {
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ);
 	idx_t wal_size = handle->GetFileSize();


### PR DESCRIPTION
This PR fixes an issue where doing a replay of a truncated WAL, and then continuing operation, would result in writing data past the (truncated) WAL. This would then result in that data being discarded in subsequent start-ups as the system would find the previously ignored truncated data and assume all data after that point was garbage. This PR addresses this by correctly truncating the WAL to the last successfully read entry if we resume operation prior to writing new data to the WAL in this scenario.

This PR also cleans up the WAL accessors (superseding https://github.com/duckdb/duckdb/pull/14328). The `StorageManager` now always instantiates a `WriteAheadLog` object. The `WriteAheadLog` object internally keeps track of whether or not a WAL object is exists and what the size is, without unnecessarily creating the WAL file in situations where this is not required.