### PR TITLE
Skip TPC-DS Q67 on DOUBLE

### DIFF
--- a/test/sql/storage/compression/alprd/alprd_tpcds.test_slow
+++ b/test/sql/storage/compression/alprd/alprd_tpcds.test_slow
@@ -656,7 +656,17 @@ PRAGMA tpcds(${i})
 
 endloop
 
-loop i 50 99
+# skip tpcds 67 - inconsistent without decimals
+loop i 50 66
+
+query I
+PRAGMA tpcds(${i})
+----
+<FILE>:extension/tpcds/dsdgen/answers/sf1/${i}.csv
+
+endloop
+
+loop i 68 99
 
 query I
 PRAGMA tpcds(${i})


### PR DESCRIPTION
This query has inconsistent results due to minor differences in the `sum` result when run on floating points - skip it to avoid it failing spuriously when running the tests