### PR TITLE
[Dev] Use `UnifiedVectorFormat` instead of a flattened `Vector` in `UpdateSegment::Update`

### DIFF
--- a/src/include/duckdb/common/types/row/tuple_data_states.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_states.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/perfect_map_set.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/vector_cache.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 

--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -67,9 +67,10 @@ private:
 
 public:
 	typedef void (*initialize_update_function_t)(UpdateInfo &base_info, Vector &base_data, UpdateInfo &update_info,
-	                                             Vector &update, const SelectionVector &sel);
+	                                             UnifiedVectorFormat &update, const SelectionVector &sel);
 	typedef void (*merge_update_function_t)(UpdateInfo &base_info, Vector &base_data, UpdateInfo &update_info,
-	                                        Vector &update, row_t *ids, idx_t count, const SelectionVector &sel);
+	                                        UnifiedVectorFormat &update, row_t *ids, idx_t count,
+	                                        const SelectionVector &sel);
 	typedef void (*fetch_update_function_t)(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info,
 	                                        Vector &result);
 	typedef void (*fetch_committed_function_t)(UpdateInfo &info, Vector &result);
@@ -78,8 +79,8 @@ public:
 	typedef void (*fetch_row_function_t)(transaction_t start_time, transaction_t transaction_id, UpdateInfo &info,
 	                                     idx_t row_idx, Vector &result, idx_t result_idx);
 	typedef void (*rollback_update_function_t)(UpdateInfo &base_info, UpdateInfo &rollback_info);
-	typedef idx_t (*statistics_update_function_t)(UpdateSegment *segment, SegmentStatistics &stats, Vector &update,
-	                                              idx_t count, SelectionVector &sel);
+	typedef idx_t (*statistics_update_function_t)(UpdateSegment *segment, SegmentStatistics &stats,
+	                                              UnifiedVectorFormat &update, idx_t count, SelectionVector &sel);
 
 private:
 	initialize_update_function_t initialize_update_function;

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -659,7 +659,7 @@ static void InitializeUpdateValidity(UpdateInfo &base_info, Vector &base_data, U
 
 	if (!update_mask.AllValid()) {
 		for (idx_t i = 0; i < update_info.N; i++) {
-			auto idx = sel.get_index(i);
+			auto idx = update.sel->get_index(sel.get_index(i));
 			tuple_data[i] = update_mask.RowIsValidUnsafe(idx);
 		}
 	} else {

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -985,7 +985,8 @@ idx_t UpdateValidityStatistics(UpdateSegment *segment, SegmentStatistics &stats,
 	auto &validity = stats.statistics;
 	if (!mask.AllValid() && !validity.CanHaveNull()) {
 		for (idx_t i = 0; i < count; i++) {
-			if (!mask.RowIsValid(i)) {
+			auto idx = update.sel->get_index(i);
+			if (!mask.RowIsValid(idx)) {
 				validity.SetHasNullFast();
 				break;
 			}

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -818,7 +818,6 @@ static void MergeUpdateLoopInternal(UpdateInfo &base_info, V *base_table_data, U
 	// all of these should be sorted, otherwise the below algorithm does not work
 	for (idx_t i = 1; i < count; i++) {
 		auto prev_idx = sel.get_index(i - 1);
-
 		auto idx = sel.get_index(i);
 		D_ASSERT(ids[idx] > ids[prev_idx] && ids[idx] >= row_t(base_id) &&
 		         ids[idx] < row_t(base_id + STANDARD_VECTOR_SIZE));
@@ -1124,7 +1123,6 @@ static idx_t SortSelectionVector(SelectionVector &sel, idx_t count, row_t *ids) 
 	for (idx_t i = 1; i < count; i++) {
 		auto prev_idx = sorted_sel.get_index(i - 1);
 		auto idx = sorted_sel.get_index(i);
-
 		D_ASSERT(ids[idx] >= ids[prev_idx]);
 		if (ids[prev_idx] != ids[idx]) {
 			sorted_sel.set_index(pos++, idx);
@@ -1177,7 +1175,6 @@ void UpdateSegment::Update(TransactionData transaction, idx_t column_index, Vect
 	SelectionVector sel;
 	{
 		lock_guard<mutex> stats_guard(stats_lock);
-		//! Create a selection vector from the updates, the selection vector maps to the raw indices (no indirection)
 		count = statistics_update_function(this, stats, update_format, count, sel);
 	}
 	if (count == 0) {
@@ -1187,8 +1184,7 @@ void UpdateSegment::Update(TransactionData transaction, idx_t column_index, Vect
 	// subsequent algorithms used by the update require row ids to be (1) sorted, and (2) unique
 	// this is usually the case for "standard" queries (e.g. UPDATE tbl SET x=bla WHERE cond)
 	// however, for more exotic queries involving e.g. cross products/joins this might not be the case
-	// hence we explicitly check here if the ids are sorted and, if not, sort + duplicate eliminate them (if two or more
-	// updates target the same id)
+	// hence we explicitly check here if the ids are sorted and, if not, sort + duplicate eliminate them
 	count = SortSelectionVector(sel, count, ids);
 	D_ASSERT(count > 0);
 


### PR DESCRIPTION
This PR is the first step to fixing https://github.com/duckdblabs/duckdb-internal/issues/4528

The problem is that we made a slice of a Vector, then use Flatten on that slice, adjusting the data of the Vector in a way that breaks the further assumptions about the vector.