### PR TITLE
Bump delta to working commit

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -56,7 +56,7 @@ endif()
 if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
-            GIT_TAG 846019edcc27000721ff9c4281e85a63d1aa10de
+            GIT_TAG 6d626173e9efa6615c25eb08d979d1372100d5db
     )
 endif()
 


### PR DESCRIPTION
Example of build problems:
- v1.2-histrionicus: https://github.com/duckdb/duckdb/actions/runs/13556221109
- main: https://github.com/duckdb/duckdb/actions/runs/13556221101

This is against `v1.2-histrionicus` branch, so that it can then later merged in `main` while keeping the config aligned.