### PR TITLE
Filter Combiner Clean-up: move filter pushdown to separate functions, remove old commented out code

### DIFF
--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -53,50 +53,17 @@ public:
 	void GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback);
 	bool HasFilters();
 	TableFilterSet GenerateTableScanFilters(const vector<ColumnIndex> &column_ids);
-	// vector<unique_ptr<TableFilter>> GenerateZonemapChecks(vector<idx_t> &column_ids, vector<unique_ptr<TableFilter>>
-	// &pushed_filters);
 
 private:
 	FilterResult AddFilter(Expression &expr);
 	FilterResult AddBoundComparisonFilter(Expression &expr);
 	FilterResult AddTransitiveFilters(BoundComparisonExpression &comparison, bool is_root = true);
 	unique_ptr<Expression> FindTransitiveFilter(Expression &expr);
-	// unordered_map<idx_t, std::pair<Value *, Value *>>
-	// FindZonemapChecks(vector<idx_t> &column_ids, unordered_set<idx_t> &not_constants, Expression *filter);
 	Expression &GetNode(Expression &expr);
 	idx_t GetEquivalenceSet(Expression &expr);
 	FilterResult AddConstantComparison(vector<ExpressionValueInformation> &info_list, ExpressionValueInformation info);
-	//
-	//	//! Functions used to push and generate OR Filters
-	//	void LookUpConjunctions(Expression *expr);
-	//	bool BFSLookUpConjunctions(BoundConjunctionExpression *conjunction);
-	//	void VerifyOrsToPush(Expression &expr);
-	//
-	//	bool UpdateConjunctionFilter(BoundComparisonExpression *comparison_expr);
-	//	bool UpdateFilterByColumn(BoundColumnRefExpression *column_ref, BoundComparisonExpression *comparison_expr);
-	//	void GenerateORFilters(TableFilterSet &table_filter, vector<idx_t> &column_ids);
-	//
-	//	template <typename CONJUNCTION_TYPE>
-	//	void GenerateConjunctionFilter(BoundConjunctionExpression *conjunction, ConjunctionFilter *last_conj_filter) {
-	//		auto new_filter = NextConjunctionFilter<CONJUNCTION_TYPE>(conjunction);
-	//		auto conj_filter_ptr = (ConjunctionFilter *)new_filter.get();
-	//		last_conj_filter->child_filters.push_back(std::move(new_filter));
-	//		last_conj_filter = conj_filter_ptr;
-	//	}
-	//
-	//	template <typename CONJUNCTION_TYPE>
-	//	unique_ptr<TableFilter> NextConjunctionFilter(BoundConjunctionExpression *conjunction) {
-	//		unique_ptr<ConjunctionFilter> conj_filter = make_uniq<CONJUNCTION_TYPE>();
-	//		for (auto &expr : conjunction->children) {
-	//			auto comp_expr = (BoundComparisonExpression *)expr.get();
-	//			auto &const_expr =
-	//			    (comp_expr->left->type == ExpressionType::VALUE_CONSTANT) ? *comp_expr->left : *comp_expr->right;
-	//			auto const_value = ExpressionExecutor::EvaluateScalar(const_expr);
-	//			auto const_filter = make_uniq<ConstantFilter>(comp_expr->type, const_value);
-	//			conj_filter->child_filters.push_back(std::move(const_filter));
-	//		}
-	//		return std::move(conj_filter);
-	//	}
+
+	bool TryGenerateConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids, column_t column_id, vector<ExpressionValueInformation> &info_list);
 
 private:
 	vector<unique_ptr<Expression>> remaining_filters;
@@ -106,26 +73,6 @@ private:
 	map<idx_t, vector<ExpressionValueInformation>> constant_values;
 	map<idx_t, vector<reference<Expression>>> equivalence_map;
 	idx_t set_index = 0;
