### PR TITLE
In PhysicalInsert call FinalFlush before merging row groups into local storage

### DIFF
--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -712,6 +712,7 @@ SinkCombineResultType PhysicalInsert::Combine(ExecutionContext &context, Operato
 	} else {
 		// we have written rows to disk optimistically - merge directly into the transaction-local storage
 		lstate.writer->WriteLastRowGroup(*lstate.local_collection);
+		lstate.writer->FinalFlush();
 		gstate.table.GetStorage().LocalMerge(context.client, *lstate.local_collection);
 		gstate.table.GetStorage().FinalizeOptimisticWriter(context.client, *lstate.writer);
 	}

--- a/test/sql/storage/optimistic_write/optimistic_write_mixed.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_mixed.test_slow
@@ -1,0 +1,23 @@
+# name: test/sql/storage/optimistic_write/optimistic_write_mixed.test_slow
+# description: Test mix of optimistic writes
+# group: [optimistic_write]
+
+require parquet
+
+statement ok
+copy (select uuid() sw_id, uuid()::varchar sw_system_object, uuid()::varchar source_system_id, uuid()::varchar source_system, uuid()::varchar source_system_object, uuid()::varchar source_system_field_name, random() <= 0.9 as is_primary from range(728478))
+to '__TEST_DIR__/external_ids_generated.parquet';
+
+load __TEST_DIR__/external_ids.db
+
+statement ok
+PRAGMA force_compression='uncompressed';
+
+statement ok
+SET threads = 48;
+
+statement ok
+SET preserve_insertion_order = false;
+
+statement ok
+create table external_ids_tbl as from parquet_scan('__TEST_DIR__/external_ids_generated.parquet');


### PR DESCRIPTION
This fixes an issue where sporadically we could run into a nullpointer exception when flushing partial blocks later on.

Essentially what could happen is that we would have blocks that were added to the partial block manager in the transaction-local storage get appended to later on again, leading to the same segment being registered with multiple partial blocks. Flushing the partial block manager before merging the segments resolves this issue as it ensures the segments are converted into disk-backed persistent blocks, which prevents them from being appended to again later on.