### PR TITLE
Add parallel memset when building hash join table

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -677,7 +677,7 @@ void JoinHashTable::InsertHashes(Vector &hashes_v, const idx_t count, TupleDataC
 	}
 }
 
-void JoinHashTable::InitializePointerTable() {
+void JoinHashTable::AllocatePointerTable() {
 	capacity = PointerTableCapacity(Count());
 	D_ASSERT(IsPowerOfTwo(capacity));
 
@@ -699,10 +699,12 @@ void JoinHashTable::InitializePointerTable() {
 	}
 	D_ASSERT(hash_map.GetSize() == capacity * sizeof(ht_entry_t));
 
-	// initialize HT with all-zero entries
-	std::fill_n(entries, capacity, ht_entry_t());
-
 	bitmask = capacity - 1;
+}
+
+void JoinHashTable::InitializePointerTable(idx_t entry_idx_from, idx_t entry_idx_to) {
+	// initialize HT with all-zero entries
+	std::fill_n(entries + entry_idx_from, entry_idx_to - entry_idx_from, ht_entry_t());
 }
 
 void JoinHashTable::Finalize(idx_t chunk_idx_from, idx_t chunk_idx_to, bool parallel) {

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -461,8 +461,8 @@ public:
 			// Parallel memset
 			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx += ENTRIES_PER_TASK) {
 				auto entry_idx_to = MinValue<idx_t>(entry_idx + ENTRIES_PER_TASK, entry_count);
-				finalize_tasks.push_back(make_uniq<HashJoinTableInitTask>(shared_from_this(), context, sink,
-				                                                          entry_idx, entry_idx_to, sink.op));
+				finalize_tasks.push_back(make_uniq<HashJoinTableInitTask>(shared_from_this(), context, sink, entry_idx,
+				                                                          entry_idx_to, sink.op));
 			}
 		}
 		SetTasks(std::move(finalize_tasks));

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -523,7 +523,7 @@ public:
 		    sink.max_partition_size + JoinHashTable::PointerTableSize(sink.max_partition_count);
 		const auto skew = static_cast<double>(max_partition_ht_size) / static_cast<double>(sink.total_size);
 
-		if (num_threads == 1 || (ht.Count() < PARALLEL_CONSTRUCT_THRESHOLD && skew > SKEW_SINGLE_THREADED_THRESHOLD &&
+		if (num_threads == 1 || ((ht.Count() < PARALLEL_CONSTRUCT_THRESHOLD || skew > SKEW_SINGLE_THREADED_THRESHOLD) &&
 		                         !context.config.verify_parallelism)) {
 			// Single-threaded finalize
 			finalize_tasks.push_back(

--- a/src/include/duckdb/execution/join_hashtable.hpp
+++ b/src/include/duckdb/execution/join_hashtable.hpp
@@ -177,8 +177,10 @@ public:
 	void Merge(JoinHashTable &other);
 	//! Combines the partitions in sink_collection into data_collection, as if it were not partitioned
 	void Unpartition();
+	//! Allocate the pointer table for the probe
+	void AllocatePointerTable();
 	//! Initialize the pointer table for the probe
-	void InitializePointerTable();
+	void InitializePointerTable(idx_t entry_idx_from, idx_t entry_idx_to);
 	//! Finalize the build of the HT, constructing the actual hash table and making the HT ready for probing.
 	//! Finalize must be called before any call to Probe, and after Finalize is called Build should no longer be
 	//! ever called.


### PR DESCRIPTION
I found that when the number of threads and tables are both large, single-threaded memset (fill_n) becomes a bottleneck for hash joins. Therefore, I added parallel memset functionality. The following are the test results using 16 threads on TPCH with a scale factor of 30, the machine having 2x Intel(R) Xeon(R) Platinum 8474C @ 2.10GHz and 512GB of memory.
```
q01.benchmark
Old timing: 0.307804
New timing: 0.305122

q02.benchmark
Old timing: 0.09011
New timing: 0.081623

q03.benchmark
Old timing: 0.219148
New timing: 0.185937

q04.benchmark
Old timing: 0.197395
New timing: 0.172733

q05.benchmark
Old timing: 0.200423
New timing: 0.177111

q06.benchmark
Old timing: 0.056182
New timing: 0.055329

q07.benchmark
Old timing: 0.220938
New timing: 0.185942

q08.benchmark
Old timing: 0.238767
New timing: 0.221206

q09.benchmark
Old timing: 0.81091
New timing: 0.74094

q10.benchmark
Old timing: 0.384993
New timing: 0.358605

q11.benchmark
Old timing: 0.043594
New timing: 0.047106

q12.benchmark
Old timing: 0.149087
New timing: 0.152796

q13.benchmark
Old timing: 0.607926
New timing: 0.588897

q14.benchmark
Old timing: 0.140369
New timing: 0.110691

q15.benchmark
Old timing: 0.100208
New timing: 0.09759

q16.benchmark
Old timing: 0.121195
New timing: 0.11974

q17.benchmark
Old timing: 0.332341
New timing: 0.326049

q18.benchmark
Old timing: 0.666402
New timing: 0.641981

q19.benchmark
Old timing: 0.248784
New timing: 0.236629

q20.benchmark
Old timing: 0.174007
New timing: 0.175727

q21.benchmark
Old timing: 0.700216
New timing: 0.629451

q22.benchmark
Old timing: 0.141347
New timing: 0.128283


Old timing geometric mean: 0.2120037943770715
New timing geometric mean: 0.19861073916154134, roughly 6% faster
```






