### PR TITLE
Issue #16407: Try_Strptime Invalid TimeZone

### DIFF
--- a/extension/icu/icu-datefunc.cpp
+++ b/extension/icu/icu-datefunc.cpp
@@ -71,13 +71,20 @@ unique_ptr<FunctionData> ICUDateFunc::Bind(ClientContext &context, ScalarFunctio
 	return make_uniq<BindData>(context);
 }
 
-void ICUDateFunc::SetTimeZone(icu::Calendar *calendar, const string_t &tz_id) {
+bool ICUDateFunc::TrySetTimeZone(icu::Calendar *calendar, const string_t &tz_id) {
 	auto tz = icu_66::TimeZone::createTimeZone(icu::UnicodeString::fromUTF8(icu::StringPiece(tz_id.GetString())));
 	if (*tz == icu::TimeZone::getUnknown()) {
 		delete tz;
-		throw NotImplementedException("Unknown TimeZone '%s'", tz_id.GetString());
+		return false;
 	}
 	calendar->adoptTimeZone(tz);
+	return true;
+}
+
+void ICUDateFunc::SetTimeZone(icu::Calendar *calendar, const string_t &tz_id) {
+	if (!TrySetTimeZone(calendar, tz_id)) {
+		throw NotImplementedException("Unknown TimeZone '%s'", tz_id.GetString());
+	}
 }
 
 timestamp_t ICUDateFunc::GetTimeUnsafe(icu::Calendar *calendar, uint64_t micros) {

--- a/extension/icu/include/icu-datefunc.hpp
+++ b/extension/icu/include/icu-datefunc.hpp
@@ -49,7 +49,9 @@ struct ICUDateFunc {
 	static duckdb::unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
 	                                             vector<duckdb::unique_ptr<Expression>> &arguments);
 
-	//! Sets the time zone for the calendar.
+	//! Tries to set the time zone for the calendar and returns false if it is not valid.
+	static bool TrySetTimeZone(icu::Calendar *calendar, const string_t &tz_id);
+	//! Sets the time zone for the calendar. Throws if it is not valid
 	static void SetTimeZone(icu::Calendar *calendar, const string_t &tz_id);
 	//! Gets the timestamp from the calendar, throwing if it is not in range.
 	static bool TryGetTime(icu::Calendar *calendar, uint64_t micros, timestamp_t &result);

--- a/test/sql/function/timestamp/test_icu_strptime.test
+++ b/test/sql/function/timestamp/test_icu_strptime.test
@@ -589,3 +589,9 @@ statement error
 SELECT TIMESTAMPTZ '294247-01-10 04:00:54.7758';
 ----
 Conversion Error: ICU date overflows timestamp range
+
+# Invalid time zones should produce NULL, not an error
+query I
+select try_strptime('2015-01-05 00:00:00 FNORD', '%Y-%m-%d %H:%M:%S %Z');
+----
+NULL


### PR DESCRIPTION
* Refactor SetTimeZone to call new TrySetTimeZone
* Pull strptime time zone checks out of ToMicros.

fixes: duckdb/duckdb#16407
fixes: dudblabs/duckdb-internal#4313