### PR TITLE
Use ColumnSegment::FilterSelection and SelectionVector for filtering in Parquet scans

### DIFF
--- a/extension/parquet/decoder/dictionary_decoder.cpp
+++ b/extension/parquet/decoder/dictionary_decoder.cpp
@@ -34,8 +34,7 @@ void DictionaryDecoder::InitializePage() {
 	block->inc(block->len);
 }
 
-void DictionaryDecoder::ConvertDictToSelVec(uint32_t *offsets, const SelectionVector &rows, idx_t count,
-                                            idx_t result_offset) {
+void DictionaryDecoder::ConvertDictToSelVec(uint32_t *offsets, const SelectionVector &rows, idx_t count) {
 	D_ASSERT(count <= STANDARD_VECTOR_SIZE);
 	for (idx_t idx = 0; idx < count; idx++) {
 		auto row_idx = rows.get_index(idx);
@@ -73,7 +72,7 @@ void DictionaryDecoder::Read(uint8_t *defines, idx_t read_count, Vector &result,
 		// for the valid entries - decode the offsets
 		offset_buffer.resize(reader.reader.allocator, sizeof(uint32_t) * valid_count);
 		dict_decoder->GetBatch<uint32_t>(offset_buffer.ptr, valid_count);
-		ConvertDictToSelVec(reinterpret_cast<uint32_t *>(offset_buffer.ptr), valid_sel, valid_count, result_offset);
+		ConvertDictToSelVec(reinterpret_cast<uint32_t *>(offset_buffer.ptr), valid_sel, valid_count);
 	}
 #ifdef DEBUG
 	dictionary_selection_vector.Verify(read_count, dictionary_size + 1);

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -40,8 +40,6 @@ using duckdb_parquet::PageHeader;
 using duckdb_parquet::SchemaElement;
 using duckdb_parquet::Type;
 
-typedef std::bitset<STANDARD_VECTOR_SIZE> parquet_filter_t;
-
 enum class ColumnEncoding {
 	INVALID,
 	DICTIONARY,

--- a/extension/parquet/include/decoder/dictionary_decoder.hpp
+++ b/extension/parquet/include/decoder/dictionary_decoder.hpp
@@ -26,7 +26,7 @@ public:
 	void Skip(uint8_t *defines, idx_t skip_count);
 
 private:
-	void ConvertDictToSelVec(uint32_t *offsets, const SelectionVector &rows, idx_t count, idx_t result_offset);
+	void ConvertDictToSelVec(uint32_t *offsets, const SelectionVector &rows, idx_t count);
 
 private:
 	ColumnReader &reader;


### PR DESCRIPTION
This is faster - it has been optimized and the result of the filtering stage needs to be a selection vector anyway. It also allows us to delete a bunch of code.