### PR TITLE
Add `struct_concat`

### DIFF
--- a/src/function/function_list.cpp
+++ b/src/function/function_list.cpp
@@ -150,6 +150,7 @@ static const StaticFunctionDefinition function[] = {
 	DUCKDB_SCALAR_FUNCTION(StripAccentsFun),
 	DUCKDB_SCALAR_FUNCTION(StrlenFun),
 	DUCKDB_SCALAR_FUNCTION_SET(StrpTimeFun),
+	DUCKDB_SCALAR_FUNCTION(StructConcatFun),
 	DUCKDB_SCALAR_FUNCTION_SET(StructExtractFun),
 	DUCKDB_SCALAR_FUNCTION(StructPackFun),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(SubstrFun),

--- a/src/function/scalar/struct/CMakeLists.txt
+++ b/src/function/scalar/struct/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library_unity(duckdb_func_struct_main OBJECT struct_extract.cpp
-                  struct_pack.cpp)
+                  struct_pack.cpp struct_concat.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_struct_main>
     PARENT_SCOPE)

--- a/src/function/scalar/struct/functions.json
+++ b/src/function/scalar/struct/functions.json
@@ -19,5 +19,12 @@
         "description": "Create an unnamed STRUCT (tuple) containing the argument values.",
         "example": "row(i, i % 4, i / 4)",
         "type": "scalar_function"
