### PR TITLE
[Nested] Enable Varargs in `LIST_CONCAT`

### DIFF
--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -335,9 +335,9 @@ static unique_ptr<BaseStatistics> ListConcatStats(ClientContext &context, Functi
 
 ScalarFunction ListConcatFun::GetFunction() {
 	// The arguments and return types are set in the binder function.
-	auto fun = ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::LIST(LogicalType::ANY)},
-	                          LogicalType::LIST(LogicalType::ANY), ConcatFunction, BindConcatFunction, nullptr,
+	auto fun = ScalarFunction({}, LogicalType::LIST(LogicalType::ANY), ConcatFunction, BindConcatFunction, nullptr,
 	                          ListConcatStats);
+	fun.varargs = LogicalType::LIST(LogicalType::ANY);
 	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 	return fun;
 }

--- a/test/sql/function/list/list_concat.test
+++ b/test/sql/function/list/list_concat.test
@@ -41,6 +41,36 @@ SELECT list_concat([1, 2], [])
 ----
 [1, 2]
 
+query T
+SELECT list_concat([1, 2], [3, 4], [5, 6])
+----
+[1, 2, 3, 4, 5, 6]
+
+query T
+SELECT list_concat([1, 2], [3, 4], [])
+----
+[1, 2, 3, 4]
+
+query T
+SELECT list_concat([1, 2], [], [5, 6])
+----
+[1, 2, 5, 6]
+
+query T
+SELECT list_concat([], [3, 4], [5, 6])
+----
+[3, 4, 5, 6]
+
+query T
+SELECT list_concat([], [], [5, 6])
+----
+[5, 6]
+
+query T
+SELECT list_concat([1, 2], [3, 4], [5, 6], [7, 8])
+----
+[1, 2, 3, 4, 5, 6, 7, 8]
+
 statement error
 SELECT list_concat([1, 2], 3)
 ----
@@ -97,20 +127,40 @@ SELECT list_concat([NULL], [3, 4])
 [NULL, 3, 4]
 
 query T
+SELECT list_concat([1, 2], [3, 4], [NULL])
+----
+[1, 2, 3, 4, NULL]
+
+# nested types
+query T
 SELECT list_concat([[1, 2]], [[3, 4]])
 ----
 [[1, 2], [3, 4]]
 
-# nested types
+query T
+SELECT list_concat([[1, 2]], [[3, 4]], [[5, 6]])
+----
+[[1, 2], [3, 4], [5, 6]]
+
 query T
 SELECT list_concat([{a: 1}, {a: 2}], [{a: 3}, {a: 4}])
 ----
 [{'a': 1}, {'a': 2}, {'a': 3}, {'a': 4}]
 
 query T
+SELECT list_concat([{a: 1}, {a: 2}], [{a: 3}, {a: 4}], [{a: 5}, {a: 6}])
+----
+[{'a': 1}, {'a': 2}, {'a': 3}, {'a': 4}, {'a': 5}, {'a': 6}]
+
+query T
 SELECT list_concat([[[1], [2]], [[3], [4]]], [[[5], [6]], [[7], [8]]])
 ----
 [[[1], [2]], [[3], [4]], [[5], [6]], [[7], [8]]]
+
+query T
+SELECT list_concat([[[1], [2]], [[3], [4]]], [[[5], [6]], [[7], [8]]], [[[9], [10]], [[11], [12]]])
+----
+[[[1], [2]], [[3], [4]], [[5], [6]], [[7], [8]], [[9], [10]], [[11], [12]]]
 
 statement ok
 CREATE TABLE test AS SELECT range % 4 i, range j, range k FROM range(16)
@@ -125,6 +175,14 @@ SELECT i, list_concat(j, k) FROM lists
 1	[1, 5, 9, 13, 1, 5, 9, 13]
 2	[2, 6, 10, 14, 2, 6, 10, 14]
 3	[3, 7, 11, 15, 3, 7, 11, 15]
