### PR TITLE
Benchmark runner summary

### DIFF
--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -17,8 +17,6 @@
 
 using namespace duckdb;
 
-std::map<std::string, std::string> summary{};
-
 void BenchmarkRunner::RegisterBenchmark(Benchmark *benchmark) {
 	GetInstance().benchmarks.push_back(benchmark);
 }
@@ -60,6 +58,7 @@ void BenchmarkRunner::InitializeBenchmarkDirectory() {
 atomic<bool> is_active;
 atomic<bool> timeout;
 atomic<bool> summarize;
+std::map<std::string, std::string> summary{};
 
 void sleep_thread(Benchmark *benchmark, BenchmarkRunner *runner, BenchmarkState *state, bool hotrun,
                   const optional_idx &optional_timeout) {

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -118,8 +118,9 @@ void BenchmarkRunner::LogOutput(string message) {
 	}
 }
 
-void BenchmarkRunner::LogSummary(string benchmark, string message) {
-	string failure_message = benchmark + "\n" + message;
+void BenchmarkRunner::LogSummary(string benchmark, string message, size_t i) {
+	string log_result_line = StringUtil::Format("%s\t%d\t", benchmark, i) + "\tINCORRECT\n";
+	string failure_message = benchmark + "\nname\trun\ttiming\n" + log_result_line + message;
 	summary.push_back(failure_message);
 }
 
@@ -180,7 +181,7 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 					LogResult("INCORRECT");
 					LogLine("INCORRECT RESULT: " + verify);
 					LogOutput("INCORRECT RESULT: " + verify);
-					LogSummary(benchmark->name, "INCORRECT RESULT: " + verify);
+					LogSummary(benchmark->name, "INCORRECT RESULT: " + verify, i);
 					break;
 				} else {
 					LogResult(std::to_string(profiler.Elapsed()));
@@ -399,9 +400,12 @@ int main(int argc, char **argv) {
 	const auto configuration_error = run_benchmarks();
 	
 	if (!summary.empty() && summarize) {
-		std::cout << "\n===============================  FAILURES SUMMARY  ===============================\n" << std::endl;
+		std::cout << "\n====================================================" << std::endl;
+		std::cout << "================  FAILURES SUMMARY  ================" << std::endl;
+		std::cout << "====================================================\n" << std::endl;
 		for (size_t i = 0; i < summary.size(); i++) {
-			std::cout << i + 1 << ". " << summary[i] << std::endl;
+			std::cout << i + 1 << ": " << summary[i] << std::endl;
+			std::cout << "----------------------------------------------------" << std::endl;
 		}
 	}
 	

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -398,7 +398,7 @@ int main(int argc, char **argv) {
 	LoadInterpretedBenchmarks(*fs);
 	parse_arguments(argc, argv);
 	const auto configuration_error = run_benchmarks();
-	
+
 	if (!summary.empty() && summarize) {
 		std::cout << "\n====================================================" << std::endl;
 		std::cout << "================  FAILURES SUMMARY  ================" << std::endl;
@@ -408,7 +408,7 @@ int main(int argc, char **argv) {
 			std::cout << "----------------------------------------------------" << std::endl;
 		}
 	}
-	
+
 	if (configuration_error != ConfigurationError::None) {
 		print_error_message(configuration_error);
 		exit(1);

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -17,6 +17,8 @@
 
 using namespace duckdb;
 
+std::map<std::string, std::string> summary{};
+
 void BenchmarkRunner::RegisterBenchmark(Benchmark *benchmark) {
 	GetInstance().benchmarks.push_back(benchmark);
 }
@@ -174,6 +176,7 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 					LogResult("INCORRECT");
 					LogLine("INCORRECT RESULT: " + verify);
 					LogOutput("INCORRECT RESULT: " + verify);
+					summary[benchmark->name] = verify;
 					break;
 				} else {
 					LogResult(std::to_string(profiler.Elapsed()));

--- a/benchmark/benchmark_runner.cpp
+++ b/benchmark/benchmark_runner.cpp
@@ -58,7 +58,7 @@ void BenchmarkRunner::InitializeBenchmarkDirectory() {
 atomic<bool> is_active;
 atomic<bool> timeout;
 atomic<bool> summarize;
-std::map<std::string, std::string> summary{};
+std::vector<std::string> summary;
 
 void sleep_thread(Benchmark *benchmark, BenchmarkRunner *runner, BenchmarkState *state, bool hotrun,
                   const optional_idx &optional_timeout) {
@@ -118,6 +118,11 @@ void BenchmarkRunner::LogOutput(string message) {
 	}
 }
 
+void BenchmarkRunner::LogSummary(string benchmark, string message) {
+	string failure_message = benchmark + "\n" + message;
+	summary.push_back(failure_message);
+}
+
 void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 	Profiler profiler;
 	auto display_name = benchmark->DisplayName();
@@ -175,7 +180,7 @@ void BenchmarkRunner::RunBenchmark(Benchmark *benchmark) {
 					LogResult("INCORRECT");
 					LogLine("INCORRECT RESULT: " + verify);
 					LogOutput("INCORRECT RESULT: " + verify);
-					summary[benchmark->name] = verify;
+					LogSummary(benchmark->name, "INCORRECT RESULT: " + verify);
 					break;
 				} else {
 					LogResult(std::to_string(profiler.Elapsed()));
@@ -395,10 +400,8 @@ int main(int argc, char **argv) {
 	
 	if (!summary.empty() && summarize) {
 		std::cout << "\n===============================  FAILURES SUMMARY  ===============================\n" << std::endl;
-		int i = 1;
-		for (const auto& item : summary) {
-			std::cout << i << ". [" << item.first << "]: " << item.second << std::endl;
-			i++;
+		for (size_t i = 0; i < summary.size(); i++) {
+			std::cout << i + 1 << ". " << summary[i] << std::endl;
 		}
 	}
 	

--- a/benchmark/include/benchmark_runner.hpp
+++ b/benchmark/include/benchmark_runner.hpp
@@ -42,6 +42,7 @@ public:
 	void LogLine(string message);
 	void LogResult(string message);
 	void LogOutput(string message);
+	void LogSummary(string benchmark, string message);
 
 	void RunBenchmark(Benchmark *benchmark);
 	void RunBenchmarks();

--- a/benchmark/include/benchmark_runner.hpp
+++ b/benchmark/include/benchmark_runner.hpp
@@ -42,7 +42,7 @@ public:
 	void LogLine(string message);
 	void LogResult(string message);
 	void LogOutput(string message);
-	void LogSummary(string benchmark, string message);
+	void LogSummary(string benchmark, string message, size_t i);
 
 	void RunBenchmark(Benchmark *benchmark);
 	void RunBenchmarks();

--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -72,7 +72,9 @@ class BenchmarkRunnerConfig:
             "--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600)."
         )
         parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
-        parser.add_argument("--no-summary", type=str, default=False, help="No failures summary is outputed when passing this flag.")
+        parser.add_argument(
+            "--no-summary", type=str, default=False, help="No failures summary is outputed when passing this flag."
+        )
 
         # Parse arguments
         parsed_args = parser.parse_args()
@@ -128,7 +130,10 @@ class BenchmarkRunner:
         except subprocess.TimeoutExpired:
             print("Failed to run benchmark " + benchmark)
             print(f"Aborted due to exceeding the limit of {timeout_seconds} seconds")
-            return 'Failed to run benchmark ' + benchmark, f"Aborted due to exceeding the limit of {timeout_seconds} seconds"
+            return (
+                'Failed to run benchmark ' + benchmark,
+                f"Aborted due to exceeding the limit of {timeout_seconds} seconds",
+            )
         if returncode != 0:
             print("Failed to run benchmark " + benchmark)
             print(STDERR_HEADER)

--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -72,7 +72,7 @@ class BenchmarkRunnerConfig:
             "--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600)."
         )
         parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
-        parser.add_argument("--no-summary", type=str, default=False, help="No failures summary will be outputed.")
+        parser.add_argument("--no-summary", type=str, default=False, help="No failures summary is outputed when passing this flag.")
 
         # Parse arguments
         parsed_args = parser.parse_args()

--- a/scripts/regression/benchmark.py
+++ b/scripts/regression/benchmark.py
@@ -35,6 +35,7 @@ class BenchmarkRunnerConfig:
     disable_timeout: bool = False
     max_timeout: int = MAX_TIMEOUT
     root_dir: str = ""
+    no_summary: bool = False
 
     @classmethod
     def from_params(cls, benchmark_runner, benchmark_file, **kwargs) -> "BenchmarkRunnerConfig":
@@ -43,6 +44,7 @@ class BenchmarkRunnerConfig:
         disable_timeout = kwargs.get("disable_timeout", False)
         max_timeout = kwargs.get("max_timeout", MAX_TIMEOUT)
         root_dir = kwargs.get("root_dir", "")
+        no_summary = kwargs.get("no_summary", False)
 
         config = cls(
             benchmark_runner=benchmark_runner,
@@ -52,6 +54,7 @@ class BenchmarkRunnerConfig:
             disable_timeout=disable_timeout,
             max_timeout=max_timeout,
             root_dir=root_dir,
+            no_summary=no_summary,
         )
         return config
 
@@ -69,6 +72,7 @@ class BenchmarkRunnerConfig:
             "--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600)."
         )
         parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
+        parser.add_argument("--no-summary", type=str, default=False, help="No failures summary will be outputed.")
 
         # Parse arguments
         parsed_args = parser.parse_args()
@@ -82,6 +86,7 @@ class BenchmarkRunnerConfig:
             disable_timeout=parsed_args.disable_timeout,
             max_timeout=parsed_args.max_timeout,
             root_dir=parsed_args.root_dir,
+            no_summary=parsed_args.no_summary,
         )
         return config
 
@@ -103,9 +108,11 @@ class BenchmarkRunner:
             benchmark_args.extend([f"--threads={self.config.threads}"])
         if self.config.disable_timeout:
             benchmark_args.extend(["--disable-timeout"])
+        if self.config.no_summary:
+            benchmark_args.extend(["--no-summary"])
         return benchmark_args
 
-    def run_benchmark(self, benchmark) -> Union[float, str]:
+    def run_benchmark(self, benchmark) -> Tuple[Union[float, str], Optional[str]]:
         benchmark_args = self.construct_args(benchmark)
         timeout_seconds = DEFAULT_TIMEOUT
         if self.config.disable_timeout:
@@ -121,7 +128,7 @@ class BenchmarkRunner:
         except subprocess.TimeoutExpired:
             print("Failed to run benchmark " + benchmark)
             print(f"Aborted due to exceeding the limit of {timeout_seconds} seconds")
-            return 'Failed to run benchmark ' + benchmark
+            return 'Failed to run benchmark ' + benchmark, f"Aborted due to exceeding the limit of {timeout_seconds} seconds"
         if returncode != 0:
             print("Failed to run benchmark " + benchmark)
             print(STDERR_HEADER)
@@ -131,7 +138,7 @@ class BenchmarkRunner:
             if 'HTTP' in err:
                 print("Ignoring HTTP error and terminating the running of the regression tests")
                 exit(0)
-            return 'Failed to run benchmark ' + benchmark
+            return 'Failed to run benchmark ' + benchmark, err
         if self.config.verbose:
             print(err)
         # read the input CSV
@@ -148,17 +155,20 @@ class BenchmarkRunner:
                 else:
                     timings.append(row[2])
                     self.complete_timings.append(row[2])
-            return float(statistics.median(timings))
+            return float(statistics.median(timings)), None
         except:
             print("Failed to run benchmark " + benchmark)
             print(err)
-            return 'Failed to run benchmark ' + benchmark
+            return 'Failed to run benchmark ' + benchmark, err
 
     def run_benchmarks(self, benchmark_list: List[str]):
         results = {}
+        failures = {}
         for benchmark in benchmark_list:
-            results[benchmark] = self.run_benchmark(benchmark)
-        return results
+            result, failure_message = self.run_benchmark(benchmark)
+            results[benchmark] = result
+            failures[benchmark] = failure_message if failure_message else None
+        return results, failures
 
 
 def main():

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -82,6 +82,7 @@ benchmark_list = old_runner.benchmark_list
 
 summary = []
 
+
 @dataclass
 class BenchmarkResult:
     benchmark: str
@@ -89,6 +90,7 @@ class BenchmarkResult:
     new_result: Union[float, str]
     old_failure: Optional[str] = None
     new_failure: Optional[str] = None
+
 
 multiply_percentage = 1.0 + REGRESSION_THRESHOLD_PERCENTAGE
 other_results: List[BenchmarkResult] = []
@@ -145,7 +147,7 @@ if len(regression_list) > 0:
             new_data = {
                 "benchmark": regression.benchmark,
                 "old_failure": regression.old_failure,
-                "new_failure": regression.new_failure
+                "new_failure": regression.new_failure,
             }
             summary.append(new_data)
         print("")

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -206,5 +206,6 @@ if summary and not no_summary:
             print("New:\n", failure_message["new_failure"])
         else:
             print(failure_message["old_failure"])
+        print("-", 52)
 
 exit(exit_code)

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -193,7 +193,12 @@ if os.path.isdir("duckdb_benchmark_data"):
     shutil.rmtree('duckdb_benchmark_data')
 
 if summary and not no_summary:
-    print("\n\n=============================   FAILURES  SUMMARY   =============================\n")
+    print(
+        '''\n\n====================================================
+================  FAILURES SUMMARY  ================
+====================================================
+'''
+    )
     for i, failure_message in enumerate(summary, start=1):
         print(f"{i}: ", failure_message["benchmark"])
         if failure_message["old_failure"] != failure_message["new_failure"]:
@@ -201,6 +206,5 @@ if summary and not no_summary:
             print("New:\n", failure_message["new_failure"])
         else:
             print(failure_message["old_failure"])
-        print("---------------------------------------------------------------------------------\n")
 
 exit(exit_code)

--- a/scripts/regression/test_runner.py
+++ b/scripts/regression/test_runner.py
@@ -49,6 +49,7 @@ parser.add_argument("--nofail", action="store_true", help="Do not fail on regres
 parser.add_argument("--disable-timeout", action="store_true", help="Disable timeout.")
 parser.add_argument("--max-timeout", type=int, default=3600, help="Set maximum timeout in seconds (default: 3600).")
 parser.add_argument("--root-dir", type=str, default="", help="Root directory.")
+parser.add_argument("--no-summary", type=str, default=False, help="No summary in the end.")
 
 # Parse the arguments
 args = parser.parse_args()
@@ -63,6 +64,7 @@ no_regression_fail = args.nofail
 disable_timeout = args.disable_timeout
 max_timeout = args.max_timeout
 root_dir = args.root_dir
+no_summary = args.no_summary
 
 if not os.path.isfile(old_runner_path):
     print(f"Failed to find old runner {old_runner_path}")
@@ -78,13 +80,15 @@ new_runner = BenchmarkRunner(BenchmarkRunnerConfig.from_params(new_runner_path, 
 
 benchmark_list = old_runner.benchmark_list
 
+summary = []
 
 @dataclass
 class BenchmarkResult:
     benchmark: str
     old_result: Union[float, str]
     new_result: Union[float, str]
-
+    old_failure: Optional[str] = None
+    new_failure: Optional[str] = None
 
 multiply_percentage = 1.0 + REGRESSION_THRESHOLD_PERCENTAGE
 other_results: List[BenchmarkResult] = []
@@ -101,15 +105,19 @@ for i in range(NUMBER_REPETITIONS):
 '''
     )
 
-    old_results = old_runner.run_benchmarks(benchmark_list)
-    new_results = new_runner.run_benchmarks(benchmark_list)
+    old_results, old_failures = old_runner.run_benchmarks(benchmark_list)
+    new_results, new_failures = new_runner.run_benchmarks(benchmark_list)
 
     for benchmark in benchmark_list:
         old_res = old_results[benchmark]
         new_res = new_results[benchmark]
+
+        old_fail = old_failures[benchmark]
+        new_fail = new_failures[benchmark]
+
         if isinstance(old_res, str) or isinstance(new_res, str):
             # benchmark failed to run - always a regression
-            error_list.append(BenchmarkResult(benchmark, old_res, new_res))
+            error_list.append(BenchmarkResult(benchmark, old_res, new_res, old_fail, new_fail))
         elif (no_regression_fail == False) and (
             (old_res + REGRESSION_THRESHOLD_SECONDS) * multiply_percentage < new_res
         ):
@@ -120,6 +128,7 @@ for i in range(NUMBER_REPETITIONS):
 
 exit_code = 0
 regression_list.extend(error_list)
+summary = []
 if len(regression_list) > 0:
     exit_code = 1
     print(
@@ -132,6 +141,13 @@ if len(regression_list) > 0:
         print(f"{regression.benchmark}")
         print(f"Old timing: {regression.old_result}")
         print(f"New timing: {regression.new_result}")
+        if regression.old_failure or regression.new_failure:
+            new_data = {
+                "benchmark": regression.benchmark,
+                "old_failure": regression.old_failure,
+                "new_failure": regression.new_failure
+            }
+            summary.append(new_data)
         print("")
     print(
         '''====================================================
@@ -175,4 +191,16 @@ else:
 # nuke cached benchmark data between runs
 if os.path.isdir("duckdb_benchmark_data"):
     shutil.rmtree('duckdb_benchmark_data')
+
+if summary and not no_summary:
+    print("\n\n=============================   FAILURES  SUMMARY   =============================\n")
+    for i, failure_message in enumerate(summary, start=1):
+        print(f"{i}: ", failure_message["benchmark"])
+        if failure_message["old_failure"] != failure_message["new_failure"]:
+            print("Old:\n", failure_message["old_failure"])
+            print("New:\n", failure_message["new_failure"])
+        else:
+            print(failure_message["old_failure"])
+        print("---------------------------------------------------------------------------------\n")
+
 exit(exit_code)


### PR DESCRIPTION
Currently, when running the regression tests with `scripts/regression/test_runner.py`, the log messages are printed on the go without providing a clear indication of what caused the regression. For example, the logs might look like this:
```
====================================================
==============  REGRESSIONS DETECTED   =============
====================================================

benchmark/micro/cast/cast_date_string.benchmark
Old timing: Failed to run benchmark benchmark/micro/cast/cast_date_string.benchmark
New timing: Failed to run benchmark benchmark/micro/cast/cast_date_string.benchmark

...

Old: INCORRECT
New: INCORRECT
```

You have to scroll through all the logs to find the[ details of the failure(s)](https://github.com/duckdb/duckdb/actions/runs/13633032917/job/38105283806?pr=16487#step:15:785).
The `benchmark_runner` outputs the sequence of run results without any additional information.

This PR adds the Failures Summary printed out right in the end of the logs by default.
Passing `--no-summary` flag to the `benchmark_runner` (e.g. `./build/release/benchmark/benchmark_runner`) or to the python runner (`scripts/regression/test_runner.py`) turns Failures Summary off.

I've tried to minimise the details in the summary, but in python script it has more lines though. 
The output looks a bit different for both cases - it's just because the python script captures the whole error message provided by `benchmark_runner`. 

From the `benchmark_runner`:
```
====================================================
================  FAILURES SUMMARY  ================
====================================================

1:  benchmark/micro/cast/cast_date_string.benchmark
name    run     timing
benchmark/micro/cast/cast_date_string.benchmark 1       INCORRECT
INCORRECT RESULT: Error in result on row 1 column 1: expected value "1992-01-01 00:00:00qqqq" but got value "1992-01-01 00:00:00"
Obtained result:
min(CAST(d AS VARCHAR))
VARCHAR
[ Rows: 1]
1992-01-01 00:00:00
```

From the python `test_runner`:
```
===============================  FAILURES SUMMARY  ===============================

1. benchmark/micro/cast/cast_date_string.benchmark
INCORRECT RESULT: Error in result on row 1 column 1: expected value "1992-01-01 00:00:00qqqq" but got value "1992-01-01 00:00:00"
Obtained result:
min(CAST(d AS VARCHAR))
VARCHAR
[ Rows: 1]
1992-01-01 00:00:00
```

If anyone has better idea, how this should be implemented, please feel free to write a comment.

A work to do is to write the failures summary to a file and upload it on WeeklyRegression run so it'd be possible to track the issues.