### PR TITLE
Issue #15067: Postgres Age Compatibility

### DIFF
--- a/extension/core_functions/scalar/date/age.cpp
+++ b/extension/core_functions/scalar/date/age.cpp
@@ -5,17 +5,23 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
 
 namespace duckdb {
 
 static void AgeFunctionStandard(DataChunk &input, ExpressionState &state, Vector &result) {
 	D_ASSERT(input.ColumnCount() == 1);
-	auto current_timestamp = Timestamp::GetCurrentTimestamp();
+	//	Subtract argument from current_date (at midnight)
+	//	Theoretically, this should be TZ-sensitive, but since we have to be able to handle
+	//	plain TZ when ICU is not loaded, we implement this in UTC (like everything else)
+	//	To get the PG behaviour, we overload these functions in ICU for TSTZ arguments.
+	auto current_date = Timestamp::FromDatetime(
+	    Timestamp::GetDate(MetaTransaction::Get(state.GetContext()).start_timestamp), dtime_t(0));
 
 	UnaryExecutor::ExecuteWithNulls<timestamp_t, interval_t>(input.data[0], result, input.size(),
 	                                                         [&](timestamp_t input, ValidityMask &mask, idx_t idx) {
 		                                                         if (Timestamp::IsFinite(input)) {
-			                                                         return Interval::GetAge(current_timestamp, input);
+			                                                         return Interval::GetAge(current_date, input);
 		                                                         } else {
 			                                                         mask.SetInvalid(idx);
 			                                                         return interval_t();

--- a/extension/icu/icu-dateadd.cpp
+++ b/extension/icu/icu-dateadd.cpp
@@ -37,7 +37,7 @@ static inline void CalendarAddHour(icu::Calendar *calendar, int64_t interval_hou
 		while (interval_hour > 0) {
 			calendar->add(UCAL_HOUR,
 			              interval_hour > NumericLimits<int32_t>::Maximum() ? NumericLimits<int32_t>::Maximum()
-			                                                                : interval_hour,
+			                                                                : static_cast<int32_t>(interval_hour),
 			              status);
 			interval_hour -= NumericLimits<int32_t>::Maximum();
 		}
@@ -45,7 +45,7 @@ static inline void CalendarAddHour(icu::Calendar *calendar, int64_t interval_hou
 		while (interval_hour < 0) {
 			calendar->add(UCAL_HOUR,
 			              interval_hour < NumericLimits<int32_t>::Minimum() ? NumericLimits<int32_t>::Minimum()
-			                                                                : interval_hour,
+			                                                                : static_cast<int32_t>(interval_hour),
 			              status);
 			interval_hour -= NumericLimits<int32_t>::Minimum();
 		}
@@ -85,13 +85,13 @@ timestamp_t ICUCalendarAdd::Operation(timestamp_t timestamp, interval_t interval
 	// Break units apart to avoid overflow
 	auto interval_h = interval.micros / Interval::MICROS_PER_MSEC;
 
-	const auto interval_ms = interval_h % Interval::MSECS_PER_SEC;
+	const auto interval_ms = static_cast<int32_t>(interval_h % Interval::MSECS_PER_SEC);
 	interval_h /= Interval::MSECS_PER_SEC;
 
-	const auto interval_s = interval_h % Interval::SECS_PER_MINUTE;
+	const auto interval_s = static_cast<int32_t>(interval_h % Interval::SECS_PER_MINUTE);
 	interval_h /= Interval::SECS_PER_MINUTE;
 
-	const auto interval_m = interval_h % Interval::MINS_PER_HOUR;
+	const auto interval_m = static_cast<int32_t>(interval_h % Interval::MINS_PER_HOUR);
 	interval_h /= Interval::MINS_PER_HOUR;
 
 	if (interval.months < 0 || interval.days < 0 || interval.micros < 0) {
@@ -204,7 +204,9 @@ struct ICUDateAdd : public ICUDateFunc {
 		auto &info = func_expr.bind_info->Cast<BindData>();
 		CalendarPtr calendar(info.calendar->clone());
 
-		auto end_date = Timestamp::GetCurrentTimestamp();
+		//	Subtract argument from current_date (at midnight)
+		const auto end_date = CurrentMidnight(calendar.get(), state);
+
 		UnaryExecutor::Execute<TA, TR>(args.data[0], result, args.size(), [&](TA start_date) {
 			return OP::template Operation<timestamp_t, TA, TR>(end_date, start_date, calendar.get());
 		});

--- a/extension/icu/icu-datetrunc.cpp
+++ b/extension/icu/icu-datetrunc.cpp
@@ -224,6 +224,13 @@ ICUDateFunc::part_trunc_t ICUDateFunc::TruncationFactory(DatePartSpecifier type)
 	}
 }
 
+timestamp_t ICUDateFunc::CurrentMidnight(icu::Calendar *calendar, ExpressionState &state) {
+	const auto current_timestamp = MetaTransaction::Get(state.GetContext()).start_timestamp;
+	auto current_micros = SetTime(calendar, current_timestamp);
+	ICUDateTrunc::TruncDay(calendar, current_micros);
+	return GetTime(calendar);
+}
+
 void RegisterICUDateTruncFunctions(DatabaseInstance &db) {
 	ICUDateTrunc::AddBinaryTimestampFunction("date_trunc", db);
 	ICUDateTrunc::AddBinaryTimestampFunction("datetrunc", db);

--- a/extension/icu/include/icu-datefunc.hpp
+++ b/extension/icu/include/icu-datefunc.hpp
@@ -77,6 +77,7 @@ struct ICUDateFunc {
 	//! Truncates the calendar time to the given part precision
 	typedef void (*part_trunc_t)(icu::Calendar *calendar, uint64_t &micros);
 	static part_trunc_t TruncationFactory(DatePartSpecifier part);
+	static timestamp_t CurrentMidnight(icu::Calendar *calendar, ExpressionState &state);
 
 	//! Subtracts the two times at the given part precision
 	typedef int64_t (*part_sub_t)(icu::Calendar *calendar, timestamp_t start_date, timestamp_t end_date);


### PR DESCRIPTION
Fix the default argument in the single-argument AGE implementations to be current midnight, as per PG.

fixes: duckdb/duckdb#15067
fixes: duckdblabs/duckdb-internal#3603