### PR TITLE
[tests] Add allow_unsigned_extensions require

### DIFF
--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -1092,6 +1092,15 @@ class SQLLogicContext:
                 return RequireResult.MISSING
             return RequireResult.PRESENT
 
+        allow_unsigned_extensions = connection.execute(
+            "select value::BOOLEAN from duckdb_settings() where name == 'allow_unsigned_extensions'"
+        ).fetchone()[0]
+        if param == "allow_unsigned_extensions":
+            if allow_unsigned_extensions == False:
+                # If extension validation is turned on (that is allow_unsigned_extensions=False), skip test
+                return RequireResult.MISSING
+            return RequireResult.PRESENT
+
         excluded_from_autoloading = True
         for ext in self.runner.AUTOLOADABLE_EXTENSIONS:
             if ext == param:

--- a/test/extension/load_extension.test
+++ b/test/extension/load_extension.test
@@ -6,6 +6,8 @@ require notmingw
 
 require skip_reload
 
+require allow_unsigned_extensions
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/extension/load_test_alias.test
+++ b/test/extension/load_test_alias.test
@@ -6,6 +6,8 @@ require skip_reload
 
 require notmingw
 
+require allow_unsigned_extensions
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/extension/test_alias_point.test
+++ b/test/extension/test_alias_point.test
@@ -6,6 +6,8 @@ require skip_reload
 
 require notmingw
 
+require allow_unsigned_extensions
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/extension/test_custom_type_modifier_cast.test
+++ b/test/extension/test_custom_type_modifier_cast.test
@@ -6,6 +6,8 @@ require skip_reload
 
 require notmingw
 
+require allow_unsigned_extensions
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/extension/test_tags.test
+++ b/test/extension/test_tags.test
@@ -6,6 +6,8 @@ require skip_reload
 
 require notmingw
 
+require allow_unsigned_extensions
+
 statement ok
 PRAGMA enable_verification
 

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -522,6 +522,12 @@ RequireResult SQLLogicTestRunner::CheckRequire(SQLLogicParser &parser, const vec
 		}
 		return RequireResult::PRESENT;
 	}
+	if (param == "allow_unsigned_extensions") {
+		if (config->options.allow_unsigned_extensions) {
+			return RequireResult::PRESENT;
+		}
+		return RequireResult::MISSING;
+	}
 
 	bool excluded_from_autoloading = true;
 	for (const auto &ext : AUTOLOADABLE_EXTENSIONS) {


### PR DESCRIPTION
This only adds a currently unused require to test that do require loading of local extensions.

This change allow to separate tests that can't be run if ones where to set `allow_unsigned_extensions` to false.

Note that there are yet no changes checked in that will actually use this feature, but it's used to stress testing 
signed extensions for example in https://github.com/carlopi/duckdb/actions/runs/13648796593/job/38152545371#step:11:4076.