### PR TITLE
Add SUM(BOOL) overload

### DIFF
--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -157,6 +157,12 @@ unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggreg
 
 AggregateFunction GetSumAggregate(PhysicalType type) {
 	switch (type) {
+	case PhysicalType::BOOL: {
+		auto function = AggregateFunction::UnaryAggregate<SumState<int64_t>, bool, hugeint_t, IntegerSumOperation>(
+		    LogicalType::BOOLEAN, LogicalType::HUGEINT);
+		function.order_dependent = AggregateOrderDependent::NOT_ORDER_DEPENDENT;
+		return function;
+	}
 	case PhysicalType::INT16: {
 		auto function = AggregateFunction::UnaryAggregate<SumState<int64_t>, int16_t, hugeint_t, IntegerSumOperation>(
 		    LogicalType::SMALLINT, LogicalType::HUGEINT);
@@ -209,6 +215,7 @@ AggregateFunctionSet SumFun::GetFunctions() {
 	sum.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
 	                                  nullptr, nullptr, FunctionNullHandling::DEFAULT_NULL_HANDLING, nullptr,
 	                                  BindDecimalSum));
+	sum.AddFunction(GetSumAggregate(PhysicalType::BOOL));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT16));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT32));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT64));

--- a/test/sql/aggregate/aggregates/test_aggregate_types.test
+++ b/test/sql/aggregate/aggregates/test_aggregate_types.test
@@ -162,9 +162,11 @@ NULL
 1
 1
 
-statement error
+query I
 SELECT SUM(b) FROM booleans GROUP BY g ORDER BY g
 ----
+0
+1
 
 statement error
 SELECT AVG(b) FROM booleans GROUP BY g ORDER BY g

--- a/test/sql/aggregate/aggregates/test_aggregate_types_scalar.test
+++ b/test/sql/aggregate/aggregates/test_aggregate_types_scalar.test
@@ -23,9 +23,10 @@ SELECT SUM(1), SUM(NULL), SUM(33.3)
 NULL
 33.3
 
-statement error
+query I
 SELECT SUM(True)
 ----
+1
 
 statement error
 SELECT SUM('hello')

--- a/test/sql/function/list/aggregates/sum_bool.test
+++ b/test/sql/function/list/aggregates/sum_bool.test
@@ -1,0 +1,17 @@
+# name: test/sql/function/list/aggregates/sum_bool.test
+# description: Test the SUM(bool)
+# group: [aggregates]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers SELECT CASE WHEN i%3=0 THEN NULL ELSE i END i FROM range(10000) t(i);
+
+query III
+SELECT SUM(i > 500), SUM(i=1), SUM(i IS NULL) FROM integers
+----
+6332	1	3334

--- a/test/sql/function/list/aggregates/types.test
+++ b/test/sql/function/list/aggregates/types.test
@@ -27,7 +27,7 @@ NULL
 endloop
 
 # any other result
-foreach func_name approx_count_distinct count entropy array_agg list histogram
+foreach func_name approx_count_distinct count entropy array_agg list histogram sum
 
 statement ok
 SELECT list_aggr([False], '${func_name}')
@@ -38,7 +38,7 @@ SELECT list_aggr([NULL::BOOLEAN], '${func_name}')
 endloop
 
 # statement error for BOOLEAN
-foreach func_name avg favg bit_and bit_or bit_xor kurtosis mad product sem skewness sum fsum sumKahan kahan_sum var_samp var_pop stddev stddev_pop variance stddev_samp
+foreach func_name avg favg bit_and bit_or bit_xor kurtosis mad product sem skewness fsum sumKahan kahan_sum var_samp var_pop stddev stddev_pop variance stddev_samp
 
 statement error
 SELECT list_aggr([False], '${func_name}')


### PR DESCRIPTION
This is a useful overload that allows the user to quickly count the amount of matches for a boolean condition, it is essentially syntactic sugar for:

```sql
SELECT SUM(CASE WHEN [cond] THEN 1 END) FROM tbl
```

As an added bonus, it is also slightly faster than the above expression:

```sql
SELECT SUM(l_extendedprice > 500) FROM lineitem;
-- 0.020s
SELECT SUM(CASE WHEN l_extendedprice > 500 THEN 1 END) FROM lineitem;
-- 0.028s
```