### PR TITLE
Reset buffer before allocating a new one in `ResizableBuffer`

### DIFF
--- a/extension/parquet/include/resizable_buffer.hpp
+++ b/extension/parquet/include/resizable_buffer.hpp
@@ -98,6 +98,7 @@ public:
 		}
 		if (new_size > alloc_len) {
 			alloc_len = NextPowerOfTwo(new_size);
+			allocated_data.Reset(); // Have to reset before allocating new buffer (otherwise we use ~2x the memory)
 			allocated_data = allocator.Allocate(alloc_len);
 			ptr = allocated_data.get();
 		}


### PR DESCRIPTION
Slightly reduces the memory usage of the Parquet reader in some edge cases

Fixes https://github.com/duckdb/duckdb/issues/15687