### PR TITLE
[Julia]: Auto-generate api.jl with new order

### DIFF
--- a/tools/juliapkg/scripts/generate_c_api_julia.py
+++ b/tools/juliapkg/scripts/generate_c_api_julia.py
@@ -852,7 +852,7 @@ def configure_parser():
     parser.add_argument(
         "--use-original-order",
         action="store_true",
-        default=True,
+        default=False,
         help="Use the original order of the functions from the old API file. New functions will be appended at the end.",
     )
 

--- a/tools/juliapkg/update_api.sh
+++ b/tools/juliapkg/update_api.sh
@@ -13,7 +13,6 @@ cd "$GIR_ROOT_DIR"
 # Generate the Julia API
 python tools/juliapkg/scripts/generate_c_api_julia.py \
     --auto-1-index \
-    --use-original-order \
     --capi-dir src/include/duckdb/main/capi/header_generation \
     tools/juliapkg/src/api.jl
 


### PR DESCRIPTION
This is a follow up PR to #15474 that changes the order in which the functions in `api.jl` are defined. They now have the same order as in `duckdb.h` and with proper grouping.

To switch back to the original order the `--use-original-order` flag in the `update_api.sh` script can be set.

In the previous PR the original order was intentionally kept to more easily spot discrepancies between the hand-coded and automatically generated wrapper and to keep the git diff to a minimum for review.