### PR TITLE
Add bind_operator callback to TableFunction - allowing table functions to directly emit a LogicalOperator

### DIFF
--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -19,7 +19,7 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
 		op.file_path = fs.JoinPath(path, "tmp_" + base);
 	}
 	if (op.per_thread_output || op.file_size_bytes.IsValid() || op.rotate || op.partition_output ||
-	    !op.partition_columns.empty() || op.overwrite_mode != CopyOverwriteMode::COPY_ERROR_ON_CONFLICT) {
+	    !op.partition_columns.empty()) {
 		// hive-partitioning/per-thread output does not care about insertion order, and does not support batch indexes
 		preserve_insertion_order = false;
 		supports_batch_index = false;

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -18,13 +18,14 @@ TableFunction::TableFunction(string name, vector<LogicalType> arguments, table_f
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
     : SimpleNamedParameterFunction(std::move(name), std::move(arguments)), bind(bind), bind_replace(nullptr),
-      init_global(init_global), init_local(init_local), function(function), in_out_function(nullptr),
-      in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr), cardinality(nullptr),
-      pushdown_complex_filter(nullptr), to_string(nullptr), dynamic_to_string(nullptr), table_scan_progress(nullptr),
-      get_partition_data(nullptr), get_bind_info(nullptr), type_pushdown(nullptr), get_multi_file_reader(nullptr),
-      supports_pushdown_type(nullptr), get_partition_info(nullptr), get_partition_stats(nullptr),
-      get_virtual_columns(nullptr), serialize(nullptr), deserialize(nullptr), projection_pushdown(false),
-      filter_pushdown(false), filter_prune(false), sampling_pushdown(false), late_materialization(false) {
+      bind_operator(nullptr), init_global(init_global), init_local(init_local), function(function),
+      in_out_function(nullptr), in_out_function_final(nullptr), statistics(nullptr), dependency(nullptr),
+      cardinality(nullptr), pushdown_complex_filter(nullptr), to_string(nullptr), dynamic_to_string(nullptr),
+      table_scan_progress(nullptr), get_partition_data(nullptr), get_bind_info(nullptr), type_pushdown(nullptr),
+      get_multi_file_reader(nullptr), supports_pushdown_type(nullptr), get_partition_info(nullptr),
+      get_partition_stats(nullptr), get_virtual_columns(nullptr), serialize(nullptr), deserialize(nullptr),
+      projection_pushdown(false), filter_pushdown(false), filter_prune(false), sampling_pushdown(false),
+      late_materialization(false) {
 }
 
 TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function,
@@ -32,15 +33,7 @@ TableFunction::TableFunction(const vector<LogicalType> &arguments, table_functio
                              table_function_init_local_t init_local)
     : TableFunction(string(), arguments, function, bind, init_global, init_local) {
 }
-TableFunction::TableFunction()
-    : SimpleNamedParameterFunction("", {}), bind(nullptr), bind_replace(nullptr), init_global(nullptr),
-      init_local(nullptr), function(nullptr), in_out_function(nullptr), statistics(nullptr), dependency(nullptr),
-      cardinality(nullptr), pushdown_complex_filter(nullptr), to_string(nullptr), dynamic_to_string(nullptr),
-      table_scan_progress(nullptr), get_partition_data(nullptr), get_bind_info(nullptr), type_pushdown(nullptr),
-      get_multi_file_reader(nullptr), supports_pushdown_type(nullptr), get_partition_info(nullptr),
-      get_partition_stats(nullptr), get_virtual_columns(nullptr), serialize(nullptr), deserialize(nullptr),
-      projection_pushdown(false), filter_pushdown(false), filter_prune(false), sampling_pushdown(false),
-      late_materialization(false) {
+TableFunction::TableFunction() : TableFunction("", {}, nullptr, nullptr, nullptr, nullptr) {
 }
 
 bool TableFunction::Equal(const TableFunction &rhs) const {

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -266,6 +266,9 @@ public:
 typedef unique_ptr<FunctionData> (*table_function_bind_t)(ClientContext &context, TableFunctionBindInput &input,
                                                           vector<LogicalType> &return_types, vector<string> &names);
 typedef unique_ptr<TableRef> (*table_function_bind_replace_t)(ClientContext &context, TableFunctionBindInput &input);
+typedef unique_ptr<LogicalOperator> (*table_function_bind_operator_t)(ClientContext &context,
+                                                                      TableFunctionBindInput &input, idx_t bind_index,
+                                                                      vector<string> &return_names);
 typedef unique_ptr<GlobalTableFunctionState> (*table_function_init_global_t)(ClientContext &context,
                                                                              TableFunctionInitInput &input);
 typedef unique_ptr<LocalTableFunctionState> (*table_function_init_local_t)(ExecutionContext &context,
@@ -337,6 +340,10 @@ public:
 	//! to generate a logical plan that replaces the LogicalGet of a regularly bound TableFunction. The BindReplace can
 	//! also return a nullptr to indicate a regular bind needs to be performed instead.
 	table_function_bind_replace_t bind_replace;
+	//! (Optional) Bind operator function
+	//! This function is called before the regular bind function - similar to bind_replace - but allows returning a
+	//! custom LogicalOperator instead.
+	table_function_bind_operator_t bind_operator;
 	//! (Optional) global init function
 	//! Initialize the global operator state of the function.
 	//! The global operator state is used to keep track of the progress in the table function and is shared between

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -233,6 +233,8 @@ public:
 	static string ReplaceColumnsAlias(const string &alias, const string &column_name,
 	                                  optional_ptr<duckdb_re2::RE2> regex);
 
+	unique_ptr<LogicalOperator> UnionOperators(vector<unique_ptr<LogicalOperator>> nodes);
+
 private:
 	//! The parent binder (if any)
 	shared_ptr<Binder> parent;
@@ -448,8 +450,6 @@ private:
 	unique_ptr<BoundTableRef> BindShowQuery(ShowRef &ref);
 	unique_ptr<BoundTableRef> BindShowTable(ShowRef &ref);
 	unique_ptr<BoundTableRef> BindSummarize(ShowRef &ref);
-
-	unique_ptr<LogicalOperator> UnionOperators(vector<unique_ptr<LogicalOperator>> nodes);
 
 private:
 	Binder(ClientContext &context, shared_ptr<Binder> parent, BinderType binder_type);

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -303,18 +303,10 @@ void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
 		everything_referenced = true;
 		break;
 	}
-	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE: {
-		everything_referenced = true;
-		break;
-	}
-	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE: {
-		everything_referenced = true;
-		break;
-	}
-	case LogicalOperatorType::LOGICAL_CTE_REF: {
-		everything_referenced = true;
-		break;
-	}
+	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE:
+	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
+	case LogicalOperatorType::LOGICAL_CTE_REF:
+	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:
 	case LogicalOperatorType::LOGICAL_PIVOT: {
 		everything_referenced = true;
 		break;

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -53,7 +53,7 @@ static TableFunctionBindType GetTableFunctionBindType(TableFunctionCatalogEntry 
 		}
 		if (function.in_out_function) {
 			has_in_out_function = true;
-		} else if (function.function || function.bind_replace) {
+		} else if (function.function || function.bind_replace || function.bind_operator) {
 			has_standard_table_function = true;
 		} else {
 			throw InternalException("Function \"%s\" has neither in_out_function nor function defined",
@@ -197,9 +197,28 @@ unique_ptr<LogicalOperator> Binder::BindTableFunctionInternal(TableFunction &tab
 	unique_ptr<FunctionData> bind_data;
 	vector<LogicalType> return_types;
 	vector<string> return_names;
-	if (table_function.bind || table_function.bind_replace) {
+	if (table_function.bind || table_function.bind_replace || table_function.bind_operator) {
 		TableFunctionBindInput bind_input(parameters, named_parameters, input_table_types, input_table_names,
 		                                  table_function.function_info.get(), this, table_function, ref);
+		if (table_function.bind_operator) {
+			auto new_plan = table_function.bind_operator(context, bind_input, bind_index, return_names);
+			if (new_plan) {
+				new_plan->ResolveOperatorTypes();
+				if (new_plan->types.size() != return_names.size()) {
+					throw InternalException("Failed to bind \"%s\": return_types/names must have same size",
+					                        table_function.name);
+				}
+				for (auto &binding : new_plan->GetColumnBindings()) {
+					if (binding.table_index != bind_index) {
+						throw InternalException(
+						    "Failed to bind \"%s\": root bind index must be the passed in bind index",
+						    table_function.name);
+					}
+				}
+				bind_context.AddGenericBinding(bind_index, function_name, return_names, new_plan->types);
+				return new_plan;
+			}
+		}
 		if (table_function.bind_replace) {
 			auto new_plan = table_function.bind_replace(context, bind_input);
 			if (new_plan) {
@@ -210,10 +229,11 @@ unique_ptr<LogicalOperator> Binder::BindTableFunctionInternal(TableFunction &tab
 					new_plan->column_name_alias = ref.column_name_alias;
 				}
 				return CreatePlan(*Bind(*new_plan));
-			} else if (!table_function.bind) {
-				throw BinderException("Failed to bind \"%s\": nullptr returned from bind_replace without bind function",
-				                      table_function.name);
 			}
+		}
+		if (!table_function.bind) {
+			throw BinderException("Failed to bind \"%s\": nullptr returned from bind_replace without bind function",
+			                      table_function.name);
 		}
 		bind_data = table_function.bind(context, bind_input, return_types, return_names);
 	} else {


### PR DESCRIPTION
This PR adds a new callback to table functions - `bind_operator`:

```cpp
typedef unique_ptr<LogicalOperator> (*table_function_bind_operator_t)(ClientContext &context, TableFunctionBindInput &input, idx_t bind_index, vector<string> &return_names);
```

This function is similar to `bind_replace` - but instead of returning a new plan (that must be bound again) - the function can return an already bound plan directly using this callback.