### PR TITLE
Fixup problems connected to prep to 1.2.1

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -11,7 +11,7 @@ inputs:
 
   # Deploy config
   deploy_as:
-    description: 'Binary architecture name for deploy step'
+    description: 'Binary architecture name for deploy step - DEPRECATED'
     default: ''
   deploy_version:
     description: 'Version tag or commit short hash for deploy step'
@@ -217,35 +217,5 @@ runs:
     - name: Deploy
       if: ${{ inputs.deploy_as != '' }}
       shell: bash
-      env:
-        AWS_ACCESS_KEY_ID: ${{ inputs.s3_id }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.s3_key }}
-        DUCKDB_EXTENSION_SIGNING_PK: ${{ inputs.signing_pk }}
-        AWS_DEFAULT_REGION: us-east-1
-        DUCKDB_DEPLOY_SCRIPT_MODE: for_real
       run: |
-        cd  ${{ inputs.build_dir}}
-        if [[ "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-          if [[ ! -z "${{ inputs.deploy_version }}" ]] ; then
-            ./scripts/extension-upload-all.sh ${{ inputs.deploy_as }} ${{ inputs.deploy_version }}
-          elif [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
-            ./scripts/extension-upload-all.sh ${{ inputs.deploy_as }} ${{ github.ref_name }}
-          elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ ]] ; then
-            ./scripts/extension-upload-all.sh ${{ inputs.deploy_as }} `git log -1 --format=%h`
-          fi
-        fi
-
-    # Run the unittests (excluding the out-of-tree tests) with the extensions that we deployed to S3
-    - name: Test deployed extensions
-      if: ${{ inputs.deploy_as != '' && inputs.run_tests == 1 }}
-      shell: bash
-      env:
-        AWS_ACCESS_KEY_ID: ${{ inputs.s3_id }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.s3_key }}
-        AWS_DEFAULT_REGION: us-east-1
-      run: |
-        rm -rf ~/.duckdb
-        cd  ${{ inputs.build_dir}}
-        if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-          ./scripts/extension-upload-test.sh
-        fi
+        exit 1

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -42,6 +42,7 @@ jobs:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
+      run_all: ${{ inputs.run_all }}
 
   python:
     uses: ./.github/workflows/Python.yml

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -25,6 +25,7 @@ jobs:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
+      run_all: ${{ inputs.run_all }}
 
   linux-release:
     uses: ./.github/workflows/LinuxRelease.yml

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -8,6 +8,8 @@ on:
         type: string
       skip_tests:
         type: string
+      run_all:
+        type: string
   workflow_dispatch:
     inputs:
       override_git_describe:
@@ -15,6 +17,8 @@ on:
       git_ref:
         type: string
       skip_tests:
+        type: string
+      run_all:
         type: string
   repository_dispatch:
   push:
@@ -312,12 +316,11 @@ jobs:
         python-version: '3.12'
 
     - name: Execute test
+      if: (( inputs.skip_tests != 'true' )) && (( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || inputs.run_all == 'true' )) && (( github.repository == 'duckdb/duckdb' ))
       shell: bash
       env:
           AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
           AWS_DEFAULT_REGION: us-east-1
       run: |
-          if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$GITHUB_REPOSITORY" = "duckdb/duckdb" ]] ; then
-            ./scripts/extension-upload-test.sh
-          fi
+          ./scripts/extension-upload-test.sh

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -159,7 +159,6 @@ jobs:
             build/release/extension/*/*.duckdb_extension
 
   upload-linux-extensions-gcc4:
-    ## TODO: Add a if: github.ref == main, for now this is explicitly missing to be able to test on PR, expected is this should fail due to missing secrets
     name: Upload Linux Extensions (gcc4)
     needs: manylinux-extensions-x64
     uses: ./.github/workflows/_sign_deploy_extensions.yml

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -8,6 +8,8 @@ on:
         type: string
       skip_tests:
         type: string
+      run_all:
+        type: string
   workflow_dispatch:
     inputs:
       override_git_describe:
@@ -15,6 +17,8 @@ on:
       git_ref:
         type: string
       skip_tests:
+        type: string
+      run_all:
         type: string
   repository_dispatch:
   push:
@@ -145,7 +149,7 @@ jobs:
 
  win-release-32:
     name: Windows (32 Bit)
-    if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
+    if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' || inputs.run_all == 'true'
     runs-on: windows-2019
     needs: win-release-64
 
@@ -185,7 +189,7 @@ jobs:
 
  win-release-arm64:
    name: Windows (ARM64)
-   if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb'
+   if: github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' || inputs.run_all == 'true'
    runs-on: windows-2019
    needs: win-release-64
 


### PR DESCRIPTION
Pass down `run_all` in OSX and Windows, fix outdated comment, and remove now unused signing step.