### PR TITLE
Remove bundled TPCH

### DIFF
--- a/.github/config/bundled_extensions.cmake
+++ b/.github/config/bundled_extensions.cmake
@@ -15,7 +15,6 @@
 ## Extensions that are linked
 #
 duckdb_extension_load(icu)
-duckdb_extension_load(tpch)
 duckdb_extension_load(json)
 duckdb_extension_load(parquet)
 duckdb_extension_load(autocomplete)
@@ -24,3 +23,4 @@ duckdb_extension_load(autocomplete)
 ## Extensions that are not linked, but we do want to test them as part of the release build
 #
 duckdb_extension_load(tpcds DONT_LINK)
+duckdb_extension_load(tpch DONT_LINK)


### PR DESCRIPTION
Extension loading works, those extensions have been already NOT shipped in some widely used contexts (brew CLI in particular) and it has been fine.

They seems specialised needs that should work without problem via `INSTALL / LOAD` path used by other extensions.

Also note that autoloading should work out of the box in most situations.

This helps in simplifying the matrix at: https://duckdb.org/docs/extensions/core_extensions#default-extensions, basically after that the rule will become almost everywhere shipping `icu`, `json` and `parquet`.

EDIT: Python wheels to be addressed in a follow up PR.