### PR TITLE
[Julia] Fixes a a bug that the database is not properly closed even after close() is called

### DIFF
--- a/tools/juliapkg/src/result.jl
+++ b/tools/juliapkg/src/result.jl
@@ -870,7 +870,14 @@ The resultset iterator supports the [Tables.jl](https://github.com/JuliaData/Tab
 like `DataFrame(results)`, `CSV.write("results.csv", results)`, etc.
 """
 DBInterface.execute(stmt::Stmt, params::DBInterface.StatementParams) = execute(stmt, params)
-DBInterface.execute(con::Connection, sql::AbstractString, result_type::Type) = execute(Stmt(con, sql, result_type))
+function DBInterface.execute(con::Connection, sql::AbstractString, result_type::Type)
+    stmt = Stmt(con, sql, result_type)
+    try
+        return execute(stmt)
+    finally
+        _close_stmt(stmt) # immediately close, don't wait for GC
+    end
+end
 DBInterface.execute(con::Connection, sql::AbstractString) = DBInterface.execute(con, sql, MaterializedResult)
 DBInterface.execute(db::DB, sql::AbstractString, result_type::Type) =
     DBInterface.execute(db.main_connection, sql, result_type)

--- a/tools/juliapkg/test/test_connection.jl
+++ b/tools/juliapkg/test/test_connection.jl
@@ -44,6 +44,7 @@ end
     write_data(db_path) # call the function
     @test isfile(db_path_wal) === false # WAL file should not exist
 
+    @test isfile(db_path) # check if the database file exists
     result = run(`duckdb $db_path -c "SELECT * FROM test LIMIT 1"`) # check if the database can be opened
     @test success(result)
 end

--- a/tools/juliapkg/test/test_connection.jl
+++ b/tools/juliapkg/test/test_connection.jl
@@ -17,7 +17,8 @@ end
 @testset "Test opening a bogus directory" begin
     @test_throws DuckDB.ConnectionException DBInterface.connect(DuckDB.DB, "/path/to/bogus/directory")
 end
-@testset "Test closing of the DB" begin
+
+
 @testset "Test opening and closing an on-disk database" begin
     # This checks for an issue where the DB and the connection are 
     # closed but the actual db is not (and subsequently cannot be opened

--- a/tools/juliapkg/test/test_connection.jl
+++ b/tools/juliapkg/test/test_connection.jl
@@ -45,6 +45,11 @@ end
     @test isfile(db_path_wal) === false # WAL file should not exist
 
     @test isfile(db_path) # check if the database file exists
-    result = run(`duckdb $db_path -c "SELECT * FROM test LIMIT 1"`) # check if the database can be opened
-    @test success(result)
+
+    # check if the database can be opened
+    if haskey(ENV, "JULIA_DUCKDB_LIBRARY")
+        duckdb_binary = joinpath(dirname(ENV["JULIA_DUCKDB_LIBRARY"]), "..", "duckdb")
+        result = run(`$duckdb_binary $db_path -c "SELECT * FROM test LIMIT 1"`) # check if the database can be opened
+        @test success(result)
+    end
 end

--- a/tools/juliapkg/test/test_connection.jl
+++ b/tools/juliapkg/test/test_connection.jl
@@ -17,3 +17,32 @@ end
 @testset "Test opening a bogus directory" begin
     @test_throws DuckDB.ConnectionException DBInterface.connect(DuckDB.DB, "/path/to/bogus/directory")
 end
+@testset "Test closing of the DB" begin
+@testset "Test opening and closing an on-disk database" begin
+    # This checks for an issue where the DB and the connection are 
+    # closed but the actual db is not (and subsequently cannot be opened
+    # in a different process). To check this, we create a DB, write some
+    # data to it, close the connection and check if the WAL file exists.
+    #
+    # Ideally, the WAL file should not exist, but Garbage Collection of Julia
+    # may not have run yet, so open database handles may still exist, preventing
+    # the database from being closed properly.
+
+    db_path = joinpath(mktempdir(), "duckdata.db")
+    db_path_wal = db_path * ".wal"
+
+    function write_data(dbfile::String)
+        db = DuckDB.DB(dbfile)
+        conn = DBInterface.connect(db)
+        DBInterface.execute(conn, "CREATE OR REPLACE TABLE test (a INTEGER, b INTEGER);")
+        DBInterface.execute(conn, "INSERT INTO test VALUES (1, 2);")
+        DBInterface.close!(conn)
+        DuckDB.close_database(db)
+        return true
+    end
+    write_data(db_path) # call the function
+    @test isfile(db_path_wal) === false # WAL file should not exist
+
+    result = run(`duckdb $db_path -c "SELECT * FROM test LIMIT 1"`) # check if the database can be opened
+    @test success(result)
+end


### PR DESCRIPTION
This PR adds a fix to close the database reliably. The issue is that a call to `execute` creates a prepared statement handle that keeps the database connection open even if `duckdb_disconnect` is called. 
The handle is closed automatically by the gargabe collector, however this is delayed and in the meantime the database stays locked for other processes. 

The change is to manually close the prepared statement handle after a call to `execute` to not have to wait for the garbage collector.


## Example

If the following code is executed in the REPL 

```julia
using DuckDB
import DBInterface: execute, connect, close!

"""write_data(dbfile::String)"""
function write_data(dbfile::String)
    db = DuckDB.DB(dbfile)
    conn = connect(db)
    execute(conn, "CREATE OR REPLACE TABLE test (a INTEGER, b INTEGER);")
    execute(conn, "INSERT INTO test VALUES (1, 2);")
    close!(conn)
    DuckDB.close_database(db)
    return true
end

file_name = "duckdata.db"
write_data(file_name) # database stays open
```

keep the REPL open and try open the database in a different process (e.g. `duckdb duckdata.db`). In most cases this fails with:
`Error: unable to open database "duckdata.db": IO Error: Could not set lock on file "duckdata.db"`
