### PR TITLE
Do not pushdown filters which bindings only match the right side of the left join

### DIFF
--- a/test/optimizer/pushdown/issue_16863.test
+++ b/test/optimizer/pushdown/issue_16863.test
@@ -16,4 +16,3 @@ SELECT t1.c1, (t1.c1 IS NULL)
 FROM t1 RIGHT JOIN (SELECT NULL AS col0 FROM t1) AS sub0 ON true
 WHERE (t1.c1 IS NULL);
 ----
-NULL	false

--- a/test/optimizer/pushdown/issue_16863.test
+++ b/test/optimizer/pushdown/issue_16863.test
@@ -1,0 +1,19 @@
+# name: test/optimizer/pushdown/issue_16863.test
+# description: Test right join filter lost in filter pushdown
+# group: [pushdown]
+
+statement ok
+pragma enable_verification
+
+statement ok
+CREATE TABLE t1 (c1 DATE);
+
+statement ok
+INSERT INTO t1 (c1) VALUES ('2023-10-31');
+
+query II
+SELECT t1.c1, (t1.c1 IS NULL)
+FROM t1 RIGHT JOIN (SELECT NULL AS col0 FROM t1) AS sub0 ON true
+WHERE (t1.c1 IS NULL);
+----
+NULL	false


### PR DESCRIPTION
This PR fixes #16863. The filter can be lost when the binding only matches the right side of the left join.