### PR TITLE
Fix tests for storage 65

### DIFF
--- a/test/sql/storage/optimistic_write/optimistic_write_custom_row_group_size.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_custom_row_group_size.test_slow
@@ -3,7 +3,7 @@
 # group: [optimistic_write]
 
 statement ok
-ATTACH '__TEST_DIR__/optimistic_write_custom_row_group_size.db' AS attached_db (ROW_GROUP_SIZE 204800)
+ATTACH '__TEST_DIR__/optimistic_write_custom_row_group_size.db' AS attached_db (ROW_GROUP_SIZE 204800, STORAGE_VERSION 'v1.2.0')
 
 statement ok
 USE attached_db

--- a/test/sql/storage/parallel/custom_row_group_size.test_slow
+++ b/test/sql/storage/parallel/custom_row_group_size.test_slow
@@ -5,7 +5,7 @@
 require parquet
 
 statement ok
-ATTACH '__TEST_DIR__/custom_row_group_size.db' AS custom_row_group_size (ROW_GROUP_SIZE 204800)
+ATTACH '__TEST_DIR__/custom_row_group_size.db' AS custom_row_group_size (ROW_GROUP_SIZE 204800, STORAGE_VERSION 'v1.2.0')
 
 statement ok
 USE custom_row_group_size

--- a/test/sql/storage/storage_version_65.test
+++ b/test/sql/storage/storage_version_65.test
@@ -2,6 +2,8 @@
 # description: Test attach storage version 65
 # group: [storage]
 
+require no_alternative_verify
+
 require skip_reload
 
 # The database is written with a vector size of 2048.


### PR DESCRIPTION
* Big ROW_GROUP_SIZE require explict STORAGE_VERSION
* ALTERNATIVE_VERIFY=1 implies default to be `latest`, so test do not make much sense