### PR TITLE
Expose `Value::ToSQLString()` in C API 

### DIFF
--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -27,6 +27,7 @@ DEFAULT_TIMEOUT = 600
 @dataclass
 class BenchmarkRunnerConfig:
     "Configuration for a BenchmarkRunner"
+
     benchmark_runner: str
     benchmark_file: str
     verbose: bool = False

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2537,6 +2537,14 @@ Returns the STRUCT child at index as a duckdb_value.
 */
 DUCKDB_C_API duckdb_value duckdb_get_struct_child(duckdb_value value, idx_t index);
 
+/*!
+Returns the SQL string representation of the given value.
+
+* @param value A duckdb_value.
+* @return The SQL string representation as a null-terminated string. The result must be freed with `duckdb_free`.
+*/
+DUCKDB_C_API char *duckdb_to_sql_string(duckdb_value value);
+
 //===--------------------------------------------------------------------===//
 // Logical Type Interface
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2543,7 +2543,7 @@ Returns the SQL string representation of the given value.
 * @param value A duckdb_value.
 * @return The SQL string representation as a null-terminated string. The result must be freed with `duckdb_free`.
 */
-DUCKDB_C_API char *duckdb_to_sql_string(duckdb_value value);
+DUCKDB_C_API char *duckdb_value_to_string(duckdb_value value);
 
 //===--------------------------------------------------------------------===//
 // Logical Type Interface

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -473,7 +473,7 @@ typedef struct {
 	                                               idx_t row);
 	// New string functions that are added
 
-	char *(*duckdb_to_sql_string)(duckdb_value value);
+	char *(*duckdb_value_to_string)(duckdb_value value);
 } duckdb_ext_api_v1;
 
 //===--------------------------------------------------------------------===//
@@ -889,7 +889,7 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_get_or_create_from_cache = duckdb_get_or_create_from_cache;
 	result.duckdb_destroy_instance_cache = duckdb_destroy_instance_cache;
 	result.duckdb_append_default_to_chunk = duckdb_append_default_to_chunk;
-	result.duckdb_to_sql_string = duckdb_to_sql_string;
+	result.duckdb_value_to_string = duckdb_value_to_string;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -471,6 +471,9 @@ typedef struct {
 
 	duckdb_state (*duckdb_append_default_to_chunk)(duckdb_appender appender, duckdb_data_chunk chunk, idx_t col,
 	                                               idx_t row);
+	// New string functions that are added
+
+	char *(*duckdb_to_sql_string)(duckdb_value value);
 } duckdb_ext_api_v1;
 
 //===--------------------------------------------------------------------===//
@@ -886,6 +889,7 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_get_or_create_from_cache = duckdb_get_or_create_from_cache;
 	result.duckdb_destroy_instance_cache = duckdb_destroy_instance_cache;
 	result.duckdb_append_default_to_chunk = duckdb_append_default_to_chunk;
+	result.duckdb_to_sql_string = duckdb_to_sql_string;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_string_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_string_functions.json
@@ -1,0 +1,7 @@
+{
+    "version": "unstable_new_string_functions",
+    "description": "New string functions that are added",
+    "entries": [
+        "duckdb_to_sql_string"
+    ]
+}

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_string_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_string_functions.json
@@ -2,6 +2,6 @@
     "version": "unstable_new_string_functions",
     "description": "New string functions that are added",
     "entries": [
-        "duckdb_to_sql_string"
+        "duckdb_value_to_string"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -1276,6 +1276,23 @@
                 },
                 "return_value": "The child as a duckdb_value."
             }
