### PR TITLE
RLE compression - memset alignment bytes to zero when aligning the counts

### DIFF
--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -195,12 +195,16 @@ struct RLECompressState : public CompressionState {
 		// we compact the segment by moving the counts so they are directly next to the values
 		idx_t counts_size = sizeof(rle_count_t) * entry_count;
 		idx_t original_rle_offset = RLEConstants::RLE_HEADER_SIZE + max_rle_count * sizeof(T);
-		idx_t minimal_rle_offset = AlignValue(RLEConstants::RLE_HEADER_SIZE + sizeof(T) * entry_count);
-		idx_t total_segment_size = minimal_rle_offset + counts_size;
+		idx_t minimal_rle_offset = RLEConstants::RLE_HEADER_SIZE + sizeof(T) * entry_count;
+		idx_t aligned_rle_offset = AlignValue(minimal_rle_offset);
+		idx_t total_segment_size = aligned_rle_offset + counts_size;
 		auto data_ptr = handle.Ptr();
-		memmove(data_ptr + minimal_rle_offset, data_ptr + original_rle_offset, counts_size);
+		if (aligned_rle_offset > minimal_rle_offset) {
+			memset(data_ptr + minimal_rle_offset, 0, aligned_rle_offset - minimal_rle_offset);
+		}
+		memmove(data_ptr + aligned_rle_offset, data_ptr + original_rle_offset, counts_size);
 		// store the final RLE offset within the segment
-		Store<uint64_t>(minimal_rle_offset, data_ptr);
+		Store<uint64_t>(aligned_rle_offset, data_ptr);
 		handle.Destroy();
 
 		auto &state = checkpoint_data.GetCheckpointState();

--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -578,7 +578,11 @@ CompressionFunction GetRLEFunction(PhysicalType data_type) {
 
 CompressionFunction RLEFun::GetFunction(PhysicalType type) {
 	switch (type) {
-	case PhysicalType::BOOL:
+	case PhysicalType::BOOL: {
+		auto function = GetRLEFunction<int8_t>(type);
+		function.filter = nullptr;
+		return function;
+	}
 	case PhysicalType::INT8:
 		return GetRLEFunction<int8_t>(type);
 	case PhysicalType::INT16:

--- a/test/sql/storage/compression/rle/rle_bool.test
+++ b/test/sql/storage/compression/rle/rle_bool.test
@@ -1,0 +1,29 @@
+# name: test/sql/storage/compression/rle/rle_bool.test
+# description: Test RLE with booleans
+# group: [rle]
+
+# load the DB from disk
+load __TEST_DIR__/test_rle_bool.db
+
+statement ok
+PRAGMA force_compression = 'rle'
+
+# simple RLE with few values
+statement ok
+CREATE TABLE test (a BOOLEAN);
+
+statement ok
+INSERT INTO test select false from range(2048);
+
+statement ok
+INSERT INTO test select true from range(2048);
+
+query I
+SELECT COUNT(*) FROM test WHERE a=false
+----
+2048
+
+query I
+SELECT COUNT(*) FROM test WHERE a=false
+----
+2048


### PR DESCRIPTION
This prevents leaking uninitialized memory to this location