### PR TITLE
Fix Regression workflow running against itself

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -102,7 +102,7 @@ jobs:
           git clone https://github.com/duckdb/duckdb.git
           cd duckdb
           if [[ -z "${BASE_HASH}" ]]; then
-            export CHECKOUT_HASH=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --json=headSha --limit=1 --jq '.[0].headSha')
+            export CHECKOUT_HASH=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --status=completed --json=headSha --limit=1 --jq '.[0].headSha')
           else
             export CHECKOUT_HASH="$BASE_HASH"
           fi


### PR DESCRIPTION
We removed `--status=success`, but this caused it to get the hash of the workflow currently in progress, which is always itself, as it was in progress ...

Fixed by adding `--status=completed`.