### PR TITLE
Deleted copy constructor of pending query

### DIFF
--- a/src/include/duckdb/main/pending_query_result.hpp
+++ b/src/include/duckdb/main/pending_query_result.hpp
@@ -29,6 +29,9 @@ public:
 	DUCKDB_API explicit PendingQueryResult(ErrorData error_message);
 	DUCKDB_API ~PendingQueryResult() override;
 	DUCKDB_API bool AllowStreamResult() const;
+	PendingQueryResult(const PendingQueryResult&) = delete;
+	PendingQueryResult& operator=(const PendingQueryResult&) = delete;
+
 
 public:
 	//! Executes a single task within the query, returning whether or not the query is ready.

--- a/src/include/duckdb/main/pending_query_result.hpp
+++ b/src/include/duckdb/main/pending_query_result.hpp
@@ -29,9 +29,8 @@ public:
 	DUCKDB_API explicit PendingQueryResult(ErrorData error_message);
 	DUCKDB_API ~PendingQueryResult() override;
 	DUCKDB_API bool AllowStreamResult() const;
-	PendingQueryResult(const PendingQueryResult&) = delete;
-	PendingQueryResult& operator=(const PendingQueryResult&) = delete;
-
+	PendingQueryResult(const PendingQueryResult &) = delete;
+	PendingQueryResult &operator=(const PendingQueryResult &) = delete;
 
 public:
 	//! Executes a single task within the query, returning whether or not the query is ready.


### PR DESCRIPTION
Having a non-deleted copy constructor allows me to write the following code, which crashes

```cpp
DuckDB duckdb(nullptr);
Connection con(duckdb);
auto pending = con.PendingQuery("FROM range(1000)");
auto pending2 = *pending;

pending2.Execute(); // Crashes -> Attempting to execute an unsuccessful or closed pending query result
```