### PR TITLE
C API support for non-standard timestamp values

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -1067,9 +1067,21 @@ bool TryCast::Operation(timestamp_t input, timestamp_t &result, bool strict) {
 }
 
 template <>
+bool TryCast::Operation(timestamp_sec_t input, timestamp_sec_t &result, bool strict) {
+	result.value = input.value;
+	return true;
+}
+
+template <>
 bool TryCast::Operation(timestamp_t input, timestamp_sec_t &result, bool strict) {
 	D_ASSERT(Timestamp::IsFinite(input));
 	result.value = input.value / Interval::MICROS_PER_SEC;
+	return true;
+}
+
+template <>
+bool TryCast::Operation(timestamp_ms_t input, timestamp_ms_t &result, bool strict) {
+	result.value = input.value;
 	return true;
 }
 
@@ -1081,11 +1093,23 @@ bool TryCast::Operation(timestamp_t input, timestamp_ms_t &result, bool strict) 
 }
 
 template <>
+bool TryCast::Operation(timestamp_ns_t input, timestamp_ns_t &result, bool strict) {
+	result.value = input.value;
+	return true;
+}
+
+template <>
 bool TryCast::Operation(timestamp_t input, timestamp_ns_t &result, bool strict) {
 	D_ASSERT(Timestamp::IsFinite(input));
 	if (!TryMultiplyOperator::Operation(input.value, Interval::NANOS_PER_MSEC, result.value)) {
 		throw ConversionException("Could not convert TIMESTAMP to TIMESTAMP_NS");
 	}
+	return true;
+}
+
+template <>
+bool TryCast::Operation(timestamp_tz_t input, timestamp_tz_t &result, bool strict) {
+	result.value = input.value;
 	return true;
 }
 

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -282,11 +282,26 @@ typedef struct {
 	int32_t offset;
 } duckdb_time_tz_struct;
 
-//! Timestamps are stored as microseconds since 1970-01-01.
+//! TIMESTAMP values are stored as microseconds since 1970-01-01.
 //! Use the duckdb_from_timestamp and duckdb_to_timestamp functions to extract individual information.
 typedef struct {
 	int64_t micros;
 } duckdb_timestamp;
