### PR TITLE
Fix for JSONSerializer of BLOB

### DIFF
--- a/extension/json/json_serializer.cpp
+++ b/extension/json/json_serializer.cpp
@@ -211,7 +211,7 @@ void JsonSerializer::WriteValue(bool value) {
 }
 
 void JsonSerializer::WriteDataPtr(const_data_ptr_t ptr, idx_t count) {
-	auto blob = Blob::ToBlob(string_t(const_char_ptr_cast(ptr), count));
+	auto blob = Blob::ToString(string_t(const_char_ptr_cast(ptr), count));
 	auto val = yyjson_mut_strcpy(doc, blob.c_str());
 	PushValue(val);
 }

--- a/test/sql/json/test_json_serialize_plan.test
+++ b/test/sql/json/test_json_serialize_plan.test
@@ -38,3 +38,6 @@ query I
 SELECT json_serialize_plan('SELECT * FROM nonexistent_table') LIKE '%Table with name nonexistent_table does not exist%';
 ----
 true
+
+statement ok
+select json_serialize_plan('select blob ''\\x00''');

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -509,6 +509,8 @@ public:
 class ModeAsciiRenderer : public RowRenderer {
 public:
 	explicit ModeAsciiRenderer(ShellState &state) : RowRenderer(state) {
+		col_sep = "\n";
+		row_sep = "\n";
 	}
 
 	void RenderHeader(RowResult &result) override {


### PR DESCRIPTION
This should call `Blob::ToString`, instead of re-interpreting the string as a blob again.

This PR also modifies `.mode ascii` to use newlines as separators (instead of leaving them empty) - making the output more readable.