### PR TITLE
Regression.yml: Actually checkout proper base.sha commit

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -40,7 +40,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref, '_feature') && 'feature' || 'main') }}
-  BASE_HASH: ${{ inputs.base_hash }}
+  BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || inputs.base_hash }}
 
 jobs:
   regression-test-benchmark-runner:
@@ -90,6 +90,7 @@ jobs:
           make
           git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
           cd duckdb
+          git checkout ${{ env.BASE_SHA }}
           make
           cd ..
 
@@ -104,7 +105,7 @@ jobs:
           if [[ -z "${BASE_HASH}" ]]; then
             export CHECKOUT_HASH=$(gh run list --repo duckdb/duckdb --branch=main --workflow=Regression --event=repository_dispatch --status=completed --json=headSha --limit=1 --jq '.[0].headSha')
           else
-            export CHECKOUT_HASH="$BASE_HASH"
+            export CHECKOUT_HASH="$BASE_SHA"
           fi
           git checkout $CHECKOUT_HASH
           make
@@ -214,6 +215,7 @@ jobs:
           make
           git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
           cd duckdb
+          git checkout ${{ env.BASE_SHA }}
           make
           cd ..
 
@@ -294,6 +296,7 @@ jobs:
           make
           git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
           cd duckdb
+          git checkout ${{ env.BASE_SHA }}
           make
           cd ..
 
@@ -336,6 +339,7 @@ jobs:
           make
           git clone --branch ${{ env.BASE_BRANCH }} https://github.com/duckdb/duckdb.git --depth=1
           cd duckdb
+          git checkout ${{ env.BASE_SHA }}
           make
           cd ..
 


### PR DESCRIPTION
Previously we would blindly checkout `main`, but that might change between when a PR is sent and when it's evaluated (due to other PR being merged in the timeline of a PR).

Now move to use `github.event.pull_request.base.sha` for pull_requests.

Problem discovered with @c-herrewijn looking at hard to justify behaviour on a PR of his.