### PR TITLE
[minor] Keep bit type sanity check consistent

### DIFF
--- a/src/common/types/bit.cpp
+++ b/src/common/types/bit.cpp
@@ -24,7 +24,7 @@ idx_t Bit::ComputeBitstringLen(idx_t len) {
 
 static inline idx_t GetBitPadding(const bitstring_t &bit_string) {
 	auto data = const_data_ptr_cast(bit_string.GetData());
-	D_ASSERT(idx_t(data[0]) <= 8);
+	D_ASSERT(idx_t(data[0]) < 8);
 	return data[0];
 }
 

--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -1593,7 +1593,7 @@ void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count)
 				auto oidx = sel->get_index(i);
 				if (validity.RowIsValid(oidx)) {
 					auto buf = strings[oidx].GetData();
-					D_ASSERT(*buf >= 0 && *buf < 8);
+					D_ASSERT(idx_t(*buf) < 8);
 					Bit::Verify(strings[oidx]);
 				}
 			}


### PR DESCRIPTION
Pretty minor, when reading through the `BIT` type related code, I found we have different sanity checks in two places, would be better to keep them consistent.

How I tested, I built with debug mode, then execute the following SQL statements:
```sql
D CREATE TABLE bit_tbl (val BITSTRING);
D INSERT INTO bit_tbl VALUES ('101010'::BITSTRING);
D SELECT * FROM bit_tbl;
┌────────┐
│  val   │
│  bit   │
├────────┤
│ 101010 │
└────────┘
```