### PR TITLE
FileHandle should retain the FileOpenFlags it was opened with

### DIFF
--- a/extension/httpfs/httpfs.cpp
+++ b/extension/httpfs/httpfs.cpp
@@ -441,8 +441,8 @@ unique_ptr<ResponseWrapper> HTTPFileSystem::GetRangeRequest(FileHandle &handle, 
 }
 
 HTTPFileHandle::HTTPFileHandle(FileSystem &fs, const string &path, FileOpenFlags flags, const HTTPParams &http_params)
-    : FileHandle(fs, path), http_params(http_params), flags(flags), length(0), buffer_available(0), buffer_idx(0),
-      file_offset(0), buffer_start(0), buffer_end(0) {
+    : FileHandle(fs, path, flags), http_params(http_params), flags(flags), length(0), buffer_available(0),
+      buffer_idx(0), file_offset(0), buffer_start(0), buffer_end(0) {
 }
 
 unique_ptr<HTTPFileHandle> HTTPFileSystem::CreateHandle(const string &path, FileOpenFlags flags,

--- a/src/common/compressed_file_system.cpp
+++ b/src/common/compressed_file_system.cpp
@@ -7,7 +7,7 @@ StreamWrapper::~StreamWrapper() {
 }
 
 CompressedFile::CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> child_handle_p, const string &path)
-    : FileHandle(fs, path), compressed_fs(fs), child_handle(std::move(child_handle_p)) {
+    : FileHandle(fs, path, child_handle_p->GetFlags()), compressed_fs(fs), child_handle(std::move(child_handle_p)) {
 }
 
 CompressedFile::~CompressedFile() {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -551,7 +551,8 @@ bool FileSystem::OnDiskFile(FileHandle &handle) {
 }
 // LCOV_EXCL_STOP
 
-FileHandle::FileHandle(FileSystem &file_system, string path_p) : file_system(file_system), path(std::move(path_p)) {
+FileHandle::FileHandle(FileSystem &file_system, string path_p, FileOpenFlags flags)
+    : file_system(file_system), path(std::move(path_p)), flags(flags) {
 }
 
 FileHandle::~FileHandle() {

--- a/src/common/pipe_file_system.cpp
+++ b/src/common/pipe_file_system.cpp
@@ -7,8 +7,9 @@
 namespace duckdb {
 class PipeFile : public FileHandle {
 public:
-	PipeFile(unique_ptr<FileHandle> child_handle_p, const string &path)
-	    : FileHandle(pipe_fs, path), child_handle(std::move(child_handle_p)) {
+	explicit PipeFile(unique_ptr<FileHandle> child_handle_p)
+	    : FileHandle(pipe_fs, child_handle_p->path, child_handle_p->GetFlags()),
+	      child_handle(std::move(child_handle_p)) {
 	}
 
 	PipeFileSystem pipe_fs;
@@ -51,8 +52,7 @@ void PipeFileSystem::FileSync(FileHandle &handle) {
 }
 
 unique_ptr<FileHandle> PipeFileSystem::OpenPipe(unique_ptr<FileHandle> handle) {
-	auto path = handle->path;
-	return make_uniq<PipeFile>(std::move(handle), path);
+	return make_uniq<PipeFile>(std::move(handle));
 }
 
 } // namespace duckdb

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -53,7 +53,7 @@ enum class FileType {
 
 struct FileHandle {
 public:
-	DUCKDB_API FileHandle(FileSystem &file_system, string path);
+	DUCKDB_API FileHandle(FileSystem &file_system, string path, FileOpenFlags flags);
 	FileHandle(const FileHandle &) = delete;
 	DUCKDB_API virtual ~FileHandle();
 
@@ -84,6 +84,10 @@ public:
 		return path;
 	}
 
+	FileOpenFlags GetFlags() const {
+		return flags;
+	}
+
 	template <class TARGET>
 	TARGET &Cast() {
 		DynamicCastCheck<TARGET>(this);
@@ -98,6 +102,7 @@ public:
 public:
 	FileSystem &file_system;
 	string path;
+	FileOpenFlags flags;
 };
 
 class FileSystem {

--- a/tools/pythonpkg/src/include/duckdb_python/pyfilesystem.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyfilesystem.hpp
@@ -32,7 +32,7 @@ public:
 
 class PythonFileHandle : public FileHandle {
 public:
-	PythonFileHandle(FileSystem &file_system, const string &path, const py::object &handle);
+	PythonFileHandle(FileSystem &file_system, const string &path, const py::object &handle, FileOpenFlags flags);
 	~PythonFileHandle() override;
 	void Close() override;
 

--- a/tools/pythonpkg/src/pyfilesystem.cpp
+++ b/tools/pythonpkg/src/pyfilesystem.cpp
@@ -6,8 +6,9 @@
 
 namespace duckdb {
 
-PythonFileHandle::PythonFileHandle(FileSystem &file_system, const string &path, const py::object &handle)
-    : FileHandle(file_system, path), handle(handle) {
+PythonFileHandle::PythonFileHandle(FileSystem &file_system, const string &path, const py::object &handle,
+                                   FileOpenFlags flags)
+    : FileHandle(file_system, path, flags), handle(handle) {
 }
 PythonFileHandle::~PythonFileHandle() {
 	try {
@@ -84,7 +85,7 @@ unique_ptr<FileHandle> PythonFilesystem::OpenFile(const string &path, FileOpenFl
 	string flags_s = DecodeFlags(flags);
 
 	const auto &handle = filesystem.attr("open")(path, py::str(flags_s));
-	return make_uniq<PythonFileHandle>(*this, path, handle);
+	return make_uniq<PythonFileHandle>(*this, path, handle, flags);
 }
 
 int64_t PythonFilesystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {


### PR DESCRIPTION
This causes FileHandle to remember the FileOpenFlags it was opened with. This allows FileSystem wrappers to condition logic based on the flags, such as for example, O_DIRECT.