### PR TITLE
Store transactions that have deletes on a table with indexes

### DIFF
--- a/src/include/duckdb/transaction/undo_buffer.hpp
+++ b/src/include/duckdb/transaction/undo_buffer.hpp
@@ -23,6 +23,7 @@ struct UndoBufferProperties {
 	idx_t estimated_size = 0;
 	bool has_updates = false;
 	bool has_deletes = false;
+	bool has_index_deletes = false;
 	bool has_catalog_changes = false;
 	bool has_dropped_entries = false;
 };

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -281,7 +281,8 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 
 	// commit successful: remove the transaction id from the list of active transactions
 	// potentially resulting in garbage collection
-	bool store_transaction = undo_properties.has_updates || undo_properties.has_catalog_changes || error.HasError();
+	bool store_transaction = undo_properties.has_updates || undo_properties.has_index_deletes ||
+	                         undo_properties.has_catalog_changes || error.HasError();
 	RemoveTransaction(transaction, store_transaction);
 	// now perform a checkpoint if (1) we are able to checkpoint, and (2) the WAL has reached sufficient size to
 	// checkpoint

--- a/src/transaction/undo_buffer.cpp
+++ b/src/transaction/undo_buffer.cpp
@@ -134,6 +134,9 @@ UndoBufferProperties UndoBuffer::GetProperties() {
 			if (info->is_consecutive) {
 				properties.estimated_size += sizeof(row_t) * info->count;
 			}
+			if (info->table->HasIndexes()) {
+				properties.has_index_deletes = true;
+			}
 			properties.has_deletes = true;
 			break;
 		}

--- a/test/sql/transactions/delete_index_lookup_transactions.test
+++ b/test/sql/transactions/delete_index_lookup_transactions.test
@@ -1,0 +1,53 @@
+# name: test/sql/transactions/delete_index_lookup_transactions.test
+# description: Verify indexes still correctly refer to the old state when data is deleted
+# group: [transactions]
+
+statement ok
+CREATE TABLE tbl (id INT PRIMARY KEY, payload VARCHAR);
+
+statement ok
+INSERT INTO tbl VALUES (1, 'first payload');
+
+statement ok old
+BEGIN;
+
+statement ok old
+INSERT INTO tbl VALUES (5, 'con2 payload');
+
+statement ok con1
+BEGIN;
+
+statement ok con1
+DELETE FROM tbl;
+
+statement ok con1
+COMMIT;
+
+# old should still see first_payload
+query II old
+SELECT id, payload FROM tbl WHERE id = 1 ORDER BY ALL;
+----
+1	first payload
+
+query II old
+SELECT id, payload FROM tbl WHERE id = 5 ORDER BY ALL;
+----
+5	con2 payload
+
+# new should see nothing (everything is deleted)
+query III con1
+SELECT id, payload, rowid FROM tbl WHERE id = 1 ORDER BY ALL;
+----
+
+statement ok old
+COMMIT
+
+# after commit the first payload is gone, but the new payload is not
+query II
+SELECT id, payload FROM tbl WHERE id = 1 ORDER BY ALL;
+----
+
+query II
+SELECT id, payload FROM tbl WHERE id = 5 ORDER BY ALL;
+----
+5	con2 payload


### PR DESCRIPTION
Fixes an issue where deletes from an index would accidentally be cleaned up before that was necessary

CC @taniabogatsch 