### PR TITLE
Pushdown inequality filters

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -133,17 +133,6 @@ duckdb_extension_load(sqlsmith
         GIT_TAG d6d62c1cba6b1369ba79db4bff3c67f24aaa95c2
         )
 
-################# SUBSTRAIT
-if (NOT WIN32)
-    duckdb_extension_load(substrait
-            LOAD_TESTS DONT_LINK
-            GIT_URL https://github.com/duckdb/substrait
-            GIT_TAG be71387cf0a484dc7b261a0cb21abec0d0e0ce5c
-            APPLY_PATCHES
-            )
-endif()
-
-
 ################# VSS
 duckdb_extension_load(vss
         LOAD_TESTS

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1009,8 +1009,11 @@ static void ApplyFilter(Vector &v, TableFilter &filter, parquet_filter_t &filter
 		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
 			FilterOperationSwitch<GreaterThanEquals>(v, constant_filter.constant, filter_mask, count);
 			break;
+		case ExpressionType::COMPARE_NOTEQUAL:
+			FilterOperationSwitch<NotEquals>(v, constant_filter.constant, filter_mask, count);
+			break;
 		default:
-			D_ASSERT(0);
+			throw InternalException("Unsupported comparison for Parquet filter pushdown");
 		}
 		break;
 	}

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -486,7 +486,8 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
 			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
 			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_LESSTHAN ||
-			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO) &&
+			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO ||
+			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_NOTEQUAL) &&
 			    (TypeIsNumeric(constant_value.second[0].constant.type().InternalType()) ||
 			     constant_value.second[0].constant.type().InternalType() == PhysicalType::VARCHAR ||
 			     constant_value.second[0].constant.type().InternalType() == PhysicalType::BOOL)) {

--- a/test/optimizer/pushdown/pushdown_window_partition_filter.test
+++ b/test/optimizer/pushdown/pushdown_window_partition_filter.test
@@ -134,7 +134,7 @@ logical_opt	<REGEX>:.*FILTER.*WINDOW.*
 query II
 explain select * from window_no_filter where a != 'C' order by a;
 ----
-logical_opt	<REGEX>:.*WINDOW.*FILTER.*
+logical_opt	<REGEX>:.*WINDOW.*Filters.*
 
 statement ok
 create table t2 as select range a, range%50 b, range%25 c from range(500);


### PR DESCRIPTION
This PR extends the table filter pushdown to include inequality filters. The support had been mostly there but they have just not been generated by the optimizer. This enables row group pruning based on zonemaps and early-pruning of scans of vectors using inequality filters. As with any filter this is particularly effective when the filter is very selective.