### PR TITLE
Issue #15610: Wide Secondary Ordering

### DIFF
--- a/src/function/window/window_index_tree.cpp
+++ b/src/function/window/window_index_tree.cpp
@@ -56,7 +56,7 @@ idx_t WindowIndexTree::SelectNth(const SubFrames &frames, idx_t n) const {
 	if (mst32) {
 		return mst32->NthElement(mst32->SelectNth(frames, n));
 	} else {
-		return mst64->NthElement(mst32->SelectNth(frames, n));
+		return mst64->NthElement(mst64->SelectNth(frames, n));
 	}
 }
 

--- a/src/function/window/window_merge_sort_tree.cpp
+++ b/src/function/window/window_merge_sort_tree.cpp
@@ -11,8 +11,9 @@ WindowMergeSortTree::WindowMergeSortTree(ClientContext &context, const vector<Bo
     : context(context), memory_per_thread(PhysicalOperator::GetMaxThreadMemory(context)), sort_idx(sort_idx),
       build_stage(PartitionSortStage::INIT), tasks_completed(0) {
 	// Sort the unfiltered indices by the orders
+	const auto force_external = ClientConfig::GetConfig(context).force_external;
 	LogicalType index_type;
-	if (count < std::numeric_limits<uint32_t>::max()) {
+	if (count < std::numeric_limits<uint32_t>::max() && !force_external) {
 		index_type = LogicalType::INTEGER;
 		mst32 = make_uniq<MergeSortTree32>();
 	} else {
@@ -40,7 +41,7 @@ WindowMergeSortTree::WindowMergeSortTree(ClientContext &context, const vector<Bo
 	} else {
 		global_sort = make_uniq<GlobalSortState>(buffer_manager, orders, payload_layout);
 	}
-	global_sort->external = ClientConfig::GetConfig(context).force_external;
+	global_sort->external = force_external;
 }
 
 optional_ptr<LocalSortState> WindowMergeSortTree::AddLocalSort() {

--- a/test/sql/window/test_wide_orderby.test
+++ b/test/sql/window/test_wide_orderby.test
@@ -1,0 +1,29 @@
+# name: test/sql/window/test_wide_orderby.test
+# description: Verify 32 and 64 bit tree construction
+# group: [window]
+
+foreach forced false true 
+
+# This forces 64 bit trees when true
+statement ok
+PRAGMA debug_force_external=${forced}
+
+# SelectNth
+statement ok
+SELECT last_value(i ORDER BY i DESC) OVER w AS crash
+FROM range(5_000) tbl(i)
+WINDOW w AS (ORDER BY i ASC)
+
+# Rank
+statement ok
+SELECT rank(ORDER BY i DESC) OVER w AS crash
+FROM range(5_000) tbl(i)
+WINDOW w AS (ORDER BY i ASC)
+
+# Peer End
+statement ok
+SELECT cume_dist(ORDER BY i DESC) OVER w AS crash
+FROM range(5_000) tbl(i)
+WINDOW w AS (ORDER BY i ASC)
+
+endloop


### PR DESCRIPTION
* Use the force_external pragma to force 64 bit merge sort trees
* Add coverage test for the 32/64 bit APIs
* Fix bad pointer in SelectNth

fixes: duckdb/duckdb#15610