### PR TITLE
Do not create validity mask for non-null const vector

### DIFF
--- a/src/common/types/vector.cpp
+++ b/src/common/types/vector.cpp
@@ -434,7 +434,6 @@ void Vector::SetValue(idx_t index, const Value &val) {
 	}
 	D_ASSERT(val.IsNull() || (val.type().InternalType() == GetType().InternalType()));
 
-	validity.EnsureWritable();
 	validity.Set(index, !val.IsNull());
 	auto physical_type = GetType().InternalType();
 	if (val.IsNull() && !IsStructOrArrayRecursive(GetType())) {


### PR DESCRIPTION
Most vectorized operations have a fast path when `ValidityMask::AllValid()` is true. However, when a vector references a const value, `Vector::SetValue` will always create a validity mask, which makes `ValidityMask::AllValid()` false. Here `validity.EnsureWritable` is redundant because `validity.Set` will create mask if necessary.

After this fix, more operations on constant vectors can run in the fast path. I've run the TPC-H regression test on my computer with threads=2:
```
Old timing geometric mean: 0.027221664794700867
New timing geometric mean: 0.026882768859912223, roughly 1% faster
```