### PR TITLE
Fixup linux_arm64 extension builds

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -1,0 +1,191 @@
+name: "Build Extensions"
+description: "Build, test and deploy the DuckDB extensions"
+inputs:
+  # Test config
+  run_tests:
+    description: 'Run extension tests after build'
+    default: 1
+  run_autoload_tests:
+    description: 'Runs the autoloading tests'
+    default: 1
+
+  # Deploy config
+  deploy_as:
+    description: 'Binary architecture name for deploy step'
+    default: ''
+  deploy_version:
+    description: 'Version tag or commit short hash for deploy step'
+    default: ''
+  s3_id:
+    description: 'S3 key ID'
+    default: ''
+  s3_key:
+    description: 'S3 key secret'
+    default: ''
+  signing_pk:
+    description: 'Extension signing RSA private key'
+    default: ''
+
+  # Build config
+  duckdb_arch:
+    description: 'Provide DUCKDB_PLATFORM to build system for cross compilation'
+    default: ''
+  static_link_build:
+    description: 'Links DuckDB statically to the loadable extensions'
+    default: 1
+  no_static_linking:
+    description: 'Disables linking extensions into DuckDB for testing'
+    default: 0
+  vcpkg_build:
+    description: 'Installs vcpkg and pass its toolchain to CMakes'
+    default: 1
+  build_dir:
+    description: 'DuckDB source directory to run the build in'
+    default: '.'
+  ninja:
+    description: 'Use ninja for building'
+    default: 0
+  openssl_path:
+    description: 'Directory of OpenSSL installation'
+    default: ''
+  post_install:
+    description: 'Post-install scripts to run'
+    default: ''
+  treat_warn_as_error:
+    description: 'Treat compilation warnings as errors'
+    default: 1
+  build_in_tree_extensions:
+    description: 'Build in-tree extensions'
+    default: 1
+  build_out_of_tree_extensions:
+    description: 'Build out-of-tree extensions'
+    default: 1
+  osx_universal:
+    description: 'Build Universal Binary for OSX'
+    default: 0
+  osx_arch:
+    description: 'Build specific architecture for OSX'
+    default: ''
+  aarch64_cross_compile:
+    description: 'Enable Linux aarch64 cross-compiling'
+    default: 0
+  vcpkg_target_triplet:
+    description: 'Target triplet for installing vcpkg dependencies'
+    default: ''
+  override_cc:
+    description: 'Override C Compiler'
+    default: ''
+  override_cxx:
+    description: 'Override CXX Compiler'
+    default: ''
+  unittest_script:
+    description: 'Script/program to execute the unittests'
+    default: 'python3 scripts/run_tests_one_by_one.py ./build/release/test/unittest'
+  cmake_flags:
+    description: 'Flags to be passed to cmake'
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+      - uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: 'main'
+          repository: 'duckdb/extension-ci-tools'
+          fetch-depth: 0
+
+      - name: Populate composed extension
+        shell: bash
+        run: |
+          cat duckdb/.github/config/in_tree_extensions.cmake duckdb/.github/config/out_of_tree_extensions.cmake > extension_config.cmake
+          echo "{\"dependencies\": []}" > vcpkg.json
+          cp duckdb/.github/helper_makefile/build_all_extensions Makefile
+
+      - name: Build Docker image
+        shell: bash
+        run: |
+          docker build \
+            --build-arg 'vcpkg_url=https://github.com/microsoft/vcpkg.git' \
+            --build-arg 'vcpkg_commit=a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' \
+            --build-arg 'extra_toolchains=;python3;' \
+            -t duckdb/${{ inputs.duckdb_arch }} \
+            ./extension-ci-tools/docker/${{ inputs.duckdb_arch }}
+
+      - name: Create env file for docker
+        shell: bash
+        run: |
+          touch docker_env.txt
+          echo "VCPKG_TARGET_TRIPLET=${{ inputs.vcpkg_target_triplet }}" >> docker_env.txt 
+          echo "BUILD_SHELL=1" >> docker_env.txt
+          echo "OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ inputs.vcpkg_target_triplet }}" >> docker_env.txt
+          echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ inputs.vcpkg_target_triplet }}" >> docker_env.txt
+          echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
+          echo "DUCKDB_PLATFORM=${{ inputs.duckdb_arch }}" >> docker_env.txt
+          echo "DUCKDB_GIT_VERSION=${{ inputs.override_git_describe }}" >> docker_env.txt
+          echo "LINUX_CI_IN_DOCKER=1" >> docker_env.txt
+          echo "TOOLCHAIN_FLAGS=''" >> docker_env.txt
+
+      - name: Generate timestamp for Ccache entry
+        shell: cmake -P {0}
+        id: ccache_timestamp
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: Create Ccache directory
+        shell: bash
+        run: |
+          mkdir ccache_dir
+
+      - name: Load Ccache
+        uses: actions/cache@v4
+        with:
+          path: ./ccache_dir
+          key: ccache-extension-distribution-${{ inputs.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ccache-extension-distribution-${{ inputs.duckdb_arch }}-
+
+      - name: Run configure (inside Docker)
+        shell: bash
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ inputs.duckdb_arch }} make configure_ci
+
+      - name: Build extension (inside Docker)
+        shell: bash
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ inputs.duckdb_arch }} make release
+
+      - name: Test extension (inside docker)
+        shell: bash
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ inputs.duckdb_arch }} make test_release
+
+      - name: Deploy
+        if: ${{ inputs.deploy_as != '' }}
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ inputs.s3_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ inputs.s3_key }}
+          DUCKDB_EXTENSION_SIGNING_PK: ${{ inputs.signing_pk }}
+          AWS_DEFAULT_REGION: us-east-1
+          DUCKDB_DEPLOY_SCRIPT_MODE: for_real
+        run: |
+          cd  ${{ inputs.build_dir}}
+          if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+            if [[ ! -z "${{ inputs.deploy_version }}" ]] ; then
+              ./scripts/extension-upload-all.sh ${{ inputs.deploy_as }} ${{ inputs.deploy_version }}
+            elif [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
+              ./scripts/extension-upload-all.sh ${{ inputs.deploy_as }} ${{ github.ref_name }}
+            elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ ]] ; then
+              ./scripts/extension-upload-all.sh ${{ inputs.deploy_as }} `git log -1 --format=%h`
+            fi
+          fi
+

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -191,52 +191,92 @@ jobs:
     # Builds extensions for linux_amd64
     name: Linux Extensions (x64)
     runs-on: ubuntu-latest
