### PR TITLE
[Python Dev] Add support for fully qualified references in `.table(...)` method

### DIFF
--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -135,6 +135,8 @@ public:
 	//! Returns a relation that produces a table from this connection
 	DUCKDB_API shared_ptr<Relation> Table(const string &tname);
 	DUCKDB_API shared_ptr<Relation> Table(const string &schema_name, const string &table_name);
+	DUCKDB_API shared_ptr<Relation> Table(const string &catalog_name, const string &schema_name,
+	                                      const string &table_name);
 	//! Returns a relation that produces a view from this connection
 	DUCKDB_API shared_ptr<Relation> View(const string &tname);
 	DUCKDB_API shared_ptr<Relation> View(const string &schema_name, const string &table_name);

--- a/src/include/duckdb/main/relation/delete_relation.hpp
+++ b/src/include/duckdb/main/relation/delete_relation.hpp
@@ -16,10 +16,11 @@ namespace duckdb {
 class DeleteRelation : public Relation {
 public:
 	DeleteRelation(shared_ptr<ClientContextWrapper> &context, unique_ptr<ParsedExpression> condition,
-	               string schema_name, string table_name);
+	               string catalog_name, string schema_name, string table_name);
 
 	vector<ColumnDefinition> columns;
 	unique_ptr<ParsedExpression> condition;
+	string catalog_name;
 	string schema_name;
 	string table_name;
 

--- a/src/include/duckdb/main/relation/update_relation.hpp
+++ b/src/include/duckdb/main/relation/update_relation.hpp
@@ -16,11 +16,12 @@ namespace duckdb {
 class UpdateRelation : public Relation {
 public:
 	UpdateRelation(shared_ptr<ClientContextWrapper> &context, unique_ptr<ParsedExpression> condition,
-	               string schema_name, string table_name, vector<string> update_columns,
+	               string catalog_name, string schema_name, string table_name, vector<string> update_columns,
 	               vector<unique_ptr<ParsedExpression>> expressions);
 
 	vector<ColumnDefinition> columns;
 	unique_ptr<ParsedExpression> condition;
+	string catalog_name;
 	string schema_name;
 	string table_name;
 	vector<string> update_columns;

--- a/src/main/relation/delete_relation.cpp
+++ b/src/main/relation/delete_relation.cpp
@@ -7,14 +7,16 @@
 namespace duckdb {
 
 DeleteRelation::DeleteRelation(shared_ptr<ClientContextWrapper> &context, unique_ptr<ParsedExpression> condition_p,
-                               string schema_name_p, string table_name_p)
+                               string catalog_name_p, string schema_name_p, string table_name_p)
     : Relation(context, RelationType::DELETE_RELATION), condition(std::move(condition_p)),
-      schema_name(std::move(schema_name_p)), table_name(std::move(table_name_p)) {
+      catalog_name(std::move(catalog_name_p)), schema_name(std::move(schema_name_p)),
+      table_name(std::move(table_name_p)) {
 	TryBindRelation(columns);
 }
 
 BoundStatement DeleteRelation::Bind(Binder &binder) {
 	auto basetable = make_uniq<BaseTableRef>();
+	basetable->catalog_name = catalog_name;
 	basetable->schema_name = schema_name;
 	basetable->table_name = table_name;
 
@@ -29,7 +31,8 @@ const vector<ColumnDefinition> &DeleteRelation::Columns() {
 }
 
 string DeleteRelation::ToString(idx_t depth) {
-	string str = RenderWhitespace(depth) + "DELETE FROM " + table_name;
+	string str =
+	    RenderWhitespace(depth) + "DELETE FROM " + ParseInfo::QualifierToString(catalog_name, schema_name, table_name);
 	if (condition) {
 		str += " WHERE " + condition->ToString();
 	}

--- a/src/main/relation/table_relation.cpp
+++ b/src/main/relation/table_relation.cpp
@@ -29,6 +29,7 @@ unique_ptr<TableRef> TableRelation::GetTableRef() {
 	auto table_ref = make_uniq<BaseTableRef>();
 	table_ref->schema_name = description->schema;
 	table_ref->table_name = description->table;
+	table_ref->catalog_name = description->database;
 	return std::move(table_ref);
 }
 
@@ -41,7 +42,8 @@ const vector<ColumnDefinition> &TableRelation::Columns() {
 }
 
 string TableRelation::ToString(idx_t depth) {
-	return RenderWhitespace(depth) + "Scan Table [" + description->table + "]";
+	return RenderWhitespace(depth) + "Scan Table [" +
+	       ParseInfo::QualifierToString(description->database, description->schema, description->table) + "]";
 }
 
 static unique_ptr<ParsedExpression> ParseCondition(ClientContext &context, const string &condition) {
@@ -62,8 +64,8 @@ void TableRelation::Update(vector<string> names, vector<unique_ptr<ParsedExpress
 	vector<unique_ptr<ParsedExpression>> expressions = std::move(update);
 
 	auto update_relation =
-	    make_shared_ptr<UpdateRelation>(context, std::move(condition), description->schema, description->table,
-	                                    std::move(update_columns), std::move(expressions));
+	    make_shared_ptr<UpdateRelation>(context, std::move(condition), description->database, description->schema,
+	                                    description->table, std::move(update_columns), std::move(expressions));
 	update_relation->Execute();
 }
 
@@ -72,14 +74,16 @@ void TableRelation::Update(const string &update_list, const string &condition) {
 	vector<unique_ptr<ParsedExpression>> expressions;
 	auto cond = ParseCondition(*context->GetContext(), condition);
 	Parser::ParseUpdateList(update_list, update_columns, expressions, context->GetContext()->GetParserOptions());
-	auto update = make_shared_ptr<UpdateRelation>(context, std::move(cond), description->schema, description->table,
-	                                              std::move(update_columns), std::move(expressions));
+	auto update =
+	    make_shared_ptr<UpdateRelation>(context, std::move(cond), description->database, description->schema,
+	                                    description->table, std::move(update_columns), std::move(expressions));
 	update->Execute();
 }
 
 void TableRelation::Delete(const string &condition) {
 	auto cond = ParseCondition(*context->GetContext(), condition);
-	auto del = make_shared_ptr<DeleteRelation>(context, std::move(cond), description->schema, description->table);
+	auto del = make_shared_ptr<DeleteRelation>(context, std::move(cond), description->database, description->schema,
+	                                           description->table);
 	del->Execute();
 }
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1554,7 +1554,8 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Table(const string &tname) {
 		qualified_name.schema = DEFAULT_SCHEMA;
 	}
 	try {
-		return make_uniq<DuckDBPyRelation>(connection.Table(qualified_name.schema, qualified_name.name));
+		return make_uniq<DuckDBPyRelation>(
+		    connection.Table(qualified_name.catalog, qualified_name.schema, qualified_name.name));
 	} catch (const CatalogException &) {
 		// CatalogException will be of the type '... is not a table'
 		// Not a table in the database, make a query relation that can perform replacement scans


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/4216

Also propagate the added `catalog_name` to the `::Update` and `::Delete` methods of the `TableRelation`