### PR TITLE
[SwiftRelease CI] fetch tags before checking there is already a tag with the same name

### DIFF
--- a/.github/workflows/SwiftRelease.yml
+++ b/.github/workflows/SwiftRelease.yml
@@ -61,6 +61,7 @@ jobs:
           cd source-repo
           export TAG_NAME=`python3 -c "import sys, os; sys.path.append(os.path.join('scripts')); import package_build; print(package_build.git_dev_version())"`
           cd ..
+          git -C updated-repo fetch --tags
           if [[ $(git -C updated-repo tag -l $TAG_NAME) ]]; then
             echo 'Tag '$TAG_NAME' already exists - skipping'
           else


### PR DESCRIPTION
[SwiftRelease CI](https://github.com/duckdb/duckdb/actions/runs/13488488943/job/37682897743#step:8:19) fails when it tries to push with the tag name which is already exists.
The way how it checks that looks good, but maybe it should first fetch the tag names and check only then - this PR adds a line to fetch the tags.