### PR TITLE
Revert "Skip MinGW, currently failing on main"

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -254,8 +254,7 @@ jobs:
  mingw:
      name: MinGW (64 Bit)
      runs-on: windows-2019
-     #FIXME: add this back -- if: ${{ inputs.skip_tests != 'true' }}
-     if: false
+     if: ${{ inputs.skip_tests != 'true' }}
      needs: win-release-64
      steps:
        - uses: actions/checkout@v4


### PR DESCRIPTION
This reverts commit 41a586f730dc732173755a4879ebbcc243339d77.

This should now be working, fixed likely via https://github.com/duckdb/duckdb/pull/17319