### PR TITLE
Internal #4772: Timestamp Error Parameter

### DIFF
--- a/extension/icu/icu-timezone.cpp
+++ b/extension/icu/icu-timezone.cpp
@@ -165,8 +165,7 @@ struct ICUFromNaiveTimestamp : public ICUDateFunc {
 		}
 		if (input.context->config.disable_timestamptz_casts) {
 			throw BinderException("Casting from TIMESTAMP to TIMESTAMP WITH TIME ZONE without an explicit time zone "
-			                      "has been disabled  - use \"AT TIME ZONE ...\"",
-			                      LogicalTypeIdToString(source.id()));
+			                      "has been disabled  - use \"AT TIME ZONE ...\"");
 		}
 
 		auto cast_data = make_uniq<CastData>(make_uniq<BindData>(*input.context));


### PR DESCRIPTION
* Remove bogus extra parameter in the exception text.

fixes: duckdblabs/duckdb-internal#4772