### PR TITLE
Execute test/sql/aggregate/aggregates/first_memory_usage.test_slow single threaded

### DIFF
--- a/test/sql/aggregate/aggregates/first_memory_usage.test_slow
+++ b/test/sql/aggregate/aggregates/first_memory_usage.test_slow
@@ -5,6 +5,9 @@
 load __TEST_DIR__/first_memory_usage.db
 
 statement ok
+set threads=1;
+
+statement ok
 set memory_limit='500mb';
 
 # this query uses the first() aggregate, which used to use too much memory (it did redundant allocation in Combine)


### PR DESCRIPTION
This is to prevent randomness in test, solves OSX Release CI failure.