### PR TITLE
Issue #14885: DATEPART Cache Bounds

### DIFF
--- a/src/include/duckdb/common/types/date_lookup_cache.hpp
+++ b/src/include/duckdb/common/types/date_lookup_cache.hpp
@@ -30,7 +30,7 @@ public:
 
 	//! Extracts the component, or sets the validity mask to NULL if the date is infinite
 	int64_t ExtractElement(date_t date, ValidityMask &mask, idx_t idx) const {
-		if (DUCKDB_UNLIKELY(date.days < CACHE_MIN_DATE || date.days > CACHE_MAX_DATE)) {
+		if (DUCKDB_UNLIKELY(date.days < CACHE_MIN_DATE || date.days >= CACHE_MAX_DATE)) {
 			if (DUCKDB_UNLIKELY(!Value::IsFinite(date))) {
 				mask.SetInvalid(idx);
 				return 0;

--- a/test/sql/function/date/test_date_part.test
+++ b/test/sql/function/date/test_date_part.test
@@ -264,6 +264,14 @@ NULL
 NULL
 NULL
 
+# Cache upper bound
+query I
+select date_part('year', dt::DATE) * 10,
+from generate_series('2050-01-01'::date,'2051-12-31'::date,interval 1 day) t(dt)
+where dt = '2050-12-31';
+----
+20500
+
 #
 # Two-argument timezone
 #


### PR DESCRIPTION
Fencepost error on cache bounds check.

fixes: duckdb/duckdb#14885
fixes: duckdblabs/duckdb-internal#3516