### PR TITLE
Use ordered map to preserve expressions order

### DIFF
--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -103,8 +103,8 @@ private:
 
 	expression_map_t<unique_ptr<Expression>> stored_expressions;
 	expression_map_t<idx_t> equivalence_set_map;
-	unordered_map<idx_t, vector<ExpressionValueInformation>> constant_values;
-	unordered_map<idx_t, vector<reference<Expression>>> equivalence_map;
+	map<idx_t, vector<ExpressionValueInformation>> constant_values;
+	map<idx_t, vector<reference<Expression>>> equivalence_map;
 	idx_t set_index = 0;
 	//
 	//	//! Structures used for OR Filters

--- a/test/optimizer/pushdown/issue_16104.test
+++ b/test/optimizer/pushdown/issue_16104.test
@@ -1,0 +1,15 @@
+# name: test/optimizer/pushdown/issue_16104.test
+# description: Test expressions in filter preserve the order in Push Down
+# group: [pushdown]
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+WITH random_data AS (
+    SELECT random() * 2 AS col_double
+    FROM generate_series(1, 100)
+)
+SELECT *
+FROM random_data
+WHERE abs(col_double) < 1 AND acos(col_double) > 0;


### PR DESCRIPTION
This PR fixes #16104.