### PR TITLE
Fix #15466 Transform LIMIT or OFFSET first based on order specified in prepared statement

### DIFF
--- a/src/parser/transform/statement/transform_select_node.cpp
+++ b/src/parser/transform/statement/transform_select_node.cpp
@@ -31,11 +31,20 @@ void Transformer::TransformModifiers(duckdb_libpgquery::PGSelectStmt &stmt, Quer
 			node.modifiers.push_back(std::move(limit_percent_modifier));
 		} else {
 			auto limit_modifier = make_uniq<LimitModifier>();
-			if (stmt.limitCount) {
-				limit_modifier->limit = TransformExpression(stmt.limitCount);
-			}
-			if (stmt.limitOffset) {
-				limit_modifier->offset = TransformExpression(stmt.limitOffset);
+			if (stmt.offset_first) {
+				if (stmt.limitOffset) {
+					limit_modifier->offset = TransformExpression(stmt.limitOffset);
+				}
+				if (stmt.limitCount) {
+					limit_modifier->limit = TransformExpression(stmt.limitCount);
+				}
+			} else {
+				if (stmt.limitCount) {
+					limit_modifier->limit = TransformExpression(stmt.limitCount);
+				}
+				if (stmt.limitOffset) {
+					limit_modifier->offset = TransformExpression(stmt.limitOffset);
+				}
 			}
 			node.modifiers.push_back(std::move(limit_modifier));
 		}

--- a/test/sql/prepared/prepare_offset_first.test
+++ b/test/sql/prepared/prepare_offset_first.test
@@ -1,0 +1,30 @@
+# name: test/sql/prepared/prepare_offset_first.test
+# description: Test OFFSET and LIMIT with prepared statements
+# group: [prepared]
+
+statement ok
+pragma enable_verification
+
+# Prepare a query with OFFSET and LIMIT as parameters with OFFSET written first in the query
+statement ok
+PREPARE q AS SELECT x FROM generate_series(1, 10) t(x) OFFSET ? LIMIT ?;
+
+# Execute the prepared query with OFFSET = 3 and LIMIT = 5
+query I
+EXECUTE q(3, 5);
+----
+4
+5
+6
+7
+8
+
+# Verify the result matches the direct query
+query I
+SELECT x FROM generate_series(1, 10) t(x) OFFSET 3 LIMIT 5;
+----
+4
+5
+6
+7
+8

--- a/third_party/libpg_query/grammar/grammar.cpp
+++ b/third_party/libpg_query/grammar/grammar.cpp
@@ -366,7 +366,7 @@ static PGNode* makeNamedParamRef(char *name, int location)
 static void
 insertSelectOptions(PGSelectStmt *stmt,
 					PGList *sortClause, PGList *lockingClause,
-					PGNode *limitOffset, PGNode *limitCount,
+					PGNode *limitOffset, PGNode *limitCount, PGNode *isLimitOffsetFirst,
 					PGWithClause *withClause,
 					core_yyscan_t yyscanner)
 {
@@ -410,6 +410,9 @@ insertSelectOptions(PGSelectStmt *stmt,
 					 errmsg("multiple LIMIT clauses not allowed"),
 					 parser_errposition(exprLocation(limitCount))));
 		stmt->limitCount = limitCount;
+	}
+	if (limitOffset == isLimitOffsetFirst) {
+		stmt->offset_first = true;
 	}
 	if (withClause)
 	{

--- a/third_party/libpg_query/grammar/grammar.hpp
+++ b/third_party/libpg_query/grammar/grammar.hpp
@@ -197,7 +197,7 @@ static PGList *check_func_name(PGList *names, core_yyscan_t yyscanner);
 static PGList *check_indirection(PGList *indirection, core_yyscan_t yyscanner);
 static void insertSelectOptions(PGSelectStmt *stmt,
 								PGList *sortClause, PGList *lockingClause,
-								PGNode *limitOffset, PGNode *limitCount,
+								PGNode *limitOffset, PGNode *limitCount, PGNode *isLimitOffsetFirst,
 								PGWithClause *withClause,
 								core_yyscan_t yyscanner);
 static PGNode *makeSetOp(PGSetOperation op, bool all, PGNode *larg, PGNode *rarg);

--- a/third_party/libpg_query/grammar/statements/select.y
+++ b/third_party/libpg_query/grammar/statements/select.y
@@ -73,14 +73,14 @@ select_no_parens:
 			| select_clause sort_clause
 				{
 					insertSelectOptions((PGSelectStmt *) $1, $2, NIL,
-										NULL, NULL, NULL,
+										NULL, NULL, NULL, NULL,
 										yyscanner);
 					$$ = $1;
 				}
 			| select_clause opt_sort_clause for_locking_clause opt_select_limit
 				{
 					insertSelectOptions((PGSelectStmt *) $1, $2, $3,
-										(PGNode*) list_nth($4, 0), (PGNode*) list_nth($4, 1),
+										(PGNode*) list_nth($4, 0), (PGNode*) list_nth($4, 1), (PGNode*) list_nth($4, 2),
 										NULL,
 										yyscanner);
 					$$ = $1;
@@ -88,7 +88,7 @@ select_no_parens:
 			| select_clause opt_sort_clause select_limit opt_for_locking_clause
 				{
 					insertSelectOptions((PGSelectStmt *) $1, $2, $4,
-										(PGNode*) list_nth($3, 0), (PGNode*) list_nth($3, 1),
+										(PGNode*) list_nth($3, 0), (PGNode*) list_nth($3, 1), (PGNode*) list_nth($3, 2),
 										NULL,
 										yyscanner);
 					$$ = $1;
@@ -96,7 +96,7 @@ select_no_parens:
 			| with_clause select_clause
 				{
 					insertSelectOptions((PGSelectStmt *) $2, NULL, NIL,
-										NULL, NULL,
+										NULL, NULL, NULL,
 										$1,
 										yyscanner);
 					$$ = $2;
@@ -104,7 +104,7 @@ select_no_parens:
 			| with_clause select_clause sort_clause
 				{
 					insertSelectOptions((PGSelectStmt *) $2, $3, NIL,
-										NULL, NULL,
+										NULL, NULL, NULL,
 										$1,
 										yyscanner);
 					$$ = $2;
@@ -112,7 +112,7 @@ select_no_parens:
 			| with_clause select_clause opt_sort_clause for_locking_clause opt_select_limit
 				{
 					insertSelectOptions((PGSelectStmt *) $2, $3, $4,
-										(PGNode*) list_nth($5, 0), (PGNode*) list_nth($5, 1),
+										(PGNode*) list_nth($5, 0), (PGNode*) list_nth($5, 1), (PGNode*) list_nth($5, 2),
 										$1,
 										yyscanner);
 					$$ = $2;
@@ -120,7 +120,7 @@ select_no_parens:
 			| with_clause select_clause opt_sort_clause select_limit opt_for_locking_clause
 				{
 					insertSelectOptions((PGSelectStmt *) $2, $3, $5,
-										(PGNode*) list_nth($4, 0), (PGNode*) list_nth($4, 1),
+										(PGNode*) list_nth($4, 0), (PGNode*) list_nth($4, 1), (PGNode*) list_nth($4, 2),
 										$1,
 										yyscanner);
 					$$ = $2;
@@ -640,15 +640,15 @@ opt_nulls_order: NULLS_LA FIRST_P			{ $$ = PG_SORTBY_NULLS_FIRST; }
 		;
 
 select_limit:
-			limit_clause offset_clause			{ $$ = list_make2($2, $1); }
-			| offset_clause limit_clause		{ $$ = list_make2($1, $2); }
-			| limit_clause						{ $$ = list_make2(NULL, $1); }
-			| offset_clause						{ $$ = list_make2($1, NULL); }
+			limit_clause offset_clause			{ $$ = list_make3($2, $1, NULL); }
+			| offset_clause limit_clause		{ $$ = list_make3($1, $2, $1); }
+			| limit_clause						{ $$ = list_make3(NULL, $1, NULL); }
+			| offset_clause						{ $$ = list_make3($1, NULL, $1); }
 		;
 
 opt_select_limit:
 			select_limit						{ $$ = $1; }
-			| /* EMPTY */						{ $$ = list_make2(NULL,NULL); }
+			| /* EMPTY */						{ $$ = list_make3(NULL,NULL,NULL); }
 		;
 
 limit_clause:

--- a/third_party/libpg_query/include/nodes/parsenodes.hpp
+++ b/third_party/libpg_query/include/nodes/parsenodes.hpp
@@ -1289,6 +1289,7 @@ typedef struct PGSelectStmt {
 	PGSetOperation op;         /* type of set op */
 	bool all;                  /* ALL specified? */
 	bool from_first;           /* FROM first or SELECT first */
+	bool offset_first;         /* OFFSET first or LIMIT first */
 	struct PGNode *larg; /* left child */
 	struct PGNode *rarg; /* right child */
 	                           /* Eventually add fields for CORRESPONDING spec here */

--- a/third_party/libpg_query/src_backend_parser_gram.cpp
+++ b/third_party/libpg_query/src_backend_parser_gram.cpp
@@ -1292,7 +1292,7 @@ static PGList *check_func_name(PGList *names, core_yyscan_t yyscanner);
 static PGList *check_indirection(PGList *indirection, core_yyscan_t yyscanner);
 static void insertSelectOptions(PGSelectStmt *stmt,
 								PGList *sortClause, PGList *lockingClause,
-								PGNode *limitOffset, PGNode *limitCount,
+								PGNode *limitOffset, PGNode *limitCount, PGNode *isLimitOffsetFirst,
 								PGWithClause *withClause,
 								core_yyscan_t yyscanner);
 static PGNode *makeSetOp(PGSetOperation op, bool all, PGNode *larg, PGNode *rarg);
@@ -24378,7 +24378,7 @@ yyreduce:
 #line 74 "third_party/libpg_query/grammar/statements/select.y"
     {
 					insertSelectOptions((PGSelectStmt *) (yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].list), NIL,
-										NULL, NULL, NULL,
+										NULL, NULL, NULL, NULL,
 										yyscanner);
 					(yyval.node) = (yyvsp[(1) - (2)].node);
 				;}
@@ -24388,7 +24388,7 @@ yyreduce:
 #line 81 "third_party/libpg_query/grammar/statements/select.y"
     {
 					insertSelectOptions((PGSelectStmt *) (yyvsp[(1) - (4)].node), (yyvsp[(2) - (4)].list), (yyvsp[(3) - (4)].list),
-										(PGNode*) list_nth((yyvsp[(4) - (4)].list), 0), (PGNode*) list_nth((yyvsp[(4) - (4)].list), 1),
+										(PGNode*) list_nth((yyvsp[(4) - (4)].list), 0), (PGNode*) list_nth((yyvsp[(4) - (4)].list), 1), (PGNode*) list_nth((yyvsp[(4) - (4)].list), 2),
 										NULL,
 										yyscanner);
 					(yyval.node) = (yyvsp[(1) - (4)].node);
@@ -24399,7 +24399,7 @@ yyreduce:
 #line 89 "third_party/libpg_query/grammar/statements/select.y"
     {
 					insertSelectOptions((PGSelectStmt *) (yyvsp[(1) - (4)].node), (yyvsp[(2) - (4)].list), (yyvsp[(4) - (4)].list),
-										(PGNode*) list_nth((yyvsp[(3) - (4)].list), 0), (PGNode*) list_nth((yyvsp[(3) - (4)].list), 1),
+										(PGNode*) list_nth((yyvsp[(3) - (4)].list), 0), (PGNode*) list_nth((yyvsp[(3) - (4)].list), 1), (PGNode*) list_nth((yyvsp[(3) - (4)].list), 2),
 										NULL,
 										yyscanner);
 					(yyval.node) = (yyvsp[(1) - (4)].node);
@@ -24410,7 +24410,7 @@ yyreduce:
 #line 97 "third_party/libpg_query/grammar/statements/select.y"
     {
 					insertSelectOptions((PGSelectStmt *) (yyvsp[(2) - (2)].node), NULL, NIL,
-										NULL, NULL,
+										NULL, NULL, NULL,
 										(yyvsp[(1) - (2)].with),
 										yyscanner);
 					(yyval.node) = (yyvsp[(2) - (2)].node);
@@ -24421,7 +24421,7 @@ yyreduce:
 #line 105 "third_party/libpg_query/grammar/statements/select.y"
     {
 					insertSelectOptions((PGSelectStmt *) (yyvsp[(2) - (3)].node), (yyvsp[(3) - (3)].list), NIL,
-										NULL, NULL,
+										NULL, NULL, NULL,
 										(yyvsp[(1) - (3)].with),
 										yyscanner);
 					(yyval.node) = (yyvsp[(2) - (3)].node);
@@ -24432,7 +24432,7 @@ yyreduce:
 #line 113 "third_party/libpg_query/grammar/statements/select.y"
     {
 					insertSelectOptions((PGSelectStmt *) (yyvsp[(2) - (5)].node), (yyvsp[(3) - (5)].list), (yyvsp[(4) - (5)].list),
-										(PGNode*) list_nth((yyvsp[(5) - (5)].list), 0), (PGNode*) list_nth((yyvsp[(5) - (5)].list), 1),
+										(PGNode*) list_nth((yyvsp[(5) - (5)].list), 0), (PGNode*) list_nth((yyvsp[(5) - (5)].list), 1), (PGNode*) list_nth((yyvsp[(5) - (5)].list), 2),
 										(yyvsp[(1) - (5)].with),
 										yyscanner);
 					(yyval.node) = (yyvsp[(2) - (5)].node);
@@ -24443,7 +24443,7 @@ yyreduce:
 #line 121 "third_party/libpg_query/grammar/statements/select.y"
     {
 					insertSelectOptions((PGSelectStmt *) (yyvsp[(2) - (5)].node), (yyvsp[(3) - (5)].list), (yyvsp[(5) - (5)].list),
-										(PGNode*) list_nth((yyvsp[(4) - (5)].list), 0), (PGNode*) list_nth((yyvsp[(4) - (5)].list), 1),
+										(PGNode*) list_nth((yyvsp[(4) - (5)].list), 0), (PGNode*) list_nth((yyvsp[(4) - (5)].list), 1), (PGNode*) list_nth((yyvsp[(4) - (5)].list), 2),
 										(yyvsp[(1) - (5)].with),
 										yyscanner);
 					(yyval.node) = (yyvsp[(2) - (5)].node);
@@ -25103,22 +25103,22 @@ yyreduce:
 
   case 622:
 #line 643 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.list) = list_make2((yyvsp[(2) - (2)].node), (yyvsp[(1) - (2)].node)); ;}
+    { (yyval.list) = list_make3((yyvsp[(2) - (2)].node), (yyvsp[(1) - (2)].node), NULL); ;}
     break;
 
   case 623:
 #line 644 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.list) = list_make2((yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].node)); ;}
+    { (yyval.list) = list_make3((yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].node), (yyvsp[(1) - (2)].node)); ;}
     break;
 
   case 624:
 #line 645 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.list) = list_make2(NULL, (yyvsp[(1) - (1)].node)); ;}
+    { (yyval.list) = list_make3(NULL, (yyvsp[(1) - (1)].node), NULL); ;}
     break;
 
   case 625:
 #line 646 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.list) = list_make2((yyvsp[(1) - (1)].node), NULL); ;}
+    { (yyval.list) = list_make3((yyvsp[(1) - (1)].node), NULL, (yyvsp[(1) - (1)].node)); ;}
     break;
 
   case 626:
@@ -25128,7 +25128,7 @@ yyreduce:
 
   case 627:
 #line 651 "third_party/libpg_query/grammar/statements/select.y"
-    { (yyval.list) = list_make2(NULL,NULL); ;}
+    { (yyval.list) = list_make3(NULL,NULL,NULL); ;}
     break;
 
   case 628:
@@ -32114,7 +32114,7 @@ static PGNode* makeNamedParamRef(char *name, int location)
 static void
 insertSelectOptions(PGSelectStmt *stmt,
 					PGList *sortClause, PGList *lockingClause,
-					PGNode *limitOffset, PGNode *limitCount,
+					PGNode *limitOffset, PGNode *limitCount, PGNode *isLimitOffsetFirst,
 					PGWithClause *withClause,
 					core_yyscan_t yyscanner)
 {
@@ -32159,6 +32159,9 @@ insertSelectOptions(PGSelectStmt *stmt,
 					 parser_errposition(exprLocation(limitCount))));
 		stmt->limitCount = limitCount;
 	}
+  if (limitOffset == isLimitOffsetFirst) {
+    stmt->offset_first = true;
+  }
 	if (withClause)
 	{
 		if (stmt->withClause)


### PR DESCRIPTION
Fixes #15466

I have utilized a boolean parameter `offset_first` to check whether OFFSET appears first in the query than LIMIT.
Utilized a third parameter `isLimitOffsetFirst ` in Yacc grammar file.