### PR TITLE
Remove bundled TPCH & TPCDS in Python wheels

### DIFF
--- a/tools/pythonpkg/duckdb_extension_config.cmake
+++ b/tools/pythonpkg/duckdb_extension_config.cmake
@@ -9,6 +9,3 @@
 duckdb_extension_load(json)
 duckdb_extension_load(parquet)
 duckdb_extension_load(icu)
-
-duckdb_extension_load(tpcds DONT_LINK)
-duckdb_extension_load(tpch DONT_LINK)

--- a/tools/pythonpkg/duckdb_extension_config.cmake
+++ b/tools/pythonpkg/duckdb_extension_config.cmake
@@ -7,7 +7,8 @@
 # CMakeLists.txt file with the `BUILD_PYTHON` variable.
 # TODO: unify this by making setup.py also use this configuration, making this the config for all python builds
 duckdb_extension_load(json)
-duckdb_extension_load(tpcds)
-duckdb_extension_load(tpch)
 duckdb_extension_load(parquet)
 duckdb_extension_load(icu)
+
+duckdb_extension_load(tpcds DONT_LINK)
+duckdb_extension_load(tpch DONT_LINK)

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -115,7 +115,7 @@ class build_ext(CompilerLauncherMixin, _build_ext):
 
 lib_name = 'duckdb'
 
-extensions = ['core_functions', 'parquet', 'icu', 'tpch', 'json']
+extensions = ['core_functions', 'parquet', 'icu', 'json']
 
 is_android = hasattr(sys, 'getandroidapilevel')
 is_pyodide = 'PYODIDE' in os.environ

--- a/tools/pythonpkg/tests/fast/arrow/test_tpch.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_tpch.py
@@ -1,3 +1,4 @@
+import pytest
 import duckdb
 
 try:
@@ -32,6 +33,7 @@ def check_result(result, answers):
     return True
 
 
+@pytest.mark.skip(reason="Test needs to be adapted to missing TPCH extension")
 class TestTPCHArrow(object):
     def test_tpch_arrow(self, duckdb_cursor):
         if not can_run:


### PR DESCRIPTION
Same as https://github.com/duckdb/duckdb/pull/15905, removing tpch and tpcds from duckdb Python wheels.