### PR TITLE
Dont encode + on URL

### DIFF
--- a/test/sql/copy/csv/test_url_with_plus.test
+++ b/test/sql/copy/csv/test_url_with_plus.test
@@ -1,0 +1,11 @@
+# name: test/sql/copy/csv/test_url_with_plus.test
+# description: Tests url with plus
+# group: [csv]
+
+require httpfs
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+FROM read_csv('https://d37ci6vzurychx.cloudfront.net/misc/taxi+_zone_lookup.csv');

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -2466,7 +2466,6 @@ inline std::string encode_url(const std::string &s) {
   for (size_t i = 0; s[i]; i++) {
     switch (s[i]) {
     case ' ': result += "%20"; break;
-    case '+': result += "%2B"; break;
     case '\r': result += "%0D"; break;
     case '\n': result += "%0A"; break;
     case '\'': result += "%27"; break;


### PR DESCRIPTION
Fix: https://github.com/duckdblabs/duckdb-internal/issues/3285

I'm not a specialist on URL encoding, so it's possible we just want to skip it on file names?