### PR TITLE
Clean up temporary test directory in `run_tests_one_by_one.py` even if test segfaults

### DIFF
--- a/scripts/run_tests_one_by_one.py
+++ b/scripts/run_tests_one_by_one.py
@@ -3,6 +3,8 @@ import subprocess
 import time
 import threading
 import tempfile
+import os
+import shutil
 
 import argparse
 
@@ -197,6 +199,14 @@ STDERR
 --------------------"""
         )
         print(stderr)
+
+    # if a test closes unexpectedly (e.g., SEGV), test cleanup doesn't happen,
+    # causing us to run out of space on subsequent tests in GH Actions (not much disk space there)
+    duckdb_unittest_tempdir = os.path.join(
+        os.path.dirname(unittest_program), '..', '..', '..', 'duckdb_unittest_tempdir'
+    )
+    if os.path.exists(duckdb_unittest_tempdir) and os.listdir(duckdb_unittest_tempdir):
+        shutil.rmtree(duckdb_unittest_tempdir)
     fail()
 
 


### PR DESCRIPTION
The cleanup is built into our `unittest` executable, but the cleanup doesn't happen if a test segfaults. If the test that segfaults uses a lot of space, subsequent tests may run out of disk space (GH actions don't have that much disk space). This PR makes sure the test dir is cleaned up in such cases.