### PR TITLE
Clean up partial deletes when encountering a transaction conflict in a vector

### DIFF
--- a/src/storage/table/chunk_info.cpp
+++ b/src/storage/table/chunk_info.cpp
@@ -204,7 +204,11 @@ idx_t ChunkVectorInfo::Delete(transaction_t transaction_id, row_t rows[], idx_t 
 		}
 		// first check the chunk for conflicts
 		if (deleted[rows[i]] != NOT_DELETED_ID) {
-			// tuple was already deleted by another transaction
+			// tuple was already deleted by another transaction - conflict
+			// unset any deleted tuples we set in this loop
+			for (idx_t k = 0; k < i; k++) {
+				deleted[rows[k]] = NOT_DELETED_ID;
+			}
 			throw TransactionException("Conflict on tuple deletion!");
 		}
 		// after verifying that there are no conflicts we mark the tuple as deleted

--- a/test/sql/delete/cleanup_delete_on_conflict.test
+++ b/test/sql/delete/cleanup_delete_on_conflict.test
@@ -1,0 +1,37 @@
+# name: test/sql/delete/cleanup_delete_on_conflict.test
+# description: Verify that partial deletes are cleaned up on conflicts
+# group: [delete]
+
+statement ok
+CREATE TABLE tbl(i INTEGER);
+
+statement ok
+INSERT INTO tbl FROM range(1000) t(i);
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+DELETE FROM tbl WHERE i BETWEEN 200 AND 300
+
+statement error con2
+DELETE FROM tbl WHERE i <= 500
+----
+Conflict on tuple deletion
+
+statement ok con1
+COMMIT
+
+statement ok con2
+ROLLBACK
+
+query I
+DELETE FROM tbl WHERE i <= 500
+----
+400


### PR DESCRIPTION
Otherwise the previous (aborted) transaction id would remain in the delete vector, which would cause subsequent deletes (without a database restart) to fail.
