### PR TITLE
[Python][Dev] Skip `test_pandas_selection` on Python3.8

### DIFF
--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -246,7 +246,22 @@ def duckdb_cursor():
 def integers(duckdb_cursor):
     cursor = duckdb_cursor
     cursor.execute('CREATE TABLE integers (i integer)')
-    cursor.execute('INSERT INTO integers VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(NULL)')
+    cursor.execute(
+        """
+        INSERT INTO integers VALUES
+            (0),
+            (1),
+            (2),
+            (3),
+            (4),
+            (5),
+            (6),
+            (7),
+            (8),
+            (9),
+            (NULL)
+    """
+    )
     yield
     cursor.execute("drop table integers")
 

--- a/tools/pythonpkg/tests/fast/api/test_dbapi00.py
+++ b/tools/pythonpkg/tests/fast/api/test_dbapi00.py
@@ -90,11 +90,18 @@ class TestSimpleDBAPI(object):
     def test_pandas_selection(self, duckdb_cursor, pandas, integers, timestamps):
         import datetime
 
+        from packaging.version import Version
+
+        # I don't know when this exactly changed, but 2.0.3 does not support this, recent versions do
+        if Version(pandas.__version__) <= Version('2.0.3'):
+            pytest.skip("The resulting dtype is 'object' when given a Series with dtype Int32DType")
+
         duckdb_cursor.execute('SELECT * FROM integers')
         result = duckdb_cursor.fetchdf()
-        arr = numpy.ma.masked_array(numpy.arange(11))
-        arr.mask = [False] * 10 + [True]
-        arr = {'i': pandas.Series(arr, dtype=pandas.Int32Dtype)}
+        array = numpy.ma.masked_array(numpy.arange(11))
+        array.mask = [False] * 10 + [True]
+        arr = {'i': pandas.Series(array.data, dtype=pandas.Int32Dtype)}
+        arr['i'][array.mask] = pandas.NA
         arr = pandas.DataFrame(arr)
         pandas.testing.assert_frame_equal(result, arr)
 


### PR DESCRIPTION
This PR fixes the nightly failure <https://github.com/duckdb/duckdb/actions/runs/11847998662/job/33019578870>

It first failed in the Series construction, but even when I made that pass it failed on the result checking as Pandas seems to turn the dtype into `object` for Int32Dtype series in this pandas version (2.0.3)