### PR TITLE
Don't decode special characters on redirect

### DIFF
--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2515,7 +2515,7 @@ inline std::string decode_url(const std::string &s,
         auto val = 0;
         if (from_hex_to_i(s, i + 1, 2, val)) {
           const auto converted = static_cast<char>(val);
-          if (exclude.empty() || exclude.count(converted) == 0) {
+          if (exclude.count(converted) == 0) {
             result += converted;
           } else {
             result.append(s, i, 3);

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -7110,7 +7110,7 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
   if (next_host.empty()) { next_host = host_; }
   if (next_path.empty()) { next_path = "/"; }
   
-	auto path = detail::decode_url(next_path, true, std::set<char> {'/'}) + next_query;
+  auto path = detail::decode_url(next_path, true, std::set<char> {'/'}) + next_query;
 	
   if (next_scheme == scheme && next_host == host_ && next_port == port_) {
     return detail::redirect(*this, req, res, path, location, error);

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2514,10 +2514,10 @@ inline std::string decode_url(const std::string &s,
       } else {
         auto val = 0;
 	if (from_hex_to_i(s, i + 1, 2, val)) {
-	    const auto converted = static_cast<char>(val);
-	    if (exclude.empty() || exclude.count(converted) == 0) {
-	        result += converted;
-	    } else {
+		const auto converted = static_cast<char>(val);
+		if (exclude.empty() || exclude.count(converted) == 0) {
+			result += converted;
+		} else {
 		result.append(s, i, 3);
 	   }
 	  i += 2; // '00'

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2512,15 +2512,15 @@ inline std::string decode_url(const std::string &s,
           result += s[i];
         }
       } else {
-        auto val = 0;
-	if (from_hex_to_i(s, i + 1, 2, val)) {
-		const auto converted = static_cast<char>(val);
-		if (exclude.empty() || exclude.count(converted) == 0) {
-			result += converted;
-		} else {
-		result.append(s, i, 3);
-	   }
-	  i += 2; // '00'
+				auto val = 0;
+				if (from_hex_to_i(s, i + 1, 2, val)) {
+	 				const auto converted = static_cast<char>(val);
+					if (exclude.empty() || exclude.count(converted) == 0) {
+						result += converted;
+					} else {
+						result.append(s, i, 3);
+	   			}
+	  			i += 2; // '00'
         } else {
           result += s[i];
         }

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2513,14 +2513,14 @@ inline std::string decode_url(const std::string &s,
         }
       } else {
         auto val = 0;
-				if (from_hex_to_i(s, i + 1, 2, val)) {
-		      const auto converted = static_cast<char>(val);
-					if (exclude.empty() || exclude.count(converted) == 0) {
-					    result += converted;
-					} else {
-					    result.append(s, i, 3);
-					}
-					i += 2; // '00'
+	if (from_hex_to_i(s, i + 1, 2, val)) {
+	    const auto converted = static_cast<char>(val);
+	    if (exclude.empty() || exclude.count(converted) == 0) {
+	        result += converted;
+	    } else {
+		result.append(s, i, 3);
+	   }
+	  i += 2; // '00'
         } else {
           result += s[i];
         }

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2080,8 +2080,7 @@ namespace detail {
 
 std::string encode_query_param(const std::string &value);
 
-std::string decode_url(const std::string &s, bool convert_plus_to_space);
-
+std::string decode_url(const std::string &s, bool convert_plus_to_space, const std::set<char> &exclude = {});
 void read_file(const std::string &path, std::string &out);
 
 std::string trim_copy(const std::string &s);
@@ -2495,7 +2494,8 @@ inline std::string encode_url(const std::string &s) {
 }
 
 inline std::string decode_url(const std::string &s,
-                              bool convert_plus_to_space) {
+                              bool convert_plus_to_space,
+                              const std::set<char> &exclude) {
   std::string result;
 
   for (size_t i = 0; i < s.size(); i++) {
@@ -2513,10 +2513,14 @@ inline std::string decode_url(const std::string &s,
         }
       } else {
         auto val = 0;
-        if (from_hex_to_i(s, i + 1, 2, val)) {
-          // 2 digits hex codes
-          result += static_cast<char>(val);
-          i += 2; // '00'
+				if (from_hex_to_i(s, i + 1, 2, val)) {
+		      const auto converted = static_cast<char>(val);
+					if (exclude.empty() || exclude.count(converted) == 0) {
+					    result += converted;
+					} else {
+					    result.append(s, i, 3);
+					}
+					i += 2; // '00'
         } else {
           result += s[i];
         }
@@ -7105,9 +7109,9 @@ inline bool ClientImpl::redirect(Request &req, Response &res, Error &error) {
   if (next_scheme.empty()) { next_scheme = scheme; }
   if (next_host.empty()) { next_host = host_; }
   if (next_path.empty()) { next_path = "/"; }
-
-  auto path = detail::decode_url(next_path, true) + next_query;
-
+  
+	auto path = detail::decode_url(next_path, true, std::set<char> {'/'}) + next_query;
+	
   if (next_scheme == scheme && next_host == host_ && next_port == port_) {
     return detail::redirect(*this, req, res, path, location, error);
   } else {

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2512,15 +2512,15 @@ inline std::string decode_url(const std::string &s,
           result += s[i];
         }
       } else {
-				auto val = 0;
-				if (from_hex_to_i(s, i + 1, 2, val)) {
-	 				const auto converted = static_cast<char>(val);
-					if (exclude.empty() || exclude.count(converted) == 0) {
-						result += converted;
-					} else {
-						result.append(s, i, 3);
-	   			}
-	  			i += 2; // '00'
+        auto val = 0;
+        if (from_hex_to_i(s, i + 1, 2, val)) {
+          const auto converted = static_cast<char>(val);
+          if (exclude.empty() || exclude.count(converted) == 0) {
+            result += converted;
+          } else {
+            result.append(s, i, 3);
+          }
+          i += 2; // '00'
         } else {
           result += s[i];
         }


### PR DESCRIPTION
This PR start with a small increment to extend decoding_url function to accept a set of characters that should be excluded when decoding the URL.

Given the times it's invoked a set should be fine, unless we want ultra optimization in that particular function.

The functionality just ignore '/' after decoding if it's a PATH component DURING redirects. 
Ideally, this can be reused when other parts of the code suffer from the same issue...

A test can be added, but given the URL mentioned in the issue is external and not owned by this repo, it may cause failures in the future.

```
D select count(*) from 'https://huggingface.co/api/datasets/olivierdehaene/xkcd/parquet/default/train/0.parquet';
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│     2630     │
└──────────────┘
```


Info
----------------------

The RFC says that certain characters (mostly reserved) that may interfere with the section shouldn't be decoded. 


From: https://www.urldecoder.org/
```
The reserved character "/", for example, if used in the "path" component of a URI, has the special meaning of being a delimiter between path segments. If, according to a given URI scheme, "/" needs to be in a path segment, then the three characters "%2F" (or "%2f") must be used in the segment instead of a "/".
```

From RFC: https://datatracker.ietf.org/doc/html/rfc3986#section-2.1

```
A subset of the reserved characters (gen-delims) is used as
   delimiters of the generic URI components described in [Section 3](https://datatracker.ietf.org/doc/html/rfc3986#section-3).  A
   component's ABNF syntax rule will not use the reserved or gen-delims
   rule names directly; instead, each syntax rule lists the characters
   allowed within that component (i.e., not delimiting it), and any of
   those characters that are also in the reserved set are "reserved" for
   use as subcomponent delimiters within the component.  Only the most
   common subcomponents are defined by this specification; other
   subcomponents may be defined by a URI scheme's specification, or by
   the implementation-specific syntax of a URI's dereferencing
   algorithm, provided that such subcomponents are delimited by
   characters in the reserved set allowed within that component.
```


Closes: #14819

