### PR TITLE
fix and cleanup `flatten`

### DIFF
--- a/test/sql/function/list/flatten.test
+++ b/test/sql/function/list/flatten.test
@@ -150,3 +150,13 @@ query I
 select flatten(NULL);
 ----
 NULL
+
+query IIII rowsort
+with v_data (col, list) as ( select * FROM (VALUES ('a', [1,2,3]), ('b', [4,5]), ('a', [2,6])) ),
+        v_list_of_lists ( col, list, list_of_lists ) as ( select v.*, array_agg(v.list) over (partition by v.col) from v_data v )
+select v.*, flatten(v.list_of_lists) from v_list_of_lists v;
+----
+a	[1, 2, 3]	[[1, 2, 3], [2, 6]]	[1, 2, 3, 2, 6]
+a	[2, 6]	[[1, 2, 3], [2, 6]]	[1, 2, 3, 2, 6]
+b	[4, 5]	[[4, 5]]	[4, 5]
+


### PR DESCRIPTION
The issue stems from the fact that it's not enough to just look at the total vector size of the innermost element vector to size the resulting child/selection vector. If the inner list reference the same element(s) multiple times across different `list_entry`'s there are technically more "elements" than there are "values" in the innermost vector. So we need to do another pass across the input vector before to sum up the inner `list_entry` lengths first.

I also took the opportunity to cleanup and streamline the code somewhat. 

Closes #15921