### PR TITLE
Adapt size of hash table during aggregation using HyperLogLog

### DIFF
--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -59,7 +59,7 @@ GroupedAggregateHashTable::GroupedAggregateHashTable(ClientContext &context_p, A
 	if (radix_bits >= UNPARTITIONED_RADIX_BITS_THRESHOLD) {
 		InitializeUnpartitionedData();
 	}
-	Resize(initial_capacity, true);
+	Resize(initial_capacity);
 
 	// Predicates
 	predicates.resize(layout_ptr->ColumnCount() - 1, ExpressionType::COMPARE_NOT_DISTINCT_FROM);

--- a/src/execution/aggregate_hashtable.cpp
+++ b/src/execution/aggregate_hashtable.cpp
@@ -42,7 +42,7 @@ GroupedAggregateHashTable::GroupedAggregateHashTable(ClientContext &context_p, A
                                                      vector<AggregateObject> aggregate_objects_p,
                                                      idx_t initial_capacity, idx_t radix_bits)
     : BaseAggregateHashTable(context_p, allocator, aggregate_objects_p, std::move(payload_types_p)), context(context_p),
-      radix_bits(radix_bits), count(0), capacity(0), skip_lookups(false),
+      radix_bits(radix_bits), count(0), capacity(0), sink_count(0), skip_lookups(false), enable_hll(false),
       aggregate_allocator(make_shared_ptr<ArenaAllocator>(allocator)), state(*aggregate_allocator) {
 
 	// Append hash column to the end and initialise the row layout
@@ -59,7 +59,7 @@ GroupedAggregateHashTable::GroupedAggregateHashTable(ClientContext &context_p, A
 	if (radix_bits >= UNPARTITIONED_RADIX_BITS_THRESHOLD) {
 		InitializeUnpartitionedData();
 	}
-	Resize(initial_capacity);
+	Resize(initial_capacity, true);
 
 	// Predicates
 	predicates.resize(layout_ptr->ColumnCount() - 1, ExpressionType::COMPARE_NOT_DISTINCT_FROM);
@@ -248,11 +248,32 @@ idx_t GroupedAggregateHashTable::GetSinkCount() const {
 	return sink_count;
 }
 
+idx_t GroupedAggregateHashTable::GetMaterializedCount() const {
+	auto result = partitioned_data->Count();
+	if (unpartitioned_data) {
+		result += unpartitioned_data->Count();
+	}
+	return result;
+}
+
 void GroupedAggregateHashTable::SkipLookups() {
 	skip_lookups = true;
 }
 
-void GroupedAggregateHashTable::Resize(idx_t size) {
+void GroupedAggregateHashTable::EnableHLL(bool enable) {
+	enable_hll = enable;
+}
+
+bool GroupedAggregateHashTable::HLLEnabled() const {
+	return enable_hll;
+}
+
+idx_t GroupedAggregateHashTable::GetHLLUpperBound() const {
+	D_ASSERT(enable_hll);
+	return LossyNumericCast<idx_t>((1 + HyperLogLog::GetErrorRate()) * static_cast<double>(hll.Count()));
+}
+
+void GroupedAggregateHashTable::Resize(idx_t size, bool leave_empty) {
 	D_ASSERT(size >= STANDARD_VECTOR_SIZE);
 	D_ASSERT(IsPowerOfTwo(size));
 	if (Count() != 0 && size < capacity) {
@@ -265,7 +286,7 @@ void GroupedAggregateHashTable::Resize(idx_t size) {
 	ClearPointerTable();
 	bitmask = capacity - 1;
 
-	if (Count() != 0) {
+	if (!leave_empty && Count() != 0) {
 		ReinsertTuples(*partitioned_data);
 		if (radix_bits >= UNPARTITIONED_RADIX_BITS_THRESHOLD) {
 			ReinsertTuples(*unpartitioned_data);
@@ -579,7 +600,7 @@ idx_t GroupedAggregateHashTable::FindOrCreateGroupsInternal(DataChunk &groups, V
 	const auto chunk_size = groups.size();
 	if (Count() + chunk_size > capacity || Count() + chunk_size > ResizeThreshold()) {
 		Verify();
-		Resize(capacity * 2);
+		Resize(capacity * 2, false);
 	}
 	D_ASSERT(capacity - Count() >= chunk_size); // we need to be able to fit at least one vector of data
 
@@ -599,6 +620,10 @@ idx_t GroupedAggregateHashTable::FindOrCreateGroupsInternal(DataChunk &groups, V
 
 	// convert all vectors to unified format
 	TupleDataCollection::ToUnifiedFormat(state.partitioned_append_state.chunk_state, state.group_chunk);
+
+	if (enable_hll) {
+		hll.Update(group_hashes_v, group_hashes_v, groups.size());
+	}
 
 	group_hashes_v.Flatten(chunk_size);
 	const auto hashes = FlatVector::GetData<hash_t>(group_hashes_v);

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -440,7 +440,7 @@ void DecideAdaptation(RadixHTGlobalSinkState &gstate, RadixHTLocalSinkState &lst
 		                                   RadixHTLocalSinkState::ADAPTIVITY_THRESHOLD);
 		lstate.local_sink_capacity = MaxValue(gstate.config.sink_capacity, new_capacity);
 		ht.Abandon();
-		ht.Resize(lstate.local_sink_capacity, true);
+		ht.Resize(lstate.local_sink_capacity);
 	}
 }
 
@@ -562,7 +562,7 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 		// We repartitioned, but we didn't clear the pointer table / reset the count because we're on 1 or 2 threads
 		ht.Abandon();
 		if (gstate.external) {
-			ht.Resize(lstate.local_sink_capacity, true);
+			ht.Resize(lstate.local_sink_capacity);
 		}
 	}
 

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -360,11 +360,19 @@ public:
 	//! Chunk with group columns
 	DataChunk group_chunk;
 
+	//! After seeing this many tuples, we decide whether to adapt our strategy
+	static constexpr idx_t ADAPTIVITY_THRESHOLD = 1048576;
+	//! Whether we have decided to adapt our strategy
+	bool adapted;
+	//! Sink capacity for this thread
+	idx_t local_sink_capacity;
+
 	//! Data that is abandoned ends up here (only if we're doing external aggregation)
 	unique_ptr<PartitionedTupleData> abandoned_data;
 };
 
-RadixHTLocalSinkState::RadixHTLocalSinkState(ClientContext &, const RadixPartitionedHashTable &radix_ht) {
+RadixHTLocalSinkState::RadixHTLocalSinkState(ClientContext &, const RadixPartitionedHashTable &radix_ht)
+    : adapted(false), local_sink_capacity(DConstants::INVALID_INDEX) {
 	// If there are no groups we create a fake group so everything has the same group
 	group_chunk.InitializeEmpty(radix_ht.group_types);
 	if (radix_ht.grouping_set.empty()) {
@@ -393,6 +401,46 @@ void RadixPartitionedHashTable::PopulateGroupChunk(DataChunk &group_chunk, DataC
 	}
 	group_chunk.SetCardinality(input_chunk.size());
 	group_chunk.Verify();
+}
+
+void DecideAdaptation(RadixHTGlobalSinkState &gstate, RadixHTLocalSinkState &lstate) {
+	//! If the number of unique values is greater than this percentage, we skip lookups altogether
+	static constexpr double SKIP_LOOKUP_UNIQUE_PERCENTAGE_THRESHOLD = 0.95;
+	//! If the deduplication rate could be increased by this number, we increase our sink capacity
+	static constexpr double CAPACITY_INCREASE_DEDUPLICATION_RATE_THRESHOLD = 2.0;
+
+	if (gstate.external) {
+		return; // Shouldn't adapt after this flag has been set
+	}
+
+	auto &ht = *lstate.ht;
+	const auto sink_count = ht.GetSinkCount();
+	D_ASSERT(sink_count >= RadixHTLocalSinkState::ADAPTIVITY_THRESHOLD);
+
+	// Deduplicated count (affected by HT size)
+	const auto deduplicated_count = ht.GetMaterializedCount();
+	// Estimated unique count (unaffected by HT size)
+	const auto hll_count = MinValue(ht.GetHLLUpperBound(), deduplicated_count);
+
+	// Compute actual deduplicated percentage and potential deduplicated count (estimated by hll)
+	const auto deduplicated_percentage = static_cast<double>(deduplicated_count) / static_cast<double>(sink_count);
+	const auto hll_percentage = static_cast<double>(hll_count) / static_cast<double>(sink_count);
+	if (hll_percentage > SKIP_LOOKUP_UNIQUE_PERCENTAGE_THRESHOLD) {
+		// Almost everything is unique, skip lookups, just append, defer deduplication to GetData phase
+		ht.SkipLookups();
+		return;
+	}
+
+	const auto potential_increase_rate = deduplicated_percentage / hll_percentage;
+	if (potential_increase_rate > CAPACITY_INCREASE_DEDUPLICATION_RATE_THRESHOLD) {
+		// We could be deduplicating a lot better, increase HT capacity
+		D_ASSERT(IsPowerOfTwo(RadixHTLocalSinkState::ADAPTIVITY_THRESHOLD));
+		const auto new_capacity = MinValue(GroupedAggregateHashTable::GetCapacityForCount(hll_count),
+		                                   RadixHTLocalSinkState::ADAPTIVITY_THRESHOLD);
+		lstate.local_sink_capacity = MaxValue(gstate.config.sink_capacity, new_capacity);
+		ht.Abandon();
+		ht.Resize(lstate.local_sink_capacity, true);
+	}
 }
 
 void MaybeRepartition(ClientContext &context, RadixHTGlobalSinkState &gstate, RadixHTLocalSinkState &lstate) {
@@ -447,7 +495,7 @@ void MaybeRepartition(ClientContext &context, RadixHTGlobalSinkState &gstate, Ra
 
 	const auto block_size = BufferManager::GetBufferManager(context).GetBlockSize();
 	const auto row_size_per_partition =
-	    ht.GetPartitionedData().Count() * ht.GetPartitionedData().GetLayout().GetRowWidth() / partition_count;
+	    ht.GetMaterializedCount() * ht.GetPartitionedData().GetLayout().GetRowWidth() / partition_count;
 	if (row_size_per_partition > LossyNumericCast<idx_t>(config.BLOCK_FILL_FACTOR * static_cast<double>(block_size))) {
 		// We crossed our block filling threshold, try to increment radix bits
 		config.SetRadixBits(current_radix_bits + config.REPARTITION_RADIX_BITS);
@@ -468,7 +516,15 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 	auto &gstate = input.global_state.Cast<RadixHTGlobalSinkState>();
 	auto &lstate = input.local_state.Cast<RadixHTLocalSinkState>();
 	if (!lstate.ht) {
-		lstate.ht = CreateHT(context.client, gstate.config.sink_capacity, gstate.config.GetRadixBits());
+		lstate.local_sink_capacity = gstate.config.sink_capacity;
+		lstate.ht = CreateHT(context.client, lstate.local_sink_capacity, gstate.config.GetRadixBits());
+		if (gstate.number_of_threads > RadixHTConfig::GROW_STRATEGY_THREAD_THRESHOLD) {
+			// Not using grow strategy, so we enable the HLL to potentially adapt later
+			lstate.ht->EnableHLL(true);
+		} else {
+			// Using grow strategy, so won't ever adapt
+			lstate.adapted = true;
+		}
 		gstate.active_threads++;
 	}
 
@@ -478,7 +534,14 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 	auto &ht = *lstate.ht;
 	ht.AddChunk(group_chunk, payload_input, filter);
 
-	if (ht.Count() + STANDARD_VECTOR_SIZE < GroupedAggregateHashTable::ResizeThreshold(gstate.config.sink_capacity)) {
+	// Decide whether we should adapt our strategy to the data
+	if (!lstate.adapted && lstate.ht->GetSinkCount() >= RadixHTLocalSinkState::ADAPTIVITY_THRESHOLD) {
+		DecideAdaptation(gstate, lstate);
+		ht.EnableHLL(false); // Can be disabled now (costs 5-10% performance in worst case, single column distinct)
+		lstate.adapted = true;
+	}
+
+	if (ht.Count() + STANDARD_VECTOR_SIZE < GroupedAggregateHashTable::ResizeThreshold(lstate.local_sink_capacity)) {
 		return; // We can fit another chunk
 	}
 
@@ -487,19 +550,6 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 		// This only works because we never resize the HT
 		// We don't do this when running with 1 or 2 threads, it only makes sense when there's many threads
 		ht.Abandon();
-
-		// Once we've inserted more than SKIP_LOOKUP_THRESHOLD tuples,
-		// and more than UNIQUE_PERCENTAGE_THRESHOLD were unique,
-		// we set the HT to skip doing lookups, which makes it blindly append data to the HT.
-		// This speeds up adding data, at the cost of no longer de-duplicating.
-		// The data will be de-duplicated later anyway
-		static constexpr idx_t SKIP_LOOKUP_THRESHOLD = 262144;
-		static constexpr double UNIQUE_PERCENTAGE_THRESHOLD = 0.95;
-		const auto unique_percentage =
-		    static_cast<double>(ht.GetPartitionedData().Count()) / static_cast<double>(ht.GetSinkCount());
-		if (ht.GetSinkCount() > SKIP_LOOKUP_THRESHOLD && unique_percentage > UNIQUE_PERCENTAGE_THRESHOLD) {
-			ht.SkipLookups();
-		}
 	}
 
 	// Check if we need to repartition
@@ -511,7 +561,7 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 		// We repartitioned, but we didn't clear the pointer table / reset the count because we're on 1 or 2 threads
 		ht.Abandon();
 		if (gstate.external) {
-			ht.Resize(gstate.config.sink_capacity);
+			ht.Resize(lstate.local_sink_capacity, true);
 		}
 	}
 

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -361,6 +361,7 @@ public:
 	DataChunk group_chunk;
 
 	//! After seeing this many tuples, we decide whether to adapt our strategy
+	//! This also serves as the maximum HT sink capacity
 	static constexpr idx_t ADAPTIVITY_THRESHOLD = 1048576;
 	//! Whether we have decided to adapt our strategy
 	bool adapted;

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/bit_utils.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/algorithm.hpp"
 
 namespace duckdb {
 
@@ -32,7 +33,7 @@ public:
 	static constexpr double ALPHA = 0.721347520444481703680; // 1 / (2 log(2))
 
 	static double GetErrorRate() {
-		return sqrt(PI / 2.0) / sqrt(M);
+		return std::sqrt(PI / 2.0) / sqrt(M);
 	}
 
 public:

--- a/src/include/duckdb/common/types/hyperloglog.hpp
+++ b/src/include/duckdb/common/types/hyperloglog.hpp
@@ -31,6 +31,10 @@ public:
 	static constexpr idx_t M = 1 << P;
 	static constexpr double ALPHA = 0.721347520444481703680; // 1 / (2 log(2))
 
+	static double GetErrorRate() {
+		return sqrt(PI / 2.0) / sqrt(M);
+	}
+
 public:
 	HyperLogLog() {
 		memset(k, 0, sizeof(k));

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/execution/ht_entry.hpp"
 #include "duckdb/storage/arena_allocator.hpp"
 #include "duckdb/common/row_operations/row_operations.hpp"
+#include "duckdb/common/types/hyperloglog.hpp"
 
 namespace duckdb {
 
@@ -98,17 +99,25 @@ public:
 	shared_ptr<ArenaAllocator> GetAggregateAllocator();
 
 	//! Resize the HT to the specified size. Must be larger than the current size.
-	void Resize(idx_t size);
+	void Resize(idx_t size, bool leave_empty);
 	//! Resets the pointer table of the HT to all 0's
 	void ClearPointerTable();
 	//! Set the radix bits for this HT
 	void SetRadixBits(idx_t radix_bits);
 	//! Get the radix bits for this HT
 	idx_t GetRadixBits() const;
-	//! Get the total amount of data sunk into this HT
+	//! Get the total number of tuples sunk into this HT
 	idx_t GetSinkCount() const;
+	//! Get the total number of tuples materialized currently in this HT
+	idx_t GetMaterializedCount() const;
 	//! Skips lookups from here on out
 	void SkipLookups();
+	//! Enable/disable HLL
+	void EnableHLL(bool enable);
+	//! Whether HLL is enabled
+	bool HLLEnabled() const;
+	//! Get HLL count
+	idx_t GetHLLUpperBound() const;
 
 	//! Executes the filter(if any) and update the aggregates
 	void Combine(GroupedAggregateHashTable &other);
@@ -186,6 +195,9 @@ private:
 
 		RowOperationsState row_state;
 	} state;
+
+	bool enable_hll;
+	HyperLogLog hll;
 
 private:
 	//! Disabled the copy constructor

--- a/src/include/duckdb/execution/aggregate_hashtable.hpp
+++ b/src/include/duckdb/execution/aggregate_hashtable.hpp
@@ -99,7 +99,7 @@ public:
 	shared_ptr<ArenaAllocator> GetAggregateAllocator();
 
 	//! Resize the HT to the specified size. Must be larger than the current size.
-	void Resize(idx_t size, bool leave_empty);
+	void Resize(idx_t size);
 	//! Resets the pointer table of the HT to all 0's
 	void ClearPointerTable();
 	//! Set the radix bits for this HT
@@ -169,6 +169,10 @@ private:
 	idx_t sink_count;
 	//! If true, we just append, skipping HT lookups
 	bool skip_lookups;
+	//! Whether to enable HLL counting the hashes
+	bool enable_hll;
+	//! The associated HLL
+	HyperLogLog hll;
 
 	//! The active arena allocator used by the aggregates for their internal state
 	shared_ptr<ArenaAllocator> aggregate_allocator;
@@ -195,9 +199,6 @@ private:
 
 		RowOperationsState row_state;
 	} state;
-
-	bool enable_hll;
-	HyperLogLog hll;
 
 private:
 	//! Disabled the copy constructor


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/4666 (a regression found internally)

We use tiny hash tables during thread-local pre-aggregation, which works great if data contains interesting orderings, and the same group keys appear in succession. However, when data is distributed uniformly, and there are more groups than fit in the tiny hash tables, we don't really deduplicate anything. For these distributions, increasing the size of the hash tables greatly improves performance.

Now, after ~1M rows have been ingested, we decide to increase the size of the thread-local hash table up to a maximum capacity of ~1M, if we detect that we could have been deduplicating data at more than twice the rate than we have been doing so far. These parameters can be tweaked, of course. I've set them based on some experiments on TPC-DS (mainly Q67 at SF100, which becomes ~2x faster with this optimization).