### PR TITLE
Setting descriptions grammar

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -92,7 +92,7 @@
     },
     {
         "name": "arrow_large_buffer_size",
-        "description": "If arrow buffers for strings, blobs, uuids and bits should be exported using large buffers",
+        "description": "Whether arrow buffers for strings, blobs, uuids and bits should be exported using large buffers",
         "type": "BOOLEAN",
         "scope": "global",
         "internal_setting": "arrow_offset_size",
@@ -109,7 +109,7 @@
     },
     {
         "name": "arrow_output_list_view",
-        "description": "If export to arrow format should use ListView as the physical layout for LIST columns",
+        "description": "Whether export to arrow format should use ListView as the physical layout for LIST columns",
         "type": "BOOLEAN",
         "internal_setting": "arrow_use_list_view",
         "scope": "global"
@@ -628,7 +628,7 @@
     },
     {
         "name": "produce_arrow_string_view",
-        "description": "If strings should be produced by DuckDB in Utf8View format instead of Utf8",
+        "description": "Whether strings should be produced by DuckDB in Utf8View format instead of Utf8",
         "type": "BOOLEAN",
         "scope": "global",
         "internal_setting": "produce_arrow_string_views"

--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -92,7 +92,7 @@
     },
     {
         "name": "arrow_large_buffer_size",
-        "description": "Whether arrow buffers for strings, blobs, uuids and bits should be exported using large buffers",
+        "description": "Whether Arrow buffers for strings, blobs, uuids and bits should be exported using large buffers",
         "type": "BOOLEAN",
         "scope": "global",
         "internal_setting": "arrow_offset_size",
@@ -109,7 +109,7 @@
     },
     {
         "name": "arrow_output_list_view",
-        "description": "Whether export to arrow format should use ListView as the physical layout for LIST columns",
+        "description": "Whether export to Arrow format should use ListView as the physical layout for LIST columns",
         "type": "BOOLEAN",
         "internal_setting": "arrow_use_list_view",
         "scope": "global"

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -188,7 +188,7 @@ struct ArrowLargeBufferSizeSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "arrow_large_buffer_size";
 	static constexpr const char *Description =
-	    "If arrow buffers for strings, blobs, uuids and bits should be exported using large buffers";
+	    "Whether Arrow buffers for strings, blobs, uuids and bits should be exported using large buffers";
 	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
@@ -211,7 +211,7 @@ struct ArrowOutputListViewSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "arrow_output_list_view";
 	static constexpr const char *Description =
-	    "If export to arrow format should use ListView as the physical layout for LIST columns";
+	    "Whether export to Arrow format should use ListView as the physical layout for LIST columns";
 	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
@@ -970,7 +970,7 @@ struct ProduceArrowStringViewSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "produce_arrow_string_view";
 	static constexpr const char *Description =
-	    "If strings should be produced by DuckDB in Utf8View format instead of Utf8";
+	    "Whether strings should be produced by DuckDB in Utf8View format instead of Utf8";
 	static constexpr const char *InputType = "BOOLEAN";
 	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
 	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);


### PR DESCRIPTION
This PR ports the grammar fixes of https://github.com/duckdb/duckdb-web/pull/4446 back to the main codebase, and makes sure `Arrow` is spelled consistently in messages.