### PR TITLE
Issue #15877: CUME_DIST Moving Frame

### DIFF
--- a/src/function/window/window_token_tree.cpp
+++ b/src/function/window/window_token_tree.cpp
@@ -122,13 +122,14 @@ idx_t WindowTokenTree::Rank(const idx_t lower, const idx_t upper, const idx_t ro
 
 template <typename TREE>
 static idx_t NextPeer(const TREE &tree, const idx_t lower, const idx_t upper, const idx_t row_idx) {
-	idx_t rank = 0;
+	// We return an index, not a relative position
+	idx_t idx = lower;
 	// Because tokens are dense, we can find the next peer by adding 1 to the probed token value
 	const auto needle = tree.LowestLevel()[row_idx] + 1;
 	tree.AggregateLowerBound(lower, upper, needle, [&](idx_t level, const idx_t run_begin, const idx_t run_pos) {
-		rank += run_pos - run_begin;
+		idx += run_pos - run_begin;
 	});
-	return rank;
+	return idx;
 }
 
 idx_t WindowTokenTree::PeerEnd(const idx_t lower, const idx_t upper, const idx_t row_idx) const {

--- a/test/sql/window/test_cume_dist_orderby.test
+++ b/test/sql/window/test_cume_dist_orderby.test
@@ -27,3 +27,27 @@ ORDER BY inside DESC, i
 3	10	1	0.8
 0	0	0	1.0
 1	7	0	1.0
+
+# Test moving frame with identical orderings
+query III
+SELECT 
+	i,
+	i // 2 AS inside,
+	cume_dist(ORDER BY i // 2) OVER w AS cd,
+FROM range(10) tbl(i)
+WINDOW w AS (
+	ORDER BY i // 2
+	ROWS BETWEEN 3 PRECEDING AND 3 FOLLOWING
+)
+ORDER BY 1;
+----
+0	0	0.5
+1	0	0.4
+2	1	0.6666666666666666
+3	1	0.5714285714285714
+4	2	0.7142857142857143
+5	2	0.5714285714285714
+6	3	0.7142857142857143
+7	3	0.6666666666666666
+8	4	1.0
+9	4	1.0


### PR DESCRIPTION
* Fix NextPeer to return an index instead of an offset.
* Add a test with a moving frame.

fixes: duckdb/duckdb#15877
fixes: duckdblabs/duckdb-internal#4049