### PR TITLE
TableCatalogEntry instead of DuckTableEntry in TableScanBindData

### DIFF
--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -298,7 +298,7 @@ public:
 	virtual unique_ptr<PhysicalOperator> PlanUpdate(ClientContext &context, LogicalUpdate &op,
 	                                                unique_ptr<PhysicalOperator> plan) = 0;
 	virtual unique_ptr<LogicalOperator> BindCreateIndex(Binder &binder, CreateStatement &stmt, TableCatalogEntry &table,
-	                                                    unique_ptr<LogicalOperator> plan) = 0;
+	                                                    unique_ptr<LogicalOperator> plan);
 	virtual unique_ptr<LogicalOperator> BindAlterAddIndex(Binder &binder, TableCatalogEntry &table_entry,
 	                                                      unique_ptr<LogicalOperator> plan,
 	                                                      unique_ptr<CreateIndexInfo> create_info,

--- a/src/include/duckdb/function/table/table_scan.hpp
+++ b/src/include/duckdb/function/table/table_scan.hpp
@@ -17,11 +17,11 @@ class DuckTableEntry;
 class TableCatalogEntry;
 
 struct TableScanBindData : public TableFunctionData {
-	explicit TableScanBindData(DuckTableEntry &table) : table(table), is_index_scan(false), is_create_index(false) {
+	explicit TableScanBindData(TableCatalogEntry &table) : table(table), is_index_scan(false), is_create_index(false) {
 	}
 
 	//! The table to scan.
-	DuckTableEntry &table;
+	TableCatalogEntry &table;
 	//! The old purpose of this field has been deprecated.
 	//! We now use it to express an index scan in the ANALYZE call.
 	//! I.e., we const-cast the bind data and set this to true, if we opt for an index scan.


### PR DESCRIPTION
This PR changes the `DuckTableEntry &table;` field in `TableScanBindData` to `TableCatalogEntry`. This should make the `index_binder.BindCreateIndex` function `DuckCatalog` agnostic. So, I've moved it to the default catalog instead of the duck catalog.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/3509.