### PR TITLE
Bugfixes

### DIFF
--- a/.github/patches/extensions/httpfs/last_modified.patch
+++ b/.github/patches/extensions/httpfs/last_modified.patch
@@ -1,0 +1,33 @@
+diff --git a/extension/httpfs/httpfs.cpp b/extension/httpfs/httpfs.cpp
+index e6b28e5..5847eb4 100644
+--- a/extension/httpfs/httpfs.cpp
++++ b/extension/httpfs/httpfs.cpp
+@@ -772,16 +772,18 @@ void HTTPFileHandle::Initialize(optional_ptr<FileOpener> opener) {
+ 		FullDownload(hfs, should_write_cache);
+ 	}
+ 	if (!res->headers["Last-Modified"].empty()) {
+-		auto result = StrpTimeFormat::Parse("%a, %d %h %Y %T %Z", res->headers["Last-Modified"]);
+-		struct tm tm {};
+-		tm.tm_year = result.data[0] - 1900;
+-		tm.tm_mon = result.data[1] - 1;
+-		tm.tm_mday = result.data[2];
+-		tm.tm_hour = result.data[3];
+-		tm.tm_min = result.data[4];
+-		tm.tm_sec = result.data[5];
+-		tm.tm_isdst = 0;
+-		last_modified = mktime(&tm);
++		StrpTimeFormat::ParseResult result;
++		if (StrpTimeFormat::TryParse("%a, %d %h %Y %T %Z", res->headers["Last-Modified"], result)) {
++			struct tm tm {};
++			tm.tm_year = result.data[0] - 1900;
++			tm.tm_mon = result.data[1] - 1;
++			tm.tm_mday = result.data[2];
++			tm.tm_hour = result.data[3];
++			tm.tm_min = result.data[4];
++			tm.tm_sec = result.data[5];
++			tm.tm_isdst = 0;
++			last_modified = mktime(&tm);
++		}
+ 	}
+ 
+ 	if (should_write_cache) {

--- a/extension/json/buffered_json_reader.cpp
+++ b/extension/json/buffered_json_reader.cpp
@@ -35,7 +35,7 @@ void JSONFileHandle::Reset() {
 	requested_reads = 0;
 	actual_reads = 0;
 	last_read_requested = false;
-	if (IsOpen() && CanSeek()) {
+	if (IsOpen() && !file_handle->IsPipe()) {
 		file_handle->Reset();
 	}
 }

--- a/extension/json/json_functions/read_json_objects.cpp
+++ b/extension/json/json_functions/read_json_objects.cpp
@@ -64,8 +64,8 @@ TableFunction GetReadJSONObjectsTableFunction(bool list_parameter, shared_ptr<JS
 
 TableFunctionSet JSONFunctions::GetReadJSONObjectsFunction() {
 	TableFunctionSet function_set("read_json_objects");
-	auto function_info =
-	    make_shared_ptr<JSONScanInfo>(JSONScanType::READ_JSON_OBJECTS, JSONFormat::ARRAY, JSONRecordType::RECORDS);
+	auto function_info = make_shared_ptr<JSONScanInfo>(JSONScanType::READ_JSON_OBJECTS, JSONFormat::AUTO_DETECT,
+	                                                   JSONRecordType::RECORDS);
 	function_set.AddFunction(GetReadJSONObjectsTableFunction(false, function_info));
 	function_set.AddFunction(GetReadJSONObjectsTableFunction(true, function_info));
 	return function_set;

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -853,16 +853,27 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	bool open_write = flags.OpenForWriting();
 	if (open_read && open_write) {
 		desired_access = GENERIC_READ | GENERIC_WRITE;
-		share_mode = 0;
 	} else if (open_read) {
 		desired_access = GENERIC_READ;
-		share_mode = FILE_SHARE_READ;
 	} else if (open_write) {
 		desired_access = GENERIC_WRITE;
-		share_mode = 0;
 	} else {
 		throw InternalException("READ, WRITE or both should be specified when opening a file");
 	}
+	switch (flags.Lock()) {
+	case FileLockType::NO_LOCK:
+		share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE;
+		break;
+	case FileLockType::READ_LOCK:
+		share_mode = FILE_SHARE_READ;
+		break;
+	case FileLockType::WRITE_LOCK:
+		share_mode = 0;
+		break;
+	default:
+		throw InternalException("Unknown FileLockType");
+	}
+
 	if (open_write) {
 		if (flags.CreateFileIfNotExists()) {
 			creation_disposition = OPEN_ALWAYS;

--- a/src/function/scalar/strftime_format.cpp
+++ b/src/function/scalar/strftime_format.cpp
@@ -1412,6 +1412,16 @@ StrpTimeFormat::ParseResult StrpTimeFormat::Parse(const string &format_string, c
 	return result;
 }
 
+bool StrpTimeFormat::TryParse(const string &format_string, const string &text, ParseResult &result) {
+	StrpTimeFormat format;
+	format.format_specifier = format_string;
+	string error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
+	if (!error.empty()) {
+		throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
+	}
+	return format.Parse(text, result);
+}
+
 bool StrTimeFormat::Empty() const {
 	return format_specifier.empty();
 }

--- a/src/include/duckdb/function/scalar/strftime_format.hpp
+++ b/src/include/duckdb/function/scalar/strftime_format.hpp
@@ -169,6 +169,7 @@ public:
 		return format_specifier != other.format_specifier;
 	}
 	DUCKDB_API static ParseResult Parse(const string &format, const string &text);
+	DUCKDB_API static bool TryParse(const string &format, const string &text, ParseResult &result);
 
 	DUCKDB_API bool Parse(string_t str, ParseResult &result, bool strict = false) const;
 

--- a/test/sql/json/table/read_json_objects.test
+++ b/test/sql/json/table/read_json_objects.test
@@ -9,7 +9,7 @@ require json
 statement error
 select * from read_json_objects('data/json/unterminated_quotes.ndjson')
 ----
-Invalid Input Error: Expected top-level JSON array
+Invalid Input Error: Malformed JSON
 
 # now it should work!
 query I
@@ -213,7 +213,7 @@ Invalid Input Error: Malformed JSON in file "data/json/multiple_objects_per_line
 statement error
 select * from read_json_objects('data/csv/tpcds_14.csv')
 ----
-Invalid Input Error: Expected top-level JSON array
+Invalid Input Error: Malformed JSON
 
 statement error
 select * from read_ndjson_objects('data/csv/tpcds_14.csv')
@@ -224,7 +224,7 @@ Invalid Input Error: Malformed JSON in file "data/csv/tpcds_14.csv"
 statement error
 select * from read_json_objects('data/parquet-testing/blob.parquet')
 ----
-Invalid Input Error: Expected top-level JSON array
+Invalid Input Error: Malformed JSON
 
 statement error
 select * from read_ndjson_objects('data/parquet-testing/blob.parquet')


### PR DESCRIPTION
Fixes:
1. https://github.com/duckdb/duckdb/issues/15695 by properly resetting file handle if table function is stopped early from outside `read_json` (as is the case with the recursive CTE in the issue)
2. https://github.com/duckdb/duckdb/issues/15696 by trying to parse the `"Last-Modified"` HTTP field, and ignoring the field entirely it if it fails (URL returns wrong format in the issue, but with this fix it still won't read because the URL doesn't support range requests)
3. https://github.com/duckdb/duckdb/issues/15641 by respecting the `FileLockType` on Windows instead of doing some default behavior