### PR TITLE
[CI] Avoid Linux CLI jobs to fail-fast

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -55,6 +55,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature' }}
 
     strategy:
+      fail-fast: false
       matrix:
         config: [ { runner: ubuntu-latest, arch: amd64, image: x86_64}, {runner: ubuntu-24.04-arm, arch: arm64, image: aarch64}]
 


### PR DESCRIPTION
Otherwise the default is `fail-fast: true`, that means that one side failing a test means the test on the other side are not run to completion.