### PR TITLE
Add `disabled_compression_methods` setting that can be used to disable certain compression methods

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -266,6 +266,13 @@
         "custom_implementation": true
     },
     {
+        "name": "disabled_compression_methods",
+        "description": "Disable a specific set of compression methods (comma separated)",
+        "type": "VARCHAR",
+        "scope": "global",
+        "custom_implementation": true
+    },
+    {
         "name": "disabled_filesystems",
         "description": "Disable specific file systems preventing access (e.g. LocalFileSystem)",
         "type": "VARCHAR",

--- a/src/function/compression_config.cpp
+++ b/src/function/compression_config.cpp
@@ -65,6 +65,10 @@ static optional_ptr<CompressionFunction> LoadCompressionFunction(CompressionFunc
 
 static void TryLoadCompression(DBConfig &config, vector<reference<CompressionFunction>> &result, CompressionType type,
                                const PhysicalType physical_type) {
+	if (config.options.disabled_compression_methods.find(type) != config.options.disabled_compression_methods.end()) {
+		// explicitly disabled
+		return;
+	}
 	auto function = config.GetCompressionFunction(type, physical_type);
 	if (!function) {
 		return;

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -202,6 +202,8 @@ struct DBConfigOptions {
 	uint64_t zstd_min_string_length = 4096;
 	//! Force a specific compression method to be used when checkpointing (if available)
 	CompressionType force_compression = CompressionType::COMPRESSION_AUTO;
+	//! The set of disabled compression methods (default empty)
+	set<CompressionType> disabled_compression_methods;
 	//! Force a specific bitpacking mode to be used when using the bitpacking compression method
 	BitpackingMode force_bitpacking_mode = BitpackingMode::AUTO;
 	//! Debug setting for window aggregation mode: (window, combine, separate)

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -419,6 +419,16 @@ struct DefaultSecretStorageSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct DisabledCompressionMethodsSetting {
+	using RETURN_TYPE = string;
+	static constexpr const char *Name = "disabled_compression_methods";
+	static constexpr const char *Description = "Disable a specific set of compression methods (comma separated)";
+	static constexpr const char *InputType = "VARCHAR";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct DisabledFilesystemsSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "disabled_filesystems";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -92,6 +92,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL_ALIAS("null_order", DefaultNullOrderSetting),
     DUCKDB_GLOBAL(DefaultOrderSetting),
     DUCKDB_GLOBAL(DefaultSecretStorageSetting),
+    DUCKDB_GLOBAL(DisabledCompressionMethodsSetting),
     DUCKDB_GLOBAL(DisabledFilesystemsSetting),
     DUCKDB_GLOBAL(DisabledLogTypes),
     DUCKDB_GLOBAL(DisabledOptimizersSetting),

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -51,7 +51,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"default_collation", {"nocase"}},
 	    {"default_order", {"desc"}},
 	    {"default_null_order", {"nulls_first"}},
-	    {"disabled_compression_methods", {"rle"}},
+	    {"disabled_compression_methods", {"RLE"}},
 	    {"disabled_optimizers", {"extension"}},
 	    {"debug_force_external", {Value(true)}},
 	    {"old_implicit_casting", {Value(true)}},

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -51,6 +51,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"default_collation", {"nocase"}},
 	    {"default_order", {"desc"}},
 	    {"default_null_order", {"nulls_first"}},
+	    {"disabled_compression_methods", {"rle"}},
 	    {"disabled_optimizers", {"extension"}},
 	    {"debug_force_external", {Value(true)}},
 	    {"old_implicit_casting", {Value(true)}},

--- a/test/sql/pragma/test_disabled_compression.test
+++ b/test/sql/pragma/test_disabled_compression.test
@@ -1,0 +1,23 @@
+# name: test/sql/pragma/test_disabled_compression.test
+# description: Test PRAGMA force_compression
+# group: [pragma]
+
+foreach compression rle dictionary bitpacking fsst
+
+statement ok
+PRAGMA disabled_compression_methods='${compression}'
+
+endloop
+
+statement error
+PRAGMA disabled_compression_methods='uncompressed,rle'
+----
+Uncompressed compression cannot be disabled
+
+statement ok
+PRAGMA disabled_compression_methods='dictionary,rle'
+
+statement error
+PRAGMA disabled_compression_methods='xzx'
+----
+Unrecognized compression method

--- a/test/sql/storage/compression/fsst/fsst_disable_compression.test
+++ b/test/sql/storage/compression/fsst/fsst_disable_compression.test
@@ -1,0 +1,29 @@
+# name: test/sql/storage/compression/fsst/fsst_disable_compression.test
+# description: Test disabling compresison
+# group: [fsst]
+
+# load the DB from disk
+load __TEST_DIR__/test_disabled_compression_methods.db
+
+statement ok
+CREATE TABLE test AS SELECT concat('longprefix', i) FROM range(30000) t(i);
+
+query I
+SELECT BOOL_OR(compression ILIKE '%fsst%') FROM pragma_storage_info('test')
+----
+true
+
+statement ok
+DROP TABLE test
+
+statement ok
+SET disabled_compression_methods='fsst'
+
+# verify FSST is disabled
+statement ok
+CREATE TABLE test AS SELECT concat('longprefix', i) FROM range(30000) t(i);
+
+query I
+SELECT BOOL_OR(compression ILIKE '%fsst%') FROM pragma_storage_info('test')
+----
+false


### PR DESCRIPTION
This setting is similar to `force_compression`, but does the inverse - it prevents a compression method from being selected.

Usage:

```sql
SET disabled_compression_methods='fsst';
SET disabled_compression_methods='fsst,rle';
```