### PR TITLE
[Julia] Add support for named params in prepared statements

### DIFF
--- a/tools/juliapkg/src/statement.jl
+++ b/tools/juliapkg/src/statement.jl
@@ -82,7 +82,7 @@ function bind_parameters(stmt::Stmt, params::DBInterface.PositionalStatementPara
     end
 end
 
-function bind_parameters(stmt::Stmt, params::DBInterface.NamedStatementParams)    
+function bind_parameters(stmt::Stmt, params::DBInterface.NamedStatementParams)
     N = nparameters(stmt)
     K = keytype(params)
     for i in 1:N
@@ -104,4 +104,3 @@ function bind_parameters(stmt::Stmt, params::DBInterface.NamedStatementParams)
         end
     end
 end
-

--- a/tools/juliapkg/src/statement.jl
+++ b/tools/juliapkg/src/statement.jl
@@ -37,6 +37,12 @@ end
 
 DBInterface.getconnection(stmt::Stmt) = stmt.con
 
+
+function nparameters(stmt::Stmt)
+    return Int(duckdb_nparams(stmt.handle))
+end
+
+
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::AbstractFloat) = duckdb_bind_double(stmt.handle, i, Float64(val));
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::Bool) = duckdb_bind_boolean(stmt.handle, i, val);
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::Int8) = duckdb_bind_int8(stmt.handle, i, val);
@@ -66,7 +72,7 @@ function duckdb_bind_internal(stmt::Stmt, i::Integer, val::Any)
     throw(NotImplementedException("unsupported type for bind"))
 end
 
-function bind_parameters(stmt::Stmt, params::DBInterface.StatementParams)
+function bind_parameters(stmt::Stmt, params::DBInterface.PositionalStatementParams)
     i = 1
     for param in params
         if duckdb_bind_internal(stmt, i, param) != DuckDBSuccess
@@ -75,3 +81,27 @@ function bind_parameters(stmt::Stmt, params::DBInterface.StatementParams)
         i += 1
     end
 end
+
+function bind_parameters(stmt::Stmt, params::DBInterface.NamedStatementParams)    
+    N = nparameters(stmt)
+    K = keytype(params)
+    for i in 1:N
+        name_ptr = duckdb_parameter_name(stmt.handle, i)
+        name = unsafe_string(name_ptr)
+        duckdb_free(name_ptr)
+        name_key = K(name)
+        if !haskey(params, name_key)
+            if isa(params, NamedTuple)
+                value = params[i] # FIXME this is a workaround to keep the interface consistent, see the test in test_sqlite.jl
+            else
+                throw(QueryException("Parameter '$name' not found"))
+            end
+        else
+            value = getindex(params, name_key)
+        end
+        if duckdb_bind_internal(stmt, i, value) != DuckDBSuccess
+            throw(QueryException("Failed to bind parameter '$name'"))
+        end
+    end
+end
+

--- a/tools/juliapkg/src/statement.jl
+++ b/tools/juliapkg/src/statement.jl
@@ -84,7 +84,10 @@ end
 
 function bind_parameters(stmt::Stmt, params::DBInterface.NamedStatementParams)
     N = nparameters(stmt)
-    K = keytype(params)
+    if length(params) == 0
+        return # no parameters to bind
+    end
+    K = eltype(keys(params))
     for i in 1:N
         name_ptr = duckdb_parameter_name(stmt.handle, i)
         name = unsafe_string(name_ptr)

--- a/tools/juliapkg/test/test_prepare.jl
+++ b/tools/juliapkg/test/test_prepare.jl
@@ -89,7 +89,7 @@ end
     DBInterface.close!(con)
 end
 
-@testset "Named parameters" begin
+@testset "prepare: Named parameters" begin
     con = DBInterface.connect(DuckDB.DB)
     DBInterface.execute(con, "CREATE TABLE test_table(i INTEGER, j DOUBLE)")
     stmt = DBInterface.prepare(con, raw"INSERT INTO test_table VALUES($col1, $col2)")

--- a/tools/juliapkg/test/test_prepare.jl
+++ b/tools/juliapkg/test/test_prepare.jl
@@ -92,10 +92,21 @@ end
 @testset "prepare: Named parameters" begin
     con = DBInterface.connect(DuckDB.DB)
     DBInterface.execute(con, "CREATE TABLE test_table(i INTEGER, j DOUBLE)")
