### PR TITLE
fix: allow table returning in/out functions to accept LogicalType::TABLE in any argument position.

### DIFF
--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -126,8 +126,7 @@ bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_functi
 		    child->GetExpressionType() == ExpressionType::SUBQUERY) {
 			D_ASSERT(table_function.functions.Size() == 1);
 			auto fun = table_function.functions.GetFunctionByOffset(0);
-			if (table_function.functions.Size() != 1 || fun.arguments.empty() ||
-			    fun.arguments[0].id() != LogicalTypeId::TABLE) {
+			if (table_function.functions.Size() != 1 || fun.arguments.empty()) {
 				throw BinderException(
 				    "Only table-in-out functions can have subquery parameters - %s only accepts constant parameters",
 				    fun.name);


### PR DESCRIPTION
This relaxes the restriction for table in/out functions to require the LogicalType::TABLE argument as the first argument.

This allows functions of this form.

```sql
select * from example_function('example', (select * from table));
```

This is useful to extension creators like myself.