### PR TITLE
Skip avro and iceberg due to problems with snappy, and aws too

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -14,6 +14,9 @@ inputs:
   override_git_describe:
     description: 'Override git describe'
     default: ''
+  skip_extensions:
+    description: 'Extensions to be skipped'
+    default: ''
 
 runs:
   using: "composite"
@@ -58,6 +61,7 @@ runs:
           echo "OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ inputs.vcpkg_target_triplet }}" >> docker_env.txt
           echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ inputs.vcpkg_target_triplet }}" >> docker_env.txt
           echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
+          echo "SKIP_EXTENSIONS=${{ inputs.skip_extensions }}" >> docker_env.txt
           echo "DUCKDB_PLATFORM=${{ inputs.duckdb_arch }}" >> docker_env.txt
           echo "OVERRIDE_GIT_DESCRIBE=${{ inputs.override_git_describe }}" >> docker_env.txt
           echo "LINUX_CI_IN_DOCKER=1" >> docker_env.txt

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -151,6 +151,7 @@ jobs:
           duckdb_arch: linux_amd64_gcc4
           run_tests: ${{ inputs.skip_tests != 'true' }}
           override_git_describe: ${{ inputs.override_git_describe }}
+          skip_extensions: "aws;avro;iceberg"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Attempt at fixing CI problems connected to snappy. I think the problem is that somehow the toolchain moved further (either manylinux image or else) and vcpkg build of snappy now fails in manylinux.

I have not tried yet to reproduce locally, this is a somewhat blind attempt at a fix (but if this passes LinuxExtensions in Python.yml it's good to be merged).