### PR TITLE
[Python][Dev] Lock `mypy` at 1.13

### DIFF
--- a/tools/pythonpkg/requirements-dev.txt
+++ b/tools/pythonpkg/requirements-dev.txt
@@ -5,7 +5,7 @@ setuptools>=58
 pytest
 pandas
 pytest-timeout
-mypy
+mypy<=1.13
 psutil>=5.9.0
 requests>=2.26
 fsspec


### PR DESCRIPTION
1.14 introduced [a change](https://github.com/python/mypy/pull/18005) that our `__init__.py` doesn't, and can't comply with.

Our `__init__.py` looks like this:
```py
_exported_symbols.extend([
    "Value",
    "NullValue",
    "BooleanValue",
    "UnsignedBinaryValue",
    "UnsignedShortValue",
    "UnsignedIntegerValue",
    "UnsignedLongValue",
    "BinaryValue",
    "ShortValue",
    "IntegerValue",
    "LongValue",
    "HugeIntegerValue",
    "FloatValue",
    "DoubleValue",
    "DecimalValue",
    "StringValue",
    "UUIDValue",
    "BitValue",
    "BlobValue",
    "DateValue",
    "IntervalValue",
    "TimestampValue",
    "TimestampSecondValue",
    "TimestampMilisecondValue",
    "TimestampNanosecondValue",
    "TimestampTimeZoneValue",
    "TimeValue",
    "TimeTimeZoneValue",
])

__all__ = _exported_symbols
```

Which I'm pretty sure is non-standard, and creates a warning, but this works for us

Mypy is not happy about this because it seems `__all__` is expected to be a constant expression, and expected to be copied to the `__init__.pyi` file