### PR TITLE
return InsertionOrderPreservingMap from TableFunction to_string

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -161,5 +161,6 @@ if (NOT MINGW)
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_mysql
             GIT_TAG f2a15013fb4559e1591e977c1c023aa0a369c6f3
+            APPLY_PATCHES
             )
 endif()

--- a/.github/patches/extensions/mysql_scanner/table_fun_to_string.patch
+++ b/.github/patches/extensions/mysql_scanner/table_fun_to_string.patch
@@ -1,0 +1,19 @@
+diff --git a/src/mysql_scanner.cpp b/src/mysql_scanner.cpp
+index 556716c..805044f 100644
+--- a/src/mysql_scanner.cpp
++++ b/src/mysql_scanner.cpp
+@@ -158,9 +158,11 @@ static void MySQLScan(ClientContext &context, TableFunctionInput &data, DataChun
+ 	output.SetCardinality(r);
+ }
+ 
+-static string MySQLScanToString(const FunctionData *bind_data_p) {
+-	auto &bind_data = bind_data_p->Cast<MySQLBindData>();
+-	return bind_data.table.name;
++static InsertionOrderPreservingMap<string> MySQLScanToString(TableFunctionToStringInput &input) {
++  	InsertionOrderPreservingMap<string> result;
++	auto &bind_data = input.bind_data->Cast<MySQLBindData>();
++	result["Table"] = bind_data.table.name;
++	return result;
+ }
+ 
+ static void MySQLScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,

--- a/.github/patches/extensions/postgres_scanner/table_fun_to_string.patch
+++ b/.github/patches/extensions/postgres_scanner/table_fun_to_string.patch
@@ -1,0 +1,21 @@
+diff --git a/src/postgres_scanner.cpp b/src/postgres_scanner.cpp
+index dfee871..a39abc5 100644
+--- a/src/postgres_scanner.cpp
++++ b/src/postgres_scanner.cpp
+@@ -491,10 +491,12 @@ static idx_t PostgresScanBatchIndex(ClientContext &context, const FunctionData *
+ 	return local_state.batch_idx;
+ }
+ 
+-static string PostgresScanToString(const FunctionData *bind_data_p) {
+-	D_ASSERT(bind_data_p);
+-	auto &bind_data = bind_data_p->Cast<PostgresBindData>();
+-	return bind_data.table_name;
++static InsertionOrderPreservingMap<string> PostgresScanToString(TableFunctionToStringInput &input) {
++	D_ASSERT(input.bind_data);
++	InsertionOrderPreservingMap<string> result;
++	auto &bind_data = input.bind_data->Cast<PostgresBindData>();
++	result["Table"] = bind_data.table_name;
++	return result;
+ }
+ 
+ unique_ptr<NodeStatistics> PostgresScanCardinality(ClientContext &context, const FunctionData *bind_data_p) {

--- a/.github/patches/extensions/spatial/table_fun_to_string.patch
+++ b/.github/patches/extensions/spatial/table_fun_to_string.patch
@@ -1,0 +1,21 @@
+diff --git a/spatial/src/spatial/core/index/rtree/rtree_index_scan.cpp b/spatial/src/spatial/core/index/rtree/rtree_index_scan.cpp
+index 01f2966..e09b739 100644
+--- a/spatial/src/spatial/core/index/rtree/rtree_index_scan.cpp
++++ b/spatial/src/spatial/core/index/rtree/rtree_index_scan.cpp
+@@ -128,9 +128,13 @@ unique_ptr<NodeStatistics> RTreeIndexScanCardinality(ClientContext &context, con
+ //-------------------------------------------------------------------------
+ // ToString
+ //-------------------------------------------------------------------------
+-static string RTreeIndexScanToString(const FunctionData *bind_data_p) {
+-	auto &bind_data = bind_data_p->Cast<RTreeIndexScanBindData>();
+-	return bind_data.table.name + " (RTREE INDEX SCAN : " + bind_data.index.GetIndexName() + ")";
++static InsertionOrderPreservingMap<string> RTreeIndexScanToString(TableFunctionToStringInput &input) {
++	D_ASSERT(input.bind_data);
++	InsertionOrderPreservingMap<string> result;
++	auto &bind_data = input.bind_data->Cast<RTreeIndexScanBindData>();
++	result["Table"] = bind_data.table.name;
++	result["Index"] = bind_data.index.GetIndexName();
++	return result;
+ }
+ 
+ //-------------------------------------------------------------------------

--- a/.github/patches/extensions/sqlite_scanner/table_fun_to_string.patch
+++ b/.github/patches/extensions/sqlite_scanner/table_fun_to_string.patch
@@ -1,0 +1,22 @@
+diff --git a/src/sqlite_scanner.cpp b/src/sqlite_scanner.cpp
+index e5b50c3..919e808 100644
+--- a/src/sqlite_scanner.cpp
++++ b/src/sqlite_scanner.cpp
+@@ -315,10 +315,13 @@ static void SqliteScan(ClientContext &context, TableFunctionInput &data, DataChu
+ 	}
+ }
+ 
+-static string SqliteToString(const FunctionData *bind_data_p) {
+-	D_ASSERT(bind_data_p);
+-	auto &bind_data = bind_data_p->Cast<SqliteBindData>();
+-	return StringUtil::Format("%s:%s", bind_data.file_name, bind_data.table_name);
++static InsertionOrderPreservingMap<string> SqliteToString(TableFunctionToStringInput &input) {
++	D_ASSERT(input.bind_data);
++	InsertionOrderPreservingMap<string> result;
++	auto &bind_data = input.bind_data->Cast<SqliteBindData>();
++        result["Table"] = bind_data.table_name;
++        result["File"] = bind_data.file_name;
++	return result;
+ }
+ 
+ /*

--- a/.github/patches/extensions/vss/table_fun_to_string.patch
+++ b/.github/patches/extensions/vss/table_fun_to_string.patch
@@ -1,0 +1,21 @@
+diff --git a/src/hnsw/hnsw_index_scan.cpp b/src/hnsw/hnsw_index_scan.cpp
+index bd4826c..4e0c63a 100644
+--- a/src/hnsw/hnsw_index_scan.cpp
++++ b/src/hnsw/hnsw_index_scan.cpp
+@@ -123,9 +123,13 @@ unique_ptr<NodeStatistics> HNSWIndexScanCardinality(ClientContext &context, cons
+ //-------------------------------------------------------------------------
+ // ToString
+ //-------------------------------------------------------------------------
+-static string HNSWIndexScanToString(const FunctionData *bind_data_p) {
+-	auto &bind_data = bind_data_p->Cast<HNSWIndexScanBindData>();
+-	return bind_data.table.name + " (HNSW INDEX SCAN : " + bind_data.index.GetIndexName() + ")";
++static InsertionOrderPreservingMap<string> HNSWIndexScanToString(TableFunctionToStringInput &input) {
++	D_ASSERT(input.bind_data);
++	InsertionOrderPreservingMap<string> result;
++	auto &bind_data = input.bind_data->Cast<HNSWIndexScanBindData>();
++	result["Table"] = bind_data.table.name;
++	result["HSNW Index"] = bind_data.index.GetIndexName();
++	return result;
+ }
+ 
+ //-------------------------------------------------------------------------

--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -111,7 +111,11 @@ OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context
 InsertionOrderPreservingMap<string> PhysicalTableInOutFunction::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
 	if (function.to_string) {
-		result["__text__"] = function.to_string(bind_data.get());
+		TableFunctionToStringInput input(function, bind_data.get());
+		auto to_string_result = function.to_string(input);
+		for (const auto &it : to_string_result) {
+			result[it.first] = it.second;
+		}
 	} else {
 		result["Name"] = function.name;
 	}

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -148,7 +148,11 @@ string PhysicalTableScan::GetName() const {
 InsertionOrderPreservingMap<string> PhysicalTableScan::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
 	if (function.to_string) {
-		result["__text__"] = function.to_string(bind_data.get());
+		TableFunctionToStringInput input(function, bind_data.get());
+		auto to_string_result = function.to_string(input);
+		for (const auto &it : to_string_result) {
+			result[it.first] = it.second;
+		}
 	} else {
 		result["Function"] = StringUtil::Upper(function.name);
 	}

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -372,9 +372,10 @@ void TableScanPushdownComplexFilter(ClientContext &context, LogicalGet &get, Fun
 	});
 }
 
-string TableScanToString(const FunctionData *bind_data_p) {
-	auto &bind_data = bind_data_p->Cast<TableScanBindData>();
-	string result = bind_data.table.name;
+InsertionOrderPreservingMap<string> TableScanToString(TableFunctionToStringInput &input) {
+	InsertionOrderPreservingMap<string> result;
+	auto &bind_data = input.bind_data->Cast<TableScanBindData>();
+	result["Table"] = bind_data.table.name;
 	return result;
 }
 

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -154,6 +154,14 @@ struct TableFunctionPartitionInput {
 	const vector<column_t> &partition_ids;
 };
 
+struct TableFunctionToStringInput {
+	TableFunctionToStringInput(const TableFunction &table_function_p, optional_ptr<const FunctionData> bind_data_p)
+	    : table_function(table_function_p), bind_data(bind_data_p) {
+	}
+	const TableFunction &table_function;
+	optional_ptr<const FunctionData> bind_data;
+};
+
 struct TableFunctionGetPartitionInput {
 public:
 	TableFunctionGetPartitionInput(optional_ptr<const FunctionData> bind_data_p,
@@ -253,7 +261,7 @@ typedef unique_ptr<NodeStatistics> (*table_function_cardinality_t)(ClientContext
 typedef void (*table_function_pushdown_complex_filter_t)(ClientContext &context, LogicalGet &get,
                                                          FunctionData *bind_data,
                                                          vector<unique_ptr<Expression>> &filters);
-typedef string (*table_function_to_string_t)(const FunctionData *bind_data);
+typedef InsertionOrderPreservingMap<string> (*table_function_to_string_t)(TableFunctionToStringInput &input);
 
 typedef void (*table_function_serialize_t)(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
                                            const TableFunction &function);

--- a/src/optimizer/in_clause_rewriter.cpp
+++ b/src/optimizer/in_clause_rewriter.cpp
@@ -15,8 +15,12 @@ unique_ptr<LogicalOperator> InClauseRewriter::Rewrite(unique_ptr<LogicalOperator
 	if (op->children.size() == 1) {
 		if (op->children[0]->type == LogicalOperatorType::LOGICAL_GET) {
 			auto &get = op->children[0]->Cast<LogicalGet>();
-			if (get.function.to_string && get.function.to_string(get.bind_data.get()) == "REMOTE") {
-				return op;
+			if (get.function.to_string) {
+				TableFunctionToStringInput input(get.function, get.bind_data.get());
+				auto to_string_result = get.function.to_string(input);
+				if (to_string_result["__text__"] == "REMOTE") {
+					return op;
+				}
 			}
 		}
 		root = std::move(op->children[0]);

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -61,7 +61,11 @@ InsertionOrderPreservingMap<string> LogicalGet::ParamsToString() const {
 	}
 
 	if (function.to_string) {
-		result["__text__"] = function.to_string(bind_data.get());
+		TableFunctionToStringInput input(function, bind_data.get());
+		auto to_string_result = function.to_string(input);
+		for (const auto &it : to_string_result) {
+			result[it.first] = it.second;
+		}
 	}
 	SetParamsEstimatedCardinality(result);
 	return result;

--- a/test/sql/explain/test_explain_table_scan.test
+++ b/test/sql/explain/test_explain_table_scan.test
@@ -1,0 +1,17 @@
+# name: test/sql/explain/test_explain_table_scan.test
+# description: Test explain of table scans
+# group: [explain]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER, j INTEGER)
+
+statement ok
+INSERT INTO integers VALUES (1, 1), (2, 2), (3, 3), (NULL, NULL)
+
+query II
+EXPLAIN SELECT * FROM integers
+----
+physical_plan	<REGEX>:.*Table: integers.*


### PR DESCRIPTION
Follow up of https://github.com/duckdb/duckdb/pull/13109.

This PR extends the aforementioned by allowing the TableFunction::to_string method to also return a map instead of a raw string. This allows TableFunctions to return structured information for the explain output.

Additionally, this PR reworks the parameters to the `to_string` function to also take a reference to the table function. This is required for the new delta attach functionality to be able to deduce which table is being scanned.

With these two things the delta extension can make its explain output for scanning attached tables a lot prettier by showing the name of the table scanned (thanks @djouallah for this suggestion https://github.com/duckdb/duckdb_delta/issues/117):

```
┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│           UNION           ├──────────────┐
└─────────────┬─────────────┘              │
┌─────────────┴─────────────┐┌─────────────┴─────────────┐
│        DELTA_SCAN         ││        DELTA_SCAN         │
│    ────────────────────   ││    ────────────────────   │
│         Table: dt1        ││         Table: dt2        │
│    Projections: c_name    ││    Projections: c_name    │
│                           ││                           │
│        ~150000 Rows       ││        ~150000 Rows       │
└───────────────────────────┘└───────────────────────────┘
```