### PR TITLE
Avoid UMA

### DIFF
--- a/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
@@ -207,6 +207,9 @@ struct WindowQuantileState {
 				dest[0] = skips[0].second;
 				if (skips.size() > 1) {
 					dest[1] = skips[1].second;
+				} else {
+					// Avoid UMA
+					dest[1] = skips[0].second;
 				}
 				return interp.template Extract<INPUT_TYPE, RESULT_TYPE>(dest.data(), result);
 			} catch (const duckdb_skiplistlib::skip_list::IndexError &idx_err) {


### PR DESCRIPTION
This is one out of three PRs to avoid accessing uninitialized memory. This change was necessary to satisfy CRAN's incoming checks.

CRAN uses gcc 14.2.0 with compile commands similar to the following:

```
g++  -std=gnu++17 -I"D:/RCompile/recent/R/include" -DNDEBUG -I... -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign    -c duckdb/ub_src_common_types_row.cpp -o duckdb/ub_src_common_types_row.o
```

I believe they are looking for `-Wuninitialized` and `-Wmaybe-uninitialized` .

Would you consider having similar checks as part of the CI/CD pipeline here, perhaps with `-Werror` ?