### PR TITLE
CI: Use mirror for Spark binaries

### DIFF
--- a/tools/pythonpkg/scripts/install_spark_in_cibuildwheels_linux_container.sh
+++ b/tools/pythonpkg/scripts/install_spark_in_cibuildwheels_linux_container.sh
@@ -4,6 +4,6 @@ yum install wget -y
 
 mkdir spark_installation
 cd spark_installation
-wget https://archive.apache.org/dist/spark/spark-3.5.3/spark-3.5.3-bin-hadoop3.tgz
+wget https://blobs.duckdb.org/ci/spark-3.5.3-bin-hadoop3.tgz
 tar -xvzf spark-3.5.3-bin-hadoop3.tgz
 mv spark-3.5.3-bin-hadoop3 spark


### PR DESCRIPTION
Use mirror to prevent spurious failures