### PR TITLE
Initialize create_index_info.catalog

### DIFF
--- a/src/planner/expression_binder/index_binder.cpp
+++ b/src/planner/expression_binder/index_binder.cpp
@@ -62,6 +62,7 @@ void IndexBinder::InitCreateIndexInfo(LogicalGet &get, CreateIndexInfo &info, co
 	info.scan_types.emplace_back(LogicalType::ROW_TYPE);
 	info.names = get.names;
 	info.schema = schema;
+	info.catalog = get.GetTable()->catalog.GetName();
 	get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
 }
 


### PR DESCRIPTION
`IndexBinder::BindCreateIndex` makes it easier for other `Catalog` implementors to implement `BindCreateIndex`.

However, it does not set the `catalog` field of the resulting `CreateIndexInfo`.
This PR fixes that by propagating the catalog name of the underlying table that the index is created from.


Note that `BindCreateIndex` can correctly handle cases where `create_index_info->catalog` is set and cases in which it is unset, as seen in
```
	auto &catalog = Catalog::GetCatalog(context, create_index_info->catalog);
```

I do not know of cases where `create_index_info->catalog` is set already when entering the method, but we could wrap my suggested change with an `if (info.catalog.emtpy())` branch for safety if you prefer.