### PR TITLE
[Python] Don't push down `OPTIONAL_FILTER` into `pyarrow` for the arrow scan.

### DIFF
--- a/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
@@ -339,7 +339,7 @@ py::object TransformFilterRecursive(TableFilter &filter, vector<string> column_r
 			py::object child_expression = TransformFilterRecursive(child_filter, column_ref, timezone_config, type);
 			if (expression.is(py::none())) {
 				expression = std::move(child_expression);
-			} else {
+			} else if (!child_expression.is(py::none())) {
 				expression = expression.attr("__or__")(child_expression);
 			}
 		}
@@ -353,7 +353,7 @@ py::object TransformFilterRecursive(TableFilter &filter, vector<string> column_r
 			py::object child_expression = TransformFilterRecursive(child_filter, column_ref, timezone_config, type);
 			if (expression.is(py::none())) {
 				expression = std::move(child_expression);
-			} else {
+			} else if (!child_expression.is(py::none())) {
 				expression = expression.attr("__and__")(child_expression);
 			}
 		}

--- a/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
@@ -335,9 +335,12 @@ py::object TransformFilterRecursive(TableFilter &filter, vector<string> column_r
 		for (idx_t i = 0; i < or_filter.child_filters.size(); i++) {
 			auto &child_filter = *or_filter.child_filters[i];
 			py::object child_expression = TransformFilterRecursive(child_filter, column_ref, timezone_config, type);
+			if (child_expression.is(py::none())) {
+				continue;
+			}
 			if (expression.is(py::none())) {
 				expression = std::move(child_expression);
-			} else if (!child_expression.is(py::none())) {
+			} else {
 				expression = expression.attr("__or__")(child_expression);
 			}
 		}
@@ -349,9 +352,12 @@ py::object TransformFilterRecursive(TableFilter &filter, vector<string> column_r
 		for (idx_t i = 0; i < and_filter.child_filters.size(); i++) {
 			auto &child_filter = *and_filter.child_filters[i];
 			py::object child_expression = TransformFilterRecursive(child_filter, column_ref, timezone_config, type);
+			if (child_expression.is(py::none())) {
+				continue;
+			}
 			if (expression.is(py::none())) {
 				expression = std::move(child_expression);
-			} else if (!child_expression.is(py::none())) {
+			} else {
 				expression = expression.attr("__and__")(child_expression);
 			}
 		}

--- a/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
@@ -32,6 +32,8 @@ void gil_assert();
 bool is_list_like(handle obj);
 bool is_dict_like(handle obj);
 
+std::string to_string(const object &obj);
+
 } // namespace pybind11
 
 namespace duckdb {

--- a/tools/pythonpkg/src/pybind11/pybind_wrapper.cpp
+++ b/tools/pythonpkg/src/pybind11/pybind_wrapper.cpp
@@ -36,4 +36,9 @@ bool is_dict_like(handle obj) {
 	return isinstance(obj, mapping);
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
+std::string to_string(const object &obj) {
+	return std::string(py::str(obj));
+}
+
 } // namespace pybind11

--- a/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
+++ b/tools/pythonpkg/tests/fast/arrow/test_filter_pushdown.py
@@ -947,3 +947,42 @@ class TestArrowFilterPushdown(object):
         duck_probe_arrow = duck_probe.arrow()
         duckdb_conn.register("duck_probe_arrow", duck_probe_arrow)
         assert duckdb_conn.execute("SELECT * from duck_probe_arrow where a in (1, 999)").fetchall() == [(1,), (999,)]
+
+    def test_pushdown_of_optional_filter(self, duckdb_cursor):
+        cardinality_table = pa.Table.from_pydict(
+            {
+                'column_name': [
+                    'id',
+                    'product_code',
+                    'price',
+                    'quantity',
+                    'category',
+                    'is_available',
+                    'rating',
+                    'discount',
+                    'color',
+                ],
+                'cardinality': [100, 100, 100, 45, 5, 3, 6, 39, 5],
+            }
+        )
+
+        result = duckdb.query(
+            """
+            SELECT *
+            FROM cardinality_table
+            WHERE cardinality > 1
+            ORDER BY cardinality ASC
+        """
+        )
+        res = result.fetchall()
+        assert res == [
+            ('is_available', 3),
+            ('category', 5),
+            ('color', 5),
+            ('rating', 6),
+            ('discount', 39),
+            ('quantity', 45),
+            ('id', 100),
+            ('product_code', 100),
+            ('price', 100),
+        ]


### PR DESCRIPTION
This PR fixes #16551

Optional filters are not necessary for correctness, so we don't push them down for now.
This was already done further up, but not for `AND` and `OR` filters.