### PR TITLE
Fix #15239: detect subqueries in lateral join conditions and throw an explicit error when encountered

### DIFF
--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -457,6 +457,9 @@ unique_ptr<LogicalOperator> Binder::PlanLateralJoin(unique_ptr<LogicalOperator> 
 	vector<JoinCondition> conditions;
 	vector<unique_ptr<Expression>> arbitrary_expressions;
 	if (condition) {
+		if (condition->HasSubquery()) {
+			throw BinderException(*condition, "Subqueries are not supported in LATERAL join conditions");
+		}
 		// extract join conditions, if there are any
 		LogicalComparisonJoin::ExtractJoinConditions(context, join_type, JoinRefType::REGULAR, left, right,
 		                                             std::move(condition), conditions, arbitrary_expressions);

--- a/test/fuzzer/public/lateral_join_subquery.test
+++ b/test/fuzzer/public/lateral_join_subquery.test
@@ -1,0 +1,14 @@
+# name: test/fuzzer/public/lateral_join_subquery.test
+# description: Subqueries in the join condition of lateral joins
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE t1 (c1 INT);
+
+statement error
+FROM t1 INNER JOIN (SELECT t1.c1) ON (SELECT 42);
+----
+Subqueries are not supported in LATERAL join conditions


### PR DESCRIPTION
Fixes #15239