### PR TITLE
Added `weighted_avg` function using macro

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -110,6 +110,9 @@ static const DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "geomean", {"x", nullptr}, {{nullptr, nullptr}}, "exp(avg(ln(x)))"},
 	{DEFAULT_SCHEMA, "geometric_mean", {"x", nullptr}, {{nullptr, nullptr}}, "geomean(x)"},
 
+	{DEFAULT_SCHEMA, "weighted_avg", {"value", "weight", nullptr}, {{nullptr, nullptr}}, "SUM(value * weight) / SUM(weight)"},
+	{DEFAULT_SCHEMA, "wavg", {"value", "weight", nullptr}, {{nullptr, nullptr}}, "weighted_avg(value, weight)"},
+
     {DEFAULT_SCHEMA, "list_reverse", {"l", nullptr}, {{nullptr, nullptr}}, "l[:-:-1]"},
     {DEFAULT_SCHEMA, "array_reverse", {"l", nullptr}, {{nullptr, nullptr}}, "list_reverse(l)"},
 

--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -110,7 +110,7 @@ static const DefaultMacro internal_macros[] = {
 	{DEFAULT_SCHEMA, "geomean", {"x", nullptr}, {{nullptr, nullptr}}, "exp(avg(ln(x)))"},
 	{DEFAULT_SCHEMA, "geometric_mean", {"x", nullptr}, {{nullptr, nullptr}}, "geomean(x)"},
 
-	{DEFAULT_SCHEMA, "weighted_avg", {"value", "weight", nullptr}, {{nullptr, nullptr}}, "SUM(value * weight) / SUM(weight)"},
+	{DEFAULT_SCHEMA, "weighted_avg", {"value", "weight", nullptr}, {{nullptr, nullptr}}, "SUM(value * weight) / SUM(CASE WHEN value IS NOT NULL THEN weight ELSE 0 END)"},
 	{DEFAULT_SCHEMA, "wavg", {"value", "weight", nullptr}, {{nullptr, nullptr}}, "weighted_avg(value, weight)"},
 
     {DEFAULT_SCHEMA, "list_reverse", {"l", nullptr}, {{nullptr, nullptr}}, "l[:-:-1]"},

--- a/test/sql/aggregate/aggregates/test_weighted_avg.test
+++ b/test/sql/aggregate/aggregates/test_weighted_avg.test
@@ -20,6 +20,12 @@ nan
 0.0
 0.0
 
+# test alias 'wavg'
+query R
+SELECT wavg(3, 3)
+----
+3
+
 # test weighted average on real world example
 statement ok
 CREATE TABLE students(name TEXT, grade INTEGER, etcs INTEGER);

--- a/test/sql/aggregate/aggregates/test_weighted_avg.test
+++ b/test/sql/aggregate/aggregates/test_weighted_avg.test
@@ -1,0 +1,46 @@
+# name: test/sql/aggregate/aggregates/test_weighted_avg.test
+# description: Test weighted_avg operator
+# group: [aggregates]
+
+# scalar weighted average with NULLs
+query RRRR
+SELECT weighted_avg(3, 3), weighted_avg(3, NULL), weighted_avg(NULL, 3), weighted_avg(NULL, NULL)
+----
+3
+NULL
+NULL
+NULL
+
+# scalar weighted with zero weight will result in nan
+query RRRR
+SELECT weighted_avg(3, 0), weighted_avg(3, 0.0), weighted_avg(0, 3), weighted_avg(0.0, 3)
+----
+nan
+nan
+0.0
+0.0
+
+# test weighted average on real world example
+statement ok
+CREATE TABLE students(name TEXT, grade INTEGER, etcs INTEGER);
+
+statement ok
+INSERT INTO students VALUES ('Alice', 8, 6), ('Alice', 6, 2), ('Bob', 6, 3), ('Bob', 8, 3), ('Bob', 6, 6);
+
+# Alice: (8*6 + 6*2) / (6 + 2) = 60 / 8 = 7.5
+# Bob: (6*3 + 8*3 + 6*6) / (3 + 3 + 6) = (18 + 24 + 36) / 12 = 78 / 12 = 6.5
+query II
+SELECT name, weighted_avg(grade, etcs) FROM students GROUP BY name ORDER BY name
+----
+Alice	7.5
+Bob		6.5
+
+# adding a entry with weight 0 should not change the result
+statement ok
+INSERT INTO students VALUES ('Alice', 42, 0);
+
+query II
+SELECT name, weighted_avg(grade, etcs) FROM students GROUP BY name ORDER BY name
+----
+Alice	7.5
+Bob		6.5

--- a/test/sql/aggregate/aggregates/test_weighted_avg.test
+++ b/test/sql/aggregate/aggregates/test_weighted_avg.test
@@ -50,3 +50,23 @@ SELECT name, weighted_avg(grade, etcs) FROM students GROUP BY name ORDER BY name
 ----
 Alice	7.5
 Bob		6.5
+
+# weighted_avg skips rows were the weight is NULL, so adding a row with NULL weight should not change the result
+statement ok
+INSERT INTO students VALUES ('Alice', 42, NULL);
+
+query II
+SELECT name, weighted_avg(grade, etcs) FROM students GROUP BY name ORDER BY name
+----
+Alice	7.5
+Bob		6.5
+
+# weighted_avg skips rows were the value is NULL, so adding a row with NULL value should not change the result
+statement ok
+INSERT INTO students VALUES ('Alice', NULL, 42);
+
+query II
+SELECT name, weighted_avg(grade, etcs) FROM students GROUP BY name ORDER BY name
+----
+Alice	7.5
+Bob		6.5


### PR DESCRIPTION
Hi dear DuckDB team,

I wanted to suggest adding a `weighted_avg(value, weight)` function to the default functions via a macro. I searched through the duckdb documentation and code but could not find such a function, but maybe I was looking for the wrong name/place.

Example Usecase: 
```sql
CREATE TABLE students(name TEXT, grade INTEGER, etcs INTEGER);
INSERT INTO students VALUES ('Alice', 8, 6), ('Alice', 6, 2), ('Bob', 6, 3), ('Bob', 8, 3), ('Bob', 6, 6);

SELECT name, weighted_avg(grade, etcs) as final_grade FROM students GROUP BY name ORDER BY name;
┌─────────┬─────────────┐
│  name   │ final_grade │
│ varchar │   double    │
├─────────┼─────────────┤
│ Alice   │         7.5 │
│ Bob     │         6.5 │
└─────────┴─────────────┘
```
I added also the shorter alias `wavg(value, weight)` using a macro.

Let me know if you find this a useful addition and if yes whether you have change requests.




