### PR TITLE
window: fix nullptr dereference

### DIFF
--- a/src/function/window/window_index_tree.cpp
+++ b/src/function/window/window_index_tree.cpp
@@ -56,7 +56,7 @@ idx_t WindowIndexTree::SelectNth(const SubFrames &frames, idx_t n) const {
 	if (mst32) {
 		return mst32->NthElement(mst32->SelectNth(frames, n));
 	} else {
-		return mst64->NthElement(mst32->SelectNth(frames, n));
+		return mst64->NthElement(mst64->SelectNth(frames, n));
 	}
 }
 


### PR DESCRIPTION
The bad copy-paste was the cause of a potential nullptr dereference.  
Found by Postgres Pro
Fixes: b13607625b ("Feature #12699: Window Secondary Sorts")
Signed-off-by: Maksim Korotkov <m.korotkov@postgrespro.ru>