### PR TITLE
CI: Bump container for Android build

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -45,7 +45,7 @@ jobs:
   android:
     name: Android
     runs-on: ubuntu-latest
-    container: ubuntu:18.04
+    container: ubuntu:20.04
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
 
     strategy:


### PR DESCRIPTION
Uses the container for the Android build from the EOL'd Ubuntu 18.04 to 20.04