### PR TITLE
Modify histogram test to more fuzzily check boundaries since the test can be inconsistent on different platforms

### DIFF
--- a/test/sql/aggregate/aggregates/histogram_table_function.test
+++ b/test/sql/aggregate/aggregates/histogram_table_function.test
@@ -64,19 +64,8 @@ x <= 12	13
 statement ok
 INSERT INTO integers VALUES (99999999)
 
-query II
+statement ok
 SELECT * FROM histogram_values(integers, i, technique := 'equi-height')
-----
-12	13
-25	13
-38	13
-50	13
-63	13
-76	13
-88	13
-101	13
-114	13
-99999999	13
 
 # sample integers
 query II

--- a/test/sql/aggregate/aggregates/histogram_table_function.test
+++ b/test/sql/aggregate/aggregates/histogram_table_function.test
@@ -64,8 +64,10 @@ x <= 12	13
 statement ok
 INSERT INTO integers VALUES (99999999)
 
-statement ok
-SELECT * FROM histogram_values(integers, i, technique := 'equi-height')
+query II
+SELECT COUNT(*), AVG(count) FROM histogram_values(integers, i, technique := 'equi-height')
+----
+10	13
 
 # sample integers
 query II


### PR DESCRIPTION
Histogram boundaries do a bunch of floating point arithmetic that is not consistent on all platforms - and we don't really care if the boundaries are exactly equivalent to a certain value.