### PR TITLE
Fix decorrelation of WITH USING KEY

### DIFF
--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -730,6 +730,17 @@ unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal
 			base_binding.column_index = setop.column_count;
 			table_index = setop.table_index;
 			setop.correlated_columns = correlated_columns;
+
+			if (!setop.key_targets.empty()) {
+				for (idx_t i = 0; i < correlated_columns.size(); i++) {
+					auto corr = correlated_columns[i];
+					auto colref = make_uniq<BoundColumnRefExpression>(
+					    correlated_columns[i].type,
+					    ColumnBinding(base_binding.table_index, base_binding.column_index + i));
+					setop.key_targets.push_back(std::move(colref));
+				}
+			}
+
 		} else if (plan->type == LogicalOperatorType::LOGICAL_MATERIALIZED_CTE) {
 			auto &setop = plan->Cast<LogicalMaterializedCTE>();
 			base_binding.table_index = setop.table_index;

--- a/test/sql/cte/recursive_cte_key_variant.test
+++ b/test/sql/cte/recursive_cte_key_variant.test
@@ -370,3 +370,21 @@ query II
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (SELECT 'string', 1 UNION SELECT a, b + 1 FROM tbl WHERE b < 5) SELECT * FROM tbl
 ----
 string	5
+
+query III
+select  *
+  from    range(1, 4) as _(l),
+  lateral (
+    with recursive cte(a, b) using key (a) as (
+      select 1, 0
+        union
+      select a, b + 1
+      from   recurring.cte
+      where  b < l
+    )
+    table cte
+  ) ORDER BY l
+----
+1	1	1
+2	1	2
+3	1	3


### PR DESCRIPTION
Currently, the new `USING KEY` variant of recursive CTEs is not decorrelated correctly. In addition to adding the correlated columns to the working table, they do have to be added to the `key`.

MVP:

```sql
select  *
  from    range(1, 4) as _(l),
  lateral (
    with recursive cte(a, b) using key (a) as (
      select 1, 0
        union
      select a, b + 1
      from   recurring.cte
      where  b < l
    )
    table cte
  ) ORDER BY l
```

This query should return 3 rows, but it only returns one. This PR fixes that.