### PR TITLE
Review no_extension_autoloading requires in tests: either remove, add FIXME or add EXPECTED

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -94,6 +94,7 @@ duckdb_extension_load(inet
     GIT_TAG 51d7ad789f34eecb36a2071bac5aef0e12747d70
     INCLUDE_DIR src/include
     TEST_DIR test/sql
+    APPLY_PATCHES
     )
 
 ################# POSTGRES_SCANNER

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -31,6 +31,7 @@ if (NOT MINGW)
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_aws
             GIT_TAG f743d4b3c2faecda15498d0219a1727ad6d62b5b
+            APPLY_PATCHES
             )
 endif()
 

--- a/.github/patches/extensions/aws/require_autoloading.patch
+++ b/.github/patches/extensions/aws/require_autoloading.patch
@@ -1,0 +1,20 @@
+diff --git a/test/sql/aws_errors.test b/test/sql/aws_errors.test
+index 50fb7d7..292724e 100644
+--- a/test/sql/aws_errors.test
++++ b/test/sql/aws_errors.test
+@@ -2,7 +2,7 @@
+ # description: test aws extension
+ # group: [aws]
+ 
+-require no_extension_autoloading
++require no_extension_autoloading "EXPECTED: Test relies on autoloading not to be there"
+ 
+ # Before we load the extension, this will fail
+ statement error
+@@ -22,4 +22,4 @@ httpfs extension is required for load_aws_credentials
+ require httpfs
+ 
+ statement ok
+-CALL load_aws_credentials();
+\ No newline at end of file
++CALL load_aws_credentials();

--- a/.github/patches/extensions/inet/require_autoloading.patch
+++ b/.github/patches/extensions/inet/require_autoloading.patch
@@ -1,0 +1,26 @@
+diff --git a/test/sql/test_inet_storage.test b/test/sql/test_inet_storage.test
+index 6679439..7de7620 100644
+--- a/test/sql/test_inet_storage.test
++++ b/test/sql/test_inet_storage.test
+@@ -5,7 +5,7 @@
+ require inet
+ 
+ # FIXME: Make inet properly autoloadable
+-require no_extension_autoloading
++require no_extension_autoloading "FIXME: to be reviewed whether this can be lifted"
+ 
+ # load the DB from disk
+ load __TEST_DIR__/store_inet.db
+diff --git a/test/sql/test_ipv6_inet_storage.test b/test/sql/test_ipv6_inet_storage.test
+index 5be1ff2..7dc1930 100644
+--- a/test/sql/test_ipv6_inet_storage.test
++++ b/test/sql/test_ipv6_inet_storage.test
+@@ -25,7 +25,7 @@ CREATE VIEW iview AS SELECT INET '::1'
+ restart
+ 
+ #FIXME: INET needs to be explicitly autoloaded on restart
+-require no_extension_autoloading
++require no_extension_autoloading "FIXME: INET needs to be explicitly autoloaded on restart"
+ 
+ query IIIIII
+ DESCRIBE tbl

--- a/test/extension/duckdb_extensions.test
+++ b/test/extension/duckdb_extensions.test
@@ -6,7 +6,7 @@
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO
 
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: Test relies on explcit INSTALL and LOAD"
 
 statement ok
 PRAGMA enable_verification

--- a/test/extension/update_extensions.test
+++ b/test/extension/update_extensions.test
@@ -6,7 +6,7 @@
 # -> this should be the case for our autoloading tests where we have the local_extension_repo variable set
 require-env LOCAL_EXTENSION_REPO
 
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: Test relies on explicit INSTALL and LOAD"
 
 statement ok
 PRAGMA enable_verification

--- a/test/extension/wrong_function_type.test
+++ b/test/extension/wrong_function_type.test
@@ -6,7 +6,7 @@ FROM json("['item':'phasers','year':2155','count':1035]");
 ----
 Catalog Error: Table Function with name "json" is not in the catalog, a function by this name exists in the json extension, but it's of a different type, namely Macro Function
 
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: Test relies on autoloading being disabled"
 
 # Multiple options exist, none are scalar
 statement error

