### PR TITLE
Internal #3615: Quantile Cursor Allocation

### DIFF
--- a/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
@@ -301,7 +301,7 @@ struct QuantileState {
 	}
 
 	CursorType &GetOrCreateWindowCursor(const WindowPartitionInput &partition) {
-		if (!window_state) {
+		if (!window_cursor) {
 			window_cursor = make_uniq<CursorType>(partition);
 		}
 		return *window_cursor;


### PR DESCRIPTION
Only allocate cursors once per state object, not once per value.

fixes: duckdblabs/duckdb-internal#3615