-	//
-	//	//! Structures used for OR Filters
-	//
-	//	struct ConjunctionsToPush {
-	//		BoundConjunctionExpression *root_or;
-	//
-	//		// only preserve AND if there is a single column in the expression
-	//		bool preserve_and = true;
-	//
-	//		// conjunction chain for this column
-	//		vector<unique_ptr<BoundConjunctionExpression>> conjunctions;
-	//	};
-	//
-	//	expression_map_t<vector<unique_ptr<ConjunctionsToPush>>> map_col_conjunctions;
-	//	vector<BoundColumnRefExpression *> vec_colref_insertion_order;
-	//
-	//	BoundConjunctionExpression *cur_root_or;
-	//	BoundConjunctionExpression *cur_conjunction;
-	//
-	//	BoundColumnRefExpression *cur_colref_to_push;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -24,6 +24,7 @@ class Optimizer;
 
 enum class ValueComparisonResult { PRUNE_LEFT, PRUNE_RIGHT, UNSATISFIABLE_CONDITION, PRUNE_NOTHING };
 enum class FilterResult { UNSATISFIABLE, SUCCESS, UNSUPPORTED };
+enum class FilterPushdownResult { NO_PUSHDOWN, PUSHED_DOWN_PARTIALLY, PUSHED_DOWN_FULLY };
 
 //! The FilterCombiner combines several filters and generates a logically equivalent set that is more efficient
 //! Amongst others:
@@ -63,10 +64,14 @@ private:
 	idx_t GetEquivalenceSet(Expression &expr);
 	FilterResult AddConstantComparison(vector<ExpressionValueInformation> &info_list, ExpressionValueInformation info);
 
-	bool TryGenerateConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
-	                               column_t column_id, vector<ExpressionValueInformation> &info_list);
-	bool TryGeneratePrefixFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
-	                             Expression &expr);
+	FilterPushdownResult TryGenerateConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                               column_t column_id, vector<ExpressionValueInformation> &info_list);
+	FilterPushdownResult TryPushdownExpression(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                           Expression &expr);
+	FilterPushdownResult TryGeneratePrefixFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                             Expression &expr);
+	FilterPushdownResult TryGenerateLikeFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                           Expression &expr);
 
 private:
 	vector<unique_ptr<Expression>> remaining_filters;

--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -64,14 +64,16 @@ private:
 	idx_t GetEquivalenceSet(Expression &expr);
 	FilterResult AddConstantComparison(vector<ExpressionValueInformation> &info_list, ExpressionValueInformation info);
 
-	FilterPushdownResult TryGenerateConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	FilterPushdownResult TryPushdownConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                               column_t column_id, vector<ExpressionValueInformation> &info_list);
 	FilterPushdownResult TryPushdownExpression(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                           Expression &expr);
-	FilterPushdownResult TryGeneratePrefixFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	FilterPushdownResult TryPushdownPrefixFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                             Expression &expr);
-	FilterPushdownResult TryGenerateLikeFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	FilterPushdownResult TryPushdownLikeFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                           Expression &expr);
+	FilterPushdownResult TryPushdownInFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                         Expression &expr);
 
 private:
 	vector<unique_ptr<Expression>> remaining_filters;

--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -74,6 +74,8 @@ private:
 	                                           Expression &expr);
 	FilterPushdownResult TryPushdownInFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                         Expression &expr);
+	FilterPushdownResult TryPushdownOrClause(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                         Expression &expr);
 
 private:
 	vector<unique_ptr<Expression>> remaining_filters;

--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -63,7 +63,10 @@ private:
 	idx_t GetEquivalenceSet(Expression &expr);
 	FilterResult AddConstantComparison(vector<ExpressionValueInformation> &info_list, ExpressionValueInformation info);
 
-	bool TryGenerateConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids, column_t column_id, vector<ExpressionValueInformation> &info_list);
+	bool TryGenerateConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                               column_t column_id, vector<ExpressionValueInformation> &info_list);
+	bool TryGeneratePrefixFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                             Expression &expr);
 
 private:
 	vector<unique_ptr<Expression>> remaining_filters;

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -181,224 +181,6 @@ bool FilterCombiner::HasFilters() {
 	return has_filters;
 }
 
