### PR TITLE
[Dev] Check in `insert` if the InsertionOrderPreservingMap contains the key, do nothing in that case

### DIFF
--- a/src/include/duckdb/common/insertion_order_preserving_map.hpp
+++ b/src/include/duckdb/common/insertion_order_preserving_map.hpp
@@ -96,23 +96,33 @@ public:
 	}
 
 	void insert(const string &key, V &&value) { // NOLINT: match stl API
+		if (contains(key)) {
+			return;
+		}
 		map.emplace_back(key, std::move(value));
 		map_idx[key] = map.size() - 1;
 	}
 
 	void insert(const string &key, const V &value) { // NOLINT: match stl API
+		if (contains(key)) {
+			return;
+		}
 		map.emplace_back(key, value);
 		map_idx[key] = map.size() - 1;
 	}
 
 	void insert(pair<string, V> &&value) { // NOLINT: match stl API
-		map_idx[value.first] = map.size();
+		auto &key = value.first;
+		if (contains(key)) {
+			return;
+		}
+		map_idx[key] = map.size();
 		map.push_back(std::move(value));
 	}
 
 	void erase(typename VECTOR_TYPE::iterator it) { // NOLINT: match stl API
 		auto key = it->first;
-		auto idx = map_idx[it->first];
+		auto idx = map_idx[key];
 		map.erase(it);
 		map_idx.erase(key);
 		for (auto &kv : map_idx) {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_API_OBJECTS
     test_pending_with_parameters.cpp
     test_progress_bar.cpp
     test_uuid.cpp
+    test_insertion_order_preserving_map.cpp
     test_varint.cpp
     test_threads.cpp
     test_windows_header_compatibility.cpp

--- a/test/api/test_insertion_order_preserving_map.cpp
+++ b/test/api/test_insertion_order_preserving_map.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Test Insertion Order Preserving Map: duplicate insert", "[api][.]") {
 	map.erase(it);
 
 	int count = 0;
-	for (auto &x : map) {
+	for (auto it = map.begin(); it != map.end(); it++) {
 		count++;
 	}
 	REQUIRE(count == 2);
@@ -34,7 +34,7 @@ TEST_CASE("Test Insertion Order Preserving Map: double erase", "[api][.]") {
 	map.erase(map.find("c"));
 
 	int count = 0;
-	for (auto &x : map) {
+	for (auto it = map.begin(); it != map.end(); it++) {
 		count++;
 	}
 
@@ -48,7 +48,7 @@ TEST_CASE("Test Insertion Order Preserving Map: double erase", "[api][.]") {
 	map.erase(map.find("b"));
 
 	count = 0;
-	for (auto &x : map) {
+	for (auto it = map.begin(); it != map.end(); it++) {
 		count++;
 	}
 

--- a/test/api/test_insertion_order_preserving_map.cpp
+++ b/test/api/test_insertion_order_preserving_map.cpp
@@ -1,0 +1,57 @@
+#include "catch.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/common/insertion_order_preserving_map.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Test Insertion Order Preserving Map: duplicate insert", "[api][.]") {
+	InsertionOrderPreservingMap<int> map;
+
+	map.insert("a", 1);
+	map.insert("b", 2);
+	map.insert("c", 3);
+	map.insert("b", 4);
+
+	auto it = map.find(string("c"));
+	map.erase(it);
+
+	int count = 0;
+	for (auto &x : map) {
+		count++;
+	}
+	REQUIRE(count == 2);
+}
+
+TEST_CASE("Test Insertion Order Preserving Map: double erase", "[api][.]") {
+	InsertionOrderPreservingMap<idx_t> map;
+	map.insert("a", 1);
+	map.insert("b", 2);
+	map.insert("c", 3);
+	map.insert("b", 4);
+	map.erase(map.find("c"));
+
+	int count = 0;
+	for (auto &x : map) {
+		count++;
+	}
+
+	REQUIRE(count == 2);
+
+	map.insert("a", 1);
+	map.insert("b", 2);
+	map.insert("c", 3);
+	map.insert("b", 4);
+	map.erase(map.find("c"));
+	map.erase(map.find("b"));
+
+	count = 0;
+	for (auto &x : map) {
+		count++;
+	}
+
+	REQUIRE(count == 1);
+	REQUIRE(map.find("b") == map.end());
+}


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/3798