### PR TITLE
Fix sqlite3 api wrapper link + remove R-CMD-check + add more nightly tests

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -101,6 +101,43 @@ jobs:
       run: |
           python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit --timeout 1200
 
+  release-assert-osx:
+    name: Release Assertions OSX
+    runs-on: macos-latest
+    needs: linux-memory-leaks
+    env:
+      GEN: ninja
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
+      DISABLE_SANITIZER: 1
+      CRASH_ON_ASSERT: 1
+      RUN_SLOW_VERIFIERS: 1
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install Ninja
+      run: brew install ninja
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ env.CCACHE_SAVE }}
+
+    - name: Build
+      shell: bash
+      run: UNSAFE_NUMERIC_CAST=1 make relassert
+
+    - name: Test
+      shell: bash
+      run: |
+          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit --timeout 1200
+
   smaller-binary:
     name: Smaller Binary
     runs-on: ubuntu-24.04

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -138,6 +138,43 @@ jobs:
       run: |
           python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit --timeout 1200
 
+  release-assert-osx-storage:
+    name: Release Assertions OSX Storage
+    runs-on: macos-latest
+    needs: linux-memory-leaks
+    env:
+      GEN: ninja
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
+      DISABLE_SANITIZER: 1
+      CRASH_ON_ASSERT: 1
+      RUN_SLOW_VERIFIERS: 1
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install Ninja
+      run: brew install ninja
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ env.CCACHE_SAVE }}
+
+    - name: Build
+      shell: bash
+      run: UNSAFE_NUMERIC_CAST=1 make relassert
+
+    - name: Test
+      shell: bash
+      run: |
+          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit --timeout 1200 --force-storage
+
   smaller-binary:
     name: Smaller Binary
     runs-on: ubuntu-24.04

--- a/.github/workflows/R_CMD_CHECK.yml
+++ b/.github/workflows/R_CMD_CHECK.yml
@@ -39,6 +39,7 @@ env:
 
 jobs:
   R-CMD-check:
+    if: false
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
+++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
@@ -28,7 +28,8 @@ link_threads(sqlite3_api_wrapper_static "")
 
 if(NOT WIN32 AND NOT ZOS)
   add_library(sqlite3_api_wrapper SHARED ${SQLITE_API_WRAPPER_FILES})
-  target_link_libraries(sqlite3_api_wrapper duckdb ${DUCKDB_EXTRA_LINK_FLAGS})
+  target_link_libraries(sqlite3_api_wrapper duckdb_static
+                        ${DUCKDB_EXTRA_LINK_FLAGS})
   link_threads(sqlite3_api_wrapper "")
 endif()
 


### PR DESCRIPTION
Three fixes:
1. Fix Relassert build via linking `sqlite3_api_wrapper` with `duckdb_static`.

2. Skip R-CMD-check.yml (this has been failing due to a warning, needs to be fixed and re-enabled)

3. add two new nightly tests:
* OSX + relassert
* OSX + relassert + `--force-storage`

This has also the nice consequence that sqlite3_api_wrapper linking (that caused Release Assert step to fail linking) is now tested in this PR.