### PR TITLE
[Python Dev] Fix crash with empty args for `isin` | Fix transformation for `isnotin`

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/expression/pyexpression.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/expression/pyexpression.hpp
@@ -79,6 +79,7 @@ public:
 
 	// IN / NOT IN
 
+	shared_ptr<DuckDBPyExpression> CreateCompareExpression(ExpressionType compare_type, const py::args &args);
 	shared_ptr<DuckDBPyExpression> In(const py::args &args);
 	shared_ptr<DuckDBPyExpression> NotIn(const py::args &args);
 

--- a/tools/pythonpkg/tests/fast/test_expression.py
+++ b/tools/pythonpkg/tests/fast/test_expression.py
@@ -860,6 +860,20 @@ class TestExpression(object):
         assert len(res) == 2
         assert res == [(1, 'a'), (4, 'a')]
 
+    def test_empty_in(self, filter_rel):
+        expr = ColumnExpression("a")
+        with pytest.raises(
+            duckdb.InvalidInputException, match="Incorrect amount of parameters to 'isin', needs at least 1 parameter"
+        ):
+            expr = expr.isin()
+
+        expr = ColumnExpression("a")
+        with pytest.raises(
+            duckdb.InvalidInputException,
+            match="Incorrect amount of parameters to 'isnotin', needs at least 1 parameter",
+        ):
+            expr = expr.isnotin()
+
     def test_filter_in(self, filter_rel):
         # IN expression
         expr = ColumnExpression("a")


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb/issues/16265

While I was at it, I realized that `isnotin` doesn't transform correctly, it should use `ExpressionType::COMPARE_NOT_IN`, not just wrap the `COMPARE_IN` result with an `OPERATOR_NOT`

I wonder if the optimizer catches this and made this change already, or it doesn't because the behavior is not equivalent for the two cases - either way, better to fix it here.