### PR TITLE
Add support for an explicit PRESERVE_ORDER flag for copy to file

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -46,6 +46,7 @@
 #include "duckdb/common/enums/pending_execution_result.hpp"
 #include "duckdb/common/enums/physical_operator_type.hpp"
 #include "duckdb/common/enums/prepared_statement_mode.hpp"
+#include "duckdb/common/enums/preserve_order.hpp"
 #include "duckdb/common/enums/profiler_format.hpp"
 #include "duckdb/common/enums/quantile_enum.hpp"
 #include "duckdb/common/enums/relation_type.hpp"
@@ -3118,6 +3119,25 @@ const char* EnumUtil::ToChars<PreparedStatementMode>(PreparedStatementMode value
 template<>
 PreparedStatementMode EnumUtil::FromString<PreparedStatementMode>(const char *value) {
 	return static_cast<PreparedStatementMode>(StringUtil::StringToEnum(GetPreparedStatementModeValues(), 2, "PreparedStatementMode", value));
+}
+
+const StringUtil::EnumStringLiteral *GetPreserveOrderTypeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(PreserveOrderType::AUTOMATIC), "AUTOMATIC" },
+		{ static_cast<uint32_t>(PreserveOrderType::PRESERVE_ORDER), "PRESERVE_ORDER" },
+		{ static_cast<uint32_t>(PreserveOrderType::DONT_PRESERVE_ORDER), "DONT_PRESERVE_ORDER" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<PreserveOrderType>(PreserveOrderType value) {
+	return StringUtil::EnumToString(GetPreserveOrderTypeValues(), 3, "PreserveOrderType", static_cast<uint32_t>(value));
+}
+
+template<>
+PreserveOrderType EnumUtil::FromString<PreserveOrderType>(const char *value) {
+	return static_cast<PreserveOrderType>(StringUtil::StringToEnum(GetPreserveOrderTypeValues(), 3, "PreserveOrderType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetProfilerPrintFormatValues() {

--- a/src/execution/physical_plan/plan_copy_to_file.cpp
+++ b/src/execution/physical_plan/plan_copy_to_file.cpp
@@ -10,6 +10,12 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
 	bool preserve_insertion_order = PhysicalPlanGenerator::PreserveInsertionOrder(context, plan);
 	bool supports_batch_index = PhysicalPlanGenerator::UseBatchIndex(context, plan);
 
+	if (op.preserve_order == PreserveOrderType::PRESERVE_ORDER) {
+		preserve_insertion_order = true;
+	} else if (op.preserve_order == PreserveOrderType::DONT_PRESERVE_ORDER) {
+		preserve_insertion_order = false;
+	}
+
 	auto &fs = FileSystem::GetFileSystem(context);
 	op.file_path = fs.ExpandPath(op.file_path);
 
@@ -20,6 +26,9 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
 	}
 	if (op.per_thread_output || op.file_size_bytes.IsValid() || op.rotate || op.partition_output ||
 	    !op.partition_columns.empty() || op.overwrite_mode != CopyOverwriteMode::COPY_ERROR_ON_CONFLICT) {
+		if (op.preserve_order == PreserveOrderType::PRESERVE_ORDER) {
+			throw InvalidInputException("PRESERVE_ORDER is not supported with these parameters");
+		}
 		// hive-partitioning/per-thread output does not care about insertion order, and does not support batch indexes
 		preserve_insertion_order = false;
 		supports_batch_index = false;

--- a/src/execution/physical_plan/plan_insert.cpp
+++ b/src/execution/physical_plan/plan_insert.cpp
@@ -56,7 +56,6 @@ bool PhysicalPlanGenerator::PreserveInsertionOrder(PhysicalOperator &plan) {
 }
 
 bool PhysicalPlanGenerator::UseBatchIndex(ClientContext &context, PhysicalOperator &plan) {
-	// TODO: always preserve order if query contains ORDER BY
 	auto &scheduler = TaskScheduler::GetScheduler(context);
 	if (scheduler.NumberOfThreads() == 1) {
 		// batch index usage only makes sense if we are using multiple threads

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -282,6 +282,8 @@ enum class PreparedParamType : uint8_t;
 
 enum class PreparedStatementMode : uint8_t;
 
+enum class PreserveOrderType : uint8_t;
+
 enum class ProfilerPrintFormat : uint8_t;
 
 enum class QuantileSerializationType : uint8_t;
@@ -775,6 +777,9 @@ const char* EnumUtil::ToChars<PreparedParamType>(PreparedParamType value);
 
 template<>
 const char* EnumUtil::ToChars<PreparedStatementMode>(PreparedStatementMode value);
+
+template<>
+const char* EnumUtil::ToChars<PreserveOrderType>(PreserveOrderType value);
 
 template<>
 const char* EnumUtil::ToChars<ProfilerPrintFormat>(ProfilerPrintFormat value);
@@ -1328,6 +1333,9 @@ PreparedParamType EnumUtil::FromString<PreparedParamType>(const char *value);
 
 template<>
 PreparedStatementMode EnumUtil::FromString<PreparedStatementMode>(const char *value);
+
+template<>
+PreserveOrderType EnumUtil::FromString<PreserveOrderType>(const char *value);
 
 template<>
 ProfilerPrintFormat EnumUtil::FromString<ProfilerPrintFormat>(const char *value);

--- a/src/include/duckdb/common/enums/preserve_order.hpp
+++ b/src/include/duckdb/common/enums/preserve_order.hpp
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/enums/preserve_order.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+enum class PreserveOrderType : uint8_t { AUTOMATIC = 0, PRESERVE_ORDER = 1, DONT_PRESERVE_ORDER = 2 };
+
+} // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
+++ b/src/include/duckdb/planner/operator/logical_copy_to_file.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/common/enums/preserve_order.hpp"
 
 namespace duckdb {
 
@@ -43,6 +44,7 @@ public:
 	bool partition_output;
 	bool write_partition_columns;
 	bool write_empty_file = true;
+	PreserveOrderType preserve_order = PreserveOrderType::AUTOMATIC;
 	vector<idx_t> partition_columns;
 	vector<string> names;
 	vector<LogicalType> expected_types;

--- a/src/planner/binder/statement/bind_copy.cpp
+++ b/src/planner/binder/statement/bind_copy.cpp
@@ -57,6 +57,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) 
 	bool seen_filepattern = false;
 	bool write_partition_columns = false;
 	bool write_empty_file = true;
+	PreserveOrderType preserve_order = PreserveOrderType::AUTOMATIC;
 	CopyFunctionReturnType return_type = CopyFunctionReturnType::CHANGED_ROWS;
 
 	CopyFunctionBindInput bind_input(*stmt.info);
@@ -121,6 +122,12 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) 
 		} else if (loption == "return_files") {
 			if (GetBooleanArg(context, option.second)) {
 				return_type = CopyFunctionReturnType::CHANGED_ROWS_AND_FILE_LIST;
+			}
+		} else if (loption == "preserve_order") {
+			if (GetBooleanArg(context, option.second)) {
+				preserve_order = PreserveOrderType::PRESERVE_ORDER;
+			} else {
+				preserve_order = PreserveOrderType::DONT_PRESERVE_ORDER;
 			}
 		} else if (loption == "return_stats") {
 			if (GetBooleanArg(context, option.second)) {
@@ -263,6 +270,7 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, CopyToType copy_to_type) 
 	copy->partition_columns = std::move(partition_cols);
 	copy->write_empty_file = write_empty_file;
 	copy->return_type = return_type;
+	copy->preserve_order = preserve_order;
 
 	copy->names = unique_column_names;
 	copy->expected_types = select_node.types;

--- a/src/planner/operator/logical_copy_to_file.cpp
+++ b/src/planner/operator/logical_copy_to_file.cpp
@@ -67,6 +67,7 @@ void LogicalCopyToFile::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty(215, "return_type", return_type);
 	serializer.WritePropertyWithDefault(216, "write_partition_columns", write_partition_columns, true);
 	serializer.WritePropertyWithDefault(217, "write_empty_file", write_empty_file, true);
+	serializer.WritePropertyWithDefault(218, "preserve_order", preserve_order, PreserveOrderType::AUTOMATIC);
 }
 
 unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(Deserializer &deserializer) {
@@ -112,6 +113,8 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(Deserializer &deseria
 	    deserializer.ReadPropertyWithExplicitDefault(215, "return_type", CopyFunctionReturnType::CHANGED_ROWS);
 	auto write_partition_columns = deserializer.ReadPropertyWithExplicitDefault(216, "write_partition_columns", true);
 	auto write_empty_file = deserializer.ReadPropertyWithExplicitDefault(217, "write_empty_file", true);
+	auto preserve_order =
+	    deserializer.ReadPropertyWithExplicitDefault(218, "preserve_order", PreserveOrderType::AUTOMATIC);
 
 	if (!has_serialize) {
 		// If not serialized, re-bind with the copy info
@@ -140,6 +143,7 @@ unique_ptr<LogicalOperator> LogicalCopyToFile::Deserialize(Deserializer &deseria
 	result->return_type = return_type;
 	result->write_partition_columns = write_partition_columns;
 	result->write_empty_file = write_empty_file;
+	result->preserve_order = preserve_order;
 
 	return std::move(result);
 }

--- a/test/sql/copy/parquet/copy_preserve_order.test_slow
+++ b/test/sql/copy/parquet/copy_preserve_order.test_slow
@@ -1,0 +1,61 @@
+# name: test/sql/copy/parquet/copy_preserve_order.test_slow
+# description: Test order preservation with the PRESERVE_ORDER flag
+# group: [parquet]
+
+require parquet
+
+load __TEST_DIR__/insert_order_preserving.db
+
+# test the PRESERVE_ORDER option
+statement ok
+SET preserve_insertion_order=false
+
+query I
+CREATE TABLE integers AS SELECT * FROM range(10000000) tbl(i);
+----
+10000000
+
+query I
+COPY integers TO '__TEST_DIR__/force_order_preserve.parquet' (PRESERVE_ORDER);
+----
+10000000
+
+statement ok
+CREATE VIEW integers2 AS FROM '__TEST_DIR__/force_order_preserve.parquet'
+
+query I
+SELECT SUM(i) FROM integers
+----
+49999995000000
+
+query I
+SELECT SUM(i) FROM integers2
+----
+49999995000000
+
+# verify the file was written in the correct order - for this we set the preserve_insertion_order back to true
+statement ok
+SET preserve_insertion_order=true
+
+query I
+SELECT * FROM '__TEST_DIR__/force_order_preserve.parquet' LIMIT 5
+----
+0
+1
+2
+3
+4
+
+query I
+SELECT * FROM '__TEST_DIR__/force_order_preserve.parquet' LIMIT 5 OFFSET 777778
+----
+777778
+777779
+777780
+777781
+777782
+
+statement error
+COPY integers TO '__TEST_DIR__/force_order_preserve_2.parquet' (PRESERVE_ORDER, PARTITION_BY (i), WRITE_PARTITION_COLUMNS);
+----
+PRESERVE_ORDER is not supported with these parameters


### PR DESCRIPTION
This flag allows the user to set insertion-order preservation regardless of the global setting.

For example:

```sql
SET preserve_insertion_order=false;
-- file will be written as if preserve_insertion_order = true
COPY tbl TO 'force_order_preserve.parquet' (PRESERVE_ORDER);


SET preserve_insertion_order=true;
-- file will be written as if preserve_insertion_order = false
COPY tbl TO 'force_order_preserve.parquet' (PRESERVE_ORDER FALSE);
```