### PR TITLE
add core functions make_timestamp_ns(nanos) and epoch_ns(timestamp_ts)

### DIFF
--- a/extension/core_functions/README.md
+++ b/extension/core_functions/README.md
@@ -2,7 +2,7 @@
 These functions are bundled with every installation of DuckDB.
 
 In order to add new functions, add their definition to the `functions.json` file in the respective directory.
-The function headers can then be generated the set of functions using the following command:
+The function headers can then be generated from the set of functions using the following command:
 
 ```python
 python3 scripts/generate_functions.py

--- a/extension/core_functions/function_list.cpp
+++ b/extension/core_functions/function_list.cpp
@@ -261,6 +261,7 @@ static const StaticFunctionDefinition core_functions[] = {
 	DUCKDB_SCALAR_FUNCTION_SET(MakeDateFun),
 	DUCKDB_SCALAR_FUNCTION(MakeTimeFun),
 	DUCKDB_SCALAR_FUNCTION_SET(MakeTimestampFun),
+	DUCKDB_SCALAR_FUNCTION_SET(MakeTimestampNsFun),
 	DUCKDB_SCALAR_FUNCTION(MapFun),
 	DUCKDB_SCALAR_FUNCTION(MapConcatFun),
 	DUCKDB_SCALAR_FUNCTION(MapEntriesFun),

--- a/extension/core_functions/include/core_functions/scalar/date_functions.hpp
+++ b/extension/core_functions/include/core_functions/scalar/date_functions.hpp
@@ -309,6 +309,15 @@ struct MakeTimestampFun {
 	static ScalarFunctionSet GetFunctions();
 };
 
+struct MakeTimestampNsFun {
+	static constexpr const char *Name = "make_timestamp_ns";
+	static constexpr const char *Parameters = "nanos";
+	static constexpr const char *Description = "The timestamp for the given nanoseconds since epoch";
+	static constexpr const char *Example = "make_timestamp(1732117793000000000)";
+
+	static ScalarFunctionSet GetFunctions();
+};
+
 struct MicrosecondsFun {
 	static constexpr const char *Name = "microsecond";
 	static constexpr const char *Parameters = "ts";

--- a/extension/core_functions/scalar/date/functions.json
+++ b/extension/core_functions/scalar/date/functions.json
@@ -208,6 +208,13 @@
         "type": "scalar_function_set"
     },
     {
+        "name": "make_timestamp_ns",
+        "parameters": "nanos",
+        "description": "The timestamp for the given nanoseconds since epoch",
+        "example": "make_timestamp(1732117793000000000)",
+        "type": "scalar_function_set"
+    },
+    {
         "struct": "MicrosecondsFun",
         "name": "microsecond",
         "parameters": "ts",

--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -116,6 +116,15 @@ static void ExecuteMakeTimestamp(DataChunk &input, ExpressionState &state, Vecto
 	SenaryExecutor::Execute<T, T, T, T, T, double, timestamp_t>(input, result, func);
 }
 
+template <typename T>
+static void ExecuteMakeTimestampNs(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 1);
+
+	auto func = MakeTimestampOperator::Operation<T, timestamp_ns_t>;
+	UnaryExecutor::Execute<T, timestamp_ns_t>(input.data[0], result, input.size(), func);
+	return;
+}
+
 ScalarFunctionSet MakeDateFun::GetFunctions() {
 	ScalarFunctionSet make_date("make_date");
 	make_date.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
@@ -140,6 +149,13 @@ ScalarFunctionSet MakeTimestampFun::GetFunctions() {
 	                                        LogicalType::TIMESTAMP, ExecuteMakeTimestamp<int64_t>));
 	operator_set.AddFunction(
 	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, ExecuteMakeTimestamp<int64_t>));
+	return operator_set;
+}
+
+ScalarFunctionSet MakeTimestampNsFun::GetFunctions() {
+	ScalarFunctionSet operator_set("make_timestamp_ns");
+	operator_set.AddFunction(
+	    ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP_NS, ExecuteMakeTimestampNs<int64_t>));
 	return operator_set;
 }
 

--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -97,8 +97,8 @@ struct MakeTimestampOperator {
 	}
 
 	template <typename T, typename RESULT_TYPE>
-	static RESULT_TYPE Operation(T micros) {
-		return timestamp_t(micros);
+	static RESULT_TYPE Operation(T value) {
+		return RESULT_TYPE(value);
 	}
 };
 

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -448,6 +448,11 @@ int64_t Timestamp::GetEpochNanoSeconds(timestamp_t timestamp) {
 	return result;
 }
 
+int64_t Timestamp::GetEpochNanoSeconds(timestamp_ns_t timestamp) {
+	D_ASSERT(Timestamp::IsFinite(timestamp));
+	return timestamp.value;
+}
+
 int64_t Timestamp::GetEpochRounded(timestamp_t input, int64_t power_of_ten) {
 	D_ASSERT(Timestamp::IsFinite(input));
 	//	Round away from the epoch.

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -24,6 +24,8 @@ struct dtime_tz_t; // NOLINT
 
 //! Type used to represent a TIMESTAMP. timestamp_t holds the microseconds since 1970-01-01.
 struct timestamp_t { // NOLINT
+	// NOTE: The unit of value is microseconds for timestamp_t, but it can be
+	// different for subclasses (e.g. it's nanos for timestamp_ns, etc).
 	int64_t value;
 
 	timestamp_t() = default;

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -191,6 +191,7 @@ public:
 	DUCKDB_API static int64_t GetEpochMicroSeconds(timestamp_t timestamp);
 	//! Convert a timestamp to epoch (in nanoseconds)
 	DUCKDB_API static int64_t GetEpochNanoSeconds(timestamp_t timestamp);
+	DUCKDB_API static int64_t GetEpochNanoSeconds(timestamp_ns_t timestamp);
 	//! Convert a timestamp to a rounded epoch at a given resolution.
 	DUCKDB_API static int64_t GetEpochRounded(timestamp_t timestamp, const int64_t power_of_ten);
 	//! Convert a timestamp to a Julian Day

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -423,6 +423,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"make_date", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"make_time", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"make_timestamp", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"make_timestamp_ns", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"make_timestamptz", "icu", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"map", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"map_concat", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},

--- a/test/sql/function/timestamp/make_date.test
+++ b/test/sql/function/timestamp/make_date.test
@@ -217,6 +217,18 @@ SELECT make_timestamp(0), make_timestamp(1684509234845000);
 ----
 1970-01-01 00:00:00	2023-05-19 15:13:54.845
 
+# From nanoseconds
+query II
+SELECT make_timestamp_ns(0), make_timestamp_ns(1684509234845000123);
+----
+1970-01-01 00:00:00	2023-05-19 15:13:54.845000123
+
+# Maximum value for make_timestamp_ns().
+query II
+SELECT make_timestamp_ns(9223372036854775806), make_timestamp_ns(9223372036854775807);
+----
+2262-04-11 23:47:16.854775806	infinity
+
 #
 # Times
 #

--- a/test/sql/function/timestamp/test_date_part.test
+++ b/test/sql/function/timestamp/test_date_part.test
@@ -961,3 +961,9 @@ statement error
 WITH parts(p) AS (VALUES (['year', 'month', 'day']), (['hour', 'minute', 'microsecond']))
 SELECT DATE_PART(p, ts) FROM parts, timestamps;
 ----
+
+# epoch_ns has nanosecond precision on TIMESTAMP_NS
+query I
+select epoch_ns(make_timestamp_ns(1732118940123456789))
+----
+1732118940123456789


### PR DESCRIPTION
See individual commits.