### PR TITLE
add workaround for patching httpfs ext

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -16,6 +16,11 @@
 #  VCPKG_TARGET_TRIPLET=arm64-osx
 
 ################# HTTPFS
+# Warning: the patching mechanism on windows doesn't work for httpfs somehow.
+# To patch httpfs:
+#  - add patch file, enable APPLY_PATCHES
+#  - disable windows build of httpfs by wrapping in `if (NOT WIN32)`
+#  - IMPORTANT: add a comment that tells people to restore the windows build when removing the patches
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs


### PR DESCRIPTION
Somehow the `FETCHCONTENT_POPULATE` step fails in CI with no good way to debug this. I did not manage to repro this locally, and the error messages produced are completely useless:
<details>
  <summary>See error</summary>

```
  Successfully applied patch to D:/a/duckdb/duckdb/.github/patches/extensions/httpfs/:
  RAN git diff on D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-src
  No configure step for 'httpfs_extension_fc-populate'
  No build step for 'httpfs_extension_fc-populate'
  No install step for 'httpfs_extension_fc-populate'
  No test step for 'httpfs_extension_fc-populate'
  Completed 'httpfs_extension_fc-populate'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(241,5): error MSB8066: Custom build for 'D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeFiles\f3b9797c66ae368a3d3b142f0b600a26\httpfs_extension_fc-populate-download.rule;D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeFiles\f3b9797c66ae368a3d3b142f0b600a26\httpfs_extension_fc-populate-update.rule;D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeFiles\f3b9797c66ae368a3d3b142f0b600a26\httpfs_extension_fc-populate-patch.rule;D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeFiles\f3b9797c66ae368a3d3b142f0b600a26\httpfs_extension_fc-populate-configure.rule;D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeFiles\f3b9797c66ae368a3d3b142f0b600a26\httpfs_extension_fc-populate-build.rule;D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeFiles\f3b9797c66ae368a3d3b142f0b600a26\httpfs_extension_fc-populate-install.rule;D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeFiles\f3b9797c66ae368a3d3b142f0b600a26\httpfs_extension_fc-populate-test.rule;D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeFiles\22bea71fcf663c1a2120766248011d84\httpfs_extension_fc-populate-complete.rule;D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeFiles\c0e352f43e30213971dd8faa4d28848d\httpfs_extension_fc-populate.rule;D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\CMakeLists.txt' exited with code -1. [D:\a\duckdb\duckdb\build\extension_configuration\_deps\httpfs_extension_fc-subbuild\httpfs_extension_fc-populate.vcxproj]

CMake Error at C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:1918 (message):
Error:   Build step for httpfs_extension_fc failed: 1
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:1609 (__FetchContent_populateSubbuild)
  C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:2145:EVAL:2 (__FetchContent_doPopulation)
  C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:2145 (cmake_language)
  C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:1978:EVAL:1 (__FetchContent_Populate)
  C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:1978 (cmake_language)
  CMakeLists.txt:1099 (FETCHCONTENT_POPULATE)
  CMakeLists.txt:1208 (register_external_extension)
  .github/config/out_of_tree_extensions.cmake:19 (duckdb_extension_load)
  CMakeLists.txt:1298 (include)
  ```

</details>
  

This basically means that patching httpfs should be done rarely and patches should be applied upsteam asap since they will prevent nightly builds from using httpfs on windows