### PR TITLE
JSON Reader: make read_position atomic so this can be read by the progress bar while processing the JSON file

### DIFF
--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -71,7 +71,7 @@ public:
 
 private:
 	idx_t ReadInternal(char *pointer, const idx_t requested_size);
-	idx_t ReadFromCache(char *&pointer, idx_t &size, idx_t &position);
+	idx_t ReadFromCache(char *&pointer, idx_t &size, atomic<idx_t> &position);
 
 private:
 	//! The JSON file handle
@@ -83,7 +83,7 @@ private:
 	const idx_t file_size;
 
 	//! Read properties
-	idx_t read_position;
+	atomic<idx_t> read_position;
 	atomic<idx_t> requested_reads;
 	atomic<idx_t> actual_reads;
 	atomic<bool> last_read_requested;

--- a/extension/json/json_reader.cpp
+++ b/extension/json/json_reader.cpp
@@ -148,7 +148,7 @@ idx_t JSONFileHandle::ReadInternal(char *pointer, const idx_t requested_size) {
 	return total_read_size;
 }
 
-idx_t JSONFileHandle::ReadFromCache(char *&pointer, idx_t &size, idx_t &position) {
+idx_t JSONFileHandle::ReadFromCache(char *&pointer, idx_t &size, atomic<idx_t> &position) {
 	idx_t read_size = 0;
 	idx_t total_offset = 0;
 


### PR DESCRIPTION
Fixes a TSAN issue after the JSON reader rework