### PR TITLE
Fix pyodide, add version 0.27.2

### DIFF
--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -52,6 +52,9 @@ jobs:
           - python: "3.12"
             pyodide-build: "0.26.1"
             node: "20"
+          - python: "3.12"
+            pyodide-build: "0.27.2"
+            node: "20"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Pyodide.yml
+++ b/.github/workflows/Pyodide.yml
@@ -124,7 +124,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: pyodide-python${{ matrix.version.python }}
+          name: pyodide-python${{ matrix.version.pyodide-build }}
           if-no-files-found: error
           path: |
             ./tools/pythonpkg/dist/*.whl

--- a/tools/pythonpkg/tests/fast/spark/test_spark_functions_array.py
+++ b/tools/pythonpkg/tests/fast/spark/test_spark_functions_array.py
@@ -1,9 +1,15 @@
 import pytest
+import platform
 
 _ = pytest.importorskip("duckdb.experimental.spark")
 from spark_namespace.sql import functions as F
 from spark_namespace.sql.types import Row
 from spark_namespace import USE_ACTUAL_SPARK
+
+pytestmark = pytest.mark.skipif(
+    platform.system() == "Emscripten",
+    reason="This Spark experimental test is not supported on Emscripten",
+)
 
 
 class TestSparkFunctionsArray:


### PR DESCRIPTION
Some more touches to Pyodide tests / CI, plus adding @cpcloud's https://github.com/duckdb/duckdb/pull/15862 that enabled Pyodide 0.27.2.