### PR TITLE
Typo in csv UnterminatedQuotesError how_to_fix_it

### DIFF
--- a/src/execution/operator/csv_scanner/util/csv_error.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_error.cpp
@@ -304,7 +304,7 @@ CSVError CSVError::UnterminatedQuotesError(const CSVReaderOptions &options, idx_
 	std::ostringstream how_to_fix_it;
 	how_to_fix_it << "Possible fixes:" << '\n';
 	how_to_fix_it << "* Enable ignore errors (ignore_errors=true) to skip this row" << '\n';
-	how_to_fix_it << "* Set quote do empty or to a different value (e.g., quote=\'\')" << '\n';
+	how_to_fix_it << "* Set quote to empty or to a different value (e.g., quote=\'\')" << '\n';
 	return CSVError(error.str(), UNTERMINATED_QUOTES, current_column, csv_row, error_info, row_byte_position,
 	                byte_position, options, how_to_fix_it.str(), current_path);
 }


### PR DESCRIPTION
Fixing a simple typo - the message says:
`* Set quote do empty or to a different value (e.g., quote='')`
But should say
`* Set quote to empty or to a different value (e.g., quote='')`