### PR TITLE
Parquet writer: Re-implement GetRowSize for Strings

### DIFF
--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -816,7 +816,7 @@ struct BaseParquetOperator {
 	}
 
 	template <class SRC, class TGT>
-	static idx_t GetRowSize(const Vector &, idx_t ) {
+	static idx_t GetRowSize(const Vector &, idx_t) {
 		return sizeof(TGT);
 	}
 };

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -796,7 +796,6 @@ public:
 };
 
 struct BaseParquetOperator {
-
 	template <class SRC, class TGT>
 	static void WriteToStream(const TGT &input, WriteStream &ser) {
 		ser.WriteData(const_data_ptr_cast(&input), sizeof(TGT));
@@ -814,6 +813,11 @@ struct BaseParquetOperator {
 
 	template <class SRC, class TGT>
 	static void HandleStats(ColumnWriterStatistics *stats, TGT target_value) {
+	}
+
+	template <class SRC, class TGT>
+	static idx_t GetRowSize(const Vector &, idx_t ) {
+		return sizeof(TGT);
 	}
 };
 
@@ -935,6 +939,11 @@ struct ParquetStringOperator : public BaseParquetOperator {
 	template <class SRC, class TGT>
 	static uint64_t XXHash64(const TGT &target_value) {
 		return duckdb_zstd::XXH64(target_value.GetData(), target_value.GetSize(), 0);
+	}
+
+	template <class SRC, class TGT>
+	static idx_t GetRowSize(const Vector &vector, idx_t index) {
+		return FlatVector::GetData<string_t>(vector)[index].GetSize();
 	}
 };
 
@@ -1066,6 +1075,7 @@ public:
 	// analysis state for integer values for DELTA_BINARY_PACKED/DELTA_LENGTH_BYTE_ARRAY
 	idx_t total_value_count = 0;
 	idx_t total_string_size = 0;
+	uint32_t key_bit_width = 0;
 
 	unordered_map<T, uint32_t> dictionary;
 	duckdb_parquet::Encoding::type encoding;
@@ -1335,6 +1345,8 @@ public:
 				}
 			}
 			state.dictionary.clear();
+		} else {
+			state.key_bit_width = RleBpDecoder::ComputeBitWidth(state.dictionary.size());
 		}
 	}
 
@@ -1488,9 +1500,13 @@ public:
 		// bloom filter will be queued for writing in ParquetWriter::BufferBloomFilter one level up
 	}
 
-	// TODO this now vastly over-estimates the page size
 	idx_t GetRowSize(const Vector &vector, const idx_t index, const BasicColumnWriterState &state_p) const override {
-		return sizeof(TGT);
+		auto &state = state_p.Cast<StandardColumnWriterState<SRC>>();
+		if (state.encoding == Encoding::RLE_DICTIONARY) {
+			return (state.key_bit_width + 7) / 8;
+		} else {
+			return OP::template GetRowSize<SRC, TGT>(vector, index);
+		}
 	}
 };
 


### PR DESCRIPTION
This got lost during the column writer unification. This fixes a regression in the Parquet writer where, when writing large strings, the page size would be greatly underestimated. This is used upstream in the writer to limit page size to 100MB. Since the page size would be underestimated, we would be writing much larger pages than this when writing large strings, leading to potential memory issues. In addition, since Parquet pages are limited to 2GB (on account of page size being stored as an `int32`) - I think this could also lead to too large pages being written that could not be correctly represented in the Parquet spec in certain edge cases.