### PR TITLE
Top-N: Improve performance with large heaps, and correctly call Reduce

### DIFF
--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -292,7 +292,7 @@ void TopNHeap::Reduce() {
 	// we have too many values in the heap - reduce them
 	StringHeap new_sort_heap;
 	DataChunk new_heap_data;
-	new_heap_data.Initialize(allocator, payload_types, HeapAllocSize());
+	new_heap_data.Initialize(allocator, payload_types, heap_size);
 
 	SelectionVector new_payload_sel(heap.size());
 	for (idx_t i = 0; i < heap.size(); i++) {

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -236,14 +236,14 @@ void TopNHeap::Finalize() {
 }
 
 void TopNHeap::Reduce() {
-	if (payload_chunk.size() < ReduceThreshold()) {
+	if (heap_data.size() < ReduceThreshold()) {
 		// only reduce when we pass the reduce threshold
 		return;
 	}
 	// we have too many values in the heap - reduce them
 	StringHeap new_sort_heap;
-	DataChunk new_payload_chunk;
-	new_payload_chunk.Initialize(allocator, payload_types, HeapAllocSize());
+	DataChunk new_heap_data;
+	new_heap_data.Initialize(allocator, payload_types, HeapAllocSize());
 
 	SelectionVector new_payload_sel(heap.size());
 	for (idx_t i = 0; i < heap.size(); i++) {
@@ -258,10 +258,10 @@ void TopNHeap::Reduce() {
 	}
 
 	// copy over the data from the current payload chunk to the new payload chunk
-	payload_chunk.Copy(new_payload_chunk, new_payload_sel, heap.size());
+	heap_data.Copy(new_heap_data, new_payload_sel, heap.size());
 
 	new_sort_heap.Move(sort_key_heap);
-	payload_chunk.Reference(new_payload_chunk);
+	heap_data.Reference(new_heap_data);
 }
 
 void TopNHeap::InitializeScan(TopNScanState &state, bool exclude_offset) {

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -118,6 +118,7 @@ TopNHeap::TopNHeap(ClientContext &context, Allocator &allocator, const vector<Lo
 		sort_types.push_back(expr->return_type);
 		executor.AddExpression(*expr);
 	}
+	heap.reserve(InitialHeapAllocSize());
 	vector<LogicalType> sort_keys_type {LogicalType::BLOB};
 	sort_keys.Initialize(allocator, sort_keys_type);
 	heap_data.Initialize(allocator, payload_types, InitialHeapAllocSize());

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -98,7 +98,7 @@ public:
 		return MaxValue<idx_t>(STANDARD_VECTOR_SIZE * 5ULL, 2ULL * heap_size);
 	}
 
-	idx_t HeapAllocSize() const {
+	idx_t InitialHeapAllocSize() const {
 		return MinValue<idx_t>(STANDARD_VECTOR_SIZE * 100ULL, ReduceThreshold()) + STANDARD_VECTOR_SIZE;
 	}
 };
@@ -120,7 +120,7 @@ TopNHeap::TopNHeap(ClientContext &context, Allocator &allocator, const vector<Lo
 	}
 	vector<LogicalType> sort_keys_type {LogicalType::BLOB};
 	sort_keys.Initialize(allocator, sort_keys_type);
-	heap_data.Initialize(allocator, payload_types, HeapAllocSize());
+	heap_data.Initialize(allocator, payload_types, InitialHeapAllocSize());
 	payload_chunk.Initialize(allocator, payload_types);
 	sort_chunk.Initialize(allocator, sort_types);
 }

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -265,7 +265,7 @@ void TopNHeap::Sink(DataChunk &input, optional_ptr<TopNBoundaryValue> global_bou
 		global_boundary_val = string_t(boundary_val);
 	}
 
-	if (heap_size < 1000) {
+	if (heap_size <= 100) {
 		AddSmallHeap(input, sort_keys_vec, boundary_val, global_boundary_val);
 	} else {
 		AddLargeHeap(input, sort_keys_vec, boundary_val, global_boundary_val);

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -316,12 +316,12 @@ void TopNHeap::Reduce() {
 void TopNHeap::InitializeScan(TopNScanState &state, bool exclude_offset) {
 	auto heap_copy = heap;
 	// traverse the rest of the heap
+	state.scan_order.resize(heap_copy.size());
 	while (!heap_copy.empty()) {
 		std::pop_heap(heap_copy.begin(), heap_copy.end());
-		state.scan_order.push_back(UnsafeNumericCast<sel_t>(heap_copy.back().index));
+		state.scan_order[heap_copy.size() - 1] = UnsafeNumericCast<sel_t>(heap_copy.back().index);
 		heap_copy.pop_back();
 	}
-	std::reverse(state.scan_order.begin(), state.scan_order.end());
 	state.pos = exclude_offset ? offset : 0;
 }
 

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -322,7 +322,7 @@ void TopNHeap::Reduce() {
 	// we have too many values in the heap - reduce them
 	StringHeap new_sort_heap;
 	DataChunk new_heap_data;
-	new_heap_data.Initialize(allocator, payload_types, heap_size);
+	new_heap_data.Initialize(allocator, payload_types, heap.size());
 
 	SelectionVector new_payload_sel(heap.size());
 	for (idx_t i = 0; i < heap.size(); i++) {
@@ -337,9 +337,10 @@ void TopNHeap::Reduce() {
 	}
 
 	// copy over the data from the current payload chunk to the new payload chunk
-	heap_data.Copy(new_heap_data, new_payload_sel, heap.size());
+	new_heap_data.Slice(heap_data, new_payload_sel, heap.size());
+	new_heap_data.Flatten();
 
-	new_sort_heap.Move(sort_key_heap);
+	sort_key_heap.Move(new_sort_heap);
 	heap_data.Reference(new_heap_data);
 }
 

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -244,6 +244,8 @@ void TopNHeap::AddLargeHeap(DataChunk &input, Vector &sort_keys_vec, const strin
 }
 
 void TopNHeap::Sink(DataChunk &input, optional_ptr<TopNBoundaryValue> global_boundary) {
+	static constexpr idx_t SMALL_HEAP_THRESHOLD = 100;
+
 	// compute the ordering values for the new chunk
 	sort_chunk.Reset();
 	executor.Execute(input, sort_chunk);
@@ -265,7 +267,7 @@ void TopNHeap::Sink(DataChunk &input, optional_ptr<TopNBoundaryValue> global_bou
 		global_boundary_val = string_t(boundary_val);
 	}
 
-	if (heap_size <= 100) {
+	if (heap_size <= SMALL_HEAP_THRESHOLD) {
 		AddSmallHeap(input, sort_keys_vec, boundary_val, global_boundary_val);
 	} else {
 		AddLargeHeap(input, sort_keys_vec, boundary_val, global_boundary_val);

--- a/test/optimizer/compressed_materialization.test_slow
+++ b/test/optimizer/compressed_materialization.test_slow
@@ -1,4 +1,4 @@
-# name: test/optimizer/compressed_materialization.test_coverage
+# name: test/optimizer/compressed_materialization.test_slow
 # description: Compressed materialization test
 # group: [optimizer]
 
@@ -18,7 +18,7 @@ Binder Error: Compressed materialization functions are for internal use only!
 statement ok
 create table t0 as select range%400000 a, range%400000 b from range(500000);
 
-query III
+query III rowsort
 select * from (
       select *, row_number() OVER () as row_number from (
           SELECT * FROM t0 ORDER BY 1) ta

--- a/test/sql/topn/tpch_top_n.test_slow
+++ b/test/sql/topn/tpch_top_n.test_slow
@@ -1,0 +1,78 @@
+# name: test/sql/topn/tpch_top_n.test_slow
+# description: Test Top N NULLS FIRST/LAST with few rows
+# group: [topn]
+
+require tpch
+
+statement ok
+CALL dbgen(sf=1);
+
+query I
+select l_quantity
+from lineitem
+where l_linestatus = 'O'
+order by l_quantity limit 10 offset 100;
+----
+1.00
+1.00
+1.00
+1.00
+1.00
+1.00
+1.00
+1.00
+1.00
+1.00
+
+query I
+select l_quantity
+from lineitem
+where l_linestatus = 'O'
+order by l_quantity limit 10 offset 1000000;
+----
+17.00
+17.00
+17.00
+17.00
+17.00
+17.00
+17.00
+17.00
+17.00
+17.00
+
+query I
+select sum(l_quantity)
+from lineitem
+group by l_orderkey
+order by sum(l_quantity) desc
+limit 10 offset 100;
+----
+297.00
+296.00
+296.00
+296.00
+296.00
+296.00
+296.00
+296.00
+295.00
+295.00
+
+query I
+select sum(l_quantity)
+from lineitem
+group by l_orderkey
+order by sum(l_quantity) desc
+limit 10 offset 100000;
+----
+195.00
+195.00
+195.00
+195.00
+195.00
+195.00
+195.00
+195.00
+195.00
+195.00


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/14424

Fixes #14896

#### Large Heaps

When using a large `offset`, the heap we generate in the Top-N operator is large. The previous implementation took some shortcuts that made it work poorly with large heaps, resulting in performance degradations compared to the previous implementation:

* `TopNHeap::Combine` would scan and re-insert the values in the heaps, instead of directly merging heaps
* `TopNHeap::Sink` would fully scan the heap at every iteration

This PR fixes these issues.

### `AddSmallHeap`/`AddLargeHeap`

The previous heap insertion happened in two stages:

* Insert the sort keys one-by-one into the heap
* Scan the heap to figure out which **final sort keys** still remain inside the heap
* Append the payload for the corresponding final sort keys

The main reason for this two-stage approach is to deal with many conflicts *within the same data chunk*. For example, consider the query:

```sql
SELECT * FROM lineitem ORDER BY l_orderkey DESC LIMIT 5;
```

Since `lineitem` is sorted by `l_orderkey`, every chunk we stream into the operator will be full of the new highest values. Without this two-stage approach, we will append all rows to the payload data, only to then discard most rows again. Using the two stage approach we append at most 5 rows (the heap size) to the payload at each iteration, leading to lower memory usage and fewer calls to Reduce.

### AddLargeHeap

This PR adds a new, simpler, single-stage insertion where we insert the sort keys and immediately insert payload data. We switch to this approach for heaps `>= 100 rows`. By immediately inserting the payload data we don't need to scan the heap during the sink phase, which has great speed-ups for when we are dealing with larger heaps. 

### Benchmarks

Below is an example of a Top-N with a large heap that is sped up significantly by this approach:

```sql
select l_orderkey
from lineitem
where l_linestatus = 'O'
order by l_quantity limit 100 offset 1000000;
```

| v1.1  | main |  new  |
|-------|------|-------|
| 0.86s | 6.9s | 0.77s |