--- a/test/fuzzer/sqlsmith/timestamptz_null_range.test
+++ b/test/fuzzer/sqlsmith/timestamptz_null_range.test
@@ -4,7 +4,7 @@
 
 require icu
 
-require no_extension_autoloading
+require no_extension_autoloading "FIXME: generate_series(TIMESTAMP WITH TIME ZONE,...) currently do not autoload ICU"
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/attach/attach_icu_collation.test
+++ b/test/sql/attach/attach_icu_collation.test
@@ -4,7 +4,7 @@
 
 require skip_reload
 
-require no_extension_autoloading
+require icu
 
 # The database is written with a vector size of 2048.
 require vector_size 2048
@@ -23,14 +23,6 @@ Goldmann
 Göbel
 Göthe
 Götz
-
-# cannot order by without ICU
-statement error
-SELECT * FROM db.strings ORDER BY 1
-----
-not in the catalog
-
-require icu
 
 query I
 SELECT * FROM db.strings ORDER BY 1

--- a/test/sql/catalog/test_extension_suggestion.test
+++ b/test/sql/catalog/test_extension_suggestion.test
@@ -4,7 +4,7 @@
 
 require skip_reload
 
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: This tests what happens when extension is not there"
 
 statement error
 SELECT get_substrait("select 1");

--- a/test/sql/copy/csv/test_partition_compression.test
+++ b/test/sql/copy/csv/test_partition_compression.test
@@ -5,7 +5,7 @@
 statement ok
 PRAGMA enable_verification
 
-require no_extension_autoloading
+require no_extension_autoloading "FIXME: Autoloading not working in CSV Value conversion"
 
 statement ok
 CREATE TABLE test AS VALUES ('a', 'foo', 1), ('a', 'foo', 2), ('a', 'bar', 1), ('b', 'bar', 1);

--- a/test/sql/copy/csv/timestamp_with_tz.test
+++ b/test/sql/copy/csv/timestamp_with_tz.test
@@ -16,7 +16,7 @@ Error when converting column "ts". Could not convert string "2021-05-25 04:55:03
 
 require icu
 
-require no_extension_autoloading
+require no_extension_autoloading "FIXME: In CSV value conversion we don't autoload ICU"
 
 # we can load this into a timestamptz table
 statement ok

--- a/test/sql/copy/csv/zstd_crash.test
+++ b/test/sql/copy/csv/zstd_crash.test
@@ -5,7 +5,7 @@
 statement ok
 PRAGMA enable_verification
 
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: zstd requires the parquet extension, currently not autoloaded"
 
 # zstd requires the parquet extension
 statement error

--- a/test/sql/copy/csv/zstd_fs.test
+++ b/test/sql/copy/csv/zstd_fs.test
@@ -9,7 +9,7 @@ require parquet
 
 # Zstd comes with the parquet extension but we currently can not autoload parquet for zstd. Parquet is generally bundled
 # though, so thats probably a non-issue
-require no_extension_autoloading
+require no_extension_autoloading "FIXME: zstd requires the parquet extension, currently not autoloaded"
 
 # lineitem
 statement ok

--- a/test/sql/error/extension_function_error.test
+++ b/test/sql/error/extension_function_error.test
@@ -2,7 +2,7 @@
 # description: Test usage of functions/settings that are found in extensions without having the extension loaded
 # group: [error]
 
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: This tests behaviour when extensions can't be loaded, expected"
 
 # this function is in the dbgen extension
 statement error

--- a/test/sql/function/generic/test_between_sideeffects.test
+++ b/test/sql/function/generic/test_between_sideeffects.test
@@ -4,8 +4,7 @@
 
 require icu
 
-# FIXME: Make icu properly autoloadable
-require no_extension_autoloading
+require no_extension_autoloading "FIXME: ICU is not autoloaded on '-(TIMESTAMP WITH TIME ZONE, INTERVAL)"
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/function/timetz/timetz_group_by.test
+++ b/test/sql/function/timetz/timetz_group_by.test
@@ -4,7 +4,7 @@
 
 require icu
 
