### PR TITLE
ICU: Unify TimeZone accessing code

### DIFF
--- a/extension/icu/icu-datefunc.cpp
+++ b/extension/icu/icu-datefunc.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "icu-helpers.hpp"
 #include "unicode/ucal.h"
 
 namespace duckdb {
@@ -72,19 +73,19 @@ unique_ptr<FunctionData> ICUDateFunc::Bind(ClientContext &context, ScalarFunctio
 }
 
 bool ICUDateFunc::TrySetTimeZone(icu::Calendar *calendar, const string_t &tz_id) {
-	auto tz = icu::TimeZone::createTimeZone(icu::UnicodeString::fromUTF8(icu::StringPiece(tz_id.GetString())));
-	if (*tz == icu::TimeZone::getUnknown()) {
-		delete tz;
+	string tz_str = tz_id.GetString();
+	auto tz = ICUHelpers::TryGetTimeZone(tz_str);
+	if (!tz) {
 		return false;
 	}
-	calendar->adoptTimeZone(tz);
+	calendar->adoptTimeZone(tz.release());
 	return true;
 }
 
 void ICUDateFunc::SetTimeZone(icu::Calendar *calendar, const string_t &tz_id) {
-	if (!TrySetTimeZone(calendar, tz_id)) {
-		throw NotImplementedException("Unknown TimeZone '%s'", tz_id.GetString());
-	}
+	string tz_str = tz_id.GetString();
+	auto tz = ICUHelpers::GetTimeZone(tz_str);
+	calendar->adoptTimeZone(tz.release());
 }
 
 timestamp_t ICUDateFunc::GetTimeUnsafe(icu::Calendar *calendar, uint64_t micros) {

--- a/extension/icu/include/icu-helpers.hpp
+++ b/extension/icu/include/icu-helpers.hpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// icu-helpers.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb.hpp"
+#include "unicode/timezone.h"
+
+namespace duckdb {
+
+struct ICUHelpers {
+	//! Tries to get a time zone - returns nullptr if the timezone is not found
+	static unique_ptr<icu::TimeZone> TryGetTimeZone(string &tz_str);
+	//! Gets a time zone - throws an error if the timezone is not found
+	static unique_ptr<icu::TimeZone> GetTimeZone(string &tz_str);
+};
+
+} // namespace duckdb

--- a/test/sql/timezone/test_icu_timezone.test
+++ b/test/sql/timezone/test_icu_timezone.test
@@ -30,6 +30,18 @@ SELECT  '2001-02-16 20:38:40'::TIMESTAMP AT TIME ZONE 'America/Denver';
 ----
 2001-02-16 19:38:40-08
 
+# case insensitive
+query I
+SELECT  '2001-02-16 20:38:40'::TIMESTAMP AT TIME ZONE 'america/denver';
+----
+2001-02-16 19:38:40-08
+
+# recommendation
+statement error
+SELECT  '2001-02-16 20:38:40'::TIMESTAMP AT TIME ZONE 'America/Donver';
+----
+America/Denver
+
 query I
 SELECT '2001-02-16 20:38:40-05'::TIMESTAMPTZ AT TIME ZONE 'America/Denver';
 ----


### PR DESCRIPTION
Unify the TimeZone accessing code so that we accept the same time zones everywhere. Previously this would fail:

```sql
D select timestamptz '2020-01-01' at time zone 'utc';
Not implemented Error:
Unknown TimeZone 'utc'
```

But this would work:

```sql
set timezone='utc';
```

Similarly, we now throw the "candidates" message everywhere as well.