### PR TITLE
Fix for VERIFY_VECTOR=Dictionary in Window Bounds

### DIFF
--- a/src/function/window/window_executor.cpp
+++ b/src/function/window/window_executor.cpp
@@ -24,7 +24,6 @@ void WindowExecutorBoundsState::UpdateBounds(WindowExecutorGlobalState &gstate, 
 	WindowInputExpression boundary_end(eval_chunk, gstate.executor.boundary_end_idx);
 
 	const auto count = eval_chunk.size();
-	bounds.Reset();
 	state.Bounds(bounds, row_idx, range, count, boundary_start, boundary_end, partition_mask, order_mask);
 }
 

--- a/src/function/window/window_shared_expressions.cpp
+++ b/src/function/window/window_shared_expressions.cpp
@@ -23,8 +23,8 @@ column_t WindowSharedExpressions::RegisterExpr(const unique_ptr<Expression> &exp
 	return result;
 }
 
-vector<const Expression *> WindowSharedExpressions::GetSortedExpressions(Shared &shared) {
-	vector<const Expression *> sorted(shared.size, nullptr);
+vector<optional_ptr<const Expression>> WindowSharedExpressions::GetSortedExpressions(Shared &shared) {
+	vector<optional_ptr<const Expression>> sorted(shared.size);
 	for (auto &col : shared.columns) {
 		auto &expr = col.first.get();
 		for (auto col_idx : col.second) {

--- a/src/include/duckdb/function/window/window_boundaries_state.hpp
+++ b/src/include/duckdb/function/window/window_boundaries_state.hpp
@@ -47,6 +47,9 @@ struct WindowInputExpression {
 			auto &col = chunk.data[col_idx];
 			ptype = col.GetType().InternalType();
 			scalar = (col.GetVectorType() == VectorType::CONSTANT_VECTOR);
+			if (!scalar && col.GetVectorType() != VectorType::FLAT_VECTOR) {
+				col.Flatten(chunk.size());
+			}
 		}
 	}
 

--- a/src/include/duckdb/function/window/window_shared_expressions.hpp
+++ b/src/include/duckdb/function/window/window_shared_expressions.hpp
@@ -43,7 +43,7 @@ struct WindowSharedExpressions {
 	}
 
 	//! Expression layout
-	static vector<const Expression *> GetSortedExpressions(Shared &shared);
+	static vector<optional_ptr<const Expression>> GetSortedExpressions(Shared &shared);
 
 	//! Expression execution utility
 	static void PrepareExecutors(Shared &shared, ExpressionExecutor &exec, DataChunk &chunk);


### PR DESCRIPTION
`WindowInputExpression` requires the vector to be either flat or constant - so flatten if it is not one of those two