### PR TITLE
Rework `TableFilterType::CONSTANT_COMPARISON` to work identically to constant comparisons in SQL

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -674,8 +674,6 @@ unique_ptr<DataChunk> JoinFilterPushdownInfo::Finalize(ClientContext &context, J
 				    make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(max_val));
 				info.dynamic_filters->PushFilter(op, filter_col_idx, std::move(less_equals));
 			}
-			// not null filter
-			info.dynamic_filters->PushFilter(op, filter_col_idx, make_uniq<IsNotNullFilter>());
 		}
 	}
 

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -514,13 +514,6 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 					    make_uniq<ConstantFilter>(constant_cmp.comparison_type, constant_cmp.constant);
 					table_filters.PushFilter(column_index, PushDownFilterIntoExpr(expr, std::move(constant_filter)));
 				}
-				// We need to apply a IS NOT NULL filter to the column expression because any comparison with NULL
-				// is always false.
-				// However, the rowid pseudocolumn can never be NULL.
-				if (!column_index.IsRowIdColumn()) {
-					table_filters.PushFilter(column_index, PushDownFilterIntoExpr(expr, make_uniq<IsNotNullFilter>()));
-				}
-
 				equivalence_map.erase(filter_exp);
 			}
 		}
@@ -548,7 +541,6 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 				auto upper_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHAN, Value(like_string));
 				table_filters.PushFilter(column_index, std::move(lower_bound));
 				table_filters.PushFilter(column_index, std::move(upper_bound));
-				table_filters.PushFilter(column_index, make_uniq<IsNotNullFilter>());
 			}
 			if (func.function.name == "~~" && func.children[0]->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
 			    func.children[1]->type == ExpressionType::VALUE_CONSTANT) {
@@ -581,7 +573,6 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 					//! Here the like can be transformed to an equality query
 					auto equal_filter = make_uniq<ConstantFilter>(ExpressionType::COMPARE_EQUAL, Value(prefix));
 					table_filters.PushFilter(column_index, std::move(equal_filter));
-					table_filters.PushFilter(column_index, make_uniq<IsNotNullFilter>());
 				} else {
 					//! Here the like must be transformed to a BOUND COMPARISON geq le
 					auto lower_bound =
@@ -590,7 +581,6 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 					auto upper_bound = make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHAN, Value(prefix));
 					table_filters.PushFilter(column_index, std::move(lower_bound));
 					table_filters.PushFilter(column_index, std::move(upper_bound));
-					table_filters.PushFilter(column_index, make_uniq<IsNotNullFilter>());
 				}
 			}
 		} else if (remaining_filter->type == ExpressionType::COMPARE_IN) {
@@ -629,7 +619,6 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 				auto bound_eq_comparison =
 				    make_uniq<ConstantFilter>(ExpressionType::COMPARE_EQUAL, fst_const_value_expr.value);
 				table_filters.PushFilter(column_index, std::move(bound_eq_comparison));
-				table_filters.PushFilter(column_index, make_uniq<IsNotNullFilter>());
 				remaining_filters.erase_at(rem_fil_idx--); // decrement to stay on the same idx next iteration
 				continue;
 			}
@@ -654,7 +643,6 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 				    make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(in_list.back()));
 				table_filters.PushFilter(column_index, std::move(lower_bound));
 				table_filters.PushFilter(column_index, std::move(upper_bound));
