### PR TITLE
[Dev] Fix issues in the benchmark runner related to the serialized `storage_version`

### DIFF
--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -120,7 +120,17 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 	Profiler profiler;
 	auto display_name = benchmark->DisplayName();
 
-	auto state = benchmark->Initialize(configuration);
+	duckdb::unique_ptr<BenchmarkState> state;
+	try {
+		state = benchmark->Initialize(configuration);
+		benchmark->Assert(state.get());
+	} catch (std::exception &ex) {
+		Log(StringUtil::Format("%s\t1\t", benchmark->name));
+		LogResult("ERROR");
+		duckdb::ErrorData error_data(ex);
+		LogLine(error_data.Message());
+		return;
+	}
 	auto nruns = benchmark->NRuns();
 	for (size_t i = 0; i < nruns + 1; i++) {
 		bool hotrun = i > 0;
@@ -135,16 +145,25 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 		std::thread interrupt_thread(sleep_thread, benchmark, this, state.get(), hotrun,
 		                             benchmark->Timeout(configuration));
 
-		profiler.Start();
-		benchmark->Run(state.get());
-		profiler.End();
+		string error;
+		try {
+			profiler.Start();
+			benchmark->Run(state.get());
+			profiler.End();
+		} catch (std::exception &ex) {
+			duckdb::ErrorData error_data(ex);
+			error = error_data.Message();
+		}
 
 		is_active = false;
 		interrupt_thread.join();
 		if (hotrun) {
 			LogOutput(benchmark->GetLogOutput(state.get()));
-			if (timeout) {
-				// write timeout
+			if (!error.empty()) {
+				LogResult("ERROR");
+				LogLine(error);
+				break;
+			} else if (timeout) {
 				LogResult("TIMEOUT");
 				break;
 			} else {

--- a/benchmark/include/benchmark.hpp
+++ b/benchmark/include/benchmark.hpp
@@ -43,6 +43,8 @@ public:
 	virtual duckdb::unique_ptr<BenchmarkState> Initialize(BenchmarkConfiguration &config) {
 		return nullptr;
 	}
+	//! Assert correctness after load, before run
+	virtual void Assert(BenchmarkState *state) {};
 	//! Run the benchmark
 	virtual void Run(BenchmarkState *state) = 0;
 	//! Cleanup the benchmark, called after each Run

--- a/benchmark/include/interpreted_benchmark.hpp
+++ b/benchmark/include/interpreted_benchmark.hpp
@@ -15,8 +15,20 @@
 namespace duckdb {
 struct BenchmarkFileReader;
 class MaterializedQueryResult;
+struct InterpretedBenchmarkState;
 
 const string DEFAULT_DB_PATH = "duckdb_benchmark_db.db";
+
+struct BenchmarkQuery {
+public:
+	BenchmarkQuery() {
+	}
+
+public:
+	string query;
+	idx_t column_count = 0;
+	vector<vector<string>> expected_result;
+};
 
 //! Interpreted benchmarks read the benchmark from a file
 class InterpretedBenchmark : public Benchmark {
@@ -26,6 +38,8 @@ public:
 	void LoadBenchmark();
 	//! Initialize the benchmark state
 	duckdb::unique_ptr<BenchmarkState> Initialize(BenchmarkConfiguration &config) override;
+	//! Assert correct/expected state of the db, before Run
+	void Assert(BenchmarkState *state) override;
 	//! Run the benchmark
 	void Run(BenchmarkState *state) override;
 	//! Cleanup the benchmark, called after each Run
@@ -62,10 +76,12 @@ public:
 	}
 
 private:
-	string VerifyInternal(BenchmarkState *state_p, MaterializedQueryResult &result);
+	string VerifyInternal(BenchmarkState *state_p, const BenchmarkQuery &query, MaterializedQueryResult &result);
 
-	void ReadResultFromFile(BenchmarkFileReader &reader, const string &file);
-	void ReadResultFromReader(BenchmarkFileReader &reader, const string &file);
+	BenchmarkQuery ReadQueryFromFile(BenchmarkFileReader &reader, const string &file);
+	BenchmarkQuery ReadQueryFromReader(BenchmarkFileReader &reader, const string &sql, const string &header);
+
+	unique_ptr<QueryResult> RunLoadQuery(InterpretedBenchmarkState &state, const string &load_query);
 
 private:
 	bool is_loaded = false;
@@ -81,15 +97,19 @@ private:
 	// can be used to test accessing data from a different db in a non-persistent connection
 	bool cache_no_connect = false;
 	std::unordered_set<string> extensions;
-	int64_t result_column_count = 0;
-	vector<vector<string>> result_values;
-	string result_query;
+
+	//! Queries used to assert a given state of the data
+	vector<BenchmarkQuery> assert_queries;
+	vector<BenchmarkQuery> result_queries;
+	//! How many times to retry the load, if any
+	idx_t retry_load = 0;
 
 	string display_name;
 	string display_group;
 	string subgroup;
 
 	bool in_memory = true;
+	string storage_version;
 	QueryResultType result_type = QueryResultType::MATERIALIZED_RESULT;
 	idx_t arrow_batch_size = STANDARD_VECTOR_SIZE;
 	bool require_reinit = false;

--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -43,16 +43,19 @@ struct InterpretedBenchmarkState : public BenchmarkState {
 	Connection con;
 	duckdb::unique_ptr<MaterializedQueryResult> result;
 
-	explicit InterpretedBenchmarkState(string path)
-	    : benchmark_config(GetBenchmarkConfig()), db(path.empty() ? nullptr : path.c_str(), benchmark_config.get()),
-	      con(db) {
+	explicit InterpretedBenchmarkState(string path, const string &version)
+	    : benchmark_config(GetBenchmarkConfig(version)),
+	      db(path.empty() ? nullptr : path.c_str(), benchmark_config.get()), con(db) {
 		auto &instance = BenchmarkRunner::GetInstance();
 		auto res = con.Query("PRAGMA threads=" + to_string(instance.threads));
 		D_ASSERT(!res->HasError());
 	}
 
-	duckdb::unique_ptr<DBConfig> GetBenchmarkConfig() {
+	duckdb::unique_ptr<DBConfig> GetBenchmarkConfig(const string &version = "") {
 		auto result = make_uniq<DBConfig>();
+		if (!version.empty()) {
+			result->options.serialization_compatibility = SerializationCompatibility::FromString(version);
+		}
 		result->options.load_extensions = false;
 		return result;
 	}
@@ -96,24 +99,31 @@ InterpretedBenchmark::InterpretedBenchmark(string full_path)
 	replacement_mapping["BENCHMARK_DIR"] = BenchmarkRunner::DUCKDB_BENCHMARK_DIRECTORY;
 }
 
-void InterpretedBenchmark::ReadResultFromFile(BenchmarkFileReader &reader, const string &file) {
+BenchmarkQuery InterpretedBenchmark::ReadQueryFromFile(BenchmarkFileReader &reader, const string &file) {
 	// read the results from the file
+	BenchmarkQuery query;
+	query.query = "";
+
 	DuckDB db;
 	Connection con(db);
 	auto result = con.Query("FROM read_csv('" + file +
 	                        "', delim='|', header=1, nullstr='NULL', all_varchar=1, quote ='\"', escape ='\"')");
-	result_column_count = result->ColumnCount();
+	query.column_count = result->ColumnCount();
 	for (auto &row : *result) {
 		vector<string> row_values;
 		for (idx_t col_idx = 0; col_idx < result->ColumnCount(); col_idx++) {
 			row_values.push_back(row.GetValue<string>(col_idx));
 		}
-		result_values.push_back(std::move(row_values));
+		query.expected_result.push_back(std::move(row_values));
 	}
+	return query;
 }
 
-void InterpretedBenchmark::ReadResultFromReader(BenchmarkFileReader &reader, const string &header) {
-	result_column_count = header.size();
+BenchmarkQuery InterpretedBenchmark::ReadQueryFromReader(BenchmarkFileReader &reader, const string &sql,
+                                                         const string &header) {
+	BenchmarkQuery query;
+	query.query = sql;
+	query.column_count = header.size();
 	// keep reading results until eof
 	string line;
 	while (reader.ReadLine(line)) {
@@ -121,12 +131,13 @@ void InterpretedBenchmark::ReadResultFromReader(BenchmarkFileReader &reader, con
 			break;
 		}
 		auto result_splits = StringUtil::Split(line, "\t");
-		if ((int64_t)result_splits.size() != result_column_count) {
+		if ((int64_t)result_splits.size() != query.column_count) {
 			throw std::runtime_error(reader.FormatException("expected " + std::to_string(result_splits.size()) +
-			                                                " values but got " + std::to_string(result_column_count)));
+			                                                " values but got " + std::to_string(query.column_count)));
 		}
-		result_values.push_back(std::move(result_splits));
+		query.expected_result.push_back(std::move(result_splits));
 	}
+	return query;
 }
 
 static void ThrowResultModeError(BenchmarkFileReader &reader) {
@@ -153,6 +164,7 @@ void InterpretedBenchmark::LoadBenchmark() {
 			if (queries.find(splits[0]) != queries.end()) {
 				throw std::runtime_error("Multiple calls to " + splits[0] + " in the same benchmark file");
 			}
+
 			// load command: keep reading until we find a blank line or EOF
 			string query;
 			while (reader.ReadLine(line)) {
@@ -233,8 +245,8 @@ void InterpretedBenchmark::LoadBenchmark() {
 				cache_db = string();
 			}
 		} else if (splits[0] == "storage") {
-			if (splits.size() != 2) {
-				throw std::runtime_error(reader.FormatException("storage requires a single parameter"));
+			if (splits.size() < 2) {
+				throw std::runtime_error(reader.FormatException("storage requires at least one parameter"));
 			}
 			if (splits[1] == "transient") {
 				in_memory = true;
@@ -242,6 +254,10 @@ void InterpretedBenchmark::LoadBenchmark() {
 				in_memory = false;
 			} else {
 				throw std::runtime_error(reader.FormatException("Invalid argument for storage"));
+			}
+
+			if (splits.size() == 3) {
+				storage_version = splits[2];
 			}
 		} else if (splits[0] == "require_reinit") {
 			if (splits.size() != 1) {
@@ -261,8 +277,31 @@ void InterpretedBenchmark::LoadBenchmark() {
 			} else {
 				subgroup = result;
 			}
-		} else if (splits[0] == "result_query") {
-			if (result_column_count > 0) {
+		} else if (splits[0] == "assert") {
+			// count the amount of columns
+			if (splits.size() <= 1 || splits[1].size() == 0) {
+				throw std::runtime_error(
+				    reader.FormatException("assert must be followed by a column count (e.g. result III)"));
+			}
+
+			// read the actual query
+			bool found_end = false;
+			string sql;
+			while (reader.ReadLine(line)) {
+				if (line == "----") {
+					found_end = true;
+					break;
+				}
+				sql += "\n" + line;
+			}
+			if (!found_end) {
+				throw std::runtime_error(reader.FormatException(
+				    "result_query must be followed by a query and a result (separated by ----)"));
+			}
+
+			assert_queries.push_back(ReadQueryFromReader(reader, sql, splits[1]));
+		} else if (splits[0] == "result_query" || splits[0] == "result") {
+			if (!result_queries.empty()) {
 				throw std::runtime_error(reader.FormatException("multiple results found"));
 			}
 			// count the amount of columns
@@ -278,56 +317,39 @@ void InterpretedBenchmark::LoadBenchmark() {
 				}
 			}
 			if (is_file) {
-				ReadResultFromFile(reader, splits[1]);
-			}
-			// read the actual query
-			bool found_end = false;
-			string sql;
-			while (reader.ReadLine(line)) {
-				if (line == "----") {
-					found_end = true;
-					break;
-				}
-				sql += "\n" + line;
-			}
-			result_query = sql;
-			if (!found_end) {
-				throw std::runtime_error(reader.FormatException(
-				    "result_query must be followed by a query and a result (separated by ----)"));
-			}
-			if (!is_file) {
-				ReadResultFromReader(reader, splits[1]);
-			}
-		} else if (splits[0] == "result") {
-			if (result_column_count > 0) {
-				throw std::runtime_error(reader.FormatException("multiple results found"));
-			}
-			// count the amount of columns
-			if (splits.size() <= 1 || splits[1].size() == 0) {
-				throw std::runtime_error(
-				    reader.FormatException("result must be followed by a column count (e.g. result III) or a file "
-				                           "(e.g. result /path/to/file.csv)"));
-			}
-			bool is_file = false;
-			for (idx_t i = 0; i < splits[1].size(); i++) {
-				if (splits[1][i] != 'i') {
-					is_file = true;
-					break;
-				}
-			}
-			if (is_file) {
-				ReadResultFromFile(reader, splits[1]);
-
-				// read the main file until we encounter an empty line
-				string line;
-				while (reader.ReadLine(line)) {
-					if (line.empty()) {
-						break;
-					}
-				}
+				result_queries.push_back(ReadQueryFromFile(reader, splits[1]));
 			} else {
-				ReadResultFromReader(reader, splits[1]);
+				string result_query;
+				if (splits[0] == "result_query") {
+					// read the actual query
+					bool found_end = false;
+					string sql;
+					while (reader.ReadLine(line)) {
+						if (line == "----") {
+							found_end = true;
+							break;
+						}
+						sql += "\n" + line;
+					}
+					if (!found_end) {
+						throw std::runtime_error(reader.FormatException(
+						    "result_query must be followed by a query and a result (separated by ----)"));
+					}
+					result_query = sql;
+				} else {
+					//! Read directly from the answer
+					result_query = "select * from __answer";
+				}
+				result_queries.push_back(ReadQueryFromReader(reader, result_query, splits[1]));
 			}
+		} else if (splits[0] == "retry") {
+			if (splits.size() != 3) {
+				throw std::runtime_error(reader.FormatException(splits[0] + " requires two parameters"));
+			}
+			if (splits[1] != "load") {
+				throw std::runtime_error("Only retry load is supported");
+			}
+			retry_load = std::stoull(splits[2]);
 		} else if (splits[0] == "template") {
 			// template: update the path to read
 			benchmark_path = splits[1];
@@ -358,18 +380,29 @@ void InterpretedBenchmark::LoadBenchmark() {
 	is_loaded = true;
 }
 
+unique_ptr<QueryResult> InterpretedBenchmark::RunLoadQuery(InterpretedBenchmarkState &state, const string &load_query) {
+	auto result = state.con.Query(load_query);
+	for (idx_t i = 0; i < retry_load; i++) {
+		if (!result->HasError()) {
+			break;
+		}
+		result = state.con.Query(load_query);
+	}
+	return unique_ptr_cast<MaterializedQueryResult, QueryResult>(std::move(result));
+}
+
 unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfiguration &config) {
 	duckdb::unique_ptr<QueryResult> result;
 	LoadBenchmark();
 	duckdb::unique_ptr<InterpretedBenchmarkState> state;
 	auto full_db_path = GetDatabasePath();
 	try {
-		state = make_uniq<InterpretedBenchmarkState>(full_db_path);
+		state = make_uniq<InterpretedBenchmarkState>(full_db_path, storage_version);
 	} catch (Exception &e) {
 		// if the connection throws an error, chances are it's a storage format error.
 		// In this case delete the file and connect again.
 		DeleteDatabase(full_db_path);
-		state = make_uniq<InterpretedBenchmarkState>(full_db_path);
+		state = make_uniq<InterpretedBenchmarkState>(full_db_path, storage_version);
 	}
 	extensions.insert("core_functions");
 	extensions.insert("parquet");
@@ -403,11 +436,11 @@ unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfigurati
 		auto fs = FileSystem::CreateLocal();
 		if (!fs->FileExists(fs->JoinPath(BenchmarkRunner::DUCKDB_BENCHMARK_DIRECTORY, cache_file))) {
 			// no cache or db_path specified: just run the initialization code
-			result = state->con.Query(load_query);
+			result = RunLoadQuery(*state, load_query);
 		}
 	} else if (cache_db.empty() && cache_db.compare(DEFAULT_DB_PATH) != 0) {
 		// no cache or db_path specified: just run the initialization code
-		result = state->con.Query(load_query);
+		result = RunLoadQuery(*state, load_query);
 	} else {
 		// cache or db_path is specified: try to load from one of them
 		bool in_memory_db_has_data = false;
@@ -425,7 +458,7 @@ unique_ptr<BenchmarkState> InterpretedBenchmark::Initialize(BenchmarkConfigurati
 		}
 		if (!in_memory_db_has_data) {
 			// failed to load: write the cache
-			result = state->con.Query(load_query);
+			result = RunLoadQuery(*state, load_query);
 		}
 	}
 	while (result) {
@@ -473,6 +506,22 @@ ScopedConfigSetting PrepareResultCollector(ClientConfig &config, InterpretedBenc
 		    [](ClientConfig &config) { config.result_collector = nullptr; });
 	}
 	return ScopedConfigSetting(config);
+}
+
+void InterpretedBenchmark::Assert(BenchmarkState *state_p) {
+	auto &state = (InterpretedBenchmarkState &)*state_p;
+
+	for (auto &assert_query : assert_queries) {
+		auto &query = assert_query.query;
+		auto result = state.con.Query(query);
+		if (result->HasError()) {
+			result->ThrowError();
+		}
+		auto verify_result = VerifyInternal(state_p, assert_query, *result);
+		if (!verify_result.empty()) {
+			throw InvalidInputException("Assertion query failed:\n%s", verify_result);
+		}
+	}
 }
 
 void InterpretedBenchmark::Run(BenchmarkState *state_p) {
@@ -526,21 +575,25 @@ string InterpretedBenchmark::GetDatabasePath() {
 	return db_path;
 }
 
-string InterpretedBenchmark::VerifyInternal(BenchmarkState *state_p, MaterializedQueryResult &result) {
+string InterpretedBenchmark::VerifyInternal(BenchmarkState *state_p, const BenchmarkQuery &query,
+                                            MaterializedQueryResult &result) {
 	auto &state = (InterpretedBenchmarkState &)*state_p;
-	// compare the column count
-	if (result_column_count >= 0 && (int64_t)result.ColumnCount() != result_column_count) {
+
+	auto &result_values = query.expected_result;
+	D_ASSERT(query.column_count >= 1);
+	if (query.column_count != (int64_t)result.ColumnCount()) {
 		return StringUtil::Format("Error in result: expected %lld columns but got %lld\nObtained result: %s",
-		                          (int64_t)result_column_count, (int64_t)result.ColumnCount(), result.ToString());
+		                          (int64_t)query.column_count, (int64_t)result.ColumnCount(), result.ToString());
 	}
+
 	// compare row count
-	if (result.RowCount() != result_values.size()) {
+	if (result.RowCount() != query.expected_result.size()) {
 		return StringUtil::Format("Error in result: expected %lld rows but got %lld\nObtained result: %s",
 		                          (int64_t)result_values.size(), (int64_t)result.RowCount(), result.ToString());
 	}
 	// compare values
 	for (int64_t r = 0; r < (int64_t)result_values.size(); r++) {
-		for (int64_t c = 0; c < result_column_count; c++) {
+		for (int64_t c = 0; c < query.column_count; c++) {
 			auto value = result.GetValue(c, r);
 			if (result_values[r][c] == "NULL" && value.IsNull()) {
 				continue;
@@ -578,47 +631,49 @@ string InterpretedBenchmark::Verify(BenchmarkState *state_p) {
 	if (state.result->HasError()) {
 		return state.result->GetError();
 	}
-	if (result_column_count == 0) {
+	if (result_queries.empty()) {
 		// no result specified
 		return string();
 	}
-	if (!result_query.empty()) {
-		// we are running a result query
-		// store the current result in a table called "__answer"
-		auto &collection = state.result->Collection();
-		auto &names = state.result->names;
-		auto &types = state.result->types;
-		// first create the (empty) table
-		string create_tbl = "CREATE OR REPLACE TEMP TABLE __answer(";
-		for (idx_t i = 0; i < names.size(); i++) {
-			if (i > 0) {
-				create_tbl += ", ";
-			}
-			create_tbl += KeywordHelper::WriteOptionallyQuoted(names[i]);
-			create_tbl += " ";
-			create_tbl += types[i].ToString();
-		}
-		create_tbl += ")";
-		auto new_result = state.con.Query(create_tbl);
-		if (new_result->HasError()) {
-			return new_result->GetError();
-		}
-		// now append the result to the answer table
-		auto table_info = state.con.TableInfo("__answer");
-		if (table_info == nullptr) {
-			throw std::runtime_error("Received a nullptr when querying table info of __answer");
-		}
-		state.con.Append(*table_info, collection);
-
-		// finally run the result query and verify the result of that query
-		new_result = state.con.Query(result_query);
-		if (new_result->HasError()) {
-			return new_result->GetError();
-		}
-		return VerifyInternal(state_p, *new_result);
-	} else {
-		return VerifyInternal(state_p, *state.result);
+	D_ASSERT(result_queries.size() == 1);
+	auto &query = result_queries[0];
+	if (query.query.empty()) {
+		return string();
 	}
+
+	// we are running a result query
+	// store the current result in a table called "__answer"
+	auto &collection = state.result->Collection();
+	auto &names = state.result->names;
+	auto &types = state.result->types;
+	// first create the (empty) table
+	string create_tbl = "CREATE OR REPLACE TEMP TABLE __answer(";
+	for (idx_t i = 0; i < names.size(); i++) {
+		if (i > 0) {
+			create_tbl += ", ";
+		}
+		create_tbl += KeywordHelper::WriteOptionallyQuoted(names[i]);
+		create_tbl += " ";
+		create_tbl += types[i].ToString();
+	}
+	create_tbl += ")";
+	auto new_result = state.con.Query(create_tbl);
+	if (new_result->HasError()) {
+		return new_result->GetError();
+	}
+	// now append the result to the answer table
+	auto table_info = state.con.TableInfo("__answer");
+	if (table_info == nullptr) {
+		throw std::runtime_error("Received a nullptr when querying table info of __answer");
+	}
+	state.con.Append(*table_info, collection);
+
+	// finally run the result query and verify the result of that query
+	new_result = state.con.Query(query.query);
+	if (new_result->HasError()) {
+		return new_result->GetError();
+	}
+	return VerifyInternal(state_p, query, *new_result);
 }
 
 void InterpretedBenchmark::Interrupt(BenchmarkState *state_p) {

--- a/benchmark/micro/compression/roaring/roaring_array_read.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_array_read.benchmark
@@ -4,13 +4,18 @@
 
 name Roaring Scan Array Container
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 load
 DROP TABLE IF EXISTS tbl;
 PRAGMA force_compression='Roaring';
 CREATE TABLE tbl AS SELECT case when i%25=0 then 1337 else null end as a FROM range(0, 250_000_000) tbl(i);
 checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('tbl') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 select count(*) from tbl WHERE a IS NOT NULL;

--- a/benchmark/micro/compression/roaring/roaring_array_store.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_array_store.benchmark
@@ -4,12 +4,19 @@
 
 name Roaring Write Array Container
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 load
+CREATE TABLE data_source AS SELECT case when i%25=0 then 1337 else null end as a FROM range(0, 250_000_000) tbl(i);
 PRAGMA force_compression='Roaring';
 SET checkpoint_threshold = '10.0 GB';
-CREATE TABLE data_source AS SELECT case when i%25=0 then 1337 else null end as a FROM range(0, 250_000_000) tbl(i);
+CREATE TABLE test_compression as FROM data_source;
+checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('test_compression') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 CREATE TABLE tbl AS FROM data_source;

--- a/benchmark/micro/compression/roaring/roaring_bitset_read.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_bitset_read.benchmark
@@ -4,13 +4,18 @@
 
 name Roaring Scan Run Container Inverted
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 load
 DROP TABLE IF EXISTS tbl;
 PRAGMA force_compression='Roaring';
 CREATE TABLE tbl AS SELECT case when i%3=0 then 1337 else null end as a FROM range(0, 250_000_000) tbl(i);
 checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('tbl') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 select count(*) from tbl WHERE a IS NOT NULL;

--- a/benchmark/micro/compression/roaring/roaring_bitset_store.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_bitset_store.benchmark
@@ -4,12 +4,19 @@
 
 name Roaring Write Run Container Inverted
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 load
+CREATE TABLE data_source AS SELECT case when i%3=0 then 1337 else null end as a FROM range(0, 250_000_000) tbl(i);
 PRAGMA force_compression='roaring';
 SET checkpoint_threshold = '10.0 GB';
-CREATE TABLE data_source AS SELECT case when i%3=0 then 1337 else null end as a FROM range(0, 250_000_000) tbl(i);
+CREATE TABLE test_compression as FROM data_source;
+checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('test_compression') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 CREATE TABLE tbl AS FROM data_source;

--- a/benchmark/micro/compression/roaring/roaring_inverted_array_read.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_inverted_array_read.benchmark
@@ -4,13 +4,18 @@
 
 name Roaring Scan Array Container Inverted
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 load
 DROP TABLE IF EXISTS tbl;
 PRAGMA force_compression='Roaring';
 CREATE TABLE tbl AS SELECT case when i%25=0 then null else 1337 end as a FROM range(0, 250_000_000) tbl(i);
 checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('tbl') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 select count(*) from tbl WHERE a IS NOT NULL;

--- a/benchmark/micro/compression/roaring/roaring_inverted_array_store.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_inverted_array_store.benchmark
@@ -4,12 +4,19 @@
 
 name Roaring Scan Array Container Inverted
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 load
+CREATE TABLE data_source AS SELECT case when i%25=0 then null else 1337 end as a FROM range(0, 250_000_000) tbl(i);
 PRAGMA force_compression='roaring';
 SET checkpoint_threshold = '10.0 GB';
-CREATE TABLE data_source AS SELECT case when i%25=0 then null else 1337 end as a FROM range(0, 250_000_000) tbl(i);
+CREATE TABLE test_compression as FROM data_source;
+checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('test_compression') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 CREATE TABLE tbl AS FROM data_source;

--- a/benchmark/micro/compression/roaring/roaring_inverted_run_read.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_inverted_run_read.benchmark
@@ -4,13 +4,18 @@
 
 name Roaring Scan Run Container Inverted
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 load
 DROP TABLE IF EXISTS tbl;
 PRAGMA force_compression='Roaring';
 CREATE TABLE tbl AS SELECT case when i = 0 or (i % 512 != 0 and (i % 512) < 350 or (i % 512) > 450) then 1337 else null end as a FROM range(0, 250_000_000) tbl(i);
 checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('tbl') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 select count(*) from tbl WHERE a IS NOT NULL;

--- a/benchmark/micro/compression/roaring/roaring_inverted_run_store.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_inverted_run_store.benchmark
@@ -4,12 +4,19 @@
 
 name Roaring Write Run Container Inverted
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 load
+CREATE TABLE data_source AS SELECT case when i = 0 or (i % 512 != 0 and (i % 512) < 350 or (i % 512) > 450) then 1337 else null end as a FROM range(0, 250_000_000) tbl(i);
 PRAGMA force_compression='Roaring';
 SET checkpoint_threshold = '10.0 GB';
-CREATE TABLE data_source AS SELECT case when i = 0 or (i % 512 != 0 and (i % 512) < 350 or (i % 512) > 450) then 1337 else null end as a FROM range(0, 250_000_000) tbl(i);
+CREATE TABLE test_compression as FROM data_source;
+checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('test_compression') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 CREATE TABLE tbl AS FROM data_source;

--- a/benchmark/micro/compression/roaring/roaring_run_read.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_run_read.benchmark
@@ -4,13 +4,18 @@
 
 name Roaring Scan Run Container Inverted
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 load
 DROP TABLE IF EXISTS tbl;
 PRAGMA force_compression='Roaring';
 CREATE TABLE tbl AS SELECT case when i = 0 or (i % 512 != 0 and (i % 512) < 350 or (i % 512) > 450) then null else 1337 end as a FROM range(0, 250_000_000) tbl(i);
 checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('tbl') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 select count(*) from tbl WHERE a IS NOT NULL;

--- a/benchmark/micro/compression/roaring/roaring_run_store.benchmark
+++ b/benchmark/micro/compression/roaring/roaring_run_store.benchmark
@@ -4,13 +4,20 @@
 
 name Roaring Write Run Container
 group roaring
-storage persistent
+storage persistent v1.2.0
 
 # Roughly 8 runs per Vector
 load
+CREATE TABLE data_source AS SELECT case when i = 0 or (i % 512 != 0 and (i % 512) < 350 or (i % 512) > 450) then null else 1337 end as a FROM range(0, 250_000_000) tbl(i);
 PRAGMA force_compression='Roaring';
 SET checkpoint_threshold = '10.0 GB';
-CREATE TABLE data_source AS SELECT case when i = 0 or (i % 512 != 0 and (i % 512) < 350 or (i % 512) > 450) then null else 1337 end as a FROM range(0, 250_000_000) tbl(i);
+CREATE TABLE test_compression as FROM data_source;
+checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('test_compression') where segment_type in ('VALIDITY')
+----
+Roaring
 
 run
 CREATE TABLE tbl AS FROM data_source;

--- a/benchmark/micro/compression/zstd/zstd_read.benchmark
+++ b/benchmark/micro/compression/zstd/zstd_read.benchmark
@@ -4,7 +4,7 @@
 
 name ZSTD Scan
 group zstd
-storage persistent
+storage persistent v1.2.0
 
 load
 DROP TABLE IF EXISTS zstd_strings;
@@ -12,6 +12,11 @@ PRAGMA force_compression='zstd';
 set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(8000)], (x, y) -> concat(x, y)));
 create table zstd_strings as select getvariable('my_string') as data from range(2_500_000) tbl(i);
 checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('zstd_strings') where segment_type in ('VARCHAR')
+----
+ZSTD
 
 run
 select avg(strlen(data)) from zstd_strings;

--- a/benchmark/micro/compression/zstd/zstd_store.benchmark
+++ b/benchmark/micro/compression/zstd/zstd_store.benchmark
@@ -4,13 +4,20 @@
 
 name ZSTD Compression Write
 group zstd
-storage persistent
+storage persistent v1.2.0
 require_reinit
 
 load
 DROP TABLE IF EXISTS zstd_strings;
 PRAGMA force_compression='zstd';
 set variable my_string = (list_reduce([chr(((i % 26) + ord('a'))::INTEGER) for i in range(4096)], (x, y) -> concat(x, y)));
+create table test_compression as select getvariable('my_string') as data from range(2_500_000) tbl(i);
+checkpoint;
+
+assert I
+select DISTINCT compression from pragma_storage_info('test_compression') where segment_type in ('VARCHAR')
+----
+ZSTD
 
 run
 create table zstd_strings as select getvariable('my_string') as data from range(2_500_000) tbl(i);


### PR DESCRIPTION
This PR relates to https://github.com/duckdb/duckdb/pull/15794

With that PR, we introduced an upgrade to the previously established `serialize_compatibility` flag.
The `storage_version` now lives in the db, and dictates which compression algorithms are used.
This storage_version defaults to 0.10.2 for the sake of backwards compatibility.

The ZSTD and Roaring compression algorithms were added as part of 1.2.0, which is not covered by this default.
Because of this, the benchmarks for these compression algorithms were silently using `Uncompressed`, as the forced compression algorithm is not available.

This PR adds support for `assert` blocks in the benchmark runner, which are similar to `result_query`, any number of `assert` blocks can be added to verify the state of the db before running the benchmark.

`storage persistent` can currently be used to make the db used in the benchmark a persistent one that does not live in-memory, so that it can be checkpointed.
This PR introduces a second optional option to `storage`: `storage persistent <version>` which is similar to the SQL version:
`attach 'db' (STORAGE VERSION <version>)`