### PR TITLE
Support struct projection pushdown in Parquet files

### DIFF
--- a/.github/patches/extensions/delta/fixes.patch
+++ b/.github/patches/extensions/delta/fixes.patch
@@ -1,5 +1,5 @@
 diff --git a/src/functions/delta_scan.cpp b/src/functions/delta_scan.cpp
-index 65eb34f..9b45db2 100644
+index 65eb34f..7210382 100644
 --- a/src/functions/delta_scan.cpp
 +++ b/src/functions/delta_scan.cpp
 @@ -464,7 +464,11 @@ unique_ptr<MultiFileList> DeltaSnapshot::ComplexFilterPushdown(ClientContext &co
@@ -24,6 +24,24 @@ index 65eb34f..9b45db2 100644
      return std::move(make_uniq<DeltaMultiFileReader>());
  }
  
+@@ -575,7 +579,7 @@ void DeltaMultiFileReader::BindOptions(MultiFileReaderOptions &options, MultiFil
+ void DeltaMultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, const MultiFileReaderBindData &options,
+                   const string &filename, const vector<string> &local_names,
+                   const vector<LogicalType> &global_types, const vector<string> &global_names,
+-                  const vector<column_t> &global_column_ids, MultiFileReaderData &reader_data,
++                  const vector<ColumnIndex> &global_column_ids, MultiFileReaderData &reader_data,
+                   ClientContext &context, optional_ptr<MultiFileReaderGlobalState> global_state) {
+     MultiFileReader::FinalizeBind(file_options, options, filename, local_names, global_types, global_names, global_column_ids, reader_data, context, global_state);
+ 
+@@ -600,7 +604,7 @@ void DeltaMultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_optio
+ 
+     if (!file_metadata->partition_map.empty()) {
+         for (idx_t i = 0; i < global_column_ids.size(); i++) {
+-            column_t col_id = global_column_ids[i];
++            column_t col_id = global_column_ids[i].GetPrimaryIndex();
+             if (IsRowIdColumnId(col_id)) {
+                 continue;
+             }
 @@ -618,12 +622,12 @@ void DeltaMultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_optio
      }
  }
@@ -39,8 +57,52 @@ index 65eb34f..9b45db2 100644
  }
  
  // Generate the correct Selection Vector Based on the Raw delta KernelBoolSlice dv and the row_id_column
