### PR TITLE
[Python][Dev] Fix `test_filter_pushdown.py`

### DIFF
--- a/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
@@ -282,7 +282,8 @@ py::object GetScalar(Value &constant, const string &timezone_config, const Arrow
 		constant.type().GetDecimalProperties(width, scale);
 		// pyarrow only allows 'decimal.Decimal' to be used to construct decimal scalars such as 0.05
 		auto val = import_cache.decimal.Decimal()(constant.ToString());
-		return dataset_scalar(scalar(std::move(val), decimal_type(width, scale)));
+		return dataset_scalar(
+		    scalar(std::move(val), decimal_type(py::arg("precision") = width, py::arg("scale") = scale)));
 	}
 	default:
 		throw NotImplementedException("Unimplemented type \"%s\" for Arrow Filter Pushdown",

--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -30,12 +30,11 @@ def create_pyarrow_dataset(rel):
 
 
 def test_decimal_filter_pushdown(duckdb_cursor):
-    pytest.skip("panic in polars is triggered, to be reviewed")
     pl = pytest.importorskip("polars")
     np = pytest.importorskip("numpy")
     np.random.seed(10)
 
-    df = pl.DataFrame({'x': pl.Series(np.random.uniform(-10, 10, 1000)).cast(pl.Decimal(18, 4))})
+    df = pl.DataFrame({'x': pl.Series(np.random.uniform(-10, 10, 1000)).cast(pl.Decimal(precision=18, scale=4))})
 
     query = """
         SELECT


### PR DESCRIPTION
This PR addresses <https://github.com/duckdblabs/duckdb-internal/issues/3578> partly
Namely the `Linux 3.8 -> panic in Rust` portion

The order of `precision` and `scale` was switched at some point (I believe polars 0.19.12 -> 0.19.13), which made this code break on earlier polars versions