### PR TITLE
Concurrency groups for R and Wasm

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -31,7 +31,7 @@ on:
       - '!.github/workflows/R.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  group: r-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -25,6 +25,10 @@ on:
       - '**'
       - '!.github/workflows/Wasm.yml'
 
+concurrency:
+  group: wasm-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  cancel-in-progress: true
+
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
The latest nightly-build for `R` [was skipped](https://github.com/duckdb/duckdb/actions/runs/13275346242/job/37063805368) because `higher priority waiting request for 'InvokeCI' exists`. It happened because it was in common concurrency group, but it needs its own. 

This PR adds a concurrency groups for `R` and `Wasm` workflows (in `wasm` it was missing).