### PR TITLE
Implement #14513: implement support for (a, b) IN (SELECT ...) for uncorrelated subqueries

### DIFF
--- a/src/include/duckdb/planner/expression/bound_subquery_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_subquery_expression.hpp
@@ -32,12 +32,12 @@ public:
 	unique_ptr<BoundQueryNode> subquery;
 	//! The subquery type
 	SubqueryType subquery_type;
-	//! the child expression to compare with (in case of IN, ANY, ALL operators)
-	unique_ptr<Expression> child;
+	//! the child expressions to compare with (in case of IN, ANY, ALL operators)
+	vector<unique_ptr<Expression>> children;
 	//! The comparison type of the child expression with the subquery (in case of ANY, ALL operators)
 	ExpressionType comparison_type;
-	//! The LogicalType of the subquery result. Only used for ANY expressions.
-	LogicalType child_type;
+	//! The LogicalTypes of the subquery result. Only used for ANY expressions.
+	vector<LogicalType> child_types;
 	//! The target LogicalType of the subquery result (i.e. to which type it should be casted, if child_type <>
 	//! child_target). Only used for ANY expressions.
 	LogicalType child_target;

--- a/src/planner/expression_iterator.cpp
+++ b/src/planner/expression_iterator.cpp
@@ -88,8 +88,8 @@ void ExpressionIterator::EnumerateChildren(Expression &expr,
 	}
 	case ExpressionClass::BOUND_SUBQUERY: {
 		auto &subquery_expr = expr.Cast<BoundSubqueryExpression>();
-		if (subquery_expr.child) {
-			callback(subquery_expr.child);
+		for (auto &child : subquery_expr.children) {
+			callback(child);
 		}
 		break;
 	}

--- a/src/planner/joinside.cpp
+++ b/src/planner/joinside.cpp
@@ -69,8 +69,9 @@ JoinSide JoinSide::GetJoinSide(Expression &expression, const unordered_set<idx_t
 		D_ASSERT(expression.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY);
 		auto &subquery = expression.Cast<BoundSubqueryExpression>();
 		JoinSide side = JoinSide::NONE;
-		if (subquery.child) {
-			side = GetJoinSide(*subquery.child, left_bindings, right_bindings);
+		for (auto &child : subquery.children) {
+			auto child_side = GetJoinSide(*child, left_bindings, right_bindings);
+			side = CombineJoinSide(side, child_side);
 		}
 		// correlated subquery, check the side of each of correlated columns in the subquery
 		for (auto &corr : subquery.binder->correlated_columns) {

--- a/test/fuzzer/pedro/complex_type_all_subquery.test
+++ b/test/fuzzer/pedro/complex_type_all_subquery.test
@@ -9,7 +9,7 @@ PRAGMA enable_verification
 statement error
 VALUES((0, 0) = ALL(SELECT 2));
 ----
-explicit cast is required
+Subquery returns 1 columns - expected 2
 
 # use ALL with complex types
 statement error

--- a/test/sql/subquery/scalar/subquery_row_in_any.test
+++ b/test/sql/subquery/scalar/subquery_row_in_any.test
@@ -1,0 +1,59 @@
+# name: test/sql/subquery/scalar/subquery_row_in_any.test
+# description: Test (a, b) IN (SELECT a, b ...)
+# group: [scalar]
+
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers VALUES (1), (2), (3), (NULL);
+
+query I
+SELECT (1, 2) IN (SELECT i, i + 1 FROM integers)
+----
+true
+
+# also works with explicit row function
+query I
+SELECT ROW(1, 2) IN (SELECT i, i + 1 FROM integers)
+----
+true
+
+# NULL semantics
+query I
+SELECT ROW(1, 2) IN (SELECT i, i + 2 FROM integers)
+----
+NULL
+
+query I
+SELECT ROW(1, 2) IN (SELECT i, i + 2 FROM integers WHERE i IS NOT NULL)
+----
+false
+
+query I
+select 1 where (1,2) in (select 1,2);
+----
+1
+
+query I
+select 1 where (1,2) not in (select 1,2);
+----
+
+
+statement error
+SELECT ROW(1, 2) IN (SELECT i1.i, i1.i + 1)
+FROM integers i1
+----
+not yet supported
+
+mode skip
+
+# correlated
+query I
+SELECT ROW(1, 2) IN (SELECT i1.i, i1.i + 1)
+FROM integers i1
+----
+true
+false
+false
+NULL

--- a/test/sql/subquery/scalar/subquery_row_in_any.test
+++ b/test/sql/subquery/scalar/subquery_row_in_any.test
@@ -13,6 +13,17 @@ SELECT (1, 2) IN (SELECT i, i + 1 FROM integers)
 ----
 true
 
+# it still works with the row inside the subquery
+query I
+SELECT (1, 2) IN (SELECT (i, i + 1) FROM integers)
+----
+true
+
+query I
+SELECT row(1) IN (SELECT i FROM integers)
+----
+true
+
 # also works with explicit row function
 query I
 SELECT ROW(1, 2) IN (SELECT i, i + 1 FROM integers)
@@ -39,7 +50,12 @@ query I
 select 1 where (1,2) not in (select 1,2);
 ----
 
+statement error
+SELECT (1, 2) IN (SELECT (i, i + 1, i + 2) FROM integers)
+----
+Cannot compare values of type
 
+# FIXME: correlated not yet supported
 statement error
 SELECT ROW(1, 2) IN (SELECT i1.i, i1.i + 1)
 FROM integers i1


### PR DESCRIPTION
Implement #14513 

The following syntax is now supported **for uncorrelated subqueries**, following what also works in Postgres:

```sql
SELECT (1, 2) IN (SELECT a, b FROM tbl);
```

The planning also works correctly for correlated subqueries - but the mark join with multiple join conditions is not correctly executed in the hash join currently (see the FIXME in the code). Should be addressed in the future but I felt this change was worthwhile by itself.


