### PR TITLE
Fixup shell & autocomplete versioning information

### DIFF
--- a/extension/autocomplete/autocomplete_extension.cpp
+++ b/extension/autocomplete/autocomplete_extension.cpp
@@ -481,11 +481,7 @@ std::string AutocompleteExtension::Name() {
 }
 
 std::string AutocompleteExtension::Version() const {
-#ifdef EXT_VERSION_AUTOCOMPLETE
-	return EXT_VERSION_AUTOCOMPLETE;
-#else
-	return "";
-#endif
+	return DefaultVersion();
 }
 
 } // namespace duckdb
@@ -496,7 +492,7 @@ DUCKDB_EXTENSION_API void autocomplete_init(duckdb::DatabaseInstance &db) {
 }
 
 DUCKDB_EXTENSION_API const char *autocomplete_version() {
-	return duckdb::DuckDB::LibraryVersion();
+	return duckdb::AutocompleteExtension::DefaultVersion();
 }
 }
 

--- a/src/function/table/system/duckdb_extensions.cpp
+++ b/src/function/table/system/duckdb_extensions.cpp
@@ -149,11 +149,15 @@ unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context
 			auto entry = installed_extensions.find(ext_name);
 			if (entry == installed_extensions.end() || !entry->second.installed) {
 				ExtensionInformation &info = installed_extensions[ext_name];
+
 				info.name = ext_name;
 				info.loaded = true;
 				info.extension_version = ext_install_info->version;
 				info.installed = ext_install_info->mode == ExtensionInstallMode::STATICALLY_LINKED;
 				info.install_mode = ext_install_info->mode;
+				if (ext_data.install_info->mode == ExtensionInstallMode::STATICALLY_LINKED && info.file_path.empty()) {
+					info.file_path = "(BUILT-IN)";
+				}
 			} else {
 				entry->second.loaded = true;
 				entry->second.extension_version = ext_install_info->version;

--- a/src/include/duckdb/main/extension.hpp
+++ b/src/include/duckdb/main/extension.hpp
@@ -24,6 +24,7 @@ public:
 	DUCKDB_API virtual std::string Version() const {
 		return "";
 	}
+	DUCKDB_API static const char *DefaultVersion();
 };
 
 enum class ExtensionABIType : uint8_t {

--- a/src/main/extension.cpp
+++ b/src/main/extension.cpp
@@ -137,4 +137,11 @@ bool VersioningUtils::ParseSemver(string &semver, idx_t &major_out, idx_t &minor
 	return true;
 }
 
+const char *Extension::DefaultVersion() {
+	if (ExtensionHelper::IsRelease(DuckDB::LibraryVersion())) {
+		return DuckDB::LibraryVersion();
+	}
+	return DuckDB::SourceID();
+}
+
 } // namespace duckdb

--- a/tools/sqlite3_api_wrapper/include/shell_extension.hpp
+++ b/tools/sqlite3_api_wrapper/include/shell_extension.hpp
@@ -16,6 +16,7 @@ class ShellExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/tools/sqlite3_api_wrapper/shell_extension.cpp
+++ b/tools/sqlite3_api_wrapper/shell_extension.cpp
@@ -38,4 +38,8 @@ std::string ShellExtension::Name() {
 	return "shell";
 }
 
+std::string ShellExtension::Version() const {
+	return DefaultVersion();
+}
+
 } // namespace duckdb


### PR DESCRIPTION
Executing:
```sql
SELECT extension_name, install_path, extension_version FROm duckdb_extensions() WHERE install_mode == 'STATICALLY_LINKED';
```
Before (example on v1.1.3):
```
┌────────────────┬──────────────┬───────────────────┐
│ extension_name │ install_path │ extension_version │
│    varchar     │   varchar    │      varchar      │
├────────────────┼──────────────┼───────────────────┤
│ autocomplete   │ (BUILT-IN)   │                   │
│ icu            │ (BUILT-IN)   │ v1.1.3            │
│ json           │ (BUILT-IN)   │ v1.1.3            │
│ parquet        │ (BUILT-IN)   │ v1.1.3            │
│ shell          │              │                   │
└────────────────┴──────────────┴───────────────────┘
```
After (icu I had not built locally, but no changes there):
```
┌────────────────┬──────────────┬───────────────────┐
│ extension_name │ install_path │ extension_version │
│    varchar     │   varchar    │      varchar      │
├────────────────┼──────────────┼───────────────────┤
│ autocomplete   │ (BUILT-IN)   │ f1c115d59d        │
│ core_functions │ (BUILT-IN)   │ f1c115d59d        │
│ parquet        │ (BUILT-IN)   │ f1c115d59d        │
│ shell          │ (BUILT-IN)   │ f1c115d59d        │
└────────────────┴──────────────┴───────────────────┘
```

Basically `shell` and `autocomplete` get the same version as duckdb (that is either `v1.x.y` for releases or the hash).

Minor, but should have no drawbacks.