### PR TITLE
Allow accessing profiler query tree under lock

### DIFF
--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -166,6 +166,13 @@ public:
 		return root.get();
 	}
 
+	//! Provides access to the root of the query tree, but ensures there are no concurrent modifications
+	//! This can be useful when implementing continuous profiling or making customizations
+	DUCKDB_API void GetRootUnderLock(const std::function<void(optional_ptr<ProfilingNode>)> &callback) {
+		lock_guard<std::mutex> guard(lock);
+		callback(GetRoot());
+	}
+
 private:
 	ClientContext &context;
 


### PR DESCRIPTION
Provides access to the root of the profiler query tree, but ensures there are no concurrent modifications. This can be useful when implementing continuous profiling or making customizations to the tree (e.g. blending in hybrid elements)