### PR TITLE
Internal exceptions also invalidate the DB

### DIFF
--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -32,7 +32,7 @@ string Exception::ToJSON(ExceptionType type, const string &message) {
 string Exception::ToJSON(ExceptionType type, const string &message, const unordered_map<string, string> &extra_info) {
 #ifndef DUCKDB_DEBUG_STACKTRACE
 	// by default we only enable stack traces for internal exceptions
-	if (type == ExceptionType::INTERNAL)
+	if (type == ExceptionType::INTERNAL || type == ExceptionType::FATAL)
 #endif
 	{
 		auto extended_extra_info = extra_info;

--- a/src/common/exception.cpp
+++ b/src/common/exception.cpp
@@ -71,6 +71,7 @@ bool Exception::InvalidatesTransaction(ExceptionType exception_type) {
 
 bool Exception::InvalidatesDatabase(ExceptionType exception_type) {
 	switch (exception_type) {
+	case ExceptionType::INTERNAL:
 	case ExceptionType::FATAL:
 		return true;
 	default:

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -249,7 +249,7 @@ ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success,
 		}
 	} catch (std::exception &ex) {
 		error = ErrorData(ex);
-		if (Exception::InvalidatesDatabase(error.Type()) || error.Type() == ExceptionType::INTERNAL) {
+		if (Exception::InvalidatesDatabase(error.Type())) {
 			auto &db_inst = DatabaseInstance::GetDatabase(*this);
 			ValidChecker::Invalidate(db_inst, error.RawMessage());
 		}
@@ -607,7 +607,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 			}
 		} else if (!Exception::InvalidatesTransaction(error.Type())) {
 			invalidate_transaction = false;
-		} else if (Exception::InvalidatesDatabase(error.Type()) || error.Type() == ExceptionType::INTERNAL) {
+		} else if (Exception::InvalidatesDatabase(error.Type())) {
 			// fatal exceptions invalidate the entire database
 			auto &db_instance = DatabaseInstance::GetDatabase(*this);
 			ValidChecker::Invalidate(db_instance, error.RawMessage());

--- a/src/main/profiling_info.cpp
+++ b/src/main/profiling_info.cpp
@@ -98,7 +98,7 @@ void ProfilingInfo::ResetMetrics() {
 		case MetricsType::EXTRA_INFO:
 			break;
 		default:
-			throw Exception(ExceptionType::INTERNAL, "MetricsType" + EnumUtil::ToString(metric) + "not implemented");
+			throw InternalException("MetricsType" + EnumUtil::ToString(metric) + "not implemented");
 		}
 	}
 }

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -101,6 +101,7 @@ unique_ptr<DataChunk> StreamQueryResult::FetchInternal(ClientContextLock &lock) 
 		SetError(std::move(error));
 	} catch (...) { // LCOV_EXCL_START
 		SetError(ErrorData("Unhandled exception in FetchInternal"));
+		ValidChecker::Invalidate(DatabaseInstance::GetDatabase(*context), "Unhandled exception in FetchInternal");
 	} // LCOV_EXCL_STOP
 	context->CleanupInternal(lock, this, invalidate_query);
 	return nullptr;

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -101,7 +101,6 @@ unique_ptr<DataChunk> StreamQueryResult::FetchInternal(ClientContextLock &lock) 
 		SetError(std::move(error));
 	} catch (...) { // LCOV_EXCL_START
 		SetError(ErrorData("Unhandled exception in FetchInternal"));
-		ValidChecker::Invalidate(DatabaseInstance::GetDatabase(*context), "Unhandled exception in FetchInternal");
 	} // LCOV_EXCL_STOP
 	context->CleanupInternal(lock, this, invalidate_query);
 	return nullptr;


### PR DESCRIPTION
This PR ensures consistency in how internal exceptions behave by making them invalidate the database and marking them as invalidating exceptions. Also, it adds stack traces for FATAL exceptions.

---
One thing I also noticed is, that there are [two](https://github.com/motherduckdb/public-duckdb/blob/ffa89b01df7307c1a7f4932e4ccda51371baec16/src/main/stream_query_result.cpp#L95) [instances](https://github.com/motherduckdb/public-duckdb/blob/ffa89b01df7307c1a7f4932e4ccda51371baec16/src/main/client_context.cpp#L901) of the pattern below in DuckDB. Is this something we can remove, or is it essential in these two places. It was, at least to me, not obvious, why we need those. Even if a verification step throws a `ExceptionType::FATAL`, it would not do any harm to invalidate the DB in this case, right?

```cpp
if (!config.query_verification_enabled) {
		auto &db_instance = DatabaseInstance::GetDatabase(*this);
		ValidChecker::Invalidate(db_instance, error.RawMessage());
}
```
