### PR TITLE
Parquet Reader: Split `CreateReader` into two separate stages - `ParseSchema` and `CreateReader`

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -128,6 +128,10 @@ void ColumnReader::RegisterPrefetch(ThriftFileTransport &transport, bool allow_m
 	}
 }
 
+unique_ptr<BaseStatistics> ColumnReader::Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) {
+	return Schema().Stats(reader, row_group_idx_p, columns);
+}
+
 uint64_t ColumnReader::TotalCompressedSize() {
 	if (!chunk) {
 		return 0;

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -160,9 +160,6 @@ idx_t ColumnReader::GroupRowsAvailable() {
 	return group_rows_available;
 }
 
-unique_ptr<BaseStatistics> ColumnReader::Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) {
-}
-
 void ColumnReader::PlainSkip(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values) {
 	throw NotImplementedException("PlainSkip not implemented");
 }

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -178,8 +178,8 @@ void ColumnReader::Plain(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defi
 }
 
 void ColumnReader::InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) {
-	D_ASSERT(FileIdx() < columns.size());
-	chunk = &columns[FileIdx()];
+	D_ASSERT(ColumnIndex() < columns.size());
+	chunk = &columns[ColumnIndex()];
 	protocol = &protocol_p;
 	D_ASSERT(chunk);
 	D_ASSERT(chunk->__isset.meta_data);

--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -105,9 +105,9 @@ const uint64_t ParquetDecodeUtils::BITPACK_MASKS_SIZE = sizeof(ParquetDecodeUtil
 const uint8_t ParquetDecodeUtils::BITPACK_DLEN = 8;
 
 ColumnReader::ColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema_p)
-    : column_schema(schema_p), reader(reader), page_rows_available(0), dictionary_decoder(*this), delta_binary_packed_decoder(*this),
-      rle_decoder(*this), delta_length_byte_array_decoder(*this), delta_byte_array_decoder(*this),
-      byte_stream_split_decoder(*this) {
+    : column_schema(schema_p), reader(reader), page_rows_available(0), dictionary_decoder(*this),
+      delta_binary_packed_decoder(*this), rle_decoder(*this), delta_length_byte_array_decoder(*this),
+      delta_byte_array_decoder(*this), byte_stream_split_decoder(*this) {
 }
 
 ColumnReader::~ColumnReader() {
@@ -120,7 +120,6 @@ Allocator &ColumnReader::GetAllocator() {
 ParquetReader &ColumnReader::Reader() {
 	return reader;
 }
-
 
 void ColumnReader::RegisterPrefetch(ThriftFileTransport &transport, bool allow_merge) {
 	if (chunk) {
@@ -674,14 +673,11 @@ template <class T>
 unique_ptr<ColumnReader> CreateDecimalReader(ParquetReader &reader, const ParquetColumnSchema &schema) {
 	switch (schema.type.InternalType()) {
 	case PhysicalType::INT16:
-		return make_uniq<TemplatedColumnReader<int16_t, TemplatedParquetValueConversion<T>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<int16_t, TemplatedParquetValueConversion<T>>>(reader, schema);
 	case PhysicalType::INT32:
-		return make_uniq<TemplatedColumnReader<int32_t, TemplatedParquetValueConversion<T>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<int32_t, TemplatedParquetValueConversion<T>>>(reader, schema);
 	case PhysicalType::INT64:
-		return make_uniq<TemplatedColumnReader<int64_t, TemplatedParquetValueConversion<T>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<int64_t, TemplatedParquetValueConversion<T>>>(reader, schema);
 	default:
 		throw NotImplementedException("Unimplemented internal type for CreateDecimalReader");
 	}
@@ -692,70 +688,56 @@ unique_ptr<ColumnReader> ColumnReader::CreateReader(ParquetReader &reader, const
 	case LogicalTypeId::BOOLEAN:
 		return make_uniq<BooleanColumnReader>(reader, schema);
 	case LogicalTypeId::UTINYINT:
-		return make_uniq<TemplatedColumnReader<uint8_t, TemplatedParquetValueConversion<uint32_t>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<uint8_t, TemplatedParquetValueConversion<uint32_t>>>(reader, schema);
 	case LogicalTypeId::USMALLINT:
-		return make_uniq<TemplatedColumnReader<uint16_t, TemplatedParquetValueConversion<uint32_t>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<uint16_t, TemplatedParquetValueConversion<uint32_t>>>(reader, schema);
 	case LogicalTypeId::UINTEGER:
-		return make_uniq<TemplatedColumnReader<uint32_t, TemplatedParquetValueConversion<uint32_t>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<uint32_t, TemplatedParquetValueConversion<uint32_t>>>(reader, schema);
 	case LogicalTypeId::UBIGINT:
-		return make_uniq<TemplatedColumnReader<uint64_t, TemplatedParquetValueConversion<uint64_t>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<uint64_t, TemplatedParquetValueConversion<uint64_t>>>(reader, schema);
 	case LogicalTypeId::TINYINT:
-		return make_uniq<TemplatedColumnReader<int8_t, TemplatedParquetValueConversion<int32_t>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<int8_t, TemplatedParquetValueConversion<int32_t>>>(reader, schema);
 	case LogicalTypeId::SMALLINT:
-		return make_uniq<TemplatedColumnReader<int16_t, TemplatedParquetValueConversion<int32_t>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<int16_t, TemplatedParquetValueConversion<int32_t>>>(reader, schema);
 	case LogicalTypeId::INTEGER:
-		return make_uniq<TemplatedColumnReader<int32_t, TemplatedParquetValueConversion<int32_t>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<int32_t, TemplatedParquetValueConversion<int32_t>>>(reader, schema);
 	case LogicalTypeId::BIGINT:
-		return make_uniq<TemplatedColumnReader<int64_t, TemplatedParquetValueConversion<int64_t>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<int64_t, TemplatedParquetValueConversion<int64_t>>>(reader, schema);
 	case LogicalTypeId::FLOAT:
-		return make_uniq<TemplatedColumnReader<float, TemplatedParquetValueConversion<float>>>(
-		    reader, schema);
+		return make_uniq<TemplatedColumnReader<float, TemplatedParquetValueConversion<float>>>(reader, schema);
 	case LogicalTypeId::DOUBLE:
 		if (schema.type_info == ParquetExtraTypeInfo::DECIMAL_BYTE_ARRAY) {
 			return ParquetDecimalUtils::CreateReader(reader, schema);
 		}
-		return make_uniq<TemplatedColumnReader<double, TemplatedParquetValueConversion<double>>>(
-			reader, schema);
+		return make_uniq<TemplatedColumnReader<double, TemplatedParquetValueConversion<double>>>(reader, schema);
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
 		switch (schema.type_info) {
 		case ParquetExtraTypeInfo::IMPALA_TIMESTAMP:
-			return make_uniq<CallbackColumnReader<Int96, timestamp_t, ImpalaTimestampToTimestamp>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<Int96, timestamp_t, ImpalaTimestampToTimestamp>>(reader, schema);
 		case ParquetExtraTypeInfo::UNIT_MS:
-			return make_uniq<CallbackColumnReader<int64_t, timestamp_t, ParquetTimestampMsToTimestamp>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, timestamp_t, ParquetTimestampMsToTimestamp>>(reader, schema);
 		case ParquetExtraTypeInfo::UNIT_MICROS:
-			return make_uniq<CallbackColumnReader<int64_t, timestamp_t, ParquetTimestampMicrosToTimestamp>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, timestamp_t, ParquetTimestampMicrosToTimestamp>>(reader,
+			                                                                                                schema);
 		case ParquetExtraTypeInfo::UNIT_NS:
-			return make_uniq<CallbackColumnReader<int64_t, timestamp_t, ParquetTimestampNsToTimestamp>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, timestamp_t, ParquetTimestampNsToTimestamp>>(reader, schema);
 		default:
 			throw InternalException("TIMESTAMP requires type info");
 		}
 	case LogicalTypeId::TIMESTAMP_NS:
 		switch (schema.type_info) {
 		case ParquetExtraTypeInfo::IMPALA_TIMESTAMP:
-			return make_uniq<CallbackColumnReader<Int96, timestamp_ns_t, ImpalaTimestampToTimestampNS>>(
-			    reader, schema);
+			return make_uniq<CallbackColumnReader<Int96, timestamp_ns_t, ImpalaTimestampToTimestampNS>>(reader, schema);
 		case ParquetExtraTypeInfo::UNIT_MS:
-			return make_uniq<CallbackColumnReader<int64_t, timestamp_ns_t, ParquetTimestampMsToTimestampNs>>(
-			reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, timestamp_ns_t, ParquetTimestampMsToTimestampNs>>(reader,
+			                                                                                                 schema);
 		case ParquetExtraTypeInfo::UNIT_MICROS:
-			return make_uniq<CallbackColumnReader<int64_t, timestamp_ns_t, ParquetTimestampUsToTimestampNs>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, timestamp_ns_t, ParquetTimestampUsToTimestampNs>>(reader,
+			                                                                                                 schema);
 		case ParquetExtraTypeInfo::UNIT_NS:
-			return make_uniq<CallbackColumnReader<int64_t, timestamp_ns_t, ParquetTimestampNsToTimestampNs>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, timestamp_ns_t, ParquetTimestampNsToTimestampNs>>(reader,
+			                                                                                                 schema);
 		default:
 			throw InternalException("TIMESTAMP_NS requires type info");
 		}
@@ -764,28 +746,22 @@ unique_ptr<ColumnReader> ColumnReader::CreateReader(ParquetReader &reader, const
 	case LogicalTypeId::TIME:
 		switch (schema.type_info) {
 		case ParquetExtraTypeInfo::UNIT_MS:
-			return make_uniq<CallbackColumnReader<int32_t, dtime_t, ParquetIntToTimeMs>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int32_t, dtime_t, ParquetIntToTimeMs>>(reader, schema);
 		case ParquetExtraTypeInfo::UNIT_MICROS:
-			return make_uniq<CallbackColumnReader<int64_t, dtime_t, ParquetIntToTime>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, dtime_t, ParquetIntToTime>>(reader, schema);
 		case ParquetExtraTypeInfo::UNIT_NS:
-			return make_uniq<CallbackColumnReader<int64_t, dtime_t, ParquetIntToTimeNs>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, dtime_t, ParquetIntToTimeNs>>(reader, schema);
 		default:
 			throw InternalException("TIME requires type info");
 		}
 	case LogicalTypeId::TIME_TZ:
-			switch (schema.type_info) {
+		switch (schema.type_info) {
 		case ParquetExtraTypeInfo::UNIT_MS:
-			return make_uniq<CallbackColumnReader<int32_t, dtime_tz_t, ParquetIntToTimeMsTZ>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int32_t, dtime_tz_t, ParquetIntToTimeMsTZ>>(reader, schema);
 		case ParquetExtraTypeInfo::UNIT_MICROS:
-			return make_uniq<CallbackColumnReader<int64_t, dtime_tz_t, ParquetIntToTimeTZ>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, dtime_tz_t, ParquetIntToTimeTZ>>(reader, schema);
 		case ParquetExtraTypeInfo::UNIT_NS:
-			return make_uniq<CallbackColumnReader<int64_t, dtime_tz_t, ParquetIntToTimeNsTZ>>(
-				reader, schema);
+			return make_uniq<CallbackColumnReader<int64_t, dtime_tz_t, ParquetIntToTimeNsTZ>>(reader, schema);
 		default:
 			throw InternalException("TIME_TZ requires type info");
 		}

--- a/extension/parquet/decoder/byte_stream_split_decoder.cpp
+++ b/extension/parquet/decoder/byte_stream_split_decoder.cpp
@@ -21,12 +21,12 @@ void ByteStreamSplitDecoder::Read(uint8_t *defines, idx_t read_count, Vector &re
 
 	auto &allocator = reader.reader.allocator;
 	decoded_data_buffer.reset();
-	switch (reader.schema.type) {
-	case duckdb_parquet::Type::FLOAT:
+	switch (reader.Type().InternalType()) {
+	case PhysicalType::FLOAT:
 		decoded_data_buffer.resize(allocator, sizeof(float) * valid_count);
 		bss_decoder->GetBatch<float>(decoded_data_buffer.ptr, valid_count);
 		break;
-	case duckdb_parquet::Type::DOUBLE:
+	case PhysicalType::DOUBLE:
 		decoded_data_buffer.resize(allocator, sizeof(double) * valid_count);
 		bss_decoder->GetBatch<double>(decoded_data_buffer.ptr, valid_count);
 		break;
@@ -39,11 +39,11 @@ void ByteStreamSplitDecoder::Read(uint8_t *defines, idx_t read_count, Vector &re
 
 void ByteStreamSplitDecoder::Skip(uint8_t *defines, idx_t skip_count) {
 	idx_t valid_count = reader.GetValidCount(defines, skip_count);
-	switch (reader.schema.type) {
-	case duckdb_parquet::Type::FLOAT:
+	switch (reader.Type().InternalType()) {
+	case PhysicalType::FLOAT:
 		bss_decoder->Skip<float>(valid_count);
 		break;
-	case duckdb_parquet::Type::DOUBLE:
+	case PhysicalType::DOUBLE:
 		bss_decoder->Skip<double>(valid_count);
 		break;
 	default:

--- a/extension/parquet/decoder/byte_stream_split_decoder.cpp
+++ b/extension/parquet/decoder/byte_stream_split_decoder.cpp
@@ -21,12 +21,12 @@ void ByteStreamSplitDecoder::Read(uint8_t *defines, idx_t read_count, Vector &re
 
 	auto &allocator = reader.reader.allocator;
 	decoded_data_buffer.reset();
-	switch (reader.Type().InternalType()) {
-	case PhysicalType::FLOAT:
+	switch (reader.Schema().parquet_type) {
+	case duckdb_parquet::Type::FLOAT:
 		decoded_data_buffer.resize(allocator, sizeof(float) * valid_count);
 		bss_decoder->GetBatch<float>(decoded_data_buffer.ptr, valid_count);
 		break;
-	case PhysicalType::DOUBLE:
+	case duckdb_parquet::Type::DOUBLE:
 		decoded_data_buffer.resize(allocator, sizeof(double) * valid_count);
 		bss_decoder->GetBatch<double>(decoded_data_buffer.ptr, valid_count);
 		break;
@@ -39,11 +39,11 @@ void ByteStreamSplitDecoder::Read(uint8_t *defines, idx_t read_count, Vector &re
 
 void ByteStreamSplitDecoder::Skip(uint8_t *defines, idx_t skip_count) {
 	idx_t valid_count = reader.GetValidCount(defines, skip_count);
-	switch (reader.Type().InternalType()) {
-	case PhysicalType::FLOAT:
+	switch (reader.Schema().parquet_type) {
+	case duckdb_parquet::Type::FLOAT:
 		bss_decoder->Skip<float>(valid_count);
 		break;
-	case PhysicalType::DOUBLE:
+	case duckdb_parquet::Type::DOUBLE:
 		bss_decoder->Skip<double>(valid_count);
 		break;
 	default:

--- a/extension/parquet/decoder/delta_binary_packed_decoder.cpp
+++ b/extension/parquet/decoder/delta_binary_packed_decoder.cpp
@@ -19,13 +19,13 @@ void DeltaBinaryPackedDecoder::Read(uint8_t *defines, idx_t read_count, Vector &
 
 	auto &allocator = reader.reader.allocator;
 	decoded_data_buffer.reset();
-	switch (reader.schema.type) {
-	case duckdb_parquet::Type::INT32:
+	switch (reader.Type().InternalType()) {
+	case PhysicalType::INT32:
 		decoded_data_buffer.resize(allocator, sizeof(int32_t) * (valid_count));
 		dbp_decoder->GetBatch<int32_t>(decoded_data_buffer.ptr, valid_count);
 
 		break;
-	case duckdb_parquet::Type::INT64:
+	case PhysicalType::INT64:
 		decoded_data_buffer.resize(allocator, sizeof(int64_t) * (valid_count));
 		dbp_decoder->GetBatch<int64_t>(decoded_data_buffer.ptr, valid_count);
 		break;
@@ -39,12 +39,12 @@ void DeltaBinaryPackedDecoder::Read(uint8_t *defines, idx_t read_count, Vector &
 
 void DeltaBinaryPackedDecoder::Skip(uint8_t *defines, idx_t skip_count) {
 	idx_t valid_count = reader.GetValidCount(defines, skip_count);
-	switch (reader.schema.type) {
-	case duckdb_parquet::Type::INT32:
+	switch (reader.Type().InternalType()) {
+	case PhysicalType::INT32:
 		dbp_decoder->Skip<int32_t>(valid_count);
 
 		break;
-	case duckdb_parquet::Type::INT64:
+	case PhysicalType::INT64:
 		dbp_decoder->Skip<int64_t>(valid_count);
 		break;
 

--- a/extension/parquet/decoder/delta_binary_packed_decoder.cpp
+++ b/extension/parquet/decoder/delta_binary_packed_decoder.cpp
@@ -19,13 +19,12 @@ void DeltaBinaryPackedDecoder::Read(uint8_t *defines, idx_t read_count, Vector &
 
 	auto &allocator = reader.reader.allocator;
 	decoded_data_buffer.reset();
-	switch (reader.Type().InternalType()) {
-	case PhysicalType::INT32:
+	switch (reader.Schema().parquet_type) {
+	case duckdb_parquet::Type::INT32:
 		decoded_data_buffer.resize(allocator, sizeof(int32_t) * (valid_count));
 		dbp_decoder->GetBatch<int32_t>(decoded_data_buffer.ptr, valid_count);
-
 		break;
-	case PhysicalType::INT64:
+	case duckdb_parquet::Type::INT64:
 		decoded_data_buffer.resize(allocator, sizeof(int64_t) * (valid_count));
 		dbp_decoder->GetBatch<int64_t>(decoded_data_buffer.ptr, valid_count);
 		break;
@@ -39,12 +38,11 @@ void DeltaBinaryPackedDecoder::Read(uint8_t *defines, idx_t read_count, Vector &
 
 void DeltaBinaryPackedDecoder::Skip(uint8_t *defines, idx_t skip_count) {
 	idx_t valid_count = reader.GetValidCount(defines, skip_count);
-	switch (reader.Type().InternalType()) {
-	case PhysicalType::INT32:
+	switch (reader.Schema().parquet_type) {
+	case duckdb_parquet::Type::INT32:
 		dbp_decoder->Skip<int32_t>(valid_count);
-
 		break;
-	case PhysicalType::INT64:
+	case duckdb_parquet::Type::INT64:
 		dbp_decoder->Skip<int64_t>(valid_count);
 		break;
 

--- a/extension/parquet/decoder/delta_byte_array_decoder.cpp
+++ b/extension/parquet/decoder/delta_byte_array_decoder.cpp
@@ -20,7 +20,7 @@ void DeltaByteArrayDecoder::ReadDbpData(Allocator &allocator, ResizeableBuffer &
 }
 
 void DeltaByteArrayDecoder::InitializePage() {
-	if (reader.type.InternalType() != PhysicalType::VARCHAR) {
+	if (reader.Type().InternalType() != PhysicalType::VARCHAR) {
 		throw std::runtime_error("Delta Byte Array encoding is only supported for string/blob data");
 	}
 	auto &block = *reader.block;
@@ -69,7 +69,7 @@ void DeltaByteArrayDecoder::Read(uint8_t *defines, idx_t read_count, Vector &res
 	auto &result_mask = FlatVector::Validity(result);
 	auto string_data = FlatVector::GetData<string_t>(*byte_array_data);
 	for (idx_t row_idx = 0; row_idx < read_count; row_idx++) {
-		if (defines && defines[row_idx + result_offset] != reader.max_define) {
+		if (defines && defines[row_idx + result_offset] != reader.MaxDefine()) {
 			result_mask.SetInvalid(row_idx + result_offset);
 			continue;
 		}
@@ -88,7 +88,7 @@ void DeltaByteArrayDecoder::Skip(uint8_t *defines, idx_t skip_count) {
 		throw std::runtime_error("Internal error - DeltaByteArray called but there was no byte_array_data set");
 	}
 	for (idx_t row_idx = 0; row_idx < skip_count; row_idx++) {
-		if (defines && defines[row_idx] != reader.max_define) {
+		if (defines && defines[row_idx] != reader.MaxDefine()) {
 			continue;
 		}
 		if (delta_offset >= byte_array_count) {

--- a/extension/parquet/decoder/delta_length_byte_array_decoder.cpp
+++ b/extension/parquet/decoder/delta_length_byte_array_decoder.cpp
@@ -11,7 +11,7 @@ DeltaLengthByteArrayDecoder::DeltaLengthByteArrayDecoder(ColumnReader &reader)
 }
 
 void DeltaLengthByteArrayDecoder::InitializePage() {
-	if (reader.type.InternalType() != PhysicalType::VARCHAR) {
+	if (reader.Type().InternalType() != PhysicalType::VARCHAR) {
 		throw std::runtime_error("Delta Length Byte Array encoding is only supported for string/blob data");
 	}
 	// read the binary packed lengths
@@ -28,7 +28,7 @@ void DeltaLengthByteArrayDecoder::Read(uint8_t *defines, idx_t read_count, Vecto
 	auto &result_mask = FlatVector::Validity(result);
 	for (idx_t row_idx = 0; row_idx < read_count; row_idx++) {
 		auto result_idx = result_offset + row_idx;
-		if (defines && defines[result_idx] != reader.max_define) {
+		if (defines && defines[result_idx] != reader.MaxDefine()) {
 			result_mask.SetInvalid(result_idx);
 			continue;
 		}
@@ -52,7 +52,7 @@ void DeltaLengthByteArrayDecoder::Skip(uint8_t *defines, idx_t skip_count) {
 	auto &block = *reader.block;
 	auto length_data = reinterpret_cast<uint32_t *>(length_buffer.ptr);
 	for (idx_t row_idx = 0; row_idx < skip_count; row_idx++) {
-		if (defines && defines[row_idx] != reader.max_define) {
+		if (defines && defines[row_idx] != reader.MaxDefine()) {
 			continue;
 		}
 		if (length_idx >= byte_array_count) {

--- a/extension/parquet/decoder/dictionary_decoder.cpp
+++ b/extension/parquet/decoder/dictionary_decoder.cpp
@@ -19,11 +19,11 @@ void DictionaryDecoder::InitializeDictionary(idx_t new_dictionary_size, optional
 	filter_count = 0;
 	// we use the first value in the dictionary to keep a NULL
 	if (!dictionary) {
-		dictionary = make_uniq<Vector>(reader.type, dictionary_size + 1);
+		dictionary = make_uniq<Vector>(reader.Type(), dictionary_size + 1);
 	} else if (dictionary_size > old_dict_size) {
 		dictionary->Resize(old_dict_size, dictionary_size + 1);
 	}
-	dictionary_id = reader.reader.file_name + "_" + reader.schema.name + "_" + std::to_string(reader.chunk_read_offset);
+	dictionary_id = reader.reader.file_name + "_" + reader.Schema().name + "_" + std::to_string(reader.chunk_read_offset);
 	// we use the last entry as a NULL, dictionary vectors don't have a separate validity mask
 	auto &dict_validity = FlatVector::Validity(*dictionary);
 	dict_validity.Reset(dictionary_size + 1);
@@ -77,7 +77,7 @@ idx_t DictionaryDecoder::GetValidValues(uint8_t *defines, idx_t read_count, idx_
 		for (idx_t i = 0; i < read_count; i++) {
 			valid_sel.set_index(valid_count, i);
 			dictionary_selection_vector.set_index(i, dictionary_size);
-			valid_count += defines[result_offset + i] == reader.max_define;
+			valid_count += defines[result_offset + i] == reader.MaxDefine();
 		}
 	}
 	return valid_count;

--- a/extension/parquet/decoder/dictionary_decoder.cpp
+++ b/extension/parquet/decoder/dictionary_decoder.cpp
@@ -23,7 +23,8 @@ void DictionaryDecoder::InitializeDictionary(idx_t new_dictionary_size, optional
 	} else if (dictionary_size > old_dict_size) {
 		dictionary->Resize(old_dict_size, dictionary_size + 1);
 	}
-	dictionary_id = reader.reader.file_name + "_" + reader.Schema().name + "_" + std::to_string(reader.chunk_read_offset);
+	dictionary_id =
+	    reader.reader.file_name + "_" + reader.Schema().name + "_" + std::to_string(reader.chunk_read_offset);
 	// we use the last entry as a NULL, dictionary vectors don't have a separate validity mask
 	auto &dict_validity = FlatVector::Validity(*dictionary);
 	dict_validity.Reset(dictionary_size + 1);

--- a/extension/parquet/decoder/rle_decoder.cpp
+++ b/extension/parquet/decoder/rle_decoder.cpp
@@ -9,7 +9,7 @@ RLEDecoder::RLEDecoder(ColumnReader &reader) : reader(reader), decoded_data_buff
 }
 
 void RLEDecoder::InitializePage() {
-	if (reader.type.id() != LogicalTypeId::BOOLEAN) {
+	if (reader.Type().id() != LogicalTypeId::BOOLEAN) {
 		throw std::runtime_error("RLE encoding is only supported for boolean data");
 	}
 	auto &block = reader.block;
@@ -19,7 +19,7 @@ void RLEDecoder::InitializePage() {
 
 void RLEDecoder::Read(uint8_t *defines, idx_t read_count, Vector &result, idx_t result_offset) {
 	// RLE encoding for boolean
-	D_ASSERT(reader.type.id() == LogicalTypeId::BOOLEAN);
+	D_ASSERT(reader.Type().id() == LogicalTypeId::BOOLEAN);
 	idx_t valid_count = reader.GetValidCount(defines, read_count, result_offset);
 	decoded_data_buffer.reset();
 	decoded_data_buffer.resize(reader.reader.allocator, sizeof(bool) * valid_count);

--- a/extension/parquet/geo_parquet.cpp
+++ b/extension/parquet/geo_parquet.cpp
@@ -408,8 +408,7 @@ unique_ptr<ColumnReader> GeoParquetFileMetadata::CreateColumnReader(ParquetReade
 		    make_uniq<BoundFunctionExpression>(conversion_func.return_type, conversion_func, std::move(args), nullptr);
 
 		// Create a child reader
-		auto child_reader =
-		    ColumnReader::CreateReader(reader, schema);
+		auto child_reader = ColumnReader::CreateReader(reader, schema);
 
 		// Create an expression reader that applies the conversion function to the child reader
 		return make_uniq<ExpressionColumnReader>(context, std::move(child_reader), std::move(expr));

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -83,8 +83,8 @@ public:
 		return column_schema;
 	}
 
-	inline idx_t FileIdx() const {
-		return column_schema.file_index;
+	inline idx_t ColumnIndex() const {
+		return column_schema.column_index;
 	}
 	inline idx_t MaxDefine() const {
 		return column_schema.max_define;

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -84,7 +84,7 @@ public:
 	}
 
 	inline idx_t FileIdx() const {
-		return column_schema.schema_index;
+		return column_schema.file_index;
 	}
 	inline idx_t MaxDefine() const {
 		return column_schema.max_define;

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -100,8 +100,6 @@ public:
 	// register the range this reader will touch for prefetching
 	virtual void RegisterPrefetch(ThriftFileTransport &transport, bool allow_merge);
 
-	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns);
-
 	template <class VALUE_TYPE, class CONVERSION, bool HAS_DEFINES>
 	void PlainTemplatedDefines(ByteBuffer &plain_data, uint8_t *defines, uint64_t num_values, idx_t result_offset,
 	                           Vector &result) {

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -100,6 +100,8 @@ public:
 	// register the range this reader will touch for prefetching
 	virtual void RegisterPrefetch(ThriftFileTransport &transport, bool allow_merge);
 
+	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns);
+
 	template <class VALUE_TYPE, class CONVERSION, bool HAS_DEFINES>
 	void PlainTemplatedDefines(ByteBuffer &plain_data, uint8_t *defines, uint64_t num_values, idx_t result_offset,
 	                           Vector &result) {

--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -20,6 +20,7 @@
 #include "decoder/rle_decoder.hpp"
 #include "decoder/delta_length_byte_array_decoder.hpp"
 #include "decoder/delta_byte_array_decoder.hpp"
+#include "parquet_column_schema.hpp"
 #ifndef DUCKDB_AMALGAMATION
 
 #include "duckdb/common/operator/cast_operators.hpp"
@@ -60,14 +61,11 @@ class ColumnReader {
 	friend class RLEDecoder;
 
 public:
-	ColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t file_idx_p,
-	             idx_t max_define_p, idx_t max_repeat_p);
+	ColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema_p);
 	virtual ~ColumnReader();
 
 public:
-	static unique_ptr<ColumnReader> CreateReader(ParquetReader &reader, const LogicalType &type_p,
-	                                             const SchemaElement &schema_p, idx_t schema_idx_p, idx_t max_define,
-	                                             idx_t max_repeat);
+	static unique_ptr<ColumnReader> CreateReader(ParquetReader &reader, const ParquetColumnSchema &schema);
 	virtual void InitializeRead(idx_t row_group_index, const vector<ColumnChunk> &columns, TProtocol &protocol_p);
 	virtual idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out);
 	virtual void Filter(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out,
@@ -78,14 +76,22 @@ public:
 	virtual void Skip(idx_t num_values);
 
 	ParquetReader &Reader();
-	const LogicalType &Type() const;
-	const SchemaElement &Schema() const;
-	optional_ptr<const SchemaElement> GetParentSchema() const;
-	void SetParentSchema(const SchemaElement &parent_schema);
+	const LogicalType &Type() const {
+		return column_schema.type;
+	}
+	const ParquetColumnSchema &Schema() const {
+		return column_schema;
+	}
 
-	idx_t FileIdx() const;
-	idx_t MaxDefine() const;
-	idx_t MaxRepeat() const;
+	inline idx_t FileIdx() const {
+		return column_schema.schema_index;
+	}
+	inline idx_t MaxDefine() const {
+		return column_schema.max_define;
+	}
+	idx_t MaxRepeat() const {
+		return column_schema.max_repeat;
+	}
 
 	virtual idx_t FileOffset() const;
 	virtual uint64_t TotalCompressedSize();
@@ -94,7 +100,7 @@ public:
 	// register the range this reader will touch for prefetching
 	virtual void RegisterPrefetch(ThriftFileTransport &transport, bool allow_merge);
 
-	virtual unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns);
+	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns);
 
 	template <class VALUE_TYPE, class CONVERSION, bool HAS_DEFINES>
 	void PlainTemplatedDefines(ByteBuffer &plain_data, uint8_t *defines, uint64_t num_values, idx_t result_offset,
@@ -141,7 +147,7 @@ public:
 		}
 		idx_t valid_count = 0;
 		for (idx_t i = offset; i < offset + count; i++) {
-			valid_count += defines[i] == max_define;
+			valid_count += defines[i] == MaxDefine();
 		}
 		return valid_count;
 	}
@@ -177,7 +183,7 @@ private:
 		}
 		auto &result_mask = FlatVector::Validity(result);
 		for (idx_t row_idx = result_offset; row_idx < result_offset + num_values; row_idx++) {
-			if (HAS_DEFINES && defines[row_idx] != max_define) {
+			if (HAS_DEFINES && defines[row_idx] != MaxDefine()) {
 				result_mask.SetInvalid(row_idx);
 				continue;
 			}
@@ -193,7 +199,7 @@ private:
 			return;
 		}
 		for (idx_t row_idx = 0; row_idx < num_values; row_idx++) {
-			if (HAS_DEFINES && defines[row_idx] != max_define) {
+			if (HAS_DEFINES && defines[row_idx] != MaxDefine()) {
 				continue;
 			}
 			CONVERSION::template PlainSkip<CHECKED>(plain_data, *this);
@@ -211,25 +217,18 @@ protected:
 	// applies any skips that were registered using Skip()
 	virtual void ApplyPendingSkips(data_ptr_t define_out, data_ptr_t repeat_out);
 
-	bool HasDefines() const {
-		return max_define > 0;
+	inline bool HasDefines() const {
+		return MaxDefine() > 0;
 	}
 
-	bool HasRepeats() const {
-		return max_repeat > 0;
+	inline bool HasRepeats() const {
+		return MaxRepeat() > 0;
 	}
 
 protected:
-	const SchemaElement &schema;
-	optional_ptr<const SchemaElement> parent_schema;
-
-	idx_t file_idx;
-	idx_t max_define;
-	idx_t max_repeat;
+	const ParquetColumnSchema &column_schema;
 
 	ParquetReader &reader;
-	LogicalType type;
-
 	idx_t pending_skips = 0;
 	bool page_is_filtered_out = false;
 
@@ -271,7 +270,7 @@ private:
 public:
 	template <class TARGET>
 	TARGET &Cast() {
-		if (TARGET::TYPE != PhysicalType::INVALID && type.InternalType() != TARGET::TYPE) {
+		if (TARGET::TYPE != PhysicalType::INVALID && Type().InternalType() != TARGET::TYPE) {
 			throw InternalException("Failed to cast column reader to type - type mismatch");
 		}
 		return reinterpret_cast<TARGET &>(*this);
@@ -279,7 +278,7 @@ public:
 
 	template <class TARGET>
 	const TARGET &Cast() const {
-		if (TARGET::TYPE != PhysicalType::INVALID && type.InternalType() != TARGET::TYPE) {
+		if (TARGET::TYPE != PhysicalType::INVALID && Type().InternalType() != TARGET::TYPE) {
 			throw InternalException("Failed to cast column reader to type - type mismatch");
 		}
 		return reinterpret_cast<const TARGET &>(*this);

--- a/extension/parquet/include/geo_parquet.hpp
+++ b/extension/parquet/include/geo_parquet.hpp
@@ -128,7 +128,8 @@ public:
 	void FlushColumnMeta(const string &column_name, const GeoParquetColumnMetadata &meta);
 	const unordered_map<string, GeoParquetColumnMetadata> &GetColumnMeta() const;
 
-	unique_ptr<ColumnReader> CreateColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema, ClientContext &context);
+	unique_ptr<ColumnReader> CreateColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
+	                                            ClientContext &context);
 
 	bool IsGeometryColumn(const string &column_name) const;
 	void RegisterGeometryColumn(const string &column_name);

--- a/extension/parquet/include/geo_parquet.hpp
+++ b/extension/parquet/include/geo_parquet.hpp
@@ -135,6 +135,7 @@ public:
 	void RegisterGeometryColumn(const string &column_name);
 
 	static bool IsGeoParquetConversionEnabled(const ClientContext &context);
+	static LogicalType GeometryType();
 
 private:
 	mutex write_lock;

--- a/extension/parquet/include/geo_parquet.hpp
+++ b/extension/parquet/include/geo_parquet.hpp
@@ -16,6 +16,7 @@
 #include "parquet_types.h"
 
 namespace duckdb {
+struct ParquetColumnSchema;
 
 enum class WKBGeometryType : uint16_t {
 	POINT = 1,
@@ -127,9 +128,7 @@ public:
 	void FlushColumnMeta(const string &column_name, const GeoParquetColumnMetadata &meta);
 	const unordered_map<string, GeoParquetColumnMetadata> &GetColumnMeta() const;
 
-	unique_ptr<ColumnReader> CreateColumnReader(ParquetReader &reader, const LogicalType &logical_type,
-	                                            const duckdb_parquet::SchemaElement &s_ele, idx_t schema_idx_p,
-	                                            idx_t max_define_p, idx_t max_repeat_p, ClientContext &context);
+	unique_ptr<ColumnReader> CreateColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema, ClientContext &context);
 
 	bool IsGeometryColumn(const string &column_name) const;
 	void RegisterGeometryColumn(const string &column_name);

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -30,7 +30,7 @@ struct ParquetColumnSchema {
 	ParquetColumnSchema() = default;
 	ParquetColumnSchema(idx_t max_define, idx_t max_repeat, idx_t schema_index,
 	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
-	ParquetColumnSchema(LogicalType type, idx_t max_define, idx_t max_repeat, idx_t schema_index,
+	ParquetColumnSchema(string name, LogicalType type, idx_t max_define, idx_t max_repeat, idx_t schema_index,
 	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	ParquetColumnSchema(ParquetColumnSchema parent, LogicalType cast_type);
 
@@ -40,6 +40,7 @@ struct ParquetColumnSchema {
 	idx_t max_define;
 	idx_t max_repeat;
 	idx_t schema_index;
+	optional_idx parent_schema_index;
 	uint32_t type_length = 0;
 	uint32_t type_scale = 0;
 	duckdb_parquet::Type::type parquet_type = duckdb_parquet::Type::INT32;

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -16,7 +16,8 @@ class ParquetReader;
 enum class ParquetColumnSchemaType {
 	COLUMN,
 	CAST,
-	FILE_ROW_NUMBER
+	FILE_ROW_NUMBER,
+	GEOMETRY
 };
 
 enum class ParquetExtraTypeInfo {
@@ -31,6 +32,8 @@ enum class ParquetExtraTypeInfo {
 };
 
 struct ParquetColumnSchema {
+	ParquetColumnSchema() = default;
+	ParquetColumnSchema(idx_t max_define, idx_t max_repeat, idx_t schema_index, ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	ParquetColumnSchema(LogicalType type, idx_t max_define, idx_t max_repeat, idx_t schema_index, ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	ParquetColumnSchema(ParquetColumnSchema parent, LogicalType cast_type);
 

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -13,12 +13,7 @@
 namespace duckdb {
 class ParquetReader;
 
-enum class ParquetColumnSchemaType {
-	COLUMN,
-	CAST,
-	FILE_ROW_NUMBER,
-	GEOMETRY
-};
+enum class ParquetColumnSchemaType { COLUMN, CAST, FILE_ROW_NUMBER, GEOMETRY };
 
 enum class ParquetExtraTypeInfo {
 	NONE,
@@ -33,8 +28,10 @@ enum class ParquetExtraTypeInfo {
 
 struct ParquetColumnSchema {
 	ParquetColumnSchema() = default;
-	ParquetColumnSchema(idx_t max_define, idx_t max_repeat, idx_t schema_index, ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
-	ParquetColumnSchema(LogicalType type, idx_t max_define, idx_t max_repeat, idx_t schema_index, ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
+	ParquetColumnSchema(idx_t max_define, idx_t max_repeat, idx_t schema_index,
+	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
+	ParquetColumnSchema(LogicalType type, idx_t max_define, idx_t max_repeat, idx_t schema_index,
+	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	ParquetColumnSchema(ParquetColumnSchema parent, LogicalType cast_type);
 
 	ParquetColumnSchemaType schema_type;
@@ -48,7 +45,8 @@ struct ParquetColumnSchema {
 	ParquetExtraTypeInfo type_info = ParquetExtraTypeInfo::NONE;
 	vector<ParquetColumnSchema> children;
 
-	unique_ptr<BaseStatistics> Stats(ParquetReader &reader, idx_t row_group_idx_p, const vector<ColumnChunk> &columns) const;
+	unique_ptr<BaseStatistics> Stats(ParquetReader &reader, idx_t row_group_idx_p,
+	                                 const vector<ColumnChunk> &columns) const;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -31,7 +31,7 @@ struct ParquetColumnSchema {
 	ParquetColumnSchema(idx_t max_define, idx_t max_repeat, idx_t schema_index, idx_t file_index,
 	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	ParquetColumnSchema(string name, LogicalType type, idx_t max_define, idx_t max_repeat, idx_t schema_index,
-	                    idx_t file_index, ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
+	                    idx_t column_index, ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	ParquetColumnSchema(ParquetColumnSchema parent, LogicalType cast_type);
 
 	ParquetColumnSchemaType schema_type;
@@ -40,7 +40,7 @@ struct ParquetColumnSchema {
 	idx_t max_define;
 	idx_t max_repeat;
 	idx_t schema_index;
-	idx_t file_index;
+	idx_t column_index;
 	optional_idx parent_schema_index;
 	uint32_t type_length = 0;
 	uint32_t type_scale = 0;

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -28,10 +28,10 @@ enum class ParquetExtraTypeInfo {
 
 struct ParquetColumnSchema {
 	ParquetColumnSchema() = default;
-	ParquetColumnSchema(idx_t max_define, idx_t max_repeat, idx_t schema_index,
+	ParquetColumnSchema(idx_t max_define, idx_t max_repeat, idx_t schema_index, idx_t file_index,
 	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	ParquetColumnSchema(string name, LogicalType type, idx_t max_define, idx_t max_repeat, idx_t schema_index,
-	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
+	                    idx_t file_index, ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	ParquetColumnSchema(ParquetColumnSchema parent, LogicalType cast_type);
 
 	ParquetColumnSchemaType schema_type;
@@ -40,6 +40,7 @@ struct ParquetColumnSchema {
 	idx_t max_define;
 	idx_t max_repeat;
 	idx_t schema_index;
+	idx_t file_index;
 	optional_idx parent_schema_index;
 	uint32_t type_length = 0;
 	uint32_t type_scale = 0;

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// parquet_column_schema.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "duckdb.hpp"
+#include "parquet_types.h"
+
+namespace duckdb {
+class ParquetReader;
+
+enum class ParquetColumnSchemaType {
+	COLUMN,
+	CAST,
+	FILE_ROW_NUMBER
+};
+
+enum class ParquetExtraTypeInfo {
+	NONE,
+	IMPALA_TIMESTAMP,
+	UNIT_NS,
+	UNIT_MS,
+	UNIT_MICROS,
+	DECIMAL_BYTE_ARRAY,
+	DECIMAL_INT32,
+	DECIMAL_INT64
+};
+
+struct ParquetColumnSchema {
+	ParquetColumnSchema(LogicalType type, idx_t max_define, idx_t max_repeat, idx_t schema_index, ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
+	ParquetColumnSchema(ParquetColumnSchema parent, LogicalType cast_type);
+
+	ParquetColumnSchemaType schema_type;
+	string name;
+	LogicalType type;
+	idx_t max_define;
+	idx_t max_repeat;
+	idx_t schema_index;
+	uint32_t type_length = 0;
+	uint32_t type_scale = 0;
+	ParquetExtraTypeInfo type_info = ParquetExtraTypeInfo::NONE;
+	vector<ParquetColumnSchema> children;
+
+	unique_ptr<BaseStatistics> Stats(ParquetReader &reader, idx_t row_group_idx_p, const vector<ColumnChunk> &columns);
+};
+
+} // namespace duckdb

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -48,7 +48,7 @@ struct ParquetColumnSchema {
 	ParquetExtraTypeInfo type_info = ParquetExtraTypeInfo::NONE;
 	vector<ParquetColumnSchema> children;
 
-	unique_ptr<BaseStatistics> Stats(ParquetReader &reader, idx_t row_group_idx_p, const vector<ColumnChunk> &columns);
+	unique_ptr<BaseStatistics> Stats(ParquetReader &reader, idx_t row_group_idx_p, const vector<ColumnChunk> &columns) const;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -42,6 +42,7 @@ struct ParquetColumnSchema {
 	idx_t schema_index;
 	uint32_t type_length = 0;
 	uint32_t type_scale = 0;
+	duckdb_parquet::Type::type parquet_type = duckdb_parquet::Type::INT32;
 	ParquetExtraTypeInfo type_info = ParquetExtraTypeInfo::NONE;
 	vector<ParquetColumnSchema> children;
 

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -32,7 +32,8 @@ struct ParquetColumnSchema {
 	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
 	ParquetColumnSchema(string name, LogicalType type, idx_t max_define, idx_t max_repeat, idx_t schema_index,
 	                    idx_t column_index, ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
-	ParquetColumnSchema(ParquetColumnSchema parent, LogicalType cast_type);
+	ParquetColumnSchema(ParquetColumnSchema parent, LogicalType cast_type,
+	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::CAST);
 
 	ParquetColumnSchemaType schema_type;
 	string name;

--- a/extension/parquet/include/parquet_decimal_utils.hpp
+++ b/extension/parquet/include/parquet_decimal_utils.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 class ParquetDecimalUtils {
 public:
 	template <class PHYSICAL_TYPE>
-	static PHYSICAL_TYPE ReadDecimalValue(const_data_ptr_t pointer, idx_t size, const duckdb_parquet::SchemaElement &) {
+	static PHYSICAL_TYPE ReadDecimalValue(const_data_ptr_t pointer, idx_t size, const ParquetColumnSchema &) {
 		PHYSICAL_TYPE res = 0;
 
 		auto res_ptr = (uint8_t *)&res;
@@ -46,13 +46,10 @@ public:
 		return res;
 	}
 
-	static unique_ptr<ColumnReader> CreateReader(ParquetReader &reader, const LogicalType &type_p,
-	                                             const SchemaElement &schema_p, idx_t file_idx_p, idx_t max_define,
-	                                             idx_t max_repeat);
+	static unique_ptr<ColumnReader> CreateReader(ParquetReader &reader, const ParquetColumnSchema &schema);
 };
 
 template <>
-double ParquetDecimalUtils::ReadDecimalValue(const_data_ptr_t pointer, idx_t size,
-                                             const duckdb_parquet::SchemaElement &schema_ele);
+double ParquetDecimalUtils::ReadDecimalValue(const_data_ptr_t pointer, idx_t size, const ParquetColumnSchema &schema);
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -202,6 +202,8 @@ public:
 	static unique_ptr<BaseStatistics> ReadStatistics(ClientContext &context, ParquetOptions parquet_options,
 	                                                 shared_ptr<ParquetFileMetadataCache> metadata, const string &name);
 
+	LogicalType DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema) const;
+
 private:
 	//! Construct a parquet reader but **do not** open a file, used in ReadStatistics only
 	ParquetReader(ClientContext &context, ParquetOptions parquet_options,
@@ -227,7 +229,6 @@ private:
 	ParquetColumnSchema ParseColumnSchema(const SchemaElement &s_ele, idx_t max_define, idx_t max_repeat,
 	                                      idx_t schema_index,
 	                                      ParquetColumnSchemaType type = ParquetColumnSchemaType::COLUMN);
-	LogicalType DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema);
 
 private:
 	unique_ptr<FileHandle> file_handle;

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -227,7 +227,7 @@ private:
 	uint64_t GetGroupSpan(ParquetReaderScanState &state);
 	void PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t out_col_idx);
 	ParquetColumnSchema ParseColumnSchema(const SchemaElement &s_ele, idx_t max_define, idx_t max_repeat,
-	                                      idx_t schema_index, idx_t file_index,
+	                                      idx_t schema_index, idx_t column_index,
 	                                      ParquetColumnSchemaType type = ParquetColumnSchemaType::COLUMN);
 
 private:

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -227,7 +227,7 @@ private:
 	uint64_t GetGroupSpan(ParquetReaderScanState &state);
 	void PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t out_col_idx);
 	ParquetColumnSchema ParseColumnSchema(const SchemaElement &s_ele, idx_t max_define, idx_t max_repeat,
-	                                      idx_t schema_index,
+	                                      idx_t schema_index, idx_t file_index,
 	                                      ParquetColumnSchemaType type = ParquetColumnSchemaType::COLUMN);
 
 private:

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -211,8 +211,8 @@ private:
 	bool ScanInternal(ParquetReaderScanState &state, DataChunk &output);
 	//! Parse the schema of the file
 	unique_ptr<ParquetColumnSchema> ParseSchema();
-	ParquetColumnSchema ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat,
-						       idx_t &next_schema_idx, idx_t &next_file_idx);
+	ParquetColumnSchema ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat, idx_t &next_schema_idx,
+	                                         idx_t &next_file_idx);
 
 	unique_ptr<ColumnReader> CreateReader(ClientContext &context);
 
@@ -224,7 +224,9 @@ private:
 	// Group span is the distance between the min page offset and the max page offset plus the max page compressed size
 	uint64_t GetGroupSpan(ParquetReaderScanState &state);
 	void PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t out_col_idx);
-	ParquetColumnSchema ParseColumnSchema(const SchemaElement &s_ele, idx_t max_define, idx_t max_repeat, idx_t schema_index, ParquetColumnSchemaType type = ParquetColumnSchemaType::COLUMN);
+	ParquetColumnSchema ParseColumnSchema(const SchemaElement &s_ele, idx_t max_define, idx_t max_repeat,
+	                                      idx_t schema_index,
+	                                      ParquetColumnSchemaType type = ParquetColumnSchemaType::COLUMN);
 	LogicalType DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema);
 
 private:

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -37,6 +37,7 @@ class ClientContext;
 class BaseStatistics;
 class TableFilterSet;
 class ParquetEncryptionConfig;
+class ParquetReader;
 
 struct ParquetReaderPrefetchConfig {
 	// Percentage of data in a row group span that should be scanned for enabling whole group prefetch
@@ -141,7 +142,7 @@ public:
 	shared_ptr<ParquetFileMetadataCache> metadata;
 	ParquetOptions parquet_options;
 	MultiFileReaderData reader_data;
-	unique_ptr<ColumnReader> root_reader;
+	unique_ptr<ParquetColumnSchema> root_schema;
 	shared_ptr<EncryptionUtil> encryption_util;
 
 	//! Parquet schema for the generated columns
@@ -211,6 +212,11 @@ private:
 
 	void InitializeSchema(ClientContext &context);
 	bool ScanInternal(ParquetReaderScanState &state, DataChunk &output);
+	//! Parse the schema of the file
+	unique_ptr<ParquetColumnSchema> ParseSchema();
+	ParquetColumnSchema ParseSchemaRecursive(idx_t depth, idx_t max_define, idx_t max_repeat,
+						       idx_t &next_schema_idx, idx_t &next_file_idx);
+
 	unique_ptr<ColumnReader> CreateReader(ClientContext &context);
 
 	unique_ptr<ColumnReader> CreateReaderRecursive(ClientContext &context, const vector<ColumnIndex> &indexes,

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -217,8 +217,7 @@ private:
 	unique_ptr<ColumnReader> CreateReader(ClientContext &context);
 
 	unique_ptr<ColumnReader> CreateReaderRecursive(ClientContext &context, const vector<ColumnIndex> &indexes,
-	                                               idx_t depth, idx_t max_define, idx_t max_repeat,
-	                                               idx_t &next_schema_idx, idx_t &next_file_idx);
+	                                               const ParquetColumnSchema &schema);
 	const duckdb_parquet::RowGroup &GetGroup(ParquetReaderScanState &state);
 	uint64_t GetGroupCompressedSize(ParquetReaderScanState &state);
 	idx_t GetGroupOffset(ParquetReaderScanState &state);

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -145,8 +145,6 @@ public:
 	unique_ptr<ParquetColumnSchema> root_schema;
 	shared_ptr<EncryptionUtil> encryption_util;
 
-	//! Parquet schema for the generated columns
-	vector<duckdb_parquet::SchemaElement> generated_column_schema;
 	//! Table column names - set when using COPY tbl FROM file.parquet
 	vector<string> table_columns;
 
@@ -188,7 +186,6 @@ public:
 	                  const uint32_t buffer_size);
 
 	unique_ptr<BaseStatistics> ReadStatistics(const string &name);
-	static LogicalType DeriveLogicalType(const SchemaElement &s_ele, bool binary_as_string);
 
 	FileHandle &GetHandle() {
 		return *file_handle;
@@ -228,7 +225,8 @@ private:
 	// Group span is the distance between the min page offset and the max page offset plus the max page compressed size
 	uint64_t GetGroupSpan(ParquetReaderScanState &state);
 	void PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t out_col_idx);
-	LogicalType DeriveLogicalType(const SchemaElement &s_ele);
+	ParquetColumnSchema ParseColumnSchema(const SchemaElement &s_ele, idx_t max_define, idx_t max_repeat, idx_t schema_index, ParquetColumnSchemaType type = ParquetColumnSchemaType::COLUMN);
+	LogicalType DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema);
 
 private:
 	unique_ptr<FileHandle> file_handle;

--- a/extension/parquet/include/parquet_statistics.hpp
+++ b/extension/parquet/include/parquet_statistics.hpp
@@ -28,8 +28,7 @@ struct ParquetStatisticsUtils {
 	static unique_ptr<BaseStatistics> TransformColumnStatistics(const ParquetColumnSchema &reader,
 	                                                            const vector<ColumnChunk> &columns);
 
-	static Value ConvertValue(const LogicalType &type, const ParquetColumnSchema &schema_ele,
-	                          const std::string &stats);
+	static Value ConvertValue(const LogicalType &type, const ParquetColumnSchema &schema_ele, const std::string &stats);
 
 	static bool BloomFilterSupported(const LogicalTypeId &type_id);
 

--- a/extension/parquet/include/parquet_statistics.hpp
+++ b/extension/parquet/include/parquet_statistics.hpp
@@ -20,15 +20,15 @@ using duckdb_parquet::ColumnChunk;
 using duckdb_parquet::SchemaElement;
 
 struct LogicalType;
-class ColumnReader;
+struct ParquetColumnSchema;
 class ResizeableBuffer;
 
 struct ParquetStatisticsUtils {
 
-	static unique_ptr<BaseStatistics> TransformColumnStatistics(const ColumnReader &reader,
+	static unique_ptr<BaseStatistics> TransformColumnStatistics(const ParquetColumnSchema &reader,
 	                                                            const vector<ColumnChunk> &columns);
 
-	static Value ConvertValue(const LogicalType &type, const duckdb_parquet::SchemaElement &schema_ele,
+	static Value ConvertValue(const LogicalType &type, const ParquetColumnSchema &schema_ele,
 	                          const std::string &stats);
 
 	static bool BloomFilterSupported(const LogicalTypeId &type_id);
@@ -37,7 +37,7 @@ struct ParquetStatisticsUtils {
 	                                duckdb_apache::thrift::protocol::TProtocol &file_proto, Allocator &allocator);
 
 private:
-	static Value ConvertValueInternal(const LogicalType &type, const duckdb_parquet::SchemaElement &schema_ele,
+	static Value ConvertValueInternal(const LogicalType &type, const ParquetColumnSchema &schema_ele,
 	                                  const std::string &stats);
 };
 

--- a/extension/parquet/include/reader/boolean_column_reader.hpp
+++ b/extension/parquet/include/reader/boolean_column_reader.hpp
@@ -20,11 +20,9 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::BOOL;
 
 public:
-	BooleanColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t schema_idx_p,
-	                    idx_t max_define_p, idx_t max_repeat_p)
-	    : TemplatedColumnReader<bool, BooleanParquetValueConversion>(reader, std::move(type_p), schema_p, schema_idx_p,
-	                                                                 max_define_p, max_repeat_p),
-	      byte_pos(0) {};
+	BooleanColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	    : TemplatedColumnReader<bool, BooleanParquetValueConversion>(reader, schema),
+	      byte_pos(0) {}
 
 	uint8_t byte_pos;
 

--- a/extension/parquet/include/reader/boolean_column_reader.hpp
+++ b/extension/parquet/include/reader/boolean_column_reader.hpp
@@ -21,8 +21,8 @@ public:
 
 public:
 	BooleanColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
-	    : TemplatedColumnReader<bool, BooleanParquetValueConversion>(reader, schema),
-	      byte_pos(0) {}
+	    : TemplatedColumnReader<bool, BooleanParquetValueConversion>(reader, schema), byte_pos(0) {
+	}
 
 	uint8_t byte_pos;
 

--- a/extension/parquet/include/reader/callback_column_reader.hpp
+++ b/extension/parquet/include/reader/callback_column_reader.hpp
@@ -27,11 +27,10 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	CallbackColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t file_idx_p,
-	                     idx_t max_define_p, idx_t max_repeat_p)
+	CallbackColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<DUCKDB_PHYSICAL_TYPE,
 	                            CallbackParquetValueConversion<PARQUET_PHYSICAL_TYPE, DUCKDB_PHYSICAL_TYPE, FUNC>>(
-	          reader, std::move(type_p), schema_p, file_idx_p, max_define_p, max_repeat_p) {
+	          reader, schema) {
 	}
 
 protected:

--- a/extension/parquet/include/reader/cast_column_reader.hpp
+++ b/extension/parquet/include/reader/cast_column_reader.hpp
@@ -19,13 +19,12 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	CastColumnReader(unique_ptr<ColumnReader> child_reader, LogicalType target_type);
+	CastColumnReader(unique_ptr<ColumnReader> child_reader, const ParquetColumnSchema &schema);
 
 	unique_ptr<ColumnReader> child_reader;
 	DataChunk intermediate_chunk;
 
 public:
-	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) override;
 	void InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) override;
 
 	idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result) override;

--- a/extension/parquet/include/reader/cast_column_reader.hpp
+++ b/extension/parquet/include/reader/cast_column_reader.hpp
@@ -19,10 +19,11 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	CastColumnReader(unique_ptr<ColumnReader> child_reader, const ParquetColumnSchema &schema);
+	CastColumnReader(unique_ptr<ColumnReader> child_reader, unique_ptr<ParquetColumnSchema> cast_schema);
 
 	unique_ptr<ColumnReader> child_reader;
 	DataChunk intermediate_chunk;
+	unique_ptr<ParquetColumnSchema> cast_schema;
 
 public:
 	void InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) override;

--- a/extension/parquet/include/reader/decimal_column_reader.hpp
+++ b/extension/parquet/include/reader/decimal_column_reader.hpp
@@ -21,7 +21,7 @@ struct DecimalParquetValueConversion {
 	static DUCKDB_PHYSICAL_TYPE PlainRead(ByteBuffer &plain_data, ColumnReader &reader) {
 		idx_t byte_len;
 		if (FIXED_LENGTH) {
-			byte_len = (idx_t)reader.Schema().type_length; /* sure, type length needs to be a signed int */
+			byte_len = reader.Schema().type_length;
 		} else {
 			byte_len = plain_data.read<uint32_t>();
 		}
@@ -56,11 +56,10 @@ class DecimalColumnReader
 	    TemplatedColumnReader<DUCKDB_PHYSICAL_TYPE, DecimalParquetValueConversion<DUCKDB_PHYSICAL_TYPE, FIXED_LENGTH>>;
 
 public:
-	DecimalColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, // NOLINT
-	                    idx_t file_idx_p, idx_t max_define_p, idx_t max_repeat_p)
+	DecimalColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<DUCKDB_PHYSICAL_TYPE,
 	                            DecimalParquetValueConversion<DUCKDB_PHYSICAL_TYPE, FIXED_LENGTH>>(
-	          reader, std::move(type_p), schema_p, file_idx_p, max_define_p, max_repeat_p) {
+	          reader, schema) {
 	}
 };
 

--- a/extension/parquet/include/reader/decimal_column_reader.hpp
+++ b/extension/parquet/include/reader/decimal_column_reader.hpp
@@ -58,8 +58,7 @@ class DecimalColumnReader
 public:
 	DecimalColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
 	    : TemplatedColumnReader<DUCKDB_PHYSICAL_TYPE,
-	                            DecimalParquetValueConversion<DUCKDB_PHYSICAL_TYPE, FIXED_LENGTH>>(
-	          reader, schema) {
+	                            DecimalParquetValueConversion<DUCKDB_PHYSICAL_TYPE, FIXED_LENGTH>>(reader, schema) {
 	}
 };
 

--- a/extension/parquet/include/reader/expression_column_reader.hpp
+++ b/extension/parquet/include/reader/expression_column_reader.hpp
@@ -27,7 +27,6 @@ public:
 	ExpressionExecutor executor;
 
 public:
-	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) override;
 	void InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) override;
 
 	idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result) override;

--- a/extension/parquet/include/reader/interval_column_reader.hpp
+++ b/extension/parquet/include/reader/interval_column_reader.hpp
@@ -59,10 +59,8 @@ struct IntervalValueConversion {
 class IntervalColumnReader : public TemplatedColumnReader<interval_t, IntervalValueConversion> {
 
 public:
-	IntervalColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t file_idx_p,
-	                     idx_t max_define_p, idx_t max_repeat_p)
-	    : TemplatedColumnReader<interval_t, IntervalValueConversion>(reader, std::move(type_p), schema_p, file_idx_p,
-	                                                                 max_define_p, max_repeat_p) {};
+	IntervalColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	    : TemplatedColumnReader<interval_t, IntervalValueConversion>(reader, schema) {}
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/reader/interval_column_reader.hpp
+++ b/extension/parquet/include/reader/interval_column_reader.hpp
@@ -60,7 +60,8 @@ class IntervalColumnReader : public TemplatedColumnReader<interval_t, IntervalVa
 
 public:
 	IntervalColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
-	    : TemplatedColumnReader<interval_t, IntervalValueConversion>(reader, schema) {}
+	    : TemplatedColumnReader<interval_t, IntervalValueConversion>(reader, schema) {
+	}
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/reader/list_column_reader.hpp
+++ b/extension/parquet/include/reader/list_column_reader.hpp
@@ -18,8 +18,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::LIST;
 
 public:
-	ListColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t schema_idx_p,
-	                 idx_t max_define_p, idx_t max_repeat_p, unique_ptr<ColumnReader> child_column_reader_p);
+	ListColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema, unique_ptr<ColumnReader> child_column_reader_p);
 
 	idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out) override;
 

--- a/extension/parquet/include/reader/list_column_reader.hpp
+++ b/extension/parquet/include/reader/list_column_reader.hpp
@@ -18,7 +18,8 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::LIST;
 
 public:
-	ListColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema, unique_ptr<ColumnReader> child_column_reader_p);
+	ListColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
+	                 unique_ptr<ColumnReader> child_column_reader_p);
 
 	idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out) override;
 

--- a/extension/parquet/include/reader/null_column_reader.hpp
+++ b/extension/parquet/include/reader/null_column_reader.hpp
@@ -18,9 +18,8 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	NullColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t schema_idx_p,
-	                 idx_t max_define_p, idx_t max_repeat_p)
-	    : ColumnReader(reader, std::move(type_p), schema_p, schema_idx_p, max_define_p, max_repeat_p) {};
+	NullColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	    : ColumnReader(reader, schema) {};
 
 	shared_ptr<ResizeableBuffer> dict;
 

--- a/extension/parquet/include/reader/null_column_reader.hpp
+++ b/extension/parquet/include/reader/null_column_reader.hpp
@@ -18,8 +18,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	NullColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
-	    : ColumnReader(reader, schema) {};
+	NullColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema) : ColumnReader(reader, schema) {};
 
 	shared_ptr<ResizeableBuffer> dict;
 

--- a/extension/parquet/include/reader/row_number_column_reader.hpp
+++ b/extension/parquet/include/reader/row_number_column_reader.hpp
@@ -22,13 +22,10 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INT64;
 
 public:
-	RowNumberColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t schema_idx_p,
-	                      idx_t max_define_p, idx_t max_repeat_p);
+	RowNumberColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema);
 
 public:
 	idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result) override;
-
-	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) override;
 
 	void InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns, TProtocol &protocol_p) override;
 

--- a/extension/parquet/include/reader/string_column_reader.hpp
+++ b/extension/parquet/include/reader/string_column_reader.hpp
@@ -18,8 +18,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::VARCHAR;
 
 public:
-	StringColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t schema_idx_p,
-	                   idx_t max_define_p, idx_t max_repeat_p);
+	StringColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema);
 	idx_t fixed_width_string_length;
 
 public:

--- a/extension/parquet/include/reader/struct_column_reader.hpp
+++ b/extension/parquet/include/reader/struct_column_reader.hpp
@@ -18,8 +18,7 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::STRUCT;
 
 public:
-	StructColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t schema_idx_p,
-	                   idx_t max_define_p, idx_t max_repeat_p, vector<unique_ptr<ColumnReader>> child_readers_p);
+	StructColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema, vector<unique_ptr<ColumnReader>> child_readers_p);
 
 	vector<unique_ptr<ColumnReader>> child_readers;
 

--- a/extension/parquet/include/reader/struct_column_reader.hpp
+++ b/extension/parquet/include/reader/struct_column_reader.hpp
@@ -18,7 +18,8 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::STRUCT;
 
 public:
-	StructColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema, vector<unique_ptr<ColumnReader>> child_readers_p);
+	StructColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
+	                   vector<unique_ptr<ColumnReader>> child_readers_p);
 
 	vector<unique_ptr<ColumnReader>> child_readers;
 

--- a/extension/parquet/include/reader/templated_column_reader.hpp
+++ b/extension/parquet/include/reader/templated_column_reader.hpp
@@ -48,9 +48,8 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	TemplatedColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t schema_idx_p,
-	                      idx_t max_define_p, idx_t max_repeat_p)
-	    : ColumnReader(reader, std::move(type_p), schema_p, schema_idx_p, max_define_p, max_repeat_p) {};
+	TemplatedColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	    : ColumnReader(reader, schema) {}
 
 	shared_ptr<ResizeableBuffer> dict;
 

--- a/extension/parquet/include/reader/templated_column_reader.hpp
+++ b/extension/parquet/include/reader/templated_column_reader.hpp
@@ -48,8 +48,8 @@ public:
 	static constexpr const PhysicalType TYPE = PhysicalType::INVALID;
 
 public:
-	TemplatedColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
-	    : ColumnReader(reader, schema) {}
+	TemplatedColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema) : ColumnReader(reader, schema) {
+	}
 
 	shared_ptr<ResizeableBuffer> dict;
 

--- a/extension/parquet/include/reader/uuid_column_reader.hpp
+++ b/extension/parquet/include/reader/uuid_column_reader.hpp
@@ -62,10 +62,8 @@ struct UUIDValueConversion {
 class UUIDColumnReader : public TemplatedColumnReader<hugeint_t, UUIDValueConversion> {
 
 public:
-	UUIDColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p, idx_t file_idx_p,
-	                 idx_t max_define_p, idx_t max_repeat_p)
-	    : TemplatedColumnReader<hugeint_t, UUIDValueConversion>(reader, std::move(type_p), schema_p, file_idx_p,
-	                                                            max_define_p, max_repeat_p) {};
+	UUIDColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+	    : TemplatedColumnReader<hugeint_t, UUIDValueConversion>(reader, schema) {}
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/reader/uuid_column_reader.hpp
+++ b/extension/parquet/include/reader/uuid_column_reader.hpp
@@ -63,7 +63,8 @@ class UUIDColumnReader : public TemplatedColumnReader<hugeint_t, UUIDValueConver
 
 public:
 	UUIDColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
-	    : TemplatedColumnReader<hugeint_t, UUIDValueConversion>(reader, schema) {}
+	    : TemplatedColumnReader<hugeint_t, UUIDValueConversion>(reader, schema) {
+	}
 };
 
 } // namespace duckdb

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -187,7 +187,7 @@ void ParquetMetaDataOperatorData::BindMetaData(vector<LogicalType> &return_types
 	return_types.emplace_back(LogicalType::BIGINT);
 }
 
-Value ConvertParquetStats(const LogicalType &type, const duckdb_parquet::SchemaElement &schema_ele, bool stats_is_set,
+Value ConvertParquetStats(const LogicalType &type, const ParquetColumnSchema &schema_ele, bool stats_is_set,
                           const std::string &stats) {
 	if (!stats_is_set) {
 		return Value(LogicalType::VARCHAR);
@@ -227,6 +227,7 @@ void ParquetMetaDataOperatorData::LoadRowGroupMetadata(ClientContext &context, c
 			auto &stats = col_meta.statistics;
 			auto &schema_element = meta_data->schema[schema_indexes[col_idx]];
 			auto &column_type = column_types[col_idx];
+			throw InternalException("FIXME: parquet metadata");
 
 			// file_name, LogicalType::VARCHAR
 			current_chunk.SetValue(0, count, file_path);
@@ -258,13 +259,13 @@ void ParquetMetaDataOperatorData::LoadRowGroupMetadata(ClientContext &context, c
 			// type, LogicalType::VARCHAR
 			current_chunk.SetValue(9, count, ConvertParquetElementToString(col_meta.type));
 
-			// stats_min, LogicalType::VARCHAR
-			current_chunk.SetValue(10, count,
-			                       ConvertParquetStats(column_type, schema_element, stats.__isset.min, stats.min));
-
-			// stats_max, LogicalType::VARCHAR
-			current_chunk.SetValue(11, count,
-			                       ConvertParquetStats(column_type, schema_element, stats.__isset.max, stats.max));
+			// // stats_min, LogicalType::VARCHAR
+			// current_chunk.SetValue(10, count,
+			//                        ConvertParquetStats(column_type, schema_element, stats.__isset.min, stats.min));
+			//
+			// // stats_max, LogicalType::VARCHAR
+			// current_chunk.SetValue(11, count,
+			//                        ConvertParquetStats(column_type, schema_element, stats.__isset.max, stats.max));
 
 			// stats_null_count, LogicalType::BIGINT
 			current_chunk.SetValue(12, count, ParquetElementBigint(stats.null_count, stats.__isset.null_count));
@@ -273,12 +274,12 @@ void ParquetMetaDataOperatorData::LoadRowGroupMetadata(ClientContext &context, c
 			current_chunk.SetValue(13, count, ParquetElementBigint(stats.distinct_count, stats.__isset.distinct_count));
 
 			// stats_min_value, LogicalType::VARCHAR
-			current_chunk.SetValue(
-			    14, count, ConvertParquetStats(column_type, schema_element, stats.__isset.min_value, stats.min_value));
-
-			// stats_max_value, LogicalType::VARCHAR
-			current_chunk.SetValue(
-			    15, count, ConvertParquetStats(column_type, schema_element, stats.__isset.max_value, stats.max_value));
+			// current_chunk.SetValue(
+			//     14, count, ConvertParquetStats(column_type, schema_element, stats.__isset.min_value, stats.min_value));
+			//
+			// // stats_max_value, LogicalType::VARCHAR
+			// current_chunk.SetValue(
+			//     15, count, ConvertParquetStats(column_type, schema_element, stats.__isset.max_value, stats.max_value));
 
 			// compression, LogicalType::VARCHAR
 			current_chunk.SetValue(16, count, ConvertParquetElementToString(col_meta.codec));

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -276,11 +276,13 @@ void ParquetMetaDataOperatorData::LoadRowGroupMetadata(ClientContext &context, c
 
 			// stats_min_value, LogicalType::VARCHAR
 			// current_chunk.SetValue(
-			//     14, count, ConvertParquetStats(column_type, schema_element, stats.__isset.min_value, stats.min_value));
+			//     14, count, ConvertParquetStats(column_type, schema_element, stats.__isset.min_value,
+			//     stats.min_value));
 			//
 			// // stats_max_value, LogicalType::VARCHAR
 			// current_chunk.SetValue(
-			//     15, count, ConvertParquetStats(column_type, schema_element, stats.__isset.max_value, stats.max_value));
+			//     15, count, ConvertParquetStats(column_type, schema_element, stats.__isset.max_value,
+			//     stats.max_value));
 
 			// compression, LogicalType::VARCHAR
 			current_chunk.SetValue(16, count, ConvertParquetElementToString(col_meta.codec));

--- a/extension/parquet/parquet_metadata.cpp
+++ b/extension/parquet/parquet_metadata.cpp
@@ -211,7 +211,8 @@ void ParquetMetaDataOperatorData::LoadRowGroupMetadata(ClientContext &context, c
 		if (schema_element.num_children > 0) {
 			continue;
 		}
-		column_types.push_back(ParquetReader::DeriveLogicalType(schema_element, false));
+		throw InternalException("FIXME: parquet metadata");
+		// column_types.push_back(ParquetReader::DeriveLogicalType(schema_element, false));
 		schema_indexes.push_back(schema_idx);
 	}
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -116,7 +116,7 @@ LoadMetadata(ClientContext &context, Allocator &allocator, FileHandle &file_hand
 
 	return make_shared_ptr<ParquetFileMetadataCache>(std::move(metadata), current_time, std::move(geo_metadata));
 }
-LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema) {
+LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema) const {
 	// inner node
 	if (s_ele.type == Type::FIXED_LEN_BYTE_ARRAY && !s_ele.__isset.type_length) {
 		throw IOException("FIXED_LEN_BYTE_ARRAY requires length to be set");
@@ -306,6 +306,7 @@ LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, Parquet
 		case Type::INT64:
 			return LogicalType::BIGINT;
 		case Type::INT96: // always a timestamp it would seem
+			schema.type_info = ParquetExtraTypeInfo::IMPALA_TIMESTAMP;
 			return LogicalType::TIMESTAMP;
 		case Type::FLOAT:
 			return LogicalType::FLOAT;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -123,6 +123,7 @@ LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, Parquet
 	if (s_ele.__isset.type_length) {
 		schema.type_length = NumericCast<uint32_t>(s_ele.type_length);
 	}
+	schema.parquet_type = s_ele.type;
 	if (s_ele.__isset.logicalType) {
 		if (s_ele.logicalType.__isset.UUID) {
 			if (s_ele.type == Type::FIXED_LEN_BYTE_ARRAY) {
@@ -377,7 +378,6 @@ unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &con
 	}
 }
 
-// TODO we don't need readers for columns we are not going to read ay
 unique_ptr<ColumnReader> ParquetReader::CreateReader(ClientContext &context) {
 	auto ret = CreateReaderRecursive(context, reader_data.column_indexes, *root_schema);
 	if (ret->Type().id() != LogicalTypeId::STRUCT) {

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -21,8 +21,7 @@ namespace duckdb {
 using duckdb_parquet::ConvertedType;
 using duckdb_parquet::Type;
 
-static unique_ptr<BaseStatistics> CreateNumericStats(const LogicalType &type,
-                                                     const ParquetColumnSchema &schema_ele,
+static unique_ptr<BaseStatistics> CreateNumericStats(const LogicalType &type, const ParquetColumnSchema &schema_ele,
                                                      const duckdb_parquet::Statistics &parquet_stats) {
 	auto stats = NumericStats::CreateUnknown(type);
 
@@ -59,8 +58,7 @@ Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type, const Parque
 	}
 	return result;
 }
-Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
-                                                   const ParquetColumnSchema &schema_ele,
+Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type, const ParquetColumnSchema &schema_ele,
                                                    const std::string &stats) {
 	auto stats_data = const_data_ptr_cast(stats.c_str());
 	switch (type.id()) {
@@ -136,17 +134,17 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 			switch (type.InternalType()) {
 			case PhysicalType::INT16:
 				return Value::DECIMAL(
-					ParquetDecimalUtils::ReadDecimalValue<int16_t>(stats_data, stats.size(), schema_ele), width, scale);
+				    ParquetDecimalUtils::ReadDecimalValue<int16_t>(stats_data, stats.size(), schema_ele), width, scale);
 			case PhysicalType::INT32:
 				return Value::DECIMAL(
-					ParquetDecimalUtils::ReadDecimalValue<int32_t>(stats_data, stats.size(), schema_ele), width, scale);
+				    ParquetDecimalUtils::ReadDecimalValue<int32_t>(stats_data, stats.size(), schema_ele), width, scale);
 			case PhysicalType::INT64:
 				return Value::DECIMAL(
-					ParquetDecimalUtils::ReadDecimalValue<int64_t>(stats_data, stats.size(), schema_ele), width, scale);
+				    ParquetDecimalUtils::ReadDecimalValue<int64_t>(stats_data, stats.size(), schema_ele), width, scale);
 			case PhysicalType::INT128:
 				return Value::DECIMAL(
-					ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(stats_data, stats.size(), schema_ele), width,
-					scale);
+				    ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(stats_data, stats.size(), schema_ele), width,
+				    scale);
 			default:
 				throw InvalidInputException("Unsupported internal type for decimal");
 			}
@@ -174,11 +172,11 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 		} else {
 			throw InvalidInputException("Incorrect stats size for type TIME");
 		}
-		switch(schema_ele.type_info) {
+		switch (schema_ele.type_info) {
 		case ParquetExtraTypeInfo::UNIT_MS:
 			return Value::TIME(Time::FromTimeMs(val));
 		case ParquetExtraTypeInfo::UNIT_NS:
-				return Value::TIME(Time::FromTimeNs(val));
+			return Value::TIME(Time::FromTimeNs(val));
 		case ParquetExtraTypeInfo::UNIT_MICROS:
 		default:
 			return Value::TIME(dtime_t(val));
@@ -193,7 +191,7 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 		} else {
 			throw InvalidInputException("Incorrect stats size for type TIMETZ");
 		}
-		switch(schema_ele.type_info) {
+		switch (schema_ele.type_info) {
 		case ParquetExtraTypeInfo::UNIT_MS:
 			return Value::TIMETZ(ParquetIntToTimeMsTZ(NumericCast<int32_t>(val)));
 		case ParquetExtraTypeInfo::UNIT_NS:
@@ -216,7 +214,7 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 				throw InvalidInputException("Incorrect stats size for type TIMESTAMP");
 			}
 			auto val = Load<int64_t>(stats_data);
-			switch(schema_ele.type_info) {
+			switch (schema_ele.type_info) {
 			case ParquetExtraTypeInfo::UNIT_MS:
 				timestamp_value = Timestamp::FromEpochMs(val);
 				break;
@@ -246,7 +244,7 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 				throw InvalidInputException("Incorrect stats size for type TIMESTAMP_NS");
 			}
 			auto val = Load<int64_t>(stats_data);
-			switch(schema_ele.type_info) {
+			switch (schema_ele.type_info) {
 			case ParquetExtraTypeInfo::UNIT_MS:
 				timestamp_value = ParquetTimestampMsToTimestampNs(val);
 				break;
@@ -271,8 +269,7 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 
 	// Not supported types
 	auto &type = schema.type;
-	if (type.id() == LogicalTypeId::ARRAY || type.id() == LogicalTypeId::MAP ||
-	    type.id() == LogicalTypeId::LIST) {
+	if (type.id() == LogicalTypeId::ARRAY || type.id() == LogicalTypeId::MAP || type.id() == LogicalTypeId::LIST) {
 		return nullptr;
 	}
 

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -295,7 +295,7 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 
 	// Otherwise, its a standard column with stats
 
-	auto &column_chunk = columns[schema.file_index];
+	auto &column_chunk = columns[schema.column_index];
 	if (!column_chunk.__isset.meta_data || !column_chunk.meta_data.__isset.statistics) {
 		// no stats present for row group
 		return nullptr;

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -295,7 +295,7 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 
 	// Otherwise, its a standard column with stats
 
-	auto &column_chunk = columns[schema.schema_index];
+	auto &column_chunk = columns[schema.file_index];
 	if (!column_chunk.__isset.meta_data || !column_chunk.meta_data.__isset.statistics) {
 		// no stats present for row group
 		return nullptr;

--- a/extension/parquet/parquet_statistics.cpp
+++ b/extension/parquet/parquet_statistics.cpp
@@ -3,6 +3,7 @@
 #include "duckdb.hpp"
 #include "parquet_decimal_utils.hpp"
 #include "parquet_timestamp.hpp"
+#include "parquet_reader.hpp"
 #include "reader/string_column_reader.hpp"
 #include "reader/struct_column_reader.hpp"
 #include "zstd/common/xxhash.hpp"
@@ -21,7 +22,7 @@ using duckdb_parquet::ConvertedType;
 using duckdb_parquet::Type;
 
 static unique_ptr<BaseStatistics> CreateNumericStats(const LogicalType &type,
-                                                     const duckdb_parquet::SchemaElement &schema_ele,
+                                                     const ParquetColumnSchema &schema_ele,
                                                      const duckdb_parquet::Statistics &parquet_stats) {
 	auto stats = NumericStats::CreateUnknown(type);
 
@@ -48,7 +49,7 @@ static unique_ptr<BaseStatistics> CreateNumericStats(const LogicalType &type,
 	return stats.ToUnique();
 }
 
-Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type, const duckdb_parquet::SchemaElement &schema_ele,
+Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type, const ParquetColumnSchema &schema_ele,
                                            const std::string &stats) {
 	Value result;
 	string error;
@@ -59,7 +60,7 @@ Value ParquetStatisticsUtils::ConvertValue(const LogicalType &type, const duckdb
 	return result;
 }
 Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
-                                                   const duckdb_parquet::SchemaElement &schema_ele,
+                                                   const ParquetColumnSchema &schema_ele,
                                                    const std::string &stats) {
 	auto stats_data = const_data_ptr_cast(stats.c_str());
 	switch (type.id()) {
@@ -104,13 +105,9 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 		return Value::FLOAT(val);
 	}
 	case LogicalTypeId::DOUBLE: {
-		switch (schema_ele.type) {
-		case Type::FIXED_LEN_BYTE_ARRAY:
-		case Type::BYTE_ARRAY:
+		if (schema_ele.type_info == ParquetExtraTypeInfo::DECIMAL_BYTE_ARRAY) {
 			// decimals cast to double
 			return Value::DOUBLE(ParquetDecimalUtils::ReadDecimalValue<double>(stats_data, stats.size(), schema_ele));
-		default:
-			break;
 		}
 		if (stats.size() != sizeof(double)) {
 			throw InvalidInputException("Incorrect stats size for type DOUBLE");
@@ -124,40 +121,37 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 	case LogicalTypeId::DECIMAL: {
 		auto width = DecimalType::GetWidth(type);
 		auto scale = DecimalType::GetScale(type);
-		switch (schema_ele.type) {
-		case Type::INT32: {
+		switch (schema_ele.type_info) {
+		case ParquetExtraTypeInfo::DECIMAL_INT32:
 			if (stats.size() != sizeof(int32_t)) {
 				throw InvalidInputException("Incorrect stats size for type %s", type.ToString());
 			}
 			return Value::DECIMAL(Load<int32_t>(stats_data), width, scale);
-		}
-		case Type::INT64: {
+		case ParquetExtraTypeInfo::DECIMAL_INT64:
 			if (stats.size() != sizeof(int64_t)) {
 				throw InvalidInputException("Incorrect stats size for type %s", type.ToString());
 			}
 			return Value::DECIMAL(Load<int64_t>(stats_data), width, scale);
-		}
-		case Type::BYTE_ARRAY:
-		case Type::FIXED_LEN_BYTE_ARRAY:
+		case ParquetExtraTypeInfo::DECIMAL_BYTE_ARRAY:
 			switch (type.InternalType()) {
 			case PhysicalType::INT16:
 				return Value::DECIMAL(
-				    ParquetDecimalUtils::ReadDecimalValue<int16_t>(stats_data, stats.size(), schema_ele), width, scale);
+					ParquetDecimalUtils::ReadDecimalValue<int16_t>(stats_data, stats.size(), schema_ele), width, scale);
 			case PhysicalType::INT32:
 				return Value::DECIMAL(
-				    ParquetDecimalUtils::ReadDecimalValue<int32_t>(stats_data, stats.size(), schema_ele), width, scale);
+					ParquetDecimalUtils::ReadDecimalValue<int32_t>(stats_data, stats.size(), schema_ele), width, scale);
 			case PhysicalType::INT64:
 				return Value::DECIMAL(
-				    ParquetDecimalUtils::ReadDecimalValue<int64_t>(stats_data, stats.size(), schema_ele), width, scale);
+					ParquetDecimalUtils::ReadDecimalValue<int64_t>(stats_data, stats.size(), schema_ele), width, scale);
 			case PhysicalType::INT128:
 				return Value::DECIMAL(
-				    ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(stats_data, stats.size(), schema_ele), width,
-				    scale);
+					ParquetDecimalUtils::ReadDecimalValue<hugeint_t>(stats_data, stats.size(), schema_ele), width,
+					scale);
 			default:
 				throw InvalidInputException("Unsupported internal type for decimal");
 			}
 		default:
-			throw InternalException("Unsupported internal type for decimal?..");
+			throw NotImplementedException("Unrecognized Parquet type for Decimal");
 		}
 	}
 	case LogicalTypeId::VARCHAR:
@@ -180,21 +174,13 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 		} else {
 			throw InvalidInputException("Incorrect stats size for type TIME");
 		}
-		if (schema_ele.__isset.logicalType && schema_ele.logicalType.__isset.TIME) {
-			// logical type
-			if (schema_ele.logicalType.TIME.unit.__isset.MILLIS) {
-				return Value::TIME(Time::FromTimeMs(val));
-			} else if (schema_ele.logicalType.TIME.unit.__isset.NANOS) {
-				return Value::TIME(Time::FromTimeNs(val));
-			} else if (schema_ele.logicalType.TIME.unit.__isset.MICROS) {
-				return Value::TIME(dtime_t(val));
-			} else {
-				throw InternalException("Time logicalType is set but unit is not defined");
-			}
-		}
-		if (schema_ele.converted_type == duckdb_parquet::ConvertedType::TIME_MILLIS) {
+		switch(schema_ele.type_info) {
+		case ParquetExtraTypeInfo::UNIT_MS:
 			return Value::TIME(Time::FromTimeMs(val));
-		} else {
+		case ParquetExtraTypeInfo::UNIT_NS:
+				return Value::TIME(Time::FromTimeNs(val));
+		case ParquetExtraTypeInfo::UNIT_MICROS:
+		default:
 			return Value::TIME(dtime_t(val));
 		}
 	}
@@ -207,49 +193,40 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 		} else {
 			throw InvalidInputException("Incorrect stats size for type TIMETZ");
 		}
-		if (schema_ele.__isset.logicalType && schema_ele.logicalType.__isset.TIME) {
-			// logical type
-			if (schema_ele.logicalType.TIME.unit.__isset.MILLIS) {
-				return Value::TIMETZ(ParquetIntToTimeMsTZ(NumericCast<int32_t>(val)));
-			} else if (schema_ele.logicalType.TIME.unit.__isset.MICROS) {
-				return Value::TIMETZ(ParquetIntToTimeTZ(val));
-			} else if (schema_ele.logicalType.TIME.unit.__isset.NANOS) {
-				return Value::TIMETZ(ParquetIntToTimeNsTZ(val));
-			} else {
-				throw InternalException("Time With Time Zone logicalType is set but unit is not defined");
-			}
+		switch(schema_ele.type_info) {
+		case ParquetExtraTypeInfo::UNIT_MS:
+			return Value::TIMETZ(ParquetIntToTimeMsTZ(NumericCast<int32_t>(val)));
+		case ParquetExtraTypeInfo::UNIT_NS:
+			return Value::TIMETZ(ParquetIntToTimeNsTZ(val));
+		case ParquetExtraTypeInfo::UNIT_MICROS:
+		default:
+			return Value::TIMETZ(ParquetIntToTimeTZ(val));
 		}
-		return Value::TIMETZ(ParquetIntToTimeTZ(val));
 	}
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ: {
 		timestamp_t timestamp_value;
-		if (schema_ele.type == Type::INT96) {
+		if (schema_ele.type_info == ParquetExtraTypeInfo::IMPALA_TIMESTAMP) {
 			if (stats.size() != sizeof(Int96)) {
 				throw InvalidInputException("Incorrect stats size for type TIMESTAMP");
 			}
 			timestamp_value = ImpalaTimestampToTimestamp(Load<Int96>(stats_data));
 		} else {
-			D_ASSERT(schema_ele.type == Type::INT64);
 			if (stats.size() != sizeof(int64_t)) {
 				throw InvalidInputException("Incorrect stats size for type TIMESTAMP");
 			}
 			auto val = Load<int64_t>(stats_data);
-			if (schema_ele.__isset.logicalType && schema_ele.logicalType.__isset.TIMESTAMP) {
-				// logical type
-				if (schema_ele.logicalType.TIMESTAMP.unit.__isset.MILLIS) {
-					timestamp_value = Timestamp::FromEpochMs(val);
-				} else if (schema_ele.logicalType.TIMESTAMP.unit.__isset.NANOS) {
-					timestamp_value = Timestamp::FromEpochNanoSeconds(val);
-				} else if (schema_ele.logicalType.TIMESTAMP.unit.__isset.MICROS) {
-					timestamp_value = timestamp_t(val);
-				} else {
-					throw InternalException("Timestamp logicalType is set but unit is not defined");
-				}
-			} else if (schema_ele.converted_type == duckdb_parquet::ConvertedType::TIMESTAMP_MILLIS) {
+			switch(schema_ele.type_info) {
+			case ParquetExtraTypeInfo::UNIT_MS:
 				timestamp_value = Timestamp::FromEpochMs(val);
-			} else {
+				break;
+			case ParquetExtraTypeInfo::UNIT_NS:
+				timestamp_value = Timestamp::FromEpochNanoSeconds(val);
+				break;
+			case ParquetExtraTypeInfo::UNIT_MICROS:
+			default:
 				timestamp_value = timestamp_t(val);
+				break;
 			}
 		}
 		if (type.id() == LogicalTypeId::TIMESTAMP_TZ) {
@@ -259,32 +236,27 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 	}
 	case LogicalTypeId::TIMESTAMP_NS: {
 		timestamp_ns_t timestamp_value;
-		if (schema_ele.type == Type::INT96) {
+		if (schema_ele.type_info == ParquetExtraTypeInfo::IMPALA_TIMESTAMP) {
 			if (stats.size() != sizeof(Int96)) {
 				throw InvalidInputException("Incorrect stats size for type TIMESTAMP_NS");
 			}
 			timestamp_value = ImpalaTimestampToTimestampNS(Load<Int96>(stats_data));
 		} else {
-			D_ASSERT(schema_ele.type == Type::INT64);
 			if (stats.size() != sizeof(int64_t)) {
 				throw InvalidInputException("Incorrect stats size for type TIMESTAMP_NS");
 			}
 			auto val = Load<int64_t>(stats_data);
-			if (schema_ele.__isset.logicalType && schema_ele.logicalType.__isset.TIMESTAMP) {
-				// logical type
-				if (schema_ele.logicalType.TIMESTAMP.unit.__isset.MILLIS) {
-					timestamp_value = ParquetTimestampMsToTimestampNs(val);
-				} else if (schema_ele.logicalType.TIMESTAMP.unit.__isset.NANOS) {
-					timestamp_value = ParquetTimestampNsToTimestampNs(val);
-				} else if (schema_ele.logicalType.TIMESTAMP.unit.__isset.MICROS) {
-					timestamp_value = ParquetTimestampUsToTimestampNs(val);
-				} else {
-					throw InternalException("Timestamp (NS) logicalType is set but unit is unknown");
-				}
-			} else if (schema_ele.converted_type == duckdb_parquet::ConvertedType::TIMESTAMP_MILLIS) {
+			switch(schema_ele.type_info) {
+			case ParquetExtraTypeInfo::UNIT_MS:
 				timestamp_value = ParquetTimestampMsToTimestampNs(val);
-			} else {
+				break;
+			case ParquetExtraTypeInfo::UNIT_NS:
+				timestamp_value = ParquetTimestampNsToTimestampNs(val);
+				break;
+			case ParquetExtraTypeInfo::UNIT_MICROS:
+			default:
 				timestamp_value = ParquetTimestampUsToTimestampNs(val);
+				break;
 			}
 		}
 		return Value::TIMESTAMPNS(timestamp_value);
@@ -294,28 +266,25 @@ Value ParquetStatisticsUtils::ConvertValueInternal(const LogicalType &type,
 	}
 }
 
-unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(const ColumnReader &reader,
+unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(const ParquetColumnSchema &schema,
                                                                              const vector<ColumnChunk> &columns) {
 
 	// Not supported types
-	if (reader.Type().id() == LogicalTypeId::ARRAY || reader.Type().id() == LogicalTypeId::MAP ||
-	    reader.Type().id() == LogicalTypeId::LIST) {
+	auto &type = schema.type;
+	if (type.id() == LogicalTypeId::ARRAY || type.id() == LogicalTypeId::MAP ||
+	    type.id() == LogicalTypeId::LIST) {
 		return nullptr;
 	}
 
 	unique_ptr<BaseStatistics> row_group_stats;
 
 	// Structs are handled differently (they dont have stats)
-	if (reader.Type().id() == LogicalTypeId::STRUCT) {
-		auto struct_stats = StructStats::CreateUnknown(reader.Type());
-		auto &struct_reader = reader.Cast<StructColumnReader>();
+	if (type.id() == LogicalTypeId::STRUCT) {
+		auto struct_stats = StructStats::CreateUnknown(type);
 		// Recurse into child readers
-		for (idx_t i = 0; i < struct_reader.child_readers.size(); i++) {
-			if (!struct_reader.child_readers[i]) {
-				continue;
-			}
-			auto &child_reader = *struct_reader.child_readers[i];
-			auto child_stats = ParquetStatisticsUtils::TransformColumnStatistics(child_reader, columns);
+		for (idx_t i = 0; i < schema.children.size(); i++) {
+			auto &child_schema = schema.children[i];
+			auto child_stats = ParquetStatisticsUtils::TransformColumnStatistics(child_schema, columns);
 			StructStats::SetChildStats(struct_stats, i, std::move(child_stats));
 		}
 		row_group_stats = struct_stats.ToUnique();
@@ -329,15 +298,12 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 
 	// Otherwise, its a standard column with stats
 
-	auto &column_chunk = columns[reader.FileIdx()];
+	auto &column_chunk = columns[schema.schema_index];
 	if (!column_chunk.__isset.meta_data || !column_chunk.meta_data.__isset.statistics) {
 		// no stats present for row group
 		return nullptr;
 	}
 	auto &parquet_stats = column_chunk.meta_data.statistics;
-
-	auto &type = reader.Type();
-	auto &s_ele = reader.Schema();
 
 	switch (type.id()) {
 	case LogicalTypeId::UTINYINT:
@@ -359,7 +325,7 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::DECIMAL:
-		row_group_stats = CreateNumericStats(type, s_ele, parquet_stats);
+		row_group_stats = CreateNumericStats(type, schema, parquet_stats);
 		break;
 	case LogicalTypeId::VARCHAR: {
 		auto string_stats = StringStats::CreateEmpty(type);

--- a/extension/parquet/reader/cast_column_reader.cpp
+++ b/extension/parquet/reader/cast_column_reader.cpp
@@ -6,17 +6,11 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Cast Column Reader
 //===--------------------------------------------------------------------===//
-CastColumnReader::CastColumnReader(unique_ptr<ColumnReader> child_reader_p, LogicalType target_type_p)
-    : ColumnReader(child_reader_p->Reader(), std::move(target_type_p), child_reader_p->Schema(),
-                   child_reader_p->FileIdx(), child_reader_p->MaxDefine(), child_reader_p->MaxRepeat()),
+CastColumnReader::CastColumnReader(unique_ptr<ColumnReader> child_reader_p, const ParquetColumnSchema &schema)
+    : ColumnReader(child_reader_p->Reader(), schema),
       child_reader(std::move(child_reader_p)) {
 	vector<LogicalType> intermediate_types {child_reader->Type()};
 	intermediate_chunk.Initialize(reader.allocator, intermediate_types);
-}
-
-unique_ptr<BaseStatistics> CastColumnReader::Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) {
-	// casting stats is not supported (yet)
-	return nullptr;
 }
 
 void CastColumnReader::InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns,
@@ -37,7 +31,7 @@ idx_t CastColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data_pt
 			// COPY .. FROM
 			extended_error = StringUtil::Format(
 			    "In file \"%s\" the column \"%s\" has type %s, but we are trying to load it into column ",
-			    reader.file_name, schema.name, intermediate_vector.GetType());
+			    reader.file_name, column_schema.name, intermediate_vector.GetType());
 			if (FileIdx() < reader.table_columns.size()) {
 				extended_error += "\"" + reader.table_columns[FileIdx()] + "\" ";
 			}
@@ -52,7 +46,7 @@ idx_t CastColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data_pt
 			// read_parquet() with multiple files
 			extended_error = StringUtil::Format(
 			    "In file \"%s\" the column \"%s\" has type %s, but we are trying to read it as type %s.",
-			    reader.file_name, schema.name, intermediate_vector.GetType(), result.GetType());
+			    reader.file_name, column_schema.name, intermediate_vector.GetType(), result.GetType());
 			extended_error +=
 			    "\nThis can happen when reading multiple Parquet files. The schema information is taken from "
 			    "the first Parquet file by default. Possible solutions:\n";
@@ -62,7 +56,7 @@ idx_t CastColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data_pt
 		}
 		throw ConversionException(
 		    "In Parquet reader of file \"%s\": failed to cast column \"%s\" from type %s to %s: %s\n\n%s",
-		    reader.file_name, schema.name, intermediate_vector.GetType(), result.GetType(), error_message,
+		    reader.file_name, column_schema.name, intermediate_vector.GetType(), result.GetType(), error_message,
 		    extended_error);
 	}
 	return amount;

--- a/extension/parquet/reader/cast_column_reader.cpp
+++ b/extension/parquet/reader/cast_column_reader.cpp
@@ -33,8 +33,8 @@ idx_t CastColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data_pt
 			extended_error = StringUtil::Format(
 			    "In file \"%s\" the column \"%s\" has type %s, but we are trying to load it into column ",
 			    reader.file_name, column_schema.name, intermediate_vector.GetType());
-			if (FileIdx() < reader.table_columns.size()) {
-				extended_error += "\"" + reader.table_columns[FileIdx()] + "\" ";
+			if (ColumnIndex() < reader.table_columns.size()) {
+				extended_error += "\"" + reader.table_columns[ColumnIndex()] + "\" ";
 			}
 			extended_error += StringUtil::Format("with type %s.", result.GetType());
 			extended_error += "\nThis means the Parquet schema does not match the schema of the table.";

--- a/extension/parquet/reader/cast_column_reader.cpp
+++ b/extension/parquet/reader/cast_column_reader.cpp
@@ -6,8 +6,10 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Cast Column Reader
 //===--------------------------------------------------------------------===//
-CastColumnReader::CastColumnReader(unique_ptr<ColumnReader> child_reader_p, const ParquetColumnSchema &schema)
-    : ColumnReader(child_reader_p->Reader(), schema), child_reader(std::move(child_reader_p)) {
+CastColumnReader::CastColumnReader(unique_ptr<ColumnReader> child_reader_p,
+                                   unique_ptr<ParquetColumnSchema> cast_schema_p)
+    : ColumnReader(child_reader_p->Reader(), *cast_schema_p), child_reader(std::move(child_reader_p)),
+      cast_schema(std::move(cast_schema_p)) {
 	vector<LogicalType> intermediate_types {child_reader->Type()};
 	intermediate_chunk.Initialize(reader.allocator, intermediate_types);
 }

--- a/extension/parquet/reader/cast_column_reader.cpp
+++ b/extension/parquet/reader/cast_column_reader.cpp
@@ -7,8 +7,7 @@ namespace duckdb {
 // Cast Column Reader
 //===--------------------------------------------------------------------===//
 CastColumnReader::CastColumnReader(unique_ptr<ColumnReader> child_reader_p, const ParquetColumnSchema &schema)
-    : ColumnReader(child_reader_p->Reader(), schema),
-      child_reader(std::move(child_reader_p)) {
+    : ColumnReader(child_reader_p->Reader(), schema), child_reader(std::move(child_reader_p)) {
 	vector<LogicalType> intermediate_types {child_reader->Type()};
 	intermediate_chunk.Initialize(reader.allocator, intermediate_types);
 }

--- a/extension/parquet/reader/expression_column_reader.cpp
+++ b/extension/parquet/reader/expression_column_reader.cpp
@@ -8,16 +8,10 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, unique_ptr<ColumnReader> child_reader_p,
                                                unique_ptr<Expression> expr_p)
-    : ColumnReader(child_reader_p->Reader(), expr_p->return_type, child_reader_p->Schema(), child_reader_p->FileIdx(),
-                   child_reader_p->MaxDefine(), child_reader_p->MaxRepeat()),
+    : ColumnReader(child_reader_p->Reader(), child_reader_p->Schema()),
       child_reader(std::move(child_reader_p)), expr(std::move(expr_p)), executor(context, expr.get()) {
 	vector<LogicalType> intermediate_types {child_reader->Type()};
 	intermediate_chunk.Initialize(reader.allocator, intermediate_types);
-}
-
-unique_ptr<BaseStatistics> ExpressionColumnReader::Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) {
-	// expression stats is not supported (yet)
-	return nullptr;
 }
 
 void ExpressionColumnReader::InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns,

--- a/extension/parquet/reader/expression_column_reader.cpp
+++ b/extension/parquet/reader/expression_column_reader.cpp
@@ -8,8 +8,8 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 ExpressionColumnReader::ExpressionColumnReader(ClientContext &context, unique_ptr<ColumnReader> child_reader_p,
                                                unique_ptr<Expression> expr_p)
-    : ColumnReader(child_reader_p->Reader(), child_reader_p->Schema()),
-      child_reader(std::move(child_reader_p)), expr(std::move(expr_p)), executor(context, expr.get()) {
+    : ColumnReader(child_reader_p->Reader(), child_reader_p->Schema()), child_reader(std::move(child_reader_p)),
+      expr(std::move(expr_p)), executor(context, expr.get()) {
 	vector<LogicalType> intermediate_types {child_reader->Type()};
 	intermediate_chunk.Initialize(reader.allocator, intermediate_types);
 }

--- a/extension/parquet/reader/list_column_reader.cpp
+++ b/extension/parquet/reader/list_column_reader.cpp
@@ -173,8 +173,7 @@ idx_t ListColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data_pt
 
 ListColumnReader::ListColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
                                    unique_ptr<ColumnReader> child_column_reader_p)
-    : ColumnReader(reader, schema),
-      child_column_reader(std::move(child_column_reader_p)),
+    : ColumnReader(reader, schema), child_column_reader(std::move(child_column_reader_p)),
       read_cache(reader.allocator, ListType::GetChildType(Type())), read_vector(read_cache), overflow_child_count(0) {
 
 	child_defines.resize(reader.allocator, STANDARD_VECTOR_SIZE);

--- a/extension/parquet/reader/row_number_column_reader.cpp
+++ b/extension/parquet/reader/row_number_column_reader.cpp
@@ -6,25 +6,8 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Row NumberColumn Reader
 //===--------------------------------------------------------------------===//
-RowNumberColumnReader::RowNumberColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p,
-                                             idx_t schema_idx_p, idx_t max_define_p, idx_t max_repeat_p)
-    : ColumnReader(reader, std::move(type_p), schema_p, schema_idx_p, max_define_p, max_repeat_p) {
-}
-
-unique_ptr<BaseStatistics> RowNumberColumnReader::Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns) {
-	auto stats = NumericStats::CreateUnknown(type);
-	auto &row_groups = reader.GetFileMetadata()->row_groups;
-	D_ASSERT(row_group_idx_p < row_groups.size());
-	idx_t row_group_offset_min = 0;
-	for (idx_t i = 0; i < row_group_idx_p; i++) {
-		row_group_offset_min += row_groups[i].num_rows;
-	}
-
-	NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min)));
-	NumericStats::SetMax(
-	    stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min + row_groups[row_group_idx_p].num_rows)));
-	stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
-	return stats.ToUnique();
+RowNumberColumnReader::RowNumberColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+    : ColumnReader(reader, schema) {
 }
 
 void RowNumberColumnReader::InitializeRead(idx_t row_group_idx_p, const vector<ColumnChunk> &columns,

--- a/extension/parquet/reader/string_column_reader.cpp
+++ b/extension/parquet/reader/string_column_reader.cpp
@@ -11,10 +11,8 @@ namespace duckdb {
 StringColumnReader::StringColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
     : ColumnReader(reader, schema) {
 	fixed_width_string_length = 0;
-	auto &parquet_schema = schema.schema.get();
-	if (parquet_schema.type == Type::FIXED_LEN_BYTE_ARRAY) {
-		D_ASSERT(parquet_schema.__isset.type_length);
-		fixed_width_string_length = parquet_schema.type_length;
+	if (schema.type_length > 0) {
+		fixed_width_string_length = schema.type_length;
 	}
 }
 

--- a/extension/parquet/reader/string_column_reader.cpp
+++ b/extension/parquet/reader/string_column_reader.cpp
@@ -8,13 +8,13 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // String Column Reader
 //===--------------------------------------------------------------------===//
-StringColumnReader::StringColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p,
-                                       idx_t schema_idx_p, idx_t max_define_p, idx_t max_repeat_p)
-    : ColumnReader(reader, std::move(type_p), schema_p, schema_idx_p, max_define_p, max_repeat_p) {
+StringColumnReader::StringColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema)
+    : ColumnReader(reader, schema) {
 	fixed_width_string_length = 0;
-	if (schema_p.type == Type::FIXED_LEN_BYTE_ARRAY) {
-		D_ASSERT(schema_p.__isset.type_length);
-		fixed_width_string_length = schema_p.type_length;
+	auto &parquet_schema = schema.schema.get();
+	if (parquet_schema.type == Type::FIXED_LEN_BYTE_ARRAY) {
+		D_ASSERT(parquet_schema.__isset.type_length);
+		fixed_width_string_length = parquet_schema.type_length;
 	}
 }
 

--- a/extension/parquet/reader/struct_column_reader.cpp
+++ b/extension/parquet/reader/struct_column_reader.cpp
@@ -5,12 +5,11 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Struct Column Reader
 //===--------------------------------------------------------------------===//
-StructColumnReader::StructColumnReader(ParquetReader &reader, LogicalType type_p, const SchemaElement &schema_p,
-                                       idx_t schema_idx_p, idx_t max_define_p, idx_t max_repeat_p,
+StructColumnReader::StructColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
                                        vector<unique_ptr<ColumnReader>> child_readers_p)
-    : ColumnReader(reader, std::move(type_p), schema_p, schema_idx_p, max_define_p, max_repeat_p),
+    : ColumnReader(reader, schema),
       child_readers(std::move(child_readers_p)) {
-	D_ASSERT(type.InternalType() == PhysicalType::STRUCT);
+	D_ASSERT(Type().InternalType() == PhysicalType::STRUCT);
 }
 
 ColumnReader &StructColumnReader::GetChildReader(idx_t child_idx) {
@@ -61,7 +60,7 @@ idx_t StructColumnReader::Read(uint64_t num_values, data_ptr_t define_out, data_
 	// set the validity mask for this level
 	auto &validity = FlatVector::Validity(result);
 	for (idx_t i = 0; i < read_count.GetIndex(); i++) {
-		if (define_out[i] < max_define) {
+		if (define_out[i] < MaxDefine()) {
 			validity.SetInvalid(i);
 		}
 	}

--- a/extension/parquet/reader/struct_column_reader.cpp
+++ b/extension/parquet/reader/struct_column_reader.cpp
@@ -7,8 +7,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 StructColumnReader::StructColumnReader(ParquetReader &reader, const ParquetColumnSchema &schema,
                                        vector<unique_ptr<ColumnReader>> child_readers_p)
-    : ColumnReader(reader, schema),
-      child_readers(std::move(child_readers_p)) {
+    : ColumnReader(reader, schema), child_readers(std::move(child_readers_p)) {
 	D_ASSERT(Type().InternalType() == PhysicalType::STRUCT);
 }
 

--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -35,6 +35,9 @@ public:
 		return std::move(statistics_map);
 	}
 
+	static unique_ptr<BaseStatistics> TryPropagateCast(BaseStatistics &stats, const LogicalType &source,
+	                                                   const LogicalType &target);
+
 private:
 	//! Propagate statistics through an operator
 	unique_ptr<NodeStatistics> PropagateStatistics(LogicalOperator &node, unique_ptr<LogicalOperator> &node_ptr);

--- a/test/sql/copy/parquet/test_parquet_nested.test
+++ b/test/sql/copy/parquet/test_parquet_nested.test
@@ -36,13 +36,6 @@ SELECT unnest(a) FROM parquet_scan('data/parquet-testing/arrow/nested_lists.snap
 [[a, b], [c, d], [e]]
 [NULL, [f]]
 
-
-# FIXME
-#query I
-#SELECT unnest(unnest(a)) FROM parquet_scan('data/parquet-testing/nested_lists.snappy.parquet')
-#----
-
-
 query II
 SELECT * FROM parquet_scan('data/parquet-testing/arrow/list_columns.parquet')
 ----


### PR DESCRIPTION
The current Parquet reader uses the ColumnReader for two purposes:

* Parsing schema metadata (getting the types/names and reading stats)
* Reading the data

This PR splits up these two cases. The `ParquetColumnSchema` class is added which fulfills the first purpose. The new `ParseSchema` method looks at a Parquet schema and converts that into a `ParquetColumnSchema`. This is used in the `ParquetReader` to obtain the result types of the file.

The column readers are now created using the `CreateReader` method *based on* the `ParquetColumnSchema` objects. As a result, creating the column readers is significantly simpler (as the Parquet metadata has already been parsed at this stage). We can also avoid creating column readers for columns we are not going to read - which can lead to significant performance improvements when we are only reading a small subset of the columns when reading small-ish files. 