### PR TITLE
Various nightly CI fixes

### DIFF
--- a/src/common/fsst.cpp
+++ b/src/common/fsst.cpp
@@ -20,8 +20,8 @@ string_t FSSTPrimitives::DecompressValue(void *duckdb_fsst_decoder, Vector &resu
 	                                     decompressed_string_size);
 }
 
-Value FSSTPrimitives::DecompressValue(void *duckdb_fsst_decoder, const char *compressed_string,
-                                      const idx_t compressed_string_len, vector<unsigned char> &decompress_buffer) {
+string FSSTPrimitives::DecompressValue(void *duckdb_fsst_decoder, const char *compressed_string,
+                                       const idx_t compressed_string_len, vector<unsigned char> &decompress_buffer) {
 
 	auto compressed_string_ptr = (unsigned char *)compressed_string; // NOLINT
 	auto fsst_decoder = reinterpret_cast<duckdb_fsst_decoder_t *>(duckdb_fsst_decoder);
@@ -30,7 +30,7 @@ Value FSSTPrimitives::DecompressValue(void *duckdb_fsst_decoder, const char *com
 
 	D_ASSERT(!decompress_buffer.empty());
 	D_ASSERT(decompressed_string_size <= decompress_buffer.size() - 1);
-	return Value(string(char_ptr_cast(decompress_buffer.data()), decompressed_string_size));
+	return string(char_ptr_cast(decompress_buffer.data()), decompressed_string_size);
 }
 
 } // namespace duckdb

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -607,7 +607,7 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		case LogicalTypeId::VARCHAR:
 			return Value(std::move(string_val));
 		case LogicalTypeId::BLOB:
-			return Value::BLOB_RAW(std::move(string_val));
+			return Value::BLOB_RAW(string_val);
 		default:
 			throw InternalException("Unsupported vector type for FSST vector");
 		}

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -601,9 +601,16 @@ Value Vector::GetValueInternal(const Vector &v_p, idx_t index_p) {
 		auto str_compressed = reinterpret_cast<string_t *>(data)[index];
 		auto decoder = FSSTVector::GetDecoder(*vector);
 		auto &decompress_buffer = FSSTVector::GetDecompressBuffer(*vector);
-		Value result = FSSTPrimitives::DecompressValue(decoder, str_compressed.GetData(), str_compressed.GetSize(),
-		                                               decompress_buffer);
-		return result;
+		auto string_val = FSSTPrimitives::DecompressValue(decoder, str_compressed.GetData(), str_compressed.GetSize(),
+		                                                  decompress_buffer);
+		switch (vector->GetType().id()) {
+		case LogicalTypeId::VARCHAR:
+			return Value(std::move(string_val));
+		case LogicalTypeId::BLOB:
+			return Value::BLOB_RAW(std::move(string_val));
+		default:
+			throw InternalException("Unsupported vector type for FSST vector");
+		}
 	}
 
 	switch (vector->GetType().id()) {

--- a/src/execution/operator/helper/physical_verify_vector.cpp
+++ b/src/execution/operator/helper/physical_verify_vector.cpp
@@ -75,7 +75,7 @@ OperatorResultType VerifyEmitSequenceVector(const DataChunk &input, DataChunk &c
 		}
 		}
 		bool can_be_constant = true;
-		switch(chunk.data[c].GetType().id()) {
+		switch (chunk.data[c].GetType().id()) {
 		case LogicalTypeId::INTERVAL:
 			can_be_constant = false;
 			break;

--- a/src/execution/operator/helper/physical_verify_vector.cpp
+++ b/src/execution/operator/helper/physical_verify_vector.cpp
@@ -74,6 +74,14 @@ OperatorResultType VerifyEmitSequenceVector(const DataChunk &input, DataChunk &c
 			break;
 		}
 		}
+		bool can_be_constant = true;
+		switch(chunk.data[c].GetType().id()) {
+		case LogicalTypeId::INTERVAL:
+			can_be_constant = false;
+			break;
+		default:
+			break;
+		}
 		ConstantOrSequenceInfo info;
 		info.is_constant = true;
 		for (idx_t k = state.const_idx; k < input.size(); k++) {
@@ -81,7 +89,7 @@ OperatorResultType VerifyEmitSequenceVector(const DataChunk &input, DataChunk &c
 			if (info.values.empty()) {
 				info.values.push_back(std::move(val));
 			} else if (info.is_constant) {
-				if (!ValueOperations::DistinctFrom(val, info.values[0])) {
+				if (!ValueOperations::DistinctFrom(val, info.values[0]) && can_be_constant) {
 					// found the same value! continue
 					info.values.push_back(std::move(val));
 					continue;

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -436,6 +436,7 @@ void TopNHeap::Reduce() {
 	new_heap_data.Slice(heap_data, new_payload_sel, heap.size());
 	new_heap_data.Flatten();
 
+	sort_key_heap.Destroy();
 	sort_key_heap.Move(new_sort_heap);
 	heap_data.Reference(new_heap_data);
 }

--- a/src/include/duckdb/common/fsst.hpp
+++ b/src/include/duckdb/common/fsst.hpp
@@ -20,7 +20,7 @@ class FSSTPrimitives {
 public:
 	static string_t DecompressValue(void *duckdb_fsst_decoder, Vector &result, const char *compressed_string,
 	                                const idx_t compressed_string_len, vector<unsigned char> &decompress_buffer);
-	static Value DecompressValue(void *duckdb_fsst_decoder, const char *compressed_string,
-	                             const idx_t compressed_string_len, vector<unsigned char> &decompress_buffer);
+	static string DecompressValue(void *duckdb_fsst_decoder, const char *compressed_string,
+	                              const idx_t compressed_string_len, vector<unsigned char> &decompress_buffer);
 };
 } // namespace duckdb

--- a/test/sql/copy/partitioned/partitioned_group_by.test
+++ b/test/sql/copy/partitioned/partitioned_group_by.test
@@ -2,6 +2,8 @@
 # description: Test partitioned aggregates
 # group: [partitioned]
 
+require no_vector_verification # query plans are not robust against VERIFY_VECTOR operator
+
 require parquet
 
 statement ok

--- a/third_party/zstd/include/zstd/compress/zstd_cwksp.h
+++ b/third_party/zstd/include/zstd/compress/zstd_cwksp.h
@@ -186,19 +186,6 @@ MEM_STATIC void ZSTD_cwksp_assert_internal_consistency(ZSTD_cwksp* ws) {
     assert(ws->allocStart <= ws->workspaceEnd);
     assert(ws->initOnceStart <= ZSTD_cwksp_initialAllocStart(ws));
     assert(ws->workspace <= ws->initOnceStart);
-#if ZSTD_MEMORY_SANITIZER
-    {
-        intptr_t const offset = __msan_test_shadow(ws->initOnceStart,
-            (U8*)ZSTD_cwksp_initialAllocStart(ws) - (U8*)ws->initOnceStart);
-        (void)offset;
-#if defined(ZSTD_MSAN_PRINT)
-        if(offset!=-1) {
-            __msan_print_shadow((U8*)ws->initOnceStart + offset - 8, 32);
-        }
-#endif
-        assert(offset==-1);
-    };
-#endif
 }
 
 /**


### PR DESCRIPTION
* Skip test that is not robust against the plan changes in verify vector
* ValueOperations::DistinctFrom for intervals can return true for inter… 
* FSST Vector: correctly handle BLOB data types
* Remove zstd asan primitives
* Top-N Reduce - explicitly destroy string heap in Reduce prior to over… 