### PR TITLE
Reorder headers to fix MingW broken build

### DIFF
--- a/src/main/capi/aggregate_function-c.cpp
+++ b/src/main/capi/aggregate_function-c.cpp
@@ -1,9 +1,11 @@
+// clang-format off
+#include "duckdb/main/capi/capi_internal.hpp"
+// clang-format on
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/scalar_function.hpp"
-#include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"


### PR DESCRIPTION
- The `DUCKDB_API` macro is defined in duckdb.h, so it should be
  included before any other C-API functions.

This patch moves the `capi_internal.hpp` header to the top, which
fixes #13911.  However I'm not sure if this is expected, or if
there is an underlying macro bug that is showing itself like this.
Any comments will be helpful.
  
- disable clang-format arround capi_internal.hpp to prevent automatic
  reordering

I also disabled automatic reordering by `clang-format` for _this_
header.  I hope this is acceptable.
