### PR TITLE
Skip test_sample.test_slow last statements, to be investigated

### DIFF
--- a/test/sql/sample/test_sample.test_slow
+++ b/test/sql/sample/test_sample.test_slow
@@ -214,6 +214,8 @@ statement error
 select * from integers using sample 10000%;
 ----
 
+mode skip
+
 query I
 select i from integers using sample (1 rows) repeatable (0);
 ----


### PR DESCRIPTION
Failure make a OSX Release and possibly also CI runs fail, and given it's a known but not critical issue, we can first skip the test, then fix the issue and revert this PR.