### PR TITLE
Absorb 2 wasm patches

### DIFF
--- a/src/include/duckdb/main/client_properties.hpp
+++ b/src/include/duckdb/main/client_properties.hpp
@@ -26,6 +26,7 @@ struct ClientProperties {
 	      arrow_use_list_view(arrow_use_list_view_p), produce_arrow_string_view(produce_arrow_string_view_p),
 	      arrow_lossless_conversion(lossless_conversion), client_context(client_context) {
 	}
+	ClientProperties() = default;
 
 	string time_zone = "UTC";
 	ArrowOffsetSize arrow_offset_size = ArrowOffsetSize::REGULAR;

--- a/third_party/fmt/include/fmt/format.h
+++ b/third_party/fmt/include/fmt/format.h
@@ -548,7 +548,7 @@ class u8string_view : public basic_string_view<fmt_char8_t> {
 
 #if FMT_USE_USER_DEFINED_LITERALS
 inline namespace literals {
-inline u8string_view operator"" _u(const char* s, std::size_t n) {
+inline u8string_view operator""_u(const char* s, std::size_t n) {
   return {s, n};
 }
 }  // namespace literals
@@ -3342,11 +3342,11 @@ FMT_CONSTEXPR internal::udl_formatter<Char, CHARS...> operator""_format() {
     std::string message = "The answer is {}"_format(42);
   \endrst
  */
-FMT_CONSTEXPR internal::udl_formatter<char> operator"" _format(const char* s,
+FMT_CONSTEXPR internal::udl_formatter<char> operator""_format(const char* s,
                                                                std::size_t n) {
   return {{s, n}};
 }
-FMT_CONSTEXPR internal::udl_formatter<wchar_t> operator"" _format(
+FMT_CONSTEXPR internal::udl_formatter<wchar_t> operator""_format(
     const wchar_t* s, std::size_t n) {
   return {{s, n}};
 }
@@ -3362,11 +3362,11 @@ FMT_CONSTEXPR internal::udl_formatter<wchar_t> operator"" _format(
     fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
-FMT_CONSTEXPR internal::udl_arg<char> operator"" _a(const char* s,
+FMT_CONSTEXPR internal::udl_arg<char> operator""_a(const char* s,
                                                     std::size_t n) {
   return {{s, n}};
 }
-FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
+FMT_CONSTEXPR internal::udl_arg<wchar_t> operator""_a(const wchar_t* s,
                                                        std::size_t n) {
   return {{s, n}};
 }


### PR DESCRIPTION
Two unconnected simple changes:
* adding a default constructor to ClientProperties, given all it's properties are trivially constructible should be easy.
* c++17, used in the duckdb-wasm codebase, throws warnings that are better silenced (https://en.cppreference.com/w/cpp/language/user_literal is not super clear, but `""` followed by space is deprecated, see section on 'Literal operators')