### PR TITLE
In destructor try/catch exceptions thrown when closing MiniZ streams

### DIFF
--- a/src/common/compressed_file_system.cpp
+++ b/src/common/compressed_file_system.cpp
@@ -11,7 +11,15 @@ CompressedFile::CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> 
 }
 
 CompressedFile::~CompressedFile() {
-	CompressedFile::Close();
+	// avoid closing if destroyed during stack unwinding
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	try {
+		// stream_wrapper->Close() might throw
+		CompressedFile::Close();
+	} catch (...) { // NOLINT - cannot throw in exception
+	}
 }
 
 void CompressedFile::Initialize(bool write) {

--- a/src/common/compressed_file_system.cpp
+++ b/src/common/compressed_file_system.cpp
@@ -11,10 +11,6 @@ CompressedFile::CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> 
 }
 
 CompressedFile::~CompressedFile() {
-	// avoid closing if destroyed during stack unwinding
-	if (Exception::UncaughtException()) {
-		return;
-	}
 	try {
 		// stream_wrapper->Close() might throw
 		CompressedFile::Close();


### PR DESCRIPTION
This happens from time to time in Regression runner, with failure mode:
```
terminate called after throwing an instance of 'duckdb::Exception'
  what():  {'exception_type':'IO','exception_message':'Failed to decode gzip stream: data error'}
```

I am not sure why miniz throws `data error`, possibly there is something there, but this should not terminate duckdb.

I don't have a way to test this either way, it's mostly an hypothesis but the code added should be OK.