### PR TITLE
Resolve defaults and column index map by pushing a Projection (instead of executing in the insert itself)

### DIFF
--- a/src/catalog/catalog_entry/view_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/view_catalog_entry.cpp
@@ -36,7 +36,7 @@ unique_ptr<CreateInfo> ViewCatalogEntry::GetInfo() const {
 	result->schema = schema.name;
 	result->view_name = name;
 	result->sql = sql;
-	result->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
+	result->query = query ? unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy()) : nullptr;
 	result->aliases = aliases;
 	result->names = names;
 	result->types = types;

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -2,11 +2,12 @@
 #include "duckdb/execution/operator/persistent/physical_insert.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
-#include "duckdb/storage/data_table.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/execution/operator/persistent/physical_batch_insert.hpp"
+#include "duckdb/execution/operator/projection/physical_projection.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 namespace duckdb {
 

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -72,6 +72,30 @@ bool PhysicalPlanGenerator::UseBatchIndex(PhysicalOperator &plan) {
 	return UseBatchIndex(context, plan);
 }
 
+PhysicalOperator &PhysicalPlanGenerator::ResolveDefaultsProjection(LogicalInsert &op, PhysicalOperator &child) {
+	if (op.column_index_map.empty()) {
+		throw InternalException("No defaults to push");
+	}
+	// columns specified by the user, push a projection
+	vector<LogicalType> types;
+	vector<unique_ptr<Expression>> select_list;
+	for (auto &col : op.table.GetColumns().Physical()) {
+		auto storage_idx = col.StorageOid();
+		auto mapped_index = op.column_index_map[col.Physical()];
+		if (mapped_index == DConstants::INVALID_INDEX) {
+			// push default value
+			select_list.push_back(std::move(op.bound_defaults[storage_idx]));
+		} else {
+			// push reference
+			select_list.push_back(make_uniq<BoundReferenceExpression>(col.Type(), mapped_index));
+		}
+		types.push_back(col.Type());
+	}
+	auto &proj = Make<PhysicalProjection>(std::move(types), std::move(select_list), child.estimated_cardinality);
+	proj.children.push_back(child);
+	return proj;
+}
+
 PhysicalOperator &DuckCatalog::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
                                           optional_ptr<PhysicalOperator> plan) {
 	D_ASSERT(plan);
@@ -92,20 +116,22 @@ PhysicalOperator &DuckCatalog::PlanInsert(ClientContext &context, PhysicalPlanGe
 		// that currently needs to be done for every chunk, which would add a huge bottleneck to parallelized insertion
 		parallel_streaming_insert = false;
 	}
+	if (!op.column_index_map.empty()) {
+		plan = planner.ResolveDefaultsProjection(op, *plan);
+	}
 	if (use_batch_index && !parallel_streaming_insert) {
-		auto &insert =
-		    planner.Make<PhysicalBatchInsert>(op.types, op.table, op.column_index_map, std::move(op.bound_defaults),
-		                                      std::move(op.bound_constraints), op.estimated_cardinality);
+		auto &insert = planner.Make<PhysicalBatchInsert>(op.types, op.table, std::move(op.bound_constraints),
+		                                                 op.estimated_cardinality);
 		insert.children.push_back(*plan);
 		return insert;
 	}
 
 	auto &insert = planner.Make<PhysicalInsert>(
-	    op.types, op.table, op.column_index_map, std::move(op.bound_defaults), std::move(op.bound_constraints),
-	    std::move(op.expressions), std::move(op.set_columns), std::move(op.set_types), op.estimated_cardinality,
-	    op.return_chunk, parallel_streaming_insert && num_threads > 1, op.action_type,
-	    std::move(op.on_conflict_condition), std::move(op.do_update_condition), std::move(op.on_conflict_filter),
-	    std::move(op.columns_to_fetch), op.update_is_del_and_insert);
+	    op.types, op.table, std::move(op.bound_constraints), std::move(op.expressions), std::move(op.set_columns),
+	    std::move(op.set_types), op.estimated_cardinality, op.return_chunk,
+	    parallel_streaming_insert && num_threads > 1, op.action_type, std::move(op.on_conflict_condition),
+	    std::move(op.do_update_condition), std::move(op.on_conflict_filter), std::move(op.columns_to_fetch),
+	    op.update_is_del_and_insert);
 	insert.children.push_back(*plan);
 	return insert;
 }

--- a/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_batch_insert.hpp
@@ -19,28 +19,21 @@ public:
 public:
 	//! INSERT INTO
 	PhysicalBatchInsert(vector<LogicalType> types, TableCatalogEntry &table,
-	                    physical_index_vector_t<idx_t> column_index_map, vector<unique_ptr<Expression>> bound_defaults,
 	                    vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality);
 	//! CREATE TABLE AS
 	PhysicalBatchInsert(LogicalOperator &op, SchemaCatalogEntry &schema, unique_ptr<BoundCreateTableInfo> info,
 	                    idx_t estimated_cardinality);
 
-	//! The map from insert column index to table column index
-	physical_index_vector_t<idx_t> column_index_map;
 	//! The table to insert into
 	optional_ptr<TableCatalogEntry> insert_table;
 	//! The insert types
 	vector<LogicalType> insert_types;
-	//! The default expressions of the columns for which no value is provided
-	vector<unique_ptr<Expression>> bound_defaults;
 	//! The bound constraints for the table
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	//! Table schema, in case of CREATE TABLE AS
 	optional_ptr<SchemaCatalogEntry> schema;
 	//! Create table info, in case of CREATE TABLE AS
 	unique_ptr<BoundCreateTableInfo> info;
-	// Which action to perform on conflict
-	OnConflictAction action_type;
 
 public:
 	// Source interface

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -82,6 +82,9 @@ public:
 		return physical_plan->Make<T>(std::forward<ARGS>(args)...);
 	}
 
+public:
+	PhysicalOperator &ResolveDefaultsProjection(LogicalInsert &op, PhysicalOperator &child);
+
 protected:
 	PhysicalOperator &CreatePlan(LogicalAggregate &op);
 	PhysicalOperator &CreatePlan(LogicalAnyJoin &op);


### PR DESCRIPTION
This cleans up the insert code somewhat - and shouldn't change behavior (since we were effectively just executing these expressions like a projection anyway).