### PR TITLE
C API: Add Value Relation constructor with RelationContextWrapper and ParsedExpression as argument

### DIFF
--- a/src/include/duckdb/main/relation/value_relation.hpp
+++ b/src/include/duckdb/main/relation/value_relation.hpp
@@ -21,6 +21,9 @@ public:
 	              vector<string> names, string alias = "values");
 	ValueRelation(const shared_ptr<RelationContextWrapper> &context, const vector<vector<Value>> &values,
 	              vector<string> names, string alias = "values");
+	ValueRelation(const shared_ptr<RelationContextWrapper> &context,
+	              vector<vector<unique_ptr<ParsedExpression>>> &&expressions, vector<string> names,
+	              string alias = "values");
 	ValueRelation(const shared_ptr<ClientContext> &context, const string &values, vector<string> names,
 	              string alias = "values");
 

--- a/src/main/relation/value_relation.cpp
+++ b/src/main/relation/value_relation.cpp
@@ -27,19 +27,8 @@ ValueRelation::ValueRelation(const shared_ptr<ClientContext> &context, const vec
 ValueRelation::ValueRelation(const shared_ptr<ClientContext> &context,
                              vector<vector<unique_ptr<ParsedExpression>>> &&expressions_p, vector<string> names_p,
                              string alias_p)
-    : Relation(context, RelationType::VALUE_LIST_RELATION) {
-	D_ASSERT(!expressions_p.empty());
-	if (names_p.empty()) {
-		auto &first_list = expressions_p[0];
-		for (auto &expr : first_list) {
-			names_p.push_back(expr->GetName());
-		}
-	}
-	names = std::move(names_p);
-	alias = std::move(alias_p);
-	expressions = std::move(expressions_p);
-	QueryResult::DeduplicateColumns(names);
-	TryBindRelation(columns);
+    : ValueRelation(make_shared_ptr<RelationContextWrapper>(context), std::move(expressions_p), std::move(names_p),
+                    std::move(alias_p)) {
 }
 
 ValueRelation::ValueRelation(const shared_ptr<ClientContext> &context, const string &values_list,

--- a/src/main/relation/value_relation.cpp
+++ b/src/main/relation/value_relation.cpp
@@ -66,6 +66,23 @@ ValueRelation::ValueRelation(const shared_ptr<RelationContextWrapper> &context, 
 	TryBindRelation(columns);
 }
 
+ValueRelation::ValueRelation(const shared_ptr<RelationContextWrapper> &context,
+                             vector<vector<unique_ptr<ParsedExpression>>> &&expressions_p, vector<string> names_p,
+                             string alias_p)
+    : Relation(context, RelationType::VALUE_LIST_RELATION), alias(std::move(alias_p)) {
+	D_ASSERT(!expressions_p.empty());
+	if (names_p.empty()) {
+		auto &first_list = expressions_p[0];
+		for (auto &expr : first_list) {
+			names_p.push_back(expr->GetName());
+		}
+	}
+	names = std::move(names_p);
+	expressions = std::move(expressions_p);
+	QueryResult::DeduplicateColumns(names);
+	TryBindRelation(columns);
+}
+
 unique_ptr<QueryNode> ValueRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());


### PR DESCRIPTION
* ValueRelation constructor from ParsedExpression should have two variants similar to Value, one with ClientContext ([here](https://github.com/duckdb/duckdb/blob/ca5af32c331f9d5ea49f7158d5c83a47f25b8b79/src/include/duckdb/main/relation/value_relation.hpp#L18)) and one with RelationContextWrapper ([here](https://github.com/duckdb/duckdb/blob/ca5af32c331f9d5ea49f7158d5c83a47f25b8b79/src/include/duckdb/main/relation/value_relation.hpp#L22)). PR #14757 added the one with ClientContext. The one with RelationContextWrapper is missing. 
* This PR adds this missing constructor
* This is required to avoid taking client context lock in substrait extension ([here](https://github.com/substrait-io/duckdb-substrait-extension/blob/82bad97010067ccfd48bb6d996bd5f5591fcb85a/src/from_substrait.cpp#L627-L632))
*  Prior discussion of need of this PR is [here](https://github.com/duckdb/duckdb/discussions/14689#discussioncomment-11292618)