### PR TITLE
[Nested] Optimize List Type in `list_value`

### DIFF
--- a/benchmark/micro/list/list_value_large_list.benchmark
+++ b/benchmark/micro/list/list_value_large_list.benchmark
@@ -1,0 +1,13 @@
+# name: benchmark/micro/list/list_value_large_list.benchmark
+# description: LIST_VALUE performance with very large lists
+# group: [list]
+
+name List Value
+group micro
+subgroup list
+
+load
+CREATE TABLE large_list AS SELECT list(i) AS a FROM range(1000000) t(i);
+
+run
+SELECT list_value(a, a, a, a, a) FROM large_list;

--- a/benchmark/micro/list/list_value_nested_list.benchmark
+++ b/benchmark/micro/list/list_value_nested_list.benchmark
@@ -1,0 +1,13 @@
+# name: benchmark/micro/list/list_value_nested_list.benchmark
+# description: LIST_VALUE performance with nested lists
+# group: [list]
+
+name List Value
+group micro
+subgroup list
+
+load
+CREATE TABLE nested_lists AS SELECT [[i], [i + 1]] AS a, [[i, i], [i + 1, i + 1]] as b FROM range(10000) t(i);
+
+run
+SELECT list_value(a, b, a, b, a, b, a, b, a, b, a, b, a, b) FROM nested_lists;

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -52,6 +52,55 @@ static void TemplatedListValueFunction(DataChunk &args, Vector &result) {
 	ListVector::SetListSize(result, args.size() * list_size);
 }
 
