### PR TITLE
[Fix] Disable recursion for invalidated database error

### DIFF
--- a/src/main/error_manager.cpp
+++ b/src/main/error_manager.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/main/config.hpp"
 #include "utf8proc_wrapper.hpp"
 #include "duckdb/common/exception/list.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 

--- a/src/main/error_manager.cpp
+++ b/src/main/error_manager.cpp
@@ -16,7 +16,7 @@ static const DefaultError internal_errors[] = {
      "are disabled by configuration (allow_unsigned_extensions)"},
     {ErrorType::INVALIDATED_TRANSACTION, "Current transaction is aborted (please ROLLBACK)"},
     {ErrorType::INVALIDATED_DATABASE, "Failed: database has been invalidated because of a previous fatal error. The "
-                                      "database must be restarted prior to being used again.\nOriginal error: \"%s\""},
+                                      "database must be restarted prior to being used again.\n"},
     {ErrorType::INVALID, nullptr}};
 
 string ErrorManager::FormatExceptionRecursive(ErrorType error_type, vector<ExceptionFormatValue> &values) {
@@ -25,13 +25,26 @@ string ErrorManager::FormatExceptionRecursive(ErrorType error_type, vector<Excep
 	}
 	auto entry = custom_errors.find(error_type);
 	string error;
-	if (entry == custom_errors.end()) {
-		// error was not overwritten
-		error = internal_errors[int(error_type)].error;
-	} else {
-		// error was overwritten
+	if (entry != custom_errors.end()) {
+		// Error was overwritten.
 		error = entry->second;
+		return ExceptionFormatValue::Format(error, values);
 	}
+
+	// Error was not overwritten.
+	error = internal_errors[int(error_type)].error;
+
+	if (error_type != ErrorType::INVALIDATED_DATABASE) {
+		return ExceptionFormatValue::Format(error, values);
+	}
+
+	for (const auto &val : values) {
+		if (StringUtil::Contains(val.str_val, error)) {
+			error = "%s";
+			return ExceptionFormatValue::Format(error, values);
+		}
+	}
+	error += "Original error: \"%s\"";
 	return ExceptionFormatValue::Format(error, values);
 }
 


### PR DESCRIPTION
With the current design, consecutive calls (e.g., in a concurrent environment) can cause *very* long error messages before aborting operations due to a fatal error.

This PR ensures that we only prepend the `INVALIDATED_DATABASE` prefix once.

I am unsure how to include a test for this. Locally, I just added a fatal exception to the `CREATE INDEX` code and used the test below. I'm not sure if we have some way to 'turn any exception into a fatal exception' or something.

```sql
load __TEST_DIR__/fatalerror.db;

statement ok
CREATE TABLE tbl AS SELECT range FROM range(10);

statement error
CREATE INDEX idx ON tbl (range);
----
FATAL Error: oh no

statement error
CREATE INDEX idx ON tbl (range);
----
FATAL Error: Failed: database has been invalidated because of a previous fatal error. The database must be restarted prior to being used again.
Original error: "oh no"

statement error
CREATE INDEX idx ON tbl (range);
----
FATAL Error: Failed: database has been invalidated because of a previous fatal error. The database must be restarted prior to being used again.
Original error: "oh no"
```