### PR TITLE
trigger .github/workflows/NightlyBuildsCheck.yml from external repo

### DIFF
--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -43,3 +43,18 @@ jobs:
           export URL=https://api.github.com/repos/duckdb/duckdb-odbc/actions/workflows/Vendor.yml/dispatches
           export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
+
+
+  notify-nightly-build-status:
+    name: Run Nightly build status
+    runs-on: ubuntu-latest
+    env:
+      PAT_USER: ${{ secrets.PAT_USERNAME }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+    steps:
+      - name: Run Nightly build status
+        if: ${{ github.repository == 'duckdb/duckdb' }}
+        run: |
+          export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
+          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
+          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"


### PR DESCRIPTION
Added a job triggering the `.github/workflows/NightlyBuildsCheck.yml` workflow from external repository.

We'd like to trigger the run of this workflow in the end of the `InvokeCI` run.
The `.github/workflows/NotifyExternalRepositories.yml` already has all the credentials and does the same for another workflow, that's why @carlopi suggested to add a job to trigger one more workflow run here.