### PR TITLE
[Dev] `ColumnDataCheckpointer` can now checkpoint column data and validity data together

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -54,10 +54,10 @@ UnifiedVectorFormat &UnifiedVectorFormat::operator=(UnifiedVectorFormat &&other)
 	return *this;
 }
 
-Vector::Vector(LogicalType type_p, bool create_data, bool zero_data, idx_t capacity)
+Vector::Vector(LogicalType type_p, bool create_data, bool initialize_to_zero, idx_t capacity)
     : vector_type(VectorType::FLAT_VECTOR), type(std::move(type_p)), data(nullptr), validity(capacity) {
 	if (create_data) {
-		Initialize(zero_data, capacity);
+		Initialize(initialize_to_zero, capacity);
 	}
 }
 
@@ -306,7 +306,7 @@ void Vector::Slice(const SelectionVector &sel, idx_t count, SelCache &cache) {
 	}
 }
 
-void Vector::Initialize(bool zero_data, idx_t capacity) {
+void Vector::Initialize(bool initialize_to_zero, idx_t capacity) {
 	auxiliary.reset();
 	validity.Reset();
 	auto &type = GetType();
@@ -325,7 +325,7 @@ void Vector::Initialize(bool zero_data, idx_t capacity) {
 	if (type_size > 0) {
 		buffer = VectorBuffer::CreateStandardVector(type, capacity);
 		data = buffer->GetData();
-		if (zero_data) {
+		if (initialize_to_zero) {
 			memset(data, 0, capacity * type_size);
 		}
 	}

--- a/src/include/duckdb/common/types/vector.hpp
+++ b/src/include/duckdb/common/types/vector.hpp
@@ -109,9 +109,10 @@ public:
 	/*!
 	    Create a new vector
 	    If create_data is true, the vector will be an owning empty vector.
-	    If zero_data is true, the allocated data will be zero-initialized.
+	    If initialize_to_zero is true, the allocated data will be zero-initialized.
 	*/
-	DUCKDB_API Vector(LogicalType type, bool create_data, bool zero_data, idx_t capacity = STANDARD_VECTOR_SIZE);
+	DUCKDB_API Vector(LogicalType type, bool create_data, bool initialize_to_zero,
+	                  idx_t capacity = STANDARD_VECTOR_SIZE);
 	// implicit copying of Vectors is not allowed
 	Vector(const Vector &) = delete;
 	// but moving of vectors is allowed
@@ -151,7 +152,7 @@ public:
 
 	//! Creates the data of this vector with the specified type. Any data that
 	//! is currently in the vector is destroyed.
-	DUCKDB_API void Initialize(bool zero_data = false, idx_t capacity = STANDARD_VECTOR_SIZE);
+	DUCKDB_API void Initialize(bool initialize_to_zero = false, idx_t capacity = STANDARD_VECTOR_SIZE);
 
 	//! Converts this Vector to a printable string representation
 	DUCKDB_API string ToString(idx_t count) const;

--- a/src/include/duckdb/function/compression_function.hpp
+++ b/src/include/duckdb/function/compression_function.hpp
@@ -19,7 +19,7 @@
 namespace duckdb {
 class DatabaseInstance;
 class ColumnData;
-class ColumnDataCheckpointer;
+struct ColumnDataCheckpointData;
 class ColumnSegment;
 class SegmentStatistics;
 class TableFilter;
@@ -152,7 +152,7 @@ typedef idx_t (*compression_final_analyze_t)(AnalyzeState &state);
 //===--------------------------------------------------------------------===//
 // Compress
 //===--------------------------------------------------------------------===//
-typedef unique_ptr<CompressionState> (*compression_init_compression_t)(ColumnDataCheckpointer &checkpointer,
+typedef unique_ptr<CompressionState> (*compression_init_compression_t)(ColumnDataCheckpointData &checkpoint_data,
                                                                        unique_ptr<AnalyzeState> state);
 typedef void (*compression_compress_data_t)(CompressionState &state, Vector &scan_vector, idx_t count);
 typedef void (*compression_compress_finalize_t)(CompressionState &state);

--- a/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
+++ b/src/include/duckdb/storage/compression/alprd/alprd_compress.hpp
@@ -34,9 +34,9 @@ struct AlpRDCompressionState : public CompressionState {
 public:
 	using EXACT_TYPE = typename FloatingToExact<T>::TYPE;
 
-	AlpRDCompressionState(ColumnDataCheckpointer &checkpointer, AlpRDAnalyzeState<T> *analyze_state)
-	    : CompressionState(analyze_state->info), checkpointer(checkpointer),
-	      function(checkpointer.GetCompressionFunction(CompressionType::COMPRESSION_ALPRD)) {
+	AlpRDCompressionState(ColumnDataCheckpointData &checkpoint_data, AlpRDAnalyzeState<T> *analyze_state)
+	    : CompressionState(analyze_state->info), checkpoint_data(checkpoint_data),
+	      function(checkpoint_data.GetCompressionFunction(CompressionType::COMPRESSION_ALPRD)) {
 		//! State variables from the analyze step that are needed for compression
 		state.left_parts_dict_map = std::move(analyze_state->state.left_parts_dict_map);
 		state.left_bit_width = analyze_state->state.left_bit_width;
@@ -46,10 +46,10 @@ public:
 		next_vector_byte_index_start = AlpRDConstants::HEADER_SIZE + actual_dictionary_size_bytes;
 		memcpy((void *)state.left_parts_dict, (void *)analyze_state->state.left_parts_dict,
 		       actual_dictionary_size_bytes);
-		CreateEmptySegment(checkpointer.GetRowGroup().start);
+		CreateEmptySegment(checkpoint_data.GetRowGroup().start);
 	}
 
-	ColumnDataCheckpointer &checkpointer;
+	ColumnDataCheckpointData &checkpoint_data;
 	CompressionFunction &function;
 	unique_ptr<ColumnSegment> current_segment;
 	BufferHandle handle;
@@ -100,8 +100,8 @@ public:
 	}
 
 	void CreateEmptySegment(idx_t row_start) {
-		auto &db = checkpointer.GetDatabase();
-		auto &type = checkpointer.GetType();
+		auto &db = checkpoint_data.GetDatabase();
+		auto &type = checkpoint_data.GetType();
 
 		auto compressed_segment = ColumnSegment::CreateTransientSegment(db, function, type, row_start,
 		                                                                info.GetBlockSize(), info.GetBlockSize());
@@ -176,7 +176,7 @@ public:
 	}
 
 	void FlushSegment() {
-		auto &checkpoint_state = checkpointer.GetCheckpointState();
+		auto &checkpoint_state = checkpoint_data.GetCheckpointState();
 		auto dataptr = handle.Ptr();
 
 		idx_t metadata_offset = AlignValue(UsedSpace());
@@ -277,9 +277,9 @@ public:
 };
 
 template <class T>
-unique_ptr<CompressionState> AlpRDInitCompression(ColumnDataCheckpointer &checkpointer,
+unique_ptr<CompressionState> AlpRDInitCompression(ColumnDataCheckpointData &checkpoint_data,
                                                   unique_ptr<AnalyzeState> state) {
-	return make_uniq<AlpRDCompressionState<T>>(checkpointer, (AlpRDAnalyzeState<T> *)state.get());
+	return make_uniq<AlpRDCompressionState<T>>(checkpoint_data, (AlpRDAnalyzeState<T> *)state.get());
 }
 
 template <class T>

--- a/src/include/duckdb/storage/compression/chimp/chimp_compress.hpp
+++ b/src/include/duckdb/storage/compression/chimp/chimp_compress.hpp
@@ -33,7 +33,7 @@ struct ChimpCompressionState : public CompressionState {};
 // Compression Functions
 
 template <class T>
-unique_ptr<CompressionState> ChimpInitCompression(ColumnDataCheckpointer &checkpointer,
+unique_ptr<CompressionState> ChimpInitCompression(ColumnDataCheckpointData &checkpoint_data,
                                                   unique_ptr<AnalyzeState> state) {
 	throw InternalException("Chimp has been deprecated, can no longer be used to compress data");
 	return nullptr;

--- a/src/include/duckdb/storage/compression/dictionary/compression.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/compression.hpp
@@ -23,7 +23,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 struct DictionaryCompressionCompressState : public DictionaryCompressionState {
 public:
-	DictionaryCompressionCompressState(ColumnDataCheckpointer &checkpointer_p, const CompressionInfo &info);
+	DictionaryCompressionCompressState(ColumnDataCheckpointData &checkpoint_data_p, const CompressionInfo &info);
 
 public:
 	void CreateEmptySegment(idx_t row_start);
@@ -37,7 +37,7 @@ public:
 	idx_t Finalize();
 
 public:
-	ColumnDataCheckpointer &checkpointer;
+	ColumnDataCheckpointData &checkpoint_data;
 	CompressionFunction &function;
 
 	// State regarding current segment

--- a/src/include/duckdb/storage/compression/patas/patas_compress.hpp
+++ b/src/include/duckdb/storage/compression/patas/patas_compress.hpp
@@ -35,7 +35,7 @@ struct PatasCompressionState : public CompressionState {};
 // Compression Functions
 
 template <class T>
-unique_ptr<CompressionState> PatasInitCompression(ColumnDataCheckpointer &checkpointer,
+unique_ptr<CompressionState> PatasInitCompression(ColumnDataCheckpointData &checkpoint_data,
                                                   unique_ptr<AnalyzeState> state) {
 	throw InternalException("Patas has been deprecated, can no longer be used to compress data");
 	return nullptr;

--- a/src/include/duckdb/storage/compression/roaring/roaring.hpp
+++ b/src/include/duckdb/storage/compression/roaring/roaring.hpp
@@ -319,7 +319,7 @@ public:
 
 struct RoaringCompressState : public CompressionState {
 public:
-	explicit RoaringCompressState(ColumnDataCheckpointer &checkpointer, unique_ptr<AnalyzeState> analyze_state_p);
+	explicit RoaringCompressState(ColumnDataCheckpointData &checkpoint_data, unique_ptr<AnalyzeState> analyze_state_p);
 
 public:
 	//! RoaringStateAppender interface
@@ -350,7 +350,7 @@ public:
 	ContainerMetadataCollection metadata_collection;
 	vector<ContainerMetadata> &container_metadata;
 
-	ColumnDataCheckpointer &checkpointer;
+	ColumnDataCheckpointData &checkpoint_data;
 	CompressionFunction &function;
 	unique_ptr<ColumnSegment> current_segment;
 	BufferHandle handle;

--- a/src/include/duckdb/storage/segment/uncompressed.hpp
+++ b/src/include/duckdb/storage/segment/uncompressed.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 class DatabaseInstance;
 
 struct UncompressedFunctions {
-	static unique_ptr<CompressionState> InitCompression(ColumnDataCheckpointer &checkpointer,
+	static unique_ptr<CompressionState> InitCompression(ColumnDataCheckpointData &checkpoint_data,
 	                                                    unique_ptr<AnalyzeState> state);
 	static void Compress(CompressionState &state_p, Vector &data, idx_t count);
 	static void FinalizeCompress(CompressionState &state_p);

--- a/src/include/duckdb/storage/table/column_data_checkpointer.hpp
+++ b/src/include/duckdb/storage/table/column_data_checkpointer.hpp
@@ -18,10 +18,13 @@ struct TableScanOptions;
 //! Holds state related to a single column during compression
 struct ColumnDataCheckpointData {
 public:
+	//! Default constructor used when column data does not need to be checkpointed
+	ColumnDataCheckpointData() {
+	}
 	ColumnDataCheckpointData(ColumnCheckpointState &checkpoint_state, ColumnData &col_data, DatabaseInstance &db,
-	                         RowGroup &row_group, bool has_changes, ColumnCheckpointInfo &checkpoint_info)
+	                         RowGroup &row_group, ColumnCheckpointInfo &checkpoint_info)
 	    : checkpoint_state(checkpoint_state), col_data(col_data), db(db), row_group(row_group),
-	      has_changes(has_changes), checkpoint_info(checkpoint_info) {
+	      checkpoint_info(checkpoint_info) {
 	}
 
 public:
@@ -32,13 +35,12 @@ public:
 	ColumnCheckpointState &GetCheckpointState();
 	DatabaseInstance &GetDatabase();
 
-public:
-	ColumnCheckpointState &checkpoint_state;
-	ColumnData &col_data;
-	DatabaseInstance &db;
-	RowGroup &row_group;
-	bool has_changes;
-	ColumnCheckpointInfo &checkpoint_info;
+private:
+	optional_ptr<ColumnCheckpointState> checkpoint_state;
+	optional_ptr<ColumnData> col_data;
+	optional_ptr<DatabaseInstance> db;
+	optional_ptr<RowGroup> row_group;
+	optional_ptr<ColumnCheckpointInfo> checkpoint_info;
 };
 
 struct CheckpointAnalyzeResult {

--- a/src/include/duckdb/storage/table/column_data_checkpointer.hpp
+++ b/src/include/duckdb/storage/table/column_data_checkpointer.hpp
@@ -15,18 +15,38 @@
 namespace duckdb {
 struct TableScanOptions;
 
+//! Holds state related to a single column during compression
+struct ColumnDataCheckpointData {
+public:
+	ColumnDataCheckpointData(ColumnCheckpointState &checkpoint_state, ColumnData &col_data, DatabaseInstance &db,
+	                         RowGroup &row_group, bool has_changes, ColumnCheckpointInfo &checkpoint_info)
+	    : checkpoint_state(checkpoint_state), col_data(col_data), db(db), row_group(row_group),
+	      has_changes(has_changes), checkpoint_info(checkpoint_info) {
+	}
+
+public:
+	CompressionFunction &GetCompressionFunction(CompressionType type);
+	const LogicalType &GetType() const;
+	ColumnData &GetColumnData();
+	RowGroup &GetRowGroup();
+	ColumnCheckpointState &GetCheckpointState();
+	DatabaseInstance &GetDatabase();
+
+public:
+	ColumnCheckpointState &checkpoint_state;
+	ColumnData &col_data;
+	DatabaseInstance &db;
+	RowGroup &row_group;
+	bool has_changes;
+	ColumnCheckpointInfo &checkpoint_info;
+};
+
 class ColumnDataCheckpointer {
 public:
 	ColumnDataCheckpointer(ColumnData &col_data_p, RowGroup &row_group_p, ColumnCheckpointState &state_p,
 	                       ColumnCheckpointInfo &checkpoint_info);
 
 public:
-	DatabaseInstance &GetDatabase();
-	const LogicalType &GetType() const;
-	ColumnData &GetColumnData();
-	RowGroup &GetRowGroup();
-	ColumnCheckpointState &GetCheckpointState();
-
 	void Checkpoint(const column_segment_vector_t &nodes);
 	void FinalizeCheckpoint(column_segment_vector_t &&nodes);
 	CompressionFunction &GetCompressionFunction(CompressionType type);
@@ -47,6 +67,8 @@ private:
 	Vector intermediate;
 	vector<optional_ptr<CompressionFunction>> compression_functions;
 	ColumnCheckpointInfo &checkpoint_info;
+
+	vector<unique_ptr<AnalyzeState>> analyze_states;
 };
 
 } // namespace duckdb

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -52,7 +52,7 @@ struct DictionaryCompressionStorage {
 	static bool StringAnalyze(AnalyzeState &state_p, Vector &input, idx_t count);
 	static idx_t StringFinalAnalyze(AnalyzeState &state_p);
 
-	static unique_ptr<CompressionState> InitCompression(ColumnDataCheckpointer &checkpointer,
+	static unique_ptr<CompressionState> InitCompression(ColumnDataCheckpointData &checkpoint_data,
 	                                                    unique_ptr<AnalyzeState> state);
 	static void Compress(CompressionState &state_p, Vector &scan_vector, idx_t count);
 	static void FinalizeCompress(CompressionState &state_p);
@@ -94,9 +94,9 @@ idx_t DictionaryCompressionStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 //===--------------------------------------------------------------------===//
 // Compress
 //===--------------------------------------------------------------------===//
-unique_ptr<CompressionState> DictionaryCompressionStorage::InitCompression(ColumnDataCheckpointer &checkpointer,
+unique_ptr<CompressionState> DictionaryCompressionStorage::InitCompression(ColumnDataCheckpointData &checkpoint_data,
                                                                            unique_ptr<AnalyzeState> state) {
-	return make_uniq<DictionaryCompressionCompressState>(checkpointer, state->info);
+	return make_uniq<DictionaryCompressionCompressState>(checkpoint_data, state->info);
 }
 
 void DictionaryCompressionStorage::Compress(CompressionState &state_p, Vector &scan_vector, idx_t count) {

--- a/src/storage/compression/fixed_size_uncompressed.cpp
+++ b/src/storage/compression/fixed_size_uncompressed.cpp
@@ -43,7 +43,7 @@ idx_t FixedSizeFinalAnalyze(AnalyzeState &state_p) {
 //===--------------------------------------------------------------------===//
 struct UncompressedCompressState : public CompressionState {
 public:
-	UncompressedCompressState(ColumnDataCheckpointer &checkpointer, const CompressionInfo &info);
+	UncompressedCompressState(ColumnDataCheckpointData &checkpoint_data, const CompressionInfo &info);
 
 public:
 	virtual void CreateEmptySegment(idx_t row_start);
@@ -51,35 +51,36 @@ public:
 	void Finalize(idx_t segment_size);
 
 public:
-	ColumnDataCheckpointer &checkpointer;
+	ColumnDataCheckpointData &checkpoint_data;
 	CompressionFunction &function;
 	unique_ptr<ColumnSegment> current_segment;
 	ColumnAppendState append_state;
 };
 
-UncompressedCompressState::UncompressedCompressState(ColumnDataCheckpointer &checkpointer, const CompressionInfo &info)
-    : CompressionState(info), checkpointer(checkpointer),
-      function(checkpointer.GetCompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED)) {
-	UncompressedCompressState::CreateEmptySegment(checkpointer.GetRowGroup().start);
+UncompressedCompressState::UncompressedCompressState(ColumnDataCheckpointData &checkpoint_data,
+                                                     const CompressionInfo &info)
+    : CompressionState(info), checkpoint_data(checkpoint_data),
+      function(checkpoint_data.GetCompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED)) {
+	UncompressedCompressState::CreateEmptySegment(checkpoint_data.GetRowGroup().start);
 }
 
 void UncompressedCompressState::CreateEmptySegment(idx_t row_start) {
-	auto &db = checkpointer.GetDatabase();
-	auto &type = checkpointer.GetType();
+	auto &db = checkpoint_data.GetDatabase();
+	auto &type = checkpoint_data.GetType();
 
 	auto compressed_segment =
 	    ColumnSegment::CreateTransientSegment(db, function, type, row_start, info.GetBlockSize(), info.GetBlockSize());
 	if (type.InternalType() == PhysicalType::VARCHAR) {
 		auto &state = compressed_segment->GetSegmentState()->Cast<UncompressedStringSegmentState>();
 		state.overflow_writer =
-		    make_uniq<WriteOverflowStringsToDisk>(checkpointer.GetCheckpointState().GetPartialBlockManager());
+		    make_uniq<WriteOverflowStringsToDisk>(checkpoint_data.GetCheckpointState().GetPartialBlockManager());
 	}
 	current_segment = std::move(compressed_segment);
 	current_segment->InitializeAppend(append_state);
 }
 
 void UncompressedCompressState::FlushSegment(idx_t segment_size) {
-	auto &state = checkpointer.GetCheckpointState();
+	auto &state = checkpoint_data.GetCheckpointState();
 	if (current_segment->type.InternalType() == PhysicalType::VARCHAR) {
 		auto &segment_state = current_segment->GetSegmentState()->Cast<UncompressedStringSegmentState>();
 		segment_state.overflow_writer->Flush();
@@ -96,9 +97,9 @@ void UncompressedCompressState::Finalize(idx_t segment_size) {
 	current_segment.reset();
 }
 
-unique_ptr<CompressionState> UncompressedFunctions::InitCompression(ColumnDataCheckpointer &checkpointer,
+unique_ptr<CompressionState> UncompressedFunctions::InitCompression(ColumnDataCheckpointData &checkpoint_data,
                                                                     unique_ptr<AnalyzeState> state) {
-	return make_uniq<UncompressedCompressState>(checkpointer, state->info);
+	return make_uniq<UncompressedCompressState>(checkpoint_data, state->info);
 }
 
 void UncompressedFunctions::Compress(CompressionState &state_p, Vector &data, idx_t count) {

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -137,18 +137,18 @@ struct RLECompressState : public CompressionState {
 		return (info.GetBlockSize() - RLEConstants::RLE_HEADER_SIZE) / entry_size;
 	}
 
-	RLECompressState(ColumnDataCheckpointer &checkpointer_p, const CompressionInfo &info)
-	    : CompressionState(info), checkpointer(checkpointer_p),
-	      function(checkpointer.GetCompressionFunction(CompressionType::COMPRESSION_RLE)) {
-		CreateEmptySegment(checkpointer.GetRowGroup().start);
+	RLECompressState(ColumnDataCheckpointData &checkpoint_data_p, const CompressionInfo &info)
+	    : CompressionState(info), checkpoint_data(checkpoint_data_p),
+	      function(checkpoint_data.GetCompressionFunction(CompressionType::COMPRESSION_RLE)) {
+		CreateEmptySegment(checkpoint_data.GetRowGroup().start);
 
 		state.dataptr = (void *)this;
 		max_rle_count = MaxRLECount();
 	}
 
 	void CreateEmptySegment(idx_t row_start) {
-		auto &db = checkpointer.GetDatabase();
-		auto &type = checkpointer.GetType();
+		auto &db = checkpoint_data.GetDatabase();
+		auto &type = checkpoint_data.GetType();
 
 		auto column_segment = ColumnSegment::CreateTransientSegment(db, function, type, row_start, info.GetBlockSize(),
 		                                                            info.GetBlockSize());
@@ -203,7 +203,7 @@ struct RLECompressState : public CompressionState {
 		Store<uint64_t>(minimal_rle_offset, data_ptr);
 		handle.Destroy();
 
-		auto &state = checkpointer.GetCheckpointState();
+		auto &state = checkpoint_data.GetCheckpointState();
 		state.FlushSegment(std::move(current_segment), std::move(handle), total_segment_size);
 	}
 
@@ -214,7 +214,7 @@ struct RLECompressState : public CompressionState {
 		current_segment.reset();
 	}
 
-	ColumnDataCheckpointer &checkpointer;
+	ColumnDataCheckpointData &checkpoint_data;
 	CompressionFunction &function;
 	unique_ptr<ColumnSegment> current_segment;
 	BufferHandle handle;
@@ -225,8 +225,9 @@ struct RLECompressState : public CompressionState {
 };
 
 template <class T, bool WRITE_STATISTICS>
-unique_ptr<CompressionState> RLEInitCompression(ColumnDataCheckpointer &checkpointer, unique_ptr<AnalyzeState> state) {
-	return make_uniq<RLECompressState<T, WRITE_STATISTICS>>(checkpointer, state->info);
+unique_ptr<CompressionState> RLEInitCompression(ColumnDataCheckpointData &checkpoint_data,
+                                                unique_ptr<AnalyzeState> state) {
+	return make_uniq<RLECompressState<T, WRITE_STATISTICS>>(checkpoint_data, state->info);
 }
 
 template <class T, bool WRITE_STATISTICS>

--- a/src/storage/compression/roaring/common.cpp
+++ b/src/storage/compression/roaring/common.cpp
@@ -188,9 +188,9 @@ idx_t RoaringFinalAnalyze(AnalyzeState &state) {
 	return LossyNumericCast<idx_t>((double)roaring_state.total_size * ROARING_COMPRESS_PENALTY);
 }
 
-unique_ptr<CompressionState> RoaringInitCompression(ColumnDataCheckpointer &checkpointer,
+unique_ptr<CompressionState> RoaringInitCompression(ColumnDataCheckpointData &checkpoint_data,
                                                     unique_ptr<AnalyzeState> state) {
-	return make_uniq<RoaringCompressState>(checkpointer, std::move(state));
+	return make_uniq<RoaringCompressState>(checkpoint_data, std::move(state));
 }
 
 void RoaringCompress(CompressionState &state_p, Vector &scan_vector, idx_t count) {

--- a/src/storage/compression/roaring/compress.cpp
+++ b/src/storage/compression/roaring/compress.cpp
@@ -193,13 +193,13 @@ void ContainerCompressionState::Reset() {
 //===--------------------------------------------------------------------===//
 // Compress
 //===--------------------------------------------------------------------===//
-RoaringCompressState::RoaringCompressState(ColumnDataCheckpointer &checkpointer,
+RoaringCompressState::RoaringCompressState(ColumnDataCheckpointData &checkpoint_data,
                                            unique_ptr<AnalyzeState> analyze_state_p)
     : CompressionState(analyze_state_p->info), owned_analyze_state(std::move(analyze_state_p)),
       analyze_state(owned_analyze_state->Cast<RoaringAnalyzeState>()), container_state(),
-      container_metadata(analyze_state.container_metadata), checkpointer(checkpointer),
-      function(checkpointer.GetCompressionFunction(CompressionType::COMPRESSION_ROARING)) {
-	CreateEmptySegment(checkpointer.GetRowGroup().start);
+      container_metadata(analyze_state.container_metadata), checkpoint_data(checkpoint_data),
+      function(checkpoint_data.GetCompressionFunction(CompressionType::COMPRESSION_ROARING)) {
+	CreateEmptySegment(checkpoint_data.GetRowGroup().start);
 	total_count = 0;
 	InitializeContainer();
 }
@@ -276,8 +276,8 @@ void RoaringCompressState::InitializeContainer() {
 }
 
 void RoaringCompressState::CreateEmptySegment(idx_t row_start) {
-	auto &db = checkpointer.GetDatabase();
-	auto &type = checkpointer.GetType();
+	auto &db = checkpoint_data.GetDatabase();
+	auto &type = checkpoint_data.GetType();
 
 	auto compressed_segment =
 	    ColumnSegment::CreateTransientSegment(db, function, type, row_start, info.GetBlockSize(), info.GetBlockSize());
@@ -291,7 +291,7 @@ void RoaringCompressState::CreateEmptySegment(idx_t row_start) {
 }
 
 void RoaringCompressState::FlushSegment() {
-	auto &state = checkpointer.GetCheckpointState();
+	auto &state = checkpoint_data.GetCheckpointState();
 	auto base_ptr = handle.Ptr();
 	// +======================================+
 	// |x|ddddddddddddddd||mmm|               |

--- a/src/storage/compression/zstd.cpp
+++ b/src/storage/compression/zstd.cpp
@@ -76,7 +76,7 @@ struct ZSTDStorage {
 	static bool StringAnalyze(AnalyzeState &state_p, Vector &input, idx_t count);
 	static idx_t StringFinalAnalyze(AnalyzeState &state_p);
 
-	static unique_ptr<CompressionState> InitCompression(ColumnDataCheckpointer &checkpointer,
+	static unique_ptr<CompressionState> InitCompression(ColumnDataCheckpointData &checkpoint_data,
 	                                                    unique_ptr<AnalyzeState> analyze_state_p);
 	static void Compress(CompressionState &state_p, Vector &scan_vector, idx_t count);
 	static void FinalizeCompress(CompressionState &state_p);
@@ -218,10 +218,12 @@ idx_t ZSTDStorage::StringFinalAnalyze(AnalyzeState &state_p) {
 
 class ZSTDCompressionState : public CompressionState {
 public:
-	explicit ZSTDCompressionState(ColumnDataCheckpointer &checkpointer, unique_ptr<ZSTDAnalyzeState> &&analyze_state_p)
+	explicit ZSTDCompressionState(ColumnDataCheckpointData &checkpoint_data,
+	                              unique_ptr<ZSTDAnalyzeState> &&analyze_state_p)
 	    : CompressionState(analyze_state_p->info), analyze_state(std::move(analyze_state_p)),
-	      checkpointer(checkpointer), partial_block_manager(checkpointer.GetCheckpointState().GetPartialBlockManager()),
-	      function(checkpointer.GetCompressionFunction(CompressionType::COMPRESSION_ZSTD)) {
+	      checkpoint_data(checkpoint_data),
+	      partial_block_manager(checkpoint_data.GetCheckpointState().GetPartialBlockManager()),
+	      function(checkpoint_data.GetCompressionFunction(CompressionType::COMPRESSION_ZSTD)) {
 
 		total_vector_count = GetVectorCount(analyze_state->count);
 		total_segment_count = analyze_state->segment_count;
@@ -303,7 +305,7 @@ public:
 			row_start = segment->start + segment->count;
 			FlushSegment();
 		} else {
-			row_start = checkpointer.GetRowGroup().start;
+			row_start = checkpoint_data.GetRowGroup().start;
 		}
 		CreateEmptySegment(row_start);
 
@@ -517,18 +519,18 @@ public:
 	}
 
 	void CreateEmptySegment(idx_t row_start) {
-		auto &db = checkpointer.GetDatabase();
-		auto &type = checkpointer.GetType();
+		auto &db = checkpoint_data.GetDatabase();
+		auto &type = checkpoint_data.GetType();
 		auto compressed_segment = ColumnSegment::CreateTransientSegment(db, function, type, row_start,
 		                                                                info.GetBlockSize(), info.GetBlockSize());
 		segment = std::move(compressed_segment);
 
-		auto &buffer_manager = BufferManager::GetBufferManager(checkpointer.GetDatabase());
+		auto &buffer_manager = BufferManager::GetBufferManager(checkpoint_data.GetDatabase());
 		segment_handle = buffer_manager.Pin(segment->block);
 	}
 
 	void FlushSegment() {
-		auto &state = checkpointer.GetCheckpointState();
+		auto &state = checkpoint_data.GetCheckpointState();
 		idx_t segment_block_size;
 
 		if (current_buffer.get() == &segment_handle) {
@@ -555,7 +557,7 @@ public:
 
 public:
 	unique_ptr<ZSTDAnalyzeState> analyze_state;
-	ColumnDataCheckpointer &checkpointer;
+	ColumnDataCheckpointData &checkpoint_data;
 	PartialBlockManager &partial_block_manager;
 	CompressionFunction &function;
 
@@ -611,9 +613,9 @@ public:
 	idx_t vector_size;
 };
 
-unique_ptr<CompressionState> ZSTDStorage::InitCompression(ColumnDataCheckpointer &checkpointer,
+unique_ptr<CompressionState> ZSTDStorage::InitCompression(ColumnDataCheckpointData &checkpoint_data,
                                                           unique_ptr<AnalyzeState> analyze_state_p) {
-	return make_uniq<ZSTDCompressionState>(checkpointer,
+	return make_uniq<ZSTDCompressionState>(checkpoint_data,
 	                                       unique_ptr_cast<AnalyzeState, ZSTDAnalyzeState>(std::move(analyze_state_p)));
 }
 

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -630,17 +630,6 @@ unique_ptr<ColumnCheckpointState> ColumnData::Checkpoint(RowGroup &row_group, Co
 	ColumnDataCheckpointer checkpointer(states, GetDatabase(), row_group, checkpoint_info);
 	checkpointer.Checkpoint();
 	checkpointer.FinalizeCheckpoint();
-
-	// reset the compression function
-	compression.reset();
-	// replace the old tree with the new one
-	auto new_segments = checkpoint_state->new_tree.MoveSegments();
-	auto l = data.Lock();
-	for (auto &new_segment : new_segments) {
-		AppendSegment(l, std::move(new_segment.node));
-	}
-	ClearUpdates();
-
 	return checkpoint_state;
 }
 

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -38,23 +38,43 @@ ColumnCheckpointState &ColumnDataCheckpointData::GetCheckpointState() {
 
 //! ColumnDataCheckpointer
 
-ColumnDataCheckpointer::ColumnDataCheckpointer(ColumnData &col_data_p, RowGroup &row_group_p,
-                                               ColumnCheckpointState &state_p, ColumnCheckpointInfo &checkpoint_info_p)
-    : col_data(col_data_p), row_group(row_group_p), state(state_p),
-      is_validity(col_data.type.id() == LogicalTypeId::VALIDITY),
-      intermediate(is_validity ? LogicalType::BOOLEAN : col_data.type, true, is_validity),
-      checkpoint_info(checkpoint_info_p) {
+static Vector CreateIntermediateVector(vector<reference<ColumnCheckpointState>> &states) {
+	D_ASSERT(!states.empty());
 
-	auto &config = DBConfig::GetConfig(col_data.GetDatabase());
-	auto functions = config.GetCompressionFunctions(col_data.type.InternalType());
-	for (auto &func : functions) {
-		compression_functions.push_back(&func.get());
+	auto &first_state = states[0];
+	auto &col_data = first_state.get().column_data;
+	auto &type = col_data.type;
+	if (type.id() == LogicalTypeId::VALIDITY) {
+		return Vector(LogicalType::BOOLEAN, true, /* initialize_to_zero = */ true);
+	}
+	return Vector(type, true, false);
+}
+
+ColumnDataCheckpointer::ColumnDataCheckpointer(vector<reference<ColumnCheckpointState>> &checkpoint_states,
+                                               DatabaseInstance &db, RowGroup &row_group,
+                                               ColumnCheckpointInfo &checkpoint_info)
+    : checkpoint_states(checkpoint_states), db(db), row_group(row_group),
+      intermediate(CreateIntermediateVector(checkpoint_states)), checkpoint_info(checkpoint_info) {
+
+	auto &config = DBConfig::GetConfig(db);
+	compression_functions.resize(checkpoint_states.size());
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+		auto &col_data = checkpoint_states[i].get().column_data;
+		auto to_add = config.GetCompressionFunctions(col_data.type.InternalType());
+		auto &functions = compression_functions[i];
+		for (auto &func : to_add) {
+			functions.push_back(&func.get());
+		}
 	}
 }
 
-void ColumnDataCheckpointer::ScanSegments(const column_segment_vector_t &nodes,
-                                          const std::function<void(Vector &, idx_t)> &callback) {
+void ColumnDataCheckpointer::ScanSegments(const std::function<void(Vector &, idx_t)> &callback) {
 	Vector scan_vector(intermediate.GetType(), nullptr);
+	auto &first_state = checkpoint_states[0];
+	auto &col_data = first_state.get().column_data;
+	auto &nodes = col_data.data.ReferenceSegments();
+
+	// TODO: scan all the nodes from all segments, no need for CheckpointScan to virtualize this I think..
 	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
 		auto &segment = *nodes[segment_idx].node;
 		ColumnScanState scan_state;
@@ -68,7 +88,6 @@ void ColumnDataCheckpointer::ScanSegments(const column_segment_vector_t &nodes,
 			scan_state.row_index = segment.start + base_row_index;
 
 			col_data.CheckpointScan(segment, scan_state, row_group.start, count, scan_vector);
-
 			callback(scan_vector, count);
 		}
 	}
@@ -91,134 +110,210 @@ CompressionType ForceCompression(vector<optional_ptr<CompressionFunction>> &comp
 			break;
 		}
 	}
-	if (found) {
-		// the force_compression method is available
-		// clear all other compression methods
-		// except the uncompressed method, so we can fall back on that
-		for (idx_t i = 0; i < compression_functions.size(); i++) {
-			auto &compression_function = *compression_functions[i];
-			if (compression_function.type == CompressionType::COMPRESSION_UNCOMPRESSED) {
-				continue;
-			}
-			if (compression_function.type != compression_type) {
-				compression_functions[i] = nullptr;
-			}
-		}
+	if (!found) {
+		return CompressionType::COMPRESSION_AUTO;
 	}
-	return found ? compression_type : CompressionType::COMPRESSION_AUTO;
-}
-
-unique_ptr<AnalyzeState> ColumnDataCheckpointer::DetectBestCompressionMethod(const column_segment_vector_t &nodes,
-                                                                             idx_t &compression_idx) {
-	D_ASSERT(!compression_functions.empty());
-	auto &config = DBConfig::GetConfig(col_data.GetDatabase());
-	CompressionType forced_method = CompressionType::COMPRESSION_AUTO;
-
-	auto compression_type = checkpoint_info.GetCompressionType();
-	if (compression_type != CompressionType::COMPRESSION_AUTO) {
-		forced_method = ForceCompression(compression_functions, compression_type);
-	}
-	if (compression_type == CompressionType::COMPRESSION_AUTO &&
-	    config.options.force_compression != CompressionType::COMPRESSION_AUTO) {
-		forced_method = ForceCompression(compression_functions, config.options.force_compression);
-	}
-	// set up the analyze states for each compression method
-	vector<unique_ptr<AnalyzeState>> analyze_states;
-	analyze_states.reserve(compression_functions.size());
+	// the force_compression method is available
+	// clear all other compression methods
+	// except the uncompressed method, so we can fall back on that
 	for (idx_t i = 0; i < compression_functions.size(); i++) {
-		if (!compression_functions[i]) {
-			analyze_states.push_back(nullptr);
+		auto &compression_function = *compression_functions[i];
+		if (compression_function.type == CompressionType::COMPRESSION_UNCOMPRESSED) {
 			continue;
 		}
-		analyze_states.push_back(compression_functions[i]->init_analyze(col_data, col_data.type.InternalType()));
+		if (compression_function.type != compression_type) {
+			compression_functions[i] = nullptr;
+		}
+	}
+	return compression_type;
+}
+
+void ColumnDataCheckpointer::InitAnalyze() {
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+		if (!has_changes[i]) {
+			continue;
+		}
+
+		auto &functions = compression_functions[i];
+		auto &states = analyze_states[i];
+		auto &checkpoint_state = checkpoint_states[i];
+		auto &coldata = checkpoint_state.get().column_data;
+		for (auto &func : functions) {
+			states.push_back(func->init_analyze(coldata, coldata.type.InternalType()));
+		}
+	}
+}
+
+vector<CheckpointAnalyzeResult> ColumnDataCheckpointer::DetectBestCompressionMethod() {
+	D_ASSERT(!compression_functions.empty());
+	auto &config = DBConfig::GetConfig(db);
+	vector<CompressionType> forced_methods(checkpoint_states.size(), CompressionType::COMPRESSION_AUTO);
+
+	auto compression_type = checkpoint_info.GetCompressionType();
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+		auto &functions = compression_functions[i];
+		if (compression_type != CompressionType::COMPRESSION_AUTO) {
+			forced_methods[i] = ForceCompression(functions, compression_type);
+		}
+		if (compression_type == CompressionType::COMPRESSION_AUTO &&
+		    config.options.force_compression != CompressionType::COMPRESSION_AUTO) {
+			forced_methods[i] = ForceCompression(functions, config.options.force_compression);
+		}
 	}
 
+	InitAnalyze();
+
 	// scan over all the segments and run the analyze step
-	ScanSegments(nodes, [&](Vector &scan_vector, idx_t count) {
-		for (idx_t i = 0; i < compression_functions.size(); i++) {
-			if (!compression_functions[i]) {
+	ScanSegments([&](Vector &scan_vector, idx_t count) {
+		for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+			if (!has_changes[i]) {
 				continue;
 			}
-			bool success = false;
-			if (analyze_states[i]) {
-				success = compression_functions[i]->analyze(*analyze_states[i], scan_vector, count);
-			}
-			if (!success) {
-				// could not use this compression function on this data set
-				// erase it
-				compression_functions[i] = nullptr;
-				analyze_states[i].reset();
+
+			auto &functions = compression_functions[i];
+			auto &states = analyze_states[i];
+			for (idx_t j = 0; j < functions.size(); j++) {
+				auto &state = states[j];
+				auto &func = functions[j];
+
+				if (!state) {
+					continue;
+				}
+				if (!func->analyze(*state, scan_vector, count)) {
+					state = nullptr;
+					func = nullptr;
+				}
 			}
 		}
 	});
 
-	// now that we have passed over all the data, we need to figure out the best method
-	// we do this using the final_analyze method
-	unique_ptr<AnalyzeState> state;
-	compression_idx = DConstants::INVALID_INDEX;
-	idx_t best_score = NumericLimits<idx_t>::Maximum();
-	for (idx_t i = 0; i < compression_functions.size(); i++) {
-		if (!compression_functions[i]) {
-			continue;
-		}
-		if (!analyze_states[i]) {
-			continue;
-		}
-		//! Check if the method type is the forced method (if forced is used)
-		bool forced_method_found = compression_functions[i]->type == forced_method;
-		auto score = compression_functions[i]->final_analyze(*analyze_states[i]);
+	vector<CheckpointAnalyzeResult> result;
+	result.resize(checkpoint_states.size());
 
-		//! The finalize method can return this value from final_analyze to indicate it should not be used.
-		if (score == DConstants::INVALID_INDEX) {
-			continue;
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+		auto &functions = compression_functions[i];
+		auto &states = analyze_states[i];
+		auto &forced_method = forced_methods[i];
+
+		unique_ptr<AnalyzeState> chosen_state;
+		idx_t best_score = NumericLimits<idx_t>::Maximum();
+		idx_t compression_idx = DConstants::INVALID_INDEX;
+
+		D_ASSERT(functions.size() == states.size());
+		for (idx_t j = 0; j < functions.size(); j++) {
+			auto &function = functions[j];
+			auto &state = states[j];
+
+			if (!state) {
+				continue;
+			}
+
+			//! Check if the method type is the forced method (if forced is used)
+			bool forced_method_found = function->type == forced_method;
+			// now that we have passed over all the data, we need to figure out the best method
+			// we do this using the final_analyze method
+			auto score = function->final_analyze(*state);
+
+			//! The finalize method can return this value from final_analyze to indicate it should not be used.
+			if (score == DConstants::INVALID_INDEX) {
+				continue;
+			}
+
+			if (score < best_score || forced_method_found) {
+				compression_idx = j;
+				best_score = score;
+				chosen_state = std::move(state);
+			}
+			//! If we have found the forced method, we're done
+			if (forced_method_found) {
+				break;
+			}
 		}
 
-		if (score < best_score || forced_method_found) {
-			compression_idx = i;
-			best_score = score;
-			state = std::move(analyze_states[i]);
+		if (!chosen_state) {
+			auto &checkpoint_state = checkpoint_states[i];
+			auto &col_data = checkpoint_state.get().column_data;
+			throw FatalException("No suitable compression/storage method found to store column of type %s",
+			                     col_data.type.ToString());
 		}
-		//! If we have found the forced method, we're done
-		if (forced_method_found) {
-			break;
-		}
+		D_ASSERT(compression_idx == DConstants::INVALID_INDEX);
+		result[i] = CheckpointAnalyzeResult(std::move(chosen_state), *functions[compression_idx]);
 	}
-	return state;
+	return result;
 }
 
-void ColumnDataCheckpointer::WriteToDisk(const column_segment_vector_t &nodes) {
-	// there were changes or transient segments
-	// we need to rewrite the column segments to disk
-
+void ColumnDataCheckpointer::DropSegments() {
 	// first we check the current segments
 	// if there are any persistent segments, we will mark their old block ids as modified
 	// since the segments will be rewritten their old on disk data is no longer required
-	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
-		auto segment = nodes[segment_idx].node.get();
-		segment->CommitDropSegment();
+
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+		if (!has_changes[i]) {
+			continue;
+		}
+
+		auto &state = checkpoint_states[i];
+		auto &col_data = state.get().column_data;
+		auto &nodes = col_data.data.ReferenceSegments();
+
+		// Drop the segments, as we'll be replacing them with new ones, because there are changes
+		for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
+			auto segment = nodes[segment_idx].node.get();
+			segment->CommitDropSegment();
+		}
 	}
-
-	// now we need to write our segment
-	// we will first run an analyze step that determines which compression function to use
-	idx_t compression_idx;
-	auto analyze_state = DetectBestCompressionMethod(nodes, compression_idx);
-
-	if (!analyze_state) {
-		throw FatalException("No suitable compression/storage method found to store column");
-	}
-
-	// now that we have analyzed the compression functions we can start writing to disk
-	auto best_function = compression_functions[compression_idx];
-	ColumnDataCheckpointData checkpoint_data(state, col_data, col_data.GetDatabase(), row_group, has_changes,
-	                                         checkpoint_info);
-	auto compress_state = best_function->init_compression(checkpoint_data, std::move(analyze_state));
-
-	ScanSegments(
-	    nodes, [&](Vector &scan_vector, idx_t count) { best_function->compress(*compress_state, scan_vector, count); });
-	best_function->compress_finalize(*compress_state);
 }
 
-bool ColumnDataCheckpointer::HasChanges(const column_segment_vector_t &nodes) {
+void ColumnDataCheckpointer::WriteToDisk() {
+	DropSegments();
+
+	// Analyze the candidate functions to select one of them to use for compression
+	auto analyze_result = DetectBestCompressionMethod();
+
+	// Initialize the compression for the selected function
+	D_ASSERT(analyze_result.size() == checkpoint_states.size());
+	vector<ColumnDataCheckpointData> checkpoint_data;
+	vector<unique_ptr<CompressionState>> compression_states;
+	for (idx_t i = 0; i < analyze_result.size(); i++) {
+		if (!has_changes[i]) {
+			continue;
+		}
+		auto &analyze_state = analyze_result[i].analyze_state;
+		auto &function = analyze_result[i].function;
+
+		auto &checkpoint_state = checkpoint_states[i];
+		auto &col_data = checkpoint_state.get().column_data;
+
+		checkpoint_data.emplace_back(checkpoint_state, col_data, col_data.GetDatabase(), row_group, has_changes[i],
+		                             checkpoint_info);
+		compression_states.push_back(function->init_compression(checkpoint_data[i], std::move(analyze_state)));
+	}
+
+	// Scan over the existing segment + changes and compress the data
+	ScanSegments([&](Vector &scan_vector, idx_t count) {
+		for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+			if (!has_changes[i]) {
+				continue;
+			}
+			auto &function = analyze_result[i].function;
+			auto &compression_state = compression_states[i];
+			function->compress(*compression_state, scan_vector, count);
+		}
+	});
+
+	// Finalize the compression
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+		if (!has_changes[i]) {
+			continue;
+		}
+		auto &function = analyze_result[i].function;
+		auto &compression_state = compression_states[i];
+		function->compress_finalize(*compression_state);
+	}
+}
+
+bool ColumnDataCheckpointer::HasChanges(ColumnData &col_data) {
+	auto &nodes = col_data.data.ReferenceSegments();
 	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
 		auto segment = nodes[segment_idx].node.get();
 		if (segment->segment_type == ColumnSegmentType::TRANSIENT) {
@@ -236,9 +331,13 @@ bool ColumnDataCheckpointer::HasChanges(const column_segment_vector_t &nodes) {
 	return false;
 }
 
-void ColumnDataCheckpointer::WritePersistentSegments(column_segment_vector_t nodes) {
+void ColumnDataCheckpointer::WritePersistentSegments(ColumnCheckpointState &state) {
 	// all segments are persistent and there are no updates
 	// we only need to write the metadata
+
+	auto &col_data = state.column_data;
+	auto nodes = col_data.data.MoveSegments();
+
 	for (idx_t segment_idx = 0; segment_idx < nodes.size(); segment_idx++) {
 		auto segment = nodes[segment_idx].node.get();
 		auto pointer = segment->GetDataPointer();
@@ -253,28 +352,39 @@ void ColumnDataCheckpointer::WritePersistentSegments(column_segment_vector_t nod
 	}
 }
 
-void ColumnDataCheckpointer::Checkpoint(const column_segment_vector_t &nodes) {
-	D_ASSERT(!nodes.empty());
-	has_changes = HasChanges(nodes);
-	// first check if any of the segments have changes
-	if (has_changes) {
-		WriteToDisk(nodes);
+void ColumnDataCheckpointer::Checkpoint() {
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+		auto &state = checkpoint_states[i];
+		auto &col_data = state.get().column_data;
+		has_changes.push_back(HasChanges(col_data));
+	}
+
+	bool any_has_changes = false;
+	for (idx_t i = 0; i < has_changes.size(); i++) {
+		if (has_changes[i]) {
+			any_has_changes = true;
+			break;
+		}
+	}
+	if (!any_has_changes) {
+		// Nothing has undergone any changes, no need to checkpoint
+		// just move on to finalizing
+		return;
 	}
 }
 
-void ColumnDataCheckpointer::FinalizeCheckpoint(column_segment_vector_t &&nodes) {
-	if (has_changes) {
-		nodes.clear();
-	} else {
-		WritePersistentSegments(std::move(nodes));
+void ColumnDataCheckpointer::FinalizeCheckpoint() {
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+		auto &state = checkpoint_states[i].get();
+		auto &col_data = state.column_data;
+		if (has_changes[i]) {
+			// Move the existing segments out of the column data
+			// they will be destructed at the end of the scope
+			auto to_delete = col_data.data.MoveSegments();
+		} else {
+			WritePersistentSegments(state);
+		}
 	}
-}
-
-CompressionFunction &ColumnDataCheckpointer::GetCompressionFunction(CompressionType compression_type) {
-	auto &db = col_data.GetDatabase();
-	auto &column_type = col_data.type;
-	auto &config = DBConfig::GetConfig(db);
-	return *config.GetCompressionFunction(compression_type, column_type.InternalType());
 }
 
 } // namespace duckdb

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -234,6 +234,7 @@ unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_g
 	// flushed to disk by a different thread than the one that wrote it, causing a data race
 	auto base_state = ColumnData::Checkpoint(row_group, checkpoint_info);
 	auto validity_state = validity.Checkpoint(row_group, checkpoint_info);
+
 	auto &checkpoint_state = base_state->Cast<StandardColumnCheckpointState>();
 	checkpoint_state.validity_state = std::move(validity_state);
 	return base_state;

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -394,8 +394,7 @@ void StandardColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState 
 	ColumnData::CheckpointScan(segment, state, row_group_start, count, scan_vector);
 
 	idx_t offset_in_row_group = state.row_index - row_group_start;
-	validity.CheckpointScan(*state.child_states[0].current, state.child_states[0], offset_in_row_group, count,
-	                        scan_vector);
+	validity.ScanCommittedRange(row_group_start, offset_in_row_group, count, scan_vector);
 }
 
 bool StandardColumnData::IsPersistent() {

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -235,6 +235,155 @@ unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_g
 	auto base_state = ColumnData::Checkpoint(row_group, checkpoint_info);
 	auto validity_state = validity.Checkpoint(row_group, checkpoint_info);
 
+	/* TODO: abstract this
+
+	create base checkpoint state
+	create validity checkpoint state
+
+	vector<reference<ColumnCheckpointState>> checkpoint_states;
+	vector<reference<column_segment_vector_t>> column_segments;
+
+	ColumnDataCheckpointer checkpointer(checkpoint_states);
+
+	D_ASSERT(checkpoint_states.size() == column_segments.size());
+	has_changes.reserve(checkpoint_states.size());
+	for (idx_t i = 0; i < column_segments.size(); i++) {
+	    auto &nodes = column_segments[i];
+	    has_changes.push_back(HasChanges(nodes));
+	}
+
+	bool any_has_changes = false;
+	for (auto &changes : has_changes) {
+	    if (changes) {
+	        any_has_changes = true;
+	    }
+	}
+	if (!any_has_changes) {
+	    return;
+	}
+
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+	    auto &changes = has_changes[i];
+	    if (!changes) {
+	        continue;
+	    }
+	    auto &nodes = column_segments[i];
+	    CommitDropSegments(nodes);
+	}
+
+	// vector<vector<reference<const CompressionFunction>>> compression_functions; (created as part of the
+	ColumnDataCheckpointer constructor);
+	vector<vector<unique_ptr<AnalyzeState>> analyze_states;
+	// TODO:
+	// figure out the forced compression function
+
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+	    auto &changes = has_changes[i];
+	    if (!changes) {
+	        continue;
+	    }
+
+	    auto &functions = compression_functions[i];
+	    auto &states = analyze_states[i];
+	    auto &checkpoint_state = checkpoint_states[i];
+	    auto &coldata = checkpoint_state.coldata;
+	    for (auto &func : functions) {
+	        states.push_back(func.init_analyze(coldata, coldata.GetType())
+	    }
+	}
+
+	D_ASSERT(!checkpoint_states.empty());
+	auto &first_state = checkpoint_states[0];
+	auto &coldata = first_state.coldata;
+	auto &first_nodes = column_segments[0];
+	ScanSegments(coldata, first_nodes, [](Vector &input, input_count) {
+	    for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+	        auto &changes = has_changes[i];
+	        if (!changes) {
+	            continue;
+	        }
+
+	        auto &functions = compression_functions[i];
+	        auto &states = analyze_states[i];
+	        for (idx_t j = 0; j < functions.size(); j++) {
+	            auto &function = functions[j];
+	            auto &state = states[j];
+	            if (!state) {
+	                continue;
+	            }
+	            if (!function.analyze(state, input, input_count)) {
+	                function = nullptr;
+	                state = nullptr;
+	            }
+	        }
+	    }
+	});
+
+	vector<reference<const CompressionFunction>> compression_function;
+	vector<unique_ptr<CompressionState>> compression_state;
+
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+	    auto &changes = has_changes[i];
+	    if (!changes) {
+	        continue;
+	    }
+
+	    TODO:
+	    final analyze and prefer the forced compression method
+	    followed by 'init_compression' to create the 'compression_state' for this coldata
+	}
+
+	ScanSegments(coldata, first_nodes, [](Vector &input, idx_t input_count) {
+	    for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+	        auto &changes = has_changes[i];
+	        if (!changes) {
+	            continue;
+	        }
+
+	        auto &state = compression_state[i];
+	        auto &function = compression_function[i];
+	        function.compress(state, input, input_count);
+	    }
+	});
+
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+	    auto &changes = has_changes[i];
+	    if (!changes) {
+	        continue;
+	    }
+
+	    auto &function = compression_function[i];
+	    function.compress_finalize(state);
+	}
+
+
+	for (idx_t i = 0; i < checkpoint_states.size(); i++) {
+	    auto &changes = has_changes[i];
+	    auto &coldata = checkpoint_states[i];
+
+	    auto existing_nodes = coldata.
+
+	    if (!changes) {
+	        WritePersistentSegments(coldata);
+	    } else {
+	        auto &coldata = checkpoint_states[i].coldata;
+	        new_segments = checkpointer.MoveSegments();
+	        coldata.AppendSegments(new_segments);
+	        coldata.ClearUpdates();
+	    }
+
+	    // reset the compression function
+	    coldata.compression.reset();
+	    // replace the old tree with the new one
+	    auto new_segments = checkpoint_state->new_tree.MoveSegments();
+	    for (auto &new_segment : new_segments) {
+	        coldata.AppendSegment(l, std::move(new_segment.node));
+	    }
+	    coldata.ClearUpdates();
+	}
+
+	END OF TODO */
+
 	auto &checkpoint_state = base_state->Cast<StandardColumnCheckpointState>();
 	checkpoint_state.validity_state = std::move(validity_state);
 	return base_state;
@@ -245,7 +394,8 @@ void StandardColumnData::CheckpointScan(ColumnSegment &segment, ColumnScanState 
 	ColumnData::CheckpointScan(segment, state, row_group_start, count, scan_vector);
 
 	idx_t offset_in_row_group = state.row_index - row_group_start;
-	validity.ScanCommittedRange(row_group_start, offset_in_row_group, count, scan_vector);
+	validity.CheckpointScan(*state.child_states[0].current, state.child_states[0], offset_in_row_group, count,
+	                        scan_vector);
 }
 
 bool StandardColumnData::IsPersistent() {


### PR DESCRIPTION
### ColumnDataCheckpointData

To give the compression function access to the column data, a reference to the `ColumnDataCheckpointer` was provided to the function.
This is used to extract certain ColumnData information like the LogicalType and the associated ColumnCheckpointState. Since `ColumnDataCheckpointer` is not always associated with a specific ColumnData anymore, a new struct was introduced to hold this information.

```c++
//! Holds state related to a single column during compression
struct ColumnDataCheckpointData {
public:
	//! Default constructor used when column data does not need to be checkpointed
	ColumnDataCheckpointData() {
	}
	ColumnDataCheckpointData(ColumnCheckpointState &checkpoint_state, ColumnData &col_data, DatabaseInstance &db,
	                         RowGroup &row_group, ColumnCheckpointInfo &checkpoint_info)
	    : checkpoint_state(checkpoint_state), col_data(col_data), db(db), row_group(row_group),
	      checkpoint_info(checkpoint_info) {
	}

public:
	CompressionFunction &GetCompressionFunction(CompressionType type);
	const LogicalType &GetType() const;
	ColumnData &GetColumnData();
	RowGroup &GetRowGroup();
	ColumnCheckpointState &GetCheckpointState();
	DatabaseInstance &GetDatabase();

private:
	optional_ptr<ColumnCheckpointState> checkpoint_state;
	optional_ptr<ColumnData> col_data;
	optional_ptr<DatabaseInstance> db;
	optional_ptr<RowGroup> row_group;
	optional_ptr<ColumnCheckpointInfo> checkpoint_info;
};
```

### StandardColumnData

This new functionality of the ColumnDataCheckpointer is used when checkpointing StandardColumnData, this is any type of column data that is non-nested. Nested types like list/array/struct will eventually have StandardColumnData entries as their leaves.

Previously the base data would scan its old data + the old validity data, afterwards the validity would checkpoint and scan the validity data again. This was wasteful and is removed by this change.

In addition to this fix, this change should also allow us to combine validity information into the base data's segments if the compression function allows it, reducing the physical footprint of a column. This change will be made in a future PR.