### PR TITLE
chore: Add header for g++15 compatibility

### DIFF
--- a/third_party/fsst/libfsst.hpp
+++ b/third_party/fsst/libfsst.hpp
@@ -17,6 +17,7 @@
 // You can contact the authors via the FSST source repository : https://github.com/cwida/fsst 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
CRAN complains: https://www.stats.ox.ac.uk/pub/bdr/gcc15/duckdb.out .