### PR TITLE
[Dev] MultiFileReader fix InternalError in CreateFilterMap

### DIFF
--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -508,14 +508,14 @@ void MultiFileReader::CreateMapping(const string &file_name,
 	// copy global columns and inject any different defaults
 	CreateColumnMapping(file_name, local_columns, global_columns, global_column_ids, reader_data, bind_data,
 	                    initial_file, global_state);
-	CreateFilterMap(global_columns, filters, reader_data, global_state);
+	CreateFilterMap(global_column_ids, filters, reader_data, global_state);
 }
 
-void MultiFileReader::CreateFilterMap(const vector<MultiFileReaderColumnDefinition> &global_columns,
+void MultiFileReader::CreateFilterMap(const vector<ColumnIndex> &global_column_ids,
                                       optional_ptr<TableFilterSet> filters, MultiFileReaderData &reader_data,
                                       optional_ptr<MultiFileReaderGlobalState> global_state) {
 	if (filters) {
-		auto filter_map_size = global_columns.size();
+		auto filter_map_size = global_column_ids.size();
 		if (global_state) {
 			filter_map_size += global_state->extra_columns.size();
 		}

--- a/src/include/duckdb/common/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file_reader.hpp
@@ -168,7 +168,7 @@ struct MultiFileFilterEntry {
 struct MultiFileConstantEntry {
 	MultiFileConstantEntry(idx_t column_id, Value value_p) : column_id(column_id), value(std::move(value_p)) {
 	}
-	//! The column id to apply the constant value to
+	//! The (global) column id to apply the constant value to
 	idx_t column_id;
 	//! The constant value
 	Value value;
@@ -273,7 +273,7 @@ struct MultiFileReader {
 	                                      const string &initial_file, const MultiFileReaderBindData &options,
 	                                      optional_ptr<MultiFileReaderGlobalState> global_state);
 	//! Populated the filter_map
-	DUCKDB_API virtual void CreateFilterMap(const vector<MultiFileReaderColumnDefinition> &global_columns,
+	DUCKDB_API virtual void CreateFilterMap(const vector<ColumnIndex> &global_column_ids,
 	                                        optional_ptr<TableFilterSet> filters, MultiFileReaderData &reader_data,
 	                                        optional_ptr<MultiFileReaderGlobalState> global_state);
 

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -323,3 +323,26 @@ query III
 SELECT * FROM read_parquet('__TEST_DIR__/15504.parquet', schema=map { 0: { name: 'id', type: 'int32', default_value: NULL }, 1: { name: 'arr', type: 'varchar[]', default_value: NULL }, 2: { name: 's', type: 'STRUCT(key INT, v1 TEXT, v2 TEXT)', default_value: NULL } });
 ----
 1	[a, b, c]	{'key': 1, 'v1': a, 'v2': b}
+
+# issue 16094
+statement ok
+copy (
+	select
+		x
+	from generate_series(1,100) as g(x)
+) to '__TEST_DIR__/16094.parquet'
+with (
+	field_ids {x: 1}
+);
+
+statement ok
+select
+	x,
+	filename
+from read_parquet(
+	'__TEST_DIR__/16094.parquet',
+	schema=map {
+		1: {name: 'x', type: 'int', default_value: NULL}
+	},
+	filename=True
+) where x = 1;


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb/issues/16094

First this was using `global_columns`, this list of columns is what the Reader is aware of, in this case the Parquet reader.
This list is influenced by the `schema` parameter.

`global_column_ids` comes from the `TableFunctionInitInput`, and will also contain artificial/generated columns like "filename"