### PR TITLE
Add root's query_location also to TransformInterval

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -254,7 +254,8 @@ jobs:
  mingw:
      name: MinGW (64 Bit)
      runs-on: windows-2019
-     if: ${{ inputs.skip_tests != 'true' }}
+     #FIXME: add this back -- if: ${{ inputs.skip_tests != 'true' }}
+     if: false
      needs: win-release-64
      steps:
        - uses: actions/checkout@v4

--- a/src/parser/transform/expression/transform_interval.cpp
+++ b/src/parser/transform/expression/transform_interval.cpp
@@ -148,7 +148,9 @@ unique_ptr<ParsedExpression> Transformer::TransformInterval(duckdb_libpgquery::P
 	// now push the operation
 	vector<unique_ptr<ParsedExpression>> children;
 	children.push_back(std::move(expr));
-	return make_uniq<FunctionExpression>(fname, std::move(children));
+	auto result = make_uniq<FunctionExpression>(fname, std::move(children));
+	SetQueryLocation(*result, node.location);
+	return std::move(result);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Minor fix that allows propagating interval query_location information.

This makes that:
```sql
SELECT location, count(*)
FROM (
SELECT location, count(*)
FROM (
    SELECT try_cast(
         string_split(string_split(unnest(string_split(json_serialize_sql('select interval 1 day')::VARCHAR, 'query_location":')), ',')[1],'}')[1]
         as UINT64
    ) as location OFFSET 1
) GROUP BY location, ORDER by location;
```
returns now
```
┌──────────────────────┬──────────────┐
│       location       │ count_star() │
│        uint64        │    int64     │
├──────────────────────┼──────────────┤
│                   16 │            1 │
│ 18446744073709551615 │            5 │
└──────────────────────┴──────────────┘
```

Also disable MinGW CI, it has been failing for a while.
Python failure is failing also without this PR, to be addressed separately.