### PR TITLE
Fix USING KEY reference error

### DIFF
--- a/src/include/duckdb/planner/bind_context.hpp
+++ b/src/include/duckdb/planner/bind_context.hpp
@@ -116,7 +116,8 @@ public:
 
 	//! Adds a base table with the given alias to the CTE BindContext.
 	//! We need this to correctly bind recursive CTEs with multiple references.
-	void AddCTEBinding(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types);
+	void AddCTEBinding(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
+	                   bool using_key = false);
 
 	//! Add an implicit join condition (e.g. USING (x))
 	void AddUsingBinding(const string &column_name, UsingColumnSet &set);

--- a/src/planner/bind_context.cpp
+++ b/src/planner/bind_context.cpp
@@ -694,7 +694,7 @@ void BindContext::AddGenericBinding(idx_t index, const string &alias, const vect
 }
 
 void BindContext::AddCTEBinding(idx_t index, const string &alias, const vector<string> &names,
-                                const vector<LogicalType> &types) {
+                                const vector<LogicalType> &types, bool using_key) {
 	auto binding = make_shared_ptr<Binding>(BindingType::BASE, BindingAlias(alias), types, names, index);
 
 	if (cte_bindings.find(alias) != cte_bindings.end()) {
@@ -702,6 +702,13 @@ void BindContext::AddCTEBinding(idx_t index, const string &alias, const vector<s
 	}
 	cte_bindings[alias] = std::move(binding);
 	cte_references[alias] = make_shared_ptr<idx_t>(0);
+
+	if (using_key) {
+		auto recurring_alias = "recurring." + alias;
+		cte_bindings[recurring_alias] =
+		    make_shared_ptr<Binding>(BindingType::BASE, BindingAlias(recurring_alias), types, names, index);
+		cte_references[recurring_alias] = make_shared_ptr<idx_t>(0);
+	}
 }
 
 void BindContext::AddContext(BindContext other) {

--- a/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -41,11 +41,7 @@ unique_ptr<BoundQueryNode> Binder::BindNode(RecursiveCTENode &statement) {
 
 	// Add bindings of left side to temporary CTE bindings context
 	result->right_binder->bind_context.AddCTEBinding(result->setop_index, statement.ctename, result->names,
-	                                                 result->types);
-	if (!statement.key_targets.empty()) {
-		result->right_binder->bind_context.AddCTEBinding(result->setop_index, "recurring." + statement.ctename,
-		                                                 result->names, result->types);
-	}
+	                                                 result->types, !statement.key_targets.empty());
 
 	result->right = result->right_binder->BindNode(*statement.right);
 	for (auto &c : result->left_binder->correlated_columns) {

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -163,6 +163,13 @@ unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
 
 				// Update references to CTE
 				auto cteref = bind_context.cte_references[cte_reference];
+
+				if (cteref == nullptr && ref.schema_name == "recurring") {
+					throw BinderException("There is a WITH item named \"%s\", but the recurring table cannot be "
+					                      "referenced from this part of the query.",
+					                      ref.table_name);
+				}
+
 				(*cteref)++;
 
 				result->types = ctebinding->types;

--- a/test/sql/cte/recursive_cte_key_variant.test
+++ b/test/sql/cte/recursive_cte_key_variant.test
@@ -141,6 +141,17 @@ WITH RECURSIVE tbl2(a) AS (SELECT 1 UNION SELECT a.a+1 FROM tbl2 AS a, (SELECT *
 ----
 Invalid Input Error: RECURRING can only be used with USING KEY in recursive CTE.
 
+statement error
+WITH RECURSIVE tbl(a, b) USING KEY (a) AS (SELECT 5, 1 UNION SELECT a, b + 1 FROM tbl WHERE b < a),tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
+----
+Binder Error: There is a WITH item named "tbl", but the recurring table cannot be referenced from this part of the query.
+
+statement error
+WITH RECURSIVE tbl(a, b) USING KEY (a) AS MATERIALIZED (SELECT 5, 1 UNION SELECT a, b + 1 FROM tbl WHERE b < a),tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
+----
+Binder Error: There is a WITH item named "tbl", but the recurring table cannot be referenced from this part of the query.
+
+
 #######################
 # Connected components
 #######################


### PR DESCRIPTION
This PR fixes a bug found in the nightly CI tests:
```sql
WITH RECURSIVE tbl(a, b) USING KEY (a) AS MATERIALIZED (
  SELECT 5, 1
    UNION
  SELECT a, b + 1
  FROM tbl WHERE b < a),
tbl1(a,b) AS (SELECT * FROM recurring.tbl)
SELECT * FROM tbl1;
```

The CTE `tbl1` should not be able to reference `recurring.tbl`, the Binder should detect that and throw an appropriate error. This, however, did not work as expected when the `USING KEY` CTE was `MATERIALIZED`. Then, a `shared_pointer` dereferenced to `NULL`. This is now fixed.