### PR TITLE
Re-enable workflows to run on PRs

### DIFF
--- a/.github/workflows/Julia.yml
+++ b/.github/workflows/Julia.yml
@@ -18,11 +18,16 @@ on:
       - '!.github/workflows/Julia.yml'
   merge_group:
   pull_request:
-   types: [opened, reopened, ready_for_review]
-   paths-ignore:
-      - '**'
-      - '!.github/workflows/Julia.yml'
+    types: [opened, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
       - '!tools/juliapkg/**'
+      - '.github/patches/duckdb-wasm/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Julia.yml'
 
 
 concurrency:

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -16,8 +16,7 @@ on:
       - '!.github/workflows/Main.yml'
   merge_group:
   pull_request:
-    types:
-      - auto_merge_enabled
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -16,9 +16,14 @@ on:
       - '!.github/workflows/Main.yml'
   merge_group:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types:
+      - auto_merge_enabled
     paths-ignore:
-      - '**'
+      - '**.md'
+      - 'tools/**'
+      - '!tools/shell/**'
+      - '.github/patches/duckdb-wasm/**'
+      - '.github/workflows/**'
       - '!.github/workflows/Main.yml'
 
 

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -23,8 +23,7 @@ on:
       - '!.github/workflows/Regression.yml'
   merge_group:
   pull_request:
-    types:
-      - auto_merge_enabled
+    types: [opened, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'tools/**'

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -22,6 +22,16 @@ on:
       - '.github/workflows/**'
       - '!.github/workflows/Regression.yml'
   merge_group:
+  pull_request:
+    types:
+      - auto_merge_enabled
+    paths-ignore:
+      - '**.md'
+      - 'tools/**'
+      - '!tools/pythonpkg/**'
+      - '.github/patches/duckdb-wasm/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Regression.yml'
 
 
 concurrency:

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -20,7 +20,13 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
     paths-ignore:
-      - '**'
+      - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/swift/**'
+      - '.github/patches/duckdb-wasm/**'
+      - '.github/workflows/**'
       - '!.github/workflows/Swift.yml'
 
 


### PR DESCRIPTION
The `merge_group` addition has not seemed to do anything - so let's revert back to the old ways for now