### PR TITLE
[chore] Change benchmark, to avoid loading TPCH to be required

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -123,7 +123,7 @@ jobs:
       shell: bash
       if: ${{ inputs.skip_tests != 'true' }}
       run: |
-        build/release/benchmark/benchmark_runner benchmark/tpch/sf1/q01.benchmark
+        build/release/benchmark/benchmark_runner benchmark/micro/update/update_with_join.benchmark
         build/release/duckdb -c "COPY (SELECT 42) TO '/dev/stdout' (FORMAT PARQUET)" | cat
 
  linux-release-aarch64:


### PR DESCRIPTION
Fixes a failure in LinuxRelease workflow.
Failure had no consequence since it was last step, but still removing the noise it's better.