### PR TITLE
Refactor signing linux extensions

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -167,25 +167,3 @@ runs:
         shell: bash
         run: |
           docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ inputs.duckdb_arch }} make test_release
-
-      - name: Deploy
-        if: ${{ inputs.deploy_as != '' }}
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ inputs.s3_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ inputs.s3_key }}
-          DUCKDB_EXTENSION_SIGNING_PK: ${{ inputs.signing_pk }}
-          AWS_DEFAULT_REGION: us-east-1
-          DUCKDB_DEPLOY_SCRIPT_MODE: for_real
-        run: |
-          cd  ${{ inputs.build_dir}}
-          if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            if [[ ! -z "${{ inputs.deploy_version }}" ]] ; then
-              duckdb/scripts/extension-upload-all.sh ${{ inputs.deploy_as }} ${{ inputs.deploy_version }}
-            elif [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
-              duckdb/scripts/extension-upload-all.sh ${{ inputs.deploy_as }} ${{ github.ref_name }}
-            elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ ]] ; then
-              duckdb/scripts/extension-upload-all.sh ${{ inputs.deploy_as }} "${GITHUB_SHA:0:10}"
-            fi
-          fi
-

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -217,11 +217,31 @@ jobs:
           run_autoload_tests: 0
           ninja: 1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: linux-extensions-64
           path: |
             build/release/extension/*/*.duckdb_extension
+
+ upload-linux-extensions-64:
+    name: Upload Linux Extensions (x64)
+    needs: linux-extensions-64
+    uses: ./.github/workflows/_sign_deploy_extensions.yml
+    secrets: inherit
+    with:
+      extension_artifact_name: linux-extensions-64
+      duckdb_arch: linux_amd64
+      duckdb_sha: ${{ github.sha }}
+
+ upload-linux-extensions-64-aarch64:
+    name: Upload Linux Extensions (aarch64)
+    needs: linux-extensions-64-aarch64
+    uses: ./.github/workflows/_sign_deploy_extensions.yml
+    secrets: inherit
+    with:
+      extension_artifact_name: linux-extensions-64-aarch64
+      duckdb_arch: linux_arm64
+      duckdb_sha: ${{ github.sha }}
 
  linux-extensions-64-aarch64:
     # Builds extensions for linux_arm64
@@ -251,7 +271,7 @@ jobs:
           run_autoload_tests: 0
           ninja: 1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: linux-extensions-64-aarch64
           path: |

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -315,7 +315,7 @@ jobs:
       run: |
         make
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: linux-extensions-64
         path: build/release/repository

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -152,11 +152,22 @@ jobs:
           run_autoload_tests: 0
           ninja: 1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: manylinux-extensions-x64
           path: |
             build/release/extension/*/*.duckdb_extension
+
+   upload-linux-extensions-gcc4:
+    ## TODO: Add a if: github.ref == main, for now this is explicitly missing to be able to test on PR, expected is this should fail due to missing secrets
+    name: Upload Linux Extensions (gcc4)
+    needs: manylinux-extensions-x64
+    uses: ./.github/workflows/_sign_deploy_extensions.yml
+    secrets: inherit
+    with:
+      extension_artifact_name: manylinux-extensions-x64
+      duckdb_arch: linux_amd64_gcc4
+      duckdb_sha: ${{ github.ref }}
 
    linux-python3:
     name: Python 3 Linux
@@ -232,7 +243,7 @@ jobs:
         pip install 'cibuildwheel>=2.16.2' build
         python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       if: ${{ matrix.arch == 'x86_64' }}
       with:
         name: manylinux-extensions-x64

--- a/.github/workflows/_sign_deploy_extensions.yml
+++ b/.github/workflows/_sign_deploy_extensions.yml
@@ -1,0 +1,58 @@
+#
+# Reusable workflow to upload extensions previously uploaded as a GH artifact
+#
+# Note: this workflow can be used to deploy an extension from a GH artifact from within the duckdb GitHub organisation (only repo's within the same organisation can share secrets
+#       through reusable workflows)
+name: Sign and Deploy Extensions
+on:
+  workflow_call:
+    inputs:
+      # The name artifact to download
+      extension_artifact_name:
+        required: true
+        type: string
+      # DuckDB target architure
+      duckdb_arch:
+        required: true
+        type: string
+      # DuckDB ref of DuckDB building the extension
+      duckdb_sha:
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.duckdb_sha }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.extension_artifact_name }}
+          path: to_be_deployed_extensions
+
+      - name: Deploy
+        shell: bash
+        run: |
+          tree to_be_deployed_extensions
+          mkdir deploy_me
+          cp to_be_deployed_extensions/**/* deploy_me/.
+          tree deploy_me
+
+      - name: Deploy
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
+          DUCKDB_DEPLOY_SCRIPT_MODE: for_real
+        run: |
+          pip install awscli
+          TARGET_SHA=${{ inputs.duckdb_sha }}
+          TARGET_SHA="${TARGET_SHA:0:10}"
+          echo "Extensions to be uploaded to ${TARGET_SHA}"
+          ./scripts/extension-upload-all.sh ${{ inputs.duckdb_arch }} "${TARGET_SHA}" deploy_me

--- a/scripts/extension-upload-all.sh
+++ b/scripts/extension-upload-all.sh
@@ -31,6 +31,9 @@ else
     echo "Deploying extensions.. (DRY RUN)"
 fi
 
+echo "$BASE_DIR/*.duckdb_extension"
+tree "$BASE_DIR"
+
 FILES="$BASE_DIR/*.duckdb_extension"
 for f in $FILES
 do


### PR DESCRIPTION
There has been quite some instability connected to the removal of the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION  that required some changes to the way Linux extensions for DuckDB (`linux_arm64`, `linux_amd64` and `linux_amd64_gcc4`) are built, that impacted the deploy step of extensions.

I ended up with a minor rework that should clean up the situation a bit by adding a reusable workflow called `_sign_deploy_extensons.yml` that given a folder with some extension inside will take care of signing and uploading them (via the script we already have used for month in `script/extensions-upload-all.sh`).

PR footprint aims to be as low as possible here, there are some additional improvements that can be done on top of this, such as avoiding the explcit passing of platform and version, handling release candidates automatically and adding more testing and checks of uploaded extensions, but those are NOT covered here but will be possible by wrapping the script in a reusable workflow.

This workflow is currently used only in Python.yml AND LinuxRelease.yml, where the deploy step has been already failing, so there should be no degradation from this PR.