### PR TITLE
Add back manylinux extensions

### DIFF
--- a/.github/actions/build_extensions_dockerized/action.yml
+++ b/.github/actions/build_extensions_dockerized/action.yml
@@ -59,6 +59,7 @@ runs:
           echo "OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ inputs.vcpkg_target_triplet }}" >> docker_env.txt
           echo "OPENSSL_USE_STATIC_LIBS=true" >> docker_env.txt
           echo "DUCKDB_PLATFORM=${{ inputs.duckdb_arch }}" >> docker_env.txt
+          echo "CMAKE_POLICY_VERSION_MINIMUM=3.5" >> docker_env.txt
           echo "OVERRIDE_GIT_DESCRIBE=${{ inputs.override_git_describe }}" >> docker_env.txt
           echo "LINUX_CI_IN_DOCKER=1" >> docker_env.txt
           echo "TOOLCHAIN_FLAGS=${{ inputs.duckdb_arch == 'linux_arm64' && '-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_Fortran_COMPILER=aarch64-linux-gnu-gfortran' || '' }}" >> docker_env.txt

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -126,7 +126,6 @@ jobs:
   manylinux-extensions-x64:
     name: Linux Extensions (linux_amd64_gcc4)
     needs: linux-python3-10
-    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -161,7 +160,6 @@ jobs:
 
   upload-linux-extensions-gcc4:
     name: Upload Linux Extensions (gcc4)
-    if: false
     needs: manylinux-extensions-x64
     uses: ./.github/workflows/_sign_deploy_extensions.yml
     secrets: inherit
@@ -172,8 +170,7 @@ jobs:
 
   linux-python3:
     name: Python 3 Linux
-    # needs: manylinux-extensions-x64
-    needs: linux-python3-10
+    needs: manylinux-extensions-x64
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -247,8 +244,7 @@ jobs:
         python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"
 
     - uses: actions/download-artifact@v4
-      if: false
-      # if: ${{ matrix.arch == 'x86_64' }}
+      if: ${{ matrix.arch == 'x86_64' }}
       with:
         name: manylinux-extensions-x64
         path: tools/pythonpkg


### PR DESCRIPTION
Revert of https://github.com/duckdb/duckdb/pull/16932, and add env variable `CMAKE_POLICY_VERSION_MINIMUM=3.5` to force backward compatible cmake in the container.

This still needs a fix for handling cmake 4.0.0 in mainline duckdb, but restore the extension building job