### PR TITLE
Parallel `union_by_name` for `read_json`

### DIFF
--- a/extension/json/include/json_scan.hpp
+++ b/extension/json/include/json_scan.hpp
@@ -82,25 +82,43 @@ public:
 		return candidate_formats.find(type) != candidate_formats.end();
 	}
 
-	vector<StrpTimeFormat> &GetCandidateFormats(LogicalTypeId type) {
-		D_ASSERT(HasFormats(type));
-		return candidate_formats[type];
+	idx_t NumberOfFormats(LogicalTypeId type) {
+		lock_guard<mutex> guard(lock);
+		return candidate_formats[type].size();
+	}
+
+	bool GetFormatAtIndex(LogicalTypeId type, idx_t index, StrpTimeFormat &format) {
+		lock_guard<mutex> guard(lock);
+		auto &formats = candidate_formats[type];
+		if (index >= formats.size()) {
+			return false;
+		}
+		format = formats[index];
+		return true;
+	}
+
+	void ShrinkFormatsToSize(LogicalTypeId type, idx_t size) {
+		lock_guard<mutex> guard(lock);
+		auto &formats = candidate_formats[type];
+		while (formats.size() > size) {
+			formats.pop_back();
+		}
 	}
 
 	StrpTimeFormat &GetFormat(LogicalTypeId type) {
+		lock_guard<mutex> guard(lock);
 		D_ASSERT(candidate_formats.find(type) != candidate_formats.end());
 		return candidate_formats.find(type)->second.back();
 	}
 
 	const StrpTimeFormat &GetFormat(LogicalTypeId type) const {
+		lock_guard<mutex> guard(lock);
 		D_ASSERT(candidate_formats.find(type) != candidate_formats.end());
 		return candidate_formats.find(type)->second.back();
 	}
 
-public:
-	mutable mutex lock;
-
 private:
+	mutable mutex lock;
 	type_id_map_t<vector<StrpTimeFormat>> candidate_formats;
 };
 

--- a/extension/json/include/json_structure.hpp
+++ b/extension/json/include/json_structure.hpp
@@ -45,7 +45,7 @@ private:
 	                                DateFormatMap &date_format_map);
 	void EliminateCandidateTypes(idx_t vec_count, Vector &string_vector, DateFormatMap &date_format_map);
 	bool EliminateCandidateFormats(idx_t vec_count, Vector &string_vector, const Vector &result_vector,
-	                               vector<StrpTimeFormat> &formats);
+	                               DateFormatMap &date_format_map);
 
 public:
 	unique_ptr<string> key;
