### PR TITLE
add capi functions to create map and union values

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -2463,6 +2463,31 @@ Must be destroyed with `duckdb_destroy_value`.
 DUCKDB_C_API duckdb_value duckdb_create_array_value(duckdb_logical_type type, duckdb_value *values, idx_t value_count);
 
 /*!
+Creates a map value from a map type and two arrays, one for the keys and one for the values, each of length
+`entry_count`. Must be destroyed with `duckdb_destroy_value`.
+
+* @param map_type The map type
+* @param keys The keys of the map
+* @param values The values of the map
+* @param entry_count The number of entrys (key-value pairs) in the map
+* @return The map value, or nullptr, if the parameters are invalid.
+*/
+DUCKDB_C_API duckdb_value duckdb_create_map_value(duckdb_logical_type map_type, duckdb_value *keys,
+                                                  duckdb_value *values, idx_t entry_count);
+
+/*!
+Creates a union value from a union type, a tag index, and a value.
+Must be destroyed with `duckdb_destroy_value`.
+
+* @param union_type The union type
+* @param tag_index The index of the tag of the union
+* @param value The value of the union
+* @return The union value, or nullptr, if the parameters are invalid.
+*/
+DUCKDB_C_API duckdb_value duckdb_create_union_value(duckdb_logical_type union_type, idx_t tag_index,
+                                                    duckdb_value value);
+
+/*!
 Returns the number of elements in a MAP value.
 
 * @param value The MAP value.

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -474,6 +474,11 @@ typedef struct {
 	// New string functions that are added
 
 	char *(*duckdb_value_to_string)(duckdb_value value);
+	// New value functions that are added
+
+	duckdb_value (*duckdb_create_map_value)(duckdb_logical_type map_type, duckdb_value *keys, duckdb_value *values,
+	                                        idx_t entry_count);
+	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, idx_t tag_index, duckdb_value value);
 	// An API to create new vector types
 
 	duckdb_vector (*duckdb_create_vector)(duckdb_logical_type type, idx_t capacity);
@@ -900,6 +905,8 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_destroy_instance_cache = duckdb_destroy_instance_cache;
 	result.duckdb_append_default_to_chunk = duckdb_append_default_to_chunk;
 	result.duckdb_value_to_string = duckdb_value_to_string;
+	result.duckdb_create_map_value = duckdb_create_map_value;
+	result.duckdb_create_union_value = duckdb_create_union_value;
 	result.duckdb_create_vector = duckdb_create_vector;
 	result.duckdb_destroy_vector = duckdb_destroy_vector;
 	result.duckdb_slice_vector = duckdb_slice_vector;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_value_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_value_functions.json
@@ -1,0 +1,8 @@
+{
+  "version": "unstable_new_value_functions",
+  "description": "New value functions that are added",
+  "entries": [
+      "duckdb_create_map_value",
+      "duckdb_create_union_value"
+  ]
+}

--- a/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/value_interface.json
@@ -1091,6 +1091,65 @@
             }
         },
         {
+            "name": "duckdb_create_map_value",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_logical_type",
+                    "name": "map_type"
+                },
+                {
+                    "type": "duckdb_value *",
+                    "name": "keys"
+                },
+                {
+                    "type": "duckdb_value *",
+                    "name": "values"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "entry_count"
+                }
+            ],
+            "comment": {
+                "description": "Creates a map value from a map type and two arrays, one for the keys and one for the values, each of length `entry_count`.\nMust be destroyed with `duckdb_destroy_value`.\n\n",
+                "param_comments": {
+                    "map_type": "The map type",
+                    "keys": "The keys of the map",
+                    "values": "The values of the map",
+                    "entry_count": "The number of entrys (key-value pairs) in the map"
+                },
+                "return_value": "The map value, or nullptr, if the parameters are invalid."
+            }
+        },
+        {
+            "name": "duckdb_create_union_value",
+            "return_type": "duckdb_value",
+            "params": [
+                {
+                    "type": "duckdb_logical_type",
+                    "name": "union_type"
+                },
+                {
+                    "type": "idx_t",
+                    "name": "tag_index"
+                },
+                {
+                    "type": "duckdb_value",
+                    "name": "value"
+                }
+            ],
+            "comment": {
+                "description": "Creates a union value from a union type, a tag index, and a value.\nMust be destroyed with `duckdb_destroy_value`.\n\n",
+                "param_comments": {
+                    "union_type": "The union type",
+                    "tag_index": "The index of the tag of the union",
+                    "value": "The value of the union"
+                },
+                "return_value": "The union value, or nullptr, if the parameters are invalid."
+            }
+        },
+        {
             "name": "duckdb_get_map_size",
             "return_type": "idx_t",
             "params": [

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -547,6 +547,13 @@ typedef struct {
 	char *(*duckdb_value_to_string)(duckdb_value value);
 #endif
 
+// New value functions that are added
+#ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
+	duckdb_value (*duckdb_create_map_value)(duckdb_logical_type map_type, duckdb_value *keys, duckdb_value *values,
+	                                        idx_t entry_count);
+	duckdb_value (*duckdb_create_union_value)(duckdb_logical_type union_type, idx_t tag_index, duckdb_value value);
+#endif
+
 // An API to create new vector types
 #ifdef DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 	duckdb_vector (*duckdb_create_vector)(duckdb_logical_type type, idx_t capacity);
@@ -983,6 +990,10 @@ typedef struct {
 
 // Version unstable_new_string_functions
 #define duckdb_value_to_string duckdb_ext_api.duckdb_value_to_string
+
+// Version unstable_new_value_functions
+#define duckdb_create_map_value   duckdb_ext_api.duckdb_create_map_value
+#define duckdb_create_union_value duckdb_ext_api.duckdb_create_union_value
 
 // Version unstable_new_vector_types
 #define duckdb_create_vector                 duckdb_ext_api.duckdb_create_vector

--- a/src/main/capi/duckdb_value-c.cpp
+++ b/src/main/capi/duckdb_value-c.cpp
@@ -393,6 +393,72 @@ duckdb_value duckdb_create_array_value(duckdb_logical_type type, duckdb_value *v
 	return WrapValue(array_value);
 }
 
+duckdb_value duckdb_create_map_value(duckdb_logical_type map_type, duckdb_value *keys, duckdb_value *values,
+                                     idx_t entry_count) {
+	if (!map_type || !keys || !values) {
+		return nullptr;
+	}
+	const auto &map_logical_type = UnwrapType(map_type);
+	if (map_logical_type.id() != duckdb::LogicalTypeId::MAP) {
+		return nullptr;
+	}
+	if (duckdb::TypeVisitor::Contains(map_logical_type, duckdb::LogicalTypeId::INVALID) ||
+	    duckdb::TypeVisitor::Contains(map_logical_type, duckdb::LogicalTypeId::ANY)) {
+		return nullptr;
+	}
+
+	const auto &key_logical_type = duckdb::MapType::KeyType(map_logical_type);
+	const auto &value_logical_type = duckdb::MapType::ValueType(map_logical_type);
+	duckdb::vector<duckdb::Value> unwrapped_keys;
+	duckdb::vector<duckdb::Value> unwrapped_values;
+	for (idx_t i = 0; i < entry_count; i++) {
+		const auto key = keys[i];
+		const auto value = values[i];
+		if (!key || !value) {
+			return nullptr;
+		}
+		unwrapped_keys.emplace_back(UnwrapValue(key));
+		unwrapped_values.emplace_back(UnwrapValue(value));
+	}
+	duckdb::Value *map_value = new duckdb::Value;
+	try {
+		*map_value = duckdb::Value::MAP(key_logical_type, value_logical_type, std::move(unwrapped_keys),
+		                                std::move(unwrapped_values));
+	} catch (...) {
+		delete map_value;
+		return nullptr;
+	}
+	return WrapValue(map_value);
+}
+
+duckdb_value duckdb_create_union_value(duckdb_logical_type union_type, idx_t tag_index, duckdb_value value) {
+	if (!union_type || !value) {
+		return nullptr;
+	}
+	const auto &union_logical_type = UnwrapType(union_type);
+	if (union_logical_type.id() != duckdb::LogicalTypeId::UNION) {
+		return nullptr;
+	}
+	idx_t member_count = duckdb::UnionType::GetMemberCount(union_logical_type);
+	if (tag_index >= member_count) {
+		return nullptr;
+	}
+	const auto &member_type = duckdb::UnionType::GetMemberType(union_logical_type, tag_index);
+	const auto &unwrapped_value = UnwrapValue(value);
+	if (unwrapped_value.type() != member_type) {
+		return nullptr;
+	}
+	const auto member_types = duckdb::UnionType::CopyMemberTypes(union_logical_type);
+	duckdb::Value *union_value = new duckdb::Value;
+	try {
+		*union_value = duckdb::Value::UNION(member_types, tag_index, unwrapped_value);
+	} catch (...) {
+		delete union_value;
+		return nullptr;
+	}
+	return WrapValue(union_value);
+}
+
 idx_t duckdb_get_map_size(duckdb_value value) {
 	if (!value) {
 		return 0;

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -807,6 +807,8 @@ TEST_CASE("Map value construction (happy path)", "[capi]") {
 	auto logical_type = duckdb_vector_get_column_type(vector);
 	REQUIRE(logical_type);
 	REQUIRE(duckdb_get_type_id(logical_type) == duckdb_type::DUCKDB_TYPE_MAP);
+	duckdb_destroy_logical_type(&logical_type);
+
 	auto list_entry_data = (uint64_t *)duckdb_vector_get_data(vector);
 	REQUIRE(list_entry_data);
 	REQUIRE(list_entry_data[0] == 0);           // offset
@@ -870,11 +872,12 @@ TEST_CASE("Map value construction (null values array)", "[capi]") {
 }
 
 TEST_CASE("Map value construction (invalid map type)", "[capi]") {
-	auto invalid_map_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	auto int_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
 	duckdb::vector<duckdb_value> key_vals;
 	duckdb::vector<duckdb_value> value_vals;
-	auto map_value = duckdb_create_map_value(invalid_map_type, key_vals.data(), value_vals.data(), 0);
+	auto map_value = duckdb_create_map_value(int_type, key_vals.data(), value_vals.data(), 0);
 	REQUIRE(map_value == nullptr);
+	duckdb_destroy_logical_type(&int_type);
 }
 
 TEST_CASE("Map value construction (invalid key array value types)", "[capi]") {
@@ -971,6 +974,8 @@ TEST_CASE("Union value construction (happy path)", "[capi]") {
 	auto logical_type = duckdb_vector_get_column_type(vector);
 	REQUIRE(logical_type);
 	REQUIRE(duckdb_get_type_id(logical_type) == duckdb_type::DUCKDB_TYPE_UNION);
+	duckdb_destroy_logical_type(&logical_type);
+
 	auto tags_vector = duckdb_struct_vector_get_child(vector, 0);
 	REQUIRE(tags_vector);
 	auto tags_data = (uint8_t *)duckdb_vector_get_data(tags_vector);

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -772,7 +772,7 @@ TEST_CASE("Map value construction (happy path)", "[capi]") {
 
 	duckdb::vector<duckdb_value> key_vals;
 	duckdb::vector<duckdb_value> value_vals;
-	for (int i = 0; i < entry_count; ++i) {
+	for (idx_t i = 0; i < entry_count; ++i) {
 		key_vals.push_back(duckdb_create_int32(keys[i]));
 		value_vals.push_back(duckdb_create_double(values[i]));
 	}
@@ -780,7 +780,7 @@ TEST_CASE("Map value construction (happy path)", "[capi]") {
 	auto map_value = duckdb_create_map_value(map_type, key_vals.data(), value_vals.data(), entry_count);
 	REQUIRE(map_value);
 	REQUIRE(duckdb_get_map_size(map_value) == entry_count);
-	for (int i = 0; i < entry_count; ++i) {
+	for (idx_t i = 0; i < entry_count; ++i) {
 		auto key_val = duckdb_get_map_key(map_value, i);
 		REQUIRE(duckdb_get_int32(key_val) == keys[i]);
 		duckdb_destroy_value(&key_val);
@@ -822,14 +822,14 @@ TEST_CASE("Map value construction (happy path)", "[capi]") {
 	REQUIRE(keys_data);
 	auto values_data = (double *)duckdb_vector_get_data(values_vector);
 	REQUIRE(values_data);
-	for (int i = 0; i < entry_count; ++i) {
+	for (idx_t i = 0; i < entry_count; ++i) {
 		REQUIRE(keys_data[i] == keys[i]);
 		REQUIRE(values_data[i] == values[i]);
 	}
 
 	duckdb_destroy_prepare(&prepared);
 	duckdb_destroy_value(&map_value);
-	for (int i = 0; i < entry_count; ++i) {
+	for (idx_t i = 0; i < entry_count; ++i) {
 		duckdb_destroy_value(&key_vals[i]);
 		duckdb_destroy_value(&value_vals[i]);
 	}
@@ -888,7 +888,7 @@ TEST_CASE("Map value construction (invalid key array value types)", "[capi]") {
 
 	duckdb::vector<duckdb_value> key_vals;
 	duckdb::vector<duckdb_value> value_vals;
-	for (int i = 0; i < entry_count; ++i) {
+	for (idx_t i = 0; i < entry_count; ++i) {
 		key_vals.push_back(duckdb_create_varchar(keys[i]));
 		value_vals.push_back(duckdb_create_double(values[i]));
 	}
@@ -896,7 +896,7 @@ TEST_CASE("Map value construction (invalid key array value types)", "[capi]") {
 	auto map_value = duckdb_create_map_value(map_type, key_vals.data(), value_vals.data(), entry_count);
 	REQUIRE(map_value == nullptr);
 
-	for (int i = 0; i < entry_count; ++i) {
+	for (idx_t i = 0; i < entry_count; ++i) {
 		duckdb_destroy_value(&key_vals[i]);
 		duckdb_destroy_value(&value_vals[i]);
 	}
@@ -916,7 +916,7 @@ TEST_CASE("Map value construction (invalid value array value types)", "[capi]") 
 
 	duckdb::vector<duckdb_value> key_vals;
 	duckdb::vector<duckdb_value> value_vals;
-	for (int i = 0; i < entry_count; ++i) {
+	for (idx_t i = 0; i < entry_count; ++i) {
 		key_vals.push_back(duckdb_create_int32(keys[i]));
 		value_vals.push_back(duckdb_create_varchar(values[i]));
 	}
@@ -924,7 +924,7 @@ TEST_CASE("Map value construction (invalid value array value types)", "[capi]") 
 	auto map_value = duckdb_create_map_value(map_type, key_vals.data(), value_vals.data(), entry_count);
 	REQUIRE(map_value == nullptr);
 
-	for (int i = 0; i < entry_count; ++i) {
+	for (idx_t i = 0; i < entry_count; ++i) {
 		duckdb_destroy_value(&key_vals[i]);
 		duckdb_destroy_value(&value_vals[i]);
 	}
@@ -940,11 +940,11 @@ TEST_CASE("Union value construction (happy path)", "[capi]") {
 	auto varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
 	auto int_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
 
-	duckdb_logical_type member_types[] {varchar_type, int_type};
-	const char *member_names[] {"str", "int"};
+	duckdb::vector<duckdb_logical_type> member_types {varchar_type, int_type};
+	duckdb::vector<const char *> member_names {"str", "int"};
 	idx_t member_count = 2;
 
-	auto union_type = duckdb_create_union_type(member_types, member_names, member_count);
+	auto union_type = duckdb_create_union_type(member_types.data(), member_names.data(), member_count);
 
 	idx_t tag_index = 1;
 	int32_t int32 = 42;
@@ -973,7 +973,7 @@ TEST_CASE("Union value construction (happy path)", "[capi]") {
 	REQUIRE(duckdb_get_type_id(logical_type) == duckdb_type::DUCKDB_TYPE_UNION);
 	auto tags_vector = duckdb_struct_vector_get_child(vector, 0);
 	REQUIRE(tags_vector);
-	auto tags_data = (uint16_t *)duckdb_vector_get_data(tags_vector);
+	auto tags_data = (uint8_t *)duckdb_vector_get_data(tags_vector);
 	REQUIRE(tags_data);
 	REQUIRE(tags_data[0] == tag_index);
 	auto value_vector = duckdb_struct_vector_get_child(vector, tag_index + 1);

--- a/test/api/capi/test_capi_complex_types.cpp
+++ b/test/api/capi/test_capi_complex_types.cpp
@@ -757,3 +757,297 @@ TEST_CASE("Array value construction") {
 	}
 	duckdb_destroy_value(&array_value);
 }
+
+TEST_CASE("Map value construction (happy path)", "[capi]") {
+	CAPITester tester;
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	auto key_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	auto value_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
+	auto map_type = duckdb_create_map_type(key_type, value_type);
+
+	int32_t keys[] {100, 200, 300};
+	double values[] {1.2, 3.4, 5.6};
+	idx_t entry_count = 3;
+
+	duckdb::vector<duckdb_value> key_vals;
+	duckdb::vector<duckdb_value> value_vals;
+	for (int i = 0; i < entry_count; ++i) {
+		key_vals.push_back(duckdb_create_int32(keys[i]));
+		value_vals.push_back(duckdb_create_double(values[i]));
+	}
+
+	auto map_value = duckdb_create_map_value(map_type, key_vals.data(), value_vals.data(), entry_count);
+	REQUIRE(map_value);
+	REQUIRE(duckdb_get_map_size(map_value) == entry_count);
+	for (int i = 0; i < entry_count; ++i) {
+		auto key_val = duckdb_get_map_key(map_value, i);
+		REQUIRE(duckdb_get_int32(key_val) == keys[i]);
+		duckdb_destroy_value(&key_val);
+		auto value_val = duckdb_get_map_value(map_value, i);
+		REQUIRE(duckdb_get_double(value_val) == values[i]);
+		duckdb_destroy_value(&value_val);
+	}
+
+	duckdb_prepared_statement prepared;
+	REQUIRE(duckdb_prepare(tester.connection, "select ?", &prepared) == DuckDBSuccess);
+
+	duckdb_bind_value(prepared, 1, map_value);
+
+	auto result = tester.QueryPrepared(prepared);
+	REQUIRE(result->ChunkCount() == 1);
+	auto capi_chunk = result->FetchChunk(0);
+	REQUIRE(capi_chunk);
+	auto chunk = capi_chunk->GetChunk();
+	REQUIRE(chunk);
+	auto row_count = duckdb_data_chunk_get_size(chunk);
+	REQUIRE(row_count == 1);
+	auto vector = duckdb_data_chunk_get_vector(chunk, 0);
+	REQUIRE(vector);
+	auto logical_type = duckdb_vector_get_column_type(vector);
+	REQUIRE(logical_type);
+	REQUIRE(duckdb_get_type_id(logical_type) == duckdb_type::DUCKDB_TYPE_MAP);
+	auto list_entry_data = (uint64_t *)duckdb_vector_get_data(vector);
+	REQUIRE(list_entry_data);
+	REQUIRE(list_entry_data[0] == 0);           // offset
+	REQUIRE(list_entry_data[1] == entry_count); // length
+	REQUIRE(duckdb_list_vector_get_size(vector) == entry_count);
+	auto list_child = duckdb_list_vector_get_child(vector);
+	REQUIRE(list_child);
+	auto keys_vector = duckdb_struct_vector_get_child(list_child, 0);
+	REQUIRE(keys_vector);
+	auto values_vector = duckdb_struct_vector_get_child(list_child, 1);
+	REQUIRE(values_vector);
+	auto keys_data = (int32_t *)duckdb_vector_get_data(keys_vector);
+	REQUIRE(keys_data);
+	auto values_data = (double *)duckdb_vector_get_data(values_vector);
+	REQUIRE(values_data);
+	for (int i = 0; i < entry_count; ++i) {
+		REQUIRE(keys_data[i] == keys[i]);
+		REQUIRE(values_data[i] == values[i]);
+	}
+
+	duckdb_destroy_prepare(&prepared);
+	duckdb_destroy_value(&map_value);
+	for (int i = 0; i < entry_count; ++i) {
+		duckdb_destroy_value(&key_vals[i]);
+		duckdb_destroy_value(&value_vals[i]);
+	}
+	duckdb_destroy_logical_type(&map_type);
+	duckdb_destroy_logical_type(&value_type);
+	duckdb_destroy_logical_type(&key_type);
+}
+
+TEST_CASE("Map value construction (null map type)", "[capi]") {
+	duckdb::vector<duckdb_value> key_vals;
+	duckdb::vector<duckdb_value> value_vals;
+	auto map_value = duckdb_create_map_value(nullptr, key_vals.data(), value_vals.data(), 0);
+	REQUIRE(map_value == nullptr);
+}
+
+TEST_CASE("Map value construction (null keys array)", "[capi]") {
+	auto key_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	auto value_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
+	auto map_type = duckdb_create_map_type(key_type, value_type);
+	duckdb::vector<duckdb_value> value_vals;
+	auto map_value = duckdb_create_map_value(map_type, nullptr, value_vals.data(), 0);
+	REQUIRE(map_value == nullptr);
+	duckdb_destroy_logical_type(&map_type);
+	duckdb_destroy_logical_type(&value_type);
+	duckdb_destroy_logical_type(&key_type);
+}
+
+TEST_CASE("Map value construction (null values array)", "[capi]") {
+	auto key_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	auto value_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
+	auto map_type = duckdb_create_map_type(key_type, value_type);
+	duckdb::vector<duckdb_value> key_vals;
+	auto map_value = duckdb_create_map_value(map_type, key_vals.data(), nullptr, 0);
+	REQUIRE(map_value == nullptr);
+	duckdb_destroy_logical_type(&map_type);
+	duckdb_destroy_logical_type(&value_type);
+	duckdb_destroy_logical_type(&key_type);
+}
+
+TEST_CASE("Map value construction (invalid map type)", "[capi]") {
+	auto invalid_map_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	duckdb::vector<duckdb_value> key_vals;
+	duckdb::vector<duckdb_value> value_vals;
+	auto map_value = duckdb_create_map_value(invalid_map_type, key_vals.data(), value_vals.data(), 0);
+	REQUIRE(map_value == nullptr);
+}
+
+TEST_CASE("Map value construction (invalid key array value types)", "[capi]") {
+	auto key_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	auto value_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
+	auto map_type = duckdb_create_map_type(key_type, value_type);
+
+	const char *keys[] {"a", "b", "c"}; // invalid type
+	double values[] {1.2, 3.4, 5.6};
+	idx_t entry_count = 3;
+
+	duckdb::vector<duckdb_value> key_vals;
+	duckdb::vector<duckdb_value> value_vals;
+	for (int i = 0; i < entry_count; ++i) {
+		key_vals.push_back(duckdb_create_varchar(keys[i]));
+		value_vals.push_back(duckdb_create_double(values[i]));
+	}
+
+	auto map_value = duckdb_create_map_value(map_type, key_vals.data(), value_vals.data(), entry_count);
+	REQUIRE(map_value == nullptr);
+
+	for (int i = 0; i < entry_count; ++i) {
+		duckdb_destroy_value(&key_vals[i]);
+		duckdb_destroy_value(&value_vals[i]);
+	}
+	duckdb_destroy_logical_type(&map_type);
+	duckdb_destroy_logical_type(&value_type);
+	duckdb_destroy_logical_type(&key_type);
+}
+
+TEST_CASE("Map value construction (invalid value array value types)", "[capi]") {
+	auto key_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	auto value_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
+	auto map_type = duckdb_create_map_type(key_type, value_type);
+
+	int32_t keys[] {100, 200, 300};
+	const char *values[] {"a", "b", "c"}; // invalid type
+	idx_t entry_count = 3;
+
+	duckdb::vector<duckdb_value> key_vals;
+	duckdb::vector<duckdb_value> value_vals;
+	for (int i = 0; i < entry_count; ++i) {
+		key_vals.push_back(duckdb_create_int32(keys[i]));
+		value_vals.push_back(duckdb_create_varchar(values[i]));
+	}
+
+	auto map_value = duckdb_create_map_value(map_type, key_vals.data(), value_vals.data(), entry_count);
+	REQUIRE(map_value == nullptr);
+
+	for (int i = 0; i < entry_count; ++i) {
+		duckdb_destroy_value(&key_vals[i]);
+		duckdb_destroy_value(&value_vals[i]);
+	}
+	duckdb_destroy_logical_type(&map_type);
+	duckdb_destroy_logical_type(&value_type);
+	duckdb_destroy_logical_type(&key_type);
+}
+
+TEST_CASE("Union value construction (happy path)", "[capi]") {
+	CAPITester tester;
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	auto varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+	auto int_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+
+	duckdb_logical_type member_types[] {varchar_type, int_type};
+	const char *member_names[] {"str", "int"};
+	idx_t member_count = 2;
+
+	auto union_type = duckdb_create_union_type(member_types, member_names, member_count);
+
+	idx_t tag_index = 1;
+	int32_t int32 = 42;
+	auto int32_value = duckdb_create_int32(int32);
+
+	auto union_value = duckdb_create_union_value(union_type, tag_index, int32_value);
+	REQUIRE(union_value);
+
+	duckdb_prepared_statement prepared;
+	REQUIRE(duckdb_prepare(tester.connection, "select ?", &prepared) == DuckDBSuccess);
+
+	duckdb_bind_value(prepared, 1, union_value);
+
+	auto result = tester.QueryPrepared(prepared);
+	REQUIRE(result->ChunkCount() == 1);
+	auto capi_chunk = result->FetchChunk(0);
+	REQUIRE(capi_chunk);
+	auto chunk = capi_chunk->GetChunk();
+	REQUIRE(chunk);
+	auto row_count = duckdb_data_chunk_get_size(chunk);
+	REQUIRE(row_count == 1);
+	auto vector = duckdb_data_chunk_get_vector(chunk, 0);
+	REQUIRE(vector);
+	auto logical_type = duckdb_vector_get_column_type(vector);
+	REQUIRE(logical_type);
+	REQUIRE(duckdb_get_type_id(logical_type) == duckdb_type::DUCKDB_TYPE_UNION);
+	auto tags_vector = duckdb_struct_vector_get_child(vector, 0);
+	REQUIRE(tags_vector);
+	auto tags_data = (uint16_t *)duckdb_vector_get_data(tags_vector);
+	REQUIRE(tags_data);
+	REQUIRE(tags_data[0] == tag_index);
+	auto value_vector = duckdb_struct_vector_get_child(vector, tag_index + 1);
+	REQUIRE(value_vector);
+	auto value_data = (int32_t *)duckdb_vector_get_data(value_vector);
+	REQUIRE(value_data);
+	REQUIRE(value_data[0] == int32);
+
+	duckdb_destroy_prepare(&prepared);
+	duckdb_destroy_value(&union_value);
+	duckdb_destroy_value(&int32_value);
+	duckdb_destroy_logical_type(&union_type);
+	duckdb_destroy_logical_type(&int_type);
+	duckdb_destroy_logical_type(&varchar_type);
+}
+
+TEST_CASE("Union value construction (null union type)", "[capi]") {
+	auto value = duckdb_create_int32(42);
+	auto union_value = duckdb_create_union_value(nullptr, 1, value);
+	REQUIRE(union_value == nullptr);
+	duckdb_destroy_value(&value);
+}
+
+TEST_CASE("Union value construction (null value pointer)", "[capi]") {
+	auto varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+	auto int_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	duckdb_logical_type member_types[] {varchar_type, int_type};
+	const char *member_names[] {"str", "int"};
+	idx_t member_count = 2;
+	auto union_type = duckdb_create_union_type(member_types, member_names, member_count);
+	auto union_value = duckdb_create_union_value(union_type, 1, nullptr);
+	REQUIRE(union_value == nullptr);
+	duckdb_destroy_logical_type(&union_type);
+	duckdb_destroy_logical_type(&int_type);
+	duckdb_destroy_logical_type(&varchar_type);
+}
+
+TEST_CASE("Union value construction (invalid union type)", "[capi]") {
+	auto varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+	auto value = duckdb_create_int32(42);
+	auto union_value = duckdb_create_union_value(varchar_type, 1, value);
+	REQUIRE(union_value == nullptr);
+	duckdb_destroy_value(&value);
+	duckdb_destroy_logical_type(&varchar_type);
+}
+
+TEST_CASE("Union value construction (invalid tag index)", "[capi]") {
+	auto varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+	auto int_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	duckdb_logical_type member_types[] {varchar_type, int_type};
+	const char *member_names[] {"str", "int"};
+	idx_t member_count = 2;
+	auto union_type = duckdb_create_union_type(member_types, member_names, member_count);
+	auto value = duckdb_create_int32(42);
+	auto union_value = duckdb_create_union_value(union_type, 2, value);
+	REQUIRE(union_value == nullptr);
+	duckdb_destroy_value(&value);
+	duckdb_destroy_logical_type(&union_type);
+	duckdb_destroy_logical_type(&int_type);
+	duckdb_destroy_logical_type(&varchar_type);
+}
+
+TEST_CASE("Union value construction (invalid value type)", "[capi]") {
+	auto varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+	auto int_type = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+	duckdb_logical_type member_types[] {varchar_type, int_type};
+	const char *member_names[] {"str", "int"};
+	idx_t member_count = 2;
+	auto union_type = duckdb_create_union_type(member_types, member_names, member_count);
+	auto value = duckdb_create_double(1.2);
+	auto union_value = duckdb_create_union_value(union_type, 1, value);
+	REQUIRE(union_value == nullptr);
+	duckdb_destroy_value(&value);
+	duckdb_destroy_logical_type(&union_type);
+	duckdb_destroy_logical_type(&int_type);
+	duckdb_destroy_logical_type(&varchar_type);
+}


### PR DESCRIPTION
Add two functions to the C API:
- `duckdb_create_map_value`
- `duckdb_create_union_value`

Another [PR](https://github.com/duckdb/duckdb/pull/14613) to do this was open some time ago, but it stalled. Some C API infrastructure has changed in the meantime, making it somewhat challenging to revive the old code.

This implements similar functions, informed by those in the other PR, but with slightly different signatures. I followed existing patterns for similar functions as closely as possible. Both positive and negative test cases are included, heeding the feedback in the other PR.

My main motivation for this is to unblock two items for the Node Neo API:
- https://github.com/duckdb/duckdb-node-neo/issues/167
- https://github.com/duckdb/duckdb-node-neo/issues/168

I would like to try to get this merged before DuckDB 1.3.0 is released, currently targeted for May 14th.

FYI @prashanthellina @Tishj 