### PR TITLE
Python: allow `relation.project()` to be called with both Expressions and strings

### DIFF
--- a/tools/pythonpkg/tests/fast/test_relation.py
+++ b/tools/pythonpkg/tests/fast/test_relation.py
@@ -71,6 +71,16 @@ class TestRelation(object):
         rel = get_relation(conn)
         assert rel.order('j').execute().fetchall() == [(4, 'four'), (1, 'one'), (3, 'three'), (2, 'two')]
 
+    def test_projection_mixed_types(self):
+        conn = duckdb.connect()
+        rel = get_relation(conn)
+        assert rel.project('i', duckdb.ColumnExpression('j')).execute().fetchall() == [
+            (1, 'one'),
+            (2, 'two'),
+            (3, 'three'),
+            (4, 'four'),
+        ]
+
     def test_limit_operator(self):
         conn = duckdb.connect()
         rel = get_relation(conn)


### PR DESCRIPTION
This allows `project()` to be called with an argument list containing both `Expression`s and `str`s. The latter are converted using `Parser::ParseExpressionList()`.

The use case for this is to allow `project()` to take a list of expression strings instead of having to concatenate them using  `', '.join(...)` or some other means.

## Possible alternative

An alternative would be to expose parsing arbitrary expressions or expression lists to Python, and keep `project()` as is (i.e. taking either an `str` or a list of `Expression`s).

Something along these lines were requested in https://github.com/duckdb/duckdb/discussions/14696 using a proposed `SQLExpression` class, but the implementation chose to expose a `LambdaExpression` class instead.

Having an `SQLExpression` class would be superior in that it would allow`alias()`et al. to be specified, however this change is less invasive and works for me at the moment.

Please let me know if you folks would accept/merge either of these, or have something against exposing such functionality in general.

## Usage

```python
import duckdb
from pandas import DataFrame

print(
    duckdb.project(
        DataFrame.from_dict({"a": [1]}),
        duckdb.ColumnExpression("a"),
        "a + 2"
    )
)
```

```
┌───────┬─────────┐
│   a   │ (a + 2) │
│ int64 │  int64  │
├───────┼─────────┤
│     1 │       3 │
└───────┴─────────┘
```