### PR TITLE
Python 3 Linux builds: Use ubuntu 22 instead of ubuntu 20, also no fail-fast

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -163,8 +163,9 @@ jobs:
   linux-python3:
     name: Python 3 Linux
     needs: manylinux-extensions-x64
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
         python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]


### PR DESCRIPTION
Last few nights Linux builds have been failing, with cryptic errors like:
```
        gcc: internal compiler error: Segmentation fault signal terminated program cc1
        Please submit a full bug report, with preprocessed source.
        See <http://bugzilla.redhat.com/bugzilla> for instructions.
```
I believe this to be due to some changes in the Ubuntu 20 runners images.

Using Ubuntu 22 seems to solve the problem.
For good measure adding `fast-fail: false` so that any specific platform do not shuts down the building of other platforms.