### PR TITLE
Switch logging to macros

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -842,7 +842,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	flags.Verify();
 
 	if (opener) {
-		Logger::Info("duckdb.FileSystem.LocalFileSystem.OpenFile", *opener, path_p);
+		DUCKDB_LOG_INFO(*opener, "duckdb.FileSystem.LocalFileSystem.OpenFile", path_p);
 	}
 
 	DWORD desired_access;

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -302,7 +302,7 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	}
 
 	if (opener) {
-		Logger::Info("duckdb.FileSystem.LocalFileSystem.OpenFile", *opener, path_p);
+		DUCKDB_LOG_INFO(*opener, "duckdb.FileSystem.LocalFileSystem.OpenFile", path_p);
 	}
 
 	flags.Verify();

--- a/src/function/scalar/system/write_log.cpp
+++ b/src/function/scalar/system/write_log.cpp
@@ -114,11 +114,11 @@ static void WriteLogValues(T &LogSource, LogLevel level, const string_t *data, c
                            const string &type) {
 	if (!type.empty()) {
 		for (idx_t i = 0; i < size; i++) {
-			Logger::Log(type.c_str(), LogSource, level, data[sel->get_index(i)]);
+			DUCKDB_LOG(LogSource, type.c_str(), level, data[sel->get_index(i)]);
 		}
 	} else {
 		for (idx_t i = 0; i < size; i++) {
-			Logger::Log(LogSource, level, data[sel->get_index(i)]);
+			DUCKDB_LOG(LogSource, type.c_str(), level, data[sel->get_index(i)]);
 		}
 	}
 }

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -218,7 +218,7 @@ void ClientContext::BeginQueryInternal(ClientContextLock &lock, const string &qu
 	context.client_context = reinterpret_cast<idx_t>(this);
 	context.transaction_id = transaction.GetActiveQuery();
 	logger = db->GetLogManager().CreateLogger(context, true);
-	Logger::Info("duckdb.ClientContext.BeginQuery", *this, query);
+	DUCKDB_LOG_INFO(*this, "duckdb.ClientContext.BeginQuery", query);
 }
 
 ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success, bool invalidate_transaction,

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -509,7 +509,7 @@ void DatabaseInstance::SetExtensionLoaded(const string &name, ExtensionInstallIn
 	for (auto &callback : callbacks) {
 		callback->OnExtensionLoaded(*this, name);
 	}
-	Logger::Info("duckdb.Extensions.ExtensionLoaded", *this, name);
+	DUCKDB_LOG_INFO(*this, "duckdb.Extensions.ExtensionLoaded", name);
 }
 
 SettingLookupResult DatabaseInstance::TryGetCurrentSetting(const std::string &key, Value &result) const {

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -389,7 +389,7 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 		}
 #endif
 		ExtensionHelper::LoadExternalExtension(db, *fs, extension_name);
-		Logger::Info("duckdb.Extensions.ExtensionAutoloaded", db, extension_name);
+		DUCKDB_LOG_INFO(db, "duckdb.Extensions.ExtensionAutoloaded", extension_name);
 
 	} catch (std::exception &e) {
 		ErrorData error(e);

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -250,9 +250,9 @@ vector<CheckpointAnalyzeResult> ColumnDataCheckpointer::DetectBestCompressionMet
 		D_ASSERT(compression_idx != DConstants::INVALID_INDEX);
 
 		auto &best_function = *functions[compression_idx];
-		Logger::Info(db, "FinalAnalyze(%s) result for %s.%s.%d(%s): %d", EnumUtil::ToString(best_function.type),
-		             col_data.info.GetSchemaName(), col_data.info.GetTableName(), col_data.column_index,
-		             col_data.type.ToString(), best_score);
+		DUCKDB_LOG_INFO(db, "duckdb.ColumnDataCheckPointer", "FinalAnalyze(%s) result for %s.%s.%d(%s): %d",
+		                EnumUtil::ToString(best_function.type), col_data.info.GetSchemaName(),
+		                col_data.info.GetTableName(), col_data.column_index, col_data.type.ToString(), best_score);
 		result[i] = CheckpointAnalyzeResult(std::move(chosen_state), best_function);
 	}
 	return result;

