### PR TITLE
Fix error message checking in test concurrent index

### DIFF
--- a/test/sql/parallelism/interquery/test_concurrent_index.cpp
+++ b/test/sql/parallelism/interquery/test_concurrent_index.cpp
@@ -21,9 +21,8 @@ static void CreateIntegerTable(Connection *con, int64_t count) {
 }
 
 static void CheckConstraintViolation(const string &result_str) {
-	auto constraint_violation = result_str.find("constraint violation") != string::npos ||
-	                            result_str.find("constraint violated") != string::npos ||
-	                            result_str.find("Conflict on tuple deletion") != string::npos;
+	auto constraint_violation =
+	    result_str.find("violat") != string::npos || result_str.find("Conflict on tuple deletion") != string::npos;
 	if (!constraint_violation) {
 		FAIL(result_str);
 	}


### PR DESCRIPTION
This has been changed from `violated` to `violates`, so just check `violat` for future proofing