### PR TITLE
[Fix] Fix truncate + FK internal exception and another index bug

### DIFF
--- a/src/include/duckdb/parser/constraint.hpp
+++ b/src/include/duckdb/parser/constraint.hpp
@@ -44,6 +44,15 @@ struct ForeignKeyInfo {
 	vector<PhysicalIndex> pk_keys;
 	//! The set of foreign key table's column's index
 	vector<PhysicalIndex> fk_keys;
+
+	bool IsDeleteConstraint() const {
+		return type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE ||
+		       type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
+	}
+	bool IsAppendConstraint() const {
+		return type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
+		       type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
+	}
 };
 
 //! Constraint is the base class of any type of table constraint.

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -206,7 +206,6 @@ public:
 	idx_t GetTotalRows() const;
 
 	vector<ColumnSegmentInfo> GetColumnSegmentInfo();
-	static bool IsForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, Index &index, ForeignKeyType fk_type);
 
 	//! Scans the next chunk for the CREATE INDEX operator
 	bool CreateIndexScan(TableScanState &state, DataChunk &result, TableScanType type);
@@ -259,16 +258,20 @@ private:
 	void VerifyUpdateConstraints(ConstraintState &state, ClientContext &context, DataChunk &chunk,
 	                             const vector<PhysicalIndex> &column_ids);
 	//! Verify constraints with a chunk from the Delete containing all columns of the table
-	void VerifyDeleteConstraints(TableDeleteState &state, ClientContext &context, DataChunk &chunk);
+	void VerifyDeleteConstraints(optional_ptr<LocalTableStorage> storage, TableDeleteState &state,
+	                             ClientContext &context, DataChunk &chunk);
 
 	void InitializeScanWithOffset(DuckTransaction &transaction, TableScanState &state,
 	                              const vector<StorageIndex> &column_ids, idx_t start_row, idx_t end_row);
 
-	void VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context, DataChunk &chunk,
-	                                VerifyExistenceType verify_type);
-	void VerifyAppendForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
+	void VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
+	                                const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
+	                                DataChunk &chunk, VerifyExistenceType type);
+	void VerifyAppendForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
+	                                      const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
 	                                      DataChunk &chunk);
-	void VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
+	void VerifyDeleteForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
+	                                      const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
 	                                      DataChunk &chunk);
 
 private:

--- a/src/include/duckdb/storage/table/table_index_list.hpp
+++ b/src/include/duckdb/storage/table/table_index_list.hpp
@@ -16,7 +16,7 @@
 namespace duckdb {
 
 class ConflictManager;
-
+class LocalTableStorage;
 struct IndexStorageInfo;
 struct DataTableInfo;
 
@@ -78,17 +78,19 @@ public:
 	//! Overwrite this list with the other list.
 	void Move(TableIndexList &other);
 	//! Find the foreign key matching the keys.
-	Index *FindForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, const ForeignKeyType fk_type);
+	optional_ptr<Index> FindForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, const ForeignKeyType fk_type);
 	//! Verify a foreign key constraint.
-	void VerifyForeignKey(const vector<PhysicalIndex> &fk_keys, DataChunk &chunk, ConflictManager &conflict_manager);
+	void VerifyForeignKey(optional_ptr<LocalTableStorage> storage, const vector<PhysicalIndex> &fk_keys,
+	                      DataChunk &chunk, ConflictManager &conflict_manager);
 	//! Get the combined column ids of the indexes in this list.
 	unordered_set<column_t> GetRequiredColumns();
 	//! Serialize all indexes of this table.
 	vector<IndexStorageInfo> GetStorageInfos(const case_insensitive_map_t<Value> &options);
 
 private:
+	//! A lock to prevent any concurrent changes to the indexes.
 	mutex indexes_lock;
-	// Indexes associated with the table.
+	//! Indexes associated with the table.
 	vector<unique_ptr<Index>> indexes;
 };
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -339,7 +339,8 @@ void DataTable::AddIndex(unique_ptr<Index> index) {
 }
 
 bool DataTable::HasForeignKeyIndex(const vector<PhysicalIndex> &keys, ForeignKeyType type) {
-	return info->indexes.FindForeignKeyIndex(keys, type) != nullptr;
+	auto index = info->indexes.FindForeignKeyIndex(keys, type);
+	return index != nullptr;
 }
 
 void DataTable::SetIndexStorageInfo(vector<IndexStorageInfo> index_storage_info) {
@@ -466,28 +467,6 @@ static void VerifyCheckConstraint(ClientContext &context, TableCatalogEntry &tab
 	}
 }
 
