### PR TITLE
Fix several fuzzer issues

### DIFF
--- a/src/execution/expression_executor/execute_cast.cpp
+++ b/src/execution/expression_executor/execute_cast.cpp
@@ -12,7 +12,8 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundCastE
 	result->Finalize();
 
 	if (expr.bound_cast.init_local_state) {
-		CastLocalStateParameters parameters(root.executor->GetContext(), expr.bound_cast.cast_data);
+		auto context_ptr = root.executor->HasContext() ? &root.executor->GetContext() : nullptr;
+		CastLocalStateParameters parameters(context_ptr, expr.bound_cast.cast_data);
 		result->local_state = expr.bound_cast.init_local_state(parameters);
 	}
 	return std::move(result);

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -213,6 +213,8 @@ public:
 	CatalogEntryRetriever &EntryRetriever() {
 		return entry_retriever;
 	}
+	//! Returns a ColumnRefExpression after it was resolved (i.e. past the STAR expression/USING clauses)
+	static optional_ptr<ParsedExpression> GetResolvedColumnExpression(ParsedExpression &root_expr);
 
 	void SetCanContainNulls(bool can_contain_nulls);
 	void SetAlwaysRequireRebind();

--- a/src/planner/binder/expression/bind_star_expression.cpp
+++ b/src/planner/binder/expression/bind_star_expression.cpp
@@ -185,7 +185,7 @@ void TryTransformStarLike(unique_ptr<ParsedExpression> &root) {
 	root = std::move(columns_expr);
 }
 
