### PR TITLE
chore: Add physical type translations for new timestamp types

### DIFF
--- a/src/include/duckdb/common/type_util.hpp
+++ b/src/include/duckdb/common/type_util.hpp
@@ -48,6 +48,14 @@ PhysicalType GetTypeId() {
 		return PhysicalType::INT64;
 	} else if (std::is_same<T, timestamp_t>()) {
 		return PhysicalType::INT64;
+	} else if (std::is_same<T, timestamp_sec_t>()) {
+		return PhysicalType::INT64;
+	} else if (std::is_same<T, timestamp_ms_t>()) {
+		return PhysicalType::INT64;
+	} else if (std::is_same<T, timestamp_ns_t>()) {
+		return PhysicalType::INT64;
+	} else if (std::is_same<T, timestamp_tz_t>()) {
+		return PhysicalType::INT64;
 	} else if (std::is_same<T, float>()) {
 		return PhysicalType::FLOAT;
 	} else if (std::is_same<T, double>()) {


### PR DESCRIPTION
Follow-up to #14818.

This changes the error message in https://github.com/duckdb/duckdb-r/pull/716#discussion_r1897502922 from

```
Error: Not implemented Error: Unimplemented type for cast (INVALID -> INT64)
```

to the slightly more legible 

```
Error: Not implemented Error: Unimplemented type for cast (INT64 -> INT64)
```

I do wonder why this error message refers to physical types instead of logical types. Should the formatter be using a variant of `GetArgumentType()` instead of `GetTypeId()` ?