### PR TITLE
[Fix] release shared connection pointer before it goes out of scope

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1903,7 +1903,7 @@ void DuckDBPyConnection::Cursors::ClearCursors() {
 		py::gil_scoped_acquire gil;
 		cursor->Close();
 		// Ensure destructor runs with gil if triggered.
-		cursor.reset(nullptr)
+		cursor.reset();
 	}
 
 	cursors.clear();

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1902,6 +1902,8 @@ void DuckDBPyConnection::Cursors::ClearCursors() {
 		// release it don't ask me why it can't just realize there is no GIL and move on
 		py::gil_scoped_acquire gil;
 		cursor->Close();
+		// Ensure destructor runs with gil if triggered.
+		cursor.reset(nullptr)
 	}
 
 	cursors.clear();


### PR DESCRIPTION
We get occasional segfaults inside close in a multithreaded, loaded application.
gil_scoped_acquire is destroyed before the shared pointer.
In cases where the shared_pointer had become the final reference the destructor is called without holding the GIL.