### PR TITLE
move OrderPreservationRecursive to physical_plan_generator.hpp

### DIFF
--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -10,7 +10,7 @@
 
 namespace duckdb {
 
-static OrderPreservationType OrderPreservationRecursive(PhysicalOperator &op) {
+OrderPreservationType PhysicalPlanGenerator::OrderPreservationRecursive(PhysicalOperator &op) {
 	if (op.IsSource()) {
 		return op.SourceOrder();
 	}

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -44,6 +44,9 @@ public:
 	static bool UseBatchIndex(ClientContext &context, PhysicalOperator &plan);
 	//! Whether or not we should preserve insertion order for executing the given sink
 	static bool PreserveInsertionOrder(ClientContext &context, PhysicalOperator &plan);
+	//! The order preservation type of the given operator decided by recursively looking at its children
+	static OrderPreservationType OrderPreservationRecursive(PhysicalOperator &op);
+
 
 protected:
 	unique_ptr<PhysicalOperator> CreatePlan(LogicalOperator &op);

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -47,7 +47,6 @@ public:
 	//! The order preservation type of the given operator decided by recursively looking at its children
 	static OrderPreservationType OrderPreservationRecursive(PhysicalOperator &op);
 
-
 protected:
 	unique_ptr<PhysicalOperator> CreatePlan(LogicalOperator &op);
 


### PR DESCRIPTION
Allows for the use of OrderPreservationRecursive elsewhere (eg. an extension operator that needs to decide its order preservation type)