### PR TITLE
Ensure that dependent targets are present after find_package.

### DIFF
--- a/DuckDBConfig.cmake.in
+++ b/DuckDBConfig.cmake.in
@@ -4,6 +4,12 @@
 #  DuckDB_INCLUDE_DIRS - include directories for DuckDB
 #  DuckDB_LIBRARIES    - libraries to link against
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+if(NOT @WITH_INTERNAL_ICU@)
+    find_dependency(ICU COMPONENTS i18n uc)
+endif()
+
 # Compute paths
 get_filename_component(DuckDB_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(DuckDB_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")

--- a/extension/icu/CMakeLists.txt
+++ b/extension/icu/CMakeLists.txt
@@ -32,9 +32,9 @@ link_threads(icu_extension)
 if(NOT WITH_INTERNAL_ICU)
   find_package(
     ICU
-    COMPONENTS i18n
+    COMPONENTS i18n uc
     REQUIRED)
-  target_link_libraries(icu_extension ICU::i18n)
+  target_link_libraries(icu_extension ICU::i18n ICU::uc)
 endif()
 disable_target_warnings(icu_extension)
 set(PARAMETERS "-no-warnings")


### PR DESCRIPTION
DuckDBConfig.cmake.in:

* Ensure that Threads::Threads is available with find_dependency, as it is unconditionally used: https://github.com/duckdb/duckdb/blob/60c94425622338fc47ffcd646dd5181f734d364d/CMakeLists.txt#L25

* If external ICU is selected, ensure that its targets are available.

extension\icu\CMakeLists.txt: Add missing uc component; followup from #16176