### PR TITLE
Backport "Adding gzip version of shell for linux/osx install script"/2

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -163,8 +163,9 @@ jobs:
         run: |
           python scripts/amalgamation.py
           zip -j duckdb_cli-osx-universal.zip build/release/duckdb
+          gzip -9 -k -n -c build/release/duckdb > duckdb_cli-osx-universal.gz
           zip -j libduckdb-osx-universal.zip build/release/src/libduckdb*.dylib src/amalgamation/duckdb.hpp src/include/duckdb.h
-          ./scripts/upload-assets-to-staging.sh github_release libduckdb-osx-universal.zip duckdb_cli-osx-universal.zip
+          ./scripts/upload-assets-to-staging.sh github_release libduckdb-osx-universal.zip duckdb_cli-osx-universal.zip duckdb_cli-osx-universal.gz
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
OSX side of https://github.com/duckdb/duckdb/pull/16116