### PR TITLE
Replace `FormatException` with `InvalidInputException` in Parquet reader

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -216,12 +216,6 @@ private:
 	void PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t out_col_idx);
 	LogicalType DeriveLogicalType(const SchemaElement &s_ele);
 
-	template <typename... Args>
-	std::runtime_error FormatException(const string fmt_str, Args... params) {
-		return std::runtime_error("Failed to read Parquet file \"" + file_name +
-		                          "\": " + StringUtil::Format(fmt_str, params...));
-	}
-
 private:
 	unique_ptr<FileHandle> file_handle;
 };

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -492,7 +492,8 @@ void ParquetReader::InitializeSchema(ClientContext &context) {
 	}
 	// check if we like this schema
 	if (file_meta_data->schema.size() < 2) {
-		throw FormatException("Need at least one non-root column in the file");
+		throw InvalidInputException("Failed to read Parquet file '%s': Need at least one non-root column in the file",
+		                            file_name);
 	}
 	root_reader = CreateReader(context);
 	auto &root_type = root_reader->Type();


### PR DESCRIPTION
In the Parquet reader, there is one place where a `FormatException` is thrown when the Parquet file is malformed, while in all other cases an `InvalidInputException` is used. At MotherDuck, we try to distinguish DuckDB errors that indicate serious issues and errors that are caused by external triggers (like a malformed Parquet file). For this, it would be helpful to use a consistent error type for similar errors.

This PR therefore replaces the `FormatException` with an `InvalidInputException`.

This also gives a slightly nicer error message because a `FormatException` leads the error message to be prefixed with "Invalid Error".