### PR TITLE
cmake: fix external icu

### DIFF
--- a/DuckDBConfig.cmake.in
+++ b/DuckDBConfig.cmake.in
@@ -7,7 +7,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 if(NOT @WITH_INTERNAL_ICU@)
-    find_dependency(ICU COMPONENTS i18n uc)
+    find_dependency(ICU COMPONENTS i18n uc data)
 endif()
 
 # Compute paths

--- a/extension/icu/CMakeLists.txt
+++ b/extension/icu/CMakeLists.txt
@@ -32,13 +32,16 @@ link_threads(icu_extension)
 if(NOT WITH_INTERNAL_ICU)
   find_package(
     ICU
-    COMPONENTS i18n uc
+    COMPONENTS i18n uc data
     REQUIRED)
-  target_link_libraries(icu_extension ICU::i18n ICU::uc)
+  target_link_libraries(icu_extension ICU::i18n ICU::uc ICU::data)
 endif()
 disable_target_warnings(icu_extension)
 set(PARAMETERS "-no-warnings")
 build_loadable_extension(icu ${PARAMETERS} ${ICU_EXTENSION_FILES})
+if(NOT WITH_INTERNAL_ICU)
+  target_link_libraries(icu_loadable_extension ICU::i18n ICU::uc ICU::data)
+endif()
 install(
   TARGETS icu_extension
   EXPORT "${DUCKDB_EXPORT_SET}"


### PR DESCRIPTION
Currently the external icu is broken: https://github.com/microsoft/vcpkg/issues/44408 

I have tested the fix in https://github.com/microsoft/vcpkg/pull/44410 