### PR TITLE
Internal #3583: INGNORE NULLS Race

### DIFF
--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -118,8 +118,8 @@ public:
 	}
 
 	void Finalize(CollectionPtr collection) {
+		lock_guard<mutex> ignore_nulls_guard(lock);
 		if (child_idx != DConstants::INVALID_INDEX && executor.wexpr.ignore_nulls) {
-			lock_guard<mutex> ignore_nulls_guard(lock);
 			ignore_nulls = &collection->validities[child_idx];
 		}
 	}


### PR DESCRIPTION
Move the lock to prevent partial reads befroe the write is done.

fixes: duckdblabs/duckdb-internal#3583