### PR TITLE
[PySpark] - Add broadcast function

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/functions.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Callable, Union, overload, Optional, List, Tuple
+from typing import Any, Callable, Union, overload, Optional, List, Tuple, TYPE_CHECKING
 
 from duckdb import (
     CaseExpression,
@@ -10,6 +10,8 @@ from duckdb import (
     FunctionExpression,
     LambdaExpression
 )
+if TYPE_CHECKING:
+    from .dataframe import DataFrame
 
 from ..errors import PySparkTypeError
 from ..exception import ContributionsAcceptedError
@@ -6054,3 +6056,11 @@ def instr(str: "ColumnOrName", substr: str) -> Column:
     """
     return _invoke_function("instr", _to_column_expr(str), ConstantExpression(substr))
 
+def broadcast(df: "DataFrame") -> "DataFrame":
+    """
+    The broadcast function in Spark is used to optimize joins by broadcasting a smaller
+    dataset to all the worker nodes. However, DuckDB operates on a single-node architecture .
+    As a result, the function simply returns the input DataFrame without applying any modifications
+    or optimizations, since broadcasting is not applicable in the DuckDB context.
+    """
+    return df

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_dataframe.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_dataframe.py
@@ -1,0 +1,17 @@
+import pytest
+
+_ = pytest.importorskip("duckdb.experimental.spark")
+from spark_namespace.sql import functions as F
+
+
+class TestSparkFunctionsArray:
+    def test_boradcast(self, spark):
+        data = [
+            ([1, 2, 2], 2),
+            ([2, 4, 5], 3),
+        ]
+
+        df = spark.createDataFrame(data, ["firstColumn", "secondColumn"])
+        df_broadcast = F.broadcast(df)
+
+        assert df.collect() == df_broadcast.collect()

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_dataframe.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_dataframe.py
@@ -5,7 +5,7 @@ from spark_namespace.sql import functions as F
 
 
 class TestSparkFunctionsArray:
-    def test_boradcast(self, spark):
+    def test_broadcast(self, spark):
         data = [
             ([1, 2, 2], 2),
             ([2, 4, 5], 3),


### PR DESCRIPTION
This PR adds a broadcast function to maintain compatibility with the PySpark API in a DuckDB context.

The function simply returns the input DataFrame unchanged, as broadcasting is not applicable in DuckDB's single-node architecture.

This approach ensures API compliance but does not implement any actual optimizations.

I don't know if this is the best solution or if a warning should be added to clarify the no-op behavior.