### PR TITLE
Operator's GetProgress to return ProgressData instead of double

### DIFF
--- a/.github/patches/extensions/vss/progress_data.patch
+++ b/.github/patches/extensions/vss/progress_data.patch
@@ -1,0 +1,56 @@
+diff --git a/src/hnsw/hnsw_index_physical_create.cpp b/src/hnsw/hnsw_index_physical_create.cpp
+index 82ac33e..1130598 100644
+--- a/src/hnsw/hnsw_index_physical_create.cpp
++++ b/src/hnsw/hnsw_index_physical_create.cpp
+@@ -305,17 +305,21 @@ SinkFinalizeType PhysicalCreateHNSWIndex::Finalize(Pipeline &pipeline, Event &ev
+ 	return SinkFinalizeType::READY;
+ }
+ 
+-double PhysicalCreateHNSWIndex::GetSinkProgress(ClientContext &context, GlobalSinkState &gstate,
+-                                                double source_progress) const {
++ProgressData PhysicalCreateHNSWIndex::GetSinkProgress(ClientContext &context, GlobalSinkState &gstate,
++                                                ProgressData source_progress) const {
+ 	// The "source_progress" is not relevant for CREATE INDEX statements
++	ProgressData res;
++
+ 	const auto &state = gstate.Cast<CreateHNSWIndexGlobalState>();
+ 	// First half of the progress is appending to the collection
+ 	if (!state.is_building) {
+-		return 50.0 *
+-		       MinValue(1.0, static_cast<double>(state.loaded_count) / static_cast<double>(estimated_cardinality));
++		res.done = state.loaded_count + 0.0;
++		res.total = estimated_cardinality + estimated_cardinality;
++	} else {
++		res.done = state.loaded_count + state.built_count;
++		res.total = state.loaded_count + state.loaded_count;
+ 	}
+-	// Second half is actually building the index
+-	return 50.0 + (50.0 * static_cast<double>(state.built_count) / static_cast<double>(state.loaded_count));
++	return res;
+ }
+ 
+-} // namespace duckdb
+\ No newline at end of file
++} // namespace duckdb
+diff --git a/src/include/hnsw/hnsw_index_physical_create.hpp b/src/include/hnsw/hnsw_index_physical_create.hpp
+index b620831..069887c 100644
+--- a/src/include/hnsw/hnsw_index_physical_create.hpp
++++ b/src/include/hnsw/hnsw_index_physical_create.hpp
+@@ -1,5 +1,6 @@
+ #pragma once
+ #include "duckdb/execution/physical_operator.hpp"
++#include "duckdb/execution/progress_data.hpp"
+ #include "duckdb/storage/data_table.hpp"
+ 
+ namespace duckdb {
+@@ -52,7 +53,7 @@ public:
+ 		return true;
+ 	}
+ 
+-	double GetSinkProgress(ClientContext &context, GlobalSinkState &gstate, double source_progress) const override;
++	ProgressData GetSinkProgress(ClientContext &context, GlobalSinkState &gstate, ProgressData source_progress) const override;
+ };
+ 
+-} // namespace duckdb
+\ No newline at end of file
++} // namespace duckdb

