### PR TITLE
Implement ARTOperator replacing Lookup and the recursive Insert

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -1328,7 +1328,8 @@ bool ART::MergeIndexes(IndexLock &state, BoundIndex &other_index) {
 	// Merge the ARTs.
 	D_ASSERT(tree.GetGateStatus() == other_art.tree.GetGateStatus());
 	if (tree.HasMetadata()) {
-		ARTMerger merger(Allocator::Get(db), *this);
+		ArenaAllocator arena(Allocator::Get(db));
+		ARTMerger merger(arena, *this);
 		merger.Init(tree, other_art.tree);
 		return merger.Merge() == ARTConflictType::NO_CONFLICT;
 	}

--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/storage/table_io_manager.hpp"
 #include "duckdb/execution/index/art/art_scanner.hpp"
 #include "duckdb/execution/index/art/art_merger.hpp"
+#include "duckdb/execution/index/art/art_operator.hpp"
 
 namespace duckdb {
 
@@ -453,7 +454,14 @@ bool ART::ConstructInternal(const unsafe_vector<ARTKey> &keys, const unsafe_vect
 		if (row_id_count == 1) {
 			Leaf::New(ref, row_ids[section.start].GetRowId());
 		} else {
-			Leaf::New(*this, ref, row_ids, section.start, row_id_count);
+			// Loop and insert the row IDs.
+			// We cannot use Construct in the leaf because row IDs are not sorted.
+			ArenaAllocator arena(BufferAllocator::Get(db));
+			for (idx_t i = section.start; i < section.start + row_id_count; i++) {
+				ARTOperator::Insert(arena, *this, ref, row_ids[i], 0, row_ids[i], GateStatus::GATE_SET, nullptr,
+				                    IndexAppendMode::DEFAULT);
+			}
+			ref.get().SetGateStatus(GateStatus::GATE_SET);
 		}
 		return true;
 	}
@@ -510,10 +518,10 @@ ErrorData ART::Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppe
 	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
 	auto row_count = chunk.size();
 
-	ArenaAllocator allocator(BufferAllocator::Get(db));
+	ArenaAllocator arena(BufferAllocator::Get(db));
 	unsafe_vector<ARTKey> keys(row_count);
 	unsafe_vector<ARTKey> row_id_keys(row_count);
-	GenerateKeyVectors(allocator, chunk, row_ids, keys, row_id_keys);
+	GenerateKeyVectors(arena, chunk, row_ids, keys, row_id_keys);
 
 	optional_ptr<ART> delete_art;
 	if (info.delete_index) {
@@ -529,7 +537,8 @@ ErrorData ART::Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppe
 		if (keys[i].Empty()) {
 			continue;
 		}
-		conflict_type = Insert(tree, keys[i], 0, row_id_keys[i], tree.GetGateStatus(), delete_art, info.append_mode);
+		conflict_type = ARTOperator::Insert(arena, *this, tree, keys[i], 0, row_id_keys[i], GateStatus::GATE_NOT_SET,
+		                                    delete_art, info.append_mode);
 		if (conflict_type != ARTConflictType::NO_CONFLICT) {
 			conflict_idx = i;
 			break;
@@ -567,7 +576,7 @@ ErrorData ART::Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppe
 		if (keys[i].Empty()) {
 			continue;
 		}
-		D_ASSERT(Lookup(tree, keys[i], 0));
+		D_ASSERT(ARTOperator::Lookup(*this, tree, keys[i], 0));
 	}
 #endif
 	return ErrorData();
@@ -601,148 +610,6 @@ void ART::VerifyAppend(DataChunk &chunk, IndexAppendInfo &info, optional_ptr<Con
 	}
 	ConflictManager local_manager(VerifyExistenceType::APPEND, chunk.size());
 	VerifyConstraint(chunk, info, local_manager);
-}
-
-void ART::InsertIntoEmpty(Node &node, const ARTKey &key, const idx_t depth, const ARTKey &row_id,
-                          const GateStatus status) {
-	D_ASSERT(depth <= key.len);
-	D_ASSERT(!node.HasMetadata());
-
-	if (status == GateStatus::GATE_SET) {
-		Leaf::New(node, row_id.GetRowId());
-		return;
-	}
-
-	reference<Node> ref(node);
-	auto count = key.len - depth;
-
-	Prefix::New(*this, ref, key, depth, count);
-	Leaf::New(ref, row_id.GetRowId());
-}
-
-ARTConflictType ART::InsertIntoInlined(Node &node, const ARTKey &key, const idx_t depth, const ARTKey &row_id,
-                                       const GateStatus status, optional_ptr<ART> delete_art,
-                                       const IndexAppendMode append_mode) {
-
-	if (!IsUnique() || append_mode == IndexAppendMode::INSERT_DUPLICATES) {
-		Leaf::InsertIntoInlined(*this, node, row_id, depth, status);
-		return ARTConflictType::NO_CONFLICT;
-	}
-
-	if (!delete_art) {
-		if (append_mode == IndexAppendMode::IGNORE_DUPLICATES) {
-			return ARTConflictType::NO_CONFLICT;
-		}
-		return ARTConflictType::CONSTRAINT;
-	}
-
-	// Lookup in the delete_art.
-	auto delete_leaf = delete_art->Lookup(delete_art->tree, key, 0);
-	if (!delete_leaf) {
-		return ARTConflictType::CONSTRAINT;
-	}
-
-	// The row ID has changed.
-	// Thus, the local index has a newer (local) row ID, and this is a constraint violation.
-	D_ASSERT(delete_leaf->GetType() == NType::LEAF_INLINED);
-	auto deleted_row_id = delete_leaf->GetRowId();
-	auto this_row_id = node.GetRowId();
-	if (deleted_row_id != this_row_id) {
-		return ARTConflictType::CONSTRAINT;
-	}
-
-	// The deleted key and its row ID match the current key and its row ID.
-	Leaf::InsertIntoInlined(*this, node, row_id, depth, status);
-	return ARTConflictType::NO_CONFLICT;
-}
-
-ARTConflictType ART::InsertIntoNode(Node &node, const ARTKey &key, const idx_t depth, const ARTKey &row_id,
-                                    const GateStatus status, optional_ptr<ART> delete_art,
-                                    const IndexAppendMode append_mode) {
-	D_ASSERT(depth < key.len);
-	auto child = node.GetChildMutable(*this, key[depth]);
-
-	// Recurse, if a child exists at key[depth].
-	if (child) {
-		D_ASSERT(child->HasMetadata());
-		auto conflict_type = Insert(*child, key, depth + 1, row_id, status, delete_art, append_mode);
-		node.ReplaceChild(*this, key[depth], *child);
-		return conflict_type;
-	}
-
-	// Create an inlined prefix at key[depth].
-	if (status == GateStatus::GATE_SET) {
-		Node remainder;
-		auto byte = key[depth];
-		auto conflict_type = Insert(remainder, key, depth + 1, row_id, status, delete_art, append_mode);
-		Node::InsertChild(*this, node, byte, remainder);
-		return conflict_type;
-	}
-
-	// Insert an inlined leaf at key[depth].
-	Node leaf;
-	reference<Node> ref(leaf);
-
-	// Create the prefix.
-	if (depth + 1 < key.len) {
-		auto count = key.len - depth - 1;
-		Prefix::New(*this, ref, key, depth + 1, count);
-	}
-
-	// Create the inlined leaf.
-	Leaf::New(ref, row_id.GetRowId());
-	Node::InsertChild(*this, node, key[depth], leaf);
-	return ARTConflictType::NO_CONFLICT;
-}
-
-ARTConflictType ART::Insert(Node &node, const ARTKey &key, idx_t depth, const ARTKey &row_id, const GateStatus status,
-                            optional_ptr<ART> delete_art, const IndexAppendMode append_mode) {
-	if (!node.HasMetadata()) {
-		InsertIntoEmpty(node, key, depth, row_id, status);
-		return ARTConflictType::NO_CONFLICT;
-	}
-
-	// Enter a nested leaf.
-	if (status == GateStatus::GATE_NOT_SET && node.GetGateStatus() == GateStatus::GATE_SET) {
-		if (IsUnique()) {
-			// Unique indexes can have duplicates, if another transaction DELETE + INSERT
-			// the same key. In that case, the previous value must be kept alive until all
-			// other transactions do not depend on it anymore.
-
-			// We restrict this transactionality to two-value leaves, so any subsequent
-			// incoming transaction must fail here.
-			return ARTConflictType::TRANSACTION;
-		}
-		return Insert(node, row_id, 0, row_id, GateStatus::GATE_SET, delete_art, append_mode);
-	}
-
-	auto type = node.GetType();
-	switch (type) {
-	case NType::LEAF_INLINED: {
-		return InsertIntoInlined(node, key, depth, row_id, status, delete_art, append_mode);
-	}
-	case NType::LEAF: {
-		Leaf::TransformToNested(*this, node);
-		return Insert(node, key, depth, row_id, status, delete_art, append_mode);
-	}
-	case NType::NODE_7_LEAF:
-	case NType::NODE_15_LEAF:
-	case NType::NODE_256_LEAF: {
-		// Row IDs are unique, so there are never any duplicate byte conflicts here.
-		auto byte = key[Prefix::ROW_ID_COUNT];
-		Node::InsertChild(*this, node, byte);
-		return ARTConflictType::NO_CONFLICT;
-	}
-	case NType::NODE_4:
-	case NType::NODE_16:
-	case NType::NODE_48:
-	case NType::NODE_256:
-		return InsertIntoNode(node, key, depth, row_id, status, delete_art, append_mode);
-	case NType::PREFIX:
-		return Prefix::Insert(*this, node, key, depth, row_id, status, delete_art, append_mode);
-	default:
-		throw InternalException("Invalid node type for ART::Insert.");
-	}
 }
 
 //===--------------------------------------------------------------------===//
@@ -787,7 +654,7 @@ void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
 		if (keys[i].Empty()) {
 			continue;
 		}
-		auto leaf = Lookup(tree, keys[i], 0);
+		auto leaf = ARTOperator::Lookup(*this, tree, keys[i], 0);
 		if (leaf && leaf->GetType() == NType::LEAF_INLINED) {
 			D_ASSERT(leaf->GetRowId() != row_id_keys[i].GetRowId());
 		}
@@ -894,45 +761,8 @@ void ART::Erase(Node &node, reference<const ARTKey> key, idx_t depth, reference<
 // Point and range lookups
 //===--------------------------------------------------------------------===//
 
-const unsafe_optional_ptr<const Node> ART::Lookup(const Node &node, const ARTKey &key, idx_t depth) {
-	reference<const Node> ref(node);
-	while (ref.get().HasMetadata()) {
-
-		// Return the leaf.
-		if (ref.get().IsAnyLeaf() || ref.get().GetGateStatus() == GateStatus::GATE_SET) {
-			return unsafe_optional_ptr<const Node>(ref.get());
-		}
-
-		// Traverse the prefix.
-		if (ref.get().GetType() == NType::PREFIX) {
-			auto pos = Prefix::Traverse(*this, ref, key, depth);
-			if (pos.IsValid()) {
-				// Prefix mismatch, return nullptr.
-				return nullptr;
-			}
-			continue;
-		}
-
-		// Get the child node.
-		D_ASSERT(depth < key.len);
-		auto child = ref.get().GetChild(*this, key[depth]);
-
-		// No child at the matching byte, return nullptr.
-		if (!child) {
-			return nullptr;
-		}
-
-		// Continue in the child.
-		ref = *child;
-		D_ASSERT(ref.get().HasMetadata());
-		depth++;
-	}
-
-	return nullptr;
-}
-
 bool ART::SearchEqual(ARTKey &key, idx_t max_count, unsafe_vector<row_t> &row_ids) {
-	auto leaf = Lookup(tree, key, 0);
+	auto leaf = ARTOperator::Lookup(*this, tree, key, 0);
 	if (!leaf) {
 		return true;
 	}
@@ -1089,7 +919,7 @@ void ART::VerifyLeaf(const Node &leaf, const ARTKey &key, optional_ptr<ART> dele
 	// All leaves in the delete ART are inlined.
 	unsafe_optional_ptr<const Node> deleted_leaf;
 	if (delete_art) {
-		deleted_leaf = delete_art->Lookup(delete_art->tree, key, 0);
+		deleted_leaf = ARTOperator::Lookup(*delete_art, delete_art->tree, key, 0);
 	}
 
 	// The leaf is inlined, and there is no deleted leaf with the same key.
@@ -1187,7 +1017,7 @@ void ART::VerifyConstraint(DataChunk &chunk, IndexAppendInfo &info, ConflictMana
 			continue;
 		}
 
-		auto leaf = Lookup(tree, keys[i], 0);
+		auto leaf = ARTOperator::Lookup(*this, tree, keys[i], 0);
 		if (!leaf) {
 			if (manager.AddMiss(i)) {
 				conflict_idx = i;
@@ -1464,7 +1294,7 @@ void ART::InitializeMerge(Node &node, unsafe_vector<idx_t> &upper_bounds) {
 			return ARTHandlingResult::CONTINUE;
 		}
 		if (type == NType::LEAF) {
-			throw InternalException("deprecated ART storage in InitMerge");
+			throw InternalException("deprecated ART storage in InitializeMerge");
 		}
 		const auto idx = Node::GetAllocatorIdx(type);
 		node.IncreaseBufferId(upper_bounds[idx]);

--- a/src/execution/index/art/leaf.cpp
+++ b/src/execution/index/art/leaf.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/execution/index/art/iterator.hpp"
 #include "duckdb/execution/index/art/node.hpp"
 #include "duckdb/execution/index/art/prefix.hpp"
+#include "duckdb/execution/index/art/art_operator.hpp"
 
 namespace duckdb {
 
@@ -18,73 +19,67 @@ void Leaf::New(Node &node, const row_t row_id) {
 	node.SetRowId(row_id);
 }
 
-void Leaf::New(ART &art, reference<Node> &node, const unsafe_vector<ARTKey> &row_ids, const idx_t start,
-               const idx_t count) {
-	D_ASSERT(count > 1);
-	D_ASSERT(!node.get().HasMetadata());
+void Leaf::MergeInlined(ArenaAllocator &arena, ART &art, Node &left, Node &right, GateStatus status, idx_t depth) {
+	D_ASSERT(left.GetType() == NType::LEAF_INLINED);
+	D_ASSERT(right.GetType() == NType::LEAF_INLINED);
 
-	// We cannot recurse into the leaf during Construct(...) because row IDs are not sorted.
-	for (idx_t i = 0; i < count; i++) {
-		idx_t offset = start + i;
-		art.Insert(node, row_ids[offset], 0, row_ids[offset], GateStatus::GATE_SET, nullptr, IndexAppendMode::DEFAULT);
-	}
-	node.get().SetGateStatus(GateStatus::GATE_SET);
-}
-
-void Leaf::InsertIntoInlined(ART &art, Node &node, const ARTKey &row_id, idx_t depth, const GateStatus status) {
-	D_ASSERT(node.GetType() == INLINED);
-
-	ArenaAllocator allocator(Allocator::Get(art.db));
-	auto key = ARTKey::CreateARTKey<row_t>(allocator, node.GetRowId());
-
-	GateStatus new_status;
-	if (status == GateStatus::GATE_NOT_SET || node.GetGateStatus() == GateStatus::GATE_SET) {
-		new_status = GateStatus::GATE_SET;
-	} else {
-		new_status = GateStatus::GATE_NOT_SET;
-	}
-
-	if (new_status == GateStatus::GATE_SET) {
+	status = status == GateStatus::GATE_NOT_SET ? GateStatus::GATE_SET : GateStatus::GATE_NOT_SET;
+	if (status == GateStatus::GATE_SET) {
+		// Case 1: We are outside a nested leaf,
+		// so we create a nested leaf.
 		depth = 0;
 	}
-	node.Clear();
+	// Otherwise, case 2: we are in a nested leaf with two 'compressed' prefixes.
+	// A 'compressed prefix' is an inlined leaf that could've been expanded to
+	// a prefix with an inlined leaf as its only child.
 
-	// Get the mismatching position.
-	D_ASSERT(row_id.len == key.len);
-	auto pos = row_id.GetMismatchPos(key, depth);
-	D_ASSERT(pos != DConstants::INVALID_INDEX);
-	D_ASSERT(pos >= depth);
-	auto byte = row_id.data[pos];
+	// Get the corresponding row IDs and their ART keys.
+	auto left_row_id = left.GetRowId();
+	auto right_row_id = right.GetRowId();
+	auto left_key = ARTKey::CreateARTKey<row_t>(arena, left_row_id);
+	auto right_key = ARTKey::CreateARTKey<row_t>(arena, right_row_id);
 
-	// Create the (optional) prefix and the node.
-	reference<Node> next(node);
-	auto count = pos - depth;
-	if (count != 0) {
-		Prefix::New(art, next, row_id, depth, count);
+	auto pos = left_key.GetMismatchPos(right_key, depth);
+
+	left.Clear();
+	reference<Node> node(left);
+	if (pos != depth) {
+		// The row IDs share a prefix.
+		Prefix::New(art, node, left_key, depth, pos - depth);
 	}
+
+	auto left_byte = left_key.data[pos];
+	auto right_byte = right_key.data[pos];
+
 	if (pos == Prefix::ROW_ID_COUNT) {
-		Node7Leaf::New(art, next);
-	} else {
-		Node4::New(art, next);
+		// The row IDs differ on the last byte.
+		Node7Leaf::New(art, node);
+		Node7Leaf::InsertByte(art, node, left_byte);
+		Node7Leaf::InsertByte(art, node, right_byte);
+		left.SetGateStatus(status);
+		return;
 	}
 
-	// Create the children.
-	Node row_id_node;
-	Leaf::New(row_id_node, row_id.GetRowId());
-	Node remainder;
-	if (pos != Prefix::ROW_ID_COUNT) {
-		Leaf::New(remainder, key.GetRowId());
-	}
+	// Create and insert the (compressed) children.
+	// We inline directly into the node, instead of creating prefixes
+	// with a single inlined leaf as their child.
+	Node4::New(art, node);
 
-	Node::InsertChild(art, next, key[pos], remainder);
-	Node::InsertChild(art, next, byte, row_id_node);
-	node.SetGateStatus(new_status);
+	Node left_child;
+	Leaf::New(left_child, left_row_id);
+	Node4::InsertChild(art, node, left_byte, left_child);
+
+	Node right_child;
+	Leaf::New(right_child, right_row_id);
+	Node4::InsertChild(art, node, right_byte, right_child);
+
+	left.SetGateStatus(status);
 }
 
 void Leaf::TransformToNested(ART &art, Node &node) {
 	D_ASSERT(node.GetType() == LEAF);
 
-	ArenaAllocator allocator(Allocator::Get(art.db));
+	ArenaAllocator arena(Allocator::Get(art.db));
 	Node root = Node();
 
 	// Move all row IDs into the nested leaf.
@@ -92,9 +87,9 @@ void Leaf::TransformToNested(ART &art, Node &node) {
 	while (leaf_ref.get().HasMetadata()) {
 		auto &leaf = Node::Ref<const Leaf>(art, leaf_ref, LEAF);
 		for (uint8_t i = 0; i < leaf.count; i++) {
-			auto row_id = ARTKey::CreateARTKey<row_t>(allocator, leaf.row_ids[i]);
-			auto conflict_type =
-			    art.Insert(root, row_id, 0, row_id, GateStatus::GATE_SET, nullptr, IndexAppendMode::INSERT_DUPLICATES);
+			auto row_id = ARTKey::CreateARTKey<row_t>(arena, leaf.row_ids[i]);
+			auto conflict_type = ARTOperator::Insert(arena, art, root, row_id, 0, row_id, GateStatus::GATE_SET, nullptr,
+			                                         IndexAppendMode::INSERT_DUPLICATES);
 			if (conflict_type != ARTConflictType::NO_CONFLICT) {
 				throw InternalException("invalid conflict type in Leaf::TransformToNested");
 			}

--- a/src/execution/operator/schema/physical_create_art_index.cpp
+++ b/src/execution/operator/schema/physical_create_art_index.cpp
@@ -89,13 +89,11 @@ SinkResultType PhysicalCreateARTIndex::SinkUnsorted(OperatorSinkInput &input) co
 	auto row_count = l_state.key_chunk.size();
 	auto &art = l_state.local_index->Cast<ART>();
 
-	ArenaAllocator arena(BufferAllocator::Get(art.db));
-
 	// Insert each key and its corresponding row ID.
 	for (idx_t i = 0; i < row_count; i++) {
 		auto status = art.tree.GetGateStatus();
-		auto conflict_type = ARTOperator::Insert(arena, art, art.tree, l_state.keys[i], 0, l_state.row_ids[i], status,
-		                                         nullptr, IndexAppendMode::DEFAULT);
+		auto conflict_type = ARTOperator::Insert(l_state.arena_allocator, art, art.tree, l_state.keys[i], 0,
+		                                         l_state.row_ids[i], status, nullptr, IndexAppendMode::DEFAULT);
 		D_ASSERT(conflict_type != ARTConflictType::TRANSACTION);
 		if (conflict_type == ARTConflictType::CONSTRAINT) {
 			throw ConstraintException("Data contains duplicates on indexed column(s)");

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -79,9 +79,6 @@ public:
 	//! Appends data to the locked index and verifies constraint violations.
 	ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) override;
 
-	//! Internally inserts a chunk.
-	ARTConflictType Insert(Node &node, const ARTKey &key, idx_t depth, const ARTKey &row_id, const GateStatus status,
-	                       optional_ptr<ART> delete_art, const IndexAppendMode append_mode);
 	//! Insert a chunk.
 	ErrorData Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids) override;
 	//! Insert a chunk and verifies constraint violations.
@@ -129,16 +126,6 @@ private:
 	bool SearchLess(ARTKey &upper_bound, bool equal, idx_t max_count, unsafe_vector<row_t> &row_ids);
 	bool SearchCloseRange(ARTKey &lower_bound, ARTKey &upper_bound, bool left_equal, bool right_equal, idx_t max_count,
 	                      unsafe_vector<row_t> &row_ids);
-	const unsafe_optional_ptr<const Node> Lookup(const Node &node, const ARTKey &key, idx_t depth);
-
-	void InsertIntoEmpty(Node &node, const ARTKey &key, const idx_t depth, const ARTKey &row_id,
-	                     const GateStatus status);
-	ARTConflictType InsertIntoInlined(Node &node, const ARTKey &key, const idx_t depth, const ARTKey &row_id,
-	                                  const GateStatus status, optional_ptr<ART> delete_art,
-	                                  const IndexAppendMode append_mode);
-	ARTConflictType InsertIntoNode(Node &node, const ARTKey &key, const idx_t depth, const ARTKey &row_id,
-	                               const GateStatus status, optional_ptr<ART> delete_art,
-	                               const IndexAppendMode append_mode);
 
 	string GenerateErrorKeyName(DataChunk &input, idx_t row);
 	string GenerateConstraintErrorMessage(VerifyExistenceType verify_type, const string &key_name);

--- a/src/include/duckdb/execution/index/art/art_merger.hpp
+++ b/src/include/duckdb/execution/index/art/art_merger.hpp
@@ -20,7 +20,7 @@ namespace duckdb {
 class ARTMerger {
 public:
 	ARTMerger() = delete;
-	ARTMerger(Allocator &allocator, ART &art) : arena(allocator), art(art) {
+	ARTMerger(ArenaAllocator &arena, ART &art) : arena(arena), art(art) {
 	}
 
 public:
@@ -46,7 +46,7 @@ private:
 	};
 
 	//! The arena holds any temporary memory allocated during the Merge phase.
-	ArenaAllocator arena;
+	ArenaAllocator &arena;
 	//! The ART holding the node memory.
 	ART &art;
 	//! The stack. While merging, NodeEntry elements are pushed onto of the stack.

--- a/src/include/duckdb/execution/index/art/art_merger.hpp
+++ b/src/include/duckdb/execution/index/art/art_merger.hpp
@@ -58,7 +58,6 @@ private:
 	// - if left is PREFIX, then right is also PREFIX (except for PREFIX + LEAF_INLINED).
 	void Emplace(Node &left, Node &right, const GateStatus parent_status, const idx_t depth);
 
-	void MergeInlined(NodeEntry &entry);
 	ARTConflictType MergeNodeAndInlined(NodeEntry &entry);
 
 	array_ptr<uint8_t> GetBytes(Node &leaf);

--- a/src/include/duckdb/execution/index/art/art_operator.hpp
+++ b/src/include/duckdb/execution/index/art/art_operator.hpp
@@ -1,0 +1,242 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/index/art/art_operator.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "duckdb/execution/index/art/art_key.hpp"
+#include "duckdb/execution/index/art/art.hpp"
+#include "duckdb/execution/index/art/prefix.hpp"
+#include "duckdb/execution/index/art/leaf.hpp"
+#include "duckdb/execution/index/art/base_node.hpp"
+
+namespace duckdb {
+
+//! ARTOperator provides functionality for different ART operations.
+class ARTOperator {
+public:
+	//! Lookup returns a pointer to the leaf matching the key,
+	//! or nullptr, if no such leaf exists.
+	static unsafe_optional_ptr<const Node> Lookup(ART &art, const Node &node, const ARTKey &key, idx_t depth) {
+		reference<const Node> ref(node);
+
+		while (ref.get().HasMetadata()) {
+			// Return the leaf.
+			if (ref.get().IsAnyLeaf() || ref.get().GetGateStatus() == GateStatus::GATE_SET) {
+				return unsafe_optional_ptr<const Node>(ref.get());
+			}
+
+			// Traverse the prefix.
+			if (ref.get().GetType() == NType::PREFIX) {
+				Prefix prefix(art, ref.get());
+				for (idx_t i = 0; i < prefix.data[Prefix::Count(art)]; i++) {
+					if (prefix.data[i] != key[depth]) {
+						// The key and the prefix don't match.
+						return nullptr;
+					}
+					depth++;
+				}
+				ref = *prefix.ptr;
+				continue;
+			}
+
+			// Get the child node.
+			D_ASSERT(depth < key.len);
+			auto child = ref.get().GetChild(art, key[depth]);
+
+			// No child at the key byte, return nullptr.
+			if (!child) {
+				return nullptr;
+			}
+
+			// Continue in the child.
+			ref = *child;
+			D_ASSERT(ref.get().HasMetadata());
+			depth++;
+		}
+
+		return nullptr;
+	}
+
+	//! Insert a key and its row ID into the node.
+	//! Starts at depth (in the key).
+	//! status indicates if the insert happens inside a gate or not.
+	static ARTConflictType Insert(ArenaAllocator &arena, ART &art, Node &node, const ARTKey &key, idx_t depth,
+	                              const ARTKey &row_id, GateStatus status, optional_ptr<ART> delete_art,
+	                              const IndexAppendMode append_mode) {
+		reference<Node> active_node_ref(node);
+		reference<const ARTKey> active_key_ref(key);
+
+		// Early-out, if the node is empty.
+		if (!node.HasMetadata()) {
+			D_ASSERT(depth == 0);
+			if (status == GateStatus::GATE_SET) {
+				Leaf::New(node, row_id.GetRowId());
+				return ARTConflictType::NO_CONFLICT;
+			}
+
+			Prefix::New(art, active_node_ref, active_key_ref.get(), depth, active_key_ref.get().len);
+			Leaf::New(active_node_ref, row_id.GetRowId());
+			return ARTConflictType::NO_CONFLICT;
+		}
+
+		while (active_node_ref.get().HasMetadata()) {
+			auto &active_node = active_node_ref.get();
+			auto &active_key = active_key_ref.get();
+
+			// status is GATE_SET, if we've passed a gate in the previous iteration.
+			// In that case, we have not adjusted the reference.
+			if (status == GateStatus::GATE_NOT_SET && active_node.GetGateStatus() == GateStatus::GATE_SET) {
+				if (!art.IsUnique()) {
+					// Enter a gate.
+					active_key_ref = row_id;
+					depth = 0;
+					status = GateStatus::GATE_SET;
+					continue;
+				}
+				// Unique indexes can have duplicates, if another transaction DELETE + INSERT
+				// the same key. In that case, the previous value must be kept alive until all
+				// other transactions do not depend on it anymore.
+
+				// We restrict this transactionality to two-value leaves, so any subsequent
+				// incoming transaction must fail here.
+				return ARTConflictType::TRANSACTION;
+			}
+
+			const auto type = active_node.GetType();
+			switch (type) {
+			case NType::LEAF_INLINED:
+				return InsertIntoInlined(arena, art, active_node, key, row_id, depth, status, delete_art, append_mode);
+			case NType::LEAF: {
+				Leaf::TransformToNested(art, active_node);
+				continue;
+			}
+			case NType::NODE_7_LEAF:
+			case NType::NODE_15_LEAF:
+			case NType::NODE_256_LEAF: {
+				// Row IDs are unique; there are never any duplicate byte conflicts.
+				auto byte = active_key[Prefix::ROW_ID_COUNT];
+				Node::InsertChild(art, active_node, byte);
+				return ARTConflictType::NO_CONFLICT;
+			}
+			case NType::NODE_4:
+			case NType::NODE_16:
+			case NType::NODE_48:
+			case NType::NODE_256: {
+				D_ASSERT(depth < active_key.len);
+				auto child = active_node.GetChildMutable(art, active_key[depth]);
+				if (child) {
+					// Continue in the child.
+					active_node_ref = *child;
+					depth++;
+					D_ASSERT(active_node_ref.get().HasMetadata());
+					continue;
+				}
+				InsertIntoNode(art, active_node, key, row_id, depth, status);
+				return ARTConflictType::NO_CONFLICT;
+			}
+			case NType::PREFIX: {
+				Prefix prefix(art, active_node);
+				for (idx_t i = 0; i < prefix.data[Prefix::Count(art)]; i++) {
+					if (prefix.data[i] != active_key[depth]) {
+						// The active key and the prefix don't match.
+						InsertIntoPrefix(art, active_node_ref, active_key, row_id, i, depth, status);
+						return ARTConflictType::NO_CONFLICT;
+					}
+					depth++;
+				}
+				active_node_ref = *prefix.ptr;
+				D_ASSERT(active_node_ref.get().HasMetadata());
+				continue;
+			}
+			default:
+				throw InternalException("Invalid node type for ARTOperator::Insert.");
+			}
+		}
+		throw InternalException("node without metadata in ARTOperator::Insert");
+	}
+
+private:
+	static ARTConflictType InsertIntoInlined(ArenaAllocator &arena, ART &art, Node &node, const ARTKey &key,
+	                                         const ARTKey &row_id, const idx_t depth, const GateStatus status,
+	                                         optional_ptr<ART> delete_art, const IndexAppendMode append_mode) {
+		Node row_id_node;
+		Leaf::New(row_id_node, row_id.GetRowId());
+
+		if (!art.IsUnique() || append_mode == IndexAppendMode::INSERT_DUPLICATES) {
+			Leaf::MergeInlined(arena, art, node, row_id_node, status, depth);
+			return ARTConflictType::NO_CONFLICT;
+		}
+
+		if (!delete_art) {
+			if (append_mode == IndexAppendMode::IGNORE_DUPLICATES) {
+				return ARTConflictType::NO_CONFLICT;
+			}
+			return ARTConflictType::CONSTRAINT;
+		}
+
+		// Lookup in the delete_art.
+		auto delete_leaf = Lookup(*delete_art, delete_art->tree, key, 0);
+		if (!delete_leaf) {
+			return ARTConflictType::CONSTRAINT;
+		}
+
+		// The row ID has changed.
+		// Thus, the local index has a newer (local) row ID, and this is a constraint violation.
+		D_ASSERT(delete_leaf->GetType() == NType::LEAF_INLINED);
+		auto deleted_row_id = delete_leaf->GetRowId();
+		auto this_row_id = node.GetRowId();
+		if (deleted_row_id != this_row_id) {
+			return ARTConflictType::CONSTRAINT;
+		}
+
+		// The deleted key and its row ID match the current key and its row ID.
+		Leaf::MergeInlined(arena, art, node, row_id_node, status, depth);
+		return ARTConflictType::NO_CONFLICT;
+	}
+
+	static void InsertIntoNode(ART &art, Node &node, const ARTKey &key, const ARTKey &row_id, const idx_t depth,
+	                           const GateStatus status) {
+		if (status == GateStatus::GATE_SET) {
+			// Inside gates, we compress prefixes that only have an inlined
+			// row ID as their child.
+			Node row_id_node;
+			Leaf::New(row_id_node, row_id.GetRowId());
+			Node::InsertChild(art, node, row_id[depth], row_id_node);
+			return;
+		}
+
+		Node leaf;
+		reference<Node> leaf_ref(leaf);
+		if (depth + 1 < key.len) {
+			// Outside of gates, we create a prefix for the inlined leaf.
+			auto count = key.len - depth - 1;
+			Prefix::New(art, leaf_ref, key, depth + 1, count);
+		}
+
+		// Create and insert the inlined leaf.
+		Leaf::New(leaf_ref, row_id.GetRowId());
+		Node::InsertChild(art, node, key[depth], leaf);
+	}
+
+	static void InsertIntoPrefix(ART &art, reference<Node> &node_ref, const ARTKey &key, const ARTKey &row_id,
+	                             const idx_t pos, const idx_t depth, const GateStatus status) {
+
+		const auto cast_pos = UnsafeNumericCast<uint8_t>(pos);
+		const auto byte = Prefix::GetByte(art, node_ref, cast_pos);
+
+		Node child;
+		const auto split_status = Prefix::Split(art, node_ref, child, cast_pos);
+
+		Node4::New(art, node_ref);
+		node_ref.get().SetGateStatus(split_status);
+
+		Node4::InsertChild(art, node_ref, byte, child);
+		InsertIntoNode(art, node_ref, key, row_id, depth, status);
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/index/art/art_operator.hpp
+++ b/src/include/duckdb/execution/index/art/art_operator.hpp
@@ -139,7 +139,7 @@ public:
 				return ARTConflictType::NO_CONFLICT;
 			}
 			case NType::PREFIX: {
-				Prefix prefix(art, active_node);
+				Prefix prefix(art, active_node, true);
 				for (idx_t i = 0; i < prefix.data[Prefix::Count(art)]; i++) {
 					if (prefix.data[i] != active_key[depth]) {
 						// The active key and the prefix don't match.

--- a/src/include/duckdb/execution/index/art/leaf.hpp
+++ b/src/include/duckdb/execution/index/art/leaf.hpp
@@ -17,13 +17,14 @@ namespace duckdb {
 //! There are three types of leaves.
 //! 1. LEAF_INLINED: Inlines a row ID in a Node pointer.
 //! 2. LEAF: Deprecated. A list of Leaf nodes containing row IDs.
-//! 3. Nested leaves indicated by gate nodes. If an ART key contains multiple row IDs, then we use the row IDs as keys
-//! and create a nested ART behind the gate node. As row IDs are always unique, these nested ARTs never contain
-//! duplicates themselves.
+//! 3. Nested leaves indicated by gate nodes. If an ART key contains multiple row IDs,
+//! then we use the row IDs as keys and create a nested ART behind the gate node.
+//! As row IDs are always unique, these nested ARTs never contain duplicates themselves.
 class Leaf {
 public:
 	static constexpr NType LEAF = NType::LEAF;
 	static constexpr NType INLINED = NType::LEAF_INLINED;
+
 	static constexpr uint8_t LEAF_SIZE = 4; // Deprecated.
 
 public:
@@ -39,12 +40,9 @@ private:
 public:
 	//! Inline a row ID into a node pointer.
 	static void New(Node &node, const row_t row_id);
-	//! Get a new non-inlined nested leaf node.
-	static void New(ART &art, reference<Node> &node, const unsafe_vector<ARTKey> &row_ids, const idx_t start,
-	                const idx_t count);
 
-	//! Insert a row ID into an inlined leaf.
-	static void InsertIntoInlined(ART &art, Node &node, const ARTKey &row_id, idx_t depth, const GateStatus status);
+	//! Merge two inlined leaf nodes.
+	static void MergeInlined(ArenaAllocator &arena, ART &art, Node &left, Node &right, GateStatus status, idx_t depth);
 
 	//! Transforms a deprecated leaf to a nested leaf.
 	static void TransformToNested(ART &art, Node &node);

--- a/src/include/duckdb/execution/index/art/prefix.hpp
+++ b/src/include/duckdb/execution/index/art/prefix.hpp
@@ -40,7 +40,6 @@ public:
 	static inline uint8_t Count(const ART &art) {
 		return art.prefix_count;
 	}
-	static idx_t GetMismatchWithOther(const Prefix &l_prefix, const Prefix &r_prefix, const idx_t max_count);
 	static optional_idx GetMismatchWithKey(ART &art, const Node &node, const ARTKey &key, idx_t &depth);
 	static uint8_t GetByte(const ART &art, const Node &node, const uint8_t pos);
 
@@ -68,15 +67,12 @@ public:
 	//! Shifts all subsequent bytes by pos. Frees empty nodes.
 	static void Reduce(ART &art, Node &node, const idx_t pos);
 	//! Splits the prefix at pos.
-	//! prefix_node points to the node that replaces the split byte.
-	//! child_node points to the remaining node after the split.
-	//! Returns INSIDE, if a gate node was freed, else OUTSIDE.
+	//! node references the node that replaces the split byte.
+	//! child references the remaining node after the split.
+	//! Returns GATE_SET, if a gate node was freed, else GATE_NOT_SET.
+	//! If it returns GATE_SET, then the caller must set the gate for the node replacing the split byte,
+	//! after its creation.
 	static GateStatus Split(ART &art, reference<Node> &node, Node &child, const uint8_t pos);
-
-	//! Insert a key into a prefix.
-	static ARTConflictType Insert(ART &art, Node &node, const ARTKey &key, idx_t depth, const ARTKey &row_id,
-	                              const GateStatus status, optional_ptr<ART> delete_art,
-	                              const IndexAppendMode append_mode);
 
 	//! Returns the string representation of the node, or only traverses and verifies the node and its subtree
 	static string VerifyAndToString(ART &art, const Node &node, const bool only_verify);

--- a/test/sql/index/art/nodes/test_art_node_16.test
+++ b/test/sql/index/art/nodes/test_art_node_16.test
@@ -2,10 +2,10 @@
 # description: Test ART Node 16
 # group: [nodes]
 
+load __TEST_DIR__/test_index.db
+
 statement ok
 PRAGMA enable_verification
-
-load __TEST_DIR__/test_index.db
 
 statement ok
 CREATE TABLE integers(i integer)

--- a/test/sql/index/art/nodes/test_art_node_256.test
+++ b/test/sql/index/art/nodes/test_art_node_256.test
@@ -2,11 +2,10 @@
 # description: Test ART Node 256
 # group: [nodes]
 
+load __TEST_DIR__/test_index.db
+
 statement ok
 PRAGMA enable_verification
-
-# load the DB from disk
-load __TEST_DIR__/test_index.db
 
 statement ok
 CREATE TABLE integers(i integer)

--- a/test/sql/index/art/nodes/test_art_node_48.test
+++ b/test/sql/index/art/nodes/test_art_node_48.test
@@ -2,10 +2,10 @@
 # description: Test ART Node 48
 # group: [nodes]
 
+load __TEST_DIR__/test_index.db
+
 statement ok
 PRAGMA enable_verification
-
-load __TEST_DIR__/test_index.db
 
 statement ok
 CREATE TABLE integers(i integer)


### PR DESCRIPTION
Introduces a new class: `ARTOperator`. The idea is to move more code out of `art.hpp/cpp` into a dedicated class. 
Specifically, I envision `ARTOperator` containing reasonably similar lookup/search/insert/delete/construct code. 

The separate `ARTOperator` increases readability (instead of having a huge file with everything), and makes it easier to unify duplicate code paths. The PR decreases the lines of code, even though I've added many comments. 😅 

Initially, I tried to write an operator with a stack and handlers to implement the different operations with the same operator. However, there were too many operation-specific variables, and it started getting messy. The operations are small enough to be implemented in static functions with loops and should not need a stack, anyway.

The new `Insert` function also uses an iterative strategy, eliminating recursion in that code path.