### PR TITLE
Asof join adds rows in specific case

### DIFF
--- a/src/optimizer/build_probe_side_optimizer.cpp
+++ b/src/optimizer/build_probe_side_optimizer.cpp
@@ -54,8 +54,7 @@ static void FlipChildren(LogicalOperator &op) {
 	std::swap(op.children[0], op.children[1]);
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
-	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
-	case LogicalOperatorType::LOGICAL_ASOF_JOIN: {
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN: {
 		auto &join = op.Cast<LogicalComparisonJoin>();
 		join.join_type = InverseJoinType(join.join_type);
 		for (auto &cond : join.conditions) {
@@ -242,8 +241,7 @@ void BuildProbeSideOptimizer::VisitOperator(LogicalOperator &op) {
 		}
 		break;
 	}
-	case LogicalOperatorType::LOGICAL_ANY_JOIN:
-	case LogicalOperatorType::LOGICAL_ASOF_JOIN: {
+	case LogicalOperatorType::LOGICAL_ANY_JOIN: {
 		auto &join = op.Cast<LogicalJoin>();
 		// We do not yet support the RIGHT_SEMI or RIGHT_ANTI join types for these, so don't try to flip
 		switch (join.join_type) {

--- a/test/optimizer/joins/asof_join_adds_rows.test
+++ b/test/optimizer/joins/asof_join_adds_rows.test
@@ -1,0 +1,92 @@
+# name: test/optimizer/joins/asof_join_adds_rows.test
+# description: In the join order optimizer queries need to have the correct bindings
+# group: [joins]
+
+require json
+
+
+statement ok
+create table t1 as from values (
+'2024-12-23'::TIMESTAMPTZ,
+'2024-12-23'::TIMESTAMPTZ,
+'2024-12-23'::TIMESTAMPTZ,
+'2024-12-23'::TIMESTAMPTZ,
+'2024-02-11'::TIMESTAMPTZ,
+'2024-02-11'::TIMESTAMPTZ,
+'2024-12-23'::TIMESTAMPTZ) t(a);
+
+statement ok
+create table t2 as SELECT
+  *
+FROM
+  (
+	VALUES
+	  ('fqn2', '2021-03-03'::TIMESTAMPTZ),
+	  ('fqn2', '2021-02-02'::TIMESTAMPTZ),
+	  ('fqn1', '2021-01-01'::TIMESTAMPTZ)
+  ) AS data (ap_fqn, timepoint);
+
+
+
+query III
+WITH
+  id_with_timepoint AS (
+    SELECT
+      'ID1' AS user_id,
+      '2024-12-23'::TIMESTAMPTZ AS lastSeen
+  ),
+  id_and_payload_with_timepoint AS (
+    SELECT
+      'ID1' AS user_id,
+      '2024-02-11'::TIMESTAMPTZ AS timepoint,
+      '{ "amp": [ {"k": "fqn1"}, {"k": "fqn2"}]}'::VARCHAR AS payload
+  ),
+  id_with_payload_intermediate AS (
+    SELECT
+      id_with_timepoint.user_id,
+      id_with_timepoint.lastSeen,
+      id_and_payload_with_timepoint.payload,
+    FROM
+      id_with_timepoint ASOF
+      LEFT JOIN id_and_payload_with_timepoint ON (
+        id_with_timepoint.user_id = id_and_payload_with_timepoint.user_id
+        AND id_and_payload_with_timepoint.timepoint < id_with_timepoint.lastSeen
+      )
+  ),
+  id_with_fqn AS (
+    SELECT
+      user_id,
+      lastSeen,
+      t.k_fqn
+    FROM
+      id_with_payload_intermediate
+      LEFT JOIN LATERAL UNNEST(payload ->> '$.amp[*].k') AS t (k_fqn) ON TRUE
+  ),
+  fqn_table AS (
+    SELECT
+      *
+    FROM
+      (
+        VALUES
+          ('fqn2', '2021-03-03'::TIMESTAMPTZ),
+          ('fqn2', '2021-02-02'::TIMESTAMPTZ),
+          ('fqn1', '2021-01-01'::TIMESTAMPTZ)
+      ) AS data (ap_fqn, timepoint)
+  )
+SELECT
+  id_with_fqn.user_id,
+  id_with_fqn.k_fqn,
+  fqn_table.ap_fqn,
+  fqn_table.timepoint
+FROM
+  id_with_fqn ASOF
+  LEFT JOIN fqn_table ON (
+    id_with_fqn.k_fqn = fqn_table.ap_fqn
+    AND fqn_table.timepoint < id_with_fqn.lastSeen
+  )
+ORDER BY
+  k_fqn,
+  timepoint;
+----
+ID1	fqn1	fqn1	2021-01-01 00:00:00+01
+ID1	fqn2	fqn2	2021-03-03 00:00:00+01

--- a/test/optimizer/joins/asof_join_adds_rows.test
+++ b/test/optimizer/joins/asof_join_adds_rows.test
@@ -6,39 +6,59 @@ require json
 
 
 statement ok
-create table t1 as from values (
-'2024-12-23'::TIMESTAMPTZ,
-'2024-12-23'::TIMESTAMPTZ,
-'2024-12-23'::TIMESTAMPTZ,
-'2024-12-23'::TIMESTAMPTZ,
-'2024-02-11'::TIMESTAMPTZ,
-'2024-02-11'::TIMESTAMPTZ,
-'2024-12-23'::TIMESTAMPTZ) t(a);
+create table child_join as from values (1) t(c);
 
 statement ok
-create table t2 as SELECT
-  *
-FROM
-  (
-	VALUES
-	  ('fqn2', '2021-03-03'::TIMESTAMPTZ),
-	  ('fqn2', '2021-02-02'::TIMESTAMPTZ),
-	  ('fqn1', '2021-01-01'::TIMESTAMPTZ)
-  ) AS data (ap_fqn, timepoint);
+create table small_probe as from values
+(1, '1992-03-22 01:02:03'::TIMESTAMP),
+(1, '1992-03-22 01:02:04'::TIMESTAMP),
+(1, '1992-03-22 01:02:05'::TIMESTAMP),
+(1, '1992-03-22 01:02:06'::TIMESTAMP),
+(1, '1992-03-22 01:02:07'::TIMESTAMP),
+(1, '1992-03-22 01:02:08'::TIMESTAMP) t(sp_const, a);
+
+statement ok
+create table large_build as from values
+(1, '1992-03-22 01:02:04'::TIMESTAMP),
+(1, '1992-03-22 01:02:05'::TIMESTAMP),
+(1, '1992-03-22 01:02:06'::TIMESTAMP),
+(1, '1992-03-22 01:02:07'::TIMESTAMP),
+(1, '1992-03-22 01:02:08'::TIMESTAMP),
+(1, '1992-03-22 01:02:09'::TIMESTAMP),
+(1, '1992-03-22 01:02:10'::TIMESTAMP),
+(1, '1992-03-22 01:02:11'::TIMESTAMP),
+(1, '1992-03-22 01:02:12'::TIMESTAMP),
+(1, '1992-03-22 01:02:13'::TIMESTAMP),
+(1, '1992-03-22 01:02:14'::TIMESTAMP),
+(1, '1992-03-22 01:02:15'::TIMESTAMP),
+(1, '1992-03-22 01:02:16'::TIMESTAMP),
+(1, '1992-03-22 01:02:17'::TIMESTAMP),
+(1, '1992-03-22 01:02:18'::TIMESTAMP),
+(1, '1992-03-22 01:02:19'::TIMESTAMP),
+(1, '1992-03-22 01:02:20'::TIMESTAMP) t(lb_const, b);
+
+query I
+select a from (select * from small_probe, child_join where c=sp_const) asof join large_build on (lb_const = sp_const and a < b) order by a;
+----
+1992-03-22 01:02:03
+1992-03-22 01:02:04
+1992-03-22 01:02:05
+1992-03-22 01:02:06
+1992-03-22 01:02:07
+1992-03-22 01:02:08
 
 
-
-query III
+query IIII
 WITH
   id_with_timepoint AS (
     SELECT
       'ID1' AS user_id,
-      '2024-12-23'::TIMESTAMPTZ AS lastSeen
+      '2024-12-23'::TIMESTAMP AS lastSeen
   ),
   id_and_payload_with_timepoint AS (
     SELECT
       'ID1' AS user_id,
-      '2024-02-11'::TIMESTAMPTZ AS timepoint,
+      '2024-02-11'::TIMESTAMP AS timepoint,
       '{ "amp": [ {"k": "fqn1"}, {"k": "fqn2"}]}'::VARCHAR AS payload
   ),
   id_with_payload_intermediate AS (
@@ -68,16 +88,16 @@ WITH
     FROM
       (
         VALUES
-          ('fqn2', '2021-03-03'::TIMESTAMPTZ),
-          ('fqn2', '2021-02-02'::TIMESTAMPTZ),
-          ('fqn1', '2021-01-01'::TIMESTAMPTZ)
+          ('fqn2', '2021-03-03'::TIMESTAMP),
+          ('fqn2', '2021-02-02'::TIMESTAMP),
+          ('fqn1', '2021-01-01'::TIMESTAMP)
       ) AS data (ap_fqn, timepoint)
   )
 SELECT
   id_with_fqn.user_id,
   id_with_fqn.k_fqn,
   fqn_table.ap_fqn,
-  fqn_table.timepoint
+  fqn_table.timepoint::TIMESTAMP
 FROM
   id_with_fqn ASOF
   LEFT JOIN fqn_table ON (
@@ -88,5 +108,5 @@ ORDER BY
   k_fqn,
   timepoint;
 ----
-ID1	fqn1	fqn1	2021-01-01 00:00:00+01
-ID1	fqn2	fqn2	2021-03-03 00:00:00+01
+ID1	fqn1	fqn1	2021-01-01 00:00:00
+ID1	fqn2	fqn2	2021-03-03 00:00:00

--- a/test/optimizer/joins/cross_join_and_unnest_dont_work.test
+++ b/test/optimizer/joins/cross_join_and_unnest_dont_work.test
@@ -1,13 +1,112 @@
 # name: test/optimizer/joins/cross_join_and_unnest_dont_work.test
-# description: Internal issue
+# description: In the join order optimizer queries need to have the correct bindings
 # group: [joins]
 
+require json
+
+
 statement ok
-SELECT y + z AS c
-FROM (
-	SELECT y, unnest([x]) AS z
-	FROM
-		(SELECT 1 as x),
-		(SELECT 1 as y)
-	)
- WHERE c > 0;
+create table child_join as from values (1) t(c);
+
+statement ok
+create table small_probe as from values
+(1, '1992-03-22 01:02:03'::TIMESTAMP),
+(1, '1992-03-22 01:02:04'::TIMESTAMP),
+(1, '1992-03-22 01:02:05'::TIMESTAMP),
+(1, '1992-03-22 01:02:06'::TIMESTAMP),
+(1, '1992-03-22 01:02:07'::TIMESTAMP),
+(1, '1992-03-22 01:02:08'::TIMESTAMP) t(sp_const, a);
+
+statement ok
+create table large_build as from values
+(1, '1992-03-22 01:02:04'::TIMESTAMP),
+(1, '1992-03-22 01:02:05'::TIMESTAMP),
+(1, '1992-03-22 01:02:06'::TIMESTAMP),
+(1, '1992-03-22 01:02:07'::TIMESTAMP),
+(1, '1992-03-22 01:02:08'::TIMESTAMP),
+(1, '1992-03-22 01:02:09'::TIMESTAMP),
+(1, '1992-03-22 01:02:10'::TIMESTAMP),
+(1, '1992-03-22 01:02:11'::TIMESTAMP),
+(1, '1992-03-22 01:02:12'::TIMESTAMP),
+(1, '1992-03-22 01:02:13'::TIMESTAMP),
+(1, '1992-03-22 01:02:14'::TIMESTAMP),
+(1, '1992-03-22 01:02:15'::TIMESTAMP),
+(1, '1992-03-22 01:02:16'::TIMESTAMP),
+(1, '1992-03-22 01:02:17'::TIMESTAMP),
+(1, '1992-03-22 01:02:18'::TIMESTAMP),
+(1, '1992-03-22 01:02:19'::TIMESTAMP),
+(1, '1992-03-22 01:02:20'::TIMESTAMP) t(lb_const, b);
+
+query I
+select a from (select * from small_probe, child_join where c=sp_const) asof join large_build on (lb_const = sp_const and a < b) order by a;
+----
+1992-03-22 01:02:03
+1992-03-22 01:02:04
+1992-03-22 01:02:05
+1992-03-22 01:02:06
+1992-03-22 01:02:07
+1992-03-22 01:02:08
+
+
+query IIII
+WITH
+  id_with_timepoint AS (
+    SELECT
+      'ID1' AS user_id,
+      '2024-12-23'::TIMESTAMP AS lastSeen
+  ),
+  id_and_payload_with_timepoint AS (
+    SELECT
+      'ID1' AS user_id,
+      '2024-02-11'::TIMESTAMP AS timepoint,
+      '{ "amp": [ {"k": "fqn1"}, {"k": "fqn2"}]}'::VARCHAR AS payload
+  ),
+  id_with_payload_intermediate AS (
+    SELECT
+      id_with_timepoint.user_id,
+      id_with_timepoint.lastSeen,
+      id_and_payload_with_timepoint.payload,
+    FROM
+      id_with_timepoint ASOF
+      LEFT JOIN id_and_payload_with_timepoint ON (
+        id_with_timepoint.user_id = id_and_payload_with_timepoint.user_id
+        AND id_and_payload_with_timepoint.timepoint < id_with_timepoint.lastSeen
+      )
+  ),
+  id_with_fqn AS (
+    SELECT
+      user_id,
+      lastSeen,
+      t.k_fqn
+    FROM
+      id_with_payload_intermediate
+      LEFT JOIN LATERAL UNNEST(payload ->> '$.amp[*].k') AS t (k_fqn) ON TRUE
+  ),
+  fqn_table AS (
+    SELECT
+      *
+    FROM
+      (
+        VALUES
+          ('fqn2', '2021-03-03'::TIMESTAMP),
+          ('fqn2', '2021-02-02'::TIMESTAMP),
+          ('fqn1', '2021-01-01'::TIMESTAMP)
+      ) AS data (ap_fqn, timepoint)
+  )
+SELECT
+  id_with_fqn.user_id,
+  id_with_fqn.k_fqn,
+  fqn_table.ap_fqn,
+  fqn_table.timepoint::TIMESTAMP
+FROM
+  id_with_fqn ASOF
+  LEFT JOIN fqn_table ON (
+    id_with_fqn.k_fqn = fqn_table.ap_fqn
+    AND fqn_table.timepoint < id_with_fqn.lastSeen
+  )
+ORDER BY
+  k_fqn,
+  timepoint;
+----
+ID1	fqn1	fqn1	2021-01-01 00:00:00
+ID1	fqn2	fqn2	2021-03-03 00:00:00


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/3846
Fixes https://github.com/duckdb/duckdb/issues/15506

Surprised this wasn't caught sooner. Through a missed case expression, the build side costs for the children of an asof join would be initialized to 0, so for many cases, asof join children would not be swapped. However, we prefer right deep trees, so if the left child of an asof join has children, then the asof join children would still get swapped. 

Asof Joins should not be swapped period since they are more of a table lookup than a join. This code fixes parts of the build side probe side optimizer to not swap asof joins.