### PR TITLE
[Dev] Improve/Add handling of escapes in VARCHAR -> list/struct/map and align behavior

### DIFF
--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -233,9 +233,6 @@ bool VectorStringToStruct::StringToNestedTypeCastLoop(const string_t *source_dat
 			result_mask.SetInvalid(i);
 			continue;
 		}
-		if (is_unnamed) {
-			throw ConversionException("Casting strings to unnamed structs is unsupported");
-		}
 		if (!VectorStringToStruct::SplitStruct(source_data[idx], child_vectors, i, child_names, child_masks)) {
 			string text = "Type VARCHAR with value '" + source_data[idx].GetString() +
 			              "' can't be cast to the destination type STRUCT";

--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -160,9 +160,9 @@ bool VectorStringToList::StringToNestedTypeCastLoop(const string_t *source_data,
 
 		list_data[i].offset = total;
 		if (!VectorStringToList::SplitStringList(source_data[idx], child_data, total, varchar_vector)) {
-			string text = "Type VARCHAR with value '" + source_data[idx].GetString() +
-			              "' can't be cast to the destination type LIST";
-			HandleVectorCastError::Operation<string_t>(text, result_mask, i, vector_cast_data);
+			auto error = StringUtil::Format("Type VARCHAR with value '%s' can't be cast to the destination type %s",
+			                                source_data[idx].GetString(), result.GetType().ToString());
+			HandleVectorCastError::Operation<string_t>(error, result_mask, i, vector_cast_data);
 		}
 		list_data[i].length = total - list_data[i].offset; // length is the amount of parts coming from this string
 	}
@@ -234,12 +234,12 @@ bool VectorStringToStruct::StringToNestedTypeCastLoop(const string_t *source_dat
 			continue;
 		}
 		if (!VectorStringToStruct::SplitStruct(source_data[idx], child_vectors, i, child_names, child_masks)) {
-			string text = "Type VARCHAR with value '" + source_data[idx].GetString() +
-			              "' can't be cast to the destination type STRUCT";
+			auto error = StringUtil::Format("Type VARCHAR with value '%s' can't be cast to the destination type %s",
+			                                source_data[idx].GetString(), result.GetType().ToString());
 			for (auto &child_mask : child_masks) {
 				child_mask.get().SetInvalid(i); // some values may have already been found and set valid
 			}
-			HandleVectorCastError::Operation<string_t>(text, result_mask, i, vector_cast_data);
+			HandleVectorCastError::Operation<string_t>(error, result_mask, i, vector_cast_data);
 		}
 	}
 
@@ -316,10 +316,10 @@ bool VectorStringToMap::StringToNestedTypeCastLoop(const string_t *source_data, 
 		list_data[i].offset = total;
 		if (!VectorStringToMap::SplitStringMap(source_data[idx], child_key_data, child_val_data, total,
 		                                       varchar_key_vector, varchar_val_vector)) {
-			string text = "Type VARCHAR with value '" + source_data[idx].GetString() +
-			              "' can't be cast to the destination type MAP";
+			auto error = StringUtil::Format("Type VARCHAR with value '%s' can't be cast to the destination type %s",
+			                                source_data[idx].GetString(), result.GetType().ToString());
 			FlatVector::SetNull(result, i, true);
-			HandleVectorCastError::Operation<string_t>(text, result_mask, i, vector_cast_data);
+			HandleVectorCastError::Operation<string_t>(error, result_mask, i, vector_cast_data);
 		}
 		list_data[i].length = total - list_data[i].offset;
 	}
