### PR TITLE
Clean up format script, gather all files then run concurrently instead of running concurrently per directory

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -393,28 +393,30 @@ def format_file(f, full_path, directory, ext):
         os.rename(tmpfile, full_path)
 
 
+class ToFormatFile:
+    def __init__(self, filename, full_path, directory):
+        self.filename = filename
+        self.full_path = full_path
+        self.directory = directory
+        self.ext = '.' + filename.split('.')[-1]
+
+
 def format_directory(directory):
     files = os.listdir(directory)
     files.sort()
-
-    def process_file(f):
+    result = []
+    for f in files:
         full_path = os.path.join(directory, f)
         if os.path.isdir(full_path):
             if f in ignored_directories or full_path in ignored_directories:
-                return
-            if not silent:
-                print(full_path)
-            format_directory(full_path)
+                continue
+            result += format_directory(full_path)
         elif can_format_file(full_path):
-            format_file(f, full_path, directory, '.' + f.split('.')[-1])
-
-    # Create thread for each file
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        threads = [executor.submit(process_file, f) for f in files]
-        # Wait for all tasks to complete
-        concurrent.futures.wait(threads)
+            result += [ToFormatFile(f, full_path, directory)]
+    return result
 
 
+files = []
 if format_all:
     try:
         os.system(cmake_format_command.replace("${FILE}", "CMakeLists.txt"))
@@ -422,15 +424,27 @@ if format_all:
         pass
 
     for direct in formatted_directories:
-        format_directory(direct)
+        files += format_directory(direct)
 
 else:
     for full_path in changed_files:
         splits = full_path.split(os.path.sep)
         fname = splits[-1]
         dirname = os.path.sep.join(splits[:-1])
-        ext = '.' + full_path.split('.')[-1]
-        format_file(fname, full_path, dirname, ext)
+        files.append(ToFormatFile(fname, full_path, dirname))
+
+
+def process_file(f):
+    if not silent:
+        print(f.full_path)
+    format_file(f.filename, f.full_path, f.directory, f.ext)
+
+
+# Create thread for each file
+with concurrent.futures.ThreadPoolExecutor() as executor:
+    threads = [executor.submit(process_file, f) for f in files]
+    # Wait for all tasks to complete
+    concurrent.futures.wait(threads)
 
 if check_only:
     if len(difference_files) > 0:

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -9,6 +9,8 @@ import inspect
 import subprocess
 import difflib
 import re
+import tempfile
+import uuid
 import concurrent.futures
 from python_helpers import open_utf8
 
@@ -387,7 +389,7 @@ def format_file(f, full_path, directory, ext):
             print(total_diff)
             difference_files.append(full_path)
     else:
-        tmpfile = full_path + ".tmp"
+        tmpfile = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
         with open_utf8(tmpfile, 'w+') as f:
             f.write(new_text)
         os.rename(tmpfile, full_path)

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -442,9 +442,13 @@ def process_file(f):
 
 # Create thread for each file
 with concurrent.futures.ThreadPoolExecutor() as executor:
-    threads = [executor.submit(process_file, f) for f in files]
-    # Wait for all tasks to complete
-    concurrent.futures.wait(threads)
+    try:
+        threads = [executor.submit(process_file, f) for f in files]
+        # Wait for all tasks to complete
+        concurrent.futures.wait(threads)
+    except KeyboardInterrupt:
+        executor.shutdown(wait=False, cancel_futures=True)
+        raise
 
 if check_only:
     if len(difference_files) > 0:

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -447,7 +447,7 @@ with concurrent.futures.ThreadPoolExecutor() as executor:
         # Wait for all tasks to complete
         concurrent.futures.wait(threads)
     except KeyboardInterrupt:
-        executor.shutdown(wait=False, cancel_futures=True)
+        executor.shutdown(wait=True, cancel_futures=True)
         raise
 
 if check_only:


### PR DESCRIPTION
This PR cleans up the format script by first gathering all to-be-formatted files and then running the multithreaded executor.