### PR TITLE
Explicit install of pkg-config broke, removing it

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -224,8 +224,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Ninja and Pkg-config
-        run: brew install pkg-config ninja
+      - name: Install Ninja
+        run: brew install ninja
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main


### PR DESCRIPTION
This should restore OSX extensions on nightly, tested on the full CI on my fork at https://github.com/carlopi/duckdb/actions/runs/11999095103.

This is same PR as https://github.com/duckdb/extension-ci-tools/pull/115.

Note that CI do not test anything here, since OSX extensions are skipped on PRs.