### PR TITLE
Add `get_partition_stats` callback to TableFunction to get a list of all row group metadata, and use this to speed up `COUNT(*)`

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -89,6 +89,7 @@
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/macro_function.hpp"
+#include "duckdb/function/partition_stats.hpp"
 #include "duckdb/function/scalar/compressed_materialization_utils.hpp"
 #include "duckdb/function/scalar/strftime_format.hpp"
 #include "duckdb/function/table/arrow/enum/arrow_datetime_type.hpp"

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -203,6 +203,13 @@ OperatorPartitionData TableScanGetPartitionData(ClientContext &context, TableFun
 	return OperatorPartitionData(0);
 }
 
+vector<PartitionStatistics> TableScanGetPartitionStats(ClientContext &context, GetPartitionStatsInput &input) {
+	auto &bind_data = input.bind_data->Cast<TableScanBindData>();
+	vector<PartitionStatistics> result;
+	auto &storage = bind_data.table.GetStorage();
+	return storage.GetPartitionStats(context);
+}
+
 BindInfo TableScanGetBindInfo(const optional_ptr<FunctionData> bind_data_p) {
 	auto &bind_data = bind_data_p->Cast<TableScanBindData>();
 	return BindInfo(bind_data.table);
@@ -436,6 +443,7 @@ TableFunction TableScanFunction::GetIndexScanFunction() {
 	scan_function.get_bind_info = TableScanGetBindInfo;
 	scan_function.serialize = TableScanSerialize;
 	scan_function.deserialize = TableScanDeserialize;
+	scan_function.get_partition_stats = nullptr;
 	return scan_function;
 }
 
@@ -450,6 +458,7 @@ TableFunction TableScanFunction::GetFunction() {
 	scan_function.to_string = TableScanToString;
 	scan_function.table_scan_progress = TableScanProgress;
 	scan_function.get_partition_data = TableScanGetPartitionData;
+	scan_function.get_partition_stats = TableScanGetPartitionStats;
 	scan_function.get_bind_info = TableScanGetBindInfo;
 	scan_function.projection_pushdown = true;
 	scan_function.filter_pushdown = true;

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -8,6 +8,9 @@ GlobalTableFunctionState::~GlobalTableFunctionState() {
 LocalTableFunctionState::~LocalTableFunctionState() {
 }
 
+PartitionStatistics::PartitionStatistics() : row_start(0), count(0), count_type(CountType::COUNT_APPROXIMATE) {
+}
+
 TableFunctionInfo::~TableFunctionInfo() {
 }
 
@@ -19,8 +22,8 @@ TableFunction::TableFunction(string name, vector<LogicalType> arguments, table_f
       in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr), cardinality(nullptr),
       pushdown_complex_filter(nullptr), to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
       get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
-      get_partition_info(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
-      filter_pushdown(false), filter_prune(false), sampling_pushdown(false) {
+      get_partition_info(nullptr), get_partition_stats(nullptr), serialize(nullptr), deserialize(nullptr),
+      projection_pushdown(false), filter_pushdown(false), filter_prune(false), sampling_pushdown(false) {
 }
 
 TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function,
@@ -33,8 +36,9 @@ TableFunction::TableFunction()
       init_local(nullptr), function(nullptr), in_out_function(nullptr), statistics(nullptr), dependency(nullptr),
       cardinality(nullptr), pushdown_complex_filter(nullptr), to_string(nullptr), table_scan_progress(nullptr),
       get_partition_data(nullptr), get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr),
-      supports_pushdown_type(nullptr), get_partition_info(nullptr), serialize(nullptr), deserialize(nullptr),
-      projection_pushdown(false), filter_pushdown(false), filter_prune(false), sampling_pushdown(false) {
+      supports_pushdown_type(nullptr), get_partition_info(nullptr), get_partition_stats(nullptr), serialize(nullptr),
+      deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
+      sampling_pushdown(false) {
 }
 
 bool TableFunction::Equal(const TableFunction &rhs) const {

--- a/src/include/duckdb/function/partition_stats.hpp
+++ b/src/include/duckdb/function/partition_stats.hpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/partition_stats.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+//! How a table is partitioned by a given set of columns
+enum class TablePartitionInfo : uint8_t {
+	NOT_PARTITIONED,         // the table is not partitioned by the given set of columns
+	SINGLE_VALUE_PARTITIONS, // each partition has exactly one unique value (e.g. bounds = [1,1][2,2][3,3])
+	OVERLAPPING_PARTITIONS,  // the partitions overlap **only** at the boundaries (e.g. bounds = [1,2][2,3][3,4]
+	DISJOINT_PARTITIONS      // the partitions are disjoint (e.g. bounds = [1,2][3,4][5,6])
+};
+
+enum class CountType { COUNT_EXACT, COUNT_APPROXIMATE };
+
+struct PartitionStatistics {
+	PartitionStatistics();
+
+	//! The row id start
+	idx_t row_start;
+	//! The amount of rows in the partition
+	idx_t count;
+	//! Whether or not the count is exact or approximate
+	CountType count_type;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -99,6 +99,8 @@ private:
 	unique_ptr<BaseStatistics> PropagateExpression(BoundColumnRefExpression &expr, unique_ptr<Expression> &expr_ptr);
 	unique_ptr<BaseStatistics> PropagateExpression(BoundOperatorExpression &expr, unique_ptr<Expression> &expr_ptr);
 
+	//! Try to execute aggregates using only the statistics if possible
+	void TryExecuteAggregates(LogicalAggregate &op, unique_ptr<LogicalOperator> &node_ptr);
 	void ReplaceWithEmptyResult(unique_ptr<LogicalOperator> &node);
 
 	bool ExpressionIsConstant(Expression &expr, const Value &val);

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -237,6 +237,9 @@ public:
 	//! AddIndex moves an index to this table's index list.
 	void AddIndex(unique_ptr<Index> index);
 
+	//! Returns a list of the partition stats
+	vector<PartitionStatistics> GetPartitionStats(ClientContext &context);
+
 private:
 	//! Verify the new added constraints against current persistent&local data
 	void VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint);

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -19,6 +19,7 @@
 #include "duckdb/storage/block.hpp"
 #include "duckdb/common/enums/checkpoint_type.hpp"
 #include "duckdb/storage/storage_index.hpp"
+#include "duckdb/function/partition_stats.hpp"
 
 namespace duckdb {
 class AttachedDatabase;
@@ -163,6 +164,7 @@ public:
 	unique_ptr<BaseStatistics> GetStatistics(idx_t column_idx);
 
 	void GetColumnSegmentInfo(idx_t row_group_index, vector<ColumnSegmentInfo> &result);
+	PartitionStatistics GetPartitionStats() const;
 
 	idx_t GetAllocationSize() const {
 		return allocation_size;

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -111,6 +111,7 @@ public:
 	void CommitDropColumn(idx_t index);
 	void CommitDropTable();
 
+	vector<PartitionStatistics> GetPartitionStats() const;
 	vector<ColumnSegmentInfo> GetColumnSegmentInfo();
 	const vector<LogicalType> &GetTypes() const;
 

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -79,14 +79,14 @@ class LocalTableManager {
 public:
 	shared_ptr<LocalTableStorage> MoveEntry(DataTable &table);
 	reference_map_t<DataTable, shared_ptr<LocalTableStorage>> MoveEntries();
-	optional_ptr<LocalTableStorage> GetStorage(DataTable &table);
+	optional_ptr<LocalTableStorage> GetStorage(DataTable &table) const;
 	LocalTableStorage &GetOrCreateStorage(ClientContext &context, DataTable &table);
-	idx_t EstimatedSize();
-	bool IsEmpty();
+	idx_t EstimatedSize() const;
+	bool IsEmpty() const;
 	void InsertEntry(DataTable &table, shared_ptr<LocalTableStorage> entry);
 
 private:
-	mutex table_storage_lock;
+	mutable mutex table_storage_lock;
 	reference_map_t<DataTable, shared_ptr<LocalTableStorage>> table_storage;
 };
 
@@ -145,6 +145,7 @@ public:
 	bool Find(DataTable &table);
 
 	idx_t AddedRows(DataTable &table);
+	vector<PartitionStatistics> GetPartitionStats(DataTable &table) const;
 
 	void AddColumn(DataTable &old_dt, DataTable &new_dt, ColumnDefinition &new_column,
 	               ExpressionExecutor &default_executor);

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -1,7 +1,73 @@
 #include "duckdb/optimizer/statistics_propagator.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_dummy_scan.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_expression_get.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 
 namespace duckdb {
+
+void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_ptr<LogicalOperator> &node_ptr) {
+	if (!aggr.groups.empty()) {
+		// not possible with groups
+		return;
+	}
+	if (aggr.children[0]->type != LogicalOperatorType::LOGICAL_GET) {
+		// child must be a LOGICAL_GET
+		// FIXME: we could do this with projections as well
+		return;
+	}
+	auto &get = aggr.children[0]->Cast<LogicalGet>();
+	if (!get.function.get_partition_stats) {
+		// GET does not support getting the partition stats
+		return;
+	}
+	if (!get.table_filters.filters.empty()) {
+		// we cannot do this if the GET has filters
+		return;
+	}
+	// check if all aggregates are COUNT(*)
+	for (auto &aggr_ref : aggr.expressions) {
+		if (aggr_ref->expression_class != ExpressionClass::BOUND_AGGREGATE) {
+			// not an aggregate
+			return;
+		}
+		auto &aggr_expr = aggr_ref->Cast<BoundAggregateExpression>();
+		if (aggr_expr.function.name != "count_star") {
+			// aggregate is not count star - bail
+			return;
+		}
+	}
+	// we can do the rewrite! get the stats
+	GetPartitionStatsInput input(get.function, get.bind_data.get());
+	auto partition_stats = get.function.get_partition_stats(context, input);
+	idx_t count = 0;
+	for (auto &stats : partition_stats) {
+		if (stats.count_type == CountType::COUNT_APPROXIMATE) {
+			// we cannot get an exact count
+			return;
+		}
+		count += stats.count;
+	}
+	// we got an exact count - replace the entire aggregate with a scan of the result
+	vector<LogicalType> types;
+	vector<unique_ptr<Expression>> count_results;
+	for (idx_t aggregate_index = 0; aggregate_index < aggr.expressions.size(); ++aggregate_index) {
+		auto count_result = make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(count)));
+		count_result->alias = aggr.expressions[aggregate_index]->GetName();
+		count_results.push_back(std::move(count_result));
+
+		types.push_back(LogicalType::BIGINT);
+	}
+
+	vector<vector<unique_ptr<Expression>>> expressions;
+	expressions.push_back(std::move(count_results));
+	auto expression_get =
+	    make_uniq<LogicalExpressionGet>(aggr.aggregate_index, std::move(types), std::move(expressions));
+	expression_get->children.push_back(make_uniq<LogicalDummyScan>(aggr.group_index));
+	node_ptr = std::move(expression_get);
+}
 
 unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggregate &aggr,
                                                                      unique_ptr<LogicalOperator> &node_ptr) {
@@ -34,6 +100,10 @@ unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggr
 		ColumnBinding aggregate_binding(aggr.aggregate_index, aggregate_idx);
 		statistics_map[aggregate_binding] = std::move(stats);
 	}
+
+	// after we propagate statistics - try to directly execute aggregates using statistics
+	TryExecuteAggregates(aggr, node_ptr);
+
 	// the max cardinality of an aggregate is the max cardinality of the input (i.e. when every row is a unique group)
 	return std::move(node_stats);
 }

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -38,6 +38,10 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 			// aggregate is not count star - bail
 			return;
 		}
+		if (aggr_expr.filter) {
+			// aggregate has a filter - bail
+			return;
+		}
 	}
 	// we can do the rewrite! get the stats
 	GetPartitionStatsInput input(get.function, get.bind_data.get());

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -248,6 +248,14 @@ idx_t DataTable::GetRowGroupSize() const {
 	return row_groups->GetRowGroupSize();
 }
 
+vector<PartitionStatistics> DataTable::GetPartitionStats(ClientContext &context) {
+	auto result = row_groups->GetPartitionStats();
+	auto &local_storage = LocalStorage::Get(context, db);
+	auto local_partitions = local_storage.GetPartitionStats(*this);
+	result.insert(result.end(), local_partitions.begin(), local_partitions.end());
+	return result;
+}
+
 idx_t DataTable::MaxThreads(ClientContext &context) const {
 	idx_t row_group_size = GetRowGroupSize();
 	idx_t parallel_scan_vector_count = row_group_size / STANDARD_VECTOR_SIZE;

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -240,7 +240,7 @@ void LocalTableStorage::Rollback() {
 //===--------------------------------------------------------------------===//
 // LocalTableManager
 //===--------------------------------------------------------------------===//
-optional_ptr<LocalTableStorage> LocalTableManager::GetStorage(DataTable &table) {
+optional_ptr<LocalTableStorage> LocalTableManager::GetStorage(DataTable &table) const {
 	lock_guard<mutex> l(table_storage_lock);
 	auto entry = table_storage.find(table);
 	return entry == table_storage.end() ? nullptr : entry->second.get();
@@ -259,7 +259,7 @@ LocalTableStorage &LocalTableManager::GetOrCreateStorage(ClientContext &context,
 	}
 }
 
-bool LocalTableManager::IsEmpty() {
+bool LocalTableManager::IsEmpty() const {
 	lock_guard<mutex> l(table_storage_lock);
 	return table_storage.empty();
 }
@@ -280,7 +280,7 @@ reference_map_t<DataTable, shared_ptr<LocalTableStorage>> LocalTableManager::Mov
 	return std::move(table_storage);
 }
 
-idx_t LocalTableManager::EstimatedSize() {
+idx_t LocalTableManager::EstimatedSize() const {
 	lock_guard<mutex> l(table_storage_lock);
 	idx_t estimated_size = 0;
 	for (auto &storage : table_storage) {
@@ -519,6 +519,14 @@ idx_t LocalStorage::AddedRows(DataTable &table) {
 		return 0;
 	}
 	return storage->row_groups->GetTotalRows() - storage->deleted_rows;
+}
+
+vector<PartitionStatistics> LocalStorage::GetPartitionStats(DataTable &table) const {
+	auto storage = table_manager.GetStorage(table);
+	if (!storage) {
+		return vector<PartitionStatistics>();
+	}
+	return storage->row_groups->GetPartitionStats();
 }
 
 void LocalStorage::DropTable(DataTable &table) {

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1114,6 +1114,22 @@ RowGroupPointer RowGroup::Deserialize(Deserializer &deserializer) {
 }
 
 //===--------------------------------------------------------------------===//
+// GetPartitionStats
+//===--------------------------------------------------------------------===//
+PartitionStatistics RowGroup::GetPartitionStats() const {
+	PartitionStatistics result;
+	result.row_start = start;
+	result.count = count;
+	if (HasUnloadedDeletes() || version_info.load().get()) {
+		// we have version info - approx count
+		result.count_type = CountType::COUNT_APPROXIMATE;
+	} else {
+		result.count_type = CountType::COUNT_EXACT;
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
 // GetColumnSegmentInfo
 //===--------------------------------------------------------------------===//
 void RowGroup::GetColumnSegmentInfo(idx_t row_group_index, vector<ColumnSegmentInfo> &result) {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1054,6 +1054,17 @@ void RowGroupCollection::CommitDropTable() {
 }
 
 //===--------------------------------------------------------------------===//
+// GetPartitionStats
+//===--------------------------------------------------------------------===//
+vector<PartitionStatistics> RowGroupCollection::GetPartitionStats() const {
+	vector<PartitionStatistics> result;
+	for (auto &row_group : row_groups->Segments()) {
+		result.push_back(row_group.GetPartitionStats());
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
 // GetColumnSegmentInfo
 //===--------------------------------------------------------------------===//
 vector<ColumnSegmentInfo> RowGroupCollection::GetColumnSegmentInfo() {

--- a/test/sql/aggregate/aggregates/test_count_star.test
+++ b/test/sql/aggregate/aggregates/test_count_star.test
@@ -20,4 +20,3 @@ SELECT i, COUNT() FROM integers GROUP BY i ORDER BY i
 ----
 2	1
 3	2
-

--- a/test/sql/transactions/count_star_transactions.test
+++ b/test/sql/transactions/count_star_transactions.test
@@ -1,0 +1,71 @@
+# name: test/sql/transactions/count_star_transactions.test
+# description: Test COUNT(*) with transaction local changes
+# group: [transactions]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE tbl (id INT);
+
+statement ok
+INSERT INTO tbl FROM range(10000);
+
+query I
+SELECT COUNT(*) FROM tbl
+----
+10000
+
+# deletes
+statement ok con1
+BEGIN;
+
+query I con1
+DELETE FROM tbl WHERE id%2=0
+----
+5000
+
+query I con1
+SELECT COUNT(*) FROM tbl
+----
+5000
+
+query II
+SELECT COUNT(*), COUNT(*) + 1 FROM tbl
+----
+10000	10001
+
+statement ok con1
+COMMIT;
+
+query I
+SELECT COUNT(*) FROM tbl
+----
+5000
+
+# transaction local appends
+statement ok con1
+BEGIN;
+
+query I con1
+INSERT INTO tbl FROM range(10000, 15000)
+----
+5000
+
+query I con1
+SELECT COUNT(*) FROM tbl
+----
+10000
+
+query I
+SELECT COUNT(*) FROM tbl
+----
+5000
+
+statement ok con1
+COMMIT;
+
+query I
+SELECT COUNT(*) FROM tbl
+----
+10000


### PR DESCRIPTION
This PR adds the `get_partition_stats` callback that can be used to get partition info. This can be used by the optimizer layer to make decisions on how to best process a dataset. Currently we only return counts, but the idea is that we can extend this in the future to add min/max or sortedness information.

```cpp
enum class CountType { COUNT_EXACT, COUNT_APPROXIMATE };

struct PartitionStatistics {
	PartitionStatistics();

	//! The row id start
	idx_t row_start;
	//! The amount of rows in the partition
	idx_t count;
	//! Whether or not the count is exact or approximate
	CountType count_type;
};

typedef vector<PartitionStatistics> (*table_function_get_partition_stats_t)(ClientContext &context, GetPartitionStatsInput &input);
```

###### COUNT(*)

In the statistics propagation optimizer, we use this new callback to speed up `COUNT(*)` queries over tables provided they do not have deletes or transaction-local data. When a row group has no deletes or transaction information, it returns `CountType::COUNT_EXACT`. We can then use this to compute the `COUNT(*)` correctly using only the row group metadata during optimization time. This speeds up simple queries like `SELECT COUNT(*) FROM tbl` which previously emitted row id vectors and counted them to obtain the count.

While that is reasonably fast, reading the count directly from the metadata is much faster.

Here is `COUNT(*)` over `lineitem` with TPC-H SF10.

```sql
SELECT COUNT(*) FROM lineitem;
```

| v1.1.3 |  new   |
|--------|--------|
| 0.008s | 0.001s |