### PR TITLE
Let GitHub render *.test files as SQL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.test linguist-language=sql


### PR DESCRIPTION
While not proper sqllogictest syntax, telling GitHub to render tests using SQL still makes a noticeable difference when browsing files or reviewing diffs.

Before:

<img width="477" alt="image" src="https://github.com/user-attachments/assets/7fa94c3b-88b5-4a39-a5d4-8f90a49c1826" />

After:

<img width="477" alt="image" src="https://github.com/user-attachments/assets/e177f309-febb-4ade-98f0-73e77fa61ef7" />

In the long term, we might consider adding sqlogictest to [Linguist](https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml).