### PR TITLE
remove conditional around fsync in single_file_block_manager

### DIFF
--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -672,11 +672,9 @@ void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
 		throw FatalException("Checkpoint aborted after free list write because of PRAGMA checkpoint_abort flag");
 	}
 
-	if (!options.use_direct_io) {
-		// if we are not using Direct IO we need to fsync BEFORE we write the header to ensure that all the previous
-		// blocks are written as well
-		handle->Sync();
-	}
+	// We need to fsync BEFORE we write the header to ensure that all the previous blocks are written as well
+	handle->Sync();
+
 	// set the header inside the buffer
 	header_buffer.Clear();
 	MemoryStream serializer;


### PR DESCRIPTION
This calls fsync() unconditionally, whether DIRECT_IO is enabled or not, on the DB file. DIRECT_IO doesn't guarantee durability of individual writes, so this is still necessary. If the file is already durable, this will be a NOP, so the conditional adds no value.