### PR TITLE
Add basic Python linting to tools/pythonpkg

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -55,7 +55,17 @@ env:
   CIBW_TEST_SKIP: ${{ inputs.skip_tests == 'true' && '*-*' || 'cp37-*' }}
 
 jobs:
-# This is just a sanity check of Python 3.10 running with Arrow
+  lint-python:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.git_ref }}
+    - uses: astral-sh/ruff-action@v3
+      with:
+        src: tools/pythonpkg
+  # This is just a sanity check of Python 3.10 running with Arrow
   linux-python3-10:
     name: Python 3.10 Linux
     runs-on: ubuntu-20.04

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -55,10 +55,10 @@ allowed_difference = 0
 def check_file(path, partial_coverage_dict):
     global any_failed
     global total_difference
-    if not '.cpp' in path and not '.hpp' in path:
+    if '.cpp' not in path and '.hpp' not in path:
         # files are named [path].[ch]pp
         return
-    if not '.html' in path:
+    if '.html' not in path:
         return
     with open(path, 'r') as f:
         text = f.read()

--- a/scripts/create-release-notes.py
+++ b/scripts/create-release-notes.py
@@ -36,7 +36,7 @@ def gh_api(suburl, full_url=''):
     next_link = None
     try:
         resp = urllib.request.urlopen(req)
-        if not resp.getheader("Link") is None:
+        if resp.getheader("Link") is not None:
             link_data = extract(resp.getheader("Link"))
             if "next" in link_data:
                 next_link = link_data["next"]

--- a/scripts/generate_c_api.py
+++ b/scripts/generate_c_api.py
@@ -269,7 +269,7 @@ def create_function_comment(function_obj):
         if 'params' in function_obj:
             for param in function_obj['params']:
                 param_name = param['name']
-                if not 'param_comments' in comment:
+                if 'param_comments' not in comment:
                     if not ALLOW_UNCOMMENTED_PARAMS:
                         print(comment)
                         print(f'\nMissing param comments for function {function_name}')

--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -120,7 +120,7 @@ for hpp_file in hpp_files:
                 else:
                     enum_members.append((key, strings))
 
-            if not file_path in enum_path_set:
+            if file_path not in enum_path_set:
                 enum_path_set.add(file_path)
                 enum_paths.append(file_path)
 

--- a/third_party/brotli/enc/resolve-multi-includes.py
+++ b/third_party/brotli/enc/resolve-multi-includes.py
@@ -18,7 +18,7 @@ for filename in os.listdir('.'):
     for line in file_lines:
         if '#include' in line and '_inc.h' in line:
             match = re.search(r'#include\s+"(.+)".*', line).group(1)
-            include = open(match, 'r').readlines();
+            include = open(match, 'r').readlines()
             out.write(''.join(include))
             continue
         out.write(line)

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -38,3 +38,23 @@ test-command = "python -m pytest {project}/tests/fast --verbose"
 # See https://github.com/duckdblabs/duckdb-internal/issues/1923 for context
 [tool.cibuildwheel.macos]
 before-test = 'python scripts/optional_requirements.py --exclude polars --exclude tensorflow'
+
+[tool.ruff.lint]
+extend-ignore = [
+  "E402",  # module-import-not-at-top-of-file
+  "E711",  # none-comparison
+  "E712",  # true-false-comparison
+  "E721",  # type-comparison
+  "E722",  # bare-except
+  "E731",  # lambda-assignment
+  "E741",  # ambiguous-variable-name
+  "F401",  # unused-import
+  "F402",  # import-shadowed-by-loop-var
+  "F403",  # undefined-local-with-import-star
+  "F405",  # undefined-local-with-import-star-usage
+  "F541",  # f-string-missing-placeholders
+  "F601",  # multi-value-repeated-key-literal
+  "F811",  # redefined-while-unused
+  "F821",  # undefined-name
+  "F841",  # unused-variable
+]

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -53,7 +53,6 @@ extend-ignore = [
   "F403",  # undefined-local-with-import-star
   "F405",  # undefined-local-with-import-star-usage
   "F541",  # f-string-missing-placeholders
-  "F601",  # multi-value-repeated-key-literal
   "F811",  # redefined-while-unused
   "F821",  # undefined-name
   "F841",  # unused-variable


### PR DESCRIPTION
https://docs.astral.sh/ruff is an extremely fast Python linter and code formatter, written in Rust. With [over 800 linting rules](https://docs.astral.sh/ruff/rules), ruff can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [Black](https://github.com/psf/black), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [pyupgrade](https://pypi.org/project/pyupgrade/), [autoflake](https://pypi.org/project/autoflake/), and more, all while executing tens or hundreds of times faster than any individual tool.