### PR TITLE
[Fix] Follow-up fix to the copy physical index PR

### DIFF
--- a/src/execution/operator/persistent/physical_copy_database.cpp
+++ b/src/execution/operator/persistent/physical_copy_database.cpp
@@ -13,8 +13,6 @@
 #include "duckdb/parser/parsed_data/create_index_info.hpp"
 #include "duckdb/execution/index/unbound_index.hpp"
 #include "duckdb/storage/data_table.hpp"
-#include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/expression_binder/index_binder.hpp"
 
 namespace duckdb {
 

--- a/src/execution/operator/persistent/physical_copy_database.cpp
+++ b/src/execution/operator/persistent/physical_copy_database.cpp
@@ -13,6 +13,8 @@
 #include "duckdb/parser/parsed_data/create_index_info.hpp"
 #include "duckdb/execution/index/unbound_index.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression_binder/index_binder.hpp"
 
 namespace duckdb {
 
@@ -82,7 +84,10 @@ SourceResultType PhysicalCopyDatabase::GetData(ExecutionContext &context, DataCh
 		storage_info.options.emplace("v1_0_0_storage", false);
 		auto unbound_index = make_uniq<UnboundIndex>(create_index_info.Copy(), storage_info,
 		                                             data_table.GetTableIOManager(), catalog.GetAttached());
+
 		data_table.AddIndex(std::move(unbound_index));
+		auto &data_table_info = *data_table.GetDataTableInfo();
+		data_table_info.GetIndexes().InitializeIndexes(context.client, data_table_info);
 	}
 
 	return SourceResultType::FINISHED;


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/15964

I was hoping we could copy the index without having to bind it, but that causes some issues. So, this PR addresses them by binding the index.

Fix https://github.com/duckdblabs/duckdb-internal/issues/4105
Fix https://github.com/duckdblabs/duckdb-internal/issues/4104