### PR TITLE
Try enabling and bump delta

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -64,13 +64,11 @@ endif()
 ################# DELTA
 # MinGW build is not available, and our current manylinux ci does not have enough storage space to run the rust build
 # for Delta
-if (FALSE)
 if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
-            GIT_TAG 6d626173e9efa6615c25eb08d979d1372100d5db
+            GIT_TAG 026345b9cf9092e3dd5ae42cc501ec8ed45ca09b
     )
-endif()
 endif()
 
 ################# EXCEL

--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -67,7 +67,7 @@ endif()
 if (NOT MINGW AND NOT "${OS_NAME}" STREQUAL "linux" AND NOT ${WASM_ENABLED})
     duckdb_extension_load(delta
             GIT_URL https://github.com/duckdb/duckdb-delta
-            GIT_TAG 026345b9cf9092e3dd5ae42cc501ec8ed45ca09b
+            GIT_TAG 90f244b3d572c1692867950b562df8183957b7a8
     )
 endif()
 


### PR DESCRIPTION
This is a bit of a hail-mary PR, but delta seems to build locally with the lastest commit from main as the rust build issue looks to be resolved in delta_kernel=v0.8.0 

Closes https://github.com/duckdblabs/duckdb-internal/issues/4487