### PR TITLE
Remove .open from shell.cpp

### DIFF
--- a/tools/shell/tests/test_backwards_compatibility.py
+++ b/tools/shell/tests/test_backwards_compatibility.py
@@ -10,7 +10,7 @@ import os
 def test_version_dev(shell):
     test = (
         ShellTest(shell)
-        .statement(".open test/storage/bc/db_dev.db")
+        .statement("attach 'test/storage/bc/db_dev.db' as db_dev;")
     )
     result = test.run()
     result.check_stderr("older development version")
@@ -18,7 +18,7 @@ def test_version_dev(shell):
 def test_version_0_3_1(shell):
     test = (
         ShellTest(shell)
-        .statement(".open test/storage/bc/db_031.db")
+        .statement("attach 'test/storage/bc/db_031.db' as db_031;")
     )
     result = test.run()
     result.check_stderr("v0.3.1")
@@ -26,7 +26,7 @@ def test_version_0_3_1(shell):
 def test_version_0_3_2(shell):
     test = (
         ShellTest(shell)
-        .statement(".open test/storage/bc/db_032.db")
+        .statement("attach 'test/storage/bc/db_032.db' as db_032;")
     )
     result = test.run()
     result.check_stderr("v0.3.2")
@@ -34,7 +34,7 @@ def test_version_0_3_2(shell):
 def test_version_0_4(shell):
     test = (
         ShellTest(shell)
-        .statement(".open test/storage/bc/db_04.db")
+        .statement("attach 'test/storage/bc/db_04.db' as db_04;")
     )
     result = test.run()
     result.check_stderr("v0.4.0")
@@ -42,7 +42,7 @@ def test_version_0_4(shell):
 def test_version_0_5_1(shell):
     test = (
         ShellTest(shell)
-        .statement(".open test/storage/bc/db_051.db")
+        .statement("attach 'test/storage/bc/db_051.db' as db_051;")
     )
     result = test.run()
     result.check_stderr("v0.5.1")
@@ -50,7 +50,7 @@ def test_version_0_5_1(shell):
 def test_version_0_6_0(shell):
     test = (
         ShellTest(shell)
-        .statement(".open test/storage/bc/db_060.db")
+        .statement("attach 'test/storage/bc/db_060.db' as db_060;")
     )
     result = test.run()
     result.check_stderr("v0.6.0")

--- a/tools/shell/tests/test_safe_mode.py
+++ b/tools/shell/tests/test_safe_mode.py
@@ -8,7 +8,7 @@ from conftest import ShellTest
 from tools.shell.tests.conftest import random_filepath
 
 
-@pytest.mark.parametrize("command", [".sh ls", ".cd ..", ".log file", ".import file.csv tbl", ".open new_file", ".output out", ".once out", ".excel out", ".read myfile.sql"])
+@pytest.mark.parametrize("command", [".sh ls", ".cd ..", ".log file", ".import file.csv tbl", ".output out", ".once out", ".excel out", ".read myfile.sql"])
 def test_safe_mode_command(shell, command):
     test = (
         ShellTest(shell, ['-safe'])
@@ -40,7 +40,7 @@ def test_safe_mode_database_basic(shell, random_filepath):
     result = test.run()
     result.check_stdout("6")
 
-@pytest.mark.parametrize("command", [".sh ls", ".cd ..", ".log file", ".import file.csv tbl", ".open new_file", ".output out", ".once out", ".excel out", ".read myfile.sql"])
+@pytest.mark.parametrize("command", [".sh ls", ".cd ..", ".log file", ".import file.csv tbl", ".output out", ".once out", ".excel out", ".read myfile.sql"])
 @pytest.mark.parametrize("persistent", [False, True])
 def test_safe_mode_database_commands(shell, random_filepath, command, persistent):
     arguments = ['-safe'] if not persistent else [random_filepath, '-safe']

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -673,32 +673,6 @@ def test_mode_tabs(shell):
     result = test.run()
     result.check_stdout('fourty-two')
 
-def test_open(shell, tmp_path):
-    file_one = tmp_path / "file_one"
-    file_two = tmp_path / "file_two"
-    test = (
-        ShellTest(shell)
-        .statement(f".open {file_one.as_posix()}")
-        .statement("CREATE TABLE t1 (i INTEGER);")
-        .statement("INSERT INTO t1 VALUES (42);")
-        .statement(f".open {file_two.as_posix()}")
-        .statement("CREATE TABLE t2 (i INTEGER);")
-        .statement("INSERT INTO t2 VALUES (43);")
-        .statement(f".open {file_one.as_posix()}")
-        .statement("SELECT * FROM t1;")
-    )
-    result = test.run()
-    result.check_stdout('42')
-
-@pytest.mark.parametrize('generated_file', ["blablabla"], indirect=True)
-def test_open_non_database(shell, generated_file):
-    test = (
-        ShellTest(shell)
-        .add_argument(generated_file.as_posix())
-    )
-    result = test.run()
-    result.check_stderr('not a valid DuckDB database file')
-
 def test_enable_profiling(shell):
     test = (
         ShellTest(shell)


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/4318

Removing the .open call seemed the most straightforward. I thought about calling `Attach` and `USE` under the hood, but was having trouble with error messages. I can probably fix these messages, but I believe our current thoughts are to remove functionality from shell.cpp.

