### PR TITLE
Make MemoryStream non-copyable

### DIFF
--- a/src/common/serializer/memory_stream.cpp
+++ b/src/common/serializer/memory_stream.cpp
@@ -21,6 +21,42 @@ MemoryStream::~MemoryStream() {
 	}
 }
 
+MemoryStream::MemoryStream(MemoryStream &&other) noexcept {
+	// Move the data from the other stream into this stream
+	data = other.data;
+	position = other.position;
+	capacity = other.capacity;
+	owns_data = other.owns_data;
+
+	// Reset the other stream
+	other.data = nullptr;
+	other.position = 0;
+	other.capacity = 0;
+	other.owns_data = false;
+}
+
+MemoryStream &MemoryStream::operator=(MemoryStream &&other) noexcept {
+	if (this != &other) {
+		// Free the current data
+		if (owns_data) {
+			free(data);
+		}
+
+		// Move the data from the other stream into this stream
+		data = other.data;
+		position = other.position;
+		capacity = other.capacity;
+		owns_data = other.owns_data;
+
+		// Reset the other stream
+		other.data = nullptr;
+		other.position = 0;
+		other.capacity = 0;
+		other.owns_data = false;
+	}
+	return *this;
+}
+
 void MemoryStream::WriteData(const_data_ptr_t source, idx_t write_size) {
 	while (position + write_size > capacity) {
 		if (owns_data) {

--- a/src/include/duckdb/common/serializer/memory_stream.hpp
+++ b/src/include/duckdb/common/serializer/memory_stream.hpp
@@ -33,6 +33,13 @@ public:
 	// is destroyed
 	explicit MemoryStream(data_ptr_t buffer, idx_t capacity);
 
+	// Cant copy!
+	MemoryStream(const MemoryStream &) = delete;
+	MemoryStream &operator=(const MemoryStream &) = delete;
+
+	MemoryStream(MemoryStream &&other) noexcept;
+	MemoryStream &operator=(MemoryStream &&other) noexcept;
+
 	~MemoryStream() override;
 
 	// Write data to the stream.


### PR DESCRIPTION
Also adds an explicit move constructor.

Doesn't solve any issue in particular but the lack of rule-of-5 could potentially be dangerous in the future. 