### PR TITLE
Skip building postgres_scanner due to problems instaling libxml

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -93,7 +93,7 @@ duckdb_extension_load(inet
 ################# POSTGRES_SCANNER
 # Note: tests for postgres_scanner are currently not run. All of them need a postgres server running. One test
 #       uses a remote rds server but that's not something we want to run here.
-if (NOT MINGW)
+if (NOT MINGW AND NO)   # postgres_scanner's libxml dependency is somehow problematic at the moment, skipping on nightly
     duckdb_extension_load(postgres_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/postgres_scanner


### PR DESCRIPTION
Solution might be overriding libxml's vcpkg config, to be experimented on postgres_scanner side, but for now skipping should unlock the fact that most CI should move forward (allowing subsequent checks to also be run).