### PR TITLE
Use correct element rename_list_el in grammar

### DIFF
--- a/third_party/libpg_query/grammar/statements/select.y
+++ b/third_party/libpg_query/grammar/statements/select.y
@@ -4029,7 +4029,7 @@ opt_replace_list: REPLACE '(' replace_list_opt_comma ')'		{ $$ = $3; }
 			| /*EMPTY*/								{ $$ = NULL; }
 		;
 
-rename_list_el: ColId AS ColId								{ $$ = list_make2($1, $3); }
+rename_list_el: except_name AS ColId						{ $$ = list_make2($1, $3); }
 		;
 
 rename_list:


### PR DESCRIPTION
This was the actual definition used by the generated grammar - but somehow the generated grammar ended up differing from the checked in grammar. We should add the grammar to the generated files check. The only problem there is installing the correct version of flex/bison in the CI:

```
$ > bison --version
bison (GNU Bison) 2.3
Written by Robert Corbett and Richard Stallman.

Copyright (C) 2006 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
$ > flex --version
flex 2.6.4 Apple(flex-34)
```