### PR TITLE
Fix script/regression/benchmark.py rework

### DIFF
--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -153,9 +153,9 @@ class BenchmarkRunner:
             print(err)
             return 'Failed to run benchmark ' + benchmark
 
-    def run_benchmarks(self):
+    def run_benchmarks(self, benchmark_list: List[str]):
         results = {}
-        for benchmark in self.benchmark_list:
+        for benchmark in benchmark_list:
             results[benchmark] = self.run_benchmark(benchmark)
         return results
 

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -101,8 +101,8 @@ for i in range(NUMBER_REPETITIONS):
 '''
     )
 
-    old_results = old_runner.run_benchmarks()
-    new_results = new_runner.run_benchmarks()
+    old_results = old_runner.run_benchmarks(benchmark_list)
+    new_results = new_runner.run_benchmarks(benchmark_list)
 
     for benchmark in benchmark_list:
         old_res = old_results[benchmark]


### PR DESCRIPTION
Avoid running whole list of tests, but tests only failed ones

I think #14557 reworked the benchmark runner, but the old behaviour that was only regressions where iterated on was not kept.
Basically, you run 100 tests, 3 fails, only those 3 needs to be re-run (up to 5 times in total).