### PR TITLE
Implement struct projection pushdown for JSON reads

### DIFF
--- a/extension/json/include/json_scan.hpp
+++ b/extension/json/include/json_scan.hpp
@@ -179,7 +179,8 @@ public:
 
 	//! Column names that we're actually reading (after projection pushdown)
 	vector<string> names;
-	vector<column_t> column_indices;
+	vector<column_t> column_ids;
+	vector<ColumnIndex> column_indices;
 
 	//! Buffer manager allocator
 	Allocator &allocator;

--- a/extension/json/include/json_transform.hpp
+++ b/extension/json/include/json_transform.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "duckdb/common/column_index.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/function/scalar/strftime_format.hpp"
 #include "json_common.hpp"
 
@@ -64,9 +66,10 @@ struct TryParseTimeStamp {
 
 struct JSONTransform {
 	static bool Transform(yyjson_val *vals[], yyjson_alc *alc, Vector &result, const idx_t count,
-	                      JSONTransformOptions &options);
+	                      JSONTransformOptions &options, optional_ptr<const ColumnIndex> column_index);
 	static bool TransformObject(yyjson_val *objects[], yyjson_alc *alc, const idx_t count, const vector<string> &names,
-	                            const vector<Vector *> &result_vectors, JSONTransformOptions &options);
+	                            const vector<Vector *> &result_vectors, JSONTransformOptions &options,
+	                            optional_ptr<const vector<ColumnIndex>> column_indices, bool error_unknown_key);
 	static bool GetStringVector(yyjson_val *vals[], const idx_t count, const LogicalType &target, Vector &string_vector,
 	                            JSONTransformOptions &options);
 };

--- a/extension/json/json_functions/read_json.cpp
+++ b/extension/json/json_functions/read_json.cpp
@@ -1,9 +1,9 @@
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/multi_file_reader.hpp"
 #include "json_functions.hpp"
 #include "json_scan.hpp"
 #include "json_structure.hpp"
 #include "json_transform.hpp"
