### PR TITLE
Prefetch Parquet page header

### DIFF
--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -135,8 +135,8 @@ public:
 	static constexpr uint64_t PREFETCH_FALLBACK_BUFFERSIZE = 1000000;
 
 	ThriftFileTransport(Allocator &allocator, FileHandle &handle_p, bool prefetch_mode_p)
-	    : handle(handle_p), location(0), allocator(allocator), ra_buffer(ReadAheadBuffer(allocator, handle_p)),
-	      prefetch_mode(prefetch_mode_p) {
+	    : handle(handle_p), location(0), size(handle.GetFileSize()), allocator(allocator),
+	      ra_buffer(ReadAheadBuffer(allocator, handle_p)), prefetch_mode(prefetch_mode_p) {
 	}
 
 	uint32_t read(uint8_t *buf, uint32_t len) {
@@ -195,6 +195,10 @@ public:
 		location += skip_count;
 	}
 
+	bool HasPrefetch() const {
+		return !ra_buffer.read_heads.empty() || !ra_buffer.merge_set.empty();
+	}
+
 	void SetLocation(idx_t location_p) {
 		location = location_p;
 	}
@@ -203,12 +207,13 @@ public:
 		return location;
 	}
 	idx_t GetSize() {
-		return handle.file_system.GetFileSize(handle);
+		return size;
 	}
 
 private:
 	FileHandle &handle;
 	idx_t location;
+	idx_t size;
 
 	Allocator &allocator;
 


### PR DESCRIPTION
This PR prefetches Parquet page headers so that they are read using one `FileSystem::Read` call, instead of having Thrift call into `FileSystem::Read` while decoding the page header, causing it to do many tiny reads (sometimes a few bytes at a time). This optimization will only happen when no other prefetches have happened (so it only applies to local reads), and the prefetch will get up to 256 bytes (which should cover most Parquet page headers).

When reading TPC-H SF10 lineitem using this query:
```sql
copy lineitem to 'lineitem_v1.parquet' (parquet_version v1); -- with V1 encodings
copy lineitem to 'lineitem_v2.parquet' (parquet_version v2); -- with V2 encodings
select any_value(columns(*)) from 'lineitem_v1.parquet';
select any_value(columns(*)) from 'lineitem_v2.parquet';
```
Performance improves like so:
V1: 0.48s -> 0.43s
V2: 0.36s -> 0.29s