### PR TITLE
Update cardinality during limit pushdown

### DIFF
--- a/src/optimizer/limit_pushdown.cpp
+++ b/src/optimizer/limit_pushdown.cpp
@@ -3,6 +3,8 @@
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
+#include <complex>
+
 namespace duckdb {
 
 bool LimitPushdown::CanOptimize(duckdb::LogicalOperator &op) {
@@ -30,6 +32,7 @@ unique_ptr<LogicalOperator> LimitPushdown::Optimize(unique_ptr<LogicalOperator> 
 	if (CanOptimize(*op)) {
 		auto projection = std::move(op->children[0]);
 		op->children[0] = std::move(projection->children[0]);
+		projection->SetEstimatedCardinality(op->estimated_cardinality);
 		projection->children[0] = std::move(op);
 		swap(projection, op);
 	}

--- a/src/optimizer/limit_pushdown.cpp
+++ b/src/optimizer/limit_pushdown.cpp
@@ -3,8 +3,6 @@
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
-#include <complex>
-
 namespace duckdb {
 
 bool LimitPushdown::CanOptimize(duckdb::LogicalOperator &op) {


### PR DESCRIPTION
When a limit is pushed down a projection, the projection should adopt the cardinality of the limit.
An example query where this is helpful:
```
create table tbl as select * from range(1,100) r(i);
set explain_output='all';
explain select i, i+1 from (from tbl limit 10);
```

Note that a physical plan _may_ have the correct projection cardinality (due to unrelated recursive EstimateCardinality calls later), but an optimized logical plan won't.

Before:
```
┌─────────────────────────────┐
│┌───────────────────────────┐│
││  Optimized Logical Plan   ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│         PROJECTION        │
│    ────────────────────   │
│        Expressions:       │
│             i             │
│          (i + 1)          │
│                           │
│          ~10 Rows         │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│       Expressions: i      │
│                           │
│          ~99 Rows         │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│           LIMIT           │
│    ────────────────────   │
│          ~10 Rows         │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│          SEQ_SCAN         │
│    ────────────────────   │
│            tbl            │
│                           │
│          ~99 Rows         │
└───────────────────────────┘
```

After:
```
┌─────────────────────────────┐
│┌───────────────────────────┐│
││  Optimized Logical Plan   ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│         PROJECTION        │
│    ────────────────────   │
│        Expressions:       │
│             i             │
│          (i + 1)          │
│                           │
│          ~10 Rows         │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│       Expressions: i      │
│                           │
│          ~10 Rows         │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│           LIMIT           │
│    ────────────────────   │
│          ~10 Rows         │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│          SEQ_SCAN         │
│    ────────────────────   │
│         Table: tbl        │
│                           │
│          ~99 Rows         │
└───────────────────────────┘
```