### PR TITLE
Fix some memory/storage issues in CI

### DIFF
--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -97,6 +97,7 @@ public:
 	void SetRadixBits(const idx_t &radix_bits_p);
 	bool SetRadixBitsToExternal();
 	idx_t GetRadixBits() const;
+	idx_t GetExternalRadixBits() const;
 
 private:
 	void SetRadixBitsInternal(idx_t radix_bits_p, bool external);
@@ -210,13 +211,13 @@ RadixHTGlobalSinkState::RadixHTGlobalSinkState(ClientContext &context_p, const R
 	auto tuples_per_block = block_alloc_size / radix_ht.GetLayout().GetRowWidth();
 	idx_t ht_count =
 	    LossyNumericCast<idx_t>(static_cast<double>(config.sink_capacity) / GroupedAggregateHashTable::LOAD_FACTOR);
-	auto num_partitions = RadixPartitioning::NumberOfPartitions(config.GetRadixBits());
+	auto num_partitions = RadixPartitioning::NumberOfPartitions(config.GetExternalRadixBits());
 	auto count_per_partition = ht_count / num_partitions;
 	auto blocks_per_partition = (count_per_partition + tuples_per_block) / tuples_per_block + 1;
 	if (!radix_ht.GetLayout().AllConstant()) {
 		blocks_per_partition += 2;
 	}
-	auto ht_size = blocks_per_partition * block_alloc_size + config.sink_capacity * sizeof(ht_entry_t);
+	auto ht_size = num_partitions * blocks_per_partition * block_alloc_size + config.sink_capacity * sizeof(ht_entry_t);
 
 	// This really is the minimum reservation that we can do
 	auto num_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
@@ -278,6 +279,10 @@ bool RadixHTConfig::SetRadixBitsToExternal() {
 
 idx_t RadixHTConfig::GetRadixBits() const {
 	return sink_radix_bits;
+}
+
+idx_t RadixHTConfig::GetExternalRadixBits() const {
+	return MAXIMUM_FINAL_SINK_RADIX_BITS;
 }
 
 void RadixHTConfig::SetRadixBitsInternal(const idx_t radix_bits_p, bool external) {

--- a/test/sql/json/test_json_copy_tpch.test_slow
+++ b/test/sql/json/test_json_copy_tpch.test_slow
@@ -7,10 +7,13 @@ require json
 require tpch
 
 statement ok
+set threads=4
+
+statement ok
 start transaction
 
 statement ok
-call dbgen(sf=1)
+call dbgen(sf=0.1)
 
 # export lineitem as array (ARRAY does not need TRUE to be passed)
 statement ok
@@ -30,21 +33,21 @@ start transaction
 statement ok
 call dbgen(sf=0)
 
-# lineitem json is ~2GB so this test that we can do streaming reads of json arrays
+# sf0.1 lineitem json is ~0.2GB so this tests that we can do streaming reads of json arrays
 statement ok
-set memory_limit='1gb'
+set memory_limit='100mb'
 
 statement ok
 COPY lineitem from '__TEST_DIR__/lineitem.json' (ARRAY)
 
-# 4gb should be enough for the rest
+# 500mb should be enough for the rest
 statement ok
-set memory_limit='4gb'
+set memory_limit='500mb'
 
 query I
 PRAGMA tpch(1)
 ----
-<FILE>:extension/tpch/dbgen/answers/sf1/q01.csv
+<FILE>:extension/tpch/dbgen/answers/sf0.1/q01.csv
 
 statement ok
 rollback
@@ -61,7 +64,7 @@ loop i 1 9
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf0.1/q0${i}.csv
 
 endloop
 
@@ -70,7 +73,7 @@ loop i 10 23
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf0.1/q${i}.csv
 
 endloop
 
@@ -201,7 +204,7 @@ loop i 1 9
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf0.1/q0${i}.csv
 
 endloop
 
@@ -210,6 +213,6 @@ loop i 10 23
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
+<FILE>:extension/tpch/dbgen/answers/sf0.1/q${i}.csv
 
 endloop

--- a/test/sql/parallelism/intraquery/depth_first_evaluation.test_slow
+++ b/test/sql/parallelism/intraquery/depth_first_evaluation.test_slow
@@ -9,9 +9,11 @@ load __TEST_DIR__/depth_first_evaluation.db
 statement ok
 SET temp_directory = ''
 
-# 1GiB is pretty tight
+# 2GiB is pretty tight, each single aggregation should take only slightly less
+# in this test, we're testing that we don't have multiple aggregations active simultaneously
+# so this limit should be tight enough
 statement ok
-SET memory_limit = '1GiB'
+SET memory_limit = '2GiB'
 
 statement ok
 SET threads = 4


### PR DESCRIPTION
These tests
```
test/sql/json/test_json_copy_tpch.test_slow -- 1
test/sql/aggregate/group/test_group_by_parallel.test_slow -- 2
test/sql/parallelism/intraquery/depth_first_evaluation.test_slow -- 3
```
 Were giving memory/storage issues in CI.

For (1.), I've reduced the TPC-H scale factor to 0.1 instead of 1. We're still testing what we want to test, so this shouldn't be an issue (TPC-H files are really large when exported to JSON).

For (2.), the setting `PRAGMA verify_external;` was triggering a lot of partitioning and spilling to test the external grouped aggregation behavior. It was spilling more than necessary because the HT size calculation was off a bit, especially when this setting was enabled.

For (3.), a slight increase to the memory limit in the test was enough to make it work again. We're still testing the behavior we want to.