### PR TITLE
Push the correct casts for values of different types in (X, Y) IN (SELECT X, Y)

### DIFF
--- a/src/include/duckdb/planner/expression/bound_subquery_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_subquery_expression.hpp
@@ -40,7 +40,7 @@ public:
 	vector<LogicalType> child_types;
 	//! The target LogicalType of the subquery result (i.e. to which type it should be casted, if child_type <>
 	//! child_target). Only used for ANY expressions.
-	LogicalType child_target;
+	vector<LogicalType> child_targets;
 
 public:
 	bool HasSubquery() const override {

--- a/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -153,7 +153,7 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 			}
 			child = BoundCastExpression::AddCastToType(context, std::move(child), compare_type);
 			result->child_types.push_back(subquery_type);
-			result->child_target = compare_type;
+			result->child_targets.push_back(compare_type);
 			result->children.push_back(std::move(child));
 		}
 	}

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -168,7 +168,8 @@ static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubq
 			cond.left = std::move(expr.children[child_idx]);
 			auto &child_type = expr.child_types[child_idx];
 			cond.right = BoundCastExpression::AddDefaultCastToType(
-			    make_uniq<BoundColumnRefExpression>(child_type, plan_columns[child_idx]), expr.child_target);
+			    make_uniq<BoundColumnRefExpression>(child_type, plan_columns[child_idx]),
+			    expr.child_targets[child_idx]);
 			cond.comparison = expr.comparison_type;
 			join->conditions.push_back(std::move(cond));
 		}
@@ -371,7 +372,8 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
 			compare_cond.left = std::move(expr.children[child_idx]);
 			auto &child_type = expr.child_types[child_idx];
 			compare_cond.right = BoundCastExpression::AddDefaultCastToType(
-			    make_uniq<BoundColumnRefExpression>(child_type, plan_columns[child_idx]), expr.child_target);
+			    make_uniq<BoundColumnRefExpression>(child_type, plan_columns[child_idx]),
+			    expr.child_targets[child_idx]);
 			compare_cond.comparison = expr.comparison_type;
 			delim_join->conditions.push_back(std::move(compare_cond));
 		}

--- a/test/sql/subquery/scalar/subquery_row_in_any.test
+++ b/test/sql/subquery/scalar/subquery_row_in_any.test
@@ -13,6 +13,12 @@ SELECT (1, 2) IN (SELECT i, i + 1 FROM integers)
 ----
 true
 
+# mixed types
+query I
+SELECT (date '1992-01-02', 2) IN (SELECT date '1992-01-01' + interval (i) days, i + 1 FROM integers)
+----
+true
+
 # it still works with the row inside the subquery
 query I
 SELECT (1, 2) IN (SELECT (i, i + 1) FROM integers)


### PR DESCRIPTION
Follow-up fix from https://github.com/duckdb/duckdb/pull/15259