### PR TITLE
Fix RelationStatisticsHelper to estimate table filters correctly

### DIFF
--- a/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
+++ b/src/include/duckdb/optimizer/join_order/relation_statistics_helper.hpp
@@ -45,8 +45,8 @@ public:
 	static constexpr double DEFAULT_SELECTIVITY = 0.2;
 
 public:
-	static idx_t InspectConjunctionAND(idx_t cardinality, idx_t column_index, ConjunctionAndFilter &filter,
-	                                   BaseStatistics &base_stats);
+	static idx_t InspectTableFilter(idx_t cardinality, idx_t column_index, TableFilter &filter,
+	                                BaseStatistics &base_stats);
 	//	static idx_t InspectConjunctionOR(idx_t cardinality, idx_t column_index, ConjunctionOrFilter &filter,
 	//	                                  BaseStatistics &base_stats);
 	//! Extract Statistics from a LogicalGet.

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -113,12 +113,9 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 				column_statistics = get.function.statistics(context, get.bind_data.get(), it.first);
 			}
 
-			if (column_statistics && it.second->filter_type == TableFilterType::CONJUNCTION_AND) {
-				auto &filter = it.second->Cast<ConjunctionAndFilter>();
-				idx_t cardinality_with_and_filter = RelationStatisticsHelper::InspectConjunctionAND(
-				    base_table_cardinality, it.first, filter, *column_statistics);
-				cardinality_after_filters = MinValue(cardinality_after_filters, cardinality_with_and_filter);
-			}
+			idx_t cardinality_with_filter =
+			    InspectTableFilter(base_table_cardinality, it.first, *it.second, *column_statistics);
+			cardinality_after_filters = MinValue(cardinality_after_filters, cardinality_with_filter);
 
 			if (it.second->filter_type != TableFilterType::OPTIONAL_FILTER) {
 				has_non_optional_filters = true;
@@ -379,16 +376,22 @@ RelationStats RelationStatisticsHelper::ExtractEmptyResultStats(LogicalEmptyResu
 	return stats;
 }
 
-idx_t RelationStatisticsHelper::InspectConjunctionAND(idx_t cardinality, idx_t column_index,
-                                                      ConjunctionAndFilter &filter, BaseStatistics &base_stats) {
+idx_t RelationStatisticsHelper::InspectTableFilter(idx_t cardinality, idx_t column_index, TableFilter &filter,
+                                                   BaseStatistics &base_stats) {
 	auto cardinality_after_filters = cardinality;
-	for (auto &child_filter : filter.child_filters) {
-		if (child_filter->filter_type != TableFilterType::CONSTANT_COMPARISON) {
-			continue;
+	switch (filter.filter_type) {
+	case TableFilterType::CONJUNCTION_AND: {
+		auto &and_filter = filter.Cast<ConjunctionAndFilter>();
+		for (auto &child_filter : and_filter.child_filters) {
+			cardinality_after_filters = MinValue(
+			    cardinality_after_filters, InspectTableFilter(cardinality, column_index, *child_filter, base_stats));
 		}
-		auto &comparison_filter = child_filter->Cast<ConstantFilter>();
+		return cardinality_after_filters;
+	}
+	case TableFilterType::CONSTANT_COMPARISON: {
+		auto &comparison_filter = filter.Cast<ConstantFilter>();
 		if (comparison_filter.comparison_type != ExpressionType::COMPARE_EQUAL) {
-			continue;
+			return cardinality_after_filters;
 		}
 		auto column_count = base_stats.GetDistinctCount();
 		// column_count = 0 when there is no column count (i.e parquet scans)
@@ -396,8 +399,11 @@ idx_t RelationStatisticsHelper::InspectConjunctionAND(idx_t cardinality, idx_t c
 			// we want the ceil of cardinality/column_count. We also want to avoid compiler errors
 			cardinality_after_filters = (cardinality + column_count - 1) / column_count;
 		}
+		return cardinality_after_filters;
 	}
-	return cardinality_after_filters;
+	default:
+		return cardinality_after_filters;
+	}
 }
 
 // TODO: Currently only simple AND filters are pushed into table scans.

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -113,9 +113,11 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 				column_statistics = get.function.statistics(context, get.bind_data.get(), it.first);
 			}
 
-			idx_t cardinality_with_filter =
-			    InspectTableFilter(base_table_cardinality, it.first, *it.second, *column_statistics);
-			cardinality_after_filters = MinValue(cardinality_after_filters, cardinality_with_filter);
+			if (column_statistics) {
+				idx_t cardinality_with_filter =
+					InspectTableFilter(base_table_cardinality, it.first, *it.second, *column_statistics);
+				cardinality_after_filters = MinValue(cardinality_after_filters, cardinality_with_filter);
+			}
 
 			if (it.second->filter_type != TableFilterType::OPTIONAL_FILTER) {
 				has_non_optional_filters = true;

--- a/src/optimizer/join_order/relation_statistics_helper.cpp
+++ b/src/optimizer/join_order/relation_statistics_helper.cpp
@@ -115,7 +115,7 @@ RelationStats RelationStatisticsHelper::ExtractGetStats(LogicalGet &get, ClientC
 
 			if (column_statistics) {
 				idx_t cardinality_with_filter =
-					InspectTableFilter(base_table_cardinality, it.first, *it.second, *column_statistics);
+				    InspectTableFilter(base_table_cardinality, it.first, *it.second, *column_statistics);
 				cardinality_after_filters = MinValue(cardinality_after_filters, cardinality_with_filter);
 			}
 


### PR DESCRIPTION
Follows from investigating https://github.com/duckdb/duckdb/pull/15197

Since all table filters were created as a ConjunctionAND with a `IsNotNULL` Filter, the relation statistics helper assumed all table filters were conjunction AND filters and would bail if the table filter was not a ConjunctionAND filter.  https://github.com/duckdb/duckdb/pull/15197 removed the need to add the `ISNOTNULL` filter, a side effect of this was that the table filters would not be used to estimate the cardinality of the tables. 

This PR fixes that. Let's see what the regressions do.

Fixes: https://github.com/duckdblabs/duckdb-internal/issues/3706