### PR TITLE
Avoid UMA

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -690,7 +690,7 @@ bool LineError::HandleErrors(StringValueResult &result) {
 			break;
 		case CAST_ERROR: {
 			string column_name;
-			LogicalTypeId type_id;
+			LogicalTypeId type_id = LogicalTypeId::INVALID;
 			if (cur_error.col_idx < result.names.size()) {
 				column_name = result.names[cur_error.col_idx];
 			}


### PR DESCRIPTION
This is one out of three PRs to avoid accessing uninitialized memory. This change was necessary to satisfy CRAN's incoming checks.

CRAN uses gcc 14.2.0 with compile commands similar to the following:

```
g++  -std=gnu++17 -DNDEBUG -I... -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign    -c duckdb/ub_src_common_types_row.cpp -o duckdb/ub_src_common_types_row.o
```

I believe they are looking for `-Wuninitialized` and `-Wmaybe-uninitialized` .

Would you consider having similar checks as part of the CI/CD pipeline here, perhaps with `-Werror` ?