### PR TITLE
Unify behavior of `range`/`generate_series` with PostgreSQL

### DIFF
--- a/extension/icu/icu-table-range.cpp
+++ b/extension/icu/icu-table-range.cpp
@@ -63,6 +63,8 @@ struct ICUTableRange {
 		bool inclusive_bound;
 		bool greater_than_check;
 
+		bool empty_range = false;
+
 		bool Finished(timestamp_t current_value) const {
 			if (greater_than_check) {
 				if (inclusive_bound) {
@@ -113,14 +115,12 @@ struct ICUTableRange {
 			}
 			result.greater_than_check = true;
 			if (result.start > result.end) {
-				throw BinderException(
-				    "start is bigger than end, but increment is positive: cannot generate infinite series");
+				result.empty_range = true;
 			}
 		} else {
 			result.greater_than_check = false;
 			if (result.start < result.end) {
-				throw BinderException(
-				    "start is smaller than end, but increment is negative: cannot generate infinite series");
+				result.empty_range = true;
 			}
 		}
 		result.inclusive_bound = GENERATE_SERIES;
@@ -165,6 +165,13 @@ struct ICUTableRange {
 				GenerateRangeDateTimeParameters<GENERATE_SERIES>(input, state.current_input_row, state);
 				state.initialized_row = true;
 				state.current_state = state.start;
+			}
+			if (state.empty_range) {
+				// empty range
+				output.SetCardinality(0);
+				state.current_input_row++;
+				state.initialized_row = false;
+				return OperatorResultType::HAVE_MORE_OUTPUT;
 			}
 			idx_t size = 0;
 			auto data = FlatVector::GetData<timestamp_t>(output.data[0]);

--- a/test/sql/table_function/icu_range_timestamptz.test
+++ b/test/sql/table_function/icu_range_timestamptz.test
@@ -120,12 +120,12 @@ SELECT d FROM range(TIMESTAMPTZ '1992-01-01 00:00:00-08', TIMESTAMPTZ '1992-12-3
 ----
 
 # start is smaller than end but we have a negative interval
-statement error
+query I
 SELECT d FROM range(TIMESTAMPTZ '1992-01-01 00:00:00-08', TIMESTAMPTZ '1992-12-31 12:00:00-08', INTERVAL '1 MONTH ago') tbl(d)
 ----
 
 # start is bigger than end but we have a positive interval
-statement error
+query I
 SELECT d FROM range(TIMESTAMPTZ '1993-01-01 00:00:00-08', TIMESTAMPTZ '1992-01-01 00:00:00-08', INTERVAL '1 MONTH') tbl(d)
 ----
 

--- a/test/sql/table_function/range_timestamp.test
+++ b/test/sql/table_function/range_timestamp.test
@@ -132,12 +132,12 @@ SELECT d FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1992-12-31 12:00
 ----
 
 # start is smaller than end but we have a negative interval
-statement error
+query I
 SELECT d FROM range(TIMESTAMP '1992-01-01 00:00:00', TIMESTAMP '1992-12-31 12:00:00', INTERVAL '1 MONTH ago') tbl(d)
 ----
 
 # start is bigger than end but we have a positive interval
-statement error
+query I
 SELECT d FROM range(TIMESTAMP '1993-01-01 00:00:00', TIMESTAMP '1992-01-01 00:00:00', INTERVAL '1 MONTH') tbl(d)
 ----
 

--- a/test/sql/table_function/test_range_function.test
+++ b/test/sql/table_function/test_range_function.test
@@ -88,11 +88,11 @@ statement error
 SELECT * FROM range(0, 10, 0)
 ----
 
-statement error
+query I
 SELECT * FROM range(0, 10, -1)
 ----
 
-statement error
+query I
 SELECT * FROM range(10, 0, 1)
 ----
 
@@ -222,3 +222,10 @@ query I
 select * from generate_series(0, 10, 9223372036854775807);
 ----
 0
+
+query II
+select * FROM generate_series(1, 3, 1) AS _(x), generate_series(x, 2, 1) AS __(y);
+----
+2	2
+1	1
+1	2


### PR DESCRIPTION
With this PR, _e.g._, `SELECT * FROM range(3, 1)` no longer throws an error, but returns an empty result instead. This choice is opinionated, but it is more in line with the behavior of PostgreSQL. Fixes part of issue https://github.com/duckdb/duckdb/issues/15483.