### PR TITLE
Internal #4287: INTERVAL Times DOUBLE

### DIFF
--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -17,7 +17,7 @@ namespace duckdb {
 static_assert(sizeof(timestamp_t) == sizeof(int64_t), "timestamp_t was padded");
 
 // Temporal values need to round down when changing precision,
-// but C/C++ rounds towrds 0 when you simply divide.
+// but C/C++ rounds towards 0 when you simply divide.
 // This piece of bit banging solves that problem.
 template <typename T>
 static inline T TemporalRound(T value, T scale) {

--- a/src/function/scalar/operator/multiply.cpp
+++ b/src/function/scalar/operator/multiply.cpp
@@ -49,13 +49,13 @@ inline double PGTimestampRound(const double &j) {
 template <>
 bool TryMultiplyOperator::Operation(interval_t left, double right, interval_t &result) {
 	double d = left.months * right;
-	if (isnan(d) || d < NumericLimits<int32_t>::Minimum() || d > NumericLimits<int32_t>::Maximum()) {
+	if (std::isnan(d) || d < NumericLimits<int32_t>::Minimum() || d > NumericLimits<int32_t>::Maximum()) {
 		return false;
 	}
 	result.months = LossyNumericCast<int32_t>(d);
 
 	d = left.days * right;
-	if (isnan(d) || d < NumericLimits<int32_t>::Minimum() || d > NumericLimits<int32_t>::Maximum()) {
+	if (std::isnan(d) || d < NumericLimits<int32_t>::Minimum() || d > NumericLimits<int32_t>::Maximum()) {
 		return false;
 	}
 	result.days = LossyNumericCast<int32_t>(d);
@@ -90,7 +90,7 @@ bool TryMultiplyOperator::Operation(interval_t left, double right, interval_t &r
 	 * cascade from months and days.  It might still be >24 if the combination
 	 * of cascade and the seconds factor operation itself.
 	 */
-	if (abs(sec_remainder) >= Interval::SECS_PER_DAY) {
+	if (std::fabs(sec_remainder) >= Interval::SECS_PER_DAY) {
 		result.days += LossyNumericCast<int32_t>(sec_remainder / Interval::SECS_PER_DAY);
 		sec_remainder -= LossyNumericCast<int32_t>(sec_remainder / Interval::SECS_PER_DAY) * Interval::SECS_PER_DAY;
 	}
@@ -101,7 +101,7 @@ bool TryMultiplyOperator::Operation(interval_t left, double right, interval_t &r
 		return false;
 	}
 	d = std::nearbyint(d * right + sec_remainder * Interval::MICROS_PER_SEC);
-	if (isnan(d) || !TryCast::Operation<double, int64_t>(d, result.micros)) {
+	if (std::isnan(d) || !TryCast::Operation<double, int64_t>(d, result.micros)) {
 		return false;
 	}
 

--- a/src/function/scalar/operator/multiply.cpp
+++ b/src/function/scalar/operator/multiply.cpp
@@ -4,10 +4,8 @@
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/hugeint.hpp"
 #include "duckdb/common/types/uhugeint.hpp"
-#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/windows_undefs.hpp"
 
-#include <limits>
 #include <algorithm>
 
 namespace duckdb {
@@ -39,6 +37,89 @@ interval_t MultiplyOperator::Operation(interval_t left, int64_t right) {
 template <>
 interval_t MultiplyOperator::Operation(int64_t left, interval_t right) {
 	return MultiplyOperator::Operation<interval_t, int64_t, interval_t>(right, left);
+}
+
+// TSROUND.
+// Avoid std::rint because it can raise exceptions and we know that can't happen.
+inline double PGTimestampRound(const double &j) {
+	return (std::nearbyint(((double)(j)) * Interval::MICROS_PER_SEC) / Interval::MICROS_PER_SEC);
+}
+
+// Taken from Postgres src.backend/utils/adt/timestamp.c:interval_mul
+template <>
+bool TryMultiplyOperator::Operation(interval_t left, double right, interval_t &result) {
+	double d = left.months * right;
+	if (isnan(d) || d < NumericLimits<int32_t>::Minimum() || d > NumericLimits<int32_t>::Maximum()) {
+		return false;
+	}
+	result.months = LossyNumericCast<int32_t>(d);
+
+	d = left.days * right;
+	if (isnan(d) || d < NumericLimits<int32_t>::Minimum() || d > NumericLimits<int32_t>::Maximum()) {
+		return false;
+	}
+	result.days = LossyNumericCast<int32_t>(d);
+
+	/*
+	 * The above correctly handles the whole-number part of the month and day
+	 * products, but we have to do something with any fractional part
+	 * resulting when the factor is non-integral.  We cascade the fractions
+	 * down to lower units using the conversion factors DAYS_PER_MONTH and
+	 * SECS_PER_DAY.  Note we do NOT cascade up, since we are not forced to do
+	 * so by the representation.  The user can choose to cascade up later,
+	 * using justify_hours and/or justify_days.
+	 */
+
+	/*
+	 * Fractional months full days into days.
+	 *
+	 * Floating point calculation are inherently imprecise, so these
+	 * calculations are crafted to produce the most reliable result possible.
+	 * TSROUND() is needed to more accurately produce whole numbers where
+	 * appropriate.
+	 */
+	double month_remainder = (left.months * right - result.months) * Interval::DAYS_PER_MONTH;
+	month_remainder = PGTimestampRound(month_remainder);
+	auto day_remainder = LossyNumericCast<int32_t>(month_remainder);
+
+	double sec_remainder = (left.days * right - result.days + month_remainder - day_remainder) * Interval::SECS_PER_DAY;
+	sec_remainder = PGTimestampRound(sec_remainder);
+
+	/*
+	 * Might have 24:00:00 hours due to rounding, or >24 hours because of time
+	 * cascade from months and days.  It might still be >24 if the combination
+	 * of cascade and the seconds factor operation itself.
+	 */
+	if (abs(sec_remainder) >= Interval::SECS_PER_DAY) {
+		result.days += LossyNumericCast<int32_t>(sec_remainder / Interval::SECS_PER_DAY);
+		sec_remainder -= LossyNumericCast<int32_t>(sec_remainder / Interval::SECS_PER_DAY) * Interval::SECS_PER_DAY;
+	}
+
+	/* cascade units down */
+	result.days += day_remainder;
+	if (!TryCast::Operation<int64_t, double>(left.micros, d)) {
+		return false;
+	}
+	d = std::nearbyint(d * right + sec_remainder * Interval::MICROS_PER_SEC);
+	if (isnan(d) || !TryCast::Operation<double, int64_t>(d, result.micros)) {
+		return false;
+	}
+
+	return true;
+}
+
+template <>
+interval_t MultiplyOperator::Operation(interval_t left, double right) {
+	interval_t result;
+	if (!TryMultiplyOperator::Operation(left, right, result)) {
+		throw OutOfRangeException("Overflow in multiplication of INTERVAL.");
+	}
+	return result;
+}
+
+template <>
+interval_t MultiplyOperator::Operation(double left, interval_t right) {
+	return MultiplyOperator::Operation<interval_t, double, interval_t>(right, left);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb/common/operator/multiply.hpp
+++ b/src/include/duckdb/common/operator/multiply.hpp
@@ -32,6 +32,10 @@ template <>
 interval_t MultiplyOperator::Operation(interval_t left, int64_t right);
 template <>
 interval_t MultiplyOperator::Operation(int64_t left, interval_t right);
+template <>
+interval_t MultiplyOperator::Operation(interval_t left, double right);
+template <>
+interval_t MultiplyOperator::Operation(double left, interval_t right);
 
 struct TryMultiplyOperator {
 	template <class TA, class TB, class TR>
@@ -61,6 +65,9 @@ template <>
 DUCKDB_API bool TryMultiplyOperator::Operation(hugeint_t left, hugeint_t right, hugeint_t &result);
 template <>
 DUCKDB_API bool TryMultiplyOperator::Operation(uhugeint_t left, uhugeint_t right, uhugeint_t &result);
+
+template <>
+bool TryMultiplyOperator::Operation(interval_t left, double right, interval_t &result);
 
 struct MultiplyOperatorOverflowCheck {
 	template <class TA, class TB, class TR>

--- a/test/fuzzer/sqlsmith/interval_multiply_overflow.test
+++ b/test/fuzzer/sqlsmith/interval_multiply_overflow.test
@@ -11,4 +11,4 @@ statement error
 SELECT multiply("interval", "bigint") 
 FROM all_types;
 ----
-the value is out of range for the destination type INT32
+Overflow in multiplication of INTERVAL

--- a/test/sql/function/interval/test_interval_muldiv.test
+++ b/test/sql/function/interval/test_interval_muldiv.test
@@ -1,0 +1,81 @@
+# name: test/sql/function/interval/test_interval_muldiv.test
+# description: Test PG INTERVAL DOUBLE multiply and divide.
+# group: [interval]
+
+statement ok
+PRAGMA enable_verification
+
+# From src/test/regress/sql/interval.sql
+# Test multiplication and division with intervals.
+# Floating point arithmetic rounding errors can lead to unexpected results,
+# though the code attempts to do the right thing and round up to days and
+# minutes to avoid results such as '3 days 24:00 hours' or '14:20:60'.
+# Note that it is expected for some day components to be greater than 29 and
+# some time components be greater than 23:59:59 due to how intervals are
+# stored internally.
+statement ok
+CREATE TABLE INTERVAL_MULDIV_TBL (span interval);
+
+statement ok
+INSERT INTO INTERVAL_MULDIV_TBL VALUES
+    ('41 months 12 days 360:00'),
+    ('-41 months -12 days 360:00'),
+    ('-12 days'),
+    ('9 months -27 days 12:34:56'),
+    ('-3 years 482 days 76:54:32.189'),
+    ('4 months'),
+    ('14 months'),
+    ('999 months 999 days'),
+;
+
+query I
+SELECT span * 0.3 AS product
+FROM INTERVAL_MULDIV_TBL;
+----
+1 year 12 days 122:24:00
+-1 year -12 days 93:36:00
+-3 days -14:24:00
+2 months 13 days 01:22:28.8
+-10 months 120 days 37:28:21.6567
+1 month 6 days
+4 months 6 days
+24 years 11 months 320 days 16:48:00
+
+query I
+SELECT span * 8.2 AS product
+FROM INTERVAL_MULDIV_TBL;
+----
+28 years 104 days 2961:36:00
+-28 years -104 days 2942:24:00
+-98 days -09:36:00
+6 years 1 month -197 days 93:34:27.2
+-24 years -7 months 3946 days 640:15:11.9498
+2 years 8 months 24 days
+9 years 6 months 24 days
+682 years 7 months 8215 days 19:12:00
+
+query I
+SELECT span / 10 AS quotient
+FROM INTERVAL_MULDIV_TBL;
+----
+4 months 4 days 40:48:00
+-4 months -4 days 31:12:00
+-1 day -04:48:00
+25 days -15:32:30.4
+-3 months 30 days 12:29:27.2189
+12 days
+1 month 12 days
+8 years 3 months 126 days 21:36:00
+
+query I
+SELECT span / 100 AS quotient
+FROM INTERVAL_MULDIV_TBL;
+----
+12 days 13:40:48
+-12 days -06:28:48
+-02:52:48
+2 days 10:26:44.96
+-6 days 01:14:56.72189
+1 day 04:48:00
+4 days 04:48:00
+9 months 39 days 16:33:36


### PR DESCRIPTION
* Implement this the way PG does.
* Add INTERVAL / DOUBLE as they need to be equivalent
* Remove INTERVAL / BIGINT because it does not propagate fractions correctly.

fixes: duckdblabs/duckdb-internal#4287
