### PR TITLE
Fix #16524: DEPENDENT_JOIN may not flatten

### DIFF
--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -393,17 +393,20 @@ void RecursiveDependentJoinPlanner::VisitOperator(LogicalOperator &op) {
 			auto &rec_cte = op.Cast<LogicalRecursiveCTE>();
 			binder.recursive_ctes[rec_cte.table_index] = &op;
 		}
-		root = std::move(op.children[0]);
-		D_ASSERT(root);
-		if (root->type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN) {
-			// Found a dependent join, flatten it
-			auto &new_root = root->Cast<LogicalDependentJoin>();
-			root = binder.PlanLateralJoin(std::move(new_root.children[0]), std::move(new_root.children[1]),
-			                              new_root.correlated_columns, new_root.join_type,
-			                              std::move(new_root.join_condition));
+		for (idx_t i = 0; i < op.children.size(); i++) {
+			root = std::move(op.children[i]);
+			D_ASSERT(root);
+			if (root->type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN) {
+				// Found a dependent join, flatten it
+				auto &new_root = root->Cast<LogicalDependentJoin>();
+				root = binder.PlanLateralJoin(std::move(new_root.children[0]), std::move(new_root.children[1]),
+				                              new_root.correlated_columns, new_root.join_type,
+				                              std::move(new_root.join_condition));
+			}
+			VisitOperatorExpressions(op);
+			op.children[i] = std::move(root);
 		}
-		VisitOperatorExpressions(op);
-		op.children[0] = std::move(root);
+
 		for (idx_t i = 0; i < op.children.size(); i++) {
 			D_ASSERT(op.children[i]);
 			VisitOperator(*op.children[i]);

--- a/test/issues/general/test_16524.test
+++ b/test/issues/general/test_16524.test
@@ -1,0 +1,24 @@
+# name: test/issues/general/test_16524.test
+# description: Issue 16524 - DuckDB internal error with a relatively complex JOIN involving lateral subqueries
+# group: [general]
+
+statement ok
+CREATE TABLE INT8_TBL(q1 int8, q2 int8);
+
+statement ok
+INSERT INTO INT8_TBL VALUES
+  ('  123   ','  456'),
+  ('123   ','4567890123456789'),
+  ('4567890123456789','123'),
+  (+4567890123456789,'4567890123456789'),
+  ('+4567890123456789','-4567890123456789');
+
+statement ok
+select * from
+  int8_tbl c left join (
+    int8_tbl a left join (select q1, coalesce(q2,42) as x from int8_tbl b) ss1
+      on a.q2 = ss1.q1
+    cross join
+    lateral (select q1, coalesce(ss1.x,q2) as y from int8_tbl d) ss2
+  ) on c.q2 = ss2.q1,
+  lateral (select ss2.y offset 0) ss3


### PR DESCRIPTION
This pr try to fix #16524 
LOGICAL_DEPENDENT_JOIN may not flatten when it's the right side of a join.

unit test cannot enable_verification, seems parser may throw error.