### PR TITLE
Internal #3574: INTERVAL Normlisation Carries

### DIFF
--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -166,18 +166,20 @@ public:
 	}
 };
 void interval_t::Normalize(int64_t &months, int64_t &days, int64_t &micros) const {
-	auto input = *this;
-	int64_t extra_months_d = input.days / Interval::DAYS_PER_MONTH;
-	int64_t extra_months_micros = input.micros / Interval::MICROS_PER_MONTH;
-	input.days -= UnsafeNumericCast<int32_t>(extra_months_d * Interval::DAYS_PER_MONTH);
-	input.micros -= extra_months_micros * Interval::MICROS_PER_MONTH;
+	auto &input = *this;
 
-	int64_t extra_days_micros = input.micros / Interval::MICROS_PER_DAY;
-	input.micros -= extra_days_micros * Interval::MICROS_PER_DAY;
-
-	months = input.months + extra_months_d + extra_months_micros;
-	days = input.days + extra_days_micros;
+	//  Carry left
 	micros = input.micros;
+	int64_t carry_days = micros / Interval::MICROS_PER_DAY;
+	micros -= carry_days * Interval::MICROS_PER_DAY;
+
+	days = input.days;
+	days += carry_days;
+	int64_t carry_months = days / Interval::DAYS_PER_MONTH;
+	days -= carry_months * Interval::DAYS_PER_MONTH;
+
+	months = input.months;
+	months += carry_months;
 }
 
 } // namespace duckdb

--- a/test/sql/types/interval/test_interval_comparison.test
+++ b/test/sql/types/interval/test_interval_comparison.test
@@ -46,3 +46,8 @@ SELECT INTERVAL '1' YEAR = INTERVAL '12' MONTH
 ----
 1
 
+# Double carry left
+query I
+select interval '28 days 432000 seconds' = interval '1 month 3 days';
+----
+True


### PR DESCRIPTION
Use "carry left" semantics for normalisation.

fixes: duckdb/duckdb-internal#3574