### PR TITLE
[Linux CI] Remove examples, already tested as part of OSX Release

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -123,8 +123,6 @@ jobs:
       shell: bash
       if: ${{ inputs.skip_tests != 'true' }}
       run: |
-        (cd examples/embedded-c; make)
-        (cd examples/embedded-c++; make)
         build/release/benchmark/benchmark_runner benchmark/tpch/sf1/q01.benchmark
         build/release/duckdb -c "COPY (SELECT 42) TO '/dev/stdout' (FORMAT PARQUET)" | cat
 


### PR DESCRIPTION
Fix problems such as https://github.com/duckdb/duckdb/actions/runs/12940781324/job/36097710100, this is tested elsewhere, and doing this in the container is not worth (I think), since it adds unnecessary complexity.


I have also enabled the run on every PR, it's heavy (1h40) but it's a relevant codepath we want to test. After v1.2 we can revisit this.