### PR TITLE
Parquet reader: fix for filter on file_row_number column

### DIFF
--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -776,18 +776,15 @@ void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t c
 			auto &filter = *filter_entry->second;
 
 			FilterPropagateResult prune_result;
-			if (column_reader.FileIdx() >= group.columns.size()) {
-				// generated column (e.g. file_row_number) - skip
-				return;
-			}
 			// TODO we might not have stats but STILL a bloom filter so move this up
 			// check the bloom filter if present
-			if (!column_reader.Type().IsNested() &&
+			bool is_generated_column = column_reader.FileIdx() >= group.columns.size();
+			if (!column_reader.Type().IsNested() && !is_generated_column &&
 			    ParquetStatisticsUtils::BloomFilterSupported(column_reader.Type().id()) &&
 			    ParquetStatisticsUtils::BloomFilterExcludes(filter, group.columns[column_reader.FileIdx()].meta_data,
 			                                                *state.thrift_file_proto, allocator)) {
 				prune_result = FilterPropagateResult::FILTER_ALWAYS_FALSE;
-			} else if (column_reader.Type().id() == LogicalTypeId::VARCHAR &&
+			} else if (column_reader.Type().id() == LogicalTypeId::VARCHAR && !is_generated_column &&
 			           group.columns[column_reader.FileIdx()].meta_data.statistics.__isset.min_value &&
 			           group.columns[column_reader.FileIdx()].meta_data.statistics.__isset.max_value) {
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -776,6 +776,10 @@ void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t c
 			auto &filter = *filter_entry->second;
 
 			FilterPropagateResult prune_result;
+			if (column_reader.FileIdx() >= group.columns.size()) {
+				// generated column (e.g. file_row_number) - skip
+				return;
+			}
 			// TODO we might not have stats but STILL a bloom filter so move this up
 			// check the bloom filter if present
 			if (!column_reader.Type().IsNested() &&

--- a/test/sql/copy/parquet/parquet_row_number.test
+++ b/test/sql/copy/parquet/parquet_row_number.test
@@ -13,6 +13,10 @@ select min(file_row_number), max(file_row_number), avg(file_row_number),  count(
 ----
 0	9999	4999.5	10000
 
+query I
+select l_orderkey from parquet_scan('data/parquet-testing/lineitem-top10000.gzip.parquet', file_row_number=1) where file_row_number=42;
+----
+35
 
 query III
 select sum(row_number_lag), min(row_number_lag), max(row_number_lag)  from (select file_row_number - LAG(file_row_number) OVER (ORDER BY file_row_number) as row_number_lag from parquet_scan('data/parquet-testing/lineitem-top10000.gzip.parquet', file_row_number=1));


### PR DESCRIPTION
Previously an internal exception was thrown during the stats pruning