### PR TITLE
Flip OR filter comparison if constant is on the other side

### DIFF
--- a/test/sql/filter/test_or_pushdown.test
+++ b/test/sql/filter/test_or_pushdown.test
@@ -43,7 +43,18 @@ analyzed_plan	<REGEX>:.*TABLE_SCAN.*19360.*
 query II
 explain select * from t1 where a<5 or a>10;
 ----
-physical_plan	<REGEX>:.*optional.*
+physical_plan	<REGEX>:.*optional.*a<5.*a>10.*
+
+# need to flip the comparison
+query II
+explain select * from t1 where 5>a or 10<a;
+----
+physical_plan	<REGEX>:.*optional.*a<5.*a>10.*
+
+query II
+explain select * from t1 where 5>=a or 10<=a;
+----
+physical_plan	<REGEX>:.*optional.*a<=5.*a>=10.*
 
 query II
 explain select * from t1 where a in (1, 5, 10);


### PR DESCRIPTION
When the filter is `5 > a`, we need to rewrite it into `a < 5`. The current code (incorrectly) pushes `a > 5` instead.