### PR TITLE
[Dev] Made `reference<CompressionFunction> function` private in `ColumnSegment`

### DIFF
--- a/src/include/duckdb/storage/compression/alp/alp_compress.hpp
+++ b/src/include/duckdb/storage/compression/alp/alp_compress.hpp
@@ -96,7 +96,6 @@ public:
 		auto compressed_segment = ColumnSegment::CreateTransientSegment(db, function, type, row_start,
 		                                                                info.GetBlockSize(), info.GetBlockSize());
 		current_segment = std::move(compressed_segment);
-		current_segment->function = function;
 
 		auto &buffer_manager = BufferManager::GetBufferManager(current_segment->db);
 		handle = buffer_manager.Pin(current_segment->block);

--- a/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
@@ -105,7 +105,6 @@ public:
 
 		auto compressed_segment = ColumnSegment::CreateTransientSegment(db, function, type, row_start,
 		                                                                info.GetBlockSize(), info.GetBlockSize());
-		compressed_segment->function = function;
 		current_segment = std::move(compressed_segment);
 
 		auto &buffer_manager = BufferManager::GetBufferManager(db);

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -202,7 +202,7 @@ protected:
 	idx_t GetVectorCount(idx_t vector_index) const;
 
 private:
-	void UpdateCompressionFunction(SegmentLock &l, CompressionFunction &function);
+	void UpdateCompressionFunction(SegmentLock &l, const CompressionFunction &function);
 
 protected:
 	//! The segments holding the data of this column segment
@@ -219,7 +219,7 @@ protected:
 	idx_t allocation_size;
 	//!	The compression function used by the ColumnData
 	//! This is empty if the segments have mixed compression or the ColumnData is empty
