### PR TITLE
[Swift.yml] Bump to macos-14, and switch simulation targets

### DIFF
--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -41,19 +41,19 @@ jobs:
     strategy:
       matrix:
         # destinations need to match selected version of Xcode
-        # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#installed-simulators
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#installed-simulators
         destination:
           - 'macOS'
-          - 'iOS Simulator,name=iPhone 14'
-          - 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
+          - 'iOS Simulator,name=iPhone 16'
+          - 'tvOS Simulator,name=Apple TV 4K (at 1080p) (3nd generation)'
         isRelease:
           - ${{ github.ref == 'refs/heads/main' }}
         exclude:
           - isRelease: false
-            destination: 'iOS Simulator,name=iPhone 14'
+            destination: 'iOS Simulator,name=iPhone 16'
           - isRelease: false
-            destination: 'tvOS Simulator,name=Apple TV 4K (at 1080p) (2nd generation)'
-    runs-on: macos-12
+            destination: 'tvOS Simulator,name=Apple TV 4K (at 1080p) (3nd generation)'
+    runs-on: macos-14
     steps:
 
       - name: Checkout
@@ -66,7 +66,7 @@ jobs:
         run: python3 tools/swift/create_package.py tools/swift
 
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_14.2.app && /usr/bin/xcodebuild -version
+        run: sudo xcode-select -switch /Applications/Xcode_15.4.app && /usr/bin/xcodebuild -version
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
Since a few hours Swift CI has been failing on all PRs, I think due to macos-12 being discontinued.

This fixed by bumping runner, toolchains and targets.