### PR TITLE
fix bundle-library step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,10 +494,12 @@ generate-files:
 
 bundle-library: release
 	cd build/release && \
+	rm -rf bundle && \
 	mkdir -p bundle && \
 	cp src/libduckdb_static.a bundle/. && \
 	cp third_party/*/libduckdb_*.a bundle/. && \
 	cp extension/*/lib*_extension.a bundle/. && \
 	cd bundle && \
-	find . -name '*.a' -exec ${AR} -x {} \; && \
-	${AR} cr ../libduckdb_bundle.a *.o
+	find . -name '*.a' -exec mkdir -p {}.objects \; -exec mv {} {}.objects \; && \
+	find . -name '*.a' -execdir ${AR} -x {} \; && \
+	${AR} cr ../libduckdb_bundle.a ./*/*.o


### PR DESCRIPTION
@taniabogatsch 

Caught the culprit. So the bundling step does the following:
- unpack all static libs into their object files
- repack all object files into one archive

Because this is currently just throwing all these object files into `build/release/*` there is one small problem. When object files have name collisions, they overwrite each other.

This was happening for:
- `encode.cpp`
    - `third_party/brotli/enc/encode.cpp`
    - `extension/core_functions/scalar/blob/encode.cpp`
- `base64.cpp` 
    - `third_party/mbedtls/library/base64.cpp`
    - `extension/core_functions/scalar/blob/base64.cpp`
    
I will follow up to this PR with a PR that switches all third party libraries to object libraries. This was attempted to solve this bundling issue and while not solving this problem, it does solve others so should probably also be done.

Switching extensions to object libraries is also an interesting idea but I'm slightly worried its a lot of work and may break peoples extension builds. For that reason I will not do that yet