-#include "duckdb/common/helper.hpp"
 
 namespace duckdb {
 
@@ -330,8 +330,8 @@ static void ReadJSONFunction(ClientContext &context, TableFunctionInput &data_p,
 
 	if (!gstate.names.empty()) {
 		vector<Vector *> result_vectors;
-		result_vectors.reserve(gstate.column_indices.size());
-		for (const auto &col_idx : gstate.column_indices) {
+		result_vectors.reserve(gstate.column_ids.size());
+		for (const auto &col_idx : gstate.column_ids) {
 			result_vectors.emplace_back(&output.data[col_idx]);
 		}
 
@@ -339,11 +339,12 @@ static void ReadJSONFunction(ClientContext &context, TableFunctionInput &data_p,
 		bool success;
 		if (gstate.bind_data.options.record_type == JSONRecordType::RECORDS) {
 			success = JSONTransform::TransformObject(values, lstate.GetAllocator(), count, gstate.names, result_vectors,
-			                                         lstate.transform_options);
+			                                         lstate.transform_options, gstate.column_indices,
+			                                         lstate.transform_options.error_unknown_key);
 		} else {
 			D_ASSERT(gstate.bind_data.options.record_type == JSONRecordType::VALUES);
 			success = JSONTransform::Transform(values, lstate.GetAllocator(), *result_vectors[0], count,
-			                                   lstate.transform_options);
+			                                   lstate.transform_options, gstate.column_indices[0]);
 		}
 
 		if (!success) {

--- a/extension/json/json_functions/read_json_objects.cpp
+++ b/extension/json/json_functions/read_json_objects.cpp
@@ -33,7 +33,7 @@ static void ReadJSONObjectsFunction(ClientContext &context, TableFunctionInput &
 
 	if (!gstate.names.empty()) {
 		// Create the strings without copying them
-		const auto col_idx = gstate.column_indices[0];
+		const auto col_idx = gstate.column_ids[0];
 		auto strings = FlatVector::GetData<string_t>(output.data[col_idx]);
 		auto &validity = FlatVector::Validity(output.data[col_idx]);
 		for (idx_t i = 0; i < count; i++) {

--- a/extension/json/json_scan.cpp
+++ b/extension/json/json_scan.cpp
@@ -185,8 +185,9 @@ unique_ptr<GlobalTableFunctionState> JSONGlobalTableFunctionState::Init(ClientCo
 			continue;
 		}
 
-		gstate.column_indices.push_back(col_idx);
 		gstate.names.push_back(bind_data.names[col_id]);
+		gstate.column_ids.push_back(col_idx);
+		gstate.column_indices.push_back(input.column_indexes[col_idx]);
 	}
 
 	if (gstate.names.size() < bind_data.names.size() || bind_data.options.file_options.union_by_name) {

--- a/test/sql/json/table/test_json_nested_struct_projection_pushdown.test
+++ b/test/sql/json/table/test_json_nested_struct_projection_pushdown.test
@@ -1,0 +1,51 @@
+# name: test/sql/json/table/test_json_nested_struct_projection_pushdown.test
+# description: Test JSON struct projection pushdown on deeply nested data
+# group: [table]
+
+require json
+
+statement ok
+pragma enable_verification
+
+statement ok
+COPY (SELECT {goose: 42, pigeon: 4.2, nested_duck: {nested_nested_duck: {goose: 42, pigeon: 4.2, nested_nested_nested_duck: {goose: 42, pigeon: 4.2}}, goose: 42, pigeon: 4.2}} AS duck) TO '__TEST_DIR__/nested.json'
+
+query I
+SELECT duck.goose FROM '__TEST_DIR__/nested.json'
+----
+42
+
+query I
+SELECT json.duck.goose FROM read_json('__TEST_DIR__/nested.json', records=false)
+----
+42
+
+query I
+SELECT duck.nested_duck.goose FROM '__TEST_DIR__/nested.json'
+----
+42
+
+query I
+SELECT json.duck.nested_duck.goose FROM read_json('__TEST_DIR__/nested.json', records=false)
+----
+42
+
+query I
+SELECT duck.nested_duck.nested_nested_duck.goose FROM '__TEST_DIR__/nested.json'
+----
+42
+
+query I
+SELECT json.duck.nested_duck.nested_nested_duck.goose FROM read_json('__TEST_DIR__/nested.json', records=false)
+----
+42
+
+query I
+SELECT duck.nested_duck.nested_nested_duck.nested_nested_nested_duck.goose FROM '__TEST_DIR__/nested.json'
+----
+42
+
+query I
+SELECT json.duck.nested_duck.nested_nested_duck.nested_nested_nested_duck.goose FROM read_json('__TEST_DIR__/nested.json', records=false)
+----
+42

--- a/test/sql/json/test_json_struct_projection_pushdown.test_slow
+++ b/test/sql/json/test_json_struct_projection_pushdown.test_slow
@@ -1,0 +1,164 @@
+# name: test/sql/json/test_json_struct_projection_pushdown.test_slow
+# description: Test JSON struct projection pushdown with TPC-H
+# group: [json]
+
+require json
+
+require tpch
+
+statement ok
+call dbgen(sf=1)
+
+statement ok
+export database '__TEST_DIR__/tpch_json' (format json)
+
+statement ok
+DROP TABLE customer;
+
+statement ok
+DROP TABLE lineitem;
+
+statement ok
+DROP TABLE nation;
+
+statement ok
+DROP TABLE orders;
+
+statement ok
+DROP TABLE part;
+
+statement ok
+DROP TABLE partsupp;
+
+statement ok
+DROP TABLE region;
+
+statement ok
+DROP TABLE supplier;
+
+statement ok
+CREATE VIEW customer AS
+SELECT
+	json['c_custkey']::INTEGER AS c_custkey,
+	json['c_name']::VARCHAR AS c_name,
+	json['c_address']::VARCHAR AS c_address,
+	json['c_nationkey']::INTEGER AS c_nationkey,
+	json['c_phone']::VARCHAR AS c_phone,
+	json['c_acctbal']::DECIMAL(15,2) AS c_acctbal,
+	json['c_mktsegment']::VARCHAR AS c_mktsegment,
+	json['c_comment']::VARCHAR AS c_comment,
+FROM
+	read_json_auto('__TEST_DIR__/tpch_json/customer.json', records=false)
+
+statement ok
+CREATE VIEW lineitem AS
+SELECT
+	json['l_orderkey']::INTEGER AS l_orderkey,
+	json['l_partkey']::INTEGER AS l_partkey,
+	json['l_suppkey']::INTEGER AS l_suppkey,
+	json['l_linenumber']::INTEGER AS l_linenumber,
+	json['l_quantity']::DECIMAL(15,2) AS l_quantity,
+	json['l_extendedprice']::DECIMAL(15,2) AS l_extendedprice,
+	json['l_discount']::DECIMAL(15,2) AS l_discount,
+	json['l_tax']::DECIMAL(15,2) AS l_tax,
+	json['l_returnflag']::VARCHAR AS l_returnflag,
+	json['l_linestatus']::VARCHAR AS l_linestatus,
+	json['l_shipdate']::DATE AS l_shipdate,
+	json['l_commitdate']::DATE AS l_commitdate,
+	json['l_receiptdate']::DATE AS l_receiptdate,
+	json['l_shipinstruct']::VARCHAR AS l_shipinstruct,
+	json['l_shipmode']::VARCHAR AS l_shipmode,
+	json['l_comment']::VARCHAR AS l_comment,
+FROM
+	read_json_auto('__TEST_DIR__/tpch_json/lineitem.json', records=false)
+
+statement ok
+CREATE VIEW nation AS
+SELECT
+	json['n_nationkey']::INTEGER AS n_nationkey,
+	json['n_name']::VARCHAR AS n_name,
+	json['n_regionkey']::INTEGER AS n_regionkey,
+	json['n_comment']::VARCHAR AS n_comment,
+FROM
+	read_json_auto('__TEST_DIR__/tpch_json/nation.json', records=false)
+
+statement ok
+CREATE VIEW orders AS
+SELECT
+	json['o_orderkey']::INTEGER AS o_orderkey,
+	json['o_custkey']::INTEGER AS o_custkey,
+	json['o_orderstatus']::VARCHAR AS o_orderstatus,
+	json['o_totalprice']::DECIMAL(15,2) AS o_totalprice,
+	json['o_orderdate']::DATE AS o_orderdate,
+	json['o_orderpriority']::VARCHAR AS o_orderpriority,
+	json['o_clerk']::VARCHAR AS o_clerk,
+	json['o_shippriority']::INTEGER AS o_shippriority,
+	json['o_comment']::VARCHAR AS o_comment,
+FROM
+	read_json_auto('__TEST_DIR__/tpch_json/orders.json', records=false)
+
+statement ok
+CREATE VIEW part AS
+SELECT
+	json['p_partkey']::INTEGER AS p_partkey,
+	json['p_name']::VARCHAR AS p_name,
+	json['p_mfgr']::VARCHAR AS p_mfgr,
+	json['p_brand']::VARCHAR AS p_brand,
+	json['p_type']::VARCHAR AS p_type,
+	json['p_size']::INTEGER AS p_size,
+	json['p_container']::VARCHAR AS p_container,
+	json['p_retailprice']::DECIMAL(15,2) AS p_retailprice,
+	json['p_comment']::VARCHAR AS p_comment,
+FROM
+	read_json_auto('__TEST_DIR__/tpch_json/part.json', records=false)
+
+statement ok
+CREATE VIEW partsupp AS
+SELECT
+	json['ps_partkey']::INTEGER AS ps_partkey,
+	json['ps_suppkey']::INTEGER AS ps_suppkey,
+	json['ps_availqty']::INTEGER AS ps_availqty,
+	json['ps_supplycost']::DECIMAL(15,2) AS ps_supplycost,
+	json['ps_comment']::VARCHAR AS ps_comment,
+FROM
+	read_json_auto('__TEST_DIR__/tpch_json/partsupp.json', records=false)
+
+statement ok
+CREATE VIEW region AS
+SELECT
+	json['r_regionkey']::INTEGER AS r_regionkey,
+	json['r_name']::VARCHAR AS r_name,
+	json['r_comment']::VARCHAR AS r_comment,
+FROM
+	read_json_auto('__TEST_DIR__/tpch_json/region.json', records=false)
+
+statement ok
+CREATE VIEW supplier AS
+SELECT
+	json['s_suppkey']::INTEGER AS s_suppkey,
+	json['s_name']::VARCHAR AS s_name,
+	json['s_address']::VARCHAR AS s_address,
+	json['s_nationkey']::INTEGER AS s_nationkey,
+	json['s_phone']::VARCHAR AS s_phone,
+	json['s_acctbal']::DECIMAL(15,2) AS s_acctbal,
+	json['s_comment']::VARCHAR AS s_comment,
+FROM
+	read_json_auto('__TEST_DIR__/tpch_json/supplier.json', records=false)
+
+loop i 1 9
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
+
+endloop
+
+loop i 10 23
+
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
+
+endloop


### PR DESCRIPTION
After @Mytherin did most of the heavy lifting in https://github.com/duckdb/duckdb/pull/14750, I was able to implement struct projection pushdown for JSON reads.

Although we still need to parse the entire JSON, we do not need to convert it to DuckDB Vectors, which saves a lot of time. Here are the results (not very scientific - some noise from my laptop doing other stuff) when reading TPC-H SF1 directly from JSON files as a struct, without struct projection pushdown (Before) and with (This PR).

As we can see, all queries are now faster. The difference is more pronounced for some queries, e.g., Q3, than it is for others.

| Query | Before | This PR |
|:-|-:|-:|
| 1 | 0.665 | 0.478 |
| 2 | 0.234 | 0.183 |
| 3 | 0.813 | 0.209 |
| 4 | 0.774 | 0.601 |
| 5 | 0.890 | 0.582 |
| 6 | 0.617 | 0.425 |
| 7 | 0.807 | 0.433 |
| 8 | 0.898 | 0.588 |
| 9 | 0.970 | 0.616 |
| 10 | 0.808 | 0.551 |
| 11 | 0.179 | 0.150 |
| 12 | 0.785 | 0.603 |
| 13 | 0.258 | 0.208 |
| 14 | 0.702 | 0.478 |
| 15 | 0.655 | 0.449 |
| 16 | 0.200 | 0.170 |
| 17 | 1.372 | 0.848 |
| 18 | 1.457 | 0.903 |
| 19 | 0.703 | 0.482 |
| 20 | 0.767 | 0.525 |
| 21 | 2.143 | 1.495 |
| 22 | 0.319 | 0.240 |