### PR TITLE
Add support for dynamically providing extra info post-execution in table functions, and use this to emit the total number of files read by the MultiFileReader

### DIFF
--- a/src/execution/operator/scan/physical_table_scan.cpp
+++ b/src/execution/operator/scan/physical_table_scan.cpp
@@ -279,4 +279,16 @@ bool PhysicalTableScan::ParallelSource() const {
 	return true;
 }
 
+InsertionOrderPreservingMap<string> PhysicalTableScan::ExtraSourceParams(GlobalSourceState &gstate_p,
+                                                                         LocalSourceState &lstate) const {
+	if (!function.dynamic_to_string) {
+		return InsertionOrderPreservingMap<string>();
+	}
+	auto &gstate = gstate_p.Cast<TableScanGlobalSourceState>();
+	auto &state = lstate.Cast<TableScanLocalSourceState>();
+	TableFunctionDynamicToStringInput input(function, bind_data.get(), state.local_state.get(),
+	                                        gstate.global_state.get());
+	return function.dynamic_to_string(input);
+}
+
 } // namespace duckdb

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -20,11 +20,11 @@ TableFunction::TableFunction(string name, vector<LogicalType> arguments, table_f
     : SimpleNamedParameterFunction(std::move(name), std::move(arguments)), bind(bind), bind_replace(nullptr),
       init_global(init_global), init_local(init_local), function(function), in_out_function(nullptr),
       in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr), cardinality(nullptr),
-      pushdown_complex_filter(nullptr), to_string(nullptr), table_scan_progress(nullptr), get_partition_data(nullptr),
-      get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr), supports_pushdown_type(nullptr),
-      get_partition_info(nullptr), get_partition_stats(nullptr), get_virtual_columns(nullptr), serialize(nullptr),
-      deserialize(nullptr), projection_pushdown(false), filter_pushdown(false), filter_prune(false),
-      sampling_pushdown(false), late_materialization(false) {
+      pushdown_complex_filter(nullptr), to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr),
+      get_partition_data(nullptr), get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr),
+      supports_pushdown_type(nullptr), get_partition_info(nullptr), get_partition_stats(nullptr),
+      get_virtual_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
+      filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
 }
 
 TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function,
@@ -35,11 +35,12 @@ TableFunction::TableFunction(const vector<LogicalType> &arguments, table_functio
 TableFunction::TableFunction()
     : SimpleNamedParameterFunction("", {}), bind(nullptr), bind_replace(nullptr), init_global(nullptr),
       init_local(nullptr), function(nullptr), in_out_function(nullptr), statistics(nullptr), dependency(nullptr),
-      cardinality(nullptr), pushdown_complex_filter(nullptr), to_string(nullptr), table_scan_progress(nullptr),
-      get_partition_data(nullptr), get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr),
-      supports_pushdown_type(nullptr), get_partition_info(nullptr), get_partition_stats(nullptr),
-      get_virtual_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
-      filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
+      cardinality(nullptr), pushdown_complex_filter(nullptr), to_string(nullptr), dynamic_to_string(nullptr),
+      table_scan_progress(nullptr), get_partition_data(nullptr), get_bind_info(nullptr), type_pushdown(nullptr),
+      get_multi_file_reader(nullptr), supports_pushdown_type(nullptr), get_partition_info(nullptr),
+      get_partition_stats(nullptr), get_virtual_columns(nullptr), serialize(nullptr), deserialize(nullptr),
+      projection_pushdown(false), filter_pushdown(false), filter_prune(false), sampling_pushdown(false),
+      late_materialization(false) {
 }
 
 bool TableFunction::Equal(const TableFunction &rhs) const {

--- a/src/include/duckdb/common/multi_file_reader_function.hpp
+++ b/src/include/duckdb/common/multi_file_reader_function.hpp
@@ -124,6 +124,7 @@ public:
 		pushdown_complex_filter = MultiFileComplexFilterPushdown;
 		get_partition_info = MultiFileGetPartitionInfo;
 		get_virtual_columns = MultiFileGetVirtualColumns;
+		dynamic_to_string = MultiFileDynamicToString;
 		MultiFileReader::AddParameters(*this);
 	}
 
