### PR TITLE
Use const T& and T instead of const T&& and T&& in (de)serializer

### DIFF
--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -1500,16 +1500,16 @@ static void ParquetCopySerialize(Serializer &serializer, const FunctionData &bin
 	ParquetWriteBindData default_value;
 	serializer.WritePropertyWithDefault(109, "compression_level", compression_level);
 	serializer.WritePropertyWithDefault(110, "row_groups_per_file", bind_data.row_groups_per_file,
-	                                    std::move(default_value.row_groups_per_file));
+	                                    default_value.row_groups_per_file);
 	serializer.WritePropertyWithDefault(111, "debug_use_openssl", bind_data.debug_use_openssl,
-	                                    std::move(default_value.debug_use_openssl));
+	                                    default_value.debug_use_openssl);
 	serializer.WritePropertyWithDefault(112, "dictionary_size_limit", bind_data.dictionary_size_limit,
-	                                    std::move(default_value.dictionary_size_limit));
+	                                    default_value.dictionary_size_limit);
 	serializer.WritePropertyWithDefault(113, "bloom_filter_false_positive_ratio",
 	                                    bind_data.bloom_filter_false_positive_ratio,
-	                                    std::move(default_value.bloom_filter_false_positive_ratio));
+	                                    default_value.bloom_filter_false_positive_ratio);
 	serializer.WritePropertyWithDefault(114, "parquet_version", bind_data.parquet_version,
-	                                    std::move(default_value.parquet_version));
+	                                    default_value.parquet_version);
 }
 
 static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserializer, CopyFunction &function) {
@@ -1531,15 +1531,15 @@ static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserialize
 	D_ASSERT(SerializeCompressionLevel(data->compression_level) == compression_level);
 	ParquetWriteBindData default_value;
 	data->row_groups_per_file = deserializer.ReadPropertyWithExplicitDefault<optional_idx>(
-	    110, "row_groups_per_file", std::move(default_value.row_groups_per_file));
-	data->debug_use_openssl = deserializer.ReadPropertyWithExplicitDefault<bool>(
-	    111, "debug_use_openssl", std::move(default_value.debug_use_openssl));
+	    110, "row_groups_per_file", default_value.row_groups_per_file);
+	data->debug_use_openssl =
+	    deserializer.ReadPropertyWithExplicitDefault<bool>(111, "debug_use_openssl", default_value.debug_use_openssl);
 	data->dictionary_size_limit = deserializer.ReadPropertyWithExplicitDefault<idx_t>(
-	    112, "dictionary_size_limit", std::move(default_value.dictionary_size_limit));
+	    112, "dictionary_size_limit", default_value.dictionary_size_limit);
 	data->bloom_filter_false_positive_ratio = deserializer.ReadPropertyWithExplicitDefault<double>(
-	    113, "bloom_filter_false_positive_ratio", std::move(default_value.bloom_filter_false_positive_ratio));
+	    113, "bloom_filter_false_positive_ratio", default_value.bloom_filter_false_positive_ratio);
 	data->parquet_version =
-	    deserializer.ReadPropertyWithExplicitDefault(114, "parquet_version", std::move(default_value.parquet_version));
+	    deserializer.ReadPropertyWithExplicitDefault(114, "parquet_version", default_value.parquet_version);
 
 	return std::move(data);
 }

--- a/src/common/serializer/serializer.cpp
+++ b/src/common/serializer/serializer.cpp
@@ -15,7 +15,7 @@ void Serializer::WriteValue(const vector<bool> &vec) {
 
 template <>
 void Serializer::WritePropertyWithDefault<Value>(const field_id_t field_id, const char *tag, const Value &value,
-                                                 const Value &&default_value) {
+                                                 const Value &default_value) {
 	// If current value is default, don't write it
 	if (!options.serialize_default_values && ValueOperations::NotDistinctFrom(value, default_value)) {
 		OnOptionalPropertyBegin(field_id, tag, false);

--- a/src/include/duckdb/common/serializer/deserializer.hpp
+++ b/src/include/duckdb/common/serializer/deserializer.hpp
@@ -81,7 +81,7 @@ public:
 	}
 
 	template <typename T>
-	inline T ReadPropertyWithExplicitDefault(const field_id_t field_id, const char *tag, T &&default_value) {
+	inline T ReadPropertyWithExplicitDefault(const field_id_t field_id, const char *tag, T default_value) {
 		if (!OnOptionalPropertyBegin(field_id, tag)) {
 			OnOptionalPropertyEnd(false);
 			return std::forward<T>(default_value);
@@ -104,7 +104,7 @@ public:
 	}
 
 	template <typename T>
-	inline void ReadPropertyWithExplicitDefault(const field_id_t field_id, const char *tag, T &ret, T &&default_value) {
+	inline void ReadPropertyWithExplicitDefault(const field_id_t field_id, const char *tag, T &ret, T default_value) {
 		if (!OnOptionalPropertyBegin(field_id, tag)) {
 			ret = std::forward<T>(default_value);
 			OnOptionalPropertyEnd(false);
@@ -116,7 +116,7 @@ public:
 
 	template <typename T>
 	inline void ReadPropertyWithExplicitDefault(const field_id_t field_id, const char *tag, CSVOption<T> &ret,
-	                                            T &&default_value) {
+	                                            T default_value) {
 		if (!OnOptionalPropertyBegin(field_id, tag)) {
 			ret = std::forward<T>(default_value);
 			OnOptionalPropertyEnd(false);

--- a/src/include/duckdb/common/serializer/serializer.hpp
+++ b/src/include/duckdb/common/serializer/serializer.hpp
@@ -105,7 +105,7 @@ public:
 	}
 
 	template <class T>
-	void WritePropertyWithDefault(const field_id_t field_id, const char *tag, const T &value, const T &&default_value) {
+	void WritePropertyWithDefault(const field_id_t field_id, const char *tag, const T &value, const T &default_value) {
 		// If current value is default, don't write it
 		if (!options.serialize_default_values && (value == default_value)) {
 			OnOptionalPropertyBegin(field_id, tag, false);
@@ -120,7 +120,7 @@ public:
 	// Specialization for Value (default Value comparison throws when comparing nulls)
 	template <class T>
 	void WritePropertyWithDefault(const field_id_t field_id, const char *tag, const CSVOption<T> &value,
-	                              const T &&default_value) {
+	                              const T &default_value) {
 		// If current value is default, don't write it
 		if (!options.serialize_default_values && (value == default_value)) {
 			OnOptionalPropertyBegin(field_id, tag, false);
@@ -383,7 +383,7 @@ void Serializer::WriteValue(const vector<bool> &vec);
 // Specialization for Value (default Value comparison throws when comparing nulls)
 template <>
 void Serializer::WritePropertyWithDefault<Value>(const field_id_t field_id, const char *tag, const Value &value,
-                                                 const Value &&default_value);
+                                                 const Value &default_value);
 
 // List Impl
 template <class FUNC>


### PR DESCRIPTION
Another attempt at keeping both gcc and msvc happy