### PR TITLE
Fix `BLOB` conversion in `parquet_metadata`

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -5,9 +5,8 @@
 #include "parquet_dbp_encoder.hpp"
 #include "parquet_rle_bp_decoder.hpp"
 #include "parquet_rle_bp_encoder.hpp"
-#include "parquet_writer.hpp"
 #include "parquet_statistics.hpp"
-#include "geo_parquet.hpp"
+#include "parquet_writer.hpp"
 #ifndef DUCKDB_AMALGAMATION
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
@@ -785,10 +784,10 @@ public:
 		return NumericLimits<SRC>::IsSigned() ? GetMaxValue() : string();
 	}
 	string GetMinValue() override {
-		return HasStats() ? string((char *)&min, sizeof(T)) : string();
+		return HasStats() ? string(char_ptr_cast(&min), sizeof(T)) : string();
 	}
 	string GetMaxValue() override {
-		return HasStats() ? string((char *)&max, sizeof(T)) : string();
+		return HasStats() ? string(char_ptr_cast(&max), sizeof(T)) : string();
 	}
 };
 
@@ -919,7 +918,7 @@ struct ParquetStringOperator : public BaseParquetOperator {
 
 	template <class SRC, class TGT>
 	static void HandleStats(ColumnWriterStatistics *stats, TGT target_value) {
-		auto &string_stats = (StringStatisticsState &)*stats;
+		auto &string_stats = stats->Cast<StringStatisticsState>();
 		string_stats.Update(target_value);
 	}
 

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -149,13 +149,12 @@ Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type, const duckdb
 			throw InternalException("Unsupported internal type for decimal?..");
 		}
 	}
-	case LogicalType::VARCHAR:
-	case LogicalType::BLOB:
-		if (Value::StringIsValid(stats)) {
-			return Value(stats);
-		} else {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::BLOB:
+		if (type.id() == LogicalTypeId::BLOB || !Value::StringIsValid(stats)) {
 			return Value(Blob::ToString(string_t(stats)));
 		}
+		return Value(stats);
 	case LogicalTypeId::DATE:
 		if (stats.size() != sizeof(int32_t)) {
 			throw InvalidInputException("Incorrect stats size for type DATE");

--- a/test/sql/copy/parquet/parquet_metadata_blob.test
+++ b/test/sql/copy/parquet/parquet_metadata_blob.test
@@ -1,0 +1,52 @@
+# name: test/sql/copy/parquet/parquet_metadata_blob.test
+# description: Test parquet metadata function with blobs
+# group: [parquet]
+
+require parquet
+
+statement ok
+copy (select * from values ('\x0An\xC3\xB5'::blob), ('\xFFXl\x9D'::blob) tbl(b)) to '__TEST_DIR__/blobs.parquet'
+
+# blob should be converted properly
+query I
+select stats_min_value from parquet_metadata('__TEST_DIR__/blobs.parquet')
+----
+\x0An\xC3\xB5
+
+query I
+select min(b) from '__TEST_DIR__/blobs.parquet'
+----
+\x0An\xC3\xB5
+
+query I
+select stats_max_value from parquet_metadata('__TEST_DIR__/blobs.parquet')
+----
+\xFFXl\x9D
+
+query I
+select max(b) from '__TEST_DIR__/blobs.parquet'
+----
+\xFFXl\x9D
+
+# also test cast to hex - should be same
+# note that we need to cast to BLOB for this to be the same
+# stats_{min,max}_value is VARCHAR
+query I
+select hex(stats_min_value::BLOB) from parquet_metadata('__TEST_DIR__/blobs.parquet')
+----
+0A6EC3B5
+
+query I
+select hex(min(b)) from '__TEST_DIR__/blobs.parquet'
+----
+0A6EC3B5
+
+query I
+select hex(stats_max_value::BLOB) from parquet_metadata('__TEST_DIR__/blobs.parquet')
+----
+FF586C9D
+
+query I
+select hex(max(b)) from '__TEST_DIR__/blobs.parquet'
+----
+FF586C9D

--- a/test/sql/copy/parquet/parquet_stats.test
+++ b/test/sql/copy/parquet/parquet_stats.test
@@ -62,7 +62,13 @@ query IIII
 select stats_min, stats_max, stats_min_value, stats_max_value from parquet_metadata('data/parquet-testing/varchar_stats.parquet');
 ----
 NULL	NULL	hello world	world hello
-NULL	NULL	hello\0world	world\0hello
+NULL	NULL	hello\x00world	world\x00hello
+
+# should be the same as computing min/max over these columns
+query IIII
+select min(str_val), max(str_val), min("hello\x00world"), max("hello\x00world") from 'data/parquet-testing/varchar_stats.parquet';
+----
+hello world	world hello	hello\x00world	world\x00hello
 
 query II
 select * from 'data/parquet-testing/varchar_stats.parquet';


### PR DESCRIPTION
The data was correct but not retrieved correctly from the file in the `parquet_metadata` function.