### PR TITLE
max_temp_directory_size - print "90% of available disk space" as value if temp directory is not initialized

### DIFF
--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -919,7 +919,7 @@ Value MaxTempDirectorySizeSetting::GetSetting(const ClientContext &context) {
 		return Value(StringUtil::BytesToHumanReadableString(max_swap.GetIndex()));
 	} else {
 		// The temp directory has not been used yet
-		return Value(StringUtil::BytesToHumanReadableString(0));
+		return Value("90% of available disk space");
 	}
 }
 

--- a/test/sql/storage/temp_directory/max_swap_space_inmemory.test
+++ b/test/sql/storage/temp_directory/max_swap_space_inmemory.test
@@ -21,7 +21,7 @@ PRAGMA memory_limit='2MB'
 query I
 select current_setting('max_temp_directory_size')
 ----
-0 bytes
+90% of available disk space
 
 # Set the max size explicitly
 statement ok
@@ -39,7 +39,7 @@ reset max_temp_directory_size;
 query I
 select current_setting('max_temp_directory_size')
 ----
-0 bytes
+90% of available disk space
 
 # --- Set by default to the available disk space when temp_directory exists ---
 
@@ -50,7 +50,7 @@ set temp_directory = '__TEST_DIR__';
 query I
 select current_setting('max_temp_directory_size')
 ----
-0 bytes
+90% of available disk space
 
 # --- Set explicitly by the user ---
 
@@ -104,7 +104,7 @@ set temp_directory = '__TEST_DIR__/does_not_exist'
 query I
 select current_setting('max_temp_directory_size')
 ----
-0 bytes
+90% of available disk space
 
 statement ok
 CREATE TABLE t2 AS SELECT * FROM range(1000000);

--- a/test/sql/storage/temp_directory/max_swap_space_persistent.test
+++ b/test/sql/storage/temp_directory/max_swap_space_persistent.test
@@ -21,11 +21,11 @@ SET temp_directory='';
 statement ok
 PRAGMA memory_limit='2MB';
 
-# If the 'temp_directory' is not set, then this defaults to zero.
+# If the 'temp_directory' is not set, then this defaults to 90% of available disk space.
 query I
 SELECT current_setting('max_temp_directory_size');
 ----
-0 bytes
+90% of available disk space
 
 # Set the maximum size.
 statement ok
@@ -43,7 +43,7 @@ RESET max_temp_directory_size;
 query I
 SELECT current_setting('max_temp_directory_size');
 ----
-0 bytes
+90% of available disk space
 
 # The maximum size is by default set to the available disk space, if the temp_directory exists.
 statement ok
@@ -53,7 +53,7 @@ SET temp_directory = '__TEST_DIR__';
 query I
 SELECT current_setting('max_temp_directory_size');
 ----
-0 bytes
+90% of available disk space
 
 # If we set 'max_temp_directory_size', it cannot be overwritten.
 statement ok
@@ -102,7 +102,7 @@ SET temp_directory = '__TEST_DIR__/does_not_exist';
 query I
 SELECT current_setting('max_temp_directory_size');
 ----
-0 bytes
+90% of available disk space
 
 statement ok
 CREATE TABLE t2 AS SELECT * FROM range(1000000);


### PR DESCRIPTION
Alternative fix to https://github.com/duckdb/duckdb/pull/15055