### PR TITLE
[Python Dev] Add the correct variant of the `-std=c++11` flag based on the compiler (MSVC or not)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1420,6 +1420,15 @@ if(BUILD_PYTHON)
     set(ALL_COMPILE_FLAGS "${CMAKE_CXX_FLAGS}")
   endif()
 
+  # Check for MSVC compiler and set the correct C++ standard flag
+  if(MSVC)
+    # MSVC does not support `-std=c++11` or `-std=c++14`, use `/std:c++14`
+    set(ALL_COMPILE_FLAGS "${ALL_COMPILE_FLAGS} /std:c++14")
+  else()
+    # For non-MSVC compilers, use the `-std=c++11`
+    set(ALL_COMPILE_FLAGS "${ALL_COMPILE_FLAGS} -std=c++11")
+  endif()
+
   get_target_property(duckdb_libs duckdb LINK_LIBRARIES)
 
   set(PIP_COMMAND


### PR DESCRIPTION
This PR addresses https://github.com/duckdb/duckdb/pull/16237

My local builds started failing because `-std=c++11` was missing, this should fix the issue for both flavors of compiler.
Please verify that this doesn't break the MSVC environment @cfis