### PR TITLE
Issue #11557: DECIMAL Downcast Rounding

### DIFF
--- a/src/function/cast/decimal_cast.cpp
+++ b/src/function/cast/decimal_cast.cpp
@@ -155,7 +155,7 @@ struct DecimalScaleDownCheckOperator {
 			                                data->result.GetType().ToString());
 			return HandleVectorCastError::Operation<RESULT_TYPE>(std::move(error), mask, idx, data->vector_cast_data);
 		}
-		return Cast::Operation<INPUT_TYPE, RESULT_TYPE>(input / data->factor);
+		return DecimalScaleDownOperator::Operation<INPUT_TYPE, RESULT_TYPE>(input, mask, idx, dataptr);
 	}
 };
 

--- a/test/sql/types/decimal/test_decimal.test
+++ b/test/sql/types/decimal/test_decimal.test
@@ -128,6 +128,11 @@ select CAST(-33.846 AS DECIMAL(5,0)) d0;
 ----
 -34
 
+query I
+SELECT CAST(1234567890.1235 AS DECIMAL (13, 3));
+----
+1234567890.124
+
 # various error conditions
 # scale must be bigger than or equal to width
 statement error


### PR DESCRIPTION
DecimalScaleDownCheckOperator should call DecimalScaleDownOperator after checking, not just use a simple cast.

fixes: duckdb/duckdb#11557
fixes: duckdblabs/duckdb-internal#1781