### PR TITLE
Do not aggressively allocate extra space

### DIFF
--- a/src/execution/sample/reservoir_sample.cpp
+++ b/src/execution/sample/reservoir_sample.cpp
@@ -551,7 +551,7 @@ void ReservoirSample::ExpandSerializedSample() {
 }
 
 idx_t ReservoirSample::GetReservoirChunkCapacity() const {
-	return sample_count + (FIXED_SAMPLE_SIZE_MULTIPLIER * FIXED_SAMPLE_SIZE);
+	return sample_count + (FIXED_SAMPLE_SIZE_MULTIPLIER * MinValue<idx_t>(sample_count, FIXED_SAMPLE_SIZE));
 }
 
 idx_t ReservoirSample::FillReservoir(DataChunk &chunk) {


### PR DESCRIPTION
Following up on https://github.com/duckdb/duckdb/pull/16010 I was wondering if too much memory was used during regular sampling as well. Turns out there is and it is because we over sample. 

If we have a reservoir sample of 5 rows (either by sampling 0.00005% or 5 rows) then the capacity of the reservoir is calculated to be the following

```
= sample-count + (FIXED_SAMPLE_SIZE_MULTIPLIER * FIXED_SAMPLE_SIZE)
= 5 + 10 * 2048
```

The 10*2048 is quite large compared to the 5 rows. For percentage samples the extra allocations can add up since one sample is created per 100000 rows. The updated formula is 
```
= sample-count + (FIXED_SAMPLE_SIZE_MULTIPLIER * MinValue<idx_t>(FIXED_SAMPLE_SIZE, sample_count))
= 5 + 10 * 5
```

which reduces the extra space by 400x, which will also reduce the memory pressure during sampling.