### PR TITLE
Add support for the cast_to_type function, that allows generating a cast from an expression to the type of another column

### DIFF
--- a/extension/core_functions/function_list.cpp
+++ b/extension/core_functions/function_list.cpp
@@ -122,6 +122,7 @@ static const StaticFunctionDefinition core_functions[] = {
 	DUCKDB_AGGREGATE_FUNCTION(BoolOrFun),
 	DUCKDB_SCALAR_FUNCTION(CanCastImplicitlyFun),
 	DUCKDB_SCALAR_FUNCTION(CardinalityFun),
+	DUCKDB_SCALAR_FUNCTION(CastToTypeFun),
 	DUCKDB_SCALAR_FUNCTION(CbrtFun),
 	DUCKDB_SCALAR_FUNCTION_SET(CeilFun),
 	DUCKDB_SCALAR_FUNCTION_SET_ALIAS(CeilingFun),

--- a/extension/core_functions/include/core_functions/scalar/generic_functions.hpp
+++ b/extension/core_functions/include/core_functions/scalar/generic_functions.hpp
@@ -185,4 +185,14 @@ struct IsHistogramOtherBinFun {
 	static ScalarFunction GetFunction();
 };
 
+struct CastToTypeFun {
+	static constexpr const char *Name = "cast_to_type";
+	static constexpr const char *Parameters = "param,type";
+	static constexpr const char *Description = "Casts the first argument to the type of the second argument";
+	static constexpr const char *Example = "cast_to_type('42', NULL::INTEGER)";
+	static constexpr const char *Categories = "";
+
+	static ScalarFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/extension/core_functions/scalar/generic/CMakeLists.txt
+++ b/extension/core_functions/scalar/generic/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library_unity(
   OBJECT
   alias.cpp
   binning.cpp
+  cast_to_type.cpp
   can_implicitly_cast.cpp
   current_setting.cpp
   hash.cpp

--- a/extension/core_functions/scalar/generic/cast_to_type.cpp
+++ b/extension/core_functions/scalar/generic/cast_to_type.cpp
@@ -1,0 +1,29 @@
+#include "core_functions/scalar/generic_functions.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+
+namespace duckdb {
+
+static void CastToTypeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	throw InternalException("CastToType function cannot be executed directly");
+}
+
+unique_ptr<Expression> BindCastToTypeFunction(FunctionBindExpressionInput &input) {
+	auto &return_type = input.children[1]->return_type;
+	if (return_type.id() == LogicalTypeId::UNKNOWN) {
+		// parameter - unknown return type
+		throw ParameterNotResolvedException();
+	}
+	if (return_type.id() == LogicalTypeId::SQLNULL) {
+		throw InvalidInputException("cast_to_type cannot be used to cast to NULL");
+	}
+	return BoundCastExpression::AddCastToType(input.context, std::move(input.children[0]), return_type);
+}
+
+ScalarFunction CastToTypeFun::GetFunction() {
+	auto fun = ScalarFunction({LogicalType::ANY, LogicalType::ANY}, LogicalType::ANY, CastToTypeFunction);
+	fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	fun.bind_expression = BindCastToTypeFunction;
+	return fun;
+}
+
+} // namespace duckdb

--- a/extension/core_functions/scalar/generic/functions.json
+++ b/extension/core_functions/scalar/generic/functions.json
@@ -119,5 +119,12 @@
         "description": "Whether or not the provided value is the histogram \"other\" bin (used for values not belonging to any provided bin)",
         "example": "is_histogram_other_bin(v)",
         "type": "scalar_function"
+    },
+    {
+        "name": "cast_to_type",
+        "parameters": "param,type",
+        "description": "Casts the first argument to the type of the second argument",
+        "example": "cast_to_type('42', NULL::INTEGER)",
+        "type": "scalar_function"
     }
 ]

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -120,6 +120,7 @@ static constexpr ExtensionFunctionEntry EXTENSION_FUNCTIONS[] = {
     {"broadcast", "inet", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"can_cast_implicitly", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"cardinality", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
+    {"cast_to_type", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"cbrt", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"ceil", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},
     {"ceiling", "core_functions", CatalogType::SCALAR_FUNCTION_ENTRY},

--- a/test/sql/function/generic/cast_to_type.test
+++ b/test/sql/function/generic/cast_to_type.test
@@ -1,0 +1,56 @@
+# name: test/sql/function/generic/cast_to_type.test
+# description: Test cast_to_type function
+# group: [generic]
+
+statement ok
+PRAGMA enable_verification
+
+query I
+SELECT cast_to_type('  42', NULL::INT)
+----
+42
+
+statement error
+SELECT cast_to_type('hello', NULL::INT)
+----
+Conversion Error
+
+statement ok
+CREATE OR REPLACE MACRO try_trim_null(s) AS CASE WHEN typeof(s)=='VARCHAR' THEN cast_to_type(nullif(trim(s::VARCHAR), ''), s) ELSE s END;
+
+query III
+SELECT try_trim_null(42) as trim_int, try_trim_null('  col  ') as trim_varchar, try_trim_null('') as trim_empty;
+----
+42	col	NULL
+
+statement ok
+create table tbl(i int, v varchar);
+
+statement ok
+insert into tbl values (42, ' hello '), (100, '   ');
+
+query II
+SELECT try_trim_null(COLUMNS(*)) FROM tbl
+----
+42	hello
+100	NULL
+
+# prepared statements
+statement ok
+PREPARE v1 AS SELECT cast_to_type(' 42', ?);
+
+query I
+EXECUTE v1(NULL::INT)
+----
+42
+
+query I
+EXECUTE v1(NULL::VARCHAR)
+----
+ 42
+
+# cast to NULL
+statement error
+SELECT cast_to_type(42, NULL);
+----
+cannot be used to cast to NULL


### PR DESCRIPTION
This PR adds the `cast_to_type` function. This function is transformed into a cast from the first input argument to the type of the second input argument. For example:

```sql
SELECT cast_to_type('42', NULL::INT) AS res;
┌───────┐
│  res  │
│ int32 │
├───────┤
│  42   │
└───────┘
```

This function is primarily useful in macros, as it allows us to maintain types. This helps with making generic macros (that operate on different types). For example, here is a macro that adds to a number if the input is an integer:

```sql
CREATE TABLE tbl(i INT, s VARCHAR);
INSERT INTO tbl VALUES (42, 'hello world');

CREATE MACRO conditional_add(col, nr) AS
    CASE WHEN typeof(col) == 'INTEGER'
    THEN cast_to_type(col::INTEGER + nr, col)
    ELSE col END;
SELECT conditional_add(COLUMNS(*), 100) FROM tbl;
┌───────┬─────────────┐
│   i   │      s      │
│ int32 │   varchar   │
├───────┼─────────────┤
│  142  │ hello world │
└───────┴─────────────┘
```

The way this works is that the `CASE` statement needs to return the same type in all code paths. We can perform the addition on any input column by adding a cast to the desired type - but we need to cast the result of the addition back to the source type to make the binding work. Without the cast we end up with the following error message:

```sql

CREATE MACRO broken_conditional_add(col, nr) AS
    CASE WHEN typeof(col) == 'INTEGER'
    THEN col::INTEGER + nr
    ELSE col END;
SELECT broken_conditional_add(COLUMNS(*), 100) FROM tbl;
-- Cannot mix values of type VARCHAR and INTEGER in CASE expression - an explicit cast is required
```

So we need a way of dynamically casting to the type of a column - which this PR adds using the `cast_to_type` function.