### PR TITLE
Replace funcs copies with moves in sorted_aggregate_function.cpp

### DIFF
--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -24,7 +24,7 @@ struct SortedAggregateBindData : public FunctionData {
 			arg_types.emplace_back(child->return_type);
 			ListSegmentFunctions funcs;
 			GetSegmentDataFunctions(funcs, arg_types.back());
-			arg_funcs.emplace_back(funcs);
+			arg_funcs.emplace_back(std::move(funcs));
 		}
 		auto &order_bys = *expr.order_bys;
 		sort_types.reserve(order_bys.orders.size());
@@ -34,7 +34,7 @@ struct SortedAggregateBindData : public FunctionData {
 			sort_types.emplace_back(order.expression->return_type);
 			ListSegmentFunctions funcs;
 			GetSegmentDataFunctions(funcs, sort_types.back());
-			sort_funcs.emplace_back(funcs);
+			sort_funcs.emplace_back(std::move(funcs));
 		}
 		sorted_on_args = (children.size() == order_bys.orders.size());
 		for (size_t i = 0; sorted_on_args && i < children.size(); ++i) {


### PR DESCRIPTION
Since `ListSegmentFunctions` contains members with moves cheaper than moves, e.g. std::vector

https://github.com/duckdb/duckdb/blob/ab8c90985741ac68cd203c8396022894c1771d4b/src/include/duckdb/common/types/list_segment.hpp#L51

it's more efficient to replace copies with moves.