### PR TITLE
Change the STANDARD_MASK_SIZE calculation to use size of template type.

### DIFF
--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -63,7 +63,7 @@ struct TemplatedValidityMask {
 public:
 	static constexpr const idx_t BITS_PER_VALUE = ValidityBuffer::BITS_PER_VALUE;
 	static constexpr const idx_t STANDARD_ENTRY_COUNT = (STANDARD_VECTOR_SIZE + (BITS_PER_VALUE - 1)) / BITS_PER_VALUE;
-	static constexpr const idx_t STANDARD_MASK_SIZE = STANDARD_ENTRY_COUNT * sizeof(validity_t);
+	static constexpr const idx_t STANDARD_MASK_SIZE = STANDARD_ENTRY_COUNT * sizeof(V);
 
 public:
 	inline TemplatedValidityMask() : validity_mask(nullptr), capacity(STANDARD_VECTOR_SIZE) {


### PR DESCRIPTION
Changed the calculation of STANDARD_MASK_SIZE of the `TemplatedValidityMask` class to be consistent with other operations based on the type of the template, instead of using the static type`validity_t`.