### PR TITLE
File url scheme

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -115,7 +115,7 @@ string FileSystem::GetEnvVariable(const string &name) {
 
 bool FileSystem::IsPathAbsolute(const string &path) {
 	auto path_separator = PathSeparator(path);
-	return PathMatched(path, path_separator);
+	return PathMatched(path, path_separator) || StringUtil::StartsWith(path, "file://");
 }
 
 string FileSystem::PathSeparator(const string &path) {
@@ -237,7 +237,11 @@ string FileSystem::NormalizeAbsolutePath(const string &path) {
 }
 
 string FileSystem::PathSeparator(const string &path) {
-	return "\\";
+	if (StringUtil::StartsWith(path, "file://")) {
+		return "/";
+	} else {
+		return "\\";
+	}
 }
 
 void FileSystem::SetWorkingDirectory(const string &path) {

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -115,7 +115,7 @@ string FileSystem::GetEnvVariable(const string &name) {
 
 bool FileSystem::IsPathAbsolute(const string &path) {
 	auto path_separator = PathSeparator(path);
-	return PathMatched(path, path_separator) || StringUtil::StartsWith(path, "file://");
+	return PathMatched(path, path_separator) || StringUtil::StartsWith(path, "file:/");
 }
 
 string FileSystem::PathSeparator(const string &path) {
@@ -237,7 +237,7 @@ string FileSystem::NormalizeAbsolutePath(const string &path) {
 }
 
 string FileSystem::PathSeparator(const string &path) {
-	if (StringUtil::StartsWith(path, "file://")) {
+	if (StringUtil::StartsWith(path, "file:/")) {
 		return "/";
 	} else {
 		return "\\";

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -237,7 +237,7 @@ string FileSystem::NormalizeAbsolutePath(const string &path) {
 }
 
 string FileSystem::PathSeparator(const string &path) {
-	if (StringUtil::StartsWith(path, "file:/")) {
+	if (StringUtil::StartsWith(path, "file:")) {
 		return "/";
 	} else {
 		return "\\";

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -93,7 +93,7 @@ bool LocalFileSystem::IsPipe(const string &filename, optional_ptr<FileOpener> op
 #else
 static std::wstring NormalizePathAndConvertToUnicode(const string &path) {
 	string normalized_path_copy;
-	const char * normalized_path;
+	const char *normalized_path;
 	if (StringUtil::StartsWith(path, "file://")) {
 		normalized_path_copy = LocalFileSystem::NormalizeLocalPath(path);
 		normalized_path_copy = LocalFileSystem().ConvertSeparators(normalized_path_copy);
@@ -144,7 +144,7 @@ bool LocalFileSystem::IsPipe(const string &filename, optional_ptr<FileOpener> op
 struct UnixFileHandle : public FileHandle {
 public:
 	UnixFileHandle(FileSystem &file_system, string path, int fd, FileOpenFlags flags)
-		: FileHandle(file_system, std::move(path), flags), fd(fd) {
+	    : FileHandle(file_system, std::move(path), flags), fd(fd) {
 	}
 	~UnixFileHandle() override {
 		UnixFileHandle::Close();
@@ -199,14 +199,14 @@ static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
 	// try to find out more about the process holding the lock
 	struct proc_bsdshortinfo proc;
 	if (proc_pidinfo(pid, PROC_PIDT_SHORTBSDINFO, 0, &proc, PROC_PIDT_SHORTBSDINFO_SIZE) ==
-		PROC_PIDT_SHORTBSDINFO_SIZE) {
+	    PROC_PIDT_SHORTBSDINFO_SIZE) {
 		process_name = proc.pbsi_comm; // only a short version however, let's take it in case proc_pidpath() below fails
 		// try to get actual name of conflicting process owner
 		auto pw = getpwuid(proc.pbsi_uid);
 		if (pw) {
 			process_owner = pw->pw_name;
 		}
-		}
+	}
 #else
 	return string();
 #endif
@@ -217,9 +217,9 @@ static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
 		process_name = full_exec_path;
 	}
 	return StringUtil::Format("Conflicting lock is held in %s%s",
-							  !process_name.empty() ? StringUtil::Format("%s (PID %d)", process_name, pid)
-													: StringUtil::Format("PID %d", pid),
-							  !process_owner.empty() ? StringUtil::Format(" by user %s", process_owner) : "");
+	                          !process_name.empty() ? StringUtil::Format("%s (PID %d)", process_name, pid)
+	                                                : StringUtil::Format("PID %d", pid),
+	                          !process_owner.empty() ? StringUtil::Format(" by user %s", process_owner) : "");
 }
 
 #elif __linux__
@@ -262,9 +262,9 @@ static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
 	}
 
 	return StringUtil::Format("Conflicting lock is held in %s%s",
-							  !process_name.empty() ? StringUtil::Format("%s (PID %d)", process_name, pid)
-													: StringUtil::Format("PID %d", pid),
-							  !process_owner.empty() ? StringUtil::Format(" by user %s", process_owner) : "");
+	                          !process_name.empty() ? StringUtil::Format("%s (PID %d)", process_name, pid)
+	                                                : StringUtil::Format("PID %d", pid),
+	                          !process_owner.empty() ? StringUtil::Format(" by user %s", process_owner) : "");
 }
 
 #else
@@ -281,8 +281,8 @@ bool LocalFileSystem::IsPrivateFile(const string &path_p, FileOpener *opener) {
 
 	if (lstat(normalized_path, &st) != 0) {
 		throw IOException(
-			"Failed to stat '%s' when checking file permissions, file may be missing or have incorrect permissions",
-			path.c_str());
+		    "Failed to stat '%s' when checking file permissions, file may be missing or have incorrect permissions",
+		    path.c_str());
 	}
 
 	// If group or other have any permission, the file is not private
@@ -294,7 +294,7 @@ bool LocalFileSystem::IsPrivateFile(const string &path_p, FileOpener *opener) {
 }
 
 unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenFlags flags,
-												 optional_ptr<FileOpener> opener) {
+                                                 optional_ptr<FileOpener> opener) {
 	auto path = FileSystem::ExpandPath(path_p, opener);
 	auto normalized_path = NormalizeLocalPath(path);
 	if (flags.Compression() != FileCompressionType::UNCOMPRESSED) {
@@ -401,7 +401,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 						errno = 0;
 					} else {
 						extended_error = "File locks are not supported for this file system, cannot open the file in "
-										 "read-write mode. Try opening the file in read-only mode";
+						                 "read-write mode. Try opening the file in read-only mode";
 					}
 				}
 			}
@@ -420,8 +420,8 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 						rc = fcntl(fd, F_SETLK, &fl);
 						if (rc != -1) { // success!
 							extended_error +=
-								". However, you would be able to open this database in read-only mode, e.g. by "
-								"using the -readonly parameter in the CLI";
+							    ". However, you would be able to open this database in read-only mode, e.g. by "
+							    "using the -readonly parameter in the CLI";
 						}
 					}
 				}
@@ -431,7 +431,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 				}
 				extended_error += ". See also https://duckdb.org/docs/connect/concurrency";
 				throw IOException("Could not set lock on file \"%s\": %s", {{"errno", std::to_string(retained_errno)}},
-								  path, extended_error);
+				                  path, extended_error);
 			}
 		}
 	}
@@ -443,7 +443,7 @@ void LocalFileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
 	off_t offset = lseek(fd, UnsafeNumericCast<off_t>(location), SEEK_SET);
 	if (offset == (off_t)-1) {
 		throw IOException("Could not seek to location %lld for file \"%s\": %s", {{"errno", std::to_string(errno)}},
-						  location, handle.path, strerror(errno));
+		                  location, handle.path, strerror(errno));
 	}
 }
 
