### PR TITLE
Several nightly CI fixes

### DIFF
--- a/test/sql/attach/attach_new_compression.test
+++ b/test/sql/attach/attach_new_compression.test
@@ -47,10 +47,16 @@ statement ok
 CREATE TABLE db1.tbl2 AS FROM db1.tbl
 
 statement ok
+CHECKPOINT db1
+
+statement ok
 SET force_compression='zstd';
 
 statement ok
 CREATE TABLE db1.str_tbl2 AS FROM db1.str_tbl
+
+statement ok
+CHECKPOINT db1
 
 # roaring is used now
 query I

--- a/test/sql/attach/attach_storage_version.test
+++ b/test/sql/attach/attach_storage_version.test
@@ -92,6 +92,9 @@ statement ok
 INSERT INTO default_version.tbl VALUES ('abcd'), ('efgh'), ('hello'), ('world'), (NULL);
 
 statement ok
+CHECKPOINT default_version
+
+statement ok
 DETACH default_version
 
 # we can attach the database again (without specifying the default)

--- a/test/sql/index/art/types/test_art_union.test
+++ b/test/sql/index/art/types/test_art_union.test
@@ -4,6 +4,9 @@
 
 load __TEST_DIR__/test_art_union.db
 
+# FIXME: CreateIndex should not bind on WAL replay
+require no_alternative_verify
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/storage/compression/fsst/fsst_disable_compression.test
+++ b/test/sql/storage/compression/fsst/fsst_disable_compression.test
@@ -8,6 +8,9 @@ load __TEST_DIR__/test_disabled_compression_methods.db
 statement ok
 CREATE TABLE test AS SELECT concat('longprefix', i) FROM range(30000) t(i);
 
+statement ok
+CHECKPOINT
+
 query I
 SELECT BOOL_OR(compression ILIKE '%fsst%') FROM pragma_storage_info('test')
 ----
@@ -22,6 +25,9 @@ SET disabled_compression_methods='fsst'
 # verify FSST is disabled
 statement ok
 CREATE TABLE test AS SELECT concat('longprefix', i) FROM range(30000) t(i);
+
+statement ok
+CHECKPOINT
 
 query I
 SELECT BOOL_OR(compression ILIKE '%fsst%') FROM pragma_storage_info('test')

--- a/test/sql/storage/storage_versions.test
+++ b/test/sql/storage/storage_versions.test
@@ -4,6 +4,9 @@
 
 require skip_reload
 
+# These files were created with vector-size 2048
+require vector_size 2048
+
 ## Files created via `duckdb file_name -c "CHECKPOINT;"
 
 statement ok


### PR DESCRIPTION
* Skip storage version test on vsize <> 2048
* Add checkpoint to tests that explicitly check compression methods/etc so they work with alternative verify
* Skip `test_art_union.test` for `no_alternative_verify` - there is an issue where CreateIndex binds during the wal_replay that needs to be fixed to address this