### PR TITLE
Use `likely` for assertion

### DIFF
--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/likely.hpp"
 
 namespace duckdb {
 
@@ -7,7 +8,7 @@ void DuckDBAssertInternal(bool condition, const char *condition_name, const char
 #ifdef DISABLE_ASSERTIONS
 	return;
 #endif
-	if (condition) {
+	if (DUCKDB_LIKELY(condition)) {
 		return;
 	}
 	throw InternalException("Assertion triggered in file \"%s\" on line %d: %s%s", file, linenr, condition_name,


### PR DESCRIPTION
Should be an easy no-op change. I randomly come across the assertion implementation for duckdb, and think it should be a valid and proper use case on `Likely` for better branch prediction.