### PR TITLE
Fix race/deadlock in `FixedSizebuffer::Get()`

### DIFF
--- a/src/execution/index/fixed_size_allocator.cpp
+++ b/src/execution/index/fixed_size_allocator.cpp
@@ -49,14 +49,13 @@ IndexPointer FixedSizeAllocator::New() {
 
 		// add a new buffer
 		auto buffer_id = GetAvailableBufferId();
-		FixedSizeBuffer new_buffer(block_manager);
-		buffers.insert(make_pair(buffer_id, std::move(new_buffer)));
+		buffers[buffer_id] = make_uniq<FixedSizeBuffer>(block_manager);
 		buffers_with_free_space.insert(buffer_id);
 
 		// set the bitmask
 		D_ASSERT(buffers.find(buffer_id) != buffers.end());
 		auto &buffer = buffers.find(buffer_id)->second;
-		ValidityMask mask(reinterpret_cast<validity_t *>(buffer.Get()), available_segments_per_buffer);
+		ValidityMask mask(reinterpret_cast<validity_t *>(buffer->Get()), available_segments_per_buffer);
 
 		// zero-initialize the bitmask to avoid leaking memory to disk
 		auto data = mask.GetData();
@@ -74,16 +73,16 @@ IndexPointer FixedSizeAllocator::New() {
 
 	D_ASSERT(buffers.find(buffer_id) != buffers.end());
 	auto &buffer = buffers.find(buffer_id)->second;
-	auto offset = buffer.GetOffset(bitmask_count, available_segments_per_buffer);
+	auto offset = buffer->GetOffset(bitmask_count, available_segments_per_buffer);
 
 	total_segment_count++;
-	buffer.segment_count++;
-	if (buffer.segment_count == available_segments_per_buffer) {
+	buffer->segment_count++;
+	if (buffer->segment_count == available_segments_per_buffer) {
 		buffers_with_free_space.erase(buffer_id);
 	}
 
 	// zero-initialize that segment
-	auto buffer_ptr = buffer.Get();
+	auto buffer_ptr = buffer->Get();
 	auto offset_in_buffer = buffer_ptr + offset * segment_size + bitmask_offset;
 	memset(offset_in_buffer, 0, segment_size);
 
@@ -98,24 +97,21 @@ void FixedSizeAllocator::Free(const IndexPointer ptr) {
 	D_ASSERT(buffers.find(buffer_id) != buffers.end());
 	auto &buffer = buffers.find(buffer_id)->second;
 
-	auto bitmask_ptr = reinterpret_cast<validity_t *>(buffer.Get());
+	auto bitmask_ptr = reinterpret_cast<validity_t *>(buffer->Get());
 	ValidityMask mask(bitmask_ptr, offset + 1); // FIXME
 	D_ASSERT(!mask.RowIsValid(offset));
 	mask.SetValid(offset);
 
 	D_ASSERT(total_segment_count > 0);
-	D_ASSERT(buffer.segment_count > 0);
+	D_ASSERT(buffer->segment_count > 0);
 
 	// adjust the allocator fields
 	buffers_with_free_space.insert(buffer_id);
 	total_segment_count--;
-	buffer.segment_count--;
+	buffer->segment_count--;
 }
 
 void FixedSizeAllocator::Reset() {
-	for (auto &buffer : buffers) {
-		buffer.second.Destroy();
-	}
 	buffers.clear();
 	buffers_with_free_space.clear();
 	total_segment_count = 0;
@@ -124,7 +120,7 @@ void FixedSizeAllocator::Reset() {
 idx_t FixedSizeAllocator::GetInMemorySize() const {
 	idx_t memory_usage = 0;
 	for (auto &buffer : buffers) {
-		if (buffer.second.InMemory()) {
+		if (buffer.second->InMemory()) {
 			memory_usage += block_manager.GetBlockSize();
 		}
 	}
@@ -179,9 +175,9 @@ bool FixedSizeAllocator::InitializeVacuum() {
 	idx_t available_segments_in_memory = 0;
 
 	for (auto &buffer : buffers) {
-		buffer.second.vacuum = false;
-		if (buffer.second.InMemory()) {
-			auto available_segments_in_buffer = available_segments_per_buffer - buffer.second.segment_count;
+		buffer.second->vacuum = false;
+		if (buffer.second->InMemory()) {
+			auto available_segments_in_buffer = available_segments_per_buffer - buffer.second->segment_count;
 			available_segments_in_memory += available_segments_in_buffer;
 			temporary_vacuum_buffers.emplace(available_segments_in_buffer, buffer.first);
 		}
@@ -216,7 +212,7 @@ bool FixedSizeAllocator::InitializeVacuum() {
 	for (auto &vacuum_buffer : temporary_vacuum_buffers) {
 		auto buffer_id = vacuum_buffer.second;
 		D_ASSERT(buffers.find(buffer_id) != buffers.end());
-		buffers.find(buffer_id)->second.vacuum = true;
+		buffers.find(buffer_id)->second->vacuum = true;
 		buffers_with_free_space.erase(buffer_id);
 	}
 
@@ -232,8 +228,7 @@ void FixedSizeAllocator::FinalizeVacuum() {
 	for (auto &buffer_id : vacuum_buffers) {
 		D_ASSERT(buffers.find(buffer_id) != buffers.end());
 		auto &buffer = buffers.find(buffer_id)->second;
-		D_ASSERT(buffer.InMemory());
-		buffer.Destroy();
+		D_ASSERT(buffer->InMemory());
 		buffers.erase(buffer_id);
 	}
 	vacuum_buffers.clear();
@@ -259,9 +254,9 @@ FixedSizeAllocatorInfo FixedSizeAllocator::GetInfo() const {
 
 	for (const auto &buffer : buffers) {
 		info.buffer_ids.push_back(buffer.first);
-		info.block_pointers.push_back(buffer.second.block_pointer);
-		info.segment_counts.push_back(buffer.second.segment_count);
-		info.allocation_sizes.push_back(buffer.second.allocation_size);
+		info.block_pointers.push_back(buffer.second->block_pointer);
+		info.segment_counts.push_back(buffer.second->segment_count);
+		info.allocation_sizes.push_back(buffer.second->allocation_size);
 	}
 
 	for (auto &buffer_id : buffers_with_free_space) {
@@ -273,7 +268,7 @@ FixedSizeAllocatorInfo FixedSizeAllocator::GetInfo() const {
 
 void FixedSizeAllocator::SerializeBuffers(PartialBlockManager &partial_block_manager) {
 	for (auto &buffer : buffers) {
-		buffer.second.Serialize(partial_block_manager, available_segments_per_buffer, segment_size, bitmask_offset);
+		buffer.second->Serialize(partial_block_manager, available_segments_per_buffer, segment_size, bitmask_offset);
 	}
 }
 
@@ -281,8 +276,8 @@ vector<IndexBufferInfo> FixedSizeAllocator::InitSerializationToWAL() {
 
 	vector<IndexBufferInfo> buffer_infos;
 	for (auto &buffer : buffers) {
-		buffer.second.SetAllocationSize(available_segments_per_buffer, segment_size, bitmask_offset);
-		buffer_infos.emplace_back(buffer.second.Get(), buffer.second.allocation_size);
+		buffer.second->SetAllocationSize(available_segments_per_buffer, segment_size, bitmask_offset);
+		buffer_infos.emplace_back(buffer.second->Get(), buffer.second->allocation_size);
 	}
 	return buffer_infos;
 }
@@ -300,8 +295,8 @@ void FixedSizeAllocator::Init(const FixedSizeAllocatorInfo &info) {
 		auto allocation_size = info.allocation_sizes[i];
 
 		// create the FixedSizeBuffer
-		FixedSizeBuffer new_buffer(block_manager, segment_count, allocation_size, buffer_block_pointer);
-		buffers.insert(make_pair(buffer_id, std::move(new_buffer)));
+		buffers[buffer_id] =
+		    make_uniq<FixedSizeBuffer>(block_manager, segment_count, allocation_size, buffer_block_pointer);
 		total_segment_count += segment_count;
 	}
 
@@ -324,8 +319,8 @@ void FixedSizeAllocator::Deserialize(MetadataManager &metadata_manager, const Bl
 		auto buffer_block_pointer = reader.Read<BlockPointer>();
 		auto segment_count = reader.Read<idx_t>();
 		auto allocation_size = reader.Read<idx_t>();
-		FixedSizeBuffer new_buffer(block_manager, segment_count, allocation_size, buffer_block_pointer);
-		buffers.insert(make_pair(buffer_id, std::move(new_buffer)));
+		buffers[buffer_id] =
+		    make_uniq<FixedSizeBuffer>(block_manager, segment_count, allocation_size, buffer_block_pointer);
 		total_segment_count += segment_count;
 	}
 	for (idx_t i = 0; i < buffers_with_free_space_count; i++) {
@@ -346,13 +341,12 @@ void FixedSizeAllocator::RemoveEmptyBuffers() {
 
 	auto buffer_it = buffers.begin();
 	while (buffer_it != buffers.end()) {
-		if (buffer_it->second.segment_count != 0) {
-			buffer_it++;
+		if (buffer_it->second->segment_count != 0) {
+			++buffer_it;
 			continue;
 		}
 
 		buffers_with_free_space.erase(buffer_it->first);
-		buffer_it->second.Destroy();
 		buffer_it = buffers.erase(buffer_it);
 	}
 }

--- a/src/execution/index/fixed_size_buffer.cpp
+++ b/src/execution/index/fixed_size_buffer.cpp
@@ -54,7 +54,8 @@ FixedSizeBuffer::FixedSizeBuffer(BlockManager &block_manager, const idx_t segmen
 	D_ASSERT(block_handle->BlockId() < MAXIMUM_BLOCK);
 }
 
-void FixedSizeBuffer::Destroy() {
+FixedSizeBuffer::~FixedSizeBuffer() {
+	lock_guard<mutex> l(lock);
 	if (InMemory()) {
 		// we can have multiple readers on a pinned block, and unpinning the buffer handle
 		// decrements the reader count on the underlying block handle (Destroy() unpins)

--- a/src/include/duckdb/execution/index/fixed_size_allocator.hpp
+++ b/src/include/duckdb/execution/index/fixed_size_allocator.hpp
@@ -55,7 +55,7 @@ public:
 		D_ASSERT(buffers.find(ptr.GetBufferId()) != buffers.end());
 
 		auto &buffer = buffers.find(ptr.GetBufferId())->second;
-		auto buffer_ptr = buffer.Get(dirty);
+		auto buffer_ptr = buffer->Get(dirty);
 		return buffer_ptr + ptr.GetOffset() * segment_size + bitmask_offset;
 	}
 
@@ -71,11 +71,11 @@ public:
 		D_ASSERT(buffers.find(ptr.GetBufferId()) != buffers.end());
 
 		auto &buffer = buffers.find(ptr.GetBufferId())->second;
-		if (!buffer.InMemory()) {
+		if (!buffer->InMemory()) {
 			return nullptr;
 		}
 
-		auto buffer_ptr = buffer.Get();
+		auto buffer_ptr = buffer->Get();
 		auto raw_ptr = buffer_ptr + ptr.GetOffset() * segment_size + bitmask_offset;
 		return raw_ptr;
 	}
@@ -152,7 +152,7 @@ private:
 	idx_t total_segment_count;
 
 	//! Buffers containing the segments
-	unordered_map<idx_t, FixedSizeBuffer> buffers;
+	unordered_map<idx_t, unique_ptr<FixedSizeBuffer>> buffers;
 	//! Buffers with free space
 	unordered_set<idx_t> buffers_with_free_space;
 	//! Buffers qualifying for a vacuum (helper field to allow for fast NeedsVacuum checks)

--- a/src/include/duckdb/execution/index/fixed_size_buffer.hpp
+++ b/src/include/duckdb/execution/index/fixed_size_buffer.hpp
@@ -34,6 +34,8 @@ public:
 //! yet in memory, and it only serializes dirty and non-written buffers to disk during
 //! serialization.
 class FixedSizeBuffer {
+	friend class FixedSizeAllocator;
+
 public:
 	//! Constants for fast offset calculations in the bitmask
 	static constexpr idx_t BASE[] = {0x00000000FFFFFFFF, 0x0000FFFF, 0x00FF, 0x0F, 0x3, 0x1};
@@ -46,6 +48,45 @@ public:
 	FixedSizeBuffer(BlockManager &block_manager, const idx_t segment_count, const idx_t allocation_size,
 	                const BlockPointer &block_pointer);
 
+	~FixedSizeBuffer();
+
+private:
+	//! Returns a pointer to the buffer in memory, and calls Deserialize, if the buffer is not in memory
+	data_ptr_t Get(const bool dirty_p = true) {
+		lock_guard<mutex> l(lock);
+		if (!InMemory()) {
+			Pin();
+		}
+		if (dirty_p) {
+			dirty = dirty_p;
+		}
+		return buffer_handle.Ptr();
+	}
+
+	//! Returns true, if the buffer is in-memory
+	bool InMemory() const {
+		return buffer_handle.IsValid();
+	}
+
+	//! Returns true, if the block is on-disk
+	bool OnDisk() const {
+		return block_pointer.IsValid();
+	}
+
+	//! Serializes a buffer (if dirty or not on disk)
+	void Serialize(PartialBlockManager &partial_block_manager, const idx_t available_segments, const idx_t segment_size,
+	               const idx_t bitmask_offset);
+	//! Pin a buffer (if not in-memory)
+	void Pin();
+	//! Returns the first free offset in a bitmask
+	uint32_t GetOffset(const idx_t bitmask_count, const idx_t available_segments);
+	//! Sets the allocation size, if dirty
+	void SetAllocationSize(const idx_t available_segments, const idx_t segment_size, const idx_t bitmask_offset);
+	//! Sets all uninitialized regions of a buffer in the respective partial block allocation
+	void SetUninitializedRegions(PartialBlockForIndex &p_block_for_index, const idx_t segment_size, const idx_t offset,
+	                             const idx_t bitmask_offset, const idx_t available_segments);
+
+private:
 	//! Block manager of the database instance
 	BlockManager &block_manager;
 
@@ -61,48 +102,12 @@ public:
 
 	//! Partial block id and offset
 	BlockPointer block_pointer;
-
-public:
-	//! Returns true, if the buffer is in-memory
-	inline bool InMemory() const {
-		return buffer_handle.IsValid();
-	}
-	//! Returns true, if the block is on-disk
-	inline bool OnDisk() const {
-		return block_pointer.IsValid();
-	}
-	//! Returns a pointer to the buffer in memory, and calls Deserialize, if the buffer is not in memory
-	inline data_ptr_t Get(const bool dirty_p = true) {
-		if (!InMemory()) {
-			Pin();
-		}
-		if (dirty_p) {
-			dirty = dirty_p;
-		}
-		return buffer_handle.Ptr();
-	}
-	//! Destroys the in-memory buffer and the on-disk block
-	void Destroy();
-	//! Serializes a buffer (if dirty or not on disk)
-	void Serialize(PartialBlockManager &partial_block_manager, const idx_t available_segments, const idx_t segment_size,
-	               const idx_t bitmask_offset);
-	//! Pin a buffer (if not in-memory)
-	void Pin();
-	//! Returns the first free offset in a bitmask
-	uint32_t GetOffset(const idx_t bitmask_count, const idx_t available_segments);
-	//! Sets the allocation size, if dirty
-	void SetAllocationSize(const idx_t available_segments, const idx_t segment_size, const idx_t bitmask_offset);
-
-private:
 	//! The buffer handle of the in-memory buffer
 	BufferHandle buffer_handle;
 	//! The block handle of the on-disk buffer
 	shared_ptr<BlockHandle> block_handle;
-
-private:
-	//! Sets all uninitialized regions of a buffer in the respective partial block allocation
-	void SetUninitializedRegions(PartialBlockForIndex &p_block_for_index, const idx_t segment_size, const idx_t offset,
-	                             const idx_t bitmask_offset, const idx_t available_segments);
+	//! The lock for this fixed size buffer handle
+	mutex lock;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This PR fixes a potential deadlock/race in the `FixedSizeBuffer::Get()` method where the underlying buffer handle would get evicted between the check if it's still valid and the attempt to pin it. This is now prevented by adding an internal lock to the fixed size buffer itself. 

Additionally, we move the `FixedSizeBuffer`s in the `FixedSizeAllocator` into `unique_ptr`s instead of being stored raw in the map. This makes the lifetime management tighter and also allows us to remove the `Destroy` method as that is now handled by the destructor which gets invoked whenever buffers are removed or cleared in the allocator map.

We also move almost the entire `FixedSizeBuffer` interface to be private, and make the `FixedSizeAllocator` a friend class to prevent tampering with the buffer state from outside.

Closes https://github.com/duckdb/duckdb-spatial/issues/488