### PR TITLE
Fix map_extract backwards compatability

### DIFF
--- a/extension/core_functions/function_list.cpp
+++ b/extension/core_functions/function_list.cpp
@@ -266,6 +266,7 @@ static const StaticFunctionDefinition core_functions[] = {
 	DUCKDB_SCALAR_FUNCTION(MapConcatFun),
 	DUCKDB_SCALAR_FUNCTION(MapEntriesFun),
 	DUCKDB_SCALAR_FUNCTION(MapExtractFun),
+	DUCKDB_SCALAR_FUNCTION(MapExtractValueFun),
 	DUCKDB_SCALAR_FUNCTION(MapFromEntriesFun),
 	DUCKDB_SCALAR_FUNCTION(MapKeysFun),
 	DUCKDB_SCALAR_FUNCTION(MapValuesFun),

--- a/extension/core_functions/include/core_functions/scalar/map_functions.hpp
+++ b/extension/core_functions/include/core_functions/scalar/map_functions.hpp
@@ -57,6 +57,15 @@ struct ElementAtFun {
 	static constexpr const char *Name = "element_at";
 };
 
+struct MapExtractValueFun {
+	static constexpr const char *Name = "map_extract_value";
+	static constexpr const char *Parameters = "map,key";
+	static constexpr const char *Description = "Returns the value for a given key or NULL if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map’s keys else an error is returned";
+	static constexpr const char *Example = "map_extract_value(map(['key'], ['val']), 'key')";
+
+	static ScalarFunction GetFunction();
+};
+
 struct MapFromEntriesFun {
 	static constexpr const char *Name = "map_from_entries";
 	static constexpr const char *Parameters = "map";

--- a/extension/core_functions/scalar/map/functions.json
+++ b/extension/core_functions/scalar/map/functions.json
@@ -29,6 +29,13 @@
         "aliases": ["element_at"]
     },
     {
+        "name": "map_extract_value",
+        "parameters": "map,key",
+        "description": "Returns the value for a given key or NULL if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map’s keys else an error is returned",
+        "example": "map_extract_value(map(['key'], ['val']), 'key')",
+        "type": "scalar_function"
+    },
+    {
         "name": "map_from_entries",
         "parameters": "map",
         "description": "Returns a map created from the entries of the array",

--- a/extension/core_functions/scalar/map/map_extract.cpp
+++ b/extension/core_functions/scalar/map/map_extract.cpp
@@ -106,8 +106,9 @@ static void MapExtractListFunc(DataChunk &args, ExpressionState &state, Vector &
 
 	if (map_is_null || arg_is_null) {
 		// Short-circuit if either the map or the arg is NULL
+		ListVector::SetListSize(result, 0);
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);
-		ConstantVector::SetNull(result, true);
+		ConstantVector::GetData<list_entry_t>(result)[0] = {0, 0};
 		result.Verify(count);
 		return;
 	}

--- a/extension/core_functions/scalar/map/map_extract.cpp
+++ b/extension/core_functions/scalar/map/map_extract.cpp
@@ -6,35 +6,36 @@
 
 namespace duckdb {
 
+template <bool EXTRACT_VALUE>
 static unique_ptr<FunctionData> MapExtractBind(ClientContext &, ScalarFunction &bound_function,
                                                vector<unique_ptr<Expression>> &arguments) {
 	if (arguments.size() != 2) {
 		throw BinderException("MAP_EXTRACT must have exactly two arguments");
 	}
 
-	auto &map_type = arguments[0]->return_type;
-	auto &input_type = arguments[1]->return_type;
+	const auto &map_type = arguments[0]->return_type;
+	const auto &input_type = arguments[1]->return_type;
 
 	if (map_type.id() == LogicalTypeId::SQLNULL) {
-		bound_function.return_type = LogicalTypeId::SQLNULL;
+		bound_function.return_type = EXTRACT_VALUE ? LogicalTypeId::SQLNULL : LogicalType::LIST(LogicalTypeId::SQLNULL);
 		return make_uniq<VariableReturnBindData>(bound_function.return_type);
 	}
 
 	if (map_type.id() != LogicalTypeId::MAP) {
-		throw BinderException("MAP_EXTRACT can only operate on MAPs");
+		throw BinderException("'%s' can only operate on MAPs", bound_function.name);
 	}
 	auto &value_type = MapType::ValueType(map_type);
 
 	//! Here we have to construct the List Type that will be returned
-	bound_function.return_type = value_type;
-	auto key_type = MapType::KeyType(map_type);
+	bound_function.return_type = EXTRACT_VALUE ? value_type : LogicalType::LIST(value_type);
+	const auto &key_type = MapType::KeyType(map_type);
 	if (key_type.id() != LogicalTypeId::SQLNULL && input_type.id() != LogicalTypeId::SQLNULL) {
 		bound_function.arguments[1] = MapType::KeyType(map_type);
 	}
 	return make_uniq<VariableReturnBindData>(bound_function.return_type);
 }
 
-static void MapExtractFunc(DataChunk &args, ExpressionState &state, Vector &result) {
+static void MapExtractValueFunc(DataChunk &args, ExpressionState &state, Vector &result) {
 	const auto count = args.size();
 
 	auto &map_vec = args.data[0];
@@ -94,8 +95,87 @@ static void MapExtractFunc(DataChunk &args, ExpressionState &state, Vector &resu
 	result.Verify(count);
 }
 
+static void MapExtractListFunc(DataChunk &args, ExpressionState &state, Vector &result) {
+	const auto count = args.size();
+
+	auto &map_vec = args.data[0];
+	auto &arg_vec = args.data[1];
+
+	const auto map_is_null = map_vec.GetType().id() == LogicalTypeId::SQLNULL;
+	const auto arg_is_null = arg_vec.GetType().id() == LogicalTypeId::SQLNULL;
+
+	if (map_is_null || arg_is_null) {
+		// Short-circuit if either the map or the arg is NULL
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		result.Verify(count);
+		return;
+	}
+
+	auto &key_vec = MapVector::GetKeys(map_vec);
+	auto &val_vec = MapVector::GetValues(map_vec);
+
+	// Collect the matching positions
+	Vector pos_vec(LogicalType::INTEGER, count);
+	ListSearchOp<true>(map_vec, key_vec, arg_vec, pos_vec, args.size());
+
+	UnifiedVectorFormat val_format;
+	UnifiedVectorFormat pos_format;
+	UnifiedVectorFormat lst_format;
+
+	val_vec.ToUnifiedFormat(ListVector::GetListSize(map_vec), val_format);
+	pos_vec.ToUnifiedFormat(count, pos_format);
+	map_vec.ToUnifiedFormat(count, lst_format);
+
+	const auto pos_data = UnifiedVectorFormat::GetData<int32_t>(pos_format);
+	const auto inc_list_data = ListVector::GetData(map_vec);
+	const auto out_list_data = ListVector::GetData(result);
+
+	idx_t offset = 0;
+	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+		const auto lst_idx = lst_format.sel->get_index(row_idx);
+		if (!lst_format.validity.RowIsValid(lst_idx)) {
+			FlatVector::SetNull(result, row_idx, true);
+			continue;
+		}
+
+		auto &inc_list = inc_list_data[lst_idx];
+		auto &out_list = out_list_data[row_idx];
+
+		const auto pos_idx = pos_format.sel->get_index(row_idx);
+		if (!pos_format.validity.RowIsValid(pos_idx)) {
+			// We didnt find the key in the map, so return emptyl ist
+			out_list.offset = offset;
+			out_list.length = 0;
+			continue;
+		}
+
+		// Compute the actual position of the value in the map value vector
+		const auto pos = inc_list.offset + UnsafeNumericCast<idx_t>(pos_data[pos_idx] - 1);
+		out_list.offset = offset;
+		out_list.length = 1;
+		ListVector::Append(result, val_vec, pos + 1, pos);
+		offset++;
+	}
+
+	if (args.size() == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+
+	result.Verify(count);
+}
+
+ScalarFunction MapExtractValueFun::GetFunction() {
+	ScalarFunction fun({LogicalType::ANY, LogicalType::ANY}, LogicalType::ANY, MapExtractValueFunc,
+	                   MapExtractBind<true>);
+	fun.varargs = LogicalType::ANY;
+	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	return fun;
+}
+
 ScalarFunction MapExtractFun::GetFunction() {
-	ScalarFunction fun({LogicalType::ANY, LogicalType::ANY}, LogicalType::ANY, MapExtractFunc, MapExtractBind);
+	ScalarFunction fun({LogicalType::ANY, LogicalType::ANY}, LogicalType::ANY, MapExtractListFunc,
+	                   MapExtractBind<false>);
 	fun.varargs = LogicalType::ANY;
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 	return fun;

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -430,6 +430,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"map_concat", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"map_entries", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"map_extract", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"map_extract_value", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"map_from_entries", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"map_keys", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"map_values", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},

--- a/src/planner/binder/expression/bind_operator_expression.cpp
+++ b/src/planner/binder/expression/bind_operator_expression.cpp
@@ -109,7 +109,7 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 		auto &b_exp = BoundExpression::GetExpression(*op.children[0]);
 		const auto &b_exp_type = b_exp->return_type;
 		if (b_exp_type.id() == LogicalTypeId::MAP) {
-			function_name = "map_extract";
+			function_name = "map_extract_value";
 		} else if (b_exp_type.IsJSONType() && op.children.size() == 2) {
 			function_name = "json_extract";
 			// Make sure we only extract array elements, not fields, by adding the $[] syntax
@@ -149,7 +149,7 @@ BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth)
 		if (extract_expr_type.id() == LogicalTypeId::UNION) {
 			function_name = "union_extract";
 		} else if (extract_expr_type.id() == LogicalTypeId::MAP) {
-			function_name = "map_extract";
+			function_name = "map_extract_value";
 		} else if (extract_expr_type.IsJSONType()) {
 			function_name = "json_extract";
 			// Make sure we only extract fields, not array elements, by adding $. syntax

--- a/test/sql/types/nested/map/test_map_subscript.test
+++ b/test/sql/types/nested/map/test_map_subscript.test
@@ -79,22 +79,32 @@ NULL
 query I
 select map_extract(m,1) from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as m) as T
 ----
+[10]
+
+query I
+select m[1] from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as m) as T
+----
 10
 
 query I
 select map_extract(m,3) from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as m) as T
+----
+[8]
+
+query I
+select m[3] from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as m) as T
 ----
 8
 
 query I
 select element_at(m,1) from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as m) as T
 ----
-10
+[10]
 
 query I
 select element_at(m,3) from (select MAP(LIST_VALUE(1, 2, 3, 4),LIST_VALUE(10, 9, 8, 7)) as m) as T
 ----
-8
+[8]
 
 #Map with larger-than-vector-size cardinalities
 query I
@@ -183,7 +193,7 @@ NULL
 query I
 SELECT map_extract(MAP(LIST_VALUE(10,9,12,11,13),LIST_VALUE(10,9,10,11,13)),10)
 ----
-10
+[10]
 
 #Multiple constants
 query I
@@ -209,24 +219,50 @@ from (SELECT a%4 as grp, list(a) as lsta, list(a) as lstb FROM range(7) tbl(a) g
 query I
 select MAP_EXTRACT(MAP([],[]), NULL)
 ----
-NULL
+[]
 
 query I
 select MAP_EXTRACT(MAP(NULL, NULL), NULL)
 ----
-NULL
+[]
 
 query I
 select MAP_EXTRACT(NULL, NULL)
 ----
-NULL
+[]
 
 query I
 select MAP_EXTRACT(NULL::MAP("NULL", "NULL"), NULL)
 ----
-NULL
+[]
 
 query I
 select MAP_EXTRACT(NULL::MAP(INT, BIGINT), NULL)
 ----
+[]
+
+query I
+select MAP_EXTRACT_VALUE(MAP([],[]), NULL)
+----
 NULL
+
+query I
+select MAP_EXTRACT_VALUE(MAP(NULL, NULL), NULL)
+----
+NULL
+
+query I
+select MAP_EXTRACT_VALUE(NULL, NULL)
+----
+NULL
+
+query I
+select MAP_EXTRACT_VALUE(NULL::MAP("NULL", "NULL"), NULL)
+----
+NULL
+
+query I
+select MAP_EXTRACT_VALUE(NULL::MAP(INT, BIGINT), NULL)
+----
+NULL
+

--- a/test/sql/types/nested/map/test_map_subscript_composite.test
+++ b/test/sql/types/nested/map/test_map_subscript_composite.test
@@ -111,7 +111,7 @@ NULL
 query I
 SELECT map_extract(MAP(LIST_VALUE([10],[9],[12],[11],[13]),LIST_VALUE(10,9,10,11,13)),[10])
 ----
-10
+[10]
 
 #Multiple constants
 query I

--- a/test/sql/types/nested/map/test_null_map_interaction.test
+++ b/test/sql/types/nested/map/test_null_map_interaction.test
@@ -37,9 +37,20 @@ STRUCT("key" "NULL", "value" "NULL")[]
 query I
 SELECT TYPEOF(MAP_EXTRACT(NULL::MAP(TEXT, BIGINT), 'a'));
 ----
+BIGINT[]
+
+query I
+SELECT TYPEOF((NULL::MAP(TEXT, BIGINT))['a']);
+----
 BIGINT
 
 query I
 SELECT TYPEOF(MAP_EXTRACT(NULL, 'a'));
+----
+"NULL"[]
+
+
+query I
+SELECT TYPEOF(MAP_EXTRACT_VALUE(NULL, 'a'));
 ----
 "NULL"


### PR DESCRIPTION
This PR is a follow-up from #14175 that changed the return value of `map_extract` and `element_at` to return a single value from maps by key instead of a list with the value.

This is a good change, but unfortunately It breaks backwards/forwards compatibility for serialized query plans. This PR fixes it by reverting the change to `map_extract` but instead add a new `map_extract_value` with the new behavior. It also changes the syntax sugar (e.g. `[]`) to use this new function instead, so the end user still "mostly" sees the new behavior, while the system internally still keeps the same behavior for the actual function. 