@@ -696,6 +697,13 @@ public:
 		OP::GetVirtualColumns(context, bind_data, result);
 
 		bind_data.virtual_columns = result;
+		return result;
+	}
+
+	static InsertionOrderPreservingMap<string> MultiFileDynamicToString(TableFunctionDynamicToStringInput &input) {
+		auto &gstate = input.global_state->Cast<MultiFileGlobalState>();
+		InsertionOrderPreservingMap<string> result;
+		result.insert(make_pair("Total Files Read", std::to_string(gstate.file_index.load())));
 		return result;
 	}
 

--- a/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -76,6 +76,9 @@ public:
 	bool SupportsPartitioning(const OperatorPartitionInfo &partition_info) const override;
 
 	ProgressData GetProgress(ClientContext &context, GlobalSourceState &gstate) const override;
+
+	InsertionOrderPreservingMap<string> ExtraSourceParams(GlobalSourceState &gstate,
+	                                                      LocalSourceState &lstate) const override;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/execution/physical_operator.hpp
+++ b/src/include/duckdb/execution/physical_operator.hpp
@@ -152,6 +152,11 @@ public:
 		return source_progress;
 	}
 
+	virtual InsertionOrderPreservingMap<string> ExtraSourceParams(GlobalSourceState &gstate,
+	                                                              LocalSourceState &lstate) const {
+		return InsertionOrderPreservingMap<string>();
+	}
+
 public:
 	// Sink interface
 

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -181,6 +181,20 @@ struct TableFunctionToStringInput {
 	optional_ptr<const FunctionData> bind_data;
 };
 
