### PR TITLE
Fix #17170: sort selection result in OR expression

### DIFF
--- a/src/common/types/selection_vector.cpp
+++ b/src/common/types/selection_vector.cpp
@@ -28,6 +28,10 @@ string SelectionVector::ToString(idx_t count) const {
 	return result;
 }
 
+void SelectionVector::Sort(idx_t count) {
+	std::sort(sel_vector, sel_vector + count);
+}
+
 void SelectionVector::Print(idx_t count) const {
 	Printer::Print(ToString(count));
 }

--- a/src/execution/expression_executor/execute_conjunction.cpp
+++ b/src/execution/expression_executor/execute_conjunction.cpp
@@ -131,7 +131,7 @@ idx_t ExpressionExecutor::Select(const BoundConjunctionExpression &expr, Express
 			}
 		}
 		if (true_sel) {
-			true_sel->sort(result_count);
+			true_sel->Sort(result_count);
 		}
 
 		// adapt runtime statistics

--- a/src/execution/expression_executor/execute_conjunction.cpp
+++ b/src/execution/expression_executor/execute_conjunction.cpp
@@ -130,6 +130,9 @@ idx_t ExpressionExecutor::Select(const BoundConjunctionExpression &expr, Express
 				current_sel = false_sel;
 			}
 		}
+		if (true_sel) {
+			true_sel->sort(result_count);
+		}
 
 		// adapt runtime statistics
 		state.adaptive_filter->EndFilter(filter_state);

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -95,9 +95,6 @@ public:
 	inline idx_t get_index(idx_t idx) const { // NOLINT: allow casing for legacy reasons
 		return sel_vector ? sel_vector[idx] : idx;
 	}
-	void sort(idx_t count) {
-		std::sort(sel_vector, sel_vector + count);
-	}
 	sel_t *data() { // NOLINT: allow casing for legacy reasons
 		return sel_vector;
 	}
@@ -119,6 +116,7 @@ public:
 		return sel_vector;
 	}
 	void Verify(idx_t count, idx_t vector_size) const;
+	void Sort(idx_t count);
 
 private:
 	sel_t *sel_vector;

--- a/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/include/duckdb/common/types/selection_vector.hpp
@@ -95,6 +95,9 @@ public:
 	inline idx_t get_index(idx_t idx) const { // NOLINT: allow casing for legacy reasons
 		return sel_vector ? sel_vector[idx] : idx;
 	}
+	void sort(idx_t count) {
+		std::sort(sel_vector, sel_vector + count);
+	}
 	sel_t *data() { // NOLINT: allow casing for legacy reasons
 		return sel_vector;
 	}

--- a/test/sql/conjunction/or_comparison.test
+++ b/test/sql/conjunction/or_comparison.test
@@ -48,3 +48,9 @@ SELECT pk FROM tab0 WHERE col0 < 84 OR col0 < 8 ;
 5
 7
 8
+
+query I
+select pk from tab0 where col0 = 37 or col0 = 86
+----
+0
+1


### PR DESCRIPTION
This pr try to fix #17170 , sort selection when execute CONJUNCTION_OR