### PR TITLE
Parquet: Add dedicated Select method that can be used to push selection vectors into the read

### DIFF
--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -68,6 +68,8 @@ public:
 	static unique_ptr<ColumnReader> CreateReader(ParquetReader &reader, const ParquetColumnSchema &schema);
 	virtual void InitializeRead(idx_t row_group_index, const vector<ColumnChunk> &columns, TProtocol &protocol_p);
 	virtual idx_t Read(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out);
+	virtual void Select(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out,
+	                    const SelectionVector &sel, idx_t approved_tuple_count);
 	virtual void Filter(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out,
 	                    const TableFilter &filter, SelectionVector &sel, idx_t &approved_tuple_count,
 	                    bool is_first_filter);
@@ -103,7 +105,7 @@ public:
 	unique_ptr<BaseStatistics> Stats(idx_t row_group_idx_p, const vector<ColumnChunk> &columns);
 
 	template <class VALUE_TYPE, class CONVERSION, bool HAS_DEFINES>
-	void PlainTemplatedDefines(ByteBuffer &plain_data, uint8_t *defines, uint64_t num_values, idx_t result_offset,
+	void PlainTemplatedDefines(ByteBuffer &plain_data, const uint8_t *defines, uint64_t num_values, idx_t result_offset,
 	                           Vector &result) {
 		if (CONVERSION::PlainAvailable(plain_data, num_values)) {
 			PlainTemplatedInternal<VALUE_TYPE, CONVERSION, HAS_DEFINES, false>(plain_data, defines, num_values,
@@ -114,7 +116,7 @@ public:
 		}
 	}
 	template <class VALUE_TYPE, class CONVERSION>
-	void PlainTemplated(ByteBuffer &plain_data, uint8_t *defines, uint64_t num_values, idx_t result_offset,
+	void PlainTemplated(ByteBuffer &plain_data, const uint8_t *defines, uint64_t num_values, idx_t result_offset,
 	                    Vector &result) {
 		if (HasDefines() && defines) {
 			PlainTemplatedDefines<VALUE_TYPE, CONVERSION, true>(plain_data, defines, num_values, result_offset, result);
@@ -125,7 +127,7 @@ public:
 	}
 
 	template <class CONVERSION, bool HAS_DEFINES>
-	void PlainSkipTemplatedDefines(ByteBuffer &plain_data, uint8_t *defines, uint64_t num_values) {
+	void PlainSkipTemplatedDefines(ByteBuffer &plain_data, const uint8_t *defines, uint64_t num_values) {
 		if (CONVERSION::PlainAvailable(plain_data, num_values)) {
 			PlainSkipTemplatedInternal<CONVERSION, HAS_DEFINES, false>(plain_data, defines, num_values);
 		} else {
@@ -133,7 +135,7 @@ public:
 		}
 	}
 	template <class CONVERSION>
-	void PlainSkipTemplated(ByteBuffer &plain_data, uint8_t *defines, uint64_t num_values) {
+	void PlainSkipTemplated(ByteBuffer &plain_data, const uint8_t *defines, uint64_t num_values) {
 		if (HasDefines() && defines) {
 			PlainSkipTemplatedDefines<CONVERSION, true>(plain_data, defines, num_values);
 		} else {
@@ -141,7 +143,19 @@ public:
 		}
 	}
 
-	idx_t GetValidCount(uint8_t *defines, idx_t count, idx_t offset = 0) {
+	template <class VALUE_TYPE, class CONVERSION>
+	void PlainSelectTemplated(ByteBuffer &plain_data, const uint8_t *defines, uint64_t num_values, Vector &result,
+	                          const SelectionVector &sel, idx_t approved_tuple_count) {
+		if (HasDefines() && defines) {
+			PlainSelectTemplatedInternal<VALUE_TYPE, CONVERSION, true, true>(plain_data, defines, num_values, result,
+			                                                                 sel, approved_tuple_count);
+		} else {
+			PlainSelectTemplatedInternal<VALUE_TYPE, CONVERSION, false, true>(plain_data, defines, num_values, result,
+			                                                                  sel, approved_tuple_count);
+		}
+	}
+
+	idx_t GetValidCount(uint8_t *defines, idx_t count, idx_t offset = 0) const {
 		if (!defines) {
 			return count;
 		}
@@ -156,8 +170,13 @@ protected:
 	virtual bool SupportsDirectFilter() const {
 		return false;
 	}
+	virtual bool SupportsDirectSelect() const {
+		return false;
+	}
 	void DirectFilter(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result_out,
 	                  const TableFilter &filter, SelectionVector &sel, idx_t &approved_tuple_count);
+	void DirectSelect(uint64_t num_values, data_ptr_t define_out, data_ptr_t repeat_out, Vector &result,
+	                  const SelectionVector &sel, idx_t approved_tuple_count);
 
 private:
 	//! Check if a previous table filter has filtered out this page
@@ -193,16 +212,44 @@ private:
 
 	template <class CONVERSION, bool HAS_DEFINES, bool CHECKED>
 	void PlainSkipTemplatedInternal(ByteBuffer &plain_data, const uint8_t *__restrict defines,
-	                                const uint64_t num_values) {
+	                                const uint64_t num_values, idx_t row_offset = 0) {
 		if (!HAS_DEFINES && !CHECKED && CONVERSION::PlainConstantSize() > 0) {
 			plain_data.unsafe_inc(num_values * CONVERSION::PlainConstantSize());
 			return;
 		}
-		for (idx_t row_idx = 0; row_idx < num_values; row_idx++) {
+		for (idx_t row_idx = row_offset; row_idx < row_offset + num_values; row_idx++) {
 			if (HAS_DEFINES && defines[row_idx] != MaxDefine()) {
 				continue;
 			}
 			CONVERSION::template PlainSkip<CHECKED>(plain_data, *this);
+		}
+	}
+
+	template <class VALUE_TYPE, class CONVERSION, bool HAS_DEFINES, bool CHECKED>
+	void PlainSelectTemplatedInternal(ByteBuffer &plain_data, const uint8_t *__restrict defines,
+	                                  const uint64_t num_values, Vector &result, const SelectionVector &sel,
+	                                  idx_t approved_tuple_count) {
+		const auto result_ptr = FlatVector::GetData<VALUE_TYPE>(result);
+		auto &result_mask = FlatVector::Validity(result);
+		idx_t current_entry = 0;
+		for (idx_t i = 0; i < approved_tuple_count; i++) {
+			auto next_entry = sel.get_index(i);
+			D_ASSERT(current_entry <= next_entry);
+			// perform any skips forward if required
+			PlainSkipTemplatedInternal<CONVERSION, HAS_DEFINES, CHECKED>(plain_data, defines,
+			                                                             next_entry - current_entry, current_entry);
+			// read this row
+			if (HAS_DEFINES && defines[next_entry] != MaxDefine()) {
+				result_mask.SetInvalid(next_entry);
+			} else {
+				result_ptr[next_entry] = CONVERSION::template PlainRead<CHECKED>(plain_data, *this);
+			}
+			current_entry = next_entry + 1;
+		}
+		if (current_entry < num_values) {
+			// skip forward to the end of where we are selecting
+			PlainSkipTemplatedInternal<CONVERSION, HAS_DEFINES, CHECKED>(plain_data, defines,
+			                                                             num_values - current_entry, current_entry);
 		}
 	}
 
@@ -213,6 +260,8 @@ protected:
 	virtual void Plain(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values, idx_t result_offset, Vector &result);
 	virtual void Plain(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values,
 	                   idx_t result_offset, Vector &result);
+	virtual void PlainSelect(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values,
+	                         Vector &result, const SelectionVector &sel, idx_t count);
 
 	// applies any skips that were registered using Skip()
 	virtual void ApplyPendingSkips(data_ptr_t define_out, data_ptr_t repeat_out);

--- a/extension/parquet/include/reader/string_column_reader.hpp
+++ b/extension/parquet/include/reader/string_column_reader.hpp
@@ -33,8 +33,13 @@ protected:
 	void Plain(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values, idx_t result_offset,
 	           Vector &result) override;
 	void PlainSkip(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values) override;
+	void PlainSelect(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values, Vector &result,
+	                 const SelectionVector &sel, idx_t count) override;
 
 	bool SupportsDirectFilter() const override {
+		return true;
+	}
+	bool SupportsDirectSelect() const override {
 		return true;
 	}
 };

--- a/extension/parquet/include/reader/templated_column_reader.hpp
+++ b/extension/parquet/include/reader/templated_column_reader.hpp
@@ -71,9 +71,19 @@ public:
 		PlainSkipTemplated<VALUE_CONVERSION>(plain_data, defines, num_values);
 	}
 
+	// FIXME: need to profile this to see if it makes sense for primitive types
+	// (or at what ratio of count / num_values it makes sense)
+	// void PlainSelect(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values, Vector &result,
+	//                  const SelectionVector &sel, idx_t count) override {
+	// 	PlainSelectTemplated<VALUE_TYPE, VALUE_CONVERSION>(*plain_data, defines, num_values, result, sel, count);
+	// }
+
 	bool SupportsDirectFilter() const override {
 		return true;
 	}
+	// bool SupportsDirectSelect() const override {
+	// 	return true;
+	// }
 };
 
 template <class PARQUET_PHYSICAL_TYPE, class DUCKDB_PHYSICAL_TYPE,

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1118,7 +1118,7 @@ bool ParquetReader::ScanInternal(ParquetReaderScanState &state, DataChunk &resul
 			}
 			auto &result_vector = result.data[reader_data.column_mapping[col_idx]];
 			auto &child_reader = root_reader.GetChildReader(file_col_idx);
-			child_reader.Read(result.size(), define_ptr, repeat_ptr, result_vector);
+			child_reader.Select(result.size(), define_ptr, repeat_ptr, result_vector, state.sel, filter_count);
 		}
 
 		result.Slice(state.sel, filter_count);

--- a/extension/parquet/reader/string_column_reader.cpp
+++ b/extension/parquet/reader/string_column_reader.cpp
@@ -55,4 +55,10 @@ void StringColumnReader::PlainSkip(ByteBuffer &plain_data, uint8_t *defines, idx
 	PlainSkipTemplated<StringParquetValueConversion>(plain_data, defines, num_values);
 }
 
+void StringColumnReader::PlainSelect(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values,
+                                     Vector &result, const SelectionVector &sel, idx_t count) {
+	StringVector::AddBuffer(result, make_buffer<ParquetStringVectorBuffer>(plain_data));
+	PlainSelectTemplated<string_t, StringParquetValueConversion>(*plain_data, defines, num_values, result, sel, count);
+}
+
 } // namespace duckdb


### PR DESCRIPTION
This effectively restores a previous optimization where we would skip reading elements if they were previously filtered out. For now we only enable this for strings - that has by far the highest performance benefits as we can skip UTF8 validation for any strings that we don't need to read.

For simple types like integers this optimization is not so straightforwardly useful - as we effectively replace a `memcpy` with a branchy lookup. I haven't run any benchmarks on this yet but I suspect that the usefulness of this optimization depends on selectivity - i.e. it might perform better when the selectivity is <10% (or some other to be determined threshold). I will leave that for a future PR.
