### PR TITLE
[Dev] Clean up and fix the CGroup memory/cpu limit discovery logic

### DIFF
--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -64,7 +64,9 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 		vector<string> parts;
 		auto it = line.begin();
 		while (it != line.end()) {
-			auto next = std::find_if(it, line.end(), [](char c) { return c == ':'; });
+			//! Don't make more than 3 splits
+			auto next = parts.size() == 2 ? line.end() : std::find_if(it, line.end(), [](char c) { return c == ':'; });
+
 			parts.emplace_back(it, next);
 			if (next == line.end()) {
 				break;
@@ -74,7 +76,7 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 
 		if (parts.size() < 3) {
 			//! cgroup entries are in this format:
-			// hierarchy-ID:controller-list:cgroup-path[:additional_metadata]
+			// hierarchy-ID:controller-list:cgroup-path
 			break;
 		}
 		auto hierarchy_id = std::stoi(parts[0]);

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -72,9 +72,9 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 			it = std::next(next);
 		}
 
-		if (parts.size() != 3) {
+		if (parts.size() < 3) {
 			//! cgroup entries are in this format:
-			// hierarchy-ID:controller-list:cgroup-path
+			// hierarchy-ID:controller-list:cgroup-path[:additional_metadata]
 			break;
 		}
 		auto hierarchy_id = std::stoi(parts[0]);

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -78,7 +78,11 @@ static optional_idx GetCPUCountFromQuotaAndPeriod(const CGroupEntry &entry, File
 	auto cfs_quota = StringUtil::Format(CFS_QUOTA, entry.cgroup_path);
 	auto cfs_period = StringUtil::Format(CFS_PERIOD, entry.cgroup_path);
 
-	int64_t quota, period;
+	//! See https://docs.kernel.org/scheduler/sched-bwc.html
+	//! run-time replenished within a period (in microseconds)
+	int64_t quota;
+	//! the length of a period (in microseconds)
+	int64_t period;
 	char byte_buffer[1000];
 	if (fs.FileExists(cpu_max)) {
 		// cgroup v2

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -25,6 +25,17 @@ public:
 	}
 
 public:
+	bool IsRoot() const {
+		if (hierarchy_id != 0) {
+			return false;
+		}
+		if (controller_list.size() != 1) {
+			return false;
+		}
+		return controller_list[0].empty();
+	}
+
+public:
 	idx_t hierarchy_id;
 	vector<string> controller_list;
 	string cgroup_path;
@@ -179,7 +190,7 @@ optional_idx CGroups::GetMemoryLimit(FileSystem &fs) {
 		Printer::PrintF("HierarchyId: %d | ControllerList: %s (Size %d) | CGroupPath: %s", entry.hierarchy_id,
 		                StringUtil::Join(entry.controller_list, ", "), entry.controller_list.size(), entry.cgroup_path);
 		auto &controller_list = entry.controller_list;
-		if (entry.hierarchy_id == 0 && controller_list.empty()) {
+		if (entry.IsRoot()) {
 			root_entry = i;
 			continue;
 		}
@@ -224,7 +235,7 @@ idx_t CGroups::GetCPULimit(FileSystem &fs, idx_t physical_cores) {
 	for (idx_t i = 0; i < cgroup_entries.size(); i++) {
 		auto &entry = cgroup_entries[i];
 		auto &controller_list = entry.controller_list;
-		if (entry.hierarchy_id == 0 && controller_list.empty()) {
+		if (entry.IsRoot()) {
 			root_entry = i;
 			continue;
 		}

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -172,10 +172,11 @@ optional_idx CGroups::GetMemoryLimit(FileSystem &fs) {
 	auto cgroup_entries = ParseGroupEntries(fs);
 	for (idx_t i = 0; i < cgroup_entries.size(); i++) {
 		auto &entry = cgroup_entries[i];
+		Printer::PrintF("HierarchyId: %d | ControllerList: %s | CGroupPath: %s", entry.hierarchy_id,
+		                StringUtil::Join(entry.controller_list, ", "), entry.cgroup_path);
 		auto &controller_list = entry.controller_list;
-		if (controller_list.empty()) {
+		if (entry.hierarchy_id == 0 && controller_list.empty()) {
 			root_entry = i;
-			D_ASSERT(entry.hierarchy_id == 0);
 			continue;
 		}
 		for (auto &controller : controller_list) {

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -187,9 +187,8 @@ idx_t CGroups::GetCPULimit(FileSystem &fs, idx_t physical_cores) {
 	for (idx_t i = 0; i < cgroup_entries.size(); i++) {
 		auto &entry = cgroup_entries[i];
 		auto &controller_list = entry.controller_list;
-		if (controller_list.empty()) {
+		if (entry.hierarchy_id == 0 && controller_list.empty()) {
 			root_entry = i;
-			D_ASSERT(entry.hierarchy_id == 0);
 			continue;
 		}
 		for (auto &controller : controller_list) {

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -52,7 +52,7 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 		Printer::PrintF("cgroup file bytes read: %d | buffer_size: %d", bytes_read, buffer_size);
 	}
 	buffer[bytes_read] = '\0';
-	auto cgroup_file_content = string(buffer);
+	auto cgroup_file_content = string(buffer.get());
 
 	Printer::PrintF("cgroup_file_content size: %d", cgroup_file_content.size());
 	Printer::PrintF("cgroup_file_content:\n%s", cgroup_file_content);

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -16,7 +16,7 @@ namespace duckdb {
 namespace {
 
 static constexpr const char *CGROUP_PATH = "/proc/self/cgroup";
-static constexpr const idx_t DEFAULT_CGROUP_FILE_BUFFER_SIZE = 1024;
+static constexpr const int64_t DEFAULT_CGROUP_FILE_BUFFER_SIZE = 1024;
 
 struct CGroupEntry {
 public:
@@ -66,8 +66,9 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 		while (it != line.end()) {
 			auto next = std::find_if(it, line.end(), [](char c) { return c == ':'; });
 			parts.emplace_back(it, next);
-			if (next == line.end())
+			if (next == line.end()) {
 				break;
+			}
 			it = std::next(next);
 		}
 

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -66,7 +66,7 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 		return optional_idx();
 	}
 
-	return ReadCGroupValue(fs, memory_limit_path);
+	return ReadCGroupValue(fs, memory_limit_path.c_str());
 #else
 	return optional_idx();
 #endif

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -38,20 +38,16 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 
 	auto handle = fs.OpenFile(CGROUP_PATH, FileFlags::FILE_FLAGS_READ);
 
-	int64_t buffer_size = DEFAULT_CGROUP_FILE_BUFFER_SIZE;
-	unsafe_unique_array<char> buffer = make_unsafe_uniq_array_uninitialized<char>(buffer_size);
+	char buffer[DEFAULT_CGROUP_FILE_BUFFER_SIZE];
 	int64_t bytes_read;
 	string cgroup_file_content;
 	do {
-		bytes_read = fs.Read(*handle, buffer.get(), buffer_size - 1);
-		Printer::PrintF("cgroup file bytes read: %d | buffer_size: %d", bytes_read, buffer_size);
+		bytes_read = fs.Read(*handle, buffer, DEFAULT_CGROUP_FILE_BUFFER_SIZE - 1);
 		buffer[bytes_read] = '\0';
-		cgroup_file_content += string(buffer.get());
-	} while (bytes_read >= buffer_size - 1);
+		cgroup_file_content += string(buffer);
+	} while (bytes_read >= DEFAULT_CGROUP_FILE_BUFFER_SIZE - 1);
 
-	Printer::PrintF("cgroup_file_content size: %d", cgroup_file_content.size());
 	Printer::PrintF("cgroup_file_content:\n%s", cgroup_file_content);
-
 	size_t pos = 0;
 	string line;
 	while ((pos = cgroup_file_content.find('\n')) != string::npos) {

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -18,6 +18,12 @@ static constexpr const char *CGROUP_PATH = "/proc/self/cgroup";
 static constexpr const idx_t DEFAULT_CGROUP_FILE_BUFFER_SIZE = 1024;
 
 struct CGroupEntry {
+public:
+	CGroupEntry(idx_t hierarchy_id, vector<string> &&controller_list, const string &cgroup_path)
+	    : hierarchy_id(hierarchy_id), controller_list(std::move(controller_list)), cgroup_path(cgroup_path) {
+	}
+
+public:
 	idx_t hierarchy_id;
 	vector<string> controller_list;
 	string cgroup_path;

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -37,7 +37,7 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 
 	auto handle = fs.OpenFile(CGROUP_PATH, FileFlags::FILE_FLAGS_READ);
 	string cgroup_file_content;
-	auto file_size = handle->GetFileSize();
+	int64_t file_size = handle->GetFileSize();
 	if (file_size != 0) {
 		auto buffer = make_unsafe_uniq_array_uninitialized<char>(file_size + 1);
 		auto bytes_read = fs.Read(*handle, buffer.get(), file_size);

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -51,7 +51,6 @@ optional_idx CGroups::GetCGroupV2MemoryLimit(FileSystem &fs) {
 optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 #if defined(__linux__) && !defined(DUCKDB_WASM)
 	const char *cgroup_self = "/proc/self/cgroup";
-	const char *memory_limit = "/sys/fs/cgroup/memory/%s/memory.limit_in_bytes";
 
 	if (!fs.FileExists(cgroup_self)) {
 		return optional_idx();
@@ -62,9 +61,7 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 		return optional_idx();
 	}
 
-	char memory_limit_path[256];
-	snprintf(memory_limit_path, sizeof(memory_limit_path), memory_limit, memory_cgroup_path.c_str());
-
+	auto memory_limit_path = StringUtil::Format("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", memory_cgroup_path);
 	if (!fs.FileExists(memory_limit_path)) {
 		return optional_idx();
 	}

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -37,19 +37,23 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 	}
 
 	auto handle = fs.OpenFile(CGROUP_PATH, FileFlags::FILE_FLAGS_READ);
-	string cgroup_file_content;
-	int64_t file_size = NumericCast<int64_t>(handle->GetFileSize());
-	if (file_size != 0) {
-		auto buffer = make_unsafe_uniq_array_uninitialized<char>(file_size + 1);
-		auto bytes_read = fs.Read(*handle, buffer.get(), file_size);
-		buffer[bytes_read] = '\0';
-		cgroup_file_content = string(buffer.get());
-	} else {
-		char buffer[DEFAULT_CGROUP_FILE_BUFFER_SIZE];
-		auto bytes_read = fs.Read(*handle, buffer, sizeof(buffer) - 1);
-		buffer[bytes_read] = '\0';
-		cgroup_file_content = string(buffer);
+
+	int64_t buffer_size = 0;
+	unsafe_unique_array<char> buffer;
+	int64_t bytes_read;
+	while (!buffer || bytes_read >= buffer_size - 1) {
+		if (!buffer) {
+			buffer_size = DEFAULT_CGROUP_FILE_BUFFER_SIZE;
+		} else {
+			buffer_size *= 2;
+		}
+		buffer = make_unsafe_uniq_array_uninitialized<char>(buffer_size);
+		bytes_read = fs.Read(*handle, buffer.get(), buffer_size - 1);
+		Printer::PrintF("cgroup file bytes read: %d | buffer_size: %d", bytes_read, buffer_size);
 	}
+	buffer[bytes_read] = '\0';
+	auto cgroup_file_content = string(buffer);
+
 	Printer::PrintF("cgroup_file_content size: %d", cgroup_file_content.size());
 	Printer::PrintF("cgroup_file_content:\n%s", cgroup_file_content);
 

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -64,7 +64,7 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 		Printer::PrintF("Did not find a 'memory' block in the content", cgroup_self);
 		return optional_idx();
 	}
-	Printer::PrintF("Found cgroup memory path: %s", memory_group_path);
+	Printer::PrintF("Found cgroup memory path: %s", memory_cgroup_path);
 
 	auto memory_limit_path = StringUtil::Format("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", memory_cgroup_path);
 	if (!fs.FileExists(memory_limit_path)) {

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -116,8 +116,11 @@ string CGroups::ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file) {
 	string line;
 	while ((pos = content.find('\n')) != string::npos) {
 		line = content.substr(0, pos);
-		if (line.find("memory:") == 0) {
-			return line.substr(line.find(':') + 1);
+		auto memory_pos = line.find("memory:");
+		if (memory_pos != string::npos) {
+			auto memory_path = line.substr(memory_pos + 7);
+			Printer::PrintF("Memory path found: %s", memory_path);
+			return memory_path;
 		}
 		content.erase(0, pos + 1);
 	}

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -50,8 +50,18 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 	Printer::PrintF("cgroup_file_content:\n%s", cgroup_file_content);
 	auto lines = StringUtil::Split(cgroup_file_content, "\n");
 	for (auto &line : lines) {
-		auto parts = StringUtil::Split(line, ":");
+		vector<string> parts;
+		auto it = line.begin();
+		while (it != line.end()) {
+			auto next = std::find_if(it, line.end(), [](char c) { return c == ':'; });
+			parts.emplace_back(it, next);
+			if (next == line.end())
+				break;
+			it = std::next(next);
+		}
+
 		if (parts.size() != 3) {
+			Printer::PrintF("Part count not correct, expected 3, found %d", parts.size());
 			//! cgroup entries are in this format:
 			// hierarchy-ID:controller-list:cgroup-path
 			break;

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -162,7 +162,7 @@ optional_idx CGroups::GetMemoryLimit(FileSystem &fs) {
 
 	if (root_entry.IsValid()) {
 		auto &entry = cgroup_entries[root_entry.GetIndex()];
-		auto path = StringUtil::Format("/sys/fs/cgroup/%s/memory.max", entry.cgroup_path);
+		auto path = StringUtil::Format("/sys/fs/cgroup%s/memory.max", entry.cgroup_path);
 		auto memory_limit = ReadMemoryLimit(fs, path.c_str());
 		if (memory_limit.IsValid()) {
 			return memory_limit;
@@ -170,7 +170,7 @@ optional_idx CGroups::GetMemoryLimit(FileSystem &fs) {
 	}
 	if (memory_entry.IsValid()) {
 		auto &entry = cgroup_entries[memory_entry.GetIndex()];
-		auto path = StringUtil::Format("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", entry.cgroup_path);
+		auto path = StringUtil::Format("/sys/fs/cgroup/memory%s/memory.limit_in_bytes", entry.cgroup_path);
 		auto memory_limit = ReadMemoryLimit(fs, path.c_str());
 		if (memory_limit.IsValid()) {
 			return memory_limit;

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -62,7 +62,8 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 		}
 		auto hierarchy_id = std::stoi(parts[0]);
 		auto controller_list = StringUtil::Split(parts[1], ",");
-		result.emplace_back(hierarchy_id, std::move(controller_list), parts[2]);
+		auto cgroup_path = parts[2] == "/" ? "" : parts[2];
+		result.emplace_back(hierarchy_id, std::move(controller_list), cgroup_path);
 		cgroup_file_content.erase(0, pos + 1);
 	}
 	return result;

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/types/cast_helpers.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/printer.hpp"
 
 #include <cinttypes>
 
@@ -53,19 +54,24 @@ optional_idx CGroups::GetCGroupV1MemoryLimit(FileSystem &fs) {
 	const char *cgroup_self = "/proc/self/cgroup";
 
 	if (!fs.FileExists(cgroup_self)) {
+		Printer::PrintF("Could not find cgroup file: %s", cgroup_self);
 		return optional_idx();
 	}
+	Printer::PrintF("Found cgroup file: %s", cgroup_self);
 
 	string memory_cgroup_path = ReadMemoryCGroupPath(fs, cgroup_self);
 	if (memory_cgroup_path.empty()) {
+		Printer::PrintF("Did not find a 'memory' block in the content", cgroup_self);
 		return optional_idx();
 	}
+	Printer::PrintF("Found cgroup memory path: %s", memory_group_path);
 
 	auto memory_limit_path = StringUtil::Format("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", memory_cgroup_path);
 	if (!fs.FileExists(memory_limit_path)) {
+		Printer::PrintF("Memory limit path: %s does not exist", memory_limit_path);
 		return optional_idx();
 	}
-
+	Printer::PrintF("Memory limit path: %s exists", memory_limit_path);
 	return ReadCGroupValue(fs, memory_limit_path.c_str());
 #else
 	return optional_idx();
@@ -104,6 +110,8 @@ string CGroups::ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file) {
 
 	// For cgroup v1, we're looking for a line with "memory:/path"
 	string content(buffer);
+	Printer::PrintF("cgroup file contents: %s", content);
+
 	size_t pos = 0;
 	string line;
 	while ((pos = content.find('\n')) != string::npos) {
@@ -124,8 +132,10 @@ optional_idx CGroups::ReadCGroupValue(FileSystem &fs, const char *file_path) {
 	auto bytes_read = fs.Read(*handle, buffer, 99);
 	buffer[bytes_read] = '\0';
 
+	auto contents = string_t(buffer);
+	Printer::PrintF("Contents of the memory limit file: %s", contents.GetString());
 	idx_t value;
-	if (TryCast::Operation<string_t, idx_t>(string_t(buffer), value)) {
+	if (TryCast::Operation<string_t, idx_t>(contents, value)) {
 		return optional_idx(value);
 	}
 #endif

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -50,6 +50,8 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 		buffer[bytes_read] = '\0';
 		cgroup_file_content = string(buffer);
 	}
+	Printer::PrintF("cgroup_file_content size: %d", cgroup_file_content.size());
+	Printer::PrintF("cgroup_file_content:\n%s", cgroup_file_content);
 
 	size_t pos = 0;
 	string line;

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -183,18 +183,17 @@ optional_idx CGroups::GetMemoryLimit(FileSystem &fs) {
 	auto cgroup_entries = ParseGroupEntries(fs);
 	for (idx_t i = 0; i < cgroup_entries.size(); i++) {
 		auto &entry = cgroup_entries[i];
-		                StringUtil::Join(entry.controller_list, ", "), entry.controller_list.size(), entry.cgroup_path);
-		                auto &controller_list = entry.controller_list;
-		                if (entry.IsRoot()) {
-			                root_entry = i;
-			                continue;
-		                }
-		                for (auto &controller : controller_list) {
-			                if (controller == "memory") {
-				                memory_entry = i;
-				                break;
-			                }
-		                }
+		auto &controller_list = entry.controller_list;
+		if (entry.IsRoot()) {
+			root_entry = i;
+			continue;
+		}
+		for (auto &controller : controller_list) {
+			if (controller == "memory") {
+				memory_entry = i;
+				break;
+			}
+		}
 	}
 
 	if (memory_entry.IsValid()) {

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -48,10 +48,8 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 	} while (bytes_read >= DEFAULT_CGROUP_FILE_BUFFER_SIZE - 1);
 
 	Printer::PrintF("cgroup_file_content:\n%s", cgroup_file_content);
-	size_t pos = 0;
-	string line;
-	while ((pos = cgroup_file_content.find('\n')) != string::npos) {
-		line = cgroup_file_content.substr(0, pos);
+	auto lines = StringUtil::Split(cgroup_file_content, "\n");
+	for (auto &line : lines) {
 		auto parts = StringUtil::Split(line, ":");
 		if (parts.size() != 3) {
 			//! cgroup entries are in this format:
@@ -62,7 +60,6 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 		auto controller_list = StringUtil::Split(parts[1], ",");
 		auto cgroup_path = parts[2] == "/" ? "" : parts[2];
 		result.emplace_back(hierarchy_id, std::move(controller_list), cgroup_path);
-		cgroup_file_content.erase(0, pos + 1);
 	}
 	return result;
 }

--- a/src/common/cgroups.cpp
+++ b/src/common/cgroups.cpp
@@ -37,7 +37,7 @@ static vector<CGroupEntry> ParseGroupEntries(FileSystem &fs) {
 
 	auto handle = fs.OpenFile(CGROUP_PATH, FileFlags::FILE_FLAGS_READ);
 	string cgroup_file_content;
-	int64_t file_size = handle->GetFileSize();
+	int64_t file_size = NumericCast<int64_t>(handle->GetFileSize());
 	if (file_size != 0) {
 		auto buffer = make_unsafe_uniq_array_uninitialized<char>(file_size + 1);
 		auto bytes_read = fs.Read(*handle, buffer.get(), file_size);

--- a/src/include/duckdb/common/cgroups.hpp
+++ b/src/include/duckdb/common/cgroups.hpp
@@ -18,13 +18,6 @@ class CGroups {
 public:
 	static optional_idx GetMemoryLimit(FileSystem &fs);
 	static idx_t GetCPULimit(FileSystem &fs, idx_t physical_cores);
-
-private:
-	static optional_idx GetCGroupV2MemoryLimit(FileSystem &fs);
-	static optional_idx GetCGroupV1MemoryLimit(FileSystem &fs);
-	static string ReadCGroupPath(FileSystem &fs, const char *cgroup_file);
-	static string ReadMemoryCGroupPath(FileSystem &fs, const char *cgroup_file);
-	static optional_idx ReadCGroupValue(FileSystem &fs, const char *file_path);
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This PR supersedes https://github.com/duckdb/duckdb/pull/16603

## Old Discovery
Previously, the logic consisted of:

### Memory Limit discovery

Try cgroupv2, then try cgroupv1
#### CGroupV2
- read `/proc/self/cgroup` (1024 bytes max)
- find `0::/cgroup-path`
- construct the subpath using `/sys/fs/cgroup/%s/memory.max`[1]
- read from the subpath (100 bytes)
- convert this string to a number

#### CGroupV1
- read `/proc/self/cgroup` (1024 bytes max)
- find `<hierarchy-id>:memory:/cgroup-path` (previously we skipped the hierarchy-id, fixed by #16603)
- construct the subpath using `/sys/fs/cgroup/memory/%s/memory.limit_in_bytes`[1]
- read from the subpath (100 bytes)
- convert this string to a number

### CPU Limit discovery

- check existence of `/sys/fs/cgroup/cpu.max`, if it exists, use that
- check existence of `/sys/fs/cgroup/cpu/cpu.cfs_quota_us` and `/sys/fs/cgroup/cpu/cpu.cfs_period_us`, if they exist, use that
- fall back to `physical_cores` (the hardware-based discovery we made earlier)

#### CGroupV2
`/sys/fs/cgroup/cpu.max` is part of cgroupv2
- read the `quota` and `period`
- return quota / period

#### CGroupV1
`/sys/fs/cgroup/cpu/cpu.cfs_quota_us` and `/sys/fs/cgroup/cpu/cpu.cfs_period_us` are part of cgroupv1
- read the `quota` from `cpu.cfs_quota_us`
- read the `period` from `cpu.cfs_period_us`
- return quota / period

[1] the `cgroup-path` always starts with `/` so this is somewhat wrong

## New Discovery

- read the contents of `/proc/self/cgroup`, with a buffer of 1024 bytes, **keep reading until the file is empty**.
- parse the contents into a vector of:
```c++
struct CGroupEntry {
	idx_t hierarchy_id;
	vector<string> controller_list;
	string cgroup_path;
};
```

Find the root_entry, in the shape of `hierarchy_id == 0` and `controller_list.size() == 1` and `controller_list[0].empty()`
Find the controller entry, where the controller we are looking for (`memory` or `cpu`) is present in the `controller_list`

if the controller-specific entry exists, try that first (cgroupv1). Controller-specific entries don't exist in cgroupsv2 so this doesn't affect that.
If that doesn't get a result, try the root_entry (cgroupsv2).

### Memory Limit discovery

#### CGroupV1
- construct the subpath using `/sys/fs/cgroup/memory%s/memory.limit_in_bytes` [2]
- read from the subpath (100 bytes)
- convert this string to a number
- try the same for the root directory (`/sys/fs/cgroup/memory/memory.limit_in_bytes`) [3]

#### CGroupV2
- construct the subpath using `/sys/fs/cgroup%s/memory.max` [2]
- read from the subpath (100 bytes)
- convert this string to a number
- try the same for the root directory (`/sys/fs/cgroup/memory.max`) [3]

### CPU Limit discovery

#### CGroupV1
- construct the quota subpath using `/sys/fs/cgroup/cpu%s/cpu.cfs_quota_us` [2]
- construct the period subpath using`/sys/fs/cgroup/cpu%s/cpu.cfs_period_us` [2]
- read the `quota` from `cpu.cfs_quota_us`
- read the `period` from `cpu.cfs_period_us`
- return quota / period
- try the same for the root directory (`/sys/fs/cgroup/cpu/cpu.cfs_quota_us` and `/sys/fs/cgroup/cpu/cpu.cfs_period_us`) [3]

#### CGroupV2
- construct the subpath using `/sys/fs/cgroup%s/cpu.max` [2]
- read the `quota` and `period`
- return quota / period
- try the same for the root directory (`/sys/fs/cgroup/cpu.max`) [3]

[2] %s is replaced with an empty string if the `cgroup-path` is `/`
[3] we try the root directory, as a way to avoid parsing and using the `/proc/self/mountinfo`, perhaps in the future we should be doing this properly.

TL;DR:
- Support for bigger cgroup files by reading the content until it's empty.
- Support for more complicated controller lists (memory could be combined with other controllers in a controller-list).
- CPU limit does not assume the cgroup is at the root anymore for both cgroupv1 and cgroupv2.
- Fixed the issue where paths like `sys/fs/cgroup/memory///memory.limit_in_bytes` were being constructed.
- Try the controller-specific entry first, only afterwards try the root entry.