### PR TITLE
Hopefully fixing ci runs

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -105,7 +105,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: duckdb-binaries-linux
+        name: duckdb-binaries-linux-${{ matrix.config.arch }}
         path: |
           libduckdb-linux-${{ matrix.config.arch }}.zip
           duckdb_cli-linux-${{ matrix.config.arch }}.zip


### PR DESCRIPTION
I seem to recall that it used to be fine to re-use an artifact name but this seems to be no longer the case :/