### PR TITLE
Refactor scripts/format.py

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -14,6 +14,9 @@ import uuid
 import concurrent.futures
 from python_helpers import open_utf8
 
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from format_test_benchmark import format_file_content
+
 try:
     ver = subprocess.check_output(('black', '--version'), text=True)
     if int(ver.split(' ')[1].split('.')[0]) < 24:
@@ -303,38 +306,15 @@ def get_formatted_text(f, full_path, directory, ext):
                 text += line
 
     if ext == '.test' or ext == '.test_slow' or ext == '.test_coverage' or ext == '.benchmark':
-        f = open_utf8(full_path, 'r')
-        lines = f.readlines()
-        f.close()
-
-        found_name = False
-        found_group = False
-        group_name = full_path.split('/')[-2]
-        new_path_line = '# name: ' + full_path + '\n'
-        new_group_line = '# group: [' + group_name + ']' + '\n'
-        found_diff = False
-        # Find description.
-        found_description = False
-        for line in lines:
-            if line.lower().startswith('# description:') or line.lower().startswith('#description:'):
-                if found_description:
-                    print("Error formatting file " + full_path + ", multiple lines starting with # description found")
-                    exit(1)
-                found_description = True
-                new_description_line = '# description: ' + line.split(':', 1)[1].strip() + '\n'
-        # Filter old meta.
-        meta = ['#name:', '# name:', '#description:', '# description:', '#group:', '# group:']
-        lines = [line for line in lines if not any(line.lower().startswith(m) for m in meta)]
-        # Clean up empty leading lines.
-        while lines and not lines[0].strip():
-            lines.pop(0)
-        # Ensure header is prepended.
-        header = [new_path_line]
-        if found_description:
-            header.append(new_description_line)
-        header.append(new_group_line)
-        header.append('\n')
-        return ''.join(header + lines)
+        # optimization: import and call the function directly
+        # instead of running a subprocess
+        with open(full_path, "r", encoding="utf-8") as f:
+            original_lines = f.readlines()
+        formatted, status = format_file_content(full_path, original_lines)
+        if formatted is None:
+            print(f"Failed to format {full_path}: {status}")
+            sys.exit(1)
+        return formatted
     proc_command = format_commands[ext].split(' ') + [full_path]
     proc = subprocess.Popen(
         proc_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=open(full_path) if ext == '.py' else None

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,335 +1,194 @@
-#!/usr/bin/python
-
-# this script is used to format the source directory
+#!/usr/bin/python3
 
 import os
-import time
-import sys
-import inspect
 import subprocess
-import difflib
-import re
-import tempfile
-import uuid
+import sys
+import argparse
 import concurrent.futures
-from python_helpers import open_utf8
+import difflib
+from pathlib import Path
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from format_test_benchmark import format_file_content
 
-try:
-    ver = subprocess.check_output(('black', '--version'), text=True)
-    if int(ver.split(' ')[1].split('.')[0]) < 24:
-        print('you need to run `pip install "black>=24"`', ver)
-        exit(-1)
-except Exception as e:
-    print('you need to run `pip install "black>=24"`', e)
-    exit(-1)
 
-try:
-    ver = subprocess.check_output(('clang-format', '--version'), text=True)
-    if '11.' not in ver:
-        print('you need to run `pip install clang_format==11.0.1 - `', ver)
-        exit(-1)
-except Exception as e:
-    print('you need to run `pip install clang_format==11.0.1 - `', e)
-    exit(-1)
-
-cpp_format_command = 'clang-format --sort-includes=0 -style=file'
-cmake_format_command = 'cmake-format'
-
-try:
-    subprocess.check_output(('cmake-format', '--version'), text=True)
-except Exception as e:
-    print('you need to run `pip install cmake-format`', e)
-    exit(-1)
-
-extensions = [
-    '.cpp',
-    '.ipp',
-    '.c',
-    '.hpp',
-    '.h',
-    '.cc',
-    '.hh',
-    'CMakeLists.txt',
-    '.test',
-    '.test_slow',
-    '.test_coverage',
-    '.benchmark',
-    '.py',
-    '.java',
-]
-formatted_directories = ['src', 'benchmark', 'test', 'tools', 'examples', 'extension', 'scripts']
-ignored_files = [
-    'tpch_constants.hpp',
-    'tpcds_constants.hpp',
-    '_generated',
-    'tpce_flat_input.hpp',
-    'test_csv_header.hpp',
-    'duckdb.cpp',
-    'duckdb.hpp',
-    'json.hpp',
-    'sqlite3.h',
-    'shell.c',
-    'termcolor.hpp',
-    'test_insert_invalid.test',
-    'httplib.hpp',
-    'os_win.c',
-    'glob.c',
-    'printf.c',
-    'helper.hpp',
-    'single_thread_ptr.hpp',
-    'types.hpp',
-    'default_views.cpp',
-    'default_functions.cpp',
-    'release.h',
-    'genrand.cpp',
-    'address.cpp',
-    'visualizer_constants.hpp',
-    'icu-collate.cpp',
-    'icu-collate.hpp',
-    'yyjson.cpp',
-    'yyjson.hpp',
-    'duckdb_pdqsort.hpp',
-    'stubdata.cpp',
-    'nf_calendar.cpp',
-    'nf_calendar.h',
-    'nf_localedata.cpp',
-    'nf_localedata.h',
-    'nf_zformat.cpp',
-    'nf_zformat.h',
-    'expr.cc',
-    'function_list.cpp',
-    'inlined_grammar.hpp',
-]
-ignored_directories = [
-    '.eggs',
-    '__pycache__',
-    'dbgen',
-    os.path.join('tools', 'pythonpkg', 'duckdb'),
-    os.path.join('tools', 'pythonpkg', 'build'),
-    os.path.join('tools', 'rpkg', 'src', 'duckdb'),
-    os.path.join('tools', 'rpkg', 'inst', 'include', 'cpp11'),
-    os.path.join('extension', 'tpcds', 'dsdgen'),
-    os.path.join('extension', 'jemalloc', 'jemalloc'),
-    os.path.join('extension', 'icu', 'third_party'),
-    os.path.join('tools', 'nodejs', 'src', 'duckdb'),
-]
-format_all = False
-check_only = True
-confirm = True
-silent = False
-force = False
-
-
-def print_usage():
-    print("Usage: python scripts/format.py [revision|--all] [--check|--fix] [--force]")
-    print(
-        "   [revision]     is an optional revision number, all files that changed since that revision will be formatted (default=HEAD)"
-    )
-    print("                  if [revision] is set to --all, all files will be formatted")
-    print("   --check only prints differences, --fix also fixes the files (--check is default)")
-    exit(1)
-
-
-if len(sys.argv) == 1:
-    revision = "HEAD"
-elif len(sys.argv) >= 2:
-    revision = sys.argv[1]
-else:
-    print_usage()
-
-if len(sys.argv) > 2:
-    for arg in sys.argv[2:]:
-        if arg == '--check':
-            check_only = True
-        elif arg == '--fix':
-            check_only = False
-        elif arg == '--noconfirm':
-            confirm = False
-        elif arg == '--confirm':
-            confirm = True
-        elif arg == '--silent':
-            silent = True
-        elif arg == '--force':
-            force = True
+# Check formatter versions
+def check_formatter_version(command, version_key, min_version, install_instruction):
+    try:
+        output = subprocess.check_output(command, text=True).strip()
+        # Extract version number for clang-format (e.g., "11.0.1" from "clang-format version 11.0.1...")
+        if command[0] == "clang-format":
+            version = output.split()[2].split(".")[0]
+        elif command[0] == "black":
+            version = output.split()[1].split(".")[0]
         else:
-            print_usage()
+            version = output.split()[0].split(".")[0]
+        version_key_mismatch = version_key is not None and version_key not in output
+        if version_key_mismatch or int(version) < min_version:
+            print(f"Please install {install_instruction}")
+            print(f"Required: {min_version}. Present: {version}")
+            sys.exit(1)
+    except Exception as e:
+        print(f"Please install {install_instruction}: {e}")
+        sys.exit(1)
 
-if revision == '--all':
-    format_all = True
+
+# Configuration
+EXTENSIONS = [
+    ".cpp",
+    ".ipp",
+    ".c",
+    ".hpp",
+    ".h",
+    ".cc",
+    ".hh",
+    "CMakeLists.txt",
+    ".test",
+    ".test_slow",
+    ".test_coverage",
+    ".benchmark",
+    ".py",
+    ".java",
+]
+FORMATTED_DIRECTORIES = [
+    "src",
+    "benchmark",
+    "test",
+    "tools",
+    "examples",
+    "extension",
+    "scripts",
+]
+IGNORED_FILES = {
+    "tpch_constants.hpp",
+    "tpcds_constants.hpp",
+    "_generated",
+    "tpce_flat_input.hpp",
+    "test_csv_header.hpp",
+    "duckdb.cpp",
+    "duckdb.hpp",
+    "json.hpp",
+    "sqlite3.h",
+    "shell.c",
+    "termcolor.hpp",
+    "test_insert_invalid.test",
+    "httplib.hpp",
+    "os_win.c",
+    "glob.c",
+    "printf.c",
+    "helper.hpp",
+    "single_thread_ptr.hpp",
+    "types.hpp",
+    "default_views.cpp",
+    "default_functions.cpp",
+    "release.h",
+    "genrand.cpp",
+    "address.cpp",
+    "visualizer_constants.hpp",
+    "icu-collate.cpp",
+    "icu-collate.hpp",
+    "yyjson.cpp",
+    "yyjson.hpp",
+    "duckdb_pdqsort.hpp",
+    "stubdata.cpp",
+    "nf_calendar.cpp",
+    "nf_calendar.h",
+    "nf_localedata.cpp",
+    "nf_localedata.h",
+    "nf_zformat.cpp",
+    "nf_zformat.h",
+    "expr.cc",
+    "function_list.cpp",
+    "inlined_grammar.hpp",
+}
+IGNORED_DIRECTORIES = [
+    ".eggs",
+    "__pycache__",
+    "dbgen",
+    "tools/pythonpkg/duckdb",
+    "tools/pythonpkg/build",
+    "tools/rpkg/src/duckdb",
+    "tools/rpkg/inst/include/cpp11",
+    "extension/tpcds/dsdgen",
+    "extension/jemalloc/jemalloc",
+    "extension/icu/third_party",
+    "tools/nodejs/src/duckdb",
+]
+
+CLANG_FORMAT = ["clang-format", "-i", "--sort-includes=0", "-style=file"]
+BLACK_FORMAT = ["black", "-q", "--skip-string-normalization", "--line-length", "120"]
+CMAKE_FORMAT = ["cmake-format", "-i"]
+TEST_FORMAT = ["./scripts/format_test_benchmark.py", "-i"]
+
+FORMAT_COMMANDS = {
+    ".cpp": CLANG_FORMAT,
+    ".ipp": CLANG_FORMAT,
+    ".c": CLANG_FORMAT,
+    ".hpp at": CLANG_FORMAT,
+    ".hpp": CLANG_FORMAT,
+    ".h": CLANG_FORMAT,
+    ".hh": CLANG_FORMAT,
+    ".cc": CLANG_FORMAT,
+    ".txt": CMAKE_FORMAT,
+    ".py": BLACK_FORMAT,
+    ".java": CLANG_FORMAT,
+    ".test": TEST_FORMAT,
+    ".test_slow": TEST_FORMAT,
+    ".test_coverage": TEST_FORMAT,
+    ".benchmark": TEST_FORMAT,
+}
 
 
+# Argument parsing
+def parse_args():
+    parser = argparse.ArgumentParser(description="Format source code files")
+    parser.add_argument(
+        "revision",
+        nargs="?",
+        default="HEAD",
+        help="Revision number to format all files (default: HEAD)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check formatting without modifying files (default)",
+    )
+    parser.add_argument("--all", action="store_true", help="Format all files")
+    parser.add_argument("--fix", action="store_true", help="Fix formatting issues in files")
+    parser.add_argument("--force", action="store_true", help="Format even non-standard files")
+    parser.add_argument("--silent", action="store_true", help="Suppress output of formatted files")
+    parser.add_argument("--noconfirm", action="store_true", help="Skip confirmation prompt for fixing")
+    return parser.parse_args()
+
+
+# File filtering
 def file_is_ignored(full_path):
-    if os.path.basename(full_path) in ignored_files:
-        return True
-    dirnames = os.path.sep.join(full_path.split(os.path.sep)[:-1])
-    for ignored_directory in ignored_directories:
-        if ignored_directory in dirnames:
-            return True
-    return False
+    path = Path(full_path)
+    return path.name in IGNORED_FILES or any(ignored in str(path.parent) for ignored in IGNORED_DIRECTORIES)
 
 
 def can_format_file(full_path):
-    global extensions, formatted_directories, ignored_files
-    if not os.path.isfile(full_path):
+    if not Path(full_path).is_file():
         return False
-    fname = full_path.split(os.path.sep)[-1]
-    found = False
-    # check file extension
-    for ext in extensions:
-        if full_path.endswith(ext):
-            found = True
-            break
-    if not found:
+    if not any(full_path.endswith(ext) for ext in EXTENSIONS):
         return False
-    # check ignored files
     if file_is_ignored(full_path):
         return False
-    # now check file directory
-    for dname in formatted_directories:
-        if full_path.startswith(dname):
-            return True
-    return False
+    return any(full_path.startswith(d) for d in FORMATTED_DIRECTORIES)
 
 
-action = "Formatting"
-if check_only:
-    action = "Checking"
-
-
+# File collection
 def get_changed_files(revision):
-    proc = subprocess.Popen(['git', 'diff', '--name-only', revision], stdout=subprocess.PIPE)
-    files = proc.stdout.read().decode('utf8').split('\n')
-    changed_files = []
-    for f in files:
-        if not can_format_file(f):
-            continue
-        if file_is_ignored(f):
-            continue
-        changed_files.append(f)
-    return changed_files
+    result = subprocess.run(["git", "diff", "--name-only", revision], capture_output=True, text=True)
+    return [f for f in result.stdout.splitlines() if can_format_file(f) and not file_is_ignored(f)]
 
 
-if os.path.isfile(revision):
-    print(action + " individual file: " + revision)
-    changed_files = [revision]
-elif os.path.isdir(revision):
-    print(action + " files in directory: " + revision)
-    changed_files = [os.path.join(revision, x) for x in os.listdir(revision)]
-
-    print("Changeset:")
-    for fname in changed_files:
-        print(fname)
-elif not format_all:
-    if revision == 'main':
-        # fetch new changes when comparing to the master
-        os.system("git fetch origin main:main")
-    print(action + " since branch or revision: " + revision)
-    changed_files = get_changed_files(revision)
-    if len(changed_files) == 0:
-        print("No changed files found!")
-        exit(0)
-
-    print("Changeset:")
-    for fname in changed_files:
-        print(fname)
-else:
-    print(action + " all files")
-
-if confirm and not check_only:
-    print("The files listed above will be reformatted.")
-    result = input("Continue with changes (y/n)?\n")
-    if result != 'y':
-        print("Aborting.")
-        exit(0)
-
-format_commands = {
-    '.cpp': cpp_format_command,
-    '.ipp': cpp_format_command,
-    '.c': cpp_format_command,
-    '.hpp': cpp_format_command,
-    '.h': cpp_format_command,
-    '.hh': cpp_format_command,
-    '.cc': cpp_format_command,
-    '.txt': cmake_format_command,
-    '.py': 'black --quiet - --skip-string-normalization --line-length 120 --stdin-filename',
-    '.java': cpp_format_command,
-}
-
-difference_files = []
-
-header_top = "//===----------------------------------------------------------------------===//\n"
-header_top += "//                         DuckDB\n" + "//\n"
-header_bottom = "//\n" + "//\n"
-header_bottom += "//===----------------------------------------------------------------------===//\n\n"
-base_dir = os.path.join(os.getcwd(), 'src/include')
-
-
-def get_formatted_text(f, full_path, directory, ext):
-    if not can_format_file(full_path):
-        if not force:
-            print(
-                "File "
-                + full_path
-                + " is not normally formatted - but attempted to format anyway. Use --force if formatting is desirable"
-            )
-            exit(1)
-    if f == 'list.hpp':
-        # fill in list file
-        file_list = [
-            os.path.join(dp, f)
-            for dp, dn, filenames in os.walk(directory)
-            for f in filenames
-            if os.path.splitext(f)[1] == '.hpp' and not f.endswith("list.hpp")
-        ]
-        file_list = [x.replace('src/include/', '') for x in file_list]
-        file_list.sort()
-        result = ""
-        for x in file_list:
-            result += '#include "%s"\n' % (x)
-        return result
-
-    if ext == ".hpp" and directory.startswith("src/include"):
-        with open_utf8(full_path, 'r') as f:
-            lines = f.readlines()
-
-        # format header in files
-        header_middle = "// " + os.path.relpath(full_path, base_dir) + "\n"
-        text = header_top + header_middle + header_bottom
-        is_old_header = True
-        for line in lines:
-            if not (line.startswith("//") or line.startswith("\n")) and is_old_header:
-                is_old_header = False
-            if not is_old_header:
-                text += line
-
-    if ext == '.test' or ext == '.test_slow' or ext == '.test_coverage' or ext == '.benchmark':
-        # optimization: import and call the function directly
-        # instead of running a subprocess
-        with open(full_path, "r", encoding="utf-8") as f:
-            original_lines = f.readlines()
-        formatted, status = format_file_content(full_path, original_lines)
-        if formatted is None:
-            print(f"Failed to format {full_path}: {status}")
-            sys.exit(1)
-        return formatted
-    proc_command = format_commands[ext].split(' ') + [full_path]
-    proc = subprocess.Popen(
-        proc_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=open(full_path) if ext == '.py' else None
-    )
-    new_text = proc.stdout.read().decode('utf8')
-    stderr = proc.stderr.read().decode('utf8')
-    if len(stderr) > 0:
-        print(os.getcwd())
-        print("Failed to format file " + full_path)
-        print(' '.join(proc_command))
-        print(stderr)
-        exit(1)
-    new_text = new_text.replace('\r', '')
-    new_text = re.sub(r'\n*$', '', new_text)
-    return new_text + '\n'
+def format_directory(directory):
+    files = []
+    for path in Path(directory).rglob("*"):
+        if path.is_file() and can_format_file(str(path)):
+            files.append(str(path))
+    return files
 
 
 def file_is_generated(text):
@@ -338,110 +197,136 @@ def file_is_generated(text):
     return False
 
 
-def format_file(f, full_path, directory, ext):
-    global difference_files
-    with open_utf8(full_path, 'r') as f:
-        old_text = f.read()
-    # do not format auto-generated files
-    if file_is_generated(old_text) and ext != '.py':
+# Formatting logic
+def format_file(full_path, check_only, force, silent):
+    ext = Path(full_path).suffix
+    if ext not in FORMAT_COMMANDS:
+        if not force:
+            print(f"File {full_path} is not normally formatted. Use --force to format.")
+            sys.exit(1)
         return
-    old_lines = old_text.split('\n')
 
-    new_text = get_formatted_text(f, full_path, directory, ext)
-    if ext in ('.cpp', '.hpp'):
-        new_text = new_text.replace('ARGS &&...args', 'ARGS &&... args')
-    if check_only:
-        new_lines = new_text.split('\n')
-        old_lines = [x for x in old_lines if '...' not in x]
-        new_lines = [x for x in new_lines if '...' not in x]
-        diff_result = difflib.unified_diff(old_lines, new_lines)
-        total_diff = ""
-        for diff_line in diff_result:
-            total_diff += diff_line + "\n"
-        total_diff = total_diff.strip()
-
-        if len(total_diff) > 0:
-            print("----------------------------------------")
-            print("----------------------------------------")
-            print("Found differences in file " + full_path)
-            print("----------------------------------------")
-            print("----------------------------------------")
-            print(total_diff)
-            difference_files.append(full_path)
-    else:
-        tmpfile = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
-        with open_utf8(tmpfile, 'w+') as f:
-            f.write(new_text)
-        os.rename(tmpfile, full_path)
-
-
-class ToFormatFile:
-    def __init__(self, filename, full_path, directory):
-        self.filename = filename
-        self.full_path = full_path
-        self.directory = directory
-        self.ext = '.' + filename.split('.')[-1]
-
-
-def format_directory(directory):
-    files = os.listdir(directory)
-    files.sort()
-    result = []
-    for f in files:
-        full_path = os.path.join(directory, f)
-        if os.path.isdir(full_path):
-            if f in ignored_directories or full_path in ignored_directories:
-                continue
-            result += format_directory(full_path)
-        elif can_format_file(full_path):
-            result += [ToFormatFile(f, full_path, directory)]
-    return result
-
-
-files = []
-if format_all:
-    try:
-        os.system(cmake_format_command.replace("${FILE}", "CMakeLists.txt"))
-    except:
-        pass
-
-    for direct in formatted_directories:
-        files += format_directory(direct)
-
-else:
-    for full_path in changed_files:
-        splits = full_path.split(os.path.sep)
-        fname = splits[-1]
-        dirname = os.path.sep.join(splits[:-1])
-        files.append(ToFormatFile(fname, full_path, dirname))
-
-
-def process_file(f):
     if not silent:
-        print(f.full_path)
-    format_file(f.filename, f.full_path, f.directory, f.ext)
+        print(full_path)
 
+    # Capture original and formatted content for diff
+    with open(full_path, "r", encoding="utf-8") as f:
+        original = f.read()
 
-# Create thread for each file
-with concurrent.futures.ThreadPoolExecutor() as executor:
-    try:
-        threads = [executor.submit(process_file, f) for f in files]
-        # Wait for all tasks to complete
-        concurrent.futures.wait(threads)
-    except KeyboardInterrupt:
-        executor.shutdown(wait=True, cancel_futures=True)
-        raise
+    # do not format auto-generated files
+    if file_is_generated(original) and ext != '.py':
+        return
 
-if check_only:
-    if len(difference_files) > 0:
-        print("")
-        print("")
-        print("")
-        print("Failed format-check: differences were found in the following files:")
-        for fname in difference_files:
-            print("- " + fname)
-        print('Run "make format-fix" to fix these differences automatically')
-        exit(1)
+    if check_only:
+        cmd = FORMAT_COMMANDS[ext]
+        if cmd == TEST_FORMAT:
+            # optimization: import and call the function directly
+            # instead of running a subprocess
+            with open(full_path, "r", encoding="utf-8") as f:
+                original_lines = f.readlines()
+            formatted, status = format_file_content(full_path, original_lines)
+            if formatted is None:
+                print(f"Failed to format {full_path}: {status}")
+                sys.exit(1)
+        else:
+            # Remove -i flag for check mode to avoid modifying the file
+            if "-i" in cmd:
+                cmd = [arg for arg in cmd if arg != "-i"]
+            cmd += "-"
+            process = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
+            formatted, stderr = process.communicate(input=original)
+            if stderr:
+                print(f"Failed to format {full_path}: {stderr}")
+                sys.exit(1)
+        if original != formatted:
+            print(f"Differences found in {full_path}:")
+            diff = difflib.unified_diff(
+                original.splitlines(), formatted.splitlines(), fromfile=full_path, tofile=full_path
+            )
+            # Process diff lines: join first 2 with "", rest with "\n"
+            diff_lines = list(diff)
+            if len(diff_lines) < 2:
+                diff_output = "".join(diff_lines)
+            else:
+                diff_output = "".join(diff_lines[:2]) + "\n".join(diff_lines[2:])
+            print(diff_output)
+            return full_path
     else:
+        # Format in-place
+        result = subprocess.run(FORMAT_COMMANDS[ext] + [full_path], capture_output=True, text=True)
+        if result.stderr:
+            print(f"Failed to format {full_path}: {result.stderr}")
+            sys.exit(1)
+    return None
+
+
+def main():
+    args = parse_args()
+    check_only = args.check or not args.fix
+    format_all = args.all
+
+    check_formatter_version(["clang-format", "--version"], "11.", 11, "`pip install clang-format==11.0.1`")
+    check_formatter_version(["black", "--version"], "black", 24, '`pip install "black>=24"`')
+    check_formatter_version(["cmake-format", "--version"], None, 0, "`pip install cmake-format`")
+    # Collect files to format
+    files = []
+    if Path(args.revision).is_file():
+        print(f"{'Checking' if check_only else 'Formatting'} individual file: {args.revision}")
+        files = [args.revision]
+    elif Path(args.revision).is_dir():
+        print(f"{'Checking' if check_only else 'Formatting'} files in directory: {args.revision}")
+        files = [str(p) for p in Path(args.revision).iterdir() if p.is_file()]
+    elif format_all:
+        print(f"{'Checking' if check_only else 'Formatting'} all files")
+        for d in FORMATTED_DIRECTORIES:
+            files.extend(format_directory(d))
+    else:
+        if args.revision == "main":
+            subprocess.run(["git", "fetch", "origin", "main:main"], check=True)
+        print(f"{'Checking' if check_only else 'Formatting'} since branch or revision: {args.revision}")
+        files = get_changed_files(args.revision)
+
+    if not files:
+        print("No files to format!")
+        sys.exit(0)
+
+    print("Files to process:")
+    for f in files:
+        print(f)
+
+    # Confirm before fixing
+    if not check_only and not args.noconfirm:
+        if input("Continue with changes (y/n)? ").lower() != "y":
+            print("Aborting.")
+            sys.exit(0)
+
+    # Process files in parallel
+    difference_files = []
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        try:
+            futures = [executor.submit(format_file, f, check_only, args.force, args.silent) for f in files]
+            for future in concurrent.futures.as_completed(futures):
+                result = future.result()
+                if result:
+                    difference_files.append(result)
+        except KeyboardInterrupt:
+            executor.shutdown(wait=True, cancel_futures=True)
+            raise
+
+    # Report results
+    if check_only and difference_files:
+        print("\nFailed format-check: differences found in the following files:")
+        for f in difference_files:
+            print(f"- {f}")
+        print('Run "python scripts/format.py --fix" to fix these differences.')
+        sys.exit(1)
+    elif check_only:
         print("Passed format-check")
-        exit(0)
+    else:
+        print("Formatting complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/format_test_benchmark.py
+++ b/scripts/format_test_benchmark.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def open_utf8(file_path, mode):
+    """Open a file with UTF-8 encoding."""
+    return open(file_path, mode, encoding='utf-8')
+
+
+def format_file_content(full_path, lines):
+    """Format the content of lines according to the specified logic."""
+    ext = os.path.splitext(full_path)[1] if full_path != '-' else '.test'  # Assume .test for stdin
+    if ext not in {'.test', '.test_slow', '.test_coverage', '.benchmark'}:
+        return None, 0
+
+    # Extract group name (use 'unknown' for stdin if no full_path, else derive from path)
+    group_name = Path(full_path).parent.name if full_path != '-' else 'unknown'
+    new_path_line = f'# name: {full_path}\n'
+    new_group_line = f'# group: [{group_name}]\n'
+
+    # Find description
+    found_description = False
+    new_description_line = None
+    for line in lines:
+        if line.lower().startswith(('# description:', '#description:')):
+            if found_description:
+                print(
+                    f"Error formatting file {full_path}, multiple lines starting with # description found",
+                    file=sys.stderr,
+                )
+                return None, 1
+            found_description = True
+            new_description_line = f'# description: {line.split(":", 1)[1].strip()}\n'
+
+    # Filter out old metadata lines
+    meta = ['#name:', '# name:', '#description:', '# description:', '#group:', '# group:']
+    lines = [line for line in lines if not any(line.lower().startswith(m) for m in meta)]
+
+    # Clean up empty leading lines
+    while lines and not lines[0].strip():
+        lines.pop(0)
+
+    # Construct header
+    header = [new_path_line]
+    if found_description:
+        header.append(new_description_line)
+    header.append(new_group_line)
+    header.append('\n')
+
+    # Return formatted content
+    return ''.join(header + lines), 0
+
+
+def process_file(file_path, inplace, full_path=None):
+    """Process a single file or stdin, either in-place or to stdout."""
+    effective_path = full_path if file_path == '-' and full_path else file_path
+    effective_path = effective_path.strip()
+
+    if file_path == '-':
+        if inplace:
+            print("Error: -i cannot be used with stdin", file=sys.stderr)
+            return 1
+        lines = sys.stdin.readlines()
+        formatted_content, status = format_file_content(effective_path, lines)
+        if formatted_content is not None:
+            sys.stdout.write(formatted_content)
+        return status
+
+    if not os.path.isfile(file_path):
+        print(f"Error: {file_path} is not a file", file=sys.stderr)
+        return 1
+
+    with open_utf8(file_path, 'r') as f:
+        lines = f.readlines()
+
+    formatted_content, status = format_file_content(effective_path, lines)
+    if formatted_content is None:
+        return status
+
+    if inplace:
+        with open_utf8(file_path, 'w') as f:
+            f.write(formatted_content)
+    else:
+        sys.stdout.write(formatted_content)
+
+    return status
+
+
+def main():
+    """Main function to handle command-line arguments and process files."""
+    parser = argparse.ArgumentParser(description='Format test files with standardized metadata headers.')
+    parser.add_argument('files', nargs='+', help='Files to format (use - for stdin)')
+    parser.add_argument('-i', '--inplace', action='store_true', help='Edit files in place')
+    parser.add_argument('-f', '--full-path', help='Full path to use for stdin (only with -)')
+    args = parser.parse_args()
+
+    # Validate full-path usage
+    if args.full_path and '-' not in args.files:
+        print("Error: -f/--full-path can only be used with stdin (-)", file=sys.stderr)
+        sys.exit(1)
+    if args.full_path and len(args.files) > 1:
+        print("Error: -f/--full-path cannot be used with multiple files", file=sys.stderr)
+        sys.exit(1)
+
+    exit_code = 0
+    for file_path in args.files:
+        status = process_file(file_path, args.inplace, args.full_path)
+        exit_code = max(exit_code, status)
+
+    sys.exit(exit_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_extensions_function.py
+++ b/scripts/generate_extensions_function.py
@@ -901,7 +901,8 @@ static constexpr const char *AUTOLOADABLE_EXTENSIONS[] = {
     "ui"
 }; // END_OF_AUTOLOADABLE_EXTENSIONS
 
-} // namespace duckdb"""
+} // namespace duckdb
+"""
 
     data.verify_export()
 

--- a/src/common/radix_partitioning.cpp
+++ b/src/common/radix_partitioning.cpp
@@ -25,7 +25,7 @@ public:
 };
 
 template <class OP, class RETURN_TYPE, typename... ARGS>
-RETURN_TYPE RadixBitsSwitch(const idx_t radix_bits, ARGS &&... args) {
+RETURN_TYPE RadixBitsSwitch(const idx_t radix_bits, ARGS &&...args) {
 	D_ASSERT(radix_bits <= RadixPartitioning::MAX_RADIX_BITS);
 	switch (radix_bits) {
 	case 0:

--- a/src/include/duckdb/common/allocator.hpp
+++ b/src/include/duckdb/common/allocator.hpp
@@ -145,7 +145,7 @@ void DeleteArray(T *ptr, idx_t size) {
 }
 
 template <typename T, typename... ARGS>
-T *AllocateObject(ARGS &&... args) {
+T *AllocateObject(ARGS &&...args) {
 	auto data = Allocator::DefaultAllocator().AllocateData(sizeof(T));
 	return new (data) T(std::forward<ARGS>(args)...);
 }

--- a/src/include/duckdb/execution/physical_plan_generator.hpp
+++ b/src/include/duckdb/execution/physical_plan_generator.hpp
@@ -35,7 +35,7 @@ public:
 
 public:
 	template <class T, class... ARGS>
-	PhysicalOperator &Make(ARGS &&... args) {
+	PhysicalOperator &Make(ARGS &&...args) {
 		static_assert(std::is_base_of<PhysicalOperator, T>::value, "T must be a physical operator");
 		auto mem = arena.AllocateAligned(sizeof(T));
 		auto ptr = new (mem) T(std::forward<ARGS>(args)...);
@@ -91,7 +91,7 @@ public:
 	static OrderPreservationType OrderPreservationRecursive(PhysicalOperator &op);
 
 	template <class T, class... ARGS>
-	PhysicalOperator &Make(ARGS &&... args) {
+	PhysicalOperator &Make(ARGS &&...args) {
 		return physical_plan->Make<T>(std::forward<ARGS>(args)...);
 	}
 

--- a/src/include/duckdb/main/client_context_state.hpp
+++ b/src/include/duckdb/main/client_context_state.hpp
@@ -111,7 +111,7 @@ public:
 class RegisteredStateManager {
 public:
 	template <class T, typename... ARGS>
-	shared_ptr<T> GetOrCreate(const string &key, ARGS &&... args) {
+	shared_ptr<T> GetOrCreate(const string &key, ARGS &&...args) {
 		lock_guard<mutex> l(lock);
 		auto lookup = registered_state.find(key);
 		if (lookup != registered_state.end()) {

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -47,7 +47,7 @@ public:
 	}
 
 	template <class T, class... ARGS>
-	shared_ptr<T> GetOrCreate(const string &key, ARGS &&... args) {
+	shared_ptr<T> GetOrCreate(const string &key, ARGS &&...args) {
 		lock_guard<mutex> glock(lock);
 
 		auto entry = cache.find(key);

--- a/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pybind11/pybind_wrapper.hpp
@@ -90,7 +90,7 @@ bool try_cast(const handle &object, T &result) {
 } // namespace py
 
 template <class T, typename... ARGS>
-void DefineMethod(std::vector<const char *> aliases, T &mod, ARGS &&... args) {
+void DefineMethod(std::vector<const char *> aliases, T &mod, ARGS &&...args) {
 	for (auto &alias : aliases) {
 		mod.def(alias, args...);
 	}


### PR DESCRIPTION
The current format.py creates a temp file, formats it and attempts to rename.
However, `os.rename()` can fail if the src and target are on different filesystems.

An exception is thrown, but the paralllel formatting mechanism doesn't report it to the user.

Fixed by using in-place formatting.

Also uses argparse for argument parsing.

Test plan:

```
make format-check
make format-fix
```

For each of the file types, make small format changes. Then test with --check and --fix.