### PR TITLE
Parquet Reader: emit partition stats for any files that have cached metadata, and implement `ListFilesExtended` that adds extra info to files globbed

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -290,12 +290,12 @@ jobs:
 
       - name: Build
         shell: bash
-        run: STANDARD_VECTOR_SIZE=2 make relassert
+        run: STANDARD_VECTOR_SIZE=2 make reldebug
 
       - name: Test
         shell: bash
         run: |
-          python3 scripts/run_tests_one_by_one.py build/relassert/test/unittest --no-exit --time_execution
+          python3 scripts/run_tests_one_by_one.py build/reldebug/test/unittest --no-exit --time_execution
 
  valgrind:
     name: Valgrind

--- a/extension/parquet/include/parquet_file_metadata_cache.hpp
+++ b/extension/parquet/include/parquet_file_metadata_cache.hpp
@@ -15,6 +15,8 @@
 namespace duckdb {
 struct CachingFileHandle;
 
+enum class ParquetCacheValidity { VALID, INVALID, UNKNOWN };
+
 class ParquetFileMetadataCache : public ObjectCacheEntry {
 public:
 	ParquetFileMetadataCache(unique_ptr<duckdb_parquet::FileMetaData> file_metadata, CachingFileHandle &handle,
@@ -32,6 +34,9 @@ public:
 	string GetObjectType() override;
 
 	bool IsValid(CachingFileHandle &new_handle) const;
+	//! Check if a cache entry is valid based ONLY on the OpenFileInfo (without doing any file system calls)
+	//! If the OpenFileInfo does not have enough information this can return UNKNOWN
+	ParquetCacheValidity IsValid(const OpenFileInfo &info) const;
 
 private:
 	bool validate;

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -178,6 +178,9 @@ public:
 
 	void AddVirtualColumn(column_t virtual_column_id) override;
 
+	void GetPartitionStats(vector<PartitionStatistics> &result);
+	static void GetPartitionStats(const duckdb_parquet::FileMetaData &metadata, vector<PartitionStatistics> &result);
+
 private:
 	//! Construct a parquet reader but **do not** open a file, used in ReadStatistics only
 	ParquetReader(ClientContext &context, ParquetOptions parquet_options,

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -180,6 +180,8 @@ public:
 
 	void GetPartitionStats(vector<PartitionStatistics> &result);
 	static void GetPartitionStats(const duckdb_parquet::FileMetaData &metadata, vector<PartitionStatistics> &result);
+	static bool MetadataCacheEnabled(ClientContext &context);
+	static shared_ptr<ParquetFileMetadataCache> GetMetadataCacheEntry(ClientContext &context, const OpenFileInfo &file);
 
 private:
 	//! Construct a parquet reader but **do not** open a file, used in ReadStatistics only

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -20,8 +20,36 @@ string ParquetFileMetadataCache::GetObjectType() {
 }
 
 bool ParquetFileMetadataCache::IsValid(CachingFileHandle &new_handle) const {
-	return ExternalFileCache::IsValid(validate, version_tag, last_modified, new_handle.GetVersionTag(),
-	                                  new_handle.GetLastModifiedTime());
+	return ExternalFileCache::IsValid(validate, new_handle.GetVersionTag(), new_handle.GetLastModifiedTime(),
+	                                  version_tag, last_modified);
+}
+
+ParquetCacheValidity ParquetFileMetadataCache::IsValid(const OpenFileInfo &info) const {
+	if (!info.extended_info) {
+		return ParquetCacheValidity::UNKNOWN;
+	}
+	auto &open_options = info.extended_info->options;
+	const auto validate_entry = open_options.find("validate_external_file_cache");
+	if (validate_entry != open_options.end()) {
+		// check if always valid - if so just return valid
+		if (BooleanValue::Get(validate_entry->second)) {
+			return ParquetCacheValidity::VALID;
+		}
+	}
+	const auto lm_entry = open_options.find("last_modified");
+	if (lm_entry == open_options.end()) {
+		return ParquetCacheValidity::UNKNOWN;
+	}
+	time_t new_last_modified = Timestamp::ToTimeT(lm_entry->second.GetValue<timestamp_t>());
+	string new_etag;
+	const auto etag_entry = open_options.find("etag");
+	if (etag_entry != open_options.end()) {
+		new_etag = StringValue::Get(etag_entry->second);
+	}
+	if (ExternalFileCache::IsValid(false, new_etag, new_last_modified, version_tag, last_modified)) {
+		return ParquetCacheValidity::VALID;
+	}
+	return ParquetCacheValidity::INVALID;
 }
 
 } // namespace duckdb

--- a/extension/parquet/parquet_file_metadata_cache.cpp
+++ b/extension/parquet/parquet_file_metadata_cache.cpp
@@ -20,8 +20,8 @@ string ParquetFileMetadataCache::GetObjectType() {
 }
 
 bool ParquetFileMetadataCache::IsValid(CachingFileHandle &new_handle) const {
-	return ExternalFileCache::IsValid(validate, new_handle.GetVersionTag(), new_handle.GetLastModifiedTime(),
-	                                  version_tag, last_modified);
+	return ExternalFileCache::IsValid(validate, version_tag, last_modified, new_handle.GetVersionTag(),
+	                                  new_handle.GetLastModifiedTime());
 }
 
 ParquetCacheValidity ParquetFileMetadataCache::IsValid(const OpenFileInfo &info) const {
@@ -46,7 +46,7 @@ ParquetCacheValidity ParquetFileMetadataCache::IsValid(const OpenFileInfo &info)
 	if (etag_entry != open_options.end()) {
 		new_etag = StringValue::Get(etag_entry->second);
 	}
-	if (ExternalFileCache::IsValid(false, new_etag, new_last_modified, version_tag, last_modified)) {
+	if (ExternalFileCache::IsValid(false, version_tag, last_modified, new_etag, new_last_modified)) {
 		return ParquetCacheValidity::VALID;
 	}
 	return ParquetCacheValidity::INVALID;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1133,6 +1133,23 @@ void ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &state, 
 	}
 }
 
+void ParquetReader::GetPartitionStats(vector<PartitionStatistics> &result) {
+	GetPartitionStats(*GetFileMetadata(), result);
+}
+
+void ParquetReader::GetPartitionStats(const duckdb_parquet::FileMetaData &metadata,
+                                      vector<PartitionStatistics> &result) {
+	idx_t offset = 0;
+	for (auto &row_group : metadata.row_groups) {
+		PartitionStatistics partition_stats;
+		partition_stats.row_start = offset;
+		partition_stats.count = row_group.num_rows;
+		partition_stats.count_type = CountType::COUNT_EXACT;
+		offset += row_group.num_rows;
+		result.push_back(partition_stats);
+	}
+}
+
 bool ParquetReader::ScanInternal(ClientContext &context, ParquetReaderScanState &state, DataChunk &result) {
 	if (state.finished) {
 		return false;

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -509,7 +509,6 @@ bool FileSystem::ListFiles(const string &directory, const std::function<void(con
 		    directory,
 		    [&](const OpenFileInfo &info) {
 			    bool is_dir = IsDirectory(info);
-			    ;
 			    callback(info.path, is_dir);
 		    },
 		    opener);

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -368,8 +368,12 @@ string FileSystem::ExpandPath(const string &path) {
 // LCOV_EXCL_START
 unique_ptr<FileHandle> FileSystem::OpenFileExtended(const OpenFileInfo &path, FileOpenFlags flags,
                                                     optional_ptr<FileOpener> opener) {
-	// for backwards compatibility purposes - default to OpenFile
 	throw NotImplementedException("%s: OpenFileExtended is not implemented!", GetName());
+}
+
+bool FileSystem::ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+                                   optional_ptr<FileOpener> opener) {
+	throw NotImplementedException("%s: ListFilesExtended is not implemented!", GetName());
 }
 
 unique_ptr<FileHandle> FileSystem::OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener) {
@@ -389,6 +393,10 @@ unique_ptr<FileHandle> FileSystem::OpenFile(const OpenFileInfo &file, FileOpenFl
 }
 
 bool FileSystem::SupportsOpenFileExtended() const {
+	return false;
+}
+
+bool FileSystem::SupportsListFilesExtended() const {
 	return false;
 }
 
@@ -483,9 +491,46 @@ void FileSystem::RemoveDirectory(const string &directory, optional_ptr<FileOpene
 	throw NotImplementedException("%s: RemoveDirectory is not implemented!", GetName());
 }
 
+bool FileSystem::IsDirectory(const OpenFileInfo &info) {
+	if (!info.extended_info) {
+		return false;
+	}
+	auto entry = info.extended_info->options.find("type");
+	if (entry == info.extended_info->options.end()) {
+		return false;
+	}
+	return StringValue::Get(entry->second) == "directory";
+}
+
 bool FileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
                            FileOpener *opener) {
+	if (SupportsListFilesExtended()) {
+		return ListFilesExtended(
+		    directory,
+		    [&](const OpenFileInfo &info) {
+			    bool is_dir = IsDirectory(info);
+			    ;
+			    callback(info.path, is_dir);
+		    },
+		    opener);
+	}
 	throw NotImplementedException("%s: ListFiles is not implemented!", GetName());
+}
+
+bool FileSystem::ListFiles(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+                           optional_ptr<FileOpener> opener) {
+	if (SupportsListFilesExtended()) {
+		return ListFilesExtended(directory, callback, opener);
+	} else {
+		return ListFiles(directory, [&](const string &path, bool is_dir) {
+			OpenFileInfo info(path);
+			if (is_dir) {
+				info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+				info.extended_info->options["type"] = "directory";
+			}
+			callback(info);
+		});
+	}
 }
 
 void FileSystem::MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -662,8 +662,9 @@ void LocalFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener
 	}
 }
 
-bool LocalFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
-                                FileOpener *opener) {
+bool LocalFileSystem::ListFilesExtended(const string &directory,
+                                        const std::function<void(OpenFileInfo &info)> &callback,
+                                        optional_ptr<FileOpener> opener) {
 	auto normalized_dir = NormalizeLocalPath(directory);
 	auto dir = opendir(normalized_dir);
 	if (!dir) {
@@ -676,7 +677,8 @@ bool LocalFileSystem::ListFiles(const string &directory, const std::function<voi
 	struct dirent *ent;
 	// loop over all files in the directory
 	while ((ent = readdir(dir)) != nullptr) {
-		string name = string(ent->d_name);
+		OpenFileInfo info(ent->d_name);
+		auto &name = info.path;
 		// skip . .. and empty files
 		if (name.empty() || name == "." || name == "..") {
 			continue;
@@ -692,10 +694,20 @@ bool LocalFileSystem::ListFiles(const string &directory, const std::function<voi
 			// not a file or directory: skip
 			continue;
 		}
-		// invoke callback
-		callback(name, status.st_mode & S_IFDIR);
-	}
+		// create extended info
+		info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+		auto &options = info.extended_info->options;
+		// file type
+		Value file_type(status.st_mode & S_IFDIR ? "directory" : "file");
+		options.emplace("type", std::move(file_type));
+		// file size
+		options.emplace("file_size", Value::BIGINT(UnsafeNumericCast<int64_t>(status.st_size)));
+		// last modified time
+		options.emplace("last_modified", Value::TIMESTAMP(Timestamp::FromTimeT(status.st_mtime)));
 
+		// invoke callback
+		callback(info);
+	}
 	return true;
 }
 
@@ -1248,37 +1260,38 @@ static bool IsSymbolicLink(const string &path) {
 static void RecursiveGlobDirectories(FileSystem &fs, const string &path, vector<OpenFileInfo> &result,
                                      bool match_directory, bool join_path) {
 
-	fs.ListFiles(path, [&](const string &fname, bool is_directory) {
-		string concat;
+	fs.ListFiles(path, [&](OpenFileInfo &info) {
 		if (join_path) {
-			concat = fs.JoinPath(path, fname);
-		} else {
-			concat = fname;
+			info.path = fs.JoinPath(path, info.path);
 		}
-		if (IsSymbolicLink(concat)) {
+		if (IsSymbolicLink(info.path)) {
 			return;
 		}
-		if (is_directory == match_directory) {
-			result.push_back(concat);
-		}
+		bool is_directory = FileSystem::IsDirectory(info);
+		bool return_file = is_directory == match_directory;
 		if (is_directory) {
-			RecursiveGlobDirectories(fs, concat, result, match_directory, true);
+			if (return_file) {
+				result.push_back(info);
+			}
+			RecursiveGlobDirectories(fs, info.path, result, match_directory, true);
+		} else if (return_file) {
+			result.push_back(std::move(info));
 		}
 	});
 }
 
 static void GlobFilesInternal(FileSystem &fs, const string &path, const string &glob, bool match_directory,
                               vector<OpenFileInfo> &result, bool join_path) {
-	fs.ListFiles(path, [&](const string &fname, bool is_directory) {
+	fs.ListFiles(path, [&](OpenFileInfo &info) {
+		bool is_directory = FileSystem::IsDirectory(info);
 		if (is_directory != match_directory) {
 			return;
 		}
-		if (Glob(fname.c_str(), fname.size(), glob.c_str(), glob.size())) {
+		if (Glob(info.path.c_str(), info.path.size(), glob.c_str(), glob.size())) {
 			if (join_path) {
-				result.push_back(fs.JoinPath(path, fname));
-			} else {
-				result.push_back(fname);
+				info.path = fs.JoinPath(path, info.path);
 			}
+			result.push_back(std::move(info));
 		}
 	});
 }

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1181,7 +1181,7 @@ bool LocalFileSystem::ListFilesExtended(const string &directory,
 		// file size
 		int64_t file_size_bytes =
 		    (static_cast<int64_t>(ffd.nFileSizeHigh) << 32) | static_cast<int64_t>(ffd.nFileSizeLow);
-		options.emplace("file_size", Value::BIGINT(file_size_bytes);
+		options.emplace("file_size", Value::BIGINT(file_size_bytes));
 		// last modified time
 		auto last_modified_time = FiletimeToTimeT(ffd.ftLastWriteTime);
 		options.emplace("last_modified", Value::TIMESTAMP(Timestamp::FromTimeT(last_modified_time)));

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -547,4 +547,17 @@ TimestampComponents Timestamp::GetComponents(timestamp_t timestamp) {
 	return result;
 }
 
+time_t Timestamp::ToTimeT(timestamp_t timestamp) {
+	auto components = Timestamp::GetComponents(timestamp);
+	struct tm tm {};
+	tm.tm_year = components.year - 1900;
+	tm.tm_mon = components.month - 1;
+	tm.tm_mday = components.day;
+	tm.tm_hour = components.hour;
+	tm.tm_min = components.minute;
+	tm.tm_sec = components.second;
+	tm.tm_isdst = 0;
+	return mktime(&tm);
+}
+
 } // namespace duckdb

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -560,4 +560,20 @@ time_t Timestamp::ToTimeT(timestamp_t timestamp) {
 	return mktime(&tm);
 }
 
+timestamp_t Timestamp::FromTimeT(time_t time) {
+	struct tm tm {};
+	localtime_r(&time, &tm);
+
+	int32_t year = tm.tm_year + 1900;
+	int32_t month = tm.tm_mon + 1;
+	int32_t day = tm.tm_mday;
+	int32_t hour = tm.tm_hour;
+	int32_t min = tm.tm_min;
+	int32_t sec = tm.tm_sec;
+
+	auto dt = Date::FromDate(year, month, day);
+	auto t = Time::FromTime(hour, min, sec, 0);
+	return FromDatetime(dt, t);
+}
+
 } // namespace duckdb

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/operator/multiply.hpp"
 #include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/common/windows.hpp"
 #include <ctime>
 
 namespace duckdb {
@@ -562,7 +563,11 @@ time_t Timestamp::ToTimeT(timestamp_t timestamp) {
 
 timestamp_t Timestamp::FromTimeT(time_t time) {
 	struct tm tm {};
+#ifdef DUCKDB_WINDOWS
+	tm = localtime(&tm);
+#else
 	localtime_r(&time, &tm);
+#endif
 
 	int32_t year = tm.tm_year + 1900;
 	int32_t month = tm.tm_mon + 1;

--- a/src/common/types/timestamp.cpp
+++ b/src/common/types/timestamp.cpp
@@ -562,19 +562,22 @@ time_t Timestamp::ToTimeT(timestamp_t timestamp) {
 }
 
 timestamp_t Timestamp::FromTimeT(time_t time) {
-	struct tm tm {};
 #ifdef DUCKDB_WINDOWS
-	tm = localtime(&tm);
+	auto tm = localtime(&time);
 #else
-	localtime_r(&time, &tm);
+	struct tm tm_storage {};
+	auto tm = localtime_r(&time, &tm_storage);
 #endif
+	if (!tm) {
+		throw InternalException("FromTimeT failed: null pointer returned");
+	}
 
-	int32_t year = tm.tm_year + 1900;
-	int32_t month = tm.tm_mon + 1;
-	int32_t day = tm.tm_mday;
-	int32_t hour = tm.tm_hour;
-	int32_t min = tm.tm_min;
-	int32_t sec = tm.tm_sec;
+	int32_t year = tm->tm_year + 1900;
+	int32_t month = tm->tm_mon + 1;
+	int32_t day = tm->tm_mday;
+	int32_t hour = tm->tm_hour;
+	int32_t min = tm->tm_min;
+	int32_t sec = tm->tm_sec;
 
 	auto dt = Date::FromDate(year, month, day);
 	auto t = Time::FromTime(hour, min, sec, 0);

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -95,8 +95,9 @@ void VirtualFileSystem::RemoveDirectory(const string &directory, optional_ptr<Fi
 	FindFileSystem(directory).RemoveDirectory(directory, opener);
 }
 
-bool VirtualFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
-                                  FileOpener *opener) {
+bool VirtualFileSystem::ListFilesExtended(const string &directory,
+                                          const std::function<void(OpenFileInfo &info)> &callback,
+                                          optional_ptr<FileOpener> opener) {
 	return FindFileSystem(directory).ListFiles(directory, callback, opener);
 }
 

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -165,6 +165,8 @@ public:
 	DUCKDB_API virtual bool ListFiles(const string &directory,
 	                                  const std::function<void(const string &, bool)> &callback,
 	                                  FileOpener *opener = nullptr);
+	DUCKDB_API bool ListFiles(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+	                          optional_ptr<FileOpener> opener = nullptr);
 
 	//! Move a file from source path to the target, StorageManager relies on this being an atomic action for ACID
 	//! properties
@@ -265,10 +267,17 @@ public:
 
 	DUCKDB_API virtual void SetDisabledFileSystems(const vector<string> &names);
 
+	DUCKDB_API static bool IsDirectory(const OpenFileInfo &info);
+
 protected:
 	DUCKDB_API virtual unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &path, FileOpenFlags flags,
 	                                                           optional_ptr<FileOpener> opener);
 	DUCKDB_API virtual bool SupportsOpenFileExtended() const;
+
+	DUCKDB_API virtual bool ListFilesExtended(const string &directory,
+	                                          const std::function<void(OpenFileInfo &info)> &callback,
+	                                          optional_ptr<FileOpener> opener);
+	DUCKDB_API virtual bool SupportsListFilesExtended() const;
 
 public:
 	template <class TARGET>

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -50,9 +50,6 @@ public:
 	void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override;
 	//! Recursively remove a directory and all files in it
 	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override;
-	//! List files in a directory, invoking the callback method for each one with (filename, is_dir)
-	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
-	               FileOpener *opener = nullptr) override;
 	//! Move a file from source path to the target, StorageManager relies on this being an atomic action for ACID
 	//! properties
 	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener = nullptr) override;
@@ -98,6 +95,14 @@ public:
 
 	// returns a C-string of the path that trims any file:/ prefix
 	static const char *NormalizeLocalPath(const string &path);
+
+protected:
+	bool ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+	                       optional_ptr<FileOpener> opener) override;
+
+	bool SupportsListFilesExtended() const override {
+		return true;
+	}
 
 private:
 	//! Set the file pointer of a file handle to a specified location. Reads and writes will happen from this location

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -76,13 +76,6 @@ public:
 		return GetFileSystem().RemoveDirectory(directory, GetOpener());
 	}
 
-	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
-	               FileOpener *opener = nullptr) override {
-		VerifyNoOpener(opener);
-		VerifyCanAccessDirectory(directory);
-		return GetFileSystem().ListFiles(directory, callback, GetOpener().get());
-	}
-
 	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) override {
 		VerifyNoOpener(opener);
 		VerifyCanAccessFile(source);
@@ -157,6 +150,17 @@ protected:
 	}
 
 	bool SupportsOpenFileExtended() const override {
+		return true;
+	}
+
+	bool ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+	                       optional_ptr<FileOpener> opener) override {
+		VerifyNoOpener(opener);
+		VerifyCanAccessDirectory(directory);
+		return GetFileSystem().ListFiles(directory, callback, GetOpener().get());
+	}
+
+	bool SupportsListFilesExtended() const override {
 		return true;
 	}
 

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -218,6 +218,7 @@ public:
 
 	//! Decompose a timestamp into its components
 	DUCKDB_API static TimestampComponents GetComponents(timestamp_t timestamp);
+	DUCKDB_API static time_t ToTimeT(timestamp_t);
 
 	DUCKDB_API static bool TryParseUTCOffset(const char *str, idx_t &pos, idx_t len, int &hh, int &mm, int &ss);
 

--- a/src/include/duckdb/common/types/timestamp.hpp
+++ b/src/include/duckdb/common/types/timestamp.hpp
@@ -219,6 +219,7 @@ public:
 	//! Decompose a timestamp into its components
 	DUCKDB_API static TimestampComponents GetComponents(timestamp_t timestamp);
 	DUCKDB_API static time_t ToTimeT(timestamp_t);
+	DUCKDB_API static timestamp_t FromTimeT(time_t);
 
 	DUCKDB_API static bool TryParseUTCOffset(const char *str, idx_t &pos, idx_t len, int &hh, int &mm, int &ss);
 

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -41,9 +41,6 @@ public:
 
 	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener) override;
 
-	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
-	               FileOpener *opener = nullptr) override;
-
 	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) override;
 
 	bool FileExists(const string &filename, optional_ptr<FileOpener> opener) override;
@@ -73,6 +70,13 @@ protected:
 	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
 	                                        optional_ptr<FileOpener> opener) override;
 	bool SupportsOpenFileExtended() const override {
+		return true;
+	}
+
+	bool ListFilesExtended(const string &directory, const std::function<void(OpenFileInfo &info)> &callback,
+	                       optional_ptr<FileOpener> opener) override;
+
+	bool SupportsListFilesExtended() const override {
 		return true;
 	}
 

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -101,7 +101,7 @@ public:
 	//! Gets the cached file, or creates it if is not yet present
 	CachedFile &GetOrCreateCachedFile(const string &path);
 
-	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, time_t cached_last_modified,
+	DUCKDB_API static bool IsValid(bool validate, const string &new_version_tag, time_t new_last_modified,
 	                               const string &current_version_tag, time_t current_last_modified);
 
 private:

--- a/src/include/duckdb/storage/external_file_cache.hpp
+++ b/src/include/duckdb/storage/external_file_cache.hpp
@@ -101,7 +101,7 @@ public:
 	//! Gets the cached file, or creates it if is not yet present
 	CachedFile &GetOrCreateCachedFile(const string &path);
 
-	DUCKDB_API static bool IsValid(bool validate, const string &new_version_tag, time_t new_last_modified,
+	DUCKDB_API static bool IsValid(bool validate, const string &cached_version_tag, time_t cached_last_modified,
 	                               const string &current_version_tag, time_t current_last_modified);
 
 private:

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -46,6 +46,10 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 	// we can do the rewrite! get the stats
 	GetPartitionStatsInput input(get.function, get.bind_data.get());
 	auto partition_stats = get.function.get_partition_stats(context, input);
+	if (partition_stats.empty()) {
+		// no partition stats found
+		return;
+	}
 	idx_t count = 0;
 	for (auto &stats : partition_stats) {
 		if (stats.count_type == CountType::COUNT_APPROXIMATE) {

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -13,12 +13,16 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 		// not possible with groups
 		return;
 	}
-	if (aggr.children[0]->type != LogicalOperatorType::LOGICAL_GET) {
+	// skip any projections
+	reference<LogicalOperator> child_ref = *aggr.children[0];
+	while (child_ref.get().type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		child_ref = *child_ref.get().children[0];
+	}
+	if (child_ref.get().type != LogicalOperatorType::LOGICAL_GET) {
 		// child must be a LOGICAL_GET
-		// FIXME: we could do this with projections as well
 		return;
 	}
-	auto &get = aggr.children[0]->Cast<LogicalGet>();
+	auto &get = child_ref.get().Cast<LogicalGet>();
 	if (!get.function.get_partition_stats) {
 		// GET does not support getting the partition stats
 		return;

--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -70,15 +70,15 @@ void ExternalFileCache::CachedFile::Verify(const unique_ptr<StorageLockKey> &gua
 #endif
 }
 
-bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag, time_t cached_last_modified,
+bool ExternalFileCache::IsValid(bool validate, const string &new_version_tag, time_t new_last_modified,
                                 const string &current_version_tag, time_t current_last_modified) {
 	if (!validate) {
 		return true; // Assume valid
 	}
 	if (!current_version_tag.empty()) {
-		return cached_version_tag == current_version_tag; // Validity checked by version tag (httpfs)
+		return new_version_tag == current_version_tag; // Validity checked by version tag (httpfs)
 	}
-	if (cached_last_modified != current_last_modified) {
+	if (new_last_modified != current_last_modified) {
 		return false; // The file has certainly been modified
 	}
 	// The last modified time matches. However, we cannot blindly trust this,

--- a/src/storage/external_file_cache.cpp
+++ b/src/storage/external_file_cache.cpp
@@ -70,15 +70,15 @@ void ExternalFileCache::CachedFile::Verify(const unique_ptr<StorageLockKey> &gua
 #endif
 }
 
-bool ExternalFileCache::IsValid(bool validate, const string &new_version_tag, time_t new_last_modified,
+bool ExternalFileCache::IsValid(bool validate, const string &cached_version_tag, time_t cached_last_modified,
                                 const string &current_version_tag, time_t current_last_modified) {
 	if (!validate) {
 		return true; // Assume valid
 	}
-	if (!current_version_tag.empty()) {
-		return new_version_tag == current_version_tag; // Validity checked by version tag (httpfs)
+	if (!current_version_tag.empty() || !cached_version_tag.empty()) {
+		return cached_version_tag == current_version_tag; // Validity checked by version tag (httpfs)
 	}
-	if (new_last_modified != current_last_modified) {
+	if (cached_last_modified != current_last_modified) {
 		return false; // The file has certainly been modified
 	}
 	// The last modified time matches. However, we cannot blindly trust this,

--- a/test/sql/copy/parquet/parallel_parquet_glob.test
+++ b/test/sql/copy/parquet/parallel_parquet_glob.test
@@ -34,3 +34,16 @@ query I
 select count(*) from parquet_scan('data/parquet-testing/g*/t1.parquet')
 ----
 2
+
+statement ok
+SET parquet_metadata_cache=true
+
+query I
+select count(*) from parquet_scan('data/parquet-testing/g*/t1.parquet')
+----
+2
+
+query I
+select count(*) from parquet_scan('data/parquet-testing/g*/t1.parquet')
+----
+2

--- a/test/sql/tpch/tpch_hive_partition.test_slow
+++ b/test/sql/tpch/tpch_hive_partition.test_slow
@@ -50,3 +50,16 @@ ORDER BY ALL
 ----
 2996217	114642100492.01	F
 3004998	114935210409.19	O
+
+statement ok
+SET parquet_metadata_cache=true
+
+query I
+select count(*) from lineitem
+----
+6001215
+
+query I
+select count(*) from lineitem
+----
+6001215


### PR DESCRIPTION

This PR modifies the Parquet reader to support `GetPartitionStats` when either (1) reading a single file, or (2) when all files that are read have their metadata cached. This allows us to emit partition data from Parquet files, also when globbing many files.

In order to avoid the cache invalidation from being expensive during this check, we perform the cache invalidation **only** using the `OpenFileInfo` objects that we have received from the multi file list - i.e. no additional file system calls are performed. This builds on the work in e.g. https://github.com/duckdb/duckdb-httpfs/pull/45 which alllows us to find the relevant information for performing cache invalidation during globbing and pushing that through all the relevant layers.

#### ListFilesExtended

In order to make this work also for local file systems, a new `ListFiles` method is introduced that returns `OpenFileInfo` objects instead of `string` objects:

```cpp
bool ListFiles(const string &directory, const std::function<void(OpenFileInfo &info)> &callback, 
               optional_ptr<FileOpener> opener = nullptr);
```

For backwards compatibility with other file systems, this method only needs to be optionally implemented through the `ListFilesExtended` method when `SupportsListFilesExtended` is overloaded to support true. This allows file systems to optionally implement either the extended callback or the older method.

```cpp
virtual bool ListFilesExtended(const string &directory,
                               const std::function<void(OpenFileInfo &info)> &callback,
                               optional_ptr<FileOpener> opener);
virtual bool SupportsListFilesExtended() const;
```

This PR then implements the `ListFilesExtended` callback for the `LocalFileSystem`:

* On Unix, we already did a `stat` call per file to find out if it was a directory - we now also read the file size (`st_size`) and last modified time (`st_mtime`) from the result.
* On Windows, globbing already returns a [`WIN32_FIND_DATAW`](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-win32_find_dataw) struct for each file that contains the relevant information.


#### Performance

`GetPartitionStats` is currently only used for `COUNT(*)` (see https://github.com/duckdb/duckdb/pull/15301) - although there are plans to have this used in more scenarios.

##### Single File COUNT(*)

When reading a single file, we always emit `GetPartitionStats` also without metadata caching enabled - since we have already read the metadata as part of the initial schema detection step. This allows `COUNT(*)` to always be faster in this scenario using these changes:

```sql
SELECT COUNT(*) FROM hits.parquet;
```

|  main  |  new   |
|--------|--------|
| 0.054s | 0.035s |

##### Cached COUNT(*)

When enabling metadata caching, we can see that the cached metadata is used to accelarate `COUNT(*)`:

```sql
SET parquet_metadata_cache=true;
SELECT COUNT(*) FROM 'hits_partitioned/*.parquet';
```

| main  |  new   |
|-------|--------|
| 0.048 | 0.003s |