--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -114,6 +114,9 @@ void ProgressBar::Update(bool final) {
 
 	double new_percentage = 0.0;
 	if (invalid_pipelines == 0 && progress.IsValid()) {
+		if (progress.total > 1e15) {
+			progress.Normalize(1e15);
+		}
 		query_progress.rows_processed = idx_t(progress.done);
 		query_progress.total_rows_to_process = idx_t(progress.total);
 		new_percentage = progress.ProgressDone() * 100;

--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -103,16 +103,13 @@ void ProgressBar::Update(bool final) {
 	if (!final && !supported) {
 		return;
 	}
-	double new_percentage = -1;
-	auto rows_processed = query_progress.rows_processed.load();
-	auto total_rows_to_process = query_progress.total_rows_to_process.load();
 
 	ProgressData progress;
 	idx_t invalid_pipelines = executor.GetPipelinesProgress(progress);
-	query_progress.rows_processed = progress.done;
-	query_progress.total_rows_to_process = progress.total;
+	query_progress.rows_processed = idx_t(progress.done);
+	query_progress.total_rows_to_process = idx_t(progress.total);
 
-	new_percentage = progress.ProgressDone() * 100;
+	double new_percentage = progress.ProgressDone() * 100;
 
 	if (!final && invalid_pipelines > 0) {
 		return;

--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -2,8 +2,6 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/common/progress_bar/display/terminal_progress_bar_display.hpp"
 
-#include <cmath>
-
 namespace duckdb {
 
 void QueryProgress::Initialize() {
@@ -117,11 +115,8 @@ void ProgressBar::Update(bool final) {
 	query_progress.total_rows_to_process = idx_t(progress.total);
 
 	double new_percentage = 0.0;
-	if (progress.total > 0 && invalid_pipelines == 0) {
+	if (invalid_pipelines == 0 && progress.IsValid()) {
 		new_percentage = progress.ProgressDone() * 100;
-		if (std::isnan(new_percentage)) {
-			new_percentage = 0.0;
-		}
 	}
 
 	if (!final && invalid_pipelines > 0) {

--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -111,11 +111,11 @@ void ProgressBar::Update(bool final) {
 
 	ProgressData progress;
 	idx_t invalid_pipelines = executor.GetPipelinesProgress(progress);
-	query_progress.rows_processed = idx_t(progress.done);
-	query_progress.total_rows_to_process = idx_t(progress.total);
 
 	double new_percentage = 0.0;
 	if (invalid_pipelines == 0 && progress.IsValid()) {
+		query_progress.rows_processed = idx_t(progress.done);
+		query_progress.total_rows_to_process = idx_t(progress.total);
 		new_percentage = progress.ProgressDone() * 100;
 	}
 

--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -119,8 +119,9 @@ void ProgressBar::Update(bool final) {
 	double new_percentage = 0.0;
 	if (progress.total > 0 && invalid_pipelines == 0) {
 		new_percentage = progress.ProgressDone() * 100;
-		if (std::isnan(new_percentage))
+		if (std::isnan(new_percentage)) {
 			new_percentage = 0.0;
+		}
 	}
 
 	if (!final && invalid_pipelines > 0) {

--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -109,7 +109,11 @@ void ProgressBar::Update(bool final) {
 	query_progress.rows_processed = idx_t(progress.done);
 	query_progress.total_rows_to_process = idx_t(progress.total);
 
-	double new_percentage = progress.ProgressDone() * 100;
+	double new_percentage = 0.0;
+	if (progress.total > 0) {
+		new_percentage = progress.ProgressDone() * 100;
+		if (isnan(new_percentage)) new_percentage = 0.0;
+	}
 
 	if (!final && invalid_pipelines > 0) {
 		return;

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -885,7 +885,7 @@ SourceResultType PhysicalHashAggregate::GetData(ExecutionContext &context, DataC
 	return chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
 }
 
-double PhysicalHashAggregate::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
+ProgressData PhysicalHashAggregate::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
 	auto &sink_gstate = sink_state->Cast<HashAggregateGlobalSinkState>();
 	auto &gstate = gstate_p.Cast<HashAggregateGlobalSourceState>();
 	ProgressData progress;
@@ -893,8 +893,7 @@ double PhysicalHashAggregate::GetProgress(ClientContext &context, GlobalSourceSt
 		progress.Add(groupings[radix_idx].table_data.GetProgress(
 		    context, *sink_gstate.grouping_states[radix_idx].table_state, *gstate.radix_states[radix_idx]));
 	}
-	// TODO: This is to keep current behaviour (to a point), where progress is normalize 0-100
-	return progress.ProgressDone() * 100.0;
+	return progress;
 }
 
 InsertionOrderPreservingMap<string> PhysicalHashAggregate::ParamsToString() const {

--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -888,12 +888,13 @@ SourceResultType PhysicalHashAggregate::GetData(ExecutionContext &context, DataC
 double PhysicalHashAggregate::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
 	auto &sink_gstate = sink_state->Cast<HashAggregateGlobalSinkState>();
 	auto &gstate = gstate_p.Cast<HashAggregateGlobalSourceState>();
-	double total_progress = 0;
+	ProgressData progress;
 	for (idx_t radix_idx = 0; radix_idx < groupings.size(); radix_idx++) {
-		total_progress += groupings[radix_idx].table_data.GetProgress(
-		    context, *sink_gstate.grouping_states[radix_idx].table_state, *gstate.radix_states[radix_idx]);
+		progress.Add(groupings[radix_idx].table_data.GetProgress(
+		    context, *sink_gstate.grouping_states[radix_idx].table_state, *gstate.radix_states[radix_idx]));
 	}
-	return total_progress / double(groupings.size());
+	// TODO: This is to keep current behaviour (to a point), where progress is normalize 0-100
+	return progress.ProgressDone() * 100.0;
 }
 
 InsertionOrderPreservingMap<string> PhysicalHashAggregate::ParamsToString() const {

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -940,8 +940,8 @@ ProgressData PhysicalWindow::GetProgress(ClientContext &context, GlobalSourceSta
 	const auto count = gsink.global_partition->count.load();
 	ProgressData res;
 	if (count) {
-		res.done = returned;
-		res.total = count;
+		res.done = double(returned);
+		res.total = double(count);
 	} else {
 		res.SetInvalid();
 	}

--- a/src/execution/operator/aggregate/physical_window.cpp
+++ b/src/execution/operator/aggregate/physical_window.cpp
@@ -932,13 +932,20 @@ OrderPreservationType PhysicalWindow::SourceOrder() const {
 	return OrderPreservationType::FIXED_ORDER;
 }
 
-double PhysicalWindow::GetProgress(ClientContext &context, GlobalSourceState &gsource_p) const {
+ProgressData PhysicalWindow::GetProgress(ClientContext &context, GlobalSourceState &gsource_p) const {
 	auto &gsource = gsource_p.Cast<WindowGlobalSourceState>();
 	const auto returned = gsource.returned.load();
 
 	auto &gsink = gsource.gsink;
 	const auto count = gsink.global_partition->count.load();
-	return count ? (double(returned) / double(count)) : -1;
+	ProgressData res;
+	if (count) {
+		res.done = returned;
+		res.total = count;
+	} else {
+		res.SetInvalid();
+	}
+	return res;
 }
 
 OperatorPartitionData PhysicalWindow::GetPartitionData(ExecutionContext &context, DataChunk &chunk,

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -1310,7 +1310,7 @@ ProgressData PhysicalHashJoin::GetProgress(ClientContext &context, GlobalSourceS
 
 	auto num_partitions = static_cast<double>(RadixPartitioning::NumberOfPartitions(sink.hash_table->GetRadixBits()));
 	auto partition_start = static_cast<double>(sink.hash_table->GetPartitionStart());
-	auto partition_end = static_cast<double>(sink.hash_table->GetPartitionEnd());
+	// auto partition_end = static_cast<double>(sink.hash_table->GetPartitionEnd());
 
 	// This many partitions are fully done
 	res.done = partition_start;

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -889,7 +889,7 @@ public:
 		GetNextPair(client, lstate);
 	}
 
-	double GetProgress() const {
+	ProgressData GetProgress() const {
 		auto &left_table = *gsink.tables[0];
 		auto &right_table = *gsink.tables[1];
 
@@ -903,7 +903,14 @@ public:
 		const auto r = MinValue(next_right.load(), right_outers.load());
 		const auto returned = completed.load() + l + r;
 
-		return count ? (100.0 * double(returned) / double(count)) : -1;
+		ProgressData res;
+		if (count) {
+			res.done = double(returned);
+			res.total = double(count);
+		} else {
+			res.SetInvalid();
+		}
+		return res;
 	}
 
 	const PhysicalIEJoin &op;
@@ -937,7 +944,7 @@ unique_ptr<LocalSourceState> PhysicalIEJoin::GetLocalSourceState(ExecutionContex
 	return make_uniq<IEJoinLocalSourceState>(context.client, *this);
 }
 
-double PhysicalIEJoin::GetProgress(ClientContext &context, GlobalSourceState &gsource_p) const {
+ProgressData PhysicalIEJoin::GetProgress(ClientContext &context, GlobalSourceState &gsource_p) const {
 	auto &gsource = gsource_p.Cast<IEJoinGlobalSourceState>();
 	return gsource.GetProgress();
 }

--- a/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/src/execution/operator/scan/physical_positional_scan.cpp
@@ -119,7 +119,7 @@ public:
 		return source.ColumnCount();
 	}
 
-	double GetProgress(ClientContext &context) {
+	ProgressData GetProgress(ClientContext &context) {
 		return table.GetProgress(context, global_state);
 	}
 
@@ -179,15 +179,16 @@ SourceResultType PhysicalPositionalScan::GetData(ExecutionContext &context, Data
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 
-double PhysicalPositionalScan::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
+ProgressData PhysicalPositionalScan::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
 	auto &gstate = gstate_p.Cast<PositionalScanGlobalSourceState>();
 
-	double result = child_tables[0]->GetProgress(context, *gstate.global_states[0]);
-	for (size_t t = 1; t < child_tables.size(); ++t) {
-		result = MinValue(result, child_tables[t]->GetProgress(context, *gstate.global_states[t]));
+	ProgressData res;
+
+	for (size_t t = 0; t < child_tables.size(); ++t) {
+		res.Add(child_tables[t]->GetProgress(context, *gstate.global_states[t]));
 	}
 
-	return result;
+	return res;
 }
 
 bool PhysicalPositionalScan::Equals(const PhysicalOperator &other_p) const {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -112,13 +112,19 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 	return chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;
 }
 
-double PhysicalTableScan::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
+ProgressData PhysicalTableScan::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
 	auto &gstate = gstate_p.Cast<TableScanGlobalSourceState>();
+	ProgressData res;
 	if (function.table_scan_progress) {
-		return function.table_scan_progress(context, bind_data.get(), gstate.global_state.get());
+		res.done = function.table_scan_progress(context, bind_data.get(), gstate.global_state.get());
+		res.total = 100;
+
+		res.Normalize(1e3);
+	} else {
+		// if table_scan_progress is not implemented we don't support this function yet in the progress bar
+		res.SetInvalid();
 	}
-	// if table_scan_progress is not implemented we don't support this function yet in the progress bar
-	return -1;
+	return res;
 }
 
 bool PhysicalTableScan::SupportsPartitioning(const OperatorPartitionInfo &partition_info) const {

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -116,10 +116,15 @@ ProgressData PhysicalTableScan::GetProgress(ClientContext &context, GlobalSource
 	auto &gstate = gstate_p.Cast<TableScanGlobalSourceState>();
 	ProgressData res;
 	if (function.table_scan_progress) {
-		res.done = function.table_scan_progress(context, bind_data.get(), gstate.global_state.get());
-		res.total = 100;
-
-		res.Normalize(1e3);
+		double table_progress = function.table_scan_progress(context, bind_data.get(), gstate.global_state.get());
+		if (table_progress < 0.0) {
+			res.SetInvalid();
+		} else {
+			res.done = table_progress;
+			res.total = 100.0;
+			// Assume cardinality is always 1e3
+			res.Normalize(1e3);
+		}
 	} else {
 		// if table_scan_progress is not implemented we don't support this function yet in the progress bar
 		res.SetInvalid();

--- a/src/execution/physical_operator.cpp
+++ b/src/execution/physical_operator.cpp
@@ -122,8 +122,10 @@ OperatorPartitionData PhysicalOperator::GetPartitionData(ExecutionContext &conte
 	throw InternalException("Calling GetPartitionData on a node that does not support it");
 }
 
-double PhysicalOperator::GetProgress(ClientContext &context, GlobalSourceState &gstate) const {
-	return -1;
+ProgressData PhysicalOperator::GetProgress(ClientContext &context, GlobalSourceState &gstate) const {
+	ProgressData res;
+	res.SetInvalid();
+	return res;
 }
 // LCOV_EXCL_STOP
 

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -913,25 +913,24 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 	}
 }
 
-double RadixPartitionedHashTable::GetProgress(ClientContext &, GlobalSinkState &sink_p,
-                                              GlobalSourceState &gstate_p) const {
+ProgressData RadixPartitionedHashTable::GetProgress(ClientContext &, GlobalSinkState &sink_p,
+                                                    GlobalSourceState &gstate_p) const {
 	auto &sink = sink_p.Cast<RadixHTGlobalSinkState>();
 	auto &gstate = gstate_p.Cast<RadixHTGlobalSourceState>();
 
 	// Get partition combine progress, weigh it 2x
-	double total_progress = 0;
+	ProgressData progress;
 	for (auto &partition : sink.partitions) {
-		total_progress += 2.0 * partition->progress;
+		progress.done += 2.0 * partition->progress;
 	}
 
 	// Get scan progress, weigh it 1x
-	total_progress += 1.0 * double(gstate.task_done);
+	progress.done += 1.0 * double(gstate.task_done);
 
 	// Divide by 3x for the weights, and the number of partitions to get a value between 0 and 1 again
-	total_progress /= 3.0 * double(sink.partitions.size());
+	progress.total += 3.0 * double(sink.partitions.size());
 
-	// Multiply by 100 to get a percentage
-	return 100.0 * total_progress;
+	return progress;
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/execution/task_error_manager.hpp"
+#include "duckdb/execution/progress_data.hpp"
 #include "duckdb/parallel/pipeline.hpp"
 
 #include <condition_variable>
@@ -86,7 +87,7 @@ public:
 	void AddToBeRescheduled(shared_ptr<Task> &task);
 
 	//! Returns the progress of the pipelines
-	bool GetPipelinesProgress(double &current_progress, uint64_t &current_cardinality, uint64_t &total_cardinality);
+	idx_t GetPipelinesProgress(ProgressData &progress);
 
 	void CompletePipeline() {
 		completed_pipelines++;

--- a/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp
@@ -93,7 +93,7 @@ public:
 	                                                 GlobalSourceState &gstate) const override;
 	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override;
 
-	double GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
+	ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
 
 	bool IsSource() const override {
 		return true;

--- a/src/include/duckdb/execution/operator/aggregate/physical_window.hpp
+++ b/src/include/duckdb/execution/operator/aggregate/physical_window.hpp
@@ -51,7 +51,7 @@ public:
 	bool SupportsPartitioning(const OperatorPartitionInfo &partition_info) const override;
 	OrderPreservationType SourceOrder() const override;
 
-	double GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const override;
+	ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const override;
 
 public:
 	// Sink interface

--- a/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -76,7 +76,7 @@ protected:
 	                                                 GlobalSourceState &gstate) const override;
 	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override;
 
-	double GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
+	ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
 
 	//! Becomes a source when it is an external join
 	bool IsSource() const override {

--- a/src/include/duckdb/execution/operator/join/physical_iejoin.hpp
+++ b/src/include/duckdb/execution/operator/join/physical_iejoin.hpp
@@ -46,7 +46,7 @@ public:
 		return true;
 	}
 
-	double GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const override;
+	ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const override;
 
 public:
 	// Sink Interface

--- a/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
@@ -38,7 +38,7 @@ public:
 	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
 	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override;
 
-	double GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
+	ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
 
 	bool IsSource() const override {
 		return true;

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -73,7 +73,7 @@ public:
 
 	bool SupportsPartitioning(const OperatorPartitionInfo &partition_info) const override;
 
-	double GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
+	ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/enums/explain_format.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/execution/execution_context.hpp"
+#include "duckdb/execution/progress_data.hpp"
 #include "duckdb/optimizer/join_order/join_node.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/execution/physical_operator_states.hpp"
@@ -139,10 +140,11 @@ public:
 	}
 
 	//! Returns the current progress percentage, or a negative value if progress bars are not supported
-	virtual double GetProgress(ClientContext &context, GlobalSourceState &gstate) const;
+	virtual ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate) const;
 
 	//! Returns the current progress percentage, or a negative value if progress bars are not supported
-	virtual double GetSinkProgress(ClientContext &context, GlobalSinkState &gstate, double source_progress) const {
+	virtual ProgressData GetSinkProgress(ClientContext &context, GlobalSinkState &gstate,
+	                                     const ProgressData source_progress) const {
 		return source_progress;
 	}
 

--- a/src/include/duckdb/execution/progress_data.hpp
+++ b/src/include/duckdb/execution/progress_data.hpp
@@ -15,7 +15,11 @@ namespace duckdb {
 struct ProgressData {
 	double done = 0.0;
 	double total = 0.0;
+	bool invalid = false;
 	double ProgressDone() const {
+		if (invalid) {
+			return -1.0;
+		}
 		if (total <= 0.0) {
 			D_ASSERT(total > 0.0);
 			return 0.0;
@@ -39,12 +43,19 @@ struct ProgressData {
 		if (total <= 0.0) {
 			D_ASSERT(total > 0.0);
 		}
-	
 		done /= total;
 		total = 1.0;
 		done *= target;
 		total *= target;
 	}
+	void SetInvalid() {
+		invalid = true;
+		done = 0.0;
+		total = 1.0;
+	}
+	bool IsValid() const {
+		return !invalid;
+	}
 };
 
-}
+} // namespace duckdb

--- a/src/include/duckdb/execution/progress_data.hpp
+++ b/src/include/duckdb/execution/progress_data.hpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/progress_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/assert.hpp"
+
+namespace duckdb {
+
+struct ProgressData {
+	double done = 0.0;
+	double total = 0.0;
+	double ProgressDone() const {
+		if (total <= 0.0) {
+			D_ASSERT(total > 0.0);
+			return 0.0;
+		}
+		if (done <= 0.0) {
+			D_ASSERT(done >= 0.0);
+			return 0.0;
+		}
+		if (done > total) {
+			D_ASSERT(done <= total);
+			return 1.0;
+		}
+		return done / total;
+	}
+	void Add(const ProgressData &other) {
+		done += other.done;
+		total += other.total;
+	}
+	void Normalize(const double target = 1.0) {
+		D_ASSERT(target > 0.0);
+		if (total <= 0.0) {
+			D_ASSERT(total > 0.0);
+		}
+	
+		done /= total;
+		total = 1.0;
+		done *= target;
+		total *= target;
+	}
+};
+
+}

--- a/src/include/duckdb/execution/progress_data.hpp
+++ b/src/include/duckdb/execution/progress_data.hpp
@@ -48,7 +48,7 @@ struct ProgressData {
 		total = 1.0;
 	}
 	bool IsValid() const {
-		return (!invalid) || (done < 0.0) || (total < done);
+		return (!invalid) || (done < 0.0) || (total < done) || (total <= 0.0);
 	}
 };
 

--- a/src/include/duckdb/execution/progress_data.hpp
+++ b/src/include/duckdb/execution/progress_data.hpp
@@ -48,7 +48,7 @@ struct ProgressData {
 		total = 1.0;
 	}
 	bool IsValid() const {
-		return (!invalid) || (done < 0.0) || (total < done) || (total <= 0.0);
+		return (!invalid) && (done >= 0.0) && (done <= total) && (total >= 0.0);
 	}
 };
 

--- a/src/include/duckdb/execution/progress_data.hpp
+++ b/src/include/duckdb/execution/progress_data.hpp
@@ -32,7 +32,7 @@ struct ProgressData {
 		// Normalize checks only `target`, propagating invalid
 		D_ASSERT(target > 0.0);
 		if (IsValid()) {
-			if (done > 0.0) {
+			if (total > 0.0) {
 				done /= total;
 			}
 			total = 1.0;

--- a/src/include/duckdb/execution/radix_partitioned_hashtable.hpp
+++ b/src/include/duckdb/execution/radix_partitioned_hashtable.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/types/row/tuple_data_layout.hpp"
 #include "duckdb/execution/operator/aggregate/grouped_aggregate_data.hpp"
+#include "duckdb/execution/progress_data.hpp"
 #include "duckdb/parser/group_by_node.hpp"
 
 namespace duckdb {
@@ -50,7 +51,7 @@ public:
 	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, GlobalSinkState &sink,
 	                         OperatorSourceInput &input) const;
 
-	double GetProgress(ClientContext &context, GlobalSinkState &sink_p, GlobalSourceState &gstate) const;
+	ProgressData GetProgress(ClientContext &context, GlobalSinkState &sink_p, GlobalSourceState &gstate) const;
 
 	const TupleDataLayout &GetLayout() const;
 	idx_t MaxThreads(GlobalSinkState &sink) const;

--- a/src/include/duckdb/parallel/pipeline.hpp
+++ b/src/include/duckdb/parallel/pipeline.hpp
@@ -97,7 +97,7 @@ public:
 	void PrintDependencies() const;
 
 	//! Returns query progress
-	bool GetProgress(double &current_percentage, idx_t &estimated_cardinality);
+	bool GetProgress(ProgressData &progress_data);
 
 	//! Returns a list of all operators (including source and sink) involved in this pipeline
 	vector<reference<PhysicalOperator>> GetOperators();

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -684,39 +684,21 @@ void Executor::Flush(ThreadContext &thread_context) {
 	}
 }
 
-bool Executor::GetPipelinesProgress(double &current_progress, uint64_t &current_cardinality,
-                                    uint64_t &total_cardinality) { // LCOV_EXCL_START
+idx_t Executor::GetPipelinesProgress(ProgressData &progress) { // LCOV_EXCL_START
 	lock_guard<mutex> elock(executor_lock);
 
-	vector<double> progress;
-	vector<idx_t> cardinality;
-	total_cardinality = 0;
-	current_cardinality = 0;
+	progress.done = 0;
+	progress.total = 0;
+	idx_t count_invalid = 0;
 	for (auto &pipeline : pipelines) {
-		double child_percentage;
-		idx_t child_cardinality;
-
-		if (!pipeline->GetProgress(child_percentage, child_cardinality)) {
-			return false;
+		ProgressData p;
+		if (!pipeline->GetProgress(p)) {
+			count_invalid++;
+		} else {
+			progress.Add(p);
 		}
-		progress.push_back(child_percentage);
-		cardinality.push_back(child_cardinality);
-		total_cardinality += child_cardinality;
 	}
-	if (total_cardinality == 0) {
-		return true;
-	}
-	current_progress = 0;
-
-	for (size_t i = 0; i < progress.size(); i++) {
-		progress[i] = MaxValue(0.0, MinValue(100.0, progress[i]));
-		current_cardinality = LossyNumericCast<idx_t>(static_cast<double>(
-		    static_cast<double>(current_cardinality) +
-		    static_cast<double>(progress[i]) * static_cast<double>(cardinality[i]) / static_cast<double>(100)));
-		current_progress += progress[i] * double(cardinality[i]) / double(total_cardinality);
-		D_ASSERT(current_cardinality <= total_cardinality);
-	}
-	return true;
+	return count_invalid;
 } // LCOV_EXCL_STOP
 
 bool Executor::HasResultCollector() {

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -75,12 +75,16 @@ ClientContext &Pipeline::GetClientContext() {
 bool Pipeline::GetProgress(ProgressData &progress) {
 	D_ASSERT(source);
 	idx_t source_cardinality = MinValue<idx_t>(source->estimated_cardinality, 1ULL << 48ULL);
+	if (source_cardinality < 1) {
+		source_cardinality = 1;
+	}
 	if (!initialized) {
 		progress.done = 0;
 		progress.total = double(source_cardinality);
 		return true;
 	}
 	auto &client = executor.context;
+
 	progress = source->GetProgress(client, *source_state);
 	progress.Normalize(double(source_cardinality));
 	progress.Add(sink->GetSinkProgress(client, *sink->sink_state, progress));

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -87,7 +87,7 @@ bool Pipeline::GetProgress(ProgressData &progress) {
 
 	progress = source->GetProgress(client, *source_state);
 	progress.Normalize(double(source_cardinality));
-	progress.Add(sink->GetSinkProgress(client, *sink->sink_state, progress));
+	progress = sink->GetSinkProgress(client, *sink->sink_state, progress);
 	return progress.IsValid();
 }
 

--- a/src/parallel/pipeline.cpp
+++ b/src/parallel/pipeline.cpp
@@ -77,12 +77,12 @@ bool Pipeline::GetProgress(ProgressData &progress) {
 	idx_t source_cardinality = MinValue<idx_t>(source->estimated_cardinality, 1ULL << 48ULL);
 	if (!initialized) {
 		progress.done = 0;
-		progress.total = source_cardinality;
+		progress.total = double(source_cardinality);
 		return true;
 	}
 	auto &client = executor.context;
 	progress = source->GetProgress(client, *source_state);
-	progress.Normalize(source_cardinality);
+	progress.Normalize(double(source_cardinality));
 	progress.Add(sink->GetSinkProgress(client, *sink->sink_state, progress));
 	return progress.IsValid();
 }


### PR DESCRIPTION
This is a draft PR, since I have not checked (and I would expect some failures out-of-tree extensions or Python / other APIs).

----

Operators currently when queried on progress return just a double.

Problem, how to merge two progresses?
Currently we rely on cardinalities being the same, do Min (since there cardinalities are irrelevant) or carry around cardinalities externally causing extra complexity.
Also currently error handling is done via -1.0, but not always propagated.

Proposal here is adding a:
```c++
struct ProgressData {
     double done = 0.0;
     double total = 0.0;
     bool is_valid = true;
};
```
That encodes both how much progress is done (like number of rows emitted, or whatever is relevant) and how much work is expected to be required in total.

#### Pro:
* I think this clean up code, and allows to simplify/clarify the implementation and usage of GetProgress (see for example how [src/parallel/executor.cpp](https://github.com/duckdb/duckdb/compare/main...carlopi:progress_data?expand=1#diff-6cae893584f8ae6b77f518de21317e6c4c4a39c36cbc0c74a1574d534e0ea5ae) changed)
* (minor) Avoid problems like deciding how to normalize (it's a 0-1 or 0-100), see https://github.com/duckdb/duckdb/pull/15081

#### Cons:
* code churn, also in extensions, other API

#### Questions:
* table_function_progress_t currently returns a double. Should that be also changed (via adding cardinality with default at the end of the function)? Then percentage + cardinality can be converted to ProgressData duckdb side
In this PR this is done assuming cardinality is always 1000:
```c++
	ProgressData res;
	if (function.table_scan_progress) {
		double table_progress = function.table_scan_progress(context, bind_data.get(), gstate.global_state.get());
		if (table_progress < 0.0) {
			res.SetInvalid();
		} else {
			res.done = table_progress;
			res.total = 100.0;
			// Assume cardinality is always 1e3
			res.Normalize(1e3);
		}
	} else {
		// if table_scan_progress is not implemented we don't support this function yet in the progress bar
		res.SetInvalid();
	}
	return res;
```
* FileSystem's GetProgress still return double, should this also be moved over (that's more complex since currently DUCKDB_API, but than this might also mean better now than later)