### PR TITLE
CLI `-help`: Fix default value for -nullvalue

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4686,7 +4686,7 @@ static const char zOptions[] = "   -ascii               set output mode to 'asci
                                "   -markdown            set output mode to 'markdown'\n"
                                "   -newline SEP         set output row separator. Default: '\\n'\n"
                                "   -no-stdin            exit after processing options instead of reading stdin\n"
-                               "   -nullvalue TEXT      set text string for NULL values. Default ''\n"
+                               "   -nullvalue TEXT      set text string for NULL values. Default 'NULL'\n"
                                "   -quote               set output mode to 'quote'\n"
                                "   -readonly            open the database read-only\n"
                                "   -s COMMAND           run \"COMMAND\" and exit\n"


### PR DESCRIPTION
Very minor, connected to https://github.com/duckdb/duckdb-web/issues/5033 and somehow relevant https://github.com/duckdb/community-extensions/pull/329 (where I have not been able how to pass via bash an empty string as `-nullvalue` argument).

I think having the `-help` reflect the code makes sense, eventually also to be tested or generated.