### PR TITLE
Fixup deployment of extensions for build_extensions_dockerized

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -185,7 +185,7 @@ runs:
             elif [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
               duckdb/scripts/extension-upload-all.sh ${{ inputs.deploy_as }} ${{ github.ref_name }}
             elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ ]] ; then
-              duckdb/scripts/extension-upload-all.sh ${{ inputs.deploy_as }} `git log -1 --format=%h`
+              duckdb/scripts/extension-upload-all.sh ${{ inputs.deploy_as }} "${GITHUB_SHA:0:10}"
             fi
           fi
 


### PR DESCRIPTION
Problem is: current workflow step requires to be in a valid git context and queries git for the information, that given we have already, it can be just passed down.