-    container: ubuntu:18.04
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    strategy:
+      matrix:
+        duckdb_arch: [linux_amd64]
+        vcpkg_triplet: [x64-linux]
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        ref: ${{ inputs.git_ref }}
+      - uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
-    - uses: ./.github/actions/ubuntu_18_setup
-      with:
-        vcpkg: 1
-        openssl: 1
-        ccache: 1
-        git_ref: ${{ inputs.git_ref }}
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: 'main'
+          repository: 'duckdb/extension-ci-tools'
+          fetch-depth: 0
 
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
+      - name: Populate composed extension
+        run: |
+          cat duckdb/.github/config/in_tree_extensions.cmake duckdb/.github/config/out_of_tree_extensions.cmake > extension_config.cmake
+          echo "{\"dependencies\": []}" > vcpkg.json
+          cp duckdb/.github/helper_makefile/build_all_extensions Makefile
 
-    - name: Configure OpenSSL for Rust
-      run: |
-        echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/x64-linux" >> $GITHUB_ENV
-        echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/x64-linux" >> $GITHUB_ENV
-        echo "OPENSSL_INCLUDE_DIR=`pwd`/build/release/vcpkg_installed/x64-linux/include" >> $GITHUB_ENV
-        echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
+      - name: Build Docker image
+        shell: bash
+        run: |
+          docker build \
+            --build-arg 'vcpkg_url=https://github.com/microsoft/vcpkg.git' \
+            --build-arg 'vcpkg_commit=a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' \
+            --build-arg 'extra_toolchains=;python3;' \
+            -t duckdb/${{ matrix.duckdb_arch }} \
+            ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
-    - uses: ./.github/actions/build_extensions
-      with:
-        vcpkg_target_triplet: x64-linux
-        post_install: rm build/release/src/libduckdb*
-        deploy_as: linux_amd64
-        treat_warn_as_error: 0
-        run_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
-        run_autoload_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
-        s3_id: ${{ secrets.S3_ID }}
-        s3_key: ${{ secrets.S3_KEY }}
-        signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
-        ninja: 1
+      - name: Create env file for docker
+        run: |
+          touch docker_env.txt
+          echo "VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}" >> docker_env.txt 
+          echo "BUILD_SHELL=1" >> docker_env.txt
+          echo "OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
+          echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
+          echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
+          echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
+          echo "DUCKDB_GIT_VERSION=${{ inputs.override_git_describe }}" >> docker_env.txt
+          echo "LINUX_CI_IN_DOCKER=1" >> docker_env.txt
+          echo "TOOLCHAIN_FLAGS=''" >> docker_env.txt
 
