### PR TITLE
remove O_SYNC from O_DIRECT

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -319,9 +319,8 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 #endif
 #if defined(__DARWIN__) || defined(__APPLE__) || defined(__OpenBSD__)
 		// OSX does not have O_DIRECT, instead we need to use fcntl afterwards to support direct IO
-		open_flags |= O_SYNC;
 #else
-		open_flags |= O_DIRECT | O_SYNC;
+		open_flags |= O_DIRECT;
 #endif
 	}
 
@@ -350,15 +349,17 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 		}
 		throw IOException("Cannot open file \"%s\": %s", {{"errno", std::to_string(errno)}}, path, strerror(errno));
 	}
-	// #if defined(__DARWIN__) || defined(__APPLE__)
-	// 	if (flags & FileFlags::FILE_FLAGS_DIRECT_IO) {
-	// 		// OSX requires fcntl for Direct IO
-	// 		rc = fcntl(fd, F_NOCACHE, 1);
-	// 		if (fd == -1) {
-	// 			throw IOException("Could not enable direct IO for file \"%s\": %s", path, strerror(errno));
-	// 		}
-	// 	}
-	// #endif
+
+#if defined(__DARWIN__) || defined(__APPLE__)
+	if (flags & FileFlags::FILE_FLAGS_DIRECT_IO) {
+		// OSX requires fcntl for Direct IO
+		rc = fcntl(fd, F_NOCACHE, 1);
+		if (rc == -1) {
+			throw IOException("Could not enable direct IO for file \"%s\": %s", path, strerror(errno));
+		}
+	}
+#endif
+
 	if (flags.Lock() != FileLockType::NO_LOCK) {
 		// set lock on file
 		// but only if it is not an input/output stream

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -351,7 +351,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	}
 
 #if defined(__DARWIN__) || defined(__APPLE__)
-	if (flags & FileFlags::FILE_FLAGS_DIRECT_IO) {
+	if (flags.DirectIO()) {
 		// OSX requires fcntl for Direct IO
 		rc = fcntl(fd, F_NOCACHE, 1);
 		if (rc == -1) {


### PR DESCRIPTION
The `config.use_direct_io` option has a surprising effect, which is that it also enables `O_SYNC`. This is probably not the expected or intended behavior of use_direct_io. This PR removes O_SYNC. It also re-enables direct_io for osx. I don't have context on why that was disabled so perhaps there was a good reason to disable it.

As I understand things:
- O_DIRECT disables the page-cache. This makes good sense for DuckDB, since DuckDB already has a page cache.
- O_SYNC forces all writes to be durable before they complete. This can significantly reduce performance on slower media (HDD, NFS, etc.). This doesn't appear to add any value for DuckDB since DuckDB uses fsync() for write ordering regardless.