### PR TITLE
Add filename to GZIP stream error

### DIFF
--- a/src/include/duckdb/common/gzip_file_system.hpp
+++ b/src/include/duckdb/common/gzip_file_system.hpp
@@ -24,7 +24,7 @@ public:
 	}
 
 	//! Verifies that a buffer contains a valid GZIP header
-	static void VerifyGZIPHeader(uint8_t gzip_hdr[], idx_t read_count);
+	static void VerifyGZIPHeader(uint8_t gzip_hdr[], idx_t read_count, optional_ptr<CompressedFile> source_file);
 	static bool CheckIsZip(const char *length, idx_t size);
 
 	//! Consumes a byte stream as a gzip string, returning the decompressed string

--- a/test/sql/copy/csv/zstd_crash.test
+++ b/test/sql/copy/csv/zstd_crash.test
@@ -25,7 +25,7 @@ Attempting to open a compressed file, but the compression type is not supported
 statement error
 COPY test_zst FROM 'data/csv/broken/test.csv.zst' (COMPRESSION GZIP);
 ----
-Input is not a GZIP stream
+Input is not a GZIP stream: data/csv/broken/test.csv.zst
 
 statement error
 COPY test_zst FROM 'data/csv/broken/test.csv.zst' (COMPRESSION NONE);


### PR DESCRIPTION
When querying a large list of compressed files using a wildcard, and some of those files are invalid (e.g. 0 bytes), it can be quite difficult to figure out which one is causing the problem.

This PR proposes to add the (first) invalid filename to the error message when possible.

Before:
```sql
select * from read_csv('s3://marco-crunchy-data/tmp/*.csv.gz');
IO Error: Input is not a GZIP stream
```

After:
```sql
select * from read_csv('s3://marco-crunchy-data/tmp/*.csv.gz');
IO Error: Input is not a GZIP stream: s3://marco-crunchy-data/tmp/faulty.csv.gz
```