### PR TITLE
Notify JDBC repo to run Vendor.yml workflow

### DIFF
--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -44,6 +44,19 @@ jobs:
           export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
 
+  notify-jdbc-run:
+    name: Run JDBC Vendor
+    runs-on: ubuntu-latest
+    env:
+      PAT_USER: ${{ secrets.PAT_USERNAME }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+    steps:
+      - name: Run JDBC Vendor
+        if: ${{ github.repository == 'duckdb/duckdb' }}
+        run: |
+          export URL=https://api.github.com/repos/duckdb/duckdb-java/actions/workflows/Vendor.yml/dispatches
+          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
+          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
 
   notify-nightly-build-status:
     name: Run Nightly build status


### PR DESCRIPTION
This change adds a dispatch call to `Vendor.yml` JDBC workflow the same way it is now done for ODBC repo. On JDBC side the workflow changes are being added in PR duckdb/duckdb-java#172 .

ODBC call was initially added in #16730, see details in that PR.