### PR TITLE
Fix Test introduced by new sampling

### DIFF
--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -504,8 +504,8 @@ void ReservoirSample::EvictOverBudgetSamples() {
 	auto types = reservoir_chunk->chunk.GetTypes();
 	D_ASSERT(num_samples_to_keep <= sample_count);
 	D_ASSERT(stats_sample);
-	D_ASSERT(sample_count == STANDARD_VECTOR_SIZE);
-	auto new_reservoir_chunk = CreateNewSampleChunk(types, STANDARD_VECTOR_SIZE);
+	D_ASSERT(sample_count == FIXED_SAMPLE_SIZE);
+	auto new_reservoir_chunk = CreateNewSampleChunk(types, FIXED_SAMPLE_SIZE);
 
 	// The current selection vector can potentially have 2048 valid mappings.
 	// If we need to save a sample with less rows than that, we need to do the following
@@ -716,7 +716,7 @@ void ReservoirSample::AddToReservoir(DataChunk &chunk) {
 
 	idx_t tuples_consumed = FillReservoir(chunk);
 	base_reservoir_sample->num_entries_seen_total += tuples_consumed;
-	D_ASSERT(reservoir_chunk->chunk.size() >= 1);
+	D_ASSERT(sample_count == 0 || reservoir_chunk->chunk.size() >= 1);
 
 	if (tuples_consumed == chunk.size()) {
 		return;

--- a/test/sql/sample/test_sample.test_slow
+++ b/test/sql/sample/test_sample.test_slow
@@ -214,19 +214,13 @@ statement error
 select * from integers using sample 10000%;
 ----
 
-query I nosort repeatable_1_row
+query I
 select i from integers using sample (1 rows) repeatable (0);
 ----
+96
 
-query I nosort repeatable_1_row
-select i from integers using sample (1 rows) repeatable (0);
-----
-
-query I nosort repeatable_2_rows
+query I
 select i from integers using sample reservoir(1%) repeatable (0) order by i;
 ----
-
-query I nosort repeatable_2_rows
-select i from integers using sample reservoir(1%) repeatable (0) order by i;
-----
-
+58
+127

--- a/test/sql/sample/test_sample.test_slow
+++ b/test/sql/sample/test_sample.test_slow
@@ -214,13 +214,19 @@ statement error
 select * from integers using sample 10000%;
 ----
 
-query I
+query I nosort repeatable_1_row
 select i from integers using sample (1 rows) repeatable (0);
 ----
-79
 
-query I
+query I nosort repeatable_1_row
+select i from integers using sample (1 rows) repeatable (0);
+----
+
+query I nosort repeatable_2_rows
 select i from integers using sample reservoir(1%) repeatable (0) order by i;
 ----
-87
-164
+
+query I nosort repeatable_2_rows
+select i from integers using sample reservoir(1%) repeatable (0) order by i;
+----
+


### PR DESCRIPTION
Random seems to change behavior on CI vs. local every once in a while. E.g this test [passed](https://github.com/duckdb/duckdb/pull/14914/files#diff-11cce9af3b5b8ec371185eade3aa7839f9783270a63bc768e9b37ecfc3fb6ec5L221) when sampling was initially merged. I think a better long term fix is to just make sure the value is repeatable using the unittestci  features

fixes https://github.com/duckdblabs/duckdb-internal/issues/3791
fixes https://github.com/duckdblabs/duckdb-internal/issues/3792

