### PR TITLE
platform.hpp: Propagate DUCKDB_EXPLICIT_PLATFORM, avoid early return

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,10 @@ if(${FORCE_COLORED_OUTPUT})
   endif()
 endif()
 
+if (DUCKDB_EXPLICIT_PLATFORM)
+    add_definitions(-DDUCKDB_CUSTOM_PLATFORM=${DUCKDB_EXPLICIT_PLATFORM})
+endif()
+
 option (WASM_ENABLED "Are DuckDB-Wasm extensions build enabled" FALSE)
 if (DEFINED ENV{WASM_EXTENSIONS})
      set(WASM_ENABLED "$ENV{WASM_EXTENSIONS}")

--- a/src/include/duckdb/common/platform.hpp
+++ b/src/include/duckdb/common/platform.hpp
@@ -37,7 +37,7 @@ namespace duckdb {
 std::string DuckDBPlatform() { // NOLINT: allow definition in header
 #if defined(DUCKDB_CUSTOM_PLATFORM)
 	return DUCKDB_QUOTE_DEFINE(DUCKDB_CUSTOM_PLATFORM);
-#endif
+#else
 #if defined(DUCKDB_WASM_VERSION)
 	// DuckDB-Wasm requires CUSTOM_PLATFORM to be defined
 	static_assert(0, "DUCKDB_WASM_VERSION should rely on CUSTOM_PLATFORM being provided");
@@ -84,6 +84,7 @@ std::string DuckDBPlatform() { // NOLINT: allow definition in header
 	postfix = "_mingw";
 #endif
 	return os + "_" + arch + postfix;
+#endif
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Two fixes emerged after https://github.com/duckdb/duckdb/pull/16956:
1. add remapping between DUCKDB_EXPLICIT_PLATFORM and DUCKDB_CUSTOM_PLATFORM, this might use a clean-up, I think only one should be necessary, but starting with baby steps
2. preprocessor logic do not compose with early returns (!)

Raised by @Tishj in https://github.com/duckdb/duckdb-avro/pull/21, but this is relevant in general since it meant there was actually no way to short circuit the erorr.

Now that this is in place, I would consider expanding the detection so that behaviour is uniform between unsupported platforms (eg. also `__FreeBSD__` and other might just error out at compile time if platform is not explicitly provided).