### PR TITLE
CodeQuality: ubuntu-20 to ubuntu-22, lock black to version 24 and trick clang_format detection

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   format-check:
     name: Format Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       CC: gcc-10
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install
         shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format-11 && sudo pip3 install cmake-format black cxxheaderparser pcpp
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format-11 && sudo pip3 install cmake-format 'black==24.*' cxxheaderparser pcpp 'clang_format==11.0.1'
 
       - name: List Installed Packages
         shell: bash
@@ -73,7 +73,7 @@ jobs:
   enum-check:
     name: C Enum Integrity Check
     needs: format-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       CC: gcc-10


### PR DESCRIPTION
Adding 'clang_format==11.0.1' I am not really sure why it needs to be there, but here we are ...