### PR TITLE
Run containerized builds requiring deprecatd ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION only on main/feature

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -46,6 +46,7 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     container: ubuntu:18.04
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
 
     strategy:
       matrix:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -55,6 +55,7 @@ jobs:
     name: Linux (x64)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
       ENABLE_EXTENSION_AUTOLOADING: 1

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -187,6 +187,7 @@ jobs:
     needs: linux-memory-leaks
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
@@ -212,6 +213,7 @@ jobs:
     name: Linux (32 Bit)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
     needs: linux-memory-leaks
     env:
       CC: /usr/bin/gcc
@@ -284,6 +286,7 @@ jobs:
      runs-on: ubuntu-latest
      needs: linux-memory-leaks
      container: ubuntu:18.04
+     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
      env:
         GEN: ninja
         DUCKDEBUG: 1

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -120,6 +120,7 @@ jobs:
     name: Linux Extensions (linux_amd64_gcc4)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
     needs: linux-python3-9
     env:
       GEN: ninja


### PR DESCRIPTION
Idea for this PR is avoiding some noise in CI and the potential confusion to DuckDB contributors.

For additional context:
* Using `container:` implies all actions are run within a given containerized image
* for security & maintenance reasons, actions are required to use recent tooling
* eventually those tools (like node 20) will not be supported on images such as manylinux_2014

Solution is running the dockerized parts piece-by-piece, while interacting with actions at the `native` layer.

This has been worked on in the duckdb/extension-ci-tools repository, via https://github.com/duckdb/extension-ci-tools/pull/79 and subsequent PRs, now we need to port this to duckdb/duckdb.

This PR only avoid the noise in CI, given those workflow will fail without fix, I don't see much value in running them at all.

Proper fix to be rolled piece-by-piece, Python for example will be eventually solved via: https://github.com/duckdb/duckdb/pull/14987, where this part has then to be reverted.
