### PR TITLE
Speed up scans of Uncompressed strings

### DIFF
--- a/src/include/duckdb/storage/checkpoint/string_checkpoint_state.hpp
+++ b/src/include/duckdb/storage/checkpoint/string_checkpoint_state.hpp
@@ -33,19 +33,6 @@ struct StringBlock {
 	unique_ptr<StringBlock> next;
 };
 
-struct string_location_t { // NOLINT
-	string_location_t(block_id_t block_id, int32_t offset) : block_id(block_id), offset(offset) {
-	}
-	string_location_t() {
-	}
-	bool IsValid(const idx_t block_size) {
-		auto cast_block_size = NumericCast<int32_t>(block_size);
-		return offset < cast_block_size && (block_id == INVALID_BLOCK || block_id >= MAXIMUM_BLOCK);
-	}
-	block_id_t block_id;
-	int32_t offset;
-};
-
 struct UncompressedStringSegmentState : public CompressedSegmentState {
 	~UncompressedStringSegmentState() override;
 

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -102,9 +102,10 @@ void UncompressedStringStorage::StringScanPartial(ColumnSegment &segment, Column
 
 	for (idx_t i = 0; i < scan_count; i++) {
 		// std::abs used since offsets can be negative to indicate big strings
-		auto string_length = UnsafeNumericCast<uint32_t>(std::abs(base_data[start + i]) - std::abs(previous_offset));
+		auto current_offset = base_data[start + i];
+		auto string_length = UnsafeNumericCast<uint32_t>(std::abs(current_offset) - std::abs(previous_offset));
 		result_data[result_offset + i] =
-		    FetchStringFromDict(segment, dict, result, baseptr, base_data[start + i], string_length);
+		    FetchStringFromDict(segment, dict, result, baseptr, current_offset, string_length);
 		previous_offset = base_data[start + i];
 	}
 }
@@ -146,7 +147,7 @@ void UncompressedStringStorage::StringFetchRow(ColumnSegment &segment, ColumnFet
 
 	auto dict_offset = base_data[row_id];
 	uint32_t string_length;
-	if ((idx_t)row_id == 0) {
+	if (DUCKDB_UNLIKELY(row_id == 0LL)) {
 		// edge case where this is the first string in the dict
 		string_length = NumericCast<uint32_t>(std::abs(dict_offset));
 	} else {
@@ -418,47 +419,6 @@ void UncompressedStringStorage::ReadStringMarker(data_ptr_t target, block_id_t &
 	memcpy(&block_id, target, sizeof(block_id_t));
 	target += sizeof(block_id_t);
 	memcpy(&offset, target, sizeof(int32_t));
-}
-
-string_location_t UncompressedStringStorage::FetchStringLocation(StringDictionaryContainer dict, data_ptr_t base_ptr,
-                                                                 int32_t dict_offset, const idx_t block_size) {
-	D_ASSERT(dict_offset + NumericCast<int32_t>(block_size) >= 0 && dict_offset <= NumericCast<int32_t>(block_size));
-	if (dict_offset >= 0) {
-		return string_location_t(INVALID_BLOCK, dict_offset);
-	}
-
-	string_location_t result;
-	ReadStringMarker(base_ptr + dict.end - NumericCast<idx_t>(-1 * dict_offset), result.block_id, result.offset);
-	return result;
-}
-
-string_t UncompressedStringStorage::FetchStringFromDict(ColumnSegment &segment, StringDictionaryContainer dict,
-                                                        Vector &result, data_ptr_t base_ptr, int32_t dict_offset,
-                                                        uint32_t string_length) {
-	// Fetch the base data.
-	auto block_size = segment.GetBlockManager().GetBlockSize();
-	D_ASSERT(dict_offset <= NumericCast<int32_t>(block_size));
-	string_location_t location = FetchStringLocation(dict, base_ptr, dict_offset, block_size);
-	return FetchString(segment, dict, result, base_ptr, location, string_length);
-}
-
-string_t UncompressedStringStorage::FetchString(ColumnSegment &segment, StringDictionaryContainer dict, Vector &result,
-                                                data_ptr_t base_ptr, string_location_t location,
-                                                uint32_t string_length) {
-	if (location.block_id != INVALID_BLOCK) {
-		// big string marker: read from separate block
-		return ReadOverflowString(segment, result, location.block_id, location.offset);
-	}
-	if (location.offset == 0) {
-		return string_t(nullptr, 0);
-	}
-
-	// normal string: read string from this block
-	auto dict_end = base_ptr + dict.end;
-	auto dict_pos = dict_end - location.offset;
-
-	auto str_ptr = char_ptr_cast(dict_pos);
-	return string_t(str_ptr, string_length);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This PR reworks the scan code of uncompressed strings, simplifying it and speeding it up.

Running the following query on a TPC-H SF10 database (in uncompressed format) leads to the following performance improvement:

```sql
select avg(strlen(l_comment)) from lineitem;
```

|  main  |  New  |
|--------|-------|
| 0.042s | 0.03s |
