### PR TITLE
Fix #15526: CTE use operator type modified by intersect_all

### DIFF
--- a/src/execution/physical_plan/plan_cte.cpp
+++ b/src/execution/physical_plan/plan_cte.cpp
@@ -24,7 +24,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalMaterializ
 	auto right = CreatePlan(*op.children[1]);
 
 	unique_ptr<PhysicalCTE> cte;
-	cte = make_uniq<PhysicalCTE>(op.ctename, op.table_index, op.children[1]->types, std::move(left), std::move(right),
+	cte = make_uniq<PhysicalCTE>(op.ctename, op.table_index, right->types, std::move(left), std::move(right),
 	                             op.estimated_cardinality);
 	cte->working_table = working_table;
 	cte->cte_scans = materialized_ctes[op.table_index];

--- a/test/fuzzer/public/lateral_join_subquery.test
+++ b/test/fuzzer/public/lateral_join_subquery.test
@@ -12,3 +12,6 @@ statement error
 FROM t1 INNER JOIN (SELECT t1.c1) ON (SELECT 42);
 ----
 Subqueries are not supported in LATERAL join conditions
+
+statement ok
+SELECT  c01 from values('string') as _(c01), LATERAL ( WITH ta02 AS MATERIALIZED ( SELECT 'string' ) ( SELECT 'string' ) INTERSECT ALL ( SELECT 'string' ) );


### PR DESCRIPTION
This pr try to fix #15526 , intersect all add window row_num column into LogicalOperator so cannot use its types.