### PR TITLE
[shell] UBIGINT is also an integer type

### DIFF
--- a/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
+++ b/tools/sqlite3_api_wrapper/sqlite3_api_wrapper.cpp
@@ -542,6 +542,12 @@ int sqlite3_column_type(sqlite3_stmt *pStmt, int iCol) {
 	case LogicalTypeId::SMALLINT:
 	case LogicalTypeId::INTEGER:
 	case LogicalTypeId::BIGINT: /* TODO: Maybe blob? */
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::UHUGEINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::VARINT:
 		return SQLITE_INTEGER;
 	case LogicalTypeId::FLOAT:
 	case LogicalTypeId::DOUBLE:


### PR DESCRIPTION
Fixes very minor problem, but making sure this is somewhat consistent makes sense.

Testcase:
```
.mode markdown
SELECT 1::UBIGINT, 1::BIGINT;
```
Should be rendered with the same alignment.

Arguably also VARINT needs to be handled there.