-bool DataTable::IsForeignKeyIndex(const vector<PhysicalIndex> &fk_keys, Index &index, ForeignKeyType fk_type) {
-	if (fk_type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE ? !index.IsUnique() : !index.IsForeign()) {
-		return false;
-	}
-	if (fk_keys.size() != index.GetColumnIds().size()) {
-		return false;
-	}
-	for (auto &fk_key : fk_keys) {
-		bool is_found = false;
-		for (auto &index_key : index.GetColumnIds()) {
-			if (fk_key.index == index_key) {
-				is_found = true;
-				break;
-			}
-		}
-		if (!is_found) {
-			return false;
-		}
-	}
-	return true;
-}
-
 // Find the first index that is not null, and did not find a match
 static idx_t FirstMissingMatch(const ManagedSelection &matches) {
 	idx_t match_idx = 0;
@@ -537,65 +516,71 @@ static bool IsAppend(VerifyExistenceType verify_type) {
 	return verify_type == VerifyExistenceType::APPEND_FK;
 }
 
-void DataTable::VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
+void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
+                                           const BoundForeignKeyConstraint &bound_foreign_key, ClientContext &context,
                                            DataChunk &chunk, VerifyExistenceType verify_type) {
-	const vector<PhysicalIndex> *src_keys_ptr = &bfk.info.fk_keys;
-	const vector<PhysicalIndex> *dst_keys_ptr = &bfk.info.pk_keys;
+	reference<const vector<PhysicalIndex>> src_keys_ptr = bound_foreign_key.info.fk_keys;
+	reference<const vector<PhysicalIndex>> dst_keys_ptr = bound_foreign_key.info.pk_keys;
 
 	bool is_append = IsAppend(verify_type);
 	if (!is_append) {
-		src_keys_ptr = &bfk.info.pk_keys;
-		dst_keys_ptr = &bfk.info.fk_keys;
+		src_keys_ptr = bound_foreign_key.info.pk_keys;
+		dst_keys_ptr = bound_foreign_key.info.fk_keys;
 	}
 
-	auto &table_entry_ptr =
-	    Catalog::GetEntry<TableCatalogEntry>(context, db.GetName(), bfk.info.schema, bfk.info.table);
-	// make the data chunk to check
+	// Get the column types in their physical order.
+	auto &table_entry = Catalog::GetEntry<TableCatalogEntry>(context, db.GetName(), bound_foreign_key.info.schema,
+	                                                         bound_foreign_key.info.table);
 	vector<LogicalType> types;
-	for (auto &col : table_entry_ptr.GetColumns().Physical()) {
+	for (auto &col : table_entry.GetColumns().Physical()) {
 		types.emplace_back(col.Type());
 	}
+
+	// Create the data chunk that has to be verified.
 	DataChunk dst_chunk;
 	dst_chunk.InitializeEmpty(types);
-	for (idx_t i = 0; i < src_keys_ptr->size(); i++) {
-		dst_chunk.data[(*dst_keys_ptr)[i].index].Reference(chunk.data[(*src_keys_ptr)[i].index]);
+	for (idx_t i = 0; i < src_keys_ptr.get().size(); i++) {
+		auto &src_chunk = chunk.data[src_keys_ptr.get()[i].index];
+		dst_chunk.data[dst_keys_ptr.get()[i].index].Reference(src_chunk);
 	}
-	dst_chunk.SetCardinality(chunk.size());
-	auto &data_table = table_entry_ptr.GetStorage();
 
-	idx_t count = dst_chunk.size();
+	auto count = chunk.size();
+	dst_chunk.SetCardinality(count);
 	if (count <= 0) {
 		return;
 	}
 
-	// Set up a way to record conflicts, rather than directly throw on them
+	// Record conflicts instead of throwing immediately.
 	unordered_set<column_t> empty_column_list;
 	ConflictInfo empty_conflict_info(empty_column_list, false);
-	ConflictManager regular_conflicts(verify_type, count, &empty_conflict_info);
-	ConflictManager transaction_conflicts(verify_type, count, &empty_conflict_info);
-	regular_conflicts.SetMode(ConflictManagerMode::SCAN);
-	transaction_conflicts.SetMode(ConflictManagerMode::SCAN);
+	ConflictManager global_conflicts(verify_type, count, &empty_conflict_info);
+	ConflictManager local_conflicts(verify_type, count, &empty_conflict_info);
+	global_conflicts.SetMode(ConflictManagerMode::SCAN);
+	local_conflicts.SetMode(ConflictManagerMode::SCAN);
 
-	data_table.info->indexes.VerifyForeignKey(*dst_keys_ptr, dst_chunk, regular_conflicts);
-	regular_conflicts.Finalize();
-	auto &regular_matches = regular_conflicts.Conflicts();
+	// Global constraint verification.
+	auto &data_table = table_entry.GetStorage();
+	data_table.info->indexes.VerifyForeignKey(storage, dst_keys_ptr, dst_chunk, global_conflicts);
+	global_conflicts.Finalize();
+	auto &global_matches = global_conflicts.Conflicts();
 
-	// check if we can insert the chunk into the reference table's local storage
+	// Check if we can insert the chunk into the local storage.
 	auto &local_storage = LocalStorage::Get(context, db);
-	bool error = IsForeignKeyConstraintError(is_append, count, regular_matches);
-	bool transaction_error = false;
-	bool transaction_check = local_storage.Find(data_table);
+	bool local_error = false;
+	auto local_verification = local_storage.Find(data_table);
 
-	if (transaction_check) {
-		auto &transact_index = local_storage.GetIndexes(data_table);
-		transact_index.VerifyForeignKey(*dst_keys_ptr, dst_chunk, transaction_conflicts);
-		transaction_conflicts.Finalize();
-		auto &transaction_matches = transaction_conflicts.Conflicts();
-		transaction_error = IsForeignKeyConstraintError(is_append, count, transaction_matches);
+	// Local constraint verification.
+	if (local_verification) {
+		auto &local_indexes = local_storage.GetIndexes(data_table);
+		local_indexes.VerifyForeignKey(storage, dst_keys_ptr, dst_chunk, local_conflicts);
+		local_conflicts.Finalize();
+		auto &local_matches = local_conflicts.Conflicts();
+		local_error = IsForeignKeyConstraintError(is_append, count, local_matches);
 	}
 
-	if (!transaction_error && !error) {
-		// No error occurred;
+	// No constraint violation.
+	auto global_error = IsForeignKeyConstraintError(is_append, count, global_matches);
+	if (!global_error && !local_error) {
 		return;
 	}
 
@@ -605,29 +590,29 @@ void DataTable::VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk,
 
 	auto fk_type = is_append ? ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE : ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
 	// check whether or not the chunk can be inserted or deleted into the referenced table' storage
-	index = data_table.info->indexes.FindForeignKeyIndex(*dst_keys_ptr, fk_type);
-	if (transaction_check) {
+	index = data_table.info->indexes.FindForeignKeyIndex(dst_keys_ptr, fk_type);
+	if (local_verification) {
 		auto &transact_index = local_storage.GetIndexes(data_table);
 		// check whether or not the chunk can be inserted or deleted into the referenced table' storage
-		transaction_index = transact_index.FindForeignKeyIndex(*dst_keys_ptr, fk_type);
+		transaction_index = transact_index.FindForeignKeyIndex(dst_keys_ptr, fk_type);
 	}
 
-	if (!transaction_check) {
+	if (!local_verification) {
 		// Only local state is checked, throw the error
-		D_ASSERT(error);
-		auto failed_index = LocateErrorIndex(is_append, regular_matches);
+		D_ASSERT(global_error);
+		auto failed_index = LocateErrorIndex(is_append, global_matches);
 		D_ASSERT(failed_index != DConstants::INVALID_INDEX);
 		ThrowForeignKeyConstraintError(failed_index, is_append, *index, dst_chunk);
 	}
-	if (transaction_error && error && is_append) {
+	if (local_error && global_error && is_append) {
 		// When we want to do an append, we only throw if the foreign key does not exist in both transaction and local
 		// storage
-		auto &transaction_matches = transaction_conflicts.Conflicts();
+		auto &transaction_matches = local_conflicts.Conflicts();
 		idx_t failed_index = DConstants::INVALID_INDEX;
 		idx_t regular_idx = 0;
 		idx_t transaction_idx = 0;
 		for (idx_t i = 0; i < count; i++) {
-			bool in_regular = regular_matches.IndexMapsToLocation(regular_idx, i);
+			bool in_regular = global_matches.IndexMapsToLocation(regular_idx, i);
 			regular_idx += in_regular;
 			bool in_transaction = transaction_matches.IndexMapsToLocation(transaction_idx, i);
 			transaction_idx += in_transaction;
@@ -646,14 +631,14 @@ void DataTable::VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk,
 		ThrowForeignKeyConstraintError(failed_index, true, *index, dst_chunk);
 	}
 	if (!is_append) {
-		D_ASSERT(transaction_check);
-		auto &transaction_matches = transaction_conflicts.Conflicts();
-		if (error) {
-			auto failed_index = LocateErrorIndex(false, regular_matches);
+		D_ASSERT(local_verification);
+		auto &transaction_matches = local_conflicts.Conflicts();
+		if (global_error) {
+			auto failed_index = LocateErrorIndex(false, global_matches);
 			D_ASSERT(failed_index != DConstants::INVALID_INDEX);
 			ThrowForeignKeyConstraintError(failed_index, false, *index, dst_chunk);
 		} else {
-			D_ASSERT(transaction_error);
+			D_ASSERT(local_error);
 			D_ASSERT(transaction_matches.Count() != DConstants::INVALID_INDEX);
 			auto failed_index = LocateErrorIndex(false, transaction_matches);
 			D_ASSERT(failed_index != DConstants::INVALID_INDEX);
@@ -662,14 +647,16 @@ void DataTable::VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk,
 	}
 }
 
-void DataTable::VerifyAppendForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
-                                                 DataChunk &chunk) {
-	VerifyForeignKeyConstraint(bfk, context, chunk, VerifyExistenceType::APPEND_FK);
+void DataTable::VerifyAppendForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
+                                                 const BoundForeignKeyConstraint &bound_foreign_key,
+                                                 ClientContext &context, DataChunk &chunk) {
+	VerifyForeignKeyConstraint(storage, bound_foreign_key, context, chunk, VerifyExistenceType::APPEND_FK);
 }
 
-void DataTable::VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
-                                                 DataChunk &chunk) {
-	VerifyForeignKeyConstraint(bfk, context, chunk, VerifyExistenceType::DELETE_FK);
+void DataTable::VerifyDeleteForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
+                                                 const BoundForeignKeyConstraint &bound_foreign_key,
+                                                 ClientContext &context, DataChunk &chunk) {
+	VerifyForeignKeyConstraint(storage, bound_foreign_key, context, chunk, VerifyExistenceType::DELETE_FK);
 }
 
 void DataTable::VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint) {
@@ -754,7 +741,6 @@ void DataTable::VerifyAppendConstraints(ConstraintState &constraint_state, Clien
                                         optional_ptr<ConflictManager> manager) {
 
 	auto &table = constraint_state.table;
-
 	if (table.HasGeneratedColumns()) {
 		// Verify the generated columns against the inserted values.
 		auto binder = Binder::CreateBinder(context);
@@ -799,10 +785,9 @@ void DataTable::VerifyAppendConstraints(ConstraintState &constraint_state, Clien
 			break;
 		}
 		case ConstraintType::FOREIGN_KEY: {
-			auto &bfk = constraint->Cast<BoundForeignKeyConstraint>();
-			if (bfk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
-			    bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
-				VerifyAppendForeignKeyConstraint(bfk, context, chunk);
+			auto &bound_foreign_key = constraint->Cast<BoundForeignKeyConstraint>();
+			if (bound_foreign_key.info.IsAppendConstraint()) {
+				VerifyAppendForeignKeyConstraint(storage, bound_foreign_key, context, chunk);
 			}
 			break;
 		}
@@ -1220,9 +1205,8 @@ static bool TableHasDeleteConstraints(TableCatalogEntry &table) {
 		case ConstraintType::UNIQUE:
 			break;
 		case ConstraintType::FOREIGN_KEY: {
-			auto &bfk = constraint->Cast<ForeignKeyConstraint>();
-			if (bfk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE ||
-			    bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+			auto &foreign_key = constraint->Cast<ForeignKeyConstraint>();
+			if (foreign_key.info.IsDeleteConstraint()) {
 				return true;
 			}
 			break;
@@ -1234,7 +1218,8 @@ static bool TableHasDeleteConstraints(TableCatalogEntry &table) {
 	return false;
 }
 
-void DataTable::VerifyDeleteConstraints(TableDeleteState &state, ClientContext &context, DataChunk &chunk) {
+void DataTable::VerifyDeleteConstraints(optional_ptr<LocalTableStorage> storage, TableDeleteState &state,
+                                        ClientContext &context, DataChunk &chunk) {
 	for (auto &constraint : state.constraint_state->bound_constraints) {
 		switch (constraint->type) {
 		case ConstraintType::NOT_NULL:
@@ -1242,10 +1227,9 @@ void DataTable::VerifyDeleteConstraints(TableDeleteState &state, ClientContext &
 		case ConstraintType::UNIQUE:
 			break;
 		case ConstraintType::FOREIGN_KEY: {
-			auto &bfk = constraint->Cast<BoundForeignKeyConstraint>();
-			if (bfk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE ||
-			    bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
-				VerifyDeleteForeignKeyConstraint(bfk, context, chunk);
+			auto &bound_foreign_key = constraint->Cast<BoundForeignKeyConstraint>();
+			if (bound_foreign_key.info.IsDeleteConstraint()) {
+				VerifyDeleteForeignKeyConstraint(storage, bound_foreign_key, context, chunk);
 			}
 			break;
 		}
@@ -1284,6 +1268,7 @@ idx_t DataTable::Delete(TableDeleteState &state, ClientContext &context, Vector 
 
 	auto &transaction = DuckTransaction::Get(context, db);
 	auto &local_storage = LocalStorage::Get(transaction);
+	auto storage = local_storage.GetStorage(*this);
 
 	row_identifiers.Flatten(count);
 	auto ids = FlatVector::GetData<row_t>(row_identifiers);
@@ -1308,11 +1293,11 @@ idx_t DataTable::Delete(TableDeleteState &state, ClientContext &context, Vector 
 		// This is a transaction-local DELETE.
 		if (is_transaction_delete) {
 			if (state.has_delete_constraints) {
-				// perform the constraint verification
+				// Verify any delete constraints.
 				ColumnFetchState fetch_state;
 				local_storage.FetchChunk(*this, offset_ids, current_count, state.col_ids, state.verify_chunk,
 				                         fetch_state);
-				VerifyDeleteConstraints(state, context, state.verify_chunk);
+				VerifyDeleteConstraints(storage, state, context, state.verify_chunk);
 			}
 			delete_count += local_storage.Delete(*this, offset_ids, current_count);
 			continue;
@@ -1320,10 +1305,10 @@ idx_t DataTable::Delete(TableDeleteState &state, ClientContext &context, Vector 
 
 		// This is a regular DELETE.
 		if (state.has_delete_constraints) {
-			// perform the constraint verification
+			// Verify any delete constraints.
 			ColumnFetchState fetch_state;
 			Fetch(transaction, state.verify_chunk, state.col_ids, offset_ids, current_count, fetch_state);
-			VerifyDeleteConstraints(state, context, state.verify_chunk);
+			VerifyDeleteConstraints(storage, state, context, state.verify_chunk);
 		}
 		delete_count += row_groups->Delete(transaction, *this, ids + current_offset, current_count);
 	}

--- a/test/sql/constraints/foreignkey/test_foreignkey.test
+++ b/test/sql/constraints/foreignkey/test_foreignkey.test
@@ -291,3 +291,18 @@ CREATE TABLE fkt(j INTEGER, FOREIGN KEY (j) REFERENCES pkt(i))
 
 statement ok
 INSERT INTO fkt VALUES (NULL)
+
+# Truncate on self-reference is not yet supported.
+statement ok
+CREATE TABLE t (id INT PRIMARY KEY, parent INT REFERENCES t (id));
+
+statement ok
+INSERT INTO t VALUES (1, NULL);
+
+statement ok
+INSERT INTO t VALUES (2, 1), (3, 1);
+
+statement error
+TRUNCATE t;
+----
+Violates foreign key constraint

--- a/test/sql/index/art/constraints/test_art_tx_upsert_with_global_nested.test
+++ b/test/sql/index/art/constraints/test_art_tx_upsert_with_global_nested.test
@@ -37,13 +37,13 @@ COMMIT;
 statement ok con2
 BEGIN
 
-statement error con2
-INSERT OR REPLACE INTO tbl VALUES (1, ['con2 payload']);
-----
-<REGEX>:TransactionContext Error.*Conflict on tuple deletion.*
-
 statement ok con2
-ROLLBACK;
+INSERT OR REPLACE INTO tbl VALUES (1, ['con2 payload']);
+
+statement error con2
+COMMIT;
+----
+<REGEX>:TransactionContext Error.*write-write conflict on key.*
 
 statement ok old
 COMMIT;


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/3893.

I've also tried moving the delete indexes into the FK constraint verification. There are a few first steps, mostly pushing the `LocalTableStorage` to where it is needed. The same was already done for functions such as the following.
```cpp
static void VerifyUniqueIndexes(TableIndexList &indexes, optional_ptr<LocalTableStorage> storage, DataChunk &chunk,
	                                optional_ptr<ConflictManager> manager);
```


However, the verification would be outside this PR's scope, and the code to populate the delete indexes with the respective values is still missing.

There's also a bit of code tidying here and there, as the foreign key code has not seen much love recently.