### PR TITLE
Fix for row-id pushdown, and remove unnecessarily complicated method

### DIFF
--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -439,46 +439,6 @@ bool RowGroup::CheckZonemap(ScanFilterInfo &filters) {
 	return true;
 }
 
-static idx_t GetFilterScanCount(ColumnScanState &state, TableFilter &filter) {
-	switch (filter.filter_type) {
-	case TableFilterType::STRUCT_EXTRACT: {
-		auto &struct_filter = filter.Cast<StructFilter>();
-		auto &child_state = state.child_states[1 + struct_filter.child_idx]; // +1 for validity
-		auto &child_filter = struct_filter.child_filter;
-		return GetFilterScanCount(child_state, *child_filter);
-	}
-	case TableFilterType::CONJUNCTION_AND: {
-		auto &conjunction_state = filter.Cast<ConjunctionAndFilter>();
-		idx_t max_count = 0;
-		for (auto &child_filter : conjunction_state.child_filters) {
-			max_count = std::max(GetFilterScanCount(state, *child_filter), max_count);
-		}
-		return max_count;
-	}
-	case TableFilterType::CONJUNCTION_OR: {
-		auto &conjunction_state = filter.Cast<ConjunctionOrFilter>();
-		idx_t max_count = 0;
-		for (auto &child_filter : conjunction_state.child_filters) {
-			max_count = std::max(GetFilterScanCount(state, *child_filter), max_count);
-		}
-		return max_count;
-	}
-	case TableFilterType::OPTIONAL_FILTER: {
-		auto &zone_filter = filter.Cast<OptionalFilter>();
-		return GetFilterScanCount(state, *zone_filter.child_filter);
-	}
-	case TableFilterType::IS_NULL:
-	case TableFilterType::IS_NOT_NULL:
-	case TableFilterType::CONSTANT_COMPARISON:
-	case TableFilterType::IN_FILTER:
-	case TableFilterType::DYNAMIC_FILTER:
-		return state.current->start + state.current->count;
-	default: {
-		throw NotImplementedException("Unimplemented filter type for zonemap");
-	}
-	}
-}
-
 bool RowGroup::CheckZonemapSegments(CollectionScanState &state) {
 	auto &filters = state.GetFilterInfo();
 	for (auto &entry : filters.GetFilterList()) {
@@ -502,7 +462,13 @@ bool RowGroup::CheckZonemapSegments(CollectionScanState &state) {
 		}
 
 		// check zone map segment.
-		idx_t target_row = GetFilterScanCount(state.column_scans[column_idx], filter);
+		auto &column_scan_state = state.column_scans[column_idx];
+		auto current_segment = column_scan_state.current;
+		if (!current_segment) {
+			// no segment to skip
+			continue;
+		}
+		idx_t target_row = current_segment->start + current_segment->count;
 		if (target_row >= state.max_row) {
 			target_row = state.max_row;
 		}

--- a/test/sql/optimizer/test_rowid_pushdown.test
+++ b/test/sql/optimizer/test_rowid_pushdown.test
@@ -26,3 +26,17 @@ query II
 EXPLAIN SELECT * FROM t1 where rowid = 200000;
 ----
 physical_plan	<REGEX>:.*Filters: rowid=200000.*
+
+query I
+SELECT * FROM t1 where rowid IN (SELECT rowid FROM t1 ORDER BY rowid DESC LIMIT 10) ORDER BY rowid;
+----
+250090
+250091
+250092
+250093
+250094
+250095
+250096
+250097
+250098
+250099


### PR DESCRIPTION
Row IDs don't have segments, so we can't do segment-level skipping.

This problem only shows up with dynamic filters, since the filter changes while we're in the middle of a scan. With a static filter we would never get to this point (since the row group would be filtered out entirely at an earlier stage).