@@ -452,7 +452,7 @@ idx_t LocalFileSystem::GetFilePointer(FileHandle &handle) {
 	off_t position = lseek(fd, 0, SEEK_CUR);
 	if (position == (off_t)-1) {
 		throw IOException("Could not get file position file \"%s\": %s", {{"errno", std::to_string(errno)}},
-						  handle.path, strerror(errno));
+		                  handle.path, strerror(errno));
 	}
 	return UnsafeNumericCast<idx_t>(position);
 }
@@ -462,15 +462,15 @@ void LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 	auto read_buffer = char_ptr_cast(buffer);
 	while (nr_bytes > 0) {
 		int64_t bytes_read =
-			pread(fd, read_buffer, UnsafeNumericCast<size_t>(nr_bytes), UnsafeNumericCast<off_t>(location));
+		    pread(fd, read_buffer, UnsafeNumericCast<size_t>(nr_bytes), UnsafeNumericCast<off_t>(location));
 		if (bytes_read == -1) {
 			throw IOException("Could not read from file \"%s\": %s", {{"errno", std::to_string(errno)}}, handle.path,
-							  strerror(errno));
+			                  strerror(errno));
 		}
 		if (bytes_read == 0) {
 			throw IOException(
-				"Could not read enough bytes from file \"%s\": attempted to read %llu bytes from location %llu",
-				handle.path, nr_bytes, location);
+			    "Could not read enough bytes from file \"%s\": attempted to read %llu bytes from location %llu",
+			    handle.path, nr_bytes, location);
 		}
 		read_buffer += bytes_read;
 		nr_bytes -= bytes_read;
@@ -483,7 +483,7 @@ int64_t LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes
 	int64_t bytes_read = read(fd, buffer, UnsafeNumericCast<size_t>(nr_bytes));
 	if (bytes_read == -1) {
 		throw IOException("Could not read from file \"%s\": %s", {{"errno", std::to_string(errno)}}, handle.path,
-						  strerror(errno));
+		                  strerror(errno));
 	}
 	return bytes_read;
 }
