### PR TITLE
[Dev] Don't try to include `third_party/mbedtls/VERSION` with `package_build.py`

### DIFF
--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -26,7 +26,6 @@ def third_party_includes():
     includes += [os.path.join('third_party', 'brotli', 'common')]
     includes += [os.path.join('third_party', 'brotli', 'dec')]
     includes += [os.path.join('third_party', 'brotli', 'enc')]
-    includes += [os.path.join('third_party', 'mbedtls')]
     includes += [os.path.join('third_party', 'mbedtls', 'include')]
     includes += [os.path.join('third_party', 'mbedtls', 'library')]
     includes += [os.path.join('third_party', 'miniz')]


### PR DESCRIPTION
Ran into this when locally building python with `BUILD_PYTHON=1 make debug`