### PR TITLE
[Fix] MinGW bundle static libs

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -60,6 +60,9 @@ inputs:
   build_out_of_tree_extensions:
     description: 'Build out-of-tree extensions'
     default: 1
+  bundle_static_lib_mode:
+    description: 'Build the default bundled extensions to publish the static libs'
+    default: 0
   osx_universal:
     description: 'Build Universal Binary for OSX'
     default: 0
@@ -91,6 +94,7 @@ runs:
     - name: Setup DuckDB extension build config
       shell: bash
       run: |
+        export EXTENSION_CONFIGS="$EXTENSION_CONFIGS;${{ inputs.bundle_static_lib_mode == 1 && '.github/config/bundled_extensions.cmake' || ''}}"
         export EXTENSION_CONFIGS="$EXTENSION_CONFIGS;${{ inputs.build_in_tree_extensions == 1 && '.github/config/in_tree_extensions.cmake' || ''}}"
         export EXTENSION_CONFIGS="$EXTENSION_CONFIGS;${{ inputs.build_out_of_tree_extensions == 1 && '.github/config/out_of_tree_extensions.cmake' || '' }}"
         echo "EXTENSION_CONFIGS=$EXTENSION_CONFIGS" >> $GITHUB_ENV

--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -107,8 +107,8 @@ jobs:
     name: Windows MingW static libs
     runs-on: windows-2019
     env:
-      ENABLE_EXTENSION_AUTOLOADING: ${{ inputs.build_static_lib_mode }}
-      ENABLE_EXTENSION_AUTOINSTALL: ${{ inputs.build_static_lib_mode }}
+      ENABLE_EXTENSION_AUTOLOADING: 1
+      ENABLE_EXTENSION_AUTOINSTALL: 1
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -106,6 +106,9 @@ jobs:
   bundle-mingw-static-lib:
     name: Windows MingW static libs
     runs-on: windows-2019
+    env:
+      ENABLE_EXTENSION_AUTOLOADING: ${{ inputs.build_static_lib_mode }}
+      ENABLE_EXTENSION_AUTOINSTALL: ${{ inputs.build_static_lib_mode }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -130,9 +133,12 @@ jobs:
           override_cc: gcc
           override_cxx: g++
           vcpkg_build: 1
-          no_static_linking: 1
+          no_static_linking: 0
           run_tests: 0
           run_autoload_tests: 0
+          build_in_tree_extensions: 0
+          build_out_of_tree_extensions: 0
+          bundle_static_lib_mode: 1
 
       - name: Bundle static library
         shell: bash


### PR DESCRIPTION
- Enable `autoload` and `autoinstall`
- Statically link and bundle the default extensions