### PR TITLE
NULL check for invalid result

### DIFF
--- a/src/main/capi/result-c.cpp
+++ b/src/main/capi/result-c.cpp
@@ -538,6 +538,9 @@ idx_t duckdb_column_count(duckdb_result *result) {
 	if (!result) {
 		return 0;
 	}
+	if (result->internal_data == NULL) {
+		return 0;
+	}
 	auto &result_data = *(reinterpret_cast<duckdb::DuckDBResultData *>(result->internal_data));
 	return result_data.result->ColumnCount();
 }


### PR DESCRIPTION
We run into a crash today where our code would check for column count in a result and result in a crash. While we can keep track of this ourselves and fix it, it may be helpful to have some  checks in the C API for DuckDB to check for the internal pointers being valid instead of a crash.