### PR TITLE
Allowing SELECT x.* for union types

### DIFF
--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -550,8 +550,7 @@ void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
 			column_names[1] = expr.relation_name;
 
 			for (auto &child : struct_children) {
-				if (child.first.empty()) { // UNIONs have a nameless first child with the tag, we can't query that
-					D_ASSERT(col_type.id() == LogicalTypeId::UNION);
+				if (child.first.empty()) { // UNIONS and ROWs have unnamed children, we don't want to bind those
 					continue;
 				}
 				QualifiedColumnName qualified_name(child.first);

--- a/test/sql/types/union/union_extract.test
+++ b/test/sql/types/union/union_extract.test
@@ -139,3 +139,13 @@ query III
 from (values('asdf'::UNION(a INTEGER, b VARCHAR, c FLOAT))) v(c) select c.*;
 ----
 NULL	asdf	NULL
+
+statement error
+FROM (VALUES (row(1,2))) as t(i) SELECT i.*;
+----
+SELECT list is empty
+
+statement error
+FROM (VALUES (row(1))) as t(i) SELECT i.*;
+----
+SELECT list is empty

--- a/test/sql/types/union/union_extract.test
+++ b/test/sql/types/union/union_extract.test
@@ -133,3 +133,9 @@ EXECUTE p1('c');
 NULL
 text
 NULL
+
+
+query III
+from (values('asdf'::UNION(a INTEGER, b VARCHAR, c FLOAT))) v(c) select c.*;
+----
+NULL	asdf	NULL


### PR DESCRIPTION
Selecting all columns from a union using `*` now works because why not:
```SQL
FROM (VALUES('asdf'::UNION(a INTEGER, b VARCHAR, c FLOAT))) v(c) 
SELECT c.*;
```

returns 

|  a   |  b   |  c   |
|------|------|------|
| NULL | asdf | NULL |

Before:

`Binder Error: Cannot extract field from expression "c.*" because it is not a struct`