### PR TITLE
Use ISNULL in conjunction or filters

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -708,15 +708,16 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 					if (const_val->value.IsNull()) {
 						switch (comparison_type) {
 						case ExpressionType::COMPARE_DISTINCT_FROM: {
-							auto null_filter = make_uniq<IsNullFilter>();
-							conj_filter->child_filters.push_back(std::move(null_filter));
-							break;
-						}
-						case ExpressionType::COMPARE_NOT_DISTINCT_FROM: {
 							auto null_filter = make_uniq<IsNotNullFilter>();
 							conj_filter->child_filters.push_back(std::move(null_filter));
 							break;
 						}
+						case ExpressionType::COMPARE_NOT_DISTINCT_FROM: {
+							auto null_filter = make_uniq<IsNullFilter>();
+							conj_filter->child_filters.push_back(std::move(null_filter));
+							break;
+						}
+						// if any other comparison type (i.e EQUAL, NOT_EQUAL) DO NOT PUSH A TABLE FILTER.
 						default:
 							break;
 						}

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -717,7 +717,7 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 							conj_filter->child_filters.push_back(std::move(null_filter));
 							break;
 						}
-						// if any other comparison type (i.e EQUAL, NOT_EQUAL) DO NOT PUSH A TABLE FILTER.
+						// if any other comparison type (i.e EQUAL, NOT_EQUAL) do not push a table filter
 						default:
 							break;
 						}

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -707,13 +707,11 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 					    invert ? FlipComparisonExpression(comp.GetExpressionType()) : comp.GetExpressionType();
 					if (const_val->value.IsNull()) {
 						switch (comparison_type) {
-						case ExpressionType::COMPARE_EQUAL:
 						case ExpressionType::COMPARE_DISTINCT_FROM: {
 							auto null_filter = make_uniq<IsNullFilter>();
 							conj_filter->child_filters.push_back(std::move(null_filter));
 							break;
 						}
-						case ExpressionType::COMPARE_NOTEQUAL:
 						case ExpressionType::COMPARE_NOT_DISTINCT_FROM: {
 							auto null_filter = make_uniq<IsNotNullFilter>();
 							conj_filter->child_filters.push_back(std::move(null_filter));
@@ -734,8 +732,6 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 			}
 		}
 	}
-
-	//	GenerateORFilters(table_filters, column_ids);
 
 	return table_filters;
 }

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -705,8 +705,27 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex
 					}
 					auto comparison_type =
 					    invert ? FlipComparisonExpression(comp.GetExpressionType()) : comp.GetExpressionType();
