### PR TITLE
throw() -> noexcept in skiplist

### DIFF
--- a/third_party/skiplist/SkipList.h
+++ b/third_party/skiplist/SkipList.h
@@ -493,7 +493,7 @@ namespace duckdb_skiplistlib {
 
             const std::string &message() const { return msg; }
 
-            virtual ~Exception() throw() {}
+            virtual ~Exception() noexcept {}
 
         protected:
             std::string msg;


### PR DESCRIPTION
`throw()` has been deprecated since C++11. `noexcept` is the replacement.