### PR TITLE
Add `require ram` to test runner, and use to limit distinct_grouping_tpch.test

### DIFF
--- a/test/sql/aggregate/distinct/grouped/distinct_grouping_tpch.test_slow
+++ b/test/sql/aggregate/distinct/grouped/distinct_grouping_tpch.test_slow
@@ -3,7 +3,7 @@
 
 require tpch
 
-require ram 4gb
+require ram 8gb
 
 statement ok
 pragma enable_verification

--- a/test/sql/aggregate/distinct/grouped/distinct_grouping_tpch.test_slow
+++ b/test/sql/aggregate/distinct/grouped/distinct_grouping_tpch.test_slow
@@ -3,6 +3,8 @@
 
 require tpch
 
+require ram 4gb
+
 statement ok
 pragma enable_verification
 

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -374,6 +374,22 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 #endif
 	}
 
+	if (param == "ram") {
+		if (params.size() != 2) {
+			parser.Fail("require ram requires a parameter");
+		}
+		// require a minimum amount of ram
+		auto required_limit = DBConfig::ParseMemoryLimit(params[1]);
+		auto limit = FileSystem::GetAvailableMemory();
+		if (!limit.IsValid()) {
+			return RequireResult::MISSING;
+		}
+		if (limit.GetIndex() < required_limit) {
+			return RequireResult::MISSING;
+		}
+		return RequireResult::PRESENT;
+	}
+
 	if (param == "vector_size") {
 		if (params.size() != 2) {
 			parser.Fail("require vector_size requires a parameter");


### PR DESCRIPTION
This adds the following `require` syntax to the sqllogic test runner:

```sql
require ram 4gb
```

Certain Github Actions machines have a very limited amount of RAM and disk space available, leading to test failures (particularly in combination with `verify_external`).