+struct TableFunctionDynamicToStringInput {
+	TableFunctionDynamicToStringInput(const TableFunction &table_function_p,
+	                                  optional_ptr<const FunctionData> bind_data_p,
+	                                  optional_ptr<LocalTableFunctionState> local_state_p,
+	                                  optional_ptr<GlobalTableFunctionState> global_state_p)
+	    : table_function(table_function_p), bind_data(bind_data_p), local_state(local_state_p),
+	      global_state(global_state_p) {
+	}
+	const TableFunction &table_function;
+	optional_ptr<const FunctionData> bind_data;
+	optional_ptr<LocalTableFunctionState> local_state;
+	optional_ptr<GlobalTableFunctionState> global_state;
+};
+
 struct TableFunctionGetPartitionInput {
 public:
 	TableFunctionGetPartitionInput(optional_ptr<const FunctionData> bind_data_p,
@@ -282,6 +296,8 @@ typedef void (*table_function_pushdown_complex_filter_t)(ClientContext &context,
                                                          FunctionData *bind_data,
                                                          vector<unique_ptr<Expression>> &filters);
 typedef InsertionOrderPreservingMap<string> (*table_function_to_string_t)(TableFunctionToStringInput &input);
+typedef InsertionOrderPreservingMap<string> (*table_function_dynamic_to_string_t)(
+    TableFunctionDynamicToStringInput &input);
 
 typedef void (*table_function_serialize_t)(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
                                            const TableFunction &function);
@@ -348,8 +364,10 @@ public:
 	//! (Optional) pushdown a set of arbitrary filter expressions, rather than only simple comparisons with a constant
 	//! Any functions remaining in the expression list will be pushed as a regular filter after the scan
 	table_function_pushdown_complex_filter_t pushdown_complex_filter;
-	//! (Optional) function for rendering the operator to a string in profiling output
+	//! (Optional) function for rendering the operator to a string in explain/profiling output (invoked pre-execution)
 	table_function_to_string_t to_string;
+	//! (Optional) function for rendering the operator to a string in profiling output (invoked post-execution)
+	table_function_dynamic_to_string_t dynamic_to_string;
 	//! (Optional) return how much of the table we have scanned up to this point (% of the data)
 	table_function_progress_t table_scan_progress;
 	//! (Optional) returns the partition info of the current scan operator

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -71,10 +71,13 @@ public:
 public:
 	DUCKDB_API void StartOperator(optional_ptr<const PhysicalOperator> phys_op);
 	DUCKDB_API void EndOperator(optional_ptr<DataChunk> chunk);
+	DUCKDB_API void FinishSource(GlobalSourceState &gstate, LocalSourceState &lstate);
 
 	//! Adds the timings in the OperatorProfiler (tree) to the QueryProfiler (tree).
 	DUCKDB_API void Flush(const PhysicalOperator &phys_op);
 	DUCKDB_API OperatorInformation &GetOperatorInfo(const PhysicalOperator &phys_op);
+	DUCKDB_API bool OperatorInfoIsInitialized(const PhysicalOperator &phys_op);
+	DUCKDB_API void AddExtraInfo(InsertionOrderPreservingMap<string> extra_info);
 
 public:
 	ClientContext &context;

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -375,9 +375,12 @@ void OperatorProfiler::StartOperator(optional_ptr<const PhysicalOperator> phys_o
 
 	if (!settings.empty()) {
 		if (ProfilingInfo::Enabled(settings, MetricsType::EXTRA_INFO)) {
-			auto &info = GetOperatorInfo(*active_operator);
-			auto params = active_operator->ParamsToString();
-			info.extra_info = params;
+			if (!OperatorInfoIsInitialized(*active_operator)) {
+				// first time calling into this operator - fetch the info
+				auto &info = GetOperatorInfo(*active_operator);
+				auto params = active_operator->ParamsToString();
+				info.extra_info = params;
+			}
 		}
 
 		// Start the timing of the current operator.
@@ -392,7 +395,7 @@ void OperatorProfiler::EndOperator(optional_ptr<DataChunk> chunk) {
 		return;
 	}
 	if (!active_operator) {
-		throw InternalException("OperatorProfiler: Attempting to call EndOperator while another operator is active");
+		throw InternalException("OperatorProfiler: Attempting to call EndOperator while no operator is active");
 	}
 
 	if (!settings.empty()) {
@@ -410,6 +413,37 @@ void OperatorProfiler::EndOperator(optional_ptr<DataChunk> chunk) {
 		}
 	}
 	active_operator = nullptr;
+}
+
+void OperatorProfiler::FinishSource(GlobalSourceState &gstate, LocalSourceState &lstate) {
+	if (!enabled) {
+		return;
+	}
+	if (!active_operator) {
+		throw InternalException("OperatorProfiler: Attempting to call FinishSource while no operator is active");
+	}
+	if (!settings.empty()) {
+		if (ProfilingInfo::Enabled(settings, MetricsType::EXTRA_INFO)) {
+			// we're emitting extra info - get the extra source info
+			auto &info = GetOperatorInfo(*active_operator);
+			auto extra_info = active_operator->ExtraSourceParams(gstate, lstate);
+			for (auto &new_info : extra_info) {
+				auto entry = info.extra_info.find(new_info.first);
+				if (entry != info.extra_info.end()) {
+					// entry exists - override
+					entry->second = std::move(new_info.second);
+				} else {
+					// entry does not exist yet - insert
+					info.extra_info.insert(std::move(new_info));
+				}
+			}
+		}
+	}
+}
+
+bool OperatorProfiler::OperatorInfoIsInitialized(const PhysicalOperator &phys_op) {
+	auto entry = operator_infos.find(phys_op);
+	return entry != operator_infos.end();
 }
 
 OperatorInformation &OperatorProfiler::GetOperatorInfo(const PhysicalOperator &phys_op) {

--- a/src/parallel/pipeline_executor.cpp
+++ b/src/parallel/pipeline_executor.cpp
@@ -527,9 +527,12 @@ SourceResultType PipelineExecutor::FetchFromSource(DataChunk &result) {
 	OperatorSourceInput source_input = {*pipeline.source_state, *local_source_state, interrupt_state};
 	auto res = GetData(result, source_input);
 
-	// Ensures Sinks only return empty results when Blocking or Finished
+	// Ensures sources only return empty results when Blocking or Finished
 	D_ASSERT(res != SourceResultType::BLOCKED || result.size() == 0);
-
+	if (res == SourceResultType::FINISHED) {
+		// final call into the source - finish source execution
+		context.thread.profiler.FinishSource(*pipeline.source_state, *local_source_state);
+	}
 	EndOperator(*pipeline.source, &result);
 
 	return res;

--- a/test/sql/copy/partitioned/hive_partition_join_pushdown.test
+++ b/test/sql/copy/partitioned/hive_partition_join_pushdown.test
@@ -11,12 +11,25 @@ CREATE TABLE tbl AS SELECT i//1000 AS partition, i FROM range(10000) t(i)
 statement ok
 COPY tbl TO '__TEST_DIR__/partition_join_pushdown' (FORMAT parquet, PARTITION_BY (partition))
 
+query II
+EXPLAIN ANALYZE SELECT COUNT(*), MIN(partition), MAX(partition), SUM(i)
+FROM '__TEST_DIR__/partition_join_pushdown/**/*.parquet'
+----
+analyzed_plan	<REGEX>:.*Total Files Read.*10.*
+
 query IIII
 SELECT COUNT(*), MIN(partition), MAX(partition), SUM(i)
 FROM '__TEST_DIR__/partition_join_pushdown/**/*.parquet'
 WHERE partition=(SELECT MAX(partition) FROM tbl)
 ----
 1000	9	9	9499500
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*), MIN(partition), MAX(partition), SUM(i)
+FROM '__TEST_DIR__/partition_join_pushdown/**/*.parquet'
+WHERE partition=(SELECT MAX(partition) FROM tbl)
+----
+analyzed_plan	<REGEX>:.*Total Files Read.*1.*
 
 query IIII
 SELECT COUNT(*), MIN(partition), MAX(partition), SUM(i)


### PR DESCRIPTION
This PR adds a new callback to table functions:

```cpp
typedef InsertionOrderPreservingMap<string> (*table_function_dynamic_to_string_t)(
    TableFunctionDynamicToStringInput &input);
```

This callback is similar to the `to_string` callback, but can be used to provide extra information that is only known after executing the function. This will not be displayed when running `EXPLAIN`, but will be displayed when running `EXPLAIN ANALYZE`. For example:

```sql
CREATE TABLE tbl AS SELECT i//1000 AS partition, i FROM range(10000) t(i);
SELECT COUNT(distinct partition) AS num_partitions FROM tbl;
┌────────────────┐
│ num_partitions │
│     int64      │
├────────────────┤
│       10       │
└────────────────┘
COPY tbl TO 'partition_join_pushdown' (FORMAT parquet, PARTITION_BY (partition));

-- we don't know how many partitions we are scanning yet
EXPLAIN SELECT * FROM 'partition_join_pushdown/**/*.parquet' WHERE partition=(SELECT MAX(partition) FROM tbl);
┌─────────────┴─────────────┐
│       PARQUET_SCAN        │
│    ────────────────────   │
│         Function:         │
│        PARQUET_SCAN       │
│                           │
│        Projections:       │
│         partition         │
│             i             │
│                           │
│                           │
│                           │
│                           │
│                           │
│                           │
│                           │
│        ~10000 Rows        │
└───────────────────────────┘

-- after execution we know how many partitions we read
EXPLAIN ANALYZE SELECT * FROM 'partition_join_pushdown/**/*.parquet' WHERE partition=(SELECT MAX(partition) FROM tbl);
┌─────────────┴─────────────┐
│         TABLE_SCAN        │
│    ────────────────────   │
│         Function:         │
│        PARQUET_SCAN       │
│                           │
│        Projections:       │
│         partition         │
│             i             │
│                           │
│    Total Files Read: 1    │
│                           │
│                           │
│                           │
│                           │
│                           │
│         1000 Rows         │
│          (0.00s)          │
└───────────────────────────┘

```

CC @samansmink @taniabogatsch 
