### PR TITLE
[Julia] support binding for vectors

### DIFF
--- a/tools/juliapkg/src/statement.jl
+++ b/tools/juliapkg/src/statement.jl
@@ -67,9 +67,7 @@ duckdb_bind_internal(stmt::Stmt, i::Integer, val::Vector{UInt8}) = duckdb_bind_b
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::WeakRefString{UInt8}) =
     duckdb_bind_varchar_length(stmt.handle, i, val.ptr, val.len);
 function duckdb_bind_internal(stmt::Stmt, i::Integer, val::AbstractVector{T}) where {T}
-    type = create_logical_type(T)
-    values = create_value.(val)
-    value = Value(duckdb_create_list_value(type.handle, map(x -> x.handle, values), length(values)))
+    value = create_value(val)
     return duckdb_bind_value(stmt.handle, i, value.handle)
 end
 

--- a/tools/juliapkg/src/statement.jl
+++ b/tools/juliapkg/src/statement.jl
@@ -66,6 +66,12 @@ duckdb_bind_internal(stmt::Stmt, i::Integer, val::AbstractString) =
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::Vector{UInt8}) = duckdb_bind_blob(stmt.handle, i, val, sizeof(val));
 duckdb_bind_internal(stmt::Stmt, i::Integer, val::WeakRefString{UInt8}) =
     duckdb_bind_varchar_length(stmt.handle, i, val.ptr, val.len);
+function duckdb_bind_internal(stmt::Stmt, i::Integer, val::AbstractVector{T}) where {T}
+    type = create_logical_type(T)
+    values = create_value.(val)
+    value = Value(duckdb_create_list_value(type.handle, map(x -> x.handle, values), length(values)))
+    return duckdb_bind_value(stmt.handle, i, value.handle)
+end
 
 function duckdb_bind_internal(stmt::Stmt, i::Integer, val::Any)
     println(val)

--- a/tools/juliapkg/test/Project.toml
+++ b/tools/juliapkg/test/Project.toml
@@ -2,6 +2,7 @@
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DuckDB = "d2f5444f-75bc-4fdf-ac35-56f514c445e1"
 FixedPointDecimals = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/tools/juliapkg/test/Project.toml
+++ b/tools/juliapkg/test/Project.toml
@@ -2,7 +2,6 @@
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-DuckDB = "d2f5444f-75bc-4fdf-ac35-56f514c445e1"
 FixedPointDecimals = "fb4d412d-6eee-574d-9565-ede6634db7b0"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/tools/juliapkg/test/test_prepare.jl
+++ b/tools/juliapkg/test/test_prepare.jl
@@ -27,7 +27,7 @@
 
     # can bind vectors to parameters
     stmt = DBInterface.prepare(con, "FROM test_table WHERE i IN ?;")
-    results = DBInterface.execute(stmt, ([1,2], ))
+    results = DBInterface.execute(stmt, ([1, 2],))
     df = DataFrame(results)
 
     @test all(df.i .∈ Ref([1, 2]))

--- a/tools/juliapkg/test/test_prepare.jl
+++ b/tools/juliapkg/test/test_prepare.jl
@@ -26,8 +26,8 @@
     @test isequal(df.j, [3.5, missing, 0.5, 1, 2, 4, 8, -0.5])
 
     # can bind vectors to parameters
-    stmt = DBInterface.prepare(con, "FROM test_table WHERE i IN (?, ?);")
-    results = DBInterface.execute(stmt, (1, 2))
+    stmt = DBInterface.prepare(con, "FROM test_table WHERE i IN ?;")
+    results = DBInterface.execute(stmt, ([1,2], ))
     df = DataFrame(results)
 
     @test all(df.i .∈ Ref([1, 2]))

--- a/tools/juliapkg/test/test_prepare.jl
+++ b/tools/juliapkg/test/test_prepare.jl
@@ -25,6 +25,13 @@
     @test isequal(df.i, [1, missing, 2, 1, 2, 3, 4, 5])
     @test isequal(df.j, [3.5, missing, 0.5, 1, 2, 4, 8, -0.5])
 
+    # can bind vectors to parameters
+    stmt = DBInterface.prepare(con, "FROM test_table WHERE i IN (?, ?);")
+    results = DBInterface.execute(stmt, (1, 2))
+    df = DataFrame(results)
+
+    @test all(df.i .∈ Ref([1, 2]))
+
     # verify that double-closing does not cause any problems
     DBInterface.close!(stmt)
     DBInterface.close!(stmt)


### PR DESCRIPTION
Hi DuckDB team!

I am submitting a very small PR to improve value binding to parameters in prepared statements. This is especially important when using the SQL `IN` operator, for example. I have tried to follow the contribution guide, and included a small test.

Previously we could not bind vectors to parameters, the code in the tests would fail (relevant snippet below). This PR fixes this behavior.

```julia
stmt = DBInterface.prepare(con, "FROM test_table WHERE i IN ?;")
results = DBInterface.execute(stmt, ([1,2], ))
df = DataFrame(results)
```

With the following error:

```julia
ERROR: unsupported type for bind
Stacktrace:
 [1] duckdb_bind_internal(stmt::DuckDB.Stmt, i::Int64, val::Vector{Int64})
   @ DuckDB ~/.julia/packages/DuckDB/vI6tj/src/statement.jl:72
 [2] bind_parameters(stmt::DuckDB.Stmt, params::Tuple{Vector{Int64}})
   @ DuckDB ~/.julia/packages/DuckDB/vI6tj/src/statement.jl:78
 [3] execute(stmt::DuckDB.Stmt, params::Tuple{Vector{Int64}})
   @ DuckDB ~/.julia/packages/DuckDB/vI6tj/src/result.jl:709
 [4] execute(stmt::DuckDB.Stmt, params::Tuple{Vector{Int64}})
   @ DuckDB ~/.julia/packages/DuckDB/vI6tj/src/result.jl:872
 [5] top-level scope
   @ ~/some-path-removed-for-security
```

Thanks to the new support for List types provided in https://github.com/duckdb/duckdb/pull/16512 the same code now returns:

```julia
julia> df = DataFrame(results)
4×2 DataFrame
 Row │ i      j       
     │ Int32  Float64 
─────┼────────────────
   1 │     1      3.5
   2 │     2      0.5
   3 │     1      1.0
   4 │     2      2.0
```