### PR TITLE
Checksum backward compatibility

### DIFF
--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -1,10 +1,65 @@
 #include "duckdb/common/checksum.hpp"
-#include "duckdb/common/types/hash.hpp"
 
 namespace duckdb {
 
 hash_t Checksum(uint64_t x) {
 	return x * UINT64_C(0xbf58476d1ce4e5b9);
+}
+
+// MIT License
+// Copyright (c) 2018-2021 Martin Ankerl
+// https://github.com/martinus/robin-hood-hashing/blob/3.11.5/LICENSE
+hash_t ChecksumRemainder(void *ptr, size_t len) noexcept {
+	static constexpr uint64_t M = UINT64_C(0xc6a4a7935bd1e995);
+	static constexpr uint64_t SEED = UINT64_C(0xe17a1465);
+	static constexpr unsigned int R = 47;
+
+	auto const *const data64 = static_cast<uint64_t const *>(ptr);
+	uint64_t h = SEED ^ (len * M);
+
+	size_t const n_blocks = len / 8;
+	for (size_t i = 0; i < n_blocks; ++i) {
+		auto k = Load<uint64_t>(reinterpret_cast<const_data_ptr_t>(data64 + i));
+
+		k *= M;
+		k ^= k >> R;
+		k *= M;
+
+		h ^= k;
+		h *= M;
+	}
+
+	auto const *const data8 = reinterpret_cast<uint8_t const *>(data64 + n_blocks);
+	switch (len & 7U) {
+	case 7:
+		h ^= static_cast<uint64_t>(data8[6]) << 48U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 6:
+		h ^= static_cast<uint64_t>(data8[5]) << 40U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 5:
+		h ^= static_cast<uint64_t>(data8[4]) << 32U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 4:
+		h ^= static_cast<uint64_t>(data8[3]) << 24U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 3:
+		h ^= static_cast<uint64_t>(data8[2]) << 16U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 2:
+		h ^= static_cast<uint64_t>(data8[1]) << 8U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 1:
+		h ^= static_cast<uint64_t>(data8[0]);
+		h *= M;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	default:
+		break;
+	}
+	h ^= h >> R;
+	h *= M;
+	h ^= h >> R;
+	return static_cast<hash_t>(h);
 }
 
 uint64_t Checksum(uint8_t *buffer, size_t size) {
@@ -17,7 +72,7 @@ uint64_t Checksum(uint8_t *buffer, size_t size) {
 	}
 	if (size - i * 8 > 0) {
 		// the remaining 0-7 bytes we hash using a string hash
-		result ^= Hash(buffer + i * 8, size - i * 8);
+		result ^= ChecksumRemainder(buffer + i * 8, size - i * 8);
 	}
 	return result;
 }

--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/common/checksum.hpp"
 
+#include "duckdb/common/helper.hpp"
+
 namespace duckdb {
 
 hash_t Checksum(uint64_t x) {


### PR DESCRIPTION
This shouldn't use our `Hash` function, but it did. Since we changed it, this broke backward compatibility of WAL files. This is only on `main`, so fixing it now should make v1.2 WAL files compatible with future v1.3 binaries.