### PR TITLE
Downloading extension should be via HTTPS

### DIFF
--- a/extension/ExtensionDistribution.md
+++ b/extension/ExtensionDistribution.md
@@ -1,11 +1,11 @@
 ## Extension served via URLs
 
 When performing `INSTALL name`, if the file is not present locally or bundled via static linking, it will be downloaded from the network.
-Extensions are served from URLs like: http://extensions.duckdb.org/v0.8.1/windows_arm64/name.duckdb_extension.gz
+Extensions are served from URLs like: https://extensions.duckdb.org/v0.8.1/windows_arm64/name.duckdb_extension.gz
 
 Unpacking this:
 ```
-http://extensions.duckdb.org/              The extension registry URL (can have subfolders)
+https://extensions.duckdb.org/              The extension registry URL (can have subfolders)
 v0.8.1/                                     The version identifier
 osx_arm64/                                  The platform this extension is compatible with
 name                                        The default name of a given extension

--- a/src/include/duckdb/main/extension_install_info.hpp
+++ b/src/include/duckdb/main/extension_install_info.hpp
@@ -55,9 +55,9 @@ public:
 
 struct ExtensionRepository {
 	//! All currently available repositories
-	static constexpr const char *CORE_REPOSITORY_URL = "http://extensions.duckdb.org";
-	static constexpr const char *CORE_NIGHTLY_REPOSITORY_URL = "http://nightly-extensions.duckdb.org";
-	static constexpr const char *COMMUNITY_REPOSITORY_URL = "http://community-extensions.duckdb.org";
+	static constexpr const char *CORE_REPOSITORY_URL = "https://extensions.duckdb.org";
+	static constexpr const char *CORE_NIGHTLY_REPOSITORY_URL = "https://nightly-extensions.duckdb.org";
+	static constexpr const char *COMMUNITY_REPOSITORY_URL = "https://community-extensions.duckdb.org";
 
 	//! Debugging repositories (target local, relative paths that are produced by DuckDB's build system)
 	static constexpr const char *BUILD_DEBUG_REPOSITORY_PATH = "./build/debug/repository";

--- a/test/extension/install_extension.test
+++ b/test/extension/install_extension.test
@@ -12,25 +12,25 @@ set extension_directory='__TEST_DIR__/install_extension'
 statement error
 INSTALL will_never_exist;
 ----
-Failed to download extension "will_never_exist" at URL "http://extensions.duckdb.org
+Failed to download extension "will_never_exist" at URL "https://extensions.duckdb.org
 
 # Explicitly install from core
 statement error
 INSTALL will_never_exist FROM core;
 ----
-Failed to download extension "will_never_exist" at URL "http://extensions.duckdb.org
+Failed to download extension "will_never_exist" at URL "https://extensions.duckdb.org
 
 # Explicitly install from nightly
 statement error
 INSTALL will_never_exist FROM core_nightly;
 ----
-Failed to download extension "will_never_exist" at URL "http://nightly-extensions.duckdb.org
+Failed to download extension "will_never_exist" at URL "https://nightly-extensions.duckdb.org
 
 # Explicitly install from community
 statement error
 INSTALL will_never_exist FROM community;
 ----
-Failed to download extension "will_never_exist" at URL "http://community-extensions.duckdb.org
+Failed to download extension "will_never_exist" at URL "https://community-extensions.duckdb.org
 
 # Alias can not quoted: string literals are interpreted as paths
 statement error

--- a/tools/shell/tests/test_http_logging.py
+++ b/tools/shell/tests/test_http_logging.py
@@ -12,7 +12,7 @@ def test_http_logging_stderr(shell):
     test = (
         ShellTest(shell)
         .statement("SET enable_http_logging=true;")
-        .statement("install 'http://extensions.duckdb.org/v0.10.1/osx_arm64/httpfs.duckdb_extension.gzzz';")
+        .statement("install 'https://extensions.duckdb.org/v0.10.1/osx_arm64/httpfs.duckdb_extension.gzzz';")
     )
     result = test.run()
     result.check_stderr("HTTP Request")
@@ -28,7 +28,7 @@ def test_http_logging_file(shell, tmp_path):
         ShellTest(shell)
         .statement("SET enable_http_logging=true;")
         .statement(f"SET http_logging_output='{temp_file.as_posix()}'")
-        .statement("install 'http://extensions.duckdb.org/v0.10.1/osx_arm64/httpfs.duckdb_extension.gzzz';")
+        .statement("install 'https://extensions.duckdb.org/v0.10.1/osx_arm64/httpfs.duckdb_extension.gzzz';")
     )
     result = test.run()
 


### PR DESCRIPTION
Congratz on the launch with duckdb-ui, I was curious as to how it works and checked the traffic, only to realise the extensions are being loaded over HTTP. 

While this is somewhat a low risk factor, it is possible for someone in the same LAN to hijack these dns and potentially push down malicious extension & get remote code execution. 

I have updated the links where i can find them and also fix the test.