### PR TITLE
remove duplicate FastMem copies in binary

### DIFF
--- a/src/include/duckdb/common/fast_mem.hpp
+++ b/src/include/duckdb/common/fast_mem.hpp
@@ -11,17 +11,17 @@
 #include "duckdb/common/types.hpp"
 
 template <size_t SIZE>
-static inline void MemcpyFixed(void *dest, const void *src) {
+inline void MemcpyFixed(void *dest, const void *src) {
 	memcpy(dest, src, SIZE);
 }
 
 template <size_t SIZE>
-static inline int MemcmpFixed(const void *str1, const void *str2) {
+inline int MemcmpFixed(const void *str1, const void *str2) {
 	return memcmp(str1, str2, SIZE);
 }
 
 template <size_t SIZE>
-static inline void MemsetFixed(void *ptr, int value) {
+inline void MemsetFixed(void *ptr, int value) {
 	memset(ptr, value, SIZE);
 }
 
@@ -30,7 +30,7 @@ namespace duckdb {
 //! This templated memcpy is significantly faster than std::memcpy,
 //! but only when you are calling memcpy with a const size in a loop.
 //! For instance `while (<cond>) { memcpy(<dest>, <src>, const_size); ... }`
-static inline void FastMemcpy(void *dest, const void *src, const size_t size) {
+inline void FastMemcpy(void *dest, const void *src, const size_t size) {
 	// LCOV_EXCL_START
 	switch (size) {
 	case 0:
@@ -556,7 +556,7 @@ static inline void FastMemcpy(void *dest, const void *src, const size_t size) {
 //! This templated memcmp is significantly faster than std::memcmp,
 //! but only when you are calling memcmp with a const size in a loop.
 //! For instance `while (<cond>) { memcmp(<str1>, <str2>, const_size); ... }`
-static inline int FastMemcmp(const void *str1, const void *str2, const size_t size) {
+inline int FastMemcmp(const void *str1, const void *str2, const size_t size) {
 	// LCOV_EXCL_START
 	switch (size) {
 	case 0:
@@ -695,7 +695,7 @@ static inline int FastMemcmp(const void *str1, const void *str2, const size_t si
 	// LCOV_EXCL_STOP
 }
 
-static inline void FastMemset(void *ptr, int value, size_t size) {
+inline void FastMemset(void *ptr, int value, size_t size) {
 	// LCOV_EXCL_START
 	switch (size) {
 	case 0:


### PR DESCRIPTION
`FastMem` functions are marked with `static inline`. However `static` tellls compiler to generate one copy of function in every translation unit, and `FastMem` functions are too large to be inlined. So currently there are duplicate `FastMem` copies in duckdb's binary, even compiled with full LTO.

It can be checked by:
```
nm duckdb | grep FastMem 
0000000000f9a050 t _ZN6duckdbL10FastMemcmpEPKvS1_m
0000000001143d30 t _ZN6duckdbL10FastMemcmpEPKvS1_m
000000000129f4a0 t _ZN6duckdbL10FastMemcmpEPKvS1_m
0000000000f94800 t _ZN6duckdbL10FastMemcpyEPvPKvm
0000000000fb74d0 t _ZN6duckdbL10FastMemcpyEPvPKvm
0000000000fbccd0 t _ZN6duckdbL10FastMemsetEPvim
```

The better way is to use only `inline` instead. This slightly reduces binary size at about 30KB.

For more details, refer to [this Stack Overflow answer](https://stackoverflow.com/questions/12836171/difference-between-an-inline-function-and-static-inline-function). 