### PR TITLE
shell: make -bail work for more errors

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -174,7 +174,7 @@ public:
 
 	void PrintDatabaseError(const char *zErr);
 	int ShellDatabaseError(sqlite3 *db);
-	int RunInitialCommand(char *sql);
+	int RunInitialCommand(char *sql, bool bail);
 
 	int RenderRow(RowRenderer &renderer, RowResult &result);
 
@@ -203,8 +203,8 @@ public:
 
 	int RunOneSqlLine(char *zSql);
 	string GetDefaultDuckDBRC();
-	void ProcessDuckDBRC(const char *file);
-	void ProcessFile(const string &file, bool is_duckdb_rc = false);
+	bool ProcessDuckDBRC(const char *file);
+	bool ProcessFile(const string &file, bool is_duckdb_rc = false);
 	int ProcessInput();
 };
 

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -385,8 +385,8 @@ static void endTimer(void) {
 #define ArraySize(X) (int)(sizeof(X) / sizeof(X[0]))
 
 /*
-** If the following flag is set, then command execution stops
-** at an error if we are not interactive.
+** If the following flag is set, then command execution stops at an error
+** if we are not interactive, including any error in processed files.
 */
 static bool bail_on_error = false;
 
@@ -638,11 +638,11 @@ idx_t ShellState::RenderLength(const string &str) {
 	return RenderLength(str.c_str());
 }
 
-int ShellState::RunInitialCommand(char *sql) {
+int ShellState::RunInitialCommand(char *sql, bool bail) {
 	int rc;
 	if (sql[0] == '.') {
 		rc = DoMetaCommand(sql);
-		if (rc && bail_on_error) {
+		if (rc && bail) {
 			return rc == 2 ? false : rc;
 		}
 	} else {
@@ -654,12 +654,12 @@ int ShellState::RunInitialCommand(char *sql) {
 		if (zErrMsg != 0) {
 			PrintDatabaseError(zErrMsg);
 			sqlite3_free(zErrMsg);
-			if (bail_on_error) {
+			if (bail) {
 				return rc != 0 ? rc : 1;
 			}
 		} else if (rc != 0) {
 			utf8_printf(stderr, "Error: unable to process SQL: \"%s\"\n", sql);
-			if (bail_on_error) {
+			if (bail) {
 				return rc;
 			}
 		}
@@ -4626,28 +4626,31 @@ string ShellState::GetDefaultDuckDBRC() {
 ** Read input from the file given by sqliterc_override.  Or if that
 ** parameter is NULL, take input from ~/.duckdbrc
 **
-** Returns the number of errors.
+** Returns true if successful, false otherwise.
 */
 
-void ShellState::ProcessFile(const string &file, bool is_duckdb_rc) {
+bool ShellState::ProcessFile(const string &file, bool is_duckdb_rc) {
 	FILE *inSaved = in;
 	int savedLineno = lineno;
+	int rc;
 
 	in = fopen(file.c_str(), "rb");
 	if (in) {
 		if (stdin_is_interactive && is_duckdb_rc) {
 			utf8_printf(stderr, "-- Loading resources from %s\n", file.c_str());
 		}
-		ProcessInput();
+		rc = ProcessInput();
 		fclose(in);
 	} else if (!is_duckdb_rc) {
 		utf8_printf(stderr, "Failed to read file \"%s\"\n", file.c_str());
+		rc = 1;
 	}
 	in = inSaved;
 	lineno = savedLineno;
+	return rc == 0;
 }
 
-void ShellState::ProcessDuckDBRC(const char *file) {
+bool ShellState::ProcessDuckDBRC(const char *file) {
 	string path;
 	if (!file) {
 		// use default .duckdbrc path
@@ -4656,11 +4659,11 @@ void ShellState::ProcessDuckDBRC(const char *file) {
 			// could not find home directory - return
 			raw_printf(stderr, "-- warning: cannot find home directory;"
 			                   " cannot read ~/.duckdbrc\n");
-			return;
+			return true;
 		}
 		file = path.c_str();
 	}
-	ProcessFile(file, true);
+	return ProcessFile(file, true);
 }
 
 /*
@@ -4903,6 +4906,8 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			data.openFlags |= DUCKDB_UNSIGNED_EXTENSIONS;
 		} else if (strcmp(z, "-safe") == 0) {
 			safe_mode = true;
+		} else if (strcmp(z, "-bail") == 0) {
+			bail_on_error = true;
 		}
 	}
 	verify_uninitialized();
@@ -4946,7 +4951,9 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 	** is given on the command line, look for a file named ~/.sqliterc and
 	** try to process it.
 	*/
-	data.ProcessDuckDBRC(zInitFile);
+	if (!data.ProcessDuckDBRC(zInitFile) && bail_on_error) {
+		return 1;
+	}
 
 	/* Make a second pass through the command-line argument and set
 	** options.  This second pass is delayed until after the initialization
@@ -5030,7 +5037,10 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 				break;
 			}
 			z = cmdline_option_value(argc, argv, ++i);
-			data.ProcessFile(string(z));
+			if (!data.ProcessFile(string(z))) {
+				free(azCmd);
+				return 1;
+			}
 		} else if (strcmp(z, "-cmd") == 0 || strcmp(z, "-c") == 0 || strcmp(z, "-s") == 0) {
 			if (strcmp(z, "-c") == 0 || strcmp(z, "-s") == 0) {
 				readStdin = false;
@@ -5042,8 +5052,10 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			if (i == argc - 1) {
 				break;
 			}
+			// Always bail if -c or -s fail
+			bool bail = bail_on_error || !strcmp(z, "-c") || !strcmp(z, "-s");
 			z = cmdline_option_value(argc, argv, ++i);
-			rc = data.RunInitialCommand(z);
+			rc = data.RunInitialCommand(z, bail);
 			if (rc != 0) {
 				free(azCmd);
 				return rc;
@@ -5052,7 +5064,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv) {
 			// safe mode has been set before
 		} else if (strcmp(z, "-ui") == 0) {
 			// run the UI command
-			rc = data.RunInitialCommand((char *)data.ui_command.c_str());
+			rc = data.RunInitialCommand((char *)data.ui_command.c_str(), true);
 			if (rc != 0) {
 				free(azCmd);
 				return rc;


### PR DESCRIPTION
I noticed that `-bail` doesn't have any effect in several cases, most notably when passing init commands, so I tried to fix it.

- `-cmd` and `-init` with `-bail` will exit on error without starting the shell
- `-cmd` and `-init` without `-bail` will continue to start the shell as before
- `-f` / `-s` / `-c` will now always exit with 1 on error

```shell
❯ build/release/duckdb -c boom; echo $?
Parser Error:
syntax error at or near "boom"

LINE 1: boom
        ^
1

❯ build/release/duckdb -s boom; echo $?
Parser Error:
syntax error at or near "boom"

LINE 1: boom
        ^
1

❯ build/release/duckdb -cmd boom; echo $?
-- Loading resources from /Users/mathias/.duckdbrc
Parser Error:
syntax error at or near "boom"

LINE 1: boom
        ^
v1.3.0-dev1569 9d11d953e6
Enter ".help" for usage hints.
🟡◗

0

❯ build/release/duckdb -cmd boom -bail; echo $?
-- Loading resources from /Users/mathias/.duckdbrc
Parser Error:
syntax error at or near "boom"

LINE 1: boom
        ^
1

❯ build/release/duckdb -init init.sql; echo $?
-- Loading resources from init.sql
Parser Error:
syntax error at or near "boom"

LINE 1: boom;
        ^
v1.3.0-dev1569 9d11d953e6
Enter ".help" for usage hints.
D

0

❯ build/release/duckdb -init init.sql -bail; echo $?
-- Loading resources from init.sql
Parser Error:
syntax error at or near "boom"

LINE 1: boom;
        ^
1

❯ build/release/duckdb -f init.sql; echo $?
Parser Error:
syntax error at or near "boom"

LINE 1: boom;
        ^
1
```