### PR TITLE
Annotate errors in table macros with the call position of the table macro

### DIFF
--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -283,7 +283,14 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 		binder->can_contain_nulls = true;
 
 		binder->alias = ref.alias.empty() ? "unnamed_query" : ref.alias;
-		auto query = binder->BindNode(*query_node);
+		unique_ptr<BoundQueryNode> query;
+		try {
+			query = binder->BindNode(*query_node);
+		} catch (std::exception &ex) {
+			ErrorData error(ex);
+			error.AddQueryLocation(ref);
+			error.Throw();
+		}
 
 		idx_t bind_index = query->GetRootIndex();
 		// string alias;

--- a/test/sql/error/error_position.test
+++ b/test/sql/error/error_position.test
@@ -1,0 +1,15 @@
+# name: test/sql/error/error_position.test
+# description: Test error position
+# group: [error]
+
+# error within table macro
+statement ok
+create macro checksum(x) as table SELECT bit_xor(md5_number(CAST(COLUMNS(*) AS VARCHAR))) FROM query_table(table_name);
+
+statement ok
+set errors_as_json=true;
+
+statement error
+select * from checksum('tbl');
+----
+<REGEX>:.*"position".*:.*"14".*


### PR DESCRIPTION
This now correctly points at the call of the table macro as the source of the error, instead of a location within the table macro (which does not make sense in the query that is actually being run).

Example:
```sql
D create macro count_tbl(x) as table SELECT COUNT(*) FROM query_table(table_name);
D select * from count_tbl('tbl');
```
```
Catalog Error:
Table with name table_name does not exist!
Did you mean "pg_tablespace"?

LINE 1: select * from count_tbl('tbl');
                      ^

```