### PR TITLE
[Dev] Reset to the vector cache so the vectors are clean for the scan

### DIFF
--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -174,6 +174,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	}
 
 	auto &delete_chunk = index_update ? l_state.delete_chunk : l_state.mock_chunk;
+	delete_chunk.Reset();
 	delete_chunk.SetCardinality(update_count);
 
 	if (index_update) {

--- a/test/issues/rigger/test_609.test
+++ b/test/issues/rigger/test_609.test
@@ -7,13 +7,21 @@ PRAGMA enable_verification
 
 # Incorrect result for MIN() on expression involving rowid
 statement ok
-CREATE TABLE t0(c0 INT, c1 INT);
+CREATE TABLE t0(
+	c0 INT,
+	c1 INT
+);
 
 statement ok
-INSERT INTO t0(c0) VALUES (0), (0), (0), (0), (0), (0), (0), (0), (0), (0), (0), (0), (0), (0), (0), (0),  (0), (0), (0), (0), (0), (0), (NULL), (NULL);
+INSERT INTO t0(c0) SELECT 0 from range(22);
 
 statement ok
-CREATE INDEX b ON t0(c1);
+INSERT INTO t0(c0) SELECT NULL from range(2);
+
+statement ok
+CREATE INDEX b ON t0(
+	c1
+);
 
 statement ok
 UPDATE t0 SET c1 = NULL;


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/3799

Problem was that the `Fetch` call does a scan which expects that the validity of `result` is clean.