-// unordered_map<idx_t, std::pair<Value *, Value *>> MergeAnd(unordered_map<idx_t, std::pair<Value *, Value *>> &f_1,
-//                                                            unordered_map<idx_t, std::pair<Value *, Value *>> &f_2) {
-// 	unordered_map<idx_t, std::pair<Value *, Value *>> result;
-// 	for (auto &f : f_1) {
-// 		auto it = f_2.find(f.first);
-// 		if (it == f_2.end()) {
-// 			result[f.first] = f.second;
-// 		} else {
-// 			Value *min = nullptr, *max = nullptr;
-// 			if (it->second.first && f.second.first) {
-// 				if (*f.second.first > *it->second.first) {
-// 					min = f.second.first;
-// 				} else {
-// 					min = it->second.first;
-// 				}
-
-// 			} else if (it->second.first) {
-// 				min = it->second.first;
-// 			} else if (f.second.first) {
-// 				min = f.second.first;
-// 			} else {
-// 				min = nullptr;
-// 			}
-// 			if (it->second.second && f.second.second) {
-// 				if (*f.second.second < *it->second.second) {
-// 					max = f.second.second;
-// 				} else {
-// 					max = it->second.second;
-// 				}
-// 			} else if (it->second.second) {
-// 				max = it->second.second;
-// 			} else if (f.second.second) {
-// 				max = f.second.second;
-// 			} else {
-// 				max = nullptr;
-// 			}
-// 			result[f.first] = {min, max};
-// 			f_2.erase(f.first);
-// 		}
-// 	}
-// 	for (auto &f : f_2) {
-// 		result[f.first] = f.second;
-// 	}
-// 	return result;
-// }
-
-// unordered_map<idx_t, std::pair<Value *, Value *>> MergeOr(unordered_map<idx_t, std::pair<Value *, Value *>> &f_1,
-//                                                           unordered_map<idx_t, std::pair<Value *, Value *>> &f_2) {
-// 	unordered_map<idx_t, std::pair<Value *, Value *>> result;
-// 	for (auto &f : f_1) {
-// 		auto it = f_2.find(f.first);
-// 		if (it != f_2.end()) {
-// 			Value *min = nullptr, *max = nullptr;
-// 			if (it->second.first && f.second.first) {
-// 				if (*f.second.first < *it->second.first) {
-// 					min = f.second.first;
-// 				} else {
-// 					min = it->second.first;
-// 				}
-// 			}
-// 			if (it->second.second && f.second.second) {
-// 				if (*f.second.second > *it->second.second) {
-// 					max = f.second.second;
-// 				} else {
-// 					max = it->second.second;
-// 				}
-// 			}
-// 			result[f.first] = {min, max};
-// 			f_2.erase(f.first);
-// 		}
-// 	}
-// 	return result;
-// }
-
-// unordered_map<idx_t, std::pair<Value *, Value *>>
-// FilterCombiner::FindZonemapChecks(vector<idx_t> &column_ids, unordered_set<idx_t> &not_constants, Expression *filter)
-// { 	unordered_map<idx_t, std::pair<Value *, Value *>> checks; 	switch (filter->type) { 	case
-// ExpressionType::CONJUNCTION_OR: {
-// 		//! For a filter to
-// 		auto &or_exp = filter->Cast<BoundConjunctionExpression>();
-// 		checks = FindZonemapChecks(column_ids, not_constants, or_exp.children[0].get());
-// 		for (size_t i = 1; i < or_exp.children.size(); ++i) {
-// 			auto child_check = FindZonemapChecks(column_ids, not_constants, or_exp.children[i].get());
-// 			checks = MergeOr(checks, child_check);
-// 		}
-// 		return checks;
-// 	}
-// 	case ExpressionType::CONJUNCTION_AND: {
-// 		auto &and_exp = filter->Cast<BoundConjunctionExpression>();
-// 		checks = FindZonemapChecks(column_ids, not_constants, and_exp.children[0].get());
-// 		for (size_t i = 1; i < and_exp.children.size(); ++i) {
-// 			auto child_check = FindZonemapChecks(column_ids, not_constants, and_exp.children[i].get());
-// 			checks = MergeAnd(checks, child_check);
-// 		}
-// 		return checks;
-// 	}
-// 	case ExpressionType::COMPARE_IN: {
-// 		auto &comp_in_exp = filter->Cast<BoundOperatorExpression>();
-// 		if (comp_in_exp.children[0]->type == ExpressionType::BOUND_COLUMN_REF) {
-// 			Value *min = nullptr, *max = nullptr;
-// 			auto &column_ref = comp_in_exp.children[0]->Cast<BoundColumnRefExpression>();
-// 			for (size_t i {1}; i < comp_in_exp.children.size(); i++) {
-// 				if (comp_in_exp.children[i]->type != ExpressionType::VALUE_CONSTANT) {
-// 					//! This indicates the column has a comparison that is not with a constant
-// 					not_constants.insert(column_ids[column_ref.binding.column_index]);
-// 					break;
-// 				} else {
-// 					auto &const_value_expr = comp_in_exp.children[i]->Cast<BoundConstantExpression>();
-// 					if (const_value_expr.value.IsNull()) {
-// 						return checks;
-// 					}
-// 					if (!min && !max) {
-// 						min = &const_value_expr.value;
-// 						max = min;
-// 					} else {
-// 						if (*min > const_value_expr.value) {
-// 							min = &const_value_expr.value;
-// 						}
-// 						if (*max < const_value_expr.value) {
-// 							max = &const_value_expr.value;
-// 						}
-// 					}
-// 				}
-// 			}
-// 			checks[column_ids[column_ref.binding.column_index]] = {min, max};
-// 		}
-// 		return checks;
-// 	}
-// 	case ExpressionType::COMPARE_EQUAL: {
-// 		auto &comp_exp = filter->Cast<BoundComparisonExpression>();
-// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
-// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_CONSTANT)) {
-// 			auto &column_ref = comp_exp.left->Cast<BoundColumnRefExpression>();
-// 			auto &constant_value_expr = comp_exp.right->Cast<BoundConstantExpression>();
-// 			checks[column_ids[column_ref.binding.column_index]] = {&constant_value_expr.value,
-// 			                                                       &constant_value_expr.value};
-// 		}
-// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_CONSTANT &&
-// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_COLUMN_REF)) {
-// 			auto &column_ref = comp_exp.right->Cast<BoundColumnRefExpression>();
-// 			auto &constant_value_expr = comp_exp.left->Cast<BoundConstantExpression>();
-// 			checks[column_ids[column_ref.binding.column_index]] = {&constant_value_expr.value,
-// 			                                                       &constant_value_expr.value};
-// 		}
-// 		return checks;
-// 	}
-// 	case ExpressionType::COMPARE_LESSTHAN:
-// 	case ExpressionType::COMPARE_LESSTHANOREQUALTO: {
-// 		auto &comp_exp = filter->Cast<BoundComparisonExpression>();
-// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
-// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_CONSTANT)) {
-// 			auto &column_ref = comp_exp.left->Cast<BoundColumnRefExpression>();
-// 			auto &constant_value_expr = comp_exp.right->Cast<BoundConstantExpression>();
-// 			checks[column_ids[column_ref.binding.column_index]] = {nullptr, &constant_value_expr.value};
-// 		}
-// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_CONSTANT &&
-// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_COLUMN_REF)) {
-// 			auto &column_ref = comp_exp.right->Cast<BoundColumnRefExpression>();
-// 			auto &constant_value_expr = comp_exp.left->Cast<BoundConstantExpression>();
-// 			checks[column_ids[column_ref.binding.column_index]] = {&constant_value_expr.value, nullptr};
-// 		}
-// 		return checks;
-// 	}
-// 	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-// 	case ExpressionType::COMPARE_GREATERTHAN: {
-// 		auto &comp_exp = filter->Cast<BoundComparisonExpression>();
-// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
-// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_CONSTANT)) {
-// 			auto &column_ref = comp_exp.left->Cast<BoundColumnRefExpression>();
-// 			auto &constant_value_expr = comp_exp.right->Cast<BoundConstantExpression>();
-// 			checks[column_ids[column_ref.binding.column_index]] = {&constant_value_expr.value, nullptr};
-// 		}
-// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_CONSTANT &&
-// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_COLUMN_REF)) {
-// 			auto &column_ref = comp_exp.right->Cast<BoundColumnRefExpression>();
-// 			auto &constant_value_expr = comp_exp.left->Cast<BoundConstantExpression>();
-// 			checks[column_ids[column_ref.binding.column_index]] = {nullptr, &constant_value_expr.value};
-// 		}
-// 		return checks;
-// 	}
-// 	default:
-// 		return checks;
-// 	}
-// }
-
-// vector<TableFilter> FilterCombiner::GenerateZonemapChecks(vector<idx_t> &column_ids,
-//                                                           vector<TableFilter> &pushed_filters) {
-// 	vector<TableFilter> zonemap_checks;
-// 	unordered_set<idx_t> not_constants;
-// 	//! We go through the remaining filters and capture their min max
-// 	if (remaining_filters.empty()) {
-// 		return zonemap_checks;
-// 	}
-
-// 	auto checks = FindZonemapChecks(column_ids, not_constants, remaining_filters[0].get());
-// 	for (size_t i = 1; i < remaining_filters.size(); ++i) {
-// 		auto child_check = FindZonemapChecks(column_ids, not_constants, remaining_filters[i].get());
-// 		checks = MergeAnd(checks, child_check);
-// 	}
-// 	//! We construct the equivalent filters
-// 	for (auto not_constant : not_constants) {
-// 		checks.erase(not_constant);
-// 	}
-// 	for (const auto &pushed_filter : pushed_filters) {
-// 		checks.erase(column_ids[pushed_filter.column_index]);
-// 	}
-// 	for (const auto &check : checks) {
-// 		if (check.second.first) {
-// 			zonemap_checks.emplace_back(check.second.first->Copy(), ExpressionType::COMPARE_GREATERTHANOREQUALTO,
-// 			                            check.first);
-// 		}
-// 		if (check.second.second) {
-// 			zonemap_checks.emplace_back(check.second.second->Copy(), ExpressionType::COMPARE_LESSTHANOREQUALTO,
-// 			                            check.first);
-// 		}
-// 	}
-// 	return zonemap_checks;
-// }
 
 // Try to extract a column index from a bound column ref expression, or a column ref recursively nested
 // inside of a struct_extract call. If the expression is not a column ref (or nested column ref), return false.