-    - uses: actions/upload-artifact@v3
-      with:
-        name: linux-extensions-64
-        path: |
-          build/release/extension/*/*.duckdb_extension
+      - name: Generate timestamp for Ccache entry
+        shell: cmake -P {0}
+        id: ccache_timestamp
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: Create Ccache directory
+        run: |
+          mkdir ccache_dir
+
+      - name: Load Ccache
+        uses: actions/cache@v4
+        with:
+          path: ./ccache_dir
+          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+
+      - name: Run configure (inside Docker)
+        shell: bash
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make configure_ci
+
+      - name: Build extension (inside Docker)
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make release
+
+      - name: Test extension (inside docker)
+        run: |
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test_release
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: linux-extensions-64
+          path: |
+            build/release/extension/*/*.duckdb_extension
 
  linux-extensions-64-aarch64:
     # Builds extensions for linux_arm64

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -227,6 +227,8 @@ jobs:
     # Builds extensions for linux_arm64
     name: Linux Extensions (aarch64)
     runs-on: ubuntu-latest
+    needs: linux-extensions-64
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -55,6 +55,7 @@ jobs:
     name: Linux (x64)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
+    needs: linux-extensions-64
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
     env:
       EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
@@ -135,10 +136,10 @@ jobs:
  linux-release-aarch64:
    # Builds binaries for linux_arm64
    name: Linux (aarch64)
-   if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
    runs-on: ubuntu-latest
-   needs: linux-release-64
+   needs: linux-extensions-64
    container: ubuntu:18.04
+   if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
    env:
      EXTENSION_CONFIGS: '${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake'
      ENABLE_EXTENSION_AUTOLOADING: 1
@@ -191,7 +192,7 @@ jobs:
     name: Linux Extensions (x64)
     runs-on: ubuntu-latest
     container: ubuntu:18.04
-    needs: linux-release-64
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
@@ -240,10 +241,10 @@ jobs:
  linux-extensions-64-aarch64:
     # Builds extensions for linux_arm64
     name: Linux Extensions (aarch64)
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     container: ubuntu:18.04
-    needs: linux-release-64
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
+    needs: linux-extensions-64
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
@@ -367,7 +368,7 @@ jobs:
     name: Symbol Leakage
     if: ${{ inputs.skip_tests != 'true' }}
     runs-on: ubuntu-20.04
-    needs: linux-release-64
+    needs: linux-extensions-64
 
     steps:
     - uses: actions/checkout@v3
@@ -396,7 +397,7 @@ jobs:
  amalgamation-tests:
     name: Amalgamation Tests
     if: ${{ inputs.skip_tests != 'true' }}
