### PR TITLE
Skip piecewise merge join for type interval

### DIFF
--- a/src/execution/operator/join/physical_piecewise_merge_join.cpp
+++ b/src/execution/operator/join/physical_piecewise_merge_join.cpp
@@ -154,6 +154,16 @@ SinkFinalizeType PhysicalPiecewiseMergeJoin::Finalize(Pipeline &pipeline, Event 
 	return SinkFinalizeType::READY;
 }
 
+bool PhysicalPiecewiseMergeJoin::IsSupported(const vector<JoinCondition> &conditions) {
+	for (auto &cond : conditions) {
+		// INTERVAL type does not supported memory comparison
+		if (cond.left->return_type.InternalType() == PhysicalType::INTERVAL) {
+			return false;
+		}
+	}
+	return true;
+}
+
 //===--------------------------------------------------------------------===//
 // Operator
 //===--------------------------------------------------------------------===//

--- a/src/execution/physical_plan/plan_comparison_join.cpp
+++ b/src/execution/physical_plan/plan_comparison_join.cpp
@@ -192,7 +192,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::PlanComparisonJoin(LogicalCo
 		if (can_iejoin) {
 			plan = make_uniq<PhysicalIEJoin>(op, std::move(left), std::move(right), std::move(op.conditions),
 			                                 op.join_type, op.estimated_cardinality);
-		} else if (can_merge) {
+		} else if (can_merge && PhysicalPiecewiseMergeJoin::IsSupported(op.conditions)) {
 			// range join: use piecewise merge join
 			plan =
 			    make_uniq<PhysicalPiecewiseMergeJoin>(op, std::move(left), std::move(right), std::move(op.conditions),

--- a/src/include/duckdb/execution/operator/join/physical_piecewise_merge_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_piecewise_merge_join.hpp
@@ -70,6 +70,7 @@ public:
 	bool ParallelSink() const override {
 		return true;
 	}
+	static bool IsSupported(const vector<JoinCondition> &conditions);
 
 private:
 	// resolve joins that output max N elements (SEMI, ANTI, MARK)

--- a/test/sql/join/join_issue_14834.test
+++ b/test/sql/join/join_issue_14834.test
@@ -1,0 +1,18 @@
+# name: test/sql/join/join_issue_14834.test
+# description: Issue #14834: Unexpected result when using INTERVAL and INNER JOIN subquery.
+# group: [join]
+
+statement ok
+CREATE  TABLE  t0(c1 INTERVAL);
+
+statement ok
+INSERT INTO t0(c1) VALUES ('1 month'), ('3 days');
+
+
+query II nosort
+SELECT * FROM t0 INNER  JOIN  (SELECT  INTERVAL 1000 DAY AS col0 FROM t0) AS sub0  ON (t0.c1 < sub0.col0);
+----
+1 month	1000 days
+3 days	1000 days
+1 month	1000 days
+3 days	1000 days


### PR DESCRIPTION
This PR fixes #14834, interval can't be compared by memory but piecewise merge join uses the memory comparison.