### PR TITLE
[Python][Dev] Bump the minimum pybind11 version from `2.6` to `2.9`

### DIFF
--- a/tools/pythonpkg/requirements-dev.txt
+++ b/tools/pythonpkg/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy>=1.14
-pybind11>=2.6.0
+pybind11>=2.9.0
 setuptools_scm>=6.3
 setuptools>=58
 pytest


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb/issues/16101