### PR TITLE
Parquet reader: rename metadata cache setting to `parquet_metadata_cache`, and avoid using it for stats

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -467,60 +467,17 @@ public:
 		}
 
 		// NOTE: we do not want to parse the Parquet metadata for the sole purpose of getting column statistics
-
-		auto &config = DBConfig::GetConfig(context);
-
-		if (bind_data.file_list->GetExpandResult() != FileExpandResult::MULTIPLE_FILES) {
-			if (bind_data.initial_reader) {
-				// most common path, scanning single parquet file
-				return bind_data.initial_reader->ReadStatistics(bind_data.names[column_index]);
-			} else if (!config.options.object_cache_enable) {
-				// our initial reader was reset
-				return nullptr;
-			}
-		} else if (config.options.object_cache_enable) {
-			// multiple files, object cache enabled: merge statistics
-			unique_ptr<BaseStatistics> overall_stats;
-
-			auto &cache = ObjectCache::GetObjectCache(context);
-			// for more than one file, we could be lucky and metadata for *every* file is in the object cache (if
-			// enabled at all)
-			FileSystem &fs = FileSystem::GetFileSystem(context);
-
-			for (const auto &file_name : bind_data.file_list->Files()) {
-				auto metadata = cache.Get<ParquetFileMetadataCache>(file_name);
-				if (!metadata) {
-					// missing metadata entry in cache, no usable stats
-					return nullptr;
-				}
-				if (!fs.IsRemoteFile(file_name)) {
-					auto handle = fs.OpenFile(file_name, FileFlags::FILE_FLAGS_READ);
-					// we need to check if the metadata cache entries are current
-					if (fs.GetLastModifiedTime(*handle) >= metadata->read_time) {
-						// missing or invalid metadata entry in cache, no usable stats overall
-						return nullptr;
-					}
-				} else {
-					// for remote files we just avoid reading stats entirely
-					return nullptr;
-				}
-				// get and merge stats for file
-				auto file_stats = ParquetReader::ReadStatistics(context, bind_data.parquet_options, metadata,
-				                                                bind_data.names[column_index]);
-				if (!file_stats) {
-					return nullptr;
-				}
-				if (overall_stats) {
-					overall_stats->Merge(*file_stats);
-				} else {
-					overall_stats = std::move(file_stats);
-				}
-			}
-			// success!
-			return overall_stats;
+		if (bind_data.file_list->GetExpandResult() == FileExpandResult::MULTIPLE_FILES) {
+			// multiple files, no luck!
+			return nullptr;
 		}
+		if (!bind_data.initial_reader) {
+			// no reader
+			return nullptr;
+		}
+		// scanning single parquet file and we have the metadata read already
+		return bind_data.initial_reader->ReadStatistics(bind_data.names[column_index]);
 
-		// multiple files and no object cache, no luck!
 		return nullptr;
 	}
 
