### PR TITLE
bump out-of-tree extensions to v1.2.2

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -91,7 +91,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG d41bbe60ad8307cb6f95dfeec0f614ce50375209
+            GIT_TAG 43b4e37f6e859d6c1c67b787ac511659e9e0b6fb
             )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -46,7 +46,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG d3c5013a3d296f2055b14cdbffa9d066f0663c67
+            GIT_TAG e92e45b30ba17594b1101db22699a2244adfaeb1
             )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -35,7 +35,7 @@ endif()
 ################# AVRO
 if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(avro
-            LOAD_TESTS DONT_LINK
+            LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-avro
             GIT_TAG 1357c64c91b1f8b4df1e4f7178584a530fb3679b
     )
@@ -46,7 +46,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG d3c5013a3d296f2055b14cdbffa9d066f0663c67
+            GIT_TAG b3050f35c6e99fa35465230493eeab14a78a0409
             )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -35,7 +35,7 @@ endif()
 ################# AVRO
 if (NOT MINGW)
     duckdb_extension_load(avro
-            LOAD_TESTS
+            LOAD_TESTS DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-avro
             GIT_TAG ed18629fa56a97e0796a3582110b51ddd125159d
     )

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -19,7 +19,7 @@
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 85ac4667bcb0d868199e156f8dd918b0278db7b9
+    GIT_TAG c22532453e9fab8404f91729708d9f35e23d323d
     INCLUDE_DIR extension/httpfs/include
     )
 
@@ -46,7 +46,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG b3050f35c6e99fa35465230493eeab14a78a0409
+            GIT_TAG d3c5013a3d296f2055b14cdbffa9d066f0663c67
             )
 endif()
 
@@ -91,7 +91,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED} AND NOT ${MUSL_ENABLED})
     duckdb_extension_load(iceberg
 #            ${LOAD_ICEBERG_TESTS} TODO: re-enable once autoloading test is fixed
             GIT_URL https://github.com/duckdb/duckdb-iceberg
-            GIT_TAG 43b4e37f6e859d6c1c67b787ac511659e9e0b6fb
+            GIT_TAG d41bbe60ad8307cb6f95dfeec0f614ce50375209
             )
 endif()
 

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -46,7 +46,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG b3050f35c6e99fa35465230493eeab14a78a0409
+            GIT_TAG d3c5013a3d296f2055b14cdbffa9d066f0663c67
             )
 endif()
 

--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -692,6 +692,7 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {{"s3/config", "h
                                                                 {"s3/credential_chain", "aws"},
                                                                 {"gcs/credential_chain", "aws"},
                                                                 {"r2/credential_chain", "aws"},
+                                                                {"aws/credential_chain", "aws"},
                                                                 {"azure/access_token", "azure"},
                                                                 {"azure/config", "azure"},
                                                                 {"azure/credential_chain", "azure"},

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1074,6 +1074,7 @@ static constexpr ExtensionEntry EXTENSION_SECRET_PROVIDERS[] = {
     {"s3/credential_chain", "aws"},
     {"gcs/credential_chain", "aws"},
     {"r2/credential_chain", "aws"},
+    {"aws/credential_chain", "aws"},
     {"azure/access_token", "azure"},
     {"azure/config", "azure"},
     {"azure/credential_chain", "azure"},

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -981,6 +981,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"prefetch_all_parquet_files", "parquet"},
     {"s3_access_key_id", "httpfs"},
     {"s3_endpoint", "httpfs"},
+    {"s3_kms_key_id", "httpfs"},
     {"s3_region", "httpfs"},
     {"s3_secret_access_key", "httpfs"},
     {"s3_session_token", "httpfs"},


### PR DESCRIPTION
bump duckdb-httpfs, and duckdb-aws to latest version of v1.2-histrionicus

Also removing `DONT_LINK` from avro since duckdb-iceberg tries to automatically load it, and if it is not available duckdb-iceberg will through an error. This means any time iceberg is autoloaded and avro is not available/linked, then statements/tests will fail.

EDIT: not bumping iceberg in this PR. Want to try and isolate errors.


EDIT2: Not bumping aws, there seems to be an issue with windows and provider `credential_chain`. Want to try and debug it on the windows laptop first