@@ -84,6 +84,7 @@ public:
 struct JSONStructure {
 public:
 	static void ExtractStructure(yyjson_val *val, JSONStructureNode &node, bool ignore_errors);
+	static void MergeNodes(JSONStructureNode &merged, const JSONStructureNode &node);
 	static LogicalType StructureToType(ClientContext &context, const JSONStructureNode &node, idx_t max_depth,
 	                                   double field_appearance_threshold, idx_t map_inference_threshold,
 	                                   idx_t depth = 0, const LogicalType &null_type = LogicalType::JSON());

--- a/extension/json/json_functions/json_structure.cpp
+++ b/extension/json/json_functions/json_structure.cpp
@@ -261,8 +261,7 @@ void JSONStructureNode::EliminateCandidateTypes(const idx_t vec_count, Vector &s
 		const auto type = candidate_types.back();
 		Vector result_vector(type, vec_count);
 		if (date_format_map.HasFormats(type)) {
-			auto &formats = date_format_map.GetCandidateFormats(type);
-			if (EliminateCandidateFormats(vec_count, string_vector, result_vector, formats)) {
+			if (EliminateCandidateFormats(vec_count, string_vector, result_vector, date_format_map)) {
 				return;
 			} else {
 				candidate_types.pop_back();
@@ -304,12 +303,27 @@ bool TryParse(Vector &string_vector, StrpTimeFormat &format, const idx_t count) 
 }
 
 bool JSONStructureNode::EliminateCandidateFormats(const idx_t vec_count, Vector &string_vector,
-                                                  const Vector &result_vector, vector<StrpTimeFormat> &formats) {
+                                                  const Vector &result_vector, DateFormatMap &date_format_map) {
 	D_ASSERT(descriptions.size() == 1 && descriptions[0].type == LogicalTypeId::VARCHAR);
+
 	const auto type = result_vector.GetType().id();
-	for (idx_t i = formats.size(); i != 0; i--) {
-		const idx_t actual_index = i - 1;
-		auto &format = formats[actual_index];
+	auto &formats = date_format_map.GetCandidateFormats(type);
+	idx_t i;
+	{
+		lock_guard<mutex> guard(date_format_map.lock);
+		i = formats.size();
+	}
+
+	for (; i != 0; i--) {
+		StrpTimeFormat format;
+		{
+			lock_guard<mutex> guard(date_format_map.lock);
+			if (i > formats.size()) {
+				continue;
+			}
+			format = formats[i - 1];
+		}
+
 		bool success;
 		switch (type) {
 		case LogicalTypeId::DATE:
@@ -321,13 +335,16 @@ bool JSONStructureNode::EliminateCandidateFormats(const idx_t vec_count, Vector 
 		default:
 			throw InternalException("No date/timestamp formats for %s", EnumUtil::ToString(type));
 		}
+
 		if (success) {
+			lock_guard<mutex> guard(date_format_map.lock);
 			while (formats.size() > i) {
 				formats.pop_back();
 			}
 			return true;
 		}
 	}
+
 	return false;
 }
 
@@ -531,14 +548,12 @@ static LogicalType StructureToTypeArray(ClientContext &context, const JSONStruct
 	                                                        depth + 1, null_type));
 }
 
-static void MergeNodes(JSONStructureNode &merged, const JSONStructureNode &node);
-
 static void MergeNodeArray(JSONStructureNode &merged, const JSONStructureDescription &child_desc) {
 	D_ASSERT(child_desc.type == LogicalTypeId::LIST);
 	auto &merged_desc = merged.GetOrCreateDescription(LogicalTypeId::LIST);
 	auto &merged_child = merged_desc.GetOrCreateChild();
 	for (auto &list_child : child_desc.children) {
-		MergeNodes(merged_child, list_child);
+		JSONStructure::MergeNodes(merged_child, list_child);
 	}
 }
 
@@ -548,7 +563,7 @@ static void MergeNodeObject(JSONStructureNode &merged, const JSONStructureDescri
 	for (auto &struct_child : child_desc.children) {
 		const auto &struct_child_key = *struct_child.key;
 		auto &merged_child = merged_desc.GetOrCreateChild(struct_child_key.c_str(), struct_child_key.length());
-		MergeNodes(merged_child, struct_child);
+		JSONStructure::MergeNodes(merged_child, struct_child);
 	}
 }
 
@@ -570,7 +585,7 @@ static void MergeNodeVal(JSONStructureNode &merged, const JSONStructureDescripti
 	merged.initialized = true;
 }
 
-static void MergeNodes(JSONStructureNode &merged, const JSONStructureNode &node) {
+void JSONStructure::MergeNodes(JSONStructureNode &merged, const JSONStructureNode &node) {
 	merged.count += node.count;
 	merged.null_count += node.null_count;
 	for (const auto &child_desc : node.descriptions) {
@@ -695,7 +710,7 @@ static LogicalType GetMergedType(ClientContext &context, const JSONStructureNode
 	auto &desc = node.descriptions[0];
 	JSONStructureNode merged;
 	for (const auto &child : desc.children) {
-		MergeNodes(merged, child);
+		JSONStructure::MergeNodes(merged, child);
 	}
 	return JSONStructure::StructureToType(context, merged, max_depth, field_appearance_threshold,
 	                                      map_inference_threshold, depth + 1, null_type);

--- a/extension/json/json_functions/read_json.cpp
+++ b/extension/json/json_functions/read_json.cpp
@@ -4,6 +4,7 @@
 #include "json_scan.hpp"
 #include "json_structure.hpp"
 #include "json_transform.hpp"
+#include "duckdb/parallel/task_executor.hpp"
 
 namespace duckdb {
 
@@ -36,20 +37,18 @@ static inline LogicalType RemoveDuplicateStructKeys(const LogicalType &type, con
 	}
 }
 
-void JSONScan::AutoDetect(ClientContext &context, JSONScanData &bind_data, vector<LogicalType> &return_types,
-                          vector<string> &names) {
-	// Change scan type during detection
-	bind_data.type = JSONScanType::SAMPLE;
+class JSONSchemaTask : public BaseExecutorTask {
+public:
+	JSONSchemaTask(TaskExecutor &executor, ClientContext &context_p, JSONScanData &bind_data_p,
+	               JSONStructureNode &node_p, const idx_t file_idx_start_p, const idx_t file_idx_end_p)
+	    : BaseExecutorTask(executor), context(context_p), bind_data(bind_data_p), node(node_p),
+	      file_idx_start(file_idx_start_p), file_idx_end(file_idx_end_p), allocator(BufferAllocator::Get(context)),
+	      string_vector(LogicalType::VARCHAR) {
+	}
 
-	// These are used across files (if union_by_name)
-	JSONStructureNode node;
-	ArenaAllocator allocator(BufferAllocator::Get(context));
-	Vector string_vector(LogicalType::VARCHAR);
-
-	// Loop through the files (if union_by_name, else sample up to sample_size rows or maximum_sample_files files)
-	idx_t remaining = bind_data.sample_size;
-	for (idx_t file_idx = 0; file_idx < bind_data.files.size(); file_idx++) {
-		// Create global/local state and place the reader in the right field
+	static idx_t ExecuteInternal(ClientContext &context, JSONScanData &bind_data, JSONStructureNode &node,
+	                             const idx_t file_idx, ArenaAllocator &allocator, Vector &string_vector,
+	                             idx_t remaining) {
 		JSONScanGlobalState gstate(context, bind_data);
 		JSONScanLocalState lstate(context, gstate);
 		if (file_idx == 0) {
@@ -61,12 +60,12 @@ void JSONScan::AutoDetect(ClientContext &context, JSONScanData &bind_data, vecto
 		// Read and detect schema
 		while (remaining != 0) {
 			allocator.Reset();
-			auto read_count = lstate.ReadNext(gstate);
+			const auto read_count = lstate.ReadNext(gstate);
 			if (read_count == 0) {
 				break;
 			}
 
-			idx_t next = MinValue<idx_t>(read_count, remaining);
+			const auto next = MinValue<idx_t>(read_count, remaining);
 			for (idx_t i = 0; i < next; i++) {
 				const auto &val = lstate.values[i];
 				if (val) {
@@ -85,13 +84,62 @@ void JSONScan::AutoDetect(ClientContext &context, JSONScanData &bind_data, vecto
 			bind_data.avg_tuple_size = lstate.total_read_size / lstate.total_tuple_count;
 		}
 
-		// Close the file and stop detection if not union_by_name
-		if (bind_data.options.file_options.union_by_name) {
-			// When union_by_name=true we sample sample_size per file
-			remaining = bind_data.sample_size;
-		} else if (remaining == 0 || file_idx == bind_data.maximum_sample_files - 1) {
-			// When union_by_name=false, we sample sample_size in total (across the first maximum_sample_files files)
-			break;
+		return remaining;
+	}
+
+	void ExecuteTask() override {
+		for (idx_t file_idx = file_idx_start; file_idx < file_idx_end; file_idx++) {
+			ExecuteInternal(context, bind_data, node, file_idx, allocator, string_vector, bind_data.sample_size);
+		}
+	}
+
+private:
+	ClientContext &context;
+	JSONScanData &bind_data;
+	JSONStructureNode &node;
+	const idx_t file_idx_start;
+	const idx_t file_idx_end;
+
+	ArenaAllocator allocator;
+	Vector string_vector;
+};
+
+void JSONScan::AutoDetect(ClientContext &context, JSONScanData &bind_data, vector<LogicalType> &return_types,
+                          vector<string> &names) {
+	// Change scan type during detection
+	bind_data.type = JSONScanType::SAMPLE;
+
+	JSONStructureNode node;
+	if (bind_data.options.file_options.union_by_name) {
+		const auto num_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+		const auto files_per_task = (bind_data.files.size() + num_threads - 1) / num_threads;
+		const auto num_tasks = bind_data.files.size() / files_per_task;
+		vector<JSONStructureNode> task_nodes(num_tasks);
+
+		// Same idea as in union_by_name.hpp
+		TaskExecutor executor(context);
+		for (idx_t task_idx = 0; task_idx < num_tasks; task_idx++) {
+			const auto file_idx_start = task_idx * files_per_task;
+			auto task = make_uniq<JSONSchemaTask>(executor, context, bind_data, task_nodes[task_idx], file_idx_start,
+			                                      file_idx_start + files_per_task);
+			executor.ScheduleTask(std::move(task));
+		}
+		executor.WorkOnTasks();
+
+		// Merge task nodes into one
+		for (auto &task_node : task_nodes) {
+			JSONStructure::MergeNodes(node, task_node);
+		}
+	} else {
+		ArenaAllocator allocator(BufferAllocator::Get(context));
+		Vector string_vector(LogicalType::VARCHAR);
+		idx_t remaining = bind_data.sample_size;
+		for (idx_t file_idx = 0; file_idx < bind_data.files.size(); file_idx++) {
+			remaining = JSONSchemaTask::ExecuteInternal(context, bind_data, node, file_idx, allocator, string_vector,
+			                                            remaining);
+			if (remaining == 0 || file_idx == bind_data.maximum_sample_files - 1) {
+				break; // We sample sample_size in total (across the first maximum_sample_files files)
+			}
 		}
 	}
 

--- a/extension/json/json_scan.cpp
+++ b/extension/json/json_scan.cpp
@@ -249,7 +249,7 @@ unique_ptr<LocalTableFunctionState> JSONLocalTableFunctionState::Init(ExecutionC
 	auto result = make_uniq<JSONLocalTableFunctionState>(context.client, gstate.state);
 
 	// Copy the transform options / date format map because we need to do thread-local stuff
-	result->state.date_format_map = gstate.state.bind_data.date_format_map;
+	result->state.date_format_map = gstate.state.bind_data.date_format_map.Copy();
 	result->state.transform_options = gstate.state.transform_options;
 	result->state.transform_options.date_format_map = &result->state.date_format_map;
 


### PR DESCRIPTION
This PR implements parallel `union_by_name` for `read_json`, similar to how it is implemented for CSV/Parquet. The code paths for CSV/Parquet are unified but do not support nested type unification, which is crucial for JSON. Hence, JSON follows a different code path and is not automatically parallelized.

I've put the schema detection in a `Task` and made each thread create one `JSONStructureNode` to be merged later (using existing code!). So this is mostly shuffling code around. The only annoying thing is that the `DateFormatMap` is shared over the threads, so I had to add a lock for now. In the future, I want to have this be thread-local and have one per column rather than a single global one, but this seems like the best option for now.

Speedup is similar to CSV/Parquet. I have a local directory of ~14k nested JSON files and the following query:
```sql
DESCRIBE FROM read_json('*.json', union_by_name=true);
```
Went down from ~2.7s to ~0.5s.