### PR TITLE
Issue #15246: Negative Nanosecond Timestamps

### DIFF
--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -17,6 +17,15 @@ namespace duckdb {
 
 static_assert(sizeof(timestamp_t) == sizeof(int64_t), "timestamp_t was padded");
 
+// Temporal values need to round down when changing precision,
+// but C/C++ rounds towrds 0 when you simply divide.
+// This piece of bit banging solves that problem.
+template <typename T>
+static inline T TemporalRound(T value, T scale) {
+	const auto negative = int(value < 0);
+	return UnsafeNumericCast<T>((value + negative) / scale - negative);
+}
+
 // timestamp/datetime uses 64 bits, high 32 bits for date and low 32 bits for time
 // string format is YYYY-MM-DDThh:mm:ssZ
 // T may be a space
@@ -342,7 +351,7 @@ void Timestamp::Convert(timestamp_t timestamp, date_t &out_date, dtime_t &out_ti
 }
 
 void Timestamp::Convert(timestamp_ns_t input, date_t &out_date, dtime_t &out_time, int32_t &out_nanos) {
-	timestamp_t ms(input.value / Interval::NANOS_PER_MICRO);
+	timestamp_t ms(TemporalRound(input.value, Interval::NANOS_PER_MICRO));
 	out_date = Timestamp::GetDate(ms);
 	int64_t days_nanos;
 	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(out_date.days, Interval::NANOS_PER_DAY,

--- a/test/sql/types/timestamp/test_timestamp_types.test
+++ b/test/sql/types/timestamp/test_timestamp_types.test
@@ -74,6 +74,12 @@ AS tbl(s)
 2024-06-04 10:17:10.9
 2024-06-04 10:17:10
 
+# Negative timestamp_ns
+query I
+select '1969-01-01T23:59:59.9999999'::timestamp_ns;
+----
+1969-01-01 23:59:59.9999999
+
 # TIME conversions are now supported
 query I
 select sec::TIME from timestamp;


### PR DESCRIPTION
Round down instead of towards zero when decomposing timestamp_ns_t values.

fixes: duckdb/duckdb#15246
fixes: duckdblabs/duckdb-internal#3720