### PR TITLE
Internal #4490: Window Threading Cleanup

### DIFF
--- a/src/common/sort/partition_state.cpp
+++ b/src/common/sort/partition_state.cpp
@@ -1,11 +1,8 @@
 #include "duckdb/common/sort/partition_state.hpp"
 
-#include "duckdb/common/types/column/column_data_consumer.hpp"
 #include "duckdb/common/row_operations/row_operations.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/parallel/executor_task.hpp"
-
-#include <numeric>
 
 namespace duckdb {
 
@@ -476,7 +473,7 @@ void PartitionLocalMergeState::ExecuteTask() {
 bool PartitionGlobalMergeState::AssignTask(PartitionLocalMergeState &local_state) {
 	lock_guard<mutex> guard(lock);
 
-	if (tasks_assigned >= total_tasks) {
+	if (tasks_assigned >= total_tasks && !TryPrepareNextStage()) {
 		return false;
 	}
 
@@ -495,15 +492,13 @@ void PartitionGlobalMergeState::CompleteTask() {
 }
 
 bool PartitionGlobalMergeState::TryPrepareNextStage() {
-	lock_guard<mutex> guard(lock);
-
 	if (tasks_completed < total_tasks) {
 		return false;
 	}
 
 	tasks_assigned = tasks_completed = 0;
 
-	switch (stage) {
+	switch (stage.load()) {
 	case PartitionSortStage::INIT:
 		//	If the partitions are unordered, don't scan in parallel
 		//	because it produces non-deterministic orderings.
@@ -626,23 +621,6 @@ bool PartitionGlobalMergeStates::ExecuteTask(PartitionLocalMergeState &local_sta
 			}
 
 			// Try to assign work for this hash group to this thread
-			if (global_state->AssignTask(local_state)) {
-				// We assigned a task to this thread!
-				// Break out of this loop to re-enter the top-level loop and execute the task
-				break;
-			}
-
-			// Hash group global state couldn't assign a task to this thread
-			// Try to prepare the next stage
-			if (!global_state->TryPrepareNextStage()) {
-				// This current hash group is not yet done
-				// But we were not able to assign a task for it to this thread
-				// See if the next hash group is better
-				continue;
-			}
-
-			// We were able to prepare the next stage for this hash group!
-			// Try to assign a task once more
 			if (global_state->AssignTask(local_state)) {
 				// We assigned a task to this thread!
 				// Break out of this loop to re-enter the top-level loop and execute the task

--- a/src/include/duckdb/common/sort/partition_state.hpp
+++ b/src/include/duckdb/common/sort/partition_state.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "duckdb/common/sort/sort.hpp"
-#include "duckdb/common/types/column/partitioned_column_data.hpp"
 #include "duckdb/common/radix_partitioning.hpp"
 #include "duckdb/parallel/base_pipeline_event.hpp"
 
@@ -160,7 +159,6 @@ public:
 	explicit PartitionGlobalMergeState(PartitionGlobalSinkState &sink);
 
 	bool IsFinished() const {
-		lock_guard<mutex> guard(lock);
 		return stage == PartitionSortStage::FINISHED;
 	}
 
@@ -180,7 +178,7 @@ public:
 
 private:
 	mutable mutex lock;
-	PartitionSortStage stage;
+	atomic<PartitionSortStage> stage;
 	idx_t total_tasks;
 	idx_t tasks_assigned;
 	idx_t tasks_completed;

--- a/src/include/duckdb/common/types/validity_mask.hpp
+++ b/src/include/duckdb/common/types/validity_mask.hpp
@@ -112,16 +112,11 @@ public:
 			auto entry = GetValidityEntry(entry_idx++);
 			// Handle ragged end (if not exactly multiple of BITS_PER_VALUE)
 			if (entry_idx == entry_count && count % BITS_PER_VALUE != 0) {
-				idx_t idx_in_entry;
-				GetEntryIndex(count, entry_idx, idx_in_entry);
-				for (idx_t i = 0; i < idx_in_entry; ++i) {
-					valid += idx_t(RowIsValid(entry, i));
-				}
-				break;
-			}
-
-			// Handle all set
-			if (AllValid(entry)) {
+				const auto shift = BITS_PER_VALUE - (count % BITS_PER_VALUE);
+				const auto mask = ValidityBuffer::MAX_ENTRY >> shift;
+				entry &= mask;
+			} else if (AllValid(entry)) {
+				// Handle all set
 				valid += BITS_PER_VALUE;
 				continue;
 			}


### PR DESCRIPTION
* Convert PartitionGlobalMergeState::IsFinished to be lock-free
* Reduce locking in PartitionGlobalMergeStates::ExecuteTask
* Convert TaskErrorManager::HasError to be lock-free
* Replace ragged loop in TemplatedValidityMask::CountValid with masking