### PR TITLE
Fix #16554: emit blobs as part of .dump

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -1739,11 +1739,7 @@ void ShellState::ExecutePreparedStatement(sqlite3_stmt *pStmt) {
 		/* extract the data and data types */
 		for (int i = 0; i < nCol; i++) {
 			result.types[i] = sqlite3_column_type(pStmt, i);
-			if (result.types[i] == SQLITE_BLOB && cMode == RenderMode::INSERT) {
-				result.data[i] = "";
-			} else {
-				result.data[i] = (const char *)sqlite3_column_text(pStmt, i);
-			}
+			result.data[i] = (const char *)sqlite3_column_text(pStmt, i);
 			if (!result.data[i] && result.types[i] != SQLITE_NULL) {
 				// OOM
 				rc = SQLITE_NOMEM;

--- a/tools/shell/tests/test_shell_basics.py
+++ b/tools/shell/tests/test_shell_basics.py
@@ -834,6 +834,17 @@ def test_dump_mixed(shell):
     result = test.run()
     result.check_stdout('CREATE TABLE a(d DATE, k FLOAT, t TIMESTAMP);')
 
+def test_dump_blobs(shell):
+    test = (
+        ShellTest(shell)
+        .statement("create table test(t VARCHAR, b BLOB);")
+        .statement(".changes off")
+        .statement("insert into test values('literal blob', '\\x07\\x08\\x09');")
+        .statement(".dump")
+    )
+    result = test.run()
+    result.check_stdout("'\\x07\\x08\\x09'")
+
 def test_invalid_csv(shell, tmp_path):
     file = tmp_path / 'nonsencsv.csv'
     with open(file, 'wb+') as f:
@@ -868,18 +879,6 @@ def test_mode_trash(shell):
     )
     result = test.run()
     result.check_stdout('')
-
-@pytest.mark.skip(reason="Broken test, ported directly, was commented out")
-def test_dump_blobs(shell):
-    test = (
-        ShellTest(shell)
-        .statement("CREATE TABLE a (b BLOB);")
-        .statement(".changes off")
-        .statement("INSERT INTO a VALUES (DATE '1992-01-01', 0.3, NOW());")
-        .statement(".dump")
-    )
-    result = test.run()
-    result.check_stdout('COMMIT')
 
 def test_sqlite_comments(shell):
     # Using /* <comment> */


### PR DESCRIPTION
Fixes #16554

I looked through the history and could not figure out why this was explicitly disabled