### PR TITLE
PhysicalTableScan: Adapt to allow async behaviour

### DIFF
--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -111,8 +111,7 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 	switch (function.in_out_function(context, data, g_state.input_chunk, chunk)) {
 	case OperatorResultType::BLOCKED: {
 		auto guard = g_state.Lock();
-		g_state.BlockSource(guard, input.interrupt_state);
-		return SourceResultType::BLOCKED;
+		return g_state.BlockSource(guard, input.interrupt_state);
 	}
 	default:
 		// FIXME: Handling for other cases (such as NEED_MORE_INPUT) breaks current functionality and extensions that

--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -108,7 +108,18 @@ SourceResultType PhysicalTableScan::GetData(ExecutionContext &context, DataChunk
 	if (g_state.in_out_final) {
 		function.in_out_function_final(context, data, chunk);
 	}
-	function.in_out_function(context, data, g_state.input_chunk, chunk);
+	switch (function.in_out_function(context, data, g_state.input_chunk, chunk)) {
+	case OperatorResultType::BLOCKED: {
+		auto guard = g_state.Lock();
+		g_state.BlockSource(guard, input.interrupt_state);
+		return SourceResultType::BLOCKED;
+	}
+	default:
+		// FIXME: Handling for other cases (such as NEED_MORE_INPUT) breaks current functionality and extensions that
+		// might be relying on current behaviour. Needs a rework that is not in scope
+		break;
+	}
+
 	if (chunk.size() == 0 && function.in_out_function_final) {
 		function.in_out_function_final(context, data, chunk);
 		g_state.in_out_final = true;


### PR DESCRIPTION
Bumped into this while looking to supporting JavaScript async UDF functionality in duckdb-wasm. This is the only duckdb/duckdb change, other fixes to be added on duckdb-wasm side, afterward it can be properly tested there.

I think this also makes sense in general for DuckDB, where an operator can now properly BLOCK and handle resuming on a side. This is particularly relevant for the poll path, expecially when single threaded (since no other work can happen otherwise).

This is at the moment an untested codepath in duckdb/duckdb CI, I need to add a test.