### PR TITLE
Issue #16563: FLOAT to DECIMAL

### DIFF
--- a/src/common/operator/cast_operators.cpp
+++ b/src/common/operator/cast_operators.cpp
@@ -2316,7 +2316,8 @@ bool DoubleToDecimalCast(SRC input, DST &result, CastParameters &parameters, uin
 		HandleCastError::AssignError(error, parameters);
 		return false;
 	}
-	result = Cast::Operation<SRC, DST>(static_cast<SRC>(value));
+	// For some reason PG does not use statistical rounding here (even though it _does_ for integers...)
+	result = Cast::Operation<SRC, DST>(static_cast<SRC>(roundedValue));
 	return true;
 }
 

--- a/test/sql/cast/float_decimal_cast.test
+++ b/test/sql/cast/float_decimal_cast.test
@@ -1,0 +1,17 @@
+# name: test/sql/cast/float_decimal_cast.test
+# description: Rounding half up in float => decimal casts
+# group: [cast]
+
+statement ok
+PRAGMA enable_verification
+
+# PG does NOT use statistical ("Banker's") rounding for floating point => decimal
+
+foreach src FLOAT DOUBLE
+
+query II
+select 1.35::${src}::decimal(3, 1), 1.45::${src}::decimal(3, 1)
+----
+1.4	1.5
+
+endloop

--- a/test/sql/join/iejoin/iejoin_projection_maps.test
+++ b/test/sql/join/iejoin/iejoin_projection_maps.test
@@ -27,7 +27,7 @@ query IIIIII
 SELECT SUM(id) AS id, SUM(id2) AS id2, SUM(id3) AS id3, SUM(value) AS sum_value, SUM(one_min_value) AS sum_one_min_value, sum_value + sum_one_min_value AS sum
 FROM df
 ----
-252652	29774	17657	2497.951	2502.045	4999.996
+252652	29774	17657	2498.192	2502.191	5000.383
 
 statement ok
 PRAGMA enable_verification
@@ -37,6 +37,8 @@ foreach prefer False True
 
 statement ok
 PRAGMA prefer_range_joins=${prefer};
+
+# mode output_hash
 
 query I
 SELECT id2, id3, id3_right, sum(value * value_right) as value
@@ -51,7 +53,7 @@ FROM (
 GROUP BY ALL
 ORDER BY ALL
 ----
-660 values hashing to 787fff9f7e1d4749631eac7194d6ed44
+660 values hashing to fe2237dbeb18fe3400d5323bcab26dd2
 
 endloop
 


### PR DESCRIPTION
* Use half up rounding instead of statistical rounding for these casts
* Our double arithmetic for integral conversions still has some warts when values get large...