### PR TITLE
Guess Parquet footer size

### DIFF
--- a/src/function/scalar/compressed_materialization/compress_integral.cpp
+++ b/src/function/scalar/compressed_materialization/compress_integral.cpp
@@ -46,7 +46,11 @@ static void IntegralCompressFunction(DataChunk &args, ExpressionState &state, Ve
 	    [&](const INPUT_TYPE &input) {
 		    return TemplatedIntegralCompress<INPUT_TYPE, RESULT_TYPE>::Operation(input, min_val);
 	    },
+#if defined(D_ASSERT_IS_ENABLED)
+	    FunctionErrors::CAN_THROW_RUNTIME_ERROR); // Can only throw a runtime error when assertions are enabled
+#else
 	    FunctionErrors::CANNOT_ERROR);
+#endif
 }
 
 template <class INPUT_TYPE, class RESULT_TYPE>

--- a/src/function/scalar/compressed_materialization/compress_string.cpp
+++ b/src/function/scalar/compressed_materialization/compress_string.cpp
@@ -69,8 +69,13 @@ inline uint8_t StringCompress(const string_t &input) {
 
 template <class RESULT_TYPE>
 static void StringCompressFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	UnaryExecutor::Execute<string_t, RESULT_TYPE>(args.data[0], result, args.size(), StringCompress<RESULT_TYPE>,
-	                                              FunctionErrors::CANNOT_ERROR);
+	UnaryExecutor::Execute<string_t, RESULT_TYPE>(
+	    args.data[0], result, args.size(), StringCompress<RESULT_TYPE>,
+#if defined(D_ASSERT_IS_ENABLED)
+	    FunctionErrors::CAN_THROW_RUNTIME_ERROR); // Can only throw a runtime error when assertions are enabled
+#else
+	    FunctionErrors::CANNOT_ERROR);
+#endif
 }
 
 template <class RESULT_TYPE>

--- a/src/include/duckdb/common/assert.hpp
+++ b/src/include/duckdb/common/assert.hpp
@@ -35,5 +35,6 @@ DUCKDB_API void DuckDBAssertInternal(bool condition, const char *condition_name,
 }
 
 #define D_ASSERT(condition) duckdb::DuckDBAssertInternal(bool(condition), #condition, __FILE__, __LINE__)
+#define D_ASSERT_IS_ENABLED
 
 #endif

--- a/src/include/duckdb/common/helper.hpp
+++ b/src/include/duckdb/common/helper.hpp
@@ -184,6 +184,12 @@ constexpr T MinValue(T a, T b) {
 	return a < b ? a : b;
 }
 
