### PR TITLE
Improve performance of `UNNEST/UNPIVOT` by using selection vectors to unnest multiple lists at once

### DIFF
--- a/benchmark/pivot/unpivot_struct_input.benchmark
+++ b/benchmark/pivot/unpivot_struct_input.benchmark
@@ -1,0 +1,14 @@
+# name: benchmark/pivot/unpivot_struct_input.benchmark
+# description: Unpivot with a struct column as input column that must be projected alongside the unpivot columns
+# group: [pivot]
+
+name Nested Unpivot
+group csv
+
+load
+CREATE TABLE structs AS
+SELECT {'id': i, 'uuid': uuid(), 'str_uuid': uuid()::varchar} AS struct, i AS "2020", i + 10 AS "2021", i + 100 AS "2022", i + 1000 AS "2023", i + 10000 AS "2024"
+FROM range(10000000) t(i)
+
+run
+UNPIVOT structs ON "2020", "2021", "2022", "2023", "2024"

--- a/benchmark/pivot/unpivot_struct_payload.benchmark
+++ b/benchmark/pivot/unpivot_struct_payload.benchmark
@@ -1,0 +1,14 @@
+# name: benchmark/pivot/unpivot_struct_payload.benchmark
+# description: Unpivot with a struct column as input column as payload
+# group: [pivot]
+
+name Nested Unpivot
+group csv
+
+load
+CREATE TABLE structs AS
+SELECT i AS id, {'id': i} AS "2020", {'id': i + 10} AS "2021", {'id': i + 100} AS "2022", {'id': i + 1000} AS "2023", {'id': i + 10000} AS "2024"
+FROM range(10000000) t(i)
+
+run
+UNPIVOT structs ON "2020", "2021", "2022", "2023", "2024"