-optional_ptr<ParsedExpression> GetStarChildExpression(ParsedExpression &root_expr) {
+optional_ptr<ParsedExpression> Binder::GetResolvedColumnExpression(ParsedExpression &root_expr) {
 	optional_ptr<ParsedExpression> expr = &root_expr;
 	while (expr) {
 		if (expr->type == ExpressionType::COLUMN_REF) {
@@ -248,7 +248,7 @@ void Binder::ExpandStarExpression(unique_ptr<ParsedExpression> expr,
 			}
 			vector<unique_ptr<ParsedExpression>> new_list;
 			for (idx_t i = 0; i < star_list.size(); i++) {
-				auto child_expr = GetStarChildExpression(*star_list[i]);
+				auto child_expr = GetResolvedColumnExpression(*star_list[i]);
 				if (!child_expr) {
 					continue;
 				}
@@ -317,7 +317,7 @@ void Binder::ExpandStarExpression(unique_ptr<ParsedExpression> expr,
 		auto new_expr = expr->Copy();
 		ReplaceStarExpression(new_expr, star_list[i]);
 		if (StarExpression::IsColumns(*star)) {
-			auto expr = GetStarChildExpression(*star_list[i]);
+			auto expr = GetResolvedColumnExpression(*star_list[i]);
 			if (expr) {
 				auto &colref = expr->Cast<ColumnRefExpression>();
 				if (new_expr->alias.empty()) {

--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -310,7 +310,6 @@ void Binder::BindModifiers(BoundQueryNode &result, idx_t table_index, const vect
 		switch (bound_mod->type) {
 		case ResultModifierType::DISTINCT_MODIFIER: {
 			auto &distinct = bound_mod->Cast<BoundDistinctModifier>();
-			D_ASSERT(!distinct.target_distincts.empty());
 			// set types of distinct targets
 			for (auto &expr : distinct.target_distincts) {
 				expr = FinalizeBindOrderExpression(std::move(expr), table_index, names, sql_types, bind_state);

--- a/src/planner/binder/query_node/plan_query_node.cpp
+++ b/src/planner/binder/query_node/plan_query_node.cpp
@@ -13,6 +13,9 @@ unique_ptr<LogicalOperator> Binder::VisitQueryNode(BoundQueryNode &node, unique_
 		switch (mod->type) {
 		case ResultModifierType::DISTINCT_MODIFIER: {
 			auto &bound = mod->Cast<BoundDistinctModifier>();
+			if (bound.target_distincts.empty()) {
+				break;
+			}
 			auto distinct = make_uniq<LogicalDistinct>(std::move(bound.target_distincts), bound.distinct_type);
 			distinct->AddChild(std::move(root));
 			root = std::move(distinct);

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -148,7 +148,6 @@ void ReplaceColumnBindings(Expression &expr, idx_t source, idx_t dest) {
 void Binder::BindDoUpdateSetExpressions(const string &table_alias, LogicalInsert &insert, UpdateSetInfo &set_info,
                                         TableCatalogEntry &table, TableStorageInfo &storage_info) {
 	D_ASSERT(insert.children.size() == 1);
-	D_ASSERT(insert.children[0]->type == LogicalOperatorType::LOGICAL_PROJECTION);
 
 	vector<column_t> logical_column_ids;
 	vector<string> column_names;

--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -494,6 +494,9 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 		if (values_list) {
 			throw BinderException("INSERT BY NAME can only be used when inserting from a SELECT statement");
 		}
+		if (stmt.default_values) {
+			throw BinderException("INSERT BY NAME cannot be combined with with DEFAULT VALUES");
+		}
 		if (!stmt.columns.empty()) {
 			throw BinderException("INSERT BY NAME cannot be combined with an explicit column list");
 		}

--- a/src/planner/binder/tableref/bind_pivot.cpp
+++ b/src/planner/binder/tableref/bind_pivot.cpp
@@ -97,10 +97,11 @@ static unique_ptr<SelectNode> ConstructInitialGrouping(PivotRef &ref, vector<uni
 	if (ref.groups.empty()) {
 		// if rows are not specified any columns that are not pivoted/aggregated on are added to the GROUP BY clause
 		for (auto &entry : all_columns) {
-			if (entry->type != ExpressionType::COLUMN_REF) {
+			auto column_entry = Binder::GetResolvedColumnExpression(*entry);
+			if (!column_entry) {
 				throw InternalException("Unexpected child of pivot source - not a ColumnRef");
 			}
-			auto &columnref = entry->Cast<ColumnRefExpression>();
+			auto &columnref = column_entry->Cast<ColumnRefExpression>();
 			if (handled_columns.find(columnref.GetColumnName()) == handled_columns.end()) {
 				// not handled - add to grouping set
 				subquery->groups.group_expressions.push_back(make_uniq<ConstantExpression>(

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -750,6 +750,8 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 	}
 	case LogicalOperatorType::LOGICAL_SAMPLE:
 		throw BinderException("Sampling in correlated subqueries is not (yet) supported");
+	case LogicalOperatorType::LOGICAL_POSITIONAL_JOIN:
+		throw BinderException("Positional join in correlated subqueries is not (yet) supported");
 	default:
 		throw InternalException("Logical operator type \"%s\" for dependent join", LogicalOperatorToString(plan->type));
 	}

--- a/test/fuzzer/public/cast_index_expression.test
+++ b/test/fuzzer/public/cast_index_expression.test
@@ -1,0 +1,14 @@
+# name: test/fuzzer/public/cast_index_expression.test
+# description: Test CREATE INDEX using an index expression that triggers a cast
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE v00 (c01 INT, c02 STRING);
+
+statement error
+CREATE INDEX i_index ON v00 USING ART ( NULLIF ( v00, 'string' ) );
+----
+Invalid type for index key

--- a/test/fuzzer/public/columns_using.test
+++ b/test/fuzzer/public/columns_using.test
@@ -1,0 +1,20 @@
+# name: test/fuzzer/public/columns_using.test
+# description: Test COLUMNS regex in combination with the USING clause for a FULL join
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE v00 (c01 INT);
+
+statement error
+SELECT COLUMNS('v00')
+FROM v00 AS t1 FULL JOIN v00 AS t2 USING (c01) ;
+----
+No matching columns found
+
+query I
+SELECT COLUMNS('c01')
+FROM v00 AS t1 FULL JOIN v00 AS t2 USING (c01) ;
+----

--- a/test/fuzzer/public/distinct_on_non_integer_literal.test
+++ b/test/fuzzer/public/distinct_on_non_integer_literal.test
@@ -1,0 +1,14 @@
+# name: test/fuzzer/public/distinct_on_non_integer_literal.test
+# description: Test DISTINCT ON non-integer literal
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+SET order_by_non_integer_literal=true;
+
+query I
+SELECT DISTINCT ON ('string') 'x' AS c02;
+----
+x

--- a/test/fuzzer/public/insert_by_name_default.test
+++ b/test/fuzzer/public/insert_by_name_default.test
@@ -1,0 +1,14 @@
+# name: test/fuzzer/public/insert_by_name_default.test
+# description: Insert by name + default values
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE t0(i INT)
+
+statement error
+INSERT INTO t0 BY NAME DEFAULT VALUES;
+----
+INSERT BY NAME cannot be combined with with DEFAULT VALUES

--- a/test/fuzzer/public/insert_or_replace_default_values.test
+++ b/test/fuzzer/public/insert_or_replace_default_values.test
@@ -1,0 +1,41 @@
+# name: test/fuzzer/public/insert_or_replace_default_values.test
+# description: Test INSERT OR REPLACE with DEFAULT VALUES
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE SEQUENCE seq
+
+statement ok
+CREATE TABLE tbl(id INTEGER PRIMARY KEY DEFAULT 1, payload INTEGER DEFAULT nextval('seq'));
+
+statement ok
+INSERT OR REPLACE INTO tbl DEFAULT VALUES;
+
+query II
+FROM tbl
+----
+1	1
+
+statement ok
+INSERT OR REPLACE INTO tbl DEFAULT VALUES;
+
+query II
+FROM tbl
+----
+1	2
+
+statement ok
+INSERT OR IGNORE INTO tbl DEFAULT VALUES;
+
+query II
+FROM tbl
+----
+1	2
+
+statement error
+INSERT INTO tbl DEFAULT VALUES;
+----
+constraint

--- a/test/fuzzer/public/pivot_full_join_using.test
+++ b/test/fuzzer/public/pivot_full_join_using.test
@@ -1,0 +1,16 @@
+# name: test/fuzzer/public/pivot_full_join_using.test
+# description: Test pivoting on a USING column that comes from a FULL JOIN
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE t1 (c01 INT, c02 INT);
+
+statement ok
+CREATE TABLE t2 (c01 INT, c03 INT);
+
+query II
+PIVOT t1 FULL JOIN t2 USING ( c01 ) ON c01;
+----

--- a/test/fuzzer/public/positional_join_correlated_subquery.test
+++ b/test/fuzzer/public/positional_join_correlated_subquery.test
@@ -1,0 +1,15 @@
+# name: test/fuzzer/public/positional_join_correlated_subquery.test
+# description: Test positional join in correlated subqueries
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE v00 (c01 INT, c02 STRING);
+
+statement error
+SELECT (SELECT 42 FROM (SELECT c01) POSITIONAL JOIN (SELECT c02))
+FROM v00;
+----
+not (yet) supported

--- a/test/fuzzer/public/semi_join_using.test
+++ b/test/fuzzer/public/semi_join_using.test
@@ -1,0 +1,33 @@
+# name: test/fuzzer/public/semi_join_using.test
+# description: Test SEMI JOIN with USING clause
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE v00 (c01 INT, c02 STRING);
+
+statement error
+SELECT c02
+FROM (
+	v00 AS t1
+	NATURAL JOIN
+	v00 AS t2 ),
+	( v00 AS ta04
+	SEMI JOIN v00 AS ta05
+	USING ( c02 ) ) ;
+----
+Ambiguous column reference
+
+
+query III
+SELECT t1.c02, t2.c02, ta04.c02
+FROM (
+	v00 AS t1
+	NATURAL JOIN
+	v00 AS t2 ),
+	( v00 AS ta04
+	SEMI JOIN v00 AS ta05
+	USING ( c02 ) ) ;
+----


### PR DESCRIPTION
Fixes #15207: remove unnecessary/incorrect assertion + add tests
Fixes #15206: only grab client context if it is available in execute_cast
Fixes #15199: skip DISTINCT ON if the target list has been emptied (bec… 
Fixes #15201: For SEMI/ANTI join, remove USING columns from the BindContext as well
Fixes #15202: correctly traverse COALESCE in child expressions in COLUM… 
Fixes #15203: throw explicit unsupported error when encountering positi… 
Fixes #15195: we do not support INSERT BY NAME + DEFAULT VALUES
Fixes #15198: correctly handle USING columns of FULL JOIN in PIVOT as well

Thanks @SteveLeungYL for filing!