### PR TITLE
Extension type modifier followup

### DIFF
--- a/src/catalog/catalog_entry/type_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/type_catalog_entry.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 
 TypeCatalogEntry::TypeCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTypeInfo &info)
     : StandardEntry(CatalogType::TYPE_ENTRY, schema, catalog, info.name), user_type(info.type),
-      bind_modifiers(info.bind_modifiers) {
+      bind_function(info.bind_function) {
 	this->temporary = info.temporary;
 	this->internal = info.internal;
 	this->dependencies = info.dependencies;
@@ -35,7 +35,7 @@ unique_ptr<CreateInfo> TypeCatalogEntry::GetInfo() const {
 	result->dependencies = dependencies;
 	result->comment = comment;
 	result->tags = tags;
-	result->bind_modifiers = bind_modifiers;
+	result->bind_function = bind_function;
 	return std::move(result);
 }
 

--- a/src/common/extra_type_info.cpp
+++ b/src/common/extra_type_info.cpp
@@ -12,46 +12,67 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Extension Type Info
 //===--------------------------------------------------------------------===//
+//
+// Extension type info never take part in equality checks, unless both have the same type.
+//
+bool ExtensionTypeInfo::Equals(optional_ptr<ExtensionTypeInfo> lhs, optional_ptr<ExtensionTypeInfo> rhs) {
+	// Either both are null, or both are the same, so they are equal
+	if (lhs.get() == rhs.get()) {
+		return true;
+	}
+	// If one is null, then we cant compare them
+	if (lhs == nullptr || rhs == nullptr) {
+		return true;
+	}
 
-static bool CompareModifiers(const vector<Value> &left, const vector<Value> &right) {
-	// Check if the common prefix of the properties is the same for both types
-	const auto common_props = MinValue(left.size(), right.size());
-	for (idx_t i = 0; i < common_props; i++) {
-		if (left[i].type() != right[i].type()) {
+	// Both are not null, so we can compare them
+	D_ASSERT(lhs != nullptr && rhs != nullptr);
+
+	// Compare modifiers
+	const auto &lhs_mods = lhs->modifiers;
+	const auto &rhs_mods = rhs->modifiers;
+	const auto common_mods = MinValue(lhs_mods.size(), rhs_mods.size());
+	for (idx_t i = 0; i < common_mods; i++) {
+		// If the types are not strictly equal, they are not equal
+		auto &lhs_val = lhs_mods[i].value;
+		auto &rhs_val = rhs_mods[i].value;
+
+		if (lhs_val.type() != rhs_val.type()) {
 			return false;
 		}
-		// Special case for nulls:
-		// For type modifiers, NULL is equivalent to ANY
-		if (left[i].IsNull() || right[i].IsNull()) {
+
+		// If both are null, its fine
+		if (lhs_val.IsNull() && rhs_val.IsNull()) {
 			continue;
 		}
 
-		if (left[i] != right[i]) {
+		// If one is null, the other must be null too
+		if (lhs_val.IsNull() != rhs_val.IsNull()) {
 			return false;
 		}
-	}
-	return true;
-}
 
-bool ExtensionTypeInfo::Equals(optional_ptr<ExtensionTypeInfo> other_p) const {
-	if (other_p == nullptr) {
-		return false;
-	}
-	if (!CompareModifiers(modifiers, other_p->modifiers)) {
-		return false;
+		if (lhs_val != rhs_val) {
+			return false;
+		}
 	}
 
 	// Properties are optional, so only compare those present in both
-	for (auto &kv : properties) {
-		auto it = other_p->properties.find(kv.first);
-		if (it == other_p->properties.end()) {
+	const auto &lhs_props = lhs->properties;
+	const auto &rhs_props = rhs->properties;
+
+	for (const auto &kv : lhs_props) {
+		auto it = rhs_props.find(kv.first);
+		if (it == rhs_props.end()) {
+			// Continue
 			continue;
 		}
 		if (kv.second != it->second) {
+			// Mismatch!
 			return false;
 		}
 	}
 
+	// All ok!
 	return true;
 }
 
@@ -91,13 +112,16 @@ bool ExtraTypeInfo::Equals(ExtraTypeInfo *other_p) const {
 			if (!alias.empty()) {
 				return false;
 			}
+			if (extension_info) {
+				return false;
+			}
 			//! We only need to compare aliases when both types have them in this case
 			return true;
 		}
 		if (alias != other_p->alias) {
 			return false;
 		}
-		if (extension_info && !extension_info->Equals(other_p->extension_info.get())) {
+		if (!ExtensionTypeInfo::Equals(extension_info, other_p->extension_info)) {
 			return false;
 		}
 		return true;
@@ -111,7 +135,7 @@ bool ExtraTypeInfo::Equals(ExtraTypeInfo *other_p) const {
 	if (alias != other_p->alias) {
 		return false;
 	}
-	if (extension_info && !extension_info->Equals(other_p->extension_info.get())) {
+	if (!ExtensionTypeInfo::Equals(extension_info, other_p->extension_info)) {
 		return false;
 	}
 	return EqualsInternal(other_p);

--- a/src/common/extra_type_info.cpp
+++ b/src/common/extra_type_info.cpp
@@ -12,9 +12,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Extension Type Info
 //===--------------------------------------------------------------------===//
-//
-// Extension type info never take part in equality checks, unless both have the same type.
-//
+
 bool ExtensionTypeInfo::Equals(optional_ptr<ExtensionTypeInfo> lhs, optional_ptr<ExtensionTypeInfo> rhs) {
 	// Either both are null, or both are the same, so they are equal
 	if (lhs.get() == rhs.get()) {

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -365,7 +365,7 @@ bool TypeIsInteger(PhysicalType type) {
 	       type == PhysicalType::UINT128;
 }
 
-static string TypeModifierListToString(const vector<Value> &mod_list) {
+static string TypeModifierListToString(const vector<LogicalTypeModifier> &mod_list) {
 	string result;
 	if (mod_list.empty()) {
 		return result;
@@ -499,7 +499,14 @@ string LogicalType::ToString() const {
 		result += KeywordHelper::WriteOptionallyQuoted(type);
 
 		if (!mods.empty()) {
-			result += TypeModifierListToString(mods);
+			result += "(";
+			for (idx_t i = 0; i < mods.size(); i++) {
+				result += mods[i].ToString();
+				if (i < mods.size() - 1) {
+					result += ", ";
+				}
+			}
+			result += ")";
 		}
 
 		return result;

--- a/src/function/cast/cast_function_set.cpp
+++ b/src/function/cast/cast_function_set.cpp
@@ -150,10 +150,6 @@ public:
 			}
 		}
 
-		auto leq = target_type_entry->first == target;
-		auto req = target == target_type_entry->first;
-		D_ASSERT(leq || req);
-
 		return &target_type_entry->second;
 	}
 

--- a/src/function/cast/cast_function_set.cpp
+++ b/src/function/cast/cast_function_set.cpp
@@ -150,6 +150,10 @@ public:
 			}
 		}
 
+		auto leq = target_type_entry->first == target;
+		auto req = target == target_type_entry->first;
+		D_ASSERT(leq || req);
+
 		return &target_type_entry->second;
 	}
 

--- a/src/include/duckdb/catalog/catalog_entry/type_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/type_catalog_entry.hpp
@@ -27,7 +27,7 @@ public:
 
 	LogicalType user_type;
 
-	bind_type_modifiers_function_t bind_modifiers;
+	bind_logical_type_function_t bind_function;
 
 public:
 	unique_ptr<CreateInfo> GetInfo() const override;

--- a/src/include/duckdb/common/extension_type_info.hpp
+++ b/src/include/duckdb/common/extension_type_info.hpp
@@ -2,18 +2,36 @@
 
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/types/value.hpp"
-#include "duckdb/common/serializer/serializer.hpp"
 
 namespace duckdb {
 
+class Serializer;
+class Deserializer;
+
+struct LogicalTypeModifier {
+public:
+	explicit LogicalTypeModifier(Value value_p) : value(std::move(value_p)) {
+	}
+	string ToString() const {
+		return label.empty() ? value.ToString() : label;
+	}
+
+public:
+	Value value;
+	string label;
+
+	void Serialize(Serializer &serializer) const;
+	static LogicalTypeModifier Deserialize(Deserializer &source);
+};
+
 struct ExtensionTypeInfo {
-	vector<Value> modifiers;
+	vector<LogicalTypeModifier> modifiers;
 	unordered_map<string, Value> properties;
 
 public:
 	void Serialize(Serializer &serializer) const;
 	static unique_ptr<ExtensionTypeInfo> Deserialize(Deserializer &source);
-	bool Equals(optional_ptr<ExtensionTypeInfo> other_p) const;
+	static bool Equals(optional_ptr<ExtensionTypeInfo> rhs, optional_ptr<ExtensionTypeInfo> lhs);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_util.hpp
+++ b/src/include/duckdb/main/extension_util.hpp
@@ -69,7 +69,7 @@ public:
 
 	//! Registers a new type
 	DUCKDB_API static void RegisterType(DatabaseInstance &db, string type_name, LogicalType type,
-	                                    bind_type_modifiers_function_t bind_type_modifiers = nullptr);
+	                                    bind_logical_type_function_t bind_function = nullptr);
 
 	//! Registers a new secret type
 	DUCKDB_API static void RegisterSecretType(DatabaseInstance &db, SecretType secret_type);

--- a/src/include/duckdb/parser/parsed_data/create_type_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_type_info.hpp
@@ -15,18 +15,18 @@
 
 namespace duckdb {
 
-struct BindTypeModifiersInput {
+struct BindLogicalTypeInput {
 	ClientContext &context;
-	const LogicalType &type;
+	const LogicalType &base_type;
 	const vector<Value> &modifiers;
 };
 
 //! The type to bind type modifiers to a type
-typedef LogicalType (*bind_type_modifiers_function_t)(BindTypeModifiersInput &input);
+typedef LogicalType (*bind_logical_type_function_t)(const BindLogicalTypeInput &input);
 
 struct CreateTypeInfo : public CreateInfo {
 	CreateTypeInfo();
-	CreateTypeInfo(string name_p, LogicalType type_p, bind_type_modifiers_function_t bind_modifiers_p = nullptr);
+	CreateTypeInfo(string name_p, LogicalType type_p, bind_logical_type_function_t bind_function_p = nullptr);
 
 	//! Name of the Type
 	string name;
@@ -35,7 +35,7 @@ struct CreateTypeInfo : public CreateInfo {
 	//! Used by create enum from query
 	unique_ptr<SQLStatement> query;
 	//! Bind type modifiers to the type
-	bind_type_modifiers_function_t bind_modifiers;
+	bind_logical_type_function_t bind_function;
 
 public:
 	unique_ptr<CreateInfo> Copy() const override;

--- a/src/include/duckdb/storage/serialization/types.json
+++ b/src/include/duckdb/storage/serialization/types.json
@@ -1,12 +1,30 @@
 [
   {
+    "class": "LogicalTypeModifier",
+    "includes": [ "duckdb/common/extension_type_info.hpp" ],
+    "members": [
+      {
+        "id": 100,
+        "name": "value",
+        "type": "Value"
+      },
+      {
+        "id": 101,
+        "name": "label",
+        "type": "string"
+      }
+    ],
+    "pointer_type": "none",
+    "constructor": ["value"]
+  },
+  {
     "class": "ExtensionTypeInfo",
     "includes": [ "duckdb/common/extension_type_info.hpp" ],
     "members": [
       {
         "id": 100,
         "name": "modifiers",
-        "type": "vector<Value>"
+        "type": "vector<LogicalTypeModifier>"
       },
       {
         "id": 101,

--- a/src/main/extension/extension_util.cpp
+++ b/src/main/extension/extension_util.cpp
@@ -184,7 +184,7 @@ TableFunctionCatalogEntry &ExtensionUtil::GetTableFunction(DatabaseInstance &db,
 }
 
 void ExtensionUtil::RegisterType(DatabaseInstance &db, string type_name, LogicalType type,
-                                 bind_type_modifiers_function_t bind_modifiers) {
+                                 bind_logical_type_function_t bind_modifiers) {
 	D_ASSERT(!type_name.empty());
 	CreateTypeInfo info(std::move(type_name), std::move(type), bind_modifiers);
 	info.temporary = true;

--- a/src/parser/parsed_data/create_type_info.cpp
+++ b/src/parser/parsed_data/create_type_info.cpp
@@ -6,11 +6,11 @@
 
 namespace duckdb {
 
-CreateTypeInfo::CreateTypeInfo() : CreateInfo(CatalogType::TYPE_ENTRY), bind_modifiers(nullptr) {
+CreateTypeInfo::CreateTypeInfo() : CreateInfo(CatalogType::TYPE_ENTRY), bind_function(nullptr) {
 }
-CreateTypeInfo::CreateTypeInfo(string name_p, LogicalType type_p, bind_type_modifiers_function_t bind_modifiers_p)
+CreateTypeInfo::CreateTypeInfo(string name_p, LogicalType type_p, bind_logical_type_function_t bind_function_p)
     : CreateInfo(CatalogType::TYPE_ENTRY), name(std::move(name_p)), type(std::move(type_p)),
-      bind_modifiers(bind_modifiers_p) {
+      bind_function(bind_function_p) {
 }
 
 unique_ptr<CreateInfo> CreateTypeInfo::Copy() const {
@@ -21,7 +21,7 @@ unique_ptr<CreateInfo> CreateTypeInfo::Copy() const {
 	if (query) {
 		result->query = query->Copy();
 	}
-	result->bind_modifiers = bind_modifiers;
+	result->bind_function = bind_function;
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_types.cpp
+++ b/src/storage/serialization/serialize_types.cpp
@@ -122,13 +122,13 @@ shared_ptr<ExtraTypeInfo> DecimalTypeInfo::Deserialize(Deserializer &deserialize
 }
 
 void ExtensionTypeInfo::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<vector<Value>>(100, "modifiers", modifiers);
+	serializer.WritePropertyWithDefault<vector<LogicalTypeModifier>>(100, "modifiers", modifiers);
 	serializer.WritePropertyWithDefault<unordered_map<string, Value>>(101, "properties", properties, unordered_map<string, Value>());
 }
 
 unique_ptr<ExtensionTypeInfo> ExtensionTypeInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<ExtensionTypeInfo>(new ExtensionTypeInfo());
-	deserializer.ReadPropertyWithDefault<vector<Value>>(100, "modifiers", result->modifiers);
+	deserializer.ReadPropertyWithDefault<vector<LogicalTypeModifier>>(100, "modifiers", result->modifiers);
 	deserializer.ReadPropertyWithExplicitDefault<unordered_map<string, Value>>(101, "properties", result->properties, unordered_map<string, Value>());
 	return result;
 }
@@ -153,6 +153,18 @@ shared_ptr<ExtraTypeInfo> ListTypeInfo::Deserialize(Deserializer &deserializer) 
 	auto result = duckdb::shared_ptr<ListTypeInfo>(new ListTypeInfo());
 	deserializer.ReadProperty<LogicalType>(200, "child_type", result->child_type);
 	return std::move(result);
+}
+
+void LogicalTypeModifier::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<Value>(100, "value", value);
+	serializer.WritePropertyWithDefault<string>(101, "label", label);
+}
+
+LogicalTypeModifier LogicalTypeModifier::Deserialize(Deserializer &deserializer) {
+	auto value = deserializer.ReadProperty<Value>(100, "value");
+	LogicalTypeModifier result(value);
+	deserializer.ReadPropertyWithDefault<string>(101, "label", result.label);
+	return result;
 }
 
 void StringTypeInfo::Serialize(Serializer &serializer) const {

--- a/test/extension/test_custom_type_modifier.test_slow
+++ b/test/extension/test_custom_type_modifier.test_slow
@@ -91,7 +91,7 @@ d
 statement error
 CREATE TABLE t3 (i BOUNDED(200, 300));
 ----
-Binder Error: Cannot apply '2' type modifier(s) to type 'BOUNDED' taking at most '1' type modifier(s)
+Binder Error: BOUNDED type must have one modifier
 
 statement ok
 CREATE TYPE user_type AS INTEGER
@@ -105,12 +105,12 @@ Binder Error: Type 'user_type' does not take any type modifiers
 statement error
 SELECT 1::BOUNDED(NULL)
 ----
-Invalid Input Error: BOUNDED type must have a max value
+BOUNDED type modifier must be integer
 
 statement error
 SELECT 1::BOUNDED(900000000000000000)
 ----
-Binder Error: Cannot apply type modifier '900000000000000000' to type 'BOUNDED', expected value of type 'INTEGER'
+BOUNDED type modifier must be integer
 
 
 # MinMax Type
@@ -192,8 +192,7 @@ SELECT parameter_types from duckdb_functions() where function_name = 'bounded_as
 ----
 [BOUNDED(255)]
 
-# BOUNDED's default type modifier values is NULL, but it could theorietically be set to something else
 query I
 SELECT parameter_types from duckdb_functions() where function_name = 'bounded_add';
 ----
-[BOUNDED(NULL), BOUNDED(NULL)]
+[BOUNDED, BOUNDED]

--- a/test/extension/test_custom_type_modifier_cast.test
+++ b/test/extension/test_custom_type_modifier_cast.test
@@ -1,0 +1,18 @@
+# name: test/extension/test_custom_type_modifier_cast.test
+# description: Test custom type level metadata.
+# group: [extension]
+
+require skip_reload
+
+require notmingw
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+LOAD '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
+
+statement error
+SELECT 1::MINMAX(500, 1000);
+----
+Conversion Error: Value 1 is outside of range [500,1000]


### PR DESCRIPTION
This PR is another followup to #15373

It turns out that the equality operation for types with/without type modifiers was not symmetric, which besides being generally confusing, also caused some issues on platforms where e.g. the STL compares e.g. map keys (using ==) with the arguments in different order.

This has now been fixed, but I also did some other simplification/future proofing.

The equality comparison logic for extension type modifiers is now much simpler. Basically, type modifiers do not affect the equality of types unless both types have modifiers, in which case their common sequence are compared in order. In short:

Given a type `T` with some combination of modifiers `A` and `B`

- `T == T(A)`
- `T == T(A, B)`
- `T(A) == T(A, B)`
- `T(A) != T(B)`
- `T(A, B) != T(B)`
- `T(B, A) != T(A, B)`

There is no special wildcard logic for NULLs or whatnot.
Additionally, I've also removed the logic for declaring "default type mods" as it mostly just complicates things. If you want to enable type modifiers for a type you need to provide a `bind_logical_type_function_t` callback when registering the type and implement the logic for attaching the modifiers yourself. Similarly, if you want to enforce the presence/absence or some relation between type modifiers you should implement that logic in the `Bind` callback for the individual scalar/aggregate/table functions where it matters, as trying to generalize this to somehow work declaratively is not really possible with duckdbs existing type infrastructure. 

I've also attempted to "future proof" future changes to type modifiers by wrapping the Value in a new `LogicalTypeModifier` struct, which enables us to add additional fields without breaking serialization. 

With this change I've also added an optional "label" string to the `LogicalTypeModifier` struct, which if present, will be used when printing the type instead of the `ToString` of the actual type modifier value. This provides extension authors some more control over how type mods are presented to users. E.g. you may want to store a really large value, but make sure it's truncated or print some shorthand instead. 
