### PR TITLE
Python test runner: Avoid enabling profiling when executing restart command

### DIFF
--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -949,7 +949,7 @@ class SQLLogicContext:
             # If enable_profiling is NULL, skip setting custom_profiling_settings to not
             # accidentally enable profiling.
             # In that case, custom_profiling_settings is set to the default value anyway.
-            if name == "custom_profiling_settings" and not "enable_profiling" in old_settings:
+            if name == "custom_profiling_settings" and "enable_profiling" not in old_settings:
                 continue
                 
             query = f"SET {name}='{value}'"

--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -951,7 +951,7 @@ class SQLLogicContext:
             # In that case, custom_profiling_settings is set to the default value anyway.
             if name == "custom_profiling_settings" and "enable_profiling" not in old_settings:
                 continue
-                
+
             query = f"SET {name}='{value}'"
             con.execute(query)
 

--- a/scripts/sqllogictest/result.py
+++ b/scripts/sqllogictest/result.py
@@ -933,6 +933,7 @@ class SQLLogicContext:
         self.runner.database = SQLLogicDatabase(path, self)
         self.pool = self.runner.database.connect()
         con = self.pool.get_connection()
+
         for setting in old_settings:
             name, value = setting
             if name in [
@@ -942,12 +943,16 @@ class SQLLogicContext:
                 'allow_unredacted_secrets',
                 'duckdb_api',
             ]:
-                # Can not be set after initialization
+                # Cannot be set after initialization
                 continue
-            if name in ['profiling_mode', 'enable_profiling']:
-                # FIXME: 'profiling_mode' becomes "standard" when requested, but that's not actually the default setting
+
+            # If enable_profiling is NULL, skip setting custom_profiling_settings to not
+            # accidentally enable profiling.
+            # In that case, custom_profiling_settings is set to the default value anyway.
+            if name == "custom_profiling_settings" and not "enable_profiling" in old_settings:
                 continue
-            query = f"set {name}='{value}'"
+                
+            query = f"SET {name}='{value}'"
             con.execute(query)
 
     def execute_set(self, statement: Set):


### PR DESCRIPTION
When restarting a database in the Python test runner (`execute_restart`), the old config options are "copied over".

If the `enable_profiling` and `profiling_mode` options have not been changed, they are NULL and filtered out by this query:

`select name, value from duckdb_settings() where value != 'NULL' and value != ''`

Howerver, `custom_profiling_settings` has a non-empty default value. When running `SET custom_profiling_settings='<default_value>'`, this query enables profiling and therefore changes the values of `enable_profiling` and `profiling_mode`.

To prevent this, setting `custom_profiling_settings` is now skipped if `enable_profiling` is NULL. If `enable_profiling` is NULL, `custom_profiling_settings` is set to its default value anyway.