### PR TITLE
make test always fail in case of internal exception

### DIFF
--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -263,20 +263,14 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 		// internal errors are never expected
 		// neither are "unoptimized result differs from original result" errors
 
-		bool internal_error = false;
-		if (result.HasError()) {
-			if (TestIsInternalError(runner.always_fail_error_messages, result.GetError())) {
-				internal_error = true;
-			}
+		if (result.HasError() && TestIsInternalError(runner.always_fail_error_messages, result.GetError())) {
+			logger.InternalException(result);
+			return false;
 		}
-		if (!internal_error) {
-			if (expected_result == ExpectedResult::RESULT_UNKNOWN) {
-				error = false;
-			} else {
-				error = !error;
-			}
+		if (expected_result == ExpectedResult::RESULT_UNKNOWN) {
+			error = false;
 		} else {
-			expected_result = ExpectedResult::RESULT_SUCCESS;
+			error = !error;
 		}
 		if (result.HasError() && !statement.expected_error.empty()) {
 			if (!StringUtil::Contains(result.GetError(), statement.expected_error)) {

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -277,6 +277,15 @@ void SQLLogicTestLogger::ExpectedErrorMismatch(const string &expected_error, Mat
 	result.Print();
 }
 
+void SQLLogicTestLogger::InternalException(MaterializedQueryResult &result) {
+	PrintErrorHeader("Query failed with internal exception!");
+	PrintLineSep();
+	PrintSQL();
+	PrintHeader("Actual result:");
+	PrintLineSep();
+	result.Print();
+}
+
 void SQLLogicTestLogger::LoadDatabaseFail(const string &dbpath, const string &message) {
 	PrintErrorHeader(string(), 0, "Failed to load database " + dbpath);
 	PrintLineSep();

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -49,6 +49,7 @@ public:
 	void WrongResultHash(QueryResult *expected_result, MaterializedQueryResult &result);
 	void UnexpectedStatement(bool expect_ok, MaterializedQueryResult &result);
 	void ExpectedErrorMismatch(const string &expected_error, MaterializedQueryResult &result);
+	void InternalException(MaterializedQueryResult &result);
 	static void LoadDatabaseFail(const string &dbpath, const string &message);
 
 private:


### PR DESCRIPTION
This PR is needed to make sqllogic tests always fail in case of an internal exception.

Without this change, tests like the one below always pass, while they should fail in case of an internal exception

```
statement maybe
<some query throwing an internal exception>
----
<REGEX>:.*