### PR TITLE
Mention configuration option that avoids total string size error in error message

### DIFF
--- a/src/include/duckdb/common/arrow/appender/varchar_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/varchar_data.hpp
@@ -86,9 +86,9 @@ struct ArrowVarcharData {
 			    UnsafeNumericCast<idx_t>(last_offset) + string_length > NumericLimits<int32_t>::Maximum()) {
 				D_ASSERT(append_data.options.arrow_offset_size == ArrowOffsetSize::REGULAR);
 				throw InvalidInputException(
-				    "Arrow Appender: The maximum total string size for regular string buffers is "
-				    "%u but the offset of %lu exceeds this. Try setting `arrow_large_buffer_size` to `true`.",
-				    NumericLimits<int32_t>::Maximum(), current_offset);
+				    "Arrow Appender: The offset (%lu) exceeds the maximum total string size for regular string buffers (%u). "
+				    "Enable `arrow_large_buffer_size` for larger buffers.",
+				    current_offset, NumericLimits<int32_t>::Maximum());
 			}
 			offset_data[offset_idx] = UnsafeNumericCast<BUFTYPE>(current_offset);
 

--- a/src/include/duckdb/common/arrow/appender/varchar_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/varchar_data.hpp
@@ -87,7 +87,7 @@ struct ArrowVarcharData {
 				D_ASSERT(append_data.options.arrow_offset_size == ArrowOffsetSize::REGULAR);
 				throw InvalidInputException(
 				    "Arrow Appender: The maximum total string size for regular string buffers is "
-				    "%u but the offset of %lu exceeds this.",
+				    "%u but the offset of %lu exceeds this. Try setting `arrow_large_buffer_size` to `true`.",
 				    NumericLimits<int32_t>::Maximum(), current_offset);
 			}
 			offset_data[offset_idx] = UnsafeNumericCast<BUFTYPE>(current_offset);

--- a/src/include/duckdb/common/arrow/appender/varchar_data.hpp
+++ b/src/include/duckdb/common/arrow/appender/varchar_data.hpp
@@ -86,9 +86,10 @@ struct ArrowVarcharData {
 			    UnsafeNumericCast<idx_t>(last_offset) + string_length > NumericLimits<int32_t>::Maximum()) {
 				D_ASSERT(append_data.options.arrow_offset_size == ArrowOffsetSize::REGULAR);
 				throw InvalidInputException(
-				    "Arrow Appender: The offset (%lu) exceeds the maximum total string size for regular string buffers (%u). "
-				    "Enable `arrow_large_buffer_size` for larger buffers.",
-				    current_offset, NumericLimits<int32_t>::Maximum());
+				    "Arrow Appender: The maximum total string size for regular string buffers is "
+				    "%u but the offset of %lu exceeds this.\n* SET arrow_large_buffer_size=true to use large string "
+				    "buffers",
+				    NumericLimits<int32_t>::Maximum(), current_offset);
 			}
 			offset_data[offset_idx] = UnsafeNumericCast<BUFTYPE>(current_offset);
 


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/15486

Make large string error message match arge lists error message at https://github.com/duckdb/duckdb/blob/ab8c90985741ac68cd203c8396022894c1771d4b/src/include/duckdb/common/arrow/appender/list_data.hpp#L76