### PR TITLE
Fix missing **kwargs in adbc_driver_duckdb.dbapi.connect()

### DIFF
--- a/tools/pythonpkg/adbc_driver_duckdb/dbapi.py
+++ b/tools/pythonpkg/adbc_driver_duckdb/dbapi.py
@@ -92,7 +92,7 @@ ROWID = adbc_driver_manager.dbapi.ROWID
 # Functions
 
 
-def connect(path: typing.Optional[str] = None) -> "Connection":
+def connect(path: typing.Optional[str] = None, **kwargs) -> "Connection":
     """Connect to DuckDB via ADBC."""
     db = None
     conn = None
@@ -100,7 +100,7 @@ def connect(path: typing.Optional[str] = None) -> "Connection":
     try:
         db = adbc_driver_duckdb.connect(path)
         conn = adbc_driver_manager.AdbcConnection(db)
-        return adbc_driver_manager.dbapi.Connection(db, conn)
+        return adbc_driver_manager.dbapi.Connection(db, conn, **kwargs)
     except Exception:
         if conn:
             conn.close()


### PR DESCRIPTION
Fixed missing **kwargs. Without kwargs connect() isn't following the adbc connect() standard and can't support additional options like autocommit..

```
>>> c = connect(autocommit=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: connect() got an unexpected keyword argument 'autocommit'
```

ADBC standard:

![image](https://github.com/user-attachments/assets/7b2b6351-719a-4fe9-b9ac-7bd719f25dba)



```python
Python 3.9.20 (main, Oct  3 2024, 07:38:01) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>>
>>> import adbc_driver_duckdb
>>> import adbc_driver_manager
>>> import adbc_driver_manager.dbapi
>>>
>>>
>>> def connect(path: str = None):
...     """Connect to DuckDB via ADBC."""
...     db = None
...     conn = None
...     try:
...         db = adbc_driver_duckdb.connect(path)
...         conn = adbc_driver_manager.AdbcConnection(db)
...         return adbc_driver_manager.dbapi.Connection(db, conn)
...     except Exception:
...         if conn:
...             conn.close()
...         if db:
...             db.close()
...         raise
...
>>> c = connect(autocommit=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: connect() got an unexpected keyword argument 'autocommit'
>>>
>>> c = connect()
>>> c._autocommit
False
>>>
>>>
>>> def connect_fixed(path: str = None, **kwargs):
...     """Connect to DuckDB via ADBC."""
...     db = None
...     conn = None
...     try:
...         db = adbc_driver_duckdb.connect(path)
...         conn = adbc_driver_manager.AdbcConnection(db)
...         return adbc_driver_manager.dbapi.Connection(db, conn, **kwargs)
...     except Exception:
...         if conn:
...             conn.close()
...         if db:
...             db.close()
...         raise
...
>>> c_fixed = connect_fixed()
>>> c_fixed._autocommit
False
>>>
>>> c_fixed = connect_fixed(autocommit=False)
>>> c_fixed._autocommit
False
>>>
>>> c_fixed = connect_fixed(autocommit=True)
>>> c_fixed._autocommit
True
>>>
```
