### PR TITLE
Push dynamic Top-N filters for VARCHAR columns as well

### DIFF
--- a/src/planner/filter/dynamic_filter.cpp
+++ b/src/planner/filter/dynamic_filter.cpp
@@ -31,7 +31,7 @@ string DynamicFilter::ToString(const string &column_name) {
 }
 
 unique_ptr<Expression> DynamicFilter::ToExpression(const Expression &column) const {
-	if (!filter_data) {
+	if (!filter_data || !filter_data->initialized) {
 		auto bound_constant = make_uniq<BoundConstantExpression>(Value(true));
 		return std::move(bound_constant);
 	}


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/15099, enable this for `VARCHAR` columns.

Also fix an issue in `DynamicFilter::ToExpression` which was incorrectly not checking the initialized flag.