### PR TITLE
custom_extension_repository to also be the default autoinstall_extension_repository

### DIFF
--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -224,6 +224,14 @@ bool ExtensionHelper::TryAutoLoadExtension(ClientContext &context, const string 
 	}
 }
 
+static string GetAutoInstallExtensionsRepository(const DBConfigOptions &options) {
+	string repository_url = options.autoinstall_extension_repo;
+	if (repository_url.empty()) {
+		repository_url = options.custom_extension_repo;
+	}
+	return repository_url;
+}
+
 bool ExtensionHelper::TryAutoLoadExtension(DatabaseInstance &instance, const string &extension_name) noexcept {
 	if (instance.ExtensionIsLoaded(extension_name)) {
 		return true;
@@ -232,8 +240,8 @@ bool ExtensionHelper::TryAutoLoadExtension(DatabaseInstance &instance, const str
 	try {
 		auto &fs = FileSystem::GetFileSystem(instance);
 		if (dbconfig.options.autoinstall_known_extensions) {
-			auto autoinstall_repo =
-			    ExtensionRepository::GetRepositoryByUrl(dbconfig.options.autoinstall_extension_repo);
+			auto repository_url = GetAutoInstallExtensionsRepository(dbconfig.options);
+			auto autoinstall_repo = ExtensionRepository::GetRepositoryByUrl(repository_url);
 			ExtensionInstallOptions options;
 			options.repository = autoinstall_repo;
 			ExtensionHelper::InstallExtension(instance, fs, extension_name, options);
@@ -382,10 +390,10 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 		auto fs = FileSystem::CreateLocal();
 #ifndef DUCKDB_WASM
 		if (dbconfig.options.autoinstall_known_extensions) {
-			//! Get the autoloading repository
-			auto repository = ExtensionRepository::GetRepositoryByUrl(dbconfig.options.autoinstall_extension_repo);
+			auto repository_url = GetAutoInstallExtensionsRepository(dbconfig.options);
+			auto autoinstall_repo = ExtensionRepository::GetRepositoryByUrl(repository_url);
 			ExtensionInstallOptions options;
-			options.repository = repository;
+			options.repository = autoinstall_repo;
 			ExtensionHelper::InstallExtension(db, *fs, extension_name, options);
 		}
 #endif

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -220,11 +220,10 @@ string ExtensionHelper::ExtensionUrlTemplate(optional_ptr<const DatabaseInstance
 	} else {
 		versioned_path = "/${REVISION}/${PLATFORM}/${NAME}.duckdb_extension";
 	}
+	string default_endpoint = ExtensionRepository::DEFAULT_REPOSITORY_URL;
 #ifdef WASM_LOADABLE_EXTENSIONS
-	string default_endpoint = DEFAULT_REPOSITORY;
 	versioned_path = versioned_path + ".wasm";
 #else
-	string default_endpoint = ExtensionRepository::DEFAULT_REPOSITORY_URL;
 	versioned_path = versioned_path + CompressionExtensionFromType(FileCompressionType::GZIP);
 #endif
 	string url_template = repository.path + versioned_path;

--- a/test/extension/duckdb_extension_settings.test
+++ b/test/extension/duckdb_extension_settings.test
@@ -1,0 +1,28 @@
+# name: test/extension/duckdb_extension_settings.test
+# description: settings for extensions
+# group: [extension]
+
+statement ok
+SET autoinstall_known_extensions = true;
+
+statement ok
+SET autoload_known_extensions = true;
+
+statement ok
+SET extension_directory = '__TEST_DIR__/custom_extension_directory';
+
+statement ok
+SET custom_extension_repository = '__TEST_DIR__/not_existing_folder'
+
+statement error
+FROM read_csv('https://some.org/file.csv');
+----
+not_existing_folder
+
+statement ok
+SET autoinstall_extension_repository = '__TEST_DIR__/other_folder';
+
+statement error
+FROM read_csv('https://some.org/file.csv');
+----
+other_folder


### PR DESCRIPTION
Currently there are 2 settings that need to be overridden to change the default (remote) extension repository:
```
SET custom_extension_repository = '...'
SET autoinstall_extension_repository = '...'
```
Having those point to different endpoint I think it's an historical artifact, and mostly used to test autoinstall and autoloading in our unittester.

Documentation do not mention `autoinstall_extension_repository` at all, and I think users would assume setting `custom_extension_repository` should download from that one both these cases:
```
INSTALL delta;
--- this uses custom_extension_repository
FROM 'https://some.org/file.csv';
--- this autoinstall and autoload httpfs from autoinstall_extension_repository
```

The proposed solution, that I think should keep flexibility when needed (e.g. testing framework) while keeping most current workflow working is using `custom_extension_repository` as default when `autoinstall_extension_repository` is not set.

Added a test, that in current DuckDB fails while INSTALLing the extension from default repo (even though `custom_extension_repository` had been set):
```
FROM read_csv('https://some.org/file.csv');
Actual result:
================================================================================
Extension Autoloading Error: An error occurred while trying to automatically install the required extension 'httpfs':
Failed to download extension "httpfs" at URL "http://extensions.duckdb.org/c837f1082a/osx_arm64/httpfs.duckdb_extension.gz" (HTTP 403)
Extension "httpfs" is an existing extension.

For more info, visit https://duckdb.org/docs/extensions/troubleshooting/?version=c837f1082a&platform=osx_arm64&extension=httpfs
```

Fixes also a minor mistake within an `#ifdef`.