### PR TITLE
Fix #16122: bind default values in a sub-binder to avoid modifying the catalog search path of the current binder

### DIFF
--- a/src/catalog/catalog_entry_retriever.cpp
+++ b/src/catalog/catalog_entry_retriever.cpp
@@ -76,7 +76,7 @@ void CatalogEntryRetriever::Inherit(const CatalogEntryRetriever &parent) {
 	this->search_path = parent.search_path;
 }
 
-CatalogSearchPath &CatalogEntryRetriever::GetSearchPath() {
+const CatalogSearchPath &CatalogEntryRetriever::GetSearchPath() const {
 	if (search_path) {
 		return *search_path;
 	}

--- a/src/catalog/catalog_search_path.cpp
+++ b/src/catalog/catalog_search_path.cpp
@@ -189,11 +189,11 @@ void CatalogSearchPath::Set(CatalogSearchEntry new_value, CatalogSetPathType set
 	Set(std::move(new_paths), set_type);
 }
 
-const vector<CatalogSearchEntry> &CatalogSearchPath::Get() {
+const vector<CatalogSearchEntry> &CatalogSearchPath::Get() const {
 	return paths;
 }
 
-string CatalogSearchPath::GetDefaultSchema(const string &catalog) {
+string CatalogSearchPath::GetDefaultSchema(const string &catalog) const {
 	for (auto &path : paths) {
 		if (path.catalog == TEMP_CATALOG) {
 			continue;
@@ -205,7 +205,7 @@ string CatalogSearchPath::GetDefaultSchema(const string &catalog) {
 	return DEFAULT_SCHEMA;
 }
 
-string CatalogSearchPath::GetDefaultSchema(ClientContext &context, const string &catalog) {
+string CatalogSearchPath::GetDefaultSchema(ClientContext &context, const string &catalog) const {
 	for (auto &path : paths) {
 		if (path.catalog == TEMP_CATALOG) {
 			continue;
@@ -221,7 +221,7 @@ string CatalogSearchPath::GetDefaultSchema(ClientContext &context, const string 
 	return DEFAULT_SCHEMA;
 }
 
-string CatalogSearchPath::GetDefaultCatalog(const string &schema) {
+string CatalogSearchPath::GetDefaultCatalog(const string &schema) const {
 	if (DefaultSchemaGenerator::IsDefaultSchema(schema)) {
 		return SYSTEM_CATALOG;
 	}
@@ -236,7 +236,7 @@ string CatalogSearchPath::GetDefaultCatalog(const string &schema) {
 	return INVALID_CATALOG;
 }
 
-vector<string> CatalogSearchPath::GetCatalogsForSchema(const string &schema) {
+vector<string> CatalogSearchPath::GetCatalogsForSchema(const string &schema) const {
 	vector<string> catalogs;
 	if (DefaultSchemaGenerator::IsDefaultSchema(schema)) {
 		catalogs.push_back(SYSTEM_CATALOG);
@@ -250,7 +250,7 @@ vector<string> CatalogSearchPath::GetCatalogsForSchema(const string &schema) {
 	return catalogs;
 }
 
-vector<string> CatalogSearchPath::GetSchemasForCatalog(const string &catalog) {
+vector<string> CatalogSearchPath::GetSchemasForCatalog(const string &catalog) const {
 	vector<string> schemas;
 	for (auto &path : paths) {
 		if (StringUtil::CIEquals(path.catalog, catalog)) {
@@ -260,7 +260,7 @@ vector<string> CatalogSearchPath::GetSchemasForCatalog(const string &catalog) {
 	return schemas;
 }
 
-const CatalogSearchEntry &CatalogSearchPath::GetDefault() {
+const CatalogSearchEntry &CatalogSearchPath::GetDefault() const {
 	const auto &paths = Get();
 	D_ASSERT(paths.size() >= 2);
 	return paths[1];
@@ -281,7 +281,7 @@ void CatalogSearchPath::SetPathsInternal(vector<CatalogSearchEntry> new_paths) {
 }
 
 bool CatalogSearchPath::SchemaInSearchPath(ClientContext &context, const string &catalog_name,
-                                           const string &schema_name) {
+                                           const string &schema_name) const {
 	for (auto &path : paths) {
 		if (!StringUtil::CIEquals(path.schema, schema_name)) {
 			continue;

--- a/src/include/duckdb/catalog/catalog_entry_retriever.hpp
+++ b/src/include/duckdb/catalog/catalog_entry_retriever.hpp
@@ -56,7 +56,7 @@ public:
 	                                           OnEntryNotFound on_entry_not_found = OnEntryNotFound::THROW_EXCEPTION,
 	                                           QueryErrorContext error_context = QueryErrorContext());
 
-	CatalogSearchPath &GetSearchPath();
+	const CatalogSearchPath &GetSearchPath() const;
 	void SetSearchPath(vector<CatalogSearchEntry> entries);
 
 	void SetCallback(catalog_entry_callback_t callback);

--- a/src/include/duckdb/catalog/catalog_search_path.hpp
+++ b/src/include/duckdb/catalog/catalog_search_path.hpp
@@ -48,20 +48,21 @@ public:
 	DUCKDB_API void Set(vector<CatalogSearchEntry> new_paths, CatalogSetPathType set_type);
 	DUCKDB_API void Reset();
 
-	DUCKDB_API const vector<CatalogSearchEntry> &Get();
-	const vector<CatalogSearchEntry> &GetSetPaths() {
+	DUCKDB_API const vector<CatalogSearchEntry> &Get() const;
+	const vector<CatalogSearchEntry> &GetSetPaths() const {
 		return set_paths;
 	}
-	DUCKDB_API const CatalogSearchEntry &GetDefault();
+	DUCKDB_API const CatalogSearchEntry &GetDefault() const;
 	//! FIXME: this method is deprecated
-	DUCKDB_API string GetDefaultSchema(const string &catalog);
-	DUCKDB_API string GetDefaultSchema(ClientContext &context, const string &catalog);
-	DUCKDB_API string GetDefaultCatalog(const string &schema);
+	DUCKDB_API string GetDefaultSchema(const string &catalog) const;
+	DUCKDB_API string GetDefaultSchema(ClientContext &context, const string &catalog) const;
+	DUCKDB_API string GetDefaultCatalog(const string &schema) const;
 
-	DUCKDB_API vector<string> GetSchemasForCatalog(const string &catalog);
-	DUCKDB_API vector<string> GetCatalogsForSchema(const string &schema);
+	DUCKDB_API vector<string> GetSchemasForCatalog(const string &catalog) const;
+	DUCKDB_API vector<string> GetCatalogsForSchema(const string &schema) const;
 
-	DUCKDB_API bool SchemaInSearchPath(ClientContext &context, const string &catalog_name, const string &schema_name);
+	DUCKDB_API bool SchemaInSearchPath(ClientContext &context, const string &catalog_name,
+	                                   const string &schema_name) const;
 
 private:
 	//! Set paths without checking if they exist

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -271,13 +271,14 @@ void Binder::BindDefaultValues(const ColumnList &columns, vector<unique_ptr<Expr
 		schema_name = DEFAULT_SCHEMA;
 	}
 
-	// FIXME: We might want to save the existing search path of the binder
 	vector<CatalogSearchEntry> defaults_search_path;
 	defaults_search_path.emplace_back(catalog_name, schema_name);
 	if (schema_name != DEFAULT_SCHEMA) {
 		defaults_search_path.emplace_back(catalog_name, DEFAULT_SCHEMA);
 	}
-	entry_retriever.SetSearchPath(std::move(defaults_search_path));
+
+	auto default_binder = Binder::CreateBinder(context, *this);
+	default_binder->entry_retriever.SetSearchPath(std::move(defaults_search_path));
 
 	for (auto &column : columns.Physical()) {
 		unique_ptr<Expression> bound_default;
@@ -288,9 +289,9 @@ void Binder::BindDefaultValues(const ColumnList &columns, vector<unique_ptr<Expr
 			if (default_copy->HasParameter()) {
 				throw BinderException("DEFAULT values cannot contain parameters");
 			}
-			ConstantBinder default_binder(*this, context, "DEFAULT value");
-			default_binder.target_type = column.Type();
-			bound_default = default_binder.Bind(default_copy);
+			ConstantBinder default_value_binder(*default_binder, context, "DEFAULT value");
+			default_value_binder.target_type = column.Type();
+			bound_default = default_value_binder.Bind(default_copy);
 		} else {
 			// no default value specified: push a default value of constant null
 			bound_default = make_uniq<BoundConstantExpression>(Value(column.Type()));

--- a/test/sql/attach/attach_issue16122.test
+++ b/test/sql/attach/attach_issue16122.test
@@ -1,0 +1,30 @@
+# name: test/sql/attach/attach_issue16122.test
+# description: Issue #16122 - Attach binding to incorrect table
+# group: [attach]
+
+require noforcestorage
+
+load __TEST_DIR__/issue16122.db
+
+
+statement ok
+create table mytable (C1 VARCHAR(10));
+
+statement ok
+insert into mytable values ('a');
+
+statement ok
+attach '__TEST_DIR__/issue16122_new.db' as TOMERGE;
+
+statement ok
+create table TOMERGE.mytable (C1 VARCHAR(10));
+
+query I
+insert into TOMERGE.mytable SELECT * FROM mytable;
+----
+1
+
+query I
+select * from TOMERGE.mytable;
+----
+a


### PR DESCRIPTION
Fixes #16122