### PR TITLE
python: use PyUnicode_FromStringAndSize()

### DIFF
--- a/tools/pythonpkg/src/numpy/array_wrapper.cpp
+++ b/tools/pythonpkg/src/numpy/array_wrapper.cpp
@@ -141,97 +141,12 @@ struct TimeConvert {
 };
 
 struct StringConvert {
-	template <class T>
-	static void ConvertUnicodeValueTemplated(T *result, int32_t *codepoints, idx_t codepoint_count, const char *data,
-	                                         idx_t ascii_count) {
-		// we first fill in the batch of ascii characters directly
-		for (idx_t i = 0; i < ascii_count; i++) {
-			result[i] = data[i];
-		}
-		// then we fill in the remaining codepoints from our codepoint array
-		for (idx_t i = 0; i < codepoint_count; i++) {
-			result[ascii_count + i] = codepoints[i];
-		}
-	}
-
-	static PyObject *ConvertUnicodeValue(const char *data, idx_t len, idx_t start_pos) {
-		// slow path: check the code points
-		// we know that all characters before "start_pos" were ascii characters, so we don't need to check those
-
-		// allocate an array of code points so we only have to convert the codepoints once
-		// short-string optimization
-		// we know that the max amount of codepoints is the length of the string
-		// for short strings (less than 64 bytes) we simply statically allocate an array of 256 bytes (64x int32)
-		// this avoids memory allocation for small strings (common case)
-		idx_t remaining = len - start_pos;
-		unique_ptr<int32_t[]> allocated_codepoints;
-		int32_t static_codepoints[64];
-		int32_t *codepoints;
-		if (remaining > 64) {
-			allocated_codepoints = unique_ptr<int32_t[]>(new int32_t[remaining]);
-			codepoints = allocated_codepoints.get();
-		} else {
-			codepoints = static_codepoints;
-		}
-		// now we iterate over the remainder of the string to convert the UTF8 string into a sequence of codepoints
-		// and to find the maximum codepoint
-		int32_t max_codepoint = 127;
-		int sz;
-		idx_t pos = start_pos;
-		idx_t codepoint_count = 0;
-		while (pos < len) {
-			codepoints[codepoint_count] = Utf8Proc::UTF8ToCodepoint(data + pos, sz);
-			pos += sz;
-			if (codepoints[codepoint_count] > max_codepoint) {
-				max_codepoint = codepoints[codepoint_count];
-			}
-			codepoint_count++;
-		}
-		// based on the max codepoint, we construct the result string
-		auto result = PyUnicode_New(start_pos + codepoint_count, max_codepoint);
-		// based on the resulting unicode kind, we fill in the code points
-		auto result_handle = py::handle(result);
-		auto kind = PyUtil::PyUnicodeKind(result_handle);
-		switch (kind) {
-		case PyUnicode_1BYTE_KIND:
-			ConvertUnicodeValueTemplated<Py_UCS1>(PyUtil::PyUnicode1ByteData(result_handle), codepoints,
-			                                      codepoint_count, data, start_pos);
-			break;
-		case PyUnicode_2BYTE_KIND:
-			ConvertUnicodeValueTemplated<Py_UCS2>(PyUtil::PyUnicode2ByteData(result_handle), codepoints,
-			                                      codepoint_count, data, start_pos);
-			break;
-		case PyUnicode_4BYTE_KIND:
-			ConvertUnicodeValueTemplated<Py_UCS4>(PyUtil::PyUnicode4ByteData(result_handle), codepoints,
-			                                      codepoint_count, data, start_pos);
-			break;
-		default:
-			throw NotImplementedException("Unsupported typekind constant '%d' for Python Unicode Compact decode", kind);
-		}
-		return result;
-	}
-
 	template <class DUCKDB_T, class NUMPY_T>
 	static PyObject *ConvertValue(string_t val, NumpyAppendData &append_data) {
 		(void)append_data;
-		// we could use PyUnicode_FromStringAndSize here, but it does a lot of verification that we don't need
-		// because of that it is a lot slower than it needs to be
 		auto data = const_data_ptr_cast(val.GetData());
 		auto len = val.GetSize();
-		// check if there are any non-ascii characters in there
-		for (idx_t i = 0; i < len; i++) {
-			if (data[i] > 127) {
-				// there are! fallback to slower case
-				return ConvertUnicodeValue(const_char_ptr_cast(data), len, i);
-			}
-		}
-		// no unicode: fast path
-		// directly construct the string and memcpy it
-		auto result = PyUnicode_New(len, 127);
-		auto result_handle = py::handle(result);
-		auto target_data = PyUtil::PyUnicodeDataMutable(result_handle);
-		memcpy(target_data, data, len);
-		return result;
+		return PyUnicode_FromStringAndSize(const_char_ptr_cast(data), len);
 	}
 	template <class NUMPY_T, bool PANDAS>
 	static NUMPY_T NullValue(bool &set_mask) {


### PR DESCRIPTION
DuckDB introduced optimization for UTF-8 decoder.
It is up to 40% faster for short non-ASCII case.
But it is 4x slower for long ASCII case.

Python has optimized code to decode ASCII. So decoding UTF-8 containing long ASCII part is faster than UTF8Proc::UTF8ToCodepoint.
And I am optimizing short non-ASCII case handling in CPython.

ref: https://github.com/python/cpython/pull/126025#issuecomment-2440002116

## Background

* Using PEP 393 based API that heavily depending on current CPython internal in 3rd party code makes difficult to evolve Python internal (e.g. use UTF-8 as internal representation of Unicode).
* Using PEP 393 slows down Python implementations other than CPython that use UTF-8 string representations. e.g. PyPy.
* PyUnicode_FromStringAndSize is Stable ABI. Moving from non-Stable ABI to Stable ABI makes you possible to build Python modules that works with several Python versions.