### PR TITLE
[Dev] Slight cleanup of `assert.hpp`

### DIFF
--- a/src/include/duckdb/common/assert.hpp
+++ b/src/include/duckdb/common/assert.hpp
@@ -10,7 +10,16 @@
 
 #pragma once
 
-#if (defined(DUCKDB_USE_STANDARD_ASSERT) || !defined(DEBUG)) && !defined(DUCKDB_FORCE_ASSERT) && !defined(__MVS__)
+// clang-format off
+#if ( \
+    /* Not a debug build */ \
+    !defined(DEBUG) && \
+    /* FORCE_ASSERT is not set (enables assertions even on release mode when set to true) */ \
+    !defined(DUCKDB_FORCE_ASSERT) && \
+    /* The project is not compiled for Microsoft Visual Studio */ \
+    !defined(__MVS__) \
+)
+// clang-format on
 
 #include <assert.h>
 #define D_ASSERT assert

--- a/src/include/duckdb/common/assert.hpp
+++ b/src/include/duckdb/common/assert.hpp
@@ -21,6 +21,8 @@
 )
 // clang-format on
 
+//! On most builds, NDEBUG is defined, turning the assert call into a NO-OP
+//! Only the 'else' condition is supposed to check the assertions
 #include <assert.h>
 #define D_ASSERT assert
 namespace duckdb {


### PR DESCRIPTION
I was confirming whether or not `relassert` was running `DuckDBAssertInternal`, it does (though it looks like it somehow misses certain assertions because of optimizations(?))

Always found this condition a bit hard to read, so I separated it into separate lines, and also removed the use of `DUCKDB_USE_STANDARD_ASSERT`, since I could find no reference to this define anywhere else (setting or reading)