### PR TITLE
Pass commit ID to NotifyExternalRepositories.yml

### DIFF
--- a/.github/workflows/InvokeCI.yml
+++ b/.github/workflows/InvokeCI.yml
@@ -126,8 +126,8 @@ jobs:
     if: ${{ inputs.git_ref == '' && always() }} 
     with:
       is-success: ${{ needs.prepare-status.outputs.is-success }}
-      target-branch: ${{ github.ref_name }}
-      duckdb-sha: ${{ github.ref }}
+      target-branch: ${{ github.ref }}
+      duckdb-sha: ${{ github.sha }}
       triggering-event: ${{ github.event_name }}
       should-publish: 'true'
 
@@ -138,7 +138,7 @@ jobs:
     if: ${{ inputs.git_ref != '' && always() }}
     with:
       is-success: ${{ needs.prepare-status.outputs.is-success }}
-      target-branch: ${{ github.ref_name }}
-      duckdb-sha: ${{ inputs.git_ref }}
+      target-branch: ${{ inputs.git_ref }}
+      duckdb-sha: ${{ github.sha }}
       triggering-event: ${{ github.event_name }}
       should-publish: 'true'

--- a/.github/workflows/NotifyExternalRepositories.yml
+++ b/.github/workflows/NotifyExternalRepositories.yml
@@ -66,7 +66,7 @@ jobs:
         if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-odbc/actions/workflows/Vendor.yml/dispatches
-          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
+          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
 
   notify-jdbc-run:
@@ -81,7 +81,7 @@ jobs:
         if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-java/actions/workflows/Vendor.yml/dispatches
-          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
+          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"duckdb-sha": "${{ inputs.duckdb-sha }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"
 
   notify-nightly-build-status:
@@ -95,5 +95,5 @@ jobs:
         if: ${{ github.repository == 'duckdb/duckdb' }}
         run: |
           export URL=https://api.github.com/repos/duckdb/duckdb-build-status/actions/workflows/NightlyBuildsCheck.yml/dispatches
-          export DATA='{"ref": "refs/heads/${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
+          export DATA='{"ref": "${{ inputs.target-branch }}", "inputs": {"event": "${{ inputs.triggering-event }}", "should_publish": "${{ inputs.should-publish }}"}}'
           curl -v -XPOST -u "${PAT_USER}:${PAT_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" $URL --data "$DATA"


### PR DESCRIPTION
There is a problem uncovered with ODBC/JDBC repos notifications. These notifications are expected to be dispatched only after all tests are passed to ensure that the exact commit of the imported DuckDB sources has the full set of extensions published.

Currently `github.ref` (for `main` branch) or `inputs.git_ref` (for custom branch) values are passed to `NotifyExternalRepositories.yml` in `duckdb-sha` parameter, for example: `refs/heads/main`. This causes the `Vendor.yml` on ODBC/JDBC side to checkout the latest commit on the `main` branch that does not necessary match the actual commit value with which `InvokeCI.yml` was run.

Proposed change uses `github.sha` instead assuming that it is available in `InvokeCI.yml` (at least correct commit ID is displayed in web UI for it). It also passes `github.ref` (or `input.git_ref`) as a `target-branch` parameter to `NotifyExternalRepositories.yml` instead the `github.ref_name`.