### PR TITLE
[Arrow] Fix scan of an object providing the PyCapsuleInterface when projection pushdown is possible.

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -475,9 +475,11 @@ ArrowTableFunction::ArrowScanInitLocalInternal(ClientContext &context, TableFunc
 	auto result = make_uniq<ArrowScanLocalState>(std::move(current_chunk));
 	result->column_ids = input.column_ids;
 	result->filters = input.filters.get();
-	if (!input.projection_ids.empty()) {
+	if (input.CanRemoveFilterColumns()) {
 		auto &asgs = global_state_p->Cast<ArrowScanGlobalState>();
 		result->all_columns.Initialize(context, asgs.scanned_types);
+	} else {
+		result->column_ids.clear();
 	}
 	if (!ArrowScanParallelStateNext(context, input.bind_data.get(), *result, global_state)) {
 		return nullptr;

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -1361,7 +1361,7 @@ void ArrowTableFunction::ArrowToDuckDB(ArrowScanLocalState &scan_state, const ar
 		}
 
 		D_ASSERT(arrow_convert_data.find(col_idx) != arrow_convert_data.end());
-		auto &arrow_type = *arrow_convert_data.at(idx);
+		auto &arrow_type = *arrow_convert_data.at(col_idx);
 		auto &array_state = scan_state.GetState(col_idx);
 
 		// Make sure this Vector keeps the Arrow chunk alive in case we can zero-copy the data

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -1340,7 +1340,7 @@ static void ColumnArrowToDuckDBDictionary(Vector &vector, ArrowArray &array, Arr
 void ArrowTableFunction::ArrowToDuckDB(ArrowScanLocalState &scan_state, const arrow_column_map_t &arrow_convert_data,
                                        DataChunk &output, idx_t start, bool arrow_scan_is_projected) {
 	for (idx_t idx = 0; idx < output.ColumnCount(); idx++) {
-		auto col_idx = scan_state.column_ids[idx];
+		auto col_idx = scan_state.column_ids.empty() ? idx : scan_state.column_ids[idx];
 
 		// If projection was not pushed down into the arrow scanner, but projection pushdown is enabled on the
 		// table function, we need to use original column ids here.
@@ -1361,7 +1361,7 @@ void ArrowTableFunction::ArrowToDuckDB(ArrowScanLocalState &scan_state, const ar
 		}
 
 		D_ASSERT(arrow_convert_data.find(col_idx) != arrow_convert_data.end());
-		auto &arrow_type = *arrow_convert_data.at(col_idx);
+		auto &arrow_type = *arrow_convert_data.at(idx);
 		auto &array_state = scan_state.GetState(col_idx);
 
 		// Make sure this Vector keeps the Arrow chunk alive in case we can zero-copy the data

--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -65,6 +65,8 @@ public:
 	shared_ptr<DependencyItem> dependency;
 	//! Arrow table data
 	ArrowTableType arrow_table;
+	//! Whether projection pushdown is enabled on the scan
+	bool projection_pushdown_enabled = true;
 };
 
 struct ArrowRunEndEncodingState {
@@ -184,6 +186,8 @@ public:
 	//! Binds an arrow table
 	static unique_ptr<FunctionData> ArrowScanBind(ClientContext &context, TableFunctionBindInput &input,
 	                                              vector<LogicalType> &return_types, vector<string> &names);
+	static unique_ptr<FunctionData> ArrowScanBindDumb(ClientContext &context, TableFunctionBindInput &input,
+	                                                  vector<LogicalType> &return_types, vector<string> &names);
 	//! Actual conversion from Arrow to DuckDB
 	static void ArrowToDuckDB(ArrowScanLocalState &scan_state, const arrow_column_map_t &arrow_convert_data,
 	                          DataChunk &output, idx_t start, bool arrow_scan_is_projected = true);

--- a/tools/pythonpkg/duckdb_extension_config.cmake
+++ b/tools/pythonpkg/duckdb_extension_config.cmake
@@ -7,7 +7,6 @@
 # CMakeLists.txt file with the `BUILD_PYTHON` variable.
 # TODO: unify this by making setup.py also use this configuration, making this the config for all python builds
 duckdb_extension_load(json)
-duckdb_extension_load(fts)
 duckdb_extension_load(tpcds)
 duckdb_extension_load(tpch)
 duckdb_extension_load(parquet)


### PR DESCRIPTION
This PR fixes #14980

We have no explicit support for scanning a single RecordBatch. Because the RecordBatch provides `__arrow_c_stream__` it gets scanned by using this.

To remove the reliance on pyarrow we disable the pushdowns for this scan, which caused a problem when projection pushdown *would* have been used by the regular `arrow_scan` table function.