### PR TITLE
Skip Dynamic Join Ordering Algorithm if there are many relations

### DIFF
--- a/benchmark/large/other/join_order_many_relations.benchmark
+++ b/benchmark/large/other/join_order_many_relations.benchmark
@@ -1,0 +1,43 @@
+# name: benchmark/large/other/join_order_many_relations.benchmark
+# description: Test or filter pushdown
+# group: [other]
+
+
+load
+create table t1 as select range id1 from range(100);
+create table t2 as select range id2 from range(200);
+create table t3 as select range id3 from range(400);
+create table t4 as select range id4 from range(500);
+create table t5 as select range id5 from range(600);
+create table t6 as select range id6 from range(700);
+create table t7 as select range id7 from range(800);
+create table t8 as select range id8 from range(900);
+create table t9 as select range id9 from range(1000);
+create table t10 as select range id10 from range(1100);
+create table t11 as select range id11 from range(1200);
+create table t12 as select range id12 from range(1300);
+create table t13 as select range id13 from range(1400);
+create table t14 as select range id14 from range(1500);
+create table t15 as select range id15 from range(1600);
+
+run
+pragma disabled_optimizers='join_filter_pushdown,statistics_propagation';
+select count(*) from t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15
+where
+id1 = id2 and
+id2 = id3 and
+id3 = id4 and
+id4 = id5 and
+id5 = id6 and
+id6 = id7 and
+id7 = id8 and
+id8 = id9 and
+id9 = id10 and
+id10 = id11 and
+id11 = id12 and
+id12 = id13 and
+id13 = id14 and
+id14 = id15
+
+result I
+100

--- a/benchmark/large/other/join_order_many_relations.benchmark
+++ b/benchmark/large/other/join_order_many_relations.benchmark
@@ -2,7 +2,6 @@
 # description: Test or filter pushdown
 # group: [other]
 
-
 load
 create table t1 as select range id1 from range(100);
 create table t2 as select range id2 from range(200);

--- a/src/include/duckdb/optimizer/join_order/plan_enumerator.hpp
+++ b/src/include/duckdb/optimizer/join_order/plan_enumerator.hpp
@@ -33,6 +33,8 @@ public:
 	    : query_graph(query_graph), query_graph_manager(query_graph_manager), cost_model(cost_model) {
 	}
 
+	static constexpr idx_t THRESHOLD_TO_SWAP_TO_APPROXIMATE = 12;
+
 	//! Perform the join order solving
 	void SolveJoinOrder();
 	void InitLeafPlans();

--- a/src/optimizer/join_order/plan_enumerator.cpp
+++ b/src/optimizer/join_order/plan_enumerator.cpp
@@ -472,7 +472,7 @@ void PlanEnumerator::InitLeafPlans() {
 void PlanEnumerator::SolveJoinOrder() {
 	bool force_no_cross_product = query_graph_manager.context.config.force_no_cross_product;
 	// first try to solve the join order exactly
-	if (query_graph_manager.relation_manager.NumRelations() >= 13) {
+	if (query_graph_manager.relation_manager.NumRelations() >= THRESHOLD_TO_SWAP_TO_APPROXIMATE) {
 		SolveJoinOrderApproximately();
 	} else if (!SolveJoinOrderExactly()) {
 		// otherwise, if that times out we resort to a greedy algorithm

--- a/src/optimizer/join_order/plan_enumerator.cpp
+++ b/src/optimizer/join_order/plan_enumerator.cpp
@@ -472,7 +472,9 @@ void PlanEnumerator::InitLeafPlans() {
 void PlanEnumerator::SolveJoinOrder() {
 	bool force_no_cross_product = query_graph_manager.context.config.force_no_cross_product;
 	// first try to solve the join order exactly
-	if (!SolveJoinOrderExactly()) {
+	if (query_graph_manager.relation_manager.NumRelations() >= 13) {
+		SolveJoinOrderApproximately();
+	} else if (!SolveJoinOrderExactly()) {
 		// otherwise, if that times out we resort to a greedy algorithm
 		SolveJoinOrderApproximately();
 	}


### PR DESCRIPTION
If there are a large number of relations, it's possible a lot of time is spent in the join order optimizer to enumerate all plans.  It's possible the dynamic algorithm doesn't finish and then we swap to greedy. In some cases greedy will use partial plans from the dynamic algorithm, but it's also possible that the trade-off of calculating the join orders for the bushy plans from the dynamic algorithm isn't worth it. This happens mostly when the number of relations is >= 12.

Here are some tests done on my M1 on imdb and tpcds

The benchmarks below switch to the approximate join ordering algorithm in main. I've compared those timings with&without an eager switch to `SolveApproximate`.

|           benchmark            | median without eager swap |  median with eager swap | Num relations |
|------------------------------|----------------|----------|------:|
| benchmark/imdb/27a.benchmark | 0.06039         | 0.030662      |   12 |
| benchmark/imdb/27b.benchmark | 0.071378        | 0.02472       |  12 |
| benchmark/imdb/27c.benchmark | 0.061162        | 0.03022       |  12 |
| benchmark/imdb/28a.benchmark | 0.21814         | 0.197419      |  14 |
| benchmark/imdb/28b.benchmark | 0.18084         | 0.136542      |  14 |
| benchmark/imdb/28c.benchmark | 0.225531        | 0.206862      |  14 |
| benchmark/imdb/29a.benchmark | 0.087202        | 0.061589      |  17 |
| benchmark/imdb/29b.benchmark | 0.116307        | 0.088206      |  17 | 
| benchmark/imdb/29c.benchmark | 0.220925        | 0.192836      |  17 |
| benchmark/imdb/33a.benchmark | 0.077164        | 0.034794      |  14 |
| benchmark/imdb/33b.benchmark | 0.07918         | 0.044542      |  14 |
| benchmark/imdb/33c.benchmark | 0.085106      | 0.044752      |  14 |

The total run times are quite small, but as you can see, in some cases there is a speed up of almost 50% (33c).


TPCDS
|           benchmark            | median without eager swap |  median with eager swap | Num relations |
|------------------------------|----------------|----------|------:|
| benchmark/tpcds/sf1/q09.benchmark | 0.050805        | 0.028115        | 16      |
| benchmark/tpcds/sf1/q64.benchmark | 0.088561        | 0.041977        | 18      |