### PR TITLE
Fix issue with empty ranges

### DIFF
--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -105,6 +105,7 @@ static void GenerateRangeParameters(DataChunk &input, idx_t row_id, RangeFunctio
 	if (result.increment == 0) {
 		throw BinderException("interval cannot be 0!");
 	}
+	result.empty_range = false;
 	if (result.start > result.end && result.increment > 0) {
 		result.empty_range = true;
 	}

--- a/test/sql/function/list/generate_series.test
+++ b/test/sql/function/list/generate_series.test
@@ -211,3 +211,10 @@ query I
 SELECT range(NULL, NULL, NULL)
 ----
 NULL
+
+query II
+SELECT * FROM (SELECT 1 UNION ALL SELECT 0 UNION ALL SELECT 2) AS _(x), generate_series(1, x) AS __(y) ORDER BY x, y
+----
+1	1
+2	1
+2	2


### PR DESCRIPTION
Under certain circumstances, a single empty invocation of `range`/`generate_series` would result in an empty result for the entire `generate_series` join:

```sql
SELECT * FROM
  (SELECT 1 UNION ALL SELECT 0 UNION ALL SELECT 2) AS _(x),
  generate_series(1, x) AS __(y) ORDER BY x, y
```

We have to reset the `empty_range` flag each time.