### PR TITLE
When Deserializing, Sample Selection Vectors should be initialized to `FIXED_SAMPLE_SIZE`

### DIFF
--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -50,7 +50,7 @@ ReservoirSample::ReservoirSample(idx_t sample_count, unique_ptr<ReservoirChunk> 
 	if (reservoir_chunk) {
 		this->reservoir_chunk = std::move(reservoir_chunk);
 		sel_size = this->reservoir_chunk->chunk.size();
-		sel = SelectionVector(0, sel_size);
+		sel = SelectionVector(0, FIXED_SAMPLE_SIZE);
 		ExpandSerializedSample();
 	}
 	stats_sample = true;
@@ -301,6 +301,7 @@ void ReservoirSample::SimpleMerge(ReservoirSample &other) {
 	auto offset = reservoir_chunk->chunk.size();
 	for (idx_t i = keep_from_this; i < size_after_merge; i++) {
 		if (i >= GetActiveSampleCount()) {
+			D_ASSERT(sel_size >= GetActiveSampleCount());
 			sel.set_index(GetActiveSampleCount(), offset);
 			sel_size += 1;
 		} else {

--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -50,7 +50,10 @@ ReservoirSample::ReservoirSample(idx_t sample_count, unique_ptr<ReservoirChunk> 
 	if (reservoir_chunk) {
 		this->reservoir_chunk = std::move(reservoir_chunk);
 		sel_size = this->reservoir_chunk->chunk.size();
-		sel = SelectionVector(0, FIXED_SAMPLE_SIZE);
+		sel = SelectionVector( FIXED_SAMPLE_SIZE);
+		for (idx_t i = 0; i < sel_size; i++) {
+			sel.set_index(i, i);
+		}
 		ExpandSerializedSample();
 	}
 	stats_sample = true;

--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -50,7 +50,7 @@ ReservoirSample::ReservoirSample(idx_t sample_count, unique_ptr<ReservoirChunk> 
 	if (reservoir_chunk) {
 		this->reservoir_chunk = std::move(reservoir_chunk);
 		sel_size = this->reservoir_chunk->chunk.size();
-		sel = SelectionVector( FIXED_SAMPLE_SIZE);
+		sel = SelectionVector(FIXED_SAMPLE_SIZE);
 		for (idx_t i = 0; i < sel_size; i++) {
 			sel.set_index(i, i);
 		}

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -32,7 +32,7 @@ struct SelectionVector {
 		Initialize(count);
 	}
 	SelectionVector(idx_t start, idx_t count) {
-		Initialize(count);
+		Initialize(MaxValue<idx_t>(count, STANDARD_VECTOR_SIZE));
 		for (idx_t i = 0; i < count; i++) {
 			set_index(i, start + i);
 		}

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -32,7 +32,7 @@ struct SelectionVector {
 		Initialize(count);
 	}
 	SelectionVector(idx_t start, idx_t count) {
-		Initialize(MaxValue<idx_t>(count, STANDARD_VECTOR_SIZE));
+		Initialize(count);
 		for (idx_t i = 0; i < count; i++) {
 			set_index(i, start + i);
 		}


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/3998

Previously the selection vector was initialized to the size of the chunk that is deserialized. However, if the sample is merged with another sample that has many many samples, then the selection vector needs to be large enough to store those samples as well (up to the `FIXED_SAMPLE_SIZE`).