@@ -493,14 +493,14 @@ void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, 
 	auto write_buffer = char_ptr_cast(buffer);
 	while (nr_bytes > 0) {
 		int64_t bytes_written =
-			pwrite(fd, write_buffer, UnsafeNumericCast<size_t>(nr_bytes), UnsafeNumericCast<off_t>(location));
+		    pwrite(fd, write_buffer, UnsafeNumericCast<size_t>(nr_bytes), UnsafeNumericCast<off_t>(location));
 		if (bytes_written < 0) {
 			throw IOException("Could not write file \"%s\": %s", {{"errno", std::to_string(errno)}}, handle.path,
-							  strerror(errno));
+			                  strerror(errno));
 		}
 		if (bytes_written == 0) {
 			throw IOException("Could not write to file \"%s\" - attempted to write 0 bytes: %s",
-							  {{"errno", std::to_string(errno)}}, handle.path, strerror(errno));
+			                  {{"errno", std::to_string(errno)}}, handle.path, strerror(errno));
 		}
 		write_buffer += bytes_written;
 		nr_bytes -= bytes_written;
@@ -516,7 +516,7 @@ int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_byte
 		int64_t current_bytes_written = write(fd, buffer, bytes_to_write);
 		if (current_bytes_written <= 0) {
 			throw IOException("Could not write file \"%s\": %s", {{"errno", std::to_string(errno)}}, handle.path,
-							  strerror(errno));
+			                  strerror(errno));
 		}
 		bytes_written += current_bytes_written;
 		buffer = (void *)(data_ptr_cast(buffer) + current_bytes_written);
@@ -533,7 +533,7 @@ bool LocalFileSystem::Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_
 #else
 	int fd = handle.Cast<UnixFileHandle>().fd;
 	int res = fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, UnsafeNumericCast<int64_t>(offset_bytes),
-						UnsafeNumericCast<int64_t>(length_bytes));
+	                    UnsafeNumericCast<int64_t>(length_bytes));
 	return res == 0;
 #endif
 #else
@@ -546,7 +546,7 @@ int64_t LocalFileSystem::GetFileSize(FileHandle &handle) {
 	struct stat s;
 	if (fstat(fd, &s) == -1) {
 		throw IOException("Failed to get file size for file \"%s\": %s", {{"errno", std::to_string(errno)}},
-						  handle.path, strerror(errno));
+		                  handle.path, strerror(errno));
 	}
 	return s.st_size;
 }
@@ -556,7 +556,7 @@ time_t LocalFileSystem::GetLastModifiedTime(FileHandle &handle) {
 	struct stat s;
 	if (fstat(fd, &s) == -1) {
 		throw IOException("Failed to get last modified time for file \"%s\": %s", {{"errno", std::to_string(errno)}},
-						  handle.path, strerror(errno));
+		                  handle.path, strerror(errno));
 	}
 	return s.st_mtime;
 }
@@ -570,7 +570,7 @@ void LocalFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
 	int fd = handle.Cast<UnixFileHandle>().fd;
 	if (ftruncate(fd, new_size) != 0) {
 		throw IOException("Could not truncate file \"%s\": %s", {{"errno", std::to_string(errno)}}, handle.path,
-						  strerror(errno));
+		                  strerror(errno));
 	}
 }
 
@@ -597,11 +597,11 @@ void LocalFileSystem::CreateDirectory(const string &directory, optional_ptr<File
 		/* Directory does not exist. EEXIST for race condition */
 		if (mkdir(normalized_dir, 0755) != 0 && errno != EEXIST) {
 			throw IOException("Failed to create directory \"%s\": %s", {{"errno", std::to_string(errno)}}, directory,
-							  strerror(errno));
+			                  strerror(errno));
 		}
 	} else if (!S_ISDIR(st.st_mode)) {
 		throw IOException("Failed to create directory \"%s\": path exists but is not a directory!",
-						  {{"errno", std::to_string(errno)}}, directory);
+		                  {{"errno", std::to_string(errno)}}, directory);
 	}
 }
 
@@ -654,12 +654,12 @@ void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener
 	auto normalized_file = NormalizeLocalPath(filename);
 	if (std::remove(normalized_file) != 0) {
 		throw IOException("Could not remove file \"%s\": %s", {{"errno", std::to_string(errno)}}, filename,
-						  strerror(errno));
+		                  strerror(errno));
 	}
 }
 
 bool LocalFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
