### PR TITLE
fix: remove ununsed stream struct member from ArrowScanLocalState

### DIFF
--- a/src/include/duckdb/function/table/arrow.hpp
+++ b/src/include/duckdb/function/table/arrow.hpp
@@ -133,7 +133,6 @@ public:
 	}
 
 public:
-	unique_ptr<ArrowArrayStreamWrapper> stream;
 	shared_ptr<ArrowArrayWrapper> chunk;
 	idx_t chunk_offset = 0;
 	idx_t batch_index = 0;


### PR DESCRIPTION
The `stream` structure member was unused, so for clarity this removes it.