### PR TITLE
Issue #16649: SelectNth Remainders

### DIFF
--- a/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
+++ b/extension/core_functions/include/core_functions/aggregate/quantile_sort_tree.hpp
@@ -8,17 +8,13 @@
 
 #pragma once
 
-#include "duckdb/common/sort/sort.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
-#include "duckdb/common/types/row/row_layout.hpp"
 #include "core_functions/aggregate/quantile_helpers.hpp"
-#include "duckdb/execution/merge_sort_tree.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/function/window/window_index_tree.hpp"
 #include <algorithm>
-#include <numeric>
 #include <stdlib.h>
 #include <utility>
 
@@ -89,7 +85,7 @@ struct QuantileDirect {
 	using RESULT_TYPE = T;
 
 	inline const INPUT_TYPE &operator()(const INPUT_TYPE &x) const {
-		return x;
+		return x; // NOLINT
 	}
 };
 
@@ -365,7 +361,7 @@ struct QuantileSortTree {
 	}
 
 	inline idx_t SelectNth(const SubFrames &frames, size_t n) const {
-		return index_tree->SelectNth(frames, n);
+		return index_tree->SelectNth(frames, n).first;
 	}
 
 	template <typename INPUT_TYPE, typename RESULT_TYPE, bool DISCRETE>

--- a/src/function/window/window_index_tree.cpp
+++ b/src/function/window/window_index_tree.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/function/window/window_index_tree.hpp"
 
-#include <thread>
 #include <utility>
 
 namespace duckdb {
@@ -52,11 +51,21 @@ void WindowIndexTreeLocalState::BuildLeaves() {
 	}
 }
 
