### PR TITLE
Parquet reader: only set invalid entry in the dictionary when the column has defines

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -286,7 +286,7 @@ void ColumnReader::PrepareRead(optional_ptr<const TableFilter> filter) {
 		if (dictionary_size < 0) {
 			throw std::runtime_error("Invalid dictionary page header (num_values < 0)");
 		}
-		dictionary_decoder.InitializeDictionary(dictionary_size, filter);
+		dictionary_decoder.InitializeDictionary(dictionary_size, filter, HasDefines());
 		break;
 	}
 	default:

--- a/extension/parquet/include/decoder/dictionary_decoder.hpp
+++ b/extension/parquet/include/decoder/dictionary_decoder.hpp
@@ -20,7 +20,7 @@ public:
 	explicit DictionaryDecoder(ColumnReader &reader);
 
 public:
-	void InitializeDictionary(idx_t dictionary_size, optional_ptr<const TableFilter> filter);
+	void InitializeDictionary(idx_t dictionary_size, optional_ptr<const TableFilter> filter, bool has_defines);
 	void InitializePage();
 	idx_t Read(uint8_t *defines, idx_t read_count, Vector &result, idx_t result_offset);
 	void Skip(uint8_t *defines, idx_t skip_count);
@@ -48,6 +48,7 @@ private:
 	unique_ptr<Vector> dictionary;
 	unsafe_unique_array<bool> filter_result;
 	idx_t filter_count;
+	bool can_have_nulls;
 	string dictionary_id;
 };
 


### PR DESCRIPTION
Similar to https://github.com/duckdb/duckdb/pull/16142 - but now using only whether or not a column has defines instead of trying to do it dynamically when a `NULL` value is encountered