### PR TITLE
Refactor relassert runs, adding some variations in compiler / statically linked extensions

### DIFF
--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -65,14 +65,12 @@ jobs:
 
   release-assert:
     name: Release Assertions
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: linux-memory-leaks
     env:
-      CC: gcc-10
-      CXX: g++-10
       GEN: ninja
       BUILD_JEMALLOC: 1
-      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;httpfs"
       DISABLE_SANITIZER: 1
       CRASH_ON_ASSERT: 1
       RUN_SLOW_VERIFIERS: 1

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -105,7 +105,7 @@ jobs:
     needs: linux-memory-leaks
     env:
       GEN: ninja
-      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet"
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;httpfs"
       DISABLE_SANITIZER: 1
       CRASH_ON_ASSERT: 1
       RUN_SLOW_VERIFIERS: 1
@@ -119,7 +119,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install Ninja
-      run: brew install ninja
+      run: brew install ninja llvm
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main
@@ -129,7 +129,7 @@ jobs:
 
     - name: Build
       shell: bash
-      run: UNSAFE_NUMERIC_CAST=1 make relassert
+      run: CMAKE_LLVM_PATH='/opt/homebrew/opt/llvm' UNSAFE_NUMERIC_CAST=1 make relassert
 
     - name: Test
       shell: bash

--- a/.github/workflows/NightlyTests.yml
+++ b/.github/workflows/NightlyTests.yml
@@ -209,33 +209,28 @@ jobs:
       run: |
           build/release/test/unittest "*"
 
-  linux-clang:
-    name: Clang 14
-    runs-on: ubuntu-22.04
+  release-assert-clang:
+    name: Release Assertions with Clang
+    runs-on: ubuntu-latest
     needs: linux-memory-leaks
     env:
-      CC: /home/runner/work/llvm/bin/clang
-      CPP: /home/runner/work/llvm/bin/clang-cpp
-      CXX: /home/runner/work/llvm/bin/clang++
-      LD: /home/runner/work/llvm/bin/ld.lld
-      EXTENSION_STATIC_BUILD: 1
-      CORE_EXTENSIONS: "json"
-      TREAT_WARNINGS_AS_ERRORS: 1
+      CC: clang
+      CXX: clang++
+      GEN: ninja
+      BUILD_JEMALLOC: 1
+      CORE_EXTENSIONS: "icu;tpch;tpcds;fts;json;inet;httpfs"
+      DISABLE_SANITIZER: 1
+      CRASH_ON_ASSERT: 1
+      RUN_SLOW_VERIFIERS: 1
 
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - name: Install LLVM and Clang
-      uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: "14.0"
-        directory: '/home/runner/work/llvm'
-
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
+    - name: Install
+      shell: bash
+      run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build llvm
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main
@@ -245,11 +240,12 @@ jobs:
 
     - name: Build
       shell: bash
-      run: make release
+      run: UNSAFE_NUMERIC_CAST=1 make relassert
 
     - name: Test
       shell: bash
-      run: make allunit
+      run: |
+          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest "*" --no-exit --timeout 1200
 
   linux-compile-32:
     name: Linux (32 Bit)


### PR DESCRIPTION
Cleans up various `relassert` runs, varying things a bit so that ideally different scenarios are stress tested.

After this:
* "Release Assertions" runs on `ubuntu-latest`, using default compiler (at this moment `GNU 13.3.0`) and tests also `httpfs`
* "Release Assertions with Clang" runs on `ubuntu-latest`, using latest default LLVM from apt (that is `Clang 18.1.3`)
* "Release Assertions OSX" runs on `macos-latest`, using default LLVM from brew (`Clang 19.1.7`) and tests also `httpfs`
* "Release Assertions OSX Storage" runs on `macos-latest` uses default compiler (`AppleClang 15.0.0.15000309 `) and tests with `--force-storage`

Note that there are some more failures, but this I would say it's good, and this is a workflow where this is OK.