### PR TITLE
Remove sampling functionality

### DIFF
--- a/src/include/duckdb/storage/table/table_statistics.hpp
+++ b/src/include/duckdb/storage/table/table_statistics.hpp
@@ -49,7 +49,7 @@ public:
 	//! The reference can only be safely accessed while the lock is held
 	ColumnStatistics &GetStats(TableStatisticsLock &lock, idx_t i);
 	//! Get a reference to the table sample - this requires us to hold the lock.
-	BlockingSample &GetTableSampleRef(TableStatisticsLock &lock);
+	// BlockingSample &GetTableSampleRef(TableStatisticsLock &lock);
 	//! Take ownership of the sample, needed for merging. Requires the lock
 	unique_ptr<BlockingSample> GetTableSample(TableStatisticsLock &lock);
 	void SetTableSample(TableStatisticsLock &lock, unique_ptr<BlockingSample> sample);

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -553,6 +553,7 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 		// if we have serialized the row groups - push the serialized block pointers into the commit state
 		commit_state->AddRowGroupData(*table, start_index, optimistically_written_count, std::move(row_group_data));
 	}
+	stats.MergeStats(data.stats);
 	total_rows += data.total_rows.load();
 }
 

--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -142,10 +142,10 @@ ColumnStatistics &TableStatistics::GetStats(TableStatisticsLock &lock, idx_t i) 
 	return *column_stats[i];
 }
 
-BlockingSample &TableStatistics::GetTableSampleRef(TableStatisticsLock &lock) {
-	D_ASSERT(table_sample);
-	return *table_sample;
-}
+// BlockingSample &TableStatistics::GetTableSampleRef(TableStatisticsLock &lock) {
+//	D_ASSERT(table_sample);
+//	return *table_sample;
+//}
 
 unique_ptr<BlockingSample> TableStatistics::GetTableSample(TableStatisticsLock &lock) {
 	return std::move(table_sample);

--- a/test/sql/sample/table_samples/basic_sample_tests.test
+++ b/test/sql/sample/table_samples/basic_sample_tests.test
@@ -1,6 +1,8 @@
 # name: test/sql/sample/table_samples/basic_sample_tests.test
 # group: [table_samples]
 
+mode skip
+
 # currently require fixed vector size since the "randomness" of the sample depends on
 # the vector size. If the vector size decreases, the randomness of the sample decreases
 # This is especially noticeable for small tables and their samples

--- a/test/sql/sample/table_samples/sample_stores_rows_from_later_on.test_slow
+++ b/test/sql/sample/table_samples/sample_stores_rows_from_later_on.test_slow
@@ -2,6 +2,8 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
+mode skip
+
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 

--- a/test/sql/sample/table_samples/table_sample_converts_to_block_sample.test
+++ b/test/sql/sample/table_samples/table_sample_converts_to_block_sample.test
@@ -2,6 +2,8 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
+mode skip
+
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 

--- a/test/sql/sample/table_samples/table_sample_is_stored.test_slow
+++ b/test/sql/sample/table_samples/table_sample_is_stored.test_slow
@@ -2,6 +2,8 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
+mode skip
+
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 

--- a/test/sql/sample/table_samples/test_sample_is_destroyed_on_updates.test
+++ b/test/sql/sample/table_samples/test_sample_is_destroyed_on_updates.test
@@ -2,6 +2,8 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
+mode skip
+
 # required when testing table samples. See basic_sample_test.test
 require vector_size 2048
 

--- a/test/sql/sample/table_samples/test_sample_types.test
+++ b/test/sql/sample/table_samples/test_sample_types.test
@@ -2,6 +2,8 @@
 # description: Test sampling of larger relations
 # group: [table_samples]
 
+mode skip
+
 # test valid sampling types (for now only integral types)
 
 statement ok

--- a/test/sql/sample/table_samples/test_table_sample_errors.test
+++ b/test/sql/sample/table_samples/test_table_sample_errors.test
@@ -2,6 +2,8 @@
 # description: test table sampl[e errors
 # group: [table_samples]
 
+mode skip
+
 statement ok
 create table t1 as select range a from range(204800);
 


### PR DESCRIPTION
Addresses https://github.com/duckdblabs/duckdb-internal/issues/4110

Sampling has bad memory management right now, which is causing larger ingestions to fail. In the interest of releasing early next week, it's probably best that it is removed and later added when memory issues are resolved