### PR TITLE
Fix NULL key handling in mark join

### DIFF
--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1113,7 +1113,9 @@ void ScanStructure::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &chi
 		if (!jdata.validity.AllValid()) {
 			for (idx_t i = 0; i < join_keys.size(); i++) {
 				auto jidx = jdata.sel->get_index(i);
-				mask.Set(i, jdata.validity.RowIsValidUnsafe(jidx));
+				if (!jdata.validity.RowIsValidUnsafe(jidx)) {
+					mask.SetInvalid(i);
+				}
 			}
 		}
 	}

--- a/src/execution/join_hashtable.cpp
+++ b/src/execution/join_hashtable.cpp
@@ -1120,12 +1120,9 @@ void ScanStructure::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &chi
 		}
 	}
 	// now set the remaining entries to either true or false based on whether a match was found
-	if (found_match) {
-		for (idx_t i = 0; i < child.size(); i++) {
-			bool_result[i] = found_match[i];
-		}
-	} else {
-		memset(bool_result, 0, sizeof(bool) * child.size());
+	D_ASSERT(found_match);
+	for (idx_t i = 0; i < child.size(); i++) {
+		bool_result[i] = found_match[i];
 	}
 	// if the right side contains NULL values, the result of any FALSE becomes NULL
 	if (ht.has_null) {

--- a/src/execution/operator/join/physical_comparison_join.cpp
+++ b/src/execution/operator/join/physical_comparison_join.cpp
@@ -82,7 +82,6 @@ void PhysicalComparisonJoin::ConstructEmptyJoinResult(JoinType join_type, bool h
 		result.Reference(input);
 	} else if (join_type == JoinType::MARK) {
 		// MARK join with empty hash table
-		D_ASSERT(join_type == JoinType::MARK);
 		D_ASSERT(result.ColumnCount() == input.ColumnCount() + 1);
 		auto &result_vector = result.data.back();
 		D_ASSERT(result_vector.GetType() == LogicalType::BOOLEAN);

--- a/test/sql/subquery/scalar/in_multiple_columns.test
+++ b/test/sql/subquery/scalar/in_multiple_columns.test
@@ -1,0 +1,21 @@
+# name: test/sql/subquery/scalar/in_multiple_columns.test
+# description: Test IN operator with multiple columns
+# group: [scalar]
+
+statement ok
+CREATE TABLE table1(x INTEGER, y INTEGER);
+
+statement ok
+INSERT INTO table1 VALUES (NULL, 2), (1, NULL);
+
+statement ok
+CREATE TABLE table2(i INTEGER);
+
+statement ok
+INSERT INTO table2 VALUES (1), (2), (3);
+
+query I
+SELECT (x, y) IN (SELECT i, i + 1 FROM table2) from table1;
+----
+NULL
+NULL


### PR DESCRIPTION
```sql
CREATE TABLE table1(x INTEGER, y INTEGER);
INSERT INTO table1 VALUES (NULL, 2), (1, NULL);

CREATE TABLE table2(i INTEGER);
INSERT INTO table2 VALUES (1), (2), (3);

SELECT (x, y) IN (SELECT i, i + 1 FROM table2) FROM table1;
```
I've tested in mysql, postgresql and sqlite, the results are all two nulls. But duckdb gives
```
false
null
```

This is because the result mask is overwritten by mask in the last column, ignoring NULLs in other columns.