### PR TITLE
Python Client: Faster Python Object Conversion

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
@@ -47,8 +47,7 @@ PythonObjectType GetPythonObjectType(py::handle &ele);
 
 bool TryTransformPythonNumeric(Value &res, py::handle ele, const LogicalType &target_type = LogicalType::UNKNOWN);
 bool DictionaryHasMapFormat(const PyDictionary &dict);
-void TransformPythonObject(py::handle ele, Vector &vector, idx_t result_offset,
-						   bool nan_as_null = true);
+void TransformPythonObject(py::handle ele, Vector &vector, idx_t result_offset, bool nan_as_null = true);
 Value TransformPythonValue(py::handle ele, const LogicalType &target_type = LogicalType::UNKNOWN,
                            bool nan_as_null = true);
 

--- a/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_conversion.hpp
@@ -47,6 +47,8 @@ PythonObjectType GetPythonObjectType(py::handle &ele);
 
 bool TryTransformPythonNumeric(Value &res, py::handle ele, const LogicalType &target_type = LogicalType::UNKNOWN);
 bool DictionaryHasMapFormat(const PyDictionary &dict);
+void TransformPythonObject(py::handle ele, Vector &vector, idx_t result_offset,
+						   bool nan_as_null = true);
 Value TransformPythonValue(py::handle ele, const LogicalType &target_type = LogicalType::UNKNOWN,
                            bool nan_as_null = true);
 

--- a/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_objects.hpp
@@ -185,6 +185,7 @@ public:
 	int32_t day;
 
 public:
+	date_t ToDate();
 	Value ToDuckValue();
 };
 

--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -958,7 +958,17 @@ void TransformPythonObjectInternal(py::handle ele, A &result, const B &param,
 	}
 	case PythonObjectType::Tuple: {
 		auto list_size = py::len(ele);
-		OP::HandleTuple(result, param, ele, list_size);
+		auto &conversion_target = OP::ConversionTarget(result, param);
+		switch (conversion_target.id()) {
+		case LogicalTypeId::STRUCT:
+		case LogicalTypeId::UNKNOWN:
+		case LogicalTypeId::LIST:
+		case LogicalTypeId::ARRAY:
+			OP::HandleTuple(result, param, ele, list_size);
+			break;
+		default:
+			throw InvalidInputException("Can't convert tuple to a Value of type %s", conversion_target);
+		}
 		break;
 	}
 	case PythonObjectType::String: {

--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -520,10 +520,10 @@ struct PythonValueConversion {
 		result = Value(val).DefaultCastAs(cast_as);
 	}
 	static void HandleLongAsDouble(Value &result, const LogicalType &target_type, double val) {
-		result = Value::DOUBLE(val);
+		result = Value::DOUBLE(val).DefaultCastAs(target_type);
 	}
 	static void HandleUnsignedBigint(Value &result, const LogicalType &target_type, uint64_t val) {
-		result = Value::UBIGINT(val);
+		result = Value::UBIGINT(val).DefaultCastAs(target_type);
 	}
 	static void HandleBigint(Value &res, const LogicalType &target_type, int64_t value) {
 		switch (target_type.id()) {

--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -520,10 +520,12 @@ struct PythonValueConversion {
 		result = Value(val).DefaultCastAs(cast_as);
 	}
 	static void HandleLongAsDouble(Value &result, const LogicalType &target_type, double val) {
-		result = Value::DOUBLE(val).DefaultCastAs(target_type);
+		auto cast_as = target_type.id() == LogicalTypeId::UNKNOWN ? LogicalType::DOUBLE : target_type;
+		result = Value::DOUBLE(val).DefaultCastAs(cast_as);
 	}
 	static void HandleUnsignedBigint(Value &result, const LogicalType &target_type, uint64_t val) {
-		result = Value::UBIGINT(val).DefaultCastAs(target_type);
+		auto cast_as = target_type.id() == LogicalTypeId::UNKNOWN ? LogicalType::UBIGINT : target_type;
+		result = Value::UBIGINT(val).DefaultCastAs(cast_as);
 	}
 	static void HandleBigint(Value &res, const LogicalType &target_type, int64_t value) {
 		switch (target_type.id()) {

--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -817,7 +817,7 @@ struct PythonVectorConversion {
 			auto &child_array = ArrayVector::GetEntry(result);
 			idx_t start_offset = result_offset * array_size;
 			for(idx_t i = 0; i < list_size; i++) {
-				auto child_ele = ele.attr("__getitem__")(i);
+				auto child_ele = PyList_GetItem(ele.ptr(), i);
 				TransformPythonObject(child_ele, child_array, start_offset + i);
 			}
 			return;
@@ -835,7 +835,7 @@ struct PythonVectorConversion {
 			// convert the child elements
 			auto &child_vector = ListVector::GetEntry(result);
 			for(idx_t i = 0; i < list_size; i++) {
-				auto child_ele = ele.attr("__getitem__")(i);
+				auto child_ele = PyList_GetItem(ele.ptr(), i);
 				TransformPythonObject(child_ele, child_vector, start_offset + i);
 			}
 			ListVector::SetListSize(result, start_offset + list_size);

--- a/tools/pythonpkg/src/native/python_objects.cpp
+++ b/tools/pythonpkg/src/native/python_objects.cpp
@@ -360,6 +360,10 @@ PyDate::PyDate(py::handle &ele) {
 	day = PyDateTime::GetDays(ele);
 }
 
+date_t PyDate::ToDate() {
+	return Date::FromDate(year, month, day);
+}
+
 Value PyDate::ToDuckValue() {
 	auto value = Value::DATE(year, month, day);
 	return value;

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -144,16 +144,13 @@ static void SetInvalidRecursive(Vector &out, idx_t index) {
 //! 'count' is the amount of rows in the 'out' vector
 //! 'offset' is the current row number within this vector
 void ScanNumpyObject(PyObject *object, idx_t offset, Vector &out) {
-
 	// handle None
 	if (object == Py_None) {
 		SetInvalidRecursive(out, offset);
 		return;
 	}
 
-	auto val = TransformPythonValue(object, out.GetType());
-	// Check if the Value type is accepted for the LogicalType of Vector
-	out.SetValue(offset, val);
+	TransformPythonObject(object, out, offset);
 }
 
 static void VerifyMapConstraints(Vector &vec, idx_t count) {
@@ -184,7 +181,6 @@ void VerifyTypeConstraints(Vector &vec, idx_t count) {
 void NumpyScan::ScanObjectColumn(PyObject **col, idx_t stride, idx_t count, idx_t offset, Vector &out) {
 	// numpy_col is a sequential list of objects, that make up one "column" (Vector)
 	out.SetVectorType(VectorType::FLAT_VECTOR);
-	auto &mask = FlatVector::Validity(out);
 	PythonGILWrapper gil; // We're creating python objects here, so we need the GIL
 
 	if (stride == sizeof(PyObject *)) {


### PR DESCRIPTION
This PR reworks the Python Object conversion to directly convert many types into a result `Vector` instead of first going through a `duckdb::Value`, leading to significantly faster conversion. This is particulary relevant for converting `object` columns, and for Python scalar UDFs.

For example, consider the following script converting a large list of Python objects:


```py
import duckdb
import time

def int_list_udf(input) -> list[int]:
    return list(range(100000))
con = duckdb.connect()

con.create_function('int_list_udf', int_list_udf, return_type=list[int])


start = time.time()
print(con.sql("SELECT SUM(LIST_SUM(int_list_udf(x))) AS x FROM range(100) t(x);").df())
end = time.time()
print(end - start)
```

| v1.2 | New  |
|------|------|
| 2.1s | 0.3s |