### PR TITLE
Avoid UMA

### DIFF
--- a/src/common/types/row/tuple_data_segment.cpp
+++ b/src/common/types/row/tuple_data_segment.cpp
@@ -15,23 +15,23 @@ void TupleDataChunkPart::SetHeapEmpty() {
 	base_heap_ptr = nullptr;
 }
 
-void SwapTupleDataChunkPart(TupleDataChunkPart &a, TupleDataChunkPart &b) {
-	std::swap(a.row_block_index, b.row_block_index);
-	std::swap(a.row_block_offset, b.row_block_offset);
-	std::swap(a.heap_block_index, b.heap_block_index);
-	std::swap(a.heap_block_offset, b.heap_block_offset);
-	std::swap(a.base_heap_ptr, b.base_heap_ptr);
-	std::swap(a.total_heap_size, b.total_heap_size);
-	std::swap(a.count, b.count);
+void MoveTupleDataChunkPart(TupleDataChunkPart &a, TupleDataChunkPart &b) {
+	a.row_block_index = b.row_block_index;
+	a.row_block_offset = b.row_block_offset;
+	a.heap_block_index = b.heap_block_index;
+	a.heap_block_offset = b.heap_block_offset;
+	a.base_heap_ptr = b.base_heap_ptr;
+	a.total_heap_size = b.total_heap_size;
+	a.count = b.count;
 	std::swap(a.lock, b.lock);
 }
 
 TupleDataChunkPart::TupleDataChunkPart(TupleDataChunkPart &&other) noexcept : lock((other.lock)) {
-	SwapTupleDataChunkPart(*this, other);
+	MoveTupleDataChunkPart(*this, other);
 }
 
 TupleDataChunkPart &TupleDataChunkPart::operator=(TupleDataChunkPart &&other) noexcept {
-	SwapTupleDataChunkPart(*this, other);
+	MoveTupleDataChunkPart(*this, other);
 	return *this;
 }
 


### PR DESCRIPTION
This is one out of three PRs to avoid accessing uninitialized memory. This change was necessary to satisfy CRAN's incoming checks.

CRAN uses gcc 14.2.0 with compile commands similar to the following:

```
g++  -std=gnu++17 -DNDEBUG -I... -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign    -c duckdb/ub_src_common_types_row.cpp -o duckdb/ub_src_common_types_row.o
```

I believe they are looking for `-Wuninitialized` and `-Wmaybe-uninitialized` .

Would you consider having similar checks as part of the CI/CD pipeline here, perhaps with `-Werror` ?