### PR TITLE
Allow installing extensions with external access allowlist

### DIFF
--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -156,6 +156,8 @@ public:
 	DUCKDB_API virtual bool DirectoryExists(const string &directory, optional_ptr<FileOpener> opener = nullptr);
 	//! Create a directory if it does not exist
 	DUCKDB_API virtual void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr);
+	//! Helper function that uses DirectoryExists and CreateDirectory to ensure all directories in path are created
+	DUCKDB_API virtual void CreateDirectoriesRecursive(const string &path, optional_ptr<FileOpener> opener = nullptr);
 	//! Recursively remove a directory and all files in it
 	DUCKDB_API virtual void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr);
 

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -118,19 +118,7 @@ string ExtensionHelper::ExtensionDirectory(DatabaseInstance &db, FileSystem &fs)
 	string extension_directory = GetExtensionDirectoryPath(db, fs);
 	{
 		if (!fs.DirectoryExists(extension_directory)) {
-			auto sep = fs.PathSeparator(extension_directory);
-			auto splits = StringUtil::Split(extension_directory, sep);
-			D_ASSERT(!splits.empty());
-			string extension_directory_prefix;
-			if (StringUtil::StartsWith(extension_directory, sep)) {
-				extension_directory_prefix = sep; // this is swallowed by Split otherwise
-			}
-			for (auto &split : splits) {
-				extension_directory_prefix = extension_directory_prefix + split + sep;
-				if (!fs.DirectoryExists(extension_directory_prefix)) {
-					fs.CreateDirectory(extension_directory_prefix);
-				}
-			}
+			fs.CreateDirectoriesRecursive(extension_directory);
 		}
 	}
 	D_ASSERT(fs.DirectoryExists(extension_directory));
@@ -560,9 +548,6 @@ ExtensionHelper::InstallExtensionInternal(DatabaseInstance &db, FileSystem &fs, 
 #ifdef DUCKDB_DISABLE_EXTENSION_LOAD
 	throw PermissionException("Installing external extensions is disabled through a compile time flag");
 #else
-	if (!db.config.options.enable_external_access) {
-		throw PermissionException("Installing extensions is disabled through configuration");
-	}
 
 	auto extension_name = ApplyExtensionAlias(fs.ExtractBaseName(extension));
 	string local_extension_path = fs.JoinPath(local_path, extension_name + ".duckdb_extension");

--- a/test/sql/extensions/allowed_directories_install.test
+++ b/test/sql/extensions/allowed_directories_install.test
@@ -1,0 +1,28 @@
+# name: test/sql/extensions/allowed_directories_install.test
+# description: Test extension installation with allowed_directories setting
+# group: [extensions]
+
+statement ok
+set extension_directory='__TEST_DIR__/extension_dir'
+
+statement ok
+SET allowed_directories=['__TEST_DIR__', 'http://', 'https://'];
+
+statement ok
+SET enable_external_access=false;
+
+# error messsage `Failed to download extension` means duckdb
+statement error
+INSTALL bogus FROM 'http://not.existent';
+----
+Failed to download extension
+
+# now switch the extension directory to one that is not in the allowed_directories list
+statement ok
+set extension_directory='/tmp'
+
+# duckdb will throw permission error because /tmp is not allowed
+statement error
+INSTALL bogus FROM 'http://not.existent';
+----
+Permission Error: Cannot access directory


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/14568 added a mechanism to add certain files and dirs to an allowlist to allow some IO even when `enable_external_access` is false.

This PR aims to extend that to also allow installing extensions.

With this PR you can:
```SQL
SET extension_directory= 'my_extension_dir';
SET allowed_directories=['my_extension_dir', 'http://', 'https://'];
SET enable_external_access=false;
install my_ext;
```

Note that when using absolute paths EITHER the extension directory needs to exists already OR the allowed directories should contain the path to the parent dir of the extension dir. This is because to create the extension directory, `FileSystem::DirectoryExists` needs to be called on the directory in which the extension directory will sit. So for example:

```SET extension_directory= '/some/path/to/extensions';```
where `/some/path/to/extensions` does not exists yet will only work with:
```
SET allowed_directories=['/some/path/to', 'http://', 'https://'];
```