### PR TITLE
[Arrow] Fix a bug related to ArrowArray lifetimes in the arrow scan code

### DIFF
--- a/src/function/cast/struct_cast.cpp
+++ b/src/function/cast/struct_cast.cpp
@@ -128,6 +128,7 @@ static bool StructToStructCast(Vector &source, Vector &result, idx_t count, Cast
 	source.Flatten(count);
 	auto &result_validity = FlatVector::Validity(result);
 	result_validity = FlatVector::Validity(source);
+	result.Verify(count);
 	return all_converted;
 }
 

--- a/tools/pythonpkg/src/python_udf.cpp
+++ b/tools/pythonpkg/src/python_udf.cpp
@@ -126,6 +126,7 @@ static void ConvertArrowTableToVector(const py::object &table, Vector &out, Clie
 
 	VectorOperations::Cast(context, result.data[0], out, count);
 	out.Flatten(count);
+	out.Verify(count);
 }
 
 static string NullHandlingError() {


### PR DESCRIPTION
This PR fixes #15626 

When scanning an arrow array containing string data, we do a zero-copy, attaching the lifetime of the ArrowArray that holds the string data to that of the Vector.

Only problem was that it seems that we didn't do this for child vectors, which caused the ArrowArray to die before it should.
This should be fixed by this PR.