### PR TITLE
Adjustments on test to bypass sniffing limitation on vector_size

### DIFF
--- a/data/csv/per_thread/c1.csv
+++ b/data/csv/per_thread/c1.csv
@@ -1,5 +1,5 @@
 c_category,c_bool,c_float,c_int,c_string
-a,true,1.0,42.0,a
 a,false,3.2,,"b,c"
+a,true,1.0,42.0,a
 b,true,3.0,123.0,e
 b,true,4.0,321.0,f

--- a/test/sql/copy/csv/glob/read_csv_glob.test
+++ b/test/sql/copy/csv/glob/read_csv_glob.test
@@ -15,7 +15,6 @@ select typeof(#1),typeof(#2),typeof(#3),typeof(#4),typeof(#5) FROM read_csv(['da
 ----
 VARCHAR	BOOLEAN	DOUBLE	DOUBLE	VARCHAR
 
-# All varchar because we force c2 to be the sniffed file
 query IIIII
 select typeof(#1),typeof(#2),typeof(#3),typeof(#4),typeof(#5) FROM read_csv(['data/csv/per_thread/c2.csv', 'data/csv/per_thread/c1.csv', 'data/csv/per_thread/c3.csv']) limit 1
 ----


### PR DESCRIPTION
Our dialect detection performs a more detailed inspection on the first vector of each dialect configuration.

This test fails to properly detect the `"` as a quote when `STANDARD_VECTOR_SIZE=2`.

We could force the dialect detection to process a fixed, and even configurable, number of tuples instead of relying on the vector size. However, this approach seems a bit excessive.