### PR TITLE
Remove iceberg, again

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -80,6 +80,8 @@ else ()
     set(LOAD_ICEBERG_TESTS "")
 endif()
 
+### Boost::filesystem, a vcpkg iceberg dependency, is currently not compatible with linux_arm64 platform
+if (NO)
 if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
     duckdb_extension_load(iceberg
             ${LOAD_ICEBERG_TESTS}
@@ -87,6 +89,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
             GIT_TAG d62d91d8a089371c4d1862a88f2e62a97bc2af3a
             APPLY_PATCHES
             )
+endif()
 endif()
 
 ################# INET


### PR DESCRIPTION
This is a revert of https://github.com/duckdb/duckdb/pull/15456, that reintroduced it.

When building Boost::filesystem, an iceberg VCPKG's dependency, in the context of the linux_arm64 cross-compiled platform there is a funny dependency on a specific CMake version.

While investigating, it's saner to remove it from CI and avoid unneded failures.

"I'll be back", duckdb-iceberg