### PR TITLE
Fix ADBC to properly quote table and schema names

### DIFF
--- a/test/api/adbc/test_adbc.cpp
+++ b/test/api/adbc/test_adbc.cpp
@@ -196,8 +196,8 @@ TEST_CASE("ADBC - Test ingestion - Quoted Table and Schema", "[adbc]") {
 	InitializeADBCError(&adbc_error);
 
 	ArrowSchema arrow_schema;
-	REQUIRE(SUCCESS(
-	    AdbcConnectionGetTableSchema(&db.adbc_connection, nullptr, "my schema", "my table", &arrow_schema, &adbc_error)));
+	REQUIRE(SUCCESS(AdbcConnectionGetTableSchema(&db.adbc_connection, nullptr, "my schema", "my table", &arrow_schema,
+	                                             &adbc_error)));
 	REQUIRE((arrow_schema.n_children == 1));
 	arrow_schema.release(&arrow_schema);
 }
@@ -1544,7 +1544,7 @@ TEST_CASE("Test AdbcConnectionGetObjects", "[adbc]") {
 	}
 	//  Now lets test some errors
 	{
-		ADBCTestDatabase db("test_errors");  
+		ADBCTestDatabase db("test_errors");
 		// Create Arrow Result
 		auto input_data = db.QueryArrow("SELECT 42");
 		// Create Table 'my_table' from the Arrow Result


### PR DESCRIPTION
Some queries are being constructed in the ADBC API without taking proper quoting and escaping into account for object names. 