### PR TITLE
Re-enable azure out of tree extension

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -43,10 +43,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
             )
 endif()
 
-### Currently libxml2, an azure dependency, has the repository repo return 503
-### Re-enable AZURE when the problem goes away. This means AZURE needs to be
-### build on a side
-if (NO)
 ################# AZURE
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(azure
@@ -55,7 +51,6 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
             GIT_TAG a40ecb7bc9036eb8ecc5bf30db935a31b78011f5
             APPLY_PATCHES
             )
-endif()
 endif()
 
 ################# DELTA

--- a/.github/patches/extensions/azure/file_handle.patch
+++ b/.github/patches/extensions/azure/file_handle.patch
@@ -1,0 +1,13 @@
+diff --git a/src/azure_filesystem.cpp b/src/azure_filesystem.cpp
+index fb4cfd8..65e0856 100644
+--- a/src/azure_filesystem.cpp
++++ b/src/azure_filesystem.cpp
+@@ -21,7 +21,7 @@ void AzureContextState::QueryEnd() {
+ 
+ AzureFileHandle::AzureFileHandle(AzureStorageFileSystem &fs, string path, FileOpenFlags flags,
+                                  const AzureReadOptions &read_options)
+-    : FileHandle(fs, std::move(path)), flags(flags),
++    : FileHandle(fs, std::move(path), flags), flags(flags),
+       // File info
+       length(0), last_modified(0),
+       // Read info


### PR DESCRIPTION
This used to fail very frequently with a download problem on libxml2, this might have been solved either by bumping to a more recent VCPKG or due to libxml2 or possibly different settings in the gnome.gitlab repository.

This reverts https://github.com/duckdb/duckdb/pull/15126.

I am not sure if problems have actually went away, I am triggering a bunch of different tests, lets see.