### PR TITLE
Backport "Adding gzip version of shell for linux/osx install script"

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -95,9 +95,10 @@ jobs:
       run: |
         python3 scripts/amalgamation.py
         zip -j duckdb_cli-linux-amd64.zip build/release/duckdb
+        gzip -9 -k -n -c build/release/duckdb > duckdb_cli-linux-amd64.gz
         zip -j libduckdb-linux-amd64.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
         zip -j libduckdb-src.zip src/amalgamation/duckdb.hpp src/amalgamation/duckdb.cpp src/include/duckdb.h src/include/duckdb_extension.h
-        ./scripts/upload-assets-to-staging.sh github_release libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip
+        ./scripts/upload-assets-to-staging.sh github_release libduckdb-src.zip libduckdb-linux-amd64.zip duckdb_cli-linux-amd64.zip duckdb_cli-linux-amd64.gz
 
     - uses: actions/upload-artifact@v4
       with:
@@ -105,6 +106,7 @@ jobs:
         path: |
           libduckdb-linux-amd64.zip
           duckdb_cli-linux-amd64.zip
+          duckdb_cli-linux-amd64.gz
 
     - name: Test
       shell: bash
@@ -162,8 +164,9 @@ jobs:
        run: |
          python3 scripts/amalgamation.py
          zip -j duckdb_cli-linux-aarch64.zip build/release/duckdb
+         gzip -9 -k -n -c build/release/duckdb > duckdb_cli-linux-arm64.gz
          zip -j libduckdb-linux-aarch64.zip build/release/src/libduckdb*.* src/amalgamation/duckdb.hpp src/include/duckdb.h
-         ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-aarch64.zip duckdb_cli-linux-aarch64.zip
+         ./scripts/upload-assets-to-staging.sh github_release libduckdb-linux-aarch64.zip duckdb_cli-linux-aarch64.zip duckdb_cli-linux-arm64.gz
 
      - uses: actions/upload-artifact@v4
        with:
@@ -171,6 +174,7 @@ jobs:
          path: |
            libduckdb-linux-aarch64.zip
            duckdb_cli-linux-aarch64.zip
+           duckdb_cli-linux-arm64.gz
 
  # Linux extensions for builds that use C++11 ABI, currently these are all linux builds based on ubuntu >= 18 (e.g. NodeJS)
  # note that the linux-release-64 is based on the manylinux-based extensions, which are built in .github/workflows/Python.yml


### PR DESCRIPTION
See https://github.com/duckdb/duckdb/pull/16116