### PR TITLE
If arrow extension is not registered, use format information instead of failing

### DIFF
--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -6,7 +6,6 @@
 #include "duckdb/common/arrow/arrow_converter.hpp"
 #include "duckdb/common/arrow/schema_metadata.hpp"
 #include "duckdb/common/types/vector.hpp"
-#include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
 
 namespace duckdb {
 

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -6,12 +6,18 @@
 #include "duckdb/common/arrow/arrow_converter.hpp"
 #include "duckdb/common/arrow/schema_metadata.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
 
 namespace duckdb {
 
 ArrowTypeExtension::ArrowTypeExtension(string extension_name, string arrow_format,
                                        shared_ptr<ArrowTypeExtensionData> type)
     : extension_metadata(std::move(extension_name), {}, {}, std::move(arrow_format)), type_extension(std::move(type)) {
+}
+
+ArrowTypeExtension::ArrowTypeExtension(ArrowExtensionMetadata &extension_metadata, unique_ptr<ArrowType> type)
+    : extension_metadata(extension_metadata) {
+	type_extension = make_shared_ptr<ArrowTypeExtensionData>(type->GetDuckType());
 }
 
 ArrowExtensionMetadata::ArrowExtensionMetadata(string extension_name, string vendor_name, string type_name,
@@ -197,10 +203,12 @@ ArrowTypeExtension GetArrowExtensionInternal(
     unordered_map<ArrowExtensionMetadata, ArrowTypeExtension, HashArrowTypeExtension> &type_extensions,
     ArrowExtensionMetadata info) {
 	if (type_extensions.find(info) == type_extensions.end()) {
+		auto og_info = info;
 		info.SetArrowFormat("");
 		if (type_extensions.find(info) == type_extensions.end()) {
-			throw NotImplementedException("Arrow Extension with configuration:\n%s not yet registered",
-			                              info.ToString());
+			auto format = og_info.GetArrowFormat();
+			auto type = ArrowType::GetTypeFromFormat(format);
+			return ArrowTypeExtension(og_info, std::move(type));
 		}
 	}
 	return type_extensions[info];

--- a/src/common/arrow/schema_metadata.cpp
+++ b/src/common/arrow/schema_metadata.cpp
@@ -66,7 +66,7 @@ ArrowSchemaMetadata ArrowSchemaMetadata::NonCanonicalType(const string &type_nam
 
 bool ArrowSchemaMetadata::HasExtension() const {
 	auto arrow_extension = GetOption(ArrowSchemaMetadata::ARROW_EXTENSION_NAME);
-	return !arrow_extension.empty() && !StringUtil::StartsWith(arrow_extension, "ogc");
+	return !arrow_extension.empty();
 }
 
 ArrowExtensionMetadata ArrowSchemaMetadata::GetExtensionInfo(string format) {

--- a/src/function/table/arrow/arrow_duck_schema.cpp
+++ b/src/function/table/arrow/arrow_duck_schema.cpp
@@ -56,7 +56,7 @@ void ArrowType::ThrowIfInvalid() const {
 	}
 }
 
-unique_ptr<ArrowType> ArrowType::GetTypeFromFormat(DBConfig &config, ArrowSchema &schema, string &format) {
+unique_ptr<ArrowType> ArrowType::GetTypeFromFormat(string &format) {
 	if (format == "n") {
 		return make_uniq<ArrowType>(LogicalType::SQLNULL);
 	} else if (format == "b") {
@@ -178,6 +178,14 @@ unique_ptr<ArrowType> ArrowType::GetTypeFromFormat(DBConfig &config, ArrowSchema
 			throw NotImplementedException(" Timestamptz precision of not accepted");
 		}
 		return make_uniq<ArrowType>(LogicalType::TIMESTAMP_TZ, std::move(type_info));
+	}
+	return nullptr;
+}
+
+unique_ptr<ArrowType> ArrowType::GetTypeFromFormat(DBConfig &config, ArrowSchema &schema, string &format) {
+	auto type = GetTypeFromFormat(format);
+	if (type) {
+		return type;
 	}
 	if (format == "+l") {
 		return CreateListType(config, *schema.children[0], ArrowVariableSizeType::NORMAL, false);

--- a/src/include/duckdb/common/arrow/arrow_type_extension.hpp
+++ b/src/include/duckdb/common/arrow/arrow_type_extension.hpp
@@ -70,6 +70,8 @@ typedef shared_ptr<ArrowType> (*get_type_t)(const ArrowSchema &schema, const Arr
 class ArrowTypeExtension {
 public:
 	ArrowTypeExtension() {};
+	//! This type is not registered, so we just use whatever is the format and hope for the best
+	explicit ArrowTypeExtension(ArrowExtensionMetadata &extension_metadata, unique_ptr<ArrowType> type);
 	//! We either have simple extensions where we only return one type
 	ArrowTypeExtension(string extension_name, string arrow_format, shared_ptr<ArrowTypeExtensionData> type);
 	ArrowTypeExtension(string vendor_name, string type_name, string arrow_format,

--- a/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
+++ b/src/include/duckdb/function/table/arrow/arrow_duck_schema.hpp
@@ -84,6 +84,7 @@ public:
 	}
 	void ThrowIfInvalid() const;
 
+	static unique_ptr<ArrowType> GetTypeFromFormat(string &format);
 	static unique_ptr<ArrowType> GetTypeFromFormat(DBConfig &config, ArrowSchema &schema, string &format);
 
 	static unique_ptr<ArrowType> GetTypeFromSchema(DBConfig &config, ArrowSchema &schema);

--- a/tools/pythonpkg/tests/fast/arrow/test_arrow_extensions.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_arrow_extensions.py
@@ -134,8 +134,8 @@ class TestCanonicalExtensionTypes(object):
 
         arrow_table = pa.Table.from_arrays([storage_array, age_array], names=['pedro_pedro_pedro', 'age'])
 
-        with pytest.raises(duckdb.NotImplementedException, match="pedro.binary"):
-            duck_arrow = duckdb_cursor.execute('FROM arrow_table').arrow()
+        duck_arrow = duckdb_cursor.execute('FROM arrow_table').arrow()
+        assert duckdb_cursor.execute('FROM duck_arrow').fetchall() == [(b'pedro', 29)]
 
     def test_hugeint(self):
         con = duckdb.connect()


### PR DESCRIPTION
Fix: https://github.com/duckdblabs/duckdb-internal/issues/3978