### PR TITLE
[Fix] Flush local storage before any deletes

### DIFF
--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -313,7 +313,7 @@ static idx_t PerformOnConflictAction(InsertLocalState &lstate, InsertGlobalState
 		}
 		auto &local_storage = LocalStorage::Get(context.client, data_table.db);
 		if (gstate.initialized) {
-			// Flush the data first, it might be referenced by the Update
+			// Flush any local appends that could be referenced by the UPDATE.
 			data_table.FinalizeLocalAppend(gstate.append_state);
 			gstate.initialized = false;
 		}
@@ -326,6 +326,11 @@ static idx_t PerformOnConflictAction(InsertLocalState &lstate, InsertGlobalState
 		data_table.Delete(delete_state, context.client, row_ids, update_chunk.size());
 	} else {
 		auto &local_storage = LocalStorage::Get(context.client, data_table.db);
+		if (gstate.initialized) {
+			// Flush any local appends that could be referenced by the DELETE.
+			data_table.FinalizeLocalAppend(gstate.append_state);
+			gstate.initialized = false;
+		}
 		local_storage.Delete(data_table, row_ids, update_chunk.size());
 	}
 

--- a/test/sql/index/art/constraints/test_art_upsert_duplicate.test
+++ b/test/sql/index/art/constraints/test_art_upsert_duplicate.test
@@ -1,0 +1,28 @@
+# name: test/sql/index/art/constraints/test_art_upsert_duplicate.test
+# description: Test an UPSERT with a duplicate in the VALUES list.
+# group: [constraints]
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+CREATE TABLE hero (
+        name VARCHAR NOT NULL,
+        secret_name VARCHAR NOT NULL,
+        age INTEGER,
+        PRIMARY KEY (name));
+
+statement ok
+CREATE INDEX ix_hero_age ON hero (age);
+
+statement ok
+INSERT INTO hero (name, secret_name, age)
+VALUES
+	('Captain North America', 'Esteban Rogelios', 93),
+	('Rusty-Man', 'Tommy Sharp', 48),
+	('Tarantula', 'Natalia Roman-on', 32),
+	('Spider-Boy', 'Pedro Parqueador', 17),
+	('Captain North America', 'Esteban Rogelios', 93)
+ON CONFLICT (name) DO UPDATE
+SET	secret_name = EXCLUDED.secret_name,
+	age = EXCLUDED.age;


### PR DESCRIPTION
I picked up the previous work on https://github.com/duckdb/duckdb/issues/16331 by @Tishj and added a test.

As far as I can tell, setting the `gstate` to uninitialised is fine, here, and flushing before deleting fixes the issue.