### PR TITLE
Fix for #15080 cgroup v2 memory limit not being read correctly

### DIFF
--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -86,7 +86,13 @@ string CGroups::ReadCGroupPath(FileSystem &fs, const char *cgroup_file) {
 	string content(buffer);
 	auto pos = content.find("::");
 	if (pos != string::npos) {
-		return content.substr(pos + 2);
+		// remove trailing \n
+		auto pos2 = content.find('\n', pos + 2);
+		if (pos2 != string::npos) {
+			return content.substr(pos + 2, pos2 - (pos + 2));
+		} else {
+			return content.substr(pos + 2);
+		}
 	}
 #endif
 	return "";


### PR DESCRIPTION
Remove the trailing "\n" as noted in #15080 .  