### PR TITLE
Pull OpenFileExtended through the opener and virtual file system layers

### DIFF
--- a/src/function/table/read_file.cpp
+++ b/src/function/table/read_file.cpp
@@ -133,7 +133,7 @@ static void ReadFileExecute(ClientContext &context, TableFunctionInput &input, D
 
 		// Given the columns requested, do we even need to open the file?
 		if (state.requires_file_open) {
-			file_handle = fs.OpenFile(file.path, FileFlags::FILE_FLAGS_READ);
+			file_handle = fs.OpenFile(file, FileFlags::FILE_FLAGS_READ);
 		}
 
 		for (idx_t col_idx = 0; col_idx < state.column_ids.size(); col_idx++) {

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -22,13 +22,6 @@ public:
 	void VerifyCanAccessDirectory(const string &path);
 	void VerifyCanAccessFile(const string &path);
 
-	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
-	                                optional_ptr<FileOpener> opener = nullptr) override {
-		VerifyNoOpener(opener);
-		VerifyCanAccessFile(path);
-		return GetFileSystem().OpenFile(path, flags, GetOpener());
-	}
-
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
 		GetFileSystem().Read(handle, buffer, nr_bytes, location);
 	};
@@ -150,6 +143,18 @@ public:
 
 	vector<string> ListSubSystems() override {
 		return GetFileSystem().ListSubSystems();
+	}
+
+protected:
+	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
+	                                        optional_ptr<FileOpener> opener = nullptr) override {
+		VerifyNoOpener(opener);
+		VerifyCanAccessFile(file.path);
+		return GetFileSystem().OpenFile(file, flags, GetOpener());
+	}
+
+	bool SupportsOpenFileExtended() const override {
+		return true;
 	}
 
 private:

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -19,9 +19,6 @@ class VirtualFileSystem : public FileSystem {
 public:
 	VirtualFileSystem();
 
-	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
-	                                optional_ptr<FileOpener> opener = nullptr) override;
-
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 
@@ -70,6 +67,13 @@ public:
 	void SetDisabledFileSystems(const vector<string> &names) override;
 
 	string PathSeparator(const string &path) override;
+
+protected:
+	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
+	                                        optional_ptr<FileOpener> opener) override;
+	bool SupportsOpenFileExtended() const override {
+		return true;
+	}
 
 private:
 	FileSystem &FindFileSystem(const string &path);


### PR DESCRIPTION
This allows the `OpenFileInfo` to actually be used in the file systems' `OpenFileExtended` call.