### PR TITLE
Run the Regression GitHub Action on an ARM processor

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   regression-test-benchmark-runner:
     name: Regression Tests
-    runs-on: ubuntu-22-arm
+    runs-on: ubuntu-22.04-arm
     env:
       CC: gcc-10
       CXX: g++-10
@@ -181,7 +181,7 @@ jobs:
 
   regression-test-storage:
     name: Storage Size Regression Test
-    runs-on: ubuntu-22-arm
+    runs-on: ubuntu-22.04-arm
     env:
       CC: gcc-10
       CXX: g++-10
@@ -261,7 +261,7 @@ jobs:
 
   regression-test-binary-size:
     name: Regression test binary size
-    runs-on: ubuntu-22-arm
+    runs-on: ubuntu-22.04-arm
     env:
       CC: gcc-10
       CXX: g++-10
@@ -303,7 +303,7 @@ jobs:
 
   regression-test-plan-cost:
     name: Regression Test Join Order Plan Cost
-    runs-on: ubuntu-22-arm
+    runs-on: ubuntu-22.04-arm
     env:
       CC: gcc-10
       CXX: g++-10

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   regression-test-benchmark-runner:
     name: Regression Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22-arm
     env:
       CC: gcc-10
       CXX: g++-10
@@ -181,7 +181,7 @@ jobs:
 
   regression-test-storage:
     name: Storage Size Regression Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22-arm
     env:
       CC: gcc-10
       CXX: g++-10
@@ -261,7 +261,7 @@ jobs:
 
   regression-test-binary-size:
     name: Regression test binary size
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22-arm
     env:
       CC: gcc-10
       CXX: g++-10
@@ -303,7 +303,7 @@ jobs:
 
   regression-test-plan-cost:
     name: Regression Test Join Order Plan Cost
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22-arm
     env:
       CC: gcc-10
       CXX: g++-10


### PR DESCRIPTION
Try speeding up a long running GitHub Action by running it on an ARM processor.
[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `os: ubuntu-24.04-arm`

Previous runs: https://github.com/duckdb/duckdb/actions/workflows/Regression.yml

This might not be a great example because the `build` step takes the bulk of the time and the cache (hendrikmuhs/ccache-action@main) is invalid because of the change of processor and the cache save being set to `false`.