### PR TITLE
[Python Dev] Fix the versioning of the nightly python builds

### DIFF
--- a/scripts/amalgamation.py
+++ b/scripts/amalgamation.py
@@ -277,7 +277,7 @@ def git_commit_hash():
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-main_branch_versioning = os.getenv('MAIN_BRANCH_VERSIONING') or 1
+main_branch_versioning = False if os.getenv('MAIN_BRANCH_VERSIONING') == "0" else True
 
 
 def git_dev_version():
@@ -291,7 +291,7 @@ def git_dev_version():
         else:
             # not on a tag: increment the version by one and add a -devX suffix
             # this needs to keep in sync with changes to CMakeLists.txt
-            if main_branch_versioning:
+            if main_branch_versioning == True:
                 # increment minor version
                 version_splits[1] = str(int(version_splits[1]) + 1)
             else:

--- a/scripts/package_build.py
+++ b/scripts/package_build.py
@@ -143,7 +143,7 @@ def get_relative_path(source_dir, target_file):
 # - scripts/package_build.py
 # - tools/pythonpkg/setup.py
 ######
-main_branch_versioning = os.getenv('MAIN_BRANCH_VERSIONING') or 1
+main_branch_versioning = False if os.getenv('MAIN_BRANCH_VERSIONING') == "0" else True
 
 
 def get_git_describe():
@@ -210,7 +210,7 @@ def git_dev_version():
         else:
             # not on a tag: increment the version by one and add a -devX suffix
             # this needs to keep in sync with changes to CMakeLists.txt
-            if main_branch_versioning == 1:
+            if main_branch_versioning == True:
                 # increment minor version
                 version_splits[1] = str(int(version_splits[1]) + 1)
             else:

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -6,6 +6,36 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "duckdb"
+dynamic = ["version"]
+description = "DuckDB in-process database"
+readme = "README.md"
+keywords = ["DuckDB", "Database", "SQL", "OLAP"]
+requires-python = ">=3.7.0"
+classifiers = [
+    "Topic :: Database :: Database Engines/Servers",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License"
+]
+[project.urls]
+Documentation = "https://duckdb.org/docs/api/python/overview"
+Source = "https://github.com/duckdb/duckdb/blob/main/tools/pythonpkg"
+Issues = "https://github.com/duckdb/duckdb/issues"
+Changelog = "https://github.com/duckdb/duckdb/releases"
+
+# Formerly 'tests_require' in setup() arguments
+[project.optional-dependencies]
+test = [
+    "google-cloud-storage",
+    "mypy",
+    "pytest"
+]
+
+[tool.setuptools]
+packages = ["duckdb"]
+include-package-data = true
+
 ### CI Builwheel configurations ###
 
 # Default config runs all tests and requires at least one extension to be tested against

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -6,10 +6,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools_scm]
-root = "../.."
-local_scheme = "no-local-version"
-
 ### CI Builwheel configurations ###
 
 # Default config runs all tests and requires at least one extension to be tested against

--- a/tools/pythonpkg/pyproject.toml
+++ b/tools/pythonpkg/pyproject.toml
@@ -18,23 +18,15 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License"
 ]
+authors = [
+	{name = "Hannes Muehleisen", email = "hannes@cwi.nl"}
+]
+
 [project.urls]
 Documentation = "https://duckdb.org/docs/api/python/overview"
 Source = "https://github.com/duckdb/duckdb/blob/main/tools/pythonpkg"
 Issues = "https://github.com/duckdb/duckdb/issues"
 Changelog = "https://github.com/duckdb/duckdb/releases"
-
-# Formerly 'tests_require' in setup() arguments
-[project.optional-dependencies]
-test = [
-    "google-cloud-storage",
-    "mypy",
-    "pytest"
-]
-
-[tool.setuptools]
-packages = ["duckdb"]
-include-package-data = true
 
 ### CI Builwheel configurations ###
 
@@ -43,7 +35,7 @@ include-package-data = true
 dependency-versions = "latest"
 before-build = 'pip install numpy>=2.0'
 before-test = 'python scripts/optional_requirements.py'
-test-requires = 'pytest'
+test-requires = ["pytest", "google-cloud-storage", "mypy"]
 test-command = 'DUCKDB_PYTHON_TEST_EXTENSION_PATH={project} DUCKDB_PYTHON_TEST_EXTENSION_REQUIRED=1 python -m pytest {project}/tests --verbose'
 
 [tool.cibuildwheel.environment]

--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -452,6 +452,7 @@ setup(
     data_files=data_files,
     # NOTE: might need to be find_packages() ?
     packages=packages,
+    include_package_data=True,
     long_description="See here for an introduction: https://duckdb.org/docs/api/python/overview",
     ext_modules=[libduckdb],
     use_scm_version={


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/4450

Summary of changes:
- The `version=package_version` is rewritten into a setuptools custom `version_scheme` callback.
- Support `OVERRIDE_GIT_DESCRIBE` by implementing a custom `parse` method for `setuptools_scm`.
- Fix the handling of `MAIN_BRANCH_VERSIONING` in `package_build.py` (this is used by both source distributions and distributed wheel builds)
- Replaced `tests_require` with `test-requires` in the `[tool.cibuildwheel]` section of the `pyproject.toml` (tests_require has been deprecated and even removed for a while).
- Modernize the build, move a bunch of information from `setup()` call to `pyproject.toml`