### PR TITLE
`PhysicalTopN`: Buffer-allocated `StringHeap`

### DIFF
--- a/extension/jemalloc/jemalloc/include/jemalloc/jemalloc.h
+++ b/extension/jemalloc/jemalloc/include/jemalloc/jemalloc.h
@@ -5,8 +5,8 @@
 extern "C" {
 #endif
 
-// DuckDB uses a 5s decay
-#define DUCKDB_JEMALLOC_DECAY 5
+// DuckDB uses a 1s decay
+#define DUCKDB_JEMALLOC_DECAY 1
 
 /* Defined if __attribute__((...)) syntax is supported. */
 #define JEMALLOC_HAVE_ATTR

--- a/src/execution/operator/order/physical_top_n.cpp
+++ b/src/execution/operator/order/physical_top_n.cpp
@@ -163,8 +163,8 @@ TopNHeap::TopNHeap(ClientContext &context, Allocator &allocator, const vector<Lo
                    const vector<BoundOrderByNode> &orders_p, idx_t limit, idx_t offset)
     : allocator(allocator), buffer_manager(BufferManager::GetBufferManager(context)), payload_types(payload_types_p),
       orders(orders_p), limit(limit), offset(offset), heap_size(limit + offset), executor(context),
-      matching_sel(STANDARD_VECTOR_SIZE), final_sel(STANDARD_VECTOR_SIZE), true_sel(STANDARD_VECTOR_SIZE),
-      false_sel(STANDARD_VECTOR_SIZE), new_remaining_sel(STANDARD_VECTOR_SIZE) {
+      sort_key_heap(allocator), matching_sel(STANDARD_VECTOR_SIZE), final_sel(STANDARD_VECTOR_SIZE),
+      true_sel(STANDARD_VECTOR_SIZE), false_sel(STANDARD_VECTOR_SIZE), new_remaining_sel(STANDARD_VECTOR_SIZE) {
 	// initialize the executor and the sort_chunk
 	vector<LogicalType> sort_types;
 	for (auto &order : orders) {
@@ -190,7 +190,7 @@ TopNHeap::TopNHeap(ClientContext &context, const vector<LogicalType> &payload_ty
 
 TopNHeap::TopNHeap(ExecutionContext &context, const vector<LogicalType> &payload_types,
                    const vector<BoundOrderByNode> &orders, idx_t limit, idx_t offset)
-    : TopNHeap(context.client, Allocator::Get(context.client), payload_types, orders, limit, offset) {
+    : TopNHeap(context.client, BufferAllocator::Get(context.client), payload_types, orders, limit, offset) {
 }
 
 void TopNHeap::AddSmallHeap(DataChunk &input, Vector &sort_keys_vec) {


### PR DESCRIPTION
This memory was not yet being taken into account by the buffer manager, which would cause us to go over the limit with larger TopN queries.

EDIT: I've also reduced the jemalloc decay delay to 1s as this reduces our memory footprint without affecting performance much at all.

EDIT2: I've made sure we also use the buffer allocator for sorted aggregate states, which makes sure we also throw an OOM exception for https://github.com/duckdblabs/duckdb-internal/issues/4131