### PR TITLE
Fix various ci nightly

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   linux-memory-leaks:
      name: Linux Memory Leaks
-     runs-on: ubuntu-20.04
+     runs-on: ubuntu-24.04
      env:
        GEN: ninja
 
@@ -103,11 +103,9 @@ jobs:
 
   smaller-binary:
     name: Smaller Binary
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: linux-memory-leaks
     env:
-      CC: gcc-10
-      CXX: g++-10
       GEN: ninja
       BUILD_JEMALLOC: 1
       CORE_EXTENSIONS: "icu;tpch;tpcds;json"
@@ -212,13 +210,12 @@ jobs:
   linux-release-32:
     name: Linux (32 Bit)
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64
+    container: quay.io/pypa/manylinux2028_x86_64
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
     needs: linux-memory-leaks
     env:
       CC: /usr/bin/gcc
       CXX: /usr/bin/g++
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - uses: actions/checkout@v3
@@ -230,7 +227,6 @@ jobs:
           ninja-build: 1
           ccache: 1
           glibc32: 1
-          gcc_4_8: 1 # Note: we run this job on the older gcc 4.8 toolchain
 
       - name: Build
         shell: bash
@@ -490,11 +486,9 @@ jobs:
 
   no-string-inline:
     name: No String Inline / Destroy Unpinned Blocks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: linux-memory-leaks
     env:
-      CC: gcc-10
-      CXX: g++-10
       GEN: ninja
       CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
       DISABLE_STRING_INLINE: 1
@@ -613,11 +607,9 @@ jobs:
 
   force-blocking-sink-source:
     name: Forcing async Sinks/Sources
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: linux-memory-leaks
     env:
-      CC: gcc-10
-      CXX: g++-10
       GEN: ninja
       CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
       FORCE_ASYNC_SINK_SOURCE: 1
@@ -806,11 +798,9 @@ jobs:
 
   block-sizes:
     name: Block Sizes
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: linux-memory-leaks
     env:
-      CC: gcc-10
-      CXX: g++-10
       GEN: ninja
       BLOCK_ALLOC_SIZE: 16384
       CORE_EXTENSIONS: "json;parquet"

