### PR TITLE
make ValidityMask::RowIsValidUnsafe really unsafe

### DIFF
--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -188,7 +188,7 @@ public:
 		D_ASSERT(validity_mask);
 		idx_t entry_idx, idx_in_entry;
 		GetEntryIndex(row_idx, entry_idx, idx_in_entry);
-		auto entry = GetValidityEntry(entry_idx);
+		auto entry = GetValidityEntryUnsafe(entry_idx);
 		return RowIsValid(entry, idx_in_entry);
 	}
 


### PR DESCRIPTION
Although I haven't run benchmarks, the release binary size has been reduced by ~35KB, which should result in some performance improvements.