### PR TITLE
Remove `installed` column from duckdb extensions()

### DIFF
--- a/src/function/pragma/pragma_queries.cpp
+++ b/src/function/pragma/pragma_queries.cpp
@@ -130,7 +130,7 @@ string PragmaVersion(ClientContext &context, const FunctionParameters &parameter
 
 string PragmaExtensionVersions(ClientContext &context, const FunctionParameters &parameters) {
 	return "select extension_name, extension_version, install_mode, installed_from from duckdb_extensions() where "
-	       "installed";
+	       "install_mode IS NOT NULL";
 }
 
 string PragmaPlatform(ClientContext &context, const FunctionParameters &parameters) {

--- a/src/function/table/system/duckdb_extensions.cpp
+++ b/src/function/table/system/duckdb_extensions.cpp
@@ -42,9 +42,6 @@ static unique_ptr<FunctionData> DuckDBExtensionsBind(ClientContext &context, Tab
 	names.emplace_back("loaded");
 	return_types.emplace_back(LogicalType::BOOLEAN);
 
-	names.emplace_back("installed");
-	return_types.emplace_back(LogicalType::BOOLEAN);
-
 	names.emplace_back("install_path");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
@@ -190,25 +187,24 @@ void DuckDBExtensionsFunction(ClientContext &context, TableFunctionInput &data_p
 	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = data.entries[data.offset];
 
+		int col = 0;
 		// return values:
 		// extension_name LogicalType::VARCHAR
-		output.SetValue(0, count, Value(entry.name));
+		output.SetValue(col++, count, Value(entry.name));
 		// loaded LogicalType::BOOLEAN
-		output.SetValue(1, count, Value::BOOLEAN(entry.loaded));
-		// installed LogicalType::BOOLEAN
-		output.SetValue(2, count, Value::BOOLEAN(entry.installed));
+		output.SetValue(col++, count, Value::BOOLEAN(entry.loaded));
 		// install_path LogicalType::VARCHAR
-		output.SetValue(3, count, Value(entry.file_path));
+		output.SetValue(col++, count, Value(entry.file_path));
 		// description LogicalType::VARCHAR
-		output.SetValue(4, count, Value(entry.description));
+		output.SetValue(col++, count, Value(entry.description));
 		// aliases     LogicalType::LIST(LogicalType::VARCHAR)
-		output.SetValue(5, count, Value::LIST(LogicalType::VARCHAR, entry.aliases));
+		output.SetValue(col++, count, Value::LIST(LogicalType::VARCHAR, entry.aliases));
 		// extension version     LogicalType::LIST(LogicalType::VARCHAR)
-		output.SetValue(6, count, Value(entry.extension_version));
+		output.SetValue(col++, count, Value(entry.extension_version));
 		// installed_mode LogicalType::VARCHAR
-		output.SetValue(7, count, entry.installed ? Value(EnumUtil::ToString(entry.install_mode)) : Value());
+		output.SetValue(col++, count, entry.installed ? Value(EnumUtil::ToString(entry.install_mode)) : Value());
 		// installed_source LogicalType::VARCHAR
-		output.SetValue(8, count, Value(entry.installed_from));
+		output.SetValue(col++, count, Value(entry.installed_from));
 
 		data.offset++;
 		count++;

--- a/test/extension/update_extensions.test
+++ b/test/extension/update_extensions.test
@@ -59,7 +59,7 @@ loadable_extension_demo	(empty)	NOT_A_REPOSITORY	default-version	default-version
 
 # Doublecheck duckdb_extensions()
 query IIII rowsort
-SELECT extension_name, extension_version, install_mode, installed_from from duckdb_extensions() where installed
+SELECT extension_name, extension_version, install_mode, installed_from from duckdb_extensions() where install_mode IS NOT NULL
 ----
 json	<REGEX>:.*	REPOSITORY	<REGEX>:.*
 loadable_extension_demo	default-version	CUSTOM_PATH	<REGEX>:.*loadable\_extension\_demo\.duckdb_extension

--- a/test/extension/update_extensions_ci.test
+++ b/test/extension/update_extensions_ci.test
@@ -49,7 +49,7 @@ set extension_directory='${LOCAL_EXTENSION_DIR_MALFORMED_INFO}'
 
 # this will now throw IOError
 statement error
-FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 IO Error: Failed to read info file for 'tpcds' extension
 
@@ -65,7 +65,7 @@ FORCE INSTALL '${DIRECT_INSTALL_DIR}/tpcds.duckdb_extension';
 
 # Things are back to normal
 query IIII
-SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 tpcds	CUSTOM_PATH	./build/extension_metadata_test_data/direct_install/tpcds.duckdb_extension	v0.0.1
 
@@ -86,7 +86,7 @@ set extension_directory='${LOCAL_EXTENSION_DIR_INFO_INCORRECT_VERSION}'
 
 # duckdb_extensions() only reads the metadata. No extension files are opened
 query IIII
-SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 tpch	REPOSITORY	./build/extension_metadata_test_data/repository	v0.0.1
 
@@ -112,7 +112,7 @@ statement ok
 set extension_directory='${LOCAL_EXTENSION_DIR}'
 
 query IIII rowsort
-SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 inet	UNKNOWN	(empty)	(empty)
 json	REPOSITORY	./build/extension_metadata_test_data/repository	v0.0.1
@@ -144,7 +144,7 @@ tpch	<REGEX>:.*	UPDATED	v0.0.1	v0.0.2
 
 # duckdb_extensions() now also showing updated version
 query IIII rowsort
-SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 inet	UNKNOWN	(empty)	(empty)
 json	REPOSITORY	./build/extension_metadata_test_data/repository	v0.0.1
@@ -178,7 +178,7 @@ load inet;
 
 # Ensure the result is still fine after loading; this will ensure Version() call matches the encoded footer value
 query IIII rowsort
-SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 inet	REPOSITORY	./build/extension_metadata_test_data/repository	v0.0.2
 json	REPOSITORY	./build/extension_metadata_test_data/repository	v0.0.1
@@ -254,7 +254,7 @@ set extension_directory='__TEST_DIR__/update_extensions_ci_fresh'
 
 # Nothing installed beforehand
 query IIII
-SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 
 # Install from the remote repo
@@ -263,7 +263,7 @@ force install inet from '${REMOTE_EXTENSION_REPO_UPDATED}'
 
 # Installed from the minio repo now
 query IIII
-SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 inet	REPOSITORY	http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo	v0.0.2
 
@@ -302,7 +302,7 @@ install '${REMOTE_EXTENSION_REPO_DIRECT_PATH}/inet.duckdb_extension.gz'
 
 # inet still the same
 query IIII
-SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, installed_from, extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 inet	REPOSITORY	http://duckdb-minio.com:9000/test-bucket-public/ci-test-repo	v0.0.2
 
@@ -312,7 +312,7 @@ force install '${REMOTE_EXTENSION_REPO_DIRECT_PATH}/inet.duckdb_extension.gz'
 
 # inet is now from a custom path
 query IIII
-SELECT extension_name, install_mode, parse_filename(installed_from), extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, parse_filename(installed_from), extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 inet	CUSTOM_PATH	inet.duckdb_extension.gz	v0.0.2
 
@@ -321,7 +321,7 @@ statement ok
 install inet from '${REMOTE_EXTENSION_REPO_UPDATED}'
 
 query IIII
-SELECT extension_name, install_mode, parse_filename(installed_from), extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, parse_filename(installed_from), extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 inet	CUSTOM_PATH	inet.duckdb_extension.gz	v0.0.2
 
@@ -351,7 +351,7 @@ from tpcds_queries();
 
 # The file should be from the custom path, NOT the autoinstall repo
 query IIII
-SELECT extension_name, install_mode, parse_filename(installed_from), extension_version FROM duckdb_extensions() where installed and extension_name not in ('jemalloc', 'parquet', 'core_functions')
+SELECT extension_name, install_mode, parse_filename(installed_from), extension_version FROM duckdb_extensions() where install_mode IS NOT NULL and extension_name not in ('jemalloc', 'parquet', 'core_functions')
 ----
 inet	CUSTOM_PATH	inet.duckdb_extension.gz	v0.0.2
 tpcds	REPOSITORY	repository	v0.0.1


### PR DESCRIPTION
This is marginal, main advantage is that it allow smoothen up situation between native and duckdb-wasm in the Web use case.

In the case of DuckDB in a Web page, the concept of installed extensions is slightly different, since INSTALL basically registers an URL endpoint, but actual download happens lazily on load.

Plus currently we have multiple fields basically carrying similar informations:
* installed
* install_path
* install_mode

Of them the relevant one is `install_mode`, that carries informations about where the extension did came.

The last 2 are being set only when installed is `true`.

Plus this has been broken, so I guess that's information we can still get away with changing this.