### PR TITLE
[BugFix]: Swap join children, not left and right set

### DIFF
--- a/src/optimizer/join_order/query_graph_manager.cpp
+++ b/src/optimizer/join_order/query_graph_manager.cpp
@@ -265,7 +265,9 @@ GenerateJoinRelation QueryGraphManager::GenerateJoins(vector<unique_ptr<LogicalO
 					break;
 				}
 			}
-
+			if (chosen_filter->join_type == JoinType::SEMI) {
+				auto break_here = 0;
+			}
 			auto join = make_uniq<LogicalComparisonJoin>(chosen_filter->join_type);
 			// Here we optimize build side probe side. Our build side is the right side
 			// So the right plans should have lower cardinalities.
@@ -288,8 +290,9 @@ GenerateJoinRelation QueryGraphManager::GenerateJoins(vector<unique_ptr<LogicalO
 				bool invert = !JoinRelationSet::IsSubset(*left.set, *f->left_set);
 				// If the left and right set are inverted AND it is a semi or anti join
 				// swap left and right children back.
+
 				if (invert && (f->join_type == JoinType::SEMI || f->join_type == JoinType::ANTI)) {
-					std::swap(left, right);
+					std::swap(join->children[0], join->children[1]);
 					invert = false;
 				}
 

--- a/src/optimizer/join_order/query_graph_manager.cpp
+++ b/src/optimizer/join_order/query_graph_manager.cpp
@@ -265,9 +265,6 @@ GenerateJoinRelation QueryGraphManager::GenerateJoins(vector<unique_ptr<LogicalO
 					break;
 				}
 			}
-			if (chosen_filter->join_type == JoinType::SEMI) {
-				auto break_here = 0;
-			}
 			auto join = make_uniq<LogicalComparisonJoin>(chosen_filter->join_type);
 			// Here we optimize build side probe side. Our build side is the right side
 			// So the right plans should have lower cardinalities.

--- a/test/optimizer/column_binding_error.test
+++ b/test/optimizer/column_binding_error.test
@@ -1,0 +1,28 @@
+# name: test/optimizer/column_binding_error.test
+# description: column binding error test inspired by #16426,
+# group: [optimizer]
+
+require tpch
+
+statement ok
+CREATE TABLE stats(num_docs) AS SELECT 1;
+
+statement ok
+CREATE TABLE postings(docid, termid, tf) AS SELECT range, range, 1 FROM range(30);
+
+statement ok
+CREATE TABLE docs(docid) AS FROM range(2);
+
+statement ok
+WITH termids(termid) AS (SELECT 1)
+SELECT
+  (SELECT num_docs FROM stats),
+  (SELECT num_docs FROM stats),
+  (SELECT num_docs FROM stats),
+  (SELECT num_docs FROM stats),
+  (SELECT num_docs FROM stats),
+  (SELECT num_docs FROM stats)
+FROM postings
+JOIN docs USING (docid)
+JOIN termids USING (termid)
+WHERE termid IN (SELECT termid FROM termids);


### PR DESCRIPTION
Only the left and right set were being swapped, but not the actual join children. I think this case is very rare, hence why it has not been caught in our current CI suite. 

Fixes https://github.com/duckdb/duckdb/issues/16426
Fixes https://github.com/duckdblabs/duckdb-internal/issues/4323