### PR TITLE
Use _win32 with MSVC

### DIFF
--- a/extension/tpcds/dsdgen/include/dsdgen-c/porting.h
+++ b/extension/tpcds/dsdgen/include/dsdgen-c/porting.h
@@ -57,7 +57,7 @@
 
 #include <stdint.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <sys/timeb.h>
 #define timeb _timeb
 #define ftime _ftime
@@ -76,7 +76,7 @@ typedef HUGE_TYPE ds_key_t;
 char *strdup(const char *);
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h>
 #include <windows.h>
 #include <winbase.h>

--- a/extension/tpch/dbgen/text.cpp
+++ b/extension/tpch/dbgen/text.cpp
@@ -22,10 +22,10 @@
 #include "dbgen/config.h"
 
 #include <stdlib.h>
-#ifndef WIN32
+#ifndef _WIN32
  /* Change for Windows NT */
 #include <unistd.h>
-#endif /* WIN32 */
+#endif /* _WIN32 */
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>


### PR DESCRIPTION
Fix building Duckdb on Windows with MSVC 2022. _win32 is the correct define for MSVC (and I believe mingw64 these days) - see https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170