--- a/extension/core_functions/core_functions_extension.cpp
+++ b/extension/core_functions/core_functions_extension.cpp
@@ -8,8 +8,57 @@
 
 namespace duckdb {
 
+static void FillFunctionParameters(FunctionDescription &function_description, const char *function_name,
+                                   vector<string> &parameters, vector<string> &descriptions, vector<string> &examples) {
+	for (string &parameter : parameters) {
+		vector<string> parameter_name_type = StringUtil::Split(parameter, "::");
+		if (parameter_name_type.size() == 1) {
+			function_description.parameter_names.push_back(std::move(parameter_name_type[0]));
+			function_description.parameter_types.push_back(LogicalType::ANY);
+		} else if (parameter_name_type.size() == 2) {
+			function_description.parameter_names.push_back(std::move(parameter_name_type[0]));
+			function_description.parameter_types.push_back(DBConfig::ParseLogicalType(parameter_name_type[1]));
+		} else {
+			throw InternalException("Ill formed function variant for function '%s'", function_name);
+		}
+	}
+}
+
 template <class T>
-void FillFunctionDescriptions(const StaticFunctionDefinition &function, T &info);
+static void FillFunctionDescriptions(const StaticFunctionDefinition &function, T &info) {
+	vector<string> variants = StringUtil::Split(function.parameters, '\1');
+	vector<string> descriptions = StringUtil::Split(function.description, '\1');
+	vector<string> examples = StringUtil::Split(function.example, '\1');
+
+	// add single variant for functions that take no arguments
+	if (variants.empty()) {
+		variants.push_back("");
+	}
+
+	for (idx_t variant_index = 0; variant_index < variants.size(); variant_index++) {
+		FunctionDescription function_description;
+		// parameter_names and parameter_types
+		vector<string> parameters = StringUtil::SplitWithParentheses(variants[variant_index], ',');
+		FillFunctionParameters(function_description, function.name, parameters, descriptions, examples);
+		// description
+		if (descriptions.size() == variants.size()) {
+			function_description.description = descriptions[variant_index];
+		} else if (descriptions.size() == 1) {
+			function_description.description = descriptions[0];
+		} else if (!descriptions.empty()) {
+			throw InternalException("Incorrect number of function descriptions for function '%s'", function.name);
+		}
+		// examples
+		if (examples.size() == variants.size()) {
+			function_description.examples = StringUtil::Split(examples[variant_index], '\2');
+		} else if (examples.size() == 1) {
+			function_description.examples = StringUtil::Split(examples[0], '\2');
+		} else if (!examples.empty()) {
+			throw InternalException("Incorrect number of function examples for function '%s'", function.name);
+		}
+		info.descriptions.push_back(std::move(function_description));
+	}
+}
 
 template <class T>
 static void FillExtraInfo(const StaticFunctionDefinition &function, T &info) {

--- a/extension/core_functions/core_functions_extension.cpp
+++ b/extension/core_functions/core_functions_extension.cpp
@@ -3,62 +3,11 @@
 
 #include "core_functions/function_list.hpp"
 #include "duckdb/main/extension_util.hpp"
+#include "duckdb/function/register_function_list_helper.hpp"
 #include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
 namespace duckdb {
-
-static void FillFunctionParameters(FunctionDescription &function_description, const char *function_name,
-                                   vector<string> &parameters, vector<string> &descriptions, vector<string> &examples) {
-	for (string &parameter : parameters) {
-		vector<string> parameter_name_type = StringUtil::Split(parameter, "::");
-		if (parameter_name_type.size() == 1) {
-			function_description.parameter_names.push_back(std::move(parameter_name_type[0]));
-			function_description.parameter_types.push_back(LogicalType::ANY);
-		} else if (parameter_name_type.size() == 2) {
-			function_description.parameter_names.push_back(std::move(parameter_name_type[0]));
-			function_description.parameter_types.push_back(DBConfig::ParseLogicalType(parameter_name_type[1]));
-		} else {
-			throw InternalException("Ill formed function variant for function '%s'", function_name);
-		}
-	}
-}
-
-template <class T>
-static void FillFunctionDescriptions(const StaticFunctionDefinition &function, T &info) {
-	vector<string> variants = StringUtil::Split(function.parameters, '\1');
-	vector<string> descriptions = StringUtil::Split(function.description, '\1');
-	vector<string> examples = StringUtil::Split(function.example, '\1');
-
-	// add single variant for functions that take no arguments
-	if (variants.empty()) {
-		variants.push_back("");
-	}
-
-	for (idx_t variant_index = 0; variant_index < variants.size(); variant_index++) {
-		FunctionDescription function_description;
-		// parameter_names and parameter_types
-		vector<string> parameters = StringUtil::SplitWithParentheses(variants[variant_index], ',');
-		FillFunctionParameters(function_description, function.name, parameters, descriptions, examples);
-		// description
-		if (descriptions.size() == variants.size()) {
-			function_description.description = descriptions[variant_index];
-		} else if (descriptions.size() == 1) {
-			function_description.description = descriptions[0];
-		} else if (!descriptions.empty()) {
-			throw InternalException("Incorrect number of function descriptions for function '%s'", function.name);
-		}
-		// examples
-		if (examples.size() == variants.size()) {
-			function_description.examples = StringUtil::Split(examples[variant_index], '\2');
-		} else if (examples.size() == 1) {
-			function_description.examples = StringUtil::Split(examples[0], '\2');
-		} else if (!examples.empty()) {
-			throw InternalException("Incorrect number of function examples for function '%s'", function.name);
-		}
-		info.descriptions.push_back(std::move(function_description));
-	}
-}
 
 template <class T>
 static void FillExtraInfo(const StaticFunctionDefinition &function, T &info) {

--- a/src/function/register_function_list.cpp
+++ b/src/function/register_function_list.cpp
@@ -23,7 +23,7 @@ static void FillFunctionParameters(FunctionDescription &function_description, co
 }
 
 template <class T>
-void FillFunctionDescriptions(const StaticFunctionDefinition &function, T &info) {
+static void FillFunctionDescriptions(const StaticFunctionDefinition &function, T &info) {
 	vector<string> variants = StringUtil::Split(function.parameters, '\1');
 	vector<string> descriptions = StringUtil::Split(function.description, '\1');
 	vector<string> examples = StringUtil::Split(function.example, '\1');

--- a/src/function/register_function_list.cpp
+++ b/src/function/register_function_list.cpp
@@ -1,62 +1,11 @@
 #include "duckdb/catalog/default/default_types.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/function_list.hpp"
+#include "duckdb/function/register_function_list_helper.hpp"
 #include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
 namespace duckdb {
-
-static void FillFunctionParameters(FunctionDescription &function_description, const char *function_name,
-                                   vector<string> &parameters, vector<string> &descriptions, vector<string> &examples) {
-	for (string &parameter : parameters) {
-		vector<string> parameter_name_type = StringUtil::Split(parameter, "::");
-		if (parameter_name_type.size() == 1) {
-			function_description.parameter_names.push_back(std::move(parameter_name_type[0]));
-			function_description.parameter_types.push_back(LogicalType::ANY);
-		} else if (parameter_name_type.size() == 2) {
-			function_description.parameter_names.push_back(std::move(parameter_name_type[0]));
-			function_description.parameter_types.push_back(DBConfig::ParseLogicalType(parameter_name_type[1]));
-		} else {
-			throw InternalException("Ill formed function variant for function '%s'", function_name);
-		}
-	}
-}
-
-template <class T>
-static void FillFunctionDescriptions(const StaticFunctionDefinition &function, T &info) {
-	vector<string> variants = StringUtil::Split(function.parameters, '\1');
-	vector<string> descriptions = StringUtil::Split(function.description, '\1');
-	vector<string> examples = StringUtil::Split(function.example, '\1');
-
-	// add single variant for functions that take no arguments
-	if (variants.empty()) {
-		variants.push_back("");
-	}
-
-	for (idx_t variant_index = 0; variant_index < variants.size(); variant_index++) {
-		FunctionDescription function_description;
-		// parameter_names and parameter_types
-		vector<string> parameters = StringUtil::SplitWithParentheses(variants[variant_index], ',');
-		FillFunctionParameters(function_description, function.name, parameters, descriptions, examples);
-		// description
-		if (descriptions.size() == variants.size()) {
-			function_description.description = descriptions[variant_index];
-		} else if (descriptions.size() == 1) {
-			function_description.description = descriptions[0];
-		} else if (!descriptions.empty()) {
-			throw InternalException("Incorrect number of function descriptions for function '%s'", function.name);
-		}
-		// examples
-		if (examples.size() == variants.size()) {
-			function_description.examples = StringUtil::Split(examples[variant_index], '\2');
-		} else if (examples.size() == 1) {
-			function_description.examples = StringUtil::Split(examples[0], '\2');
-		} else if (!examples.empty()) {
-			throw InternalException("Incorrect number of function examples for function '%s'", function.name);
-		}
-		info.descriptions.push_back(std::move(function_description));
-	}
-}
 
 template <class T>
 static void FillExtraInfo(const StaticFunctionDefinition &function, T &info) {

--- a/src/include/duckdb/function/register_function_list_helper.hpp
+++ b/src/include/duckdb/function/register_function_list_helper.hpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/register_function_list_helper.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/main/config.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+
+namespace duckdb {
+
+static void FillFunctionParameters(FunctionDescription &function_description, const char *function_name,
+                                   vector<string> &parameters, vector<string> &descriptions, vector<string> &examples) {
+	for (string &parameter : parameters) {
+		vector<string> parameter_name_type = StringUtil::Split(parameter, "::");
+		if (parameter_name_type.size() == 1) {
+			function_description.parameter_names.push_back(std::move(parameter_name_type[0]));
+			function_description.parameter_types.push_back(LogicalType::ANY);
+		} else if (parameter_name_type.size() == 2) {
+			function_description.parameter_names.push_back(std::move(parameter_name_type[0]));
+			function_description.parameter_types.push_back(DBConfig::ParseLogicalType(parameter_name_type[1]));
+		} else {
+			throw InternalException("Ill formed function variant for function '%s'", function_name);
+		}
+	}
+}
+
+template <class FunctionDefinition, class T>
+static void FillFunctionDescriptions(const FunctionDefinition &function, T &info) {
+	vector<string> variants = StringUtil::Split(function.parameters, '\1');
+	vector<string> descriptions = StringUtil::Split(function.description, '\1');
+	vector<string> examples = StringUtil::Split(function.example, '\1');
+
+	// add single variant for functions that take no arguments
+	if (variants.empty()) {
+		variants.push_back("");
+	}
+
+	for (idx_t variant_index = 0; variant_index < variants.size(); variant_index++) {
+		FunctionDescription function_description;
+		// parameter_names and parameter_types
+		vector<string> parameters = StringUtil::SplitWithParentheses(variants[variant_index], ',');
+		FillFunctionParameters(function_description, function.name, parameters, descriptions, examples);
+		// description
+		if (descriptions.size() == variants.size()) {
+			function_description.description = descriptions[variant_index];
+		} else if (descriptions.size() == 1) {
+			function_description.description = descriptions[0];
+		} else if (!descriptions.empty()) {
+			throw InternalException("Incorrect number of function descriptions for function '%s'", function.name);
+		}
+		// examples
+		if (examples.size() == variants.size()) {
+			function_description.examples = StringUtil::Split(examples[variant_index], '\2');
+		} else if (examples.size() == 1) {
+			function_description.examples = StringUtil::Split(examples[0], '\2');
+		} else if (!examples.empty()) {
+			throw InternalException("Incorrect number of function examples for function '%s'", function.name);
+		}
+		info.descriptions.push_back(std::move(function_description));
+	}
+}
+
+} // namespace duckdb

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -380,7 +380,7 @@ public:
 
 	void CompressString(const string_t &string, bool end_of_vector) {
 		duckdb_zstd::ZSTD_inBuffer in_buffer = {/*data = */ string.GetData(),
-		                                        /*length = */ string.GetSize(),
+		                                        /*length = */ size_t(string.GetSize()),
 		                                        /*pos = */ 0};
 
 		if (!end_of_vector && string.GetSize() == 0) {


### PR DESCRIPTION
Fixing a bunch of compiler errors found looking at different nightly workflows.

`FillFunctionDescriptions` stuff I am not sure how it worked at all.

Moved also some workflow to ubuntu-24.04, while other stay at ubuntu-20.04, that should vary a bit more what's tested.

This should fix Pyodide builds (now there is a mysterious runtime error that might be actual duckdb-python problem in 2 run /3, to be looked at next week) and allow other builds to move from build stage failures further.