-					auto const_filter = make_uniq<ConstantFilter>(comparison_type, const_val->value);
-					conj_filter->child_filters.push_back(std::move(const_filter));
+					if (const_val->value.IsNull()) {
+						switch (comparison_type) {
+						case ExpressionType::COMPARE_EQUAL:
+						case ExpressionType::COMPARE_DISTINCT_FROM: {
+							auto null_filter = make_uniq<IsNullFilter>();
+							conj_filter->child_filters.push_back(std::move(null_filter));
+							break;
+						}
+						case ExpressionType::COMPARE_NOTEQUAL:
+						case ExpressionType::COMPARE_NOT_DISTINCT_FROM: {
+							auto null_filter = make_uniq<IsNotNullFilter>();
+							conj_filter->child_filters.push_back(std::move(null_filter));
+							break;
+						}
+						default:
+							break;
+						}
+					} else {
+						auto const_filter = make_uniq<ConstantFilter>(comparison_type, const_val->value);
+						conj_filter->child_filters.push_back(std::move(const_filter));
+					}
 				}
 				if (column_id.IsValid()) {
 					optional_filter->child_filter = std::move(conj_filter);

--- a/test/optimizer/pushdown/join_filter_pushdown.test
+++ b/test/optimizer/pushdown/join_filter_pushdown.test
@@ -2,20 +2,26 @@
 # description: Test sampling of larger relations
 # group: [pushdown]
 
-statement ok
-CREATE TABLE t1 AS FROM VALUES
-('619d9199-bc25-41d7-803e-1fa801b4b952'::UUID, NULL::VARCHAR),
-('1ada8361-c20b-4e9f-9c8e-15689039cc75'::UUID, '91'::VARCHAR),
-('f5a8a7d8-6bc5-4337-a296-d52078156051'::UUID, NULL::VARCHAR) t(s, i);
+# statement ok
+# CREATE TABLE t1 AS FROM VALUES
+# ('619d9199-bc25-41d7-803e-1fa801b4b952'::UUID, NULL::VARCHAR),
+# ('1ada8361-c20b-4e9f-9c8e-15689039cc75'::UUID, '91'::VARCHAR),
+# ('f5a8a7d8-6bc5-4337-a296-d52078156051'::UUID, NULL::VARCHAR) t(s, i);
+#
+# statement ok
+# CREATE TABLE t2 as from values
+#  ('Int'),
+#  ('91'),
+#  ('13',),
+#  ('sst',) t(v);
+#
+# statement ok
+# SELECT t1.s
+# FROM t1
+# LEFT JOIN t2 ON t1.i = t2.v;
 
 statement ok
-CREATE TABLE t2 as from values
- ('Int'),
- ('91'),
- ('13',),
- ('sst',) t(v);
+CREATE TABLE  t0(c1 INT);
 
 statement ok
-SELECT t1.s
-FROM t1
-LEFT JOIN t2 ON t1.i = t2.v;
+SELECT * FROM t0 WHERE ((t0.c1 IS DISTINCT FROM NULL) OR (NOT NULL));

--- a/test/optimizer/pushdown/join_filter_pushdown.test
+++ b/test/optimizer/pushdown/join_filter_pushdown.test
@@ -2,26 +2,20 @@
 # description: Test sampling of larger relations
 # group: [pushdown]
 
-# statement ok
-# CREATE TABLE t1 AS FROM VALUES
-# ('619d9199-bc25-41d7-803e-1fa801b4b952'::UUID, NULL::VARCHAR),
-# ('1ada8361-c20b-4e9f-9c8e-15689039cc75'::UUID, '91'::VARCHAR),
-# ('f5a8a7d8-6bc5-4337-a296-d52078156051'::UUID, NULL::VARCHAR) t(s, i);
-#
-# statement ok
-# CREATE TABLE t2 as from values
-#  ('Int'),
-#  ('91'),
-#  ('13',),
-#  ('sst',) t(v);
-#
-# statement ok
-# SELECT t1.s
-# FROM t1
-# LEFT JOIN t2 ON t1.i = t2.v;
+statement ok
+CREATE TABLE t1 AS FROM VALUES
+('619d9199-bc25-41d7-803e-1fa801b4b952'::UUID, NULL::VARCHAR),
+('1ada8361-c20b-4e9f-9c8e-15689039cc75'::UUID, '91'::VARCHAR),
+('f5a8a7d8-6bc5-4337-a296-d52078156051'::UUID, NULL::VARCHAR) t(s, i);
 
 statement ok
-CREATE TABLE  t0(c1 INT);
+CREATE TABLE t2 as from values
+ ('Int'),
+ ('91'),
+ ('13',),
+ ('sst',) t(v);
 
 statement ok
-SELECT * FROM t0 WHERE ((t0.c1 IS DISTINCT FROM NULL) OR (NOT NULL));
+SELECT t1.s
+FROM t1
+LEFT JOIN t2 ON t1.i = t2.v;

--- a/test/optimizer/pushdown/table_or_pushdown.test
+++ b/test/optimizer/pushdown/table_or_pushdown.test
@@ -305,7 +305,21 @@ statement ok
 CREATE TABLE t0(c1 INT);
 
 statement ok
+insert into t0 values (1), (2), (2), (0);
+
+statement ok
 SELECT * FROM t0 WHERE ((t0.c1 IS DISTINCT FROM NULL) OR (NOT NULL));
+
+statement ok
+SELECT * FROM t0 WHERE ((t0.c1 = NULL) OR (NOT NULL) OR (t0.c1 = 1));
+
+query I
+select * from t0 where (NULL OR cast(t0.c1 as bool)) order by all;
+----
+1
+2
+2
+
 
 mode skip
 

--- a/test/optimizer/pushdown/table_or_pushdown.test
+++ b/test/optimizer/pushdown/table_or_pushdown.test
@@ -305,10 +305,31 @@ statement ok
 CREATE TABLE t0(c1 INT);
 
 statement ok
-insert into t0 values (1), (2), (2), (0);
+insert into t0 values (1), (2), (2), (0), (NULL);
 
-statement ok
-SELECT * FROM t0 WHERE ((t0.c1 IS DISTINCT FROM NULL) OR (NOT NULL));
+# is distinct from NULL
+query I
+SELECT * FROM t0 WHERE ((t0.c1 IS DISTINCT FROM NULL) OR (NULL));
+----
+1
+2
+2
+0
+
+# is not distinct from NULL
+query I
+SELECT * FROM t0 WHERE ((t0.c1 IS NOT DISTINCT FROM NULL) OR (NULL));
+----
+NULL
+
+# = NULL in conjunction or
+query I
+SELECT * FROM t0 WHERE ((t0.c1 = NULL) OR (NULL));
+----
+
+query I
+SELECT * FROM t0 WHERE ((t0.c1 != NULL) OR (NULL));
+----
 
 statement ok
 SELECT * FROM t0 WHERE ((t0.c1 = NULL) OR (NOT NULL) OR (t0.c1 = 1));

--- a/test/optimizer/pushdown/table_or_pushdown.test
+++ b/test/optimizer/pushdown/table_or_pushdown.test
@@ -300,6 +300,13 @@ SELECT * FROM integers WHERE a!=1 OR a>3 OR a<2 ORDER by a
 4	4
 5	5
 
+# test comparison with null in OR conjunctions uses ISNULL/ISNOTNULL table filter
+statement ok
+CREATE TABLE t0(c1 INT);
+
+statement ok
+SELECT * FROM t0 WHERE ((t0.c1 IS DISTINCT FROM NULL) OR (NOT NULL));
+
 mode skip
 
 #### numeric statistics

--- a/test/optimizer/pushdown/table_or_pushdown.test
+++ b/test/optimizer/pushdown/table_or_pushdown.test
@@ -302,10 +302,7 @@ SELECT * FROM integers WHERE a!=1 OR a>3 OR a<2 ORDER by a
 
 # test comparison with null in OR conjunctions uses ISNULL/ISNOTNULL table filter
 statement ok
-CREATE TABLE t0(c1 INT);
-
-statement ok
-insert into t0 values (1), (2), (2), (0), (NULL);
+CREATE TABLE t0 as from values (1), (2), (2), (0), (NULL) t(c1);
 
 # is distinct from NULL
 query I


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/3838
Fixes https://github.com/duckdb/duckdb/issues/15479

When adding support for OR filters in table filter scans, we forgot to check for NULL in the conjunction OR. 