### PR TITLE
Add make_date(INT) function, similar to make_timestamp(BIGINT)

### DIFF
--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -11,6 +11,17 @@
 
 namespace duckdb {
 
+struct MakeDateFromEpochOperator {
+	static date_t Operation(int32_t val) {
+		return Date::EpochDaysToDate(val);
+	}
+};
+
+static void MakeDateFromEpoch(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 1);
+	UnaryExecutor::Execute<int32_t, date_t>(input.data[0], result, input.size(), MakeDateFromEpochOperator::Operation);
+}
+
 struct MakeDateOperator {
 	template <typename YYYY, typename MM, typename DD, typename RESULT_TYPE>
 	static RESULT_TYPE Operation(YYYY yyyy, MM mm, DD dd) {
@@ -118,6 +129,7 @@ static void ExecuteMakeTimestamp(DataChunk &input, ExpressionState &state, Vecto
 
 ScalarFunctionSet MakeDateFun::GetFunctions() {
 	ScalarFunctionSet make_date("make_date");
+	make_date.AddFunction(ScalarFunction({LogicalType::INTEGER}, LogicalType::DATE, MakeDateFromEpoch));
 	make_date.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
 	                                     LogicalType::DATE, ExecuteMakeDate<int64_t>));
 

--- a/extension/core_functions/scalar/date/make_date.cpp
+++ b/extension/core_functions/scalar/date/make_date.cpp
@@ -11,15 +11,9 @@
 
 namespace duckdb {
 
-struct MakeDateFromEpochOperator {
-	static date_t Operation(int32_t val) {
-		return Date::EpochDaysToDate(val);
-	}
-};
-
 static void MakeDateFromEpoch(DataChunk &input, ExpressionState &state, Vector &result) {
 	D_ASSERT(input.ColumnCount() == 1);
-	UnaryExecutor::Execute<int32_t, date_t>(input.data[0], result, input.size(), MakeDateFromEpochOperator::Operation);
+	result.Reinterpret(input.data[0]);
 }
 
 struct MakeDateOperator {

--- a/test/sql/function/timestamp/make_date.test
+++ b/test/sql/function/timestamp/make_date.test
@@ -87,6 +87,13 @@ FROM (SELECT make_date(year(d), month(d), NULL) md FROM dates) t
 WHERE md IS NOT NULL
 ----
 
+# round trip
+query I
+SELECT *
+FROM dates
+WHERE d <> make_date((d - date '1970-01-01')::INT)
+----
+
 # Constants
 query IIII
 SELECT


### PR DESCRIPTION
`make_date(INT)` turns days since the unix epoch (`1970-01-01`) into a `DATE` object