### PR TITLE
[Arrow] Filter pushdown decimal fix

### DIFF
--- a/tools/pythonpkg/duckdb_extension_config.cmake
+++ b/tools/pythonpkg/duckdb_extension_config.cmake
@@ -7,7 +7,6 @@
 # CMakeLists.txt file with the `BUILD_PYTHON` variable.
 # TODO: unify this by making setup.py also use this configuration, making this the config for all python builds
 duckdb_extension_load(json)
-duckdb_extension_load(fts)
 duckdb_extension_load(tpcds)
 duckdb_extension_load(tpch)
 duckdb_extension_load(parquet)

--- a/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
@@ -276,25 +276,13 @@ py::object GetScalar(Value &constant, const string &timezone_config, const Arrow
 	case LogicalTypeId::BLOB:
 		return dataset_scalar(py::bytes(constant.GetValueUnsafe<string>()));
 	case LogicalTypeId::DECIMAL: {
-		py::object date_type = py::module_::import("pyarrow").attr("decimal128");
+		py::object decimal_type = py::module_::import("pyarrow").attr("decimal128");
 		uint8_t width;
 		uint8_t scale;
 		constant.type().GetDecimalProperties(width, scale);
-		switch (constant.type().InternalType()) {
-		case PhysicalType::INT16:
-			return dataset_scalar(scalar(constant.GetValue<int16_t>(), date_type(width, scale)));
-		case PhysicalType::INT32:
-			return dataset_scalar(scalar(constant.GetValue<int32_t>(), date_type(width, scale)));
-		case PhysicalType::INT64:
-			return dataset_scalar(scalar(constant.GetValue<int64_t>(), date_type(width, scale)));
-		default: {
-			auto hugeint_value = constant.GetValue<hugeint_t>();
-			auto hugeint_value_py = py::cast(hugeint_value.upper);
-			hugeint_value_py = hugeint_value_py.attr("__mul__")(NumericLimits<uint64_t>::Maximum());
-			hugeint_value_py = hugeint_value_py.attr("__add__")(hugeint_value.lower);
-			return dataset_scalar(scalar(hugeint_value_py, date_type(width, scale)));
-		}
-		}
+		// pyarrow only allows 'decimal.Decimal' to be used to construct decimal scalars such as 0.05
+		auto val = import_cache.decimal.Decimal()(constant.ToString());
+		return dataset_scalar(scalar(std::move(val), decimal_type(width, scale)));
 	}
 	default:
 		throw NotImplementedException("Unimplemented type \"%s\" for Arrow Filter Pushdown",


### PR DESCRIPTION
This PR fixes #14953

We have to go through `decimal.Decimal`, using the `int` path does not work for decimals below 1

i.e `pa.scalar(500, pa.decimal128(18, 4))` does not result in `0.05`