### PR TITLE
Notify nightly build status

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -87,9 +87,8 @@ jobs:
       git_ref: ${{ inputs.git_ref }}
       skip_tests: ${{ inputs.skip_tests }}
 
-  notify-external-repos-main:
-    uses: ./.github/workflows/NotifyExternalRepositories.yml
-    secrets: inherit
+  prepare-status:
+    runs-on: ubuntu-latest
     needs:
       - osx
       - linux-release
@@ -99,27 +98,45 @@ jobs:
       - R
       - Wasm
       - static-libraries
-    if: ${{ inputs.git_ref == '' }}
+    outputs:
+      is-success: ${{ steps.set-output.outputs.success }}
+    steps:
+      - id: set-output
+        run:
+          if [ "${{ needs.osx.result }}" == "success" ] && \
+             [ "${{ needs.linux-release.result }}" == "success" ] && \
+             [ "${{ needs.linux-release.result }}" == "success" ] && \
+             [ "${{ needs.windows.result }}" == "success" ] && \
+             [ "${{ needs.python.result }}" == "success" ] && \
+             [ "${{ needs.pyodide.result }}" == "success" ] && \
+             [ "${{ needs.R.result }}" == "success" ] && \
+             [ "${{ needs.Wasm.result }}" == "success" ] && \
+             [ "${{ needs.static-libraries.result }}" == "success" ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+    
+  notify-external-repos-main:
+    uses: ./.github/workflows/NotifyExternalRepositories.yml
+    secrets: inherit
+    needs: prepare-status  
+    if: ${{ inputs.git_ref == '' }} 
     with:
+      is-success: ${{ needs.prepare-status.outputs.is-success }}
       target-branch: ${{ github.ref_name }}
       duckdb-sha: ${{ github.ref }}
-      triggering_event: ${{ github.event_name }}
-      should_publish: 'true'
+      triggering-event: ${{ github.event_name }}
+      should-publish: true
 
   notify-specific-branch-on-external-repos:
     uses: ./.github/workflows/NotifyExternalRepositories.yml
     secrets: inherit
-    needs:
-      - osx
-      - linux-release
-      - windows
-      - python
-      - pyodide
-      - R
-      - Wasm
-      - static-libraries
+    needs: prepare-status
     if: ${{ inputs.git_ref != '' }}
     with:
+      is-success: ${{ needs.prepare-status.outputs.is-success }}
       target-branch: ${{ github.ref_name }}
       duckdb-sha: ${{ inputs.git_ref }}
-      triggering_event: ${{ github.event_name }}
+      triggering-event: ${{ github.event_name }}
+      should-publish: true

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -102,16 +102,17 @@ jobs:
       is-success: ${{ steps.set-output.outputs.success }}
     steps:
       - id: set-output
+        shell: bash
         run:
-          if [ "${{ needs.osx.result }}" == "success" ] && \
-             [ "${{ needs.linux-release.result }}" == "success" ] && \
-             [ "${{ needs.linux-release.result }}" == "success" ] && \
-             [ "${{ needs.windows.result }}" == "success" ] && \
-             [ "${{ needs.python.result }}" == "success" ] && \
-             [ "${{ needs.pyodide.result }}" == "success" ] && \
-             [ "${{ needs.R.result }}" == "success" ] && \
-             [ "${{ needs.Wasm.result }}" == "success" ] && \
-             [ "${{ needs.static-libraries.result }}" == "success" ]; then
+          if [[ "${{ needs.osx.result }}" == "success" && \
+                "${{ needs.linux-release.result }}" == "success" && \
+                "${{ needs.linux-release.result }}" == "success" && \
+                "${{ needs.windows.result }}" == "success" && \
+                "${{ needs.python.result }}" == "success" && \
+                "${{ needs.pyodide.result }}" == "success" && \
+                "${{ needs.R.result }}" == "success" && \
+                "${{ needs.Wasm.result }}" == "success" && \
+                "${{ needs.static-libraries.result }}" == "success" ]]; then
             echo "success=true" >> $GITHUB_OUTPUT
           else
             echo "success=false" >> $GITHUB_OUTPUT
@@ -121,7 +122,7 @@ jobs:
     uses: ./.github/workflows/NotifyExternalRepositories.yml
     secrets: inherit
     needs: prepare-status  
-    if: ${{ inputs.git_ref == '' }} 
+    if: ${{ inputs.git_ref == '' && always() }} 
     with:
       is-success: ${{ needs.prepare-status.outputs.is-success }}
       target-branch: ${{ github.ref_name }}
@@ -133,7 +134,7 @@ jobs:
     uses: ./.github/workflows/NotifyExternalRepositories.yml
     secrets: inherit
     needs: prepare-status
-    if: ${{ inputs.git_ref != '' }}
+    if: ${{ inputs.git_ref != '' && always() }}
     with:
       is-success: ${{ needs.prepare-status.outputs.is-success }}
       target-branch: ${{ github.ref_name }}

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -103,6 +103,8 @@ jobs:
     with:
       target-branch: ${{ github.ref_name }}
       duckdb-sha: ${{ github.ref }}
+      triggering_event: ${{ github.event_name }}
+      should_publish: 'true'
 
   notify-specific-branch-on-external-repos:
     uses: ./.github/workflows/NotifyExternalRepositories.yml
@@ -120,3 +122,4 @@ jobs:
     with:
       target-branch: ${{ github.ref_name }}
       duckdb-sha: ${{ inputs.git_ref }}
+      triggering_event: ${{ github.event_name }}

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -12,6 +12,14 @@ on:
         required: true
         default: ''
         type: 'string'
+      triggering_event:
+        description: 'Which event triggered the run'
+        default: ''
+        type: 'string'
+      should_publish:
+        description: 'Should the called workflow push updates'
+        default: 'false'
+        type: 'string'
   workflow_dispatch:
     inputs:
       duckdb-sha:
@@ -23,6 +31,14 @@ on:
         description: 'Which Branch to Target'
         required: true
         default: ''
+        type: 'string'
+      triggering_event:
+        description: 'Which event triggered the run'
+        default: ''
+        type: 'string'
+      should_publish:
+        description: 'Should the called workflow push updates'
+        default: 'false'
         type: 'string'
 
 concurrency:
@@ -56,5 +72,5 @@ jobs:
         if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
-          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
+          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"branch": "${{ inputs.target-branch }}", "event": "${{ inputs.triggering_event }}", "should_publish": "${{ inputs.should_publish }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -12,14 +12,18 @@ on:
         required: true
         default: ''
         type: 'string'
-      triggering_event:
+      triggering-event:
         description: 'Which event triggered the run'
         default: ''
         type: 'string'
-      should_publish:
-        description: 'Should the called workflow push updates'
-        default: 'false'
-        type: 'string'
+      should-publish:
+        description: 'Should the called workflow push updates or not'
+        default: false
+        type: 'boolean'
+      is-success:
+        description: 'True, if all the builds in InvokeCI had succeeded'
+        default: false
+        type: 'boolean'
   workflow_dispatch:
     inputs:
       duckdb-sha:
@@ -32,14 +36,18 @@ on:
         required: true
         default: ''
         type: 'string'
-      triggering_event:
+      triggering-event:
         description: 'Which event triggered the run'
         default: ''
         type: 'string'
-      should_publish:
+      should-publish:
         description: 'Should the called workflow push updates'
-        default: 'false'
-        type: 'string'
+        default: false
+        type: 'boolean'
+      is-success:
+        description: 'True, if all the builds in InvokeCI had succeeded'
+        default: false
+        type: 'boolean'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -49,6 +57,7 @@ jobs:
   notify-odbc-run:
     name: Run ODBC Vendor
     runs-on: ubuntu-latest
+    if: ${{ inputs.is-success }}
     env:
       PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
The idea is to trigger the `NightlyBuildsStatus.yml` in the end of the `InvokeCI.yml` run.
There is a `NotifyExternalRepositories.yml` workflow for triggering workflow run on the external repos - we just need to pass there all the inputs needed by `NightlyBuildsStatus.yml` run (branch name, event name, should the status report be published or not).

The `NotifyExternalRepositories.yml` triggers two workflows: [duckdb-odbc](https://github.com/duckdb/duckdb-odbc/tree/main)/[.github](https://github.com/duckdb/duckdb-odbc/tree/main/.github)/[workflows](https://github.com/duckdb/duckdb-odbc/tree/main/.github/workflows)/`Vendor.yml` and [duckdb-build-status](https://github.com/duckdb/duckdb-build-status/tree/main)/[.github](https://github.com/duckdb/duckdb-build-status/tree/main/.github)/[workflows](https://github.com/duckdb/duckdb-build-status/tree/main/.github/workflows)`/NightlyBuildsCheck.yml` workflows.
`Vendor.yml` should be triggered only when all builds had succeeded.
`NightlyBuildsStatus.yml` should run in any case. 

So we need to add one more job to `InvokeCI.yml` to create `is-success` status, which is `true` only when **all** builds had succeeded. Then `is-success` status should be passed to the `NotifyExternalRepositories.yml` and its value should be checked before the `Vendor.yml` workflow run is called. We should add `always()` condition to the "notifying" jobs `if:` conditions - that makes them not get skipped in case there a builds not succeeded ([tested here](https://github.com/hmeriann/trigger_nightly_check/actions/runs/14446186717)).