### PR TITLE
Added query progress callback

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -4542,6 +4542,10 @@ Destroys the cast function object.
 */
 DUCKDB_API void duckdb_destroy_cast_function(duckdb_cast_function *cast_function);
 
+typedef void (*duckdb_progress_callback_t)(duckdb_query_progress_type progress);
+
+DUCKDB_API void duckdb_set_progress_callback(duckdb_connection connection, duckdb_progress_callback_t callback);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -89,6 +89,8 @@ public:
 	//! Data for the currently running transaction
 	TransactionContext transaction;
 
+	duckdb_progress_callback_t progress_callback = nullptr;
+
 public:
 	MetaTransaction &ActiveTransaction() {
 		return transaction.ActiveTransaction();

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -89,7 +89,7 @@ public:
 	//! Data for the currently running transaction
 	TransactionContext transaction;
 
-	duckdb_progress_callback_t progress_callback = nullptr;
+	std::function<void(QueryProgress)> progress_callback = nullptr;
 
 public:
 	MetaTransaction &ActiveTransaction() {

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -129,6 +129,23 @@ duckdb_query_progress_type duckdb_query_progress(duckdb_connection connection) {
 	return query_progress_type;
 }
 
+void duckdb_set_progress_callback(duckdb_connection connection, duckdb_progress_callback_t callback) {
+    if (!connection) {
+        return;
+    }
+
+    Connection* conn = reinterpret_cast<Connection *>(connection);
+
+    if (!callback) {
+        // Remove callback if nullptr is passed
+		conn->context->progress_callback = nullptr;
+        return;
+    }
+
+    // Store the callback and user data
+	conn->context->progress_callback = callback;
+}
+
 void duckdb_disconnect(duckdb_connection *connection) {
 	if (connection && *connection) {
 		Connection *conn = reinterpret_cast<Connection *>(*connection);

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -141,7 +141,13 @@ void duckdb_set_progress_callback(duckdb_connection connection, duckdb_progress_
 		return;
 	}
 
-	conn->context->progress_callback = callback;
+	conn->context->progress_callback = ([callback](duckdb::QueryProgress progress) {
+		duckdb_query_progress_type query_progress_type;
+		query_progress_type.percentage = progress.GetPercentage();
+		query_progress_type.rows_processed = progress.GetRowsProcesseed();
+		query_progress_type.total_rows_to_process = progress.GetTotalRowsToProcess();
+		callback(query_progress_type);
+	});
 }
 
 void duckdb_disconnect(duckdb_connection *connection) {

--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -130,19 +130,17 @@ duckdb_query_progress_type duckdb_query_progress(duckdb_connection connection) {
 }
 
 void duckdb_set_progress_callback(duckdb_connection connection, duckdb_progress_callback_t callback) {
-    if (!connection) {
-        return;
-    }
+	if (!connection) {
+		return;
+	}
 
-    Connection* conn = reinterpret_cast<Connection *>(connection);
+	Connection *conn = reinterpret_cast<Connection *>(connection);
 
-    if (!callback) {
-        // Remove callback if nullptr is passed
+	if (!callback) {
 		conn->context->progress_callback = nullptr;
-        return;
-    }
+		return;
+	}
 
-    // Store the callback and user data
 	conn->context->progress_callback = callback;
 }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -590,6 +590,16 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 			active_query->progress_bar->Update(is_finished);
 			query_progress = active_query->progress_bar->GetDetailedQueryProgress();
 		}
+
+		if (progress_callback) {
+			duckdb_query_progress_type progress;
+			progress.percentage = query_progress.GetPercentage();
+			progress.rows_processed = query_progress.GetRowsProcesseed();
+			progress.total_rows_to_process = query_progress.GetTotalRowsToProcess();
+
+			progress_callback(progress);
+		}
+
 		return query_result;
 	} catch (std::exception &ex) {
 		auto error = ErrorData(ex);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -592,12 +592,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 		}
 
 		if (progress_callback) {
-			duckdb_query_progress_type progress;
-			progress.percentage = query_progress.GetPercentage();
-			progress.rows_processed = query_progress.GetRowsProcesseed();
-			progress.total_rows_to_process = query_progress.GetTotalRowsToProcess();
-
-			progress_callback(progress);
+			progress_callback(query_progress);
 		}
 
 		return query_result;


### PR DESCRIPTION
Currently we can get query progress with the `duckdb_query_progress` function but we need to poll it during the query execution. This PR adds `duckdb_set_progress_callback` function that we can use to register a callback that will be executed whenever query progress changes.

@Mytherin If you think this is worth adding, I'll add the function to the header generation files.