### PR TITLE
Skip building azure extension due to problems installing libxml

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -34,6 +34,10 @@ if (NOT MINGW)
             )
 endif()
 
+### Currently libxml2, an azure dependency, has the repository repo return 503
+### Re-enable AZURE when the problem goes away. This means AZURE needs to be
+### build on a side
+if (NO)
 ################# AZURE
 if (NOT MINGW)
     duckdb_extension_load(azure
@@ -42,6 +46,7 @@ if (NOT MINGW)
             GIT_TAG a40ecb7bc9036eb8ecc5bf30db935a31b78011f5
             APPLY_PATCHES
             )
+endif()
 endif()
 
 ################# DELTA


### PR DESCRIPTION
Solution might be overriding libxml's vcpkg config, to be experimented on extension side.

Note this means `azure` will not be built on regular CI, and needs to be handled separately.

Tradeoff I think it's still OK, given most CI, also on forks or PRs is failing mid-vcpkg due to problems fetching from the `gnome.gitlab.com` endpoint that appears to be under water and returning 503.