### PR TITLE
BundleStaticLibs to be also triggered by InvokeCI

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -72,3 +72,11 @@ jobs:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
+
+  static-libraries:
+    uses: ./.github/workflows/BundleStaticLibs.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}


### PR DESCRIPTION
I think this should be fine if ends only on `main`, given that is that (as default branch) that dictates what happens.