+
+    # Check named syntax with Kwargs and Dict
     stmt = DBInterface.prepare(con, raw"INSERT INTO test_table VALUES($col1, $col2)")
     DBInterface.execute(stmt, Dict(["col1" => 1, "col2" => 3.5]))
     DBInterface.execute(stmt; col1 = 2, col2 = 4.5)
+    results = DBInterface.execute(con, "SELECT * FROM test_table") |> DataFrame
+    @test isequal(results.i, [1, 2])
+    @test isequal(results.j, [3.5, 4.5])
 
+
+    # Check positional syntax
+    DBInterface.execute(con, "TRUNCATE TABLE test_table")
+    stmt = DBInterface.prepare(con, raw"INSERT INTO test_table VALUES($2, $1)")
+    DBInterface.execute(stmt, (3.5, 1))
+    DBInterface.execute(stmt, (4.5, 2))
     results = DBInterface.execute(con, "SELECT * FROM test_table") |> DataFrame
     @test isequal(results.i, [1, 2])
     @test isequal(results.j, [3.5, 4.5])

--- a/tools/juliapkg/test/test_prepare.jl
+++ b/tools/juliapkg/test/test_prepare.jl
@@ -89,6 +89,38 @@ end
     DBInterface.close!(con)
 end
 
+@testset "Named parameters" begin
+    con = DBInterface.connect(DuckDB.DB)
+    DBInterface.execute(con, "CREATE TABLE test_table(i INTEGER, j DOUBLE)")
+    stmt = DBInterface.prepare(con, raw"INSERT INTO test_table VALUES($col1, $col2)")
+    DBInterface.execute(stmt, Dict(["col1" => 1, "col2" => 3.5]))
+    DBInterface.execute(stmt; col1 = 2, col2 = 4.5)
+
+    results = DBInterface.execute(con, "SELECT * FROM test_table") |> DataFrame
+    @test isequal(results.i, [1, 2])
+    @test isequal(results.j, [3.5, 4.5])
+
+    DBInterface.close!(con)
+end
+
+@testset "DBInterface.prepare: execute many" begin
+    con = DBInterface.connect(DuckDB.DB)
+
+    DBInterface.execute(con, "CREATE TABLE test_table(i INTEGER, j DOUBLE)")
+    @test_throws DuckDB.QueryException DBInterface.prepare(con, "INSERT INTO test_table VALUES(:col1, :col2)")
+    stmt = DBInterface.prepare(con, raw"INSERT INTO test_table VALUES($col1, $col2)")
+    col1 = [1, 2, 3, 4, 5]
+    col2 = [1, 2, 4, 8, -0.5]
+    DBInterface.executemany(stmt, (col1 = col1, col2 = col2))
+    results = DBInterface.execute(con, "SELECT * FROM test_table") |> DataFrame
+
+    @test isequal(results.i, col1)
+    @test isequal(results.j, col2)
+
+    DBInterface.close!(con)
+end
+
+
 @testset "DBInterface.prepare: ambiguous parameters" begin
     con = DBInterface.connect(DuckDB.DB)
 

--- a/tools/juliapkg/test/test_sqlite.jl
+++ b/tools/juliapkg/test/test_sqlite.jl
@@ -171,6 +171,7 @@ end
         DuckDB.drop!(db, "temp")
 
         DBInterface.execute(db, "CREATE TABLE temp AS SELECT * FROM Album")
+        # FIXME Does it make sense to use named parameters here?
         r = DBInterface.execute(db, "SELECT * FROM temp LIMIT ?", (a = 3,)) |> columntable
         @test length(r) == 3 && length(r[1]) == 3
         r = DBInterface.execute(db, "SELECT * FROM temp LIMIT ?", a = 3) |> columntable


### PR DESCRIPTION
This PR adds support prepared statements with named parameters that use the DuckDB dialect:

```sql
-- Named
INSERT INTO test_table VALUES($col1, $col2)
-- Positional 
INSERT INTO test_table VALUES($2, $1)
```

Named parameters with `:col1` are still unsupported.

To stay consistent with the current interface, arguments provided as NamedTuples can be used as positional or named arguments.

```julia
# still works
DBInterface.execute(db, "SELECT * FROM temp LIMIT ?", (a = 3,))
```