### PR TITLE
Avoid building Python 3.7 wheels also for Linux

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -180,7 +180,7 @@ jobs:
       matrix:
         duckdb_arch: [linux_amd64_gcc4]
         arch: [x86_64, aarch64]
-        python_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]
+        python_build: [cp38-*, cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]
         manylinux: [manylinux2014, manylinux_2_28]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || inputs.run_all == 'true' }}


### PR DESCRIPTION
This solves a problem with new reworked versioning in https://github.com/duckdb/duckdb/pull/16739, probably due to added dependencies. For now removing 3.7, to be considered if to be reinstated or good as is.