### PR TITLE
Fix build_extensions_dockerized Deploy step by moving to correct folder

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -178,7 +178,8 @@ runs:
           AWS_DEFAULT_REGION: us-east-1
           DUCKDB_DEPLOY_SCRIPT_MODE: for_real
         run: |
-          cd  ${{ inputs.build_dir}}
+          cp -r build duckdb/.
+          cd duckdb
           if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             if [[ ! -z "${{ inputs.deploy_version }}" ]] ; then
               ./scripts/extension-upload-all.sh ${{ inputs.deploy_as }} ${{ inputs.deploy_version }}


### PR DESCRIPTION
This should fix Linux extensions upload on nightly.