### PR TITLE
Do not assume constant comparison is compare equal

### DIFF
--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -461,10 +461,10 @@ static bool ApplyBloomFilter(const TableFilter &duckdb_filter, ParquetBloomFilte
 	switch (duckdb_filter.filter_type) {
 	case TableFilterType::CONSTANT_COMPARISON: {
 		auto &constant_filter = duckdb_filter.Cast<ConstantFilter>();
-		D_ASSERT(constant_filter.comparison_type == ExpressionType::COMPARE_EQUAL);
+		auto is_compare_equal = constant_filter.comparison_type == ExpressionType::COMPARE_EQUAL;
 		D_ASSERT(!constant_filter.constant.IsNull());
 		auto hash = ValueXXH64(constant_filter.constant);
-		return hash > 0 && !bloom_filter.FilterCheck(hash);
+		return hash > 0 && !bloom_filter.FilterCheck(hash) && is_compare_equal;
 	}
 	case TableFilterType::CONJUNCTION_AND: {
 		auto &conjunction_and_filter = duckdb_filter.Cast<ConjunctionAndFilter>();


### PR DESCRIPTION
Not every constant comparison is a CompareEqual comparison. ApplyBloomFilter should return true when a constant comparison is a compare equal, but if it is a compare greater than or a compare less than, we should not apply the bloom filter.

fixes https://github.com/duckdblabs/duckdb-internal/issues/3657