### PR TITLE
Fix [InvokeCI / NotifyExternalRepository] GitHub Actions has encountered an internal error when running your job.

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -113,6 +113,7 @@ jobs:
 
   prepare-status:
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - osx
       - linux-release
@@ -161,7 +162,7 @@ jobs:
     if: ${{ inputs.git_ref != '' && always() }}
     with:
       is-success: ${{ needs.prepare-status.outputs.is-success }}
-      target-branch: ${{ github.ref_name }}
+      target-branch: 'main'
       duckdb-sha: ${{ inputs.git_ref }}
       triggering-event: ${{ github.event_name }}
       should-publish: 'true'

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -20,73 +20,97 @@ concurrency:
 
 jobs:
   osx:
-    uses: ./.github/workflows/OSX.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
-      run_all: ${{ inputs.run_all }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+    # uses: ./.github/workflows/OSX.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    #   run_all: ${{ inputs.run_all }}
 
   linux-release:
-    uses: ./.github/workflows/LinuxRelease.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
+    # uses: ./.github/workflows/LinuxRelease.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
 
   windows:
-    uses: ./.github/workflows/Windows.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
-      run_all: ${{ inputs.run_all }}
+    # uses: ./.github/workflows/Windows.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    #   run_all: ${{ inputs.run_all }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
 
   python:
-    uses: ./.github/workflows/Python.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
-      run_all: ${{ inputs.run_all }}
-      override_twine_upload: ${{ inputs.twine_upload }}
+    # uses: ./.github/workflows/Python.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    #   run_all: ${{ inputs.run_all }}
+    #   override_twine_upload: ${{ inputs.twine_upload }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
 
   pyodide:
-    uses: ./.github/workflows/Pyodide.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
+    # uses: ./.github/workflows/Pyodide.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
 
   R:
-    uses: ./.github/workflows/R.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
+    # uses: ./.github/workflows/R.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
 
   Wasm:
-    uses: ./.github/workflows/Wasm.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
+    # uses: ./.github/workflows/Wasm.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
 
   static-libraries:
-    uses: ./.github/workflows/BundleStaticLibs.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
-
+    # uses: ./.github/workflows/BundleStaticLibs.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+      
   prepare-status:
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -114,9 +114,9 @@ jobs:
                 "${{ needs.R.result }}" == "success" && \
                 "${{ needs.Wasm.result }}" == "success" && \
                 "${{ needs.static-libraries.result }}" == "success" ]]; then
-            echo "success='true'" >> $GITHUB_OUTPUT
+            echo "success=true" >> $GITHUB_OUTPUT
           else
-            echo "success='false'" >> $GITHUB_OUTPUT
+            echo "success=false" >> $GITHUB_OUTPUT
           fi
     
   notify-external-repos-main:

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -20,97 +20,73 @@ concurrency:
 
 jobs:
   osx:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-    # uses: ./.github/workflows/OSX.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    #   run_all: ${{ inputs.run_all }}
+    uses: ./.github/workflows/OSX.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
+      run_all: ${{ inputs.run_all }}
 
   linux-release:
-    # uses: ./.github/workflows/LinuxRelease.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
+    uses: ./.github/workflows/LinuxRelease.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
 
   windows:
-    # uses: ./.github/workflows/Windows.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    #   run_all: ${{ inputs.run_all }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
+    uses: ./.github/workflows/Windows.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
+      run_all: ${{ inputs.run_all }}
 
   python:
-    # uses: ./.github/workflows/Python.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    #   run_all: ${{ inputs.run_all }}
-    #   override_twine_upload: ${{ inputs.twine_upload }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
+    uses: ./.github/workflows/Python.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
+      run_all: ${{ inputs.run_all }}
+      override_twine_upload: ${{ inputs.twine_upload }}
 
   pyodide:
-    # uses: ./.github/workflows/Pyodide.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
+    uses: ./.github/workflows/Pyodide.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
 
   R:
-    # uses: ./.github/workflows/R.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-
+    uses: ./.github/workflows/R.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
+    
   Wasm:
-    # uses: ./.github/workflows/Wasm.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
+    uses: ./.github/workflows/Wasm.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
 
   static-libraries:
-    # uses: ./.github/workflows/BundleStaticLibs.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-      
+    uses: ./.github/workflows/BundleStaticLibs.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
+
   prepare-status:
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -20,72 +20,96 @@ concurrency:
 
 jobs:
   osx:
