### PR TITLE
Dynamically push table filters from Top-N operator

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -3588,19 +3588,20 @@ const StringUtil::EnumStringLiteral *GetTableFilterTypeValues() {
 		{ static_cast<uint32_t>(TableFilterType::CONJUNCTION_AND), "CONJUNCTION_AND" },
 		{ static_cast<uint32_t>(TableFilterType::STRUCT_EXTRACT), "STRUCT_EXTRACT" },
 		{ static_cast<uint32_t>(TableFilterType::OPTIONAL_FILTER), "OPTIONAL_FILTER" },
-		{ static_cast<uint32_t>(TableFilterType::IN_FILTER), "IN_FILTER" }
+		{ static_cast<uint32_t>(TableFilterType::IN_FILTER), "IN_FILTER" },
+		{ static_cast<uint32_t>(TableFilterType::DYNAMIC_FILTER), "DYNAMIC_FILTER" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<TableFilterType>(TableFilterType value) {
-	return StringUtil::EnumToString(GetTableFilterTypeValues(), 8, "TableFilterType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetTableFilterTypeValues(), 9, "TableFilterType", static_cast<uint32_t>(value));
 }
 
 template<>
 TableFilterType EnumUtil::FromString<TableFilterType>(const char *value) {
-	return static_cast<TableFilterType>(StringUtil::StringToEnum(GetTableFilterTypeValues(), 8, "TableFilterType", value));
+	return static_cast<TableFilterType>(StringUtil::StringToEnum(GetTableFilterTypeValues(), 9, "TableFilterType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetTablePartitionInfoValues() {

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -128,17 +128,6 @@ private:
 		return false;
 	}
 
-	inline bool EntryShouldBeAdded(const string_t &sort_key, const string &boundary_val,
-	                               const string_t &global_boundary_val) {
-		// first compare against the global boundary value (if there is any)
-		if (!boundary_val.empty() && sort_key > global_boundary_val) {
-			// this entry is out-of-range for the global boundary val
-			// it will never be in the final result even if it fits in this heap
-			return false;
-		}
-		return EntryShouldBeAdded(sort_key);
-	}
-
 	inline void AddEntryToHeap(const TopNEntry &entry) {
 		if (heap.size() >= heap_size) {
 			std::pop_heap(heap.begin(), heap.end());

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -490,6 +490,9 @@ unique_ptr<LocalSinkState> PhysicalTopN::GetLocalSinkState(ExecutionContext &con
 }
 
 unique_ptr<GlobalSinkState> PhysicalTopN::GetGlobalSinkState(ClientContext &context) const {
+	if (dynamic_filter) {
+		dynamic_filter->Reset();
+	}
 	return make_uniq<TopNGlobalState>(context, *this);
 }
 

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -8,9 +8,12 @@
 namespace duckdb {
 
 PhysicalTopN::PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset,
-                           idx_t estimated_cardinality)
+                           shared_ptr<DynamicFilterData> dynamic_filter_p, idx_t estimated_cardinality)
     : PhysicalOperator(PhysicalOperatorType::TOP_N, std::move(types), estimated_cardinality), orders(std::move(orders)),
-      limit(limit), offset(offset) {
+      limit(limit), offset(offset), dynamic_filter(std::move(dynamic_filter_p)) {
+}
+
+PhysicalTopN::~PhysicalTopN() {
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/execution/physical_plan/plan_top_n.cpp
+++ b/src/execution/physical_plan/plan_top_n.cpp
@@ -9,8 +9,9 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) 
 
 	auto plan = CreatePlan(*op.children[0]);
 
-	auto top_n = make_uniq<PhysicalTopN>(op.types, std::move(op.orders), NumericCast<idx_t>(op.limit),
-	                                     NumericCast<idx_t>(op.offset), op.estimated_cardinality);
+	auto top_n =
+	    make_uniq<PhysicalTopN>(op.types, std::move(op.orders), NumericCast<idx_t>(op.limit),
+	                            NumericCast<idx_t>(op.offset), std::move(op.dynamic_filter), op.estimated_cardinality);
 	top_n->children.push_back(std::move(plan));
 	return std::move(top_n);
 }

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -15,9 +15,10 @@
 namespace duckdb {
 class DataChunk;
 class DynamicTableFilterSet;
+class LogicalGet;
+class JoinHashTable;
 struct GlobalUngroupedAggregateState;
 struct LocalUngroupedAggregateState;
-class JoinHashTable;
 
 struct JoinFilterPushdownColumn {
 	//! The probe column index to which this filter should be applied

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -45,6 +45,13 @@ struct JoinFilterPushdownFilter {
 	vector<JoinFilterPushdownColumn> columns;
 };
 
+struct PushdownFilterTarget {
+	PushdownFilterTarget(LogicalGet &get, vector<JoinFilterPushdownColumn> columns_p) : get(get), columns(std::move(columns_p)) {}
+
+	LogicalGet &get;
+	vector<JoinFilterPushdownColumn> columns;
+};
+
 struct JoinFilterPushdownInfo {
 	//! The join condition indexes for which we compute the min/max aggregates
 	vector<idx_t> join_condition;

--- a/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
+++ b/src/include/duckdb/execution/operator/join/join_filter_pushdown.hpp
@@ -46,7 +46,9 @@ struct JoinFilterPushdownFilter {
 };
 
 struct PushdownFilterTarget {
-	PushdownFilterTarget(LogicalGet &get, vector<JoinFilterPushdownColumn> columns_p) : get(get), columns(std::move(columns_p)) {}
+	PushdownFilterTarget(LogicalGet &get, vector<JoinFilterPushdownColumn> columns_p)
+	    : get(get), columns(std::move(columns_p)) {
+	}
 
 	LogicalGet &get;
 	vector<JoinFilterPushdownColumn> columns;

--- a/src/include/duckdb/execution/operator/order/physical_top_n.hpp
+++ b/src/include/duckdb/execution/operator/order/physical_top_n.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/bound_query_node.hpp"
 
 namespace duckdb {
+struct DynamicFilterData;
 
 //! Represents a physical ordering of the data. Note that this will not change
 //! the data but only add a selection vector.
@@ -21,11 +22,14 @@ public:
 
 public:
 	PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset,
-	             idx_t estimated_cardinality);
+	             shared_ptr<DynamicFilterData> dynamic_filter, idx_t estimated_cardinality);
+	~PhysicalTopN() override;
 
 	vector<BoundOrderByNode> orders;
 	idx_t limit;
 	idx_t offset;
+	//! Dynamic table filter (if any)
+	shared_ptr<DynamicFilterData> dynamic_filter;
 
 public:
 	// Source interface

--- a/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
@@ -23,7 +23,7 @@ public:
 public:
 	void VisitOperator(LogicalOperator &op) override;
 	static void GetPushdownFilterTargets(LogicalOperator &op, vector<JoinFilterPushdownColumn> columns,
-					  vector<PushdownFilterTarget> &targets);
+	                                     vector<PushdownFilterTarget> &targets);
 
 private:
 	void GenerateJoinFilters(LogicalComparisonJoin &join);

--- a/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
@@ -20,7 +20,10 @@ class JoinFilterPushdownOptimizer : public LogicalOperatorVisitor {
 public:
 	explicit JoinFilterPushdownOptimizer(Optimizer &optimizer);
 
+public:
 	void VisitOperator(LogicalOperator &op) override;
+	static void GetPushdownFilterTargets(LogicalOperator &op, vector<JoinFilterPushdownColumn> columns,
+					  vector<PushdownFilterTarget> &targets);
 
 private:
 	void GenerateJoinFilters(LogicalComparisonJoin &join);

--- a/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
@@ -13,6 +13,7 @@
 
 namespace duckdb {
 class Optimizer;
+struct JoinFilterPushdownColumn;
 
 //! The JoinFilterPushdownOptimizer links comparison joins to data sources to enable dynamic execution-time filter
 //! pushdown

--- a/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
+++ b/src/include/duckdb/optimizer/join_filter_pushdown_optimizer.hpp
@@ -14,6 +14,7 @@
 namespace duckdb {
 class Optimizer;
 struct JoinFilterPushdownColumn;
+struct PushdownFilterTarget;
 
 //! The JoinFilterPushdownOptimizer links comparison joins to data sources to enable dynamic execution-time filter
 //! pushdown

--- a/src/include/duckdb/optimizer/topn_optimizer.hpp
+++ b/src/include/duckdb/optimizer/topn_optimizer.hpp
@@ -20,6 +20,9 @@ public:
 	unique_ptr<LogicalOperator> Optimize(unique_ptr<LogicalOperator> op);
 	//! Whether we can perform the optimization on this operator
 	static bool CanOptimize(LogicalOperator &op);
+
+private:
+	void PushdownDynamicFilters(LogicalTopN &op);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/topn_optimizer.hpp
+++ b/src/include/duckdb/optimizer/topn_optimizer.hpp
@@ -12,6 +12,7 @@
 
 namespace duckdb {
 class LogicalOperator;
+class LogicalTopN;
 class Optimizer;
 
 class TopN {

--- a/src/include/duckdb/planner/filter/dynamic_filter.hpp
+++ b/src/include/duckdb/planner/filter/dynamic_filter.hpp
@@ -21,6 +21,7 @@ struct DynamicFilterData {
 	bool initialized = false;
 
 	void SetValue(Value val);
+	void Reset();
 };
 
 class DynamicFilter : public TableFilter {

--- a/src/include/duckdb/planner/filter/dynamic_filter.hpp
+++ b/src/include/duckdb/planner/filter/dynamic_filter.hpp
@@ -18,6 +18,9 @@ namespace duckdb {
 struct DynamicFilterData {
 	mutex lock;
 	unique_ptr<TableFilter> filter;
+	bool initialized = false;
+
+	void SetValue(Value val);
 };
 
 class DynamicFilter : public TableFilter {

--- a/src/include/duckdb/planner/filter/dynamic_filter.hpp
+++ b/src/include/duckdb/planner/filter/dynamic_filter.hpp
@@ -1,0 +1,44 @@
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/planner/filter/dynamic_filter.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/planner/table_filter.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/enums/expression_type.hpp"
+
+namespace duckdb {
+
+struct DynamicFilterData {
+	mutex lock;
+	unique_ptr<TableFilter> filter;
+};
+
+class DynamicFilter : public TableFilter {
+public:
+	static constexpr const TableFilterType TYPE = TableFilterType::DYNAMIC_FILTER;
+
+public:
+	DynamicFilter();
+	explicit DynamicFilter(shared_ptr<DynamicFilterData> filter_data);
+
+	//! The shared, dynamic filter data
+	shared_ptr<DynamicFilterData> filter_data;
+
+public:
+	FilterPropagateResult CheckStatistics(BaseStatistics &stats) override;
+	string ToString(const string &column_name) override;
+	bool Equals(const TableFilter &other) const override;
+	unique_ptr<TableFilter> Copy() const override;
+	unique_ptr<Expression> ToExpression(const Expression &column) const override;
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<TableFilter> Deserialize(Deserializer &deserializer);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_top_n.hpp
+++ b/src/include/duckdb/planner/operator/logical_top_n.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/logical_operator.hpp"
 
 namespace duckdb {
+struct DynamicFilterData;
 
 //! LogicalTopN represents a comibination of ORDER BY and LIMIT clause, using Min/Max Heap
 class LogicalTopN : public LogicalOperator {
@@ -19,15 +20,16 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_TOP_N;
 
 public:
-	LogicalTopN(vector<BoundOrderByNode> orders, idx_t limit, idx_t offset)
-	    : LogicalOperator(LogicalOperatorType::LOGICAL_TOP_N), orders(std::move(orders)), limit(limit), offset(offset) {
-	}
+	LogicalTopN(vector<BoundOrderByNode> orders, idx_t limit, idx_t offset);
+	~LogicalTopN() override;
 
 	vector<BoundOrderByNode> orders;
 	//! The maximum amount of elements to emit
 	idx_t limit;
 	//! The offset from the start to begin emitting elements
 	idx_t offset;
+	//! Dynamic table filter (if any)
+	shared_ptr<DynamicFilterData> dynamic_filter;
 
 public:
 	vector<ColumnBinding> GetColumnBindings() override {

--- a/src/include/duckdb/planner/table_filter.hpp
+++ b/src/include/duckdb/planner/table_filter.hpp
@@ -31,7 +31,8 @@ enum class TableFilterType : uint8_t {
 	CONJUNCTION_AND = 4,     // AND of different filters
 	STRUCT_EXTRACT = 5,      // filter applies to child-column of struct
 	OPTIONAL_FILTER = 6,     // executing filter is not required for query correctness
-	IN_FILTER = 7            // col IN (C1, C2, C3, ...)
+	IN_FILTER = 7,           // col IN (C1, C2, C3, ...)
+	DYNAMIC_FILTER = 8       // dynamic filters can be updated at run-time
 };
 
 //! TableFilter represents a filter pushed down into the table scan.

--- a/src/include/duckdb/storage/serialization/table_filter.json
+++ b/src/include/duckdb/storage/serialization/table_filter.json
@@ -134,5 +134,15 @@
       }
     ],
     "constructor": ["values"]
+  },
+  {
+    "class": "DynamicFilter",
+    "base": "TableFilter",
+    "includes": [
+      "duckdb/planner/filter/dynamic_filter.hpp"
+    ],
+    "enum": "DYNAMIC_FILTER",
+    "members": [
+    ]
   }
 ]

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -30,8 +30,9 @@ bool PushdownJoinFilterExpression(Expression &expr, JoinFilterPushdownColumn &fi
 	return true;
 }
 
-void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op, vector<JoinFilterPushdownColumn> columns,
-                                  vector<PushdownFilterTarget> &targets) {
+void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op,
+                                                           vector<JoinFilterPushdownColumn> columns,
+                                                           vector<PushdownFilterTarget> &targets) {
 	auto &probe_child = op;
 	switch (probe_child.type) {
 	case LogicalOperatorType::LOGICAL_LIMIT:
@@ -199,7 +200,7 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 	// recurse the query tree to find the LogicalGets in which we can push the filter info
 	vector<PushdownFilterTarget> pushdown_filter_targets;
 	GetPushdownFilterTargets(*join.children[0], pushdown_columns, pushdown_filter_targets);
-	for(auto &target : pushdown_filter_targets) {
+	for (auto &target : pushdown_filter_targets) {
 		auto &get = target.get;
 		// pushdown info can be applied to this LogicalGet - push the dynamic table filter set
 		if (!get.dynamic_filters) {

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -30,8 +30,8 @@ bool PushdownJoinFilterExpression(Expression &expr, JoinFilterPushdownColumn &fi
 	return true;
 }
 
-void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdownColumn> columns,
-                                  JoinFilterPushdownInfo &pushdown_info) {
+void JoinFilterPushdownOptimizer::GetPushdownFilterTargets(LogicalOperator &op, vector<JoinFilterPushdownColumn> columns,
+                                  vector<PushdownFilterTarget> &targets) {
 	auto &probe_child = op;
 	switch (probe_child.type) {
 	case LogicalOperatorType::LOGICAL_LIMIT:
@@ -43,7 +43,7 @@ void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdown
 	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
 		// does not affect probe side - recurse into left child
 		// FIXME: we can probably recurse into more operators here (e.g. window, unnest)
-		GenerateJoinFiltersRecursive(*probe_child.children[0], std::move(columns), pushdown_info);
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
 		break;
 	case LogicalOperatorType::LOGICAL_UNNEST: {
 		auto &unnest = probe_child.Cast<LogicalUnnest>();
@@ -54,7 +54,7 @@ void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdown
 				return;
 			}
 		}
-		GenerateJoinFiltersRecursive(*probe_child.children[0], std::move(columns), pushdown_info);
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_EXCEPT:
@@ -80,7 +80,7 @@ void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdown
 				child_columns.push_back(new_col);
 			}
 			// then recurse into the child
-			GenerateJoinFiltersRecursive(*child, std::move(child_columns), pushdown_info);
+			GetPushdownFilterTargets(*child, std::move(child_columns), targets);
 
 			// for EXCEPT we can only recurse into the first (left) child
 			if (probe_child.type == LogicalOperatorType::LOGICAL_EXCEPT) {
@@ -102,15 +102,7 @@ void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdown
 				return;
 			}
 		}
-		// pushdown info can be applied to this LogicalGet - push the dynamic table filter set
-		if (!get.dynamic_filters) {
-			get.dynamic_filters = make_shared_ptr<DynamicTableFilterSet>();
-		}
-
-		JoinFilterPushdownFilter get_filter;
-		get_filter.dynamic_filters = get.dynamic_filters;
-		get_filter.columns = std::move(columns);
-		pushdown_info.probe_info.push_back(std::move(get_filter));
+		targets.emplace_back(get, std::move(columns));
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_PROJECTION: {
@@ -127,7 +119,7 @@ void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdown
 				return;
 			}
 		}
-		GenerateJoinFiltersRecursive(*probe_child.children[0], std::move(columns), pushdown_info);
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
 		break;
 	}
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
@@ -144,7 +136,7 @@ void GenerateJoinFiltersRecursive(LogicalOperator &op, vector<JoinFilterPushdown
 				return;
 			}
 		}
-		GenerateJoinFiltersRecursive(*probe_child.children[0], std::move(columns), pushdown_info);
+		GetPushdownFilterTargets(*probe_child.children[0], std::move(columns), targets);
 		break;
 	}
 	default:
@@ -205,7 +197,20 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 		return;
 	}
 	// recurse the query tree to find the LogicalGets in which we can push the filter info
-	GenerateJoinFiltersRecursive(*join.children[0], pushdown_columns, *pushdown_info);
+	vector<PushdownFilterTarget> pushdown_filter_targets;
+	GetPushdownFilterTargets(*join.children[0], pushdown_columns, pushdown_filter_targets);
+	for(auto &target : pushdown_filter_targets) {
+		auto &get = target.get;
+		// pushdown info can be applied to this LogicalGet - push the dynamic table filter set
+		if (!get.dynamic_filters) {
+			get.dynamic_filters = make_shared_ptr<DynamicTableFilterSet>();
+		}
+
+		JoinFilterPushdownFilter get_filter;
+		get_filter.dynamic_filters = get.dynamic_filters;
+		get_filter.columns = std::move(target.columns);
+		pushdown_info->probe_info.push_back(std::move(get_filter));
+	}
 
 	// Even if we cannot find any table sources in which we can push down filters,
 	// we still initialize the aggregate states so that we have the possibility of doing a perfect hash join

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -8,6 +8,8 @@
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
 #include "duckdb/planner/filter/null_filter.hpp"
+#include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
+#include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
 
 namespace duckdb {
 

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -1,15 +1,16 @@
 #include "duckdb/optimizer/topn_optimizer.hpp"
 
 #include "duckdb/common/limits.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
-#include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
-#include "duckdb/planner/filter/null_filter.hpp"
+#include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/optimizer/join_filter_pushdown_optimizer.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 
 namespace duckdb {
 
@@ -58,7 +59,7 @@ void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 	vector<JoinFilterPushdownColumn> columns;
 	JoinFilterPushdownColumn column;
 	column.probe_column_index = colref.binding;
-	columns.emplace_back(std::move(column));
+	columns.emplace_back(column);
 	vector<PushdownFilterTarget> pushdown_targets;
 	JoinFilterPushdownOptimizer::GetPushdownFilterTargets(*op.children[0], std::move(columns), pushdown_targets);
 	if (pushdown_targets.empty()) {

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -36,11 +36,6 @@ bool TopN::CanOptimize(LogicalOperator &op) {
 
 void TopN::PushdownDynamicFilters(LogicalTopN &op) {
 	// pushdown dynamic filters through the Top-N operator
-	if (op.orders[0].null_order == OrderByNullType::NULLS_FIRST) {
-		// FIXME: not supported for NULLS FIRST quite yet
-		// we can support NULLS FIRST by doing (x IS NULL) OR [boundary value]
-		return;
-	}
 	auto &type = op.orders[0].expression->return_type;
 	if (!TypeIsIntegral(type.InternalType())) {
 		// only supported for integral types currently

--- a/src/optimizer/topn_optimizer.cpp
+++ b/src/optimizer/topn_optimizer.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/dynamic_filter.hpp"
 
 namespace duckdb {
 
@@ -30,6 +32,66 @@ bool TopN::CanOptimize(LogicalOperator &op) {
 		return child_op->type == LogicalOperatorType::LOGICAL_ORDER_BY;
 	}
 	return false;
+}
+
+void TopN::PushdownDynamicFilters(LogicalTopN &op) {
+	// pushdown dynamic filters through the Top-N operator
+	if (op.orders[0].null_order == OrderByNullType::NULLS_FIRST) {
+		// FIXME: not supported for NULLS FIRST quite yet
+		return;
+	}
+	auto &type = op.orders[0].expression->return_type;
+	if (!TypeIsIntegral(type.InternalType())) {
+		// only supported for integral types currently
+		return;
+	}
+	if (op.orders[0].expression->type != ExpressionType::BOUND_COLUMN_REF) {
+		// we can only pushdown on ORDER BY [col] currently
+		return;
+	}
+	auto &colref = op.orders[0].expression->Cast<BoundColumnRefExpression>();
+	vector<JoinFilterPushdownColumn> columns;
+	JoinFilterPushdownColumn column;
+	column.probe_column_index = colref.binding;
+	columns.emplace_back(std::move(column));
+	vector<PushdownFilterTarget> pushdown_targets;
+	JoinFilterPushdownOptimizer::GetPushdownFilterTargets(*op.children[0], std::move(columns), pushdown_targets);
+	if (pushdown_targets.empty()) {
+		// no pushdown targets
+		return;
+	}
+	// found pushdown targets! generate dynamic filters
+	unique_ptr<TableFilter> base_filter;
+	if (op.orders[0].type == OrderType::ASCENDING) {
+		// for ascending order, we want the lowest N elements, so we filter on C <= [boundary]
+		// note: if we only have a single order clause, we could filter on C < boundary instead
+		// but that doesn't work with us pushing the sentinel value here
+		auto initial_bound = Value::MaximumValue(type);
+		base_filter = make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(initial_bound));
+	} else {
+		// for descending order, we want the highest N elements, so we filter on C >= [boundary]
+		auto initial_bound = Value::MinimumValue(type);
+		base_filter = make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(initial_bound));
+	}
+	auto filter_data = make_shared_ptr<DynamicFilterData>();
+	filter_data->filter = std::move(base_filter);
+
+	// put the filter into the Top-N clause
+	op.dynamic_filter = filter_data;
+
+	for (auto &target : pushdown_targets) {
+		auto &get = target.get;
+		D_ASSERT(target.columns.size() == 1);
+		auto col_idx = target.columns[0].probe_column_index.column_index;
+
+		// create the actual dynamic filter
+		auto dynamic_filter = make_uniq<DynamicFilter>(filter_data);
+		auto optional_filter = make_uniq<OptionalFilter>(std::move(dynamic_filter));
+
+		// push the filter into the table scan
+		auto &column_index = get.GetColumnIds()[col_idx];
+		get.table_filters.PushFilter(column_index, std::move(optional_filter));
+	}
 }
 
 unique_ptr<LogicalOperator> TopN::Optimize(unique_ptr<LogicalOperator> op) {
@@ -66,6 +128,7 @@ unique_ptr<LogicalOperator> TopN::Optimize(unique_ptr<LogicalOperator> op) {
 		if (topn->children[0]->has_estimated_cardinality && topn->children[0]->estimated_cardinality < limit_val) {
 			cardinality = topn->children[0]->estimated_cardinality;
 		}
+		PushdownDynamicFilters(*topn);
 		topn->SetEstimatedCardinality(cardinality);
 		op = std::move(topn);
 

--- a/src/planner/filter/CMakeLists.txt
+++ b/src/planner/filter/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library_unity(
   OBJECT
   conjunction_filter.cpp
   constant_filter.cpp
+  dynamic_filter.cpp
   in_filter.cpp
   null_filter.cpp
   struct_filter.cpp

--- a/src/planner/filter/dynamic_filter.cpp
+++ b/src/planner/filter/dynamic_filter.cpp
@@ -15,6 +15,9 @@ FilterPropagateResult DynamicFilter::CheckStatistics(BaseStatistics &stats) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	lock_guard<mutex> l(filter_data->lock);
+	if (!filter_data->initialized) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
 	return filter_data->filter->CheckStatistics(stats);
 }
 
@@ -45,6 +48,12 @@ bool DynamicFilter::Equals(const TableFilter &other_p) const {
 
 unique_ptr<TableFilter> DynamicFilter::Copy() const {
 	return make_uniq<DynamicFilter>(filter_data);
+}
+
+void DynamicFilterData::SetValue(Value val) {
+	lock_guard<mutex> l(lock);
+	filter->Cast<ConstantFilter>().constant = std::move(val);
+	initialized = true;
 }
 
 } // namespace duckdb

--- a/src/planner/filter/dynamic_filter.cpp
+++ b/src/planner/filter/dynamic_filter.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/planner/filter/dynamic_filter.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 
 namespace duckdb {

--- a/src/planner/filter/dynamic_filter.cpp
+++ b/src/planner/filter/dynamic_filter.cpp
@@ -1,0 +1,50 @@
+#include "duckdb/planner/filter/dynamic_filter.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+
+namespace duckdb {
+
+DynamicFilter::DynamicFilter() : TableFilter(TableFilterType::DYNAMIC_FILTER) {
+}
+
+DynamicFilter::DynamicFilter(shared_ptr<DynamicFilterData> filter_data_p)
+    : TableFilter(TableFilterType::DYNAMIC_FILTER), filter_data(std::move(filter_data_p)) {
+}
+
+FilterPropagateResult DynamicFilter::CheckStatistics(BaseStatistics &stats) {
+	if (!filter_data) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	lock_guard<mutex> l(filter_data->lock);
+	return filter_data->filter->CheckStatistics(stats);
+}
+
+string DynamicFilter::ToString(const string &column_name) {
+	if (filter_data) {
+		return "Dynamic Filter (" + column_name + ")";
+	} else {
+		return "Empty Dynamic Filter (" + column_name + ")";
+	}
+}
+
+unique_ptr<Expression> DynamicFilter::ToExpression(const Expression &column) const {
+	if (!filter_data) {
+		auto bound_constant = make_uniq<BoundConstantExpression>(Value(true));
+		return bound_constant;
+	}
+	lock_guard<mutex> l(filter_data->lock);
+	return filter_data->filter->ToExpression(column);
+}
+
+bool DynamicFilter::Equals(const TableFilter &other_p) const {
+	if (!TableFilter::Equals(other_p)) {
+		return false;
+	}
+	auto &other = other_p.Cast<DynamicFilter>();
+	return other.filter_data.get() == filter_data.get();
+}
+
+unique_ptr<TableFilter> DynamicFilter::Copy() const {
+	return make_uniq<DynamicFilter>(filter_data);
+}
+
+} // namespace duckdb

--- a/src/planner/filter/dynamic_filter.cpp
+++ b/src/planner/filter/dynamic_filter.cpp
@@ -33,7 +33,7 @@ string DynamicFilter::ToString(const string &column_name) {
 unique_ptr<Expression> DynamicFilter::ToExpression(const Expression &column) const {
 	if (!filter_data) {
 		auto bound_constant = make_uniq<BoundConstantExpression>(Value(true));
-		return bound_constant;
+		return std::move(bound_constant);
 	}
 	lock_guard<mutex> l(filter_data->lock);
 	return filter_data->filter->ToExpression(column);

--- a/src/planner/filter/dynamic_filter.cpp
+++ b/src/planner/filter/dynamic_filter.cpp
@@ -51,9 +51,17 @@ unique_ptr<TableFilter> DynamicFilter::Copy() const {
 }
 
 void DynamicFilterData::SetValue(Value val) {
+	if (val.IsNull()) {
+		return;
+	}
 	lock_guard<mutex> l(lock);
 	filter->Cast<ConstantFilter>().constant = std::move(val);
 	initialized = true;
+}
+
+void DynamicFilterData::Reset() {
+	lock_guard<mutex> l(lock);
+	initialized = false;
 }
 
 } // namespace duckdb

--- a/src/planner/filter/null_filter.cpp
+++ b/src/planner/filter/null_filter.cpp
@@ -20,7 +20,7 @@ FilterPropagateResult IsNullFilter::CheckStatistics(BaseStatistics &stats) {
 }
 
 string IsNullFilter::ToString(const string &column_name) {
-	return column_name + "IS NULL";
+	return column_name + " IS NULL";
 }
 
 unique_ptr<TableFilter> IsNullFilter::Copy() const {

--- a/src/planner/operator/logical_top_n.cpp
+++ b/src/planner/operator/logical_top_n.cpp
@@ -2,6 +2,13 @@
 
 namespace duckdb {
 
+LogicalTopN::LogicalTopN(vector<BoundOrderByNode> orders, idx_t limit, idx_t offset)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_TOP_N), orders(std::move(orders)), limit(limit), offset(offset) {
+}
+
+LogicalTopN::~LogicalTopN() {
+}
+
 idx_t LogicalTopN::EstimateCardinality(ClientContext &context) {
 	auto child_cardinality = LogicalOperator::EstimateCardinality(context);
 	if (child_cardinality < limit) {

--- a/src/storage/serialization/serialize_table_filter.cpp
+++ b/src/storage/serialization/serialize_table_filter.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/filter/struct_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
+#include "duckdb/planner/filter/dynamic_filter.hpp"
 
 namespace duckdb {
 
@@ -31,6 +32,9 @@ unique_ptr<TableFilter> TableFilter::Deserialize(Deserializer &deserializer) {
 		break;
 	case TableFilterType::CONSTANT_COMPARISON:
 		result = ConstantFilter::Deserialize(deserializer);
+		break;
+	case TableFilterType::DYNAMIC_FILTER:
+		result = DynamicFilter::Deserialize(deserializer);
 		break;
 	case TableFilterType::IN_FILTER:
 		result = InFilter::Deserialize(deserializer);
@@ -85,6 +89,15 @@ unique_ptr<TableFilter> ConstantFilter::Deserialize(Deserializer &deserializer) 
 	auto comparison_type = deserializer.ReadProperty<ExpressionType>(200, "comparison_type");
 	auto constant = deserializer.ReadProperty<Value>(201, "constant");
 	auto result = duckdb::unique_ptr<ConstantFilter>(new ConstantFilter(comparison_type, constant));
+	return std::move(result);
+}
+
+void DynamicFilter::Serialize(Serializer &serializer) const {
+	TableFilter::Serialize(serializer);
+}
+
+unique_ptr<TableFilter> DynamicFilter::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<DynamicFilter>(new DynamicFilter());
 	return std::move(result);
 }
 

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -454,6 +454,7 @@ static idx_t GetFilterScanCount(ColumnScanState &state, TableFilter &filter) {
 	case TableFilterType::IS_NOT_NULL:
 	case TableFilterType::CONSTANT_COMPARISON:
 	case TableFilterType::IN_FILTER:
+	case TableFilterType::DYNAMIC_FILTER:
 		return state.current->start + state.current->count;
 	default: {
 		throw NotImplementedException("Unimplemented filter type for zonemap");


### PR DESCRIPTION
When executing a Top-N query, we need to find the top or bottom `N` values for a given set of conditions. The Top-N operator builds the result through a heap in which we keep track of the top-N values seen so far. For any given heap of `N` values, we know that any row that has an ordering column value that is larger (or smaller, for `DESC` ordering) will not be in the result set at that moment.

In the Top-N operator, we already keep track of this value - called the `boundary value` - and use it to prune out rows that we know are not going to be inserted into the heap early on in the `Sink` call. While this works in speeding up the Top-N operator itself, we still need to scan the rows from the base storage before finding out these rows will not make it into the final result.

This PR extends the Top-N operator to push the boundary value into the scans as a table filter. This is similar to the dynamic table filters generated through joins (introduced in https://github.com/duckdb/duckdb/pull/12908), but "more dynamic". While the filters generated through joins are generated once (when the HT build is complete), the Top-N filters are updated whenever the boundary value is updated - which can happen for every `Sink` call.

#### Implementation

The implementation works through a new table filter - the `DynamicFilter`. This is a regular `TableFilter` that holds a shared pointer to a `DynamicFilterData ` - which contains a child table filter together with a lock:

```cpp
struct DynamicFilterData {
	mutex lock;
	unique_ptr<TableFilter> filter;
	bool initialized = false;
};
```

This filter is generated in the `TopN` optimizer. The `TopN` contains a shared pointer to the `DynamicFilterData` as well. The `TopN` operator then updates the underlying filter during the `Sink` phase whenever the global boundary value is updated to a new value.

##### Performance

Below is an illustration of the performance gain we can obtain here, running this query over TPC-H SF10:

```sql
SELECT * FROM lineitem ORDER BY l_orderkey LIMIT 5;
```

| main  |  New  |
|-------|-------|
| 0.19s | 0.02s |

Note that this is not always beneficial, e.g. when looking in descending order in this scenario. Since the table is naturally ordered and we scan data in the table's natural order, we are never able to prune any row groups:

```sql
SELECT * FROM lineitem ORDER BY l_orderkey DESC LIMIT 5;
```

| main  |  New  |
|-------|-------|
| 0.23s | 0.23s |


#### Limitations

* When the `ORDER BY` clause has multiple order conditions, we can only generate the filter for the first order condition (since the value of the remaining ones is unknown).
* We currently only support `NULLS LAST` ordering. It is possible to extend to `NULLS FIRST`, but this is more tricky as we need to take `NULL` values into account in the generated filters/boundary value.
