### PR TITLE
Update the `.clang-format` file to disable sorting includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 ---
 BasedOnStyle: LLVM
+SortIncludes: false
 TabWidth: 4
 IndentWidth: 4
 ColumnLimit: 120


### PR DESCRIPTION
We already do this in the format script, might as well put it in the format file for simplicity (also my IDE doesn't allow me to specify sort-includes separately when a file is provided as style)