### PR TITLE
Scan validity from dictionary vectors directly, and skip scanning validity when we encounter a dictionary vector

### DIFF
--- a/src/storage/compression/dictionary/decompression.cpp
+++ b/src/storage/compression/dictionary/decompression.cpp
@@ -43,16 +43,16 @@ void CompressedStringScanState::Initialize(ColumnSegment &segment, bool initiali
 	block_size = segment.GetBlockManager().GetBlockSize();
 
 	dict = DictionaryCompression::GetDictionary(segment, *handle);
-	dictionary = make_buffer<Vector>(segment.type, index_buffer_count);
-	dictionary_size = index_buffer_count;
-
 	if (!initialize_dictionary) {
 		// Used by fetch, as fetch will never produce a DictionaryVector
 		return;
 	}
 
+	dictionary = make_buffer<Vector>(segment.type, index_buffer_count);
+	dictionary_size = index_buffer_count;
 	auto dict_child_data = FlatVector::GetData<string_t>(*(dictionary));
-	for (uint32_t i = 0; i < index_buffer_count; i++) {
+	FlatVector::SetNull(*dictionary, 0, true);
+	for (uint32_t i = 1; i < index_buffer_count; i++) {
 		// NOTE: the passing of dict_child_vector, will not be used, its for big strings
 		uint16_t str_len = GetStringLength(i);
 		dict_child_data[i] = FetchStringFromDict(UnsafeNumericCast<int32_t>(index_buffer_ptr[i]), str_len);

--- a/src/storage/compression/roaring/common.cpp
+++ b/src/storage/compression/roaring/common.cpp
@@ -220,6 +220,10 @@ void RoaringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t sc
 }
 
 void RoaringScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	if (result.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		// dictionary encoding handles the validity itself
+		return;
+	}
 	RoaringScanPartial(segment, state, scan_count, result, 0);
 }
 

--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -401,6 +401,10 @@ void ValidityScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t s
 }
 
 void ValidityScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	if (result.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		// dictionary encoding handles the validity itself
+		return;
+	}
 	result.Flatten(scan_count);
 
 	auto start = segment.GetRelativeIndex(state.row_index);

--- a/test/sql/function/autocomplete/create_schema.test
+++ b/test/sql/function/autocomplete/create_schema.test
@@ -24,6 +24,8 @@ FROM sql_auto_complete('CREATE SCHEMA IF NOT EX') LIMIT 1;
 ----
 EXISTS 	21
 
+require skip_reload
+
 # attached database
 # suggest a catalog
 statement ok

--- a/test/sql/function/autocomplete/create_table.test
+++ b/test/sql/function/autocomplete/create_table.test
@@ -109,6 +109,8 @@ FROM sql_auto_complete('CREATE TABLE SC') LIMIT 1;
 ----
 "SCHEMA".	13
 
+require skip_reload
+
 # suggest a catalog
 statement ok
 ATTACH ':memory:' AS attached_in_memory;


### PR DESCRIPTION
This prevents unnecessarily flattening dictionary vectors when scanning.

The two test changes are unrelated but just minor fixes from issues encountered while testing this change.

CC @Tishj 