### PR TITLE
EXPLAIN/EXPLAIN ANALYZE - limit max lines of each extra info element, instead of truncating the entire node

### DIFF
--- a/src/common/tree_renderer/text_tree_renderer.cpp
+++ b/src/common/tree_renderer/text_tree_renderer.cpp
@@ -168,13 +168,12 @@ void TextTreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_
 	for (idx_t x = 0; x < root.width; x++) {
 		auto node = root.GetNode(x, y);
 		if (node) {
-			SplitUpExtraInfo(node->extra_text, extra_info[x]);
+			SplitUpExtraInfo(node->extra_text, extra_info[x], config.max_extra_lines);
 			if (extra_info[x].size() > extra_height) {
 				extra_height = extra_info[x].size();
 			}
 		}
 	}
-	extra_height = MinValue<idx_t>(extra_height, config.max_extra_lines);
 	idx_t halfway_point = (extra_height + 1) / 2;
 	// now we render the actual node
 	for (idx_t render_y = 0; render_y <= extra_height; render_y++) {
@@ -405,7 +404,8 @@ void TextTreeRenderer::SplitStringBuffer(const string &source, vector<string> &r
 	}
 }
 
-void TextTreeRenderer::SplitUpExtraInfo(const InsertionOrderPreservingMap<string> &extra_info, vector<string> &result) {
+void TextTreeRenderer::SplitUpExtraInfo(const InsertionOrderPreservingMap<string> &extra_info, vector<string> &result,
+                                        idx_t max_lines) {
 	if (extra_info.empty()) {
 		return;
 	}
@@ -467,6 +467,18 @@ void TextTreeRenderer::SplitUpExtraInfo(const InsertionOrderPreservingMap<string
 			break;
 		}
 		auto splits = StringUtil::Split(str, "\n");
+		if (splits.size() > max_lines) {
+			// truncate this entry
+			vector<string> truncated_splits;
+			for (idx_t i = 0; i < max_lines / 2; i++) {
+				truncated_splits.push_back(std::move(splits[i]));
+			}
+			truncated_splits.push_back("...");
+			for (idx_t i = splits.size() - max_lines / 2; i < splits.size(); i++) {
+				truncated_splits.push_back(std::move(splits[i]));
+			}
+			splits = std::move(truncated_splits);
+		}
 		for (auto &split : splits) {
 			SplitStringBuffer(split, result);
 		}

--- a/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
+++ b/src/include/duckdb/common/tree_renderer/text_tree_renderer.hpp
@@ -112,7 +112,8 @@ private:
 	bool CanSplitOnThisChar(char l);
 	bool IsPadding(char l);
 	string RemovePadding(string l);
-	void SplitUpExtraInfo(const InsertionOrderPreservingMap<string> &extra_info, vector<string> &result);
+	void SplitUpExtraInfo(const InsertionOrderPreservingMap<string> &extra_info, vector<string> &result,
+	                      idx_t max_lines);
 	void SplitStringBuffer(const string &source, vector<string> &result);
 };
 


### PR DESCRIPTION
Previously we would truncate the entire node in the tree when it exceeded the render limit (default: 30 lines), also with no indication it was truncated, e.g.:

```sql
┌─────────────┴─────────────┐
│         TABLE_SCAN        │
│    ────────────────────   │
│            hits           │
│                           │
│        Projections:       │
│          WatchID          │
│         JavaEnable        │
│           Title           │
│         GoodEvent         │
│         EventTime         │
│         EventDate         │
│         CounterID         │
│          ClientIP         │
│          RegionID         │
│           UserID          │
│        CounterClass       │
│             OS            │
│         UserAgent         │
│            URL            │
│          Referer          │
│         IsRefresh         │
│     RefererCategoryID     │
│      RefererRegionID      │
│       URLCategoryID       │
│        URLRegionID        │
│      ResolutionWidth      │
│      ResolutionHeight     │
│      ResolutionDepth      │
│         FlashMajor        │
│         FlashMinor        │
│        FlashMinor2        │
└───────────────────────────┘
```

This PR modifies it to instead limit each *component*. This means all components are always visible (i.e. we don't hide the run-time in the operators). We also add an indication the truncation happened. For example:

```sql
┌─────────────┴─────────────┐
│         TABLE_SCAN        │
│    ────────────────────   │
│        Table: hits        │
│                           │
│        Projections:       │
│          WatchID          │
│         JavaEnable        │
│           Title           │
│         GoodEvent         │
│         EventTime         │
│         EventDate         │
│         CounterID         │
│          ClientIP         │
│          RegionID         │
│           UserID          │
│        CounterClass       │
│             OS            │
│         UserAgent         │
│            URL            │
│            ...            │
│      ParamCurrencyID      │
│    OpenstatServiceName    │
│     OpenstatCampaignID    │
│        OpenstatAdID       │
│      OpenstatSourceID     │
│         UTMSource         │
│         UTMMedium         │
│        UTMCampaign        │
│         UTMContent        │
│          UTMTerm          │
│          FromTag          │
│          HasGCLID         │
│        RefererHash        │
│          URLHash          │
│            CLID           │
│                           │
│       99997497 Rows       │
│         (101.31s)         │
└───────────────────────────┘

```