### PR TITLE
Share null mask with constant null arg vector

### DIFF
--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -44,7 +44,8 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 				// input is constant null, return constant null
 				result.Reference(info.value);
 				auto &result_mask = ConstantVector::Validity(result);
-				result_mask.Copy(result_mask, args.size());
+				auto &input_mask = ConstantVector::Validity(args.data[idx]);
+				result_mask.Initialize(input_mask);
 				ConstantVector::SetNull(result, true);
 				return;
 			}

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -43,6 +43,8 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 			if (ConstantVector::IsNull(args.data[idx])) {
 				// input is constant null, return constant null
 				result.Reference(info.value);
+				auto &result_mask = ConstantVector::Validity(result);
+				result_mask.Copy(result_mask, args.size());
 				ConstantVector::SetNull(result, true);
 				return;
 			}

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -42,7 +42,7 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 		case VectorType::CONSTANT_VECTOR: {
 			if (ConstantVector::IsNull(args.data[idx])) {
 				// input is constant null, return constant null
-				result.Reference(info.value);
+				result.SetVectorType(VectorType::CONSTANT_VECTOR);
 				auto &result_mask = ConstantVector::Validity(result);
 				auto &input_mask = ConstantVector::Validity(args.data[idx]);
 				result_mask.Initialize(input_mask);

--- a/test/sql/join/inner/not_between_is_null.test
+++ b/test/sql/join/inner/not_between_is_null.test
@@ -1,0 +1,22 @@
+# name: test/sql/join/inner/not_between_is_null.test
+# description: Test INNER JOIN with NOT BETWEEN and IS NULL conditions
+# group: [inner]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t1(c0 INT);
+CREATE TABLE t2(c0 INT);
+
+statement ok
+INSERT INTO t1(c0) VALUES (-18), (NULL);
+
+statement ok
+INSERT INTO t2(c0) VALUES (NULL);
+
+query II
+SELECT * FROM t1 INNER JOIN t2 ON ((t1.c0 NOT BETWEEN t2.c0 AND t2.c0) IS NULL);
+----
+-18	NULL
+NULL	NULL


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/17217

When the constant_or_null function encounters a constant NULL input, it will set the null mask of result vector for row 0 to invalid.

If the null mask is shared with other function arg vector (due to a previous Combine() call), modifying the null mask for row 0 would incorrectly affect the arg vector. This leads to wrong query result.

Share the null mask with the constant NULL arg vector should fix the issue.
