### PR TITLE
Fix several CLI issues

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1654,7 +1654,6 @@ public:
 void ShellState::ExecutePreparedStatement(sqlite3_stmt *pStmt) {
 	if (cMode == RenderMode::DUCKBOX) {
 		size_t max_rows = this->max_rows;
-		;
 		size_t max_width = this->max_width;
 		if (!outfile.empty() && outfile[0] != '|') {
 			max_rows = (size_t)-1;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1651,11 +1651,18 @@ public:
 /*
 ** Run a prepared statement
 */
-void ShellState::ExecutePreparedStatement(sqlite3_stmt *pStmt /* Statment to run */
-) {
+void ShellState::ExecutePreparedStatement(sqlite3_stmt *pStmt) {
 	if (cMode == RenderMode::DUCKBOX) {
-		size_t max_rows = outfile.empty() || outfile[0] == '|' ? this->max_rows : (size_t)-1;
-		size_t max_width = outfile.empty() || outfile[0] == '|' ? this->max_width : (size_t)-1;
+		size_t max_rows = this->max_rows;
+		;
+		size_t max_width = this->max_width;
+		if (!outfile.empty() && outfile[0] != '|') {
+			max_rows = (size_t)-1;
+			max_width = (size_t)-1;
+		}
+		if (!stdout_is_console) {
+			max_width = (size_t)-1;
+		}
 		DuckBoxRenderer renderer(*this, HighlightResults());
 		sqlite3_print_duckbox(pStmt, max_rows, max_width, nullValue.c_str(), columns, thousand_separator,
 		                      decimal_separator, &renderer);

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4767,11 +4767,15 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 				azCmd[nCmd - 1] = z;
 			}
 		}
-		if (z[1] == '-')
+		if (z[1] == '-') {
 			z++;
+		}
 		if (strcmp(z, "-separator") == 0 || strcmp(z, "-nullvalue") == 0 || strcmp(z, "-newline") == 0 ||
-		    strcmp(z, "-cmd") == 0 || strcmp(z, "-c") == 0 || strcmp(z, "-s") == 0) {
+		    strcmp(z, "-cmd") == 0) {
 			(void)cmdline_option_value(argc, argv, ++i);
+		} else if (strcmp(z, "-c") == 0 || strcmp(z, "-s") == 0) {
+			(void)cmdline_option_value(argc, argv, ++i);
+			stdin_is_interactive = false;
 		} else if (strcmp(z, "-init") == 0) {
 			zInitFile = cmdline_option_value(argc, argv, ++i);
 		} else if (strcmp(z, "-batch") == 0) {

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1621,7 +1621,6 @@ private:
 	bool highlight = true;
 };
 
-
 class TrashRenderer : public duckdb::BaseResultRenderer {
 public:
 	TrashRenderer() {
@@ -1645,7 +1644,7 @@ public:
 	void RenderFooter(const string &) override {
 	}
 
-	void PrintText(const string &, HighlightElementType ) {
+	void PrintText(const string &, HighlightElementType) {
 	}
 };
 

--- a/tools/shell/shell_highlight.cpp
+++ b/tools/shell/shell_highlight.cpp
@@ -19,7 +19,7 @@ static HighlightElement highlight_elements[] = {{"error", PrintColor::RED, Print
                                                 {"numeric_constant", PrintColor::YELLOW, PrintIntensity::STANDARD},
                                                 {"string_constant", PrintColor::YELLOW, PrintIntensity::STANDARD},
                                                 {"line_indicator", PrintColor::STANDARD, PrintIntensity::BOLD},
-                                                {"column_name", PrintColor::STANDARD, PrintIntensity::BOLD},
+                                                {"column_name", PrintColor::STANDARD, PrintIntensity::STANDARD},
                                                 {"column_type", PrintColor::STANDARD, PrintIntensity::STANDARD},
                                                 {"numeric_value", PrintColor::STANDARD, PrintIntensity::STANDARD},
                                                 {"string_value", PrintColor::STANDARD, PrintIntensity::STANDARD},

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -834,9 +834,6 @@ unique_ptr<RowRenderer> ShellState::GetRowRenderer(RenderMode mode) {
 		return unique_ptr<RowRenderer>(new ModeSemiRenderer(*this));
 	case RenderMode::PRETTY:
 		return unique_ptr<RowRenderer>(new ModePrettyRenderer(*this));
-	case RenderMode::TRASH:
-		// no renderer
-		return nullptr;
 	default:
 		throw std::runtime_error("Unsupported mode for GetRowRenderer");
 	}

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -618,6 +618,10 @@ public:
 					state.Print("1e999");
 				} else if (strcmp(data[i], "-inf") == 0) {
 					state.Print("-1e999");
+				} else if (strcmp(data[i], "nan") == 0) {
+					state.Print("null");
+				} else if (strcmp(data[i], "-nan") == 0) {
+					state.Print("null");
 				} else {
 					state.Print(data[i]);
 				}

--- a/tools/shell/tests/test_highlighting.py
+++ b/tools/shell/tests/test_highlighting.py
@@ -14,11 +14,10 @@ def test_highlight_column_header(shell):
     test = (
         ShellTest(shell)
         .statement(".highlight_results on")
-        .statement(lineitem_ddl)
-        .statement('select * from lineitem;')
+        .statement('select NULL AS r;')
     )
     result = test.run()
-    result.check_stdout('\x1b[1ml_comment\x1b[0m')
+    result.check_stdout('\x1b[90mNULL\x1b[0m')
 @pytest.mark.skipif(os.name == 'nt', reason="Windows highlighting does not use shell escapes")
 def test_custom_highlight(shell):
     test = (

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -593,12 +593,11 @@ def test_mode_json_infinity(shell):
     test = (
         ShellTest(shell)
         .statement(".mode json")
-        .statement("SELECT 'inf'::DOUBLE AS inf, '-inf'::DOUBLE AS ninf, 'nan'::DOUBLE AS nan;")
+        .statement("SELECT 'inf'::DOUBLE AS inf, '-inf'::DOUBLE AS ninf, 'nan'::DOUBLE AS nan, '-nan'::DOUBLE AS nnan;")
     )
     result = test.run()
-    result.check_stdout('[{"inf":1e999,"ninf":-1e999,"nan":nan}]')
+    result.check_stdout('[{"inf":1e999,"ninf":-1e999,"nan":null,"nnan":null}]')
 
-# Original comment: FIXME sqlite3_column_blob
 def test_mode_insert(shell):
     test = (
         ShellTest(shell)


### PR DESCRIPTION
* Fix https://github.com/duckdb/duckdb/issues/14905: convert nan to null in `.mode json` output
* Speed up `.mode trash` renderer by using the DuckBox renderer code-path which avoids the (slow) iteration using the SQLite API wrapper
* When piping output to a console, ignore the terminal width and instead render the full width of the result
* When using `-c` or `-s` to execute a single statement, set `stdin_is_interactive` to false - this prevents printing the `-- Loading resources from /Users/myth/.duckdbrc` message
* No longer bold column names by default 
