### PR TITLE
Enable tests using no_alternative_verify

### DIFF
--- a/test/optimizer/topn/topn_optimizer.test
+++ b/test/optimizer/topn/topn_optimizer.test
@@ -44,7 +44,7 @@ EXPLAIN SELECT * FROM (SELECT * FROM range(100000000) AS _(x) ORDER BY x) AS cte
 ----
 logical_opt	<REGEX>:.*TOP_N.*
 
-require noalternativeverify
+require no_alternative_verify
 
 # top n optimization with more complex projection pull up
 query II

--- a/test/sql/cte/materialized/test_cte_in_cte_materialized.test
+++ b/test/sql/cte/materialized/test_cte_in_cte_materialized.test
@@ -48,9 +48,9 @@ with cte1 as MATERIALIZED (Select i as j from a) select * from cte1 where j = (w
 ----
 42
 
-require noalternativeverify
+require no_alternative_verify
 
-# same name, both get materialized with ALTERNATIVE_VERIFY, so we need 'noalternativeverify'
+# same name, both get materialized with ALTERNATIVE_VERIFY, so we need 'no_alternative_verify'
 query I
 with cte as materialized (Select i as j from a) select * from cte where j = (with cte as (select max(j) as j from cte) select j from cte);
 ----

--- a/test/sql/cte/test_cte.test
+++ b/test/sql/cte/test_cte.test
@@ -182,7 +182,7 @@ SELECT * FROM t ORDER BY b;
 5
 7
 
-require noalternativeverify
+require no_alternative_verify
 
 # FIXME: this one should work with ALTERNATIVE_VERIFY, but doesn't yet
 # something wrong with binding a CTE inside a recursive CTE

--- a/test/sql/cte/test_issue_5673.test
+++ b/test/sql/cte/test_issue_5673.test
@@ -31,9 +31,9 @@ select * from some_more_logic;
 ----
 1
 
-require noalternativeverify
+require no_alternative_verify
 
-# this one needs 'noalternativeverify' otherwise the error message is different
+# this one needs 'no_alternative_verify' otherwise the error message is different
 statement error
 with
 orders as (


### PR DESCRIPTION
These tests were inadvertently disabled because the name of the require flag changed sometime back.

Note: The same should be checked on all extension tests (I think a test from the fts extension has the same issue).