### PR TITLE
[Dev] Fix wrong result reported by Roaring Compression `FinalAnalyze`

### DIFF
--- a/src/include/duckdb/storage/compression/roaring/roaring.hpp
+++ b/src/include/duckdb/storage/compression/roaring/roaring.hpp
@@ -244,7 +244,9 @@ public:
 	//! Flushed analyze data
 
 	//! The space used by the current segment
-	idx_t space_used = 0;
+	idx_t data_size = 0;
+	idx_t metadata_size = 0;
+
 	//! The total amount of segments to write
 	idx_t segment_count = 0;
 	//! The amount of values in the current segment;

--- a/test/sql/storage/compression/roaring/roaring_analyze_array.test
+++ b/test/sql/storage/compression/roaring/roaring_analyze_array.test
@@ -1,0 +1,81 @@
+# name: test/sql/storage/compression/roaring/roaring_analyze_array.test
+# description: Check the produced (final_)analyze result
+# group: [roaring]
+
+require block_size 262144
+
+load __TEST_DIR__/test_roaring.db
+
+statement ok
+set logging_level='info';
+
+# 1 rowgroup
+statement ok
+set variable dataset_size = 122880;
+
+statement ok
+PRAGMA force_compression='uncompressed'
+
+statement ok
+set enable_logging=true;
+
+statement ok
+CREATE TABLE test_uncompressed AS SELECT
+	case
+		when i%25=0
+			then 1337
+		else null
+	end
+	FROM range(getvariable('dataset_size')) tbl(i);
+
+statement ok
+checkpoint
+
+statement ok
+set enable_logging=false;
+
+query I
+SELECT message.split(': ')[2]::INTEGER FROM duckdb_logs
+where
+	message.starts_with('FinalAnalyze') and
+	message.contains('test_uncompressed') and
+	message.contains('VALIDITY') and
+	message.contains('COMPRESSION_UNCOMPRESSED');
+----
+15360
+
+statement ok
+PRAGMA force_compression='roaring'
+
+statement ok
+set enable_logging=true;
+
+statement ok
+CREATE TABLE test_roaring AS select * from test_uncompressed;
+
+statement ok
+checkpoint
+
+statement ok
+set enable_logging=false;
+
+# For single row group
+# 60 vectors with 82 non-null values per vector
+# Total compressed bytes:
+# 2 bits (is_inverted + is_run) + 8 bits (cardinality) = 10 bits per Vector
+# 10 * 60 = 600 bits == 75 bytes of metadata per RowGroup
+#
+# 8 (compressed overhead) + (82 * sizeof(uint8_t)) = 90 bytes per Vector
+# 90 * 60 = 5400 bytes of data per RowGroup
+# 5475 bytes
+
+# We 2x the actual result, to pay for the slower decompression speed
+query I
+SELECT message.split(': ')[2]::INTEGER FROM duckdb_logs
+where
+	message.starts_with('FinalAnalyze') and
+	message.contains('test_roaring') and
+	message.contains('VALIDITY') and
+	message.contains('COMPRESSION_ROARING');
+----
+10944

--- a/test/sql/storage/compression/roaring/roaring_analyze_array.test
+++ b/test/sql/storage/compression/roaring/roaring_analyze_array.test
@@ -4,6 +4,8 @@
 
 require block_size 262144
 
+require noforcestorage
+
 load __TEST_DIR__/test_roaring.db
 
 statement ok

--- a/test/sql/storage/compression/roaring/roaring_analyze_bitset.test
+++ b/test/sql/storage/compression/roaring/roaring_analyze_bitset.test
@@ -4,6 +4,8 @@
 
 require block_size 262144
 
+require noforcestorage
+
 load __TEST_DIR__/test_roaring.db
 
 statement ok

--- a/test/sql/storage/compression/roaring/roaring_analyze_bitset.test
+++ b/test/sql/storage/compression/roaring/roaring_analyze_bitset.test
@@ -1,0 +1,81 @@
+# name: test/sql/storage/compression/roaring/roaring_analyze_bitset.test
+# description: Check the produced (final_)analyze result
+# group: [roaring]
+
+require block_size 262144
+
+load __TEST_DIR__/test_roaring.db
+
+statement ok
+set logging_level='info';
+
+# 1 rowgroup
+statement ok
+set variable dataset_size = 122880;
+
+statement ok
+PRAGMA force_compression='uncompressed'
+
+statement ok
+set enable_logging=true;
+
+statement ok
+CREATE TABLE test_uncompressed AS SELECT
+	case
+		when i%3=0
+			then 1337
+		else null
+	end
+	FROM range(getvariable('dataset_size')) tbl(i);
+
+statement ok
+checkpoint
+
+statement ok
+set enable_logging=false;
+
+query I
+SELECT message.split(': ')[2]::INTEGER FROM duckdb_logs
+where
+	message.starts_with('FinalAnalyze') and
+	message.contains('test_uncompressed') and
+	message.contains('VALIDITY') and
+	message.contains('COMPRESSION_UNCOMPRESSED');
+----
+15360
+
+statement ok
+PRAGMA force_compression='roaring'
+
+statement ok
+set enable_logging=true;
+
+statement ok
+CREATE TABLE test_roaring AS select * from test_uncompressed;
+
+statement ok
+checkpoint
+
+statement ok
+set enable_logging=false;
+
+# For single row group
+# 60 vectors with 7 or 8 runs of nulls per vector
+# Total compressed bytes:
+# 2 bits (is_inverted + is_run) = 2 bits per Vector
+# 2 * 60 = 120 bits == 15 bytes of metadata per RowGroup
+#
+# 256 bytes bytes per Vector
+# 256 * 60 = 15360 bytes of data per RowGroup
+# 15375 bytes
+
+# We 2x the actual result, to pay for the slower decompression speed
+query I
+SELECT message.split(': ')[2]::INTEGER FROM duckdb_logs
+where
+	message.starts_with('FinalAnalyze') and
+	message.contains('test_roaring') and
+	message.contains('VALIDITY') and
+	message.contains('COMPRESSION_ROARING');
+----
+30872

