### PR TITLE
Output exception message on parse exception

### DIFF
--- a/test/sql/cte/cte_describe.test
+++ b/test/sql/cte/cte_describe.test
@@ -26,9 +26,9 @@ with cte as (select 42 AS a) FROM (SUMMARIZE TABLE cte)
 statement error
 with cte as (select 42 AS a) (DESCRIBE TABLE cte)
 ----
-not allowed
+Parser Error: exprLocation NOT IMPLEMENTED
 
 statement error
 (DESCRIBE TABLE cte) ORDER BY 1
 ----
-not allowed
+Parser Error: exprLocation NOT IMPLEMENTED

--- a/third_party/libpg_query/pg_functions.cpp
+++ b/third_party/libpg_query/pg_functions.cpp
@@ -111,9 +111,8 @@ void pg_parser_parse(const char *query, parse_result *res) {
 	} catch (std::exception &ex) {
 		res->success = false;
 		res->error_message = ex.what();
+		res->error_location = pg_parser_state.pg_err_pos;
 	}
-	res->error_message = pg_parser_state.pg_err_msg;
-	res->error_location = pg_parser_state.pg_err_pos;
 }
 
 void pg_parser_cleanup() {
@@ -128,8 +127,7 @@ void pg_parser_cleanup() {
 }
 
 int ereport(int code, ...) {
-	std::string err = "parser error : " + std::string(pg_parser_state.pg_err_msg);
-	throw std::runtime_error(err);
+	throw std::runtime_error(pg_parser_state.pg_err_msg);
 }
 void elog(int code, const char *fmt, ...) {
 	throw std::runtime_error("elog NOT IMPLEMENTED");


### PR DESCRIPTION
Looks like a mistake that the exception message is overwritten for parse exceptions.

Status quo:
```
D select e'\xff';
Parser Error:

D 
```

This PR:
```
D select e'\xff';
Parser Error:
pg_verifymbstr NOT IMPLEMENTED
D 
```