### PR TITLE
Fix #15010: in map cast only access validity when child elements were not fully converted

### DIFF
--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -342,8 +342,8 @@ bool VectorStringToMap::StringToNestedTypeCastLoop(const string_t *source_data, 
 		vector_cast_data.all_converted = false;
 	}
 
-	auto &key_validity = FlatVector::Validity(result_key_child);
 	if (!vector_cast_data.all_converted) {
+		auto &key_validity = FlatVector::Validity(result_key_child);
 		for (idx_t row_idx = 0; row_idx < count; row_idx++) {
 			if (!result_mask.RowIsValid(row_idx)) {
 				continue;

--- a/test/fuzzer/afl/case_map_cast.test
+++ b/test/fuzzer/afl/case_map_cast.test
@@ -1,0 +1,7 @@
+# name: test/fuzzer/afl/case_map_cast.test
+# description: Test case with map
+# group: [afl]
+
+query I
+SELECT TRUE WHERE CASE MAP { } WHEN 'abc' [ ('any_string' IN (NULL::VARCHAR)): ] THEN TRUE END ;
+----


### PR DESCRIPTION
Fixes #15010 