### PR TITLE
Grow string dictionary dynamically in Parquet writer

### DIFF
--- a/extension/parquet/include/parquet_bss_encoder.hpp
+++ b/extension/parquet/include/parquet_bss_encoder.hpp
@@ -15,11 +15,14 @@ namespace duckdb {
 class BssEncoder {
 public:
 	explicit BssEncoder(const idx_t total_value_count_p, const idx_t bit_width_p)
-	    : total_value_count(total_value_count_p), bit_width(bit_width_p), count(0),
-	      buffer(Allocator::DefaultAllocator().Allocate(total_value_count * bit_width + 1)) {
+	    : total_value_count(total_value_count_p), bit_width(bit_width_p), count(0) {
 	}
 
 public:
+	void BeginWrite(Allocator &allocator) {
+		buffer = allocator.Allocate(total_value_count * bit_width + 1);
+	}
+
 	template <class T>
 	void WriteValue(const T &value) {
 		D_ASSERT(sizeof(T) == bit_width);
@@ -40,24 +43,5 @@ private:
 	idx_t count;
 	AllocatedData buffer;
 };
-
-namespace bss_encoder {
-
-template <class T>
-void WriteValue(BssEncoder &encoder, const T &value) {
-	throw InternalException("Can't write type to BYTE_STREAM_SPLIT column");
-}
-
-template <>
-void WriteValue(BssEncoder &encoder, const float &value) {
-	encoder.WriteValue(value);
-}
-
-template <>
-void WriteValue(BssEncoder &encoder, const double &value) {
-	encoder.WriteValue(value);
-}
-
-} // namespace bss_encoder
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_dbp_encoder.hpp
+++ b/extension/parquet/include/parquet_dbp_encoder.hpp
@@ -23,7 +23,27 @@ public:
 	}
 
 public:
-	void BeginWrite(WriteStream &writer, const int64_t &first_value) {
+	template <class T>
+	void BeginWrite(WriteStream &writer, const T &first_value) {
+		throw InternalException("DbpEncoder should only be used with integers");
+	}
+
+	template <class T>
+	void WriteValue(WriteStream &writer, const T &value) {
+		throw InternalException("DbpEncoder should only be used with integers");
+	}
+
+	void FinishWrite(WriteStream &writer) {
+		if (count + block_count != total_value_count) {
+			throw InternalException("value count mismatch when writing DELTA_BINARY_PACKED");
+		}
+		if (block_count != 0) {
+			WriteBlock(writer);
+		}
+	}
+
+private:
+	void BeginWriteInternal(WriteStream &writer, const int64_t &first_value) {
 		// <block size in values> <number of miniblocks in a block> <total value count> <first value>
 
 		// the block size is a multiple of 128; it is stored as a ULEB128 int
@@ -50,7 +70,7 @@ public:
 		block_count = 0;
 	}
 
-	void WriteValue(WriteStream &writer, const int64_t &value) {
+	void WriteValueInternal(WriteStream &writer, const int64_t &value) {
 		// 1. Compute the differences between consecutive elements. For the first element in the block,
 		// use the last element in the previous block or, in the case of the first block,
 		// use the first value of the whole sequence, stored in the header.
@@ -72,16 +92,6 @@ public:
 		}
 	}
 
-	void FinishWrite(WriteStream &writer) {
-		if (count + block_count != total_value_count) {
-			throw InternalException("value count mismatch when writing DELTA_BINARY_PACKED");
-		}
-		if (block_count != 0) {
-			WriteBlock(writer);
-		}
-	}
-
-private:
 	void WriteBlock(WriteStream &writer) {
 		D_ASSERT(count + block_count == total_value_count || block_count == BLOCK_SIZE_IN_VALUES);
 		const auto number_of_miniblocks =
@@ -176,58 +186,44 @@ private:
 	data_t data_packed[NUMBER_OF_VALUES_IN_A_MINIBLOCK * sizeof(int64_t)];
 };
 
-namespace dbp_encoder {
-
-template <class T>
-void BeginWrite(DbpEncoder &encoder, WriteStream &writer, const T &first_value) {
-	throw InternalException("Can't write type to DELTA_BINARY_PACKED column");
+template <>
+inline void DbpEncoder::BeginWrite(WriteStream &writer, const int32_t &first_value) {
+	BeginWriteInternal(writer, first_value);
 }
 
 template <>
-void BeginWrite(DbpEncoder &encoder, WriteStream &writer, const int64_t &first_value) {
-	encoder.BeginWrite(writer, first_value);
+inline void DbpEncoder::BeginWrite(WriteStream &writer, const int64_t &first_value) {
+	BeginWriteInternal(writer, first_value);
 }
 
 template <>
-void BeginWrite(DbpEncoder &encoder, WriteStream &writer, const int32_t &first_value) {
-	BeginWrite(encoder, writer, UnsafeNumericCast<int64_t>(first_value));
+inline void DbpEncoder::BeginWrite(WriteStream &writer, const uint32_t &first_value) {
+	BeginWriteInternal(writer, first_value);
 }
 
 template <>
-void BeginWrite(DbpEncoder &encoder, WriteStream &writer, const uint64_t &first_value) {
-	encoder.BeginWrite(writer, UnsafeNumericCast<int64_t>(first_value));
+inline void DbpEncoder::BeginWrite(WriteStream &writer, const uint64_t &first_value) {
+	BeginWriteInternal(writer, first_value);
 }
 
 template <>
-void BeginWrite(DbpEncoder &encoder, WriteStream &writer, const uint32_t &first_value) {
-	BeginWrite(encoder, writer, UnsafeNumericCast<int64_t>(first_value));
-}
-
-template <class T>
-void WriteValue(DbpEncoder &encoder, WriteStream &writer, const T &value) {
-	throw InternalException("Can't write type to DELTA_BINARY_PACKED column");
+inline void DbpEncoder::WriteValue(WriteStream &writer, const int32_t &first_value) {
+	WriteValueInternal(writer, first_value);
 }
 
 template <>
-void WriteValue(DbpEncoder &encoder, WriteStream &writer, const int64_t &value) {
-	encoder.WriteValue(writer, value);
+inline void DbpEncoder::WriteValue(WriteStream &writer, const int64_t &first_value) {
+	WriteValueInternal(writer, first_value);
 }
 
 template <>
-void WriteValue(DbpEncoder &encoder, WriteStream &writer, const int32_t &value) {
-	WriteValue(encoder, writer, UnsafeNumericCast<int64_t>(value));
+inline void DbpEncoder::WriteValue(WriteStream &writer, const uint32_t &first_value) {
+	WriteValueInternal(writer, first_value);
 }
 
 template <>
-void WriteValue(DbpEncoder &encoder, WriteStream &writer, const uint64_t &value) {
-	encoder.WriteValue(writer, UnsafeNumericCast<int64_t>(value));
+inline void DbpEncoder::WriteValue(WriteStream &writer, const uint64_t &first_value) {
+	WriteValueInternal(writer, first_value);
 }
-
-template <>
-void WriteValue(DbpEncoder &encoder, WriteStream &writer, const uint32_t &value) {
-	WriteValue(encoder, writer, UnsafeNumericCast<int64_t>(value));
-}
-
-} // namespace dbp_encoder
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_dlba_encoder.hpp
+++ b/extension/parquet/include/parquet_dlba_encoder.hpp
@@ -16,25 +16,28 @@ namespace duckdb {
 class DlbaEncoder {
 public:
 	DlbaEncoder(const idx_t total_value_count_p, const idx_t total_string_size_p)
-	    : dbp_encoder(total_value_count_p), total_string_size(total_string_size_p),
-	      buffer(Allocator::DefaultAllocator().Allocate(total_string_size + 1)),
-	      stream(make_unsafe_uniq<MemoryStream>(buffer.get(), buffer.GetSize())) {
+	    : dbp_encoder(total_value_count_p), total_string_size(total_string_size_p) {
 	}
 
 public:
-	void BeginWrite(WriteStream &writer, const string_t &first_value) {
-		dbp_encoder.BeginWrite(writer, UnsafeNumericCast<int64_t>(first_value.GetSize()));
-		stream->WriteData(const_data_ptr_cast(first_value.GetData()), first_value.GetSize());
+	template <class T>
+	void BeginWrite(Allocator &, WriteStream &, const T &) {
+		throw InternalException("DlbaEncoder should only be used with strings");
 	}
 
-	void WriteValue(WriteStream &writer, const string_t &value) {
-		dbp_encoder.WriteValue(writer, UnsafeNumericCast<int64_t>(value.GetSize()));
-		stream->WriteData(const_data_ptr_cast(value.GetData()), value.GetSize());
+	template <class T>
+	void WriteValue(WriteStream &, const T &) {
+		throw InternalException("DlbaEncoder should only be used with strings");
 	}
 
 	void FinishWrite(WriteStream &writer) {
 		dbp_encoder.FinishWrite(writer);
 		writer.WriteData(buffer.get(), stream->GetPosition());
+	}
+
+	template <class SRC>
+	static idx_t GetStringSize(const SRC &) {
+		return 0;
 	}
 
 private:
@@ -44,39 +47,23 @@ private:
 	unsafe_unique_ptr<MemoryStream> stream;
 };
 
-namespace dlba_encoder {
-
-template <class T>
-void BeginWrite(DlbaEncoder &encoder, WriteStream &writer, const T &first_value) {
-	throw InternalException("Can't write type to DELTA_LENGTH_BYTE_ARRAY column");
+template <>
+inline void DlbaEncoder::BeginWrite(Allocator &allocator, WriteStream &writer, const string_t &first_value) {
+	buffer = allocator.Allocate(total_string_size + 1);
+	stream = make_unsafe_uniq<MemoryStream>(buffer.get(), buffer.GetSize());
+	dbp_encoder.BeginWrite(writer, UnsafeNumericCast<int64_t>(first_value.GetSize()));
+	stream->WriteData(const_data_ptr_cast(first_value.GetData()), first_value.GetSize());
 }
 
 template <>
-void BeginWrite(DlbaEncoder &encoder, WriteStream &writer, const string_t &first_value) {
-	encoder.BeginWrite(writer, first_value);
-}
-
-template <class T>
-void WriteValue(DlbaEncoder &encoder, WriteStream &writer, const T &value) {
-	throw InternalException("Can't write type to DELTA_LENGTH_BYTE_ARRAY column");
+inline void DlbaEncoder::WriteValue(WriteStream &writer, const string_t &value) {
+	dbp_encoder.WriteValue(writer, UnsafeNumericCast<int64_t>(value.GetSize()));
+	stream->WriteData(const_data_ptr_cast(value.GetData()), value.GetSize());
 }
 
 template <>
-void WriteValue(DlbaEncoder &encoder, WriteStream &writer, const string_t &value) {
-	encoder.WriteValue(writer, value);
-}
-
-// helpers to get size from strings
-template <class SRC>
-static idx_t GetDlbaStringSize(const SRC &) {
-	return 0;
-}
-
-template <>
-idx_t GetDlbaStringSize(const string_t &src_value) {
+inline idx_t DlbaEncoder::GetStringSize(const string_t &src_value) {
 	return src_value.GetSize();
 }
-
-} // namespace dlba_encoder
 
 } // namespace duckdb

--- a/extension/parquet/include/writer/primitive_column_writer.hpp
+++ b/extension/parquet/include/writer/primitive_column_writer.hpp
@@ -63,16 +63,10 @@ public:
 
 	//! We limit the uncompressed page size to 100MB
 	//! The max size in Parquet is 2GB, but we choose a more conservative limit
-	static constexpr const idx_t MAX_UNCOMPRESSED_PAGE_SIZE = 100000000;
+	static constexpr const idx_t MAX_UNCOMPRESSED_PAGE_SIZE = 104857600ULL;
 	//! Dictionary pages must be below 2GB. Unlike data pages, there's only one dictionary page.
 	//! For this reason we go with a much higher, but still a conservative upper bound of 1GB;
-	static constexpr const idx_t MAX_UNCOMPRESSED_DICT_PAGE_SIZE = 1e9;
-	//! If the dictionary has this many entries, we stop creating the dictionary
-	static constexpr const idx_t DICTIONARY_ANALYZE_THRESHOLD = 1e4;
-	//! The maximum size a key entry in an RLE page takes
-	static constexpr const idx_t MAX_DICTIONARY_KEY_SIZE = sizeof(uint32_t);
-	//! The size of encoding the string length
-	static constexpr const idx_t STRING_LENGTH_SIZE = sizeof(uint32_t);
+	static constexpr const idx_t MAX_UNCOMPRESSED_DICT_PAGE_SIZE = 1073741824ULL;
 
 public:
 	unique_ptr<ColumnWriterState> InitializeWriteState(duckdb_parquet::RowGroup &row_group) override;

--- a/extension/parquet/include/writer/templated_column_writer.hpp
+++ b/extension/parquet/include/writer/templated_column_writer.hpp
@@ -89,8 +89,8 @@ public:
 	                                 duckdb_parquet::Encoding::type encoding_p,
 	                                 const PrimitiveDictionary<SRC, TGT, OP> &dictionary_p)
 	    : encoding(encoding_p), dbp_initialized(false), dbp_encoder(total_value_count), dlba_initialized(false),
-	      dlba_encoder(total_value_count, total_string_size), bss_encoder(total_value_count, sizeof(TGT)),
-	      dictionary(dictionary_p), dict_written_value(false),
+	      dlba_encoder(total_value_count, total_string_size), bss_initialized(false),
+	      bss_encoder(total_value_count, sizeof(TGT)), dictionary(dictionary_p), dict_written_value(false),
 	      dict_bit_width(RleBpDecoder::ComputeBitWidth(dictionary.GetSize())), dict_encoder(dict_bit_width) {
 	}
 	duckdb_parquet::Encoding::type encoding;
@@ -101,6 +101,7 @@ public:
 	bool dlba_initialized;
 	DlbaEncoder dlba_encoder;
 
+	bool bss_initialized;
 	BssEncoder bss_encoder;
 
 	const PrimitiveDictionary<SRC, TGT, OP> &dictionary;
@@ -142,7 +143,7 @@ public:
 		switch (page_state.encoding) {
 		case duckdb_parquet::Encoding::DELTA_BINARY_PACKED:
 			if (!page_state.dbp_initialized) {
-				dbp_encoder::BeginWrite<int64_t>(page_state.dbp_encoder, temp_writer, 0);
+				page_state.dbp_encoder.BeginWrite(temp_writer, 0);
 			}
 			page_state.dbp_encoder.FinishWrite(temp_writer);
 			break;
@@ -158,11 +159,15 @@ public:
 			break;
 		case duckdb_parquet::Encoding::DELTA_LENGTH_BYTE_ARRAY:
 			if (!page_state.dlba_initialized) {
-				dlba_encoder::BeginWrite<string_t>(page_state.dlba_encoder, temp_writer, string_t(""));
+				page_state.dlba_encoder.BeginWrite(BufferAllocator::Get(writer.GetContext()), temp_writer,
+				                                   string_t(""));
 			}
 			page_state.dlba_encoder.FinishWrite(temp_writer);
 			break;
 		case duckdb_parquet::Encoding::BYTE_STREAM_SPLIT:
+			if (!page_state.bss_initialized) {
+				page_state.bss_encoder.BeginWrite(BufferAllocator::Get(writer.GetContext()));
+			}
 			page_state.bss_encoder.FinishWrite(temp_writer);
 			break;
 		case duckdb_parquet::Encoding::PLAIN:
@@ -201,7 +206,7 @@ public:
 				const auto &src_value = data_ptr[vector_index];
 				state.dictionary.Insert(src_value);
 				state.total_value_count++;
-				state.total_string_size += dlba_encoder::GetDlbaStringSize(src_value);
+				state.total_string_size += DlbaEncoder::GetStringSize(src_value);
 			}
 		} else {
 			for (idx_t i = 0; i < vcount; i++) {
@@ -212,7 +217,7 @@ public:
 					const auto &src_value = data_ptr[vector_index];
 					state.dictionary.Insert(src_value);
 					state.total_value_count++;
-					state.total_string_size += dlba_encoder::GetDlbaStringSize(src_value);
+					state.total_string_size += DlbaEncoder::GetStringSize(src_value);
 				}
 				vector_index++;
 			}
@@ -352,7 +357,7 @@ private:
 					}
 					const TGT target_value = OP::template Operation<SRC, TGT>(data_ptr[r]);
 					OP::template HandleStats<SRC, TGT>(stats, target_value);
-					dbp_encoder::BeginWrite(page_state.dbp_encoder, temp_writer, target_value);
+					page_state.dbp_encoder.BeginWrite(temp_writer, target_value);
 					page_state.dbp_initialized = true;
 					r++; // skip over
 					break;
@@ -365,7 +370,7 @@ private:
 				}
 				const TGT target_value = OP::template Operation<SRC, TGT>(data_ptr[r]);
 				OP::template HandleStats<SRC, TGT>(stats, target_value);
-				dbp_encoder::WriteValue(page_state.dbp_encoder, temp_writer, target_value);
+				page_state.dbp_encoder.WriteValue(temp_writer, target_value);
 			}
 			break;
 		}
@@ -379,7 +384,8 @@ private:
 					}
 					const TGT target_value = OP::template Operation<SRC, TGT>(data_ptr[r]);
 					OP::template HandleStats<SRC, TGT>(stats, target_value);
-					dlba_encoder::BeginWrite(page_state.dlba_encoder, temp_writer, target_value);
+					page_state.dlba_encoder.BeginWrite(BufferAllocator::Get(writer.GetContext()), temp_writer,
+					                                   target_value);
 					page_state.dlba_initialized = true;
 					r++; // skip over
 					break;
@@ -392,18 +398,22 @@ private:
 				}
 				const TGT target_value = OP::template Operation<SRC, TGT>(data_ptr[r]);
 				OP::template HandleStats<SRC, TGT>(stats, target_value);
-				dlba_encoder::WriteValue(page_state.dlba_encoder, temp_writer, target_value);
+				page_state.dlba_encoder.WriteValue(temp_writer, target_value);
 			}
 			break;
 		}
 		case duckdb_parquet::Encoding::BYTE_STREAM_SPLIT: {
+			if (page_state.bss_initialized) {
+				page_state.bss_encoder.BeginWrite(BufferAllocator::Get(writer.GetContext()));
+				page_state.bss_initialized = true;
+			}
 			for (idx_t r = chunk_start; r < chunk_end; r++) {
 				if (!ALL_VALID && !mask.RowIsValid(r)) {
 					continue;
 				}
 				const TGT target_value = OP::template Operation<SRC, TGT>(data_ptr[r]);
 				OP::template HandleStats<SRC, TGT>(stats, target_value);
-				bss_encoder::WriteValue(page_state.bss_encoder, target_value);
+				page_state.bss_encoder.WriteValue(target_value);
 			}
 			break;
 		}

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -16,6 +16,7 @@
 #include "parquet_writer.hpp"
 #include "reader/struct_column_reader.hpp"
 #include "zstd_file_system.hpp"
+#include "writer/primitive_column_writer.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -763,7 +764,8 @@ struct ParquetWriteBindData : public TableFunctionData {
 		dictionary_size_limit = row_group_size / 20;
 	}
 
-	idx_t string_dictionary_page_size_limit = 1048576;
+	//! This is huge but we grow it starting from 1 MB
+	idx_t string_dictionary_page_size_limit = PrimitiveColumnWriter::MAX_UNCOMPRESSED_DICT_PAGE_SIZE;
 
 	//! What false positive rate are we willing to accept for bloom filters
 	double bloom_filter_false_positive_ratio = 0.01;
@@ -892,9 +894,10 @@ unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFunctionBi
 			dictionary_size_limit_set = true;
 		} else if (loption == "string_dictionary_page_size_limit") {
 			auto val = option.second[0].GetValue<uint64_t>();
-			if (val > PrimitiveDictionary<uint32_t>::MAXIMUM_POSSIBLE_SIZE) {
-				throw BinderException("string_dictionary_page_size_limit must be less than or equal to %llu",
-				                      PrimitiveDictionary<uint32_t>::MAXIMUM_POSSIBLE_SIZE);
+			if (val > PrimitiveColumnWriter::MAX_UNCOMPRESSED_DICT_PAGE_SIZE || val == 0) {
+				throw BinderException(
+				    "string_dictionary_page_size_limit cannot be 0 and must be less than or equal to %llu",
+				    PrimitiveColumnWriter::MAX_UNCOMPRESSED_DICT_PAGE_SIZE);
 			}
 			bind_data->string_dictionary_page_size_limit = val;
 		} else if (loption == "bloom_filter_false_positive_ratio") {

--- a/src/include/duckdb/common/primitive_dictionary.hpp
+++ b/src/include/duckdb/common/primitive_dictionary.hpp
@@ -37,15 +37,18 @@ private:
 
 public:
 	static constexpr uint32_t MAXIMUM_POSSIBLE_SIZE = INVALID_INDEX - 1;
+	static constexpr idx_t INITIAL_TARGET_CAPACITY = 1048576;
 
 	//! PrimitiveDictionary is a fixed-size linear probing hash table for primitive types
 	//! It is used to dictionary-encode data in, e.g., Parquet files
-	PrimitiveDictionary(Allocator &allocator, idx_t maximum_size_p, idx_t target_capacity_p)
-	    : maximum_size(maximum_size_p), size(0), capacity(NextPowerOfTwo(maximum_size * LOAD_FACTOR)),
-	      capacity_mask(capacity - 1), target_capacity(target_capacity_p),
+	PrimitiveDictionary(Allocator &allocator_p, idx_t maximum_size_p, idx_t maximum_target_capacity_p)
+	    : allocator(allocator_p), maximum_size(maximum_size_p), size(0),
+	      capacity(NextPowerOfTwo(maximum_size * LOAD_FACTOR)), capacity_mask(capacity - 1),
+	      maximum_target_capacity(maximum_target_capacity_p),
 	      allocated_dictionary(allocator.Allocate(capacity * sizeof(primitive_dictionary_entry_t))),
-	      allocated_target(
-	          allocator.Allocate(std::is_same<TGT, string_t>::value ? target_capacity : capacity * sizeof(TGT))),
+	      allocated_target(allocator.Allocate(std::is_same<TGT, string_t>::value
+	                                              ? MinValue(INITIAL_TARGET_CAPACITY, maximum_target_capacity)
+	                                              : capacity * sizeof(TGT))),
 	      target_stream(allocated_target.get(), allocated_target.GetSize()),
 	      dictionary(reinterpret_cast<primitive_dictionary_entry_t *>(allocated_dictionary.get())), full(false) {
 		// Initialize empty
@@ -150,8 +153,41 @@ private:
 	template <typename S = SRC, typename std::enable_if<std::is_same<S, string_t>::value, int>::type = 0>
 	bool AddToTarget(SRC &src_value) {
 		// If source is string, target must also be string
-		if (target_stream.GetPosition() + OP::template WriteSize<SRC, TGT>(src_value) > target_stream.GetCapacity()) {
-			return false; // Out of capacity
+		const auto required_size = target_stream.GetPosition() + OP::template WriteSize<SRC, TGT>(src_value);
+		if (required_size > allocated_target.GetSize()) {
+			// Out of capacity, allocate a new buffer
+			idx_t new_target_capacity = allocated_target.GetSize();
+			while (new_target_capacity < required_size) {
+				if (new_target_capacity == maximum_target_capacity) {
+					return false; // Maximum capacity isn't enough
+				}
+				// Double the size, or add the maximum increment
+				new_target_capacity += MinValue(new_target_capacity, MAXIMUM_TARGET_CAPACITY_INCREMENT);
+				// Bound by maximum capacity
+				new_target_capacity = MinValue(new_target_capacity, maximum_target_capacity);
+			}
+			auto new_allocated_target = allocator.Allocate(new_target_capacity);
+
+			// Copy over data and replace
+			const auto old_ptr = allocated_target.get();
+			const auto new_ptr = new_allocated_target.get();
+			memcpy(new_ptr, old_ptr, allocated_target.GetSize());
+			allocated_target = std::move(new_allocated_target);
+
+			// Also replace the stream
+			MemoryStream new_target_stream(allocated_target.get(), allocated_target.GetSize());
+			new_target_stream.SetPosition(target_stream.GetPosition());
+			target_stream = std::move(new_target_stream);
+
+			// Recompute string pointers from old to new buffer
+			for (idx_t i = 0; i < capacity; i++) {
+				auto &entry = dictionary[i];
+				if (entry.IsEmpty() || entry.value.IsInlined()) {
+					continue;
+				}
+				entry.value.SetPointer(
+				    char_ptr_cast(new_ptr + (const_data_ptr_cast(entry.value.GetPointer()) - old_ptr)));
+			}
 		}
 
 		const auto ptr = target_stream.GetData() + target_stream.GetPosition() + sizeof(uint32_t);
@@ -165,6 +201,8 @@ private:
 	}
 
 private:
+	Allocator &allocator;
+
 	//! Maximum size and current size
 	const idx_t maximum_size;
 	idx_t size;
@@ -174,7 +212,8 @@ private:
 	const idx_t capacity_mask;
 
 	//! Capacity of target encoded data
-	const idx_t target_capacity;
+	const idx_t maximum_target_capacity;
+	static constexpr idx_t MAXIMUM_TARGET_CAPACITY_INCREMENT = 33554432ULL;
 
 	//! Allocated regions for dictionary/target
 	AllocatedData allocated_dictionary;

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -256,3 +256,10 @@ copy (select (r1.range*10)::VARCHAR r,
 from range(100) r1, range(100) order by r) to '__TEST_DIR__/bloom9.parquet' (format parquet, ROW_GROUP_SIZE 10000, string_dictionary_page_size_limit 4294967295);
 ----
 Binder Error
+
+# cannot be 0
+statement error
+copy (select (r1.range*10)::VARCHAR r,
+from range(100) r1, range(100) order by r) to '__TEST_DIR__/bloom9.parquet' (format parquet, ROW_GROUP_SIZE 10000, string_dictionary_page_size_limit 0);
+----
+Binder Error

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -263,3 +263,22 @@ copy (select (r1.range*10)::VARCHAR r,
 from range(100) r1, range(100) order by r) to '__TEST_DIR__/bloom9.parquet' (format parquet, ROW_GROUP_SIZE 10000, string_dictionary_page_size_limit 0);
 ----
 Binder Error
+
+# test some repeated large strings
+# this should give dictionary
+statement ok
+copy (select repeat('abc', 1_000_000) || (range % 100) s from range(1000)) to '__TEST_DIR__/my.parquet';
+
+query I
+select encodings from parquet_metadata('__TEST_DIR__/my.parquet');
+----
+RLE_DICTIONARY
+
+# this cannot do dictionary because the strings exceed the limit
+statement ok
+copy (select repeat('abc', 1_000_000) || (range % 100) s from range(1000)) to '__TEST_DIR__/my.parquet' (STRING_DICTIONARY_PAGE_SIZE_LIMIT 4_000_000);
+
+query I
+select encodings = 'RLE_DICTIONARY' from parquet_metadata('__TEST_DIR__/my.parquet');
+----
+false

--- a/test/sql/copy/parquet/bloom_filters.test
+++ b/test/sql/copy/parquet/bloom_filters.test
@@ -267,7 +267,7 @@ Binder Error
 # test some repeated large strings
 # this should give dictionary
 statement ok
-copy (select repeat('abc', 1_000_000) || (range % 100) s from range(1000)) to '__TEST_DIR__/my.parquet';
+copy (select repeat('abc', 500_000) || (range % 10) s from range(100)) to '__TEST_DIR__/my.parquet';
 
 query I
 select encodings from parquet_metadata('__TEST_DIR__/my.parquet');
@@ -276,7 +276,7 @@ RLE_DICTIONARY
 
 # this cannot do dictionary because the strings exceed the limit
 statement ok
-copy (select repeat('abc', 1_000_000) || (range % 100) s from range(1000)) to '__TEST_DIR__/my.parquet' (STRING_DICTIONARY_PAGE_SIZE_LIMIT 4_000_000);
+copy (select repeat('abc', 500_000) || (range % 10) s from range(100)) to '__TEST_DIR__/my.parquet' (STRING_DICTIONARY_PAGE_SIZE_LIMIT 4_000_000);
 
 query I
 select encodings = 'RLE_DICTIONARY' from parquet_metadata('__TEST_DIR__/my.parquet');


### PR DESCRIPTION
The `PrimitiveDictionary` that we've added for dictionary compression in Parquet (only on `main` now, and will be released in v1.3.0) would statically allocate `STRING_DICTIONARY_PAGE_SIZE_LIMIT` bytes for the strings. It defaults to 1 MB. If the total string size exceeds this, DuckDB bails on dictionary compression.

This is a bit restrictive, and does not work well when there are many long strings that aren't unique. This PR makes it so that we initialize at 1 MB, and then we dynamically grow until `STRING_DICTIONARY_PAGE_SIZE_LIMIT`, which now defaults to 1 GB. This allows large strings to still be dictionary-compressed by our writer.