### PR TITLE
Parallel HT Zeroing: Set entries_per_task so that there are 4x more tasks than threads

### DIFF
--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -374,6 +374,45 @@ SinkCombineResultType PhysicalHashJoin::Combine(ExecutionContext &context, Opera
 //===--------------------------------------------------------------------===//
 // Finalize
 //===--------------------------------------------------------------------===//
+
+static constexpr idx_t PARALLEL_CONSTRUCT_THRESHOLD = 1048576;
+static constexpr double SKEW_SINGLE_THREADED_THRESHOLD = 0.33;
+
+//! If the data is very skewed (many of the exact same key), our finalize will become slow,
+//! due to completely slamming the same atomic using compare-and-swaps.
+//! We can detect this because we partition the data, and go for a single-threaded finalize instead.
+static bool KeysAreSkewed(const HashJoinGlobalSinkState &sink) {
+	const auto max_partition_ht_size =
+	    sink.max_partition_size + JoinHashTable::PointerTableSize(sink.max_partition_count);
+	const auto skew = static_cast<double>(max_partition_ht_size) / static_cast<double>(sink.total_size);
+	return skew > SKEW_SINGLE_THREADED_THRESHOLD;
+}
+
+//! If we have only one thread, always finalize single-threaded. Otherwise, we finalize in parallel if we
+//! have more than 1M rows or if we want to verify parallelism.
+static bool FinalizeSingleThreaded(const HashJoinGlobalSinkState &sink, const bool consider_skew) {
+
+	// if only one thread, finalize single-threaded
+	const auto num_threads = NumericCast<idx_t>(sink.num_threads);
+	if (num_threads == 1) {
+		return true;
+	}
+
+	// if we want to verify parallelism, finalize parallel
+	if (sink.context.config.verify_parallelism) {
+		return false;
+	}
+
+	// finalize single-threaded if we have less than 1M rows
+	const auto &ht = *sink.hash_table;
+	const bool ht_is_small = ht.Count() < PARALLEL_CONSTRUCT_THRESHOLD;
+
+	if (consider_skew) {
+		return ht_is_small || KeysAreSkewed(sink);
+	}
+	return ht_is_small;
+}
+
 static idx_t GetTupleWidth(const vector<LogicalType> &types, bool &all_constant) {
 	idx_t tuple_width = 0;
 	all_constant = true;
@@ -453,7 +492,9 @@ public:
 		auto &ht = *sink.hash_table;
 		const auto entry_count = ht.capacity;
 		auto num_threads = NumericCast<idx_t>(sink.num_threads);
-		if (num_threads == 1 || (entry_count < PARALLEL_CONSTRUCT_THRESHOLD && !context.config.verify_parallelism)) {
+
+		// we don't have to check whether it is too skewed here, as we only initialize the pointer table
+		if (FinalizeSingleThreaded(sink, false)) {
 			// Single-threaded memset
 			finalize_tasks.push_back(
 			    make_uniq<HashJoinTableInitTask>(shared_from_this(), context, sink, 0U, entry_count, sink.op));
@@ -469,8 +510,6 @@ public:
 		}
 		SetTasks(std::move(finalize_tasks));
 	}
-
-	static constexpr const idx_t PARALLEL_CONSTRUCT_THRESHOLD = 1048576;
 	static constexpr const idx_t MINIMUM_ENTRIES_PER_TASK = 131072;
 };
 
@@ -510,17 +549,9 @@ public:
 		vector<shared_ptr<Task>> finalize_tasks;
 		auto &ht = *sink.hash_table;
 		const auto chunk_count = ht.GetDataCollection().ChunkCount();
-		const auto num_threads = NumericCast<idx_t>(sink.num_threads);
 
-		// If the data is very skewed (many of the exact same key), our finalize will become slow,
-		// due to completely slamming the same atomic using compare-and-swaps.
-		// We can detect this because we partition the data, and go for a single-threaded finalize instead.
-		const auto max_partition_ht_size =
-		    sink.max_partition_size + JoinHashTable::PointerTableSize(sink.max_partition_count);
-		const auto skew = static_cast<double>(max_partition_ht_size) / static_cast<double>(sink.total_size);
-
-		if (num_threads == 1 || ((ht.Count() < PARALLEL_CONSTRUCT_THRESHOLD || skew > SKEW_SINGLE_THREADED_THRESHOLD) &&
-		                         !context.config.verify_parallelism)) {
+		// if the keys are too skewed, we finalize single-threaded
+		if (FinalizeSingleThreaded(sink, true)) {
 			// Single-threaded finalize
 			finalize_tasks.push_back(
 			    make_uniq<HashJoinFinalizeTask>(shared_from_this(), context, sink, 0U, chunk_count, false, sink.op));
@@ -541,9 +572,7 @@ public:
 		sink.hash_table->finalized = true;
 	}
 
-	static constexpr idx_t PARALLEL_CONSTRUCT_THRESHOLD = 1048576;
 	static constexpr idx_t CHUNKS_PER_TASK = 64;
-	static constexpr double SKEW_SINGLE_THREADED_THRESHOLD = 0.33;
 };
 
 void HashJoinGlobalSinkState::ScheduleFinalize(Pipeline &pipeline, Event &event) {
@@ -1149,11 +1178,8 @@ void HashJoinGlobalSourceState::PrepareBuild(HashJoinGlobalSinkState &sink) {
 	if (sink.context.config.verify_parallelism) {
 		build_chunks_per_thread = 1;
 	} else {
-		const auto max_partition_ht_size =
-		    sink.max_partition_size + JoinHashTable::PointerTableSize(sink.max_partition_count);
-		const auto skew = static_cast<double>(max_partition_ht_size) / static_cast<double>(sink.total_size);
 
-		if (skew > HashJoinFinalizeEvent::SKEW_SINGLE_THREADED_THRESHOLD) {
+		if (KeysAreSkewed(sink)) {
 			build_chunks_per_thread = build_chunk_count; // This forces single-threaded building
 		} else {
 			build_chunks_per_thread = // Same task size as in HashJoinFinalizeEvent

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -458,8 +458,8 @@ public:
 			finalize_tasks.push_back(
 			    make_uniq<HashJoinTableInitTask>(shared_from_this(), context, sink, 0U, entry_count, sink.op));
 		} else {
-			// have 4 times more tasks than threads
-			const idx_t entries_per_task = entry_count / num_threads / 4;
+			// have 4 times more tasks than threads, but bound the to a minimum
+			const idx_t entries_per_task = MaxValue(entry_count / num_threads / 4, MINIMUM_ENTRIES_PER_TASK);
 			// Parallel memset
 			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx += entries_per_task) {
 				auto entry_idx_to = MinValue<idx_t>(entry_idx + entries_per_task, entry_count);
@@ -471,6 +471,7 @@ public:
 	}
 
 	static constexpr const idx_t PARALLEL_CONSTRUCT_THRESHOLD = 1048576;
+	static constexpr const idx_t MINIMUM_ENTRIES_PER_TASK = 131072;
 };
 
 class HashJoinFinalizeTask : public ExecutorTask {

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -458,9 +458,11 @@ public:
 			finalize_tasks.push_back(
 			    make_uniq<HashJoinTableInitTask>(shared_from_this(), context, sink, 0U, entry_count, sink.op));
 		} else {
+			// have 4 times more tasks than threads
+			const idx_t entries_per_task = entry_count / num_threads / 4;
 			// Parallel memset
-			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx += ENTRIES_PER_TASK) {
-				auto entry_idx_to = MinValue<idx_t>(entry_idx + ENTRIES_PER_TASK, entry_count);
+			for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx += entries_per_task) {
+				auto entry_idx_to = MinValue<idx_t>(entry_idx + entries_per_task, entry_count);
 				finalize_tasks.push_back(make_uniq<HashJoinTableInitTask>(shared_from_this(), context, sink, entry_idx,
 				                                                          entry_idx_to, sink.op));
 			}
@@ -469,7 +471,6 @@ public:
 	}
 
 	static constexpr const idx_t PARALLEL_CONSTRUCT_THRESHOLD = 1048576;
-	static constexpr const idx_t ENTRIES_PER_TASK = 131072;
 };
 
 class HashJoinFinalizeTask : public ExecutorTask {


### PR DESCRIPTION
I noticed a regression for building very large hash tables. The issue is that with the current fixed size of tasks, for very big hash tables too many tasks are generated which leads to the hash table not being accessed sequentially for zeroing, which itself leads to performance regressions. I think the parallel zero is a great improvement, but I think it would be even better with a less granular parallelism taking into account the number of threads and the size of the hash table. 

My benchmark consists of only building the join hash table on `100 000 000` unique keys by joining on an empty probe and disabling the optimizer to prevent join side swapping: 

```sql
load
ATTACH '/Users/paul/micro.duckdb' AS micro;
USE micro;
PRAGMA disable_optimizer;
PRAGMA disable_progress_bar;

run
SELECT * FROM probe JOIN build ON probe.key = build.key;
``` 

Where 
```sql
CREATE TABLE probe (key BIGINT);
CREATE TABLE build AS
  SELECT
      range AS key,
  FROM
      RANGE(0, 100_000_000)
  ORDER BY hash(key + 32);
```

Running on a Macbook Pro with an M4 and 8 threads I get the following performance numbers:

Experiment | Strategy | Average Timing
-- | -- | --
1 | ENTRIES_PER_TASK = 131072 | 0.404637
2 | entries_per_task = entry_count / num_threads / 16 |  0.336537 
3 | entries_per_task = entry_count / num_threads / 8 | 0.306807
4 | entries_per_task = entry_count / num_threads / 4 | 0.286299
5 | entries_per_task = entry_count / num_threads / 2 | 0.289076
6 | entries_per_task = entry_count / num_threads / 1 | 0.285086

To still have more tasks than threads I now set the number of tasks to be 4 times the number of cores, but we could even think about having the same amount of tasks then cores. Let me know what you think. 
