### PR TITLE
Move the no string inline/alternative verify workflow to Main.yml

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -358,41 +358,6 @@ jobs:
       shell: bash
       run: python3 scripts/exported_symbols_check.py build/release/src/libduckdb*.so
 
- no-string-inline:
-    name: No String Inline / Destroy Unpinned Blocks
-    runs-on: ubuntu-24.04
-    env:
-      GEN: ninja
-      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
-      DISABLE_STRING_INLINE: 1
-      DESTROY_UNPINNED_BLOCKS: 1
-      ALTERNATIVE_VERIFY: 1
-      DISABLE_POINTER_SALT: 1
-      LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install
-        shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
-
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@main
-        with:
-          key: ${{ github.job }}
-          save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
-
-      - name: Build
-        shell: bash
-        run: make relassert
-
-      - name: Test
-        shell: bash
-        run: build/relassert/test/unittest
-
  amalgamation-tests:
     name: Amalgamation Tests
     if: ${{ inputs.skip_tests != 'true' }}

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -358,6 +358,41 @@ jobs:
       shell: bash
       run: python3 scripts/exported_symbols_check.py build/release/src/libduckdb*.so
 
+ no-string-inline:
+    name: No String Inline / Destroy Unpinned Blocks
+    runs-on: ubuntu-24.04
+    env:
+      GEN: ninja
+      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
+      DISABLE_STRING_INLINE: 1
+      DESTROY_UNPINNED_BLOCKS: 1
+      ALTERNATIVE_VERIFY: 1
+      DISABLE_POINTER_SALT: 1
+      LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        shell: bash
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}
+          save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
+      - name: Build
+        shell: bash
+        run: make relassert
+
+      - name: Test
+        shell: bash
+        run: build/relassert/test/unittest
+
  amalgamation-tests:
     name: Amalgamation Tests
     if: ${{ inputs.skip_tests != 'true' }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -191,6 +191,42 @@ jobs:
       shell: bash
       run: build/reldebug/test/unittest --force-reload --force-storage
 
+ no-string-inline:
+    name: No String Inline / Destroy Unpinned Blocks
+    runs-on: ubuntu-24.04
+    needs: force-storage
+    env:
+      GEN: ninja
+      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
+      DISABLE_STRING_INLINE: 1
+      DESTROY_UNPINNED_BLOCKS: 1
+      ALTERNATIVE_VERIFY: 1
+      DISABLE_POINTER_SALT: 1
+      LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        shell: bash
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}
+          save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
+      - name: Build
+        shell: bash
+        run: make relassert
+
+      - name: Test
+        shell: bash
+        run: build/relassert/test/unittest
+
  vector-sizes:
     name: Vector Sizes
     runs-on: ubuntu-22.04

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -390,42 +390,6 @@ jobs:
         run: |
           ./scripts/run_extension_medata_tests.sh
 
-  no-string-inline:
-    name: No String Inline / Destroy Unpinned Blocks
-    runs-on: ubuntu-24.04
-    needs: linux-memory-leaks
-    env:
-      GEN: ninja
-      CORE_EXTENSIONS: "icu;parquet;tpch;tpcds;fts;json;inet"
-      DISABLE_STRING_INLINE: 1
-      DESTROY_UNPINNED_BLOCKS: 1
-      ALTERNATIVE_VERIFY: 1
-      DISABLE_POINTER_SALT: 1
-      LSAN_OPTIONS: suppressions=${{ github.workspace }}/.sanitizer-leak-suppressions.txt
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install
-        shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
-
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@main
-        with:
-          key: ${{ github.job }}
-          save: ${{ env.CCACHE_SAVE }}
-
-      - name: Build
-        shell: bash
-        run: make relassert
-
-      - name: Test
-        shell: bash
-        run: build/relassert/test/unittest
-
   latest-storage:
     name: Latest Storage
     runs-on: ubuntu-22.04

--- a/extension/core_functions/scalar/list/array_slice.cpp
+++ b/extension/core_functions/scalar/list/array_slice.cpp
@@ -418,6 +418,7 @@ static unique_ptr<FunctionData> ArraySliceBind(ClientContext &context, ScalarFun
 		}
 		if (arguments[0]->return_type.IsJSONType()) {
 			// This is needed to avoid producing invalid JSON
+			bound_function.arguments[0] = LogicalType::VARCHAR;
 			bound_function.return_type = LogicalType::VARCHAR;
 		} else {
 			bound_function.return_type = arguments[0]->return_type;

--- a/test/sql/cte/recursive_cte_key_variant.test
+++ b/test/sql/cte/recursive_cte_key_variant.test
@@ -127,14 +127,14 @@ statement error
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (SELECT 5, 1 UNION SELECT a, b + 1 FROM tbl WHERE b < a),
 tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
 ----
-Binder Error: There is a WITH item named "tbl", but the recurring table cannot be referenced from this part of the query.
+cannot be referenced
 
 # second cte references recurring table of first like the first cte
 statement error
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (SELECT  * FROM ((VALUES (5, 1), (6,1)) UNION SELECT a, b + 1 FROM recurring.tbl WHERE b < a) WHERE a = 5),
 tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
 ----
-Binder Error: There is a WITH item named "tbl", but the recurring table cannot be referenced from this part of the query.
+cannot be referenced
 
 statement error
 WITH RECURSIVE tbl2(a) AS (SELECT 1 UNION SELECT a.a+1 FROM tbl2 AS a, (SELECT * FROM recurring.tbl2) AS b WHERE a.a < 2) SELECT * FROM tbl2;
@@ -144,12 +144,12 @@ Invalid Input Error: RECURRING can only be used with USING KEY in recursive CTE.
 statement error
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS (SELECT 5, 1 UNION SELECT a, b + 1 FROM tbl WHERE b < a),tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
 ----
-Binder Error: There is a WITH item named "tbl", but the recurring table cannot be referenced from this part of the query.
+cannot be referenced
 
 statement error
 WITH RECURSIVE tbl(a, b) USING KEY (a) AS MATERIALIZED (SELECT 5, 1 UNION SELECT a, b + 1 FROM tbl WHERE b < a),tbl1(a,b) AS (SELECT * FROM recurring.tbl) SELECT * FROM tbl1;
 ----
-Binder Error: There is a WITH item named "tbl", but the recurring table cannot be referenced from this part of the query.
+cannot be referenced
 
 
 #######################


### PR DESCRIPTION
This PR moves the no string inline/alternative verify workflow to Main.yml, and fixes a few minor issues with the workflow