### PR TITLE
Fix #15584: correctly shift delim_offset when decorrelating joins where the correlation only occurs on the RHS of the join

### DIFF
--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -401,6 +401,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 				// only right has correlation: push into right
 				plan->children[1] = PushDownDependentJoinInternal(std::move(plan->children[1]),
 				                                                  parent_propagate_null_values, lateral_depth);
+				delim_offset += plan->children[0]->GetColumnBindings().size();
 				// Remove the correlated columns coming from outside for current join node
 				return plan;
 			}
@@ -419,6 +420,7 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 				// only right has correlation: push into right
 				plan->children[1] = PushDownDependentJoinInternal(std::move(plan->children[1]),
 				                                                  parent_propagate_null_values, lateral_depth);
+				delim_offset += plan->children[0]->GetColumnBindings().size();
 				return plan;
 			}
 		} else if (join.join_type == JoinType::MARK) {

--- a/test/fuzzer/public/lateral_in_right_side_of_join.test
+++ b/test/fuzzer/public/lateral_in_right_side_of_join.test
@@ -1,0 +1,28 @@
+# name: test/fuzzer/public/lateral_in_right_side_of_join.test
+# description: Lateral correlation in right side of join
+# group: [public]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE t0(c0 INT , c1 VARCHAR);
+
+statement ok
+CREATE TABLE t1( c1 INT);
+
+statement ok
+INSERT INTO t0 VALUES(4, 3);
+
+statement ok
+INSERT INTO t1 VALUES(2);
+
+query IIII
+SELECT * FROM t1, t0 JOIN LATERAL (SELECT t1.c1 AS col0) _subq ON true;
+----
+2	4	3	2
+
+query IIII
+SELECT * FROM t1, t0 INNER JOIN (SELECT t1.c1 AS col0) ON true;
+----
+2	4	3	2


### PR DESCRIPTION
Fixes #15584