### PR TITLE
remove failing benchmark 

### DIFF
--- a/.github/regression/realnest.csv
+++ b/.github/regression/realnest.csv
@@ -13,4 +13,3 @@ benchmark/realnest/13_multi_join_nested_data_with_filtering.benchmark
 benchmark/realnest/14_list_slice.benchmark
 benchmark/realnest/15_list_sort.benchmark
 benchmark/realnest/16_most_common_list_aggregates.benchmark
-benchmark/realnest/17_list_aggregates_histogram_stddev_mode.benchmark


### PR DESCRIPTION
This PR removes a mention of the `benchmark/realnest/17_list_aggregates_histogram_stddev_mode.benchmark` from the `realnest.csv` file, because the query sporadically caused failure of the `Regression` workflow.

This is a temporary solution for issue https://github.com/duckdblabs/duckdb-internal/issues/3409.