@@ -1750,6 +1707,9 @@ void ParquetExtension::Load(DuckDB &db) {
 	config.AddExtensionOption("prefetch_all_parquet_files",
 	                          "Use the prefetching mechanism for all types of parquet files", LogicalType::BOOLEAN,
 	                          Value(false));
+	config.AddExtensionOption("parquet_metadata_cache",
+	                          "Cache Parquet metadata - useful when reading the same files multiple times",
+	                          LogicalType::BOOLEAN, Value(false));
 	config.AddExtensionOption(
 	    "enable_geoparquet_conversion",
 	    "Attempt to decode/encode geometry data in/as GeoParquet files if the spatial extension is present.",

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -561,11 +561,13 @@ ParquetReader::ParquetReader(ClientContext &context_p, string file_name_p, Parqu
 		encryption_util = make_shared_ptr<duckdb_mbedtls::MbedTlsWrapper::AESGCMStateMBEDTLSFactory>();
 	}
 
-	// If object cached is disabled
+	// If metadata cached is disabled
 	// or if this file has cached metadata
 	// or if the cached version already expired
 	if (!metadata_p) {
-		if (!ObjectCache::ObjectCacheEnabled(context_p)) {
+		Value metadata_cache = false;
+		context_p.TryGetCurrentSetting("parquet_metadata_cache", metadata_cache);
+		if (!metadata_cache.GetValue<bool>()) {
 			metadata =
 			    LoadMetadata(context_p, allocator, *file_handle, parquet_options.encryption_config, *encryption_util);
 		} else {

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -333,10 +333,11 @@
     },
     {
         "name": "enable_object_cache",
-        "description": "Whether or not object cache is used to cache e.g. Parquet metadata",
+        "description": "[PLACEHOLDER] Legacy setting - does nothing",
         "type": "BOOLEAN",
         "scope": "global",
-        "internal_setting": "object_cache_enable"
+        "internal_setting": "object_cache_enable",
+        "custom_implementation": true
     },
     {
         "name": "enable_profiling",

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -99,11 +99,9 @@ static void PragmaDisableForceParallelism(ClientContext &context, const Function
 }
 
 static void PragmaEnableObjectCache(ClientContext &context, const FunctionParameters &parameters) {
-	DBConfig::GetConfig(context).options.object_cache_enable = true;
 }
 
 static void PragmaDisableObjectCache(ClientContext &context, const FunctionParameters &parameters) {
-	DBConfig::GetConfig(context).options.object_cache_enable = false;
 }
 
 static void PragmaEnableCheckpointOnShutdown(ClientContext &context, const FunctionParameters &parameters) {

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -173,8 +173,6 @@ struct DBConfigOptions {
 	DefaultOrderByNullType default_null_order = DefaultOrderByNullType::NULLS_LAST;
 	//! enable COPY and related commands
 	bool enable_external_access = true;
-	//! Whether or not object cache is used
-	bool object_cache_enable = false;
 	//! Whether or not the global http metadata cache is used
 	bool http_metadata_cache_enable = false;
 	//! HTTP Proxy config as 'hostname:port'

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -957,6 +957,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"mysql_debug_show_queries", "mysql_scanner"},
     {"mysql_experimental_filter_pushdown", "mysql_scanner"},
     {"mysql_tinyint1_as_boolean", "mysql_scanner"},
+    {"parquet_metadata_cache", "parquet"},
     {"pg_array_as_varchar", "postgres_scanner"},
     {"pg_connection_cache", "postgres_scanner"},
     {"pg_connection_limit", "postgres_scanner"},

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -519,7 +519,7 @@ struct EnableMacroDependenciesSetting {
 struct EnableObjectCacheSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "enable_object_cache";
-	static constexpr const char *Description = "Whether or not object cache is used to cache e.g. Parquet metadata";
+	static constexpr const char *Description = "[PLACEHOLDER] Legacy setting - does nothing";
 	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -74,7 +74,6 @@ public:
 	}
 
 	DUCKDB_API static ObjectCache &GetObjectCache(ClientContext &context);
-	DUCKDB_API static bool ObjectCacheEnabled(ClientContext &context);
 
 private:
 	//! Object Cache

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -497,22 +497,6 @@ Value EnableMacroDependenciesSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
-// Enable Object Cache
-//===----------------------------------------------------------------------===//
-void EnableObjectCacheSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
-	config.options.object_cache_enable = input.GetValue<bool>();
-}
-
-void EnableObjectCacheSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
-	config.options.object_cache_enable = DBConfig().options.object_cache_enable;
-}
-
-Value EnableObjectCacheSetting::GetSetting(const ClientContext &context) {
-	auto &config = DBConfig::GetConfig(context);
-	return Value::BOOLEAN(config.options.object_cache_enable);
-}
-
-//===----------------------------------------------------------------------===//
 // Enable Progress Bar
 //===----------------------------------------------------------------------===//
 void EnableProgressBarSetting::SetLocal(ClientContext &context, const Value &input) {

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -611,6 +611,19 @@ bool EnableExternalAccessSetting::OnGlobalReset(DatabaseInstance *db, DBConfig &
 }
 
 //===----------------------------------------------------------------------===//
+// Enable Object Cache
+//===----------------------------------------------------------------------===//
+void EnableObjectCacheSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+}
+
+void EnableObjectCacheSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+}
+
+Value EnableObjectCacheSetting::GetSetting(const ClientContext &context) {
+	return Value();
+}
+
+//===----------------------------------------------------------------------===//
 // Enable Profiling
 //===----------------------------------------------------------------------===//
 void EnableProfilingSetting::SetLocal(ClientContext &context, const Value &input) {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -56,10 +56,6 @@ ObjectCache &ObjectCache::GetObjectCache(ClientContext &context) {
 	return context.db->GetObjectCache();
 }
 
-bool ObjectCache::ObjectCacheEnabled(ClientContext &context) {
-	return context.db->config.options.object_cache_enable;
-}
-
 idx_t StorageManager::GetWALSize() {
 	return wal->GetWALSize();
 }

--- a/test/api/test_config.cpp
+++ b/test/api/test_config.cpp
@@ -17,7 +17,6 @@ TEST_CASE("Test DB config configuration", "[api]") {
 	test_options["default_order"] = {"asc", "desc"};
 	test_options["default_null_order"] = {"nulls_first", "nulls_last"};
 	test_options["enable_external_access"] = {"true", "false"};
-	test_options["enable_object_cache"] = {"true", "false"};
 	test_options["max_memory"] = {"-1", "16GB"};
 	test_options["threads"] = {"1", "4"};
 

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -144,6 +144,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "allow_unsigned_extensions",  // cant change this while db is running
 	    "allow_community_extensions", // cant change this while db is running
 	    "allow_unredacted_secrets",   // cant change this while db is running
+	    "enable_object_cache",
 	    "streaming_buffer_size",
 	    "log_query_path",
 	    "password",

--- a/test/parquet/parquet_long_string_stats.test
+++ b/test/parquet/parquet_long_string_stats.test
@@ -7,7 +7,7 @@ require httpfs
 require parquet
 
 statement ok
-pragma enable_object_cache;
+set parquet_metadata_cache=true;
 
 # the constant comparison that is pushed down is longer than DuckDB's 8 bytes that are used in StringStatistics
 # its prefix is equal to the max up to the last byte

--- a/test/sql/copy/parquet/parquet_6933.test
+++ b/test/sql/copy/parquet/parquet_6933.test
@@ -1,5 +1,5 @@
 # name: test/sql/copy/parquet/parquet_6933.test
-# description: Issue #6933: Segfault when using enable_object_cache alongside union_by_name for parquet files
+# description: Issue #6933: Segfault when using parquet_metadata_cache alongside union_by_name for parquet files
 # group: [parquet]
 
 require parquet
@@ -37,7 +37,7 @@ statement ok
 COPY table2 TO '__TEST_DIR__/output2.parquet' (FORMAT PARQUET);
 
 statement ok
-PRAGMA enable_object_cache;
+set parquet_metadata_cache=true;
 
 query II
 SELECT name, number FROM read_parquet(['__TEST_DIR__/output*.parquet'], union_by_name=True) ORDER BY name, number

--- a/test/sql/copy/parquet/parquet_filename_filter.test
+++ b/test/sql/copy/parquet/parquet_filename_filter.test
@@ -61,7 +61,7 @@ select id, value as filename, date from parquet_scan('data/parquet-testing/hive-
 # These tests confirm that the ParquetScanStats will properly handle the pruned files list
 
 statement ok
-pragma enable_object_cache
+SET parquet_metadata_cache=true;
 
 query II
 select id, value from parquet_scan('data/parquet-testing/hive-partitioning/*/*/*/test.parquet', FILENAME=1) where filename like '%mismatching_count%' and id > 1;

--- a/test/sql/copy/parquet/parquet_metadata_cache.test
+++ b/test/sql/copy/parquet/parquet_metadata_cache.test
@@ -5,7 +5,7 @@
 require parquet
 
 statement ok
-pragma enable_object_cache
+SET parquet_metadata_cache=true;
 
 # test the cached file
 query II

--- a/test/sql/copy/parquet/test_parquet_stats.test
+++ b/test/sql/copy/parquet/test_parquet_stats.test
@@ -77,10 +77,6 @@ explain select * from parquet_scan('data/parquet-testing/data-types.parquet') wh
 
 # see if stats work correctly for globs
 
-statement ok
-pragma disable_object_cache
-
-
 query I nosort nostats
 explain select time from parquet_scan('data/parquet-testing/timestamp*.parquet') where time > '2020-10-06'
 ----
@@ -88,6 +84,8 @@ explain select time from parquet_scan('data/parquet-testing/timestamp*.parquet')
 statement ok
 SET parquet_metadata_cache=true;
 
+# we no longer gather stats with parquet_metadata_cache=true (for now?)
+mode skip
 
 # no stats since there are two files and the cache is on but we have not read all files yet
 query I nosort nostats

--- a/test/sql/copy/parquet/test_parquet_stats.test
+++ b/test/sql/copy/parquet/test_parquet_stats.test
@@ -86,7 +86,7 @@ explain select time from parquet_scan('data/parquet-testing/timestamp*.parquet')
 ----
 
 statement ok
-pragma enable_object_cache
+SET parquet_metadata_cache=true;
 
 
 # no stats since there are two files and the cache is on but we have not read all files yet

--- a/test/sql/copy/s3/glob_s3_paging.test_slow
+++ b/test/sql/copy/s3/glob_s3_paging.test_slow
@@ -71,9 +71,9 @@ endloop
 
 endloop
 
-# test with enable_object_cache = true
+# test with parquet_metadata_cache = true
 statement ok
-SET enable_object_cache=true
+SET parquet_metadata_cache=true;
 
 foreach urlstyle path vhost
 


### PR DESCRIPTION
This PR renames the parquet metadata cache setting to the more descriptive `parquet_metadata_cache`:

```sql
SET parquet_metadata_cache=true;
```

In addition, we no longer use the metadata cache for propagating column statistics. Previously, we would try to use metadata stored in the cache to propagate column statistics - but this could cause large slowdowns when scanning many files because (1) the code to obtain the stats from the metadata was not optimized, and this could happen `number_of_files * number_of_columns` times, and (2) we would open each file to check if the file had not gone stale before doing this - which could again cause many file system operations. This could cause large slowdowns when enabling the metadata cache. 

This PR just disables this behavior entirely and now uses the metadata cache exclusively to prevent re-reading the metadata from disk. In a future PR we might be able to use the stats again given that we can greatly optimize the code for obtaining the stats.