-    uses: ./.github/workflows/OSX.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
-      run_all: ${{ inputs.run_all }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+    # uses: ./.github/workflows/OSX.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    #   run_all: ${{ inputs.run_all }}
 
   linux-release:
-    uses: ./.github/workflows/LinuxRelease.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+    # uses: ./.github/workflows/LinuxRelease.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
 
   windows:
-    uses: ./.github/workflows/Windows.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
-      run_all: ${{ inputs.run_all }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+    # uses: ./.github/workflows/Windows.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    #   run_all: ${{ inputs.run_all }}
 
   python:
-    uses: ./.github/workflows/Python.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
-      run_all: ${{ inputs.run_all }}
-      override_twine_upload: ${{ inputs.twine_upload }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+    # uses: ./.github/workflows/Python.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
+    #   run_all: ${{ inputs.run_all }}
+    #   override_twine_upload: ${{ inputs.twine_upload }}
 
   pyodide:
-    uses: ./.github/workflows/Pyodide.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+    # uses: ./.github/workflows/Pyodide.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
 
   R:
-    uses: ./.github/workflows/R.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+    # uses: ./.github/workflows/R.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
 
   Wasm:
-    uses: ./.github/workflows/Wasm.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+    # uses: ./.github/workflows/Wasm.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
 
   static-libraries:
-    uses: ./.github/workflows/BundleStaticLibs.yml
-    secrets: inherit
-    with:
-      override_git_describe: ${{ inputs.override_git_describe }}
-      git_ref: ${{ inputs.git_ref }}
-      skip_tests: ${{ inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+    # uses: ./.github/workflows/BundleStaticLibs.yml
+    # secrets: inherit
+    # with:
+    #   override_git_describe: ${{ inputs.override_git_describe }}
+    #   git_ref: ${{ inputs.git_ref }}
+    #   skip_tests: ${{ inputs.skip_tests }}
 
   prepare-status:
     runs-on: ubuntu-latest

--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -20,96 +20,72 @@ concurrency:
 
 jobs:
   osx:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-    # uses: ./.github/workflows/OSX.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    #   run_all: ${{ inputs.run_all }}
+    uses: ./.github/workflows/OSX.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
+      run_all: ${{ inputs.run_all }}
 
   linux-release:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-    # uses: ./.github/workflows/LinuxRelease.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
+    uses: ./.github/workflows/LinuxRelease.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
 
   windows:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 1
-    # uses: ./.github/workflows/Windows.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    #   run_all: ${{ inputs.run_all }}
+    uses: ./.github/workflows/Windows.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
+      run_all: ${{ inputs.run_all }}
 
   python:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-    # uses: ./.github/workflows/Python.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
-    #   run_all: ${{ inputs.run_all }}
-    #   override_twine_upload: ${{ inputs.twine_upload }}
+    uses: ./.github/workflows/Python.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
+      run_all: ${{ inputs.run_all }}
+      override_twine_upload: ${{ inputs.twine_upload }}
 
   pyodide:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-    # uses: ./.github/workflows/Pyodide.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
+    uses: ./.github/workflows/Pyodide.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
 
   R:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 1
-    # uses: ./.github/workflows/R.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
+    uses: ./.github/workflows/R.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
 
   Wasm:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-    # uses: ./.github/workflows/Wasm.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
+    uses: ./.github/workflows/Wasm.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
 
   static-libraries:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-    # uses: ./.github/workflows/BundleStaticLibs.yml
-    # secrets: inherit
-    # with:
-    #   override_git_describe: ${{ inputs.override_git_describe }}
-    #   git_ref: ${{ inputs.git_ref }}
-    #   skip_tests: ${{ inputs.skip_tests }}
+    uses: ./.github/workflows/BundleStaticLibs.yml
+    secrets: inherit
+    with:
+      override_git_describe: ${{ inputs.override_git_describe }}
+      git_ref: ${{ inputs.git_ref }}
+      skip_tests: ${{ inputs.skip_tests }}
 
   prepare-status:
     runs-on: ubuntu-latest
@@ -162,7 +138,7 @@ jobs:
     if: ${{ inputs.git_ref != '' && always() }}
     with:
       is-success: ${{ needs.prepare-status.outputs.is-success }}
-      target-branch: 'main'
+      target-branch: ${{ github.ref_name }}
       duckdb-sha: ${{ inputs.git_ref }}
       triggering-event: ${{ github.event_name }}
       should-publish: 'true'

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -72,6 +72,7 @@ jobs:
   notify-jdbc-run:
     name: Run JDBC Vendor
     runs-on: ubuntu-latest
+    if: ${{ inputs.is-success == 'true' }}
     env:
       PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
@@ -91,10 +92,8 @@ jobs:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
       - name: Run Nightly build status
-        # if: ${{ github.repository == 'duckdb/duckdb' }}
+        if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
-        
-          # export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
-          export URL=https://api.github.com/repos/hmeriann/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
+          export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
           export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"branch": "${{ inputs.target-branch }}", "event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -91,8 +91,10 @@ jobs:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
       - name: Run Nightly build status
-        if: ${{ github.repository == 'duckdb/duckdb' }}
+        # if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
-          export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
+        
+          # export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
+          export URL=https://api.github.com/repos/hmeriann/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
           export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"branch": "${{ inputs.target-branch }}", "event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -78,11 +78,12 @@ jobs:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
       - name: Run JDBC Vendor
-        if: ${{ github.repository == 'duckdb/duckdb' }}
+        # if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
-          export URL=https://api.github.com/repos/duckdb/duckdb-java/actions/workflows/Vendor.yml/dispatches
-          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
-          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
+          echo SHOULD TRIGGER THE RUN
+          # export URL=https://api.github.com/repos/duckdb/duckdb-java/actions/workflows/Vendor.yml/dispatches
+          # export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
+          # curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
 
   notify-nightly-build-status:
     name: Run Nightly build status
@@ -92,7 +93,7 @@ jobs:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
       - name: Run Nightly build status
-        if: ${{ github.repository == 'duckdb/duckdb' }}
+        # if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
           export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -78,12 +78,11 @@ jobs:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
       - name: Run JDBC Vendor
-        # if: ${{ github.repository == 'duckdb/duckdb' }}
+        if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
-          echo SHOULD TRIGGER THE RUN
-          # export URL=https://api.github.com/repos/duckdb/duckdb-java/actions/workflows/Vendor.yml/dispatches
-          # export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
-          # curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
+          export URL=https://api.github.com/repos/duckdb/duckdb-java/actions/workflows/Vendor.yml/dispatches
+          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
+          curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
 
   notify-nightly-build-status:
     name: Run Nightly build status
@@ -93,7 +92,7 @@ jobs:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
       - name: Run Nightly build status
-        # if: ${{ github.repository == 'duckdb/duckdb' }}
+        if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
           export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -57,7 +57,7 @@ jobs:
   notify-odbc-run:
     name: Run ODBC Vendor
     runs-on: ubuntu-latest
-    if: ${{ inputs.is-success == 'true' }}
+    if: ${{ inputs.is-success }}
     env:
       PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
   notify-jdbc-run:
     name: Run JDBC Vendor
     runs-on: ubuntu-latest
-    if: ${{ inputs.is-success == 'true' }}
+    if: ${{ inputs.is-success }}
     env:
       PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -57,7 +57,7 @@ jobs:
   notify-odbc-run:
     name: Run ODBC Vendor
     runs-on: ubuntu-latest
-    if: ${{ inputs.is-success }}
+    if: ${{ inputs.is-success == 'true' }}
     env:
       PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
   notify-jdbc-run:
     name: Run JDBC Vendor
     runs-on: ubuntu-latest
-    if: ${{ inputs.is-success }}
+    if: ${{ inputs.is-success == 'true' }}
     env:
       PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -95,5 +95,5 @@ jobs:
         if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
-          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"branch": "${{ inputs.target-branch }}", "event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
+          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"


### PR DESCRIPTION
GitHub Actions didn't provide more details in the [error message](https://github.com/duckdb/duckdb/actions/runs/14607342802/job/40992045763), so I ran some test workflows.

We are not expecting the `InvokeCI / NotifyExternalRepository` would skip `Run ODBC Vendor` job and fail `Run JDBC Vendor` and `Run Nightly Build Status` jobs.

The issue was in the boolean values passed as string inputs to the called `NotifyExternalRepository` workflow, where they were interpreted as booleans ([here](https://github.com/hmeriann/duckdb/blob/main/.github/workflows/NotifyExternalRepositories.yml#L60)).

This PR fixes that and adds missing `if` conditions to both workflows: to the `prepare-status:` job in `InvokeCI` (that job creates a flag to trigger or not the ODBC/JDBC Vendors) and to the `notify-jdbc-run` job in `NotifyExternalRepositories` (to make it have the same behaviour as `notify-odbc-run`)