### PR TITLE
Parquet Reader: Split DeltaLengthByteArray decoder from DeltaByteArray, and read the strings in a streaming manner

### DIFF
--- a/extension/parquet/decoder/CMakeLists.txt
+++ b/extension/parquet/decoder/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library_unity(
   byte_stream_split_decoder.cpp
   delta_binary_packed_decoder.cpp
   delta_byte_array_decoder.cpp
+  delta_length_byte_array_decoder.cpp
   dictionary_decoder.cpp
   rle_decoder.cpp)
 set(PARQUET_EXTENSION_FILES

--- a/extension/parquet/decoder/delta_length_byte_array_decoder.cpp
+++ b/extension/parquet/decoder/delta_length_byte_array_decoder.cpp
@@ -1,0 +1,53 @@
+#include "decoder/delta_length_byte_array_decoder.hpp"
+#include "decoder/delta_byte_array_decoder.hpp"
+#include "column_reader.hpp"
+#include "parquet_reader.hpp"
+#include "reader/templated_column_reader.hpp"
+
+namespace duckdb {
+
+DeltaLengthByteArrayDecoder::DeltaLengthByteArrayDecoder(ColumnReader &reader) : reader(reader) {
+}
+
+void DeltaLengthByteArrayDecoder::InitializePage() {
+	if (reader.type.InternalType() != PhysicalType::VARCHAR) {
+		throw std::runtime_error("Delta Length Byte Array encoding is only supported for string/blob data");
+	}
+	// read the binary packed lengths
+	auto &block = *reader.block;
+	auto &allocator = reader.reader.allocator;
+	length_buffer = DeltaByteArrayDecoder::ReadDbpData(allocator, block, byte_array_count);
+	length_idx = 0;
+}
+
+void DeltaLengthByteArrayDecoder::Read(uint8_t *defines, idx_t read_count, Vector &result, idx_t result_offset) {
+	if (!length_buffer) {
+		throw std::runtime_error("Internal error - DeltaLengthByteArrayDecoder called but there was no length buffer");
+	}
+	auto &block = *reader.block;
+	auto length_data = reinterpret_cast<uint32_t *>(length_buffer->ptr);
+	auto result_data = FlatVector::GetData<string_t>(result);
+	auto &result_mask = FlatVector::Validity(result);
+	for (idx_t row_idx = 0; row_idx < read_count; row_idx++) {
+		auto result_idx = result_offset + row_idx;
+		if (defines && defines[result_idx] != reader.max_define) {
+			result_mask.SetInvalid(result_idx);
+			continue;
+		}
+		if (length_idx >= byte_array_count) {
+			throw IOException(
+			    "DELTA_LENGTH_BYTE_ARRAY - length mismatch between values and byte array lengths (attempted "
+			    "read of %d from %d entries) - corrupt file?",
+			    length_idx, byte_array_count);
+		}
+		auto str_len = length_data[length_idx++];
+		block.available(str_len);
+		result_data[result_idx] = StringVector::EmptyString(result, str_len);
+		auto str_data = result_data[result_idx].GetDataWriteable();
+		memcpy(str_data, block.ptr, str_len);
+		block.inc(str_len);
+		result_data[result_idx].Finalize();
+	}
+}
+
+} // namespace duckdb

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -18,6 +18,7 @@
 #include "decoder/delta_binary_packed_decoder.hpp"
 #include "decoder/dictionary_decoder.hpp"
 #include "decoder/rle_decoder.hpp"
+#include "decoder/delta_length_byte_array_decoder.hpp"
 #include "decoder/delta_byte_array_decoder.hpp"
 #ifndef DUCKDB_AMALGAMATION
 
@@ -56,6 +57,7 @@ class ColumnReader {
 	friend class ByteStreamSplitDecoder;
 	friend class DeltaBinaryPackedDecoder;
 	friend class DeltaByteArrayDecoder;
+	friend class DeltaLengthByteArrayDecoder;
 	friend class DictionaryDecoder;
 	friend class RLEDecoder;
 
@@ -197,6 +199,7 @@ private:
 	DictionaryDecoder dictionary_decoder;
 	DeltaBinaryPackedDecoder delta_binary_packed_decoder;
 	RLEDecoder rle_decoder;
+	DeltaLengthByteArrayDecoder delta_length_byte_array_decoder;
 	DeltaByteArrayDecoder delta_byte_array_decoder;
 	ByteStreamSplitDecoder byte_stream_split_decoder;
 

--- a/extension/parquet/include/decoder/delta_length_byte_array_decoder.hpp
+++ b/extension/parquet/include/decoder/delta_length_byte_array_decoder.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// decoder/delta_byte_array_decoder.hpp
+// decoder/delta_length_byte_array_decoder.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -15,22 +15,20 @@
 namespace duckdb {
 class ColumnReader;
 
-class DeltaByteArrayDecoder {
+class DeltaLengthByteArrayDecoder {
 public:
-	explicit DeltaByteArrayDecoder(ColumnReader &reader);
+	explicit DeltaLengthByteArrayDecoder(ColumnReader &reader);
 
 public:
 	void InitializePage();
 
 	void Read(uint8_t *defines, idx_t read_count, Vector &result, idx_t result_offset);
 
-	static shared_ptr<ResizeableBuffer> ReadDbpData(Allocator &allocator, ResizeableBuffer &buffer, idx_t &value_count);
-
 private:
 	ColumnReader &reader;
-	unique_ptr<Vector> byte_array_data;
+	shared_ptr<ResizeableBuffer> length_buffer;
 	idx_t byte_array_count = 0;
-	idx_t delta_offset = 0;
+	idx_t length_idx;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
Strings stored using the `DELTA_LENGTH_BYTE_ARRAY` encoding can easily be read in a streaming manner - there is no need to materialize them in a separate string dictionary like we do with strings encoded using `DELTA_BYTE_ARRAY`.