### PR TITLE
IEJoin GetProgress: Normalize to 0-100

### DIFF
--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -903,7 +903,7 @@ public:
 		const auto r = MinValue(next_right.load(), right_outers.load());
 		const auto returned = completed.load() + l + r;
 
-		return count ? (double(returned) / double(count)) : -1;
+		return count ? (100.0 * double(returned) / double(count)) : -1;
 	}
 
 	const PhysicalIEJoin &op;


### PR DESCRIPTION
GetProgress is expected to be in the range 0-100 (or -1 for error cases), here was missing normalization.