### PR TITLE
Properly set size of row group in written Parquet files

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -717,6 +717,7 @@ void BasicColumnWriter::FinalizeWrite(ColumnWriterState &state_p) {
 	column_chunk.meta_data.total_compressed_size =
 	    UnsafeNumericCast<int64_t>(column_writer.GetTotalWritten() - start_offset);
 	column_chunk.meta_data.total_uncompressed_size = UnsafeNumericCast<int64_t>(total_uncompressed_size);
+	state.row_group.total_byte_size += column_chunk.meta_data.total_uncompressed_size;
 
 	if (state.bloom_filter) {
 		writer.BufferBloomFilter(state.col_idx, std::move(state.bloom_filter));

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -395,7 +395,6 @@ void ParquetWriter::PrepareRowGroup(ColumnDataCollection &buffer, PreparedRowGro
 	// set up a new row group for this chunk collection
 	auto &row_group = result.row_group;
 	row_group.num_rows = NumericCast<int64_t>(buffer.Count());
-	row_group.total_byte_size = NumericCast<int64_t>(buffer.SizeInBytes());
 	row_group.__isset.file_offset = true;
 
 	auto &states = result.states;


### PR DESCRIPTION
We were setting the size in DuckDB's own internal format, but it should be the uncompressed (i.e., non zstd/snappy) size in the Parquet file.