### PR TITLE
Rework upload ci via reusable workflow

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -256,35 +256,6 @@ jobs:
         run: |
           python3 scripts/run_tests_one_by_one.py ./build/release/test/unittest
 
-      - name: Deploy
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
-          DUCKDB_DEPLOY_SCRIPT_MODE: for_real
-        run: |
-          if [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            pip install awscli
-            ./scripts/extension-upload-all.sh ${{ matrix.duckdb_arch }} ${{ github.ref_name }}
-          elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            pip install awscli
-            ./scripts/extension-upload-all.sh ${{ matrix.duckdb_arch }} `git log -1 --format=%h`
-          else
-            echo "would do: ./scripts/extension-upload-all.sh ${{ matrix.duckdb_arch }} ${{ github.ref_name }}"
-          fi
-
-      - name: Test loadable extensions
-        if: ${{ matrix.osx_arch == 'arm64' &&  inputs.skip_tests != 'true' }}
-        shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
-          AWS_DEFAULT_REGION: us-east-1
-        run: |
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            ./scripts/extension-upload-test.sh
-          fi
-
       - name: Rebuild DuckDB without any extensions linked, but with same extension config
         if: ${{ matrix.osx_arch == 'arm64' }}
         shell: bash
@@ -306,3 +277,47 @@ jobs:
           python3 scripts/get_test_list.py --file-contains 'require ' --list '"*.test"' > test.list
           python3 scripts/get_test_list.py --file-contains 'require-env LOCAL_EXTENSION_REPO' --list '"*.test"' >> test.list
           python3 scripts/run_tests_one_by_one.py ./build/release/test/unittest '-f test.list'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: duckdb-extensions-${{ matrix.duckdb_arch }}
+          path: |
+            build/release/extension/*/*.duckdb_extension
+
+  upload-osx-extensions:
+    name: Upload OSX Extensions
+    needs: xcode-extensions
+    uses: ./.github/workflows/_sign_deploy_extensions.yml
+    secrets: inherit
+    strategy:
+      matrix:
+        duckdb_arch: [ 'osx_amd64', 'osx_arm64' ]
+    with:
+      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
+      duckdb_arch: ${{ matrix.duckdb_arch }}
+      duckdb_sha: ${{ github.sha }}
+
+  test-uploaded-extensions:
+    name: Test uploaded OSX Extensions
+    needs: upload-osx-extensions
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Execute test
+      shell: bash
+      env:
+          AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
+          AWS_DEFAULT_REGION: us-east-1
+      run: |
+          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+            ./scripts/extension-upload-test.sh
+          fi

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -66,12 +66,26 @@ jobs:
           duckdb_arch: windows_amd64_mingw
           vcpkg_target_triplet: x64-mingw-static
           treat_warn_as_error: 0
-          s3_id: ${{ secrets.S3_ID }}
-          s3_key: ${{ secrets.S3_KEY }}
-          signing_pk: ${{ secrets.DUCKDB_EXTENSION_SIGNING_PK }}
           override_cc: gcc
           override_cxx: g++
           vcpkg_build: 1
           no_static_linking: 1
           run_tests: 0
           run_autoload_tests: 0
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows_amd64_mingw-extensions
+          path: |
+            build/release/extension/*/*.duckdb_extension
+
+  upload-mingw-extensions:
+    name: Upload MinGW Extensions
+    needs: rstats-windows-extensions
+    uses: ./.github/workflows/_sign_deploy_extensions.yml
+    secrets: inherit
+    with:
+      extension_artifact_name: windows_amd64_mingw-extensions
+      duckdb_arch: windows_amd64_mingw
+      duckdb_sha: ${{ github.sha }}
+

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -99,3 +99,15 @@ jobs:
           path: |
             build/${{ matrix.duckdb_arch }}/extension/*/*.duckdb_extension.wasm
 
+ upload-wasm-extensions:
+    name: Upload Wasm Extensions
+    needs: wasm-extensions
+    uses: ./.github/workflows/_sign_deploy_extensions.yml
+    secrets: inherit
+    strategy:
+      matrix:
+        duckdb_arch: [wasm_mvp, wasm_eh, wasm_threads]
+    with:
+      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
+      duckdb_arch: ${{ matrix.duckdb_arch }}
+      duckdb_sha: ${{ github.sha }}


### PR DESCRIPTION
This changes R.yml, Wasm.yml and OSX.yml to upload the duckdb extensions built there to go through the reusable workflow already introduced for Linux extensions.

Advantage in centralizing to single workflow is that it makes easier to track and modify it.

Also the change make from steps executed only on nightly CI to step always executed, and only the actual upload will fail on PRs. This should make so this PR CI can be reviewed and have some guarantees that stuff should happening as intended.

This has a risk of breaking upload on nightly (for OSX and R), but I think this is made in way to minimize potential problems.
For Wasm this make so that nigthly duckdb version get the equivalent set of `duckdb_extension.wasm`.