+
+//! TIMESTAMP_S values are stored as seconds since 1970-01-01.
+typedef struct {
+	int64_t seconds;
+} duckdb_timestamp_s;
+
+//! TIMESTAMP_MS values are stored as milliseconds since 1970-01-01.
+typedef struct {
+	int64_t millis;
+} duckdb_timestamp_ms;
+
+//! TIMESTAMP_NS values are stored as nanoseconds since 1970-01-01.
+typedef struct {
+	int64_t nanos;
+} duckdb_timestamp_ns;
 
 typedef struct {
 	duckdb_date_struct date;
@@ -1325,10 +1340,34 @@ DUCKDB_API duckdb_timestamp duckdb_to_timestamp(duckdb_timestamp_struct ts);
 /*!
 Test a `duckdb_timestamp` to see if it is a finite value.
 
-* @param ts The timestamp object, as obtained from a `DUCKDB_TYPE_TIMESTAMP` column.
+* @param ts The duckdb_timestamp object, as obtained from a `DUCKDB_TYPE_TIMESTAMP` column.
 * @return True if the timestamp is finite, false if it is ±infinity.
 */
 DUCKDB_API bool duckdb_is_finite_timestamp(duckdb_timestamp ts);
+
+/*!
+Test a `duckdb_timestamp_s` to see if it is a finite value.
+
+* @param ts The duckdb_timestamp_s object, as obtained from a `DUCKDB_TYPE_TIMESTAMP_S` column.
+* @return True if the timestamp is finite, false if it is ±infinity.
+*/
+DUCKDB_API bool duckdb_is_finite_timestamp_s(duckdb_timestamp_s ts);
+
+/*!
+Test a `duckdb_timestamp_ms` to see if it is a finite value.
+
+* @param ts The duckdb_timestamp_ms object, as obtained from a `DUCKDB_TYPE_TIMESTAMP_MS` column.
+* @return True if the timestamp is finite, false if it is ±infinity.
+*/
+DUCKDB_API bool duckdb_is_finite_timestamp_ms(duckdb_timestamp_ms ts);
+
+/*!
+Test a `duckdb_timestamp_ns` to see if it is a finite value.
+
+* @param ts The duckdb_timestamp_ns object, as obtained from a `DUCKDB_TYPE_TIMESTAMP_NS` column.
+* @return True if the timestamp is finite, false if it is ±infinity.
+*/
+DUCKDB_API bool duckdb_is_finite_timestamp_ns(duckdb_timestamp_ns ts);
 
 //===--------------------------------------------------------------------===//
 // Hugeint Helpers
@@ -1996,10 +2035,42 @@ DUCKDB_API duckdb_value duckdb_create_time_tz_value(duckdb_time_tz value);
 /*!
 Creates a TIMESTAMP value from a duckdb_timestamp
 
-* @param input The timestamp value
+* @param input The duckdb_timestamp value
 * @return The value. This must be destroyed with `duckdb_destroy_value`.
 */
 DUCKDB_API duckdb_value duckdb_create_timestamp(duckdb_timestamp input);
+
+/*!
+Creates a TIMESTAMP_TZ value from a duckdb_timestamp
+
+* @param input The duckdb_timestamp value
+* @return The value. This must be destroyed with `duckdb_destroy_value`.
+*/
+DUCKDB_API duckdb_value duckdb_create_timestamp_tz(duckdb_timestamp input);
+
+/*!
+Creates a TIMESTAMP_S value from a duckdb_timestamp_s
+
+* @param input The duckdb_timestamp_s value
+* @return The value. This must be destroyed with `duckdb_destroy_value`.
+*/
+DUCKDB_API duckdb_value duckdb_create_timestamp_s(duckdb_timestamp_s input);
+
+/*!
+Creates a TIMESTAMP_MS value from a duckdb_timestamp_ms
+
+* @param input The duckdb_timestamp_ms value
+* @return The value. This must be destroyed with `duckdb_destroy_value`.
+*/
+DUCKDB_API duckdb_value duckdb_create_timestamp_ms(duckdb_timestamp_ms input);
+
+/*!
+Creates a TIMESTAMP_NS value from a duckdb_timestamp_ns
+
+* @param input The duckdb_timestamp_ns value
+* @return The value. This must be destroyed with `duckdb_destroy_value`.
+*/
+DUCKDB_API duckdb_value duckdb_create_timestamp_ns(duckdb_timestamp_ns input);
 
 /*!
 Creates a value from an interval
@@ -2150,9 +2221,41 @@ DUCKDB_API duckdb_time_tz duckdb_get_time_tz(duckdb_value val);
 Returns the TIMESTAMP value of the given value.
 
 * @param val A duckdb_value containing a TIMESTAMP
-* @return A duckdb_timestamp, or MinValue<timestamp_t> if the value cannot be converted
+* @return A duckdb_timestamp, or MinValue<timestamp> if the value cannot be converted
 */
 DUCKDB_API duckdb_timestamp duckdb_get_timestamp(duckdb_value val);
+
+/*!
+Returns the TIMESTAMP_TZ value of the given value.
+
+* @param val A duckdb_value containing a TIMESTAMP_TZ
+* @return A duckdb_timestamp, or MinValue<timestamp_tz> if the value cannot be converted
+*/
+DUCKDB_API duckdb_timestamp duckdb_get_timestamp_tz(duckdb_value val);
+
+/*!
+Returns the duckdb_timestamp_s value of the given value.
+
+* @param val A duckdb_value containing a TIMESTAMP_S
+* @return A duckdb_timestamp_s, or MinValue<timestamp_s> if the value cannot be converted
+*/
+DUCKDB_API duckdb_timestamp_s duckdb_get_timestamp_s(duckdb_value val);
+
+/*!
+Returns the duckdb_timestamp_ms value of the given value.
+
+* @param val A duckdb_value containing a TIMESTAMP_MS
+* @return A duckdb_timestamp_ms, or MinValue<timestamp_ms> if the value cannot be converted
+*/
+DUCKDB_API duckdb_timestamp_ms duckdb_get_timestamp_ms(duckdb_value val);
+
+/*!
+Returns the duckdb_timestamp_ns value of the given value.
+
+* @param val A duckdb_value containing a TIMESTAMP_NS
+* @return A duckdb_timestamp_ns, or MinValue<timestamp_ns> if the value cannot be converted
+*/
+DUCKDB_API duckdb_timestamp_ns duckdb_get_timestamp_ns(duckdb_value val);
 
 /*!
 Returns the interval value of the given value.

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -615,11 +615,19 @@ DUCKDB_API bool TryCast::Operation(timestamp_t input, dtime_tz_t &result, bool s
 template <>
 DUCKDB_API bool TryCast::Operation(timestamp_t input, timestamp_t &result, bool strict);
 template <>
+DUCKDB_API bool TryCast::Operation(timestamp_sec_t input, timestamp_sec_t &result, bool strict);
+template <>
 DUCKDB_API bool TryCast::Operation(timestamp_t input, timestamp_sec_t &result, bool strict);
+template <>
+DUCKDB_API bool TryCast::Operation(timestamp_ms_t input, timestamp_ms_t &result, bool strict);
 template <>
 DUCKDB_API bool TryCast::Operation(timestamp_t input, timestamp_ms_t &result, bool strict);
 template <>
+DUCKDB_API bool TryCast::Operation(timestamp_ns_t input, timestamp_ns_t &result, bool strict);
+template <>
 DUCKDB_API bool TryCast::Operation(timestamp_t input, timestamp_ns_t &result, bool strict);
+template <>
+DUCKDB_API bool TryCast::Operation(timestamp_tz_t input, timestamp_tz_t &result, bool strict);
 template <>
 DUCKDB_API bool TryCast::Operation(timestamp_t input, timestamp_tz_t &result, bool strict);
 

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -441,6 +441,17 @@ typedef struct {
 	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
 	duckdb_state (*duckdb_appender_add_column)(duckdb_appender appender, const char *name);
 	duckdb_state (*duckdb_appender_clear_columns)(duckdb_appender appender);
+	bool (*duckdb_is_finite_timestamp_s)(duckdb_timestamp_s ts);
+	bool (*duckdb_is_finite_timestamp_ms)(duckdb_timestamp_ms ts);
+	bool (*duckdb_is_finite_timestamp_ns)(duckdb_timestamp_ns ts);
+	duckdb_value (*duckdb_create_timestamp_tz)(duckdb_timestamp input);
+	duckdb_value (*duckdb_create_timestamp_s)(duckdb_timestamp_s input);
+	duckdb_value (*duckdb_create_timestamp_ms)(duckdb_timestamp_ms input);
+	duckdb_value (*duckdb_create_timestamp_ns)(duckdb_timestamp_ns input);
+	duckdb_timestamp (*duckdb_get_timestamp_tz)(duckdb_value val);
+	duckdb_timestamp_s (*duckdb_get_timestamp_s)(duckdb_value val);
+	duckdb_timestamp_ms (*duckdb_get_timestamp_ms)(duckdb_value val);
+	duckdb_timestamp_ns (*duckdb_get_timestamp_ns)(duckdb_value val);
 } duckdb_ext_api_v0;
 
 //===--------------------------------------------------------------------===//
@@ -832,6 +843,17 @@ inline duckdb_ext_api_v0 CreateAPIv0() {
 	result.duckdb_get_struct_child = duckdb_get_struct_child;
 	result.duckdb_appender_add_column = duckdb_appender_add_column;
 	result.duckdb_appender_clear_columns = duckdb_appender_clear_columns;
+	result.duckdb_is_finite_timestamp_s = duckdb_is_finite_timestamp_s;
+	result.duckdb_is_finite_timestamp_ms = duckdb_is_finite_timestamp_ms;
+	result.duckdb_is_finite_timestamp_ns = duckdb_is_finite_timestamp_ns;
+	result.duckdb_create_timestamp_tz = duckdb_create_timestamp_tz;
+	result.duckdb_create_timestamp_s = duckdb_create_timestamp_s;
+	result.duckdb_create_timestamp_ms = duckdb_create_timestamp_ms;
+	result.duckdb_create_timestamp_ns = duckdb_create_timestamp_ns;
+	result.duckdb_get_timestamp_tz = duckdb_get_timestamp_tz;
+	result.duckdb_get_timestamp_s = duckdb_get_timestamp_s;
+	result.duckdb_get_timestamp_ms = duckdb_get_timestamp_ms;
+	result.duckdb_get_timestamp_ns = duckdb_get_timestamp_ns;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v0/dev/dev.json
@@ -13,6 +13,17 @@
         "duckdb_get_enum_value",
         "duckdb_get_struct_child",
         "duckdb_appender_add_column",
-        "duckdb_appender_clear_columns"
+        "duckdb_appender_clear_columns",
+        "duckdb_is_finite_timestamp_s",
+        "duckdb_is_finite_timestamp_ms",
+        "duckdb_is_finite_timestamp_ns",
+        "duckdb_create_timestamp_tz",
+        "duckdb_create_timestamp_s",
+        "duckdb_create_timestamp_ms",
+        "duckdb_create_timestamp_ns",
+        "duckdb_get_timestamp_tz",
+        "duckdb_get_timestamp_s",
+        "duckdb_get_timestamp_ms",
+        "duckdb_get_timestamp_ns"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/date_time_timestamp_helpers.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/date_time_timestamp_helpers.json
@@ -171,7 +171,58 @@
             "comment": {
                 "description": "Test a `duckdb_timestamp` to see if it is a finite value.\n\n",
                 "param_comments": {
-                    "ts": "The timestamp object, as obtained from a `DUCKDB_TYPE_TIMESTAMP` column."
+                    "ts": "The duckdb_timestamp object, as obtained from a `DUCKDB_TYPE_TIMESTAMP` column."
+                },
+                "return_value": "True if the timestamp is finite, false if it is \u00b1infinity."
+            }
+        },
+        {
+            "name": "duckdb_is_finite_timestamp_s",
+            "return_type": "bool",
+            "params": [
+                {
+                    "type": "duckdb_timestamp_s",
+                    "name": "ts"
+                }
+            ],
+            "comment": {
+                "description": "Test a `duckdb_timestamp_s` to see if it is a finite value.\n\n",
+                "param_comments": {
+                    "ts": "The duckdb_timestamp_s object, as obtained from a `DUCKDB_TYPE_TIMESTAMP_S` column."
+                },
+                "return_value": "True if the timestamp is finite, false if it is \u00b1infinity."
+            }
+        },
+        {
+            "name": "duckdb_is_finite_timestamp_ms",
+            "return_type": "bool",
+            "params": [
+                {
+                    "type": "duckdb_timestamp_ms",
+                    "name": "ts"
+                }
+            ],
+            "comment": {
+                "description": "Test a `duckdb_timestamp_ms` to see if it is a finite value.\n\n",
+                "param_comments": {
+                    "ts": "The duckdb_timestamp_ms object, as obtained from a `DUCKDB_TYPE_TIMESTAMP_MS` column."
+                },
+                "return_value": "True if the timestamp is finite, false if it is \u00b1infinity."
+            }
+        },
+        {
+            "name": "duckdb_is_finite_timestamp_ns",
+            "return_type": "bool",
+            "params": [
+                {
+                    "type": "duckdb_timestamp_ns",
+                    "name": "ts"
+                }
+            ],
+            "comment": {
+                "description": "Test a `duckdb_timestamp_ns` to see if it is a finite value.\n\n",
+                "param_comments": {
+                    "ts": "The duckdb_timestamp_ns object, as obtained from a `DUCKDB_TYPE_TIMESTAMP_NS` column."
                 },
                 "return_value": "True if the timestamp is finite, false if it is \u00b1infinity."
             }

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -341,7 +341,75 @@
             "comment": {
                 "description": "Creates a TIMESTAMP value from a duckdb_timestamp\n\n",
                 "param_comments": {
-                    "input": "The timestamp value"
+                    "input": "The duckdb_timestamp value"
+                },
+                "return_value": "The value. This must be destroyed with `duckdb_destroy_value`."
+            }
+        },
+        {
+            "name": "duckdb_create_timestamp_tz",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_timestamp",
+                    "name": "input"
+                }
+            ],
+            "comment": {
+                "description": "Creates a TIMESTAMP_TZ value from a duckdb_timestamp\n\n",
+                "param_comments": {
+                    "input": "The duckdb_timestamp value"
+                },
+                "return_value": "The value. This must be destroyed with `duckdb_destroy_value`."
+            }
+        },
+        {
+            "name": "duckdb_create_timestamp_s",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_timestamp_s",
+                    "name": "input"
+                }
+            ],
+            "comment": {
+                "description": "Creates a TIMESTAMP_S value from a duckdb_timestamp_s\n\n",
+                "param_comments": {
+                    "input": "The duckdb_timestamp_s value"
+                },
+                "return_value": "The value. This must be destroyed with `duckdb_destroy_value`."
+            }
+        },
+        {
+            "name": "duckdb_create_timestamp_ms",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_timestamp_ms",
+                    "name": "input"
+                }
+            ],
+            "comment": {
+                "description": "Creates a TIMESTAMP_MS value from a duckdb_timestamp_ms\n\n",
+                "param_comments": {
+                    "input": "The duckdb_timestamp_ms value"
+                },
+                "return_value": "The value. This must be destroyed with `duckdb_destroy_value`."
+            }
+        },
+        {
+            "name": "duckdb_create_timestamp_ns",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_timestamp_ns",
+                    "name": "input"
+                }
+            ],
+            "comment": {
+                "description": "Creates a TIMESTAMP_NS value from a duckdb_timestamp_ns\n\n",
+                "param_comments": {
+                    "input": "The duckdb_timestamp_ns value"
                 },
                 "return_value": "The value. This must be destroyed with `duckdb_destroy_value`."
             }
@@ -671,7 +739,75 @@
                 "param_comments": {
                     "val": "A duckdb_value containing a TIMESTAMP"
                 },
-                "return_value": "A duckdb_timestamp, or MinValue<timestamp_t> if the value cannot be converted"
+                "return_value": "A duckdb_timestamp, or MinValue<timestamp> if the value cannot be converted"
+            }
+        },
+        {
+            "name": "duckdb_get_timestamp_tz",
+            "return_type": "duckdb_timestamp",
+            "params": [
+                {
+                    "type": "duckdb_value",
+                    "name": "val"
+                }
+            ],
+            "comment": {
+                "description": "Returns the TIMESTAMP_TZ value of the given value.\n\n",
+                "param_comments": {
+                    "val": "A duckdb_value containing a TIMESTAMP_TZ"
+                },
+                "return_value": "A duckdb_timestamp, or MinValue<timestamp_tz> if the value cannot be converted"
+            }
+        },
+        {
+            "name": "duckdb_get_timestamp_s",
+            "return_type": "duckdb_timestamp_s",
+            "params": [
+                {
+                    "type": "duckdb_value",
+                    "name": "val"
+                }
+            ],
+            "comment": {
+                "description": "Returns the duckdb_timestamp_s value of the given value.\n\n",
+                "param_comments": {
+                    "val": "A duckdb_value containing a TIMESTAMP_S"
+                },
+                "return_value": "A duckdb_timestamp_s, or MinValue<timestamp_s> if the value cannot be converted"
+            }
+        },
+        {
+            "name": "duckdb_get_timestamp_ms",
+            "return_type": "duckdb_timestamp_ms",
+            "params": [
+                {
+                    "type": "duckdb_value",
+                    "name": "val"
+                }
+            ],
+            "comment": {
+                "description": "Returns the duckdb_timestamp_ms value of the given value.\n\n",
+                "param_comments": {
+                    "val": "A duckdb_value containing a TIMESTAMP_MS"
+                },
+                "return_value": "A duckdb_timestamp_ms, or MinValue<timestamp_ms> if the value cannot be converted"
+            }
+        },
+        {
+            "name": "duckdb_get_timestamp_ns",
+            "return_type": "duckdb_timestamp_ns",
+            "params": [
+                {
+                    "type": "duckdb_value",
+                    "name": "val"
+                }
+            ],
+            "comment": {
+                "description": "Returns the duckdb_timestamp_ns value of the given value.\n\n",
+                "param_comments": {
+                    "val": "A duckdb_value containing a TIMESTAMP_NS"
+                },
+                "return_value": "A duckdb_timestamp_ns, or MinValue<timestamp_ns> if the value cannot be converted"
             }
         },
         {

--- a/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
+++ b/src/include/duckdb/main/capi/header_generation/header_base.hpp.template
@@ -279,11 +279,26 @@ typedef struct {
 	int32_t offset;
 } duckdb_time_tz_struct;
 
-//! Timestamps are stored as microseconds since 1970-01-01.
+//! TIMESTAMP values are stored as microseconds since 1970-01-01.
 //! Use the duckdb_from_timestamp and duckdb_to_timestamp functions to extract individual information.
 typedef struct {
 	int64_t micros;
 } duckdb_timestamp;
+
+//! TIMESTAMP_S values are stored as seconds since 1970-01-01.
+typedef struct {
+	int64_t seconds;
+} duckdb_timestamp_s;
+
+//! TIMESTAMP_MS values are stored as milliseconds since 1970-01-01.
+typedef struct {
+	int64_t millis;
+} duckdb_timestamp_ms;
+
+//! TIMESTAMP_NS values are stored as nanoseconds since 1970-01-01.
+typedef struct {
+	int64_t nanos;
+} duckdb_timestamp_ns;
 
 typedef struct {
 	duckdb_date_struct date;

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -505,6 +505,17 @@ typedef struct {
 	duckdb_value (*duckdb_get_struct_child)(duckdb_value value, idx_t index);
 	duckdb_state (*duckdb_appender_add_column)(duckdb_appender appender, const char *name);
 	duckdb_state (*duckdb_appender_clear_columns)(duckdb_appender appender);
+	bool (*duckdb_is_finite_timestamp_s)(duckdb_timestamp_s ts);
+	bool (*duckdb_is_finite_timestamp_ms)(duckdb_timestamp_ms ts);
+	bool (*duckdb_is_finite_timestamp_ns)(duckdb_timestamp_ns ts);
+	duckdb_value (*duckdb_create_timestamp_tz)(duckdb_timestamp input);
+	duckdb_value (*duckdb_create_timestamp_s)(duckdb_timestamp_s input);
+	duckdb_value (*duckdb_create_timestamp_ms)(duckdb_timestamp_ms input);
+	duckdb_value (*duckdb_create_timestamp_ns)(duckdb_timestamp_ns input);
+	duckdb_timestamp (*duckdb_get_timestamp_tz)(duckdb_value val);
+	duckdb_timestamp_s (*duckdb_get_timestamp_s)(duckdb_value val);
+	duckdb_timestamp_ms (*duckdb_get_timestamp_ms)(duckdb_value val);
+	duckdb_timestamp_ns (*duckdb_get_timestamp_ns)(duckdb_value val);
 #endif
 
 } duckdb_ext_api_v0;
@@ -887,7 +898,18 @@ typedef struct {
 #define duckdb_destroy_cast_function                duckdb_ext_api.duckdb_destroy_cast_function
 
 // Version dev
+#define duckdb_is_finite_timestamp_s             duckdb_ext_api.duckdb_is_finite_timestamp_s
+#define duckdb_is_finite_timestamp_ms            duckdb_ext_api.duckdb_is_finite_timestamp_ms
+#define duckdb_is_finite_timestamp_ns            duckdb_ext_api.duckdb_is_finite_timestamp_ns
 #define duckdb_param_logical_type                duckdb_ext_api.duckdb_param_logical_type
+#define duckdb_create_timestamp_tz               duckdb_ext_api.duckdb_create_timestamp_tz
+#define duckdb_create_timestamp_s                duckdb_ext_api.duckdb_create_timestamp_s
+#define duckdb_create_timestamp_ms               duckdb_ext_api.duckdb_create_timestamp_ms
+#define duckdb_create_timestamp_ns               duckdb_ext_api.duckdb_create_timestamp_ns
+#define duckdb_get_timestamp_tz                  duckdb_ext_api.duckdb_get_timestamp_tz
+#define duckdb_get_timestamp_s                   duckdb_ext_api.duckdb_get_timestamp_s
+#define duckdb_get_timestamp_ms                  duckdb_ext_api.duckdb_get_timestamp_ms
+#define duckdb_get_timestamp_ns                  duckdb_ext_api.duckdb_get_timestamp_ns
 #define duckdb_is_null_value                     duckdb_ext_api.duckdb_is_null_value
 #define duckdb_create_null_value                 duckdb_ext_api.duckdb_create_null_value
 #define duckdb_get_list_size                     duckdb_ext_api.duckdb_get_list_size

--- a/src/main/capi/datetime-c.cpp
+++ b/src/main/capi/datetime-c.cpp
@@ -10,6 +10,9 @@ using duckdb::Timestamp;
 
 using duckdb::date_t;
 using duckdb::dtime_t;
+using duckdb::timestamp_ms_t;
+using duckdb::timestamp_ns_t;
+using duckdb::timestamp_sec_t;
 using duckdb::timestamp_t;
 
 duckdb_date_struct duckdb_from_date(duckdb_date date) {
@@ -98,4 +101,16 @@ duckdb_timestamp duckdb_to_timestamp(duckdb_timestamp_struct ts) {
 
 bool duckdb_is_finite_timestamp(duckdb_timestamp ts) {
 	return Timestamp::IsFinite(timestamp_t(ts.micros));
+}
+
+bool duckdb_is_finite_timestamp_s(duckdb_timestamp_s ts) {
+	return Timestamp::IsFinite(timestamp_sec_t(ts.seconds));
+}
+
+bool duckdb_is_finite_timestamp_ms(duckdb_timestamp_ms ts) {
+	return Timestamp::IsFinite(timestamp_ms_t(ts.millis));
+}
+
+bool duckdb_is_finite_timestamp_ns(duckdb_timestamp_ns ts) {
+	return Timestamp::IsFinite(timestamp_ns_t(ts.nanos));
 }

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -160,7 +160,7 @@ duckdb_timestamp duckdb_get_timestamp(duckdb_value val) {
 
 duckdb_value duckdb_create_timestamp_tz(duckdb_timestamp input) {
 	duckdb::timestamp_tz_t ts(input.micros);
-	return CAPICreateValue(ts); 
+	return CAPICreateValue(ts);
 }
 
 duckdb_timestamp duckdb_get_timestamp_tz(duckdb_value val) {
@@ -172,7 +172,7 @@ duckdb_timestamp duckdb_get_timestamp_tz(duckdb_value val) {
 
 duckdb_value duckdb_create_timestamp_s(duckdb_timestamp_s input) {
 	duckdb::timestamp_sec_t ts(input.seconds);
-	return CAPICreateValue(ts); 
+	return CAPICreateValue(ts);
 }
 
 duckdb_timestamp_s duckdb_get_timestamp_s(duckdb_value val) {
@@ -184,7 +184,7 @@ duckdb_timestamp_s duckdb_get_timestamp_s(duckdb_value val) {
 
 duckdb_value duckdb_create_timestamp_ms(duckdb_timestamp_ms input) {
 	duckdb::timestamp_ms_t ts(input.millis);
-	return CAPICreateValue(ts); 
+	return CAPICreateValue(ts);
 }
 
 duckdb_timestamp_ms duckdb_get_timestamp_ms(duckdb_value val) {
@@ -196,7 +196,7 @@ duckdb_timestamp_ms duckdb_get_timestamp_ms(duckdb_value val) {
 
 duckdb_value duckdb_create_timestamp_ns(duckdb_timestamp_ns input) {
 	duckdb::timestamp_ns_t ts(input.nanos);
-	return CAPICreateValue(ts); 
+	return CAPICreateValue(ts);
 }
 
 duckdb_timestamp_ns duckdb_get_timestamp_ns(duckdb_value val) {

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -153,9 +153,57 @@ duckdb_value duckdb_create_timestamp(duckdb_timestamp input) {
 
 duckdb_timestamp duckdb_get_timestamp(duckdb_value val) {
 	if (!val) {
-		return duckdb_timestamp {0};
+		return {0};
 	}
 	return {CAPIGetValue<duckdb::timestamp_t, LogicalTypeId::TIMESTAMP>(val).value};
+}
+
+duckdb_value duckdb_create_timestamp_tz(duckdb_timestamp input) {
+	duckdb::timestamp_tz_t ts(input.micros);
+	return CAPICreateValue(ts); 
+}
+
+duckdb_timestamp duckdb_get_timestamp_tz(duckdb_value val) {
+	if (!val) {
+		return {0};
+	}
+	return {CAPIGetValue<duckdb::timestamp_tz_t, LogicalTypeId::TIMESTAMP_TZ>(val).value};
+}
+
+duckdb_value duckdb_create_timestamp_s(duckdb_timestamp_s input) {
+	duckdb::timestamp_sec_t ts(input.seconds);
+	return CAPICreateValue(ts); 
+}
+
+duckdb_timestamp_s duckdb_get_timestamp_s(duckdb_value val) {
+	if (!val) {
+		return {0};
+	}
+	return {CAPIGetValue<duckdb::timestamp_sec_t, LogicalTypeId::TIMESTAMP_SEC>(val).value};
+}
+
+duckdb_value duckdb_create_timestamp_ms(duckdb_timestamp_ms input) {
+	duckdb::timestamp_ms_t ts(input.millis);
+	return CAPICreateValue(ts); 
+}
+
+duckdb_timestamp_ms duckdb_get_timestamp_ms(duckdb_value val) {
+	if (!val) {
+		return {0};
+	}
+	return {CAPIGetValue<duckdb::timestamp_ms_t, LogicalTypeId::TIMESTAMP_MS>(val).value};
+}
+
+duckdb_value duckdb_create_timestamp_ns(duckdb_timestamp_ns input) {
+	duckdb::timestamp_ns_t ts(input.nanos);
+	return CAPICreateValue(ts); 
+}
+
+duckdb_timestamp_ns duckdb_get_timestamp_ns(duckdb_value val) {
+	if (!val) {
+		return {0};
+	}
+	return {CAPIGetValue<duckdb::timestamp_ns_t, LogicalTypeId::TIMESTAMP_NS>(val).value};
 }
 
 duckdb_value duckdb_create_interval(duckdb_interval input) {

--- a/src/main/capi/helper-c.cpp
+++ b/src/main/capi/helper-c.cpp
@@ -197,6 +197,7 @@ idx_t GetCTypeSize(duckdb_type type) {
 	case DUCKDB_TYPE_TIME:
 		return sizeof(duckdb_time);
 	case DUCKDB_TYPE_TIMESTAMP:
+	case DUCKDB_TYPE_TIMESTAMP_TZ:
 	case DUCKDB_TYPE_TIMESTAMP_S:
 	case DUCKDB_TYPE_TIMESTAMP_MS:
 	case DUCKDB_TYPE_TIMESTAMP_NS:

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -404,6 +404,38 @@ TEST_CASE("duckdb_create_value", "[capi]") {
 	}
 
 	{
+		auto val = duckdb_create_timestamp_tz({1});
+		REQUIRE(duckdb_get_timestamp_tz(nullptr).micros == 0);
+		auto result = duckdb_get_timestamp_tz(val);
+		REQUIRE(result.micros == 1);
+		duckdb_destroy_value(&val);
+	}
+
+	{
+		auto val = duckdb_create_timestamp_s({1});
+		REQUIRE(duckdb_get_timestamp_s(nullptr).seconds == 0);
+		auto result = duckdb_get_timestamp_s(val);
+		REQUIRE(result.seconds == 1);
+		duckdb_destroy_value(&val);
+	}
+
+	{
+		auto val = duckdb_create_timestamp_ms({1});
+		REQUIRE(duckdb_get_timestamp_ms(nullptr).millis == 0);
+		auto result = duckdb_get_timestamp_ms(val);
+		REQUIRE(result.millis == 1);
+		duckdb_destroy_value(&val);
+	}
+
+	{
+		auto val = duckdb_create_timestamp_ns({1});
+		REQUIRE(duckdb_get_timestamp_ns(nullptr).nanos == 0);
+		auto result = duckdb_get_timestamp_ns(val);
+		REQUIRE(result.nanos == 1);
+		duckdb_destroy_value(&val);
+	}
+
+	{
 		auto val = duckdb_create_interval({1, 1, 1});
 		auto result = duckdb_get_interval(val);
 		REQUIRE(result.months == 1);
@@ -609,6 +641,82 @@ TEST_CASE("Test Infinite Dates", "[capi]") {
 		ts = result->Fetch<duckdb_timestamp>(2, 0);
 		REQUIRE(!duckdb_is_finite_timestamp(ts));
 		REQUIRE(ts.micros > 0);
+	}
+
+	{
+		auto result = tester.Query("SELECT '-infinity'::TIMESTAMPTZ, 'epoch'::TIMESTAMPTZ, 'infinity'::TIMESTAMPTZ");
+		REQUIRE(NO_FAIL(*result));
+		REQUIRE(result->ColumnCount() == 3);
+		REQUIRE(result->ErrorMessage() == nullptr);
+
+		auto ts = result->Fetch<duckdb_timestamp>(0, 0);
+		REQUIRE(!duckdb_is_finite_timestamp(ts));
+		REQUIRE(ts.micros < 0);
+
+		ts = result->Fetch<duckdb_timestamp>(1, 0);
+		REQUIRE(duckdb_is_finite_timestamp(ts));
+		REQUIRE(ts.micros == 0);
+
+		ts = result->Fetch<duckdb_timestamp>(2, 0);
+		REQUIRE(!duckdb_is_finite_timestamp(ts));
+		REQUIRE(ts.micros > 0);
+	}
+
+	{
+		auto result = tester.Query("SELECT '-infinity'::TIMESTAMP_S, 'epoch'::TIMESTAMP_S, 'infinity'::TIMESTAMP_S");
+		REQUIRE(NO_FAIL(*result));
+		REQUIRE(result->ColumnCount() == 3);
+		REQUIRE(result->ErrorMessage() == nullptr);
+
+		auto ts = result->Fetch<duckdb_timestamp_s>(0, 0);
+		REQUIRE(!duckdb_is_finite_timestamp_s(ts));
+		REQUIRE(ts.seconds < 0);
+
+		ts = result->Fetch<duckdb_timestamp_s>(1, 0);
+		REQUIRE(duckdb_is_finite_timestamp_s(ts));
+		REQUIRE(ts.seconds == 0);
+
+		ts = result->Fetch<duckdb_timestamp_s>(2, 0);
+		REQUIRE(!duckdb_is_finite_timestamp_s(ts));
+		REQUIRE(ts.seconds > 0);
+	}
+
+	{
+		auto result = tester.Query("SELECT '-infinity'::TIMESTAMP_MS, 'epoch'::TIMESTAMP_MS, 'infinity'::TIMESTAMP_MS");
+		REQUIRE(NO_FAIL(*result));
+		REQUIRE(result->ColumnCount() == 3);
+		REQUIRE(result->ErrorMessage() == nullptr);
+
+		auto ts = result->Fetch<duckdb_timestamp_ms>(0, 0);
+		REQUIRE(!duckdb_is_finite_timestamp_ms(ts));
+		REQUIRE(ts.millis < 0);
+
+		ts = result->Fetch<duckdb_timestamp_ms>(1, 0);
+		REQUIRE(duckdb_is_finite_timestamp_ms(ts));
+		REQUIRE(ts.millis == 0);
+
+		ts = result->Fetch<duckdb_timestamp_ms>(2, 0);
+		REQUIRE(!duckdb_is_finite_timestamp_ms(ts));
+		REQUIRE(ts.millis > 0);
+	}
+
+	{
+		auto result = tester.Query("SELECT '-infinity'::TIMESTAMP_NS, 'epoch'::TIMESTAMP_NS, 'infinity'::TIMESTAMP_NS");
+		REQUIRE(NO_FAIL(*result));
+		REQUIRE(result->ColumnCount() == 3);
+		REQUIRE(result->ErrorMessage() == nullptr);
+
+		auto ts = result->Fetch<duckdb_timestamp_ns>(0, 0);
+		REQUIRE(!duckdb_is_finite_timestamp_ns(ts));
+		REQUIRE(ts.nanos < 0);
+
+		ts = result->Fetch<duckdb_timestamp_ns>(1, 0);
+		REQUIRE(duckdb_is_finite_timestamp_ns(ts));
+		REQUIRE(ts.nanos == 0);
+
+		ts = result->Fetch<duckdb_timestamp_ns>(2, 0);
+		REQUIRE(!duckdb_is_finite_timestamp_ns(ts));
+		REQUIRE(ts.nanos > 0);
 	}
 }
 

--- a/test/helpers/capi_tester.cpp
+++ b/test/helpers/capi_tester.cpp
@@ -89,6 +89,24 @@ duckdb_timestamp CAPIResult::Fetch(idx_t col, idx_t row) {
 }
 
 template <>
+duckdb_timestamp_s CAPIResult::Fetch(idx_t col, idx_t row) {
+	auto data = (duckdb_timestamp_s *)duckdb_column_data(&result, col);
+	return data[row];
+}
+
+template <>
+duckdb_timestamp_ms CAPIResult::Fetch(idx_t col, idx_t row) {
+	auto data = (duckdb_timestamp_ms *)duckdb_column_data(&result, col);
+	return data[row];
+}
+
+template <>
+duckdb_timestamp_ns CAPIResult::Fetch(idx_t col, idx_t row) {
+	auto data = (duckdb_timestamp_ns *)duckdb_column_data(&result, col);
+	return data[row];
+}
+
+template <>
 duckdb_interval CAPIResult::Fetch(idx_t col, idx_t row) {
 	return duckdb_value_interval(&result, col, row);
 }

--- a/test/include/capi_tester.hpp
+++ b/test/include/capi_tester.hpp
@@ -187,6 +187,12 @@ duckdb_time CAPIResult::Fetch(idx_t col, idx_t row);
 template <>
 duckdb_timestamp CAPIResult::Fetch(idx_t col, idx_t row);
 template <>
+duckdb_timestamp_s CAPIResult::Fetch(idx_t col, idx_t row);
+template <>
+duckdb_timestamp_ms CAPIResult::Fetch(idx_t col, idx_t row);
+template <>
+duckdb_timestamp_ns CAPIResult::Fetch(idx_t col, idx_t row);
+template <>
 duckdb_interval CAPIResult::Fetch(idx_t col, idx_t row);
 template <>
 duckdb_blob CAPIResult::Fetch(idx_t col, idx_t row);


### PR DESCRIPTION
Updated subset of https://github.com/duckdb/duckdb/pull/14865.

New C API types:
- `duckdb_timestamp_s`
- `duckdb_timestamp_ms`
- `duckdb_timestamp_ns`

New C API functions:
- Finiteness checks:
  - `duckdb_is_finite_timestamp_s`
  - `duckdb_is_finite_timestamp_ms`
  - `duckdb_is_finite_timestamp_ns`
- Value creation/access:
  - `duckdb_create_timestamp_tz`, `duckdb_get_timestamp_tz`
  - `duckdb_create_timestamp_s`, `duckdb_get_timestamp_s`
  - `duckdb_create_timestamp_ms`, `duckdb_get_timestamp_ms`
  - `duckdb_create_timestamp_ns`, `duckdb_get_timestamp_ns`

New unit tests for all new functions have been added, along with support in the CAPI Tester to fetch these types.

To get these working, I also added:
- New trivial cast operations for these types.
- A missing case in GetCTypeSize (TIMESTAMP_TZ).

(Without these changes, the new tests fail.)