### PR TITLE
Install errors to point to documentation

### DIFF
--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -236,6 +236,7 @@ public:
 
 	static bool IsRelease(const string &version_tag);
 	static bool CreateSuggestions(const string &extension_name, string &message);
+	static string ExtensionInstallDocumentationLink(const string &extension_name);
 
 private:
 	static unique_ptr<ExtensionInstallInfo> InstallExtensionInternal(DatabaseInstance &db, FileSystem &fs,

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -456,15 +456,11 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 		if (!should_retry || retry_count >= MAX_RETRY_COUNT) {
 			// if we should not retry or exceeded the number of retries - bubble up the error
 			string message;
-			auto exact_match = ExtensionHelper::CreateSuggestions(extension_name, message);
+			ExtensionHelper::CreateSuggestions(extension_name, message);
 
 			auto documentation_link = ExtensionHelper::ExtensionInstallDocumentationLink(extension_name);
 			if (!documentation_link.empty()) {
 				message += "\nFor more info, visit " + documentation_link;
-			}
-
-			if (exact_match && !ExtensionHelper::IsRelease(DuckDB::LibraryVersion())) {
-				message += "\nAre you using a development build? In this case, extensions might not (yet) be uploaded.";
 			}
 			if (res.error() == duckdb_httplib::Error::Success) {
 				throw HTTPException(res.value(), "Failed to download extension \"%s\" at URL \"%s%s\" (HTTP %n)\n%s",

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -59,7 +59,7 @@ const vector<string> ExtensionHelper::PathComponents() {
 string ExtensionHelper::ExtensionInstallDocumentationLink(const string &extension_name) {
 	auto components = PathComponents();
 
-	string link = "https://duckdb.org/docs/installing_extensions";
+	string link = "https://duckdb.org/docs/extensions/troubleshooting";
 
 	if (components.size() >= 2) {
 		link += "/?version=" + components[0] + "&platform=" + components[1] + "&extension=" + extension_name;

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -56,6 +56,18 @@ const vector<string> ExtensionHelper::PathComponents() {
 	return vector<string> {GetVersionDirectoryName(), DuckDB::Platform()};
 }
 
+string ExtensionHelper::ExtensionInstallDocumentationLink(const string &extension_name) {
+	auto components = PathComponents();
+
+	string link = "https://duckdb.org/docs/installing_extensions";
+
+	if (components.size() >= 2) {
+		link += "/?version=" + components[0] + "&platform=" + components[1] + "&extension=" + extension_name;
+	}
+
+	return link;
+}
+
 duckdb::string ExtensionHelper::DefaultExtensionFolder(FileSystem &fs) {
 	string home_directory = fs.GetHomeDirectory();
 	// exception if the home directory does not exist, don't create whatever we think is home
@@ -445,6 +457,12 @@ static unique_ptr<ExtensionInstallInfo> InstallFromHttpUrl(DatabaseInstance &db,
 			// if we should not retry or exceeded the number of retries - bubble up the error
 			string message;
 			auto exact_match = ExtensionHelper::CreateSuggestions(extension_name, message);
+
+			auto documentation_link = ExtensionHelper::ExtensionInstallDocumentationLink(extension_name);
+			if (!documentation_link.empty()) {
+				message += "\nFor more info, visit " + documentation_link;
+			}
+
 			if (exact_match && !ExtensionHelper::IsRelease(DuckDB::LibraryVersion())) {
 				message += "\nAre you using a development build? In this case, extensions might not (yet) be uploaded.";
 			}

--- a/test/extension/install_extension.test
+++ b/test/extension/install_extension.test
@@ -37,3 +37,9 @@ statement error
 INSTALL will_never_exist FROM 'core';
 ----
 IO Error: Failed to copy local extension "will_never_exist" at PATH 
+
+# Error message should point to extensions troubleshooting page
+statement error
+INSTALL will_never_exist FROM core;
+----
+For more info, visit https://duckdb.org/docs/extensions/troubleshooting


### PR DESCRIPTION
Install error messages are at the moment reported by users as confusing, see for example https://github.com/duckdb/duckdb/discussions/15988

Idea is providing a documentation URL (that is at the moment not existing), where we could also version/platform adapt the error message.
Main advantage is that the error message can be adapted / iterated AFTER a given release is out.

Possibly one implementation would be listing the known extensions / community extensions for a given combination of version and platform.

After this PR:
```
D INSTALL iamnotexisting;
HTTP Error:
Failed to download extension "iamnotexisting" at URL "http://extensions.duckdb.org/061967287d/osx_arm64/iamnotexisting.duckdb_extension.gz" (HTTP 403)

Candidate extensions: "inet", "postgres", "autocomplete", "sqlite", "sqlite_scanner"
For more info, visit https://duckdb.org/docs/extensions/troubleshooting/?version=061967287d&platform=osx_arm64&extension=iamnotexisting
```
While otherwise it would be:
```
D INSTALL iamnotexisting;
HTTP Error:
Failed to download extension "iamnotexisting" at URL "http://extensions.duckdb.org/061967287d/osx_arm64/iamnotexisting.duckdb_extension.gz" (HTTP 403)

Candidate extensions: "inet", "postgres", "autocomplete", "sqlite", "sqlite_scanner"
```

Also removing the line:
```
Are you using a development build? In this case, extensions might not (yet) be uploaded.
```
that might happen if extension fails on a known extension, since that information can be included in the docs people are pointed to.

The doc page is not existing (yet).