### PR TITLE
Use Arrow extension GetType() implementation when converting Arrow arrays

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -80,8 +80,8 @@ void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child,
 bool SetArrowExtension(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
                        ClientContext &context) {
 	auto &config = DBConfig::GetConfig(context);
-	if (config.HasArrowExtension(type.id())) {
-		auto arrow_extension = config.GetArrowExtension(type.id());
+	if (config.HasArrowExtension(type)) {
+		auto arrow_extension = config.GetArrowExtension(type);
 		arrow_extension.PopulateArrowSchema(root_holder, child, type, context, arrow_extension);
 		return true;
 	}

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -239,6 +239,21 @@ bool DBConfig::HasArrowExtension(const LogicalType &type) const {
 	return !arrow_extensions->type_to_info[type_info].empty();
 }
 
+bool DBConfig::HasArrowExtension(ArrowExtensionMetadata info) const {
+	lock_guard<mutex> l(arrow_extensions->lock);
+	if (type_extensions.find(info) != type_extensions.end()) {
+		return true;
+	}
+
+	auto og_info = info;
+	info.SetArrowFormat("");
+	if (type_extensions.find(info) == type_extensions.end()) {
+		return true;
+	}
+
+	return false;
+}
+
 struct ArrowJson {
 	static unique_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
 		const auto format = string(schema.format);

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -243,14 +243,12 @@ struct ArrowJson {
 	static unique_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
 		const auto format = string(schema.format);
 		if (format == "u") {
-			return make_uniq<ArrowType>(LogicalType::JSON(),
-			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
+			return make_uniq<ArrowType>(LogicalType::JSON(), make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
 		} else if (format == "U") {
 			return make_uniq<ArrowType>(LogicalType::JSON(),
 			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
 		} else if (format == "vu") {
-			return make_uniq<ArrowType>(LogicalType::JSON(),
-			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::VIEW));
+			return make_uniq<ArrowType>(LogicalType::JSON(), make_uniq<ArrowStringInfo>(ArrowVariableSizeType::VIEW));
 		}
 		throw InvalidInputException("Arrow extension type \"%s\" not supported for arrow.json", format.c_str());
 	}
@@ -278,8 +276,7 @@ struct ArrowBit {
 	static unique_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
 		const auto format = string(schema.format);
 		if (format == "z") {
-			return make_uniq<ArrowType>(LogicalType::BIT,
-			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
+			return make_uniq<ArrowType>(LogicalType::BIT, make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
 		} else if (format == "Z") {
 			return make_uniq<ArrowType>(LogicalType::BIT,
 			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
@@ -306,8 +303,7 @@ struct ArrowVarint {
 	static unique_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
 		const auto format = string(schema.format);
 		if (format == "z") {
-			return make_uniq<ArrowType>(LogicalType::VARINT,
-			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
+			return make_uniq<ArrowType>(LogicalType::VARINT, make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
 		} else if (format == "Z") {
 			return make_uniq<ArrowType>(LogicalType::VARINT,
 			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -126,14 +126,14 @@ ArrowExtensionMetadata ArrowTypeExtension::GetInfo() const {
 	return extension_metadata;
 }
 
-shared_ptr<ArrowType> ArrowTypeExtension::GetType(const ArrowSchema &schema,
+unique_ptr<ArrowType> ArrowTypeExtension::GetType(const ArrowSchema &schema,
                                                   const ArrowSchemaMetadata &schema_metadata) const {
 	if (get_type) {
 		return get_type(schema, schema_metadata);
 	}
 	// FIXME: THis is not good
 	auto duckdb_type = type_extension->GetDuckDBType();
-	return make_shared_ptr<ArrowType>(duckdb_type);
+	return make_uniq<ArrowType>(duckdb_type);
 }
 
 shared_ptr<ArrowTypeExtensionData> ArrowTypeExtension::GetTypeExtension() const {
@@ -240,17 +240,17 @@ bool DBConfig::HasArrowExtension(const LogicalType &type) const {
 }
 
 struct ArrowJson {
-	static shared_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
+	static unique_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
 		const auto format = string(schema.format);
 		if (format == "u") {
-			return make_shared_ptr<ArrowType>(LogicalType::JSON(),
-			                                  make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
+			return make_uniq<ArrowType>(LogicalType::JSON(),
+			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
 		} else if (format == "U") {
-			return make_shared_ptr<ArrowType>(LogicalType::JSON(),
-			                                  make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
+			return make_uniq<ArrowType>(LogicalType::JSON(),
+			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
 		} else if (format == "vu") {
-			return make_shared_ptr<ArrowType>(LogicalType::JSON(),
-			                                  make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
+			return make_uniq<ArrowType>(LogicalType::JSON(),
+			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::VIEW));
 		}
 		throw InvalidInputException("Arrow extension type \"%s\" not supported for arrow.json", format.c_str());
 	}
@@ -275,14 +275,14 @@ struct ArrowJson {
 };
 
 struct ArrowBit {
-	static shared_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
+	static unique_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
 		const auto format = string(schema.format);
 		if (format == "z") {
-			return make_shared_ptr<ArrowType>(LogicalType::BIT,
-			                                  make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
+			return make_uniq<ArrowType>(LogicalType::BIT,
+			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
 		} else if (format == "Z") {
-			return make_shared_ptr<ArrowType>(LogicalType::BIT,
-			                                  make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
+			return make_uniq<ArrowType>(LogicalType::BIT,
+			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
 		}
 		throw InvalidInputException("Arrow extension type \"%s\" not supported for BIT type", format.c_str());
 	}
@@ -303,14 +303,14 @@ struct ArrowBit {
 };
 
 struct ArrowVarint {
-	static shared_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
+	static unique_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) {
 		const auto format = string(schema.format);
 		if (format == "z") {
-			return make_shared_ptr<ArrowType>(LogicalType::VARINT,
-			                                  make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
+			return make_uniq<ArrowType>(LogicalType::VARINT,
+			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::NORMAL));
 		} else if (format == "Z") {
-			return make_shared_ptr<ArrowType>(LogicalType::VARINT,
-			                                  make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
+			return make_uniq<ArrowType>(LogicalType::VARINT,
+			                            make_uniq<ArrowStringInfo>(ArrowVariableSizeType::SUPER_SIZE));
 		}
 		throw InvalidInputException("Arrow extension type \"%s\" not supported for Varint", format.c_str());
 	}

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -241,6 +241,8 @@ bool DBConfig::HasArrowExtension(const LogicalType &type) const {
 
 bool DBConfig::HasArrowExtension(ArrowExtensionMetadata info) const {
 	lock_guard<mutex> l(arrow_extensions->lock);
+	auto type_extensions = arrow_extensions->type_extensions;
+
 	if (type_extensions.find(info) != type_extensions.end()) {
 		return true;
 	}

--- a/src/common/arrow/arrow_type_extension.cpp
+++ b/src/common/arrow/arrow_type_extension.cpp
@@ -249,7 +249,7 @@ bool DBConfig::HasArrowExtension(ArrowExtensionMetadata info) const {
 
 	auto og_info = info;
 	info.SetArrowFormat("");
-	if (type_extensions.find(info) == type_extensions.end()) {
+	if (type_extensions.find(info) != type_extensions.end()) {
 		return true;
 	}
 

--- a/src/function/table/arrow/arrow_duck_schema.cpp
+++ b/src/function/table/arrow/arrow_duck_schema.cpp
@@ -369,9 +369,11 @@ unique_ptr<ArrowType> ArrowType::GetTypeFromSchema(DBConfig &config, ArrowSchema
 	auto arrow_type = GetTypeFromFormat(config, schema, format);
 	if (schema_metadata.HasExtension()) {
 		auto extension_info = schema_metadata.GetExtensionInfo(string(format));
-		auto extension = config.GetArrowExtension(extension_info);
-		arrow_type = extension.GetType(schema, schema_metadata);
-		arrow_type->extension_data = extension.GetTypeExtension();
+		if (config.HasArrowExtension(config)) {
+			auto extension = config.GetArrowExtension(extension_info);
+			arrow_type = extension.GetType(schema, schema_metadata);
+			arrow_type->extension_data = extension.GetTypeExtension();
+		}
 	}
 
 	return arrow_type;

--- a/src/function/table/arrow/arrow_duck_schema.cpp
+++ b/src/function/table/arrow/arrow_duck_schema.cpp
@@ -367,11 +367,13 @@ unique_ptr<ArrowType> ArrowType::GetTypeFromSchema(DBConfig &config, ArrowSchema
 	// Let's first figure out if this type is an extension type
 	ArrowSchemaMetadata schema_metadata(schema.metadata);
 	auto arrow_type = GetTypeFromFormat(config, schema, format);
-	if (schema_metadata.HasExtension() && config.HasArrowExtension(schema_metadata)) {
+	if (schema_metadata.HasExtension()) {
 		auto extension_info = schema_metadata.GetExtensionInfo(string(format));
-		auto extension = config.GetArrowExtension(extension_info);
-		arrow_type = extension.GetType(schema, schema_metadata);
-		arrow_type->extension_data = extension.GetTypeExtension();
+		if (config.HasArrowExtension(extension_info)) {
+			auto extension = config.GetArrowExtension(extension_info);
+			arrow_type = extension.GetType(schema, schema_metadata);
+			arrow_type->extension_data = extension.GetTypeExtension();
+		}
 	}
 
 	return arrow_type;

--- a/src/function/table/arrow/arrow_duck_schema.cpp
+++ b/src/function/table/arrow/arrow_duck_schema.cpp
@@ -369,8 +369,11 @@ unique_ptr<ArrowType> ArrowType::GetTypeFromSchema(DBConfig &config, ArrowSchema
 	auto arrow_type = GetTypeFromFormat(config, schema, format);
 	if (schema_metadata.HasExtension()) {
 		auto extension_info = schema_metadata.GetExtensionInfo(string(format));
-		arrow_type->extension_data = config.GetArrowExtension(extension_info).GetTypeExtension();
+		auto extension = config.GetArrowExtension(extension_info);
+		arrow_type = extension.GetType(schema, schema_metadata);
+		arrow_type->extension_data = extension.GetTypeExtension();
 	}
+
 	return arrow_type;
 }
 

--- a/src/function/table/arrow/arrow_duck_schema.cpp
+++ b/src/function/table/arrow/arrow_duck_schema.cpp
@@ -367,13 +367,11 @@ unique_ptr<ArrowType> ArrowType::GetTypeFromSchema(DBConfig &config, ArrowSchema
 	// Let's first figure out if this type is an extension type
 	ArrowSchemaMetadata schema_metadata(schema.metadata);
 	auto arrow_type = GetTypeFromFormat(config, schema, format);
-	if (schema_metadata.HasExtension()) {
+	if (schema_metadata.HasExtension() && config.HasArrowExtension(schema_metadata)) {
 		auto extension_info = schema_metadata.GetExtensionInfo(string(format));
-		if (config.HasArrowExtension(config)) {
-			auto extension = config.GetArrowExtension(extension_info);
-			arrow_type = extension.GetType(schema, schema_metadata);
-			arrow_type->extension_data = extension.GetTypeExtension();
-		}
+		auto extension = config.GetArrowExtension(extension_info);
+		arrow_type = extension.GetType(schema, schema_metadata);
+		arrow_type->extension_data = extension.GetTypeExtension();
 	}
 
 	return arrow_type;

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -1104,7 +1104,7 @@ static void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowArraySca
 				break;
 			case ArrowArrayPhysicalType::DEFAULT:
 				ColumnArrowToDuckDB(child_entry, child_array, child_state, size, child_type, nested_offset,
-				                    &struct_validity_mask, NumericCast<uint64_t>(array.offset), true);
+				                    &struct_validity_mask, NumericCast<uint64_t>(array.offset), false);
 				break;
 			default:
 				throw NotImplementedException("ArrowArrayPhysicalType not recognized");
@@ -1131,14 +1131,14 @@ static void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowArraySca
 
 			switch (array_physical_type) {
 			case ArrowArrayPhysicalType::DICTIONARY_ENCODED:
-				ColumnArrowToDuckDBDictionary(child, child_array, child_state, size, child_type, true);
+				ColumnArrowToDuckDBDictionary(child, child_array, child_state, size, child_type);
 				break;
 			case ArrowArrayPhysicalType::RUN_END_ENCODED:
-				ColumnArrowToDuckDBRunEndEncoded(child, child_array, child_state, size, child_type, true);
+				ColumnArrowToDuckDBRunEndEncoded(child, child_array, child_state, size, child_type);
 				break;
 			case ArrowArrayPhysicalType::DEFAULT:
 				ColumnArrowToDuckDB(child, child_array, child_state, size, child_type, nested_offset, &validity_mask,
-				                    true);
+				                    false);
 				break;
 			default:
 				throw NotImplementedException("ArrowArrayPhysicalType not recognized");

--- a/src/function/table/arrow_conversion.cpp
+++ b/src/function/table/arrow_conversion.cpp
@@ -119,7 +119,7 @@ static void ColumnArrowToDuckDBRunEndEncoded(Vector &vector, const ArrowArray &a
 static void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowArrayScanState &array_state, idx_t size,
                                 const ArrowType &arrow_type, int64_t nested_offset = -1,
                                 ValidityMask *parent_mask = nullptr, uint64_t parent_offset = 0,
-								bool ignore_extensions = false);
+                                bool ignore_extensions = false);
 
 static void ColumnArrowToDuckDBDictionary(Vector &vector, ArrowArray &array, ArrowArrayScanState &array_state,
                                           idx_t size, const ArrowType &arrow_type, int64_t nested_offset = -1,

--- a/src/include/duckdb/common/arrow/arrow_type_extension.hpp
+++ b/src/include/duckdb/common/arrow/arrow_type_extension.hpp
@@ -65,7 +65,7 @@ typedef void (*populate_arrow_schema_t)(DuckDBArrowSchemaHolder &root_holder, Ar
                                         const LogicalType &type, ClientContext &context,
                                         const ArrowTypeExtension &extension);
 
-typedef shared_ptr<ArrowType> (*get_type_t)(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata);
+typedef unique_ptr<ArrowType> (*get_type_t)(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata);
 
 class ArrowTypeExtension {
 public:
@@ -86,7 +86,7 @@ public:
 
 	ArrowExtensionMetadata GetInfo() const;
 
-	shared_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) const;
+	unique_ptr<ArrowType> GetType(const ArrowSchema &schema, const ArrowSchemaMetadata &schema_metadata) const;
 
 	shared_ptr<ArrowTypeExtensionData> GetTypeExtension() const;
 

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -382,6 +382,7 @@ public:
 	DUCKDB_API ArrowTypeExtension GetArrowExtension(ArrowExtensionMetadata info) const;
 	DUCKDB_API ArrowTypeExtension GetArrowExtension(const LogicalType &type) const;
 	DUCKDB_API bool HasArrowExtension(const LogicalType &type) const;
+	DUCKDB_API bool HasArrowExtension(ArrowExtensionMetadata info) const;
 	DUCKDB_API void RegisterArrowExtension(const ArrowTypeExtension &extension) const;
 
 	bool operator==(const DBConfig &other);


### PR DESCRIPTION
A possible fix to https://github.com/duckdb/duckdb/pull/15285#discussion_r1921637000 

I think the problem is that the `GetType()` implementation provided when registering the extension was never called. I am not sure this is the fix you all want to go with, but the current conversion (for extensions) I think will fail in some pretty common cases (e.g., https://github.com/duckdb/duckdb-spatial/pull/485 ).