### PR TITLE
Return invalid `BufferHandle` upon loading a destroyed `BlockHandle`

### DIFF
--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -366,6 +366,10 @@ BufferHandle StandardBufferManager::Pin(shared_ptr<BlockHandle> &handle) {
 			// now we can actually load the current block
 			D_ASSERT(handle->Readers() == 0);
 			buf = handle->Load(std::move(reusable_buffer));
+			if (!buf.IsValid()) {
+				reservation.Resize(0);
+				return buf; // Buffer was destroyed (e.g., due to DestroyBufferUpon::Eviction)
+			}
 			auto &memory_charge = handle->GetMemoryCharge(lock);
 			memory_charge = std::move(reservation);
 			// in the case of a variable sized block, the buffer may be smaller than a full block.


### PR DESCRIPTION
Blocks can be destroyed at any time if they are flagged with `DestroyBufferUpon::EVICTION` when they are not pinned. If we try to pin them later, they should return an invalid `BufferHandle` instead of running into an `InternalException`.

I found this myself while playing around when doing some Parquet joins with low memory settings.