### PR TITLE
Filter Combiner: Allow rowid pushdown for IN/OR filters and pushdown for temporal types

### DIFF
--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -529,10 +529,6 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 			return FilterPushdownResult::NO_PUSHDOWN;
 		}
 
-		if (const_val->value.type().IsTemporal()) {
-			// pushdown on temporal types not supported (why?)
-			return FilterPushdownResult::NO_PUSHDOWN;
-		}
 		auto comparison_type = invert ? FlipComparisonExpression(comp.GetExpressionType()) : comp.GetExpressionType();
 		if (const_val->value.IsNull()) {
 			switch (comparison_type) {

--- a/test/sql/filter/test_or_pushdown.test
+++ b/test/sql/filter/test_or_pushdown.test
@@ -9,7 +9,7 @@ statement ok
 PRAGMA explain_output = PHYSICAL_ONLY;
 
 statement ok
-create table t1 as select range a, 'foo' || (range%100)::VARCHAR b, 100000-range c from range(900000);
+create table t1 as select range a, 'foo' || (range%100)::VARCHAR b, 100000-range c, timestamp '1992-01-01' + interval (range * 20) minute d from range(900000);
 
 query I
 select count(*) from t1 where a < 5 or b = 'foo8';
@@ -75,3 +75,15 @@ query II
 explain select b from t1 where b = 'foo9' or b = 'foo10';
 ----
 physical_plan	<REGEX>:.*optional.*
+
+# two different row groups can be propagated here.
+query I
+select a from t1 where d=timestamp '1992-01-01 01:40:00' or d=timestamp '2026-03-22 23:40:00'
+----
+5
+899999
+
+query II
+explain select a from t1 where d=timestamp '1992-01-01 01:40:00' or d=timestamp '2026-03-22 23:40:00'
+----
+physical_plan	<REGEX>:.*optional.*d.*

--- a/test/sql/optimizer/test_rowid_pushdown.test
+++ b/test/sql/optimizer/test_rowid_pushdown.test
@@ -40,3 +40,27 @@ SELECT * FROM t1 where rowid IN (SELECT rowid FROM t1 ORDER BY rowid DESC LIMIT 
 250097
 250098
 250099
+
+# IN filter
+query I
+SELECT * FROM t1 where rowid IN (6, 9) ORDER BY ALL;
+----
+106
+109
+
+query II
+EXPLAIN SELECT * FROM t1 where rowid IN (6, 9);
+----
+physical_plan	<REGEX>:.*Filters:.*rowid.*IN.*(6.*9).*
+
+# OR clause
+query I
+SELECT * FROM t1 where rowid = 6 OR rowid = 9 ORDER BY ALL;
+----
+106
+109
+
+query II
+EXPLAIN SELECT * FROM t1 where rowid = 6 OR rowid = 9 ORDER BY ALL;
+----
+physical_plan	<REGEX>:.*Filters:.*rowid.*6.*rowid.*9.*


### PR DESCRIPTION
This removes a few restrictions that are no longer required to enable filter pushdown on more types