### PR TITLE
[Dev] Fix output (long lines > 333 characters) getting truncated in shell

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -546,9 +546,6 @@ void ShellState::UTF8WidthPrint(FILE *pOut, idx_t w, const string &str, bool rig
 	int i;
 	int n;
 	int aw = w < 0 ? -w : w;
-	char zBuf[1000];
-	if (aw > (int)sizeof(zBuf) / 3)
-		aw = (int)sizeof(zBuf) / 3;
 #ifdef HAVE_LINENOISE
 	i = linenoiseGetRenderPosition(zUtf, strlen(zUtf), aw, &n);
 	if (i < 0)


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb-web/issues/4734

`zBuf` was probably used at some point, but it's now entirely unused, only used to truncate the output for no reason, causing all lines to get capped to 333 characters.