@@ -379,10 +379,9 @@ bool VectorStringToArray::StringToNestedTypeCastLoop(const string_t *source_data
 		if (array_size != str_array_size) {
 			if (all_lengths_match) {
 				all_lengths_match = false;
-				auto msg =
-				    StringUtil::Format("Type VARCHAR with value '%s' can't be cast to the destination type ARRAY[%u]"
-				                       ", the size of the array must match the destination type",
-				                       source_data[idx].GetString(), array_size);
+				auto msg = StringUtil::Format("Type VARCHAR with value '%s' can't be cast to the destination type %s"
+				                              ", the size of the array must match the destination type",
+				                              source_data[idx].GetString(), result.GetType().ToString());
 				if (parameters.strict) {
 					throw ConversionException(msg);
 				}
@@ -418,9 +417,9 @@ bool VectorStringToArray::StringToNestedTypeCastLoop(const string_t *source_data
 		}
 
 		if (!VectorStringToList::SplitStringList(source_data[idx], child_data, total, varchar_vector)) {
-			auto text = StringUtil::Format("Type VARCHAR with value '%s' can't be cast to the destination type ARRAY",
-			                               source_data[idx].GetString());
-			HandleVectorCastError::Operation<string_t>(text, result_mask, i, vector_cast_data);
+			auto error = StringUtil::Format("Type VARCHAR with value '%s' can't be cast to the destination type %s",
+			                                source_data[idx].GetString(), result.GetType().ToString());
+			HandleVectorCastError::Operation<string_t>(error, result_mask, i, vector_cast_data);
 		}
 	}
 	D_ASSERT(total == child_count);

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -1,18 +1,18 @@
 #include "duckdb/function/cast/vector_cast_helpers.hpp"
-#include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/stack.hpp"
+#include "duckdb/common/typedefs.hpp"
 
 namespace {
 
 struct StringCastInputState {
 public:
-	StringCastInputState(const char *buf, idx_t &pos, idx_t &len) : buf(buf), pos(pos), len(len) {
+	StringCastInputState(const char *buf, duckdb::idx_t &pos, duckdb::idx_t &len) : buf(buf), pos(pos), len(len) {
 	}
 
 public:
 	const char *buf;
-	idx_t &pos;
-	idx_t &len;
+	duckdb::idx_t &pos;
+	duckdb::idx_t &len;
 	bool escaped = false;
 };
 

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -565,56 +565,52 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 			idx_t end_pos;
 			while (pos < len && (buf[pos] != ':' || input_state.escaped)) {
 				bool set_escaped = false;
-				if (buf[pos] == '"' || buf[pos] == '\'') {
+
+				if (input_state.escaped) {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						if (!SkipToCloseQuotes(input_state)) {
-							return false;
-						}
+					end_pos = pos;
+				} else if (buf[pos] == '"' || buf[pos] == '\'') {
+					if (!start_pos.IsValid()) {
+						start_pos = pos;
+					}
+					if (!SkipToCloseQuotes(input_state)) {
+						return false;
 					}
 					end_pos = pos;
 				} else if (buf[pos] == '{') {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						if (!SkipToClose(input_state, lvl, '}')) {
-							return false;
-						}
+					if (!SkipToClose(input_state, lvl, '}')) {
+						return false;
 					}
 					end_pos = pos;
 				} else if (buf[pos] == '(') {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						if (!SkipToClose(input_state, lvl, ')')) {
-							return false;
-						}
+					if (!SkipToClose(input_state, lvl, ')')) {
+						return false;
 					}
 					end_pos = pos;
 				} else if (buf[pos] == '[') {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						lvl++;
-						if (!SkipToClose(input_state, lvl, ']')) {
-							return false;
-						}
+					lvl++;
+					if (!SkipToClose(input_state, lvl, ']')) {
+						return false;
 					}
 					end_pos = pos;
 				} else if (buf[pos] == '\\') {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						set_escaped = true;
-					}
+					set_escaped = true;
 					end_pos = pos;
-				} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
+				} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
@@ -649,56 +645,52 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 			SkipWhitespace(input_state);
 			while (pos < len && ((buf[pos] != ',' && buf[pos] != '}') || input_state.escaped)) {
 				bool set_escaped = false;
-				if (buf[pos] == '"' || buf[pos] == '\'') {
+
+				if (input_state.escaped) {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						if (!SkipToCloseQuotes(input_state)) {
-							return false;
-						}
+					end_pos = pos;
+				} else if (buf[pos] == '"' || buf[pos] == '\'') {
+					if (!start_pos.IsValid()) {
+						start_pos = pos;
+					}
+					if (!SkipToCloseQuotes(input_state)) {
+						return false;
 					}
 					end_pos = pos;
 				} else if (buf[pos] == '{') {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						if (!SkipToClose(input_state, lvl, '}')) {
-							return false;
-						}
+					if (!SkipToClose(input_state, lvl, '}')) {
+						return false;
 					}
 					end_pos = pos;
 				} else if (buf[pos] == '(') {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						if (!SkipToClose(input_state, lvl, ')')) {
-							return false;
-						}
+					if (!SkipToClose(input_state, lvl, ')')) {
+						return false;
 					}
 					end_pos = pos;
 				} else if (buf[pos] == '[') {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						lvl++;
-						if (!SkipToClose(input_state, lvl, ']')) {
-							return false;
-						}
+					lvl++;
+					if (!SkipToClose(input_state, lvl, ']')) {
+						return false;
 					}
 					end_pos = pos;
 				} else if (buf[pos] == '\\') {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!input_state.escaped) {
-						set_escaped = true;
-					}
+					set_escaped = true;
 					end_pos = pos;
-				} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
+				} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -573,59 +573,9 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 			optional_idx start_pos;
 			idx_t end_pos;
 			while (pos < len && ((buf[pos] != ',' && buf[pos] != ')') || input_state.escaped)) {
-				bool set_escaped = false;
-
-				if (input_state.escaped) {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '"' || buf[pos] == '\'') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					if (!SkipToCloseQuotes(input_state)) {
-						return false;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '{') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					if (!SkipToClose(input_state)) {
-						return false;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '(') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					if (!SkipToClose(input_state)) {
-						return false;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '[') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					if (!SkipToClose(input_state)) {
-						return false;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '\\') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					set_escaped = true;
-					end_pos = pos;
-				} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					end_pos = pos;
+				if (!ValueStateTransition(input_state, start_pos, end_pos)) {
+					return false;
 				}
-				pos++;
-				input_state.escaped = set_escaped;
 			}
 			if (pos == len) {
 				return false;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -138,7 +138,7 @@ public:
 			if (!escaped) {
 				if (buf[start + i] == '\\') {
 					escaped = true;
-				} else {
+				} else if (buf[start + i] != '\'' && buf[start + i] != '"') {
 					string_data[copied_count++] = buf[start + i];
 				}
 			} else {
@@ -191,21 +191,15 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 			}
 			end_pos = pos;
 		} else if ((buf[pos] == '"' || buf[pos] == '\'')) {
+			if (!start_pos.IsValid()) {
+				start_pos = pos;
+			}
 			if (!input_state.escaped) {
-				if (!start_pos.IsValid()) {
-					//! Trim the start quote
-					start_pos = pos + 1;
-				}
 				if (!SkipToCloseQuotes(input_state)) {
 					return false;
 				}
-				end_pos = pos - 1;
-			} else {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				end_pos = pos;
 			}
+			end_pos = pos;
 		} else if (buf[pos] == '{') {
 			if (!start_pos.IsValid()) {
 				start_pos = pos;
@@ -239,7 +233,12 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 			start_pos = optional_idx();
 			continue;
 		} else if (buf[pos] == '\\') {
-			input_state.escaped = true;
+			if (!start_pos.IsValid()) {
+				start_pos = pos;
+			}
+			if (!input_state.escaped) {
+				input_state.escaped = true;
+			}
 		} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
 			if (!start_pos.IsValid()) {
 				start_pos = pos;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -470,7 +470,6 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 	}
 
 	if (end_char == '}') {
-
 		//! Regular struct, in the form of `{name: value, name_2: value_2, ...}`
 		while (pos < len) {
 			optional_idx start_pos;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -530,59 +530,9 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 			pos++;
 			SkipWhitespace(input_state);
 			while (pos < len && ((buf[pos] != ',' && buf[pos] != '}') || input_state.escaped)) {
-				bool set_escaped = false;
-
-				if (input_state.escaped) {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '"' || buf[pos] == '\'') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					if (!SkipToCloseQuotes(input_state)) {
-						return false;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '{') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					if (!SkipToClose(input_state)) {
-						return false;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '(') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					if (!SkipToClose(input_state)) {
-						return false;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '[') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					if (!SkipToClose(input_state)) {
-						return false;
-					}
-					end_pos = pos;
-				} else if (buf[pos] == '\\') {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					set_escaped = true;
-					end_pos = pos;
-				} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
-					if (!start_pos.IsValid()) {
-						start_pos = pos;
-					}
-					end_pos = pos;
+				if (!ValueStateTransition(input_state, start_pos, end_pos)) {
+					return false;
 				}
-				pos++;
-				input_state.escaped = set_escaped;
 			}
 			if (pos == len) {
 				return false;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -387,46 +387,43 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 		idx_t end_pos;
 		while (pos < len && (buf[pos] != '=' || input_state.escaped)) {
 			bool set_escaped = false;
-			if (buf[pos] == '"' || buf[pos] == '\'') {
+			if (input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!input_state.escaped) {
-					if (!SkipToCloseQuotes(input_state)) {
-						return false;
-					}
+				end_pos = pos;
+			} else if (buf[pos] == '"' || buf[pos] == '\'') {
+				if (!start_pos.IsValid()) {
+					start_pos = pos;
+				}
+				if (!SkipToCloseQuotes(input_state)) {
+					return false;
 				}
 				end_pos = pos;
 			} else if (buf[pos] == '{') {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!input_state.escaped) {
-					if (!SkipToClose(input_state, lvl, '}')) {
-						return false;
-					}
+				if (!SkipToClose(input_state, lvl, '}')) {
+					return false;
 				}
 				end_pos = pos;
 			} else if (buf[pos] == '[') {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!input_state.escaped) {
-					lvl++;
-					if (!SkipToClose(input_state, lvl, ']')) {
-						return false;
-					}
+				lvl++;
+				if (!SkipToClose(input_state, lvl, ']')) {
+					return false;
 				}
 				end_pos = pos;
 			} else if (buf[pos] == '\\') {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!input_state.escaped) {
-					set_escaped = true;
-				}
+				set_escaped = true;
 				end_pos = pos;
-			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
+			} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
@@ -451,46 +448,44 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 		SkipWhitespace(input_state);
 		while (pos < len && ((buf[pos] != ',' && buf[pos] != '}') || input_state.escaped)) {
 			bool set_escaped = false;
-			if (buf[pos] == '"' || buf[pos] == '\'') {
+
+			if (input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!input_state.escaped) {
-					if (!SkipToCloseQuotes(input_state)) {
-						return false;
-					}
+				end_pos = pos;
+			} else if (buf[pos] == '"' || buf[pos] == '\'') {
+				if (!start_pos.IsValid()) {
+					start_pos = pos;
+				}
+				if (!SkipToCloseQuotes(input_state)) {
+					return false;
 				}
 				end_pos = pos;
 			} else if (buf[pos] == '{') {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!input_state.escaped) {
-					if (!SkipToClose(input_state, lvl, '}')) {
-						return false;
-					}
+				if (!SkipToClose(input_state, lvl, '}')) {
+					return false;
 				}
 				end_pos = pos;
 			} else if (buf[pos] == '[') {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!input_state.escaped) {
-					lvl++;
-					if (!SkipToClose(input_state, lvl, ']')) {
-						return false;
-					}
+				lvl++;
+				if (!SkipToClose(input_state, lvl, ']')) {
+					return false;
 				}
 				end_pos = pos;
 			} else if (buf[pos] == '\\') {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!input_state.escaped) {
-					set_escaped = true;
-				}
+				set_escaped = true;
 				end_pos = pos;
-			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
+			} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -160,9 +160,18 @@ static string_t HandleString(Vector &vec, const char *buf, idx_t start, idx_t en
 				//! Close scope
 				scopes.pop();
 			}
-			if (!quoted && (current_char == '[' || current_char == '{')) {
+			if (!quoted && (current_char == '[' || current_char == '{' || current_char == '(')) {
 				//! New scope
-				scopes.push(current_char == '[' ? ']' : '}');
+				char end_char;
+				if (current_char == '[') {
+					end_char = ']';
+				} else if (current_char == '{') {
+					end_char = '}';
+				} else {
+					D_ASSERT(current_char == '(');
+					end_char = ')';
+				}
+				scopes.push(end_char);
 			}
 			//! Regular character
 			string_data[copied_count++] = current_char;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -623,6 +623,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 		pos++;
 		SkipWhitespace(input_state);
 		while (pos < len && ((buf[pos] != ',' && buf[pos] != '}') || input_state.escaped)) {
+			bool set_escaped = false;
 			if (buf[pos] == '"' || buf[pos] == '\'') {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
@@ -659,7 +660,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 					start_pos = pos;
 				}
 				if (!input_state.escaped) {
-					input_state.escaped = true;
+					set_escaped = true;
 				}
 			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 				if (!start_pos.IsValid()) {
@@ -668,6 +669,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 				end_pos = pos;
 			}
 			pos++;
+			input_state.escaped = set_escaped;
 		}
 		if (pos == len) {
 			return false;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -280,7 +280,6 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 				} else {
 					auto start = start_pos.GetIndex();
 					auto end = (end_pos + 1) - start;
-					auto substr = std::string(buf + start, end);
 					state.HandleValue(buf, start, end_pos + 1);
 				}
 				seen_value = true;
@@ -441,11 +440,12 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 			return false;
 		}
 		if (!start_pos.IsValid()) {
-			//! Key can not be empty
-			return false;
+			start_pos = 0;
+			end_pos = 0;
+		} else {
+			end_pos++;
 		}
-		auto key_substr = std::string(buf + start_pos.GetIndex(), buf + end_pos + 1);
-		if (!state.HandleKey(buf, start_pos.GetIndex(), end_pos + 1)) {
+		if (!state.HandleKey(buf, start_pos.GetIndex(), end_pos)) {
 			return false;
 		}
 		start_pos = optional_idx();
@@ -506,7 +506,6 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 			//! Value is empty
 			state.HandleValue(buf, 0, 0);
 		} else {
-			auto value_substr = std::string(buf + start_pos.GetIndex(), buf + end_pos + 1);
 			state.HandleValue(buf, start_pos.GetIndex(), end_pos + 1);
 		}
 		if (buf[pos] == '}') {

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -279,7 +279,6 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 					state.HandleValue(buf, 0, 0);
 				} else {
 					auto start = start_pos.GetIndex();
-					auto end = (end_pos + 1) - start;
 					state.HandleValue(buf, start, end_pos + 1);
 				}
 				seen_value = true;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -70,15 +70,15 @@ static bool SkipToCloseQuotes(StringCastInputState &input_state) {
 	return false;
 }
 
-static bool SkipToClose(StringCastInputState &input_state, idx_t &lvl, char close_bracket) {
+static bool SkipToClose(StringCastInputState &input_state, idx_t &lvl) {
 	auto &idx = input_state.pos;
 	auto &buf = input_state.buf;
 	auto &len = input_state.len;
 	auto &escaped = input_state.escaped;
-	idx++;
+
+	D_ASSERT(buf[idx] == '{' || buf[idx] == '[' || buf[idx] == '(');
 
 	vector<char> brackets;
-	brackets.push_back(close_bracket);
 	while (idx < len) {
 		if (!escaped) {
 			if (buf[idx] == '"' || buf[idx] == '\'') {
@@ -250,8 +250,7 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 				start_pos = pos;
 			}
 			//! Start of a LIST
-			lvl++;
-			if (!SkipToClose(input_state, lvl, ']')) {
+			if (!SkipToClose(input_state, lvl)) {
 				return false;
 			}
 			end_pos = pos;
@@ -269,7 +268,7 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 			}
 			//! Start of a STRUCT
 			idx_t struct_lvl = 0;
-			if (!SkipToClose(input_state, struct_lvl, '}')) {
+			if (!SkipToClose(input_state, struct_lvl)) {
 				return false;
 			}
 			end_pos = pos;
@@ -279,7 +278,7 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 			}
 			//! Start of an (unnamed) STRUCT
 			idx_t struct_lvl = 0;
-			if (!SkipToClose(input_state, struct_lvl, ')')) {
+			if (!SkipToClose(input_state, struct_lvl)) {
 				return false;
 			}
 			end_pos = pos;
@@ -417,7 +416,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!SkipToClose(input_state, lvl, '}')) {
+				if (!SkipToClose(input_state, lvl)) {
 					return false;
 				}
 				end_pos = pos;
@@ -425,7 +424,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!SkipToClose(input_state, lvl, ')')) {
+				if (!SkipToClose(input_state, lvl)) {
 					return false;
 				}
 				end_pos = pos;
@@ -433,8 +432,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				lvl++;
-				if (!SkipToClose(input_state, lvl, ']')) {
+				if (!SkipToClose(input_state, lvl)) {
 					return false;
 				}
 				end_pos = pos;
@@ -488,7 +486,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!SkipToClose(input_state, lvl, '}')) {
+				if (!SkipToClose(input_state, lvl)) {
 					return false;
 				}
 				end_pos = pos;
@@ -496,7 +494,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				if (!SkipToClose(input_state, lvl, ')')) {
+				if (!SkipToClose(input_state, lvl)) {
 					return false;
 				}
 				end_pos = pos;
@@ -504,8 +502,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
-				lvl++;
-				if (!SkipToClose(input_state, lvl, ']')) {
+				if (!SkipToClose(input_state, lvl)) {
 					return false;
 				}
 				end_pos = pos;
@@ -662,7 +659,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!SkipToClose(input_state, lvl, '}')) {
+					if (!SkipToClose(input_state, lvl)) {
 						return false;
 					}
 					end_pos = pos;
@@ -670,7 +667,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!SkipToClose(input_state, lvl, ')')) {
+					if (!SkipToClose(input_state, lvl)) {
 						return false;
 					}
 					end_pos = pos;
@@ -678,8 +675,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					lvl++;
-					if (!SkipToClose(input_state, lvl, ']')) {
+					if (!SkipToClose(input_state, lvl)) {
 						return false;
 					}
 					end_pos = pos;
@@ -757,7 +753,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!SkipToClose(input_state, lvl, '}')) {
+					if (!SkipToClose(input_state, lvl)) {
 						return false;
 					}
 					end_pos = pos;
@@ -765,7 +761,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					if (!SkipToClose(input_state, lvl, ')')) {
+					if (!SkipToClose(input_state, lvl)) {
 						return false;
 					}
 					end_pos = pos;
@@ -773,8 +769,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 					if (!start_pos.IsValid()) {
 						start_pos = pos;
 					}
-					lvl++;
-					if (!SkipToClose(input_state, lvl, ']')) {
+					if (!SkipToClose(input_state, lvl)) {
 						return false;
 					}
 					end_pos = pos;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -224,9 +224,6 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 	idx_t end_pos;
 	bool seen_value = false;
 	while (pos < len) {
-		if (pos == len) {
-			return false;
-		}
 		bool set_escaped = false;
 
 		if (input_state.escaped) {
@@ -352,6 +349,67 @@ struct SplitStringMapOperation {
 	}
 };
 
+static inline bool MapKeyOrValueStateTransition(StringCastInputState &input_state, optional_idx &start_pos,
+                                                idx_t &end_pos) {
+	auto &buf = input_state.buf;
+	auto &pos = input_state.pos;
+
+	bool set_escaped = false;
+	if (input_state.escaped) {
+		if (!start_pos.IsValid()) {
+			start_pos = pos;
+		}
+		end_pos = pos;
+	} else if (buf[pos] == '"' || buf[pos] == '\'') {
+		if (!start_pos.IsValid()) {
+			start_pos = pos;
+		}
+		if (!SkipToCloseQuotes(input_state)) {
+			return false;
+		}
+		end_pos = pos;
+	} else if (buf[pos] == '{') {
+		if (!start_pos.IsValid()) {
+			start_pos = pos;
+		}
+		if (!SkipToClose(input_state)) {
+			return false;
+		}
+		end_pos = pos;
+	} else if (buf[pos] == '(') {
+		if (!start_pos.IsValid()) {
+			start_pos = pos;
+		}
+		if (!SkipToClose(input_state)) {
+			return false;
+		}
+		end_pos = pos;
+	} else if (buf[pos] == '[') {
+		if (!start_pos.IsValid()) {
+			start_pos = pos;
+		}
+		if (!SkipToClose(input_state)) {
+			return false;
+		}
+		end_pos = pos;
+	} else if (buf[pos] == '\\') {
+		if (!start_pos.IsValid()) {
+			start_pos = pos;
+		}
+		set_escaped = true;
+		end_pos = pos;
+	} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
+		if (!start_pos.IsValid()) {
+			start_pos = pos;
+		}
+		end_pos = pos;
+	}
+	input_state.escaped = set_escaped;
+	pos++;
+
+	return true;
+}
+
 template <class OP>
 static bool SplitStringMapInternal(const string_t &input, OP &state) {
 	const char *buf = input.GetData();
@@ -378,58 +436,9 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 		optional_idx start_pos;
 		idx_t end_pos;
 		while (pos < len && (buf[pos] != '=' || input_state.escaped)) {
-			bool set_escaped = false;
-			if (input_state.escaped) {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '"' || buf[pos] == '\'') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				if (!SkipToCloseQuotes(input_state)) {
-					return false;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '{') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				if (!SkipToClose(input_state)) {
-					return false;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '(') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				if (!SkipToClose(input_state)) {
-					return false;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '[') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				if (!SkipToClose(input_state)) {
-					return false;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '\\') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				set_escaped = true;
-				end_pos = pos;
-			} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				end_pos = pos;
+			if (!MapKeyOrValueStateTransition(input_state, start_pos, end_pos)) {
+				return false;
 			}
-			input_state.escaped = set_escaped;
-			pos++;
 		}
 		if (pos == len) {
 			return false;
@@ -447,59 +456,9 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 		pos++;
 		SkipWhitespace(input_state);
 		while (pos < len && ((buf[pos] != ',' && buf[pos] != '}') || input_state.escaped)) {
-			bool set_escaped = false;
-
-			if (input_state.escaped) {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '"' || buf[pos] == '\'') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				if (!SkipToCloseQuotes(input_state)) {
-					return false;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '{') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				if (!SkipToClose(input_state)) {
-					return false;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '(') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				if (!SkipToClose(input_state)) {
-					return false;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '[') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				if (!SkipToClose(input_state)) {
-					return false;
-				}
-				end_pos = pos;
-			} else if (buf[pos] == '\\') {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				set_escaped = true;
-				end_pos = pos;
-			} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
-				if (!start_pos.IsValid()) {
-					start_pos = pos;
-				}
-				end_pos = pos;
+			if (!MapKeyOrValueStateTransition(input_state, start_pos, end_pos)) {
+				return false;
 			}
-			input_state.escaped = set_escaped;
-			pos++;
 		}
 		if (pos == len) {
 			return false;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -273,6 +273,16 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 				return false;
 			}
 			end_pos = pos;
+		} else if (buf[pos] == '(') {
+			if (!start_pos.IsValid()) {
+				start_pos = pos;
+			}
+			//! Start of an (unnamed) STRUCT
+			idx_t struct_lvl = 0;
+			if (!SkipToClose(input_state, struct_lvl, ')')) {
+				return false;
+			}
+			end_pos = pos;
 		} else if ((buf[pos] == ',' || buf[pos] == ']')) {
 			if (buf[pos] != ']' || start_pos.IsValid() || seen_value) {
 				if (!start_pos.IsValid()) {
@@ -411,6 +421,14 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 					return false;
 				}
 				end_pos = pos;
+			} else if (buf[pos] == '(') {
+				if (!start_pos.IsValid()) {
+					start_pos = pos;
+				}
+				if (!SkipToClose(input_state, lvl, ')')) {
+					return false;
+				}
+				end_pos = pos;
 			} else if (buf[pos] == '[') {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
@@ -471,6 +489,14 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 					start_pos = pos;
 				}
 				if (!SkipToClose(input_state, lvl, '}')) {
+					return false;
+				}
+				end_pos = pos;
+			} else if (buf[pos] == '(') {
+				if (!start_pos.IsValid()) {
+					start_pos = pos;
+				}
+				if (!SkipToClose(input_state, lvl, ')')) {
 					return false;
 				}
 				end_pos = pos;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -580,6 +580,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 	}
 
 	if (end_char == '}') {
+
 		//! Regular struct, in the form of `{name: value, name_2: value_2, ...}`
 		while (pos < len) {
 			optional_idx start_pos;
@@ -727,7 +728,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 		D_ASSERT(end_char == ')');
 		idx_t child_idx = 0;
 		while (pos < len) {
-			if (child_idx == child_names.size()) {
+			if (child_idx == child_masks.size()) {
 				return false;
 			}
 
@@ -817,6 +818,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 			pos++;
 			SkipWhitespace(input_state);
 		}
+		(void)child_idx;
 	}
 	pos++;
 	SkipWhitespace(input_state);

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -34,21 +34,12 @@ inline static void SkipWhitespace(StringCastInputState &input_state) {
 	auto &buf = input_state.buf;
 	auto &pos = input_state.pos;
 	auto &len = input_state.len;
-	while (pos < len) {
-		bool set_escaped = false;
-		if (buf[pos] == '\\') {
-			if (!input_state.escaped) {
-				set_escaped = true;
-			}
-		} else if (StringUtil::CharacterIsSpace(buf[pos])) {
-			if (input_state.escaped) {
-				break;
-			}
-		} else {
-			break;
-		}
+	if (input_state.escaped) {
+		return;
+	}
+	while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
 		pos++;
-		input_state.escaped = set_escaped;
+		input_state.escaped = false;
 	}
 }
 

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -285,6 +285,7 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 			if (!input_state.escaped) {
 				set_escaped = true;
 			}
+			end_pos = pos;
 		} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 			if (!start_pos.IsValid()) {
 				start_pos = pos;
@@ -416,6 +417,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!input_state.escaped) {
 					set_escaped = true;
 				}
+				end_pos = pos;
 			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
@@ -479,6 +481,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!input_state.escaped) {
 					set_escaped = true;
 				}
+				end_pos = pos;
 			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
@@ -589,6 +592,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 				if (!input_state.escaped) {
 					set_escaped = true;
 				}
+				end_pos = pos;
 			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
@@ -662,6 +666,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 				if (!input_state.escaped) {
 					set_escaped = true;
 				}
+				end_pos = pos;
 			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -34,9 +34,21 @@ inline static void SkipWhitespace(StringCastInputState &input_state) {
 	auto &buf = input_state.buf;
 	auto &pos = input_state.pos;
 	auto &len = input_state.len;
-	while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
+	while (pos < len) {
+		bool set_escaped = false;
+		if (buf[pos] == '\\') {
+			if (!input_state.escaped) {
+				set_escaped = true;
+			}
+		} else if (StringUtil::CharacterIsSpace(buf[pos])) {
+			if (input_state.escaped) {
+				break;
+			}
+		} else {
+			break;
+		}
 		pos++;
-		input_state.escaped = false;
+		input_state.escaped = set_escaped;
 	}
 }
 
@@ -282,7 +294,7 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 			if (!input_state.escaped) {
 				set_escaped = true;
 			}
-		} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
+		} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 			if (!start_pos.IsValid()) {
 				start_pos = pos;
 			}
@@ -413,7 +425,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!input_state.escaped) {
 					set_escaped = true;
 				}
-			} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
+			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
@@ -476,7 +488,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				if (!input_state.escaped) {
 					set_escaped = true;
 				}
-			} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
+			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
@@ -586,7 +598,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 				if (!input_state.escaped) {
 					set_escaped = true;
 				}
-			} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
+			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}
@@ -658,7 +670,7 @@ bool VectorStringToStruct::SplitStruct(const string_t &input, vector<unique_ptr<
 				if (!input_state.escaped) {
 					input_state.escaped = true;
 				}
-			} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
+			} else if (!StringUtil::CharacterIsSpace(buf[pos]) || input_state.escaped) {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
 				}

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -141,12 +141,9 @@ static bool SplitStringListInternal(const string_t &input, OP &state) {
 			idx_t struct_lvl = 0;
 			SkipToClose(pos, buf, len, struct_lvl, '}');
 		} else if (buf[pos] == ',' || buf[pos] == ']') {
-			idx_t trailing_whitespace = 0;
-			while (StringUtil::CharacterIsSpace(buf[pos - trailing_whitespace - 1])) {
-				trailing_whitespace++;
-			}
+			auto trimmed_pos = StringTrim(buf, start_pos, pos);
 			if (buf[pos] != ']' || start_pos != pos || seen_value) {
-				state.HandleValue(buf, start_pos, pos - trailing_whitespace);
+				state.HandleValue(buf, start_pos, trimmed_pos);
 				seen_value = true;
 			}
 			if (buf[pos] == ']') {

--- a/src/function/cast/vector_cast_helpers.cpp
+++ b/src/function/cast/vector_cast_helpers.cpp
@@ -437,6 +437,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 		pos++;
 		SkipWhitespace(input_state);
 		while (pos < len && ((buf[pos] != ',' && buf[pos] != '}') || input_state.escaped)) {
+			bool set_escaped = false;
 			if (buf[pos] == '"' || buf[pos] == '\'') {
 				if (!start_pos.IsValid()) {
 					start_pos = pos;
@@ -473,7 +474,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 					start_pos = pos;
 				}
 				if (!input_state.escaped) {
-					input_state.escaped = true;
+					set_escaped = true;
 				}
 			} else if (!StringUtil::CharacterIsSpace(buf[pos])) {
 				if (!start_pos.IsValid()) {
@@ -481,6 +482,7 @@ static bool SplitStringMapInternal(const string_t &input, OP &state) {
 				}
 				end_pos = pos;
 			}
+			input_state.escaped = set_escaped;
 			pos++;
 		}
 		if (pos == len) {

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -206,7 +206,7 @@ SELECT CAST($$['hello','world', '!']$$ AS VARCHAR[]);
 [hello, world, !]
 
 query I
-SELECT CAST($$[''hello'',''world'', ''!'']$$ AS VARCHAR[]);
+SELECT CAST($$[\'hello\',\'world\', \'!\']$$ AS VARCHAR[]);
 ----
 ['hello', 'world', '!']
 
@@ -216,7 +216,7 @@ SELECT CAST($$[[ ['🦆, 🦆, 🦆']], [[duck, db, '🦆'] ]]$$ AS VARCHAR[][][
 [[[🦆, 🦆, 🦆]], [[duck, db, 🦆]]]
 
 query I
-SELECT CAST($$["can't", "you're", "i'm"]$$ AS VARCHAR[]);
+SELECT CAST($$[can\'t, you\'re, i\'m]$$ AS VARCHAR[]);
 ----
 [can't, you're, i'm]
 
@@ -249,7 +249,7 @@ SELECT CAST('[          [ [12,     13,14], [8, 9         ]  ],[[ 4    ]   ],    
 [[[12, 13, 14], [8, 9]], [[4]], [[2, 1, 0]]]
 
 query I
-SELECT CAST($$["   hello","          '  world", "!         "]$$ AS VARCHAR[]);
+SELECT CAST($$["   hello","          \'  world", "!         "]$$ AS VARCHAR[]);
 ----
 [   hello,           '  world, !         ]
 
@@ -259,7 +259,7 @@ SELECT CAST('[   hello     ,   world      , !         ]' AS VARCHAR[]);
 [hello, world, !]
 
 query I
-SELECT CAST($$[    [ "   hello"]  ,["            world"        ],[ "!        "           ]      ]$$ AS VARCHAR[][]);
+SELECT CAST($$[    [ \"   hello\"]  ,[\"            world\"        ],[ \"!        \"           ]      ]$$ AS VARCHAR[][]);
 ----
 [[   hello], [            world], [!        ]]
 

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -532,4 +532,9 @@ select '[{"bar":"\"\"\\\"\"\"\\"}]'::STRUCT(bar VARCHAR)[];
 query III
 select $$[\  \\abc\\ \ , def, ghi]$$::VARCHAR[] a, a[1], len(a[1])
 ----
+[\  \\abc\\ \, def, ghi]	\  \\abc\\ \	12
+
+query III
+select $$["\  \\abc\\ \ ", def, ghi]$$::VARCHAR[] a, a[1], len(a[1])
+----
 [  \abc\  , def, ghi]	  \abc\  	9

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -511,11 +511,11 @@ statement error
 select '[{"bar":"\\""}]'::VARCHAR[];
 ----
 
-# escapes are only processed once the {} is cast as well
+# Unescaped doublequote ends the quote early, leaving an uneven amount of `"`, causing an error
 statement error
-query I
 select '[{"bar":"\\""}]'::STRUCT(bar VARCHAR)[];
 ----
+can't be cast to the destination type LIST
 
 # uneven amount of escapes does escape the "
 query I

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -488,7 +488,7 @@ statement ok
 CREATE TABLE assorted_lists(col1 INT[], col2 VARCHAR[], col3 DATE[]);
 
 statement ok
-COPY (SELECT [8,7,6], '[hello, Duck''DB]', '[2022-12-2, 1929-01-25]') TO '__TEST_DIR__/assorted_lists.csv' (Header 0);
+COPY (SELECT [8,7,6], $$[hello, Duck\\'DB]$$, '[2022-12-2, 1929-01-25]') TO '__TEST_DIR__/assorted_lists.csv' (Header 0);
 
 statement ok
 COPY assorted_lists FROM '__TEST_DIR__/assorted_lists.csv';
@@ -507,19 +507,24 @@ select '[{"bar":"\""}]'::VARCHAR[];
 ----
 [{"bar":"\""}]
 
-# escaped '\', does not count as an escape for "
 statement error
 select '[{"bar":"\\""}]'::VARCHAR[];
 ----
 
+# escapes are only processed once the {} is cast as well
+statement error
+query I
+select '[{"bar":"\\""}]'::STRUCT(bar VARCHAR)[];
+----
+
 # uneven amount of escapes does escape the "
 query I
-select '[{"bar":"\\\""}]'::VARCHAR[];
+select '[{"bar":"\\\""}]'::STRUCT(bar VARCHAR)[];
 ----
-[{"bar":"\\\""}]
+[{'bar': \"}]
 
 # all are escaped except for the last one
 query I
-select '[{"bar":"\"\"\\\"\"\"\\"}]'::VARCHAR[];
+select '[{"bar":"\"\"\\\"\"\"\\"}]'::STRUCT(bar VARCHAR)[];
 ----
-[{"bar":"\"\"\\\"\"\"\\"}]
+[{'bar': ""\"""\}]

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -259,7 +259,7 @@ SELECT CAST('[   hello     ,   world      , !         ]' AS VARCHAR[]);
 [hello, world, !]
 
 query I
-SELECT CAST($$[    [ \"   hello\"]  ,[\"            world\"        ],[ \"!        \"           ]      ]$$ AS VARCHAR[][]);
+SELECT CAST($$[    [ "   hello"]  ,["            world"        ],[ "!        "           ]      ]$$ AS VARCHAR[][]);
 ----
 [[   hello], [            world], [!        ]]
 

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -16,7 +16,7 @@ SELECT '[12,13,14]'::INT[];
 query I
 SELECT '["hello", "world", "!"]'::VARCHAR[];
 ----
-["hello", "world", "!"]
+[hello, world, !]
 
 query I
 SELECT CAST('[Hello World!]' AS VARCHAR[]);
@@ -110,8 +110,8 @@ INSERT INTO stringList VALUES ('["hello","world","!"]'), ('["Amazing","text"]'),
 query I
 SELECT col1::VARCHAR[] FROM stringList;
 ----
-["hello", "world", "!"]
-["Amazing", "text"]
+[hello, world, !]
+[Amazing, text]
 [Hello World!]
 
 # ---------------------------------------------------
@@ -124,8 +124,8 @@ INSERT INTO nestedStrings VALUES ('[["hello"], ["world"],["!"]]'), ('[["Amazing"
 query I
 SELECT col1::VARCHAR[][] FROM nestedStrings;
 ----
-[["hello"], ["world"], ["!"]]
-[["Amazing"], ["text"]]
+[[hello], [world], [!]]
+[[Amazing], [text]]
 [[Hello World!]]
 
 # ---------------------------------------------------
@@ -138,8 +138,8 @@ INSERT INTO superNestedStrings VALUES ('[[[[["hello"]]], [[["world"],["!"]]]]]')
 query I
 SELECT col1::VARCHAR[][][][][] FROM superNestedStrings;
 ----
-[[[[["hello"]]], [[["world"], ["!"]]]]]
-[[[[["Amazing"]], [["text"]]]]]
+[[[[[hello]]], [[[world], [!]]]]]
+[[[[[Amazing]], [[text]]]]]
 [[[[[Hello World!]]]]]
 
 # ---------------------------------------------------
@@ -201,39 +201,39 @@ SELECT col1::INT[][][][][][] FROM crazyNested;
 #               Quote handling
 # ---------------------------------------------------
 query I
-SELECT CAST('[''hello'',''world'', ''!'']' AS VARCHAR[]);
+SELECT CAST($$['hello','world', '!']$$ AS VARCHAR[]);
+----
+[hello, world, !]
+
+query I
+SELECT CAST($$[''hello'',''world'', ''!'']$$ AS VARCHAR[]);
 ----
 ['hello', 'world', '!']
 
 query I
-SELECT CAST('[''''hello'''',''''world'''', ''''!'''']' AS VARCHAR[]);
+SELECT CAST($$[[ ['🦆, 🦆, 🦆']], [[duck, db, '🦆'] ]]$$ AS VARCHAR[][][]);
 ----
-[''hello'', ''world'', ''!'']
+[[[🦆, 🦆, 🦆]], [[duck, db, 🦆]]]
 
 query I
-SELECT CAST('[[ [''🦆, 🦆, 🦆'']], [[duck, db, ''🦆''] ]]' AS VARCHAR[][][]);
-----
-[[['🦆, 🦆, 🦆']], [[duck, db, '🦆']]]
-
-query I
-SELECT CAST('["can''t", "you''re", "i''m"]' AS VARCHAR[]);
-----
-["can't", "you're", "i'm"]
-
-query I
-SELECT CAST('[can''t, you''re, i''m]' AS VARCHAR[]);
+SELECT CAST($$["can't", "you're", "i'm"]$$ AS VARCHAR[]);
 ----
 [can't, you're, i'm]
 
 query I
-SELECT CAST('["]", "hello", "world"]' AS VARCHAR[]);
+SELECT CAST($$[can't, you're, i'm]$$ AS VARCHAR[]);
 ----
-["]", "hello", "world"]
+[can't, you're, i'm]
 
 query I
-SELECT CAST('['']'', "hello", "world"]' AS VARCHAR[]);
+SELECT CAST($$["]", "hello", "world"]$$ AS VARCHAR[]);
 ----
-[']', "hello", "world"]
+[], hello, world]
+
+query I
+SELECT CAST($$[']', "hello", "world"]$$ AS VARCHAR[]);
+----
+[], hello, world]
 
 
 #               Test for whitespaces
@@ -249,9 +249,9 @@ SELECT CAST('[          [ [12,     13,14], [8, 9         ]  ],[[ 4    ]   ],    
 [[[12, 13, 14], [8, 9]], [[4]], [[2, 1, 0]]]
 
 query I
-SELECT CAST('["   hello","          ''  world", "!         "]' AS VARCHAR[]);
+SELECT CAST($$["   hello","          '  world", "!         "]$$ AS VARCHAR[]);
 ----
-["   hello", "          '  world", "!         "]
+[   hello,           '  world, !         ]
 
 query I
 SELECT CAST('[   hello     ,   world      , !         ]' AS VARCHAR[]);     
@@ -259,9 +259,9 @@ SELECT CAST('[   hello     ,   world      , !         ]' AS VARCHAR[]);
 [hello, world, !]
 
 query I
-SELECT CAST('[    [ "   hello"]  ,["            world"        ],[ "!        "           ]      ]' AS VARCHAR[][]);
+SELECT CAST($$[    [ "   hello"]  ,["            world"        ],[ "!        "           ]      ]$$ AS VARCHAR[][]);
 ----
-[["   hello"], ["            world"], ["!        "]]
+[[   hello], [            world], [!        ]]
 
 
 #               Empty list

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -221,7 +221,7 @@ SELECT CAST($$["can't", "you're", "i'm"]$$ AS VARCHAR[]);
 [can't, you're, i'm]
 
 query I
-SELECT CAST($$[can't, you're, i'm]$$ AS VARCHAR[]);
+SELECT CAST($$[can\'t, you\'re, i\'m]$$ AS VARCHAR[]);
 ----
 [can't, you're, i'm]
 

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -528,3 +528,8 @@ query I
 select '[{"bar":"\"\"\\\"\"\"\\"}]'::STRUCT(bar VARCHAR)[];
 ----
 [{'bar': ""\"""\}]
+
+query III
+select $$[\  \\abc\\ \ , def, ghi]$$::VARCHAR[] a, a[1], len(a[1])
+----
+[  \abc\  , def, ghi]	  \abc\  	9

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -515,7 +515,7 @@ select '[{"bar":"\\""}]'::VARCHAR[];
 statement error
 select '[{"bar":"\\""}]'::STRUCT(bar VARCHAR)[];
 ----
-can't be cast to the destination type LIST
+can't be cast to the destination type STRUCT(bar VARCHAR)[]
 
 # uneven amount of escapes does escape the "
 query I

--- a/test/sql/cast/string_to_list_cast.test
+++ b/test/sql/cast/string_to_list_cast.test
@@ -249,9 +249,9 @@ SELECT CAST('[          [ [12,     13,14], [8, 9         ]  ],[[ 4    ]   ],    
 [[[12, 13, 14], [8, 9]], [[4]], [[2, 1, 0]]]
 
 query I
-SELECT CAST($$["   hello","          \'  world", "!         "]$$ AS VARCHAR[]);
+SELECT CAST($$["   hello","          \"'  world", "!         "]$$ AS VARCHAR[]);
 ----
-[   hello,           '  world, !         ]
+[   hello,           "'  world, !         ]
 
 query I
 SELECT CAST('[   hello     ,   world      , !         ]' AS VARCHAR[]);     

--- a/test/sql/cast/string_to_list_escapes.test
+++ b/test/sql/cast/string_to_list_escapes.test
@@ -1,0 +1,198 @@
+# name: test/sql/cast/string_to_list_escapes.test
+# group: [cast]
+
+query I
+SELECT $$[hello, world]$$::VARCHAR[];
+----
+[hello, world]
+
+query I
+SELECT $$[hello\ world, world]$$::VARCHAR[];
+----
+[hello world, world]
+
+query I
+SELECT $$[hello\,world, test]$$::VARCHAR[];
+----
+[hello,world, test]
+
+query I
+SELECT $$[hello\,, test]$$::VARCHAR[];
+----
+[hello,, test]
+
+query I
+SELECT $$[hello\"quoted\"text, more]$$::VARCHAR[];
+----
+[hello"quoted"text, more]
+
+query I
+SELECT $$[escaped\\backslash, test]$$::VARCHAR[];
+----
+[escaped\backslash, test]
+
+query I
+SELECT $$[nested[brackets], test]$$::VARCHAR[];
+----
+[nested[brackets], test]
+
+query I
+SELECT $$[quote\'in\'string, test]$$::VARCHAR[];
+----
+[quote'in'string, test]
+
+query I
+SELECT $$[mix\ of\ special\,chars]$$::VARCHAR[];
+----
+[mix of special,chars]
+
+query I
+SELECT $$["ends with space ", "trailing space "]$$::VARCHAR[];
+----
+[ends with space , trailing space ]
+
+query I
+SELECT $$["ends with comma,", "another,"]$$::VARCHAR[];
+----
+[ends with comma,, another,]
+
+query I
+SELECT $$["quote at end\"", "\""]$$::VARCHAR[];
+----
+[quote at end", "]
+
+query I
+SELECT $$["ends with bracket]", "[bracket"]$$::VARCHAR[];
+----
+[ends with bracket], [bracket]
+
+query I
+SELECT $$["backslash at end\\", "\\"]$$::VARCHAR[];
+----
+[backslash at end\, \]
+
+query I
+SELECT $$[" space at start", " leading space"]$$::VARCHAR[];
+----
+[ space at start,  leading space]
+
+query I
+SELECT $$[",comma at start", ",leading comma"]$$::VARCHAR[];
+----
+[,comma at start, ,leading comma]
+
+query I
+SELECT $$["\"quote at start", "\"leading quote"]$$::VARCHAR[];
+----
+["quote at start, "leading quote]
+
+query I
+SELECT $$["[bracket at start", "[leading bracket"]$$::VARCHAR[];
+----
+[[bracket at start, [leading bracket]
+
+query I
+SELECT $$["\\backslash at start", "\\leading backslash"]$$::VARCHAR[];
+----
+[\backslash at start, \leading backslash]
+
+query I
+SELECT $$[" space at start and end ", " leading and trailing space "]$$::VARCHAR[];
+----
+[ space at start and end ,  leading and trailing space ]
+
+query I
+SELECT $$[",comma at start and end,", ",leading and trailing comma,"]$$::VARCHAR[];
+----
+[,comma at start and end,, ,leading and trailing comma,]
+
+query I
+SELECT $$["\"quote at start and end\"", "\"leading and trailing quote\""]$$::VARCHAR[];
+----
+["quote at start and end", "leading and trailing quote"]
+
+query I
+SELECT $$["[bracket at start and end]", "[leading and trailing bracket]"]$$::VARCHAR[];
+----
+[[bracket at start and end], [leading and trailing bracket]]
+
+query I
+SELECT $$["\\backslash at start and end\\", "\\leading and trailing backslash\\"]$$::VARCHAR[];
+----
+[\backslash at start and end\, \leading and trailing backslash\]
+
+
+query I
+SELECT $$[" mix, of special\ characters " , "[various] \"combinations\" "]$$::VARCHAR[];
+----
+[ mix, of special characters , [various] "combinations" ]
+
+query I
+SELECT $$[", starts and ends with ,", "[brackets] and ,commas,"]$$::VARCHAR[];
+----
+[, starts and ends with ,, [brackets] and ,commas,]
+
+query I
+SELECT $$["\"quotes\" and \ spaces ", "\ leading and trailing \ "]$$::VARCHAR[];
+----
+["quotes" and  spaces ,  leading and trailing  ]
+
+query I
+SELECT $$["[complex\ combination, of\" special]", "\\all cases covered\\"]$$::VARCHAR[];
+----
+[[complex combination, of" special], \all cases covered\]
+
+query I
+SELECT $$["hello, world"]$$::VARCHAR[];
+----
+[hello, world]
+
+statement error
+SELECT $$["missing quote]]$$::VARCHAR[]; -- Mismatched quotes
+----
+can't be cast to the destination type
+
+statement error
+SELECT $$["backslash at end\"]$$::VARCHAR[]; -- Improper escaping
+----
+can't be cast to the destination type
+
+statement error
+SELECT $$[unescaped[bracket]$$::VARCHAR[]; -- Unescaped bracket
+----
+can't be cast to the destination type
+
+statement error
+SELECT $$[unterminated string]"]$$::VARCHAR[];
+----
+can't be cast to the destination type
+
+query I
+SELECT $$[]$$::VARCHAR[];  -- Empty list
+----
+[]
+
+query I
+SELECT $$[""]$$::VARCHAR[]; -- List with empty string
+----
+[]
+
+query I
+SELECT $$[" "]$$::VARCHAR[]; -- List with whitespace string
+----
+[ ]
+
+query I
+SELECT $$["\\"]$$::VARCHAR[]; -- List with only a backslash
+----
+[\]
+
+query I
+SELECT $$["\""]$$::VARCHAR[]; -- List with only a quote
+----
+["]
+
+query I
+SELECT $$[\,]$$::VARCHAR[]; -- List with only a comma
+----
+[,]

--- a/test/sql/cast/string_to_list_escapes.test
+++ b/test/sql/cast/string_to_list_escapes.test
@@ -7,19 +7,34 @@ SELECT $$[hello, world]$$::VARCHAR[];
 [hello, world]
 
 query I
-SELECT $$[hello\ world, world]$$::VARCHAR[];
+SELECT $$["hello\ world", world]$$::VARCHAR[];
 ----
 [hello world, world]
 
 query I
+SELECT $$[hello\ world, world]$$::VARCHAR[];
+----
+[hello\ world, world]
+
+query I
 SELECT $$[hello\,world, test]$$::VARCHAR[];
+----
+[hello\, world, test]
+
+query I
+SELECT $$["hello\,world", test]$$::VARCHAR[];
 ----
 [hello,world, test]
 
 query I
-SELECT $$[hello\,, test]$$::VARCHAR[];
+SELECT $$["hello\,", test]$$::VARCHAR[];
 ----
 [hello,, test]
+
+query I
+SELECT $$[hello\,, test]$$::VARCHAR[];
+----
+[hello\, , test]
 
 query I
 SELECT $$[hello\"quoted\"text, more]$$::VARCHAR[];
@@ -29,12 +44,27 @@ SELECT $$[hello\"quoted\"text, more]$$::VARCHAR[];
 query I
 SELECT $$[escaped\\backslash, test]$$::VARCHAR[];
 ----
+[escaped\\backslash, test]
+
+query I
+SELECT $$["escaped\\backslash", test]$$::VARCHAR[];
+----
 [escaped\backslash, test]
 
 query I
 SELECT $$[nested[brackets], test]$$::VARCHAR[];
 ----
 [nested[brackets], test]
+
+statement error
+SELECT $$[nested[bracket, test]$$::VARCHAR[];
+----
+can't be cast to the destination type VARCHAR[]
+
+query I
+SELECT $$[nested"["bracket, test]$$::VARCHAR[];
+----
+[nested[bracket, test]
 
 query I
 SELECT $$[quote\'in\'string, test]$$::VARCHAR[];
@@ -43,6 +73,11 @@ SELECT $$[quote\'in\'string, test]$$::VARCHAR[];
 
 query I
 SELECT $$[mix\ of\ special\,chars]$$::VARCHAR[];
+----
+[mix\ of\ special\, chars]
+
+query I
+SELECT $$["mix\ of\ special\,chars"]$$::VARCHAR[];
 ----
 [mix of special,chars]
 
@@ -193,6 +228,16 @@ SELECT $$["\""]$$::VARCHAR[]; -- List with only a quote
 ["]
 
 query I
-SELECT $$[\,]$$::VARCHAR[]; -- List with only a comma
+SELECT $$[\,]$$::VARCHAR[]; -- List with only a comma (not quoted)
+----
+[\, ]
+
+query I
+SELECT $$["\,"]$$::VARCHAR[]; -- List with only a comma
+----
+[,]
+
+query I
+SELECT $$[","]$$::VARCHAR[]; -- List with only a comma
 ----
 [,]

--- a/test/sql/cast/string_to_map_cast.test_slow
+++ b/test/sql/cast/string_to_map_cast.test_slow
@@ -76,12 +76,12 @@ SELECT CAST('{''hello''=2, ''world''=50, ''!''=12}' AS MAP(VARCHAR, INT));
 {hello=2, world=50, !=12}
 
 query I
-SELECT CAST('{''''hello''''=hello, ''''world''''=world, ''''!''''=!}' AS MAP(VARCHAR, VARCHAR));
+SELECT CAST($${\'hello\'=hello, \'world\'=world, \'!\'=!}$$ AS MAP(VARCHAR, VARCHAR));
 ----
 {'hello'=hello, 'world'=world, '!'=!}
 
 query I
-SELECT CAST('{[[''🦆, 🦆, 🦆'']]=100, [[duck, db, ''🦆'']]=101}' AS MAP(VARCHAR[][], INT));
+SELECT CAST($${[[\'🦆, 🦆, 🦆\']]=100, [[duck, db, \'🦆\']]=101}$$ AS MAP(VARCHAR[][], INT));
 ----
 {[['🦆, 🦆, 🦆']]=100, [[duck, db, '🦆']]=101}
 
@@ -114,8 +114,8 @@ SELECT CAST('{ [12,     13,14]=val, [       8, 9         ]      =val, [ 4    ]=v
 {[12, 13, 14]=val, [8, 9]=val, [4]=val}
 
 query I
-SELECT CAST('   { { a:[2,    3], b:  Duckster      }=         {50.0        =50}, {a    : [9,1,4], b:Duck          }
-                ={  1      =    0}  }' AS MAP(STRUCT(a INT[], b VARCHAR), MAP(INT, DOUBLE)));
+SELECT CAST($$   { { a:[2,    3], b:  Duckster      }=         {50.0        =50}, {a    : [9,1,4], b:Duck          }
+                ={  1      =    0}  }$$ AS MAP(STRUCT(a INT[], b VARCHAR), MAP(INT, DOUBLE)));
 ----
 {{'a': [2, 3], 'b': Duckster}={50=50.0}, {'a': [9, 1, 4], 'b': Duck}={1=0.0}}
 

--- a/test/sql/cast/string_to_map_escapes.test
+++ b/test/sql/cast/string_to_map_escapes.test
@@ -1,0 +1,141 @@
+# name: test/sql/cast/string_to_map_escapes.test
+# group: [cast]
+
+# Valid: key and value with escaped space
+query I
+SELECT $${key\ with\ space = value\ with\ space}$$::MAP(VARCHAR, VARCHAR);
+----
+{key with space=value with space}
+
+# Valid: key with escaped quote and value with escaped quote
+query I
+SELECT $${\"key\" = \"value\"}$$::MAP(VARCHAR, VARCHAR);
+----
+{"key"="value"}
+
+# Valid: key with escaped backslash, value with escaped backslash
+query I
+SELECT $${key\ with\ backslash = value\ with\ backslash}$$::MAP(VARCHAR, VARCHAR);
+----
+{key with backslash=value with backslash}
+
+# Valid: key with escaped comma, value with escaped comma
+query I
+SELECT $${key\ with\, comma = value\ with\, comma}$$::MAP(VARCHAR, VARCHAR);
+----
+{key with, comma=value with, comma}
+
+# Valid: key and value with escaped colon
+query I
+SELECT $${key\ with\ colon\: = value\ with\ colon\:}$$::MAP(VARCHAR, VARCHAR);
+----
+{key with colon:=value with colon:}
+
+## FIXME: not sure what to do here, maybe we shouldn't "respect scopes" if the child type is not nested
+## Valid: key and value with parentheses
+#query I
+#SELECT $${key\ (with\ parens) = value\ (with\ parens)}$$::MAP(VARCHAR, VARCHAR);
+#----
+#{key (with parens)=value (with parens)}
+
+# Valid: key contains unescaped space
+query I
+SELECT $${key with space = value with space}$$::MAP(VARCHAR, VARCHAR);
+----
+{key with space=value with space}
+
+# Invalid: key input contains quotes
+query I
+SELECT $${key"with"quote = value}$$::MAP(VARCHAR, VARCHAR);
+----
+{keywithquote=value}
+
+# Valid: value input contains quotes
+query I
+SELECT $${key = value"with"quote}$$::MAP(VARCHAR, VARCHAR);
+----
+{key=valuewithquote}
+
+# Valid: key contains unescaped comma
+query I
+SELECT $${key,with,comma = value}$$::MAP(VARCHAR, VARCHAR);
+----
+{key,with,comma=value}
+
+# Invalid: value contains unescaped comma
+statement error
+SELECT $${key = value,with,comma}$$::MAP(VARCHAR, VARCHAR);
+----
+can't be cast to the destination type MAP
+
+# Valid: key contains unescaped curly bracket
+query I
+SELECT $${key{with}bracket = value}$$::MAP(VARCHAR, VARCHAR);
+----
+{key{with}bracket=value}
+
+# Invalid: value contains unescaped curly bracket
+query I
+SELECT $${key = value{with}bracket}$$::MAP(VARCHAR, VARCHAR);
+----
+{key=value{with}bracket}
+
+# Valid: key contains useless backslashes
+query I
+SELECT $${key\with\backslash = value}$$::MAP(VARCHAR, VARCHAR);
+----
+{keywithbackslash=value}
+
+# Valid: value contains useless backslashes
+query I
+SELECT $${key = value\with\backslash}$$::MAP(VARCHAR, VARCHAR);
+----
+{key=valuewithbackslash}
+
+# Valid: key/value contains unescaped equal sign
+query II
+SELECT $${key=with=equals = value}$$::MAP(VARCHAR, VARCHAR) a, a['key'];
+----
+{key=with=equals = value}	with=equals = value
+
+# Valid: key/value contains unescaped equal sign
+query II
+SELECT $${key\=with=equals = value}$$::MAP(VARCHAR, VARCHAR) a, a['key=with'];
+----
+{key=with=equals = value}	equals = value
+
+# Valid: key/value contains unescaped equal sign
+query II
+SELECT $${key\=with\=equals = value}$$::MAP(VARCHAR, VARCHAR) a, a['key=with=equals'];
+----
+{key=with=equals=value}	value
+
+# Edge Case: Empty MAP with no keys/values
+query I
+SELECT $${}$$::MAP(VARCHAR, VARCHAR);
+----
+{}
+
+# Valid: MAP with empty key and value
+query I
+SELECT $${=}$$::MAP(VARCHAR, VARCHAR);
+----
+{=}
+
+# Edge Case: MAP with special characters only (escaped)
+query I
+SELECT $${\{escaped\brace\} = \}escaped\brace\\}$$::MAP(VARCHAR, VARCHAR);
+----
+{{escapedbrace}=}escapedbrace\}
+
+# Edge Case: MAP with only a key and no value
+query I
+SELECT $${key=}$$::MAP(VARCHAR, VARCHAR);
+----
+{key=}
+
+# Valid: MAP with an empty key
+query I
+SELECT $${=value}$$::MAP(VARCHAR, VARCHAR);
+----
+{=value}

--- a/test/sql/cast/string_to_map_escapes.test
+++ b/test/sql/cast/string_to_map_escapes.test
@@ -3,7 +3,7 @@
 
 # Valid: key and value with escaped space
 query I
-SELECT $${key\ with\ space = value\ with\ space}$$::MAP(VARCHAR, VARCHAR);
+SELECT $${"key\ with\ space" = "value\ with\ space"}$$::MAP(VARCHAR, VARCHAR);
 ----
 {key with space=value with space}
 
@@ -15,19 +15,19 @@ SELECT $${\"key\" = \"value\"}$$::MAP(VARCHAR, VARCHAR);
 
 # Valid: key with escaped backslash, value with escaped backslash
 query I
-SELECT $${key\ with\ backslash = value\ with\ backslash}$$::MAP(VARCHAR, VARCHAR);
+SELECT $${"key\ with\ backslash" = "value\ with\ backslash"}$$::MAP(VARCHAR, VARCHAR);
 ----
 {key with backslash=value with backslash}
 
 # Valid: key with escaped comma, value with escaped comma
 query I
-SELECT $${key\ with\, comma = value\ with\, comma}$$::MAP(VARCHAR, VARCHAR);
+SELECT $${"key\ with\, comma" = "value\ with\, comma"}$$::MAP(VARCHAR, VARCHAR);
 ----
 {key with, comma=value with, comma}
 
 # Valid: key and value with escaped colon
 query I
-SELECT $${key\ with\ colon\: = value\ with\ colon\:}$$::MAP(VARCHAR, VARCHAR);
+SELECT $${"key\ with\ colon\:" = "value\ with\ colon\:"}$$::MAP(VARCHAR, VARCHAR);
 ----
 {key with colon:=value with colon:}
 
@@ -82,13 +82,13 @@ SELECT $${key = value{with}bracket}$$::MAP(VARCHAR, VARCHAR);
 
 # Valid: key contains useless backslashes
 query I
-SELECT $${key\with\backslash = value}$$::MAP(VARCHAR, VARCHAR);
+SELECT $${"key\with\backslash" = value}$$::MAP(VARCHAR, VARCHAR);
 ----
 {keywithbackslash=value}
 
 # Valid: value contains useless backslashes
 query I
-SELECT $${key = value\with\backslash}$$::MAP(VARCHAR, VARCHAR);
+SELECT $${key = "value\with\backslash"}$$::MAP(VARCHAR, VARCHAR);
 ----
 {key=valuewithbackslash}
 
@@ -100,13 +100,13 @@ SELECT $${key=with=equals = value}$$::MAP(VARCHAR, VARCHAR) a, a['key'];
 
 # Valid: key/value contains unescaped equal sign
 query II
-SELECT $${key\=with=equals = value}$$::MAP(VARCHAR, VARCHAR) a, a['key=with'];
+SELECT $${"key\=with" = equals = value}$$::MAP(VARCHAR, VARCHAR) a, a['key=with'];
 ----
 {key=with=equals = value}	equals = value
 
 # Valid: key/value contains unescaped equal sign
 query II
-SELECT $${key\=with\=equals = value}$$::MAP(VARCHAR, VARCHAR) a, a['key=with=equals'];
+SELECT $${"key\=with\=equals" = value}$$::MAP(VARCHAR, VARCHAR) a, a['key=with=equals'];
 ----
 {key=with=equals=value}	value
 
@@ -123,8 +123,14 @@ SELECT $${=}$$::MAP(VARCHAR, VARCHAR);
 {=}
 
 # Edge Case: MAP with special characters only (escaped)
-query I
+statement error
 SELECT $${\{escaped\brace\} = \}escaped\brace\\}$$::MAP(VARCHAR, VARCHAR);
+----
+can't be cast to the destination type MAP(VARCHAR, VARCHAR)
+
+# Edge Case: MAP with special characters only (escaped)
+query I
+SELECT $${"\{escaped\brace\}" = "\}escaped\brace\\"}$$::MAP(VARCHAR, VARCHAR);
 ----
 {{escapedbrace}=}escapedbrace\}
 

--- a/test/sql/cast/string_to_nested_types_cast.test_slow
+++ b/test/sql/cast/string_to_nested_types_cast.test_slow
@@ -78,7 +78,7 @@ SELECT CAST(LIST(timestamp_ns)::VARCHAR AS TIME[]) FROM test_all_types();
 query I
 SELECT CAST(LIST(blob)::VARCHAR AS BLOB[]) FROM test_all_types();
 ----
-[thisisalongblobx00withnullbytes, x00x00x00a, NULL]
+[thisisalongblob\x00withnullbytes, \x00\x00\x00a, NULL]
 
 query I
 SELECT CAST(LIST(interval)::VARCHAR AS INTERVAL[]) FROM test_all_types();
@@ -191,8 +191,8 @@ SELECT CAST(struct_pack(A=>timestamp_ns)::VARCHAR AS STRUCT(A TIME)) FROM test_a
 query I
 SELECT CAST(struct_pack(A=>blob)::VARCHAR AS STRUCT(A BLOB)) FROM test_all_types();
 ----
-{'A': thisisalongblobx00withnullbytes}
-{'A': x00x00x00a}
+{'A': thisisalongblob\x00withnullbytes}
+{'A': \x00\x00\x00a}
 {'A': NULL}
 
 query I

--- a/test/sql/cast/string_to_nested_types_cast.test_slow
+++ b/test/sql/cast/string_to_nested_types_cast.test_slow
@@ -78,7 +78,7 @@ SELECT CAST(LIST(timestamp_ns)::VARCHAR AS TIME[]) FROM test_all_types();
 query I
 SELECT CAST(LIST(blob)::VARCHAR AS BLOB[]) FROM test_all_types();
 ----
-[thisisalongblob\x00withnullbytes, \x00\x00\x00a, NULL]
+[thisisalongblobx00withnullbytes, x00x00x00a, NULL]
 
 query I
 SELECT CAST(LIST(interval)::VARCHAR AS INTERVAL[]) FROM test_all_types();
@@ -191,8 +191,8 @@ SELECT CAST(struct_pack(A=>timestamp_ns)::VARCHAR AS STRUCT(A TIME)) FROM test_a
 query I
 SELECT CAST(struct_pack(A=>blob)::VARCHAR AS STRUCT(A BLOB)) FROM test_all_types();
 ----
-{'A': thisisalongblob\x00withnullbytes}
-{'A': \x00\x00\x00a}
+{'A': thisisalongblobx00withnullbytes}
+{'A': x00x00x00a}
 {'A': NULL}
 
 query I

--- a/test/sql/cast/string_to_struct_cast.test
+++ b/test/sql/cast/string_to_struct_cast.test
@@ -205,7 +205,7 @@ SELECT ' {      }   '::STRUCT(a INT, b DATE);
 statement error
 SELECT '{  key_A:     2, key_B: {key_C: hello world    }     X   }'::STRUCT(key_A INT, key_B STRUCT(key_C VARCHAR));
 ----
-
+can't be cast to the destination type STRUCT(key_C VARCHAR)
 
 
 #               NULL values
@@ -319,50 +319,62 @@ NULL
 statement error
 SELECT CAST('[{a:3}]' AS STRUCT(a INT));
 ----
+can't be cast to the destination type STRUCT(a INTEGER)
 
 statement error
 SELECT CAST('Hello World' AS STRUCT(a VARCHAR));
 ----
+can't be cast to the destination type STRUCT(a VARCHAR)
 
 statement error
 SELECT CAST('{a: 3}}' AS STRUCT(a INT));
 ----
+can't be cast to the destination type STRUCT(a INTEGER)
 
 statement error
 SELECT CAST('{a: 3, b:{c: 8}}}' AS STRUCT(a INT, b STRUCT(c INT)));
 ----
+can't be cast to the destination type STRUCT(a INTEGER, b STRUCT(c INTEGER))
 
 statement error
 SELECT CAST('{{a: 3}' AS STRUCT(a INT));
 ----
+can't be cast to the destination type STRUCT(a INTEGER)
 
 statement error
 SELECT CAST('{a:3}, {b:1}' AS STRUCT(a INT, b INT));
 ----
+can't be cast to the destination type STRUCT(a INTEGER, b INTEGER)
 
 statement error
 SELECT CAST('{a:{a:3}, b:{{b:1}}}' AS STRUCT(a STRUCT(a INT), b STRUCT(b INT)));
 ----
+can't be cast to the destination type STRUCT(b INTEGER)
 
 statement error
 SELECT CAST('{a: 3 1}' AS STRUCT(a INT));
 ----
+Could not convert string '3 1' to INT32
 
 statement error
 SELECT CAST('{a:3,, b:1}' AS STRUCT(a INT, b INT));
 ----
+can't be cast to the destination type STRUCT(a INTEGER, b INTEGER)
 
 statement error
 SELECT CAST('}{a:5}' AS STRUCT(a INT));
 ----
+can't be cast to the destination type STRUCT(a INTEGER)
 
 statement error
 SELECT CAST('{a:{b:{d: 800}, {c: "Duck"}}}' AS STRUCT(a STRUCT(b STRUCT(d INT), c STRUCT(c VARCHAR))));
 ----
+can't be cast to the destination type STRUCT(b STRUCT(d INTEGER), c STRUCT(c VARCHAR))
 
 statement error
 SELECT CAST('{[{]}}' AS STRUCT(a VARCHAR[]));
 ----
+can't be cast to the destination type STRUCT(a VARCHAR[])
 
 
 

--- a/test/sql/cast/string_to_struct_escapes.test
+++ b/test/sql/cast/string_to_struct_escapes.test
@@ -47,7 +47,7 @@ SELECT $${name: "John "Doe"}$$::STRUCT(name VARCHAR);
 ----
 can't be cast to the destination type
 
-# Invalid: Value contains a comma that isn't escaped
+# second key has no ending character (:)
 statement error
 SELECT $${name: John, age, 30}$$::STRUCT(name VARCHAR, age INT);
 ----
@@ -101,3 +101,104 @@ statement error
 SELECT $${name: "John, age: 30}$$::STRUCT(name VARCHAR, age INT);
 ----
 can't be cast to the destination type
+
+query I
+SELECT $${}$$::STRUCT(name VARCHAR, age INT);
+----
+{'name': NULL, 'age': NULL}
+
+# STRUCT with whitespace around colon (escaped)
+query I
+SELECT $${name : John, age : 30}$$::STRUCT(name VARCHAR, age INT);
+----
+{'name': John, 'age': 30}
+
+# STRUCT with escaped backslash in value
+query I
+SELECT $${path: "C:\\Users\\John"}$$::STRUCT(path VARCHAR);
+----
+{'path': C:\Users\John}
+
+# STRUCT with special characters in value, properly escaped
+query I
+SELECT $${description: "Special characters: \\, \", ;, (, )"}$$::STRUCT(description VARCHAR);
+----
+{'description': Special characters: \, ", ;, (, )}
+
+# Valid: Name with escaped space
+query I
+SELECT $${first\ name: "John", age: 30}$$::STRUCT("first name" VARCHAR, age INT);
+----
+{'first name': John, 'age': 30}
+
+# Valid: Name with escaped quote
+query I
+SELECT $${\"quote at start\": "value", age: 30}$$::STRUCT("""quote at start""" VARCHAR, age INT);
+----
+{'"quote at start"': value, 'age': 30}
+
+# Valid: Name with escaped backslash
+query I
+SELECT $${backslash\\name: "John Doe", age: 30}$$::STRUCT("backslash\name" VARCHAR, age INT);
+----
+{'backslash\name': John Doe, 'age': 30}
+
+# Valid: Name with escaped comma
+query I
+SELECT $${user\,name: "Alice", age: 25}$$::STRUCT("user,name" VARCHAR, age INT);
+----
+{'user,name': Alice, 'age': 25}
+
+# Valid: Name with escaped parenthesis
+query I
+SELECT $${user\(name\): "Alice", status: "active"}$$::STRUCT("user(name)" VARCHAR, status VARCHAR);
+----
+{'user(name)': Alice, 'status': active}
+
+# Valid: Name with unescaped parenthesis
+query I
+SELECT $${user(name): "Alice", status: "active"}$$::STRUCT("user(name)" VARCHAR, status VARCHAR);
+----
+{'user(name)': Alice, 'status': active}
+
+# Valid: Name with escaped space at end
+query I
+SELECT $${user\ name\ : "Alice", age\ : 25}$$::STRUCT("user name " VARCHAR, "age " INT);
+----
+{'user name ': Alice, 'age ': 25}
+
+# Invalid: Name contains unescaped quote
+statement error
+SELECT $${"quote"start": "value", age: 30}$$::STRUCT("quote""start" VARCHAR, age INT);
+----
+can't be cast to the destination type
+
+# Invalid: Name contains unescaped backslash
+statement error
+SELECT $${backslash\name: "John", age: 30}$$::STRUCT("backslash\name" VARCHAR, age INT);
+----
+can't be cast to the destination type
+
+# Valid: Name contains (unescaped) opening parenthesis
+query I
+SELECT $${user(name: "Alice", age: 25}$$::STRUCT("user(name" VARCHAR, age INT);
+----
+{'user(name': Alice, 'age': 25}
+
+# Name is single double quote
+query I
+SELECT $${\": "value", age: 30}$$::STRUCT("""" VARCHAR, age INTEGER)
+----
+{'"': value, 'age': 30}
+
+# Name with only a special character (escaped)
+query I
+SELECT $${\\: "escaped", age: 30}$$::STRUCT("\" VARCHAR, age INT);
+----
+{'\': escaped, 'age': 30}
+
+# Name with only a special character (not escaped)
+query I
+SELECT $${@: "value", age: 30}$$::STRUCT("@" VARCHAR, age INT);
+----
+{'@': value, 'age': 30}

--- a/test/sql/cast/string_to_struct_escapes.test
+++ b/test/sql/cast/string_to_struct_escapes.test
@@ -67,9 +67,15 @@ can't be cast to the destination type
 
 # Invalid: Name contains a backslash
 statement error
-SELECT $${backslash\name: value}$$::STRUCT("backslash\name" VARCHAR);
+SELECT $${"backslash\name": value}$$::STRUCT("backslash\name" VARCHAR);
 ----
 can't be cast to the destination type
+
+# Valid: Name contains a backslash outside of quotes, interpreted as literal
+query I
+SELECT $${backslash\name: value}$$::STRUCT("backslash\name" VARCHAR);
+----
+{'backslash\name': value}
 
 # first `:` is not escaped, won't match the "name:" struct key
 statement error
@@ -77,9 +83,15 @@ SELECT $${name: test, value: 30}$$::STRUCT("name:" VARCHAR, value INT);
 ----
 can't be cast to the destination type
 
-# Name can contain escaped `:`
-query I
+# Invalid: Name can contain escaped `:`, but only in quotes
+statement error
 SELECT $${name\:: test, value: 30}$$::STRUCT("name:" VARCHAR, value INT);
+----
+can't be cast to the destination type STRUCT("name:" VARCHAR, "value" INTEGER)
+
+# Valid: Name can contain escaped `:` in quotes
+query I
+SELECT $${"name\:": test, value: 30}$$::STRUCT("name:" VARCHAR, value INT);
 ----
 {'name:': test, 'value': 30}
 
@@ -125,9 +137,14 @@ SELECT $${description: "Special characters: \\, \", ;, (, )"}$$::STRUCT(descript
 ----
 {'description': Special characters: \, ", ;, (, )}
 
+statement error
+SELECT $${first\ name: "John", age: 30}$$::STRUCT("first name" VARCHAR, age INT);
+----
+can't be cast to the destination type STRUCT("first name" VARCHAR, age INTEGER)
+
 # Valid: Name with escaped space
 query I
-SELECT $${first\ name: "John", age: 30}$$::STRUCT("first name" VARCHAR, age INT);
+SELECT $${"first\ name": "John", age: 30}$$::STRUCT("first name" VARCHAR, age INT);
 ----
 {'first name': John, 'age': 30}
 
@@ -137,21 +154,42 @@ SELECT $${\"quote at start\": "value", age: 30}$$::STRUCT("""quote at start""" V
 ----
 {'"quote at start"': value, 'age': 30}
 
+statement error
+SELECT $${backslash\\name: "John Doe", age: 30}$$::STRUCT("backslash\name" VARCHAR, age INT);
+----
+can't be cast to the destination type STRUCT("backslash\name" VARCHAR, age INTEGER)
+
 # Valid: Name with escaped backslash
 query I
-SELECT $${backslash\\name: "John Doe", age: 30}$$::STRUCT("backslash\name" VARCHAR, age INT);
+SELECT $${"backslash\\name": "John Doe", age: 30}$$::STRUCT("backslash\name" VARCHAR, age INT);
 ----
 {'backslash\name': John Doe, 'age': 30}
 
+statement error
+SELECT $${user\,name: "Alice", age: 25}$$::STRUCT("user,name" VARCHAR, age INT);
+----
+can't be cast to the destination type STRUCT("user,name" VARCHAR, age INTEGER)
+
 # Valid: Name with escaped comma
 query I
-SELECT $${user\,name: "Alice", age: 25}$$::STRUCT("user,name" VARCHAR, age INT);
+SELECT $${"user\,name": "Alice", age: 25}$$::STRUCT("user,name" VARCHAR, age INT);
 ----
 {'user,name': Alice, 'age': 25}
 
+# Valid: Name with comma
+query I
+SELECT $${"user,name": "Alice", age: 25}$$::STRUCT("user,name" VARCHAR, age INT);
+----
+{'user,name': Alice, 'age': 25}
+
+statement error
+SELECT $${user\(name\): "Alice", status: "active"}$$::STRUCT("user(name)" VARCHAR, status VARCHAR);
+----
+can't be cast to the destination type STRUCT("user(name)" VARCHAR, status VARCHAR)
+
 # Valid: Name with escaped parenthesis
 query I
-SELECT $${user\(name\): "Alice", status: "active"}$$::STRUCT("user(name)" VARCHAR, status VARCHAR);
+SELECT $${"user\(name\)": "Alice", status: "active"}$$::STRUCT("user(name)" VARCHAR, status VARCHAR);
 ----
 {'user(name)': Alice, 'status': active}
 
@@ -163,9 +201,14 @@ SELECT $${user(name): "Alice", status: "active"}$$::STRUCT("user(name)" VARCHAR,
 
 # Valid: Name with escaped space at end
 query I
-SELECT $${user\ name\ : "Alice", age\ : 25}$$::STRUCT("user name " VARCHAR, "age " INT);
+SELECT $${"user\ name\ ": "Alice", "age ": 25}$$::STRUCT("user name " VARCHAR, "age " INT);
 ----
 {'user name ': Alice, 'age ': 25}
+
+statement error
+SELECT $${user\ name\ : "Alice", age\ : 25}$$::STRUCT("user name " VARCHAR, "age " INT);
+----
+can't be cast to the destination type STRUCT("user name " VARCHAR, "age " INTEGER)
 
 # Invalid: Name contains unescaped quote
 statement error
@@ -173,11 +216,11 @@ SELECT $${"quote"start": "value", age: 30}$$::STRUCT("quote""start" VARCHAR, age
 ----
 can't be cast to the destination type
 
-# Invalid: Name contains unescaped backslash
-statement error
+# Valid: Name contains unescaped backslash outside of quotes
+query I
 SELECT $${backslash\name: "John", age: 30}$$::STRUCT("backslash\name" VARCHAR, age INT);
 ----
-can't be cast to the destination type
+{'backslash\name': John, 'age': 30}
 
 # Valid: Name contains (unescaped) opening parenthesis
 query I
@@ -191,9 +234,14 @@ SELECT $${\": "value", age: 30}$$::STRUCT("""" VARCHAR, age INTEGER)
 ----
 {'"': value, 'age': 30}
 
+statement error
+SELECT $${\\: "escaped", age: 30}$$::STRUCT("\" VARCHAR, age INT);
+----
+can't be cast to the destination type STRUCT("\" VARCHAR, age INTEGER)
+
 # Name with only a special character (escaped)
 query I
-SELECT $${\\: "escaped", age: 30}$$::STRUCT("\" VARCHAR, age INT);
+SELECT $${"\\": "escaped", age: 30}$$::STRUCT("\" VARCHAR, age INT);
 ----
 {'\': escaped, 'age': 30}
 

--- a/test/sql/cast/string_to_struct_escapes.test
+++ b/test/sql/cast/string_to_struct_escapes.test
@@ -1,0 +1,103 @@
+# name: test/sql/cast/string_to_struct_escapes.test
+# group: [cast]
+
+query I
+SELECT $${name: value, age: 30}$$::STRUCT(name VARCHAR, age INT);
+----
+{'name': value, 'age': 30}
+
+query I
+SELECT $${name: John, city: "New York"}$$::STRUCT(name VARCHAR, city VARCHAR);
+----
+{'name': John, 'city': New York}
+
+query I
+SELECT $${quote_at_start: "\"test\"", age: 30}$$::STRUCT(quote_at_start VARCHAR, age INT);
+----
+{'quote_at_start': "test", 'age': 30}
+
+query I
+SELECT $${user_name: Alice, status: active}$$::STRUCT(user_name VARCHAR, status VARCHAR);
+----
+{'user_name': Alice, 'status': active}
+
+query I
+SELECT $${special_characters: "comma, semicolon; and backslash\\", age: 30}$$::STRUCT(special_characters VARCHAR, age INT);
+----
+{'special_characters': comma, semicolon; and backslash\, 'age': 30}
+
+query I
+SELECT $${a: 10, b: "hello world"}$$::STRUCT(a INT, b VARCHAR);
+----
+{'a': 10, 'b': hello world}
+
+query I
+SELECT $${first_name: "John", last_name: "Doe", age: 28}$$::STRUCT(first_name VARCHAR, last_name VARCHAR, age INT);
+----
+{'first_name': John, 'last_name': Doe, 'age': 28}
+
+query I
+SELECT $${first name: John, age: 30}$$::STRUCT("first name" VARCHAR, age INT);
+----
+{'first name': John, 'age': 30}
+
+# Invalid: Value contains a quote that isn't escaped
+statement error
+SELECT $${name: "John "Doe"}$$::STRUCT(name VARCHAR);
+----
+can't be cast to the destination type
+
+# Invalid: Value contains a comma that isn't escaped
+statement error
+SELECT $${name: John, age, 30}$$::STRUCT(name VARCHAR, age INT);
+----
+can't be cast to the destination type
+
+# Name is free to contain `,`, only `:` is problematic
+query I
+SELECT $${user,name: Alice, age: 30}$$::STRUCT("user,name" VARCHAR, age INT);
+----
+{'user,name': Alice, 'age': 30}
+
+# Invalid: Contains an unescaped closing bracket
+statement error
+SELECT $${name: Alice, age: 30})$$::STRUCT(name VARCHAR, age INT);
+----
+can't be cast to the destination type
+
+# Invalid: Name contains a backslash
+statement error
+SELECT $${backslash\name: value}$$::STRUCT("backslash\name" VARCHAR);
+----
+can't be cast to the destination type
+
+# first `:` is not escaped, won't match the "name:" struct key
+statement error
+SELECT $${name: test, value: 30}$$::STRUCT("name:" VARCHAR, value INT);
+----
+can't be cast to the destination type
+
+# Name can contain escaped `:`
+query I
+SELECT $${name\:: test, value: 30}$$::STRUCT("name:" VARCHAR, value INT);
+----
+{'name:': test, 'value': 30}
+
+# Name consists of `{}`, not a problem, with this syntax we expect a name, which is a plain string
+# Only reserved character there is `:` (and quotes, and backslash of course)
+query I
+SELECT $${{name}: John, age: 3}$$::STRUCT("{name}" VARCHAR, age INT);
+----
+{'{name}': John, 'age': 3}
+
+# Name has `{` which normally starts a bracket that disables interpreting escape characters
+query I
+SELECT $${{\"name\"}: John, age: 3}$$::STRUCT("{""name""}" VARCHAR, age INT);
+----
+{'{"name"}': John, 'age': 3}
+
+# Invalid: Unterminated string value
+statement error
+SELECT $${name: "John, age: 30}$$::STRUCT(name VARCHAR, age INT);
+----
+can't be cast to the destination type

--- a/test/sql/cast/string_to_unnamed_struct.test
+++ b/test/sql/cast/string_to_unnamed_struct.test
@@ -52,7 +52,7 @@ select [row([7,8,9], [10,11,12]), $$([1,2,3], [4,5,6])$$]
 statement error
 select [row([4,5,6]), $$([1,2,3],)$$]
 ----
-can't be cast to the destination type STRUCT
+can't be cast to the destination type STRUCT(INTEGER[])
 
 # Empty string in the second child of the unnamed struct
 query I

--- a/test/sql/cast/string_to_unnamed_struct.test
+++ b/test/sql/cast/string_to_unnamed_struct.test
@@ -1,0 +1,61 @@
+# name: test/sql/cast/string_to_unnamed_struct.test
+# group: [cast]
+
+# Basic single value struct
+query I
+select $$(abc)$$::STRUCT(a VARCHAR)
+----
+{'a': abc}
+
+# Multiple values
+query I
+select $$(abc, def, ghi)$$::STRUCT(a VARCHAR, b VARCHAR, c VARCHAR)
+----
+{'a': abc, 'b': def, 'c': ghi}
+
+# Empty unnamed struct
+query I
+select $$()$$::STRUCT(a VARCHAR)
+----
+{'a': NULL}
+
+# Nested regular struct inside unnamed struct
+query I
+select $$({'amount': 42})$$::STRUCT(a STRUCT(amount INT))
+----
+{'a': {'amount': 42}}
+
+# Nested unnamed struct inside unnamed struct
+query I
+select $$((42))$$::STRUCT(a STRUCT(amount INT))
+----
+{'a': {'amount': 42}}
+
+# Nested unnamed struct AND regular struct inside unnamed struct
+query I
+select $$((42), {amount: 21})$$::STRUCT(a STRUCT(amount INT), b STRUCT(amount INT))
+----
+{'a': {'amount': 42}, 'b': {'amount': 21}}
+
+# List inside unnamed struct
+query I
+select $$([1,2,3], [4,5,6])$$::STRUCT(a INTEGER[], b INTEGER[])
+----
+{'a': [1, 2, 3], 'b': [4, 5, 6]}
+
+statement error
+select $$([1,2,3],)$$::STRUCT(a INTEGER[])
+----
+can't be cast to the destination type STRUCT
+
+# Empty string in the second child of the unnamed struct
+query I
+select $$([1,2,3],)$$::STRUCT(a INTEGER[], b VARCHAR)
+----
+{'a': [1, 2, 3], 'b': }
+
+# Empty string in the second child of a named struct
+query I
+select $${'a': [1,2,3],'b':}$$::STRUCT(a INTEGER[], b VARCHAR)
+----
+{'a': [1, 2, 3], 'b': }

--- a/test/sql/cast/string_to_unnamed_struct.test
+++ b/test/sql/cast/string_to_unnamed_struct.test
@@ -61,6 +61,6 @@ select $${'a': [1,2,3],'b':}$$::STRUCT(a INTEGER[], b VARCHAR)
 {'a': [1, 2, 3], 'b': }
 
 query I
-select $$[("  test  "), {'a': (\\  test  \\)}]$$::STRUCT(a VARCHAR)[]
+select $$[(("  test  ")), {'a': (\\  test  \\)}]$$::STRUCT(a STRUCT("inner" VARCHAR))[]
 ----
-[{'a':   test  }, {'a': (\\  test  \\)}]
+[{'a': {'inner':   test  }}, {'a': {'inner': \  test  \}}]

--- a/test/sql/cast/string_to_unnamed_struct.test
+++ b/test/sql/cast/string_to_unnamed_struct.test
@@ -75,4 +75,4 @@ select [
 	$$[(("  test  ")), {'a': (\\  test  \\)}]$$
 ]
 ----
-[[{'a': {'inner':   test  }}, {'a': {'inner': \  test  \}}], [{'a': {'inner':   test  }}, {'a': {'inner': \  test  \}}]]
+[[{'a': {'inner':   test  }}, {'a': {'inner': \  test  \}}], [{'a': {'inner':   test  }}, {'a': {'inner': \\  test  \\}}]]

--- a/test/sql/cast/string_to_unnamed_struct.test
+++ b/test/sql/cast/string_to_unnamed_struct.test
@@ -59,3 +59,8 @@ query I
 select $${'a': [1,2,3],'b':}$$::STRUCT(a INTEGER[], b VARCHAR)
 ----
 {'a': [1, 2, 3], 'b': }
+
+query I
+select $$[("  test  "), {'a': (\\  test  \\)}]$$::STRUCT(a VARCHAR)[]
+----
+[{'a':   test  }, {'a': (\\  test  \\)}]

--- a/test/sql/cast/string_to_unnamed_struct.test
+++ b/test/sql/cast/string_to_unnamed_struct.test
@@ -3,64 +3,76 @@
 
 # Basic single value struct
 query I
-select $$(abc)$$::STRUCT(a VARCHAR)
+select [row('a'), $$(abc)$$]
 ----
-{'a': abc}
+[(a), (abc)]
 
 # Multiple values
 query I
-select $$(abc, def, ghi)$$::STRUCT(a VARCHAR, b VARCHAR, c VARCHAR)
+select [row('a', 'b', 'c'), $$(abc, def, ghi)$$]
 ----
-{'a': abc, 'b': def, 'c': ghi}
+[(a, b, c), (abc, def, ghi)]
 
 # Empty unnamed struct
 query I
-select $$()$$::STRUCT(a VARCHAR)
+select [row('a'),$$()$$]
 ----
-{'a': NULL}
+[(a), (NULL)]
+
+# Empty string in unnamed struct
+query I
+select [row('a'),$$('')$$]
+----
+[(a), ()]
 
 # Nested regular struct inside unnamed struct
 query I
-select $$({'amount': 42})$$::STRUCT(a STRUCT(amount INT))
+select [row({'amount': 21}), $$({'amount': 42})$$]
 ----
-{'a': {'amount': 42}}
+[({'amount': 21}), ({'amount': 42})]
 
 # Nested unnamed struct inside unnamed struct
 query I
-select $$((42))$$::STRUCT(a STRUCT(amount INT))
+select [row(row(21)), $$((42))$$]
 ----
-{'a': {'amount': 42}}
+[((21)), ((42))]
 
 # Nested unnamed struct AND regular struct inside unnamed struct
 query I
-select $$((42), {amount: 21})$$::STRUCT(a STRUCT(amount INT), b STRUCT(amount INT))
+select [row(row(21), {'amount': 42}), $$((42), {amount: 21})$$]
 ----
-{'a': {'amount': 42}, 'b': {'amount': 21}}
+[((21), {'amount': 42}), ((42), {'amount': 21})]
 
 # List inside unnamed struct
 query I
-select $$([1,2,3], [4,5,6])$$::STRUCT(a INTEGER[], b INTEGER[])
+select [row([7,8,9], [10,11,12]), $$([1,2,3], [4,5,6])$$]
 ----
-{'a': [1, 2, 3], 'b': [4, 5, 6]}
+[([7, 8, 9], [10, 11, 12]), ([1, 2, 3], [4, 5, 6])]
 
 statement error
-select $$([1,2,3],)$$::STRUCT(a INTEGER[])
+select [row([4,5,6]), $$([1,2,3],)$$]
 ----
 can't be cast to the destination type STRUCT
 
 # Empty string in the second child of the unnamed struct
 query I
-select $$([1,2,3],)$$::STRUCT(a INTEGER[], b VARCHAR)
+select [row([4,5,6], 'abc'), $$([1,2,3],)$$]
 ----
-{'a': [1, 2, 3], 'b': }
+[([4, 5, 6], abc), ([1, 2, 3], )]
 
 # Empty string in the second child of a named struct
 query I
-select $${'a': [1,2,3],'b':}$$::STRUCT(a INTEGER[], b VARCHAR)
+select [{'a': [4,5,6], 'b': 'abc'}, $${'a': [1,2,3],'b':}$$]
 ----
-{'a': [1, 2, 3], 'b': }
+[{'a': [4, 5, 6], 'b': abc}, {'a': [1, 2, 3], 'b': }]
 
 query I
-select $$[(("  test  ")), {'a': (\\  test  \\)}]$$::STRUCT(a STRUCT("inner" VARCHAR))[]
+select [
+	[
+		row(row('  test  ')),
+		{'a': {'inner': '\  test  \'}}
+	],
+	$$[(("  test  ")), {'a': (\\  test  \\)}]$$
+]
 ----
-[{'a': {'inner':   test  }}, {'a': {'inner': \  test  \}}]
+[[{'a': {'inner':   test  }}, {'a': {'inner': \  test  \}}], [{'a': {'inner':   test  }}, {'a': {'inner': \  test  \}}]]

--- a/test/sql/types/nested/array/array_cast.test
+++ b/test/sql/types/nested/array/array_cast.test
@@ -29,6 +29,7 @@ SELECT list_extract(array_value(1, 2, 3), 2)
 statement error
 SELECT * FROM UNNEST(array_value(1, 2, 3))
 ----
+UNNEST requires a single list as input
 
 # Should be able to cast to list with unnest
 query I
@@ -72,6 +73,7 @@ SELECT ['1.0', '2.0', '3.0']::DOUBLE[3]
 statement error
 SELECT [1, 2, 3]::BLOB[3]
 ----
+Unimplemented type for cast (INTEGER -> BLOB)
 
 # Should be able to cast from NULL
 query I
@@ -138,11 +140,13 @@ NULL
 statement error
 SELECT (['2', 'abc', '3']::VARCHAR[3])::INT[]
 ----
+Could not convert string 'abc' to INT32
 
 # Should not be able to cast to unrelated type
 statement error
 SELECT ([1,2,3]::INT[3])::INT;
 ----
+Unimplemented type for cast (INTEGER[3] -> INTEGER)
 
 # Should not be able to cast to list if child types fail
 query I

--- a/test/sql/types/nested/array/array_try_cast.test
+++ b/test/sql/types/nested/array/array_try_cast.test
@@ -53,7 +53,7 @@ NULL
 statement error
 SELECT CAST('[1,2]' as INTEGER[3]);
 ----
-Conversion Error: Type VARCHAR with value '[1,2]' can't be cast to the destination type ARRAY[3], the size of the array must match the destination type
+Conversion Error: Type VARCHAR with value '[1,2]' can't be cast to the destination type INTEGER[3], the size of the array must match the destination type
 
 query I
 SELECT CAST('[NULL, [1], [NULL]]' as INTEGER[1][3]);
@@ -78,7 +78,7 @@ SELECT CAST('[NULL, [1,NULL,3], [1,2,3]]' as INTEGER[3][3]);
 statement error
 SELECT CAST('[NULL, [1,NULL,3], [1,2]]' as INTEGER[3][3]);
 ----
-Conversion Error: Type VARCHAR with value '[1,2]' can't be cast to the destination type ARRAY[3], the size of the array must match the destination type
+Conversion Error: Type VARCHAR with value '[1,2]' can't be cast to the destination type INTEGER[3], the size of the array must match the destination type
 
 query I
 SELECT TRY_CAST('[NULL, [1,NULL,3], [1,2]]' as INTEGER[3][3]);

--- a/test/sql/types/struct/unnamed_struct_casts.test
+++ b/test/sql/types/struct/unnamed_struct_casts.test
@@ -10,7 +10,8 @@ select row(42, 'hello') union all select '{'': 42,'': hello}';
 ----
 Conversion Error
 
-statement error
+query I
 select row(42, 'hello') union all select '(84, world)';
 ----
-unsupported
+(42, hello)
+(84, world)


### PR DESCRIPTION
This PR fixes <https://github.com/duckdblabs/duckdb-internal/issues/3945>

The following behavior applies to casting from `VARCHAR` -> `LIST`|`STRUCT`|`MAP`

- Backslashes outside of quotes are treated as literals, unless they are followed by a single/double quote, in which case they act as an escape character and are removed from the result.
- Backslashes inside of quotes are always treated as escape characters, to use a literal backslash inside quotes, the backslash has to be escaped (`\\`), unescaped backslashes are removed from the result.

Quotes that are used to start and end a quoted value are removed from the result.
`[""""]` -> `[]`
`['''']` -> `[]`
`['"']` -> `["]`
`["'"]` -> `[']`

Whenever your string contains a character that is considered special by the casting logic, it should be wrapped in quotes.
To preserve leading or trailing spaces, the value should also be wrapped in quotes.
The list of characters that are *always*[1] special: `(whitespace)`, `{`, `}`, `(`, `)`, `[`, `]`, `"`, `'`, `\`
Other characters that are special in certain contexts:
- STRUCT key: `:`
- MAP key: `=`
- LIST, MAP, STRUCT value: `,`

[1] STRUCT key permits the use of `{`, `}`, `(`, `)`, `[`, `]`

------------------------------------------------------------

This PR also adds support for casting from `VARCHAR` -> unnamed `STRUCT`
In the form of `( <value>, <value2>, ..., <value n> )`