### PR TITLE
Re-enable some tests, removing `mode skip` or moving it later

### DIFF
--- a/test/optimizer/pushdown/table_or_pushdown.test
+++ b/test/optimizer/pushdown/table_or_pushdown.test
@@ -5,8 +5,6 @@
 statement ok
 PRAGMA enable_verification
 
-# FIXME: re-enable when OR pushdown is fixed
-mode skip
 
 statement ok
 CREATE TABLE integers AS SELECT a as a, a as b FROM generate_series(1, 5, 1) tbl(a)
@@ -75,7 +73,7 @@ INSERT INTO strings VALUES ('AAAAAAAAAAAAAAA11111'), ('AAAAAAAAAAAAAAA99999')
 query II
 EXPLAIN SELECT * FROM strings WHERE s>'AAAAAAAAAAAAAAA1'
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*Filters: s>AAAAAAAAAAAAAAA1.*
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*s>'AAAAAAAAAAAAAAA1'.*
 
 query I
 SELECT * FROM strings WHERE s>'AAAAAAAAAAAAAAA1'
@@ -88,8 +86,7 @@ AAAAAAAAAAAAAAA99999
 query II
 EXPLAIN SELECT * FROM strings WHERE s>'AAAAAAAAAAAAAAA' OR s<'AAAAAAAAAAAAAAA99999A'
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*Filters: s>AAAAAAAAAAAAAAA|.*OR s<AAAAAAAAAAAAAAA99999A.*
-
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*s>.*'AAAAAAAAAAAAAAA'|.*OR.*s<.*'AAAAAAAAAAAAAAA99999A'.*
 
 query I
 SELECT * FROM strings WHERE s>'AAAAAAAAAAAAAAA' OR s<'AAAAAAAAAAAAAAA99999A'
@@ -120,7 +117,7 @@ CCCC
 query II
 EXPLAIN SELECT * FROM strings WHERE s!='BBBB' or s>'BBBB'
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*Filters: s!=BBBB OR s>BBBB.*
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*s!=.*'BBBB'.*OR.*s>.*'BBBB'.*
 
 
 query I
@@ -133,7 +130,7 @@ CCCC
 query II
 EXPLAIN SELECT * FROM integers WHERE a!=1 OR a!=2
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*Filters: a!=1 OR a!=2.*
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*a!=1.*OR.*a!=2.*
 
 query II
 SELECT * FROM integers WHERE a!=1 OR a!=2 ORDER BY a
@@ -148,7 +145,7 @@ SELECT * FROM integers WHERE a!=1 OR a!=2 ORDER BY a
 query II
 EXPLAIN SELECT * FROM integers WHERE a>2 AND (a=3 OR a=5)
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*Filters: a>2 AND a IS NOT.*NULL.*
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*a>2.*
 
 query II
 SELECT * FROM integers WHERE a>2 AND (a=3 OR a=5) ORDER BY a
@@ -162,7 +159,7 @@ SELECT * FROM integers WHERE a>2 AND (a=3 OR a=5) ORDER BY a
 query II
 EXPLAIN SELECT * FROM integers WHERE (a<2 OR a>3) AND (a=1 OR a=4)
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*Filters: a<2 OR a>3 AND a=1.*OR.*a=4.*
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*a<2.*OR.*a>3.*AND.*a=1.*OR.*a=4.*
 
 query II
 SELECT * FROM integers WHERE (a<2 OR a>3) AND (a=1 OR a=4)
@@ -173,7 +170,7 @@ SELECT * FROM integers WHERE (a<2 OR a>3) AND (a=1 OR a=4)
 query II
 EXPLAIN SELECT * FROM integers WHERE (a<2 OR a>3) AND (a=1 OR a=4) AND (b=1 OR b<5)
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*Filters: a<2 OR a>3 AND a=1.*OR.*a=4.*b=1 OR b<5.*
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*a<2.*OR.*a>3.*AND.*a=1.*OR.*a=4.*b=1 OR b<5.*
 
 query II
 SELECT * FROM integers WHERE (a<2 OR a>3) AND (a=1 OR a=4) AND (b=1 OR b<5)
@@ -223,7 +220,7 @@ SELECT * FROM integers WHERE a=1 OR (CASE WHEN a%2=0 THEN true ELSE false END)
 query II
 EXPLAIN SELECT * FROM integers WHERE (a=1 OR a=4) AND (a=1 OR (CASE WHEN a%2=0 THEN true ELSE false END)) AND (concat(a=1, b=1)='truetrue' OR a=2) AND (a::CHAR LIKE '1' OR a=5)
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*Filters: a=1 OR a=4.*|$
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*a=1.*OR.*a=4.*|$
 
 query II
 SELECT * FROM integers WHERE (a=1 OR a=4) AND (a=1 OR (CASE WHEN a%2=0 THEN true ELSE false END)) AND (concat(a=1, b=1)='truetrue' OR a=2) AND (a::CHAR LIKE '1' OR a=5)
@@ -242,8 +239,8 @@ physical_plan	<!REGEX>:.*SEQ_SCAN.*Filters:.*
 query II
 SELECT * FROM integers WHERE a=1 OR a IS NULL ORDER BY a
 ----
-NULL	NULL
 1	1
+NULL	NULL
 
 query II
 EXPLAIN SELECT * FROM integers WHERE a=1 OR a IS NOT NULL
@@ -268,11 +265,11 @@ physical_plan	<!REGEX>:.*SEQ_SCAN.*Filters:.*
 query II
 SELECT * FROM integers WHERE a!=1 OR a IS NULL ORDER BY a
 ----
-NULL	NULL
 2	2
 3	3
 4	4
 5	5
+NULL	NULL
 
 # notequal and not null
 query II