-idx_t WindowIndexTree::SelectNth(const SubFrames &frames, idx_t n) const {
+pair<idx_t, idx_t> WindowIndexTree::SelectNth(const SubFrames &frames, idx_t n) const {
 	if (mst32) {
-		return mst32->NthElement(mst32->SelectNth(frames, n));
+		const auto nth = mst32->SelectNth(frames, n);
+		if (nth.second) {
+			return nth;
+		} else {
+			return {mst32->NthElement(nth.first), 0};
+		}
 	} else {
-		return mst64->NthElement(mst64->SelectNth(frames, n));
+		const auto nth = mst64->SelectNth(frames, n);
+		if (nth.second) {
+			return nth;
+		} else {
+			return {mst64->NthElement(nth.first), 0};
+		}
 	}
 }
 

--- a/src/function/window/window_value_function.cpp
+++ b/src/function/window/window_value_function.cpp
@@ -311,7 +311,12 @@ void WindowLeadLagExecutor::EvaluateInternal(WindowExecutorGlobalState &gstate, 
 				const auto n = NumericCast<idx_t>(val_idx);
 				const auto nth_index = glstate.value_tree->SelectNth(frames, n);
 				// (4) evaluate the expression provided to LEAD/LAG on this row.
-				cursor.CopyCell(0, nth_index, result, i);
+				if (nth_index.second) {
+					//	Overflow
+					FlatVector::SetNull(result, i, true);
+				} else {
+					cursor.CopyCell(0, nth_index.first, result, i);
+				}
 			} else if (wexpr.default_expr) {
 				leadlag_default.CopyCell(result, i);
 			} else {
@@ -425,7 +430,8 @@ void WindowFirstValueExecutor::EvaluateInternal(WindowExecutorGlobalState &gstat
 
 			if (frame_width) {
 				const auto first_idx = gvstate.value_tree->SelectNth(frames, 0);
-				cursor.CopyCell(0, first_idx, result, i);
+				D_ASSERT(first_idx.second == 0);
+				cursor.CopyCell(0, first_idx.first, result, i);
 			} else {
 				FlatVector::SetNull(result, i, true);
 			}
@@ -474,8 +480,19 @@ void WindowLastValueExecutor::EvaluateInternal(WindowExecutorGlobalState &gstate
 			}
 
 			if (frame_width) {
-				const auto last_idx = gvstate.value_tree->SelectNth(frames, frame_width - 1);
-				cursor.CopyCell(0, last_idx, result, i);
+				auto n = frame_width - 1;
+				auto last_idx = gvstate.value_tree->SelectNth(frames, n);
+				if (last_idx.second && last_idx.second <= n) {
+					//	Frame larger than data. Since we want last, we back off by the overflow
+					n -= last_idx.second;
+					last_idx = gvstate.value_tree->SelectNth(frames, n);
+				}
+				if (last_idx.second) {
+					//	No last value - give up.
+					FlatVector::SetNull(result, i, true);
+				} else {
+					cursor.CopyCell(0, last_idx.first, result, i);
+				}
 			} else {
 				FlatVector::SetNull(result, i, true);
 			}
@@ -541,7 +558,12 @@ void WindowNthValueExecutor::EvaluateInternal(WindowExecutorGlobalState &gstate,
 
 			if (n < frame_width) {
 				const auto nth_index = gvstate.value_tree->SelectNth(frames, n - 1);
-				cursor.CopyCell(0, nth_index, result, i);
+				if (nth_index.second) {
+					// Past end of frame
+					FlatVector::SetNull(result, i, true);
+				} else {
+					cursor.CopyCell(0, nth_index.first, result, i);
+				}
 			} else {
 				FlatVector::SetNull(result, i, true);
 			}

--- a/src/include/duckdb/execution/merge_sort_tree.hpp
+++ b/src/include/duckdb/execution/merge_sort_tree.hpp
@@ -118,7 +118,8 @@ struct MergeSortTree {
 
 	void Build();
 
-	idx_t SelectNth(const SubFrames &frames, idx_t n) const;
+	//	{nth index, remainder}
+	pair<idx_t, idx_t> SelectNth(const SubFrames &frames, idx_t n) const;
 
 	inline ElementType NthElement(idx_t i) const {
 		return tree.front().first[i];
@@ -436,10 +437,10 @@ void MergeSortTree<E, O, CMP, F, C>::BuildRun(idx_t level_idx, idx_t run_idx) {
 }
 
 template <typename E, typename O, typename CMP, uint64_t F, uint64_t C>
-idx_t MergeSortTree<E, O, CMP, F, C>::SelectNth(const SubFrames &frames, idx_t n) const {
+pair<idx_t, idx_t> MergeSortTree<E, O, CMP, F, C>::SelectNth(const SubFrames &frames, idx_t n) const {
 	// Handle special case of a one-element tree
 	if (tree.size() < 2) {
-		return 0;
+		return {0, 0};
 	}
 
 	// 	The first level contains a single run,
@@ -566,7 +567,7 @@ idx_t MergeSortTree<E, O, CMP, F, C>::SelectNth(const SubFrames &frames, idx_t n
 		}
 	}
 
-	return result;
+	return {result, n};
 }
 
 template <typename E, typename O, typename CMP, uint64_t F, uint64_t C>

--- a/src/include/duckdb/function/window/window_index_tree.hpp
+++ b/src/include/duckdb/function/window/window_index_tree.hpp
@@ -36,7 +36,8 @@ public:
 	unique_ptr<WindowAggregatorState> GetLocalState() override;
 
 	//! Find the Nth index in the set of subframes
-	idx_t SelectNth(const SubFrames &frames, idx_t n) const;
+	//! Returns {nth index, 0} or {nth offset, overflow}
+	pair<idx_t, idx_t> SelectNth(const SubFrames &frames, idx_t n) const;
 };
 
 } // namespace duckdb

--- a/test/sql/window/test_value_orderby.test
+++ b/test/sql/window/test_value_orderby.test
@@ -29,3 +29,19 @@ ORDER BY 2
 9	8	9	1	7
 6	9	9	1	6
 3	10	9	1	6
+
+# Frame larger than data
+query I
+with IDS as (
+    select * as idx from generate_series(1,4)
+),DATA as (
+    select *, (case when idx != 3 then idx * 1.0 else NULL end) as value from IDS
+)
+SELECT 
+ last(value ORDER BY idx IGNORE NULLS) OVER (ORDER BY idx ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
+FROM DATA
+----
+1.0
+2.0
+2.0
+4.0


### PR DESCRIPTION
* Extend MergeSortTree::SelectNth to return remainders
* Use the remainders to handle out of bounds results appropriately.

fixes: duckdb/duckdb#16649
fixes: duckdblabs/duckdb-internal#4430