### PR TITLE
Add extended file info to OpenFileInfo, and use this to pass encryption keys and footer size to Parquet reader

### DIFF
--- a/extension/json/include/json_reader.hpp
+++ b/extension/json/include/json_reader.hpp
@@ -177,7 +177,7 @@ struct JSONError {
 
 class JSONReader : public BaseFileReader {
 public:
-	JSONReader(ClientContext &context, JSONReaderOptions options, string file_name);
+	JSONReader(ClientContext &context, JSONReaderOptions options, OpenFileInfo file);
 
 	void OpenJSONFile();
 	void CloseHandle();

--- a/extension/json/json_reader.cpp
+++ b/extension/json/json_reader.cpp
@@ -174,8 +174,8 @@ idx_t JSONFileHandle::ReadFromCache(char *&pointer, idx_t &size, atomic<idx_t> &
 	return read_size;
 }
 
-JSONReader::JSONReader(ClientContext &context, JSONReaderOptions options_p, string file_name_p)
-    : BaseFileReader(std::move(file_name_p)), context(context), options(std::move(options_p)), initialized(0),
+JSONReader::JSONReader(ClientContext &context, JSONReaderOptions options_p, OpenFileInfo file_p)
+    : BaseFileReader(std::move(file_p)), context(context), options(std::move(options_p)), initialized(0),
       next_buffer_index(0), thrown(false) {
 }
 

--- a/extension/parquet/include/thrift_tools.hpp
+++ b/extension/parquet/include/thrift_tools.hpp
@@ -203,6 +203,10 @@ public:
 		location = location_p;
 	}
 
+	optional_ptr<ReadHead> GetReadHead(idx_t pos) {
+		return ra_buffer.GetReadHead(pos);
+	}
+
 	idx_t GetLocation() {
 		return location;
 	}

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -519,12 +519,12 @@ shared_ptr<BaseFileReader> ParquetMultiFileInfo::CreateReader(ClientContext &con
                                                               const OpenFileInfo &file, idx_t file_idx,
                                                               const MultiFileBindData &multi_bind_data) {
 	auto &bind_data = multi_bind_data.bind_data->Cast<ParquetReadBindData>();
-	return make_shared_ptr<ParquetReader>(context, file.path, bind_data.parquet_options);
+	return make_shared_ptr<ParquetReader>(context, file, bind_data.parquet_options);
 }
 
 shared_ptr<BaseFileReader> ParquetMultiFileInfo::CreateReader(ClientContext &context, const OpenFileInfo &file,
                                                               ParquetOptions &options, const MultiFileOptions &) {
-	return make_shared_ptr<ParquetReader>(context, file.path, options);
+	return make_shared_ptr<ParquetReader>(context, file, options);
 }
 
 shared_ptr<BaseUnionData> ParquetMultiFileInfo::GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx) {

--- a/src/common/types/blob.cpp
+++ b/src/common/types/blob.cpp
@@ -157,6 +157,13 @@ string Blob::ToBlob(string_t str, CastParameters &parameters) {
 }
 
 // base64 functions are adapted from https://gist.github.com/tomykaira/f0fd86b6c73063283afe550bc5d77594
+string Blob::ToBase64(string_t blob) {
+	auto base64_size = Blob::ToBase64Size(blob);
+	auto data = make_uniq_array<char>(base64_size);
+	Blob::ToBase64(blob, data.get());
+	return string(data.get(), base64_size);
+}
+
 idx_t Blob::ToBase64Size(string_t blob) {
 	// every 4 characters in base64 encode 3 bytes, plus (potential) padding at the end
 	auto input_size = blob.GetSize();
@@ -205,6 +212,13 @@ static constexpr int BASE64_DECODING_TABLE[256] = {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+
+string Blob::FromBase64(string_t blob) {
+	auto decoded_size = Blob::FromBase64Size(blob);
+	auto data = make_uniq_array<data_t>(decoded_size);
+	Blob::FromBase64(blob, data.get(), decoded_size);
+	return string(char_ptr_cast(data.get()), decoded_size);
+}
 
 idx_t Blob::FromBase64Size(string_t str) {
 	auto input_data = str.GetData();

--- a/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -288,6 +288,7 @@ shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context
 	if (bind_data.file_list->GetExpandResult() == FileExpandResult::SINGLE_FILE) {
 		options.auto_detect = false;
 	}
+
 	shared_ptr<CSVBufferManager> buffer_manager;
 	if (file_idx == 0) {
 		buffer_manager = csv_data.buffer_manager;
@@ -295,7 +296,7 @@ shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context
 			buffer_manager.reset();
 		}
 	}
-	return make_shared_ptr<CSVFileScan>(context, file.path, std::move(options), bind_data.file_options, bind_data.names,
+	return make_shared_ptr<CSVFileScan>(context, file, std::move(options), bind_data.file_options, bind_data.names,
 	                                    bind_data.types, csv_data.csv_schema, gstate.SingleThreadedRead(),
 	                                    std::move(buffer_manager), false);
 }
@@ -303,12 +304,12 @@ shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context
 shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context, const OpenFileInfo &file,
                                                           CSVReaderOptions &options,
                                                           const MultiFileOptions &file_options) {
-	return make_shared_ptr<CSVFileScan>(context, file.path, options, file_options);
+	return make_shared_ptr<CSVFileScan>(context, file, options, file_options);
 }
 
 shared_ptr<BaseUnionData> CSVMultiFileInfo::GetUnionData(shared_ptr<BaseFileReader> scan_p, idx_t file_idx) {
 	auto &scan = scan_p->Cast<CSVFileScan>();
-	auto data = make_shared_ptr<CSVUnionData>(scan_p->GetFileName());
+	auto data = make_shared_ptr<CSVUnionData>(scan_p->file);
 	if (file_idx == 0) {
 		data->options = scan.options;
 		data->names = scan.GetNames();

--- a/src/include/duckdb/common/multi_file/multi_file_data.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_data.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/common/open_file_info.hpp"
 #include <numeric>
 
 namespace duckdb {

--- a/src/include/duckdb/common/open_file_info.hpp
+++ b/src/include/duckdb/common/open_file_info.hpp
@@ -9,8 +9,14 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/types/value.hpp"
 
 namespace duckdb {
+
+struct ExtendedOpenFileInfo {
+	unordered_map<string, Value> options;
+};
 
 struct OpenFileInfo {
 	OpenFileInfo() = default;
@@ -19,6 +25,7 @@ struct OpenFileInfo {
 	}
 
 	string path;
+	shared_ptr<ExtendedOpenFileInfo> extended_info;
 
 public:
 	bool operator<(const OpenFileInfo &rhs) const {

--- a/src/include/duckdb/common/types/blob.hpp
+++ b/src/include/duckdb/common/types/blob.hpp
@@ -47,11 +47,13 @@ public:
 	DUCKDB_API static string ToBlob(string_t str, CastParameters &parameters);
 
 	// base 64 conversion functions
+	DUCKDB_API static string ToBase64(string_t blob);
 	//! Returns the string size of a blob -> base64 conversion
 	DUCKDB_API static idx_t ToBase64Size(string_t blob);
 	//! Converts a blob to a base64 string, output should have space for at least ToBase64Size(blob) bytes
 	DUCKDB_API static void ToBase64(string_t blob, char *output);
 
+	DUCKDB_API static string FromBase64(string_t blob);
 	//! Returns the string size of a base64 string -> blob conversion
 	DUCKDB_API static idx_t FromBase64Size(string_t str);
 	//! Converts a base64 string to a blob, output should have space for at least FromBase64Size(blob) bytes


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb/pull/17071

This PR extends the  `OpenFileInfo` struct with `ExtendedOpenFileInfo`:

```cpp
struct ExtendedOpenFileInfo {
	unordered_map<string, Value> options;
};
```

The Parquet reader is extended to support two keys in this struct:

* `encryption_key`: used to pass a global encryption key for the Parquet file to the reader
* `footer_size`: used to pass the footer size of the Parquet file to the reader. This can be used to skip the separate reading of the footer length from the back of the file - instead we can directly read the footer. Note that this must be exactly correct - an error is thrown if an incorrect footer size is provided.