### PR TITLE
Fix some external join benchmark specifications

### DIFF
--- a/benchmark/micro/join/external_join_partition_order.benchmark
+++ b/benchmark/micro/join/external_join_partition_order.benchmark
@@ -12,12 +12,12 @@ create table build as select range c from range(1000e5::bigint);
 create table probe as select range c from range(1000e5::bigint);
 
 init
-set threads=1;
+set threads=4;
 set temp_directory='${BENCHMARK_DIR}/external_join_partition_order.duckdb.tmp';
 set memory_limit='1000mb';
 
 run
-select sum(c) from probe join build using (c)
+select count(*) from probe join build using (c)
 
 result I
-4999999950000000
+100000000

--- a/benchmark/micro/join/external_join_partition_selection.benchmark
+++ b/benchmark/micro/join/external_join_partition_selection.benchmark
@@ -18,7 +18,7 @@ set temp_directory='${BENCHMARK_DIR}/external_join_partition_selection.duckdb.tm
 set memory_limit='500mb';
 
 run
-select sum(c) from probe join build using (c)
+select count(*) from probe join build using (c)
 
 result I
-50000620000000
+20000000


### PR DESCRIPTION
Found by CI.

I changed this benchmark a few times before sending the PR last time, but the DB was cached so I got a bit confused. I removed my local cache and properly checked the results this time.