### PR TITLE
Fuzzer Fix: Fix Avg for NULL cast to TIMESTAMP

### DIFF
--- a/extension/core_functions/aggregate/algebraic/avg.cpp
+++ b/extension/core_functions/aggregate/algebraic/avg.cpp
@@ -126,8 +126,8 @@ struct DiscreteAverageOperation : public BaseSumOperation<AverageSetOperation, A
 		if (state.count == 0) {
 			finalize_data.ReturnNull();
 		} else {
-			uint64_t remainder;
-			target = Hugeint::Cast<T>(Hugeint::DivModPositive(state.value, state.count, remainder));
+			hugeint_t remainder;
+			target = Hugeint::Cast<T>(Hugeint::DivMod(state.value, state.count, remainder));
 			// Round the result
 			target += (remainder > (state.count / 2));
 		}

--- a/test/fuzzer/duckfuzz/temporal_avg.test
+++ b/test/fuzzer/duckfuzz/temporal_avg.test
@@ -1,0 +1,9 @@
+# name: test/fuzzer/duckfuzz/temporal_avg.test
+# description: Fuzzyduck issue #1128
+# group: [duckfuzz]
+
+statement ok
+create table all_types as select * exclude(small_enum, medium_enum, large_enum) from test_all_types();
+
+statement ok
+SELECT avg(c1) FROM test_vector_types(CAST(NULL AS TIMESTAMP)) AS test_vector_types(c1);


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-fuzzer/issues/3990

Fix (I think) Is to not use the DivModPositive Function as it assumes the LHS is positive. However, it seems like when NULL is cast to `Timestamp` a negative timestamp/hugeint_t value is used. 

Another fix may be a different timestamp value when casting NULL.

Commit causing the error was [1e404813c9ec1ebe47e4d1b4dccfd86ad978ba7d](https://github.com/duckdb/duckdb/commit/1e404813c9ec1ebe47e4d1b4dccfd86ad978ba7d).

CC @hawkfish 