### PR TITLE
[InvokeCI] Add missing pipe to run instruction

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -103,7 +103,7 @@ jobs:
     steps:
       - id: set-output
         shell: bash
-        run:
+        run: |
           if [[ "${{ needs.osx.result }}" == "success" && \
                 "${{ needs.linux-release.result }}" == "success" && \
                 "${{ needs.linux-release.result }}" == "success" && \


### PR DESCRIPTION
The latest InvokeCI run had failed because of missing pipe in the `prepare-status` step's `run:` instruction.
This PR add a missing pipe and it should fix the ["unexpected end of command" issue](https://github.com/duckdb/duckdb/actions/runs/14505429008/job/40705456895#step:2:1).