### PR TITLE
Parquet remove unnecessary std::move

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -1499,16 +1499,16 @@ static void ParquetCopySerialize(Serializer &serializer, const FunctionData &bin
 	D_ASSERT(DeserializeCompressionLevel(compression_level) == bind_data.compression_level);
 	serializer.WritePropertyWithDefault(109, "compression_level", compression_level);
 	serializer.WritePropertyWithDefault(110, "row_groups_per_file", bind_data.row_groups_per_file,
-	                                    std::move(ParquetWriteBindData().row_groups_per_file));
+	                                    ParquetWriteBindData().row_groups_per_file);
 	serializer.WritePropertyWithDefault(111, "debug_use_openssl", bind_data.debug_use_openssl,
-	                                    std::move(ParquetWriteBindData().debug_use_openssl));
+	                                    ParquetWriteBindData().debug_use_openssl);
 	serializer.WritePropertyWithDefault(112, "dictionary_size_limit", bind_data.dictionary_size_limit,
-	                                    std::move(ParquetWriteBindData().dictionary_size_limit));
+	                                    ParquetWriteBindData().dictionary_size_limit);
 	serializer.WritePropertyWithDefault(113, "bloom_filter_false_positive_ratio",
 	                                    bind_data.bloom_filter_false_positive_ratio,
-	                                    std::move(ParquetWriteBindData().bloom_filter_false_positive_ratio));
+	                                    ParquetWriteBindData().bloom_filter_false_positive_ratio);
 	serializer.WritePropertyWithDefault(114, "parquet_version", bind_data.parquet_version,
-	                                    std::move(ParquetWriteBindData().parquet_version));
+	                                    ParquetWriteBindData().parquet_version);
 }
 
 static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserializer, CopyFunction &function) {
@@ -1529,15 +1529,15 @@ static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserialize
 	data->compression_level = DeserializeCompressionLevel(compression_level);
 	D_ASSERT(SerializeCompressionLevel(data->compression_level) == compression_level);
 	data->row_groups_per_file = deserializer.ReadPropertyWithExplicitDefault<optional_idx>(
-	    110, "row_groups_per_file", std::move(ParquetWriteBindData().row_groups_per_file));
+	    110, "row_groups_per_file", ParquetWriteBindData().row_groups_per_file);
 	data->debug_use_openssl = deserializer.ReadPropertyWithExplicitDefault<bool>(
-	    111, "debug_use_openssl", std::move(ParquetWriteBindData().debug_use_openssl));
+	    111, "debug_use_openssl", ParquetWriteBindData().debug_use_openssl);
 	data->dictionary_size_limit = deserializer.ReadPropertyWithExplicitDefault<idx_t>(
-	    112, "dictionary_size_limit", std::move(ParquetWriteBindData().dictionary_size_limit));
+	    112, "dictionary_size_limit", ParquetWriteBindData().dictionary_size_limit);
 	data->bloom_filter_false_positive_ratio = deserializer.ReadPropertyWithExplicitDefault<double>(
-	    113, "bloom_filter_false_positive_ratio", std::move(ParquetWriteBindData().bloom_filter_false_positive_ratio));
-	data->parquet_version = deserializer.ReadPropertyWithExplicitDefault(
-	    114, "parquet_version", std::move(ParquetWriteBindData().parquet_version));
+	    113, "bloom_filter_false_positive_ratio", ParquetWriteBindData().bloom_filter_false_positive_ratio);
+	data->parquet_version =
+	    deserializer.ReadPropertyWithExplicitDefault(114, "parquet_version", ParquetWriteBindData().parquet_version);
 
 	return std::move(data);
 }


### PR DESCRIPTION
Flagged as warning turned error in some CI run.