### PR TITLE
Adding an extension option shouldn't delete a set value and promote unrecognized options

### DIFF
--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -380,7 +380,13 @@ void DBConfig::AddExtensionOption(const string &name, string description, Logica
                                   const Value &default_value, set_option_callback_t function) {
 	extension_parameters.insert(
 	    make_pair(name, ExtensionOption(std::move(description), std::move(parameter), function, default_value)));
-	if (!default_value.IsNull()) {
+	// copy over unrecognized options, if they match the new extension option
+	auto iter = options.unrecognized_options.find(name);
+	if (iter != options.unrecognized_options.end()) {
+		options.set_variables[name] = iter->second;
+		options.unrecognized_options.erase(iter);
+	}
+	if (!default_value.IsNull() && options.set_variables.find(name) == options.set_variables.end()) {
 		// Default value is set, insert it into the 'set_variables' list
 		options.set_variables[name] = default_value;
 	}


### PR DESCRIPTION
The current implementation of AddExtensionOption immediately sets the default value into the current config, which makes sense. However, if the extension in question is loaded as part of the main database type, and the the value is already set by the caller, the default value shouldn't override it. On top of it, it may be that the current value may be in `unrecognized_options` where config options get to for unknown options. Now that the extension is loaded and the option is configured, it is nice to get it from there as well automatically. 

PS I don't know how to test it other than by hand with our extension. Guidance welcome.