### PR TITLE
Add duckdb secret types function

### DIFF
--- a/src/function/table/system/CMakeLists.txt
+++ b/src/function/table/system/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library_unity(
   duckdb_schemas.cpp
   duckdb_secrets.cpp
   duckdb_which_secret.cpp
+  duckdb_secret_types.cpp
   duckdb_sequences.cpp
   duckdb_settings.cpp
   duckdb_tables.cpp

--- a/src/function/table/system/duckdb_secret_types.cpp
+++ b/src/function/table/system/duckdb_secret_types.cpp
@@ -1,0 +1,71 @@
+#include "duckdb/function/table/system_functions.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/main/secret/secret.hpp"
+
+namespace duckdb {
+
+struct DuckDBSecretTypesData : public GlobalTableFunctionState {
+	DuckDBSecretTypesData() : offset(0) {
+	}
+
+	vector<SecretType> types;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBSecretTypesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                   vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("default_provider");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("extension");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBSecretTypesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<DuckDBSecretTypesData>();
+
+	auto &secret_manager = SecretManager::Get(context);
+	result->types = secret_manager.AllSecretTypes();
+
+	return std::move(result);
+}
+
+void DuckDBSecretTypesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<DuckDBSecretTypesData>();
+	if (data.offset >= data.types.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.types.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.types[data.offset++];
+
+		// return values:
+		// type, LogicalType::VARCHAR
+		output.SetValue(0, count, Value(entry.name));
+		// default_provider, LogicalType::VARCHAR
+		output.SetValue(1, count, Value(entry.default_provider));
+		// extension, LogicalType::VARCHAR
+		output.SetValue(2, count, Value(entry.extension));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBSecretTypesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("duckdb_secret_types", {}, DuckDBSecretTypesFunction, DuckDBSecretTypesBind, DuckDBSecretTypesInit));
+}
+
+} // namespace duckdb

--- a/src/function/table/system/duckdb_secret_types.cpp
+++ b/src/function/table/system/duckdb_secret_types.cpp
@@ -16,7 +16,7 @@ struct DuckDBSecretTypesData : public GlobalTableFunctionState {
 };
 
 static unique_ptr<FunctionData> DuckDBSecretTypesBind(ClientContext &context, TableFunctionBindInput &input,
-                                                   vector<LogicalType> &return_types, vector<string> &names) {
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
 	names.emplace_back("type");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
@@ -64,8 +64,8 @@ void DuckDBSecretTypesFunction(ClientContext &context, TableFunctionInput &data_
 }
 
 void DuckDBSecretTypesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(
-	    TableFunction("duckdb_secret_types", {}, DuckDBSecretTypesFunction, DuckDBSecretTypesBind, DuckDBSecretTypesInit));
+	set.AddFunction(TableFunction("duckdb_secret_types", {}, DuckDBSecretTypesFunction, DuckDBSecretTypesBind,
+	                              DuckDBSecretTypesInit));
 }
 
 } // namespace duckdb

--- a/src/function/table/system_functions.cpp
+++ b/src/function/table/system_functions.cpp
@@ -31,6 +31,7 @@ void BuiltinFunctions::RegisterSQLiteFunctions() {
 	DuckDBOptimizersFun::RegisterFunction(*this);
 	DuckDBSecretsFun::RegisterFunction(*this);
 	DuckDBWhichSecretFun::RegisterFunction(*this);
+	DuckDBSecretTypesFun::RegisterFunction(*this);
 	DuckDBSequencesFun::RegisterFunction(*this);
 	DuckDBSettingsFun::RegisterFunction(*this);
 	DuckDBTablesFun::RegisterFunction(*this);

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -95,6 +95,10 @@ struct DuckDBOptimizersFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct DuckDBSecretTypesFun {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct DuckDBSequencesFun {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/main/secret/secret.hpp
+++ b/src/include/duckdb/main/secret/secret.hpp
@@ -78,6 +78,8 @@ struct SecretType {
 	secret_deserializer_t deserializer;
 	//! Provider to use when non is specified
 	string default_provider;
+	//! The extension that registered this secret type
+	string extension;
 };
 
 enum class SecretSerializationType : uint8_t {

--- a/src/include/duckdb/main/secret/secret_manager.hpp
+++ b/src/include/duckdb/main/secret/secret_manager.hpp
@@ -135,6 +135,9 @@ public:
 	//! List all secrets from all secret storages
 	DUCKDB_API vector<SecretEntry> AllSecrets(CatalogTransaction transaction);
 
+	//! List all secret types
+	DUCKDB_API vector<SecretType> AllSecretTypes();
+
 	//! Secret Manager settings
 	DUCKDB_API virtual void SetEnablePersistentSecrets(bool enabled);
 	DUCKDB_API virtual void ResetEnablePersistentSecrets();

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -489,6 +489,17 @@ vector<SecretEntry> SecretManager::AllSecrets(CatalogTransaction transaction) {
 	return result;
 }
 
+vector<SecretType> SecretManager::AllSecretTypes() {
+	unique_lock<mutex> lck(manager_lock);
+	vector<SecretType> result;
+
+	for (const auto& secret : secret_types) {
+		result.push_back(secret.second);
+	}
+
+	return result;
+}
+
 void SecretManager::ThrowOnSettingChangeIfInitialized() {
 	if (initialized) {
 		throw InvalidInputException(

--- a/src/main/secret/secret_manager.cpp
+++ b/src/main/secret/secret_manager.cpp
@@ -493,7 +493,7 @@ vector<SecretType> SecretManager::AllSecretTypes() {
 	unique_lock<mutex> lck(manager_lock);
 	vector<SecretType> result;
 
-	for (const auto& secret : secret_types) {
+	for (const auto &secret : secret_types) {
 		result.push_back(secret.second);
 	}
 

--- a/test/sql/secrets/secret_types_function.test
+++ b/test/sql/secrets/secret_types_function.test
@@ -1,0 +1,13 @@
+# name: test/sql/secrets/secret_types_function.test
+# description: Test duckdb_secret_types function
+# group: [secrets]
+
+statement ok
+PRAGMA enable_verification;
+
+require httpfs
+
+mode output_result
+
+statement ok
+FROM duckdb_secret_types();

--- a/test/sql/secrets/secret_types_function.test
+++ b/test/sql/secrets/secret_types_function.test
@@ -2,7 +2,14 @@
 # description: Test duckdb_secret_types function
 # group: [secrets]
 
+query III
+FROM duckdb_secret_types() WHERE type IN ['s3', 'r2', 'gcs', 'http'] ORDER BY type
+----
+http	config	(empty)
+
 require httpfs
+
+require no_extension_autoloading "EXPECTED: The duckdb_secret_types() function does not trigger autoloading httpfs"
 
 query III
 FROM duckdb_secret_types() WHERE type IN ['s3', 'r2', 'gcs', 'http'] ORDER BY type

--- a/test/sql/secrets/secret_types_function.test
+++ b/test/sql/secrets/secret_types_function.test
@@ -2,12 +2,12 @@
 # description: Test duckdb_secret_types function
 # group: [secrets]
 
-statement ok
-PRAGMA enable_verification;
-
 require httpfs
 
-mode output_result
-
-statement ok
-FROM duckdb_secret_types();
+query III
+FROM duckdb_secret_types() WHERE type IN ['s3', 'r2', 'gcs', 'http'] ORDER BY type
+----
+gcs	config	(empty)
+http	config	(empty)
+r2	config	(empty)
+s3	config		(empty)


### PR DESCRIPTION
Allows listing the currently available secret types. Intended for internal use mostly.