### PR TITLE
OSX.yml & Windows.yml: remove repository_dispatch, already handled by InvokeCI

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -20,7 +20,6 @@ on:
         type: string
       run_all:
         type: string
-  repository_dispatch:
   push:
     branches-ignore:
       - 'main'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -20,7 +20,6 @@ on:
         type: string
       run_all:
         type: string
-  repository_dispatch:
   push:
     branches-ignore:
       - 'main'


### PR DESCRIPTION
This avoids running the same jobs twice, one via InvokeCI and one via repository_dispatch.
This cuts some unneded CI, but also makes so extensions and binaries are not uploaded twice.