### PR TITLE
Skip tests, cleaning up known failures in CI

### DIFF
--- a/test/sql/catalog/dependencies/test_concurrent_index_creation.test
+++ b/test/sql/catalog/dependencies/test_concurrent_index_creation.test
@@ -2,6 +2,8 @@
 # description: Test concurrent alter and rename of tables
 # group: [dependencies]
 
+mode skip
+
 require skip_reload
 
 statement ok

--- a/test/sql/copy/csv/14874.test
+++ b/test/sql/copy/csv/14874.test
@@ -2,6 +2,8 @@
 # description: Test for issue #14784
 # group: [csv]
 
+mode skip
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/copy/csv/test_big_line.test_slow
+++ b/test/sql/copy/csv/test_big_line.test_slow
@@ -2,6 +2,8 @@
 # description: Test big lines
 # group: [csv]
 
+mode skip
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/types/nested/array/array_large.test
+++ b/test/sql/types/nested/array/array_large.test
@@ -1,6 +1,8 @@
 # name: test/sql/types/nested/array/array_large.test
 # group: [array]
 
+require ram 8gb
+
 # Test large arrays (> VECTOR_SIZE elements)
 
 statement ok

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -54,6 +54,12 @@ class SQLLogicTestExecutor(SQLLogicRunner):
                 'test/sql/pragma/profiling/test_custom_profiling_rows_scanned.test',  # we perform additional queries that mess with the expected metrics
                 'test/sql/pragma/profiling/test_custom_profiling_disable_metrics.test',  # we perform additional queries that mess with the expected metrics
                 'test/sql/pragma/profiling/test_custom_profiling_result_set_size.test',  # we perform additional queries that mess with the expected metrics
+                'test/sql/pragma/profiling/test_custom_profiling_result_set_size.test',  # we perform additional queries that mess with the expected metrics
+                'test/sql/cte/materialized/materialized_cte_modifiers.test',  # problems connected to auto installing tpcds from remote
+                'test/sql/tpcds/dsdgen_readonly.test',  # problems connected to auto installing tpcds from remote
+                'test/sql/tpcds/tpcds_sf0.test',  # problems connected to auto installing tpcds from remote
+                'test/sql/optimizer/plan/test_filter_pushdown_materialized_cte.test', # probkems connected to auto installing tpcds from remote
+                'test/sql/explain/test_explain_analyze.test',  # unknown problem with changes in API
             ]
         )
         # TODO: get this from the `duckdb` package

--- a/tools/pythonpkg/scripts/sqllogictest_python.py
+++ b/tools/pythonpkg/scripts/sqllogictest_python.py
@@ -58,7 +58,7 @@ class SQLLogicTestExecutor(SQLLogicRunner):
                 'test/sql/cte/materialized/materialized_cte_modifiers.test',  # problems connected to auto installing tpcds from remote
                 'test/sql/tpcds/dsdgen_readonly.test',  # problems connected to auto installing tpcds from remote
                 'test/sql/tpcds/tpcds_sf0.test',  # problems connected to auto installing tpcds from remote
-                'test/sql/optimizer/plan/test_filter_pushdown_materialized_cte.test', # probkems connected to auto installing tpcds from remote
+                'test/sql/optimizer/plan/test_filter_pushdown_materialized_cte.test',  # problems connected to auto installing tpcds from remote
                 'test/sql/explain/test_explain_analyze.test',  # unknown problem with changes in API
             ]
         )


### PR DESCRIPTION
Those are all tracked and investigated on a side.

In some case this is expected, in others test to be re-introduced in relevant PRs.