### PR TITLE
Fix #15570: preserve alias when using bind_replace in table functions

### DIFF
--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -203,7 +203,9 @@ unique_ptr<LogicalOperator> Binder::BindTableFunctionInternal(TableFunction &tab
 		                                  table_function.function_info.get(), this, table_function, ref);
 		if (table_function.bind_replace) {
 			auto new_plan = table_function.bind_replace(context, bind_input);
-			if (new_plan != nullptr) {
+			if (new_plan) {
+				new_plan->alias = ref.alias;
+				new_plan->column_name_alias = ref.column_name_alias;
 				return CreatePlan(*Bind(*new_plan));
 			} else if (!table_function.bind) {
 				throw BinderException("Failed to bind \"%s\": nullptr returned from bind_replace without bind function",

--- a/test/sql/catalog/function/query_function.test
+++ b/test/sql/catalog/function/query_function.test
@@ -249,6 +249,16 @@ FROM query_table('SELECT 4 + 2');
 ----
 Catalog Error: Table with name SELECT 4 + 2 does not exist!
 
+query I
+SELECT f.* FROM query_table('tbl_int') as f;
+----
+42
+
+query I
+SELECT f.x FROM query_table('tbl_int') as f(x);
+----
+42
+
 # test by_name argument
 query I
 FROM query_table(['tbl_int', 'tbl_varchar', 'tbl_empty', 'tbl2_varchar'], false);


### PR DESCRIPTION
Fix #15570