### PR TITLE
Parquet Reader: for DeltaLengthByteArray encoding, directly refer to strings from the block without copying

### DIFF
--- a/extension/parquet/column_reader.cpp
+++ b/extension/parquet/column_reader.cpp
@@ -549,7 +549,7 @@ void ColumnReader::ReadData(idx_t read_now, data_ptr_t define_out, data_ptr_t re
 		rle_decoder.Read(define_ptr, read_now, result, result_offset);
 		break;
 	case ColumnEncoding::DELTA_LENGTH_BYTE_ARRAY:
-		delta_length_byte_array_decoder.Read(define_ptr, read_now, result, result_offset);
+		delta_length_byte_array_decoder.Read(block, define_ptr, read_now, result, result_offset);
 		break;
 	case ColumnEncoding::DELTA_BYTE_ARRAY:
 		delta_byte_array_decoder.Read(define_ptr, read_now, result, result_offset);

--- a/extension/parquet/include/decoder/delta_length_byte_array_decoder.hpp
+++ b/extension/parquet/include/decoder/delta_length_byte_array_decoder.hpp
@@ -22,7 +22,8 @@ public:
 public:
 	void InitializePage();
 
-	void Read(uint8_t *defines, idx_t read_count, Vector &result, idx_t result_offset);
+	void Read(shared_ptr<ResizeableBuffer> &block, uint8_t *defines, idx_t read_count, Vector &result,
+	          idx_t result_offset);
 	void Skip(uint8_t *defines, idx_t skip_count);
 
 private:

--- a/extension/parquet/include/reader/string_column_reader.hpp
+++ b/extension/parquet/include/reader/string_column_reader.hpp
@@ -25,6 +25,8 @@ public:
 	static void VerifyString(const char *str_data, uint32_t str_len, const bool isVarchar);
 	void VerifyString(const char *str_data, uint32_t str_len);
 
+	static void ReferenceBlock(Vector &result, shared_ptr<ResizeableBuffer> &block);
+
 protected:
 	void Plain(ByteBuffer &plain_data, uint8_t *defines, idx_t num_values, idx_t result_offset,
 	           Vector &result) override {

--- a/extension/parquet/reader/string_column_reader.cpp
+++ b/extension/parquet/reader/string_column_reader.cpp
@@ -45,9 +45,13 @@ private:
 	shared_ptr<ResizeableBuffer> buffer;
 };
 
+void StringColumnReader::ReferenceBlock(Vector &result, shared_ptr<ResizeableBuffer> &block) {
+	StringVector::AddBuffer(result, make_buffer<ParquetStringVectorBuffer>(block));
+}
+
 void StringColumnReader::Plain(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values,
                                idx_t result_offset, Vector &result) {
-	StringVector::AddBuffer(result, make_buffer<ParquetStringVectorBuffer>(plain_data));
+	ReferenceBlock(result, plain_data);
 	PlainTemplated<string_t, StringParquetValueConversion>(*plain_data, defines, num_values, result_offset, result);
 }
 
@@ -57,7 +61,7 @@ void StringColumnReader::PlainSkip(ByteBuffer &plain_data, uint8_t *defines, idx
 
 void StringColumnReader::PlainSelect(shared_ptr<ResizeableBuffer> &plain_data, uint8_t *defines, idx_t num_values,
                                      Vector &result, const SelectionVector &sel, idx_t count) {
-	StringVector::AddBuffer(result, make_buffer<ParquetStringVectorBuffer>(plain_data));
+	ReferenceBlock(result, plain_data);
 	PlainSelectTemplated<string_t, StringParquetValueConversion>(*plain_data, defines, num_values, result, sel, count);
 }
 


### PR DESCRIPTION
This speeds up reads of data encoded with `DeltaLengthByteArray` - given we can write this ourselves now that seems relevant :)