### PR TITLE
use random seeds for bernoulli sample when parallel is enabled

### DIFF
--- a/src/execution/operator/helper/physical_streaming_sample.cpp
+++ b/src/execution/operator/helper/physical_streaming_sample.cpp
@@ -6,9 +6,9 @@
 namespace duckdb {
 
 PhysicalStreamingSample::PhysicalStreamingSample(vector<LogicalType> types, unique_ptr<SampleOptions> options,
-							idx_t estimated_cardinality)
+                                                 idx_t estimated_cardinality)
     : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, std::move(types), estimated_cardinality),
-		sample_options(std::move(options)) {
+      sample_options(std::move(options)) {
 	percentage = sample_options->sample_size.GetValue<double>() / 100;
 }
 

--- a/src/execution/operator/helper/physical_streaming_sample.cpp
+++ b/src/execution/operator/helper/physical_streaming_sample.cpp
@@ -5,10 +5,11 @@
 
 namespace duckdb {
 
-PhysicalStreamingSample::PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage,
-                                                 int64_t seed, idx_t estimated_cardinality)
-    : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, std::move(types), estimated_cardinality), method(method),
-      percentage(percentage / 100), seed(seed) {
+PhysicalStreamingSample::PhysicalStreamingSample(vector<LogicalType> types, unique_ptr<SampleOptions> options,
+							idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, std::move(types), estimated_cardinality),
+		sample_options(std::move(options)) {
+	percentage = sample_options->sample_size.GetValue<double>() / 100;
 }
 
 //===--------------------------------------------------------------------===//
@@ -49,13 +50,21 @@ void PhysicalStreamingSample::BernoulliSample(DataChunk &input, DataChunk &resul
 	}
 }
 
+bool PhysicalStreamingSample::ParallelOperator() const {
+	return !sample_options->repeatable;
+}
+
 unique_ptr<OperatorState> PhysicalStreamingSample::GetOperatorState(ExecutionContext &context) const {
-	return make_uniq<StreamingSampleOperatorState>(seed);
+	if (!ParallelOperator()) {
+		return make_uniq<StreamingSampleOperatorState>(static_cast<int64_t>(sample_options->seed.GetIndex()));
+	}
+	RandomEngine random;
+	return make_uniq<StreamingSampleOperatorState>(static_cast<int64_t>(random.NextRandomInteger64()));
 }
 
 OperatorResultType PhysicalStreamingSample::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
                                                     GlobalOperatorState &gstate, OperatorState &state) const {
-	switch (method) {
+	switch (sample_options->method) {
 	case SampleMethod::BERNOULLI_SAMPLE:
 		BernoulliSample(input, chunk, state);
 		break;
@@ -70,7 +79,7 @@ OperatorResultType PhysicalStreamingSample::Execute(ExecutionContext &context, D
 
 InsertionOrderPreservingMap<string> PhysicalStreamingSample::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
-	result["Sample Method"] = EnumUtil::ToString(method) + ": " + to_string(100 * percentage) + "%";
+	result["Sample Method"] = EnumUtil::ToString(sample_options->method) + ": " + to_string(100 * percentage) + "%";
 	return result;
 }
 

--- a/src/execution/operator/helper/physical_streaming_sample.cpp
+++ b/src/execution/operator/helper/physical_streaming_sample.cpp
@@ -51,7 +51,7 @@ void PhysicalStreamingSample::BernoulliSample(DataChunk &input, DataChunk &resul
 }
 
 bool PhysicalStreamingSample::ParallelOperator() const {
-	return !sample_options->repeatable;
+	return !(sample_options->repeatable || sample_options->seed.IsValid());
 }
 
 unique_ptr<OperatorState> PhysicalStreamingSample::GetOperatorState(ExecutionContext &context) const {

--- a/src/execution/physical_plan/plan_sample.cpp
+++ b/src/execution/physical_plan/plan_sample.cpp
@@ -28,8 +28,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSample &op
 			                      "reservoir sampling or use a sample_size",
 			                      EnumUtil::ToString(op.sample_options->method));
 		}
-		sample = make_uniq<PhysicalStreamingSample>(
-		    op.types, std::move(op.sample_options), op.estimated_cardinality);
+		sample = make_uniq<PhysicalStreamingSample>(op.types, std::move(op.sample_options), op.estimated_cardinality);
 		break;
 	default:
 		throw InternalException("Unimplemented sample method");

--- a/src/execution/physical_plan/plan_sample.cpp
+++ b/src/execution/physical_plan/plan_sample.cpp
@@ -29,8 +29,7 @@ unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSample &op
 			                      EnumUtil::ToString(op.sample_options->method));
 		}
 		sample = make_uniq<PhysicalStreamingSample>(
-		    op.types, op.sample_options->method, op.sample_options->sample_size.GetValue<double>(),
-		    static_cast<int64_t>(op.sample_options->seed.GetIndex()), op.estimated_cardinality);
+		    op.types, std::move(op.sample_options), op.estimated_cardinality);
 		break;
 	default:
 		throw InternalException("Unimplemented sample method");