--- a/test/sql/storage/compression/roaring/roaring_analyze_run.test
+++ b/test/sql/storage/compression/roaring/roaring_analyze_run.test
@@ -1,0 +1,81 @@
+# name: test/sql/storage/compression/roaring/roaring_analyze_run.test
+# description: Check the produced (final_)analyze result
+# group: [roaring]
+
+require block_size 262144
+
+load __TEST_DIR__/test_roaring.db
+
+statement ok
+set logging_level='info';
+
+# 1 rowgroup
+statement ok
+set variable dataset_size = 122880;
+
+statement ok
+PRAGMA force_compression='uncompressed'
+
+statement ok
+set enable_logging=true;
+
+statement ok
+CREATE TABLE test_uncompressed AS SELECT
+	case
+		when i = 0 or (i % 512 != 0 and (i % 512) < 350 or (i % 512) > 450)
+			then null
+		else 1337
+	end
+	FROM range(getvariable('dataset_size')) tbl(i);
+
+statement ok
+checkpoint
+
+statement ok
+set enable_logging=false;
+
+query I
+SELECT message.split(': ')[2]::INTEGER FROM duckdb_logs
+where
+	message.starts_with('FinalAnalyze') and
+	message.contains('test_uncompressed') and
+	message.contains('VALIDITY') and
+	message.contains('COMPRESSION_UNCOMPRESSED');
+----
+15360
+
+statement ok
+PRAGMA force_compression='roaring'
+
+statement ok
+set enable_logging=true;
+
+statement ok
+CREATE TABLE test_roaring AS select * from test_uncompressed;
+
+statement ok
+checkpoint
+
+statement ok
+set enable_logging=false;
+
+# For single row group
+# 60 vectors with 7 or 8 runs of nulls per vector
+# Total compressed bytes:
+# 2 bits (is_inverted + is_run) + 7 bits (run_size) = 9 bits per Vector
+# 9 * 60 = 540 bits == 67 bytes of metadata per RowGroup
+#
+# 8 (compressed overhead) + (8 * sizeof(uint16_t)) = 24 bytes per Vector
+# 24 * 60 = 1440 bytes of data per RowGroup
+# 1507 bytes
+
+# We 2x the actual result, to pay for the slower decompression speed
+query I
+SELECT message.split(': ')[2]::INTEGER FROM duckdb_logs
+where
+	message.starts_with('FinalAnalyze') and
+	message.contains('test_roaring') and
+	message.contains('VALIDITY') and
+	message.contains('COMPRESSION_ROARING');
+----
+3024

--- a/test/sql/storage/compression/roaring/roaring_analyze_run.test
+++ b/test/sql/storage/compression/roaring/roaring_analyze_run.test
@@ -4,6 +4,8 @@
 
 require block_size 262144
 
+require noforcestorage
+
 load __TEST_DIR__/test_roaring.db
 
 statement ok

--- a/test/sql/storage/compression/zstd/zstd_compression_ratio.test_slow
+++ b/test/sql/storage/compression/zstd/zstd_compression_ratio.test_slow
@@ -7,6 +7,12 @@ require block_size 262144
 load __TEST_DIR__/test_zstd_compression_ratio.db
 
 statement ok
+set enable_logging=true;
+
+statement ok
+set logging_level='info';
+
+statement ok
 PRAGMA force_compression='zstd'
 
 statement ok
@@ -30,6 +36,12 @@ create table test_compressed as (
 statement ok
 checkpoint
 
+# We analyzed the ZSTD compressed data to be 230.8 Mb
+query I
+SELECT message FROM duckdb_logs where message.starts_with('FinalAnalyze') and message.contains('test_compressed') and message.contains('VARCHAR') order by timestamp;
+----
+FinalAnalyze(COMPRESSION_ZSTD) result for main.test_compressed.0(VARCHAR): 230801376
+
 statement ok
 PRAGMA force_compression='uncompressed'
 
@@ -49,6 +61,12 @@ CREATE TABLE test_uncompressed as (
 
 statement ok
 checkpoint
+
+# The Uncompressed data to would have been 462.4 Mb
+query I
+SELECT message FROM duckdb_logs where message.starts_with('FinalAnalyze') and message.contains('test_uncompressed') and message.contains('VARCHAR') order by timestamp;
+----
+FinalAnalyze(COMPRESSION_UNCOMPRESSED) result for main.test_uncompressed.0(VARCHAR): 462400000
 
 query I
 SELECT compression FROM pragma_storage_info('test_compressed') WHERE segment_type != 'VALIDITY' AND compression != 'ZSTD';
@@ -70,6 +88,7 @@ CREATE TYPE test_result AS UNION (
     )
 );
 
+# This roughly aligns with comparing Uncompressed/ZSTD FinalAnalyze results (which is ~2x)
 statement ok
 set variable min_ratio = 1.8;
 set variable max_ratio = 2.5;


### PR DESCRIPTION
The metadata size was being calculated for all the groups in the segment, but we were adding this to the total `space_used`
We know split the `space_used` into `data_size` and `metadata_size`.

`metadata_size` gets recalculated with every flushed container, whereas `data_size` is added onto for every container.
We make use of the new [logging](#15119) system to test this! 🥳 