### PR TITLE
Fix #16278: late materialization should not trigger on very large limits, and it should never trigger on limits without offsets when preserve_insertion_order = false

### DIFF
--- a/src/include/duckdb/optimizer/late_materialization.hpp
+++ b/src/include/duckdb/optimizer/late_materialization.hpp
@@ -14,6 +14,7 @@
 namespace duckdb {
 class LogicalOperator;
 class LogicalGet;
+class LogicalLimit;
 class Optimizer;
 
 //! Transform
@@ -34,7 +35,7 @@ private:
 	void ReplaceTableReferences(Expression &expr, idx_t new_table_index);
 	unique_ptr<Expression> GetExpression(LogicalOperator &op, idx_t column_index);
 	void ReplaceExpressionReferences(LogicalOperator &next_op, unique_ptr<Expression> &expr);
-	bool OptimizeLargeLimit(LogicalOperator &child);
+	bool OptimizeLargeLimit(LogicalLimit &limit, idx_t limit_val, bool has_offset);
 
 private:
 	Optimizer &optimizer;

--- a/src/optimizer/late_materialization.cpp
+++ b/src/optimizer/late_materialization.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/main/client_config.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 


### PR DESCRIPTION
Fixes #16278