+@@ -670,14 +674,14 @@ unique_ptr<MultiFileReaderGlobalState> DeltaMultiFileReader::InitializeGlobalSta
+                                                                                    const duckdb::MultiFileList &file_list,
+                                                                                    const vector<duckdb::LogicalType> &global_types,
+                                                                                    const vector<std::string> &global_names,
+-                                                                                   const vector<duckdb::column_t> &global_column_ids) {
++                                                                                   const vector<duckdb::ColumnIndex> &global_column_ids) {
+     vector<LogicalType> extra_columns;
+     vector<pair<string, idx_t>> mapped_columns;
+ 
+     // Create a map of the columns that are in the projection
+     case_insensitive_map_t<idx_t> selected_columns;
+     for (idx_t i = 0; i < global_column_ids.size(); i++) {
+-        auto global_id = global_column_ids[i];
++        auto global_id = global_column_ids[i].GetPrimaryIndex();
+         if (IsRowIdColumnId(global_id)) {
+             continue;
+         }
+@@ -736,7 +740,7 @@ unique_ptr<MultiFileReaderGlobalState> DeltaMultiFileReader::InitializeGlobalSta
+ // in the parquet files, we just add null constant columns
+ static void CustomMulfiFileNameMapping(const string &file_name, const vector<LogicalType> &local_types,
+                                         const vector<string> &local_names, const vector<LogicalType> &global_types,
+-                                        const vector<string> &global_names, const vector<column_t> &global_column_ids,
++                                        const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
+                                         MultiFileReaderData &reader_data, const string &initial_file,
+                                         optional_ptr<MultiFileReaderGlobalState> global_state) {
+     D_ASSERT(global_types.size() == global_names.size());
+@@ -760,7 +764,7 @@ static void CustomMulfiFileNameMapping(const string &file_name, const vector<Log
+ 			continue;
+ 		}
+ 		// not constant - look up the column in the name map
+-		auto global_id = global_column_ids[i];
++		auto global_id = global_column_ids[i].GetPrimaryIndex();
+ 		if (global_id >= global_types.size()) {
+ 			throw InternalException(
+ 			    "MultiFileReader::CreatePositionalMapping - global_id is out of range in global_types for this file");
+@@ -800,7 +804,7 @@ static void CustomMulfiFileNameMapping(const string &file_name, const vector<Log
+ 
+ void DeltaMultiFileReader::CreateNameMapping(const string &file_name, const vector<LogicalType> &local_types,
+                                         const vector<string> &local_names, const vector<LogicalType> &global_types,
+-                                        const vector<string> &global_names, const vector<column_t> &global_column_ids,
++                                        const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
+                                         MultiFileReaderData &reader_data, const string &initial_file,
+                                         optional_ptr<MultiFileReaderGlobalState> global_state) {
+     // First call the base implementation to do most mapping
 diff --git a/src/include/functions/delta_scan.hpp b/src/include/functions/delta_scan.hpp
-index aac35cc..84220f9 100644
+index aac35cc..d90968b 100644
 --- a/src/include/functions/delta_scan.hpp
 +++ b/src/include/functions/delta_scan.hpp
 @@ -103,9 +103,9 @@ struct DeltaMultiFileReaderGlobalState : public MultiFileReaderGlobalState {
@@ -55,3 +117,26 @@ index aac35cc..84220f9 100644
                     FileGlobOptions options) override;
  
      //! Override the regular parquet bind using the MultiFileReader Bind. The bind from these are what DuckDB's file
+@@ -119,19 +119,19 @@ struct DeltaMultiFileReader : public MultiFileReader {
+ 
+     void CreateNameMapping(const string &file_name, const vector<LogicalType> &local_types,
+                       const vector<string> &local_names, const vector<LogicalType> &global_types,
+-                      const vector<string> &global_names, const vector<column_t> &global_column_ids,
++                      const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
+                       MultiFileReaderData &reader_data, const string &initial_file,
+                       optional_ptr<MultiFileReaderGlobalState> global_state) override;
+ 
+     unique_ptr<MultiFileReaderGlobalState> InitializeGlobalState(ClientContext &context, const MultiFileReaderOptions &file_options,
+                           const MultiFileReaderBindData &bind_data, const MultiFileList &file_list,
+                           const vector<LogicalType> &global_types, const vector<string> &global_names,
+-                          const vector<column_t> &global_column_ids) override;
++                          const vector<ColumnIndex> &global_column_ids) override;
+ 
+     void FinalizeBind(const MultiFileReaderOptions &file_options, const MultiFileReaderBindData &options,
+                                        const string &filename, const vector<string> &local_names,
+                                        const vector<LogicalType> &global_types, const vector<string> &global_names,
+-                                       const vector<column_t> &global_column_ids, MultiFileReaderData &reader_data,
++                                       const vector<ColumnIndex> &global_column_ids, MultiFileReaderData &reader_data,
+                                        ClientContext &context, optional_ptr<MultiFileReaderGlobalState> global_state) override;
+ 
+     //! Override the FinalizeChunk method

--- a/benchmark/tpch/struct/tpch_q1_struct_nested_parquet.benchmark
+++ b/benchmark/tpch/struct/tpch_q1_struct_nested_parquet.benchmark
@@ -1,0 +1,18 @@
+# name: benchmark/tpch/struct/tpch_q1_struct_nested_parquet.benchmark
+# description: Run Q01 over lineitem stored in structs in a Parquet file
+# group: [struct]
+
+name Q01 Structs (Parquet)
+group tpch
+subgroup sf1
+
+require tpch
+
+load
+CALL dbgen(sf=1, suffix='_normalized');
+COPY (SELECT {'id': rowid, 'values': lineitem_normalized} AS struct_val FROM lineitem_normalized) TO '${BENCHMARK_DIR}/lineitem_struct.parquet';
+CREATE VIEW lineitem AS SELECT UNNEST(struct_val, recursive := True) FROM read_parquet('${BENCHMARK_DIR}/lineitem_struct.parquet');
+
+run extension/tpch/dbgen/queries/q01.sql
+
+result extension/tpch/dbgen/answers/sf1/q01.csv

--- a/benchmark/tpch/struct/tpch_q1_struct_parquet.benchmark
+++ b/benchmark/tpch/struct/tpch_q1_struct_parquet.benchmark
@@ -1,0 +1,18 @@
+# name: benchmark/tpch/struct/tpch_q1_struct_parquet.benchmark
+# description: Run Q01 over lineitem stored in structs in a Parquet file
+# group: [struct]
+
+name Q01 Structs (Parquet)
+group tpch
+subgroup sf1
+
+require tpch
+
+load
+CALL dbgen(sf=1, suffix='_normalized');
+COPY (SELECT lineitem_normalized AS struct_val FROM lineitem_normalized) TO '${BENCHMARK_DIR}/lineitem_struct.parquet';
+CREATE VIEW lineitem AS SELECT UNNEST(struct_val) FROM read_parquet('${BENCHMARK_DIR}/lineitem_struct.parquet');
+
+run extension/tpch/dbgen/queries/q01.sql
+
+result extension/tpch/dbgen/answers/sf1/q01.csv

--- a/extension/json/json_scan.cpp
+++ b/extension/json/json_scan.cpp
@@ -209,7 +209,7 @@ unique_ptr<GlobalTableFunctionState> JSONGlobalTableFunctionState::Init(ClientCo
 	for (auto &reader : gstate.json_readers) {
 		MultiFileReader().FinalizeBind(reader->GetOptions().file_options, gstate.bind_data.reader_bind,
 		                               reader->GetFileName(), gstate.names, dummy_types, bind_data.names,
-		                               input.column_ids, reader->reader_data, context, nullptr);
+		                               input.column_indexes, reader->reader_data, context, nullptr);
 	}
 
 	return std::move(result);

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -1179,12 +1179,11 @@ StructColumnReader::StructColumnReader(ParquetReader &reader, LogicalType type_p
 	D_ASSERT(type.InternalType() == PhysicalType::STRUCT);
 }
 
-ColumnReader *StructColumnReader::GetChildReader(idx_t child_idx) {
-	D_ASSERT(child_idx < child_readers.size());
+ColumnReader &StructColumnReader::GetChildReader(idx_t child_idx) {
 	if (!child_readers[child_idx]) {
 		throw InternalException("StructColumnReader::GetChildReader(%d) - but this child reader is not set", child_idx);
 	}
-	return child_readers[child_idx].get();
+	return *child_readers[child_idx].get();
 }
 
 void StructColumnReader::InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns,

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -202,8 +202,9 @@ private:
 	bool ScanInternal(ParquetReaderScanState &state, DataChunk &output);
 	unique_ptr<ColumnReader> CreateReader(ClientContext &context);
 
-	unique_ptr<ColumnReader> CreateReaderRecursive(ClientContext &context, idx_t depth, idx_t max_define,
-	                                               idx_t max_repeat, idx_t &next_schema_idx, idx_t &next_file_idx);
+	unique_ptr<ColumnReader> CreateReaderRecursive(ClientContext &context, const vector<ColumnIndex> &indexes,
+	                                               idx_t depth, idx_t max_define, idx_t max_repeat,
+	                                               idx_t &next_schema_idx, idx_t &next_file_idx);
 	const duckdb_parquet::RowGroup &GetGroup(ParquetReaderScanState &state);
 	uint64_t GetGroupCompressedSize(ParquetReaderScanState &state);
 	idx_t GetGroupOffset(ParquetReaderScanState &state);

--- a/extension/parquet/include/struct_column_reader.hpp
+++ b/extension/parquet/include/struct_column_reader.hpp
@@ -24,7 +24,7 @@ public:
 	vector<unique_ptr<ColumnReader>> child_readers;
 
 public:
-	ColumnReader *GetChildReader(idx_t child_idx);
+	ColumnReader &GetChildReader(idx_t child_idx);
 
 	void InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) override;
 

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -299,6 +299,9 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 		auto &struct_reader = reader.Cast<StructColumnReader>();
 		// Recurse into child readers
 		for (idx_t i = 0; i < struct_reader.child_readers.size(); i++) {
+			if (!struct_reader.child_readers[i]) {
+				continue;
+			}
 			auto &child_reader = *struct_reader.child_readers[i];
 			auto child_stats = ParquetStatisticsUtils::TransformColumnStatistics(child_reader, columns);
 			StructStats::SetChildStats(struct_stats, i, std::move(child_stats));

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -246,7 +246,7 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 		}
 	}
 	for (idx_t i = 0; i < global_column_ids.size(); i++) {
-		auto col_idx = global_column_ids[i];
+		auto &col_idx = global_column_ids[i];
 		if (col_idx.IsRowIdColumn()) {
 			// row-id
 			reader_data.constant_map.emplace_back(i, Value::BIGINT(42));
@@ -300,8 +300,9 @@ MultiFileReader::InitializeGlobalState(ClientContext &context, const MultiFileRe
 
 void MultiFileReader::CreateNameMapping(const string &file_name, const vector<LogicalType> &local_types,
                                         const vector<string> &local_names, const vector<LogicalType> &global_types,
-                                        const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
-                                        MultiFileReaderData &reader_data, const string &initial_file,
+                                        const vector<string> &global_names,
+                                        const vector<ColumnIndex> &global_column_ids, MultiFileReaderData &reader_data,
+                                        const string &initial_file,
                                         optional_ptr<MultiFileReaderGlobalState> global_state) {
 	D_ASSERT(global_types.size() == global_names.size());
 	D_ASSERT(local_types.size() == local_names.size());
@@ -358,9 +359,10 @@ void MultiFileReader::CreateNameMapping(const string &file_name, const vector<Lo
 		// the types are the same - create the mapping
 		reader_data.column_mapping.push_back(i);
 		reader_data.column_ids.push_back(local_id);
+		reader_data.column_indexes.emplace_back(local_id);
 	}
 
-	reader_data.empty_columns = reader_data.column_ids.empty();
+	reader_data.empty_columns = reader_data.column_indexes.empty();
 }
 
 void MultiFileReader::CreateMapping(const string &file_name, const vector<LogicalType> &local_types,

--- a/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
@@ -10,7 +10,7 @@ CSVUnionData::~CSVUnionData() {
 
 CSVFileScan::CSVFileScan(ClientContext &context, shared_ptr<CSVBufferManager> buffer_manager_p,
                          shared_ptr<CSVStateMachine> state_machine_p, const CSVReaderOptions &options_p,
-                         const ReadCSVData &bind_data, const vector<column_t> &column_ids, CSVSchema &file_schema)
+                         const ReadCSVData &bind_data, const vector<ColumnIndex> &column_ids, CSVSchema &file_schema)
     : file_path(options_p.file_path), file_idx(0), buffer_manager(std::move(buffer_manager_p)),
       state_machine(std::move(state_machine_p)), file_size(buffer_manager->file_handle->FileSize()),
       error_handler(make_shared_ptr<CSVErrorHandler>(options_p.ignore_errors.GetValue())),
@@ -60,7 +60,7 @@ void CSVFileScan::SetStart() {
 }
 
 CSVFileScan::CSVFileScan(ClientContext &context, const string &file_path_p, const CSVReaderOptions &options_p,
-                         const idx_t file_idx_p, const ReadCSVData &bind_data, const vector<column_t> &column_ids,
+                         const idx_t file_idx_p, const ReadCSVData &bind_data, const vector<ColumnIndex> &column_ids,
                          CSVSchema &file_schema, bool per_file_single_threaded)
     : file_path(file_path_p), file_idx(file_idx_p),
       error_handler(make_shared_ptr<CSVErrorHandler>(options_p.ignore_errors.GetValue())), options(options_p) {

--- a/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
+++ b/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 
 CSVGlobalState::CSVGlobalState(ClientContext &context_p, const shared_ptr<CSVBufferManager> &buffer_manager,
                                const CSVReaderOptions &options, idx_t system_threads_p, const vector<string> &files,
-                               vector<column_t> column_ids_p, const ReadCSVData &bind_data_p)
+                               vector<ColumnIndex> column_ids_p, const ReadCSVData &bind_data_p)
     : context(context_p), system_threads(system_threads_p), column_ids(std::move(column_ids_p)),
       sniffer_mismatch_error(options.sniffer_user_mismatch_error), bind_data(bind_data_p) {
 

--- a/src/function/table/read_csv.cpp
+++ b/src/function/table/read_csv.cpp
@@ -170,7 +170,7 @@ static unique_ptr<GlobalTableFunctionState> ReadCSVInitGlobal(ClientContext &con
 		return nullptr;
 	}
 	return make_uniq<CSVGlobalState>(context, bind_data.buffer_manager, bind_data.options,
-	                                 context.db->NumberOfThreads(), bind_data.files, input.column_ids, bind_data);
+	                                 context.db->NumberOfThreads(), bind_data.files, input.column_indexes, bind_data);
 }
 
 unique_ptr<LocalTableFunctionState> ReadCSVInitLocal(ExecutionContext &context, TableFunctionInitInput &input,

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -93,6 +93,8 @@ struct MultiFileConstantEntry {
 struct MultiFileReaderData {
 	//! The column ids to read from the file
 	vector<idx_t> column_ids;
+	//! The column indexes to read from the file
+	vector<ColumnIndex> column_indexes;
 	//! The mapping of column id -> result column id
 	//! The result chunk will be filled as follows: chunk.data[column_mapping[i]] = ReadColumn(column_ids[i]);
 	vector<idx_t> column_mapping;
@@ -167,21 +169,21 @@ struct MultiFileReader {
 	InitializeGlobalState(ClientContext &context, const MultiFileReaderOptions &file_options,
 	                      const MultiFileReaderBindData &bind_data, const MultiFileList &file_list,
 	                      const vector<LogicalType> &global_types, const vector<string> &global_names,
-	                      const vector<column_t> &global_column_ids);
+	                      const vector<ColumnIndex> &global_column_ids);
 
 	//! Finalize the bind phase of the multi-file reader after we know (1) the required (output) columns, and (2) the
 	//! pushed down table filters
 	DUCKDB_API virtual void FinalizeBind(const MultiFileReaderOptions &file_options,
 	                                     const MultiFileReaderBindData &options, const string &filename,
 	                                     const vector<string> &local_names, const vector<LogicalType> &global_types,
-	                                     const vector<string> &global_names, const vector<column_t> &global_column_ids,
+	                                     const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
 	                                     MultiFileReaderData &reader_data, ClientContext &context,
 	                                     optional_ptr<MultiFileReaderGlobalState> global_state);
 
 	//! Create all required mappings from the global types/names to the file-local types/names
 	DUCKDB_API virtual void CreateMapping(const string &file_name, const vector<LogicalType> &local_types,
 	                                      const vector<string> &local_names, const vector<LogicalType> &global_types,
-	                                      const vector<string> &global_names, const vector<column_t> &global_column_ids,
+	                                      const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
 	                                      optional_ptr<TableFilterSet> filters, MultiFileReaderData &reader_data,
 	                                      const string &initial_file, const MultiFileReaderBindData &options,
 	                                      optional_ptr<MultiFileReaderGlobalState> global_state);
@@ -248,7 +250,7 @@ struct MultiFileReader {
 	template <class READER_CLASS>
 	void InitializeReader(READER_CLASS &reader, const MultiFileReaderOptions &options,
 	                      const MultiFileReaderBindData &bind_data, const vector<LogicalType> &global_types,
-	                      const vector<string> &global_names, const vector<column_t> &global_column_ids,
+	                      const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
 	                      optional_ptr<TableFilterSet> table_filters, const string &initial_file,
 	                      ClientContext &context, optional_ptr<MultiFileReaderGlobalState> global_state) {
 		FinalizeBind(options, bind_data, reader.GetFileName(), reader.GetNames(), global_types, global_names,
@@ -302,7 +304,7 @@ struct MultiFileReader {
 protected:
 	virtual void CreateNameMapping(const string &file_name, const vector<LogicalType> &local_types,
 	                               const vector<string> &local_names, const vector<LogicalType> &global_types,
-	                               const vector<string> &global_names, const vector<column_t> &global_column_ids,
+	                               const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
 	                               MultiFileReaderData &reader_data, const string &initial_file,
 	                               optional_ptr<MultiFileReaderGlobalState> global_state);
 

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -176,14 +176,15 @@ struct MultiFileReader {
 	DUCKDB_API virtual void FinalizeBind(const MultiFileReaderOptions &file_options,
 	                                     const MultiFileReaderBindData &options, const string &filename,
 	                                     const vector<string> &local_names, const vector<LogicalType> &global_types,
-	                                     const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
-	                                     MultiFileReaderData &reader_data, ClientContext &context,
-	                                     optional_ptr<MultiFileReaderGlobalState> global_state);
+	                                     const vector<string> &global_names,
+	                                     const vector<ColumnIndex> &global_column_ids, MultiFileReaderData &reader_data,
+	                                     ClientContext &context, optional_ptr<MultiFileReaderGlobalState> global_state);
 
 	//! Create all required mappings from the global types/names to the file-local types/names
 	DUCKDB_API virtual void CreateMapping(const string &file_name, const vector<LogicalType> &local_types,
 	                                      const vector<string> &local_names, const vector<LogicalType> &global_types,
-	                                      const vector<string> &global_names, const vector<ColumnIndex> &global_column_ids,
+	                                      const vector<string> &global_names,
+	                                      const vector<ColumnIndex> &global_column_ids,
 	                                      optional_ptr<TableFilterSet> filters, MultiFileReaderData &reader_data,
 	                                      const string &initial_file, const MultiFileReaderBindData &options,
 	                                      optional_ptr<MultiFileReaderGlobalState> global_state);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp
@@ -42,11 +42,11 @@ public:
 	//! This means the options are alreadu set, and the buffer manager is already up and runinng.
 	CSVFileScan(ClientContext &context, shared_ptr<CSVBufferManager> buffer_manager,
 	            shared_ptr<CSVStateMachine> state_machine, const CSVReaderOptions &options,
-	            const ReadCSVData &bind_data, const vector<column_t> &column_ids, CSVSchema &file_schema);
+	            const ReadCSVData &bind_data, const vector<ColumnIndex> &column_ids, CSVSchema &file_schema);
 	//! Constructor for new CSV Files, we must initialize the buffer manager and the state machine
 	//! Path to this file
 	CSVFileScan(ClientContext &context, const string &file_path, const CSVReaderOptions &options, const idx_t file_idx,
-	            const ReadCSVData &bind_data, const vector<column_t> &column_ids, CSVSchema &file_schema,
+	            const ReadCSVData &bind_data, const vector<ColumnIndex> &column_ids, CSVSchema &file_schema,
 	            bool per_file_single_threaded);
 
 	CSVFileScan(ClientContext &context, const string &file_name, const CSVReaderOptions &options);

--- a/src/include/duckdb/execution/operator/csv_scanner/global_csv_state.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/global_csv_state.hpp
@@ -23,7 +23,7 @@ namespace duckdb {
 struct CSVGlobalState : public GlobalTableFunctionState {
 	CSVGlobalState(ClientContext &context, const shared_ptr<CSVBufferManager> &buffer_manager_p,
 	               const CSVReaderOptions &options, idx_t system_threads_p, const vector<string> &files,
-	               vector<column_t> column_ids_p, const ReadCSVData &bind_data);
+	               vector<ColumnIndex> column_ids_p, const ReadCSVData &bind_data);
 
 	~CSVGlobalState() override {
 	}
@@ -59,7 +59,7 @@ private:
 	//! Number of threads being used in this scanner
 	idx_t running_threads = 1;
 	//! The column ids to read
-	vector<column_t> column_ids;
+	vector<ColumnIndex> column_ids;
 
 	string sniffer_mismatch_error;
 

--- a/test/sql/optimizer/plan/plan_struct_projection_pushdown.test
+++ b/test/sql/optimizer/plan/plan_struct_projection_pushdown.test
@@ -1,0 +1,110 @@
+# name: test/sql/optimizer/plan/plan_struct_projection_pushdown.test
+# description: Test struct projection pushdown
+# group: [plan]
+
+require parquet
+
+statement ok
+CREATE TABLE struct_pushdown_test(id INT, struct_col STRUCT(sub_col1 integer, sub_col2 bool));
+
+statement ok
+INSERT INTO struct_pushdown_test VALUES (1, {'sub_col1': 42, 'sub_col2': true}), (2, NULL), (3, {'sub_col1': 84, 'sub_col2': NULL}), (4, {'sub_col1': NULL, 'sub_col2': false});
+
+statement ok
+COPY struct_pushdown_test TO '__TEST_DIR__/struct_pushdown_test.parquet'
+
+statement ok
+PRAGMA explain_output = 'PHYSICAL_ONLY';
+
+foreach source struct_pushdown_test read_parquet('__TEST_DIR__/struct_pushdown_test.parquet')
+
+# verify we are only selecting sub_col2
+query II
+EXPLAIN SELECT struct_col.sub_col2 FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col.sub_col2.*
+
+# verify we are only selecting sub_col1
+query II
+EXPLAIN SELECT struct_col.sub_col1 FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col.sub_col1.*
+
+query II
+EXPLAIN SELECT struct_col.sub_col1, struct_col.sub_col2 FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col.sub_col1.*struct_col.sub_col2.*
+
+# here we need to select the entire column
+query II
+EXPLAIN SELECT struct_col.sub_col1, struct_col FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col .*
+
+endloop
+
+# do the same with 2-nested structs
+statement ok
+CREATE TABLE nested_struct_pushdown_test(id INT, struct_col STRUCT(name STRUCT(v VARCHAR, id INT), nested_struct STRUCT(a integer, b bool)));
+
+statement ok
+INSERT INTO nested_struct_pushdown_test
+VALUES (1, {'name': {'v': 'Row 1', 'id': 1}, 'nested_struct': {'a': 42, 'b': true}}),
+       (2, NULL),
+       (3, {'name': {'v': 'Row 3', 'id': 3}, 'nested_struct': {'a': 84, 'b': NULL}}),
+       (4, {'name': NULL, 'nested_struct': {'a': NULL, 'b': false}});
+
+statement ok
+COPY nested_struct_pushdown_test TO '__TEST_DIR__/nested_struct_pushdown_test.parquet'
+
+foreach source nested_struct_pushdown_test read_parquet('__TEST_DIR__/nested_struct_pushdown_test.parquet')
+
+query II
+EXPLAIN SELECT struct_col.name.id FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col.name.id.*
+
+query II
+EXPLAIN SELECT struct_col.name.id, struct_col.name FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col.name .*
+
+query II
+EXPLAIN SELECT struct_col.name.id, struct_col FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col .*
+
+endloop
+
+# 3 layers of nesting
+statement ok
+CREATE OR REPLACE TABLE nested_struct_pushdown_test(id INT, struct_col STRUCT(s STRUCT(name STRUCT(v VARCHAR, id INT), nested_struct STRUCT(a integer, b bool))));
+
+statement ok
+INSERT INTO nested_struct_pushdown_test
+VALUES (1, {'s': {'name': {'v': 'Row 1', 'id': 1}, 'nested_struct': {'a': 42, 'b': true}}}),
+       (2, NULL),
+       (3, {'s': {'name': {'v': 'Row 3', 'id': 3}, 'nested_struct': {'a': 84, 'b': NULL}}}),
+       (4, {'s': {'name': NULL, 'nested_struct': {'a': NULL, 'b': false}}});
+
+statement ok
+COPY nested_struct_pushdown_test TO '__TEST_DIR__/nested_struct_pushdown_test.parquet'
+
+foreach source nested_struct_pushdown_test read_parquet('__TEST_DIR__/nested_struct_pushdown_test.parquet')
+
+query II
+EXPLAIN SELECT struct_col.s.name.id FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col.s.name.id.*
+
+query II
+EXPLAIN SELECT struct_col.s.name.id, struct_col.s.name FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col.s.name .*
+
+query II
+EXPLAIN SELECT struct_col.s.name.id, struct_col FROM ${source};
+----
+physical_plan	<REGEX>:.*struct_col .*
+
+endloop

--- a/test/sql/tpch/tpch_sf1_struct_parquet.test_slow
+++ b/test/sql/tpch/tpch_sf1_struct_parquet.test_slow
@@ -1,0 +1,41 @@
+# name: test/sql/tpch/tpch_sf1_struct_parquet.test_slow
+# description: Test TPC-H SF1
+# group: [tpch]
+
+require parquet
+
+require tpch
+
+load __TEST_DIR__/tpch_sf1_struct.db
+
+statement ok
+CALL dbgen(sf=1, suffix='_normal');
+
+foreach tbl customer lineitem nation orders part partsupp region supplier
+
+statement ok
+COPY (SELECT ${tbl}_normal val FROM ${tbl}_normal) TO '__TEST_DIR__/${tbl}_struct_sf1.parquet'
+
+statement ok
+CREATE VIEW ${tbl} AS SELECT UNNEST(val) FROM read_parquet('__TEST_DIR__/${tbl}_struct_sf1.parquet')
+
+endloop
+
+
+loop i 1 9
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
+
+endloop
+
+loop i 10 23
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
+
+endloop

--- a/test/sql/types/struct/nested_struct_projection_pushdown.test
+++ b/test/sql/types/struct/nested_struct_projection_pushdown.test
@@ -21,10 +21,7 @@ VALUES (1, {'name': {'v': 'Row 1', 'id': 1}, 'nested_struct': {'a': 42, 'b': tru
 statement ok
 COPY test_structs TO '__TEST_DIR__/test_structs.parquet'
 
-statement ok
-CREATE VIEW test_struct_view AS FROM '__TEST_DIR__/test_structs.parquet'
-
-foreach source test_structs test_struct_view
+foreach source test_structs read_parquet('__TEST_DIR__/test_structs.parquet')
 
 query I
 SELECT s.nested_struct FROM ${source}
@@ -104,10 +101,7 @@ VALUES (1, {'s': {'name': {'v': 'Row 1', 'id': 1}, 'nested_struct': {'a': 42, 'b
 statement ok
 COPY test_structs_nested TO '__TEST_DIR__/test_structs.parquet'
 
-statement ok
-CREATE VIEW test_struct_nested_view AS FROM '__TEST_DIR__/test_structs.parquet'
-
-foreach source test_structs_nested test_struct_nested_view
+foreach source test_structs_nested read_parquet('__TEST_DIR__/test_structs.parquet')
 
 query I
 SELECT base.s.nested_struct FROM ${source}

--- a/test/sql/types/struct/nested_struct_projection_pushdown.test
+++ b/test/sql/types/struct/nested_struct_projection_pushdown.test
@@ -2,6 +2,8 @@
 # description: Test nested struct projection pushdown
 # group: [struct]
 
+require parquet
+
 statement ok
 PRAGMA enable_verification
 
@@ -16,8 +18,16 @@ VALUES (1, {'name': {'v': 'Row 1', 'id': 1}, 'nested_struct': {'a': 42, 'b': tru
        (3, {'name': {'v': 'Row 3', 'id': 3}, 'nested_struct': {'a': 84, 'b': NULL}}),
        (4, {'name': NULL, 'nested_struct': {'a': NULL, 'b': false}});
 
+statement ok
+COPY test_structs TO '__TEST_DIR__/test_structs.parquet'
+
+statement ok
+CREATE VIEW test_struct_view AS FROM '__TEST_DIR__/test_structs.parquet'
+
+foreach source test_structs test_struct_view
+
 query I
-SELECT s.nested_struct FROM test_structs
+SELECT s.nested_struct FROM ${source}
 ----
 {'a': 42, 'b': true}
 NULL
@@ -25,7 +35,7 @@ NULL
 {'a': NULL, 'b': false}
 
 query I
-SELECT s.nested_struct.a FROM test_structs
+SELECT s.nested_struct.a FROM ${source}
 ----
 42
 NULL
@@ -33,7 +43,7 @@ NULL
 NULL
 
 query II
-SELECT s.nested_struct.a, s.name.v FROM test_structs
+SELECT s.nested_struct.a, s.name.v FROM ${source}
 ----
 42	Row 1
 NULL	NULL
@@ -41,7 +51,7 @@ NULL	NULL
 NULL	NULL
 
 query III
-SELECT s.nested_struct.a, s.nested_struct.b, s.nested_struct FROM test_structs
+SELECT s.nested_struct.a, s.nested_struct.b, s.nested_struct FROM ${source}
 ----
 42	true	{'a': 42, 'b': true}
 NULL	NULL	NULL
@@ -49,7 +59,7 @@ NULL	NULL	NULL
 NULL	false	{'a': NULL, 'b': false}
 
 query II
-SELECT s.nested_struct.a, s.nested_struct FROM test_structs
+SELECT s.nested_struct.a, s.nested_struct FROM ${source}
 ----
 42	{'a': 42, 'b': true}
 NULL	NULL
@@ -57,7 +67,7 @@ NULL	NULL
 NULL	{'a': NULL, 'b': false}
 
 query II
-SELECT s.nested_struct, s.nested_struct.a FROM test_structs
+SELECT s.nested_struct, s.nested_struct.a FROM ${source}
 ----
 {'a': 42, 'b': true}	42
 NULL	NULL
@@ -65,7 +75,7 @@ NULL	NULL
 {'a': NULL, 'b': false}	NULL
 
 query II
-SELECT s.name.id, s.nested_struct.b,  FROM test_structs
+SELECT s.name.id, s.nested_struct.b,  FROM ${source}
 ----
 1	true
 NULL	NULL
@@ -73,10 +83,11 @@ NULL	NULL
 NULL	false
 
 query I
-SELECT s.name.v FROM test_structs WHERE s.nested_struct.b
+SELECT s.name.v FROM ${source} WHERE s.nested_struct.b
 ----
 Row 1
 
+endloop
 
 # 3 layers of nesting
 statement ok
@@ -89,8 +100,17 @@ VALUES (1, {'s': {'name': {'v': 'Row 1', 'id': 1}, 'nested_struct': {'a': 42, 'b
        (3, {'s': {'name': {'v': 'Row 3', 'id': 3}, 'nested_struct': {'a': 84, 'b': NULL}}}),
        (4, {'s': {'name': NULL, 'nested_struct': {'a': NULL, 'b': false}}});
 
+
+statement ok
+COPY test_structs_nested TO '__TEST_DIR__/test_structs.parquet'
+
+statement ok
+CREATE VIEW test_struct_nested_view AS FROM '__TEST_DIR__/test_structs.parquet'
+
+foreach source test_structs_nested test_struct_nested_view
+
 query I
-SELECT base.s.nested_struct FROM test_structs_nested
+SELECT base.s.nested_struct FROM ${source}
 ----
 {'a': 42, 'b': true}
 NULL
@@ -98,7 +118,7 @@ NULL
 {'a': NULL, 'b': false}
 
 query I
-SELECT base.s.nested_struct.a FROM test_structs_nested
+SELECT base.s.nested_struct.a FROM ${source}
 ----
 42
 NULL
@@ -106,7 +126,7 @@ NULL
 NULL
 
 query II
-SELECT base.s.nested_struct.a, base.s.name.v FROM test_structs_nested
+SELECT base.s.nested_struct.a, base.s.name.v FROM ${source}
 ----
 42	Row 1
 NULL	NULL
@@ -114,7 +134,7 @@ NULL	NULL
 NULL	NULL
 
 query III
-SELECT base.s.nested_struct.a, base.s.nested_struct.b, base.s.nested_struct FROM test_structs_nested
+SELECT base.s.nested_struct.a, base.s.nested_struct.b, base.s.nested_struct FROM ${source}
 ----
 42	true	{'a': 42, 'b': true}
 NULL	NULL	NULL
@@ -122,7 +142,7 @@ NULL	NULL	NULL
 NULL	false	{'a': NULL, 'b': false}
 
 query II
-SELECT base.s.nested_struct.a, base.s.nested_struct FROM test_structs_nested
+SELECT base.s.nested_struct.a, base.s.nested_struct FROM ${source}
 ----
 42	{'a': 42, 'b': true}
 NULL	NULL
@@ -130,7 +150,7 @@ NULL	NULL
 NULL	{'a': NULL, 'b': false}
 
 query II
-SELECT base.s.nested_struct.a, base.s FROM test_structs_nested
+SELECT base.s.nested_struct.a, base.s FROM ${source}
 ----
 42	{'name': {'v': Row 1, 'id': 1}, 'nested_struct': {'a': 42, 'b': true}}
 NULL	NULL
@@ -138,7 +158,7 @@ NULL	NULL
 NULL	{'name': NULL, 'nested_struct': {'a': NULL, 'b': false}}
 
 query II
-SELECT base.s.nested_struct, base.s.nested_struct.a FROM test_structs_nested
+SELECT base.s.nested_struct, base.s.nested_struct.a FROM ${source}
 ----
 {'a': 42, 'b': true}	42
 NULL	NULL
@@ -146,7 +166,7 @@ NULL	NULL
 {'a': NULL, 'b': false}	NULL
 
 query II
-SELECT base.s.name.id, base.s.nested_struct.b,  FROM test_structs_nested
+SELECT base.s.name.id, base.s.nested_struct.b,  FROM ${source}
 ----
 1	true
 NULL	NULL
@@ -154,6 +174,8 @@ NULL	NULL
 NULL	false
 
 query I
-SELECT base.s.name.v FROM test_structs_nested WHERE base.s.nested_struct.b
+SELECT base.s.name.v FROM ${source} WHERE base.s.nested_struct.b
 ----
 Row 1
+
+endloop

--- a/test/sql/types/struct/struct_projection_pushdown.test
+++ b/test/sql/types/struct/struct_projection_pushdown.test
@@ -2,6 +2,8 @@
 # description: Test struct projection pushdown
 # group: [struct]
 
+require parquet
+
 statement ok
 PRAGMA enable_verification
 
@@ -11,8 +13,16 @@ CREATE TABLE test_structs(id INT, s STRUCT(a integer, b bool));
 statement ok
 INSERT INTO test_structs VALUES (1, {'a': 42, 'b': true}), (2, NULL), (3, {'a': 84, 'b': NULL}), (4, {'a': NULL, 'b': false});
 
+statement ok
+COPY test_structs TO '__TEST_DIR__/test_structs.parquet'
+
+statement ok
+CREATE VIEW test_struct_view AS FROM '__TEST_DIR__/test_structs.parquet'
+
+foreach source test_structs test_struct_view
+
 query I
-SELECT s.b FROM test_structs
+SELECT s.b FROM ${source}
 ----
 true
 NULL
@@ -20,7 +30,7 @@ NULL
 false
 
 query I
-SELECT s['b'] FROM test_structs
+SELECT s['b'] FROM ${source}
 ----
 true
 NULL
@@ -28,7 +38,7 @@ NULL
 false
 
 query II
-SELECT s['b'], s FROM test_structs
+SELECT s['b'], s FROM ${source}
 ----
 true	{'a': 42, 'b': true}
 NULL	NULL
@@ -36,7 +46,7 @@ NULL	{'a': 84, 'b': NULL}
 false	{'a': NULL, 'b': false}
 
 query II
-SELECT s.b, s.a FROM test_structs
+SELECT s.b, s.a FROM ${source}
 ----
 true	42
 NULL	NULL
@@ -44,19 +54,21 @@ NULL	84
 false	NULL
 
 query I
-SELECT s FROM test_structs WHERE s.b
+SELECT s FROM ${source} WHERE s.b
 ----
 {'a': 42, 'b': true}
 
 query I
-SELECT a FROM (SELECT UNNEST(s) FROM test_structs) WHERE b
+SELECT a FROM (SELECT UNNEST(s) FROM ${source}) WHERE b
 ----
 42
 
 query I
-SELECT id FROM test_structs WHERE s.b
+SELECT id FROM ${source} WHERE s.b
 ----
 1
+
+endloop
 
 statement ok
 UPDATE test_structs SET s={'a': 84, 'b': false} WHERE id=2

--- a/test/sql/types/struct/struct_projection_pushdown.test
+++ b/test/sql/types/struct/struct_projection_pushdown.test
@@ -16,10 +16,7 @@ INSERT INTO test_structs VALUES (1, {'a': 42, 'b': true}), (2, NULL), (3, {'a': 
 statement ok
 COPY test_structs TO '__TEST_DIR__/test_structs.parquet'
 
-statement ok
-CREATE VIEW test_struct_view AS FROM '__TEST_DIR__/test_structs.parquet'
-
-foreach source test_structs test_struct_view
+foreach source test_structs read_parquet('__TEST_DIR__/test_structs.parquet')
 
 query I
 SELECT s.b FROM ${source}

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -88,7 +88,7 @@ bool TestResultHelper::CheckQueryResult(const Query &query, ExecuteContext &cont
 
 	vector<string> comparison_values;
 	if (values.size() == 1 && ResultIsFile(values[0])) {
-		auto fname = SQLLogicTestRunner::LoopReplacement(values[0], context.running_loops);
+		auto fname = runner.LoopReplacement(values[0], context.running_loops);
 		string csv_error;
 		comparison_values = LoadResultFromFile(fname, result.names, expected_column_count, csv_error);
 		if (!csv_error.empty()) {

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -197,7 +197,7 @@ void Command::Execute(ExecuteContext &context) const {
 		return;
 	}
 	// perform the string replacement
-	context.sql_query = SQLLogicTestRunner::LoopReplacement(base_sql_query, context.running_loops);
+	context.sql_query = runner.LoopReplacement(base_sql_query, context.running_loops);
 	// execute the iterated statement
 	ExecuteInternal(context);
 }
@@ -512,7 +512,7 @@ void UnzipCommand::ExecuteInternal(ExecuteContext &context) const {
 }
 
 void LoadCommand::ExecuteInternal(ExecuteContext &context) const {
-	auto resolved_path = SQLLogicTestRunner::LoopReplacement(dbpath, context.running_loops);
+	auto resolved_path = runner.LoopReplacement(dbpath, context.running_loops);
 	if (!readonly) {
 		// delete the target database file, if it exists
 		DeleteDatabase(resolved_path);

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -132,6 +132,7 @@ void SQLLogicTestRunner::Reconnect() {
 }
 
 string SQLLogicTestRunner::ReplaceLoopIterator(string text, string loop_iterator_name, string replacement) {
+	replacement = ReplaceKeywords(replacement);
 	if (StringUtil::Contains(loop_iterator_name, ",")) {
 		auto name_splits = StringUtil::Split(loop_iterator_name, ",");
 		auto replacement_splits = StringUtil::Split(replacement, ",");

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -69,9 +69,9 @@ public:
 	void Reconnect();
 	void StartLoop(LoopDefinition loop);
 	void EndLoop();
-	static string ReplaceLoopIterator(string text, string loop_iterator_name, string replacement);
-	static string LoopReplacement(string text, const vector<LoopDefinition> &loops);
-	static bool ForEachTokenReplace(const string &parameter, vector<string> &result);
+	string ReplaceLoopIterator(string text, string loop_iterator_name, string replacement);
+	string LoopReplacement(string text, const vector<LoopDefinition> &loops);
+	bool ForEachTokenReplace(const string &parameter, vector<string> &result);
 
 private:
 	RequireResult CheckRequire(SQLLogicParser &parser, const vector<string> &params);


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/14750 - this PR extends the Parquet reader and the MultiFileReader to work with `ColumnIndex` - allowing pushdown into struct fields. Internally the way this works in the reader is that the `StructColumnReader` can now leave certain child readers on `NULL`. Child readers that are left on `NULL` are not scanned - they instead emit a constant `NULL` value.


### Benchmarks

Below is a benchmark running TPC-H Q01 over SF10. For the struct case, we store the entire rows in a struct field, and then extract it using a view, e.g.:

```sql
CALL dbgen(sf=10, suffix='_normalized');
COPY (SELECT lineitem_normalized AS row_val FROM lineitem_normalized) TO 'lineitem_struct.parquet';
CREATE VIEW lineitem AS SELECT UNNEST(row_val) FROM 'lineitem_struct.parquet';
```

We can see even more significant speed-ups than when using our native storage - primarily because reading the (unnecessary) string columns in Parquet format is significantly slower than when using our native format.

| Query | Struct (v1.1) | Struct (new) | Regular |
|-------|---------------|--------------|---------|
| Q01   | 1.23s         | 0.38s        | 0.35s   |


### Explain

This PR also adds support to the `EXPLAIN` for showing which sub-columns are selected in the projection list of a scan, for example:

```sql
explain select struct_val.l_orderkey, struct_val.l_partkey from lineitem_struct.parquet;

┌───────────────────────────┐
│         PROJECTION        │
│    ────────────────────   │
│ struct_extract(struct_val,│
│        'l_orderkey')      │
│ struct_extract(struct_val,│
│        'l_partkey')       │
│                           │
│        ~60175 Rows        │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│       PARQUET_SCAN        │
│    ────────────────────   │
│         Function:         │
│        PARQUET_SCAN       │
│                           │
│        Projections:       │
│   struct_val.l_orderkey   │
│    struct_val.l_partkey   │
│                           │
│        ~60175 Rows        │
└───────────────────────────┘

```
