### PR TITLE
filename_pattern.cpp: Do not overwrite position in case of "id" pattern

### DIFF
--- a/src/common/filename_pattern.cpp
+++ b/src/common/filename_pattern.cpp
@@ -14,12 +14,12 @@ void FilenamePattern::SetFilenamePattern(const string &pattern) {
 	if (pos != string::npos) {
 		base = StringUtil::Replace(base, id_format, "");
 		uuid = false;
-	}
-
-	pos = base.find(uuid_format);
-	if (pos != string::npos) {
-		base = StringUtil::Replace(base, uuid_format, "");
-		uuid = true;
+	} else {
+		pos = base.find(uuid_format);
+		if (pos != string::npos) {
+			base = StringUtil::Replace(base, uuid_format, "");
+			uuid = true;
+		}
 	}
 
 	pos = std::min(pos, (idx_t)base.length());


### PR DESCRIPTION
Probable fix of https://github.com/duckdb/duckdb/issues/8901