### PR TITLE
Skip spatial on MinGW, given otherwise mingw extensions CI will fail

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -117,6 +117,8 @@ if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
             )
 endif()
 
+# mingw CI with all extensions at once is somehow not happy
+if (NOT MINGW)
 ################# SPATIAL
 duckdb_extension_load(spatial
     DONT_LINK LOAD_TESTS
@@ -125,6 +127,7 @@ duckdb_extension_load(spatial
     INCLUDE_DIR spatial/include
     TEST_DIR test/sql
     )
+endif()
 
 ################# SQLITE_SCANNER
 # Static linking on windows does not properly work due to symbol collision


### PR DESCRIPTION
Discussed with @Maxxen, strange thing is that spatial builds correctly in its repo on all platform, but fails for some yet to be investigated reasons in https://github.com/duckdb/duckdb/actions/runs/12226753436/job/34102494725#step:5:15134 like:

```
[ 56%] Linking CXX shared library spatial.duckdb_extension
C:\rtools42\x86_64-w64-mingw32.static.posix\bin/ld.exe: ../../vcpkg_installed/x64-mingw-static/lib/libgeos.a(WKBReader.cpp.obj):WKBReader.cpp:(.text+0x205): undefined reference to `std::istream::seekg(std::fpos<int>)'
collect2.exe: error: ld returned 1 exit status
gmake.exe[3]: *** [extension/spatial/CMakeFiles/spatial_loadable_extension.dir/build.make:2366: extension/spatial/spatial.duckdb_extension] Error 1
```

I think safest is just skip in R and investigate on a side and then reverted.

If this is not solved by next release, we can always just publish spatial via its repository.