### PR TITLE
Remove extension definitions to prevent re-compilation of the entire system on commit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1328,6 +1328,10 @@ foreach(EXT_NAME IN LISTS DUCKDB_EXTENSION_NAMES)
   else()
     message(FATAL_ERROR "No path found for registered extension '${EXT_NAME}'")
   endif()
+
+  if (NOT "${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_EXT_VERSION}" STREQUAL "")
+    remove_definitions(-DEXT_VERSION_${EXT_NAME_UPPERCASE}="${DUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_EXT_VERSION}")
+  endif()
 endforeach()
 
 # Output the extensions that we linked into DuckDB for some nice build logs


### PR DESCRIPTION
The extensions add an `EXT_VERSION_[XXX]` definition (e.g. `EXT_VERSION_PARQUET`) - which defaults to the current git hash. These definitions are not removed afterwards, leading to subsequent compilation units to all have this definition, and stacking them up as extensions get built, e.g.:

`autocomplete` -> `-DEXT_VERSION_AUTOCOMPLETE=\"5001ce5bc7\" `
`icu` -> `-DEXT_VERSION_AUTOCOMPLETE=\"5001ce5bc7\" -DEXT_VERSION_ICU=\"5001ce5bc7\"`

etc...

This is not really a problem, but these definitions change when a commit is made, leading to unnecessary recompilation. As these definitions pollute also the compilation of the main source tree this leads to recompiling of the entire system upon commit. By removing the definitions we make it so that we "only" recompile the extensions on commit instead.