### PR TITLE
Add uniq_ptr_cast for interpreted benchmark.

### DIFF
--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -374,7 +374,7 @@ unique_ptr<QueryResult> InterpretedBenchmark::RunLoadQuery(InterpretedBenchmarkS
 		}
 		result = state.con.Query(load_query);
 	}
-	return result;
+	return unique_ptr_cast<MaterializedQueryResult, QueryResult>(std::move(result));
 }
 
 unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfiguration &config) {


### PR DESCRIPTION
Weekly Regression Runner couldn't build the Benchmark runner. Came down to a uniq_ptr_cast issue. 

Failing workflow https://github.com/duckdblabs/duckdb-internal/actions/runs/13231781654