+        },
+        {
+            "name": "duckdb_to_sql_string",
+            "return_type": "char *",
+            "params": [
+                {
+                    "type": "duckdb_value",
+                    "name": "value"
+                }
+            ],
+            "comment": {
+                "description": "Returns the SQL string representation of the given value.\n\n",
+                "param_comments": {
+                    "value": "A duckdb_value."
+                },
+                "return_value": "The SQL string representation as a null-terminated string. The result must be freed with `duckdb_free`."
+            }
         }
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -1278,7 +1278,7 @@
             }
         },
         {
-            "name": "duckdb_to_sql_string",
+            "name": "duckdb_value_to_string",
             "return_type": "char *",
             "params": [
                 {

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -544,7 +544,7 @@ typedef struct {
 
 // New string functions that are added
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
-	char *(*duckdb_to_sql_string)(duckdb_value value);
+	char *(*duckdb_value_to_string)(duckdb_value value);
 #endif
 
 } duckdb_ext_api_v1;
@@ -970,7 +970,7 @@ typedef struct {
 #define duckdb_append_default_to_chunk duckdb_ext_api.duckdb_append_default_to_chunk
 
 // Version unstable_new_string_functions
-#define duckdb_to_sql_string duckdb_ext_api.duckdb_to_sql_string
+#define duckdb_value_to_string duckdb_ext_api.duckdb_value_to_string
 
 //===--------------------------------------------------------------------===//
 // Struct Global Macros

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -542,6 +542,11 @@ typedef struct {
 	                                               idx_t row);
 #endif
 
+// New string functions that are added
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	char *(*duckdb_to_sql_string)(duckdb_value value);
+#endif
+
 } duckdb_ext_api_v1;
 
 //===--------------------------------------------------------------------===//
@@ -963,6 +968,9 @@ typedef struct {
 
 // Version unstable_new_append_functions
 #define duckdb_append_default_to_chunk duckdb_ext_api.duckdb_append_default_to_chunk
+
+// Version unstable_new_string_functions
+#define duckdb_to_sql_string duckdb_ext_api.duckdb_to_sql_string
 
 //===--------------------------------------------------------------------===//
 // Struct Global Macros

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -537,3 +537,13 @@ duckdb_value duckdb_get_struct_child(duckdb_value value, idx_t index) {
 
 	return WrapValue(new duckdb::Value(children[index]));
 }
+
+char *duckdb_to_sql_string(duckdb_value val) {
+	auto v = UnwrapValue(val);
+	auto str = v.ToSQLString();
+
+	auto result = reinterpret_cast<char *>(malloc(sizeof(char) * (str.size() + 1)));
+	memcpy(result, str.c_str(), str.size());
+	result[str.size()] = '\0';
+	return result;
+}

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -538,7 +538,11 @@ duckdb_value duckdb_get_struct_child(duckdb_value value, idx_t index) {
 	return WrapValue(new duckdb::Value(children[index]));
 }
 
-char *duckdb_to_sql_string(duckdb_value val) {
+char *duckdb_value_to_string(duckdb_value val) {
+	if (!val) {
+		return nullptr;
+	}
+
 	auto v = UnwrapValue(val);
 	auto str = v.ToSQLString();
 

--- a/test/api/capi/test_capi_values.cpp
+++ b/test/api/capi/test_capi_values.cpp
@@ -430,7 +430,7 @@ TEST_CASE("Test UUID value", "[capi]") {
 
 TEST_CASE("Test SQL string conversion", "[capi]") {
 	auto uint_val = duckdb_create_uint64(42);
-	auto uint_val_str = duckdb_to_sql_string(uint_val);
+	auto uint_val_str = duckdb_value_to_string(uint_val);
 	REQUIRE(string(uint_val_str).compare("42") == 0);
 
 	duckdb_destroy_value(&uint_val);

--- a/test/api/capi/test_capi_values.cpp
+++ b/test/api/capi/test_capi_values.cpp
@@ -427,3 +427,12 @@ TEST_CASE("Test UUID value", "[capi]") {
 		duckdb_destroy_value(&uuid_value);
 	}
 }
+
+TEST_CASE("Test SQL string conversion", "[capi]") {
+	auto uint_val = duckdb_create_uint64(42);
+	auto uint_val_str = duckdb_to_sql_string(uint_val);
+	REQUIRE(string(uint_val_str).compare("42") == 0);
+
+	duckdb_destroy_value(&uint_val);
+	duckdb_free(uint_val_str);
+}

--- a/tools/pythonpkg/tests/fast/numpy/test_numpy_new_path.py
+++ b/tools/pythonpkg/tests/fast/numpy/test_numpy_new_path.py
@@ -1,5 +1,5 @@
-""" The support for scaning over numpy arrays reuses many codes for pandas.
-    Therefore, we only test the new codes and exec paths.
+"""The support for scaning over numpy arrays reuses many codes for pandas.
+Therefore, we only test the new codes and exec paths.
 """
 
 import numpy as np

--- a/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
+++ b/tools/pythonpkg/tests/fast/udf/test_null_filtering.py
@@ -106,8 +106,8 @@ def get_types():
         ),
         Candidate(
             BLOB,
-            b'\xF6\x96\xB0\x85',
-            b'\x85\xB0\x96\xF6',
+            b'\xf6\x96\xb0\x85',
+            b'\x85\xb0\x96\xf6',
         ),
         Candidate(
             INTERVAL,

--- a/tools/pythonpkg/tests/fast/udf/test_scalar.py
+++ b/tools/pythonpkg/tests/fast/udf/test_scalar.py
@@ -50,7 +50,7 @@ class TestScalarUDF(object):
             (DATE, datetime.date(2005, 3, 11)),
             (TIMESTAMP, datetime.datetime(2009, 2, 13, 11, 5, 53)),
             (TIME, datetime.time(14, 1, 12)),
-            (BLOB, b'\xF6\x96\xB0\x85'),
+            (BLOB, b'\xf6\x96\xb0\x85'),
             (INTERVAL, datetime.timedelta(days=30969, seconds=999, microseconds=999999)),
             (BOOLEAN, True),
             (


### PR DESCRIPTION
Resolves https://github.com/duckdb/duckdb/discussions/16233, exposing `Value::ToSQLString()` as `duckdb_to_sql_string()`. The motivation is to use this from some bindings to OCaml that I'm working on.

The random diffs which are unrelated to the functionality here are due to running `make format-fix`.