### PR TITLE
This Xmas, I wanted BitpackingMode info in `pragma_storage_info` but …

### DIFF
--- a/src/include/duckdb/storage/compression/bitpacking.hpp
+++ b/src/include/duckdb/storage/compression/bitpacking.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/function/compression_function.hpp"
 
 namespace duckdb {
 
@@ -16,5 +17,17 @@ enum class BitpackingMode : uint8_t { INVALID, AUTO, CONSTANT, CONSTANT_DELTA, D
 
 BitpackingMode BitpackingModeFromString(const string &str);
 string BitpackingModeToString(const BitpackingMode &mode);
+
+struct SerializedBitpackingSegmentState : public ColumnSegmentState {
+public:
+	SerializedBitpackingSegmentState();
+	explicit SerializedBitpackingSegmentState(unordered_map<BitpackingMode, idx_t> counts_p);
+
+public:
+	void Serialize(Serializer &serializer) const override;
+
+protected:
+	unordered_map<BitpackingMode, idx_t> counts;
+};
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/compression/bitpacking.hpp
+++ b/src/include/duckdb/storage/compression/bitpacking.hpp
@@ -26,7 +26,6 @@ public:
 public:
 	void Serialize(Serializer &serializer) const override;
 
-protected:
 	unordered_map<BitpackingMode, idx_t> counts;
 };
 

--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -18,7 +18,6 @@
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/checkpoint/string_checkpoint_state.hpp"
 #include "duckdb/storage/segment/uncompressed.hpp"
-#include "duckdb/storage/string_uncompressed.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/column_segment.hpp"
 #include "duckdb/storage/table/scan_state.hpp"

--- a/src/storage/compression/bitpacking.cpp
+++ b/src/storage/compression/bitpacking.cpp
@@ -723,7 +723,6 @@ public:
 			current_delta_offset = *reinterpret_cast<T *>(current_group_ptr);
 			current_group_ptr += sizeof(T);
 		}
-
 	}
 
 	void Skip(ColumnSegment &segment, idx_t skip_count) {
@@ -969,7 +968,7 @@ void BitpackingSkip(ColumnSegment &segment, ColumnScanState &state, idx_t skip_c
 
 template <class T>
 unique_ptr<CompressedSegmentState> BitpackingInitSegment(ColumnSegment &segment, block_id_t block_id,
-														 optional_ptr<ColumnSegmentState> segment_state) {
+                                                         optional_ptr<ColumnSegmentState> segment_state) {
 	// segment_state is not used for Bitpacking (no specialized serialize/deserialize methods)
 	// block_id would equal INVALID_BLOCK for a constant value block (not materialized)
 	// auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
@@ -989,14 +988,12 @@ unique_ptr<CompressedSegmentState> BitpackingInitSegment(ColumnSegment &segment,
 template <class T, bool WRITE_STATISTICS = true>
 CompressionFunction GetBitpackingFunction(PhysicalType data_type) {
 	auto bitpacking = CompressionFunction(
-										  CompressionType::COMPRESSION_BITPACKING, data_type,
-										  BitpackingInitAnalyze<T>, BitpackingAnalyze<T>, BitpackingFinalAnalyze<T>,
-										  BitpackingInitCompression<T, WRITE_STATISTICS>, BitpackingCompress<T, WRITE_STATISTICS>,
-										  BitpackingFinalizeCompress<T, WRITE_STATISTICS>,
-										  BitpackingInitScan<T>, BitpackingScan<T>, BitpackingScanPartial<T>,
-										  BitpackingFetchRow<T>, BitpackingSkip<T>);
+	    CompressionType::COMPRESSION_BITPACKING, data_type, BitpackingInitAnalyze<T>, BitpackingAnalyze<T>,
+	    BitpackingFinalAnalyze<T>, BitpackingInitCompression<T, WRITE_STATISTICS>,
+	    BitpackingCompress<T, WRITE_STATISTICS>, BitpackingFinalizeCompress<T, WRITE_STATISTICS>, BitpackingInitScan<T>,
+	    BitpackingScan<T>, BitpackingScanPartial<T>, BitpackingFetchRow<T>, BitpackingSkip<T>);
 	bitpacking.init_segment = BitpackingInitSegment<T>;
-	//bitpacking.serialize_state = BitpackingSerializeState<T>;
+	// bitpacking.serialize_state = BitpackingSerializeState<T>;
 	// bitpacking.deserialize_state = BitpackingDeserializeState<T>;
 	// bitpacking.cleanup_state = ZSTDStorage::CleanupState;
 	return bitpacking;


### PR DESCRIPTION
…Santa did not bring it;

so I tried myself ;-)

This pull request will do:

- Create a BitpackingSegmentState that overrides GetSegmentInfo to return mode info
- Add BitpackingInitSegment that returns segment-info (used in ColumnData)
- Add BitpackingInitSegment / init_segment to the compressionfunction

(I also renamed BitpackingCompressState to BitpackingCompressionState for consistency with other compression code.)

The approach implemented seems to work correctly and passes tests locally.

However, the new information is only shown when you first close the database and reopen it. If you only use `CHECKPOINT`, `init_segment` is not called and the modes not reported. I am stuck where to fix this; it seems that this would be a step related to `ConvertToPersistent` that I overlook but I do not understand what I need to do to make it work.

I have tested using the following SQL (but because of this incomplete behaviour not yet added as a test):

```
pragma force_compression = 'BitPacking';
CREATE or replace TABLE test (a INTEGER, b INTEGER);
insert into test values (10,12), (11,12), (12,11), (NULL,NULL);
insert into test values (10,12), (33,33), (33,33), (10,12);
select segment_id, row_group_id, block_id, block_offset, compression, segment_info FROM pragma_storage_info('test') order by segment_id, row_group_id  asc;
checkpoint;
select segment_id, row_group_id, block_id, block_offset, compression, segment_info FROM pragma_storage_info('test') order by segment_id, row_group_id  asc;
```

After closing the CLI and restarting it on the same database, and then doing
```
select segment_id, row_group_id, block_id, block_offset, compression, segment_info FROM pragma_storage_info('test') order by segment_id, row_group_id  asc;
```

the `pragma_storage_info` reports `segment_info` that includes the bitpacking mode.

Hoping for some DuckDB compression guru advice, A.

```
D select segment_id, row_group_id, block_id, block_offset, compression, segment_info FROM pragma_storage_info('test') order by segment_id, row_group_id  asc;
┌────────────┬──────────────┬──────────┬──────────────┬──────────────┬──────────────┐
│ segment_id │ row_group_id │ block_id │ block_offset │ compression  │ segment_info │
│   int64    │    int64     │  int64   │    int64     │   varchar    │   varchar    │
├────────────┼──────────────┼──────────┼──────────────┼──────────────┼──────────────┤
│          0 │            0 │        1 │            0 │ BitPacking   │ Mode: for    │
│          0 │            0 │        1 │           48 │ Uncompressed │              │
│          0 │            0 │        1 │          304 │ BitPacking   │ Mode: for    │
│          0 │            0 │        1 │          352 │ Uncompressed │              │
└────────────┴──────────────┴──────────┴──────────────┴──────────────┴──────────────┘
```