### PR TITLE
Adaptive table filter: initialize filter order based on heuristics

### DIFF
--- a/src/execution/adaptive_filter.cpp
+++ b/src/execution/adaptive_filter.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/optimizer/expression_heuristics.hpp"
 #include "duckdb/execution/adaptive_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/common/numeric_utils.hpp"
@@ -23,11 +24,10 @@ AdaptiveFilter::AdaptiveFilter(const Expression &expr) : observe_interval(10), e
 
 AdaptiveFilter::AdaptiveFilter(const TableFilterSet &table_filters)
     : observe_interval(10), execute_interval(20), warmup(true) {
-	for (idx_t idx = 0; idx < table_filters.filters.size(); idx++) {
-		permutation.push_back(idx);
+	permutation = ExpressionHeuristics::GetInitialOrder(table_filters);
+	for (idx_t idx = 1; idx < table_filters.filters.size(); idx++) {
 		swap_likeliness.push_back(100);
 	}
-	swap_likeliness.pop_back();
 	right_random_border = 100 * (table_filters.filters.size() - 1);
 }
 

--- a/src/include/duckdb/optimizer/expression_heuristics.hpp
+++ b/src/include/duckdb/optimizer/expression_heuristics.hpp
@@ -12,6 +12,8 @@
 #include "duckdb/common/unordered_map.hpp"
 
 namespace duckdb {
+class TableFilterSet;
+class TableFilter;
 
 class ExpressionHeuristics : public LogicalOperatorVisitor {
 public:
@@ -27,27 +29,23 @@ public:
 	//! Reorder the expressions of a filter
 	void ReorderExpressions(vector<unique_ptr<Expression>> &expressions);
 	//! Return the cost of an expression
-	idx_t Cost(Expression &expr);
+	static idx_t Cost(Expression &expr);
+
+	static vector<idx_t> GetInitialOrder(const TableFilterSet &table_filters);
 
 	unique_ptr<Expression> VisitReplace(BoundConjunctionExpression &expr, unique_ptr<Expression> *expr_ptr) override;
 	//! Override this function to search for filter operators
 	void VisitOperator(LogicalOperator &op) override;
 
 private:
-	unordered_map<std::string, idx_t> function_costs = {
-	    {"+", 5},       {"-", 5},    {"&", 5},          {"#", 5},
-	    {">>", 5},      {"<<", 5},   {"abs", 5},        {"*", 10},
-	    {"%", 10},      {"/", 15},   {"date_part", 20}, {"year", 20},
-	    {"round", 100}, {"~~", 200}, {"!~~", 200},      {"regexp_matches", 200},
-	    {"||", 200}};
-
-	idx_t ExpressionCost(BoundBetweenExpression &expr);
-	idx_t ExpressionCost(BoundCaseExpression &expr);
-	idx_t ExpressionCost(BoundCastExpression &expr);
-	idx_t ExpressionCost(BoundComparisonExpression &expr);
-	idx_t ExpressionCost(BoundConjunctionExpression &expr);
-	idx_t ExpressionCost(BoundFunctionExpression &expr);
-	idx_t ExpressionCost(BoundOperatorExpression &expr, ExpressionType expr_type);
-	idx_t ExpressionCost(PhysicalType return_type, idx_t multiplier);
+	static idx_t ExpressionCost(BoundBetweenExpression &expr);
+	static idx_t ExpressionCost(BoundCaseExpression &expr);
+	static idx_t ExpressionCost(BoundCastExpression &expr);
+	static idx_t ExpressionCost(BoundComparisonExpression &expr);
+	static idx_t ExpressionCost(BoundConjunctionExpression &expr);
+	static idx_t ExpressionCost(BoundFunctionExpression &expr);
+	static idx_t ExpressionCost(BoundOperatorExpression &expr, ExpressionType expr_type);
+	static idx_t ExpressionCost(PhysicalType return_type, idx_t multiplier);
+	static idx_t Cost(TableFilter &filter);
 };
 } // namespace duckdb

--- a/src/include/duckdb/planner/table_filter.hpp
+++ b/src/include/duckdb/planner/table_filter.hpp
@@ -13,7 +13,7 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/common/types.hpp"
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/map.hpp"
 #include "duckdb/planner/column_binding.hpp"
 #include "duckdb/common/column_index.hpp"
 
@@ -79,7 +79,7 @@ public:
 
 class TableFilterSet {
 public:
-	unordered_map<idx_t, unique_ptr<TableFilter>> filters;
+	map<idx_t, unique_ptr<TableFilter>> filters;
 
 public:
 	void PushFilter(const ColumnIndex &col_idx, unique_ptr<TableFilter> filter);

--- a/src/include/duckdb/storage/serialization/nodes.json
+++ b/src/include/duckdb/storage/serialization/nodes.json
@@ -535,7 +535,7 @@
       {
         "id": 100,
         "name": "filters",
-        "type": "unordered_map<idx_t, TableFilter*>"
+        "type": "map<idx_t, TableFilter*>"
       }
     ],
     "pointer_type": "none"

--- a/src/storage/serialization/serialize_nodes.cpp
+++ b/src/storage/serialization/serialize_nodes.cpp
@@ -647,12 +647,12 @@ StrpTimeFormat StrpTimeFormat::Deserialize(Deserializer &deserializer) {
 }
 
 void TableFilterSet::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<unordered_map<idx_t, unique_ptr<TableFilter>>>(100, "filters", filters);
+	serializer.WritePropertyWithDefault<map<idx_t, unique_ptr<TableFilter>>>(100, "filters", filters);
 }
 
 TableFilterSet TableFilterSet::Deserialize(Deserializer &deserializer) {
 	TableFilterSet result;
-	deserializer.ReadPropertyWithDefault<unordered_map<idx_t, unique_ptr<TableFilter>>>(100, "filters", result.filters);
+	deserializer.ReadPropertyWithDefault<map<idx_t, unique_ptr<TableFilter>>>(100, "filters", result.filters);
 	return result;
 }
 


### PR DESCRIPTION
Similar to how we re-order filters in `WHERE` clauses - this should provide a better start for table filters