### PR TITLE
Suggested Change: Replace MD5 with SHA-256 due to collision vulnerability

### DIFF
--- a/src/common/crypto/md5.cpp
+++ b/src/common/crypto/md5.cpp
@@ -133,6 +133,8 @@ static void MD5Transform(uint32_t buf[4], const uint32_t in[16]) {
 	buf[3] += d;
 }
 
+
+
 /*
  * Start MD5 accumulation.  Set bit count to 0 and buffer to mysterious
  * initialization constants.


### PR DESCRIPTION
**Description:**

This PR suggests replacing the MD5 hashing function with SHA-256 due to MD5's known vulnerability to collision attacks. The MD5Transform() function in this repository is nearly identical to the one in the Linux kernel (commit [bc0b96b](https://github.com/torvalds/linux/commit/bc0b96b54a21246e377122d54569eef71cec535f)), but the refactor does not address MD5's cryptographic weaknesses.

The MD5 collision vulnerability (CVE-2004-2761) has been a known issue for years, demonstrating that MD5 is prone to collision attacks. As MD5 is considered cryptographically broken, its use in secure applications is strongly discouraged.

**Suggested Changes:**

    Replace MD5 with the more secure SHA-256 hashing function to mitigate vulnerabilities related to collision attacks.
    Ensure the hashing function meets modern cryptographic standards and eliminate the security risks associated with MD5.

**Additional Note:**

To submit this PR, I made a minor modification by adding an empty line in one of the files to trigger a valid commit. This change does not affect the functionality of the code, and the primary focus of this PR is the proposed replacement of MD5 with SHA-256.

**References:**

    [CVE-2004-2761: MD5 Collision Vulnerability](https://nvd.nist.gov/vuln/detail/cve-2004-2761)
    [Linux Commit: Refactor MD5](https://github.com/torvalds/linux/commit/bc0b96b54a21246e377122d54569eef71cec535f)