### PR TITLE
[Python SQLLogic Test Runner] Implement support for the `unzip` statement

### DIFF
--- a/scripts/sqllogictest/__init__.py
+++ b/scripts/sqllogictest/__init__.py
@@ -20,6 +20,7 @@ from .statement import (
     Sleep,
     SleepUnit,
     Skip,
+    Unzip,
     Unskip,
 )
 from .decorator import SkipIf, OnlyIf
@@ -50,6 +51,7 @@ __all__ = [
     Sleep,
     SleepUnit,
     Skip,
+    Unzip,
     Unskip,
     SkipIf,
     OnlyIf,

--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -21,6 +21,7 @@ from .statement import (
     Sleep,
     SleepUnit,
     Skip,
+    Unzip,
     SortStyle,
     Unskip,
 )
@@ -764,6 +765,7 @@ class SQLLogicContext:
             Restart: self.execute_restart,
             HashThreshold: self.execute_hash_threshold,
             Set: self.execute_set,
+            Unzip: self.execute_unzip,
             Loop: self.execute_loop,
             Foreach: self.execute_foreach,
             Endloop: None,  # <-- should never be encountered outside of Loop/Foreach
@@ -899,6 +901,18 @@ class SQLLogicContext:
 
     def execute_skip(self, statement: Skip):
         self.runner.skip()
+
+    def execute_unzip(self, statement: Unzip):
+        import gzip
+        import shutil
+
+        source = self.replace_keywords(statement.source)
+        destination = self.replace_keywords(statement.destination)
+
+        with gzip.open(source, 'rb') as f_in:
+            with open(destination, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        print(f"Extracted to '{destination}'")
 
     def execute_unskip(self, statement: Unskip):
         self.runner.unskip()

--- a/scripts/sqllogictest/statement/__init__.py
+++ b/scripts/sqllogictest/statement/__init__.py
@@ -14,6 +14,7 @@ from .require_env import RequireEnv
 from .restart import Restart
 from .reconnect import Reconnect
 from .sleep import Sleep, SleepUnit
+from .unzip import Unzip
 
 from .skip import Skip, Unskip
 
@@ -35,6 +36,7 @@ __all__ = [
     Sleep,
     SleepUnit,
     Skip,
+    Unzip,
     Unskip,
     SortStyle,
 ]

--- a/scripts/sqllogictest/statement/unzip.py
+++ b/scripts/sqllogictest/statement/unzip.py
@@ -1,0 +1,9 @@
+from sqllogictest.base_statement import BaseStatement
+from sqllogictest.token import Token
+
+
+class Unzip(BaseStatement):
+    def __init__(self, header: Token, line: int, source: str, destination: str):
+        super().__init__(header, line)
+        self.source = source
+        self.destination = destination

--- a/scripts/sqllogictest/token.py
+++ b/scripts/sqllogictest/token.py
@@ -22,6 +22,7 @@ class TokenType(Enum):
     SQLLOGIC_RESTART = auto()
     SQLLOGIC_RECONNECT = auto()
     SQLLOGIC_SLEEP = auto()
+    SQLLOGIC_UNZIP = auto()
 
 
 class Token:


### PR DESCRIPTION
This PR fixes <https://github.com/duckdblabs/duckdb-internal/issues/3994>

`unzip` was added a while back, but support for it was never added to the python sqllogic tester implementation.
Resulting in a parser error for tests that used this new statement type.