### PR TITLE
Top-N: Perform global boundary checking before doing sort-key conversion

### DIFF
--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -503,11 +503,31 @@ idx_t PositionComparator::Final<duckdb::DistinctLessThan>(Vector &left, Vector &
 }
 
 template <>
+idx_t PositionComparator::Final<duckdb::DistinctLessThanNullsFirst>(Vector &left, Vector &right,
+																	const SelectionVector &sel, idx_t count,
+																	optional_ptr<SelectionVector> true_sel,
+																	optional_ptr<SelectionVector> false_sel,
+																	optional_ptr<ValidityMask> null_mask) {
+	// DistinctGreaterThan has NULLs last
+	return VectorOperations::DistinctGreaterThan(right, left, &sel, count, true_sel, false_sel, null_mask);
+}
+
+template <>
 idx_t PositionComparator::Final<duckdb::DistinctGreaterThan>(Vector &left, Vector &right, const SelectionVector &sel,
                                                              idx_t count, optional_ptr<SelectionVector> true_sel,
                                                              optional_ptr<SelectionVector> false_sel,
                                                              optional_ptr<ValidityMask> null_mask) {
 	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, false_sel, null_mask);
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctGreaterThanNullsFirst>(Vector &left, Vector &right,
+																	   const SelectionVector &sel, idx_t count,
+																	   optional_ptr<SelectionVector> true_sel,
+																	   optional_ptr<SelectionVector> false_sel,
+																	   optional_ptr<ValidityMask> null_mask) {
+	// DistinctLessThan has NULLs last
+	return VectorOperations::DistinctLessThan(right, left, &sel, count, true_sel, false_sel, null_mask);
 }
 
 using StructEntries = vector<unique_ptr<Vector>>;
@@ -1178,6 +1198,16 @@ idx_t VectorOperations::DistinctGreaterThan(Vector &left, Vector &right, optiona
 	                                                                     null_mask);
 }
 
+// true := A > B with nulls being minimal
+idx_t VectorOperations::DistinctGreaterThanNullsFirst(Vector &left, Vector &right,
+													  optional_ptr<const SelectionVector> sel, idx_t count,
+													  optional_ptr<SelectionVector> true_sel,
+													  optional_ptr<SelectionVector> false_sel,
+													  optional_ptr<ValidityMask> null_mask) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanNullsFirst>(left, right, sel, count, true_sel,
+																				   false_sel, null_mask);
+}
+
 // true := A >= B with nulls being maximal
 idx_t VectorOperations::DistinctGreaterThanEquals(Vector &left, Vector &right, optional_ptr<const SelectionVector> sel,
                                                   idx_t count, optional_ptr<SelectionVector> true_sel,
@@ -1193,6 +1223,15 @@ idx_t VectorOperations::DistinctLessThan(Vector &left, Vector &right, optional_p
                                          optional_ptr<ValidityMask> null_mask) {
 	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThan>(right, left, sel, count, true_sel, false_sel,
 	                                                                     null_mask);
+}
+
+// true := A < B with nulls being minimal
+idx_t VectorOperations::DistinctLessThanNullsFirst(Vector &left, Vector &right, optional_ptr<const SelectionVector> sel,
+												   idx_t count, optional_ptr<SelectionVector> true_sel,
+												   optional_ptr<SelectionVector> false_sel,
+												   optional_ptr<ValidityMask> null_mask) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanNullsFirst>(right, left, sel, count, true_sel,
+																				   false_sel, nullptr);
 }
 
 // true := A <= B with nulls being maximal