+//! Like std::clamp (C++17), returns v if within bounds, else nearest bound
+template <typename T>
+constexpr T ClampValue(T v, T min, T max) {
+	return MinValue(MaxValue(v, min), max);
+}
+
 template <typename T>
 T AbsValue(T a) {
 	return a < 0 ? -a : a;

--- a/test/parquet/parquet_long_string_stats.test
+++ b/test/parquet/parquet_long_string_stats.test
@@ -6,7 +6,7 @@ require httpfs
 
 require parquet
 
-# need to disable this otherwise we
+# need to disable this otherwise we just cache everything
 statement ok
 set enable_external_file_cache=false;
 
@@ -23,4 +23,4 @@ select count(*)
 FROM 'https://github.com/duckdb/duckdb-data/releases/download/v1.0/event_baserunning_advance_attempt.parquet'
 where game_id > 'WS2197109301';
 ----
-analyzed_plan	<REGEX>:.*2.0 KiB.*
+analyzed_plan	<REGEX>:.*GET: 1.*

--- a/test/sql/copy/parquet/parquet_glob_s3.test
+++ b/test/sql/copy/parquet/parquet_glob_s3.test
@@ -23,6 +23,12 @@ require-env DUCKDB_S3_USE_SSL
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 
+# this test was written before we implemented the external file cache
+# when it is enabled, the request counts are different
+# we disable it so this test still makes sense
+statement ok
+set enable_external_file_cache=false;
+
 # Copy files to S3 before beginning tests
 statement ok
 COPY (select * from 'data/parquet-testing/glob/t1.parquet') to 's3://test-bucket/parquet_glob_s3/glob/t1.parquet';

--- a/test/sql/copy/parquet/test_parquet_force_download.test
+++ b/test/sql/copy/parquet/test_parquet_force_download.test
@@ -31,7 +31,7 @@ SET force_download=false;
 query II
 explain analyze SELECT id, first_name, last_name, email FROM PARQUET_SCAN('https://raw.githubusercontent.com/duckdb/duckdb/main/data/parquet-testing/userdata1.parquet')
 ----
-analyzed_plan	<REGEX>:.*GET: 3.*
+analyzed_plan	<REGEX>:.*GET: 2.*
 
 query I
 SELECT count(*) FROM PARQUET_SCAN('https://raw.githubusercontent.com/duckdb/duckdb/main/data/parquet-testing/userdata1.parquet')

--- a/test/sql/copy/s3/metadata_cache.test
+++ b/test/sql/copy/s3/metadata_cache.test
@@ -23,6 +23,12 @@ require-env DUCKDB_S3_USE_SSL
 # override the default behaviour of skipping HTTP errors and connection failures: this test fails on connection issues
 set ignore_error_messages
 
+# this test was written before we implemented the external file cache
+# when it is enabled, the request counts are different
+# we disable it so this test still makes sense
+statement ok
+set enable_external_file_cache=false;
+
 statement ok
 CREATE TABLE test as SELECT * FROM range(0,10) tbl(i);
 

--- a/test/sql/storage/external_file_cache/external_file_cache_parquet.test_slow
+++ b/test/sql/storage/external_file_cache/external_file_cache_parquet.test_slow
@@ -31,11 +31,10 @@ create view lineitem as from '__TEST_DIR__/test_efc_lineitem.parquet';
 # otherwise, we run into problems with file systems with low time resolution for last modified time
 sleep 11 seconds
 
-# creating the view has loaded the last 8 bytes and the footer (separately, for now)
+# creating the view has loaded the footer
 query I
 select loaded from duckdb_external_file_cache() order by location;
 ----
-true
 true
 
 # select the first column
@@ -43,7 +42,7 @@ statement ok
 select l_orderkey from lineitem;
 
 query II
-select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where nr_bytes > 1000;
+select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where nr_bytes > 100000;
 ----
 23.0	true
 
@@ -52,7 +51,7 @@ statement ok
 select l_suppkey from lineitem;
 
 query II
-select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where nr_bytes > 1000 order by location;
+select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where nr_bytes > 100000 order by location;
 ----
 23.0	1
 10.0	1
@@ -62,7 +61,7 @@ statement ok
 select l_orderkey, l_partkey, l_suppkey, l_linenumber from lineitem;
 
 query II
-select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where nr_bytes > 1000 order by location;
+select round(nr_bytes / 1048576), loaded from duckdb_external_file_cache() where nr_bytes > 100000 order by location;
 ----
 47.0	1
 


### PR DESCRIPTION
... based on file size, when the file is remote.

Round trips to a remote file source are very expensive. When reading a Parquet file, we currently need 3 round trips to get the footer (one `HEAD`, one `GET` to read the footer size, and another `GET` to read the footer given that size). This PR implements guessing the footer size. If we're wrong, we end up with 3 round trips like before. If we're right, we only need 2 round trips.

We guess the Parquet footer size to be 1/1000th of the file size, and always between 16-256kb. We bound the guess to reduce the risk of causing unnecessary overhead. At these read sizes, there is virtually no noticeable penalty for guessing wrong, while potentially yielding a significant benefit.

The cost is incurred once per Parquet file. When reading many Parquet files at once with a glob pattern, this adds up. Typically, with such queries, the Parquet files are quite small, so we're targeting these kind of queries with this optimization. When reading large Parquet files, our guess might be wrong, but that's (probably) OK, since the extra round trip will likely be insignificant compared to the cost of reading that large Parquet file.

I've also taken the liberty to fix some of our `NightlyTest` CI run failures. I've added `set enable_external_file_cache=false;` to a few tests so that we get the expected number of `GET` requests again, and I've prevented some assertion failures in `CompressedMaterialization` that were caused by our dictionary expression executor by adding `FunctionErrors::CAN_THROW_RUNTIME_ERROR` when assertions are enabled.