@@ -480,47 +262,68 @@ bool FilterCombiner::IsDenseRange(vector<Value> &in_list) {
 	return true;
 }
 
+static bool SupportedFilterComparison(ExpressionType expression_type) {
+	switch(expression_type) {
+	case ExpressionType::COMPARE_EQUAL:
+	case ExpressionType::COMPARE_GREATERTHAN:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return true;
+	default:
+			return false;
+	}
+}
+
+bool FilterCombiner::TryGenerateConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids, column_t column_id, vector<ExpressionValueInformation> &info_list) {
+	if (info_list.empty()) {
+		// no constants - already removed
+		return false;
+	}
+	auto filter_exp = equivalence_map.end();
+	auto &constant_info = info_list[0];
+	auto physical_type = constant_info.constant.type().InternalType();
+	// check if the type is supported
+	if (!TypeIsNumeric(physical_type) && physical_type != PhysicalType::VARCHAR && physical_type != PhysicalType::BOOL) {
+		// not supported
+		return false;
+	}
+	if (!SupportedFilterComparison(constant_info.comparison_type)) {
+		return false;
+	}
+	//! Here we check if these filters are column references
+	filter_exp = equivalence_map.find(column_id);
+
+	if (filter_exp->second.size() != 1) {
+		return false;
+	}
+
+	auto &expr = filter_exp->second[0];
+	auto equiv_set = filter_exp->first;
+
+	// Try to get the column index, either from bound column ref, or a column ref nested inside of a
+	// struct_extract call
+	ColumnIndex column_index;
+	if (!TryGetBoundColumnIndex(column_ids, expr, column_index)) {
+		return false;
+	}
+
+	auto &constant_list = constant_values.find(equiv_set)->second;
+	for (auto &constant_cmp : constant_list) {
+		auto constant_filter =
+			make_uniq<ConstantFilter>(constant_cmp.comparison_type, constant_cmp.constant);
+		table_filters.PushFilter(column_index, PushDownFilterIntoExpr(expr, std::move(constant_filter)));
+	}
+	equivalence_map.erase(filter_exp);
+	return true;
+}
+
 TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex> &column_ids) {
 	TableFilterSet table_filters;
 	//! First, we figure the filters that have constant expressions that we can push down to the table scan
 	for (auto &constant_value : constant_values) {
-		if (!constant_value.second.empty()) {
-			auto filter_exp = equivalence_map.end();
-			if ((constant_value.second[0].comparison_type == ExpressionType::COMPARE_EQUAL ||
-			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
-			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
-			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_LESSTHAN ||
-			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO ||
-			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_NOTEQUAL) &&
-			    (TypeIsNumeric(constant_value.second[0].constant.type().InternalType()) ||
-			     constant_value.second[0].constant.type().InternalType() == PhysicalType::VARCHAR ||
-			     constant_value.second[0].constant.type().InternalType() == PhysicalType::BOOL)) {
-				//! Here we check if these filters are column references
-				filter_exp = equivalence_map.find(constant_value.first);
-
-				if (filter_exp->second.size() != 1) {
-					continue;
-				}
-
-				auto &expr = filter_exp->second[0];
-				auto equiv_set = filter_exp->first;
-
-				// Try to get the column index, either from bound column ref, or a column ref nested inside of a
-				// struct_extract call
-				ColumnIndex column_index;
-				if (!TryGetBoundColumnIndex(column_ids, expr, column_index)) {
-					continue;
-				}
-
-				auto &constant_list = constant_values.find(equiv_set)->second;
-				for (auto &constant_cmp : constant_list) {
-					auto constant_filter =
-					    make_uniq<ConstantFilter>(constant_cmp.comparison_type, constant_cmp.constant);
-					table_filters.PushFilter(column_index, PushDownFilterIntoExpr(expr, std::move(constant_filter)));
-				}
-				equivalence_map.erase(filter_exp);
-			}
-		}
+		TryGenerateConstantFilter(table_filters, column_ids, constant_value.first, constant_value.second);
 	}
 	//! Here we look for LIKE or IN filters
 	for (idx_t rem_fil_idx = 0; rem_fil_idx < remaining_filters.size(); rem_fil_idx++) {
@@ -748,12 +551,7 @@ static bool IsLessThan(ExpressionType type) {
 
 FilterResult FilterCombiner::AddBoundComparisonFilter(Expression &expr) {
 	auto &comparison = expr.Cast<BoundComparisonExpression>();
-	if (comparison.GetExpressionType() != ExpressionType::COMPARE_LESSTHAN &&
-	    comparison.GetExpressionType() != ExpressionType::COMPARE_LESSTHANOREQUALTO &&
-	    comparison.GetExpressionType() != ExpressionType::COMPARE_GREATERTHAN &&
-	    comparison.GetExpressionType() != ExpressionType::COMPARE_GREATERTHANOREQUALTO &&
-	    comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL &&
-	    comparison.GetExpressionType() != ExpressionType::COMPARE_NOTEQUAL) {
+	if (!SupportedFilterComparison(comparison.GetExpressionType())) {
 		// only support [>, >=, <, <=, ==, !=] expressions
 		return FilterResult::UNSUPPORTED;
 	}
@@ -1246,175 +1044,5 @@ ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, 
 		return InvertValueComparisonResult(CompareValueInformation(right, left));
 	}
 }
-//
-// void FilterCombiner::LookUpConjunctions(Expression *expr) {
-//	if (expr->GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
-//		auto root_or_expr = (BoundConjunctionExpression *)expr;
-//		for (const auto &entry : map_col_conjunctions) {
-//			for (const auto &conjs_to_push : entry.second) {
-//				if (conjs_to_push->root_or->Equals(root_or_expr)) {
-//					return;
-//				}
-//			}
-//		}
-//
-//		cur_root_or = root_or_expr;
-//		cur_conjunction = root_or_expr;
-//		cur_colref_to_push = nullptr;
-//		if (!BFSLookUpConjunctions(cur_root_or)) {
-//			if (cur_colref_to_push) {
-//				auto entry = map_col_conjunctions.find(cur_colref_to_push);
-//				auto &vec_conjs_to_push = entry->second;
-//				if (vec_conjs_to_push.size() == 1) {
-//					map_col_conjunctions.erase(entry);
-//					return;
-//				}
-//				vec_conjs_to_push.pop_back();
-//			}
-//		}
-//		return;
-//	}
-//
-//	// Verify if the expression has a column already pushed down by other OR expression
-//	VerifyOrsToPush(*expr);
-//}
-//
-// bool FilterCombiner::BFSLookUpConjunctions(BoundConjunctionExpression *conjunction) {
-//	vector<BoundConjunctionExpression *> conjunctions_to_visit;
-//
-//	for (auto &child : conjunction->children) {
-//		switch (child->GetExpressionClass()) {
-//		case ExpressionClass::BOUND_CONJUNCTION: {
-//			auto child_conjunction = (BoundConjunctionExpression *)child.get();
-//			conjunctions_to_visit.emplace_back(child_conjunction);
-//			break;
-//		}
-//		case ExpressionClass::BOUND_COMPARISON: {
-//			if (!UpdateConjunctionFilter((BoundComparisonExpression *)child.get())) {
-//				return false;
-//			}
-//			break;
-//		}
-//		default: {
-//			return false;
-//		}
-//		}
-//	}
-//
-//	for (auto child_conjunction : conjunctions_to_visit) {
-//		cur_conjunction = child_conjunction;
-//		// traverse child conjunction
-//		if (!BFSLookUpConjunctions(child_conjunction)) {
-//			return false;
-//		}
-//	}
-//	return true;
-//}
-//
-// void FilterCombiner::VerifyOrsToPush(Expression &expr) {
-//	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
-//		auto colref = (BoundColumnRefExpression *)&expr;
-//		auto entry = map_col_conjunctions.find(colref);
-//		if (entry == map_col_conjunctions.end()) {
-//			return;
-//		}
-//		map_col_conjunctions.erase(entry);
-//	}
-//	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { VerifyOrsToPush(child); });
-//}
-//
-// bool FilterCombiner::UpdateConjunctionFilter(BoundComparisonExpression *comparison_expr) {
-//	bool left_is_scalar = comparison_expr->left->IsFoldable();
-//	bool right_is_scalar = comparison_expr->right->IsFoldable();
-//
-//	Expression *non_scalar_expr;
-//	if (left_is_scalar || right_is_scalar) {
-//		// only support comparison with scalar
-//		non_scalar_expr = left_is_scalar ? comparison_expr->right.get() : comparison_expr->left.get();
-//
-//		if (non_scalar_expr->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
-//			return UpdateFilterByColumn((BoundColumnRefExpression *)non_scalar_expr, comparison_expr);
-//		}
-//	}
-//
-//	return false;
-//}
-//
-// bool FilterCombiner::UpdateFilterByColumn(BoundColumnRefExpression *column_ref,
-//                                          BoundComparisonExpression *comparison_expr) {
-//	if (cur_colref_to_push == nullptr) {
-//		cur_colref_to_push = column_ref;
-//
-//		auto or_conjunction = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
-//		or_conjunction->children.emplace_back(comparison_expr->Copy());
-//
-//		unique_ptr<ConjunctionsToPush> conjs_to_push = make_uniq<ConjunctionsToPush>();
-//		conjs_to_push->conjunctions.emplace_back(std::move(or_conjunction));
-//		conjs_to_push->root_or = cur_root_or;
-//
-//		auto &&vec_col_conjs = map_col_conjunctions[column_ref];
-//		vec_col_conjs.emplace_back(std::move(conjs_to_push));
-//		vec_colref_insertion_order.emplace_back(column_ref);
-//		return true;
-//	}
-//
-//	auto entry = map_col_conjunctions.find(cur_colref_to_push);
-//	D_ASSERT(entry != map_col_conjunctions.end());
-//	auto &conjunctions_to_push = entry->second.back();
-//
-//	if (!cur_colref_to_push->Equals(column_ref)) {
-//		// check for multiple colunms in the same root OR node
-//		if (cur_root_or == cur_conjunction) {
-//			return false;
-//		}
-//		// found an AND using a different column, we should stop the look up
-//		if (cur_conjunction->GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
-//			return false;
-//		}
-//
-//		// found a different column, AND conditions cannot be preserved anymore
-//		conjunctions_to_push->preserve_and = false;
-//		return true;
-//	}
-//
-//	auto &last_conjunction = conjunctions_to_push->conjunctions.back();
-//	if (cur_conjunction->GetExpressionType() == last_conjunction->GetExpressionType()) {
-//		last_conjunction->children.emplace_back(comparison_expr->Copy());
-//	} else {
-//		auto new_conjunction = make_uniq<BoundConjunctionExpression>(cur_conjunction->GetExpressionType());
-//		new_conjunction->children.emplace_back(comparison_expr->Copy());
-//		conjunctions_to_push->conjunctions.emplace_back(std::move(new_conjunction));
-//	}
-//	return true;
-//}
-//
-// void FilterCombiner::GenerateORFilters(TableFilterSet &table_filter, vector<idx_t> &column_ids) {
-//	for (const auto colref : vec_colref_insertion_order) {
-//		auto column_index = column_ids[colref->binding.column_index];
-//		if (column_index == COLUMN_IDENTIFIER_ROW_ID) {
-//			break;
-//		}
-//
-//		for (const auto &conjunctions_to_push : map_col_conjunctions[colref]) {
-//			// root OR filter to push into the TableFilter
-//			auto root_or_filter = make_uniq<ConjunctionOrFilter>();
-//			// variable to hold the last conjuntion filter pointer
-//			// the next filter will be added into it, i.e., we create a chain of conjunction filters
-//			ConjunctionFilter *last_conj_filter = root_or_filter.get();
-//
-//			for (auto &conjunction : conjunctions_to_push->conjunctions) {
-//				if (conjunction->GetExpressionType() == ExpressionType::CONJUNCTION_AND &&
-//				    conjunctions_to_push->preserve_and) {
-//					GenerateConjunctionFilter<ConjunctionAndFilter>(conjunction.get(), last_conj_filter);
-//				} else {
-//					GenerateConjunctionFilter<ConjunctionOrFilter>(conjunction.get(), last_conj_filter);
-//				}
-//			}
-//			table_filter.PushFilter(column_index, std::move(root_or_filter));
-//		}
-//	}
-//	map_col_conjunctions.clear();
-//	vec_colref_insertion_order.clear();
-//}
 
 } // namespace duckdb

--- a/test/optimizer/pushdown/table_filter_pushdown.test
+++ b/test/optimizer/pushdown/table_filter_pushdown.test
@@ -107,7 +107,7 @@ logical_opt	<!REGEX>:.*FILTER.*
 
 # more complex filters cannot be pushed down
 query II
-EXPLAIN SELECT i FROM tablinho where i like 'bla%'
+EXPLAIN SELECT i FROM tablinho where i like 'bl_a%'
 ----
 logical_opt	<REGEX>:.*FILTER.*
 

--- a/test/optimizer/regex_optimizer.test
+++ b/test/optimizer/regex_optimizer.test
@@ -1,5 +1,5 @@
 # name: test/optimizer/regex_optimizer.test
-# description: Test Like Optimization Rules
+# description: Test Regex Optimization Rules
 # group: [optimizer]
 
 statement ok


### PR DESCRIPTION
This PR cleans up the FilterCombiner:

* The `GenerateTableScanFilters` had been growing, this PR splits the various pieces into separate functions which makes the function much more readable
* At some point (years ago) we commented out a bunch of code here - that is unlikely to ever come back, so just remove it

This shouldn't change functionality with one minor exception: when pushing down a `prefix(col, 'literal')` filter, we now remove the original `prefix` filter (since the filter we are pushing down exactly computes the prefix).