### PR TITLE
Try unescaping path before globbing

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1258,9 +1258,10 @@ static void GlobFilesInternal(FileSystem &fs, const string &path, const string &
 	});
 }
 
-// Try to unescape glob patterns to a literal path.
-// Returns true if the path can be unescaped to a literal path, and the literal path is returned in result.
-// Returns false if the path cannot be unescaped to a literal path.
+// Attempts to unescape glob patterns to a literal path.
+// Returns true if the path can be unescaped, with the resulting literal path stored in 'result'.
+// Returns false if the path cannot be unescaped.
+// If the path contains no glob patterns, it is returned as-is.
 //
 // Examples:
 // 	"abc" -> true, "abc"
@@ -1272,11 +1273,11 @@ static bool TryUnescapeGlob(const string &path, string &result) {
 	result.reserve(path.size());
 	for (idx_t i = 0; i < path.size(); ) {
 		if (path[i] == '[' && i + 2 < path.size() && path[i + 2] == ']') {
-			// replace [c] -> c
+			// Replace [c] -> c
 			result += path[i + 1];
 			i += 3;
 		} else if (path[i] == '*' || path[i] == '?' || path[i] == '[') {
-			// can not be unescaped due to special characters
+			// Cannot unescape due to special characters
 			return false;
 		} else {
 			result += path[i];

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1271,7 +1271,7 @@ static void GlobFilesInternal(FileSystem &fs, const string &path, const string &
 static bool TryUnescapeGlob(const string &path, string &result) {
 	result.clear();
 	result.reserve(path.size());
-	for (idx_t i = 0; i < path.size(); ) {
+	for (idx_t i = 0; i < path.size();) {
 		if (path[i] == '[' && i + 2 < path.size() && path[i + 2] == ']') {
 			// Replace [c] -> c
 			result += path[i + 1];


### PR DESCRIPTION
Currently, when filenames contain glob special characters like `*`, `?`, or `[`, we need to escape the paths before passing them to DuckDB. However, even after escaping, DuckDB still treats these paths as glob patterns, causing it to scan the entire directory. While DuckDB eventually finds the correct files, this unnecessary directory scan can lead to significant performance overhead. This issue is especially problematic on distributed file systems, where operations like the following can become extremely slow:

```sql
# Assume the 'data' directory contains 1,000,000 parquet files: [1].parquet to [1000000].parquet
# We only want to read 100 of them
# This statement results in 1,000,000 x 100 stat operations
create view v as select * from read_parquet(['data/[[]1].parquet', 'data/[[]2].parquet', ..., 'data/[[]100].parquet']);
```

To address this performance bottleneck, this PR enhances the `Glob` function to detect escaped paths. If an escaped path is identified, it is directly unescaped to its original form, avoiding the costly glob operation.