### PR TITLE
Fix tests not to use compatibility version latest

### DIFF
--- a/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
+++ b/test/sql/catalog/function/test_macro_default_arg_with_dependencies.test
@@ -2,7 +2,7 @@
 # group: [function]
 
 statement ok
-set storage_compatibility_version='latest'
+set storage_compatibility_version='v1.0.0'
 
 statement ok
 set enable_macro_dependencies=true

--- a/test/sql/catalog/view/recursive_view_with_dependencies.test
+++ b/test/sql/catalog/view/recursive_view_with_dependencies.test
@@ -3,7 +3,7 @@
 # group: [view]
 
 statement ok
-set storage_compatibility_version='latest'
+set storage_compatibility_version='v1.0.0'
 
 statement ok
 set enable_view_dependencies=true

--- a/test/sql/catalog/view/test_view_schema_change_with_dependencies.test
+++ b/test/sql/catalog/view/test_view_schema_change_with_dependencies.test
@@ -3,7 +3,7 @@
 # group: [view]
 
 statement ok
-set storage_compatibility_version='latest'
+set storage_compatibility_version='v1.0.0'
 
 statement ok
 set enable_view_dependencies=true

--- a/test/sql/catalog/view/test_view_sql_with_dependencies.test
+++ b/test/sql/catalog/view/test_view_sql_with_dependencies.test
@@ -3,7 +3,7 @@
 # group: [view]
 
 statement ok
-set storage_compatibility_version='latest'
+set storage_compatibility_version='v1.0.0'
 
 statement ok
 set enable_view_dependencies=true

--- a/test/sql/copy/parquet/parquet_copy_type_mismatch.test
+++ b/test/sql/copy/parquet/parquet_copy_type_mismatch.test
@@ -8,7 +8,7 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-SET storage_compatibility_version='latest'
+SET storage_compatibility_version='v1.1.0'
 
 statement ok
 CREATE TABLE integers(i INTEGER);


### PR DESCRIPTION
Tests should never use `latest`, but specify what's the intended version explicitly.

This was part of https://github.com/duckdb/duckdb/pull/14981, but this is independent and can go ahead at a different speed.