### PR TITLE
Dont try to load extension if storage type is already registered

### DIFF
--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -167,15 +167,21 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, 
 		DBPathAndType::CheckMagicBytes(fs, info.path, options.db_type);
 	}
 
-	// If we are loading a database type from an extension, then we need to check if that extension is loaded.
-	if (!options.db_type.empty()) {
-		if (!Catalog::TryAutoLoad(context, options.db_type)) {
-			// FIXME: Here it might be preferable to use an AutoLoadOrThrow kind of function
-			// so that either there will be success or a message to throw, and load will be
-			// attempted only once respecting the auto-loading options
-			ExtensionHelper::LoadExternalExtension(context, options.db_type);
-		}
+	if(options.db_type.empty()) {
 		return;
+	}
+
+	if(config.storage_extensions.find(options.db_type) != config.storage_extensions.end()) {
+		// If the database type is already registered, we don't need to load it again.
+		return;
+	}
+
+	// If we are loading a database type from an extension, then we need to check if that extension is loaded.
+	if (!Catalog::TryAutoLoad(context, options.db_type)) {
+		// FIXME: Here it might be preferable to use an AutoLoadOrThrow kind of function
+		// so that either there will be success or a message to throw, and load will be
+		// attempted only once respecting the auto-loading options
+		ExtensionHelper::LoadExternalExtension(context, options.db_type);
 	}
 }
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -167,11 +167,11 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, 
 		DBPathAndType::CheckMagicBytes(fs, info.path, options.db_type);
 	}
 
-	if(options.db_type.empty()) {
+	if (options.db_type.empty()) {
 		return;
 	}
 
-	if(config.storage_extensions.find(options.db_type) != config.storage_extensions.end()) {
+	if (config.storage_extensions.find(options.db_type) != config.storage_extensions.end()) {
 		// If the database type is already registered, we don't need to load it again.
 		return;
 	}


### PR DESCRIPTION
This fixes an issue that occurs when an extension provides a storage type that is not named the same as the extension. 

Even if the extension was loaded, we would still fall into the `ExtensionHelper::LoadExternalExtension` path and try to load an extension with the name of the storage type, throwing an error. Now we first check if a storage type with the target name has already been made available by a previously loaded extension.