### PR TITLE
csv_scanner: fix order of evaluation of arguments to a function

### DIFF
--- a/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
+++ b/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
@@ -28,7 +28,8 @@ CSVGlobalState::CSVGlobalState(ClientContext &context_p, const shared_ptr<CSVBuf
 	}
 	idx_t cur_file_idx = 0;
 	while (file_scans.back()->start_iterator.done && file_scans.size() < files.size()) {
-		file_scans.emplace_back(make_uniq<CSVFileScan>(context, files[++cur_file_idx], options, cur_file_idx, bind_data,
+		cur_file_idx++;
+		file_scans.emplace_back(make_uniq<CSVFileScan>(context, files[cur_file_idx], options, cur_file_idx, bind_data,
 		                                               column_ids, file_schema, false));
 	}
 	// There are situations where we only support single threaded scanning


### PR DESCRIPTION
Replaced computing of the variable "cur_file_idx". The order of evaluation of arguments to a function is unspecified(ISO IEC 14882-2011:1.9.3)  
Found by Postgres Pro
Fixes: fd25f07e3b ("more small fix and test adjustment")