### PR TITLE
Avoid running autoloading tests from remote when not deploying

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -233,7 +233,7 @@ runs:
 
     # Run the unittests (excluding the out-of-tree tests) with the extensions that we deployed to S3
     - name: Test deployed extensions
-      if: ${{ inputs.run_tests == 1 }}
+      if: ${{ inputs.deploy_as != '' && inputs.run_tests == 1 }}
       shell: bash
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.s3_id }}

--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -124,7 +124,6 @@ jobs:
 
       - uses: ./.github/actions/build_extensions
         with:
-          deploy_as: windows_amd64_mingw
           duckdb_arch: windows_amd64_mingw
           vcpkg_target_triplet: x64-mingw-static
           treat_warn_as_error: 0

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -62,7 +62,6 @@ jobs:
 
       - uses: ./.github/actions/build_extensions
         with:
-          deploy_as: windows_amd64_mingw
           duckdb_arch: windows_amd64_mingw
           vcpkg_target_triplet: x64-mingw-static
           treat_warn_as_error: 0

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -280,7 +280,6 @@ jobs:
      - uses: ./.github/actions/build_extensions
        with:
          vcpkg_target_triplet: x64-windows-static-md
-         deploy_as: windows_amd64
          treat_warn_as_error: 0
          run_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}
          run_autoload_tests: ${{ inputs.skip_tests != 'true' && 1 || 0 }}


### PR DESCRIPTION
Yet another step to streamlining uploads and fixing a problem with testing loading from remote endpoints in Windows workflow. This can't be done BEFORE actually uploading.

The tests needs to be reviewed post v1.2.0, now avoiding the failure and unifying the code more.

This avoids errors like tonight nightly run: https://github.com/duckdb/duckdb/actions/runs/13104026020/job/36557104073.