### PR TITLE
Fixup extension selection

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -24,7 +24,7 @@ duckdb_extension_load(httpfs
     )
 
 ################# ARROW
-if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
+if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(arrow
             LOAD_TESTS DONT_LINK
             GIT_URL https://github.com/duckdb/arrow
@@ -34,7 +34,7 @@ if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
 endif()
 
 ################## AWS
-if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
+if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_aws
@@ -48,7 +48,7 @@ endif()
 ### build on a side
 if (NO)
 ################# AZURE
-if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
+if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(azure
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_azure
@@ -61,7 +61,7 @@ endif()
 ################# DELTA
 # MinGW build is not available, and our current manylinux ci does not have enough storage space to run the rust build
 # for Delta
-if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT $ENV{WASM_EXTENSIONS})
+if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb_delta
@@ -86,7 +86,7 @@ duckdb_extension_load(excel
 #    set(LOAD_ICEBERG_TESTS "")
 #endif()
 #
-#if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
+#if (NOT MINGW AND NOT ${WASM_ENABLED})
 #    duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS}
 #            GIT_URL https://github.com/duckdb/duckdb_iceberg
@@ -108,7 +108,7 @@ duckdb_extension_load(inet
 ################# POSTGRES_SCANNER
 # Note: tests for postgres_scanner are currently not run. All of them need a postgres server running. One test
 #       uses a remote rds server but that's not something we want to run here.
-if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
+if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(postgres_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/postgres_scanner
@@ -144,7 +144,7 @@ duckdb_extension_load(sqlite_scanner
         APPLY_PATCHES
         )
 
-if (NOT $ENV{WASM_EXTENSIONS})
+if (NOT ${WASM_ENABLED})
 duckdb_extension_load(sqlsmith
         DONT_LINK LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb_sqlsmith
@@ -163,7 +163,7 @@ duckdb_extension_load(vss
     )
 
 ################# MYSQL
-if (NOT MINGW AND NOT $ENV{WASM_EXTENSIONS})
+if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(mysql_scanner
             DONT_LINK
             LOAD_TESTS

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -256,6 +256,12 @@ jobs:
         run: |
           python3 scripts/run_tests_one_by_one.py ./build/release/test/unittest
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: duckdb-extensions-${{ matrix.duckdb_arch }}
+          path: |
+            build/release/extension/*/*.duckdb_extension
+
       - name: Rebuild DuckDB without any extensions linked, but with same extension config
         if: ${{ matrix.osx_arch == 'arm64' }}
         shell: bash
@@ -277,12 +283,6 @@ jobs:
           python3 scripts/get_test_list.py --file-contains 'require ' --list '"*.test"' > test.list
           python3 scripts/get_test_list.py --file-contains 'require-env LOCAL_EXTENSION_REPO' --list '"*.test"' >> test.list
           python3 scripts/run_tests_one_by_one.py ./build/release/test/unittest '-f test.list'
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: duckdb-extensions-${{ matrix.duckdb_arch }}
-          path: |
-            build/release/extension/*/*.duckdb_extension
 
   upload-osx-extensions:
     name: Upload OSX Extensions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,11 @@ if(${FORCE_COLORED_OUTPUT})
   endif()
 endif()
 
+option (WASM_ENABLED "Are DuckDB-Wasm extensions build enabled" FALSE)
+if (DEFINED ENV{WASM_EXTENSIONS})
+     set(WASM_ENABLED "$ENV{WASM_EXTENSIONS}")
+endif()
+
 set(M32_FLAG "")
 if(FORCE_32_BIT)
   set(M32_FLAG " -m32 ")

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -13,6 +13,6 @@ duckdb_extension_load(parquet)
 
 # The Linux allocator has issues so we use jemalloc, but only on x86 because page sizes are fixed at 4KB.
 # Configuring jemalloc properly for 32bit is a hassle, and not worth it so we only enable on 64bit
-if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS AND NOT $ENV{WASM_EXTENSIONS})
+if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT FORCE_32_BIT AND OS_NAME STREQUAL "linux" AND NOT WASM_LOADABLE_EXTENSIONS AND NOT CLANG_TIDY AND NOT ANDROID AND NOT ZOS AND NOT ${WASM_ENABLED})
     duckdb_extension_load(jemalloc)
 endif()

--- a/scripts/extension-upload-all.sh
+++ b/scripts/extension-upload-all.sh
@@ -31,10 +31,19 @@ else
     echo "Deploying extensions.. (DRY RUN)"
 fi
 
-FILES="$BASE_DIR/*.duckdb_extension"
+if [[ $1 == wasm* ]]; then
+  FILES="$BASE_DIR/*.duckdb_extension.wasm"
+else
+  FILES="$BASE_DIR/*.duckdb_extension"
+fi
+
 for f in $FILES
 do
-    ext_name=`basename $f .duckdb_extension`
+    if [[ $1 == wasm* ]]; then
+      ext_name=`basename $f .duckdb_extension.wasm`
+    else
+      ext_name=`basename $f .duckdb_extension`
+    fi
     echo "found extension: '$ext_name'"
 
     # args: <name> <extension_version> <duckdb_version> <architecture> <s3_bucket> <copy_to_latest> <copy_to_versioned> [<path_to_ext>]


### PR DESCRIPTION
Fix various problems connected to rework of extension uploading:
* non properly tested CMake syntax made postgres (and mysql, delta, and a few other extensions) being skipped
* osx_arm64 folder would detele itself since extensions were uploaded too late
* wam extension were skipped since only pattern *.duckdb_extension was considered for upload

Fixes https://github.com/duckdb/duckdb/issues/15265.