### PR TITLE
std::thread::hardware_concurrency() might fail, use 1 in that case

### DIFF
--- a/benchmark/include/benchmark_runner.hpp
+++ b/benchmark/include/benchmark_runner.hpp
@@ -49,7 +49,7 @@ public:
 	vector<Benchmark *> benchmarks;
 	ofstream out_file;
 	ofstream log_file;
-	uint32_t threads = std::thread::hardware_concurrency();
+	uint32_t threads = MaxValue<uint32_t>(std::thread::hardware_concurrency(), 1u);
 };
 
 } // namespace duckdb

--- a/extension/jemalloc/jemalloc_extension.cpp
+++ b/extension/jemalloc/jemalloc_extension.cpp
@@ -123,7 +123,8 @@ unsigned duckdb_malloc_ncpus() {
 #ifdef DUCKDB_NO_THREADS
 	return 1
 #else
-	return duckdb::NumericCast<unsigned>(std::thread::hardware_concurrency());
+	unsigned concurrency = duckdb::NumericCast<unsigned>(std::thread::hardware_concurrency());
+	return std::max(concurrency, 1u);
 #endif
 }
 

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -462,7 +462,7 @@ idx_t DBConfig::GetSystemMaxThreads(FileSystem &fs) {
 	}
 	return MaxValue<idx_t>(CGroups::GetCPULimit(fs, physical_cores), 1);
 #else
-	return physical_cores;
+	return MaxValue<idx_t>(physical_cores, 1);
 #endif
 #endif
 }

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -314,7 +314,8 @@ vector<string> TestResultHelper::LoadResultFromFile(string fname, vector<string>
                                                     string &error) {
 	DuckDB db(nullptr);
 	Connection con(db);
-	con.Query("PRAGMA threads=" + to_string(std::thread::hardware_concurrency()));
+	auto threads = MaxValue<idx_t>(std::thread::hardware_concurrency(), 1);
+	con.Query("PRAGMA threads=" + to_string(threads));
 	fname = StringUtil::Replace(fname, "<FILE>:", "");
 
 	string struct_definition = "STRUCT_PACK(";


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency

Should fix https://github.com/duckdb/duckdb/issues/14903#issuecomment-2624809118