### PR TITLE
Fix an if statement that is always True

### DIFF
--- a/scripts/python_helpers.py
+++ b/scripts/python_helpers.py
@@ -17,7 +17,7 @@ def normalize_path(path):
         normed = map(lambda p: normalize(p), path)
         return list(normed)
 
-    if (isinstance, str):
+    if isinstance(path, str):
         return normalize(path)
 
     raise Exception("Can only be called with a str or list argument")


### PR DESCRIPTION
% `python3 -c "print((isinstance, str))"`
```
(<built-in function isinstance>, <class 'str'>)
```
% `python3 -c "print(bool((isinstance, str)))"`
```
True
```
% `ruff check ---select=E9,F63,F7`
```
Error: scripts/python_helpers.py:20:8: F634 If test is a tuple, which is always `True`
```
Current state:
* Always return `normalize(path)`

Proposed state:
* Return `normalize(path)` if `path` is a `str` otherwise raise an `Exception` which should probably be a `TypeError` instead of a generic `Exception`.