-require no_extension_autoloading
+require no_extension_autoloading "FIXME: Autoload on generate_series(TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE, INTERVAL)"
 
 statement ok
 create table time_testtz as select i::timetz as t from generate_series(TIMESTAMPtz '2001-04-10', TIMESTAMPtz '2001-04-11', INTERVAL 30 MINUTE) as t(i);

--- a/test/sql/json/table/read_json_objects.test
+++ b/test/sql/json/table/read_json_objects.test
@@ -2,13 +2,6 @@
 # description: Read ndjson files
 # group: [table]
 
-require no_extension_autoloading
-
-# this was the previous implementation, doesn't work without JSON extension (no JSON type in catalog)
-statement error
-SELECT * FROM read_csv('data/json/example_n.ndjson', columns={'json': 'JSON'}, delim=NULL, header=0, quote=NULL, escape=NULL)
-----
-
 require json
 
 # we cannot check the error output for the specific byte, because on Windows the \n are replaced with \r\n

--- a/test/sql/parser/test_value_functions.test
+++ b/test/sql/parser/test_value_functions.test
@@ -2,7 +2,7 @@
 # description: Test SQL value functions
 # group: [parser]
 
-require no_extension_autoloading
+require no_extension_autoloading "FIXME: Unimplemented type for cast (TIMESTAMP WITH TIME ZONE -> DATE)"
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/secrets/create_secret_hffs_autoload.test
+++ b/test/sql/secrets/create_secret_hffs_autoload.test
@@ -2,7 +2,7 @@
 # description: Test huggingface secrets autoload
 # group: [secrets]
 
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: Test relies on autoloading being disabled"
 
 statement ok
 PRAGMA enable_verification;

--- a/test/sql/secrets/secret_autoloading_errors.test
+++ b/test/sql/secrets/secret_autoloading_errors.test
@@ -2,7 +2,7 @@
 # description: Test that error messages for secret manager makes sense
 # group: [secrets]
 
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: Tests failures on loading extensions
 
 statement error
 CREATE SECRET (TYPE S3)

--- a/test/sql/settings/allowed_directories.test
+++ b/test/sql/settings/allowed_directories.test
@@ -5,7 +5,7 @@
 require skip_reload
 
 # enable_external_access = false disables extension loading
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: Test disable autoloading"
 
 require parquet
 

--- a/test/sql/settings/allowed_paths.test
+++ b/test/sql/settings/allowed_paths.test
@@ -5,7 +5,7 @@
 require skip_reload
 
 # enable_external_access = false disables extension loading
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: Test disable loading of extensions"
 
 # we can set allowed_directories as much as we want
 statement ok

--- a/test/sql/settings/test_disabled_file_system_httpfs.test
+++ b/test/sql/settings/test_disabled_file_system_httpfs.test
@@ -4,7 +4,7 @@
 
 require skip_reload
 
-require no_extension_autoloading
+require no_extension_autoloading "EXPECTED: Test disable loading from local file system"
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/storage/icu_collation.test
+++ b/test/sql/storage/icu_collation.test
@@ -4,7 +4,7 @@
 
 require skip_reload
 
-require no_extension_autoloading
+require icu
 
 # The database is written with a vector size of 2048.
 require vector_size 2048
@@ -22,14 +22,6 @@ Goldmann
 Göbel
 Göthe
 Götz
-
-# cannot order by without ICU
-statement error
-SELECT * FROM strings ORDER BY 1
-----
-not in the catalog
-
-require icu
 
 query I
 SELECT * FROM strings ORDER BY 1

--- a/test/sql/table_function/duckdb_extensions.test
+++ b/test/sql/table_function/duckdb_extensions.test
@@ -2,8 +2,6 @@
 # description: Test duckdb_extensions function
 # group: [table_function]
 
-require no_extension_autoloading
-
 statement ok
 SELECT * FROM duckdb_extensions();
 
@@ -13,6 +11,9 @@ SELECT aliases FROM duckdb_extensions() WHERE extension_name='postgres_scanner';
 [postgres]
 
 require tpch