-	optional_ptr<CompressionFunction> compression;
+	optional_ptr<const CompressionFunction> compression;
 };
 
 struct PersistentColumnData {

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -500,7 +500,6 @@ public:
 
 		auto compressed_segment = ColumnSegment::CreateTransientSegment(db, function, type, row_start,
 		                                                                info.GetBlockSize(), info.GetBlockSize());
-		compressed_segment->function = function;
 		current_segment = std::move(compressed_segment);
 
 		auto &buffer_manager = BufferManager::GetBufferManager(db);

--- a/src/storage/compression/dictionary/compression.cpp
+++ b/src/storage/compression/dictionary/compression.cpp
@@ -18,7 +18,6 @@ void DictionaryCompressionCompressState::CreateEmptySegment(idx_t row_start) {
 	auto compressed_segment =
 	    ColumnSegment::CreateTransientSegment(db, function, type, row_start, info.GetBlockSize(), info.GetBlockSize());
 	current_segment = std::move(compressed_segment);
-	current_segment->function = function;
 
 	// Reset the buffers and the string map.
 	current_string_map.clear();

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -240,7 +240,6 @@ public:
 		auto compressed_segment = ColumnSegment::CreateTransientSegment(db, function, type, row_start,
 		                                                                info.GetBlockSize(), info.GetBlockSize());
 		current_segment = std::move(compressed_segment);
-		current_segment->function = function;
 		Reset();
 	}
 

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -152,7 +152,6 @@ struct RLECompressState : public CompressionState {
 
 		auto column_segment = ColumnSegment::CreateTransientSegment(db, function, type, row_start, info.GetBlockSize(),
 		                                                            info.GetBlockSize());
-		column_segment->function = function;
 		current_segment = std::move(column_segment);
 
 		auto &buffer_manager = BufferManager::GetBufferManager(db);

--- a/src/storage/compression/roaring/compress.cpp
+++ b/src/storage/compression/roaring/compress.cpp
@@ -281,7 +281,6 @@ void RoaringCompressState::CreateEmptySegment(idx_t row_start) {
 
 	auto compressed_segment =
 	    ColumnSegment::CreateTransientSegment(db, function, type, row_start, info.GetBlockSize(), info.GetBlockSize());
-	compressed_segment->function = function;
 	current_segment = std::move(compressed_segment);
 
 	auto &buffer_manager = BufferManager::GetBufferManager(db);

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -522,7 +522,6 @@ public:
 		auto compressed_segment = ColumnSegment::CreateTransientSegment(db, function, type, row_start,
 		                                                                info.GetBlockSize(), info.GetBlockSize());
 		segment = std::move(compressed_segment);
-		segment->function = function;
 
 		auto &buffer_manager = BufferManager::GetBufferManager(checkpointer.GetDatabase());
 		segment_handle = buffer_manager.Pin(segment->block);

--- a/src/storage/table/column_checkpoint_state.cpp
+++ b/src/storage/table/column_checkpoint_state.cpp
@@ -171,11 +171,6 @@ void ColumnCheckpointState::FlushSegmentInternal(unique_ptr<ColumnSegment> segme
 		// Writer will decide whether to reuse this block.
 		partial_block_manager.RegisterPartialBlock(std::move(allocation));
 	} else {
-		// constant block: no need to write anything to disk besides the stats
-		// set up the compression function to constant
-		auto &config = DBConfig::GetConfig(db);
-		segment->function =
-		    *config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, segment->type.InternalType());
 		segment->ConvertToPersistent(nullptr, INVALID_BLOCK);
 	}
 
@@ -189,9 +184,10 @@ void ColumnCheckpointState::FlushSegmentInternal(unique_ptr<ColumnSegment> segme
 		data_pointer.row_start = last_pointer.row_start + last_pointer.tuple_count;
 	}
 	data_pointer.tuple_count = tuple_count;
-	data_pointer.compression_type = segment->function.get().type;
-	if (segment->function.get().serialize_state) {
-		data_pointer.segment_state = segment->function.get().serialize_state(*segment);
+	auto &compression_function = segment->GetCompressionFunction();
+	data_pointer.compression_type = compression_function.type;
+	if (compression_function.serialize_state) {
+		data_pointer.segment_state = compression_function.serialize_state(*segment);
 	}
 
 	// append the segment to the new segment tree

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -67,7 +67,7 @@ ColumnSegment::ColumnSegment(DatabaseInstance &db, shared_ptr<BlockHandle> block
                              const unique_ptr<ColumnSegmentState> segment_state_p)
 
     : SegmentBase<ColumnSegment>(start, count), db(db), type(type), type_size(GetTypeIdSize(type.InternalType())),
-      segment_type(segment_type), function(function_p), stats(std::move(statistics)), block(std::move(block_p)),
+      segment_type(segment_type), stats(std::move(statistics)), block(std::move(block_p)), function(function_p),
       block_id(block_id_p), offset(offset), segment_size(segment_size_p) {
 
 	if (function.get().init_segment) {
@@ -81,8 +81,8 @@ ColumnSegment::ColumnSegment(DatabaseInstance &db, shared_ptr<BlockHandle> block
 ColumnSegment::ColumnSegment(ColumnSegment &other, const idx_t start)
 
     : SegmentBase<ColumnSegment>(start, other.count.load()), db(other.db), type(std::move(other.type)),
-      type_size(other.type_size), segment_type(other.segment_type), function(other.function),
-      stats(std::move(other.stats)), block(std::move(other.block)), block_id(other.block_id), offset(other.offset),
+      type_size(other.type_size), segment_type(other.segment_type), stats(std::move(other.stats)),
+      block(std::move(other.block)), function(other.function), block_id(other.block_id), offset(other.offset),
       segment_size(other.segment_size), segment_state(std::move(other.segment_state)) {
 
 	// For constant segments (CompressionType::COMPRESSION_CONSTANT) the block is a nullptr.

--- a/src/storage/table/column_segment.cpp
+++ b/src/storage/table/column_segment.cpp
@@ -228,8 +228,12 @@ void ColumnSegment::ConvertToPersistent(optional_ptr<BlockManager> block_manager
 	offset = 0;
 
 	if (block_id == INVALID_BLOCK) {
-		// constant block: reset the block buffer
+		// constant block: no need to write anything to disk besides the stats
+		// set up the compression function to constant
 		D_ASSERT(stats.statistics.IsConstant());
+		auto &config = DBConfig::GetConfig(db);
+		function = *config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, type.InternalType());
+		// reset the block buffer
 		block.reset();
 	} else {
 		D_ASSERT(!stats.statistics.IsConstant());
@@ -548,6 +552,10 @@ idx_t ColumnSegment::FilterSelection(SelectionVector &sel, Vector &vector, Unifi
 	default:
 		throw InternalException("FIXME: unsupported type for filter selection");
 	}
+}
+
+const CompressionFunction &ColumnSegment::GetCompressionFunction() {
+	return function.get();
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This PR is a follow up to a change made in #14878 

In that PR we changed `CreateTransientSegment` to require the CompressionFunction, because of that it is now always set by the constructor, making the deleted lines in every touched compression function obsolete.

Because of this I tried to downgrade the type from `reference<CompressionFunction>` to `const CompressionFunction &`
In doing so I discovered there is one place where it *does* actually need to change; when the stats say the segment is constant.

This change was made outside of the ColumnSegment, but it immediately calls into a method of the ColumnSegment where it has access to the required variables as well, so I moved the code and made the member private.

I think this should help in reasoning about the ColumnSegment, as it is now clear when and how the `function` member can change.