### PR TITLE
Pass `ClientContext` to catalog initialize, and postpone index binding when replaying the WAL

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1127,4 +1127,8 @@ bool Catalog::IsTemporaryCatalog() const {
 	return db.IsTemporary();
 }
 
+void Catalog::Initialize(optional_ptr<ClientContext> context, bool load_builtin) {
+	Initialize(load_builtin);
+}
+
 } // namespace duckdb

--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -82,7 +82,7 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 
 	//! Initialize the database.
 	const auto storage_options = info->GetStorageOptions();
-	attached_db->Initialize(storage_options);
+	attached_db->Initialize(context.client, storage_options);
 	if (!options.default_table.name.empty()) {
 		attached_db->GetCatalog().SetDefaultTable(options.default_table.schema, options.default_table.name);
 	}

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -117,6 +117,7 @@ public:
 		return false;
 	}
 	virtual void Initialize(bool load_builtin) = 0;
+	virtual void Initialize(optional_ptr<ClientContext> context, bool load_builtin);
 
 	bool IsSystemCatalog() const;
 	bool IsTemporaryCatalog() const;

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -64,7 +64,7 @@ public:
 	~AttachedDatabase() override;
 
 	//! Initializes the catalog and storage of the attached database.
-	void Initialize(StorageOptions options = StorageOptions());
+	void Initialize(optional_ptr<ClientContext> context = nullptr, StorageOptions options = StorageOptions());
 	void Close();
 
 	Catalog &ParentCatalog() override;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -173,11 +173,11 @@ string AttachedDatabase::ExtractDatabaseName(const string &dbpath, FileSystem &f
 	return name;
 }
 
-void AttachedDatabase::Initialize(StorageOptions options) {
+void AttachedDatabase::Initialize(optional_ptr<ClientContext> context, StorageOptions options) {
 	if (IsSystem()) {
-		catalog->Initialize(true);
+		catalog->Initialize(context, true);
 	} else {
-		catalog->Initialize(false);
+		catalog->Initialize(context, false);
 	}
 	if (storage) {
 		storage->Initialize(options);

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -201,16 +201,14 @@ void DatabaseInstance::CreateMainDatabase() {
 	info.path = config.options.database_path;
 
 	optional_ptr<AttachedDatabase> initial_database;
-	{
-		Connection con(*this);
-		con.BeginTransaction();
-		AttachOptions options(config.options);
-		initial_database = db_manager->AttachDatabase(*con.context, info, options);
-		con.Commit();
-	}
+	Connection con(*this);
+	con.BeginTransaction();
+	AttachOptions options(config.options);
+	initial_database = db_manager->AttachDatabase(*con.context, info, options);
 
 	initial_database->SetInitialDatabase();
-	initial_database->Initialize();
+	initial_database->Initialize(*con.context);
+	con.Commit();
 }
 
 static void ThrowExtensionSetUnrecognizedOptions(const case_insensitive_map_t<Value> &unrecognized_options) {

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -658,7 +658,6 @@ void WriteAheadLogDeserializer::ReplayCreateIndex() {
 	if (DeserializeOnly()) {
 		return;
 	}
-
 	auto &info = create_info->Cast<CreateIndexInfo>();
 
 	// Ensure that the index type exists.
@@ -666,41 +665,16 @@ void WriteAheadLogDeserializer::ReplayCreateIndex() {
 		info.index_type = ART::TYPE_NAME;
 	}
 
-	auto index_type = context.db->config.GetIndexTypes().FindByName(info.index_type);
-	if (!index_type) {
-		throw InternalException("Index type \"%s\" not recognized", info.index_type);
-	}
+	auto &table = catalog.GetEntry<TableCatalogEntry>(context, create_info->schema, info.table).Cast<DuckTableEntry>();
+	auto &storage = table.GetStorage();
+	auto &io_manager = TableIOManager::Get(storage);
 
 	// Create the index in the catalog.
-	auto &table = catalog.GetEntry<TableCatalogEntry>(context, create_info->schema, info.table).Cast<DuckTableEntry>();
-	auto &index = table.schema.CreateIndex(context, info, table)->Cast<DuckIndexEntry>();
+	table.schema.CreateIndex(context, info, table);
 
-	// Add the table to the bind context to bind the parsed expressions.
-	auto binder = Binder::CreateBinder(context);
-	vector<LogicalType> column_types;
-	vector<string> column_names;
-	for (auto &col : table.GetColumns().Logical()) {
-		column_types.push_back(col.Type());
-		column_names.push_back(col.Name());
-	}
-
-	// create a binder to bind the parsed expressions
-	vector<ColumnIndex> column_ids;
-	binder->bind_context.AddBaseTable(0, string(), column_names, column_types, column_ids, table);
-	IndexBinder idx_binder(*binder, context);
-
-	// Bind the parsed expressions to create unbound expressions.
-	vector<unique_ptr<Expression>> unbound_expressions;
-	for (auto &expr : index.parsed_expressions) {
-		auto copy = expr->Copy();
-		unbound_expressions.push_back(idx_binder.Bind(copy));
-	}
-
-	auto &storage = table.GetStorage();
-	CreateIndexInput input(TableIOManager::Get(storage), storage.db, info.constraint_type, info.index_name,
-	                       info.column_ids, unbound_expressions, index_info, info.options);
-	auto index_instance = index_type->create_instance(input);
-	storage.AddIndex(std::move(index_instance));
+	// add the index to the storage
+	auto unbound_index = make_uniq<UnboundIndex>(std::move(create_info), std::move(index_info), io_manager, db);
+	storage.AddIndex(std::move(unbound_index));
 }
 
 void WriteAheadLogDeserializer::ReplayDropIndex() {


### PR DESCRIPTION
This PR passes the `ClientContext` into the `Catalog::Initialize` method. For backwards compatibility, the old `Initialize` method is also preserved. 

Performing this change also revealed an issue in the WAL replay code - where we would bind expressions during the `ReplayCreateIndex`. This is solved by postponing index binding and emitting an `UnboundIndex` instead (to be bound at a later moment). 