### PR TITLE
Add run_benchmark.py script

### DIFF
--- a/scripts/generate_presigned_url.sh
+++ b/scripts/generate_presigned_url.sh
@@ -12,10 +12,10 @@ COPY lineitem TO 'data/parquet-testing/presigned/presigned-url-lineitem.parquet'
 
 EOF
 )
-build/release/duckdb -c "$generate_large_parquet_query"
+duckdb -c "$generate_large_parquet_query"
 
 mkdir -p data/attach_test/
 
 # Generate Storage Version
-build/release/duckdb  data/attach_test/attach.db < test/sql/storage_version/generate_storage_version.sql
-build/release/duckdb  data/attach_test/lineitem_sf1.db -c "CALL dbgen(sf=1)"
+duckdb  data/attach_test/attach.db < test/sql/storage_version/generate_storage_version.sql
+duckdb  data/attach_test/lineitem_sf1.db -c "CALL dbgen(sf=1)"

--- a/scripts/generate_presigned_url.sh
+++ b/scripts/generate_presigned_url.sh
@@ -12,10 +12,10 @@ COPY lineitem TO 'data/parquet-testing/presigned/presigned-url-lineitem.parquet'
 
 EOF
 )
-duckdb -c "$generate_large_parquet_query"
+build/release/duckdb -c "$generate_large_parquet_query"
 
 mkdir -p data/attach_test/
 
 # Generate Storage Version
-duckdb  data/attach_test/attach.db < test/sql/storage_version/generate_storage_version.sql
-duckdb  data/attach_test/lineitem_sf1.db -c "CALL dbgen(sf=1)"
+build/release/duckdb  data/attach_test/attach.db < test/sql/storage_version/generate_storage_version.sql
+build/release/duckdb  data/attach_test/lineitem_sf1.db -c "CALL dbgen(sf=1)"

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,0 +1,52 @@
+import argparse
+import os
+import subprocess
+import re
+
+parser = argparse.ArgumentParser(description='Run a full benchmark using the CLI and report the results.')
+parser.add_argument('--shell', action='store', help='Path to the CLI', default='build/reldebug/duckdb')
+parser.add_argument('--database', action='store', help='Path to the database file to load data from')
+parser.add_argument(
+    '--queries', action='store', help='Path to the list of queries to run (e.g. benchmark/clickbench/queries)'
+)
+parser.add_argument('--nrun', action='store', help='The number of runs', default=3)
+
+args = parser.parse_args()
+
+queries = os.listdir(args.queries)
+queries.sort()
+ran_queries = []
+timings = []
+for q in queries:
+    if 'load.sql' in q:
+        continue
+    command = [args.shell, args.database]
+    command += ['-c', '.timer on']
+    for i in range(args.nrun):
+        command += ['-c', '.read ' + os.path.join(args.queries, q)]
+    res = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    stdout = res.stdout.decode('utf8').strip()
+    stderr = res.stderr.decode('utf8').strip()
+    results = re.findall(r'Run Time \(s\): real (\d+.\d+)', stdout)
+    if res.returncode != 0 or 'Error:\n' in stderr or len(results) != args.nrun:
+        print("------- Failed to run query -------")
+        print(q)
+        print("------- stdout -------")
+        print(stdout)
+        print("------- stderr -------")
+        print(stderr)
+        exit(1)
+    results = [float(x) for x in results]
+    print(f"Timings for {q}: " + str(results))
+    ran_queries.append(q)
+    timings.append(results[1])
+
+print('')
+sql_query = 'SELECT UNNEST(['
+sql_query += ','.join(["'" + x + "'" for x in ran_queries]) + ']) as query'
+sql_query += ","
+sql_query += "UNNEST(["
+sql_query += ','.join([str(x) for x in timings])
+sql_query += "]) as timing;"
+print(sql_query)


### PR DESCRIPTION
This PR adds the `run_benchmark.py` script that can be used to easily run a full benchmark (e.g. TPC-H, TPC-DS, ClickBench) using the CLI.

Usage:

```bash
python scripts/run_benchmark.py --shell duckdb --database hits.db --queries benchmark/clickbench/queries
```

Output:

