### PR TITLE
CLI: Add -f [FILE] argument that allows execution of a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ unittest_release: release
 	build/release/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
 
 unittestci:
-	python3 scripts/run_tests_one_by_one.py build/debug/test/unittest
+	python3 scripts/run_tests_one_by_one.py build/debug/test/unittest --time_execution
 	build/debug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
 
 unittestarrow:

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4573,6 +4573,7 @@ static const char zOptions[] = "   -ascii               set output mode to 'asci
                                "   -c COMMAND           run \"COMMAND\" and exit\n"
                                "   -csv                 set output mode to 'csv'\n"
                                "   -echo                print commands before execution\n"
+                               "   -f FILENAME          read/process named file and exit\n"
                                "   -init FILENAME       read/process named file\n"
                                "   -[no]header          turn headers on or off\n"
                                "   -help                show this message\n"
@@ -4784,6 +4785,9 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			stdin_is_interactive = false;
 		} else if (strcmp(z, "-init") == 0) {
 			zInitFile = cmdline_option_value(argc, argv, ++i);
+		} else if (strcmp(z, "-f") == 0) {
+			zInitFile = cmdline_option_value(argc, argv, ++i);
+			stdin_is_interactive = false;
 		} else if (strcmp(z, "-batch") == 0) {
 			/* Need to check for batch mode here to so we can avoid printing
 			** informational messages (like from process_sqliterc) before
@@ -4857,6 +4861,9 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			z++;
 		}
 		if (strcmp(z, "-init") == 0) {
+			i++;
+		} else if (strcmp(z, "-f") == 0) {
+			readStdin = false;
 			i++;
 		} else if (strcmp(z, "-html") == 0) {
 			data.mode = RenderMode::HTML;

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4780,14 +4780,11 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 		if (strcmp(z, "-separator") == 0 || strcmp(z, "-nullvalue") == 0 || strcmp(z, "-newline") == 0 ||
 		    strcmp(z, "-cmd") == 0) {
 			(void)cmdline_option_value(argc, argv, ++i);
-		} else if (strcmp(z, "-c") == 0 || strcmp(z, "-s") == 0) {
+		} else if (strcmp(z, "-c") == 0 || strcmp(z, "-s") == 0 || strcmp(z, "-f") == 0) {
 			(void)cmdline_option_value(argc, argv, ++i);
 			stdin_is_interactive = false;
 		} else if (strcmp(z, "-init") == 0) {
 			zInitFile = cmdline_option_value(argc, argv, ++i);
-		} else if (strcmp(z, "-f") == 0) {
-			zInitFile = cmdline_option_value(argc, argv, ++i);
-			stdin_is_interactive = false;
 		} else if (strcmp(z, "-batch") == 0) {
 			/* Need to check for batch mode here to so we can avoid printing
 			** informational messages (like from process_sqliterc) before
@@ -4862,9 +4859,6 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 		}
 		if (strcmp(z, "-init") == 0) {
 			i++;
-		} else if (strcmp(z, "-f") == 0) {
-			readStdin = false;
-			i++;
 		} else if (strcmp(z, "-html") == 0) {
 			data.mode = RenderMode::HTML;
 		} else if (strcmp(z, "-list") == 0) {
@@ -4926,6 +4920,13 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			usage(1);
 		} else if (strcmp(z, "-no-stdin") == 0) {
 			readStdin = false;
+		} else if (strcmp(z, "-f") == 0) {
+			readStdin = false;
+			if (i == argc - 1) {
+				break;
+			}
+			z = cmdline_option_value(argc, argv, ++i);
+			data.ProcessDuckDBRC(z);
 		} else if (strcmp(z, "-cmd") == 0 || strcmp(z, "-c") == 0 || strcmp(z, "-s") == 0) {
 			if (strcmp(z, "-c") == 0 || strcmp(z, "-s") == 0) {
 				readStdin = false;
@@ -4934,8 +4935,9 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			** that simply appear on the command-line.  This seems goofy.  It would
 			** be better if all commands ran in the order that they appear.  But
 			** we retain the goofy behavior for historical compatibility. */
-			if (i == argc - 1)
+			if (i == argc - 1) {
 				break;
+			}
 			z = cmdline_option_value(argc, argv, ++i);
 			if (z[0] == '.') {
 				rc = data.DoMetaCommand(z);

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -304,6 +304,14 @@ def test_execute_file(shell, generated_file):
     result = test.run()
     result.check_stdout("42")
 
+@pytest.mark.parametrize('generated_file', ["insert into tbl values (42)"], indirect=True)
+def test_execute_files(shell, generated_file):
+    test = (
+        ShellTest(shell, ['-c', 'CREATE TABLE tbl(i INT)', '-f', generated_file.as_posix(), '-f', generated_file.as_posix(), '-c', 'SELECT SUM(i) FROM tbl'])
+    )
+    result = test.run()
+    result.check_stdout("84")
+
 def test_show_basic(shell):
     test = (
         ShellTest(shell)

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -296,6 +296,14 @@ def test_read(shell, generated_file):
     result = test.run()
     result.check_stdout("42")
 
+@pytest.mark.parametrize('generated_file', ["select 42"], indirect=True)
+def test_execute_file(shell, generated_file):
+    test = (
+        ShellTest(shell, ['-f', generated_file.as_posix()])
+    )
+    result = test.run()
+    result.check_stdout("42")
+
 def test_show_basic(shell):
     test = (
         ShellTest(shell)


### PR DESCRIPTION
Usage:

`duckdb -f [FILE]`

Similar to `-c`, but reads the commands from a file. 

Note that this seems similar to `-init [FILE]` at first glance as well, but there are several differences:
* `-f [FILE]` exits after it is done executing commands
* `-init [FILE]` replaces the reading of `~/.duckdbrc`, `-f` does not
* `-f [FILE]` can be executed multiple times
* `-f [FILE]` plays "nicely" with `-c` - commands are executed in the same order as they appear

For example:

```sql
echo 'create table tbl(i int);' > create.sql
echo 'insert into tbl values (42), (84);' > load.sql
duckdb -f create.sql -f load.sql -c "SELECT SUM(i) FROM tbl"
┌────────┐
│ sum(i) │
│ int128 │
├────────┤
│    126 │
└────────┘
```