### PR TITLE
Rely on extension-ci-tools workflow to build linux_amd64_gcc4 extensions

### DIFF
--- a/.github/helper_makefile/build_all_extensions
+++ b/.github/helper_makefile/build_all_extensions
@@ -1,0 +1,16 @@
+PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Configuration to build all extensions
+# This is used in combination with extension-ci-tools to fake an extension that as as extension_config.cmake the content of
+# in-tree and out-of-tree configuration files.
+EXT_NAME=all_extensions
+EXT_CONFIG=${PROJ_DIR}extension_config.cmake
+
+# Include the Makefile from extension-ci-tools
+include extension-ci-tools/makefiles/duckdb_extension.Makefile
+
+configure_ci:
+	cd duckdb && BUILD_ALL_EXT=1 make extension_configuration && cp build/extension_configuration/vcpkg.json ../.
+
+test_release:
+	python3 duckdb/scripts/run_tests_one_by_one.py ./build/release/test/unittest

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -119,47 +119,100 @@ jobs:
    manylinux-extensions-x64:
     name: Linux Extensions (linux_amd64_gcc4)
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
+    strategy:
+      matrix:
+        duckdb_arch: [linux_amd64_gcc4]
+        vcpkg_triplet: [x64-linux]
     needs: linux-python3-9
+
     env:
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       GEN: ninja
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        ref: ${{ inputs.git_ref }}
+      - uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
-    - uses: ./.github/actions/manylinux_2014_setup
-      with:
-        aws-cli: 1
-        ninja-build: 1
-        ccache: 1
-        nodejs: 1
-        ssh: 1
-        python_alias: 1
-        openssl: 1
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: 'main'
+          repository: 'duckdb/extension-ci-tools'
+          fetch-depth: 0
 
-    - uses: ./.github/actions/build_extensions
-      with:
-        vcpkg_target_triplet: x64-linux
-        post_install: rm build/release/src/libduckdb*
-        deploy_as: linux_amd64_gcc4
-        s3_id: ${{ secrets.S3_ID }}
-        s3_key: ${{ secrets.S3_KEY }}
-        signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
-        run_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
-        run_autoload_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
-        treat_warn_as_error: 0
-        ninja: 1
+      - name: Populate composed extension
+        run: |
+          cat duckdb/.github/config/in_tree_extensions.cmake duckdb/.github/config/out_of_tree_extensions.cmake > extension_config.cmake
+          echo "{\"dependencies\": []}" > vcpkg.json
+          cp duckdb/.github/helper_makefile/build_all_extensions Makefile
 
-    - uses: actions/upload-artifact@v3
-      with:
-        name: manylinux-extensions-x64
-        path: |
-          build/release/extension/*/*.duckdb_extension
+
+      - name: Build Docker image
+        shell: bash
+        run: |
+          docker build \
+            --build-arg 'vcpkg_url=https://github.com/microsoft/vcpkg.git' \
+            --build-arg 'vcpkg_commit=a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' \
+            --build-arg 'extra_toolchains=;python3;' \
+            -t duckdb/${{ matrix.duckdb_arch }} \
+            ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
+
+      - name: Create env file for docker
+        run: |
+          touch docker_env.txt
+          echo "VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}" >> docker_env.txt 
+          echo "BUILD_SHELL=1" >> docker_env.txt
+          echo "OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
+          echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
+          echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
+          echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
+          echo "DUCKDB_GIT_VERSION=${{ inputs.override_git_describe }}" >> docker_env.txt
+          echo "LINUX_CI_IN_DOCKER=1" >> docker_env.txt
+          echo "TOOLCHAIN_FLAGS=''" >> docker_env.txt
+
+      - name: Generate timestamp for Ccache entry
+        shell: cmake -P {0}
+        id: ccache_timestamp
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: Create Ccache directory
+        run: |
+          mkdir ccache_dir
+
+      - name: Load Ccache
+        uses: actions/cache@v4
+        with:
+          path: ./ccache_dir
+          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+
+      - name: Run configure (inside Docker)
+        shell: bash
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make configure_ci
+
+      - name: Build extension (inside Docker)
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make release
+
+      - name: Test extension (inside docker)
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test_release
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: manylinux-extensions-x64
+          path: |
+            build/release/extension/*/*.duckdb_extension
 
    linux-python3:
     name: Python 3 Linux


### PR DESCRIPTION
Idea is instead of executing whole workflow job containerized, that means that actions will be run within the container, that in turn means it's hard to  use older images since they will not have the required dependecies versions for the actions (in particular node 20).

Solution is to containerize explicitly the relevant tests in the workflow, invoking actions outside of the container in the regular image that powers the workflow.

Heavy lifting has been done by @samansmink in https://github.com/duckdb/extension-ci-tools/pull/79 and connected PRs.

This PR allows to avoid the need for ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION in Python CI.