### PR TITLE
Test now passes due to flexible quote on CSVs

### DIFF
--- a/test/sql/copy/csv/test_bug_9952.test_slow
+++ b/test/sql/copy/csv/test_bug_9952.test_slow
@@ -6,9 +6,12 @@ statement ok
 PRAGMA enable_verification
 
 statement error
-FROM read_csv('data/csv/num.tsv.gz',quote = '"')
+FROM read_csv('data/csv/num.tsv.gz',quote = '"', rfc_4180=true)
 ----
 Value with unterminated quote found.
+
+statement ok
+FROM read_csv('data/csv/num.tsv.gz',quote = '"')
 
 statement ok
 FROM read_csv('data/csv/num.tsv.gz')


### PR DESCRIPTION
Somehow this test escaped a prior CI run, basically it now passes due to the new quote flexible algorithm.