### PR TITLE
Correctly propagate ClientContext to TaskExecutor

### DIFF
--- a/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
+++ b/src/include/duckdb/storage/checkpoint/table_data_writer.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/parallel/task_executor.hpp"
 #include "duckdb/storage/checkpoint/row_group_writer.hpp"
 
 namespace duckdb {
@@ -37,9 +38,8 @@ public:
 	virtual void AddRowGroup(RowGroupPointer &&row_group_pointer, unique_ptr<RowGroupWriter> writer);
 	virtual CheckpointType GetCheckpointType() const = 0;
 
-	TaskScheduler &GetScheduler();
 	DatabaseInstance &GetDatabase();
-	optional_ptr<ClientContext> GetClientContext();
+	unique_ptr<TaskExecutor> CreateTaskExecutor();
 
 protected:
 	DuckTableEntry &table;

--- a/src/storage/checkpoint/table_data_writer.cpp
+++ b/src/storage/checkpoint/table_data_writer.cpp
@@ -31,12 +31,15 @@ void TableDataWriter::AddRowGroup(RowGroupPointer &&row_group_pointer, unique_pt
 	row_group_pointers.push_back(std::move(row_group_pointer));
 }
 
-TaskScheduler &TableDataWriter::GetScheduler() {
-	return TaskScheduler::GetScheduler(GetDatabase());
-}
-
 DatabaseInstance &TableDataWriter::GetDatabase() {
 	return table.ParentCatalog().GetDatabase();
+}
+
+unique_ptr<TaskExecutor> TableDataWriter::CreateTaskExecutor() {
+	if (client_context) {
+		return make_uniq<TaskExecutor>(*client_context);
+	}
+	return make_uniq<TaskExecutor>(TaskScheduler::GetScheduler(GetDatabase()));
 }
 
 SingleFileTableDataWriter::SingleFileTableDataWriter(SingleFileCheckpointWriter &checkpoint_manager,

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -748,7 +748,7 @@ void RowGroupCollection::UpdateColumn(TransactionData transaction, Vector &row_i
 struct CollectionCheckpointState {
 	CollectionCheckpointState(RowGroupCollection &collection, TableDataWriter &writer,
 	                          vector<SegmentNode<RowGroup>> &segments, TableStatistics &global_stats)
-	    : collection(collection), writer(writer), executor(writer.GetScheduler()), segments(segments),
+	    : collection(collection), writer(writer), executor(writer.CreateTaskExecutor()), segments(segments),
 	      global_stats(global_stats) {
 		writers.resize(segments.size());
 		write_data.resize(segments.size());
@@ -756,7 +756,7 @@ struct CollectionCheckpointState {
 
 	RowGroupCollection &collection;
 	TableDataWriter &writer;
-	TaskExecutor executor;
+	unique_ptr<TaskExecutor> executor;
 	vector<SegmentNode<RowGroup>> &segments;
 	vector<unique_ptr<RowGroupWriter>> writers;
 	vector<RowGroupWriteData> write_data;
@@ -767,7 +767,7 @@ struct CollectionCheckpointState {
 class BaseCheckpointTask : public BaseExecutorTask {
 public:
 	explicit BaseCheckpointTask(CollectionCheckpointState &checkpoint_state)
-	    : BaseExecutorTask(checkpoint_state.executor), checkpoint_state(checkpoint_state) {
+	    : BaseExecutorTask(*checkpoint_state.executor), checkpoint_state(checkpoint_state) {
 	}
 
 protected:
@@ -1000,7 +1000,7 @@ bool RowGroupCollection::ScheduleVacuumTasks(CollectionCheckpointState &checkpoi
 	// schedule the vacuum task
 	auto vacuum_task = make_uniq<VacuumTask>(checkpoint_state, state, segment_idx, merge_count, target_count,
 	                                         merge_rows, state.row_start);
-	checkpoint_state.executor.ScheduleTask(std::move(vacuum_task));
+	checkpoint_state.executor->ScheduleTask(std::move(vacuum_task));
 	// skip vacuuming by the row groups we have merged
 	state.next_vacuum_idx = next_idx;
 	state.row_start += merge_rows;
@@ -1045,17 +1045,17 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 			// schedule a checkpoint task for this row group
 			entry.node->MoveToCollection(*this, vacuum_state.row_start);
 			auto checkpoint_task = GetCheckpointTask(checkpoint_state, segment_idx);
-			checkpoint_state.executor.ScheduleTask(std::move(checkpoint_task));
+			checkpoint_state.executor->ScheduleTask(std::move(checkpoint_task));
 			vacuum_state.row_start += entry.node->count;
 		}
 	} catch (const std::exception &e) {
 		ErrorData error(e);
-		checkpoint_state.executor.PushError(std::move(error));
-		checkpoint_state.executor.WorkOnTasks(); // ensure all tasks have completed first before rethrowing
+		checkpoint_state.executor->PushError(std::move(error));
+		checkpoint_state.executor->WorkOnTasks(); // ensure all tasks have completed first before rethrowing
 		throw;
 	}
 	// all tasks have been successfully scheduled - execute tasks until we are done
-	checkpoint_state.executor.WorkOnTasks();
+	checkpoint_state.executor->WorkOnTasks();
 
 	// no errors - finalize the row groups
 	idx_t new_total_rows = 0;


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/16451 that fixes the situation where checkpoint / vacuum tasks would not be correctly identified as belonging to a given query / transaction because the ClientContext wasn't correctly set.