### PR TITLE
Aggregation: For dictionaries without an id - use the correct threshold to bail-out on using the dictionary

### DIFF
--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -329,7 +329,7 @@ optional_idx GroupedAggregateHashTable::TryAddDictionaryGroups(DataChunk &groups
 	if (dictionary_id.empty()) {
 		// dictionary has no id, we can't cache across vectors
 		// only use dictionary compression if there are fewer entries than groups
-		if (dict_size >= groups.size() * DICTIONARY_THRESHOLD) {
+		if (dict_size * DICTIONARY_THRESHOLD >= groups.size()) {
 			// dictionary is too large - use regular aggregation
 			return optional_idx();
 		}


### PR DESCRIPTION
We should bail-out when `dict_size * DICTIONARY_THRESHOLD` is bigger than the number of rows in the chunk, not the other way around.

Note that in practice this code doesn't really get triggered right now because we only emit dictionary vectors with ids.