+
+query II rowsort
+SELECT i, list_concat(j, k, j, k, j, k) FROM lists
+----
+0	[0, 4, 8, 12, 0, 4, 8, 12, 0, 4, 8, 12, 0, 4, 8, 12, 0, 4, 8, 12, 0, 4, 8, 12]
+1	[1, 5, 9, 13, 1, 5, 9, 13, 1, 5, 9, 13, 1, 5, 9, 13, 1, 5, 9, 13, 1, 5, 9, 13]
+2	[2, 6, 10, 14, 2, 6, 10, 14, 2, 6, 10, 14, 2, 6, 10, 14, 2, 6, 10, 14, 2, 6, 10, 14]
+3	[3, 7, 11, 15, 3, 7, 11, 15, 3, 7, 11, 15, 3, 7, 11, 15, 3, 7, 11, 15, 3, 7, 11, 15]
 
 statement error
 SELECT i, list_concat(j, cast(k AS VARCHAR)) FROM lists

--- a/test/sql/function/list/list_concat.test
+++ b/test/sql/function/list/list_concat.test
@@ -131,6 +131,16 @@ SELECT list_concat([1, 2], [3, 4], [NULL])
 ----
 [1, 2, 3, 4, NULL]
 
+query T
+SELECT list_concat([1, 2], [3, 4], NULL)
+----
+[1, 2, 3, 4]
+
+query T
+SELECT list_concat(NULL, [3, 4], [5, 6])
+----
+[3, 4, 5, 6]
+
 # nested types
 query T
 SELECT list_concat([[1, 2]], [[3, 4]])
@@ -266,3 +276,5 @@ statement error
 SELECT concat([42], [84], 'str')
 ----
 an explicit cast is required
+
+

--- a/test/sql/function/string/test_concat_binding.test
+++ b/test/sql/function/string/test_concat_binding.test
@@ -58,10 +58,10 @@ select 'hi' || NULL;
 ----
 NULL
 
-statement error
+query I
 select list_concat([1], [2], [3]);
 ----
-Binder Error: No function matches the given name and argument types 'list_concat(INTEGER[], INTEGER[], INTEGER[])'.
+[1, 2, 3]
 
 query I
 select [1] || [2] || [3];

--- a/test/sql/function/string/test_concat_binding.test
+++ b/test/sql/function/string/test_concat_binding.test
@@ -53,6 +53,16 @@ select concat([1], 'hello');
 ----
 Binder Error: Cannot concatenate types INTEGER[] and VARCHAR
 
+statement error
+SELECT list_concat([1, 2], ['3', '4'])
+----
+Binder Error: Cannot concatenate lists of types INTEGER[] and VARCHAR[]
+
+statement error
+SELECT list_concat([1, 2], 4)
+----
+Binder Error: No function matches the given name and argument types 'list_concat(INTEGER[], INTEGER_LITERAL)'. You might need to add explicit type casts.
+
 query I
 select 'hi' || NULL;
 ----

--- a/test/sql/types/list/list_concat_null.test
+++ b/test/sql/types/list/list_concat_null.test
@@ -49,3 +49,8 @@ query I
 select list_concat([42]::INT[1], [43]::INT[1], NULL::INT[1], [44]::INT[1], NULL::INT[1], [45]::INT[1]);
 ----
 [42, 43, 44, 45]
+
+query I
+select list_concat([1]::INT[1], [2, 3]::INT[2]);
+----
+[1, 2, 3]

--- a/test/sql/types/list/list_concat_null.test
+++ b/test/sql/types/list/list_concat_null.test
@@ -14,6 +14,12 @@ SELECT b || NULL from x1;
 statement ok
 SELECT NULL || NULL from x1;
 
+statement ok
+SELECT NULL || b || NULL from x1;
+
+statement ok
+SELECT b || NULL || b from x1;
+
 query I
 select concat([42]);
 ----
@@ -26,5 +32,20 @@ select concat([42], [43], [], [44], [], [45]);
 
 query I
 select concat([42]::INT[1], [43]::INT[1], NULL::INT[1], [44]::INT[1], NULL::INT[1], [45]::INT[1]);
+----
+[42, 43, 44, 45]
+
+query I
+select list_concat([42]);
+----
+[42]
+
+query I
+select list_concat([42], [43], [], [44], [], [45]);
+----
+[42, 43, 44, 45]
+
+query I
+select list_concat([42]::INT[1], [43]::INT[1], NULL::INT[1], [44]::INT[1], NULL::INT[1], [45]::INT[1]);
 ----
 [42, 43, 44, 45]


### PR DESCRIPTION
Adds `varargs` to `LIST_CONCAT`, as well as some tests.

Fixes #16639