@@ -292,7 +289,7 @@ SELECT * FROM integers WHERE a!=1 OR a IS NOT NULL ORDER BY a
 query II
 EXPLAIN SELECT * FROM integers WHERE a!=1 OR a>3 OR a<2 ORDER by a
 ----
-physical_plan	<REGEX>:.*SEQ_SCAN.*Filters: a!=1 OR a>3 OR a<2.*
+physical_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*a!=1.*OR.*a>3.*OR.*a.*<.*2.*
 
 query II
 SELECT * FROM integers WHERE a!=1 OR a>3 OR a<2 ORDER by a
@@ -303,6 +300,8 @@ SELECT * FROM integers WHERE a!=1 OR a>3 OR a<2 ORDER by a
 4	4
 5	5
 
+mode skip
+
 #### numeric statistics
 # notequal and constant > max
 query II
@@ -311,6 +310,8 @@ EXPLAIN SELECT * FROM integers WHERE a!=10 OR a>3
 physical_plan	<!REGEX>:.*SEQ_SCAN.*Filters:.*
 
 ## The predicate a!=10 is greater than the numeric_statistics::max implying that it is always true within an OR conjunction
+
+mode unskip
 
 query II
 SELECT * FROM integers WHERE a!=10 OR a>3
@@ -325,17 +326,21 @@ SELECT * FROM integers WHERE a!=10 OR a>3
 statement ok
 PRAGMA enable_profiling
 
+mode skip
+
 # should return 2 rows: 1 and 5
 query II
 EXPLAIN ANALYZE SELECT a FROM integers WHERE a<2 OR a>4
 ----
-analyzed_plan	<REGEX>:.*SEQ_SCAN.*Filters: a<2 OR a>4.*2[ \t].*
+analyzed_plan	<REGEX>:.*SEQ_SCAN.*Filters:.*a<2.*OR.*a>4.*2 Rows.*
 
 # should return 1 row: 1
 query II
 EXPLAIN ANALYZE SELECT a FROM integers WHERE a<2 OR a>5
 ----
-analyzed_plan	<REGEX>:.*SEQ_SCAN.*Filters: a<2 OR a>5.*1[ \t].*
+analyzed_plan	<REGEX>:.*SEQ_SCAN.*Filters: a<2 OR a>5.*1 Rows.*
+
+mode unskip
 
 statement ok
 PRAGMA disable_profiling

--- a/test/sql/aggregate/aggregates/test_count.test
+++ b/test/sql/aggregate/aggregates/test_count.test
@@ -2,14 +2,8 @@
 # description: Test COUNT operator
 # group: [aggregates]
 
-mode skip
-
-# FIXME - prepared statements on COUNT DISTINCT run into an internal error
-
 statement ok
 PRAGMA enable_verification
-
-mode unskip
 
 # test counts on scalar values
 query IIIII

--- a/test/sql/insert/insert_from_many_grouping_sets.test
+++ b/test/sql/insert/insert_from_many_grouping_sets.test
@@ -2,9 +2,6 @@
 # description: Test parallel insert from many groups
 # group: [insert]
 
-# FIXME: occasionally this test fails on the CI with a thread sanitizer failure
-mode skip
-
 statement ok
 CREATE TABLE integers AS SELECT i, i%2 as j FROM generate_series(0,999999,1) tbl(i);
 

--- a/test/sql/storage/commit_abort_large.test_slow
+++ b/test/sql/storage/commit_abort_large.test_slow
@@ -2,11 +2,6 @@
 # description: Test abort of commit with many values
 # group: [storage]
 
-# FIXME: this test fails right now because deleted tuples are not correctly removed
-# while checkpointing, which causes the start-up after checkpoint to fail during
-# primary index construction. It should be re-enabled when deleted tuples are properly vacuumed.
-mode skip
-
 # load the DB from disk
 load __TEST_DIR__/commit_abort.db
 

--- a/test/sql/storage/commit_abort_medium.test
+++ b/test/sql/storage/commit_abort_medium.test
@@ -5,11 +5,6 @@
 # load the DB from disk
 load __TEST_DIR__/commit_abort.db
 
-# FIXME: this test fails right now because deleted tuples are not correctly removed
-# while checkpointing, which causes the start-up after checkpoint to fail during
-# primary index construction. It should be re-enabled when deleted tuples are properly vacuumed.
-mode skip
-
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/storage/commit_index_deletes.test
+++ b/test/sql/storage/commit_index_deletes.test
@@ -2,11 +2,6 @@
 # description: Test commit of index with deletes
 # group: [storage]
 
-# FIXME: this test fails right now because deleted tuples are not correctly removed
-# while checkpointing, which causes the start-up after checkpoint to fail during
-# primary index construction. It should be re-enabled when deleted tuples are properly vacuumed.
-mode skip
-
 # load the DB from disk
 load __TEST_DIR__/commit_abort.db
 


### PR DESCRIPTION
Tests touched:
* test/sql/storage/commit_index_deletes.test -> indexes rework to make them more flexible (and more standard compliant)
* test/sql/storage/commit_abort_medium.test -> indexes, see above
* test/sql/storage/commit_abort_large.test_slow -> indexes, see above
* test/sql/insert/insert_from_many_grouping_sets.test -> test was removed due to thread sanitizer failures that are apparently gone (hard to say where, but plently of bugfixes went in)
* test/sql/aggregate/aggregates/test_count.test -> apparently COUNT DISTINCT was supposed to throw InternalError, now working
* test/optimizer/pushdown/table_or_pushdown.test -> adapting to new formatting, to NULL last instead of first, and re-enabling all but 2 tests (to be reviewed separately)

This is minor, but given they appear to work as intended (modulo some minor changes due to bit-rot), it's better to have them enabled.