### PR TITLE
Make `file_row_number` a virtual column, and support per-file virtual columns in the MultiFileReader

### DIFF
--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -101,6 +101,7 @@ struct ParquetOptions {
 
 	bool binary_as_string = false;
 	bool file_row_number = false;
+	optional_idx file_row_number_idx;
 	shared_ptr<ParquetEncryptionConfig> encryption_config;
 	bool debug_use_openssl = true;
 
@@ -173,6 +174,8 @@ public:
 	string GetReaderType() const override {
 		return "Parquet";
 	}
+
+	void AddVirtualColumn(column_t virtual_column_id) override;
 
 private:
 	//! Construct a parquet reader but **do not** open a file, used in ReadStatistics only

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -134,6 +134,10 @@ struct ParquetUnionData : public BaseUnionData {
 
 class ParquetReader : public BaseFileReader {
 public:
+	// Reserved field id used for the "ord" field according to the iceberg spec (used for file_row_number)
+	static constexpr int32_t ORDINAL_FIELD_ID = 2147483645;
+
+public:
 	ParquetReader(ClientContext &context, string file_name, ParquetOptions parquet_options,
 	              shared_ptr<ParquetFileMetadataCache> metadata = nullptr);
 	~ParquetReader() override;

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -101,7 +101,6 @@ struct ParquetOptions {
 
 	bool binary_as_string = false;
 	bool file_row_number = false;
-	optional_idx file_row_number_idx;
 	shared_ptr<ParquetEncryptionConfig> encryption_config;
 	bool debug_use_openssl = true;
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -186,6 +186,14 @@ static void BindSchema(ClientContext &context, vector<LogicalType> &return_types
 		res.default_expression = make_uniq<ConstantExpression>(column.default_value);
 		reader_bind.schema.emplace_back(std::move(res));
 	}
+	ParseFileRowNumberOption(reader_bind, options, return_types, names);
+	if (options.file_row_number) {
+		MultiFileColumnDefinition res("file_row_number", LogicalType::BIGINT);
+		res.identifier = Value::INTEGER(ParquetReader::ORDINAL_FIELD_ID);
+		schema_col_names.push_back(res.name);
+		schema_col_types.push_back(res.type);
+		reader_bind.schema.emplace_back(std::move(res));
+	}
 
 	if (match_by_field_id) {
 		reader_bind.mapping = MultiFileColumnMappingMode::BY_FIELD_ID;
@@ -200,8 +208,6 @@ static void BindSchema(ClientContext &context, vector<LogicalType> &return_types
 	names = schema_col_names;
 	return_types = schema_col_types;
 	D_ASSERT(names.size() == return_types.size());
-
-	ParseFileRowNumberOption(reader_bind, options, return_types, names);
 }
 
 void ParquetMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<string> &names,

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -134,7 +134,6 @@ static void ParseFileRowNumberOption(MultiFileReaderBindData &bind_data, Parquet
 			    "Using file_row_number option on file with column named file_row_number is not supported");
 		}
 
-		options.file_row_number_idx = names.size();
 		return_types.emplace_back(LogicalType::BIGINT);
 		names.emplace_back("file_row_number");
 	}

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -36,6 +36,8 @@
 
 namespace duckdb {
 
+constexpr int32_t ParquetReader::ORDINAL_FIELD_ID;
+
 using duckdb_parquet::ColumnChunk;
 using duckdb_parquet::ConvertedType;
 using duckdb_parquet::FieldRepetitionType;
@@ -612,6 +614,10 @@ unique_ptr<ParquetColumnSchema> ParquetReader::ParseSchema() {
 MultiFileColumnDefinition ParquetReader::ParseColumnDefinition(const FileMetaData &file_meta_data,
                                                                ParquetColumnSchema &element) {
 	MultiFileColumnDefinition result(element.name, element.type);
+	if (element.schema_type == ParquetColumnSchemaType::FILE_ROW_NUMBER) {
+		result.identifier = Value::INTEGER(ORDINAL_FIELD_ID);
+		return result;
+	}
 	auto &column_schema = file_meta_data.schema[element.schema_index];
 
 	if (column_schema.__isset.field_id) {

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -16,6 +16,7 @@
 namespace duckdb {
 
 constexpr column_t MultiFileReader::COLUMN_IDENTIFIER_FILENAME;
+constexpr column_t MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER;
 
 MultiFileReaderGlobalState::~MultiFileReaderGlobalState() {
 }

--- a/src/include/duckdb/common/multi_file/base_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/base_file_reader.hpp
@@ -56,6 +56,10 @@ public:
 		//! Whether or not to push casts into the cast map
 		return false;
 	}
+	//! Adds a virtual column to be projected at the end
+	virtual void AddVirtualColumn(column_t virtual_column_id) {
+		throw InternalException("Reader %s does not support AddVirtualColumn", GetReaderType());
+	}
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -33,6 +33,7 @@ enum class ReaderInitializeType { INITIALIZED, SKIP_READING_FILE };
 struct MultiFileReader {
 public:
 	static constexpr column_t COLUMN_IDENTIFIER_FILENAME = UINT64_C(9223372036854775808);
+	static constexpr column_t COLUMN_IDENTIFIER_FILE_ROW_NUMBER = UINT64_C(9223372036854775809);
 
 public:
 	virtual ~MultiFileReader();

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -21,8 +21,6 @@ struct MultiFileReaderBindData {
 	column_t filename_idx = DConstants::INVALID_INDEX;
 	//! The set of hive partitioning indexes (if any)
 	vector<HivePartitioningIndex> hive_partitioning_indexes;
-	//! The (global) column id of the file_row_number column (if any)
-	column_t file_row_number_idx = DConstants::INVALID_INDEX;
 	//! (optional) The schema set by the multi file reader
 	vector<MultiFileColumnDefinition> schema;
 	//! The method used to map local -> global columns

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -192,6 +192,18 @@ FROM read_parquet('__TEST_DIR__/integers.parquet', schema=map {
 ----
 5
 
+# we can still select virtual columns as well
+query III
+SELECT file_row_number, filename[-16:], i4
+FROM read_parquet('__TEST_DIR__/integers.parquet', schema=map {
+                    1: {name: 'i1', type: 'BIGINT', default_value: NULL},
+                    3: {name: 'i3', type: 'BIGINT', default_value: NULL},
+                    4: {name: 'i4', type: 'BIGINT', default_value: 2},
+                    5: {name: 'i5', type: 'BIGINT', default_value: NULL}
+                  })
+----
+0	integers.parquet	2
+
 # projection still, even with different generated columns
 query III
 SELECT file_row_number, filename[-16:], i4

--- a/test/sql/copy/parquet/parquet_virtual_file_row_number.test
+++ b/test/sql/copy/parquet/parquet_virtual_file_row_number.test
@@ -1,0 +1,23 @@
+# name: test/sql/copy/parquet/parquet_virtual_file_row_number.test
+# description: Test file_row_number virtual column
+# group: [parquet]
+
+require parquet
+
+# File row number without the file_row_number option
+query I
+select file_row_number from 'data/parquet-testing/glob/t1.parquet'
+----
+0
+
+query I
+select file_row_number from 'data/parquet-testing/glob/t1.parquet' where file_row_number=0
+----
+0
+
+query IIII
+select i, j, replace(filename, '\', '/'), file_row_number from 'data/parquet-testing/glob*/t?.parquet' order by i;
+----
+1	a	data/parquet-testing/glob/t1.parquet	0
+2	b	data/parquet-testing/glob/t2.parquet	0
+3	c	data/parquet-testing/glob2/t1.parquet	0


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/duckdb/pull/16248

This PR reworks the `file_row_number` to be a virtual column in the Parquet reader, so the following query now works:

```sql
SELECT l_orderkey, file_row_number FROM lineitem.parquet;
```

This PR also implements the necessary infrastructure for allowing arbitrary virtual columns to be defined by readers, so in the future adding new virtual columns to readers will be much simpler. 

This rework allows for the removal of a bunch of hacky special-case code around the `file_row_number` column - this can now all live in the Parquet reader itself. Emitting the file row number is as simple as adding the special code (`MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER `) to the set of projected column ids.
