### PR TITLE
update duckdb-binaries-windows to use duckdb_arch as a suffix

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -16,7 +16,6 @@ on:
         type: string
       skip_tests:
         type: string
-  repository_dispatch:
   push:
     branches-ignore:
       - 'main'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -16,6 +16,7 @@ on:
         type: string
       skip_tests:
         type: string
+  repository_dispatch:
   push:
     branches-ignore:
       - 'main'
@@ -53,6 +54,9 @@ jobs:
     # Builds binaries for windows_amd64
     name: Windows (64 Bit)
     runs-on: windows-2019
+    strategy:
+      matrix:
+        duckdb_arch: [windows_amd64]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -106,16 +110,16 @@ jobs:
       run: |
         python scripts/amalgamation.py
         choco install zip -y --force
-        zip -j duckdb_cli-windows-amd64.zip Release/duckdb.exe
-        zip -j libduckdb-windows-amd64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
-        ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-amd64.zip duckdb_cli-windows-amd64.zip
+        zip -j duckdb_cli-${{ matrix.duckdb_arch }}.zip Release/duckdb.exe
+        zip -j libduckdb-${{ matrix.duckdb_arch }}.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
+        ./scripts/upload-assets-to-staging.sh github_release libduckdb-${{ matrix.duckdb_arch }}.zip duckdb_cli-${{ matrix.duckdb_arch }}.zip
 
     - uses: actions/upload-artifact@v4
       with:
-        name: duckdb-binaries-windows-amd64
+        name: duckdb-binaries-${{ matrix.duckdb_arch }}
         path: |
-          libduckdb-windows-amd64.zip
-          duckdb_cli-windows-amd64.zip
+          libduckdb-${{ matrix.duckdb_arch }}.zip
+          duckdb_cli-${{ matrix.duckdb_arch }}.zip
 
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Duckdb.dll export symbols with C++ on Windows
@@ -167,6 +171,9 @@ jobs:
    if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
    runs-on: windows-2019
    needs: win-release-64
+   strategy:
+    matrix:
+      duckdb_arch: [windows_arm64]
 
    steps:
      - uses: actions/checkout@v4
@@ -187,7 +194,7 @@ jobs:
      - name: Build
        shell: bash
        run: |
-         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=ARM64 -DDUCKDB_EXTENSION_CONFIGS="${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake" -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE" -DDUCKDB_EXPLICIT_PLATFORM=windows_arm64 -DDUCKDB_CUSTOM_PLATFORM=windows_arm64 -DBUILD_UNITTESTS=FALSE
+         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=ARM64 -DDUCKDB_EXTENSION_CONFIGS="${GITHUB_WORKSPACE}/.github/config/bundled_extensions.cmake" -DOVERRIDE_GIT_DESCRIBE="$OVERRIDE_GIT_DESCRIBE" -DDUCKDB_EXPLICIT_PLATFORM=${{ matrix.duckdb_arch }} -DDUCKDB_CUSTOM_PLATFORM=${{ matrix.duckdb_arch }} -DBUILD_UNITTESTS=FALSE
          cmake --build . --config Release --parallel
 
      - name: Deploy
@@ -198,16 +205,16 @@ jobs:
        run: |
          python scripts/amalgamation.py
          choco install zip -y --force
-         zip -j duckdb_cli-windows-arm64.zip Release/duckdb.exe
-         zip -j libduckdb-windows-arm64.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
-         ./scripts/upload-assets-to-staging.sh github_release libduckdb-windows-arm64.zip duckdb_cli-windows-arm64.zip
+         zip -j duckdb_cli-${{ matrix.duckdb_arch }}.zip Release/duckdb.exe
+         zip -j libduckdb-${{ matrix.duckdb_arch }}.zip src/Release/duckdb.dll src/Release/duckdb.lib src/amalgamation/duckdb.hpp src/include/duckdb.h
+         ./scripts/upload-assets-to-staging.sh github_release libduckdb-${{ matrix.duckdb_arch }}.zip duckdb_cli-${{ matrix.duckdb_arch }}.zip
 
      - uses: actions/upload-artifact@v4
        with:
-         name: duckdb-binaries-windows-arm64
+         name: duckdb-binaries-${{ matrix.duckdb_arch }}
          path: |
-           libduckdb-windows-arm64.zip
-           duckdb_cli-windows-arm64.zip
+           libduckdb-${{ matrix.duckdb_arch }}.zip
+           duckdb_cli-${{ matrix.duckdb_arch }}.zip
 
  mingw:
      name: MinGW (64 Bit)
@@ -286,18 +293,21 @@ jobs:
 
      - uses: actions/upload-artifact@v4
        with:
-         name: windows_amd64-extensions
+         name: duckdb-extensions-windows_amd64
          path: |
            build/release/extension/*/*.duckdb_extension
 
  upload-windows_amd64-extensions:
     name: Upload windows_amd64 Extensions
     needs: win-extensions-64
+    strategy:
+      matrix:
+        duckdb_arch: [windows_amd64]
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
     with:
-      extension_artifact_name: windows_amd64-extensions
-      duckdb_arch: windows_amd64
+      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
+      duckdb_arch: ${{ matrix.duckdb_arch }}
       duckdb_sha: ${{ github.sha }}
 
  win-packaged-upload:
@@ -308,17 +318,17 @@ jobs:
    steps:
     - uses: actions/download-artifact@v4
       with:
-        name: duckdb-binaries-windows-arm64
+        name: duckdb-binaries-windows_arm64
 
     - uses: actions/download-artifact@v4
       with:
-        name: duckdb-binaries-windows-amd64
+        name: duckdb-binaries-windows_amd64
 
     - uses: actions/upload-artifact@v4
       with:
         name: duckdb-binaries-windows
         path: |
-          libduckdb-windows-amd64.zip
-          duckdb_cli-windows-amd64.zip
-          libduckdb-windows-arm64.zip
-          duckdb_cli-windows-arm64.zip
+          libduckdb-windows_amd64.zip
+          duckdb_cli-windows_amd64.zip
+          libduckdb-windows_arm64.zip
+          duckdb_cli-windows_arm64.zip


### PR DESCRIPTION
Currently, the naming pattern for DuckDB binaries for `duckdb-binaries-windows` is inconsistent with the naming pattern used for DuckDB builds for another platforms, because it doesn't come from the `duckdb_arch` variable:
```
duckdb-binaries-osx_arm64
duckdb-binaries-osx_amd64
duckdb-binaries-windows-amd64
duckdb-binaries-windows-arm64
duckdb-binaries-linux_amd64
duckdb-binaries-linux_arm64
```

This PR makes it use `duckdb_arch` variable in binaries names