### PR TITLE
Always parallelize `read_json` schema detection

### DIFF
--- a/extension/json/json_functions/read_json.cpp
+++ b/extension/json/json_functions/read_json.cpp
@@ -150,42 +150,32 @@ void JSONScan::AutoDetect(ClientContext &context, MultiFileBindData &bind_data, 
 	JSONStructureNode node;
 	auto &options = json_data.options;
 	auto files = bind_data.file_list->GetAllFiles();
-	auto file_count = files.size();
+	auto file_count = bind_data.file_options.union_by_name
+	                      ? files.size()
+	                      : MinValue<idx_t>(options.maximum_sample_files, files.size());
 	bind_data.union_readers.resize(files.empty() ? 0 : files.size());
 
 	AutoDetectState auto_detect_state(context, bind_data, files, date_format_map);
-	if (bind_data.file_options.union_by_name) {
-		const auto num_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
-		const auto files_per_task = (file_count + num_threads - 1) / num_threads;
-		const auto num_tasks = file_count / files_per_task;
-		vector<JSONStructureNode> task_nodes(num_tasks);
+	const auto num_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	const auto files_per_task = (file_count + num_threads - 1) / num_threads;
+	const auto num_tasks = file_count / files_per_task;
+	vector<JSONStructureNode> task_nodes(num_tasks);
 
-		// Same idea as in union_by_name.hpp
-		TaskExecutor executor(context);
-		for (idx_t task_idx = 0; task_idx < num_tasks; task_idx++) {
-			const auto file_idx_start = task_idx * files_per_task;
-			auto task = make_uniq<JSONSchemaTask>(executor, auto_detect_state, task_nodes[task_idx], file_idx_start,
-			                                      file_idx_start + files_per_task);
-			executor.ScheduleTask(std::move(task));
-		}
-		executor.WorkOnTasks();
-
-		// Merge task nodes into one
-		for (auto &task_node : task_nodes) {
-			JSONStructure::MergeNodes(node, task_node);
-		}
-	} else {
-		ArenaAllocator allocator(BufferAllocator::Get(context));
-		Vector string_vector(LogicalType::VARCHAR);
-		idx_t remaining = options.sample_size;
-		for (idx_t file_idx = 0; file_idx < file_count; file_idx++) {
-			remaining =
-			    JSONSchemaTask::ExecuteInternal(auto_detect_state, node, file_idx, allocator, string_vector, remaining);
-			if (remaining == 0 || file_idx == options.maximum_sample_files - 1) {
-				break; // We sample sample_size in total (across the first maximum_sample_files files)
-			}
-		}
+	// Same idea as in union_by_name.hpp
+	TaskExecutor executor(context);
+	for (idx_t task_idx = 0; task_idx < num_tasks; task_idx++) {
+		const auto file_idx_start = task_idx * files_per_task;
+		auto task = make_uniq<JSONSchemaTask>(executor, auto_detect_state, task_nodes[task_idx], file_idx_start,
+		                                      file_idx_start + files_per_task);
+		executor.ScheduleTask(std::move(task));
 	}
+	executor.WorkOnTasks();
+
+	// Merge task nodes into one
+	for (auto &task_node : task_nodes) {
+		JSONStructure::MergeNodes(node, task_node);
+	}
+
 	// set the max threads/estimated per-file cardinality
 	if (auto_detect_state.files_scanned > 0 && auto_detect_state.tuples_scanned > 0) {
 		auto average_tuple_size = auto_detect_state.bytes_scanned / auto_detect_state.tuples_scanned;

--- a/test/sql/json/table/json_multi_file_reader.test
+++ b/test/sql/json/table/json_multi_file_reader.test
@@ -145,11 +145,15 @@ order by j;
 statement ok
 SELECT * FROM read_json_auto(['data/json/with_uuid.json', 'data/json/example_n.ndjson'])
 
-# both have 5 rows, so if we set sample_size=1, we cannot read them together anymore, because we only sample 1 file
+# both have 5 rows, so if we set sample_size=1, and maximum_sample_files=1, we cannot read them together anymore
 statement error
-SELECT * FROM read_json_auto(['data/json/with_uuid.json', 'data/json/example_n.ndjson'], sample_size=1)
+SELECT * FROM read_json_auto(['data/json/with_uuid.json', 'data/json/example_n.ndjson'], sample_size=1, maximum_sample_files=1)
 ----
 Invalid Input Error
+
+# if we increase maximum_sample_files, or set union_by_name=true, then we can read them again
+statement ok
+SELECT * FROM read_json_auto(['data/json/with_uuid.json', 'data/json/example_n.ndjson'], sample_size=1, maximum_sample_files=99)
 
 # if we set union_by_name=true, then we sample sample_size rows per file, so then we can read them again
 statement ok


### PR DESCRIPTION
We already implemented this for `union_by_name=true`, but it makes sense to just always do this, as we may read multiple files during the bind to infer the schema.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/4225