### PR TITLE
enable autoloading for iceberg and delta for storage

### DIFF
--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -718,6 +718,7 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "excel",
     "fts",
     "httpfs",
+    "iceberg",
     "inet",
     "icu",
     "json",
@@ -729,6 +730,7 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "postgres_scanner",
     "tpcds",
     "tpch"
+    "uc_catalog"
 }; // END_OF_AUTOLOADABLE_EXTENSIONS
 
 } // namespace duckdb"""

--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -729,7 +729,7 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "sqlsmith",
     "postgres_scanner",
     "tpcds",
-    "tpch"
+    "tpch",
     "uc_catalog"
 }; // END_OF_AUTOLOADABLE_EXTENSIONS
 

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1069,26 +1069,10 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"mysql/config", "mysql_scanner"},
     {"postgres/config", "postgres_scanner"}}; // EXTENSION_SECRET_PROVIDERS
 
-static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"aws",
-                                                          "azure",
-                                                          "autocomplete",
-                                                          "core_functions",
-                                                          "delta",
-                                                          "excel",
-                                                          "fts",
-                                                          "httpfs",
-                                                          "iceberg",
-                                                          "inet",
-                                                          "icu",
-                                                          "json",
-                                                          "motherduck",
-                                                          "mysql_scanner",
-                                                          "parquet",
-                                                          "sqlite_scanner",
-                                                          "sqlsmith",
-                                                          "postgres_scanner",
-                                                          "tpcds",
-                                                          "tpch",
-                                                          "uc_catalog"}; // END_OF_AUTOLOADABLE_EXTENSIONS
+static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
+    "aws",        "azure",         "autocomplete", "core_functions", "delta",    "excel",
+    "fts",        "httpfs",        "iceberg",      "inet",           "icu",      "json",
+    "motherduck", "mysql_scanner", "parquet",      "sqlite_scanner", "sqlsmith", "postgres_scanner",
+    "tpcds",      "tpch",          "uc_catalog"}; // END_OF_AUTOLOADABLE_EXTENSIONS
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1069,10 +1069,26 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"mysql/config", "mysql_scanner"},
     {"postgres/config", "postgres_scanner"}}; // EXTENSION_SECRET_PROVIDERS
 
-static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
-    "aws",        "azure",         "autocomplete", "core_functions", "delta",    "excel",
-    "fts",        "httpfs",        "iceberg",      "inet",           "icu",      "json",
-    "motherduck", "mysql_scanner", "parquet",      "sqlite_scanner", "sqlsmith", "postgres_scanner",
-    "tpcds",      "tpch",          "uc_catalog"}; // END_OF_AUTOLOADABLE_EXTENSIONS
+static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"aws",
+                                                          "azure",
+                                                          "autocomplete",
+                                                          "core_functions",
+                                                          "delta",
+                                                          "excel",
+                                                          "fts",
+                                                          "httpfs",
+                                                          "iceberg",
+                                                          "inet",
+                                                          "icu",
+                                                          "json",
+                                                          "motherduck",
+                                                          "mysql_scanner",
+                                                          "parquet",
+                                                          "sqlite_scanner",
+                                                          "sqlsmith",
+                                                          "postgres_scanner",
+                                                          "tpcds",
+                                                          "tpch"
+                                                          "uc_catalog"}; // END_OF_AUTOLOADABLE_EXTENSIONS
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1077,6 +1077,7 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"aws",
                                                           "excel",
                                                           "fts",
                                                           "httpfs",
+                                                          "iceberg",
                                                           "inet",
                                                           "icu",
                                                           "json",
@@ -1087,6 +1088,7 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"aws",
                                                           "sqlsmith",
                                                           "postgres_scanner",
                                                           "tpcds",
-                                                          "tpch"}; // END_OF_AUTOLOADABLE_EXTENSIONS
+                                                          "tpch",
+                                                          "uc_catalog"}; // END_OF_AUTOLOADABLE_EXTENSIONS
 
 } // namespace duckdb

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1088,7 +1088,7 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {"aws",
                                                           "sqlsmith",
                                                           "postgres_scanner",
                                                           "tpcds",
-                                                          "tpch"
+                                                          "tpch",
                                                           "uc_catalog"}; // END_OF_AUTOLOADABLE_EXTENSIONS
 
 } // namespace duckdb

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -140,7 +140,7 @@ DefaultExtension ExtensionHelper::GetDefaultExtension(idx_t index) {
 // Allow Auto-Install Extensions
 //===--------------------------------------------------------------------===//
 static const char *const auto_install[] = {"motherduck", "postgres_scanner", "mysql_scanner", "sqlite_scanner",
-                                           nullptr};
+                                           "delta",      "iceberg",          "uc_catalog",    nullptr};
 
 // TODO: unify with new autoload mechanism
 bool ExtensionHelper::AllowAutoInstall(const string &extension) {


### PR DESCRIPTION
This allows native DuckDB to run:

```SQL
ATTACH 'delta_table' as dt (TYPE delta);
FROM dt;
```
without explicit install or load statements. Same for iceberg when we implement it