### PR TITLE
Only select options that generate more columns with null_padding, if they at least hold 50% of consistency

### DIFF
--- a/data/csv/multi_quote.csv
+++ b/data/csv/multi_quote.csv
@@ -1,0 +1,8 @@
+datecol,textcol
+1/1/19,"text"
+1/2/19,"text"
+1/3/19,"text"
+1/4/19,"text"
+1/5/19,"text"
+1/6/19,"text, with comma"
+1/9/19,'text'

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -397,7 +397,13 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 				}
 			}
 		}
-		if (max_columns_found == num_cols && ignored_rows > min_ignored_rows) {
+		if (max_columns_found == num_cols && (ignored_rows > min_ignored_rows)) {
+			return;
+		}
+		if (max_columns_found > 1 && num_cols > max_columns_found && consistent_rows < best_consistent_rows / 2 &&
+		    options.null_padding) {
+			// When null_padding is true, we only give preference to a max number of columns if null padding is at least
+			// 25% as consistent as the best case scenario
 			return;
 		}
 		if (quoted && num_cols < max_columns_found) {

--- a/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/dialect_detection.cpp
@@ -403,7 +403,7 @@ void CSVSniffer::AnalyzeDialectCandidate(unique_ptr<ColumnCountScanner> scanner,
 		if (max_columns_found > 1 && num_cols > max_columns_found && consistent_rows < best_consistent_rows / 2 &&
 		    options.null_padding) {
 			// When null_padding is true, we only give preference to a max number of columns if null padding is at least
-			// 25% as consistent as the best case scenario
+			// 50% as consistent as the best case scenario
 			return;
 		}
 		if (quoted && num_cols < max_columns_found) {

--- a/test/sql/copy/csv/test_read_csv.test
+++ b/test/sql/copy/csv/test_read_csv.test
@@ -6,6 +6,17 @@ statement ok
 PRAGMA enable_verification
 
 query II
+FROM read_csv('data/csv/multi_quote.csv', null_padding = true)
+----
+2019-01-01	text
+2019-02-01	text
+2019-03-01	text
+2019-04-01	text
+2019-05-01	text
+2019-06-01	text, with comma
+2019-09-01	'text'
+
+query II
 FROM read_csv('data/csv/bad_escape.csv')
 ----
 332	Surname, Firstname


### PR DESCRIPTION
Fix: https://github.com/duckdb/duckdb/issues/16215