### PR TITLE
Enable stack traces by default, split into getting the frame pointers and resolve symbols only when the error is finalized, and add support for demangling

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library_unity(
   radix_partitioning.cpp
   re2_regex.cpp
   random_engine.cpp
+  stacktrace.cpp
   string_util.cpp
   enum_util.cpp
   symbols.cpp

--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -10,8 +10,7 @@ void DuckDBAssertInternal(bool condition, const char *condition_name, const char
 	if (condition) {
 		return;
 	}
-	throw InternalException("Assertion triggered in file \"%s\" on line %d: %s%s", file, linenr, condition_name,
-	                        Exception::GetStackTrace());
+	throw InternalException("Assertion triggered in file \"%s\" on line %d: %s", file, linenr, condition_name);
 }
 
 } // namespace duckdb

--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/stacktrace.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/query_error_context.hpp"
 #include "duckdb/parser/tableref.hpp"

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -11,9 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #endif
-#ifdef DUCKDB_DEBUG_STACKTRACE
-#include <execinfo.h>
-#endif
+#include "duckdb/common/stacktrace.hpp"
 
 namespace duckdb {
 
@@ -32,13 +30,16 @@ string Exception::ToJSON(ExceptionType type, const string &message) {
 }
 
 string Exception::ToJSON(ExceptionType type, const string &message, const unordered_map<string, string> &extra_info) {
-#ifdef DUCKDB_DEBUG_STACKTRACE
-	auto extended_extra_info = extra_info;
-	extended_extra_info["stack_trace"] = Exception::GetStackTrace();
-	return StringUtil::ExceptionToJSONMap(type, message, extended_extra_info);
-#else
-	return StringUtil::ExceptionToJSONMap(type, message, extra_info);
+#ifndef DUCKDB_DEBUG_STACKTRACE
+	// by default we only enable stack traces for internal exceptions
+	if (type == ExceptionType::INTERNAL)
 #endif
+	{
+		auto extended_extra_info = extra_info;
+		extended_extra_info["stack_trace_pointers"] = StackTrace::GetStacktracePointers();
+		return StringUtil::ExceptionToJSONMap(type, message, extended_extra_info);
+	}
+	return StringUtil::ExceptionToJSONMap(type, message, extra_info);
 }
 
 bool Exception::UncaughtException() {
@@ -73,22 +74,8 @@ bool Exception::InvalidatesDatabase(ExceptionType exception_type) {
 	}
 }
 
-string Exception::GetStackTrace(int max_depth) {
-#ifdef DUCKDB_DEBUG_STACKTRACE
-	string result;
-	auto callstack = unique_ptr<void *[]>(new void *[max_depth]);
-	int frames = backtrace(callstack.get(), max_depth);
-	char **strs = backtrace_symbols(callstack.get(), frames);
-	for (int i = 0; i < frames; i++) {
-		result += strs[i];
-		result += "\n";
-	}
-	free(strs);
-	return "\n" + result;
-#else
-	// Stack trace not available. Toggle DUCKDB_DEBUG_STACKTRACE in exception.cpp to enable stack traces.
-	return "";
-#endif
+string Exception::GetStackTrace(idx_t max_depth) {
+	return StackTrace::GetStackTrace(max_depth);
 }
 
 string Exception::ConstructMessageRecursive(const string &msg, std::vector<ExceptionFormatValue> &values) {
@@ -333,6 +320,7 @@ FatalException::FatalException(ExceptionType type, const string &msg) : Exceptio
 InternalException::InternalException(const string &msg) : Exception(ExceptionType::INTERNAL, msg) {
 #ifdef DUCKDB_CRASH_ON_ASSERT
 	Printer::Print("ABORT THROWN BY INTERNAL EXCEPTION: " + msg);
+	Printer::Print(StackTrace::GetStackTrace());
 	abort();
 #endif
 }

--- a/src/common/stacktrace.cpp
+++ b/src/common/stacktrace.cpp
@@ -2,14 +2,14 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 
-#if defined(__GLIBC__) || defined (__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__)
 #include <execinfo.h>
 #include <cxxabi.h>
 #endif
 
 namespace duckdb {
 
-#if defined(__GLIBC__) || defined (__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__)
 static string UnmangleSymbol(string symbol) {
 	// find the mangled name
 	idx_t mangle_start = symbol.size();

--- a/src/common/stacktrace.cpp
+++ b/src/common/stacktrace.cpp
@@ -1,0 +1,87 @@
+#include "duckdb/common/stacktrace.hpp"
+#include "duckdb/common/string_util.hpp"
+
+#ifndef _WIN32
+#include <execinfo.h>
+#include <cxxabi.h>
+#endif
+
+namespace duckdb {
+
+#ifndef _WIN32
+static string UnmangleSymbol(string symbol) {
+	// find the mangled name
+	idx_t mangle_start = symbol.size();
+	idx_t mangle_end = 0;
+	for (idx_t i = 0; i < symbol.size(); ++i) {
+		if (symbol[i] == '_') {
+			mangle_start = i;
+			break;
+		}
+	}
+	for (idx_t i = mangle_start; i < symbol.size(); i++) {
+		if (StringUtil::CharacterIsSpace(symbol[i])) {
+			mangle_end = i;
+			break;
+		}
+	}
+	if (mangle_start >= mangle_end) {
+		return symbol;
+	}
+	string mangled_symbol = symbol.substr(mangle_start, mangle_end - mangle_start);
+
+	int status;
+	auto demangle_result = abi::__cxa_demangle(mangled_symbol.c_str(), NULL, NULL, &status);
+	if (status != 0 || !demangle_result) {
+		return symbol;
+	}
+	string result;
+	result += symbol.substr(0, mangle_start);
+	result += demangle_result;
+	result += symbol.substr(mangle_end);
+	free(demangle_result);
+	return result;
+}
+
+string StackTrace::GetStacktracePointers(idx_t max_depth) {
+	string result;
+	auto callstack = unique_ptr<void *[]>(new void *[max_depth]);
+	int frames = backtrace(callstack.get(), NumericCast<int32_t>(max_depth));
+	// skip two frames (these are always StackTrace::...)
+	for (idx_t i = 2; i < NumericCast<idx_t>(frames); i++) {
+		if (!result.empty()) {
+			result += ";";
+		}
+		result += to_string(CastPointerToValue(callstack[i]));
+	}
+	return result;
+}
+
+string StackTrace::ResolveStacktraceSymbols(const string &pointers) {
+	auto splits = StringUtil::Split(pointers, ";");
+	idx_t frame_count = splits.size();
+	auto callstack = unique_ptr<void *[]>(new void *[frame_count]);
+	for (idx_t i = 0; i < frame_count; i++) {
+		callstack[i] = cast_uint64_to_pointer(StringUtil::ToUnsigned(splits[i]));
+	}
+	string result;
+	char **strs = backtrace_symbols(callstack.get(), NumericCast<int>(frame_count));
+	for (idx_t i = 0; i < frame_count; i++) {
+		result += UnmangleSymbol(strs[i]);
+		result += "\n";
+	}
+	free(strs);
+	return "\n" + result;
+}
+
+#else
+string StackTrace::GetStacktracePointers() {
+	return string();
+}
+
+string StackTrace::ResolveStacktraceSymbols(const string &pointers) {
+	return string();
+}
+#endif
+
+} // namespace duckdb

--- a/src/common/stacktrace.cpp
+++ b/src/common/stacktrace.cpp
@@ -76,7 +76,7 @@ string StackTrace::ResolveStacktraceSymbols(const string &pointers) {
 }
 
 #else
-string StackTrace::GetStacktracePointers() {
+string StackTrace::GetStacktracePointers(idx_t max_depth) {
 	return string();
 }
 

--- a/src/common/stacktrace.cpp
+++ b/src/common/stacktrace.cpp
@@ -2,14 +2,14 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/to_string.hpp"
 
-#ifndef _WIN32
+#if defined(__GLIBC__) || defined (__APPLE__)
 #include <execinfo.h>
 #include <cxxabi.h>
 #endif
 
 namespace duckdb {
 
-#ifndef _WIN32
+#if defined(__GLIBC__) || defined (__APPLE__)
 static string UnmangleSymbol(string symbol) {
 	// find the mangled name
 	idx_t mangle_start = symbol.size();

--- a/src/common/stacktrace.cpp
+++ b/src/common/stacktrace.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/stacktrace.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/to_string.hpp"
 
 #ifndef _WIN32
 #include <execinfo.h>
@@ -31,7 +32,7 @@ static string UnmangleSymbol(string symbol) {
 	string mangled_symbol = symbol.substr(mangle_start, mangle_end - mangle_start);
 
 	int status;
-	auto demangle_result = abi::__cxa_demangle(mangled_symbol.c_str(), NULL, NULL, &status);
+	auto demangle_result = abi::__cxa_demangle(mangled_symbol.c_str(), nullptr, nullptr, &status);
 	if (status != 0 || !demangle_result) {
 		return symbol;
 	}
@@ -70,7 +71,7 @@ string StackTrace::ResolveStacktraceSymbols(const string &pointers) {
 		result += UnmangleSymbol(strs[i]);
 		result += "\n";
 	}
-	free(strs);
+	free(reinterpret_cast<void *>(strs));
 	return "\n" + result;
 }
 

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -53,6 +53,10 @@ bool StringUtil::Contains(const string &haystack, const char &needle_char) {
 	return (haystack.find(needle_char) != string::npos);
 }
 
+idx_t StringUtil::ToUnsigned(const string &str) {
+	return std::stoull(str);
+}
+
 void StringUtil::LTrim(string &str) {
 	auto it = str.begin();
 	while (it != str.end() && CharacterIsSpace(*it)) {

--- a/src/include/duckdb/common/error_data.hpp
+++ b/src/include/duckdb/common/error_data.hpp
@@ -47,6 +47,7 @@ public:
 		return extra_info;
 	}
 
+	DUCKDB_API void FinalizeError();
 	DUCKDB_API void AddErrorLocation(const string &query);
 	DUCKDB_API void ConvertErrorToJSON();
 

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -137,7 +137,7 @@ public:
 
 	DUCKDB_API static bool UncaughtException();
 
-	DUCKDB_API static string GetStackTrace(int max_depth = 120);
+	DUCKDB_API static string GetStackTrace(idx_t max_depth = 120);
 	static string FormatStackTrace(const string &message = "") {
 		return (message + "\n" + GetStackTrace());
 	}

--- a/src/include/duckdb/common/stacktrace.hpp
+++ b/src/include/duckdb/common/stacktrace.hpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/stacktrace.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+class StackTrace {
+public:
+	static string GetStacktracePointers(idx_t max_depth = 120);
+	static string ResolveStacktraceSymbols(const string &pointers);
+
+	inline static string GetStackTrace(idx_t max_depth = 120) {
+		return ResolveStacktraceSymbols(GetStacktracePointers(max_depth));
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -165,6 +165,8 @@ public:
 	DUCKDB_API static void URLDecodeBuffer(const char *input, idx_t input_size, char *output,
 	                                       bool plus_to_space = false);
 
+	DUCKDB_API static idx_t ToUnsigned(const string &str);
+
 	template <class T>
 	static string ToString(const vector<T> &input, const string &separator) {
 		vector<string> input_list;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -170,9 +170,10 @@ void ClientContext::Destroy() {
 }
 
 void ClientContext::ProcessError(ErrorData &error, const string &query) const {
+	error.FinalizeError();
 	if (config.errors_as_json) {
 		error.ConvertErrorToJSON();
-	} else if (!query.empty()) {
+	} else {
 		error.AddErrorLocation(query);
 	}
 }


### PR DESCRIPTION
This PR enables printing stack traces by default for internal exceptions instead of hiding this behind a separate compilation flag. The `DUCKDB_DEBUG_STACKTRACE ` compilation flag can be used to enable this for all exceptions. This uses the `backtrace` function which is available on Linux with GLIBC and on MacOS. We also use `abi::__cxa_demangle` to demangle the C++ symbols and print a readable stack trace. These stack traces should help debug internal exceptions.

In addition, this PR splits up the stack trace generation into two steps:

* Obtaining the stack trace pointers (using `backtrace`). This is done when the exception is thrown.
* Resolving the symbols using `backtrace_symbols`. This is done when the exception has bubbled up to the user.

Getting the backtrace pointers is much cheaper than resolving the symbols - so postponing the resolution of symbols makes it cheaper to throw exceptions. This is not very relevant for internal exceptions - but is relevant when enabling this for all exceptions, since we don't always propagate exceptions upwards to the user. 