+    },
+    {
+        "name": "struct_concat",
+        "parameters": "struct,struct,...",
+        "description": "Merge the multiple STRUCTs into a single STRUCT.",
+        "example": "struct_concat(struct_pack(i := 4), struct_pack(s := 'string'))",
+        "type": "scalar_function"
     }
 ]

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 
 namespace duckdb {

--- a/src/function/scalar/struct/struct_concat.cpp
+++ b/src/function/scalar/struct/struct_concat.cpp
@@ -1,0 +1,96 @@
+#include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/function/scalar/struct_functions.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/storage/statistics/struct_stats.hpp"
+
+namespace duckdb {
+
+static void StructConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &result_cols = StructVector::GetEntries(result);
+	idx_t offset = 0;
+
+	if (!args.AllConstant()) {
+		// Unless all arguments are constant, we flatten the input to make sure it's homogeneous
+		args.Flatten();
+	}
+
+	for (auto &arg : args.data) {
+		const auto &child_cols = StructVector::GetEntries(arg);
+		for (auto &child_col : child_cols) {
+			result_cols[offset++]->Reference(*child_col);
+		}
+	}
+	D_ASSERT(offset == result_cols.size());
+
+	if (args.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> StructConcatBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	case_insensitive_set_t name_collision_set;
+
+	// collect names and deconflict, construct return type
+	if (arguments.empty()) {
+		throw InvalidInputException("struct_concat: At least one argument is required");
+	}
+
+	child_list_t<LogicalType> combined_children;
+	case_insensitive_set_t name_set;
+
+	for (idx_t arg_idx = 0; arg_idx < arguments.size(); arg_idx++) {
+		const auto &arg = arguments[arg_idx];
+		if (arg->return_type.id() != LogicalTypeId::STRUCT) {
+			throw InvalidInputException("struct_concat: Argument at position \"%d\" is not a STRUCT", arg_idx + 1);
+		}
+
+		const auto &child_types = StructType::GetChildTypes(arg->return_type);
+		for (const auto &child : child_types) {
+			if (name_set.find(child.first) != name_set.end()) {
+				throw InvalidInputException("struct_concat: Arguments contain duplicate STRUCT entry \"%s\"",
+				                            child.first);
+			}
+			name_set.insert(child.first);
+			combined_children.push_back(child);
+		}
+	}
+
+	bound_function.return_type = LogicalType::STRUCT(combined_children);
+	return make_uniq<VariableReturnBindData>(bound_function.return_type);
+}
+
+unique_ptr<BaseStatistics> StructConcatStats(ClientContext &context, FunctionStatisticsInput &input) {
+	const auto &expr = input.expr;
+
+	auto &arg_stats = input.child_stats;
+	auto &arg_exprs = input.expr.children;
+
+	auto struct_stats = StructStats::CreateUnknown(expr.return_type);
+	idx_t struct_index = 0;
+
+	for (idx_t arg_idx = 0; arg_idx < arg_exprs.size(); arg_idx++) {
+		auto &arg_stat = arg_stats[arg_idx];
+		auto &arg_type = arg_exprs[arg_idx]->return_type;
+		for (idx_t child_idx = 0; child_idx < StructType::GetChildCount(arg_type); child_idx++) {
+			auto &child_stat = StructStats::GetChildStats(arg_stat, child_idx);
+			StructStats::SetChildStats(struct_stats, struct_index++, child_stat);
+		}
+	}
+	return struct_stats.ToUnique();
+}
+
+ScalarFunction StructConcatFun::GetFunction() {
+	ScalarFunction fun("struct_concat", {}, LogicalTypeId::STRUCT, StructConcatFunction, StructConcatBind, nullptr,
+	                   StructConcatStats);
+	fun.varargs = LogicalType::ANY;
+	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	fun.serialize = VariableReturnBindData::Serialize;
+	fun.deserialize = VariableReturnBindData::Deserialize;
+	return fun;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/function/scalar/struct_functions.hpp
+++ b/src/include/duckdb/function/scalar/struct_functions.hpp
@@ -42,4 +42,13 @@ struct RowFun {
 	static ScalarFunction GetFunction();
 };
 
+struct StructConcatFun {
+	static constexpr const char *Name = "struct_concat";
+	static constexpr const char *Parameters = "struct,struct,...";
+	static constexpr const char *Description = "Merge the multiple STRUCTs into a single STRUCT.";
+	static constexpr const char *Example = "struct_concat(struct_pack(i := 4), struct_pack(s := 'string'))";
+
+	static ScalarFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/test/sql/types/struct/struct_concat.test
+++ b/test/sql/types/struct/struct_concat.test
@@ -58,3 +58,13 @@ statement error
 SELECT struct_concat({'a': 'first struct'}, {'a': 'second struct'});
 ----
 Invalid Input Error: struct_concat: Arguments contain duplicate STRUCT entry "a"
+
+statement error
+SELECT struct_concat({'a': 'named struct'}, row(10));
+----
+Invalid Input Error: struct_concat: Cannot mix named and unnamed STRUCTs
+
+query I
+SELECT struct_concat(row('a'), row('b'));
+----
+(a, b)

--- a/test/sql/types/struct/struct_concat.test
+++ b/test/sql/types/struct/struct_concat.test
@@ -1,0 +1,60 @@
+# name: test/sql/types/struct/struct_concat.test
+# group: [struct]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT struct_concat({'a': 1}, {'b': NULL}, NULL::STRUCT(k INT), struct_pack( x := 'foobar'));;
+----
+{'a': 1, 'b': NULL, 'k': NULL, 'x': foobar}
+
+statement ok
+CREATE TABLE t1 AS SELECT {'i': i, 'j': i + i % 2} as s FROM generate_series(1, 15) AS t(i);
+
+# Test mixed flat and constant arguments
+query I rowsort
+SELECT struct_concat({'a': 2, 'b': NULL}, s) FROM t1;
+----
+{'a': 2, 'b': NULL, 'i': 1, 'j': 2}
+{'a': 2, 'b': NULL, 'i': 10, 'j': 10}
+{'a': 2, 'b': NULL, 'i': 11, 'j': 12}
+{'a': 2, 'b': NULL, 'i': 12, 'j': 12}
+{'a': 2, 'b': NULL, 'i': 13, 'j': 14}
+{'a': 2, 'b': NULL, 'i': 14, 'j': 14}
+{'a': 2, 'b': NULL, 'i': 15, 'j': 16}
+{'a': 2, 'b': NULL, 'i': 2, 'j': 2}
+{'a': 2, 'b': NULL, 'i': 3, 'j': 4}
+{'a': 2, 'b': NULL, 'i': 4, 'j': 4}
+{'a': 2, 'b': NULL, 'i': 5, 'j': 6}
+{'a': 2, 'b': NULL, 'i': 6, 'j': 6}
+{'a': 2, 'b': NULL, 'i': 7, 'j': 8}
+{'a': 2, 'b': NULL, 'i': 8, 'j': 8}
+{'a': 2, 'b': NULL, 'i': 9, 'j': 10}
+
+# Test dictionary vector concatenation
+query I rowsort
+SELECT struct_concat(s, {'a': 2, 'b': NULL}) FROM t1 WHERE s.i % 2 = 0;
+----
+{'i': 10, 'j': 10, 'a': 2, 'b': NULL}
+{'i': 12, 'j': 12, 'a': 2, 'b': NULL}
+{'i': 14, 'j': 14, 'a': 2, 'b': NULL}
+{'i': 2, 'j': 2, 'a': 2, 'b': NULL}
+{'i': 4, 'j': 4, 'a': 2, 'b': NULL}
+{'i': 6, 'j': 6, 'a': 2, 'b': NULL}
+{'i': 8, 'j': 8, 'a': 2, 'b': NULL}
+
+statement error
+SELECT struct_concat();
+----
+Invalid Input Error: struct_concat: At least one argument is required
+
+statement error
+SELECT struct_concat(NULL::STRUCT(k INT), 'not a struct');
+----
+Invalid Input Error: struct_concat: Argument at position "2" is not a STRUCT
+
+statement error
+SELECT struct_concat({'a': 'first struct'}, {'a': 'second struct'});
+----
+Invalid Input Error: struct_concat: Arguments contain duplicate STRUCT entry "a"

--- a/test/sql/types/struct/struct_concat.test
+++ b/test/sql/types/struct/struct_concat.test
@@ -60,6 +60,16 @@ SELECT struct_concat({'a': 'first struct'}, {'a': 'second struct'});
 Invalid Input Error: struct_concat: Arguments contain duplicate STRUCT entry "a"
 
 statement error
+SELECT struct_concat({'a': 'first struct'}, {'A': 'second struct'});
+----
+Invalid Input Error: struct_concat: Arguments contain case-insensitive duplicate STRUCT entry "A" and "a"
+
+statement error
+SELECT struct_concat({'a': 1}, NULL);
+----
+Invalid Input Error: struct_concat: Argument at position "2" is not a STRUCT
+
+statement error
 SELECT struct_concat({'a': 'named struct'}, row(10));
 ----
 Invalid Input Error: struct_concat: Cannot mix named and unnamed STRUCTs
@@ -68,3 +78,21 @@ query I
 SELECT struct_concat(row('a'), row('b'));
 ----
 (a, b)
+
+statement ok
+PREPARE v1 AS SELECT struct_concat({'a': 1}, ?);
+
+query I
+EXECUTE v1({'b': 42});
+----
+{'a': 1, 'b': 42}
+
+statement ok
+PREPARE v2 AS SELECT struct_concat({'a': ?}, {'b': 42});
+
+query I
+EXECUTE v2(1);
+----
+{'a': 1, 'b': 42}
+
+


### PR DESCRIPTION
This PR adds a new `struct_concat` function to merge multiple structs horizontally.
Concatenating structs with duplicate keys results in an error. Concatenating unnamed structs is supported, but you cannot mix named and unnamed.

A future cool improvement to consider when there are structs containing keys of the same name would be to merge their entries into a new list of the type of the duplicate key (or max logical type). The resulting new member could even be a ARRAY as the number of duplicates would be known at bind time. 