### PR TITLE
Only generate physical plan for LogicalPrepare when it is going to be used

### DIFF
--- a/src/execution/physical_plan/plan_prepare.cpp
+++ b/src/execution/physical_plan/plan_prepare.cpp
@@ -8,8 +8,8 @@ namespace duckdb {
 unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPrepare &op) {
 	D_ASSERT(op.children.size() <= 1);
 
-	// generate physical plan
-	if (!op.children.empty()) {
+	// generate physical plan only when all parameters are bound (otherwise the physical plan won't be used anyway)
+	if (op.prepared->properties.bound_all_parameters && !op.children.empty()) {
 		auto plan = CreatePlan(*op.children[0]);
 		op.prepared->types = plan->types;
 		op.prepared->plan = std::move(plan);


### PR DESCRIPTION
Optimizers are being skipped when the plan consists of a LogicalPrepare where not all parameters have successfully had their types determined (see `LogicalPrepare::RequireOptimizer` which checks `prepared->properties.bound_all_parameters`). DuckDB then still creates a physical plan, which fails for custom extensions when plan creation is dependent on the custom optimizer having run.

Creating the physical plan (just to be thrown away later) is unnecessary though, so we can skip this.