### PR TITLE
Fix extension check when load database

### DIFF
--- a/src/execution/operator/schema/physical_attach.cpp
+++ b/src/execution/operator/schema/physical_attach.cpp
@@ -64,10 +64,6 @@ SourceResultType PhysicalAttach::GetData(ExecutionContext &context, DataChunk &c
 
 	string extension = "";
 	if (FileSystem::IsRemoteFile(path, extension)) {
-		if (!ExtensionHelper::TryAutoLoadExtension(context.client, extension)) {
-			throw MissingExtensionException("Attaching path '%s' requires extension '%s' to be loaded", path,
-			                                extension);
-		}
 		if (options.access_mode == AccessMode::AUTOMATIC) {
 			// Attaching of remote files gets bumped to READ_ONLY
 			// This is due to the fact that on most (all?) remote files writes to DB are not available

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -261,7 +261,9 @@ void SingleFileBlockManager::LoadExistingDatabase() {
 	handle = fs.OpenFile(path, flags);
 	if (!handle) {
 		// this can only happen in read-only mode - as that is when we set FILE_FLAGS_NULL_IF_NOT_EXISTS
-		throw IOException("Cannot open database \"%s\" in read-only mode: database does not exist, or cannot be opened by already registered filesystems.", path);
+		throw IOException("Cannot open database \"%s\" in read-only mode: database does not exist, or cannot be opened "
+						  "by already registered filesystems.",
+                          path);
 	}
 
 	MainHeader::CheckMagicBytes(*handle);

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -261,7 +261,7 @@ void SingleFileBlockManager::LoadExistingDatabase() {
 	handle = fs.OpenFile(path, flags);
 	if (!handle) {
 		// this can only happen in read-only mode - as that is when we set FILE_FLAGS_NULL_IF_NOT_EXISTS
-		throw IOException("Cannot open database \"%s\" in read-only mode: database does not exist", path);
+		throw IOException("Cannot open database \"%s\" in read-only mode: database does not exist, or cannot be opened by already registered filesystems.", path);
 	}
 
 	MainHeader::CheckMagicBytes(*handle);


### PR DESCRIPTION
Issue details see https://github.com/duckdb/duckdb/issues/17177

I think the reason why duckdb checks extension load situation is better error message: we want to let users know missing extension is (or say, could be) the reason of a failed attach operation.

So in this PR, I did two things:
- I remove the **known extension** load status check, which is useless (and somewhat unfair :( )to community extensions;
- I updated the error message for a failed db attachment, so users could still understand and be prompted potential extension load issue.