### PR TITLE
Allow the cpptrace library to generate stacktraces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,7 @@ option(BUILD_RDTSC "Enable the rdtsc instruction." FALSE)
 option(TEST_REMOTE_INSTALL "Test installation of specific extensions." FALSE)
 option(SMALLER_BINARY "Produce a smaller binary by trimming specialized code paths. This can negatively affect performance." FALSE)
 option(NATIVE_ARCH "Compile targeting the native architecture" FALSE)
+option(DUCKDB_CPPTRACE "Use cpptrace library for exception stacktraces" FALSE)
 
 if(${BUILD_RDTSC})
   add_compile_definitions(RDTSC)
@@ -516,6 +517,10 @@ endif()
 
 if(FORCE_ASSERT)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDUCKDB_FORCE_ASSERT")
+endif()
+
+if(DUCKDB_CPPTRACE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDUCKDB_CPPTRACE")
 endif()
 
 if("${VERIFY_VECTOR}" STREQUAL "none" OR "${VERIFY_VECTOR}" STREQUAL "OFF")
@@ -1515,4 +1520,14 @@ if(EXISTS ${CMAKE_CONFIG_TEMPLATE} AND EXISTS ${CMAKE_CONFIG_VERSION_TEMPLATE})
     FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/DuckDBConfig.cmake"
           "${PROJECT_BINARY_DIR}/DuckDBConfigVersion.cmake"
     DESTINATION "${INSTALL_CMAKE_DIR}")
+endif()
+
+if(DUCKDB_CPPTRACE)
+    include(FetchContent)
+    FetchContent_Declare(
+      cpptrace
+      GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+      GIT_TAG        v0.7.5 # <HASH or TAG>
+    )
+    FetchContent_MakeAvailable(cpptrace)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,11 @@ ifdef DUCKDB_PLATFORM
 	endif
 endif
 
+# Set to reldebug to create a library bundle with debug info.
+ifeq ("${BUNDLE_LIBRARY_BASE}", "")
+    BUNDLE_LIBRARY_BASE:="release"
+endif
+
 clean:
 	rm -rf build
 
@@ -500,7 +505,7 @@ generate-files:
 	$(MAKE) format-main
 
 bundle-setup:
-	cd build/release && \
+	cd build/${BUNDLE_LIBRARY_BASE} && \
 	rm -rf bundle && \
 	mkdir -p bundle && \
 	cp src/libduckdb_static.a bundle/. && \
@@ -511,12 +516,12 @@ bundle-setup:
 	find . -name '*.a' -execdir ${AR} -x {} \;
 
 bundle-library-o: bundle-setup
-	cd build/release/bundle && \
+	cd build/${BUNDLE_LIBRARY_BASE}/bundle && \
 	echo ./*/*.o | xargs ${AR} cr ../libduckdb_bundle.a
 
 bundle-library-obj: bundle-setup
-	cd build/release/bundle && \
+	cd build/${BUNDLE_LIBRARY_BASE}/bundle && \
 	echo ./*/*.obj | xargs ${AR} cr ../libduckdb_bundle.a
 
-bundle-library: release
+bundle-library: ${BUNDLE_LIBRARY_BASE}
 	make bundle-library-o

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,12 +63,18 @@ if(AMALGAMATION_BUILD)
   target_link_libraries(duckdb ${DUCKDB_SYSTEM_LIBS})
   link_threads(duckdb)
   link_extension_libraries(duckdb)
+  if(DUCKDB_CPPTRACE)
+    target_link_libraries(duckdb cpptrace::cpptrace)
+  endif()
 
   add_library(duckdb_static STATIC
               "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
   target_link_libraries(duckdb_static ${DUCKDB_SYSTEM_LIBS})
   link_threads(duckdb_static)
   link_extension_libraries(duckdb_static)
+  if(DUCKDB_CPPTRACE)
+    target_link_libraries(duckdb_static cpptrace::cpptrace)
+  endif()
 
   install(FILES "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.hpp"
                 "${PROJECT_SOURCE_DIR}/src/include/duckdb.h"
@@ -134,11 +140,17 @@ else()
   target_link_libraries(duckdb ${DUCKDB_LINK_LIBS})
   link_threads(duckdb)
   link_extension_libraries(duckdb)
+  if(DUCKDB_CPPTRACE)
+    target_link_libraries(duckdb cpptrace::cpptrace)
+  endif()
 
   add_library(duckdb_static STATIC ${ALL_OBJECT_FILES})
   target_link_libraries(duckdb_static ${DUCKDB_LINK_LIBS})
   link_threads(duckdb_static)
   link_extension_libraries(duckdb_static)
+  if(DUCKDB_CPPTRACE)
+    target_link_libraries(duckdb_static cpptrace::cpptrace)
+  endif()
 
   target_include_directories(
     duckdb PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/include/duckdb/common/stacktrace.hpp
+++ b/src/include/duckdb/common/stacktrace.hpp
@@ -9,6 +9,9 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#ifdef DUCKDB_CPPTRACE
+#include <cpptrace/cpptrace.hpp>
+#endif
 
 namespace duckdb {
 
@@ -18,7 +21,11 @@ public:
 	static string ResolveStacktraceSymbols(const string &pointers);
 
 	inline static string GetStackTrace(idx_t max_depth = 120) {
+#ifdef DUCKDB_CPPTRACE
+		return cpptrace::generate_trace().to_string(false);
+#else
 		return ResolveStacktraceSymbols(GetStacktracePointers(max_depth));
+#endif
 	}
 };
 


### PR DESCRIPTION
On Linux, when using DuckDB as a shared library integrated with other runtimes (e.g., golang) you don't get the stacktrace with file, function and line numbers. The `cpptrace` library helps with that. The default configuration works with `libgcc unwind`, `libdwarf` for symbols and `cxxabi` for demangling.

To use cpptrace, set `CMAKE_VARS` to `"-DDUCKDB_CPPTRACE=1"`. You should use the `reldebug` target (or set `CMAKE_BUILD_TYPE to RelWithDebInfo`) to ensure debug symbols are generated.