### PR TITLE
Add late_materialization_max_rows setting that allows you to configure the threshold at which late materialization is triggered

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -517,6 +517,12 @@
         "scope": "local"
     },
     {
+        "name": "late_materialization_max_rows",
+        "description": "The maximum amount of rows in the LIMIT/SAMPLE for which we trigger late materialization",
+        "type": "UBIGINT",
+        "scope": "local"
+    },
+    {
         "name": "lock_configuration",
         "description": "Whether or not the configuration can be altered",
         "type": "BOOLEAN",

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -120,6 +120,9 @@ struct ClientConfig {
 	//! The maximum amount of OR filters we generate dynamically from a hash join
 	idx_t dynamic_or_filter_threshold = 50;
 
+	//! The maximum amount of rows in the LIMIT/SAMPLE for which we trigger late materialization
+	idx_t late_materialization_max_rows = 50;
+
 	//! Whether the "/" division operator defaults to integer division or floating point division
 	bool integer_division = false;
 	//! When a scalar subquery returns multiple rows - return a random row instead of returning an error

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -783,6 +783,17 @@ struct IntegerDivisionSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct LateMaterializationMaxRowsSetting {
+	using RETURN_TYPE = idx_t;
+	static constexpr const char *Name = "late_materialization_max_rows";
+	static constexpr const char *Description =
+	    "The maximum amount of rows in the LIMIT/SAMPLE for which we trigger late materialization";
+	static constexpr const char *InputType = "UBIGINT";
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct LockConfigurationSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "lock_configuration";

--- a/src/include/duckdb/optimizer/late_materialization.hpp
+++ b/src/include/duckdb/optimizer/late_materialization.hpp
@@ -39,7 +39,7 @@ private:
 private:
 	Optimizer &optimizer;
 	//! The max row count for which we will consider late materialization
-	idx_t max_row_count = 50;
+	idx_t max_row_count;
 };
 
 } // namespace duckdb

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -126,6 +126,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(IndexScanMaxCountSetting),
     DUCKDB_GLOBAL(IndexScanPercentageSetting),
     DUCKDB_LOCAL(IntegerDivisionSetting),
+    DUCKDB_LOCAL(LateMaterializationMaxRowsSetting),
     DUCKDB_GLOBAL(LockConfigurationSetting),
     DUCKDB_LOCAL(LogQueryPathSetting),
     DUCKDB_GLOBAL(LoggingLevel),

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -771,6 +771,23 @@ Value IntegerDivisionSetting::GetSetting(const ClientContext &context) {
 }
 
 //===----------------------------------------------------------------------===//
+// Late Materialization Max Rows
+//===----------------------------------------------------------------------===//
+void LateMaterializationMaxRowsSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.late_materialization_max_rows = input.GetValue<idx_t>();
+}
+
+void LateMaterializationMaxRowsSetting::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).late_materialization_max_rows = ClientConfig().late_materialization_max_rows;
+}
+
+Value LateMaterializationMaxRowsSetting::GetSetting(const ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	return Value::UBIGINT(config.late_materialization_max_rows);
+}
+
+//===----------------------------------------------------------------------===//
 // Lock Configuration
 //===----------------------------------------------------------------------===//
 void LockConfigurationSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/optimizer/late_materialization.cpp
+++ b/src/optimizer/late_materialization.cpp
@@ -372,7 +372,7 @@ unique_ptr<LogicalOperator> LateMaterialization::Optimize(unique_ptr<LogicalOper
 			}
 		}
 		if (TryLateMaterialization(op)) {
-			return std::move(op);
+			return op;
 		}
 		break;
 	}
@@ -383,7 +383,7 @@ unique_ptr<LogicalOperator> LateMaterialization::Optimize(unique_ptr<LogicalOper
 		}
 		// for the top-n we need to visit the order elements
 		if (TryLateMaterialization(op)) {
-			return std::move(op);
+			return op;
 		}
 		break;
 	}
@@ -396,7 +396,7 @@ unique_ptr<LogicalOperator> LateMaterialization::Optimize(unique_ptr<LogicalOper
 			break;
 		}
 		if (TryLateMaterialization(op)) {
-			return std::move(op);
+			return op;
 		}
 		break;
 	}

--- a/src/optimizer/late_materialization.cpp
+++ b/src/optimizer/late_materialization.cpp
@@ -15,6 +15,7 @@
 namespace duckdb {
 
 LateMaterialization::LateMaterialization(Optimizer &optimizer) : optimizer(optimizer) {
+	max_row_count = ClientConfig::GetConfig(optimizer.context).late_materialization_max_rows;
 }
 
 idx_t LateMaterialization::GetOrInsertRowId(LogicalGet &get) {

--- a/src/optimizer/late_materialization.cpp
+++ b/src/optimizer/late_materialization.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/main/client_config.hpp"
 
 namespace duckdb {
 

--- a/test/sql/topn/top_n_materialization.test
+++ b/test/sql/topn/top_n_materialization.test
@@ -129,3 +129,20 @@ SELECT j, k, l, i FROM test WHERE i > 5 ORDER BY j DESC LIMIT 2;
 ----
 10	11	-9	9
 09	10	-8	8
+
+# test late materialization setting
+statement ok
+SET late_materialization_max_rows=0
+
+query II
+explain SELECT * FROM test ORDER BY j DESC LIMIT 2;
+----
+logical_opt	<!REGEX>:.*COMPARISON_JOIN.*
+
+statement ok
+RESET late_materialization_max_rows
+
+query II
+explain SELECT * FROM test ORDER BY j DESC LIMIT 2;
+----
+logical_opt	<REGEX>:.*COMPARISON_JOIN.*


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/15692

This PR adds the `late_materialization_max_rows` setting that allows you to configure the threshold at which late materialization is triggered. The default value is `50`.

Example usage:

```sql
SET late_materialization_max_rows=1000;
explain SELECT * FROM lineitem ORDER BY l_orderkey DESC LIMIT 1000;
```

The exact best setting is hard to determine - essentially the row-id pushdown has two components to it (1) the OR filter push-down, which is done for up to `dynamic_or_filter_threshold` rows (defaults to 50) and the min-max filter pushdown. 

The row-id rewrite generally always provides performance improvements for up to `dynamic_or_filter_threshold` which is why we select that as a default. Beyond that, it depends on the locality of the rows. If the min-max filter on row-ids is selective (i.e. the rows we select are close together physically in the table) the row-id rewrite is effective. If the rows are spread out, the rewrite can worsen performance.

CC @abramk
