### PR TITLE
Make entries field non-nullable for Arrow map type

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -73,6 +73,7 @@ void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child,
 	InitializeChild(root_holder.nested_children.back()[0], root_holder);
 	child.children = &root_holder.nested_children_ptr.back()[0];
 	child.children[0]->name = "entries";
+	child.children[0]->flags = 0; // Set the 'entries' field to non-nullable
 	SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), options, context);
 }
 


### PR DESCRIPTION
`SetArrowMapFormat` in the `ArrowConverter` would produce a schema where the nullability of the `entries` field is set to Nullable. This is actually not correct.

Without this fix the arrow produced by DuckDB causes problems when I try to feed it to the Delta Kernel, which uses arrow rust to decode our schema and then complains about this nullability being incorrect.