### PR TITLE
Fix #16552: adjust join condition sequence

### DIFF
--- a/src/planner/binder/tableref/plan_joinref.cpp
+++ b/src/planner/binder/tableref/plan_joinref.cpp
@@ -203,9 +203,6 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(ClientContext &con
 			// all conditions were pushed down, add TRUE predicate
 			arbitrary_expressions.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(true)));
 		}
-		for (auto &condition : conditions) {
-			arbitrary_expressions.push_back(JoinCondition::CreateExpression(std::move(condition)));
-		}
 		// if we get here we could not create any JoinConditions
 		// turn this into an arbitrary expression join
 		auto any_join = make_uniq<LogicalAnyJoin>(type);
@@ -214,8 +211,21 @@ unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(ClientContext &con
 		any_join->children.push_back(std::move(right_child));
 		// AND all the arbitrary expressions together
 		// do the same with any remaining conditions
-		any_join->condition = std::move(arbitrary_expressions[0]);
-		for (idx_t i = 1; i < arbitrary_expressions.size(); i++) {
+		idx_t start_idx = 0;
+		if (conditions.empty()) {
+			// no conditions, just use the arbitrary expressions
+			any_join->condition = std::move(arbitrary_expressions[0]);
+			start_idx = 1;
+		} else {
+			// we have some conditions as well
+			any_join->condition = JoinCondition::CreateExpression(std::move(conditions[0]));
+			for (idx_t i = 1; i < conditions.size(); i++) {
+				any_join->condition = make_uniq<BoundConjunctionExpression>(
+				    ExpressionType::CONJUNCTION_AND, std::move(any_join->condition),
+				    JoinCondition::CreateExpression(std::move(conditions[i])));
+			}
+		}
+		for (idx_t i = start_idx; i < arbitrary_expressions.size(); i++) {
 			any_join->condition = make_uniq<BoundConjunctionExpression>(
 			    ExpressionType::CONJUNCTION_AND, std::move(any_join->condition), std::move(arbitrary_expressions[i]));
 		}


### PR DESCRIPTION
This pr tries to fix #16552 with just one simple idea: JoinCondition may be faster, so it should be executed first instead of arbitrary expressions.

And I have some doubts when checking this issue:
Does the order of filter expressions in sql have to be respected if any expression ``CanThrow() == true``?

If not, then ``ExpressionHeuristics`` shouldn't skip optimising filter expression sequence as modified in #14672

If indeed it needs to do so, then ``LogicalComparisonJoin::ExtractJoinConditions`` shouldn't split expressions by ``LogicalFilter::SplitPredicates(expressions)`` because this method doesn't keep original expressions sequence.