### PR TITLE
Internal #3860: Deserialise Secondary Orderings

### DIFF
--- a/src/planner/expression/bound_window_expression.cpp
+++ b/src/planner/expression/bound_window_expression.cpp
@@ -233,7 +233,7 @@ unique_ptr<Expression> BoundWindowExpression::Deserialize(Deserializer &deserial
 	deserializer.ReadPropertyWithExplicitDefault(211, "default_expr", result->default_expr, unique_ptr<Expression>());
 	deserializer.ReadProperty(212, "exclude_clause", result->exclude_clause);
 	deserializer.ReadProperty(213, "distinct", result->distinct);
-	deserializer.ReadProperty(214, "arg_orders", result->arg_orders);
+	deserializer.ReadPropertyWithExplicitDefault(214, "arg_orders", result->arg_orders, vector<BoundOrderByNode>());
 	return std::move(result);
 }
 


### PR DESCRIPTION
* Add missing default for arg_orders

fixes: duckdblabs/duckdb-internal#3860