### PR TITLE
Fix -std=c++11

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -173,7 +173,7 @@ libraries = []
 if 'DUCKDB_BINARY_DIR' in os.environ:
     existing_duckdb_dir = os.environ['DUCKDB_BINARY_DIR']
 if 'DUCKDB_COMPILE_FLAGS' in os.environ:
-    toolchain_args = ['-std=c++11'] + os.environ['DUCKDB_COMPILE_FLAGS'].split()
+    toolchain_args = os.environ['DUCKDB_COMPILE_FLAGS'].split()
 if 'DUCKDB_LIBS' in os.environ:
     libraries = os.environ['DUCKDB_LIBS'].split(' ')
 


### PR DESCRIPTION
 is invalid with MSVC. It it is set correctly here - https://github.com/duckdb/duckdb/blob/main/tools/pythonpkg/setup.py#L162 and L165, but then reset again at https://github.com/duckdb/duckdb/blob/main/tools/pythonpkg/setup.py#L176 but incorrectly for all compilers.