### PR TITLE
Optimize PhysicalTopN operator

### DIFF
--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -215,8 +215,6 @@ void TopNHeap::Sink(DataChunk &input, optional_ptr<TopNBoundaryValue> global_bou
 }
 
 void TopNHeap::Combine(TopNHeap &other) {
-	other.Finalize();
-
 	// FIXME: heaps can be merged directly instead of doing it like this
 	// that only really speeds things up if heaps are very large, however
 	TopNScanState state;
@@ -336,6 +334,8 @@ SinkResultType PhysicalTopN::Sink(ExecutionContext &context, DataChunk &chunk, O
 SinkCombineResultType PhysicalTopN::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
 	auto &gstate = input.global_state.Cast<TopNGlobalState>();
 	auto &lstate = input.local_state.Cast<TopNLocalState>();
+
+	lstate.heap.Finalize();
 
 	// scan the local top N and append it to the global heap
 	lock_guard<mutex> glock(gstate.lock);


### PR DESCRIPTION
If TopNLocalState heap `Finalize()` is called before locking in `PhysicalTopN::Combine()`, the performance of PhysicalTopN operator can improve much, especially in deep paging scenario (i.e., limit + offset is large) because the batching data to sort is large.
# Benchmark
## Environment
- Dataset: TPC-H 100GB
- CPU: 96 core
- Memory: 754 GB
- Test SQL:
```sql
-- shallow paging
select l_orderkey, sum(l_quantity)
from lineitem
group by l_orderkey
order by sum(l_quantity) desc
limit 100 offset 100;

-- deep paging
select l_orderkey, sum(l_quantity)
from lineitem
group by l_orderkey
order by sum(l_quantity) desc
limit 100 offset 1000000;
```
## Result
Time unit: sec
| SQL Type | Before Optimization | After Optimization |
|:--------|:-------|:--------|
| shallow paging | 4.091 | **3.133** |
| deep paging | 29.324 | **10.493** |