### PR TITLE
Serialization compatibility version to be encoded in the Database file

### DIFF
--- a/extension/json/include/json_serializer.hpp
+++ b/extension/json/include/json_serializer.hpp
@@ -26,7 +26,8 @@ private:
 
 public:
 	explicit JsonSerializer(yyjson_mut_doc *doc, bool skip_if_null, bool skip_if_empty, bool skip_if_default)
-	    : doc(doc), stack({yyjson_mut_obj(doc)}), skip_if_null(skip_if_null), skip_if_empty(skip_if_empty) {
+	    : Serializer(SerializationOptions::DefaultOldestSupported()), doc(doc), stack({yyjson_mut_obj(doc)}),
+	      skip_if_null(skip_if_null), skip_if_empty(skip_if_empty) {
 		options.serialize_enum_as_string = true;
 		options.serialize_default_values = !skip_if_default;
 	}

--- a/src/common/serializer/serializer.cpp
+++ b/src/common/serializer/serializer.cpp
@@ -1,7 +1,46 @@
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
+
+SerializationOptions::SerializationOptions(const SerializationCompatibility &serialization_compat) {
+	serialization_compatibility = serialization_compat;
+}
+
+SerializationOptions::SerializationOptions(const AttachedDatabase &db) {
+	serialization_compatibility = SerializationCompatibility::FromIndex(db.GetCompatibilityVersion());
+}
+
+SerializationOptions::SerializationOptions(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	serialization_compatibility =
+	    SerializationCompatibility::FromIndex(config.options.serialization_compatibility.serialization_version);
+}
+
+SerializationOptions SerializationOptions::DefaultOldestSupported() {
+	SerializationOptions res(SerializationCompatibility::Default());
+	return res;
+}
+
+SerializationOptions SerializationOptions::Latest() {
+	SerializationOptions res(SerializationCompatibility::Latest());
+	return res;
+}
+
+SerializationOptions SerializationOptions::From(const AttachedDatabase &db) {
+	SerializationOptions res(db);
+	return res;
+}
+
+SerializationOptions SerializationOptions::From(const ClientContext &context) {
+	SerializationOptions res(context);
+	return res;
+}
+
+SerializationOptions SerializationOptions::From(const SerializationCompatibility &serialization_compat) {
+	return SerializationOptions {serialization_compat};
+}
 
 template <>
 void Serializer::WriteValue(const vector<bool> &vec) {

--- a/src/common/types/data_chunk.cpp
+++ b/src/common/types/data_chunk.cpp
@@ -370,7 +370,7 @@ void DataChunk::Verify() {
 
 	// verify that we can round-trip chunk serialization
 	MemoryStream mem_stream;
-	BinarySerializer serializer(mem_stream);
+	BinarySerializer serializer(mem_stream, SerializationOptions::Latest());
 
 	serializer.Begin();
 	Serialize(serializer);

--- a/src/include/duckdb/common/serializer/binary_serializer.hpp
+++ b/src/include/duckdb/common/serializer/binary_serializer.hpp
@@ -18,9 +18,8 @@ namespace duckdb {
 
 class BinarySerializer : public Serializer {
 public:
-	explicit BinarySerializer(WriteStream &stream, SerializationOptions options_p = SerializationOptions())
-	    : stream(stream) {
-		options = std::move(options_p);
+	explicit BinarySerializer(WriteStream &stream, const SerializationOptions &options_p)
+	    : Serializer(options_p), stream(stream) {
 		// Override the value set by the passed in SerializationOptions
 		options.serialize_enum_as_string = false;
 	}
@@ -55,8 +54,8 @@ private:
 
 public:
 	template <class T>
-	static void Serialize(const T &value, WriteStream &stream, SerializationOptions options = SerializationOptions()) {
-		BinarySerializer serializer(stream, std::move(options));
+	static void Serialize(const T &value, WriteStream &stream, const SerializationOptions &options) {
+		BinarySerializer serializer(stream, options);
 		serializer.OnObjectBegin();
 		value.Serialize(serializer);
 		serializer.OnObjectEnd();

--- a/src/include/duckdb/common/serializer/serializer.hpp
+++ b/src/include/duckdb/common/serializer/serializer.hpp
@@ -26,7 +26,17 @@
 namespace duckdb {
 
 class SerializationOptions {
+protected:
+	explicit SerializationOptions(const SerializationCompatibility &serialization_compat);
+	explicit SerializationOptions(const AttachedDatabase &db);
+	explicit SerializationOptions(const ClientContext &context);
+
 public:
+	static SerializationOptions DefaultOldestSupported();
+	static SerializationOptions Latest();
+	static SerializationOptions From(const AttachedDatabase &db);
+	static SerializationOptions From(const ClientContext &context);
+	static SerializationOptions From(const SerializationCompatibility &serialization_compat);
 	bool serialize_enum_as_string = false;
 	bool serialize_default_values = false;
 	SerializationCompatibility serialization_compatibility = SerializationCompatibility::Default();
@@ -38,6 +48,8 @@ protected:
 	SerializationData data;
 
 public:
+	explicit Serializer(const SerializationOptions &opts) : options(opts) {
+	}
 	virtual ~Serializer() {
 	}
 

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -93,7 +93,32 @@ public:
 	static bool NameIsReserved(const string &name);
 	static string ExtractDatabaseName(const string &dbpath, FileSystem &fs);
 
+	idx_t GetCompatibilityVersion() const {
+		if (!compatibility_version.IsValid()) {
+			throw InternalException("Compatibility version queried before call to SetCompatibilityVersion");
+		}
+		return compatibility_version.GetIndex();
+	}
+	string GetCompatibilityVersionName() const {
+		idx_t id = GetCompatibilityVersion();
+		return GetSerializationVersionName(id);
+	}
+	void SetCompatibilityVersion(const string &compatibility_version) {
+		auto version = GetSerializationVersion(compatibility_version.c_str());
+		if (version.IsValid()) {
+			SetCompatibilityVersionImpl(version.GetIndex());
+		} else {
+			SetCompatibilityVersionImpl(DEFAULT_SERIALIZATION_VERSION_INFO);
+		}
+	}
+
 private:
+	void SetCompatibilityVersionImpl(idx_t compat_version) {
+		if (compatibility_version.IsValid()) {
+			throw InternalException("Compatibility version already set");
+		}
+		compatibility_version = compat_version;
+	}
 	DatabaseInstance &db;
 	unique_ptr<StorageManager> storage;
 	unique_ptr<Catalog> catalog;
@@ -103,6 +128,7 @@ private:
 	optional_ptr<StorageExtension> storage_extension;
 	bool is_initial_database = false;
 	bool is_closed = false;
+	optional_idx compatibility_version;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -103,22 +103,24 @@ public:
 		idx_t id = GetCompatibilityVersion();
 		return GetSerializationVersionName(id);
 	}
-	void SetCompatibilityVersion(const string &compatibility_version) {
+	void SetCompatibilityVersion(const string &compatibility_version, idx_t default_value) {
 		auto version = GetSerializationVersion(compatibility_version.c_str());
 		if (version.IsValid()) {
-			SetCompatibilityVersionImpl(version.GetIndex());
+			SetCompatibilityVersion(version.GetIndex());
+		} else if (compatibility_version.empty()) {
+			SetCompatibilityVersion(default_value);
 		} else {
-			SetCompatibilityVersionImpl(DEFAULT_SERIALIZATION_VERSION_INFO);
+			SetCompatibilityVersion(LATEST_SERIALIZATION_VERSION_INFO);
 		}
 	}
-
-private:
-	void SetCompatibilityVersionImpl(idx_t compat_version) {
+	void SetCompatibilityVersion(idx_t compat_version) {
 		if (compatibility_version.IsValid()) {
 			throw InternalException("Compatibility version already set");
 		}
 		compatibility_version = compat_version;
 	}
+
+private:
 	DatabaseInstance &db;
 	unique_ptr<StorageManager> storage;
 	unique_ptr<Catalog> catalog;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -97,6 +97,7 @@ struct ExtensionOption {
 
 class SerializationCompatibility {
 public:
+	static SerializationCompatibility FromIndex(const idx_t version);
 	static SerializationCompatibility FromString(const string &input);
 	static SerializationCompatibility Default();
 	static SerializationCompatibility Latest();

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1060,7 +1060,6 @@ struct StorageCompatibilityVersionSetting {
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
-	static string GetSetting(const DBConfig &config);
 };
 
 struct StreamingBufferSizeSetting {

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1060,6 +1060,7 @@ struct StorageCompatibilityVersionSetting {
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
 	static Value GetSetting(const ClientContext &context);
+	static string GetSetting(const DBConfig &config);
 };
 
 struct StreamingBufferSizeSetting {

--- a/src/include/duckdb/planner/logical_operator.hpp
+++ b/src/include/duckdb/planner/logical_operator.hpp
@@ -23,6 +23,8 @@
 
 namespace duckdb {
 
+class SerializationCompatibility;
+
 //! LogicalOperator is the base class of the logical operators present in the
 //! logical query tree
 class LogicalOperator {
@@ -69,7 +71,7 @@ public:
 	virtual void Serialize(Serializer &serializer) const;
 	static unique_ptr<LogicalOperator> Deserialize(Deserializer &deserializer);
 
-	virtual unique_ptr<LogicalOperator> Copy(ClientContext &context) const;
+	virtual unique_ptr<LogicalOperator> Copy(ClientContext &context, const SerializationCompatibility &a) const;
 
 	virtual bool RequireOptimizer() const {
 		return true;

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -59,7 +59,11 @@ extern const uint64_t VERSION_NUMBER;
 string GetDuckDBVersion(idx_t version_number);
 optional_idx GetStorageVersion(const char *version_string);
 optional_idx GetSerializationVersion(const char *version_string);
+string GetSerializationVersionName(idx_t index);
 vector<string> GetSerializationCandidates();
+extern const uint64_t DEFAULT_STORAGE_VERSION_INFO;
+extern const uint64_t DEFAULT_SERIALIZATION_VERSION_INFO;
+extern const uint64_t LATEST_SERIALIZATION_VERSION_INFO;
 
 //! The MainHeader is the first header in the storage file. The MainHeader is typically written only once for a database
 //! file.
@@ -76,6 +80,9 @@ struct MainHeader {
 	uint64_t flags[FLAG_COUNT];
 	static void CheckMagicBytes(FileHandle &handle);
 
+	string CompatibilityGitDesc() {
+		return string(char_ptr_cast(compatibility_git_desc), 0, MAX_VERSION_SIZE);
+	}
 	string LibraryGitDesc() {
 		return string(char_ptr_cast(library_git_desc), 0, MAX_VERSION_SIZE);
 	}
@@ -85,6 +92,8 @@ struct MainHeader {
 
 	void Write(WriteStream &ser);
 	static MainHeader Read(ReadStream &source);
+
+	data_t compatibility_git_desc[MAX_VERSION_SIZE];
 
 private:
 	data_t library_git_desc[MAX_VERSION_SIZE];

--- a/src/include/duckdb/storage/storage_options.hpp
+++ b/src/include/duckdb/storage/storage_options.hpp
@@ -18,6 +18,8 @@ struct StorageOptions {
 	optional_idx block_alloc_size;
 	//! The row group size for this attached database (if any)
 	optional_idx row_group_size;
+	//! The compatibility version for this attached database (if any, "" means none provided)
+	string compatibility_version;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/write_ahead_log.hpp
+++ b/src/include/duckdb/storage/write_ahead_log.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/enums/wal_type.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/serializer/buffered_file_writer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/storage/block.hpp"
@@ -117,6 +118,10 @@ public:
 
 	void WriteCheckpoint(MetaBlockPointer meta_block);
 
+	const SerializationOptions &GetSerializationOptions() {
+		return serialization_options;
+	}
+
 protected:
 	static unique_ptr<WriteAheadLog> ReplayInternal(AttachedDatabase &database, unique_ptr<FileHandle> handle);
 
@@ -127,6 +132,7 @@ protected:
 	string wal_path;
 	atomic<idx_t> wal_size;
 	atomic<WALInitState> init_state;
+	SerializationOptions serialization_options;
 };
 
 } // namespace duckdb

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -99,6 +99,9 @@ AttachedDatabase::AttachedDatabase(DatabaseInstance &db, Catalog &catalog_p, str
 		if (StringUtil::CIEquals(entry.first, "row_group_size")) {
 			continue;
 		}
+		if (StringUtil::CIEquals(entry.first, "compatibility_version")) {
+			continue;
+		}
 		throw BinderException("Unrecognized option for attach \"%s\"", entry.first);
 	}
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -663,6 +663,14 @@ bool DBConfig::CanAccessFile(const string &input_path, FileType type) {
 	return true;
 }
 
+SerializationCompatibility SerializationCompatibility::FromIndex(const idx_t version) {
+	SerializationCompatibility result;
+	result.duckdb_version = "";
+	result.serialization_version = version;
+	result.manually_set = false;
+	return result;
+}
+
 SerializationCompatibility SerializationCompatibility::FromString(const string &input) {
 	if (input.empty()) {
 		throw InvalidInputException("Version string can not be empty");

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -185,7 +185,8 @@ static void WriteExtensionFileToDisk(FileSystem &fs, const string &path, void *d
 
 static void WriteExtensionMetadataFileToDisk(FileSystem &fs, const string &path, ExtensionInstallInfo &metadata) {
 	auto file_writer = BufferedFileWriter(fs, path);
-	BinarySerializer::Serialize(metadata, file_writer);
+	// Extension info is currently per-version, so also Latest is OK here
+	BinarySerializer::Serialize(metadata, file_writer, SerializationOptions::DefaultOldestSupported());
 	file_writer.Sync();
 }
 

--- a/src/main/secret/secret_storage.cpp
+++ b/src/main/secret/secret_storage.cpp
@@ -175,7 +175,8 @@ static void WriteSecretFileToDisk(FileSystem &fs, const string &path, const Base
 
 	auto file_writer = BufferedFileWriter(fs, path, open_flags);
 
-	auto serializer = BinarySerializer(file_writer);
+	SerializationOptions serialization_options_default(SerializationOptions::DefaultOldestSupported());
+	auto serializer = BinarySerializer(file_writer, serialization_options_default);
 	serializer.Begin();
 	secret.Serialize(serializer);
 	serializer.End();

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1124,10 +1124,6 @@ Value StorageCompatibilityVersionSetting::GetSetting(const ClientContext &contex
 	return Value(version_name);
 }
 
-string StorageCompatibilityVersionSetting::GetSetting(const DBConfig &config) {
-	return config.options.serialization_compatibility.duckdb_version;
-}
-
 //===----------------------------------------------------------------------===//
 // Streaming Buffer Size
 //===----------------------------------------------------------------------===//

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1124,6 +1124,10 @@ Value StorageCompatibilityVersionSetting::GetSetting(const ClientContext &contex
 	return Value(version_name);
 }
 
+string StorageCompatibilityVersionSetting::GetSetting(const DBConfig &config) {
+	return config.options.serialization_compatibility.duckdb_version;
+}
+
 //===----------------------------------------------------------------------===//
 // Streaming Buffer Size
 //===----------------------------------------------------------------------===//

--- a/src/parser/parsed_data/attach_info.cpp
+++ b/src/parser/parsed_data/attach_info.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
-
 #include "duckdb/storage/storage_info.hpp"
 #include "duckdb/common/optional_idx.hpp"
 
@@ -15,6 +14,8 @@ StorageOptions AttachInfo::GetStorageOptions() const {
 			storage_options.block_alloc_size = entry.second.GetValue<uint64_t>();
 		} else if (entry.first == "row_group_size") {
 			storage_options.row_group_size = entry.second.GetValue<uint64_t>();
+		} else if (entry.first == "compatibility_version") {
+			storage_options.compatibility_version = entry.second.GetValue<string>();
 		}
 	}
 	return storage_options;

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -186,12 +186,10 @@ void Planner::VerifyPlan(ClientContext &context, unique_ptr<LogicalOperator> &op
 	try {
 		MemoryStream stream;
 
-		SerializationOptions options;
+		SerializationOptions options(SerializationOptions::Latest());
 		if (config.options.serialization_compatibility.manually_set) {
 			// Override the default of 'latest' if this was manually set (for testing, mostly)
 			options.serialization_compatibility = config.options.serialization_compatibility;
-		} else {
-			options.serialization_compatibility = SerializationCompatibility::Latest();
 		}
 
 		BinarySerializer::Serialize(*op, stream, options);

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -59,8 +59,10 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 	// this is where the row groups for this table start
 	auto pointer = table_data_writer.GetMetaBlockPointer();
 
+	SerializationOptions serialization_options(SerializationOptions::From(table.GetStorage().db));
+
 	// Serialize statistics as a single unit
-	BinarySerializer stats_serializer(table_data_writer);
+	BinarySerializer stats_serializer(table_data_writer, serialization_options);
 	stats_serializer.Begin();
 	global_stats.Serialize(stats_serializer);
 	stats_serializer.End();
@@ -75,7 +77,7 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 		}
 
 		// Each RowGroup is its own unit
-		BinarySerializer row_group_serializer(table_data_writer);
+		BinarySerializer row_group_serializer(table_data_writer, serialization_options);
 		row_group_serializer.Begin();
 		RowGroup::Serialize(row_group_pointer, row_group_serializer);
 		row_group_serializer.End();
@@ -86,8 +88,7 @@ void SingleFileTableDataWriter::FinalizeTable(const TableStatistics &global_stat
 	serializer.WriteProperty(101, "table_pointer", pointer);
 	serializer.WriteProperty(102, "total_rows", total_rows);
 
-	auto db_options = checkpoint_manager.db.GetDatabase().config.options;
-	auto v1_0_0_storage = db_options.serialization_compatibility.serialization_version < 3;
+	auto v1_0_0_storage = checkpoint_manager.db.GetCompatibilityVersion() < 3;
 	case_insensitive_map_t<Value> options;
 	if (!v1_0_0_storage) {
 		options.emplace("v1_0_0_storage", v1_0_0_storage);

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -179,9 +179,7 @@ void SingleFileCheckpointWriter::CreateCheckpoint() {
 	        ]
 	    }
 	 */
-	SerializationOptions serialization_options;
-
-	serialization_options.serialization_compatibility = config.options.serialization_compatibility;
+	SerializationOptions serialization_options(SerializationOptions::From(db));
 
 	BinarySerializer serializer(*metadata_writer, serialization_options);
 	serializer.Begin();

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -245,7 +245,10 @@ void SingleFileBlockManager::LoadExistingDatabase() {
 	// otherwise, we check the metadata of the file
 	ReadAndChecksum(header_buffer, 0);
 	MainHeader header = DeserializeHeaderStructure<MainHeader>(header_buffer.buffer);
-	db.SetCompatibilityVersion(char_ptr_cast(header.compatibility_git_desc));
+
+	// Database files <= 1.1.3 had nothing in the compatibility_git_desc field, that is equivalent to version 1
+	const idx_t DEFAULT_STORAGE_VERSION_FOR_EMPTY_DBS = 1;
+	db.SetCompatibilityVersion(char_ptr_cast(header.compatibility_git_desc), DEFAULT_STORAGE_VERSION_FOR_EMPTY_DBS);
 
 	// read the database headers from disk
 	DatabaseHeader h1;

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -36,9 +36,9 @@ void MainHeader::Write(WriteStream &ser) {
 	for (idx_t i = 0; i < FLAG_COUNT; i++) {
 		ser.Write<uint64_t>(flags[i]);
 	}
-	ser.WriteData(compatibility_git_desc, MainHeader::MAX_VERSION_SIZE);
-	SerializeVersionNumber(ser, DuckDB::SourceID());
 	SerializeVersionNumber(ser, DuckDB::LibraryVersion());
+	SerializeVersionNumber(ser, DuckDB::SourceID());
+	ser.WriteData(compatibility_git_desc, MainHeader::MAX_VERSION_SIZE);
 }
 
 void MainHeader::CheckMagicBytes(FileHandle &handle) {
@@ -87,9 +87,9 @@ MainHeader MainHeader::Read(ReadStream &source) {
 	for (idx_t i = 0; i < FLAG_COUNT; i++) {
 		header.flags[i] = source.Read<uint64_t>();
 	}
-	DeserializeVersionNumber(source, header.compatibility_git_desc);
 	DeserializeVersionNumber(source, header.library_git_desc);
 	DeserializeVersionNumber(source, header.library_git_hash);
+	DeserializeVersionNumber(source, header.compatibility_git_desc);
 	return header;
 }
 

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/checksum.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
@@ -35,8 +36,9 @@ void MainHeader::Write(WriteStream &ser) {
 	for (idx_t i = 0; i < FLAG_COUNT; i++) {
 		ser.Write<uint64_t>(flags[i]);
 	}
-	SerializeVersionNumber(ser, DuckDB::LibraryVersion());
+	ser.WriteData(compatibility_git_desc, MainHeader::MAX_VERSION_SIZE);
 	SerializeVersionNumber(ser, DuckDB::SourceID());
+	SerializeVersionNumber(ser, DuckDB::LibraryVersion());
 }
 
 void MainHeader::CheckMagicBytes(FileHandle &handle) {
@@ -85,6 +87,7 @@ MainHeader MainHeader::Read(ReadStream &source) {
 	for (idx_t i = 0; i < FLAG_COUNT; i++) {
 		header.flags[i] = source.Read<uint64_t>();
 	}
+	DeserializeVersionNumber(source, header.compatibility_git_desc);
 	DeserializeVersionNumber(source, header.library_git_desc);
 	DeserializeVersionNumber(source, header.library_git_hash);
 	return header;
@@ -178,6 +181,12 @@ void SingleFileBlockManager::CreateNewDatabase() {
 	header_buffer.Clear();
 
 	MainHeader main_header;
+
+	memset(main_header.compatibility_git_desc, 0, MainHeader::MAX_VERSION_SIZE);
+	string version_name = db.GetCompatibilityVersionName();
+	memcpy(main_header.compatibility_git_desc, version_name.c_str(),
+	       MinValue<idx_t>(version_name.size(), MainHeader::MAX_VERSION_SIZE));
+
 	main_header.version_number = VERSION_NUMBER;
 	memset(main_header.flags, 0, sizeof(uint64_t) * 4);
 
@@ -235,7 +244,8 @@ void SingleFileBlockManager::LoadExistingDatabase() {
 	MainHeader::CheckMagicBytes(*handle);
 	// otherwise, we check the metadata of the file
 	ReadAndChecksum(header_buffer, 0);
-	DeserializeHeaderStructure<MainHeader>(header_buffer.buffer);
+	MainHeader header = DeserializeHeaderStructure<MainHeader>(header_buffer.buffer);
+	db.SetCompatibilityVersion(char_ptr_cast(header.compatibility_git_desc));
 
 	// read the database headers from disk
 	DatabaseHeader h1;

--- a/src/storage/storage_info.cpp
+++ b/src/storage/storage_info.cpp
@@ -117,6 +117,15 @@ optional_idx GetSerializationVersion(const char *version_string) {
 	return optional_idx();
 }
 
+string GetSerializationVersionName(idx_t index) {
+	for (idx_t i = 0; serialization_version_info[i].version_name; i++) {
+		if (serialization_version_info[i].serialization_version == index) {
+			return serialization_version_info[i].version_name;
+		}
+	}
+	return "";
+}
+
 vector<string> GetSerializationCandidates() {
 	vector<string> candidates;
 	for (idx_t i = 0; serialization_version_info[i].version_name; i++) {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -139,7 +139,7 @@ void SingleFileStorageManager::LoadDatabase(StorageOptions storage_options) {
 	if (InMemory()) {
 		block_manager = make_uniq<InMemoryBlockManager>(BufferManager::GetBufferManager(db), DEFAULT_BLOCK_ALLOC_SIZE);
 		table_io_manager = make_uniq<SingleFileTableIOManager>(*block_manager, DEFAULT_ROW_GROUP_SIZE);
-		db.SetCompatibilityVersion("latest");
+		db.SetCompatibilityVersion(LATEST_SERIALIZATION_VERSION_INFO);
 		return;
 	}
 
@@ -193,8 +193,7 @@ void SingleFileStorageManager::LoadDatabase(StorageOptions storage_options) {
 		if (!storage_options.compatibility_version.empty()) {
 			compatibility_version = storage_options.compatibility_version;
 		}
-		// TODO fix handling for future version
-		db.SetCompatibilityVersion(compatibility_version);
+		db.SetCompatibilityVersion(compatibility_version, DEFAULT_SERIALIZATION_VERSION_INFO);
 
 		// Initialize the block manager before creating a new database.
 		auto sf_block_manager = make_uniq<SingleFileBlockManager>(db, path, options);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -188,8 +188,11 @@ void SingleFileStorageManager::LoadDatabase(StorageOptions storage_options) {
 			options.block_alloc_size = config.options.default_block_alloc_size;
 		}
 
+		// Set options from config
+		string compatibility_version = StorageCompatibilityVersionSetting::GetSetting(config);
+		db.SetCompatibilityVersion(compatibility_version);
+
 		// Initialize the block manager before creating a new database.
-		db.SetCompatibilityVersion(config.options.serialization_compatibility.duckdb_version.c_str());
 		auto sf_block_manager = make_uniq<SingleFileBlockManager>(db, path, options);
 		sf_block_manager->CreateNewDatabase();
 		block_manager = std::move(sf_block_manager);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -139,6 +139,7 @@ void SingleFileStorageManager::LoadDatabase(StorageOptions storage_options) {
 	if (InMemory()) {
 		block_manager = make_uniq<InMemoryBlockManager>(BufferManager::GetBufferManager(db), DEFAULT_BLOCK_ALLOC_SIZE);
 		table_io_manager = make_uniq<SingleFileTableIOManager>(*block_manager, DEFAULT_ROW_GROUP_SIZE);
+		db.SetCompatibilityVersion("latest");
 		return;
 	}
 
@@ -188,6 +189,7 @@ void SingleFileStorageManager::LoadDatabase(StorageOptions storage_options) {
 		}
 
 		// Initialize the block manager before creating a new database.
+		db.SetCompatibilityVersion(config.options.serialization_compatibility.duckdb_version.c_str());
 		auto sf_block_manager = make_uniq<SingleFileBlockManager>(db, path, options);
 		sf_block_manager->CreateNewDatabase();
 		block_manager = std::move(sf_block_manager);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -19,6 +19,10 @@
 
 namespace duckdb {
 
+static string StorageCompatibilityGetSettingHelper(const DBConfig &config) {
+	return config.options.serialization_compatibility.duckdb_version;
+}
+
 StorageManager::StorageManager(AttachedDatabase &db, string path_p, bool read_only)
     : db(db), path(std::move(path_p)), read_only(read_only) {
 
@@ -189,7 +193,7 @@ void SingleFileStorageManager::LoadDatabase(StorageOptions storage_options) {
 		}
 
 		// Set options from config
-		string compatibility_version = StorageCompatibilityVersionSetting::GetSetting(config);
+		string compatibility_version = StorageCompatibilityGetSettingHelper(config);
 		if (!storage_options.compatibility_version.empty()) {
 			compatibility_version = storage_options.compatibility_version;
 		}

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1019,7 +1019,7 @@ RowGroupPointer RowGroup::Checkpoint(RowGroupWriteData write_data, RowGroupWrite
 		// Just as above, the state can refer to many other states, so this
 		// can cascade recursively into more pointer writes.
 		auto persistent_data = state->ToPersistentData();
-		BinarySerializer serializer(data_writer);
+		BinarySerializer serializer(data_writer, SerializationOptions::From(GetCollection().GetAttached()));
 		serializer.Begin();
 		persistent_data.Serialize(serializer);
 		serializer.End();

--- a/src/verification/deserialized_statement_verifier.cpp
+++ b/src/verification/deserialized_statement_verifier.cpp
@@ -16,7 +16,8 @@ DeserializedStatementVerifier::Create(const SQLStatement &statement,
 
 	auto &select_stmt = statement.Cast<SelectStatement>();
 	MemoryStream stream;
-	BinarySerializer::Serialize(select_stmt, stream);
+	SerializationOptions s(SerializationOptions::Latest());
+	BinarySerializer::Serialize(select_stmt, stream, s);
 	stream.Rewind();
 	auto result = BinaryDeserializer::Deserialize<SelectStatement>(stream);
 

--- a/test/api/serialized_plans/test_plan_serialization_bwc.cpp
+++ b/test/api/serialized_plans/test_plan_serialization_bwc.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Generate serialized plans file", "[.][serialization]") {
 		planner.CreatePlan(std::move(p.statements[0]));
 		auto plan = std::move(planner.plan);
 
-		BinarySerializer serializer(target);
+		BinarySerializer serializer(target, SerializationOptions::DefaultOldestSupported());
 		serializer.Begin();
 		plan->Serialize(serializer);
 		serializer.End();

--- a/test/api/test_plan_serialization.cpp
+++ b/test/api/test_plan_serialization.cpp
@@ -36,7 +36,7 @@ static void test_helper(string sql, duckdb::vector<string> fixtures = duckdb::ve
 		plan = optimizer.Optimize(std::move(plan));
 
 		// LogicalOperator's copy utilizes its serialize and deserialize methods
-		auto new_plan = plan->Copy(*con.context);
+		auto new_plan = plan->Copy(*con.context, SerializationCompatibility::Default());
 
 		auto optimized_plan = optimizer.Optimize(std::move(new_plan));
 		con.context->transaction.Commit();
@@ -68,7 +68,7 @@ static void test_helper_multi_db(string sql, duckdb::vector<string> fixtures = d
 		plan = optimizer.Optimize(std::move(plan));
 
 		// LogicalOperator's copy utilizes its serialize and deserialize methods
-		auto new_plan = plan->Copy(*con.context);
+		auto new_plan = plan->Copy(*con.context, SerializationCompatibility::Default());
 
 		auto optimized_plan = optimizer.Optimize(std::move(new_plan));
 		con.context->transaction.Commit();

--- a/test/common/test_hyperlog.cpp
+++ b/test/common/test_hyperlog.cpp
@@ -56,8 +56,7 @@ TEST_CASE("Test that hyperloglog works", "[hyperloglog]") {
 
 TEST_CASE("Test different hyperloglog version serialization", "[hyperloglog]") {
 	MemoryStream stream;
-	SerializationOptions options;
-	options.serialization_compatibility = SerializationCompatibility::FromString("v1.0.0");
+	SerializationOptions options(SerializationOptions::From(SerializationCompatibility::FromString("v1.0.0")));
 
 	// Add 100M values to a NEW HyperLogLog
 	HyperLogLog original_log;

--- a/test/extension/loadable_extension_optimizer_demo.cpp
+++ b/test/extension/loadable_extension_optimizer_demo.cpp
@@ -102,7 +102,7 @@ public:
 		}
 
 		MemoryStream stream;
-		BinarySerializer serializer(stream);
+		BinarySerializer serializer(stream, SerializationOptions::DefaultOldestSupported());
 		serializer.Begin();
 		plan->Serialize(serializer);
 		serializer.End();

--- a/test/extension/test_remote_optimizer.cpp
+++ b/test/extension/test_remote_optimizer.cpp
@@ -106,7 +106,7 @@ TEST_CASE("Test using a remote optimizer pass in case thats important to someone
 			REQUIRE(write(connfd, &num_chunks, sizeof(idx_t)) == sizeof(idx_t));
 			for (auto &chunk : collection.Chunks()) {
 				MemoryStream target;
-				BinarySerializer serializer(target);
+				BinarySerializer serializer(target, SerializationOptions::DefaultOldestSupported());
 				serializer.Begin();
 				chunk.Serialize(serializer);
 				serializer.End();

--- a/test/serialize/serialization_test.cpp
+++ b/test/serialize/serialization_test.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Test default values", "[serialization]") {
 	foo_in.c = 44;
 
 	MemoryStream stream;
-	SerializationOptions options;
+	SerializationOptions options(SerializationOptions::DefaultOldestSupported());
 	options.serialize_default_values = false;
 	BinarySerializer::Serialize(foo_in, stream, options);
 	auto pos1 = stream.GetPosition();
@@ -167,7 +167,7 @@ TEST_CASE("Test deleted values", "[serialization]") {
 	FooV2 v2_in = {1, 3, make_uniq<Complex>(1, "foo"), nullptr};
 
 	MemoryStream stream;
-	SerializationOptions options;
+	SerializationOptions options(SerializationOptions::DefaultOldestSupported());
 	options.serialize_default_values = false;
 	// First of, sanity check that foov1 <-> foov1 works
 	BinarySerializer::Serialize(v1_in, stream, options);

--- a/test/sql/attach/attach_compatibility_version.test
+++ b/test/sql/attach/attach_compatibility_version.test
@@ -1,0 +1,73 @@
+# name: test/sql/attach/attach_compatibility_version.test
+# description: Tests attaching database files with different block allocation sizes.
+# group: [attach]
+
+require skip_reload
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH '__TEST_DIR__/version1_1_0.db' (COMPATIBILITY_VERSION 'v1.1.0');
+
+statement ok
+DETACH version1_1_0
+
+statement error
+ATTACH '__TEST_DIR__/version1_1_0.db' (COMPATIBILITY_VERSION 'v1.2.0');
+----
+Invalid Input Error: compatibility_version parameter does not match the file's compatibility_version
+
+# 1.0.0 and 1.1.3 have the same underlying version
+statement ok
+ATTACH '__TEST_DIR__/version1_1_0.db' (COMPATIBILITY_VERSION 'v1.1.3');
+
+statement ok
+DETACH version1_1_0
+
+statement ok
+ATTACH '__TEST_DIR__/version_default.db';
+
+statement ok
+DETACH version_default
+
+# 0.10.0 is the current default
+statement ok
+ATTACH '__TEST_DIR__/version_default.db' (COMPATIBILITY_VERSION 'v0.10.0');
+
+statement ok
+DETACH version_default
+
+# 0.10.0 is the current default, that has same version as 0.10.2
+statement ok
+ATTACH '__TEST_DIR__/version_default.db' (COMPATIBILITY_VERSION 'v0.10.2');
+
+statement ok
+DETACH version_default
+
+statement ok
+ATTACH '__TEST_DIR__/version_from_the_future.db' (COMPATIBILITY_VERSION 'v100.0.0');
+
+statement ok
+DETACH version_from_the_future
+
+# 1.2.0 is the current upcoming version
+statement ok
+ATTACH '__TEST_DIR__/version_from_the_future.db' (COMPATIBILITY_VERSION 'v1.2.0');
+
+statement ok
+ATTACH 'data/storage/block_size_16kb.db' (COMPATIBILITY_VERSION 'v0.10.0');
+
+statement ok
+DETACH block_size_16kb
+
+statement ok
+ATTACH 'data/storage/block_size_16kb.db' (COMPATIBILITY_VERSION 'v0.10.0');
+
+statement ok
+DETACH block_size_16kb
+
+statement error
+ATTACH 'data/storage/block_size_16kb.db' (COMPATIBILITY_VERSION 'v1.0.0');
+----
+Invalid Input Error: compatibility_version parameter does not match the file's compatibility_version

--- a/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
+++ b/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
@@ -2,7 +2,7 @@
 # group: [function]
 
 statement ok
-set storage_compatibility_version='latest'
+set storage_compatibility_version='v1.0.0'
 
 statement ok
 set enable_macro_dependencies=true

--- a/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
+++ b/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
@@ -1,6 +1,8 @@
 # name: test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
 # group: [function]
 
+require skip_reload
+
 statement ok
 set storage_compatibility_version='v1.0.0'
 

--- a/test/sql/catalog/view/recursive_view_with_dependencies.test
+++ b/test/sql/catalog/view/recursive_view_with_dependencies.test
@@ -3,7 +3,7 @@
 # group: [view]
 
 statement ok
-set storage_compatibility_version='latest'
+set storage_compatibility_version='v1.0.0'
 
 statement ok
 set enable_view_dependencies=true

--- a/test/sql/catalog/view/test_view_schema_change_with_dependencies.test
+++ b/test/sql/catalog/view/test_view_schema_change_with_dependencies.test
@@ -3,7 +3,7 @@
 # group: [view]
 
 statement ok
-set storage_compatibility_version='latest'
+set storage_compatibility_version='v1.0.0'
 
 statement ok
 set enable_view_dependencies=true

--- a/test/sql/catalog/view/test_view_schema_change_with_dependencies.test
+++ b/test/sql/catalog/view/test_view_schema_change_with_dependencies.test
@@ -2,6 +2,8 @@
 # description: Test views with changing schema
 # group: [view]
 
+require skip_reload
+
 statement ok
 set storage_compatibility_version='v1.0.0'
 

--- a/test/sql/catalog/view/test_view_sql_with_dependencies.test
+++ b/test/sql/catalog/view/test_view_sql_with_dependencies.test
@@ -3,7 +3,7 @@
 # group: [view]
 
 statement ok
-set storage_compatibility_version='latest'
+set storage_compatibility_version='v1.0.0'
 
 statement ok
 set enable_view_dependencies=true

--- a/test/sql/catalog/view/test_view_sql_with_dependencies.test
+++ b/test/sql/catalog/view/test_view_sql_with_dependencies.test
@@ -2,6 +2,8 @@
 # description: Test behavior of 'sql' on various different views
 # group: [view]
 
+require skip_reload
+
 statement ok
 set storage_compatibility_version='v1.0.0'
 

--- a/test/sql/copy/parquet/parquet_copy_type_mismatch.test
+++ b/test/sql/copy/parquet/parquet_copy_type_mismatch.test
@@ -8,7 +8,7 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-SET storage_compatibility_version='latest'
+SET storage_compatibility_version='v1.1.0'
 
 statement ok
 CREATE TABLE integers(i INTEGER);

--- a/test/sql/export/export_generated_columns.test
+++ b/test/sql/export/export_generated_columns.test
@@ -2,6 +2,8 @@
 # description: Test export of generated columns
 # group: [export]
 
+require skip_reload
+
 statement ok
 pragma storage_compatibility_version='v1.1.0'
 


### PR DESCRIPTION
This PR change the `serialization_compatibility_version` from being a setting set on every session to be written on creation in the database file (and so persisted across versions).

Basic example, works both in older and newer DuckDB versions:
```sql
ATTACH 'file1.db';
  --- write something, to be serialized targeting version v0.10.0
SET serialization_compatibility_version = 'v1.0.0';
ATTACH 'file2.db';
  --- write something, to be serialized targeting v1.0.0
```
But in older DuckDB versions the setting influenced how the file is written right now, with this PR this is persisted, example:
```
DETACH file2;
ATTACH 'file2.db';
  --- write something, to be serialized targeting v1.0.0 after this PR, v0.10.0 before this PR
```

There is also an ATTACH option:
```sql
ATTACH 'file3.db' (COMPATIBILITY_VERSION 'v1.1.0');
   --- file will target COMPATIBILITY_VERSION v1.1.0
```

Note that for a given DuckDB database file, compatibility_version is a property of the file itself that is only set on initialisation.

This PR should allow to convert database files, like:
```sql
ATTACH 'file_from_the_future.db'; --- assume there are some newer compression methods in this file
ATTACH 'compatible_file.db' (COMPATIBILITY_VERSION 'v1.0.0');
COPY DATABASE FROM file_from_the_future TO compatible_file;
```

Where `file_from_the_future.db` might support better encoding, `compatible_file.db` will contain the same actual logical content but encoded differently.

### Implementation details
* Serializer, and class derived from it, needs to initialize explicitly what's the target serialization they need to support. This is cumbersome, and might break extensions relying on old API, but I think it's better to require explicit serialization target
* The more relevant changes are:
   - in [src/storage/single_file_block_manager.cpp](https://github.com/duckdb/duckdb/compare/main...carlopi:duckdb:serialization_compatibility_to_db_option?expand=1#diff-2394eca9e55d311346da3ca2aa50864c3112279aa4b66f67145e55514a68d0a9) where there is the logic to read and write versions to the DuckDB database file
   - in [src/storage/storage_manager.cpp](https://github.com/duckdb/duckdb/compare/main...carlopi:duckdb:serialization_compatibility_to_db_option?expand=1#diff-e7011d3b462dceef33c2e4ac4cade5f4e69cabdd18eb3dc3c89b61d059deb9a3) where there is the logic that decides what compatibility_version to use, that is `latest` when in memory, the one from the DB file when opening an existing file, or the one either from the AttachOption or the setting when creating a new file

### Follow up:
* expose this to SQL, possibly by adding a tag so that it can be queried via `duckdb_databases()` 
* add switch on `compatibility_version` on whether to serialize ZSTD segments or other changes
* adding more tests
* adding more testing across DuckDB versions