### PR TITLE
Properly set `external` flag again in `RadixPartitionedHashTable`

### DIFF
--- a/src/common/types/column/column_data_allocator.cpp
+++ b/src/common/types/column/column_data_allocator.cpp
@@ -54,12 +54,7 @@ ColumnDataAllocator::~ColumnDataAllocator() {
 	for (auto &block : blocks) {
 		block.handle->SetDestroyBufferUpon(DestroyBufferUpon::UNPIN);
 	}
-	const auto data_size = SizeInBytes();
 	blocks.clear();
-	if (Allocator::SupportsFlush() &&
-	    data_size > alloc.buffer_manager->GetBufferPool().GetAllocatorBulkDeallocationFlushThreshold()) {
-		Allocator::FlushAll();
-	}
 }
 
 BufferHandle ColumnDataAllocator::Pin(uint32_t block_id) {

--- a/src/common/types/row/tuple_data_segment.cpp
+++ b/src/common/types/row/tuple_data_segment.cpp
@@ -119,10 +119,6 @@ TupleDataSegment::~TupleDataSegment() {
 	}
 	pinned_row_handles.clear();
 	pinned_heap_handles.clear();
-	if (Allocator::SupportsFlush() && allocator &&
-	    data_size > allocator->GetBufferManager().GetBufferPool().GetAllocatorBulkDeallocationFlushThreshold()) {
-		Allocator::FlushAll();
-	}
 	allocator.reset();
 }
 

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -281,12 +281,12 @@ idx_t RadixHTConfig::GetRadixBits() const {
 }
 
 void RadixHTConfig::SetRadixBitsInternal(const idx_t radix_bits_p, bool external) {
-	if (sink_radix_bits >= radix_bits_p || sink.any_combined) {
+	if (sink_radix_bits > radix_bits_p || sink.any_combined) {
 		return;
 	}
 
 	auto guard = sink.Lock();
-	if (sink_radix_bits >= radix_bits_p || sink.any_combined) {
+	if (sink_radix_bits > radix_bits_p || sink.any_combined) {
 		return;
 	}
 


### PR DESCRIPTION
I found out that we weren't unpinning any blocks in the hash aggregation, causing us to run out of memory. This is due to the `external` flag not being set. I think this happened because I changed the partitioning code a bit when optimizing the hash aggregation before the holidays.

I've also removed some unnecessary flushes. These should already be handled properly in `standard_buffer_manager.cpp`.