### PR TITLE
Add Notify External Repositories Workflow

### DIFF
--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -1,0 +1,33 @@
+name: Notify External Repositories
+on:
+  workflow_dispatch:
+    inputs:
+      duckdb-sha:
+        description: 'Vendor Specific DuckDB SHA'
+        required: false
+        default: ''
+        type: 'string'
+      target-branch:
+        description: 'Which Branch to Target'
+        required: true
+        default: ''
+        type: 'string'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  notify-odbc-run:
+    name: Run ODBC Vendor
+    runs-on: ubuntu-latest
+    env:
+      PAT_USER: ${{ secrets.PAT_USER }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+    steps:
+      - name: Run ODBC Vendor
+        if: ${{ github.repo == 'duckdb/duckdb' }}
+        run: |
+          export URL=https://api.github.com/repos/duckdb/duckdb-odbc/actions/workflows/Vendor/dispatches
+          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
+          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -22,7 +22,7 @@ jobs:
     name: Run ODBC Vendor
     runs-on: ubuntu-latest
     env:
-      PAT_USER: ${{ secrets.PAT_USER }}
+      PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
       - name: Run ODBC Vendor


### PR DESCRIPTION
Currently, the ODBC driver vendors DuckDB on a nightly schedule. However, this process does not verify whether a commit successfully builds an extension. As a result, some ODBC versions become incompatible with extensions due to vendoring an incomplete or incompatible commit.  

This PR introduces a new workflow that allows the vendor workflow to be triggered directly from `duckdb/duckdb`. Eventually this could be integrated into InvokeCI, after the extension build, and then executed on both the main and current release branch on ODBC.

Additionally, this workflow could be generalized to support other clients by allowing input parameters for a target repository and workflow or extended with specific runs for specific drivers.  

##### Current Issues & Open Questions:
- The authentication tokens in the workflow are not functioning correctly. Any insights on the correct tokens to use?  
- Should we make this workflow more generic now or iterate on it after validating its effectiveness for ODBC?  

Would appreciate feedback on the approach and any suggestions on token handling.

CC: @carlopi 
