### PR TITLE
Rework ICU age computation to convert to a timestamp and use the regular interval age computation

### DIFF
--- a/extension/icu/icu-dateadd.cpp
+++ b/extension/icu/icu-dateadd.cpp
@@ -168,15 +168,9 @@ interval_t ICUCalendarSub::Operation(timestamp_t end_date, timestamp_t start_dat
 
 template <>
 interval_t ICUCalendarAge::Operation(timestamp_t end_date, timestamp_t start_date, icu::Calendar *calendar) {
-	if (start_date > end_date) {
-		auto negated = Operation<timestamp_t, timestamp_t, interval_t>(start_date, end_date, calendar);
-		return {-negated.months, -negated.days, -negated.micros};
-	}
-	auto start_data = ICUHelpers::DecomposeTimestamp(timestamp_tz_t(start_date.value), calendar);
-	auto end_data = ICUHelpers::DecomposeTimestamp(timestamp_tz_t(end_date.value), calendar);
-	auto start_ts = ICUHelpers::ToTimestamp(start_data);
-	auto end_ts = ICUHelpers::ToTimestamp(end_data);
-	return Interval::GetAge(end_ts, start_ts);
+	auto start_data = ICUHelpers::GetComponents(timestamp_tz_t(start_date.value), calendar);
+	auto end_data = ICUHelpers::GetComponents(timestamp_tz_t(end_date.value), calendar);
+	return Interval::GetAge(end_data, start_data, start_date > end_date);
 }
 
 struct ICUDateAdd : public ICUDateFunc {

--- a/extension/icu/icu-list-range.cpp
+++ b/extension/icu/icu-list-range.cpp
@@ -60,7 +60,7 @@ struct ICUListRange : public ICUDateFunc {
 			increment_value = ListIncrementValue(row_idx);
 		}
 
-		uint64_t ListLength(idx_t row_idx, icu::Calendar *calendar) {
+		uint64_t ListLength(idx_t row_idx, TZCalendar &calendar) {
 			timestamp_t start_value;
 			timestamp_t end_value;
 			interval_t increment_value;
@@ -68,7 +68,7 @@ struct ICUListRange : public ICUDateFunc {
 			return ListLength(start_value, end_value, increment_value, INCLUSIVE_BOUND, calendar);
 		}
 
-		void Increment(timestamp_t &input, interval_t increment, icu::Calendar *calendar) {
+		void Increment(timestamp_t &input, interval_t increment, TZCalendar &calendar) {
 			input = Add(calendar, input, increment);
 		}
 
@@ -77,7 +77,7 @@ struct ICUListRange : public ICUDateFunc {
 		UnifiedVectorFormat vdata[3];
 
 		uint64_t ListLength(timestamp_t start_value, timestamp_t end_value, interval_t increment_value,
-		                    bool inclusive_bound, icu::Calendar *calendar) {
+		                    bool inclusive_bound, TZCalendar &calendar) {
 			bool is_positive = increment_value.months > 0 || increment_value.days > 0 || increment_value.micros > 0;
 			bool is_negative = increment_value.months < 0 || increment_value.days < 0 || increment_value.micros < 0;
 			if (!is_negative && !is_positive) {
@@ -130,8 +130,7 @@ struct ICUListRange : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &bind_info = func_expr.bind_info->Cast<BindData>();
-		CalendarPtr calendar_ptr(bind_info.calendar->clone());
-		auto calendar = calendar_ptr.get();
+		TZCalendar calendar(*bind_info.calendar, bind_info.cal_setting);
 
 		RangeInfoStruct<INCLUSIVE_BOUND> info(args);
 		idx_t args_size = 1;

--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -473,10 +473,10 @@ struct ICUStrftime : public ICUDateFunc {
 
 		idx_t year_length;
 		bool add_bc;
-		const auto date_len = DateToStringCast::Length(ts_data.year, year_length, add_bc);
+		const auto date_len = DateToStringCast::YearLength(ts_data.year, year_length, add_bc);
 
 		char micro_buffer[6];
-		const auto time_len = TimeToStringCast::Length(ts_data.microsecond, micro_buffer);
+		const auto time_len = TimeToStringCast::MicrosLength(ts_data.microsecond, micro_buffer);
 
 		auto offset = ExtractField(calendar, UCAL_ZONE_OFFSET) + ExtractField(calendar, UCAL_DST_OFFSET);
 		offset /= Interval::MSECS_PER_SEC;

--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -1,5 +1,6 @@
 #include "include/icu-strptime.hpp"
 #include "include/icu-datefunc.hpp"
+#include "include/icu-helpers.hpp"
 
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
@@ -17,6 +18,28 @@
 
 namespace duckdb {
 
+TimestampData ICUHelpers::DecomposeTimestamp(timestamp_tz_t ts, icu::Calendar *calendar) {
+	// Get the parts in the given time zone
+	uint64_t micros = ICUDateFunc::SetTime(calendar, timestamp_t(ts.value));
+
+	TimestampData ts_data;
+	ts_data.date_units[0] = ICUDateFunc::ExtractField(calendar, UCAL_EXTENDED_YEAR);
+	ts_data.date_units[1] = ICUDateFunc::ExtractField(calendar, UCAL_MONTH) + 1;
+	ts_data.date_units[2] = ICUDateFunc::ExtractField(calendar, UCAL_DATE);
+
+	ts_data.time_units[0] = ICUDateFunc::ExtractField(calendar, UCAL_HOUR_OF_DAY);
+	ts_data.time_units[1] = ICUDateFunc::ExtractField(calendar, UCAL_MINUTE);
+	ts_data.time_units[2] = ICUDateFunc::ExtractField(calendar, UCAL_SECOND);
+	ts_data.time_units[3] = UnsafeNumericCast<int32_t>(
+	    ICUDateFunc::ExtractField(calendar, UCAL_MILLISECOND) * Interval::MICROS_PER_MSEC + micros);
+	return ts_data;
+}
+
+timestamp_t ICUHelpers::ToTimestamp(TimestampData data) {
+	date_t date_val = Date::FromDate(data.date_units[0], data.date_units[1], data.date_units[2]);
+	dtime_t time_val = Time::FromTime(data.time_units[0], data.time_units[1], data.time_units[2], data.time_units[3]);
+	return Timestamp::FromDatetime(date_val, time_val);
+}
 struct ICUStrptime : public ICUDateFunc {
 	using ParseResult = StrpTimeFormat::ParseResult;
 
@@ -445,27 +468,15 @@ struct ICUStrftime : public ICUDateFunc {
 			return StringVector::AddString(result, Timestamp::ToString(input));
 		}
 
-		// Get the parts in the given time zone
-		uint64_t micros = SetTime(calendar, input);
-
-		int32_t date_units[3];
-		date_units[0] = ExtractField(calendar, UCAL_EXTENDED_YEAR); // strftime doesn't understand eras.
-		date_units[1] = ExtractField(calendar, UCAL_MONTH) + 1;
-		date_units[2] = ExtractField(calendar, UCAL_DATE);
-
-		int32_t time_units[4];
-		time_units[0] = ExtractField(calendar, UCAL_HOUR_OF_DAY);
-		time_units[1] = ExtractField(calendar, UCAL_MINUTE);
-		time_units[2] = ExtractField(calendar, UCAL_SECOND);
-		time_units[3] =
-		    UnsafeNumericCast<int32_t>(ExtractField(calendar, UCAL_MILLISECOND) * Interval::MICROS_PER_MSEC + micros);
+		// decompose the timestamp
+		TimestampData ts_data = ICUHelpers::DecomposeTimestamp(timestamp_tz_t(input.value), calendar);
 
 		idx_t year_length;
 		bool add_bc;
-		const auto date_len = DateToStringCast::Length(date_units, year_length, add_bc);
+		const auto date_len = DateToStringCast::Length(ts_data.date_units, year_length, add_bc);
 
 		char micro_buffer[6];
-		const auto time_len = TimeToStringCast::Length(time_units, micro_buffer);
+		const auto time_len = TimeToStringCast::Length(ts_data.time_units, micro_buffer);
 
 		auto offset = ExtractField(calendar, UCAL_ZONE_OFFSET) + ExtractField(calendar, UCAL_DST_OFFSET);
 		offset /= Interval::MSECS_PER_SEC;
@@ -479,11 +490,11 @@ struct ICUStrftime : public ICUDateFunc {
 		string_t target = StringVector::EmptyString(result, len);
 		auto buffer = target.GetDataWriteable();
 
-		DateToStringCast::Format(buffer, date_units, year_length, add_bc);
+		DateToStringCast::Format(buffer, ts_data.date_units, year_length, add_bc);
 		buffer += date_len;
 		*buffer++ = ' ';
 
-		TimeToStringCast::Format(buffer, time_len, time_units, micro_buffer);
+		TimeToStringCast::Format(buffer, time_len, ts_data.time_units, micro_buffer);
 		buffer += time_len;
 
 		memcpy(buffer, offset_str.c_str(), offset_len);

--- a/extension/icu/icu-table-range.cpp
+++ b/extension/icu/icu-table-range.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "include/icu-datefunc.hpp"
 #include "unicode/calendar.h"
+#include "tz_calendar.hpp"
 
 namespace duckdb {
 
@@ -151,8 +152,7 @@ struct ICUTableRange {
 	                                                DataChunk &input, DataChunk &output) {
 		auto &bind_data = data_p.bind_data->Cast<ICURangeBindData>();
 		auto &state = data_p.local_state->Cast<ICURangeLocalState>();
-		CalendarPtr calendar_ptr(bind_data.calendar->clone());
-		auto calendar = calendar_ptr.get();
+		TZCalendar calendar(*bind_data.calendar, bind_data.cal_setting);
 		while (true) {
 			if (!state.initialized_row) {
 				// initialize for the current input row

--- a/extension/icu/icu-timebucket.cpp
+++ b/extension/icu/icu-timebucket.cpp
@@ -62,7 +62,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 	}
 
 	static inline timestamp_t WidthConvertibleToMicrosCommon(int64_t bucket_width_micros, const timestamp_t ts,
-	                                                         const timestamp_t origin, icu::Calendar *calendar) {
+	                                                         const timestamp_t origin, TZCalendar &calendar) {
 		if (!bucket_width_micros) {
 			throw OutOfRangeException("Can't bucket using zero microseconds");
 		}
@@ -78,13 +78,13 @@ struct ICUTimeBucket : public ICUDateFunc {
 	}
 
 	static inline timestamp_t WidthConvertibleToDaysCommon(int32_t bucket_width_days, const timestamp_t ts,
-	                                                       const timestamp_t origin, icu::Calendar *calendar) {
+	                                                       const timestamp_t origin, TZCalendar &calendar) {
 		if (!bucket_width_days) {
 			throw OutOfRangeException("Can't bucket using zero days");
 		}
 		const auto sub_days = SubtractFactory(DatePartSpecifier::DAY);
 
-		int64_t ts_days = sub_days(calendar, origin, ts);
+		int64_t ts_days = sub_days(calendar.GetICUCalendar(), origin, ts);
 		int64_t result_days = (ts_days / bucket_width_days) * bucket_width_days;
 		if (result_days < NumericLimits<int32_t>::Minimum() || result_days > NumericLimits<int32_t>::Maximum()) {
 			throw OutOfRangeException("Timestamp out of range");
@@ -100,13 +100,14 @@ struct ICUTimeBucket : public ICUDateFunc {
 	}
 
 	static inline timestamp_t WidthConvertibleToMonthsCommon(int32_t bucket_width_months, const timestamp_t ts,
-	                                                         const timestamp_t origin, icu::Calendar *calendar) {
+	                                                         const timestamp_t origin, TZCalendar &calendar_p) {
 		if (!bucket_width_months) {
 			throw OutOfRangeException("Can't bucket using zero months");
 		}
 		const auto trunc_months = TruncationFactory(DatePartSpecifier::MONTH);
 		const auto sub_months = SubtractFactory(DatePartSpecifier::MONTH);
 
+		auto calendar = calendar_p.GetICUCalendar();
 		uint64_t tmp_micros = SetTime(calendar, ts);
 		trunc_months(calendar, tmp_micros);
 		timestamp_t truncated_ts = GetTimeUnsafe(calendar, tmp_micros);
@@ -126,7 +127,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 			    SubtractOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(result_months, bucket_width_months);
 		}
 
-		return Add(calendar, truncated_origin, interval_t {static_cast<int32_t>(result_months), 0, 0});
+		return Add(calendar_p, truncated_origin, interval_t {static_cast<int32_t>(result_months), 0, 0});
 	}
 
 	template <typename TA, typename TB, typename TR, typename OP>
@@ -157,7 +158,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 	}
 
 	struct WidthConvertibleToMicrosBinaryOperator {
-		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, icu::Calendar *calendar) {
+		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -167,7 +168,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 	};
 
 	struct WidthConvertibleToDaysBinaryOperator {
-		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, icu::Calendar *calendar) {
+		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -177,7 +178,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 	};
 
 	struct WidthConvertibleToMonthsBinaryOperator {
-		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, icu::Calendar *calendar) {
+		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -187,7 +188,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 	};
 
 	struct BinaryOperator {
-		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, icu::Calendar *calendar) {
+		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, TZCalendar &calendar) {
 			BucketWidthType bucket_width_type = ClassifyBucketWidthErrorThrow(bucket_width);
 			switch (bucket_width_type) {
 			case BucketWidthType::CONVERTIBLE_TO_MICROS:
@@ -204,7 +205,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct OffsetWidthConvertibleToMicrosTernaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, interval_t offset,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -217,7 +218,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct OffsetWidthConvertibleToDaysTernaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, interval_t offset,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -230,7 +231,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct OffsetWidthConvertibleToMonthsTernaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, interval_t offset,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -243,7 +244,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct OffsetTernaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, interval_t offset,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			BucketWidthType bucket_width_type = ClassifyBucketWidthErrorThrow(bucket_width);
 			switch (bucket_width_type) {
 			case BucketWidthType::CONVERTIBLE_TO_MICROS:
@@ -260,7 +261,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct OriginWidthConvertibleToMicrosTernaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, timestamp_t origin,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -270,7 +271,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct OriginWidthConvertibleToDaysTernaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, timestamp_t origin,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -280,7 +281,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct OriginWidthConvertibleToMonthsTernaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, timestamp_t origin,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -290,7 +291,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct OriginTernaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, timestamp_t origin,
-		                                    ValidityMask &mask, idx_t idx, icu::Calendar *calendar) {
+		                                    ValidityMask &mask, idx_t idx, TZCalendar &calendar) {
 			if (!Value::IsFinite(origin)) {
 				mask.SetInvalid(idx);
 				return timestamp_t(0);
@@ -311,7 +312,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct TimeZoneWidthConvertibleToMicrosBinaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, timestamp_t origin,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -321,7 +322,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct TimeZoneWidthConvertibleToDaysBinaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, timestamp_t origin,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -331,7 +332,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct TimeZoneWidthConvertibleToMonthsBinaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, timestamp_t origin,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar) {
 			if (!Value::IsFinite(ts)) {
 				return ts;
 			}
@@ -341,7 +342,8 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 	struct TimeZoneTernaryOperator {
 		static inline timestamp_t Operation(interval_t bucket_width, timestamp_t ts, string_t tz,
-		                                    icu::Calendar *calendar) {
+		                                    TZCalendar &calendar_p) {
+			auto calendar = calendar_p.GetICUCalendar();
 			SetTimeZone(calendar, tz);
 
 			timestamp_t origin;
@@ -349,13 +351,13 @@ struct ICUTimeBucket : public ICUDateFunc {
 			switch (bucket_width_type) {
 			case BucketWidthType::CONVERTIBLE_TO_MICROS:
 				origin = ICUDateFunc::FromNaive(calendar, Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
-				return TimeZoneWidthConvertibleToMicrosBinaryOperator::Operation(bucket_width, ts, origin, calendar);
+				return TimeZoneWidthConvertibleToMicrosBinaryOperator::Operation(bucket_width, ts, origin, calendar_p);
 			case BucketWidthType::CONVERTIBLE_TO_DAYS:
 				origin = ICUDateFunc::FromNaive(calendar, Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
-				return TimeZoneWidthConvertibleToDaysBinaryOperator::Operation(bucket_width, ts, origin, calendar);
+				return TimeZoneWidthConvertibleToDaysBinaryOperator::Operation(bucket_width, ts, origin, calendar_p);
 			case BucketWidthType::CONVERTIBLE_TO_MONTHS:
 				origin = ICUDateFunc::FromNaive(calendar, Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_2));
-				return TimeZoneWidthConvertibleToMonthsBinaryOperator::Operation(bucket_width, ts, origin, calendar);
+				return TimeZoneWidthConvertibleToMonthsBinaryOperator::Operation(bucket_width, ts, origin, calendar_p);
 			default:
 				throw NotImplementedException("Bucket type not implemented for ICU TIME_BUCKET");
 			}
@@ -367,9 +369,8 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.bind_info->Cast<BindData>();
-		CalendarPtr calendar_ptr(info.calendar->clone());
-		auto calendar = calendar_ptr.get();
-		SetTimeZone(calendar, string_t("UTC"));
+		TZCalendar calendar(*info.calendar, info.cal_setting);
+		SetTimeZone(calendar.GetICUCalendar(), string_t("UTC"));
 
 		auto &bucket_width_arg = args.data[0];
 		auto &ts_arg = args.data[1];
@@ -423,9 +424,8 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.bind_info->Cast<BindData>();
-		CalendarPtr calendar_ptr(info.calendar->clone());
-		auto calendar = calendar_ptr.get();
-		SetTimeZone(calendar, string_t("UTC"));
+		TZCalendar calendar(*info.calendar, info.cal_setting);
+		SetTimeZone(calendar.GetICUCalendar(), string_t("UTC"));
 
 		auto &bucket_width_arg = args.data[0];
 		auto &ts_arg = args.data[1];
@@ -488,9 +488,8 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.bind_info->Cast<BindData>();
-		CalendarPtr calendar_ptr(info.calendar->clone());
-		auto calendar = calendar_ptr.get();
-		SetTimeZone(calendar, string_t("UTC"));
+		TZCalendar calendar(*info.calendar, info.cal_setting);
+		SetTimeZone(calendar.GetICUCalendar(), string_t("UTC"));
 
 		auto &bucket_width_arg = args.data[0];
 		auto &ts_arg = args.data[1];
@@ -556,8 +555,7 @@ struct ICUTimeBucket : public ICUDateFunc {
 
 		auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
 		auto &info = func_expr.bind_info->Cast<BindData>();
-		CalendarPtr calendar_ptr(info.calendar->clone());
-		auto calendar = calendar_ptr.get();
+		TZCalendar calendar(*info.calendar, info.cal_setting);
 
 		auto &bucket_width_arg = args.data[0];
 		auto &ts_arg = args.data[1];
@@ -570,13 +568,13 @@ struct ICUTimeBucket : public ICUDateFunc {
 				ConstantVector::SetNull(result, true);
 			} else {
 				interval_t bucket_width = *ConstantVector::GetData<interval_t>(bucket_width_arg);
-				SetTimeZone(calendar, *ConstantVector::GetData<string_t>(tz_arg));
+				SetTimeZone(calendar.GetICUCalendar(), *ConstantVector::GetData<string_t>(tz_arg));
 				timestamp_t origin;
 				BucketWidthType bucket_width_type = ClassifyBucketWidth(bucket_width);
 				switch (bucket_width_type) {
 				case BucketWidthType::CONVERTIBLE_TO_MICROS:
-					origin =
-					    ICUDateFunc::FromNaive(calendar, Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
+					origin = ICUDateFunc::FromNaive(calendar.GetICUCalendar(),
+					                                Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
 					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
 					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
 						    return TimeZoneWidthConvertibleToMicrosBinaryOperator::Operation(bucket_width, ts, origin,
@@ -584,8 +582,8 @@ struct ICUTimeBucket : public ICUDateFunc {
 					    });
 					break;
 				case BucketWidthType::CONVERTIBLE_TO_DAYS:
-					origin =
-					    ICUDateFunc::FromNaive(calendar, Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
+					origin = ICUDateFunc::FromNaive(calendar.GetICUCalendar(),
+					                                Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_1));
 					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
 					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
 						    return TimeZoneWidthConvertibleToDaysBinaryOperator::Operation(bucket_width, ts, origin,
@@ -593,8 +591,8 @@ struct ICUTimeBucket : public ICUDateFunc {
 					    });
 					break;
 				case BucketWidthType::CONVERTIBLE_TO_MONTHS:
-					origin =
-					    ICUDateFunc::FromNaive(calendar, Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_2));
+					origin = ICUDateFunc::FromNaive(calendar.GetICUCalendar(),
+					                                Timestamp::FromEpochMicroSeconds(DEFAULT_ORIGIN_MICROS_2));
 					BinaryExecutor::Execute<interval_t, timestamp_t, timestamp_t>(
 					    bucket_width_arg, ts_arg, result, args.size(), [&](interval_t bucket_width, timestamp_t ts) {
 						    return TimeZoneWidthConvertibleToMonthsBinaryOperator::Operation(bucket_width, ts, origin,

--- a/extension/icu/include/icu-datefunc.hpp
+++ b/extension/icu/include/icu-datefunc.hpp
@@ -13,12 +13,11 @@
 #include "duckdb/common/enums/date_part_specifier.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "unicode/calendar.h"
+#include "tz_calendar.hpp"
 
 namespace duckdb {
 
 struct ICUDateFunc {
-	using CalendarPtr = duckdb::unique_ptr<icu::Calendar>;
-
 	struct BindData : public FunctionData {
 		explicit BindData(ClientContext &context);
 		BindData(const string &tz_setting, const string &cal_setting);
@@ -66,11 +65,11 @@ struct ICUDateFunc {
 	//! Subtracts the field of the given date from the calendar
 	static int32_t SubtractField(icu::Calendar *calendar, UCalendarDateFields field, timestamp_t end_date);
 	//! Adds the timestamp and the interval using the calendar
-	static timestamp_t Add(icu::Calendar *calendar, timestamp_t timestamp, interval_t interval);
+	static timestamp_t Add(TZCalendar &calendar, timestamp_t timestamp, interval_t interval);
 	//! Subtracts the interval from the timestamp using the calendar
-	static timestamp_t Sub(icu::Calendar *calendar, timestamp_t timestamp, interval_t interval);
+	static timestamp_t Sub(TZCalendar &calendar, timestamp_t timestamp, interval_t interval);
 	//! Subtracts the latter timestamp from the former timestamp using the calendar
-	static interval_t Sub(icu::Calendar *calendar, timestamp_t end_date, timestamp_t start_date);
+	static interval_t Sub(TZCalendar &calendar, timestamp_t end_date, timestamp_t start_date);
 	//! Pulls out the bin values from the timestamp assuming it is an instant,
 	//! constructs an ICU timestamp, and then converts that back to a DuckDB instant
 	//! Adding offset doesn't really work around DST because the bin values are ambiguous

--- a/extension/icu/include/icu-helpers.hpp
+++ b/extension/icu/include/icu-helpers.hpp
@@ -10,13 +10,9 @@
 
 #include "duckdb.hpp"
 #include "unicode/timezone.h"
+#include "duckdb/common/types/timestamp.hpp"
 
 namespace duckdb {
-
-struct TimestampData {
-	int32_t date_units[3];
-	int32_t time_units[4];
-};
 
 struct ICUHelpers {
 	//! Tries to get a time zone - returns nullptr if the timezone is not found
@@ -24,9 +20,9 @@ struct ICUHelpers {
 	//! Gets a time zone - throws an error if the timezone is not found
 	static unique_ptr<icu::TimeZone> GetTimeZone(string &tz_str);
 
-	static TimestampData DecomposeTimestamp(timestamp_tz_t ts, icu::Calendar *calendar);
+	static TimestampComponents GetComponents(timestamp_tz_t ts, icu::Calendar *calendar);
 
-	static timestamp_t ToTimestamp(TimestampData data);
+	static timestamp_t ToTimestamp(TimestampComponents data);
 };
 
 } // namespace duckdb

--- a/extension/icu/include/icu-helpers.hpp
+++ b/extension/icu/include/icu-helpers.hpp
@@ -13,11 +13,20 @@
 
 namespace duckdb {
 
+struct TimestampData {
+	int32_t date_units[3];
+	int32_t time_units[4];
+};
+
 struct ICUHelpers {
 	//! Tries to get a time zone - returns nullptr if the timezone is not found
 	static unique_ptr<icu::TimeZone> TryGetTimeZone(string &tz_str);
 	//! Gets a time zone - throws an error if the timezone is not found
 	static unique_ptr<icu::TimeZone> GetTimeZone(string &tz_str);
+
+	static TimestampData DecomposeTimestamp(timestamp_tz_t ts, icu::Calendar *calendar);
+
+	static timestamp_t ToTimestamp(TimestampData data);
 };
 
 } // namespace duckdb

--- a/extension/icu/include/tz_calendar.hpp
+++ b/extension/icu/include/tz_calendar.hpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// tz_calendar.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "icu-datefunc.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+using CalendarPtr = duckdb::unique_ptr<icu::Calendar>;
+
+struct TZCalendar {
+	TZCalendar(icu::Calendar &calendar_p, const string &cal_setting)
+	    : calendar(CalendarPtr(calendar_p.clone())),
+	      is_gregorian(cal_setting.empty() || StringUtil::CIEquals(cal_setting, "gregorian")) {
+	}
+
+	icu::Calendar *GetICUCalendar() {
+		return calendar.get();
+	}
+	bool IsGregorian() const {
+		return is_gregorian;
+	}
+
+	CalendarPtr calendar;
+	bool is_gregorian;
+};
+
+} // namespace duckdb

--- a/src/common/types/interval.cpp
+++ b/src/common/types/interval.cpp
@@ -342,38 +342,20 @@ int64_t Interval::GetNanoseconds(const interval_t &val) {
 	return nano;
 }
 
-interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
-	D_ASSERT(Timestamp::IsFinite(timestamp_1) && Timestamp::IsFinite(timestamp_2));
-	date_t date1, date2;
-	dtime_t time1, time2;
+interval_t Interval::GetAge(TimestampComponents ts1, TimestampComponents ts2, bool is_negative) {
+	// perform the differences
+	auto year_diff = ts1.year - ts2.year;
+	auto month_diff = ts1.month - ts2.month;
+	auto day_diff = ts1.day - ts2.day;
 
-	Timestamp::Convert(timestamp_1, date1, time1);
-	Timestamp::Convert(timestamp_2, date2, time2);
-
-	// and from date extract the years, months and days
-	int32_t year1, month1, day1;
-	int32_t year2, month2, day2;
-	Date::Convert(date1, year1, month1, day1);
-	Date::Convert(date2, year2, month2, day2);
-	// finally perform the differences
-	auto year_diff = year1 - year2;
-	auto month_diff = month1 - month2;
-	auto day_diff = day1 - day2;
-
-	// and from time extract hours, minutes, seconds and milliseconds
-	int32_t hour1, min1, sec1, micros1;
-	int32_t hour2, min2, sec2, micros2;
-	Time::Convert(time1, hour1, min1, sec1, micros1);
-	Time::Convert(time2, hour2, min2, sec2, micros2);
-	// finally perform the differences
-	auto hour_diff = hour1 - hour2;
-	auto min_diff = min1 - min2;
-	auto sec_diff = sec1 - sec2;
-	auto micros_diff = micros1 - micros2;
+	auto hour_diff = ts1.hour - ts2.hour;
+	auto min_diff = ts1.minute - ts2.minute;
+	auto sec_diff = ts1.second - ts2.second;
+	auto micros_diff = ts1.microsecond - ts2.microsecond;
 
 	// flip sign if necessary
 	bool sign_flipped = false;
-	if (timestamp_1 < timestamp_2) {
+	if (is_negative) {
 		year_diff = -year_diff;
 		month_diff = -month_diff;
 		day_diff = -day_diff;
@@ -401,11 +383,11 @@ interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 		day_diff--;
 	}
 	while (day_diff < 0) {
-		if (timestamp_1 < timestamp_2) {
-			day_diff += Date::IsLeapYear(year1) ? Date::LEAP_DAYS[month1] : Date::NORMAL_DAYS[month1];
+		if (is_negative) {
+			day_diff += Date::IsLeapYear(ts1.year) ? Date::LEAP_DAYS[ts1.month] : Date::NORMAL_DAYS[ts1.month];
 			month_diff--;
 		} else {
-			day_diff += Date::IsLeapYear(year2) ? Date::LEAP_DAYS[month2] : Date::NORMAL_DAYS[month2];
+			day_diff += Date::IsLeapYear(ts2.year) ? Date::LEAP_DAYS[ts2.month] : Date::NORMAL_DAYS[ts2.month];
 			month_diff--;
 		}
 	}
@@ -430,6 +412,15 @@ interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
 	interval.micros = Time::FromTime(hour_diff, min_diff, sec_diff, micros_diff).micros;
 
 	return interval;
+}
+
+interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
+	D_ASSERT(Timestamp::IsFinite(timestamp_1) && Timestamp::IsFinite(timestamp_2));
+
+	auto ts_component1 = Timestamp::GetComponents(timestamp_1);
+	auto ts_component2 = Timestamp::GetComponents(timestamp_2);
+
+	return Interval::GetAge(ts_component1, ts_component2, timestamp_1 < timestamp_2);
 }
 
 interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2) {

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -535,4 +535,16 @@ double Timestamp::GetJulianDay(timestamp_t timestamp) {
 	return result;
 }
 
+TimestampComponents Timestamp::GetComponents(timestamp_t timestamp) {
+	date_t date;
+	dtime_t time;
+
+	Convert(timestamp, date, time);
+
+	TimestampComponents result;
+	Date::Convert(date, result.year, result.month, result.day);
+	Time::Convert(time, result.hour, result.minute, result.second, result.microsecond);
+	return result;
+}
+
 } // namespace duckdb

--- a/src/include/duckdb/common/types/cast_helpers.hpp
+++ b/src/include/duckdb/common/types/cast_helpers.hpp
@@ -192,54 +192,65 @@ struct UhugeintToStringCast {
 };
 
 struct DateToStringCast {
-	static idx_t Length(int32_t date[], idx_t &year_length, bool &add_bc) {
+	static idx_t Length(int32_t &year, idx_t &year_length, bool &add_bc) {
 		// format is YYYY-MM-DD with optional (BC) at the end
 		// regular length is 10
 		idx_t length = 6;
 		year_length = 4;
 		add_bc = false;
-		if (date[0] <= 0) {
+		if (year <= 0) {
 			// add (BC) suffix
 			length += 5;
-			date[0] = -date[0] + 1;
+			year = -year + 1;
 			add_bc = true;
 		}
 
 		// potentially add extra characters depending on length of year
-		year_length += date[0] >= 10000;
-		year_length += date[0] >= 100000;
-		year_length += date[0] >= 1000000;
-		year_length += date[0] >= 10000000;
+		year_length += year >= 10000;
+		year_length += year >= 100000;
+		year_length += year >= 1000000;
+		year_length += year >= 10000000;
 		length += year_length;
 		return length;
 	}
 
-	static void Format(char *data, int32_t date[], idx_t year_length, bool add_bc) {
+	static idx_t Length(int32_t date[], idx_t &year_length, bool &add_bc) {
+		return Length(date[0], year_length, add_bc);
+	}
+
+	static void FormatComponent(char *&ptr, int32_t number) {
+		ptr[0] = '-';
+		if (number < 10) {
+			ptr[1] = '0';
+			ptr[2] = UnsafeNumericCast<char>('0' + number);
+		} else {
+			auto index = UnsafeNumericCast<idx_t>(number * 2);
+			ptr[1] = duckdb_fmt::internal::data::digits[index];
+			ptr[2] = duckdb_fmt::internal::data::digits[index + 1];
+		}
+		ptr += 3;
+	}
+
+	static void Format(char *data, int32_t year, int32_t month, int32_t day, idx_t year_length, bool add_bc) {
 		// now we write the string, first write the year
 		auto endptr = data + year_length;
-		endptr = NumericHelper::FormatUnsigned(date[0], endptr);
+		endptr = NumericHelper::FormatUnsigned(year, endptr);
 		// add optional leading zeros
 		while (endptr > data) {
 			*--endptr = '0';
 		}
 		// now write the month and day
 		auto ptr = data + year_length;
-		for (int i = 1; i <= 2; i++) {
-			ptr[0] = '-';
-			if (date[i] < 10) {
-				ptr[1] = '0';
-				ptr[2] = UnsafeNumericCast<char>('0' + date[i]);
-			} else {
-				auto index = UnsafeNumericCast<idx_t>(date[i] * 2);
-				ptr[1] = duckdb_fmt::internal::data::digits[index];
-				ptr[2] = duckdb_fmt::internal::data::digits[index + 1];
-			}
-			ptr += 3;
-		}
+		FormatComponent(ptr, month);
+		FormatComponent(ptr, day);
 		// optionally add BC to the end of the date
 		if (add_bc) {
 			memcpy(ptr, " (BC)", 5); // NOLINT
 		}
+	}
+
+	static void Format(char *data, int32_t date[], idx_t year_length, bool add_bc) {
+		Format(data, date[0], date[1], date[2], year_length, add_bc);
 	}
 };
 
@@ -261,11 +272,11 @@ struct TimeToStringCast {
 		return UnsafeNumericCast<int32_t>(trailing_zeros);
 	}
 
-	static idx_t Length(int32_t time[], char micro_buffer[]) {
+	static idx_t Length(int32_t micros, char micro_buffer[]) {
 		// format is HH:MM:DD.MS
 		// microseconds come after the time with a period separator
 		idx_t length;
-		if (time[3] == 0) {
+		if (micros == 0) {
 			// no microseconds
 			// format is HH:MM:DD
 			length = 8;
@@ -276,9 +287,13 @@ struct TimeToStringCast {
 			// we write backwards and pad with zeros to the left
 			// now we figure out how many digits we need to include by looking backwards
 			// and checking how many zeros we encounter
-			length -= NumericCast<idx_t>(FormatMicros(time[3], micro_buffer));
+			length -= NumericCast<idx_t>(FormatMicros(micros, micro_buffer));
 		}
 		return length;
+	}
+
+	static idx_t Length(int32_t time[], char micro_buffer[]) {
+		return Length(time[3], micro_buffer);
 	}
 
 	static void FormatTwoDigits(char *ptr, int32_t value) {
@@ -293,20 +308,23 @@ struct TimeToStringCast {
 		}
 	}
 
-	static void Format(char *data, idx_t length, int32_t time[], char micro_buffer[]) {
+	static void Format(char *data, idx_t length, int32_t hour, int32_t minute, int32_t second, int32_t microsecond,
+	                   char micro_buffer[]) {
 		// first write hour, month and day
-		auto ptr = data;
-		ptr[2] = ':';
-		ptr[5] = ':';
-		for (int i = 0; i <= 2; i++) {
-			FormatTwoDigits(ptr, time[i]);
-			ptr += 3;
-		}
+		FormatTwoDigits(data, hour);
+		data[2] = ':';
+		FormatTwoDigits(data + 3, minute);
+		data[5] = ':';
+		FormatTwoDigits(data + 6, second);
 		if (length > 8) {
 			// write the micro seconds at the end
 			data[8] = '.';
 			memcpy(data + 9, micro_buffer, length - 9);
 		}
+	}
+
+	static void Format(char *data, idx_t length, int32_t time[], char micro_buffer[]) {
+		Format(data, length, time[0], time[1], time[2], time[3], micro_buffer);
 	}
 };
 

--- a/src/include/duckdb/common/types/cast_helpers.hpp
+++ b/src/include/duckdb/common/types/cast_helpers.hpp
@@ -192,7 +192,7 @@ struct UhugeintToStringCast {
 };
 
 struct DateToStringCast {
-	static idx_t Length(int32_t &year, idx_t &year_length, bool &add_bc) {
+	static idx_t YearLength(int32_t &year, idx_t &year_length, bool &add_bc) {
 		// format is YYYY-MM-DD with optional (BC) at the end
 		// regular length is 10
 		idx_t length = 6;
@@ -215,7 +215,7 @@ struct DateToStringCast {
 	}
 
 	static idx_t Length(int32_t date[], idx_t &year_length, bool &add_bc) {
-		return Length(date[0], year_length, add_bc);
+		return YearLength(date[0], year_length, add_bc);
 	}
 
 	static void FormatComponent(char *&ptr, int32_t number) {
@@ -272,7 +272,7 @@ struct TimeToStringCast {
 		return UnsafeNumericCast<int32_t>(trailing_zeros);
 	}
 
-	static idx_t Length(int32_t micros, char micro_buffer[]) {
+	static idx_t MicrosLength(int32_t micros, char micro_buffer[]) {
 		// format is HH:MM:DD.MS
 		// microseconds come after the time with a period separator
 		idx_t length;
@@ -293,7 +293,7 @@ struct TimeToStringCast {
 	}
 
 	static idx_t Length(int32_t time[], char micro_buffer[]) {
-		return Length(time[3], micro_buffer);
+		return MicrosLength(time[3], micro_buffer);
 	}
 
 	static void FormatTwoDigits(char *ptr, int32_t value) {

--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -144,7 +144,7 @@ public:
 	//! Get Interval in Nanoseconds
 	static int64_t GetNanoseconds(const interval_t &val);
 
-	//! Returns the age between two timestamps (including 30 day months)
+	//! Returns the age between two timestamps (including months)
 	static interval_t GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2);
 
 	//! Returns the exact difference between two timestamps (days and seconds)

--- a/src/include/duckdb/common/types/interval.hpp
+++ b/src/include/duckdb/common/types/interval.hpp
@@ -17,6 +17,7 @@ struct dtime_t;     // NOLINT: literal casing
 struct date_t;      // NOLINT: literal casing
 struct dtime_tz_t;  // NOLINT: literal casing
 struct timestamp_t; // NOLINT: literal casing
+struct TimestampComponents;
 
 class Serializer;
 class Deserializer;
@@ -146,6 +147,8 @@ public:
 
 	//! Returns the age between two timestamps (including months)
 	static interval_t GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2);
+	//! Returns the age between two timestamp components
+	static interval_t GetAge(TimestampComponents ts1, TimestampComponents ts2, bool is_negative);
 
 	//! Returns the exact difference between two timestamps (days and seconds)
 	static interval_t GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2);

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -119,6 +119,17 @@ enum class TimestampCastResult : uint8_t {
 	STRICT_UTC
 };
 
+struct TimestampComponents {
+	int32_t year;
+	int32_t month;
+	int32_t day;
+
+	int32_t hour;
+	int32_t minute;
+	int32_t second;
+	int32_t microsecond;
+};
+
 //! The static Timestamp class holds helper functions for the timestamp types.
 class Timestamp {
 public:
@@ -204,6 +215,9 @@ public:
 	DUCKDB_API static int64_t GetEpochRounded(timestamp_t timestamp, const int64_t power_of_ten);
 	//! Convert a timestamp to a Julian Day
 	DUCKDB_API static double GetJulianDay(timestamp_t timestamp);
+
+	//! Decompose a timestamp into its components
+	DUCKDB_API static TimestampComponents GetComponents(timestamp_t timestamp);
 
 	DUCKDB_API static bool TryParseUTCOffset(const char *str, idx_t &pos, idx_t len, int &hh, int &mm, int &ss);
 

--- a/test/sql/function/timestamp/test_icu_age.test
+++ b/test/sql/function/timestamp/test_icu_age.test
@@ -64,21 +64,21 @@ INSERT INTO timestamps VALUES
 query T
 SELECT AGE(t1, TIMESTAMPTZ '1957-06-13') FROM timestamps;
 ----
-43 years 9 months 28 days
+43 years 9 months 27 days
 56 years 10 months 12 days
 56 years 10 months 12 days
-61 years 11 months 29 days
+61 years 11 months 28 days
 NULL
-61 years 11 months 29 days
+61 years 11 months 28 days
 NULL
 
 # Time fields caused by DST
 query T
 SELECT AGE(TIMESTAMPTZ '2001-04-10', t2) FROM timestamps;
 ----
-43 years 9 months 28 days
+43 years 9 months 27 days
 -13 years -7 days
--12 years -8 months -22 days
+-12 years -8 months -21 days
 -18 years -2 months -1 day
 -18 years -2 months -1 day
 NULL
@@ -87,7 +87,7 @@ NULL
 query T
 SELECT AGE(t1, t2) FROM timestamps;
 ----
-43 years 9 months 28 days
+43 years 9 months 27 days
 8 days
 3 months 24 days
 00:00:00

--- a/test/sql/timezone/icu_calendar_operations.test
+++ b/test/sql/timezone/icu_calendar_operations.test
@@ -1,0 +1,22 @@
+# name: test/sql/timezone/icu_calendar_operations.test
+# description: Test the ICU calendar interface
+# group: [timezone]
+
+require icu
+
+# Normalise the testing locale
+statement ok
+SET Calendar = 'hebrew';
+
+statement ok
+SET TimeZone = 'UTC';
+
+query I
+SELECT AGE(timestamptz '2020-01-01' + interval (30) day, timestamptz '2020-01-01')
+----
+1 month
+
+query I
+SELECT AGE(timestamptz '2020-06-01' + interval (230) day, timestamptz '2020-06-01')
+----
+7 months 23 days

--- a/test/sql/timezone/icu_calendar_operations.test
+++ b/test/sql/timezone/icu_calendar_operations.test
@@ -20,3 +20,8 @@ query I
 SELECT AGE(timestamptz '2020-06-01' + interval (230) day, timestamptz '2020-06-01')
 ----
 7 months 23 days
+
+query I
+SELECT AGE(timestamptz '2021-06-01', timestamptz '2020-06-01' + interval (230) day)
+----
+5 months 7 days


### PR DESCRIPTION
Effectively we switch to decomposing the timestamp into its base units (year/month/day/hour/minute/second) - and then converting those units back into a timestamp, followed by performing the interval age computation.

This greatly speeds up the ICU age computation, and also aligns our results with that of Postgres.

Previously:
```sql
D set timezone='UTC';
D select age(timestamptz '2001-04-10', TIMESTAMPTZ '1957-06-13') as res;
┌───────────────────────────┐
│            res            │
│         interval          │
├───────────────────────────┤
│ 43 years 9 months 28 days │
└───────────────────────────┘
```

Current behavior (and Postgres behavior):

```sql
postgres=# set timezone='UTC';
SET
postgres=# select age(timestamptz '2001-04-10', TIMESTAMPTZ '1957-06-13') as res;
           res           
-------------------------
 43 years 9 mons 27 days
(1 row)

```

