### PR TITLE
Internal #4303: Windowed DISTINCT Leaks

### DIFF
--- a/src/function/window/window_aggregate_states.cpp
+++ b/src/function/window/window_aggregate_states.cpp
@@ -7,6 +7,9 @@ WindowAggregateStates::WindowAggregateStates(const AggregateObject &aggr)
 }
 
 void WindowAggregateStates::Initialize(idx_t count) {
+	// Don't leak - every Initialize must be matched with a Destroy
+	D_ASSERT(states.empty());
+
 	states.resize(count * state_size);
 	auto state_ptr = states.data();
 

--- a/src/function/window/window_distinct_aggregator.cpp
+++ b/src/function/window/window_distinct_aggregator.cpp
@@ -744,6 +744,9 @@ void WindowDistinctAggregatorLocalState::Evaluate(const WindowDistinctAggregator
 
 	//	Finalise the result aggregates and write to the result
 	statef.Finalize(result);
+
+	//	Destruct any non-POD state
+	statef.Destroy();
 }
 
 unique_ptr<WindowAggregatorState> WindowDistinctAggregator::GetLocalState(const WindowAggregatorState &gstate) const {


### PR DESCRIPTION
* Destroy chunk level states instead of leaking them.

fixes: duckdblabs/duckdb-internal#4303