--- a/src/common/vector_operations/is_distinct_from.cpp
+++ b/src/common/vector_operations/is_distinct_from.cpp
@@ -504,10 +504,10 @@ idx_t PositionComparator::Final<duckdb::DistinctLessThan>(Vector &left, Vector &
 
 template <>
 idx_t PositionComparator::Final<duckdb::DistinctLessThanNullsFirst>(Vector &left, Vector &right,
-																	const SelectionVector &sel, idx_t count,
-																	optional_ptr<SelectionVector> true_sel,
-																	optional_ptr<SelectionVector> false_sel,
-																	optional_ptr<ValidityMask> null_mask) {
+                                                                    const SelectionVector &sel, idx_t count,
+                                                                    optional_ptr<SelectionVector> true_sel,
+                                                                    optional_ptr<SelectionVector> false_sel,
+                                                                    optional_ptr<ValidityMask> null_mask) {
 	// DistinctGreaterThan has NULLs last
 	return VectorOperations::DistinctGreaterThan(right, left, &sel, count, true_sel, false_sel, null_mask);
 }
@@ -522,10 +522,10 @@ idx_t PositionComparator::Final<duckdb::DistinctGreaterThan>(Vector &left, Vecto
 
 template <>
 idx_t PositionComparator::Final<duckdb::DistinctGreaterThanNullsFirst>(Vector &left, Vector &right,
-																	   const SelectionVector &sel, idx_t count,
-																	   optional_ptr<SelectionVector> true_sel,
-																	   optional_ptr<SelectionVector> false_sel,
-																	   optional_ptr<ValidityMask> null_mask) {
+                                                                       const SelectionVector &sel, idx_t count,
+                                                                       optional_ptr<SelectionVector> true_sel,
+                                                                       optional_ptr<SelectionVector> false_sel,
+                                                                       optional_ptr<ValidityMask> null_mask) {
 	// DistinctLessThan has NULLs last
 	return VectorOperations::DistinctLessThan(right, left, &sel, count, true_sel, false_sel, null_mask);
 }
@@ -1200,12 +1200,12 @@ idx_t VectorOperations::DistinctGreaterThan(Vector &left, Vector &right, optiona
 
 // true := A > B with nulls being minimal
 idx_t VectorOperations::DistinctGreaterThanNullsFirst(Vector &left, Vector &right,
-													  optional_ptr<const SelectionVector> sel, idx_t count,
-													  optional_ptr<SelectionVector> true_sel,
-													  optional_ptr<SelectionVector> false_sel,
-													  optional_ptr<ValidityMask> null_mask) {
+                                                      optional_ptr<const SelectionVector> sel, idx_t count,
+                                                      optional_ptr<SelectionVector> true_sel,
+                                                      optional_ptr<SelectionVector> false_sel,
+                                                      optional_ptr<ValidityMask> null_mask) {
 	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanNullsFirst>(left, right, sel, count, true_sel,
-																				   false_sel, null_mask);
+	                                                                               false_sel, null_mask);
 }
 
 // true := A >= B with nulls being maximal
@@ -1227,11 +1227,11 @@ idx_t VectorOperations::DistinctLessThan(Vector &left, Vector &right, optional_p
 
 // true := A < B with nulls being minimal
 idx_t VectorOperations::DistinctLessThanNullsFirst(Vector &left, Vector &right, optional_ptr<const SelectionVector> sel,
-												   idx_t count, optional_ptr<SelectionVector> true_sel,
-												   optional_ptr<SelectionVector> false_sel,
-												   optional_ptr<ValidityMask> null_mask) {
+                                                   idx_t count, optional_ptr<SelectionVector> true_sel,
+                                                   optional_ptr<SelectionVector> false_sel,
+                                                   optional_ptr<ValidityMask> null_mask) {
 	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanNullsFirst>(right, left, sel, count, true_sel,
-																				   false_sel, nullptr);
+	                                                                               false_sel, nullptr);
 }
 
 // true := A <= B with nulls being maximal

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -69,6 +69,7 @@ public:
 	unsafe_vector<TopNEntry> heap;
 	const vector<LogicalType> &payload_types;
 	const vector<BoundOrderByNode> &orders;
+	vector<OrderModifiers> modifiers;
 	idx_t limit;
 	idx_t offset;
 	idx_t heap_size;
@@ -81,6 +82,16 @@ public:
 
 	SelectionVector matching_sel;
 
+	DataChunk compare_chunk;
+	//! Cached global boundary value as a set of constant vectors
+	DataChunk boundary_values;
+	//! Cached global boundary value in sort-key format
+	string boundary_val;
+	SelectionVector final_sel;
+	SelectionVector true_sel;
+	SelectionVector false_sel;
+	SelectionVector new_remaining_sel;
+
 public:
 	void Sink(DataChunk &input, optional_ptr<TopNBoundaryValue> boundary_value = nullptr);
 	void Combine(TopNHeap &other);
@@ -90,10 +101,9 @@ public:
 	void InitializeScan(TopNScanState &state, bool exclude_offset);
 	void Scan(TopNScanState &state, DataChunk &chunk);
 
-	void AddSmallHeap(DataChunk &input, Vector &sort_keys_vec, const string &boundary_val,
-	                  const string_t &global_boundary_val);
-	void AddLargeHeap(DataChunk &input, Vector &sort_keys_vec, const string &boundary_val,
-	                  const string_t &global_boundary_val);
+	bool CheckBoundaryValues(DataChunk &sort_chunk, DataChunk &payload, TopNBoundaryValue &boundary_val);
+	void AddSmallHeap(DataChunk &input, Vector &sort_keys_vec);
+	void AddLargeHeap(DataChunk &input, Vector &sort_keys_vec);
 
 public:
 	idx_t ReduceThreshold() const {
@@ -146,13 +156,15 @@ TopNHeap::TopNHeap(ClientContext &context, Allocator &allocator, const vector<Lo
                    const vector<BoundOrderByNode> &orders_p, idx_t limit, idx_t offset)
     : allocator(allocator), buffer_manager(BufferManager::GetBufferManager(context)), payload_types(payload_types_p),
       orders(orders_p), limit(limit), offset(offset), heap_size(limit + offset), executor(context),
-      matching_sel(STANDARD_VECTOR_SIZE) {
+      matching_sel(STANDARD_VECTOR_SIZE), final_sel(STANDARD_VECTOR_SIZE),
+      true_sel(STANDARD_VECTOR_SIZE), false_sel(STANDARD_VECTOR_SIZE), new_remaining_sel(STANDARD_VECTOR_SIZE) {
 	// initialize the executor and the sort_chunk
 	vector<LogicalType> sort_types;
 	for (auto &order : orders) {
 		auto &expr = order.expression;
 		sort_types.push_back(expr->return_type);
 		executor.AddExpression(*expr);
+		modifiers.emplace_back(order.type, order.null_order);
 	}
 	heap.reserve(InitialHeapAllocSize());
 	vector<LogicalType> sort_keys_type {LogicalType::BLOB};
@@ -160,6 +172,8 @@ TopNHeap::TopNHeap(ClientContext &context, Allocator &allocator, const vector<Lo
 	heap_data.Initialize(allocator, payload_types, InitialHeapAllocSize());
 	payload_chunk.Initialize(allocator, payload_types);
 	sort_chunk.Initialize(allocator, sort_types);
+	compare_chunk.Initialize(allocator, sort_types);
+	boundary_values.Initialize(allocator, sort_types);
 }
 
 TopNHeap::TopNHeap(ClientContext &context, const vector<LogicalType> &payload_types,
@@ -172,8 +186,7 @@ TopNHeap::TopNHeap(ExecutionContext &context, const vector<LogicalType> &payload
     : TopNHeap(context.client, Allocator::Get(context.client), payload_types, orders, limit, offset) {
 }
 
-void TopNHeap::AddSmallHeap(DataChunk &input, Vector &sort_keys_vec, const string &boundary_val,
-                            const string_t &global_boundary_val) {
+void TopNHeap::AddSmallHeap(DataChunk &input, Vector &sort_keys_vec) {
 	// insert the sort keys into the priority queue
 	constexpr idx_t BASE_INDEX = NumericLimits<uint32_t>::Maximum();
 
@@ -181,7 +194,7 @@ void TopNHeap::AddSmallHeap(DataChunk &input, Vector &sort_keys_vec, const strin
 	auto sort_key_values = FlatVector::GetData<string_t>(sort_keys_vec);
 	for (idx_t r = 0; r < input.size(); r++) {
 		auto &sort_key = sort_key_values[r];
-		if (!EntryShouldBeAdded(sort_key, boundary_val, global_boundary_val)) {
+		if (!EntryShouldBeAdded(sort_key)) {
 			continue;
 		}
 		// replace the previous top entry with the new entry
@@ -217,14 +230,13 @@ void TopNHeap::AddSmallHeap(DataChunk &input, Vector &sort_keys_vec, const strin
 	heap_data.Append(input, true, &matching_sel, match_count);
 }
 
-void TopNHeap::AddLargeHeap(DataChunk &input, Vector &sort_keys_vec, const string &boundary_val,
-                            const string_t &global_boundary_val) {
+void TopNHeap::AddLargeHeap(DataChunk &input, Vector &sort_keys_vec) {
 	auto sort_key_values = FlatVector::GetData<string_t>(sort_keys_vec);
 	idx_t base_index = heap_data.size();
 	idx_t match_count = 0;
 	for (idx_t r = 0; r < input.size(); r++) {
 		auto &sort_key = sort_key_values[r];
-		if (!EntryShouldBeAdded(sort_key, boundary_val, global_boundary_val)) {
+		if (!EntryShouldBeAdded(sort_key)) {
 			continue;
 		}
 		// replace the previous top entry with the new entry
@@ -243,6 +255,80 @@ void TopNHeap::AddLargeHeap(DataChunk &input, Vector &sort_keys_vec, const strin
 	heap_data.Append(input, true, &matching_sel, match_count);
 }
 
+bool TopNHeap::CheckBoundaryValues(DataChunk &sort_chunk, DataChunk &payload, TopNBoundaryValue &global_boundary) {
+	// get the global boundary value
+	auto current_boundary_val = global_boundary.GetBoundaryValue();
+	if (current_boundary_val.empty()) {
+		// no boundary value (yet) - don't do anything
+		return true;
+	}
+	if (current_boundary_val != boundary_val) {
+		// new boundary value - decode
+		boundary_val = std::move(current_boundary_val);
+		CreateSortKeyHelpers::DecodeSortKey(string_t(boundary_val), boundary_values, 0, modifiers);
+	}
+
+	// we have boundary values
+	// from these boundary values, determine which values we should insert (if any)
+	idx_t final_count = 0;
+
+	SelectionVector remaining_sel(nullptr);
+	idx_t remaining_count = sort_chunk.size();
+	for (idx_t i = 0; i < orders.size(); i++) {
+		if (remaining_sel.data()) {
+			compare_chunk.data[i].Slice(sort_chunk.data[i], remaining_sel, remaining_count);
+		} else {
+			compare_chunk.data[i].Reference(sort_chunk.data[i]);
+		}
+		bool is_last = i + 1 == orders.size();
+		idx_t true_count;
+		if (orders[i].null_order == OrderByNullType::NULLS_LAST) {
+			if (orders[i].type == OrderType::ASCENDING) {
+				true_count = VectorOperations::DistinctLessThan(compare_chunk.data[i], boundary_values.data[i],
+				                                                &remaining_sel, remaining_count, &true_sel, &false_sel);
+			} else {
+				true_count = VectorOperations::DistinctGreaterThanNullsFirst(compare_chunk.data[i],
+				                                                             boundary_values.data[i], &remaining_sel,
+				                                                             remaining_count, &true_sel, &false_sel);
+			}
+		} else {
+			D_ASSERT(orders[i].null_order == OrderByNullType::NULLS_FIRST);
+			if (orders[i].type == OrderType::ASCENDING) {
+				true_count = VectorOperations::DistinctLessThanNullsFirst(compare_chunk.data[i],
+				                                                          boundary_values.data[i], &remaining_sel,
+				                                                          remaining_count, &true_sel, &false_sel);
+			} else {
+				true_count =
+				    VectorOperations::DistinctGreaterThan(compare_chunk.data[i], boundary_values.data[i],
+				                                          &remaining_sel, remaining_count, &true_sel, &false_sel);
+			}
+		}
+
+		if (true_count > 0) {
+			memcpy(final_sel.data() + final_count, true_sel.data(), true_count * sizeof(sel_t));
+			final_count += true_count;
+		}
+		idx_t false_count = remaining_count - true_count;
+		if (!is_last && false_count > 0) {
+			// check what we should continue to check
+			compare_chunk.data[i].Slice(sort_chunk.data[i], false_sel, false_count);
+			remaining_count = VectorOperations::NotDistinctFrom(compare_chunk.data[i], boundary_values.data[i],
+			                                                    &false_sel, false_count, &new_remaining_sel, nullptr);
+			remaining_sel.Initialize(new_remaining_sel);
+		} else {
+			break;
+		}
+	}
+	if (final_count == 0) {
+		return false;
+	}
+	if (final_count < sort_chunk.size()) {
+		sort_chunk.Slice(final_sel, final_count);
+		payload.Slice(final_sel, final_count);
+	}
+	return true;
+}
+
 void TopNHeap::Sink(DataChunk &input, optional_ptr<TopNBoundaryValue> global_boundary) {
 	static constexpr idx_t SMALL_HEAP_THRESHOLD = 100;
 
@@ -250,27 +336,23 @@ void TopNHeap::Sink(DataChunk &input, optional_ptr<TopNBoundaryValue> global_bou
 	sort_chunk.Reset();
 	executor.Execute(input, sort_chunk);
 
-	// construct the sort key from the sort chunk
-	vector<OrderModifiers> modifiers;
-	for (auto &order : orders) {
-		modifiers.emplace_back(order.type, order.null_order);
+	if (global_boundary) {
+		// if we have a global boundary value check which rows pass before doing anything
+		if (!CheckBoundaryValues(sort_chunk, input, *global_boundary)) {
+			// nothing in this chunk can be in the final result
+			return;
+		}
 	}
+
+	// construct the sort key from the sort chunk
 	sort_keys.Reset();
 	auto &sort_keys_vec = sort_keys.data[0];
 	CreateSortKeyHelpers::CreateSortKey(sort_chunk, modifiers, sort_keys_vec);
 
-	// fetch the current global boundary (if any)
-	string boundary_val;
-	string_t global_boundary_val;
-	if (global_boundary) {
-		boundary_val = global_boundary->GetBoundaryValue();
-		global_boundary_val = string_t(boundary_val);
-	}
-
 	if (heap_size <= SMALL_HEAP_THRESHOLD) {
-		AddSmallHeap(input, sort_keys_vec, boundary_val, global_boundary_val);
+		AddSmallHeap(input, sort_keys_vec);
 	} else {
-		AddLargeHeap(input, sort_keys_vec, boundary_val, global_boundary_val);
+		AddLargeHeap(input, sort_keys_vec);
 	}
 
 	// if we modified the heap we might be able to update the global boundary

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -773,8 +773,8 @@ static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 // Decode Sort Key
 //===--------------------------------------------------------------------===//
 struct DecodeSortKeyVectorData {
-	DecodeSortKeyVectorData(const LogicalType &type, OrderModifiers modifiers) :
-		flip_bytes(modifiers.order_type == OrderType::DESCENDING) {
+	DecodeSortKeyVectorData(const LogicalType &type, OrderModifiers modifiers)
+	    : flip_bytes(modifiers.order_type == OrderType::DESCENDING) {
 		null_byte = SortKeyVectorData::NULL_FIRST_BYTE;
 		valid_byte = SortKeyVectorData::NULL_LAST_BYTE;
 		if (modifiers.null_type == OrderByNullType::NULLS_LAST) {
@@ -785,7 +785,7 @@ struct DecodeSortKeyVectorData {
 		// within nested types NULLS LAST/NULLS FIRST is dependent on ASC/DESC order instead
 		// don't blame me this is what Postgres does
 		auto child_null_type =
-			modifiers.order_type == OrderType::ASCENDING ? OrderByNullType::NULLS_LAST : OrderByNullType::NULLS_FIRST;
+		    modifiers.order_type == OrderType::ASCENDING ? OrderByNullType::NULLS_LAST : OrderByNullType::NULLS_FIRST;
 		OrderModifiers child_modifiers(modifiers.order_type, child_null_type);
 		switch (type.InternalType()) {
 		case PhysicalType::STRUCT: {
@@ -809,7 +809,6 @@ struct DecodeSortKeyVectorData {
 			break;
 		}
 	}
-
 
 	data_t null_byte;
 	data_t valid_byte;
@@ -1016,10 +1015,11 @@ void CreateSortKeyHelpers::DecodeSortKey(string_t sort_key, Vector &result, idx_
 	DecodeSortKeyRecursive(decode_data, sort_key_data, result, result_idx);
 }
 
-void CreateSortKeyHelpers::DecodeSortKey(string_t sort_key, DataChunk &result, idx_t result_idx, const vector<OrderModifiers> &modifiers) {
+void CreateSortKeyHelpers::DecodeSortKey(string_t sort_key, DataChunk &result, idx_t result_idx,
+                                         const vector<OrderModifiers> &modifiers) {
 	DecodeSortKeyData decode_data(sort_key);
 	D_ASSERT(modifiers.size() == result.ColumnCount());
-	for(idx_t c = 0; c < result.ColumnCount(); c++) {
+	for (idx_t c = 0; c < result.ColumnCount(); c++) {
 		auto &vec = result.data[c];
 		DecodeSortKeyVectorData vector_data(vec.GetType(), modifiers[c]);
 		DecodeSortKeyRecursive(decode_data, vector_data, vec, result_idx);

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -772,23 +772,66 @@ static void CreateSortKeyFunction(DataChunk &args, ExpressionState &state, Vecto
 //===--------------------------------------------------------------------===//
 // Decode Sort Key
 //===--------------------------------------------------------------------===//
+struct DecodeSortKeyVectorData {
+	DecodeSortKeyVectorData(const LogicalType &type, OrderModifiers modifiers) :
+		flip_bytes(modifiers.order_type == OrderType::DESCENDING) {
+		null_byte = SortKeyVectorData::NULL_FIRST_BYTE;
+		valid_byte = SortKeyVectorData::NULL_LAST_BYTE;
+		if (modifiers.null_type == OrderByNullType::NULLS_LAST) {
+			std::swap(null_byte, valid_byte);
+		}
+
+		// NULLS FIRST/NULLS LAST passed in by the user are only respected at the top level
+		// within nested types NULLS LAST/NULLS FIRST is dependent on ASC/DESC order instead
+		// don't blame me this is what Postgres does
+		auto child_null_type =
+			modifiers.order_type == OrderType::ASCENDING ? OrderByNullType::NULLS_LAST : OrderByNullType::NULLS_FIRST;
+		OrderModifiers child_modifiers(modifiers.order_type, child_null_type);
+		switch (type.InternalType()) {
+		case PhysicalType::STRUCT: {
+			auto &children = StructType::GetChildTypes(type);
+			for (auto &child_type : children) {
+				child_data.emplace_back(child_type.second, child_modifiers);
+			}
+			break;
+		}
+		case PhysicalType::ARRAY: {
+			auto &child_type = ArrayType::GetChildType(type);
+			child_data.emplace_back(child_type, child_modifiers);
+			break;
+		}
+		case PhysicalType::LIST: {
+			auto &child_type = ListType::GetChildType(type);
+			child_data.emplace_back(child_type, child_modifiers);
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+
+	data_t null_byte;
+	data_t valid_byte;
+	vector<DecodeSortKeyVectorData> child_data;
+	bool flip_bytes;
+};
+
 struct DecodeSortKeyData {
-	explicit DecodeSortKeyData(OrderModifiers modifiers, string_t &sort_key)
-	    : data(const_data_ptr_cast(sort_key.GetData())), size(sort_key.GetSize()), position(0),
-	      flip_bytes(modifiers.order_type == OrderType::DESCENDING) {
+	explicit DecodeSortKeyData(string_t &sort_key)
+	    : data(const_data_ptr_cast(sort_key.GetData())), size(sort_key.GetSize()), position(0) {
 	}
 
 	const_data_ptr_t data;
 	idx_t size;
 	idx_t position;
-	bool flip_bytes;
 };
 
-void DecodeSortKeyRecursive(DecodeSortKeyData &decode_data, SortKeyVectorData &vector_data, Vector &result,
+void DecodeSortKeyRecursive(DecodeSortKeyData &decode_data, DecodeSortKeyVectorData &vector_data, Vector &result,
                             idx_t result_idx);
 
 template <class OP>
-void TemplatedDecodeSortKey(DecodeSortKeyData &decode_data, SortKeyVectorData &vector_data, Vector &result,
+void TemplatedDecodeSortKey(DecodeSortKeyData &decode_data, DecodeSortKeyVectorData &vector_data, Vector &result,
                             idx_t result_idx) {
 	auto validity_byte = decode_data.data[decode_data.position];
 	decode_data.position++;
@@ -797,11 +840,11 @@ void TemplatedDecodeSortKey(DecodeSortKeyData &decode_data, SortKeyVectorData &v
 		FlatVector::Validity(result).SetInvalid(result_idx);
 		return;
 	}
-	idx_t increment = OP::Decode(decode_data.data + decode_data.position, result, result_idx, decode_data.flip_bytes);
+	idx_t increment = OP::Decode(decode_data.data + decode_data.position, result, result_idx, vector_data.flip_bytes);
 	decode_data.position += increment;
 }
 
-void DecodeSortKeyStruct(DecodeSortKeyData &decode_data, SortKeyVectorData &vector_data, Vector &result,
+void DecodeSortKeyStruct(DecodeSortKeyData &decode_data, DecodeSortKeyVectorData &vector_data, Vector &result,
                          idx_t result_idx) {
 	// check if the top-level is valid or not
 	auto validity_byte = decode_data.data[decode_data.position];
@@ -815,11 +858,11 @@ void DecodeSortKeyStruct(DecodeSortKeyData &decode_data, SortKeyVectorData &vect
 	auto &child_entries = StructVector::GetEntries(result);
 	for (idx_t c = 0; c < child_entries.size(); c++) {
 		auto &child_entry = child_entries[c];
-		DecodeSortKeyRecursive(decode_data, *vector_data.child_data[c], *child_entry, result_idx);
+		DecodeSortKeyRecursive(decode_data, vector_data.child_data[c], *child_entry, result_idx);
 	}
 }
 
-void DecodeSortKeyList(DecodeSortKeyData &decode_data, SortKeyVectorData &vector_data, Vector &result,
+void DecodeSortKeyList(DecodeSortKeyData &decode_data, DecodeSortKeyVectorData &vector_data, Vector &result,
                        idx_t result_idx) {
 	// check if the top-level is valid or not
 	auto validity_byte = decode_data.data[decode_data.position];
@@ -833,7 +876,7 @@ void DecodeSortKeyList(DecodeSortKeyData &decode_data, SortKeyVectorData &vector
 	// we don't know how many there will be
 	// decode child elements until we encounter the list delimiter
 	auto list_delimiter = SortKeyVectorData::LIST_DELIMITER;
-	if (decode_data.flip_bytes) {
+	if (vector_data.flip_bytes) {
 		list_delimiter = ~list_delimiter;
 	}
 	auto list_data = FlatVector::GetData<list_entry_t>(result);
@@ -849,7 +892,7 @@ void DecodeSortKeyList(DecodeSortKeyData &decode_data, SortKeyVectorData &vector
 		ListVector::Reserve(result, new_list_size);
 
 		// now decode the entry
-		DecodeSortKeyRecursive(decode_data, *vector_data.child_data[0], child_vector, new_list_size - 1);
+		DecodeSortKeyRecursive(decode_data, vector_data.child_data[0], child_vector, new_list_size - 1);
 	}
 	// skip the list delimiter
 	decode_data.position++;
@@ -859,7 +902,7 @@ void DecodeSortKeyList(DecodeSortKeyData &decode_data, SortKeyVectorData &vector
 	ListVector::SetListSize(result, new_list_size);
 }
 
-void DecodeSortKeyArray(DecodeSortKeyData &decode_data, SortKeyVectorData &vector_data, Vector &result,
+void DecodeSortKeyArray(DecodeSortKeyData &decode_data, DecodeSortKeyVectorData &vector_data, Vector &result,
                         idx_t result_idx) {
 	// check if the top-level is valid or not
 	auto validity_byte = decode_data.data[decode_data.position];
@@ -874,7 +917,7 @@ void DecodeSortKeyArray(DecodeSortKeyData &decode_data, SortKeyVectorData &vecto
 	// however the decoded data still contains a list delimiter
 	// we use this delimiter to verify we successfully decoded the entire array
 	auto list_delimiter = SortKeyVectorData::LIST_DELIMITER;
-	if (decode_data.flip_bytes) {
+	if (vector_data.flip_bytes) {
 		list_delimiter = ~list_delimiter;
 	}
 	auto &child_vector = ArrayVector::GetEntry(result);
@@ -890,7 +933,7 @@ void DecodeSortKeyArray(DecodeSortKeyData &decode_data, SortKeyVectorData &vecto
 			break;
 		}
 		// now decode the entry
-		DecodeSortKeyRecursive(decode_data, *vector_data.child_data[0], child_vector, child_start + found_elements - 1);
+		DecodeSortKeyRecursive(decode_data, vector_data.child_data[0], child_vector, child_start + found_elements - 1);
 	}
 	// skip the list delimiter
 	decode_data.position++;
@@ -900,7 +943,7 @@ void DecodeSortKeyArray(DecodeSortKeyData &decode_data, SortKeyVectorData &vecto
 	}
 }
 
-void DecodeSortKeyRecursive(DecodeSortKeyData &decode_data, SortKeyVectorData &vector_data, Vector &result,
+void DecodeSortKeyRecursive(DecodeSortKeyData &decode_data, DecodeSortKeyVectorData &vector_data, Vector &result,
                             idx_t result_idx) {
 	switch (result.GetType().InternalType()) {
 	case PhysicalType::BOOL:
@@ -946,7 +989,7 @@ void DecodeSortKeyRecursive(DecodeSortKeyData &decode_data, SortKeyVectorData &v
 		TemplatedDecodeSortKey<SortKeyConstantOperator<hugeint_t>>(decode_data, vector_data, result, result_idx);
 		break;
 	case PhysicalType::VARCHAR:
-		if (vector_data.vec.GetType().id() == LogicalTypeId::VARCHAR) {
+		if (result.GetType().id() == LogicalTypeId::VARCHAR) {
 			TemplatedDecodeSortKey<SortKeyVarcharOperator>(decode_data, vector_data, result, result_idx);
 		} else {
 			TemplatedDecodeSortKey<SortKeyBlobOperator>(decode_data, vector_data, result, result_idx);
@@ -962,15 +1005,25 @@ void DecodeSortKeyRecursive(DecodeSortKeyData &decode_data, SortKeyVectorData &v
 		DecodeSortKeyArray(decode_data, vector_data, result, result_idx);
 		break;
 	default:
-		throw NotImplementedException("Unsupported type %s in DecodeSortKey", vector_data.vec.GetType());
+		throw NotImplementedException("Unsupported type %s in DecodeSortKey", result.GetType());
 	}
 }
 
 void CreateSortKeyHelpers::DecodeSortKey(string_t sort_key, Vector &result, idx_t result_idx,
                                          OrderModifiers modifiers) {
-	SortKeyVectorData sort_key_data(result, 0, modifiers);
-	DecodeSortKeyData decode_data(modifiers, sort_key);
+	DecodeSortKeyVectorData sort_key_data(result.GetType(), modifiers);
+	DecodeSortKeyData decode_data(sort_key);
 	DecodeSortKeyRecursive(decode_data, sort_key_data, result, result_idx);
+}
+
+void CreateSortKeyHelpers::DecodeSortKey(string_t sort_key, DataChunk &result, idx_t result_idx, const vector<OrderModifiers> &modifiers) {
+	DecodeSortKeyData decode_data(sort_key);
+	D_ASSERT(modifiers.size() == result.ColumnCount());
+	for(idx_t c = 0; c < result.ColumnCount(); c++) {
+		auto &vec = result.data[c];
+		DecodeSortKeyVectorData vector_data(vec.GetType(), modifiers[c]);
+		DecodeSortKeyRecursive(decode_data, vector_data, vec, result_idx);
+	}
 }
 
 ScalarFunction CreateSortKeyFun::GetFunction() {

--- a/src/include/duckdb/common/operator/comparison_operators.hpp
+++ b/src/include/duckdb/common/operator/comparison_operators.hpp
@@ -107,6 +107,13 @@ struct DistinctGreaterThan {
 	}
 };
 
+struct DistinctGreaterThanNullsFirst {
+	template <class T>
+	static inline bool Operation(const T &left, const T &right, bool left_null, bool right_null) {
+		return DistinctGreaterThan::Operation(left, right, right_null, left_null);
+	}
+};
+
 struct DistinctGreaterThanEquals {
 	template <class T>
 	static inline bool Operation(const T &left, const T &right, bool left_null, bool right_null) {
@@ -118,6 +125,13 @@ struct DistinctLessThan {
 	template <class T>
 	static inline bool Operation(const T &left, const T &right, bool left_null, bool right_null) {
 		return DistinctGreaterThan::Operation(right, left, right_null, left_null);
+	}
+};
+
+struct DistinctLessThanNullsFirst {
+	template <class T>
+	static inline bool Operation(const T &left, const T &right, bool left_null, bool right_null) {
+		return DistinctGreaterThan::Operation(right, left, left_null, right_null);
 	}
 };
 

--- a/src/include/duckdb/common/vector_operations/vector_operations.hpp
+++ b/src/include/duckdb/common/vector_operations/vector_operations.hpp
@@ -129,6 +129,16 @@ struct VectorOperations {
 	                                    idx_t count, optional_ptr<SelectionVector> true_sel,
 	                                    optional_ptr<SelectionVector> false_sel,
 	                                    optional_ptr<ValidityMask> null_mask = nullptr);
+	// true := A > B with nulls being minimal
+	static idx_t DistinctGreaterThanNullsFirst(Vector &left, Vector &right, optional_ptr<const SelectionVector> sel,
+						   idx_t count, optional_ptr<SelectionVector> true_sel,
+						   optional_ptr<SelectionVector> false_sel,
+						   optional_ptr<ValidityMask> null_mask = nullptr);
+	// true := A < B with nulls being minimal
+	static idx_t DistinctLessThanNullsFirst(Vector &left, Vector &right, optional_ptr<const SelectionVector> sel,
+						idx_t count, optional_ptr<SelectionVector> true_sel,
+						optional_ptr<SelectionVector> false_sel,
+						optional_ptr<ValidityMask> null_mask = nullptr);
 
 	//===--------------------------------------------------------------------===//
 	// Nested Comparisons

--- a/src/include/duckdb/common/vector_operations/vector_operations.hpp
+++ b/src/include/duckdb/common/vector_operations/vector_operations.hpp
@@ -131,14 +131,14 @@ struct VectorOperations {
 	                                    optional_ptr<ValidityMask> null_mask = nullptr);
 	// true := A > B with nulls being minimal
 	static idx_t DistinctGreaterThanNullsFirst(Vector &left, Vector &right, optional_ptr<const SelectionVector> sel,
-						   idx_t count, optional_ptr<SelectionVector> true_sel,
-						   optional_ptr<SelectionVector> false_sel,
-						   optional_ptr<ValidityMask> null_mask = nullptr);
+	                                           idx_t count, optional_ptr<SelectionVector> true_sel,
+	                                           optional_ptr<SelectionVector> false_sel,
+	                                           optional_ptr<ValidityMask> null_mask = nullptr);
 	// true := A < B with nulls being minimal
 	static idx_t DistinctLessThanNullsFirst(Vector &left, Vector &right, optional_ptr<const SelectionVector> sel,
-						idx_t count, optional_ptr<SelectionVector> true_sel,
-						optional_ptr<SelectionVector> false_sel,
-						optional_ptr<ValidityMask> null_mask = nullptr);
+	                                        idx_t count, optional_ptr<SelectionVector> true_sel,
+	                                        optional_ptr<SelectionVector> false_sel,
+	                                        optional_ptr<ValidityMask> null_mask = nullptr);
 
 	//===--------------------------------------------------------------------===//
 	// Nested Comparisons

--- a/src/include/duckdb/function/create_sort_key.hpp
+++ b/src/include/duckdb/function/create_sort_key.hpp
@@ -49,7 +49,8 @@ struct CreateSortKeyHelpers {
 	static void CreateSortKey(DataChunk &input, const vector<OrderModifiers> &modifiers, Vector &result);
 	static void CreateSortKey(Vector &input, idx_t input_count, OrderModifiers modifiers, Vector &result);
 	static void DecodeSortKey(string_t sort_key, Vector &result, idx_t result_idx, OrderModifiers modifiers);
-	static void DecodeSortKey(string_t sort_key, DataChunk &result, idx_t result_idx, const vector<OrderModifiers> &modifiers);
+	static void DecodeSortKey(string_t sort_key, DataChunk &result, idx_t result_idx,
+	                          const vector<OrderModifiers> &modifiers);
 	static void CreateSortKeyWithValidity(Vector &input, Vector &result, const OrderModifiers &modifiers,
 	                                      const idx_t count);
 };

--- a/src/include/duckdb/function/create_sort_key.hpp
+++ b/src/include/duckdb/function/create_sort_key.hpp
@@ -49,6 +49,7 @@ struct CreateSortKeyHelpers {
 	static void CreateSortKey(DataChunk &input, const vector<OrderModifiers> &modifiers, Vector &result);
 	static void CreateSortKey(Vector &input, idx_t input_count, OrderModifiers modifiers, Vector &result);
 	static void DecodeSortKey(string_t sort_key, Vector &result, idx_t result_idx, OrderModifiers modifiers);
+	static void DecodeSortKey(string_t sort_key, DataChunk &result, idx_t result_idx, const vector<OrderModifiers> &modifiers);
 	static void CreateSortKeyWithValidity(Vector &input, Vector &result, const OrderModifiers &modifiers,
 	                                      const idx_t count);
 };


### PR DESCRIPTION
This PR is essentially a partial revert of https://github.com/duckdb/duckdb/pull/14424 - that fixes a performance regression that was caused by the Top-N operator doing the global boundary checking **after** constructing the sort key, instead of before. This meant that, even for rows where we would be certain they would not be added to the heap, we would be constructing sort keys. This PR brings back the old code that allows the boundary values to be checked directly on the sort keys. In order to facilitate this, we deserialize the global boundary value (stored as a sort key) back into a `DataChunk` that can be compared against directly.