-    needs: linux-release-64
+    needs: linux-extensions-64
     runs-on: ubuntu-20.04
     env:
       CC: clang
@@ -427,7 +428,8 @@ jobs:
     name: Linux (32 Bit)
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64
-    needs: linux-release-64
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
+    needs: linux-extensions-64
     env:
       CC: /usr/bin/gcc
       CXX: /usr/bin/g++

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -203,74 +203,19 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
-      - uses: actions/checkout@v4
-        name: Checkout Extension CI tools
+      - uses: ./duckdb/.github/actions/build_extensions_dockerized
         with:
-          path: 'extension-ci-tools'
-          ref: 'main'
-          repository: 'duckdb/extension-ci-tools'
-          fetch-depth: 0
-
-      - name: Populate composed extension
-        run: |
-          cat duckdb/.github/config/in_tree_extensions.cmake duckdb/.github/config/out_of_tree_extensions.cmake > extension_config.cmake
-          echo "{\"dependencies\": []}" > vcpkg.json
-          cp duckdb/.github/helper_makefile/build_all_extensions Makefile
-
-      - name: Build Docker image
-        shell: bash
-        run: |
-          docker build \
-            --build-arg 'vcpkg_url=https://github.com/microsoft/vcpkg.git' \
-            --build-arg 'vcpkg_commit=a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' \
-            --build-arg 'extra_toolchains=;python3;' \
-            -t duckdb/${{ matrix.duckdb_arch }} \
-            ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
-
-      - name: Create env file for docker
-        run: |
-          touch docker_env.txt
-          echo "VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}" >> docker_env.txt 
-          echo "BUILD_SHELL=1" >> docker_env.txt
-          echo "OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
-          echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
-          echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
-          echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
-          echo "DUCKDB_GIT_VERSION=${{ inputs.override_git_describe }}" >> docker_env.txt
-          echo "LINUX_CI_IN_DOCKER=1" >> docker_env.txt
-          echo "TOOLCHAIN_FLAGS=''" >> docker_env.txt
-
-      - name: Generate timestamp for Ccache entry
-        shell: cmake -P {0}
-        id: ccache_timestamp
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
-
-      - name: Create Ccache directory
-        run: |
-          mkdir ccache_dir
-
-      - name: Load Ccache
-        uses: actions/cache@v4
-        with:
-          path: ./ccache_dir
-          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
-
-      - name: Run configure (inside Docker)
-        shell: bash
-        run: |
-          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make configure_ci
-
-      - name: Build extension (inside Docker)
-        run: |
-          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make release
-
-      - name: Test extension (inside docker)
-        run: |
-          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test_release
+          vcpkg_target_triplet: x64-linux
+          deploy_as: linux_amd64
+          duckdb_arch: linux_amd64
+          treat_warn_as_error: 0
+          s3_id: ${{ secrets.S3_ID }}
+          s3_key: ${{ secrets.S3_KEY }}
+          signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
+          aarch64_cross_compile: 1
+          run_tests: 0 # Cannot run tests here due to cross-compiling
+          run_autoload_tests: 0
+          ninja: 1
 
       - uses: actions/upload-artifact@v3
         with:
@@ -282,39 +227,15 @@ jobs:
     # Builds extensions for linux_arm64
     name: Linux Extensions (aarch64)
     runs-on: ubuntu-latest
-    container: ubuntu:18.04
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
-    needs: linux-extensions-64
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - uses: actions/checkout@v3
         with:
