### PR TITLE
When loading LogicalDependency from a database file or WAL file, modify the catalog to the catalog that we are loading into

### DIFF
--- a/scripts/generate_serialization.py
+++ b/scripts/generate_serialization.py
@@ -141,6 +141,7 @@ SWITCH_CODE_FORMAT = '''\tswitch ({switch_variable}) {{
 SET_DESERIALIZE_PARAMETER_FORMAT = '\tdeserializer.Set<{property_type}>({property_name});\n'
 UNSET_DESERIALIZE_PARAMETER_FORMAT = '\tdeserializer.Unset<{property_type}>();\n'
 GET_DESERIALIZE_PARAMETER_FORMAT = 'deserializer.Get<{property_type}>()'
+TRY_GET_DESERIALIZE_PARAMETER_FORMAT = 'deserializer.TryGet<{property_type}>()'
 
 SWITCH_HEADER_FORMAT = '\tcase {enum_type}::{enum_value}:\n'
 
@@ -166,7 +167,7 @@ MOVE_LIST = [
     'BoundLimitNode',
 ]
 
-REFERENCE_LIST = ['ClientContext', 'bound_parameter_map_t']
+REFERENCE_LIST = ['ClientContext', 'bound_parameter_map_t', 'Catalog']
 
 
 def is_container(type):
@@ -621,13 +622,19 @@ def generate_class_code(class_entry):
                         constructor_parameters += entry.deserialize_property
                     found = True
                     break
-            if constructor_entry.startswith('$'):
+            if constructor_entry.startswith('$') or constructor_entry.startswith('?'):
                 if len(constructor_parameters) > 0:
                     constructor_parameters += ", "
-                param_type = constructor_entry.replace('$', '')
-                if param_type in REFERENCE_LIST:
-                    param_type += ' &'
-                constructor_parameters += GET_DESERIALIZE_PARAMETER_FORMAT.format(property_type=param_type)
+                is_optional = constructor_entry.startswith('?')
+                if is_optional:
+                    param_type = constructor_entry.replace('?', '')
+                    get_format = TRY_GET_DESERIALIZE_PARAMETER_FORMAT
+                else:
+                    param_type = constructor_entry.replace('$', '')
+                    get_format = GET_DESERIALIZE_PARAMETER_FORMAT
+                    if param_type in REFERENCE_LIST:
+                        param_type += ' &'
+                constructor_parameters += get_format.format(property_type=param_type)
                 found = True
             if class_entry.base_object is not None:
                 for entry in class_entry.base_object.set_parameters:

--- a/src/catalog/dependency_list.cpp
+++ b/src/catalog/dependency_list.cpp
@@ -61,6 +61,13 @@ LogicalDependency::LogicalDependency(CatalogEntry &entry) {
 	}
 }
 
+LogicalDependency::LogicalDependency(optional_ptr<Catalog> catalog_p, CatalogEntryInfo entry_p, string catalog_str)
+    : entry(std::move(entry_p)), catalog(std::move(catalog_str)) {
+	if (catalog_p) {
+		catalog = catalog_p->GetName();
+	}
+}
+
 bool LogicalDependency::operator==(const LogicalDependency &other) const {
 	return other.entry.name == entry.name && other.entry.schema == entry.schema && other.entry.type == entry.type;
 }

--- a/src/include/duckdb/catalog/dependency_list.hpp
+++ b/src/include/duckdb/catalog/dependency_list.hpp
@@ -31,6 +31,7 @@ public:
 public:
 	explicit LogicalDependency(CatalogEntry &entry);
 	LogicalDependency();
+	LogicalDependency(optional_ptr<Catalog> catalog, CatalogEntryInfo entry, string catalog_str);
 	bool operator==(const LogicalDependency &other) const;
 
 public:

--- a/src/include/duckdb/common/serializer/deserializer.hpp
+++ b/src/include/duckdb/common/serializer/deserializer.hpp
@@ -159,6 +159,11 @@ public:
 		return data.Get<T>();
 	}
 
+	template <class T>
+	optional_ptr<T> TryGet() {
+		return data.TryGet<T>();
+	}
+
 	//! Unset a serialization property
 	template <class T>
 	void Unset() {

--- a/src/include/duckdb/common/serializer/serialization_data.hpp
+++ b/src/include/duckdb/common/serializer/serialization_data.hpp
@@ -30,6 +30,7 @@ struct SerializationData {
 
 	stack<reference<ClientContext>> contexts;
 	stack<reference<DatabaseInstance>> databases;
+	stack<reference<Catalog>> catalogs;
 	stack<idx_t> enums;
 	stack<reference<bound_parameter_map_t>> parameter_data;
 	stack<const_reference<LogicalType>> types;
@@ -41,6 +42,9 @@ struct SerializationData {
 
 	template <class T>
 	T Get() = delete;
+
+	template <class T>
+	optional_ptr<T> TryGet() = delete;
 
 	template <class T>
 	void Unset() = delete;
@@ -163,6 +167,27 @@ inline void SerializationData::Unset<ClientContext>() {
 	contexts.pop();
 }
 
+template <>
+inline void SerializationData::Set(Catalog &catalog) {
+	catalogs.emplace(catalog);
+}
+
+template <>
+inline Catalog &SerializationData::Get() {
+	AssertNotEmpty(catalogs);
+	return catalogs.top();
+}
+
+template <>
+inline optional_ptr<Catalog> SerializationData::TryGet() {
+	return catalogs.empty() ? nullptr : &catalogs.top().get();
+}
+
+template <>
+inline void SerializationData::Unset<Catalog>() {
+	AssertNotEmpty(catalogs);
+	catalogs.pop();
+}
 template <>
 inline void SerializationData::Set(DatabaseInstance &db) {
 	databases.emplace(db);

--- a/src/include/duckdb/storage/serialization/dependency.json
+++ b/src/include/duckdb/storage/serialization/dependency.json
@@ -40,7 +40,8 @@
 				"type": "string"
 			}
 		],
-		"pointer_type": "none"
+		"pointer_type": "none",
+		"constructor": ["?Catalog", "entry", "catalog"]
 	},
 	{
 		"class": "LogicalDependencyList",

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -259,11 +259,13 @@ void SingleFileCheckpointWriter::CreateCheckpoint() {
 
 void CheckpointReader::LoadCheckpoint(CatalogTransaction transaction, MetadataReader &reader) {
 	BinaryDeserializer deserializer(reader);
+	deserializer.Set<Catalog &>(catalog);
 	deserializer.Begin();
 	deserializer.ReadList(100, "catalog_entries", [&](Deserializer::List &list, idx_t i) {
 		return list.ReadObject([&](Deserializer &obj) { ReadEntry(transaction, obj); });
 	});
 	deserializer.End();
+	deserializer.Unset<Catalog>();
 }
 
 MetadataManager &SingleFileCheckpointReader::GetMetadataManager() {

--- a/src/storage/serialization/serialize_dependency.cpp
+++ b/src/storage/serialization/serialize_dependency.cpp
@@ -30,9 +30,9 @@ void LogicalDependency::Serialize(Serializer &serializer) const {
 }
 
 LogicalDependency LogicalDependency::Deserialize(Deserializer &deserializer) {
-	LogicalDependency result;
-	deserializer.ReadProperty<CatalogEntryInfo>(100, "entry", result.entry);
-	deserializer.ReadPropertyWithDefault<string>(101, "catalog", result.catalog);
+	auto entry = deserializer.ReadProperty<CatalogEntryInfo>(100, "entry");
+	auto catalog = deserializer.ReadPropertyWithDefault<string>(101, "catalog");
+	LogicalDependency result(deserializer.TryGet<Catalog>(), entry, std::move(catalog));
 	return result;
 }
 

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -50,11 +50,13 @@ public:
 	WriteAheadLogDeserializer(ReplayState &state_p, BufferedFileReader &stream_p, bool deserialize_only = false)
 	    : state(state_p), db(state.db), context(state.context), catalog(state.catalog), data(nullptr),
 	      stream(nullptr, 0), deserializer(stream_p), deserialize_only(deserialize_only) {
+		deserializer.Set<Catalog &>(catalog);
 	}
 	WriteAheadLogDeserializer(ReplayState &state_p, unique_ptr<data_t[]> data_p, idx_t size,
 	                          bool deserialize_only = false)
 	    : state(state_p), db(state.db), context(state.context), catalog(state.catalog), data(std::move(data_p)),
 	      stream(data.get(), size), deserializer(stream), deserialize_only(deserialize_only) {
+		deserializer.Set<Catalog &>(catalog);
 	}
 
 	static WriteAheadLogDeserializer Open(ReplayState &state_p, BufferedFileReader &stream,

--- a/test/sql/attach/attach_serialize_dependency.test
+++ b/test/sql/attach/attach_serialize_dependency.test
@@ -1,0 +1,63 @@
+# name: test/sql/attach/attach_serialize_dependency.test
+# description: Test attach and re-attach with serialized dependencies
+# group: [attach]
+
+require skip_reload
+
+statement ok
+set storage_compatibility_version='latest';
+
+statement ok
+attach '__TEST_DIR__/db1.db';
+
+statement ok
+use db1;
+
+statement ok
+CREATE TABLE A (A1 INTEGER PRIMARY KEY,A2 VARCHAR, A3 INTEGER);
+
+statement ok
+CREATE INDEX A_index ON A (A2);
+
+statement ok
+CREATE TABLE B(B1 INTEGER REFERENCES A(A1));
+
+statement ok
+use memory;
+
+statement ok
+detach db1;
+
+statement ok
+attach '__TEST_DIR__/db1.db' as other_db;
+
+# now test with a WAL
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+statement ok
+attach '__TEST_DIR__/db2.db';
+
+statement ok
+use db2;
+
+statement ok
+CREATE TABLE A (A1 INTEGER PRIMARY KEY,A2 VARCHAR, A3 INTEGER);
+
+statement ok
+CREATE INDEX A_index ON A (A2);
+
+statement ok
+CREATE TABLE B(B1 INTEGER REFERENCES A(A1));
+
+statement ok
+use memory;
+
+statement ok
+detach db2;
+
+statement ok
+attach '__TEST_DIR__/db2.db' as other_db2;

--- a/test/sql/attach/attach_serialize_dependency.test
+++ b/test/sql/attach/attach_serialize_dependency.test
@@ -2,7 +2,7 @@
 # description: Test attach and re-attach with serialized dependencies
 # group: [attach]
 
-require skip_reload
+require noforcestorage
 
 statement ok
 set storage_compatibility_version='latest';


### PR DESCRIPTION
Fixes an issue where attaching a database with dependencies under a different name would fail