### PR TITLE
Change Invalid Unicode Error to Invalid Encoding

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -435,7 +435,7 @@ void StringValueResult::AddValueToVector(const char *value_ptr, const idx_t size
 				HandleUnicodeError(cur_col_id, last_position);
 			}
 			// If we got here, we are ignoring errors, hence we must ignore this line.
-			current_errors.Insert(INVALID_UNICODE, cur_col_id, chunk_col_id, last_position);
+			current_errors.Insert(INVALID_ENCODING, cur_col_id, chunk_col_id, last_position);
 			static_cast<string_t *>(vector_ptr[chunk_col_id])[number_of_rows] = StringVector::AddStringOrBlob(
 			    parse_chunk.data[chunk_col_id], string_t(value_ptr, UnsafeNumericCast<uint32_t>(0)));
 			break;
@@ -627,7 +627,7 @@ void StringValueResult::HandleUnicodeError(idx_t col_idx, LinePosition &error_po
 bool LineError::HandleErrors(StringValueResult &result) {
 	bool skip_sniffing = false;
 	for (auto &cur_error : current_errors) {
-		if (cur_error.type == CSVErrorType::INVALID_UNICODE) {
+		if (cur_error.type == CSVErrorType::INVALID_ENCODING) {
 			skip_sniffing = true;
 		}
 	}
@@ -663,7 +663,7 @@ bool LineError::HandleErrors(StringValueResult &result) {
 				    line_pos.GetGlobalPosition(result.requested_size), result.path);
 			}
 			break;
-		case INVALID_UNICODE: {
+		case INVALID_ENCODING: {
 			if (result.current_line_position.begin == line_pos) {
 				csv_error = CSVError::InvalidUTF8(
 				    result.state_machine.options, col_idx, lines_per_batch, borked_line,

--- a/src/execution/operator/csv_scanner/util/csv_error.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_error.cpp
@@ -155,7 +155,7 @@ bool IsCSVErrorAcceptedReject(CSVErrorType type) {
 	case CSVErrorType::TOO_FEW_COLUMNS:
 	case CSVErrorType::MAXIMUM_LINE_SIZE:
 	case CSVErrorType::UNTERMINATED_QUOTES:
-	case CSVErrorType::INVALID_UNICODE:
+	case CSVErrorType::INVALID_ENCODING:
 		return true;
 	default:
 		return false;
@@ -173,8 +173,8 @@ string CSVErrorTypeToEnum(CSVErrorType type) {
 		return "LINE SIZE OVER MAXIMUM";
 	case CSVErrorType::UNTERMINATED_QUOTES:
 		return "UNQUOTED VALUE";
-	case CSVErrorType::INVALID_UNICODE:
-		return "INVALID UNICODE";
+	case CSVErrorType::INVALID_ENCODING:
+		return "INVALID ENCODING";
 	case CSVErrorType::INVALID_STATE:
 		return "INVALID STATE";
 	default:
@@ -579,11 +579,14 @@ CSVError CSVError::InvalidUTF8(const CSVReaderOptions &options, idx_t current_co
                                const string &current_path) {
 	std::ostringstream error;
 	// How many columns were expected and how many were found
-	error << "Invalid unicode (byte sequence mismatch) detected." << '\n';
+	error << "Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded." << '\n';
 	std::ostringstream how_to_fix_it;
+	how_to_fix_it
+	    << "Possible Solution: Set the correct encoding, if available, to read this CSV File.(e.g., encoding='UTF-16')"
+	    << '\n';
 	how_to_fix_it << "Possible Solution: Enable ignore errors (ignore_errors=true) to skip this row" << '\n';
-	return CSVError(error.str(), INVALID_UNICODE, current_column, csv_row, error_info, row_byte_position, byte_position,
-	                options, how_to_fix_it.str(), current_path);
+	return CSVError(error.str(), INVALID_ENCODING, current_column, csv_row, error_info, row_byte_position,
+	                byte_position, options, how_to_fix_it.str(), current_path);
 }
 
 bool CSVErrorHandler::PrintLineNumber(const CSVError &error) const {
@@ -597,7 +600,7 @@ bool CSVErrorHandler::PrintLineNumber(const CSVError &error) const {
 	case TOO_MANY_COLUMNS:
 	case MAXIMUM_LINE_SIZE:
 	case NULLPADDED_QUOTED_NEW_VALUE:
-	case INVALID_UNICODE:
+	case INVALID_ENCODING:
 		return true;
 	default:
 		return false;

--- a/src/execution/operator/csv_scanner/util/csv_error.cpp
+++ b/src/execution/operator/csv_scanner/util/csv_error.cpp
@@ -579,10 +579,11 @@ CSVError CSVError::InvalidUTF8(const CSVReaderOptions &options, idx_t current_co
                                const string &current_path) {
 	std::ostringstream error;
 	// How many columns were expected and how many were found
-	error << "Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded." << '\n';
+	error << "Invalid unicode (byte sequence mismatch) detected. This file is not " << options.encoding << " encoded."
+	      << '\n';
 	std::ostringstream how_to_fix_it;
 	how_to_fix_it
-	    << "Possible Solution: Set the correct encoding, if available, to read this CSV File.(e.g., encoding='UTF-16')"
+	    << "Possible Solution: Set the correct encoding, if available, to read this CSV File (e.g., encoding='UTF-16')"
 	    << '\n';
 	how_to_fix_it << "Possible Solution: Enable ignore errors (ignore_errors=true) to skip this row" << '\n';
 	return CSVError(error.str(), INVALID_ENCODING, current_column, csv_row, error_info, row_byte_position,

--- a/src/execution/operator/persistent/csv_rejects_table.cpp
+++ b/src/execution/operator/persistent/csv_rejects_table.cpp
@@ -70,7 +70,7 @@ void CSVRejectsTable::InitializeTable(ClientContext &context, const ReadCSVData 
 	order_errors.SetValue(2, "TOO MANY COLUMNS");
 	order_errors.SetValue(3, "UNQUOTED VALUE");
 	order_errors.SetValue(4, "LINE SIZE OVER MAXIMUM");
-	order_errors.SetValue(5, "INVALID UNICODE");
+	order_errors.SetValue(5, "INVALID ENCODING");
 	order_errors.SetValue(6, "INVALID STATE");
 
 	LogicalType enum_type = LogicalType::ENUM(enum_name, order_errors, number_of_accepted_errors);

--- a/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/csv_error.hpp
@@ -43,7 +43,7 @@ enum CSVErrorType : uint8_t {
 	SNIFFING = 5,          //! If something went wrong during sniffing and was not possible to find suitable candidates
 	MAXIMUM_LINE_SIZE = 6, //! Maximum line size was exceeded by a line in the CSV File
 	NULLPADDED_QUOTED_NEW_VALUE = 7, //! If the null_padding option is set, and we have quoted new values in parallel
-	INVALID_UNICODE = 8,             //! If we have invalid unicode values
+	INVALID_ENCODING = 8,            //! If we have invalid UTF-8 encoded values
 	INVALID_STATE = 9                //! If our CSV Scanner ended up in an invalid state
 };
 

--- a/src/include/duckdb/function/encoding_function.hpp
+++ b/src/include/duckdb/function/encoding_function.hpp
@@ -41,8 +41,9 @@ public:
 		D_ASSERT(bytes_per_iteration > 0);
 		D_ASSERT(lookup_bytes > 0);
 	};
-	EncodingFunction(const string &encode_name, encode_t encode_function, const idx_t bytes_per_iteration,
-	                 const idx_t lookup_bytes, const uintptr_t map, const size_t map_size)
+
+	DUCKDB_API EncodingFunction(const string &encode_name, encode_t encode_function, const idx_t bytes_per_iteration,
+	                            const idx_t lookup_bytes, const uintptr_t map, const size_t map_size)
 	    : conversion_map(map), map_size(map_size), name(encode_name), encode_function(encode_function),
 	      max_bytes_per_iteration(bytes_per_iteration), lookup_bytes(lookup_bytes) {
 		D_ASSERT(encode_function);

--- a/test/sql/copy/csv/rejects/test_invalid_utf_rejects.test
+++ b/test/sql/copy/csv/rejects/test_invalid_utf_rejects.test
@@ -14,7 +14,7 @@ from read_csv('data/csv/test/invalid_utf_big.csv',columns = {'col1': 'VARCHAR','
 query IIIIIIIII rowsort
 SELECT * EXCLUDE (scan_id) FROM reject_errors ORDER BY ALL;
 ----
-0	3001	54001	54007	2	col2	INVALID UNICODE	valid,invalid_??_part,valid	Invalid unicode (byte sequence mismatch) detected.
-0	3012	54209	54221	3	col3	INVALID UNICODE	valid,valid,invalid_??_part	Invalid unicode (byte sequence mismatch) detected.
-0	3023	54417	54423	2	col2	INVALID UNICODE	valid,invalid_??_part,valid	Invalid unicode (byte sequence mismatch) detected.
-0	3034	54625	54637	3	col3	INVALID UNICODE	valid,valid,invalid_??_part	Invalid unicode (byte sequence mismatch) detected.
+0	3001	54001	54007	2	col2	INVALID ENCODING	valid,invalid_??_part,valid	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	3012	54209	54221	3	col3	INVALID ENCODING	valid,valid,invalid_??_part	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	3023	54417	54423	2	col2	INVALID ENCODING	valid,invalid_??_part,valid	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	3034	54625	54637	3	col3	INVALID ENCODING	valid,valid,invalid_??_part	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.

--- a/test/sql/copy/csv/rejects/test_invalid_utf_rejects.test
+++ b/test/sql/copy/csv/rejects/test_invalid_utf_rejects.test
@@ -14,7 +14,7 @@ from read_csv('data/csv/test/invalid_utf_big.csv',columns = {'col1': 'VARCHAR','
 query IIIIIIIII rowsort
 SELECT * EXCLUDE (scan_id) FROM reject_errors ORDER BY ALL;
 ----
-0	3001	54001	54007	2	col2	INVALID ENCODING	valid,invalid_??_part,valid	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
-0	3012	54209	54221	3	col3	INVALID ENCODING	valid,valid,invalid_??_part	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
-0	3023	54417	54423	2	col2	INVALID ENCODING	valid,invalid_??_part,valid	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
-0	3034	54625	54637	3	col3	INVALID ENCODING	valid,valid,invalid_??_part	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	3001	54001	54007	2	col2	INVALID ENCODING	valid,invalid_??_part,valid	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
+0	3012	54209	54221	3	col3	INVALID ENCODING	valid,valid,invalid_??_part	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
+0	3023	54417	54423	2	col2	INVALID ENCODING	valid,invalid_??_part,valid	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
+0	3034	54625	54637	3	col3	INVALID ENCODING	valid,valid,invalid_??_part	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.

--- a/test/sql/copy/csv/rejects/test_mixed.test
+++ b/test/sql/copy/csv/rejects/test_mixed.test
@@ -63,4 +63,4 @@ SELECT * EXCLUDE (scan_id) FROM reject_errors ORDER BY ALL;
 0	19	205	207	2	b	CAST	1,bla,"pedro"	Error when converting column "b". Could not convert string "bla" to 'INTEGER'
 0	22	243	247	3	c	UNQUOTED VALUE	1,2,"pedro"bla	Value with unterminated quote found.
 0	32	366	366	NULL	NULL	LINE SIZE OVER MAXIMUM	1,2,"pedro thiago timbo holanda"	Maximum line size of 20 bytes exceeded. Actual Size:32 bytes.
-0	38	459	463	3	c	INVALID ENCODING	1,2,"pedro??"	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	38	459	463	3	c	INVALID ENCODING	1,2,"pedro??"	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.

--- a/test/sql/copy/csv/rejects/test_mixed.test
+++ b/test/sql/copy/csv/rejects/test_mixed.test
@@ -63,4 +63,4 @@ SELECT * EXCLUDE (scan_id) FROM reject_errors ORDER BY ALL;
 0	19	205	207	2	b	CAST	1,bla,"pedro"	Error when converting column "b". Could not convert string "bla" to 'INTEGER'
 0	22	243	247	3	c	UNQUOTED VALUE	1,2,"pedro"bla	Value with unterminated quote found.
 0	32	366	366	NULL	NULL	LINE SIZE OVER MAXIMUM	1,2,"pedro thiago timbo holanda"	Maximum line size of 20 bytes exceeded. Actual Size:32 bytes.
-0	38	459	463	3	c	INVALID UNICODE	1,2,"pedro??"	Invalid unicode (byte sequence mismatch) detected.
+0	38	459	463	3	c	INVALID ENCODING	1,2,"pedro??"	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.

--- a/test/sql/copy/csv/rejects/test_multiple_errors_same_line.test
+++ b/test/sql/copy/csv/rejects/test_multiple_errors_same_line.test
@@ -268,7 +268,7 @@ oogie boogie	3	2023-01-01	2
 query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position;
 ----
-0	3	59	59	1	name	INVALID UNICODE	oogie bo??gie,bla, 2023-01-01, 2	Invalid unicode (byte sequence mismatch) detected.
+0	3	59	59	1	name	INVALID ENCODING	oogie bo??gie,bla, 2023-01-01, 2	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
 0	3	59	73	2	age	CAST	oogie bo??gie,bla, 2023-01-01, 2	Error when converting column "age". Could not convert string "bla" to 'INTEGER'
 
 statement ok
@@ -288,7 +288,7 @@ oogie boogie	3	2023-01-01	2
 query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position;
 ----
-0	3	59	59	1	name	INVALID UNICODE	oogie bo??gie,3, 2023-01-01	Invalid unicode (byte sequence mismatch) detected.
+0	3	59	59	1	name	INVALID ENCODING	oogie bo??gie,3, 2023-01-01	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
 0	3	59	86	3	barks	MISSING COLUMNS	oogie bo??gie,3, 2023-01-01	Expected Number of Columns: 4 Found: 3
 
 statement ok
@@ -309,7 +309,7 @@ query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position, error_message;
 ----
 0	3	59	125	5	NULL	TOO MANY COLUMNS	oogie bo??gieoogie boogieoogie boogieoogie boogie,3, 2023-01-01, 2, 5	Expected Number of Columns: 4 Found: 5
-0	3	59	59	1	name	INVALID UNICODE	oogie bo??gieoogie boogieoogie boogieoogie boogie,3, 2023-01-01, 2, 5	Invalid unicode (byte sequence mismatch) detected.
+0	3	59	59	1	name	INVALID ENCODING	oogie bo??gieoogie boogieoogie boogieoogie boogie,3, 2023-01-01, 2, 5	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
 0	3	59	59	NULL	NULL	LINE SIZE OVER MAXIMUM	oogie bo??gieoogie boogieoogie boogieoogie boogie,3, 2023-01-01, 2, 5	Maximum line size of 40 bytes exceeded. Actual Size:69 bytes.
 
 statement ok
@@ -329,7 +329,7 @@ oogie boogie	3	2023-01-01	2
 query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position;
 ----
-0	3	59	59	1	name	INVALID UNICODE	oogie bo??gie,3, 2023-01-01, 2, 5	Invalid unicode (byte sequence mismatch) detected.
+0	3	59	59	1	name	INVALID ENCODING	oogie bo??gie,3, 2023-01-01, 2, 5	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
 0	3	59	89	5	NULL	TOO MANY COLUMNS	oogie bo??gie,3, 2023-01-01, 2, 5	Expected Number of Columns: 4 Found: 5
 
 statement ok
@@ -350,7 +350,7 @@ query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position;
 ----
 0	3	71	71	1	name	UNQUOTED VALUE	"oogie"bla, bo??gie,3, 2023-01-01, 2	Value with unterminated quote found.
-0	3	71	82	2	last_name	INVALID UNICODE	"oogie"bla, bo??gie,3, 2023-01-01, 2	Invalid unicode (byte sequence mismatch) detected.
+0	3	71	82	2	last_name	INVALID ENCODING	"oogie"bla, bo??gie,3, 2023-01-01, 2	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
 
 statement ok
 DROP TABLE reject_errors;

--- a/test/sql/copy/csv/rejects/test_multiple_errors_same_line.test
+++ b/test/sql/copy/csv/rejects/test_multiple_errors_same_line.test
@@ -268,7 +268,7 @@ oogie boogie	3	2023-01-01	2
 query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position;
 ----
-0	3	59	59	1	name	INVALID ENCODING	oogie bo??gie,bla, 2023-01-01, 2	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	3	59	59	1	name	INVALID ENCODING	oogie bo??gie,bla, 2023-01-01, 2	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
 0	3	59	73	2	age	CAST	oogie bo??gie,bla, 2023-01-01, 2	Error when converting column "age". Could not convert string "bla" to 'INTEGER'
 
 statement ok
@@ -288,7 +288,7 @@ oogie boogie	3	2023-01-01	2
 query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position;
 ----
-0	3	59	59	1	name	INVALID ENCODING	oogie bo??gie,3, 2023-01-01	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	3	59	59	1	name	INVALID ENCODING	oogie bo??gie,3, 2023-01-01	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
 0	3	59	86	3	barks	MISSING COLUMNS	oogie bo??gie,3, 2023-01-01	Expected Number of Columns: 4 Found: 3
 
 statement ok
@@ -309,7 +309,7 @@ query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position, error_message;
 ----
 0	3	59	125	5	NULL	TOO MANY COLUMNS	oogie bo??gieoogie boogieoogie boogieoogie boogie,3, 2023-01-01, 2, 5	Expected Number of Columns: 4 Found: 5
-0	3	59	59	1	name	INVALID ENCODING	oogie bo??gieoogie boogieoogie boogieoogie boogie,3, 2023-01-01, 2, 5	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	3	59	59	1	name	INVALID ENCODING	oogie bo??gieoogie boogieoogie boogieoogie boogie,3, 2023-01-01, 2, 5	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
 0	3	59	59	NULL	NULL	LINE SIZE OVER MAXIMUM	oogie bo??gieoogie boogieoogie boogieoogie boogie,3, 2023-01-01, 2, 5	Maximum line size of 40 bytes exceeded. Actual Size:69 bytes.
 
 statement ok
@@ -329,7 +329,7 @@ oogie boogie	3	2023-01-01	2
 query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position;
 ----
-0	3	59	59	1	name	INVALID ENCODING	oogie bo??gie,3, 2023-01-01, 2, 5	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	3	59	59	1	name	INVALID ENCODING	oogie bo??gie,3, 2023-01-01, 2, 5	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
 0	3	59	89	5	NULL	TOO MANY COLUMNS	oogie bo??gie,3, 2023-01-01, 2, 5	Expected Number of Columns: 4 Found: 5
 
 statement ok
@@ -350,7 +350,7 @@ query IIIIIIIII rowsort
 SElECT * EXCLUDE (scan_id)  FROM reject_errors ORDER BY byte_position;
 ----
 0	3	71	71	1	name	UNQUOTED VALUE	"oogie"bla, bo??gie,3, 2023-01-01, 2	Value with unterminated quote found.
-0	3	71	82	2	last_name	INVALID ENCODING	"oogie"bla, bo??gie,3, 2023-01-01, 2	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	3	71	82	2	last_name	INVALID ENCODING	"oogie"bla, bo??gie,3, 2023-01-01, 2	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
 
 statement ok
 DROP TABLE reject_errors;

--- a/test/sql/copy/csv/test_non_unicode_header.test
+++ b/test/sql/copy/csv/test_non_unicode_header.test
@@ -24,8 +24,8 @@ endloop
 query IIIIIIIII
 select * exclude(scan_id ) from reject_errors order by all limit 5
 ----
-0	1	1	1	1	column0	INVALID UNICODE	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected.
-0	1	1	12	2	column1	INVALID UNICODE	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected.
-0	1	1	18	3	column2	INVALID UNICODE	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected.
+0	1	1	1	1	column0	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	1	1	12	2	column1	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	1	1	18	3	column2	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
 0	1	1	25	4	column3	CAST	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Error when converting column "column3". Could not convert string "Cert?" to 'BIGINT'
-0	1	1	31	5	column4	INVALID UNICODE	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected.
+0	1	1	31	5	column4	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.

--- a/test/sql/copy/csv/test_non_unicode_header.test
+++ b/test/sql/copy/csv/test_non_unicode_header.test
@@ -24,8 +24,8 @@ endloop
 query IIIIIIIII
 select * exclude(scan_id ) from reject_errors order by all limit 5
 ----
-0	1	1	1	1	column0	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
-0	1	1	12	2	column1	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
-0	1	1	18	3	column2	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	1	1	1	1	column0	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
+0	1	1	12	2	column1	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
+0	1	1	18	3	column2	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.
 0	1	1	25	4	column3	CAST	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Error when converting column "column3". Could not convert string "Cert?" to 'BIGINT'
-0	1	1	31	5	column4	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not UTF-8 encoded.
+0	1	1	31	5	column4	INVALID ENCODING	Bank Name?,City?,State?,Cert?,Acquiring Institution?,Closing Date?,Fund	Invalid unicode (byte sequence mismatch) detected. This file is not utf-8 encoded.


### PR DESCRIPTION
Also adds:
`Possible Solution: Set the correct encoding, if available, to read this CSV File.(e.g., encoding='UTF-16')` as a possible fix to this type of error.

Fix: https://github.com/duckdblabs/duckdb-internal/issues/4700