### PR TITLE
[Bugfix] Use `Allocator` in `MemoryStream` and prevent `realloc` loop

### DIFF
--- a/src/common/serializer/memory_stream.cpp
+++ b/src/common/serializer/memory_stream.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/common/serializer/memory_stream.hpp"
 
+#include "duckdb/common/allocator.hpp"
+
 namespace duckdb {
 
 MemoryStream::MemoryStream(idx_t capacity) : position(0), capacity(capacity), owns_data(true) {


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/4077 (found internally)