### PR TITLE
Fix min/max values in numeric cast exception message

### DIFF
--- a/src/include/duckdb/common/numeric_utils.hpp
+++ b/src/include/duckdb/common/numeric_utils.hpp
@@ -76,17 +76,17 @@ struct NumericCastImpl<TO, FROM, false> {
 
 		if (!NumericLimits<FROM>::IsSigned() && !NumericLimits<TO>::IsSigned() &&
 		    (unsigned_in < unsigned_min || unsigned_in > unsigned_max)) {
-			ThrowNumericCastError(val, minval, maxval);
+			ThrowNumericCastError(val, static_cast<TO>(unsigned_min), static_cast<TO>(unsigned_max));
 		}
 
 		if (NumericLimits<FROM>::IsSigned() && NumericLimits<TO>::IsSigned() &&
 		    (signed_in < signed_min || signed_in > signed_max)) {
-			ThrowNumericCastError(val, minval, maxval);
+			ThrowNumericCastError(val, static_cast<TO>(signed_min), static_cast<TO>(signed_max));
 		}
 
 		if (NumericLimits<FROM>::IsSigned() != NumericLimits<TO>::IsSigned() &&
 		    (signed_in < signed_min || unsigned_in > unsigned_max)) {
-			ThrowNumericCastError(val, minval, maxval);
+			ThrowNumericCastError(val, static_cast<TO>(signed_min), static_cast<TO>(unsigned_max));
 		}
 
 		return static_cast<TO>(val);


### PR DESCRIPTION
Numeric cast exception message show up with incorrect min/max values. Example:

`Internal Exception: ABORT THROWN BY INTERNAL EXCEPTION: Information loss on integer cast: value -296 outside of target range [-9223372036854775808, 9223372036854775807]`
Clearly -296 is within the range shown. This is because the exception should be provided signed/unsigned values depending on the failure case.