### PR TITLE
Fix issue with sorting dev versions in pypi_cleanup.py script to keep on PyPi the most recent dev versions

### DIFF
--- a/scripts/pypi_cleanup.py
+++ b/scripts/pypi_cleanup.py
@@ -144,7 +144,9 @@ class PypiCleanup:
                 if version_key in releases_by_date.keys():
                     pkg_vers.extend(versions)
                 else:
-                    pkg_vers.extend(versions[:-how_many_dev_versions_to_keep])
+                    # sort by the suffix casted to int to keep only the most recent builds
+                    sorted_versions = sorted(versions, key=lambda x: int(x.split('dev')[-1]))
+                    pkg_vers.extend(sorted_versions[:-how_many_dev_versions_to_keep])
 
             if not actually_delete:
                 print("Following pkg_vers can be deleted: ", pkg_vers)


### PR DESCRIPTION
In the PR https://github.com/duckdb/duckdb/pull/16634 I created a bug which created a problem, when last nightly branch `v1.2-histironicus` uploaded `1.2.2.dev132`, and then got deleted by `scripts/pypi_cleanup.py` triggered by the main run ([run link](https://github.com/duckdb/duckdb/actions/runs/14096235756/job/39498278728#step:5:18))
(this was raised by Boaz at MD)

The issue appeared because of the string sort, when `1.2.2.dev128` is smaller than `1.2.2.dev96` since 1 < 9.

This PR adds a lambda function to sort by dev version number casted to int.
Tested with decreased number of versions to keep and
1. append '1.2.2.dev132' value to list before sorting:
```
defaultdict(<class 'list'>, {'1.2.2': ['1.2.2.dev83', '1.2.2.dev96', '1.2.2.dev132'], '1.3.0': ['1.3.0.dev1734', '1.3.0.dev1738', '1.3.0.dev1793', '1.3.0.dev1894']})
Following pkg_vers can be deleted:  ['1.2.2.dev83', '1.3.0.dev1734', '1.3.0.dev1738']
```
2. insert '1.2.2.dev132' value to the beginning of the list before sorting:
```
defaultdict(<class 'list'>, {'1.2.2': ['1.2.2.dev132', '1.2.2.dev83', '1.2.2.dev96'], '1.3.0': ['1.3.0.dev1734', '1.3.0.dev1738', '1.3.0.dev1793', '1.3.0.dev1894']})
Following pkg_vers can be deleted:  ['1.2.2.dev83', '1.3.0.dev1734', '1.3.0.dev1738']
```