### PR TITLE
fix passing a null path to the C API instance cache

### DIFF
--- a/src/main/capi/duckdb-c.cpp
+++ b/src/main/capi/duckdb-c.cpp
@@ -35,7 +35,11 @@ duckdb_state duckdb_open_internal(DBInstanceCacheWrapper *cache, const char *pat
 		}
 
 		if (cache) {
-			wrapper->database = cache->instance_cache->GetOrCreateInstance(path, *db_config, true);
+			duckdb::string path_str;
+			if (path) {
+				path_str = path;
+			}
+			wrapper->database = cache->instance_cache->GetOrCreateInstance(path_str, *db_config, true);
 		} else {
 			wrapper->database = duckdb::make_shared_ptr<DuckDB>(path, db_config);
 		}

--- a/test/api/capi/test_capi_instance_cache.cpp
+++ b/test/api/capi/test_capi_instance_cache.cpp
@@ -38,3 +38,30 @@ TEST_CASE("Test the database instance cache in the C API", "[api][.]") {
 
 	duckdb_destroy_instance_cache(&instance_cache);
 }
+
+TEST_CASE("Test the database instance cache in the C API with a null path", "[capi]") {
+	auto instance_cache = duckdb_create_instance_cache();
+	duckdb_database db;
+	auto state = duckdb_get_or_create_from_cache(instance_cache, nullptr, &db, nullptr, nullptr);
+	REQUIRE(state == DuckDBSuccess);
+	duckdb_close(&db);
+	duckdb_destroy_instance_cache(&instance_cache);
+}
+
+TEST_CASE("Test the database instance cache in the C API with an empty path", "[capi]") {
+	auto instance_cache = duckdb_create_instance_cache();
+	duckdb_database db;
+	auto state = duckdb_get_or_create_from_cache(instance_cache, "", &db, nullptr, nullptr);
+	REQUIRE(state == DuckDBSuccess);
+	duckdb_close(&db);
+	duckdb_destroy_instance_cache(&instance_cache);
+}
+
+TEST_CASE("Test the database instance cache in the C API with a memory path", "[capi]") {
+	auto instance_cache = duckdb_create_instance_cache();
+	duckdb_database db;
+	auto state = duckdb_get_or_create_from_cache(instance_cache, ":memory:", &db, nullptr, nullptr);
+	REQUIRE(state == DuckDBSuccess);
+	duckdb_close(&db);
+	duckdb_destroy_instance_cache(&instance_cache);
+}


### PR DESCRIPTION
While working on exposing the instance cache through Node Neo using the C API, I found that passing `nullptr` to the `path` argument of `duckdb_get_or_create_from_cache` resulted in a seg fault. Note that `duckdb_open` accepts `nullptr` just fine. Both functions are documented to accept `nullptr`.

This occurred because the C++ API takes a `duckdb::string`, which can't contain `nullptr`, but the C API was passing in a `const char *` that could be `nullptr`. The simple fix is to check for `nullptr` in this case and pass an empty string instead.

I added a few basic tests of this function for various special values of the `path` argument: `nullptr`, empty string, and `":memory:"`. The `nullptr` test case fails without this fix; the other two are fine.

Note that I'm submitting this PR to the `v1.2-histrionicus` branch in the hopes it can get in before the release of 1.2.1 this week.