--- a/third_party/re2/util/logging.h
+++ b/third_party/re2/util/logging.h
@@ -34,26 +34,26 @@
 #define CHECK_EQ(x, y)	CHECK((x) == (y))
 #define CHECK_NE(x, y)	CHECK((x) != (y))
 
-#define LOG_INFO LogMessage(__FILE__, __LINE__)
-#define LOG_WARNING LogMessage(__FILE__, __LINE__)
-#define LOG_ERROR LogMessage(__FILE__, __LINE__)
-#define LOG_FATAL LogMessageFatal(__FILE__, __LINE__)
-#define LOG_QFATAL LOG_FATAL
+#define RE2_LOG_INFO LogMessage(__FILE__, __LINE__)
+#define RE2_LOG_WARNING LogMessage(__FILE__, __LINE__)
+#define RE2_LOG_ERROR LogMessage(__FILE__, __LINE__)
+#define RE2_LOG_FATAL LogMessageFatal(__FILE__, __LINE__)
+#define RE2_LOG_QFATAL RE2_LOG_FATAL
 
 // It seems that one of the Windows header files defines ERROR as 0.
 #ifdef _WIN32
-#define LOG_0 LOG_INFO
+#define LOG_0 RE2_LOG_INFO
 #endif
 
 #ifdef NDEBUG
-#define LOG_DFATAL LOG_ERROR
+#define RE2_LOG_DFATAL RE2_LOG_ERROR
 #else
-#define LOG_DFATAL LOG_FATAL
+#define RE2_LOG_DFATAL RE2_LOG_FATAL
 #endif
 
-#define LOG(severity) LOG_ ## severity.stream()
+#define LOG(severity) RE2_LOG_ ## severity.stream()
 
-#define VLOG(x) if((x)>0){}else LOG_INFO.stream()
+#define VLOG(x) if((x)>0){}else RE2_LOG_INFO.stream()
 
 class LogMessage {
  public:


### PR DESCRIPTION
@hannes ran into an issue where `logger.hpp` would not compile on gcc4.8 due to the variadic template params in the lambda here:
```C++
//! Logger::Log with StringUtil::Format
template <class T, typename... ARGS>
static void Log(const char *log_type, T &log_context_source, LogLevel log_level, const char *format_string,
                ARGS... params) {
    Logger::Get(log_context_source).Log(log_type, log_level, [&]() {
        return StringUtil::Format(format_string, params...);
    });
}
```

This triggered me because I realized that the lambdas were causing allocations even when logging was disabled. The solution is to remove the `Log` methods alltogether and use macros to call `ShouldLog` and `WriteLog` directly:

```C++
//! Logger Macro's are preferred method of calling logger
#define DUCKDB_LOG(SOURCE, TYPE, LEVEL, ...)                                                                 \
	{                                                                                                                                          \ 
		auto &logger = Logger::Get(SOURCE);                                                                            \
		if (logger.ShouldLog(TYPE, LEVEL)) {                                                                           \
			logger.WriteLog(TYPE, LEVEL, __VA_ARGS__);                                                                 \
		}                                                                                                              \
	}
```
This way you can simply pass any expression that returns a string, which will then only get executed if logging is actually enabled, for example:
```C++
DUCKDB_LOG_INFO(*this, "duckdb.Extensions.ExtensionLoaded", CallExpensiveStringGenerationFunction());
```
No more finnicking with lambdas and the function is only called when we are actually writing to the log

While doing all this I also decided to remove all logging functions without a log type: I think having no log type is bad practice, at the very least every log entry should have either `duckdb` or `<extension_name>`.