### PR TITLE
Fixes for vsize=2 tests

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -42,6 +42,8 @@ struct IndexScanLocalState : public LocalTableFunctionState {
 	//! The DataChunk containing all read columns.
 	//! This includes filter columns, which are immediately removed.
 	DataChunk all_columns;
+	//! Fetch state
+	ColumnFetchState fetch_state;
 };
 
 static StorageIndex TransformStorageIndex(const ColumnIndex &column_id) {
@@ -116,7 +118,6 @@ public:
 	//! Synchronize changes to the global index scan state.
 	mutex index_scan_lock;
 
-	ColumnFetchState fetch_state;
 	TableScanState table_scan_state;
 
 public:
@@ -160,10 +161,10 @@ public:
 
 			if (CanRemoveFilterColumns()) {
 				l_state.all_columns.Reset();
-				storage.Fetch(tx, l_state.all_columns, column_ids, local_vector, scan_count, fetch_state);
+				storage.Fetch(tx, l_state.all_columns, column_ids, local_vector, scan_count, l_state.fetch_state);
 				output.ReferenceColumns(l_state.all_columns, projection_ids);
 			} else {
-				storage.Fetch(tx, output, column_ids, local_vector, scan_count, fetch_state);
+				storage.Fetch(tx, output, column_ids, local_vector, scan_count, l_state.fetch_state);
 			}
 		}
 

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -32,7 +32,7 @@ struct SelectionVector {
 		Initialize(count);
 	}
 	SelectionVector(idx_t start, idx_t count) {
-		Initialize(STANDARD_VECTOR_SIZE);
+		Initialize(MaxValue<idx_t>(count, STANDARD_VECTOR_SIZE));
 		for (idx_t i = 0; i < count; i++) {
 			set_index(i, start + i);
 		}


### PR DESCRIPTION
* SelectionVector(start, count) should respect the count when initializing
* `ColumnFetchState` needs to be transaction-local, not part of the global state