### PR TITLE
Changes to encodings to make them more flexible to replacement maps.

### DIFF
--- a/src/execution/operator/csv_scanner/encode/csv_encoder.cpp
+++ b/src/execution/operator/csv_scanner/encode/csv_encoder.cpp
@@ -45,7 +45,7 @@ CSVEncoder::CSVEncoder(const DBConfig &config, const string &encoding_name_to_fi
 		error << "The CSV Reader does not support the encoding: \"" << encoding_name_to_find << "\"\n";
 		error << "The currently supported encodings are: " << '\n';
 		for (auto &encoding_function : loaded_encodings) {
-			error << "*  " << encoding_function.get().GetType() << '\n';
+			error << "*  " << encoding_function.get().GetName() << '\n';
 		}
 		throw InvalidInputException(error.str());
 	}

--- a/src/execution/operator/csv_scanner/encode/csv_encoder.cpp
+++ b/src/execution/operator/csv_scanner/encode/csv_encoder.cpp
@@ -77,7 +77,7 @@ idx_t CSVEncoder::Encode(FileHandle &file_handle_input, char *output_buffer, con
 	if (encoded_buffer.HasDataToRead()) {
 		encoding_function->GetFunction()(
 		    encoded_buffer.Ptr(), encoded_buffer.cur_pos, encoded_buffer.GetSize(), output_buffer, output_buffer_pos,
-		    decoded_buffer_size, remaining_bytes_buffer.Ptr(), remaining_bytes_buffer.actual_encoded_buffer_size);
+		    decoded_buffer_size, remaining_bytes_buffer.Ptr(), remaining_bytes_buffer.actual_encoded_buffer_size, encoding_function.get());
 	}
 	// 3. a new encoded buffer from the file
 	while (output_buffer_pos < decoded_buffer_size) {
@@ -88,7 +88,7 @@ idx_t CSVEncoder::Encode(FileHandle &file_handle_input, char *output_buffer, con
 		encoded_buffer.SetSize(actual_encoded_bytes);
 		encoding_function->GetFunction()(
 		    encoded_buffer.Ptr(), encoded_buffer.cur_pos, encoded_buffer.GetSize(), output_buffer, output_buffer_pos,
-		    decoded_buffer_size, remaining_bytes_buffer.Ptr(), remaining_bytes_buffer.actual_encoded_buffer_size);
+		    decoded_buffer_size, remaining_bytes_buffer.Ptr(), remaining_bytes_buffer.actual_encoded_buffer_size, encoding_function.get());
 		if (output_buffer_pos == current_decoded_buffer_start) {
 			return output_buffer_pos;
 		}

--- a/src/execution/operator/csv_scanner/encode/csv_encoder.cpp
+++ b/src/execution/operator/csv_scanner/encode/csv_encoder.cpp
@@ -75,17 +75,20 @@ idx_t CSVEncoder::Encode(FileHandle &file_handle_input, char *output_buffer, con
 	}
 	// 2. remaining encoded buffer
 	if (encoded_buffer.HasDataToRead()) {
-		encoding_function->GetFunction()(
-		   encoded_buffer, output_buffer, output_buffer_pos,
-		   decoded_buffer_size, remaining_bytes_buffer.Ptr(), remaining_bytes_buffer.actual_encoded_buffer_size, encoding_function.get());
+		encoding_function->GetFunction()(encoded_buffer, output_buffer, output_buffer_pos, decoded_buffer_size,
+		                                 remaining_bytes_buffer.Ptr(),
+		                                 remaining_bytes_buffer.actual_encoded_buffer_size, encoding_function.get());
 	}
 	// 3. a new encoded buffer from the file
 	while (output_buffer_pos < decoded_buffer_size) {
 		idx_t current_decoded_buffer_start = output_buffer_pos;
 		vector<char> pass_on_buffer;
-		if (encoded_buffer.cur_pos != encoded_buffer.GetSize() && encoding_function->GetLookupBytes() > encoded_buffer.GetSize() - encoded_buffer.cur_pos) {
-			// We don't have enough lookup bytes for it, if that's the case, we need to set off these bytes to the next buffer
-			for (idx_t i = encoded_buffer.GetSize() - encoded_buffer.cur_pos; i < encoding_function->GetLookupBytes(); i++) {
+		if (encoded_buffer.cur_pos != encoded_buffer.GetSize() &&
+		    encoding_function->GetLookupBytes() > encoded_buffer.GetSize() - encoded_buffer.cur_pos) {
+			// We don't have enough lookup bytes for it, if that's the case, we need to set off these bytes to the next
+			// buffer
+			for (idx_t i = encoded_buffer.GetSize() - encoded_buffer.cur_pos; i < encoding_function->GetLookupBytes();
+			     i++) {
 				pass_on_buffer.push_back(encoded_buffer.Ptr()[i]);
 			}
 		}
@@ -96,15 +99,15 @@ idx_t CSVEncoder::Encode(FileHandle &file_handle_input, char *output_buffer, con
 		if (has_pass_on_byte) {
 			encoded_buffer.Ptr()[pass_on_buffer.size()] = pass_on_byte;
 		}
-		auto actual_encoded_bytes =
-		    static_cast<idx_t>(file_handle_input.Read(encoded_buffer.Ptr() + pass_on_buffer.size() + has_pass_on_byte, encoded_buffer.GetCapacity() - pass_on_buffer.size() - has_pass_on_byte));
+		auto actual_encoded_bytes = static_cast<idx_t>(
+		    file_handle_input.Read(encoded_buffer.Ptr() + pass_on_buffer.size() + has_pass_on_byte,
+		                           encoded_buffer.GetCapacity() - pass_on_buffer.size() - has_pass_on_byte));
 		encoded_buffer.SetSize(actual_encoded_bytes + pass_on_buffer.size() + has_pass_on_byte);
 		if (actual_encoded_bytes < encoded_buffer.GetCapacity() - pass_on_buffer.size()) {
 			encoded_buffer.last_buffer = true;
 			has_pass_on_byte = false;
 		} else {
-			auto bytes_read =
-				static_cast<idx_t>(file_handle_input.Read(&pass_on_byte, 1));
+			auto bytes_read = static_cast<idx_t>(file_handle_input.Read(&pass_on_byte, 1));
 			if (bytes_read == 0) {
 				encoded_buffer.last_buffer = true;
 				has_pass_on_byte = false;
@@ -112,9 +115,9 @@ idx_t CSVEncoder::Encode(FileHandle &file_handle_input, char *output_buffer, con
 				has_pass_on_byte = true;
 			}
 		}
-		encoding_function->GetFunction()(
-		    encoded_buffer, output_buffer, output_buffer_pos,
-		    decoded_buffer_size, remaining_bytes_buffer.Ptr(), remaining_bytes_buffer.actual_encoded_buffer_size, encoding_function.get());
+		encoding_function->GetFunction()(encoded_buffer, output_buffer, output_buffer_pos, decoded_buffer_size,
+		                                 remaining_bytes_buffer.Ptr(),
+		                                 remaining_bytes_buffer.actual_encoded_buffer_size, encoding_function.get());
 		if (output_buffer_pos == current_decoded_buffer_start) {
 			return output_buffer_pos;
 		}

--- a/src/function/encoding_function.cpp
+++ b/src/function/encoding_function.cpp
@@ -12,7 +12,7 @@ struct DefaultEncodeMethod {
 
 void DecodeUTF16ToUTF8(const char *source_buffer, idx_t &source_buffer_current_position, const idx_t source_buffer_size,
                        char *target_buffer, idx_t &target_buffer_current_position, const idx_t target_buffer_size,
-                       char *remaining_bytes_buffer, idx_t &remaining_bytes_size) {
+                       char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function) {
 
 	for (; source_buffer_current_position < source_buffer_size; source_buffer_current_position += 2) {
 		if (target_buffer_current_position == target_buffer_size) {
@@ -65,7 +65,7 @@ void DecodeUTF16ToUTF8(const char *source_buffer, idx_t &source_buffer_current_p
 
 void DecodeLatin1ToUTF8(const char *source_buffer, idx_t &source_buffer_current_position,
                         const idx_t source_buffer_size, char *target_buffer, idx_t &target_buffer_current_position,
-                        const idx_t target_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size) {
+                        const idx_t target_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function) {
 	for (; source_buffer_current_position < source_buffer_size; source_buffer_current_position++) {
 		if (target_buffer_current_position == target_buffer_size) {
 			// We are done
@@ -95,14 +95,14 @@ void DecodeLatin1ToUTF8(const char *source_buffer, idx_t &source_buffer_current_
 
 void DecodeUTF8(const char *source_buffer, idx_t &source_buffer_current_position, const idx_t source_buffer_size,
                 char *target_buffer, idx_t &target_buffer_current_position, const idx_t target_buffer_size,
-                char *remaining_bytes_buffer, idx_t &remaining_bytes_size) {
+                char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function) {
 	throw InternalException("Decode UTF8 is not a valid function, and should be verified one level up.");
 }
 
 void EncodingFunctionSet::Initialize(DBConfig &config) {
-	config.RegisterEncodeFunction({"utf-8", DecodeUTF8, 1, 1});
-	config.RegisterEncodeFunction({"latin-1", DecodeLatin1ToUTF8, 2, 1});
-	config.RegisterEncodeFunction({"utf-16", DecodeUTF16ToUTF8, 2, 2});
+	config.RegisterEncodeFunction({"utf-8", DecodeUTF8, 1});
+	config.RegisterEncodeFunction({"latin-1", DecodeLatin1ToUTF8, 2});
+	config.RegisterEncodeFunction({"utf-16", DecodeUTF16ToUTF8, 2});
 }
 
 void DBConfig::RegisterEncodeFunction(const EncodingFunction &function) const {

--- a/src/function/encoding_function.cpp
+++ b/src/function/encoding_function.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/function/encoding_function.hpp"
 #include "duckdb/main/config.hpp"
 
+#include "duckdb/execution/operator/csv_scanner/encode/csv_encoder.hpp"
+
 namespace duckdb {
 
 struct DefaultEncodeMethod {
@@ -10,18 +12,18 @@ struct DefaultEncodeMethod {
 	idx_t bytes_per_iteration;
 };
 
-void DecodeUTF16ToUTF8(const char *source_buffer, idx_t &source_buffer_current_position, const idx_t source_buffer_size,
+void DecodeUTF16ToUTF8(CSVEncoderBuffer& encoded_buffer,
                        char *target_buffer, idx_t &target_buffer_current_position, const idx_t target_buffer_size,
                        char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function) {
-
-	for (; source_buffer_current_position < source_buffer_size; source_buffer_current_position += 2) {
+	auto encoded_ptr = encoded_buffer.Ptr();
+	for (; encoded_buffer.cur_pos < encoded_buffer.actual_encoded_buffer_size; encoded_buffer.cur_pos += 2) {
 		if (target_buffer_current_position == target_buffer_size) {
 			// We are done
 			return;
 		}
 		const uint16_t ch =
-		    static_cast<uint16_t>(static_cast<unsigned char>(source_buffer[source_buffer_current_position]) |
-		                          (static_cast<unsigned char>(source_buffer[source_buffer_current_position + 1]) << 8));
+		    static_cast<uint16_t>(static_cast<unsigned char>(encoded_ptr[encoded_buffer.cur_pos]) |
+		                          (static_cast<unsigned char>(encoded_ptr[encoded_buffer.cur_pos + 1]) << 8));
 		if (ch >= 0xD800 && ch <= 0xDFFF) {
 			throw InvalidInputException("File is not utf-16 encoded");
 		}
@@ -33,7 +35,7 @@ void DecodeUTF16ToUTF8(const char *source_buffer, idx_t &source_buffer_current_p
 			target_buffer[target_buffer_current_position++] = static_cast<char>(0xC0 | (ch >> 6));
 			if (target_buffer_current_position == target_buffer_size) {
 				// We are done, but we have to store one byte for the next chunk!
-				source_buffer_current_position += 2;
+				encoded_buffer.cur_pos += 2;
 				remaining_bytes_buffer[0] = static_cast<char>(0x80 | (ch & 0x3F));
 				remaining_bytes_size = 1;
 				return;
@@ -44,7 +46,7 @@ void DecodeUTF16ToUTF8(const char *source_buffer, idx_t &source_buffer_current_p
 			target_buffer[target_buffer_current_position++] = static_cast<char>(0xE0 | (ch >> 12));
 			if (target_buffer_current_position == target_buffer_size) {
 				// We are done, but we have to store two bytes for the next chunk!
-				source_buffer_current_position += 2;
+				encoded_buffer.cur_pos += 2;
 				remaining_bytes_buffer[0] = static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
 				remaining_bytes_buffer[1] = static_cast<char>(0x80 | (ch & 0x3F));
 				remaining_bytes_size = 2;
@@ -53,7 +55,7 @@ void DecodeUTF16ToUTF8(const char *source_buffer, idx_t &source_buffer_current_p
 			target_buffer[target_buffer_current_position++] = static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
 			if (target_buffer_current_position == target_buffer_size) {
 				// We are done, but we have to store one byte for the next chunk!
-				source_buffer_current_position += 2;
+				encoded_buffer.cur_pos += 2;
 				remaining_bytes_buffer[0] = static_cast<char>(0x80 | (ch & 0x3F));
 				remaining_bytes_size = 1;
 				return;
@@ -63,15 +65,15 @@ void DecodeUTF16ToUTF8(const char *source_buffer, idx_t &source_buffer_current_p
 	}
 }
 
-void DecodeLatin1ToUTF8(const char *source_buffer, idx_t &source_buffer_current_position,
-                        const idx_t source_buffer_size, char *target_buffer, idx_t &target_buffer_current_position,
+void DecodeLatin1ToUTF8(CSVEncoderBuffer& encoded_buffer, char *target_buffer, idx_t &target_buffer_current_position,
                         const idx_t target_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function) {
-	for (; source_buffer_current_position < source_buffer_size; source_buffer_current_position++) {
+	auto encoded_ptr = encoded_buffer.Ptr();
+	for (; encoded_buffer.cur_pos < encoded_buffer.actual_encoded_buffer_size; encoded_buffer.cur_pos++) {
 		if (target_buffer_current_position == target_buffer_size) {
 			// We are done
 			return;
 		}
-		const unsigned char ch = static_cast<unsigned char>(source_buffer[source_buffer_current_position]);
+		const unsigned char ch = static_cast<unsigned char>(encoded_ptr[encoded_buffer.cur_pos]);
 		if (ch > 0x7F && ch <= 0x9F) {
 			throw InvalidInputException("File is not latin-1 encoded");
 		}
@@ -83,7 +85,7 @@ void DecodeLatin1ToUTF8(const char *source_buffer, idx_t &source_buffer_current_
 			target_buffer[target_buffer_current_position++] = static_cast<char>(0xc2 + (ch > 0xbf));
 			if (target_buffer_current_position == target_buffer_size) {
 				// We are done, but we have to store one byte for the next chunk!
-				source_buffer_current_position++;
+				encoded_buffer.cur_pos++;
 				remaining_bytes_buffer[0] = static_cast<char>((ch & 0x3f) + 0x80);
 				remaining_bytes_size = 1;
 				return;
@@ -93,8 +95,7 @@ void DecodeLatin1ToUTF8(const char *source_buffer, idx_t &source_buffer_current_
 	}
 }
 
-void DecodeUTF8(const char *source_buffer, idx_t &source_buffer_current_position, const idx_t source_buffer_size,
-                char *target_buffer, idx_t &target_buffer_current_position, const idx_t target_buffer_size,
+void DecodeUTF8(CSVEncoderBuffer& encoded_buffer, char *target_buffer, idx_t &target_buffer_current_position, const idx_t target_buffer_size,
                 char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function) {
 	throw InternalException("Decode UTF8 is not a valid function, and should be verified one level up.");
 }

--- a/src/function/encoding_function.cpp
+++ b/src/function/encoding_function.cpp
@@ -107,11 +107,11 @@ void EncodingFunctionSet::Initialize(DBConfig &config) {
 
 void DBConfig::RegisterEncodeFunction(const EncodingFunction &function) const {
 	lock_guard<mutex> l(encoding_functions->lock);
-	const auto decode_type = function.GetType();
-	if (encoding_functions->functions.find(decode_type) != encoding_functions->functions.end()) {
-		throw InvalidInputException("Decoding function with name %s already registered", decode_type);
+	const auto name = function.GetName();
+	if (encoding_functions->functions.find(name) != encoding_functions->functions.end()) {
+		throw InvalidInputException("Decoding function with name %s already registered", name);
 	}
-	encoding_functions->functions[decode_type] = function;
+	encoding_functions->functions[name] = function;
 }
 
 optional_ptr<EncodingFunction> DBConfig::GetEncodeFunction(const string &name) const {

--- a/src/function/encoding_function.cpp
+++ b/src/function/encoding_function.cpp
@@ -100,9 +100,9 @@ void DecodeUTF8(const char *source_buffer, idx_t &source_buffer_current_position
 }
 
 void EncodingFunctionSet::Initialize(DBConfig &config) {
-	config.RegisterEncodeFunction({"utf-8", DecodeUTF8, 1});
-	config.RegisterEncodeFunction({"latin-1", DecodeLatin1ToUTF8, 2});
-	config.RegisterEncodeFunction({"utf-16", DecodeUTF16ToUTF8, 2});
+	config.RegisterEncodeFunction({"utf-8", DecodeUTF8, 1,1});
+	config.RegisterEncodeFunction({"latin-1", DecodeLatin1ToUTF8, 2,1});
+	config.RegisterEncodeFunction({"utf-16", DecodeUTF16ToUTF8, 2,2});
 }
 
 void DBConfig::RegisterEncodeFunction(const EncodingFunction &function) const {

--- a/src/function/encoding_function.cpp
+++ b/src/function/encoding_function.cpp
@@ -12,9 +12,9 @@ struct DefaultEncodeMethod {
 	idx_t bytes_per_iteration;
 };
 
-void DecodeUTF16ToUTF8(CSVEncoderBuffer& encoded_buffer,
-                       char *target_buffer, idx_t &target_buffer_current_position, const idx_t target_buffer_size,
-                       char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function) {
+void DecodeUTF16ToUTF8(CSVEncoderBuffer &encoded_buffer, char *target_buffer, idx_t &target_buffer_current_position,
+                       const idx_t target_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size,
+                       EncodingFunction *encoding_function) {
 	auto encoded_ptr = encoded_buffer.Ptr();
 	for (; encoded_buffer.cur_pos < encoded_buffer.actual_encoded_buffer_size; encoded_buffer.cur_pos += 2) {
 		if (target_buffer_current_position == target_buffer_size) {
@@ -65,8 +65,9 @@ void DecodeUTF16ToUTF8(CSVEncoderBuffer& encoded_buffer,
 	}
 }
 
-void DecodeLatin1ToUTF8(CSVEncoderBuffer& encoded_buffer, char *target_buffer, idx_t &target_buffer_current_position,
-                        const idx_t target_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function) {
+void DecodeLatin1ToUTF8(CSVEncoderBuffer &encoded_buffer, char *target_buffer, idx_t &target_buffer_current_position,
+                        const idx_t target_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size,
+                        EncodingFunction *encoding_function) {
 	auto encoded_ptr = encoded_buffer.Ptr();
 	for (; encoded_buffer.cur_pos < encoded_buffer.actual_encoded_buffer_size; encoded_buffer.cur_pos++) {
 		if (target_buffer_current_position == target_buffer_size) {
@@ -95,15 +96,16 @@ void DecodeLatin1ToUTF8(CSVEncoderBuffer& encoded_buffer, char *target_buffer, i
 	}
 }
 
-void DecodeUTF8(CSVEncoderBuffer& encoded_buffer, char *target_buffer, idx_t &target_buffer_current_position, const idx_t target_buffer_size,
-                char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function) {
+void DecodeUTF8(CSVEncoderBuffer &encoded_buffer, char *target_buffer, idx_t &target_buffer_current_position,
+                const idx_t target_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size,
+                EncodingFunction *encoding_function) {
 	throw InternalException("Decode UTF8 is not a valid function, and should be verified one level up.");
 }
 
 void EncodingFunctionSet::Initialize(DBConfig &config) {
-	config.RegisterEncodeFunction({"utf-8", DecodeUTF8, 1,1});
-	config.RegisterEncodeFunction({"latin-1", DecodeLatin1ToUTF8, 2,1});
-	config.RegisterEncodeFunction({"utf-16", DecodeUTF16ToUTF8, 2,2});
+	config.RegisterEncodeFunction({"utf-8", DecodeUTF8, 1, 1});
+	config.RegisterEncodeFunction({"latin-1", DecodeLatin1ToUTF8, 2, 1});
+	config.RegisterEncodeFunction({"utf-16", DecodeUTF16ToUTF8, 2, 2});
 }
 
 void DBConfig::RegisterEncodeFunction(const EncodingFunction &function) const {

--- a/src/include/duckdb/execution/operator/csv_scanner/encode/csv_encoder.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/encode/csv_encoder.hpp
@@ -35,6 +35,8 @@ struct CSVEncoderBuffer {
 	idx_t cur_pos = 0;
 	//! The actual encoded buffer size, from the last file_handle read.
 	idx_t actual_encoded_buffer_size = 0;
+	//! If this is the last buffer
+	bool last_buffer = false;
 
 private:
 	//! The encoded buffer, we only have one per file, so we cache it and make sure to pass over unused bytes.
@@ -58,5 +60,8 @@ private:
 	CSVEncoderBuffer remaining_bytes_buffer;
 	//! Actual Encoding Function
 	optional_ptr<EncodingFunction> encoding_function;
+	//! Pass-on Byte, used to check if we are done with the file, but must be appended to next buffer
+	char pass_on_byte;
+	bool has_pass_on_byte = false;
 };
 } // namespace duckdb

--- a/src/include/duckdb/function/encoding_function.hpp
+++ b/src/include/duckdb/function/encoding_function.hpp
@@ -40,6 +40,14 @@ public:
 		D_ASSERT(bytes_per_iteration > 0);
 		D_ASSERT(lookup_bytes > 0);
 	};
+	EncodingFunction(const string &encode_name, encode_t encode_function,
+	                 const idx_t bytes_per_iteration, const idx_t lookup_bytes, const map<vector<uint8_t>, vector<uint8_t>> &conversion_map)
+	    : conversion_map(conversion_map), name(encode_name),
+	      encode_function(encode_function), max_bytes_per_iteration(bytes_per_iteration), lookup_bytes(lookup_bytes) {
+		D_ASSERT(encode_function);
+		D_ASSERT(bytes_per_iteration > 0);
+		D_ASSERT(lookup_bytes > 0);
+	};
 
 	~EncodingFunction() {};
 
@@ -53,9 +61,11 @@ public:
 		return max_bytes_per_iteration;
 	}
 	idx_t GetLookupBytes() const {
-		return max_bytes_per_iteration;
+		return lookup_bytes;
 	}
 
+	//! Optional convertion map, that indicates byte replacements.
+	map<vector<uint8_t>, vector<uint8_t>> conversion_map;
 protected:
 	//! The encoding type of this function (e.g., utf-8)
 	string name;

--- a/src/include/duckdb/function/encoding_function.hpp
+++ b/src/include/duckdb/function/encoding_function.hpp
@@ -32,7 +32,7 @@ public:
 
 	EncodingFunction(const string &encode_type, encode_t encode_function, const idx_t ratio,
 	                 const idx_t bytes_per_iteration)
-	    : encoding_type(encode_type), encode_function(encode_function), ratio(ratio),
+	    : name(encode_type), encode_function(encode_function), ratio(ratio),
 	      bytes_per_iteration(bytes_per_iteration) {
 		D_ASSERT(ratio > 0);
 		D_ASSERT(encode_function);
@@ -41,8 +41,8 @@ public:
 
 	~EncodingFunction() {};
 
-	string GetType() const {
-		return encoding_type;
+	string GetName() const {
+		return name;
 	}
 	encode_t GetFunction() const {
 		return encode_function;
@@ -56,7 +56,7 @@ public:
 
 private:
 	//! The encoding type of this function (e.g., utf-8)
-	string encoding_type;
+	string name;
 	//! The actual encoding function
 	encode_t encode_function;
 	//! Ratio of the max size this encoded buffer could ever reach on a decoded buffer

--- a/src/include/duckdb/function/encoding_function.hpp
+++ b/src/include/duckdb/function/encoding_function.hpp
@@ -24,18 +24,19 @@ class EncodingFunction;
 
 struct CSVEncoderBuffer;
 //! Decode function, basically takes information about the decoded and the encoded buffers.
-typedef void (*encode_t)(CSVEncoderBuffer& encoded_buffer, char *decoded_buffer, idx_t &decoded_buffer_current_position,
-                         const idx_t decoded_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function);
+typedef void (*encode_t)(CSVEncoderBuffer &encoded_buffer, char *decoded_buffer, idx_t &decoded_buffer_current_position,
+                         const idx_t decoded_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size,
+                         EncodingFunction *encoding_function);
 
 class EncodingFunction {
 public:
 	EncodingFunction() : encode_function(nullptr), max_bytes_per_iteration(0) {
 	}
 
-	EncodingFunction(const string &encode_name, encode_t encode_function,
-	                 const idx_t bytes_per_iteration, const idx_t lookup_bytes)
-	    : name(encode_name), encode_function(encode_function),
-	      max_bytes_per_iteration(bytes_per_iteration), lookup_bytes(lookup_bytes) {
+	EncodingFunction(const string &encode_name, encode_t encode_function, const idx_t bytes_per_iteration,
+	                 const idx_t lookup_bytes)
+	    : name(encode_name), encode_function(encode_function), max_bytes_per_iteration(bytes_per_iteration),
+	      lookup_bytes(lookup_bytes) {
 		D_ASSERT(encode_function);
 		D_ASSERT(bytes_per_iteration > 0);
 		D_ASSERT(lookup_bytes > 0);

--- a/src/include/duckdb/function/encoding_function.hpp
+++ b/src/include/duckdb/function/encoding_function.hpp
@@ -41,10 +41,10 @@ public:
 		D_ASSERT(bytes_per_iteration > 0);
 		D_ASSERT(lookup_bytes > 0);
 	};
-	EncodingFunction(const string &encode_name, encode_t encode_function,
-	                 const idx_t bytes_per_iteration, const idx_t lookup_bytes, const uintptr_t map, const size_t map_size)
-	    : conversion_map(map), map_size(map_size), name(encode_name),
-	      encode_function(encode_function), max_bytes_per_iteration(bytes_per_iteration), lookup_bytes(lookup_bytes) {
+	EncodingFunction(const string &encode_name, encode_t encode_function, const idx_t bytes_per_iteration,
+	                 const idx_t lookup_bytes, const uintptr_t map, const size_t map_size)
+	    : conversion_map(map), map_size(map_size), name(encode_name), encode_function(encode_function),
+	      max_bytes_per_iteration(bytes_per_iteration), lookup_bytes(lookup_bytes) {
 		D_ASSERT(encode_function);
 		D_ASSERT(bytes_per_iteration > 0);
 		D_ASSERT(lookup_bytes > 0);
@@ -66,8 +66,9 @@ public:
 	}
 
 	//! Optional convertion map, that indicates byte replacements.
-	uintptr_t conversion_map{};
-	size_t map_size{};
+	uintptr_t conversion_map {};
+	size_t map_size {};
+
 protected:
 	//! The encoding type of this function (e.g., utf-8)
 	string name;

--- a/src/include/duckdb/function/encoding_function.hpp
+++ b/src/include/duckdb/function/encoding_function.hpp
@@ -31,12 +31,13 @@ public:
 	EncodingFunction() : encode_function(nullptr), max_bytes_per_iteration(0) {
 	}
 
-	EncodingFunction(const string &encode_type, encode_t encode_function,
-	                 const idx_t bytes_per_iteration)
-	    : name(encode_type), encode_function(encode_function),
-	      max_bytes_per_iteration(bytes_per_iteration) {
+	EncodingFunction(const string &encode_name, encode_t encode_function,
+	                 const idx_t bytes_per_iteration, const idx_t lookup_bytes)
+	    : name(encode_name), encode_function(encode_function),
+	      max_bytes_per_iteration(bytes_per_iteration), lookup_bytes(lookup_bytes) {
 		D_ASSERT(encode_function);
 		D_ASSERT(bytes_per_iteration > 0);
+		D_ASSERT(lookup_bytes > 0);
 	};
 
 	~EncodingFunction() {};
@@ -50,8 +51,11 @@ public:
 	idx_t GetBytesPerIteration() const {
 		return max_bytes_per_iteration;
 	}
+	idx_t GetLookupBytes() const {
+		return max_bytes_per_iteration;
+	}
 
-private:
+protected:
 	//! The encoding type of this function (e.g., utf-8)
 	string name;
 	//! The actual encoding function
@@ -60,6 +64,8 @@ private:
 	//! e.g., one iteration of Latin-1 to UTF-8 can generate max 2 bytes.
 	//! However, one iteration of UTF-16 to UTF-8, can generate up to 3 UTF-8 bytes.
 	idx_t max_bytes_per_iteration;
+	//! How many bytes we have to lookup before knowing the bytes we have to output
+	idx_t lookup_bytes = 1;
 };
 
 //! The set of encoding functions

--- a/src/include/duckdb/function/encoding_function.hpp
+++ b/src/include/duckdb/function/encoding_function.hpp
@@ -21,9 +21,10 @@ namespace duckdb {
 struct DBConfig;
 
 class EncodingFunction;
+
+struct CSVEncoderBuffer;
 //! Decode function, basically takes information about the decoded and the encoded buffers.
-typedef void (*encode_t)(const char *encoded_buffer, idx_t &encoded_buffer_current_position,
-                         const idx_t encoded_buffer_size, char *decoded_buffer, idx_t &decoded_buffer_current_position,
+typedef void (*encode_t)(CSVEncoderBuffer& encoded_buffer, char *decoded_buffer, idx_t &decoded_buffer_current_position,
                          const idx_t decoded_buffer_size, char *remaining_bytes_buffer, idx_t &remaining_bytes_size, EncodingFunction* encoding_function);
 
 class EncodingFunction {

--- a/src/include/duckdb/function/encoding_function.hpp
+++ b/src/include/duckdb/function/encoding_function.hpp
@@ -41,8 +41,8 @@ public:
 		D_ASSERT(lookup_bytes > 0);
 	};
 	EncodingFunction(const string &encode_name, encode_t encode_function,
-	                 const idx_t bytes_per_iteration, const idx_t lookup_bytes, const map<vector<uint8_t>, vector<uint8_t>> &conversion_map)
-	    : conversion_map(conversion_map), name(encode_name),
+	                 const idx_t bytes_per_iteration, const idx_t lookup_bytes, const uintptr_t map, const size_t map_size)
+	    : conversion_map(map), map_size(map_size), name(encode_name),
 	      encode_function(encode_function), max_bytes_per_iteration(bytes_per_iteration), lookup_bytes(lookup_bytes) {
 		D_ASSERT(encode_function);
 		D_ASSERT(bytes_per_iteration > 0);
@@ -65,7 +65,8 @@ public:
 	}
 
 	//! Optional convertion map, that indicates byte replacements.
-	map<vector<uint8_t>, vector<uint8_t>> conversion_map;
+	uintptr_t conversion_map{};
+	size_t map_size{};
 protected:
 	//! The encoding type of this function (e.g., utf-8)
 	string name;


### PR DESCRIPTION
This PR changes a bit of the encoding infrastructure so we can easily use a c array to store the byte changes we need to do when encoding from X to UTF-8.

https://github.com/pdet/duckdb-encodings is already using this mechanism.