### PR TITLE
CLI: Add .safe_mode as a dot command as well

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -2205,6 +2205,7 @@ static const char *azHelp[] = {
     ".quit                    Exit this program",
     ".read FILE               Read input from FILE",
     ".rows                    Row-wise rendering of query results (default)",
+    ".safe_mode               Enable safe-mode",
     ".schema ?PATTERN?        Show the CREATE statements matching PATTERN",
     "     Options:",
     "         --indent            Try to pretty-print the schema",
@@ -3178,6 +3179,15 @@ MetadataResult SetRowRendering(ShellState &state, const char **azArg, idx_t nArg
 	return MetadataResult::SUCCESS;
 }
 
+MetadataResult EnableSafeMode(ShellState &state, const char **azArg, idx_t nArg) {
+	safe_mode = true;
+	if (state.db) {
+		// db has been opened - disable external access
+		sqlite3_exec(state.db, "SET enable_external_access=false", NULL, NULL, NULL);
+	}
+	return MetadataResult::SUCCESS;
+}
+
 bool ShellState::SetOutputMode(const char *mode_str, const char *tbl_name) {
 	idx_t n2 = StringLength(mode_str);
 	char c2 = mode_str[0];
@@ -4118,6 +4128,7 @@ static const MetadataCommand metadata_commands[] = {
     {"rows", 1, SetRowRendering, "", "Row-wise rendering of query results (default)", 0},
     {"restore", 0, nullptr, "", "", 3},
     {"save", 0, nullptr, "?DB? FILE", "Backup DB (default \"main\") to FILE", 3},
+    {"safe_mode", 0, EnableSafeMode, "", "enable safe-mode", 0},
     {"separator", 0, SetSeparator, "COL ?ROW?", "Change the column and row separators", 0},
     {"schema", 0, DisplaySchemas, "?PATTERN?", "Show the CREATE statements matching PATTERN", 0},
     {"shell", 0, RunShellCommand, "CMD ARGS...", "Run CMD ARGS... in a system shell", 0},

--- a/tools/shell/tests/test_safe_mode.py
+++ b/tools/shell/tests/test_safe_mode.py
@@ -18,6 +18,18 @@ def test_safe_mode_command(shell, command):
     result.check_stderr('cannot be used in -safe mode')
 
 
+@pytest.mark.parametrize("param", [(".sh ls", 'cannot be used in -safe mode'), ("INSTALL extension", "Permission Error")])
+def test_safe_mode_dot_command(shell, param):
+    command = param[0]
+    expected_error = param[1]
+    test = (
+        ShellTest(shell)
+        .statement('.safe_mode')
+        .statement(command)
+    )
+    result = test.run()
+    result.check_stderr(expected_error)
+
 def test_safe_mode_database_basic(shell, random_filepath):
     test = (
         ShellTest(shell, [random_filepath, '-safe'])


### PR DESCRIPTION
See https://github.com/duckdb/duckdb/pull/14509, but as a dot command:

```sql
.safe_mode
ATTACH 'external_db.db';
-- Permission Error:
-- Cannot access file "external_db.db" - file system operations are disabled by configuration
```

This is useful because it allows us to do some initial setup (if desired) before enabling safe mode:

```sql
ATTACH 'permitted_db.db';
.safe_mode
-- we cannot attach new databases, but we can access permitted_db
```