### PR TITLE
[Dev] Fix erroneous assert in `ZSTD` scan for `LogicalTypeId::VARCHAR`

### DIFF
--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -889,7 +889,7 @@ public:
 
 	void ScanInternal(ZSTDVectorScanState &scan_state, idx_t count, Vector &result, idx_t result_offset) {
 		D_ASSERT(scan_state.scanned_count + count <= scan_state.metadata.count);
-		D_ASSERT(result.GetType().id() == LogicalTypeId::VARCHAR);
+		D_ASSERT(result.GetType().InternalType() == PhysicalType::VARCHAR);
 
 		string_length_t *string_lengths = &scan_state.string_lengths[scan_state.scanned_count];
 		idx_t uncompressed_length = 0;


### PR DESCRIPTION
This PR fixes #15354 

Other assertions and the TypeIsSupported method:
```c++
bool ZSTDFun::TypeIsSupported(PhysicalType type) {
	return type == PhysicalType::VARCHAR;
}
```

All check for `PhysicalType::VARCHAR`, which is a wider net than `LogicalTypeId::VARCHAR`, causing this:
```c++
D_ASSERT(result.GetType().id() == LogicalTypeId::VARCHAR);
```

To (needlessly) panic when a BLOB or BITSTRING is encountered, when assertions are turned on (debug builds).