### PR TITLE
take the column ids from the logical get, don't require a LogicalGet …

### DIFF
--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -53,7 +53,7 @@ public:
 
 	void GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback);
 	bool HasFilters();
-	TableFilterSet GenerateTableScanFilters(const LogicalGet &get, vector<FilterPushdownResult> &pushdown_results);
+	TableFilterSet GenerateTableScanFilters(const vector<ColumnIndex> &column_ids, vector<FilterPushdownResult> &pushdown_results);
 
 	FilterPushdownResult TryPushdownGenericExpression(LogicalGet &get, Expression &expr);
 
@@ -68,8 +68,7 @@ private:
 
 	FilterPushdownResult TryPushdownConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                               column_t column_id, vector<ExpressionValueInformation> &info_list);
-	FilterPushdownResult TryPushdownExpression(const LogicalGet &get, TableFilterSet &table_filters,
-	                                           const vector<ColumnIndex> &column_ids, Expression &expr);
+	FilterPushdownResult TryPushdownExpression(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids, Expression &expr);
 	FilterPushdownResult TryPushdownPrefixFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                             Expression &expr);
 	FilterPushdownResult TryPushdownLikeFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,

--- a/src/include/duckdb/optimizer/filter_combiner.hpp
+++ b/src/include/duckdb/optimizer/filter_combiner.hpp
@@ -53,7 +53,8 @@ public:
 
 	void GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback);
 	bool HasFilters();
-	TableFilterSet GenerateTableScanFilters(const vector<ColumnIndex> &column_ids, vector<FilterPushdownResult> &pushdown_results);
+	TableFilterSet GenerateTableScanFilters(const vector<ColumnIndex> &column_ids,
+	                                        vector<FilterPushdownResult> &pushdown_results);
 
 	FilterPushdownResult TryPushdownGenericExpression(LogicalGet &get, Expression &expr);
 
@@ -68,7 +69,8 @@ private:
 
 	FilterPushdownResult TryPushdownConstantFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                               column_t column_id, vector<ExpressionValueInformation> &info_list);
-	FilterPushdownResult TryPushdownExpression(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids, Expression &expr);
+	FilterPushdownResult TryPushdownExpression(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
+	                                           Expression &expr);
 	FilterPushdownResult TryPushdownPrefixFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,
 	                                             Expression &expr);
 	FilterPushdownResult TryPushdownLikeFilter(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids,

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -603,8 +603,7 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }
 
-FilterPushdownResult FilterCombiner::TryPushdownExpression(const LogicalGet &get, TableFilterSet &table_filters,
-                                                           const vector<ColumnIndex> &column_ids, Expression &expr) {
+FilterPushdownResult FilterCombiner::TryPushdownExpression(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids, Expression &expr) {
 	auto pushdown_result = TryPushdownPrefixFilter(table_filters, column_ids, expr);
 	if (pushdown_result != FilterPushdownResult::NO_PUSHDOWN) {
 		return pushdown_result;
@@ -624,10 +623,8 @@ FilterPushdownResult FilterCombiner::TryPushdownExpression(const LogicalGet &get
 	return FilterPushdownResult::NO_PUSHDOWN;
 }
 
-TableFilterSet FilterCombiner::GenerateTableScanFilters(const LogicalGet &get,
-                                                        vector<FilterPushdownResult> &pushdown_results) {
+TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex> &column_ids, vector<FilterPushdownResult> &pushdown_results) {
 	TableFilterSet table_filters;
-	auto &column_ids = get.GetColumnIds();
 	//! First, we figure the filters that have constant expressions that we can push down to the table scan
 	for (auto &constant_value : constant_values) {
 		auto expr_id = constant_value.first;
@@ -637,7 +634,7 @@ TableFilterSet FilterCombiner::GenerateTableScanFilters(const LogicalGet &get,
 	//! Here we look for LIKE or IN filters
 	for (idx_t rem_fil_idx = 0; rem_fil_idx < remaining_filters.size(); rem_fil_idx++) {
 		auto &remaining_filter = remaining_filters[rem_fil_idx];
-		auto pushdown_result = TryPushdownExpression(get, table_filters, column_ids, *remaining_filter);
+		auto pushdown_result = TryPushdownExpression(table_filters, column_ids, *remaining_filter);
 		if (pushdown_result == FilterPushdownResult::PUSHED_DOWN_FULLY) {
 			// the filter has been pushed down entirely - we can prune it
 			remaining_filters.erase_at(rem_fil_idx--);

--- a/src/optimizer/filter_combiner.cpp
+++ b/src/optimizer/filter_combiner.cpp
@@ -603,7 +603,8 @@ FilterPushdownResult FilterCombiner::TryPushdownOrClause(TableFilterSet &table_f
 	return FilterPushdownResult::PUSHED_DOWN_PARTIALLY;
 }
 
-FilterPushdownResult FilterCombiner::TryPushdownExpression(TableFilterSet &table_filters, const vector<ColumnIndex> &column_ids, Expression &expr) {
+FilterPushdownResult FilterCombiner::TryPushdownExpression(TableFilterSet &table_filters,
+                                                           const vector<ColumnIndex> &column_ids, Expression &expr) {
 	auto pushdown_result = TryPushdownPrefixFilter(table_filters, column_ids, expr);
 	if (pushdown_result != FilterPushdownResult::NO_PUSHDOWN) {
 		return pushdown_result;
@@ -623,7 +624,8 @@ FilterPushdownResult FilterCombiner::TryPushdownExpression(TableFilterSet &table
 	return FilterPushdownResult::NO_PUSHDOWN;
 }
 
-TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex> &column_ids, vector<FilterPushdownResult> &pushdown_results) {
+TableFilterSet FilterCombiner::GenerateTableScanFilters(const vector<ColumnIndex> &column_ids,
+                                                        vector<FilterPushdownResult> &pushdown_results) {
 	TableFilterSet table_filters;
 	//! First, we figure the filters that have constant expressions that we can push down to the table scan
 	for (auto &constant_value : constant_values) {

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -52,7 +52,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 
 	//! We generate the table filters that will be executed during the table scan
 	vector<FilterPushdownResult> pushdown_results;
-	get.table_filters = combiner.GenerateTableScanFilters(get, pushdown_results);
+	get.table_filters = combiner.GenerateTableScanFilters(get.GetColumnIds(), pushdown_results);
 
 	GenerateFilters();
 


### PR DESCRIPTION
This PR is a follow up to #17213 

The prototype of the `GenerateTableScanFilters` changed in a way that made it too restrictive to be adapted to by users of the old version.

In both Delta and Iceberg we rely on this method for the `ComplexFilterPushdown`
(I've also removed the `LogicalGet &` from the `TryPushdownExpression` as it was not used entirely there)