### PR TITLE
[Python][Dev] Fix issues with new/updated tests in the python sqllogictest implementation

### DIFF
--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -458,6 +458,19 @@ def matches_regex(input: str, actual_str: str) -> bool:
     return regex_matches == should_match
 
 
+def has_external_access(conn):
+    # this is required for the python tester to work, as we make use of replacement scans
+    try:
+        res = conn.sql("select current_setting('enable_external_access')").fetchone()[0]
+        return res
+    except duckdb.TransactionException:
+        return True
+    except duckdb.BinderException:
+        return True
+    except duckdb.InvalidInputException:
+        return True
+
+
 def compare_values(result: QueryResult, actual_str, expected_str, current_column):
     error = False
 
@@ -707,7 +720,7 @@ class SQLLogicContext:
         # Apply a replacement for every registered keyword
         if '__BUILD_DIRECTORY__' in input:
             self.skiptest("Test contains __BUILD_DIRECTORY__ which isnt supported")
-        for key, value in self.keywords.items():
+        for key, value in self.keywords.items().__reversed__():
             input = input.replace(key, value)
         return input
 
@@ -815,6 +828,8 @@ class SQLLogicContext:
     def execute_query(self, query: Query):
         assert isinstance(query, Query)
         conn = self.get_connection(query.connection_name)
+        if not has_external_access(conn):
+            self.skiptest("enable_external_access is explicitly disabled by the test")
         sql_query = '\n'.join(query.lines)
         sql_query = self.replace_keywords(sql_query)
 
@@ -978,6 +993,9 @@ class SQLLogicContext:
     def execute_statement(self, statement: Statement):
         assert isinstance(statement, Statement)
         conn = self.get_connection(statement.connection_name)
+        if not has_external_access(conn):
+            self.skiptest("enable_external_access is explicitly disabled by the test")
+
         sql_query = '\n'.join(statement.lines)
         sql_query = self.replace_keywords(sql_query)
 

--- a/test/fuzzer/duckfuzz/regex_syntax_2889.test
+++ b/test/fuzzer/duckfuzz/regex_syntax_2889.test
@@ -31,8 +31,3 @@ statement error
 SELECT
 ----
 <REGEX>:Parser Error.*clause without selection list.*
-
-statement error
-SELECT
-----
-<!REGEX>:Parser Error

--- a/test/sql/attach/attach_export_import.test
+++ b/test/sql/attach/attach_export_import.test
@@ -49,6 +49,9 @@ SELECT * FROM integers
 does not exist
 
 statement ok
+drop view integers_view;
+
+statement ok
 IMPORT DATABASE '__TEST_DIR__/export_test'
 
 query I nosort q1

--- a/test/sql/pragma/profiling/test_custom_profiling_result_set_size.test
+++ b/test/sql/pragma/profiling/test_custom_profiling_result_set_size.test
@@ -25,11 +25,19 @@ PRAGMA disable_profiling;
 statement ok
 CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '__TEST_DIR__/profiling_output.json';
 
+statement ok
+CREATE TYPE Result AS UNION (
+    Ok BOOLEAN,
+    Err BIGINT
+);
+
 # Expected size: 144 = 9 (length of list) * 12 (size of a string)
 query I
-SELECT
-	CASE WHEN result_set_size = 144 THEN 'true'
-	ELSE 'false' END
+SELECT 
+    CASE 
+        WHEN result_set_size = 144 THEN TRUE::Result
+        ELSE result_set_size::Result
+    END AS result
 FROM metrics_output;
 ----
 true

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -47,6 +47,13 @@ class SQLLogicTestExecutor(SQLLogicRunner):
                 'test/sql/pragma/test_custom_profiling_settings.test',  # Because of logic related to enabling 'restart' statement capabilities, this will not measure the right statement
                 'test/sql/copy/csv/test_copy.test',  # JSON is always loaded
                 'test/sql/copy/csv/test_timestamptz_12926.test',  # ICU is always loaded
+                'test/fuzzer/pedro/in_clause_optimization_error.test',  # error message differs due to a different execution path
+                'test/sql/order/test_limit_parameter.test',  # error message differs due to a different execution path
+                'test/sql/catalog/test_set_search_path.test',  # current_query() is not the same
+                'test/sql/catalog/table/create_table_parameters.test',  # prepared statement error quirks
+                'test/sql/pragma/profiling/test_custom_profiling_rows_scanned.test',  # we perform additional queries that mess with the expected metrics
+                'test/sql/pragma/profiling/test_custom_profiling_disable_metrics.test',  # we perform additional queries that mess with the expected metrics
+                'test/sql/pragma/profiling/test_custom_profiling_result_set_size.test',  # we perform additional queries that mess with the expected metrics
             ]
         )
         # TODO: get this from the `duckdb` package


### PR DESCRIPTION
This PR fixes the failing python sqllogictest nightly-test run

Almost all of these are very benign, there is one adjustment I had to make that made me raise an eyebrow.
Possibly pointing to a problem in the C++ API ?

In `test/sql/attach/attach_export_import.test` I've had to add a `drop view integers_view` statement to get the test to pass on the python sqllogictester, which makes me wonder: why does the C++ variant not run into this same problem?

Or is the error somehow getting swallowed?