### PR TITLE
Fix pessimizing move issue in collate_expression's copy.

### DIFF
--- a/src/parser/expression/collate_expression.cpp
+++ b/src/parser/expression/collate_expression.cpp
@@ -33,7 +33,7 @@ bool CollateExpression::Equal(const CollateExpression &a, const CollateExpressio
 unique_ptr<ParsedExpression> CollateExpression::Copy() const {
 	auto copy = make_uniq<CollateExpression>(collation, child->Copy());
 	copy->CopyProperties(*this);
-	return std::move(copy);
+	return copy;
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Such seemingly helpful moves are harmful since they make returned value ineligible for copy elision.  More context is in https://devblogs.microsoft.com/oldnewthing/20231124-00/?p=109059

There are lots of other places where the same issue happens in the codebase and I'd recommend using tools like clang-tidy to fix all of them.