### PR TITLE
Add missing lock to UpdateSegment::FetchRow, and cleanup API to require the lock

### DIFF
--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -93,7 +93,7 @@ private:
 	statistics_update_function_t statistics_update_function;
 
 private:
-	UndoBufferPointer GetUpdateNode(idx_t vector_idx) const;
+	UndoBufferPointer GetUpdateNode(StorageLockKey &lock, idx_t vector_idx) const;
 	void InitializeUpdateInfo(idx_t vector_idx);
 	void InitializeUpdateInfo(UpdateInfo &info, row_t *ids, const SelectionVector &sel, idx_t count, idx_t vector_index,
 	                          idx_t vector_offset);

--- a/test/sql/parallelism/interquery/concurrent_index_reads_while_updating.test_slow
+++ b/test/sql/parallelism/interquery/concurrent_index_reads_while_updating.test_slow
@@ -1,0 +1,40 @@
+# name: test/sql/parallelism/interquery/concurrent_index_reads_while_updating.test_slow
+# description: Test concurrent index reads while updating
+# group: [interquery]
+
+statement ok
+CREATE TABLE integers(i INTEGER PRIMARY KEY, value BIGINT)
+
+statement ok
+INSERT INTO integers SELECT i, i%10 FROM range(10) t(i);
+
+# 10 update threads, 10 reading threads
+concurrentloop threadid 0 20
+
+loop i 0 500
+
+skipif threadid<=10
+statement ok
+SELECT * FROM integers WHERE i=(hash(${threadid} + ${i})%100)
+
+endloop
+
+loop i 0 100
+
+skipif threadid>10
+statement ok
+UPDATE integers SET value = value + 1 WHERE i=${threadid}
+
+skipif threadid>10
+statement ok
+UPDATE integers SET value = value - 1 WHERE i=${threadid}
+
+
+endloop
+
+endloop
+
+query II
+SELECT COUNT(*), SUM(i) FROM integers
+----
+10	45


### PR DESCRIPTION
Fixes a data race when mixing index lookups together with updates.

Also clean-up the API to require the lock so this cannot be forgotten again going forward.

CC @staticlibs