### PR TITLE
Enhance LineNoise Word Deletion to Be Quote-Sensitive

### DIFF
--- a/tools/shell/linenoise/include/linenoise.hpp
+++ b/tools/shell/linenoise/include/linenoise.hpp
@@ -129,6 +129,7 @@ public:
 	static bool IsWordBoundary(char c);
 	static bool AllWhitespace(const char *z);
 	static bool IsSpace(char c);
+	static bool IsQuote(char c);
 
 	TabCompletion TabComplete() const;
 

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -688,7 +688,6 @@ void Linenoise::EditDeletePrevWord() {
 	while (pos > 0 && IsSpace(buf[pos - 1])) {
 		pos--;
 	}
-	//
 	while (pos > 0 && !IsSpace(buf[pos - 1]) && IsQuote(buf[pos - 1])) {
 		pos--;
 	}

--- a/tools/shell/linenoise/linenoise.cpp
+++ b/tools/shell/linenoise/linenoise.cpp
@@ -669,6 +669,16 @@ bool Linenoise::IsSpace(char c) {
 	}
 }
 
+bool Linenoise::IsQuote(char c) {
+	switch (c) {
+	case '\'':
+	case '"':
+		return true;
+	default:
+		return false;
+	}
+}
+
 /* Delete the previous word, maintaining the cursor at the start of the
  * current word. */
 void Linenoise::EditDeletePrevWord() {
@@ -678,7 +688,8 @@ void Linenoise::EditDeletePrevWord() {
 	while (pos > 0 && IsSpace(buf[pos - 1])) {
 		pos--;
 	}
-	while (pos > 0 && !IsSpace(buf[pos - 1])) {
+	//
+	while (pos > 0 && !IsSpace(buf[pos - 1]) && IsQuote(buf[pos - 1])) {
 		pos--;
 	}
 	diff = old_pos - pos;
@@ -695,7 +706,7 @@ void Linenoise::EditDeleteNextWord() {
 	while (next_pos < len && IsSpace(buf[next_pos])) {
 		next_pos++;
 	}
-	while (next_pos < len && !IsSpace(buf[next_pos])) {
+	while (next_pos < len && !IsSpace(buf[next_pos]) && IsQuote(buf[pos - 1])) {
 		next_pos++;
 	}
 	diff = next_pos - pos;


### PR DESCRIPTION
When using CLI tools with the classic readline library (psql, zsh, etc.),  
`Ctrl+W` `Alt+D` deletes text up to special characters (`/`, `_` , `-`, `'`, `"` , etc.), not just spaces. 

Currently, DuckDB's LineNoise implementation only recognizes spaces when deleting words. but i think Improve the `deletePreWord` and `deleteNextWord` functions to recognize additional delimiter characters (including quotes), creating a more intuitive editing experience.

With this change, when positioned at the end of quote: 

```sql 
FROM 's3://really long uuuuuuuuuuuuuurrrrrrrrrrrrrrrrrrrrlllllllllllllllllllllll/foo.parquet'
```
Pressing Ctrl+W would delete the entire URL string in one action (currently requires two: one for Ctrl+W followed by a quote keystroke), then allow replacing it with another S3 URL. 



![output](https://github.com/user-attachments/assets/774ca56c-6742-480f-a6cc-8ee9a6a1392d)


