### PR TITLE
[Fix] Keep original expression for macro + lambda's with subqueries

### DIFF
--- a/src/include/duckdb/parser/expression/lambda_expression.hpp
+++ b/src/include/duckdb/parser/expression/lambda_expression.hpp
@@ -30,6 +30,8 @@ public:
 	unique_ptr<ParsedExpression> lhs;
 	//! The lambda or JSON expression (RHS)
 	unique_ptr<ParsedExpression> expr;
+	//! Band-aid for conflicts between lambda binding and JSON binding.
+	unique_ptr<ParsedExpression> copied_expr;
 
 public:
 	//! Returns a vector to the column references in the LHS expression, and fills the error message,

--- a/test/sql/function/list/lambdas/lambdas_and_macros.test
+++ b/test/sql/function/list/lambdas/lambdas_and_macros.test
@@ -63,3 +63,9 @@ SELECT scoping_macro([11, 22], 3, 4);
 ----
 [18, 29]
 
+statement ok
+CREATE OR REPLACE MACRO foo(bar) AS (SELECT apply([bar], x -> 0));
+
+statement ok
+SELECT foo(v) FROM (SELECT 0 AS v);
+


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/17007.