### PR TITLE
[no-op] Remove unused function `GetValueRefUnsafe`

### DIFF
--- a/src/include/duckdb/common/types/value.hpp
+++ b/src/include/duckdb/common/types/value.hpp
@@ -208,9 +208,6 @@ public:
 	// type of the value. Only use this if you know what you are doing.
 	template <class T>
 	T GetValueUnsafe() const;
-	//! Returns a reference to the internal value. This can only be used for primitive types.
-	template <class T>
-	T &GetReferenceUnsafe();
 
 	//! Return a copy of this value
 	Value Copy() const {


### PR DESCRIPTION
This PR should be a no-op, search through the codebase, I found the function is not used anywhere.
```
src/include/duckdb/common/types/value.hpp:      T &GetReferenceUnsafe();
src/include/duckdb/storage/statistics/numeric_stats.hpp:                nstats.max.GetReferenceUnsafe<T>() = val;
src/include/duckdb/storage/statistics/numeric_stats.hpp:                nstats.min.GetReferenceUnsafe<T>() = val;
src/include/duckdb/storage/statistics/numeric_stats.hpp:                UpdateValue<T>(new_value, nstats.min.GetReferenceUnsafe<T>(), nstats.max.GetReferenceUnsafe<T>());
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:  T &GetReferenceUnsafe();
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline bool &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline int8_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline int16_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline int32_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline int64_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline hugeint_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline uhugeint_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline uint8_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline uint16_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline uint32_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline uint64_t &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline float &NumericValueUnion::GetReferenceUnsafe() {
src/include/duckdb/storage/statistics/numeric_stats_union.hpp:DUCKDB_API inline double &NumericValueUnion::GetReferenceUnsafe() {
```

How I tested:
- I compile the duckdb with `CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make` and it compiles without issue
- For these type of changes, compilation/link success (usually) indicates no problem