### PR TITLE
Avoid building for Python 3.7 on Windows

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -349,14 +349,10 @@ jobs:
       runs-on: windows-2019
       strategy:
        matrix:
-        python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]
+        python_build: [cp38-*, cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         exclude:
-          - isRelease: false
-            python_build: 'cp37-*'
-          - isRelease: false
-            python_build: 'cp38-*'
           - isRelease: false
             python_build: 'cp39-*'
           - isRelease: false


### PR DESCRIPTION
Currently this fails CI like:
```
+ Download https://github.com/pypa/get-virtualenv/blob/20.27.1/public/virtualenv.pyz?raw=true to C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\virtualenv-20.27.1.pyz
  + 'C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe' -sS 'C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\virtualenv-20.27.1.pyz' --activators= --no-periodic-update --pip=embed --no-setuptools --no-wheel --python 'C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.7.9\tools\python.exe' 'C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv'
  created virtual environment CPython3.7.9.final.0-64 in 1418ms
    creator CPython3Windows(dest=C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv, clear=False, no_vcs_ignore=False, global=False)
    seeder FromAppData(download=False, pip=embed, via=copy, app_data_dir=C:\Users\runneradmin\AppData\Local\pypa\virtualenv)
      added seed packages: pip==24.3.1
  + python -m pip install --upgrade pip
  Traceback (most recent call last):
    File "C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.7.9\tools\lib\runpy.py", line 193, in _run_module_as_main
      "__main__", mod_spec)
    File "C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.7.9\tools\lib\runpy.py", line 85, in _run_code
      exec(code, run_globals)
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv\lib\site-packages\pip\__main__.py", line 22, in <module>
      from pip._internal.cli.main import main as _main
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv\lib\site-packages\pip\_internal\cli\main.py", line 11, in <module>
      from pip._internal.cli.autocompletion import autocomplete
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv\lib\site-packages\pip\_internal\cli\autocompletion.py", line 10, in <module>
      from pip._internal.cli.main_parser import create_main_parser
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv\lib\site-packages\pip\_internal\cli\main_parser.py", line 9, in <module>
      from pip._internal.build_env import get_runnable_pip
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv\lib\site-packages\pip\_internal\build_env.py", line 18, in <module>
      from pip._internal.cli.spinners import open_spinner
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv\lib\site-packages\pip\_internal\cli\spinners.py", line 9, in <module>
      from pip._internal.utils.logging import get_indentation
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv\lib\site-packages\pip\_internal\utils\logging.py", line 13, in <module>
      from pip._vendor.rich.console import (
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv\lib\site-packages\pip\_vendor\rich\console.py", line 41, in <module>
      from pip._vendor.typing_extensions import (
    File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-me_w9d2n\cp37-win_amd64\build\venv\lib\site-packages\pip\_vendor\typing_extensions.py", line [103](https://github.com/duckdb/duckdb/actions/runs/12110544722/job/33761676341#step:8:105)9
      def TypedDict(typename, fields=_marker, /, *, total=True, closed=False, **kwargs):
                                              ^
  SyntaxError: invalid syntax
```

It looks to me this means cibw/pip is not handling Python 3.7 on Windows, and that is a sign we can let it go.