### PR TITLE
Reset db cache entry in the input parameter after being copied

### DIFF
--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -463,6 +463,7 @@ void DatabaseInstance::Configure(DBConfig &new_config, const char *database_path
 		                                                 config.options.allocator_bulk_deallocation_flush_threshold);
 	}
 	config.db_cache_entry = new_config.db_cache_entry;
+	new_config.db_cache_entry.reset();
 }
 
 DBConfig &DBConfig::GetConfig(ClientContext &context) {


### PR DESCRIPTION
This PR fixes test instance cache hang. The cache entry is copied in the global config and will not be released, so the following loop will run forever.
```cpp
        // in duckdb/src/main/db_instance_cache.cpp   GetInstanceInternal
	if (!db_instance) {
		// if the database does not exist, but the cache entry still exists, the database is being shut down
		// we need to wait until the database is fully shut down to safely proceed
		// we do this here using a busy spin
		while (cache_entry) {
			// clear our cache entry
			cache_entry.reset();
			// try to lock it again
			cache_entry = entry->second.lock();
		}
		// the cache entry has now been deleted - clear it from the set of database instances and return
		db_instances.erase(entry);
		return nullptr;
	}
```