### PR TITLE
Only notify JDBC when all runs are successful

### DIFF
--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -72,6 +72,7 @@ jobs:
   notify-jdbc-run:
     name: Run JDBC Vendor
     runs-on: ubuntu-latest
+    if: ${{ inputs.is-success == 'true' }}
     env:
       PAT_USER: ${{ secrets.PAT_USERNAME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
This change adds the check to JDBC notification workflow that all nightly CI runs are sucessful. The check is added the same way it is used for ODBC notifications.

This check is necessary to make sure, that JDBC/ODBC only imports engine sources for the commit for which the whole set of extensions is built and available.