### PR TITLE
[Dev] Mention the problematic type in UNNEST BinderException

### DIFF
--- a/src/planner/binder/expression/bind_unnest_expression.cpp
+++ b/src/planner/binder/expression/bind_unnest_expression.cpp
@@ -149,7 +149,8 @@ BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth, b
 	case LogicalTypeId::SQLNULL:
 		break;
 	default:
-		return BindResult(BinderException(function, "UNNEST() can only be applied to lists, structs and NULL"));
+		return BindResult(BinderException(function, "UNNEST() can only be applied to lists, structs and NULL, not %s",
+		                                  child_type.ToString()));
 	}
 
 	idx_t list_unnests;


### PR DESCRIPTION
Addresses an issue found in <https://github.com/duckdb/duckdb/issues/16428>

New error message from the referenced issue:
```
Binder Error: UNNEST() can only be applied to lists, structs and NULL, not JSON
``` 