### PR TITLE
Add file_index virtual column to the multi file reader that returns the file index of the read file

### DIFF
--- a/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/src/common/multi_file/multi_file_column_mapper.cpp
@@ -647,11 +647,13 @@ MultiFileColumnMapper::EvaluateConstantFilters(ResultColumnMapping &mapping,
 		//! FIXME: this does not check for filters against struct fields that are not present in the file
 		auto global_column_id = global_column_ids[global_index].GetPrimaryIndex();
 		Value constant_value;
-		auto virtual_it = virtual_columns.find(global_column_ids[global_index].GetPrimaryIndex());
+		auto virtual_it = virtual_columns.find(global_column_id);
 		if (virtual_it != virtual_columns.end()) {
 			auto &virtual_column = virtual_it->second;
 			if (virtual_column.name == "filename") {
 				constant_value = Value(reader_data.reader->GetFileName());
+			} else if (global_column_id == MultiFileReader::COLUMN_IDENTIFIER_FILE_INDEX) {
+				constant_value = Value::UBIGINT(reader_data.reader->file_list_idx.GetIndex());
 			} else {
 				throw InternalException("Unrecognized virtual column found: %s", virtual_column.name);
 			}

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -18,6 +18,7 @@ namespace duckdb {
 
 constexpr column_t MultiFileReader::COLUMN_IDENTIFIER_FILENAME;
 constexpr column_t MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER;
+constexpr column_t MultiFileReader::COLUMN_IDENTIFIER_FILE_INDEX;
 constexpr int32_t MultiFileReader::ORDINAL_FIELD_ID;
 constexpr int32_t MultiFileReader::FILENAME_FIELD_ID;
 constexpr int32_t MultiFileReader::ROW_ID_FIELD_ID;
@@ -261,6 +262,7 @@ void MultiFileReader::GetVirtualColumns(ClientContext &context, MultiFileReaderB
 		bind_data.filename_idx = COLUMN_IDENTIFIER_FILENAME;
 		result.insert(make_pair(COLUMN_IDENTIFIER_FILENAME, TableColumn("filename", LogicalType::VARCHAR)));
 	}
+	result.insert(make_pair(COLUMN_IDENTIFIER_FILE_INDEX, TableColumn("file_index", LogicalType::UBIGINT)));
 }
 
 void MultiFileReader::FinalizeBind(MultiFileReaderData &reader_data, const MultiFileOptions &file_options,
@@ -284,9 +286,14 @@ void MultiFileReader::FinalizeBind(MultiFileReaderData &reader_data, const Multi
 		auto &col_id = global_column_ids[i];
 		auto column_id = col_id.GetPrimaryIndex();
 		if ((options.filename_idx.IsValid() && column_id == options.filename_idx.GetIndex()) ||
-		    column_id == MultiFileReader::COLUMN_IDENTIFIER_FILENAME) {
+		    column_id == COLUMN_IDENTIFIER_FILENAME) {
 			// filename
 			reader_data.constant_map.Add(global_idx, Value(filename));
+			continue;
+		}
+		if (column_id == COLUMN_IDENTIFIER_FILE_INDEX) {
+			// filename
+			reader_data.constant_map.Add(global_idx, Value::UBIGINT(reader_data.reader->file_list_idx.GetIndex()));
 			continue;
 		}
 		if (IsVirtualColumn(column_id)) {

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -34,6 +34,7 @@ struct MultiFileReader {
 public:
 	static constexpr column_t COLUMN_IDENTIFIER_FILENAME = UINT64_C(9223372036854775808);
 	static constexpr column_t COLUMN_IDENTIFIER_FILE_ROW_NUMBER = UINT64_C(9223372036854775809);
+	static constexpr column_t COLUMN_IDENTIFIER_FILE_INDEX = UINT64_C(9223372036854775810);
 	// Reserved field id used for the "_file" field according to the iceberg spec (used for file_row_number)
 	static constexpr int32_t ORDINAL_FIELD_ID = 2147483645;
 	// Reserved field id used for the "_pos" field according to the iceberg spec (used for file_row_number)

--- a/test/sql/copy/parquet/parquet_virtual_columns.test
+++ b/test/sql/copy/parquet/parquet_virtual_columns.test
@@ -4,6 +4,26 @@
 
 require parquet
 
+# file_index
+query I
+SELECT file_index FROM 'data/parquet-testing/glob/t1.parquet'
+----
+0
+
+query III
+SELECT file_index, i, j FROM read_parquet(['data/parquet-testing/glob/t1.parquet', 'data/parquet-testing/glob/t2.parquet', 'data/parquet-testing/glob2/t1.parquet'])
+----
+0	1	a
+1	2	b
+2	3	c
+
+query III
+SELECT file_index, i, j
+FROM read_parquet(['data/parquet-testing/glob/t1.parquet', 'data/parquet-testing/glob/t2.parquet', 'data/parquet-testing/glob2/t1.parquet'])
+WHERE file_index=1
+----
+1	2	b
+
 # Filename without the filename option
 statement ok
 select filename from 'data/parquet-testing/glob/t1.parquet'


### PR DESCRIPTION
This PR adds the `file_index` virtual column to the multi file reader. This is an index of the file into the file list of the multi file reader. For example:

```sql
D SELECT file_index, filename FROM read_parquet(['data/parquet-testing/glob/t1.parquet', 'data/parquet-testing/glob/t2.parquet', 'data/parquet-testing/glob2/t1.parquet']);
┌────────────┬───────────────────────────────────────┐
│ file_index │               filename                │
│   uint64   │                varchar                │
├────────────┼───────────────────────────────────────┤
│          0 │ data/parquet-testing/glob/t1.parquet  │
│          1 │ data/parquet-testing/glob/t2.parquet  │
│          2 │ data/parquet-testing/glob2/t1.parquet │
└────────────┴───────────────────────────────────────┘
```