-								FileOpener *opener) {
+                                FileOpener *opener) {
 	auto normalized_dir = NormalizeLocalPath(directory);
 	auto dir = opendir(normalized_dir);
 	if (!dir) {
@@ -728,8 +728,8 @@ std::string LocalFileSystem::GetLastErrorAsString() {
 
 	LPSTR messageBuffer = nullptr;
 	idx_t size =
-		FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-					   NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+	    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+	                   NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
 
 	std::string message(messageBuffer, size);
 
@@ -742,7 +742,7 @@ std::string LocalFileSystem::GetLastErrorAsString() {
 struct WindowsFileHandle : public FileHandle {
 public:
 	WindowsFileHandle(FileSystem &file_system, string path, HANDLE fd, FileOpenFlags flags)
-		: FileHandle(file_system, path, flags), position(0), fd(fd) {
+	    : FileHandle(file_system, path, flags), position(0), fd(fd) {
 	}
 	~WindowsFileHandle() override {
 		Close();
@@ -829,7 +829,7 @@ bool LocalFileSystem::IsPrivateFile(const string &path_p, FileOpener *opener) {
 }
 
 unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenFlags flags,
-												 optional_ptr<FileOpener> opener) {
+                                                 optional_ptr<FileOpener> opener) {
 	auto path = FileSystem::ExpandPath(path_p, opener);
 	auto unicode_path = NormalizePathAndConvertToUnicode(path);
 	if (flags.Compression() != FileCompressionType::UNCOMPRESSED) {
@@ -866,7 +866,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 		flags_and_attributes |= FILE_FLAG_NO_BUFFERING;
 	}
 	HANDLE hFile = CreateFileW(unicode_path.c_str(), desired_access, share_mode, NULL, creation_disposition,
-							   flags_and_attributes, NULL);
+	                           flags_and_attributes, NULL);
 	if (hFile == INVALID_HANDLE_VALUE) {
 		if (flags.ReturnNullIfNotExists() && GetLastError() == ERROR_FILE_NOT_FOUND) {
 			return nullptr;
@@ -912,7 +912,7 @@ static DWORD FSInternalRead(FileHandle &handle, HANDLE hFile, void *buffer, int6
 	if (!rc) {
 		auto error = LocalFileSystem::GetLastErrorAsString();
 		throw IOException("Could not read file \"%s\" (error in ReadFile(location: %llu, nr_bytes: %lld)): %s",
-						  handle.path, location, nr_bytes, error);
+		                  handle.path, location, nr_bytes, error);
 	}
 	return bytes_read;
 }
@@ -922,7 +922,7 @@ void LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, i
 	auto bytes_read = FSInternalRead(handle, hFile, buffer, nr_bytes, location);
 	if (bytes_read != nr_bytes) {
 		throw IOException("Could not read all bytes from file \"%s\": wanted=%lld read=%lld", handle.path, nr_bytes,
-						  bytes_read);
+		                  bytes_read);
 	}
 }
 
@@ -958,7 +958,7 @@ static int64_t FSWrite(FileHandle &handle, HANDLE hFile, void *buffer, int64_t n
 		DWORD current_bytes_written = FSInternalWrite(handle, hFile, buffer, bytes_to_write, location);
 		if (current_bytes_written <= 0) {
 			throw IOException("Could not write file \"%s\": %s", {{"errno", std::to_string(errno)}}, handle.path,
-							  strerror(errno));
+			                  strerror(errno));
 		}
 		bytes_written += current_bytes_written;
 		buffer = (void *)(data_ptr_cast(buffer) + current_bytes_written);
@@ -973,7 +973,7 @@ void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, 
 	auto bytes_written = FSWrite(handle, hFile, buffer, nr_bytes, location);
 	if (bytes_written != nr_bytes) {
 		throw IOException("Could not write all bytes from file \"%s\": wanted=%lld wrote=%lld", handle.path, nr_bytes,
-						  bytes_written);
+		                  bytes_written);
 	}
 }
 
@@ -1097,7 +1097,7 @@ void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener
 }
 
 bool LocalFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
-								FileOpener *opener) {
+                                FileOpener *opener) {
 	string search_dir = JoinPath(directory, "*");
 	auto unicode_path = NormalizePathAndConvertToUnicode(search_dir);
 
@@ -1202,7 +1202,7 @@ static bool IsSymbolicLink(const string &path) {
 }
 
 static void RecursiveGlobDirectories(FileSystem &fs, const string &path, vector<string> &result, bool match_directory,
-									 bool join_path) {
+                                     bool join_path) {
 
 	fs.ListFiles(path, [&](const string &fname, bool is_directory) {
 		string concat;
@@ -1224,7 +1224,7 @@ static void RecursiveGlobDirectories(FileSystem &fs, const string &path, vector<
 }
 
 static void GlobFilesInternal(FileSystem &fs, const string &path, const string &glob, bool match_directory,
-							  vector<string> &result, bool join_path) {
+                              vector<string> &result, bool join_path) {
 	fs.ListFiles(path, [&](const string &fname, bool is_directory) {
 		if (is_directory != match_directory) {
 			return;
@@ -1321,7 +1321,7 @@ vector<string> LocalFileSystem::Glob(const string &path, FileOpener *opener) {
 				continue;
 			}
 			if (splits.empty()) {
-//				splits.push_back(path.substr(file_url_path_offset, i-file_url_path_offset));
+				//				splits.push_back(path.substr(file_url_path_offset, i-file_url_path_offset));
 				splits.push_back(path.substr(0, i));
 			} else {
 				splits.push_back(path.substr(last_pos, i - last_pos));

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1080,7 +1080,7 @@ void LocalFileSystem::RemoveDirectory(const string &directory, optional_ptr<File
 }
 
 void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
-	auto normalized_path = LocalFileSystem::NormalizeLocalPath(directory);
+	auto normalized_path = LocalFileSystem::NormalizeLocalPath(filename);
 	auto unicode_path = WindowsUtil::UTF8ToUnicode(normalized_path);
 	if (!DeleteFileW(unicode_path.c_str())) {
 		auto error = LocalFileSystem::GetLastErrorAsString();

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -96,6 +96,9 @@ public:
 	//! Checks a file is private (checks for 600 on linux/macos, TODO: currently always returns true on windows)
 	static bool IsPrivateFile(const string &path_p, FileOpener *opener);
 
+	// Gets a pointer to the normalized file path (skipping any potential file:// prefix)
+	static const char* NormalizeLocalPath(const string &path);
+
 private:
 	//! Set the file pointer of a file handle to a specified location. Reads and writes will happen from this location
 	void SetFilePointer(FileHandle &handle, idx_t location);

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -96,7 +96,7 @@ public:
 	//! Checks a file is private (checks for 600 on linux/macos, TODO: currently always returns true on windows)
 	static bool IsPrivateFile(const string &path_p, FileOpener *opener);
 
-	// Gets a pointer to the normalized file path (skipping any potential file:// prefix)
+	// returns a C-string of the path that trims any file:// prefix
 	static const char *NormalizeLocalPath(const string &path);
 
 private:

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -97,7 +97,7 @@ public:
 	static bool IsPrivateFile(const string &path_p, FileOpener *opener);
 
 	// Gets a pointer to the normalized file path (skipping any potential file:// prefix)
-	static const char* NormalizeLocalPath(const string &path);
+	static const char *NormalizeLocalPath(const string &path);
 
 private:
 	//! Set the file pointer of a file handle to a specified location. Reads and writes will happen from this location

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -96,7 +96,7 @@ public:
 	//! Checks a file is private (checks for 600 on linux/macos, TODO: currently always returns true on windows)
 	static bool IsPrivateFile(const string &path_p, FileOpener *opener);
 
-	// returns a C-string of the path that trims any file:// prefix
+	// returns a C-string of the path that trims any file:/ prefix
 	static const char *NormalizeLocalPath(const string &path);
 
 private:

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -43,9 +43,9 @@ TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	}
 
 	// Path of format file:///bla/bla on 'nix and file:///X:/bla/bla on Windows
-	auto dname_triple_slash = fs->JoinPath("file://",dname_converted_slashes);
+	auto dname_triple_slash = fs->JoinPath("file://", dname_converted_slashes);
 	// Path of format file://localhost/bla/bla on 'nix and file://localhost/X:/bla/bla on Windows
-	auto dname_localhost = fs->JoinPath("file://localhost",dname_converted_slashes);
+	auto dname_localhost = fs->JoinPath("file://localhost", dname_converted_slashes);
 
 	string fname = "TEST_FILE";
 	string fname2 = "TEST_FILE_TWO";

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -36,8 +36,17 @@ TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
 	auto dname = fs->JoinPath(fs->GetWorkingDirectory(), TestCreatePath("TEST_DIR"));
 	auto dname_converted_slashes = StringUtil::Replace(dname, "\\", "/");
+
+	// handle differences between windows and linux
+	if (StringUtil::StartsWith(dname_converted_slashes, "/")) {
+		dname_converted_slashes = dname_converted_slashes.substr(1);
+	}
+
+	// Path of format file:///bla/bla on 'nix and file:///X:/bla/bla on Windows
 	auto dname_triple_slash = fs->JoinPath("file://",dname_converted_slashes);
+	// Path of format file://localhost/bla/bla on 'nix and file://localhost/X:/bla/bla on Windows
 	auto dname_localhost = fs->JoinPath("file://localhost",dname_converted_slashes);
+
 	string fname = "TEST_FILE";
 	string fname2 = "TEST_FILE_TWO";
 

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -11,9 +11,18 @@ using namespace std;
 static void create_dummy_file(string fname) {
 	string normalized_string;
 	if (StringUtil::StartsWith(fname, "file:///")) {
+#ifdef _WIN32
+		normalized_string = fname.substr(8);
+#else
 		normalized_string = fname.substr(7);
+#endif
+
 	} else if (StringUtil::StartsWith(fname, "file://localhost/")) {
+#ifdef _WIN32
 		normalized_string = fname.substr(18);
+#else
+		normalized_string = fname.substr(18);
+#endif
 	} else {
 		normalized_string = fname;
 	}
@@ -26,8 +35,9 @@ static void create_dummy_file(string fname) {
 TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
 	auto dname = fs->JoinPath(fs->GetWorkingDirectory(), TestCreatePath("TEST_DIR"));
-	auto dname_triple_slash = "file://" + dname;
-	auto dname_localhost = "file://localhost" + dname;
+	auto dname_converted_slashes = StringUtil::Replace(dname, "\\", "/");
+	auto dname_triple_slash = fs->JoinPath("file://",dname_converted_slashes);
+	auto dname_localhost = fs->JoinPath("file://localhost",dname_converted_slashes);
 	string fname = "TEST_FILE";
 	string fname2 = "TEST_FILE_TWO";
 

--- a/test/common/test_file_system.cpp
+++ b/test/common/test_file_system.cpp
@@ -46,6 +46,7 @@ TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	auto dname_triple_slash = fs->JoinPath("file://", dname_converted_slashes);
 	// Path of format file://localhost/bla/bla on 'nix and file://localhost/X:/bla/bla on Windows
 	auto dname_localhost = fs->JoinPath("file://localhost", dname_converted_slashes);
+	auto dname_no_host = fs->JoinPath("file:", dname_converted_slashes);
 
 	string fname = "TEST_FILE";
 	string fname2 = "TEST_FILE_TWO";
@@ -63,6 +64,7 @@ TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 
 	auto fname_in_dir = fs->JoinPath(dname_triple_slash, fname);
 	auto fname_in_dir2 = fs->JoinPath(dname_localhost, fname2);
+	auto fname_in_dir3 = fs->JoinPath(dname_no_host, fname2);
 
 	create_dummy_file(fname_in_dir);
 	REQUIRE(fs->FileExists(fname_in_dir));
@@ -84,8 +86,8 @@ TEST_CASE("Make sure the file:// protocol works as expected", "[file_system]") {
 	REQUIRE(!fs->FileExists(fname_in_dir));
 	REQUIRE(fs->FileExists(fname_in_dir2));
 
-	auto file_listing_after_move = fs->Glob(fs->JoinPath(dname_localhost, "*"));
-	REQUIRE(file_listing_after_move[0] == fname_in_dir2);
+	auto file_listing_after_move = fs->Glob(fs->JoinPath(dname_no_host, "*"));
+	REQUIRE(file_listing_after_move[0] == fname_in_dir3);
 
 	fs->RemoveDirectory(dname_triple_slash);
 

--- a/test/common/test_local_file_urls.test
+++ b/test/common/test_local_file_urls.test
@@ -1,5 +1,5 @@
 # name: test/common/test_local_file_urls.test
-# group: [file_system]
+# group: [common]
 
 # Note: __WORKING_DIRECTORY__ will be replaced with the full path to the working dir of the tests (root of duckdb repo)
 

--- a/test/common/test_local_file_urls.test
+++ b/test/common/test_local_file_urls.test
@@ -3,40 +3,46 @@
 
 # Note: __WORKING_DIRECTORY__ will be replaced with the full path to the working dir of the tests (root of duckdb repo)
 
+statement ok
+SET VARIABLE work_dir_triple_slash='file:///' || replace('__WORKING_DIRECTORY__', '\', '/')
+
+statement ok
+SET VARIABLE work_dir_localhost='file://localhost/' || replace('__WORKING_DIRECTORY__', '\', '/') || '/'
+
 # testing file:///some/path/to/duckdb/repo
 query II
-SELECT * FROM "file://__WORKING_DIRECTORY__/data/csv/normalize.csv";
+SELECT * FROM read_csv_auto(getvariable('work_dir_triple_slash') || '/data/csv/normalize.csv');
 ----
 John	ipsum
 
 # testing file://localhost/some/path/to/duckdb/repo
 query II
-SELECT * FROM "file://localhost__WORKING_DIRECTORY__/data/csv/normalize.csv";
+SELECT * FROM read_csv_auto(getvariable('work_dir_localhost') || '/data/csv/normalize.csv');
 ----
 John	ipsum
 
 # Test glob with file:///some/path
 query II
-SELECT file[:8], parse_filename(file) FROM glob('file://__WORKING_DIRECTORY__/data/*/bad_date_timestamp_mix.csv')
+SELECT file[:8], parse_filename(file) FROM glob(getvariable('work_dir_triple_slash') || '/data/*/bad_date_timestamp_mix.csv')
 ----
 file:///	bad_date_timestamp_mix.csv
 
 # Test glob with file://localhost/some/path/to/duckdb/repo
 query II
-SELECT file[:17], parse_filename(file) FROM glob('file://localhost__WORKING_DIRECTORY__/data/*/bad_date_timestamp_mix.csv')
+SELECT file[:17], parse_filename(file) FROM glob(getvariable('work_dir_localhost') || '/data/*/bad_date_timestamp_mix.csv')
 ----
 file://localhost/	bad_date_timestamp_mix.csv
 
 # Test scanning multiple files using glob with file:///some/path
 query III
-SELECT id, filename[:8], parse_filename(filename) FROM read_csv_auto("file://__WORKING_DIRECTORY__/data/csv/hive-partitioning/simple/*/*/test.csv", filename=1) ORDER BY id
+SELECT id, filename[:8], parse_filename(filename) FROM read_csv_auto(getvariable('work_dir_triple_slash') || '/data/csv/hive-partitioning/simple/*/*/test.csv', filename=1) ORDER BY id
 ----
 1	file:///	test.csv
 2	file:///	test.csv
 
 # Test scanning multiple files using glob with file://localhost/some/path
 query III
-SELECT id, filename[:17], parse_filename(filename) FROM read_csv_auto("file://localhost__WORKING_DIRECTORY__/data/csv/hive-partitioning/simple/*/*/test.csv", filename=1) ORDER BY id
+SELECT id, filename[:17], parse_filename(filename) FROM read_csv_auto(getvariable('work_dir_localhost') || '/data/csv/hive-partitioning/simple/*/*/test.csv', filename=1) ORDER BY id
 ----
 1	file://localhost/	test.csv
 2	file://localhost/	test.csv
@@ -54,12 +60,12 @@ statement ok
 create secret secret_without_file_path (TYPE HTTP);
 
 query I
-SELECT name FROM which_secret('file://__WORKING_DIRECTORY__/data/csv/hive-partitioning/simple/*/*/test.csv', 'http')
+SELECT name FROM which_secret(getvariable('work_dir_triple_slash') || '/data/csv/hive-partitioning/simple/*/*/test.csv', 'http')
 ----
 secret_file_url_tripleslash
 
 query I
-SELECT name FROM which_secret('file://localhost__WORKING_DIRECTORY__/data/csv/hive-partitioning/simple/*/*/test.csv', 'http')
+SELECT name FROM which_secret(getvariable('work_dir_localhost') || '/data/csv/hive-partitioning/simple/*/*/test.csv', 'http')
 ----
 secret_file_url_localhost
 

--- a/test/common/test_local_file_urls.test
+++ b/test/common/test_local_file_urls.test
@@ -4,10 +4,10 @@
 # Note: __WORKING_DIRECTORY__ will be replaced with the full path to the working dir of the tests (root of duckdb repo)
 
 statement ok
-SET VARIABLE work_dir_triple_slash='file:///' || replace('__WORKING_DIRECTORY__', '\', '/')
+SET VARIABLE work_dir_triple_slash='file:///' || ltrim(replace('__WORKING_DIRECTORY__', '\', '/'), '/')
 
 statement ok
-SET VARIABLE work_dir_localhost='file://localhost/' || replace('__WORKING_DIRECTORY__', '\', '/') || '/'
+SET VARIABLE work_dir_localhost='file://localhost/' || ltrim(replace('__WORKING_DIRECTORY__', '\', '/'), '/')
 
 # testing file:///some/path/to/duckdb/repo
 query II

--- a/test/common/test_local_file_urls.test
+++ b/test/common/test_local_file_urls.test
@@ -4,10 +4,19 @@
 # Note: __WORKING_DIRECTORY__ will be replaced with the full path to the working dir of the tests (root of duckdb repo)
 
 statement ok
+SET VARIABLE work_dir_no_host='file:/' || ltrim(replace('__WORKING_DIRECTORY__', '\', '/'), '/')
+
+statement ok
 SET VARIABLE work_dir_triple_slash='file:///' || ltrim(replace('__WORKING_DIRECTORY__', '\', '/'), '/')
 
 statement ok
 SET VARIABLE work_dir_localhost='file://localhost/' || ltrim(replace('__WORKING_DIRECTORY__', '\', '/'), '/')
+
+# testing file:/some/path/to/duckdb/repo
+query II
+SELECT * FROM read_csv_auto(getvariable('work_dir_no_host') || '/data/csv/normalize.csv');
+----
+John	ipsum
 
 # testing file:///some/path/to/duckdb/repo
 query II
@@ -21,6 +30,12 @@ SELECT * FROM read_csv_auto(getvariable('work_dir_localhost') || '/data/csv/norm
 ----
 John	ipsum
 
+# Test glob with file:/some/path
+query II
+SELECT file[:6], parse_filename(file) FROM glob(getvariable('work_dir_no_host') || '/data/*/bad_date_timestamp_mix.csv')
+----
+file:/	bad_date_timestamp_mix.csv
+
 # Test glob with file:///some/path
 query II
 SELECT file[:8], parse_filename(file) FROM glob(getvariable('work_dir_triple_slash') || '/data/*/bad_date_timestamp_mix.csv')
@@ -32,6 +47,13 @@ query II
 SELECT file[:17], parse_filename(file) FROM glob(getvariable('work_dir_localhost') || '/data/*/bad_date_timestamp_mix.csv')
 ----
 file://localhost/	bad_date_timestamp_mix.csv
+
+# Test scanning multiple files using glob with file:/some/path
+query III
+SELECT id, filename[:6], parse_filename(filename) FROM read_csv_auto(getvariable('work_dir_no_host') || '/data/csv/hive-partitioning/simple/*/*/test.csv', filename=1) ORDER BY id
+----
+1	file:/	test.csv
+2	file:/	test.csv
 
 # Test scanning multiple files using glob with file:///some/path
 query III

--- a/test/common/test_local_file_urls.test
+++ b/test/common/test_local_file_urls.test
@@ -41,6 +41,7 @@ SELECT id, filename[:17], parse_filename(filename) FROM read_csv_auto("file://lo
 1	file://localhost/	test.csv
 2	file://localhost/	test.csv
 
+require noforcestorage
 
 # Ensure secrets work correctly using the file://
 statement ok

--- a/test/common/test_local_file_urls.test
+++ b/test/common/test_local_file_urls.test
@@ -1,0 +1,69 @@
+# name: test/common/test_local_file_urls.test
+# group: [file_system]
+
+# Note: __WORKING_DIRECTORY__ will be replaced with the full path to the working dir of the tests (root of duckdb repo)
+
+# testing file:///some/path/to/duckdb/repo
+query II
+SELECT * FROM "file://__WORKING_DIRECTORY__/data/csv/normalize.csv";
+----
+John	ipsum
+
+# testing file://localhost/some/path/to/duckdb/repo
+query II
+SELECT * FROM "file://localhost__WORKING_DIRECTORY__/data/csv/normalize.csv";
+----
+John	ipsum
+
+# Test glob with file:///some/path
+query II
+SELECT file[:8], parse_filename(file) FROM glob('file://__WORKING_DIRECTORY__/data/*/bad_date_timestamp_mix.csv')
+----
+file:///	bad_date_timestamp_mix.csv
+
+# Test glob with file://localhost/some/path/to/duckdb/repo
+query II
+SELECT file[:17], parse_filename(file) FROM glob('file://localhost__WORKING_DIRECTORY__/data/*/bad_date_timestamp_mix.csv')
+----
+file://localhost/	bad_date_timestamp_mix.csv
+
+# Test scanning multiple files using glob with file:///some/path
+query III
+SELECT id, filename[:8], parse_filename(filename) FROM read_csv_auto("file://__WORKING_DIRECTORY__/data/csv/hive-partitioning/simple/*/*/test.csv", filename=1) ORDER BY id
+----
+1	file:///	test.csv
+2	file:///	test.csv
+
+# Test scanning multiple files using glob with file://localhost/some/path
+query III
+SELECT id, filename[:17], parse_filename(filename) FROM read_csv_auto("file://localhost__WORKING_DIRECTORY__/data/csv/hive-partitioning/simple/*/*/test.csv", filename=1) ORDER BY id
+----
+1	file://localhost/	test.csv
+2	file://localhost/	test.csv
+
+
+# Ensure secrets work correctly using the file://
+statement ok
+create secret secret_file_url_tripleslash (TYPE HTTP, scope 'file:///');
+
+statement ok
+create secret secret_file_url_localhost (TYPE HTTP, scope 'file://localhost/');
+
+statement ok
+create secret secret_without_file_path (TYPE HTTP);
+
+query I
+SELECT name FROM which_secret('file://__WORKING_DIRECTORY__/data/csv/hive-partitioning/simple/*/*/test.csv', 'http')
+----
+secret_file_url_tripleslash
+
+query I
+SELECT name FROM which_secret('file://localhost__WORKING_DIRECTORY__/data/csv/hive-partitioning/simple/*/*/test.csv', 'http')
+----
+secret_file_url_localhost
+
+# raw paths now do not match
+query I
+SELECT name FROM which_secret('__WORKING_DIRECTORY__/data/csv/hive-partitioning/simple/*/*/test.csv', 'http')
+----
+secret_without_file_path


### PR DESCRIPTION
Takes a stab at https://github.com/duckdb/duckdb/issues/13669 @djouallah

This PR adds support for [`file://` urls](https://en.wikipedia.org/wiki/File_URI_scheme) to the LocalFileSystem.

It currently supports urls of 3 different formats:

- `file:/some/path` (host omitted completely)
- `file:///some/path` (empty host)
- `file://localhost/some/path` (localhost as host)

Note that the following is not supported because they are non-standard (and actually forbidden by the spec) formats:
- relative paths (`file:some/relative/path`)
- double-slash paths (`file://some/path`)

Additionally, we also don't support
- non-localhost hosts (`file://somehostsomewhere/some/path`)

For the non-standard formats we could consider implementing them anyway if they show up a lot.