### PR TITLE
ProgressBarDisplay: Pass down 'query' and 'total_time'

### DIFF
--- a/src/common/progress_bar/progress_bar.cpp
+++ b/src/common/progress_bar/progress_bar.cpp
@@ -68,6 +68,18 @@ QueryProgress ProgressBar::GetDetailedQueryProgress() {
 	return query_progress;
 }
 
+void ProgressBar::AddTextualInfo(const string &tag, const string &info) {
+	if (display) {
+		display->AddTextualInfo(tag, info);
+	}
+}
+
+void ProgressBar::AddNumericInfo(const string &tag, double info) {
+	if (display) {
+		display->AddNumericInfo(tag, info);
+	}
+}
+
 void ProgressBar::Start() {
 	profiler.Start();
 	query_progress.Initialize();
@@ -148,6 +160,7 @@ void ProgressBar::FinishProgressBarPrint() {
 		return;
 	}
 	D_ASSERT(display);
+	display->AddNumericInfo("total_time", profiler.Elapsed());
 	display->Finish();
 	finished = true;
 	if (query_progress.percentage == 0) {

--- a/src/include/duckdb/common/progress_bar/progress_bar.hpp
+++ b/src/include/duckdb/common/progress_bar/progress_bar.hpp
@@ -51,6 +51,9 @@ public:
 	void Start();
 	//! Updates the progress bar and prints it to the screen
 	void Update(bool final);
+	//! Pass extra information to the ProgressBarDisplay (if any)
+	void AddTextualInfo(const string &tag, const string &info);
+	void AddNumericInfo(const string &tag, double info);
 	QueryProgress GetDetailedQueryProgress();
 	void PrintProgress(int percentage);
 	void FinishProgressBarPrint();

--- a/src/include/duckdb/common/progress_bar/progress_bar_display.hpp
+++ b/src/include/duckdb/common/progress_bar/progress_bar_display.hpp
@@ -20,6 +20,10 @@ public:
 public:
 	virtual void Update(double percentage) = 0;
 	virtual void Finish() = 0;
+	virtual void AddTextualInfo(const string &tag, const string &info) {
+	}
+	virtual void AddNumericInfo(const string &tag, double info) {
+	}
 };
 
 } // namespace duckdb

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -524,6 +524,7 @@ ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock, shared_
 		}
 		active_query->progress_bar =
 		    make_uniq<ProgressBar>(executor, NumericCast<idx_t>(config.wait_time), display_create_func);
+		active_query->progress_bar->AddTextualInfo("query", active_query->query);
 		active_query->progress_bar->Start();
 		query_progress.Restart();
 	}


### PR DESCRIPTION
Marginal, idea here is that allowing ProgressBarDisplay to override those methods allows passing down of some more relevant informations / customize progress bars a bit more with information that is already available.

Then ProgressBarDisplay could show the total time consumed by the query, potentially even in a remote situation (where recomputing the time again is not really feasible. 

Bumped against this in the context of duckdb-wasm, where worker(s) send pass those messages but can't really reimplement timing or so.

As a whole it's marginal so also to be reviewed later. I might want to consider include this on the DuckDB-Wasm side, but should have no real effects.