### PR TITLE
Fix httpfs patches: avoid `git log` since might contain unsanitised `error` word

### DIFF
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -16,16 +16,12 @@
 #  VCPKG_TARGET_TRIPLET=arm64-osx
 
 ################# HTTPFS
-# Warning: the patching mechanism on windows doesn't work for httpfs somehow.
-# To patch httpfs:
-#  - add patch file, enable APPLY_PATCHES
-#  - disable windows build of httpfs by wrapping in `if (NOT WIN32)`
-#  - IMPORTANT: add a comment that tells people to restore the windows build when removing the patches
 duckdb_extension_load(httpfs
     LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-httpfs
     GIT_TAG 85ac4667bcb0d868199e156f8dd918b0278db7b9
     INCLUDE_DIR extension/httpfs/include
+    APPLY_PATCHES
     )
 
 ### Skip due to missing patch

--- a/.github/patches/extensions/httpfs/httpfs.patch
+++ b/.github/patches/extensions/httpfs/httpfs.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index ed12193..b556e8f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,7 @@
+ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+ 
++# Hey, I am a patch
++
+ # Configuration of extension
+ EXT_NAME=httpfs
+ EXT_CONFIG=${PROJ_DIR}extension_config.cmake

--- a/scripts/apply_extension_patches.py
+++ b/scripts/apply_extension_patches.py
@@ -35,7 +35,6 @@ if not patches:
     raise_error(error_message)
 
 print(f"Resetting patches in {directory}\n")
-subprocess.run(["git", "log"], check=True)
 subprocess.run(["git", "clean", "-f"], check=True)
 subprocess.run(["git", "reset", "--hard", "HEAD"], check=True)
 # Apply each patch file using patch


### PR DESCRIPTION
Avoid `git log` while applying patches, that will print a bunch of content to stdout.
The stdout then might (or not) contain the word error, interpreted by MSBuild's cmake as an... error.

Thanks to the internet, at https://stackoverflow.com/questions/78622876/visual-studio-msbuild-error-msb8066-custom-build and https://developercommunity.visualstudio.com/t/MSBuild:-error:-output-of-custom-build/10554390?sort=newest, and @ccfelius that first raised the problem.

Fixes https://github.com/duckdb/duckdb/issues/16177, also reverts https://github.com/duckdb/duckdb/pull/16722.

This should unlock https://github.com/duckdb/duckdb/pull/16196 and https://github.com/duckdb/duckdb/pull/16463.