### PR TITLE
Fix duckdb_extensions() listing

### DIFF
--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -90,6 +90,12 @@ string ExtensionHelper::GetExtensionDirectoryPath(DatabaseInstance &db, FileSyst
 	extension_directory = fs.ConvertSeparators(extension_directory);
 	// expand ~ in extension directory
 	extension_directory = fs.ExpandPath(extension_directory);
+
+	auto path_components = PathComponents();
+	for (auto &path_ele : path_components) {
+		extension_directory = fs.JoinPath(extension_directory, path_ele);
+	}
+
 	return extension_directory;
 }
 
@@ -117,13 +123,6 @@ string ExtensionHelper::ExtensionDirectory(DatabaseInstance &db, FileSystem &fs)
 	}
 	D_ASSERT(fs.DirectoryExists(extension_directory));
 
-	auto path_components = PathComponents();
-	for (auto &path_ele : path_components) {
-		extension_directory = fs.JoinPath(extension_directory, path_ele);
-		if (!fs.DirectoryExists(extension_directory)) {
-			fs.CreateDirectory(extension_directory);
-		}
-	}
 	return extension_directory;
 }
 

--- a/test/extension/autoloading_base.test
+++ b/test/extension/autoloading_base.test
@@ -10,6 +10,11 @@ require-env LOCAL_EXTENSION_REPO
 statement ok
 set extension_directory='__TEST_DIR__/autoloading_base'
 
+query I
+SELECT (count(*) > 0) FROM duckdb_extensions() WHERE install_path ILIKE '%duckdb_extension'
+----
+false
+
 ### No autoloading nor installing: throw error with installation hint
 statement ok
 set autoload_known_extensions=false
@@ -87,3 +92,8 @@ SET s3_region='eu-west-1';
 
 statement ok
 select * from read_json_auto('data/json/example_n.ndjson');
+
+query I
+SELECT (count(*) > 0) FROM duckdb_extensions() WHERE install_path ILIKE '%duckdb_extension';
+----
+true


### PR DESCRIPTION
Currently:
```
INSTALL tpcds;
LOAD tpcds;
FROM duckdb_extensions() WHERE extension_name = 'tpcds';
```
Do not show the extension as installed.

This was a problem only with `duckdb_extensions()`, not with INSTALL, LOAD or UPDATE codepaths, but seems a relevant piece to get right.

Found by @hmeriann while testing.