### PR TITLE
[Dev] Fix an unnecessary copy in Dictionary compression

### DIFF
--- a/src/include/duckdb/storage/compression/dictionary/compression.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/compression.hpp
@@ -47,7 +47,6 @@ public:
 	data_ptr_t current_end_ptr;
 
 	// Buffers and map for current segment
-	StringHeap heap;
 	string_map_t<uint32_t> current_string_map;
 	vector<uint32_t> index_buffer;
 	vector<uint32_t> selection_buffer;


### PR DESCRIPTION
There is no need to copy the strings to a separate heap.
We already copy the string to the dictionary in the segment, the map is only ever referenced while the segment is alive, so we can safely reference data from this.