### PR TITLE
Implicit STRUCT to STRUCT cast for mismatching member names

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -988,6 +988,72 @@ static bool CombineUnequalTypes(const LogicalType &left, const LogicalType &righ
 }
 
 template <class OP>
+static bool CombineStructTypes(const LogicalType &left, const LogicalType &right, LogicalType &result) {
+	auto &left_children = StructType::GetChildTypes(left);
+	auto &right_children = StructType::GetChildTypes(right);
+
+	auto left_unnamed = StructType::IsUnnamed(left);
+	auto is_unnamed = left_unnamed || StructType::IsUnnamed(right);
+	child_list_t<LogicalType> child_types;
+
+	// At least one side is unnamed, so we attempt positional casting.
+	if (is_unnamed) {
+		if (left_children.size() != right_children.size()) {
+			// We can't cast, or create the super-set.
+			return false;
+		}
+
+		for (idx_t i = 0; i < left_children.size(); i++) {
+			LogicalType child_type;
+			if (!OP::Operation(left_children[i].second, right_children[i].second, child_type)) {
+				return false;
+			}
+			auto &child_name = left_unnamed ? right_children[i].first : left_children[i].first;
+			child_types.emplace_back(child_name, std::move(child_type));
+		}
+		result = LogicalType::STRUCT(child_types);
+		return true;
+	}
+
+	// Create a super-set of the STRUCT fields.
+	// First, create a name->index map of the right children.
+	case_insensitive_map_t<idx_t> right_children_map;
+	for (idx_t i = 0; i < right_children.size(); i++) {
+		auto &name = right_children[i].first;
+		right_children_map[name] = i;
+	}
+
+	for (idx_t i = 0; i < left_children.size(); i++) {
+		auto &left_child = left_children[i];
+		auto right_child_it = right_children_map.find(left_child.first);
+
+		if (right_child_it == right_children_map.end()) {
+			// We can directly put the left child.
+			child_types.emplace_back(left_child.first, left_child.second);
+			continue;
+		}
+
+		// We need to recurse to ensure the children have a maximum logical type.
+		LogicalType child_type;
+		auto &right_child = right_children[right_child_it->second];
+		if (!OP::Operation(left_child.second, right_child.second, child_type)) {
+			return false;
+		}
+		child_types.emplace_back(left_child.first, std::move(child_type));
+		right_children_map.erase(right_child_it);
+	}
+
+	// Add all remaining right children.
+	for (const auto &right_child_it : right_children_map) {
+		auto &right_child = right_children[right_child_it.second];
+		child_types.emplace_back(right_child.first, right_child.second);
+	}
+
+	result = LogicalType::STRUCT(child_types);
+	return true;
+}
+
+template <class OP>
 static bool CombineEqualTypes(const LogicalType &left, const LogicalType &right, LogicalType &result) {
 	// Since both left and right are equal we get the left type as our type_id for checks
 	auto type_id = left.id();
@@ -1058,31 +1124,7 @@ static bool CombineEqualTypes(const LogicalType &left, const LogicalType &right,
 		return true;
 	}
 	case LogicalTypeId::STRUCT: {
-		// struct: perform recursively on each child
-		auto &left_child_types = StructType::GetChildTypes(left);
-		auto &right_child_types = StructType::GetChildTypes(right);
-		bool left_unnamed = StructType::IsUnnamed(left);
-		auto any_unnamed = left_unnamed || StructType::IsUnnamed(right);
-		if (left_child_types.size() != right_child_types.size()) {
-			// child types are not of equal size, we can't cast
-			// return false
-			return false;
-		}
-		child_list_t<LogicalType> child_types;
-		for (idx_t i = 0; i < left_child_types.size(); i++) {
-			LogicalType child_type;
-			// Child names must be in the same order OR either one of the structs must be unnamed
-			if (!any_unnamed && !StringUtil::CIEquals(left_child_types[i].first, right_child_types[i].first)) {
-				return false;
-			}
-			if (!OP::Operation(left_child_types[i].second, right_child_types[i].second, child_type)) {
-				return false;
-			}
-			auto &child_name = left_unnamed ? right_child_types[i].first : left_child_types[i].first;
-			child_types.emplace_back(child_name, std::move(child_type));
-		}
-		result = LogicalType::STRUCT(child_types);
-		return true;
+		return CombineStructTypes<OP>(left, right, result);
 	}
 	case LogicalTypeId::UNION: {
 		auto left_member_count = UnionType::GetMemberCount(left);

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1374,10 +1374,10 @@ void Vector::Deserialize(Deserializer &deserializer, idx_t count) {
 }
 
 void Vector::SetVectorType(VectorType vector_type_p) {
-	this->vector_type = vector_type_p;
+	vector_type = vector_type_p;
 	auto physical_type = GetType().InternalType();
-	if (TypeIsConstantSize(physical_type) &&
-	    (GetVectorType() == VectorType::CONSTANT_VECTOR || GetVectorType() == VectorType::FLAT_VECTOR)) {
+	auto flat_or_const = GetVectorType() == VectorType::CONSTANT_VECTOR || GetVectorType() == VectorType::FLAT_VECTOR;
+	if (TypeIsConstantSize(physical_type) && flat_or_const) {
 		auxiliary.reset();
 	}
 	if (vector_type == VectorType::CONSTANT_VECTOR && physical_type == PhysicalType::STRUCT) {
@@ -1782,23 +1782,29 @@ void Vector::DebugShuffleNestedVector(Vector &vector, idx_t count) {
 void FlatVector::SetNull(Vector &vector, idx_t idx, bool is_null) {
 	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
 	vector.validity.Set(idx, !is_null);
-	if (is_null) {
-		auto &type = vector.GetType();
-		auto internal_type = type.InternalType();
-		if (internal_type == PhysicalType::STRUCT) {
-			// set all child entries to null as well
-			auto &entries = StructVector::GetEntries(vector);
-			for (auto &entry : entries) {
-				FlatVector::SetNull(*entry, idx, is_null);
-			}
-		} else if (internal_type == PhysicalType::ARRAY) {
-			// set the child element in the array to null as well
-			auto &child = ArrayVector::GetEntry(vector);
-			auto array_size = ArrayType::GetSize(type);
-			auto child_offset = idx * array_size;
-			for (idx_t i = 0; i < array_size; i++) {
-				FlatVector::SetNull(child, child_offset + i, is_null);
-			}
+	if (!is_null) {
+		return;
+	}
+
+	auto &type = vector.GetType();
+	auto internal_type = type.InternalType();
+
+	// Set all child entries to NULL.
+	if (internal_type == PhysicalType::STRUCT) {
+		auto &entries = StructVector::GetEntries(vector);
+		for (auto &entry : entries) {
+			FlatVector::SetNull(*entry, idx, is_null);
+		}
+		return;
+	}
+
+	// Set all child entries to NULL.
+	if (internal_type == PhysicalType::ARRAY) {
+		auto &child = ArrayVector::GetEntry(vector);
+		auto array_size = ArrayType::GetSize(type);
+		auto child_offset = idx * array_size;
+		for (idx_t i = 0; i < array_size; i++) {
+			FlatVector::SetNull(child, child_offset + i, is_null);
 		}
 	}
 }

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -1,4 +1,4 @@
-#include "duckdb/common/exception.hpp"
+#include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/function/cast/default_casts.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/function/cast/bound_cast_data.hpp"

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -7,51 +7,61 @@ namespace duckdb {
 unique_ptr<BoundCastData> StructBoundCastData::BindStructToStructCast(BindCastInput &input, const LogicalType &source,
                                                                       const LogicalType &target) {
 	vector<BoundCastInfo> child_cast_info;
-	auto &source_child_types = StructType::GetChildTypes(source);
-	auto &result_child_types = StructType::GetChildTypes(target);
+	auto &source_children = StructType::GetChildTypes(source);
+	auto &target_children = StructType::GetChildTypes(target);
 
 	auto target_is_unnamed = StructType::IsUnnamed(target);
 	auto source_is_unnamed = StructType::IsUnnamed(source);
 
-	if (source_child_types.size() != result_child_types.size()) {
+	auto is_unnamed = target_is_unnamed || source_is_unnamed;
+	if (is_unnamed && source_children.size() != target_children.size()) {
 		throw TypeMismatchException(input.query_location, source, target, "Cannot cast STRUCTs of different size");
 	}
-	bool named_struct_cast = !source_is_unnamed && !target_is_unnamed;
-	case_insensitive_map_t<idx_t> target_members;
-	if (named_struct_cast) {
-		for (idx_t i = 0; i < result_child_types.size(); i++) {
-			auto &target_name = result_child_types[i].first;
-			if (target_members.find(target_name) != target_members.end()) {
-				throw NotImplementedException("Error while casting - duplicate name \"%s\" in struct", target_name);
+
+	case_insensitive_map_t<idx_t> target_children_map;
+	if (!is_unnamed) {
+		for (idx_t i = 0; i < target_children.size(); i++) {
+			auto &name = target_children[i].first;
+			if (target_children_map.find(name) != target_children_map.end()) {
+				throw NotImplementedException("Error while casting - duplicate name \"%s\" in struct", name);
 			}
-			target_members[target_name] = i;
+			target_children_map[name] = i;
 		}
 	}
-	vector<idx_t> child_member_map;
-	child_member_map.reserve(source_child_types.size());
-	for (idx_t source_idx = 0; source_idx < source_child_types.size(); source_idx++) {
-		auto &source_child = source_child_types[source_idx];
-		idx_t target_idx;
-		if (named_struct_cast) {
-			// named struct cast - find corresponding member in target
-			auto entry = target_members.find(source_child.first);
-			if (entry == target_members.end()) {
-				throw TypeMismatchException(input.query_location, source, target,
-				                            "Cannot cast STRUCTs - element \"" + source_child.first +
-				                                "\" in source struct was not found in target struct");
+
+	vector<idx_t> source_indexes;
+	vector<idx_t> target_indexes;
+	vector<idx_t> target_null_indexes;
+
+	for (idx_t i = 0; i < source_children.size(); i++) {
+		auto &source_child = source_children[i];
+		auto target_idx = i;
+
+		// Map to the correct index for names structs.
+		if (!is_unnamed) {
+			auto target_child = target_children_map.find(source_child.first);
+			if (target_child == target_children_map.end()) {
+				// Skip any children that have no target.
+				continue;
 			}
-			target_idx = entry->second;
-			target_members.erase(entry);
-		} else {
-			// unnamed struct cast - positionally cast elements
-			target_idx = source_idx;
+			target_idx = target_child->second;
+			target_children_map.erase(target_child);
 		}
-		child_member_map.push_back(target_idx);
-		auto child_cast = input.GetCastFunction(source_child.second, result_child_types[target_idx].second);
+
+		source_indexes.push_back(i);
+		target_indexes.push_back(target_idx);
+		auto child_cast = input.GetCastFunction(source_child.second, target_children[target_idx].second);
 		child_cast_info.push_back(std::move(child_cast));
 	}
-	D_ASSERT(child_member_map.size() == source_child_types.size());
-	return make_uniq<StructBoundCastData>(std::move(child_cast_info), target, std::move(child_member_map));
+
+	// The remaining target children have no match in the source struct.
+	// Thus, they become NULL.
+	for (const auto &target_child : target_children_map) {
+		target_null_indexes.push_back(target_child.second);
+	}
+
+	return make_uniq<StructBoundCastData>(std::move(child_cast_info), target, std::move(source_indexes),
+	                                      std::move(target_indexes), std::move(target_null_indexes));
 }
 
 unique_ptr<FunctionLocalState> StructBoundCastData::InitStructCastLocalState(CastLocalStateParameters &parameters) {
@@ -71,32 +81,46 @@ unique_ptr<FunctionLocalState> StructBoundCastData::InitStructCastLocalState(Cas
 
 static bool StructToStructCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	auto &cast_data = parameters.cast_data->Cast<StructBoundCastData>();
-	auto &lstate = parameters.local_state->Cast<StructCastLocalState>();
-	auto &source_child_types = StructType::GetChildTypes(source.GetType());
-	auto &source_children = StructVector::GetEntries(source);
-	D_ASSERT(source_children.size() == StructType::GetChildTypes(result.GetType()).size());
+	auto &l_state = parameters.local_state->Cast<StructCastLocalState>();
 
-	auto &result_children = StructVector::GetEntries(result);
+	auto &source_vectors = StructVector::GetEntries(source);
+	auto &target_children = StructVector::GetEntries(result);
+
 	bool all_converted = true;
-	for (idx_t c_idx = 0; c_idx < source_child_types.size(); c_idx++) {
-		auto source_idx = c_idx;
-		auto target_idx = cast_data.child_member_map[source_idx];
-		auto &source_child_vector = *source_children[source_idx];
-		auto &result_child_vector = *result_children[target_idx];
-		CastParameters child_parameters(parameters, cast_data.child_cast_info[c_idx].cast_data,
-		                                lstate.local_states[c_idx]);
-		if (!cast_data.child_cast_info[c_idx].function(source_child_vector, result_child_vector, count,
-		                                               child_parameters)) {
+	for (idx_t i = 0; i < cast_data.source_indexes.size(); i++) {
+		auto source_idx = cast_data.source_indexes[i];
+		auto target_idx = cast_data.target_indexes[i];
+
+		auto &source_vector = *source_vectors[source_idx];
+		auto &target_vector = *target_children[target_idx];
+
+		auto &child_cast_info = cast_data.child_cast_info[i];
+		CastParameters child_parameters(parameters, child_cast_info.cast_data, l_state.local_states[i]);
+		auto success = child_cast_info.function(source_vector, target_vector, count, child_parameters);
+		if (!success) {
 			all_converted = false;
 		}
 	}
+
+	if (!cast_data.target_null_indexes.empty()) {
+		for (idx_t i = 0; i < cast_data.target_null_indexes.size(); i++) {
+			auto target_idx = cast_data.target_null_indexes[i];
+			auto &target_vector = *target_children[target_idx];
+
+			target_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(target_vector, true);
+		}
+	}
+
 	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
 		ConstantVector::SetNull(result, ConstantVector::IsNull(source));
-	} else {
-		source.Flatten(count);
-		FlatVector::Validity(result) = FlatVector::Validity(source);
+		return all_converted;
 	}
+
+	source.Flatten(count);
+	auto &result_validity = FlatVector::Validity(result);
+	result_validity = FlatVector::Validity(source);
 	return all_converted;
 }
 

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -32,6 +32,7 @@ unique_ptr<BoundCastData> StructBoundCastData::BindStructToStructCast(BindCastIn
 	vector<idx_t> source_indexes;
 	vector<idx_t> target_indexes;
 	vector<idx_t> target_null_indexes;
+	bool has_any_match = is_unnamed;
 
 	for (idx_t i = 0; i < source_children.size(); i++) {
 		auto &source_child = source_children[i];
@@ -46,12 +47,17 @@ unique_ptr<BoundCastData> StructBoundCastData::BindStructToStructCast(BindCastIn
 			}
 			target_idx = target_child->second;
 			target_children_map.erase(target_child);
+			has_any_match = true;
 		}
 
 		source_indexes.push_back(i);
 		target_indexes.push_back(target_idx);
 		auto child_cast = input.GetCastFunction(source_child.second, target_children[target_idx].second);
 		child_cast_info.push_back(std::move(child_cast));
+	}
+
+	if (!has_any_match) {
+		throw BinderException("STRUCT to STRUCT cast must have at least one matching member");
 	}
 
 	// The remaining target children have no match in the source struct.

--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/exception.hpp"
 #include "duckdb/function/cast/default_casts.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/function/cast/bound_cast_data.hpp"

--- a/src/include/duckdb/function/cast/bound_cast_data.hpp
+++ b/src/include/duckdb/function/cast/bound_cast_data.hpp
@@ -48,21 +48,27 @@ struct ListCast {
 };
 
 struct StructBoundCastData : public BoundCastData {
-	StructBoundCastData(vector<BoundCastInfo> child_casts, LogicalType target_p, vector<idx_t> child_member_map_p)
+	StructBoundCastData(vector<BoundCastInfo> child_casts, LogicalType target_p, vector<idx_t> source_indexes_p,
+	                    vector<idx_t> target_indexes_p, vector<idx_t> target_null_indexes_p)
 	    : child_cast_info(std::move(child_casts)), target(std::move(target_p)),
-	      child_member_map(std::move(child_member_map_p)) {
-		D_ASSERT(child_cast_info.size() == child_member_map.size());
+	      source_indexes(std::move(source_indexes_p)), target_indexes(std::move(target_indexes_p)),
+	      target_null_indexes(std::move(target_null_indexes_p)) {
+		D_ASSERT(child_cast_info.size() == source_indexes.size());
+		D_ASSERT(source_indexes.size() == target_indexes.size());
 	}
 	StructBoundCastData(vector<BoundCastInfo> child_casts, LogicalType target_p)
 	    : child_cast_info(std::move(child_casts)), target(std::move(target_p)) {
 		for (idx_t i = 0; i < child_cast_info.size(); i++) {
-			child_member_map.push_back(i);
+			source_indexes.push_back(i);
+			target_indexes.push_back(i);
 		}
 	}
 
 	vector<BoundCastInfo> child_cast_info;
 	LogicalType target;
-	vector<idx_t> child_member_map;
+	vector<idx_t> source_indexes;
+	vector<idx_t> target_indexes;
+	vector<idx_t> target_null_indexes;
 
 	static unique_ptr<BoundCastData> BindStructToStructCast(BindCastInput &input, const LogicalType &source,
 	                                                        const LogicalType &target);
@@ -74,7 +80,8 @@ public:
 		for (auto &info : child_cast_info) {
 			copy_info.push_back(info.Copy());
 		}
-		return make_uniq<StructBoundCastData>(std::move(copy_info), target, child_member_map);
+		return make_uniq<StructBoundCastData>(std::move(copy_info), target, source_indexes, target_indexes,
+		                                      target_null_indexes);
 	}
 };
 

--- a/test/common/test_cast_struct.test
+++ b/test/common/test_cast_struct.test
@@ -5,55 +5,55 @@
 statement ok
 PRAGMA enable_verification
 
-query I
+statement error
 SELECT struct_pack(b => 42)::STRUCT(a INT);
 ----
-{'a': NULL}
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
-query I
+statement error
 SELECT struct_extract(struct_pack(b => 42)::STRUCT(a INT), 'a');
 ----
-NULL
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
 query I
 SELECT struct_extract(struct_pack(a => 42)::STRUCT(a STRING), 'a');
 ----
 42
 
-query I
+statement error
 SELECT struct_extract(struct_pack(b => 42)::ROW(a INT), 'a');
 ----
-NULL
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
 query I
 SELECT struct_extract(struct_pack(a => 42)::ROW(a INT), 'a');
 ----
 42
 
-query I
+statement error
 SELECT struct_extract(struct_pack(b => 42::DOUBLE)::STRUCT(a INT), 'a');
 ----
-NULL
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
 query I
 SELECT struct_extract(struct_pack(a => 42::DOUBLE)::STRUCT(a INT), 'a');
 ----
 42
 
-query I
+statement error
 SELECT struct_extract(struct_pack(b => '42'::DOUBLE)::STRUCT(a INT), 'a');
 ----
-NULL
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
 query I
 SELECT struct_extract(struct_pack(a => '42'::DOUBLE)::STRUCT(a INT), 'a');
 ----
 42
 
-query I
+statement error
 SELECT struct_pack(b => '42'::DOUBLE)::STRUCT(a INT, c STRING)
 ----
-{'a': NULL, 'c': NULL}
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
 statement error
 SELECT struct_pack(b => 'hello'::STRING)::STRUCT(b INT)
@@ -75,15 +75,15 @@ SELECT struct_pack(a => struct_pack(b => 42)::STRUCT(b INT))::STRUCT(a INT)
 ----
 Unimplemented type for cast (STRUCT(b INTEGER) -> INTEGER)
 
-query I
+statement error
 SELECT struct_pack(b => 'hello'::STRING)::STRUCT(a INT)
 ----
-{'a': NULL}
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
-query I
+statement error
 SELECT struct_pack(b => '42'::DOUBLE, c => 'asdf'::STRING)::STRUCT(a1 INT, a2 STRING);
 ----
-{'a1': NULL, 'a2': NULL}
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
 query I
 SELECT struct_pack(a1 => '42'::DOUBLE, a2 => 'asdf'::STRING)::STRUCT(a1 INT, a2 STRING);

--- a/test/common/test_cast_struct.test
+++ b/test/common/test_cast_struct.test
@@ -5,106 +5,108 @@
 statement ok
 PRAGMA enable_verification
 
-# struct to struct casts with different names doesn't work
-statement error
-select struct_extract(struct_pack(b=>42)::struct(a integer), 'a');
+query I
+SELECT struct_pack(b => 42)::STRUCT(a INT);
 ----
-element "b" in source struct was not found in target struct
+{'a': NULL}
 
 query I
-select struct_extract(struct_pack(a=>42)::struct(a string), 'a');
+SELECT struct_extract(struct_pack(b => 42)::STRUCT(a INT), 'a');
+----
+NULL
+
+query I
+SELECT struct_extract(struct_pack(a => 42)::STRUCT(a STRING), 'a');
 ----
 42
 
-# this all also doesn't works with the row type
-statement error
-select struct_extract(struct_pack(b=>42)::row(a integer), 'a');
+query I
+SELECT struct_extract(struct_pack(b => 42)::ROW(a INT), 'a');
 ----
-element "b" in source struct was not found in target struct
+NULL
 
 query I
-select struct_extract(struct_pack(a=>42)::row(a integer), 'a');
+SELECT struct_extract(struct_pack(a => 42)::ROW(a INT), 'a');
 ----
 42
 
-# struct to struct casts with different names AND different types
-statement error
-select struct_extract(struct_pack(b=>42::double)::struct(a integer), 'a');
+query I
+SELECT struct_extract(struct_pack(b => 42::DOUBLE)::STRUCT(a INT), 'a');
 ----
-element "b" in source struct was not found in target struct
+NULL
 
 query I
-select struct_extract(struct_pack(a=>42::double)::struct(a integer), 'a');
+SELECT struct_extract(struct_pack(a => 42::DOUBLE)::STRUCT(a INT), 'a');
 ----
 42
 
-statement error
-select struct_extract(struct_pack(b=>'42'::double)::struct(a integer), 'a');
+query I
+SELECT struct_extract(struct_pack(b => '42'::DOUBLE)::STRUCT(a INT), 'a');
 ----
-element "b" in source struct was not found in target struct
+NULL
 
 query I
-select struct_extract(struct_pack(a=>'42'::double)::struct(a integer), 'a');
+SELECT struct_extract(struct_pack(a => '42'::DOUBLE)::STRUCT(a INT), 'a');
 ----
 42
 
-statement error
-select struct_pack(b=>'42'::double)::struct(a integer, c string)
+query I
+SELECT struct_pack(b => '42'::DOUBLE)::STRUCT(a INT, c STRING)
 ----
-Type STRUCT(b DOUBLE) does not match with STRUCT(a INTEGER, c VARCHAR). Cannot cast STRUCTs of different size
+{'a': NULL, 'c': NULL}
 
 statement error
-select struct_pack(b=>'hello'::string)::struct(b integer)
+SELECT struct_pack(b => 'hello'::STRING)::STRUCT(b INT)
 ----
 Could not convert string 'hello' to INT32
 
 statement error
-select struct_pack(a=>'hello'::string, b=>'world'::string)::struct(a string, b integer)
+SELECT struct_pack(a => 'hello'::STRING, b => 'world'::STRING)::STRUCT(a STRING, b INT)
 ----
 Could not convert string 'world' to INT32
 
 statement error
-select struct_pack(a=>[1,2,3])::struct(a integer)
+SELECT struct_pack(a => [1, 2, 3])::STRUCT(a INT)
 ----
 Unimplemented type for cast (INTEGER[] -> INTEGER)
 
 statement error
-select struct_pack(a=>struct_pack(b=>42)::struct(b integer))::struct(a integer)
+SELECT struct_pack(a => struct_pack(b => 42)::STRUCT(b INT))::STRUCT(a INT)
 ----
 Unimplemented type for cast (STRUCT(b INTEGER) -> INTEGER)
 
-statement error
-select struct_pack(b=>'hello'::string)::struct(a integer)
+query I
+SELECT struct_pack(b => 'hello'::STRING)::STRUCT(a INT)
 ----
-element "b" in source struct was not found in target struct
-
-statement error
-select struct_pack(b=>'42'::double, c => 'asdf'::string)::struct(a1 integer, a2 string);
-----
-element "b" in source struct was not found in target struct
+{'a': NULL}
 
 query I
-select struct_pack(a1 =>'42'::double, a2 => 'asdf'::string)::struct(a1 integer, a2 string);
+SELECT struct_pack(b => '42'::DOUBLE, c => 'asdf'::STRING)::STRUCT(a1 INT, a2 STRING);
+----
+{'a1': NULL, 'a2': NULL}
+
+query I
+SELECT struct_pack(a1 => '42'::DOUBLE, a2 => 'asdf'::STRING)::STRUCT(a1 INT, a2 STRING);
 ----
 {'a1': 42, 'a2': asdf}
 
 query I
-select ROW(42, 'asdf');
+SELECT ROW(42, 'asdf');
 ----
 (42, asdf)
 
 statement error
-select ROW();
+SELECT ROW();
 ----
-Can't pack nothing into a struct
+pack nothing into a struct
 
 query I
-select ROW(NULL);
+SELECT ROW(NULL);
 ----
 (NULL)
 
 query I
-select ROW(NULL, NULL);
+SELECT ROW(NULL, NULL);
 ----
 (NULL, NULL)
 
@@ -115,51 +117,52 @@ SELECT CAST(ROW(1, 2) AS ROW(a INTEGER, b INTEGER))
 {'a': 1, 'b': 2}
 
 query I
-select a::row(a integer, b string) r from (VALUES (ROW(1, 'asdf')), (ROW(4, 'fdsa'))) s(a);
+SELECT a::ROW(a INT, b STRING) r FROM (VALUES (ROW(1, 'asdf')), (ROW(4, 'fdsa'))) s(a);
 ----
 {'a': 1, 'b': asdf}
 {'a': 4, 'b': fdsa}
 
 statement error
-select struct_extract({'a': a}, a) from (select a::varchar as a from range(10) tbl(a));
+SELECT struct_extract({'a': a}, a) FROM (SELECT a::VARCHAR AS a FROM range(10) tbl(a));
 ----
 Key name for struct_extract needs to be a constant string
 
 statement error
-select struct_extract({'a': 42}, 42)
+SELECT struct_extract({'a': 42}, 42)
 ----
 can only be used on unnamed structs
 
 query I
-select struct_extract_at({'a': 42}, 1)
+SELECT struct_extract_at({'a': 42}, 1)
 ----
 42
 
 statement error
-select struct_extract_at({'a': 42}, 0)
+SELECT struct_extract_at({'a': 42}, 0)
 ----
 out of range
 
 statement error
-select struct_extract_at({'a': 42}, 42)
+SELECT struct_extract_at({'a': 42}, 42)
 ----
 out of range
 
-
-# test string to struct within struct casting
+# Test string to struct cast within struct casting.
 query I
-SELECT {a:{b:'{a:3, b: "Hello World"}'}}::STRUCT(a STRUCT(b STRUCT(a INT, b VARCHAR)));
+SELECT {a: {b: '{a: 3, b: "Hello World"}'}}::STRUCT(a STRUCT(b STRUCT(a INT, b VARCHAR)));
 ----
 {'a': {'b': {'a': 3, 'b': Hello World}}}
 
-# test if try_cast continues after encountering error
+# Test if try_cast continues after encountering error.
 query I 
-SELECT TRY_CAST(struct_pack(a=>4, b=> 'Ducky', c=>'1964-06-15') AS STRUCT(a INT, b DOUBLE, c DATE));
+SELECT TRY_CAST(struct_pack(a => 4, b => 'Ducky', c => '1964-06-15')
+AS STRUCT(a INT, b DOUBLE, c DATE));
 ----
 {'a': 4, 'b': NULL, 'c': 1964-06-15}
 
 query I 
-SELECT TRY_CAST(struct_pack(a=>4, b=> 'Ducky', c=>'Tommorow', d=>{a:3.0}) AS STRUCT(a VARCHAR[], b VARCHAR, c DATE, d STRUCT(a INT)));
+SELECT TRY_CAST(struct_pack(a => 4, b => 'Ducky', c => 'Tommorow', d => {a:3.0})
+AS STRUCT(a VARCHAR[], b VARCHAR, c DATE, d STRUCT(a INT)));
 ----
 {'a': NULL, 'b': Ducky, 'c': NULL, 'd': {'a': 3}}
 

--- a/test/sql/cast/cast_error_location.test
+++ b/test/sql/cast/cast_error_location.test
@@ -137,11 +137,10 @@ SELECT l::utinyint[] FROM cast_table
 ----
 ^
 
-# struct cast
-statement error
-SELECT int_struct::row(x tinyint) FROM cast_table
+query I
+SELECT int_struct::ROW(x TINYINT) FROM cast_table
 ----
-^
+{'x': NULL}
 
 # double -> float
 statement error

--- a/test/sql/cast/cast_error_location.test
+++ b/test/sql/cast/cast_error_location.test
@@ -137,12 +137,13 @@ SELECT l::utinyint[] FROM cast_table
 ----
 ^
 
-query I
+statement error
 SELECT int_struct::ROW(x TINYINT) FROM cast_table
 ----
-{'x': NULL}
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
-# double -> float
+# DOUBLE to FLOAT cast.
+
 statement error
 select dbl::float FROM cast_table
 ----

--- a/test/sql/setops/test_union_by_name.test
+++ b/test/sql/setops/test_union_by_name.test
@@ -168,11 +168,16 @@ select {'a': '0'} as c union all by name select {'a': 0} as c
 query I
 SELECT {'a': 'hello'} AS c UNION ALL BY NAME SELECT {'b': 'hello'} AS c;
 ----
-{'a': hello}
-{'a': NULL}
+{'a': hello, 'b': NULL}
+{'a': NULL, 'b': hello}
 
 query I
 SELECT {'a': 'hello'} AS c UNION ALL BY NAME SELECT {'a': 'hello', 'b': 'world'} AS c;
 ----
-{'a': hello}
-{'a': hello}
+{'a': hello, 'b': NULL}
+{'a': hello, 'b': world}
+
+query I
+SELECT [{'a': 42}, {'b': 84}];
+----
+[{'a': 42, 'b': NULL}, {'a': NULL, 'b': 84}]

--- a/test/sql/setops/test_union_by_name.test
+++ b/test/sql/setops/test_union_by_name.test
@@ -165,12 +165,14 @@ select {'a': '0'} as c union all by name select {'a': 0} as c
 {'a': 0}
 {'a': 0}
 
-statement error
-select {'a': 'hello'} as c union all by name select {'b': 'hello'} as c;
+query I
+SELECT {'a': 'hello'} AS c UNION ALL BY NAME SELECT {'b': 'hello'} AS c;
 ----
-<REGEX>:Mismatch Type Error.*Type STRUCT\(b VARCHAR\) does not match with STRUCT\(a VARCHAR\).*
+{'a': hello}
+{'a': NULL}
 
-statement error
-select {'a': 'hello'} as c union all by name select {'a': 'hello', 'b': 'world'} as c;
+query I
+SELECT {'a': 'hello'} AS c UNION ALL BY NAME SELECT {'a': 'hello', 'b': 'world'} AS c;
 ----
-<REGEX>:Mismatch Type Error.*Type STRUCT\(a VARCHAR, b VARCHAR\).*with STRUCT\(a VARCHAR\).*
+{'a': hello}
+{'a': hello}

--- a/test/sql/types/struct/struct_cast.test
+++ b/test/sql/types/struct/struct_cast.test
@@ -152,3 +152,20 @@ AS tab(col)
 {'duck': NULL}
 {'duck': NULL}
 {'duck': NULL}
+
+# Allow missing / additional STRUCT fields.
+
+query I
+SELECT {'i': 42, 'j': 84}::STRUCT(i INT) AS result;
+----
+{'i': 42}
+
+query I
+SELECT {'i': 42}::STRUCT(i INT, j INT) AS result;
+----
+{'i': 42, 'j': NULL}
+
+query I
+SELECT {'a': 7, 'i': 42, 'j': 84, 'k': 42}::STRUCT(m INT, k INT, l INT) AS result;
+----
+{'m': NULL, 'k': 42, 'l': NULL}

--- a/test/sql/types/struct/struct_different_names.test
+++ b/test/sql/types/struct/struct_different_names.test
@@ -14,10 +14,8 @@ INSERT INTO t1 VALUES (ROW(NULL));
 statement ok
 CREATE TABLE foo (bar struct(pip int));
 
-statement error
+statement ok
 INSERT INTO foo VALUES ({'ignoreme': 3});
-----
-element "ignoreme" in source struct was not found in target struct
 
 statement error
 create table wrong as from (VALUES (ROW(3)));
@@ -28,9 +26,10 @@ statement ok
 INSERT INTO foo VALUES (ROW(42));
 
 query I
-SELECT * FROM foo;
+SELECT bar FROM foo ORDER BY ALL;
 ----
 {'pip': 42}
+{'pip': NULL}
 
 statement ok
 CREATE OR REPLACE TABLE T AS SELECT [{'a': 'A', 'b':'B'}] as x, [{'b':'BB','a':'AA'}] as y;
@@ -40,18 +39,26 @@ SELECT x, y, ARRAY_CONCAT(x, y) FROM T;
 ----
 an explicit cast is required
 
-statement error
+statement ok
 INSERT INTO t1 VALUES ({c: 34});
+
+query I
+SELECT s FROM t1 ORDER BY ALL;
 ----
-element "c" in source struct was not found in target struct
+{'v': NULL}
+{'v': NULL}
 
 statement ok
 CREATE OR REPLACE TABLE T (s STRUCT(a INT, b INT));
 
-statement error
+statement ok
 INSERT INTO T VALUES ({l: 1, m: 2}), ({x: 3, y: 4});
+
+query I
+SELECT s FROM T ORDER BY ALL;
 ----
-element "l" in source struct was not found in target struct
+{'a': NULL, 'b': NULL}
+{'a': NULL, 'b': NULL}
 
 # Can insert unnamed struct into named struct
 

--- a/test/sql/types/struct/struct_different_names.test
+++ b/test/sql/types/struct/struct_different_names.test
@@ -5,22 +5,34 @@
 statement ok
 PRAGMA enable_verification
 
+statement error
+CREATE TABLE wrong AS FROM (VALUES (ROW(3)));
+----
+<REGEX>:Invalid Input Error.*A table cannot be created from an unnamed struct.*
+
 statement ok
 CREATE TABLE t1 (s STRUCT(v VARCHAR)); 
 
 statement ok
 INSERT INTO t1 VALUES (ROW(NULL));
 
+statement error
+INSERT INTO t1 VALUES ({c: 34});
+----
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
+
+query I
+SELECT s FROM t1 ORDER BY ALL;
+----
+{'v': NULL}
+
 statement ok
 CREATE TABLE foo (bar struct(pip int));
 
-statement ok
-INSERT INTO foo VALUES ({'ignoreme': 3});
-
 statement error
-create table wrong as from (VALUES (ROW(3)));
+INSERT INTO foo VALUES ({'ignoreme': 3});
 ----
-Invalid Input Error: A table cannot be created from an unnamed struct
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
 statement ok
 INSERT INTO foo VALUES (ROW(42));
@@ -29,63 +41,52 @@ query I
 SELECT bar FROM foo ORDER BY ALL;
 ----
 {'pip': 42}
-{'pip': NULL}
 
 statement ok
-CREATE OR REPLACE TABLE T AS SELECT [{'a': 'A', 'b':'B'}] as x, [{'b':'BB','a':'AA'}] as y;
+CREATE OR REPLACE TABLE T AS SELECT [{'a': 'A', 'b':'B'}] AS x, [{'b':'BB','a':'AA'}] AS y;
 
-statement error
+query III
 SELECT x, y, ARRAY_CONCAT(x, y) FROM T;
 ----
-an explicit cast is required
-
-statement ok
-INSERT INTO t1 VALUES ({c: 34});
-
-query I
-SELECT s FROM t1 ORDER BY ALL;
-----
-{'v': NULL}
-{'v': NULL}
+[{'a': A, 'b': B}]	[{'b': BB, 'a': AA}]	[{'a': A, 'b': B}, {'a': AA, 'b': BB}]
 
 statement ok
 CREATE OR REPLACE TABLE T (s STRUCT(a INT, b INT));
 
-statement ok
+statement error
 INSERT INTO T VALUES ({l: 1, m: 2}), ({x: 3, y: 4});
+----
+<REGEX>:Binder Error.*STRUCT to STRUCT cast must have at least one matching member.*
 
 query I
 SELECT s FROM T ORDER BY ALL;
 ----
-{'a': NULL, 'b': NULL}
-{'a': NULL, 'b': NULL}
 
-# Can insert unnamed struct into named struct
+# Can insert an unnamed STRUCT into a named STRUCT.
 
 statement ok
-create table tbl (a STRUCT(a int, b varchar));
+CREATE TABLE tbl (a STRUCT(a INT, b VARCHAR));
 
 statement ok
-insert into tbl VALUES(ROW(5, 'hello'));
+INSERT INTO tbl VALUES (ROW(5, 'hello'));
 
-# Can insert named struct into unnamed struct
 statement error
-create table tbl2 as select ROW(42, 'world') a;
+CREATE TABLE tbl2 AS SELECT ROW(42, 'world') a;
 ----
-Invalid Input Error: A table cannot be created from an unnamed struct
+<REGEX>:Invalid Input Error.*A table cannot be created from an unnamed struct.*
 
-statement error
+query I
 SELECT [{'foo': True}, {'bar': False}, {'foobar': NULL}];
 ----
-an explicit cast is required
+[{'foo': true, 'bar': NULL, 'foobar': NULL}, {'foo': NULL, 'bar': false, 'foobar': NULL}, {'foo': NULL, 'bar': NULL, 'foobar': NULL}]
 
-statement error
-select [(13,24), {'a': 42, 'b': 84}, (43, 85), {'b':10, 'a':123123}] as res;
+query I
+select [(13, 24), {'a': 42, 'b': 84}, (43, 85), {'b': 10, 'a': 123123}] AS res;
 ----
-an explicit cast is required
+[{'a': 13, 'b': 24}, {'a': 42, 'b': 84}, {'a': 43, 'b': 85}, {'a': 123123, 'b': 10}]
 
 statement ok
-PREPARE v1 as SELECT ROW(?);
+PREPARE v1 AS SELECT ROW(?);
 
 statement ok
 EXECUTE v1(42);

--- a/test/sql/types/struct/struct_named_cast.test
+++ b/test/sql/types/struct/struct_named_cast.test
@@ -22,11 +22,10 @@ SELECT {'a': ['1', '2', '3'], 'b': 84}::STRUCT(b INT, A INT[])
 ----
 {'b': 84, 'A': [1, 2, 3]}
 
-# name mismatch
-statement error
+query I
 SELECT {'a': ['1', '2', '3'], 'b': 84}::STRUCT(b INT, c INT[])
 ----
-element "a" in source struct was not found in target struct
+{'b': 84, 'c': NULL}
 
 # unnamed struct cast
 query I


### PR DESCRIPTION
This PR adds support for implicit casts between STRUCTs with mismatching member names.

```sql
CREATE TABLE lists2 (l2 STRUCT(str VARCHAR, i INTEGER));
INSERT INTO lists2 VALUES({str: 'abc'});
```

```sql
SELECT {'i': 42, 'j': 84}::STRUCT(i INT) AS result;
┌───────────────────┐
│      result       │
│ struct(i integer) │
├───────────────────┤
│ {'i': 42}         │
└───────────────────┘
SELECT {'i': 42}::STRUCT(i INT, j INT) AS result;
┌──────────────────────────────┐
│            result            │
│ struct(i integer, j integer) │
├──────────────────────────────┤
│ {'i': 42, 'j': NULL}         │
└──────────────────────────────┘
```