### PR TITLE
Add connection and transaction identifiers

### DIFF
--- a/src/catalog/default/default_views.cpp
+++ b/src/catalog/default/default_views.cpp
@@ -27,7 +27,6 @@ static const DefaultView internal_views[] = {
     {DEFAULT_SCHEMA, "duckdb_types", "SELECT * FROM duckdb_types()"},
     {DEFAULT_SCHEMA, "duckdb_views", "SELECT * FROM duckdb_views() WHERE NOT internal"},
 	{DEFAULT_SCHEMA, "duckdb_logs", "SELECT * exclude (l.context_id, c.context_id) FROM duckdb_logs() as l JOIN duckdb_log_contexts() as c ON l.context_id=c.context_id order by timestamp;"},
-	{DEFAULT_SCHEMA, "duckdb_logs_previous_transaction", "SELECT * FROM duckdb_logs WHERE transaction_id=current_transaction_id()-1 and connection_id=current_connection_id();"},
     {"pg_catalog", "pg_am", "SELECT 0 oid, 'art' amname, NULL amhandler, 'i' amtype"},
     {"pg_catalog", "pg_attribute", "SELECT table_oid attrelid, column_name attname, data_type_id atttypid, 0 attstattarget, NULL attlen, column_index attnum, 0 attndims, -1 attcacheoff, case when data_type ilike '%decimal%' then numeric_precision*1000+numeric_scale else -1 end atttypmod, false attbyval, NULL attstorage, NULL attalign, NOT is_nullable attnotnull, column_default IS NOT NULL atthasdef, false atthasmissing, '' attidentity, '' attgenerated, false attisdropped, true attislocal, 0 attinhcount, 0 attcollation, NULL attcompression, NULL attacl, NULL attoptions, NULL attfdwoptions, NULL attmissingval FROM duckdb_columns()"},
     {"pg_catalog", "pg_attrdef", "SELECT column_index oid, table_oid adrelid, column_index adnum, column_default adbin from duckdb_columns() where column_default is not null;"},

--- a/src/catalog/default/default_views.cpp
+++ b/src/catalog/default/default_views.cpp
@@ -27,6 +27,7 @@ static const DefaultView internal_views[] = {
     {DEFAULT_SCHEMA, "duckdb_types", "SELECT * FROM duckdb_types()"},
     {DEFAULT_SCHEMA, "duckdb_views", "SELECT * FROM duckdb_views() WHERE NOT internal"},
 	{DEFAULT_SCHEMA, "duckdb_logs", "SELECT * exclude (l.context_id, c.context_id) FROM duckdb_logs() as l JOIN duckdb_log_contexts() as c ON l.context_id=c.context_id order by timestamp;"},
+	{DEFAULT_SCHEMA, "duckdb_logs_previous_transaction", "SELECT * FROM duckdb_logs WHERE transaction_id=current_transaction_id()-1 and connection_id=current_connection_id();"},
     {"pg_catalog", "pg_am", "SELECT 0 oid, 'art' amname, NULL amhandler, 'i' amtype"},
     {"pg_catalog", "pg_attribute", "SELECT table_oid attrelid, column_name attname, data_type_id atttypid, 0 attstattarget, NULL attlen, column_index attnum, 0 attndims, -1 attcacheoff, case when data_type ilike '%decimal%' then numeric_precision*1000+numeric_scale else -1 end atttypmod, false attbyval, NULL attstorage, NULL attalign, NOT is_nullable attnotnull, column_default IS NOT NULL atthasdef, false atthasmissing, '' attidentity, '' attgenerated, false attisdropped, true attislocal, 0 attinhcount, 0 attcollation, NULL attcompression, NULL attacl, NULL attoptions, NULL attfdwoptions, NULL attmissingval FROM duckdb_columns()"},
     {"pg_catalog", "pg_attrdef", "SELECT column_index oid, table_oid adrelid, column_index adnum, column_default adbin from duckdb_columns() where column_default is not null;"},

--- a/src/function/function_list.cpp
+++ b/src/function/function_list.cpp
@@ -92,6 +92,7 @@ static const StaticFunctionDefinition function[] = {
 	DUCKDB_AGGREGATE_FUNCTION(CountStarFun),
 	DUCKDB_SCALAR_FUNCTION(CreateSortKeyFun),
 	DUCKDB_SCALAR_FUNCTION(CurrentConnectionId),
+	DUCKDB_SCALAR_FUNCTION(CurrentQueryId),
 	DUCKDB_SCALAR_FUNCTION(CurrentTransactionId),
 	DUCKDB_SCALAR_FUNCTION(CurrvalFun),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(DivideFun),

--- a/src/function/function_list.cpp
+++ b/src/function/function_list.cpp
@@ -91,6 +91,8 @@ static const StaticFunctionDefinition function[] = {
 	DUCKDB_AGGREGATE_FUNCTION_SET(CountFun),
 	DUCKDB_AGGREGATE_FUNCTION(CountStarFun),
 	DUCKDB_SCALAR_FUNCTION(CreateSortKeyFun),
+	DUCKDB_SCALAR_FUNCTION(CurrentConnectionId),
+	DUCKDB_SCALAR_FUNCTION(CurrentTransactionId),
 	DUCKDB_SCALAR_FUNCTION(CurrvalFun),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(DivideFun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(EndsWithFun),

--- a/src/function/pragma/pragma_functions.cpp
+++ b/src/function/pragma/pragma_functions.cpp
@@ -112,6 +112,14 @@ static void PragmaDisableCheckpointOnShutdown(ClientContext &context, const Func
 	DBConfig::GetConfig(context).options.checkpoint_on_shutdown = false;
 }
 
+static void PragmaEnableLogging(ClientContext &context, const FunctionParameters &parameters) {
+	context.db->GetLogManager().SetEnableLogging(true);
+}
+
+static void PragmaDisableLogging(ClientContext &context, const FunctionParameters &parameters) {
+	context.db->GetLogManager().SetEnableLogging(false);
+}
+
 static void PragmaEnableOptimizer(ClientContext &context, const FunctionParameters &parameters) {
 	ClientConfig::GetConfig(context).enable_optimizer = true;
 }
@@ -143,6 +151,9 @@ void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
 
 	set.AddFunction(PragmaFunction::PragmaStatement("enable_object_cache", PragmaEnableObjectCache));
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_object_cache", PragmaDisableObjectCache));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_logging", PragmaEnableLogging));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_logging", PragmaDisableLogging));
 
 	set.AddFunction(PragmaFunction::PragmaStatement("enable_optimizer", PragmaEnableOptimizer));
 	set.AddFunction(PragmaFunction::PragmaStatement("disable_optimizer", PragmaDisableOptimizer));

--- a/src/function/scalar/system/CMakeLists.txt
+++ b/src/function/scalar/system/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library_unity(duckdb_func_system OBJECT aggregate_export.cpp write_log.cpp)
+add_library_unity(duckdb_func_system OBJECT aggregate_export.cpp write_log.cpp
+                  current_transaction_id.cpp current_connection_id.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_system>
     PARENT_SCOPE)

--- a/src/function/scalar/system/CMakeLists.txt
+++ b/src/function/scalar/system/CMakeLists.txt
@@ -1,5 +1,11 @@
-add_library_unity(duckdb_func_system OBJECT aggregate_export.cpp write_log.cpp
-                  current_transaction_id.cpp current_connection_id.cpp)
+add_library_unity(
+  duckdb_func_system
+  OBJECT
+  aggregate_export.cpp
+  write_log.cpp
+  current_transaction_id.cpp
+  current_connection_id.cpp
+  current_query_id.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_func_system>
     PARENT_SCOPE)

--- a/src/function/scalar/system/current_connection_id.cpp
+++ b/src/function/scalar/system/current_connection_id.cpp
@@ -8,12 +8,12 @@
 namespace duckdb {
 
 struct CurrentConnectionIdData : FunctionData {
-	explicit CurrentConnectionIdData(Value connection_id_p) : connection_id(connection_id_p) {
+	explicit CurrentConnectionIdData(Value connection_id_p) : connection_id(std::move(connection_id_p)) {
 	}
 	Value connection_id;
 
 	unique_ptr<FunctionData> Copy() const override {
-		return make_uniq<CurrentConnectionIdData>(this->connection_id);
+		return make_uniq<CurrentConnectionIdData>(connection_id);
 	}
 	bool Equals(const FunctionData &other_p) const override {
 		return connection_id == other_p.Cast<CurrentConnectionIdData>().connection_id;

--- a/src/function/scalar/system/current_connection_id.cpp
+++ b/src/function/scalar/system/current_connection_id.cpp
@@ -1,0 +1,39 @@
+#include "duckdb/function/scalar/system_functions.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/main/client_data.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+#include "utf8proc.hpp"
+
+namespace duckdb {
+
+struct CurrentConnectionIdData : FunctionData {
+	explicit CurrentConnectionIdData(Value transaction_id_p) : transaction_id(transaction_id_p) {
+	}
+	Value transaction_id;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<CurrentConnectionIdData>(this->transaction_id);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return transaction_id == other_p.Cast<CurrentConnectionIdData>().transaction_id;
+	}
+};
+
+unique_ptr<FunctionData> CurrentConnectionIdBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	return make_uniq<CurrentConnectionIdData>(Value::UBIGINT(context.GetConnectionId()));
+}
+
+static void CurrentConnectionIdFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	const auto &info = func_expr.bind_info->Cast<CurrentConnectionIdData>();
+	result.Reference(info.transaction_id);
+}
+
+ScalarFunction CurrentConnectionId::GetFunction() {
+	return ScalarFunction({}, LogicalType::UBIGINT, CurrentConnectionIdFunction, CurrentConnectionIdBind, nullptr,
+	                      nullptr, nullptr, LogicalType::ANY, FunctionStability::VOLATILE);
+}
+
+} // namespace duckdb

--- a/src/function/scalar/system/current_connection_id.cpp
+++ b/src/function/scalar/system/current_connection_id.cpp
@@ -8,15 +8,15 @@
 namespace duckdb {
 
 struct CurrentConnectionIdData : FunctionData {
-	explicit CurrentConnectionIdData(Value transaction_id_p) : transaction_id(transaction_id_p) {
+	explicit CurrentConnectionIdData(Value connection_id_p) : connection_id(connection_id_p) {
 	}
-	Value transaction_id;
+	Value connection_id;
 
 	unique_ptr<FunctionData> Copy() const override {
-		return make_uniq<CurrentConnectionIdData>(this->transaction_id);
+		return make_uniq<CurrentConnectionIdData>(this->connection_id);
 	}
 	bool Equals(const FunctionData &other_p) const override {
-		return transaction_id == other_p.Cast<CurrentConnectionIdData>().transaction_id;
+		return connection_id == other_p.Cast<CurrentConnectionIdData>().connection_id;
 	}
 };
 
@@ -28,12 +28,12 @@ unique_ptr<FunctionData> CurrentConnectionIdBind(ClientContext &context, ScalarF
 static void CurrentConnectionIdFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 	const auto &info = func_expr.bind_info->Cast<CurrentConnectionIdData>();
-	result.Reference(info.transaction_id);
+	result.Reference(info.connection_id);
 }
 
 ScalarFunction CurrentConnectionId::GetFunction() {
 	return ScalarFunction({}, LogicalType::UBIGINT, CurrentConnectionIdFunction, CurrentConnectionIdBind, nullptr,
-	                      nullptr, nullptr, LogicalType::ANY, FunctionStability::VOLATILE);
+	                      nullptr, nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/system/current_query_id.cpp
+++ b/src/function/scalar/system/current_query_id.cpp
@@ -1,0 +1,45 @@
+#include "duckdb/function/scalar/system_functions.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/main/client_data.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+#include "utf8proc.hpp"
+
+namespace duckdb {
+
+struct CurrentQueryIdData : FunctionData {
+	explicit CurrentQueryIdData(Value query_id_p) : query_id(query_id_p) {
+	}
+	Value query_id;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<CurrentQueryIdData>(this->query_id);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return query_id == other_p.Cast<CurrentQueryIdData>().query_id;
+	}
+};
+
+unique_ptr<FunctionData> CurrentQueryIdBind(ClientContext &context, ScalarFunction &bound_function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+	Value query_id;
+	if (context.transaction.HasActiveTransaction()) {
+		query_id = Value::UBIGINT(context.transaction.GetActiveQuery());
+	} else {
+		query_id = Value();
+	}
+	return make_uniq<CurrentQueryIdData>(query_id);
+}
+
+static void CurrentQueryIdFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	const auto &info = func_expr.bind_info->Cast<CurrentQueryIdData>();
+	result.Reference(info.query_id);
+}
+
+ScalarFunction CurrentQueryId::GetFunction() {
+	return ScalarFunction({}, LogicalType::UBIGINT, CurrentQueryIdFunction, CurrentQueryIdBind, nullptr, nullptr,
+	                      nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+}
+
+} // namespace duckdb

--- a/src/function/scalar/system/current_query_id.cpp
+++ b/src/function/scalar/system/current_query_id.cpp
@@ -8,12 +8,12 @@
 namespace duckdb {
 
 struct CurrentQueryIdData : FunctionData {
-	explicit CurrentQueryIdData(Value query_id_p) : query_id(query_id_p) {
+	explicit CurrentQueryIdData(Value query_id_p) : query_id(std::move(query_id_p)) {
 	}
 	Value query_id;
 
 	unique_ptr<FunctionData> Copy() const override {
-		return make_uniq<CurrentQueryIdData>(this->query_id);
+		return make_uniq<CurrentQueryIdData>(query_id);
 	}
 	bool Equals(const FunctionData &other_p) const override {
 		return query_id == other_p.Cast<CurrentQueryIdData>().query_id;

--- a/src/function/scalar/system/current_transaction_id.cpp
+++ b/src/function/scalar/system/current_transaction_id.cpp
@@ -24,7 +24,7 @@ unique_ptr<FunctionData> CurrentTransactionIdBind(ClientContext &context, Scalar
                                                   vector<unique_ptr<Expression>> &arguments) {
 	Value transaction_id;
 	if (context.transaction.HasActiveTransaction()) {
-		transaction_id = Value::UBIGINT(context.transaction.ActiveTransaction().transaction_id);
+		transaction_id = Value::UBIGINT(context.transaction.ActiveTransaction().global_transaction_id);
 	} else {
 		transaction_id = Value();
 	}

--- a/src/function/scalar/system/current_transaction_id.cpp
+++ b/src/function/scalar/system/current_transaction_id.cpp
@@ -39,7 +39,7 @@ static void CurrentTransactionIdFunction(DataChunk &args, ExpressionState &state
 
 ScalarFunction CurrentTransactionId::GetFunction() {
 	return ScalarFunction({}, LogicalType::UBIGINT, CurrentTransactionIdFunction, CurrentTransactionIdBind, nullptr,
-	                      nullptr, nullptr, LogicalType::ANY, FunctionStability::VOLATILE);
+	                      nullptr, nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
 }
 
 } // namespace duckdb

--- a/src/function/scalar/system/current_transaction_id.cpp
+++ b/src/function/scalar/system/current_transaction_id.cpp
@@ -1,0 +1,45 @@
+#include "duckdb/function/scalar/system_functions.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/main/client_data.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+#include "utf8proc.hpp"
+
+namespace duckdb {
+
+struct CurrentTransactionIdData : FunctionData {
+	explicit CurrentTransactionIdData(Value transaction_id_p) : transaction_id(transaction_id_p) {
+	}
+	Value transaction_id;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<CurrentTransactionIdData>(this->transaction_id);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return transaction_id == other_p.Cast<CurrentTransactionIdData>().transaction_id;
+	}
+};
+
+unique_ptr<FunctionData> CurrentTransactionIdBind(ClientContext &context, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments) {
+	Value transaction_id;
+	if (context.transaction.HasActiveTransaction()) {
+		transaction_id = Value::UBIGINT(context.transaction.ActiveTransaction().transaction_id);
+	} else {
+		transaction_id = Value();
+	}
+	return make_uniq<CurrentTransactionIdData>(transaction_id);
+}
+
+static void CurrentTransactionIdFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	const auto &info = func_expr.bind_info->Cast<CurrentTransactionIdData>();
+	result.Reference(info.transaction_id);
+}
+
+ScalarFunction CurrentTransactionId::GetFunction() {
+	return ScalarFunction({}, LogicalType::UBIGINT, CurrentTransactionIdFunction, CurrentTransactionIdBind, nullptr,
+	                      nullptr, nullptr, LogicalType::ANY, FunctionStability::VOLATILE);
+}
+
+} // namespace duckdb

--- a/src/function/scalar/system/current_transaction_id.cpp
+++ b/src/function/scalar/system/current_transaction_id.cpp
@@ -2,18 +2,19 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/common/types/value.hpp"
 
 #include "utf8proc.hpp"
 
 namespace duckdb {
 
 struct CurrentTransactionIdData : FunctionData {
-	explicit CurrentTransactionIdData(Value transaction_id_p) : transaction_id(transaction_id_p) {
+	explicit CurrentTransactionIdData(Value transaction_id_p) : transaction_id(std::move(transaction_id_p)) {
 	}
 	Value transaction_id;
 
 	unique_ptr<FunctionData> Copy() const override {
-		return make_uniq<CurrentTransactionIdData>(this->transaction_id);
+		return make_uniq<CurrentTransactionIdData>(transaction_id);
 	}
 	bool Equals(const FunctionData &other_p) const override {
 		return transaction_id == other_p.Cast<CurrentTransactionIdData>().transaction_id;

--- a/src/function/scalar/system/functions.json
+++ b/src/function/scalar/system/functions.json
@@ -20,5 +20,19 @@
         "example": "write_log('Hello')",
         "type": "scalar_function_set",
         "struct": "WriteLogFun"
+    },
+    {
+        "name": "current_connection_id",
+        "description": "Get the current connection_id",
+        "example": "current_connection_id()",
+        "type": "scalar_function",
+        "struct": "CurrentConnectionId"
+    },
+    {
+        "name": "current_transaction_id",
+        "description": "Get the current (connection-local) transaction_id",
+        "example": "current_transaction_id('Hello')",
+        "type": "scalar_function",
+        "struct": "CurrentTransactionId"
     }
 ]

--- a/src/function/scalar/system/functions.json
+++ b/src/function/scalar/system/functions.json
@@ -30,9 +30,16 @@
     },
     {
         "name": "current_transaction_id",
-        "description": "Get the current (connection-local) transaction_id",
-        "example": "current_transaction_id('Hello')",
+        "description": "Get the current global transaction_id",
+        "example": "current_transaction_id()",
         "type": "scalar_function",
         "struct": "CurrentTransactionId"
+    },
+    {
+        "name": "current_query_id",
+        "description": "Get the current query_id",
+        "example": "current_transaction_id('Hello')",
+        "type": "scalar_function",
+        "struct": "CurrentQueryId"
     }
 ]

--- a/src/function/table/system/duckdb_log_contexts.cpp
+++ b/src/function/table/system/duckdb_log_contexts.cpp
@@ -37,6 +37,9 @@ static unique_ptr<FunctionData> DuckDBLogContextBind(ClientContext &context, Tab
 	names.emplace_back("transaction_id");
 	return_types.emplace_back(LogicalType::UBIGINT);
 
+	names.emplace_back("query_id");
+	return_types.emplace_back(LogicalType::UBIGINT);
+
 	names.emplace_back("thread");
 	return_types.emplace_back(LogicalType::UBIGINT);
 

--- a/src/function/table/system/duckdb_log_contexts.cpp
+++ b/src/function/table/system/duckdb_log_contexts.cpp
@@ -40,7 +40,7 @@ static unique_ptr<FunctionData> DuckDBLogContextBind(ClientContext &context, Tab
 	names.emplace_back("query_id");
 	return_types.emplace_back(LogicalType::UBIGINT);
 
-	names.emplace_back("thread");
+	names.emplace_back("thread_id");
 	return_types.emplace_back(LogicalType::UBIGINT);
 
 	return nullptr;

--- a/src/function/table/system/duckdb_log_contexts.cpp
+++ b/src/function/table/system/duckdb_log_contexts.cpp
@@ -31,7 +31,7 @@ static unique_ptr<FunctionData> DuckDBLogContextBind(ClientContext &context, Tab
 	names.emplace_back("scope");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
-	names.emplace_back("client_context");
+	names.emplace_back("connection_id");
 	return_types.emplace_back(LogicalType::UBIGINT);
 
 	names.emplace_back("transaction_id");

--- a/src/include/duckdb/common/typedefs.hpp
+++ b/src/include/duckdb/common/typedefs.hpp
@@ -31,6 +31,9 @@ typedef uint32_t sel_t;
 //! Type used for transaction timestamps
 typedef idx_t transaction_t;
 
+//! Type used to identify connections
+typedef idx_t connection_t;
+
 //! Type used for column identifiers
 typedef idx_t column_t;
 //! Type used for storage (column) identifiers

--- a/src/include/duckdb/function/scalar/system_functions.hpp
+++ b/src/include/duckdb/function/scalar/system_functions.hpp
@@ -54,7 +54,16 @@ struct CurrentConnectionId {
 struct CurrentTransactionId {
 	static constexpr const char *Name = "current_transaction_id";
 	static constexpr const char *Parameters = "";
-	static constexpr const char *Description = "Get the current (connection-local) transaction_id";
+	static constexpr const char *Description = "Get the current global transaction_id";
+	static constexpr const char *Example = "current_transaction_id()";
+
+	static ScalarFunction GetFunction();
+};
+
+struct CurrentQueryId {
+	static constexpr const char *Name = "current_query_id";
+	static constexpr const char *Parameters = "";
+	static constexpr const char *Description = "Get the current query_id";
 	static constexpr const char *Example = "current_transaction_id('Hello')";
 
 	static ScalarFunction GetFunction();

--- a/src/include/duckdb/function/scalar/system_functions.hpp
+++ b/src/include/duckdb/function/scalar/system_functions.hpp
@@ -42,4 +42,22 @@ struct WriteLogFun {
 	static ScalarFunctionSet GetFunctions();
 };
 
+struct CurrentConnectionId {
+	static constexpr const char *Name = "current_connection_id";
+	static constexpr const char *Parameters = "";
+	static constexpr const char *Description = "Get the current connection_id";
+	static constexpr const char *Example = "current_connection_id()";
+
+	static ScalarFunction GetFunction();
+};
+
+struct CurrentTransactionId {
+	static constexpr const char *Name = "current_transaction_id";
+	static constexpr const char *Parameters = "";
+	static constexpr const char *Description = "Get the current (connection-local) transaction_id";
+	static constexpr const char *Example = "current_transaction_id('Hello')";
+
+	static ScalarFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/src/include/duckdb/logging/logging.hpp
+++ b/src/include/duckdb/logging/logging.hpp
@@ -68,7 +68,7 @@ struct LoggingContext {
 
 	LogContextScope scope;
 
-	optional_idx thread;
+	optional_idx thread_id;
 	optional_idx connection_id;
 	optional_idx transaction_id;
 	optional_idx query_id;

--- a/src/include/duckdb/logging/logging.hpp
+++ b/src/include/duckdb/logging/logging.hpp
@@ -69,7 +69,7 @@ struct LoggingContext {
 	LogContextScope scope;
 
 	optional_idx thread;
-	optional_idx client_context;
+	optional_idx connection_id;
 	optional_idx transaction_id;
 };
 

--- a/src/include/duckdb/logging/logging.hpp
+++ b/src/include/duckdb/logging/logging.hpp
@@ -71,6 +71,7 @@ struct LoggingContext {
 	optional_idx thread;
 	optional_idx connection_id;
 	optional_idx transaction_id;
+	optional_idx query_id;
 };
 
 struct RegisteredLoggingContext {

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -207,6 +207,8 @@ public:
 	//! Returns the current query string (if any)
 	const string &GetCurrentQuery();
 
+	connection_t GetConnectionId() const;
+
 	//! Fetch a list of table names that are required for a given query
 	DUCKDB_API unordered_set<string> GetTableNames(const string &query);
 
@@ -305,6 +307,8 @@ private:
 	unique_ptr<ActiveQueryContext> active_query;
 	//! The current query progress
 	QueryProgress query_progress;
+	//! The connection corresponding to this client context
+	connection_t connection_id;
 };
 
 class ClientContextLock {

--- a/src/include/duckdb/main/connection.hpp
+++ b/src/include/duckdb/main/connection.hpp
@@ -244,6 +244,10 @@ public:
 	}
 	// NOLINTEND
 
+protected:
+	//! Identified used to uniquely identify connections to the database.
+	connection_t connection_id;
+
 private:
 	unique_ptr<QueryResult> QueryParamsRecursive(const string &query, vector<Value> &values);
 

--- a/src/include/duckdb/main/connection_manager.hpp
+++ b/src/include/duckdb/main/connection_manager.hpp
@@ -16,6 +16,7 @@
 namespace duckdb {
 class ClientContext;
 class DatabaseInstance;
+class Connection;
 
 class ConnectionManager {
 public:
@@ -30,6 +31,8 @@ public:
 	}
 	idx_t GetConnectionCount() const;
 
+	void AssignConnectionId(Connection &connection);
+
 	static ConnectionManager &Get(DatabaseInstance &db);
 	static ConnectionManager &Get(ClientContext &context);
 
@@ -37,6 +40,8 @@ private:
 	mutex connections_lock;
 	reference_map_t<ClientContext, weak_ptr<ClientContext>> connections;
 	atomic<idx_t> connection_count;
+
+	atomic<connection_t> current_connection_id;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/database_manager.hpp
+++ b/src/include/duckdb/main/database_manager.hpp
@@ -78,6 +78,12 @@ public:
 	transaction_t ActiveQueryNumber() const {
 		return current_query_number;
 	}
+	transaction_t GetNewTransactionNumber() {
+		return current_transaction_id++;
+	}
+	transaction_t ActiveTransactionNumber() const {
+		return current_transaction_id;
+	}
 	idx_t NextOid() {
 		return next_oid++;
 	}
@@ -101,6 +107,8 @@ private:
 	atomic<idx_t> next_oid;
 	//! The current query number
 	atomic<transaction_t> current_query_number;
+	//! The current transaction number
+	atomic<transaction_t> current_transaction_id;
 	//! The current default database
 	string default_database;
 

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -25,11 +25,13 @@ class Transaction;
 //! The MetaTransaction manages multiple transactions for different attached databases
 class MetaTransaction {
 public:
-	DUCKDB_API MetaTransaction(ClientContext &context, timestamp_t start_timestamp);
+	DUCKDB_API MetaTransaction(ClientContext &context, timestamp_t start_timestamp, transaction_t transaction_id);
 
 	ClientContext &context;
 	//! The timestamp when the transaction started
 	timestamp_t start_timestamp;
+	//! The (connection-local) identifier of the transaction
+	transaction_t transaction_id;
 	//! The validity checker of the transaction
 	ValidChecker transaction_validity;
 	//! The active query number

--- a/src/include/duckdb/transaction/meta_transaction.hpp
+++ b/src/include/duckdb/transaction/meta_transaction.hpp
@@ -25,13 +25,14 @@ class Transaction;
 //! The MetaTransaction manages multiple transactions for different attached databases
 class MetaTransaction {
 public:
-	DUCKDB_API MetaTransaction(ClientContext &context, timestamp_t start_timestamp, transaction_t transaction_id);
+	DUCKDB_API MetaTransaction(ClientContext &context, timestamp_t start_timestamp,
+	                           transaction_t global_transaction_id);
 
 	ClientContext &context;
 	//! The timestamp when the transaction started
 	timestamp_t start_timestamp;
-	//! The (connection-local) identifier of the transaction
-	transaction_t transaction_id;
+	//! The global identifier of the transaction
+	transaction_t global_transaction_id;
 	//! The validity checker of the transaction
 	ValidChecker transaction_validity;
 	//! The active query number

--- a/src/include/duckdb/transaction/transaction_context.hpp
+++ b/src/include/duckdb/transaction/transaction_context.hpp
@@ -62,6 +62,8 @@ private:
 	unique_ptr<MetaTransaction> current_transaction;
 
 	TransactionContext(const TransactionContext &) = delete;
+
+	transaction_t current_transaction_id;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/transaction_context.hpp
+++ b/src/include/duckdb/transaction/transaction_context.hpp
@@ -62,8 +62,6 @@ private:
 	unique_ptr<MetaTransaction> current_transaction;
 
 	TransactionContext(const TransactionContext &) = delete;
-
-	transaction_t current_transaction_id;
 };
 
 } // namespace duckdb

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -39,7 +39,7 @@ void StdOutLogStorage::WriteLogEntry(timestamp_t timestamp, LogLevel level, cons
 	    EnumUtil::ToString(level), log_message, EnumUtil::ToString(context.context.scope),
 	    context.context.connection_id.IsValid() ? to_string(context.context.connection_id.GetIndex()) : "NULL",
 	    context.context.transaction_id.IsValid() ? to_string(context.context.transaction_id.GetIndex()) : "NULL",
-	    context.context.thread.IsValid() ? to_string(context.context.thread.GetIndex()) : "NULL");
+	    context.context.thread_id.IsValid() ? to_string(context.context.thread_id.GetIndex()) : "NULL");
 }
 
 void StdOutLogStorage::WriteLogEntries(DataChunk &chunk, const RegisteredLoggingContext &context) {
@@ -166,9 +166,9 @@ void InMemoryLogStorage::WriteLoggingContext(const RegisteredLoggingContext &con
 		FlatVector::Validity(log_context_buffer->data[4]).SetInvalid(size);
 	}
 
-	if (context.context.thread.IsValid()) {
+	if (context.context.thread_id.IsValid()) {
 		auto thread_data = FlatVector::GetData<idx_t>(log_context_buffer->data[5]);
-		thread_data[size] = context.context.thread.GetIndex();
+		thread_data[size] = context.context.thread_id.GetIndex();
 	} else {
 		FlatVector::Validity(log_context_buffer->data[5]).SetInvalid(size);
 	}

--- a/src/logging/log_storage.cpp
+++ b/src/logging/log_storage.cpp
@@ -37,7 +37,7 @@ void StdOutLogStorage::WriteLogEntry(timestamp_t timestamp, LogLevel level, cons
 	std::cout << StringUtil::Format(
 	    "[LOG] %s, %s, %s, %s, %s, %s, %s, %s\n", Value::TIMESTAMP(timestamp).ToString(), log_type,
 	    EnumUtil::ToString(level), log_message, EnumUtil::ToString(context.context.scope),
-	    context.context.client_context.IsValid() ? to_string(context.context.client_context.GetIndex()) : "NULL",
+	    context.context.connection_id.IsValid() ? to_string(context.context.connection_id.GetIndex()) : "NULL",
 	    context.context.transaction_id.IsValid() ? to_string(context.context.transaction_id.GetIndex()) : "NULL",
 	    context.context.thread.IsValid() ? to_string(context.context.thread.GetIndex()) : "NULL");
 }
@@ -70,7 +70,7 @@ InMemoryLogStorage::InMemoryLogStorage(DatabaseInstance &db_p)
 	vector<LogicalType> log_context_schema = {
 	    LogicalType::UBIGINT, // context_id
 	    LogicalType::VARCHAR, // scope TODO: enumify
-	    LogicalType::UBIGINT, // client_context
+	    LogicalType::UBIGINT, // connection_id
 	    LogicalType::UBIGINT, // transaction_id
 	    LogicalType::UBIGINT, // thread
 	};
@@ -146,9 +146,9 @@ void InMemoryLogStorage::WriteLoggingContext(const RegisteredLoggingContext &con
 	context_scope_data[size] =
 	    StringVector::AddString(log_context_buffer->data[1], EnumUtil::ToString(context.context.scope));
 
-	if (context.context.client_context.IsValid()) {
+	if (context.context.connection_id.IsValid()) {
 		auto client_context_data = FlatVector::GetData<idx_t>(log_context_buffer->data[2]);
-		client_context_data[size] = context.context.client_context.GetIndex();
+		client_context_data[size] = context.context.connection_id.GetIndex();
 	} else {
 		FlatVector::Validity(log_context_buffer->data[2]).SetInvalid(size);
 	}

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -215,7 +215,8 @@ void ClientContext::BeginQueryInternal(ClientContextLock &lock, const string &qu
 	// Refresh the logger to ensure we are in sync with global log settings
 	LoggingContext context(LogContextScope::CONNECTION);
 	context.connection_id = connection_id;
-	context.transaction_id = transaction.ActiveTransaction().transaction_id;
+	context.transaction_id = transaction.ActiveTransaction().global_transaction_id;
+	context.query_id = transaction.GetActiveQuery();
 	logger = db->GetLogManager().CreateLogger(context, true);
 	DUCKDB_LOG_INFO(*this, "duckdb.ClientContext.BeginQuery", query);
 }

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -138,13 +138,12 @@ struct DebugClientContextState : public ClientContextState {
 #endif
 
 ClientContext::ClientContext(shared_ptr<DatabaseInstance> database)
-    : db(std::move(database)), interrupted(false), transaction(*this) {
+    : db(std::move(database)), interrupted(false), transaction(*this), connection_id(DConstants::INVALID_INDEX) {
 	registered_state = make_uniq<RegisteredStateManager>();
 #ifdef DEBUG
 	registered_state->GetOrCreate<DebugClientContextState>("debug_client_context_state");
 #endif
 	LoggingContext context(LogContextScope::CONNECTION);
-	context.client_context = reinterpret_cast<idx_t>(this);
 	logger = db->GetLogManager().CreateLogger(context, true);
 	client_data = make_uniq<ClientData>(*this);
 }
@@ -215,8 +214,8 @@ void ClientContext::BeginQueryInternal(ClientContextLock &lock, const string &qu
 
 	// Refresh the logger to ensure we are in sync with global log settings
 	LoggingContext context(LogContextScope::CONNECTION);
-	context.client_context = reinterpret_cast<idx_t>(this);
-	context.transaction_id = transaction.GetActiveQuery();
+	context.connection_id = connection_id;
+	context.transaction_id = transaction.ActiveTransaction().transaction_id;
 	logger = db->GetLogManager().CreateLogger(context, true);
 	DUCKDB_LOG_INFO(*this, "duckdb.ClientContext.BeginQuery", query);
 }
@@ -260,7 +259,7 @@ ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success,
 	// Refresh the logger
 	logger->Flush();
 	LoggingContext context(LogContextScope::CONNECTION);
-	context.client_context = reinterpret_cast<idx_t>(this);
+	context.connection_id = reinterpret_cast<idx_t>(this);
 	logger = db->GetLogManager().CreateLogger(context, true);
 
 	// Notify any registered state of query end
@@ -314,6 +313,10 @@ Logger &ClientContext::GetLogger() const {
 const string &ClientContext::GetCurrentQuery() {
 	D_ASSERT(active_query);
 	return active_query->query;
+}
+
+connection_t ClientContext::GetConnectionId() const {
+	return connection_id;
 }
 
 unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lock, PendingQueryResult &pending) {

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -20,7 +20,10 @@ namespace duckdb {
 
 Connection::Connection(DatabaseInstance &database)
     : context(make_shared_ptr<ClientContext>(database.shared_from_this())), warning_cb(nullptr) {
-	ConnectionManager::Get(database).AddConnection(*context);
+	auto &connection_manager = ConnectionManager::Get(database);
+	connection_manager.AddConnection(*context);
+	connection_manager.AssignConnectionId(*this);
+
 #ifdef DEBUG
 	EnableProfiling();
 	context->config.emit_profiler_output = false;
@@ -34,11 +37,13 @@ Connection::Connection(DuckDB &database) : Connection(*database.instance) {
 Connection::Connection(Connection &&other) noexcept : warning_cb(nullptr) {
 	std::swap(context, other.context);
 	std::swap(warning_cb, other.warning_cb);
+	std::swap(connection_id, other.connection_id);
 }
 
 Connection &Connection::operator=(Connection &&other) noexcept {
 	std::swap(context, other.context);
 	std::swap(warning_cb, other.warning_cb);
+	std::swap(connection_id, other.connection_id);
 	return *this;
 }
 

--- a/src/main/connection_manager.cpp
+++ b/src/main/connection_manager.cpp
@@ -5,7 +5,7 @@
 
 namespace duckdb {
 
-ConnectionManager::ConnectionManager() : connection_count(0) {
+ConnectionManager::ConnectionManager() : connection_count(0), current_connection_id(0) {
 }
 
 void ConnectionManager::AddConnection(ClientContext &context) {
@@ -28,6 +28,10 @@ void ConnectionManager::RemoveConnection(ClientContext &context) {
 
 idx_t ConnectionManager::GetConnectionCount() const {
 	return connection_count;
+}
+
+void ConnectionManager::AssignConnectionId(Connection &connection) {
+	connection.context->connection_id = current_connection_id.fetch_add(1, std::memory_order_relaxed) + 1;
 }
 
 vector<shared_ptr<ClientContext>> ConnectionManager::GetConnectionList() {

--- a/src/main/connection_manager.cpp
+++ b/src/main/connection_manager.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/main/connection_manager.hpp"
 #include "duckdb/common/exception/transaction_exception.hpp"
+#include "duckdb/main/connection.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/planner/extension_callback.hpp"
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -12,7 +12,7 @@
 namespace duckdb {
 
 DatabaseManager::DatabaseManager(DatabaseInstance &db)
-    : next_oid(0), current_query_number(1), current_transaction_id(1) {
+    : next_oid(0), current_query_number(1), current_transaction_id(0) {
 	system = make_uniq<AttachedDatabase>(db);
 	databases = make_uniq<CatalogSet>(system->GetCatalog());
 }

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -12,7 +12,7 @@
 namespace duckdb {
 
 DatabaseManager::DatabaseManager(DatabaseInstance &db)
-    : next_oid(0), current_query_number(1), current_transaction_id(0) {
+    : next_oid(0), current_query_number(1), current_transaction_id(1) {
 	system = make_uniq<AttachedDatabase>(db);
 	databases = make_uniq<CatalogSet>(system->GetCatalog());
 }

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -11,7 +11,8 @@
 
 namespace duckdb {
 
-DatabaseManager::DatabaseManager(DatabaseInstance &db) : next_oid(0), current_query_number(1) {
+DatabaseManager::DatabaseManager(DatabaseInstance &db)
+    : next_oid(0), current_query_number(1), current_transaction_id(0) {
 	system = make_uniq<AttachedDatabase>(db);
 	databases = make_uniq<CatalogSet>(system->GetCatalog());
 }

--- a/src/parallel/thread_context.cpp
+++ b/src/parallel/thread_context.cpp
@@ -7,7 +7,13 @@ namespace duckdb {
 
 ThreadContext::ThreadContext(ClientContext &context) : profiler(context) {
 	LoggingContext log_context(LogContextScope::THREAD);
-	log_context.connection_id = reinterpret_cast<idx_t>(&context);
+
+	log_context.connection_id = context.GetConnectionId();
+	if (context.transaction.HasActiveTransaction()) {
+		log_context.transaction_id = context.transaction.ActiveTransaction().global_transaction_id;
+		log_context.query_id = context.transaction.GetActiveQuery();
+	}
+
 	log_context.thread = TaskScheduler::GetEstimatedCPUId();
 	if (context.transaction.HasActiveTransaction()) {
 		log_context.transaction_id = context.transaction.GetActiveQuery();

--- a/src/parallel/thread_context.cpp
+++ b/src/parallel/thread_context.cpp
@@ -14,7 +14,7 @@ ThreadContext::ThreadContext(ClientContext &context) : profiler(context) {
 		log_context.query_id = context.transaction.GetActiveQuery();
 	}
 
-	log_context.thread = TaskScheduler::GetEstimatedCPUId();
+	log_context.thread_id = TaskScheduler::GetEstimatedCPUId();
 	if (context.transaction.HasActiveTransaction()) {
 		log_context.transaction_id = context.transaction.GetActiveQuery();
 	}

--- a/src/parallel/thread_context.cpp
+++ b/src/parallel/thread_context.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 
 ThreadContext::ThreadContext(ClientContext &context) : profiler(context) {
 	LoggingContext log_context(LogContextScope::THREAD);
-	log_context.client_context = reinterpret_cast<idx_t>(&context);
+	log_context.connection_id = reinterpret_cast<idx_t>(&context);
 	log_context.thread = TaskScheduler::GetEstimatedCPUId();
 	if (context.transaction.HasActiveTransaction()) {
 		log_context.transaction_id = context.transaction.GetActiveQuery();

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -7,9 +7,10 @@
 
 namespace duckdb {
 
-MetaTransaction::MetaTransaction(ClientContext &context_p, timestamp_t start_timestamp_p)
-    : context(context_p), start_timestamp(start_timestamp_p), active_query(MAXIMUM_QUERY_ID),
-      modified_database(nullptr), is_read_only(false) {
+MetaTransaction::MetaTransaction(ClientContext &context_p, timestamp_t start_timestamp_p,
+                                 transaction_t transaction_id_p)
+    : context(context_p), start_timestamp(start_timestamp_p), transaction_id(transaction_id_p),
+      active_query(MAXIMUM_QUERY_ID), modified_database(nullptr), is_read_only(false) {
 }
 
 MetaTransaction &MetaTransaction::Get(ClientContext &context) {

--- a/src/transaction/meta_transaction.cpp
+++ b/src/transaction/meta_transaction.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 
 MetaTransaction::MetaTransaction(ClientContext &context_p, timestamp_t start_timestamp_p,
                                  transaction_t transaction_id_p)
-    : context(context_p), start_timestamp(start_timestamp_p), transaction_id(transaction_id_p),
+    : context(context_p), start_timestamp(start_timestamp_p), global_transaction_id(transaction_id_p),
       active_query(MAXIMUM_QUERY_ID), modified_database(nullptr), is_read_only(false) {
 }
 

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -12,7 +12,7 @@
 namespace duckdb {
 
 TransactionContext::TransactionContext(ClientContext &context)
-    : context(context), auto_commit(true), current_transaction(nullptr) {
+    : context(context), auto_commit(true), current_transaction(nullptr), current_transaction_id(0) {
 }
 
 TransactionContext::~TransactionContext() {
@@ -29,7 +29,7 @@ void TransactionContext::BeginTransaction() {
 		throw TransactionException("cannot start a transaction within a transaction");
 	}
 	auto start_timestamp = Timestamp::GetCurrentTimestamp();
-	current_transaction = make_uniq<MetaTransaction>(context, start_timestamp);
+	current_transaction = make_uniq<MetaTransaction>(context, start_timestamp, current_transaction_id++);
 
 	// Notify any registered state of transaction begin
 	for (auto &state : context.registered_state->States()) {

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -12,7 +12,7 @@
 namespace duckdb {
 
 TransactionContext::TransactionContext(ClientContext &context)
-    : context(context), auto_commit(true), current_transaction(nullptr), current_transaction_id(0) {
+    : context(context), auto_commit(true), current_transaction(nullptr) {
 }
 
 TransactionContext::~TransactionContext() {
@@ -29,7 +29,8 @@ void TransactionContext::BeginTransaction() {
 		throw TransactionException("cannot start a transaction within a transaction");
 	}
 	auto start_timestamp = Timestamp::GetCurrentTimestamp();
-	current_transaction = make_uniq<MetaTransaction>(context, start_timestamp, current_transaction_id++);
+	auto global_transaction_id = context.db->GetDatabaseManager().GetNewTransactionNumber();
+	current_transaction = make_uniq<MetaTransaction>(context, start_timestamp, global_transaction_id);
 
 	// Notify any registered state of transaction begin
 	for (auto &state : context.registered_state->States()) {

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_context_state.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/database.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"

--- a/test/sql/logging/logging.test
+++ b/test/sql/logging/logging.test
@@ -4,7 +4,7 @@
 
 require noforcestorage
 
-query IIIIIIII
+query IIIIIIIII
 from duckdb_logs
 ----
 
@@ -18,7 +18,7 @@ statement ok
 SELECT 1;
 
 query IIIII
-SELECT * EXCLUDE (timestamp, client_context, transaction_id) FROM duckdb_logs
+SELECT * EXCLUDE (timestamp, connection_id, transaction_id, query_id) FROM duckdb_logs
 ----
 duckdb.ClientContext.BeginQuery	INFO	SELECT 1;	CONNECTION	NULL
 
@@ -27,10 +27,10 @@ set enable_logging=false;
 
 # With logging disabled, the log will persist
 query IIIII
-SELECT * EXCLUDE (timestamp, client_context, transaction_id) FROM duckdb_logs
+SELECT * EXCLUDE (timestamp, connection_id, transaction_id, query_id) FROM duckdb_logs
 ----
 duckdb.ClientContext.BeginQuery	INFO	SELECT 1;	CONNECTION	NULL
-duckdb.ClientContext.BeginQuery	INFO	SELECT * EXCLUDE (timestamp, client_context, transaction_id) FROM duckdb_logs	CONNECTION	NULL
+duckdb.ClientContext.BeginQuery	INFO	SELECT * EXCLUDE (timestamp, connection_id, transaction_id, query_id) FROM duckdb_logs	CONNECTION	NULL
 duckdb.ClientContext.BeginQuery	INFO	set enable_logging=false;	CONNECTION	NULL
 
 statement ok
@@ -46,5 +46,5 @@ Invalid Input Error: Log storage 'quack' is not yet registered
 
 # Storage is now cleared because switching storage will clear it
 query IIIII
-SELECT * EXCLUDE (timestamp, client_context, transaction_id) FROM duckdb_logs
+SELECT * EXCLUDE (timestamp, connection_id, transaction_id, query_id) FROM duckdb_logs
 ----

--- a/test/sql/logging/logging_context_ids.test
+++ b/test/sql/logging/logging_context_ids.test
@@ -2,6 +2,8 @@
 # description: Check the connection_id and transaction_id fields
 # group: [logging]
 
+require noforcestorage
+
 statement ok con1
 set enable_logging=true
 

--- a/test/sql/logging/logging_context_ids.test
+++ b/test/sql/logging/logging_context_ids.test
@@ -1,0 +1,66 @@
+# name: test/sql/logging/logging_context_ids.test
+# description: Check the connection_id and transaction_id fields
+# group: [logging]
+
+statement ok con1
+set enable_logging=true
+
+# We use these to offet the ids which don't start at 0 here due to internal queries/transactions that DuckDB performs
+statement ok con2
+set variable base_transaction_id = current_transaction_id() + 2
+
+statement ok con2
+set variable base_query_id = current_query_id() + 1
+
+# Con2 will do use autocommit on a new connection
+statement ok con2
+SELECT write_log('hey1', log_type := 'test_logging_autocommit')
+
+statement ok con2
+SELECT write_log('hey2', log_type := 'test_logging_autocommit')
+
+# We expect transaction_ids 1 & 2 here
+query II con2
+SELECT
+    transaction_id - getvariable('base_transaction_id') as relative_transaction_id,
+    query_id - getvariable('base_query_id') as relative_query_id,
+FROM duckdb_logs
+WHERE
+    connection_id=current_connection_id() and
+    type='test_logging_autocommit';
+----
+0	0
+1	1
+
+# Con3 will do the same, but within a transaction
+# Again, we calculate the offsets first
+statement ok con3
+set variable base_transaction_id = current_transaction_id() + 2
+
+statement ok con3
+set variable base_query_id = current_query_id() + 1
+
+statement ok con3
+BEGIN TRANSACTION;
+
+statement ok con3
+SELECT write_log('hey1', log_type := 'test_logging_transaction')
+
+statement ok con3
+SELECT write_log('hey2', log_type := 'test_logging_transaction')
+
+statement ok con3
+COMMIT
+
+# Now both queries were performed in the same transaction
+query II con3
+SELECT
+    transaction_id - getvariable('base_transaction_id') as relative_transaction_id,
+    query_id - getvariable('base_query_id') as query_id,
+FROM duckdb_logs
+WHERE
+    connection_id=current_connection_id() and
+    type='test_logging_transaction';
+----
+0	1
+0	2

--- a/test/sql/logging/test_logging_function.test
+++ b/test/sql/logging/test_logging_function.test
@@ -4,7 +4,7 @@
 
 require noforcestorage
 
-query IIIIIIII
+query IIIIIIIII
 from duckdb_logs
 ----
 
@@ -13,6 +13,16 @@ pragma enable_logging;
 
 statement ok
 set logging_level='info';
+
+# We use these to offet the ids which don't start at 0 here due to internal queries/transactions that DuckDB performs
+statement ok
+set variable base_connection_id = current_connection_id()
+
+statement ok
+set variable base_transaction_id = current_transaction_id() + 2
+
+statement ok
+set variable base_query_id = current_query_id() + 1
 
 statement ok
 SELECT write_log('hello from the global log scope', level := 'info', scope := 'database', log_type := 'global_type' ) from range(0,3);
@@ -27,7 +37,7 @@ statement ok
 from duckdb_logs
 
 query IIII
-SELECT * EXCLUDE (timestamp, client_context, transaction_id, thread) FROM duckdb_logs where starts_with(message, 'hello from the') order by timestamp
+SELECT * EXCLUDE (timestamp, connection_id, transaction_id, query_id, thread_id) FROM duckdb_logs where starts_with(message, 'hello from the') order by timestamp
 ----
 global_type	INFO	hello from the global log scope	DATABASE
 global_type	INFO	hello from the global log scope	DATABASE
@@ -38,3 +48,21 @@ client_context_type	INFO	hello from the connection log scope	CONNECTION
 opener_type	INFO	hello from the file_opener log scope	CONNECTION
 opener_type	INFO	hello from the file_opener log scope	CONNECTION
 opener_type	INFO	hello from the file_opener log scope	CONNECTION
+
+query IIII
+SELECT
+    type,
+    connection_id - getvariable('base_connection_id'),
+    transaction_id - getvariable('base_transaction_id'),
+    query_id - getvariable('base_query_id')
+FROM duckdb_logs where starts_with(message, 'hello from the') order by timestamp
+----
+global_type	NULL	NULL	NULL
+global_type	NULL	NULL	NULL
+global_type	NULL	NULL	NULL
+client_context_type	0	1	1
+client_context_type	0	1	1
+client_context_type	0	1	1
+opener_type	0	2	2
+opener_type	0	2	2
+opener_type	0	2	2

--- a/test/sql/logging/test_logging_function.test
+++ b/test/sql/logging/test_logging_function.test
@@ -37,17 +37,17 @@ statement ok
 from duckdb_logs
 
 query IIII
-SELECT * EXCLUDE (timestamp, connection_id, transaction_id, query_id, thread_id) FROM duckdb_logs where starts_with(message, 'hello from the') order by timestamp
+SELECT * EXCLUDE (timestamp, connection_id, transaction_id, query_id, thread_id) FROM duckdb_logs where starts_with(message, 'hello from the') order by query_id
 ----
-global_type	INFO	hello from the global log scope	DATABASE
-global_type	INFO	hello from the global log scope	DATABASE
-global_type	INFO	hello from the global log scope	DATABASE
 client_context_type	INFO	hello from the connection log scope	CONNECTION
 client_context_type	INFO	hello from the connection log scope	CONNECTION
 client_context_type	INFO	hello from the connection log scope	CONNECTION
 opener_type	INFO	hello from the file_opener log scope	CONNECTION
 opener_type	INFO	hello from the file_opener log scope	CONNECTION
 opener_type	INFO	hello from the file_opener log scope	CONNECTION
+global_type	INFO	hello from the global log scope	DATABASE
+global_type	INFO	hello from the global log scope	DATABASE
+global_type	INFO	hello from the global log scope	DATABASE
 
 query IIII
 SELECT
@@ -55,14 +55,14 @@ SELECT
     connection_id - getvariable('base_connection_id'),
     transaction_id - getvariable('base_transaction_id'),
     query_id - getvariable('base_query_id')
-FROM duckdb_logs where starts_with(message, 'hello from the') order by timestamp
+FROM duckdb_logs where starts_with(message, 'hello from the') order by query_id
 ----
-global_type	NULL	NULL	NULL
-global_type	NULL	NULL	NULL
-global_type	NULL	NULL	NULL
 client_context_type	0	1	1
 client_context_type	0	1	1
 client_context_type	0	1	1
 opener_type	0	2	2
 opener_type	0	2	2
 opener_type	0	2	2
+global_type	NULL	NULL	NULL
+global_type	NULL	NULL	NULL
+global_type	NULL	NULL	NULL

--- a/test/sql/logging/test_logging_function.test
+++ b/test/sql/logging/test_logging_function.test
@@ -9,7 +9,7 @@ from duckdb_logs
 ----
 
 statement ok
-set enable_logging=true;
+pragma enable_logging;
 
 statement ok
 set logging_level='info';

--- a/test/sql/logging/test_logging_function_large.test_slow
+++ b/test/sql/logging/test_logging_function_large.test_slow
@@ -4,7 +4,7 @@
 
 require noforcestorage
 
-query IIIIIIII
+query IIIIIIIII
 from duckdb_logs
 ----
 


### PR DESCRIPTION
### What?
This PR adds logging-related improvements:
- adds new (database-globally unique) ids for `Connection` and `MetaTransactions`.
- adds new system scalar functions: `current_connection_id`, `current_transaction_id`, `current_query_id`
- adds `pragma enable_logging` and `pragma disable_logging`

a LogContext now holds 4 identifiers to help understand where a log entry came from:

identifier | description | generated by
-- | -- | -- | 
connection_id | identifies the `Connection`/`ClientContext` |  `ConnectionManager::AssignConnectionId`
transaction_id | identifies the `MetaTransaction`, unique across connections |  `DatabaseManager::GetNewTransactionNumber`
query_id | identifies the individual query, unique across connections, also called the query number internally |  `DatabaseManager::GetNewQueryNumber`
thread_id | identifies which thread the log entry came from | `TaskScheduler::GetEstimatedCPUId`

### Why?
With this we can do cool stuff like:

-> Get logs of previous query:
```SQL
PRAGMA enable_logging;

SELECT 1 as value;
SELECT 2 as value;  

-- prints the log messages generated only for `SELECT 2 as value;` 
SELECT * FROM duckdb_logs WHERE query_id=current_query_id()-1; 
```

-> Get logs of previous transaction:
```SQL
PRAGMA enable_logging;

BEGIN TRANSACTION;
SELECT write_log('my_label');
SELECT 1 as value;
SELECT 2 as value;
COMMIT;  

-- prints the log messages generated for the whole previous transaction
SELECT * FROM duckdb_logs WHERE transaction_id=current_transaction_id()-1; 
```

-> Store the transaction id of a transaction you're interested in logging
```SQL
PRAGMA enable_logging;

BEGIN TRANSACTION;
SET VARIABLE my_transaction_id = current_transaction_id();
SELECT 1 as value;
SELECT 2 as value;
COMMIT;

-- Only prints messages from the first transaction 
FROM duckdb_logs 
WHERE transaction_id = getvariable('my_transaction_id')
```

-> Group queries and add labels in the log through transactions
```SQL
PRAGMA enable_logging;

BEGIN TRANSACTION;
SELECT write_log('my_label');
SELECT 1 as value;
SELECT 2 as value;
COMMIT;

BEGIN TRANSACTION;
SELECT write_log('my_label_2');
SELECT 3 as value;
SELECT 4 as value;
COMMIT;

-- Only prints messages from the transaction which contains the 'my_label' log message
FROM duckdb_logs 
WHERE transaction_id IN (
	SELECT transaction_id 
	FROM duckdb_logs
	WHERE message='my_label'
)
```

### Future work
As we think more about how we want to use logging, I think we can consider creating a set of utility macros to run the above. examples and whatever other crazy stuff we can come up it.
