### PR TITLE
Avoid unnecessarily projecting the input columns of the UNPIVOT operator in the UNNEST

### DIFF
--- a/test/sql/pivot/unpivot_internal_names.test
+++ b/test/sql/pivot/unpivot_internal_names.test
@@ -1,0 +1,19 @@
+# name: test/sql/pivot/unpivot_internal_names.test
+# description: Test unpivoting on a table with names used internally by the unpivot operator
+# group: [pivot]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE unpivot_names(unpivot_names VARCHAR, unpivot_list VARCHAR, unpivot_list_2 VARCHAR, col1 INT, col2 INT, col3 INT);
+
+statement ok
+INSERT INTO unpivot_names VALUES ('unpivot_names', 'unpivot_list', 'unpivot_list_2', 1, 2, 3);
+
+query IIIII
+UNPIVOT unpivot_names ON COLUMNS('col*')
+----
+unpivot_names	unpivot_list	unpivot_list_2	col1	1
+unpivot_names	unpivot_list	unpivot_list_2	col2	2
+unpivot_names	unpivot_list	unpivot_list_2	col3	3


### PR DESCRIPTION
 Fixes #13552

This greatly improves performance when unpivoting on many columns. Previously these columns would be projected out and then immediately discarded - leading to a lot of wasted time.

Below is a benchmark where we are unpivoting 10,000 columns:

```sql
create table r as select id, concat('column_', id) as column_name, concat('value_', id) as  column_value from (select unnest(generate_series(1,10000)) as id);
create table pivoted as pivot r on column_name using first(id) group by id;
select count(*) from (unpivot pivoted on columns(* exclude id) into name 'column_name' value 'column_value');
```

| v1.2.0 |  New  |
|--------|-------|
| 145.4s | 0.77s |
