### PR TITLE
Fuzzer #3297: Nth Value Indexing

### DIFF
--- a/src/execution/window_executor.cpp
+++ b/src/execution/window_executor.cpp
@@ -2146,10 +2146,10 @@ void WindowNthValueExecutor::EvaluateInternal(WindowExecutorGlobalState &gstate,
 		}
 		// Returns value evaluated at the row that is the n'th row of the window frame (counting from 1);
 		// returns NULL if there is no such row.
-		if (nth_col.CellIsNull(row_idx)) {
+		if (nth_col.CellIsNull(i)) {
 			FlatVector::SetNull(result, i, true);
 		} else {
-			auto n_param = nth_col.GetCell<int64_t>(row_idx);
+			auto n_param = nth_col.GetCell<int64_t>(i);
 			if (n_param < 1) {
 				FlatVector::SetNull(result, i, true);
 			} else {

--- a/test/fuzzer/nthvalue_indexing.test
+++ b/test/fuzzer/nthvalue_indexing.test
@@ -1,0 +1,13 @@
+# name: test/fuzzer/nthvalue_indexing.test
+# description: Test partitions > chunk size
+# group: [fuzzer]
+
+require tpch
+
+statement ok
+call dbgen(sf=0.1);
+
+statement ok
+SELECT DISTINCT nth_value(NULL, (c2 IS NOT NULL)) OVER (PARTITION BY 1585 ROWS BETWEEN CURRENT ROW AND CURRENT ROW) 
+FROM part AS t10(c1, c2, c3, c4, c5, c6, c7, c8, c9) 
+ORDER BY * ASC NULLS LAST


### PR DESCRIPTION
Fix indexing problem triggered when the partition size is larger than the chunk size.

fixes: duckdb/duckdb-fuzzer#3297