### PR TITLE
Call Notify External Repositories from Invoke CI

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -87,17 +87,35 @@ jobs:
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
 
-  notify-odbc-main:
+  notify-external-repos-main:
     uses: ./.github/workflows/NotifyExternalRepositories.yml
     secrets: inherit
+    needs:
+      - osx
+      - linux-release
+      - windows
+      - python
+      - pyodide
+      - R
+      - Wasm
+      - static-libraries
     if: ${{ inputs.git_ref == '' }}
     with:
       target-branch: ${{ github.ref_name }}
       duckdb-sha: ${{ github.head_ref }}
 
-  notify-odbc-specific-branch:
+  notify-specific-branch-on-external-repos:
     uses: ./.github/workflows/NotifyExternalRepositories.yml
     secrets: inherit
+    needs:
+      - osx
+      - linux-release
+      - windows
+      - python
+      - pyodide
+      - R
+      - Wasm
+      - static-libraries
     if: ${{ inputs.git_ref != '' }}
     with:
       target-branch: ${{ github.ref_name }}

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -86,3 +86,19 @@ jobs:
       override_git_describe: ${{ inputs.override_git_describe }}
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
+
+  notify-odbc-main:
+    uses: ./.github/workflows/NotifyExternalRepositories.yml
+    secrets: inherit
+    if: ${{ inputs.git_ref == '' }}
+    with:
+      target-branch: ${{ github.ref_name }}
+      duckdb-sha: ${{ github.head_ref }}
+
+  notify-odbc-specific-branch:
+    uses: ./.github/workflows/NotifyExternalRepositories.yml
+    secrets: inherit
+    if: ${{ inputs.git_ref != '' }}
+    with:
+      target-branch: ${{ github.ref_name }}
+      duckdb-sha: ${{ inputs.git_ref }}

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -1,5 +1,17 @@
 name: Notify External Repositories
 on:
+  workflow_call:
+    inputs:
+      duckdb-sha:
+        description: 'Vendor Specific DuckDB SHA'
+        required: false
+        default: ''
+        type: 'string'
+      target-branch:
+        description: 'Which Branch to Target'
+        required: true
+        default: ''
+        type: 'string'
   workflow_dispatch:
     inputs:
       duckdb-sha:


### PR DESCRIPTION
Adds two workflow calls:
- if `git_ref` is empty, runs the vendor script on the odbc main branch
- otherwise passes `git_ref` as the `duckdb_sha` and runs on the corresponding branch on odbc

I've tested on my fork, the script works, cannot confirm that the vendor script is run, will have to see after the merge. 