### PR TITLE
Parquet reader: batch check if buffer is available in RLEBpDecoder

### DIFF
--- a/extension/parquet/include/column_reader.hpp
+++ b/extension/parquet/include/column_reader.hpp
@@ -213,8 +213,12 @@ private:
 	template <class CONVERSION, bool HAS_DEFINES, bool CHECKED>
 	void PlainSkipTemplatedInternal(ByteBuffer &plain_data, const uint8_t *__restrict defines,
 	                                const uint64_t num_values, idx_t row_offset = 0) {
-		if (!HAS_DEFINES && !CHECKED && CONVERSION::PlainConstantSize() > 0) {
-			plain_data.unsafe_inc(num_values * CONVERSION::PlainConstantSize());
+		if (!HAS_DEFINES && CONVERSION::PlainConstantSize() > 0) {
+			if (CHECKED) {
+				plain_data.inc(num_values * CONVERSION::PlainConstantSize());
+			} else {
+				plain_data.unsafe_inc(num_values * CONVERSION::PlainConstantSize());
+			}
 			return;
 		}
 		for (idx_t row_idx = row_offset; row_idx < row_offset + num_values; row_idx++) {

--- a/extension/parquet/include/decode_utils.hpp
+++ b/extension/parquet/include/decode_utils.hpp
@@ -186,12 +186,17 @@ public:
 		} while (val != 0);
 	}
 
-	template <class T>
+	template <class T, bool CHECKED = true>
 	static T VarintDecode(ByteBuffer &buf) {
 		T result = 0;
 		uint8_t shift = 0;
 		while (true) {
-			auto byte = buf.read<uint8_t>();
+			uint8_t byte;
+			if (CHECKED) {
+				byte = buf.read<uint8_t>();
+			} else {
+				byte = buf.unsafe_read<uint8_t>();
+			}
 			result |= T(byte & 127) << shift;
 			if ((byte & 128) == 0) {
 				break;

--- a/extension/parquet/include/reader/templated_column_reader.hpp
+++ b/extension/parquet/include/reader/templated_column_reader.hpp
@@ -71,19 +71,9 @@ public:
 		PlainSkipTemplated<VALUE_CONVERSION>(plain_data, defines, num_values);
 	}
 
-	// FIXME: need to profile this to see if it makes sense for primitive types
-	// (or at what ratio of count / num_values it makes sense)
-	// void PlainSelect(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values, Vector &result,
-	//                  const SelectionVector &sel, idx_t count) override {
-	// 	PlainSelectTemplated<VALUE_TYPE, VALUE_CONVERSION>(*plain_data, defines, num_values, result, sel, count);
-	// }
-
 	bool SupportsDirectFilter() const override {
 		return true;
 	}
-	// bool SupportsDirectSelect() const override {
-	// 	return true;
-	// }
 };
 
 template <class PARQUET_PHYSICAL_TYPE, class DUCKDB_PHYSICAL_TYPE,


### PR DESCRIPTION
When reading long chains of `RleBpDecoder` data - `NextCounts` can be called many times. Instead of checking if there is enough buffer available for every byte we can batch check if we are certain we have enough bytes available. The varint that we are reading is limited to max 5 bytes (as more does not fit into a `uint32_t`) so we can just call `check_available` once. This improves performance by ~10% when reading data with many small batches.