### PR TITLE
Have CSV Parellel tests on CI again

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -219,7 +219,6 @@ jobs:
           -e ENABLE_EXTENSION_AUTOINSTALL=1                                      \
           -e BUILD_BENCHMARK=1                                                   \
           -e FORCE_WARN_UNUSED=1                                                 \
-          -e DUCKDB_RUN_PARALLEL_CSV_TESTS=1                                     \
           quay.io/pypa/manylinux2014_x86_64                                      \
           bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make bundle-library -C $PWD"
       - name: Print platform

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -84,7 +84,6 @@ jobs:
         -e ENABLE_EXTENSION_AUTOINSTALL=1                                      \
         -e BUILD_BENCHMARK=1                                                   \
         -e FORCE_WARN_UNUSED=1                                                 \
-        -e DUCKDB_RUN_PARALLEL_CSV_TESTS=1                                     \
         quay.io/pypa/manylinux2014_${{ matrix.config.image }}                  \
         bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make -C $PWD"
 

--- a/test/README.md
+++ b/test/README.md
@@ -7,8 +7,6 @@ Some of the tests require a special environment flag to be set so they can prope
 ### Parallel CSV Reader
 The tests located in `test/parallel_csv/test_parallel_csv.cpp` run the parallel CSV reader over multiple configurations of threads
 and buffer sizes.
-To run them `DUCKDB_RUN_PARALLEL_CSV_TESTS` must be set. This is done because these tests are quite slow and should only be executed
-on release builds with no debugging options set.
 
 ### ADBC
 The ADBC tests are in `test/api/adbc/test_adbc.cpp`. To run them the DuckDB library path must be provided in the `DUCKDB_INSTALL_LIB` variable.

--- a/test/parallel_csv/test_parallel_csv.cpp
+++ b/test/parallel_csv/test_parallel_csv.cpp
@@ -25,8 +25,6 @@ const string tbl_zst = "tbl.zst";
 
 const string csv_extensions[5] = {csv, tsv, csv_gz, csv_zst, tbl_zst};
 
-const char *run = std::getenv("DUCKDB_RUN_PARALLEL_CSV_TESTS");
-
 bool RunVariableBuffer(const string &path, idx_t buffer_size, bool set_temp_dir,
                        ColumnDataCollection *ground_truth = nullptr, const string &add_parameters = "") {
 	DuckDB db(nullptr);
@@ -78,9 +76,6 @@ bool RunFull(std::string &path, std::set<std::string> *skip = nullptr, const str
              bool set_temp_dir = false) {
 	DuckDB db(nullptr);
 	Connection conn(db);
-	if (!run) {
-		return true;
-	}
 	// Here we run the csv file first with the full buffer.
 	// Then a combination of multiple buffers.
 	if (skip) {

--- a/test/parallel_csv/test_parallel_csv.cpp
+++ b/test/parallel_csv/test_parallel_csv.cpp
@@ -226,6 +226,9 @@ TEST_CASE("Test Parallel CSV All Files - data/csv", "[parallel-csv][.]") {
 	// This file requires a temp_dir for offloading
 	skip.insert("data/csv/hebere.csv.gz");
 	skip.insert("data/csv/no_quote.csv");
+	// FIXME: This should be fixed when we get the strict mode working with mixed new line delims
+	skip.insert("data/csv/mixed_new_line.csv");
+
 	RunTestOnFolder("data/csv/", &skip);
 }
 


### PR DESCRIPTION
At some point one of the CI refactors, disabled the Parallel CSV Tests.

This PR makes the CI run it again, all tests are slow, and they take about ~20 seconds, so the extra flag is not really necessary.

The file `data/csv/mixed_new_line.csv` is breaking, but should be fixed with: https://github.com/duckdb/duckdb/pull/15959

Hence I'm skipping it for now.