```
Timings for q01.sql: [0.013, 0.008, 0.008]
Timings for q02.sql: [0.036, 0.014, 0.015]
Timings for q03.sql: [0.044, 0.02, 0.019]
Timings for q04.sql: [0.059, 0.031, 0.032]
Timings for q05.sql: [0.197, 0.181, 0.173]
Timings for q06.sql: [0.253, 0.2, 0.198]
Timings for q07.sql: [0.02, 0.013, 0.012]
Timings for q08.sql: [0.017, 0.015, 0.016]
Timings for q09.sql: [0.235, 0.206, 0.209]
Timings for q10.sql: [0.324, 0.301, 0.3]
Timings for q11.sql: [0.091, 0.064, 0.064]
Timings for q12.sql: [0.089, 0.078, 0.087]
Timings for q13.sql: [0.21, 0.189, 0.182]
Timings for q14.sql: [0.354, 0.316, 0.311]
Timings for q15.sql: [0.228, 0.208, 0.197]
Timings for q16.sql: [0.22, 0.199, 0.206]
Timings for q17.sql: [0.453, 0.387, 0.387]
Timings for q18.sql: [0.427, 0.374, 0.384]
Timings for q19.sql: [0.797, 0.669, 0.635]
Timings for q20.sql: [0.027, 0.018, 0.017]
Timings for q21.sql: [0.845, 0.424, 0.418]
Timings for q22.sql: [0.658, 0.266, 0.276]
Timings for q23.sql: [1.113, 0.45, 0.408]
Timings for q24.sql: [4.886, 2.31, 1.973]
Timings for q25.sql: [0.203, 0.077, 0.078]
Timings for q26.sql: [0.096, 0.085, 0.085]
Timings for q27.sql: [0.105, 0.086, 0.084]
Timings for q28.sql: [0.712, 0.254, 0.258]
Timings for q29.sql: [7.227, 6.906, 6.668]
Timings for q30.sql: [0.541, 0.524, 0.531]
Timings for q31.sql: [0.232, 0.192, 0.189]
Timings for q32.sql: [0.3, 0.215, 0.217]
Timings for q33.sql: [0.911, 0.865, 0.857]
Timings for q34.sql: [0.947, 0.796, 0.779]
Timings for q35.sql: [0.97, 0.804, 0.84]
Timings for q36.sql: [0.246, 0.243, 0.266]
Timings for q37.sql: [0.018, 0.015, 0.015]
Timings for q38.sql: [0.014, 0.007, 0.006]
Timings for q39.sql: [0.013, 0.008, 0.008]
Timings for q40.sql: [0.039, 0.03, 0.029]
Timings for q41.sql: [0.014, 0.003, 0.002]
Timings for q42.sql: [0.012, 0.002, 0.003]
Timings for q43.sql: [0.013, 0.003, 0.003]
```

In addition a query is printed:

```sql
SELECT UNNEST(['q01.sql','q02.sql','q03.sql','q04.sql','q05.sql','q06.sql','q07.sql','q08.sql','q09.sql','q10.sql','q11.sql','q12.sql','q13.sql','q14.sql','q15.sql','q16.sql','q17.sql','q18.sql','q19.sql','q20.sql','q21.sql','q22.sql','q23.sql','q24.sql','q25.sql','q26.sql','q27.sql','q28.sql','q29.sql','q30.sql','q31.sql','q32.sql','q33.sql','q34.sql','q35.sql','q36.sql','q37.sql','q38.sql','q39.sql','q40.sql','q41.sql','q42.sql','q43.sql']) as query,UNNEST([0.008,0.014,0.02,0.031,0.181,0.2,0.013,0.015,0.206,0.301,0.064,0.078,0.189,0.316,0.208,0.199,0.387,0.374,0.669,0.018,0.424,0.266,0.45,2.31,0.077,0.085,0.086,0.254,6.906,0.524,0.192,0.215,0.865,0.796,0.804,0.243,0.015,0.007,0.008,0.03,0.003,0.002,0.003]) as timing;
```

This can be used to easily visualize the result, and compare it (e.g. by joining it to a different CLI):

```
┌─────────┬──────────────┐
│  query  │    timing    │
│ varchar │ decimal(4,3) │
├─────────┼──────────────┤
│ q01.sql │        0.008 │
│ q02.sql │        0.014 │
│ q03.sql │        0.020 │
│ q04.sql │        0.031 │
│ q05.sql │        0.181 │
│ q06.sql │        0.200 │
│ q07.sql │        0.013 │
│ q08.sql │        0.015 │
│ q09.sql │        0.206 │
│ q10.sql │        0.301 │
│ q11.sql │        0.064 │
│ q12.sql │        0.078 │
│ q13.sql │        0.189 │
│ q14.sql │        0.316 │
│ q15.sql │        0.208 │
│ q16.sql │        0.199 │
│ q17.sql │        0.387 │
│ q18.sql │        0.374 │
│ q19.sql │        0.669 │
│ q20.sql │        0.018 │
│ q21.sql │        0.424 │
│ q22.sql │        0.266 │
│ q23.sql │        0.450 │
│ q24.sql │        2.310 │
│ q25.sql │        0.077 │
│ q26.sql │        0.085 │
│ q27.sql │        0.086 │
│ q28.sql │        0.254 │
│ q29.sql │        6.906 │
│ q30.sql │        0.524 │
│ q31.sql │        0.192 │
│ q32.sql │        0.215 │
│ q33.sql │        0.865 │
│ q34.sql │        0.796 │
│ q35.sql │        0.804 │
│ q36.sql │        0.243 │
│ q37.sql │        0.015 │
│ q38.sql │        0.007 │
│ q39.sql │        0.008 │
│ q40.sql │        0.030 │
│ q41.sql │        0.003 │
│ q42.sql │        0.002 │
│ q43.sql │        0.003 │
├─────────┴──────────────┤
│ 43 rows      2 columns │
└────────────────────────┘

```