### PR TITLE
In Clause Rewriter: add mark column to the filter projection map to avoid projecting it upwards which can cause issues with set operations

### DIFF
--- a/src/include/duckdb/optimizer/in_clause_rewriter.hpp
+++ b/src/include/duckdb/optimizer/in_clause_rewriter.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/planner/logical_operator_visitor.hpp"
+#include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 
 namespace duckdb {

--- a/src/include/duckdb/optimizer/in_clause_rewriter.hpp
+++ b/src/include/duckdb/optimizer/in_clause_rewriter.hpp
@@ -21,6 +21,7 @@ public:
 
 	ClientContext &context;
 	Optimizer &optimizer;
+	optional_ptr<LogicalOperator> current_op;
 	unique_ptr<LogicalOperator> root;
 
 public:

--- a/src/include/duckdb/optimizer/in_clause_rewriter.hpp
+++ b/src/include/duckdb/optimizer/in_clause_rewriter.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/planner/logical_operator_visitor.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 
 namespace duckdb {
 class ClientContext;

--- a/src/optimizer/in_clause_rewriter.cpp
+++ b/src/optimizer/in_clause_rewriter.cpp
@@ -6,9 +6,9 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/operator/logical_column_data_get.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/execution/expression_executor.hpp"
-#include "duckdb/planner/operator/logical_filter.hpp"
 
 namespace duckdb {
 

--- a/src/optimizer/in_clause_rewriter.cpp
+++ b/src/optimizer/in_clause_rewriter.cpp
@@ -12,10 +12,17 @@
 namespace duckdb {
 
 unique_ptr<LogicalOperator> InClauseRewriter::Rewrite(unique_ptr<LogicalOperator> op) {
-	if (op->children.size() == 1) {
+	switch (op->type) {
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+	case LogicalOperatorType::LOGICAL_FILTER: {
+		current_op = op.get();
 		root = std::move(op->children[0]);
 		VisitOperatorExpressions(*op);
 		op->children[0] = std::move(root);
+		break;
+	}
+	default:
+		break;
 	}
 
 	for (auto &child : op->children) {
@@ -104,6 +111,19 @@ unique_ptr<Expression> InClauseRewriter::VisitReplace(BoundOperatorExpression &e
 	cond.comparison = ExpressionType::COMPARE_EQUAL;
 	join->conditions.push_back(std::move(cond));
 	root = std::move(join);
+
+	if (current_op->type == LogicalOperatorType::LOGICAL_FILTER) {
+		// project out the mark index again
+		auto &filter = current_op->Cast<LogicalFilter>();
+		if (filter.projection_map.empty()) {
+			auto child_bindings = root->GetColumnBindings();
+			for (idx_t i = 0; i < child_bindings.size(); i++) {
+				if (child_bindings[i].table_index != chunk_index) {
+					filter.projection_map.push_back(i);
+				}
+			}
+		}
+	}
 
 	// we replace the original subquery with a BoundColumnRefExpression referring to the mark column
 	unique_ptr<Expression> result =

--- a/src/optimizer/in_clause_rewriter.cpp
+++ b/src/optimizer/in_clause_rewriter.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
 
 namespace duckdb {
 

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -290,15 +290,6 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 			}
 		}
 		return;
-	case LogicalOperatorType::LOGICAL_FILTER: {
-		auto &filter = op.Cast<LogicalFilter>();
-		if (filter.HasProjectionMap()) {
-			// if we have any entries in the filter projection map don't prune any columns
-			// FIXME: we can do something more clever here
-			everything_referenced = true;
-		}
-		break;
-	}
 	case LogicalOperatorType::LOGICAL_DISTINCT: {
 		auto &distinct = op.Cast<LogicalDistinct>();
 		if (distinct.distinct_type == DistinctType::DISTINCT_ON) {

--- a/test/fuzzer/pedro/in_clause_setop_rewrite.test
+++ b/test/fuzzer/pedro/in_clause_setop_rewrite.test
@@ -1,0 +1,22 @@
+# name: test/fuzzer/pedro/in_clause_setop_rewrite.test
+# description: "Type mismatch for SET OPERATION", with IN with more than 4 elements, and UNION
+# group: [pedro]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table t0(id int);
+
+statement ok
+insert into t0 values(1);
+
+query I
+SELECT c1 FROM ((SELECT 1 AS c1) UNION (SELECT id AS c1 FROM t0 limit 1)) A where c1 IN (1, 2, 3, 4);
+----
+1
+
+query I
+SELECT c1 FROM ((SELECT 1 AS c1) UNION (SELECT id AS c1 FROM t0 limit 1)) A where c1 IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+----
+1


### PR DESCRIPTION
Fixes an issue found internally