### PR TITLE
Fix InFilter::ToString, visible via EXPLAIN ANALYZE for example

### DIFF
--- a/src/planner/filter/in_filter.cpp
+++ b/src/planner/filter/in_filter.cpp
@@ -48,7 +48,7 @@ FilterPropagateResult InFilter::CheckStatistics(BaseStatistics &stats) {
 string InFilter::ToString(const string &column_name) {
 	string in_list;
 	for (auto &val : values) {
-		if (in_list.empty()) {
+		if (!in_list.empty()) {
 			in_list += ", ";
 		}
 		in_list += val.ToSQLString();


### PR DESCRIPTION
Very minor, changes representation from:
```
b in (, 110100)
```
to
```
b in (1, 10, 100)
```