### PR TITLE
Avoid throwing an exception (that is then swallowed) when computing compressed materialization over stats that are not set

### DIFF
--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -329,6 +329,9 @@ unique_ptr<CompressExpression> CompressedMaterialization::GetCompressExpression(
 static Value GetIntegralRangeValue(ClientContext &context, const LogicalType &type, const BaseStatistics &stats) {
 	auto min = NumericStats::Min(stats);
 	auto max = NumericStats::Max(stats);
+	if (max < min) {
+		return Value::HUGEINT(NumericLimits<hugeint_t>::Maximum());
+	}
 
 	vector<unique_ptr<Expression>> arguments;
 	arguments.emplace_back(make_uniq<BoundConstantExpression>(max));


### PR DESCRIPTION
When stats are uninitialized `MIN` is set to `INT_MAX` and `MAX` is set to `INT_MIN`, i.e. `max < min`. This PR detects this situation and early-outs in the compressed materialization optimizer. This will otherwise throw an exception in `ExpressionExecutor::TryEvaluateScalar` which will get swallowed - but shows up when debugging.