### PR TITLE
Add support for UUID v7 to Filename Pattern - and clean it up so that it correctly supports composite patterns

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -67,6 +67,7 @@
 #include "duckdb/common/extra_type_info.hpp"
 #include "duckdb/common/file_buffer.hpp"
 #include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/common/filename_pattern.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/common/multi_file/multi_file_options.hpp"
@@ -1801,6 +1802,26 @@ const char* EnumUtil::ToChars<FileLockType>(FileLockType value) {
 template<>
 FileLockType EnumUtil::FromString<FileLockType>(const char *value) {
 	return static_cast<FileLockType>(StringUtil::StringToEnum(GetFileLockTypeValues(), 3, "FileLockType", value));
+}
+
+const StringUtil::EnumStringLiteral *GetFileNameSegmentTypeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(FileNameSegmentType::LITERAL), "LITERAL" },
+		{ static_cast<uint32_t>(FileNameSegmentType::UUID_V4), "UUID_V4" },
+		{ static_cast<uint32_t>(FileNameSegmentType::UUID_V7), "UUID_V7" },
+		{ static_cast<uint32_t>(FileNameSegmentType::OFFSET), "OFFSET" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<FileNameSegmentType>(FileNameSegmentType value) {
+	return StringUtil::EnumToString(GetFileNameSegmentTypeValues(), 4, "FileNameSegmentType", static_cast<uint32_t>(value));
+}
+
+template<>
+FileNameSegmentType EnumUtil::FromString<FileNameSegmentType>(const char *value) {
+	return static_cast<FileNameSegmentType>(StringUtil::StringToEnum(GetFileNameSegmentTypeValues(), 4, "FileNameSegmentType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetFilterPropagateResultValues() {

--- a/src/common/filename_pattern.cpp
+++ b/src/common/filename_pattern.cpp
@@ -14,7 +14,7 @@ FilenamePattern::FilenamePattern() {
 	segments.emplace_back(FileNameSegmentType::OFFSET);
 }
 
-FilenamePattern::FilenamePattern(string base, idx_t pos, bool uuid, vector<FileNameSegment> segments_p) {
+FilenamePattern::FilenamePattern(const string &base, idx_t pos, bool uuid, vector<FileNameSegment> segments_p) {
 	if (!segments_p.empty()) {
 		segments = std::move(segments_p);
 		return;
@@ -54,7 +54,7 @@ void FilenamePattern::SetFilenamePattern(const string &pattern) {
 			continue;
 		}
 		// found a { - check if this is one of the supported pattern
-		idx_t remaining_length = patterns.size() - i;
+		idx_t remaining_length = pattern.size() - i;
 		for (auto &pat : patterns) {
 			if (remaining_length < pat.pattern.size()) {
 				// cannot match

--- a/src/common/filename_pattern.cpp
+++ b/src/common/filename_pattern.cpp
@@ -3,40 +3,182 @@
 
 namespace duckdb {
 
+FileNameSegment::FileNameSegment(string data) : type(FileNameSegmentType::LITERAL), data(std::move(data)) {
+}
+
+FileNameSegment::FileNameSegment(FileNameSegmentType type) : type(type) {
+}
+
+FilenamePattern::FilenamePattern() {
+	segments.emplace_back("data_");
+	segments.emplace_back(FileNameSegmentType::OFFSET);
+}
+
+FilenamePattern::FilenamePattern(string base, idx_t pos, bool uuid, vector<FileNameSegment> segments_p) {
+	if (!segments_p.empty()) {
+		segments = std::move(segments_p);
+		return;
+	}
+	// deserialize from legacy pattern
+	if (pos > 0) {
+		segments.emplace_back(base.substr(0, pos));
+	}
+	if (uuid) {
+		segments.emplace_back(FileNameSegmentType::UUID_V4);
+	} else {
+		segments.emplace_back(FileNameSegmentType::OFFSET);
+	}
+	if (pos < base.size()) {
+		segments.emplace_back(base.substr(pos, base.size() - pos));
+	}
+}
+
 void FilenamePattern::SetFilenamePattern(const string &pattern) {
-	const string id_format {"{i}"};
-	const string uuid_format {"{uuid}"};
+	struct StringPattern {
+		StringPattern(string pattern_p, FileNameSegmentType type) : pattern(std::move(pattern_p)), type(type) {
+		}
 
-	base = pattern;
+		string pattern;
+		FileNameSegmentType type;
+	};
+	vector<StringPattern> patterns;
+	patterns.emplace_back("{i}", FileNameSegmentType::OFFSET);
+	patterns.emplace_back("{uuid}", FileNameSegmentType::UUID_V4);
+	patterns.emplace_back("{uuidv4}", FileNameSegmentType::UUID_V4);
+	patterns.emplace_back("{uuidv7}", FileNameSegmentType::UUID_V7);
 
-	pos = base.find(id_format);
-	uuid = false;
-	if (pos != string::npos) {
-		base = StringUtil::Replace(base, id_format, "");
-		uuid = false;
+	idx_t current_pos = 0;
+	segments.clear();
+	for (idx_t i = 0; i < pattern.size(); i++) {
+		if (pattern[i] != '{') {
+			continue;
+		}
+		// found a { - check if this is one of the supported pattern
+		idx_t remaining_length = patterns.size() - i;
+		for (auto &pat : patterns) {
+			if (remaining_length < pat.pattern.size()) {
+				// cannot match
+				continue;
+			}
+			if (memcmp(pat.pattern.c_str(), pattern.c_str() + i, pat.pattern.size()) != 0) {
+				// no match
+				continue;
+			}
+			// found a match!
+			if (i > current_pos) {
+				// add a literal pattern
+				segments.emplace_back(pattern.substr(current_pos, i - current_pos));
+			}
+			// add the pattern here
+			segments.emplace_back(pat.type);
+
+			// advance the search forward
+			i += pat.pattern.size() - 1;
+			current_pos = i + 1;
+			break;
+		}
 	}
-
-	pos = base.find(uuid_format);
-	if (pos != string::npos) {
-		base = StringUtil::Replace(base, uuid_format, "");
-		uuid = true;
+	// add the final pattern (if any)
+	if (current_pos < pattern.size()) {
+		segments.emplace_back(pattern.substr(current_pos));
 	}
-
-	pos = std::min(pos, (idx_t)base.length());
+	if (segments.size() == 1 && segments[0].type == FileNameSegmentType::LITERAL) {
+		// if we have ONLY a literal we add an offset at the end
+		segments.emplace_back(FileNameSegmentType::OFFSET);
+	}
 }
 
 string FilenamePattern::CreateFilename(FileSystem &fs, const string &path, const string &extension,
                                        idx_t offset) const {
-	string result(base);
-	string replacement;
-
-	if (uuid) {
-		replacement = UUID::ToString(UUID::GenerateRandomUUID());
-	} else {
-		replacement = std::to_string(offset);
+	string result;
+	for (auto &segment : segments) {
+		switch (segment.type) {
+		case FileNameSegmentType::LITERAL:
+			result += segment.data;
+			break;
+		case FileNameSegmentType::UUID_V4:
+			result += UUID::ToString(UUID::GenerateRandomUUID());
+			break;
+		case FileNameSegmentType::UUID_V7:
+			result += UUID::ToString(UUIDv7::GenerateRandomUUID());
+			break;
+		case FileNameSegmentType::OFFSET:
+			result += std::to_string(offset);
+			break;
+		default:
+			throw InternalException("Unsupported type for Filename Pattern");
+		}
 	}
-	result.insert(pos, replacement);
 	return fs.JoinPath(path, result + "." + extension);
+}
+
+bool FilenamePattern::HasUUID() const {
+	for (auto &segment : segments) {
+		if (segment.type == FileNameSegmentType::UUID_V4 || segment.type == FileNameSegmentType::UUID_V7) {
+			return true;
+		}
+	}
+	return false;
+}
+
+struct LegacyFilenamePattern {
+	string base;
+	idx_t pos;
+};
+
+bool SupportsLegacyFilenamePattern(const vector<FileNameSegment> &segments) {
+	idx_t non_literal_count = 0;
+	for (auto &segment : segments) {
+		if (segment.type == FileNameSegmentType::UUID_V7) {
+			// UUID v7 is not supported in legacy mode
+			return false;
+		}
+		if (segment.type != FileNameSegmentType::LITERAL) {
+			non_literal_count++;
+		}
+	}
+	if (non_literal_count != 1) {
+		// legacy mode requires exactly one non-literal
+		return false;
+	}
+	return true;
+}
+
+LegacyFilenamePattern GetLegacyFilenamePattern(const vector<FileNameSegment> &segments) {
+	LegacyFilenamePattern pattern;
+	// construct the base + pos
+	for (auto &segment : segments) {
+		if (segment.type == FileNameSegmentType::LITERAL) {
+			// add the literal to the base
+			pattern.base += segment.data;
+		} else {
+			// non-literal: set the position to the current location
+			pattern.pos = pattern.base.size();
+		}
+	}
+	return pattern;
+}
+
+string FilenamePattern::SerializeBase() const {
+	if (!SupportsLegacyFilenamePattern(segments)) {
+		return string();
+	}
+	return GetLegacyFilenamePattern(segments).base;
+}
+
+idx_t FilenamePattern::SerializePos() const {
+	if (!SupportsLegacyFilenamePattern(segments)) {
+		return 0;
+	}
+	return GetLegacyFilenamePattern(segments).pos;
+}
+
+vector<FileNameSegment> FilenamePattern::SerializeSegments() const {
+	if (SupportsLegacyFilenamePattern(segments)) {
+		// for legacy mode we don't serialize the segments
+		return vector<FileNameSegment>();
+	}
+	return segments;
 }
 
 } // namespace duckdb

--- a/src/common/filename_pattern.cpp
+++ b/src/common/filename_pattern.cpp
@@ -14,7 +14,7 @@ FilenamePattern::FilenamePattern() {
 	segments.emplace_back(FileNameSegmentType::OFFSET);
 }
 
-FilenamePattern::FilenamePattern(const string &base, idx_t pos, bool uuid, vector<FileNameSegment> segments_p) {
+FilenamePattern::FilenamePattern(string base, idx_t pos, bool uuid, vector<FileNameSegment> segments_p) {
 	if (!segments_p.empty()) {
 		segments = std::move(segments_p);
 		return;
@@ -28,7 +28,9 @@ FilenamePattern::FilenamePattern(const string &base, idx_t pos, bool uuid, vecto
 	} else {
 		segments.emplace_back(FileNameSegmentType::OFFSET);
 	}
-	if (pos < base.size()) {
+	if (pos == 0 && !base.empty()) {
+		segments.emplace_back(std::move(base));
+	} else if (pos < base.size()) {
 		segments.emplace_back(base.substr(pos, base.size() - pos));
 	}
 }

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -178,6 +178,8 @@ enum class FileGlobOptions : uint8_t;
 
 enum class FileLockType : uint8_t;
 
+enum class FileNameSegmentType : uint8_t;
+
 enum class FilterPropagateResult : uint8_t;
 
 enum class ForeignKeyType : uint8_t;
@@ -621,6 +623,9 @@ const char* EnumUtil::ToChars<FileGlobOptions>(FileGlobOptions value);
 
 template<>
 const char* EnumUtil::ToChars<FileLockType>(FileLockType value);
+
+template<>
+const char* EnumUtil::ToChars<FileNameSegmentType>(FileNameSegmentType value);
 
 template<>
 const char* EnumUtil::ToChars<FilterPropagateResult>(FilterPropagateResult value);
@@ -1177,6 +1182,9 @@ FileGlobOptions EnumUtil::FromString<FileGlobOptions>(const char *value);
 
 template<>
 FileLockType EnumUtil::FromString<FileLockType>(const char *value);
+
+template<>
+FileNameSegmentType EnumUtil::FromString<FileNameSegmentType>(const char *value);
 
 template<>
 FilterPropagateResult EnumUtil::FromString<FilterPropagateResult>(const char *value);

--- a/src/include/duckdb/common/filename_pattern.hpp
+++ b/src/include/duckdb/common/filename_pattern.hpp
@@ -34,7 +34,7 @@ public:
 class FilenamePattern {
 public:
 	FilenamePattern();
-	FilenamePattern(string base, idx_t pos, bool uuid, vector<FileNameSegment> segments);
+	FilenamePattern(const string &base, idx_t pos, bool uuid, vector<FileNameSegment> segments);
 
 public:
 	void SetFilenamePattern(const string &pattern);

--- a/src/include/duckdb/common/filename_pattern.hpp
+++ b/src/include/duckdb/common/filename_pattern.hpp
@@ -34,7 +34,7 @@ public:
 class FilenamePattern {
 public:
 	FilenamePattern();
-	FilenamePattern(const string &base, idx_t pos, bool uuid, vector<FileNameSegment> segments);
+	FilenamePattern(string base, idx_t pos, bool uuid, vector<FileNameSegment> segments);
 
 public:
 	void SetFilenamePattern(const string &pattern);

--- a/src/include/duckdb/common/optional_idx.hpp
+++ b/src/include/duckdb/common/optional_idx.hpp
@@ -47,6 +47,10 @@ public:
 		return index == rhs.index;
 	}
 
+	inline bool operator!=(const optional_idx &rhs) const {
+		return index != rhs.index;
+	}
+
 private:
 	idx_t index;
 };

--- a/src/include/duckdb/planner/operator/logical_empty_result.hpp
+++ b/src/include/duckdb/planner/operator/logical_empty_result.hpp
@@ -22,6 +22,7 @@ public:
 
 public:
 	explicit LogicalEmptyResult(unique_ptr<LogicalOperator> op);
+	LogicalEmptyResult(vector<LogicalType> return_types, vector<ColumnBinding> bindings);
 
 	//! The set of return types of the empty result
 	vector<LogicalType> return_types;

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -949,17 +949,43 @@
       {
         "id": 200,
         "name": "base",
-        "type": "string"
+        "type": "string",
+        "serialize_property": "SerializeBase()"
       },
       {
         "id": 201,
         "name": "pos",
-        "type": "idx_t"
+        "type": "idx_t",
+        "serialize_property": "SerializePos()"
       },
       {
         "id": 202,
         "name": "uuid",
-        "type": "bool"
+        "type": "bool",
+        "serialize_property": "HasUUID()"
+      },
+      {
+        "id": 203,
+        "name": "segments",
+        "type": "vector<FileNameSegment>",
+        "serialize_property": "SerializeSegments()"
+      }
+    ],
+    "constructor": ["base", "pos", "uuid", "segments"]
+  },
+  {
+    "class": "FileNameSegment",
+    "pointer_type": "none",
+    "members": [
+      {
+        "id": 200,
+        "name": "type",
+        "type": "FileNameSegmentType"
+      },
+      {
+        "id": 201,
+        "name": "data",
+        "type": "string"
       }
     ]
   }

--- a/src/planner/operator/logical_empty_result.cpp
+++ b/src/planner/operator/logical_empty_result.cpp
@@ -11,6 +11,11 @@ LogicalEmptyResult::LogicalEmptyResult(unique_ptr<LogicalOperator> op)
 	this->return_types = op->types;
 }
 
+LogicalEmptyResult::LogicalEmptyResult(vector<LogicalType> return_types_p, vector<ColumnBinding> bindings_p)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_EMPTY_RESULT), return_types(std::move(return_types_p)),
+      bindings(std::move(bindings_p)) {
+}
+
 LogicalEmptyResult::LogicalEmptyResult() : LogicalOperator(LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
 }
 

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -189,17 +189,31 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 	return result;
 }
 
+void FileNameSegment::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<FileNameSegmentType>(200, "type", type);
+	serializer.WritePropertyWithDefault<string>(201, "data", data);
+}
+
+FileNameSegment FileNameSegment::Deserialize(Deserializer &deserializer) {
+	FileNameSegment result;
+	deserializer.ReadProperty<FileNameSegmentType>(200, "type", result.type);
+	deserializer.ReadPropertyWithDefault<string>(201, "data", result.data);
+	return result;
+}
+
 void FilenamePattern::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<string>(200, "base", base);
-	serializer.WritePropertyWithDefault<idx_t>(201, "pos", pos);
-	serializer.WritePropertyWithDefault<bool>(202, "uuid", uuid);
+	serializer.WritePropertyWithDefault<string>(200, "base", SerializeBase());
+	serializer.WritePropertyWithDefault<idx_t>(201, "pos", SerializePos());
+	serializer.WritePropertyWithDefault<bool>(202, "uuid", HasUUID());
+	serializer.WritePropertyWithDefault<vector<FileNameSegment>>(203, "segments", SerializeSegments());
 }
 
 FilenamePattern FilenamePattern::Deserialize(Deserializer &deserializer) {
-	FilenamePattern result;
-	deserializer.ReadPropertyWithDefault<string>(200, "base", result.base);
-	deserializer.ReadPropertyWithDefault<idx_t>(201, "pos", result.pos);
-	deserializer.ReadPropertyWithDefault<bool>(202, "uuid", result.uuid);
+	auto base = deserializer.ReadPropertyWithDefault<string>(200, "base");
+	auto pos = deserializer.ReadPropertyWithDefault<idx_t>(201, "pos");
+	auto uuid = deserializer.ReadPropertyWithDefault<bool>(202, "uuid");
+	auto segments = deserializer.ReadPropertyWithDefault<vector<FileNameSegment>>(203, "segments");
+	FilenamePattern result(std::move(base), pos, uuid, std::move(segments));
 	return result;
 }
 

--- a/test/sql/copy/format_uuid.test
+++ b/test/sql/copy/format_uuid.test
@@ -114,8 +114,6 @@ COPY test5 TO '__TEST_DIR__/part' (FORMAT PARQUET, PARTITION_BY (a));
 ----
 Directory
 
-
-
 # Test where the FILENAME_PATTERN param has no value
 statement error
 COPY test4 TO '__TEST_DIR__/to_be_overwritten' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PATTERN);
@@ -135,15 +133,33 @@ SELECT * FROM '__TEST_DIR__/to_be_overwritten/a=9/a_file_name*.parquet';
 ----
 36	6561	9
 
-
 # Test with a combination of {i} and {uuid}
 statement ok
 COPY test5 TO '__TEST_DIR__/incorrect_pos' (FORMAT PARQUET, PARTITION_BY (a), filename_pattern "a_name{i}_with_{uuid}_numbers");
 
 query III sort
-SELECT * FROM '__TEST_DIR__/incorrect_pos/a=5/a_name_with_????????-????-4???-????-????????????_numbers.parquet';
+SELECT * FROM '__TEST_DIR__/incorrect_pos/a=5/a_name?_with_????????-????-4???-????-????????????_numbers.parquet';
 ----
 25	3125	5
+
+# Test UUID v7
+statement ok
+COPY test5 TO '__TEST_DIR__/uuid_v7' (FORMAT PARQUET, PARTITION_BY (a), filename_pattern "a_name_with_{uuidv7}");
+
+query III sort
+SELECT * FROM '__TEST_DIR__/uuid_v7/a=5/a_name_with_????????-????-7???-????-????????????.parquet';
+----
+25	3125	5
+
+# Test UUID v7 mixed with UUID v4
+statement ok
+COPY test5 TO '__TEST_DIR__/mixed_uuid_types' (FORMAT PARQUET, PARTITION_BY (a), filename_pattern "a_name{uuid}_with_{uuidv7}_numbers");
+
+query III sort
+SELECT * FROM '__TEST_DIR__/mixed_uuid_types/a=5/a_name????????-????-4???-????-????????????_with_????????-????-7???-????-????????????_numbers.parquet';
+----
+25	3125	5
+
 
 # Test "{uuid}" with per_thread_output TRUE
 statement ok

--- a/test/sql/copy/format_uuid.test
+++ b/test/sql/copy/format_uuid.test
@@ -34,10 +34,10 @@ query III
 SELECT * FROM test2;
 ----
 0	0	0
-1	2	1 
+1	2	1
 2	4	4
 3	6	9
-4	8	16 
+4	8	16
 5	10	25
 6	12	36
 7	14	49
@@ -51,6 +51,23 @@ COPY test2 TO '__TEST_DIR__/part' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PA
 # the filename contains a uuid
 query III
 SELECT * FROM '__TEST_DIR__/part/a=9/leading_????????-????-4???-????-????????????.parquet';
+----
+18	81	9
+
+statement ok
+COPY test2 TO '__TEST_DIR__/trailing' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PATTERN "{uuid}_trailing");
+
+# the filename contains a uuid
+query III
+SELECT * FROM '__TEST_DIR__/trailing/a=9/????????-????-4???-????-????????????_trailing.parquet';
+----
+18	81	9
+
+statement ok
+COPY test2 TO '__TEST_DIR__/only_offset' (FORMAT PARQUET, PARTITION_BY (a), FILENAME_PATTERN "{i}");
+
+query III
+SELECT * FROM '__TEST_DIR__/only_offset/a=9/?.parquet';
 ----
 18	81	9
 


### PR DESCRIPTION
`UUID v7` pattern can be set with `{uuidv7}`, e.g.:

```sql
COPY tbl TO 'partitioned_dir' (filename_pattern "{uuidv7}", FORMAT PARQUET, PARTITION_BY (part_key));
```

This PR also adds a corresponding `{uuidv4}` option. `{uuid}` maps to `{uuidv4}` (as it dit before).

This PR also reworks the filename pattern so it correctly supports composite patterns, e.g. this now works as expected:

```sql
COPY tbl TO 'partitioned_dir' (filename_pattern "{uuidv7}{i}{uuid}", FORMAT PARQUET, PARTITION_BY (part_key), );
```