### PR TITLE
improve error messages for mismatching versions of extensions

### DIFF
--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -400,8 +400,7 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 		}
 
 		if (!signature_valid) {
-			throw IOException(db.config.error_manager->FormatException(ErrorType::UNSIGNED_EXTENSION, filename) +
-			                  metadata_mismatch_error);
+			throw IOException(db.config.error_manager->FormatException(ErrorType::UNSIGNED_EXTENSION, filename));
 		}
 
 		if (!metadata_mismatch_error.empty()) {

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -399,13 +399,12 @@ bool ExtensionHelper::TryInitialLoad(DatabaseInstance &db, FileSystem &fs, const
 			signature_valid = false;
 		}
 
-		if (!signature_valid) {
-			throw IOException(db.config.error_manager->FormatException(ErrorType::UNSIGNED_EXTENSION, filename));
+		if (!metadata_mismatch_error.empty()) {
+			throw InvalidInputException(metadata_mismatch_error);
 		}
 
-		if (!metadata_mismatch_error.empty()) {
-			// Signed extensions perform the full check
-			throw InvalidInputException(metadata_mismatch_error);
+		if (!signature_valid) {
+			throw IOException(db.config.error_manager->FormatException(ErrorType::UNSIGNED_EXTENSION, filename));
 		}
 	} else if (!db.config.options.allow_extensions_metadata_mismatch) {
 		if (!metadata_mismatch_error.empty()) {

--- a/test/extension/update_extensions_ci.test
+++ b/test/extension/update_extensions_ci.test
@@ -202,13 +202,13 @@ statement error
 FORCE INSTALL '${DIRECT_INSTALL_DIR}/json_incorrect_version.duckdb_extension';
 ----
 Failed to install './build/extension_metadata_test_data/direct_install/json_incorrect_version.duckdb_extension'
-The file was built for DuckDB version 'v1337', but we can only load extensions built for DuckDB version
+The file was built specifically for DuckDB version 'v1337' and can only be loaded with that version of DuckDB. (this version of DuckDB is
 
 statement error
 FORCE INSTALL json_incorrect_version FROM '${LOCAL_EXTENSION_REPO_INCORRECT_DUCKDB_VERSION}';
 ----
 Failed to install 'json_incorrect_version'
-The file was built for DuckDB version 'v1337', but we can only load extensions built for DuckDB version
+The file was built specifically for DuckDB version 'v1337' and can only be loaded with that version of DuckDB. (this version of DuckDB is
 
 # These should print both errors
 statement error
@@ -235,7 +235,7 @@ The file was built for the platform 'test_platform', but we can only load extens
 statement error
 LOAD '${DIRECT_INSTALL_DIR}/json_incorrect_version.duckdb_extension';
 ----
-The file was built for DuckDB version 'v1337', but we can only load extensions built for DuckDB version
+The file was built specifically for DuckDB version 'v1337' and can only be loaded with that version of DuckDB. (this version of DuckDB is
 
 # Note that this is the json extension with incorrect platform and version
 statement error


### PR DESCRIPTION
Solves a problem where confusing error messages would get thrown when trying to load experimental C API extensions that were still versioned with C API version `v0.0.1`