### PR TITLE
Fetch default schema from the catalog, instead of always defaulting to "main"

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -426,7 +426,12 @@ vector<CatalogSearchEntry> GetCatalogEntries(CatalogEntryRetriever &retriever, c
 			entries.emplace_back(catalog, schema_name);
 		}
 		if (entries.empty()) {
-			entries.emplace_back(catalog, DEFAULT_SCHEMA);
+			auto catalog_entry = Catalog::GetCatalogEntry(context, catalog);
+			if (catalog_entry) {
+				entries.emplace_back(catalog, catalog_entry->GetDefaultSchema());
+			} else {
+				entries.emplace_back(catalog, DEFAULT_SCHEMA);
+			}
 		}
 	} else {
 		// specific catalog and schema provided
@@ -1071,6 +1076,10 @@ vector<MetadataBlockInfo> Catalog::GetMetadataInfo(ClientContext &context) {
 
 optional_ptr<DependencyManager> Catalog::GetDependencyManager() {
 	return nullptr;
+}
+
+string Catalog::GetDefaultSchema() const {
+	return DEFAULT_SCHEMA;
 }
 
 //! Whether this catalog has a default table. Catalogs with a default table can be queries by their catalog name

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -193,6 +193,18 @@ const vector<CatalogSearchEntry> &CatalogSearchPath::Get() {
 	return paths;
 }
 
+string CatalogSearchPath::GetDefaultSchema(const string &catalog) {
+	for (auto &path : paths) {
+		if (path.catalog == TEMP_CATALOG) {
+			continue;
+		}
+		if (StringUtil::CIEquals(path.catalog, catalog)) {
+			return path.schema;
+		}
+	}
+	return DEFAULT_SCHEMA;
+}
+
 string CatalogSearchPath::GetDefaultSchema(ClientContext &context, const string &catalog) {
 	for (auto &path : paths) {
 		if (path.catalog == TEMP_CATALOG) {

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -165,7 +165,7 @@ void CatalogSearchPath::Set(vector<CatalogSearchEntry> new_paths, CatalogSetPath
 		if (path.catalog.empty()) {
 			auto catalog = Catalog::GetCatalogEntry(context, path.schema);
 			if (catalog) {
-				auto schema = catalog->GetSchema(context, DEFAULT_SCHEMA, OnEntryNotFound::RETURN_NULL);
+				auto schema = catalog->GetSchema(context, catalog->GetDefaultSchema(), OnEntryNotFound::RETURN_NULL);
 				if (schema) {
 					path.catalog = std::move(path.schema);
 					path.schema = schema->name;
@@ -193,7 +193,7 @@ const vector<CatalogSearchEntry> &CatalogSearchPath::Get() {
 	return paths;
 }
 
-string CatalogSearchPath::GetDefaultSchema(const string &catalog) {
+string CatalogSearchPath::GetDefaultSchema(ClientContext &context, const string &catalog) {
 	for (auto &path : paths) {
 		if (path.catalog == TEMP_CATALOG) {
 			continue;
@@ -201,6 +201,10 @@ string CatalogSearchPath::GetDefaultSchema(const string &catalog) {
 		if (StringUtil::CIEquals(path.catalog, catalog)) {
 			return path.schema;
 		}
+	}
+	auto catalog_entry = Catalog::GetCatalogEntry(context, catalog);
+	if (catalog_entry) {
+		return catalog_entry->GetDefaultSchema();
 	}
 	return DEFAULT_SCHEMA;
 }

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -315,7 +315,11 @@ public:
 		return CatalogLookupBehavior::STANDARD;
 	}
 
+	//! Returns the default schema of the catalog
+	virtual string GetDefaultSchema() const;
+
 	//! The default table is used for `SELECT * FROM <catalog_name>;`
+	//! FIXME: these should be virtual methods
 	DUCKDB_API bool HasDefaultTable() const;
 	DUCKDB_API void SetDefaultTable(const string &schema, const string &name);
 	DUCKDB_API string GetDefaultTable() const;

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -53,7 +53,7 @@ public:
 		return set_paths;
 	}
 	DUCKDB_API const CatalogSearchEntry &GetDefault();
-	DUCKDB_API string GetDefaultSchema(const string &catalog);
+	DUCKDB_API string GetDefaultSchema(ClientContext &context, const string &catalog);
 	DUCKDB_API string GetDefaultCatalog(const string &schema);
 
 	DUCKDB_API vector<string> GetSchemasForCatalog(const string &catalog);

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -53,6 +53,8 @@ public:
 		return set_paths;
 	}
 	DUCKDB_API const CatalogSearchEntry &GetDefault();
+	//! FIXME: this method is deprecated
+	DUCKDB_API string GetDefaultSchema(const string &catalog);
 	DUCKDB_API string GetDefaultSchema(ClientContext &context, const string &catalog);
 	DUCKDB_API string GetDefaultCatalog(const string &schema);
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -98,7 +98,7 @@ SchemaCatalogEntry &Binder::BindSchema(CreateInfo &info) {
 		info.catalog = default_entry.catalog;
 		info.schema = default_entry.schema;
 	} else if (IsInvalidSchema(info.schema)) {
-		info.schema = search_path->GetDefaultSchema(info.catalog);
+		info.schema = search_path->GetDefaultSchema(context, info.catalog);
 	} else if (IsInvalidCatalog(info.catalog)) {
 		info.catalog = search_path->GetDefaultCatalog(info.schema);
 	}


### PR DESCRIPTION
This shouldn't change anything in regular DuckDB operation, but allows some hacks to be removed from the postgres extension (which uses `public` as default schema).