### PR TITLE
Avoid fast fail: change defaults to run all tests in more cases

### DIFF
--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -19,7 +19,8 @@ def valid_timeout(value):
 
 parser = argparse.ArgumentParser(description='Run tests one by one with optional flags.')
 parser.add_argument('unittest_program', help='Path to the unittest program')
-parser.add_argument('--no-exit', action='store_true', help='Do not exit after running tests')
+parser.add_argument('--no-exit', action='store_true', help='Execute all tests, without stopping on first error')
+parser.add_argument('--fast-fail', action='store_true', help='Terminate on first error')
 parser.add_argument('--profile', action='store_true', help='Enable profiling')
 parser.add_argument('--no-assertions', action='store_false', help='Disable assertions')
 parser.add_argument('--time_execution', action='store_true', help='Measure and print the execution time of each test')
@@ -47,6 +48,13 @@ if not args.unittest_program:
 # Access the arguments
 unittest_program = args.unittest_program
 no_exit = args.no_exit
+fast_fail = args.fast_fail
+
+if no_exit:
+    if fast_fail:
+        print("--no-exit and --fast-fail can't be combined")
+        exit(1)
+
 profile = args.profile
 assertions = args.no_assertions
 time_execution = args.time_execution
@@ -87,7 +95,7 @@ all_passed = True
 def fail():
     global all_passed
     all_passed = False
-    if not no_exit:
+    if fast_fail:
         exit(1)
 
 

--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -332,9 +332,9 @@ class QueryResult:
                 hash_compare_error = values[0] != hash_value
 
             if hash_compare_error:
-                expected_result = self.result_label_map.get(query_label)
-                logger.wrong_result_hash(expected_result, self)
-                self.fail_query(query)
+                expected_result = runner.result_label_map.get(query_label)
+                # logger.wrong_result_hash(expected_result, self)
+                context.fail(query)
 
             assert not hash_compare_error
 

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -173,6 +173,7 @@ def main():
         file_paths = [os.path.relpath(path, test_directory) for path in file_paths]
 
     start_offset = args.start_offset
+    should_fail = False
 
     total_tests = len(file_paths)
     for i, file_path in enumerate(file_paths):
@@ -201,11 +202,13 @@ def main():
             continue
         if result.type == ExecuteResult.Type.ERROR:
             print("ERROR")
-            exit(1)
+            should_fail = True
     if len(executor.skip_log) != 0:
         for item in executor.skip_log:
             print(item)
         executor.skip_log.clear()
+    if should_fail:
+        exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
scripts/run_tests_one_by_one.py and SQLLogic's tests Python wrapper currently exit on first failure.

I think it carries more information, given multiple failures might be easier to debug, for limited cost, given default should be still all passing so all executed.

Also fix some nonsense in scripts/sqllogictest/result.py, unsure when it has become outdated.