### PR TITLE
Add DictionaryId that can be used to uniquely identify dictionaries, and use this in the aggregate HT to cache look-ups

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -264,6 +264,7 @@ void ColumnReader::PrepareRead(parquet_filter_t &filter) {
 		} else if (dictionary_size > old_dict_size) {
 			dictionary->Resize(old_dict_size, dictionary_size + 1);
 		}
+		dictionary_id = reader.file_name + "_" + schema.name + "_" + std::to_string(chunk_read_offset);
 		// we use the first entry as a NULL, dictionary vectors don't have a separate validity mask
 		FlatVector::Validity(*dictionary).SetInvalid(0);
 		PlainReference(block, *dictionary);
@@ -577,6 +578,7 @@ idx_t ColumnReader::Read(uint64_t num_values, parquet_filter_t &filter, data_ptr
 			                    reinterpret_cast<uint8_t *>(define_out), filter, read_now, result_offset);
 			if (result_offset == 0) {
 				result.Dictionary(*dictionary, dictionary_size + 1, dictionary_selection_vector, read_now);
+				DictionaryVector::SetDictionaryId(result, dictionary_id);
 				D_ASSERT(result.GetVectorType() == VectorType::DICTIONARY_VECTOR);
 			} else {
 				D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -192,6 +192,7 @@ private:
 	SelectionVector dictionary_selection_vector;
 	idx_t dictionary_size;
 	unique_ptr<Vector> dictionary;
+	string dictionary_id;
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -338,6 +338,14 @@ struct DictionaryVector {
 		VerifyDictionary(vector);
 		return vector.buffer->Cast<DictionaryBuffer>().GetDictionarySize();
 	}
+	static inline const string &DictionaryId(const Vector &vector) {
+		VerifyDictionary(vector);
+		return vector.buffer->Cast<DictionaryBuffer>().GetDictionaryId();
+	}
+	static inline void SetDictionaryId(Vector &vector, string new_id) {
+		VerifyDictionary(vector);
+		vector.buffer->Cast<DictionaryBuffer>().SetDictionaryId(std::move(new_id));
+	}
 };
 
 struct FlatVector {

--- a/src/include/duckdb/common/types/vector_buffer.hpp
+++ b/src/include/duckdb/common/types/vector_buffer.hpp
@@ -165,10 +165,18 @@ public:
 	optional_idx GetDictionarySize() const {
 		return dictionary_size;
 	}
+	void SetDictionaryId(string id) {
+		dictionary_id = std::move(id);
+	}
+	const string &GetDictionaryId() const {
+		return dictionary_id;
+	}
 
 private:
 	SelectionVector sel_vector;
 	optional_idx dictionary_size;
+	//! A unique identifier for the dictionary that can be used to check if two dictionaries are equivalent
+	string dictionary_id;
 };
 
 class VectorStringBuffer : public VectorBuffer {

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -110,8 +110,8 @@ private:
 	struct AggregateDictionaryState {
 		AggregateDictionaryState();
 
-		//! The current dictionary vector (if any)
-		optional_ptr<Vector> dictionary;
+		//! The current dictionary vector id (if any)
+		string dictionary_id;
 		DataChunk unique_values;
 		Vector hashes;
 		Vector new_dictionary_pointers;

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -548,6 +548,7 @@ void DictionaryCompressionStorage::StringScanPartial(ColumnSegment &segment, Col
 		BitpackingPrimitives::UnPackBuffer<sel_t>(dst, src, scan_count, scan_state.current_width);
 
 		result.Dictionary(*(scan_state.dictionary), scan_state.dictionary_size, *scan_state.sel_vec, scan_count);
+		DictionaryVector::SetDictionaryId(result, to_string(CastPointerToValue(&segment)));
 	}
 }
 


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/15152

This PR enables the caching of results computed for dictionaries across vectors by (optionally) assigning them with a unique identifier. The identifier is a string that needs to be unique so we can distinguish between a vector having the same dictionary or a different dictionary as the previous vector. It does not have to be globally unique (i.e. really only in the same pipeline for the same thread). 

* For our own storage, the dictionary id is set to the `ColumnSegment` pointer address. Since we never de-allocate `ColumnSegments` while scanning this works
* For Parquet dictionaries, the dictionary id is set to `[parquet_filename]_[column_name]_[byte_offset]`