### PR TITLE
DatabaseInstance's destructor: avoid throwing (and not cleaning up)

### DIFF
--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -68,7 +68,9 @@ DatabaseInstance::DatabaseInstance() {
 
 DatabaseInstance::~DatabaseInstance() {
 	// destroy all attached databases
-	GetDatabaseManager().ResetDatabases(scheduler);
+	if (db_manager) {
+		db_manager->ResetDatabases(scheduler);
+	}
 	// destroy child elements
 	connection_manager.reset();
 	object_cache.reset();


### PR DESCRIPTION
Simple test-case is:
```c++

int main() {
        duckdb::DatabaseInstance db;
	// db.Initialize not called
        return 1;
}
```
Where a not properly constructed DatabaseInstance will terminate the program before, and not afterwards.

There might be cases where (possibly due to exceptions) we get in a not fully initialized state, this avoids an exception that might not have a chance to be caught (and possibly might lead to failure).

Bumped into this by writing a test unit-test for a wrong PR, that had the unit-tester abort.