### PR TITLE
Fix Sampling tests that are failing Nightly when Block Size/Vector size are not default

### DIFF
--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -492,13 +492,6 @@ void ReservoirSample::EvictOverBudgetSamples() {
 	// if we over sampled, make sure we only keep the highest percentage samples
 	std::unordered_set<idx_t> selections_to_delete;
 
-	bool shuffle_sample = false;
-	if (GetPriorityQueueSize() == 0) {
-		// means we haven't even ingested FIXED_SAMPLE_SIZE values
-		// shuffle all available values (this is for when STANDARD_VECTOR_SIZE << FIXED_SAMPLE_SIZE);
-		shuffle_sample = true;
-	}
-
 	while (num_samples_to_keep < GetPriorityQueueSize()) {
 		auto top = PopFromWeightQueue();
 		D_ASSERT(top.second < sel_size);
@@ -518,23 +511,15 @@ void ReservoirSample::EvictOverBudgetSamples() {
 	// If we need to save a sample with less rows than that, we need to do the following
 	// 1. Create a new selection vector that doesn't point to the rows we are evicting
 	SelectionVector new_sel(num_samples_to_keep);
-	if (!shuffle_sample) {
-		idx_t offset = 0;
-		for (idx_t i = 0; i < num_samples_to_keep + selections_to_delete.size(); i++) {
-			if (selections_to_delete.find(i) == selections_to_delete.end()) {
-				D_ASSERT(i - offset < num_samples_to_keep);
-				new_sel.set_index(i - offset, sel.get_index(i));
-			} else {
-				offset += 1;
-			}
-		}
-	} else {
-		auto random_vec = GetRandomizedVector(reservoir_chunk->chunk.size(), static_cast<idx_t>(num_samples_to_keep));
-		for (idx_t i = 0; i < num_samples_to_keep; i++) {
-			new_sel.set_index(i, random_vec[i]);
+	idx_t offset = 0;
+	for (idx_t i = 0; i < num_samples_to_keep + selections_to_delete.size(); i++) {
+		if (selections_to_delete.find(i) == selections_to_delete.end()) {
+			D_ASSERT(i - offset < num_samples_to_keep);
+			new_sel.set_index(i - offset, sel.get_index(i));
+		} else {
+			offset += 1;
 		}
 	}
-
 	// 2. Update row_ids in our weights so that they don't store rows ids to
 	//    indexes in the selection vector that have been evicted.
 	if (!selections_to_delete.empty()) {
@@ -728,8 +713,6 @@ void ReservoirSample::AddToReservoir(DataChunk &chunk) {
 	if (destroyed || chunk.size() == 0) {
 		return;
 	}
-
-	// Printer::Print("adding " + to_string(chunk.size()) + " samples to reservoir");
 
 	idx_t tuples_consumed = FillReservoir(chunk);
 	base_reservoir_sample->num_entries_seen_total += tuples_consumed;

--- a/src/include/duckdb/execution/reservoir_sample.hpp
+++ b/src/include/duckdb/execution/reservoir_sample.hpp
@@ -172,7 +172,13 @@ public:
 	static constexpr const SampleType TYPE = SampleType::RESERVOIR_SAMPLE;
 
 	constexpr static idx_t FIXED_SAMPLE_SIZE_MULTIPLIER = 10;
-	constexpr static idx_t FAST_TO_SLOW_THRESHOLD = 60;
+	// size is small enough, then the threshold to switch
+	// MinValue between std vec size and fixed sample size.
+	// During 'fast' sampling, we want every new vector to have the potential
+	// to add to the sample. If the threshold is too far below the standard vector size, then
+	// samples in the sample have a higher weight than new samples coming in.
+	// i.e during vector_size=2, 2 new samples will not be significant compared 2048 samples from 204800 tuples.
+	constexpr static idx_t FAST_TO_SLOW_THRESHOLD = MinValue<idx_t>(STANDARD_VECTOR_SIZE, 60);
 
 	// If the table has less than 204800 rows, this is the percentage
 	// of values we save when serializing/returning a sample.

--- a/test/sql/sample/table_samples/basic_sample_tests.test
+++ b/test/sql/sample/table_samples/basic_sample_tests.test
@@ -1,6 +1,8 @@
 # name: test/sql/sample/table_samples/basic_sample_tests.test
 # group: [table_samples]
 
+require vector_size 2048
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sql/sample/table_samples/basic_sample_tests.test
+++ b/test/sql/sample/table_samples/basic_sample_tests.test
@@ -1,6 +1,9 @@
 # name: test/sql/sample/table_samples/basic_sample_tests.test
 # group: [table_samples]
 
+# currently require fixed vector size since the "randomness" of the sample depends on
+# the vector size. If the vector size decreases, the randomness of the sample decreases
+# This is especially noticeable for small tables and their samples
 require vector_size 2048
 
 statement ok

--- a/test/sql/sample/table_samples/sample_stores_rows_from_later_on.test_slow
+++ b/test/sql/sample/table_samples/sample_stores_rows_from_later_on.test_slow
@@ -2,6 +2,7 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
+# required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 
 require noforcestorage

--- a/test/sql/sample/table_samples/table_sample_converts_to_block_sample.test
+++ b/test/sql/sample/table_samples/table_sample_converts_to_block_sample.test
@@ -2,6 +2,7 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
+# required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 
 require noforcestorage

--- a/test/sql/sample/table_samples/table_sample_is_stored.test_slow
+++ b/test/sql/sample/table_samples/table_sample_is_stored.test_slow
@@ -2,6 +2,7 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
+# required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 
 require noforcestorage

--- a/test/sql/sample/table_samples/test_sample_is_destroyed_on_updates.test
+++ b/test/sql/sample/table_samples/test_sample_is_destroyed_on_updates.test
@@ -2,6 +2,7 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
+# required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 
 load __TEST_DIR__/test_sample_is_destroyed_on_update.db


### PR DESCRIPTION
Skipping tests, but also adding some more functionality to make sure we keep track of all the tuples that a reservoir sample has seen/processed. There was an early out causing sample to only keep track of the first 10000 or so tuples when standard vector size was 2.

Nightly test on my own branch is here
https://github.com/Tmonster/duckdb/actions/runs/12990703618