### PR TITLE
[Dev] Make the various mappings in `MultiFileReaderData` typesafe

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -57,6 +57,7 @@ if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
             GIT_TAG 6d626173e9efa6615c25eb08d979d1372100d5db
+            APPLY_PATCHES
     )
 endif()
 

--- a/.github/patches/extensions/delta/multi_file_reader_type_safety.patch
+++ b/.github/patches/extensions/delta/multi_file_reader_type_safety.patch
@@ -1,0 +1,126 @@
+diff --git a/src/functions/delta_scan/delta_multi_file_reader.cpp b/src/functions/delta_scan/delta_multi_file_reader.cpp
+index b36853a..e67ba9d 100644
+--- a/src/functions/delta_scan/delta_multi_file_reader.cpp
++++ b/src/functions/delta_scan/delta_multi_file_reader.cpp
+@@ -65,16 +65,17 @@ static void FinalizeBindBaseOverride(const MultiFileReaderOptions &file_options,
+ 		}
+ 	}
+ 	for (idx_t i = 0; i < global_column_ids.size(); i++) {
++		auto global_idx = MultiFileGlobalIndex(i);
+ 		auto &col_idx = global_column_ids[i];
+ 		if (col_idx.IsRowIdColumn()) {
+ 			// row-id
+-			reader_data.constant_map.emplace_back(i, Value::BIGINT(42));
++			reader_data.constant_map.Add(global_idx, Value::BIGINT(42));
+ 			continue;
+ 		}
+ 		auto column_id = col_idx.GetPrimaryIndex();
+ 		if (column_id == options.filename_idx) {
+ 			// filename
+-			reader_data.constant_map.emplace_back(i, Value(filename));
++			reader_data.constant_map.Add(global_idx, Value(filename));
+ 			continue;
+ 		}
+ 		if (file_options.union_by_name) {
+@@ -87,7 +88,7 @@ static void FinalizeBindBaseOverride(const MultiFileReaderOptions &file_options,
+ 			if (not_present_in_file) {
+ 				// we need to project a column with name \"global_name\" - but it does not exist in the current file
+ 				// push a NULL value of the specified type
+-				reader_data.constant_map.emplace_back(i, Value(type));
++				reader_data.constant_map.Add(global_idx, Value(type));
+ 				continue;
+ 			}
+ 		}
+@@ -190,7 +191,8 @@ void DeltaMultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_optio
+ 			// We add the constant column for the delta_file_number option
+ 			// NOTE: we add a placeholder here, to demonstrate how we can also populate extra columns in the
+ 			// FinalizeChunk
+-			reader_data.constant_map.emplace_back(delta_global_state.delta_file_number_idx, Value::UBIGINT(0));
++			auto global_idx = MultiFileGlobalIndex(delta_global_state.delta_file_number_idx);
++			reader_data.constant_map.Add(global_idx, Value::UBIGINT(0));
+ 		}
+ 	}
+ 
+@@ -201,6 +203,7 @@ void DeltaMultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_optio
+ 
+ 	if (!file_metadata.partition_map.empty()) {
+ 		for (idx_t i = 0; i < global_column_ids.size(); i++) {
++			auto global_idx = MultiFileGlobalIndex(i);
+ 			column_t col_id = global_column_ids[i].GetPrimaryIndex();
+ 			if (IsRowIdColumnId(col_id)) {
+ 				continue;
+@@ -209,10 +212,10 @@ void DeltaMultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_optio
+ 			if (col_partition_entry != file_metadata.partition_map.end()) {
+ 				auto &current_type = global_columns[col_id].type;
+ 				if (current_type == LogicalType::BLOB) {
+-					reader_data.constant_map.emplace_back(i, Value::BLOB_RAW(col_partition_entry->second));
++					reader_data.constant_map.Add(global_idx, Value::BLOB_RAW(col_partition_entry->second));
+ 				} else {
+ 					auto maybe_value = Value(col_partition_entry->second).DefaultCastAs(current_type);
+-					reader_data.constant_map.emplace_back(i, maybe_value);
++					reader_data.constant_map.Add(global_idx, maybe_value);
+ 				}
+ 			}
+ 		}
+@@ -311,15 +314,16 @@ static void CustomMulfiFileNameMapping(const string &file_name,
+                                        const string &initial_file,
+                                        optional_ptr<MultiFileReaderGlobalState> global_state) {
+ 	// we have expected types: create a map of name -> column index
+-	case_insensitive_map_t<idx_t> name_map;
+-	for (idx_t col_idx = 0; col_idx < local_columns.size(); col_idx++) {
+-		name_map[local_columns[col_idx].name] = col_idx;
++	case_insensitive_map_t<MultiFileLocalColumnId> name_map;
++	for (idx_t col_id = 0; col_id < local_columns.size(); col_id++) {
++		name_map.emplace(local_columns[col_id].name, MultiFileLocalColumnId(col_id));
+ 	}
+ 	for (idx_t i = 0; i < global_column_ids.size(); i++) {
+ 		// check if this is a constant column
++		auto global_idx = MultiFileGlobalIndex(i);
+ 		bool constant = false;
+ 		for (auto &entry : reader_data.constant_map) {
+-			if (entry.column_id == i) {
++			if (entry.column_idx.GetIndex() == i) {
+ 				constant = true;
+ 				break;
+ 			}
+@@ -347,7 +351,7 @@ static void CustomMulfiFileNameMapping(const string &file_name,
+ 			// FIXME: this override is pretty hacky: for missing columns we just insert NULL constants
+ 			auto &global_type = global_columns[global_id].type;
+ 			Value val(global_type);
+-			reader_data.constant_map.push_back({i, val});
++			reader_data.constant_map.Add(global_idx, val);
+ 			continue;
+ 		}
+ 		// we found the column in the local file - check if the types are the same
+@@ -360,7 +364,7 @@ static void CustomMulfiFileNameMapping(const string &file_name,
+ 			reader_data.cast_map[local_id] = global_type;
+ 		}
+ 		// the types are the same - create the mapping
+-		reader_data.column_mapping.push_back(i);
++		reader_data.column_mapping.push_back(global_idx);
+ 		reader_data.column_ids.push_back(local_id);
+ 	}
+ 
+@@ -387,9 +391,9 @@ void DeltaMultiFileReader::CreateColumnMapping(const string &file_name,
+ 		D_ASSERT(delta_global_state.file_row_number_idx != DConstants::INVALID_INDEX);
+ 
+ 		// Build the name map
+-		case_insensitive_map_t<idx_t> name_map;
+-		for (idx_t col_idx = 0; col_idx < local_columns.size(); col_idx++) {
+-			name_map[local_columns[col_idx].name] = col_idx;
++		case_insensitive_map_t<MultiFileLocalColumnId> name_map;
++		for (idx_t col_id = 0; col_id < local_columns.size(); col_id++) {
++			name_map.emplace(local_columns[col_id].name, MultiFileLocalColumnId(col_id));
+ 		}
+ 
+ 		// Lookup the required column in the local map
+@@ -400,7 +404,8 @@ void DeltaMultiFileReader::CreateColumnMapping(const string &file_name,
+ 
+ 		// Register the column to be scanned from this file
+ 		reader_data.column_ids.push_back(entry->second);
+-		reader_data.column_mapping.push_back(delta_global_state.file_row_number_idx);
++		auto global_idx = MultiFileGlobalIndex(delta_global_state.file_row_number_idx);
++		reader_data.column_mapping.push_back(global_idx);
+ 	}
+ 
+ 	// This may have changed: update it

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1104,15 +1104,14 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 			}
 			auto &scan_filter = state.scan_filters[state.adaptive_filter->permutation[i]];
 			auto filter_entry = reader_data.filter_map[scan_filter.filter_idx];
-			if (filter_entry == DConstants::INVALID_INDEX) {
+			if (filter_entry.is_constant) {
 				// this is a constant vector, look for the constant
-				D_ASSERT(reader_data.constant_map.count(scan_filter.filter_idx));
-				auto &constant = reader_data.constant_map[scan_filter.filter_idx];
+				auto &constant = reader_data.constant_map[filter_entry.index].value;
 				Vector constant_vector(constant);
 				ColumnReader::ApplyFilter(constant_vector, scan_filter.filter, *scan_filter.filter_state, scan_count,
 				                          state.sel, filter_count);
 			} else {
-				auto id = filter_entry;
+				auto id = filter_entry.index;
 				auto file_col_idx = reader_data.column_ids[id];
 				auto result_idx = reader_data.column_mapping[id];
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -392,12 +392,12 @@ unique_ptr<ColumnReader> ParquetReader::CreateReader(ClientContext &context) {
 	// add casts if required
 	auto &root_struct_reader = ret->Cast<StructColumnReader>();
 	for (auto &entry : reader_data.cast_map) {
-		auto column_idx = entry.first;
+		auto column_id = entry.first;
 		auto &expected_type = entry.second;
-		auto child_reader = std::move(root_struct_reader.child_readers[column_idx]);
+		auto child_reader = std::move(root_struct_reader.child_readers[column_id]);
 		auto cast_schema = make_uniq<ParquetColumnSchema>(child_reader->Schema(), expected_type);
 		auto cast_reader = make_uniq<CastColumnReader>(std::move(child_reader), std::move(cast_schema));
-		root_struct_reader.child_readers[column_idx] = std::move(cast_reader);
+		root_struct_reader.child_readers[column_id] = std::move(cast_reader);
 	}
 	return ret;
 }
@@ -862,7 +862,7 @@ static FilterPropagateResult CheckParquetStringFilter(BaseStatistics &stats, con
 	}
 }
 
-void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t col_idx) {
+void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, local_idx_t col_idx) {
 	auto &group = GetGroup(state);
 	auto column_id = reader_data.column_ids[col_idx];
 	auto &column_reader = state.root_reader->Cast<StructColumnReader>().GetChildReader(column_id);
@@ -870,8 +870,8 @@ void ParquetReader::PrepareRowGroupBuffer(ParquetReaderScanState &state, idx_t c
 	if (reader_data.filters) {
 		auto stats = column_reader.Stats(state.group_idx_list[state.current_group], group.columns);
 		// filters contain output chunk index, not file col idx!
-		auto global_id = reader_data.column_mapping[col_idx];
-		auto filter_entry = reader_data.filters->filters.find(global_id);
+		auto global_index = reader_data.column_mapping[col_idx];
+		auto filter_entry = reader_data.filters->filters.find(global_index);
 
 		if (stats && filter_entry != reader_data.filters->filters.end()) {
 			auto &filter = *filter_entry->second;
@@ -1113,11 +1113,11 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 				                          state.sel, filter_count);
 			} else {
 				auto id = filter_entry;
-				auto file_col_idx = reader_data.column_ids[id];
-				auto result_idx = reader_data.column_mapping[id];
+				local_column_id_t local_col_idx = reader_data.column_ids[id];
+				global_idx_t result_idx = reader_data.column_mapping[id];
 
 				auto &result_vector = result.data[result_idx];
-				auto &child_reader = root_reader.GetChildReader(file_col_idx);
+				auto &child_reader = root_reader.GetChildReader(local_col_idx);
 				child_reader.Filter(scan_count, define_ptr, repeat_ptr, result_vector, scan_filter.filter,
 				                    *scan_filter.filter_state, state.sel, filter_count, i == 0);
 				need_to_read[id] = false;
@@ -1143,9 +1143,10 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 			result.Slice(state.sel, filter_count);
 		}
 	} else {
-		for (idx_t col_idx = 0; col_idx < reader_data.column_ids.size(); col_idx++) {
+		for (local_idx_t col_idx = 0; col_idx < reader_data.column_ids.size(); col_idx++) {
 			auto file_col_idx = reader_data.column_ids[col_idx];
-			auto &result_vector = result.data[reader_data.column_mapping[col_idx]];
+			global_idx_t global_col_idx = reader_data.column_mapping[col_idx];
+			auto &result_vector = result.data[global_col_idx];
 			auto &child_reader = root_reader.GetChildReader(file_col_idx);
 			auto rows_read = child_reader.Read(scan_count, define_ptr, repeat_ptr, result_vector);
 			if (rows_read != scan_count) {

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1106,7 +1106,9 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 			auto filter_entry = reader_data.filter_map[scan_filter.filter_idx];
 			if (filter_entry.is_constant) {
 				// this is a constant vector, look for the constant
-				auto &constant = reader_data.constant_map[filter_entry.index].value;
+				D_ASSERT(filter_entry.index == DConstants::INVALID_INDEX);
+				D_ASSERT(reader_data.constant_map.count(scan_filter.filter_idx));
+				auto &constant = reader_data.constant_map[scan_filter.filter_idx];
 				Vector constant_vector(constant);
 				ColumnReader::ApplyFilter(constant_vector, scan_filter.filter, *scan_filter.filter_state, scan_count,
 				                          state.sel, filter_count);

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1109,7 +1109,8 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 			auto &scan_filter = state.scan_filters[state.adaptive_filter->permutation[i]];
 			auto global_idx = MultiFileGlobalIndex(scan_filter.filter_idx);
 			auto filter_entry = reader_data.filter_map[global_idx];
-			if (filter_entry.is_constant) {
+			D_ASSERT(filter_entry.IsSet());
+			if (filter_entry.IsConstant()) {
 				// this is a constant vector, look for the constant
 				auto constant_index = filter_entry.GetConstantIndex();
 				auto &constant = reader_data.constant_map[constant_index].value;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1104,16 +1104,15 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 			}
 			auto &scan_filter = state.scan_filters[state.adaptive_filter->permutation[i]];
 			auto filter_entry = reader_data.filter_map[scan_filter.filter_idx];
-			if (filter_entry.is_constant) {
+			if (filter_entry == DConstants::INVALID_INDEX) {
 				// this is a constant vector, look for the constant
-				D_ASSERT(filter_entry.index == DConstants::INVALID_INDEX);
 				D_ASSERT(reader_data.constant_map.count(scan_filter.filter_idx));
 				auto &constant = reader_data.constant_map[scan_filter.filter_idx];
 				Vector constant_vector(constant);
 				ColumnReader::ApplyFilter(constant_vector, scan_filter.filter, *scan_filter.filter_state, scan_count,
 				                          state.sel, filter_count);
 			} else {
-				auto id = filter_entry.index;
+				auto id = filter_entry;
 				auto file_col_idx = reader_data.column_ids[id];
 				auto result_idx = reader_data.column_mapping[id];
 

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1111,15 +1111,15 @@ bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState 
 				ColumnReader::ApplyFilter(constant_vector, scan_filter.filter, *scan_filter.filter_state, scan_count,
 				                          state.sel, filter_count);
 			} else {
-				auto id = filter_entry.index;
-				local_column_id_t local_col_idx = reader_data.column_ids[id];
-				global_idx_t result_idx = reader_data.column_mapping[id];
+				local_idx_t local_idx = filter_entry.index;
+				local_column_id_t column_id = reader_data.column_ids[local_idx];
+				global_idx_t result_idx = reader_data.column_mapping[local_idx];
 
 				auto &result_vector = result.data[result_idx];
-				auto &child_reader = root_reader.GetChildReader(local_col_idx);
+				auto &child_reader = root_reader.GetChildReader(column_id);
 				child_reader.Filter(scan_count, define_ptr, repeat_ptr, result_vector, scan_filter.filter,
 				                    *scan_filter.filter_state, state.sel, filter_count, i == 0);
-				need_to_read[id] = false;
+				need_to_read[local_idx] = false;
 			}
 		}
 		state.adaptive_filter->EndFilter(filter_state);

--- a/src/common/multi_file_list.cpp
+++ b/src/common/multi_file_list.cpp
@@ -30,7 +30,7 @@ MultiFilePushdownInfo::MultiFilePushdownInfo(idx_t table_index, const vector<str
 bool PushdownInternal(ClientContext &context, const MultiFileReaderOptions &options, MultiFilePushdownInfo &info,
                       vector<unique_ptr<Expression>> &filters, vector<string> &expanded_files) {
 	HivePartitioningFilterInfo filter_info;
-	for (local_idx_t i = 0; i < info.column_ids.size(); i++) {
+	for (idx_t i = 0; i < info.column_ids.size(); i++) {
 		if (IsVirtualColumn(info.column_ids[i])) {
 			continue;
 		}
@@ -61,8 +61,8 @@ bool PushdownInternal(ClientContext &context, const MultiFileReaderOptions &opti
 	// construct the set of expressions from the table filters
 	vector<unique_ptr<Expression>> filter_expressions;
 	for (auto &entry : filters.filters) {
-		local_idx_t local_index = entry.first;
-		local_column_id_t column_idx = column_ids[local_index];
+		idx_t local_index = entry.first;
+		idx_t column_idx = column_ids[local_index];
 		if (IsVirtualColumn(column_idx)) {
 			continue;
 		}

--- a/src/common/multi_file_list.cpp
+++ b/src/common/multi_file_list.cpp
@@ -30,7 +30,7 @@ MultiFilePushdownInfo::MultiFilePushdownInfo(idx_t table_index, const vector<str
 bool PushdownInternal(ClientContext &context, const MultiFileReaderOptions &options, MultiFilePushdownInfo &info,
                       vector<unique_ptr<Expression>> &filters, vector<string> &expanded_files) {
 	HivePartitioningFilterInfo filter_info;
-	for (idx_t i = 0; i < info.column_ids.size(); i++) {
+	for (local_idx_t i = 0; i < info.column_ids.size(); i++) {
 		if (IsVirtualColumn(info.column_ids[i])) {
 			continue;
 		}
@@ -61,7 +61,8 @@ bool PushdownInternal(ClientContext &context, const MultiFileReaderOptions &opti
 	// construct the set of expressions from the table filters
 	vector<unique_ptr<Expression>> filter_expressions;
 	for (auto &entry : filters.filters) {
-		auto column_idx = column_ids[entry.first];
+		local_idx_t local_index = entry.first;
+		local_column_id_t column_idx = column_ids[local_index];
 		if (IsVirtualColumn(column_idx)) {
 			continue;
 		}

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -279,7 +279,11 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 		auto column_id = col_idx.GetPrimaryIndex();
 		if (column_id == options.filename_idx) {
 			// filename
-			reader_data.constant_map.emplace_back(i, Value(filename));
+			auto emplace_result = reader_data.constant_map.emplace(std::make_pair(i, Value(filename)));
+			if (!emplace_result.second) {
+				throw InternalException(
+				    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
+			}
 			continue;
 		}
 		if (IsVirtualColumn(column_id)) {
@@ -293,7 +297,12 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 			for (auto &entry : options.hive_partitioning_indexes) {
 				if (column_id == entry.index) {
 					Value value = file_options.GetHivePartitionValue(partitions[entry.value], entry.value, context);
-					reader_data.constant_map.emplace_back(i, value);
+					auto emplace_result = reader_data.constant_map.emplace(std::make_pair(i, value));
+					if (!emplace_result.second) {
+						throw InternalException(
+						    "Tried to create a constant value for column_id %d but it already has a constant assigned!",
+						    i);
+					}
 					found_partition = true;
 					break;
 				}
@@ -312,7 +321,11 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 			if (not_present_in_file) {
 				// we need to project a column with name \"global_name\" - but it does not exist in the current file
 				// push a NULL value of the specified type
-				reader_data.constant_map.emplace_back(i, Value(type));
+				auto emplace_result = reader_data.constant_map.emplace(std::make_pair(i, Value(type)));
+				if (!emplace_result.second) {
+					throw InternalException(
+					    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
+				}
 				continue;
 			}
 		}
@@ -342,16 +355,9 @@ void MultiFileReader::CreateColumnMappingByName(const string &file_name,
 		auto &column = local_columns[col_idx];
 		name_map[column.name] = col_idx;
 	}
+
 	for (idx_t i = 0; i < global_column_ids.size(); i++) {
-		// check if this is a constant column
-		bool constant = false;
-		for (auto &entry : reader_data.constant_map) {
-			if (entry.column_id == i) {
-				constant = true;
-				break;
-			}
-		}
-		if (constant) {
+		if (reader_data.constant_map.count(i)) {
 			// this column is constant for this file
 			continue;
 		}
@@ -372,7 +378,12 @@ void MultiFileReader::CreateColumnMappingByName(const string &file_name,
 		if (entry == name_map.end()) {
 			// identiier not present in file, use default value
 			if (global_column.default_expression) {
-				reader_data.constant_map.emplace_back(i, global_column.GetDefaultValue());
+				auto emplace_result =
+				    reader_data.constant_map.emplace(std::make_pair(i, global_column.GetDefaultValue()));
+				if (!emplace_result.second) {
+					throw InternalException(
+					    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
+				}
 				continue;
 			} else {
 				string candidate_names;
@@ -441,16 +452,7 @@ void MultiFileReader::CreateColumnMappingByFieldId(const string &file_name,
 
 	// loop through the schema definition
 	for (idx_t i = 0; i < global_column_ids.size(); i++) {
-
-		// check if this is a constant column
-		bool constant = false;
-		for (auto &entry : reader_data.constant_map) {
-			if (entry.column_id == i) {
-				constant = true;
-				break;
-			}
-		}
-		if (constant) {
+		if (reader_data.constant_map.count(i)) {
 			// this column is constant for this file
 			continue;
 		}
@@ -481,7 +483,11 @@ void MultiFileReader::CreateColumnMappingByFieldId(const string &file_name,
 				throw NotImplementedException("Default expression that isn't constant is not supported yet");
 			}
 			auto &constant_expr = default_val->Cast<ConstantExpression>();
-			reader_data.constant_map.emplace_back(i, constant_expr.value);
+			auto emplace_result = reader_data.constant_map.emplace(std::make_pair(i, constant_expr.value));
+			if (!emplace_result.second) {
+				throw InternalException(
+				    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
+			}
 			continue;
 		}
 
@@ -554,9 +560,9 @@ void MultiFileReader::CreateFilterMap(const vector<ColumnIndex> &global_column_i
 			reader_data.filter_map[map_index].index = c;
 			reader_data.filter_map[map_index].is_constant = false;
 		}
-		for (idx_t c = 0; c < reader_data.constant_map.size(); c++) {
-			auto constant_index = reader_data.constant_map[c].column_id;
-			reader_data.filter_map[constant_index].index = c;
+		for (auto &entry : reader_data.constant_map) {
+			auto constant_index = entry.first;
+			reader_data.filter_map[constant_index].index = DConstants::INVALID_INDEX;
 			reader_data.filter_map[constant_index].is_constant = true;
 		}
 	}
@@ -567,7 +573,7 @@ void MultiFileReader::FinalizeChunk(ClientContext &context, const MultiFileReade
                                     optional_ptr<MultiFileReaderGlobalState> global_state) {
 	// reference all the constants set up in MultiFileReader::FinalizeBind
 	for (auto &entry : reader_data.constant_map) {
-		chunk.data[entry.column_id].Reference(entry.value);
+		chunk.data[entry.first].Reference(entry.second);
 	}
 	chunk.Verify();
 }
@@ -578,18 +584,12 @@ void MultiFileReader::GetPartitionData(ClientContext &context, const MultiFileRe
                                        const OperatorPartitionInfo &partition_info,
                                        OperatorPartitionData &partition_data) {
 	for (auto &col : partition_info.partition_columns) {
-		bool found_constant = false;
-		for (auto &constant : reader_data.constant_map) {
-			if (constant.column_id == col) {
-				found_constant = true;
-				partition_data.partition_data.emplace_back(constant.value);
-				break;
-			}
-		}
-		if (!found_constant) {
+		auto entry = reader_data.constant_map.find(col);
+		if (entry == reader_data.constant_map.end()) {
 			throw InternalException(
 			    "MultiFileReader::GetPartitionData - did not find constant for the given partition");
 		}
+		partition_data.partition_data.emplace_back(entry->second);
 	}
 }
 

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -557,13 +557,11 @@ void MultiFileReader::CreateFilterMap(const vector<ColumnIndex> &global_column_i
 
 		for (idx_t c = 0; c < reader_data.column_mapping.size(); c++) {
 			auto map_index = reader_data.column_mapping[c];
-			reader_data.filter_map[map_index].index = c;
-			reader_data.filter_map[map_index].is_constant = false;
+			reader_data.filter_map[map_index] = c;
 		}
 		for (auto &entry : reader_data.constant_map) {
 			auto constant_index = entry.first;
-			reader_data.filter_map[constant_index].index = DConstants::INVALID_INDEX;
-			reader_data.filter_map[constant_index].is_constant = true;
+			reader_data.filter_map[constant_index] = DConstants::INVALID_INDEX;
 		}
 	}
 }

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -279,11 +279,7 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 		auto column_id = col_idx.GetPrimaryIndex();
 		if (column_id == options.filename_idx) {
 			// filename
-			auto emplace_result = reader_data.constant_map.emplace(i, Value(filename));
-			if (!emplace_result.second) {
-				throw InternalException(
-				    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
-			}
+			reader_data.constant_map.emplace_back(i, Value(filename));
 			continue;
 		}
 		if (IsVirtualColumn(column_id)) {
@@ -297,12 +293,7 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 			for (auto &entry : options.hive_partitioning_indexes) {
 				if (column_id == entry.index) {
 					Value value = file_options.GetHivePartitionValue(partitions[entry.value], entry.value, context);
-					auto emplace_result = reader_data.constant_map.emplace(i, value);
-					if (!emplace_result.second) {
-						throw InternalException(
-						    "Tried to create a constant value for column_id %d but it already has a constant assigned!",
-						    i);
-					}
+					reader_data.constant_map.emplace_back(i, value);
 					found_partition = true;
 					break;
 				}
@@ -321,11 +312,7 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 			if (not_present_in_file) {
 				// we need to project a column with name \"global_name\" - but it does not exist in the current file
 				// push a NULL value of the specified type
-				auto emplace_result = reader_data.constant_map.emplace(i, Value(type));
-				if (!emplace_result.second) {
-					throw InternalException(
-					    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
-				}
+				reader_data.constant_map.emplace_back(i, Value(type));
 				continue;
 			}
 		}
@@ -355,9 +342,12 @@ void MultiFileReader::CreateColumnMappingByName(const string &file_name,
 		auto &column = local_columns[col_idx];
 		name_map[column.name] = col_idx;
 	}
-
 	for (idx_t i = 0; i < global_column_ids.size(); i++) {
-		if (reader_data.constant_map.count(i)) {
+		// check if this is a constant column
+		auto constant_entry =
+		    std::find_if(reader_data.constant_map.begin(), reader_data.constant_map.end(),
+		                 [&i](const MultiFileConstantEntry &constant) { return constant.column_id == i; });
+		if (constant_entry != reader_data.constant_map.end()) {
 			// this column is constant for this file
 			continue;
 		}
@@ -378,11 +368,7 @@ void MultiFileReader::CreateColumnMappingByName(const string &file_name,
 		if (entry == name_map.end()) {
 			// identiier not present in file, use default value
 			if (global_column.default_expression) {
-				auto emplace_result = reader_data.constant_map.emplace(i, global_column.GetDefaultValue());
-				if (!emplace_result.second) {
-					throw InternalException(
-					    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
-				}
+				reader_data.constant_map.emplace_back(i, global_column.GetDefaultValue());
 				continue;
 			} else {
 				string candidate_names;
@@ -451,7 +437,12 @@ void MultiFileReader::CreateColumnMappingByFieldId(const string &file_name,
 
 	// loop through the schema definition
 	for (idx_t i = 0; i < global_column_ids.size(); i++) {
-		if (reader_data.constant_map.count(i)) {
+
+		// check if this is a constant column
+		auto constant_entry =
+		    std::find_if(reader_data.constant_map.begin(), reader_data.constant_map.end(),
+		                 [&i](const MultiFileConstantEntry &constant) { return constant.column_id == i; });
+		if (constant_entry != reader_data.constant_map.end()) {
 			// this column is constant for this file
 			continue;
 		}
@@ -482,11 +473,7 @@ void MultiFileReader::CreateColumnMappingByFieldId(const string &file_name,
 				throw NotImplementedException("Default expression that isn't constant is not supported yet");
 			}
 			auto &constant_expr = default_val->Cast<ConstantExpression>();
-			auto emplace_result = reader_data.constant_map.emplace(i, constant_expr.value);
-			if (!emplace_result.second) {
-				throw InternalException(
-				    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
-			}
+			reader_data.constant_map.emplace_back(i, constant_expr.value);
 			continue;
 		}
 
@@ -556,11 +543,13 @@ void MultiFileReader::CreateFilterMap(const vector<ColumnIndex> &global_column_i
 
 		for (idx_t c = 0; c < reader_data.column_mapping.size(); c++) {
 			auto map_index = reader_data.column_mapping[c];
-			reader_data.filter_map[map_index] = c;
+			reader_data.filter_map[map_index].index = c;
+			reader_data.filter_map[map_index].is_constant = false;
 		}
-		for (auto &entry : reader_data.constant_map) {
-			auto constant_index = entry.first;
-			reader_data.filter_map[constant_index] = DConstants::INVALID_INDEX;
+		for (idx_t c = 0; c < reader_data.constant_map.size(); c++) {
+			auto constant_index = reader_data.constant_map[c].column_id;
+			reader_data.filter_map[constant_index].index = c;
+			reader_data.filter_map[constant_index].is_constant = true;
 		}
 	}
 }
@@ -570,7 +559,7 @@ void MultiFileReader::FinalizeChunk(ClientContext &context, const MultiFileReade
                                     optional_ptr<MultiFileReaderGlobalState> global_state) {
 	// reference all the constants set up in MultiFileReader::FinalizeBind
 	for (auto &entry : reader_data.constant_map) {
-		chunk.data[entry.first].Reference(entry.second);
+		chunk.data[entry.column_id].Reference(entry.value);
 	}
 	chunk.Verify();
 }
@@ -581,12 +570,14 @@ void MultiFileReader::GetPartitionData(ClientContext &context, const MultiFileRe
                                        const OperatorPartitionInfo &partition_info,
                                        OperatorPartitionData &partition_data) {
 	for (auto &col : partition_info.partition_columns) {
-		auto entry = reader_data.constant_map.find(col);
-		if (entry == reader_data.constant_map.end()) {
+		auto constant_entry =
+		    std::find_if(reader_data.constant_map.begin(), reader_data.constant_map.end(),
+		                 [&col](const MultiFileConstantEntry &constant) { return constant.column_id == col; });
+		if (constant_entry == reader_data.constant_map.end()) {
 			throw InternalException(
 			    "MultiFileReader::GetPartitionData - did not find constant for the given partition");
 		}
-		partition_data.partition_data.emplace_back(entry->second);
+		partition_data.partition_data.emplace_back(constant_entry->value);
 	}
 }
 

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -279,7 +279,7 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 		auto column_id = col_idx.GetPrimaryIndex();
 		if (column_id == options.filename_idx) {
 			// filename
-			auto emplace_result = reader_data.constant_map.emplace(std::make_pair(i, Value(filename)));
+			auto emplace_result = reader_data.constant_map.emplace(i, Value(filename));
 			if (!emplace_result.second) {
 				throw InternalException(
 				    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
@@ -297,7 +297,7 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 			for (auto &entry : options.hive_partitioning_indexes) {
 				if (column_id == entry.index) {
 					Value value = file_options.GetHivePartitionValue(partitions[entry.value], entry.value, context);
-					auto emplace_result = reader_data.constant_map.emplace(std::make_pair(i, value));
+					auto emplace_result = reader_data.constant_map.emplace(i, value);
 					if (!emplace_result.second) {
 						throw InternalException(
 						    "Tried to create a constant value for column_id %d but it already has a constant assigned!",
@@ -321,7 +321,7 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 			if (not_present_in_file) {
 				// we need to project a column with name \"global_name\" - but it does not exist in the current file
 				// push a NULL value of the specified type
-				auto emplace_result = reader_data.constant_map.emplace(std::make_pair(i, Value(type)));
+				auto emplace_result = reader_data.constant_map.emplace(i, Value(type));
 				if (!emplace_result.second) {
 					throw InternalException(
 					    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
@@ -378,8 +378,7 @@ void MultiFileReader::CreateColumnMappingByName(const string &file_name,
 		if (entry == name_map.end()) {
 			// identiier not present in file, use default value
 			if (global_column.default_expression) {
-				auto emplace_result =
-				    reader_data.constant_map.emplace(std::make_pair(i, global_column.GetDefaultValue()));
+				auto emplace_result = reader_data.constant_map.emplace(i, global_column.GetDefaultValue());
 				if (!emplace_result.second) {
 					throw InternalException(
 					    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);
@@ -483,7 +482,7 @@ void MultiFileReader::CreateColumnMappingByFieldId(const string &file_name,
 				throw NotImplementedException("Default expression that isn't constant is not supported yet");
 			}
 			auto &constant_expr = default_val->Cast<ConstantExpression>();
-			auto emplace_result = reader_data.constant_map.emplace(std::make_pair(i, constant_expr.value));
+			auto emplace_result = reader_data.constant_map.emplace(i, constant_expr.value);
 			if (!emplace_result.second) {
 				throw InternalException(
 				    "Tried to create a constant value for column_id %d but it already has a constant assigned!", i);

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -274,7 +274,7 @@ void MultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_options, c
 			name_map[column.name] = col_idx;
 		}
 	}
-	for (idx_t i = 0; i < global_column_ids.size(); i++) {
+	for (global_idx_t i = 0; i < global_column_ids.size(); i++) {
 		auto &col_idx = global_column_ids[i];
 		auto column_id = col_idx.GetPrimaryIndex();
 		if (column_id == options.filename_idx) {
@@ -349,14 +349,14 @@ void MultiFileReader::CreateColumnMappingByName(const string &file_name,
                                                 const MultiFileReaderBindData &bind_data, const string &initial_file,
                                                 optional_ptr<MultiFileReaderGlobalState> global_state) {
 
-	// we have expected types: create a map of name -> column index
-	case_insensitive_map_t<idx_t> name_map;
-	for (idx_t col_idx = 0; col_idx < local_columns.size(); col_idx++) {
+	// we have expected types: create a map of name -> (local) column id
+	case_insensitive_map_t<local_column_id_t> name_map;
+	for (local_column_id_t col_idx = 0; col_idx < local_columns.size(); col_idx++) {
 		auto &column = local_columns[col_idx];
 		name_map[column.name] = col_idx;
 	}
 
-	for (idx_t i = 0; i < global_column_ids.size(); i++) {
+	for (global_idx_t i = 0; i < global_column_ids.size(); i++) {
 		if (reader_data.constant_map.count(i)) {
 			// this column is constant for this file
 			continue;
@@ -401,7 +401,7 @@ void MultiFileReader::CreateColumnMappingByName(const string &file_name,
 			}
 		}
 		// we found the column in the local file - check if the types are the same
-		auto local_id = entry->second;
+		local_column_id_t local_id = entry->second;
 		D_ASSERT(global_id < global_columns.size());
 		D_ASSERT(local_id < local_columns.size());
 		auto &global_type = global_columns[global_id].type;
@@ -438,7 +438,7 @@ void MultiFileReader::CreateColumnMappingByFieldId(const string &file_name,
 #endif
 
 	// we have expected types: create a map of field_id -> column index
-	unordered_map<int32_t, idx_t> field_id_map;
+	unordered_map<int32_t, local_column_id_t> field_id_map;
 	for (idx_t col_idx = 0; col_idx < local_columns.size(); col_idx++) {
 		auto &column = local_columns[col_idx];
 		if (column.identifier.IsNull()) {
@@ -450,7 +450,7 @@ void MultiFileReader::CreateColumnMappingByFieldId(const string &file_name,
 	}
 
 	// loop through the schema definition
-	for (idx_t i = 0; i < global_column_ids.size(); i++) {
+	for (global_idx_t i = 0; i < global_column_ids.size(); i++) {
 		if (reader_data.constant_map.count(i)) {
 			// this column is constant for this file
 			continue;
@@ -490,7 +490,7 @@ void MultiFileReader::CreateColumnMappingByFieldId(const string &file_name,
 			continue;
 		}
 
-		const auto &local_id = it->second;
+		const local_column_id_t &local_id = it->second;
 		auto &local_column = local_columns[local_id];
 		ColumnIndex local_index(local_id);
 		if (local_column.type != global_column.type) {
@@ -554,8 +554,8 @@ void MultiFileReader::CreateFilterMap(const vector<ColumnIndex> &global_column_i
 		}
 		reader_data.filter_map.resize(filter_map_size);
 
-		for (idx_t c = 0; c < reader_data.column_mapping.size(); c++) {
-			auto map_index = reader_data.column_mapping[c];
+		for (global_column_id_t c = 0; c < reader_data.column_mapping.size(); c++) {
+			global_idx_t map_index = reader_data.column_mapping[c];
 			reader_data.filter_map[map_index] = c;
 		}
 		for (auto &entry : reader_data.constant_map) {

--- a/src/common/multi_file_reader.cpp
+++ b/src/common/multi_file_reader.cpp
@@ -552,20 +552,19 @@ void MultiFileReader::CreateFilterMap(const vector<ColumnIndex> &global_column_i
 	if (global_state) {
 		filter_map_size += global_state->extra_columns.size();
 	}
+
 	reader_data.filter_map.resize(filter_map_size);
 
 	D_ASSERT(reader_data.column_mapping.size() == reader_data.column_ids.size());
 	for (idx_t c = 0; c < reader_data.column_mapping.size(); c++) {
 		auto col_idx = MultiFileLocalIndex(c);
 		auto global_idx = reader_data.column_mapping[col_idx];
-		reader_data.filter_map[global_idx].index = c;
-		reader_data.filter_map[global_idx].is_constant = false;
+		reader_data.filter_map[global_idx].Set(col_idx);
 	}
 	for (idx_t c = 0; c < reader_data.constant_map.size(); c++) {
 		auto constant_idx = MultiFileConstantMapIndex(c);
 		auto global_idx = reader_data.constant_map[constant_idx].column_idx;
-		reader_data.filter_map[global_idx].index = c;
-		reader_data.filter_map[global_idx].is_constant = true;
+		reader_data.filter_map[global_idx].Set(constant_idx);
 	}
 }
 

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1035,9 +1035,9 @@ void StringValueScanner::Flush(DataChunk &insert_chunk) {
 	auto &names = csv_file_scan->GetNames();
 	auto &reader_data = csv_file_scan->reader_data;
 	// Now Do the cast-aroo
-	for (idx_t c = 0; c < reader_data.column_ids.size(); c++) {
+	for (global_idx_t c = 0; c < reader_data.column_ids.size(); c++) {
 		idx_t col_idx = c;
-		idx_t result_idx = reader_data.column_mapping[c];
+		global_idx_t result_idx = reader_data.column_mapping[c];
 		if (!csv_file_scan->projection_ids.empty()) {
 			result_idx = reader_data.column_mapping[csv_file_scan->projection_ids[c].second];
 		}

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1035,16 +1035,18 @@ void StringValueScanner::Flush(DataChunk &insert_chunk) {
 	auto &names = csv_file_scan->GetNames();
 	auto &reader_data = csv_file_scan->reader_data;
 	// Now Do the cast-aroo
-	for (local_idx_t col_idx = 0; col_idx < reader_data.column_ids.size(); col_idx++) {
-		global_idx_t result_idx = reader_data.column_mapping[col_idx];
+	for (idx_t i = 0; i < reader_data.column_ids.size(); i++) {
+		auto col_idx = MultiFileLocalIndex(i);
+		auto global_idx = reader_data.column_mapping[col_idx];
 		if (!csv_file_scan->projection_ids.empty()) {
-			result_idx = reader_data.column_mapping[csv_file_scan->projection_ids[col_idx].second];
+			auto local_idx = MultiFileLocalIndex(csv_file_scan->projection_ids[col_idx].second);
+			global_idx = reader_data.column_mapping[local_idx];
 		}
 		if (col_idx >= parse_chunk.ColumnCount()) {
 			throw InvalidInputException("Mismatch between the schema of different files");
 		}
 		auto &parse_vector = parse_chunk.data[col_idx];
-		auto &result_vector = insert_chunk.data[result_idx];
+		auto &result_vector = insert_chunk.data[global_idx];
 		auto &type = result_vector.GetType();
 		auto &parse_type = parse_vector.GetType();
 		if (!type.IsJSONType() &&

--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1035,11 +1035,10 @@ void StringValueScanner::Flush(DataChunk &insert_chunk) {
 	auto &names = csv_file_scan->GetNames();
 	auto &reader_data = csv_file_scan->reader_data;
 	// Now Do the cast-aroo
-	for (global_idx_t c = 0; c < reader_data.column_ids.size(); c++) {
-		idx_t col_idx = c;
-		global_idx_t result_idx = reader_data.column_mapping[c];
+	for (local_idx_t col_idx = 0; col_idx < reader_data.column_ids.size(); col_idx++) {
+		global_idx_t result_idx = reader_data.column_mapping[col_idx];
 		if (!csv_file_scan->projection_ids.empty()) {
-			result_idx = reader_data.column_mapping[csv_file_scan->projection_ids[c].second];
+			result_idx = reader_data.column_mapping[csv_file_scan->projection_ids[col_idx].second];
 		}
 		if (col_idx >= parse_chunk.ColumnCount()) {
 			throw InvalidInputException("Mismatch between the schema of different files");

--- a/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
@@ -125,8 +125,9 @@ void CSVFileScan::InitializeFileNamesTypes() {
 	// We need to be sure that our types are also following the cast_map
 	if (!reader_data.cast_map.empty()) {
 		for (idx_t i = 0; i < reader_data.column_ids.size(); i++) {
-			if (reader_data.cast_map.find(reader_data.column_ids[i]) != reader_data.cast_map.end()) {
-				file_types[i] = reader_data.cast_map[reader_data.column_ids[i]];
+			auto entry = reader_data.cast_map.find(reader_data.column_ids[i]);
+			if (entry != reader_data.cast_map.end()) {
+				file_types[i] = entry->second;
 			}
 		}
 	}

--- a/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
@@ -112,10 +112,11 @@ void CSVFileScan::InitializeFileNamesTypes() {
 	}
 
 	for (idx_t i = 0; i < reader_data.column_ids.size(); i++) {
-		idx_t result_idx = reader_data.column_ids[i];
-		file_types.emplace_back(types[result_idx]);
-		projected_columns.insert(result_idx);
-		projection_ids.emplace_back(result_idx, i);
+		auto col_idx = MultiFileLocalIndex(i);
+		auto column_id = reader_data.column_ids[col_idx];
+		file_types.emplace_back(types[column_id.GetId()]);
+		projected_columns.insert(column_id.GetId());
+		projection_ids.emplace_back(column_id.GetId(), col_idx);
 	}
 
 	if (reader_data.column_ids.empty()) {
@@ -125,7 +126,8 @@ void CSVFileScan::InitializeFileNamesTypes() {
 	// We need to be sure that our types are also following the cast_map
 	if (!reader_data.cast_map.empty()) {
 		for (idx_t i = 0; i < reader_data.column_ids.size(); i++) {
-			auto entry = reader_data.cast_map.find(reader_data.column_ids[i]);
+			auto local_idx = MultiFileLocalIndex(i);
+			auto entry = reader_data.cast_map.find(reader_data.column_ids[local_idx]);
 			if (entry != reader_data.cast_map.end()) {
 				file_types[i] = entry->second;
 			}
@@ -150,8 +152,9 @@ const vector<LogicalType> &CSVFileScan::GetTypes() {
 
 void CSVFileScan::InitializeProjection() {
 	for (idx_t i = 0; i < options.dialect_options.num_cols; i++) {
-		reader_data.column_ids.push_back(i);
-		reader_data.column_mapping.push_back(i);
+		reader_data.column_ids.push_back(MultiFileLocalColumnId(i));
+		//! FIXME: where is this mapping to???
+		reader_data.column_mapping.push_back(MultiFileGlobalIndex(i));
 	}
 }
 

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -101,15 +101,6 @@ struct MultiFileFilterEntry {
 	bool is_constant = false;
 };
 
-struct MultiFileConstantEntry {
-	MultiFileConstantEntry(idx_t column_id, Value value_p) : column_id(column_id), value(std::move(value_p)) {
-	}
-	//! The (global) column id to apply the constant value to
-	idx_t column_id;
-	//! The constant value
-	Value value;
-};
-
 struct MultiFileReaderData {
 	//! The column ids to read from the file
 	vector<idx_t> column_ids;
@@ -125,8 +116,8 @@ struct MultiFileReaderData {
 	vector<MultiFileFilterEntry> filter_map;
 	//! The set of table filters
 	optional_ptr<TableFilterSet> filters;
-	//! The constants that should be applied at the various positions
-	vector<MultiFileConstantEntry> constant_map;
+	//! The mapping of (global) column_id -> constant value
+	unordered_map<idx_t, Value> constant_map;
 	//! Map of column_id -> cast, used when reading multiple files when files have diverging types
 	//! for the same column
 	unordered_map<column_t, LogicalType> cast_map;

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -134,9 +134,10 @@ struct MultiFileReaderData {
 	vector<global_idx_t> column_mapping;
 	//! Whether or not there are no columns to read. This can happen when a file only consists of constants
 	bool empty_columns = false;
-	//! vector containing a mapping from `global_idx_t` -> `local_idx_t` (or DConstants::INVALID_INDEX if constant)
+	//! Filters can point to either (1) local columns in the file, or (2) constant values in the `constant_map`
+	//! This map specifies where the to-be-filtered value can be found
 	vector<MultiFileFilterEntry> filter_map;
-	//! The set of table filters, which
+	//! The set of table filters
 	optional_ptr<TableFilterSet> filters;
 	//! The constants that should be applied at the various positions
 	//! `local_idx_t` -> `MultiFileConstantEntry`

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -17,8 +17,6 @@
 
 namespace duckdb {
 
-//! global column_id
-using global_column_id_t = idx_t;
 //! local column_id
 using local_column_id_t = idx_t;
 

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -113,10 +113,10 @@ struct MultiFileFilterEntry {
 };
 
 struct MultiFileConstantEntry {
-	MultiFileConstantEntry(idx_t column_id, Value value_p) : column_id(column_id), value(std::move(value_p)) {
+	MultiFileConstantEntry(idx_t column_idx, Value value_p) : column_idx(column_idx), value(std::move(value_p)) {
 	}
-	//! The (global) column id to apply the constant value to
-	global_column_id_t column_id;
+	//! The (global) column idx to apply the constant value to
+	global_idx_t column_idx;
 	//! The constant value
 	Value value;
 };
@@ -136,11 +136,11 @@ struct MultiFileReaderData {
 	bool empty_columns = false;
 	//! Filters can point to either (1) local columns in the file, or (2) constant values in the `constant_map`
 	//! This map specifies where the to-be-filtered value can be found
+	//! `global_idx_t` -> `MultiFileFilterEntry`
 	vector<MultiFileFilterEntry> filter_map;
 	//! The set of table filters
 	optional_ptr<TableFilterSet> filters;
 	//! The constants that should be applied at the various positions
-	//! `local_idx_t` -> `MultiFileConstantEntry`
 	vector<MultiFileConstantEntry> constant_map;
 	//! Map of (local) column_id -> cast, used when reading multiple files when files have diverging types
 	//! for the same column

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -96,6 +96,20 @@ public:
 	Value identifier;
 };
 
+struct MultiFileFilterEntry {
+	idx_t index = DConstants::INVALID_INDEX;
+	bool is_constant = false;
+};
+
+struct MultiFileConstantEntry {
+	MultiFileConstantEntry(idx_t column_id, Value value_p) : column_id(column_id), value(std::move(value_p)) {
+	}
+	//! The (global) column id to apply the constant value to
+	idx_t column_id;
+	//! The constant value
+	Value value;
+};
+
 struct MultiFileReaderData {
 	//! The column ids to read from the file
 	vector<idx_t> column_ids;
@@ -108,11 +122,11 @@ struct MultiFileReaderData {
 	bool empty_columns = false;
 	//! Filters can point to either (1) local columns in the file, or (2) constant values in the `constant_map`
 	//! This map specifies where the to-be-filtered value can be found
-	vector<idx_t> filter_map;
+	vector<MultiFileFilterEntry> filter_map;
 	//! The set of table filters
 	optional_ptr<TableFilterSet> filters;
-	//! The mapping of (global) column_id -> constant value
-	unordered_map<idx_t, Value> constant_map;
+	//! The constants that should be applied at the various positions
+	vector<MultiFileConstantEntry> constant_map;
 	//! Map of column_id -> cast, used when reading multiple files when files have diverging types
 	//! for the same column
 	unordered_map<column_t, LogicalType> cast_map;

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -17,14 +17,6 @@
 
 namespace duckdb {
 
-//! local column_id
-using local_column_id_t = idx_t;
-
-//! index into a global mapping
-using global_idx_t = idx_t;
-//! index into a local mapping
-using local_idx_t = idx_t;
-
 struct MultiFileReaderColumnDefinition {
 public:
 	MultiFileReaderColumnDefinition(const string &name, const LogicalType &type) : name(name), type(type) {
@@ -104,45 +96,261 @@ public:
 	Value identifier;
 };
 
-struct MultiFileFilterEntry {
-	//! index into 'constant_map' if 'is_constant' else this is a 'local_idx_t'
-	idx_t index = DConstants::INVALID_INDEX;
-	bool is_constant = false;
+//! fwd declare
+struct MultiFileCastMap;
+
+struct MultiFileLocalColumnId {
+	friend class MultiFileCastMap;
+
+public:
+	explicit MultiFileLocalColumnId(column_t column_id) : column_id(column_id) {
+	}
+
+public:
+	operator idx_t() {
+		return column_id;
+	}
+	idx_t GetId() const {
+		return column_id;
+	}
+
+private:
+	column_t column_id;
+};
+
+//! fwd declare
+template <class T>
+struct MultiFileLocalColumnIds;
+struct MultiFileGlobalColumnIds;
+struct MultiFileColumnMapping;
+struct MultiFileFilterMap;
+struct MultiFileConstantMap;
+
+struct MultiFileLocalIndex {
+	//! these are allowed to access the index
+	template <class T>
+	friend class MultiFileLocalColumnIds;
+	friend class MultiFileColumnMapping;
+
+public:
+	explicit MultiFileLocalIndex(idx_t index) : index(index) {
+	}
+
+public:
+	operator idx_t() {
+		return index;
+	}
+	idx_t GetIndex() const {
+		return index;
+	}
+
+private:
+	idx_t index;
+};
+
+struct MultiFileGlobalIndex {
+	friend class MultiFileGlobalColumnIds;
+	friend class MultiFileFilterMap;
+
+public:
+	explicit MultiFileGlobalIndex(idx_t index) : index(index) {
+	}
+
+public:
+	operator idx_t() {
+		return index;
+	}
+	idx_t GetIndex() const {
+		return index;
+	}
+
+private:
+	idx_t index;
 };
 
 struct MultiFileConstantEntry {
-	MultiFileConstantEntry(idx_t column_idx, Value value_p) : column_idx(column_idx), value(std::move(value_p)) {
+	MultiFileConstantEntry(MultiFileGlobalIndex column_idx, Value value_p)
+	    : column_idx(column_idx), value(std::move(value_p)) {
 	}
 	//! The (global) column idx to apply the constant value to
-	global_idx_t column_idx;
+	MultiFileGlobalIndex column_idx;
 	//! The constant value
 	Value value;
 };
 
+//! index used to access the constant map
+struct MultiFileConstantMapIndex {
+	friend class MultiFileConstantMap;
+
+public:
+	explicit MultiFileConstantMapIndex(idx_t index) : index(index) {
+	}
+
+public:
+private:
+	idx_t index;
+};
+
+struct MultiFileFilterEntry {
+public:
+	MultiFileConstantMapIndex GetConstantIndex() const {
+		D_ASSERT(is_constant);
+		return MultiFileConstantMapIndex(index);
+	}
+	MultiFileLocalIndex GetLocalIndex() const {
+		D_ASSERT(!is_constant);
+		return MultiFileLocalIndex(index);
+	}
+
+public:
+	//! ConstantMapIndex if 'is_constant' else this is a LocalIndex
+	idx_t index = DConstants::INVALID_INDEX;
+	bool is_constant = false;
+};
+
+template <class T>
+struct MultiFileLocalColumnIds {
+public:
+	void push_back(T column_id) { // NOLINT: matching name of std
+		column_ids.push_back(column_id);
+	}
+	template <typename... Args>
+	void emplace_back(Args &&...args) {
+		column_ids.emplace_back(std::forward<Args>(args)...);
+	}
+	const T &operator[](MultiFileLocalIndex index) {
+		return column_ids[index.index];
+	}
+	bool empty() const { // NOLINT: matching name of std
+		return column_ids.empty();
+	}
+	idx_t size() const { // NOLINT: matching name of std
+		return column_ids.size();
+	}
+
+private:
+	vector<T> column_ids;
+};
+
+struct MultiFileColumnMapping {
+public:
+	void push_back(MultiFileGlobalIndex global_index) { // NOLINT: matching name of std
+		column_mapping.push_back(global_index);
+	}
+	const MultiFileGlobalIndex &operator[](MultiFileLocalIndex local_index) {
+		return column_mapping[local_index.index];
+	}
+	idx_t size() const { // NOLINT: matching name of std
+		return column_mapping.size();
+	}
+
+private:
+	vector<MultiFileGlobalIndex> column_mapping;
+};
+
+struct MultiFileFilterMap {
+public:
+	void push_back(MultiFileFilterEntry &&filter_entry) { // NOLINT: matching name of std
+		filter_map.push_back(std::move(filter_entry));
+	}
+	MultiFileFilterEntry &operator[](MultiFileGlobalIndex global_index) {
+		return filter_map[global_index.index];
+	}
+	void resize(idx_t size) { // NOLINT: matching name of std
+		filter_map.resize(size);
+	}
+
+private:
+	vector<MultiFileFilterEntry> filter_map;
+};
+
+struct MultiFileConstantMap {
+public:
+	using iterator = vector<MultiFileConstantEntry>::iterator;
+	using const_iterator = vector<MultiFileConstantEntry>::const_iterator;
+
+public:
+	template <typename... Args>
+	void Add(Args &&...args) {
+		constant_map.emplace_back(std::forward<Args>(args)...);
+	}
+	const MultiFileConstantEntry &operator[](MultiFileConstantMapIndex constant_index) {
+		return constant_map[constant_index.index];
+	}
+	idx_t size() const { // NOLINT: matching name of std
+		return constant_map.size();
+	}
+	// Iterator support
+	iterator begin() {
+		return constant_map.begin();
+	}
+	iterator end() {
+		return constant_map.end();
+	}
+	const_iterator begin() const {
+		return constant_map.begin();
+	}
+	const_iterator end() const {
+		return constant_map.end();
+	}
+
+private:
+	vector<MultiFileConstantEntry> constant_map;
+};
+
+struct MultiFileCastMap {
+public:
+	using iterator = unordered_map<column_t, LogicalType>::iterator;
+	using const_iterator = unordered_map<column_t, LogicalType>::const_iterator;
+
+public:
+	LogicalType &operator[](MultiFileLocalColumnId column_id) {
+		return cast_map[column_id.column_id];
+	}
+	// Iterator support
+	iterator begin() {
+		return cast_map.begin();
+	}
+	iterator end() {
+		return cast_map.end();
+	}
+	const_iterator begin() const {
+		return cast_map.begin();
+	}
+	const_iterator end() const {
+		return cast_map.end();
+	}
+	iterator find(MultiFileLocalColumnId column_id) {
+		return cast_map.find(column_id.column_id);
+	}
+	bool empty() const {
+		return cast_map.empty();
+	}
+
+private:
+	unordered_map<column_t, LogicalType> cast_map;
+};
+
 struct MultiFileReaderData {
 	//! The column ids to read from the file
-	//! vector containing a mapping from (indexed with) `local_idx_t` -> `local_column_id_t`
-	vector<local_column_id_t> column_ids;
+	MultiFileLocalColumnIds<MultiFileLocalColumnId> column_ids;
 	//! The column indexes to read from the file
-	//! vector containing a mapping from (indexed with) `local_idx_t` -> `local_column_id_t` (as a ColumnIndex)
 	vector<ColumnIndex> column_indexes;
 	//! The mapping of column id -> result column id
 	//! The result chunk will be filled as follows: chunk.data[column_mapping[i]] = ReadColumn(column_ids[i]);
-	//! vector containing a mapping from `local_idx_t` -> `global_idx_t`
-	vector<global_idx_t> column_mapping;
+	MultiFileColumnMapping column_mapping;
 	//! Whether or not there are no columns to read. This can happen when a file only consists of constants
 	bool empty_columns = false;
 	//! Filters can point to either (1) local columns in the file, or (2) constant values in the `constant_map`
 	//! This map specifies where the to-be-filtered value can be found
-	//! `global_idx_t` -> `MultiFileFilterEntry`
-	vector<MultiFileFilterEntry> filter_map;
+	MultiFileFilterMap filter_map;
 	//! The set of table filters
 	optional_ptr<TableFilterSet> filters;
 	//! The constants that should be applied at the various positions
-	vector<MultiFileConstantEntry> constant_map;
+	MultiFileConstantMap constant_map;
 	//! Map of (local) column_id -> cast, used when reading multiple files when files have diverging types
 	//! for the same column
-	unordered_map<local_column_id_t, LogicalType> cast_map;
+	MultiFileCastMap cast_map;
 	//! (Optionally) The MultiFileReader-generated metadata corresponding to the currently read file
 	optional_idx file_list_idx;
 };

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -98,6 +98,7 @@ public:
 
 //! fwd declare
 struct MultiFileCastMap;
+struct MultiFileFilterEntry;
 
 struct MultiFileLocalColumnId {
 	friend class MultiFileCastMap;
@@ -131,6 +132,7 @@ struct MultiFileLocalIndex {
 	template <class T>
 	friend class MultiFileLocalColumnIds;
 	friend class MultiFileColumnMapping;
+	friend class MultiFileFilterEntry;
 
 public:
 	explicit MultiFileLocalIndex(idx_t index) : index(index) {
@@ -181,6 +183,7 @@ struct MultiFileConstantEntry {
 //! index used to access the constant map
 struct MultiFileConstantMapIndex {
 	friend class MultiFileConstantMap;
+	friend class MultiFileFilterEntry;
 
 public:
 	explicit MultiFileConstantMapIndex(idx_t index) : index(index) {
@@ -193,19 +196,45 @@ private:
 
 struct MultiFileFilterEntry {
 public:
+	MultiFileFilterEntry() : is_set(false), is_constant(false), index(DConstants::INVALID_INDEX) {
+	}
+
+public:
+	void Set(MultiFileConstantMapIndex constant_index) {
+		is_set = true;
+		is_constant = true;
+		index = constant_index.index;
+	}
+	void Set(MultiFileLocalIndex local_index) {
+		is_set = true;
+		is_constant = false;
+		index = local_index.index;
+	}
+
+	bool IsSet() const {
+		return is_set;
+	}
+	bool IsConstant() const {
+		D_ASSERT(is_set);
+		return is_constant;
+	}
+
 	MultiFileConstantMapIndex GetConstantIndex() const {
+		D_ASSERT(is_set);
 		D_ASSERT(is_constant);
 		return MultiFileConstantMapIndex(index);
 	}
 	MultiFileLocalIndex GetLocalIndex() const {
+		D_ASSERT(is_set);
 		D_ASSERT(!is_constant);
 		return MultiFileLocalIndex(index);
 	}
 
-public:
+private:
+	bool is_set;
+	bool is_constant;
 	//! ConstantMapIndex if 'is_constant' else this is a LocalIndex
-	idx_t index = DConstants::INVALID_INDEX;
-	bool is_constant = false;
+	idx_t index;
 };
 
 template <class T>

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -101,7 +101,7 @@ struct MultiFileCastMap;
 struct MultiFileFilterEntry;
 
 struct MultiFileLocalColumnId {
-	friend class MultiFileCastMap;
+	friend struct MultiFileCastMap;
 
 public:
 	explicit MultiFileLocalColumnId(column_t column_id) : column_id(column_id) {
@@ -130,9 +130,9 @@ struct MultiFileConstantMap;
 struct MultiFileLocalIndex {
 	//! these are allowed to access the index
 	template <class T>
-	friend class MultiFileLocalColumnIds;
-	friend class MultiFileColumnMapping;
-	friend class MultiFileFilterEntry;
+	friend struct MultiFileLocalColumnIds;
+	friend struct MultiFileColumnMapping;
+	friend struct MultiFileFilterEntry;
 
 public:
 	explicit MultiFileLocalIndex(idx_t index) : index(index) {
@@ -151,8 +151,8 @@ private:
 };
 
 struct MultiFileGlobalIndex {
-	friend class MultiFileGlobalColumnIds;
-	friend class MultiFileFilterMap;
+	friend struct MultiFileGlobalColumnIds;
+	friend struct MultiFileFilterMap;
 
 public:
 	explicit MultiFileGlobalIndex(idx_t index) : index(index) {
@@ -182,8 +182,8 @@ struct MultiFileConstantEntry {
 
 //! index used to access the constant map
 struct MultiFileConstantMapIndex {
-	friend class MultiFileConstantMap;
-	friend class MultiFileFilterEntry;
+	friend struct MultiFileConstantMap;
+	friend struct MultiFileFilterEntry;
 
 public:
 	explicit MultiFileConstantMapIndex(idx_t index) : index(index) {

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -108,7 +108,7 @@ public:
 	}
 
 public:
-	operator idx_t() {
+	operator idx_t() { // NOLINT: allow implicit conversion
 		return column_id;
 	}
 	idx_t GetId() const {
@@ -139,7 +139,7 @@ public:
 	}
 
 public:
-	operator idx_t() {
+	operator idx_t() { // NOLINT: allow implicit conversion
 		return index;
 	}
 	idx_t GetIndex() const {
@@ -159,7 +159,7 @@ public:
 	}
 
 public:
-	operator idx_t() {
+	operator idx_t() { // NOLINT: allow implicit conversion
 		return index;
 	}
 	idx_t GetIndex() const {
@@ -279,8 +279,8 @@ private:
 
 struct MultiFileFilterMap {
 public:
-	void push_back(MultiFileFilterEntry &&filter_entry) { // NOLINT: matching name of std
-		filter_map.push_back(std::move(filter_entry));
+	void push_back(const MultiFileFilterEntry &filter_entry) { // NOLINT: matching name of std
+		filter_map.push_back(filter_entry);
 	}
 	MultiFileFilterEntry &operator[](MultiFileGlobalIndex global_index) {
 		return filter_map[global_index.index];

--- a/src/include/duckdb/common/base_file_reader.hpp
+++ b/src/include/duckdb/common/base_file_reader.hpp
@@ -96,11 +96,6 @@ public:
 	Value identifier;
 };
 
-struct MultiFileFilterEntry {
-	idx_t index = DConstants::INVALID_INDEX;
-	bool is_constant = false;
-};
-
 struct MultiFileReaderData {
 	//! The column ids to read from the file
 	vector<idx_t> column_ids;
@@ -113,7 +108,7 @@ struct MultiFileReaderData {
 	bool empty_columns = false;
 	//! Filters can point to either (1) local columns in the file, or (2) constant values in the `constant_map`
 	//! This map specifies where the to-be-filtered value can be found
-	vector<MultiFileFilterEntry> filter_map;
+	vector<idx_t> filter_map;
 	//! The set of table filters
 	optional_ptr<TableFilterSet> filters;
 	//! The mapping of (global) column_id -> constant value


### PR DESCRIPTION
This PR does not change anything functionality-wise

In the `MultiFileReaderData` we have many mappings, used in various contexts, and many of these mappings are tied to each other - if one changes, the other should also change.

All of these were using `idx_t`, which made it very confusing and error-prone to use and understand what type of index is required and produced.

This PR introduces the following structs as typesafe replacements:
- `MultiFileLocalColumnId`
- `MultiFileLocalIndex`
- `MultiFileGlobalIndex`
- `MultiFileConstantMapIndex`
- `MultiFileLocalColumnIds`
- `MultiFileColumnMapping`
- `MultiFileFilterMap`
- `MultiFileConstantMap`
- `MultiFileCastMap`

column_ids, column_mapping, filter_map, constant_map and cast_map are indexed with and produce the typed indexes
`MultiFileFilterEntry` has been changed to produce `MultiFileConstantMapIndex` or `MultiFileLocalIndex` depending on the way it was set.