### PR TITLE
improve ReadAheadBuffer::AddReadHead error message

### DIFF
--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -98,7 +98,10 @@ struct ReadAheadBuffer {
 		}
 
 		if (read_head.GetEnd() > handle.GetFileSize()) {
-			throw std::runtime_error("Prefetch registered for bytes outside file");
+			throw std::runtime_error("Prefetch registered for bytes outside file: " + handle.GetPath() +
+			                         ", attempted range: [" + std::to_string(pos) + ", " +
+			                         std::to_string(read_head.GetEnd()) +
+			                         "), file size: " + std::to_string(handle.GetFileSize()));
 		}
 	}
 


### PR DESCRIPTION
We had a user running into this error when dealing with a corrupted parquet file. It would be more helpful if ddb provided a bit more information on which file was corrupted etc. I made this change to provide more context on what went wrong in order to help users/developers debug this issue more effectively.