### PR TITLE
Added getters for enum and struct type values

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2282,7 +2282,7 @@ Creates an enum value from a type and a value. Must be destroyed with `duckdb_de
 * @param value The value for the enum
 * @return The enum value, or nullptr.
 */
-DUCKDB_API duckdb_value duckdb_create_enum(duckdb_logical_type type, uint64_t value);
+DUCKDB_API duckdb_value duckdb_create_enum_value(duckdb_logical_type type, uint64_t value);
 
 /*!
 Returns the enum value of the given value.
@@ -2291,14 +2291,6 @@ Returns the enum value of the given value.
 * @return A uint64_t, or MinValue<uint64> if the value cannot be converted
 */
 DUCKDB_API uint64_t duckdb_get_enum_value(duckdb_value value);
-
-/*!
-Returns the number of children in a STRUCT value.
-
-* @param value The STRUCT value.
-* @return The number of children in the struct.
-*/
-DUCKDB_API idx_t duckdb_get_struct_child_count(duckdb_value value);
 
 /*!
 Returns the STRUCT child at index as a duckdb_value.

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2275,6 +2275,40 @@ Returns the LIST child at index as a duckdb_value.
 */
 DUCKDB_API duckdb_value duckdb_get_list_child(duckdb_value value, idx_t index);
 
+/*!
+Creates an enum value from a type and a value. Must be destroyed with `duckdb_destroy_value`.
+
+* @param type The type of the enum
+* @param value The value for the enum
+* @return The enum value, or nullptr.
+*/
+DUCKDB_API duckdb_value duckdb_create_enum(duckdb_logical_type type, uint64_t value);
+
+/*!
+Returns the enum value of the given value.
+
+* @param value A duckdb_value containing an enum
+* @return A uint64_t, or MinValue<uint64> if the value cannot be converted
+*/
+DUCKDB_API uint64_t duckdb_get_enum_value(duckdb_value value);
+
+/*!
+Returns the number of children in a STRUCT value.
+
+* @param value The STRUCT value.
+* @return The number of children in the struct.
+*/
+DUCKDB_API idx_t duckdb_get_struct_child_count(duckdb_value value);
+
+/*!
+Returns the STRUCT child at index as a duckdb_value.
+
+* @param value The STRUCT value.
+* @param index The index of the child.
+* @return The child as a duckdb_value.
+*/
+DUCKDB_API duckdb_value duckdb_get_struct_child(duckdb_value value, idx_t index);
+
 //===--------------------------------------------------------------------===//
 // Logical Type Interface
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -436,6 +436,10 @@ typedef struct {
 	duckdb_value (*duckdb_create_null_value)();
 	idx_t (*duckdb_get_list_size)(duckdb_value value);
 	duckdb_value (*duckdb_get_list_child)(duckdb_value value, idx_t index);
+	duckdb_value (*duckdb_create_enum)(duckdb_logical_type type, uint64_t value);
+	uint64_t (*duckdb_get_enum_value)(duckdb_value value);
+	idx_t (*duckdb_get_struct_child_count)(duckdb_value value);
+	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
 } duckdb_ext_api_v0;
 
 //===--------------------------------------------------------------------===//
@@ -822,6 +826,10 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_create_null_value = duckdb_create_null_value;
 	result.duckdb_get_list_size = duckdb_get_list_size;
 	result.duckdb_get_list_child = duckdb_get_list_child;
+	result.duckdb_create_enum = duckdb_create_enum;
+	result.duckdb_get_enum_value = duckdb_get_enum_value;
+	result.duckdb_get_struct_child_count = duckdb_get_struct_child_count;
+	result.duckdb_get_struct_child = duckdb_get_struct_child;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -436,9 +436,8 @@ typedef struct {
 	duckdb_value (*duckdb_create_null_value)();
 	idx_t (*duckdb_get_list_size)(duckdb_value value);
 	duckdb_value (*duckdb_get_list_child)(duckdb_value value, idx_t index);
-	duckdb_value (*duckdb_create_enum)(duckdb_logical_type type, uint64_t value);
+	duckdb_value (*duckdb_create_enum_value)(duckdb_logical_type type, uint64_t value);
 	uint64_t (*duckdb_get_enum_value)(duckdb_value value);
-	idx_t (*duckdb_get_struct_child_count)(duckdb_value value);
 	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
 } duckdb_ext_api_v0;
 
@@ -826,9 +825,8 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_create_null_value = duckdb_create_null_value;
 	result.duckdb_get_list_size = duckdb_get_list_size;
 	result.duckdb_get_list_child = duckdb_get_list_child;
-	result.duckdb_create_enum = duckdb_create_enum;
+	result.duckdb_create_enum_value = duckdb_create_enum_value;
 	result.duckdb_get_enum_value = duckdb_get_enum_value;
-	result.duckdb_get_struct_child_count = duckdb_get_struct_child_count;
 	result.duckdb_get_struct_child = duckdb_get_struct_child;
 	return result;
 }

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -9,9 +9,8 @@
         "duckdb_create_null_value",
         "duckdb_get_list_size",
         "duckdb_get_list_child",
-        "duckdb_create_enum",
+        "duckdb_create_enum_value",
         "duckdb_get_enum_value",
-        "duckdb_get_struct_child_count",
         "duckdb_get_struct_child"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -8,6 +8,10 @@
         "duckdb_is_null_value",
         "duckdb_create_null_value",
         "duckdb_get_list_size",
-        "duckdb_get_list_child"
+        "duckdb_get_list_child",
+        "duckdb_create_enum",
+        "duckdb_get_enum_value",
+        "duckdb_get_struct_child_count",
+        "duckdb_get_struct_child"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -943,6 +943,84 @@
                 },
                 "return_value": "The child as a duckdb_value."
             }
+        },
+        {
+            "name": "duckdb_create_enum",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_logical_type",
+                    "name": "type"
+                },
+                {
+                    "type": "uint64_t",
+                    "name": "value"
+                }
+            ],
+            "comment": {
+                "description": "Creates an enum value from a type and a value. Must be destroyed with `duckdb_destroy_value`.\n\n",
+                "param_comments": {
+                    "type": "The type of the enum",
+                    "value": "The value for the enum"
+                },
+                "return_value": "The enum value, or nullptr."
+            }
+        },
+        {
+            "name": "duckdb_get_enum_value",
+            "return_type": "uint64_t",
+            "params": [
+                {
+                    "type": "duckdb_value",
+                    "name": "value"
+                }
+            ],
+            "comment": {
+                "description": "Returns the enum value of the given value.\n\n",
+                "param_comments": {
+                    "value": "A duckdb_value containing an enum"
+                },
+                "return_value": "A uint64_t, or MinValue<uint64> if the value cannot be converted"
+            }
+        },
+        {
+            "name": "duckdb_get_struct_child_count",
+            "return_type": "idx_t",
+            "params": [
+                {
+                    "type": "duckdb_value",
+                    "name": "value"
+                }
+            ],
+            "comment": {
+                "description": "Returns the number of children in a STRUCT value.\n\n",
+                "param_comments": {
+                    "value": "The STRUCT value."
+                },
+                "return_value": "The number of children in the struct."
+            }
+        },
+        {
+            "name": "duckdb_get_struct_child",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_value",
+                    "name": "value"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "index"
+                }
+            ],
+            "comment": {
+                "description": "Returns the STRUCT child at index as a duckdb_value.\n\n",
+                "param_comments": {
+                    "value": "The STRUCT value.",
+                    "index": "The index of the child."
+                },
+                "return_value": "The child as a duckdb_value."
+            }
         }
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -945,7 +945,7 @@
             }
         },
         {
-            "name": "duckdb_create_enum",
+            "name": "duckdb_create_enum_value",
             "return_type": "duckdb_value",
             "params": [
                 {
@@ -981,23 +981,6 @@
                     "value": "A duckdb_value containing an enum"
                 },
                 "return_value": "A uint64_t, or MinValue<uint64> if the value cannot be converted"
-            }
-        },
-        {
-            "name": "duckdb_get_struct_child_count",
-            "return_type": "idx_t",
-            "params": [
-                {
-                    "type": "duckdb_value",
-                    "name": "value"
-                }
-            ],
-            "comment": {
-                "description": "Returns the number of children in a STRUCT value.\n\n",
-                "param_comments": {
-                    "value": "The STRUCT value."
-                },
-                "return_value": "The number of children in the struct."
             }
         },
         {

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -500,9 +500,8 @@ typedef struct {
 	duckdb_value (*duckdb_create_null_value)();
 	idx_t (*duckdb_get_list_size)(duckdb_value value);
 	duckdb_value (*duckdb_get_list_child)(duckdb_value value, idx_t index);
-	duckdb_value (*duckdb_create_enum)(duckdb_logical_type type, uint64_t value);
+	duckdb_value (*duckdb_create_enum_value)(duckdb_logical_type type, uint64_t value);
 	uint64_t (*duckdb_get_enum_value)(duckdb_value value);
-	idx_t (*duckdb_get_struct_child_count)(duckdb_value value);
 	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
 #endif
 
@@ -891,9 +890,8 @@ typedef struct {
 #define duckdb_create_null_value                 duckdb_ext_api.duckdb_create_null_value
 #define duckdb_get_list_size                     duckdb_ext_api.duckdb_get_list_size
 #define duckdb_get_list_child                    duckdb_ext_api.duckdb_get_list_child
-#define duckdb_create_enum                       duckdb_ext_api.duckdb_create_enum
+#define duckdb_create_enum_value                 duckdb_ext_api.duckdb_create_enum_value
 #define duckdb_get_enum_value                    duckdb_ext_api.duckdb_get_enum_value
-#define duckdb_get_struct_child_count            duckdb_ext_api.duckdb_get_struct_child_count
 #define duckdb_get_struct_child                  duckdb_ext_api.duckdb_get_struct_child
 #define duckdb_appender_create_ext               duckdb_ext_api.duckdb_appender_create_ext
 #define duckdb_table_description_create_ext      duckdb_ext_api.duckdb_table_description_create_ext

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -500,6 +500,10 @@ typedef struct {
 	duckdb_value (*duckdb_create_null_value)();
 	idx_t (*duckdb_get_list_size)(duckdb_value value);
 	duckdb_value (*duckdb_get_list_child)(duckdb_value value, idx_t index);
+	duckdb_value (*duckdb_create_enum)(duckdb_logical_type type, uint64_t value);
+	uint64_t (*duckdb_get_enum_value)(duckdb_value value);
+	idx_t (*duckdb_get_struct_child_count)(duckdb_value value);
+	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
 #endif
 
 } duckdb_ext_api_v0;
@@ -887,6 +891,10 @@ typedef struct {
 #define duckdb_create_null_value                 duckdb_ext_api.duckdb_create_null_value
 #define duckdb_get_list_size                     duckdb_ext_api.duckdb_get_list_size
 #define duckdb_get_list_child                    duckdb_ext_api.duckdb_get_list_child
+#define duckdb_create_enum                       duckdb_ext_api.duckdb_create_enum
+#define duckdb_get_enum_value                    duckdb_ext_api.duckdb_get_enum_value
+#define duckdb_get_struct_child_count            duckdb_ext_api.duckdb_get_struct_child_count
+#define duckdb_get_struct_child                  duckdb_ext_api.duckdb_get_struct_child
 #define duckdb_appender_create_ext               duckdb_ext_api.duckdb_appender_create_ext
 #define duckdb_table_description_create_ext      duckdb_ext_api.duckdb_table_description_create_ext
 #define duckdb_table_description_get_column_name duckdb_ext_api.duckdb_table_description_get_column_name

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -369,3 +369,65 @@ duckdb_value duckdb_get_list_child(duckdb_value value, idx_t index) {
 
 	return WrapValue(new duckdb::Value(children[index]));
 }
+
+duckdb_value duckdb_create_enum(duckdb_logical_type type, uint64_t value) {
+	if (!type) {
+		return nullptr;
+	}
+
+	auto &logical_type = UnwrapType(type);
+	if (logical_type.id() != LogicalTypeId::ENUM) {
+		return nullptr;
+	}
+
+	if (value >= duckdb::EnumType::GetSize(logical_type)) {
+		return nullptr;
+	}
+
+	return WrapValue(new duckdb::Value(duckdb::Value::ENUM(value, logical_type)));
+}
+
+uint64_t duckdb_get_enum_value(duckdb_value value) {
+	if (!value) {
+		return 0;
+	}
+
+	auto val = UnwrapValue(value);
+	if (val.type().id() != LogicalTypeId::ENUM || val.IsNull()) {
+		return 0;
+	}
+
+	return val.GetValue<uint64_t>();
+}
+
+idx_t duckdb_get_struct_child_count(duckdb_value value) {
+	if (!value) {
+		return 0;
+	}
+
+	auto val = UnwrapValue(value);
+	if (val.type().id() != LogicalTypeId::STRUCT || val.IsNull()) {
+		return 0;
+	}
+
+	auto &children = duckdb::StructValue::GetChildren(val);
+	return children.size();
+}
+
+duckdb_value duckdb_get_struct_child(duckdb_value value, idx_t index) {
+	if (!value) {
+		return nullptr;
+	}
+
+	auto val = UnwrapValue(value);
+	if (val.type().id() != LogicalTypeId::STRUCT || val.IsNull()) {
+		return nullptr;
+	}
+
+	auto &children = duckdb::StructValue::GetChildren(val);
+	if (index >= children.size()) {
+		return nullptr;
+	}
+
+	return WrapValue(new duckdb::Value(children[index]));
+}

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -370,7 +370,7 @@ duckdb_value duckdb_get_list_child(duckdb_value value, idx_t index) {
 	return WrapValue(new duckdb::Value(children[index]));
 }
 
-duckdb_value duckdb_create_enum(duckdb_logical_type type, uint64_t value) {
+duckdb_value duckdb_create_enum_value(duckdb_logical_type type, uint64_t value) {
 	if (!type) {
 		return nullptr;
 	}
@@ -398,20 +398,6 @@ uint64_t duckdb_get_enum_value(duckdb_value value) {
 	}
 
 	return val.GetValue<uint64_t>();
-}
-
-idx_t duckdb_get_struct_child_count(duckdb_value value) {
-	if (!value) {
-		return 0;
-	}
-
-	auto val = UnwrapValue(value);
-	if (val.type().id() != LogicalTypeId::STRUCT || val.IsNull()) {
-		return 0;
-	}
-
-	auto &children = duckdb::StructValue::GetChildren(val);
-	return children.size();
 }
 
 duckdb_value duckdb_get_struct_child(duckdb_value value, idx_t index) {

--- a/test/api/capi/test_capi_values.cpp
+++ b/test/api/capi/test_capi_values.cpp
@@ -61,3 +61,73 @@ TEST_CASE("Test LIST getters", "[capi]") {
 
 	duckdb_destroy_value(&list_value);
 }
+
+TEST_CASE("Test ENUM getters", "[capi]") {
+	const char *mnames[5] = {"apple", "banana", "cherry", "orange", "elderberry"};
+	duckdb_logical_type enum_type = duckdb_create_enum_type(mnames, 5);
+
+	duckdb_value enum_val = duckdb_create_enum(enum_type, 2);
+	REQUIRE(enum_val);
+
+	auto val = duckdb_get_enum_value(nullptr);
+	REQUIRE(val == 0);
+
+	val = duckdb_get_enum_value(enum_val);
+	REQUIRE(val == 2);
+
+	duckdb_destroy_value(&enum_val);
+
+	enum_val = duckdb_create_enum(enum_type, 4);
+	REQUIRE(enum_val);
+
+	val = duckdb_get_enum_value(enum_val);
+	REQUIRE(val == 4);
+
+	duckdb_destroy_value(&enum_val);
+
+	enum_val = duckdb_create_enum(enum_type, 5);
+	REQUIRE(!enum_val);
+
+	enum_val = duckdb_create_enum(enum_type, 6);
+	REQUIRE(!enum_val);
+
+	duckdb_destroy_value(&enum_val);
+
+	duckdb_destroy_logical_type(&enum_type);
+}
+
+TEST_CASE("Test STRUCT getters", "[capi]") {
+	duckdb_logical_type mtypes[2] = {duckdb_create_logical_type(DUCKDB_TYPE_UBIGINT),
+	                                 duckdb_create_logical_type(DUCKDB_TYPE_BIGINT)};
+	const char *mnames[2] = {"a", "b"};
+	duckdb_logical_type struct_type = duckdb_create_struct_type(mtypes, mnames, 2);
+	duckdb_destroy_logical_type(&mtypes[0]);
+	duckdb_destroy_logical_type(&mtypes[1]);
+
+	duckdb_value svals[2] = {duckdb_create_uint64(42), duckdb_create_int64(-42)};
+	duckdb_value struct_val = duckdb_create_struct_value(struct_type, svals);
+	duckdb_destroy_logical_type(&struct_type);
+	duckdb_destroy_value(&svals[0]);
+	duckdb_destroy_value(&svals[1]);
+
+	auto val = duckdb_get_struct_child(nullptr, 0);
+	REQUIRE(!val);
+
+	val = duckdb_get_struct_child(struct_val, 0);
+	REQUIRE(val);
+	REQUIRE(duckdb_get_uint64(val) == 42);
+	duckdb_destroy_value(&val);
+
+	val = duckdb_get_struct_child(struct_val, 1);
+	REQUIRE(val);
+	REQUIRE(duckdb_get_int64(val) == -42);
+	duckdb_destroy_value(&val);
+
+	val = duckdb_get_struct_child(struct_val, 2);
+	REQUIRE(!val);
+
+	REQUIRE(duckdb_get_struct_child_count(nullptr) == 0);
+	REQUIRE(duckdb_get_struct_child_count(struct_val) == 2);
+
+	duckdb_destroy_value(&struct_val);
+}

--- a/test/api/capi/test_capi_values.cpp
+++ b/test/api/capi/test_capi_values.cpp
@@ -66,7 +66,7 @@ TEST_CASE("Test ENUM getters", "[capi]") {
 	const char *mnames[5] = {"apple", "banana", "cherry", "orange", "elderberry"};
 	duckdb_logical_type enum_type = duckdb_create_enum_type(mnames, 5);
 
-	duckdb_value enum_val = duckdb_create_enum(enum_type, 2);
+	duckdb_value enum_val = duckdb_create_enum_value(enum_type, 2);
 	REQUIRE(enum_val);
 
 	auto val = duckdb_get_enum_value(nullptr);
@@ -77,7 +77,7 @@ TEST_CASE("Test ENUM getters", "[capi]") {
 
 	duckdb_destroy_value(&enum_val);
 
-	enum_val = duckdb_create_enum(enum_type, 4);
+	enum_val = duckdb_create_enum_value(enum_type, 4);
 	REQUIRE(enum_val);
 
 	val = duckdb_get_enum_value(enum_val);
@@ -85,10 +85,10 @@ TEST_CASE("Test ENUM getters", "[capi]") {
 
 	duckdb_destroy_value(&enum_val);
 
-	enum_val = duckdb_create_enum(enum_type, 5);
+	enum_val = duckdb_create_enum_value(enum_type, 5);
 	REQUIRE(!enum_val);
 
-	enum_val = duckdb_create_enum(enum_type, 6);
+	enum_val = duckdb_create_enum_value(enum_type, 6);
 	REQUIRE(!enum_val);
 
 	duckdb_destroy_value(&enum_val);
@@ -125,9 +125,6 @@ TEST_CASE("Test STRUCT getters", "[capi]") {
 
 	val = duckdb_get_struct_child(struct_val, 2);
 	REQUIRE(!val);
-
-	REQUIRE(duckdb_get_struct_child_count(nullptr) == 0);
-	REQUIRE(duckdb_get_struct_child_count(struct_val) == 2);
 
 	duckdb_destroy_value(&struct_val);
 }


### PR DESCRIPTION
Added the following missing C-API functions for accessing ENUM and STRUCT values

```c
DUCKDB_API duckdb_value duckdb_create_enum_value(duckdb_logical_type type, uint64_t value);
DUCKDB_API uint64_t duckdb_get_enum_value(duckdb_value value);
DUCKDB_API duckdb_value duckdb_get_struct_child(duckdb_value value, idx_t index);
```

Also related to:
https://github.com/duckdb/duckdb/issues/14728

UPDATE:
- Removed `duckdb_get_struct_child_count`
- Changed `duckdb_create_enum` to `duckdb_create_enum_value`