### PR TITLE
bump sqlsmith extension tag

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -133,7 +133,7 @@ duckdb_extension_load(sqlite_scanner
 duckdb_extension_load(sqlsmith
         DONT_LINK LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb-sqlsmith
-        GIT_TAG b13723fe701f1e38d2cd65b3b6eb587c6553a251
+        GIT_TAG e1eb0ae02a258f176d6e06b84c0d6c7a09c6b4da
         )
 
 ################# VSS


### PR DESCRIPTION
bumping the sqlsmith extension to a more recent version. Previous tag was on December 13, 2024.