### PR TITLE
Initialize random_seed to silence warning on uninitialized variable

### DIFF
--- a/src/common/random_engine.cpp
+++ b/src/common/random_engine.cpp
@@ -20,7 +20,7 @@ struct RandomState {
 RandomEngine::RandomEngine(int64_t seed) : random_state(make_uniq<RandomState>()) {
 	if (seed < 0) {
 #ifdef __linux__
-		idx_t random_seed;
+		idx_t random_seed = 0;
 		auto result = syscall(SYS_getrandom, &random_seed, sizeof(random_seed), 0);
 		if (result == -1) {
 			// Something went wrong with the syscall, we use chrono


### PR DESCRIPTION
Example of failure: https://github.com/duckdb/duckdb/actions/runs/12700951834/job/35404617301

Here detection is likely off (to a degree, given I would expect random not to use the passed in content, but hard to say).
Given it costs nothing it's better to just initialize it.