### PR TITLE
Add a setting `scheduler_process_partial` that allows partial scheduling of tasks in the background threads

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -738,6 +738,12 @@
         "scope": "local"
     },
     {
+        "name": "scheduler_process_partial",
+        "description": "Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries",
+        "type": "BOOLEAN",
+        "scope": "global"
+    },
+    {
         "name": "schema",
         "description": "Sets the default search schema. Equivalent to setting search_path to a single value.",
         "type": "VARCHAR",

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -290,6 +290,8 @@ struct DBConfigOptions {
 	set<string> allowed_directories;
 	//! The log configuration
 	LogConfig log_config = LogConfig();
+	//! Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries
+	bool scheduler_process_partial = true;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -291,7 +291,11 @@ struct DBConfigOptions {
 	//! The log configuration
 	LogConfig log_config = LogConfig();
 	//! Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries
+#ifdef DUCKDB_ALTERNATIVE_VERIFY
+	bool scheduler_process_partial = true;
+#else
 	bool scheduler_process_partial = false;
+#endif
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -291,7 +291,7 @@ struct DBConfigOptions {
 	//! The log configuration
 	LogConfig log_config = LogConfig();
 	//! Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries
-	bool scheduler_process_partial = true;
+	bool scheduler_process_partial = false;
 
 	bool operator==(const DBConfigOptions &other) const;
 };

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1122,6 +1122,17 @@ struct ScalarSubqueryErrorOnMultipleRowsSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct SchedulerProcessPartialSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "scheduler_process_partial";
+	static constexpr const char *Description =
+	    "Partially process tasks before rescheduling - allows for more scheduler fairness between separate queries";
+	static constexpr const char *InputType = "BOOLEAN";
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct SchemaSetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "schema";

--- a/src/include/duckdb/parallel/task.hpp
+++ b/src/include/duckdb/parallel/task.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 
 namespace duckdb {
 class ClientContext;
@@ -50,6 +51,9 @@ public:
 	virtual bool TaskBlockedOnResult() const {
 		return false;
 	}
+
+public:
+	optional_ptr<ProducerToken> token;
 };
 
 } // namespace duckdb

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -161,6 +161,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(ProfilingModeSetting),
     DUCKDB_LOCAL(ProgressBarTimeSetting),
     DUCKDB_LOCAL(ScalarSubqueryErrorOnMultipleRowsSetting),
+    DUCKDB_GLOBAL(SchedulerProcessPartialSetting),
     DUCKDB_LOCAL(SchemaSetting),
     DUCKDB_LOCAL(SearchPathSetting),
     DUCKDB_GLOBAL(SecretDirectorySetting),

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -1118,6 +1118,22 @@ Value ScalarSubqueryErrorOnMultipleRowsSetting::GetSetting(const ClientContext &
 }
 
 //===----------------------------------------------------------------------===//
+// Scheduler Process Partial
+//===----------------------------------------------------------------------===//
+void SchedulerProcessPartialSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.options.scheduler_process_partial = input.GetValue<bool>();
+}
+
+void SchedulerProcessPartialSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.scheduler_process_partial = DBConfig().options.scheduler_process_partial;
+}
+
+Value SchedulerProcessPartialSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.options.scheduler_process_partial);
+}
+
+//===----------------------------------------------------------------------===//
 // Zstd Min String Length
 //===----------------------------------------------------------------------===//
 void ZstdMinStringLengthSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -63,8 +63,6 @@ BaseExecutorTask::BaseExecutorTask(TaskExecutor &executor) : executor(executor) 
 }
 
 TaskExecutionResult BaseExecutorTask::Execute(TaskExecutionMode mode) {
-	(void)mode;
-	D_ASSERT(mode == TaskExecutionMode::PROCESS_ALL);
 	if (executor.HasError()) {
 		// another task encountered an error - bailout
 		executor.FinishTask();

--- a/test/api/capi/test_capi_streaming.cpp
+++ b/test/api/capi/test_capi_streaming.cpp
@@ -29,6 +29,7 @@ TEST_CASE("Test streaming results in C API", "[capi]") {
 	auto chunk = result->StreamChunk();
 
 	idx_t value = duckdb::DConstants::INVALID_INDEX;
+	idx_t result_count = 0;
 	while (chunk) {
 		auto old_value = value;
 
@@ -40,6 +41,9 @@ TEST_CASE("Test streaming results in C API", "[capi]") {
 			// one.
 			REQUIRE(value > old_value);
 		}
+		REQUIRE(chunk->size() > 0);
+		result_count += chunk->size();
+		REQUIRE(result_count <= 1000000);
 		chunk = result->StreamChunk();
 	}
 }

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -167,6 +167,7 @@ bool OptionIsExcludedFromTest(const string &name) {
 	    "custom_user_agent",
 	    "default_block_size",
 	    "index_scan_percentage",
+	    "scheduler_process_partial",
 	    "index_scan_max_count"};
 	return excluded_options.count(name) == 1;
 }

--- a/test/sql/tpch/tpch_partial_scheduling.test_slow
+++ b/test/sql/tpch/tpch_partial_scheduling.test_slow
@@ -1,0 +1,27 @@
+# name: test/sql/tpch/tpch_partial_scheduling.test_slow
+# description: Test TPC-H SF1 while running all queries at oncem
+# group: [tpch]
+
+require tpch
+
+statement ok
+CALL dbgen(sf=1);
+
+statement ok
+SET scheduler_process_partial=true;
+
+concurrentloop i 1 23
+
+onlyif i<=9
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q0${i}.csv
+
+onlyif i>=10
+query I
+PRAGMA tpch(${i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q${i}.csv
+
+endloop


### PR DESCRIPTION
This PR adds a new setting - `scheduler_process_partial` - that allows partial scheduling of tasks in the background threads. Normally, the background tasks pass `TaskExecutionMode::PROCESS_ALL` to the tasks they execute - leading to them being stuck on processing the task fully until it is completed. As a result, long-running queries can block short-running queries.

In regular DuckDB operation - that is not a big problem, because every connection has its own "processing thread" that works only on the queries it issues - and hence short-running queries still make some progress. That is not always the case - however. When using certain APIs (e.g. the pending query API) the foreground thread might not participate in the query processing, leaving everything to the background tasks. As a result, short-running queries can become starved.

Enabling this setting improves fairness by only working on tasks partially before rescheduling. As a result, bigger tasks will need more "rounds" and short-running queries will complete without stalling. The setting is disabled by default for now as in most instances this will not be required - but is enabled in CI with the alternative verification setting. 