### PR TITLE
Unified use of constant MainHeader: FLAG_COUNT

### DIFF
--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -179,7 +179,7 @@ void SingleFileBlockManager::CreateNewDatabase() {
 
 	MainHeader main_header;
 	main_header.version_number = VERSION_NUMBER;
-	memset(main_header.flags, 0, sizeof(uint64_t) * 4);
+	memset(main_header.flags, 0, sizeof(uint64_t) * MainHeader::FLAG_COUNT);
 
 	SerializeHeaderStructure<MainHeader>(main_header, header_buffer.buffer);
 	// now write the header to the file


### PR DESCRIPTION
For the number of flags in MainHeader, we should uniformly use constant definitions instead of using constants in some places and directly using the value 4 in others