### PR TITLE
LinuxRelease.yml: Pass down override git describe

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -11,6 +11,9 @@ inputs:
   vcpkg_target_triplet:
     description: 'Target triplet for installing vcpkg dependencies'
     default: ''
+  override_git_describe:
+    description: 'Override git describe'
+    default: ''
 
 runs:
   using: "composite"
@@ -56,7 +59,7 @@ runs:
           echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ inputs.vcpkg_target_triplet }}" >> docker_env.txt
           echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
           echo "DUCKDB_PLATFORM=${{ inputs.duckdb_arch }}" >> docker_env.txt
-          echo "DUCKDB_GIT_VERSION=${{ inputs.override_git_describe }}" >> docker_env.txt
+          echo "OVERRIDE_GIT_DESCRIBE=${{ inputs.override_git_describe }}" >> docker_env.txt
           echo "LINUX_CI_IN_DOCKER=1" >> docker_env.txt
           echo "TOOLCHAIN_FLAGS=${{ inputs.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt
           echo "CC=${{ inputs.duckdb_arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || '' }}" >> docker_env.txt

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -195,6 +195,7 @@ jobs:
           vcpkg_target_triplet: x64-linux
           duckdb_arch: linux_amd64
           run_tests: ${{ inputs.skip_tests != 'true' }}
+          override_git_describe: ${{ inputs.override_git_describe }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -234,6 +235,7 @@ jobs:
           vcpkg_target_triplet: x64-linux
           duckdb_arch: linux_amd64_musl
           run_tests: ${{ inputs.skip_tests != 'true' }}
+          override_git_describe: ${{ inputs.override_git_describe }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -279,6 +281,7 @@ jobs:
           vcpkg_target_triplet: arm64-linux
           duckdb_arch: linux_arm64
           run_tests: ${{ inputs.skip_tests != 'true' }}
+          override_git_describe: ${{ inputs.override_git_describe }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -150,6 +150,7 @@ jobs:
           vcpkg_target_triplet: x64-linux
           duckdb_arch: linux_amd64_gcc4
           run_tests: ${{ inputs.skip_tests != 'true' }}
+          override_git_describe: ${{ inputs.override_git_describe }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This do not change anything on the regular path, but do pass down what should be overridden.

I am testing this on my fork by providing a bogus descriptor, looks to behave as expected (https://github.com/carlopi/duckdb/actions/runs/13670863693/job/38220629656)

Important thing: this do not change anything on a regular path where an override is not provided, so CI here should be mostly checking for nonsense.