### PR TITLE
Fix #15659: VARCHAR parameters now count as STRING_LITERAL again

### DIFF
--- a/src/include/duckdb/planner/expression/bound_parameter_data.hpp
+++ b/src/include/duckdb/planner/expression/bound_parameter_data.hpp
@@ -17,7 +17,7 @@ struct BoundParameterData {
 public:
 	BoundParameterData() {
 	}
-	explicit BoundParameterData(Value val) : value(std::move(val)), return_type(value.type()) {
+	explicit BoundParameterData(Value val) : value(std::move(val)), return_type(GetDefaultType(value.type())) {
 	}
 	BoundParameterData(Value val, LogicalType type_p) : value(std::move(val)), return_type(std::move(type_p)) {
 	}
@@ -39,6 +39,14 @@ public:
 
 	void Serialize(Serializer &serializer) const;
 	static shared_ptr<BoundParameterData> Deserialize(Deserializer &deserializer);
+
+private:
+	LogicalType GetDefaultType(const LogicalType &type) {
+		if (value.type().id() == LogicalTypeId::VARCHAR && StringType::GetCollation(type).empty()) {
+			return LogicalTypeId::STRING_LITERAL;
+		}
+		return value.type();
+	}
 };
 
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -28,6 +28,7 @@ void ExpressionBinder::TestCollation(ClientContext &context, const string &colla
 
 static bool SwitchVarcharComparison(const LogicalType &type) {
 	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
 	case LogicalTypeId::TINYINT:
 	case LogicalTypeId::SMALLINT:
 	case LogicalTypeId::INTEGER:

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -43,7 +43,10 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 		if (is_literal) {
 			auto &constant = bound_expr->Cast<BoundConstantExpression>();
 			LogicalType return_type;
-			if (constant.return_type.IsIntegral()) {
+			if (constant.return_type == LogicalTypeId::VARCHAR &&
+			    StringType::GetCollation(constant.return_type).empty()) {
+				return_type = LogicalTypeId::STRING_LITERAL;
+			} else if (constant.return_type.IsIntegral()) {
 				return_type = LogicalType::INTEGER_LITERAL(constant.value);
 			} else {
 				return_type = constant.value.type();

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -51,8 +51,8 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 			parameter_data = BoundParameterData(std::move(constant.value), std::move(return_type));
 		} else {
 			auto value = ExpressionExecutor::EvaluateScalar(context, *bound_expr, true);
-			auto &value_type = value.type();
-			parameter_data = BoundParameterData(std::move(value), value_type);
+			auto value_type = value.type();
+			parameter_data = BoundParameterData(std::move(value), std::move(value_type));
 		}
 		bind_values[pair.first] = std::move(parameter_data);
 	}

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -43,10 +43,7 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 		if (is_literal) {
 			auto &constant = bound_expr->Cast<BoundConstantExpression>();
 			LogicalType return_type;
-			if (constant.return_type == LogicalTypeId::VARCHAR &&
-			    StringType::GetCollation(constant.return_type).empty()) {
-				return_type = LogicalTypeId::STRING_LITERAL;
-			} else if (constant.return_type.IsIntegral()) {
+			if (constant.return_type.IsIntegral()) {
 				return_type = LogicalType::INTEGER_LITERAL(constant.value);
 			} else {
 				return_type = constant.value.type();
@@ -54,7 +51,8 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 			parameter_data = BoundParameterData(std::move(constant.value), std::move(return_type));
 		} else {
 			auto value = ExpressionExecutor::EvaluateScalar(context, *bound_expr, true);
-			parameter_data = BoundParameterData(std::move(value));
+			auto &value_type = value.type();
+			parameter_data = BoundParameterData(std::move(value), value_type);
 		}
 		bind_values[pair.first] = std::move(parameter_data);
 	}

--- a/test/sql/cast/boolean_autocast.test
+++ b/test/sql/cast/boolean_autocast.test
@@ -53,6 +53,11 @@ SELECT true='1';
 true
 
 query T
+SELECT true='1'::VARCHAR;
+----
+true
+
+query T
 SELECT true='0';
 ----
 false

--- a/test/sql/collate/collate_filter_pushdown.test
+++ b/test/sql/collate/collate_filter_pushdown.test
@@ -20,4 +20,4 @@ insert into t63(c0) values ('1');
 query I
 SELECT t63.c0 FROM t0 NATURAL LEFT JOIN t63;
 ----
-NULL
+1

--- a/tools/pythonpkg/tests/fast/test_parameter_list.py
+++ b/tools/pythonpkg/tests/fast/test_parameter_list.py
@@ -28,3 +28,18 @@ class TestParameterList(object):
         con = duckdb.default_connection()
         res = con.execute('select isnan(cast(? as double))', (float("nan"),))
         assert res.fetchone()[0] == True
+
+    def test_string_parameter(self, duckdb_cursor):
+        conn = duckdb.connect()
+        conn.execute("create table orders (o_orderdate date)")
+        conn.execute("insert into orders values (date '1992-01-01', date '1994-01-01')")
+        conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM ORDERS
+            WHERE O_ORDERDATE BETWEEN ? AND ?
+            """,
+            ["1994-01-01", "1996-01-01"],
+        )
+        res = conn.fetchall()
+        assert res == [(1,)]

--- a/tools/pythonpkg/tests/fast/test_parameter_list.py
+++ b/tools/pythonpkg/tests/fast/test_parameter_list.py
@@ -32,7 +32,7 @@ class TestParameterList(object):
     def test_string_parameter(self, duckdb_cursor):
         conn = duckdb.connect()
         conn.execute("create table orders (o_orderdate date)")
-        conn.execute("insert into orders values (date '1992-01-01', date '1994-01-01')")
+        conn.execute("insert into orders values (date '1992-01-01'), (date '1994-01-01')")
         conn.execute(
             """
             SELECT COUNT(*)


### PR DESCRIPTION
Fixes #15659 

This partially reverts https://github.com/duckdb/duckdb/pull/12759 for `VARCHAR` columns.

Previously parameters would always count as literals - i.e. passing in a parameter `1` would bind as an `INTEGER_LITERAL`, and a parameter `'str'` would bind as a string literal. This matters because literals have special binding rules where they adopt surrounding types, so string literals can be used as dates, but `VARCHAR` columns cannot (see [literal typing here](https://duckdb.org/2024/02/13/announcing-duckdb-0100.html))

For integer literals this fixes issues where types were ignored causing overflow errors when used in conjunction with smaller integer types. For string literals, however, this can cause previously working code to now throw binder errors. This PR reverts the behavior so that the code in the linked issue works again.