### PR TITLE
Support COLUMN_IDENTIFIER_EMPTY

### DIFF
--- a/src/function/table/arrow.cpp
+++ b/src/function/table/arrow.cpp
@@ -85,7 +85,7 @@ unique_ptr<ArrowArrayStreamWrapper> ProduceArrowScan(const ArrowScanFunctionData
 	auto &arrow_types = function.arrow_table.GetColumns();
 	for (idx_t idx = 0; idx < column_ids.size(); idx++) {
 		auto col_idx = column_ids[idx];
-		if (col_idx != COLUMN_IDENTIFIER_ROW_ID) {
+		if (col_idx != COLUMN_IDENTIFIER_ROW_ID && col_idx != COLUMN_IDENTIFIER_EMPTY) {
 			auto &schema = *function.schema_root.arrow_schema.children[col_idx];
 			arrow_types.at(col_idx)->ThrowIfInvalid();
 			parameters.projected_columns.projection_map[idx] = schema.name;

--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -231,9 +231,6 @@ protected:
 	//! -----Utility Functions:-----
 	//! Gets Arrow Table's Cardinality
 	static unique_ptr<NodeStatistics> ArrowScanCardinality(ClientContext &context, const FunctionData *bind_data);
-	//! Gets the progress on the table scan, used for Progress Bars
-	static double ArrowProgress(ClientContext &context, const FunctionData *bind_data,
-	                            const GlobalTableFunctionState *global_state);
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This is necessary to handle multiple arrow ipc files in the arrow extension

I've also removed `ArrowProgress` since that's never defined nor used.