### PR TITLE
Add the missing binding for json_serialize_sql

### DIFF
--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -161,6 +161,10 @@ ScalarFunctionSet JSONFunctions::GetSerializeSqlFunction() {
 	    {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN}, LogicalType::JSON(),
 	    JsonSerializeFunction, JsonSerializeBind, nullptr, nullptr, JSONFunctionLocalState::Init));
 
+	set.AddFunction(ScalarFunction(
+	    {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
+	    LogicalType::JSON(), JsonSerializeFunction, JsonSerializeBind, nullptr, nullptr, JSONFunctionLocalState::Init));
+
 	return set;
 }
 

--- a/test/sql/json/test_json_serialize_sql.test
+++ b/test/sql/json/test_json_serialize_sql.test
@@ -15,6 +15,10 @@ SELECT json_serialize_sql('SELECT *, 1 + 2 FROM tbl1', skip_null := true, skip_e
 statement ok
 SELECT json_serialize_sql('SELECT * FROM (SELECT 1 + 2)', skip_null := true, skip_empty := true);
 
+# Example with all parameters
+statement ok
+SELECT json_serialize_sql('SELECT * FROM (SELECT 1 + 2)', skip_default := true, skip_empty := true, skip_null := true, format := true);
+
 # Example with syntax error
 query I
 SELECT json_serialize_sql('SELECT AND LAUNCH ROCKETS WHERE 1 = 1');


### PR DESCRIPTION
Fix https://github.com/duckdb/duckdb/issues/16590. The `json_serialize_sql` can take 4 boolean parameters (https://github.com/duckdb/duckdb/issues/15503#issuecomment-2572768612).

Also add a test case.