### PR TITLE
Pass down CMAKE_POLICY_VERSION_MINIMUM and fix for local development

### DIFF
--- a/.github/actions/build_extensions/action.yml
+++ b/.github/actions/build_extensions/action.yml
@@ -88,6 +88,9 @@ inputs:
     description: 'Flags to be passed to cmake'
     default: ''
 
+env:
+  CMAKE_POLICY_VERSION_MINIMUM: 3.5
+
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/Wasm.yml
+++ b/.github/workflows/Wasm.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
 jobs:
  wasm-extensions:

--- a/scripts/merge_vcpkg_deps.py
+++ b/scripts/merge_vcpkg_deps.py
@@ -17,7 +17,7 @@ merged_overlay_ports = []
 def prefix_overlay_ports(overlay_ports, path_to_vcpkg_json):
     def prefix_overlay_port(overlay_port):
         vcpkg_prefix_path = path_to_vcpkg_json[0 : path_to_vcpkg_json.find("/vcpkg.json")]
-        return vcpkg_prefix_path + overlay_port
+        return vcpkg_prefix_path + '/' + overlay_port
 
     return map(prefix_overlay_port, overlay_ports)
 

--- a/scripts/merge_vcpkg_deps.py
+++ b/scripts/merge_vcpkg_deps.py
@@ -17,6 +17,8 @@ merged_overlay_ports = []
 def prefix_overlay_ports(overlay_ports, path_to_vcpkg_json):
     def prefix_overlay_port(overlay_port):
         vcpkg_prefix_path = path_to_vcpkg_json[0 : path_to_vcpkg_json.find("/vcpkg.json")]
+        if len(vcpkg_prefix_path) == 0:
+            return overlay_port
         return vcpkg_prefix_path + '/' + overlay_port
 
     return map(prefix_overlay_port, overlay_ports)


### PR DESCRIPTION
CMAKE_POLICY_VERSION_MINIMUM needs currently to be passed as env variable, so fixing failures in Wasm and possibly elsewhere for when CMake is bumped to 4.0.0

Also fixing a corner case, unsure if ever worked, where a slash would be missing and `some/path` + "`./vcpkg.json` would be constructed as `some/path./vcpkg.json` that do not work. Now `some/path/./vcpkg.json`. With corner case for empty paths.