### PR TITLE
Fix Python dictionary key is repeated

### DIFF
--- a/scripts/sqllogictest/parser/parser.py
+++ b/scripts/sqllogictest/parser/parser.py
@@ -99,7 +99,6 @@ class SQLLogicParser:
             "<integral>": ["tinyint", "smallint", "integer", "bigint", "hugeint"],
             "<signed>": ["tinyint", "smallint", "integer", "bigint", "hugeint"],
             "<unsigned>": ["utinyint", "usmallint", "uinteger", "ubigint", "uhugeint"],
-            "<unsigned>": ["utinyint", "usmallint", "uinteger", "ubigint", "uhugeint"],
             "<all_types_columns>": [
                 "bool",
                 "tinyint",

--- a/tools/pythonpkg/tests/fast/pandas/test_fetch_nested.py
+++ b/tools/pythonpkg/tests/fast/pandas/test_fetch_nested.py
@@ -270,7 +270,7 @@ class TestFetchNested(object):
             'a': [
                 {
                     '1':10,
-                    '2':9,
+                    # '2':9,  # This value will be overwritten by '2':11 below.
                     '3':8,
                     '4':7,
                     '2':11,

--- a/tools/pythonpkg/tests/fast/test_type.py
+++ b/tools/pythonpkg/tests/fast/test_type.py
@@ -125,9 +125,9 @@ class TestType(object):
         type = duckdb.list_type(list[str])
         assert str(type.child) == "VARCHAR[]"
 
-        mapping = {'VARCHAR': str, 'BIGINT': int, 'BLOB': bytes, 'BLOB': bytearray, 'BOOLEAN': bool, 'DOUBLE': float}
-        for expected, type in mapping.items():
-            res = duckdb.list_type(type)
+        mapping = {str: 'VARCHAR', int: 'BIGINT', bytes: 'BLOB', bytearray: 'BLOB', bool: 'BOOLEAN', float: 'DOUBLE'}
+        for duckdb_type, expected in mapping.items():
+            res = duckdb.list_type(duckdb_type)
             assert str(res.child) == expected
 
         res = duckdb.list_type({'a': str, 'b': int})


### PR DESCRIPTION
Related to
* #15642

% `ruff check --select=F6 --output-format=concise`
```
scripts/sqllogictest/parser/parser.py:102:13: F601 Dictionary key literal `"<unsigned>"` repeated
tools/pythonpkg/tests/fast/pandas/test_fetch_nested.py:276:21: F601 Dictionary key literal `'2'` repeated
tools/pythonpkg/tests/fast/test_type.py:128:66: F601 Dictionary key literal `'BLOB'` repeated
```
Fixes:
1. The key and value are both duplicated so remove one item.
2. The first item is overwritten by the second as part of the test so make that explicit.
3. The current code tests 5 data types while the proposed code tests 6.

```python
>>> len({'VARCHAR': str, 'BIGINT': int, 'BLOB': bytes, 'BLOB': bytearray, 'BOOLEAN': bool, 'DOUBLE': float})
5
>>> len({str: 'VARCHAR', int: 'BIGINT', bytes: 'BLOB', bytearray: 'BLOB', bool: 'BOOLEAN', float: 'DOUBLE'})
6
```
% [`ruff rule F601`](https://docs.astral.sh/ruff/rules/multi-value-repeated-key-literal)
# multi-value-repeated-key-literal (F601)

Derived from the **Pyflakes** linter.

Fix is sometimes available.

## What it does
Checks for dictionary literals that associate multiple values with the
same key.

## Why is this bad?
Dictionary keys should be unique. If a key is associated with multiple values,
the earlier values will be overwritten. Including multiple values for the
same key in a dictionary literal is likely a mistake.

## Example
```python
foo = {
    "bar": 1,
    "baz": 2,
    "baz": 3,
}
foo["baz"]  # 3
```

Use instead:
```python
foo = {
    "bar": 1,
    "baz": 2,
}
foo["baz"]  # 2
```

## References
- [Python documentation: Dictionaries](https://docs.python.org/3/tutorial/datastructures.html#dictionaries)
