### PR TITLE
Store catalog and schema names in Function objects for serialization

### DIFF
--- a/src/catalog/catalog_entry/scalar_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/scalar_function_catalog_entry.cpp
@@ -1,12 +1,17 @@
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/parser/parsed_data/alter_scalar_function_info.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
 
 ScalarFunctionCatalogEntry::ScalarFunctionCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema,
                                                        CreateScalarFunctionInfo &info)
     : FunctionEntry(CatalogType::SCALAR_FUNCTION_ENTRY, catalog, schema, info), functions(info.functions) {
+	for (auto &function : functions.functions) {
+		function.catalog_name = catalog.GetAttached().GetName();
+		function.schema_name = schema.name;
+	}
 }
 
 unique_ptr<CatalogEntry> ScalarFunctionCatalogEntry::AlterEntry(CatalogTransaction transaction, AlterInfo &info) {

--- a/src/catalog/catalog_entry/table_function_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_function_catalog_entry.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/parser/parsed_data/alter_table_function_info.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
 
@@ -7,6 +8,10 @@ TableFunctionCatalogEntry::TableFunctionCatalogEntry(Catalog &catalog, SchemaCat
                                                      CreateTableFunctionInfo &info)
     : FunctionEntry(CatalogType::TABLE_FUNCTION_ENTRY, catalog, schema, info), functions(std::move(info.functions)) {
 	D_ASSERT(this->functions.Size() > 0);
+	for (auto &function : functions.functions) {
+		function.catalog_name = catalog.GetAttached().GetName();
+		function.schema_name = schema.name;
+	}
 }
 
 unique_ptr<CatalogEntry> TableFunctionCatalogEntry::AlterEntry(CatalogTransaction transaction, AlterInfo &info) {

--- a/src/common/exception/binder_exception.cpp
+++ b/src/common/exception/binder_exception.cpp
@@ -23,16 +23,23 @@ BinderException BinderException::ColumnNotFound(const string &name, const vector
 	    StringUtil::Format("Referenced column \"%s\" not found in FROM clause!%s", name, candidate_str), extra_info);
 }
 
-BinderException BinderException::NoMatchingFunction(const string &name, const vector<LogicalType> &arguments,
+BinderException BinderException::NoMatchingFunction(const string &catalog_name, const string &schema_name,
+                                                    const string &name, const vector<LogicalType> &arguments,
                                                     const vector<string> &candidates) {
 	auto extra_info = Exception::InitializeExtraInfo("NO_MATCHING_FUNCTION", optional_idx());
 	// no matching function was found, throw an error
-	string call_str = Function::CallToString(name, arguments);
+	string call_str = Function::CallToString(catalog_name, schema_name, name, arguments);
 	string candidate_str;
 	for (auto &candidate : candidates) {
 		candidate_str += "\t" + candidate + "\n";
 	}
 	extra_info["name"] = name;
+	if (!catalog_name.empty()) {
+		extra_info["catalog"] = catalog_name;
+	}
+	if (!schema_name.empty()) {
+		extra_info["schema"] = schema_name;
+	}
 	extra_info["call"] = call_str;
 	if (!candidates.empty()) {
 		extra_info["candidates"] = StringUtil::Join(candidates, ",");

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -49,7 +49,7 @@ SimpleFunction::~SimpleFunction() {
 }
 
 string SimpleFunction::ToString() const {
-	return Function::CallToString(name, arguments, varargs);
+	return Function::CallToString(catalog_name, schema_name, name, arguments, varargs);
 }
 
 bool SimpleFunction::HasVarArgs() const {
@@ -65,7 +65,7 @@ SimpleNamedParameterFunction::~SimpleNamedParameterFunction() {
 }
 
 string SimpleNamedParameterFunction::ToString() const {
-	return Function::CallToString(name, arguments, named_parameters);
+	return Function::CallToString(catalog_name, schema_name, name, arguments, named_parameters);
 }
 
 bool SimpleNamedParameterFunction::HasNamedParameters() const {
@@ -84,7 +84,7 @@ BaseScalarFunction::~BaseScalarFunction() {
 }
 
 string BaseScalarFunction::ToString() const {
-	return Function::CallToString(name, arguments, varargs, return_type);
+	return Function::CallToString(catalog_name, schema_name, name, arguments, varargs, return_type);
 }
 
 // add your initializer for new functions here
@@ -113,8 +113,18 @@ hash_t BaseScalarFunction::Hash() const {
 	return hash;
 }
 
-string Function::CallToString(const string &name, const vector<LogicalType> &arguments, const LogicalType &varargs) {
-	string result = name + "(";
+static bool RequiresCatalogAndSchemaNamePrefix(const string &catalog_name, const string &schema_name) {
+	return !catalog_name.empty() && catalog_name != SYSTEM_CATALOG && !schema_name.empty() &&
+	       schema_name != DEFAULT_SCHEMA;
+}
+
+string Function::CallToString(const string &catalog_name, const string &schema_name, const string &name,
+                              const vector<LogicalType> &arguments, const LogicalType &varargs) {
+	string result;
+	if (RequiresCatalogAndSchemaNamePrefix(catalog_name, schema_name)) {
+		result += catalog_name + "." + schema_name + ".";
+	}
+	result += name + "(";
 	vector<string> string_arguments;
 	for (auto &arg : arguments) {
 		string_arguments.push_back(arg.ToString());
@@ -126,14 +136,16 @@ string Function::CallToString(const string &name, const vector<LogicalType> &arg
 	return result + ")";
 }
 
-string Function::CallToString(const string &name, const vector<LogicalType> &arguments, const LogicalType &varargs,
+string Function::CallToString(const string &catalog_name, const string &schema_name, const string &name,
+                              const vector<LogicalType> &arguments, const LogicalType &varargs,
                               const LogicalType &return_type) {
-	string result = CallToString(name, arguments, varargs);
+	string result = CallToString(catalog_name, schema_name, name, arguments, varargs);
 	result += " -> " + return_type.ToString();
 	return result;
 }
 
-string Function::CallToString(const string &name, const vector<LogicalType> &arguments,
+string Function::CallToString(const string &catalog_name, const string &schema_name, const string &name,
+                              const vector<LogicalType> &arguments,
                               const named_parameter_type_map_t &named_parameters) {
 	vector<string> input_arguments;
 	input_arguments.reserve(arguments.size() + named_parameters.size());
@@ -143,7 +155,11 @@ string Function::CallToString(const string &name, const vector<LogicalType> &arg
 	for (auto &kv : named_parameters) {
 		input_arguments.push_back(StringUtil::Format("%s : %s", kv.first, kv.second.ToString()));
 	}
-	return StringUtil::Format("%s(%s)", name, StringUtil::Join(input_arguments, ", "));
+	string prefix = "";
+	if (RequiresCatalogAndSchemaNamePrefix(catalog_name, schema_name)) {
+		prefix = StringUtil::Format("%s.%s.", catalog_name, schema_name);
+	}
+	return StringUtil::Format("%s%s(%s)", prefix, name, StringUtil::Join(input_arguments, ", "));
 }
 
 void Function::EraseArgument(SimpleFunction &bound_function, vector<unique_ptr<Expression>> &arguments,

--- a/src/include/duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/catalog/catalog_set.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
 
@@ -24,6 +25,10 @@ public:
 public:
 	AggregateFunctionCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateAggregateFunctionInfo &info)
 	    : FunctionEntry(CatalogType::AGGREGATE_FUNCTION_ENTRY, catalog, schema, info), functions(info.functions) {
+		for (auto &function : functions.functions) {
+			function.catalog_name = catalog.GetAttached().GetName();
+			function.schema_name = schema.name;
+		}
 	}
 
 	//! The aggregate functions

--- a/src/include/duckdb/common/exception/binder_exception.hpp
+++ b/src/include/duckdb/common/exception/binder_exception.hpp
@@ -44,8 +44,8 @@ public:
 
 	static BinderException ColumnNotFound(const string &name, const vector<string> &similar_bindings,
 	                                      QueryErrorContext context = QueryErrorContext());
-	static BinderException NoMatchingFunction(const string &name, const vector<LogicalType> &arguments,
-	                                          const vector<string> &candidates);
+	static BinderException NoMatchingFunction(const string &catalog_name, const string &schema_name, const string &name,
+	                                          const vector<LogicalType> &arguments, const vector<string> &candidates);
 	static BinderException Unsupported(ParsedExpression &expr, const string &message);
 };
 

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -105,15 +105,24 @@ public:
 	//! Additional Information to specify function from it's name
 	string extra_info;
 
+	// Optional catalog name of the function
+	string catalog_name;
+
+	// Optional schema name of the function
+	string schema_name;
+
 public:
 	//! Returns the formatted string name(arg1, arg2, ...)
-	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
+	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
+	                                      const vector<LogicalType> &arguments,
 	                                      const LogicalType &varargs = LogicalType::INVALID);
 	//! Returns the formatted string name(arg1, arg2..) -> return_type
-	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
-	                                      const LogicalType &varargs, const LogicalType &return_type);
+	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
+	                                      const vector<LogicalType> &arguments, const LogicalType &varargs,
+	                                      const LogicalType &return_type);
 	//! Returns the formatted string name(arg1, arg2.., np1=a, np2=b, ...)
-	DUCKDB_API static string CallToString(const string &name, const vector<LogicalType> &arguments,
+	DUCKDB_API static string CallToString(const string &catalog_name, const string &schema_name, const string &name,
+	                                      const vector<LogicalType> &arguments,
 	                                      const named_parameter_type_map_t &named_parameters);
 
 	//! Used in the bind to erase an argument from a function

--- a/src/include/duckdb/function/function_binder.hpp
+++ b/src/include/duckdb/function/function_binder.hpp
@@ -83,9 +83,9 @@ private:
 	                                         const vector<LogicalType> &arguments, ErrorData &error);
 
 	template <class T>
-	optional_idx MultipleCandidateException(const string &name, FunctionSet<T> &functions,
-	                                        vector<idx_t> &candidate_functions, const vector<LogicalType> &arguments,
-	                                        ErrorData &error);
+	optional_idx MultipleCandidateException(const string &catalog_name, const string &schema_name, const string &name,
+	                                        FunctionSet<T> &functions, vector<idx_t> &candidate_functions,
+	                                        const vector<LogicalType> &arguments, ErrorData &error);
 
 	template <class T>
 	optional_idx BindFunctionFromArguments(const string &name, FunctionSet<T> &functions,


### PR DESCRIPTION
Functions created in arbitrary catalogs and schemas require their catalog and schema names to be serialized. Without this, FunctionSerializer fails to locate functions as it only searches SYSTEM_CATALOG and DEFAULT_SCHEMA.

This change adds catalog and schema name storage to Function objects. The corresponding names are set during the construction of ScalarFunctionCatalogEntry, TableFunctionCatalogEntry, and AggregateFunctionCatalogEntry instances, ensuring successful serialization and reference resolution.

This was suggested in discussion on Discord by @Tishj 