### PR TITLE
Add `ExternalFileCache` validation as option for `ExtendedOpenFileInfo`

### DIFF
--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -79,6 +79,8 @@ private:
 	OpenFileInfo path;
 	//! Flags used to open the file
 	FileOpenFlags flags;
+	//! Whether to validate the cache entry
+	bool validate;
 	//! The associated CachedFile with cached ranges
 	CachedFile &cached_file;
 
@@ -113,8 +115,6 @@ private:
 	FileSystem &file_system;
 	//! The External File Cache that caches the files
 	ExternalFileCache &external_file_cache;
-	//! Whether to validate cache entries
-	bool validate;
 };
 
 } // namespace duckdb

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -11,8 +11,7 @@
 namespace duckdb {
 
 CachingFileSystem::CachingFileSystem(FileSystem &file_system_p, DatabaseInstance &db)
-    : file_system(file_system_p), external_file_cache(ExternalFileCache::Get(db)), validate(true) {
-	// TODO: "validate" defaults to true (for now)
+    : file_system(file_system_p), external_file_cache(ExternalFileCache::Get(db)) {
 }
 
 CachingFileSystem::~CachingFileSystem() {
@@ -29,8 +28,13 @@ unique_ptr<CachingFileHandle> CachingFileSystem::OpenFile(const OpenFileInfo &pa
 CachingFileHandle::CachingFileHandle(CachingFileSystem &caching_file_system_p, const OpenFileInfo &path_p,
                                      FileOpenFlags flags_p, CachedFile &cached_file_p)
     : caching_file_system(caching_file_system_p), external_file_cache(caching_file_system.external_file_cache),
-      path(path_p), flags(flags_p), cached_file(cached_file_p), position(0) {
-	if (!external_file_cache.IsEnabled() || caching_file_system.validate) {
+      path(path_p), flags(flags_p), validate(true), cached_file(cached_file_p), position(0) {
+	auto &open_options = path.extended_info->options;
+	const auto validate_entry = open_options.find("validate_external_file_cache");
+	if (validate_entry != open_options.end()) {
+		validate = BooleanValue::Get(validate_entry->second);
+	}
+	if (!external_file_cache.IsEnabled() || validate) {
 		// If caching is disabled, or if we must validate cache entries, we always have to open the file
 		GetFileHandle();
 		return;
@@ -54,7 +58,7 @@ FileHandle &CachingFileHandle::GetFileHandle() {
 		version_tag = caching_file_system.file_system.GetVersionTag(*file_handle);
 
 		auto guard = cached_file.lock.GetExclusiveLock();
-		if (!cached_file.IsValid(guard, caching_file_system.validate, version_tag, last_modified, current_time)) {
+		if (!cached_file.IsValid(guard, validate, version_tag, last_modified, current_time)) {
 			cached_file.Ranges(guard).clear(); // Invalidate entire cache
 		}
 		cached_file.FileSize(guard) = file_handle->GetFileSize();
@@ -143,7 +147,7 @@ string CachingFileHandle::GetPath() const {
 }
 
 idx_t CachingFileHandle::GetFileSize() {
-	if (file_handle || caching_file_system.validate) {
+	if (file_handle || validate) {
 		return GetFileHandle().GetFileSize();
 	}
 	auto guard = cached_file.lock.GetSharedLock();
@@ -151,7 +155,7 @@ idx_t CachingFileHandle::GetFileSize() {
 }
 
 time_t CachingFileHandle::GetLastModifiedTime() {
-	if (file_handle || caching_file_system.validate) {
+	if (file_handle || validate) {
 		GetFileHandle();
 		return last_modified;
 	}
@@ -160,7 +164,7 @@ time_t CachingFileHandle::GetLastModifiedTime() {
 }
 
 bool CachingFileHandle::CanSeek() {
-	if (file_handle || caching_file_system.validate) {
+	if (file_handle || validate) {
 		return GetFileHandle().CanSeek();
 	}
 	auto guard = cached_file.lock.GetSharedLock();
@@ -172,7 +176,7 @@ bool CachingFileHandle::IsRemoteFile() const {
 }
 
 bool CachingFileHandle::OnDiskFile() {
-	if (file_handle || caching_file_system.validate) {
+	if (file_handle || validate) {
 		return GetFileHandle().OnDiskFile();
 	}
 	auto guard = cached_file.lock.GetSharedLock();
@@ -180,7 +184,7 @@ bool CachingFileHandle::OnDiskFile() {
 }
 
 const string &CachingFileHandle::GetVersionTag(const unique_ptr<StorageLockKey> &guard) {
-	if (file_handle || caching_file_system.validate) {
+	if (file_handle || validate) {
 		GetFileHandle();
 		return version_tag;
 	}

--- a/src/storage/caching_file_system.cpp
+++ b/src/storage/caching_file_system.cpp
@@ -29,10 +29,12 @@ CachingFileHandle::CachingFileHandle(CachingFileSystem &caching_file_system_p, c
                                      FileOpenFlags flags_p, CachedFile &cached_file_p)
     : caching_file_system(caching_file_system_p), external_file_cache(caching_file_system.external_file_cache),
       path(path_p), flags(flags_p), validate(true), cached_file(cached_file_p), position(0) {
-	auto &open_options = path.extended_info->options;
-	const auto validate_entry = open_options.find("validate_external_file_cache");
-	if (validate_entry != open_options.end()) {
-		validate = BooleanValue::Get(validate_entry->second);
+	if (path.extended_info) {
+		const auto &open_options = path.extended_info->options;
+		const auto validate_entry = open_options.find("validate_external_file_cache");
+		if (validate_entry != open_options.end()) {
+			validate = BooleanValue::Get(validate_entry->second);
+		}
 	}
 	if (!external_file_cache.IsEnabled() || validate) {
 		// If caching is disabled, or if we must validate cache entries, we always have to open the file


### PR DESCRIPTION
This PR adds functionality to bypass the built-in cache validation for `ExternalFileCache` by adding the key `"validate_external_file_cache"` with value `false`, to the `ExtendedOpenFileInfo` of `OpenFileInfo`. This is not exposed to users, so it can only be used internally. This avoids doing a `HEAD` request for files that have been queried before.

The Iceberg/Delta extensions should be able to set this to `false` safely.  cc @Tmonster 