### PR TITLE
Benchmark runner: catch and log errors + add support for `retry load N` syntax

### DIFF
--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -123,7 +123,7 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 	duckdb::unique_ptr<BenchmarkState> state;
 	try {
 		state = benchmark->Initialize(configuration);
-	} catch(std::exception &ex) {
+	} catch (std::exception &ex) {
 		Log(StringUtil::Format("%s\t1\t", benchmark->name));
 		LogResult("ERROR");
 		duckdb::ErrorData error_data(ex);
@@ -149,7 +149,7 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 			profiler.Start();
 			benchmark->Run(state.get());
 			profiler.End();
-		} catch(std::exception &ex) {
+		} catch (std::exception &ex) {
 			duckdb::ErrorData error_data(ex);
 			error = error_data.Message();
 		}

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -120,7 +120,16 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 	Profiler profiler;
 	auto display_name = benchmark->DisplayName();
 
-	auto state = benchmark->Initialize(configuration);
+	duckdb::unique_ptr<BenchmarkState> state;
+	try {
+		state = benchmark->Initialize(configuration);
+	} catch(std::exception &ex) {
+		Log(StringUtil::Format("%s\t1\t", benchmark->name));
+		LogResult("ERROR");
+		duckdb::ErrorData error_data(ex);
+		LogLine(error_data.Message());
+		return;
+	}
 	auto nruns = benchmark->NRuns();
 	for (size_t i = 0; i < nruns + 1; i++) {
 		bool hotrun = i > 0;
@@ -135,16 +144,25 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 		std::thread interrupt_thread(sleep_thread, benchmark, this, state.get(), hotrun,
 		                             benchmark->Timeout(configuration));
 
-		profiler.Start();
-		benchmark->Run(state.get());
-		profiler.End();
+		string error;
+		try {
+			profiler.Start();
+			benchmark->Run(state.get());
+			profiler.End();
+		} catch(std::exception &ex) {
+			duckdb::ErrorData error_data(ex);
+			error = error_data.Message();
+		}
 
 		is_active = false;
 		interrupt_thread.join();
 		if (hotrun) {
 			LogOutput(benchmark->GetLogOutput(state.get()));
-			if (timeout) {
-				// write timeout
+			if (!error.empty()) {
+				LogResult("ERROR");
+				LogLine(error);
+				break;
+			} else if (timeout) {
 				LogResult("TIMEOUT");
 				break;
 			} else {

--- a/benchmark/h2oai/group/h2oai.benchmark.in
+++ b/benchmark/h2oai/group/h2oai.benchmark.in
@@ -9,6 +9,8 @@ group H2OAI
 
 cache h2oai.duckdb
 
+retry load 5
+
 load benchmark/h2oai/group/queries/load.sql
 
 run benchmark/h2oai/group/queries/q${QUERY_NUMBER_PADDED}.sql

--- a/benchmark/h2oai/join/h2oai.benchmark.in
+++ b/benchmark/h2oai/join/h2oai.benchmark.in
@@ -11,6 +11,8 @@ storage persistent
 
 cache h2oaijoin.duckdb
 
+retry load 5
+
 load benchmark/h2oai/join/queries/load.sql
 
 run benchmark/h2oai/join/queries/q${QUERY_NUMBER_PADDED}.sql

--- a/benchmark/h2oai/join/queries/load.sql
+++ b/benchmark/h2oai/join/queries/load.sql
@@ -1,4 +1,4 @@
-CREATE TABLE x AS SELECT * FROM read_csv_auto('https://github.com/duckdb/duckdb-data/releases/download/v1.0/J1_1e7_NA_0_0.csv.gz');
-CREATE TABLE small AS SELECT * FROM read_csv_auto('https://github.com/duckdb/duckdb-data/releases/download/v1.0/J1_1e7_1e1_0_0.csv.gz');
-CREATE TABLE medium AS SELECT * FROM read_csv_auto('https://github.com/duckdb/duckdb-data/releases/download/v1.0/J1_1e7_1e4_0_0.csv.gz');
-CREATE TABLE big AS SELECT * FROM read_csv_auto('https://github.com/duckdb/duckdb-data/releases/download/v1.0/J1_1e7_1e7_0_0.csv.gz');
+CREATE TABLE IF NOT EXISTS x AS SELECT * FROM read_csv_auto('https://github.com/duckdb/duckdb-data/releases/download/v1.0/J1_1e7_NA_0_0.csv.gz');
+CREATE TABLE IF NOT EXISTS small AS SELECT * FROM read_csv_auto('https://github.com/duckdb/duckdb-data/releases/download/v1.0/J1_1e7_1e1_0_0.csv.gz');
+CREATE TABLE IF NOT EXISTS medium AS SELECT * FROM read_csv_auto('https://github.com/duckdb/duckdb-data/releases/download/v1.0/J1_1e7_1e4_0_0.csv.gz');
+CREATE TABLE IF NOT EXISTS big AS SELECT * FROM read_csv_auto('https://github.com/duckdb/duckdb-data/releases/download/v1.0/J1_1e7_1e7_0_0.csv.gz');

--- a/benchmark/include/interpreted_benchmark.hpp
+++ b/benchmark/include/interpreted_benchmark.hpp
@@ -15,6 +15,7 @@
 namespace duckdb {
 struct BenchmarkFileReader;
 class MaterializedQueryResult;
+struct InterpretedBenchmarkState;
 
 const string DEFAULT_DB_PATH = "duckdb_benchmark_db.db";
 
@@ -67,6 +68,8 @@ private:
 	void ReadResultFromFile(BenchmarkFileReader &reader, const string &file);
 	void ReadResultFromReader(BenchmarkFileReader &reader, const string &file);
 
+	unique_ptr<QueryResult> RunLoadQuery(InterpretedBenchmarkState &state, const string &load_query);
+
 private:
 	bool is_loaded = false;
 	std::unordered_map<string, string> replacement_mapping;
@@ -84,6 +87,8 @@ private:
 	int64_t result_column_count = 0;
 	vector<vector<string>> result_values;
 	string result_query;
+	//! How many times to retry the load, if any
+	idx_t retry_load = 0;
 
 	string display_name;
 	string display_group;

--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -328,6 +328,14 @@ void InterpretedBenchmark::LoadBenchmark() {
 			} else {
 				ReadResultFromReader(reader, splits[1]);
 			}
+		} else if (splits[0] == "retry") {
+			if (splits.size() != 3) {
+				throw std::runtime_error(reader.FormatException(splits[0] + " requires two parameters"));
+			}
+			if (splits[1] != "load") {
+				throw std::runtime_error("Only retry load is supported");
+			}
+			retry_load = std::stoull(splits[2]);
 		} else if (splits[0] == "template") {
 			// template: update the path to read
 			benchmark_path = splits[1];
@@ -356,6 +364,17 @@ void InterpretedBenchmark::LoadBenchmark() {
 	}
 	run_query = queries["run"];
 	is_loaded = true;
+}
+
+unique_ptr<QueryResult> InterpretedBenchmark::RunLoadQuery(InterpretedBenchmarkState &state, const string &load_query) {
+	auto result = state.con.Query(load_query);
+	for (idx_t i = 0; i < retry_load; i++) {
+		if (!result->HasError()) {
+			break;
+		}
+		result = state.con.Query(load_query);
+	}
+	return result;
 }
 
 unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfiguration &config) {
@@ -403,11 +422,11 @@ unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfigurati
 		auto fs = FileSystem::CreateLocal();
 		if (!fs->FileExists(fs->JoinPath(BenchmarkRunner::DUCKDB_BENCHMARK_DIRECTORY, cache_file))) {
 			// no cache or db_path specified: just run the initialization code
-			result = state->con.Query(load_query);
+			result = RunLoadQuery(*state, load_query);
 		}
 	} else if (cache_db.empty() && cache_db.compare(DEFAULT_DB_PATH) != 0) {
 		// no cache or db_path specified: just run the initialization code
-		result = state->con.Query(load_query);
+		result = RunLoadQuery(*state, load_query);
 	} else {
 		// cache or db_path is specified: try to load from one of them
 		bool in_memory_db_has_data = false;
@@ -425,7 +444,7 @@ unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfigurati
 		}
 		if (!in_memory_db_has_data) {
 			// failed to load: write the cache
-			result = state->con.Query(load_query);
+			result = RunLoadQuery(*state, load_query);
 		}
 	}
 	while (result) {


### PR DESCRIPTION
Instead of terminating with an uncaught exception the benchmark runner now logs that there was an error.

In addition, we add a new syntax `retry load N` which can be used to retry the load phase up to `N` times in case of errors. We use this in the h2oai benchmark (which downloads CSV files from a remote source and sporadically runs into failures on our CI). 