### PR TITLE
Skipping lookups in `GroupedAggregateHashTable` if (almost) everything is unique

### DIFF
--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -205,6 +205,9 @@ idx_t GroupedAggregateHashTable::ApplyBitMask(hash_t hash) const {
 
 void GroupedAggregateHashTable::Verify() {
 #ifdef DEBUG
+	if (skip_lookups) {
+		return;
+	}
 	idx_t total_count = 0;
 	for (idx_t i = 0; i < capacity; i++) {
 		const auto &entry = entries[i];

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -476,7 +476,7 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 		static constexpr double UNIQUE_PERCENTAGE_THRESHOLD = 0.95;
 		const auto unique_percentage =
 		    static_cast<double>(ht.GetPartitionedData().Count()) / static_cast<double>(ht.GetSinkCount());
-		if (ht.GetSinkCount() > SKIP_LOOKUP_THRESHOLD && unique_percentage < UNIQUE_PERCENTAGE_THRESHOLD) {
+		if (ht.GetSinkCount() > SKIP_LOOKUP_THRESHOLD && unique_percentage > UNIQUE_PERCENTAGE_THRESHOLD) {
 			ht.SkipLookups();
 		}
 	}

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -464,8 +464,21 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 	if (gstate.number_of_threads > RadixHTConfig::GROW_STRATEGY_THREAD_THRESHOLD || gstate.external) {
 		// 'Reset' the HT without taking its data, we can just keep appending to the same collection
 		// This only works because we never resize the HT
-		ht.Abandon();
 		// We don't do this when running with 1 or 2 threads, it only makes sense when there's many threads
+		ht.Abandon();
+
+		// Once we've inserted more than SKIP_LOOKUP_THRESHOLD tuples,
+		// and more than UNIQUE_PERCENTAGE_THRESHOLD were unique,
+		// we set the HT to skip doing lookups, which makes it blindly append data to the HT.
+		// This speeds up adding data, at the cost of no longer de-duplicating.
+		// The data will be de-duplicated later anyway
+		static constexpr idx_t SKIP_LOOKUP_THRESHOLD = 262144;
+		static constexpr double UNIQUE_PERCENTAGE_THRESHOLD = 0.95;
+		const auto unique_percentage =
+		    static_cast<double>(ht.GetPartitionedData().Count()) / static_cast<double>(ht.GetSinkCount());
+		if (ht.GetSinkCount() > SKIP_LOOKUP_THRESHOLD && unique_percentage < UNIQUE_PERCENTAGE_THRESHOLD) {
+			ht.SkipLookups();
+		}
 	}
 
 	// Check if we need to repartition

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -94,6 +94,10 @@ public:
 	void SetRadixBits(idx_t radix_bits);
 	//! Get the radix bits for this HT
 	idx_t GetRadixBits() const;
+	//! Get the total amount of data sunk into this HT
+	idx_t GetSinkCount() const;
+	//! Skips lookups from here on out
+	void SkipLookups();
 
 	//! Executes the filter(if any) and update the aggregates
 	void Combine(GroupedAggregateHashTable &other);
@@ -158,6 +162,11 @@ private:
 	idx_t hash_offset;
 	//! Bitmask for getting relevant bits from the hashes to determine the position
 	hash_t bitmask;
+
+	//! How many tuples went into this HT (before de-duplication)
+	idx_t sink_count;
+	//! If true, we just append, skipping HT lookups
+	bool skip_lookups;
 
 	//! The active arena allocator used by the aggregates for their internal state
 	shared_ptr<ArenaAllocator> aggregate_allocator;


### PR DESCRIPTION
We can skip doing lookups and deduplication in `GroupedAggregateHashTable` in the first phase of `RadixPartitionedHashTable` if (almost) everything is unique. We do lookups and deduplication in the second phase anyway. I've set thresholds such that this triggers after seeing `262144` tuples, of which 95% were unique.

This optimization speeds up queries like the following where there are many unique values:
```sql
select count(*) from (select distinct l_orderkey, l_linenumber from lineitem);
```
At TPC-H SF100, the execution time is reduced from ~5.2s to ~4.5s.