### PR TITLE
fix: add StringStats::SetMaxStringLength

### DIFF
--- a/src/include/duckdb/storage/statistics/string_stats.hpp
+++ b/src/include/duckdb/storage/statistics/string_stats.hpp
@@ -54,6 +54,8 @@ struct StringStats {
 
 	//! Resets the max string length so HasMaxStringLength() is false
 	DUCKDB_API static void ResetMaxStringLength(BaseStatistics &stats);
+	//! Sets the max string length
+	DUCKDB_API static void SetMaxStringLength(BaseStatistics &stats, uint32_t length);
 	//! FIXME: make this part of Set on statistics
 	DUCKDB_API static void SetContainsUnicode(BaseStatistics &stats);
 

--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -91,6 +91,12 @@ void StringStats::ResetMaxStringLength(BaseStatistics &stats) {
 	StringStats::GetDataUnsafe(stats).has_max_string_length = false;
 }
 
+void StringStats::SetMaxStringLength(BaseStatistics &stats, uint32_t length) {
+	auto &data = StringStats::GetDataUnsafe(stats);
+	data.has_max_string_length = true;
+	data.max_string_length = length;
+}
+
 void StringStats::SetContainsUnicode(BaseStatistics &stats) {
 	StringStats::GetDataUnsafe(stats).has_unicode = true;
 }


### PR DESCRIPTION
Add a function that allows the maximum string length to be added to a `StringStats` structure.  This allows users of `StringStats` to not have to send the full (potentially large) string to the `Update()` function.