### PR TITLE
Join Filter Pushdown does not push down in filters when nulls are present

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -600,9 +600,10 @@ void JoinFilterPushdownInfo::PushInFilter(const JoinFilterPushdownFilter &info, 
 	}
 	vector<Value> in_list(unique_ht_values.begin(), unique_ht_values.end());
 
-	// generating the OR filter only makes sense if the range is not dense
+	// generating the OR filter only makes sense if the range is
+	// not dense and that the range does not contain NULL
 	// i.e. if we have the values [0, 1, 2, 3, 4] - the min/max is fully equivalent to the OR filter
-	if (FilterCombiner::IsDenseRange(in_list)) {
+	if (FilterCombiner::ContainsNull(in_list) || FilterCombiner::IsDenseRange(in_list)) {
 		return;
 	}
 

--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -48,6 +48,7 @@ public:
 	//! Returns whether or not a set of integral values is a dense range (i.e. 1, 2, 3, 4, 5)
 	//! If this returns true - this sorts "in_list" as a side-effect
 	static bool IsDenseRange(vector<Value> &in_list);
+	static bool ContainsNull(vector<Value> &in_list);
 
 	void GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback);
 	bool HasFilters();

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -438,6 +438,15 @@ static unique_ptr<TableFilter> PushDownFilterIntoExpr(const Expression &expr, un
 	return inner_filter;
 }
 
+bool FilterCombiner::ContainsNull(vector<Value> &in_list) {
+	for (idx_t i = 1; i < in_list.size(); i++) {
+		if (in_list[i].IsNull()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 bool FilterCombiner::IsDenseRange(vector<Value> &in_list) {
 	if (in_list.empty()) {
 		return true;
@@ -451,6 +460,9 @@ bool FilterCombiner::IsDenseRange(vector<Value> &in_list) {
 	// check if the gap between each value is exactly one
 	hugeint_t prev_value = in_list[0].GetValue<hugeint_t>();
 	for (idx_t i = 1; i < in_list.size(); i++) {
+		if (in_list[i].IsNull()) {
+			return true;
+		}
 		hugeint_t current_value = in_list[i].GetValue<hugeint_t>();
 		hugeint_t diff;
 		if (!TrySubtractOperator::Operation(current_value, prev_value, diff)) {

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -439,7 +439,7 @@ static unique_ptr<TableFilter> PushDownFilterIntoExpr(const Expression &expr, un
 }
 
 bool FilterCombiner::ContainsNull(vector<Value> &in_list) {
-	for (idx_t i = 1; i < in_list.size(); i++) {
+	for (idx_t i = 0; i < in_list.size(); i++) {
 		if (in_list[i].IsNull()) {
 			return true;
 		}
@@ -460,9 +460,6 @@ bool FilterCombiner::IsDenseRange(vector<Value> &in_list) {
 	// check if the gap between each value is exactly one
 	hugeint_t prev_value = in_list[0].GetValue<hugeint_t>();
 	for (idx_t i = 1; i < in_list.size(); i++) {
-		if (in_list[i].IsNull()) {
-			return true;
-		}
 		hugeint_t current_value = in_list[i].GetValue<hugeint_t>();
 		hugeint_t diff;
 		if (!TrySubtractOperator::Operation(current_value, prev_value, diff)) {

--- a/test/optimizer/pushdown/join_filter_pushdown.test
+++ b/test/optimizer/pushdown/join_filter_pushdown.test
@@ -1,0 +1,21 @@
+# name: test/optimizer/pushdown/join_filter_pushdown.test
+# description: Test sampling of larger relations
+# group: [pushdown]
+
+statement ok
+CREATE TABLE t1 AS FROM VALUES
+('619d9199-bc25-41d7-803e-1fa801b4b952'::UUID, NULL::VARCHAR),
+('1ada8361-c20b-4e9f-9c8e-15689039cc75'::UUID, '91'::VARCHAR),
+('f5a8a7d8-6bc5-4337-a296-d52078156051'::UUID, NULL::VARCHAR) t(s, i);
+
+statement ok
+CREATE TABLE t2 as from values
+ ('Int'),
+ ('91'),
+ ('13',),
+ ('sst',) t(v);
+
+statement ok
+SELECT t1.s
+FROM t1
+LEFT JOIN t2 ON t1.i = t2.v;


### PR DESCRIPTION
Title.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/3547

Edit:
Fixes https://github.com/duckdblabs/duckdb-internal/issues/3565

Fixes https://github.com/duckdb/duckdb/issues/14988