### PR TITLE
Update flaky return_files.test

### DIFF
--- a/test/sql/copy/return_files.test
+++ b/test/sql/copy/return_files.test
@@ -26,6 +26,8 @@ COPY integers TO '__TEST_DIR__/test_batch_copy_to_file.parquet' (RETURN_FILES TR
 statement ok
 SET threads=2;
 
+# as mentioned in per_thread_output.test, the number of files do not necessarily match the number of threads
+# here, we check if the number of rows are correct and at least one file has been written.
 query II
 COPY integers TO '__TEST_DIR__/test_per_thread_output' (RETURN_FILES, PER_THREAD_OUTPUT);
 ----

--- a/test/sql/copy/return_files.test
+++ b/test/sql/copy/return_files.test
@@ -29,7 +29,7 @@ SET threads=2;
 query II
 COPY integers TO '__TEST_DIR__/test_per_thread_output' (RETURN_FILES, PER_THREAD_OUTPUT);
 ----
-200000	<REGEX>:.*data_0.csv.*data_1.csv.*
+200000	<REGEX>:.*data_0.csv.*
 
 require notwindows
 


### PR DESCRIPTION
Even when PER_THREAD_OUTPUT is set to true, the number of files written with `COPY TO` may not match the number of threads as described in  a [comment here](https://github.com/duckdb/duckdb/blob/527f651b6939247fb3a8486e84140f795a73581b/test/sql/copy/per_thread_output.test#L24-L27). 
Therefore, I updated the return_files test to check if the number of rows are correct and at least one file has been written.