### PR TITLE
Inline ListLambdaBindData methods

### DIFF
--- a/extension/core_functions/lambda_functions.cpp
+++ b/extension/core_functions/lambda_functions.cpp
@@ -223,17 +223,6 @@ void ExecuteExpression(const idx_t elem_cnt, const LambdaFunctions::ColumnInfo &
 // ListLambdaBindData
 //===--------------------------------------------------------------------===//
 
-unique_ptr<FunctionData> ListLambdaBindData::Copy() const {
-	auto lambda_expr_copy = lambda_expr ? lambda_expr->Copy() : nullptr;
-	return make_uniq<ListLambdaBindData>(return_type, std::move(lambda_expr_copy), has_index);
-}
-
-bool ListLambdaBindData::Equals(const FunctionData &other_p) const {
-	auto &other = other_p.Cast<ListLambdaBindData>();
-	return Expression::Equals(lambda_expr, other.lambda_expr) && return_type == other.return_type &&
-	       has_index == other.has_index;
-}
-
 void ListLambdaBindData::Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
                                    const ScalarFunction &) {
 	auto &bind_data = bind_data_p->Cast<ListLambdaBindData>();

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -12,9 +12,6 @@
 
 namespace duckdb {
 
-FunctionData::~FunctionData() {
-}
-
 bool FunctionData::Equals(const FunctionData *left, const FunctionData *right) {
 	if (left == right) {
 		return true;

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -56,7 +56,7 @@ enum class FunctionCollationHandling : uint8_t {
 };
 
 struct FunctionData {
-	DUCKDB_API virtual ~FunctionData();
+	DUCKDB_API virtual ~FunctionData() = default;
 
 	DUCKDB_API virtual unique_ptr<FunctionData> Copy() const = 0;
 	DUCKDB_API virtual bool Equals(const FunctionData &other) const = 0;


### PR DESCRIPTION
Im not sure exactly why, but somehow the rust linux build broke at the linking step after upgrading to v1.2.0, complaining about missing typeinfo for the ListLambdaBindData. ... I think this is because the destructor/virtual methods are not present in the resulting unity build for planner/expression? 

Either way, moving them to the header seems to resolve it on my private fork. Here the compilation succeeds, although there are some test failures as I had to bump the tag to get the rust build script to work (you can't just give it a branch/commit) https://github.com/Maxxen/duckdb-rs/actions/runs/13346304316/job/37277138519

The annoying thing with the rust client is that it requires checking out a versioned tag of the duckdb source tree, so Im not sure how to get this patch applied over there, but we can figure that out separately. Otherwise it's going to be fixed when we bump to v1.2.1 in a couple weeks. 

Related issue https://github.com/duckdb/duckdb-rs/issues/436