### PR TITLE
Rework Wasm extensions CI, and use out_of_tree_extensions.cmake

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -24,7 +24,7 @@ duckdb_extension_load(httpfs
     )
 
 ################# ARROW
-if (NOT MINGW)
+if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
     duckdb_extension_load(arrow
             LOAD_TESTS DONT_LINK
             GIT_URL https://github.com/duckdb/arrow
@@ -34,7 +34,7 @@ if (NOT MINGW)
 endif()
 
 ################## AWS
-if (NOT MINGW)
+if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_aws
@@ -48,7 +48,7 @@ endif()
 ### build on a side
 if (NO)
 ################# AZURE
-if (NOT MINGW)
+if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
     duckdb_extension_load(azure
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_azure
@@ -61,7 +61,7 @@ endif()
 ################# DELTA
 # MinGW build is not available, and our current manylinux ci does not have enough storage space to run the rust build
 # for Delta
-if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux")
+if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT $ENV{WASM_EXTENSIONS})
     duckdb_extension_load(delta
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_delta
@@ -86,7 +86,7 @@ duckdb_extension_load(excel
 #    set(LOAD_ICEBERG_TESTS "")
 #endif()
 #
-#if (NOT MINGW)
+#if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
 #    duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS}
 #            GIT_URL https://github.com/duckdb/duckdb_iceberg
@@ -108,7 +108,7 @@ duckdb_extension_load(inet
 ################# POSTGRES_SCANNER
 # Note: tests for postgres_scanner are currently not run. All of them need a postgres server running. One test
 #       uses a remote rds server but that's not something we want to run here.
-if (NOT MINGW)
+if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
     duckdb_extension_load(postgres_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/postgres_scanner
@@ -141,11 +141,13 @@ duckdb_extension_load(sqlite_scanner
         APPLY_PATCHES
         )
 
+if (NOT $ENV{WASM_EXTENSIONS})
 duckdb_extension_load(sqlsmith
         DONT_LINK LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb_sqlsmith
         GIT_TAG d6d62c1cba6b1369ba79db4bff3c67f24aaa95c2
         )
+endif()
 
 ################# VSS
 duckdb_extension_load(vss
@@ -158,7 +160,7 @@ duckdb_extension_load(vss
     )
 
 ################# MYSQL
-if (NOT MINGW)
+if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
     duckdb_extension_load(mysql_scanner
             DONT_LINK
             LOAD_TESTS

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -1,131 +1,101 @@
 name: DuckDB-Wasm extensions
 on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   workflow_dispatch:
     inputs:
-      # Git ref of the duckdb-wasm repo
-      duckdb_wasm_ref:
-        required: true
+      override_git_describe:
         type: string
-      # Git ref of the duckdb repo
-      duckdb_ref:
-        required: true
+      git_ref:
         type: string
-      # Git ref of the duckdb repo
-      platforms:
-        required: false
-        default: '["wasm_mvp", "wasm_eh", "wasm_threads"]'
+      skip_tests:
         type: string
-      # Publish extensions on extensions.duckdb.org?
-      release_s3:
-        required: true
-        type: boolean
-        default: false
+  repository_dispatch:
+  push:
+    branches:
+      - '**'
+      - '!main'
+      - '!feature'
+    paths-ignore:
+      - '**'
+      - '!.github/workflows/Wasm.yml'
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
-  build_wasm:
-    name: Build extensions
+ wasm-extensions:
+    # Builds extensions for linux_amd64
+    name: Linux Extensions (x64)
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        duckdb_wasm_arch: ${{ fromJSON(github.event.inputs.platforms) }}
-    env:
-      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
-      DUCKDB_PLATFORM: "${{ matrix.duckdb_wasm_arch }}"
+        duckdb_arch: [wasm_mvp, wasm_eh, wasm_threads]
 
     steps:
-            - uses: actions/checkout@v4
-              with:
-                  ref: ${{ inputs.duckdb_wasm_ref }}
-                  fetch-depth: 0
-                  submodules: true
-                  repository: duckdb/duckdb-wasm
+      - uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
 
-            - uses: mymindstorm/setup-emsdk@v12
-              with:
-                  version: 'latest'
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: 'main'
+          repository: 'duckdb/extension-ci-tools'
+          fetch-depth: 0
 
-            - name: Install
-              shell: bash
-              run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+      - uses: mymindstorm/setup-emsdk@v13
+        with:
+          version: '3.1.71'
 
-            - name: Setup vcpkg
-              uses: lukka/run-vcpkg@v11.1
-              with:
-                  vcpkgGitCommitId: 5e5d0e1cd7785623065e77eff011afdeec1a3574
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: '5e5d0e1cd7785623065e77eff011afdeec1a3574'
+          vcpkgGitURL: 'https://github.com/microsoft/vcpkg.git'
 
-            - name: Setup Ccache
-              uses: hendrikmuhs/ccache-action@main
-              with:
-                  key: ${{ github.job }}-${{ matrix.duckdb_wasm_arch }}
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        continue-on-error: true
+        with:
+          key: ${{ github.job }}-${{ matrix.duckdb_arch }}
 
-            - name: PatchDuckDB
-              run: |
-                 cd submodules/duckdb
-                 git checkout ${{ github.event.inputs.duckdb_ref }}
-                 cd ../..
-                 make apply_patches
-                 cp extension_config_wasm.cmake submodules/duckdb/extension/extension_config.cmake
+      - name: Populate composed extension
+        shell: bash
+        run: |
+          cat duckdb/.github/config/in_tree_extensions.cmake duckdb/.github/config/out_of_tree_extensions.cmake > extension_config.cmake
+          echo "{\"dependencies\": []}" > vcpkg.json
+          cp duckdb/.github/helper_makefile/build_all_extensions Makefile
 
-            - name: Build Wasm module MVP
-              if: ${{ matrix.duckdb_wasm_arch == 'wasm_mvp' }}
-              run: |
-                DUCKDB_PLATFORM=wasm_mvp DUCKDB_WASM_LOADABLE_EXTENSIONS="signed" GEN=ninja ./scripts/wasm_build_lib.sh relsize mvp
+      - name: Run configure
+        shell: bash
+        env:
+          DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
+          WASM_EXTENSIONS: 1
+        run: |
+          sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format-11 cmake
+          make configure_ci
 
-            - name: Build Wasm module EH
-              if: ${{ matrix.duckdb_wasm_arch == 'wasm_eh' }}
-              run: |
-                DUCKDB_PLATFORM=wasm_eh DUCKDB_WASM_LOADABLE_EXTENSIONS="signed" GEN=ninja ./scripts/wasm_build_lib.sh relsize eh
+      - name: Build Wasm module
+        shell: bash
+        env:
+          VCPKG_TOOLCHAIN_PATH: /home/runner/work/duckdb/duckdb/vcpkg/scripts/buildsystems/vcpkg.cmake
+          WASM_EXTENSIONS: 1
+        run: |
+          make ${{ matrix.duckdb_arch }}
 
-            - name: Build Wasm module THREADS
-              if: ${{ matrix.duckdb_wasm_arch == 'wasm_threads' }}
-              run: |
-                DUCKDB_PLATFORM=wasm_threads DUCKDB_WASM_LOADABLE_EXTENSIONS="signed" GEN=ninja ./scripts/wasm_build_lib.sh relsize coi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: duckdb-extensions-${{ matrix.duckdb_arch }}
+          path: |
+            build/${{ matrix.duckdb_arch }}/extension/*/*.duckdb_extension.wasm
 
-            - name: Upload artifact
-              uses: actions/upload-artifact@v4
-              with:
-                  name: duckdb_extensions_${{ env.DUCKDB_PLATFORM }}
-                  path: build/extension_repository/${{ inputs.duckdb_ref }}/${{ env.DUCKDB_PLATFORM }}
-                  retention-days: 1
-
-  publish:
-    name: Publish extensions
-    runs-on: ubuntu-latest
-    needs:
-    - build_wasm
-    strategy:
-      matrix:
-        duckdb_arch: ${{ fromJSON(github.event.inputs.platforms) }}
-    steps:
-            - uses: actions/checkout@v4
-
-            - uses: actions/download-artifact@v4
-              with:
-                name: duckdb_extensions_${{ matrix.duckdb_arch }}
-                path: build/to_be_deployed/${{ inputs.duckdb_ref }}/${{ matrix.duckdb_arch }}
-
-            - uses: actions/setup-python@v5
-              with:
-                python-version: '3.12'
-
-            - name: Install aws
-              run: |
-                  pip install awscli
-
-            - name: Sign and deploy Wasm extensions (no credentials)
-              if: ${{ ! inputs.release_s3 }}
-              run: |
-                  bash ./scripts/extension-upload-wasm.sh ${{ matrix.duckdb_arch }} ${{ inputs.duckdb_ref }}
-
-            - name: Sign and deploy Wasm extensions (with credentials)
-              if: ${{ inputs.release_s3 }}
-              env:
-                  AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
-                  AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
-                  AWS_DEFAULT_REGION: us-east-1
-                  DUCKDB_EXTENSION_SIGNING_PK: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
-              run: |
-                  bash ./scripts/extension-upload-wasm.sh ${{ matrix.duckdb_arch }} ${{ inputs.duckdb_ref }}

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -13,6 +13,6 @@ duckdb_extension_load(parquet)
 
 # The Linux allocator has issues so we use jemalloc, but only on x86 because page sizes are fixed at 4KB.
 # Configuring jemalloc properly for 32bit is a hassle, and not worth it so we only enable on 64bit
-if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS AND NOT $ENV{WASM_EXTENSIONS})
     duckdb_extension_load(jemalloc)
 endif()


### PR DESCRIPTION
Thanks to work in the bump to [recent spatial](https://github.com/duckdb/duckdb/pull/15158) and other work that went in CI recently, this should make trivial to keep in sink extensions for DuckDB-Wasm and other platforms.

Note that this DO NOT yet uploads or sign extensions, but that's an independent step that can be done in a follow up.