### PR TITLE
[Dev] CGroup v1 memory limit fix

### DIFF
--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -66,7 +66,7 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 		return optional_idx();
 	}
 
-	return ReadCGroupValue(fs, memory_limit_path);
+	return ReadCGroupValue(fs, memory_limit_path.c_str());
 #else
 	return optional_idx();
 #endif

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -51,7 +51,6 @@ optional_idx CGroups::GetCGroupV2MemoryLimit(FileSystem &fs) {
 optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 #if defined(__linux__) && !defined(DUCKDB_WASM)
 	const char *cgroup_self = "/proc/self/cgroup";
-	const char *memory_limit = "/sys/fs/cgroup/memory/%s/memory.limit_in_bytes";
 
 	if (!fs.FileExists(cgroup_self)) {
 		return optional_idx();
@@ -62,9 +61,7 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 		return optional_idx();
 	}
 
-	char memory_limit_path[256];
-	snprintf(memory_limit_path, sizeof(memory_limit_path), memory_limit, memory_cgroup_path.c_str());
-
+	auto memory_limit_path = StringUtil::Format("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", memory_cgroup_path);
 	if (!fs.FileExists(memory_limit_path)) {
 		return optional_idx();
 	}

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -64,7 +64,7 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 		Printer::PrintF("Did not find a 'memory' block in the content", cgroup_self);
 		return optional_idx();
 	}
-	Printer::PrintF("Found cgroup memory path: %s", memory_group_path);
+	Printer::PrintF("Found cgroup memory path: %s", memory_cgroup_path);
 
 	auto memory_limit_path = StringUtil::Format("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", memory_cgroup_path);
 	if (!fs.FileExists(memory_limit_path)) {

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -116,8 +116,11 @@ string CGroups::ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file) {
 	string line;
 	while ((pos = content.find('\n')) != string::npos) {
 		line = content.substr(0, pos);
-		if (line.find("memory:") == 0) {
-			return line.substr(line.find(':') + 1);
+		auto memory_pos = line.find("memory:");
+		if (memory_pos != string::npos) {
+			auto memory_path = line.substr(memory_pos + 7);
+			Printer::PrintF("Memory path found: %s", memory_path);
+			return memory_path;
 		}
 		content.erase(0, pos + 1);
 	}

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/types/cast_helpers.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/printer.hpp"
 
 #include <cinttypes>
 
@@ -53,19 +54,24 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 	const char *cgroup_self = "/proc/self/cgroup";
 
 	if (!fs.FileExists(cgroup_self)) {
+		Printer::PrintF("Could not find cgroup file: %s", cgroup_self);
 		return optional_idx();
 	}
+	Printer::PrintF("Found cgroup file: %s", cgroup_self);
 
 	string memory_cgroup_path = ReadMemoryCGroupPath(fs, cgroup_self);
 	if (memory_cgroup_path.empty()) {
+		Printer::PrintF("Did not find a 'memory' block in the content", cgroup_self);
 		return optional_idx();
 	}
+	Printer::PrintF("Found cgroup memory path: %s", memory_group_path);
 
 	auto memory_limit_path = StringUtil::Format("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", memory_cgroup_path);
 	if (!fs.FileExists(memory_limit_path)) {
+		Printer::PrintF("Memory limit path: %s does not exist", memory_limit_path);
 		return optional_idx();
 	}
-
+	Printer::PrintF("Memory limit path: %s exists", memory_limit_path);
 	return ReadCGroupValue(fs, memory_limit_path.c_str());
 #else
 	return optional_idx();
@@ -104,6 +110,8 @@ string CGroups::ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file) {
 
 	// For cgroup v1, we're looking for a line with "memory:/path"
 	string content(buffer);
+	Printer::PrintF("cgroup file contents: %s", content);
+
 	size_t pos = 0;
 	string line;
 	while ((pos = content.find('\n')) != string::npos) {
@@ -124,8 +132,10 @@ optional_idx CGroups::ReadCGroupValue(FileSystem &fs, const char *file_path) {
 	auto bytes_read = fs.Read(*handle, buffer, 99);
 	buffer[bytes_read] = '\0';
 
+	auto contents = string_t(buffer);
+	Printer::PrintF("Contents of the memory limit file: %s", contents.GetString());
 	idx_t value;
-	if (TryCast::Operation<string_t, idx_t>(string_t(buffer), value)) {
+	if (TryCast::Operation<string_t, idx_t>(contents, value)) {
 		return optional_idx(value);
 	}
 #endif


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb/issues/7651#issuecomment-2708219957

Changes are that we no longer expect `memory:` to be at the start of the line, it can be in any part of the line.
I did not find merit in the other part, about the `memory_cgroup_path ` not being correct.

Tested with docker-compose, on a Linux VM, after modifying `GRUB_CMDLINE_LINUX="systemd.unified_cgroup_hierarchy=0"` in the `/etc/default/grub`.