### PR TITLE
Detect when tables have been dropped or altered, and prevent deletes in this scenario

### DIFF
--- a/src/catalog/catalog_entry.cpp
+++ b/src/catalog/catalog_entry.cpp
@@ -112,6 +112,9 @@ void CatalogEntry::Verify(Catalog &catalog_p) {
 void CatalogEntry::Rollback(CatalogEntry &prev_entry) {
 }
 
+void CatalogEntry::OnDrop() {
+}
+
 InCatalogEntry::InCatalogEntry(CatalogType type, Catalog &catalog, string name)
     : CatalogEntry(type, catalog, std::move(name)), catalog(catalog) {
 }

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -821,6 +821,10 @@ void DuckTableEntry::Rollback(CatalogEntry &prev_entry) {
 	}
 }
 
+void DuckTableEntry::OnDrop() {
+	storage->SetAsDropped();
+}
+
 unique_ptr<CatalogEntry> DuckTableEntry::AddConstraint(ClientContext &context, AddConstraintInfo &info) {
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	create_info->comment = comment;
@@ -872,7 +876,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::Copy(ClientContext &context) const {
 }
 
 void DuckTableEntry::SetAsRoot() {
-	storage->SetAsRoot();
+	storage->SetAsMainTable();
 	storage->SetTableName(name);
 }
 

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -400,6 +400,8 @@ bool CatalogSet::DropEntryInternal(CatalogTransaction transaction, const string 
 		throw CatalogException("Cannot drop entry \"%s\" because it is an internal system entry", entry->name);
 	}
 
+	entry->OnDrop();
+
 	// create a new tombstone entry and replace the currently stored one
 	// set the timestamp to the timestamp of the current transaction
 	// and point it at the tombstone node

--- a/src/execution/operator/schema/physical_create_art_index.cpp
+++ b/src/execution/operator/schema/physical_create_art_index.cpp
@@ -174,8 +174,9 @@ SinkFinalizeType PhysicalCreateARTIndex::Finalize(Pipeline &pipeline, Event &eve
 	state.global_index->VerifyAllocations();
 
 	auto &storage = table.GetStorage();
-	if (!storage.IsRoot()) {
-		throw TransactionException("cannot add an index to a table that has been altered");
+	if (!storage.IsMainTable()) {
+		throw TransactionException(
+		    "Transaction conflict: cannot add an index to a table that has been altered or dropped");
 	}
 
 	auto &schema = table.schema;

--- a/src/include/duckdb/catalog/catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry.hpp
@@ -70,6 +70,7 @@ public:
 	virtual unique_ptr<CatalogEntry> AlterEntry(CatalogTransaction transaction, AlterInfo &info);
 	virtual void UndoAlter(ClientContext &context, AlterInfo &info);
 	virtual void Rollback(CatalogEntry &prev_entry);
+	virtual void OnDrop();
 
 	virtual unique_ptr<CatalogEntry> Copy(ClientContext &context) const;
 

--- a/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
@@ -28,6 +28,7 @@ public:
 	unique_ptr<CatalogEntry> AlterEntry(CatalogTransaction, AlterInfo &info) override;
 	void UndoAlter(ClientContext &context, AlterInfo &info) override;
 	void Rollback(CatalogEntry &prev_entry) override;
+	void OnDrop() override;
 
 	//! Returns the underlying storage of the table
 	DataTable &GetStorage() override;

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -200,6 +200,9 @@ public:
 	bool IsMainTable() const {
 		return this->version == DataTableVersion::MAIN_TABLE;
 	}
+	bool IsRoot() const {
+		return IsMainTable();
+	}
 	string TableModification() const;
 
 	//! Get statistics of a physical column within the table

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -43,8 +43,14 @@ struct ConstraintState;
 struct TableUpdateState;
 enum class VerifyExistenceType : uint8_t;
 
+enum class DataTableVersion {
+	MAIN_TABLE, // this is the newest version of the table - it has not been altered or dropped
+	ALTERED,    // this table has been altered
+	DROPPED     // this table has been dropped
+};
+
 //! DataTable represents a physical table on disk
-class DataTable {
+class DataTable : public enable_shared_from_this<DataTable> {
 public:
 	//! Constructs a new data table from an (optional) set of persistent segments
 	DataTable(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_manager, const string &schema,
@@ -183,13 +189,18 @@ public:
 	//! Remove the row identifiers from all the indexes of the table
 	void RemoveFromIndexes(Vector &row_identifiers, idx_t count);
 
-	void SetAsRoot() {
-		this->is_root = true;
+	void SetAsMainTable() {
+		this->version = DataTableVersion::MAIN_TABLE;
 	}
 
-	bool IsRoot() {
-		return this->is_root;
+	void SetAsDropped() {
+		this->version = DataTableVersion::DROPPED;
 	}
+
+	bool IsMainTable() const {
+		return this->version == DataTableVersion::MAIN_TABLE;
+	}
+	string TableModification() const;
 
 	//! Get statistics of a physical column within the table
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id);
@@ -290,8 +301,7 @@ private:
 	mutex append_lock;
 	//! The row groups of the table
 	shared_ptr<RowGroupCollection> row_groups;
-	//! Whether or not the data table is the root DataTable for this table; the root DataTable is the newest version
-	//! that can be appended to
-	atomic<bool> is_root;
+	//! The version of the data table
+	atomic<DataTableVersion> version;
 };
 } // namespace duckdb

--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -81,10 +81,10 @@ public:
 		return write_lock.get();
 	}
 
-	void UpdateCollection(shared_ptr<RowGroupCollection> &collection);
-
 	//! Get a shared lock on a table
 	shared_ptr<CheckpointLock> SharedLockTable(DataTableInfo &info);
+
+	void ModifyTable(DataTable &tbl);
 
 private:
 	DuckTransactionManager &transaction_manager;
@@ -99,8 +99,8 @@ private:
 	mutex sequence_lock;
 	//! Map of all sequences that were used during the transaction and the value they had in this transaction
 	reference_map_t<SequenceCatalogEntry, reference<SequenceValue>> sequence_usage;
-	//! Collections that are updated by this transaction
-	reference_map_t<RowGroupCollection, shared_ptr<RowGroupCollection>> updated_collections;
+	//! Tables that are modified by this transaction
+	reference_map_t<DataTable, shared_ptr<DataTable>> modified_tables;
 	//! Lock for the active_locks map
 	mutex active_locks_lock;
 	struct ActiveTableLock {

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -78,6 +78,7 @@ void DuckTransaction::PushCatalogEntry(CatalogEntry &entry, data_ptr_t extra_dat
 
 void DuckTransaction::PushDelete(DataTable &table, RowVersionManager &info, idx_t vector_idx, row_t rows[], idx_t count,
                                  idx_t base_row) {
+	ModifyTable(table);
 	bool is_consecutive = true;
 	// check if the rows are consecutive
 	for (idx_t i = 0; i < count; i++) {
@@ -143,14 +144,14 @@ void DuckTransaction::PushSequenceUsage(SequenceCatalogEntry &sequence, const Se
 	}
 }
 
-void DuckTransaction::UpdateCollection(shared_ptr<RowGroupCollection> &collection) {
-	auto collection_ref = reference<RowGroupCollection>(*collection);
-	auto entry = updated_collections.find(collection_ref);
-	if (entry != updated_collections.end()) {
+void DuckTransaction::ModifyTable(DataTable &tbl) {
+	auto table_ref = reference<DataTable>(tbl);
+	auto entry = modified_tables.find(table_ref);
+	if (entry != modified_tables.end()) {
 		// already exists
 		return;
 	}
-	updated_collections.insert(make_pair(collection_ref, collection));
+	modified_tables.insert(make_pair(table_ref, tbl.shared_from_this()));
 }
 
 bool DuckTransaction::ChangesMade() {
@@ -233,6 +234,14 @@ ErrorData DuckTransaction::Commit(AttachedDatabase &db, transaction_t new_commit
 	if (!ChangesMade()) {
 		// no need to flush anything if we made no changes
 		return ErrorData();
+	}
+	for (auto &entry : modified_tables) {
+		auto &tbl = entry.first.get();
+		if (!tbl.IsMainTable()) {
+			return ErrorData(
+			    TransactionException("Attempting to modify table %s but another transaction has %s this table",
+			                         tbl.GetTableName(), tbl.TableModification()));
+		}
 	}
 	D_ASSERT(db.IsSystem() || db.IsTemporary() || !IsReadOnly());
 

--- a/test/sql/alter/add_col/test_add_col_transactions.test
+++ b/test/sql/alter/add_col/test_add_col_transactions.test
@@ -50,9 +50,11 @@ statement error con2
 INSERT INTO test (i, j) VALUES (3, 3)
 ----
 
-# but we can delete rows!
-statement ok con2
+# nor delete
+statement error con2
 DELETE FROM test WHERE i=1
+----
+altered
 
 query III con1
 SELECT * FROM test
@@ -63,6 +65,7 @@ SELECT * FROM test
 query II con2
 SELECT * FROM test
 ----
+1	1
 2	2
 
 # cannot update an altered table
@@ -85,6 +88,7 @@ COMMIT
 query III con1
 SELECT * FROM test
 ----
+1	100	NULL
 2	100	NULL
 
 statement ok con1

--- a/test/sql/alter/alter_type/test_alter_type_transactions.test
+++ b/test/sql/alter/alter_type/test_alter_type_transactions.test
@@ -50,9 +50,11 @@ statement error con2
 INSERT INTO test (i, j) VALUES (3, 3)
 ----
 
-# but we can delete rows!
-statement ok con2
+# nor delete
+statement error con2
 DELETE FROM test WHERE i=1
+----
+altered
 
 query TI con1
 SELECT * FROM test
@@ -63,6 +65,7 @@ SELECT * FROM test
 query II con2
 SELECT * FROM test
 ----
+1	1
 2	2
 
 # we cannot update rows on tables that have been altered
@@ -86,6 +89,7 @@ COMMIT
 query TI con1
 SELECT * FROM test
 ----
+1	1
 2	2
 
 statement ok con1

--- a/test/sql/alter/drop_col/test_drop_col_transactions.test
+++ b/test/sql/alter/drop_col/test_drop_col_transactions.test
@@ -49,10 +49,13 @@ ALTER TABLE test DROP COLUMN i
 statement error con2
 INSERT INTO test (i, j) VALUES (3, 3)
 ----
+altered
 
-# but we can delete rows!
-statement ok con2
+# nor delete
+statement error con2
 DELETE FROM test WHERE i=1
+----
+altered
 
 query I con1
 SELECT * FROM test
@@ -63,6 +66,7 @@ SELECT * FROM test
 query II con2
 SELECT * FROM test
 ----
+1	1
 2	2
 
 # we can't update on tables that have been altered
@@ -85,6 +89,7 @@ COMMIT
 query I con1
 SELECT * FROM test
 ----
+100
 100
 
 statement ok con1

--- a/test/sql/parallelism/interquery/concurrent_update_drop.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_update_drop.test_slow
@@ -14,7 +14,6 @@ onlyif threadid=0
 statement maybe
 UPDATE t1 SET i = 4 WHERE i = 2
 ----
-does not exist
 
 onlyif threadid=1
 statement ok

--- a/test/sql/transactions/conflict_drop_then_delete.test
+++ b/test/sql/transactions/conflict_drop_then_delete.test
@@ -1,0 +1,66 @@
+# name: test/sql/transactions/conflict_drop_then_delete.test
+# description: Conflict: drop a table, then delete from a table in another transaction
+# group: [transactions]
+
+load __TEST_DIR__/conflict_drop_then_delete.db
+
+statement ok
+create or replace table original_table as from range(10) select 1 as col
+
+statement ok
+SET immediate_transaction_mode=true
+
+# drop a table, then delete from that table in another transaction
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+create table new_incremental as
+  from range(10000)
+  select 42 as col
+
+statement ok con2
+drop table original_table
+
+statement ok con2
+COMMIT
+
+statement ok con1
+delete from original_table where rowid % 2 = 0
+
+statement error con1
+COMMIT
+----
+another transaction has dropped this table
+
+statement ok
+create or replace table original_table as from range(10) select 1 as col
+
+# do the same - but now reverse: delete from the table, then drop
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+delete from original_table where rowid % 2 = 0
+
+statement ok con1
+create table new_incremental as
+  from range(10000)
+  select 42 as col
+
+statement ok con2
+drop table original_table
+
+statement ok con2
+COMMIT
+
+statement error con1
+COMMIT
+----
+another transaction has dropped this table

--- a/test/sql/transactions/conflict_rename_append.test
+++ b/test/sql/transactions/conflict_rename_append.test
@@ -2,7 +2,7 @@
 # description: Conflict: rename, then drop a table, then append to it from another transaction
 # group: [transactions]
 
-load __TEST_DIR__/md2.db
+load __TEST_DIR__/conflict_rename_append.db
 
 statement ok
 create or replace table original_table as from range(10) select 1 as col

--- a/test/sql/transactions/conflict_rename_append.test
+++ b/test/sql/transactions/conflict_rename_append.test
@@ -1,0 +1,57 @@
+# name: test/sql/transactions/conflict_rename_append.test
+# description: Conflict: rename, then drop a table, then append to it from another transaction
+# group: [transactions]
+
+load __TEST_DIR__/md2.db
+
+statement ok
+create or replace table original_table as from range(10) select 1 as col
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+create table new_incremental as
+  from range(10000)
+  select 42 as col
+
+statement ok con1
+insert into original_table
+  from new_incremental
+
+statement ok con1
+drop table new_incremental
+
+statement ok con1
+create table new_incremental as
+  from range(10000)
+  select 42 as col
+
+statement ok con2
+alter table original_table rename to backup_table
+
+statement ok con2
+create table temp_table as
+  from range(100) select 2 as col
+
+statement ok con2
+alter table temp_table rename to original_table
+
+statement ok con2
+drop table backup_table
+
+statement ok con2
+COMMIT
+
+statement error con1
+COMMIT
+----
+dropped
+
+restart

--- a/test/sql/transactions/rollback_drop.test
+++ b/test/sql/transactions/rollback_drop.test
@@ -1,0 +1,28 @@
+# name: test/sql/transactions/rollback_drop.test
+# description: Rollback a drop then try to delete
+# group: [transactions]
+
+load __TEST_DIR__/rollback_drop.db
+
+statement ok
+create or replace table original_table as from range(10) select 1 as col
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok
+BEGIN
+
+statement ok
+DROP TABLE original_table
+
+statement ok
+ROLLBACK
+
+statement ok
+delete from original_table where rowid % 2 = 0
+
+query I
+SELECT COUNT(*) FROM original_table;
+----
+5


### PR DESCRIPTION
This PR fixes an issue in transaction management around the handling of deletes and dropped tables. Previously we would not correctly detect that a different transaction had dropped a table we had outstanding deletes for. This could result in exceptions being thrown as well as non-replayable WAL files (as the WAL would contain entries like `DROP TABLE -> DELETE FROM TABLE`). 

This PR now makes it so these scenarios are correctly detected, and a transaction conflict is thrown if one transaction drops a table and the other tries to delete from that same table.