--- a/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
@@ -19,8 +19,7 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::STREAMING_SAMPLE;
 
 public:
-	PhysicalStreamingSample(vector<LogicalType> types, unique_ptr<SampleOptions> options,
-	                        idx_t estimated_cardinality);
+	PhysicalStreamingSample(vector<LogicalType> types, unique_ptr<SampleOptions> options, idx_t estimated_cardinality);
 
 	unique_ptr<SampleOptions> sample_options;
 	double percentage;

--- a/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
+++ b/src/include/duckdb/execution/operator/helper/physical_streaming_sample.hpp
@@ -19,12 +19,11 @@ public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::STREAMING_SAMPLE;
 
 public:
-	PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage, int64_t seed,
+	PhysicalStreamingSample(vector<LogicalType> types, unique_ptr<SampleOptions> options,
 	                        idx_t estimated_cardinality);
 
-	SampleMethod method;
+	unique_ptr<SampleOptions> sample_options;
 	double percentage;
-	int64_t seed;
 
 public:
 	// Operator interface
@@ -32,9 +31,7 @@ public:
 	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
 	                           GlobalOperatorState &gstate, OperatorState &state) const override;
 
-	bool ParallelOperator() const override {
-		return true;
-	}
+	bool ParallelOperator() const override;
 
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
 

--- a/test/sql/sample/bernoulli_sampling.test
+++ b/test/sql/sample/bernoulli_sampling.test
@@ -1,0 +1,57 @@
+# name: test/sql/sample/bernoulli_sampling.test
+# description: Test reservoir sample crash on large data sets
+# group: [sample]
+
+
+statement ok
+create table output (num_rows INT);
+
+statement ok
+select setseed(0.3);
+
+loop i 0 500
+
+statement ok
+WITH some_tab AS (
+    SELECT UNNEST(range(1000)) AS id
+),
+some_tab_unq AS (
+    SELECT distinct(id) AS id FROM some_tab
+),
+sampled AS (
+    select id from some_tab_unq
+    USING SAMPLE 1% (bernoulli)
+)
+INSERT INTO output select count(*) as n_rows FROM sampled;
+
+endloop
+
+
+query III
+select min(num_rows) > 0, max(num_rows) < 25, count(*) FILTER (num_rows = 0) = 0 from output;
+----
+true	true	true
+
+query III
+select avg(rowid), min(rowid), max(rowid) from output where num_rows = 0;
+----
+NULL	NULL	NULL
+
+
+
+statement ok
+create table t1 as select range id from range(1000);
+
+statement ok
+select setseed(0.6);
+
+query I nosort result_1
+select id from t1 USING SAMPLE 1% (bernoulli, 5);
+----
+
+query I nosort result_1
+select id from t1 USING SAMPLE 1% (bernoulli, 5);
+----
+
+
+

--- a/test/sql/sample/bernoulli_sampling.test
+++ b/test/sql/sample/bernoulli_sampling.test
@@ -26,17 +26,15 @@ INSERT INTO output select count(*) as n_rows FROM sampled;
 endloop
 
 
-query III
-select min(num_rows) > 0, max(num_rows) < 25, count(*) FILTER (num_rows = 0) = 0 from output;
+query II
+select min(num_rows) > 0, count(*) FILTER (num_rows = 0) = 0 from output;
 ----
-true	true	true
+true	true
 
 query III
 select avg(rowid), min(rowid), max(rowid) from output where num_rows = 0;
 ----
 NULL	NULL	NULL
-
-
 
 statement ok
 create table t1 as select range id from range(1000);

--- a/test/sql/sample/bernoulli_sampling.test
+++ b/test/sql/sample/bernoulli_sampling.test
@@ -2,7 +2,6 @@
 # description: Test reservoir sample crash on large data sets
 # group: [sample]
 
-
 statement ok
 create table output (num_rows INT);
 


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/4203
fixes https://github.com/duckdb/duckdb/issues/16175

For smaller data sizes and a parallel Bernoulli sample, you could get skewed results. This is because the same seed was used for all threads. So if you have 10 threads and a data size of 1000, then every thread gets ~100 rows. In the example, the sample size was 1%. It's possible the random engine doesn't produce a value <0.01 for the first 100 randomly generated values. This means none of the threads return a value for the result.

The fix is to assign every thread a random seed, but if repeatable is set, then we set `ParallelSink` to false and we use the seed, guaranteeing a repeatable result.

This PR is similar to how reservoir sampling currently behaves. 
related PR
https://github.com/duckdb/duckdb/pull/14797/files