### PR TITLE
Avoid repartitioning out-of-core hash joins if very, very skewed 

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -209,7 +209,7 @@ struct ParquetWriteGlobalState : public GlobalFunctionData {
 
 struct ParquetWriteLocalState : public LocalFunctionData {
 	explicit ParquetWriteLocalState(ClientContext &context, const vector<LogicalType> &types)
-	    : buffer(context, types, ColumnDataAllocatorType::HYBRID) {
+	    : buffer(BufferAllocator::Get(context), types) {
 		buffer.InitializeAppend(append_state);
 	}
 

--- a/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -143,7 +143,7 @@ public:
 	FixedBatchCopyState current_task = FixedBatchCopyState::SINKING_DATA;
 
 	void InitializeCollection(ClientContext &context, const PhysicalOperator &op) {
-		collection = make_uniq<ColumnDataCollection>(context, op.children[0]->types, ColumnDataAllocatorType::HYBRID);
+		collection = make_uniq<ColumnDataCollection>(BufferAllocator::Get(context), op.children[0]->types);
 		collection->InitializeAppend(append_state);
 		local_memory_usage = 0;
 	}
@@ -434,7 +434,7 @@ void PhysicalBatchCopyToFile::RepartitionBatches(ClientContext &context, GlobalS
 				// the collection is too large for a batch - we need to repartition
 				// create an empty collection
 				auto new_collection =
-				    make_uniq<ColumnDataCollection>(context, children[0]->types, ColumnDataAllocatorType::HYBRID);
+				    make_uniq<ColumnDataCollection>(BufferAllocator::Get(context), children[0]->types);
 				append_batch = make_uniq<FixedRawBatchData>(0U, std::move(new_collection));
 			}
 			if (append_batch) {
@@ -458,8 +458,7 @@ void PhysicalBatchCopyToFile::RepartitionBatches(ClientContext &context, GlobalS
 			// the collection is full - move it to the result and create a new one
 			task_manager.AddTask(make_uniq<PrepareBatchTask>(gstate.scheduled_batch_index++, std::move(append_batch)));
 
-			auto new_collection =
-			    make_uniq<ColumnDataCollection>(context, children[0]->types, ColumnDataAllocatorType::HYBRID);
+			auto new_collection = make_uniq<ColumnDataCollection>(BufferAllocator::Get(context), children[0]->types);
 			append_batch = make_uniq<FixedRawBatchData>(0U, std::move(new_collection));
 			append_batch->collection->InitializeAppend(append_state);
 		}


### PR DESCRIPTION
... and use BufferAllocator to buffer data for Parquet instead of `ColumnDataAllocatorType::HYBRID`.

I ran into this while joining two Parquet files - one of which had only one distinct join key. Repartitioning doesn't help, as this will only cause an OOM exception later, so we shouldn't repartition at all, and fail early (or succeed if it _just_ fits in memory!).

I've also changed the allocator type for buffering data, as I found this caused excessive spilling when we were on the edge of the memory limit. We're now routing allocations through the buffer allocator, but not allowing them to spill.

This sped up the Parquet join I was doing from ~40s to ~6s.