### PR TITLE
Remove linux_amd64_gcc4 extensions build job from Python.yml to Extensions.yml

### DIFF
--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -10,8 +10,6 @@ on:
         type: string
       run_all:
         type: string
-      override_twine_upload:
-        type: string
   workflow_dispatch:
     inputs:
       override_git_describe:
@@ -21,8 +19,6 @@ on:
       skip_tests:
         type: string
       run_all:
-        type: string
-      override_twine_upload:
         type: string
   push:
     branches-ignore:

--- a/.github/workflows/Extensions.yml
+++ b/.github/workflows/Extensions.yml
@@ -1,0 +1,109 @@
+name: Python
+on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
+      run_all:
+        type: string
+      override_twine_upload:
+        type: string
+  workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
+      run_all:
+        type: string
+      override_twine_upload:
+        type: string
+  push:
+    branches-ignore:
+      - 'main'
+      - 'feature'
+      - 'v*.*-*'
+    paths-ignore:
+      - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/pythonpkg/**'
+      - '.github/patches/duckdb-wasm/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Extensions.yml'
+  merge_group:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - 'examples/**'
+      - 'test/**'
+      - 'tools/**'
+      - '!tools/pythonpkg/**'
+      - '.github/patches/duckdb-wasm/**'
+      - '.github/workflows/**'
+      - '!.github/workflows/Extensions.yml'
+
+
+concurrency:
+  group: extensions-${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}-${{ inputs.override_git_describe }}
+  cancel-in-progress: true
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  OVERRIDE_GIT_DESCRIBE: ${{ inputs.override_git_describe }}
+
+jobs:
+  manylinux-extensions-x64:
+    name: Linux Extensions (linux_amd64_gcc4)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        duckdb_arch: [linux_amd64_gcc4]
+        vcpkg_triplet: [x64-linux]
+  
+    env:
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      GEN: ninja
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - uses: ./duckdb/.github/actions/build_extensions_dockerized
+        with:
+          vcpkg_target_triplet: x64-linux
+          duckdb_arch: linux_amd64_gcc4
+          run_tests: ${{ inputs.skip_tests != 'true' }}
+          override_git_describe: ${{ inputs.override_git_describe }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: duckdb-extensions-${{ matrix.duckdb_arch }}
+          path: |
+            build/release/extension/*/*.duckdb_extension
+
+  upload-linux-extensions-gcc4:
+    name: Upload Linux Extensions (gcc4)
+    needs: manylinux-extensions-x64
+    strategy:
+      matrix:
+        duckdb_arch: [linux_amd64_gcc4]
+    uses: ./.github/workflows/_sign_deploy_extensions.yml
+    secrets: inherit
+    with:
+      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
+      duckdb_arch: ${{ matrix.duckdb_arch }}
+      duckdb_sha: ${{ github.sha }}

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -19,6 +19,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  extensions:
+    uses: ./.github/workflows/Extensions.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
+      run_all: ${{ inputs.run_all }}
+
   osx:
     uses: ./.github/workflows/OSX.yml
     secrets: inherit
@@ -91,6 +100,7 @@ jobs:
     uses: ./.github/workflows/NotifyExternalRepositories.yml
     secrets: inherit
     needs:
+      - extensions
       - osx
       - linux-release
       - windows
@@ -108,6 +118,7 @@ jobs:
     uses: ./.github/workflows/NotifyExternalRepositories.yml
     secrets: inherit
     needs:
+      - extensions
       - osx
       - linux-release
       - windows

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -123,54 +123,6 @@ jobs:
         # TODO: Use ccache inside container, see https://github.com/pypa/cibuildwheel/issues/1030
         cibuildwheel --output-dir wheelhouse --config-file pyproject.toml duckdb_tarball
 
-  manylinux-extensions-x64:
-    name: Linux Extensions (linux_amd64_gcc4)
-    needs: linux-python3-10
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        duckdb_arch: [linux_amd64_gcc4]
-        vcpkg_triplet: [x64-linux]
-  
-    env:
-      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
-      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
-      GEN: ninja
-      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: 'duckdb'
-          fetch-depth: 0
-          ref: ${{ inputs.git_ref }}
-
-      - uses: ./duckdb/.github/actions/build_extensions_dockerized
-        with:
-          vcpkg_target_triplet: x64-linux
-          duckdb_arch: linux_amd64_gcc4
-          run_tests: ${{ inputs.skip_tests != 'true' }}
-          override_git_describe: ${{ inputs.override_git_describe }}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: duckdb-extensions-${{ matrix.duckdb_arch }}
-          path: |
-            build/release/extension/*/*.duckdb_extension
-
-  upload-linux-extensions-gcc4:
-    name: Upload Linux Extensions (gcc4)
-    needs: manylinux-extensions-x64
-    strategy:
-      matrix:
-        duckdb_arch: [linux_amd64_gcc4]
-    uses: ./.github/workflows/_sign_deploy_extensions.yml
-    secrets: inherit
-    with:
-      extension_artifact_name: duckdb-extensions-${{ matrix.duckdb_arch }}
-      duckdb_arch: ${{ matrix.duckdb_arch }}
-      duckdb_sha: ${{ github.sha }}
-
   linux-python3:
     name: Python 3 Linux
     needs: manylinux-extensions-x64
@@ -247,11 +199,12 @@ jobs:
         pip install 'cibuildwheel>=2.16.2' build
         python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"
 
-    - uses: actions/download-artifact@v4
-      if: ${{ matrix.arch == 'x86_64' }}
-      with:
-        name: duckdb-extensions-${{ matrix.duckdb_arch }}
-        path: tools/pythonpkg
+    # This could be considered to be added back IF step is executed later than Extensions.yml
+    #- uses: actions/download-artifact@v4
+    #  if: ${{ matrix.arch == 'x86_64' }}
+    #  with:
+    #    name: duckdb-extensions-${{ matrix.duckdb_arch }}
+    #    path: tools/pythonpkg
 
     - name: List extensions to be tested
       shell: bash


### PR DESCRIPTION
Currently Pyhton.yml does 2 different things:
* build python source codes and wheels
* build extensions for `linux_amd64_gcc4`

This is somewhat wasteful, since `linux_amd64_gcc4` are being moved out in any case, so this particular problem is solved, but more in general I would think we should structure CI like:
1. a job, Extensions.yml, responsible for building and deploying extensions on all platforms
2. other jobs, in separate workflows, build binaries that might use those extensions
3. a testing job that combines some extensions and some binaries, testing they work together
4. workflows in separate repositories that might depend on extensions being built

For example with Python:
* as long as part of duckdb/duckdb repository, it can still test extensions paired with Python wheels, but without being restricted on only `linux_amd64_gcc4`
* once moved out of core: the same can be implemented but mono-directional, python repository is informed of extensions being buillt, and then it can build wheels AND test them in combinations with extensions (and publish only on success).

This PR has conflicts with https://github.com/duckdb/duckdb/pull/16956, maybe thinking about this that needs to go in first.