### PR TITLE
Remove delta from extensions built on a nightly basis (vs 1.2-histrionicus)

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -62,11 +62,13 @@ endif()
 ################# DELTA
 # MinGW build is not available, and our current manylinux ci does not have enough storage space to run the rust build
 # for Delta
+if (FALSE)
 if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
             GIT_TAG 6d626173e9efa6615c25eb08d979d1372100d5db
     )
+endif()
 endif()
 
 ################# EXCEL


### PR DESCRIPTION
Currently fails like:
```
[6/1091] Performing configure step for 'delta_kernel'
FAILED: rust/src/delta_kernel-stamp/delta_kernel-configure /Users/runner/work/duckdb/duckdb/build/release/rust/src/delta_kernel-stamp/delta_kernel-configure
cd /Users/runner/work/duckdb/duckdb/build/release/rust/src/delta_kernel && /opt/homebrew/bin/cmake -E env --unset=CC --unset=CXX --unset=LD env cargo update -p chrono --precise 0.4.38 && /opt/homebrew/bin/cmake -E touch /Users/runner/work/duckdb/duckdb/build/release/rust/src/delta_kernel-stamp/delta_kernel-configure
    Updating crates.io index
    Updating crates.io index
error: failed to select a version for the requirement `chrono = "^0.4.40"`
candidate versions found which didn't match: 0.4.38
location searched: crates.io index
required by package `parquet v54.3.0`
    ... which satisfies dependency `parquet_54 = "^54"` (locked to 54.3.0) of package `delta_kernel v0.7.0 (/Users/runner/work/duckdb/duckdb/build/release/rust/src/delta_kernel/kernel)`
    ... which satisfies path dependency `delta_kernel` (locked to 0.7.0) of package `acceptance v0.7.0 (/Users/runner/work/duckdb/duckdb/build/release/rust/src/delta_kernel/acceptance)
```