-				table_filters.PushFilter(column_index, make_uniq<IsNotNullFilter>());
 
 				remaining_filters.erase_at(rem_fil_idx--); // decrement to stay on the same idx next iteration
 			} else {

--- a/test/sql/copy/parquet/parquet_hive.test
+++ b/test/sql/copy/parquet/parquet_hive.test
@@ -187,7 +187,7 @@ COPY (SELECT * FROM t1) TO '__TEST_DIR__/hive_filters_2' (FORMAT PARQUET, PARTIT
 query II
 EXPLAIN select a from parquet_scan('__TEST_DIR__/hive_filters/*/*.parquet', HIVE_PARTITIONING=1, HIVE_TYPES_AUTOCAST=0) where c::INT=500 and a::INT < 4;
 ----
-physical_plan	<REGEX>:.*PARQUET_SCAN.*Filters:.*a<4 AND a IS NOT.*NULL.*File Filters:.*\(CAST\(c AS.*INTEGER\) = 500\).*
+physical_plan	<REGEX>:.*PARQUET_SCAN.*Filters:.*a<4.*File Filters:.*\(CAST\(c AS.*INTEGER\) = 500\).*
 
 # unsatisfiable file filters also show up
 query II

--- a/test/sql/filter/test_struct_pushdown.test
+++ b/test/sql/filter/test_struct_pushdown.test
@@ -15,7 +15,7 @@ INSERT INTO test_structs VALUES ({'a': 1, 'b': true}), ({'a': 2, 'b': false}), (
 query II
 EXPLAIN SELECT * FROM test_structs WHERE i.a < 2;
 ----
-physical_plan	<REGEX>:.*Filters:.*i\.a<2 AND i\.a IS NOT NULL.*
+physical_plan	<REGEX>:.*Filters:.*i\.a<2.*
 
 query I
 SELECT * FROM test_structs WHERE i.a < 2;
@@ -26,7 +26,7 @@ SELECT * FROM test_structs WHERE i.a < 2;
 query II
 EXPLAIN SELECT * FROM test_structs WHERE i.a > 2;
 ----
-physical_plan	<REGEX>:.*Filters:.*i\.a>2 AND i\.a IS NOT NULL.*
+physical_plan	<REGEX>:.*Filters:.*i\.a>2.*
 
 query I
 SELECT * FROM test_structs WHERE i.a > 2;
@@ -37,7 +37,7 @@ SELECT * FROM test_structs WHERE i.a > 2;
 query II
 EXPLAIN SELECT * FROM test_structs WHERE i.A < 2;
 ----
-physical_plan	<REGEX>:.*Filters:.*i\.A<2 AND i\.A IS NOT NULL.*
+physical_plan	<REGEX>:.*Filters:.*i\.A<2.*
 
 query I
 SELECT * FROM test_structs WHERE i.A < 2;
@@ -78,7 +78,7 @@ INSERT INTO string_structs VALUES ({'a': 'foo', 'b': 'bar'}), ({'a': 'baz', 'b':
 query II
 EXPLAIN SELECT * FROM string_structs WHERE s.a = 'foo';
 ----
-physical_plan	<REGEX>:.*Filters:.*s\.a='foo' AND s\.a IS NOT.*NULL.*
+physical_plan	<REGEX>:.*Filters:.*s\.a='foo'.*
 
 query I
 SELECT * FROM string_structs WHERE s.a = 'foo';
@@ -99,12 +99,12 @@ restart
 query II
 EXPLAIN SELECT * FROM large_structs WHERE i.a > 150000;
 ----
-physical_plan	<REGEX>:.*Filters:.*i\.a>150000 AND i\.a IS NOT.*NULL.*
+physical_plan	<REGEX>:.*Filters:.*i\.a>150000.*
 
 query II
 EXPLAIN SELECT MIN(i.a), MAX(i.a), COUNT(*) FROM large_structs WHERE i.a > 150000;
 ----
-physical_plan	<REGEX>:.*Filters:.*i\.a>150000 AND i\.a IS NOT.*NULL.*
+physical_plan	<REGEX>:.*Filters:.*i\.a>150000.*
 
 query III
 SELECT MIN(i.a), MAX(i.a), COUNT(*) FROM large_structs WHERE i.a > 150000;
@@ -128,7 +128,7 @@ INSERT INTO nested_structs VALUES
 query II
 EXPLAIN SELECT * FROM nested_structs WHERE s.a.b < 2;
 ----
-physical_plan	<REGEX>:.*Filters:.*s\.a\.b<2 AND s\.a\.b IS NOT.*NULL.*
+physical_plan	<REGEX>:.*Filters:.*s\.a\.b<2.*
 
 query I
 SELECT * FROM nested_structs WHERE s.a.b < 2;
@@ -138,7 +138,7 @@ SELECT * FROM nested_structs WHERE s.a.b < 2;
 query II
 EXPLAIN SELECT * FROM nested_structs WHERE s.a.c = true AND s.d.e = 5;
 ----
-physical_plan	<REGEX>:.*Filters:.*s\.a\.c=true AND s\.a.*\.c IS.*NOT NULL AND s\.d\.e=5 AND.*s\.d\.e IS NOT NULL.*
+physical_plan	<REGEX>:.*Filters:.*s\.a\.c=true AND s\.d\.e=5.*
 
 query I
 SELECT * FROM nested_structs WHERE s.a.c = true AND s.d.e = 5;
@@ -148,7 +148,7 @@ SELECT * FROM nested_structs WHERE s.a.c = true AND s.d.e = 5;
 query II
 EXPLAIN SELECT * FROM nested_structs WHERE s.d.f = 'bar';
 ----
-physical_plan	<REGEX>:.*Filters:.*s\.d\.f='bar' AND s\.d\.f IS.*NOT NULL.*
+physical_plan	<REGEX>:.*Filters:.*s\.d\.f='bar'.*
 
 query I
 SELECT * FROM nested_structs WHERE s.d.f = 'bar';
@@ -165,7 +165,7 @@ COPY (FROM test_structs) TO '__TEST_DIR__/test_structs.parquet' (FORMAT PARQUET)
 query II
 EXPLAIN SELECT * FROM read_parquet('__TEST_DIR__/test_structs.parquet') WHERE i.a < 2;
 ----
-physical_plan	<REGEX>:.*Filters:.*i\.a<2 AND i\.a IS NOT NULL.*
+physical_plan	<REGEX>:.*Filters:.*i\.a<2.*
 
 query I
 SELECT * FROM read_parquet('__TEST_DIR__/test_structs.parquet') WHERE i.a < 2;
@@ -192,7 +192,7 @@ COPY (FROM string_structs) TO '__TEST_DIR__/string_structs.parquet' (FORMAT PARQ
 query II
 EXPLAIN SELECT * FROM read_parquet('__TEST_DIR__/string_structs.parquet') WHERE s.a = 'foo';
 ----
-physical_plan	<REGEX>:.*Filters:.*s\.a='foo' AND s\.a IS NOT.*NULL.*
+physical_plan	<REGEX>:.*Filters:.*s\.a='foo'.*
 
 query I
 SELECT * FROM read_parquet('__TEST_DIR__/string_structs.parquet') WHERE s.a = 'foo';
@@ -207,7 +207,7 @@ COPY (FROM nested_structs) TO '__TEST_DIR__/nested_structs.parquet' (FORMAT PARQ
 query II
 EXPLAIN SELECT * FROM read_parquet('__TEST_DIR__/nested_structs.parquet') WHERE s.a.b < 2;
 ----
-physical_plan	<REGEX>:.*Filters:.*s\.a\.b<2 AND s\.a\.b IS NOT.*NULL.*
+physical_plan	<REGEX>:.*Filters:.*s\.a\.b<2.*
 
 query I
 SELECT * FROM read_parquet('__TEST_DIR__/nested_structs.parquet') WHERE s.a.b < 2;
@@ -217,7 +217,7 @@ SELECT * FROM read_parquet('__TEST_DIR__/nested_structs.parquet') WHERE s.a.b < 
 query II
 EXPLAIN SELECT * FROM read_parquet('__TEST_DIR__/nested_structs.parquet') WHERE s.a.c = true AND s.d.e = 5;
 ----
-physical_plan	<REGEX>:.*Filters:.*s\.a\.c=true AND s\.a\.c IS.*NOT NULL AND s\.d\.e=5 AND.*s\.d\.e IS NOT NULL.*
+physical_plan	<REGEX>:.*Filters:.*s\.a\.c=true AND s\.d\.e=5.*
 
 query I
 SELECT * FROM read_parquet('__TEST_DIR__/nested_structs.parquet') WHERE s.a.c = true AND s.d.e = 5;
@@ -232,7 +232,7 @@ COPY (SELECT {'i': n} as s FROM generate_series(100000) as t(n)) TO '__TEST_DIR_
 query II
 EXPLAIN SELECT * FROM read_parquet('__TEST_DIR__/large.parquet') WHERE s.i >= 500 AND s.i < 5000;
 ----
-physical_plan	<REGEX>:.*Filters:.*s\.i>=500 AND s\.i<5000 AND.*s\.i IS NOT NULL.*
+physical_plan	<REGEX>:.*Filters:.*s\.i>=500 AND s\.i<5000.*
 
 query II
 SELECT min(s.i), max(s.i) FROM read_parquet('__TEST_DIR__/large.parquet') WHERE s.i >= 500 AND s.i < 5000;

--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -771,7 +771,7 @@ class TestArrowFilterPushdown(object):
         input = query_res[0][1]
         if 'PANDAS_SCAN' in input:
             pytest.skip(reason="This version of pandas does not produce an Arrow object")
-        match = re.search(r".*ARROW_SCAN.*Filters:.*s\.a<2 AND s\.a IS NOT NULL.*", input, flags=re.DOTALL)
+        match = re.search(r".*ARROW_SCAN.*Filters:.*s\.a<2.*", input, flags=re.DOTALL)
         assert match
 
         # Check that the filter is applied correctly
@@ -785,7 +785,7 @@ class TestArrowFilterPushdown(object):
 
         # the explain-output is pretty cramped, so just make sure we see both struct references.
         match = re.search(
-            r".*ARROW_SCAN.*Filters:.*s\.a<3 AND s\.a IS NOT NULL.*AND s\.b=true AND s\.b IS.*NOT NULL.*",
+            r".*ARROW_SCAN.*Filters:.*s\.a<3.*AND s\.b=true.*",
             query_res[0][1],
             flags=re.DOTALL,
         )
@@ -841,7 +841,7 @@ class TestArrowFilterPushdown(object):
         input = query_res[0][1]
         if 'PANDAS_SCAN' in input:
             pytest.skip(reason="This version of pandas does not produce an Arrow object")
-        match = re.search(r".*ARROW_SCAN.*Filters:.*s\.a\.b<2 AND s\.a\.b IS NOT.*NULL.*", input, flags=re.DOTALL)
+        match = re.search(r".*ARROW_SCAN.*Filters:.*s\.a\.b<2.*", input, flags=re.DOTALL)
         assert match
 
         # Check that the filter is applied correctly
@@ -858,7 +858,7 @@ class TestArrowFilterPushdown(object):
 
         # the explain-output is pretty cramped, so just make sure we see both struct references.
         match = re.search(
-            r".*ARROW_SCAN.*Filters:.*s\.a\.c=true AND s\.a\.c IS.*NOT NULL AND s\.d\.e=5 AND.*s\.d\.e IS NOT NULL.*",
+            r".*ARROW_SCAN.*Filters:.*s\.a\.c=true.*AND s\.d\.e=5.*",
             query_res[0][1],
             flags=re.DOTALL,
         )
@@ -879,7 +879,7 @@ class TestArrowFilterPushdown(object):
 
         res = query_res.fetchone()[1]
         match = re.search(
-            r".*ARROW_SCAN.*Filters:.*s\.d\.f='bar' AND s\.d\.f IS.*NOT NULL.*",
+            r".*ARROW_SCAN.*Filters:.*s\.d\.f='bar'.*",
             res,
             flags=re.DOTALL,
         )


### PR DESCRIPTION
This PR reworks the `TableFilterType::CONSTANT_COMPARISON` so that it works identically to constant comparisons in SQL with regards to NULL values, i.e. it filters out all `NULL` values. Previously, this used to be a bit of a mess:

* When encountering a constant comparison (e.g. `x = 5`), we would always push `x=5 AND x IS NOT NULL`
* Constant comparisons in our table scan would remove `NULL` values, and then run the `x IS NOT NULL` filter separately for no reason (since the constant comparison had already removed all `NULL` values)
* Constant comparisons when converted to expressions would be converted back into the `x = 5` form, which filters out `NULL` values, effectively not being round-trippable
* For the Parquet reader, we would actually not filter out `NULL` values in the constant comparison, but we would need to check if values were `NULL` anyway - only to then always filter them out (since we never pushed a constant comparison without a `IS NOT NULL` filter anyway)

This PR makes this consistent and speeds things up a little by skipping unnecessary checks. 