### PR TITLE
Reduce locking with `FILE_SIZE_BYTES`/`ROW_GROUPS_PER_FILE` in Parquet writer

### DIFF
--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/encryption_state.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/atomic.hpp"
 #include "duckdb/common/serializer/buffered_file_writer.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/function/copy_function.hpp"
@@ -113,8 +114,7 @@ public:
 		return *writer;
 	}
 	idx_t FileSize() {
-		lock_guard<mutex> glock(lock);
-		return writer->total_written;
+		return total_written;
 	}
 	idx_t DictionarySizeLimit() const {
 		return dictionary_size_limit;
@@ -129,8 +129,7 @@ public:
 		return compression_level;
 	}
 	idx_t NumberOfRowGroups() {
-		lock_guard<mutex> glock(lock);
-		return file_meta_data.row_groups.size();
+		return num_row_groups;
 	}
 	ParquetVersion GetParquetVersion() const {
 		return parquet_version;
@@ -170,6 +169,9 @@ private:
 	vector<ParquetColumnSchema> column_schemas;
 
 	unique_ptr<BufferedFileWriter> writer;
+	//! Atomics to reduce contention when rotating writes to multiple Parquet files
+	atomic<idx_t> total_written;
+	atomic<idx_t> num_row_groups;
 	std::shared_ptr<duckdb_apache::thrift::protocol::TProtocol> protocol;
 	duckdb_parquet::FileMetaData file_meta_data;
 	std::mutex lock;

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -352,11 +352,12 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
       encryption_config(std::move(encryption_config_p)), dictionary_size_limit(dictionary_size_limit_p),
       string_dictionary_page_size_limit(string_dictionary_page_size_limit_p),
       bloom_filter_false_positive_ratio(bloom_filter_false_positive_ratio_p), compression_level(compression_level_p),
-      debug_use_openssl(debug_use_openssl_p), parquet_version(parquet_version) {
+      debug_use_openssl(debug_use_openssl_p), parquet_version(parquet_version), total_written(0), num_row_groups(0) {
 
 	// initialize the file writer
 	writer = make_uniq<BufferedFileWriter>(fs, file_name.c_str(),
 	                                       FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+
 	if (encryption_config) {
 		auto &config = DBConfig::GetConfig(context);
 		if (config.encryption_util && debug_use_openssl) {
@@ -373,6 +374,7 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
 		// parquet files start with the string "PAR1"
 		writer->WriteData(const_data_ptr_cast("PAR1"), 4);
 	}
+
 	TCompactProtocolFactoryT<MyTransport> tproto_factory;
 	protocol = tproto_factory.getProtocol(std::make_shared<MyTransport>(*writer));
 
@@ -542,6 +544,9 @@ void ParquetWriter::FlushRowGroup(PreparedRowGroup &prepared) {
 	// append the row group to the file meta data
 	file_meta_data.row_groups.push_back(row_group);
 	file_meta_data.num_rows += row_group.num_rows;
+
+	total_written = writer->GetTotalWritten();
+	num_row_groups++;
 }
 
 void ParquetWriter::Flush(ColumnDataCollection &buffer) {

--- a/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_copy_to_file.hpp
@@ -97,5 +97,7 @@ public:
 private:
 	unique_ptr<GlobalFunctionData> CreateFileState(ClientContext &context, GlobalSinkState &sink,
 	                                               StorageLockKey &global_lock) const;
+	void WriteRotateInternal(ExecutionContext &context, GlobalSinkState &global_state,
+	                         const std::function<void(GlobalFunctionData &)> &fun) const;
 };
 } // namespace duckdb

--- a/test/sql/copy/file_size_bytes_large.test_slow
+++ b/test/sql/copy/file_size_bytes_large.test_slow
@@ -3,10 +3,13 @@
 # group: [copy]
 
 statement ok
+set threads=4
+
+statement ok
 CREATE TABLE bigdata AS SELECT i AS col_a, i AS col_b FROM range(0, 10000000) tbl(i);
 
 statement ok
-COPY (FROM bigdata) TO '__TEST_DIR__/file_size_bytes_csv42' (FORMAT CSV, FILE_SIZE_BYTES '200kb');
+COPY (FROM bigdata) TO '__TEST_DIR__/file_size_bytes_csv42' (FORMAT CSV, FILE_SIZE_BYTES '1mb');
 
 query I
 SELECT COUNT(*) FROM read_csv('__TEST_DIR__/file_size_bytes_csv42/*.csv')
@@ -19,12 +22,12 @@ SELECT AVG(col_a), AVG(col_b) FROM read_csv('__TEST_DIR__/file_size_bytes_csv42/
 4999999.5	4999999.5
 
 query I
-SELECT COUNT(*) BETWEEN 550 AND 800 FROM glob('__TEST_DIR__/file_size_bytes_csv42/*.csv')
+SELECT COUNT(*) BETWEEN 100 AND 200 FROM glob('__TEST_DIR__/file_size_bytes_csv42/*.csv')
 ----
 1
 
 statement ok
-COPY (FROM bigdata) TO '__TEST_DIR__/file_size_bytes_csv43' (FORMAT CSV, FILE_SIZE_BYTES '200kb', PER_THREAD_OUTPUT TRUE);
+COPY (FROM bigdata) TO '__TEST_DIR__/file_size_bytes_csv43' (FORMAT CSV, FILE_SIZE_BYTES '1mb', PER_THREAD_OUTPUT TRUE);
 
 query I
 SELECT COUNT(*) FROM read_csv_auto('__TEST_DIR__/file_size_bytes_csv43/*.csv')
@@ -37,6 +40,6 @@ SELECT AVG(col_a), AVG(col_b) FROM read_csv('__TEST_DIR__/file_size_bytes_csv43/
 4999999.5	4999999.5
 
 query I
-SELECT COUNT(*) BETWEEN 550 AND 800 FROM glob('__TEST_DIR__/file_size_bytes_csv43/*.csv')
+SELECT COUNT(*) BETWEEN 100 AND 200 FROM glob('__TEST_DIR__/file_size_bytes_csv43/*.csv')
 ----
 1

--- a/test/sql/copy/row_groups_per_file_large.test_slow
+++ b/test/sql/copy/row_groups_per_file_large.test_slow
@@ -25,7 +25,7 @@ SELECT avg(col_a), avg(col_b) FROM read_parquet('__TEST_DIR__/row_groups_per_fil
 4999999.5	4999999.5
 
 query I
-SELECT count(*) BETWEEN 15 AND 25 FROM glob('__TEST_DIR__/row_groups_per_file42/*.parquet')
+SELECT count(*) BETWEEN 10 AND 25 FROM glob('__TEST_DIR__/row_groups_per_file42/*.parquet')
 ----
 true
 
@@ -43,6 +43,6 @@ SELECT avg(col_a), avg(col_b) FROM read_parquet('__TEST_DIR__/row_groups_per_fil
 4999999.5	4999999.5
 
 query I
-SELECT count(*) BETWEEN 15 AND 25 FROM glob('__TEST_DIR__/row_groups_per_file43/*.parquet')
+SELECT count(*) BETWEEN 10 AND 25 FROM glob('__TEST_DIR__/row_groups_per_file43/*.parquet')
 ----
 true


### PR DESCRIPTION
When all threads work on `COPY TO` to a single output file, there will always be some contention. We try too keep this to a minimum. However, for the `FILE_SIZE_BYTES`/`ROW_GROUPS_PER_FILE` parameters, we used a single lock to manage rotating to the next file, which leads to very low CPU utilization.

When threads write to a single output file (using `PER_THREAD_OUTPUT`), there isn't any contention:
```sql
call dbgen(sf=10);
set preserve_insertion_order=false;
copy lineitem to 'lineitem' (format parquet, row_group_size_bytes '128mb', file_size_bytes '128mb', per_thread_output true, overwrite true);
```
The `COPY TO` query finishes in ~2.2s on my laptop. When we remove `PER_THREAD_OUTPUT`:
```sql
copy lineitem to 'lineitem' (format parquet, row_group_size_bytes '128mb', file_size_bytes '128mb', overwrite true);
```
The query finishes in ~16s, more than 7x slower, even though there are 10 threads available.

In this PR, I've reworked the locking mechanism, which has brought the time of the second query down to ~2.3s, only slightly slower than with `PER_THREAD_OUTPUT`.