### PR TITLE
Fix wrongly used github.ref to sha

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -167,7 +167,7 @@ jobs:
     with:
       extension_artifact_name: manylinux-extensions-x64
       duckdb_arch: linux_amd64_gcc4
-      duckdb_sha: ${{ github.ref }}
+      duckdb_sha: ${{ github.sha }}
 
    linux-python3:
     name: Python 3 Linux


### PR DESCRIPTION
Align to what's correctly done in LinuxRelease.yml.

This is a non-fatal error, but did end up with extensions uploaded to the wrong subfolder, so needs to be fixed.