### PR TITLE
Setting `temp_directory` to `NULL` should be same as setting it to `''`

### DIFF
--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1149,7 +1149,7 @@ void TempDirectorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, con
 	if (!config.options.enable_external_access) {
 		throw PermissionException("Modifying the temp_directory has been disabled by configuration");
 	}
-	config.options.temporary_directory = input.ToString();
+	config.options.temporary_directory = input.IsNull() ? "" : input.ToString();
 	config.options.use_temporary_directory = !config.options.temporary_directory.empty();
 	if (db) {
 		auto &buffer_manager = BufferManager::GetBufferManager(*db);

--- a/test/sql/storage/temp_directory/temp_directory_null.test
+++ b/test/sql/storage/temp_directory/temp_directory_null.test
@@ -1,0 +1,20 @@
+# name: test/sql/storage/temp_directory/temp_directory_null.test
+# group: [temp_directory]
+
+# this one worked from the start
+statement ok
+set temp_directory=''
+
+query  I
+select value from duckdb_settings() where name = 'temp_directory'
+----
+(empty)
+
+# this used to create a directory with name "null" - should also be empty to denote NO temp dir
+statement ok
+set temp_directory=null
+
+query  I
+select value from duckdb_settings() where name = 'temp_directory'
+----
+(empty)


### PR DESCRIPTION
It used to create a directory with name `NULL` before, which was confusing.