### PR TITLE
[Python Dev] No longer trigger a DeprecationWarning when using a UDF

### DIFF
--- a/tools/pythonpkg/scripts/cache_data.json
+++ b/tools/pythonpkg/scripts/cache_data.json
@@ -312,7 +312,6 @@
         "full_path": "numpy",
         "name": "numpy",
         "children": [
-            "numpy.core",
             "numpy.ma",
             "numpy.ndarray",
             "numpy.datetime64",
@@ -338,20 +337,6 @@
             "numpy.clongdouble"
         ],
         "required": false
-    },
-    "numpy.core": {
-        "type": "attribute",
-        "full_path": "numpy.core",
-        "name": "core",
-        "children": [
-            "numpy.core.multiarray"
-        ]
-    },
-    "numpy.core.multiarray": {
-        "type": "attribute",
-        "full_path": "numpy.core.multiarray",
-        "name": "multiarray",
-        "children": []
     },
     "numpy.ma": {
         "type": "attribute",

--- a/tools/pythonpkg/scripts/imports.py
+++ b/tools/pythonpkg/scripts/imports.py
@@ -55,7 +55,6 @@ ipywidgets.FloatProgress
 
 import numpy
 
-numpy.core.multiarray
 numpy.ma.masked
 numpy.ma.masked_array
 numpy.ndarray

--- a/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/numpy_module.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/import_cache/modules/numpy_module.hpp
@@ -26,18 +26,6 @@ public:
 	PythonImportCacheItem masked_array;
 };
 
-struct NumpyCoreCacheItem : public PythonImportCacheItem {
-
-public:
-	NumpyCoreCacheItem(optional_ptr<PythonImportCacheItem> parent)
-	    : PythonImportCacheItem("core", parent), multiarray("multiarray", this) {
-	}
-	~NumpyCoreCacheItem() override {
-	}
-
-	PythonImportCacheItem multiarray;
-};
-
 struct NumpyCacheItem : public PythonImportCacheItem {
 
 public:
@@ -45,9 +33,9 @@ public:
 
 public:
 	NumpyCacheItem()
-	    : PythonImportCacheItem("numpy"), core(this), ma(this), ndarray("ndarray", this),
-	      datetime64("datetime64", this), generic("generic", this), int64("int64", this), bool_("bool_", this),
-	      byte("byte", this), ubyte("ubyte", this), short_("short", this), ushort_("ushort", this), intc("intc", this),
+	    : PythonImportCacheItem("numpy"), ma(this), ndarray("ndarray", this), datetime64("datetime64", this),
+	      generic("generic", this), int64("int64", this), bool_("bool_", this), byte("byte", this),
+	      ubyte("ubyte", this), short_("short", this), ushort_("ushort", this), intc("intc", this),
 	      uintc("uintc", this), int_("int_", this), uint("uint", this), longlong("longlong", this),
 	      ulonglong("ulonglong", this), half("half", this), float16("float16", this), single("single", this),
 	      longdouble("longdouble", this), csingle("csingle", this), cdouble("cdouble", this),
@@ -56,7 +44,6 @@ public:
 	~NumpyCacheItem() override {
 	}
 
-	NumpyCoreCacheItem core;
 	NumpyMaCacheItem ma;
 	PythonImportCacheItem ndarray;
 	PythonImportCacheItem datetime64;


### PR DESCRIPTION
This PR fixes #16370

Numpy has deprecated access to `numpy.core` in 2.0.0, we need to make sure `multiarray` does not get imported by a non-main thread for the first time, as this causes a segfault.

`multiarray` is sadly not exposed through the public API, so we kind of jump through a couple hoops to not trigger the warning anymore, while still remaining backwards compatible.

What does scare me a little is that I did not run into the DeprecationWarning during testing, so I wonder if accessing `multiarray` in this roundabout fashion is taking the right path, if it's not then we could still run the risk of running into the aforementioned segfault.