+static void ListValueListFunction(DataChunk &args, Vector &result) {
+	const idx_t list_size = args.ColumnCount();
+	ListVector::Reserve(result, args.size() * list_size);
+	const auto result_data = FlatVector::GetData<list_entry_t>(result);
+	auto &result_list = ListVector::GetEntry(result);
+	auto &result_child_vector = ListVector::GetEntry(result_list);
+	const auto result_list_data = FlatVector::GetData<list_entry_t>(result_list);
+	auto &result_list_validity = FlatVector::Validity(result_list);
+
+	vector<idx_t> col_offsets(list_size);
+	idx_t offset_sum = 0;
+	for (idx_t i = 0; i < list_size; i++) {
+		col_offsets[i] = offset_sum;
+
+		auto list = args.data[i];
+
+		UnifiedVectorFormat list_data;
+		list.ToUnifiedFormat(args.size(), list_data);
+		const auto length = ListVector::GetListSize(list);
+		auto &child_vector = ListVector::GetEntry(list);
+
+		VectorOperations::Copy(child_vector, result_child_vector, length, 0, offset_sum);
+
+		offset_sum += length;
+	}
+	ListVector::SetListSize(result_list, offset_sum);
+
+	const auto result_unified_format = args.ToUnifiedFormat();
+	for (idx_t r = 0; r < args.size(); r++) {
+		for (idx_t c = 0; c < list_size; c++) {
+			const auto input_idx = result_unified_format[c].sel->get_index(r);
+			const auto result_idx = r * list_size + c;
+			const auto input_data = UnifiedVectorFormat::GetData<list_entry_t>(result_unified_format[c]);
+			if (result_unified_format[c].validity.RowIsValid(input_idx)) {
+				const auto length = input_data[input_idx].length;
+				result_list_data[result_idx] = list_entry_t(col_offsets[c], length);
+
+				col_offsets[c] += length;
+			} else {
+				result_list_validity.SetInvalid(result_idx);
+			}
+
+		}
+		result_data[r].offset = r * list_size;
+		result_data[r].length = list_size;
+	}
+	ListVector::SetListSize(result, args.size() * list_size);
+}
+
 static void TemplatedListValueFunctionFallback(DataChunk &args, Vector &result) {
 	auto &child_type = ListType::GetChildType(result.GetType());
 	auto result_data = FlatVector::GetData<list_entry_t>(result);
@@ -124,6 +173,9 @@ static void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &r
 		break;
 	case PhysicalType::VARCHAR:
 		TemplatedListValueFunction<string_t, ListValueStringAssign>(args, result);
+		break;
+	case PhysicalType::LIST:
+		ListValueListFunction(args, result);
 		break;
 	default: {
 		TemplatedListValueFunctionFallback(args, result);

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -73,6 +73,10 @@ static void ListValueListFunction(DataChunk &args, Vector &result) {
 		const auto length = ListVector::GetListSize(list);
 		auto &child_vector = ListVector::GetEntry(list);
 
+		if (length == 0) {
+			//! Nothing to add
+			continue;
+		}
 		VectorOperations::Copy(child_vector, result_child_vector, length, 0, offset_sum);
 
 		offset_sum += length;
@@ -93,7 +97,6 @@ static void ListValueListFunction(DataChunk &args, Vector &result) {
 			} else {
 				result_list_validity.SetInvalid(result_idx);
 			}
-
 		}
 		result_data[r].offset = r * list_size;
 		result_data[r].length = list_size;

--- a/extension/core_functions/scalar/list/list_value.cpp
+++ b/extension/core_functions/scalar/list/list_value.cpp
@@ -82,13 +82,14 @@ static void ListValueListFunction(DataChunk &args, Vector &result) {
 	const auto result_data = FlatVector::GetData<list_entry_t>(result);
 	const auto result_list_data = FlatVector::GetData<list_entry_t>(result_list);
 	auto &result_list_validity = FlatVector::Validity(result_list);
-	const auto result_unified_format = args.ToUnifiedFormat();
+
+	const auto args_unified_format = args.ToUnifiedFormat();
 	for (idx_t r = 0; r < args.size(); r++) {
 		for (idx_t c = 0; c < list_size; c++) {
-			const auto input_idx = result_unified_format[c].sel->get_index(r);
+			const auto input_idx = args_unified_format[c].sel->get_index(r);
 			const auto result_idx = r * list_size + c;
-			const auto input_data = UnifiedVectorFormat::GetData<list_entry_t>(result_unified_format[c]);
-			if (result_unified_format[c].validity.RowIsValid(input_idx)) {
+			const auto input_data = UnifiedVectorFormat::GetData<list_entry_t>(args_unified_format[c]);
+			if (args_unified_format[c].validity.RowIsValid(input_idx)) {
 				const auto length = input_data[input_idx].length;
 				const auto offset = col_offsets[c] + input_data[input_idx].offset;
 				result_list_data[result_idx] = list_entry_t(offset, length);

--- a/test/sql/function/list/list_value.test
+++ b/test/sql/function/list/list_value.test
@@ -12,11 +12,6 @@ SELECT LIST_VALUE([1, 7], [2], [3]);
 [[1, 7], [2], [3]]
 
 query I
-SELECT LIST_VALUE([1, 7], [2], [3]);
-----
-[[1, 7], [2], [3]]
-
-query I
 SELECT LIST_VALUE([1, 7], [2], [3], NULL);
 ----
 [[1, 7], [2], [3], NULL]

--- a/test/sql/function/list/list_value.test
+++ b/test/sql/function/list/list_value.test
@@ -176,18 +176,6 @@ SELECT LIST_VALUE(a, b, c) FROM nested_list_table;
 [[[7, 7], [8, 8, 8]], [[9]], [[10, 10], [11, 11, 11]]]
 [[[12, NULL]], [NULL, [13, 13, 13]], NULL]
 
-# test very large table
-statement ok
-CREATE TABLE large_list_table(a INTEGER[], b INTEGER[], c INTEGER[]);
-
-statement ok
-INSERT INTO large_list_table SELECT [i, i, i], [i + 1, i + 1], [i + 2] FROM range(10000) tbl(i);
-
-query I
-SELECT LIST_VALUE(a, b, c) FROM large_list_table WHERE a[1] = 1;
-----
-[[1, 1, 1], [2, 2], [3]]
-
 # errors
 statement error
 SELECT LIST_VALUE([1, 1], ['a', 'a'], [ROW(2, 2), ROW(3, 3)]);

--- a/test/sql/function/list/list_value.test
+++ b/test/sql/function/list/list_value.test
@@ -1,0 +1,195 @@
+# name: test/sql/function/list/list_value.test
+# description: Test the list_value function
+# group: [list]
+
+statement ok
+pragma enable_verification
+
+# nested lists
+query I
+SELECT LIST_VALUE([1, 7], [2], [3]);
+----
+[[1, 7], [2], [3]]
+
+query I
+SELECT LIST_VALUE([1, 7], [2], [3]);
+----
+[[1, 7], [2], [3]]
+
+query I
+SELECT LIST_VALUE([1, 7], [2], [3], NULL);
+----
+[[1, 7], [2], [3], NULL]
+
+query I
+SELECT LIST_VALUE([1, 7], [2], NULL, [3]);
+----
+[[1, 7], [2], NULL, [3]]
+
+query I
+SELECT LIST_VALUE([1, 7], [NULL], [2], [3]);
+----
+[[1, 7], [NULL], [2], [3]]
+
+# nested lists in table
+statement ok
+CREATE TABLE test_table (c1 INTEGER[], c2 INTEGER[], c3 INTEGER[]);
+
+statement ok
+INSERT INTO test_table VALUES ([1, 1], [2, 2], [3]);
+
+statement ok
+INSERT INTO test_table VALUES ([4], [5, 5, 5], [6, 6]);
+
+statement ok
+INSERT INTO test_table VALUES ([7, 7, 7, 7], [8], [9, 9, 9]);
+
+statement ok
+INSERT INTO test_table VALUES ([], [], []);
+
+statement ok
+INSERT INTO test_table VALUES ([-1, -1, NULL], NULL, [-2, -2]);
+
+query I
+SELECT LIST_VALUE(c1, c2, c3) FROM test_table;
+----
+[[1, 1], [2, 2], [3]]
+[[4], [5, 5, 5], [6, 6]]
+[[7, 7, 7, 7], [8], [9, 9, 9]]
+[[], [], []]
+[[-1, -1, NULL], NULL, [-2, -2]]
+
+# structs in nested lists
+query I
+SELECT LIST_VALUE(ROW(1, 1), ROW(2, 2), ROW(3, 3));
+----
+[(1, 1), (2, 2), (3, 3)]
+
+query I
+SELECT LIST_VALUE(ROW(1, 1), ROW(2, 2), ROW(3, 3), NULL);
+----
+[(1, 1), (2, 2), (3, 3), NULL]
+
+query I
+SELECT LIST_VALUE(ROW(1, 1), ROW(NULL, 2), NULL, ROW(3, 3));
+----
+[(1, 1), (NULL, 2), NULL, (3, 3)]
+
+statement ok
+CREATE TABLE struct_table(a ROW(a INTEGER, b INTEGER)[], b ROW(a INTEGER, b INTEGER)[], c ROW(a INTEGER, b INTEGER)[]);
+
+statement ok
+INSERT INTO STRUCT_TABLE VALUES ([ROW(1, 1), ROW(2, 2)], [ROW(3, 3), ROW(4, 4)], [ROW(5, 5), ROW(6, 6)]);
+
+statement ok
+INSERT INTO STRUCT_TABLE VALUES ([ROW(7, 7), ROW(8, 8)], [ROW(9, 9)], [ROW(10, 10), ROW(11, 11), ROW(12, 12)]);
+
+statement ok
+INSERT INTO STRUCT_TABLE VALUES ([ROW(13, 13)], [ROW(14, 14), ROW(15, 15), ROW(16, 16)], [ROW(17, 17), ROW(18, 18)]);
+
+statement ok
+INSERT INTO STRUCT_TABLE VALUES ([NULL, ROW(20, 20)], NULL, [ROW(23, 23), ROW(24, 24), ROW(25, 25), ROW(26, 26)]);
+
+query I
+SELECT LIST_VALUE(a, b, c) FROM struct_table;
+----
+[[{'a': 1, 'b': 1}, {'a': 2, 'b': 2}], [{'a': 3, 'b': 3}, {'a': 4, 'b': 4}], [{'a': 5, 'b': 5}, {'a': 6, 'b': 6}]]
+[[{'a': 7, 'b': 7}, {'a': 8, 'b': 8}], [{'a': 9, 'b': 9}], [{'a': 10, 'b': 10}, {'a': 11, 'b': 11}, {'a': 12, 'b': 12}]]
+[[{'a': 13, 'b': 13}], [{'a': 14, 'b': 14}, {'a': 15, 'b': 15}, {'a': 16, 'b': 16}], [{'a': 17, 'b': 17}, {'a': 18, 'b': 18}]]
+[[NULL, {'a': 20, 'b': 20}], NULL, [{'a': 23, 'b': 23}, {'a': 24, 'b': 24}, {'a': 25, 'b': 25}, {'a': 26, 'b': 26}]]
+
+# strings in nested lists
+query I
+SELECT LIST_VALUE(['a', 'a'], ['b', 'b', 'b'], ['c']);
+----
+[[a, a], [b, b, b], [c]]
+
+query I
+SELECT LIST_VALUE(['a', 'a'], ['b', 'b', 'b'], ['c'], NULL);
+----
+[[a, a], [b, b, b], [c], NULL]
+
+query I
+SELECT LIST_VALUE(['a', 'a'], ['b', 'b', NULL], NULL, ['c']);
+----
+[[a, a], [b, b, NULL], NULL, [c]]
+
+statement ok
+CREATE TABLE string_table(a VARCHAR[], b VARCHAR[], c VARCHAR[]);
+
+statement ok
+INSERT INTO string_table VALUES (['a', 'a'], ['b', 'b', 'b'], ['c']);
+
+statement ok
+INSERT INTO string_table VALUES (['d'], ['e', 'e', 'e', 'e'], ['f', 'f']);
+
+statement ok
+INSERT INTO string_table VALUES (['g', 'g', 'g', 'g'], ['h'], ['i', 'i', 'i']);
+
+statement ok
+INSERT INTO string_table VALUES (['j', 'j'], NULL, ['k', 'k', 'k']);
+
+statement ok
+INSERT INTO string_table VALUES (['l', 'l', 'l'], ['m', 'm'], [NULL, 'n', 'n']);
+
+query I
+SELECT LIST_VALUE(a, b, c) FROM string_table;
+----
+[[a, a], [b, b, b], [c]]
+[[d], [e, e, e, e], [f, f]]
+[[g, g, g, g], [h], [i, i, i]]
+[[j, j], NULL, [k, k, k]]
+[[l, l, l], [m, m], [NULL, n, n]]
+
+# nested lists in lists
+query I
+SELECT LIST_VALUE([[1, 1], [2]], [[3, 3], [4, 4, 4, 4], [5, 5]], [[6, 6]]);
+----
+[[[1, 1], [2]], [[3, 3], [4, 4, 4, 4], [5, 5]], [[6, 6]]]
+
+query I
+SELECT LIST_VALUE([[1, 1], [2]], [[3, 3], [4, 4, 4, 4], [5, 5]], [[6, 6]], NULL);
+----
+[[[1, 1], [2]], [[3, 3], [4, 4, 4, 4], [5, 5]], [[6, 6]], NULL]
+
+query I
+SELECT LIST_VALUE([[1, 1], [2]], [[3, 3], [4, 4, NULL, 4], [5, 5]], NULL, [[6, 6]]);
+----
+[[[1, 1], [2]], [[3, 3], [4, 4, NULL, 4], [5, 5]], NULL, [[6, 6]]]
+
+statement ok
+CREATE TABLE nested_list_table(a INTEGER[][], b INTEGER[][], c INTEGER[][]);
+
+statement ok
+INSERT INTO nested_list_table VALUES ([[1, 1, 1], [2]], [[3, 3], [4, 4, 4, 4], [5, 5]], [[6, 6]]);
+
+statement ok
+INSERT INTO nested_list_table VALUES ([[7, 7], [8, 8, 8]], [[9]], [[10, 10], [11, 11, 11]]);
+
+statement ok
+INSERT INTO nested_list_table VALUES ([[12, NULL]], [NULL, [13, 13, 13]], NULL);
+
+query I
+SELECT LIST_VALUE(a, b, c) FROM nested_list_table;
+----
+[[[1, 1, 1], [2]], [[3, 3], [4, 4, 4, 4], [5, 5]], [[6, 6]]]
+[[[7, 7], [8, 8, 8]], [[9]], [[10, 10], [11, 11, 11]]]
+[[[12, NULL]], [NULL, [13, 13, 13]], NULL]
+
+# test very large table
+statement ok
+CREATE TABLE large_list_table(a INTEGER[], b INTEGER[], c INTEGER[]);
+
+statement ok
+INSERT INTO large_list_table SELECT [i, i, i], [i + 1, i + 1], [i + 2] FROM range(10000) tbl(i);
+
+query I
+SELECT LIST_VALUE(a, b, c) FROM large_list_table WHERE a[1] = 1;
+----
+[[1, 1, 1], [2, 2], [3]]
+
+# errors
+statement error
+SELECT LIST_VALUE([1, 1], ['a', 'a'], [ROW(2, 2), ROW(3, 3)]);
+----
+Binder Error: Cannot create a list of types INTEGER[] and VARCHAR[] - an explicit cast is required

--- a/test/sql/function/list/list_value.test_slow
+++ b/test/sql/function/list/list_value.test_slow
@@ -1,0 +1,24 @@
+# name: test/sql/function/list/list_value.test_slow
+# description: Test the list_value function
+# group: [list]
+
+test very large table
+statement ok
+CREATE TABLE large_list_table(a INTEGER[], b INTEGER[], c INTEGER[]);
+
+statement ok
+INSERT INTO large_list_table SELECT [i, i, i], [i + 1, i + 1], [i + 2] FROM range(10000) tbl(i);
+
+query I
+SELECT LIST_VALUE(a, b, c) FROM large_list_table WHERE a[1] = 1;
+----
+[[1, 1, 1], [2, 2], [3]]
+
+load
+CREATE TABLE large_list_table AS SELECT [i, i, i] AS a, [i + 1, i + 1] AS b, [i + 2] AS c FROM range(100000000) tbl(i);
+
+run
+SELECT LIST_VALUE(a, b, c) FROM large_list_table WHERE a[1] = 1;
+
+result I
+[[1, 1, 1], [2, 2], [3]]

--- a/test/sql/function/list/list_value.test_slow
+++ b/test/sql/function/list/list_value.test_slow
@@ -2,7 +2,7 @@
 # description: Test the list_value function
 # group: [list]
 
-test very large table
+# test very large table
 statement ok
 CREATE TABLE large_list_table(a INTEGER[], b INTEGER[], c INTEGER[]);
 

--- a/test/sql/function/list/list_value.test_slow
+++ b/test/sql/function/list/list_value.test_slow
@@ -13,12 +13,3 @@ query I
 SELECT LIST_VALUE(a, b, c) FROM large_list_table WHERE a[1] = 1;
 ----
 [[1, 1, 1], [2, 2], [3]]
-
-load
-CREATE TABLE large_list_table AS SELECT [i, i, i] AS a, [i + 1, i + 1] AS b, [i + 2] AS c FROM range(100000000) tbl(i);
-
-run
-SELECT LIST_VALUE(a, b, c) FROM large_list_table WHERE a[1] = 1;
-
-result I
-[[1, 1, 1], [2, 2], [3]]


### PR DESCRIPTION
In https://github.com/duckdb/duckdb/pull/12468 `list_value` was optimized for primitive types. This PR aims to build on that and optimize list types.

For example:

##### Large Tables
```sql
CREATE TABLE large_list_table AS SELECT [i, i, i] AS a, [i + 1, i + 1] AS b, [i + 2] AS c FROM range(100000000) tbl(i);

SELECT LIST_VALUE(a, b, c) FROM large_list_table;
```

| 1.2.2 | New |
|---|---|
| 28.55s |  8.68s |

##### Large Lists
```sql
CREATE TABLE large_list AS SELECT list(i) AS a FROM range(1000000) t(i);

SELECT list_value(a, a, a, a, a) FROM large_list;
```
| 1.2.2 | New |
|---|---|
| 0.487s |  0.0234s |

##### Nested Lists
```sql
CREATE TABLE nested_lists AS SELECT [[i], [i + 1]] AS a, [[i, i], [i + 1, i + 1]] as b FROM range(10000) t(i);

SELECT list_value(a, b, a, b, a, b, a, b, a, b, a, b, a, b) FROM nested_lists;
```

| 1.2.2 | New |
|---|---|
| 0.128s |  0.0075s |

While these results show improvements, the timings are still slower than desired. Profiling suggests that most of the time is spent in VectorOperations::Copy. Any feedback or suggestions on how to further improve performance would be greatly appreciated!

Some additional tests and benchmarks have also been included.