### PR TITLE
Update AddCTE exception type from Internal to Binder

### DIFF
--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -478,7 +478,7 @@ void Binder::AddCTE(const string &name, CommonTableExpressionInfo &info) {
 	D_ASSERT(!name.empty());
 	auto entry = CTE_bindings.find(name);
 	if (entry != CTE_bindings.end()) {
-		throw InternalException("Duplicate CTE \"%s\" in query!", name);
+		throw BinderException("Duplicate CTE \"%s\" in query!", name);
 	}
 	CTE_bindings.insert(make_pair(name, reference<CommonTableExpressionInfo>(info)));
 }


### PR DESCRIPTION
We had users running into this exception which causes a db invalidation (and server crashes) as a result. This seems like an error that should not be at that level of severity? Updating this to be a BinderException.