### PR TITLE
Allow inputting a base hash in Regression workflow

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -2,10 +2,12 @@ name: Regression
 on:
   workflow_call:
     inputs:
-      base_hash: string
+      base_hash:
+        type: string
   workflow_dispatch:
     inputs:
-      base_hash: string
+      base_hash:
+        type: string
   repository_dispatch:
   push:
     branches:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -93,7 +93,7 @@ jobs:
           make
           cd ..
 
-      # For NightlyTest we fetch the last commit hash that successfully completed Regression on main
+      # For NightlyTest we fetch the last commit hash that ran Regression on main
       - name: Build Main and Previous Successful Regression Hash
         if: ${{ github.repository == 'duckdb/duckdb' && github.ref == 'refs/heads/main' }}
         shell: bash
@@ -102,7 +102,7 @@ jobs:
           git clone https://github.com/duckdb/duckdb.git
           cd duckdb
           if [[ -z "${BASE_HASH}" ]]; then
-            export CHECKOUT_HASH=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --status=success --json=headSha --limit=1 --jq '.[0].headSha')
+            export CHECKOUT_HASH=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --json=headSha --limit=1 --jq '.[0].headSha')
           else
             export CHECKOUT_HASH="$BASE_HASH"
           fi

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -1,6 +1,11 @@
 name: Regression
 on:
+  workflow_call:
+    inputs:
+      base_hash: string
   workflow_dispatch:
+    inputs:
+      base_hash: string
   repository_dispatch:
   push:
     branches:
@@ -33,6 +38,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref, '_feature') && 'feature' || 'main') }}
+  BASE_HASH: ${{ inputs.base_hash }}
 
 jobs:
   regression-test-benchmark-runner:
@@ -93,7 +99,12 @@ jobs:
           make
           git clone https://github.com/duckdb/duckdb.git
           cd duckdb
-          git checkout $(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --status=success --json=headSha --limit=1 --jq '.[0].headSha')
+          if [[ -z "${BASE_HASH}" ]]; then
+            export CHECKOUT_HASH=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --status=success --json=headSha --limit=1 --jq '.[0].headSha')
+          else
+            export CHECKOUT_HASH="$BASE_HASH"
+          fi
+          git checkout $CHECKOUT_HASH
           make
           cd ..
 
@@ -101,6 +112,12 @@ jobs:
         shell: bash
         run: |
           cp -r benchmark duckdb/
+
+      - name: Regression Test Fivetran
+        if: ${{ github.repository == 'duckdb/duckdb' && github.ref == 'refs/heads/main' }}
+        shell: bash
+        run: |
+          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks benchmark/fivetran/benchmark_list.csv --verbose --threads 2
 
       - name: Regression Test Micro
         if: always()
@@ -159,12 +176,6 @@ jobs:
           wget https://duckdb-blobs.s3.amazonaws.com/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
           cp duckdb_benchmark_data/real_nest.duckdb duckdb/duckdb_benchmark_data/real_nest.duckdb
           python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/realnest.csv --verbose --threads 2
-
-      - name: Regression Test Fivetran
-        if: ${{ github.repository == 'duckdb/duckdb' && github.ref == 'refs/heads/main' }}
-        shell: bash
-        run: |
-          python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks benchmark/fivetran/benchmark_list.csv --verbose --threads 2
 
   regression-test-storage:
     name: Storage Size Regression Test


### PR DESCRIPTION
Since #14973, our nightly no longer runs regressions against itself (always succeeding) but against the last successful nightly regression, now sometimes failing. This has caught a [CSV regression](https://github.com/duckdb/duckdb/actions/runs/12110544726/job/33761104729#step:17:228).

If we don't fix this regression, subsequent workflow runs will fail indefinitely. Sometimes, however, we want to accept regressions, for example, so the CSV reader can parse more timestamp types (at the cost of taking more time - at least, I think that's what's happening here). In such cases, we need to re-run the regression workflow against itself so that it succeeds.

This PR adds an input parameter to run the regression test against a specific DuckDB version. This would also allow us to run the current main against v.1.13.