### PR TITLE
[Python] Fix deadlock in `from_parquet` with `file_globs` caused by not releasing the GIL

### DIFF
--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -265,10 +265,13 @@ public:
 	unique_ptr<DuckDBPyRelation> FromParquet(const string &file_glob, bool binary_as_string, bool file_row_number,
 	                                         bool filename, bool hive_partitioning, bool union_by_name,
 	                                         const py::object &compression = py::none());
-
 	unique_ptr<DuckDBPyRelation> FromParquets(const vector<string> &file_globs, bool binary_as_string,
 	                                          bool file_row_number, bool filename, bool hive_partitioning,
 	                                          bool union_by_name, const py::object &compression = py::none());
+
+	unique_ptr<DuckDBPyRelation> FromParquetInternal(Value &&file_param, bool binary_as_string, bool file_row_number,
+	                                                 bool filename, bool hive_partitioning, bool union_by_name,
+	                                                 const py::object &compression = py::none());
 
 	unique_ptr<DuckDBPyRelation> FromArrow(py::object &arrow_object);
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -1676,14 +1676,14 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDF(const PandasDataFrame &v
 	return make_uniq<DuckDBPyRelation>(std::move(rel));
 }
 
-unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromParquet(const string &file_glob, bool binary_as_string,
-                                                             bool file_row_number, bool filename,
-                                                             bool hive_partitioning, bool union_by_name,
-                                                             const py::object &compression) {
+unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromParquetInternal(Value &&file_param, bool binary_as_string,
+                                                                     bool file_row_number, bool filename,
+                                                                     bool hive_partitioning, bool union_by_name,
+                                                                     const py::object &compression) {
 	auto &connection = con.GetConnection();
 	string name = "parquet_" + StringUtil::GenerateRandomName();
 	vector<Value> params;
-	params.emplace_back(file_glob);
+	params.emplace_back(std::move(file_param));
 	named_parameter_map_t named_parameters({{"binary_as_string", Value::BOOLEAN(binary_as_string)},
 	                                        {"file_row_number", Value::BOOLEAN(file_row_number)},
 	                                        {"filename", Value::BOOLEAN(filename)},
@@ -1701,32 +1701,27 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromParquet(const string &file_
 	return make_uniq<DuckDBPyRelation>(connection.TableFunction("parquet_scan", params, named_parameters)->Alias(name));
 }
 
+unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromParquet(const string &file_glob, bool binary_as_string,
+                                                             bool file_row_number, bool filename,
+                                                             bool hive_partitioning, bool union_by_name,
+                                                             const py::object &compression) {
+	auto file_param = Value(file_glob);
+	return FromParquetInternal(std::move(file_param), binary_as_string, file_row_number, filename, hive_partitioning,
+	                           union_by_name, compression);
+}
+
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromParquets(const vector<string> &file_globs, bool binary_as_string,
                                                               bool file_row_number, bool filename,
                                                               bool hive_partitioning, bool union_by_name,
                                                               const py::object &compression) {
-	auto &connection = con.GetConnection();
-	string name = "parquet_" + StringUtil::GenerateRandomName();
 	vector<Value> params;
 	auto file_globs_as_value = vector<Value>();
 	for (const auto &file : file_globs) {
 		file_globs_as_value.emplace_back(file);
 	}
-	params.emplace_back(Value::LIST(file_globs_as_value));
-	named_parameter_map_t named_parameters({{"binary_as_string", Value::BOOLEAN(binary_as_string)},
-	                                        {"file_row_number", Value::BOOLEAN(file_row_number)},
-	                                        {"filename", Value::BOOLEAN(filename)},
-	                                        {"hive_partitioning", Value::BOOLEAN(hive_partitioning)},
-	                                        {"union_by_name", Value::BOOLEAN(union_by_name)}});
-
-	if (!py::none().is(compression)) {
-		if (!py::isinstance<py::str>(compression)) {
-			throw InvalidInputException("from_parquet only accepts 'compression' as a string");
-		}
-		named_parameters["compression"] = Value(py::str(compression));
-	}
-
-	return make_uniq<DuckDBPyRelation>(connection.TableFunction("parquet_scan", params, named_parameters)->Alias(name));
+	auto file_param = Value::LIST(file_globs_as_value);
+	return FromParquetInternal(std::move(file_param), binary_as_string, file_row_number, filename, hive_partitioning,
+	                           union_by_name, compression);
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromArrow(py::object &arrow_object) {

--- a/tools/pythonpkg/tests/fast/api/test_fsspec.py
+++ b/tools/pythonpkg/tests/fast/api/test_fsspec.py
@@ -1,0 +1,51 @@
+import pytest
+import duckdb
+import io
+
+fsspec = pytest.importorskip("fsspec")
+
+
+class TestReadParquet(object):
+    def test_fsspec_deadlock(self, duckdb_cursor, tmp_path):
+        # Create test parquet data
+        file_path = tmp_path / "data.parquet"
+        duckdb_cursor.sql("COPY (FROM range(50_000)) TO '{}' (FORMAT parquet)".format(str(file_path)))
+        with open(file_path, "rb") as f:
+            parquet_data = f.read()
+
+        class TestFileSystem(fsspec.AbstractFileSystem):
+            protocol = "deadlock"
+
+            @property
+            def fsid(self):
+                return "deadlock"
+
+            def ls(self, path, detail=True, **kwargs):
+                vals = [k for k in self._data.keys() if k.startswith(path)]
+                if detail:
+                    return [
+                        {
+                            "name": path,
+                            "size": len(self._data[path]),
+                            "type": "file",
+                            "created": 0,
+                            "islink": False,
+                        }
+                        for path in vals
+                    ]
+                else:
+                    return vals
+
+            def _open(self, path, **kwargs):
+                return io.BytesIO(self._data[path])
+
+            def __init__(self):
+                super().__init__()
+                self._data = {"a": parquet_data, "b": parquet_data}
+
+        fsspec.register_implementation("deadlock", TestFileSystem, clobber=True)
+        fs = fsspec.filesystem('deadlock')
+        duckdb_cursor.register_filesystem(fs)
+
+        result = duckdb_cursor.read_parquet(file_globs=["deadlock://a", "deadlock://b"], union_by_name=True)
+        assert len(result.fetchall()) == 100_000


### PR DESCRIPTION
This PR fixes #16501 

This was already fixed for `read_parquet` without `file_globs`, but the crucial `py::gil_scoped_release` was missing in the other variant, I've unified them to avoid problems like this in the future