### PR TITLE
Fix minor DuckDB-Wasm problem with stacktraces, that would be shown twice

### DIFF
--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -121,8 +121,9 @@ void ErrorData::AddErrorLocation(const string &query) {
 	}
 	{
 		auto entry = extra_info.find("stack_trace");
-		if (entry != extra_info.end()) {
+		if (entry != extra_info.end() && !entry->second.empty()) {
 			raw_message += "\n\nStack Trace:\n" + entry->second;
+			entry->second = "";
 		}
 	}
 	final_message = ConstructFinalMessage();


### PR DESCRIPTION
Also handle the fact that empty stacktraces (say Windows or DuckDB-Wasm) should not be shown.

I don't really have a show / test this behaviour. That's a cool TODO, not for today