### PR TITLE
Linux CLI: override platform for ARM manylinux

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [ { runner: ubuntu-latest, arch: amd64, image: x86_64}, {runner: ubuntu-24.04-arm, arch: arm64, image: aarch64}]
+        config: [ { runner: ubuntu-latest, arch: amd64, image: x86_64, duckdb_arch: linux_amd64_gcc4}, {runner: ubuntu-24.04-arm, arch: arm64, image: aarch64, duckdb_arch: linux_arm64}]
 
     name: Linux CLI (${{ matrix.config.arch }})
     runs-on: ${{ matrix.config.runner }}
@@ -84,6 +84,7 @@ jobs:
         -e ENABLE_EXTENSION_AUTOINSTALL=1                                      \
         -e BUILD_BENCHMARK=1                                                   \
         -e FORCE_WARN_UNUSED=1                                                 \
+        -e DUCKDB_PLATFORM=${{ matrix.config.duckdb_arch }}                    \
         quay.io/pypa/manylinux2014_${{ matrix.config.image }}                  \
         bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make -C $PWD"
 


### PR DESCRIPTION
Currently we don't distribute extensions for `linux_arm64_gcc4` flavor, so I think it make little sense to distribute a CLI binary that can't load them.

This is not super clean, since then there might be cases where CLI can be launched but extensions load will fail due to a LIBC version mismatch, but I think that's somehow better that no extensions for all.

This needs to be reviewed going into v1.3, I will add it as task.