### PR TITLE
Use checkpoint bind in DuckTableEntry::Copy to avoid re-validating default values (and potentially causing issues during WAL replay)

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -863,7 +863,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::Copy(ClientContext &context) const {
 	}
 
 	auto binder = Binder::CreateBinder(context);
-	auto bound_create_info = binder->BindCreateTableInfo(std::move(create_info), schema);
+	auto bound_create_info = binder->BindCreateTableCheckpoint(std::move(create_info), schema);
 	return make_uniq<DuckTableEntry>(catalog, schema, *bound_create_info, storage);
 }
 

--- a/test/sql/attach/attach_wal_alter_sequence.test
+++ b/test/sql/attach/attach_wal_alter_sequence.test
@@ -2,6 +2,8 @@
 # description: Test binding of a WAL with a sequence entry in it
 # group: [attach]
 
+require skip_reload
+
 statement ok
 PRAGMA disable_checkpoint_on_shutdown
 

--- a/test/sql/attach/attach_wal_alter_sequence.test
+++ b/test/sql/attach/attach_wal_alter_sequence.test
@@ -1,0 +1,50 @@
+# name: test/sql/attach/attach_wal_alter_sequence.test
+# description: Test binding of a WAL with a sequence entry in it
+# group: [attach]
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB';
+
+# create a table with hugeints
+statement ok
+attach '__TEST_DIR__/attach_wal_with_sequence.db' as db1;
+
+statement ok
+CREATE SEQUENCE db1.seq;
+
+statement ok
+CREATE TABLE db1.test (a INTEGER DEFAULT nextval('seq'), b INTEGER, c INTEGER DEFAULT currval('seq'));
+
+statement ok
+INSERT INTO db1.test (b) VALUES (1);
+
+statement ok
+alter table db1.test RENAME TO blubb;
+
+statement ok
+INSERT INTO db1.blubb (b) VALUES (10);
+
+query III
+SELECT * FROM db1.blubb
+----
+1	1	1
+2	10	2
+
+statement ok
+DETACH db1
+
+statement ok
+attach '__TEST_DIR__/attach_wal_with_sequence.db' as db2;
+
+statement ok
+INSERT INTO db2.blubb (b) VALUES (100);
+
+query III
+SELECT * FROM db2.blubb
+----
+1	1	1
+2	10	2
+3	100	3


### PR DESCRIPTION
Fixes an issue where we would try to bind expressions during WAL replay