### PR TITLE
Move the DatabaseCacheEntry into the DBConfig, and set it before the constructor is called

### DIFF
--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -56,6 +56,7 @@ class CompressionInfo;
 class EncryptionUtil;
 
 struct CompressionFunctionSet;
+struct DatabaseCacheEntry;
 struct DBConfig;
 
 enum class CheckpointAbort : uint8_t {
@@ -331,6 +332,8 @@ public:
 	vector<unique_ptr<ExtensionCallback>> extension_callbacks;
 	//! Encryption Util for OpenSSL
 	shared_ptr<EncryptionUtil> encryption_util;
+	//! Reference to the database cache entry (if any)
+	shared_ptr<DatabaseCacheEntry> db_cache_entry;
 
 public:
 	DUCKDB_API static DBConfig &GetConfig(ClientContext &context);

--- a/src/include/duckdb/main/database.hpp
+++ b/src/include/duckdb/main/database.hpp
@@ -77,7 +77,6 @@ public:
 	                                                    const AttachOptions &options);
 
 	void AddExtensionInfo(const string &name, const ExtensionLoadedInfo &info);
-	void SetDatabaseCacheEntry(shared_ptr<DatabaseCacheEntry> entry);
 
 private:
 	void Initialize(const char *path, DBConfig *config);
@@ -95,7 +94,6 @@ private:
 	unordered_map<string, ExtensionInfo> loaded_extensions_info;
 	ValidChecker db_validity;
 	unique_ptr<DatabaseFileSystem> db_file_system;
-	shared_ptr<DatabaseCacheEntry> db_cache_entry;
 	shared_ptr<LogManager> log_manager;
 
 	duckdb_ext_api_v1 (*create_api_v1)();

--- a/src/include/duckdb/main/db_instance_cache.hpp
+++ b/src/include/duckdb/main/db_instance_cache.hpp
@@ -18,6 +18,7 @@ namespace duckdb {
 class DBInstanceCache;
 
 struct DatabaseCacheEntry {
+	DatabaseCacheEntry();
 	explicit DatabaseCacheEntry(const shared_ptr<DuckDB> &database);
 	~DatabaseCacheEntry();
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -86,7 +86,7 @@ DatabaseInstance::~DatabaseInstance() {
 	}
 	Allocator::SetBackgroundThreads(false);
 	// after all destruction is complete clear the cache entry
-	db_cache_entry.reset();
+	config.db_cache_entry.reset();
 }
 
 BufferManager &BufferManager::GetBufferManager(DatabaseInstance &db) {
@@ -107,10 +107,6 @@ DatabaseInstance &DatabaseInstance::GetDatabase(ClientContext &context) {
 
 const DatabaseInstance &DatabaseInstance::GetDatabase(const ClientContext &context) {
 	return *context.db;
-}
-
-void DatabaseInstance::SetDatabaseCacheEntry(shared_ptr<DatabaseCacheEntry> entry) {
-	db_cache_entry = std::move(entry);
 }
 
 DatabaseManager &DatabaseInstance::GetDatabaseManager() {
@@ -464,6 +460,7 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 		                                                 config.options.buffer_manager_track_eviction_timestamps,
 		                                                 config.options.allocator_bulk_deallocation_flush_threshold);
 	}
+	config.db_cache_entry = new_config.db_cache_entry;
 }
 
 DBConfig &DBConfig::GetConfig(ClientContext &context) {


### PR DESCRIPTION
This enables it to be accessed through e.g. extensions