### PR TITLE
[Dev] Fix Roaring compression bug on appending small vectors

### DIFF
--- a/src/include/duckdb/storage/compression/roaring/appender.hpp
+++ b/src/include/duckdb/storage/compression/roaring/appender.hpp
@@ -69,10 +69,45 @@ public:
 				idx_t to_append =
 				    MinValue<idx_t>(ROARING_CONTAINER_SIZE - STATE_TYPE::Count(state), input_size - appended);
 
+				// Deal with a ragged start, when 'appended' isn't a multiple of ValidityMask::BITS_PER_VALUE
+				// then we need to process the remainder of the entry
+				idx_t entry_offset = appended / ValidityMask::BITS_PER_VALUE;
+				auto previous_entry_remainder = appended % ValidityMask::BITS_PER_VALUE;
+				if (DUCKDB_UNLIKELY(previous_entry_remainder != 0)) {
+					auto validity_entry = validity.GetValidityEntry(entry_offset);
+
+					idx_t to_process = ValidityMask::BITS_PER_VALUE - previous_entry_remainder;
+					validity_t mask;
+					if (to_append < to_process) {
+						// Limit the amount of bits to set
+						auto left_bits = to_process - to_append;
+						to_process = to_append;
+						mask = ValidityUncompressed::UPPER_MASKS[to_process] >> left_bits;
+					} else {
+						mask = ValidityUncompressed::UPPER_MASKS[to_process];
+					}
+
+					auto masked_entry = (validity_entry & mask) >> previous_entry_remainder;
+					if (masked_entry == ValidityUncompressed::LOWER_MASKS[to_process]) {
+						// All bits are set
+						STATE_TYPE::HandleAllValid(state, to_process);
+					} else if (masked_entry == 0) {
+						// None of the bits are set
+						STATE_TYPE::HandleNoneValid(state, to_process);
+					} else {
+						// Mixed set/unset bits
+						AppendBytes(state, masked_entry, to_process);
+					}
+
+					to_append -= to_process;
+					appended += to_process;
+					entry_offset++;
+				}
+
 				auto entry_count = to_append / ValidityMask::BITS_PER_VALUE;
 				for (idx_t entry_index = 0; entry_index < entry_count; entry_index++) {
 					// get the validity entry at this index
-					auto validity_entry = validity.GetValidityEntry(entry_index);
+					auto validity_entry = validity.GetValidityEntry(entry_offset + entry_index);
 					if (ValidityMask::AllValid(validity_entry)) {
 						// All bits are set
 						STATE_TYPE::HandleAllValid(state, ValidityMask::BITS_PER_VALUE);
@@ -88,7 +123,7 @@ public:
 				// Deal with a ragged end, when the validity entry isn't entirely used
 				idx_t remainder = to_append % ValidityMask::BITS_PER_VALUE;
 				if (DUCKDB_UNLIKELY(remainder != 0)) {
-					auto validity_entry = validity.GetValidityEntry(entry_count);
+					auto validity_entry = validity.GetValidityEntry(entry_offset + entry_count);
 					auto masked = validity_entry & ValidityUncompressed::LOWER_MASKS[remainder];
 					if (masked == ValidityUncompressed::LOWER_MASKS[remainder]) {
 						// All bits are set

--- a/test/sql/storage/compression/roaring/roaring_appends.test_slow
+++ b/test/sql/storage/compression/roaring/roaring_appends.test_slow
@@ -1,0 +1,39 @@
+# name: test/sql/storage/compression/roaring/roaring_appends.test_slow
+# group: [roaring]
+
+require block_size 262144
+
+load __TEST_DIR__/test_roaring_appends.db
+
+statement ok
+PRAGMA force_compression='roaring';
+
+statement ok
+set checkpoint_threshold = '100mb';
+
+statement ok
+CREATE TABLE test (a BIGINT);
+
+foreach size 50 100 250 1025 1500
+
+statement ok
+delete from test;
+
+loop i 1 30
+
+statement ok
+INSERT INTO test SELECT case when i%25=0 then 1337 else null end FROM range(0,${size}) tbl(i);
+
+statement ok
+checkpoint
+
+query I
+select count(*) = (${size} / 25) * ${i} from test WHERE a IS NOT NULL;
+----
+true
+
+#i
+endloop
+
+#size
+endloop

--- a/test/sql/storage/compression/roaring/roaring_smaller_than_vector.test
+++ b/test/sql/storage/compression/roaring/roaring_smaller_than_vector.test
@@ -27,9 +27,6 @@ select count(*) from test WHERE a IS NOT NULL;
 41
 
 statement ok
-pragma verify_serializer
-
-statement ok
 INSERT INTO test SELECT case when i%25=0 then 1337 else null end FROM range(0,1025) tbl(i);
 
 statement ok

--- a/test/sql/storage/compression/roaring/roaring_smaller_than_vector.test
+++ b/test/sql/storage/compression/roaring/roaring_smaller_than_vector.test
@@ -1,0 +1,44 @@
+# name: test/sql/storage/compression/roaring/roaring_smaller_than_vector.test
+# group: [roaring]
+
+require block_size 262144
+
+load __TEST_DIR__/test_roaring2.db
+
+statement ok
+PRAGMA force_compression='roaring';
+
+statement ok
+set checkpoint_threshold = '10mb';
+
+# simple compression with few values
+statement ok
+CREATE TABLE test (a BIGINT);
+
+statement ok
+INSERT INTO test SELECT case when i%25=0 then 1337 else null end FROM range(0,1025) tbl(i);
+
+statement ok
+checkpoint
+
+query I
+select count(*) from test WHERE a IS NOT NULL;
+----
+41
+
+statement ok
+pragma verify_serializer
+
+statement ok
+INSERT INTO test SELECT case when i%25=0 then 1337 else null end FROM range(0,1025) tbl(i);
+
+statement ok
+checkpoint;
+
+query I
+select count(*) from test WHERE a IS NOT NULL;
+----
+82
+
+statement ok
+DROP TABLE test;


### PR DESCRIPTION
This PR fixes <https://github.com/duckdblabs/duckdb-internal/issues/3748>

Two issues with AppendVector:
- We were using `validity.GetValidityEntry(entry_idx)` where `entry_idx` is entirely based on `to_append` and does not account for offset within the validity, based on `appended`.
- We were not accounting for "ragged starts", which means the bits we care about are the top N bits of a validity entry, where the other `ValidityMask::BITS_PER_VALUE - N` bits are already processed.