### PR TITLE
Unify Parquet Metadata cache invalidation logic with Cached File System cache invalidation

### DIFF
--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -16,6 +16,7 @@ set(PARQUET_EXTENSION_FILES
     column_writer.cpp
     parquet_crypto.cpp
     parquet_extension.cpp
+    parquet_file_metadata_cache.cpp
     parquet_float16.cpp
     parquet_multi_file_info.cpp
     parquet_metadata.cpp

--- a/extension/parquet/include/parquet_file_metadata_cache.hpp
+++ b/extension/parquet/include/parquet_file_metadata_cache.hpp
@@ -8,41 +8,35 @@
 #pragma once
 
 #include "duckdb.hpp"
-#ifndef DUCKDB_AMALGAMATION
 #include "duckdb/storage/object_cache.hpp"
 #include "geo_parquet.hpp"
-#endif
 #include "parquet_types.h"
-namespace duckdb {
 
-//! ParquetFileMetadataCache
+namespace duckdb {
+struct CachingFileHandle;
+
 class ParquetFileMetadataCache : public ObjectCacheEntry {
 public:
-	ParquetFileMetadataCache() : metadata(nullptr) {
-	}
-	ParquetFileMetadataCache(unique_ptr<duckdb_parquet::FileMetaData> file_metadata, time_t r_time,
-	                         unique_ptr<GeoParquetFileMetadata> geo_metadata)
-	    : metadata(std::move(file_metadata)), read_time(r_time), geo_metadata(std::move(geo_metadata)) {
-	}
-
+	ParquetFileMetadataCache(unique_ptr<duckdb_parquet::FileMetaData> file_metadata, CachingFileHandle &handle,
+	                         unique_ptr<GeoParquetFileMetadata> geo_metadata);
 	~ParquetFileMetadataCache() override = default;
 
 	//! Parquet file metadata
 	unique_ptr<const duckdb_parquet::FileMetaData> metadata;
 
-	//! read time
-	time_t read_time;
-
 	//! GeoParquet metadata
 	unique_ptr<GeoParquetFileMetadata> geo_metadata;
 
 public:
-	static string ObjectType() {
-		return "parquet_metadata";
-	}
+	static string ObjectType();
+	string GetObjectType() override;
 
-	string GetObjectType() override {
-		return ObjectType();
-	}
+	bool IsValid(CachingFileHandle &new_handle);
+
+private:
+	bool validate;
+	time_t last_modified;
+	string version_tag;
 };
+
 } // namespace duckdb

--- a/extension/parquet/include/parquet_file_metadata_cache.hpp
+++ b/extension/parquet/include/parquet_file_metadata_cache.hpp
@@ -31,7 +31,7 @@ public:
 	static string ObjectType();
 	string GetObjectType() override;
 
-	bool IsValid(CachingFileHandle &new_handle);
+	bool IsValid(CachingFileHandle &new_handle) const;
 
 private:
 	bool validate;

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -1,0 +1,27 @@
+#include "parquet_file_metadata_cache.hpp"
+#include "duckdb/storage/external_file_cache.hpp"
+#include "duckdb/storage/caching_file_system.hpp"
+
+namespace duckdb {
+
+ParquetFileMetadataCache::ParquetFileMetadataCache(unique_ptr<duckdb_parquet::FileMetaData> file_metadata,
+                                                   CachingFileHandle &handle,
+                                                   unique_ptr<GeoParquetFileMetadata> geo_metadata)
+    : metadata(std::move(file_metadata)), geo_metadata(std::move(geo_metadata)), validate(handle.Validate()),
+      last_modified(handle.GetLastModifiedTime()), version_tag(handle.GetVersionTag()) {
+}
+
+string ParquetFileMetadataCache::ObjectType() {
+	return "parquet_metadata";
+}
+
+string ParquetFileMetadataCache::GetObjectType() {
+	return ObjectType();
+}
+
+bool ParquetFileMetadataCache::IsValid(CachingFileHandle &new_handle) {
+	return ExternalFileCache::IsValid(validate, version_tag, last_modified, new_handle.GetVersionTag(),
+	                                  new_handle.GetLastModifiedTime());
+}
+
+} // namespace duckdb

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -19,7 +19,7 @@ string ParquetFileMetadataCache::GetObjectType() {
 	return ObjectType();
 }
 
-bool ParquetFileMetadataCache::IsValid(CachingFileHandle &new_handle) {
+bool ParquetFileMetadataCache::IsValid(CachingFileHandle &new_handle) const {
 	return ExternalFileCache::IsValid(validate, version_tag, last_modified, new_handle.GetVersionTag(),
 	                                  new_handle.GetLastModifiedTime());
 }

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -95,8 +95,6 @@ static shared_ptr<ParquetFileMetadataCache>
 LoadMetadata(ClientContext &context, Allocator &allocator, CachingFileHandle &file_handle,
              const shared_ptr<const ParquetEncryptionConfig> &encryption_config, const EncryptionUtil &encryption_util,
              optional_idx footer_size) {
-	auto current_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-
 	auto file_proto = CreateThriftFileProtocol(file_handle, false);
 	auto &transport = reinterpret_cast<ThriftFileTransport &>(*file_proto->getTransport());
 	auto file_size = transport.GetSize();
@@ -175,8 +173,7 @@ LoadMetadata(ClientContext &context, Allocator &allocator, CachingFileHandle &fi
 
 	// Try to read the GeoParquet metadata (if present)
 	auto geo_metadata = GeoParquetFileMetadata::TryRead(*metadata, context);
-
-	return make_shared_ptr<ParquetFileMetadataCache>(std::move(metadata), current_time, std::move(geo_metadata));
+	return make_shared_ptr<ParquetFileMetadataCache>(std::move(metadata), file_handle, std::move(geo_metadata));
 }
 
 LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema) const {
@@ -781,7 +778,6 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 	} else {
 		encryption_util = make_shared_ptr<duckdb_mbedtls::MbedTlsWrapper::AESStateMBEDTLSFactory>();
 	}
-
 	// If metadata cached is disabled
 	// or if this file has cached metadata
 	// or if the cached version already expired
@@ -792,9 +788,8 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 			metadata = LoadMetadata(context_p, allocator, *file_handle, parquet_options.encryption_config,
 			                        *encryption_util, footer_size);
 		} else {
-			auto last_modify_time = file_handle->GetLastModifiedTime();
 			metadata = ObjectCache::GetObjectCache(context_p).Get<ParquetFileMetadataCache>(file.path);
-			if (!metadata || (last_modify_time + 10 >= metadata->read_time)) {
+			if (!metadata || !metadata->IsValid(*file_handle)) {
 				metadata = LoadMetadata(context_p, allocator, *file_handle, parquet_options.encryption_config,
 				                        *encryption_util, footer_size);
 				ObjectCache::GetObjectCache(context_p).Put(file.path, metadata);

--- a/src/include/duckdb/storage/caching_file_system.hpp
+++ b/src/include/duckdb/storage/caching_file_system.hpp
@@ -47,6 +47,8 @@ public:
 	DUCKDB_API string GetPath() const;
 	DUCKDB_API idx_t GetFileSize();
 	DUCKDB_API time_t GetLastModifiedTime();
+	DUCKDB_API string GetVersionTag();
+	DUCKDB_API bool Validate() const;
 	DUCKDB_API bool CanSeek();
 	DUCKDB_API bool IsRemoteFile() const;
 	DUCKDB_API bool OnDiskFile();

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -62,7 +62,7 @@ public:
 		void Verify(const unique_ptr<StorageLockKey> &guard) const;
 		//! Whether the CachedFile is still valid given the current modified/version tag
 		bool IsValid(const unique_ptr<StorageLockKey> &guard, bool validate, const string &current_version_tag,
-		             time_t current_last_modified, int64_t access_time);
+		             time_t current_last_modified);
 
 		//! Get reference to properties (must hold the lock)
 		idx_t &FileSize(const unique_ptr<StorageLockKey> &guard);
@@ -100,6 +100,9 @@ public:
 	BufferManager &GetBufferManager() const;
 	//! Gets the cached file, or creates it if is not yet present
 	CachedFile &GetOrCreateCachedFile(const string &path);
+
+	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, time_t cached_last_modified,
+	                               const string &current_version_tag, time_t current_last_modified);
 
 private:
 	//! The BufferManager used to cache files

--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -72,7 +72,6 @@ void ExternalFileCache::CachedFile::Verify(const unique_ptr<StorageLockKey> &gua
 
 bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag, time_t cached_last_modified,
                                 const string &current_version_tag, time_t current_last_modified) {
-	const auto access_time = duration_cast<std::chrono::seconds>(system_clock::now().time_since_epoch()).count();
 	if (!validate) {
 		return true; // Assume valid
 	}
@@ -86,6 +85,7 @@ bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag,
 	// because some file systems use a low resolution clock to set the last modified time.
 	// So, we will require that the last modified time is more than 10 seconds ago.
 	static constexpr int64_t LAST_MODIFIED_THRESHOLD = 10;
+	const auto access_time = duration_cast<std::chrono::seconds>(system_clock::now().time_since_epoch()).count();
 	if (access_time < current_last_modified) {
 		return false; // Last modified in the future?
 	}


### PR DESCRIPTION
Rather than having separate logic - this should really use the same logic for cache invalidation.