### PR TITLE
Continue download request if HTTP server is not honoring RANGE requests

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -721,11 +721,11 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 					}
 				}
 				res = std::move(range_res);
+			} else {
+				throw HTTPException(*res, "Unable to connect to URL \"%s\": %s (%s)", res->http_url,
+				                    to_string(res->code), res->error);
 			}
 		}
-	} else {
-		throw HTTPException(*res, "Unable to connect to URL \"%s\": %s (%s)", res->http_url, to_string(res->code),
-		                    res->error);
 	}
 
 	// Initialize the read buffer now that we know the file exists
@@ -763,6 +763,7 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
 
 			// Mark the file as initialized, set its final length, and unlock it to allowing parallel reads
 			cached_file_handle->SetInitialized(length);
+
 			// We shouldn't write these to cache
 			should_write_cache = false;
 		} else {


### PR DESCRIPTION
Allow httpfs to continue download attempt when target server is not honoring / supporting RANGE requests.

Per the RFC, it's valid for a server to IGNORE *range* headers and return 200 instead.
This patch continues the expected logic when a 200 is found instead of the expected 206.

The server mentioned at #14837  is also providing CHUNK responses.

Closes: #14837 
