### PR TITLE
[PySpark] - Add cache function to dataframe

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
@@ -1434,9 +1434,10 @@ class DataFrame:
         """
         duck_uuid = self.session.sql("select gen_random_uuid()").head()[0]
         uuid_str = str(duck_uuid).replace("-", "_")
-        cache_table = f"cache_table_{uuid_str}"
-        self.relation.create(cache_table)
-        return self.session.sql(f"select * from {cache_table}")
+        cache_name = f"cache_table_{uuid_str}"
+        cache_df = self.relation # noqa F841
+        self.session.conn.sql(f"CREATE TEMPORARY TABLE {cache_name} AS SELECT * FROM cache_df;")
+        return self.session.sql(f"select * from {cache_name}")
 
 
 __all__ = ["DataFrame"]

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
@@ -1405,6 +1405,33 @@ class DataFrame:
     
 
     def cache(self) -> "DataFrame":
+        """Persists the :class:`DataFrame` with the default storage level (`MEMORY_AND_DISK_DESER`).
+
+        .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Supports Spark Connect.
+
+        Notes
+        -----
+        The default storage level has changed to `MEMORY_AND_DISK_DESER` to match Scala in 3.0.
+
+        Returns
+        -------
+        :class:`DataFrame`
+            Cached DataFrame.
+
+        Examples
+        --------
+        >>> df = spark.range(1)
+        >>> df.cache()
+        DataFrame[id: bigint]
+
+        >>> df.explain()  # doctest: +SKIP
+        == Physical Plan ==
+        AdaptiveSparkPlan isFinalPlan=false
+        +- InMemoryTableScan ...
+        """
         duck_uuid = self.session.sql("select gen_random_uuid()").head()[0]
         uuid_str = str(duck_uuid).replace("-", "_")
         cache_table = f"cache_table_{uuid_str}"

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/dataframe.py
@@ -1402,6 +1402,14 @@ class DataFrame:
 
         rows = [construct_row(x, columns) for x in result]
         return rows
+    
+
+    def cache(self) -> "DataFrame":
+        duck_uuid = self.session.sql("select gen_random_uuid()").head()[0]
+        uuid_str = str(duck_uuid).replace("-", "_")
+        cache_table = f"cache_table_{uuid_str}"
+        self.relation.create(cache_table)
+        return self.session.sql(f"select * from {cache_table}")
 
 
 __all__ = ["DataFrame"]

--- a/tools/pythonpkg/tests/fast/spark/test_spark_dataframe_cache.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_dataframe_cache.py
@@ -1,0 +1,55 @@
+import pytest
+
+_ = pytest.importorskip("duckdb.experimental.spark")
+
+
+from spark_namespace.sql.types import (
+    LongType,
+    StructType,
+    BooleanType,
+    StructField,
+    StringType,
+    IntegerType,
+    LongType,
+    Row,
+    ArrayType,
+    MapType,
+)
+from spark_namespace.sql.functions import col, struct, when, lit, array_contains
+from spark_namespace.sql.functions import sum, avg, max, min, mean, count
+
+
+@pytest.fixture
+def df1(spark):
+    data = [("James", 34), ("Michael", 56), ("Robert", 30), ("Maria", 24)]
+    dataframe = spark.createDataFrame(data=data, schema=["name", "id"])
+    yield dataframe
+
+
+@pytest.fixture
+def df2(spark):
+    data2 = [(34, "James"), (45, "Maria"), (45, "Jen"), (34, "Jeff")]
+    dataframe = spark.createDataFrame(data=data2, schema=["id", "name"])
+    yield dataframe
+
+
+class TestDataFrameCache(object):
+    def test_cache_two_tables(self, df1, df2):
+        cached_one_df = df1.cache()
+        result_one = cached_one_df.collect()
+        expected_one = [
+            Row(name='James', id=34),
+            Row(name='Michael', id=56),
+            Row(name='Robert', id=30),
+            Row(name='Maria', id=24),
+        ]
+        assert result_one == expected_one
+        cached_two_df = df2.cache()
+        result_two = cached_two_df.collect()
+        expected_two = [
+            Row(id=34, name='James'),
+            Row(id=45, name='Maria'),
+            Row(id=45, name='Jen'),
+            Row(id=34, name='Jeff'),
+        ]
+        assert result_two == expected_two


### PR DESCRIPTION
Use temp table to replicate the spark dataframe cache function.