### PR TITLE
InternalException should only invalidate database when encountered during execution

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -66,7 +66,6 @@ bool Exception::InvalidatesTransaction(ExceptionType exception_type) {
 
 bool Exception::InvalidatesDatabase(ExceptionType exception_type) {
 	switch (exception_type) {
-	case ExceptionType::INTERNAL:
 	case ExceptionType::FATAL:
 		return true;
 	default:

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -236,7 +236,7 @@ ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success,
 		}
 	} catch (std::exception &ex) {
 		error = ErrorData(ex);
-		if (Exception::InvalidatesDatabase(error.Type())) {
+		if (Exception::InvalidatesDatabase(error.Type()) || error.Type() == ExceptionType::INTERNAL) {
 			auto &db_inst = DatabaseInstance::GetDatabase(*this);
 			ValidChecker::Invalidate(db_inst, error.RawMessage());
 		}
@@ -584,7 +584,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 			}
 		} else if (!Exception::InvalidatesTransaction(error.Type())) {
 			invalidate_transaction = false;
-		} else if (Exception::InvalidatesDatabase(error.Type())) {
+		} else if (Exception::InvalidatesDatabase(error.Type()) || error.Type() == ExceptionType::INTERNAL) {
 			// fatal exceptions invalidate the entire database
 			auto &db_instance = DatabaseInstance::GetDatabase(*this);
 			ValidChecker::Invalidate(db_instance, error.RawMessage());


### PR DESCRIPTION
Internal exceptions signal failures of internal assertions in DuckDB - as such we force the database to be shut down, as they might leave DuckDB in an unknown state.

Most of the internal exceptions we encounter, however, happen during the bind/optimization phases - and these do not have any danger of leaving the database in an unknown state. This PR makes it so that only internal exceptions encountered during the execution or commit/rollback phases invalidate the database.