### PR TITLE
Clean up benchmark data before each new regression job start

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -170,10 +170,11 @@ jobs:
           python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/csv.csv --verbose --threads 2
 
       - name: Regression Test RealNest 
-        if: ${{ github.event_name != 'repository_dispatch' }}
+        if: always()
         shell: bash
         run: |
           mkdir -p duckdb_benchmark_data
+          rm -R duckdb/duckdb_benchmark_data
           mkdir -p duckdb/duckdb_benchmark_data
           wget https://duckdb-blobs.s3.amazonaws.com/data/realnest/realnest.duckdb --output-document=duckdb_benchmark_data/real_nest.duckdb
           cp duckdb_benchmark_data/real_nest.duckdb duckdb/duckdb_benchmark_data/real_nest.duckdb

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -170,7 +170,7 @@ jobs:
           python scripts/regression/test_runner.py --old duckdb/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/csv.csv --verbose --threads 2
 
       - name: Regression Test RealNest 
-        if: always()
+        if: ${{ github.event_name != 'repository_dispatch' }}
         shell: bash
         run: |
           mkdir -p duckdb_benchmark_data


### PR DESCRIPTION
Regression tests fail only on `nightly-build` runs so we could disable them for `nightly-build` for now as discussed [here](https://github.com/duckdblabs/duckdb-internal/issues/4010#event-16026598475)

`github.event_name != 'repository_dispatch'` condition should not it let run on `nighly_build`