### PR TITLE
shell: fix sometimes-uninitialized error

### DIFF
--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -4632,7 +4632,7 @@ string ShellState::GetDefaultDuckDBRC() {
 bool ShellState::ProcessFile(const string &file, bool is_duckdb_rc) {
 	FILE *inSaved = in;
 	int savedLineno = lineno;
-	int rc;
+	int rc = 0;
 
 	in = fopen(file.c_str(), "rb");
 	if (in) {


### PR DESCRIPTION
This is a follow-up to #16594, which introduced the problem.

Thanks to @Tishj for bringing it up [here](https://github.com/duckdb/duckdb/pull/16594#issuecomment-2741373243).

(I only encountered the error with `make CXXFLAGS=-Wall`, which makes me wonder a) why that's not the default and b) why CI didn't catch this bug?)