### PR TITLE
Avoid cleaning up past releases if we have not just uploaded a new one

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -427,7 +427,7 @@ jobs:
      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
      name: PyPi Release Cleanup
      runs-on: ubuntu-20.04
-     needs: linux-python3-9
+     needs: twine-upload
      env:
        PYPI_CLEANUP_USERNAME: 'mytherin'
        PYPI_CLEANUP_PASSWORD: ${{secrets.PYPI_CLEANUP_PASSWORD}}


### PR DESCRIPTION
Currently Python CI did fail for 10 nights in a row due to multiple unconnected issues (mainly deprecation of ALLOW_UNSAFE_NODE and randomness that creept in) and that means that we do not have any installable `nightly` version via:
```
pip install duckdb --pre --upgrade
```
(currently will install only v1.1.3)

Solution is inverting the logic: cleanup is triggered only AFTER uploading something, that should guarantee that it never remains empty.