### PR TITLE
Populate schemata.sql_path.

### DIFF
--- a/src/function/table/system/duckdb_schemas.cpp
+++ b/src/function/table/system/duckdb_schemas.cpp
@@ -86,8 +86,7 @@ void DuckDBSchemasFunction(ClientContext &context, TableFunctionInput &data_p, D
 		if (entry.catalog.IsSystemCatalog() || entry.catalog.InMemory()) {
 			output.SetValue(col++, count, Value());
 		} else {
-			const auto &db_path = Catalog::GetCatalog(entry.ParentCatalog().GetAttached()).GetDBPath();
-			output.SetValue(col++, count, Value(db_path));
+			output.SetValue(col++, count, Value(entry.catalog.GetDBPath()));
 		}
 
 		data.offset++;

--- a/src/function/table/system/duckdb_schemas.cpp
+++ b/src/function/table/system/duckdb_schemas.cpp
@@ -83,7 +83,12 @@ void DuckDBSchemasFunction(ClientContext &context, TableFunctionInput &data_p, D
 		// "internal", PhysicalType::BOOLEAN
 		output.SetValue(col++, count, Value::BOOLEAN(entry.internal));
 		// "sql", PhysicalType::VARCHAR
-		output.SetValue(col++, count, Value());
+		if (entry.catalog.IsSystemCatalog() || entry.catalog.InMemory()) {
+			output.SetValue(col++, count, Value());
+		} else {
+			const auto &db_path = Catalog::GetCatalog(entry.ParentCatalog().GetAttached()).GetDBPath();
+			output.SetValue(col++, count, Value(db_path));
+		}
 
 		data.offset++;
 		count++;

--- a/test/sql/table_function/information_schema.test
+++ b/test/sql/table_function/information_schema.test
@@ -138,3 +138,19 @@ query I
 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema='scheme'
 ----
 0
+
+statement ok
+ATTACH '__TEST_DIR__/schemata.db' AS fsdb
+
+query I
+SELECT sql_path = '__TEST_DIR__/schemata.db' FROM information_schema.schemata WHERE catalog_name = 'fsdb'
+----
+true
+
+statement ok
+DETACH fsdb;
+
+query I
+SELECT DISTINCT sql_path FROM information_schema.schemata WHERE catalog_name <> 'fsdb'
+----
+NULL


### PR DESCRIPTION
Implement `information_schema.schemata.sql_path` to conveniently see where attached databases are located. I wasn't sure the best way to get the path and would greatly appreciate any suggestions of a better way. Thanks!

https://duckdb.org/docs/sql/meta/information_schema.html#schemata-database-catalog-and-schema