### PR TITLE
Fix CheckMarkToSemi conversion in FilterPushdown optimizer

### DIFF
--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -14,6 +14,7 @@ using Filter = FilterPushdown::Filter;
 
 void FilterPushdown::CheckMarkToSemi(LogicalOperator &op, unordered_set<idx_t> &table_bindings) {
 	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
 		auto &join = op.Cast<LogicalComparisonJoin>();
 		if (join.join_type != JoinType::MARK) {
@@ -31,7 +32,6 @@ void FilterPushdown::CheckMarkToSemi(LogicalOperator &op, unordered_set<idx_t> &
 	case LogicalOperatorType::LOGICAL_PROJECTION: {
 		// when we encounter a projection, replace the table_bindings with
 		// the tables in the projection
-		auto plan_bindings = op.GetColumnBindings();
 		auto &proj = op.Cast<LogicalProjection>();
 		auto proj_bindings = proj.GetColumnBindings();
 		unordered_set<idx_t> new_table_bindings;
@@ -40,8 +40,8 @@ void FilterPushdown::CheckMarkToSemi(LogicalOperator &op, unordered_set<idx_t> &
 			auto &expr = proj.expressions.at(col_index);
 			vector<ColumnBinding> bindings_to_keep;
 			ExpressionIterator::EnumerateExpression(expr, [&](Expression &child) {
-				if (expr->expression_class == ExpressionClass::BOUND_COLUMN_REF) {
-					auto &col_ref = expr->Cast<BoundColumnRefExpression>();
+				if (child.expression_class == ExpressionClass::BOUND_COLUMN_REF) {
+					auto &col_ref = child.Cast<BoundColumnRefExpression>();
 					bindings_to_keep.push_back(col_ref.binding);
 				}
 			});

--- a/test/issues/general/test_13542.test
+++ b/test/issues/general/test_13542.test
@@ -1,0 +1,45 @@
+# name: test/issues/general/test_13542.test
+# description: Correlated subquery related? Failed to bind column reference "once_state2" [35.0] (bindings: {#[1.0], #[33.0]})
+# group: [general]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table stuff (
+      ts timestamp,
+      item_id int,
+      type text
+    );
+
+query III
+with
+    unique_items as (
+       select distinct item_id from stuff
+    ),
+    state_stuff as (
+      select
+        item_id,
+        exists (select 1 from stuff c where s.item_id = c.item_id
+                and type = 'state1') as once_state1,
+        exists (select 1 from stuff c where s.item_id = c.item_id
+                and type = 'state2') as once_state2
+      from unique_items s)
+    select * from state_stuff;
+----
+
+query III
+with
+    unique_items as (
+       select distinct item_id from stuff
+    ),
+    state_stuff as (
+      select
+        item_id,
+        exists (select 1 from stuff c where s.item_id = c.item_id
+                and type = 'state1') as once_state1,
+        exists (select 1 from stuff c where s.item_id = c.item_id
+                and type = 'state2') as once_state2
+      from unique_items s)
+    select * from state_stuff where not once_state2;
+----


### PR DESCRIPTION
This fixes issue #13542

---

The expression traversal in `FilterPushdown::CheckMarkToSemi` contained a bug. The child expressions were never checked.