### PR TITLE
[Fix] Perform eager constraint checking during physical batch insert

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -523,7 +523,8 @@ SinkResultType PhysicalBatchInsert::Sink(ExecutionContext &context, DataChunk &c
 	auto &storage = table.GetStorage();
 	auto &local_storage = LocalStorage::Get(context.client, storage.db);
 	auto local_table_storage = local_storage.GetStorage(table.GetStorage());
-	storage.VerifyAppendConstraints(*lstate.constraint_state, context.client, lstate.insert_chunk, local_table_storage, nullptr);
+	storage.VerifyAppendConstraints(*lstate.constraint_state, context.client, lstate.insert_chunk, local_table_storage,
+	                                nullptr);
 
 	auto new_row_group = lstate.current_collection->Append(lstate.insert_chunk, lstate.current_append_state);
 	if (new_row_group) {

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -519,8 +519,11 @@ SinkResultType PhysicalBatchInsert::Sink(ExecutionContext &context, DataChunk &c
 	if (!lstate.constraint_state) {
 		lstate.constraint_state = table.GetStorage().InitializeConstraintState(table, bound_constraints);
 	}
+
 	auto &storage = table.GetStorage();
-	storage.VerifyAppendConstraints(*lstate.constraint_state, context.client, lstate.insert_chunk, nullptr, nullptr);
+	auto &local_storage = LocalStorage::Get(context.client, storage.db);
+	auto local_table_storage = local_storage.GetStorage(table.GetStorage());
+	storage.VerifyAppendConstraints(*lstate.constraint_state, context.client, lstate.insert_chunk, local_table_storage, nullptr);
 
 	auto new_row_group = lstate.current_collection->Append(lstate.insert_chunk, lstate.current_append_state);
 	if (new_row_group) {

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -478,13 +478,12 @@ static idx_t HandleInsertConflicts(TableCatalogEntry &table, ExecutionContext &c
 
 	ConflictInfo conflict_info(conflict_target);
 	ConflictManager conflict_manager(VerifyExistenceType::APPEND, tuples.size(), &conflict_info);
+	auto storage = local_storage.GetStorage(data_table);
 	if (GLOBAL) {
 		auto &constraint_state = lstate.GetConstraintState(data_table, table);
-		auto storage = local_storage.GetStorage(data_table);
 		data_table.VerifyAppendConstraints(constraint_state, context.client, tuples, storage, &conflict_manager);
 	} else {
 		auto &indexes = local_storage.GetIndexes(data_table);
-		auto storage = local_storage.GetStorage(data_table);
 		DataTable::VerifyUniqueIndexes(indexes, storage, tuples, &conflict_manager);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/16604.
Fixes https://github.com/duckdb/duckdb/issues/16520.

I added the reproduction for #16604. #16520 is more complicated to include in the tests as it fetches a remote file. Both use `INSERT INTO tbl SELECT * FROM other_tbl`, which triggers the physical batch insert code.

I've also quickly confirmed #16604 locally, but maybe @sgrebnov, you want to check out this PR and try it yourself.
