### PR TITLE
[Dev] Fix `EXPORT DATABASE` missing semicolons in produced `schema.sql`

### DIFF
--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -41,7 +41,7 @@ static void WriteCatalogEntries(stringstream &ss, catalog_entry_vector_t &entrie
 		} catch (const NotImplementedException &) {
 			ss << entry.get().ToSQL();
 		}
-		ss << '\n';
+		ss << ";\n";
 	}
 	ss << '\n';
 }

--- a/src/parser/parsed_data/create_type_info.cpp
+++ b/src/parser/parsed_data/create_type_info.cpp
@@ -61,6 +61,7 @@ string CreateTypeInfo::ToString() const {
 		result += " AS ";
 		result += type.ToString();
 	}
+	result += ";";
 	return result;
 }
 


### PR DESCRIPTION
This PR fixes #16719 

Also added semicolons extra to every line in the `schema.sql`, better have too many than not enough.