### PR TITLE
[Dev] Fix issue related to unpacked columns and the NOT operator

### DIFF
--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -13,7 +13,7 @@ namespace duckdb {
 
 LogicalType ExpressionBinder::ResolveNotType(OperatorExpression &op, vector<unique_ptr<Expression>> &children) {
 	// NOT expression, cast child to BOOLEAN
-	D_ASSERT(children.size() != 1);
+	D_ASSERT(children.size() == 1);
 	children[0] = BoundCastExpression::AddCastToType(context, std::move(children[0]), LogicalType::BOOLEAN);
 	return LogicalType(LogicalTypeId::BOOLEAN);
 }

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -13,7 +13,11 @@ namespace duckdb {
 
 LogicalType ExpressionBinder::ResolveNotType(OperatorExpression &op, vector<unique_ptr<Expression>> &children) {
 	// NOT expression, cast child to BOOLEAN
-	D_ASSERT(children.size() == 1);
+	if (children.size() != 1) {
+		throw BinderException(
+		    "Failed to bind the NOT operator, too many child expressions found (%d), expected only one",
+		    children.size());
+	}
 	children[0] = BoundCastExpression::AddCastToType(context, std::move(children[0]), LogicalType::BOOLEAN);
 	return LogicalType(LogicalTypeId::BOOLEAN);
 }

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -13,11 +13,7 @@ namespace duckdb {
 
 LogicalType ExpressionBinder::ResolveNotType(OperatorExpression &op, vector<unique_ptr<Expression>> &children) {
 	// NOT expression, cast child to BOOLEAN
-	if (children.size() != 1) {
-		throw BinderException(
-		    "Failed to bind the NOT operator, too many child expressions found (%d), expected only one",
-		    children.size());
-	}
+	D_ASSERT(children.size() != 1);
 	children[0] = BoundCastExpression::AddCastToType(context, std::move(children[0]), LogicalType::BOOLEAN);
 	return LogicalType(LogicalTypeId::BOOLEAN);
 }

--- a/src/planner/binder/expression/bind_unpacked_star_expression.cpp
+++ b/src/planner/binder/expression/bind_unpacked_star_expression.cpp
@@ -50,6 +50,10 @@ static void ReplaceInFunction(unique_ptr<ParsedExpression> &expr, expression_lis
 static void ReplaceInOperator(unique_ptr<ParsedExpression> &expr, expression_list_t &star_list) {
 	auto &operator_expr = expr->Cast<OperatorExpression>();
 
+	if (operator_expr.type == ExpressionType::OPERATOR_NOT) {
+		throw BinderException("*COLUMNS() can not be used together with the NOT operator");
+	}
+
 	// Replace children
 	expression_list_t new_children;
 	for (auto &child : operator_expr.children) {

--- a/src/planner/binder/expression/bind_unpacked_star_expression.cpp
+++ b/src/planner/binder/expression/bind_unpacked_star_expression.cpp
@@ -50,8 +50,21 @@ static void ReplaceInFunction(unique_ptr<ParsedExpression> &expr, expression_lis
 static void ReplaceInOperator(unique_ptr<ParsedExpression> &expr, expression_list_t &star_list) {
 	auto &operator_expr = expr->Cast<OperatorExpression>();
 
-	if (operator_expr.type == ExpressionType::OPERATOR_NOT) {
-		throw BinderException("*COLUMNS() can not be used together with the NOT operator");
+	vector<ExpressionType> allowed_types({
+	    ExpressionType::OPERATOR_COALESCE,
+	    ExpressionType::COMPARE_IN,
+	    ExpressionType::COMPARE_NOT_IN,
+	});
+	bool allowed = false;
+	for (idx_t i = 0; i < allowed_types.size() && !allowed; i++) {
+		auto &type = allowed_types[i];
+		if (operator_expr.type == type) {
+			allowed = true;
+		}
+	}
+	if (!allowed) {
+		throw BinderException("*COLUMNS() can not be used together with the '%s' operator",
+		                      EnumUtil::ToString(operator_expr.type));
 	}
 
 	// Replace children

--- a/test/fuzzer/fuzz_not_unpacked_columns.test
+++ b/test/fuzzer/fuzz_not_unpacked_columns.test
@@ -7,4 +7,4 @@ CREATE TABLE v00 (c01 INT, c02 STRING);
 statement error
 SELECT NOT (*COLUMNS(*)) FROM v00;
 ----
-Binder Error: Failed to bind the NOT operator, too many child expressions found (2), expected only one
+Binder Error: *COLUMNS() can not be used together with the NOT operator

--- a/test/fuzzer/fuzz_not_unpacked_columns.test
+++ b/test/fuzzer/fuzz_not_unpacked_columns.test
@@ -1,0 +1,10 @@
+# name: test/fuzzer/fuzz_not_unpacked_columns.test
+# group: [fuzzer]
+
+statement ok
+CREATE TABLE v00 (c01 INT, c02 STRING);
+
+statement error
+SELECT NOT (*COLUMNS(*)) FROM v00;
+----
+Binder Error: Failed to bind the NOT operator, too many child expressions found (2), expected only one

--- a/test/fuzzer/fuzz_not_unpacked_columns.test
+++ b/test/fuzzer/fuzz_not_unpacked_columns.test
@@ -7,4 +7,34 @@ CREATE TABLE v00 (c01 INT, c02 STRING);
 statement error
 SELECT NOT (*COLUMNS(*)) FROM v00;
 ----
-Binder Error: *COLUMNS() can not be used together with the NOT operator
+Binder Error: *COLUMNS() can not be used together with the 'OPERATOR_NOT' operator
+
+statement error
+SELECT (*COLUMNS(*) IS NOT NULL) FROM v00;
+----
+Binder Error: *COLUMNS() can not be used together with the 'OPERATOR_IS_NOT_NULL' operator
+
+statement error
+SELECT (*COLUMNS(*) IS NULL) FROM v00;
+----
+Binder Error: *COLUMNS() can not be used together with the 'OPERATOR_IS_NULL' operator
+
+statement error
+SELECT (*COLUMNS(*))[2] FROM v00;
+----
+Binder Error: *COLUMNS() can not be used together with the 'ARRAY_EXTRACT' operator
+
+statement error
+SELECT (*COLUMNS(*))[2:1:0] FROM v00;
+----
+Binder Error: *COLUMNS() can not be used together with the 'ARRAY_SLICE' operator
+
+statement error
+SELECT (*COLUMNS(*)).a FROM v00;
+----
+Binder Error: *COLUMNS() can not be used together with the 'STRUCT_EXTRACT' operator
+
+statement error
+SELECT construct_array(*COLUMNS(*)) FROM v00;
+----
+Binder Error: *COLUMNS() can not be used together with the 'ARRAY_CONSTRUCTOR' operator


### PR DESCRIPTION
This PR fixes #15290 

NOT only expected a single expression, because in the grammar it only takes a single expression
Because of `*COLUMNS(...)` this can expand to multiple expressions

The internal exception has been turned into a binder exception, disallowing the use of *COLUMNS here (if it resolves to more than a single expression)