### PR TITLE
fsst: Avoid to propagate alignment information in FSST_UNALIGNED_STORE

### DIFF
--- a/third_party/fsst/fsst.h
+++ b/third_party/fsst/fsst.h
@@ -172,7 +172,7 @@ duckdb_fsst_decompress(
    unsigned long long*__restrict__ symbol = (unsigned long long* __restrict__) decoder->symbol; 
    size_t code, posOut = 0, posIn = 0;
 #ifndef FSST_MUST_ALIGN /* defining on platforms that require aligned memory access may help their performance */
-#define FSST_UNALIGNED_STORE(dst,src) memcpy((unsigned long long*) (dst), &(src), sizeof(unsigned long long))
+#define FSST_UNALIGNED_STORE(dst,src) memcpy((void*) (dst), &(src), sizeof(unsigned long long))
 #if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
    while (posOut+32 <= size && posIn+4 <= lenIn) {
       unsigned int nextBlock, escapeMask;


### PR DESCRIPTION
This would incur in errors like:
```
runtime error: store to misaligned address 0x62100092b903 for type 'unsigned long long *', which requires 8 byte alignment with:
....
```

Reproduction:
```
GEN=ninja make relassert && ./build/relassert/test/unittest --force-storage
```
(for example in test test/optimizer/expression_rewriter/functions_that_error_are_not_reordered.test and others)

I think cast to `(unsigned long long *)` is at best not used by compiler, but compiler is right in assuming that means aligned stores (given pointers needs 8bytes alligment for the cast to be sound).