### PR TITLE
Include extension_util.hpp in libduckdb

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -39,6 +39,7 @@ main_header_files = [
     os.path.join(include_dir, 'duckdb', 'common', 'serializer', 'memory_stream.hpp'),
     os.path.join(include_dir, 'duckdb', 'main', 'appender.hpp'),
     os.path.join(include_dir, 'duckdb', 'main', 'client_context.hpp'),
+    os.path.join(include_dir, 'duckdb', 'main', 'extension_util.hpp'),
     os.path.join(include_dir, 'duckdb', 'function', 'function.hpp'),
     os.path.join(include_dir, 'duckdb', 'function', 'table_function.hpp'),
     os.path.join(include_dir, 'duckdb', 'parser', 'parsed_data', 'create_table_function_info.hpp'),


### PR DESCRIPTION
The amalgamation already includes the utils, but right now you need to declare `RegisterFunction` and friends yourself before you can call them.