### PR TITLE
Speed-up contains by using `memchr` on every iteration

### DIFF
--- a/src/function/scalar/string/contains.cpp
+++ b/src/function/scalar/string/contains.cpp
@@ -8,7 +8,6 @@
 
 namespace duckdb {
 
-#ifndef DUCKDB_SMALLER_BINARY
 struct ContainsAligned {
 	template <class UNSIGNED>
 	static bool MatchRemainder(const unsigned char *haystack, const unsigned char *needle, idx_t needle_size) {
@@ -26,7 +25,6 @@ struct ContainsUnaligned {
 		return matches == needle_size - sizeof(UNSIGNED);
 	}
 };
-#endif
 
 struct ContainsGeneric {
 	template <class UNSIGNED>
@@ -73,7 +71,6 @@ idx_t FindStrInStr(const unsigned char *haystack, idx_t haystack_size, const uns
 	idx_t base_offset = UnsafeNumericCast<idx_t>(const_uchar_ptr_cast(location) - haystack);
 	haystack_size -= base_offset;
 	haystack = const_uchar_ptr_cast(location);
-#ifndef DUCKDB_SMALLER_BINARY
 	// switch algorithm depending on needle size
 	switch (needle_size) {
 	case 1:
@@ -93,11 +90,8 @@ idx_t FindStrInStr(const unsigned char *haystack, idx_t haystack_size, const uns
 	case 8:
 		return Contains<uint64_t, ContainsAligned>(haystack, haystack_size, needle, 8, base_offset);
 	default:
-#endif
 		return Contains<uint64_t, ContainsGeneric>(haystack, haystack_size, needle, needle_size, base_offset);
-#ifndef DUCKDB_SMALLER_BINARY
 	}
-#endif
 }
 
 idx_t FindStrInStr(const string_t &haystack_s, const string_t &needle_s) {

--- a/src/function/scalar/string/contains.cpp
+++ b/src/function/scalar/string/contains.cpp
@@ -9,93 +9,58 @@
 namespace duckdb {
 
 #ifndef DUCKDB_SMALLER_BINARY
-template <class UNSIGNED, idx_t NEEDLE_SIZE>
-static idx_t ContainsUnaligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle, idx_t base_offset) {
-	if (NEEDLE_SIZE > haystack_size) {
-		// needle is bigger than haystack: haystack cannot contain needle
-		return DConstants::INVALID_INDEX;
+struct ContainsAligned {
+	template <class UNSIGNED>
+	static bool MatchRemainder(const unsigned char *haystack, const unsigned char *needle, idx_t needle_size) {
+		return true;
 	}
-	haystack_size -= NEEDLE_SIZE - 1;
-	auto needle_entry = Load<UNSIGNED>(needle);
-	for(idx_t offset = 0; offset < haystack_size; offset++) {
-		// start off by performing a memchr to find the first character of the
-		auto location = static_cast<const unsigned char *>(memchr(haystack + offset, needle[0], haystack_size - offset));
-		if (!location) {
-			return DConstants::INVALID_INDEX;
-		}
-		// for this position we first compare the haystack with the needle
-		offset = UnsafeNumericCast<idx_t>(location - haystack);
-		auto haystack_entry = Load<UNSIGNED>(location);
-		if (needle_entry == haystack_entry) {
-			idx_t matches = 0;
-			for(idx_t i = sizeof(UNSIGNED); i < NEEDLE_SIZE; i++) {
-				matches += location[i] == needle[i];
-			}
-			if (matches == NEEDLE_SIZE - sizeof(UNSIGNED)) {
-				return base_offset + offset;
-			}
-		}
-	}
-	return DConstants::INVALID_INDEX;
-}
+};
 
-template <class UNSIGNED>
-static idx_t ContainsAligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
-                             idx_t base_offset) {
-	if (sizeof(UNSIGNED) > haystack_size) {
-		// needle is bigger than haystack: haystack cannot contain needle
-		return DConstants::INVALID_INDEX;
-	}
-	haystack_size -= sizeof(UNSIGNED) - 1;
-	auto needle_entry = Load<UNSIGNED>(needle);
-	for(idx_t offset = 0; offset < haystack_size; offset++) {
-		// start off by performing a memchr to find the first character of the
-		auto location = static_cast<const unsigned char *>(memchr(haystack + offset, needle[0], haystack_size - offset));
-		if (!location) {
-			return DConstants::INVALID_INDEX;
+struct ContainsUnaligned {
+	template <class UNSIGNED>
+	static bool MatchRemainder(const unsigned char *haystack, const unsigned char *needle, idx_t needle_size) {
+		idx_t matches = 0;
+		for (idx_t i = sizeof(UNSIGNED); i < needle_size; i++) {
+			matches += haystack[i] == needle[i];
 		}
-		// for this position we first compare the haystack with the needle
-		offset = UnsafeNumericCast<idx_t>(location - haystack);
-		auto haystack_entry = Load<UNSIGNED>(location);
-		if (needle_entry == haystack_entry) {
-			return base_offset + offset;
-		}
+		return matches == needle_size - sizeof(UNSIGNED);
 	}
-	return DConstants::INVALID_INDEX;
-}
+};
 #endif
 
-idx_t ContainsGeneric(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
+struct ContainsGeneric {
+	template <class UNSIGNED>
+	static bool MatchRemainder(const unsigned char *haystack, const unsigned char *needle, idx_t needle_size) {
+		return memcmp(haystack + sizeof(UNSIGNED), needle + sizeof(UNSIGNED), needle_size - sizeof(UNSIGNED)) == 0;
+	}
+};
+
+template <class UNSIGNED, class OP>
+static idx_t Contains(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
                       idx_t needle_size, idx_t base_offset) {
 	if (needle_size > haystack_size) {
 		// needle is bigger than haystack: haystack cannot contain needle
 		return DConstants::INVALID_INDEX;
 	}
-	// this implementation is inspired by Raphael Javaux's faststrstr (https://github.com/RaphaelJ/fast_strstr)
-	// generic contains; note that we can't use strstr because we don't have null-terminated strings anymore
-	// we keep track of a shifting window sum of all characters with window size equal to needle_size
-	// this shifting sum is used to avoid calling into memcmp;
-	// we only need to call into memcmp when the window sum is equal to the needle sum
-	// when that happens, the characters are potentially the same and we call into memcmp to check if they are
-	uint32_t sums_diff = 0;
-	for (idx_t i = 0; i < needle_size; i++) {
-		sums_diff += haystack[i];
-		sums_diff -= needle[i];
-	}
-	idx_t offset = 0;
-	while (true) {
-		if (sums_diff == 0 && haystack[offset] == needle[0]) {
-			if (memcmp(haystack + offset, needle, needle_size) == 0) {
+	haystack_size -= needle_size - 1;
+	auto needle_entry = Load<UNSIGNED>(needle);
+	for (idx_t offset = 0; offset < haystack_size; offset++) {
+		// start off by performing a memchr to find the first character of the
+		auto location =
+		    static_cast<const unsigned char *>(memchr(haystack + offset, needle[0], haystack_size - offset));
+		if (!location) {
+			return DConstants::INVALID_INDEX;
+		}
+		// for this position we first compare the haystack with the needle
+		offset = UnsafeNumericCast<idx_t>(location - haystack);
+		auto haystack_entry = Load<UNSIGNED>(location);
+		if (needle_entry == haystack_entry) {
+			if (OP::template MatchRemainder<UNSIGNED>(location, needle, needle_size)) {
 				return base_offset + offset;
 			}
 		}
-		if (offset >= haystack_size - needle_size) {
-			return DConstants::INVALID_INDEX;
-		}
-		sums_diff -= haystack[offset];
-		sums_diff += haystack[offset + needle_size];
-		offset++;
 	}
+	return DConstants::INVALID_INDEX;
 }
 
 idx_t FindStrInStr(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle, idx_t needle_size) {
@@ -114,24 +79,24 @@ idx_t FindStrInStr(const unsigned char *haystack, idx_t haystack_size, const uns
 	case 1:
 		return base_offset;
 	case 2:
-		return ContainsAligned<uint16_t>(haystack, haystack_size, needle, base_offset);
+		return Contains<uint16_t, ContainsAligned>(haystack, haystack_size, needle, 2, base_offset);
 	case 3:
-		return ContainsUnaligned<uint16_t, 3>(haystack, haystack_size, needle, base_offset);
+		return Contains<uint16_t, ContainsUnaligned>(haystack, haystack_size, needle, 3, base_offset);
 	case 4:
-		return ContainsAligned<uint32_t>(haystack, haystack_size, needle, base_offset);
+		return Contains<uint32_t, ContainsAligned>(haystack, haystack_size, needle, 4, base_offset);
 	case 5:
-		return ContainsUnaligned<uint32_t, 5>(haystack, haystack_size, needle, base_offset);
+		return Contains<uint32_t, ContainsUnaligned>(haystack, haystack_size, needle, 5, base_offset);
 	case 6:
-		return ContainsUnaligned<uint32_t, 6>(haystack, haystack_size, needle, base_offset);
+		return Contains<uint32_t, ContainsUnaligned>(haystack, haystack_size, needle, 6, base_offset);
 	case 7:
-		return ContainsUnaligned<uint32_t, 7>(haystack, haystack_size, needle, base_offset);
+		return Contains<uint32_t, ContainsUnaligned>(haystack, haystack_size, needle, 7, base_offset);
 	case 8:
-		return ContainsAligned<uint64_t>(haystack, haystack_size, needle, base_offset);
+		return Contains<uint64_t, ContainsAligned>(haystack, haystack_size, needle, 8, base_offset);
 	default:
-		return ContainsGeneric(haystack, haystack_size, needle, needle_size, base_offset);
+#endif
+		return Contains<uint64_t, ContainsGeneric>(haystack, haystack_size, needle, needle_size, base_offset);
+#ifndef DUCKDB_SMALLER_BINARY
 	}
-#else
-	return ContainsGeneric(haystack, haystack_size, needle, needle_size, base_offset);
 #endif
 }
 


### PR DESCRIPTION
This PR reworks the implementation for `contains` (which also gets generated as part of `LIKE '%str%'` by the optimizer).

Previously we had three different implementations - for small aligned contains (2/4/8 bytes), small unaligned contains (3/5/6/7 bytes) and a generic fallback for needles > 8 bytes. These implementations were pretty distinct and not entirely optimal - they did a lot of work for every byte even if an early-out could be used to speed this up in many cases.

This PR unifies these three implementations and leans on `memchr` to find the beginning of possible matches - followed by doing an actual matching comparison. The way this works is that we first do the comparison with the largest unsigned integer that fits in the needle (so either 2/4/8 bytes) - followed by a `memcmp` for the remaining bytes (if any). 

Running this query on `hits` we can see this improves performance in all cases - but especially for small unaligned searches and large searches.

```sql
SELECT COUNT(*) FROM hits WHERE URL LIKE '%goog%';
```
|     LIKE     | Search Size | v1.2.0 |  New  |
|--------------|-------------|--------|-------|
| %goog%       | 4           | 0.35s  | 0.31s |
| %google%     | 6           | 0.41s  | 0.33s |
| %google.com% | 10          | 0.43s  | 0.32s |
