### PR TITLE
Remove misleading lock comment in data table

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -365,7 +365,6 @@ void DataTable::VerifyIndexBuffers() {
 	});
 }
 
-// Lock?
 void DataTable::CleanupAppend(transaction_t lowest_transaction, idx_t start, idx_t count) {
 	row_groups->CleanupAppend(lowest_transaction, start, count);
 }


### PR DESCRIPTION
Just a small follow-up to the review comment in https://github.com/duckdb/duckdb/pull/17034.