### PR TITLE
MAIN_BRANCH_VERSIONING: Adopt also for Python build and amalgamation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,13 @@ if(${EXPORT_DYNAMIC_SYMBOLS})
 endif()
 
 set(VERSIONING_TAG_MATCH "v*.*.*")
+######
+# MAIN_BRANCH_VERSIONING default value needs to keep in sync between:
+# - CMakeLists.txt
+# - scripts/amalgamation.py
+# - scripts/package_build.py
+# - tools/pythonpkg/setup.py
+######
 option(MAIN_BRANCH_VERSIONING "Versioning scheme for main branch" TRUE)
 if(${MAIN_BRANCH_VERSIONING})
   set(VERSIONING_TAG_MATCH "v*.*.0")

--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -270,6 +270,16 @@ def git_commit_hash():
     return hash
 
 
+######
+# MAIN_BRANCH_VERSIONING default value needs to keep in sync between:
+# - CMakeLists.txt
+# - scripts/amalgamation.py
+# - scripts/package_build.py
+# - tools/pythonpkg/setup.py
+######
+main_branch_versioning = os.getenv('MAIN_BRANCH_VERSIONING') or 1
+
+
 def git_dev_version():
     try:
         long_version = package_build.get_git_describe()
@@ -280,7 +290,13 @@ def git_dev_version():
             return "v" + '.'.join(version_splits)
         else:
             # not on a tag: increment the version by one and add a -devX suffix
-            version_splits[2] = str(int(version_splits[2]) + 1)
+            # this needs to keep in sync with changes to CMakeLists.txt
+            if main_branch_versioning:
+                # increment minor version
+                version_splits[1] = str(int(version_splits[1]) + 1)
+            else:
+                # increment patch version
+                version_splits[2] = str(int(version_splits[2]) + 1)
             return "v" + '.'.join(version_splits) + "-dev" + dev_version
     except:
         return "v0.0.0"

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -5,6 +5,7 @@ import os
 import platform
 import sys
 import traceback
+import subprocess
 from functools import lru_cache
 from glob import glob
 from os.path import exists
@@ -376,7 +377,77 @@ spark_packages = [
 
 packages.extend(spark_packages)
 
+######
+# MAIN_BRANCH_VERSIONING default value needs to keep in sync between:
+# - CMakeLists.txt
+# - scripts/amalgamation.py
+# - scripts/package_build.py
+# - tools/pythonpkg/setup.py
+######
+main_branch_versioning = os.getenv('MAIN_BRANCH_VERSIONING') or 1
+
+
+def get_git_describe():
+    override_git_describe = os.getenv('OVERRIDE_GIT_DESCRIBE') or ''
+    versioning_tag_match = 'v*.*.*'
+    if main_branch_versioning:
+        versioning_tag_match = 'v*.*.0'
+    # empty override_git_describe, either since env was empty string or not existing
+    # -> ask git (that can fail, so except in place)
+    if len(override_git_describe) == 0:
+        try:
+            return (
+                subprocess.check_output(
+                    ['git', 'describe', '--tags', '--long', '--debug', '--match', versioning_tag_match]
+                )
+                .strip()
+                .decode('utf8')
+            )
+        except subprocess.CalledProcessError:
+            return "v0.0.0-0-gdeadbeeff"
+    if len(override_git_describe.split('-')) == 3:
+        return override_git_describe
+    if len(override_git_describe.split('-')) == 1:
+        override_git_describe += "-0"
+    assert len(override_git_describe.split('-')) == 2
+    try:
+        return (
+            override_git_describe
+            + "-g"
+            + subprocess.check_output(['git', 'log', '-1', '--format=%h']).strip().decode('utf8')
+        )
+    except subprocess.CalledProcessError:
+        return override_git_describe + "-g" + "deadbeeff"
+
+
+def git_dev_version():
+    # if 'SETUPTOOLS_SCM_PRETEND_VERSION' in os.environ:
+    #    return prefix_version(os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'])
+    try:
+        long_version = get_git_describe()
+        version_splits = long_version.split('-')[0].lstrip('v').split('.')
+        dev_version = long_version.split('-')[1]
+        if int(dev_version) == 0:
+            # directly on a tag: emit the regular version
+            return "v" + '.'.join(version_splits)
+        else:
+            # not on a tag: increment the version by one and add a -devX suffix
+            # this needs to keep in sync with changes to CMakeLists.txt
+            if main_branch_versioning == 1:
+                # increment minor version
+                version_splits[1] = str(int(version_splits[1]) + 1)
+            else:
+                # increment patch version
+                version_splits[2] = str(int(version_splits[2]) + 1)
+            return "v" + '.'.join(version_splits) + "-dev" + dev_version
+    except:
+        return "v0.0.0"
+
+
+package_version = git_dev_version()
+
 setup(
+    version=package_version,
     name=lib_name,
     description='DuckDB in-process database',
     keywords='DuckDB Database SQL OLAP',


### PR DESCRIPTION
Note that duplicating everything 3 times in Python and 1 in CMake is not exactly the best pattern

Follow up of https://github.com/duckdb/duckdb/pull/16366 to handle also Python builds