### PR TITLE
Use aws s3api put-object to avoid override

### DIFF
--- a/scripts/extension-upload-single.sh
+++ b/scripts/extension-upload-single.sh
@@ -65,7 +65,7 @@ if [ -z "$AWS_ACCESS_KEY_ID" ]; then
 fi
 
 # Set dry run unless guard var is set
-DRY_RUN_PARAM="--dryrun"
+DRY_RUN_PARAM="--if-match '1234567890abcdef'"
 if [ "$DUCKDB_DEPLOY_SCRIPT_MODE" == "for_real" ]; then
   DRY_RUN_PARAM=""
 fi

--- a/scripts/extension-upload-single.sh
+++ b/scripts/extension-upload-single.sh
@@ -78,17 +78,17 @@ if [[ $7 = 'true' ]]; then
   fi
 
   if [[ $4 == wasm* ]]; then
-    aws s3api put-object --bucket s3://$5 --key $1/$2/$3/$4/$1.duckdb_extension.wasm --body $1.duckdb_extension.wasm $DRY_RUN_PARAM --content-encoding br --content-type="application/wasm" --if-none-match '*'
+    aws s3api put-object --bucket $5 --key $1/$2/$3/$4/$1.duckdb_extension.wasm --body $1.duckdb_extension.wasm $DRY_RUN_PARAM --content-encoding br --content-type="application/wasm" --if-none-match '*'
   else
-    aws s3api put-object --bucket s3://$5 --key $1/$2/$3/$4/$1.duckdb_extension.gz --body $1.duckdb_extension.gz $DRY_RUN_PARAM --if-none-match '*'
+    aws s3api put-object --bucket $5 --key $1/$2/$3/$4/$1.duckdb_extension.gz --body $1.duckdb_extension.gz $DRY_RUN_PARAM --if-none-match '*'
   fi
 fi
 
 # upload to latest version
 if [[ $6 = 'true' ]]; then
   if [[ $4 == wasm* ]]; then
-    aws s3api put-object --bucket s3://$5 --key $3/$4/$1.duckdb_extension.wasm --body $1.duckdb_extension.wasm $DRY_RUN_PARAM --content-encoding br --content-type="application/wasm" --if-none-match '*'
+    aws s3api put-object --bucket $5 --key $3/$4/$1.duckdb_extension.wasm --body $1.duckdb_extension.wasm $DRY_RUN_PARAM --content-encoding br --content-type="application/wasm" --if-none-match '*'
   else
-    aws s3api put-object --bucket s3://$5 --key $3/$4/$1.duckdb_extension.gz --body $1.duckdb_extension.gz $DRY_RUN_PARAM --if-none-match '*'
+    aws s3api put-object --bucket $5 --key $3/$4/$1.duckdb_extension.gz --body $1.duckdb_extension.gz $DRY_RUN_PARAM --if-none-match '*'
   fi
 fi

--- a/scripts/extension-upload-single.sh
+++ b/scripts/extension-upload-single.sh
@@ -78,17 +78,17 @@ if [[ $7 = 'true' ]]; then
   fi
 
   if [[ $4 == wasm* ]]; then
-    aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.wasm $DRY_RUN_PARAM --acl public-read --content-encoding br --content-type="application/wasm"
+    aws s3api put-object --bucket s3://$5 --key $1/$2/$3/$4/$1.duckdb_extension.wasm --body $1.duckdb_extension.wasm $DRY_RUN_PARAM --content-encoding br --content-type="application/wasm" --if-none-match '*'
   else
-    aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.gz $DRY_RUN_PARAM --acl public-read
+    aws s3api put-object --bucket s3://$5 --key $1/$2/$3/$4/$1.duckdb_extension.gz --body $1.duckdb_extension.gz $DRY_RUN_PARAM --if-none-match '*'
   fi
 fi
 
 # upload to latest version
 if [[ $6 = 'true' ]]; then
   if [[ $4 == wasm* ]]; then
-    aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.wasm $DRY_RUN_PARAM --acl public-read --content-encoding br --content-type="application/wasm"
+    aws s3api put-object --bucket s3://$5 --key $3/$4/$1.duckdb_extension.wasm --body $1.duckdb_extension.wasm $DRY_RUN_PARAM --content-encoding br --content-type="application/wasm" --if-none-match '*'
   else
-    aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.gz $DRY_RUN_PARAM --acl public-read
+    aws s3api put-object --bucket s3://$5 --key $3/$4/$1.duckdb_extension.gz --body $1.duckdb_extension.gz $DRY_RUN_PARAM --if-none-match '*'
   fi
 fi

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -61,5 +61,5 @@ python3 -m pip install awscli
 for var in "${@: 2}"
 do
     filename=$(basename -- "$var")
-    aws s3api put-object --bucket s3://duckdb-staging --key $TARGET/$GITHUB_REPOSITORY/$FOLDER/$filename --body $var $DRY_RUN_PARAM --if-none-match '*' --region us-east-2
+    aws s3api put-object --bucket duckdb-staging --key $TARGET/$GITHUB_REPOSITORY/$FOLDER/$filename --body $var $DRY_RUN_PARAM --if-none-match '*' --region us-east-2
 done

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -60,5 +60,6 @@ python3 -m pip install awscli
 
 for var in "${@: 2}"
 do
-    aws s3 cp $var s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/$FOLDER/ $DRY_RUN_PARAM --region us-east-2
+    filename=$(basename -- "$var")
+    aws s3api put-object --bucket s3://duckdb-staging --key $TARGET/$GITHUB_REPOSITORY/$FOLDER/$filename --body $var $DRY_RUN_PARAM --if-none-match '*' --region us-east-2
 done

--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -25,12 +25,12 @@ DRY_RUN_PARAM=""
 # dryrun if repo is not duckdb/duckdb
 if [ "$GITHUB_REPOSITORY" != "duckdb/duckdb" ]; then
   echo "Repository is $GITHUB_REPOSITORY (not duckdb/duckdb)"
-  DRY_RUN_PARAM="--dryrun"
+  DRY_RUN_PARAM="--if-match '1234567890abcdef'"
 fi
 # dryrun if we are not in main
 if [ "$GITHUB_REF" != "refs/heads/main" ]; then
   echo "git ref is $GITHUB_REF (not refs/heads/main)"
-  DRY_RUN_PARAM="--dryrun"
+  DRY_RUN_PARAM="--if-match '1234567890abcdef'"
 fi
 
 if [ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
@@ -41,7 +41,7 @@ fi
 # dryrun if AWS key is not set
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then
   echo "No access key available"
-  DRY_RUN_PARAM="--dryrun"
+  DRY_RUN_PARAM="--if-match '1234567890abcdef'"
 fi
 
 


### PR DESCRIPTION
This changes (for the better?) two different things:
* extensions stored on S3 are not publicly reachable (since I believe that's handled via CDN)
* `aws s3api put-object --if-none-match '*'` is used instead of `aws s3 cp`, that will override objects

This is clearly untested, but strategy to check this is working as intended would be, for the first part just merging and checking if nightly extensions are reachable via the extension endpoint (and if not changing CDN settings), and for the second part:
* merge this in main
* trigger InvokeCI this twice with the same commit, checking what happens
* first run is expected to be successful
* second run is expected to be also successful, but don't upload any artifact (this can be checked with timestamps AND looking at the logs)