### PR TITLE
Explicitly flush the thread-local optimistic writer in `PhysicalBatchInsert` when finalizing

### DIFF
--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -646,10 +646,10 @@ SinkFinalizeType PhysicalBatchInsert::Finalize(Pipeline &pipeline, Event &event,
 			data_table.LocalMerge(context, collection);
 			data_table.ResetOptimisticCollection(context, collection_index);
 		}
-		writer->FinalFlush();
 
 		auto &optimistic_writer = data_table.GetOptimisticWriter(context);
 		optimistic_writer.Merge(*writer);
+		optimistic_writer.FinalFlush();
 		memory_manager.FinalCheck();
 		return SinkFinalizeType::READY;
 	}

--- a/src/execution/operator/persistent/physical_batch_insert.cpp
+++ b/src/execution/operator/persistent/physical_batch_insert.cpp
@@ -646,6 +646,7 @@ SinkFinalizeType PhysicalBatchInsert::Finalize(Pipeline &pipeline, Event &event,
 			data_table.LocalMerge(context, collection);
 			data_table.ResetOptimisticCollection(context, collection_index);
 		}
+		writer->FinalFlush();
 
 		auto &optimistic_writer = data_table.GetOptimisticWriter(context);
 		optimistic_writer.Merge(*writer);

--- a/test/sql/storage/optimistic_write/optimistic_write_multi_statement.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_multi_statement.test_slow
@@ -1,0 +1,27 @@
+# name: test/sql/storage/optimistic_write/optimistic_write_multi_statement.test_slow
+# description: Test large appends within individual transactions
+# group: [optimistic_write]
+
+load __TEST_DIR__/optimistic_write_multi_statement.db
+
+statement ok
+SET force_compression='uncompressed';
+
+statement ok
+CREATE TABLE main_tbl (v INT);
+
+statement ok
+BEGIN
+
+foreach file_size 130815 68295 68490
+
+statement ok
+CREATE OR REPLACE TEMPORARY TABLE insert_tbl AS FROM range(${file_size});
+
+statement ok
+INSERT INTO main_tbl FROM insert_tbl;
+
+endloop
+
+statement ok
+COMMIT

--- a/test/sql/storage/optimistic_write/optimistic_write_multi_statement.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_multi_statement.test_slow
@@ -1,5 +1,5 @@
 # name: test/sql/storage/optimistic_write/optimistic_write_multi_statement.test_slow
-# description: Test large appends within individual transactions
+# description: Test multiple appends across statements within the same transaction
 # group: [optimistic_write]
 
 load __TEST_DIR__/optimistic_write_multi_statement.db

--- a/test/sql/storage/optimistic_write/optimistic_write_multi_statement_string.test_slow
+++ b/test/sql/storage/optimistic_write/optimistic_write_multi_statement_string.test_slow
@@ -1,0 +1,29 @@
+# name: test/sql/storage/optimistic_write/optimistic_write_multi_statement_string.test_slow
+# description: Test multiple appends across statements within the same transaction
+# group: [optimistic_write]
+
+require parquet
+
+load __TEST_DIR__/optimistic_write_multi_statement_string.db
+
+statement ok
+SET force_compression='uncompressed';
+
+statement ok
+CREATE TABLE main_tbl (v VARCHAR);
+
+statement ok
+BEGIN
+
+foreach file_size 130815 125018 125774 77995
+
+statement ok
+COPY (SELECT uuid()::VARCHAR FROM range(${file_size})) TO '__TEST_DIR__/file.parquet' (ROW_GROUP_SIZE 100000000);
+
+statement ok
+INSERT INTO main_tbl FROM '__TEST_DIR__/file.parquet';
+
+endloop
+
+statement ok
+COMMIT


### PR DESCRIPTION
This fixes an issue that could pop up when inserting from specific row group sizes with `SET preserve_insertion_order=true`