+
+statement ok
+LOAD tpch;
 
 query I
 SELECT extension_name FROM duckdb_extensions() WHERE loaded AND extension_name='tpch';

--- a/test/sql/table_function/range_non_foldable.test
+++ b/test/sql/table_function/range_non_foldable.test
@@ -2,7 +2,7 @@
 # description: Issue #5546: non-foldable constant parameters to table function
 # group: [table_function]
 
-require no_extension_autoloading
+require no_extension_autoloading "FIXME: Unimplemented type for cast (TIMESTAMP WITH TIME ZONE -> DATE)"
 
 require icu
 

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -297,6 +297,29 @@ bool SQLLogicTestRunner::ForEachTokenReplace(const string &parameter, vector<str
 	return collection;
 }
 
+static string ParseExplanation(SQLLogicParser &parser, const vector<string> &params, int &index) {
+	string res;
+	std::cout << params[index] << "\n";
+	if (params[index].empty() || params[index][0] != '"') {
+		parser.Fail("Quoted parameter should start with double quotes");
+	}
+
+	res += params[index].substr(1);
+	index++;
+
+	while (index < params.size()) {
+		res += " " + params[index];
+		index++;
+
+		if (res.back() == '"') {
+			res.pop_back();
+			break;
+		}
+	}
+
+	return res;
+}
+
 RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vector<string> &params) {
 	if (params.size() < 1) {
 		parser.Fail("require requires a single parameter");
@@ -459,6 +482,17 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 	}
 
 	if (param == "no_extension_autoloading") {
+		if (params.size() < 2) {
+			parser.Fail("require no_extension_autoloading needs an explanation string");
+		}
+		int index = 1;
+		string explanation = ParseExplanation(parser, params, index);
+		if (explanation.rfind("EXPECTED", 0) == 0 || explanation.rfind("FIXME", 0) == 0) {
+			// good, explanation is properly formatted
+		} else {
+			parser.Fail(
+			    "require no_extension_autoloading explanation string should begin with either 'EXPECTED' or FIXME'");
+		}
 		if (config->options.autoload_known_extensions) {
 			// If autoloading is on, we skip this test
 			return RequireResult::MISSING;

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -297,9 +297,8 @@ bool SQLLogicTestRunner::ForEachTokenReplace(const string &parameter, vector<str
 	return collection;
 }
 
-static string ParseExplanation(SQLLogicParser &parser, const vector<string> &params, int &index) {
+static string ParseExplanation(SQLLogicParser &parser, const vector<string> &params, size_t &index) {
 	string res;
-	std::cout << params[index] << "\n";
 	if (params[index].empty() || params[index][0] != '"') {
 		parser.Fail("Quoted parameter should start with double quotes");
 	}
@@ -485,7 +484,7 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 		if (params.size() < 2) {
 			parser.Fail("require no_extension_autoloading needs an explanation string");
 		}
-		int index = 1;
+		size_t index = 1;
 		string explanation = ParseExplanation(parser, params, index);
 		if (explanation.rfind("EXPECTED", 0) == 0 || explanation.rfind("FIXME", 0) == 0) {
 			// good, explanation is properly formatted


### PR DESCRIPTION
Added a way to inline explanations in the require clause, currently mandatory for `no_extension_autoloading`.

There is a pattern of adding comments above the require, but this makes it mandatory to have either a string starting with `FIXME: some text` or `EXPECTED: lorem ipsum`.
Behaviour is equivalent, but they should encode (to future devs) whether it's something that needs fixing and eventually be removed or it's needed for the test to actually make sense.

We could have infrastructure then to list the FIXME in the final report (or if a given flag is passed), or even just grep the test files.

While doing a pass, removed some instances of `require no_extensions_autoloading` that have been solved, and categorize either as FIXME or EXPECTED the others.

Note that changing SQLLogic parser might influence extensions tests (breaking them), but that's OK.

FIXME are currently related either to ICU types or functions not triggering autoloading or connected to ZSTD requiring parquet loaded (and not triggering autoloading).