### PR TITLE
Update progress_bar.cpp / drop DUCKDB_DISABLE_PRINT macro

### DIFF
--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -130,13 +130,11 @@ void ProgressBar::Update(bool final) {
 		query_progress.percentage = new_percentage;
 	}
 	if (ShouldPrint(final)) {
-#ifndef DUCKDB_DISABLE_PRINT
 		if (final) {
 			FinishProgressBarPrint();
 		} else {
 			PrintProgress(LossyNumericCast<int>(query_progress.percentage.load()));
 		}
-#endif
 	}
 }
 


### PR DESCRIPTION
#ifndef DUCKDB_DISABLE_PRINT seems redundant since it is already  used in printer.cpp and it prevents from using a display set via config.create_display_func when compiled with flag -DDUCKDB_DISABLE_PRINT, like the duckdb-r package, where I'm trying to implement a display.

https://github.com/duckdb/duckdb/blob/main/src/common/printer.cpp
https://github.com/duckdb/duckdb-r/pull/951

PrintProgress  -> TerminalProgressBarDisplay::Update -> TerminalProgressBarDisplay::PrintProgressInternal -> Printer::RawPrint and there is a macro there.

Plus there is already a config option to enable_progress_bar and default is FALSE.

So. Can it be remove?
cc: @krlmlr 
