### PR TITLE
Verify UTF-8 in `DeltaLengthByteArrayDecoder` and speed it up

### DIFF
--- a/extension/parquet/include/decoder/delta_length_byte_array_decoder.hpp
+++ b/extension/parquet/include/decoder/delta_length_byte_array_decoder.hpp
@@ -30,6 +30,8 @@ private:
 	template <bool HAS_DEFINES>
 	void ReadInternal(shared_ptr<ResizeableBuffer> &block, uint8_t *defines, idx_t read_count, Vector &result,
 	                  idx_t result_offset);
+	template <bool HAS_DEFINES>
+	void SkipInternal(uint8_t *defines, idx_t skip_count);
 
 private:
 	ColumnReader &reader;

--- a/src/function/scalar/string/strip_accents.cpp
+++ b/src/function/scalar/string/strip_accents.cpp
@@ -6,11 +6,12 @@
 namespace duckdb {
 
 bool IsAscii(const char *input, idx_t n) {
+	static constexpr uint64_t MASK = 0x8080808080808080U;
+
 	// Check 8 bytes at a time
-	static constexpr uint64_t MASK = 0x8080808080808080;
 	idx_t i = 0;
-	for (; i + sizeof(MASK) <= n; i += sizeof(MASK)) {
-		if (DUCKDB_UNLIKELY(Load<uint64_t>(const_data_ptr_cast(input + i)) & MASK)) {
+	for (; i + sizeof(uint64_t) <= n; i += sizeof(uint64_t)) {
+		if ((Load<uint64_t>(const_data_ptr_cast(input + i)) & MASK)) {
 			// non-ascii character in the next 8 bytes
 			return false;
 		}

--- a/src/function/scalar/string/strip_accents.cpp
+++ b/src/function/scalar/string/strip_accents.cpp
@@ -7,11 +7,11 @@ namespace duckdb {
 
 bool IsAscii(const char *input, idx_t n) {
 	// Check 8 bytes at a time
-	static constexpr size_t MASK = 0x8080808080808080;
+	static constexpr uint64_t MASK = 0x8080808080808080;
 	idx_t i = 0;
 	for (; i + sizeof(MASK) <= n; i += sizeof(MASK)) {
-		if (DUCKDB_UNLIKELY(Load<size_t>(const_data_ptr_cast(input + i)) & MASK)) {
-			// non-ascii character
+		if (DUCKDB_UNLIKELY(Load<uint64_t>(const_data_ptr_cast(input + i)) & MASK)) {
+			// non-ascii character in the next 8 bytes
 			return false;
 		}
 	}

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -75,18 +75,16 @@ static inline UnicodeType UTF8ExtraByteLoop(const int first_pos_seq, int utf8cha
 UnicodeType Utf8Proc::Analyze(const char *s, size_t len, UnicodeInvalidReason *invalid_reason, size_t *invalid_pos) {
 	UnicodeType type = UnicodeType::ASCII;
 
-	// Check 8 bytes at a time until we hit non-ASCII
 	static constexpr size_t MASK = 0x8080808080808080;
-	size_t i = 0;
-	for (; i + sizeof(MASK) <= len; i += sizeof(MASK)) {
-		if (DUCKDB_UNLIKELY(Load<size_t>(const_data_ptr_cast(s + i)) & MASK)) {
-			break;
+	for (size_t i = 0; i < len; i++) {
+		// Check 8 bytes at a time until we hit non-ASCII
+		for (; i + sizeof(MASK) < len; i += sizeof(MASK)) {
+			if (DUCKDB_UNLIKELY(Load<size_t>(const_data_ptr_cast(s + i)) & MASK)) {
+				break;
+			}
 		}
-	}
 
-	for (; i < len; i++) {
 		int c = (int)s[i];
-
 		if ((c & 0x80) == 0) {
 			continue;
 		}

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -2,6 +2,7 @@
 #include "utf8proc.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/helper.hpp"
 
 using namespace std;
 
@@ -74,7 +75,16 @@ static inline UnicodeType UTF8ExtraByteLoop(const int first_pos_seq, int utf8cha
 UnicodeType Utf8Proc::Analyze(const char *s, size_t len, UnicodeInvalidReason *invalid_reason, size_t *invalid_pos) {
 	UnicodeType type = UnicodeType::ASCII;
 
-	for (size_t i = 0; i < len; i++) {
+	// Check 8 bytes at a time until we hit non-ASCII
+	static constexpr size_t MASK = 0x8080808080808080;
+	size_t i = 0;
+	for (; i + sizeof(MASK) <= len; i += sizeof(MASK)) {
+		if (DUCKDB_UNLIKELY(Load<size_t>(const_data_ptr_cast(s + i)) & MASK)) {
+			break;
+		}
+	}
+
+	for (; i < len; i++) {
 		int c = (int)s[i];
 
 		if ((c & 0x80) == 0) {

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -75,12 +75,12 @@ static inline UnicodeType UTF8ExtraByteLoop(const int first_pos_seq, int utf8cha
 UnicodeType Utf8Proc::Analyze(const char *s, size_t len, UnicodeInvalidReason *invalid_reason, size_t *invalid_pos) {
 	UnicodeType type = UnicodeType::ASCII;
 
-	static constexpr size_t MASK = 0x8080808080808080;
+	static constexpr uint64_t MASK = 0x8080808080808080;
 	for (size_t i = 0; i < len; i++) {
 		// Check 8 bytes at a time until we hit non-ASCII
 		for (; i + sizeof(MASK) < len; i += sizeof(MASK)) {
-			if (DUCKDB_UNLIKELY(Load<size_t>(const_data_ptr_cast(s + i)) & MASK)) {
-				break;
+			if (DUCKDB_UNLIKELY((Load<uint64_t>(const_data_ptr_cast(s + i)) & MASK) != 0)) {
+				break; // Non-ASCII in the next 8 bytes
 			}
 		}
 

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -75,11 +75,11 @@ static inline UnicodeType UTF8ExtraByteLoop(const int first_pos_seq, int utf8cha
 UnicodeType Utf8Proc::Analyze(const char *s, size_t len, UnicodeInvalidReason *invalid_reason, size_t *invalid_pos) {
 	UnicodeType type = UnicodeType::ASCII;
 
-	static constexpr uint64_t MASK = 0x8080808080808080;
+	static constexpr uint64_t MASK = 0x8080808080808080U;
 	for (size_t i = 0; i < len; i++) {
 		// Check 8 bytes at a time until we hit non-ASCII
-		for (; i + sizeof(MASK) < len; i += sizeof(MASK)) {
-			if (DUCKDB_UNLIKELY((Load<uint64_t>(const_data_ptr_cast(s + i)) & MASK) != 0)) {
+		for (; i + sizeof(uint64_t) < len; i += sizeof(uint64_t)) {
+			if ((Load<uint64_t>(const_data_ptr_cast(s + i)) & MASK)) {
 				break; // Non-ASCII in the next 8 bytes
 			}
 		}


### PR DESCRIPTION
Although Parquet should be valid UTF-8, we can never be sure what other writers do, so we validate this. This validation was already there for `PLAIN`/`RLE_DICTIONARY` encoding but was missing for `DELTA_LENGTH_BYTE_ARRAY`. This PR adds the verification there as well.

Verifying UTF-8 takes is somewhat costly, so I've also worked on speeding it up by checking 8 bytes at a time, instead of 1 byte. This is especially nice for `DELTA_LENGTH_BYTE_ARRAY`, as the strings are stored without their lengths in between, so we can verify many strings in one go.