--- a/benchmark/tpch/pivot/lineitem_unpivot.benchmark
+++ b/benchmark/tpch/pivot/lineitem_unpivot.benchmark
@@ -1,0 +1,32 @@
+# name: benchmark/tpch/pivot/lineitem_unpivot.benchmark
+# description: lineitem unpivot
+# group: [pivot]
+
+name Lineitem Unpivot
+group pivot
+subgroup tpch
+
+require tpch
+
+cache tpch_sf1.duckdb
+
+load
+CALL dbgen(sf=1);
+
+run
+WITH unpivoted_data AS (
+UNPIVOT (SELECT l_orderkey, l_returnflag, l_shipinstruct FROM lineitem) ON l_returnflag, l_shipinstruct
+)
+SELECT name, value, AVG(l_orderkey) FROM unpivoted_data GROUP BY ALL ORDER BY ALL
+
+result III
+l_returnflag	A	3000424.4368691635
+l_returnflag	N	3000145.266271816
+l_returnflag	R	3000411.306590167
+l_shipinstruct	COLLECT COD	3000543.885344478
+l_shipinstruct	DELIVER IN PERSON	3000377.511525631
+l_shipinstruct	NONE	2999474.842545817
+l_shipinstruct	TAKE BACK RETURN	3000722.611838043
+
+
+

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -12,8 +12,7 @@ namespace duckdb {
 class UnnestOperatorState : public OperatorState {
 public:
 	UnnestOperatorState(ClientContext &context, const vector<unique_ptr<Expression>> &select_list)
-	    : current_row(0), list_position(0), first_fetch(true),
-	      input_sel(STANDARD_VECTOR_SIZE), executor(context) {
+	    : current_row(0), list_position(0), first_fetch(true), input_sel(STANDARD_VECTOR_SIZE), executor(context) {
 
 		// for each UNNEST in the select_list, we add the child expression to the expression executor
 		// and set the return type in the list_data chunk, which will contain the evaluated expression results
@@ -25,7 +24,9 @@ public:
 			executor.AddExpression(*bue.child.get());
 
 			unnest_sels.emplace_back(STANDARD_VECTOR_SIZE);
+			null_sels.emplace_back(STANDARD_VECTOR_SIZE);
 		}
+		null_counts.resize(list_data_types.size());
 
 		auto &allocator = Allocator::Get(context);
 		list_data.Initialize(allocator, list_data_types);
@@ -40,6 +41,8 @@ public:
 	bool first_fetch;
 	SelectionVector input_sel;
 	vector<SelectionVector> unnest_sels;
+	vector<SelectionVector> null_sels;
+	vector<idx_t> null_counts;
 
 	ExpressionExecutor executor;
 	DataChunk list_data;
@@ -50,8 +53,7 @@ public:
 	//! Reset the fields of the unnest operator state
 	void Reset();
 	//! Prepare the input for the next unnest
-	void PrepareInput(DataChunk &input,
-							 const vector<unique_ptr<Expression>> &select_list);
+	void PrepareInput(DataChunk &input, const vector<unique_ptr<Expression>> &select_list);
 };
 
 void UnnestOperatorState::Reset() {
@@ -66,155 +68,7 @@ PhysicalUnnest::PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expr
 	D_ASSERT(!this->select_list.empty());
 }
 
-static void UnnestNull(idx_t start, idx_t end, Vector &result) {
-
-	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
-	auto &validity = FlatVector::Validity(result);
-	for (idx_t i = start; i < end; i++) {
-		validity.SetInvalid(i);
-	}
-
-	const auto &logical_type = result.GetType();
-	if (logical_type.InternalType() == PhysicalType::STRUCT) {
-		const auto &struct_children = StructVector::GetEntries(result);
-		for (auto &child : struct_children) {
-			UnnestNull(start, end, *child);
-		}
-	} else if (logical_type.InternalType() == PhysicalType::ARRAY) {
-		auto &array_child = ArrayVector::GetEntry(result);
-		auto array_size = ArrayType::GetSize(logical_type);
-		UnnestNull(start * array_size, end * array_size, array_child);
-	}
-}
-
-template <class T>
-static void TemplatedUnnest(UnifiedVectorFormat &vector_data, idx_t start, idx_t end, Vector &result) {
-
-	auto source_data = UnifiedVectorFormat::GetData<T>(vector_data);
-	auto &source_mask = vector_data.validity;
-
-	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
-	auto result_data = FlatVector::GetData<T>(result);
-	auto &result_mask = FlatVector::Validity(result);
-
-	for (idx_t i = start; i < end; i++) {
-		auto source_idx = vector_data.sel->get_index(i);
-		auto target_idx = i - start;
-		if (source_mask.RowIsValid(source_idx)) {
-			result_data[target_idx] = source_data[source_idx];
-			result_mask.SetValid(target_idx);
-		} else {
-			result_mask.SetInvalid(target_idx);
-		}
-	}
-}
-
-static void UnnestValidity(UnifiedVectorFormat &vector_data, idx_t start, idx_t end, Vector &result) {
-
-	auto &source_mask = vector_data.validity;
-	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
-	auto &result_mask = FlatVector::Validity(result);
-
-	for (idx_t i = start; i < end; i++) {
-		auto source_idx = vector_data.sel->get_index(i);
-		auto target_idx = i - start;
-		result_mask.Set(target_idx, source_mask.RowIsValid(source_idx));
-	}
-}
-
-static void UnnestVector(UnifiedVectorFormat &child_vector_data, Vector &child_vector, idx_t list_size, idx_t start,
-                         idx_t end, Vector &result) {
-
-	D_ASSERT(child_vector.GetType() == result.GetType());
-	switch (result.GetType().InternalType()) {
-	case PhysicalType::BOOL:
-	case PhysicalType::INT8:
-		TemplatedUnnest<int8_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::INT16:
-		TemplatedUnnest<int16_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::INT32:
-		TemplatedUnnest<int32_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::INT64:
-		TemplatedUnnest<int64_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::INT128:
-		TemplatedUnnest<hugeint_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::UINT8:
-		TemplatedUnnest<uint8_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::UINT16:
-		TemplatedUnnest<uint16_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::UINT32:
-		TemplatedUnnest<uint32_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::UINT64:
-		TemplatedUnnest<uint64_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::UINT128:
-		TemplatedUnnest<uhugeint_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::FLOAT:
-		TemplatedUnnest<float>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::DOUBLE:
-		TemplatedUnnest<double>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::INTERVAL:
-		TemplatedUnnest<interval_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::VARCHAR:
-		TemplatedUnnest<string_t>(child_vector_data, start, end, result);
-		break;
-	case PhysicalType::LIST: {
-		// the child vector of result now references the child vector source
-		// FIXME: only reference relevant children (start - end) instead of all
-		auto &target = ListVector::GetEntry(result);
-		target.Reference(ListVector::GetEntry(child_vector));
-		ListVector::SetListSize(result, ListVector::GetListSize(child_vector));
-		// unnest
-		TemplatedUnnest<list_entry_t>(child_vector_data, start, end, result);
-		break;
-	}
-	case PhysicalType::STRUCT: {
-		auto &child_vector_entries = StructVector::GetEntries(child_vector);
-		auto &result_entries = StructVector::GetEntries(result);
-
-		// set the validity mask for the 'outer' struct vector before unnesting its children
-		UnnestValidity(child_vector_data, start, end, result);
-
-		for (idx_t i = 0; i < child_vector_entries.size(); i++) {
-			UnifiedVectorFormat child_vector_entries_data;
-			child_vector_entries[i]->ToUnifiedFormat(list_size, child_vector_entries_data);
-			UnnestVector(child_vector_entries_data, *child_vector_entries[i], list_size, start, end,
-			             *result_entries[i]);
-		}
-		break;
-	}
-	case PhysicalType::ARRAY: {
-		auto array_size = ArrayType::GetSize(child_vector.GetType());
-		auto &source_array = ArrayVector::GetEntry(child_vector);
-		auto &target_array = ArrayVector::GetEntry(result);
-
-		UnnestValidity(child_vector_data, start, end, result);
-
-		UnifiedVectorFormat child_array_data;
-		source_array.ToUnifiedFormat(list_size * array_size, child_array_data);
-		UnnestVector(child_array_data, source_array, list_size * array_size, start * array_size, end * array_size,
-		             target_array);
-		break;
-	}
-	default:
-		throw InternalException("Unimplemented type for UNNEST.");
-	}
-}
-
-void UnnestOperatorState::PrepareInput(DataChunk &input,
-                         const vector<unique_ptr<Expression>> &select_list) {
+void UnnestOperatorState::PrepareInput(DataChunk &input, const vector<unique_ptr<Expression>> &select_list) {
 	list_data.Reset();
 	// execute the expressions inside each UNNEST in the select_list to get the list data
 	// execution results (lists) are kept in list_data chunk
@@ -248,12 +102,12 @@ void UnnestOperatorState::PrepareInput(DataChunk &input,
 	if (list_data.size() > unnest_lengths.size()) {
 		unnest_lengths.resize(list_data.size());
 	}
-	for(idx_t r = 0; r < list_data.size(); r++) {
+	for (idx_t r = 0; r < list_data.size(); r++) {
 		unnest_lengths[r] = 0;
 	}
 	for (idx_t col_idx = 0; col_idx < list_data.ColumnCount(); col_idx++) {
 		auto &vector_data = list_vector_data[col_idx];
-		for(idx_t r = 0; r < list_data.size(); r++) {
+		for (idx_t r = 0; r < list_data.size(); r++) {
 			auto current_idx = vector_data.sel->get_index(r);
 			if (!vector_data.validity.RowIsValid(current_idx)) {
 				continue;
@@ -306,30 +160,46 @@ OperatorResultType PhysicalUnnest::ExecuteInternal(ExecutionContext &context, Da
 		idx_t result_length = 0;
 		idx_t unnest_list_count = 0;
 		auto initial_row = state.current_row;
-		while(result_length < STANDARD_VECTOR_SIZE && state.current_row < input.size()) {
-			auto current_row_length = MinValue<idx_t>(STANDARD_VECTOR_SIZE - result_length, state.unnest_lengths[state.current_row] - state.list_position);
+		for (idx_t col_idx = 0; col_idx < state.list_data.ColumnCount(); col_idx++) {
+			state.null_counts[col_idx] = 0;
+		}
+		while (result_length < STANDARD_VECTOR_SIZE && state.current_row < input.size()) {
+			auto current_row_length = MinValue<idx_t>(STANDARD_VECTOR_SIZE - result_length,
+			                                          state.unnest_lengths[state.current_row] - state.list_position);
 
 			if (current_row_length > 0) {
 				// set up the selection vectors
 				if (include_input) {
-					for(idx_t r = 0; r < current_row_length; r++) {
+					for (idx_t r = 0; r < current_row_length; r++) {
 						state.input_sel.set_index(result_length + r, state.current_row);
 					}
 				}
 				for (idx_t col_idx = 0; col_idx < state.list_data.ColumnCount(); col_idx++) {
 					auto &vector_data = state.list_vector_data[col_idx];
 					auto current_idx = vector_data.sel->get_index(state.current_row);
-					auto list_data = UnifiedVectorFormat::GetData<list_entry_t>(vector_data);
-					if (!vector_data.validity.RowIsValid(current_idx)) {
-						throw InternalException("This should never be reached");
+					idx_t list_length = 0;
+					idx_t list_offset = 0;
+					if (vector_data.validity.RowIsValid(current_idx)) {
+						auto list_data = UnifiedVectorFormat::GetData<list_entry_t>(vector_data);
+						auto list_entry = list_data[current_idx];
+						list_length = list_entry.length;
+						list_offset = list_entry.offset;
 					}
-					auto list_entry = list_data[current_idx];
-					if (list_entry.length != current_row_length) {
-						throw InternalException("Unnest lists with different lengths should take a different code path");
-					}
+					// unnest any entries we can
+					idx_t unnest_length = MinValue<idx_t>(list_length - state.list_position, current_row_length);
 					auto &unnest_sel = state.unnest_sels[col_idx];
-					for(idx_t r = 0; r < current_row_length; r++) {
-						unnest_sel.set_index(result_length + r, list_entry.offset + state.list_position + r);
+					for (idx_t r = 0; r < unnest_length; r++) {
+						unnest_sel.set_index(result_length + r, list_offset + state.list_position + r);
+					}
+					// for any remaining entries (if any) - set them in the null selection
+					auto &null_sel = state.null_sels[col_idx];
+					for (idx_t r = unnest_length; r < current_row_length; r++) {
+						// we unnest the first row in the child list
+						// this is chosen arbitrarily - we will override it with `NULL` afterwards
+						// FIXME if the child list has a `NULL` entry we can directly unnest that and avoid having
+						// to override it - this is a potential optimization we could do in the future
+						unnest_sel.set_index(result_length + r, 0);
+						null_sel.set_index(state.null_counts[col_idx]++, result_length + r);
 					}
 				}
 
@@ -363,80 +233,27 @@ OperatorResultType PhysicalUnnest::ExecuteInternal(ExecutionContext &context, Da
 				chunk.SetCardinality(0);
 				break;
 			}
-			auto &child_vector = ListVector::GetEntry(state.list_data.data[col_idx]);
-			chunk.data[col_offset + col_idx].Slice(child_vector, state.unnest_sels[col_idx], result_length);
+			auto &list_vector = state.list_data.data[col_idx];
+			auto &result_vector = chunk.data[col_offset + col_idx];
+			if (ListVector::GetListSize(list_vector) == 0) {
+				// we cannot slice empty lists - but if our child list is empty we can only return NULL anyway
+				result_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+				ConstantVector::SetNull(result_vector, true);
+				continue;
+			}
+			auto &child_vector = ListVector::GetEntry(list_vector);
+			result_vector.Slice(child_vector, state.unnest_sels[col_idx], result_length);
+			if (state.null_counts[col_idx] > 0) {
+				// we have NULL values that we need to set - flatten
+				result_vector.Flatten(result_length);
+				auto &result_mask = FlatVector::Validity(result_vector);
+				auto &null_sel = state.null_sels[col_idx];
+				for (idx_t idx = 0; idx < state.null_counts[col_idx]; idx++) {
+					auto null_index = null_sel.get_index(idx);
+					result_mask.SetInvalid(null_index);
+				}
+			}
 		}
-		chunk.Verify();
-		//
-		//
-		//
-		// // each UNNEST in the select_list contains a list (or NULL) for this row, find the longest list
-		// // we emit chunks of either STANDARD_VECTOR_SIZE or smaller
-		// auto this_chunk_len = MinValue<idx_t>(STANDARD_VECTOR_SIZE, state.unnest_lengths[state.current_row] - state.list_position);
-		// chunk.SetCardinality(this_chunk_len);
-		//
-		// // if we include other projection input columns, e.g. SELECT 1, UNNEST([1, 2]);, then
-		// // we need to add them to the resulting chunk
-		// idx_t col_offset = 0;
-		// if (include_input) {
-		// 	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
-		// 		ConstantVector::Reference(chunk.data[col_idx], input.data[col_idx], state.current_row, input.size());
-		// 	}
-		// 	col_offset = input.ColumnCount();
-		// }
-		//
-		// // unnest the lists
-		// for (idx_t col_idx = 0; col_idx < state.list_data.ColumnCount(); col_idx++) {
-		//
-		// 	auto &result_vector = chunk.data[col_idx + col_offset];
-		//
-		// 	if (state.list_data.data[col_idx].GetType() == LogicalType::SQLNULL) {
-		// 		// UNNEST(NULL)
-		// 		chunk.SetCardinality(0);
-		// 		break;
-		// 	}
-		//
-		// 	auto &vector_data = state.list_vector_data[col_idx];
-		// 	auto current_idx = vector_data.sel->get_index(state.current_row);
-		//
-		// 	if (!vector_data.validity.RowIsValid(current_idx)) {
-		// 		UnnestNull(0, this_chunk_len, result_vector);
-		// 		continue;
-		// 	}
-		//
-		// 	auto list_data = UnifiedVectorFormat::GetData<list_entry_t>(vector_data);
-		// 	auto list_entry = list_data[current_idx];
-		//
-		// 	idx_t list_count = 0;
-		// 	if (state.list_position < list_entry.length) {
-		// 		// there are still list_count elements to unnest
-		// 		list_count = MinValue<idx_t>(this_chunk_len, list_entry.length - state.list_position);
-		//
-		// 		auto &list_vector = state.list_data.data[col_idx];
-		// 		auto &child_vector = ListVector::GetEntry(list_vector);
-		// 		auto list_size = ListVector::GetListSize(list_vector);
-		// 		auto &child_vector_data = state.list_child_data[col_idx];
-		//
-		// 		auto base_offset = list_entry.offset + state.list_position;
-		// 		UnnestVector(child_vector_data, child_vector, list_size, base_offset, base_offset + list_count,
-		// 		             result_vector);
-		// 	}
-		//
-		// 	// fill the rest with NULLs
-		// 	if (list_count != this_chunk_len) {
-		// 		UnnestNull(list_count, this_chunk_len, result_vector);
-		// 	}
-		// }
-		//
-		// chunk.Verify();
-		//
-		// state.list_position += this_chunk_len;
-		// if (state.list_position == state.unnest_lengths[state.current_row]) {
-		// 	state.current_row++;
-		// 	state.list_position = 0;
-		// }
-
-		// we only emit one unnested row (that contains data) at a time
 	} while (chunk.size() == 0);
 	return OperatorResultType::HAVE_MORE_OUTPUT;
 }

--- a/src/execution/operator/projection/physical_unnest.cpp
+++ b/src/execution/operator/projection/physical_unnest.cpp
@@ -246,11 +246,10 @@ OperatorResultType PhysicalUnnest::ExecuteInternal(ExecutionContext &context, Da
 			if (state.null_counts[col_idx] > 0) {
 				// we have NULL values that we need to set - flatten
 				result_vector.Flatten(result_length);
-				auto &result_mask = FlatVector::Validity(result_vector);
 				auto &null_sel = state.null_sels[col_idx];
 				for (idx_t idx = 0; idx < state.null_counts[col_idx]; idx++) {
 					auto null_index = null_sel.get_index(idx);
-					result_mask.SetInvalid(null_index);
+					FlatVector::SetNull(result_vector, null_index, true);
 				}
 			}
 		}


### PR DESCRIPTION
The current `UNNEST` implementation handles one list a time. While that works fine for large lists, we often unnest small lists. One scenario where we unnest small lists is in `UNPIVOT`, where the list size is equivalent to the amount of columns we are unpivoting. For example, the query:

```sql
UNPIVOT (SELECT l_orderkey, l_returnflag, l_shipinstruct FROM lineitem) ON l_returnflag, l_shipinstruct;
```

Is translated into the below query:

```sql
SELECT l_orderkey, UNNEST(['l_returnflag', 'l_shipinstruct']) AS name, UNNEST([l_returnflag, l_shipinstruct]) AS value
FROM lineitem;
```

This frequently leads to unnesting of small lists (in the above example lists of size 2).

The current `UNNEST` implementation handles this inefficiently because it will, in this scenario, emit vectors of at most size 2. This PR reworks the `UNNEST` to handle multiple lists at once. In addition, it also gets rid of the copying that `UNNEST` would previously do by instead rewriting `UNNEST` to only work using selection vectors.

Effectively we traverse the input lists and construct a selection vector with the rows we need from (1) the input payload, and (2) the list entries. We then slice the input/list children with these selection vectors.

When unnesting lists of different sizes we must add `NULL` entries. We do this as a separate pass - we slice the first row of the given list vector, and then call `Flatten` + assign `NULL` to the entries for which this is required. This is slower - but still does not require any special code. The flattening could be avoided if the list child has `NULL` entries itself but that is not guaranteed, so for now this optimization is skipped. I also presume that unnesting multiple lists of different lengths is probably pretty rare (but have no data to back that up).

### Performance

Below is the performance of the given `UNPIVOT` query running on TPC-H SF10:


```sql
UNPIVOT (SELECT l_orderkey, l_returnflag, l_shipinstruct FROM lineitem) ON l_returnflag, l_shipinstruct;
```

| v1.2.0 |  New  |
|--------|-------|
| 8.9s   | 0.37s |