### PR TITLE
Fix for bitstring_agg on empty result - only complain about missing stats when we actually process rows

### DIFF
--- a/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
@@ -234,13 +234,11 @@ idx_t BitStringAggOperation::GetRange(uhugeint_t min, uhugeint_t max) {
 unique_ptr<BaseStatistics> BitstringPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
                                                    AggregateStatisticsInput &input) {
 
-	if (!NumericStats::HasMinMax(input.child_stats[0])) {
-		throw BinderException("Could not retrieve required statistics. Alternatively, try by providing the statistics "
-		                      "explicitly: BITSTRING_AGG(col, min, max) ");
+	if (NumericStats::HasMinMax(input.child_stats[0])) {
+		auto &bind_agg_data = input.bind_data->Cast<BitstringAggBindData>();
+		bind_agg_data.min = NumericStats::Min(input.child_stats[0]);
+		bind_agg_data.max = NumericStats::Max(input.child_stats[0]);
 	}
-	auto &bind_agg_data = input.bind_data->Cast<BitstringAggBindData>();
-	bind_agg_data.min = NumericStats::Min(input.child_stats[0]);
-	bind_agg_data.max = NumericStats::Max(input.child_stats[0]);
 	return nullptr;
 }
 

--- a/test/sql/aggregate/aggregates/bitstring_agg_empty.test
+++ b/test/sql/aggregate/aggregates/bitstring_agg_empty.test
@@ -1,0 +1,27 @@
+# name: test/sql/aggregate/aggregates/bitstring_agg_empty.test
+# description: Test BITSTRING_AGG operator
+# group: [aggregates]
+
+statement ok
+PRAGMA verify_external
+
+require skip_reload
+
+statement ok
+CREATE TABLE t1 (k VARCHAR, el VARCHAR);
+
+statement ok
+CREATE VIEW t1_v AS (SELECT * FROM t1 LIMIT 0);
+
+statement ok
+CREATE TABLE el_ids (el VARCHAR, idx INTEGER);
+
+statement ok
+INSERT INTO el_ids VALUES ('el', 10);
+
+query II
+SELECT    k, bitstring_agg(idx)
+FROM      t1_v
+JOIN      el_ids USING (el)
+GROUP BY  k;
+----


### PR DESCRIPTION
Fixes an issue found internally