+          path: 'duckdb'
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
-      - uses: ./.github/actions/ubuntu_18_setup
-        with:
-          vcpkg: 1
-          openssl: 1
-          aarch64_cross_compile: 1
-          ccache: 1
-          git_ref: ${{ inputs.git_ref }}
-
-      - name: Setup Rust for cross compilation
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-unknown-linux-gnu
-
-      - name: Configure OpenSSL for Rust
-        run: |
-          echo "OPENSSL_ROOT_DIR=`pwd`/build/release/vcpkg_installed/arm64-linux" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=`pwd`/build/release/vcpkg_installed/arm64-linux" >> $GITHUB_ENV
-          echo "OPENSSL_INCLUDE_DIR=`pwd`/build/release/vcpkg_installed/arm64-linux/include" >> $GITHUB_ENV
-          echo "OPENSSL_USE_STATIC_LIBS=true" >> $GITHUB_ENV
-
-      - uses: ./.github/actions/build_extensions
+      - uses: ./duckdb/.github/actions/build_extensions_dockerized
         with:
           vcpkg_target_triplet: arm64-linux
           deploy_as: linux_arm64

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -138,75 +138,19 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
 
-      - uses: actions/checkout@v4
-        name: Checkout Extension CI tools
+      - uses: ./duckdb/.github/actions/build_extensions_dockerized
         with:
-          path: 'extension-ci-tools'
-          ref: 'main'
-          repository: 'duckdb/extension-ci-tools'
-          fetch-depth: 0
-
-      - name: Populate composed extension
-        run: |
-          cat duckdb/.github/config/in_tree_extensions.cmake duckdb/.github/config/out_of_tree_extensions.cmake > extension_config.cmake
-          echo "{\"dependencies\": []}" > vcpkg.json
-          cp duckdb/.github/helper_makefile/build_all_extensions Makefile
-
-
-      - name: Build Docker image
-        shell: bash
-        run: |
-          docker build \
-            --build-arg 'vcpkg_url=https://github.com/microsoft/vcpkg.git' \
-            --build-arg 'vcpkg_commit=a1a1cbc975abf909a6c8985a6a2b8fe20bbd9bd6' \
-            --build-arg 'extra_toolchains=;python3;' \
-            -t duckdb/${{ matrix.duckdb_arch }} \
-            ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
-
-      - name: Create env file for docker
-        run: |
-          touch docker_env.txt
-          echo "VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}" >> docker_env.txt 
-          echo "BUILD_SHELL=1" >> docker_env.txt
-          echo "OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
-          echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_triplet }}" >> docker_env.txt
-          echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
-          echo "DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}" >> docker_env.txt
-          echo "DUCKDB_GIT_VERSION=${{ inputs.override_git_describe }}" >> docker_env.txt
-          echo "LINUX_CI_IN_DOCKER=1" >> docker_env.txt
-          echo "TOOLCHAIN_FLAGS=''" >> docker_env.txt
-
-      - name: Generate timestamp for Ccache entry
-        shell: cmake -P {0}
-        id: ccache_timestamp
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
-
-      - name: Create Ccache directory
-        run: |
-          mkdir ccache_dir
-
-      - name: Load Ccache
-        uses: actions/cache@v4
-        with:
-          path: ./ccache_dir
-          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ steps.ccache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
-
-      - name: Run configure (inside Docker)
-        shell: bash
-        run: |
-          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make configure_ci
-
-      - name: Build extension (inside Docker)
-        run: |
-          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make release
-
-      - name: Test extension (inside docker)
-        run: |
-          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make test_release
+          vcpkg_target_triplet: x64-linux
+          deploy_as: linux_amd64_gcc4
+          duckdb_arch: linux_amd64_gcc4
+          treat_warn_as_error: 0
+          s3_id: ${{ secrets.S3_ID }}
+          s3_key: ${{ secrets.S3_KEY }}
+          signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
+          aarch64_cross_compile: 1
+          run_tests: 0 # Cannot run tests here due to cross-compiling
+          run_autoload_tests: 0
+          ninja: 1
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Reworked into a separate action `build_extensions_dockerized/action.yml, using the same action for linux_arm_gcc4 (in the Python workflow), linux_arm64 (first step in the LinuxRelease workflow) and linux_amd64.

This latest one has a problem in handling spatial, that I think will be handled by bumping to the more recent spatial, to be done in a separate PR.

Also minor rework in inverting the dependencies for LinuxRelease.yml, that allows to cut time to discover problems.