### PR TITLE
Fix #17251: Eliminate duplicates after a set operation using set sema…

### DIFF
--- a/src/execution/physical_plan/plan_set_operation.cpp
+++ b/src/execution/physical_plan/plan_set_operation.cpp
@@ -101,19 +101,6 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
 		throw InternalException("Unexpected operator type for set operation");
 	}
 
-	// if the ALL specifier is not given, we have to ensure distinct results. Hence, push a GROUP BY ALL
-	if (!op.setop_all) { // no ALL, use distinct semantics
-		auto &types = result->GetTypes();
-		vector<unique_ptr<Expression>> groups, aggregates /* left empty */;
-		for (idx_t i = 0; i < types.size(); i++) {
-			groups.push_back(make_uniq<BoundReferenceExpression>(types[i], i));
-		}
-		auto &group_by = Make<PhysicalHashAggregate>(context, op.types, std::move(aggregates), std::move(groups),
-		                                             result->estimated_cardinality);
-		group_by.children.push_back(*result);
-		result = group_by;
-	}
-
 	D_ASSERT(result);
 	return *result;
 }

--- a/src/parser/transform/statement/transform_select_node.cpp
+++ b/src/parser/transform/statement/transform_select_node.cpp
@@ -154,6 +154,11 @@ unique_ptr<QueryNode> Transformer::TransformSelectInternal(duckdb_libpgquery::PG
 		default:
 			throw InternalException("Unexpected setop type");
 		}
+
+		if (!stmt.all) {
+			result.modifiers.push_back(make_uniq<DistinctModifier>());
+		}
+
 		if (stmt.sampleOptions) {
 			throw ParserException("SAMPLE clause is only allowed in regular SELECT statements");
 		}

--- a/test/sql/binder/test_duplicate_in_set_operation.test
+++ b/test/sql/binder/test_duplicate_in_set_operation.test
@@ -1,0 +1,47 @@
+# name: test/sql/binder/test_duplicate_set_operation.test
+# description: Test whether duplicate can be performed correctly in set operation
+# group: [binder]
+
+statement ok
+create table t1(col1 varchar collate nocase);
+
+statement ok
+create table t2(col1 varchar collate nocase);
+
+statement ok
+insert into t1 values ('a');
+
+statement ok
+insert into t2 values ('A');
+
+statement ok
+pragma enable_verification;
+
+query I
+select upper(col1)
+from (
+	select *
+	from t1
+	union
+	select *
+	from t2
+) d;
+----
+A
+
+
+statement ok
+pragma explain_output='physical_only';
+
+# Ensure that duplicate is performed correctly in the HASH_GROUP_BY operator
+query II
+explain select upper(col1)
+from (
+	select *
+	from t1
+	union
+	select *
+	from t2
+) d;
+----
+physical_plan	<REGEX>:.* Aggregates: .*\"first\"\(\#1\).*


### PR DESCRIPTION
Currently, the set operation using set semantics does not consider the impact of collation when eliminating duplicates. This can be fixed by adding a DistinctModifier in the transform process.

Fixes https://github.com/duckdb/duckdb/issues/17251
