### PR TITLE
Use steady clock for profiler

### DIFF
--- a/src/include/duckdb/common/chrono.hpp
+++ b/src/include/duckdb/common/chrono.hpp
@@ -17,5 +17,6 @@ using std::chrono::high_resolution_clock;
 using std::chrono::milliseconds;
 using std::chrono::nanoseconds;
 using std::chrono::system_clock;
+using std::chrono::steady_clock;
 using std::chrono::time_point;
 } // namespace duckdb

--- a/src/include/duckdb/common/chrono.hpp
+++ b/src/include/duckdb/common/chrono.hpp
@@ -16,7 +16,7 @@ using std::chrono::duration_cast;
 using std::chrono::high_resolution_clock;
 using std::chrono::milliseconds;
 using std::chrono::nanoseconds;
-using std::chrono::system_clock;
 using std::chrono::steady_clock;
+using std::chrono::system_clock;
 using std::chrono::time_point;
 } // namespace duckdb

--- a/src/include/duckdb/common/profiler.hpp
+++ b/src/include/duckdb/common/profiler.hpp
@@ -45,6 +45,6 @@ private:
 	bool finished = false;
 };
 
-using Profiler = BaseProfiler<system_clock>;
+using Profiler = BaseProfiler<steady_clock>;
 
 } // namespace duckdb


### PR DESCRIPTION
As documented in C++ STL [doc](https://en.cppreference.com/w/cpp/chrono/steady_clock) for `steady_clock`:
```
This clock is not related to wall clock time (for example, it can be time since last reboot), and is most suitable 
for measuring intervals.
```
