### PR TITLE
Fix PyPi upload also for branches, when twine_upload is provided

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -50,7 +50,7 @@ jobs:
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
       run_all: ${{ inputs.run_all }}
-      twine_upload: ${{ inputs.twine_upload }}
+      override_twine_upload: ${{ inputs.twine_upload }}
 
   pyodide:
     uses: ./.github/workflows/Pyodide.yml

--- a/.github/workflows/OnTag.yml
+++ b/.github/workflows/OnTag.yml
@@ -14,6 +14,7 @@ jobs:
     secrets: inherit
     with:
       override_git_describe: ${{ inputs.override_git_describe || github.ref_name }}
+      twine_upload: 'true'
 
   staged_upload:
     uses: ./.github/workflows/StagedUpload.yml

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -10,7 +10,7 @@ on:
         type: string
       run_all:
         type: string
-      twine_upload:
+      override_twine_upload:
         type: string
   workflow_dispatch:
     inputs:
@@ -22,7 +22,7 @@ on:
         type: string
       run_all:
         type: string
-      twine_upload:
+      override_twine_upload:
         type: string
   push:
     branches-ignore:
@@ -469,8 +469,10 @@ jobs:
       - win-python3
       - linux-python3
     # Note that want to run this by default ONLY if no override_git_describe is provided
-    # This means we are not staging a release
-    if: (( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || inputs.twine_upload == 'true' )) && (( inputs.override_git_describe == '' )) && (( github.repository == 'duckdb/duckdb' ))
+    # This means we are not staging a release, or we explicitly set `twine_upload`
+    # Why? If present, it means we are staging releases, and we want to do the upload manually
+    if: (( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || inputs.override_twine_upload == 'true' )) && (( inputs.override_git_describe == '' )) && (( github.repository == 'duckdb/duckdb' ))
     uses: ./.github/workflows/TwineUpload.yml
     secrets: inherit
-    # Why? If present, it means we are staging releases, and we want to do the upload manually
+    with:
+      twine_upload: 'true'

--- a/.github/workflows/TwineUpload.yml
+++ b/.github/workflows/TwineUpload.yml
@@ -4,9 +4,13 @@ on:
     inputs:
       override_git_describe:
         type: string
+      twine_upload:
+        type: string
   workflow_dispatch:
     inputs:
       override_git_describe:
+        type: string
+      twine_upload:
         type: string
 
 env:
@@ -47,12 +51,13 @@ jobs:
           aws s3 cp --recursive "s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/twine_upload" to_be_uploaded --region us-east-2
 
       - name: Deploy
+        if: ${{ inputs.twine_upload == 'true' }}
         env:
           TWINE_USERNAME: '__token__'
           TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
         shell: bash
         run: |
           cd tools/pythonpkg
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
+          if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
             twine upload --non-interactive --disable-progress-bar --skip-existing to_be_uploaded/*
           fi


### PR DESCRIPTION
Moved conditions around, but should be the same as before but for providing a way to override the logic that says: either `override_git_describe` is provided or needs to be on `main` branch.

This can be used to distribute Python packages for branches.