### PR TITLE
Call ProcessError also for PendingQueries

### DIFF
--- a/src/common/error_data.cpp
+++ b/src/common/error_data.cpp
@@ -95,7 +95,7 @@ bool ErrorData::operator==(const ErrorData &other) const {
 }
 
 void ErrorData::ConvertErrorToJSON() {
-	if (raw_message.empty() || raw_message[0] == '{') {
+	if (!raw_message.empty() && raw_message[0] == '{') {
 		// empty or already JSON
 		return;
 	}

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1049,7 +1049,9 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query,
 
 		return PendingQueryInternal(*lock, std::move(statements[0]), params, true);
 	} catch (std::exception &ex) {
-		return make_uniq<PendingQueryResult>(ErrorData(ex));
+		ErrorData error(ex);
+		ProcessError(error, query);
+		return make_uniq<PendingQueryResult>(std::move(error));
 	}
 }
 

--- a/test/api/test_pending_query.cpp
+++ b/test/api/test_pending_query.cpp
@@ -2,6 +2,7 @@
 #include "test_helpers.hpp"
 
 #include <thread>
+#include "duckdb/common/string_util.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -104,6 +105,12 @@ TEST_CASE("Test Pending Query API", "[api][.]") {
 		// query the connection as normal after
 		result = con.Query("SELECT 42");
 		REQUIRE(CHECK_COLUMN(result, 0, {42}));
+	}
+	SECTION("Pending results errors as JSON") {
+		con.Query("SET errors_as_json = true;");
+		auto pending_query = con.PendingQuery("SELCT 32;");
+		REQUIRE(pending_query->HasError());
+		REQUIRE(duckdb::StringUtil::Contains(pending_query->GetError(), "SYNTAX_ERROR"));
 	}
 }
 

--- a/test/sql/settings/errors_as_json.test
+++ b/test/sql/settings/errors_as_json.test
@@ -19,6 +19,11 @@ SELECT cbl FROM (VALUES (42)) t(col)
 COLUMN_NOT_FOUND
 
 statement error
+SECT cbl FROM (VALUES (42)) t(col)
+----
+SYNTAX_ERROR
+
+statement error
 select corr('hello', 'world')
 ----
 NO_MATCHING_FUNCTION


### PR DESCRIPTION
Only properly relevant change are the 3 lines in `src/main/client_context.cpp`.

Reported by @Y-- in the context of duckdb-wasm.