### PR TITLE
[Dev] Fix race condition in ColumnData that was *very seldomly* causing a segfault

### DIFF
--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -83,8 +83,16 @@ void StandardColumnData::Filter(TransactionData transaction, idx_t vector_index,
                                 SelectionVector &sel, idx_t &count, const TableFilter &filter) {
 	// check if we can do a specialized select
 	// the compression functions need to support this
-	bool has_filter = HasCompressionFunction() && GetCompressionFunction().filter;
-	bool validity_has_filter = validity.HasCompressionFunction() && validity.GetCompressionFunction().filter;
+	bool has_filter;
+	bool validity_has_filter;
+	{
+		auto base_lock = data.Lock();
+		auto validity_lock = validity.data.Lock();
+
+		has_filter = HasCompressionFunction() && GetCompressionFunction().filter;
+		validity_has_filter = validity.HasCompressionFunction() && validity.GetCompressionFunction().filter;
+	}
+
 	auto target_count = GetVectorCount(vector_index);
 	auto scan_type = GetVectorScanType(state, target_count, result);
 	bool scan_entire_vector = scan_type == ScanVectorType::SCAN_ENTIRE_VECTOR;
@@ -102,8 +110,16 @@ void StandardColumnData::Select(TransactionData transaction, idx_t vector_index,
                                 SelectionVector &sel, idx_t sel_count) {
 	// check if we can do a specialized select
 	// the compression functions need to support this
-	bool has_select = HasCompressionFunction() && GetCompressionFunction().select;
-	bool validity_has_select = validity.HasCompressionFunction() && validity.GetCompressionFunction().select;
+	bool has_select;
+	bool validity_has_select;
+	{
+		auto base_lock = data.Lock();
+		auto validity_lock = validity.data.Lock();
+
+		has_select = HasCompressionFunction() && GetCompressionFunction().select;
+		validity_has_select = validity.HasCompressionFunction() && validity.GetCompressionFunction().select;
+	}
+
 	auto target_count = GetVectorCount(vector_index);
 	auto scan_type = GetVectorScanType(state, target_count, result);
 	bool scan_entire_vector = scan_type == ScanVectorType::SCAN_ENTIRE_VECTOR;


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/3816

Maybe we don't want to use the segment tree lock for this? But that's currently being used to ensure concurrent access to the `compression` variable, in `ColumnData::Checkpoint`