### PR TITLE
Retain join partition order

### DIFF
--- a/benchmark/micro/join/external_join_partition_order.benchmark
+++ b/benchmark/micro/join/external_join_partition_order.benchmark
@@ -1,0 +1,23 @@
+# name: benchmark/micro/join/external_join_partition_order.benchmark
+# description: Test that the external hash join partition selection selects even partitions sequentially
+# group: [join]
+
+name External Join Partition Order
+group join
+
+cache external_join_partition_order.duckdb
+
+load
+create table build as select range c from range(2000e5::bigint);
+create table probe as select range c from range(2000e5::bigint);
+
+init
+set threads=4;
+set temp_directory='${BENCHMARK_DIR}/external_join_partition_order.duckdb.tmp';
+set memory_limit='2000mb';
+
+run
+select sum(c) from probe join build using (c)
+
+result I
+19999999900000000

--- a/benchmark/micro/join/external_join_partition_order.benchmark
+++ b/benchmark/micro/join/external_join_partition_order.benchmark
@@ -8,16 +8,16 @@ group join
 cache external_join_partition_order.duckdb
 
 load
-create table build as select range c from range(2000e5::bigint);
-create table probe as select range c from range(2000e5::bigint);
+create table build as select range c from range(1000e5::bigint);
+create table probe as select range c from range(1000e5::bigint);
 
 init
-set threads=4;
+set threads=1;
 set temp_directory='${BENCHMARK_DIR}/external_join_partition_order.duckdb.tmp';
-set memory_limit='2000mb';
+set memory_limit='1000mb';
 
 run
 select sum(c) from probe join build using (c)
 
 result I
-19999999900000000
+4999999950000000

--- a/benchmark/micro/join/external_join_partition_selection.benchmark
+++ b/benchmark/micro/join/external_join_partition_selection.benchmark
@@ -1,5 +1,5 @@
 # name: benchmark/micro/join/external_join_partition_selection.benchmark
-# description: Test that the external hash join partition selection
+# description: Test that the external hash join partition selection selects the large partition last
 # group: [join]
 
 name External Join Partition Selection

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1528,18 +1528,28 @@ bool JoinHashTable::PrepareExternalFinalize(const idx_t max_ht_size) {
 
 	// Create vector with unfinished partition indices
 	auto &partitions = sink_collection->GetPartitions();
+	auto min_partition_size = NumericLimits<idx_t>::Maximum();
 	vector<idx_t> partition_indices;
 	partition_indices.reserve(num_partitions);
 	for (idx_t partition_idx = 0; partition_idx < num_partitions; partition_idx++) {
-		if (!completed_partitions.RowIsValidUnsafe(partition_idx)) {
-			partition_indices.push_back(partition_idx);
+		if (completed_partitions.RowIsValidUnsafe(partition_idx)) {
+			continue;
 		}
+		partition_indices.push_back(partition_idx);
+		// Keep track of min partition size
+		const auto size =
+		    partitions[partition_idx]->SizeInBytes() + PointerTableSize(partitions[partition_idx]->Count());
+		min_partition_size = MinValue(min_partition_size, size);
 	}
+
 	// Sort partitions by size, from small to large
-	std::sort(partition_indices.begin(), partition_indices.end(), [&](const idx_t &lhs, const idx_t &rhs) {
+	std::stable_sort(partition_indices.begin(), partition_indices.end(), [&](const idx_t &lhs, const idx_t &rhs) {
 		const auto lhs_size = partitions[lhs]->SizeInBytes() + PointerTableSize(partitions[lhs]->Count());
 		const auto rhs_size = partitions[rhs]->SizeInBytes() + PointerTableSize(partitions[rhs]->Count());
+		// We divide by min_partition_size so that minor differences in partition sizes don't mess up the original order
+		// This "rounds" everything to a multiple of min_partition_size
 		return lhs_size < rhs_size;
+		// return lhs_size / min_partition_size < rhs_size / min_partition_size;
 	});
 
 	// Determine which partitions should go next

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1546,10 +1546,10 @@ bool JoinHashTable::PrepareExternalFinalize(const idx_t max_ht_size) {
 	std::stable_sort(partition_indices.begin(), partition_indices.end(), [&](const idx_t &lhs, const idx_t &rhs) {
 		const auto lhs_size = partitions[lhs]->SizeInBytes() + PointerTableSize(partitions[lhs]->Count());
 		const auto rhs_size = partitions[rhs]->SizeInBytes() + PointerTableSize(partitions[rhs]->Count());
-		// We divide by min_partition_size so that minor differences in partition sizes don't mess up the original order
-		// This "rounds" everything to a multiple of min_partition_size
-		return lhs_size < rhs_size;
-		// return lhs_size / min_partition_size < rhs_size / min_partition_size;
+		// We divide by min_partition_size, effectively rouding everything down to a multiple of min_partition_size
+		// Makes it so minor differences in partition sizes don't mess up the original order
+		// Retaining as much of the original order as possible reduces I/O (partition idx determines eviction queue idx)
+		return lhs_size / min_partition_size < rhs_size / min_partition_size;
 	});
 
 	// Determine which partitions should go next


### PR DESCRIPTION
Follow-up of #15389, which improved partition selection by choosing small partitions first.

An oversight of that PR was that completely relying on sizes to select partitions will shuffle the partition order even if there are tiny differences which we wouldn't really care about. This PR rounds the partition sizes down to a multiple of the smallest partition size before sorting and using a stable sort. This way, tiny differences in partition sizes don't affect the sort order, and we will retain the original order as much as possible.

I've added a benchmark file, but was not able to see a significant difference with and without the change. However, counted I/O calls and saw that read/writes were reduced by around 5%, so this should help more on machines with slower disks.