### PR TITLE
Correctly propagate child-types in MAP to the internal struct values, and test httpfs in LATEST_STORAGE

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -527,7 +527,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
       GEN: ninja
-      CORE_EXTENSIONS: "parquet;json;tpch;tpcds"
+      CORE_EXTENSIONS: "parquet;json;tpch;tpcds;httpfs"
       DEBUG_STACKTRACE: 1
       LATEST_STORAGE: 1
       BLOCK_VERIFICATION: 1

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -784,15 +784,21 @@ Value Value::MAP(const LogicalType &key_type, const LogicalType &value_type, vec
 	unordered_set<hash_t> unique_keys;
 
 	for (idx_t i = 0; i < keys.size(); i++) {
-		child_list_t<Value> new_children;
+		child_list_t<LogicalType> struct_types;
+		vector<Value> new_children;
+		struct_types.reserve(2);
 		new_children.reserve(2);
+
+		struct_types.push_back(make_pair("key", key_type));
+		struct_types.push_back(make_pair("value", value_type));
 
 		auto key = keys[i].DefaultCastAs(key_type);
 		MapKeyCheck(unique_keys, key);
 
-		new_children.push_back(std::make_pair("key", key));
-		new_children.push_back(std::make_pair("value", values[i].DefaultCastAs(value_type)));
-		values[i] = Value::STRUCT(std::move(new_children));
+		new_children.push_back(key);
+		new_children.push_back(values[i]);
+		auto struct_type = LogicalType::STRUCT(std::move(struct_types));
+		values[i] = Value::STRUCT(struct_type, std::move(new_children));
 	}
 
 	result.value_info_ = make_shared_ptr<NestedValueInfo>(std::move(values));
@@ -1990,7 +1996,7 @@ void Value::SerializeChildren(Serializer &serializer, const vector<Value> &child
 	serializer.WriteObject(102, "value", [&](Serializer &child_serializer) {
 		child_serializer.WriteList(100, "children", children.size(), [&](Serializer::List &list, idx_t i) {
 			auto &value_type = GetChildType(parent_type, i);
-			bool serialize_type = value_type.id() == LogicalTypeId::ANY;
+			bool serialize_type = value_type.InternalType() == PhysicalType::INVALID;
 			if (!serialize_type && !SerializeTypeMatches(value_type, children[i].type())) {
 				throw InternalException("Error when serializing type - serializing a child of a nested value with type "
 				                        "%s, but expected type %s",
@@ -2087,7 +2093,7 @@ void Value::Serialize(Serializer &serializer) const {
 
 Value Value::Deserialize(Deserializer &deserializer) {
 	auto type = deserializer.ReadPropertyWithExplicitDefault<LogicalType>(100, "type", LogicalTypeId::INVALID);
-	if (type.id() == LogicalTypeId::INVALID) {
+	if (type.InternalType() == PhysicalType::INVALID) {
 		type = deserializer.Get<const LogicalType &>();
 	}
 	auto is_null = deserializer.ReadProperty<bool>(101, "is_null");


### PR DESCRIPTION
Fixes an issue with secret (de)serialization introduced by the Value serialization rework.