### PR TITLE
Use Adaptive Filters in the Parquet reader

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -16,7 +16,6 @@
 #include "duckdb/common/multi_file_reader_options.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/storage/table/scan_filter.hpp"
 #include "column_reader.hpp"
 #include "parquet_file_metadata_cache.hpp"
 #include "parquet_rle_bp_decoder.hpp"

--- a/extension/parquet/include/reader/string_column_reader.hpp
+++ b/extension/parquet/include/reader/string_column_reader.hpp
@@ -31,8 +31,8 @@ public:
 	idx_t fixed_width_string_length;
 
 public:
-	static uint32_t VerifyString(const char *str_data, uint32_t str_len, const bool isVarchar);
-	uint32_t VerifyString(const char *str_data, uint32_t str_len);
+	static void VerifyString(const char *str_data, uint32_t str_len, const bool isVarchar);
+	void VerifyString(const char *str_data, uint32_t str_len);
 
 protected:
 	void Plain(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values, idx_t result_offset,

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -854,9 +854,6 @@ void ParquetReader::InitializeScan(ClientContext &context, ParquetReaderScanStat
 
 		state.file_handle = fs.OpenFile(file_handle->path, flags);
 	}
-	state.scan_filters.clear();
-	state.adaptive_filter.reset();
-
 	state.thrift_file_proto = CreateThriftFileProtocol(allocator, *state.file_handle, state.prefetch_mode);
 	state.root_reader = CreateReader(context);
 	state.define_buf.resize(allocator, STANDARD_VECTOR_SIZE);

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -979,18 +979,28 @@ bool ParquetReader::ScanInternal(ParquetReaderScanState &state, DataChunk &resul
 		vector<bool> need_to_read(reader_data.column_ids.size(), true);
 
 		state.sel.Initialize(nullptr);
+		if (!adaptive_filter) {
+			adaptive_filter = make_uniq<AdaptiveFilter>(*reader_data.filters);
+			for(auto &entry : reader_data.filters->filters) {
+				scan_filters.emplace_back(entry.first, *entry.second);
+			}
+		}
+
 		// first load the columns that are used in filters
-		for (auto &filter_col : reader_data.filters->filters) {
+		// auto filter_state = adaptive_filter->BeginFilter();
+		for(idx_t i = 0; i < scan_filters.size(); i++) {
+		//for (auto &filter_col : reader_data.filters->filters) {
 			if (filter_count == 0) {
 				// if no rows are left we can stop checking filters
 				break;
 			}
-			auto filter_entry = reader_data.filter_map[filter_col.first];
+			auto &scan_filter = scan_filters[i];
+			auto filter_entry = reader_data.filter_map[scan_filter.filter_idx];
 			if (filter_entry.is_constant) {
 				// this is a constant vector, look for the constant
 				auto &constant = reader_data.constant_map[filter_entry.index].value;
 				Vector constant_vector(constant);
-				ApplyFilter(constant_vector, *filter_col.second, scan_count, state.sel, filter_count);
+				ApplyFilter(constant_vector, scan_filter.filter, scan_count, state.sel, filter_count);
 			} else {
 				auto id = filter_entry.index;
 				auto file_col_idx = reader_data.column_ids[id];
@@ -999,10 +1009,11 @@ bool ParquetReader::ScanInternal(ParquetReaderScanState &state, DataChunk &resul
 				auto &result_vector = result.data[result_idx];
 				auto &child_reader = root_reader.GetChildReader(file_col_idx);
 				child_reader.Read(scan_count, define_ptr, repeat_ptr, result_vector);
-				ApplyFilter(result_vector, *filter_col.second, scan_count, state.sel, filter_count);
+				ApplyFilter(result_vector, scan_filter.filter, scan_count, state.sel, filter_count);
 				need_to_read[id] = false;
 			}
 		}
+		// adaptive_filter->EndFilter(filter_state);
 
 		// we still may have to read some cols
 		for (idx_t col_idx = 0; col_idx < reader_data.column_ids.size(); col_idx++) {


### PR DESCRIPTION
This allows filters to be re-ordered dynamically similar to our table scan