### PR TITLE
[Python] Align the behavior between `sql` and `execute` for `.pl()` call

### DIFF
--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -2022,8 +2022,11 @@ py::dict DuckDBPyConnection::FetchTF() {
 }
 
 PolarsDataFrame DuckDBPyConnection::FetchPolars(idx_t rows_per_batch) {
-	auto arrow = FetchArrow(rows_per_batch);
-	return py::cast<PolarsDataFrame>(py::module::import("polars").attr("DataFrame")(arrow));
+	if (!con.HasResult()) {
+		throw InvalidInputException("No open result set");
+	}
+	auto &result = con.GetResult();
+	return result.ToPolars(rows_per_batch);
 }
 
 duckdb::pyarrow::RecordBatchReader DuckDBPyConnection::FetchRecordBatchReader(const idx_t rows_per_batch) {

--- a/tools/pythonpkg/tests/fast/arrow/test_polars.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_polars.py
@@ -30,6 +30,10 @@ class TestPolars(object):
         con_result = con.execute('SELECT * FROM df').pl()
         pl_testing.assert_frame_equal(df, con_result)
 
+    def test_execute_polars(self, duckdb_cursor):
+        res1 = duckdb_cursor.execute("SELECT 1 AS a, 2 AS a").pl()
+        assert res1.columns == ['a', 'a_1']
+
     def test_register_polars(self, duckdb_cursor):
         con = duckdb.connect()
         df = pl.DataFrame(


### PR DESCRIPTION
This PR fixes #15528 

When using `sql` (or `query`) followed by `.pl()` the produced polars dataframe has deduplicated columns
With `.execute` the second occurrence of the duplicated name was deleted, this has been fixed.