### PR TITLE
Fix #17311: correctly check for presence of recursive keys in transformer

### DIFF
--- a/src/parser/transform/helpers/transform_cte.cpp
+++ b/src/parser/transform/helpers/transform_cte.cpp
@@ -45,10 +45,11 @@ void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause &de_with_clause, 
 		auto info = make_uniq<CommonTableExpressionInfo>();
 
 		auto &cte = *PGPointerCast<duckdb_libpgquery::PGCommonTableExpr>(cte_ele->data.ptr_value);
-
-		auto key_target = PGPointerCast<duckdb_libpgquery::PGNode>(cte.recursive_keys->head->data.ptr_value);
-		if (key_target) {
-			TransformExpressionList(*cte.recursive_keys, info->key_targets);
+		if (cte.recursive_keys) {
+			auto key_target = PGPointerCast<duckdb_libpgquery::PGNode>(cte.recursive_keys->head->data.ptr_value);
+			if (key_target) {
+				TransformExpressionList(*cte.recursive_keys, info->key_targets);
+			}
 		}
 
 		if (cte.aliascolnames) {

--- a/test/sql/cte/cte_issue_17311.test
+++ b/test/sql/cte/cte_issue_17311.test
@@ -1,0 +1,21 @@
+# name: test/sql/cte/cte_issue_17311.test
+# description: Test for CTE issue #17311
+# group: [cte]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE RECURSIVE VIEW nums (n) AS
+    VALUES (1)
+UNION ALL
+    SELECT n+1 FROM nums WHERE n < 5;
+
+query I
+FROM nums
+----
+1
+2
+3
+4
+5


### PR DESCRIPTION
Fixes #17311

This snuck in in https://github.com/duckdb/duckdb/pull/12430