### PR TITLE
fix: Fix compiler warning for uninitialized access

### DIFF
--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -28,9 +28,10 @@ Connection::Connection(DatabaseInstance &database)
 }
 
 Connection::Connection(DuckDB &database) : Connection(*database.instance) {
+	// Initialization of warning_cb happens in the other constructor
 }
 
-Connection::Connection(Connection &&other) noexcept {
+Connection::Connection(Connection &&other) noexcept : warning_cb(nullptr) {
 	std::swap(context, other.context);
 	std::swap(warning_cb, other.warning_cb);
 }


### PR DESCRIPTION
Flagged by CRAN.

Follow-up to https://github.com/duckdb/duckdb/pull/14627.