### PR TITLE
unified names for duckdb-extensions

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -207,7 +207,6 @@ jobs:
     strategy:
       matrix:
         duckdb_arch: [linux_amd64_musl]
-        vcpkg_triplet: [x64-linux]
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
     with:
@@ -249,7 +248,6 @@ jobs:
     strategy:
       matrix:
         duckdb_arch: [linux_arm64]
-        vcpkg_triplet: [arm64-linux]
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
     with:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -149,24 +149,27 @@ jobs:
 
       - uses: ./duckdb/.github/actions/build_extensions_dockerized
         with:
-          vcpkg_target_triplet: x64-linux
-          duckdb_arch: linux_amd64
+          vcpkg_target_triplet: ${{ matrix.vcpkg_triplet }}
+          duckdb_arch: ${{ matrix.duckdb_arch }}
           run_tests: ${{ inputs.skip_tests != 'true' }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-extensions-64
+          name: duckdb-extensions-${{ matrix.duckdb_arch }}
           path: |
             build/release/extension/*/*.duckdb_extension
 
  upload-linux-extensions-64:
     name: Upload Linux Extensions (x64)
     needs: linux-extensions-64
+    strategy:
+      matrix:
+        duckdb_arch: [linux_amd64]
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
     with:
-      extension_artifact_name: linux-extensions-64
-      duckdb_arch: linux_amd64
+      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
+      duckdb_arch: ${{ matrix.duckdb_arch }}
       duckdb_sha: ${{ github.sha }}
 
  linux-extensions-64-musl:
@@ -188,34 +191,28 @@ jobs:
 
       - uses: ./duckdb/.github/actions/build_extensions_dockerized
         with:
-          vcpkg_target_triplet: x64-linux
-          duckdb_arch: linux_amd64_musl
+          vcpkg_target_triplet: ${{ matrix.vcpkg_triplet }}
+          duckdb_arch: ${{ matrix.duckdb_arch }}
           run_tests: ${{ inputs.skip_tests != 'true' }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-extensions-64-musl
+          name: duckdb-extensions-${{ matrix.duckdb_arch }}
           path: |
             build/release/extension/*/*.duckdb_extension
 
  upload-linux-extensions-64-musl:
     name: Upload Linux Extensions (musl + x64)
     needs: linux-extensions-64-musl
+    strategy:
+      matrix:
+        duckdb_arch: [linux_amd64_musl]
+        vcpkg_triplet: [x64-linux]
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
     with:
-      extension_artifact_name: linux-extensions-64-musl
-      duckdb_arch: linux_amd64_musl
-      duckdb_sha: ${{ github.sha }}
-
- upload-linux-extensions-64-aarch64:
-    name: Upload Linux Extensions (aarch64)
-    needs: linux-extensions-64-aarch64
-    uses: ./.github/workflows/_sign_deploy_extensions.yml
-    secrets: inherit
-    with:
-      extension_artifact_name: linux-extensions-64-aarch64
-      duckdb_arch: linux_arm64
+      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
+      duckdb_arch: ${{ matrix.duckdb_arch }}
       duckdb_sha: ${{ github.sha }}
 
  linux-extensions-64-aarch64:
@@ -223,7 +220,10 @@ jobs:
     name: Linux Extensions (aarch64)
     runs-on: ubuntu-latest
     needs: linux-extensions-64
-
+    strategy:
+      matrix:
+        duckdb_arch: [linux_arm64]
+        vcpkg_triplet: [arm64-linux]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -233,16 +233,30 @@ jobs:
 
       - uses: ./duckdb/.github/actions/build_extensions_dockerized
         with:
-          vcpkg_target_triplet: arm64-linux
-          duckdb_arch: linux_arm64
+          vcpkg_target_triplet: ${{ matrix.vcpkg_triplet }}
+          duckdb_arch: ${{ matrix.duckdb_arch }}
           run_tests: ${{ inputs.skip_tests != 'true' }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: linux-extensions-64-aarch64
+          name: duckdb-extensions-${{ matrix.duckdb_arch }}
           path: |
             build/release/extension/*/*.duckdb_extension
-
+ 
+ upload-linux-extensions-64-aarch64:
+    name: Upload Linux Extensions (aarch64)
+    needs: linux-extensions-64-aarch64
+    strategy:
+      matrix:
+        duckdb_arch: [linux_arm64]
+        vcpkg_triplet: [arm64-linux]
+    uses: ./.github/workflows/_sign_deploy_extensions.yml
+    secrets: inherit
+    with:
+      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
+      duckdb_arch: ${{ matrix.duckdb_arch }}
+      duckdb_sha: ${{ github.sha }}
+          
  check-load-install-extensions:
     name: Checks extension entries
     if: ${{ inputs.skip_tests != 'true' }}
@@ -283,7 +297,7 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: linux-extensions-64
+        name: duckdb-extensions-linux_amd64
         path: build/release/repository
 
     - name: Check if extension_entries.hpp is up to date

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -150,7 +150,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: manylinux-extensions-x64
+          name: duckdb-extensions-${{ matrix.duckdb_arch }}
           path: |
             build/release/extension/*/*.duckdb_extension
 
@@ -158,11 +158,14 @@ jobs:
     ## TODO: Add a if: github.ref == main, for now this is explicitly missing to be able to test on PR, expected is this should fail due to missing secrets
     name: Upload Linux Extensions (gcc4)
     needs: manylinux-extensions-x64
+    strategy:
+      matrix:
+        duckdb_arch: [linux_amd64_gcc4]
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
     with:
-      extension_artifact_name: manylinux-extensions-x64
-      duckdb_arch: linux_amd64_gcc4
+      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
+      duckdb_arch: ${{ matrix.duckdb_arch }}
       duckdb_sha: ${{ github.sha }}
 
   linux-python3:
@@ -172,6 +175,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        duckdb_arch: [linux_amd64_gcc4]
         arch: [x86_64, aarch64]
         python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]
         manylinux: [manylinux2014, manylinux_2_28]
@@ -243,7 +247,7 @@ jobs:
     - uses: actions/download-artifact@v4
       if: ${{ matrix.arch == 'x86_64' }}
       with:
-        name: manylinux-extensions-x64
+        name: duckdb-extensions-${{ matrix.duckdb_arch }}
         path: tools/pythonpkg
 
     - name: List extensions to be tested

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: windows_amd64_mingw-extensions
+          name: duckdb-extensions-windows_amd64_mingw
           path: |
             build/release/extension/*/*.duckdb_extension
 
@@ -84,7 +84,7 @@ jobs:
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
     with:
-      extension_artifact_name: windows_amd64_mingw-extensions
+      extension_artifact_name: duckdb-extensions-windows_amd64_mingw
       duckdb_arch: windows_amd64_mingw
       duckdb_sha: ${{ github.sha }}
 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -54,9 +54,6 @@ jobs:
     # Builds binaries for windows_amd64
     name: Windows (64 Bit)
     runs-on: windows-2019
-    strategy:
-      matrix:
-        duckdb_arch: [windows_amd64]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -110,16 +107,16 @@ jobs:
       run: |
         python scripts/amalgamation.py
         choco install zip -y --force
-        zip -j duckdb_cli-${{ matrix.duckdb_arch }}.zip Release/duckdb.exe
-        zip -j libduckdb-${{ matrix.duckdb_arch }}.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
-        ./scripts/upload-assets-to-staging.sh github_release libduckdb-${{ matrix.duckdb_arch }}.zip duckdb_cli-${{ matrix.duckdb_arch }}.zip
+        zip -j duckdb_cli-windows-amd64.zip Release/duckdb.exe
+        zip -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
+        ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip
 
     - uses: actions/upload-artifact@v4
       with:
-        name: duckdb-binaries-${{ matrix.duckdb_arch }}
+        name: duckdb-binaries-windows-amd64
         path: |
-          libduckdb-${{ matrix.duckdb_arch }}.zip
-          duckdb_cli-${{ matrix.duckdb_arch }}.zip
+          libduckdb-windows-amd64.zip
+          duckdb_cli-windows-amd64.zip
 
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Duckdb.dll export symbols with C++ on Windows
@@ -171,9 +168,6 @@ jobs:
    if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
    runs-on: windows-2019
    needs: win-release-64
-   strategy:
-    matrix:
-      duckdb_arch: [windows_arm64]
 
    steps:
      - uses: actions/checkout@v4
@@ -194,7 +188,7 @@ jobs:
      - name: Build
        shell: bash
        run: |
-         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=ARM64 -DDUCKDB_EXTENSION_CONFIGS="${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake" -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE" -DDUCKDB_EXPLICIT_PLATFORM=${{ matrix.duckdb_arch }} -DDUCKDB_CUSTOM_PLATFORM=${{ matrix.duckdb_arch }} -DBUILD_UNITTESTS=FALSE
+         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=ARM64 -DDUCKDB_EXTENSION_CONFIGS="${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake" -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE" -DDUCKDB_EXPLICIT_PLATFORM=windows_arm64 -DDUCKDB_CUSTOM_PLATFORM=windows_arm64 -DBUILD_UNITTESTS=FALSE
          cmake --build . --config Release --parallel
 
      - name: Deploy
@@ -205,16 +199,16 @@ jobs:
        run: |
          python scripts/amalgamation.py
          choco install zip -y --force
-         zip -j duckdb_cli-${{ matrix.duckdb_arch }}.zip Release/duckdb.exe
-         zip -j libduckdb-${{ matrix.duckdb_arch }}.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
-         ./scripts/upload-assets-to-staging.sh github_release libduckdb-${{ matrix.duckdb_arch }}.zip duckdb_cli-${{ matrix.duckdb_arch }}.zip
+         zip -j duckdb_cli-windows-arm64.zip Release/duckdb.exe
+         zip -j libduckdb-windows-arm64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
+         ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-arm64.zip duckdb_cli-windows-arm64.zip
 
      - uses: actions/upload-artifact@v4
        with:
-         name: duckdb-binaries-${{ matrix.duckdb_arch }}
+         name: duckdb-binaries-windows-arm64
          path: |
-           libduckdb-${{ matrix.duckdb_arch }}.zip
-           duckdb_cli-${{ matrix.duckdb_arch }}.zip
+           libduckdb-windows-arm64.zip
+           duckdb_cli-windows-arm64.zip
 
  mingw:
      name: MinGW (64 Bit)
@@ -300,14 +294,11 @@ jobs:
  upload-windows_amd64-extensions:
     name: Upload windows_amd64 Extensions
     needs: win-extensions-64
-    strategy:
-      matrix:
-        duckdb_arch: [windows_amd64]
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
     with:
-      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
-      duckdb_arch: ${{ matrix.duckdb_arch }}
+      extension_artifact_name: duckdb-extensions-windows_amd64
+      duckdb_arch: windows_amd64
       duckdb_sha: ${{ github.sha }}
 
  win-packaged-upload:
@@ -318,17 +309,17 @@ jobs:
    steps:
     - uses: actions/download-artifact@v4
       with:
-        name: duckdb-binaries-windows_arm64
+        name: duckdb-binaries-windows-arm64
 
     - uses: actions/download-artifact@v4
       with:
-        name: duckdb-binaries-windows_amd64
+        name: duckdb-binaries-windows-amd64
 
     - uses: actions/upload-artifact@v4
       with:
         name: duckdb-binaries-windows
         path: |
-          libduckdb-windows_amd64.zip
-          duckdb_cli-windows_amd64.zip
-          libduckdb-windows_arm64.zip
-          duckdb_cli-windows_arm64.zip
+          libduckdb-windows-amd64.zip
+          duckdb_cli-windows-amd64.zip
+          libduckdb-windows-arm64.zip
+          duckdb_cli-windows-arm64.zip

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -54,6 +54,9 @@ jobs:
     # Builds binaries for windows_amd64
     name: Windows (64 Bit)
     runs-on: windows-2019
+    strategy:
+      matrix:
+        duckdb_arch: [windows_amd64]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -107,16 +110,16 @@ jobs:
       run: |
         python scripts/amalgamation.py
         choco install zip -y --force
-        zip -j duckdb_cli-windows-amd64.zip Release/duckdb.exe
-        zip -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
-        ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip
+        zip -j duckdb_cli-${{ matrix.duckdb_arch }}.zip Release/duckdb.exe
+        zip -j libduckdb-${{ matrix.duckdb_arch }}.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
+        ./scripts/upload-assets-to-staging.sh github_release libduckdb-${{ matrix.duckdb_arch }}.zip duckdb_cli-${{ matrix.duckdb_arch }}.zip
 
     - uses: actions/upload-artifact@v4
       with:
-        name: duckdb-binaries-windows-amd64
+        name: duckdb-binaries-${{ matrix.duckdb_arch }}
         path: |
-          libduckdb-windows-amd64.zip
-          duckdb_cli-windows-amd64.zip
+          libduckdb-${{ matrix.duckdb_arch }}.zip
+          duckdb_cli-${{ matrix.duckdb_arch }}.zip
 
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Duckdb.dll export symbols with C++ on Windows
@@ -168,6 +171,9 @@ jobs:
    if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
    runs-on: windows-2019
    needs: win-release-64
+   strategy:
+    matrix:
+      duckdb_arch: [windows_arm64]
 
    steps:
      - uses: actions/checkout@v4
@@ -188,7 +194,7 @@ jobs:
      - name: Build
        shell: bash
        run: |
-         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=ARM64 -DDUCKDB_EXTENSION_CONFIGS="${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake" -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE" -DDUCKDB_EXPLICIT_PLATFORM=windows_arm64 -DDUCKDB_CUSTOM_PLATFORM=windows_arm64 -DBUILD_UNITTESTS=FALSE
+         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=ARM64 -DDUCKDB_EXTENSION_CONFIGS="${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake" -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE" -DDUCKDB_EXPLICIT_PLATFORM=${{ matrix.duckdb_arch }} -DDUCKDB_CUSTOM_PLATFORM=${{ matrix.duckdb_arch }} -DBUILD_UNITTESTS=FALSE
          cmake --build . --config Release --parallel
 
      - name: Deploy
@@ -199,16 +205,16 @@ jobs:
        run: |
          python scripts/amalgamation.py
          choco install zip -y --force
-         zip -j duckdb_cli-windows-arm64.zip Release/duckdb.exe
-         zip -j libduckdb-windows-arm64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
-         ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-arm64.zip duckdb_cli-windows-arm64.zip
+         zip -j duckdb_cli-${{ matrix.duckdb_arch }}.zip Release/duckdb.exe
+         zip -j libduckdb-${{ matrix.duckdb_arch }}.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
+         ./scripts/upload-assets-to-staging.sh github_release libduckdb-${{ matrix.duckdb_arch }}.zip duckdb_cli-${{ matrix.duckdb_arch }}.zip
 
      - uses: actions/upload-artifact@v4
        with:
-         name: duckdb-binaries-windows-arm64
+         name: duckdb-binaries-${{ matrix.duckdb_arch }}
          path: |
-           libduckdb-windows-arm64.zip
-           duckdb_cli-windows-arm64.zip
+           libduckdb-${{ matrix.duckdb_arch }}.zip
+           duckdb_cli-${{ matrix.duckdb_arch }}.zip
 
  mingw:
      name: MinGW (64 Bit)
@@ -287,18 +293,21 @@ jobs:
 
      - uses: actions/upload-artifact@v4
        with:
-         name: windows_amd64-extensions
+         name: duckdb-extensions-windows_amd64
          path: |
            build/release/extension/*/*.duckdb_extension
 
  upload-windows_amd64-extensions:
     name: Upload windows_amd64 Extensions
     needs: win-extensions-64
+    strategy:
+      matrix:
+        duckdb_arch: [windows_amd64]
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
     with:
-      extension_artifact_name: windows_amd64-extensions
-      duckdb_arch: windows_amd64
+      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
+      duckdb_arch: ${{ matrix.duckdb_arch }}
       duckdb_sha: ${{ github.sha }}
 
  win-packaged-upload:
@@ -309,17 +318,17 @@ jobs:
    steps:
     - uses: actions/download-artifact@v4
       with:
-        name: duckdb-binaries-windows-arm64
+        name: duckdb-binaries-windows_arm64
 
     - uses: actions/download-artifact@v4
       with:
-        name: duckdb-binaries-windows-amd64
+        name: duckdb-binaries-windows_amd64
 
     - uses: actions/upload-artifact@v4
       with:
         name: duckdb-binaries-windows
         path: |
-          libduckdb-windows-amd64.zip
-          duckdb_cli-windows-amd64.zip
-          libduckdb-windows-arm64.zip
-          duckdb_cli-windows-arm64.zip
+          libduckdb-windows_amd64.zip
+          duckdb_cli-windows_amd64.zip
+          libduckdb-windows_arm64.zip
+          duckdb_cli-windows_arm64.zip


### PR DESCRIPTION
Currently, the naming pattern for DuckDB extensions is inconsistent with the naming pattern used for DuckDB binaries.
Specifically:
- Extension names:
```
linux-extensions-64
duckdb-extensions-${{ matrix.duckdb_arch }} (OSX and Wasm)
windows_amd64_mingw-extensions
```

This PR aligns the naming pattern for extensions across all platforms to use `duckdb-extensions-${{ matrix.duckdb_arch }}` 