### PR TITLE
Add filter on repository_dispatch to Regression nightly run

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -102,7 +102,7 @@ jobs:
           git clone https://github.com/duckdb/duckdb.git
           cd duckdb
           if [[ -z "${BASE_HASH}" ]]; then
-            export CHECKOUT_HASH=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --status=completed --json=headSha --limit=1 --jq '.[0].headSha')
+            export CHECKOUT_HASH=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --event=repository_dispatch --status=completed --json=headSha --limit=1 --jq '.[0].headSha')
           else
             export CHECKOUT_HASH="$BASE_HASH"
           fi


### PR DESCRIPTION
Fix for when contributors send PR using `main` as branch name, that trips figuring out the hash like tonight.

Note that codepath is not tested in CI for PRs, so CI run are not relevant here.