### PR TITLE
Add libs folder to bundled static libs

### DIFF
--- a/.github/workflows/BundleStaticLibs.yml
+++ b/.github/workflows/BundleStaticLibs.yml
@@ -81,7 +81,8 @@ jobs:
 
       - name: Bundle static library
         shell: bash
-        run: make bundle-library-o
+        run: |
+          make gather-libs
 
       - name: Print platform
         shell: bash
@@ -94,14 +95,14 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           python3 scripts/amalgamation.py
-          zip -j static-lib-osx-${{ matrix.architecture }}.zip src/include/duckdb.h build/release/libduckdb_bundle.a
-          ./scripts/upload-assets-to-staging.sh github_release static-lib-osx-${{ matrix.architecture }}.zip
+          zip -r -j static-libs-osx-${{ matrix.architecture }}.zip src/include/duckdb.h build/release/libs/
+          ./scripts/upload-assets-to-staging.sh github_release static-libs-osx-${{ matrix.architecture }}.zip
 
       - uses: actions/upload-artifact@v4
         with:
-          name: duckdb-static-lib-osx-${{ matrix.architecture }}
+          name: duckdb-static-libs-osx-${{ matrix.architecture }}
           path: |
-            static-lib-osx-${{ matrix.architecture }}.zip
+            static-libs-osx-${{ matrix.architecture }}.zip
 
   bundle-mingw-static-lib:
     name: Windows MingW static libs
@@ -143,7 +144,7 @@ jobs:
       - name: Bundle static library
         shell: bash
         run: |
-          make bundle-library-obj
+          make gather-libs
 
       - name: Deploy
         shell: bash
@@ -151,14 +152,14 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
-          zip -j static-lib-windows-mingw.zip src/include/duckdb.h build/release/libduckdb_bundle.a
-          ./scripts/upload-assets-to-staging.sh github_release static-lib-windows-mingw.zip
+          zip -r -j static-libs-windows-mingw.zip src/include/duckdb.h build/release/libs/
+          ./scripts/upload-assets-to-staging.sh github_release static-libs-windows-mingw.zip
 
       - uses: actions/upload-artifact@v4
         with:
-          name: duckdb-static-lib-windows-mingw
+          name: duckdb-static-libs-windows-mingw
           path: |
-            static-lib-windows-mingw.zip
+            static-libs-windows-mingw.zip
   bundle-linux-arm64-static-libs:
     name: Linux arm64 static libs
     runs-on: ubuntu-latest
@@ -184,7 +185,7 @@ jobs:
           -e FORCE_WARN_UNUSED=1                                                 \
           -e DUCKDB_PLATFORM=linux_arm64                                         \
           ubuntu:18.04                                                           \
-          bash -c "/duckdb/scripts/setup_ubuntu1804.sh && git config --global --add safe.directory /duckdb && make bundle-library -C /duckdb"
+          bash -c "/duckdb/scripts/setup_ubuntu1804.sh && git config --global --add safe.directory /duckdb && make gather-libs -C /duckdb"
       - name: Deploy
         shell: bash
         env:
@@ -192,13 +193,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           python3 scripts/amalgamation.py
-          zip -j static-lib-linux-arm64.zip src/include/duckdb.h build/release/libduckdb_bundle.a
-          ./scripts/upload-assets-to-staging.sh github_release static-lib-linux-arm64.zip
+          zip -r -j static-libs-linux-arm64.zip src/include/duckdb.h build/release/libs/
+          ./scripts/upload-assets-to-staging.sh github_release static-libs-linux-arm64.zip
       - uses: actions/upload-artifact@v4
         with:
-          name: duckdb-static-lib-linux-arm64
+          name: duckdb-static-libs-linux-arm64
           path: |
-            static-lib-linux-arm64.zip
+            static-libs-linux-arm64.zip
   bundle-linux-amd64-static-libs:
     name: Linux amd64 static libs
     runs-on: ubuntu-latest
@@ -227,7 +228,7 @@ jobs:
           -e FORCE_WARN_UNUSED=1                                                 \
           -e DUCKDB_RUN_PARALLEL_CSV_TESTS=1                                     \
           quay.io/pypa/manylinux2014_x86_64                                      \
-          bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make bundle-library -C $PWD"
+          bash -c "yum install -y perl-IPC-Cmd && git config --global --add safe.directory $PWD && make gather-libs -C $PWD"
       - name: Print platform
         shell: bash
         run: ./build/release/duckdb -c "PRAGMA platform;"
@@ -239,10 +240,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           python3 scripts/amalgamation.py
-          zip -j static-lib-linux-amd64.zip src/include/duckdb.h build/release/libduckdb_bundle.a
-          ./scripts/upload-assets-to-staging.sh github_release static-lib-linux-amd64.zip
+          zip -r -j static-libs-linux-amd64.zip src/include/duckdb.h build/release/libs/
+          ./scripts/upload-assets-to-staging.sh github_release static-libs-linux-amd64.zip
       - uses: actions/upload-artifact@v4
         with:
-          name: duckdb-static-lib-linux-amd64
+          name: duckdb-static-libs-linux-amd64
           path: |
-            static-lib-linux-amd64.zip
+            static-libs-linux-amd64.zip

--- a/Makefile
+++ b/Makefile
@@ -519,3 +519,11 @@ bundle-library-obj: bundle-setup
 
 bundle-library: release
 	make bundle-library-o
+
+gather-libs: release
+	cd build/release && \
+	rm -rf libs && \
+	mkdir -p libs && \
+	cp src/libduckdb_static.a libs/. && \
+	cp third_party/*/libduckdb_*.a libs/. && \
+	cp extension/*/lib*_extension.a libs/.


### PR DESCRIPTION
For some OS + architecture combinations, the bundled static libraries exceed 100MB, which can be inconvenient.

This PR adds a gather-libs target that collects the individual libraries (pre-bundling) and puts them in a libs folder. When publishing the existing artifact, it also zips that additional libs folder.

Follow-up to https://github.com/duckdb/duckdb/pull/16654.