### PR TITLE
Update shell.cpp to fix #16333

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -3237,7 +3237,7 @@ MetadataResult SetColumnRendering(ShellState &state, const char **azArg, idx_t n
 }
 
 MetadataResult SetRowRendering(ShellState &state, const char **azArg, idx_t nArg) {
-	state.columns = 1;
+	state.columns = 0;
 	return MetadataResult::SUCCESS;
 }
 


### PR DESCRIPTION
This is a proposed fix for #16333 as it seems SetColumnRendering and SetRowRendering do the same thing instead of SetRowRendering returning state.columns back to the default value.
