### PR TITLE
Make `max_temp_directory_size` round-trip

### DIFF
--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -548,8 +548,9 @@ idx_t DBConfig::ParseMemoryLimit(const string &arg) {
 	} else if (unit == "tib") {
 		multiplier = 1024LL * 1024LL * 1024LL * 1024LL;
 	} else {
-		throw ParserException("Unknown unit for memory_limit: %s (expected: KB, MB, GB, TB for 1000^i units or KiB, "
-		                      "MiB, GiB, TiB for 1024^i unites)");
+		throw ParserException("Unknown unit for memory_limit: '%s' (expected: KB, MB, GB, TB for 1000^i units or KiB, "
+		                      "MiB, GiB, TiB for 1024^i units)",
+		                      unit);
 	}
 	return LossyNumericCast<idx_t>(static_cast<double>(multiplier) * limit);
 }

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -895,6 +895,10 @@ Value MaxMemorySetting::GetSetting(const ClientContext &context) {
 // Max Temp Directory Size
 //===----------------------------------------------------------------------===//
 void MaxTempDirectorySizeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	if (input == "90% of available disk space") {
+		ResetGlobal(db, config);
+		return;
+	}
 	auto maximum_swap_space = DBConfig::ParseMemoryLimit(input.ToString());
 	if (maximum_swap_space == DConstants::INVALID_INDEX) {
 		// We use INVALID_INDEX to indicate that the value is not set by the user


### PR DESCRIPTION
Python reimplementation of SQLogic tests relies on setting (at least some of them) to be 'round-tripped',
Basically that:
```sql
SET VARIABLE A = (SELECT current_setting('max_temp_directory_size'));
SET max_temp_directory_size = getvariable('A');
```
should be always valid (and not change the setting).

After https://github.com/duckdb/duckdb/pull/15057 MaxMemorySetting implementation was not able to round-trip due to the introduction of the special "90% of current memory setting" string to handle the special case.

Note that making the string a static const * would likely be better, but was unsure where to move it.

Adding this both since it's minor but nice to have AND since will restore nightly SQLogic Python reimplementation.

Also fixing a problem in the syntax of the error that was thrown.
This is to be tested in the Python's SQLogic implementation.