### PR TITLE
Generating random data for mbedtls without key

### DIFF
--- a/third_party/mbedtls/include/mbedtls_wrapper.hpp
+++ b/third_party/mbedtls/include/mbedtls_wrapper.hpp
@@ -70,6 +70,7 @@ class AESStateMBEDTLS : public duckdb::EncryptionState {
 		                          duckdb::idx_t out_len) override;
 		DUCKDB_API size_t Finalize(duckdb::data_ptr_t out, duckdb::idx_t out_len, duckdb::data_ptr_t tag, duckdb::idx_t tag_len) override;
 
+		DUCKDB_API static void GenerateRandomDataStatic(duckdb::data_ptr_t data, duckdb::idx_t len);
 		DUCKDB_API void GenerateRandomData(duckdb::data_ptr_t data, duckdb::idx_t len) override;
 		DUCKDB_API void FinalizeGCM(duckdb::data_ptr_t tag, duckdb::idx_t tag_len);
 		DUCKDB_API const mbedtls_cipher_info_t *GetCipher(size_t key_len);

--- a/third_party/mbedtls/mbedtls_wrapper.cpp
+++ b/third_party/mbedtls/mbedtls_wrapper.cpp
@@ -255,7 +255,7 @@ MbedTlsWrapper::AESStateMBEDTLS::~AESStateMBEDTLS() {
 	}
 }
 
-void MbedTlsWrapper::AESStateMBEDTLS::GenerateRandomData(duckdb::data_ptr_t data, duckdb::idx_t len) {
+void MbedTlsWrapper::AESStateMBEDTLS::GenerateRandomDataStatic(duckdb::data_ptr_t data, duckdb::idx_t len) {
 	duckdb::RandomEngine random_engine(duckdb::Timestamp::GetCurrentTimestamp().value);
 	while (len != 0) {
 		const auto random_integer = random_engine.NextRandomInteger();
@@ -264,6 +264,11 @@ void MbedTlsWrapper::AESStateMBEDTLS::GenerateRandomData(duckdb::data_ptr_t data
 		data += next;
 		len -= next;
 	}
+}
+
+
+void MbedTlsWrapper::AESStateMBEDTLS::GenerateRandomData(duckdb::data_ptr_t data, duckdb::idx_t len) {
+	GenerateRandomDataStatic(data, len);
 }
 
 void MbedTlsWrapper::AESStateMBEDTLS::InitializeEncryption(duckdb::const_data_ptr_t iv, duckdb::idx_t iv_len, const std::string *key) {

--- a/third_party/thrift/thrift/transport/TTransport.h
+++ b/third_party/thrift/thrift/transport/TTransport.h
@@ -23,6 +23,7 @@
 #include "thrift/Thrift.h"
 #include "thrift/transport/TTransportException.h"
 #include <memory>
+#include <cstdint>
 #include <string>
 
 namespace duckdb_apache {


### PR DESCRIPTION
For generating random data with mbedtls we don't actually need to initialise an AES state, which means we also do not need a key. However, now, we require to initialise an encryption state, and if no proper key is given this throws an error.

This PR fixes this behaviour by making a static generate random data function that can be called independently of the mbedtls AES state.