### PR TITLE
Allow SQL prepared statements to bre rebound

### DIFF
--- a/src/include/duckdb/main/client_context_state.hpp
+++ b/src/include/duckdb/main/client_context_state.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/valid_checker.hpp"
+#include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
 #include "duckdb/main/database_manager.hpp"
@@ -31,12 +32,12 @@ class RegisteredStateManager;
 enum class RebindQueryInfo { DO_NOT_REBIND, ATTEMPT_TO_REBIND };
 
 struct PreparedStatementCallbackInfo {
-	PreparedStatementCallbackInfo(PreparedStatementData &prepared_statement, const PendingQueryParameters &parameters)
+	PreparedStatementCallbackInfo(PreparedStatementData &prepared_statement, const optional_ptr<case_insensitive_map_t<BoundParameterData>>& parameters)
 	    : prepared_statement(prepared_statement), parameters(parameters) {
 	}
 
 	PreparedStatementData &prepared_statement;
-	const PendingQueryParameters &parameters;
+	optional_ptr<case_insensitive_map_t<BoundParameterData>> parameters;
 };
 
 //! ClientContextState is virtual base class for ClientContext-local (or Query-Local, using QueryEnd callback) state

--- a/src/include/duckdb/main/client_context_state.hpp
+++ b/src/include/duckdb/main/client_context_state.hpp
@@ -32,7 +32,8 @@ class RegisteredStateManager;
 enum class RebindQueryInfo { DO_NOT_REBIND, ATTEMPT_TO_REBIND };
 
 struct PreparedStatementCallbackInfo {
-	PreparedStatementCallbackInfo(PreparedStatementData &prepared_statement, const optional_ptr<case_insensitive_map_t<BoundParameterData>>& parameters)
+	PreparedStatementCallbackInfo(PreparedStatementData &prepared_statement,
+	                              const optional_ptr<case_insensitive_map_t<BoundParameterData>> &parameters)
 	    : prepared_statement(prepared_statement), parameters(parameters) {
 	}
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -561,7 +561,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientCon
 	}
 
 	for (auto &state : registered_state->States()) {
-		PreparedStatementCallbackInfo info(*prepared, parameters);
+		PreparedStatementCallbackInfo info(*prepared, parameters.parameters);
 		auto new_rebind = state->OnExecutePrepared(*this, info, rebind);
 		if (new_rebind == RebindQueryInfo::ATTEMPT_TO_REBIND) {
 			rebind = RebindQueryInfo::ATTEMPT_TO_REBIND;

--- a/src/planner/binder/statement/bind_execute.cpp
+++ b/src/planner/binder/statement/bind_execute.cpp
@@ -66,10 +66,7 @@ BoundStatement Binder::Bind(ExecuteStatement &stmt) {
 		rebind = RebindQueryInfo::ATTEMPT_TO_REBIND;
 	}
 	for (auto &state : context.registered_state->States()) {
-		PendingQueryParameters query_parameters;
-		query_parameters.parameters = bind_values;
-		query_parameters.allow_stream_result = false; // TODO, how do I get this value?
-		PreparedStatementCallbackInfo info(*prepared, query_parameters);
+		PreparedStatementCallbackInfo info(*prepared, bind_values);
 		auto new_rebind = state->OnExecutePrepared(context, info, rebind);
 		if (new_rebind == RebindQueryInfo::ATTEMPT_TO_REBIND) {
 			rebind = RebindQueryInfo::ATTEMPT_TO_REBIND;


### PR DESCRIPTION
This makes the lifecycle of prepared and non-prepared statements more similar, by calling the `OnExecutePrepared` also for SQL prepared statements