### PR TITLE
Fix #14938: when combining ENUM with SQLNULL/UNKNOWN types, preserve the ENUM type

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -862,7 +862,7 @@ CatalogEntryLookup Catalog::TryLookupEntry(CatalogEntryRetriever &retriever, Cat
 	// lookup
 	if (type == CatalogType::TABLE_ENTRY) {
 		auto lookup_result_default_table =
-		    TryLookupDefaultTable(retriever, type, catalog, schema, name, if_not_found, error_context);
+		    TryLookupDefaultTable(retriever, type, catalog, schema, name, OnEntryNotFound::RETURN_NULL, error_context);
 
 		if (lookup_result_default_table.Found() && lookup_result.Found()) {
 			ThrowDefaultTableAmbiguityException(lookup_result, lookup_result_default_table, name);

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -887,14 +887,8 @@ LogicalType LogicalType::NormalizeType(const LogicalType &type) {
 template <class OP>
 static bool CombineUnequalTypes(const LogicalType &left, const LogicalType &right, LogicalType &result) {
 	// left and right are not equal
-	// for enums, match the varchar rules
-	if (left.id() == LogicalTypeId::ENUM) {
-		return OP::Operation(LogicalType::VARCHAR, right, result);
-	} else if (right.id() == LogicalTypeId::ENUM) {
-		return OP::Operation(left, LogicalType::VARCHAR, result);
-	}
-	// NULL/string literals/unknown (parameter) types always take the other type
-	LogicalTypeId other_types[] = {LogicalTypeId::SQLNULL, LogicalTypeId::UNKNOWN, LogicalTypeId::STRING_LITERAL};
+	// NULL/unknown (parameter) types always take the other type
+	LogicalTypeId other_types[] = {LogicalTypeId::SQLNULL, LogicalTypeId::UNKNOWN};
 	for (auto &other_type : other_types) {
 		if (left.id() == other_type) {
 			result = LogicalType::NormalizeType(right);
@@ -903,6 +897,22 @@ static bool CombineUnequalTypes(const LogicalType &left, const LogicalType &righ
 			result = LogicalType::NormalizeType(left);
 			return true;
 		}
+	}
+
+	// for enums, match the varchar rules
+	if (left.id() == LogicalTypeId::ENUM) {
+		return OP::Operation(LogicalType::VARCHAR, right, result);
+	} else if (right.id() == LogicalTypeId::ENUM) {
+		return OP::Operation(left, LogicalType::VARCHAR, result);
+	}
+
+	// for everything but enums - string literals also take the other type
+	if (left.id() == LogicalTypeId::STRING_LITERAL) {
+		result = LogicalType::NormalizeType(right);
+		return true;
+	} else if (right.id() == LogicalTypeId::STRING_LITERAL) {
+		result = LogicalType::NormalizeType(left);
+		return true;
 	}
 
 	// for other types - use implicit cast rules to check if we can combine the types

--- a/test/sql/types/enum/test_enum_case.test
+++ b/test/sql/types/enum/test_enum_case.test
@@ -1,0 +1,20 @@
+# name: test/sql/types/enum/test_enum_case.test
+# description: Test enum in CASE expressions
+# group: [enum]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TYPE E1 AS ENUM ('v1', 'v2');
+
+statement ok
+CREATE TABLE t1 (v E1);
+
+statement ok
+INSERT INTO t1 VALUES ('v1');
+
+query I
+SELECT typeof(CASE WHEN 1 THEN v END) FROM t1;
+----
+ENUM('v1', 'v2')


### PR DESCRIPTION
Fixes #14938